### PR TITLE
fix: harden model context and compaction

### DIFF
--- a/.changeset/quiet-context-guardrails.md
+++ b/.changeset/quiet-context-guardrails.md
@@ -1,0 +1,14 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/codex": patch
+"@opengeni/config": patch
+"@opengeni/db": patch
+"@opengeni/react": patch
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Bound model-facing textual tool output with Codex-compatible semantics, account
+for complete current model input, make compaction failure/progress transitions
+durable and convergent, and replace recursive session discovery with a compact
+paginated projection.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -25,7 +25,7 @@ import {
   listScheduledTaskRuns,
   listScheduledTasks,
   listSessionEvents,
-  listSessions,
+  listSessionDiscoverySummaries,
   listRigs,
   listSocialConnections,
   listSocialPosts,
@@ -1257,11 +1257,22 @@ function registerWorkspaceOrchestrationTools(
     server.registerTool(
       "sessions_list",
       {
-        description: "List sessions in this workspace, newest first.",
-        inputSchema: { limit: z4.number().int().positive().optional() },
+        description:
+          "List compact high-level session status in this workspace, newest first. Use session_get for one session's detailed resources/tools/settings. The list never returns full session objects or history.",
+        inputSchema: {
+          limit: z4.number().int().positive().max(100).optional(),
+          cursor: z4.string().max(512).optional(),
+          includeLastMessage: z4.boolean().optional(),
+        },
       },
-      async ({ limit }) =>
-        json({ sessions: await listSessions(deps.db, grant.workspaceId, boundedMcpLimit(limit)) }),
+      async ({ limit, cursor, includeLastMessage }) => {
+        const page = await listSessionDiscoverySummaries(deps.db, grant.workspaceId, {
+          limit: boundedSessionDiscoveryLimit(limit),
+          ...(cursor ? { cursor: decodeSessionDiscoveryCursor(cursor) } : {}),
+          includeLastMessage: includeLastMessage === true,
+        });
+        return json(capSessionDiscoveryPage(page, includeLastMessage === true));
+      },
     );
 
     server.registerTool(
@@ -1905,6 +1916,148 @@ function boundedMcpLimit(limit: number | undefined): number {
     return 100;
   }
   return Math.min(500, Math.max(1, Math.floor(limit)));
+}
+
+const SESSION_DISCOVERY_DEFAULT_LIMIT = 20;
+const SESSION_DISCOVERY_MAX_LIMIT = 100;
+const SESSION_DISCOVERY_TEXT_CHARS = 600;
+const SESSION_DISCOVERY_PAGE_MAX_BYTES = 128_000;
+
+function boundedSessionDiscoveryLimit(limit: number | undefined): number {
+  if (!limit || !Number.isFinite(limit)) return SESSION_DISCOVERY_DEFAULT_LIMIT;
+  return Math.min(SESSION_DISCOVERY_MAX_LIMIT, Math.max(1, Math.floor(limit)));
+}
+
+function encodeSessionDiscoveryCursor(cursor: { createdAt: Date | string; id: string }): string {
+  return Buffer.from(
+    JSON.stringify({
+      createdAt:
+        cursor.createdAt instanceof Date ? cursor.createdAt.toISOString() : cursor.createdAt,
+      id: cursor.id,
+    }),
+    "utf8",
+  ).toString("base64url");
+}
+
+function decodeSessionDiscoveryCursor(value: string): { createdAt: Date; id: string } {
+  try {
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as {
+      createdAt?: unknown;
+      id?: unknown;
+    };
+    const createdAt = typeof parsed.createdAt === "string" ? new Date(parsed.createdAt) : null;
+    if (
+      !createdAt ||
+      Number.isNaN(createdAt.getTime()) ||
+      typeof parsed.id !== "string" ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(parsed.id)
+    ) {
+      throw new Error("invalid cursor fields");
+    }
+    return { createdAt, id: parsed.id };
+  } catch {
+    throw new Error("sessions_list cursor is invalid");
+  }
+}
+
+function capSessionDiscoveryText(value: string | null, maxChars = SESSION_DISCOVERY_TEXT_CHARS) {
+  if (value === null || value.length <= maxChars) {
+    return { text: value, truncated: false };
+  }
+  const marker = `…[${value.length - maxChars} chars truncated]…`;
+  const body = Math.max(0, maxChars - marker.length);
+  const head = Math.ceil(body * 0.7);
+  const tail = body - head;
+  return {
+    text: `${value.slice(0, head)}${marker}${tail > 0 ? value.slice(-tail) : ""}`,
+    truncated: true,
+  };
+}
+
+export function capSessionDiscoveryPage(
+  page: Awaited<ReturnType<typeof listSessionDiscoverySummaries>>,
+  includeLastMessage: boolean,
+) {
+  const projected = page.sessions.map((session) => {
+    const title = capSessionDiscoveryText(session.title, 200);
+    const goal = session.goal ? capSessionDiscoveryText(session.goal.text) : null;
+    const preview = includeLastMessage
+      ? capSessionDiscoveryText(session.latestMessage?.preview ?? null)
+      : null;
+    const blocker = session.effectiveControl.primaryBlocker;
+    return {
+      id: session.id,
+      title: title.text,
+      titleTruncated: title.truncated,
+      parentSessionId: session.parentSessionId,
+      isRoot: session.parentSessionId === null,
+      status: session.status,
+      pause: {
+        state: session.effectiveControl.state,
+        source: blocker
+          ? {
+              kind: blocker.kind,
+              ...(blocker.sessionId ? { sessionId: blocker.sessionId } : {}),
+              displayName: capSessionDiscoveryText(blocker.displayName, 200).text,
+            }
+          : null,
+      },
+      goal: session.goal
+        ? {
+            status: session.goal.status,
+            summary: goal!.text,
+            summaryTruncated: goal!.truncated,
+          }
+        : null,
+      queuedPromptCount: session.queuedPromptCount,
+      children: session.treeStats,
+      ...(includeLastMessage
+        ? {
+            latestMessage: session.latestMessage
+              ? {
+                  type: session.latestMessage.type,
+                  preview: preview!.text,
+                  previewTruncated: preview!.truncated,
+                }
+              : null,
+          }
+        : {}),
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+    };
+  });
+
+  let kept = projected;
+  let responseTruncated = false;
+  while (
+    kept.length > 1 &&
+    Buffer.byteLength(JSON.stringify({ sessions: kept }), "utf8") >
+      SESSION_DISCOVERY_PAGE_MAX_BYTES - 2_048
+  ) {
+    kept = kept.slice(0, -1);
+    responseTruncated = true;
+  }
+  const lastKept = kept.at(-1);
+  const droppedForByteCap = kept.length < projected.length;
+  const nextCursor = droppedForByteCap
+    ? lastKept
+      ? encodeSessionDiscoveryCursor({ createdAt: lastKept.createdAt, id: lastKept.id })
+      : null
+    : page.nextCursor
+      ? encodeSessionDiscoveryCursor(page.nextCursor)
+      : null;
+  return {
+    sessions: kept,
+    total: page.total,
+    hasMore: page.hasMore || droppedForByteCap,
+    nextCursor,
+    responseTruncated,
+    ...(responseTruncated
+      ? {
+          truncationReason: `response exceeded ${SESSION_DISCOVERY_PAGE_MAX_BYTES} bytes; continue with nextCursor`,
+        }
+      : {}),
+  };
 }
 
 function parseMcpDate(raw: string, label: string): Date {

--- a/apps/api/test/session-discovery-page.test.ts
+++ b/apps/api/test/session-discovery-page.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { capSessionDiscoveryPage } from "../src/mcp/server";
+
+function uuid(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+}
+
+describe("sessions_list compact discovery projection", () => {
+  test("caps every unbounded field and the complete serialized page", () => {
+    const huge = "x".repeat(50_000);
+    const sessions = Array.from({ length: 100 }, (_, index) => ({
+      id: uuid(index + 1),
+      title: huge,
+      parentSessionId: index === 0 ? null : uuid(1),
+      status: "idle",
+      effectiveControl: { state: "running", primaryBlocker: null },
+      goal: { status: "active", text: huge },
+      queuedPromptCount: index,
+      treeStats: {
+        directChildren: 0,
+        totalDescendants: 0,
+        runningDescendants: 0,
+        queuedDescendants: 0,
+        attentionDescendants: 0,
+        pausedDescendants: 0,
+        failedDescendants: 0,
+      },
+      latestMessage: { type: "agent.message.completed", preview: huge },
+      createdAt: new Date(Date.UTC(2026, 6, 18, 0, 0, index)).toISOString(),
+      updatedAt: new Date(Date.UTC(2026, 6, 18, 0, 0, index)).toISOString(),
+    }));
+    const result = capSessionDiscoveryPage(
+      {
+        sessions,
+        total: sessions.length,
+        hasMore: false,
+        nextCursor: null,
+      } as any,
+      true,
+    );
+    const serialized = JSON.stringify(result);
+    expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(128_000);
+    expect(result.responseTruncated).toBe(true);
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).toBeTruthy();
+    expect(result.sessions[0]!.title).toContain("chars truncated");
+    expect(result.sessions[0]!.goal!.summary).toContain("chars truncated");
+    expect(result.sessions[0]!.latestMessage!.preview).toContain("chars truncated");
+    expect(serialized).not.toContain(huge);
+  });
+
+  test("omits latest-message data unless explicitly requested", () => {
+    const result = capSessionDiscoveryPage(
+      {
+        sessions: [
+          {
+            id: uuid(1),
+            title: "one",
+            parentSessionId: null,
+            status: "idle",
+            effectiveControl: { state: "running", primaryBlocker: null },
+            goal: null,
+            queuedPromptCount: 0,
+            treeStats: {
+              directChildren: 0,
+              totalDescendants: 0,
+              runningDescendants: 0,
+              queuedDescendants: 0,
+              attentionDescendants: 0,
+              pausedDescendants: 0,
+              failedDescendants: 0,
+            },
+            latestMessage: { type: "user.message", preview: "secret tail" },
+            createdAt: "2026-07-18T00:00:00.000Z",
+            updatedAt: "2026-07-18T00:00:00.000Z",
+          },
+        ],
+        total: 1,
+        hasMore: false,
+        nextCursor: null,
+      } as any,
+      false,
+    );
+    expect(result.sessions[0]).not.toHaveProperty("latestMessage");
+  });
+});

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -42,6 +42,7 @@ import {
   clearDurablePendingSessionToolCalls,
   appendSessionHistoryItems,
   isSessionCompactionRequested,
+  recordSkippedContextCompaction,
   countSessionHistoryItems,
   getActiveSessionHistoryItems,
   nextSessionHistoryPosition,
@@ -440,6 +441,28 @@ export function modelUsageSourceKey(input: {
   return input.dispatchId ? `${input.dispatchId}:${input.positionalKey}` : input.positionalKey;
 }
 
+export function providerContextTokens(
+  usage:
+    | {
+        inputTokens?: number;
+        outputTokens?: number;
+        totalTokens?: number;
+      }
+    | null
+    | undefined,
+): number | null {
+  const total = usage?.totalTokens;
+  if (typeof total === "number" && Number.isFinite(total) && total > 0) {
+    return total;
+  }
+  const input = usage?.inputTokens;
+  if (typeof input !== "number" || !Number.isFinite(input) || input <= 0) {
+    return null;
+  }
+  const output = usage?.outputTokens;
+  return input + (typeof output === "number" && Number.isFinite(output) && output > 0 ? output : 0);
+}
+
 /**
  * A provider call has already consumed tokens by the time its usage frame is
  * available. Losing the Codex credential lease at the renewal checkpoint must
@@ -565,12 +588,13 @@ export function historyRowsToAppend(
   // persistedHistoryCount to preserve the pre-compaction behaviour (contiguous
   // positions from 0) when callers do not pass an explicit next position.
   nextPosition: number = persistedHistoryCount,
+  toolOutputTruncationTokens?: number,
 ): {
   rows: Array<{ position: number; item: Record<string, unknown> }>;
   nextWatermark: number;
   nextPosition: number;
 } {
-  const sanitized = sanitizeHistoryItemsForModel(rawHistory).filter(
+  const sanitized = sanitizeHistoryItemsForModel(rawHistory, toolOutputTruncationTokens).filter(
     (item) => !isEphemeralInternalContext(item),
   );
   if (sanitized.length <= persistedHistoryCount) {
@@ -1366,6 +1390,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       | null = null;
     let turnStartedPublished = false;
     let stream: Awaited<ReturnType<OpenGeniRuntime["runStream"]>> | undefined;
+    // Reconciliation is declared before provider routing so every turn-end path
+    // can share one closure. It cannot run until `stream` exists, by which time
+    // this value has been rebound to the turn's resolved model policy.
+    let modelRunSettings: Settings = settings;
     const publishSandboxLifecycleEvents = async (sandbox: ResumedTurnSandbox): Promise<void> => {
       const established = sandbox.established;
       if (publish && established.origin && established.origin !== "resumed") {
@@ -1602,6 +1630,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             rawHistory as Array<Record<string, unknown>>,
             persistedHistoryCount,
             nextHistoryPosition,
+            modelRunSettings.modelToolOutputTruncationTokens,
           );
           const hasModelOrToolProgress = rows.some((row) =>
             isModelOrToolProgressHistoryItem(row.item),
@@ -1621,6 +1650,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               // runs, so this is the turn's effective account. The read path uses
               // it to strip cross-account reasoning.encrypted_content next turn.
               producerCodexCredentialId: effectiveCodexCredentialId,
+              modelToolOutputTruncationTokens: modelRunSettings.modelToolOutputTruncationTokens,
               items: rows,
             });
             if (!appended) {
@@ -2552,7 +2582,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // raw window, effective ceiling, and auto-compact limit are distinct live
       // catalog values and must reach pre-turn compaction, history guards, and
       // every model call together.
-      const modelRunSettings = resolvedModel
+      modelRunSettings = resolvedModel
         ? settingsWithResolvedModelContext(runSettings, resolvedModel.configured)
         : runSettings;
       // WORKSPACE MODEL POLICY — the authoritative hard gate. Runs immediately
@@ -2700,6 +2730,25 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 ...(promptCacheKey ? { promptCacheKey } : {}),
               });
 
+      const consumeFailedRequestedCompaction = async (failedTurnId: string): Promise<void> => {
+        const skipped = await recordSkippedContextCompaction(db, {
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          sessionId: input.sessionId,
+          turnId: failedTurnId,
+          expectedExecutionGeneration: executionGeneration,
+          expectedAttemptId: input.attemptId,
+          reason: "summarization_failed",
+        });
+        if (!skipped.recorded) {
+          if (skipped.reason === "request_not_pending") return;
+          throw new TurnAttemptFencedError(
+            "turn attempt was fenced while consuming a failed context compaction request",
+          );
+        }
+        await publishDurableSessionEvents(bus, input.workspaceId, input.sessionId, skipped.events);
+      };
+
       if (turn.source === "compaction") {
         const persistentSessionSettings = {
           titleIsSet: Boolean(session.title?.trim()),
@@ -2725,25 +2774,30 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         );
         let outcome: Awaited<ReturnType<typeof maybeCompactContext>> | null = null;
         if (requested) {
-          outcome = await maybeCompactContext(
-            db,
-            modelRunSettings,
-            {
-              accountId: input.accountId,
-              workspaceId: input.workspaceId,
-              sessionId: input.sessionId,
-              turnId: turn.id,
-              executionGeneration,
-              attemptId: input.attemptId,
-            },
-            session.lastInputTokens,
-            compactionSummarizerFor(compactionInstructions),
-            {
-              force: true,
-              clearRequestedCompaction: true,
-              trigger: "operator",
-            },
-          );
+          try {
+            outcome = await maybeCompactContext(
+              db,
+              modelRunSettings,
+              {
+                accountId: input.accountId,
+                workspaceId: input.workspaceId,
+                sessionId: input.sessionId,
+                turnId: turn.id,
+                executionGeneration,
+                attemptId: input.attemptId,
+              },
+              session.lastInputTokens,
+              compactionSummarizerFor(compactionInstructions),
+              {
+                force: true,
+                clearRequestedCompaction: true,
+                trigger: "operator",
+              },
+            );
+          } catch (error) {
+            await consumeFailedRequestedCompaction(turn.id);
+            throw error;
+          }
           if (outcome.events.length > 0) {
             if (outcome.compacted) {
               recordContextCompaction(observability, "operator");
@@ -3566,11 +3620,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // RunState verbatim and recovering attempts already compacted, if needed,
       // before the first attempt's model boundary.
       if (triggerType === "user.message" || triggerType === "system.update.delivered") {
+        let forced = false;
         try {
           // Operator /compact (the slash command) sets a durable request flag;
           // observe it without consuming it so a failed/stale attempt cannot
           // lose the request. The replacement transaction clears it on success.
-          const forced = await isSessionCompactionRequested(db, input.workspaceId, input.sessionId);
+          forced = await isSessionCompactionRequested(db, input.workspaceId, input.sessionId);
           const outcome = await maybeCompactContext(
             db,
             modelRunSettings,
@@ -3608,6 +3663,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             );
           }
         } catch (compactError) {
+          if (forced && turnId) {
+            await consumeFailedRequestedCompaction(turnId);
+          }
           observability.error("context compaction failed", {
             sessionId: input.sessionId,
             turnId,
@@ -3740,30 +3798,38 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         triggerLabel: "overflow" | "proactive" | "operator",
         recoverySignalTokens: number | null,
       ) => {
-        const outcome = await maybeCompactContext(
-          db,
-          modelRunSettings,
-          {
-            accountId: input.accountId,
-            workspaceId: input.workspaceId,
-            sessionId: input.sessionId,
-            turnId: activeTurnId,
-            executionGeneration,
-            attemptId: input.attemptId,
-          },
-          // Never reuse the persisted prior-turn signal for recovery. Proactive
-          // guards provide their exact current signal; provider overflows do not,
-          // so null derives decision metadata from active history. Forced
-          // recovery proves progress separately by comparing the replacement
-          // with the current active-history estimate in maybeCompactContext.
-          recoverySignalTokens,
-          compactSummarizer,
-          {
-            force: true,
-            ...(triggerLabel === "operator" ? { clearRequestedCompaction: true } : {}),
-            trigger: triggerLabel,
-          },
-        );
+        let outcome: Awaited<ReturnType<typeof maybeCompactContext>>;
+        try {
+          outcome = await maybeCompactContext(
+            db,
+            modelRunSettings,
+            {
+              accountId: input.accountId,
+              workspaceId: input.workspaceId,
+              sessionId: input.sessionId,
+              turnId: activeTurnId,
+              executionGeneration,
+              attemptId: input.attemptId,
+            },
+            // Never reuse the persisted prior-turn signal for recovery. Proactive
+            // guards provide their exact current signal; provider overflows do not,
+            // so null derives decision metadata from active history. Forced
+            // recovery proves progress separately by comparing the replacement
+            // with the current active-history estimate in maybeCompactContext.
+            recoverySignalTokens,
+            compactSummarizer,
+            {
+              force: true,
+              ...(triggerLabel === "operator" ? { clearRequestedCompaction: true } : {}),
+              trigger: triggerLabel,
+            },
+          );
+        } catch (error) {
+          if (triggerLabel === "operator") {
+            await consumeFailedRequestedCompaction(activeTurnId);
+          }
+          throw error;
+        }
         if (outcome.events.length > 0) {
           if (outcome.compacted) {
             recordContextCompaction(observability, triggerLabel);
@@ -3787,7 +3853,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         let responseUsageCount = 0;
         // Actual input tokens of the most recent model response this turn; the
         // pre-read trigger for the NEXT turn. Persisted at every turn-end path.
-        let lastInputTokensObserved: number | null = null;
+        let lastProviderContextTokensObserved: number | null = null;
+        let providerContextRevision = 0;
         throwIfWorkerShuttingDown();
         const ownedEstablished = resolvedSandbox?.established ?? lazyOwnedSandbox;
         const runStreamOnce = (): ReturnType<OpenGeniRuntime["runStream"]> =>
@@ -3831,7 +3898,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   },
                 }
               : {}),
-            contextCompactionSignalTokens: () => lastInputTokensObserved,
+            contextCompactionSignal: () =>
+              lastProviderContextTokensObserved === null
+                ? null
+                : {
+                    revision: providerContextRevision,
+                    totalTokens: lastProviderContextTokensObserved,
+                  },
             contextCompactionRequested: () =>
               isSessionCompactionRequested(db, input.workspaceId, input.sessionId),
           });
@@ -3915,7 +3988,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   const observed = responseUsage.usage?.inputTokens;
                   if (typeof observed === "number" && observed > 0) {
                     recordModelInputTokens(observability, streamProvider, observed);
-                    lastInputTokensObserved = observed;
+                  }
+                  const observedTotal = providerContextTokens(responseUsage.usage);
+                  if (observedTotal !== null) {
+                    lastProviderContextTokensObserved = observedTotal;
+                    providerContextRevision += 1;
                   }
                   // Prompt-cache efficiency for this response — same usage frame as the
                   // input-token accounting above, so the two are always consistent.
@@ -4043,7 +4120,17 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           const aggregateInput = (aggregateUsage as { inputTokens?: unknown } | undefined)
             ?.inputTokens;
           if (typeof aggregateInput === "number" && aggregateInput > 0) {
-            lastInputTokensObserved = aggregateInput;
+            const aggregateContext = providerContextTokens(
+              aggregateUsage as {
+                inputTokens?: number;
+                outputTokens?: number;
+                totalTokens?: number;
+              },
+            );
+            if (aggregateContext !== null) {
+              lastProviderContextTokensObserved = aggregateContext;
+              providerContextRevision += 1;
+            }
           }
           const aggregateSourceKey = modelUsageSourceKey({
             responseId: null,

--- a/apps/worker/src/activities/capabilities.ts
+++ b/apps/worker/src/activities/capabilities.ts
@@ -14,6 +14,7 @@ import {
   CODEX_MODEL_CONTEXT_WINDOW_TOKENS,
   CODEX_MODEL_EFFECTIVE_CONTEXT_WINDOW_TOKENS,
   CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT,
+  CODEX_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS,
   CODEX_MODEL_ID_PREFIX,
   CODEX_PROVIDER_BASE_URL,
   CODEX_PROVIDER_ID,
@@ -174,6 +175,7 @@ export function withCodexProvider(settings: Settings): Settings {
       contextWindowTokens: CODEX_MODEL_CONTEXT_WINDOW_TOKENS,
       effectiveContextWindowTokens: CODEX_MODEL_EFFECTIVE_CONTEXT_WINDOW_TOKENS,
       autoCompactTokenLimit: CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT,
+      toolOutputTruncationTokens: CODEX_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS,
     })),
   };
   return { ...settings, modelProvidersJson: JSON.stringify([...providers, codexProvider]) };

--- a/apps/worker/src/activities/context-compaction.ts
+++ b/apps/worker/src/activities/context-compaction.ts
@@ -8,8 +8,10 @@ import {
   SUMMARY_BUFFER_TOKENS,
   buildCompactionPromptInput,
   buildCompactionReplacementHistory,
+  compactionReplacementFingerprint,
   decideCompaction,
   estimateTokens,
+  latestCompactionReplacementFingerprint,
   sanitizeHistoryItemsForModel,
   summarizeForCompaction,
   type CompactionItem,
@@ -33,6 +35,7 @@ export type MaybeCompactResult =
       thresholdTokens: number;
       estimatedTokensBefore: number;
       estimatedTokensAfter: number;
+      replacementFingerprint: string;
       events: SessionEvent[];
     };
 
@@ -130,6 +133,8 @@ export async function maybeCompactContext(
   const summaryBody = await summarizeWithCodexOverflowTrimming(summarize, settings, items);
   const replacementHistory = buildCompactionReplacementHistory(items, summaryBody);
   const estimatedTokensAfter = estimateTokens(replacementHistory);
+  const replacementFingerprint = compactionReplacementFingerprint(replacementHistory);
+  const previousReplacementFingerprint = latestCompactionReplacementFingerprint(items);
   const summaryItem = replacementHistory.at(-1);
   if (!summaryItem) {
     return {
@@ -137,6 +142,35 @@ export async function maybeCompactContext(
       reason: "compaction produced no replacement history",
       events: [],
       requestConsumed: false,
+    };
+  }
+  if (previousReplacementFingerprint === replacementFingerprint) {
+    let requestConsumed = false;
+    if (options.clearRequestedCompaction) {
+      const skipped = await recordSkippedContextCompaction(db, {
+        ...scope,
+        expectedExecutionGeneration: scope.executionGeneration,
+        expectedAttemptId: scope.attemptId,
+        reason: "replacement_unchanged",
+      });
+      if (!skipped.recorded) {
+        throw new TurnAttemptFencedError(
+          "turn attempt was fenced while consuming an unchanged context compaction request",
+        );
+      }
+      requestConsumed = true;
+      return {
+        compacted: false,
+        reason: "replacement_unchanged",
+        events: skipped.events,
+        requestConsumed,
+      };
+    }
+    return {
+      compacted: false,
+      reason: "replacement_unchanged",
+      events: [],
+      requestConsumed,
     };
   }
   if (estimatedTokensAfter >= estimatedTokensBefore) {
@@ -199,6 +233,7 @@ export async function maybeCompactContext(
     thresholdTokens: decision.thresholdTokens,
     estimatedTokensBefore,
     estimatedTokensAfter,
+    replacementFingerprint,
     events: applied.events,
   };
 }

--- a/apps/worker/test/context-compaction-activity.test.ts
+++ b/apps/worker/test/context-compaction-activity.test.ts
@@ -13,7 +13,11 @@ import {
 } from "@opengeni/db";
 import * as schema from "@opengeni/db/schema";
 import type { EventBus } from "@opengeni/events";
-import type { OpenGeniRuntime } from "@opengeni/runtime";
+import {
+  EmptyCompactionSummaryError,
+  SUMMARY_PREFIX,
+  type OpenGeniRuntime,
+} from "@opengeni/runtime";
 import {
   acquireSharedTestDatabase,
   testSettings,
@@ -227,6 +231,142 @@ describe("standalone context compaction execution", () => {
     ]);
   });
 
+  test("a failed standalone summary consumes the request once and preserves active history", async () => {
+    const suffix = crypto.randomUUID();
+    const access = await bootstrapWorkspace(client.db, {
+      accountExternalSource: "test",
+      accountExternalId: `account-${suffix}`,
+      accountName: "Failed standalone compaction test",
+      workspaceExternalSource: "test",
+      workspaceExternalId: `workspace-${suffix}`,
+      workspaceName: "Failed standalone compaction test",
+      subjectId: `subject-${suffix}`,
+    });
+    const grant = access.workspaceGrants[0]!;
+    const session = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "initial",
+      resources: [],
+      metadata: {},
+      model: "scripted-compactor",
+      sandboxBackend: "none",
+    });
+    const originalItems = [
+      { type: "message", role: "user", content: "preserve this request" },
+      {
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "work in progress ".repeat(1_000) }],
+      },
+    ];
+    await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      await db.insert(schema.sessionHistoryItems).values(
+        originalItems.map((item, position) => ({
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId!,
+          sessionId: session.id,
+          position,
+          item,
+        })),
+      );
+    });
+    await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
+
+    const runtime = {
+      configure: () => undefined,
+      resolveTurnModel: () => ({
+        client: {
+          chat: {
+            completions: {
+              create: async () => ({
+                id: "chatcmpl-empty",
+                usage: { prompt_tokens: 100, completion_tokens: 0, total_tokens: 100 },
+                choices: [{ message: { content: "" }, finish_reason: "stop" }],
+              }),
+            },
+          },
+        },
+        provider: { id: "test-chat", kind: "api-key", api: "chat", builtin: false },
+        configured: {
+          id: "scripted-compactor",
+          contextWindowTokens: 250_000,
+          effectiveContextWindowTokens: 250_000,
+          autoCompactLimitTokens: 225_000,
+          hostedWebSearch: false,
+        },
+      }),
+      buildAgent: () => {
+        throw new Error("failed standalone compaction entered the agent runtime");
+      },
+      prepareTools: () => {
+        throw new Error("failed standalone compaction prepared tools");
+      },
+      prepareInput: () => {
+        throw new Error("failed standalone compaction prepared input");
+      },
+      runStream: () => {
+        throw new Error("failed standalone compaction started inference");
+      },
+      serializeApprovals: () => {
+        throw new Error("failed standalone compaction serialized approvals");
+      },
+    } as unknown as OpenGeniRuntime;
+    const bus = {
+      publish: async () => undefined,
+      subscribe: async function* () {},
+      close: async () => undefined,
+    } as unknown as EventBus;
+    const activities = createActivityTestHarness({
+      settings: testSettings({
+        databaseUrl: shared.appUrl,
+        openaiModel: "scripted-compactor",
+        sandboxBackend: "none",
+      }),
+      db: client.db,
+      bus,
+      runtime,
+    });
+
+    const attemptId = crypto.randomUUID();
+    const result = await activities.runAgentTurn({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+      workflowRunId: crypto.randomUUID(),
+      attemptId,
+      trigger: { kind: "next" },
+    });
+
+    expect(result).toMatchObject({ status: "failed", attemptId });
+    if (result.status === "unclaimed") throw new Error("Compaction was not claimed");
+    expect(await isSessionCompactionRequested(client.db, grant.workspaceId!, session.id)).toBe(
+      false,
+    );
+    expect(
+      (await getActiveSessionHistoryItems(client.db, grant.workspaceId!, session.id)).map(
+        (row) => row.item,
+      ),
+    ).toEqual(originalItems);
+    const turn = await getSessionTurn(client.db, grant.workspaceId!, result.turnId);
+    expect(turn).toMatchObject({ source: "compaction", status: "failed" });
+    const events = await listSessionEvents(client.db, grant.workspaceId!, session.id, {
+      after: 0,
+      limit: 100,
+    });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "session.context.compaction.skipped",
+        payload: { reason: "summarization_failed" },
+      }),
+    );
+    expect(
+      events.filter((event) => event.type === "session.context.compaction.requested"),
+    ).toHaveLength(1);
+  });
+
   test("consumes an operator request without replacing history when its summary is not smaller", async () => {
     const suffix = crypto.randomUUID();
     const access = await bootstrapWorkspace(client.db, {
@@ -403,6 +543,162 @@ describe("standalone context compaction execution", () => {
         content: expect.stringContaining("Recovered compact context"),
       }),
     ]);
+  });
+
+  test("an empty checkpoint cannot mutate or consume before the caller records terminal failure", async () => {
+    const suffix = crypto.randomUUID();
+    const access = await bootstrapWorkspace(client.db, {
+      accountExternalSource: "test",
+      accountExternalId: `account-${suffix}`,
+      accountName: "Empty checkpoint test",
+      workspaceExternalSource: "test",
+      workspaceExternalId: `workspace-${suffix}`,
+      workspaceName: "Empty checkpoint test",
+      subjectId: `subject-${suffix}`,
+    });
+    const grant = access.workspaceGrants[0]!;
+    const session = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "initial",
+      resources: [],
+      metadata: {},
+      model: "scripted-compactor",
+      sandboxBackend: "none",
+    });
+    const originalItems = [
+      { type: "message", role: "user", content: "x".repeat(100_000) },
+      {
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "work in progress" }],
+      },
+    ];
+    await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      await db.insert(schema.sessionHistoryItems).values(
+        originalItems.map((item, position) => ({
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId!,
+          sessionId: session.id,
+          position,
+          item,
+        })),
+      );
+    });
+    await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
+    const attemptId = crypto.randomUUID();
+    const turn = await claimCompactionForAttempt(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      attemptId,
+    );
+
+    await expect(
+      maybeCompactContext(
+        client.db,
+        testSettings({ contextWindowTokens: 250_000 }),
+        {
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId!,
+          sessionId: session.id,
+          turnId: turn!.id,
+          executionGeneration: turn!.executionGeneration,
+          attemptId,
+        },
+        null,
+        async () => "   ",
+        { force: true, clearRequestedCompaction: true, trigger: "operator" },
+      ),
+    ).rejects.toBeInstanceOf(EmptyCompactionSummaryError);
+    expect(await isSessionCompactionRequested(client.db, grant.workspaceId!, session.id)).toBe(
+      true,
+    );
+    expect(
+      (await getActiveSessionHistoryItems(client.db, grant.workspaceId!, session.id)).map(
+        (row) => row.item,
+      ),
+    ).toEqual(originalItems);
+  });
+
+  test("an exact repeated checkpoint is consumed once without another history rewrite", async () => {
+    const suffix = crypto.randomUUID();
+    const access = await bootstrapWorkspace(client.db, {
+      accountExternalSource: "test",
+      accountExternalId: `account-${suffix}`,
+      accountName: "Repeated checkpoint test",
+      workspaceExternalSource: "test",
+      workspaceExternalId: `workspace-${suffix}`,
+      workspaceName: "Repeated checkpoint test",
+      subjectId: `subject-${suffix}`,
+    });
+    const grant = access.workspaceGrants[0]!;
+    const session = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "initial",
+      resources: [],
+      metadata: {},
+      model: "scripted-compactor",
+      sandboxBackend: "none",
+    });
+    const originalItems = [
+      { type: "message", role: "user", content: "keep this user request" },
+      {
+        type: "message",
+        role: "user",
+        content: `${SUMMARY_PREFIX}\nsame checkpoint`,
+        opengeni_context_summary: true,
+      },
+    ];
+    await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      await db.insert(schema.sessionHistoryItems).values(
+        originalItems.map((item, position) => ({
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId!,
+          sessionId: session.id,
+          position,
+          item,
+        })),
+      );
+    });
+    await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
+    const attemptId = crypto.randomUUID();
+    const turn = await claimCompactionForAttempt(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      attemptId,
+    );
+    const outcome = await maybeCompactContext(
+      client.db,
+      testSettings({ contextWindowTokens: 250_000 }),
+      {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn!.id,
+        executionGeneration: turn!.executionGeneration,
+        attemptId,
+      },
+      null,
+      async () => "same checkpoint",
+      { force: true, clearRequestedCompaction: true, trigger: "operator" },
+    );
+    expect(outcome).toMatchObject({
+      compacted: false,
+      reason: "replacement_unchanged",
+      requestConsumed: true,
+    });
+    expect(await isSessionCompactionRequested(client.db, grant.workspaceId!, session.id)).toBe(
+      false,
+    );
+    expect(
+      (await getActiveSessionHistoryItems(client.db, grant.workspaceId!, session.id)).map(
+        (row) => row.item,
+      ),
+    ).toEqual(originalItems);
   });
 
   test("matches Codex's overflow floor by trying the checkpoint prompt alone once", async () => {

--- a/docs/context-compaction.md
+++ b/docs/context-compaction.md
@@ -1,7 +1,8 @@
 # Conversation context compaction
 
 OpenGeni has one compaction mechanism: durable, portable plaintext compaction
-that follows the local compaction path in Codex CLI 0.144.5. It is used for
+that follows the local compaction path in Codex CLI 0.144.6 (upstream tag
+`rust-v0.144.6`, commit `5d1fbf26c43abc65a203928b2e31561cb039e06d`). It is used for
 OpenAI, Azure, Codex subscriptions, and registry providers. There is no
 provider-side mode, off switch, compatibility ladder, request-local history
 trim, or deterministic non-model fallback.
@@ -37,7 +38,7 @@ If a model has no explicit automatic limit, OpenGeni uses
 0.9 and is clamped to 0.3–0.9. An explicit limit is capped at 90% of the raw
 window, matching Codex core.
 
-The Codex subscription catalog verified with Codex CLI 0.144.5 on 2026-07-17
+The Codex subscription catalog verified with Codex CLI 0.144.6 on 2026-07-18
 has:
 
 | quantity | tokens |
@@ -46,10 +47,31 @@ has:
 | effective input window (95%) | 258,400 |
 | automatic compaction limit (90%) | 244,800 |
 
-The signal prefers provider-reported input usage from the exact current turn
-attempt. Before the first provider usage exists, it estimates serialized input
-at roughly four characters per token. Attempt fencing prevents a stale worker
-from overwriting the signal used by the current attempt.
+Before a provider response exists, the guard estimates the complete outgoing
+request: active items, instructions, and tool schemas. After a response, it
+anchors to that exact response's provider-reported **total** tokens and adds all
+locally appended items after the last model-generated item, plus any positive
+instruction or tool-schema growth. That anchor is accepted only when the usage
+revision belongs to the immediately preceding model request. If stream
+consumption lags the SDK's background model loop, the guard uses the complete
+request estimate instead of binding delayed usage to a newer request. A durable prior-turn input count is only a
+conservative floor; it can never hide a larger active-history estimate. Attempt
+fencing prevents a stale worker from overwriting durable token state.
+
+## Model-facing tool output
+
+Every resolved model carries a textual tool-output policy. The Codex catalog's
+10,000-token policy is the default; OpenGeni applies Codex's exact 1.2x JSON
+serialization allowance, UTF-8-safe head/tail truncation, and explicit
+`…N tokens truncated…` marker. Structured textual parts share one sequential
+budget while images, files, and encrypted content remain structured.
+
+The same pure normalizer runs at both canonical boundaries: before new
+`session_history_items` rows are written and again at the final live model-input
+seam. Raw pending tool-call receipts remain out-of-band until settlement so
+Pause, Steer, failure, and deploy recovery can still reconcile the real outcome.
+UI/audit events are a separate projection and are never used to reconstruct
+model history.
 
 ## What the summarizer sees
 
@@ -67,8 +89,10 @@ plain-text adapter because Chat Completions has a different item protocol.
 If the summarizer request exceeds the context window, OpenGeni removes exactly
 one oldest history item and retries, retaining the checkpoint prompt. It repeats
 until the request fits or only the prompt remains. Other provider errors
-propagate and do not mutate active history. An empty model summary becomes
-Codex's explicit `(no summary available)` placeholder.
+propagate and do not mutate active history. An empty model response is a typed
+compaction failure with bounded, content-free response diagnostics; the old
+active history remains byte-for-byte active. OpenGeni never installs a
+manufactured placeholder as conversation truth.
 
 ## Durable replacement
 
@@ -84,6 +108,9 @@ as user boundaries. Assistant messages, reasoning, tool calls, and tool results
 leave the active model history but remain in inactive audit rows.
 
 The generated replacement must estimate strictly smaller than the active input.
+Its deterministic fingerprint must also differ from the latest durable
+replacement; an exact repeat settles once as `replacement_unchanged` instead of
+entering another compaction/retry cycle.
 One transaction locks workspace, session, and turn; verifies
 `turnId + executionGeneration + attemptId`; supersedes every old active row;
 inserts the replacement at fresh whole-number positions; updates
@@ -110,7 +137,12 @@ replacement history and continues the work.
 
 If summarization fails, the turn ends with an honest
 `context_compaction_failed` result. OpenGeni does not continue with silently
-trimmed input and does not install a mechanical fallback summary.
+trimmed input and does not install a mechanical fallback summary. When the
+failure belongs to an explicit `/compact`, the exact attempt also records
+`session.context.compaction.skipped(reason="summarization_failed")` and clears
+that one request, so an idle maintenance execution cannot immediately recreate
+itself forever. The active history stays unchanged and the user may request a
+fresh retry.
 
 Manual `/compact` sets one durable idempotent request. During active inference,
 the worker observes it at the next model boundary and retries sampling in the
@@ -121,9 +153,11 @@ row; it exists to own model allocation, attempt fencing, recovery, and
 settlement, and it never prepares tools or a sandbox.
 
 The exact attempt that successfully installs the replacement clears the request
-in the same transaction. If there is no active history, or the generated
-checkpoint is not strictly smaller, the exact attempt instead records
+in the same transaction. If there is no active history, the generated
+checkpoint is not strictly smaller, or it exactly repeats the latest durable
+replacement, the exact attempt instead records
 `session.context.compaction.skipped` with that reason and clears the request in
 one transaction without changing history. A failed, paused, recovered, or
 superseded attempt cannot lose the request or publish a current compaction
-result.
+result; only an authoritatively recorded terminal summarization failure consumes
+the request as described above.

--- a/packages/codex/src/constants.ts
+++ b/packages/codex/src/constants.ts
@@ -31,7 +31,7 @@ export const CODEX_MODEL_ID_PREFIX = "codex/";
 export const CODEX_FALLBACK_MODEL_SLUGS = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] as const;
 
 // Live Codex model-catalog values for every exposed gpt-5.6 subscription slug.
-// Verified 2026-07-17 against Codex CLI 0.144.5's freshly fetched
+// Verified 2026-07-18 against Codex CLI 0.144.6's freshly fetched
 // ~/.codex/models_cache.json and the matching openai/codex core derivations:
 //   raw context window                = 272,000
 //   effective input window (95%)      = 258,400
@@ -52,7 +52,7 @@ export const CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT = Math.floor(
 // 2026-07-09: 0.142.4 filtered every GPT-5.6 slug out of GET /models, while the
 // official Codex 0.144.0+ releases return all three exact slugs above. Keep
 // this pinned to the latest stable Codex release we have verified end-to-end.
-export const CODEX_CLIENT_VERSION = "0.144.5";
+export const CODEX_CLIENT_VERSION = "0.144.6";
 
 export const CODEX_REFRESH_WINDOW_MS = 5 * 60 * 1000; // proactive refresh when within 5 min of exp (spec §1.1)
 export const CODEX_REFRESH_FALLBACK_MS = 8 * 24 * 60 * 60 * 1000; // 8 days when exp is unparseable

--- a/packages/codex/src/index.ts
+++ b/packages/codex/src/index.ts
@@ -8,3 +8,4 @@ export * from "./api-client";
 export * from "./request-context";
 export * from "./fetch";
 export * from "./mcp-sanitize";
+export * from "./model-output-truncation";

--- a/packages/codex/src/model-output-truncation.ts
+++ b/packages/codex/src/model-output-truncation.ts
@@ -1,0 +1,255 @@
+/**
+ * Canonical model-facing tool-output truncation.
+ *
+ * Ported from openai/codex `rust-v0.144.6` (commit
+ * 5d1fbf26c43abc65a203928b2e31561cb039e06d):
+ *
+ * - `codex-rs/utils/string/src/truncate.rs`
+ * - `codex-rs/utils/output-truncation/src/lib.rs`
+ * - `codex-rs/core/src/context_manager/history.rs`
+ *
+ * The live gpt-5.6 model catalog declares a 10,000-token truncation policy.
+ * Codex applies a 1.2x allowance before serializing a function-call output, so
+ * the effective textual payload budget is 12,000 approximate tokens. Images,
+ * files, and encrypted content are preserved; textual content shares one
+ * sequential budget and carries an explicit head/tail truncation marker.
+ *
+ * This module deliberately has no database or Agents SDK dependency. Both the
+ * runtime request seam and the database history boundary call the same pure
+ * function, so replayed conversation truth is identical to live model input.
+ */
+
+export type ModelHistoryItem = Record<string, unknown>;
+
+export const CODEX_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS = 10_000;
+export const CODEX_TOOL_OUTPUT_SERIALIZATION_ALLOWANCE = 1.2;
+export const DEFAULT_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS =
+  CODEX_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS;
+
+const APPROX_BYTES_PER_TOKEN = 4;
+const TOOL_RESULT_TYPES = new Set([
+  "function_call_result",
+  "function_call_output",
+  "custom_tool_call_output",
+  "shell_call_output",
+  "apply_patch_call_output",
+]);
+const STRUCTURAL_STRING_KEYS = new Set([
+  "type",
+  "role",
+  "status",
+  "name",
+  "id",
+  "callId",
+  "call_id",
+  "namespace",
+  "detail",
+  "mimeType",
+  "media_type",
+]);
+
+export function modelToolOutputSerializationBudgetTokens(
+  policyTokens = DEFAULT_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS,
+): number {
+  return Math.ceil(Math.max(0, policyTokens) * CODEX_TOOL_OUTPUT_SERIALIZATION_ALLOWANCE);
+}
+
+export function approximateTokenCount(value: string): number {
+  return Math.ceil(Buffer.byteLength(value, "utf8") / APPROX_BYTES_PER_TOKEN);
+}
+
+/** Exact Codex-style middle truncation for a token policy. */
+export function truncateMiddleWithTokenBudget(value: string, maxTokens: number): string {
+  if (value.length === 0) return value;
+  const maxBytes = Math.max(0, maxTokens) * APPROX_BYTES_PER_TOKEN;
+  const valueBytes = Buffer.byteLength(value, "utf8");
+  if (maxTokens > 0 && valueBytes <= maxBytes) return value;
+  if (maxBytes === 0) {
+    return `…${approximateTokenCount(value)} tokens truncated…`;
+  }
+
+  const leftBudget = Math.floor(maxBytes / 2);
+  const rightBudget = maxBytes - leftBudget;
+  // Do not materialize `Array.from(value)`: production tool results can be
+  // multi-megabyte strings and one JS element per code point multiplies peak
+  // memory. A single UTF-8 buffer gives bounded scans at the two cut points.
+  const bytes = Buffer.from(value, "utf8");
+  let leftEnd = Math.min(leftBudget, bytes.length);
+  while (leftEnd > 0 && leftEnd < bytes.length && isUtf8ContinuationByte(bytes[leftEnd]!)) {
+    leftEnd -= 1;
+  }
+  let rightStart = Math.max(0, bytes.length - rightBudget);
+  while (rightStart < bytes.length && isUtf8ContinuationByte(bytes[rightStart]!)) {
+    rightStart += 1;
+  }
+  const left = bytes.subarray(0, leftEnd).toString("utf8");
+  const right = bytes.subarray(rightStart).toString("utf8");
+  const removedBytes = Math.max(0, valueBytes - maxBytes);
+  const removedTokens = Math.ceil(removedBytes / APPROX_BYTES_PER_TOKEN);
+  return `${left}…${removedTokens} tokens truncated…${right}`;
+}
+
+function isUtf8ContinuationByte(value: number): boolean {
+  return (value & 0xc0) === 0x80;
+}
+
+/**
+ * Bound every model-visible tool-result item. Non-result items are returned by
+ * reference. Result items are cloned only when their textual output changes.
+ */
+export function boundModelToolOutputItem<T extends ModelHistoryItem>(
+  item: T,
+  policyTokens = DEFAULT_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS,
+): T {
+  const type = typeof item.type === "string" ? item.type : "";
+  if (!TOOL_RESULT_TYPES.has(type)) return item;
+  const budget = modelToolOutputSerializationBudgetTokens(policyTokens);
+  const boundedOutput = boundToolOutputValue(item.output, budget);
+  return boundedOutput === item.output ? item : ({ ...item, output: boundedOutput } as T);
+}
+
+export function boundModelToolOutputItems<T extends ModelHistoryItem>(
+  items: readonly T[],
+  policyTokens = DEFAULT_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS,
+): T[] {
+  return items.map((item) => boundModelToolOutputItem(item, policyTokens));
+}
+
+function boundToolOutputValue(output: unknown, budgetTokens: number): unknown {
+  if (typeof output === "string") {
+    // Text-transport computer/view_image tools use a data URL because Chat
+    // Completions has no structured image result. It is still image protocol,
+    // not textual tool output; truncating its base64 permanently corrupts it.
+    if (isImageDataUrl(output)) return output;
+    return truncateMiddleWithTokenBudget(output, budgetTokens);
+  }
+  if (Array.isArray(output)) {
+    // Responses content arrays have an explicit text/image/file protocol and
+    // follow Codex's sequential item policy exactly. Shell/apply adapters can
+    // instead return arrays of objects containing stdout/stderr; those share
+    // the same total text budget through the generic leaf walker.
+    return output.every(
+      (item) =>
+        item &&
+        typeof item === "object" &&
+        (isTextContentItem(item as Record<string, unknown>) ||
+          isNonTextContentItem(item as Record<string, unknown>)),
+    )
+      ? boundStructuredOutputItems(output, budgetTokens)
+      : boundTextLeaves(output, { remaining: budgetTokens, omitted: 0 });
+  }
+  if (!output || typeof output !== "object") return output;
+
+  const record = output as Record<string, unknown>;
+  if (isTextContentItem(record)) {
+    const text = record.text as string;
+    if (isImageDataUrl(text)) return output;
+    const bounded = truncateMiddleWithTokenBudget(text, budgetTokens);
+    return bounded === text ? output : { ...record, text: bounded };
+  }
+  if (isNonTextContentItem(record)) return output;
+
+  // Shell/apply-patch result objects are not structured Responses content, but
+  // can contain arbitrarily large stdout/stderr leaves. Preserve their shape
+  // while sharing one sequential text budget across the whole value.
+  const state = { remaining: budgetTokens, omitted: 0 };
+  return boundTextLeaves(record, state);
+}
+
+function boundStructuredOutputItems(items: unknown[], budgetTokens: number): unknown[] {
+  let remaining = budgetTokens;
+  let omitted = 0;
+  let changed = false;
+  const out: unknown[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== "object" || !isTextContentItem(item as Record<string, unknown>)) {
+      out.push(item);
+      continue;
+    }
+    const record = item as Record<string, unknown>;
+    const text = record.text as string;
+    if (isImageDataUrl(text)) {
+      out.push(item);
+      continue;
+    }
+    if (remaining === 0) {
+      omitted += 1;
+      changed = true;
+      continue;
+    }
+    const cost = approximateTokenCount(text);
+    if (cost <= remaining) {
+      out.push(item);
+      remaining -= cost;
+      continue;
+    }
+    out.push({ ...record, text: truncateMiddleWithTokenBudget(text, remaining) });
+    remaining = 0;
+    changed = true;
+  }
+  if (omitted > 0) {
+    out.push({ type: "input_text", text: `[omitted ${omitted} text items ...]` });
+  }
+  return changed ? out : items;
+}
+
+function boundTextLeaves(
+  value: unknown,
+  state: { remaining: number; omitted: number },
+  depth = 0,
+): unknown {
+  if (typeof value === "string") {
+    if (isImageDataUrl(value)) return value;
+    if (state.remaining === 0) {
+      state.omitted += 1;
+      return `[omitted text field ${state.omitted} ...]`;
+    }
+    const cost = approximateTokenCount(value);
+    if (cost <= state.remaining) {
+      state.remaining -= cost;
+      return value;
+    }
+    const bounded = truncateMiddleWithTokenBudget(value, state.remaining);
+    state.remaining = 0;
+    return bounded;
+  }
+  if (!value || typeof value !== "object" || depth >= 12) return value;
+  if (Array.isArray(value)) {
+    return value.map((entry) => boundTextLeaves(entry, state, depth + 1));
+  }
+  const record = value as Record<string, unknown>;
+  if (isNonTextContentItem(record)) return value;
+  if (isTextContentItem(record)) {
+    const text = boundTextLeaves(record.text, state, depth + 1);
+    return text === record.text ? value : { ...record, text };
+  }
+  return Object.fromEntries(
+    Object.entries(record).map(([key, entry]) => [
+      key,
+      typeof entry === "string" && STRUCTURAL_STRING_KEYS.has(key)
+        ? entry
+        : boundTextLeaves(entry, state, depth + 1),
+    ]),
+  );
+}
+
+function isTextContentItem(value: Record<string, unknown>): boolean {
+  return (
+    typeof value.text === "string" &&
+    (value.type === "text" || value.type === "input_text" || value.type === "output_text")
+  );
+}
+
+function isNonTextContentItem(value: Record<string, unknown>): boolean {
+  return (
+    value.type === "image" ||
+    value.type === "input_image" ||
+    value.type === "file" ||
+    value.type === "input_file" ||
+    value.type === "encrypted_content"
+  );
+}
+
+function isImageDataUrl(value: string): boolean {
+  return /^data:image\/[a-z0-9.+-]+;base64,/i.test(value);
+}

--- a/packages/codex/test/model-output-truncation.test.ts
+++ b/packages/codex/test/model-output-truncation.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import {
+  boundModelToolOutputItem,
+  modelToolOutputSerializationBudgetTokens,
+  truncateMiddleWithTokenBudget,
+} from "../src/model-output-truncation";
+
+describe("Codex-parity model tool-output truncation", () => {
+  test("uses the live 10k policy with Codex's 1.2x serialization allowance", () => {
+    expect(modelToolOutputSerializationBudgetTokens()).toBe(12_000);
+  });
+
+  test("matches Codex's head/tail token marker", () => {
+    expect(
+      truncateMiddleWithTokenBudget(
+        "this is an example of a long output that should be truncated",
+        5,
+      ),
+    ).toBe("this is an…10 tokens truncated… truncated");
+  });
+
+  test("preserves UTF-8 boundaries", () => {
+    const value = "😀".repeat(20);
+    const bounded = truncateMiddleWithTokenBudget(value, 5);
+    expect(bounded).toContain("tokens truncated");
+    expect(bounded).not.toContain("�");
+  });
+
+  test("bounds function output text without changing call/result truth", () => {
+    const item = {
+      type: "function_call_result",
+      name: "sessions_list",
+      callId: "call-1",
+      status: "completed",
+      output: { type: "text", text: "x".repeat(100) },
+    };
+    const bounded = boundModelToolOutputItem(item, 5);
+    expect(bounded).toMatchObject({
+      type: "function_call_result",
+      name: "sessions_list",
+      callId: "call-1",
+      status: "completed",
+      output: { type: "text" },
+    });
+    expect((bounded.output as { text: string }).text).toContain("tokens truncated");
+    expect(item.output.text).toHaveLength(100);
+  });
+
+  test("shares one sequential budget across structured text and preserves images", () => {
+    const image = { type: "input_image", image: "data:image/png;base64,abc" };
+    const item = {
+      type: "function_call_result",
+      name: "mixed",
+      callId: "call-2",
+      status: "completed",
+      output: [
+        { type: "input_text", text: "a".repeat(12) },
+        image,
+        { type: "input_text", text: "b".repeat(80) },
+        { type: "input_text", text: "dropped" },
+      ],
+    };
+    const bounded = boundModelToolOutputItem(item, 5);
+    expect(bounded.output).toEqual([
+      item.output[0],
+      image,
+      expect.objectContaining({
+        type: "input_text",
+        text: expect.stringContaining("tokens truncated"),
+      }),
+      { type: "input_text", text: "[omitted 1 text items ...]" },
+    ]);
+  });
+
+  test("bounds stdout and stderr inside structured shell results", () => {
+    const item = {
+      type: "shell_call_output",
+      callId: "call-shell",
+      output: [
+        {
+          stdout: "s".repeat(100),
+          stderr: "e".repeat(100),
+          outcome: { type: "exit", exitCode: 0 },
+        },
+      ],
+    };
+    const bounded = boundModelToolOutputItem(item, 5);
+    const output = bounded.output as Array<{
+      stdout: string;
+      stderr: string;
+      outcome: { type: string; exitCode: number };
+    }>;
+    expect(output[0]!.stdout).toContain("tokens truncated");
+    expect(output[0]!.stderr).toContain("omitted text field");
+    expect(output[0]!.outcome).toEqual({ type: "exit", exitCode: 0 });
+  });
+
+  test("preserves MCP content discriminators while bounding nested text", () => {
+    const item = {
+      type: "function_call_result",
+      callId: "call-mcp",
+      output: {
+        isError: false,
+        content: [{ type: "text", text: "m".repeat(100) }],
+      },
+    };
+    const bounded = boundModelToolOutputItem(item, 5);
+    expect(bounded.output).toMatchObject({
+      isError: false,
+      content: [{ type: "text", text: expect.stringContaining("tokens truncated") }],
+    });
+  });
+
+  test("never truncates hosted computer screenshot protocol", () => {
+    const item = {
+      type: "computer_call_result",
+      callId: "computer-1",
+      output: { type: "computer_screenshot", data: "a".repeat(266_000) },
+    };
+    expect(boundModelToolOutputItem(item, 5)).toBe(item);
+  });
+
+  test("never truncates a text-transport screenshot data URL", () => {
+    const dataUrl = `data:image/png;base64,${"a".repeat(266_000)}`;
+    const item = {
+      type: "function_call_result",
+      name: "computer_screenshot",
+      callId: "computer-2",
+      status: "completed",
+      output: dataUrl,
+    };
+    expect(boundModelToolOutputItem(item, 5)).toBe(item);
+    expect(item.output).toBe(dataUrl);
+  });
+
+  test("never truncates structured function-result images", () => {
+    const item = {
+      type: "function_call_result",
+      name: "view_image",
+      callId: "image-1",
+      status: "completed",
+      output: {
+        type: "image",
+        image: { data: "a".repeat(266_000), mediaType: "image/png" },
+      },
+    };
+    expect(boundModelToolOutputItem(item, 5)).toBe(item);
+  });
+
+  test("leaves empty and already-bounded output byte-identical", () => {
+    const empty = {
+      type: "function_call_result",
+      name: "empty",
+      callId: "call-3",
+      status: "completed",
+      output: { type: "text", text: "" },
+    };
+    expect(boundModelToolOutputItem(empty)).toBe(empty);
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -216,6 +216,10 @@ const SettingsSchema = z.object({
   // Model-catalog auto-compact limit. When present it is clamped to
   // 90% of the raw window, matching Codex core's auto_compact_token_limit().
   contextAutoCompactThresholdTokens: z.coerce.number().int().positive().optional(),
+  // Provider-neutral fallback for canonical model-facing tool-result text.
+  // The current stable Codex catalog policy is 10k tokens; the truncator adds
+  // Codex's 1.2x JSON serialization allowance when applying it.
+  modelToolOutputTruncationTokens: z.coerce.number().int().positive().default(10_000),
   authRequired: EnvBoolean.default(false),
   accessKey: z.string().optional(),
   authAllowHealth: EnvBoolean.default(true),
@@ -750,6 +754,9 @@ const RegistryModelSchema = z.object({
   contextWindowTokens: z.number().int().positive().optional(),
   effectiveContextWindowTokens: z.number().int().positive().optional(),
   autoCompactTokenLimit: z.number().int().positive().optional(),
+  // Canonical model-facing function/tool-result policy. The runtime applies
+  // the same 1.2x serialization allowance as Codex when materializing output.
+  toolOutputTruncationTokens: z.number().int().positive().optional(),
   reasoningEffort: z.boolean().optional(), // model accepts a reasoning-effort control
   hostedWebSearch: z.boolean().optional(), // provider executes the hosted web_search tool for this model
   pricing: ModelPricingSchema.optional(),
@@ -808,6 +815,7 @@ export interface ConfiguredModel {
   contextWindowTokens?: number | undefined;
   effectiveContextWindowTokens?: number | undefined;
   autoCompactTokenLimit?: number | undefined;
+  toolOutputTruncationTokens?: number | undefined;
   reasoningEffort: boolean;
   hostedWebSearch: boolean;
 }
@@ -1010,6 +1018,7 @@ export function getSettings(): Settings {
     contextCompactionThresholdRatio: optional("OPENGENI_COMPACTION_THRESHOLD_RATIO"),
     contextReservedOutputTokens: optional("OPENGENI_CONTEXT_RESERVED_OUTPUT_TOKENS"),
     contextAutoCompactThresholdTokens: optional("OPENGENI_CONTEXT_AUTO_COMPACT_THRESHOLD_TOKENS"),
+    modelToolOutputTruncationTokens: optional("OPENGENI_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS"),
     authRequired: optional("OPENGENI_AUTH_REQUIRED"),
     accessKey: optional("OPENGENI_ACCESS_KEY"),
     authAllowHealth: optional("OPENGENI_AUTH_ALLOW_HEALTH"),
@@ -1368,6 +1377,7 @@ export function configuredModels(settings: Settings): ConfiguredModel[] {
       providerLabel: builtinLabel,
       api: "responses" as const,
       contextWindowTokens: settings.contextWindowTokens,
+      toolOutputTruncationTokens: settings.modelToolOutputTruncationTokens,
       reasoningEffort: true,
       hostedWebSearch: settings.webSearchEnabled,
     }));
@@ -1389,6 +1399,9 @@ export function configuredModels(settings: Settings): ConfiguredModel[] {
         ...(model.autoCompactTokenLimit === undefined
           ? {}
           : { autoCompactTokenLimit: model.autoCompactTokenLimit }),
+        ...(model.toolOutputTruncationTokens === undefined
+          ? {}
+          : { toolOutputTruncationTokens: model.toolOutputTruncationTokens }),
         reasoningEffort: model.reasoningEffort ?? false,
         hostedWebSearch: model.hostedWebSearch ?? false,
       });
@@ -1485,7 +1498,10 @@ export function settingsWithResolvedModelContext(
   settings: Settings,
   model: Pick<
     ConfiguredModel,
-    "contextWindowTokens" | "effectiveContextWindowTokens" | "autoCompactTokenLimit"
+    | "contextWindowTokens"
+    | "effectiveContextWindowTokens"
+    | "autoCompactTokenLimit"
+    | "toolOutputTruncationTokens"
   >,
 ): Settings {
   const contextWindowTokens = model.contextWindowTokens ?? settings.contextWindowTokens;
@@ -1503,6 +1519,9 @@ export function settingsWithResolvedModelContext(
     ...(model.autoCompactTokenLimit === undefined
       ? {}
       : { contextAutoCompactThresholdTokens: model.autoCompactTokenLimit }),
+    ...(model.toolOutputTruncationTokens === undefined
+      ? {}
+      : { modelToolOutputTruncationTokens: model.toolOutputTruncationTokens }),
   };
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -82,7 +82,7 @@ import {
   SessionSystemUpdatePayload,
 } from "@opengeni/contracts";
 import { environmentsEncryptionKeyBytes, type Settings } from "@opengeni/config";
-import { isCodexBilledModel } from "@opengeni/codex";
+import { boundModelToolOutputItem, isCodexBilledModel } from "@opengeni/codex";
 // Re-exported so consumers get the whole codex-billed detection surface (the pure
 // prefix test + the credential-aware predicates below) from a single import.
 export { isCodexBilledModel } from "@opengeni/codex";
@@ -11423,6 +11423,173 @@ export async function listSessions(
   });
 }
 
+export type SessionDiscoveryCursor = { createdAt: Date; id: string };
+export type SessionDiscoverySummary = {
+  id: string;
+  title: string | null;
+  parentSessionId: string | null;
+  status: SessionStatus;
+  effectiveControl: Session["effectiveControl"];
+  goal: { status: SessionGoalStatus; text: string } | null;
+  queuedPromptCount: number;
+  treeStats: NonNullable<Session["treeStats"]>;
+  latestMessage: { type: SessionEventType; preview: string | null } | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/**
+ * Compact-by-construction discovery projection for the first-party
+ * `sessions_list` MCP tool. It never selects instructions, resources, tools,
+ * MCP metadata, repositories, settings, or full event/history bodies.
+ */
+export async function listSessionDiscoverySummaries(
+  db: Database,
+  workspaceId: string,
+  options: {
+    limit: number;
+    cursor?: SessionDiscoveryCursor;
+    includeLastMessage?: boolean;
+  },
+): Promise<{
+  sessions: SessionDiscoverySummary[];
+  hasMore: boolean;
+  nextCursor: SessionDiscoveryCursor | null;
+  total: number;
+}> {
+  const limit = Math.max(1, Math.min(100, Math.floor(options.limit)));
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const cursorPredicate = options.cursor
+      ? or(
+          lt(schema.sessions.createdAt, options.cursor.createdAt),
+          and(
+            eq(schema.sessions.createdAt, options.cursor.createdAt),
+            lt(schema.sessions.id, options.cursor.id),
+          ),
+        )
+      : undefined;
+    const rows = await scopedDb
+      .select({
+        id: schema.sessions.id,
+        title: schema.sessions.title,
+        parentSessionId: schema.sessions.parentSessionId,
+        status: schema.sessions.status,
+        createdAt: schema.sessions.createdAt,
+        updatedAt: schema.sessions.updatedAt,
+      })
+      .from(schema.sessions)
+      .where(and(eq(schema.sessions.workspaceId, workspaceId), cursorPredicate))
+      .orderBy(desc(schema.sessions.createdAt), desc(schema.sessions.id))
+      .limit(limit + 1);
+    const hasMore = rows.length > limit;
+    const page = rows.slice(0, limit);
+    const ids = page.map((row) => row.id);
+    const [{ total } = { total: 0 }] = await scopedDb
+      .select({ total: sql<number>`count(*)::int` })
+      .from(schema.sessions)
+      .where(eq(schema.sessions.workspaceId, workspaceId));
+    if (ids.length === 0) {
+      return { sessions: [], hasMore: false, nextCursor: null, total: Number(total) };
+    }
+
+    const controls = await sessionControlProjections(scopedDb, workspaceId, ids);
+    const treeStats = await sessionTreeStatsForSessions(scopedDb, workspaceId, ids);
+    const goals = await scopedDb
+      .select({
+        sessionId: schema.sessionGoals.sessionId,
+        status: schema.sessionGoals.status,
+        text: schema.sessionGoals.text,
+      })
+      .from(schema.sessionGoals)
+      .where(
+        and(
+          eq(schema.sessionGoals.workspaceId, workspaceId),
+          inArray(schema.sessionGoals.sessionId, ids),
+        ),
+      );
+    const goalsBySession = new Map(goals.map((goal) => [goal.sessionId, goal]));
+    const queueCounts = await scopedDb
+      .select({
+        sessionId: schema.sessionTurns.sessionId,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(schema.sessionTurns)
+      .where(
+        and(
+          eq(schema.sessionTurns.workspaceId, workspaceId),
+          inArray(schema.sessionTurns.sessionId, ids),
+          eq(schema.sessionTurns.status, "queued"),
+          inArray(schema.sessionTurns.source, ["user", "api"]),
+        ),
+      )
+      .groupBy(schema.sessionTurns.sessionId);
+    const queueBySession = new Map(
+      queueCounts.map((entry) => [entry.sessionId, Number(entry.count)]),
+    );
+    const latestMessages = options.includeLastMessage
+      ? await scopedDb
+          .selectDistinctOn([schema.sessionEvents.sessionId], {
+            sessionId: schema.sessionEvents.sessionId,
+            type: schema.sessionEvents.type,
+            // Extract only the bounded textual preview in PostgreSQL. Selecting
+            // the JSON payload here would re-materialize the exact multi-MB
+            // event bodies this compact discovery path exists to avoid.
+            preview: sql<string | null>`left(coalesce(
+              ${schema.sessionEvents.payload}->>'text',
+              ${schema.sessionEvents.payload}->>'message',
+              ${schema.sessionEvents.payload}->>'content'
+            ), 1200)`,
+          })
+          .from(schema.sessionEvents)
+          .where(
+            and(
+              eq(schema.sessionEvents.workspaceId, workspaceId),
+              inArray(schema.sessionEvents.sessionId, ids),
+              inArray(schema.sessionEvents.type, ["user.message", "agent.message.completed"]),
+            ),
+          )
+          .orderBy(schema.sessionEvents.sessionId, desc(schema.sessionEvents.sequence))
+      : [];
+    const latestBySession = new Map(latestMessages.map((entry) => [entry.sessionId, entry]));
+    const sessions = page.map((row): SessionDiscoverySummary => {
+      const control = controls.get(row.id);
+      if (!control) throw new Error(`Effective control missing for session ${row.id}`);
+      const goal = goalsBySession.get(row.id);
+      const latest = latestBySession.get(row.id);
+      return {
+        id: row.id,
+        title: row.title,
+        parentSessionId: row.parentSessionId,
+        status: row.status as SessionStatus,
+        effectiveControl: control,
+        goal: goal ? { status: goal.status as SessionGoalStatus, text: goal.text } : null,
+        queuedPromptCount: queueBySession.get(row.id) ?? 0,
+        treeStats: treeStats.get(row.id) ?? {
+          directChildren: 0,
+          totalDescendants: 0,
+          runningDescendants: 0,
+          queuedDescendants: 0,
+          attentionDescendants: 0,
+          pausedDescendants: 0,
+          failedDescendants: 0,
+        },
+        latestMessage: latest
+          ? { type: latest.type as SessionEventType, preview: latest.preview }
+          : null,
+        createdAt: row.createdAt.toISOString(),
+        updatedAt: row.updatedAt.toISOString(),
+      };
+    });
+    const last = page.at(-1);
+    return {
+      sessions,
+      hasMore,
+      nextCursor: hasMore && last ? { createdAt: last.createdAt, id: last.id } : null,
+      total: Number(total),
+    };
+  });
+}
+
 export type SessionLineage = {
   ancestors: Session[];
   children: LineageNode[];
@@ -11989,6 +12156,7 @@ export async function appendSessionHistoryItems(
     // id), or null/undefined on the non-codex path. Stored verbatim so the read
     // path can strip cross-account reasoning.encrypted_content blobs per turn.
     producerCodexCredentialId?: string | null;
+    modelToolOutputTruncationTokens?: number;
     items: Array<{ position: number; item: Record<string, unknown> }>;
   },
 ): Promise<boolean> {
@@ -12018,7 +12186,12 @@ export async function appendSessionHistoryItems(
               turnId: input.turnId,
               producerCodexCredentialId: input.producerCodexCredentialId ?? null,
               position: entry.position,
-              item: sanitizeModelPayload(entry.item),
+              // This is the canonical model-memory boundary. The pending-call
+              // ledger and audit event may retain their separate raw/preview
+              // forms, but conversation truth is always the bounded Codex form.
+              item: sanitizeModelPayload(
+                boundModelToolOutputItem(entry.item, input.modelToolOutputTruncationTokens),
+              ),
             })),
           )
           .onConflictDoNothing({
@@ -12586,7 +12759,11 @@ export async function recordSkippedContextCompaction(
     turnId: string;
     expectedExecutionGeneration: number;
     expectedAttemptId: string;
-    reason: "no_history" | "replacement_not_smaller";
+    reason:
+      | "no_history"
+      | "replacement_not_smaller"
+      | "replacement_unchanged"
+      | "summarization_failed";
   },
 ): Promise<
   | { recorded: true; events: SessionEvent[] }

--- a/packages/db/src/session-tool-call-settlement.ts
+++ b/packages/db/src/session-tool-call-settlement.ts
@@ -1,4 +1,5 @@
 import type { SessionEvent } from "@opengeni/contracts";
+import { boundModelToolOutputItem } from "@opengeni/codex";
 import { and, asc, eq, sql } from "drizzle-orm";
 import type { Database } from "./index";
 import { sanitizeEventPayload, sanitizeModelPayload } from "./event-payload-sanitizer";
@@ -210,7 +211,7 @@ export async function closePendingSessionToolCallsInTransaction(
         sessionId: input.sessionId,
         turnId: input.turnId,
         position: nextPosition++,
-        item: sanitizeModelPayload(resolution.result),
+        item: sanitizeModelPayload(boundModelToolOutputItem(resolution.result)),
         active: true,
       });
     }

--- a/packages/db/test/migration-0053.test.ts
+++ b/packages/db/test/migration-0053.test.ts
@@ -7,9 +7,8 @@ import postgres from "postgres";
 import {
   chooseShardedHome,
   selectCodexCredentialLeaseForTurn,
-  type CodexRotationAccount,
 } from "../../../apps/worker/src/activities/codex-rotation";
-import { acquireCodexCredentialLease, createDb } from "../src/index";
+import { acquireCodexCredentialLease, createDb, type CodexLeaseAccountStatus } from "../src/index";
 import { migrate } from "../src/migrate";
 
 const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), "../drizzle");
@@ -169,7 +168,17 @@ describe("migration 0053 (Codex credential leases)", () => {
             rotation_enabled = true,
             lease_rotation_enabled = false
         where workspace_id = ${workspaceId}`;
-      const rollbackAccounts: CodexRotationAccount[] = [credentialA, credentialB].map((id) => ({
+      // Production's allocator order is `created_at ASC, id ASC`. Both fixture
+      // credentials are inserted in one statement, so PostgreSQL gives them the
+      // same transaction timestamp and the UUID tie-breaker is authoritative;
+      // INSERT RETURNING order is not. Build the expected sharding snapshot from
+      // the exact production ordering so this migration proof is deterministic.
+      const stableCredentialIds = await admin<{ id: string }[]>`
+        select id
+        from codex_subscription_credentials
+        where workspace_id = ${workspaceId}
+        order by created_at asc, id asc`;
+      const rollbackAccounts: CodexLeaseAccountStatus[] = stableCredentialIds.map(({ id }) => ({
         id,
         chatgptAccountId: null,
         label: null,
@@ -195,30 +204,7 @@ describe("migration 0053 (Codex credential leases)", () => {
       }));
       const rollbackSelection = selectCodexCredentialLeaseForTurn({
         context: {
-          accounts: [credentialA, credentialB].map((id) => ({
-            id,
-            chatgptAccountId: null,
-            label: null,
-            accountEmail: null,
-            planType: "pro",
-            status: "active",
-            allocatorEnabled: true,
-            isActive: id === credentialB,
-            expiresAt: null,
-            lastRefreshAt: null,
-            lastError: null,
-            primaryUsedPercent: 0,
-            primaryResetAt: null,
-            secondaryUsedPercent: 0,
-            secondaryResetAt: null,
-            usageCheckedAt: null,
-            exhaustedUntil: null,
-            connectorNamespaces: null,
-            connectorsCheckedAt: null,
-            activeLeaseCount: 0,
-            selectionCount: 0,
-            lastSelectedAt: null,
-          })),
+          accounts: rollbackAccounts,
           activeCredentialId: credentialB,
           rotationEnabled: true,
           leaseRotationEnabled: false,

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -23,6 +23,7 @@ import {
   getSession,
   getSessionTurn,
   listOutstandingSessionSystemUpdates,
+  listSessionDiscoverySummaries,
   listSessionSystemUpdatesForTurn,
   listUsageEvents,
   listWorkspaceControlEvents,
@@ -184,6 +185,173 @@ async function claimTestSessionWork(
 }
 
 describe("clean session control plane", () => {
+  test("session discovery is compact-by-query and cursor-stable", async () => {
+    const { grant, session: first } = await fixture();
+    const second = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "second",
+      resources: [],
+      metadata: { mustNeverLeak: "x".repeat(100_000) },
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    const third = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "third",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await appendSessionEvents(client.db, grant.workspaceId!, second.id, [
+      { type: "user.message", payload: { text: "p".repeat(20_000) } },
+    ]);
+
+    const all = await listSessionDiscoverySummaries(client.db, grant.workspaceId!, {
+      limit: 3,
+      includeLastMessage: true,
+    });
+    const projectedSecond = all.sessions.find((entry) => entry.id === second.id)!;
+    expect(projectedSecond.latestMessage?.preview).toHaveLength(1_200);
+    expect(JSON.stringify(projectedSecond)).not.toContain("mustNeverLeak");
+
+    const pageOne = await listSessionDiscoverySummaries(client.db, grant.workspaceId!, {
+      limit: 2,
+    });
+    expect(pageOne).toMatchObject({ total: 3, hasMore: true });
+    expect(pageOne.sessions).toHaveLength(2);
+    expect(pageOne.nextCursor).toBeTruthy();
+
+    const pageTwo = await listSessionDiscoverySummaries(client.db, grant.workspaceId!, {
+      limit: 2,
+      cursor: pageOne.nextCursor!,
+    });
+    expect(pageTwo.sessions).toHaveLength(1);
+    expect(pageTwo.hasMore).toBe(false);
+    expect(new Set([...pageOne.sessions, ...pageTwo.sessions].map((entry) => entry.id))).toEqual(
+      new Set([first.id, second.id, third.id]),
+    );
+  });
+
+  test("canonical history bounds tool output while the pending receipt keeps raw recovery evidence", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "inspect a very large result");
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId },
+    );
+    const huge = "x".repeat(500_000);
+    expect(
+      await appendSessionHistoryItems(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn!.id,
+        expectedExecutionGeneration: turn!.executionGeneration,
+        expectedAttemptId: attemptId,
+        modelToolOutputTruncationTokens: 100,
+        items: [
+          {
+            position: 0,
+            item: {
+              type: "function_call",
+              callId: "canonical-call",
+              name: "sessions_list",
+              arguments: "{}",
+            },
+          },
+          {
+            position: 1,
+            item: {
+              type: "function_call_result",
+              callId: "canonical-call",
+              output: { type: "text", text: huge },
+            },
+          },
+        ],
+      }),
+    ).toBe(true);
+    const canonical = await getActiveSessionHistoryItems(client.db, grant.workspaceId!, session.id);
+    const canonicalText = (canonical[1]!.item.output as { text: string }).text;
+    expect(canonicalText).toContain("tokens truncated");
+    expect(canonicalText.length).toBeLessThan(1_000);
+
+    expect(
+      await registerPendingSessionToolCall(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn!.id,
+        executionGeneration: turn!.executionGeneration,
+        attemptId,
+        callId: "pending-call",
+        callType: "function_call",
+        callItem: {
+          type: "function_call",
+          callId: "pending-call",
+          name: "raw_tool",
+          arguments: "{}",
+        },
+      }),
+    ).toEqual({ accepted: true, registered: true });
+    await recordPendingSessionToolCallResult(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      turnId: turn!.id,
+      executionGeneration: turn!.executionGeneration,
+      attemptId,
+      callId: "pending-call",
+      resultItem: {
+        type: "function_call_result",
+        callId: "pending-call",
+        output: { type: "text", text: huge },
+      },
+    });
+    const [pending] = await withWorkspaceRls(client.db, grant.workspaceId!, (db) =>
+      db
+        .select({ resultItem: schema.sessionPendingToolCalls.resultItem })
+        .from(schema.sessionPendingToolCalls)
+        .where(eq(schema.sessionPendingToolCalls.callId, "pending-call")),
+    );
+    expect(((pending!.resultItem as any).output as { text: string }).text).toBe(huge);
+
+    const recovery = await requestSessionTurnRecovery(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: turn!.id,
+      triggerEventId: turn!.triggerEventId,
+      attemptId,
+      reason: "worker_shutdown",
+    });
+    expect(recovery).toMatchObject({ action: "recovering" });
+    const recoveredHistory = await getActiveSessionHistoryItems(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+    );
+    const recoveredResult = recoveredHistory
+      .map((row) => row.item)
+      .find(
+        (item) =>
+          item.type === "function_call_result" &&
+          (item as { callId?: unknown }).callId === "pending-call",
+      ) as { output: { text: string } };
+    expect(recoveredResult.output.text).toContain("tokens truncated");
+    expect(recoveredResult.output.text.length).toBeLessThan(50_000);
+    const recoveryOutput = recovery.events.find(
+      (event) =>
+        event.type === "agent.toolCall.output" &&
+        (event.payload as { id?: unknown }).id === "pending-call",
+    )?.payload as { output: { text: string } };
+    expect(recoveryOutput.output.text).toBe(huge);
+  });
+
   test("bulk control projection accepts an empty session page", async () => {
     const { grant } = await fixture();
     expect(

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -393,7 +393,7 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
           tone: "waiting",
           text:
             before && after
-              ? `Context compacted from approximately ${before} to ${after} tokens.`
+              ? `Active conversation history compacted from approximately ${before} to ${after} tokens.`
               : "Context compacted so the turn could continue.",
           occurredAt: event.occurredAt,
         });
@@ -406,13 +406,17 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
         items.push({
           kind: "notice",
           id: event.id,
-          tone: "waiting",
+          tone: reason === "summarization_failed" ? "failed" : "waiting",
           text:
             reason === "no_history"
               ? "Context compaction skipped because there is no active history to compact."
               : reason === "replacement_not_smaller"
                 ? "Context compaction skipped because the generated checkpoint would not reduce the context."
-                : "Context compaction was not needed.",
+                : reason === "replacement_unchanged"
+                  ? "Context compaction stopped because it reproduced the same checkpoint without making progress."
+                  : reason === "summarization_failed"
+                    ? "Context compaction failed without replacing the active conversation history. Request it again to retry."
+                    : "Context compaction was not needed.",
           occurredAt: event.occurredAt,
         });
         break;

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -694,7 +694,7 @@ describe("buildTimeline", () => {
     expect(items[0]).toMatchObject({
       kind: "notice",
       tone: "waiting",
-      text: "Context compacted from approximately 288,000 to 23,091 tokens.",
+      text: "Active conversation history compacted from approximately 288,000 to 23,091 tokens.",
     });
   });
 
@@ -729,6 +729,20 @@ describe("buildTimeline", () => {
         kind: "notice",
         tone: "waiting",
         text: "Context compaction skipped because the generated checkpoint would not reduce the context.",
+      }),
+    ]);
+  });
+
+  test("shows a terminal compaction-summary failure without claiming history changed", () => {
+    reset();
+    const items = buildTimeline([
+      event("session.context.compaction.skipped", { reason: "summarization_failed" }),
+    ]);
+    expect(items).toEqual([
+      expect.objectContaining({
+        kind: "notice",
+        tone: "failed",
+        text: "Context compaction failed without replacing the active conversation history. Request it again to retry.",
       }),
     ]);
   });

--- a/packages/runtime/src/context-compaction.ts
+++ b/packages/runtime/src/context-compaction.ts
@@ -9,6 +9,7 @@
  */
 
 import { TOOL_CALL_RESULT_TYPE_BY_CALL_TYPE } from "./history-sanitizer";
+import { createHash } from "node:crypto";
 
 export type CompactionItem = Record<string, unknown>;
 
@@ -53,6 +54,19 @@ export const USER_MESSAGE_TRUNCATION_MARKER =
 
 const RESULT_TYPE_BY_CALL_TYPE = TOOL_CALL_RESULT_TYPE_BY_CALL_TYPE;
 const RESULT_TYPES = new Set(Object.values(RESULT_TYPE_BY_CALL_TYPE));
+const MODEL_GENERATED_ITEM_TYPES = new Set([
+  "reasoning",
+  "function_call",
+  "custom_tool_call",
+  "tool_search_call",
+  "web_search_call",
+  "image_generation_call",
+  "computer_call",
+  "shell_call",
+  "apply_patch_call",
+  "compaction",
+  "context_compaction",
+]);
 
 function itemType(item: unknown): string | undefined {
   if (!item || typeof item !== "object") {
@@ -109,6 +123,109 @@ export function estimateTokens(items: readonly CompactionItem[]): number {
   return total;
 }
 
+export function estimateSerializedValueTokens(value: unknown): number {
+  let serialized: string;
+  try {
+    serialized = typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    serialized = String(value);
+  }
+  return Math.ceil(Buffer.byteLength(serialized ?? "", "utf8") / 4);
+}
+
+export type CompleteModelInputFootprint = {
+  input: readonly CompactionItem[];
+  instructionsTokens: number;
+  toolSchemaTokens: number;
+};
+
+export type ProviderContextTokenSignal = {
+  /** Monotonic within one sampled run; advances after every model response. */
+  revision: number;
+  /** Provider total tokens after that response (input + generated output). */
+  totalTokens: number;
+};
+
+export type CompleteModelInputEstimate = {
+  tokens: number;
+  source: "complete_estimate" | "provider_plus_local";
+  inputTokens: number;
+  instructionsTokens: number;
+  toolSchemaTokens: number;
+  appendedAfterModelTokens: number;
+};
+
+/**
+ * Match Codex history accounting: after one provider response, start from its
+ * authoritative TOTAL token count and add only local items placed after the
+ * newest model-generated item. System instructions and tool schemas are
+ * compared with the exact request footprint that produced the provider count;
+ * positive growth is added. Without a bound anchor, estimate the entire
+ * outgoing request rather than trusting stale usage from an earlier turn.
+ */
+export function estimateCompleteModelInput(input: {
+  current: CompleteModelInputFootprint;
+  provider?: ProviderContextTokenSignal | null;
+  providerRequestFootprint?: CompleteModelInputFootprint | null;
+}): CompleteModelInputEstimate {
+  const inputTokens = estimateTokens(input.current.input);
+  const instructionsTokens = input.current.instructionsTokens;
+  const toolSchemaTokens = input.current.toolSchemaTokens;
+  if (!input.provider || !input.providerRequestFootprint || input.provider.totalTokens <= 0) {
+    return {
+      tokens: inputTokens + instructionsTokens + toolSchemaTokens,
+      source: "complete_estimate",
+      inputTokens,
+      instructionsTokens,
+      toolSchemaTokens,
+      appendedAfterModelTokens: 0,
+    };
+  }
+
+  const appended = itemsAfterLastModelGeneratedItem(input.current.input);
+  const appendedAfterModelTokens = estimateTokens(appended);
+  const instructionGrowth = Math.max(
+    0,
+    instructionsTokens - input.providerRequestFootprint.instructionsTokens,
+  );
+  const toolSchemaGrowth = Math.max(
+    0,
+    toolSchemaTokens - input.providerRequestFootprint.toolSchemaTokens,
+  );
+  return {
+    tokens:
+      input.provider.totalTokens + appendedAfterModelTokens + instructionGrowth + toolSchemaGrowth,
+    source: "provider_plus_local",
+    inputTokens,
+    instructionsTokens,
+    toolSchemaTokens,
+    appendedAfterModelTokens,
+  };
+}
+
+export function itemsAfterLastModelGeneratedItem(
+  items: readonly CompactionItem[],
+): CompactionItem[] {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (isModelGeneratedItem(items[index])) {
+      return items.slice(index + 1);
+    }
+  }
+  // Codex treats a provider token anchor without any model-generated item as
+  // unbound. Callers therefore fall back to a complete estimate in that case.
+  return items.slice();
+}
+
+export function hasModelGeneratedItem(items: readonly CompactionItem[]): boolean {
+  return items.some(isModelGeneratedItem);
+}
+
+function isModelGeneratedItem(item: unknown): boolean {
+  const type = itemType(item);
+  if (type === "message") return itemRole(item) === "assistant";
+  return MODEL_GENERATED_ITEM_TYPES.has(type ?? "");
+}
+
 export function clampCompactionThresholdRatio(value: number | undefined | null): number {
   const numeric =
     typeof value === "number" && Number.isFinite(value)
@@ -159,7 +276,11 @@ export function decideCompaction(input: {
     typeof input.lastInputTokens === "number" && input.lastInputTokens > 0
       ? input.lastInputTokens
       : 0;
-  const signalTokens = recorded > 0 ? recorded : estimateTokens(input.items);
+  const activeHistoryEstimate = estimateTokens(input.items);
+  // A durable provider count belongs to an earlier request. The full active
+  // estimate is a conservative cross-turn floor until an exact same-run anchor
+  // is available in the per-call guard.
+  const signalTokens = Math.max(recorded, activeHistoryEstimate);
   if (input.items.length === 0) {
     return { shouldCompact: false, reason: "no_history", signalTokens, thresholdTokens };
   }
@@ -195,6 +316,19 @@ export class CompactionNeededError extends Error {
     this.thresholdTokens = input.thresholdTokens;
     this.signalSource = input.signalSource;
     this.trigger = trigger;
+  }
+}
+
+export class EmptyCompactionSummaryError extends Error {
+  readonly diagnostics: Record<string, unknown>;
+
+  constructor(diagnostics: Record<string, unknown> = {}) {
+    const compact = JSON.stringify(diagnostics).slice(0, 2_000);
+    super(
+      `Compaction summarizer returned no assistant text; active history was preserved${compact ? ` (${compact})` : ""}`,
+    );
+    this.name = "EmptyCompactionSummaryError";
+    this.diagnostics = diagnostics;
   }
 }
 
@@ -262,12 +396,46 @@ export function buildCompactionReplacementHistory(
   return history;
 }
 
+export function compactionReplacementFingerprint(items: readonly CompactionItem[]): string {
+  // PostgreSQL JSONB does not preserve JavaScript object-key insertion order.
+  // Canonicalize recursively so a replacement has the same identity before
+  // and after its durable round trip.
+  const serialized = JSON.stringify(canonicalJsonValue(items));
+  return createHash("sha256").update(serialized, "utf8").digest("hex");
+}
+
+function canonicalJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalJsonValue);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalJsonValue(entry)]),
+  );
+}
+
+/** Fingerprint the latest durable replacement prefix in active history. */
+export function latestCompactionReplacementFingerprint(
+  items: readonly CompactionItem[],
+): string | null {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (isCompactionSummary(items[index])) {
+      return compactionReplacementFingerprint(items.slice(0, index + 1));
+    }
+  }
+  return null;
+}
+
 /**
  * Build the synthetic summary item (a plain user message) appended to the
  * rebuilt active history.
  */
 export function buildSummaryItem(summaryBody: string): CompactionItem {
-  const trimmed = summaryBody.trim() || "(no summary available)";
+  const trimmed = summaryBody.trim();
+  if (!trimmed) {
+    throw new EmptyCompactionSummaryError({ stage: "build_summary_item" });
+  }
   return {
     type: "message",
     role: "user",

--- a/packages/runtime/src/history-sanitizer.ts
+++ b/packages/runtime/src/history-sanitizer.ts
@@ -28,6 +28,10 @@
  */
 
 import { SCREENSHOT_FAILURE_CARD_IMAGE_URL } from "./screenshot-error-card";
+import {
+  boundModelToolOutputItems,
+  DEFAULT_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS,
+} from "@opengeni/codex";
 
 /** A history item is any JSON object; we only inspect a few discriminator fields. */
 export type HistoryItem = Record<string, unknown>;
@@ -224,7 +228,10 @@ export function elideSupersededViewImagePairs<T extends HistoryItem>(items: read
  * types exist with that id, the call appearing before the result. Calls and
  * results that satisfy that survive untouched.
  */
-export function sanitizeHistoryItemsForModel<T extends HistoryItem>(items: readonly T[]): T[] {
+export function sanitizeHistoryItemsForModel<T extends HistoryItem>(
+  items: readonly T[],
+  toolOutputTruncationTokens = DEFAULT_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS,
+): T[] {
   if (items.length === 0) {
     return [];
   }
@@ -314,10 +321,12 @@ export function sanitizeHistoryItemsForModel<T extends HistoryItem>(items: reado
     }
   }
 
-  if (dropped.size === 0) {
-    return items.map(stripInternalResumeMarker);
-  }
-  return items.filter((_item, index) => !dropped.has(index)).map(stripInternalResumeMarker);
+  const paired =
+    dropped.size === 0 ? items.slice() : items.filter((_item, index) => !dropped.has(index));
+  return boundModelToolOutputItems(
+    paired.map(stripInternalResumeMarker),
+    toolOutputTruncationTokens,
+  );
 }
 
 /**

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -104,6 +104,7 @@ import {
   CODEX_APPS_MCP_SERVER_ID,
   CODEX_MODEL_ID_PREFIX,
   CODEX_ORIGINATOR,
+  boundModelToolOutputItems,
   codexAppsSanitizingFetch,
   codexRequestStorage,
   codexSubscriptionFetch,
@@ -121,10 +122,15 @@ import {
 import { installCodexToolSearch } from "./codex-tool-search";
 import {
   CompactionNeededError,
+  EmptyCompactionSummaryError,
   SUMMARY_BUFFER_TOKENS,
   compactionThresholdTokens,
-  estimateTokens,
+  estimateCompleteModelInput,
+  estimateSerializedValueTokens,
+  hasModelGeneratedItem,
   renderCompactionPromptInputForChat,
+  type CompleteModelInputFootprint,
+  type ProviderContextTokenSignal,
 } from "./context-compaction";
 import {
   createSandboxClient,
@@ -188,17 +194,23 @@ export { OpenAIChatCompletionsModel, OpenAIResponsesModel } from "@openai/agents
 
 export {
   CompactionNeededError,
+  EmptyCompactionSummaryError,
   buildCompactionPromptInput,
   buildCompactionReplacementHistory,
+  compactionReplacementFingerprint,
   compactionThresholdTokens,
   clampCompactionThresholdRatio,
   decideCompaction,
   buildSummaryItem,
   findCompactionNeededError,
   isCompactionSummary,
+  latestCompactionReplacementFingerprint,
   isUserMessage,
   estimateTokens,
   estimateItemTokens,
+  estimateCompleteModelInput,
+  estimateSerializedValueTokens,
+  hasModelGeneratedItem,
   renderCompactionPromptInputForChat,
   COMPACTION_SUMMARY_MARKER,
   COMPACTION_PROMPT,
@@ -816,7 +828,11 @@ export async function summarizeForCompaction(
     }
     const text = (completion as { choices?: Array<{ message?: { content?: unknown } }> })
       .choices?.[0]?.message?.content;
-    return typeof text === "string" ? text.trim() : "";
+    const summary = typeof text === "string" ? text.trim() : "";
+    if (!summary) {
+      throw new EmptyCompactionSummaryError(compactionResponseDiagnostics(completion, summary));
+    }
+    return summary;
   }
   // Use the same SDK Responses adapter as the real agent call. It converts the
   // structured AgentInputItems (callId/providerData/etc.) to provider wire
@@ -844,7 +860,67 @@ export async function summarizeForCompaction(
   if (usage) {
     await options.onUsage?.(usage);
   }
-  return extractResponseOutputText(response).trim();
+  const summary = extractResponseOutputText(response).trim();
+  if (!summary) {
+    throw new EmptyCompactionSummaryError(compactionResponseDiagnostics(response, summary));
+  }
+  return summary;
+}
+
+/** Bounded, content-free diagnostics for a semantically empty checkpoint. */
+export function compactionResponseDiagnostics(
+  response: unknown,
+  extractedText = extractResponseOutputText(response).trim(),
+): Record<string, unknown> {
+  if (!response || typeof response !== "object") {
+    return { responseShape: typeof response, extractedTextLength: extractedText.length };
+  }
+  const record = response as Record<string, unknown>;
+  const output = Array.isArray(record.output) ? record.output : [];
+  const outputItems = output.slice(0, 50).map((item) => {
+    if (!item || typeof item !== "object") return { type: typeof item };
+    const value = item as Record<string, unknown>;
+    const content = Array.isArray(value.content) ? value.content : [];
+    return {
+      type: typeof value.type === "string" ? value.type : null,
+      role: typeof value.role === "string" ? value.role : null,
+      status: typeof value.status === "string" ? value.status : null,
+      contentPartTypes: content
+        .slice(0, 50)
+        .map((part) =>
+          part && typeof part === "object" && typeof (part as { type?: unknown }).type === "string"
+            ? (part as { type: string }).type
+            : typeof part,
+        ),
+      contentPartCount: content.length,
+    };
+  });
+  const choices = Array.isArray(record.choices) ? record.choices : [];
+  const usage = modelResponseUsageFromResponse(response)?.usage;
+  const incomplete =
+    record.incomplete_details && typeof record.incomplete_details === "object"
+      ? (record.incomplete_details as Record<string, unknown>)
+      : null;
+  return {
+    responseId: typeof record.id === "string" ? record.id : null,
+    status: typeof record.status === "string" ? record.status : null,
+    outputItemCount: output.length,
+    outputItems,
+    choiceCount: choices.length,
+    finishReasons: choices
+      .slice(0, 20)
+      .map((choice) =>
+        choice && typeof choice === "object"
+          ? ((choice as Record<string, unknown>).finish_reason ?? null)
+          : null,
+      ),
+    incompleteReason:
+      incomplete && typeof incomplete.reason === "string" ? incomplete.reason : null,
+    inputTokens: usage?.inputTokens ?? null,
+    outputTokens: usage?.outputTokens ?? null,
+    totalTokens: usage?.totalTokens ?? null,
+    extractedTextLength: extractedText.length,
+  };
 }
 
 /**
@@ -2588,6 +2664,7 @@ class PrefixedMcpServer implements MCPServer {
   // doesn't spam the log when the SDK re-lists across model turns.
   private readonly bestEffort: boolean;
   private loggedListToolsFailure = false;
+  private listedToolSchemaTokens = 0;
 
   constructor(
     private readonly inner: MCPServer,
@@ -2644,12 +2721,19 @@ class PrefixedMcpServer implements MCPServer {
       }
       return [];
     }
-    return tools
+    const exposed = tools
       .filter((tool) => this.isAllowed(tool.name))
       .map((tool) => ({
         ...tool,
         name: prefixedMcpToolName(this.name, tool.name),
       }));
+    this.listedToolSchemaTokens = estimateSerializedValueTokens(exposed);
+    return exposed;
+  }
+
+  /** Latest exact tools/list projection used to build the model request. */
+  modelToolSchemaTokens(): number {
+    return this.listedToolSchemaTokens;
   }
 
   async callTool(
@@ -2842,7 +2926,7 @@ export type RunAgentStreamOptions = {
   sandboxClient?: unknown;
   sandboxEnvironment?: Record<string, string>;
   onRuntimeEvent?: (event: NormalizedRuntimeEvent) => Promise<void> | void;
-  contextCompactionSignalTokens?: () => number | null | undefined;
+  contextCompactionSignal?: () => ProviderContextTokenSignal | null | undefined;
   contextCompactionRequested?: () => boolean | Promise<boolean>;
   // Host-managed git credential renewal registration. Called only after the
   // initial token-file seed completed on a real provisioned box. The worker
@@ -2888,7 +2972,7 @@ export type RunAgentStreamOptions = {
 };
 
 export type ContextRobustnessFilterOptions = {
-  contextCompactionSignalTokens?: () => number | null | undefined;
+  contextCompactionSignal?: () => ProviderContextTokenSignal | null | undefined;
   contextCompactionRequested?: () => boolean | Promise<boolean>;
   throwOnCompactionNeeded?: boolean;
 };
@@ -2995,24 +3079,89 @@ export const elideSupersededViewImagesFilter: CallModelInputFilter = ({ modelDat
   ) as unknown as AgentInputItem[],
 });
 
+/**
+ * Canonical Codex-style tool-result bound at the final model-input seam. The
+ * identical pure normalizer also runs before conversation rows are persisted,
+ * so this is a live-turn defense rather than a request-only alternate history.
+ */
+export function boundModelToolOutputsFilterForSettings(settings: Settings): CallModelInputFilter {
+  return ({ modelData }) => ({
+    ...modelData,
+    input: boundModelToolOutputItems(
+      modelData.input as unknown as Array<Record<string, unknown>>,
+      settings.modelToolOutputTruncationTokens,
+    ) as unknown as AgentInputItem[],
+  });
+}
+
+function estimateAgentToolSchemaTokens(agent: Agent<any, any>): number {
+  const localTools = Array.isArray((agent as { tools?: unknown }).tools)
+    ? ((agent as { tools: unknown[] }).tools ?? [])
+    : [];
+  const localDescriptors = localTools.map((candidate) => {
+    if (!candidate || typeof candidate !== "object") return candidate;
+    const tool = candidate as Record<string, unknown>;
+    return {
+      type: tool.type,
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+      inputSchema: tool.inputSchema,
+      strict: tool.strict,
+      providerData: tool.providerData,
+    };
+  });
+  const mcpServers = Array.isArray((agent as { mcpServers?: unknown }).mcpServers)
+    ? ((agent as { mcpServers: unknown[] }).mcpServers ?? [])
+    : [];
+  const mcpTokens = mcpServers.reduce<number>((total, server) => {
+    const getter = (server as { modelToolSchemaTokens?: () => number } | null)
+      ?.modelToolSchemaTokens;
+    return total + (typeof getter === "function" ? getter.call(server) : 0);
+  }, 0);
+  return estimateSerializedValueTokens(localDescriptors) + mcpTokens;
+}
+
 export function contextRobustnessFilterForSettings(
   settings: Settings,
   options: ContextRobustnessFilterOptions = {},
 ): CallModelInputFilter {
   const thresholdTokens = compactionThresholdTokens(settings);
-  return async ({ modelData }) => {
+  let previousRequest: { revision: number; footprint: CompleteModelInputFootprint } | null = null;
+  let requestRevision = 0;
+  return async ({ modelData, agent }) => {
     const input = modelData.input;
     if (options.throwOnCompactionNeeded) {
-      const reported = options.contextCompactionSignalTokens?.();
-      const hasReported = typeof reported === "number" && reported > 0;
-      const signalTokens = hasReported
-        ? reported
-        : estimateTokens(input as unknown as Array<Record<string, unknown>>);
+      const reported = options.contextCompactionSignal?.();
+      const current: CompleteModelInputFootprint = {
+        input: input as unknown as Array<Record<string, unknown>>,
+        instructionsTokens: estimateSerializedValueTokens(modelData.instructions ?? ""),
+        toolSchemaTokens: estimateAgentToolSchemaTokens(agent),
+      };
+      // Stream consumption can lag the SDK's background model loop. A provider
+      // usage signal is safe only when its response revision belongs to the
+      // immediately preceding request. Never attach a delayed response count to
+      // a newer footprint: doing so can hide all model output produced between
+      // them and recreate an under-counting compaction loop.
+      const boundProvider =
+        reported &&
+        previousRequest &&
+        reported.revision === previousRequest.revision &&
+        hasModelGeneratedItem(current.input)
+          ? reported
+          : null;
+      const estimate = estimateCompleteModelInput({
+        current,
+        provider: boundProvider,
+        providerRequestFootprint: boundProvider ? (previousRequest?.footprint ?? null) : null,
+      });
+      const signalTokens = estimate.tokens;
+      previousRequest = { revision: ++requestRevision, footprint: current };
       if (await options.contextCompactionRequested?.()) {
         throw new CompactionNeededError({
           signalTokens,
           thresholdTokens,
-          signalSource: hasReported ? "provider" : "estimate",
+          signalSource: boundProvider ? "provider" : "estimate",
           trigger: "operator",
         });
       }
@@ -3020,7 +3169,7 @@ export function contextRobustnessFilterForSettings(
         throw new CompactionNeededError({
           signalTokens,
           thresholdTokens,
-          signalSource: hasReported ? "provider" : "estimate",
+          signalSource: boundProvider ? "provider" : "estimate",
         });
       }
     }
@@ -3057,6 +3206,7 @@ export function callModelInputFilterForSettings(
   const filters: CallModelInputFilter[] = [
     normalizeComputerCallsFilter,
     elideSupersededViewImagesFilter,
+    boundModelToolOutputsFilterForSettings(settings),
   ];
   if (settings.openaiProviderItemIds === "strip") {
     filters.push(stripProviderItemIdsFilter);
@@ -3148,23 +3298,24 @@ export async function runAgentStream(
     const decoratedClient = withSandboxLifecycleHooks(resourceClient, ownedHooks, ownedHookContext);
     const ownedFilter = composeCallModelInputFilters(
       [
-        callModelInputFilterForSettings(settings, {
-          throwOnCompactionNeeded: Boolean(
-            overrides.contextCompactionSignalTokens || overrides.contextCompactionRequested,
-          ),
-          ...(overrides.contextCompactionSignalTokens
-            ? {
-                contextCompactionSignalTokens: overrides.contextCompactionSignalTokens,
-              }
-            : {}),
-          ...(overrides.contextCompactionRequested
-            ? {
-                contextCompactionRequested: overrides.contextCompactionRequested,
-              }
-            : {}),
-        }),
+        callModelInputFilterForSettings(settings),
         genesisTitleInputFilter,
         overrides.callModelInputFilter,
+        // A caller filter may synthesize model input. Re-apply the idempotent
+        // canonical bound at the literal final seam before accounting/provider
+        // serialization so no extension can bypass the policy.
+        boundModelToolOutputsFilterForSettings(settings),
+        contextRobustnessFilterForSettings(settings, {
+          throwOnCompactionNeeded: Boolean(
+            overrides.contextCompactionSignal || overrides.contextCompactionRequested,
+          ),
+          ...(overrides.contextCompactionSignal
+            ? { contextCompactionSignal: overrides.contextCompactionSignal }
+            : {}),
+          ...(overrides.contextCompactionRequested
+            ? { contextCompactionRequested: overrides.contextCompactionRequested }
+            : {}),
+        }),
       ].filter((f): f is CallModelInputFilter => Boolean(f)),
     );
     const ownedRunOptions: Parameters<typeof run>[2] = {
@@ -3239,21 +3390,21 @@ export async function runAgentStream(
   // OpenGeni's durable conversation truth is still reconciled explicitly below.
   const callModelInputFilter = composeCallModelInputFilters(
     [
-      callModelInputFilterForSettings(settings, {
+      callModelInputFilterForSettings(settings),
+      genesisTitleInputFilter,
+      overrides.callModelInputFilter,
+      boundModelToolOutputsFilterForSettings(settings),
+      contextRobustnessFilterForSettings(settings, {
         throwOnCompactionNeeded: Boolean(
-          overrides.contextCompactionSignalTokens || overrides.contextCompactionRequested,
+          overrides.contextCompactionSignal || overrides.contextCompactionRequested,
         ),
-        ...(overrides.contextCompactionSignalTokens
-          ? {
-              contextCompactionSignalTokens: overrides.contextCompactionSignalTokens,
-            }
+        ...(overrides.contextCompactionSignal
+          ? { contextCompactionSignal: overrides.contextCompactionSignal }
           : {}),
         ...(overrides.contextCompactionRequested
           ? { contextCompactionRequested: overrides.contextCompactionRequested }
           : {}),
       }),
-      genesisTitleInputFilter,
-      overrides.callModelInputFilter,
     ].filter((f): f is CallModelInputFilter => Boolean(f)),
   );
   const runOptions: Parameters<typeof run>[2] = {

--- a/packages/runtime/test/context-compaction.test.ts
+++ b/packages/runtime/test/context-compaction.test.ts
@@ -4,6 +4,7 @@ import {
   COMPACTION_PROMPT,
   COMPACTION_SUMMARY_MARKER,
   CompactionNeededError,
+  EmptyCompactionSummaryError,
   DEFAULT_COMPACTION_THRESHOLD_RATIO,
   MAX_COMPACTION_THRESHOLD_RATIO,
   MIN_COMPACTION_THRESHOLD_RATIO,
@@ -15,7 +16,10 @@ import {
   compactionThresholdTokens,
   clampCompactionThresholdRatio,
   decideCompaction,
+  estimateCompleteModelInput,
   findCompactionNeededError,
+  compactionReplacementFingerprint,
+  latestCompactionReplacementFingerprint,
   isCompactionSummary,
   isEphemeralInternalContext,
   isUserMessage,
@@ -87,8 +91,8 @@ describe("codex-parity constants and summary marker", () => {
     expect(item.content).toBe(`${SUMMARY_PREFIX}\nhandoff body`);
   });
 
-  test("an empty provider summary uses Codex's explicit placeholder", () => {
-    expect(buildSummaryItem("   ").content).toBe(`${SUMMARY_PREFIX}\n(no summary available)`);
+  test("an empty provider summary fails without manufacturing durable history", () => {
+    expect(() => buildSummaryItem("   ")).toThrow(EmptyCompactionSummaryError);
   });
 });
 
@@ -140,16 +144,16 @@ describe("single portable compaction threshold", () => {
     ).toBe(750);
   });
 
-  test("prefers provider-reported input tokens over the estimate", () => {
-    const items = [bigUser(900_000, "x")];
+  test("never lets a stale provider count hide larger active history", () => {
+    const items = [bigUser(1_000_000, "x")];
     const decision = decideCompaction({
       items,
       lastInputTokens: 10,
       contextWindowTokens: WINDOW,
       contextReservedOutputTokens: RESERVED_OUTPUT,
     });
-    expect(decision.signalTokens).toBe(10);
-    expect(decision.shouldCompact).toBe(false);
+    expect(decision.signalTokens).toBeGreaterThan(1_000_000);
+    expect(decision.shouldCompact).toBe(true);
   });
 
   test("uses char/4 estimate only when there is no provider signal yet", () => {
@@ -187,6 +191,101 @@ describe("single portable compaction threshold", () => {
     });
     expect(decision.shouldCompact).toBe(true);
     expect(decision.reason).toBe("force");
+  });
+});
+
+describe("complete outgoing model-input accounting", () => {
+  test("counts history, instructions, and tool schemas before a provider anchor exists", () => {
+    const estimate = estimateCompleteModelInput({
+      current: {
+        input: [user("u".repeat(400))],
+        instructionsTokens: 700,
+        toolSchemaTokens: 900,
+      },
+    });
+    expect(estimate.source).toBe("complete_estimate");
+    expect(estimate.tokens).toBe(
+      estimate.inputTokens + estimate.instructionsTokens + estimate.toolSchemaTokens,
+    );
+  });
+
+  test("anchors to provider total tokens and adds every item after the last model output", () => {
+    const prior = {
+      input: [user("question"), assistant("answer"), call("c1")],
+      instructionsTokens: 100,
+      toolSchemaTokens: 200,
+    };
+    const current = {
+      input: [...prior.input, result("c1", "x".repeat(4_000))],
+      instructionsTokens: 100,
+      toolSchemaTokens: 200,
+    };
+    const estimate = estimateCompleteModelInput({
+      current,
+      provider: { revision: 1, totalTokens: 12_345 },
+      providerRequestFootprint: prior,
+    });
+    expect(estimate.source).toBe("provider_plus_local");
+    expect(estimate.appendedAfterModelTokens).toBeGreaterThan(1_000);
+    expect(estimate.tokens).toBe(12_345 + estimate.appendedAfterModelTokens);
+  });
+
+  test("adds positive instruction and tool-schema growth to a provider anchor", () => {
+    const prior = {
+      input: [user("question"), assistant("answer")],
+      instructionsTokens: 100,
+      toolSchemaTokens: 200,
+    };
+    const estimate = estimateCompleteModelInput({
+      current: { ...prior, instructionsTokens: 130, toolSchemaTokens: 270 },
+      provider: { revision: 2, totalTokens: 10_000 },
+      providerRequestFootprint: prior,
+    });
+    expect(estimate.tokens).toBe(10_100);
+  });
+
+  test("treats an anchor without a model-generated boundary as unbound at the caller", () => {
+    const current = {
+      input: [user("only user input")],
+      instructionsTokens: 10,
+      toolSchemaTokens: 20,
+    };
+    const estimate = estimateCompleteModelInput({ current });
+    expect(estimate.source).toBe("complete_estimate");
+  });
+});
+
+describe("durable compaction progress identity", () => {
+  test("is stable across PostgreSQL JSONB object-key reordering", () => {
+    expect(
+      compactionReplacementFingerprint([
+        { type: "message", role: "user", content: "same", nested: { z: 1, a: 2 } },
+      ]),
+    ).toBe(
+      compactionReplacementFingerprint([
+        { nested: { a: 2, z: 1 }, content: "same", role: "user", type: "message" },
+      ]),
+    );
+  });
+
+  test("recognizes an exact repeat of the latest replacement across attempts", () => {
+    const replacement = buildCompactionReplacementHistory([user("question")], "same summary");
+    expect(latestCompactionReplacementFingerprint(replacement)).toBe(
+      compactionReplacementFingerprint(replacement),
+    );
+    expect(
+      compactionReplacementFingerprint(
+        buildCompactionReplacementHistory(replacement, "same summary"),
+      ),
+    ).toBe(compactionReplacementFingerprint(replacement));
+  });
+
+  test("does not conflate a genuinely changed checkpoint with a repeat", () => {
+    const first = buildCompactionReplacementHistory([user("question")], "first summary");
+    const second = buildCompactionReplacementHistory(first, "second summary");
+    expect(compactionReplacementFingerprint(second)).not.toBe(
+      latestCompactionReplacementFingerprint(first),
+    );
   });
 });
 
@@ -383,6 +482,43 @@ describe("provider-proof compaction transcript", () => {
         usage: { inputTokens: 321, outputTokens: 12, totalTokens: 333 },
       },
     ]);
+  });
+
+  test("rejects a semantically empty provider response with content-free diagnostics", async () => {
+    const fakeClient = {
+      responses: {
+        create: async () => ({
+          id: "resp_empty",
+          status: "incomplete",
+          incomplete_details: { reason: "max_output_tokens" },
+          usage: { input_tokens: 321, output_tokens: 0, total_tokens: 321 },
+          output: [{ type: "reasoning", content: [] }],
+        }),
+      },
+    };
+    try {
+      await summarizeForCompaction(
+        testSettings({ openaiProvider: "azure" }),
+        buildCompactionPromptInput([user("deploy it")]),
+        {
+          client: fakeClient as any,
+          api: "responses",
+          model: "scripted-model",
+        },
+      );
+      throw new Error("expected empty compaction response to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(EmptyCompactionSummaryError);
+      expect((error as EmptyCompactionSummaryError).diagnostics).toMatchObject({
+        responseId: "resp_empty",
+        status: "incomplete",
+        incompleteReason: "max_output_tokens",
+        extractedTextLength: 0,
+      });
+      expect(JSON.stringify((error as EmptyCompactionSummaryError).diagnostics)).not.toContain(
+        "deploy it",
+      );
+    }
   });
 
   test("renders the full checkpoint input without silently dropping old records", () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -41,6 +41,7 @@ import {
   prepareRunInput,
   stripProviderItemIdsFilter,
   callModelInputFilterForSettings,
+  contextRobustnessFilterForSettings,
   prefixedMcpToolName,
   prepareAgentTools,
   runAzureCliLoginHook,
@@ -3934,6 +3935,151 @@ describe("provider item id stripping", () => {
 
     expect(clientOut.input).toEqual(input);
     expect(serverOut.input).toEqual(input);
+  });
+
+  test("callModelInputFilterForSettings bounds a multi-megabyte tool result before model input", async () => {
+    const filter = callModelInputFilterForSettings(testSettings())!;
+    const original = "x".repeat(2_000_000);
+    const input = [
+      { type: "function_call", callId: "huge-1", name: "sessions_list", arguments: "{}" },
+      {
+        type: "function_call_result",
+        callId: "huge-1",
+        output: { type: "text", text: original },
+      },
+    ] as any;
+    const result = await filter({
+      modelData: { input },
+      agent: {} as any,
+      context: undefined,
+    });
+    const text = ((result.input[1] as any).output as { text: string }).text;
+    expect(text).toContain("tokens truncated");
+    expect(Buffer.byteLength(text, "utf8")).toBeLessThan(50_000);
+    expect(((input[1] as any).output as { text: string }).text).toBe(original);
+  });
+
+  test("same-run provider totals add the complete trailing tool result before the next call", async () => {
+    let signal: { revision: number; totalTokens: number } | null = null;
+    const filter = contextRobustnessFilterForSettings(
+      testSettings({
+        contextWindowTokens: 20_000,
+        contextAutoCompactThresholdTokens: 10_000,
+      }),
+      {
+        throwOnCompactionNeeded: true,
+        contextCompactionSignal: () => signal,
+      },
+    );
+    const userOnly = [{ type: "message", role: "user", content: "start" }] as any;
+    await filter({
+      modelData: { input: userOnly, instructions: "system" },
+      agent: {} as any,
+      context: undefined,
+    });
+    signal = { revision: 1, totalTokens: 200 };
+    const next = [
+      ...userOnly,
+      { type: "function_call", callId: "c1", name: "sessions_list", arguments: "{}" },
+      { type: "function_call_result", callId: "c1", output: "x".repeat(48_000) },
+    ] as any;
+    try {
+      await filter({
+        modelData: { input: next, instructions: "system" },
+        agent: {} as any,
+        context: undefined,
+      });
+      throw new Error("expected complete trailing tool output to trigger compaction");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CompactionNeededError);
+      expect((error as CompactionNeededError).signalSource).toBe("provider");
+      expect((error as CompactionNeededError).signalTokens).toBeGreaterThan(10_000);
+    }
+  });
+
+  test("a delayed provider usage signal cannot bind to a newer model request", async () => {
+    let signal: { revision: number; totalTokens: number } | null = null;
+    const filter = contextRobustnessFilterForSettings(
+      testSettings({
+        contextWindowTokens: 20_000,
+        contextAutoCompactThresholdTokens: 10_000,
+      }),
+      {
+        throwOnCompactionNeeded: true,
+        contextCompactionSignal: () => signal,
+      },
+    );
+    const first = [{ type: "message", role: "user", content: "start" }] as any;
+    await filter({
+      modelData: { input: first, instructions: "system" },
+      agent: {} as any,
+      context: undefined,
+    });
+    // The SDK can prepare request two before the stream consumer observes the
+    // usage frame for request one.
+    const second = [
+      ...first,
+      { type: "message", role: "assistant", content: "first response" },
+      { type: "message", role: "user", content: "continue" },
+    ] as any;
+    await filter({
+      modelData: { input: second, instructions: "system" },
+      agent: {} as any,
+      context: undefined,
+    });
+
+    signal = { revision: 1, totalTokens: 200 };
+    const third = [
+      ...second,
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "x".repeat(48_000) }],
+      },
+      { type: "message", role: "user", content: "continue again" },
+    ] as any;
+    try {
+      await filter({
+        modelData: { input: third, instructions: "system" },
+        agent: {} as any,
+        context: undefined,
+      });
+      throw new Error("expected the complete estimate to trigger compaction");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CompactionNeededError);
+      expect((error as CompactionNeededError).signalSource).toBe("estimate");
+      expect((error as CompactionNeededError).signalTokens).toBeGreaterThan(10_000);
+    }
+  });
+
+  test("first-call accounting includes instructions and tool schemas", async () => {
+    const filter = contextRobustnessFilterForSettings(
+      testSettings({
+        contextWindowTokens: 10_000,
+        contextAutoCompactThresholdTokens: 5_000,
+      }),
+      { throwOnCompactionNeeded: true },
+    );
+    const agent = {
+      tools: [
+        {
+          type: "function",
+          name: "large_schema",
+          description: "d".repeat(24_000),
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    } as any;
+    await expect(
+      filter({
+        modelData: {
+          input: [{ type: "message", role: "user", content: "small" }] as any,
+          instructions: "system",
+        },
+        agent,
+        context: undefined,
+      }),
+    ).rejects.toBeInstanceOf(CompactionNeededError);
   });
 
   test("callModelInputFilterForSettings observes an operator compaction request before each model call", async () => {

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -47,6 +47,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     contextWindowTokens: 1_050_000,
     contextCompactionThresholdRatio: 0.9,
     contextReservedOutputTokens: 128_000,
+    modelToolOutputTruncationTokens: 10_000,
     betterAuthSecret: undefined,
     betterAuthAllowedHosts: "",
     betterAuthCookieDomain: undefined,


### PR DESCRIPTION
## Summary

- bound canonical and live model-facing textual tool output with Codex 0.144.6 semantics while preserving images/files
- account for complete model input and bind provider usage only to the immediately preceding request
- make compaction failures and repeated replacements durable, truthful, and convergent
- replace unbounded sessions_list payloads with compact keyset pagination
- eliminate the migration-0053 sharded-home test nondeterminism discovered by the real-DB release gate

## Verification

- Fable 5 independent review: release-ready, zero blockers
- full real-DB suite: 3,158 pass, 3 gated live-Modal skips, 0 fail (3,161 total)
- focused changed suites: 292 pass
- migration-0053: eight consecutive isolated passes plus parallel full-suite pass
- format, lint, all 20 typecheck projects, full production build and web bundle budgets
- publish closure guard
- 144 MB adversarial tool-output benchmark: 1.44 MB bounded in ~28.6 ms, +35 MB heap / +42 MB RSS

Production deployment and live target-session verification follow after merge.