### PR TITLE
fix(react): bound queued prompt previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,10 @@ jobs:
       - name: Install pinned Playwright Chromium runtime
         run: bunx playwright install --with-deps chromium
 
+      - name: OPE-9 queue surface browser acceptance
+        id: queue_surface_browser
+        run: bun scripts/run-browser-e2e.ts ./test/e2e/queue-surface.browser.e2e.ts
+
       - name: OPE-26 session pin browser acceptance
         id: session_pin_browser
         env:

--- a/packages/react/demo/queue-fixtures.ts
+++ b/packages/react/demo/queue-fixtures.ts
@@ -11,6 +11,7 @@ export const QUEUE_BOUNDARY_CLUSTERS = {
 export type QueueBoundaryCluster = keyof typeof QUEUE_BOUNDARY_CLUSTERS;
 export type QueueBoundaryEdge = "head" | "tail";
 export type QueueBoundaryMaximum = 180 | 360;
+export type QueueFallbackKind = "whitespace" | "combining" | "zwj";
 
 export const HOSTILE_QUEUE_PROMPT = [
   "# Production migration follow-up 👩🏽‍💻",
@@ -37,6 +38,21 @@ export function queuePromptFingerprint(index: number): string {
 
 export function queueHarnessPrompt(index: number): string {
   return `${HOSTILE_QUEUE_PROMPT}\n${queuePromptFingerprint(index)}`;
+}
+
+export function queuePromptVisibleIdentity(index: number): string {
+  return Array.from(queuePromptFingerprint(index)).slice(-18).join("");
+}
+
+export function queueFallbackPrompt(kind: QueueFallbackKind): string {
+  switch (kind) {
+    case "whitespace":
+      return " ".repeat(2_000);
+    case "combining":
+      return `e${"\u0301".repeat(10_000)}`;
+    case "zwj":
+      return `👩${"\u200d👩".repeat(1_000)}`;
+  }
 }
 
 /** A prompt whose named grapheme crosses the old code-point-only preview cut. */

--- a/packages/react/demo/queue-fixtures.ts
+++ b/packages/react/demo/queue-fixtures.ts
@@ -12,6 +12,7 @@ export type QueueBoundaryCluster = keyof typeof QUEUE_BOUNDARY_CLUSTERS;
 export type QueueBoundaryEdge = "head" | "tail";
 export type QueueBoundaryMaximum = 180 | 360;
 export type QueueFallbackKind = "whitespace" | "combining" | "zwj";
+export type QueueHarnessErrorShape = "unbroken" | "multiline";
 export const QUEUE_VISIBILITY_PROBE_KINDS = [
   "short-zwj",
   "variation-selector",
@@ -48,6 +49,21 @@ export function queuePromptFingerprint(index: number): string {
 
 export function queueHarnessPrompt(index: number): string {
   return `${HOSTILE_QUEUE_PROMPT}\n${queuePromptFingerprint(index)}`;
+}
+
+export function queueHarnessError(shape: QueueHarnessErrorShape): string {
+  if (shape === "multiline") {
+    return [
+      "Queue provider returned a multiline diagnostic.",
+      ...Array.from(
+        { length: 48 },
+        (_, index) =>
+          `Diagnostic ${String(index + 1).padStart(2, "0")}: https://queue.invalid/${"segment".repeat(80)}?request=fixture-${String(index + 1).padStart(2, "0")}`,
+      ),
+      "Recovery code: RETRY_SAFE",
+    ].join("\n");
+  }
+  return `QUEUE_ERROR_${"X".repeat(65_536)}_RECOVERY_CODE`;
 }
 
 export function queuePromptVisibleIdentity(index: number): string {

--- a/packages/react/demo/queue-fixtures.ts
+++ b/packages/react/demo/queue-fixtures.ts
@@ -1,5 +1,17 @@
 export const OMITTED_QUEUE_SOURCE_MARKER = "Exact undisclosed middle source marker.";
 
+export const QUEUE_BOUNDARY_CLUSTERS = {
+  zwj: "👩🏽‍💻",
+  skinTone: "👍🏽",
+  combining: "e\u0301",
+  flag: "🇺🇳",
+  keycap: "1\uFE0F\u20E3",
+} as const;
+
+export type QueueBoundaryCluster = keyof typeof QUEUE_BOUNDARY_CLUSTERS;
+export type QueueBoundaryEdge = "head" | "tail";
+export type QueueBoundaryMaximum = 180 | 360;
+
 export const HOSTILE_QUEUE_PROMPT = [
   "# Production migration follow-up 👩🏽‍💻",
   "",
@@ -25,4 +37,44 @@ export function queuePromptFingerprint(index: number): string {
 
 export function queueHarnessPrompt(index: number): string {
   return `${HOSTILE_QUEUE_PROMPT}\n${queuePromptFingerprint(index)}`;
+}
+
+/** A prompt whose named grapheme crosses the old code-point-only preview cut. */
+export function queueBoundaryPrompt(
+  maxCharacters: QueueBoundaryMaximum,
+  edge: QueueBoundaryEdge,
+  clusterName: QueueBoundaryCluster,
+): string {
+  const { prefixCharacters, suffixCharacters } = queueBoundaryBudgets(maxCharacters);
+  const cluster = QUEUE_BOUNDARY_CLUSTERS[clusterName];
+  if (edge === "head") {
+    return `${"a".repeat(prefixCharacters - 1)}${cluster}${"x".repeat(
+      maxCharacters * 3,
+    )}${"z".repeat(suffixCharacters)}`;
+  }
+  return `${"a".repeat(prefixCharacters)}${"x".repeat(maxCharacters * 3)}${cluster}${"z".repeat(
+    suffixCharacters - 1,
+  )}`;
+}
+
+/** Exact safe summary expected when the boundary grapheme is omitted whole. */
+export function queueBoundarySummary(
+  maxCharacters: QueueBoundaryMaximum,
+  edge: QueueBoundaryEdge,
+): string {
+  const { prefixCharacters, suffixCharacters } = queueBoundaryBudgets(maxCharacters);
+  return edge === "head"
+    ? `${"a".repeat(prefixCharacters - 1)} … ${"z".repeat(suffixCharacters)}`
+    : `${"a".repeat(prefixCharacters)} … ${"z".repeat(suffixCharacters - 1)}`;
+}
+
+function queueBoundaryBudgets(maxCharacters: QueueBoundaryMaximum): {
+  prefixCharacters: number;
+  suffixCharacters: number;
+} {
+  const suffixCharacters = maxCharacters === 180 ? 60 : 120;
+  return {
+    prefixCharacters: maxCharacters - 3 - suffixCharacters,
+    suffixCharacters,
+  };
 }

--- a/packages/react/demo/queue-fixtures.ts
+++ b/packages/react/demo/queue-fixtures.ts
@@ -1,0 +1,17 @@
+export const HOSTILE_QUEUE_PROMPT = [
+  "# Production migration follow-up 👩🏽‍💻",
+  "",
+  "Preserve this Markdown and source text exactly; the row itself must remain compact.",
+  "",
+  "```sh",
+  `curl --fail-with-body https://example.test/${"unbroken-token-".repeat(600)}`,
+  "```",
+  "",
+  `Bidirectional source: ${String.fromCodePoint(0x202e)}isolated${String.fromCodePoint(0x202c)}`,
+  ...Array.from(
+    { length: 80 },
+    (_, index) =>
+      `${String(index + 1).padStart(3, "0")} | reconnect-safe log line | Δοκιμή | اختبار | テスト`,
+  ),
+  "Exact trailing line.",
+].join("\n");

--- a/packages/react/demo/queue-fixtures.ts
+++ b/packages/react/demo/queue-fixtures.ts
@@ -12,6 +12,16 @@ export type QueueBoundaryCluster = keyof typeof QUEUE_BOUNDARY_CLUSTERS;
 export type QueueBoundaryEdge = "head" | "tail";
 export type QueueBoundaryMaximum = 180 | 360;
 export type QueueFallbackKind = "whitespace" | "combining" | "zwj";
+export const QUEUE_VISIBILITY_PROBE_KINDS = [
+  "short-zwj",
+  "variation-selector",
+  "word-joiner",
+  "bidi-controls",
+  "tag-characters",
+  "controls",
+  "mixed-visible",
+] as const;
+export type QueueVisibilityProbeKind = (typeof QUEUE_VISIBILITY_PROBE_KINDS)[number];
 
 export const HOSTILE_QUEUE_PROMPT = [
   "# Production migration follow-up 👩🏽‍💻",
@@ -52,6 +62,25 @@ export function queueFallbackPrompt(kind: QueueFallbackKind): string {
       return `e${"\u0301".repeat(10_000)}`;
     case "zwj":
       return `👩${"\u200d👩".repeat(1_000)}`;
+  }
+}
+
+export function queueVisibilityProbePrompt(kind: QueueVisibilityProbeKind): string {
+  switch (kind) {
+    case "short-zwj":
+      return "\u200d".repeat(8);
+    case "variation-selector":
+      return "\ufe0f".repeat(8);
+    case "word-joiner":
+      return "\u2060".repeat(8);
+    case "bidi-controls":
+      return "\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069";
+    case "tag-characters":
+      return String.fromCodePoint(0xe0061, 0xe0062, 0xe0063, 0xe007f);
+    case "controls":
+      return "\u0000\u0001\u0007\u0008\u000e\u001f\u007f\u0085";
+    case "mixed-visible":
+      return "\u200d\u2060Visible identity 😀\ufe0f\u2069";
   }
 }
 

--- a/packages/react/demo/queue-fixtures.ts
+++ b/packages/react/demo/queue-fixtures.ts
@@ -1,3 +1,5 @@
+export const OMITTED_QUEUE_SOURCE_MARKER = "Exact undisclosed middle source marker.";
+
 export const HOSTILE_QUEUE_PROMPT = [
   "# Production migration follow-up 👩🏽‍💻",
   "",
@@ -8,6 +10,7 @@ export const HOSTILE_QUEUE_PROMPT = [
   "```",
   "",
   `Bidirectional source: ${String.fromCodePoint(0x202e)}isolated${String.fromCodePoint(0x202c)}`,
+  OMITTED_QUEUE_SOURCE_MARKER,
   ...Array.from(
     { length: 80 },
     (_, index) =>
@@ -15,3 +18,11 @@ export const HOSTILE_QUEUE_PROMPT = [
   ),
   "Exact trailing line.",
 ].join("\n");
+
+export function queuePromptFingerprint(index: number): string {
+  return `Queued destination fingerprint: ${String(index + 1).padStart(3, "0")} 😀`;
+}
+
+export function queueHarnessPrompt(index: number): string {
+  return `${HOSTILE_QUEUE_PROMPT}\n${queuePromptFingerprint(index)}`;
+}

--- a/packages/react/demo/queue-harness.css
+++ b/packages/react/demo/queue-harness.css
@@ -1,0 +1,13 @@
+[data-queue-harness] {
+  min-height: 100dvh;
+  background: radial-gradient(
+      circle at 50% 120%,
+      color-mix(in oklch, var(--color-brand) 9%, transparent),
+      transparent 42%
+    ),
+    var(--color-bg);
+}
+
+[data-queue-harness-frame] {
+  height: min(52rem, calc(100dvh - 2rem));
+}

--- a/packages/react/demo/queue-harness.tsx
+++ b/packages/react/demo/queue-harness.tsx
@@ -7,10 +7,12 @@ import {
   queueBoundaryPrompt,
   queueFallbackPrompt,
   queueHarnessPrompt,
+  queueVisibilityProbePrompt,
   type QueueBoundaryCluster,
   type QueueBoundaryEdge,
   type QueueBoundaryMaximum,
   type QueueFallbackKind,
+  type QueueVisibilityProbeKind,
 } from "./queue-fixtures";
 import "../../../apps/web/src/styles.css";
 import "./queue-harness.css";
@@ -31,6 +33,7 @@ const boundaryMaximum = parseBoundaryMaximum(params.get("boundaryMax"));
 const boundaryEdge = parseBoundaryEdge(params.get("boundaryEdge"));
 const boundaryCluster = parseBoundaryCluster(params.get("boundaryCluster"));
 const fallbackKind = parseFallbackKind(params.get("fallback"));
+const visibilityProbeKind = parseVisibilityProbeKind(params.get("visibility"));
 
 if (theme === "light") {
   document.documentElement.dataset.ogTheme = "light";
@@ -45,7 +48,9 @@ function makeTurn(index: number): SessionTurn {
       ? queueBoundaryPrompt(boundaryMaximum, boundaryEdge, boundaryCluster)
       : index === 0 && fallbackKind
         ? queueFallbackPrompt(fallbackKind)
-        : queueHarnessPrompt(index);
+        : index === 0 && visibilityProbeKind
+          ? queueVisibilityProbePrompt(visibilityProbeKind)
+          : queueHarnessPrompt(index);
   return {
     id: `${String(index + 1).padStart(8, "0")}-1111-4111-8111-${suffix}`,
     workspaceId: "11111111-1111-4111-8111-111111111111",
@@ -92,6 +97,21 @@ function parseBoundaryCluster(value: string | null): QueueBoundaryCluster | null
 
 function parseFallbackKind(value: string | null): QueueFallbackKind | null {
   return value === "whitespace" || value === "combining" || value === "zwj" ? value : null;
+}
+
+function parseVisibilityProbeKind(value: string | null): QueueVisibilityProbeKind | null {
+  switch (value) {
+    case "short-zwj":
+    case "variation-selector":
+    case "word-joiner":
+    case "bidi-controls":
+    case "tag-characters":
+    case "controls":
+    case "mixed-visible":
+      return value;
+    default:
+      return null;
+  }
 }
 
 const composer: ComposerState & { hasDraftContent: () => boolean } = {

--- a/packages/react/demo/queue-harness.tsx
+++ b/packages/react/demo/queue-harness.tsx
@@ -2,7 +2,7 @@ import type { SessionTurn } from "@opengeni/sdk";
 import { useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { QueueSurface, type ComposerState, type UseTurnQueueResult } from "../src/index";
-import { HOSTILE_QUEUE_PROMPT } from "./queue-fixtures";
+import { queueHarnessPrompt } from "./queue-fixtures";
 import "../../../apps/web/src/styles.css";
 import "./queue-harness.css";
 
@@ -36,7 +36,7 @@ function makeTurn(index: number): SessionTurn {
     status: "queued",
     source: "user",
     position: index + 1,
-    prompt: `${index + 1} / ${initialCount}\n${HOSTILE_QUEUE_PROMPT}`,
+    prompt: queueHarnessPrompt(index),
     resources: [{ kind: "file", fileId: `fixture-file-${index + 1}` }],
     tools: [],
     model: "gpt-5.3-codex",

--- a/packages/react/demo/queue-harness.tsx
+++ b/packages/react/demo/queue-harness.tsx
@@ -6,12 +6,14 @@ import {
   QUEUE_BOUNDARY_CLUSTERS,
   queueBoundaryPrompt,
   queueFallbackPrompt,
+  queueHarnessError,
   queueHarnessPrompt,
   queueVisibilityProbePrompt,
   type QueueBoundaryCluster,
   type QueueBoundaryEdge,
   type QueueBoundaryMaximum,
   type QueueFallbackKind,
+  type QueueHarnessErrorShape,
   type QueueVisibilityProbeKind,
 } from "./queue-fixtures";
 import "../../../apps/web/src/styles.css";
@@ -34,6 +36,9 @@ const boundaryEdge = parseBoundaryEdge(params.get("boundaryEdge"));
 const boundaryCluster = parseBoundaryCluster(params.get("boundaryCluster"));
 const fallbackKind = parseFallbackKind(params.get("fallback"));
 const visibilityProbeKind = parseVisibilityProbeKind(params.get("visibility"));
+const errorSource = parseErrorSource(params.get("error"));
+const errorShape = parseErrorShape(params.get("errorShape"));
+const initialErrorMessage = errorSource ? queueHarnessError(errorShape) : null;
 
 if (theme === "light") {
   document.documentElement.dataset.ogTheme = "light";
@@ -114,6 +119,16 @@ function parseVisibilityProbeKind(value: string | null): QueueVisibilityProbeKin
   }
 }
 
+type QueueHarnessErrorSource = "queue" | "mutation";
+
+function parseErrorSource(value: string | null): QueueHarnessErrorSource | null {
+  return value === "queue" || value === "mutation" ? value : null;
+}
+
+function parseErrorShape(value: string | null): QueueHarnessErrorShape {
+  return value === "multiline" ? "multiline" : "unbroken";
+}
+
 const composer: ComposerState & { hasDraftContent: () => boolean } = {
   value: "",
   setValue: () => {},
@@ -146,6 +161,14 @@ function QueueHarness() {
     Array.from({ length: initialCount }, (_, index) => makeTurn(index)),
   );
   const [loading, setLoading] = useState(params.get("loading") === "1");
+  const [queueError, setQueueError] = useState<Error | null>(() =>
+    errorSource === "queue" && initialErrorMessage ? new Error(initialErrorMessage) : null,
+  );
+  const [mutationError, setMutationError] = useState<Error | null>(() =>
+    errorSource === "mutation" && initialErrorMessage ? new Error(initialErrorMessage) : null,
+  );
+  const [refreshCount, setRefreshCount] = useState(0);
+  const [clearMutationErrorCount, setClearMutationErrorCount] = useState(0);
 
   useEffect(() => {
     window.__OPE9_PROMPT__ = turns[0]?.prompt ?? "";
@@ -165,8 +188,11 @@ function QueueHarness() {
       effectiveControl: null,
       stoppingPreviousAttempt: false,
       loading,
-      error: null,
-      refresh: async () => {},
+      error: queueError,
+      refresh: async () => {
+        setRefreshCount((current) => current + 1);
+        setQueueError(null);
+      },
       moveTurn: async () => true,
       editTurn: async () => null,
       steerTurn: async () => true,
@@ -174,10 +200,13 @@ function QueueHarness() {
       pendingByTurn: {},
       mutationFor: () => null,
       mutating: false,
-      mutationError: null,
-      clearMutationError: () => {},
+      mutationError,
+      clearMutationError: () => {
+        setClearMutationErrorCount((current) => current + 1);
+        setMutationError(null);
+      },
     }),
-    [loading, turns],
+    [loading, mutationError, queueError, turns],
   );
 
   return (
@@ -186,6 +215,8 @@ function QueueHarness() {
       data-og-theme={theme === "light" ? "light" : undefined}
       data-queue-harness
       data-theme={theme}
+      data-refresh-count={refreshCount}
+      data-clear-mutation-error-count={clearMutationErrorCount}
     >
       <section
         className="flex w-full max-w-5xl flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-lg max-sm:h-dvh max-sm:rounded-none max-sm:border-0"

--- a/packages/react/demo/queue-harness.tsx
+++ b/packages/react/demo/queue-harness.tsx
@@ -5,10 +5,12 @@ import { QueueSurface, type ComposerState, type UseTurnQueueResult } from "../sr
 import {
   QUEUE_BOUNDARY_CLUSTERS,
   queueBoundaryPrompt,
+  queueFallbackPrompt,
   queueHarnessPrompt,
   type QueueBoundaryCluster,
   type QueueBoundaryEdge,
   type QueueBoundaryMaximum,
+  type QueueFallbackKind,
 } from "./queue-fixtures";
 import "../../../apps/web/src/styles.css";
 import "./queue-harness.css";
@@ -28,6 +30,7 @@ const readOnly = params.get("readOnly") === "1";
 const boundaryMaximum = parseBoundaryMaximum(params.get("boundaryMax"));
 const boundaryEdge = parseBoundaryEdge(params.get("boundaryEdge"));
 const boundaryCluster = parseBoundaryCluster(params.get("boundaryCluster"));
+const fallbackKind = parseFallbackKind(params.get("fallback"));
 
 if (theme === "light") {
   document.documentElement.dataset.ogTheme = "light";
@@ -40,7 +43,9 @@ function makeTurn(index: number): SessionTurn {
   const prompt =
     index === 0 && boundaryMaximum && boundaryEdge && boundaryCluster
       ? queueBoundaryPrompt(boundaryMaximum, boundaryEdge, boundaryCluster)
-      : queueHarnessPrompt(index);
+      : index === 0 && fallbackKind
+        ? queueFallbackPrompt(fallbackKind)
+        : queueHarnessPrompt(index);
   return {
     id: `${String(index + 1).padStart(8, "0")}-1111-4111-8111-${suffix}`,
     workspaceId: "11111111-1111-4111-8111-111111111111",
@@ -85,9 +90,14 @@ function parseBoundaryCluster(value: string | null): QueueBoundaryCluster | null
     : null;
 }
 
-const composer: ComposerState = {
+function parseFallbackKind(value: string | null): QueueFallbackKind | null {
+  return value === "whitespace" || value === "combining" || value === "zwj" ? value : null;
+}
+
+const composer: ComposerState & { hasDraftContent: () => boolean } = {
   value: "",
   setValue: () => {},
+  hasDraftContent: () => false,
   send: async () => true,
   steer: async () => true,
   sending: false,

--- a/packages/react/demo/queue-harness.tsx
+++ b/packages/react/demo/queue-harness.tsx
@@ -1,0 +1,164 @@
+import type { SessionTurn } from "@opengeni/sdk";
+import { useEffect, useMemo, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { QueueSurface, type ComposerState, type UseTurnQueueResult } from "../src/index";
+import { HOSTILE_QUEUE_PROMPT } from "./queue-fixtures";
+import "../../../apps/web/src/styles.css";
+import "./queue-harness.css";
+
+declare global {
+  interface Window {
+    __OPE9_PROMPT__: string;
+    __ope9AppendQueuePrompt?: () => void;
+    __ope9SetQueueLoading?: (loading: boolean) => void;
+  }
+}
+
+const params = new URLSearchParams(window.location.search);
+const initialCount = Math.min(100, Math.max(1, Number(params.get("count") ?? "1") || 1));
+const theme = params.get("theme") === "light" ? "light" : "dark";
+const readOnly = params.get("readOnly") === "1";
+
+if (theme === "light") {
+  document.documentElement.dataset.ogTheme = "light";
+} else {
+  delete document.documentElement.dataset.ogTheme;
+}
+
+function makeTurn(index: number): SessionTurn {
+  const suffix = String(index + 1).padStart(12, "0");
+  return {
+    id: `${String(index + 1).padStart(8, "0")}-1111-4111-8111-${suffix}`,
+    workspaceId: "11111111-1111-4111-8111-111111111111",
+    sessionId: "22222222-2222-4222-8222-222222222222",
+    triggerEventId: `${String(index + 1).padStart(8, "0")}-3333-4333-8333-${suffix}`,
+    temporalWorkflowId: "ope-9-queue-browser-harness",
+    status: "queued",
+    source: "user",
+    position: index + 1,
+    prompt: `${index + 1} / ${initialCount}\n${HOSTILE_QUEUE_PROMPT}`,
+    resources: [{ kind: "file", fileId: `fixture-file-${index + 1}` }],
+    tools: [],
+    model: "gpt-5.3-codex",
+    reasoningEffort: "high",
+    sandboxBackend: "modal",
+    sandboxOs: null,
+    metadata: {},
+    version: 1,
+    executionGeneration: 0,
+    activeAttemptId: null,
+    lineage: {},
+    startedAt: null,
+    finishedAt: null,
+    createdAt: "2026-07-19T00:00:00.000Z",
+    updatedAt: "2026-07-19T00:00:00.000Z",
+  };
+}
+
+const composer: ComposerState = {
+  value: "",
+  setValue: () => {},
+  send: async () => true,
+  steer: async () => true,
+  sending: false,
+  canSend: false,
+  pause: async () => {},
+  pausing: false,
+  resume: async () => {},
+  resumeScope: async () => {},
+  resuming: false,
+  draft: null,
+  draftRevision: 0,
+  draftLoading: false,
+  draftSaving: false,
+  draftConflict: null,
+  applyDraft: () => {},
+  reloadDraft: async () => {},
+  resolveDraftConflict: async () => {},
+  restoredResources: [],
+  removeRestoredResource: () => {},
+  error: null,
+  clearError: () => {},
+};
+
+function QueueHarness() {
+  const [turns, setTurns] = useState(() =>
+    Array.from({ length: initialCount }, (_, index) => makeTurn(index)),
+  );
+  const [loading, setLoading] = useState(params.get("loading") === "1");
+
+  useEffect(() => {
+    window.__OPE9_PROMPT__ = turns[0]?.prompt ?? "";
+    window.__ope9AppendQueuePrompt = () =>
+      setTurns((current) => [...current, makeTurn(current.length)]);
+    window.__ope9SetQueueLoading = setLoading;
+    return () => {
+      delete window.__ope9AppendQueuePrompt;
+      delete window.__ope9SetQueueLoading;
+    };
+  }, [turns]);
+
+  const queue = useMemo<UseTurnQueueResult>(
+    () => ({
+      snapshot: null,
+      queue: turns,
+      effectiveControl: null,
+      stoppingPreviousAttempt: false,
+      loading,
+      error: null,
+      refresh: async () => {},
+      moveTurn: async () => true,
+      editTurn: async () => null,
+      steerTurn: async () => true,
+      removeTurn: async () => true,
+      pendingByTurn: {},
+      mutationFor: () => null,
+      mutating: false,
+      mutationError: null,
+      clearMutationError: () => {},
+    }),
+    [loading, turns],
+  );
+
+  return (
+    <main
+      className="og-root flex min-h-dvh items-center justify-center bg-bg p-4 text-fg max-sm:p-0"
+      data-og-theme={theme === "light" ? "light" : undefined}
+      data-queue-harness
+      data-theme={theme}
+    >
+      <section
+        className="flex w-full max-w-5xl flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-lg max-sm:h-dvh max-sm:rounded-none max-sm:border-0"
+        data-queue-harness-frame
+        aria-label="Session queue presentation fixture"
+      >
+        <header className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
+          <div>
+            <h1 className="text-xs font-semibold">Queued prompt presentation</h1>
+            <p className="text-2xs text-fg-subtle">Deterministic OPE-9 browser fixture</p>
+          </div>
+          <span className="rounded-md border border-border px-2 py-1 text-2xs text-fg-muted">
+            {theme} · {readOnly ? "read-only" : "interactive"}
+          </span>
+        </header>
+        <div className="min-h-0 flex-1 overflow-hidden bg-surface-2/20 p-4">
+          <div className="mx-auto flex h-full max-w-3xl flex-col justify-end rounded-lg border border-border/70 bg-bg/30">
+            <div className="min-h-0 flex-1 p-4 text-xs text-fg-subtle">
+              <p>Session timeline remains independently scrollable above the queue.</p>
+            </div>
+            {readOnly ? (
+              <QueueSurface queue={queue} readOnly />
+            ) : (
+              <QueueSurface queue={queue} composer={composer} />
+            )}
+            <div className="mx-4 mb-4 min-h-20 rounded-lg border border-border bg-surface px-3 py-2 text-xs text-fg-muted">
+              Message the agent…
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<QueueHarness />);

--- a/packages/react/demo/queue-harness.tsx
+++ b/packages/react/demo/queue-harness.tsx
@@ -2,7 +2,14 @@ import type { SessionTurn } from "@opengeni/sdk";
 import { useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { QueueSurface, type ComposerState, type UseTurnQueueResult } from "../src/index";
-import { queueHarnessPrompt } from "./queue-fixtures";
+import {
+  QUEUE_BOUNDARY_CLUSTERS,
+  queueBoundaryPrompt,
+  queueHarnessPrompt,
+  type QueueBoundaryCluster,
+  type QueueBoundaryEdge,
+  type QueueBoundaryMaximum,
+} from "./queue-fixtures";
 import "../../../apps/web/src/styles.css";
 import "./queue-harness.css";
 
@@ -18,6 +25,9 @@ const params = new URLSearchParams(window.location.search);
 const initialCount = Math.min(100, Math.max(1, Number(params.get("count") ?? "1") || 1));
 const theme = params.get("theme") === "light" ? "light" : "dark";
 const readOnly = params.get("readOnly") === "1";
+const boundaryMaximum = parseBoundaryMaximum(params.get("boundaryMax"));
+const boundaryEdge = parseBoundaryEdge(params.get("boundaryEdge"));
+const boundaryCluster = parseBoundaryCluster(params.get("boundaryCluster"));
 
 if (theme === "light") {
   document.documentElement.dataset.ogTheme = "light";
@@ -27,6 +37,10 @@ if (theme === "light") {
 
 function makeTurn(index: number): SessionTurn {
   const suffix = String(index + 1).padStart(12, "0");
+  const prompt =
+    index === 0 && boundaryMaximum && boundaryEdge && boundaryCluster
+      ? queueBoundaryPrompt(boundaryMaximum, boundaryEdge, boundaryCluster)
+      : queueHarnessPrompt(index);
   return {
     id: `${String(index + 1).padStart(8, "0")}-1111-4111-8111-${suffix}`,
     workspaceId: "11111111-1111-4111-8111-111111111111",
@@ -36,7 +50,7 @@ function makeTurn(index: number): SessionTurn {
     status: "queued",
     source: "user",
     position: index + 1,
-    prompt: queueHarnessPrompt(index),
+    prompt,
     resources: [{ kind: "file", fileId: `fixture-file-${index + 1}` }],
     tools: [],
     model: "gpt-5.3-codex",
@@ -53,6 +67,22 @@ function makeTurn(index: number): SessionTurn {
     createdAt: "2026-07-19T00:00:00.000Z",
     updatedAt: "2026-07-19T00:00:00.000Z",
   };
+}
+
+function parseBoundaryMaximum(value: string | null): QueueBoundaryMaximum | null {
+  if (value === "180") return 180;
+  if (value === "360") return 360;
+  return null;
+}
+
+function parseBoundaryEdge(value: string | null): QueueBoundaryEdge | null {
+  return value === "head" || value === "tail" ? value : null;
+}
+
+function parseBoundaryCluster(value: string | null): QueueBoundaryCluster | null {
+  return value && Object.hasOwn(QUEUE_BOUNDARY_CLUSTERS, value)
+    ? (value as QueueBoundaryCluster)
+    : null;
 }
 
 const composer: ComposerState = {

--- a/packages/react/demo/queue.html
+++ b/packages/react/demo/queue.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
+    <title>@opengeni/react — queue surface harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/queue-harness.tsx"></script>
+  </body>
+</html>

--- a/packages/react/demo/vite.config.ts
+++ b/packages/react/demo/vite.config.ts
@@ -13,11 +13,13 @@ export default defineConfig({
     chunkSizeWarningLimit: 800,
     rollupOptions: {
       // Pages: the full component harness (index.html), the timeline tool-call
-      // renderer harness (timeline.html), and the Machines / enrollment UI
-      // screenshot harness (machines.html — M9 / V12), all static.
+      // renderer harness (timeline.html), the queue presentation browser
+      // regression (queue.html), and the Machines / enrollment UI screenshot
+      // harness (machines.html — M9 / V12), all static.
       input: {
         main: resolve(__dirname, "index.html"),
         timeline: resolve(__dirname, "timeline.html"),
+        queue: resolve(__dirname, "queue.html"),
         machines: resolve(__dirname, "machines.html"),
         workbench: resolve(__dirname, "workbench.html"),
         workbenchDock: resolve(__dirname, "workbench-dock.html"),

--- a/packages/react/src/components/queue-surface.tsx
+++ b/packages/react/src/components/queue-surface.tsx
@@ -65,7 +65,8 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
   } | null>(null);
   const count = queue.queue.length;
   const collapsedPreview = useMemo(
-    () => queuePromptPreview(queue.queue[0]?.prompt ?? "", QUEUE_COLLAPSED_PREVIEW_CHARACTERS),
+    () =>
+      queuePromptPreview(queue.queue[0]?.prompt ?? "", QUEUE_COLLAPSED_PREVIEW_CHARACTERS).summary,
     [queue.queue],
   );
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
@@ -366,10 +367,12 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
                     className="line-clamp-3 break-all whitespace-pre-wrap [unicode-bidi:plaintext]"
                     dir="auto"
                   >
-                    {queuePromptPreview(
-                      queue.queue.find((turn) => turn.id === draggedTurnId)?.prompt ?? "",
-                      QUEUE_ROW_PREVIEW_CHARACTERS,
-                    )}
+                    {
+                      queuePromptPreview(
+                        queue.queue.find((turn) => turn.id === draggedTurnId)?.prompt ?? "",
+                        QUEUE_ROW_PREVIEW_CHARACTERS,
+                      ).summary
+                    }
                   </p>
                 </div>
               ) : null}
@@ -412,6 +415,8 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
 const QUEUE_ROW_PREVIEW_CHARACTERS = 360;
 const QUEUE_COLLAPSED_PREVIEW_CHARACTERS = 180;
 const QUEUE_PREVIEW_GRAPHEME_CONTEXT_CHARACTERS = 32;
+const QUEUE_PREVIEW_REFERENCE_SAMPLE_CHARACTERS = 32;
+const QUEUE_VISIBLE_END_IDENTITY_CHARACTERS = 18;
 const QUEUE_PREVIEW_SEPARATOR = " … ";
 const queuePreviewSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
@@ -419,6 +424,13 @@ type BoundedPromptSample = {
   value: string;
   characters: number;
   truncated: boolean;
+};
+
+type QueuePromptPreview = {
+  summary: string;
+  visibleStart: string;
+  visibleIdentity: string | null;
+  visibleIdentityLabel: "End" | "Safe boundary" | null;
 };
 
 /**
@@ -429,10 +441,18 @@ type BoundedPromptSample = {
  * than fragmented, and malformed UTF-16 is replaced only in the summary. The
  * durable prompt remains exact and no operation scans or copies it in full.
  */
-function queuePromptPreview(prompt: string, maxCharacters: number): string {
+function queuePromptPreview(prompt: string, maxCharacters: number): QueuePromptPreview {
   const wholePromptProbe = samplePromptStart(prompt, maxCharacters + 1);
   if (!wholePromptProbe.truncated && wholePromptProbe.characters <= maxCharacters) {
-    return replaceLoneSurrogates(wholePromptProbe.value);
+    const summary = replaceLoneSurrogates(wholePromptProbe.value);
+    return hasVisiblePromptContent(summary)
+      ? {
+          summary,
+          visibleStart: summary,
+          visibleIdentity: null,
+          visibleIdentityLabel: null,
+        }
+      : fallbackPromptPreview(prompt.length, wholePromptProbe.value, wholePromptProbe.value);
   }
 
   const suffixCharacters = Math.min(Math.floor(maxCharacters / 3), 120);
@@ -471,7 +491,82 @@ function queuePromptPreview(prompt: string, maxCharacters: number): string {
 
   const prefix = takeWholeGraphemesFromStart(prefixSegments, prefixCharacters);
   const suffix = takeWholeGraphemesFromEnd(suffixSegments, suffixCharacters);
-  return `${prefix}${QUEUE_PREVIEW_SEPARATOR}${suffix}`;
+  const reference = boundedPromptSampleReference(
+    prompt.length,
+    prefixSample.value,
+    suffixSample.value,
+  );
+
+  if (!hasVisiblePromptContent(prefix) && !hasVisiblePromptContent(suffix)) {
+    return fallbackPromptPreview(prompt.length, prefixSample.value, suffixSample.value);
+  }
+
+  const safeSuffix = hasVisiblePromptContent(suffix)
+    ? suffix
+    : promptPreviewFallbackLabel(reference);
+  const summary = `${prefix}${QUEUE_PREVIEW_SEPARATOR}${safeSuffix}`;
+  if (!hasVisiblePromptContent(prefix)) {
+    return {
+      summary,
+      visibleStart: safeSuffix,
+      visibleIdentity: null,
+      visibleIdentityLabel: null,
+    };
+  }
+
+  const endIdentity = takeWholeGraphemesFromEnd(
+    suffixSegments,
+    QUEUE_VISIBLE_END_IDENTITY_CHARACTERS,
+  );
+  return {
+    summary,
+    visibleStart: prefix,
+    visibleIdentity: hasVisiblePromptContent(endIdentity) ? endIdentity : `ref ${reference}`,
+    visibleIdentityLabel: hasVisiblePromptContent(endIdentity) ? "End" : "Safe boundary",
+  };
+}
+
+function fallbackPromptPreview(
+  promptLength: number,
+  startSample: string,
+  endSample: string,
+): QueuePromptPreview {
+  const summary = promptPreviewFallbackLabel(
+    boundedPromptSampleReference(promptLength, startSample, endSample),
+  );
+  return {
+    summary,
+    visibleStart: summary,
+    visibleIdentity: null,
+    visibleIdentityLabel: null,
+  };
+}
+
+function promptPreviewFallbackLabel(reference: string): string {
+  return `Content omitted at safe boundary · ref ${reference}`;
+}
+
+function boundedPromptSampleReference(
+  promptLength: number,
+  startSample: string,
+  endSample: string,
+): string {
+  const head = samplePromptStart(startSample, QUEUE_PREVIEW_REFERENCE_SAMPLE_CHARACTERS).value;
+  const tail = samplePromptEnd(endSample, QUEUE_PREVIEW_REFERENCE_SAMPLE_CHARACTERS).value;
+  let hash = 0x811c9dc5;
+  for (const value of [String(promptLength), head, tail]) {
+    for (let index = 0; index < value.length; index += 1) {
+      hash ^= value.charCodeAt(index);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    hash ^= 0xffff;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0").toUpperCase();
+}
+
+function hasVisiblePromptContent(value: string): boolean {
+  return value.trim().length > 0;
 }
 
 function samplePromptStart(prompt: string, maxCharacters: number): BoundedPromptSample {
@@ -559,6 +654,7 @@ function takeWholeGraphemesFromEnd(segments: string[], maxCharacters: number): s
     characters += segmentCharacters;
   }
   while (selected[0]?.trim().length === 0) selected.shift();
+  while (selected.at(-1)?.trim().length === 0) selected.pop();
   return selected.join("");
 }
 
@@ -596,15 +692,40 @@ function QueuePrompt({
 
   return (
     <div className="min-w-0 max-w-full">
-      <p
-        aria-label={`Queued prompt ${index + 1} summary: ${preview}`}
-        className="line-clamp-1 max-w-full overflow-hidden whitespace-pre-wrap break-all text-xs leading-5 text-fg [unicode-bidi:plaintext] sm:line-clamp-3"
+      <div
+        aria-label={`Queued prompt ${index + 1} summary: ${preview.summary}`}
+        className="max-w-full overflow-hidden text-xs leading-5 text-fg"
         data-testid={`queue-prompt-preview-${index + 1}`}
         dir="auto"
         role="note"
       >
-        <span aria-hidden="true">{preview}</span>
-      </p>
+        <span aria-hidden="true" className="flex min-w-0 max-w-full items-baseline gap-2 sm:block">
+          <span
+            className="line-clamp-1 min-w-0 flex-1 whitespace-pre-wrap break-all [unicode-bidi:plaintext] sm:line-clamp-2"
+            data-testid={`queue-prompt-start-${index + 1}`}
+            dir="auto"
+          >
+            {preview.visibleStart}
+          </span>
+          {preview.visibleIdentity && preview.visibleIdentityLabel ? (
+            <span
+              className="flex min-w-0 max-w-[70%] shrink-0 items-center gap-1 text-2xs leading-4 text-fg-muted sm:mt-0.5 sm:max-w-full"
+              data-testid={`queue-prompt-identity-row-${index + 1}`}
+            >
+              <span className="shrink-0 font-medium text-fg-subtle">
+                {preview.visibleIdentityLabel}
+              </span>
+              <span
+                className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono [unicode-bidi:plaintext]"
+                data-testid={`queue-prompt-identity-${index + 1}`}
+                dir="auto"
+              >
+                {preview.visibleIdentity}
+              </span>
+            </span>
+          ) : null}
+        </span>
+      </div>
       <button
         type="button"
         aria-controls={fullContentId}
@@ -802,37 +923,38 @@ function SortableQueueRow({
               align="end"
               sideOffset={4}
               className="z-50 w-48 rounded-md border border-border bg-surface p-1 text-xs text-fg shadow-lg"
+              data-testid={`queue-actions-menu-${index + 1}`}
             >
               <DropdownMenu.Item
-                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2"
+                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 pointer-coarse:min-h-11"
                 onSelect={onEdit}
               >
                 <PencilIcon className="size-3.5" /> Edit in composer
               </DropdownMenu.Item>
               <DropdownMenu.Separator className="my-1 h-px bg-border" />
               <DropdownMenu.Item
-                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50"
+                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-11"
                 disabled={index === 0}
                 onSelect={() => onMove(0)}
               >
                 <ArrowUpToLineIcon className="size-3.5" /> Move to top
               </DropdownMenu.Item>
               <DropdownMenu.Item
-                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50"
+                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-11"
                 disabled={index === 0}
                 onSelect={() => onMove(index - 1)}
               >
                 Move up
               </DropdownMenu.Item>
               <DropdownMenu.Item
-                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50"
+                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-11"
                 disabled={index === count - 1}
                 onSelect={() => onMove(index + 1)}
               >
                 Move down
               </DropdownMenu.Item>
               <DropdownMenu.Item
-                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50"
+                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-11"
                 disabled={index === count - 1}
                 onSelect={() => onMove(count - 1)}
               >

--- a/packages/react/src/components/queue-surface.tsx
+++ b/packages/react/src/components/queue-surface.tsx
@@ -54,36 +54,6 @@ export type QueueSurfaceProps =
       readOnly: true;
     };
 
-const QUEUE_ROW_PREVIEW_CHARACTERS = 360;
-const QUEUE_COLLAPSED_PREVIEW_CHARACTERS = 180;
-
-/**
- * Build a bounded head/tail summary of an arbitrary queued prompt. Sampling
- * both ends distinguishes prompts with equal long prefixes, while `Array.from`
- * keeps both boundaries from splitting a surrogate pair. Only small slices are
- * scanned, so a multi-megabyte durable prompt is never copied in full.
- */
-function queuePromptPreview(prompt: string, maxCharacters: number): string {
-  const scanned = prompt.slice(0, maxCharacters * 2 + 1);
-  const characters = Array.from(scanned);
-  if (scanned.length === prompt.length && characters.length <= maxCharacters) {
-    return prompt;
-  }
-
-  const separator = " … ";
-  const suffixCharacters = Math.min(Math.floor(maxCharacters / 3), 120);
-  const prefixCharacters = maxCharacters - Array.from(separator).length - suffixCharacters;
-  const prefix = Array.from(prompt.slice(0, prefixCharacters * 2 + 1))
-    .slice(0, prefixCharacters)
-    .join("")
-    .trimEnd();
-  const suffix = Array.from(prompt.slice(-(suffixCharacters * 2 + 1)))
-    .slice(-suffixCharacters)
-    .join("")
-    .trimStart();
-  return `${prefix}${separator}${suffix}`;
-}
-
 export function QueueSurface({ queue, composer, readOnly = false }: QueueSurfaceProps) {
   const [open, setOpen] = useState(false);
   const [replaceDraftFor, setReplaceDraftFor] = useState<string | null>(null);
@@ -437,6 +407,178 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
       </p>
     </div>
   );
+}
+
+const QUEUE_ROW_PREVIEW_CHARACTERS = 360;
+const QUEUE_COLLAPSED_PREVIEW_CHARACTERS = 180;
+const QUEUE_PREVIEW_GRAPHEME_CONTEXT_CHARACTERS = 32;
+const QUEUE_PREVIEW_SEPARATOR = " … ";
+const queuePreviewSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+type BoundedPromptSample = {
+  value: string;
+  characters: number;
+  truncated: boolean;
+};
+
+/**
+ * Build a bounded head/tail summary of an arbitrary queued prompt. Sampling
+ * both ends distinguishes prompts with equal long prefixes. Each sampled edge
+ * has a small amount of grapheme context so ordinary emoji/combining sequences
+ * can be retained whole. A cluster that exceeds that context is omitted rather
+ * than fragmented, and malformed UTF-16 is replaced only in the summary. The
+ * durable prompt remains exact and no operation scans or copies it in full.
+ */
+function queuePromptPreview(prompt: string, maxCharacters: number): string {
+  const wholePromptProbe = samplePromptStart(prompt, maxCharacters + 1);
+  if (!wholePromptProbe.truncated && wholePromptProbe.characters <= maxCharacters) {
+    return replaceLoneSurrogates(wholePromptProbe.value);
+  }
+
+  const suffixCharacters = Math.min(Math.floor(maxCharacters / 3), 120);
+  const prefixCharacters =
+    maxCharacters - codePointLength(QUEUE_PREVIEW_SEPARATOR) - suffixCharacters;
+  const prefixSample = samplePromptStart(
+    prompt,
+    prefixCharacters + QUEUE_PREVIEW_GRAPHEME_CONTEXT_CHARACTERS,
+  );
+  const suffixSample = samplePromptEnd(
+    prompt,
+    suffixCharacters + QUEUE_PREVIEW_GRAPHEME_CONTEXT_CHARACTERS,
+  );
+  const prefixSegments = segmentPromptSample(prefixSample.value);
+  const suffixSegments = segmentPromptSample(suffixSample.value);
+
+  // A cluster at a truncated sampling edge may continue outside the sample.
+  // Prefix sampling starts at the true source start, so only its last segment
+  // is ambiguous. Suffix sampling ends at the true source end, so its first is.
+  if (prefixSample.truncated) prefixSegments.pop();
+  if (suffixSample.truncated) {
+    let ambiguousSegment = suffixSegments.shift();
+    // A locally segmented leading fragment ending in ZWJ can join the next
+    // pictographic segment when omitted left context supplies its base. Keep
+    // backing off until that uncertainty no longer propagates to the right.
+    while (ambiguousSegment?.endsWith("\u200d") && suffixSegments.length > 0) {
+      ambiguousSegment = suffixSegments.shift();
+    }
+    // Regional Indicator pairing depends on the parity of the preceding run.
+    // If that run reaches the unknown sample boundary, omit all of its visible
+    // leading segments rather than potentially recombining halves of flags.
+    while (suffixSegments[0] && startsWithRegionalIndicator(suffixSegments[0])) {
+      suffixSegments.shift();
+    }
+  }
+
+  const prefix = takeWholeGraphemesFromStart(prefixSegments, prefixCharacters);
+  const suffix = takeWholeGraphemesFromEnd(suffixSegments, suffixCharacters);
+  return `${prefix}${QUEUE_PREVIEW_SEPARATOR}${suffix}`;
+}
+
+function samplePromptStart(prompt: string, maxCharacters: number): BoundedPromptSample {
+  let end = 0;
+  let characters = 0;
+  while (end < prompt.length && characters < maxCharacters) {
+    const first = prompt.charCodeAt(end);
+    end +=
+      isHighSurrogate(first) &&
+      end + 1 < prompt.length &&
+      isLowSurrogate(prompt.charCodeAt(end + 1))
+        ? 2
+        : 1;
+    characters += 1;
+  }
+  return { value: prompt.slice(0, end), characters, truncated: end < prompt.length };
+}
+
+function samplePromptEnd(prompt: string, maxCharacters: number): BoundedPromptSample {
+  let start = prompt.length;
+  let characters = 0;
+  while (start > 0 && characters < maxCharacters) {
+    start -= 1;
+    if (
+      isLowSurrogate(prompt.charCodeAt(start)) &&
+      start > 0 &&
+      isHighSurrogate(prompt.charCodeAt(start - 1))
+    ) {
+      start -= 1;
+    }
+    characters += 1;
+  }
+  return { value: prompt.slice(start), characters, truncated: start > 0 };
+}
+
+function segmentPromptSample(sample: string): string[] {
+  return Array.from(
+    queuePreviewSegmenter.segment(replaceLoneSurrogates(sample)),
+    ({ segment }) => segment,
+  );
+}
+
+function replaceLoneSurrogates(value: string): string {
+  let sanitized = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const current = value.charCodeAt(index);
+    if (
+      isHighSurrogate(current) &&
+      index + 1 < value.length &&
+      isLowSurrogate(value.charCodeAt(index + 1))
+    ) {
+      sanitized += value.slice(index, index + 2);
+      index += 1;
+    } else if (isHighSurrogate(current) || isLowSurrogate(current)) {
+      sanitized += "�";
+    } else {
+      sanitized += value[index];
+    }
+  }
+  return sanitized;
+}
+
+function takeWholeGraphemesFromStart(segments: string[], maxCharacters: number): string {
+  const selected: string[] = [];
+  let characters = 0;
+  for (const segment of segments) {
+    const segmentCharacters = codePointLength(segment);
+    if (characters + segmentCharacters > maxCharacters) break;
+    selected.push(segment);
+    characters += segmentCharacters;
+  }
+  while (selected.at(-1)?.trim().length === 0) selected.pop();
+  return selected.join("");
+}
+
+function takeWholeGraphemesFromEnd(segments: string[], maxCharacters: number): string {
+  const selected: string[] = [];
+  let characters = 0;
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    const segment = segments[index];
+    if (!segment) continue;
+    const segmentCharacters = codePointLength(segment);
+    if (characters + segmentCharacters > maxCharacters) break;
+    selected.unshift(segment);
+    characters += segmentCharacters;
+  }
+  while (selected[0]?.trim().length === 0) selected.shift();
+  return selected.join("");
+}
+
+function codePointLength(value: string): number {
+  let characters = 0;
+  for (const _character of value) characters += 1;
+  return characters;
+}
+
+function startsWithRegionalIndicator(value: string): boolean {
+  const codePoint = value.codePointAt(0);
+  return codePoint !== undefined && codePoint >= 0x1f1e6 && codePoint <= 0x1f1ff;
+}
+
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
 }
 
 function QueuePrompt({

--- a/packages/react/src/components/queue-surface.tsx
+++ b/packages/react/src/components/queue-surface.tsx
@@ -387,9 +387,16 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
           <div className="border-t border-border p-2">
             <div
               role="alert"
-              className="flex items-center gap-2 rounded-md bg-status-failed/10 px-2 py-1.5 text-xs text-status-failed"
+              className="flex min-w-0 max-w-full flex-wrap items-start gap-2 rounded-md bg-status-failed/10 px-2 py-1.5 text-xs text-status-failed"
             >
-              <span className="min-w-0 flex-1">
+              <span
+                role="region"
+                aria-label="Queue error details"
+                tabIndex={0}
+                className="max-h-[min(5rem,20dvh)] min-w-0 max-w-full flex-[1_1_5rem] overflow-auto overscroll-contain whitespace-pre-wrap rounded-sm outline-none [overflow-wrap:anywhere] [unicode-bidi:plaintext] focus-visible:ring-2 focus-visible:ring-ring/40"
+                data-testid="queue-error-message"
+                dir="auto"
+              >
                 {(queue.mutationError ?? queue.error)?.message}
               </span>
               <button
@@ -400,7 +407,7 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
                 }}
                 aria-label="Dismiss queue error and retry"
                 title="Retry loading the queue"
-                className="inline-flex size-7 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-3 focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:size-[44px]"
+                className="ms-auto inline-flex size-7 shrink-0 items-center justify-center self-start rounded-md outline-none transition-colors hover:bg-surface-3 focus-visible:ring-2 focus-visible:ring-ring/40 motion-reduce:transition-none pointer-coarse:size-[44px]"
               >
                 <RotateCwIcon className="size-3.5" />
               </button>

--- a/packages/react/src/components/queue-surface.tsx
+++ b/packages/react/src/components/queue-surface.tsx
@@ -29,7 +29,13 @@ import {
   Trash2Icon,
   ZapIcon,
 } from "lucide-react";
-import { useCallback, useMemo, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import {
+  useCallback,
+  useId,
+  useMemo,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 
 import { DropdownMenu } from "radix-ui";
 import type { ComposerState } from "../hooks/use-composer";
@@ -47,6 +53,24 @@ export type QueueSurfaceProps =
       composer?: undefined;
       readOnly: true;
     };
+
+const QUEUE_ROW_PREVIEW_CHARACTERS = 360;
+const QUEUE_COLLAPSED_PREVIEW_CHARACTERS = 180;
+
+/**
+ * Build only a small visual prefix of an arbitrary queued prompt. `Array.from`
+ * keeps a truncation boundary from splitting a surrogate pair, while the
+ * initial slice prevents a multi-megabyte prompt from being copied/scanned in
+ * full merely to render a queue row. The durable prompt remains untouched.
+ */
+function queuePromptPreview(prompt: string, maxCharacters: number): string {
+  const scanned = prompt.slice(0, maxCharacters * 2 + 1);
+  const characters = Array.from(scanned);
+  if (scanned.length === prompt.length && characters.length <= maxCharacters) {
+    return prompt;
+  }
+  return `${characters.slice(0, maxCharacters).join("").trimEnd()}…`;
+}
 
 export function QueueSurface({ queue, composer, readOnly = false }: QueueSurfaceProps) {
   const [open, setOpen] = useState(false);
@@ -237,6 +261,7 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
           aria-expanded={open}
         >
           <ChevronDownIcon
+            aria-hidden="true"
             className={`size-3.5 shrink-0 text-fg-subtle transition-transform ${open ? "rotate-180" : ""}`}
           />
           <span className="text-xs font-medium text-fg">
@@ -248,17 +273,35 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
             </span>
           ) : null}
           {!open && count > 0 ? (
-            <span className="min-w-0 flex-1 truncate text-xs text-fg-muted">
-              {queue.queue[0]?.prompt}
+            <span
+              aria-hidden="true"
+              className="min-w-0 flex-1 truncate text-xs text-fg-muted"
+              data-testid="queue-collapsed-preview"
+              dir="auto"
+            >
+              {queuePromptPreview(queue.queue[0]?.prompt ?? "", QUEUE_COLLAPSED_PREVIEW_CHARACTERS)}
             </span>
           ) : null}
           {queue.loading ? <Loader2Icon className="ml-auto size-3.5 animate-spin" /> : null}
         </button>
 
         {open && count > 0 && readOnly ? (
-          <ol className="divide-y divide-border border-t border-border" aria-label="Queued prompts">
+          <ol
+            className="max-h-[min(30rem,60dvh)] divide-y divide-border overflow-y-auto overscroll-contain border-t border-border"
+            aria-label="Queued prompts"
+            data-testid="queue-list"
+          >
             {queue.queue.map((turn, index) => (
-              <ReadOnlyQueueRow key={turn.id} turn={turn} index={index} />
+              <ReadOnlyQueueRow
+                key={turn.id}
+                turn={turn}
+                index={index}
+                onDisclosureChange={(expanded) =>
+                  setAnnouncement(
+                    `Full content for queued prompt ${index + 1} ${expanded ? "shown" : "hidden"}.`,
+                  )
+                }
+              />
             ))}
           </ol>
         ) : null}
@@ -277,8 +320,9 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
           >
             <SortableContext items={ids} strategy={verticalListSortingStrategy}>
               <ol
-                className="divide-y divide-border border-t border-border"
+                className="max-h-[min(30rem,60dvh)] divide-y divide-border overflow-y-auto overscroll-contain border-t border-border"
                 aria-label="Queued prompts"
+                data-testid="queue-list"
               >
                 {displayedQueue.map((turn, index) => (
                   <SortableQueueRow
@@ -314,14 +358,31 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
                         if (removed) focusAfterQueueRemoval(index);
                       });
                     }}
+                    onDisclosureChange={(expanded) =>
+                      setAnnouncement(
+                        `Full content for queued prompt ${index + 1} ${expanded ? "shown" : "hidden"}.`,
+                      )
+                    }
                   />
                 ))}
               </ol>
             </SortableContext>
             <DragOverlay modifiers={[verticalOnly]}>
               {draggedTurnId ? (
-                <div className="max-w-xl rounded-md border border-brand/40 bg-surface px-3 py-2 text-xs text-fg shadow-lg">
-                  {queue.queue.find((turn) => turn.id === draggedTurnId)?.prompt}
+                <div
+                  className="max-h-20 w-[min(36rem,calc(100vw-2rem))] max-w-[calc(100vw-2rem)] overflow-hidden rounded-md border border-brand/40 bg-surface px-3 py-2 text-xs text-fg shadow-lg"
+                  data-testid="queue-drag-overlay"
+                >
+                  <p
+                    aria-hidden="true"
+                    className="line-clamp-3 break-all whitespace-pre-wrap [unicode-bidi:plaintext]"
+                    dir="auto"
+                  >
+                    {queuePromptPreview(
+                      queue.queue.find((turn) => turn.id === draggedTurnId)?.prompt ?? "",
+                      QUEUE_ROW_PREVIEW_CHARACTERS,
+                    )}
+                  </p>
                 </div>
               ) : null}
             </DragOverlay>
@@ -360,25 +421,91 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
   );
 }
 
-function ReadOnlyQueueRow({ turn, index }: { turn: SessionTurn; index: number }) {
+function QueuePrompt({
+  prompt,
+  index,
+  onDisclosureChange,
+}: {
+  prompt: string;
+  index: number;
+  onDisclosureChange: (expanded: boolean) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const fullContentId = useId();
+  const preview = useMemo(() => queuePromptPreview(prompt, QUEUE_ROW_PREVIEW_CHARACTERS), [prompt]);
+
+  return (
+    <div className="min-w-0 max-w-full">
+      <p
+        aria-hidden="true"
+        className="line-clamp-1 max-w-full overflow-hidden whitespace-pre-wrap break-all text-xs leading-5 text-fg [unicode-bidi:plaintext] sm:line-clamp-3"
+        data-testid={`queue-prompt-preview-${index + 1}`}
+        dir="auto"
+      >
+        {preview}
+      </p>
+      <button
+        type="button"
+        aria-controls={fullContentId}
+        aria-expanded={expanded}
+        aria-label={`${expanded ? "Hide" : "Show"} full content for queued prompt ${index + 1}`}
+        className="mt-1 inline-flex min-h-7 items-center gap-1 rounded-md text-2xs font-medium text-fg-muted outline-none transition-colors hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:min-h-11"
+        onClick={() => {
+          const next = !expanded;
+          setExpanded(next);
+          onDisclosureChange(next);
+        }}
+      >
+        <ChevronDownIcon
+          aria-hidden="true"
+          className={`size-3 shrink-0 transition-transform ${expanded ? "rotate-180" : ""}`}
+        />
+        {expanded ? "Hide full prompt" : "View full prompt"}
+      </button>
+      {expanded ? (
+        <pre
+          id={fullContentId}
+          role="region"
+          aria-label={`Full content for queued prompt ${index + 1}`}
+          className="mt-1.5 max-h-64 max-w-full overflow-auto overscroll-contain rounded-md border border-border bg-surface-2/60 p-2 whitespace-pre-wrap break-all font-mono text-xs leading-5 text-fg [unicode-bidi:plaintext]"
+          data-testid={`queue-prompt-full-${index + 1}`}
+          dir="auto"
+          tabIndex={0}
+        >
+          {prompt}
+        </pre>
+      ) : null}
+    </div>
+  );
+}
+
+function ReadOnlyQueueRow({
+  turn,
+  index,
+  onDisclosureChange,
+}: {
+  turn: SessionTurn;
+  index: number;
+  onDisclosureChange: (expanded: boolean) => void;
+}) {
   return (
     <li className="flex min-w-0 items-start gap-2 bg-surface px-3 py-2">
       <span className="mt-1 shrink-0 font-mono text-2xs text-fg-subtle">{index + 1}</span>
       <div className="min-w-0 flex-1">
-        <p className="whitespace-pre-wrap break-words text-xs leading-5 text-fg">{turn.prompt}</p>
-        <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5 text-2xs text-fg-subtle">
+        <QueuePrompt prompt={turn.prompt} index={index} onDisclosureChange={onDisclosureChange} />
+        <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap text-2xs text-fg-subtle">
           {turn.resources.length > 0 ? (
-            <span>
+            <span className="shrink-0">
               {turn.resources.length} resource{turn.resources.length === 1 ? "" : "s"}
             </span>
           ) : null}
           {turn.tools.length > 0 ? (
-            <span>
+            <span className="shrink-0">
               {turn.tools.length} tool{turn.tools.length === 1 ? "" : "s"}
             </span>
           ) : null}
-          <span>{turn.model}</span>
-          <span>{turn.reasoningEffort}</span>
+          <span className="min-w-0 truncate">{turn.model}</span>
+          <span className="shrink-0">{turn.reasoningEffort}</span>
         </div>
       </div>
     </li>
@@ -399,6 +526,7 @@ function SortableQueueRow({
   onCancelReplace,
   onSteer,
   onDelete,
+  onDisclosureChange,
 }: {
   turn: SessionTurn;
   index: number;
@@ -413,6 +541,7 @@ function SortableQueueRow({
   onCancelReplace: () => void;
   onSteer: () => void;
   onDelete: () => void;
+  onDisclosureChange: (expanded: boolean) => void;
 }) {
   const sortable = useSortable({
     id: turn.id,
@@ -428,7 +557,7 @@ function SortableQueueRow({
       }}
       className={`bg-surface ${sortable.isDragging || keyboardDragging ? "relative z-10 shadow-lg ring-1 ring-brand/40" : ""}`}
     >
-      <div className="flex min-w-0 items-start gap-1.5 px-2 py-2 sm:gap-2 sm:px-3">
+      <div className="grid min-w-0 grid-cols-[auto_auto_minmax(0,1fr)_auto_auto_auto] items-start gap-x-1.5 px-2 py-2 sm:gap-x-2 sm:px-3">
         <button
           data-queue-handle
           ref={sortable.setActivatorNodeRef}
@@ -437,28 +566,30 @@ function SortableQueueRow({
           {...sortable.listeners}
           onKeyDown={onHandleKeyDown}
           disabled={pending !== null}
-          className="mt-0.5 inline-flex size-7 shrink-0 touch-none items-center justify-center rounded-md text-fg-subtle hover:bg-surface-2 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:size-11"
+          className="col-start-1 row-start-1 mt-0.5 inline-flex size-7 shrink-0 touch-none items-center justify-center rounded-md text-fg-subtle hover:bg-surface-2 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:size-11"
           aria-label={`Reorder queued prompt ${index + 1}`}
           title="Drag to reorder. Press Space, arrows, then Space to drop."
         >
           <GripVerticalIcon className="size-3.5" />
         </button>
-        <span className="mt-1 shrink-0 font-mono text-2xs text-fg-subtle">{index + 1}</span>
-        <div className="min-w-0 flex-1">
-          <p className="whitespace-pre-wrap break-words text-xs leading-5 text-fg">{turn.prompt}</p>
-          <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5 text-2xs text-fg-subtle">
+        <span className="col-start-2 row-start-1 mt-1 shrink-0 font-mono text-2xs text-fg-subtle">
+          {index + 1}
+        </span>
+        <div className="col-span-full row-start-2 min-w-0 pt-1 sm:col-span-1 sm:col-start-3 sm:row-start-1 sm:pt-0">
+          <QueuePrompt prompt={turn.prompt} index={index} onDisclosureChange={onDisclosureChange} />
+          <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap text-2xs text-fg-subtle">
             {turn.resources.length > 0 ? (
-              <span>
+              <span className="shrink-0">
                 {turn.resources.length} resource{turn.resources.length === 1 ? "" : "s"}
               </span>
             ) : null}
             {turn.tools.length > 0 ? (
-              <span>
+              <span className="shrink-0">
                 {turn.tools.length} tool{turn.tools.length === 1 ? "" : "s"}
               </span>
             ) : null}
-            <span>{turn.model}</span>
-            <span>{turn.reasoningEffort}</span>
+            <span className="min-w-0 truncate">{turn.model}</span>
+            <span className="shrink-0">{turn.reasoningEffort}</span>
           </div>
         </div>
         <button
@@ -467,7 +598,7 @@ function SortableQueueRow({
           onClick={onSteer}
           aria-label={`Steer queued prompt ${index + 1}`}
           title="Make this the next direction"
-          className="inline-flex h-7 shrink-0 items-center justify-center gap-1 rounded-md px-2 text-xs font-medium outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:min-h-11"
+          className="col-start-4 row-start-1 inline-flex h-7 shrink-0 items-center justify-center gap-1 rounded-md px-2 text-xs font-medium outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:min-h-11"
         >
           {pending === "steer" ? (
             <Loader2Icon className="size-3.5 animate-spin" />
@@ -482,7 +613,7 @@ function SortableQueueRow({
           onClick={onDelete}
           aria-label={`Delete queued prompt ${index + 1}`}
           title="Delete this queued prompt"
-          className="inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 hover:text-status-failed focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:size-11"
+          className="col-start-5 row-start-1 inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 hover:text-status-failed focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:size-11"
         >
           {pending === "delete" ? (
             <Loader2Icon className="size-3.5 animate-spin" />
@@ -496,7 +627,7 @@ function SortableQueueRow({
               type="button"
               disabled={pending !== null}
               aria-label={`More actions for queued prompt ${index + 1}`}
-              className="inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:size-11"
+              className="col-start-6 row-start-1 inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:size-11"
             >
               {pending && pending !== "steer" && pending !== "delete" ? (
                 <Loader2Icon className="size-3.5 animate-spin" />

--- a/packages/react/src/components/queue-surface.tsx
+++ b/packages/react/src/components/queue-surface.tsx
@@ -242,7 +242,7 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
         ) : null}
         <button
           type="button"
-          className="flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left outline-none transition-colors hover:bg-surface-2/60 focus-visible:bg-surface-2/60 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/40 pointer-coarse:min-h-11"
+          className="flex w-full min-w-0 flex-wrap items-center gap-2 px-3 py-2 text-left outline-none transition-colors hover:bg-surface-2/60 focus-visible:bg-surface-2/60 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/40 pointer-coarse:min-h-[44px]"
           onClick={() => setOpen((value) => !value)}
           aria-description={!open && count > 0 ? collapsedPreview.summary : undefined}
           aria-expanded={open}
@@ -263,10 +263,10 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
           {!open && count > 0 ? (
             <span
               aria-hidden="true"
-              className={`min-w-0 flex-1 truncate text-fg-muted ${
+              className={`max-w-full truncate text-fg-muted ${
                 collapsedPreview.collapsedVisual === collapsedPreview.summary
-                  ? "text-xs"
-                  : "text-[10px]"
+                  ? "min-w-0 flex-1 text-xs"
+                  : "shrink-0 text-[10px]"
               }`}
               data-testid="queue-collapsed-preview"
               dir="auto"
@@ -400,7 +400,7 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
                 }}
                 aria-label="Dismiss queue error and retry"
                 title="Retry loading the queue"
-                className="inline-flex size-7 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-3 focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:size-11"
+                className="inline-flex size-7 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-3 focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:size-[44px]"
               >
                 <RotateCwIcon className="size-3.5" />
               </button>
@@ -437,6 +437,7 @@ type QueuePromptPreview = {
   visibleStart: string;
   visibleIdentity: string | null;
   visibleIdentityLabel: "End" | "Safe boundary" | null;
+  isFallback: boolean;
 };
 
 /**
@@ -458,6 +459,7 @@ function queuePromptPreview(prompt: string, maxCharacters: number): QueuePromptP
           visibleStart: summary,
           visibleIdentity: null,
           visibleIdentityLabel: null,
+          isFallback: false,
         }
       : fallbackPromptPreview(prompt.length, wholePromptProbe.value, wholePromptProbe.value);
   }
@@ -519,6 +521,7 @@ function queuePromptPreview(prompt: string, maxCharacters: number): QueuePromptP
       visibleStart: safeSuffix,
       visibleIdentity: null,
       visibleIdentityLabel: null,
+      isFallback: false,
     };
   }
 
@@ -532,6 +535,7 @@ function queuePromptPreview(prompt: string, maxCharacters: number): QueuePromptP
     visibleStart: prefix,
     visibleIdentity: hasVisiblePromptContent(endIdentity) ? endIdentity : `ref ${reference}`,
     visibleIdentityLabel: hasVisiblePromptContent(endIdentity) ? "End" : "Safe boundary",
+    isFallback: false,
   };
 }
 
@@ -551,6 +555,7 @@ function fallbackPromptPreview(
     visibleStart: `Omitted · ${reference}`,
     visibleIdentity: null,
     visibleIdentityLabel: null,
+    isFallback: true,
   };
 }
 
@@ -709,7 +714,7 @@ function QueuePrompt({
   const preview = useMemo(() => queuePromptPreview(prompt, QUEUE_ROW_PREVIEW_CHARACTERS), [prompt]);
 
   return (
-    <div className="min-w-0 max-w-full">
+    <div className="w-full min-w-0 max-w-full">
       <div
         aria-label={`Queued prompt ${index + 1} summary: ${preview.summary}`}
         className="max-w-full overflow-hidden text-xs leading-5 text-fg"
@@ -719,7 +724,7 @@ function QueuePrompt({
       >
         <span aria-hidden="true" className="flex min-w-0 max-w-full items-baseline gap-2 sm:block">
           <span
-            className="line-clamp-1 min-w-0 flex-1 whitespace-pre-wrap break-all [unicode-bidi:plaintext] sm:line-clamp-2"
+            className={`${preview.isFallback ? "" : "line-clamp-1 sm:line-clamp-2"} min-w-0 flex-1 whitespace-pre-wrap break-all [unicode-bidi:plaintext]`}
             data-testid={`queue-prompt-start-${index + 1}`}
             dir="auto"
           >
@@ -749,7 +754,8 @@ function QueuePrompt({
         aria-controls={fullContentId}
         aria-expanded={expanded}
         aria-label={`${expanded ? "Hide" : "Show"} full content for queued prompt ${index + 1}`}
-        className="mt-1 inline-flex min-h-7 items-center gap-1 rounded-md text-2xs font-medium text-fg-muted outline-none transition-colors hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:min-h-11"
+        className="mt-1 inline-flex min-h-7 min-w-0 max-w-full items-center gap-1 whitespace-normal rounded-md text-left text-2xs font-medium text-fg-muted outline-none transition-colors hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:min-h-[44px]"
+        data-testid={`queue-prompt-disclosure-${index + 1}`}
         onClick={() => {
           const next = !expanded;
           setExpanded(next);
@@ -767,7 +773,7 @@ function QueuePrompt({
           id={fullContentId}
           role="region"
           aria-label={`Full content for queued prompt ${index + 1}`}
-          className="mt-1.5 max-h-64 max-w-full overflow-auto overscroll-contain rounded-md border border-border bg-surface-2/60 p-2 whitespace-pre-wrap break-all font-mono text-xs leading-5 text-fg [unicode-bidi:plaintext]"
+          className="mt-1.5 max-h-64 w-full min-w-0 max-w-full overflow-auto overscroll-contain rounded-md border border-border bg-surface-2/60 p-2 whitespace-pre-wrap break-all font-mono text-xs leading-5 text-fg [unicode-bidi:plaintext]"
           data-testid={`queue-prompt-full-${index + 1}`}
           dir="auto"
           tabIndex={0}
@@ -857,7 +863,7 @@ function SortableQueueRow({
       }}
       className={`bg-surface ${sortable.isDragging || keyboardDragging ? "relative z-10 shadow-lg ring-1 ring-brand/40" : ""}`}
     >
-      <div className="grid min-w-0 grid-cols-[auto_auto_minmax(0,1fr)_auto_auto_auto] items-start gap-x-1.5 px-2 py-1.5 sm:gap-x-2 sm:px-3 sm:py-2">
+      <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-start gap-x-1.5 px-2 py-1.5 sm:grid-cols-[auto_auto_minmax(0,1fr)_auto] sm:gap-x-2 sm:px-3 sm:py-2">
         <button
           data-queue-handle
           ref={sortable.setActivatorNodeRef}
@@ -866,7 +872,7 @@ function SortableQueueRow({
           {...sortable.listeners}
           onKeyDown={onHandleKeyDown}
           disabled={pending !== null}
-          className="col-start-1 row-start-1 mt-0.5 inline-flex size-7 shrink-0 touch-none items-center justify-center rounded-md text-fg-subtle hover:bg-surface-2 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:size-11"
+          className="col-start-1 row-start-1 mt-0.5 inline-flex size-7 shrink-0 touch-none items-center justify-center rounded-md text-fg-subtle hover:bg-surface-2 hover:text-fg focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:size-[44px]"
           aria-label={`Reorder queued prompt ${index + 1}`}
           title="Drag to reorder. Press Space, arrows, then Space to drop."
         >
@@ -892,95 +898,97 @@ function SortableQueueRow({
             <span className="shrink-0">{turn.reasoningEffort}</span>
           </div>
         </div>
-        <button
-          type="button"
-          disabled={pending !== null}
-          onClick={onSteer}
-          aria-label={`Steer queued prompt ${index + 1}`}
-          title="Make this the next direction"
-          className="col-start-4 row-start-3 inline-flex h-7 shrink-0 items-center justify-center gap-1 rounded-md px-2 text-xs font-medium outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 sm:row-start-1 pointer-coarse:min-h-11"
-        >
-          {pending === "steer" ? (
-            <Loader2Icon className="size-3.5 animate-spin" />
-          ) : (
-            <ZapIcon className="size-3.5" />
-          )}
-          <span className="hidden sm:inline">Steer</span>
-        </button>
-        <button
-          type="button"
-          disabled={pending !== null}
-          onClick={onDelete}
-          aria-label={`Delete queued prompt ${index + 1}`}
-          title="Delete this queued prompt"
-          className="col-start-5 row-start-3 inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 hover:text-status-failed focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 sm:row-start-1 pointer-coarse:size-11"
-        >
-          {pending === "delete" ? (
-            <Loader2Icon className="size-3.5 animate-spin" />
-          ) : (
-            <Trash2Icon className="size-3.5" />
-          )}
-        </button>
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger asChild>
-            <button
-              type="button"
-              disabled={pending !== null}
-              aria-label={`More actions for queued prompt ${index + 1}`}
-              className="col-start-6 row-start-3 inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 sm:row-start-1 pointer-coarse:size-11"
-            >
-              {pending && pending !== "steer" && pending !== "delete" ? (
-                <Loader2Icon className="size-3.5 animate-spin" />
-              ) : (
-                <EllipsisIcon className="size-3.5" />
-              )}
-            </button>
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content
-              align="end"
-              sideOffset={4}
-              className="z-50 w-48 rounded-md border border-border bg-surface p-1 text-xs text-fg shadow-lg"
-              data-testid={`queue-actions-menu-${index + 1}`}
-            >
-              <DropdownMenu.Item
-                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 pointer-coarse:min-h-11"
-                onSelect={onEdit}
+        <div className="col-span-full row-start-3 flex min-w-0 items-start justify-end gap-1.5 sm:col-span-1 sm:col-start-4 sm:row-start-1 sm:gap-2">
+          <button
+            type="button"
+            disabled={pending !== null}
+            onClick={onSteer}
+            aria-label={`Steer queued prompt ${index + 1}`}
+            title="Make this the next direction"
+            className="inline-flex h-7 shrink-0 items-center justify-center gap-1 rounded-md px-2 text-xs font-medium outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:min-h-[44px] pointer-coarse:min-w-[44px]"
+          >
+            {pending === "steer" ? (
+              <Loader2Icon className="size-3.5 animate-spin" />
+            ) : (
+              <ZapIcon className="size-3.5" />
+            )}
+            <span className="hidden sm:inline">Steer</span>
+          </button>
+          <button
+            type="button"
+            disabled={pending !== null}
+            onClick={onDelete}
+            aria-label={`Delete queued prompt ${index + 1}`}
+            title="Delete this queued prompt"
+            className="inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 hover:text-status-failed focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:size-[44px]"
+          >
+            {pending === "delete" ? (
+              <Loader2Icon className="size-3.5 animate-spin" />
+            ) : (
+              <Trash2Icon className="size-3.5" />
+            )}
+          </button>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
+              <button
+                type="button"
+                disabled={pending !== null}
+                aria-label={`More actions for queued prompt ${index + 1}`}
+                className="inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:size-[44px]"
               >
-                <PencilIcon className="size-3.5" /> Edit in composer
-              </DropdownMenu.Item>
-              <DropdownMenu.Separator className="my-1 h-px bg-border" />
-              <DropdownMenu.Item
-                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-11"
-                disabled={index === 0}
-                onSelect={() => onMove(0)}
+                {pending && pending !== "steer" && pending !== "delete" ? (
+                  <Loader2Icon className="size-3.5 animate-spin" />
+                ) : (
+                  <EllipsisIcon className="size-3.5" />
+                )}
+              </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content
+                align="end"
+                sideOffset={4}
+                className="z-50 w-48 max-w-[calc(100vw-16px)] rounded-md border border-border bg-surface p-1 text-xs text-fg shadow-lg"
+                data-testid={`queue-actions-menu-${index + 1}`}
               >
-                <ArrowUpToLineIcon className="size-3.5" /> Move to top
-              </DropdownMenu.Item>
-              <DropdownMenu.Item
-                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-11"
-                disabled={index === 0}
-                onSelect={() => onMove(index - 1)}
-              >
-                Move up
-              </DropdownMenu.Item>
-              <DropdownMenu.Item
-                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-11"
-                disabled={index === count - 1}
-                onSelect={() => onMove(index + 1)}
-              >
-                Move down
-              </DropdownMenu.Item>
-              <DropdownMenu.Item
-                className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-11"
-                disabled={index === count - 1}
-                onSelect={() => onMove(count - 1)}
-              >
-                <ArrowDownToLineIcon className="size-3.5" /> Move to bottom
-              </DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
+                <DropdownMenu.Item
+                  className="flex min-w-0 cursor-default items-center gap-2 whitespace-normal break-words rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 pointer-coarse:min-h-[44px]"
+                  onSelect={onEdit}
+                >
+                  <PencilIcon className="size-3.5" /> Edit in composer
+                </DropdownMenu.Item>
+                <DropdownMenu.Separator className="my-1 h-px bg-border" />
+                <DropdownMenu.Item
+                  className="flex min-w-0 cursor-default items-center gap-2 whitespace-normal break-words rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-[44px]"
+                  disabled={index === 0}
+                  onSelect={() => onMove(0)}
+                >
+                  <ArrowUpToLineIcon className="size-3.5" /> Move to top
+                </DropdownMenu.Item>
+                <DropdownMenu.Item
+                  className="flex min-w-0 cursor-default items-center gap-2 whitespace-normal break-words rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-[44px]"
+                  disabled={index === 0}
+                  onSelect={() => onMove(index - 1)}
+                >
+                  Move up
+                </DropdownMenu.Item>
+                <DropdownMenu.Item
+                  className="flex min-w-0 cursor-default items-center gap-2 whitespace-normal break-words rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-[44px]"
+                  disabled={index === count - 1}
+                  onSelect={() => onMove(index + 1)}
+                >
+                  Move down
+                </DropdownMenu.Item>
+                <DropdownMenu.Item
+                  className="flex min-w-0 cursor-default items-center gap-2 whitespace-normal break-words rounded-sm px-2 py-1.5 outline-none focus:bg-surface-2 data-[disabled]:opacity-50 pointer-coarse:min-h-[44px]"
+                  disabled={index === count - 1}
+                  onSelect={() => onMove(count - 1)}
+                >
+                  <ArrowDownToLineIcon className="size-3.5" /> Move to bottom
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Root>
+        </div>
       </div>
       {confirmingReplace ? (
         <div className="mx-3 mb-2 rounded-md border border-status-waiting/30 bg-status-waiting/10 p-2 text-xs text-fg">

--- a/packages/react/src/components/queue-surface.tsx
+++ b/packages/react/src/components/queue-surface.tsx
@@ -58,10 +58,10 @@ const QUEUE_ROW_PREVIEW_CHARACTERS = 360;
 const QUEUE_COLLAPSED_PREVIEW_CHARACTERS = 180;
 
 /**
- * Build only a small visual prefix of an arbitrary queued prompt. `Array.from`
- * keeps a truncation boundary from splitting a surrogate pair, while the
- * initial slice prevents a multi-megabyte prompt from being copied/scanned in
- * full merely to render a queue row. The durable prompt remains untouched.
+ * Build a bounded head/tail summary of an arbitrary queued prompt. Sampling
+ * both ends distinguishes prompts with equal long prefixes, while `Array.from`
+ * keeps both boundaries from splitting a surrogate pair. Only small slices are
+ * scanned, so a multi-megabyte durable prompt is never copied in full.
  */
 function queuePromptPreview(prompt: string, maxCharacters: number): string {
   const scanned = prompt.slice(0, maxCharacters * 2 + 1);
@@ -69,7 +69,19 @@ function queuePromptPreview(prompt: string, maxCharacters: number): string {
   if (scanned.length === prompt.length && characters.length <= maxCharacters) {
     return prompt;
   }
-  return `${characters.slice(0, maxCharacters).join("").trimEnd()}…`;
+
+  const separator = " … ";
+  const suffixCharacters = Math.min(Math.floor(maxCharacters / 3), 120);
+  const prefixCharacters = maxCharacters - Array.from(separator).length - suffixCharacters;
+  const prefix = Array.from(prompt.slice(0, prefixCharacters * 2 + 1))
+    .slice(0, prefixCharacters)
+    .join("")
+    .trimEnd();
+  const suffix = Array.from(prompt.slice(-(suffixCharacters * 2 + 1)))
+    .slice(-suffixCharacters)
+    .join("")
+    .trimStart();
+  return `${prefix}${separator}${suffix}`;
 }
 
 export function QueueSurface({ queue, composer, readOnly = false }: QueueSurfaceProps) {
@@ -82,7 +94,6 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
     projectedIndex: number;
   } | null>(null);
   const count = queue.queue.length;
-  const collapsedPreviewId = useId();
   const collapsedPreview = useMemo(
     () => queuePromptPreview(queue.queue[0]?.prompt ?? "", QUEUE_COLLAPSED_PREVIEW_CHARACTERS),
     [queue.queue],
@@ -263,7 +274,7 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
           type="button"
           className="flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left outline-none transition-colors hover:bg-surface-2/60 focus-visible:bg-surface-2/60 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/40 pointer-coarse:min-h-11"
           onClick={() => setOpen((value) => !value)}
-          aria-describedby={!open && count > 0 ? collapsedPreviewId : undefined}
+          aria-description={!open && count > 0 ? collapsedPreview : undefined}
           aria-expanded={open}
           aria-label={`${count} queued prompt${count === 1 ? "" : "s"}${readOnly ? " Read-only" : ""}`}
         >
@@ -281,7 +292,7 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
           ) : null}
           {!open && count > 0 ? (
             <span
-              id={collapsedPreviewId}
+              aria-hidden="true"
               className="min-w-0 flex-1 truncate text-xs text-fg-muted"
               data-testid="queue-collapsed-preview"
               dir="auto"
@@ -450,7 +461,7 @@ function QueuePrompt({
         dir="auto"
         role="note"
       >
-        {preview}
+        <span aria-hidden="true">{preview}</span>
       </p>
       <button
         type="button"
@@ -565,7 +576,7 @@ function SortableQueueRow({
       }}
       className={`bg-surface ${sortable.isDragging || keyboardDragging ? "relative z-10 shadow-lg ring-1 ring-brand/40" : ""}`}
     >
-      <div className="grid min-w-0 grid-cols-[auto_auto_minmax(0,1fr)_auto_auto_auto] items-start gap-x-1.5 px-2 py-2 sm:gap-x-2 sm:px-3">
+      <div className="grid min-w-0 grid-cols-[auto_auto_minmax(0,1fr)_auto_auto_auto] items-start gap-x-1.5 px-2 py-1.5 sm:gap-x-2 sm:px-3 sm:py-2">
         <button
           data-queue-handle
           ref={sortable.setActivatorNodeRef}
@@ -583,7 +594,7 @@ function SortableQueueRow({
         <span className="col-start-2 row-start-1 mt-1 shrink-0 font-mono text-2xs text-fg-subtle">
           {index + 1}
         </span>
-        <div className="col-span-full row-start-2 min-w-0 pt-1 sm:col-span-1 sm:col-start-3 sm:row-start-1 sm:pt-0">
+        <div className="col-span-full row-start-2 min-w-0 sm:col-span-1 sm:col-start-3 sm:row-start-1">
           <QueuePrompt prompt={turn.prompt} index={index} onDisclosureChange={onDisclosureChange} />
           <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap text-2xs text-fg-subtle">
             {turn.resources.length > 0 ? (
@@ -606,7 +617,7 @@ function SortableQueueRow({
           onClick={onSteer}
           aria-label={`Steer queued prompt ${index + 1}`}
           title="Make this the next direction"
-          className="col-start-4 row-start-1 inline-flex h-7 shrink-0 items-center justify-center gap-1 rounded-md px-2 text-xs font-medium outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:min-h-11"
+          className="col-start-4 row-start-3 inline-flex h-7 shrink-0 items-center justify-center gap-1 rounded-md px-2 text-xs font-medium outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 sm:row-start-1 pointer-coarse:min-h-11"
         >
           {pending === "steer" ? (
             <Loader2Icon className="size-3.5 animate-spin" />
@@ -621,7 +632,7 @@ function SortableQueueRow({
           onClick={onDelete}
           aria-label={`Delete queued prompt ${index + 1}`}
           title="Delete this queued prompt"
-          className="col-start-5 row-start-1 inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 hover:text-status-failed focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:size-11"
+          className="col-start-5 row-start-3 inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 hover:text-status-failed focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 sm:row-start-1 pointer-coarse:size-11"
         >
           {pending === "delete" ? (
             <Loader2Icon className="size-3.5 animate-spin" />
@@ -635,7 +646,7 @@ function SortableQueueRow({
               type="button"
               disabled={pending !== null}
               aria-label={`More actions for queued prompt ${index + 1}`}
-              className="col-start-6 row-start-1 inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:size-11"
+              className="col-start-6 row-start-3 inline-flex size-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 sm:row-start-1 pointer-coarse:size-11"
             >
               {pending && pending !== "steer" && pending !== "delete" ? (
                 <Loader2Icon className="size-3.5 animate-spin" />

--- a/packages/react/src/components/queue-surface.tsx
+++ b/packages/react/src/components/queue-surface.tsx
@@ -82,6 +82,11 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
     projectedIndex: number;
   } | null>(null);
   const count = queue.queue.length;
+  const collapsedPreviewId = useId();
+  const collapsedPreview = useMemo(
+    () => queuePromptPreview(queue.queue[0]?.prompt ?? "", QUEUE_COLLAPSED_PREVIEW_CHARACTERS),
+    [queue.queue],
+  );
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
 
   const displayedQueue = useMemo(() => {
@@ -258,7 +263,9 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
           type="button"
           className="flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left outline-none transition-colors hover:bg-surface-2/60 focus-visible:bg-surface-2/60 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/40 pointer-coarse:min-h-11"
           onClick={() => setOpen((value) => !value)}
+          aria-describedby={!open && count > 0 ? collapsedPreviewId : undefined}
           aria-expanded={open}
+          aria-label={`${count} queued prompt${count === 1 ? "" : "s"}${readOnly ? " Read-only" : ""}`}
         >
           <ChevronDownIcon
             aria-hidden="true"
@@ -274,12 +281,12 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
           ) : null}
           {!open && count > 0 ? (
             <span
-              aria-hidden="true"
+              id={collapsedPreviewId}
               className="min-w-0 flex-1 truncate text-xs text-fg-muted"
               data-testid="queue-collapsed-preview"
               dir="auto"
             >
-              {queuePromptPreview(queue.queue[0]?.prompt ?? "", QUEUE_COLLAPSED_PREVIEW_CHARACTERS)}
+              {collapsedPreview}
             </span>
           ) : null}
           {queue.loading ? <Loader2Icon className="ml-auto size-3.5 animate-spin" /> : null}
@@ -437,10 +444,11 @@ function QueuePrompt({
   return (
     <div className="min-w-0 max-w-full">
       <p
-        aria-hidden="true"
+        aria-label={`Queued prompt ${index + 1} summary: ${preview}`}
         className="line-clamp-1 max-w-full overflow-hidden whitespace-pre-wrap break-all text-xs leading-5 text-fg [unicode-bidi:plaintext] sm:line-clamp-3"
         data-testid={`queue-prompt-preview-${index + 1}`}
         dir="auto"
+        role="note"
       >
         {preview}
       </p>

--- a/packages/react/src/components/queue-surface.tsx
+++ b/packages/react/src/components/queue-surface.tsx
@@ -65,8 +65,7 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
   } | null>(null);
   const count = queue.queue.length;
   const collapsedPreview = useMemo(
-    () =>
-      queuePromptPreview(queue.queue[0]?.prompt ?? "", QUEUE_COLLAPSED_PREVIEW_CHARACTERS).summary,
+    () => queuePromptPreview(queue.queue[0]?.prompt ?? "", QUEUE_COLLAPSED_PREVIEW_CHARACTERS),
     [queue.queue],
   );
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
@@ -245,7 +244,7 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
           type="button"
           className="flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left outline-none transition-colors hover:bg-surface-2/60 focus-visible:bg-surface-2/60 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/40 pointer-coarse:min-h-11"
           onClick={() => setOpen((value) => !value)}
-          aria-description={!open && count > 0 ? collapsedPreview : undefined}
+          aria-description={!open && count > 0 ? collapsedPreview.summary : undefined}
           aria-expanded={open}
           aria-label={`${count} queued prompt${count === 1 ? "" : "s"}${readOnly ? " Read-only" : ""}`}
         >
@@ -264,11 +263,15 @@ export function QueueSurface({ queue, composer, readOnly = false }: QueueSurface
           {!open && count > 0 ? (
             <span
               aria-hidden="true"
-              className="min-w-0 flex-1 truncate text-xs text-fg-muted"
+              className={`min-w-0 flex-1 truncate text-fg-muted ${
+                collapsedPreview.collapsedVisual === collapsedPreview.summary
+                  ? "text-xs"
+                  : "text-[10px]"
+              }`}
               data-testid="queue-collapsed-preview"
               dir="auto"
             >
-              {collapsedPreview}
+              {collapsedPreview.collapsedVisual}
             </span>
           ) : null}
           {queue.loading ? <Loader2Icon className="ml-auto size-3.5 animate-spin" /> : null}
@@ -419,6 +422,8 @@ const QUEUE_PREVIEW_REFERENCE_SAMPLE_CHARACTERS = 32;
 const QUEUE_VISIBLE_END_IDENTITY_CHARACTERS = 18;
 const QUEUE_PREVIEW_SEPARATOR = " … ";
 const queuePreviewSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+const queuePromptNonRenderingCodePoint =
+  /[\p{White_Space}\p{Control}\p{Default_Ignorable_Code_Point}]/u;
 
 type BoundedPromptSample = {
   value: string;
@@ -428,6 +433,7 @@ type BoundedPromptSample = {
 
 type QueuePromptPreview = {
   summary: string;
+  collapsedVisual: string;
   visibleStart: string;
   visibleIdentity: string | null;
   visibleIdentityLabel: "End" | "Safe boundary" | null;
@@ -448,6 +454,7 @@ function queuePromptPreview(prompt: string, maxCharacters: number): QueuePromptP
     return hasVisiblePromptContent(summary)
       ? {
           summary,
+          collapsedVisual: summary,
           visibleStart: summary,
           visibleIdentity: null,
           visibleIdentityLabel: null,
@@ -508,6 +515,7 @@ function queuePromptPreview(prompt: string, maxCharacters: number): QueuePromptP
   if (!hasVisiblePromptContent(prefix)) {
     return {
       summary,
+      collapsedVisual: summary,
       visibleStart: safeSuffix,
       visibleIdentity: null,
       visibleIdentityLabel: null,
@@ -520,6 +528,7 @@ function queuePromptPreview(prompt: string, maxCharacters: number): QueuePromptP
   );
   return {
     summary,
+    collapsedVisual: summary,
     visibleStart: prefix,
     visibleIdentity: hasVisiblePromptContent(endIdentity) ? endIdentity : `ref ${reference}`,
     visibleIdentityLabel: hasVisiblePromptContent(endIdentity) ? "End" : "Safe boundary",
@@ -531,12 +540,15 @@ function fallbackPromptPreview(
   startSample: string,
   endSample: string,
 ): QueuePromptPreview {
-  const summary = promptPreviewFallbackLabel(
-    boundedPromptSampleReference(promptLength, startSample, endSample),
-  );
+  const reference = boundedPromptSampleReference(promptLength, startSample, endSample);
+  const summary = promptPreviewFallbackLabel(reference);
   return {
     summary,
-    visibleStart: summary,
+    collapsedVisual: `Omitted · ${reference}`,
+    // The complete fallback remains the canonical accessible summary. Narrow
+    // collapsed/row layouts paint the bounded reference in a compact truthful
+    // form so ellipsis cannot hide the only identifying portion.
+    visibleStart: `Omitted · ${reference}`,
     visibleIdentity: null,
     visibleIdentityLabel: null,
   };
@@ -566,7 +578,13 @@ function boundedPromptSampleReference(
 }
 
 function hasVisiblePromptContent(value: string): boolean {
-  return value.trim().length > 0;
+  // Callers pass only the already-bounded whole/head/tail preview samples.
+  // Default-ignorables and controls can survive trim() while painting no row
+  // identity at all (for example ZWJ, VS16, bidi controls, and tag characters).
+  for (const character of value) {
+    if (!queuePromptNonRenderingCodePoint.test(character)) return true;
+  }
+  return false;
 }
 
 function samplePromptStart(prompt: string, maxCharacters: number): BoundedPromptSample {

--- a/packages/react/test/queue-surface.test.tsx
+++ b/packages/react/test/queue-surface.test.tsx
@@ -6,6 +6,12 @@ import type { ComposerState } from "../src/hooks/use-composer";
 import type { UseTurnQueueResult } from "../src/hooks/use-turn-queue";
 import { fakeTurn } from "./fake-client";
 import { registerDom, renderComponent, type RenderedComponent } from "./render-hook";
+import {
+  QUEUE_BOUNDARY_CLUSTERS,
+  queueBoundaryPrompt,
+  queueBoundarySummary,
+  type QueueBoundaryMaximum,
+} from "../demo/queue-fixtures";
 
 registerDom();
 
@@ -81,6 +87,68 @@ async function click(target: Element | null): Promise<void> {
     (target as HTMLElement).click();
     await Promise.resolve();
   });
+}
+
+async function renderedPromptSummary(
+  prompt: string,
+  maxCharacters: QueueBoundaryMaximum,
+): Promise<{ accessibleSummary: string; summary: string }> {
+  mounted = await renderComponent(
+    <QueueSurface
+      queue={queue({
+        queue: [
+          fakeTurn({
+            id: "33333333-3333-4333-8333-333333333333",
+            prompt,
+          }),
+        ],
+      })}
+      composer={composer()}
+    />,
+  );
+
+  let summaryElement: Element | null;
+  let accessibleSummary: string;
+  if (maxCharacters === 180) {
+    summaryElement = mounted.container.querySelector('[data-testid="queue-collapsed-preview"]');
+    accessibleSummary =
+      mounted.container
+        .querySelector('button[aria-label="1 queued prompt"]')
+        ?.getAttribute("aria-description") ?? "";
+  } else {
+    await click(mounted.container.querySelector('button[aria-expanded="false"]'));
+    summaryElement = mounted.container.querySelector('[data-testid="queue-prompt-preview-1"]');
+    accessibleSummary = (summaryElement?.getAttribute("aria-label") ?? "").replace(
+      /^Queued prompt 1 summary: /,
+      "",
+    );
+  }
+  const summary = summaryElement?.textContent ?? "";
+
+  const current = mounted;
+  mounted = null;
+  await current.unmount();
+  document.body.replaceChildren();
+  return { accessibleSummary, summary };
+}
+
+function isWellFormedUnicode(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const current = value.charCodeAt(index);
+    if (current >= 0xd800 && current <= 0xdbff) {
+      if (
+        index + 1 >= value.length ||
+        value.charCodeAt(index + 1) < 0xdc00 ||
+        value.charCodeAt(index + 1) > 0xdfff
+      ) {
+        return false;
+      }
+      index += 1;
+    } else if (current >= 0xdc00 && current <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
 }
 
 describe("QueueSurface", () => {
@@ -195,6 +263,116 @@ describe("QueueSurface", () => {
     await click(disclosure);
     expect(mounted.container.querySelector('[data-testid="queue-prompt-full-1"]')).toBeNull();
     expect(mounted.container.textContent).toContain("Full content for queued prompt 1 hidden.");
+  });
+
+  test("backs off whole graphemes at both preview cuts and both strict bounds", async () => {
+    for (const maxCharacters of [180, 360] as const) {
+      for (const edge of ["head", "tail"] as const) {
+        for (const clusterName of Object.keys(QUEUE_BOUNDARY_CLUSTERS) as Array<
+          keyof typeof QUEUE_BOUNDARY_CLUSTERS
+        >) {
+          const { accessibleSummary, summary } = await renderedPromptSummary(
+            queueBoundaryPrompt(maxCharacters, edge, clusterName),
+            maxCharacters,
+          );
+          expect(summary).toBe(queueBoundarySummary(maxCharacters, edge));
+          expect(accessibleSummary).toBe(summary);
+          expect(Array.from(summary)).toHaveLength(maxCharacters - 1);
+          expect(Array.from(summary).length).toBeLessThanOrEqual(maxCharacters);
+          expect(isWellFormedUnicode(summary)).toBe(true);
+        }
+      }
+    }
+  });
+
+  test("sanitizes malformed summaries but discloses the exact durable source", async () => {
+    const prompt = `${"a".repeat(116)}\ud800${"x".repeat(500)}\udc00${"z".repeat(59)}`;
+    const state = queue({
+      queue: [
+        fakeTurn({
+          id: "33333333-3333-4333-8333-333333333333",
+          prompt,
+        }),
+      ],
+    });
+    mounted = await renderComponent(<QueueSurface queue={state} composer={composer()} />);
+
+    const collapsed = mounted.container.querySelector('[data-testid="queue-collapsed-preview"]');
+    expect(collapsed?.textContent).toContain("�");
+    expect(isWellFormedUnicode(collapsed?.textContent ?? "")).toBe(true);
+
+    await click(mounted.container.querySelector('button[aria-expanded="false"]'));
+    const preview = mounted.container.querySelector('[data-testid="queue-prompt-preview-1"]');
+    expect(preview?.textContent).toContain("�");
+    expect(isWellFormedUnicode(preview?.textContent ?? "")).toBe(true);
+    expect(preview?.getAttribute("aria-label")).toBe(
+      `Queued prompt 1 summary: ${preview?.textContent}`,
+    );
+
+    await click(
+      mounted.container.querySelector('button[aria-label="Show full content for queued prompt 1"]'),
+    );
+    expect(
+      mounted.container.querySelector('[data-testid="queue-prompt-full-1"]')?.textContent,
+    ).toBe(prompt);
+  });
+
+  test("bounds grapheme segmentation work for huge pathological clusters", async () => {
+    const prototype = Intl.Segmenter.prototype;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(prototype, "segment");
+    const originalSegment = prototype.segment;
+    const observedInputLengths: number[] = [];
+    Object.defineProperty(prototype, "segment", {
+      configurable: true,
+      writable: true,
+      value(this: Intl.Segmenter, input: string) {
+        if (input.length > 800) throw new Error(`unbounded queue preview segment: ${input.length}`);
+        observedInputLengths.push(input.length);
+        return originalSegment.call(this, input);
+      },
+    });
+
+    try {
+      const longMarks = "\u0301".repeat(500_000);
+      const regionalIndicator = String.fromCodePoint(0x1f1e6);
+      const prompts = [
+        `${"a".repeat(116)}e${longMarks}${"x".repeat(500_000)}${"z".repeat(120)}`,
+        `${"a".repeat(237)}${"x".repeat(500_000)}e${longMarks}`,
+        `${"a".repeat(237)}${"x".repeat(500_000)}${regionalIndicator.repeat(
+          100,
+        )}${"z".repeat(100)}`,
+      ];
+      const summaries: string[] = [];
+      for (const prompt of prompts) {
+        const { accessibleSummary, summary } = await renderedPromptSummary(prompt, 360);
+        expect(accessibleSummary).toBe(summary);
+        expect(Array.from(summary).length).toBeLessThanOrEqual(360);
+        expect(isWellFormedUnicode(summary)).toBe(true);
+        summaries.push(summary);
+      }
+      expect(summaries[2]).toBe(`${"a".repeat(237)} … ${"z".repeat(100)}`);
+      expect(summaries[2]).not.toContain(regionalIndicator);
+
+      for (const maxCharacters of [180, 360] as const) {
+        const suffixCharacters = maxCharacters / 3;
+        const prefixCharacters = maxCharacters - 3 - suffixCharacters;
+        const locallyRetainableFragment = `👩${"\u200d👩".repeat((suffixCharacters - 4) / 2)}`;
+        const oversizedCluster = `👩${"\u0301".repeat(33)}\u200d${locallyRetainableFragment}`;
+        const { accessibleSummary, summary } = await renderedPromptSummary(
+          `${"a".repeat(prefixCharacters)}${"x".repeat(500_000)}${oversizedCluster}zz`,
+          maxCharacters,
+        );
+        expect(summary).toBe(`${"a".repeat(prefixCharacters)} … zz`);
+        expect(accessibleSummary).toBe(summary);
+        expect(summary).not.toContain("👩");
+        expect(summary).not.toContain("\u200d");
+      }
+    } finally {
+      if (originalDescriptor) Object.defineProperty(prototype, "segment", originalDescriptor);
+    }
+
+    expect(observedInputLengths.length).toBeGreaterThan(0);
+    expect(Math.max(...observedInputLengths)).toBeLessThanOrEqual(538);
   });
 
   test("keeps a 100-row queue inside one bounded scroll region", async () => {

--- a/packages/react/test/queue-surface.test.tsx
+++ b/packages/react/test/queue-surface.test.tsx
@@ -127,6 +127,94 @@ describe("QueueSurface", () => {
     expect(mounted.container.textContent).toContain("second queued prompt");
   });
 
+  test("bounds hostile prompt previews and discloses the exact source only on demand", async () => {
+    const prompt = [
+      "# Multiline prompt 👩🏽‍💻",
+      "```sh",
+      `curl https://example.test/${"unbroken".repeat(300)}`,
+      "```",
+      `Bidirectional source: ${String.fromCodePoint(0x202e)}isolated${String.fromCodePoint(0x202c)}`,
+      "Exact trailing line.",
+    ].join("\n");
+    const state = queue({
+      queue: [
+        fakeTurn({
+          id: "33333333-3333-4333-8333-333333333333",
+          prompt,
+        }),
+      ],
+    });
+    mounted = await renderComponent(<QueueSurface queue={state} composer={composer()} />);
+
+    const collapsed = mounted.container.querySelector('[data-testid="queue-collapsed-preview"]');
+    expect(collapsed?.getAttribute("aria-hidden")).toBe("true");
+    expect(collapsed?.textContent?.endsWith("…")).toBe(true);
+    expect(collapsed?.textContent).not.toBe(prompt);
+
+    await click(mounted.container.querySelector('button[aria-expanded="false"]'));
+    const preview = mounted.container.querySelector('[data-testid="queue-prompt-preview-1"]');
+    expect(preview?.classList.contains("line-clamp-1")).toBe(true);
+    expect(preview?.classList.contains("sm:line-clamp-3")).toBe(true);
+    expect(preview?.classList.contains("break-all")).toBe(true);
+    expect(preview?.getAttribute("aria-hidden")).toBe("true");
+    expect(preview?.getAttribute("dir")).toBe("auto");
+    expect(preview?.textContent?.endsWith("…")).toBe(true);
+    expect(preview?.textContent).not.toBe(prompt);
+    expect(mounted.container.querySelector('[data-testid="queue-prompt-full-1"]')).toBeNull();
+
+    const disclosure = mounted.container.querySelector(
+      'button[aria-label="Show full content for queued prompt 1"]',
+    );
+    await click(disclosure);
+    expect(disclosure?.getAttribute("aria-expanded")).toBe("true");
+
+    const full = mounted.container.querySelector('[data-testid="queue-prompt-full-1"]');
+    expect(full?.textContent).toBe(prompt);
+    expect(full?.getAttribute("role")).toBe("region");
+    expect(full?.getAttribute("aria-label")).toBe("Full content for queued prompt 1");
+    expect(full?.getAttribute("tabindex")).toBe("0");
+    expect(full?.getAttribute("dir")).toBe("auto");
+    expect(full?.classList.contains("max-h-64")).toBe(true);
+    expect(full?.classList.contains("max-w-full")).toBe(true);
+    expect(full?.classList.contains("overflow-auto")).toBe(true);
+    expect(full?.classList.contains("whitespace-pre-wrap")).toBe(true);
+    expect(full?.classList.contains("break-all")).toBe(true);
+    expect(mounted.container.textContent).toContain("Full content for queued prompt 1 shown.");
+
+    await click(disclosure);
+    expect(mounted.container.querySelector('[data-testid="queue-prompt-full-1"]')).toBeNull();
+    expect(mounted.container.textContent).toContain("Full content for queued prompt 1 hidden.");
+  });
+
+  test("keeps a 100-row queue inside one bounded scroll region", async () => {
+    const items = Array.from({ length: 100 }, (_, index) =>
+      fakeTurn({
+        id: `${String(index + 1).padStart(8, "0")}-1111-4111-8111-111111111111`,
+        prompt: `${index + 1}: ${"x".repeat(2_000)}`,
+      }),
+    );
+    mounted = await renderComponent(
+      <QueueSurface queue={queue({ queue: items })} composer={composer()} />,
+    );
+
+    await click(mounted.container.querySelector('button[aria-expanded="false"]'));
+    const list = mounted.container.querySelector('[data-testid="queue-list"]');
+    expect(list?.className).toContain("max-h-[min(30rem,60dvh)]");
+    expect(list?.classList.contains("overflow-y-auto")).toBe(true);
+    expect(list?.classList.contains("overscroll-contain")).toBe(true);
+    expect(
+      mounted.container.querySelectorAll('[data-testid^="queue-prompt-preview-"]'),
+    ).toHaveLength(100);
+    expect(mounted.container.querySelectorAll('[data-testid^="queue-prompt-full-"]')).toHaveLength(
+      0,
+    );
+    for (const preview of mounted.container.querySelectorAll(
+      '[data-testid^="queue-prompt-preview-"]',
+    )) {
+      expect(Array.from(preview.textContent ?? "").length).toBeLessThanOrEqual(361);
+    }
+  });
+
   test("explains the durable Steer shutdown fence instead of looking stuck in an ordinary queue", async () => {
     mounted = await renderComponent(
       <QueueSurface queue={queue({ stoppingPreviousAttempt: true })} composer={composer()} />,

--- a/packages/react/test/queue-surface.test.tsx
+++ b/packages/react/test/queue-surface.test.tsx
@@ -8,8 +8,10 @@ import { fakeTurn } from "./fake-client";
 import { registerDom, renderComponent, type RenderedComponent } from "./render-hook";
 import {
   QUEUE_BOUNDARY_CLUSTERS,
+  QUEUE_VISIBILITY_PROBE_KINDS,
   queueBoundaryPrompt,
   queueBoundarySummary,
+  queueVisibilityProbePrompt,
   type QueueBoundaryMaximum,
 } from "../demo/queue-fixtures";
 
@@ -92,7 +94,7 @@ async function click(target: Element | null): Promise<void> {
 async function renderedPromptSummary(
   prompt: string,
   maxCharacters: QueueBoundaryMaximum,
-): Promise<{ accessibleSummary: string; summary: string }> {
+): Promise<{ accessibleSummary: string; summary: string; visualSummary: string }> {
   mounted = await renderComponent(
     <QueueSurface
       queue={queue({
@@ -123,13 +125,14 @@ async function renderedPromptSummary(
       "",
     );
   }
-  const summary = maxCharacters === 180 ? (summaryElement?.textContent ?? "") : accessibleSummary;
+  const visualSummary = summaryElement?.textContent ?? "";
+  const summary = accessibleSummary;
 
   const current = mounted;
   mounted = null;
   await current.unmount();
   document.body.replaceChildren();
-  return { accessibleSummary, summary };
+  return { accessibleSummary, summary, visualSummary };
 }
 
 function isWellFormedUnicode(value: string): boolean {
@@ -349,6 +352,7 @@ describe("QueueSurface", () => {
         `${"a".repeat(237)}${"x".repeat(500_000)}${regionalIndicator.repeat(
           100,
         )}${"z".repeat(100)}`,
+        "\u200d".repeat(500_000),
       ];
       const summaries: string[] = [];
       for (const prompt of prompts) {
@@ -360,6 +364,7 @@ describe("QueueSurface", () => {
       }
       expect(summaries[2]).toBe(`${"a".repeat(237)} … ${"z".repeat(100)}`);
       expect(summaries[2]).not.toContain(regionalIndicator);
+      expect(summaries[3]).toMatch(/^Content omitted at safe boundary · ref [0-9A-F]{8}$/);
 
       for (const maxCharacters of [180, 360] as const) {
         const suffixCharacters = maxCharacters / 3;
@@ -417,13 +422,110 @@ describe("QueueSurface", () => {
     );
     await click(mounted.container.querySelector('button[aria-expanded="false"]'));
     const preview = mounted.container.querySelector('[data-testid="queue-prompt-preview-1"]');
-    expect(preview?.textContent).toMatch(/^Content omitted at safe boundary · ref [0-9A-F]{8}$/);
+    const namedSummary = (preview?.getAttribute("aria-label") ?? "").replace(
+      /^Queued prompt 1 summary: /,
+      "",
+    );
+    expect(namedSummary).toMatch(/^Content omitted at safe boundary · ref [0-9A-F]{8}$/);
+    expect(preview?.textContent).toMatch(/^Omitted · [0-9A-F]{8}$/);
+    expect(namedSummary.endsWith(preview?.textContent?.replace("Omitted · ", "") ?? "")).toBe(true);
     await click(
       mounted.container.querySelector('button[aria-label="Show full content for queued prompt 1"]'),
     );
     expect(
       mounted.container.querySelector('[data-testid="queue-prompt-full-1"]')?.textContent,
     ).toBe(oversizedZwjCluster);
+  });
+
+  test("falls back for short non-painting prompts while retaining mixed visible content", async () => {
+    const nonPaintingKinds = QUEUE_VISIBILITY_PROBE_KINDS.filter(
+      (kind) => kind !== "mixed-visible",
+    );
+    const fallbackSummaries = new Set<string>();
+
+    for (const kind of nonPaintingKinds) {
+      const prompt = queueVisibilityProbePrompt(kind);
+      const summaries: string[] = [];
+      for (const maxCharacters of [180, 360] as const) {
+        const { accessibleSummary, summary } = await renderedPromptSummary(prompt, maxCharacters);
+        expect(summary).toMatch(/^Content omitted at safe boundary · ref [0-9A-F]{8}$/);
+        expect(Array.from(summary).length).toBeLessThanOrEqual(maxCharacters);
+        expect(isWellFormedUnicode(summary)).toBe(true);
+        expect(accessibleSummary).toBe(summary);
+        summaries.push(summary);
+      }
+      expect(summaries[0]).toBe(summaries[1]);
+      fallbackSummaries.add(summaries[0] ?? "");
+    }
+    expect(fallbackSummaries.size).toBe(nonPaintingKinds.length);
+
+    const mixedPrompt = queueVisibilityProbePrompt("mixed-visible");
+    for (const maxCharacters of [180, 360] as const) {
+      const { accessibleSummary, summary } = await renderedPromptSummary(
+        mixedPrompt,
+        maxCharacters,
+      );
+      expect(summary).toBe(mixedPrompt);
+      expect(summary).toContain("Visible identity 😀");
+      expect(summary).not.toContain("Content omitted at safe boundary");
+      expect(accessibleSummary).toBe(summary);
+    }
+
+    const prompts = nonPaintingKinds.map(queueVisibilityProbePrompt);
+    mounted = await renderComponent(
+      <QueueSurface
+        queue={queue({
+          queue: prompts.map((prompt, index) =>
+            fakeTurn({
+              id: `${String(index + 1).padStart(8, "0")}-3333-4333-8333-333333333333`,
+              prompt,
+            }),
+          ),
+        })}
+        composer={composer()}
+      />,
+    );
+    const collapsedToggle = mounted.container.querySelector(
+      'button[aria-label="6 queued prompts"]',
+    );
+    const collapsedVisual = mounted.container.querySelector(
+      '[data-testid="queue-collapsed-preview"]',
+    );
+    expect(collapsedToggle?.getAttribute("aria-description")).toMatch(
+      /^Content omitted at safe boundary · ref [0-9A-F]{8}$/,
+    );
+    expect(collapsedVisual?.textContent).toMatch(/^Omitted · [0-9A-F]{8}$/);
+    expect(
+      collapsedToggle
+        ?.getAttribute("aria-description")
+        ?.endsWith(collapsedVisual?.textContent?.replace("Omitted · ", "") ?? ""),
+    ).toBe(true);
+    await click(mounted.container.querySelector('button[aria-expanded="false"]'));
+    for (const [index, prompt] of prompts.entries()) {
+      const ordinal = index + 1;
+      const preview = mounted.container.querySelector(
+        `[data-testid="queue-prompt-preview-${ordinal}"]`,
+      );
+      expect(preview?.getAttribute("aria-label")).toMatch(
+        new RegExp(`^Queued prompt ${ordinal} summary: Content omitted at safe boundary · ref `),
+      );
+      expect(preview?.textContent).toMatch(/^Omitted · [0-9A-F]{8}$/);
+      expect(
+        preview
+          ?.getAttribute("aria-label")
+          ?.endsWith(preview?.textContent?.replace("Omitted · ", "") ?? ""),
+      ).toBe(true);
+      expect(preview?.textContent).not.toContain(prompt);
+      await click(
+        mounted.container.querySelector(
+          `button[aria-label="Show full content for queued prompt ${ordinal}"]`,
+        ),
+      );
+      expect(
+        mounted.container.querySelector(`[data-testid="queue-prompt-full-${ordinal}"]`)
+          ?.textContent,
+      ).toBe(prompt);
+    }
   });
 
   test("keeps a 100-row queue inside one bounded scroll region", async () => {

--- a/packages/react/test/queue-surface.test.tsx
+++ b/packages/react/test/queue-surface.test.tsx
@@ -148,12 +148,13 @@ describe("QueueSurface", () => {
 
     const collapsed = mounted.container.querySelector('[data-testid="queue-collapsed-preview"]');
     const collapsedToggle = mounted.container.querySelector('button[aria-expanded="false"]');
-    expect(collapsed?.getAttribute("aria-hidden")).toBeNull();
-    expect(collapsed?.id).not.toBe("");
-    expect(collapsedToggle?.getAttribute("aria-describedby")).toBe(collapsed?.id);
+    expect(collapsed?.getAttribute("aria-hidden")).toBe("true");
+    expect(collapsedToggle?.getAttribute("aria-description")).toBe(collapsed?.textContent);
+    expect(collapsedToggle?.getAttribute("aria-describedby")).toBeNull();
     expect(collapsedToggle?.getAttribute("aria-label")).toBe("1 queued prompt");
-    expect(collapsed?.textContent?.endsWith("…")).toBe(true);
-    expect(Array.from(collapsed?.textContent ?? "")).toHaveLength(181);
+    expect(collapsed?.textContent).toContain(" … ");
+    expect(collapsed?.textContent).toContain("Exact trailing line.");
+    expect(Array.from(collapsed?.textContent ?? "").length).toBeLessThanOrEqual(180);
     expect(collapsed?.textContent).not.toBe(prompt);
 
     await click(collapsedToggle);
@@ -164,12 +165,12 @@ describe("QueueSurface", () => {
     expect(preview?.getAttribute("aria-hidden")).toBeNull();
     expect(preview?.getAttribute("role")).toBe("note");
     expect(preview?.getAttribute("dir")).toBe("auto");
-    expect(preview?.textContent?.endsWith("…")).toBe(true);
+    expect(preview?.textContent).toContain(" … ");
+    expect(preview?.querySelector('[aria-hidden="true"]')?.textContent).toBe(preview?.textContent);
     expect(preview?.textContent).not.toBe(prompt);
     expect(preview?.getAttribute("aria-label")).toBe(
       `Queued prompt 1 summary: ${preview?.textContent}`,
     );
-    expect(preview?.getAttribute("aria-label")).not.toContain("Exact trailing line.");
     expect(mounted.container.querySelector('[data-testid="queue-prompt-full-1"]')).toBeNull();
 
     const disclosure = mounted.container.querySelector(
@@ -197,13 +198,16 @@ describe("QueueSurface", () => {
   });
 
   test("keeps a 100-row queue inside one bounded scroll region", async () => {
-    const items = Array.from({ length: 100 }, (_, index) => {
-      const leading = `${index + 1}: `;
-      return fakeTurn({
+    const sharedPrefix = `${"x".repeat(236)}😀${"x".repeat(1_800)}`;
+    const items = Array.from({ length: 100 }, (_, index) =>
+      fakeTurn({
         id: `${String(index + 1).padStart(8, "0")}-1111-4111-8111-111111111111`,
-        prompt: `${leading}${"x".repeat(360 - Array.from(leading).length - 1)}😀tail${"y".repeat(2_000)}`,
-      });
-    });
+        prompt: `${sharedPrefix}\nQueued destination fingerprint: ${String(index + 1).padStart(3, "0")} 😀`,
+      }),
+    );
+    expect(new Set(items.map((turn) => Array.from(turn.prompt).slice(0, 500).join(""))).size).toBe(
+      1,
+    );
     mounted = await renderComponent(
       <QueueSurface queue={queue({ queue: items })} composer={composer()} />,
     );
@@ -219,16 +223,23 @@ describe("QueueSurface", () => {
     expect(mounted.container.querySelectorAll('[data-testid^="queue-prompt-full-"]')).toHaveLength(
       0,
     );
+    const accessibleContent = new Set<string>();
+    let index = 0;
     for (const preview of mounted.container.querySelectorAll(
       '[data-testid^="queue-prompt-preview-"]',
     )) {
-      expect(Array.from(preview.textContent ?? "").length).toBeLessThanOrEqual(361);
-      expect(preview.textContent?.endsWith("😀…")).toBe(true);
+      expect(Array.from(preview.textContent ?? "").length).toBeLessThanOrEqual(360);
+      expect(preview.textContent).toContain("😀 … ");
+      expect(preview.textContent?.endsWith(`${String(index + 1).padStart(3, "0")} 😀`)).toBe(true);
       const label = preview.getAttribute("aria-label") ?? "";
       expect(label).toContain(" summary: ");
       expect(label.endsWith(preview.textContent ?? "")).toBe(true);
       expect(label.length).toBeLessThan(410);
+      expect(preview.querySelector('[aria-hidden="true"]')?.textContent).toBe(preview.textContent);
+      accessibleContent.add(label.replace(/^Queued prompt \d+ summary: /, ""));
+      index += 1;
     }
+    expect(accessibleContent.size).toBe(100);
   });
 
   test("explains the durable Steer shutdown fence instead of looking stuck in an ordinary queue", async () => {

--- a/packages/react/test/queue-surface.test.tsx
+++ b/packages/react/test/queue-surface.test.tsx
@@ -147,19 +147,29 @@ describe("QueueSurface", () => {
     mounted = await renderComponent(<QueueSurface queue={state} composer={composer()} />);
 
     const collapsed = mounted.container.querySelector('[data-testid="queue-collapsed-preview"]');
-    expect(collapsed?.getAttribute("aria-hidden")).toBe("true");
+    const collapsedToggle = mounted.container.querySelector('button[aria-expanded="false"]');
+    expect(collapsed?.getAttribute("aria-hidden")).toBeNull();
+    expect(collapsed?.id).not.toBe("");
+    expect(collapsedToggle?.getAttribute("aria-describedby")).toBe(collapsed?.id);
+    expect(collapsedToggle?.getAttribute("aria-label")).toBe("1 queued prompt");
     expect(collapsed?.textContent?.endsWith("…")).toBe(true);
+    expect(Array.from(collapsed?.textContent ?? "")).toHaveLength(181);
     expect(collapsed?.textContent).not.toBe(prompt);
 
-    await click(mounted.container.querySelector('button[aria-expanded="false"]'));
+    await click(collapsedToggle);
     const preview = mounted.container.querySelector('[data-testid="queue-prompt-preview-1"]');
     expect(preview?.classList.contains("line-clamp-1")).toBe(true);
     expect(preview?.classList.contains("sm:line-clamp-3")).toBe(true);
     expect(preview?.classList.contains("break-all")).toBe(true);
-    expect(preview?.getAttribute("aria-hidden")).toBe("true");
+    expect(preview?.getAttribute("aria-hidden")).toBeNull();
+    expect(preview?.getAttribute("role")).toBe("note");
     expect(preview?.getAttribute("dir")).toBe("auto");
     expect(preview?.textContent?.endsWith("…")).toBe(true);
     expect(preview?.textContent).not.toBe(prompt);
+    expect(preview?.getAttribute("aria-label")).toBe(
+      `Queued prompt 1 summary: ${preview?.textContent}`,
+    );
+    expect(preview?.getAttribute("aria-label")).not.toContain("Exact trailing line.");
     expect(mounted.container.querySelector('[data-testid="queue-prompt-full-1"]')).toBeNull();
 
     const disclosure = mounted.container.querySelector(
@@ -187,12 +197,13 @@ describe("QueueSurface", () => {
   });
 
   test("keeps a 100-row queue inside one bounded scroll region", async () => {
-    const items = Array.from({ length: 100 }, (_, index) =>
-      fakeTurn({
+    const items = Array.from({ length: 100 }, (_, index) => {
+      const leading = `${index + 1}: `;
+      return fakeTurn({
         id: `${String(index + 1).padStart(8, "0")}-1111-4111-8111-111111111111`,
-        prompt: `${index + 1}: ${"x".repeat(2_000)}`,
-      }),
-    );
+        prompt: `${leading}${"x".repeat(360 - Array.from(leading).length - 1)}😀tail${"y".repeat(2_000)}`,
+      });
+    });
     mounted = await renderComponent(
       <QueueSurface queue={queue({ queue: items })} composer={composer()} />,
     );
@@ -212,6 +223,11 @@ describe("QueueSurface", () => {
       '[data-testid^="queue-prompt-preview-"]',
     )) {
       expect(Array.from(preview.textContent ?? "").length).toBeLessThanOrEqual(361);
+      expect(preview.textContent?.endsWith("😀…")).toBe(true);
+      const label = preview.getAttribute("aria-label") ?? "";
+      expect(label).toContain(" summary: ");
+      expect(label.endsWith(preview.textContent ?? "")).toBe(true);
+      expect(label.length).toBeLessThan(410);
     }
   });
 

--- a/packages/react/test/queue-surface.test.tsx
+++ b/packages/react/test/queue-surface.test.tsx
@@ -123,7 +123,7 @@ async function renderedPromptSummary(
       "",
     );
   }
-  const summary = summaryElement?.textContent ?? "";
+  const summary = maxCharacters === 180 ? (summaryElement?.textContent ?? "") : accessibleSummary;
 
   const current = mounted;
   mounted = null;
@@ -227,18 +227,24 @@ describe("QueueSurface", () => {
 
     await click(collapsedToggle);
     const preview = mounted.container.querySelector('[data-testid="queue-prompt-preview-1"]');
-    expect(preview?.classList.contains("line-clamp-1")).toBe(true);
-    expect(preview?.classList.contains("sm:line-clamp-3")).toBe(true);
-    expect(preview?.classList.contains("break-all")).toBe(true);
+    const visibleStart = preview?.querySelector('[data-testid="queue-prompt-start-1"]');
+    const visibleIdentity = preview?.querySelector('[data-testid="queue-prompt-identity-1"]');
+    expect(visibleStart?.classList.contains("line-clamp-1")).toBe(true);
+    expect(visibleStart?.classList.contains("sm:line-clamp-2")).toBe(true);
+    expect(visibleStart?.classList.contains("break-all")).toBe(true);
     expect(preview?.getAttribute("aria-hidden")).toBeNull();
     expect(preview?.getAttribute("role")).toBe("note");
     expect(preview?.getAttribute("dir")).toBe("auto");
-    expect(preview?.textContent).toContain(" … ");
+    const namedSummary = (preview?.getAttribute("aria-label") ?? "").replace(
+      /^Queued prompt 1 summary: /,
+      "",
+    );
+    expect(namedSummary).toContain(" … ");
+    expect(namedSummary).toContain("Exact trailing line.");
+    expect(visibleIdentity?.textContent).toBe("act trailing line.");
     expect(preview?.querySelector('[aria-hidden="true"]')?.textContent).toBe(preview?.textContent);
     expect(preview?.textContent).not.toBe(prompt);
-    expect(preview?.getAttribute("aria-label")).toBe(
-      `Queued prompt 1 summary: ${preview?.textContent}`,
-    );
+    expect(preview?.getAttribute("aria-label")).toBe(`Queued prompt 1 summary: ${namedSummary}`);
     expect(mounted.container.querySelector('[data-testid="queue-prompt-full-1"]')).toBeNull();
 
     const disclosure = mounted.container.querySelector(
@@ -303,11 +309,13 @@ describe("QueueSurface", () => {
 
     await click(mounted.container.querySelector('button[aria-expanded="false"]'));
     const preview = mounted.container.querySelector('[data-testid="queue-prompt-preview-1"]');
-    expect(preview?.textContent).toContain("�");
-    expect(isWellFormedUnicode(preview?.textContent ?? "")).toBe(true);
-    expect(preview?.getAttribute("aria-label")).toBe(
-      `Queued prompt 1 summary: ${preview?.textContent}`,
+    const namedSummary = (preview?.getAttribute("aria-label") ?? "").replace(
+      /^Queued prompt 1 summary: /,
+      "",
     );
+    expect(namedSummary).toContain("�");
+    expect(isWellFormedUnicode(namedSummary)).toBe(true);
+    expect(preview?.getAttribute("aria-label")).toBe(`Queued prompt 1 summary: ${namedSummary}`);
 
     await click(
       mounted.container.querySelector('button[aria-label="Show full content for queued prompt 1"]'),
@@ -375,6 +383,49 @@ describe("QueueSurface", () => {
     expect(Math.max(...observedInputLengths)).toBeLessThanOrEqual(538);
   });
 
+  test("uses a bounded truthful fallback when no complete visible grapheme can be sampled", async () => {
+    const oversizedCombiningCluster = `e${"\u0301".repeat(10_000)}`;
+    const oversizedZwjCluster = `👩${"\u200d👩".repeat(1_000)}`;
+    const prompts = [" \n\t ", " ".repeat(2_000), oversizedCombiningCluster, oversizedZwjCluster];
+
+    for (const prompt of prompts) {
+      const summaries: string[] = [];
+      for (const maxCharacters of [180, 360] as const) {
+        const { accessibleSummary, summary } = await renderedPromptSummary(prompt, maxCharacters);
+        expect(summary).toMatch(/^Content omitted at safe boundary · ref [0-9A-F]{8}$/);
+        expect(summary).not.toBe(" … ");
+        expect(Array.from(summary).length).toBeLessThanOrEqual(maxCharacters);
+        expect(isWellFormedUnicode(summary)).toBe(true);
+        expect(accessibleSummary).toBe(summary);
+        summaries.push(summary);
+      }
+      expect(summaries[0]).toBe(summaries[1]);
+    }
+
+    mounted = await renderComponent(
+      <QueueSurface
+        queue={queue({
+          queue: [
+            fakeTurn({
+              id: "33333333-3333-4333-8333-333333333333",
+              prompt: oversizedZwjCluster,
+            }),
+          ],
+        })}
+        composer={composer()}
+      />,
+    );
+    await click(mounted.container.querySelector('button[aria-expanded="false"]'));
+    const preview = mounted.container.querySelector('[data-testid="queue-prompt-preview-1"]');
+    expect(preview?.textContent).toMatch(/^Content omitted at safe boundary · ref [0-9A-F]{8}$/);
+    await click(
+      mounted.container.querySelector('button[aria-label="Show full content for queued prompt 1"]'),
+    );
+    expect(
+      mounted.container.querySelector('[data-testid="queue-prompt-full-1"]')?.textContent,
+    ).toBe(oversizedZwjCluster);
+  });
+
   test("keeps a 100-row queue inside one bounded scroll region", async () => {
     const sharedPrefix = `${"x".repeat(236)}😀${"x".repeat(1_800)}`;
     const items = Array.from({ length: 100 }, (_, index) =>
@@ -402,22 +453,29 @@ describe("QueueSurface", () => {
       0,
     );
     const accessibleContent = new Set<string>();
+    const visibleIdentities = new Set<string>();
     let index = 0;
     for (const preview of mounted.container.querySelectorAll(
       '[data-testid^="queue-prompt-preview-"]',
     )) {
-      expect(Array.from(preview.textContent ?? "").length).toBeLessThanOrEqual(360);
-      expect(preview.textContent).toContain("😀 … ");
-      expect(preview.textContent?.endsWith(`${String(index + 1).padStart(3, "0")} 😀`)).toBe(true);
       const label = preview.getAttribute("aria-label") ?? "";
       expect(label).toContain(" summary: ");
-      expect(label.endsWith(preview.textContent ?? "")).toBe(true);
       expect(label.length).toBeLessThan(410);
+      const summary = label.replace(/^Queued prompt \d+ summary: /, "");
+      expect(Array.from(summary).length).toBeLessThanOrEqual(360);
+      expect(summary).toContain("😀 … ");
+      expect(summary.endsWith(`${String(index + 1).padStart(3, "0")} 😀`)).toBe(true);
+      const identity = preview.querySelector(
+        `[data-testid="queue-prompt-identity-${index + 1}"]`,
+      )?.textContent;
+      expect(identity).toBe(`fingerprint: ${String(index + 1).padStart(3, "0")} 😀`);
       expect(preview.querySelector('[aria-hidden="true"]')?.textContent).toBe(preview.textContent);
-      accessibleContent.add(label.replace(/^Queued prompt \d+ summary: /, ""));
+      accessibleContent.add(summary);
+      visibleIdentities.add(identity ?? "");
       index += 1;
     }
     expect(accessibleContent.size).toBe(100);
+    expect(visibleIdentities.size).toBe(100);
   });
 
   test("explains the durable Steer shutdown fence instead of looking stuck in an ordinary queue", async () => {

--- a/packages/react/test/queue-surface.test.tsx
+++ b/packages/react/test/queue-surface.test.tsx
@@ -580,6 +580,64 @@ describe("QueueSurface", () => {
     expect(visibleIdentities.size).toBe(100);
   });
 
+  test("keeps exact hostile queue errors in a bounded keyboard scroller beside retry", async () => {
+    const queueFailure = new Error("queue failed");
+    const mutationFailure = new Error(
+      `Mutation failed\nhttps://queue.invalid/${"unbroken".repeat(10_000)}\nRetry safely`,
+    );
+    const calls: string[] = [];
+    mounted = await renderComponent(
+      <QueueSurface
+        queue={queue({
+          error: queueFailure,
+          mutationError: mutationFailure,
+          clearMutationError: () => calls.push("clear"),
+          refresh: async () => {
+            calls.push("refresh");
+          },
+        })}
+        composer={composer()}
+      />,
+    );
+
+    const alert = mounted.container.querySelector('[role="alert"]');
+    const message = mounted.container.querySelector('[data-testid="queue-error-message"]');
+    const retry = mounted.container.querySelector(
+      'button[aria-label="Dismiss queue error and retry"]',
+    );
+    expect(alert?.classList.contains("min-w-0")).toBe(true);
+    expect(alert?.classList.contains("max-w-full")).toBe(true);
+    expect(alert?.classList.contains("flex-wrap")).toBe(true);
+    expect(message?.textContent).toBe(mutationFailure.message);
+    expect(message?.textContent).not.toContain(queueFailure.message);
+    expect(message?.getAttribute("role")).toBe("region");
+    expect(message?.getAttribute("aria-label")).toBe("Queue error details");
+    expect(message?.getAttribute("tabindex")).toBe("0");
+    expect(message?.getAttribute("dir")).toBe("auto");
+    expect(message?.classList.contains("max-h-[min(5rem,20dvh)]")).toBe(true);
+    expect(message?.classList.contains("flex-[1_1_5rem]")).toBe(true);
+    expect(message?.classList.contains("overflow-auto")).toBe(true);
+    expect(message?.classList.contains("whitespace-pre-wrap")).toBe(true);
+    expect(message?.classList.contains("[overflow-wrap:anywhere]")).toBe(true);
+    expect(message?.classList.contains("[unicode-bidi:plaintext]")).toBe(true);
+    expect(retry?.classList.contains("shrink-0")).toBe(true);
+    expect(retry?.classList.contains("self-start")).toBe(true);
+
+    await click(retry);
+    expect(calls).toEqual(["clear", "refresh"]);
+  });
+
+  test("renders queue load errors losslessly when there is no mutation error", async () => {
+    const failure = new Error(`Load failed: ${"Q".repeat(20_000)}`);
+    mounted = await renderComponent(
+      <QueueSurface queue={queue({ error: failure })} composer={composer()} />,
+    );
+
+    expect(
+      mounted.container.querySelector('[data-testid="queue-error-message"]')?.textContent,
+    ).toBe(failure.message);
+  });
+
   test("explains the durable Steer shutdown fence instead of looking stuck in an ordinary queue", async () => {
     mounted = await renderComponent(
       <QueueSurface queue={queue({ stoppingPreviousAttempt: true })} composer={composer()} />,

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -6,6 +6,7 @@ const testFiles =
     ? requestedTestFiles
     : [
         "./test/e2e/browser.e2e.ts",
+        "./test/e2e/queue-surface.browser.e2e.ts",
         "./test/e2e/session-pins.browser.e2e.ts",
         "./test/e2e/workbench.browser.e2e.ts",
       ];

--- a/test/e2e/queue-surface.browser.e2e.ts
+++ b/test/e2e/queue-surface.browser.e2e.ts
@@ -10,6 +10,7 @@ import {
   queueBoundaryPrompt,
   queueBoundarySummary,
   queueFallbackPrompt,
+  queueHarnessError,
   queueHarnessPrompt,
   queuePromptFingerprint,
   queuePromptVisibleIdentity,
@@ -18,6 +19,7 @@ import {
   type QueueBoundaryEdge,
   type QueueBoundaryMaximum,
   type QueueFallbackKind,
+  type QueueHarnessErrorShape,
   type QueueVisibilityProbeKind,
 } from "../../packages/react/demo/queue-fixtures";
 
@@ -171,6 +173,61 @@ type TextResizeReflowEvidence = {
   exactDisclosure: boolean;
 };
 
+type QueueErrorSource = "queue" | "mutation";
+
+type QueueErrorBoxGeometry = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+  clientWidth: number;
+  scrollWidth: number;
+  clientHeight: number;
+  scrollHeight: number;
+  horizontalOverflow: number;
+  verticalOverflow: number;
+  insideViewport: boolean;
+};
+
+type QueueErrorGeometry = {
+  alert: QueueErrorBoxGeometry;
+  message: QueueErrorBoxGeometry;
+  retry: QueueErrorBoxGeometry;
+  surface: QueueErrorBoxGeometry;
+  documentOverflow: number;
+  messageTextInside: boolean;
+  messageInsideAlert: boolean;
+  retryInsideAlert: boolean;
+  messageRetryOverlap: boolean;
+  messageOverflowWrap: string;
+  messageWhiteSpace: string;
+  messageOverflowX: string;
+  messageOverflowY: string;
+  messageDirection: string;
+  alertDirection: string;
+};
+
+type QueueErrorEvidence = {
+  viewport: { width: 320; height: 800 };
+  rootFontSize: "32px";
+  theme: (typeof themes)[number];
+  source: QueueErrorSource;
+  shape: QueueHarnessErrorShape;
+  direction: "ltr" | "rtl";
+  collapsed: QueueErrorGeometry;
+  expanded: QueueErrorGeometry;
+  menu: PortalMenuGeometry;
+  menuOpen: QueueErrorGeometry;
+  keyboardScrollTop: number;
+  axAlertPresent: boolean;
+  axRegionPresent: boolean;
+  axExactMessagePresent: boolean;
+  refreshCount: number;
+  clearMutationErrorCount: number;
+};
+
 describe("queue surface browser acceptance", () => {
   let browser: Browser;
   let demo: StartedProcess;
@@ -179,6 +236,7 @@ describe("queue surface browser acceptance", () => {
   const graphemeBoundaryEvidence: GraphemeBoundaryEvidence[] = [];
   const visibilityEvidence: QueueVisibilityEvidence[] = [];
   const textResizeReflowEvidence: TextResizeReflowEvidence[] = [];
+  const queueErrorEvidence: QueueErrorEvidence[] = [];
   let accessibilityEvidence: BrowserAccessibilityEvidence | null = null;
 
   beforeAll(async () => {
@@ -250,6 +308,10 @@ describe("queue surface browser acceptance", () => {
     await writeFile(
       `${evidenceDir}/text-resize-reflow.json`,
       `${JSON.stringify({ cases: textResizeReflowEvidence }, null, 2)}\n`,
+    );
+    await writeFile(
+      `${evidenceDir}/queue-errors.json`,
+      `${JSON.stringify({ cases: queueErrorEvidence }, null, 2)}\n`,
     );
     await Promise.allSettled([demo?.stop(), browser?.close()]);
   }, 60_000);
@@ -997,6 +1059,156 @@ describe("queue surface browser acceptance", () => {
     }
   }, 60_000);
 
+  test("hostile queue errors stay lossless and bounded at 320px and 200% text", async () => {
+    const viewport = { width: 320, height: 800 } as const;
+    const sources = ["queue", "mutation"] as const satisfies readonly QueueErrorSource[];
+    const shapes = ["unbroken", "multiline"] as const satisfies readonly QueueHarnessErrorShape[];
+
+    for (const theme of themes) {
+      for (const source of sources) {
+        for (const shape of shapes) {
+          const direction = shape === "multiline" ? "rtl" : "ltr";
+          const context = await browser.newContext({
+            viewport,
+            hasTouch: true,
+            isMobile: true,
+            reducedMotion: "reduce",
+          });
+          try {
+            const page = await context.newPage();
+            const diagnostics = observePageFailures(page);
+            const search = new URLSearchParams({
+              count: "1",
+              error: source,
+              errorShape: shape,
+              theme,
+            });
+            await page.goto(`${baseUrl}/queue.html?${search}`, { waitUntil: "networkidle" });
+            await page.addStyleTag({ content: ":root { font-size: 32px !important; }" });
+            await page.evaluate((value) => {
+              document.documentElement.dir = value;
+            }, direction);
+            await page.evaluate(() => document.fonts.ready);
+
+            const exactMessage = queueHarnessError(shape);
+            const message = page.getByRole("region", {
+              name: "Queue error details",
+              exact: true,
+            });
+            const retry = page.getByRole("button", {
+              name: "Dismiss queue error and retry",
+              exact: true,
+            });
+            await message.waitFor();
+            expect(await message.textContent()).toBe(exactMessage);
+
+            const collapsed = await queueErrorGeometry(page);
+            assertBoundedQueueError(collapsed, direction === "ltr");
+            expect(collapsed.message.verticalOverflow).toBeGreaterThan(0);
+            expect(collapsed.message.height).toBeLessThanOrEqual(161);
+            expect(collapsed.retry.width).toBeGreaterThanOrEqual(43);
+            expect(collapsed.retry.height).toBeGreaterThanOrEqual(43);
+            expect(collapsed.messageDirection).toBe("ltr");
+            expect(collapsed.alertDirection).toBe(direction);
+
+            const tree = await chromeAccessibilityTree(page);
+            const axAlertPresent = tree.some((node) => !node.ignored && node.role === "alert");
+            const axRegionPresent = tree.some(
+              (node) =>
+                !node.ignored && node.role === "region" && node.name === "Queue error details",
+            );
+            const axExactMessagePresent = tree.some(
+              (node) => !node.ignored && node.name === exactMessage,
+            );
+            expect(axAlertPresent).toBe(true);
+            expect(axRegionPresent).toBe(true);
+            expect(axExactMessagePresent).toBe(true);
+            await page.screenshot({
+              path: `${evidenceDir}/after-320-${theme}-${source}-${shape}-error-collapsed.png`,
+              animations: "disabled",
+            });
+
+            await page.getByRole("button", { name: "1 queued prompt", exact: true }).click();
+            await message.scrollIntoViewIfNeeded();
+            const expanded = await queueErrorGeometry(page);
+            assertBoundedQueueError(expanded, direction === "ltr");
+            expect(expanded.message.verticalOverflow).toBeGreaterThan(0);
+
+            await page
+              .getByRole("button", { name: "More actions for queued prompt 1", exact: true })
+              .click();
+            const menu = await measurePortalMenu(page, 1);
+            expect(menu.itemCount).toBe(5);
+            expect(menu.insideViewport).toBe(true);
+            expect(menu.itemWidths.every((width) => width > 0 && width <= viewport.width)).toBe(
+              true,
+            );
+            expect(menu.itemHeights.every((height) => height >= 43)).toBe(true);
+            const menuOpen = await queueErrorGeometry(page);
+            assertBoundedQueueError(menuOpen, direction === "ltr");
+            await page.screenshot({
+              path: `${evidenceDir}/after-320-${theme}-${source}-${shape}-error-menu.png`,
+              animations: "disabled",
+            });
+            await page.keyboard.press("Escape");
+
+            await message.focus();
+            expect(await message.evaluate((element) => document.activeElement === element)).toBe(
+              true,
+            );
+            await message.evaluate((element) => {
+              element.scrollTop = 0;
+            });
+            await page.keyboard.press("PageDown");
+            await page.waitForTimeout(50);
+            const keyboardScrollTop = await message.evaluate((element) => element.scrollTop);
+            expect(keyboardScrollTop).toBeGreaterThan(0);
+            await page.keyboard.press("Tab");
+            expect(await retry.evaluate((element) => document.activeElement === element)).toBe(
+              true,
+            );
+            await page.keyboard.press("Enter");
+            await page.getByRole("alert").waitFor({ state: "detached" });
+            const retryCounts = await page.locator("[data-queue-harness]").evaluate((element) => ({
+              refresh: Number((element as HTMLElement).dataset.refreshCount),
+              clearMutationError: Number((element as HTMLElement).dataset.clearMutationErrorCount),
+            }));
+            expect(retryCounts).toEqual({ refresh: 1, clearMutationError: 1 });
+            expect((await pageMetrics(page)).documentOverflow).toBeLessThanOrEqual(1);
+
+            if (source === "queue" && shape === "multiline") {
+              const report = await new AxeBuilder({ page })
+                .withTags(["wcag2a", "wcag2aa"])
+                .analyze();
+              expect(report.violations).toEqual([]);
+            }
+            expect(diagnostics).toEqual([]);
+            queueErrorEvidence.push({
+              viewport,
+              rootFontSize: "32px",
+              theme,
+              source,
+              shape,
+              direction,
+              collapsed,
+              expanded,
+              menu,
+              menuOpen,
+              keyboardScrollTop,
+              axAlertPresent,
+              axRegionPresent,
+              axExactMessagePresent,
+              refreshCount: retryCounts.refresh,
+              clearMutationErrorCount: retryCounts.clearMutationError,
+            });
+          } finally {
+            await context.close();
+          }
+        }
+      }
+    }
+  }, 90_000);
+
   test("Chrome exposes whole graphemes at every head and tail preview boundary", async () => {
     const boundaryViewports = [
       { width: 320, height: 800 },
@@ -1402,6 +1614,106 @@ async function measurePortalMenu(page: Page, index: number): Promise<PortalMenuG
         menuBounds.bottom <= window.innerHeight + 0.5,
     };
   });
+}
+
+async function queueErrorGeometry(page: Page): Promise<QueueErrorGeometry> {
+  return page.evaluate(() => {
+    const alert = document.querySelector<HTMLElement>('[role="alert"]');
+    const message = document.querySelector<HTMLElement>('[data-testid="queue-error-message"]');
+    const retry = document.querySelector<HTMLElement>(
+      'button[aria-label="Dismiss queue error and retry"]',
+    );
+    const surface = document.querySelector<HTMLElement>('[data-testid="queue-surface"]');
+    if (!alert || !message || !retry || !surface) {
+      throw new Error("Queue error geometry requires the alert, message, retry, and surface");
+    }
+
+    const box = (element: HTMLElement): QueueErrorBoxGeometry => {
+      const bounds = element.getBoundingClientRect();
+      return {
+        left: bounds.left,
+        right: bounds.right,
+        top: bounds.top,
+        bottom: bounds.bottom,
+        width: bounds.width,
+        height: bounds.height,
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+        clientHeight: element.clientHeight,
+        scrollHeight: element.scrollHeight,
+        horizontalOverflow: Math.max(0, element.scrollWidth - element.clientWidth),
+        verticalOverflow: Math.max(0, element.scrollHeight - element.clientHeight),
+        insideViewport:
+          bounds.left >= -0.5 &&
+          bounds.right <= window.innerWidth + 0.5 &&
+          bounds.top >= -0.5 &&
+          bounds.bottom <= window.innerHeight + 0.5,
+      };
+    };
+    const inside = (inner: DOMRect, outer: DOMRect) =>
+      inner.left >= outer.left - 0.5 &&
+      inner.right <= outer.right + 0.5 &&
+      inner.top >= outer.top - 0.5 &&
+      inner.bottom <= outer.bottom + 0.5;
+    const alertBounds = alert.getBoundingClientRect();
+    const messageBounds = message.getBoundingClientRect();
+    const retryBounds = retry.getBoundingClientRect();
+    const range = document.createRange();
+    range.selectNodeContents(message);
+    const textBounds = range.getBoundingClientRect();
+    const messageStyles = getComputedStyle(message);
+
+    return {
+      alert: box(alert),
+      message: box(message),
+      retry: box(retry),
+      surface: box(surface),
+      documentOverflow: Math.max(0, document.documentElement.scrollWidth - window.innerWidth),
+      messageTextInside:
+        textBounds.left >= messageBounds.left - 0.5 &&
+        textBounds.right <= messageBounds.right + 0.5,
+      messageInsideAlert: inside(messageBounds, alertBounds),
+      retryInsideAlert: inside(retryBounds, alertBounds),
+      messageRetryOverlap:
+        Math.max(
+          0,
+          Math.min(messageBounds.right, retryBounds.right) -
+            Math.max(messageBounds.left, retryBounds.left),
+        ) > 0.5 &&
+        Math.max(
+          0,
+          Math.min(messageBounds.bottom, retryBounds.bottom) -
+            Math.max(messageBounds.top, retryBounds.top),
+        ) > 0.5,
+      messageOverflowWrap: messageStyles.overflowWrap,
+      messageWhiteSpace: messageStyles.whiteSpace,
+      messageOverflowX: messageStyles.overflowX,
+      messageOverflowY: messageStyles.overflowY,
+      messageDirection: messageStyles.direction,
+      alertDirection: getComputedStyle(alert).direction,
+    };
+  });
+}
+
+function assertBoundedQueueError(
+  geometry: QueueErrorGeometry,
+  requireAggregateTextBounds: boolean,
+): void {
+  expect(geometry.documentOverflow).toBeLessThanOrEqual(1);
+  expect(geometry.alert.horizontalOverflow).toBeLessThanOrEqual(1);
+  expect(geometry.message.horizontalOverflow).toBeLessThanOrEqual(1);
+  expect(geometry.surface.horizontalOverflow).toBeLessThanOrEqual(1);
+  expect(geometry.alert.insideViewport).toBe(true);
+  expect(geometry.message.insideViewport).toBe(true);
+  expect(geometry.retry.insideViewport).toBe(true);
+  if (requireAggregateTextBounds) expect(geometry.messageTextInside).toBe(true);
+  expect(geometry.messageInsideAlert).toBe(true);
+  expect(geometry.retryInsideAlert).toBe(true);
+  expect(geometry.messageRetryOverlap).toBe(false);
+  expect(geometry.messageOverflowWrap).toBe("anywhere");
+  expect(geometry.messageWhiteSpace).toBe("pre-wrap");
+  expect(geometry.messageOverflowX).toBe("auto");
+  expect(geometry.messageOverflowY).toBe("auto");
 }
 
 async function refreshQueue(page: Page): Promise<void> {

--- a/test/e2e/queue-surface.browser.e2e.ts
+++ b/test/e2e/queue-surface.browser.e2e.ts
@@ -6,16 +6,19 @@ import { chromium, type Browser, type Page } from "playwright";
 import { freePort, runCommand, startProcess, type StartedProcess } from "@opengeni/testing";
 import {
   OMITTED_QUEUE_SOURCE_MARKER,
+  QUEUE_VISIBILITY_PROBE_KINDS,
   queueBoundaryPrompt,
   queueBoundarySummary,
   queueFallbackPrompt,
   queueHarnessPrompt,
   queuePromptFingerprint,
   queuePromptVisibleIdentity,
+  queueVisibilityProbePrompt,
   type QueueBoundaryCluster,
   type QueueBoundaryEdge,
   type QueueBoundaryMaximum,
   type QueueFallbackKind,
+  type QueueVisibilityProbeKind,
 } from "../../packages/react/demo/queue-fixtures";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
@@ -107,12 +110,41 @@ type GraphemeBoundaryEvidence = {
   exactDisclosure: boolean;
 };
 
+type TextPaintGeometry = {
+  text: string;
+  elementWidth: number;
+  textWidth: number;
+  textHeight: number;
+  intersectionWidth: number;
+  intersectionHeight: number;
+  fullyVisible: boolean;
+  insideRow: boolean | null;
+  insideViewport: boolean;
+};
+
+type QueueVisibilityEvidence = {
+  viewport: (typeof viewports)[number];
+  theme: (typeof themes)[number];
+  kind: QueueVisibilityProbeKind;
+  usedFallback: boolean;
+  collapsedSummary: string;
+  collapsedVisual: string;
+  collapsedGeometry: TextPaintGeometry;
+  expandedSummary: string;
+  expandedVisual: string;
+  expandedGeometry: TextPaintGeometry;
+  collapsedAccessibleDescription: string;
+  expandedAccessibleName: string;
+  exactDisclosure: boolean;
+};
+
 describe("queue surface browser acceptance", () => {
   let browser: Browser;
   let demo: StartedProcess;
   let baseUrl: string;
   const measurements: BrowserMeasurement[] = [];
   const graphemeBoundaryEvidence: GraphemeBoundaryEvidence[] = [];
+  const visibilityEvidence: QueueVisibilityEvidence[] = [];
   let accessibilityEvidence: BrowserAccessibilityEvidence | null = null;
 
   beforeAll(async () => {
@@ -176,6 +208,10 @@ describe("queue surface browser acceptance", () => {
     await writeFile(
       `${evidenceDir}/grapheme-boundaries.json`,
       `${JSON.stringify({ cases: graphemeBoundaryEvidence }, null, 2)}\n`,
+    );
+    await writeFile(
+      `${evidenceDir}/painted-fallbacks.json`,
+      `${JSON.stringify({ cases: visibilityEvidence }, null, 2)}\n`,
     );
     await Promise.allSettled([demo?.stop(), browser?.close()]);
   }, 60_000);
@@ -567,16 +603,18 @@ describe("queue surface browser acceptance", () => {
         await page.goto(`${baseUrl}/queue.html?count=1&theme=light&fallback=${fallback}`, {
           waitUntil: "networkidle",
         });
-        const collapsedSummary =
+        const collapsedVisual =
           (await page.getByTestId("queue-collapsed-preview").textContent()) ?? "";
-        expect(collapsedSummary).toMatch(/^Content omitted at safe boundary · ref [0-9A-F]{8}$/);
-        expect(Array.from(collapsedSummary).length).toBeLessThanOrEqual(180);
-        expect(isWellFormedUnicode(collapsedSummary)).toBe(true);
+        expect(collapsedVisual).toMatch(/^Omitted · [0-9A-F]{8}$/);
+        expect(Array.from(collapsedVisual).length).toBeLessThanOrEqual(180);
+        expect(isWellFormedUnicode(collapsedVisual)).toBe(true);
         const collapsedTree = await chromeAccessibilityTree(page);
         const collapsedControl = collapsedTree.find(
           (node) => !node.ignored && node.role === "button" && node.name === "1 queued prompt",
         );
-        expect(collapsedControl?.description).toBe(collapsedSummary);
+        const collapsedSummary = collapsedControl?.description ?? "";
+        expect(collapsedSummary).toMatch(/^Content omitted at safe boundary · ref [0-9A-F]{8}$/);
+        expect(collapsedSummary.endsWith(collapsedVisual.replace("Omitted · ", ""))).toBe(true);
 
         await page.getByRole("button", { name: "1 queued prompt", exact: true }).click();
         const preview = page.getByTestId("queue-prompt-preview-1");
@@ -585,7 +623,7 @@ describe("queue surface browser acceptance", () => {
           "",
         );
         expect(expandedSummary).toBe(collapsedSummary);
-        expect(await page.getByTestId("queue-prompt-start-1").textContent()).toBe(collapsedSummary);
+        expect(await page.getByTestId("queue-prompt-start-1").textContent()).toBe(collapsedVisual);
         expect(await page.getByTestId("queue-prompt-identity-1").count()).toBe(0);
         const expandedTree = await chromeAccessibilityTree(page);
         const summaryNode = queueSummaryNodes(expandedTree)[0];
@@ -613,6 +651,7 @@ describe("queue surface browser acceptance", () => {
             })
             .textContent(),
         ).toBe(queueFallbackPrompt(fallback));
+        await page.evaluate(() => document.fonts.ready);
         expect((await pageMetrics(page)).documentOverflow).toBeLessThanOrEqual(1);
       }
       expect(diagnostics).toEqual([]);
@@ -620,6 +659,144 @@ describe("queue surface browser acceptance", () => {
       await context.close();
     }
   }, 30_000);
+
+  test("styled Chrome paints bounded identities for non-rendering prompt code points", async () => {
+    for (const viewport of viewports) {
+      const context = await browser.newContext({
+        viewport,
+        hasTouch: viewport.width <= 768,
+        isMobile: viewport.width <= 375,
+      });
+      try {
+        const page = await context.newPage();
+        const diagnostics = observePageFailures(page);
+        for (const theme of themes) {
+          for (const kind of QUEUE_VISIBILITY_PROBE_KINDS) {
+            const exactPrompt = queueVisibilityProbePrompt(kind);
+            const usedFallback = kind !== "mixed-visible";
+            await page.goto(`${baseUrl}/queue.html?count=1&theme=${theme}&visibility=${kind}`, {
+              waitUntil: "networkidle",
+            });
+
+            const collapsedVisual =
+              (await page.getByTestId("queue-collapsed-preview").textContent()) ?? "";
+            const collapsedTree = await chromeAccessibilityTree(page);
+            const collapsedControl = collapsedTree.find(
+              (node) => !node.ignored && node.role === "button" && node.name === "1 queued prompt",
+            );
+            const collapsedSummary = collapsedControl?.description ?? "";
+            if (usedFallback) {
+              expect(collapsedSummary).toMatch(
+                /^Content omitted at safe boundary · ref [0-9A-F]{8}$/,
+              );
+              expect(collapsedSummary).not.toContain(exactPrompt);
+              expect(collapsedVisual).toMatch(/^Omitted · [0-9A-F]{8}$/);
+              expect(collapsedSummary.endsWith(collapsedVisual.replace("Omitted · ", ""))).toBe(
+                true,
+              );
+            } else {
+              expect(collapsedSummary).toBe(exactPrompt);
+              expect(collapsedSummary).toContain("Visible identity 😀");
+              expect(collapsedVisual).toBe(exactPrompt);
+            }
+            expect(Array.from(collapsedSummary).length).toBeLessThanOrEqual(180);
+            expect(isWellFormedUnicode(collapsedSummary)).toBe(true);
+            const collapsedGeometry = await textPaintGeometry(page, "queue-collapsed-preview");
+            expect(collapsedGeometry.textWidth).toBeGreaterThan(0);
+            expect(collapsedGeometry.intersectionWidth).toBeGreaterThan(0);
+            expect(collapsedGeometry.intersectionHeight).toBeGreaterThan(0);
+            expect(collapsedGeometry.fullyVisible).toBe(true);
+            expect(collapsedGeometry.insideViewport).toBe(true);
+
+            if (usedFallback) {
+              expect(collapsedControl?.description).toBe(collapsedSummary);
+            } else {
+              expect(collapsedControl?.description).toContain("Visible identity 😀");
+            }
+            expect(await page.locator('[data-testid^="queue-prompt-full-"]').count()).toBe(0);
+
+            const captureFallbackScreenshots =
+              viewport.width === 320 && theme === "light" && kind === "short-zwj";
+            if (captureFallbackScreenshots) {
+              await page.screenshot({
+                path: `${evidenceDir}/after-320-light-default-ignorable-fallback-collapsed.png`,
+                animations: "disabled",
+              });
+            }
+
+            await page.getByRole("button", { name: "1 queued prompt", exact: true }).click();
+            const preview = page.getByTestId("queue-prompt-preview-1");
+            const expandedSummary = ((await preview.getAttribute("aria-label")) ?? "").replace(
+              /^Queued prompt 1 summary: /,
+              "",
+            );
+            expect(expandedSummary).toBe(collapsedSummary);
+            const expandedStart =
+              (await page.getByTestId("queue-prompt-start-1").textContent()) ?? "";
+            expect(expandedStart).toBe(collapsedVisual);
+            const expandedGeometry = await textPaintGeometry(page, "queue-prompt-start-1");
+            expect(expandedGeometry.textWidth).toBeGreaterThan(0);
+            expect(expandedGeometry.intersectionWidth).toBeGreaterThan(0);
+            expect(expandedGeometry.intersectionHeight).toBeGreaterThan(0);
+            expect(expandedGeometry.fullyVisible).toBe(true);
+            expect(expandedGeometry.insideRow).toBe(true);
+            expect(expandedGeometry.insideViewport).toBe(true);
+
+            const expandedTree = await chromeAccessibilityTree(page);
+            const summaryNode = queueSummaryNodes(expandedTree)[0];
+            if (usedFallback) {
+              expect(summaryNode?.name).toBe(`Queued prompt 1 summary: ${collapsedSummary}`);
+            } else {
+              expect(summaryNode?.name).toContain("Visible identity 😀");
+            }
+            expect(unignoredDescendants(expandedTree, summaryNode?.nodeId ?? "")).toHaveLength(0);
+
+            if (captureFallbackScreenshots) {
+              await page.screenshot({
+                path: `${evidenceDir}/after-320-light-default-ignorable-fallback-expanded.png`,
+                animations: "disabled",
+              });
+            }
+
+            await page
+              .getByRole("button", {
+                name: "Show full content for queued prompt 1",
+                exact: true,
+              })
+              .click();
+            const disclosedPrompt =
+              (await page
+                .getByRole("region", {
+                  name: "Full content for queued prompt 1",
+                  exact: true,
+                })
+                .textContent()) ?? "";
+            expect(disclosedPrompt).toBe(exactPrompt);
+            expect((await pageMetrics(page)).documentOverflow).toBeLessThanOrEqual(1);
+
+            visibilityEvidence.push({
+              viewport,
+              theme,
+              kind,
+              usedFallback,
+              collapsedSummary,
+              collapsedVisual,
+              collapsedGeometry,
+              expandedSummary,
+              expandedVisual: expandedStart,
+              expandedGeometry,
+              collapsedAccessibleDescription: collapsedControl?.description ?? "",
+              expandedAccessibleName: summaryNode?.name ?? "",
+              exactDisclosure: disclosedPrompt === exactPrompt,
+            });
+          }
+        }
+        expect(diagnostics).toEqual([]);
+      } finally {
+        await context.close();
+      }
+    }
+  }, 180_000);
 
   test("Chrome exposes whole graphemes at every head and tail preview boundary", async () => {
     const boundaryViewports = [
@@ -913,6 +1090,53 @@ async function queueIdentityGeometry(page: Page, count: number): Promise<QueueId
         };
       });
   }, count);
+}
+
+async function textPaintGeometry(page: Page, testId: string): Promise<TextPaintGeometry> {
+  return page.getByTestId(testId).evaluate((element) => {
+    const bounds = element.getBoundingClientRect();
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const textBounds = range.getBoundingClientRect();
+    const rowBounds = element.closest<HTMLElement>("[data-queue-turn-id]")?.getBoundingClientRect();
+    const intersectionWidth = Math.max(
+      0,
+      Math.min(bounds.right, textBounds.right) - Math.max(bounds.left, textBounds.left),
+    );
+    const intersectionHeight = Math.max(
+      0,
+      Math.min(bounds.bottom, textBounds.bottom) - Math.max(bounds.top, textBounds.top),
+    );
+    const styles = getComputedStyle(element);
+    return {
+      text: element.textContent ?? "",
+      elementWidth: bounds.width,
+      textWidth: textBounds.width,
+      textHeight: textBounds.height,
+      intersectionWidth,
+      intersectionHeight,
+      fullyVisible:
+        styles.display !== "none" &&
+        styles.visibility !== "hidden" &&
+        Number(styles.opacity) > 0 &&
+        textBounds.left >= bounds.left - 0.5 &&
+        textBounds.right <= bounds.right + 0.5 &&
+        textBounds.top >= bounds.top - 0.5 &&
+        textBounds.bottom <= bounds.bottom + 0.5,
+      insideRow:
+        rowBounds === undefined
+          ? null
+          : textBounds.left >= rowBounds.left - 0.5 &&
+            textBounds.right <= rowBounds.right + 0.5 &&
+            textBounds.top >= rowBounds.top - 0.5 &&
+            textBounds.bottom <= rowBounds.bottom + 0.5,
+      insideViewport:
+        textBounds.left >= -0.5 &&
+        textBounds.right <= window.innerWidth + 0.5 &&
+        textBounds.top >= -0.5 &&
+        textBounds.bottom <= window.innerHeight + 0.5,
+    };
+  });
 }
 
 async function measurePortalMenu(page: Page, index: number): Promise<PortalMenuGeometry> {

--- a/test/e2e/queue-surface.browser.e2e.ts
+++ b/test/e2e/queue-surface.browser.e2e.ts
@@ -29,11 +29,34 @@ type BrowserMeasurement = {
   colorScheme: string;
 };
 
+type BrowserAccessibilityEvidence = {
+  viewport: { width: number; height: number };
+  queueSize: number;
+  collapsed: {
+    controlName: string;
+    boundedDescription: string;
+    exactTrailingSourcePresent: boolean;
+  };
+  expanded: {
+    summaryCount: number;
+    uniqueSummaryCount: number;
+    firstSummary: string;
+    lastSummary: string;
+    exactTrailingSourcePresent: boolean;
+  };
+  disclosed: {
+    regionName: string;
+    exactPromptPresent: boolean;
+    exactTrailingSourcePresent: boolean;
+  };
+};
+
 describe("queue surface browser acceptance", () => {
   let browser: Browser;
   let demo: StartedProcess;
   let baseUrl: string;
   const measurements: BrowserMeasurement[] = [];
+  let accessibilityEvidence: BrowserAccessibilityEvidence | null = null;
 
   beforeAll(async () => {
     const port = await freePort();
@@ -86,6 +109,12 @@ describe("queue surface browser acceptance", () => {
       `${evidenceDir}/measurements.json`,
       `${JSON.stringify({ measurements }, null, 2)}\n`,
     );
+    if (accessibilityEvidence) {
+      await writeFile(
+        `${evidenceDir}/accessibility.json`,
+        `${JSON.stringify(accessibilityEvidence, null, 2)}\n`,
+      );
+    }
     await Promise.allSettled([demo?.stop(), browser?.close()]);
   }, 60_000);
 
@@ -246,7 +275,120 @@ describe("queue surface browser acceptance", () => {
     expect((await pageMetrics(readOnlyPage)).documentOverflow).toBeLessThanOrEqual(1);
     await readOnlyContext.close();
   }, 30_000);
+
+  test("Chrome exposes 100 bounded prompt summaries before exact-source disclosure", async () => {
+    const viewport = { width: 320, height: 800 };
+    const context = await browser.newContext({ viewport, hasTouch: true, isMobile: true });
+    try {
+      const page = await context.newPage();
+      const diagnostics = observePageFailures(page);
+      await page.goto(`${baseUrl}/queue.html?count=100&theme=light`, {
+        waitUntil: "networkidle",
+      });
+
+      const collapsedTree = await chromeAccessibilityTree(page);
+      const collapsedControl = collapsedTree.find(
+        (node) => node.role === "button" && node.name === "100 queued prompts",
+      );
+      expect(collapsedControl).toBeDefined();
+      expect(collapsedControl?.description).toMatch(/^1 \/ 100\s+# Production migration/);
+      expect(Array.from(collapsedControl?.description ?? "").length).toBeLessThanOrEqual(181);
+      expect(accessibleTreeIncludes(collapsedTree, "Exact trailing line.")).toBe(false);
+
+      await page.getByRole("button", { name: "100 queued prompts", exact: true }).click();
+      const expandedTree = await chromeAccessibilityTree(page);
+      const summaries = expandedTree
+        .filter((node) => node.role === "note" && /^Queued prompt \d+ summary: /.test(node.name))
+        .map((node) => node.name);
+      expect(summaries).toHaveLength(100);
+      expect(new Set(summaries).size).toBe(100);
+      for (let index = 0; index < summaries.length; index += 1) {
+        expect(
+          summaries[index]?.startsWith(`Queued prompt ${index + 1} summary: ${index + 1} / 100`),
+        ).toBe(true);
+        expect(Array.from(summaries[index] ?? "").length).toBeLessThanOrEqual(400);
+      }
+      expect(accessibleTreeIncludes(expandedTree, "Exact trailing line.")).toBe(false);
+      expect(
+        expandedTree.some(
+          (node) => node.role === "region" && node.name === "Full content for queued prompt 1",
+        ),
+      ).toBe(false);
+
+      await page
+        .getByRole("button", {
+          name: "Show full content for queued prompt 1",
+          exact: true,
+        })
+        .click();
+      const exactPrompt = `1 / 100\n${HOSTILE_QUEUE_PROMPT}`;
+      const disclosedTree = await chromeAccessibilityTree(page);
+      const disclosedRegion = disclosedTree.find(
+        (node) => node.role === "region" && node.name === "Full content for queued prompt 1",
+      );
+      expect(disclosedRegion).toBeDefined();
+      expect(disclosedTree.some((node) => node.name === exactPrompt)).toBe(true);
+      expect(accessibleTreeIncludes(disclosedTree, "Exact trailing line.")).toBe(true);
+      expect((await pageMetrics(page)).documentOverflow).toBeLessThanOrEqual(1);
+      expect(diagnostics).toEqual([]);
+
+      accessibilityEvidence = {
+        viewport,
+        queueSize: summaries.length,
+        collapsed: {
+          controlName: collapsedControl?.name ?? "",
+          boundedDescription: collapsedControl?.description ?? "",
+          exactTrailingSourcePresent: accessibleTreeIncludes(collapsedTree, "Exact trailing line."),
+        },
+        expanded: {
+          summaryCount: summaries.length,
+          uniqueSummaryCount: new Set(summaries).size,
+          firstSummary: summaries[0] ?? "",
+          lastSummary: summaries.at(-1) ?? "",
+          exactTrailingSourcePresent: accessibleTreeIncludes(expandedTree, "Exact trailing line."),
+        },
+        disclosed: {
+          regionName: disclosedRegion?.name ?? "",
+          exactPromptPresent: disclosedTree.some((node) => node.name === exactPrompt),
+          exactTrailingSourcePresent: accessibleTreeIncludes(disclosedTree, "Exact trailing line."),
+        },
+      };
+      await capture(page, viewport.width, "light", "disclosed");
+    } finally {
+      await context.close();
+    }
+  }, 30_000);
 });
+
+type AccessibleTreeNode = {
+  role: string;
+  name: string;
+  description: string;
+};
+
+async function chromeAccessibilityTree(page: Page): Promise<AccessibleTreeNode[]> {
+  const session = await page.context().newCDPSession(page);
+  try {
+    const { nodes } = await session.send("Accessibility.getFullAXTree");
+    return nodes
+      .filter((node) => !node.ignored)
+      .map((node) => ({
+        role: accessibilityValue(node.role),
+        name: accessibilityValue(node.name),
+        description: accessibilityValue(node.description),
+      }));
+  } finally {
+    await session.detach();
+  }
+}
+
+function accessibilityValue(value: { value?: unknown } | undefined): string {
+  return typeof value?.value === "string" ? value.value : "";
+}
+
+function accessibleTreeIncludes(nodes: AccessibleTreeNode[], expected: string): boolean {
+  return nodes.some((node) => node.name.includes(expected) || node.description.includes(expected));
+}
 
 async function refreshQueue(page: Page): Promise<void> {
   await page.evaluate(() => window.__ope9SetQueueLoading?.(true));

--- a/test/e2e/queue-surface.browser.e2e.ts
+++ b/test/e2e/queue-surface.browser.e2e.ts
@@ -1,16 +1,23 @@
 import AxeBuilder from "@axe-core/playwright";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { chromium, type Browser, type Page } from "playwright";
 import { freePort, runCommand, startProcess, type StartedProcess } from "@opengeni/testing";
 import {
   OMITTED_QUEUE_SOURCE_MARKER,
+  queueBoundaryPrompt,
+  queueBoundarySummary,
   queueHarnessPrompt,
   queuePromptFingerprint,
+  type QueueBoundaryCluster,
+  type QueueBoundaryEdge,
+  type QueueBoundaryMaximum,
 } from "../../packages/react/demo/queue-fixtures";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
-const evidenceDir = process.env.OPENGENI_OPE9_EVIDENCE_DIR ?? "/tmp/opengeni-ope9-queue-evidence";
+const evidenceDir =
+  process.env.OPENGENI_OPE9_EVIDENCE_DIR ?? "/tmp/opengeni-ope9-queue-evidence-grapheme";
 const viewports = [
   { width: 320, height: 800 },
   { width: 360, height: 800 },
@@ -66,11 +73,23 @@ type BrowserAccessibilityEvidence = {
   };
 };
 
+type GraphemeBoundaryEvidence = {
+  viewport: { width: number; height: number };
+  maxCharacters: QueueBoundaryMaximum;
+  edge: QueueBoundaryEdge;
+  cluster: QueueBoundaryCluster;
+  summary: string;
+  codePointLength: number;
+  chromeAccessibleSummary: string;
+  exactDisclosure: boolean;
+};
+
 describe("queue surface browser acceptance", () => {
   let browser: Browser;
   let demo: StartedProcess;
   let baseUrl: string;
   const measurements: BrowserMeasurement[] = [];
+  const graphemeBoundaryEvidence: GraphemeBoundaryEvidence[] = [];
   let accessibilityEvidence: BrowserAccessibilityEvidence | null = null;
 
   beforeAll(async () => {
@@ -85,10 +104,11 @@ describe("queue surface browser acceptance", () => {
       if (build.exitCode !== 0) {
         throw new Error(`Queue demo build failed:\n${build.stdout}\n${build.stderr}`);
       }
-      browser = await chromium.launch({
-        executablePath:
-          process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ?? "/usr/local/bin/chromium",
-      });
+      const configuredChromium = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+      const sandboxChromium = "/usr/local/bin/chromium";
+      const executablePath =
+        configuredChromium ?? (existsSync(sandboxChromium) ? sandboxChromium : undefined);
+      browser = await chromium.launch(executablePath ? { executablePath } : undefined);
       demo = await startProcess(
         [
           "bun",
@@ -130,6 +150,10 @@ describe("queue surface browser acceptance", () => {
         `${JSON.stringify(accessibilityEvidence, null, 2)}\n`,
       );
     }
+    await writeFile(
+      `${evidenceDir}/grapheme-boundaries.json`,
+      `${JSON.stringify({ cases: graphemeBoundaryEvidence }, null, 2)}\n`,
+    );
     await Promise.allSettled([demo?.stop(), browser?.close()]);
   }, 60_000);
 
@@ -441,6 +465,112 @@ describe("queue surface browser acceptance", () => {
       await context.close();
     }
   }, 30_000);
+
+  test("Chrome exposes whole graphemes at every head and tail preview boundary", async () => {
+    const boundaryViewports = [
+      { width: 320, height: 800 },
+      { width: 360, height: 800 },
+      { width: 375, height: 812 },
+    ] as const;
+    const clusterNames = ["zwj", "combining"] as const;
+
+    for (const viewport of boundaryViewports) {
+      const context = await browser.newContext({ viewport, hasTouch: true, isMobile: true });
+      try {
+        const page = await context.newPage();
+        const diagnostics = observePageFailures(page);
+        for (const maxCharacters of [180, 360] as const) {
+          for (const edge of ["head", "tail"] as const) {
+            for (const cluster of clusterNames) {
+              const search = new URLSearchParams({
+                boundaryCluster: cluster,
+                boundaryEdge: edge,
+                boundaryMax: String(maxCharacters),
+                count: "1",
+                theme: "light",
+              });
+              await page.goto(`${baseUrl}/queue.html?${search}`, { waitUntil: "networkidle" });
+
+              let summary: string;
+              let chromeAccessibleSummary: string;
+              if (maxCharacters === 180) {
+                summary = (await page.getByTestId("queue-collapsed-preview").textContent()) ?? "";
+                const tree = await chromeAccessibilityTree(page);
+                const control = tree.find(
+                  (node) =>
+                    !node.ignored && node.role === "button" && node.name === "1 queued prompt",
+                );
+                chromeAccessibleSummary = control?.description ?? "";
+                expect(exposedNodesContaining(tree, summary)).toHaveLength(1);
+                await page.getByRole("button", { name: "1 queued prompt", exact: true }).click();
+              } else {
+                await page.getByRole("button", { name: "1 queued prompt", exact: true }).click();
+                summary = (await page.getByTestId("queue-prompt-preview-1").textContent()) ?? "";
+                const tree = await chromeAccessibilityTree(page);
+                const summaryNode = queueSummaryNodes(tree)[0];
+                chromeAccessibleSummary = (summaryNode?.name ?? "").replace(
+                  /^Queued prompt 1 summary: /,
+                  "",
+                );
+                expect(unignoredDescendants(tree, summaryNode?.nodeId ?? "")).toHaveLength(0);
+              }
+
+              expect(summary).toBe(queueBoundarySummary(maxCharacters, edge));
+              expect(chromeAccessibleSummary).toBe(summary);
+              expect(Array.from(summary).length).toBeLessThanOrEqual(maxCharacters);
+              expect(isWellFormedUnicode(summary)).toBe(true);
+
+              if (
+                (cluster === "zwj" && edge === "head") ||
+                (cluster === "combining" && edge === "tail")
+              ) {
+                await page.screenshot({
+                  path: `${evidenceDir}/grapheme-${viewport.width}-${maxCharacters}-${edge}-${cluster}.png`,
+                  animations: "disabled",
+                });
+              }
+
+              await page
+                .getByRole("button", {
+                  name: "Show full content for queued prompt 1",
+                  exact: true,
+                })
+                .click();
+              const exactPrompt = queueBoundaryPrompt(maxCharacters, edge, cluster);
+              expect(
+                await page
+                  .getByRole("region", {
+                    name: "Full content for queued prompt 1",
+                    exact: true,
+                  })
+                  .textContent(),
+              ).toBe(exactPrompt);
+              const disclosedTree = await chromeAccessibilityTree(page);
+              const exactDisclosure = disclosedTree.some(
+                (node) => !node.ignored && node.name === exactPrompt,
+              );
+              expect(exactDisclosure).toBe(true);
+              expect((await pageMetrics(page)).documentOverflow).toBeLessThanOrEqual(1);
+
+              graphemeBoundaryEvidence.push({
+                viewport,
+                maxCharacters,
+                edge,
+                cluster,
+                summary,
+                codePointLength: Array.from(summary).length,
+                chromeAccessibleSummary,
+                exactDisclosure,
+              });
+            }
+          }
+        }
+        expect(diagnostics).toEqual([]);
+      } finally {
+        await context.close();
+      }
+    }
+  }, 90_000);
 });
 
 type AccessibleTreeNode = {
@@ -473,6 +603,25 @@ async function chromeAccessibilityTree(page: Page): Promise<AccessibleTreeNode[]
 
 function accessibilityValue(value: { value?: unknown } | undefined): string {
   return typeof value?.value === "string" ? value.value : "";
+}
+
+function isWellFormedUnicode(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const current = value.charCodeAt(index);
+    if (current >= 0xd800 && current <= 0xdbff) {
+      if (
+        index + 1 >= value.length ||
+        value.charCodeAt(index + 1) < 0xdc00 ||
+        value.charCodeAt(index + 1) > 0xdfff
+      ) {
+        return false;
+      }
+      index += 1;
+    } else if (current >= 0xdc00 && current <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function queueSummaryNodes(nodes: AccessibleTreeNode[]): AccessibleTreeNode[] {

--- a/test/e2e/queue-surface.browser.e2e.ts
+++ b/test/e2e/queue-surface.browser.e2e.ts
@@ -8,11 +8,14 @@ import {
   OMITTED_QUEUE_SOURCE_MARKER,
   queueBoundaryPrompt,
   queueBoundarySummary,
+  queueFallbackPrompt,
   queueHarnessPrompt,
   queuePromptFingerprint,
+  queuePromptVisibleIdentity,
   type QueueBoundaryCluster,
   type QueueBoundaryEdge,
   type QueueBoundaryMaximum,
+  type QueueFallbackKind,
 } from "../../packages/react/demo/queue-fixtures";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
@@ -40,12 +43,32 @@ type BrowserMeasurement = {
   backgroundLightness: number | null;
   colorScheme: string;
   focusOrder: FocusMeasurement[];
+  identityGeometry: QueueIdentityGeometry[];
+  portalMenuGeometry: PortalMenuGeometry;
 };
 
 type FocusMeasurement = {
   name: string;
   centerX: number;
   centerY: number;
+};
+
+type QueueIdentityGeometry = {
+  text: string;
+  elementWidth: number;
+  textWidth: number;
+  intersectionWidth: number;
+  intersectionHeight: number;
+  fullyVisible: boolean;
+  insideRow: boolean;
+  insideViewport: boolean;
+};
+
+type PortalMenuGeometry = {
+  itemCount: number;
+  itemHeights: number[];
+  itemWidths: number[];
+  insideViewport: boolean;
 };
 
 type BrowserAccessibilityEvidence = {
@@ -229,6 +252,21 @@ describe("queue surface browser acceptance", () => {
           );
         }
 
+        const identityGeometry = await queueIdentityGeometry(page, 2);
+        expect(identityGeometry).toHaveLength(2);
+        expect(new Set(identityGeometry.map((identity) => identity.text)).size).toBe(2);
+        for (let index = 0; index < identityGeometry.length; index += 1) {
+          const identity = identityGeometry[index];
+          expect(identity?.text).toBe(queuePromptVisibleIdentity(index));
+          expect(identity?.elementWidth ?? 0).toBeGreaterThan(0);
+          expect(identity?.textWidth ?? 0).toBeGreaterThan(0);
+          expect(identity?.intersectionWidth ?? 0).toBeGreaterThan(0);
+          expect(identity?.intersectionHeight ?? 0).toBeGreaterThan(0);
+          expect(identity?.fullyVisible).toBe(true);
+          expect(identity?.insideRow).toBe(true);
+          expect(identity?.insideViewport).toBe(true);
+        }
+
         const focusOrder = await sequentialQueueFocusOrder(page);
         expect(focusOrder.map((item) => item.name)).toEqual([
           "Reorder queued prompt 1",
@@ -245,6 +283,24 @@ describe("queue surface browser acceptance", () => {
             expect(height).toBeGreaterThanOrEqual(43);
           }
         }
+
+        await page
+          .getByRole("button", { name: "More actions for queued prompt 1", exact: true })
+          .click();
+        const portalMenuGeometry = await measurePortalMenu(page, 1);
+        expect(portalMenuGeometry.itemCount).toBe(5);
+        expect(portalMenuGeometry.insideViewport).toBe(true);
+        expect(portalMenuGeometry.itemWidths.every((width) => width > 0)).toBe(true);
+        if (viewport.width <= 768) {
+          expect(portalMenuGeometry.itemHeights.every((height) => height >= 43)).toBe(true);
+        }
+        if (viewport.width === 320 && theme === "light") {
+          await page.screenshot({
+            path: `${evidenceDir}/after-320-light-menu.png`,
+            animations: "disabled",
+          });
+        }
+        await page.keyboard.press("Escape");
         await capture(page, viewport.width, theme, "expanded");
 
         const disclosure = page.getByRole("button", {
@@ -303,6 +359,8 @@ describe("queue surface browser acceptance", () => {
           backgroundLightness: collapsed.backgroundLightness,
           colorScheme: collapsed.colorScheme,
           focusOrder,
+          identityGeometry,
+          portalMenuGeometry,
         });
         await context.close();
       }
@@ -350,6 +408,31 @@ describe("queue surface browser acceptance", () => {
     ).toBe(queueHarnessPrompt(0));
     expect((await pageMetrics(readOnlyPage)).documentOverflow).toBeLessThanOrEqual(1);
     await readOnlyContext.close();
+  }, 30_000);
+
+  test("portaled actions retain a 44px coarse-pointer target at every acceptance width", async () => {
+    for (const viewport of viewports) {
+      const context = await browser.newContext({ viewport, hasTouch: true });
+      try {
+        const page = await context.newPage();
+        const diagnostics = observePageFailures(page);
+        await page.goto(`${baseUrl}/queue.html?count=2&theme=light`, {
+          waitUntil: "networkidle",
+        });
+        await page.getByRole("button", { name: "2 queued prompts", exact: true }).click();
+        await page
+          .getByRole("button", { name: "More actions for queued prompt 1", exact: true })
+          .click();
+        const geometry = await measurePortalMenu(page, 1);
+        expect(geometry.itemCount).toBe(5);
+        expect(geometry.itemHeights.every((height) => height >= 43)).toBe(true);
+        expect(geometry.itemWidths.every((width) => width > 0)).toBe(true);
+        expect(geometry.insideViewport).toBe(true);
+        expect(diagnostics).toEqual([]);
+      } finally {
+        await context.close();
+      }
+    }
   }, 30_000);
 
   test("Chrome exposes one useful bounded summary per duplicate-prefix prompt", async () => {
@@ -466,6 +549,78 @@ describe("queue surface browser acceptance", () => {
     }
   }, 30_000);
 
+  test("Chrome exposes bounded fallback references and exact source disclosure", async () => {
+    const fallbackKinds = [
+      "whitespace",
+      "combining",
+      "zwj",
+    ] as const satisfies readonly QueueFallbackKind[];
+    const context = await browser.newContext({
+      viewport: { width: 320, height: 800 },
+      hasTouch: true,
+      isMobile: true,
+    });
+    try {
+      const page = await context.newPage();
+      const diagnostics = observePageFailures(page);
+      for (const fallback of fallbackKinds) {
+        await page.goto(`${baseUrl}/queue.html?count=1&theme=light&fallback=${fallback}`, {
+          waitUntil: "networkidle",
+        });
+        const collapsedSummary =
+          (await page.getByTestId("queue-collapsed-preview").textContent()) ?? "";
+        expect(collapsedSummary).toMatch(/^Content omitted at safe boundary · ref [0-9A-F]{8}$/);
+        expect(Array.from(collapsedSummary).length).toBeLessThanOrEqual(180);
+        expect(isWellFormedUnicode(collapsedSummary)).toBe(true);
+        const collapsedTree = await chromeAccessibilityTree(page);
+        const collapsedControl = collapsedTree.find(
+          (node) => !node.ignored && node.role === "button" && node.name === "1 queued prompt",
+        );
+        expect(collapsedControl?.description).toBe(collapsedSummary);
+
+        await page.getByRole("button", { name: "1 queued prompt", exact: true }).click();
+        const preview = page.getByTestId("queue-prompt-preview-1");
+        const expandedSummary = ((await preview.getAttribute("aria-label")) ?? "").replace(
+          /^Queued prompt 1 summary: /,
+          "",
+        );
+        expect(expandedSummary).toBe(collapsedSummary);
+        expect(await page.getByTestId("queue-prompt-start-1").textContent()).toBe(collapsedSummary);
+        expect(await page.getByTestId("queue-prompt-identity-1").count()).toBe(0);
+        const expandedTree = await chromeAccessibilityTree(page);
+        const summaryNode = queueSummaryNodes(expandedTree)[0];
+        expect(summaryNode?.name).toBe(`Queued prompt 1 summary: ${collapsedSummary}`);
+        expect(unignoredDescendants(expandedTree, summaryNode?.nodeId ?? "")).toHaveLength(0);
+
+        if (fallback === "zwj") {
+          await page.screenshot({
+            path: `${evidenceDir}/after-320-light-safe-boundary.png`,
+            animations: "disabled",
+          });
+        }
+
+        await page
+          .getByRole("button", {
+            name: "Show full content for queued prompt 1",
+            exact: true,
+          })
+          .click();
+        expect(
+          await page
+            .getByRole("region", {
+              name: "Full content for queued prompt 1",
+              exact: true,
+            })
+            .textContent(),
+        ).toBe(queueFallbackPrompt(fallback));
+        expect((await pageMetrics(page)).documentOverflow).toBeLessThanOrEqual(1);
+      }
+      expect(diagnostics).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  }, 30_000);
+
   test("Chrome exposes whole graphemes at every head and tail preview boundary", async () => {
     const boundaryViewports = [
       { width: 320, height: 800 },
@@ -505,7 +660,10 @@ describe("queue surface browser acceptance", () => {
                 await page.getByRole("button", { name: "1 queued prompt", exact: true }).click();
               } else {
                 await page.getByRole("button", { name: "1 queued prompt", exact: true }).click();
-                summary = (await page.getByTestId("queue-prompt-preview-1").textContent()) ?? "";
+                summary = (
+                  (await page.getByTestId("queue-prompt-preview-1").getAttribute("aria-label")) ??
+                  ""
+                ).replace(/^Queued prompt 1 summary: /, "");
                 const tree = await chromeAccessibilityTree(page);
                 const summaryNode = queueSummaryNodes(tree)[0];
                 chromeAccessibleSummary = (summaryNode?.name ?? "").replace(
@@ -704,6 +862,76 @@ function assertCoherentFocusGeometry(order: FocusMeasurement[], viewportWidth: n
     expect(order[index]?.centerX ?? 0).toBeGreaterThan(order[index - 1]?.centerX ?? Infinity);
   }
   expect(order[5]?.centerY ?? 0).toBeGreaterThan(order[4]?.centerY ?? Infinity);
+}
+
+async function queueIdentityGeometry(page: Page, count: number): Promise<QueueIdentityGeometry[]> {
+  return page.evaluate((expectedCount) => {
+    const intersect = (first: DOMRect, second: DOMRect) => ({
+      width: Math.max(0, Math.min(first.right, second.right) - Math.max(first.left, second.left)),
+      height: Math.max(0, Math.min(first.bottom, second.bottom) - Math.max(first.top, second.top)),
+    });
+    return Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid^="queue-prompt-identity-"]'),
+    )
+      .filter((element) => !element.dataset.testid?.includes("-row-"))
+      .slice(0, expectedCount)
+      .map((element) => {
+        const elementBounds = element.getBoundingClientRect();
+        const range = document.createRange();
+        range.selectNodeContents(element);
+        const textBounds = range.getBoundingClientRect();
+        const rowBounds = element
+          .closest<HTMLElement>("[data-queue-turn-id]")
+          ?.getBoundingClientRect();
+        const intersection = intersect(elementBounds, textBounds);
+        const styles = getComputedStyle(element);
+        return {
+          text: element.textContent ?? "",
+          elementWidth: elementBounds.width,
+          textWidth: textBounds.width,
+          intersectionWidth: intersection.width,
+          intersectionHeight: intersection.height,
+          fullyVisible:
+            styles.display !== "none" &&
+            styles.visibility !== "hidden" &&
+            Number(styles.opacity) > 0 &&
+            textBounds.left >= elementBounds.left - 0.5 &&
+            textBounds.right <= elementBounds.right + 0.5 &&
+            textBounds.top >= elementBounds.top - 0.5 &&
+            textBounds.bottom <= elementBounds.bottom + 0.5,
+          insideRow:
+            rowBounds !== undefined &&
+            textBounds.left >= rowBounds.left - 0.5 &&
+            textBounds.right <= rowBounds.right + 0.5 &&
+            textBounds.top >= rowBounds.top - 0.5 &&
+            textBounds.bottom <= rowBounds.bottom + 0.5,
+          insideViewport:
+            textBounds.left >= -0.5 &&
+            textBounds.right <= window.innerWidth + 0.5 &&
+            textBounds.top >= -0.5 &&
+            textBounds.bottom <= window.innerHeight + 0.5,
+        };
+      });
+  }, count);
+}
+
+async function measurePortalMenu(page: Page, index: number): Promise<PortalMenuGeometry> {
+  const menu = page.getByTestId(`queue-actions-menu-${index}`);
+  await menu.waitFor();
+  return menu.evaluate((element) => {
+    const menuBounds = element.getBoundingClientRect();
+    const items = Array.from(element.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+    return {
+      itemCount: items.length,
+      itemHeights: items.map((item) => item.getBoundingClientRect().height),
+      itemWidths: items.map((item) => item.getBoundingClientRect().width),
+      insideViewport:
+        menuBounds.left >= -0.5 &&
+        menuBounds.right <= window.innerWidth + 0.5 &&
+        menuBounds.top >= -0.5 &&
+        menuBounds.bottom <= window.innerHeight + 0.5,
+    };
+  });
 }
 
 async function refreshQueue(page: Page): Promise<void> {

--- a/test/e2e/queue-surface.browser.e2e.ts
+++ b/test/e2e/queue-surface.browser.e2e.ts
@@ -1,0 +1,330 @@
+import AxeBuilder from "@axe-core/playwright";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { chromium, type Browser, type Page } from "playwright";
+import { freePort, runCommand, startProcess, type StartedProcess } from "@opengeni/testing";
+import { HOSTILE_QUEUE_PROMPT } from "../../packages/react/demo/queue-fixtures";
+
+const repoRoot = new URL("../..", import.meta.url).pathname;
+const evidenceDir = process.env.OPENGENI_OPE9_EVIDENCE_DIR ?? "/tmp/opengeni-ope9-queue-evidence";
+const viewports = [
+  { width: 360, height: 800 },
+  { width: 375, height: 812 },
+  { width: 768, height: 960 },
+  { width: 1440, height: 1000 },
+] as const;
+const themes = ["dark", "light"] as const;
+
+type BrowserMeasurement = {
+  viewport: (typeof viewports)[number];
+  theme: (typeof themes)[number];
+  collapsedHeight: number;
+  expandedListHeight: number;
+  expandedListScrollHeight: number;
+  disclosedHeight: number;
+  disclosedScrollHeight: number;
+  documentOverflow: number;
+  backgroundColor: string;
+  backgroundLightness: number | null;
+  colorScheme: string;
+};
+
+describe("queue surface browser acceptance", () => {
+  let browser: Browser;
+  let demo: StartedProcess;
+  let baseUrl: string;
+  const measurements: BrowserMeasurement[] = [];
+
+  beforeAll(async () => {
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    await mkdir(evidenceDir, { recursive: true });
+    try {
+      const build = await runCommand(["bun", "run", "vite", "build", "demo"], {
+        cwd: `${repoRoot}/packages/react`,
+        timeoutMs: 60_000,
+      });
+      if (build.exitCode !== 0) {
+        throw new Error(`Queue demo build failed:\n${build.stdout}\n${build.stderr}`);
+      }
+      browser = await chromium.launch({
+        executablePath:
+          process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ?? "/usr/local/bin/chromium",
+      });
+      demo = await startProcess(
+        [
+          "bun",
+          "run",
+          "vite",
+          "preview",
+          "demo",
+          "--host",
+          "127.0.0.1",
+          "--port",
+          String(port),
+          "--strictPort",
+        ],
+        {
+          cwd: `${repoRoot}/packages/react`,
+          ready: async () =>
+            (
+              await fetch(`${baseUrl}/queue.html`, {
+                signal: AbortSignal.timeout(2_000),
+              }).catch(() => null)
+            )?.ok === true,
+          timeoutMs: 45_000,
+        },
+      );
+    } catch (error) {
+      await Promise.allSettled([demo?.stop(), browser?.close()]);
+      throw error;
+    }
+  }, 90_000);
+
+  afterAll(async () => {
+    await writeFile(
+      `${evidenceDir}/measurements.json`,
+      `${JSON.stringify({ measurements }, null, 2)}\n`,
+    );
+    await Promise.allSettled([demo?.stop(), browser?.close()]);
+  }, 60_000);
+
+  test("large prompts and 100 rows stay bounded across the viewport and theme matrix", async () => {
+    for (const viewport of viewports) {
+      for (const theme of themes) {
+        const context = await browser.newContext({
+          viewport,
+          hasTouch: viewport.width <= 768,
+          isMobile: viewport.width <= 375,
+        });
+        const page = await context.newPage();
+        const diagnostics = observePageFailures(page);
+        await page.goto(`${baseUrl}/queue.html?count=100&theme=${theme}`, {
+          waitUntil: "networkidle",
+        });
+        const surface = page.getByTestId("queue-surface");
+        await surface.waitFor();
+
+        const collapsed = await pageMetrics(page);
+        expect(collapsed.documentOverflow).toBeLessThanOrEqual(1);
+        expect(collapsed.surfaceHeight).toBeLessThanOrEqual(48);
+        expect(collapsed.collapsedPreviewCharacters).toBeLessThanOrEqual(181);
+        expect(collapsed.colorScheme).toBe(theme);
+        expect(collapsed.backgroundLightness).not.toBeNull();
+        if (theme === "light") {
+          expect(collapsed.backgroundLightness ?? 0).toBeGreaterThan(0.9);
+        } else {
+          expect(collapsed.backgroundLightness ?? 1).toBeLessThan(0.3);
+        }
+        await capture(page, viewport.width, theme, "collapsed");
+
+        const toggle = page.getByRole("button", { name: "100 queued prompts" });
+        await toggle.focus();
+        await page.keyboard.press("Enter");
+        const list = page.getByTestId("queue-list");
+        await list.waitFor();
+        expect(await list.getAttribute("aria-label")).toBe("Queued prompts");
+        expect(await page.locator("[data-queue-turn-id]").count()).toBe(100);
+        expect(await page.locator('[data-testid^="queue-prompt-full-"]').count()).toBe(0);
+
+        const expanded = await pageMetrics(page);
+        expect(expanded.documentOverflow).toBeLessThanOrEqual(1);
+        expect(expanded.listHeight).toBeLessThanOrEqual(
+          Math.min(480, Math.round(viewport.height * 0.6)) + 2,
+        );
+        expect(expanded.listScrollHeight).toBeGreaterThan(expanded.listHeight);
+        expect(expanded.maxPreviewHeight).toBeLessThanOrEqual(61);
+        expect(expanded.maxRowHeight).toBeLessThanOrEqual(160);
+
+        if (viewport.width <= 768) {
+          for (const height of expanded.coarseControlHeights) {
+            expect(height).toBeGreaterThanOrEqual(43);
+          }
+        }
+        await capture(page, viewport.width, theme, "expanded");
+
+        const disclosure = page.getByRole("button", {
+          name: "Show full content for queued prompt 1",
+          exact: true,
+        });
+        await disclosure.focus();
+        await page.keyboard.press("Enter");
+        expect(
+          await page
+            .getByRole("button", {
+              name: "Hide full content for queued prompt 1",
+              exact: true,
+            })
+            .getAttribute("aria-expanded"),
+        ).toBe("true");
+        const full = page.getByRole("region", {
+          name: "Full content for queued prompt 1",
+          exact: true,
+        });
+        expect(await full.textContent()).toBe(`1 / 100\n${HOSTILE_QUEUE_PROMPT}`);
+
+        const disclosed = await pageMetrics(page);
+        expect(disclosed.documentOverflow).toBeLessThanOrEqual(1);
+        expect(disclosed.fullHeight).toBeLessThanOrEqual(258);
+        expect(disclosed.fullScrollHeight).toBeGreaterThan(disclosed.fullHeight);
+        expect(disclosed.fullOverflow).toBeLessThanOrEqual(1);
+        await page.keyboard.press("Tab");
+        expect(await full.evaluate((element) => document.activeElement === element)).toBe(true);
+        await capture(page, viewport.width, theme, "disclosed");
+
+        await refreshQueue(page);
+        await page.getByRole("button", { name: "101 queued prompts" }).waitFor();
+        const refreshed = await pageMetrics(page);
+        expect(refreshed.documentOverflow).toBeLessThanOrEqual(1);
+        expect(refreshed.listHeight).toBeLessThanOrEqual(
+          Math.min(480, Math.round(viewport.height * 0.6)) + 2,
+        );
+        expect(await full.textContent()).toBe(`1 / 100\n${HOSTILE_QUEUE_PROMPT}`);
+
+        if (viewport.width === 360 || viewport.width === 1440) {
+          const report = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
+          expect(report.violations).toEqual([]);
+        }
+        expect(diagnostics).toEqual([]);
+        measurements.push({
+          viewport,
+          theme,
+          collapsedHeight: collapsed.surfaceHeight,
+          expandedListHeight: expanded.listHeight,
+          expandedListScrollHeight: expanded.listScrollHeight,
+          disclosedHeight: disclosed.fullHeight,
+          disclosedScrollHeight: disclosed.fullScrollHeight,
+          documentOverflow: disclosed.documentOverflow,
+          backgroundColor: collapsed.backgroundColor,
+          backgroundLightness: collapsed.backgroundLightness,
+          colorScheme: collapsed.colorScheme,
+        });
+        await context.close();
+      }
+    }
+  }, 120_000);
+
+  test("dragging and read-only disclosure cannot escape the viewport", async () => {
+    const context = await browser.newContext({ viewport: { width: 375, height: 812 } });
+    const page = await context.newPage();
+    await page.goto(`${baseUrl}/queue.html?count=2&theme=dark`, { waitUntil: "networkidle" });
+    await page.getByRole("button", { name: "2 queued prompts" }).click();
+    const handle = page.getByRole("button", { name: "Reorder queued prompt 1" });
+    const box = await handle.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) throw new Error("queue drag handle has no layout box");
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height + 24, { steps: 4 });
+    const overlay = page.getByTestId("queue-drag-overlay");
+    await overlay.waitFor();
+    const overlayBox = await overlay.boundingBox();
+    expect(overlayBox).not.toBeNull();
+    expect(overlayBox?.height ?? Infinity).toBeLessThanOrEqual(82);
+    expect(overlayBox?.width ?? Infinity).toBeLessThanOrEqual(343);
+    await page.mouse.up();
+    expect((await pageMetrics(page)).documentOverflow).toBeLessThanOrEqual(1);
+    await context.close();
+
+    const readOnlyContext = await browser.newContext({ viewport: { width: 768, height: 960 } });
+    const readOnlyPage = await readOnlyContext.newPage();
+    await readOnlyPage.goto(`${baseUrl}/queue.html?count=1&theme=light&readOnly=1`, {
+      waitUntil: "networkidle",
+    });
+    await readOnlyPage.getByRole("button", { name: /1 queued prompt Read-only/ }).click();
+    expect(await readOnlyPage.getByRole("button", { name: /^Steer queued prompt/ }).count()).toBe(
+      0,
+    );
+    await readOnlyPage
+      .getByRole("button", { name: "Show full content for queued prompt 1", exact: true })
+      .click();
+    expect(
+      await readOnlyPage
+        .getByRole("region", { name: "Full content for queued prompt 1", exact: true })
+        .textContent(),
+    ).toBe(`1 / 1\n${HOSTILE_QUEUE_PROMPT}`);
+    expect((await pageMetrics(readOnlyPage)).documentOverflow).toBeLessThanOrEqual(1);
+    await readOnlyContext.close();
+  }, 30_000);
+});
+
+async function refreshQueue(page: Page): Promise<void> {
+  await page.evaluate(() => window.__ope9SetQueueLoading?.(true));
+  await page.locator('[data-testid="queue-surface"] .animate-spin').waitFor();
+  await page.evaluate(() => window.__ope9AppendQueuePrompt?.());
+  await page.getByRole("button", { name: "101 queued prompts" }).waitFor();
+  await page.evaluate(() => window.__ope9SetQueueLoading?.(false));
+}
+
+async function capture(
+  page: Page,
+  width: number,
+  theme: (typeof themes)[number],
+  state: "collapsed" | "expanded" | "disclosed",
+): Promise<void> {
+  await page.screenshot({
+    path: `${evidenceDir}/after-${width}-${theme}-${state}.png`,
+    animations: "disabled",
+  });
+}
+
+async function pageMetrics(page: Page) {
+  return page.evaluate(() => {
+    const surface = document.querySelector<HTMLElement>('[data-testid="queue-surface"]');
+    const list = document.querySelector<HTMLElement>('[data-testid="queue-list"]');
+    const full = document.querySelector<HTMLElement>('[data-testid="queue-prompt-full-1"]');
+    const rows = Array.from(document.querySelectorAll<HTMLElement>("[data-queue-turn-id]"));
+    const previews = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid^="queue-prompt-preview-"]'),
+    );
+    const controls = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        "[data-queue-turn-id]:first-child button[aria-label], [data-queue-turn-id]:first-child [data-queue-handle]",
+      ),
+    );
+    const harness = document.querySelector<HTMLElement>("[data-queue-harness]");
+    const harnessStyles = harness ? getComputedStyle(harness) : null;
+    const backgroundColor = harnessStyles?.backgroundColor ?? "";
+    const lightnessMatch = /^oklch\(([\d.]+)(%)?/.exec(backgroundColor);
+    const backgroundLightness = lightnessMatch
+      ? Number(lightnessMatch[1]) / (lightnessMatch[2] ? 100 : 1)
+      : null;
+    return {
+      documentOverflow: Math.max(0, document.documentElement.scrollWidth - window.innerWidth),
+      surfaceHeight: Math.round(surface?.getBoundingClientRect().height ?? 0),
+      collapsedPreviewCharacters: Array.from(
+        document.querySelector<HTMLElement>('[data-testid="queue-collapsed-preview"]')
+          ?.textContent ?? "",
+      ).length,
+      listHeight: Math.round(list?.getBoundingClientRect().height ?? 0),
+      listScrollHeight: list?.scrollHeight ?? 0,
+      maxRowHeight: Math.round(
+        Math.max(0, ...rows.map((row) => row.getBoundingClientRect().height)),
+      ),
+      maxPreviewHeight: Math.round(
+        Math.max(0, ...previews.map((preview) => preview.getBoundingClientRect().height)),
+      ),
+      coarseControlHeights: controls.map((control) =>
+        Math.round(control.getBoundingClientRect().height),
+      ),
+      fullHeight: Math.round(full?.getBoundingClientRect().height ?? 0),
+      fullScrollHeight: full?.scrollHeight ?? 0,
+      fullOverflow: full ? Math.max(0, full.scrollWidth - full.clientWidth) : 0,
+      backgroundColor,
+      backgroundLightness,
+      colorScheme: harnessStyles?.colorScheme ?? "",
+    };
+  });
+}
+
+function observePageFailures(page: Page): string[] {
+  const diagnostics: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "warning" || message.type() === "error") {
+      diagnostics.push(`console:${message.text()}`);
+    }
+  });
+  page.on("pageerror", (error) => diagnostics.push(`page:${String(error)}`));
+  page.on("requestfailed", (request) => diagnostics.push(`request:${request.url()}`));
+  return diagnostics;
+}

--- a/test/e2e/queue-surface.browser.e2e.ts
+++ b/test/e2e/queue-surface.browser.e2e.ts
@@ -3,11 +3,16 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdir, writeFile } from "node:fs/promises";
 import { chromium, type Browser, type Page } from "playwright";
 import { freePort, runCommand, startProcess, type StartedProcess } from "@opengeni/testing";
-import { HOSTILE_QUEUE_PROMPT } from "../../packages/react/demo/queue-fixtures";
+import {
+  OMITTED_QUEUE_SOURCE_MARKER,
+  queueHarnessPrompt,
+  queuePromptFingerprint,
+} from "../../packages/react/demo/queue-fixtures";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
 const evidenceDir = process.env.OPENGENI_OPE9_EVIDENCE_DIR ?? "/tmp/opengeni-ope9-queue-evidence";
 const viewports = [
+  { width: 320, height: 800 },
   { width: 360, height: 800 },
   { width: 375, height: 812 },
   { width: 768, height: 960 },
@@ -27,6 +32,13 @@ type BrowserMeasurement = {
   backgroundColor: string;
   backgroundLightness: number | null;
   colorScheme: string;
+  focusOrder: FocusMeasurement[];
+};
+
+type FocusMeasurement = {
+  name: string;
+  centerX: number;
+  centerY: number;
 };
 
 type BrowserAccessibilityEvidence = {
@@ -35,19 +47,22 @@ type BrowserAccessibilityEvidence = {
   collapsed: {
     controlName: string;
     boundedDescription: string;
-    exactTrailingSourcePresent: boolean;
+    fingerprintPresent: boolean;
+    omittedMiddleSourcePresent: boolean;
   };
   expanded: {
     summaryCount: number;
-    uniqueSummaryCount: number;
+    uniqueContentSummaryCount: number;
+    distinctiveFingerprintCount: number;
+    repeatedDescendantCount: number;
     firstSummary: string;
     lastSummary: string;
-    exactTrailingSourcePresent: boolean;
+    omittedMiddleSourcePresent: boolean;
   };
   disclosed: {
     regionName: string;
     exactPromptPresent: boolean;
-    exactTrailingSourcePresent: boolean;
+    omittedMiddleSourcePresent: boolean;
   };
 };
 
@@ -137,7 +152,7 @@ describe("queue surface browser acceptance", () => {
         const collapsed = await pageMetrics(page);
         expect(collapsed.documentOverflow).toBeLessThanOrEqual(1);
         expect(collapsed.surfaceHeight).toBeLessThanOrEqual(48);
-        expect(collapsed.collapsedPreviewCharacters).toBeLessThanOrEqual(181);
+        expect(collapsed.collapsedPreviewCharacters).toBeLessThanOrEqual(180);
         expect(collapsed.colorScheme).toBe(theme);
         expect(collapsed.backgroundLightness).not.toBeNull();
         if (theme === "light") {
@@ -145,6 +160,13 @@ describe("queue surface browser acceptance", () => {
         } else {
           expect(collapsed.backgroundLightness ?? 1).toBeLessThan(0.3);
         }
+        const collapsedTree = await chromeAccessibilityTree(page);
+        const collapsedControl = collapsedTree.find(
+          (node) => !node.ignored && node.role === "button" && node.name === "100 queued prompts",
+        );
+        expect(collapsedControl?.description).toContain(queuePromptFingerprint(0));
+        expect(exposedTreeIncludes(collapsedTree, OMITTED_QUEUE_SOURCE_MARKER)).toBe(false);
+        expect(exposedNodesContaining(collapsedTree, queuePromptFingerprint(0))).toHaveLength(1);
         await capture(page, viewport.width, theme, "collapsed");
 
         const toggle = page.getByRole("button", { name: "100 queued prompts" });
@@ -163,7 +185,36 @@ describe("queue surface browser acceptance", () => {
         );
         expect(expanded.listScrollHeight).toBeGreaterThan(expanded.listHeight);
         expect(expanded.maxPreviewHeight).toBeLessThanOrEqual(61);
-        expect(expanded.maxRowHeight).toBeLessThanOrEqual(160);
+        expect(expanded.maxRowHeight).toBeLessThanOrEqual(viewport.width <= 375 ? 194 : 160);
+
+        const expandedTree = await chromeAccessibilityTree(page);
+        const summaryNodes = queueSummaryNodes(expandedTree);
+        const contentSummaries = summaryNodes.map((node) =>
+          node.name.replace(/^Queued prompt \d+ summary: /, ""),
+        );
+        expect(summaryNodes).toHaveLength(100);
+        expect(new Set(contentSummaries).size).toBe(100);
+        expect(exposedTreeIncludes(expandedTree, OMITTED_QUEUE_SOURCE_MARKER)).toBe(false);
+        for (let index = 0; index < summaryNodes.length; index += 1) {
+          expect(summaryNodes[index]?.name).toContain(queuePromptFingerprint(index));
+          expect(
+            unignoredDescendants(expandedTree, summaryNodes[index]?.nodeId ?? ""),
+          ).toHaveLength(0);
+          expect(exposedNodesContaining(expandedTree, queuePromptFingerprint(index))).toHaveLength(
+            1,
+          );
+        }
+
+        const focusOrder = await sequentialQueueFocusOrder(page);
+        expect(focusOrder.map((item) => item.name)).toEqual([
+          "Reorder queued prompt 1",
+          "Show full content for queued prompt 1",
+          "Steer queued prompt 1",
+          "Delete queued prompt 1",
+          "More actions for queued prompt 1",
+          "Reorder queued prompt 2",
+        ]);
+        assertCoherentFocusGeometry(focusOrder, viewport.width);
 
         if (viewport.width <= 768) {
           for (const height of expanded.coarseControlHeights) {
@@ -190,7 +241,7 @@ describe("queue surface browser acceptance", () => {
           name: "Full content for queued prompt 1",
           exact: true,
         });
-        expect(await full.textContent()).toBe(`1 / 100\n${HOSTILE_QUEUE_PROMPT}`);
+        expect(await full.textContent()).toBe(queueHarnessPrompt(0));
 
         const disclosed = await pageMetrics(page);
         expect(disclosed.documentOverflow).toBeLessThanOrEqual(1);
@@ -208,7 +259,7 @@ describe("queue surface browser acceptance", () => {
         expect(refreshed.listHeight).toBeLessThanOrEqual(
           Math.min(480, Math.round(viewport.height * 0.6)) + 2,
         );
-        expect(await full.textContent()).toBe(`1 / 100\n${HOSTILE_QUEUE_PROMPT}`);
+        expect(await full.textContent()).toBe(queueHarnessPrompt(0));
 
         if (viewport.width === 360 || viewport.width === 1440) {
           const report = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
@@ -227,6 +278,7 @@ describe("queue surface browser acceptance", () => {
           backgroundColor: collapsed.backgroundColor,
           backgroundLightness: collapsed.backgroundLightness,
           colorScheme: collapsed.colorScheme,
+          focusOrder,
         });
         await context.close();
       }
@@ -271,12 +323,12 @@ describe("queue surface browser acceptance", () => {
       await readOnlyPage
         .getByRole("region", { name: "Full content for queued prompt 1", exact: true })
         .textContent(),
-    ).toBe(`1 / 1\n${HOSTILE_QUEUE_PROMPT}`);
+    ).toBe(queueHarnessPrompt(0));
     expect((await pageMetrics(readOnlyPage)).documentOverflow).toBeLessThanOrEqual(1);
     await readOnlyContext.close();
   }, 30_000);
 
-  test("Chrome exposes 100 bounded prompt summaries before exact-source disclosure", async () => {
+  test("Chrome exposes one useful bounded summary per duplicate-prefix prompt", async () => {
     const viewport = { width: 320, height: 800 };
     const context = await browser.newContext({ viewport, hasTouch: true, isMobile: true });
     try {
@@ -288,30 +340,38 @@ describe("queue surface browser acceptance", () => {
 
       const collapsedTree = await chromeAccessibilityTree(page);
       const collapsedControl = collapsedTree.find(
-        (node) => node.role === "button" && node.name === "100 queued prompts",
+        (node) => !node.ignored && node.role === "button" && node.name === "100 queued prompts",
       );
       expect(collapsedControl).toBeDefined();
-      expect(collapsedControl?.description).toMatch(/^1 \/ 100\s+# Production migration/);
-      expect(Array.from(collapsedControl?.description ?? "").length).toBeLessThanOrEqual(181);
-      expect(accessibleTreeIncludes(collapsedTree, "Exact trailing line.")).toBe(false);
+      expect(collapsedControl?.description).toMatch(/^# Production migration/);
+      expect(collapsedControl?.description).toContain(queuePromptFingerprint(0));
+      expect(Array.from(collapsedControl?.description ?? "").length).toBeLessThanOrEqual(180);
+      expect(exposedNodesContaining(collapsedTree, queuePromptFingerprint(0))).toHaveLength(1);
+      expect(exposedTreeIncludes(collapsedTree, OMITTED_QUEUE_SOURCE_MARKER)).toBe(false);
 
       await page.getByRole("button", { name: "100 queued prompts", exact: true }).click();
       const expandedTree = await chromeAccessibilityTree(page);
-      const summaries = expandedTree
-        .filter((node) => node.role === "note" && /^Queued prompt \d+ summary: /.test(node.name))
-        .map((node) => node.name);
-      expect(summaries).toHaveLength(100);
-      expect(new Set(summaries).size).toBe(100);
-      for (let index = 0; index < summaries.length; index += 1) {
-        expect(
-          summaries[index]?.startsWith(`Queued prompt ${index + 1} summary: ${index + 1} / 100`),
-        ).toBe(true);
-        expect(Array.from(summaries[index] ?? "").length).toBeLessThanOrEqual(400);
+      const summaryNodes = queueSummaryNodes(expandedTree);
+      const contentSummaries = summaryNodes.map((node) =>
+        node.name.replace(/^Queued prompt \d+ summary: /, ""),
+      );
+      expect(summaryNodes).toHaveLength(100);
+      expect(new Set(contentSummaries).size).toBe(100);
+      for (let index = 0; index < summaryNodes.length; index += 1) {
+        expect(summaryNodes[index]?.name).toContain(queuePromptFingerprint(index));
+        expect(Array.from(contentSummaries[index] ?? "").length).toBeLessThanOrEqual(360);
+        expect(unignoredDescendants(expandedTree, summaryNodes[index]?.nodeId ?? "")).toHaveLength(
+          0,
+        );
+        expect(exposedNodesContaining(expandedTree, queuePromptFingerprint(index))).toHaveLength(1);
       }
-      expect(accessibleTreeIncludes(expandedTree, "Exact trailing line.")).toBe(false);
+      expect(exposedTreeIncludes(expandedTree, OMITTED_QUEUE_SOURCE_MARKER)).toBe(false);
       expect(
         expandedTree.some(
-          (node) => node.role === "region" && node.name === "Full content for queued prompt 1",
+          (node) =>
+            !node.ignored &&
+            node.role === "region" &&
+            node.name === "Full content for queued prompt 1",
         ),
       ).toBe(false);
 
@@ -321,36 +381,59 @@ describe("queue surface browser acceptance", () => {
           exact: true,
         })
         .click();
-      const exactPrompt = `1 / 100\n${HOSTILE_QUEUE_PROMPT}`;
+      const exactPrompt = queueHarnessPrompt(0);
       const disclosedTree = await chromeAccessibilityTree(page);
       const disclosedRegion = disclosedTree.find(
-        (node) => node.role === "region" && node.name === "Full content for queued prompt 1",
+        (node) =>
+          !node.ignored &&
+          node.role === "region" &&
+          node.name === "Full content for queued prompt 1",
       );
       expect(disclosedRegion).toBeDefined();
-      expect(disclosedTree.some((node) => node.name === exactPrompt)).toBe(true);
-      expect(accessibleTreeIncludes(disclosedTree, "Exact trailing line.")).toBe(true);
+      expect(disclosedTree.some((node) => !node.ignored && node.name === exactPrompt)).toBe(true);
+      expect(exposedTreeIncludes(disclosedTree, OMITTED_QUEUE_SOURCE_MARKER)).toBe(true);
       expect((await pageMetrics(page)).documentOverflow).toBeLessThanOrEqual(1);
       expect(diagnostics).toEqual([]);
 
       accessibilityEvidence = {
         viewport,
-        queueSize: summaries.length,
+        queueSize: summaryNodes.length,
         collapsed: {
           controlName: collapsedControl?.name ?? "",
           boundedDescription: collapsedControl?.description ?? "",
-          exactTrailingSourcePresent: accessibleTreeIncludes(collapsedTree, "Exact trailing line."),
+          fingerprintPresent:
+            collapsedControl?.description.includes(queuePromptFingerprint(0)) ?? false,
+          omittedMiddleSourcePresent: exposedTreeIncludes(
+            collapsedTree,
+            OMITTED_QUEUE_SOURCE_MARKER,
+          ),
         },
         expanded: {
-          summaryCount: summaries.length,
-          uniqueSummaryCount: new Set(summaries).size,
-          firstSummary: summaries[0] ?? "",
-          lastSummary: summaries.at(-1) ?? "",
-          exactTrailingSourcePresent: accessibleTreeIncludes(expandedTree, "Exact trailing line."),
+          summaryCount: summaryNodes.length,
+          uniqueContentSummaryCount: new Set(contentSummaries).size,
+          distinctiveFingerprintCount: summaryNodes.filter((node, index) =>
+            node.name.includes(queuePromptFingerprint(index)),
+          ).length,
+          repeatedDescendantCount: summaryNodes.reduce(
+            (count, node) => count + unignoredDescendants(expandedTree, node.nodeId).length,
+            0,
+          ),
+          firstSummary: summaryNodes[0]?.name ?? "",
+          lastSummary: summaryNodes.at(-1)?.name ?? "",
+          omittedMiddleSourcePresent: exposedTreeIncludes(
+            expandedTree,
+            OMITTED_QUEUE_SOURCE_MARKER,
+          ),
         },
         disclosed: {
           regionName: disclosedRegion?.name ?? "",
-          exactPromptPresent: disclosedTree.some((node) => node.name === exactPrompt),
-          exactTrailingSourcePresent: accessibleTreeIncludes(disclosedTree, "Exact trailing line."),
+          exactPromptPresent: disclosedTree.some(
+            (node) => !node.ignored && node.name === exactPrompt,
+          ),
+          omittedMiddleSourcePresent: exposedTreeIncludes(
+            disclosedTree,
+            OMITTED_QUEUE_SOURCE_MARKER,
+          ),
         },
       };
       await capture(page, viewport.width, "light", "disclosed");
@@ -361,6 +444,10 @@ describe("queue surface browser acceptance", () => {
 });
 
 type AccessibleTreeNode = {
+  nodeId: string;
+  parentId: string | null;
+  childIds: string[];
+  ignored: boolean;
   role: string;
   name: string;
   description: string;
@@ -370,13 +457,15 @@ async function chromeAccessibilityTree(page: Page): Promise<AccessibleTreeNode[]
   const session = await page.context().newCDPSession(page);
   try {
     const { nodes } = await session.send("Accessibility.getFullAXTree");
-    return nodes
-      .filter((node) => !node.ignored)
-      .map((node) => ({
-        role: accessibilityValue(node.role),
-        name: accessibilityValue(node.name),
-        description: accessibilityValue(node.description),
-      }));
+    return nodes.map((node) => ({
+      nodeId: node.nodeId,
+      parentId: node.parentId ?? null,
+      childIds: node.childIds ?? [],
+      ignored: node.ignored,
+      role: accessibilityValue(node.role),
+      name: accessibilityValue(node.name),
+      description: accessibilityValue(node.description),
+    }));
   } finally {
     await session.detach();
   }
@@ -386,8 +475,86 @@ function accessibilityValue(value: { value?: unknown } | undefined): string {
   return typeof value?.value === "string" ? value.value : "";
 }
 
-function accessibleTreeIncludes(nodes: AccessibleTreeNode[], expected: string): boolean {
-  return nodes.some((node) => node.name.includes(expected) || node.description.includes(expected));
+function queueSummaryNodes(nodes: AccessibleTreeNode[]): AccessibleTreeNode[] {
+  return nodes.filter(
+    (node) =>
+      !node.ignored && node.role === "note" && /^Queued prompt \d+ summary: /.test(node.name),
+  );
+}
+
+function exposedTreeIncludes(nodes: AccessibleTreeNode[], expected: string): boolean {
+  return exposedNodesContaining(nodes, expected).length > 0;
+}
+
+function exposedNodesContaining(
+  nodes: AccessibleTreeNode[],
+  expected: string,
+): AccessibleTreeNode[] {
+  return nodes.filter(
+    (node) =>
+      !node.ignored && (node.name.includes(expected) || node.description.includes(expected)),
+  );
+}
+
+function unignoredDescendants(
+  nodes: AccessibleTreeNode[],
+  rootNodeId: string,
+): AccessibleTreeNode[] {
+  const byId = new Map(nodes.map((node) => [node.nodeId, node]));
+  const pending = [...(byId.get(rootNodeId)?.childIds ?? [])];
+  const descendants: AccessibleTreeNode[] = [];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const nodeId = pending.shift();
+    if (!nodeId || visited.has(nodeId)) continue;
+    visited.add(nodeId);
+    const node = byId.get(nodeId);
+    if (!node) continue;
+    if (!node.ignored) descendants.push(node);
+    pending.push(...node.childIds);
+  }
+  return descendants;
+}
+
+async function sequentialQueueFocusOrder(page: Page): Promise<FocusMeasurement[]> {
+  const order: FocusMeasurement[] = [];
+  for (let index = 0; index < 6; index += 1) {
+    await page.keyboard.press("Tab");
+    order.push(
+      await page.evaluate(() => {
+        const element = document.activeElement as HTMLElement | null;
+        const bounds = element?.getBoundingClientRect();
+        return {
+          name: element?.getAttribute("aria-label") ?? "",
+          centerX: (bounds?.x ?? 0) + (bounds?.width ?? 0) / 2,
+          centerY: (bounds?.y ?? 0) + (bounds?.height ?? 0) / 2,
+        };
+      }),
+    );
+  }
+  return order;
+}
+
+function assertCoherentFocusGeometry(order: FocusMeasurement[], viewportWidth: number): void {
+  expect(order).toHaveLength(6);
+  if (viewportWidth <= 375) {
+    for (let index = 1; index < order.length; index += 1) {
+      expect((order[index]?.centerY ?? 0) + 1).toBeGreaterThanOrEqual(
+        order[index - 1]?.centerY ?? Infinity,
+      );
+    }
+    expect(order[1]?.centerY ?? 0).toBeGreaterThan(order[0]?.centerY ?? Infinity);
+    expect(order[2]?.centerY ?? 0).toBeGreaterThan(order[1]?.centerY ?? Infinity);
+    expect(order[3]?.centerX ?? 0).toBeGreaterThan(order[2]?.centerX ?? Infinity);
+    expect(order[4]?.centerX ?? 0).toBeGreaterThan(order[3]?.centerX ?? Infinity);
+    expect(order[5]?.centerY ?? 0).toBeGreaterThan(order[4]?.centerY ?? Infinity);
+    return;
+  }
+
+  for (let index = 1; index < 5; index += 1) {
+    expect(order[index]?.centerX ?? 0).toBeGreaterThan(order[index - 1]?.centerX ?? Infinity);
+  }
+  expect(order[5]?.centerY ?? 0).toBeGreaterThan(order[4]?.centerY ?? Infinity);
 }
 
 async function refreshQueue(page: Page): Promise<void> {

--- a/test/e2e/queue-surface.browser.e2e.ts
+++ b/test/e2e/queue-surface.browser.e2e.ts
@@ -2,7 +2,7 @@ import AxeBuilder from "@axe-core/playwright";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
-import { chromium, type Browser, type Page } from "playwright";
+import { chromium, type Browser, type Locator, type Page } from "playwright";
 import { freePort, runCommand, startProcess, type StartedProcess } from "@opengeni/testing";
 import {
   OMITTED_QUEUE_SOURCE_MARKER,
@@ -138,6 +138,39 @@ type QueueVisibilityEvidence = {
   exactDisclosure: boolean;
 };
 
+type ReflowGeometry = {
+  text: string;
+  left: number;
+  right: number;
+  width: number;
+  height: number;
+  scrollWidth: number;
+  clientWidth: number;
+  horizontalOverflow: number;
+  visible: boolean;
+  textInside: boolean;
+  insideViewport: boolean;
+  insideRow: boolean | null;
+  insideList: boolean | null;
+};
+
+type TextResizeReflowEvidence = {
+  viewport: { width: 320; height: 800 };
+  rootFontSize: "32px";
+  theme: (typeof themes)[number];
+  collapsed: TextPaintGeometry;
+  surfaceCollapsed: ReflowGeometry;
+  listExpanded: ReflowGeometry;
+  rowExpanded: ReflowGeometry;
+  expanded: TextPaintGeometry;
+  disclosureControl: ReflowGeometry;
+  controls: ReflowGeometry[];
+  menu: PortalMenuGeometry;
+  full: ReflowGeometry;
+  hideDisclosureControl: ReflowGeometry;
+  exactDisclosure: boolean;
+};
+
 describe("queue surface browser acceptance", () => {
   let browser: Browser;
   let demo: StartedProcess;
@@ -145,6 +178,7 @@ describe("queue surface browser acceptance", () => {
   const measurements: BrowserMeasurement[] = [];
   const graphemeBoundaryEvidence: GraphemeBoundaryEvidence[] = [];
   const visibilityEvidence: QueueVisibilityEvidence[] = [];
+  const textResizeReflowEvidence: TextResizeReflowEvidence[] = [];
   let accessibilityEvidence: BrowserAccessibilityEvidence | null = null;
 
   beforeAll(async () => {
@@ -212,6 +246,10 @@ describe("queue surface browser acceptance", () => {
     await writeFile(
       `${evidenceDir}/painted-fallbacks.json`,
       `${JSON.stringify({ cases: visibilityEvidence }, null, 2)}\n`,
+    );
+    await writeFile(
+      `${evidenceDir}/text-resize-reflow.json`,
+      `${JSON.stringify({ cases: textResizeReflowEvidence }, null, 2)}\n`,
     );
     await Promise.allSettled([demo?.stop(), browser?.close()]);
   }, 60_000);
@@ -798,6 +836,167 @@ describe("queue surface browser acceptance", () => {
     }
   }, 180_000);
 
+  test("320px mobile queue reflows at 200% root text in both themes", async () => {
+    const viewport = { width: 320, height: 800 } as const;
+    const context = await browser.newContext({ viewport, hasTouch: true, isMobile: true });
+    try {
+      const page = await context.newPage();
+      const diagnostics = observePageFailures(page);
+      for (const theme of themes) {
+        await page.goto(`${baseUrl}/queue.html?count=1&theme=${theme}&visibility=short-zwj`, {
+          waitUntil: "networkidle",
+        });
+        await page.addStyleTag({ content: ":root { font-size: 32px !important; }" });
+        await page.evaluate(() => document.fonts.ready);
+
+        const collapsed = await textPaintGeometry(page, "queue-collapsed-preview");
+        expect(collapsed.text).toMatch(/^Omitted · [0-9A-F]{8}$/);
+        expect(collapsed.elementWidth).toBeGreaterThan(0);
+        expect(collapsed.textWidth).toBeGreaterThan(0);
+        expect(collapsed.intersectionWidth).toBeGreaterThan(0);
+        expect(collapsed.intersectionHeight).toBeGreaterThan(0);
+        expect(collapsed.fullyVisible).toBe(true);
+        expect(collapsed.insideViewport).toBe(true);
+        const surfaceCollapsed = await reflowGeometry(page.getByTestId("queue-surface"));
+        expect(surfaceCollapsed.horizontalOverflow).toBeLessThanOrEqual(1);
+        expect(surfaceCollapsed.insideViewport).toBe(true);
+        expect((await pageMetrics(page)).documentOverflow).toBeLessThanOrEqual(1);
+        const collapsedTree = await chromeAccessibilityTree(page);
+        const collapsedControl = collapsedTree.find(
+          (node) => !node.ignored && node.role === "button" && node.name === "1 queued prompt",
+        );
+        expect(collapsedControl?.description).toMatch(
+          /^Content omitted at safe boundary · ref [0-9A-F]{8}$/,
+        );
+        await page.screenshot({
+          path: `${evidenceDir}/after-320-${theme}-text-resize-collapsed.png`,
+          animations: "disabled",
+        });
+
+        await page.getByRole("button", { name: "1 queued prompt", exact: true }).click();
+        const expanded = await textPaintGeometry(page, "queue-prompt-start-1");
+        expect(expanded.text).toBe(collapsed.text);
+        expect(expanded.elementWidth).toBeGreaterThan(0);
+        expect(expanded.textWidth).toBeGreaterThan(0);
+        expect(expanded.intersectionWidth).toBeGreaterThan(0);
+        expect(expanded.fullyVisible).toBe(true);
+        expect(expanded.insideRow).toBe(true);
+        expect(expanded.insideViewport).toBe(true);
+
+        const listExpanded = await reflowGeometry(page.getByTestId("queue-list"));
+        const rowExpanded = await reflowGeometry(page.locator("[data-queue-turn-id]").first());
+        expect(listExpanded.horizontalOverflow).toBeLessThanOrEqual(1);
+        expect(rowExpanded.horizontalOverflow).toBeLessThanOrEqual(1);
+        expect(listExpanded.insideViewport).toBe(true);
+        expect(rowExpanded.insideViewport).toBe(true);
+
+        const disclosure = page.getByRole("button", {
+          name: "Show full content for queued prompt 1",
+          exact: true,
+        });
+        await disclosure.scrollIntoViewIfNeeded();
+        const disclosureControl = await reflowGeometry(disclosure);
+        expect(disclosureControl.width).toBeGreaterThan(0);
+        expect(disclosureControl.textInside).toBe(true);
+        expect(disclosureControl.insideRow).toBe(true);
+        expect(disclosureControl.insideViewport).toBe(true);
+
+        const controlLocators = [
+          page.getByRole("button", { name: "Reorder queued prompt 1", exact: true }),
+          page.getByRole("button", { name: "Steer queued prompt 1", exact: true }),
+          page.getByRole("button", { name: "Delete queued prompt 1", exact: true }),
+          page.getByRole("button", { name: "More actions for queued prompt 1", exact: true }),
+        ];
+        const controls: ReflowGeometry[] = [];
+        for (const control of controlLocators) {
+          await control.scrollIntoViewIfNeeded();
+          const geometry = await reflowGeometry(control);
+          expect(geometry.width).toBeGreaterThanOrEqual(43);
+          expect(geometry.height).toBeGreaterThanOrEqual(43);
+          expect(geometry.insideRow).toBe(true);
+          expect(geometry.insideViewport).toBe(true);
+          controls.push(geometry);
+        }
+
+        await page
+          .getByRole("button", { name: "More actions for queued prompt 1", exact: true })
+          .click();
+        const menu = await measurePortalMenu(page, 1);
+        expect(menu.itemCount).toBe(5);
+        expect(menu.insideViewport).toBe(true);
+        expect(menu.itemWidths.every((width) => width > 0 && width <= viewport.width)).toBe(true);
+        expect(menu.itemHeights.every((height) => height >= 43)).toBe(true);
+        await page.screenshot({
+          path: `${evidenceDir}/after-320-${theme}-text-resize-menu.png`,
+          animations: "disabled",
+        });
+        await page.keyboard.press("Escape");
+        await page.screenshot({
+          path: `${evidenceDir}/after-320-${theme}-text-resize-expanded.png`,
+          animations: "disabled",
+        });
+
+        await disclosure.scrollIntoViewIfNeeded();
+        await disclosure.click();
+        const fullLocator = page.getByRole("region", {
+          name: "Full content for queued prompt 1",
+          exact: true,
+        });
+        await fullLocator.scrollIntoViewIfNeeded();
+        const full = await reflowGeometry(fullLocator);
+        const exactPrompt = queueVisibilityProbePrompt("short-zwj");
+        expect(await fullLocator.textContent()).toBe(exactPrompt);
+        expect(full.width).toBeGreaterThan(0);
+        expect(full.horizontalOverflow).toBeLessThanOrEqual(1);
+        expect(full.insideRow).toBe(true);
+        expect(full.insideViewport).toBe(true);
+        const hideDisclosure = page.getByRole("button", {
+          name: "Hide full content for queued prompt 1",
+          exact: true,
+        });
+        await hideDisclosure.scrollIntoViewIfNeeded();
+        const hideDisclosureControl = await reflowGeometry(hideDisclosure);
+        expect(hideDisclosureControl.textInside).toBe(true);
+        expect(hideDisclosureControl.insideRow).toBe(true);
+        expect(hideDisclosureControl.insideViewport).toBe(true);
+        expect((await pageMetrics(page)).documentOverflow).toBeLessThanOrEqual(1);
+        const disclosedTree = await chromeAccessibilityTree(page);
+        expect(
+          disclosedTree.some(
+            (node) =>
+              !node.ignored &&
+              node.role === "region" &&
+              node.name === "Full content for queued prompt 1",
+          ),
+        ).toBe(true);
+        await page.screenshot({
+          path: `${evidenceDir}/after-320-${theme}-text-resize-disclosed.png`,
+          animations: "disabled",
+        });
+
+        textResizeReflowEvidence.push({
+          viewport,
+          rootFontSize: "32px",
+          theme,
+          collapsed,
+          surfaceCollapsed,
+          listExpanded,
+          rowExpanded,
+          expanded,
+          disclosureControl,
+          controls,
+          menu,
+          full,
+          hideDisclosureControl,
+          exactDisclosure: (await fullLocator.textContent()) === exactPrompt,
+        });
+      }
+      expect(diagnostics).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  }, 60_000);
+
   test("Chrome exposes whole graphemes at every head and tail preview boundary", async () => {
     const boundaryViewports = [
       { width: 320, height: 800 },
@@ -1135,6 +1334,53 @@ async function textPaintGeometry(page: Page, testId: string): Promise<TextPaintG
         textBounds.right <= window.innerWidth + 0.5 &&
         textBounds.top >= -0.5 &&
         textBounds.bottom <= window.innerHeight + 0.5,
+    };
+  });
+}
+
+async function reflowGeometry(locator: Locator): Promise<ReflowGeometry> {
+  return locator.evaluate((element) => {
+    const bounds = element.getBoundingClientRect();
+    const textRects: DOMRect[] = [];
+    const textWalker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+    while (textWalker.nextNode()) {
+      const range = document.createRange();
+      range.selectNodeContents(textWalker.currentNode);
+      const textBounds = range.getBoundingClientRect();
+      if (textBounds.width > 0 || textBounds.height > 0) textRects.push(textBounds);
+    }
+    const rowBounds = element.closest<HTMLElement>("[data-queue-turn-id]")?.getBoundingClientRect();
+    const listBounds = element
+      .closest<HTMLElement>('[data-testid="queue-list"]')
+      ?.getBoundingClientRect();
+    const styles = getComputedStyle(element);
+    const inside = (inner: DOMRect, outer: DOMRect) =>
+      inner.left >= outer.left - 0.5 &&
+      inner.right <= outer.right + 0.5 &&
+      inner.top >= outer.top - 0.5 &&
+      inner.bottom <= outer.bottom + 0.5;
+    return {
+      text: element.textContent ?? "",
+      left: bounds.left,
+      right: bounds.right,
+      width: bounds.width,
+      height: bounds.height,
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+      horizontalOverflow: Math.max(0, element.scrollWidth - element.clientWidth),
+      visible:
+        styles.display !== "none" && styles.visibility !== "hidden" && Number(styles.opacity) > 0,
+      textInside: textRects.every(
+        (textBounds) =>
+          textBounds.left >= bounds.left - 0.5 && textBounds.right <= bounds.right + 0.5,
+      ),
+      insideViewport:
+        bounds.left >= -0.5 &&
+        bounds.right <= window.innerWidth + 0.5 &&
+        bounds.top >= -0.5 &&
+        bounds.bottom <= window.innerHeight + 0.5,
+      insideRow: rowBounds ? inside(bounds, rowBounds) : null,
+      insideList: listBounds ? inside(bounds, listBounds) : null,
     };
   });
 }


### PR DESCRIPTION
## Summary

- Bound collapsed queue previews to a surrogate-safe 180-character prefix and expanded-row previews to 360 characters, with responsive line/width containment for multiline text, code, bidi/Unicode, URLs, and huge unbroken tokens.
- Keep a 100-row expanded queue inside one bounded list scroller and bound drag overlays/metadata so queue content cannot determine document dimensions.
- Keep the exact queued prompt out of the DOM/accessibility tree until the user intentionally selects **Show full prompt**; disclosure renders the source unchanged in a focusable, labelled, bounded scroll region with an accessible hide action and announcement.
- Apply the same exact-content disclosure behavior to interactive and read-only rows while preserving existing queue data and Edit/Steer/Delete/reorder/settings semantics.
- Add a dedicated queue demo and component/browser regressions across 360/375/768/1440 widths and light/dark themes.

Linear: OPE-9. This PR does **not** change OPE-82 attachment schemas, upload/finalize behavior, draft/queue attachment persistence, model/worker projection, storage, GC, or state-machine behavior.

### Root cause

The canonical queue surface rendered the full durable prompt directly into collapsed/expanded queue content without strict character, line, height, or unbroken-token bounds. A sufficiently large queued prompt could therefore drive row and page dimensions. The fix changes presentation only: durable queue content remains exact, and full text is rendered losslessly only after intentional disclosure inside its own bounded scroller.

### Frozen candidate

- Base `origin/main`: `46744272e69f96329f47a0d3b1d6f93183d1d962`
- Head: `6d81f6e27d0c65358f6dc89ac31497507111760c`
- Tree: `e18dd6407c05143caec6558a1b636eb2b21b35bf`

## Testing

- [x] `packages/react/test/queue-surface.test.tsx`: 6 pass, 0 fail, 155 assertions.
- [x] Dedicated real-browser queue acceptance: 2 pass, 0 fail, 242 assertions (41.53s).
  - 360/375/768/1440 widths, light/dark, collapsed/expanded/disclosed states.
  - Zero horizontal document overflow; 100-row list capped at 480px; disclosed source capped at 256px with internal scrolling.
  - Keyboard disclosure/focus, coarse controls, read-only rows, drag overlay, loading/append refresh, and axe WCAG A/AA checks at 360 and 1440.
- [x] Broader UI/session-control component phase: 144 pass, 0 fail, 524 assertions.
- [x] `bun run --cwd packages/react typecheck`
- [x] `bun run --cwd packages/react build`
- [x] `bun run --cwd apps/web typecheck`
- [x] `bun run --cwd apps/web build` (including bundle budget)
- [x] Scoped `oxfmt --check`, CSS Prettier 2.8.8, and `git diff --check`.
- [ ] Repository `test:ui-session-control` browser phase: blocked before tests because this sandbox has no real PostgreSQL. The test intentionally refuses to skip: `session pin browser E2E requires real PostgreSQL; no skip is allowed`. The gate was not weakened or bypassed.

## Notes

- Production/live verification is not claimed. `https://app.opengeni.ai` resolved as DNS NXDOMAIN from this environment, and no production browser/session state was mutated; consequently there is no authenticated live “before” capture.
- Exact-path open-PR audit:
  - #486 overlaps `queue-surface.tsx` and its component test. Its `requestQueueDraftEdit()` / `composer.hasDraftContent()` work is semantically compatible, but both insert near the same declarations and require deliberate serialization preserving both behaviors.
  - #469, #478, #465, #466, and #488 each add an independent default browser-test entry near this PR’s `scripts/run-browser-e2e.ts` entry.
  - #470 adds an independent Vite demo input near this PR’s queue demo input.
  - Synthetic whole-branch merge checks show textual conflicts for these stale/in-flight heads; the OPE-9 exact-path conflicts are additive except for preserving both compatible #486 queue behaviors. Do not resolve by dropping either entry or callback.
- This is a review candidate only. Do not merge until the commissioned exact-head review and required release sequencing are complete.
