### PR TITLE
chore(repo): verify cleanup diff attributes

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -1,5 +1,7 @@
 name: Agent CI
 
+# Temporary diff-attribute canary; never merged.
+
 # PR gate for the Rust agent workspace (agent/**), purely additive to the bun CI.
 # The FULL OS matrix here IS the cross-platform proof: a macOS/Windows compile or
 # test break is caught per-PR, not at tag time — and since these legs cannot run on


### PR DESCRIPTION
Disposable canary for repository cleanup diff attributes. It changes one safe comment in one marked file and will not be merged.