### PR TITLE
[OPE-88 canary] stale-base rejection

### DIFF
--- a/.github/ope88-canary-stale-20260721t043540z.txt
+++ b/.github/ope88-canary-stale-20260721t043540z.txt
@@ -1,0 +1,1 @@
+OPE-88 disposable governance canary: stale; created 20260721T043540Z; never merge.\n


### PR DESCRIPTION
Disposable governance canary based on the pre-bootstrap parent. Expected: stale/current-base admission cannot satisfy policy; never merge. This PR will be closed and its branch deleted after evidence capture.