### PR TITLE
fix: separate workbench acceptance principal scopes

### DIFF
--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import type { WorkspaceCaptureManifest } from "@opengeni/sdk";
+import type { AccessContext, WorkspaceCaptureManifest } from "@opengeni/sdk";
 
 import {
   assertFixtureCapture,
   assertDedicatedCanaryEmail,
+  assertAcceptancePrincipalScopes,
   controlCancellationDurationMs,
   fixturePrompt,
   parseCookieHeader,
@@ -87,6 +88,48 @@ describe("workbench live acceptance preflight", () => {
     expect(() => controlCancellationDurationMs(Number.NaN, 1_000)).toThrow("must be finite");
   });
 
+  test("requires interactive scopes only from the dedicated canary principal", () => {
+    const workspaceId = "10000000-0000-4000-8000-000000000001";
+    const canary = accessContext(workspaceId, [
+      "workspace:read",
+      "sessions:create",
+      "sessions:read",
+      "sessions:control",
+      "files:read",
+      "files:write",
+      "stream:view",
+      "stream:acknowledge",
+      "terminal:attach",
+    ]);
+    const probe = accessContext(workspaceId, [
+      "workspace:read",
+      "sessions:create",
+      "sessions:read",
+      "sessions:control",
+    ]);
+
+    expect(() => assertAcceptancePrincipalScopes(canary, probe, workspaceId)).not.toThrow();
+    expect(() =>
+      assertAcceptancePrincipalScopes(
+        accessContext(workspaceId, [
+          "workspace:read",
+          "sessions:create",
+          "sessions:read",
+          "sessions:control",
+        ]),
+        probe,
+        workspaceId,
+      ),
+    ).toThrow("acceptance workbench canary lacks: files:read");
+    expect(() =>
+      assertAcceptancePrincipalScopes(
+        canary,
+        accessContext(workspaceId, ["workspace:read", "sessions:create"]),
+        workspaceId,
+      ),
+    ).toThrow("acceptance observability probe lacks: sessions:read");
+  });
+
   test("the fixture and its verifier fail closed across the documented boundary matrix", () => {
     const marker = "OPENGENI_WORKBENCH_ACCEPTANCE_001";
     const prompt = fixturePrompt(marker);
@@ -112,6 +155,27 @@ describe("workbench live acceptance preflight", () => {
     expect(() => assertFixtureCapture(manifest, marker)).toThrow("renamed fixture status drifted");
   });
 });
+
+function accessContext(
+  workspaceId: string,
+  permissions: AccessContext["workspaceGrants"][number]["permissions"],
+): AccessContext {
+  return {
+    mode: "managed",
+    subjectId: "acceptance:test",
+    accountGrants: [],
+    workspaceGrants: [
+      {
+        workspaceId,
+        accountId: "20000000-0000-4000-8000-000000000002",
+        subjectId: "acceptance:test",
+        permissions,
+      },
+    ],
+    defaultAccountId: "20000000-0000-4000-8000-000000000002",
+    defaultWorkspaceId: workspaceId,
+  };
+}
 
 function fixtureManifest(marker: string): WorkspaceCaptureManifest {
   const content = new Map<string, Uint8Array>([

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -13,7 +13,7 @@ import {
 import { assertScreenshotPainted } from "@opengeni/testing";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 
-const REQUIRED_PERMISSIONS = [
+const WORKBENCH_CANARY_PERMISSIONS = [
   "workspace:read",
   "sessions:create",
   "sessions:read",
@@ -23,6 +23,11 @@ const REQUIRED_PERMISSIONS = [
   "stream:view",
   "stream:acknowledge",
   "terminal:attach",
+] as const;
+const OBSERVABILITY_PROBE_PERMISSIONS = [
+  "workspace:read",
+  "sessions:create",
+  "sessions:read",
 ] as const;
 const SETTLED = new Set(["idle", "failed", "error", "cancelled"]);
 const CHANNEL_A_PATH = /\/sessions\/[^/]+\/(?:fs|git|terminal)\//;
@@ -252,8 +257,7 @@ async function main(): Promise<void> {
     }),
   ]);
   const workspaceId = selectWorkspace(args.workspaceId, cookieAccess, tokenAccess);
-  assertWorkspacePermissions(cookieAccess, workspaceId);
-  assertWorkspacePermissions(tokenAccess, workspaceId);
+  assertAcceptancePrincipalScopes(cookieAccess, tokenAccess, workspaceId);
   pass(
     checks,
     "security.auth-preflight",
@@ -545,13 +549,39 @@ function selectWorkspace(
   return workspaceId;
 }
 
-function assertWorkspacePermissions(context: AccessContext, workspaceId: string): void {
+export function assertAcceptancePrincipalScopes(
+  cookieAccess: AccessContext,
+  tokenAccess: AccessContext,
+  workspaceId: string,
+): void {
+  assertWorkspacePermissions(
+    cookieAccess,
+    workspaceId,
+    WORKBENCH_CANARY_PERMISSIONS,
+    "workbench canary",
+  );
+  assertWorkspacePermissions(
+    tokenAccess,
+    workspaceId,
+    OBSERVABILITY_PROBE_PERMISSIONS,
+    "observability probe",
+  );
+}
+
+function assertWorkspacePermissions(
+  context: AccessContext,
+  workspaceId: string,
+  requiredPermissions: readonly string[],
+  principalLabel: string,
+): void {
   const grant = context.workspaceGrants.find((candidate) => candidate.workspaceId === workspaceId);
-  if (!grant) throw new Error("acceptance principal has no workspace grant");
-  const missing = REQUIRED_PERMISSIONS.filter(
+  if (!grant) throw new Error(`acceptance ${principalLabel} has no workspace grant`);
+  const missing = requiredPermissions.filter(
     (permission) => !grant.permissions.includes(permission),
   );
-  if (missing.length > 0) throw new Error(`acceptance principal lacks: ${missing.join(", ")}`);
+  if (missing.length > 0) {
+    throw new Error(`acceptance ${principalLabel} lacks: ${missing.join(", ")}`);
+  }
 }
 
 async function waitForSettled(


### PR DESCRIPTION
## What changed

- require the complete interactive permission set from the dedicated workbench canary
- require only the real synthetic-turn scope from the observability probe key
- label permission failures by principal
- add regression coverage for the production scope boundary

This preserves least privilege instead of widening the observability key merely to satisfy the acceptance harness.

## Why

Staging acceptance run 29688516951 proved the canary membership had all nine permissions, then failed because the immutable runner applied that same interactive permission set to the observability bearer key. That key intentionally has only the session-probe scope.

## Verification

- `bun test scripts/workbench-live-acceptance.test.ts`: 7 pass, 0 fail
- `bun run typecheck`: all 20 projects clean
- `bun run lint`: clean
- `bun run format:check`: all 843 files clean
- `OPENGENI_REQUIRE_REAL_DB=1 bun test --max-concurrency=4 --timeout=120000`: 3306 pass, 3 opt-in live-Modal skips, 0 fail
- UBS diff scan reviewed; no finding is introduced by the changed scope logic

No package changeset: this only corrects the repository-owned release acceptance runner.
