### PR TITLE
Fix exact composer draft submission

### DIFF
--- a/.changeset/exact-drafts-submit.md
+++ b/.changeset/exact-drafts-submit.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Preserve the exact autosaved composer text when sending or steering so trailing whitespace cannot trip the draft consistency fence.

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -250,12 +250,13 @@ export function useComposer(
   const dispatch = useCallback(
     async (delivery: "send" | "steer", explicit?: string): Promise<boolean> => {
       const draftAtSend = value;
-      const text = (explicit ?? draftAtSend).trim();
+      const rawText = explicit ?? draftAtSend;
+      const hasText = rawText.trim().length > 0;
       // Resolve the extras once: a file-only message (empty text + ≥1 ready
       // resource) is legitimate, so we must not bail on empty text alone.
       const extras = resolveSendExtras(sendExtrasRef.current);
       const hasResources = restoredResources.length > 0 || (extras.resources?.length ?? 0) > 0;
-      if ((!text && !hasResources) || !sessionId || sending) {
+      if ((!hasText && !hasResources) || !sessionId || sending) {
         return false;
       }
       // Reuse the clientEventId across retries of the same draft so a
@@ -264,12 +265,15 @@ export function useComposer(
       setSending(true);
       setError(null);
       try {
-        const payload = currentDraftPayload();
+        // Trimming is only an emptiness check. A non-blank prompt must be sent
+        // byte-for-byte as the user wrote it, because expectedDraftRevision
+        // binds the submission to that exact durable draft. File-only messages
+        // use the same non-blank placeholder in both the saved draft and the
+        // submitted prompt so the content fence cannot reject its own client.
+        const sendText = hasText ? rawText : FILE_ONLY_MESSAGE_TEXT;
+        const currentPayload = currentDraftPayload();
+        const payload = currentPayload ? { ...currentPayload, text: sendText } : null;
         if (payload && !(await persistPayload(payload))) return false;
-        // The wire contract requires non-empty text (z.string().min(1)) and the
-        // worker rejects whitespace-only text; a file-only message therefore
-        // carries a minimal default so the attachments still get delivered.
-        const sendText = text || FILE_ONLY_MESSAGE_TEXT;
         const input = composeSendInput(sendText, pendingClientEventId.current, extras, {
           ...(options.effectiveControl?.controlEtag
             ? { controlEtag: options.effectiveControl.controlEtag }

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -18,7 +18,7 @@ import { fakeClient, fakeGoal, fakeTurn, SESSION_ID, WORKSPACE_ID } from "./fake
 import { OpenGeniApiError } from "@opengeni/sdk";
 import { useAvailableModels } from "../src/hooks/use-available-models";
 import { useBillingUsage } from "../src/hooks/use-billing-usage";
-import { useComposer } from "../src/hooks/use-composer";
+import { FILE_ONLY_MESSAGE_TEXT, useComposer } from "../src/hooks/use-composer";
 import { useEnvironments } from "../src/hooks/use-environments";
 import { useGoal } from "../src/hooks/use-goal";
 import { usePacks } from "../src/hooks/use-packs";
@@ -847,6 +847,117 @@ describe("useComposer durable draft and control binding", () => {
       expectedDraftRevision: 5,
       controlEtag: "control-3",
     });
+    await hook.unmount();
+  });
+
+  for (const delivery of ["send", "steer"] as const) {
+    test(`${delivery} preserves the exact autosaved draft text`, async () => {
+      const submitted: string[] = [];
+      const initial: ComposerDraft = {
+        revision: 4,
+        text: "",
+        resources: [],
+        tools: [],
+        model: "model-x",
+        reasoningEffort: "medium",
+        sourceTurnId: null,
+        sourceTurnVersion: null,
+        updatedAt: new Date().toISOString(),
+      };
+      const client = fakeClient({
+        getComposerDraft: async () => initial,
+        saveComposerDraft: async (_ws, _session, request) => ({
+          ...initial,
+          text: request.text,
+          resources: request.resources,
+          tools: request.tools,
+          model: request.model,
+          reasoningEffort: request.reasoningEffort,
+          revision: request.expectedRevision + 1,
+        }),
+        sendMessage: async (_ws, _session, input) => {
+          submitted.push((input as { text: string }).text);
+          return makeEvent(1, "user.message");
+        },
+        steerMessage: async (_ws, _session, input) => {
+          submitted.push((input as { text: string }).text);
+          return { accepted: makeEvent(1, "user.message"), turn: fakeTurn() };
+        },
+      });
+      const hook = await renderHook(
+        () =>
+          useComposer(SESSION_ID, {
+            client,
+            workspaceId: WORKSPACE_ID,
+            sendExtras: { model: "model-x", reasoningEffort: "medium" },
+          }),
+        undefined,
+      );
+      await flush();
+      const exactText = "  first line\nsecond line\n\n";
+      await flushing(async () => hook.result.current.setValue(exactText));
+      await flush(600);
+      await flushing(async () => expect(await hook.result.current[delivery]()).toBe(true));
+      expect(submitted).toEqual([exactText]);
+      await hook.unmount();
+    });
+  }
+
+  test("a whitespace-only file message saves and submits the same placeholder", async () => {
+    const savedTexts: string[] = [];
+    const submittedTexts: string[] = [];
+    const resource = {
+      kind: "file" as const,
+      fileId: "33333333-3333-4333-8333-333333333333",
+    };
+    const initial: ComposerDraft = {
+      revision: 1,
+      text: "",
+      resources: [],
+      tools: [],
+      model: "model-x",
+      reasoningEffort: "medium",
+      sourceTurnId: null,
+      sourceTurnVersion: null,
+      updatedAt: new Date().toISOString(),
+    };
+    const client = fakeClient({
+      getComposerDraft: async () => initial,
+      saveComposerDraft: async (_ws, _session, request) => {
+        savedTexts.push(request.text);
+        return {
+          ...initial,
+          text: request.text,
+          resources: request.resources,
+          tools: request.tools,
+          model: request.model,
+          reasoningEffort: request.reasoningEffort,
+          revision: request.expectedRevision + 1,
+        };
+      },
+      sendMessage: async (_ws, _session, input) => {
+        submittedTexts.push((input as { text: string }).text);
+        return makeEvent(1, "user.message");
+      },
+    });
+    const hook = await renderHook(
+      () =>
+        useComposer(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          sendExtras: {
+            model: "model-x",
+            reasoningEffort: "medium",
+            resources: [resource],
+          },
+        }),
+      undefined,
+    );
+    await flush();
+    await flushing(async () => hook.result.current.setValue(" \n"));
+    await flushing(async () => expect(await hook.result.current.send()).toBe(true));
+    expect(savedTexts.at(-1)).toBe(FILE_ONLY_MESSAGE_TEXT);
+    expect(submittedTexts).toEqual([FILE_ONLY_MESSAGE_TEXT]);
     await hook.unmount();
   });
 


### PR DESCRIPTION
## Summary
- preserve non-blank composer text byte-for-byte across autosave and Send/Steer
- canonicalize whitespace-only file messages identically before draft save and submission
- add regression coverage for trailing whitespace on Send and Steer plus file-only drafts

## Verification
- `bun test packages/react/test/chat-composer-controls.test.tsx packages/react/test/hooks.test.tsx packages/react/test/queue-surface.test.tsx apps/web/src/App.test.ts` (142 pass)
- `bun run typecheck` (20 projects clean)
- `bun run --filter @opengeni/react build`
- `bun run --filter opengeni-web build`
- `bun run lint`
- `ubs --staged` (new paths triaged; existing heuristic-only findings)