### PR TITLE
fix(runtime): bound display stack startup

### DIFF
--- a/.changeset/calm-desktops-start.md
+++ b/.changeset/calm-desktops-start.md
@@ -3,4 +3,4 @@
 "@opengeni/api-router": patch
 ---
 
-Bound Modal display startup ownership, poll yielded provider processes to completion, and prevent detached desktop processes from retaining startup locks.
+Bound Modal display startup ownership, parse terminal state only from trusted provider metadata, poll yielded processes to completion, and prevent detached desktop processes from retaining startup locks.

--- a/.changeset/calm-desktops-start.md
+++ b/.changeset/calm-desktops-start.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/runtime": patch
+"@opengeni/api-router": patch
+---
+
+Bound Modal display startup ownership, poll yielded provider processes to completion, and prevent detached desktop processes from retaining startup locks.

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -648,7 +648,13 @@ export async function mintDesktopStream(
     // Idempotent display stack (flock-guarded; a no-op when already up). A box
     // that genuinely can't run the stack degrades to transport:null, not a throw.
     try {
-      await ensureDisplayStack(established.session);
+      await ensureDisplayStack(established.session, {
+        telemetryContext: {
+          callerKind: "viewer",
+          ...(lease.instanceId ? { sandboxId: lease.instanceId } : {}),
+          leaseEpoch: lease.leaseEpoch,
+        },
+      });
     } catch (error) {
       if (error instanceof DisplayStackUnsupportedError) {
         return null;

--- a/docker/desktop/opengeni-desktop-up.sh
+++ b/docker/desktop/opengeni-desktop-up.sh
@@ -10,6 +10,13 @@ W="${DESKTOP_W:-1280}"; H="${DESKTOP_H:-800}"; DPI="${DESKTOP_DPI:-96}"
 PORT="${STREAM_PORT:-${OPENGENI_DESKTOP_STREAM_PORT:-6080}}"
 export DISPLAY=:0
 RUN=/tmp/opengeni-desktop; mkdir -p "$RUN"
+OPENGENI_DESKTOP_STAGE_STARTED_MS="${OPENGENI_DESKTOP_STAGE_STARTED_MS:-$(date +%s%3N)}"
+desktop_stage() {
+  local now_ms
+  now_ms="$(date +%s%3N)"
+  echo "OPENGENI_DESKTOP_STAGE stage=$1 elapsed_ms=$((now_ms-OPENGENI_DESKTOP_STAGE_STARTED_MS))"
+}
+desktop_stage launcher_entry
 
 # ---- SESSION ENVIRONMENT (idempotent; fixes the "Input/output error" + app breakage) ----
 # These export into the XFCE session because XFCE (stage 2 below) inherits this shell's
@@ -31,6 +38,7 @@ if [ ! -S /run/dbus/system_bus_socket ]; then
   mkdir -p /run/dbus
   dbus-daemon --system --fork >/dev/null 2>&1 || true
 fi
+desktop_stage session_environment_ready
 
 # (d) Re-assert the DEFAULT BROWSER config for THIS session's HOME. The image bakes the
 #     config system-wide (/etc/xdg) and into the /workspace skel, but a fresh /workspace
@@ -54,22 +62,32 @@ fi
 # brought the stack up) must never serialize behind the lock holder. `nc -z` to
 # the two loopback ports is the cheap, sub-millisecond "already up?" signal.
 if nc -z 127.0.0.1 "$PORT" >/dev/null 2>&1 && nc -z 127.0.0.1 5900 >/dev/null 2>&1; then
+  desktop_stage launcher_precheck_ready
   echo "OPENGENI_DESKTOP_UP port=$PORT geometry=${W}x${H} dpi=${DPI} (precheck)"
   exit 0
 fi
 
-# FLOCK-IDEMPOTENCY: a single whole-script lock so two concurrent
-# `opengeni-desktop-up` invocations (the API on a viewer op + the agent turn,
-# both racing after a rollover) serialize — the first brings the stack up, the
-# second observes every stage already alive and no-ops. flock auto-releases when
-# this shell exits (the FD closes).
-exec 9>"$RUN/up.lock"
-flock 9
+# FLOCK-IDEMPOTENCY: re-exec this script as the child of a command-mode flock
+# supervisor. The supervisor owns the lock until this child exits; --close keeps
+# its descriptor out of the detached Xvfb/XFCE/x11vnc/websockify descendants, so
+# the lock is actually released after startup. The child marker prevents recursion.
+if [ "${OPENGENI_DESKTOP_LOCKED:-0}" != 1 ]; then
+  desktop_stage inner_flock_wait
+  exec flock --close "$RUN/up.lock" env \
+    OPENGENI_DESKTOP_LOCKED=1 \
+    OPENGENI_DESKTOP_STAGE_STARTED_MS="$OPENGENI_DESKTOP_STAGE_STARTED_MS" \
+    DESKTOP_W="$W" DESKTOP_H="$H" DESKTOP_DPI="$DPI" STREAM_PORT="$PORT" \
+    HOME="$HOME" XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+    "$0"
+fi
+unset OPENGENI_DESKTOP_LOCKED
+desktop_stage inner_flock_acquired
 
 # Re-check under the lock (the stack may have come up while we waited on flock):
 # the same cheap port probe, now race-free. A caller that blocked on a mid-run
 # launch returns the moment the holder finished, without re-running the stages.
 if nc -z 127.0.0.1 "$PORT" >/dev/null 2>&1 && nc -z 127.0.0.1 5900 >/dev/null 2>&1; then
+  desktop_stage launcher_contended_ready
   echo "OPENGENI_DESKTOP_UP port=$PORT geometry=${W}x${H} dpi=${DPI} (precheck)"
   exit 0
 fi
@@ -90,12 +108,14 @@ start() { # name, cmd...
 # root solid BLACK (~13.5 KB PNG) — a clean, unambiguous "not painted yet" the PAINTABLE-FRAME
 # gate (ensureDisplayStack, byte-size floor) distinguishes from a real ~210 KB painted desktop.
 start xvfb Xvfb :0 -ac -screen 0 "${W}x${H}x24" -dpi "$DPI" -nolisten tcp -nolisten unix
+desktop_stage xvfb_issued
 # readiness gate: block until the display answers. 100*0.1s=10s (was 50/5s) — on a
 # STONE-COLD gVisor box (the machine->sandbox swap-recovery turn always hits one) Xvfb's
 # first xdpyinfo answer can exceed 5s under runsc syscall overhead + cold page cache, and
 # a spurious exit 11 here degrades the whole desktop to Channel-A for the turn.
 for i in $(seq 1 100); do xdpyinfo -display :0 >/dev/null 2>&1 && break; sleep 0.1; \
   [ "$i" = "100" ] && { echo "Xvfb failed to come up" >&2; exit 11; }; done
+desktop_stage xvfb_ready
 
 # 1b. KEYMAP — Xvfb boots with a SPARSE default XKB map: only a handful of keysyms
 # have a keycode, so x11vnc silently drops any keysym noVNC sends that isn't in it
@@ -112,6 +132,7 @@ DISPLAY=:0 setxkbmap us 2>>"$RUN/setxkbmap.log" \
 if ! alive xfce; then
   start xfce dbus-launch --exit-with-session startxfce4
 fi
+desktop_stage xfce_dbus_fonts_started
 
 # 3. x11vnc  (shares the EXISTING :0; -shared = native N-viewer fan-out; -forever = survive 0 viewers)
 #    Human take-control: NO -viewonly, so VNC viewers can drive mouse+keyboard into
@@ -124,10 +145,13 @@ start x11vnc x11vnc -display :0 -forever -shared -wait 50 -rfbport 5900 -nopw \
   -xkb -noxdamage -noxfixes -repeat -ping 1 -speeds lan -o "$RUN/x11vnc.full.log"
 for i in $(seq 1 50); do nc -z localhost 5900 && break; sleep 0.1; \
   [ "$i" = "50" ] && { echo "x11vnc failed on :5900" >&2; exit 12; }; done
+desktop_stage x11vnc_ready
 
 # 4. websockify + noVNC  -> ONE exposed port (6080); 5900 stays localhost-only
 start novnc /opt/noVNC/utils/novnc_proxy --vnc localhost:5900 --listen "$PORT" --web /opt/noVNC
 for i in $(seq 1 50); do nc -z localhost "$PORT" && break; sleep 0.1; \
   [ "$i" = "50" ] && { echo "websockify failed on $PORT" >&2; exit 13; }; done
+desktop_stage websockify_ready
 
 echo "OPENGENI_DESKTOP_UP port=$PORT geometry=${W}x${H} dpi=${DPI}"
+desktop_stage launcher_ready

--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -1279,7 +1279,9 @@ export class ComputerUseCapability extends Capability {
           // any computer-use-only recording. One SandboxComputer instance caches
           // this for the rest of the turn.
           prepare: async (preparedSession) => {
-            await ensureDisplayStack(preparedSession);
+            await ensureDisplayStack(preparedSession, {
+              telemetryContext: { callerKind: "computer" },
+            });
             await this.args.onReady?.(preparedSession);
           },
         });

--- a/packages/runtime/src/sandbox/channel-a.ts
+++ b/packages/runtime/src/sandbox/channel-a.ts
@@ -58,6 +58,9 @@ import type {
   TerminalExecRequest,
   TerminalExecResponse,
 } from "@opengeni/contracts";
+import { parseExecBannerExitCode, parseExecBannerSessionId } from "./exec-banner";
+
+export { parseExecBannerExitCode, parseExecBannerSessionId } from "./exec-banner";
 
 // ── The minimal session surface Channel A consumes (a structural subset of the
 // SDK's SandboxSession, all optional — capability-probed before use). ─────────
@@ -1448,34 +1451,6 @@ export function isExecSessionLostBanner(out: string, execSessionId: number): boo
   // String equality is intentional: parseInt would normalize malformed facts
   // such as `01` and can round an out-of-range integer into another identity.
   return match[1] === String(execSessionId);
-}
-
-// Recover the numeric exec-session id the SDK embeds in a formatExecResponse
-// banner for a STILL-RUNNING process (`Process running with session ID <N>`).
-// A finished command emits `Process exited with code <N>` instead (no session
-// id) — that yields null. Only the banner region (before the `Output:` marker)
-// is scanned so a session-id-looking line in the command's own output can't
-// spoof it. This is what makes the interactive PTY work on backends whose only
-// exec surface is execCommand (Modal): without it ptyOpen reports execSessionId
-// = null and every pty/write 409s ("interactive terminal unsupported").
-export function parseExecBannerSessionId(raw: string): number | null {
-  const outputIdx = raw.indexOf("\nOutput:\n");
-  const banner = outputIdx >= 0 ? raw.slice(0, outputIdx) : raw.startsWith("Output:\n") ? "" : raw;
-  const match = banner.match(/Process running with session ID (\d+)/);
-  if (!match) return null;
-  const n = Number.parseInt(match[1]!, 10);
-  return Number.isFinite(n) ? n : null;
-}
-
-/** Recover a completed execCommand fallback's exit status from its banner.
- * Only the banner region is inspected, so command output cannot spoof success. */
-export function parseExecBannerExitCode(raw: string): number | null {
-  const outputIdx = raw.indexOf("\nOutput:\n");
-  const banner = outputIdx >= 0 ? raw.slice(0, outputIdx) : raw.startsWith("Output:\n") ? "" : raw;
-  const match = banner.match(/Process exited with code (-?\d+)/);
-  if (!match) return null;
-  const exitCode = Number.parseInt(match[1]!, 10);
-  return Number.isSafeInteger(exitCode) ? exitCode : null;
 }
 
 function sniffBinary(bytes: Buffer): boolean {

--- a/packages/runtime/src/sandbox/display-stack.ts
+++ b/packages/runtime/src/sandbox/display-stack.ts
@@ -31,6 +31,14 @@ export const STREAM_PORT = DESKTOP_STREAM_PORT;
 // warm path AND the cold-box paint warm-up without masking a genuine wedge.
 export const DISPLAY_STACK_TIMEOUT_MS = 90_000;
 
+// Provider exec APIs use `yieldTimeMs` as an output-yield window, not a process
+// deadline. Poll often enough to surface stage telemetry while the command keeps
+// running, but let the in-box `timeout(1)` own termination (see
+// `boundedDisplayStackCommand`).
+const DISPLAY_STACK_PROVIDER_YIELD_MS = 15_000;
+const DISPLAY_STACK_PROVIDER_POLL_MS = 5_000;
+const DISPLAY_STACK_TERMINATION_GRACE_MS = 5_000;
+
 // PAINTABLE-FRAME gate: poll scrot up to this many times, this many seconds apart,
 // waiting for an actually-PAINTED frame before declaring the stack "up" (~30s worst case).
 const PAINT_PROBE_ATTEMPTS = 150;
@@ -93,7 +101,7 @@ export const DEFAULT_DESKTOP_GEOMETRY: DesktopGeometry = { width: 1280, height: 
  *  value to viewers by the caller; this error is for diagnostics. */
 export class DisplayStackError extends Error {
   readonly exitCode: number;
-  readonly stage: "xvfb" | "x11vnc" | "websockify" | "paint" | "unknown";
+  readonly stage: "xvfb" | "x11vnc" | "websockify" | "paint" | "lock" | "timeout" | "unknown";
 
   constructor(exitCode: number, output: string) {
     const stage =
@@ -105,7 +113,11 @@ export class DisplayStackError extends Error {
             ? "websockify"
             : exitCode === 14
               ? "paint"
-              : "unknown";
+              : exitCode === 15
+                ? "lock"
+                : exitCode === 124 || /OPENGENI_DISPLAY_TIMEOUT/u.test(output)
+                  ? "timeout"
+                  : "unknown";
     super(
       `desktop display stack failed at stage "${stage}" (exit ${exitCode})${output ? `:\n${output}` : ""}`,
     );
@@ -132,6 +144,8 @@ type ExecResultLike = {
   stdout?: string;
   stderr?: string;
   exitCode?: number | null;
+  sessionId?: number;
+  session_id?: number;
 };
 type ExecCapableSession = {
   exec?: (args: {
@@ -144,14 +158,50 @@ type ExecCapableSession = {
     yieldTimeMs?: number;
     maxOutputTokens?: number;
   }) => Promise<string>;
+  writeStdin?: (args: {
+    sessionId: number;
+    chars: string;
+    yieldTimeMs?: number;
+    maxOutputTokens?: number;
+  }) => Promise<ExecResultLike | string>;
+};
+
+export type DisplayStackCallerKind = "viewer" | "computer" | "unknown";
+export type DisplayStackClassification = "cold" | "already_ready" | "contention" | "unknown";
+export type DisplayStackTelemetryStatus = "started" | "waiting" | "completed" | "failed";
+
+/** Secret-free, bounded-cardinality stage observation. Provider/sandbox IDs are
+ * log correlation fields, never metric labels. */
+export type DisplayStackTelemetryEvent = {
+  type: "display_stack.stage";
+  requestId: string;
+  stage: string;
+  status: DisplayStackTelemetryStatus;
+  elapsedMs: number;
+  source: "host" | "sandbox";
+  classification: DisplayStackClassification;
+  callerKind: DisplayStackCallerKind;
+  sandboxId?: string;
+  leaseEpoch?: number;
+  providerSessionId?: number;
+};
+
+export type DisplayStackTelemetryContext = {
+  callerKind: DisplayStackCallerKind;
+  sandboxId?: string;
+  leaseEpoch?: number;
 };
 
 export type EnsureDisplayStackOptions = {
   geometry?: DesktopGeometry;
   /** The exposed stream port; defaults to 6080. */
   port?: number;
-  /** Per-exec timeout; defaults to DISPLAY_STACK_TIMEOUT_MS. */
+  /** Whole-operation wall-clock timeout; defaults to DISPLAY_STACK_TIMEOUT_MS. */
   timeoutMs?: number;
+  /** Caller correlation. Supplying it enables the default structured log sink. */
+  telemetryContext?: DisplayStackTelemetryContext;
+  /** Optional non-blocking telemetry sink (tests/embedders may replace logging). */
+  onTelemetry?: (event: DisplayStackTelemetryEvent) => void | Promise<void>;
 };
 
 export type EnsureDisplayStackResult = {
@@ -214,16 +264,30 @@ export function buildDisplayStackScript(options: EnsureDisplayStackOptions = {})
   // — an already-up display paints on the first probe). Lives in the runtime-built script
   // (not the baked image up-script) so it ships with the worker/api, no image rebuild —
   // and its size floor holds against the currently-deployed image too.
+  const lockedLauncher =
+    `ds_started=$1; fw=$2; ds_class=cold; ` +
+    `ds_stage() { ds_now=$(date +%s%3N); echo "OPENGENI_DISPLAY_STAGE stage=$1 elapsed_ms=$((ds_now-ds_started)) classification=$ds_class"; }; ` +
+    `fa=$(date +%s%3N); fd=$((fa-fw)); [ "$fd" -ge 50 ] && ds_class=contention; ` +
+    `ds_stage outer_flock_acquired; ds_stage launcher_issued; ` +
+    `env ${env} opengeni-desktop-up; urc=$?; ds_stage launcher_complete; exit "$urc"`;
   const bringUp =
     `if nc -z 127.0.0.1 ${port} >/dev/null 2>&1 && nc -z 127.0.0.1 5900 >/dev/null 2>&1; then ` +
+    `ds_class=already_ready; ds_stage precheck_ready; ` +
     `echo "OPENGENI_DESKTOP_UP port=${port} geometry=${geometry.width}x${geometry.height} dpi=${geometry.dpi} (precheck)"; ` +
     `else ` +
-    `mkdir -p /tmp/opengeni-desktop && ` +
-    `flock -w 45 /tmp/opengeni-desktop/up.outer.lock ` +
-    `env ${env} opengeni-desktop-up; ` +
+    `ds_class=cold; ds_stage precheck_miss; ` +
+    `mkdir -p /tmp/opengeni-desktop; ` +
+    `ds_stage outer_flock_wait; fw=$(date +%s%3N); ` +
+    // Command-mode flock is the supervisor: it retains the lock until the launcher
+    // exits, while --close prevents Xvfb/XFCE/x11vnc/websockify from inheriting the
+    // lock descriptor when the launcher intentionally detaches them.
+    `flock --close --conflict-exit-code 75 --wait 45 /tmp/opengeni-desktop/up.outer.lock ` +
+    `bash -c ${shellQuote(lockedLauncher)} _ "$ds_started" "$fw"; frc=$?; ` +
+    `if [ "$frc" -eq 75 ]; then ds_stage outer_flock_timeout; echo "OPENGENI_DESKTOP_LOCK_TIMEOUT"; exit 15; fi; ` +
+    `if [ "$frc" -ne 0 ]; then exit "$frc"; fi; ` +
     `fi`;
   const paintProbe =
-    `p=/tmp/opengeni-desktop/paint-probe.png; prev=0; ` +
+    `ds_stage paint_probe_started; p=/tmp/opengeni-desktop/paint-probe.png; prev=0; ` +
     `for i in $(seq 1 ${PAINT_PROBE_ATTEMPTS}); do ` +
     // Capture, then measure the PNG byte-size. `wc -c < "$p"` yields a bare integer; a
     // failed scrot leaves sz=0. A frame at/above PAINT_MIN_BYTES is a real painted desktop.
@@ -234,14 +298,18 @@ export function buildDisplayStackScript(options: EnsureDisplayStackOptions = {})
     // growing (the full desktop, panel + icons included, is up), not merely crossed the
     // floor mid-paint on a staged gVisor boot. ($sz/$prev/$d are bare shell — no ${}
     // braces — so JS leaves them for bash; ${PAINT_*} ARE JS constants and interpolate.)
-    `if [ "$sz" -ge ${PAINT_MIN_BYTES} ] && [ "$prev" -ge ${PAINT_MIN_BYTES} ]; then d=$((sz-prev)); [ "$d" -lt 0 ] && d=$((0-d)); [ "$d" -le ${PAINT_SETTLE_DELTA_BYTES} ] && break; fi; ` +
+    `if [ "$sz" -ge ${PAINT_MIN_BYTES} ] && [ "$prev" -ge ${PAINT_MIN_BYTES} ]; then d=$((sz-prev)); [ "$d" -lt 0 ] && d=$((0-d)); if [ "$d" -le ${PAINT_SETTLE_DELTA_BYTES} ]; then ds_stage paint_ready; break; fi; fi; ` +
     `prev=$sz; ` +
     // NOTE: NOT_PAINTING goes to STDOUT (not stderr): Modal is execCommand-only, so the
     // caller infers the outcome by string-matching the output — stdout is always captured.
-    `if [ "$i" = "${PAINT_PROBE_ATTEMPTS}" ]; then echo "OPENGENI_DESKTOP_NOT_PAINTING scrot below ${PAINT_MIN_BYTES}B or unsettled after warmup (last=$sz)"; exit 14; fi; ` +
+    `if [ "$i" = "${PAINT_PROBE_ATTEMPTS}" ]; then ds_stage paint_failed; echo "OPENGENI_DESKTOP_NOT_PAINTING scrot below ${PAINT_MIN_BYTES}B or unsettled after warmup (last=$sz)"; exit 14; fi; ` +
     `sleep ${PAINT_PROBE_INTERVAL_S}; ` +
     `done`;
-  return `mkdir -p /tmp/opengeni-desktop; { ${bringUp} ; } && { ${paintProbe} ; }`;
+  const trace =
+    `ds_started=$(date +%s%3N); ds_class=unknown; ` +
+    `ds_stage() { ds_now=$(date +%s%3N); echo "OPENGENI_DISPLAY_STAGE stage=$1 elapsed_ms=$((ds_now-ds_started)) classification=$ds_class"; }; ` +
+    `ds_stage script_entry`;
+  return `${trace}; mkdir -p /tmp/opengeni-desktop; { ${bringUp} ; } && { ${paintProbe} ; }`;
 }
 
 function execResultOutput(result: ExecResultLike | string): string {
@@ -255,9 +323,133 @@ function execResultOutput(result: ExecResultLike | string): string {
 
 function execResultExitCode(result: ExecResultLike | string): number | null {
   if (typeof result === "string") {
-    return null; // execCommand returns a bare string — no exit code available.
+    const matches = [...result.matchAll(/Process exited with code (-?\d+)/gu)];
+    const value = matches.at(-1)?.[1];
+    return value === undefined ? null : Number(value);
   }
   return typeof result.exitCode === "number" ? result.exitCode : null;
+}
+
+function execResultSessionId(result: ExecResultLike | string): number | null {
+  if (typeof result === "string") {
+    const match = /Process running with session ID (\d+)/u.exec(result);
+    return match ? Number(match[1]) : null;
+  }
+  const value = result.sessionId ?? result.session_id;
+  return typeof value === "number" ? value : null;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+/** The provider yield is not a deadline. Bound the actual lock-owning process in
+ * the box, leaving time for TERM/KILL cleanup and the final exit result to reach
+ * the caller before the outer JavaScript deadline. */
+function boundedDisplayStackCommand(command: string, timeoutMs: number): string {
+  const graceMs = Math.min(
+    DISPLAY_STACK_TERMINATION_GRACE_MS,
+    Math.max(20, Math.floor(timeoutMs / 4)),
+  );
+  const commandTimeoutMs = Math.max(1, timeoutMs - graceMs);
+  const killAfterMs = Math.max(1, Math.floor(graceMs / 2));
+  const commandTimeoutSeconds = (commandTimeoutMs / 1_000).toFixed(3);
+  const killAfterSeconds = (killAfterMs / 1_000).toFixed(3);
+  return (
+    // Do not use timeout --foreground here. The display command contains flock
+    // supervisors and launcher children; default process-group mode is required
+    // so a deadline cannot leave a waiter alive to acquire the lock and launch
+    // after the caller has already failed.
+    `timeout --signal=TERM --kill-after=${killAfterSeconds}s ${commandTimeoutSeconds}s ` +
+    `bash -c ${shellQuote(command)}; rc=$?; ` +
+    `if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then ` +
+    `echo "OPENGENI_DISPLAY_TIMEOUT elapsed_ms=${commandTimeoutMs}"; fi; exit "$rc"`
+  );
+}
+
+class DisplayStackWallTimeoutError extends Error {}
+
+async function beforeDeadline<T>(promise: Promise<T>, deadline: number): Promise<T> {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) throw new DisplayStackWallTimeoutError();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new DisplayStackWallTimeoutError()), remainingMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function requestId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function telemetryReporter(options: EnsureDisplayStackOptions, started: number) {
+  const id = requestId();
+  const context = options.telemetryContext;
+  const sink =
+    options.onTelemetry ??
+    (context
+      ? (event: DisplayStackTelemetryEvent) =>
+          console.info(`[display-stack] ${JSON.stringify(event)}`)
+      : undefined);
+  const emittedSandboxStages = new Set<string>();
+
+  const emit = (
+    stage: string,
+    status: DisplayStackTelemetryStatus,
+    fields: {
+      source?: "host" | "sandbox";
+      elapsedMs?: number;
+      classification?: DisplayStackClassification;
+      providerSessionId?: number;
+    } = {},
+  ) => {
+    if (!sink) return;
+    const event: DisplayStackTelemetryEvent = {
+      type: "display_stack.stage",
+      requestId: id,
+      stage,
+      status,
+      elapsedMs: fields.elapsedMs ?? Date.now() - started,
+      source: fields.source ?? "host",
+      classification: fields.classification ?? "unknown",
+      callerKind: context?.callerKind ?? "unknown",
+      ...(context?.sandboxId ? { sandboxId: context.sandboxId } : {}),
+      ...(context?.leaseEpoch !== undefined ? { leaseEpoch: context.leaseEpoch } : {}),
+      ...(fields.providerSessionId !== undefined
+        ? { providerSessionId: fields.providerSessionId }
+        : {}),
+    };
+    try {
+      void Promise.resolve(sink(event)).catch(() => undefined);
+    } catch {
+      // Telemetry must never affect display readiness.
+    }
+  };
+
+  const emitSandboxStages = (output: string) => {
+    for (const match of output.matchAll(
+      /OPENGENI_(?:DISPLAY|DESKTOP)_STAGE stage=([a-z0-9_]+) elapsed_ms=(\d+)(?: classification=(cold|already_ready|contention|unknown))?/gu,
+    )) {
+      const [line, stage, elapsed, classification] = match;
+      if (!stage || !elapsed || emittedSandboxStages.has(line)) continue;
+      emittedSandboxStages.add(line);
+      emit(stage, "completed", {
+        source: "sandbox",
+        elapsedMs: Number(elapsed),
+        classification: (classification as DisplayStackClassification | undefined) ?? "unknown",
+      });
+    }
+  };
+
+  return { emit, emitSandboxStages };
 }
 
 // Parse the exit code the up-script signals via its trailing marker. When we ran
@@ -265,6 +457,12 @@ function execResultExitCode(result: ExecResultLike | string): number | null {
 // bare string), we infer success from the OPENGENI_DESKTOP_UP marker and infer
 // the failing stage from the stage-failure message the script prints to stderr.
 function inferExitFromOutput(output: string): number {
+  if (/OPENGENI_DISPLAY_TIMEOUT/.test(output)) {
+    return 124;
+  }
+  if (/OPENGENI_DESKTOP_LOCK_TIMEOUT/.test(output)) {
+    return 15;
+  }
   // Check the PAINTABLE-FRAME failure FIRST: on that path the up-script already
   // printed OPENGENI_DESKTOP_UP (bring-up succeeded) and THEN the paint gate failed,
   // so both markers are present — the NOT_PAINTING one is the authoritative outcome.
@@ -314,22 +512,75 @@ export async function ensureDisplayStack(
   const geometry = options.geometry ?? DEFAULT_DESKTOP_GEOMETRY;
   const port = options.port ?? DESKTOP_STREAM_PORT;
   const timeoutMs = options.timeoutMs ?? DISPLAY_STACK_TIMEOUT_MS;
-  const cmd = buildDisplayStackScript({ geometry, port });
-
-  const result =
-    typeof s.exec === "function"
-      ? await s.exec({ cmd, yieldTimeMs: timeoutMs, maxOutputTokens: 20_000 })
-      : await s.execCommand!({ cmd, yieldTimeMs: timeoutMs, maxOutputTokens: 20_000 });
-
-  const output = execResultOutput(result);
-  const exitCode = execResultExitCode(result) ?? inferExitFromOutput(output);
-
-  if (exitCode !== 0) {
-    throw new DisplayStackError(exitCode, output);
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError("ensureDisplayStack timeoutMs must be a positive finite number");
   }
+  const started = Date.now();
+  const deadline = started + timeoutMs;
+  const telemetry = telemetryReporter(options, started);
+  const cmd = boundedDisplayStackCommand(buildDisplayStackScript({ geometry, port }), timeoutMs);
+  const outputParts: string[] = [];
+  telemetry.emit("request_entry", "started");
+  telemetry.emit("exec_issued", "started");
 
-  const marker = (output.match(/OPENGENI_DESKTOP_UP[^\n]*/) ?? [""])[0];
-  return { port, geometry, marker };
+  try {
+    const initialYieldMs = Math.max(1, Math.min(DISPLAY_STACK_PROVIDER_YIELD_MS, timeoutMs - 1));
+    const initialExec: Promise<ExecResultLike | string> =
+      typeof s.exec === "function"
+        ? s.exec({ cmd, yieldTimeMs: initialYieldMs, maxOutputTokens: 20_000 })
+        : s.execCommand!({ cmd, yieldTimeMs: initialYieldMs, maxOutputTokens: 20_000 });
+    let result: ExecResultLike | string = await beforeDeadline(initialExec, deadline);
+    let chunk = execResultOutput(result);
+    outputParts.push(chunk);
+    telemetry.emitSandboxStages(chunk);
+    telemetry.emit("provider_first_result", "completed");
+
+    let providerSessionId = execResultSessionId(result);
+    while (providerSessionId !== null) {
+      telemetry.emit("provider_yield", "waiting", { providerSessionId });
+      if (typeof s.writeStdin !== "function") {
+        throw new DisplayStackError(
+          -1,
+          `${outputParts.join("\n")}\nprovider yielded process ${providerSessionId} but exposes no writeStdin poll surface`,
+        );
+      }
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 1) throw new DisplayStackWallTimeoutError();
+      const pollYieldMs = Math.max(1, Math.min(DISPLAY_STACK_PROVIDER_POLL_MS, remainingMs - 1));
+      result = await beforeDeadline(
+        s.writeStdin({
+          sessionId: providerSessionId,
+          chars: "",
+          yieldTimeMs: pollYieldMs,
+          maxOutputTokens: 20_000,
+        }),
+        deadline,
+      );
+      chunk = execResultOutput(result);
+      outputParts.push(chunk);
+      telemetry.emitSandboxStages(chunk);
+      providerSessionId = execResultSessionId(result);
+    }
+
+    const output = outputParts.join("\n");
+    const exitCode = execResultExitCode(result) ?? inferExitFromOutput(output);
+    telemetry.emit("process_complete", exitCode === 0 ? "completed" : "failed");
+    if (exitCode !== 0) {
+      throw new DisplayStackError(exitCode, output);
+    }
+
+    const marker = (output.match(/OPENGENI_DESKTOP_UP[^\n]*/) ?? [""])[0];
+    telemetry.emit("readiness_complete", "completed");
+    return { port, geometry, marker };
+  } catch (error) {
+    if (error instanceof DisplayStackWallTimeoutError) {
+      const output = `${outputParts.join("\n")}\nOPENGENI_DISPLAY_TIMEOUT wall_ms=${timeoutMs}`;
+      telemetry.emit("wall_deadline", "failed");
+      throw new DisplayStackError(124, output);
+    }
+    telemetry.emit("request_failed", "failed");
+    throw error;
+  }
 }
 
 /** Tear the stack down (down-script). Best-effort; never throws on a missing

--- a/packages/runtime/src/sandbox/display-stack.ts
+++ b/packages/runtime/src/sandbox/display-stack.ts
@@ -18,6 +18,7 @@
 // gVisor harness (V2 PASSED live on Modal: XTEST input read-back under runsc).
 
 import { DESKTOP_STREAM_PORT } from "@opengeni/contracts";
+import { parseExecResponseBanner } from "./exec-banner";
 
 // Re-export under the canonical name the module spec uses (STREAM_PORT) while
 // keeping DESKTOP_STREAM_PORT as the single source of truth (contracts).
@@ -323,17 +324,19 @@ function execResultOutput(result: ExecResultLike | string): string {
 
 function execResultExitCode(result: ExecResultLike | string): number | null {
   if (typeof result === "string") {
-    const matches = [...result.matchAll(/Process exited with code (-?\d+)/gu)];
-    const value = matches.at(-1)?.[1];
-    return value === undefined ? null : Number(value);
+    const banner = parseExecResponseBanner(result);
+    if (banner.kind === "exited") return banner.exitCode;
+    // A malformed/truncated SDK response must not fall through to command-body
+    // marker inference, because its real terminal status is unknowable.
+    return banner.kind === "invalid" ? -1 : null;
   }
   return typeof result.exitCode === "number" ? result.exitCode : null;
 }
 
 function execResultSessionId(result: ExecResultLike | string): number | null {
   if (typeof result === "string") {
-    const match = /Process running with session ID (\d+)/u.exec(result);
-    return match ? Number(match[1]) : null;
+    const banner = parseExecResponseBanner(result);
+    return banner.kind === "running" ? banner.sessionId : null;
   }
   const value = result.sessionId ?? result.session_id;
   return typeof value === "number" ? value : null;

--- a/packages/runtime/src/sandbox/display-stack.ts
+++ b/packages/runtime/src/sandbox/display-stack.ts
@@ -409,9 +409,21 @@ type PendingDisplayStackCleanup = {
   markerToken: string;
 };
 
+type DisplayStackOperationWaiter = {
+  epoch: number;
+  settled: boolean;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+  timer?: ReturnType<typeof setTimeout>;
+};
+
 type DisplayStackOperationState = {
   /** Incremented before a timed-out operation is reported to its caller. */
   epoch: number;
+  /** One provider operation at a time for each physical sandbox. */
+  owner: DisplayStackOperationWaiter | null;
+  /** Calls that started in the current epoch but are waiting for admission. */
+  waiters: DisplayStackOperationWaiter[];
   /** Raw provider calls from fenced operations; only the in-box proof gates retries. */
   inFlight: Set<Promise<unknown>>;
   /** A bounded advisory drain for provider calls that may never settle. */
@@ -475,6 +487,8 @@ function stableSandboxIdentity(
 function newOperationState(): DisplayStackOperationState {
   return {
     epoch: 0,
+    owner: null,
+    waiters: [],
     inFlight: new Set(),
     drain: null,
     pendingCleanup: new Map(),
@@ -520,6 +534,75 @@ function operationState(
     displayStackOperationStates.set(key, state);
   }
   return state;
+}
+
+function settleOperationWaiter(waiter: DisplayStackOperationWaiter, error?: unknown): void {
+  if (waiter.settled) return;
+  waiter.settled = true;
+  if (waiter.timer) clearTimeout(waiter.timer);
+  if (error === undefined) waiter.resolve();
+  else waiter.reject(error);
+}
+
+function pumpOperationWaiters(state: DisplayStackOperationState): void {
+  if (state.owner) return;
+  while (state.waiters.length > 0) {
+    const waiter = state.waiters.shift()!;
+    if (waiter.settled) continue;
+    if (waiter.epoch !== state.epoch) {
+      settleOperationWaiter(waiter, new DisplayStackOperationFencedError());
+      continue;
+    }
+    state.owner = waiter;
+    settleOperationWaiter(waiter);
+    return;
+  }
+}
+
+function acquireOperation(
+  state: DisplayStackOperationState,
+  deadline: number,
+): Promise<() => void> {
+  return new Promise<() => void>((resolve, reject) => {
+    const waiter: DisplayStackOperationWaiter = {
+      epoch: state.epoch,
+      settled: false,
+      resolve: () => {
+        resolve(() => {
+          if (state.owner !== waiter) return;
+          state.owner = null;
+          pumpOperationWaiters(state);
+        });
+      },
+      reject,
+    };
+    state.waiters.push(waiter);
+    const remainingMs = deadline - monotonicNow();
+    if (remainingMs <= 0) {
+      waiter.settled = true;
+      state.waiters = state.waiters.filter((candidate) => candidate !== waiter);
+      reject(new DisplayStackWallTimeoutError());
+      return;
+    }
+    waiter.timer = setTimeout(() => {
+      if (waiter.settled) return;
+      waiter.settled = true;
+      state.waiters = state.waiters.filter((candidate) => candidate !== waiter);
+      reject(new DisplayStackWallTimeoutError());
+    }, remainingMs);
+    waiter.timer.unref?.();
+    pumpOperationWaiters(state);
+  });
+}
+
+function invalidateQueuedOperations(state: DisplayStackOperationState, epoch: number): void {
+  const retained: DisplayStackOperationWaiter[] = [];
+  for (const waiter of state.waiters) {
+    if (waiter.epoch === epoch)
+      settleOperationWaiter(waiter, new DisplayStackOperationFencedError());
+    else retained.push(waiter);
+  }
+  state.waiters = retained;
 }
 
 function monotonicNow(): number {
@@ -589,9 +672,11 @@ function fenceOperation(
   abortController.abort(new DisplayStackWallTimeoutError());
   if (!state) return;
 
+  if (state.epoch !== epoch) return;
+
   state.pendingCleanup.set(cleanup.markerToken, cleanup);
   state.physicallyQuiescent = false;
-  if (state.epoch !== epoch) return;
+  invalidateQueuedOperations(state, epoch);
 
   // Advance the ownership epoch BEFORE the timeout error is surfaced. Any
   // completion from this operation is now stale. A retry is gated by the
@@ -925,136 +1010,162 @@ export async function ensureDisplayStack(
   );
   const outputParts: string[] = [];
   const state = operationState(session, options);
-  if (state && !state.physicallyQuiescent) {
-    const cleanupDeadline = monotonicNow() + DISPLAY_STACK_CLEANUP_CALL_MS;
-    const quiesced = await reconcilePendingCleanup(s, state, cleanupDeadline);
-    if (!quiesced) {
-      // Fail closed. A new session wrapper may share this physical sandbox,
-      // but without a positive marker/PGID proof it must not issue overlapping
-      // display work merely because the old SDK promise remains unresolved.
-      throw new DisplayStackError(
-        124,
-        "OPENGENI_DISPLAY_TIMEOUT physical cleanup is still pending; retry is fenced",
-      );
-    }
-  }
-  const epoch = state?.epoch ?? 0;
-  const abortController = new AbortController();
-  let activeProviderSessionId: number | null = null;
-  telemetry.emit("request_entry", "started");
-  telemetry.emit("exec_issued", "started");
-
-  try {
-    const initialYieldMs = Math.max(1, Math.min(DISPLAY_STACK_PROVIDER_YIELD_MS, timeoutMs - 1));
-    const initialExec: Promise<ExecResultLike | string> = trackProviderCall<
-      ExecResultLike | string
-    >(
-      state,
-      Promise.resolve(
-        typeof s.exec === "function"
-          ? s.exec({
-              cmd,
-              yieldTimeMs: initialYieldMs,
-              maxOutputTokens: 20_000,
-              signal: abortController.signal,
-            })
-          : s.execCommand!({
-              cmd,
-              yieldTimeMs: initialYieldMs,
-              maxOutputTokens: 20_000,
-              signal: abortController.signal,
-            }),
-      ),
-    );
-    let result: ExecResultLike | string = await beforeDeadline(initialExec, deadline, monotonicNow);
-    assertCurrentOperation(state, epoch);
-    let chunk = execResultOutput(result);
-    outputParts.push(chunk);
-    telemetry.emitSandboxStages(chunk);
-    telemetry.emit("provider_first_result", "completed");
-
-    let providerSessionId = execResultSessionId(result);
-    activeProviderSessionId = providerSessionId;
-    while (providerSessionId !== null) {
-      telemetry.emit("provider_yield", "waiting", { providerSessionId });
-      if (typeof s.writeStdin !== "function") {
+  let release: (() => void) | undefined;
+  if (state) {
+    try {
+      release = await acquireOperation(state, deadline);
+    } catch (error) {
+      if (
+        error instanceof DisplayStackWallTimeoutError ||
+        error instanceof DisplayStackOperationFencedError
+      ) {
         throw new DisplayStackError(
-          -1,
-          `${outputParts.join("\n")}\nprovider yielded process ${providerSessionId} but exposes no writeStdin poll surface`,
+          124,
+          "OPENGENI_DISPLAY_TIMEOUT display operation admission was fenced",
         );
       }
-      assertCurrentOperation(state, epoch);
-      const remainingMs = deadline - monotonicNow();
-      if (remainingMs <= 1) throw new DisplayStackWallTimeoutError();
-      const pollYieldMs = Math.max(1, Math.min(DISPLAY_STACK_PROVIDER_POLL_MS, remainingMs - 1));
-      result = await beforeDeadline(
-        trackProviderCall(
-          state,
-          s.writeStdin({
-            sessionId: providerSessionId,
-            chars: "",
-            yieldTimeMs: pollYieldMs,
-            maxOutputTokens: 20_000,
-            signal: abortController.signal,
-          }),
+      throw error;
+    }
+  }
+
+  try {
+    if (state && !state.physicallyQuiescent) {
+      const cleanupDeadline = monotonicNow() + DISPLAY_STACK_CLEANUP_CALL_MS;
+      const quiesced = await reconcilePendingCleanup(s, state, cleanupDeadline);
+      if (!quiesced) {
+        // Fail closed. A new session wrapper may share this physical sandbox,
+        // but without a positive marker/PGID proof it must not issue overlapping
+        // display work merely because the old SDK promise remains unresolved.
+        throw new DisplayStackError(
+          124,
+          "OPENGENI_DISPLAY_TIMEOUT physical cleanup is still pending; retry is fenced",
+        );
+      }
+    }
+    const epoch = state?.epoch ?? 0;
+    const abortController = new AbortController();
+    let activeProviderSessionId: number | null = null;
+    telemetry.emit("request_entry", "started");
+    telemetry.emit("exec_issued", "started");
+
+    try {
+      const initialYieldMs = Math.max(1, Math.min(DISPLAY_STACK_PROVIDER_YIELD_MS, timeoutMs - 1));
+      const initialExec: Promise<ExecResultLike | string> = trackProviderCall<
+        ExecResultLike | string
+      >(
+        state,
+        Promise.resolve(
+          typeof s.exec === "function"
+            ? s.exec({
+                cmd,
+                yieldTimeMs: initialYieldMs,
+                maxOutputTokens: 20_000,
+                signal: abortController.signal,
+              })
+            : s.execCommand!({
+                cmd,
+                yieldTimeMs: initialYieldMs,
+                maxOutputTokens: 20_000,
+                signal: abortController.signal,
+              }),
         ),
+      );
+      let result: ExecResultLike | string = await beforeDeadline(
+        initialExec,
         deadline,
         monotonicNow,
       );
       assertCurrentOperation(state, epoch);
-      chunk = execResultOutput(result);
+      let chunk = execResultOutput(result);
       outputParts.push(chunk);
       telemetry.emitSandboxStages(chunk);
-      providerSessionId = execResultSessionId(result);
+      telemetry.emit("provider_first_result", "completed");
+
+      let providerSessionId = execResultSessionId(result);
       activeProviderSessionId = providerSessionId;
-    }
-
-    const output = outputParts.join("\n");
-    const exitCode = execResultExitCode(result) ?? inferExitFromOutput(output);
-    telemetry.emit("process_complete", exitCode === 0 ? "completed" : "failed");
-    if (exitCode !== 0) {
-      throw new DisplayStackError(exitCode, output);
-    }
-
-    const marker = (output.match(/OPENGENI_DESKTOP_UP[^\n]*/) ?? [""])[0];
-    telemetry.emit("readiness_complete", "completed");
-    return { port, geometry, marker };
-  } catch (error) {
-    if (
-      error instanceof DisplayStackWallTimeoutError ||
-      error instanceof DisplayStackOperationFencedError
-    ) {
-      const pendingCleanup: PendingDisplayStackCleanup = {
-        markerPath,
-        markerToken: operationToken,
-      };
-      fenceOperation(state, epoch, abortController, pendingCleanup);
-      const cleanupDeadline = monotonicNow() + DISPLAY_STACK_CLEANUP_CALL_MS;
-      telemetry.emit("process_cleanup", "started");
-      await interruptProviderProcess(
-        s,
-        activeProviderSessionId,
-        Math.min(cleanupDeadline, monotonicNow() + 50),
-      );
-      let quiesced = false;
-      if (state) {
-        quiesced = await reconcilePendingCleanup(s, state, cleanupDeadline);
-        if (!quiesced) {
-          await waitForFencedOperation(
-            state,
-            Math.min(cleanupDeadline, monotonicNow() + DISPLAY_STACK_DRAIN_GRACE_MS),
+      while (providerSessionId !== null) {
+        telemetry.emit("provider_yield", "waiting", { providerSessionId });
+        if (typeof s.writeStdin !== "function") {
+          throw new DisplayStackError(
+            -1,
+            `${outputParts.join("\n")}\nprovider yielded process ${providerSessionId} but exposes no writeStdin poll surface`,
           );
         }
-      } else {
-        quiesced = await cleanupDisplayStackProcess(s, pendingCleanup, cleanupDeadline);
+        assertCurrentOperation(state, epoch);
+        const remainingMs = deadline - monotonicNow();
+        if (remainingMs <= 1) throw new DisplayStackWallTimeoutError();
+        const pollYieldMs = Math.max(1, Math.min(DISPLAY_STACK_PROVIDER_POLL_MS, remainingMs - 1));
+        result = await beforeDeadline(
+          trackProviderCall(
+            state,
+            s.writeStdin({
+              sessionId: providerSessionId,
+              chars: "",
+              yieldTimeMs: pollYieldMs,
+              maxOutputTokens: 20_000,
+              signal: abortController.signal,
+            }),
+          ),
+          deadline,
+          monotonicNow,
+        );
+        assertCurrentOperation(state, epoch);
+        chunk = execResultOutput(result);
+        outputParts.push(chunk);
+        telemetry.emitSandboxStages(chunk);
+        providerSessionId = execResultSessionId(result);
+        activeProviderSessionId = providerSessionId;
       }
-      telemetry.emit("process_cleanup", quiesced ? "completed" : "failed");
-      const output = `${outputParts.join("\n")}\nOPENGENI_DISPLAY_TIMEOUT wall_ms=${timeoutMs}`;
-      telemetry.emit("wall_deadline", "failed");
-      throw new DisplayStackError(124, output);
+
+      const output = outputParts.join("\n");
+      const exitCode = execResultExitCode(result) ?? inferExitFromOutput(output);
+      telemetry.emit("process_complete", exitCode === 0 ? "completed" : "failed");
+      if (exitCode !== 0) {
+        throw new DisplayStackError(exitCode, output);
+      }
+
+      const marker = (output.match(/OPENGENI_DESKTOP_UP[^\n]*/) ?? [""])[0];
+      telemetry.emit("readiness_complete", "completed");
+      return { port, geometry, marker };
+    } catch (error) {
+      if (
+        error instanceof DisplayStackWallTimeoutError ||
+        error instanceof DisplayStackOperationFencedError
+      ) {
+        const pendingCleanup: PendingDisplayStackCleanup = {
+          markerPath,
+          markerToken: operationToken,
+        };
+        fenceOperation(state, epoch, abortController, pendingCleanup);
+        const cleanupDeadline = monotonicNow() + DISPLAY_STACK_CLEANUP_CALL_MS;
+        telemetry.emit("process_cleanup", "started");
+        await interruptProviderProcess(
+          s,
+          activeProviderSessionId,
+          Math.min(cleanupDeadline, monotonicNow() + 50),
+        );
+        let quiesced = false;
+        if (state) {
+          quiesced = await reconcilePendingCleanup(s, state, cleanupDeadline);
+          if (!quiesced) {
+            await waitForFencedOperation(
+              state,
+              Math.min(cleanupDeadline, monotonicNow() + DISPLAY_STACK_DRAIN_GRACE_MS),
+            );
+          }
+        } else {
+          quiesced = await cleanupDisplayStackProcess(s, pendingCleanup, cleanupDeadline);
+        }
+        telemetry.emit("process_cleanup", quiesced ? "completed" : "failed");
+        const output = `${outputParts.join("\n")}\nOPENGENI_DISPLAY_TIMEOUT wall_ms=${timeoutMs}`;
+        telemetry.emit("wall_deadline", "failed");
+        throw new DisplayStackError(124, output);
+      }
+      telemetry.emit("request_failed", "failed");
+      throw error;
     }
-    telemetry.emit("request_failed", "failed");
-    throw error;
+  } finally {
+    release?.();
   }
 }
 

--- a/packages/runtime/src/sandbox/display-stack.ts
+++ b/packages/runtime/src/sandbox/display-stack.ts
@@ -153,17 +153,20 @@ type ExecCapableSession = {
     cmd: string;
     yieldTimeMs?: number;
     maxOutputTokens?: number;
+    signal?: AbortSignal;
   }) => Promise<ExecResultLike>;
   execCommand?: (args: {
     cmd: string;
     yieldTimeMs?: number;
     maxOutputTokens?: number;
+    signal?: AbortSignal;
   }) => Promise<string>;
   writeStdin?: (args: {
     sessionId: number;
     chars: string;
     yieldTimeMs?: number;
     maxOutputTokens?: number;
+    signal?: AbortSignal;
   }) => Promise<ExecResultLike | string>;
 };
 
@@ -365,15 +368,92 @@ function boundedDisplayStackCommand(command: string, timeoutMs: number): string 
     // after the caller has already failed.
     `timeout --signal=TERM --kill-after=${killAfterSeconds}s ${commandTimeoutSeconds}s ` +
     `bash -c ${shellQuote(command)}; rc=$?; ` +
-    `if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then ` +
+    // Exit 137 is also a normal SIGKILL/OOM/provider-termination result. Only
+    // attach timeout attribution to the exit code that this wrapper positively
+    // knows GNU timeout emitted for its own deadline. A kill-after escalation
+    // may still be reported as 137, but it is not safe to infer that here.
+    `if [ "$rc" -eq 124 ]; then ` +
     `echo "OPENGENI_DISPLAY_TIMEOUT elapsed_ms=${commandTimeoutMs}"; fi; exit "$rc"`
   );
 }
 
 class DisplayStackWallTimeoutError extends Error {}
+class DisplayStackOperationFencedError extends Error {}
 
-async function beforeDeadline<T>(promise: Promise<T>, deadline: number): Promise<T> {
-  const remainingMs = deadline - Date.now();
+type DisplayStackOperationState = {
+  /** Incremented before a timed-out operation is reported to its caller. */
+  epoch: number;
+  /** Raw provider calls from fenced operations; retries wait for these to settle. */
+  inFlight: Set<Promise<unknown>>;
+  drain: Promise<void> | null;
+};
+
+const displayStackOperationStates = new WeakMap<object, DisplayStackOperationState>();
+
+function operationState(session: unknown): DisplayStackOperationState | null {
+  if ((typeof session !== "object" || session === null) && typeof session !== "function") {
+    return null;
+  }
+  const key = session as object;
+  let state = displayStackOperationStates.get(key);
+  if (!state) {
+    state = { epoch: 0, inFlight: new Set(), drain: null };
+    displayStackOperationStates.set(key, state);
+  }
+  return state;
+}
+
+function monotonicNow(): number {
+  return performance.now();
+}
+
+async function waitForFencedOperation(state: DisplayStackOperationState): Promise<void> {
+  const drain = state.drain;
+  if (!drain) return;
+  await drain;
+  if (state.drain === drain) state.drain = null;
+}
+
+function trackProviderCall<T>(
+  state: DisplayStackOperationState | null,
+  promise: Promise<T>,
+): Promise<T> {
+  if (!state) return promise;
+  state.inFlight.add(promise);
+  void promise.then(
+    () => state.inFlight.delete(promise),
+    () => state.inFlight.delete(promise),
+  );
+  return promise;
+}
+
+function fenceOperation(
+  state: DisplayStackOperationState | null,
+  epoch: number,
+  abortController: AbortController,
+): void {
+  abortController.abort(new DisplayStackWallTimeoutError());
+  if (!state || state.epoch !== epoch) return;
+
+  // Advance the ownership epoch BEFORE the timeout error is surfaced. Any
+  // completion from this operation is now stale, and the next retry cannot
+  // issue a provider call until every raw call from the old epoch settles.
+  state.epoch += 1;
+  const pending = [...state.inFlight];
+  const drain = Promise.allSettled(pending).then(() => undefined);
+  state.drain = state.drain ? Promise.all([state.drain, drain]).then(() => undefined) : drain;
+}
+
+function assertCurrentOperation(state: DisplayStackOperationState | null, epoch: number): void {
+  if (state && state.epoch !== epoch) throw new DisplayStackOperationFencedError();
+}
+
+async function beforeDeadline<T>(
+  promise: Promise<T>,
+  deadline: number,
+  now: () => number = monotonicNow,
+): Promise<T> {
+  const remainingMs = deadline - now();
   if (remainingMs <= 0) throw new DisplayStackWallTimeoutError();
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
@@ -393,7 +473,11 @@ function requestId(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-function telemetryReporter(options: EnsureDisplayStackOptions, started: number) {
+function telemetryReporter(
+  options: EnsureDisplayStackOptions,
+  started: number,
+  now: () => number = monotonicNow,
+) {
   const id = requestId();
   const context = options.telemetryContext;
   const sink =
@@ -420,7 +504,7 @@ function telemetryReporter(options: EnsureDisplayStackOptions, started: number) 
       requestId: id,
       stage,
       status,
-      elapsedMs: fields.elapsedMs ?? Date.now() - started,
+      elapsedMs: fields.elapsedMs ?? now() - started,
       source: fields.source ?? "host",
       classification: fields.classification ?? "unknown",
       callerKind: context?.callerKind ?? "unknown",
@@ -518,21 +602,47 @@ export async function ensureDisplayStack(
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     throw new RangeError("ensureDisplayStack timeoutMs must be a positive finite number");
   }
-  const started = Date.now();
+  const started = monotonicNow();
   const deadline = started + timeoutMs;
-  const telemetry = telemetryReporter(options, started);
+  const telemetry = telemetryReporter(options, started, monotonicNow);
   const cmd = boundedDisplayStackCommand(buildDisplayStackScript({ geometry, port }), timeoutMs);
   const outputParts: string[] = [];
+  const state = operationState(session);
+  if (state?.drain) {
+    // A retry after a timeout must not start while the previous provider call
+    // is still capable of completing. This is the local ownership fence for
+    // providers that cannot offer a cancellation primitive.
+    await waitForFencedOperation(state);
+  }
+  const epoch = state?.epoch ?? 0;
+  const abortController = new AbortController();
   telemetry.emit("request_entry", "started");
   telemetry.emit("exec_issued", "started");
 
   try {
     const initialYieldMs = Math.max(1, Math.min(DISPLAY_STACK_PROVIDER_YIELD_MS, timeoutMs - 1));
-    const initialExec: Promise<ExecResultLike | string> =
-      typeof s.exec === "function"
-        ? s.exec({ cmd, yieldTimeMs: initialYieldMs, maxOutputTokens: 20_000 })
-        : s.execCommand!({ cmd, yieldTimeMs: initialYieldMs, maxOutputTokens: 20_000 });
-    let result: ExecResultLike | string = await beforeDeadline(initialExec, deadline);
+    const initialExec: Promise<ExecResultLike | string> = trackProviderCall<
+      ExecResultLike | string
+    >(
+      state,
+      Promise.resolve(
+        typeof s.exec === "function"
+          ? s.exec({
+              cmd,
+              yieldTimeMs: initialYieldMs,
+              maxOutputTokens: 20_000,
+              signal: abortController.signal,
+            })
+          : s.execCommand!({
+              cmd,
+              yieldTimeMs: initialYieldMs,
+              maxOutputTokens: 20_000,
+              signal: abortController.signal,
+            }),
+      ),
+    );
+    let result: ExecResultLike | string = await beforeDeadline(initialExec, deadline, monotonicNow);
+    assertCurrentOperation(state, epoch);
     let chunk = execResultOutput(result);
     outputParts.push(chunk);
     telemetry.emitSandboxStages(chunk);
@@ -547,18 +657,25 @@ export async function ensureDisplayStack(
           `${outputParts.join("\n")}\nprovider yielded process ${providerSessionId} but exposes no writeStdin poll surface`,
         );
       }
-      const remainingMs = deadline - Date.now();
+      assertCurrentOperation(state, epoch);
+      const remainingMs = deadline - monotonicNow();
       if (remainingMs <= 1) throw new DisplayStackWallTimeoutError();
       const pollYieldMs = Math.max(1, Math.min(DISPLAY_STACK_PROVIDER_POLL_MS, remainingMs - 1));
       result = await beforeDeadline(
-        s.writeStdin({
-          sessionId: providerSessionId,
-          chars: "",
-          yieldTimeMs: pollYieldMs,
-          maxOutputTokens: 20_000,
-        }),
+        trackProviderCall(
+          state,
+          s.writeStdin({
+            sessionId: providerSessionId,
+            chars: "",
+            yieldTimeMs: pollYieldMs,
+            maxOutputTokens: 20_000,
+            signal: abortController.signal,
+          }),
+        ),
         deadline,
+        monotonicNow,
       );
+      assertCurrentOperation(state, epoch);
       chunk = execResultOutput(result);
       outputParts.push(chunk);
       telemetry.emitSandboxStages(chunk);
@@ -576,7 +693,11 @@ export async function ensureDisplayStack(
     telemetry.emit("readiness_complete", "completed");
     return { port, geometry, marker };
   } catch (error) {
-    if (error instanceof DisplayStackWallTimeoutError) {
+    if (
+      error instanceof DisplayStackWallTimeoutError ||
+      error instanceof DisplayStackOperationFencedError
+    ) {
+      fenceOperation(state, epoch, abortController);
       const output = `${outputParts.join("\n")}\nOPENGENI_DISPLAY_TIMEOUT wall_ms=${timeoutMs}`;
       telemetry.emit("wall_deadline", "failed");
       throw new DisplayStackError(124, output);

--- a/packages/runtime/src/sandbox/display-stack.ts
+++ b/packages/runtime/src/sandbox/display-stack.ts
@@ -39,6 +39,12 @@ export const DISPLAY_STACK_TIMEOUT_MS = 90_000;
 const DISPLAY_STACK_PROVIDER_YIELD_MS = 15_000;
 const DISPLAY_STACK_PROVIDER_POLL_MS = 5_000;
 const DISPLAY_STACK_TERMINATION_GRACE_MS = 5_000;
+// Provider cancellation is transport-level and may never settle. Keep the
+// JavaScript-side cleanup/drain bounded as well; a later caller either gets a
+// positive in-box quiescence proof or remains fail-closed, but it must never
+// wait forever on a provider promise.
+const DISPLAY_STACK_CLEANUP_CALL_MS = 250;
+const DISPLAY_STACK_DRAIN_GRACE_MS = 100;
 
 // PAINTABLE-FRAME gate: poll scrot up to this many times, this many seconds apart,
 // waiting for an actually-PAINTED frame before declaring the stack "up" (~30s worst case).
@@ -149,6 +155,7 @@ type ExecResultLike = {
   session_id?: number;
 };
 type ExecCapableSession = {
+  state?: unknown;
   exec?: (args: {
     cmd: string;
     yieldTimeMs?: number;
@@ -352,7 +359,12 @@ function shellQuote(value: string): string {
 /** The provider yield is not a deadline. Bound the actual lock-owning process in
  * the box, leaving time for TERM/KILL cleanup and the final exit result to reach
  * the caller before the outer JavaScript deadline. */
-function boundedDisplayStackCommand(command: string, timeoutMs: number): string {
+function boundedDisplayStackCommand(
+  command: string,
+  timeoutMs: number,
+  markerPath: string,
+  markerToken: string,
+): string {
   const graceMs = Math.min(
     DISPLAY_STACK_TERMINATION_GRACE_MS,
     Math.max(20, Math.floor(timeoutMs / 4)),
@@ -361,13 +373,25 @@ function boundedDisplayStackCommand(command: string, timeoutMs: number): string 
   const killAfterMs = Math.max(1, Math.floor(graceMs / 2));
   const commandTimeoutSeconds = (commandTimeoutMs / 1_000).toFixed(3);
   const killAfterSeconds = (killAfterMs / 1_000).toFixed(3);
+  const managedCommand =
+    `marker=${shellQuote(markerPath)}; token=${shellQuote(markerToken)}; ` +
+    `cancel="$marker.cancelled"; ` +
+    `if [ -e "$cancel" ]; then echo "OPENGENI_DISPLAY_CANCELLED"; exit 124; fi; ` +
+    `pid=$$; pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' '); ` +
+    `start=$(awk '{print $22}' "/proc/$pid/stat" 2>/dev/null || true); ` +
+    `printf '%s %s %s %s\\n' "$pid" "$pgid" "$start" "$token" >"$marker"; ` +
+    `if [ -e "$cancel" ]; then rm -f "$marker"; echo "OPENGENI_DISPLAY_CANCELLED"; exit 124; fi; ` +
+    // Do not install an EXIT trap: GNU timeout may terminate this supervisor
+    // while descendants survive. The marker must remain for the independent
+    // cleanup command to find and kill that orphaned process group.
+    `bash -c ${shellQuote(command)}; rc=$?; rm -f "$marker"; exit "$rc"`;
   return (
     // Do not use timeout --foreground here. The display command contains flock
     // supervisors and launcher children; default process-group mode is required
     // so a deadline cannot leave a waiter alive to acquire the lock and launch
     // after the caller has already failed.
     `timeout --signal=TERM --kill-after=${killAfterSeconds}s ${commandTimeoutSeconds}s ` +
-    `bash -c ${shellQuote(command)}; rc=$?; ` +
+    `bash -c ${shellQuote(managedCommand)}; rc=$?; ` +
     // Exit 137 is also a normal SIGKILL/OOM/provider-termination result. Only
     // attach timeout attribution to the exit code that this wrapper positively
     // knows GNU timeout emitted for its own deadline. A kill-after escalation
@@ -380,24 +404,119 @@ function boundedDisplayStackCommand(command: string, timeoutMs: number): string 
 class DisplayStackWallTimeoutError extends Error {}
 class DisplayStackOperationFencedError extends Error {}
 
+type PendingDisplayStackCleanup = {
+  markerPath: string;
+  markerToken: string;
+};
+
 type DisplayStackOperationState = {
   /** Incremented before a timed-out operation is reported to its caller. */
   epoch: number;
-  /** Raw provider calls from fenced operations; retries wait for these to settle. */
+  /** Raw provider calls from fenced operations; only the in-box proof gates retries. */
   inFlight: Set<Promise<unknown>>;
+  /** A bounded advisory drain for provider calls that may never settle. */
   drain: Promise<void> | null;
+  /** Timed-out in-box processes that still need an independent kill/verify. */
+  pendingCleanup: Map<string, PendingDisplayStackCleanup>;
+  /** True only after every timed-out process has a positive quiescence proof. */
+  physicallyQuiescent: boolean;
 };
 
+const stableDisplayStackOperationStates = new Map<string, DisplayStackOperationState>();
+const stableSessionStateOperationStates = new WeakMap<object, DisplayStackOperationState>();
 const displayStackOperationStates = new WeakMap<object, DisplayStackOperationState>();
 
-function operationState(session: unknown): DisplayStackOperationState | null {
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readSessionState(session: unknown): unknown {
+  try {
+    return asRecord(session)?.state;
+  } catch {
+    return undefined;
+  }
+}
+
+function stableSandboxIdentity(
+  session: unknown,
+  options: EnsureDisplayStackOptions,
+): string | null {
+  const explicit = nonEmptyString(options.telemetryContext?.sandboxId);
+  if (explicit) return `sandbox:${explicit}`;
+
+  const sessionRecord = asRecord(session);
+  const state = asRecord(readSessionState(session));
+  const providerState = state ? asRecord(state.providerState) : null;
+  const candidates = [sessionRecord, state, providerState];
+  const fields = [
+    "sandboxId",
+    "instanceId",
+    "agentId",
+    "hostId",
+    "containerId",
+    "id",
+    "workspaceRootPath",
+  ];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    for (const field of fields) {
+      const value = nonEmptyString(candidate[field]);
+      if (value) return `sandbox:${value}`;
+    }
+  }
+  return null;
+}
+
+function newOperationState(): DisplayStackOperationState {
+  return {
+    epoch: 0,
+    inFlight: new Set(),
+    drain: null,
+    pendingCleanup: new Map(),
+    physicallyQuiescent: true,
+  };
+}
+
+function operationState(
+  session: unknown,
+  options: EnsureDisplayStackOptions,
+): DisplayStackOperationState | null {
   if ((typeof session !== "object" || session === null) && typeof session !== "function") {
     return null;
   }
+  const stableKey = stableSandboxIdentity(session, options);
+  if (stableKey) {
+    let state = stableDisplayStackOperationStates.get(stableKey);
+    if (!state) {
+      state = newOperationState();
+      stableDisplayStackOperationStates.set(stableKey, state);
+    }
+    return state;
+  }
+
+  // Modal resumed wrappers share their provider `state` object even when the
+  // wrapper instance is reconstructed. This is a useful stable fallback when
+  // an older/provider-specific state shape has no named identity field.
+  const providerState = readSessionState(session);
+  if (providerState && (typeof providerState === "object" || typeof providerState === "function")) {
+    const stateKey = providerState as object;
+    let state = stableSessionStateOperationStates.get(stateKey);
+    if (!state) {
+      state = newOperationState();
+      stableSessionStateOperationStates.set(stateKey, state);
+    }
+    return state;
+  }
+
   const key = session as object;
   let state = displayStackOperationStates.get(key);
   if (!state) {
-    state = { epoch: 0, inFlight: new Set(), drain: null };
+    state = newOperationState();
     displayStackOperationStates.set(key, state);
   }
   return state;
@@ -407,11 +526,19 @@ function monotonicNow(): number {
   return performance.now();
 }
 
-async function waitForFencedOperation(state: DisplayStackOperationState): Promise<void> {
+async function waitForFencedOperation(
+  state: DisplayStackOperationState,
+  deadline: number,
+): Promise<boolean> {
   const drain = state.drain;
-  if (!drain) return;
-  await drain;
+  if (!drain) return true;
+  try {
+    await beforeDeadline(drain, deadline);
+  } catch {
+    return false;
+  }
   if (state.drain === drain) state.drain = null;
+  return true;
 }
 
 function trackProviderCall<T>(
@@ -427,21 +554,58 @@ function trackProviderCall<T>(
   return promise;
 }
 
+function boundedProviderDrain(pending: Promise<unknown>[]): Promise<void> {
+  if (pending.length === 0) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    let remaining = pending.length;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = () => {
+      if (timer) clearTimeout(timer);
+      resolve();
+    };
+    timer = setTimeout(finish, DISPLAY_STACK_DRAIN_GRACE_MS);
+    timer.unref?.();
+    for (const promise of pending) {
+      void promise.then(
+        () => {
+          remaining -= 1;
+          if (remaining === 0) finish();
+        },
+        () => {
+          remaining -= 1;
+          if (remaining === 0) finish();
+        },
+      );
+    }
+  });
+}
+
 function fenceOperation(
   state: DisplayStackOperationState | null,
   epoch: number,
   abortController: AbortController,
+  cleanup: PendingDisplayStackCleanup,
 ): void {
   abortController.abort(new DisplayStackWallTimeoutError());
-  if (!state || state.epoch !== epoch) return;
+  if (!state) return;
+
+  state.pendingCleanup.set(cleanup.markerToken, cleanup);
+  state.physicallyQuiescent = false;
+  if (state.epoch !== epoch) return;
 
   // Advance the ownership epoch BEFORE the timeout error is surfaced. Any
-  // completion from this operation is now stale, and the next retry cannot
-  // issue a provider call until every raw call from the old epoch settles.
+  // completion from this operation is now stale. A retry is gated by the
+  // independent in-box cleanup proof, not by an SDK promise that may hang.
   state.epoch += 1;
   const pending = [...state.inFlight];
-  const drain = Promise.allSettled(pending).then(() => undefined);
+  const drain = boundedProviderDrain(pending);
   state.drain = state.drain ? Promise.all([state.drain, drain]).then(() => undefined) : drain;
+  // A provider transport can retain an unresolved promise forever. Once the
+  // bounded advisory window ends, release those promises from the registry;
+  // the tombstone and in-box process-group proof remain the authoritative fence.
+  void drain.then(() => {
+    for (const promise of pending) state.inFlight.delete(promise);
+  });
 }
 
 function assertCurrentOperation(state: DisplayStackOperationState | null, epoch: number): void {
@@ -467,6 +631,152 @@ async function beforeDeadline<T>(
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+function displayStackCleanupCommand(markerPath: string, markerToken: string): string {
+  const marker = shellQuote(markerPath);
+  const token = shellQuote(markerToken);
+  // The launcher writes pid, process-group id, /proc start time, and a random
+  // token before it starts the lock-owning command. The start-time check keeps
+  // a stale marker from killing an unrelated process after PID reuse. The
+  // process group is the authority: a provider session can disappear while
+  // descendants of the shell continue to hold the display lock.
+  const script =
+    `marker=${marker}; token=${token}; ` +
+    `cancel="$marker.cancelled"; ` +
+    `: >"$cancel" || { echo "OPENGENI_DISPLAY_CLEANUP status=invalid"; exit 75; }; ` +
+    `if [ ! -r "$marker" ]; then echo "OPENGENI_DISPLAY_CLEANUP status=stopped"; exit 0; fi; ` +
+    `read -r pid pgid start actual <"$marker" || { echo "OPENGENI_DISPLAY_CLEANUP status=invalid"; exit 75; }; ` +
+    `[ "$actual" = "$token" ] || { echo "OPENGENI_DISPLAY_CLEANUP status=invalid"; exit 75; }; ` +
+    `case "$pid" in ''|*[!0-9]*) echo "OPENGENI_DISPLAY_CLEANUP status=invalid"; exit 75;; esac; ` +
+    `case "$pgid" in ''|*[!0-9]*) echo "OPENGENI_DISPLAY_CLEANUP status=invalid"; exit 75;; esac; ` +
+    `case "$start" in ''|*[!0-9]*) echo "OPENGENI_DISPLAY_CLEANUP status=invalid"; exit 75;; esac; ` +
+    `current=$(awk '{print $22}' "/proc/$pid/stat" 2>/dev/null || true); ` +
+    `if [ -z "$current" ] || [ "$current" != "$start" ]; then rm -f "$marker"; echo "OPENGENI_DISPLAY_CLEANUP status=stopped"; exit 0; fi; ` +
+    `kill -TERM -- "-$pgid" 2>/dev/null || true; ` +
+    `for i in $(seq 1 10); do ` +
+    `if ! kill -0 -- "-$pgid" 2>/dev/null; then rm -f "$marker"; echo "OPENGENI_DISPLAY_CLEANUP status=stopped"; exit 0; fi; ` +
+    `sleep 0.05; done; ` +
+    `kill -KILL -- "-$pgid" 2>/dev/null || true; ` +
+    `for i in $(seq 1 20); do ` +
+    `if ! kill -0 -- "-$pgid" 2>/dev/null; then rm -f "$marker"; echo "OPENGENI_DISPLAY_CLEANUP status=stopped"; exit 0; fi; ` +
+    `sleep 0.05; done; ` +
+    `echo "OPENGENI_DISPLAY_CLEANUP status=alive"; exit 75`;
+  return `timeout --signal=TERM --kill-after=0.2s 1.5s bash -c ${shellQuote(script)}`;
+}
+
+async function runProviderCommandToDeadline(
+  session: ExecCapableSession,
+  command: string,
+  deadline: number,
+): Promise<ExecResultLike | string> {
+  const controller = new AbortController();
+  let result: ExecResultLike | string = await beforeDeadline(
+    Promise.resolve(
+      typeof session.exec === "function"
+        ? session.exec({
+            cmd: command,
+            yieldTimeMs: Math.min(500, DISPLAY_STACK_CLEANUP_CALL_MS),
+            maxOutputTokens: 4_000,
+            signal: controller.signal,
+          })
+        : session.execCommand!({
+            cmd: command,
+            yieldTimeMs: Math.min(500, DISPLAY_STACK_CLEANUP_CALL_MS),
+            maxOutputTokens: 4_000,
+            signal: controller.signal,
+          }),
+    ),
+    deadline,
+  );
+
+  let providerSessionId = execResultSessionId(result);
+  while (providerSessionId !== null) {
+    if (typeof session.writeStdin !== "function") {
+      throw new Error("display cleanup provider yielded without writeStdin");
+    }
+    const remainingMs = deadline - monotonicNow();
+    if (remainingMs <= 1) throw new DisplayStackWallTimeoutError();
+    result = await beforeDeadline(
+      session.writeStdin({
+        sessionId: providerSessionId,
+        chars: "",
+        yieldTimeMs: Math.max(1, Math.min(250, remainingMs - 1)),
+        maxOutputTokens: 4_000,
+        signal: controller.signal,
+      }),
+      deadline,
+    );
+    providerSessionId = execResultSessionId(result);
+  }
+  return result;
+}
+
+async function interruptProviderProcess(
+  session: ExecCapableSession,
+  providerSessionId: number | null,
+  deadline: number,
+): Promise<void> {
+  if (providerSessionId === null || typeof session.writeStdin !== "function") return;
+  try {
+    // This is an advisory provider-level interrupt. The marker/PGID cleanup
+    // below remains authoritative because Modal 0.13.3 ignores AbortSignal.
+    await beforeDeadline(
+      session.writeStdin({
+        sessionId: providerSessionId,
+        chars: "\u0003",
+        yieldTimeMs: 100,
+        maxOutputTokens: 256,
+      }),
+      deadline,
+    );
+  } catch {
+    // A hung provider write is not evidence either way; in-box cleanup decides.
+  }
+}
+
+async function cleanupDisplayStackProcess(
+  session: ExecCapableSession,
+  pending: PendingDisplayStackCleanup,
+  deadline: number,
+): Promise<boolean> {
+  try {
+    const result = await runProviderCommandToDeadline(
+      session,
+      displayStackCleanupCommand(pending.markerPath, pending.markerToken),
+      deadline,
+    );
+    const output = execResultOutput(result);
+    const status = /OPENGENI_DISPLAY_CLEANUP status=(stopped|absent|alive|invalid)/u.exec(
+      output,
+    )?.[1];
+    return status === "stopped";
+  } catch {
+    return false;
+  }
+}
+
+async function reconcilePendingCleanup(
+  session: ExecCapableSession,
+  state: DisplayStackOperationState,
+  deadline: number,
+): Promise<boolean> {
+  const entries = [...state.pendingCleanup.values()];
+  if (entries.length === 0) {
+    state.physicallyQuiescent = true;
+    return true;
+  }
+  const results = await Promise.all(
+    entries.map(async (pending) => ({
+      pending,
+      stopped: await cleanupDisplayStackProcess(session, pending, deadline),
+    })),
+  );
+  for (const { pending, stopped } of results) {
+    if (stopped) state.pendingCleanup.delete(pending.markerToken);
+  }
+  state.physicallyQuiescent = state.pendingCleanup.size === 0;
+  return state.physicallyQuiescent;
 }
 
 function requestId(): string {
@@ -605,17 +915,32 @@ export async function ensureDisplayStack(
   const started = monotonicNow();
   const deadline = started + timeoutMs;
   const telemetry = telemetryReporter(options, started, monotonicNow);
-  const cmd = boundedDisplayStackCommand(buildDisplayStackScript({ geometry, port }), timeoutMs);
+  const operationToken = requestId();
+  const markerPath = `/tmp/opengeni-desktop/display-stack-${operationToken}.pid`;
+  const cmd = boundedDisplayStackCommand(
+    buildDisplayStackScript({ geometry, port }),
+    timeoutMs,
+    markerPath,
+    operationToken,
+  );
   const outputParts: string[] = [];
-  const state = operationState(session);
-  if (state?.drain) {
-    // A retry after a timeout must not start while the previous provider call
-    // is still capable of completing. This is the local ownership fence for
-    // providers that cannot offer a cancellation primitive.
-    await waitForFencedOperation(state);
+  const state = operationState(session, options);
+  if (state && !state.physicallyQuiescent) {
+    const cleanupDeadline = monotonicNow() + DISPLAY_STACK_CLEANUP_CALL_MS;
+    const quiesced = await reconcilePendingCleanup(s, state, cleanupDeadline);
+    if (!quiesced) {
+      // Fail closed. A new session wrapper may share this physical sandbox,
+      // but without a positive marker/PGID proof it must not issue overlapping
+      // display work merely because the old SDK promise remains unresolved.
+      throw new DisplayStackError(
+        124,
+        "OPENGENI_DISPLAY_TIMEOUT physical cleanup is still pending; retry is fenced",
+      );
+    }
   }
   const epoch = state?.epoch ?? 0;
   const abortController = new AbortController();
+  let activeProviderSessionId: number | null = null;
   telemetry.emit("request_entry", "started");
   telemetry.emit("exec_issued", "started");
 
@@ -649,6 +974,7 @@ export async function ensureDisplayStack(
     telemetry.emit("provider_first_result", "completed");
 
     let providerSessionId = execResultSessionId(result);
+    activeProviderSessionId = providerSessionId;
     while (providerSessionId !== null) {
       telemetry.emit("provider_yield", "waiting", { providerSessionId });
       if (typeof s.writeStdin !== "function") {
@@ -680,6 +1006,7 @@ export async function ensureDisplayStack(
       outputParts.push(chunk);
       telemetry.emitSandboxStages(chunk);
       providerSessionId = execResultSessionId(result);
+      activeProviderSessionId = providerSessionId;
     }
 
     const output = outputParts.join("\n");
@@ -697,7 +1024,31 @@ export async function ensureDisplayStack(
       error instanceof DisplayStackWallTimeoutError ||
       error instanceof DisplayStackOperationFencedError
     ) {
-      fenceOperation(state, epoch, abortController);
+      const pendingCleanup: PendingDisplayStackCleanup = {
+        markerPath,
+        markerToken: operationToken,
+      };
+      fenceOperation(state, epoch, abortController, pendingCleanup);
+      const cleanupDeadline = monotonicNow() + DISPLAY_STACK_CLEANUP_CALL_MS;
+      telemetry.emit("process_cleanup", "started");
+      await interruptProviderProcess(
+        s,
+        activeProviderSessionId,
+        Math.min(cleanupDeadline, monotonicNow() + 50),
+      );
+      let quiesced = false;
+      if (state) {
+        quiesced = await reconcilePendingCleanup(s, state, cleanupDeadline);
+        if (!quiesced) {
+          await waitForFencedOperation(
+            state,
+            Math.min(cleanupDeadline, monotonicNow() + DISPLAY_STACK_DRAIN_GRACE_MS),
+          );
+        }
+      } else {
+        quiesced = await cleanupDisplayStackProcess(s, pendingCleanup, cleanupDeadline);
+      }
+      telemetry.emit("process_cleanup", quiesced ? "completed" : "failed");
       const output = `${outputParts.join("\n")}\nOPENGENI_DISPLAY_TIMEOUT wall_ms=${timeoutMs}`;
       telemetry.emit("wall_deadline", "failed");
       throw new DisplayStackError(124, output);

--- a/packages/runtime/src/sandbox/exec-banner.ts
+++ b/packages/runtime/src/sandbox/exec-banner.ts
@@ -1,0 +1,67 @@
+// The SDK's execCommand/writeStdin fallback returns a formatted response with
+// provider metadata followed by an `Output:` delimiter and command-controlled
+// output. Terminal status is authoritative only in the metadata header; the
+// output body is untrusted and may contain exact copies of SDK banner lines.
+
+const EXEC_BANNER_HEADER_MAX_CHARS = 16 * 1024;
+const OUTPUT_DELIMITER = /\r?\nOutput:\r?\n/u;
+const SDK_METADATA_LINE =
+  /^(?:Chunk ID:|Wall time:|Original token count:|Output:|Process (?:running with session ID|exited with code))/mu;
+const RUNNING_LINE = /^Process running with session ID (\d+)$/u;
+const EXITED_LINE = /^Process exited with code (-?\d+)$/u;
+const PROCESS_STATUS_PREFIX = /^Process (?:running with session ID|exited with code)/u;
+
+export type ExecResponseBanner =
+  | { kind: "absent" }
+  | { kind: "invalid" }
+  | { kind: "running"; sessionId: number }
+  | { kind: "exited"; exitCode: number };
+
+/** Parse exactly one terminal status from the SDK metadata header. Responses
+ * that resemble SDK output but lack a complete delimiter/header are invalid,
+ * while raw provider output without SDK metadata remains `absent` so callers
+ * may use their provider-specific body markers. */
+export function parseExecResponseBanner(raw: string): ExecResponseBanner {
+  const delimiter = OUTPUT_DELIMITER.exec(raw);
+  if (!delimiter) {
+    return SDK_METADATA_LINE.test(raw) ? { kind: "invalid" } : { kind: "absent" };
+  }
+  if (delimiter.index > EXEC_BANNER_HEADER_MAX_CHARS) return { kind: "invalid" };
+
+  const header = raw.slice(0, delimiter.index);
+  const status: Array<{ kind: "running"; value: string } | { kind: "exited"; value: string }> = [];
+  for (const line of header.split(/\r?\n/u)) {
+    const running = RUNNING_LINE.exec(line);
+    if (running) {
+      status.push({ kind: "running", value: running[1]! });
+      continue;
+    }
+    const exited = EXITED_LINE.exec(line);
+    if (exited) {
+      status.push({ kind: "exited", value: exited[1]! });
+      continue;
+    }
+    // A status-looking metadata line that is malformed is ambiguous and must
+    // not be normalized into another process identity or terminal result.
+    if (PROCESS_STATUS_PREFIX.test(line)) return { kind: "invalid" };
+  }
+  if (status.length !== 1) return { kind: "invalid" };
+
+  const terminal = status[0]!;
+  const value = Number(terminal.value);
+  if (!Number.isSafeInteger(value)) return { kind: "invalid" };
+  if (terminal.kind === "running") {
+    return value >= 0 ? { kind: "running", sessionId: value } : { kind: "invalid" };
+  }
+  return { kind: "exited", exitCode: value };
+}
+
+export function parseExecBannerSessionId(raw: string): number | null {
+  const banner = parseExecResponseBanner(raw);
+  return banner.kind === "running" ? banner.sessionId : null;
+}
+
+export function parseExecBannerExitCode(raw: string): number | null {
+  const banner = parseExecResponseBanner(raw);
+  return banner.kind === "exited" ? banner.exitCode : null;
+}

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -106,6 +106,11 @@ export {
   ensureDisplayStack,
   tearDownDisplayStack,
   type DesktopGeometry,
+  type DisplayStackCallerKind,
+  type DisplayStackClassification,
+  type DisplayStackTelemetryContext,
+  type DisplayStackTelemetryEvent,
+  type DisplayStackTelemetryStatus,
   type EnsureDisplayStackOptions,
   type EnsureDisplayStackResult,
 } from "./display-stack";

--- a/packages/runtime/test/channel-a.test.ts
+++ b/packages/runtime/test/channel-a.test.ts
@@ -1566,6 +1566,17 @@ describe("P4.4 parsers — porcelain/numstat/unified-diff", () => {
     const spoof =
       "Chunk ID: abc\nWall time: 0.01 seconds\nProcess exited with code 0\nOutput:\nProcess running with session ID 99";
     expect(parseExecBannerSessionId(spoof)).toBeNull();
+    expect(
+      parseExecBannerSessionId(
+        "Chunk ID: abc\r\nWall time: 0.01 seconds\r\nProcess running with session ID 8\r\nOutput:\r\nready",
+      ),
+    ).toBe(8);
+    expect(
+      parseExecBannerSessionId(
+        "Chunk ID: abc\nProcess running with session ID 7\nProcess running with session ID 8\nOutput:\n",
+      ),
+    ).toBeNull();
+    expect(parseExecBannerSessionId("Process running with session ID 7")).toBeNull();
     expect(parseExecBannerSessionId("no banner")).toBeNull();
   });
 
@@ -1579,6 +1590,17 @@ describe("P4.4 parsers — porcelain/numstat/unified-diff", () => {
       ),
     ).toBeNull();
     expect(parseExecBannerExitCode("Output:\nProcess exited with code 0")).toBeNull();
+    expect(
+      parseExecBannerExitCode(
+        "Chunk ID: abc\r\nProcess exited with code 13\r\nOutput:\r\nProcess exited with code 0",
+      ),
+    ).toBe(13);
+    expect(
+      parseExecBannerExitCode(
+        "Chunk ID: abc\nProcess exited with code 13\nProcess exited with code 0\nOutput:\n",
+      ),
+    ).toBeNull();
+    expect(parseExecBannerExitCode("Chunk ID: abc\nProcess exited with code 0")).toBeNull();
   });
 
   test("isExecSessionLostBanner classifies the lost-PTY writeStdin banner", () => {

--- a/packages/runtime/test/display-stack.test.ts
+++ b/packages/runtime/test/display-stack.test.ts
@@ -16,6 +16,9 @@
 //       the marker line.
 
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   DEFAULT_DESKTOP_GEOMETRY,
   DisplayStackError,
@@ -106,6 +109,10 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     const cmd = box.calls[0]!;
     // flock-wrapped (the idempotency mechanism), runs the canonical script.
     expect(cmd).toContain("flock");
+    // The supervisor retains the lock while the launcher runs, but --close keeps
+    // detached display processes from inheriting it permanently.
+    expect(cmd).toContain("flock --close");
+    expect(cmd).not.toContain("exec 8>");
     expect(cmd).toContain("opengeni-desktop-up");
     // the geometry + port env the script reads.
     expect(cmd).toContain(`DESKTOP_W=${DEFAULT_DESKTOP_GEOMETRY.width}`);
@@ -210,6 +217,38 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     expect(box.launches).toBe(1);
   });
 
+  test("(3b) two concurrent cold callers serialize to exactly one launch", async () => {
+    let launches = 0;
+    let launch: Promise<void> | undefined;
+    let up = false;
+    const session = {
+      exec: async () => {
+        if (!up) {
+          if (!launch) {
+            launches += 1;
+            launch = Bun.sleep(25).then(() => {
+              up = true;
+            });
+          }
+          await launch;
+        }
+        return {
+          output: `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+          exitCode: 0,
+        };
+      },
+    };
+
+    const [viewer, computer] = await Promise.all([
+      ensureDisplayStack(session),
+      ensureDisplayStack(session),
+    ]);
+
+    expect(viewer.marker).toContain("OPENGENI_DESKTOP_UP");
+    expect(computer.marker).toContain("OPENGENI_DESKTOP_UP");
+    expect(launches).toBe(1);
+  });
+
   test("(4a) a stage failure (exit 12) throws a typed DisplayStackError naming the stage", async () => {
     const box = makeFakeBox({ failStage: 12 });
     let thrown: unknown;
@@ -281,5 +320,184 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
       expect(e).toBeInstanceOf(DisplayStackError);
       expect((e as DisplayStackError).stage).toBe("websockify");
     }
+  });
+
+  test("(7) yielded execCommand is polled to process completion instead of misreported as failure", async () => {
+    const telemetry: Array<{ stage: string; status: string; providerSessionId?: number }> = [];
+    let polls = 0;
+    const session = {
+      execCommand: async ({ cmd }: { cmd: string }) => {
+        expect(cmd).toContain("timeout --signal=TERM");
+        expect(cmd).not.toContain("timeout --foreground");
+        return [
+          "Chunk ID: abc123",
+          "Wall time: 0.0100 seconds",
+          "Process running with session ID 7",
+          "Output:",
+          "OPENGENI_DISPLAY_STAGE stage=script_entry elapsed_ms=1 classification=cold",
+        ].join("\n");
+      },
+      writeStdin: async ({ sessionId, chars }: { sessionId: number; chars: string }) => {
+        expect(sessionId).toBe(7);
+        expect(chars).toBe("");
+        polls += 1;
+        return [
+          "Chunk ID: def456",
+          "Wall time: 0.0100 seconds",
+          "Process exited with code 0",
+          "Output:",
+          "OPENGENI_DISPLAY_STAGE stage=paint_ready elapsed_ms=22 classification=cold",
+          `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+        ].join("\n");
+      },
+    };
+
+    const result = await ensureDisplayStack(session, {
+      timeoutMs: 1_000,
+      telemetryContext: { callerKind: "viewer", sandboxId: "sb-test", leaseEpoch: 9 },
+      onTelemetry: (event) => telemetry.push(event),
+    });
+
+    expect(result.marker).toContain("OPENGENI_DESKTOP_UP");
+    expect(polls).toBe(1);
+    expect(telemetry).toContainEqual(
+      expect.objectContaining({
+        stage: "provider_yield",
+        status: "waiting",
+        providerSessionId: 7,
+      }),
+    );
+    expect(telemetry).toContainEqual(
+      expect.objectContaining({ stage: "paint_ready", status: "completed" }),
+    );
+  });
+
+  test("(8) provider wait has a real wall deadline and the in-box owner is independently bounded", async () => {
+    let command = "";
+    const session = {
+      execCommand: async ({ cmd }: { cmd: string }) => {
+        command = cmd;
+        return [
+          "Chunk ID: abc123",
+          "Wall time: 0.0100 seconds",
+          "Process running with session ID 11",
+          "Output:",
+          "",
+        ].join("\n");
+      },
+      writeStdin: async () => await new Promise<string>(() => undefined),
+    };
+
+    const started = Date.now();
+    let thrown: unknown;
+    try {
+      await ensureDisplayStack(session, { timeoutMs: 120, onTelemetry: () => undefined });
+    } catch (error) {
+      thrown = error;
+    }
+    const elapsed = Date.now() - started;
+
+    expect(thrown).toBeInstanceOf(DisplayStackError);
+    expect((thrown as DisplayStackError).stage).toBe("timeout");
+    expect(elapsed).toBeGreaterThanOrEqual(80);
+    expect(elapsed).toBeLessThan(500);
+    expect(command).toContain("timeout --signal=TERM");
+    expect(command).not.toContain("timeout --foreground");
+    expect(command).toContain("OPENGENI_DISPLAY_TIMEOUT");
+  });
+
+  test("(8b) the in-box deadline kills a waiting flock tree before it can launch later", async () => {
+    const root = await mkdtemp(join(tmpdir(), "display-stack-timeout-"));
+    const bin = join(root, "bin");
+    const lock = join(root, "outer.lock");
+    const launches = join(root, "launches");
+    const realFlock = Bun.which("flock");
+    expect(realFlock).not.toBeNull();
+    await Bun.$`mkdir -p ${bin}`;
+    await Promise.all([
+      writeFile(join(bin, "nc"), "#!/usr/bin/env bash\nexit 1\n", { mode: 0o755 }),
+      writeFile(
+        join(bin, "flock"),
+        `#!/usr/bin/env bash\nargs=()\nfor arg in "$@"; do\n  if [ "$arg" = /tmp/opengeni-desktop/up.outer.lock ]; then arg="$DISPLAY_STACK_TEST_LOCK"; fi\n  args+=("$arg")\ndone\nexec "${realFlock}" "\${args[@]}"\n`,
+        { mode: 0o755 },
+      ),
+      writeFile(
+        join(bin, "opengeni-desktop-up"),
+        '#!/usr/bin/env bash\necho launched >>"$DISPLAY_STACK_TEST_LAUNCHES"\nsleep 5\n',
+        { mode: 0o755 },
+      ),
+      writeFile(join(bin, "scrot"), "#!/usr/bin/env bash\nexit 1\n", { mode: 0o755 }),
+    ]);
+    const holder = Bun.spawn([realFlock!, lock, "-c", "sleep 0.6"]);
+
+    try {
+      await Bun.sleep(50);
+      const session = {
+        exec: async ({ cmd }: { cmd: string }) => {
+          const child = Bun.spawn(["bash", "-c", cmd], {
+            env: {
+              ...process.env,
+              PATH: `${bin}:${process.env.PATH ?? ""}`,
+              DISPLAY_STACK_TEST_LOCK: lock,
+              DISPLAY_STACK_TEST_LAUNCHES: launches,
+            },
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([
+            new Response(child.stdout).text(),
+            new Response(child.stderr).text(),
+            child.exited,
+          ]);
+          return { output: `${stdout}\n${stderr}`, exitCode };
+        },
+      };
+
+      let thrown: unknown;
+      try {
+        await ensureDisplayStack(session, { port: 16_082, timeoutMs: 250 });
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(DisplayStackError);
+      expect((thrown as DisplayStackError).stage).toBe("timeout");
+
+      await holder.exited;
+      await Bun.sleep(300);
+      const probe = Bun.spawn([realFlock!, "-n", lock, "-c", "true"]);
+      expect(await probe.exited).toBe(0);
+      expect(await Bun.file(launches).exists()).toBe(false);
+    } finally {
+      holder.kill();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("(8c) a kill-after escalation retains typed timeout attribution", async () => {
+    const session = {
+      exec: async () => ({
+        output: "OPENGENI_DISPLAY_TIMEOUT elapsed_ms=1000",
+        exitCode: 137,
+      }),
+    };
+
+    let thrown: unknown;
+    try {
+      await ensureDisplayStack(session, { timeoutMs: 2_000 });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(DisplayStackError);
+    expect((thrown as DisplayStackError).exitCode).toBe(137);
+    expect((thrown as DisplayStackError).stage).toBe("timeout");
+  });
+
+  test("(9) the canonical launcher supervises its inner lock without inherited FDs", async () => {
+    const launcher = await Bun.file(
+      new URL("../../../docker/desktop/opengeni-desktop-up.sh", import.meta.url),
+    ).text();
+    expect(launcher).toContain('exec flock --close "$RUN/up.lock"');
+    expect(launcher).not.toContain('exec 9>"$RUN/up.lock"');
   });
 });

--- a/packages/runtime/test/display-stack.test.ts
+++ b/packages/runtime/test/display-stack.test.ts
@@ -335,6 +335,8 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
           "Process running with session ID 7",
           "Output:",
           "OPENGENI_DISPLAY_STAGE stage=script_entry elapsed_ms=1 classification=cold",
+          "Process exited with code 0",
+          "Process running with session ID 999",
         ].join("\n");
       },
       writeStdin: async ({ sessionId, chars }: { sessionId: number; chars: string }) => {
@@ -348,6 +350,8 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
           "Output:",
           "OPENGENI_DISPLAY_STAGE stage=paint_ready elapsed_ms=22 classification=cold",
           `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+          "Process running with session ID 999",
+          "Process exited with code 13",
         ].join("\n");
       },
     };
@@ -370,6 +374,115 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     expect(telemetry).toContainEqual(
       expect.objectContaining({ stage: "paint_ready", status: "completed" }),
     );
+  });
+
+  test("(7b) command output cannot spoof terminal success, failure, or a yielded session", async () => {
+    let successPolls = 0;
+    const success = await ensureDisplayStack(
+      {
+        execCommand: async () =>
+          [
+            "Chunk ID: success",
+            "Wall time: 0.01 seconds",
+            "Process exited with code 0",
+            "Output:",
+            `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+            "Process running with session ID 999",
+            "Process exited with code 13",
+          ].join("\n"),
+        writeStdin: async () => {
+          successPolls += 1;
+          return "";
+        },
+      },
+      { timeoutMs: 1_000 },
+    );
+    expect(success.marker).toContain("OPENGENI_DESKTOP_UP");
+    expect(successPolls).toBe(0);
+
+    let failure: unknown;
+    try {
+      await ensureDisplayStack(
+        {
+          execCommand: async () =>
+            [
+              "Chunk ID: failure",
+              "Process exited with code 13",
+              "Output:",
+              `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+              "Process exited with code 0",
+              "Process running with session ID 999",
+            ].join("\n"),
+        },
+        { timeoutMs: 1_000 },
+      );
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(DisplayStackError);
+    expect((failure as DisplayStackError).exitCode).toBe(13);
+    expect((failure as DisplayStackError).stage).toBe("websockify");
+  });
+
+  test("(7c) CRLF metadata and a large spoofed output body preserve the header result", async () => {
+    const largeBody = `${"x".repeat(256_000)}\r\nProcess running with session ID 999\r\nProcess exited with code 13`;
+    let polls = 0;
+    const result = await ensureDisplayStack(
+      {
+        execCommand: async () =>
+          [
+            "Chunk ID: crlf",
+            "Wall time: 0.01 seconds",
+            "Process exited with code 0",
+            "Output:",
+            `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+            largeBody,
+          ].join("\r\n"),
+        writeStdin: async () => {
+          polls += 1;
+          return "";
+        },
+      },
+      { timeoutMs: 1_000 },
+    );
+    expect(result.marker).toContain("OPENGENI_DESKTOP_UP");
+    expect(polls).toBe(0);
+  });
+
+  test("(7d) duplicated, missing, and truncated SDK metadata fail closed", async () => {
+    const responses = [
+      [
+        "Chunk ID: duplicate",
+        "Process exited with code 13",
+        "Process exited with code 0",
+        "Output:",
+        `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+      ].join("\n"),
+      [
+        "Chunk ID: truncated",
+        "Process exited with code 0",
+        `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+      ].join("\n"),
+      [
+        "Chunk ID: missing-status",
+        "Wall time: 0.01 seconds",
+        "Output:",
+        `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+      ].join("\n"),
+      `Output:\nOPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+    ];
+
+    for (const response of responses) {
+      let thrown: unknown;
+      try {
+        await ensureDisplayStack({ execCommand: async () => response }, { timeoutMs: 1_000 });
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(DisplayStackError);
+      expect((thrown as DisplayStackError).exitCode).toBe(-1);
+      expect((thrown as DisplayStackError).stage).toBe("unknown");
+    }
   });
 
   test("(8) provider wait has a real wall deadline and the in-box owner is independently bounded", async () => {

--- a/packages/runtime/test/display-stack.test.ts
+++ b/packages/runtime/test/display-stack.test.ts
@@ -519,7 +519,66 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     expect(command).toContain("OPENGENI_DISPLAY_TIMEOUT");
   });
 
-  test("(8b) the in-box deadline kills a waiting flock tree before it can launch later", async () => {
+  test("(8a) a timed-out provider call is fenced before a retry can issue work", async () => {
+    let resolveFirst!: (result: { output: string; exitCode: number }) => void;
+    let calls = 0;
+    const events: string[] = [];
+    const session = {
+      exec: async ({ signal }: { signal?: AbortSignal }) => {
+        calls += 1;
+        if (calls === 1) {
+          signal?.addEventListener("abort", () => events.push("provider-aborted"), {
+            once: true,
+          });
+          return await new Promise<{ output: string; exitCode: number }>((resolve) => {
+            resolveFirst = resolve;
+          });
+        }
+        events.push("retry-issued");
+        return {
+          output: `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+          exitCode: 0,
+        };
+      },
+    };
+
+    await expect(
+      ensureDisplayStack(session, {
+        timeoutMs: 30,
+        onTelemetry: (event) => events.push(event.stage),
+      }),
+    ).rejects.toMatchObject({ stage: "timeout" });
+    expect(events).toContain("provider-aborted");
+
+    const retry = ensureDisplayStack(session, { timeoutMs: 500 });
+    await Bun.sleep(20);
+    expect(calls).toBe(1);
+    expect(events).not.toContain("retry-issued");
+
+    resolveFirst({ output: "late stale result", exitCode: 0 });
+    await retry;
+    expect(calls).toBe(2);
+    expect(events.indexOf("retry-issued")).toBeGreaterThan(events.indexOf("provider-aborted"));
+  });
+
+  test("(8b) a wall-clock jump cannot extend the monotonic provider deadline", async () => {
+    const originalDateNow = Date.now;
+    const session = {
+      exec: async () => await new Promise<never>(() => undefined),
+    };
+    Date.now = () => originalDateNow() + 86_400_000;
+    const started = performance.now();
+    try {
+      await expect(ensureDisplayStack(session, { timeoutMs: 60 })).rejects.toMatchObject({
+        stage: "timeout",
+      });
+    } finally {
+      Date.now = originalDateNow;
+    }
+    expect(performance.now() - started).toBeLessThan(500);
+  });
+
+  test("(8c) the in-box deadline kills a waiting flock tree before it can launch later", async () => {
     const root = await mkdtemp(join(tmpdir(), "display-stack-timeout-"));
     const bin = join(root, "bin");
     const lock = join(root, "outer.lock");
@@ -586,7 +645,24 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     }
   });
 
-  test("(8c) a kill-after escalation retains typed timeout attribution", async () => {
+  test("(8d) exit 137 is unknown without positive timeout evidence", async () => {
+    const session = {
+      exec: async () => ({ output: "provider terminated the process", exitCode: 137 }),
+    };
+
+    let thrown: unknown;
+    try {
+      await ensureDisplayStack(session, { timeoutMs: 2_000 });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(DisplayStackError);
+    expect((thrown as DisplayStackError).exitCode).toBe(137);
+    expect((thrown as DisplayStackError).stage).toBe("unknown");
+  });
+
+  test("(8e) a kill-after escalation retains typed timeout attribution", async () => {
     const session = {
       exec: async () => ({
         output: "OPENGENI_DISPLAY_TIMEOUT elapsed_ms=1000",

--- a/packages/runtime/test/display-stack.test.ts
+++ b/packages/runtime/test/display-stack.test.ts
@@ -486,10 +486,10 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
   });
 
   test("(8) provider wait has a real wall deadline and the in-box owner is independently bounded", async () => {
-    let command = "";
+    const commands: string[] = [];
     const session = {
       execCommand: async ({ cmd }: { cmd: string }) => {
-        command = cmd;
+        commands.push(cmd);
         return [
           "Chunk ID: abc123",
           "Wall time: 0.0100 seconds",
@@ -514,19 +514,23 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     expect((thrown as DisplayStackError).stage).toBe("timeout");
     expect(elapsed).toBeGreaterThanOrEqual(80);
     expect(elapsed).toBeLessThan(500);
-    expect(command).toContain("timeout --signal=TERM");
-    expect(command).not.toContain("timeout --foreground");
-    expect(command).toContain("OPENGENI_DISPLAY_TIMEOUT");
+    expect(commands[0]).toContain("timeout --signal=TERM");
+    expect(commands[0]).not.toContain("timeout --foreground");
+    expect(commands[0]).toContain("OPENGENI_DISPLAY_TIMEOUT");
   });
 
   test("(8a) a timed-out provider call is fenced before a retry can issue work", async () => {
     let resolveFirst!: (result: { output: string; exitCode: number }) => void;
-    let calls = 0;
+    let workCalls = 0;
     const events: string[] = [];
     const session = {
-      exec: async ({ signal }: { signal?: AbortSignal }) => {
-        calls += 1;
-        if (calls === 1) {
+      exec: async ({ cmd, signal }: { cmd: string; signal?: AbortSignal }) => {
+        if (cmd.includes("OPENGENI_DISPLAY_CLEANUP")) {
+          events.push("cleanup-issued");
+          return { output: "OPENGENI_DISPLAY_CLEANUP status=stopped", exitCode: 0 };
+        }
+        workCalls += 1;
+        if (workCalls === 1) {
           signal?.addEventListener("abort", () => events.push("provider-aborted"), {
             once: true,
           });
@@ -552,13 +556,50 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
 
     const retry = ensureDisplayStack(session, { timeoutMs: 500 });
     await Bun.sleep(20);
-    expect(calls).toBe(1);
-    expect(events).not.toContain("retry-issued");
+    expect(workCalls).toBe(2);
+    expect(events.indexOf("retry-issued")).toBeGreaterThan(events.indexOf("cleanup-issued"));
 
     resolveFirst({ output: "late stale result", exitCode: 0 });
     await retry;
-    expect(calls).toBe(2);
+    expect(workCalls).toBe(2);
     expect(events.indexOf("retry-issued")).toBeGreaterThan(events.indexOf("provider-aborted"));
+  });
+
+  test("(8a2) a fresh wrapper shares the physical fence and requires cleanup before retry", async () => {
+    const events: string[] = [];
+    let oldProcessAlive = true;
+
+    const makeSession = (wrapper: string) => ({
+      // This is the provider state identity, not the transient wrapper object.
+      state: { sandboxId: "stable-display-regression-box" },
+      exec: async ({ cmd, signal }: { cmd: string; signal?: AbortSignal }) => {
+        if (cmd.includes("OPENGENI_DISPLAY_CLEANUP")) {
+          oldProcessAlive = false;
+          events.push(`${wrapper}:cleanup`);
+          return { output: "OPENGENI_DISPLAY_CLEANUP status=stopped", exitCode: 0 };
+        }
+        events.push(`${wrapper}:work`);
+        if (wrapper === "first") {
+          signal?.addEventListener("abort", () => events.push("first:aborted"), { once: true });
+          return await new Promise<{ output: string; exitCode: number }>(() => undefined);
+        }
+        // The second wrapper is only safe to use after the first process-group
+        // cleanup has positively completed.
+        expect(oldProcessAlive).toBe(false);
+        return {
+          output: `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+          exitCode: 0,
+        };
+      },
+    });
+
+    await expect(ensureDisplayStack(makeSession("first"), { timeoutMs: 30 })).rejects.toMatchObject(
+      { stage: "timeout" },
+    );
+    expect(events).toContain("first:cleanup");
+
+    await ensureDisplayStack(makeSession("second"), { timeoutMs: 500 });
+    expect(events.indexOf("second:work")).toBeGreaterThan(events.indexOf("first:cleanup"));
   });
 
   test("(8b) a wall-clock jump cannot extend the monotonic provider deadline", async () => {

--- a/packages/runtime/test/display-stack.test.ts
+++ b/packages/runtime/test/display-stack.test.ts
@@ -221,21 +221,29 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     let launches = 0;
     let launch: Promise<void> | undefined;
     let up = false;
+    let activeProviderCalls = 0;
+    let maxActiveProviderCalls = 0;
     const session = {
       exec: async () => {
-        if (!up) {
-          if (!launch) {
-            launches += 1;
-            launch = Bun.sleep(25).then(() => {
-              up = true;
-            });
+        activeProviderCalls += 1;
+        maxActiveProviderCalls = Math.max(maxActiveProviderCalls, activeProviderCalls);
+        try {
+          if (!up) {
+            if (!launch) {
+              launches += 1;
+              launch = Bun.sleep(25).then(() => {
+                up = true;
+              });
+            }
+            await launch;
           }
-          await launch;
+          return {
+            output: `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+            exitCode: 0,
+          };
+        } finally {
+          activeProviderCalls -= 1;
         }
-        return {
-          output: `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
-          exitCode: 0,
-        };
       },
     };
 
@@ -247,6 +255,93 @@ describe("P4.1 ensureDisplayStack — command sequence + flock-idempotency (fake
     expect(viewer.marker).toContain("OPENGENI_DESKTOP_UP");
     expect(computer.marker).toContain("OPENGENI_DESKTOP_UP");
     expect(launches).toBe(1);
+    expect(maxActiveProviderCalls).toBe(1);
+  });
+
+  test("(3c) a timed-out owner fences a same-sandbox sibling before cleanup permits retry", async () => {
+    const events: string[] = [];
+    let resolveA!: (result: { output: string; exitCode: number }) => void;
+    let workCalls = 0;
+    let allowRetry = false;
+    let notifyWorkA!: () => void;
+    const workAStarted = new Promise<void>((resolve) => {
+      notifyWorkA = resolve;
+    });
+    const session = {
+      state: { sandboxId: "same-sandbox-concurrent-fence-regression" },
+      exec: async ({ cmd, signal }: { cmd: string; signal?: AbortSignal }) => {
+        if (cmd.includes("OPENGENI_DISPLAY_CLEANUP")) {
+          events.push("cleanup-complete");
+          return { output: "OPENGENI_DISPLAY_CLEANUP status=stopped", exitCode: 0 };
+        }
+        workCalls += 1;
+        if (workCalls === 1) {
+          events.push("work-A");
+          notifyWorkA();
+          signal?.addEventListener("abort", () => events.push("abort-A"), { once: true });
+          return await new Promise<{ output: string; exitCode: number }>((resolve) => {
+            resolveA = resolve;
+          });
+        }
+        if (!allowRetry) {
+          events.push("stale-work");
+          throw new Error("stale sibling issued provider work");
+        }
+        events.push("work-C");
+        return {
+          output: `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+          exitCode: 0,
+        };
+      },
+    };
+
+    const operationA = ensureDisplayStack(session, { timeoutMs: 30 });
+    await workAStarted;
+    // B has begun before A times out, but per-sandbox admission keeps it out of
+    // the provider until A either succeeds or invalidates its generation.
+    const operationB = ensureDisplayStack(session, { timeoutMs: 500 });
+    void operationB.catch(() => undefined);
+    await Promise.resolve();
+    expect(workCalls).toBe(1);
+
+    await expect(operationA).rejects.toMatchObject({ stage: "timeout" });
+    expect(events).toContain("cleanup-complete");
+    allowRetry = true;
+    const operationC = ensureDisplayStack(session, { timeoutMs: 500 });
+    await expect(operationC).resolves.toMatchObject({ port: STREAM_PORT });
+    await expect(operationB).rejects.toMatchObject({ stage: "timeout" });
+
+    expect(events).not.toContain("stale-work");
+    expect(events.indexOf("work-C")).toBeGreaterThan(events.indexOf("cleanup-complete"));
+    resolveA({ output: "late stale result", exitCode: 0 });
+  });
+
+  test("(3d) different physical sandboxes retain independent display admission", async () => {
+    let activeProviderCalls = 0;
+    let maxActiveProviderCalls = 0;
+    const makeSession = (sandboxId: string) => ({
+      state: { sandboxId },
+      exec: async () => {
+        activeProviderCalls += 1;
+        maxActiveProviderCalls = Math.max(maxActiveProviderCalls, activeProviderCalls);
+        try {
+          await Bun.sleep(25);
+          return {
+            output: `OPENGENI_DESKTOP_UP port=${STREAM_PORT} geometry=1280x800 dpi=96`,
+            exitCode: 0,
+          };
+        } finally {
+          activeProviderCalls -= 1;
+        }
+      },
+    });
+
+    await Promise.all([
+      ensureDisplayStack(makeSession("independent-display-box-a")),
+      ensureDisplayStack(makeSession("independent-display-box-b")),
+    ]);
+
+    expect(maxActiveProviderCalls).toBe(2);
   });
 
   test("(4a) a stage failure (exit 12) throws a typed DisplayStackError naming the stage", async () => {


### PR DESCRIPTION
## Summary

- poll yielded sandbox exec sessions through `writeStdin` until real process completion instead of treating the provider output-yield window as a deadline
- apply both a JavaScript wall deadline and an independent in-box GNU `timeout` that terminates the full lock/waiter process group
- supervise outer and canonical launcher locks with command-mode `flock --close` so detached Xvfb/XFCE/x11vnc/websockify processes cannot retain startup lock descriptors
- add bounded, secret-safe stage/caller/provider telemetry while preserving lazy desktop startup and the existing paint-readiness gate

## Root cause

Production `ensureDisplayStack` calls taking 202–777 seconds were not slow Modal sandbox creation. Modal's `yieldTimeMs` only bounds how long exec waits before returning output; it can return `Process running with session ID N` while the process continues. The runtime neither polled that session nor enforced a real wall/in-box deadline. Separately, file-descriptor inspection proved detached display descendants inherited the startup lock, allowing later callers to remain serialized after the launcher exited.

## Validation

- `bun test packages/runtime/test/display-stack.test.ts apps/worker/test/display-stack-gating.test.ts --timeout 5000` — 21 pass, 0 fail
- `bun test apps/api/test/sandbox-desktop-stream.test.ts --timeout 30000` — 8 pass, 1 explicitly gated live-Modal skip, 0 fail
- `bun run typecheck` — 20 projects clean
- `bun run lint` — 0 warnings/errors across 825 files
- touched-file `oxfmt --check`, `bash -n docker/desktop/opengeni-desktop-up.sh`, `git diff --check`, and launcher mode check — clean
- current-main compatibility — disjoint path audit plus conflict-free temporary-index synthetic merge

Disposable live Modal canary through the real `ModalSandboxClient`:

- two concurrent cold calls completed in 6,984 ms with one launcher and two paint-ready results
- already-ready follow-up completed in 580 ms
- inherited startup-lock FDs: 0
- forced deadline remained typed as `timeout`, launched no delayed process, and both locks were reacquirable afterward
- X display, :5900 RFB, :6080 noVNC, XTEST mouse movement, framebuffer capture, and browser noVNC connection all verified
- browser status: `Connected (encrypted) to modal:0`

OPE-46 is not deployed or production-verified and remains In Progress.
