### PR TITLE
fix: make tool output bounds replay idempotent

### DIFF
--- a/.changeset/quiet-context-guardrails.md
+++ b/.changeset/quiet-context-guardrails.md
@@ -8,7 +8,7 @@
 "@opengeni/worker-bundle": patch
 ---
 
-Bound model-facing textual tool output with Codex-compatible semantics, account
+Bound model-facing textual tool output with Codex-compatible, replay-idempotent semantics, account
 for complete current model input, make compaction failure/progress transitions
 durable and convergent, and replace recursive session discovery with a compact
 paginated projection.

--- a/packages/codex/src/model-output-truncation.ts
+++ b/packages/codex/src/model-output-truncation.ts
@@ -27,6 +27,12 @@ export const DEFAULT_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS =
   CODEX_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS;
 
 const APPROX_BYTES_PER_TOKEN = 4;
+// Twelve decimal digits already describe ~4 TB at four bytes/token, far beyond
+// any JavaScript string the runtime can materialize. Bounding the digit run is
+// security-significant: otherwise a forged multi-megabyte run of digits could
+// make `markerBytes` as large as the entire untrusted tool result and bypass the
+// cap below.
+const TOKEN_TRUNCATION_MARKER = /…\d{1,12} tokens truncated…/u;
 const TOOL_RESULT_TYPES = new Set([
   "function_call_result",
   "function_call_output",
@@ -64,6 +70,17 @@ export function truncateMiddleWithTokenBudget(value: string, maxTokens: number):
   const maxBytes = Math.max(0, maxTokens) * APPROX_BYTES_PER_TOKEN;
   const valueBytes = Buffer.byteLength(value, "utf8");
   if (maxTokens > 0 && valueBytes <= maxBytes) return value;
+  // Codex applies this transform once while recording history, so its marker
+  // sits just outside the content budget. OpenGeni deliberately enforces the
+  // same policy both at canonical persistence and at the final provider seam.
+  // Recognize only an output whose excess is no larger than its own canonical
+  // marker; this makes that repeated enforcement byte-idempotent without letting
+  // an arbitrary oversized string bypass the cap merely by containing marker-like
+  // text. The first application remains byte-for-byte Codex 0.144.6 behavior.
+  const existingMarker = value.match(TOKEN_TRUNCATION_MARKER)?.[0];
+  if (existingMarker && valueBytes <= maxBytes + Buffer.byteLength(existingMarker, "utf8")) {
+    return value;
+  }
   if (maxBytes === 0) {
     return `…${approximateTokenCount(value)} tokens truncated…`;
   }

--- a/packages/codex/test/model-output-truncation.test.ts
+++ b/packages/codex/test/model-output-truncation.test.ts
@@ -11,12 +11,20 @@ describe("Codex-parity model tool-output truncation", () => {
   });
 
   test("matches Codex's head/tail token marker", () => {
-    expect(
-      truncateMiddleWithTokenBudget(
-        "this is an example of a long output that should be truncated",
-        5,
-      ),
-    ).toBe("this is an…10 tokens truncated… truncated");
+    const bounded = truncateMiddleWithTokenBudget(
+      "this is an example of a long output that should be truncated",
+      5,
+    );
+    expect(bounded).toBe("this is an…10 tokens truncated… truncated");
+    expect(truncateMiddleWithTokenBudget(bounded, 5)).toBe(bounded);
+  });
+
+  test("does not mistake marker-like text in an oversized raw result for a bounded result", () => {
+    const raw = `prefix …999 tokens truncated… ${"x".repeat(100)}`;
+    expect(truncateMiddleWithTokenBudget(raw, 5)).not.toBe(raw);
+
+    const forgedMarker = `…${"9".repeat(500)} tokens truncated…`;
+    expect(truncateMiddleWithTokenBudget(forgedMarker, 5)).not.toBe(forgedMarker);
   });
 
   test("preserves UTF-8 boundaries", () => {
@@ -93,6 +101,7 @@ describe("Codex-parity model tool-output truncation", () => {
     expect(output[0]!.stdout).toContain("tokens truncated");
     expect(output[0]!.stderr).toContain("omitted text field");
     expect(output[0]!.outcome).toEqual({ type: "exit", exitCode: 0 });
+    expect(boundModelToolOutputItem(bounded, 5)).toEqual(bounded);
   });
 
   test("preserves MCP content discriminators while bounding nested text", () => {


### PR DESCRIPTION
## Production finding

Post-deploy verification showed that Codex-compatible truncation output changed when the cap was enforced again at the final provider seam because upstream places its marker outside the content budget.

## Fix

- preserve byte-for-byte Codex 0.144.6 behavior on first application
- recognize only the tightly bounded canonical marker-overhead shape on replay
- bound marker digits to prevent forged-marker cap bypass
- add direct, nested, and adversarial idempotence coverage

## Evidence

- 345 affected tests, 0 failures
- all 20 typecheck projects clean
- lint and formatting clean
- Fable focused adversarial review: RELEASE-READY
- production finding reproduced against the deployed canonical history without exposing content