### PR TITLE
fix: preserve workbench files through provider failures

### DIFF
--- a/.changeset/truthful-workbench-fallback.md
+++ b/.changeset/truthful-workbench-fallback.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/react": patch
+"@opengeni/runtime": patch
+---
+
+Keep captured workspace files and diffs usable when the live sandbox provider is temporarily unavailable, surface a truthful retryable degraded state, and distinguish provider failures from invalid workspace paths.

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -50,6 +50,7 @@ import {
   ChannelAConflictError,
   ChannelANotFoundError,
   ChannelAUnsupportedError,
+  ChannelAUnavailableError,
   ChannelAValidationError,
   type ChannelASession,
   type EstablishedSandboxSession,
@@ -313,6 +314,8 @@ export async function withChannelA<T>(
  *  already-HTTPException unchanged. */
 export function mapChannelAError(error: unknown): unknown {
   if (error instanceof HTTPException) return error;
+  if (error instanceof ChannelAUnavailableError)
+    return new HTTPException(503, { message: error.message });
   if (error instanceof ChannelAValidationError)
     return new HTTPException(400, { message: error.message });
   if (error instanceof ChannelANotFoundError)

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { HTTPException } from "hono/http-exception";
+import { ChannelAUnavailableError } from "@opengeni/runtime/sandbox";
+import { mapChannelAError } from "../src/sandbox/channel-a";
 
 // P4.4 route-discipline guards for the 13 Channel-A structured-service routes (a
 // complement to the real-box runtime test + the docker e2e). The invariants the
@@ -131,8 +134,9 @@ describe("P4.4 Channel-A route discipline", () => {
     expect(gate.slice(0, 400)).toContain("sandboxOwnershipEnabled");
   });
 
-  test("the channel-a seam maps the typed service errors to explicit HTTP status (400/404/409)", () => {
-    // backend:none -> 409 before touching the box; ChannelA*Error -> 400/404/409.
+  test("the channel-a seam maps typed service errors to explicit HTTP status", () => {
+    // backend:none -> 409; bad paths stay 400/404 while transient control-plane
+    // failures are retryable 503s and never blame valid user input.
     expect(channelASeam).toContain('session.sandboxBackend === "none"');
     expect(channelASeam).toContain("HTTPException(409");
     // Wrap-tolerant: the formatter may break the guard onto its own line, so
@@ -140,6 +144,16 @@ describe("P4.4 Channel-A route discipline", () => {
     expect(channelASeam).toMatch(/ChannelAValidationError\)\s+return new HTTPException\(400/);
     expect(channelASeam).toMatch(/ChannelANotFoundError\)\s+return new HTTPException\(404/);
     expect(channelASeam).toMatch(/ChannelAConflictError\)\s+return new HTTPException\(409/);
+    expect(channelASeam).toMatch(/ChannelAUnavailableError\)\s+return new HTTPException\(503/);
+
+    const mapped = mapChannelAError(
+      new ChannelAUnavailableError("Workspace files are temporarily unavailable. Retry."),
+    );
+    expect(mapped).toBeInstanceOf(HTTPException);
+    expect((mapped as HTTPException).status).toBe(503);
+    expect((mapped as HTTPException).message).toBe(
+      "Workspace files are temporarily unavailable. Retry.",
+    );
   });
 
   test("the seam never signals Temporal / routes through a worker (API-direct only)", () => {

--- a/packages/react/src/components/file-browser.tsx
+++ b/packages/react/src/components/file-browser.tsx
@@ -6,6 +6,7 @@ import {
   FolderPlusIcon,
   PencilIcon,
   RefreshCwIcon,
+  TriangleAlertIcon,
   Trash2Icon,
 } from "lucide-react";
 import {
@@ -294,7 +295,11 @@ export function FileBrowser({
   const cursorIndex = cursor ? (rowIndexByPath.get(cursor) ?? -1) : -1;
   const activeDescendantId = cursorIndex >= 0 ? `${treeId}-item-${cursorIndex}` : undefined;
 
-  const supportsMutation = editable;
+  // A capture is immutable review data even if a stale capability document still
+  // says the machine is writable. Mutations become available only after a live
+  // reconciliation has actually succeeded.
+  const supportsMutation =
+    editable && result.source === "live" && result.error === null && !result.loading;
 
   const performDelete = useCallback(
     async (node: FileTreeNode) => {
@@ -584,8 +589,11 @@ export function FileBrowser({
   }, [menu]);
 
   const showErrorEmpty = result.error && result.tree.length === 0 && !draftCreate;
+  const showDegradedTree = result.error && result.tree.length > 0;
   const showEmpty = !result.loading && result.tree.length === 0 && !draftCreate;
-  const showToolbar = supportsMutation || Boolean(result.error) || result.loading;
+  // Retry lives next to the state it explains (the degraded/empty notice), so do
+  // not render a second toolbar retry for the same failure.
+  const showToolbar = supportsMutation || result.loading;
   const usesVirtualTree = !showErrorEmpty && !showEmpty;
 
   // Render a SINGLE node row (no recursion — children are separate flat items the
@@ -828,6 +836,34 @@ export function FileBrowser({
           </ToolbarButton>
         </div>
       )}
+
+      {showDegradedTree ? (
+        <div
+          role="status"
+          aria-live="polite"
+          data-opengeni-files-degraded
+          className="flex shrink-0 items-center gap-2 border-b border-og-status-running/30 bg-og-status-running/10 px-2 py-1.5 text-og-xs text-og-fg-muted"
+        >
+          <TriangleAlertIcon className="size-3.5 shrink-0 text-og-status-running" aria-hidden />
+          <span className="min-w-0 flex-1">
+            {result.source === "capture"
+              ? "Live files are temporarily unavailable. Showing the latest captured revision."
+              : "Live refresh failed. Showing the last loaded files."}
+          </span>
+          <button
+            type="button"
+            onClick={() => void result.refresh()}
+            disabled={result.loading}
+            className="inline-flex min-h-7 shrink-0 items-center gap-1 rounded-og-sm border border-og-border bg-og-surface-1 px-2 font-medium text-og-fg transition-colors hover:border-og-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent disabled:cursor-not-allowed disabled:opacity-50 pointer-coarse:min-h-11"
+          >
+            <RefreshCwIcon
+              className={cn("size-3", result.loading && "animate-spin motion-reduce:animate-none")}
+              aria-hidden
+            />
+            Retry
+          </button>
+        </div>
+      ) : null}
 
       {/* The tree itself. The root is a drop target so a node can be moved to "". */}
       {/* biome-ignore lint/a11y/noNoninteractiveTabindex: the tree owns keyboard nav */}

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -161,7 +161,9 @@ export function SandboxFiles({
   const captureFileUnavailable =
     fileView.error instanceof CapturedFileUnavailableError ? fileView.error : null;
   const waitingForSelectedFile =
-    liveRequestedPath === viewPath && !liveWorkspaceReady && captureFileUnavailable !== null;
+    liveRequestedPath === viewPath &&
+    (!liveWorkspaceReady || files.loading) &&
+    captureFileUnavailable !== null;
 
   if (!fileSystemAvailable) {
     return (
@@ -302,10 +304,11 @@ export function SandboxFiles({
                     <WakeButton
                       onClick={() => {
                         setLiveRequestedPath(viewPath);
-                        onWakeWorkspace();
+                        if (liveWorkspaceReady) void files.refresh();
+                        else onWakeWorkspace();
                       }}
                     >
-                      Open live file
+                      {liveWorkspaceReady ? "Retry live file" : "Open live file"}
                     </WakeButton>
                   ) : null}
                 </Notice>

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -285,7 +285,8 @@ export function useSandboxWorkspaceTabs(
 
   // The cold-paint data source: the latest turn-end capture, fetched with a single
   // api round-trip on mount (no machine). Feeds the Files tree + the Changes/Git
-  // diff when the box is not warm; a warm box always wins (live path unchanged).
+  // diff immediately; a warm box reconciles live without discarding the capture
+  // when that provider read is temporarily unavailable.
   const captureState = useWorkspaceCapture(sessionId, { events });
   const captureAvailable = captureState.available;
   const liveWorkspaceExpected = liveness === "warm" || liveness === "draining";
@@ -510,7 +511,9 @@ export function useSandboxWorkspaceTabs(
           git={git}
           stagedGit={stagedGit}
           fileSystemAvailable={fileSystemOn || captureAvailable}
-          editable={filesEditable}
+          editable={
+            filesEditable && files.source === "live" && files.error === null && !files.loading
+          }
           workspaceResting={
             !liveWorkspaceExpected &&
             liveness !== undefined &&
@@ -918,13 +921,44 @@ function ChangesTabBody({
 
   if (diff.length > 0) {
     return (
-      <WorkbenchChanges
-        diff={diff}
-        source={git.source}
-        capturedAt={git.capturedAt}
-        captureRevision={captureRevision}
-        {...(onOpenFile ? { onOpenFile } : {})}
-      />
+      <div className="flex h-full min-h-0 flex-col">
+        {git.error ? (
+          <div
+            role="status"
+            aria-live="polite"
+            data-opengeni-changes-degraded
+            className="flex shrink-0 items-center gap-2 border-b border-og-status-running/30 bg-og-status-running/10 px-2 py-1.5 text-og-xs text-og-fg-muted"
+          >
+            <TriangleAlertIcon className="size-3.5 shrink-0 text-og-status-running" aria-hidden />
+            <span className="min-w-0 flex-1">
+              {git.source === "capture"
+                ? "Live changes are temporarily unavailable. Showing the latest captured revision."
+                : "Live refresh failed. Showing the last loaded changes."}
+            </span>
+            <button
+              type="button"
+              onClick={() => void git.refresh()}
+              disabled={git.loading}
+              className="inline-flex min-h-7 shrink-0 items-center gap-1 rounded-og-sm border border-og-border bg-og-surface-1 px-2 font-medium text-og-fg transition-colors hover:border-og-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent disabled:cursor-not-allowed disabled:opacity-50 pointer-coarse:min-h-11"
+            >
+              <RefreshCwIcon
+                className={cn("size-3", git.loading && "animate-spin motion-reduce:animate-none")}
+                aria-hidden
+              />
+              Retry
+            </button>
+          </div>
+        ) : null}
+        <div className="min-h-0 flex-1">
+          <WorkbenchChanges
+            diff={diff}
+            source={git.source}
+            capturedAt={git.capturedAt}
+            captureRevision={captureRevision}
+            {...(onOpenFile ? { onOpenFile } : {})}
+          />
+        </div>
+      </div>
     );
   }
 

--- a/packages/react/src/hooks/use-sandbox-files.ts
+++ b/packages/react/src/hooks/use-sandbox-files.ts
@@ -88,11 +88,10 @@ export type UseSandboxFilesOptions = ClientOverride & {
    *  (with no `fs.changed` event) never re-lists. Passing liveness re-lists when
    *  the box first becomes warm, so the tree populates as soon as the box is up. */
   liveness?: string | undefined;
-  /** The latest turn-end workspace capture (from `useWorkspaceCapture`). When the
-   *  box is NOT warm, the tree paints INSTANTLY from this capture's tree index (the
-   *  <200ms cold first paint) instead of blocking on a Channel-A list. A warm box
-   *  always wins (live path unchanged). On the cold→warm transition the live list
-   *  is merged in place — no remount, no flash (dossier §10.4 / §12-A1/D1). */
+  /** The latest turn-end workspace capture (from `useWorkspaceCapture`). The tree
+   *  paints immediately from this durable index, then a warm box reconciles live
+   *  in place. If that live read fails, the capture remains a truthful read-only
+   *  fallback instead of turning into an empty error surface. */
   capture?: WorkspaceCaptureManifest | null | undefined;
   /** Called when an OPTIMISTIC mutation is reverted because its background
    *  Channel-A op failed (e.g. a 409 rename collision). The host wires this to a
@@ -408,6 +407,7 @@ export function useSandboxFiles(
   const [stateIdentity, setStateIdentity] = useState(identityKey);
   // Which source the tree currently reflects — "capture" (cold paint) or "live".
   const [source, setSource] = useState<"live" | "capture" | null>(null);
+  const sourceRef = useRef<"live" | "capture" | null>(null);
   const statusRef = useRef<Map<string, FileTreeStatus>>(new Map());
   // Async reads, event cursors, and debounced work are scoped to the hook's
   // workspace/session/root identity. These refs are reset/fenced at that boundary.
@@ -509,6 +509,7 @@ export function useSandboxFiles(
         applyStatus(prev.length === 0 ? children : mergeRootChildren(prev, children)),
       );
       // Live data is now serving — flip the source off the capture snapshot.
+      sourceRef.current = "live";
       setSource("live");
     } catch (cause) {
       if (refreshGenerationRef.current !== generation) return;
@@ -523,7 +524,7 @@ export function useSandboxFiles(
   // zero Channel-A calls. The tree index is workspace-relative (`treeIndex`); the
   // tint overlay comes from the capture's changed `files`. Uses the SAME merge as
   // the live reconcile so a re-seed (a newer capture arriving cold) patches deltas
-  // in place instead of remounting the tree (§12-D1). Never runs while warm.
+  // in place instead of remounting the tree (§12-D1).
   const seedFromCapture = useCallback(
     (manifest: WorkspaceCaptureManifest) => {
       const overlay = new Map<string, FileTreeStatus>();
@@ -540,6 +541,7 @@ export function useSandboxFiles(
       setTree((prev) =>
         applyStatus(prev.length === 0 ? children : mergeRootChildren(prev, children)),
       );
+      sourceRef.current = "capture";
       setSource("capture");
       setError(null);
     },
@@ -552,7 +554,7 @@ export function useSandboxFiles(
       // Capture browsing is a durable server-side read surface. Never turn a
       // folder click into a Channel-A list while cold; truncated residue already
       // renders a truthful "contents on machine" row.
-      if (!isLive && capture) return;
+      if (source === "capture" && capture) return;
       const identityGeneration = identityGenerationRef.current;
       const identitySignal = identityAbortRef.current.signal;
       // Mark this node as expanding so the FileBrowser can render a spinner while
@@ -587,7 +589,7 @@ export function useSandboxFiles(
         }
       }
     },
-    [client, workspaceId, sessionId, capture, isLive, applyStatus],
+    [client, workspaceId, sessionId, capture, source, applyStatus],
   );
 
   const readFile = useCallback(
@@ -598,7 +600,7 @@ export function useSandboxFiles(
         ? AbortSignal.any([identitySignal, requestOptions.signal])
         : identitySignal;
       const captured = capture?.files.find((file) => file.path === path && !file.deleted);
-      if (!isLive && capture) {
+      if (source === "capture" && capture) {
         if (!captured) {
           throw new CapturedFileUnavailableError(path, "not-captured");
         }
@@ -682,7 +684,7 @@ export function useSandboxFiles(
       }
       return await client.fsRead(workspaceId, sessionId, { path }, { signal });
     },
-    [client, workspaceId, sessionId, capture, isLive],
+    [client, workspaceId, sessionId, capture, source],
   );
 
   // TARGETED reconcile of a single directory — re-list ONE parent at depth 1 and
@@ -901,10 +903,9 @@ export function useSandboxFiles(
   );
 
   // Initial paint + reset on identity change. Source selection (dossier §10.4):
-  //   • warm/draining box → the LIVE list (unchanged behavior).
-  //   • cold/offline box WITH a capture → paint instantly from the capture index
-  //     (no Channel-A; the box warms in the background and the warm effect below
-  //     reconciles live in place).
+  //   • any box WITH a capture → paint instantly from the durable capture index;
+  //     a warm/draining box then reconciles live in place.
+  //   • if that live reconciliation fails, keep the capture visible and read-only.
   //   • cold box with NO capture → best-effort live list (status quo — never worse).
   // Key the seed on the capture's REVISION (a primitive), not the manifest object
   // — a consumer passing a fresh object each render (or a new revision) must not
@@ -939,6 +940,7 @@ export function useSandboxFiles(
       setTree([]);
       setStateIdentity(identityKey);
       setExpandingPaths(new Set());
+      sourceRef.current = null;
       setSource(null);
       setLoading(false);
       setError(null);
@@ -946,11 +948,11 @@ export function useSandboxFiles(
     if (!enabled) {
       return;
     }
-    if (isLive) {
-      void refresh();
-    } else if (captureRevision !== null && captureRef.current) {
-      seedFromCapture(captureRef.current);
-    } else {
+    const currentCapture = captureRevision !== null ? captureRef.current : null;
+    if (currentCapture && (identityChanged || !isLive || sourceRef.current !== "live")) {
+      seedFromCapture(currentCapture);
+    }
+    if (isLive || !currentCapture) {
       void refresh();
     }
     return () => {
@@ -1069,23 +1071,6 @@ export function useSandboxFiles(
     },
     [],
   );
-
-  // Re-list when the box first becomes warm. The FileSystem capability is
-  // advertised on a cold box too, so the mount-time `refresh()` can run before
-  // the box is up (empty/errored result); without an `fs.changed` event the tree
-  // would stay empty forever. A cold->warm transition re-lists once the box is
-  // actually serving — the real fix for the "No files" the deployed app showed.
-  const wasLiveRef = useRef(false);
-  const liveness = options.liveness;
-  useEffect(() => {
-    const live = liveness === "warm" || liveness === "draining";
-    if (enabled && live && !wasLiveRef.current) {
-      wasLiveRef.current = true;
-      void refresh();
-    } else if (!live) {
-      wasLiveRef.current = false;
-    }
-  }, [enabled, liveness, refresh]);
 
   const identityMatches = enabled && stateIdentity === identityKey;
   return {

--- a/packages/react/src/hooks/use-sandbox-git.ts
+++ b/packages/react/src/hooks/use-sandbox-git.ts
@@ -23,8 +23,9 @@ export type UseSandboxGitOptions = ClientOverride & {
   /** Lease liveness ("warm" | "draining" | "cold"). When NOT warm, the diff is
    *  served from the capture (cold/offline) instead of a live `gitDiff` RPC. */
   liveness?: string | undefined;
-  /** The latest turn-end capture (from `useWorkspaceCapture`). Supplies the cold
-   *  diff for this repo. A warm box always wins (live `gitDiff` unchanged). */
+  /** The latest turn-end capture (from `useWorkspaceCapture`). Seeds the diff
+   *  immediately; a warm box reconciles live and leaves this durable review
+   *  surface in place if the live request is temporarily unavailable. */
   capture?: WorkspaceCaptureManifest | null | undefined;
 };
 
@@ -194,6 +195,7 @@ export function useSandboxGit(
   const [behind, setBehind] = useState(0);
   const [repoRoots, setRepoRoots] = useState<string[]>([]);
   const [source, setSource] = useState<"live" | "capture" | null>(null);
+  const sourceRef = useRef<"live" | "capture" | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [stateIdentity, setStateIdentity] = useState(identityKey);
@@ -233,6 +235,7 @@ export function useSandboxGit(
       setBehind(repositories.reduce((sum, { status }) => sum + status.behind, 0));
       if (repositories.length === 0) {
         setDiff([]);
+        sourceRef.current = "live";
         setSource("live");
         return;
       }
@@ -261,6 +264,7 @@ export function useSandboxGit(
           ),
         ),
       );
+      sourceRef.current = "live";
       setSource("live");
     } catch (cause) {
       if (refreshGenerationRef.current !== generation) return;
@@ -285,6 +289,7 @@ export function useSandboxGit(
         setBehind(0);
         setRepoRoots([]);
         setDiff((prev) => (prev.length === 0 ? prev : []));
+        sourceRef.current = "capture";
         setSource("capture");
         return;
       }
@@ -301,6 +306,7 @@ export function useSandboxGit(
           ),
         ),
       );
+      sourceRef.current = "capture";
       setSource("capture");
       setError(null);
     },
@@ -331,6 +337,7 @@ export function useSandboxGit(
       setAhead(0);
       setBehind(0);
       setRepoRoots([]);
+      sourceRef.current = null;
       setSource(null);
       setLoading(false);
       setError(null);
@@ -338,11 +345,11 @@ export function useSandboxGit(
     if (!enabled) {
       return;
     }
-    if (isLive) {
-      void refresh();
-    } else if (captureRevision !== null && captureRef.current) {
-      seedFromCapture(captureRef.current);
-    } else {
+    const currentCapture = captureRevision !== null ? captureRef.current : null;
+    if (currentCapture && (identityChanged || !isLive || sourceRef.current !== "live")) {
+      seedFromCapture(currentCapture);
+    }
+    if (isLive || !currentCapture) {
       void refresh();
     }
     return () => {

--- a/packages/react/test/sandbox-components.test.tsx
+++ b/packages/react/test/sandbox-components.test.tsx
@@ -109,6 +109,27 @@ describe("FileBrowser", () => {
     await r.unmount();
   });
 
+  test("keeps captured files visible with an accessible retry state and no mutations", async () => {
+    const r = await renderComponent(
+      <FileBrowser
+        result={filesResult({
+          source: "capture",
+          capturedAt: "2026-07-19T10:44:52.383Z",
+          error: new Error("OpenGeni API 503: Workspace files are temporarily unavailable"),
+        })}
+      />,
+    );
+    await flush();
+
+    const degraded = r.container.querySelector("[data-opengeni-files-degraded]");
+    expect(degraded?.getAttribute("role")).toBe("status");
+    expect(degraded?.textContent).toContain("Showing the latest captured revision");
+    expect(r.container.textContent).toContain("README.md");
+    expect(r.container.querySelector('button[aria-label="New file"]')).toBeNull();
+    expect(r.container.querySelector('button[aria-label="Delete"]')).toBeNull();
+    await r.unmount();
+  });
+
   test("an empty tree shows the empty state (no crash)", async () => {
     const r = await renderComponent(
       <FileBrowser result={filesResult({ tree: [] })} emptyState="nothing here" />,
@@ -199,6 +220,43 @@ describe("SandboxFiles guarded-file routing", () => {
     await actRun(() => openLive!.click());
     expect(wakeCalls).toBe(1);
     expect(r.container.textContent).toContain("Waking workspace");
+    await r.unmount();
+  });
+
+  test("an already-warm capture fallback retries the live list instead of issuing a no-op wake", async () => {
+    let refreshCalls = 0;
+    let wakeCalls = 0;
+    const files = filesResult({
+      source: "capture",
+      error: new Error("OpenGeni API 503: Workspace files are temporarily unavailable"),
+      readFile: async (path) => {
+        throw new CapturedFileUnavailableError(path, "not-captured");
+      },
+      refresh: async () => {
+        refreshCalls += 1;
+      },
+    });
+    const r = await renderComponent(
+      <SandboxFiles
+        files={files}
+        git={gitResult()}
+        liveWorkspaceReady
+        onWakeWorkspace={() => {
+          wakeCalls += 1;
+        }}
+      />,
+    );
+    await flush();
+    await actRun(() => fileButton(r.container, "README.md").click());
+    await flush();
+
+    const retry = Array.from(r.container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Retry live file"),
+    );
+    expect(retry).toBeDefined();
+    await actRun(() => retry!.click());
+    expect(refreshCalls).toBe(1);
+    expect(wakeCalls).toBe(0);
     await r.unmount();
   });
 

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -735,6 +735,38 @@ describe("SandboxWorkspace capture-driven default renders with no content switch
     await rendered.unmount();
   });
 
+  test("warm provider failure keeps captured Changes visible with an accessible retry state", async () => {
+    const { client } = coldClient({
+      getStreamCapabilities: async () => fakeCapabilities(),
+      getWorkspaceCapture: async () => captureAvailable(fakeManifest(1)),
+      gitStatus: async () => {
+        throw new Error("OpenGeni API 503: Workspace files are temporarily unavailable");
+      },
+      fsList: async () => {
+        throw new Error("OpenGeni API 503: Workspace files are temporarily unavailable");
+      },
+    });
+    const rendered = await renderComponent(
+      withProvider(
+        client,
+        <SandboxWorkspace
+          sessionId={SESSION_ID}
+          events={[]}
+          primary={<div>chat</div>}
+          autoSaveId="og.test.prewarm.degraded-capture"
+        />,
+      ),
+    );
+    await flush();
+
+    expect(selectedTabText(rendered.container)).toContain("Changes");
+    const degraded = rendered.container.querySelector("[data-opengeni-changes-degraded]");
+    expect(degraded?.getAttribute("role")).toBe("status");
+    expect(degraded?.textContent).toContain("Showing the latest captured revision");
+    expect(rendered.container.textContent).toContain("app.py");
+    await rendered.unmount();
+  });
+
   test("a tab selection from the previous session does not override the new session default", async () => {
     const { client } = coldClient({
       getWorkspaceCapture: async () => captureAvailable(fakeManifest(2)),

--- a/packages/react/test/workspace-capture-hooks.test.tsx
+++ b/packages/react/test/workspace-capture-hooks.test.tsx
@@ -810,7 +810,7 @@ describe("useSandboxFiles — capture source", () => {
     await hook.unmount();
   });
 
-  test("warm uses the LIVE path (capture ignored, existing behavior)", async () => {
+  test("warm reconciles the capture to the live path when the provider succeeds", async () => {
     let fsListCalls = 0;
     const client = fakeClient({
       gitStatus: async () => ({
@@ -838,9 +838,99 @@ describe("useSandboxFiles — capture source", () => {
       undefined,
     );
     await flush();
-    expect(fsListCalls).toBeGreaterThan(0);
+    expect(fsListCalls).toBe(1);
     expect(hook.result.current.source).toBe("live");
     expect(hook.result.current.tree.map((n) => n.name)).toEqual(["live.ts"]);
+    await hook.unmount();
+  });
+
+  test("warm live-list failure preserves the capture and reads captured content server-side", async () => {
+    const content = "captured during provider failure\n";
+    const hash = createHash("sha256").update(content).digest("hex");
+    const capture = fakeManifest({
+      files: [
+        {
+          ...fakeManifest().files[0]!,
+          hash,
+          sizeBytes: Buffer.byteLength(content),
+        },
+      ],
+    });
+    let fsReadCalls = 0;
+    let captureFileCalls = 0;
+    let failLiveList = true;
+    const client = fakeClient({
+      gitStatus: async () => ({
+        isRepo: false,
+        head: null,
+        detached: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 0,
+      }),
+      fsList: async () => {
+        if (failLiveList) {
+          throw new Error("OpenGeni API 503: Workspace files are temporarily unavailable");
+        }
+        return {
+          root: treeDir("", "", [treeFile("app.py", "src/app.py", 13)]),
+          revision: 4,
+          truncated: false,
+        };
+      },
+      fsRead: async (_workspaceId, _sessionId, request) => {
+        fsReadCalls += 1;
+        return {
+          path: request.path,
+          encoding: "utf8",
+          content: "live content\n",
+          sizeBytes: 13,
+          truncated: false,
+          isBinary: false,
+          revision: 4,
+        };
+      },
+      getWorkspaceCaptureFile: async (_workspaceId, _sessionId, path, revision) => {
+        captureFileCalls += 1;
+        return {
+          path,
+          revision: revision!,
+          status: "modified",
+          hash,
+          baseHash: null,
+          sizeBytes: Buffer.byteLength(content),
+          isBinary: false,
+          tooLarge: false,
+          encoding: "utf8",
+          content,
+          contentUrl: null,
+        };
+      },
+    });
+    const hook = await renderHook(
+      () => useSandboxFiles(SESSION_ID, { ...ctx, client, capture, liveness: "warm" }),
+      undefined,
+    );
+    await flush();
+
+    expect(hook.result.current.source).toBe("capture");
+    expect(hook.result.current.tree.map((node) => node.name)).toEqual(["src", "README.md"]);
+    expect(hook.result.current.error?.message).toContain("503");
+    const read = await hook.result.current.readFile("src/app.py");
+    expect(read.content).toBe(content);
+    expect(captureFileCalls).toBe(1);
+    expect(fsReadCalls).toBe(0);
+
+    failLiveList = false;
+    await actRun(() => hook.result.current.refresh());
+    await flush();
+    expect(hook.result.current.source).toBe("live");
+    expect(hook.result.current.error).toBeNull();
+    const liveRead = await hook.result.current.readFile("src/app.py");
+    expect(liveRead.content).toBe("live content\n");
+    expect(fsReadCalls).toBe(1);
     await hook.unmount();
   });
 
@@ -914,6 +1004,7 @@ describe("useSandboxFiles — capture source", () => {
   });
 
   test("FLAGSHIP: cold→warm reconcile keeps node identity — no remount, deltas patched", async () => {
+    let fsListCalls = 0;
     const client = fakeClient({
       gitStatus: async () => ({
         isRepo: false,
@@ -927,15 +1018,18 @@ describe("useSandboxFiles — capture source", () => {
       }),
       // The live list returns the SAME two entries the capture had (unchanged),
       // plus a new file — the delta that must be patched in.
-      fsList: async () => ({
-        root: treeDir("", "", [
-          treeDir("src", "src"),
-          treeFile("README.md", "README.md", 10),
-          treeFile("new.ts", "new.ts", 3),
-        ]),
-        revision: 1,
-        truncated: false,
-      }),
+      fsList: async () => {
+        fsListCalls += 1;
+        return {
+          root: treeDir("", "", [
+            treeDir("src", "src"),
+            treeFile("README.md", "README.md", 10),
+            treeFile("new.ts", "new.ts", 3),
+          ]),
+          revision: 1,
+          truncated: false,
+        };
+      },
     });
     const hook = await renderHook(
       (props: { liveness: string }) =>
@@ -959,6 +1053,7 @@ describe("useSandboxFiles — capture source", () => {
     // Box warms → live reconcile.
     await hook.rerender({ liveness: "warm" });
     await flush();
+    expect(fsListCalls).toBe(1);
 
     const warmTree = hook.result.current.tree;
     // The tree was NEVER emptied and NOW serves live.
@@ -1460,7 +1555,7 @@ describe("useSandboxGit — capture source", () => {
     await hook.unmount();
   });
 
-  test("warm uses the live diff directly (capture ignored)", async () => {
+  test("warm reconciles the capture to the live diff", async () => {
     let gitDiffCalls = 0;
     const client = fakeClient({
       gitStatus: async () => ({
@@ -1487,6 +1582,30 @@ describe("useSandboxGit — capture source", () => {
     expect(gitDiffCalls).toBeGreaterThan(0);
     expect(hook.result.current.source).toBe("live");
     expect(hook.result.current.diff.map((d) => d.path)).toEqual(["live-only.py"]);
+    await hook.unmount();
+  });
+
+  test("warm live-Git failure preserves the captured review diff", async () => {
+    const client = fakeClient({
+      gitStatus: async () => {
+        throw new Error("OpenGeni API 503: Workspace files are temporarily unavailable");
+      },
+    });
+    const hook = await renderHook(
+      () =>
+        useSandboxGit(SESSION_ID, {
+          ...ctx,
+          client,
+          capture: fakeManifest(),
+          liveness: "warm",
+        }),
+      undefined,
+    );
+    await flush();
+
+    expect(hook.result.current.source).toBe("capture");
+    expect(hook.result.current.diff.map((file) => file.path)).toEqual(["app.py"]);
+    expect(hook.result.current.error?.message).toContain("503");
     await hook.unmount();
   });
 

--- a/packages/runtime/src/sandbox/channel-a.ts
+++ b/packages/runtime/src/sandbox/channel-a.ts
@@ -111,6 +111,15 @@ export class ChannelAValidationError extends Error {
     this.name = "ChannelAValidationError";
   }
 }
+/** A structurally valid Channel-A request could not be completed because the
+ * sandbox/provider control plane was temporarily unavailable. Callers may retry
+ * this class; it must never be presented as a bad user path. */
+export class ChannelAUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ChannelAUnavailableError";
+  }
+}
 export class ChannelAConflictError extends Error {
   constructor(message: string) {
     super(message);
@@ -346,16 +355,15 @@ export class SandboxChannelAService {
       "producer_status=${PIPESTATUS[0]};",
       `if [ "$producer_status" -ne 0 ] && [ "$producer_status" -ne 141 ]; then printf '%s\\0' ${shellQuote(FS_LIST_TRUNCATED_MARKER)}; fi`,
     ].join(" ");
-    const { stdout, exitCode, sessionId } = await this.runInConfinedDirectory(root, {
-      cmd: `bash -lc ${shellQuote(findCommand)}`,
+    const { stdout, exitCode } = await this.runInConfinedDirectory(root, {
+      cmd: internalBashCommand(findCommand),
       yieldTimeMs: 10_000,
       maxOutputTokens: Math.ceil(FS_LIST_MAX_OUTPUT_BYTES / 4) + 1_024,
     });
-    if (sessionId !== undefined) {
-      throw new ChannelAValidationError("filesystem listing exceeded its 10 second deadline");
-    }
     if (exitCode !== 0) {
-      throw new ChannelAValidationError(`filesystem listing failed with exit code ${exitCode}`);
+      throw new ChannelAUnavailableError(
+        "Workspace files are temporarily unavailable. Retry the file list.",
+      );
     }
 
     const entries = stdout.split(NUL).filter((s) => s.length > 0);
@@ -432,8 +440,18 @@ export class SandboxChannelAService {
       if (isWorkspaceEscapeError(error)) {
         throw new ChannelAValidationError(`path resolves outside workspace: ${path}`);
       }
-      throw new ChannelANotFoundError(
-        `file not found: ${path} (${error instanceof Error ? error.message : String(error)})`,
+      if (isDefinitePathNotFoundError(error)) {
+        throw new ChannelANotFoundError(`file not found: ${path}`);
+      }
+      // A native provider read can fail while exec on the same live box remains
+      // healthy. The descriptor path below is equally confined and binary-safe,
+      // so use it as a single recovery path. Unknown provider failures must never
+      // be downgraded into a false 404.
+      if (this.session.exec || this.session.execCommand) {
+        return await this.fsReadViaExec(path, req);
+      }
+      throw new ChannelAUnavailableError(
+        "Workspace files are temporarily unavailable. Retry the file read.",
       );
     }
     const bytes = typeof raw === "string" ? Buffer.from(raw, "utf8") : Buffer.from(raw);
@@ -454,7 +472,7 @@ export class SandboxChannelAService {
       `test -d "$target" || { printf '__OPENGENI_FS_NOT_FOUND__'; exit 66; }`,
       `printf '__OPENGENI_FS_CONFINED_OK__'`,
     ].join("; ");
-    const result = await this.run({ cmd: `bash -lc ${shellQuote(script)}` });
+    const result = await this.run({ cmd: internalBashCommand(script) });
     this.assertConfinementResult(result, path || ".", "directory");
   }
 
@@ -483,16 +501,21 @@ export class SandboxChannelAService {
       requireParent,
       `printf '__OPENGENI_FS_CONFINED_OK__'`,
     ].join("; ");
-    const result = await this.run({ cmd: `bash -lc ${shellQuote(script)}` });
+    const result = await this.run({ cmd: internalBashCommand(script) });
     this.assertConfinementResult(result, path, "mutation");
   }
 
   private assertConfinementResult(
-    result: { stdout: string; exitCode: number | null },
+    result: { stdout: string; exitCode: number | null; sessionId?: number },
     path: string,
     kind: "directory" | "mutation",
   ): void {
-    if (result.stdout === "__OPENGENI_FS_CONFINED_OK__") return;
+    if (result.sessionId !== undefined) {
+      throw new ChannelAUnavailableError(
+        "Workspace files are temporarily unavailable. Retry the operation.",
+      );
+    }
+    if (result.stdout.includes("__OPENGENI_FS_CONFINED_OK__")) return;
     if (result.stdout.includes("__OPENGENI_FS_ESCAPE__") || result.exitCode === 67) {
       throw new ChannelAValidationError(`path resolves outside workspace: ${path}`);
     }
@@ -502,7 +525,9 @@ export class SandboxChannelAService {
     if (result.stdout.includes("__OPENGENI_FS_NOT_FOUND__") || result.exitCode === 66) {
       throw new ChannelANotFoundError(`${kind} path not found: ${path}`);
     }
-    throw new ChannelAValidationError(`unable to validate workspace ${kind} path: ${path}`);
+    throw new ChannelAUnavailableError(
+      "Workspace files are temporarily unavailable. Retry the operation.",
+    );
   }
 
   /** Binary-safe fallback for sessions without native reads. The file is opened
@@ -520,10 +545,24 @@ export class SandboxChannelAService {
       `printf '__OPENGENI_FS_READ_OK__\\n'`,
       `head -c ${req.maxBytes} <&3 | base64 | tr -d '\\n'`,
     ].join("; ");
-    const { stdout, exitCode } = await this.run({
-      cmd: `bash -lc ${shellQuote(script)}`,
-      maxOutputTokens: Math.ceil((req.maxBytes * 4) / 3) + 1_024,
-    });
+    let result: Awaited<ReturnType<SandboxChannelAService["run"]>>;
+    try {
+      result = await this.run({
+        cmd: internalBashCommand(script),
+        maxOutputTokens: Math.ceil((req.maxBytes * 4) / 3) + 1_024,
+      });
+    } catch (error) {
+      if (error instanceof ChannelAUnsupportedError) throw error;
+      throw new ChannelAUnavailableError(
+        "Workspace files are temporarily unavailable. Retry the file read.",
+      );
+    }
+    const { stdout, exitCode, sessionId } = result;
+    if (sessionId !== undefined) {
+      throw new ChannelAUnavailableError(
+        "Workspace files are temporarily unavailable. Retry the file read.",
+      );
+    }
     if (stdout.includes("__OPENGENI_FS_ESCAPE__") || exitCode === 67) {
       throw new ChannelAValidationError(`path resolves outside workspace: ${path}`);
     }
@@ -531,10 +570,16 @@ export class SandboxChannelAService {
       throw new ChannelANotFoundError(`file not found: ${path}`);
     }
     const prefix = "__OPENGENI_FS_READ_OK__\n";
-    if (!stdout.startsWith(prefix) || (exitCode !== null && exitCode !== 0)) {
-      throw new ChannelAValidationError(`failed to read workspace file: ${path}`);
+    const successIndex = stdout.indexOf(prefix);
+    if (successIndex < 0 || (exitCode !== null && exitCode !== 0)) {
+      throw new ChannelAUnavailableError(
+        "Workspace files are temporarily unavailable. Retry the file read.",
+      );
     }
-    const bytes = Buffer.from(stdout.slice(prefix.length).replace(/\n/g, ""), "base64");
+    const bytes = Buffer.from(
+      stdout.slice(successIndex + prefix.length).replace(/\n/g, ""),
+      "base64",
+    );
     return this.shapeRead(path, bytes, req);
   }
 
@@ -1033,7 +1078,7 @@ export class SandboxChannelAService {
         'exit "$status"',
       ].join("\n");
       const { stdout } = await this.run({
-        cmd: `bash -lc ${shellQuote(command)}`,
+        cmd: internalBashCommand(command),
         workdir: this.workspaceRoot || undefined,
         yieldTimeMs: 20_000,
         // At most 256 Unix paths (PATH_MAX each) plus the status trailer. This
@@ -1243,26 +1288,47 @@ export class SandboxChannelAService {
       `printf '__OPENGENI_FS_CONFINED_OK__\\n'`,
       args.cmd,
     ].join("; ");
-    const result = await this.run({
-      ...args,
-      cmd: `bash -lc ${shellQuote(script)}`,
-      workdir: undefined,
-    });
     const successPrefix = "__OPENGENI_FS_CONFINED_OK__\n";
-    if (result.stdout.startsWith(successPrefix)) {
-      return { ...result, stdout: result.stdout.slice(successPrefix.length) };
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      let result: Awaited<ReturnType<SandboxChannelAService["run"]>>;
+      try {
+        result = await this.run({
+          ...args,
+          cmd: internalBashCommand(script),
+          workdir: undefined,
+        });
+      } catch (error) {
+        if (error instanceof ChannelAUnsupportedError) throw error;
+        if (attempt === 0) continue;
+        throw new ChannelAUnavailableError(
+          "Workspace files are temporarily unavailable. Retry the operation.",
+        );
+      }
+      if (result.sessionId !== undefined) {
+        throw new ChannelAUnavailableError(
+          "Workspace files are temporarily unavailable. Retry after the current file operation finishes.",
+        );
+      }
+      const successIndex = result.stdout.indexOf(successPrefix);
+      if (successIndex >= 0) {
+        return { ...result, stdout: result.stdout.slice(successIndex + successPrefix.length) };
+      }
+      if (result.stdout.includes("__OPENGENI_FS_ESCAPE__") || result.exitCode === 67) {
+        throw new ChannelAValidationError(`path resolves outside workspace: ${safe || "."}`);
+      }
+      if (result.stdout.includes("__OPENGENI_FS_SYMLINK__") || result.exitCode === 68) {
+        throw new ChannelAValidationError(`directory path must not be a symbolic link: ${safe}`);
+      }
+      if (result.stdout.includes("__OPENGENI_FS_NOT_FOUND__") || result.exitCode === 66) {
+        throw new ChannelANotFoundError(`directory path not found: ${safe || "."}`);
+      }
+      // Every operation using this helper is read-only. A completed result with
+      // no trusted marker can be retried once, but is never downgraded into a
+      // user-input error.
+      if (attempt === 0) continue;
     }
-    if (result.stdout === "__OPENGENI_FS_ESCAPE__" || result.exitCode === 67) {
-      throw new ChannelAValidationError(`path resolves outside workspace: ${safe || "."}`);
-    }
-    if (result.stdout === "__OPENGENI_FS_SYMLINK__" || result.exitCode === 68) {
-      throw new ChannelAValidationError(`directory path must not be a symbolic link: ${safe}`);
-    }
-    if (result.stdout === "__OPENGENI_FS_NOT_FOUND__" || result.exitCode === 66) {
-      throw new ChannelANotFoundError(`directory path not found: ${safe || "."}`);
-    }
-    throw new ChannelAValidationError(
-      `unable to validate workspace directory path: ${safe || "."}`,
+    throw new ChannelAUnavailableError(
+      "Workspace files are temporarily unavailable. Retry the operation.",
     );
   }
 
@@ -1350,6 +1416,20 @@ function isWorkspaceEscapeError(error: unknown): boolean {
     lower.includes("escapes the workspace") ||
     lower.includes("outside workspace") ||
     (lower.includes("remote validation") && lower.includes("escape"))
+  );
+}
+
+/** Classify only provider errors that carry an explicit path-miss fact. Generic
+ * 404s and "not found" text are unsafe here because they can describe the box or
+ * session disappearing rather than the requested file. */
+function isDefinitePathNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { code?: unknown; errno?: unknown; osNotFound?: unknown };
+  return (
+    candidate.osNotFound === true ||
+    candidate.code === "ENOENT" ||
+    candidate.errno === "ENOENT" ||
+    candidate.errno === -2
   );
 }
 
@@ -1442,6 +1522,12 @@ export function assertSafeRelPath(p: string): string {
 
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Run control-plane-generated Bash without user/provider startup files. The
+ * marker protocol is private control data; profile output must not corrupt it. */
+function internalBashCommand(script: string): string {
+  return `env -u BASH_ENV bash --noprofile --norc -c ${shellQuote(script)}`;
 }
 
 function assertSafePruneDirectoryName(name: string): string {

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -164,6 +164,7 @@ export {
 export {
   SandboxChannelAService,
   ChannelAValidationError,
+  ChannelAUnavailableError,
   ChannelAConflictError,
   ChannelANotFoundError,
   ChannelAUnsupportedError,

--- a/packages/runtime/test/channel-a.test.ts
+++ b/packages/runtime/test/channel-a.test.ts
@@ -11,6 +11,8 @@ import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { testSettings } from "@opengeni/testing";
 import {
   SandboxChannelAService,
+  ChannelANotFoundError,
+  ChannelAUnavailableError,
   MockAgentResponder,
   SelfhostedSession,
   parsePorcelainV2,
@@ -116,6 +118,61 @@ describe("P4.4 SandboxChannelAService — FileSystem (real local box)", () => {
     const read = await svc.fsRead({ path: "raw.dat", encoding: "utf8", maxBytes: 1024 });
     expect(read.isBinary).toBe(true);
     expect(read.encoding).toBe("base64"); // forced to base64 despite the utf8 request
+  });
+
+  test("a transient native read failure recovers through the confined descriptor path", async () => {
+    const commands: string[] = [];
+    const svc = new SandboxChannelAService({
+      session: {
+        readFile: async () => {
+          throw new Error("provider read endpoint temporarily unavailable");
+        },
+        exec: async (args) => {
+          commands.push(args.cmd);
+          return {
+            stdout: `__OPENGENI_FS_READ_OK__\n${Buffer.from("recovered\n").toString("base64")}`,
+            stderr: "",
+            exitCode: 0,
+          };
+        },
+      },
+    });
+
+    const read = await svc.fsRead({ path: "file.txt", encoding: "utf8", maxBytes: 1_024 });
+    expect(read.content).toBe("recovered\n");
+    expect(commands).toHaveLength(1);
+    expect(commands[0]?.startsWith("env -u BASH_ENV bash --noprofile --norc -c ")).toBe(true);
+  });
+
+  test("a repeated native and confined read failure is unavailable, never a false 404", async () => {
+    const svc = new SandboxChannelAService({
+      session: {
+        readFile: async () => {
+          throw new Error("provider read endpoint temporarily unavailable");
+        },
+        exec: async () => {
+          throw new Error("provider exec endpoint temporarily unavailable");
+        },
+      },
+    });
+
+    await expect(
+      svc.fsRead({ path: "file.txt", encoding: "utf8", maxBytes: 1_024 }),
+    ).rejects.toBeInstanceOf(ChannelAUnavailableError);
+  });
+
+  test("a structured native ENOENT remains a definite file miss", async () => {
+    const svc = new SandboxChannelAService({
+      session: {
+        readFile: async () => {
+          throw Object.assign(new Error("missing"), { code: "ENOENT" });
+        },
+      },
+    });
+
+    await expect(
+      svc.fsRead({ path: "missing.txt", encoding: "utf8", maxBytes: 1_024 }),
+    ).rejects.toBeInstanceOf(ChannelANotFoundError);
   });
 
   test("fsList returns a coherent tree of a known directory", async () => {
@@ -368,7 +425,83 @@ describe("P4.4 SandboxChannelAService — FileSystem (real local box)", () => {
       svc.fsListPruned({ path: "", depth: 8, maxEntries: 10, includeHidden: true }, [
         "node_modules",
       ]),
-    ).rejects.toThrow(/exceeded its 10 second deadline/);
+    ).rejects.toBeInstanceOf(ChannelAUnavailableError);
+  });
+
+  test("fsList retries one completed transient probe and uses a profile-free control shell", async () => {
+    const commands: string[] = [];
+    const svc = new SandboxChannelAService({
+      session: {
+        exec: async (args) => {
+          commands.push(args.cmd);
+          if (commands.length === 1) {
+            return { stdout: "provider temporarily unavailable", stderr: "", exitCode: 1 };
+          }
+          return { stdout: "__OPENGENI_FS_CONFINED_OK__\n", stderr: "", exitCode: 0 };
+        },
+      },
+    });
+
+    const list = await svc.fsList({ path: "", depth: 1, maxEntries: 10, includeHidden: true });
+    expect(list.root.children).toEqual([]);
+    expect(commands).toHaveLength(2);
+    for (const command of commands) {
+      expect(command.startsWith("env -u BASH_ENV bash --noprofile --norc -c ")).toBe(true);
+      expect(command).not.toContain("bash -lc");
+    }
+  });
+
+  test("fsList accepts a trusted success record after provider prelude output", async () => {
+    let calls = 0;
+    const svc = new SandboxChannelAService({
+      session: {
+        exec: async () => {
+          calls += 1;
+          return {
+            stdout: "provider prelude\n__OPENGENI_FS_CONFINED_OK__\n",
+            stderr: "",
+            exitCode: 0,
+          };
+        },
+      },
+    });
+
+    const list = await svc.fsList({ path: ".", depth: 1, maxEntries: 10, includeHidden: true });
+    expect(list.root.children).toEqual([]);
+    expect(calls).toBe(1);
+  });
+
+  test("fsList classifies repeated unmarked provider results as unavailable, never bad input", async () => {
+    let calls = 0;
+    const svc = new SandboxChannelAService({
+      session: {
+        exec: async () => {
+          calls += 1;
+          return { stdout: "", stderr: "provider unavailable", exitCode: 1 };
+        },
+      },
+    });
+
+    await expect(
+      svc.fsList({ path: ".", depth: 1, maxEntries: 10, includeHidden: true }),
+    ).rejects.toBeInstanceOf(ChannelAUnavailableError);
+    expect(calls).toBe(2);
+  });
+
+  test("deterministic confinement sentinels remain typed through surrounding provider output", async () => {
+    const svc = new SandboxChannelAService({
+      session: {
+        exec: async () => ({
+          stdout: "provider prelude\n__OPENGENI_FS_NOT_FOUND__\n",
+          stderr: "",
+          exitCode: 66,
+        }),
+      },
+    });
+
+    await expect(
+      svc.fsList({ path: "missing", depth: 1, maxEntries: 10, includeHidden: true }),
+    ).rejects.toBeInstanceOf(ChannelANotFoundError);
   });
 
   test("write with overwrite:false on an existing path throws conflict", async () => {


### PR DESCRIPTION
## Problem

A valid workspace directory such as `.` could be reported as invalid when the live sandbox provider transiently failed. The warm workbench path also discarded durable capture state, leaving the Files/Changes surfaces empty during the outage.

## Fix

- classify transient or unfinished Channel A provider operations as retryable HTTP 503, while preserving deterministic 400/404 path results
- retry read-only confinement checks once and use a binary-safe fallback for ambiguous native reads
- run generated control commands without user shell profiles
- seed warm Files and Changes from durable turn-end capture, then reconcile live
- preserve captured or last-live content with an accessible degraded-state banner and explicit retry
- fence file mutations unless the live source is healthy
- add public patch changesets for @opengeni/react and @opengeni/runtime

## Verification

- OPENGENI_REQUIRE_REAL_DB=1 bun test --max-concurrency=4 --timeout=120000: 3,305 pass, 3 opt-in live-Modal skips, 0 fail
- all 20 TypeScript projects pass
- oxfmt --check clean across 843 files
- focused workbench/runtime/API suite: 174 pass, 0 fail
- clean React package suite: 649 pass, 0 fail
- full API, worker, web, and publishable-package build passed
- web bundle budgets passed
- publish closure guard passed (16 packages)
- release-shaped SDK and React tarball consumer passed frozen-lock install, strict types, browser CSS, and SSR
- UBS diff scan introduced no critical findings

Production promotion remains merge-first: build once from merged main, prove on staging with real Modal, then promote identical digests and verify the original affected session.
