### PR TITLE
Use the full Codex subscription allowance

### DIFF
--- a/.changeset/use-full-codex-allowance.md
+++ b/.changeset/use-full-codex-allowance.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/config": patch
+"@opengeni/worker-bundle": patch
+---
+
+Keep deterministic Codex subscription sharding sticky through 99% usage and
+rotate only after actual exhaustion or a definitive provider refusal. Remove the
+configurable near-exhaustion cutoff so warning presentation cannot strand usable
+subscription allowance.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -126,6 +126,7 @@ import {
   settingsWithSessionMcpServersForRun,
 } from "./capabilities";
 import {
+  CODEX_USAGE_EXHAUSTED_PCT,
   authoritativeCodexCapacityResetAt,
   chooseRotationActive,
   classifyCodexPin,
@@ -1370,7 +1371,7 @@ export function acceptsPromptCacheKeyForTurn(
  * The turn hot path never refreshes Codex usage — only the usage API route does — so a
  * window that has actually reset still reads OVER-threshold from the stale cache, which
  * would idle-loop forever. Before idling, refresh LIVE usage for every connected account
- * the cache marks over-threshold (bounded to the account count), which re-writes the
+ * the cache marks exhausted (bounded to the account count), which re-writes the
  * cache columns, then return the re-read rows so the ranker can pick up a genuinely-reset
  * window THIS turn. A refresh/read failure is swallowed (fall back to the pre-refresh rows
  * + the bounded idle). Cooling (429'd) accounts are NOT refreshed: their exhaustedUntil
@@ -1386,11 +1387,11 @@ async function refreshCappedCodexUsageRows(
     wakeSessionWorkflow: ActivityServices["wakeSessionWorkflow"];
   },
 ): Promise<CodexAccountStatus[]> {
-  const nearPct = settings.codexRotationNearExhaustionPct;
   const stale = accounts.filter(
     (a) =>
       a.status === "active" &&
-      ((a.primaryUsedPercent ?? 0) >= nearPct || (a.secondaryUsedPercent ?? 0) >= nearPct),
+      ((a.primaryUsedPercent ?? 0) >= CODEX_USAGE_EXHAUSTED_PCT ||
+        (a.secondaryUsedPercent ?? 0) >= CODEX_USAGE_EXHAUSTED_PCT),
   );
   if (stale.length === 0) {
     return accounts;
@@ -2337,7 +2338,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             sessionPinSource,
             sessionLastCredentialId: sessionCodex?.lastCredentialId ?? null,
             continuationCredentialId: continuationCodexCredentialId,
-            nearExhaustionPct: settings.codexRotationNearExhaustionPct,
             now: new Date(),
           });
 
@@ -2547,7 +2547,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         if (codexLeaseHeld) startCodexLeaseHeartbeat();
 
         const eligibleCount = leased.accounts.filter((account) =>
-          isCodexCredentialEligible(account, settings.codexRotationNearExhaustionPct, new Date()),
+          isCodexCredentialEligible(account, new Date()),
         ).length;
         const poolDepth = eligibleCount === 0 ? "zero" : eligibleCount === 1 ? "one" : "many";
         observability.incrementCounter({
@@ -2724,7 +2724,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           if (goalActive && goal) {
             const authoritativeResetAt = authoritativeCodexCapacityResetAt(
               leased.accounts,
-              settings.codexRotationNearExhaustionPct,
               new Date(),
             );
             const armed = await armCodexCapacityWait(db, {
@@ -5249,12 +5248,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   : {}),
               }
             : null;
-          const cooldownUntil = codexCredentialCooldownUntil(
-            codexCredentialFailure,
-            serving,
-            settings.codexRotationNearExhaustionPct,
-            now,
-          );
+          const cooldownUntil = codexCredentialCooldownUntil(codexCredentialFailure, serving, now);
           const statePersisted =
             codexLeaseHolderId && codexLeaseGeneration !== null
               ? await quarantineCodexCredentialForLease(db, {
@@ -5299,7 +5293,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 activeCredentialId: rotation.activeCredentialId,
                 priorCredentialId: effectiveCodexCredentialId,
                 accounts,
-                nearExhaustionPct: settings.codexRotationNearExhaustionPct,
                 now: new Date(),
                 usedConnectors: serving?.connectorNamespaces ?? [],
               })
@@ -5422,7 +5415,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             const until = codexCredentialCooldownUntil(
               { kind: "quota", cooldownSeconds: usageLimit.resetsInSeconds },
               serving,
-              settings.codexRotationNearExhaustionPct,
               new Date(),
             )!;
             // Finding 1a: INSPECT the cooldown-write result. A swallowed best-effort
@@ -5460,7 +5452,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               const newHome = shardCredentialForSession({
                 sessionId: input.sessionId,
                 accounts: fresh,
-                nearExhaustionPct: settings.codexRotationNearExhaustionPct,
                 now: new Date(),
               });
               if (newHome) {
@@ -5509,16 +5500,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               } else {
                 // Every account capped/cooling → idle until the earliest reset across all.
                 rotated = true;
-                allCappedResetAt = earliestCodexReset(
-                  fresh,
-                  settings.codexRotationNearExhaustionPct,
-                  new Date(),
-                );
-                capacityAuthoritativeResetAt = authoritativeCodexCapacityResetAt(
-                  fresh,
-                  settings.codexRotationNearExhaustionPct,
-                  new Date(),
-                );
+                allCappedResetAt = earliestCodexReset(fresh, new Date());
+                capacityAuthoritativeResetAt = authoritativeCodexCapacityResetAt(fresh, new Date());
               }
             } else {
               const decision = chooseRotationActive({
@@ -5526,7 +5509,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 activeCredentialId: rotation.activeCredentialId,
                 priorCredentialId: effectiveCodexCredentialId,
                 accounts: fresh,
-                nearExhaustionPct: settings.codexRotationNearExhaustionPct,
                 now: new Date(),
                 // P4: the just-capped serving account's connector set is the proxy for
                 // "what this session has access to" — prefer a covering failover target.
@@ -5553,11 +5535,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               } else if (decision.kind === "allCapped") {
                 rotated = true;
                 allCappedResetAt = decision.earliestResetAt;
-                capacityAuthoritativeResetAt = authoritativeCodexCapacityResetAt(
-                  fresh,
-                  settings.codexRotationNearExhaustionPct,
-                  new Date(),
-                );
+                capacityAuthoritativeResetAt = authoritativeCodexCapacityResetAt(fresh, new Date());
               }
               // kind:"none" → fall through to today's single-account idle.
             }
@@ -6457,7 +6435,6 @@ export function codexCredentialCooldownUntil(
     CodexAccountStatus,
     "primaryUsedPercent" | "primaryResetAt" | "secondaryUsedPercent" | "secondaryResetAt"
   > | null,
-  nearExhaustionPct: number,
   now: Date,
 ): Date | null {
   if (failure.kind === "auth" || failure.kind === "forbidden") {
@@ -6479,7 +6456,7 @@ export function codexCredentialCooldownUntil(
       ]
         .filter(
           (window): window is { used: number; reset: Date } =>
-            (window.used ?? 0) >= nearExhaustionPct &&
+            (window.used ?? 0) >= CODEX_USAGE_EXHAUSTED_PCT &&
             window.reset instanceof Date &&
             window.reset.getTime() > now.getTime(),
         )

--- a/apps/worker/src/activities/codex-capacity.ts
+++ b/apps/worker/src/activities/codex-capacity.ts
@@ -9,6 +9,7 @@ import {
 } from "@opengeni/db";
 import type { Settings } from "@opengeni/config";
 import {
+  CODEX_USAGE_EXHAUSTED_PCT,
   authoritativeCodexCapacityResetAt,
   isCodexCredentialEligible,
   selectCodexCredentialLeaseForTurn,
@@ -94,7 +95,6 @@ export function codexCapacityDecision(
     sessionPinSource: context.sessionPinSource,
     sessionLastCredentialId: context.sessionLastCredentialId,
     continuationCredentialId: null,
-    nearExhaustionPct: settings.codexRotationNearExhaustionPct,
     now,
   });
   if (selected.credentialId) {
@@ -103,17 +103,12 @@ export function codexCapacityDecision(
       credentialId: selected.credentialId,
       diagnostic: {
         connectedCount: context.accounts.length,
-        eligibleCount: context.accounts.filter((account) =>
-          isCodexCredentialEligible(account, settings.codexRotationNearExhaustionPct, now),
-        ).length,
+        eligibleCount: context.accounts.filter((account) => isCodexCredentialEligible(account, now))
+          .length,
       },
     };
   }
-  const authoritativeReset = authoritativeCodexCapacityResetAt(
-    context.accounts,
-    settings.codexRotationNearExhaustionPct,
-    now,
-  );
+  const authoritativeReset = authoritativeCodexCapacityResetAt(context.accounts, now);
   return {
     kind: "unavailable",
     earliestResetAt: authoritativeReset,
@@ -135,8 +130,8 @@ async function refreshCapacityMetadata(
     (account) =>
       account.allocatorEnabled &&
       account.status === "active" &&
-      ((account.primaryUsedPercent ?? 0) >= services.settings.codexRotationNearExhaustionPct ||
-        (account.secondaryUsedPercent ?? 0) >= services.settings.codexRotationNearExhaustionPct ||
+      ((account.primaryUsedPercent ?? 0) >= CODEX_USAGE_EXHAUSTED_PCT ||
+        (account.secondaryUsedPercent ?? 0) >= CODEX_USAGE_EXHAUSTED_PCT ||
         account.usageCheckedAt === null),
   );
   await refreshCodexUsageAndRepairCapacityWaiters(

--- a/apps/worker/src/activities/codex-rotation.ts
+++ b/apps/worker/src/activities/codex-rotation.ts
@@ -114,12 +114,14 @@ export type CodexTurnLeaseSelection = {
 /** The minimum all-capped idle: continueDelayMs is clamped to at least this (never 0). */
 export const MIN_IDLE_MS = 60_000; // 60s
 /**
- * Cooldown applied to an over-threshold account whose cached reset is null / unknown
+ * Cooldown applied to an exhausted account whose cached reset is null / unknown
  * / already-elapsed (the turn hot path never refreshes usage, so a capped window's
  * reset reads stale). Treating it as "available after a default cooldown" keeps
  * availableAt — and therefore earliestReset — ALWAYS in the future.
  */
 export const DEFAULT_RESET_COOLDOWN_MS = 60_000; // 60s
+/** Cached provider usage becomes unavailable only at actual exhaustion. */
+export const CODEX_USAGE_EXHAUSTED_PCT = 100;
 
 function effectiveWindowUsed(usedPercent: number | null, resetAt: Date | null, now: Date): number {
   // A completed provider window is eligible immediately even if its last cache
@@ -192,42 +194,32 @@ function droppedConnectorsFor(acct: CodexRotationAccount, usedConnectors: string
 
 /**
  * Healthy for an already-frozen/in-flight turn = connected/usable (status
- * "active", excludes needs_relogin/error), not cooling, and under the
- * near-exhaustion threshold on BOTH windows. Allocator eligibility is
+ * "active", excludes needs_relogin/error), not cooling, and not exhausted in
+ * either provider window. Allocator eligibility is
  * deliberately separate so disabling NEW work cannot break refresh/resume.
  */
-export function isCodexCredentialHealthy(
-  acct: CodexRotationAccount,
-  nearExhaustionPct: number,
-  now: Date,
-): boolean {
+export function isCodexCredentialHealthy(acct: CodexRotationAccount, now: Date): boolean {
   return (
-    acct.status === "active" && !cooling(acct, now) && bindingUsedPct(acct, now) < nearExhaustionPct
+    acct.status === "active" &&
+    !cooling(acct, now) &&
+    bindingUsedPct(acct, now) < CODEX_USAGE_EXHAUSTED_PCT
   );
 }
 
 /** New automatic allocation requires both health and explicit allocator eligibility. */
-export function isCodexCredentialEligible(
-  acct: CodexRotationAccount,
-  nearExhaustionPct: number,
-  now: Date,
-): boolean {
-  return acct.allocatorEnabled && isCodexCredentialHealthy(acct, nearExhaustionPct, now);
+export function isCodexCredentialEligible(acct: CodexRotationAccount, now: Date): boolean {
+  return acct.allocatorEnabled && isCodexCredentialHealthy(acct, now);
 }
 
 /**
  * Public eligibility predicate (same definition as the private `eligible`): an
- * account is usable this turn iff it is connected/active, not cooling, and under
- * the near-exhaustion threshold on BOTH windows. The worker's sharded home
+ * account is usable this turn iff it is connected/active, not cooling, and below
+ * actual exhaustion on both windows. The worker's sharded home
  * health-check uses this to decide whether a session's existing policy pin is still
  * a valid home or must be re-sharded.
  */
-export function isCodexAccountEligible(
-  acct: CodexRotationAccount,
-  nearExhaustionPct: number,
-  now: Date,
-): boolean {
-  return isCodexCredentialEligible(acct, nearExhaustionPct, now);
+export function isCodexAccountEligible(acct: CodexRotationAccount, now: Date): boolean {
+  return isCodexCredentialEligible(acct, now);
 }
 
 /** Deterministic 32-bit FNV-1a over a UTF-16 code-unit stream. Pure, allocation-free. */
@@ -244,7 +236,7 @@ function fnv1a32(input: string): number {
 /**
  * Session-sharded HOME account (AM-6): the deterministic account a session runs on
  * under the "sharded" strategy — `stableAccountList[ hash(sessionId) % N ]` over the
- * ELIGIBLE (connected, not cooling, under-threshold) accounts in stable created_at
+ * ELIGIBLE (connected, not cooling, not exhausted) accounts in stable created_at
  * order (`listCodexAccountStatuses`).
  *
  * Why deterministic hash over "least-loaded by session count" (AM-6): it needs ZERO
@@ -263,13 +255,10 @@ function fnv1a32(input: string): number {
 export function shardCredentialForSession(args: {
   sessionId: string;
   accounts: CodexRotationAccount[];
-  nearExhaustionPct: number;
   now: Date;
 }): string | null {
-  const { sessionId, accounts, nearExhaustionPct, now } = args;
-  const eligibles = accounts.filter((acct) =>
-    isCodexCredentialEligible(acct, nearExhaustionPct, now),
-  );
+  const { sessionId, accounts, now } = args;
+  const eligibles = accounts.filter((acct) => isCodexCredentialEligible(acct, now));
   if (eligibles.length === 0) {
     return null;
   }
@@ -278,12 +267,8 @@ export function shardCredentialForSession(args: {
 }
 
 /** earliestResetAt across ALL connected accounts — exported for the sharded all-capped idle. */
-export function earliestCodexReset(
-  accounts: CodexRotationAccount[],
-  nearExhaustionPct: number,
-  now: Date,
-): Date {
-  return earliestReset(accounts, nearExhaustionPct, now);
+export function earliestCodexReset(accounts: CodexRotationAccount[], now: Date): Date {
+  return earliestReset(accounts, now);
 }
 
 /**
@@ -307,21 +292,20 @@ export function chooseShardedHome(args: {
   sessionId: string;
   currentPolicyPin: string | null;
   accounts: CodexRotationAccount[];
-  nearExhaustionPct: number;
   now: Date;
 }):
   | { kind: "home"; credentialId: string; rewritePin: boolean }
   | { kind: "allCapped"; earliestResetAt: Date } {
-  const { sessionId, currentPolicyPin, accounts, nearExhaustionPct, now } = args;
+  const { sessionId, currentPolicyPin, accounts, now } = args;
   const pinRow = currentPolicyPin
     ? (accounts.find((acct) => acct.id === currentPolicyPin) ?? null)
     : null;
-  if (pinRow && isCodexCredentialEligible(pinRow, nearExhaustionPct, now)) {
+  if (pinRow && isCodexCredentialEligible(pinRow, now)) {
     return { kind: "home", credentialId: currentPolicyPin!, rewritePin: false };
   }
-  const home = shardCredentialForSession({ sessionId, accounts, nearExhaustionPct, now });
+  const home = shardCredentialForSession({ sessionId, accounts, now });
   if (home == null) {
-    return { kind: "allCapped", earliestResetAt: earliestReset(accounts, nearExhaustionPct, now) };
+    return { kind: "allCapped", earliestResetAt: earliestReset(accounts, now) };
   }
   return { kind: "home", credentialId: home, rewritePin: true };
 }
@@ -338,11 +322,7 @@ export function chooseShardedHome(args: {
  * default cooldown (now + DEFAULT_RESET_COOLDOWN_MS), so the caller always idles a
  * bounded positive time and re-checks (which refreshes usage and self-heals).
  */
-export function availableAt(
-  acct: CodexRotationAccount,
-  nearExhaustionPct: number,
-  now: Date,
-): Date {
+export function availableAt(acct: CodexRotationAccount, now: Date): Date {
   const nowMs = now.getTime();
   // An unknown/elapsed block clears after a default cooldown, never in the past.
   const defaultClear = new Date(nowMs + DEFAULT_RESET_COOLDOWN_MS);
@@ -359,11 +339,13 @@ export function availableAt(
     candidates.push(resetAt != null && resetAt.getTime() > nowMs ? resetAt : defaultClear);
   };
   windowClear(
-    effectiveWindowUsed(acct.primaryUsedPercent, acct.primaryResetAt, now) >= nearExhaustionPct,
+    effectiveWindowUsed(acct.primaryUsedPercent, acct.primaryResetAt, now) >=
+      CODEX_USAGE_EXHAUSTED_PCT,
     acct.primaryResetAt,
   );
   windowClear(
-    effectiveWindowUsed(acct.secondaryUsedPercent, acct.secondaryResetAt, now) >= nearExhaustionPct,
+    effectiveWindowUsed(acct.secondaryUsedPercent, acct.secondaryResetAt, now) >=
+      CODEX_USAGE_EXHAUSTED_PCT,
     acct.secondaryResetAt,
   );
   // Ineligible for a non-quota reason (needs_relogin / error) with no known block, or
@@ -376,13 +358,9 @@ export function availableAt(
 }
 
 /** earliestResetAt across ALL connected accounts (min of each account's availableAt). */
-function earliestReset(
-  accounts: CodexRotationAccount[],
-  nearExhaustionPct: number,
-  now: Date,
-): Date {
+function earliestReset(accounts: CodexRotationAccount[], now: Date): Date {
   return accounts
-    .map((acct) => availableAt(acct, nearExhaustionPct, now))
+    .map((acct) => availableAt(acct, now))
     .reduce((a, b) => (b.getTime() < a.getTime() ? b : a));
 }
 
@@ -394,7 +372,6 @@ function earliestReset(
  */
 export function authoritativeCodexCapacityResetAt(
   accounts: CodexRotationAccount[],
-  nearExhaustionPct: number,
   now: Date,
 ): Date | null {
   const future: Date[] = [];
@@ -404,14 +381,14 @@ export function authoritativeCodexCapacityResetAt(
       future.push(account.exhaustedUntil);
     }
     if (
-      (account.primaryUsedPercent ?? 0) >= nearExhaustionPct &&
+      (account.primaryUsedPercent ?? 0) >= CODEX_USAGE_EXHAUSTED_PCT &&
       account.primaryResetAt &&
       account.primaryResetAt.getTime() > now.getTime()
     ) {
       future.push(account.primaryResetAt);
     }
     if (
-      (account.secondaryUsedPercent ?? 0) >= nearExhaustionPct &&
+      (account.secondaryUsedPercent ?? 0) >= CODEX_USAGE_EXHAUSTED_PCT &&
       account.secondaryResetAt &&
       account.secondaryResetAt.getTime() > now.getTime()
     ) {
@@ -513,7 +490,6 @@ export function chooseRotationActive(args: {
   activeCredentialId: string | null;
   priorCredentialId: string | null;
   accounts: CodexRotationAccount[];
-  nearExhaustionPct: number;
   now: Date;
   // P4 (Part B): the connectors the leaving session has access to (the leaving
   // account's cached connector set, used as the "session needs these" proxy).
@@ -521,7 +497,7 @@ export function chooseRotationActive(args: {
   // P3 (every account trivially covers → Tier 1 == all eligibles). Self-gating.
   usedConnectors?: string[];
 }): RotationDecision {
-  const { activeCredentialId, priorCredentialId, accounts, nearExhaustionPct, now } = args;
+  const { activeCredentialId, priorCredentialId, accounts, now } = args;
   // Normalize at the entry point: rotation-enabled ALWAYS behaves as sharded
   // (see effectiveRotationStrategy). args keeps the field so call sites and
   // tests can still express stored legacy values.
@@ -533,20 +509,18 @@ export function chooseRotationActive(args: {
     return { kind: "none" };
   }
 
-  const eligibles = allocatableAccounts.filter((acct) =>
-    isCodexCredentialEligible(acct, nearExhaustionPct, now),
-  );
+  const eligibles = allocatableAccounts.filter((acct) => isCodexCredentialEligible(acct, now));
 
   // The active pointer is a cursor/manual preference, NOT a sticky lease. In
   // particular, most_remaining must rank the whole eligible pool every turn;
-  // keeping a healthy active account until 90% was the production monopolization
+  // keeping a healthy active account sticky was the production monopolization
   // defect fixed by credential allocator. drain_then_next remains the one explicitly sticky
   // strategy, and a manual pin is handled by the caller as explicit policy.
   const decide = (chosen: CodexRotationAccount | undefined): RotationDecision => {
     if (!chosen) {
       return {
         kind: "allCapped",
-        earliestResetAt: earliestReset(allocatableAccounts, nearExhaustionPct, now),
+        earliestResetAt: earliestReset(allocatableAccounts, now),
       };
     }
     // P4: surface the dropped-connector note when the chosen account doesn't cover
@@ -566,7 +540,7 @@ export function chooseRotationActive(args: {
     if (eligibles.length === 0) {
       return {
         kind: "allCapped",
-        earliestResetAt: earliestReset(allocatableAccounts, nearExhaustionPct, now),
+        earliestResetAt: earliestReset(allocatableAccounts, now),
       };
     }
     const priorIdx = priorCredentialId
@@ -579,7 +553,7 @@ export function chooseRotationActive(args: {
             ...allocatableAccounts.slice(0, priorIdx + 1),
           ]
         : allocatableAccounts;
-    const chosen = ordered.find((acct) => isCodexCredentialEligible(acct, nearExhaustionPct, now));
+    const chosen = ordered.find((acct) => isCodexCredentialEligible(acct, now));
     return decide(chosen);
   }
 
@@ -588,7 +562,7 @@ export function chooseRotationActive(args: {
     const priorRow = priorCredentialId
       ? accounts.find((acct) => acct.id === priorCredentialId)
       : undefined;
-    if (priorRow && isCodexCredentialEligible(priorRow, nearExhaustionPct, now)) {
+    if (priorRow && isCodexCredentialEligible(priorRow, now)) {
       return decide(priorRow);
     }
     return decide(eligibles[0]);
@@ -648,7 +622,7 @@ export function chooseLegacyRotationActive(
     const active = args.activeCredentialId
       ? args.accounts.find((account) => account.id === args.activeCredentialId)
       : undefined;
-    if (active && isCodexCredentialEligible(active, args.nearExhaustionPct, args.now)) {
+    if (active && isCodexCredentialEligible(active, args.now)) {
       return { kind: "active", credentialId: active.id, moved: false };
     }
   }
@@ -678,7 +652,6 @@ export function selectCodexCredentialLeaseForTurn(args: {
   sessionLastCredentialId: string | null;
   /** Same-turn checkpoint/frozen account; temporary disable cannot move it. */
   continuationCredentialId?: string | null;
-  nearExhaustionPct: number;
   now: Date;
 }): CodexTurnLeaseSelection {
   const {
@@ -696,7 +669,7 @@ export function selectCodexCredentialLeaseForTurn(args: {
   const existing = existingCredentialId
     ? accounts.find((account) => account.id === existingCredentialId)
     : undefined;
-  if (existing && isCodexCredentialHealthy(existing, args.nearExhaustionPct, args.now)) {
+  if (existing && isCodexCredentialHealthy(existing, args.now)) {
     return {
       credentialId: existing.id,
       advanceActivePointer: false,
@@ -711,7 +684,7 @@ export function selectCodexCredentialLeaseForTurn(args: {
   const continuation = args.continuationCredentialId
     ? accounts.find((account) => account.id === args.continuationCredentialId)
     : undefined;
-  if (continuation && isCodexCredentialHealthy(continuation, args.nearExhaustionPct, args.now)) {
+  if (continuation && isCodexCredentialHealthy(continuation, args.now)) {
     return {
       credentialId: continuation.id,
       advanceActivePointer: false,
@@ -742,7 +715,7 @@ export function selectCodexCredentialLeaseForTurn(args: {
     if (!pinned?.allocatorEnabled) {
       return { credentialId: null, decision: { kind: "none" }, advanceActivePointer: false };
     }
-    if (isCodexCredentialHealthy(pinned, args.nearExhaustionPct, args.now)) {
+    if (isCodexCredentialHealthy(pinned, args.now)) {
       return {
         credentialId: pinned.id,
         decision: { kind: "active", credentialId: pinned.id, moved: false },
@@ -753,7 +726,7 @@ export function selectCodexCredentialLeaseForTurn(args: {
       credentialId: null,
       decision: {
         kind: "allCapped",
-        earliestResetAt: availableAt(pinned, args.nearExhaustionPct, args.now),
+        earliestResetAt: availableAt(pinned, args.now),
       },
       advanceActivePointer: false,
     };
@@ -771,7 +744,6 @@ export function selectCodexCredentialLeaseForTurn(args: {
       sessionId: args.sessionId,
       currentPolicyPin: args.sessionPinSource === "policy" ? args.sessionPinnedCredentialId : null,
       accounts,
-      nearExhaustionPct: args.nearExhaustionPct,
       now: args.now,
     });
     if (shard.kind === "allCapped") {
@@ -829,7 +801,6 @@ export function selectCodexCredentialLeaseForTurn(args: {
     // the workspace pointer is only correct when this session has never run.
     priorCredentialId: priorId,
     accounts,
-    nearExhaustionPct: args.nearExhaustionPct,
     now: args.now,
     usedConnectors: accounts.find((account) => account.id === priorId)?.connectorNamespaces ?? [],
   });

--- a/apps/worker/test/codex-capacity.test.ts
+++ b/apps/worker/test/codex-capacity.test.ts
@@ -45,7 +45,7 @@ describe("Codex capacity availability diagnostics", () => {
       accounts: [
         account("healthy"),
         account("cooling", { exhaustedUntil: future }),
-        account("capped", { primaryUsedPercent: 95, primaryResetAt: future }),
+        account("capped", { primaryUsedPercent: 100, primaryResetAt: future }),
       ],
       activeCredentialId: null,
       rotationEnabled: true,
@@ -66,7 +66,6 @@ describe("Codex capacity availability diagnostics", () => {
         context,
         testSettings({
           codexCredentialLeasingEnabled: true,
-          codexRotationNearExhaustionPct: 90,
         }),
       ),
     ).toMatchObject({

--- a/apps/worker/test/codex-rotation.test.ts
+++ b/apps/worker/test/codex-rotation.test.ts
@@ -67,7 +67,6 @@ function leasedAcct(
 const base = {
   rotationStrategy: "most_remaining" as const,
   priorCredentialId: null,
-  nearExhaustionPct: 90,
   now: NOW,
 };
 
@@ -102,9 +101,9 @@ describe("chooseRotationActive — most_remaining", () => {
     });
   });
 
-  test("active near-capped → rotate to the account with the most remaining quota", () => {
+  test("new allocation ranks usable accounts by remaining quota without a 90% cliff", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 95 }), // active, near-cap → ineligible
+      acct("a", { primaryUsedPercent: 95 }), // still eligible, but least remaining
       acct("b", { primaryUsedPercent: 40 }), // 60 remaining
       acct("c", { primaryUsedPercent: 10 }), // 90 remaining ← winner
     ];
@@ -117,8 +116,8 @@ describe("chooseRotationActive — most_remaining", () => {
 
   test("weekly window binds as hard as 5h (worst-window used pct)", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99 }), // active, capped
-      acct("b", { primaryUsedPercent: 10, secondaryUsedPercent: 95 }), // weekly near-cap → ineligible
+      acct("a", { primaryUsedPercent: 100 }), // active, capped
+      acct("b", { primaryUsedPercent: 10, secondaryUsedPercent: 95 }), // still eligible; weekly is binding
       acct("c", { primaryUsedPercent: 50, secondaryUsedPercent: 50 }), // eligible (50 remaining)
     ];
     expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts })).toEqual({
@@ -130,7 +129,7 @@ describe("chooseRotationActive — most_remaining", () => {
 
   test("remaining = min across windows (the scarcer window wins the ranking)", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99 }), // active, capped
+      acct("a", { primaryUsedPercent: 100 }), // active, capped
       acct("b", { primaryUsedPercent: 10, secondaryUsedPercent: 70 }), // remaining = min(90,30)=30
       acct("c", { primaryUsedPercent: 20, secondaryUsedPercent: 20 }), // remaining = min(80,80)=80 ← winner
     ];
@@ -143,7 +142,7 @@ describe("chooseRotationActive — most_remaining", () => {
 
   test("a cooling account is excluded even when it has the most remaining quota", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99 }), // active, capped
+      acct("a", { primaryUsedPercent: 100 }), // active, capped
       acct("b", { primaryUsedPercent: 0, exhaustedUntil: new Date(NOW.getTime() + HOUR) }), // most remaining BUT cooling
       acct("c", { primaryUsedPercent: 40 }), // eligible
     ];
@@ -156,7 +155,7 @@ describe("chooseRotationActive — most_remaining", () => {
 
   test("a cooldown in the past does NOT exclude (self-clears via now comparison)", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99 }), // active, capped
+      acct("a", { primaryUsedPercent: 100 }), // active, capped
       acct("b", { primaryUsedPercent: 10, exhaustedUntil: new Date(NOW.getTime() - HOUR) }), // expired cooldown → eligible
     ];
     expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts })).toEqual({
@@ -168,7 +167,7 @@ describe("chooseRotationActive — most_remaining", () => {
 
   test("needs_relogin / error accounts are never eligible", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99 }), // active, capped
+      acct("a", { primaryUsedPercent: 100 }), // active, capped
       acct("b", { status: "needs_relogin", primaryUsedPercent: 0 }), // unusable
       acct("c", { status: "error", primaryUsedPercent: 0 }), // unusable
     ];
@@ -178,7 +177,7 @@ describe("chooseRotationActive — most_remaining", () => {
 
   test("ties broken deterministically by list (created_at) order", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99 }), // active, capped
+      acct("a", { primaryUsedPercent: 100 }), // active, capped
       acct("b", { primaryUsedPercent: 30 }), // 70 remaining ← first in order wins the tie
       acct("c", { primaryUsedPercent: 30 }), // 70 remaining
     ];
@@ -191,8 +190,8 @@ describe("chooseRotationActive — most_remaining", () => {
 
   test("all eligible accounts capped → allCapped with the EARLIEST reset across all", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99, primaryResetAt: new Date(NOW.getTime() + 3 * HOUR) }),
-      acct("b", { primaryUsedPercent: 99, primaryResetAt: new Date(NOW.getTime() + 1 * HOUR) }), // soonest
+      acct("a", { primaryUsedPercent: 100, primaryResetAt: new Date(NOW.getTime() + 3 * HOUR) }),
+      acct("b", { primaryUsedPercent: 100, primaryResetAt: new Date(NOW.getTime() + 1 * HOUR) }), // soonest
       acct("c", { exhaustedUntil: new Date(NOW.getTime() + 2 * HOUR) }),
     ];
     const decision = chooseRotationActive({ ...base, activeCredentialId: "a", accounts });
@@ -220,7 +219,7 @@ describe("chooseRotationActive — most_remaining", () => {
 });
 
 // P3 all-capped infinite-loop bugfix. The original availableAt() seeded EPOCH0 (1970)
-// and used it as the fallback for a null/elapsed reset, so an over-threshold account
+// and used it as the fallback for a null/elapsed reset, so an exhausted account
 // with a NULL or already-elapsed cached reset yielded a PAST instant; earliestReset MINs
 // across accounts → allCapped.earliestResetAt in the deep past → continueDelayMs =
 // max(0, past − now) = 0 → a tight CPU/DB-hammering re-dispatch loop (invariant 4 violated).
@@ -229,8 +228,8 @@ const MAX_RESUME_MS = 60 * 60_000; // mirrors CODEX_USAGE_LIMIT_MAX_RESUME_MS (1
 describe("P3 all-capped idle — POSITIVE bounded delay, never 0 (invariant 4: NO THRASH)", () => {
   test("(a) all-capped with a NULL resetAt → future earliestReset → positive bounded delay (>= MIN_IDLE_MS), never 0", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99, primaryResetAt: null }), // over-threshold, unknown reset
-      acct("b", { primaryUsedPercent: 99, primaryResetAt: null }),
+      acct("a", { primaryUsedPercent: 100, primaryResetAt: null }), // exhausted, unknown reset
+      acct("b", { primaryUsedPercent: 100, primaryResetAt: null }),
     ];
     const decision = chooseRotationActive({ ...base, activeCredentialId: "a", accounts });
     expect(decision.kind).toBe("allCapped");
@@ -245,8 +244,11 @@ describe("P3 all-capped idle — POSITIVE bounded delay, never 0 (invariant 4: N
 
   test("(b) elapsed provider windows clear stale capped cache immediately", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99, primaryResetAt: new Date(NOW.getTime() - HOUR) }), // 5h reset already passed
-      acct("b", { secondaryUsedPercent: 99, secondaryResetAt: new Date(NOW.getTime() - 5 * HOUR) }), // weekly reset already passed
+      acct("a", { primaryUsedPercent: 100, primaryResetAt: new Date(NOW.getTime() - HOUR) }), // 5h reset already passed
+      acct("b", {
+        secondaryUsedPercent: 100,
+        secondaryResetAt: new Date(NOW.getTime() - 5 * HOUR),
+      }), // weekly reset already passed
     ];
     const decision = chooseRotationActive({ ...base, activeCredentialId: "a", accounts });
     expect(decision.kind).toBe("active");
@@ -266,35 +268,33 @@ describe("P3 all-capped idle — POSITIVE bounded delay, never 0 (invariant 4: N
   });
 });
 
-describe("availableAt — never a past instant for an over-threshold account (invariant 4)", () => {
-  test("(c) over-threshold account with a NULL reset → now + default cooldown, NOT the past", () => {
-    const at = availableAt(acct("a", { primaryUsedPercent: 99, primaryResetAt: null }), 90, NOW);
+describe("availableAt — never a past instant for an exhausted account (invariant 4)", () => {
+  test("(c) exhausted account with a NULL reset → now + default cooldown, NOT the past", () => {
+    const at = availableAt(acct("a", { primaryUsedPercent: 100, primaryResetAt: null }), NOW);
     expect(at.getTime()).toBe(NOW.getTime() + DEFAULT_RESET_COOLDOWN_MS);
     expect(at.getTime()).toBeGreaterThan(NOW.getTime());
   });
 
-  test("(c) over-threshold account with an ELAPSED reset → future, not the stale past instant", () => {
+  test("(c) exhausted account with an ELAPSED reset → future, not the stale past instant", () => {
     const at = availableAt(
-      acct("a", { secondaryUsedPercent: 99, secondaryResetAt: new Date(NOW.getTime() - HOUR) }),
-      90,
+      acct("a", { secondaryUsedPercent: 100, secondaryResetAt: new Date(NOW.getTime() - HOUR) }),
       NOW,
     );
     expect(at.getTime()).toBeGreaterThan(NOW.getTime());
   });
 
   test("(c) needs_relogin / error account (ineligible, no quota block) → future cooldown, not EPOCH0", () => {
-    expect(availableAt(acct("a", { status: "needs_relogin" }), 90, NOW).getTime()).toBeGreaterThan(
+    expect(availableAt(acct("a", { status: "needs_relogin" }), NOW).getTime()).toBeGreaterThan(
       NOW.getTime(),
     );
-    expect(availableAt(acct("b", { status: "error" }), 90, NOW).getTime()).toBeGreaterThan(
+    expect(availableAt(acct("b", { status: "error" }), NOW).getTime()).toBeGreaterThan(
       NOW.getTime(),
     );
   });
 
   test("a KNOWN future reset is honored exactly (the cooldown default only fills unknown/elapsed)", () => {
     const at = availableAt(
-      acct("a", { primaryUsedPercent: 99, primaryResetAt: new Date(NOW.getTime() + 3 * HOUR) }),
-      90,
+      acct("a", { primaryUsedPercent: 100, primaryResetAt: new Date(NOW.getTime() + 3 * HOUR) }),
       NOW,
     );
     expect(at.getTime()).toBe(NOW.getTime() + 3 * HOUR);
@@ -303,11 +303,10 @@ describe("availableAt — never a past instant for an over-threshold account (in
   test("clears EVERY block: a future cooldown AND a future window reset ⇒ the LATER instant", () => {
     const at = availableAt(
       acct("a", {
-        primaryUsedPercent: 99,
+        primaryUsedPercent: 100,
         primaryResetAt: new Date(NOW.getTime() + HOUR),
         exhaustedUntil: new Date(NOW.getTime() + 2 * HOUR),
       }),
-      90,
       NOW,
     );
     expect(at.getTime()).toBe(NOW.getTime() + 2 * HOUR);
@@ -316,14 +315,14 @@ describe("availableAt — never a past instant for an over-threshold account (in
 
 describe("P3 self-heal + bounded reactive walk (invariant 4)", () => {
   test("(d) SELF-HEAL: a refreshed (genuinely-reset) window makes the account eligible again — no permanent idle", () => {
-    // Stale cache: both over-threshold → allCapped (the would-be idle).
-    const stale = [acct("a", { primaryUsedPercent: 99 }), acct("b", { primaryUsedPercent: 99 })];
+    // Stale cache: both exhausted → allCapped (the would-be idle).
+    const stale = [acct("a", { primaryUsedPercent: 100 }), acct("b", { primaryUsedPercent: 100 })];
     expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts: stale }).kind).toBe(
       "allCapped",
     );
     // After the all-capped path refreshes usage, b's 5h window has ACTUALLY reset (low pct):
     // the re-rank must now pick b instead of idling forever on the stale percent.
-    const healed = [acct("a", { primaryUsedPercent: 99 }), acct("b", { primaryUsedPercent: 5 })];
+    const healed = [acct("a", { primaryUsedPercent: 100 }), acct("b", { primaryUsedPercent: 5 })];
     expect(chooseRotationActive({ ...base, activeCredentialId: "a", accounts: healed })).toEqual({
       kind: "active",
       credentialId: "b",
@@ -407,7 +406,7 @@ describe("chooseRotationActive — legacy strategies normalize to sharded rankin
   });
 
   test("stored round_robin with a capped account still ranks (old behavior picked the successor)", () => {
-    const accounts = [acct("a"), acct("b", { primaryUsedPercent: 99 }), acct("c")];
+    const accounts = [acct("a"), acct("b", { primaryUsedPercent: 100 }), acct("c")];
     // Old round_robin skipped capped "b" to pick "c". Normalized: "a" is eligible
     // and first on the equal-load tie — stay.
     expect(
@@ -426,7 +425,7 @@ describe("chooseRotationActive — legacy strategies normalize to sharded rankin
     const accounts = [
       acct("disabled-healthy", { allocatorEnabled: false }),
       acct("enabled-capped", {
-        primaryUsedPercent: 99,
+        primaryUsedPercent: 100,
         primaryResetAt: enabledReset,
       }),
     ];
@@ -454,7 +453,7 @@ describe("chooseRotationActive — legacy strategies normalize to sharded rankin
       }),
     ).toEqual({ kind: "active", credentialId: "a", moved: false });
     // Cap failover is strategy-independent and must keep working.
-    const capped = [acct("a", { primaryUsedPercent: 99 }), acct("b")];
+    const capped = [acct("a", { primaryUsedPercent: 100 }), acct("b")];
     expect(
       chooseRotationActive({
         ...base,
@@ -474,7 +473,7 @@ describe("chooseRotationActive — legacy strategies normalize to sharded rankin
 describe("chooseRotationActive — connector-aware (P4, most_remaining)", () => {
   test("empty usedConnectors → byte-identical to P3 (max remaining wins, no dropped note)", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 95 }), // active, near-cap
+      acct("a", { primaryUsedPercent: 95 }), // active and still usable
       acct("b", { primaryUsedPercent: 40, connectorNamespaces: ["github"] }), // 60 remaining
       acct("c", { primaryUsedPercent: 10, connectorNamespaces: [] }), // 90 remaining ← winner
     ];
@@ -485,7 +484,7 @@ describe("chooseRotationActive — connector-aware (P4, most_remaining)", () => 
 
   test("PREFERS a covering target even when a non-covering one has MORE remaining quota", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 95, connectorNamespaces: ["github"] }), // active, near-cap (leaving)
+      acct("a", { primaryUsedPercent: 100, connectorNamespaces: ["github"] }), // exhausted leaving account
       acct("b", { primaryUsedPercent: 50, connectorNamespaces: ["github", "gmail"] }), // covers github, 50 remaining ← winner
       acct("c", { primaryUsedPercent: 5, connectorNamespaces: ["gmail"] }), // 95 remaining BUT lacks github
     ];
@@ -503,8 +502,8 @@ describe("chooseRotationActive — connector-aware (P4, most_remaining)", () => 
 
   test("FAILS OVER to a non-covering account when it is the ONLY one with quota (+ dropped note)", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99, connectorNamespaces: ["github"] }), // active, capped (leaving)
-      acct("b", { primaryUsedPercent: 99, connectorNamespaces: ["github", "gmail"] }), // covers BUT also capped
+      acct("a", { primaryUsedPercent: 100, connectorNamespaces: ["github"] }), // active, capped (leaving)
+      acct("b", { primaryUsedPercent: 100, connectorNamespaces: ["github", "gmail"] }), // covers BUT also capped
       acct("c", { primaryUsedPercent: 10, connectorNamespaces: ["gmail"] }), // eligible BUT lacks github
     ];
     // Tier 1 (covering) is empty among eligibles → Tier 2 = {c}: failover preserved,
@@ -521,7 +520,7 @@ describe("chooseRotationActive — connector-aware (P4, most_remaining)", () => 
 
   test("null (never-probed) connector set is UNKNOWN: never Tier 1, never excluded, dropped note lists the used set", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99, connectorNamespaces: ["github"] }), // active, capped (leaving)
+      acct("a", { primaryUsedPercent: 100, connectorNamespaces: ["github"] }), // active, capped (leaving)
       acct("b", { primaryUsedPercent: 10, connectorNamespaces: null }), // unprobed → Tier 2 only, but eligible
     ];
     // No covering eligible (b is unknown) → Tier 2 picks b (failover), and since we
@@ -555,7 +554,7 @@ describe("chooseRotationActive — connector-aware (P4, most_remaining)", () => 
 
   test("a covering target that is a strict SUPERSET covers (multi-connector session)", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 99, connectorNamespaces: ["github", "linear"] }), // capped (leaving)
+      acct("a", { primaryUsedPercent: 100, connectorNamespaces: ["github", "linear"] }), // capped (leaving)
       acct("b", { primaryUsedPercent: 50, connectorNamespaces: ["github", "linear", "gmail"] }), // superset ← covers
       acct("c", { primaryUsedPercent: 5, connectorNamespaces: ["github"] }), // most quota but missing linear
     ];
@@ -680,7 +679,6 @@ describe("shardCredentialForSession — deterministic session sharding (AM-6)", 
     const first = shardCredentialForSession({
       sessionId: "session-xyz",
       accounts: pool,
-      nearExhaustionPct: 90,
       now: NOW,
     });
     for (let i = 0; i < 5; i++) {
@@ -688,7 +686,6 @@ describe("shardCredentialForSession — deterministic session sharding (AM-6)", 
         shardCredentialForSession({
           sessionId: "session-xyz",
           accounts: pool,
-          nearExhaustionPct: 90,
           now: NOW,
         }),
       ).toBe(first);
@@ -701,7 +698,6 @@ describe("shardCredentialForSession — deterministic session sharding (AM-6)", 
       const home = shardCredentialForSession({
         sessionId: `s-${i}`,
         accounts: pool,
-        nearExhaustionPct: 90,
         now: NOW,
       })!;
       counts.set(home, (counts.get(home) ?? 0) + 1);
@@ -713,20 +709,34 @@ describe("shardCredentialForSession — deterministic session sharding (AM-6)", 
     }
   });
 
+  test("keeps every 90–99% account in the deterministic shard set", () => {
+    const usable = [
+      acct("a", { primaryUsedPercent: 90 }),
+      acct("b", { secondaryUsedPercent: 94 }),
+      acct("c", { primaryUsedPercent: 99 }),
+    ];
+    const selected = new Set<string>();
+    for (let i = 0; i < 300; i++) {
+      selected.add(
+        shardCredentialForSession({ sessionId: `remaining-${i}`, accounts: usable, now: NOW })!,
+      );
+    }
+    expect(selected).toEqual(new Set(["a", "b", "c"]));
+  });
+
   test("excludes capped/cooling accounts from the shard set (re-shard picks a survivor)", () => {
     // Cap every account EXCEPT 'c' → every session must shard to 'c'.
     const oneHealthy = [
-      acct("a", { primaryUsedPercent: 95 }),
+      acct("a", { primaryUsedPercent: 100 }),
       acct("b", { exhaustedUntil: new Date(NOW.getTime() + HOUR) }),
       acct("c"),
-      acct("d", { secondaryUsedPercent: 99 }),
+      acct("d", { secondaryUsedPercent: 100 }),
     ];
     for (let i = 0; i < 25; i++) {
       expect(
         shardCredentialForSession({
           sessionId: `s-${i}`,
           accounts: oneHealthy,
-          nearExhaustionPct: 90,
           now: NOW,
         }),
       ).toBe("c");
@@ -736,14 +746,13 @@ describe("shardCredentialForSession — deterministic session sharding (AM-6)", 
   test("re-shard SPREADS the survivors, never re-concentrates on one first-eligible (AM-5)", () => {
     // 'a' capped; sessions that were on 'a' re-shard over {b,c,d}. Confirm they land on
     // DIFFERENT survivors (a first-eligible pick would send them all to 'b').
-    const survivors = [acct("a", { primaryUsedPercent: 96 }), acct("b"), acct("c"), acct("d")];
+    const survivors = [acct("a", { primaryUsedPercent: 100 }), acct("b"), acct("c"), acct("d")];
     const landed = new Set<string>();
     for (let i = 0; i < 60; i++) {
       landed.add(
         shardCredentialForSession({
           sessionId: `hot-${i}`,
           accounts: survivors,
-          nearExhaustionPct: 90,
           now: NOW,
         })!,
       );
@@ -754,30 +763,27 @@ describe("shardCredentialForSession — deterministic session sharding (AM-6)", 
 
   test("all accounts capped → null (caller idles until reset)", () => {
     const allCapped = [
-      acct("a", { primaryUsedPercent: 95 }),
+      acct("a", { primaryUsedPercent: 100 }),
       acct("b", { exhaustedUntil: new Date(NOW.getTime() + HOUR) }),
     ];
     expect(
       shardCredentialForSession({
         sessionId: "s",
         accounts: allCapped,
-        nearExhaustionPct: 90,
         now: NOW,
       }),
     ).toBeNull();
   });
 
-  test("isCodexAccountEligible mirrors the ranker's eligibility (active, not cooling, under threshold)", () => {
-    expect(isCodexAccountEligible(acct("a"), 90, NOW)).toBe(true);
-    expect(isCodexAccountEligible(acct("a", { primaryUsedPercent: 95 }), 90, NOW)).toBe(false);
+  test("isCodexAccountEligible keeps 90–99% usable and blocks actual exhaustion", () => {
+    expect(isCodexAccountEligible(acct("a"), NOW)).toBe(true);
+    expect(isCodexAccountEligible(acct("a", { primaryUsedPercent: 90 }), NOW)).toBe(true);
+    expect(isCodexAccountEligible(acct("a", { primaryUsedPercent: 99 }), NOW)).toBe(true);
+    expect(isCodexAccountEligible(acct("a", { primaryUsedPercent: 100 }), NOW)).toBe(false);
     expect(
-      isCodexAccountEligible(
-        acct("a", { exhaustedUntil: new Date(NOW.getTime() + HOUR) }),
-        90,
-        NOW,
-      ),
+      isCodexAccountEligible(acct("a", { exhaustedUntil: new Date(NOW.getTime() + HOUR) }), NOW),
     ).toBe(false);
-    expect(isCodexAccountEligible(acct("a", { status: "needs_relogin" }), 90, NOW)).toBe(false);
+    expect(isCodexAccountEligible(acct("a", { status: "needs_relogin" }), NOW)).toBe(false);
   });
 });
 
@@ -789,7 +795,6 @@ describe("chooseShardedHome — proactive home decision (AM-4/AM-7)", () => {
       sessionId: "s1",
       currentPolicyPin: null,
       accounts: pool,
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(decision.kind).toBe("home");
@@ -800,7 +805,6 @@ describe("chooseShardedHome — proactive home decision (AM-4/AM-7)", () => {
         shardCredentialForSession({
           sessionId: "s1",
           accounts: pool,
-          nearExhaustionPct: 90,
           now: NOW,
         }),
       );
@@ -812,22 +816,32 @@ describe("chooseShardedHome — proactive home decision (AM-4/AM-7)", () => {
     const home = shardCredentialForSession({
       sessionId: "s1",
       accounts: pool,
-      nearExhaustionPct: 90,
       now: NOW,
     })!;
     const decision = chooseShardedHome({
       sessionId: "s1",
       currentPolicyPin: home,
       accounts: pool,
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(decision).toEqual({ kind: "home", credentialId: home, rewritePin: false });
   });
 
+  test("a 99%-used policy home remains sticky and is not re-sharded", () => {
+    const accounts = [acct("a", { primaryUsedPercent: 99 }), acct("b")];
+    expect(
+      chooseShardedHome({
+        sessionId: "sticky-near-full",
+        currentPolicyPin: "a",
+        accounts,
+        now: NOW,
+      }),
+    ).toEqual({ kind: "home", credentialId: "a", rewritePin: false });
+  });
+
   test("capped policy pin → re-shard to a survivor and rewrite the pin durably (AM-4)", () => {
     const accounts = [
-      acct("a", { primaryUsedPercent: 97 }), // the (capped) current home
+      acct("a", { primaryUsedPercent: 100 }), // the exhausted current home
       acct("b"),
       acct("c"),
       acct("d"),
@@ -836,7 +850,6 @@ describe("chooseShardedHome — proactive home decision (AM-4/AM-7)", () => {
       sessionId: "s1",
       currentPolicyPin: "a",
       accounts,
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(decision.kind).toBe("home");
@@ -845,7 +858,7 @@ describe("chooseShardedHome — proactive home decision (AM-4/AM-7)", () => {
       expect(decision.credentialId).not.toBe("a");
       // it is the deterministic re-shard over the ELIGIBLE survivors
       expect(decision.credentialId).toBe(
-        shardCredentialForSession({ sessionId: "s1", accounts, nearExhaustionPct: 90, now: NOW }),
+        shardCredentialForSession({ sessionId: "s1", accounts, now: NOW }),
       );
     }
   });
@@ -853,14 +866,13 @@ describe("chooseShardedHome — proactive home decision (AM-4/AM-7)", () => {
   test("all accounts capped → allCapped with the earliest reset (caller idles)", () => {
     const resetAt = new Date(NOW.getTime() + HOUR);
     const accounts = [
-      acct("a", { primaryUsedPercent: 95, primaryResetAt: resetAt }),
+      acct("a", { primaryUsedPercent: 100, primaryResetAt: resetAt }),
       acct("b", { exhaustedUntil: resetAt }),
     ];
     const decision = chooseShardedHome({
       sessionId: "s1",
       currentPolicyPin: "a",
       accounts,
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(decision.kind).toBe("allCapped");
@@ -874,7 +886,6 @@ describe("chooseShardedHome — proactive home decision (AM-4/AM-7)", () => {
       sessionId: "s1",
       currentPolicyPin: "gone",
       accounts: pool,
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(decision.kind).toBe("home");
@@ -1099,10 +1110,25 @@ describe("credential allocator pin and rollout policy", () => {
       sessionPinSource: "manual",
       sessionPinnedCredentialId: "a",
       sessionLastCredentialId: null,
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(selected.credentialId).toBe("a");
+  });
+
+  test("a 99%-used manual pin remains usable and never waits or switches early", () => {
+    const selected = selectCodexCredentialLeaseForTurn({
+      context: context([leasedAcct("a", { primaryUsedPercent: 99 }), leasedAcct("b")]),
+      leasingEnabled: true,
+      sessionId: "manual-near-full",
+      sessionPinSource: "manual",
+      sessionPinnedCredentialId: "a",
+      sessionLastCredentialId: "a",
+      now: NOW,
+    });
+    expect(selected).toMatchObject({
+      credentialId: "a",
+      decision: { kind: "active", credentialId: "a", moved: false },
+    });
   });
 
   test("a capped stale policy pin leaves a non-sharded strategy free to select healthy capacity", () => {
@@ -1119,7 +1145,6 @@ describe("credential allocator pin and rollout policy", () => {
       sessionPinSource: "policy",
       sessionPinnedCredentialId: "a",
       sessionLastCredentialId: "a",
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(selected.credentialId).toBe("b");
@@ -1139,7 +1164,6 @@ describe("credential allocator pin and rollout policy", () => {
       sessionPinSource: "manual",
       sessionPinnedCredentialId: "a",
       sessionLastCredentialId: "a",
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(selected.credentialId).toBeNull();
@@ -1159,7 +1183,6 @@ describe("credential allocator pin and rollout policy", () => {
       sessionPinSource: "policy",
       sessionPinnedCredentialId: "outside-scope",
       sessionLastCredentialId: "outside-scope",
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(["pool-b-1", "pool-b-2"]).toContain(selected.credentialId);
@@ -1174,7 +1197,6 @@ describe("credential allocator pin and rollout policy", () => {
       sessionPinSource: null,
       sessionPinnedCredentialId: null,
       sessionLastCredentialId: null,
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(selected.credentialId).toBe("b");
@@ -1191,7 +1213,6 @@ describe("credential allocator pin and rollout policy", () => {
       sessionPinSource: null,
       sessionPinnedCredentialId: null,
       sessionLastCredentialId: "a",
-      nearExhaustionPct: 90,
       now: NOW,
     });
     // Pre-0053 most_remaining keeps a still-eligible active pointer sticky.
@@ -1212,7 +1233,6 @@ describe("credential allocator pin and rollout policy", () => {
       sessionPinSource: null,
       sessionPinnedCredentialId: null,
       sessionLastCredentialId: "a",
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(selected.credentialId).toBe("a");
@@ -1223,7 +1243,7 @@ describe("credential allocator pin and rollout policy", () => {
       context: {
         ...context([
           leasedAcct("a", {
-            primaryUsedPercent: 99,
+            primaryUsedPercent: 100,
             primaryResetAt: new Date(NOW.getTime() + HOUR),
           }),
           leasedAcct("b", {
@@ -1246,7 +1266,6 @@ describe("credential allocator pin and rollout policy", () => {
       sessionPinSource: null,
       sessionPinnedCredentialId: null,
       sessionLastCredentialId: "a",
-      nearExhaustionPct: 90,
       now: NOW,
     });
     // The old selector knows only capacity and picks b (90% remaining), not c.
@@ -1265,7 +1284,6 @@ describe("credential allocator pin and rollout policy", () => {
       sessionPinSource: null,
       sessionPinnedCredentialId: null,
       sessionLastCredentialId: "b",
-      nearExhaustionPct: 90,
       now: NOW,
     });
     expect(selected.credentialId).toBe("a");
@@ -1293,7 +1311,6 @@ describe("credential allocator pin and rollout policy", () => {
       sessionPinSource: null,
       sessionPinnedCredentialId: null,
       sessionLastCredentialId: "b",
-      nearExhaustionPct: 90,
       now: NOW,
     });
     // Old round_robin advanced past session-last "b" to "c". Normalized: the
@@ -1326,7 +1343,6 @@ describe("credential allocator pin and rollout policy", () => {
         sessionPinnedCredentialId: null,
         sessionLastCredentialId: "frozen",
         continuationCredentialId: "frozen",
-        nearExhaustionPct: 90,
         now: NOW,
       }).credentialId,
     ).toBe("frozen");
@@ -1338,7 +1354,6 @@ describe("credential allocator pin and rollout policy", () => {
         sessionPinSource: null,
         sessionPinnedCredentialId: null,
         sessionLastCredentialId: "frozen",
-        nearExhaustionPct: 90,
         now: NOW,
       }).credentialId,
     ).toBe("eligible");

--- a/apps/worker/test/codex-usage-limit.test.ts
+++ b/apps/worker/test/codex-usage-limit.test.ts
@@ -124,7 +124,6 @@ describe("credential allocator definitive credential failure classification", ()
       codexCredentialCooldownUntil(
         { kind: "rate_limit", cooldownSeconds: 31 },
         null,
-        90,
         now,
       )?.getTime(),
     ).toBe(now.getTime() + 31_000);
@@ -139,7 +138,6 @@ describe("credential allocator definitive credential failure classification", ()
           secondaryUsedPercent: 100,
           secondaryResetAt: weeklyReset,
         },
-        90,
         now,
       )?.getTime(),
     ).toBe(weeklyReset.getTime());
@@ -152,20 +150,14 @@ describe("credential allocator definitive credential failure classification", ()
           secondaryUsedPercent: 100,
           secondaryResetAt: weeklyReset,
         },
-        90,
         now,
       )?.getTime(),
     ).toBe(weeklyReset.getTime());
     expect(
-      codexCredentialCooldownUntil(
-        { kind: "quota", cooldownSeconds: null },
-        null,
-        90,
-        now,
-      )?.getTime(),
+      codexCredentialCooldownUntil({ kind: "quota", cooldownSeconds: null }, null, now)?.getTime(),
     ).toBe(now.getTime() + CODEX_ALLOWANCE_FALLBACK_MS);
     expect(
-      codexCredentialCooldownUntil({ kind: "auth", cooldownSeconds: null }, null, 90, now),
+      codexCredentialCooldownUntil({ kind: "auth", cooldownSeconds: null }, null, now),
     ).toBeNull();
   });
 });

--- a/docs/codex-subscription-rotation.md
+++ b/docs/codex-subscription-rotation.md
@@ -61,6 +61,13 @@ The first and third/fourth inputs are server-held. Provider usage headers improv
 capacity ranking but are **never the sole atomic allocator**. Consequently a
 burst sees earlier reservations and spreads before delayed usage headers move.
 
+Usage percentages never create a configurable "near exhaustion" cliff. Accounts
+remain eligible through 99% in either provider window; 90% is presentation-only
+warning state. Cached usage excludes an account only at 100%, while an explicit
+provider refusal installs the authoritative cooldown. Sharded policy pins remain
+sticky throughout 90–99% and are rewritten only after actual exhaustion or another
+definitive health failure.
+
 The workspace active credential is a cursor, not a sticky lease. Pin source is
 load-bearing: a `manual` (or defensively unlabeled) pin is user intent and never
 silently fails over; if it is capped, the turn enters the same durable capacity

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -258,10 +258,6 @@ const SettingsSchema = z.object({
   // enable. Turning it off restores the legacy sticky selector without a schema
   // rollback; the additive lease table/cursor columns become inert.
   codexCredentialLeasingEnabled: EnvBoolean.default(false),
-  // Multi-account P3 (auto-rotation): an account is "near exhaustion" — ineligible to be
-  // rotated TO — when EITHER usage window (5h/weekly) is at/over this percent. Default 90 to
-  // match the UI danger flip (UsageBar danger at pct >= 90). OPENGENI_CODEX_ROTATION_NEAR_EXHAUSTION_PCT.
-  codexRotationNearExhaustionPct: z.coerce.number().int().min(1).max(100).default(90),
   openaiReasoningEffort: ReasoningEffort.default("low"),
   openaiAllowedReasoningEfforts: z.string().default("low,medium,high,xhigh"),
   openaiResponsesTransport: z.enum(["http", "websocket"]).default("http"),
@@ -1039,7 +1035,6 @@ export function getSettings(): Settings {
     codexToolSearchEnabled: optional("OPENGENI_CODEX_TOOL_SEARCH_ENABLED"),
     codexCredentialLeasingEnabled: optional("OPENGENI_CODEX_CREDENTIAL_LEASING_ENABLED"),
     codexProductSku: optional("OPENGENI_CODEX_PRODUCT_SKU"),
-    codexRotationNearExhaustionPct: optional("OPENGENI_CODEX_ROTATION_NEAR_EXHAUSTION_PCT"),
     openaiReasoningEffort: optional("OPENGENI_OPENAI_REASONING_EFFORT"),
     openaiAllowedReasoningEfforts: optional("OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS"),
     openaiResponsesTransport: optional("OPENGENI_OPENAI_RESPONSES_TRANSPORT"),

--- a/packages/db/test/codex-credential-leases.test.ts
+++ b/packages/db/test/codex-credential-leases.test.ts
@@ -155,7 +155,6 @@ function selector(context: CodexCredentialLeaseSelectionContext): {
     activeCredentialId: context.activeCredentialId,
     priorCredentialId: context.activeCredentialId,
     accounts: context.accounts,
-    nearExhaustionPct: 90,
     now: new Date(),
   });
   return {
@@ -268,7 +267,7 @@ describe("credential allocator atomic Codex credential allocation", () => {
     await connectCredential(wsB!, "shared-quota");
     const reset = new Date(Date.now() + 5 * 60 * 60_000);
     await recordCodexAccountUsage(dbA, wsA!.workspaceId, credentialA, {
-      primaryUsedPercent: 99,
+      primaryUsedPercent: 100,
       primaryResetAt: reset,
       secondaryUsedPercent: 10,
       secondaryResetAt: new Date(Date.now() + 7 * 24 * 60 * 60_000),
@@ -666,7 +665,6 @@ describe("credential allocator atomic Codex credential allocation", () => {
           sessionPinnedCredentialId: null,
           sessionLastCredentialId: toggledCredential,
           continuationCredentialId: toggledCredential,
-          nearExhaustionPct: 90,
           now: new Date(),
         }),
     );

--- a/packages/db/test/migration-0053.test.ts
+++ b/packages/db/test/migration-0053.test.ts
@@ -222,7 +222,6 @@ describe("migration 0053 (Codex credential leases)", () => {
         sessionPinSource: null,
         sessionPinnedCredentialId: null,
         sessionLastCredentialId: credentialA,
-        nearExhaustionPct: 90,
         now: selectionNow,
       });
       // sharded-rotation policy: rotation-enabled always behaves as sticky-sharded, so the
@@ -233,7 +232,6 @@ describe("migration 0053 (Codex credential leases)", () => {
         sessionId: "session-test",
         currentPolicyPin: null,
         accounts: rollbackAccounts,
-        nearExhaustionPct: 90,
         now: selectionNow,
       });
       expect(expectedHome.kind).toBe("home");
@@ -269,7 +267,6 @@ describe("migration 0053 (Codex credential leases)", () => {
             sessionPinSource: null,
             sessionPinnedCredentialId: null,
             sessionLastCredentialId: credentialA,
-            nearExhaustionPct: 90,
             now: selectionNow,
           }),
       );
@@ -308,7 +305,6 @@ describe("migration 0053 (Codex credential leases)", () => {
             sessionPinSource: null,
             sessionPinnedCredentialId: null,
             sessionLastCredentialId: null,
-            nearExhaustionPct: 90,
             now: selectionNow,
           }),
       );
@@ -346,7 +342,6 @@ describe("migration 0053 (Codex credential leases)", () => {
         sessionPinSource: null,
         sessionPinnedCredentialId: null,
         sessionLastCredentialId: leased.credentialId,
-        nearExhaustionPct: 90,
         now: selectionNow,
       });
       // Rotation OFF is untouched by sharded-rotation policy: the selector returns the workspace

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -97,7 +97,6 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     codexToolSearchEnabled: false,
     codexCredentialLeasingEnabled: false,
     codexProductSku: undefined,
-    codexRotationNearExhaustionPct: 90,
     openaiReasoningEffort: "high",
     openaiAllowedReasoningEfforts: "low,medium,high,xhigh",
     openaiResponsesTransport: "http",


### PR DESCRIPTION
## Summary
- remove the configurable 90% near-exhaustion eligibility cutoff
- keep accounts and sticky sharded/manual pins usable through 99%
- treat cached usage as exhausted only at 100%, while preserving provider refusals and cooldowns
- retain deterministic sharding and all existing account-placement heuristics

## Verification
- full repository suite: 3,584 passing, 3 opt-in live-Modal tests skipped, 0 failures
- focused allocator/capacity/usage suites: 88 passing
- real-Postgres allocator lease and migration suites: 18 passing
- repository typecheck, lint, formatting, docs references, and diff checks pass