### PR TITLE
fix(repo): preserve hygiene finding line accuracy

### DIFF
--- a/scripts/check-public-repo-hygiene.test.ts
+++ b/scripts/check-public-repo-hygiene.test.ts
@@ -98,6 +98,13 @@ describe("public repository hygiene", () => {
     ).toEqual(["internal issue reference"]);
   });
 
+  test("reports an underscored issue identifier on its exact source line", () => {
+    const identifierIssue = ["__ope", "9SetQueueLoading"].join("");
+    expect(auditPublicText("fixture.ts", `safe line\n${identifierIssue}`)).toEqual([
+      { file: "fixture.ts", line: 2, reason: "internal issue reference" },
+    ]);
+  });
+
   test("rejects more personal exposure shapes", () => {
     const source = [
       ["person", "@proton.me"].join(""),

--- a/scripts/check-public-repo-hygiene.ts
+++ b/scripts/check-public-repo-hygiene.ts
@@ -51,7 +51,7 @@ const PRIVATE_AGENT_DOC = /\.agent\/[A-Z0-9_./-]+\.md\b/gi;
 const PRIVATE_WORKTREE_PATH = /\.claude\/worktrees\//gi;
 const PRIVATE_ISSUE_REFERENCE = /\bcloudgeni\s+#\d+\b/gi;
 const INTERNAL_ISSUE_REFERENCE = new RegExp(
-  ["(?:^|[^A-Za-z0-9])OPE", "(?:[-_ ]?\\d+)(?=[A-Z_a-z-]|\\b)"].join(""),
+  ["(?<![A-Za-z0-9])OPE", "(?:[-_ ]?\\d+)(?=[A-Z_a-z-]|\\b)"].join(""),
   "gi",
 );
 const INTERNAL_WORK_LABEL = /\b(?:SPIKE|BUG|FORK)[-_ ]?\d+(?=[A-Z_a-z-]|\b)/gi;


### PR DESCRIPTION
## Summary
- make the internal issue-code boundary non-consuming
- preserve detection for underscored identifiers
- report the exact source line in hygiene findings

## Verification
- bun test scripts/check-public-repo-hygiene.test.ts scripts/check-source-admission.test.ts
- bun run check:public-hygiene
- bun run typecheck
- bun run lint
- git diff --check