### PR TITLE
fix: keep release no-op pushes green

### DIFF
--- a/.changeset/selected-session-expander.md
+++ b/.changeset/selected-session-expander.md
@@ -1,5 +1,0 @@
----
-"opengeni-web": patch
----
-
-Keep session hierarchy expansion controls visible when selecting a parent session.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,19 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Validate changeset release plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          plan="$RUNNER_TEMP/changeset-status.json"
+          bunx changeset status --output "$plan"
+          changeset_count="$(jq -er '.changesets | length' "$plan")"
+          release_count="$(jq -er '.releases | length' "$plan")"
+          if [ "$changeset_count" -gt 0 ] && [ "$release_count" -eq 0 ]; then
+            echo "::error::pending changesets target only ignored/private packages and cannot produce a Version PR"
+            exit 1
+          fi
+
       - name: Generated font manifest freshness
         run: bun run check:generated-fonts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: |
           set -euo pipefail
           plan="$RUNNER_TEMP/changeset-status.json"
+          git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
+          git update-ref refs/heads/main refs/remotes/origin/main
           bunx changeset status --output "$plan"
           changeset_count="$(jq -er '.changesets | length' "$plan")"
           release_count="$(jq -er '.releases | length' "$plan")"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,28 @@ jobs:
       - name: Publish closure guard
         run: bun scripts/publish-closure-guard.ts
 
+      - name: Detect versionable changesets
+        id: release_plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          plan="$RUNNER_TEMP/changeset-status.json"
+          bunx changeset status --output "$plan"
+          changeset_count="$(jq -er '.changesets | length' "$plan")"
+          release_count="$(jq -er '.releases | length' "$plan")"
+          if [ "$changeset_count" -gt 0 ] && [ "$release_count" -eq 0 ]; then
+            echo "::error::pending changesets target only ignored/private packages and cannot produce a Version PR"
+            exit 1
+          fi
+          if [ "$release_count" -gt 0 ]; then
+            echo "has_releases=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_releases=false" >> "$GITHUB_OUTPUT"
+            echo "No publishable package changesets; a Version PR is not required."
+          fi
+
       - name: Create or update Version PR
+        if: ${{ steps.release_plan.outputs.has_releases == 'true' }}
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           version: bun run changeset:version


### PR DESCRIPTION
## Summary
- skip the Changesets Version PR action when no publishable package has a release
- reject ignored/private-only changesets in PR CI and release automation
- remove the ignored web-only changeset that caused main Release to red-fail

## Verification
- `bunx changeset status` reports zero changesets and zero releases
- actionlint 1.7.12
- `git diff --check`
- UBS staged scan: no supported source-language files, 0 findings

Closes the failure in Release run 29678258992.