### PR TITLE
Fix compaction terminal failures and retry convergence

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -42,7 +42,6 @@ import {
   clearDurablePendingSessionToolCalls,
   appendSessionHistoryItems,
   isSessionCompactionRequested,
-  recordSkippedContextCompaction,
   countSessionHistoryItems,
   getActiveSessionHistoryItems,
   nextSessionHistoryPosition,
@@ -82,6 +81,8 @@ import {
   appendWorkspaceMemory,
   composeAgentInstructions,
   summarizeForCompaction,
+  CompactionProviderResponseError,
+  EmptyCompactionSummaryError,
   ensureModalRegistryImage,
   findCompactionNeededError,
   materializeSandboxFileDownloads,
@@ -307,6 +308,29 @@ function compactionFailureReason(reason: string): string {
   return reason.startsWith("compaction summarization failed:")
     ? reason
     : `compaction summarization failed: ${reason}`;
+}
+
+function compactionFailureReasonFromError(error: unknown): string {
+  if (
+    error instanceof CompactionProviderResponseError ||
+    error instanceof EmptyCompactionSummaryError
+  ) {
+    return compactionFailureReason(error.message);
+  }
+  const errorName = error instanceof Error && error.name ? error.name : "unknown error";
+  return compactionFailureReason(`unexpected ${errorName}`);
+}
+
+function isCompactionSummaryFailure(error: unknown): boolean {
+  return (
+    error instanceof CompactionProviderResponseError || error instanceof EmptyCompactionSummaryError
+  );
+}
+
+export function shouldRecoverCompactionProviderFailure(error: unknown): boolean {
+  if (!(error instanceof CompactionProviderResponseError)) return false;
+  if (isCodexTransportError(error) && classifyCodexUsageLimitError(error)) return true;
+  return agentRunFailurePayload(error).retryable === true;
 }
 
 export function classifyContextWindowOverflowError(
@@ -1386,6 +1410,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             | "requires_action";
           sessionStatus: SessionStatus;
           activeTurnId: string | null;
+          consumeRequestedCompactionFailure?: boolean;
         }) => Promise<boolean>)
       | null = null;
     let turnStartedPublished = false;
@@ -1888,6 +1913,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   producerSeq: ++producerSeq,
                 };
         }
+        const compactionRequestFailure = inputSettlement.consumeRequestedCompactionFailure
+          ? {
+              reason: "summarization_failed" as const,
+              producerId,
+              producerSeq: ++producerSeq,
+            }
+          : undefined;
         const inputs = inputSettlement.events.map((event) => ({
           ...event,
           payload: redact(event.payload),
@@ -1905,6 +1937,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           activeTurnId: inputSettlement.activeTurnId,
           events: inputs,
           ...(recordingMutation ? { recording: recordingMutation } : {}),
+          ...(compactionRequestFailure ? { compactionRequestFailure } : {}),
         });
         if (result.action === "stale") {
           if (recordingForSettlement) {
@@ -2730,25 +2763,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 ...(promptCacheKey ? { promptCacheKey } : {}),
               });
 
-      const consumeFailedRequestedCompaction = async (failedTurnId: string): Promise<void> => {
-        const skipped = await recordSkippedContextCompaction(db, {
-          accountId: input.accountId,
-          workspaceId: input.workspaceId,
-          sessionId: input.sessionId,
-          turnId: failedTurnId,
-          expectedExecutionGeneration: executionGeneration,
-          expectedAttemptId: input.attemptId,
-          reason: "summarization_failed",
-        });
-        if (!skipped.recorded) {
-          if (skipped.reason === "request_not_pending") return;
-          throw new TurnAttemptFencedError(
-            "turn attempt was fenced while consuming a failed context compaction request",
-          );
-        }
-        await publishDurableSessionEvents(bus, input.workspaceId, input.sessionId, skipped.events);
-      };
-
       if (turn.source === "compaction") {
         const persistentSessionSettings = {
           titleIsSet: Boolean(session.title?.trim()),
@@ -2795,8 +2809,40 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               },
             );
           } catch (error) {
-            await consumeFailedRequestedCompaction(turn.id);
-            throw error;
+            // Codex retries retryable checkpoint-provider failures rather than
+            // treating them as a semantic compaction result. Keep the operator
+            // request pending and let the ordinary same-turn provider/capacity
+            // recovery path re-dispatch this exact maintenance execution.
+            if (shouldRecoverCompactionProviderFailure(error)) throw error;
+            if (!isCompactionSummaryFailure(error)) throw error;
+            const errorMessage = compactionFailureReasonFromError(error);
+            if (
+              !(await settle!({
+                events: [
+                  {
+                    type: "turn.failed",
+                    payload: {
+                      error: errorMessage,
+                      code: "context_compaction_failed",
+                      retryable: false,
+                      recovery: "user_message",
+                      compacted: false,
+                    },
+                  },
+                  { type: "session.status.changed", payload: { status: "idle" } },
+                ],
+                turnStatus: "failed",
+                sessionStatus: "idle",
+                activeTurnId: null,
+                consumeRequestedCompactionFailure: true,
+              }))
+            ) {
+              return claimedResult({ status: "cancelled" });
+            }
+            turnMetricOutcome = "failed";
+            activityStatus = "idle";
+            activityError = error;
+            return claimedResult({ status: "idle" });
           }
           if (outcome.events.length > 0) {
             if (outcome.compacted) {
@@ -3663,15 +3709,41 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             );
           }
         } catch (compactError) {
-          if (forced && turnId) {
-            await consumeFailedRequestedCompaction(turnId);
-          }
+          if (shouldRecoverCompactionProviderFailure(compactError)) throw compactError;
+          if (!isCompactionSummaryFailure(compactError)) throw compactError;
+          const errorMessage = compactionFailureReasonFromError(compactError);
           observability.error("context compaction failed", {
             sessionId: input.sessionId,
             turnId,
-            error: compactError instanceof Error ? compactError.message : String(compactError),
+            error: errorMessage,
           });
-          throw compactError;
+          if (
+            !(await settle!({
+              events: [
+                {
+                  type: "turn.failed",
+                  payload: {
+                    error: errorMessage,
+                    code: "context_compaction_failed",
+                    retryable: false,
+                    recovery: "user_message",
+                    compacted: false,
+                  },
+                },
+                { type: "session.status.changed", payload: { status: "idle" } },
+              ],
+              turnStatus: "failed",
+              sessionStatus: "idle",
+              activeTurnId: null,
+              ...(forced ? { consumeRequestedCompactionFailure: true } : {}),
+            }))
+          ) {
+            return claimedResult({ status: "cancelled" });
+          }
+          turnMetricOutcome = "failed";
+          activityStatus = "idle";
+          activityError = compactError;
+          return claimedResult({ status: "idle" });
         }
       }
       let fileMaterializationFailures: SandboxFileDownloadFailure[] = [];
