### PR TITLE
fix: keep selected session expander visible

### DIFF
--- a/.changeset/selected-session-expander.md
+++ b/.changeset/selected-session-expander.md
@@ -1,0 +1,5 @@
+---
+"opengeni-web": patch
+---
+
+Keep session hierarchy expansion controls visible when selecting a parent session.

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -35,6 +35,7 @@ import {
   buildRailForest,
   groupSessionsForRail,
   isRunningStatus,
+  mergeSessionForRail,
   recencyGroupFor,
   relativeTimeLabel,
   visibleForestRows,
@@ -263,6 +264,32 @@ describe("rail session grouping", () => {
     });
     const forest = buildRailForest([manager], NOW);
     expect(forest.running.map((node) => node.session.id)).toEqual(["manager-summary"]);
+  });
+
+  test("selected-session detail preserves the list-only hierarchy summary", () => {
+    const listProjection = railSession({
+      id: "selected-manager",
+      status: "idle",
+      treeStats: {
+        directChildren: 2,
+        totalDescendants: 4,
+        runningDescendants: 0,
+        queuedDescendants: 0,
+        attentionDescendants: 0,
+        pausedDescendants: 0,
+        failedDescendants: 0,
+      },
+    });
+    const selectedDetail = railSession({ id: "selected-manager", status: "running" });
+
+    const merged = mergeSessionForRail(listProjection, selectedDetail);
+    expect(merged.status).toBe("running");
+    expect(merged.treeStats).toEqual(listProjection.treeStats);
+
+    const refreshedStats = { ...listProjection.treeStats!, directChildren: 3 };
+    expect(
+      mergeSessionForRail(merged, { ...selectedDetail, treeStats: refreshedStats }).treeStats,
+    ).toEqual(refreshedStats);
   });
 
   test("visibleForestRows expands only where the set says so", () => {

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -54,6 +54,7 @@ import {
   SESSION_GROUP_ORDER,
   buildRailForest,
   groupSessionsForRail,
+  mergeSessionForRail,
   nodeIsActive,
   recencyGroupFor,
   relativeTimeLabel,
@@ -177,9 +178,13 @@ export function SessionList() {
       ...lineageSessions,
       ...pinned,
     ]) {
-      source.set(session.id, session);
+      const current = source.get(session.id);
+      source.set(session.id, current ? mergeSessionForRail(current, session) : session);
     }
-    for (const [id, override] of pinOverrides) source.set(id, override.session);
+    for (const [id, override] of pinOverrides) {
+      const current = source.get(id);
+      source.set(id, current ? mergeSessionForRail(current, override.session) : override.session);
+    }
     return [...source.values()];
   }, [
     activeLineage.lineage?.ancestors,

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -132,6 +132,19 @@ export type SessionTreeNode = {
   hasActiveDescendant: boolean;
 };
 
+/**
+ * Merge two projections of the same session for the rail. Detail/SSE data is
+ * fresher for lifecycle fields, but detail reads intentionally omit treeStats.
+ * An omitted list-only field must not make the selected row forget its loaded
+ * hierarchy summary (and therefore lose its disclosure control).
+ */
+export function mergeSessionForRail(current: Session, incoming: Session): Session {
+  if (incoming.treeStats !== undefined || current.treeStats === undefined) {
+    return incoming;
+  }
+  return { ...incoming, treeStats: current.treeStats };
+}
+
 export type SessionForest = {
   running: SessionTreeNode[];
   grouped: {


### PR DESCRIPTION
## Summary
- preserve list-only `treeStats` when selected-session detail/SSE projections omit them
- keep fresher selected-session lifecycle fields authoritative
- cover the selected-parent regression and authoritative hierarchy refresh

## Verification
- `bun test apps/web/src/App.test.ts` (98 pass)
- `bun run typecheck` (20/20 projects clean)
- `git diff --check`