### PR TITLE
perf(react): keep long timelines responsive (OPE-44)

### DIFF
--- a/.changeset/quick-timelines-rest.md
+++ b/.changeset/quick-timelines-rest.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Mount long session timelines progressively so the newest activity paints first and low-end browsers remain responsive while older groups hydrate.

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -20,6 +20,7 @@ import type { ComponentType } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { Collapsible } from "radix-ui";
 import {
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -108,6 +109,8 @@ export type MessageTimelineProps = {
   className?: string | undefined;
 };
 
+const INITIAL_MOUNTED_GROUPS = 1;
+
 /**
  * The session timeline: chat messages with streaming deltas, collapsed
  * activity clusters (reasoning, tool calls, sandbox work), spawned-worker
@@ -132,8 +135,10 @@ export function MessageTimeline({
   className,
 }: MessageTimelineProps) {
   const resolvedItems = useMemo(() => items ?? buildTimeline(events ?? []), [items, events]);
-  const groups = useMemo(() => groupTimeline(resolvedItems), [resolvedItems]);
-  const firstGroupKey = groups[0] ? timelineGroupKey(groups[0]) : null;
+  const allGroups = useMemo(() => groupTimeline(resolvedItems), [resolvedItems]);
+  const keyedGroups = useStableTimelineGroupKeys(allGroups);
+  const { mountedGroups: groups, mountingOlderGroups } = useProgressivelyMountedGroups(keyedGroups);
+  const firstGroupKey = allGroups[0] ? timelineGroupKey(allGroups[0]) : null;
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const topSentinelRef = useRef<HTMLDivElement | null>(null);
@@ -178,7 +183,8 @@ export function MessageTimeline({
   const firstKeyChangedForBulk =
     previousBulkFirstKeyRef.current !== undefined &&
     previousBulkFirstKeyRef.current !== firstGroupKey;
-  const bulkRender = groups.length > 0 && (bulkActive || firstKeyChangedForBulk);
+  const bulkRender =
+    allGroups.length > 0 && (bulkActive || firstKeyChangedForBulk || mountingOlderGroups);
 
   // Snapshot the topmost visible element and where it sits in the viewport, so a
   // later reflow can restore it to the same spot. Transient chrome (the backfill
@@ -221,10 +227,10 @@ export function MessageTimeline({
   // A cleared timeline (stream identity change) re-arms the reveal so the next
   // session also first paints at its bottom.
   useLayoutEffect(() => {
-    if (groups.length === 0 && revealed) {
+    if (allGroups.length === 0 && revealed) {
       setRevealed(false);
     }
-  }, [groups.length, revealed]);
+  }, [allGroups.length, revealed]);
 
   // Clear the bulk-paint marker a frame after it renders, so rows appended
   // live (streams, new turns) animate exactly as before.
@@ -234,9 +240,15 @@ export function MessageTimeline({
       return;
     }
     setBulkActive(true);
+    // Initial tails and prepended history mount from newest to oldest across
+    // frames. Keep every row born during that bulk window animation-free; only
+    // clear the marker after the authoritative group list is fully mounted.
+    if (mountingOlderGroups) {
+      return;
+    }
     const frame = requestFrame(() => setBulkActive(false));
     return () => cancelFrame(frame);
-  }, [bulkRender, firstGroupKey]);
+  }, [bulkRender, firstGroupKey, mountingOlderGroups]);
 
   // Prefetch older history well before the reader reaches the top: the
   // sentinel sits above the first group and trips 1600px early, so backfill
@@ -248,6 +260,7 @@ export function MessageTimeline({
     if (
       !root ||
       !target ||
+      mountingOlderGroups ||
       !hasOlder ||
       loadingOlder ||
       !onLoadOlder ||
@@ -265,7 +278,7 @@ export function MessageTimeline({
     );
     observer.observe(target);
     return () => observer.disconnect();
-  }, [hasOlder, loadingOlder, onLoadOlder, firstGroupKey]);
+  }, [hasOlder, loadingOlder, onLoadOlder, firstGroupKey, mountingOlderGroups]);
 
   // Scroll anchoring: when the content reflows (a fold expands/collapses, a
   // stream appends), keep following the bottom if pinned; otherwise pin the
@@ -338,7 +351,7 @@ export function MessageTimeline({
                     <p className="py-10 text-center text-sm text-og-fg-subtle">No activity yet.</p>
                   ))
                 : null}
-              {hasOlder ? (
+              {hasOlder && !mountingOlderGroups ? (
                 <div
                   ref={topSentinelRef}
                   data-og-top-sentinel=""
@@ -352,9 +365,9 @@ export function MessageTimeline({
                   <span className="og-shimmer-text font-medium">Loading earlier activity…</span>
                 </div>
               ) : null}
-              {groups.map((group, index) => (
+              {groups.map(({ group, key }, index) => (
                 <TimelineGroupView
-                  key={timelineGroupKey(group)}
+                  key={key}
                   group={group}
                   renderMessageText={renderMessageText}
                   onOpenSession={onOpenSession}
@@ -362,7 +375,7 @@ export function MessageTimeline({
                   onReconnect={onReconnect}
                   resolveProviderLogo={resolveProviderLogo}
                   toolRegistry={toolRegistry}
-                  foldLiveCluster={isAgentProgress(groups[index + 1])}
+                  foldLiveCluster={isAgentProgress(groups[index + 1]?.group)}
                 />
               ))}
               {working ? (
@@ -406,6 +419,148 @@ export function MessageTimeline({
   );
 }
 
+type MountedGroupWindow = {
+  groupKeys: string[];
+  visibleStart: number;
+};
+
+type KeyedTimelineGroup = {
+  group: TimelineGroup;
+  key: string;
+  itemIds: string[];
+};
+
+/**
+ * Projection can legitimately change a group's content-derived key while
+ * retaining its existing rows. The common pagination case is an older activity
+ * item merging into the first activity group; live appends grow the same group
+ * from the other side. Match the new authoritative groups to the previous
+ * committed groups by their durable item IDs so both the React key and the
+ * progressive-window anchor survive either change.
+ */
+function useStableTimelineGroupKeys(allGroups: TimelineGroup[]): KeyedTimelineGroup[] {
+  const previousRef = useRef<KeyedTimelineGroup[]>([]);
+  const keyedGroups = useMemo(() => {
+    const previousByItemId = new Map<string, KeyedTimelineGroup[]>();
+    for (const previous of previousRef.current) {
+      for (const itemId of previous.itemIds) {
+        const matches = previousByItemId.get(itemId);
+        if (matches) {
+          matches.push(previous);
+        } else {
+          previousByItemId.set(itemId, [previous]);
+        }
+      }
+    }
+
+    const usedKeys = new Set<string>();
+    return allGroups.map((group, index) => {
+      const itemIds = timelineGroupItemIds(group);
+      let retainedKey: string | undefined;
+      for (const itemId of itemIds) {
+        const previousMatches = previousByItemId.get(itemId);
+        const previous = previousMatches?.find((candidate) => !usedKeys.has(candidate.key));
+        if (previous) {
+          retainedKey = previous.key;
+          break;
+        }
+      }
+
+      const canonicalKey = timelineGroupKey(group);
+      let key = retainedKey ?? canonicalKey;
+      let collision = 0;
+      while (usedKeys.has(key)) {
+        key = `${canonicalKey}:${index}:${collision}`;
+        collision += 1;
+      }
+      usedKeys.add(key);
+      return { group, key, itemIds };
+    });
+  }, [allGroups]);
+
+  useLayoutEffect(() => {
+    previousRef.current = keyedGroups;
+  }, [keyedGroups]);
+
+  return keyedGroups;
+}
+
+/**
+ * Bulk history is already projected into its authoritative order before this
+ * hook runs. Mount its newest group first, then prepend one older group per
+ * animation frame so low-end browsers can paint and service input between
+ * React/Markdown commits instead of doing the entire tail in one long task.
+ *
+ * A live append does not move the first mounted key, so it is included
+ * immediately in the mounted suffix. A history prepend moves that key deeper
+ * in the array; shifting `visibleStart` by that exact prefix keeps every
+ * existing row mounted while the new prefix is revealed. If projection
+ * coalesces the seam item itself away, the earliest surviving mounted key
+ * provides the same anchor. Replacements with no shared mounted key (for
+ * example a session switch or clear-view) start a fresh suffix.
+ */
+function useProgressivelyMountedGroups(allGroups: KeyedTimelineGroup[]): {
+  mountedGroups: KeyedTimelineGroup[];
+  mountingOlderGroups: boolean;
+} {
+  const previousGroupKeysRef = useRef<string[]>([]);
+  const groupKeys = useMemo(() => {
+    const nextKeys = allGroups.map((group) => group.key);
+    return equalGroupKeys(previousGroupKeysRef.current, nextKeys)
+      ? previousGroupKeysRef.current
+      : nextKeys;
+  }, [allGroups]);
+  useLayoutEffect(() => {
+    previousGroupKeysRef.current = groupKeys;
+  }, [groupKeys]);
+  const [window, setWindow] = useState<MountedGroupWindow>(() => ({
+    groupKeys,
+    visibleStart: initialVisibleGroupIndex(allGroups.length),
+  }));
+
+  const lastPossibleStart = Math.max(0, allGroups.length - INITIAL_MOUNTED_GROUPS);
+  let visibleStart = 0;
+  if (allGroups.length > 0) {
+    const currentIndexByKey = new Map(groupKeys.map((key, index) => [key, index]));
+    const previousMountedKeys = window.groupKeys.slice(window.visibleStart);
+    const retainedStart = previousMountedKeys
+      .map((key) => currentIndexByKey.get(key))
+      .find((index): index is number => index !== undefined);
+    visibleStart =
+      retainedStart === undefined
+        ? initialVisibleGroupIndex(allGroups.length)
+        : Math.min(retainedStart, lastPossibleStart);
+  }
+
+  useEffect(() => {
+    // Synchronize a prepend/replacement before scheduling its first reveal.
+    if (window.groupKeys !== groupKeys || window.visibleStart !== visibleStart) {
+      setWindow({ groupKeys, visibleStart });
+      return;
+    }
+    if (visibleStart === 0) {
+      return;
+    }
+    const frame = requestFrame(() => {
+      setWindow((current) =>
+        current.groupKeys === groupKeys && current.visibleStart > 0
+          ? { ...current, visibleStart: current.visibleStart - 1 }
+          : current,
+      );
+    });
+    return () => cancelFrame(frame);
+  }, [groupKeys, visibleStart, window.groupKeys, window.visibleStart]);
+
+  return {
+    mountedGroups: allGroups.slice(visibleStart),
+    mountingOlderGroups: visibleStart > 0,
+  };
+}
+
+function initialVisibleGroupIndex(groupCount: number): number {
+  return Math.max(0, groupCount - INITIAL_MOUNTED_GROUPS);
+}
+
 function requestFrame(callback: FrameRequestCallback): number {
   if (typeof requestAnimationFrame === "function") {
     return requestAnimationFrame(callback);
@@ -421,7 +576,11 @@ function cancelFrame(id: number): void {
   window.clearTimeout(id);
 }
 
-function TimelineGroupView({
+// Progressive history mounting reuses the exact group objects from `allGroups`.
+// Skip repainting those stable rows on every prefix reveal; live projection
+// creates a new group object, and behavior/callback changes are separate props,
+// so ordinary streaming and host updates still invalidate immediately.
+const TimelineGroupView = memo(function TimelineGroupView({
   group,
   renderMessageText,
   onOpenSession,
@@ -531,7 +690,7 @@ function TimelineGroupView({
         />
       );
   }
-}
+});
 
 function timelineGroupKey(group: TimelineGroup): string {
   switch (group.kind) {
@@ -541,6 +700,21 @@ function timelineGroupKey(group: TimelineGroup): string {
       return group.id;
     case "turn":
       return group.id;
+  }
+}
+
+function equalGroupKeys(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((key, index) => key === right[index]);
+}
+
+function timelineGroupItemIds(group: TimelineGroup): string[] {
+  switch (group.kind) {
+    case "item":
+      return [group.item.id];
+    case "activity":
+      return group.items.map((item) => item.id);
+    case "turn":
+      return group.groups.flatMap(timelineGroupItemIds);
   }
 }
 

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { SessionEvent } from "@opengeni/sdk";
-import { MessageTimeline } from "../src";
+import { MessageTimeline, type TimelineItem } from "../src";
 import { actRun, registerDom, renderComponent, flush } from "./render-hook";
 
 registerDom();
@@ -19,6 +19,46 @@ function event(sequence: number): SessionEvent {
   };
 }
 
+function agentDelta(sequence: number, text: string): SessionEvent {
+  return {
+    ...event(sequence),
+    type: "agent.message.delta",
+    payload: { text },
+    turnId: "turn-1",
+  };
+}
+
+function reasoningDelta(sequence: number, text: string): SessionEvent {
+  return {
+    ...event(sequence),
+    type: "agent.reasoning.delta",
+    payload: { text },
+    turnId: "turn-1",
+  };
+}
+
+function userItem(id: string, text: string): TimelineItem {
+  return {
+    kind: "user-message",
+    id,
+    text,
+    resources: [],
+    tools: [],
+    occurredAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function reasoningItem(id: string, text: string): TimelineItem {
+  return {
+    kind: "reasoning",
+    id,
+    turnId: "turn-1",
+    text,
+    streaming: false,
+    occurredAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
 const originalIntersectionObserver = globalThis.IntersectionObserver;
 const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
 const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
@@ -30,6 +70,207 @@ afterEach(() => {
 });
 
 describe("MessageTimeline pagination affordances", () => {
+  test("bulk tails mount newest-first across frames and finish in exact order", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const initial = [event(1), event(2), event(3), event(4)];
+    const r = await renderComponent(<MessageTimeline events={initial} hasOlder />);
+
+    expect(r.container.textContent).toContain("message 4");
+    expect(r.container.textContent).not.toContain("message 3");
+    expect(r.container.querySelector(".animate-og-enter")).toBeNull();
+    expect(r.container.querySelector("[data-og-top-sentinel]")).toBeNull();
+
+    await runNextFrame(frames);
+    expect(r.container.textContent).toContain("message 3");
+    expect(r.container.textContent).not.toContain("message 2");
+    expect(r.container.querySelector(".animate-og-enter")).toBeNull();
+
+    await drainFrames(frames);
+    const text = r.container.textContent ?? "";
+    const positions = [1, 2, 3, 4].map((sequence) => text.indexOf(`message ${sequence}`));
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
+    for (const sequence of [1, 2, 3, 4]) {
+      expect(text.match(new RegExp(`message ${sequence}`, "g"))).toHaveLength(1);
+    }
+    expect(r.container.querySelector(".animate-og-enter")).toBeNull();
+    expect(r.container.querySelector("[data-og-top-sentinel]")).not.toBeNull();
+    await r.unmount();
+  });
+
+  test("live appends stay immediate while the older prefix is still mounting", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const initial = [event(1), event(2), event(3), event(4)];
+    const r = await renderComponent(<MessageTimeline events={initial} />);
+    await r.rerender(<MessageTimeline events={[...initial, event(5)]} />);
+
+    expect(r.container.textContent).toContain("message 4");
+    expect(r.container.textContent).toContain("message 5");
+    expect(r.container.textContent).not.toContain("message 3");
+
+    await drainFrames(frames);
+    const text = r.container.textContent ?? "";
+    for (const sequence of [1, 2, 3, 4, 5]) {
+      expect(text.match(new RegExp(`message ${sequence}`, "g"))).toHaveLength(1);
+    }
+    expect(text.indexOf("message 4")).toBeLessThan(text.indexOf("message 5"));
+    await r.unmount();
+  });
+
+  test("same-key streaming content invalidates the memoized group immediately", async () => {
+    const first = agentDelta(1, "hello ");
+    const r = await renderComponent(<MessageTimeline events={[first]} />);
+    expect(r.container.textContent).toContain("hello");
+    expect(r.container.textContent).not.toContain("hello world");
+
+    await r.rerender(<MessageTimeline events={[first, agentDelta(2, "world")]} />);
+    expect(r.container.textContent).toContain("hello world");
+    await r.unmount();
+  });
+
+  test("same-key streaming updates do not restart older-group hydration", async () => {
+    const frames: FrameRequestCallback[] = [];
+    let cancellations = 0;
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => {
+      cancellations += 1;
+    };
+
+    const initial = [event(1), event(2), event(3), agentDelta(4, "hello ")];
+    const r = await renderComponent(<MessageTimeline events={initial} />);
+    expect(r.container.textContent).toContain("hello");
+    expect(r.container.textContent).not.toContain("message 3");
+
+    await r.rerender(<MessageTimeline events={[...initial, agentDelta(5, "world")]} />);
+    expect(r.container.textContent).toContain("hello world");
+    expect(cancellations).toBe(0);
+
+    await runNextFrame(frames);
+    expect(r.container.textContent).toContain("message 3");
+    await drainFrames(frames);
+    await r.unmount();
+  });
+
+  test("a prepended page keeps mounted rows stable and reveals only its new prefix", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const r = await renderComponent(<MessageTimeline events={[event(3), event(4)]} />);
+    await drainFrames(frames);
+    await r.rerender(<MessageTimeline events={[event(1), event(2), event(3), event(4)]} />);
+
+    expect(r.container.textContent).toContain("message 3");
+    expect(r.container.textContent).toContain("message 4");
+    expect(r.container.textContent).not.toContain("message 2");
+
+    await runNextFrame(frames);
+    expect(r.container.textContent).toContain("message 2");
+    expect(r.container.textContent).not.toContain("message 1");
+    await drainFrames(frames);
+
+    const text = r.container.textContent ?? "";
+    expect(text.indexOf("message 1")).toBeLessThan(text.indexOf("message 2"));
+    expect(text.indexOf("message 2")).toBeLessThan(text.indexOf("message 3"));
+    expect(text.indexOf("message 3")).toBeLessThan(text.indexOf("message 4"));
+    await r.unmount();
+  });
+
+  test("an items prepend that merges into the first activity group keeps visible rows mounted", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const initial = [
+      reasoningItem("activity-a", "activity A"),
+      userItem("u1", "message U1"),
+      userItem("u2", "message U2"),
+      userItem("u3", "message U3"),
+    ];
+    const renderMessageText = (text: string, item: TimelineItem) => (
+      <span data-message-id={item.id}>{text}</span>
+    );
+    const r = await renderComponent(
+      <MessageTimeline items={initial} renderMessageText={renderMessageText} />,
+    );
+    await drainFrames(frames);
+    const u1Before = r.container.querySelector('[data-message-id="u1"]');
+    expect(u1Before).not.toBeNull();
+
+    await r.rerender(
+      <MessageTimeline
+        items={[reasoningItem("activity-b", "activity B"), ...initial]}
+        renderMessageText={renderMessageText}
+      />,
+    );
+
+    expect(r.container.querySelector('[data-message-id="u1"]')).toBe(u1Before);
+    expect(r.container.querySelector('[data-message-id="u2"]')).not.toBeNull();
+    expect(r.container.querySelector('[data-message-id="u3"]')).not.toBeNull();
+    await drainFrames(frames);
+    await r.unmount();
+  });
+
+  test("a raw-event prepend that merges reasoning keeps the hydrated suffix mounted", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const initial = [
+      reasoningDelta(2, "activity A"),
+      event(3),
+      reasoningDelta(4, "activity C"),
+      event(5),
+      reasoningDelta(6, "activity D"),
+      event(7),
+    ];
+    const renderMessageText = (text: string, item: TimelineItem) => (
+      <span data-message-id={item.id}>{text}</span>
+    );
+    const r = await renderComponent(
+      <MessageTimeline events={initial} renderMessageText={renderMessageText} />,
+    );
+    await drainFrames(frames);
+    const message3Before = r.container.querySelector('[data-message-id="evt-3"]');
+    expect(message3Before).not.toBeNull();
+
+    await r.rerender(
+      <MessageTimeline
+        events={[reasoningDelta(1, "activity B"), ...initial]}
+        renderMessageText={renderMessageText}
+      />,
+    );
+
+    expect(r.container.querySelector('[data-message-id="evt-3"]')).toBe(message3Before);
+    expect(r.container.querySelector('[data-message-id="evt-5"]')).not.toBeNull();
+    expect(r.container.querySelector('[data-message-id="evt-7"]')).not.toBeNull();
+    await drainFrames(frames);
+    await r.unmount();
+  });
+
   test("loadingOlder renders the quiet top row and !hasOlder renders no sentinel", async () => {
     const loading = await renderComponent(<MessageTimeline events={[event(1)]} loadingOlder />);
     await flush();
@@ -119,3 +360,23 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 });
+
+async function runNextFrame(frames: FrameRequestCallback[]): Promise<void> {
+  const frame = frames.shift();
+  if (!frame) {
+    throw new Error("expected a scheduled animation frame");
+  }
+  await actRun(() => frame(performance.now()));
+}
+
+async function drainFrames(frames: FrameRequestCallback[]): Promise<void> {
+  let count = 0;
+  while (frames.length > 0) {
+    await runNextFrame(frames);
+    count += 1;
+    if (count > 100) {
+      throw new Error("animation-frame queue did not settle");
+    }
+  }
+  await flush();
+}


### PR DESCRIPTION
## Summary

- mount the newest authoritative timeline group first, then prepend one older group per animation frame
- keep live appends immediate while historical groups hydrate
- preserve mounted rows across history prepends and suppress overlapping pagination until hydration settles
- memoize stable group views during staged prefix mounting without delaying same-key streaming updates
- add ordering, duplicate, live-append, prepend, pagination, animation, and memo-invalidation regression coverage

Linear: OPE-44

## Measured bottleneck (already-shipped work subtracted)

Production was on `a906a068` when profiled. PRs #407/#408/#409 had already removed provider-iterator flush backpressure, the workspace event-lock queue, and unbounded fresh replay; #422 had already resized web replicas. The remaining owned bottleneck was synchronous React/Markdown mount, not provider intake, PostgreSQL, NATS, or SSE.

Provider/runtime timing is kept separate:

- provider TTFT p50: **6.273 s**; p95/p99 exceed the current 10 s histogram ceiling (unchanged by this PR)
- worker inter-delta p50/p95/p99: **8.38 / 87.3 / 180.0 ms**
- batch flush p50/p95/p99: **30.8 / 49.9 / 93.0 ms**
- real PostgreSQL 5,000-event tail: **349.5 ms cold-ish plan / 44.8 ms warm fetch+decode**, zero gaps or reordering
- NATS observation: zero pending bytes and zero slow consumers

The real production compact 1,000-event tail projects to 58 items / 16 top-level groups / 124 final DOM nodes.

### Before

4× low-end Chrome, n=10:

- React p50/p95/p99: **44.2 / 81.5 / 98.1 ms**
- long tasks: **10/10 renders**, p50/p95 **135 / 192 ms**

### After at exact head `861c6fd9`

Corrected v3 harness (fixture stored once in page memory; no DevTools serialization artifact), n=10 per scenario:

| Scenario | First content p50/p95/p99 | React commit p50/p95/p99 | Long-task renders |
|---|---:|---:|---:|
| desktop | 13.0 / 14.3 / 14.3 ms | 1.2 / 2.7 / 5.9 ms | 0/10 |
| mobile | 13.4 / 14.1 / 14.1 ms | 1.2 / 2.5 / 6.0 ms | 0/10 |
| 4× low-end mobile | 20.9 / 34.0 / 34.0 ms | 5.1 / 13.9 / 27.6 ms | 1/10 (one 54 ms outlier) |

The single low-end outlier was not reproducible in a follow-up n=30 run: **0/30 long-task renders**, max React commit **33.8 ms**. Final output was always 58 items / 16 groups / 124 nodes. Background hydration p50/p95 was **488.7 / 510.9 ms**.

Observed low-end network/open p95 **671.8 ms** + exact-head first-content p95 **34.0 ms** = about **705.8 ms**, below the 750 ms fresh-tail target in this bounded sample.

Hydrated synthetic final-delta updates against the real tail, 100 commits:

- React p50/p95/p99: **11.8 / 31.1 / 40.6 ms**, max **42.6 ms**
- long tasks: **0**

## Correctness and validation

- `bun test` across all timeline, pagination, and session-event tests: **245 pass / 0 fail**
- complete React suite: **606 pass / 1 unrelated 5 s sandbox-files timeout**; the exact timed-out test passed alone in **253 ms**
- `bun run typecheck`: pass (20 projects)
- `bun run lint`: pass (0 warnings/errors)
- `bun run format:check`: pass
- `git diff --check`: pass

Regression coverage asserts exact final order, no duplicates, immediate live append, stable existing rows on prepend, pagination gating, and same-key stream invalidation. This PR changes no API, worker, PostgreSQL, NATS, SSE, Helm, dashboards, or OPE-19/OPE-52-owned files.

## Remaining proof gap

This PR does not merge, deploy, or release. Production SLO proof is blocked until OPE-25 releases the exact reviewed revision; then the same desktop/mobile/low-end measurement must be repeated against the deployed image and correlated with provider/runtime telemetry.


<!-- ope44-current-main-reconciliation -->
## Current-main reconciliation — `f023fdde`

- current base / merge-base: `77986e28331519bd9f224c9033ee62930465b01a`
- candidate head: `f023fdde34537afac472edae51d71f1f4681d4ad`
- normal non-force merge; the new base-only delta changes only `scripts/workbench-live-acceptance.ts` and its unit test to separate canary/probe scopes
- no OPE-44 source, test, changeset, React dependency, browser fixture, or browser/runtime behavior changed
- original OPE-44 commits remain unchanged (`git range-diff`: `861c6fd9 = 861c6fd9`, `54e190f1 = 54e190f1`)
- stable current-base patch ID remains `dcaed4d157106bbbec23941b7cffec3733bc2b93`
- reviewed blobs remain exact: changeset `7ad7a2d3`, component `66695e06`, test `ed166a92`; the current-base diff remains exactly those three OPE-44 files (`454` insertions, `14` deletions)

Current exact-head local gates:

- focused ordering/pagination/session-event matrix: **19/19**, 113 assertions
- complete React suite: **656/656**, 1,986 assertions
- merged-main workbench acceptance test: **7/7**, 27 assertions
- `git diff --check`: pass; tracked/index/untracked worktree clean

Natural exact-head CI run [29690065425](https://github.com/Cloudgeni-ai/opengeni/actions/runs/29690065425) is **3/3 green**. Independent Sol/xhigh exact-head review is **APPROVE**, with no blocking correctness, integration, dependency, or performance-semantic findings. The reviewer independently reproduced the three-file diff, commit/blob/patch identity, focused tests, and full React suite.

### Refreshed production baseline (read-only, natural traffic)

PR #471 is not deployed. Current workload image revisions remain mixed but all precede this PR: web `3dadb5555f1612a7bf9e2568f74168a64f652ed0`, API/turn/control workers `28290a023e09b59a9288da7a1bf845e43fc8f691`, and relay `9742ff0bb0b96a70ce97ca244998bcf9e9d4654f`. All serving deployments were ready at final reconciliation. The latest accepted one-hour natural-traffic baseline remains:

- provider TTFT p50 **5.483 s**; p95/p99 at or above the current **10 s** histogram ceiling
- worker message inter-delta p50/p95/p99 **4.93 / 83.82 / 176.29 ms**
- batch average **3.18 events/flush**
- batch flush p50/p95/p99 **42.35 / 647.03 / 962.83 ms**

Provider think time remains dominant. Batch tails overlap OPE-63 lock ordering and OPE-52 capacity, so this PR does not race those seams.

### Browser before/after and residual

The bounded production fixture remains **1,000 events / 750,298 bytes / 54 projected items / 5 top-level groups / 83 final DOM nodes**, exact in every run. Production-bundle first-content p50/p95/p99:

| Scenario | Current main | PR |
|---|---:|---:|
| desktop | 70.4 / 75.5 / 75.5 ms | **38.7 / 53.6 / 53.6 ms** |
| mobile | 67.7 / 71.2 / 71.2 ms | **37.0 / 42.1 / 42.1 ms** |
| 4× low-end mobile | 301.4 / 327.5 / 333.5 ms | **154.2 / 172.1 / 177.5 ms** |

PR final hydration p50/p95/p99 is desktop **120.9/138.3/138.3 ms**, mobile **119.1/126.0/126.0 ms**, and 4× low-end **433.6/463.0/475.9 ms**. Hydrated live streaming remains p50/p95/p99/max **8.5/24.7/30.7/40.6 ms** over 30 runs / 587 commits, with zero streaming long tasks.

The remaining low-end long-task tail comes from a **415,402-byte** settled output group plus module/bundle startup. OPE-64 owns output bounding; module startup remains the measured unowned browser seam. No additional source change was justified after subtracting the new main delta.

No merge, release, deployment, workflow dispatch, production mutation, or serving load occurred. This is reviewed readiness, **not production SLO proof**. OPE-44 remains In Progress until OPE-25 releases an exact reviewed descendant and the deployed desktop/mobile/low-end path is remeasured with provider/runtime correlation.