@@ -3798,38 +3870,30 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         triggerLabel: "overflow" | "proactive" | "operator",
         recoverySignalTokens: number | null,
       ) => {
-        let outcome: Awaited<ReturnType<typeof maybeCompactContext>>;
-        try {
-          outcome = await maybeCompactContext(
-            db,
-            modelRunSettings,
-            {
-              accountId: input.accountId,
-              workspaceId: input.workspaceId,
-              sessionId: input.sessionId,
-              turnId: activeTurnId,
-              executionGeneration,
-              attemptId: input.attemptId,
-            },
-            // Never reuse the persisted prior-turn signal for recovery. Proactive
-            // guards provide their exact current signal; provider overflows do not,
-            // so null derives decision metadata from active history. Forced
-            // recovery proves progress separately by comparing the replacement
-            // with the current active-history estimate in maybeCompactContext.
-            recoverySignalTokens,
-            compactSummarizer,
-            {
-              force: true,
-              ...(triggerLabel === "operator" ? { clearRequestedCompaction: true } : {}),
-              trigger: triggerLabel,
-            },
-          );
-        } catch (error) {
-          if (triggerLabel === "operator") {
-            await consumeFailedRequestedCompaction(activeTurnId);
-          }
-          throw error;
-        }
+        const outcome = await maybeCompactContext(
+          db,
+          modelRunSettings,
+          {
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            turnId: activeTurnId,
+            executionGeneration,
+            attemptId: input.attemptId,
+          },
+          // Never reuse the persisted prior-turn signal for recovery. Proactive
+          // guards provide their exact current signal; provider overflows do not,
+          // so null derives decision metadata from active history. Forced
+          // recovery proves progress separately by comparing the replacement
+          // with the current active-history estimate in maybeCompactContext.
+          recoverySignalTokens,
+          compactSummarizer,
+          {
+            force: true,
+            ...(triggerLabel === "operator" ? { clearRequestedCompaction: true } : {}),
+            trigger: triggerLabel,
+          },
+        );
         if (outcome.events.length > 0) {
           if (outcome.compacted) {
             recordContextCompaction(observability, triggerLabel);
@@ -4329,9 +4393,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               }
             }
           } catch (compactError) {
-            compactionFailureMessage = compactionFailureReason(
-              compactError instanceof Error ? compactError.message : String(compactError),
-            );
+            // Transient checkpoint-provider failures recover this same accepted
+            // turn through the normal provider/capacity path. They are not an
+            // empty summary and must not create a new goal continuation.
+            if (shouldRecoverCompactionProviderFailure(compactError)) throw compactError;
+            if (!isCompactionSummaryFailure(compactError)) throw compactError;
+            compactionFailureMessage = compactionFailureReasonFromError(compactError);
             observability.warn("context compaction recovery compaction failed", {
               sessionId: input.sessionId,
               turnId: activeTurnId,
@@ -4363,6 +4430,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 turnStatus: "failed",
                 sessionStatus: "idle",
                 activeTurnId: null,
+                ...(recoveryKind === "operator" ? { consumeRequestedCompactionFailure: true } : {}),
               }))
             ) {
               return claimedResult({ status: "cancelled" });

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -7,7 +7,11 @@ import {
   SandboxImageConflictError,
   SandboxLeaseSupersededError,
 } from "@opengeni/db";
-import { sanitizeHistoryItemsForModel } from "@opengeni/runtime";
+import {
+  CompactionProviderResponseError,
+  EmptyCompactionSummaryError,
+  sanitizeHistoryItemsForModel,
+} from "@opengeni/runtime";
 import { testSettings } from "@opengeni/testing";
 import {
   acceptsPromptCacheKeyForTurn,
@@ -30,6 +34,7 @@ import {
   PROVIDER_BACKPRESSURE_DELAY_MS,
   providerRecoveryResult,
   resolveActiveSandboxBackend,
+  shouldRecoverCompactionProviderFailure,
   shouldStartOnTurnRecording,
 } from "../src/activities/agent-turn";
 import { sandboxLeaseHolderIdForAttempt } from "../src/sandbox-resume";
@@ -1233,6 +1238,31 @@ describe("transient provider error classifier", () => {
     expect(payload.retryable).toBeUndefined();
     expect(payload.code).toBeUndefined();
     expect(payload.error).toBe("Invalid 'input': expected a string");
+  });
+
+  test("only transient provider compaction failures use same-turn recovery", () => {
+    expect(
+      shouldRecoverCompactionProviderFailure(
+        new CompactionProviderResponseError({ httpStatus: 503, code: "server_error" }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRecoverCompactionProviderFailure(
+        new CompactionProviderResponseError({
+          httpStatus: 429,
+          code: "rate_limit_exceeded",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRecoverCompactionProviderFailure(
+        new CompactionProviderResponseError({
+          httpStatus: 400,
+          code: "context_length_exceeded",
+        }),
+      ),
+    ).toBe(false);
+    expect(shouldRecoverCompactionProviderFailure(new EmptyCompactionSummaryError())).toBe(false);
   });
 
   test("a 503 recovers the same turn after backpressure pacing, independent of goal state", () => {

--- a/apps/worker/test/context-compaction-activity.test.ts
+++ b/apps/worker/test/context-compaction-activity.test.ts
@@ -5,7 +5,9 @@ import {
   createDb,
   createSession,
   getActiveSessionHistoryItems,
+  getSession,
   getSessionTurn,
+  initializeSessionStartAtomically,
   isSessionCompactionRequested,
   listSessionEvents,
   requestSessionCompaction,
@@ -340,7 +342,7 @@ describe("standalone context compaction execution", () => {
       trigger: { kind: "next" },
     });
 
-    expect(result).toMatchObject({ status: "failed", attemptId });
+    expect(result).toMatchObject({ status: "idle", attemptId });
     if (result.status === "unclaimed") throw new Error("Compaction was not claimed");
     expect(await isSessionCompactionRequested(client.db, grant.workspaceId!, session.id)).toBe(
       false,
@@ -352,6 +354,10 @@ describe("standalone context compaction execution", () => {
     ).toEqual(originalItems);
     const turn = await getSessionTurn(client.db, grant.workspaceId!, result.turnId);
     expect(turn).toMatchObject({ source: "compaction", status: "failed" });
+    expect(await getSession(client.db, grant.workspaceId!, session.id)).toMatchObject({
+      status: "idle",
+      activeTurnId: null,
+    });
     const events = await listSessionEvents(client.db, grant.workspaceId!, session.id, {
       after: 0,
       limit: 100,
@@ -365,6 +371,284 @@ describe("standalone context compaction execution", () => {
     expect(
       events.filter((event) => event.type === "session.context.compaction.requested"),
     ).toHaveLength(1);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "turn.failed",
+        payload: expect.objectContaining({
+          code: "context_compaction_failed",
+          retryable: false,
+          recovery: "user_message",
+        }),
+      }),
+    );
+  });
+
+  test("a transient standalone summary failure keeps the request on the same recovering turn", async () => {
+    const suffix = crypto.randomUUID();
+    const access = await bootstrapWorkspace(client.db, {
+      accountExternalSource: "test",
+      accountExternalId: `account-${suffix}`,
+      accountName: "Transient standalone compaction test",
+      workspaceExternalSource: "test",
+      workspaceExternalId: `workspace-${suffix}`,
+      workspaceName: "Transient standalone compaction test",
+      subjectId: `subject-${suffix}`,
+    });
+    const grant = access.workspaceGrants[0]!;
+    const session = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "initial",
+      resources: [],
+      metadata: {},
+      model: "scripted-compactor",
+      sandboxBackend: "none",
+    });
+    const originalItems = [
+      { type: "message", role: "user", content: "preserve this transient request" },
+      {
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "work in progress ".repeat(1_000) }],
+      },
+    ];
+    await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      await db.insert(schema.sessionHistoryItems).values(
+        originalItems.map((item, position) => ({
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId!,
+          sessionId: session.id,
+          position,
+          item,
+        })),
+      );
+    });
+    await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
+    const runtime = {
+      configure: () => undefined,
+      resolveTurnModel: () => ({
+        client: {
+          chat: {
+            completions: {
+              create: async () => {
+                throw Object.assign(new Error("temporary provider outage"), {
+                  status: 503,
+                  code: "server_error",
+                });
+              },
+            },
+          },
+        },
+        provider: { id: "test-chat", kind: "api-key", api: "chat", builtin: false },
+        configured: {
+          id: "scripted-compactor",
+          contextWindowTokens: 250_000,
+          effectiveContextWindowTokens: 250_000,
+          autoCompactLimitTokens: 225_000,
+          hostedWebSearch: false,
+        },
+      }),
+      buildAgent: () => {
+        throw new Error("transient standalone compaction entered the agent runtime");
+      },
+      prepareTools: () => {
+        throw new Error("transient standalone compaction prepared tools");
+      },
+      prepareInput: () => {
+        throw new Error("transient standalone compaction prepared input");
+      },
+      runStream: () => {
+        throw new Error("transient standalone compaction started inference");
+      },
+      serializeApprovals: () => {
+        throw new Error("transient standalone compaction serialized approvals");
+      },
+    } as unknown as OpenGeniRuntime;
+    const bus = {
+      publish: async () => undefined,
+      subscribe: async function* () {},
+      close: async () => undefined,
+    } as unknown as EventBus;
+    const activities = createActivityTestHarness({
+      settings: testSettings({
+        databaseUrl: shared.appUrl,
+        openaiModel: "scripted-compactor",
+        sandboxBackend: "none",
+      }),
+      db: client.db,
+      bus,
+      runtime,
+    });
+
+    const attemptId = crypto.randomUUID();
+    const result = await activities.runAgentTurn({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+      workflowRunId: crypto.randomUUID(),
+      attemptId,
+      trigger: { kind: "next" },
+    });
+
+    expect(result).toMatchObject({ status: "recovering", attemptId });
+    if (result.status === "unclaimed") throw new Error("Compaction was not claimed");
+    expect(await isSessionCompactionRequested(client.db, grant.workspaceId!, session.id)).toBe(
+      true,
+    );
+    expect(
+      (await getActiveSessionHistoryItems(client.db, grant.workspaceId!, session.id)).map(
+        (row) => row.item,
+      ),
+    ).toEqual(originalItems);
+    expect(await getSessionTurn(client.db, grant.workspaceId!, result.turnId)).toMatchObject({
+      source: "compaction",
+      status: "recovering",
+    });
+    expect(await getSession(client.db, grant.workspaceId!, session.id)).toMatchObject({
+      status: "recovering",
+      activeTurnId: result.turnId,
+    });
+    const events = await listSessionEvents(client.db, grant.workspaceId!, session.id, {
+      after: 0,
+      limit: 100,
+    });
+    expect(events.map((event) => event.type)).not.toContain("session.context.compaction.skipped");
+    expect(events).toContainEqual(expect.objectContaining({ type: "turn.recovery.requested" }));
+  });
+
+  test("a transient /compact inside a queued user turn preserves the request for same-turn recovery", async () => {
+    const suffix = crypto.randomUUID();
+    const access = await bootstrapWorkspace(client.db, {
+      accountExternalSource: "test",
+      accountExternalId: `account-${suffix}`,
+      accountName: "Transient in-turn compaction test",
+      workspaceExternalSource: "test",
+      workspaceExternalId: `workspace-${suffix}`,
+      workspaceName: "Transient in-turn compaction test",
+      subjectId: `subject-${suffix}`,
+    });
+    const grant = access.workspaceGrants[0]!;
+    const session = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      initialMessage: "continue after the checkpoint provider recovers",
+      resources: [],
+      metadata: {},
+      model: "scripted-compactor",
+      sandboxBackend: "none",
+    });
+    await initializeSessionStartAtomically(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      reasoningEffortFallback: "medium",
+      createdEventPayload: {},
+      goal: null,
+    });
+    await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      await db.insert(schema.sessionHistoryItems).values({
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        position: 0,
+        item: {
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "prior work ".repeat(1_000) }],
+        },
+      });
+    });
+    await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
+
+    const runtime = {
+      configure: () => undefined,
+      resolveTurnModel: () => ({
+        client: {
+          chat: {
+            completions: {
+              create: async () => {
+                throw Object.assign(new Error("temporary provider outage"), {
+                  status: 503,
+                  code: "server_error",
+                });
+              },
+            },
+          },
+        },
+        provider: { id: "test-chat", kind: "api-key", api: "chat", builtin: false },
+        configured: {
+          id: "scripted-compactor",
+          contextWindowTokens: 250_000,
+          effectiveContextWindowTokens: 250_000,
+          autoCompactLimitTokens: 225_000,
+          hostedWebSearch: false,
+        },
+      }),
+      prepareTools: async () => ({
+        mcpServers: [],
+        codexConnectorNamespaces: new Set<string>(),
+        close: async () => undefined,
+      }),
+      buildAgent: () => ({ instructions: "" }),
+      prepareInput: () => {
+        throw new Error("transient in-turn compaction prepared model input");
+      },
+      runStream: () => {
+        throw new Error("transient in-turn compaction started inference");
+      },
+      serializeApprovals: () => {
+        throw new Error("transient in-turn compaction serialized approvals");
+      },
+    } as unknown as OpenGeniRuntime;
+    const bus = {
+      publish: async () => undefined,
+      subscribe: async function* () {},
+      close: async () => undefined,
+    } as unknown as EventBus;
+    const activities = createActivityTestHarness({
+      settings: testSettings({
+        databaseUrl: shared.appUrl,
+        openaiModel: "scripted-compactor",
+        sandboxBackend: "none",
+      }),
+      db: client.db,
+      bus,
+      runtime,
+    });
+
+    const attemptId = crypto.randomUUID();
+    const result = await activities.runAgentTurn({
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+      workflowRunId: crypto.randomUUID(),
+      attemptId,
+      trigger: { kind: "next" },
+    });
+
+    expect(result).toMatchObject({ status: "recovering", attemptId });
+    if (result.status === "unclaimed") throw new Error("User turn was not claimed");
+    expect(await isSessionCompactionRequested(client.db, grant.workspaceId!, session.id)).toBe(
+      true,
+    );
+    expect(await getSessionTurn(client.db, grant.workspaceId!, result.turnId)).toMatchObject({
+      source: "user",
+      status: "recovering",
+    });
+    expect(await getSession(client.db, grant.workspaceId!, session.id)).toMatchObject({
+      status: "recovering",
+      activeTurnId: result.turnId,
+    });
+    const events = await listSessionEvents(client.db, grant.workspaceId!, session.id, {
+      after: 0,
+      limit: 100,
+    });
+    expect(events.map((event) => event.type)).not.toContain("session.context.compaction.skipped");
+    expect(events).toContainEqual(expect.objectContaining({ type: "turn.recovery.requested" }));
   });
 
   test("consumes an operator request without replacing history when its summary is not smaller", async () => {

--- a/docs/context-compaction.md
+++ b/docs/context-compaction.md
@@ -135,14 +135,36 @@ attempt, and sandbox. Compaction never creates a prompt-queue row, a recovery
 message, a new logical turn, or another sandbox. The model then sees the durable
 replacement history and continues the work.
 
-If summarization fails, the turn ends with an honest
-`context_compaction_failed` result. OpenGeni does not continue with silently
-trimmed input and does not install a mechanical fallback summary. When the
-failure belongs to an explicit `/compact`, the exact attempt also records
-`session.context.compaction.skipped(reason="summarization_failed")` and clears
-that one request, so an idle maintenance execution cannot immediately recreate
-itself forever. The active history stays unchanged and the user may request a
-fresh retry.
+If summarization produces an authoritative terminal failure, the turn ends
+with an honest `context_compaction_failed` result. OpenGeni does not continue
+with silently trimmed input and does not install a mechanical fallback summary.
+Retryable provider failures instead recover the same accepted turn through the
+ordinary provider/capacity path; they do not create another goal continuation,
+and an explicit `/compact` request remains pending for that same-turn retry.
+When a terminal failure belongs to an explicit `/compact`, one attempt-fenced
+database settlement records
+`session.context.compaction.skipped(reason="summarization_failed")`, clears that
+one request, records `turn.failed`, and returns the session to idle. A worker
+crash therefore cannot clear the request without the matching terminal truth,
+and an idle maintenance execution cannot immediately recreate itself forever.
+The active history stays unchanged and the user may request a fresh retry.
+
+Codex-subscription responses are streaming on the wire even for this
+non-streaming summarizer. Terminal `response.failed`, `response.error`, `error`,
+and `response.incomplete` events are converted to ordinary non-2xx provider
+errors before the SDK sees them; a stream with no terminal event is a protocol
+error. None of these shapes may collapse to `{}` or be mislabeled as a
+semantically empty assistant response. Persisted diagnostics contain only
+bounded status/code/request identifiers, never the provider message or model
+input.
+
+When the latest finished inference has `code="context_compaction_failed"`, an
+active goal remains active but cannot synthesize another autonomous
+continuation against the same unchanged history. A queued human prompt still
+wins immediately. A newer human/internal turn or an explicit `/compact`
+maintenance turn supplies new finished-turn truth; after it succeeds, normal
+goal continuation resumes. This gate neither creates queue work nor consumes a
+goal continuation/no-progress counter.
 
 Manual `/compact` sets one durable idempotent request. During active inference,
 the worker observes it at the next model boundary and retries sampling in the

--- a/packages/codex/src/fetch.ts
+++ b/packages/codex/src/fetch.ts
@@ -301,8 +301,9 @@ async function bufferCodexErrorResponse(res: Response): Promise<Response> {
  * event carries the full `response` payload.
  */
 async function sseToJsonResponse(res: Response): Promise<Response> {
-  const text = await res.text();
+  const text = (await res.text()).replace(/\r\n/g, "\n");
   let final: Record<string, unknown> | null = null;
+  let terminalError: Response | null = null;
   const items: unknown[] = []; // assembled from output_item.done (the codex backend
   // leaves response.completed.response.output empty and emits the items separately).
   for (const block of text.split("\n\n")) {
@@ -318,20 +319,63 @@ async function sseToJsonResponse(res: Response): Promise<Response> {
       const ev = JSON.parse(data) as {
         type?: string;
         response?: Record<string, unknown>;
+        error?: unknown;
+        code?: unknown;
+        message?: unknown;
+        param?: unknown;
         item?: unknown;
       };
       if (ev.type === "response.output_item.done" && ev.item !== undefined) {
         items.push(ev.item);
-      } else if (
-        ev.type === "response.completed" ||
-        ev.type === "response.done" ||
-        ev.type === "response.incomplete"
-      ) {
+      } else if (ev.type === "response.failed") {
+        terminalError = codexSseFailureResponse(
+          res,
+          ev.response?.error,
+          "response_failed",
+          "The Codex response failed",
+        );
+      } else if (ev.type === "error" || ev.type === "response.error") {
+        terminalError = codexSseFailureResponse(
+          res,
+          ev.error ?? ev.response?.error ?? ev,
+          "response_error",
+          "The Codex response stream reported an error",
+        );
+      } else if (ev.type === "response.incomplete") {
+        const details = ev.response?.incomplete_details;
+        const reason =
+          details && typeof details === "object"
+            ? (details as Record<string, unknown>).reason
+            : undefined;
+        terminalError = codexSseFailureResponse(
+          res,
+          {
+            code: "response_incomplete",
+            message:
+              typeof reason === "string" && reason.length > 0
+                ? `The Codex response was incomplete (${reason})`
+                : "The Codex response was incomplete",
+          },
+          "response_incomplete",
+          "The Codex response was incomplete",
+        );
+      } else if (ev.type === "response.completed" || ev.type === "response.done") {
         final = ev.response ?? null;
       }
     } catch {
       /* ignore non-JSON keepalive lines */
     }
+  }
+  if (terminalError) {
+    return terminalError;
+  }
+  if (!final) {
+    return codexSseFailureResponse(
+      res,
+      null,
+      "invalid_sse_terminal",
+      "The Codex response stream ended without a terminal response",
+    );
   }
   if (final && items.length > 0) {
     final = { ...final, output: items }; // prefer the assembled items over an empty output array
@@ -344,7 +388,63 @@ async function sseToJsonResponse(res: Response): Promise<Response> {
   const headers = new Headers(res.headers);
   headers.set("content-type", "application/json");
   headers.delete("content-length");
-  return new Response(JSON.stringify(final ?? {}), { status: 200, headers });
+  return new Response(JSON.stringify(final), { status: 200, headers });
+}
+
+const NON_RETRYABLE_SSE_ERROR_CODES = new Set([
+  "bio_policy",
+  "context_length_exceeded",
+  "cyber_policy",
+  "insufficient_quota",
+  "invalid_prompt",
+  "usage_limit_reached",
+]);
+
+/**
+ * Convert a terminal error carried inside an HTTP-200 SSE stream into the
+ * ordinary non-2xx JSON error contract expected by the OpenAI SDK. Codex CLI
+ * treats the same events as provider failures; returning a successful `{}`
+ * loses the actual cause and makes compaction look semantically empty.
+ */
+function codexSseFailureResponse(
+  source: Response,
+  rawError: unknown,
+  fallbackCode: string,
+  fallbackMessage: string,
+): Response {
+  const record =
+    rawError && typeof rawError === "object" ? (rawError as Record<string, unknown>) : {};
+  const code =
+    (typeof record.code === "string" && record.code.length > 0 ? record.code : undefined) ??
+    (typeof record.type === "string" && record.type.length > 0 ? record.type : undefined) ??
+    fallbackCode;
+  const message =
+    typeof record.message === "string" && record.message.length > 0
+      ? record.message
+      : fallbackMessage;
+  const error = {
+    type: typeof record.type === "string" && record.type.length > 0 ? record.type : code,
+    code,
+    message,
+    ...(typeof record.param === "string" ? { param: record.param } : {}),
+  };
+  const status =
+    code === "rate_limit_exceeded" ||
+    code === "usage_limit_reached" ||
+    code === "insufficient_quota"
+      ? 429
+      : NON_RETRYABLE_SSE_ERROR_CODES.has(code)
+        ? 400
+        : 502;
+  const headers = new Headers(source.headers);
+  headers.set("content-type", "application/json");
+  headers.set(CODEX_TRANSPORT_ERROR_HEADER, "1");
+  headers.delete("content-length");
+  headers.delete("content-encoding");
+  if (NON_RETRYABLE_SSE_ERROR_CODES.has(code)) {
+    headers.set("x-should-retry", "false");
+  }
+  return new Response(JSON.stringify({ error }), { status, headers });
 }
 
 /**

--- a/packages/codex/test/fetch.test.ts
+++ b/packages/codex/test/fetch.test.ts
@@ -24,10 +24,13 @@ function baseRecorder(statuses: number[] = [200]): { base: FetchLike; captures: 
     });
     const status = statuses[Math.min(i, statuses.length - 1)] ?? 200;
     i += 1;
-    return new Response("data: {}\n\n", {
-      status,
-      headers: { "content-type": "text/event-stream" },
-    });
+    return new Response(
+      'data: {"type":"response.completed","response":{"id":"r1","status":"completed","output":[]}}\n\n',
+      {
+        status,
+        headers: { "content-type": "text/event-stream" },
+      },
+    );
   };
   return { base, captures };
 }
@@ -177,7 +180,7 @@ describe("codexSubscriptionFetch", () => {
     expect(captures).toHaveLength(1);
   });
 
-  test("malformed non-streaming SSE is not replayed against another request", async () => {
+  test("malformed non-streaming SSE fails truthfully without a transport replay", async () => {
     let calls = 0;
     const response = await codexRequestStorage.run(ctx(), () =>
       codexSubscriptionFetch(async () => {
@@ -188,8 +191,90 @@ describe("codexSubscriptionFetch", () => {
         body: JSON.stringify({ stream: false }),
       }),
     );
-    expect(await response.json()).toEqual({});
+    expect(response.status).toBe(502);
+    expect(response.headers.get(CODEX_TRANSPORT_ERROR_HEADER)).toBe("1");
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_sse_terminal",
+        code: "invalid_sse_terminal",
+        message: "The Codex response stream ended without a terminal response",
+      },
+    });
     expect(calls).toBe(1);
+  });
+
+  test("non-streaming response.failed becomes a normal SDK error response", async () => {
+    let calls = 0;
+    const failure = [
+      "event: response.failed",
+      'data: {"type":"response.failed","response":{"id":"resp_failed","status":"failed","error":{"code":"context_length_exceeded","message":"input too large"}}}',
+      "",
+    ].join("\n");
+    const response = await codexRequestStorage.run(ctx(), () =>
+      codexSubscriptionFetch(async () => {
+        calls += 1;
+        return new Response(failure, { status: 200, headers: { "x-request-id": "req_failed" } });
+      })("https://chatgpt.com/backend-api/responses", {
+        method: "POST",
+        body: JSON.stringify({ stream: false }),
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(response.headers.get(CODEX_TRANSPORT_ERROR_HEADER)).toBe("1");
+    expect(response.headers.get("x-should-retry")).toBe("false");
+    expect(await response.json()).toEqual({
+      error: {
+        type: "context_length_exceeded",
+        code: "context_length_exceeded",
+        message: "input too large",
+      },
+    });
+    expect(calls).toBe(1);
+  });
+
+  test("non-streaming top-level error and response.error terminal forms do not become empty success", async () => {
+    for (const event of [
+      { type: "error", code: "server_error", message: "backend unavailable", param: null },
+      {
+        type: "response.error",
+        error: { code: "server_error", message: "backend unavailable" },
+      },
+    ]) {
+      const response = await codexRequestStorage.run(ctx(), () =>
+        codexSubscriptionFetch(
+          async () => new Response(`data: ${JSON.stringify(event)}\n\n`, { status: 200 }),
+        )("https://chatgpt.com/backend-api/responses", {
+          method: "POST",
+          body: JSON.stringify({ stream: false }),
+        }),
+      );
+      expect(response.status).toBe(502);
+      expect((await response.json()) as { error?: { code?: string } }).toMatchObject({
+        error: { code: "server_error" },
+      });
+    }
+  });
+
+  test("non-streaming response.incomplete is a provider failure like Codex CLI", async () => {
+    const response = await codexRequestStorage.run(ctx(), () =>
+      codexSubscriptionFetch(
+        async () =>
+          new Response(
+            'data: {"type":"response.incomplete","response":{"id":"resp_inc","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"}}}\n\n',
+            { status: 200 },
+          ),
+      )("https://chatgpt.com/backend-api/responses", {
+        method: "POST",
+        body: JSON.stringify({ stream: false }),
+      }),
+    );
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: "response_incomplete",
+        message: "The Codex response was incomplete (max_output_tokens)",
+      },
+    });
   });
 
   test("partial streaming body failure is surfaced without a transport replay", async () => {
@@ -246,6 +331,20 @@ describe("codexSubscriptionFetch", () => {
     expect(json.status).toBe("completed");
     expect(json.output).toHaveLength(1); // assembled from output_item.done, not the empty terminal output
     expect(json.output[0]?.type).toBe("message");
+  });
+
+  test("non-streaming caller accepts canonical CRLF SSE framing", async () => {
+    const fetchImpl = codexSubscriptionFetch(
+      async () => new Response(CODEX_SSE.replaceAll("\n", "\r\n"), { status: 200 }),
+    );
+    const res = await codexRequestStorage.run(ctx(), () =>
+      fetchImpl("https://chatgpt.com/backend-api/responses", {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-5.6-sol", input: [] }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ id: "r1", status: "completed" });
   });
 
   test("streaming caller: stream is passed through with the terminal event's empty output repaired", async () => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -18192,6 +18192,44 @@ export async function evaluateGoalContinuation(
             ? ({ decision: "queue" } as const)
             : ({ decision: "none" } as const);
         }
+        const [latestFinished] = await tx
+          .select({ id: schema.sessionTurns.id })
+          .from(schema.sessionTurns)
+          .where(
+            and(
+              eq(schema.sessionTurns.workspaceId, input.workspaceId),
+              eq(schema.sessionTurns.sessionId, input.sessionId),
+              sql`${schema.sessionTurns.finishedAt} is not null`,
+            ),
+          )
+          .orderBy(desc(schema.sessionTurns.position), desc(schema.sessionTurns.createdAt))
+          .limit(1);
+        const [contextCompactionFailure] = latestFinished
+          ? await tx
+              .select({
+                id: schema.sessionEvents.id,
+              })
+              .from(schema.sessionEvents)
+              .where(
+                and(
+                  eq(schema.sessionEvents.workspaceId, input.workspaceId),
+                  eq(schema.sessionEvents.sessionId, input.sessionId),
+                  eq(schema.sessionEvents.turnId, latestFinished.id),
+                  eq(schema.sessionEvents.type, "turn.failed"),
+                  sql`${schema.sessionEvents.payload} ->> 'code' = 'context_compaction_failed'`,
+                ),
+              )
+              .limit(1)
+          : [];
+        // A provider could not produce a durable checkpoint for the latest
+        // inference. Re-running the unchanged active history autonomously only
+        // repeats the same failure. Keep the active goal intact but inert until
+        // a human prompt, a new internal update, or an explicit /compact attempt
+        // creates newer finished-turn truth. Queued human work already won in
+        // the branch above; this never creates queue work or consumes counters.
+        if (contextCompactionFailure) {
+          return { decision: "none" } as const;
+        }
         let autoContinuations = row.autoContinuations;
         let noProgressStreak = row.noProgressStreak;
         // P3: a 429-failover continuation (the last continuation turn carried the `rotated`
@@ -18200,18 +18238,7 @@ export async function evaluateGoalContinuation(
         // mirroring the budget-pause precedent that a limits pause never consumes budget.
         let rotatedFailover = false;
         if (row.lastContinuationTurnId) {
-          const [lastFinished] = await tx
-            .select({ id: schema.sessionTurns.id })
-            .from(schema.sessionTurns)
-            .where(
-              and(
-                eq(schema.sessionTurns.workspaceId, input.workspaceId),
-                eq(schema.sessionTurns.sessionId, input.sessionId),
-                sql`${schema.sessionTurns.finishedAt} is not null`,
-              ),
-            )
-            .orderBy(desc(schema.sessionTurns.position), desc(schema.sessionTurns.createdAt))
-            .limit(1);
+          const lastFinished = latestFinished;
           if (lastFinished && lastFinished.id !== row.lastContinuationTurnId) {
             // A user/scheduled turn ran since the last continuation: human
             // re-engagement re-arms the auto-continuation budget.
@@ -20343,6 +20370,18 @@ export type ApplySessionTurnSettlementInput = {
   activeTurnId: string | null;
   events: AppendEventInput[];
   recording?: SessionTurnRecordingSettlement;
+  /**
+   * Atomically consume an operator /compact request and record why it could
+   * not install a replacement. This lives on the terminal turn settlement so
+   * a worker crash can never clear the request without also publishing the
+   * attempt-owned failure truth.
+   */
+  compactionRequestFailure?: {
+    reason: "summarization_failed";
+    producerId?: string | null;
+    producerSeq?: number | null;
+    occurredAt?: Date;
+  };
 };
 
 export type ApplySessionTurnSettlementResult =
@@ -20445,7 +20484,8 @@ export async function applySessionTurnSettlement(
         pendingInterruption !== undefined ||
         session.activeTurnId !== input.turnId ||
         !fromStatuses.includes(turnStatus as SessionTurnStatus) ||
-        turn.activeAttemptId !== input.attemptId
+        turn.activeAttemptId !== input.attemptId ||
+        (input.compactionRequestFailure !== undefined && !session.compactRequested)
       ) {
         return {
           action: "stale" as const,
@@ -20586,7 +20626,26 @@ export async function applySessionTurnSettlement(
           })
         : { sequence, events: [] as SessionEvent[], closed: 0 };
       sequence = closedTools.sequence;
-      const settlementEvents = recordingEvent ? [recordingEvent, ...input.events] : input.events;
+      const compactionRequestEvent: AppendEventInput | null = input.compactionRequestFailure
+        ? {
+            type: "session.context.compaction.skipped",
+            payload: { reason: input.compactionRequestFailure.reason },
+            ...(input.compactionRequestFailure.producerId != null
+              ? { producerId: input.compactionRequestFailure.producerId }
+              : {}),
+            ...(input.compactionRequestFailure.producerSeq != null
+              ? { producerSeq: input.compactionRequestFailure.producerSeq }
+              : {}),
+            ...(input.compactionRequestFailure.occurredAt
+              ? { occurredAt: input.compactionRequestFailure.occurredAt }
+              : {}),
+          }
+        : null;
+      const settlementEvents = [
+        ...(recordingEvent ? [recordingEvent] : []),
+        ...(compactionRequestEvent ? [compactionRequestEvent] : []),
+        ...input.events,
+      ];
       const values = settlementEvents.map((event) => {
         const payload =
           event.payload && typeof event.payload === "object"
@@ -20686,6 +20745,7 @@ export async function applySessionTurnSettlement(
         .set({
           status: effectiveSessionStatus,
           activeTurnId: input.activeTurnId,
+          ...(input.compactionRequestFailure ? { compactRequested: false } : {}),
           lastSequence: sequence,
           queueVersion: session.queueVersion + 1,
           updatedAt: now,

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -17,10 +17,12 @@ import {
   createSessionGoal,
   evaluateSessionControl,
   evaluateSessionControls,
+  evaluateGoalContinuation,
   getSessionQueueSnapshot,
   getBillingBalance,
   getActiveSessionHistoryItems,
   getSession,
+  getSessionGoal,
   getSessionTurn,
   listOutstandingSessionSystemUpdates,
   listSessionDiscoverySummaries,
@@ -1111,6 +1113,119 @@ describe("clean session control plane", () => {
     expect(
       await listOutstandingSessionSystemUpdates(client.db, grant.workspaceId!, session.id),
     ).toEqual([]);
+  });
+
+  test("a compaction failure blocks autonomous goal retry until newer finished-turn truth exists", async () => {
+    const { grant, session } = await fixture();
+    const goal = await createSessionGoal(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      text: "Finish without compaction churn",
+      createdBy: "api",
+    });
+    const firstDecision = await evaluateGoalContinuation(client.db, {
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      noProgressLimit: 3,
+    });
+    expect(firstDecision).toMatchObject({ decision: "continue", autoContinuation: 1 });
+    if (firstDecision.decision !== "continue") throw new Error("goal did not continue");
+    const update = await addSessionSystemUpdate(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      kind: "goal_continuation",
+      classification: "info",
+      sourceId: goal.id,
+      dedupeKey: `goal-continuation:${goal.id}:${goal.version}:1`,
+      summary: "Continue the goal",
+      payload: {
+        type: "goal_continuation",
+        goalId: goal.id,
+        goalVersion: goal.version,
+        autoContinuation: 1,
+        prompt: "Continue the goal",
+      },
+    });
+    if (!update.added) throw new Error("goal continuation update was not inserted");
+    const failedAttemptId = crypto.randomUUID();
+    const failedTurn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId: failedAttemptId },
+    );
+    expect(failedTurn).toMatchObject({ source: "goal", status: "running" });
+    await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: failedTurn!.id,
+      triggerEventId: failedTurn!.triggerEventId,
+      attemptId: failedAttemptId,
+      turnStatus: "failed",
+      sessionStatus: "idle",
+      activeTurnId: null,
+      events: [
+        {
+          type: "turn.failed",
+          payload: {
+            error: "checkpoint provider failed",
+            code: "context_compaction_failed",
+            retryable: false,
+            recovery: "user_message",
+          },
+        },
+      ],
+    });
+
+    expect(
+      await evaluateGoalContinuation(client.db, {
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        noProgressLimit: 3,
+      }),
+    ).toEqual({ decision: "none" });
+    expect(await getSessionGoal(client.db, grant.workspaceId!, session.id)).toMatchObject({
+      status: "active",
+      autoContinuations: 1,
+      noProgressStreak: 0,
+    });
+
+    const human = await send(grant, session.id, "Retry from the preserved history");
+    expect(
+      await evaluateGoalContinuation(client.db, {
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        noProgressLimit: 3,
+      }),
+    ).toEqual({ decision: "queue" });
+    const humanAttemptId = crypto.randomUUID();
+    const humanTurn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId: humanAttemptId },
+    );
+    expect(humanTurn?.id).toBe(human.turn.id);
+    await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: humanTurn!.id,
+      triggerEventId: humanTurn!.triggerEventId,
+      attemptId: humanAttemptId,
+      turnStatus: "completed",
+      sessionStatus: "idle",
+      activeTurnId: null,
+      events: [{ type: "turn.completed", payload: { output: "continued" } }],
+    });
+    expect(
+      await evaluateGoalContinuation(client.db, {
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        noProgressLimit: 3,
+      }),
+    ).toMatchObject({ decision: "continue", autoContinuation: 1 });
   });
 
   test("idle manual compaction is a born-running maintenance execution, never queue work", async () => {

--- a/packages/runtime/src/context-compaction.ts
+++ b/packages/runtime/src/context-compaction.ts
@@ -332,6 +332,35 @@ export class EmptyCompactionSummaryError extends Error {
   }
 }
 
+/**
+ * The checkpoint model request ended in a provider/transport failure rather
+ * than a successful response with an empty assistant message. Diagnostics are
+ * deliberately bounded and content-free so this error can be persisted on a
+ * turn without copying provider messages or conversation input into events.
+ */
+export class CompactionProviderResponseError extends Error {
+  readonly diagnostics: Record<string, unknown>;
+  readonly status?: number;
+  readonly code?: string;
+  readonly type?: string;
+  override readonly cause?: unknown;
+
+  constructor(diagnostics: Record<string, unknown> = {}, cause?: unknown) {
+    const compact = JSON.stringify(diagnostics).slice(0, 2_000);
+    super(
+      `Compaction provider request failed; active history was preserved${compact ? ` (${compact})` : ""}`,
+    );
+    this.name = "CompactionProviderResponseError";
+    this.diagnostics = diagnostics;
+    if (typeof diagnostics.httpStatus === "number") this.status = diagnostics.httpStatus;
+    if (typeof diagnostics.code === "string") this.code = diagnostics.code;
+    if (typeof diagnostics.type === "string") this.type = diagnostics.type;
+    if (cause !== undefined) {
+      Object.defineProperty(this, "cause", { value: cause, enumerable: false });
+    }
+  }
+}
+
 export function findCompactionNeededError(
   error: unknown,
   seen = new WeakSet<object>(),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -122,6 +122,7 @@ import {
 import { installCodexToolSearch } from "./codex-tool-search";
 import {
   CompactionNeededError,
+  CompactionProviderResponseError,
   EmptyCompactionSummaryError,
   SUMMARY_BUFFER_TOKENS,
   compactionThresholdTokens,
@@ -194,6 +195,7 @@ export { OpenAIChatCompletionsModel, OpenAIResponsesModel } from "@openai/agents
 
 export {
   CompactionNeededError,
+  CompactionProviderResponseError,
   EmptyCompactionSummaryError,
   buildCompactionPromptInput,
   buildCompactionReplacementHistory,
@@ -816,12 +818,17 @@ export async function summarizeForCompaction(
   const maxTokens = options.maxOutputTokens ?? SUMMARY_BUFFER_TOKENS;
   if (api === "chat") {
     const transcript = renderCompactionPromptInputForChat(input);
-    const completion = await client.chat.completions.create({
-      model,
-      max_tokens: maxTokens,
-      messages: [{ role: "user", content: transcript }],
-      ...(options.promptCacheKey ? { prompt_cache_key: options.promptCacheKey } : {}),
-    } as any);
+    let completion: unknown;
+    try {
+      completion = await client.chat.completions.create({
+        model,
+        max_tokens: maxTokens,
+        messages: [{ role: "user", content: transcript }],
+        ...(options.promptCacheKey ? { prompt_cache_key: options.promptCacheKey } : {}),
+      } as any);
+    } catch (error) {
+      throw new CompactionProviderResponseError(compactionProviderFailureDiagnostics(error), error);
+    }
     const usage = modelResponseUsageFromResponse(completion);
     if (usage) {
       await options.onUsage?.(usage);
@@ -855,16 +862,94 @@ export async function summarizeForCompaction(
     handoffs: [],
     tracing: false,
   };
-  const response = await new CompactionResponsesModel(client, model).fetchResponse(request);
+  let response: unknown;
+  try {
+    response = await new CompactionResponsesModel(client, model).fetchResponse(request);
+  } catch (error) {
+    throw new CompactionProviderResponseError(compactionProviderFailureDiagnostics(error), error);
+  }
   const usage = modelResponseUsageFromResponse(response);
   if (usage) {
     await options.onUsage?.(usage);
+  }
+  if (isFailedCompactionProviderResponse(response)) {
+    throw new CompactionProviderResponseError(compactionProviderFailureDiagnostics(response));
   }
   const summary = extractResponseOutputText(response).trim();
   if (!summary) {
     throw new EmptyCompactionSummaryError(compactionResponseDiagnostics(response, summary));
   }
   return summary;
+}
+
+function isFailedCompactionProviderResponse(response: unknown): boolean {
+  if (!response || typeof response !== "object") return false;
+  const record = response as Record<string, unknown>;
+  return (
+    record.status === "failed" ||
+    record.status === "incomplete" ||
+    (record.error !== null && record.error !== undefined)
+  );
+}
+
+/** Bounded provider diagnostics: identifiers and classifications, never messages or model data. */
+export function compactionProviderFailureDiagnostics(error: unknown): Record<string, unknown> {
+  let current = error;
+  let errorName: string | null = null;
+  let httpStatus: number | null = null;
+  let responseStatus: string | null = null;
+  let responseId: string | null = null;
+  let code: string | null = null;
+  let type: string | null = null;
+  let requestId: string | null = null;
+  const seen = new Set<object>();
+  for (let depth = 0; depth < 6 && current && typeof current === "object"; depth += 1) {
+    if (seen.has(current)) break;
+    seen.add(current);
+    const record = current as Record<string, unknown>;
+    if (!errorName && current instanceof Error) errorName = current.name;
+    if (
+      httpStatus === null &&
+      typeof record.status === "number" &&
+      Number.isFinite(record.status)
+    ) {
+      httpStatus = record.status;
+    }
+    if (responseStatus === null && typeof record.status === "string") {
+      responseStatus = record.status;
+    }
+    if (responseId === null && typeof record.id === "string") responseId = record.id;
+    if (code === null && typeof record.code === "string") code = record.code;
+    if (type === null && typeof record.type === "string") type = record.type;
+    if (requestId === null) {
+      const directRequestId = record.request_id ?? record.requestId ?? record._request_id;
+      if (typeof directRequestId === "string") requestId = directRequestId;
+      const headers = record.headers;
+      if (!requestId && headers && typeof headers === "object") {
+        const get = (headers as { get?: unknown }).get;
+        if (typeof get === "function") {
+          const headerId = get.call(headers, "x-request-id");
+          if (typeof headerId === "string") requestId = headerId;
+        }
+      }
+    }
+    const nestedError = record.error;
+    if (nestedError && typeof nestedError === "object" && !seen.has(nestedError)) {
+      const nested = nestedError as Record<string, unknown>;
+      if (code === null && typeof nested.code === "string") code = nested.code;
+      if (type === null && typeof nested.type === "string") type = nested.type;
+    }
+    current = record.cause;
+  }
+  return {
+    errorName,
+    httpStatus,
+    responseStatus,
+    responseId,
+    code,
+    type,
+    requestId,
+  };
 }
 
 /** Bounded, content-free diagnostics for a semantically empty checkpoint. */

--- a/packages/runtime/test/context-compaction.test.ts
+++ b/packages/runtime/test/context-compaction.test.ts
@@ -4,6 +4,7 @@ import {
   COMPACTION_PROMPT,
   COMPACTION_SUMMARY_MARKER,
   CompactionNeededError,
+  CompactionProviderResponseError,
   EmptyCompactionSummaryError,
   DEFAULT_COMPACTION_THRESHOLD_RATIO,
   MAX_COMPACTION_THRESHOLD_RATIO,
@@ -489,8 +490,7 @@ describe("provider-proof compaction transcript", () => {
       responses: {
         create: async () => ({
           id: "resp_empty",
-          status: "incomplete",
-          incomplete_details: { reason: "max_output_tokens" },
+          status: "completed",
           usage: { input_tokens: 321, output_tokens: 0, total_tokens: 321 },
           output: [{ type: "reasoning", content: [] }],
         }),
@@ -511,14 +511,91 @@ describe("provider-proof compaction transcript", () => {
       expect(error).toBeInstanceOf(EmptyCompactionSummaryError);
       expect((error as EmptyCompactionSummaryError).diagnostics).toMatchObject({
         responseId: "resp_empty",
-        status: "incomplete",
-        incompleteReason: "max_output_tokens",
+        status: "completed",
+        incompleteReason: null,
         extractedTextLength: 0,
       });
       expect(JSON.stringify((error as EmptyCompactionSummaryError).diagnostics)).not.toContain(
         "deploy it",
       );
     }
+  });
+
+  test("classifies a thrown provider failure without persisting its message or model input", async () => {
+    const providerError = Object.assign(
+      new Error("provider echoed deploy it and other sensitive request content"),
+      {
+        status: 502,
+        code: "server_error",
+        type: "server_error",
+        error: { code: "server_error", message: "nested sensitive provider text" },
+        headers: new Headers({ "x-request-id": "req_compaction_failed" }),
+      },
+    );
+    const fakeClient = {
+      responses: {
+        create: async () => {
+          throw providerError;
+        },
+      },
+    };
+    try {
+      await summarizeForCompaction(
+        testSettings({ openaiProvider: "azure" }),
+        buildCompactionPromptInput([user("deploy it")]),
+        {
+          client: fakeClient as any,
+          api: "responses",
+          model: "scripted-model",
+        },
+      );
+      throw new Error("expected provider compaction failure");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CompactionProviderResponseError);
+      expect((error as CompactionProviderResponseError).diagnostics).toEqual({
+        errorName: "Error",
+        httpStatus: 502,
+        responseStatus: null,
+        responseId: null,
+        code: "server_error",
+        type: "server_error",
+        requestId: "req_compaction_failed",
+      });
+      expect(JSON.stringify(error)).not.toContain("deploy it");
+      expect(JSON.stringify(error)).not.toContain("nested sensitive provider text");
+      expect((error as Error).message).not.toContain("sensitive request content");
+    }
+  });
+
+  test("classifies a failed Responses object even when a custom client returns HTTP-200 data", async () => {
+    const fakeClient = {
+      responses: {
+        create: async () => ({
+          id: "resp_failed",
+          status: "failed",
+          error: { code: "server_error", message: "must not persist this provider text" },
+          output: [],
+        }),
+      },
+    };
+    await expect(
+      summarizeForCompaction(
+        testSettings({ openaiProvider: "azure" }),
+        buildCompactionPromptInput([user("deploy it")]),
+        {
+          client: fakeClient as any,
+          api: "responses",
+          model: "scripted-model",
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "CompactionProviderResponseError",
+      diagnostics: {
+        responseStatus: "failed",
+        responseId: "resp_failed",
+        code: "server_error",
+      },
+    });
   });
 
   test("renders the full checkpoint input without silently dropping old records", () => {


### PR DESCRIPTION
## Outcome

- converts Codex HTTP-200 SSE failure/incomplete/missing-terminal events into ordinary SDK errors
- separates provider failures from genuinely empty checkpoint summaries with bounded content-free diagnostics
- recovers retryable compaction failures on the same accepted turn and preserves explicit /compact requests
- atomically consumes terminal /compact requests with skipped + failed turn truth
- prevents an unchanged latest context_compaction_failed turn from manufacturing autonomous goal retries while preserving human queue precedence and goal counters

## Verification

- 139 focused unit tests pass
- 9 mandatory real-Postgres compaction activity tests pass
- affected codex/runtime/db/worker typechecks pass
- formatter and diff checks pass
- UBS changed-production-hunk scan has no findings
- durable Fable session a16791fb-c033-4dad-a172-e61860afc44a: RELEASE-READY

## Linear

OPE-64, OPE-66, OPE-67, OPE-68, and OPE-69 contain the decision, incident evidence, and pre-release receipt. OPE-73 remains the separate rolling-deploy persistence issue.