### PR TITLE
fix(worker): expose lightweight host export entrypoint

### DIFF
--- a/.changeset/lightweight-host-export-entrypoint.md
+++ b/.changeset/lightweight-host-export-entrypoint.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Expose the durable host-export pump through a lightweight `@opengeni/worker-bundle/host-export` subpath so embedded API processes can project events and usage without loading Temporal's native worker runtime.

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -20,6 +20,10 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./host-export": {
+      "types": "./src/host-export.ts",
+      "default": "./src/host-export.ts"
     }
   },
   "publishConfig": {

--- a/apps/worker/src/host-export.ts
+++ b/apps/worker/src/host-export.ts
@@ -1,0 +1,22 @@
+/**
+ * Lightweight host-export entrypoint for embedded API processes.
+ *
+ * Importing the worker package root initializes Temporal's native worker
+ * dependency graph. Host applications that only project durable OpenGeni
+ * events or usage must not need that native runtime (or its libc contract).
+ */
+export {
+  createHostExportPump,
+  type HostExportDrainResult,
+  type HostExportPump,
+  type HostExportPumpOptions,
+} from "./host-export-pump";
+
+export type {
+  HostEventExport,
+  HostEventExportBatch,
+  HostEventSink,
+  HostUsageExport,
+  HostUsageExportBatch,
+  HostUsageSink,
+} from "@opengeni/contracts";

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -63,15 +63,13 @@ export {
   type HostExportDrainResult,
   type HostExportPump,
   type HostExportPumpOptions,
-} from "./host-export-pump";
-export type {
-  HostEventExport,
-  HostEventExportBatch,
-  HostEventSink,
-  HostUsageExport,
-  HostUsageExportBatch,
-  HostUsageSink,
-} from "@opengeni/contracts";
+  type HostEventExport,
+  type HostEventExportBatch,
+  type HostEventSink,
+  type HostUsageExport,
+  type HostUsageExportBatch,
+  type HostUsageSink,
+} from "./host-export";
 
 // The deterministic id of the ONE global reaper Schedule. A single id means
 // create() is idempotent across every worker in the pool: the first worker to

--- a/apps/worker/test/host-export-entrypoint.test.ts
+++ b/apps/worker/test/host-export-entrypoint.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 describe("host-export package entrypoint", () => {
   test("does not import Temporal's native worker graph", async () => {
+    const entrypoint = await import("@opengeni/worker-bundle/host-export");
+    expect(typeof entrypoint.createHostExportPump).toBe("function");
+
     const result = await Bun.build({
       entrypoints: [new URL("../src/host-export.ts", import.meta.url).pathname],
       target: "bun",

--- a/apps/worker/test/host-export-entrypoint.test.ts
+++ b/apps/worker/test/host-export-entrypoint.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+describe("host-export package entrypoint", () => {
+  test("does not import Temporal's native worker graph", async () => {
+    const result = await Bun.build({
+      entrypoints: [new URL("../src/host-export.ts", import.meta.url).pathname],
+      target: "bun",
+      packages: "external",
+      metafile: true,
+      write: false,
+    });
+
+    expect(result.success).toBe(true);
+    const inputs = Object.keys(result.metafile?.inputs ?? {});
+    expect(inputs.some((path) => path.includes("@temporalio/"))).toBe(false);
+    expect(inputs.some((path) => path.endsWith("apps/worker/src/index.ts"))).toBe(false);
+  });
+});

--- a/apps/worker/tsup.config.ts
+++ b/apps/worker/tsup.config.ts
@@ -15,7 +15,7 @@ import { defineConfig } from "tsup";
 // + createOpenGeniWorker + the signaler/reaper helpers) type-checks and compiles
 // cleanly for the release package.
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/host-export.ts"],
   format: ["esm"],
   target: "es2022",
   dts: true,

--- a/scripts/publish-closure-guard.ts
+++ b/scripts/publish-closure-guard.ts
@@ -214,8 +214,49 @@ function ensureBuilt(pkgDir: string): void {
   }
 }
 
-for (const { dir: pkgDir } of publishable) {
+function compiledTarget(sourceTarget: string, kind: "runtime" | "types"): string | null {
+  if (!sourceTarget.startsWith("./src/") || !/\.tsx?$/.test(sourceTarget)) {
+    return null;
+  }
+  const stem = sourceTarget.slice("./src/".length).replace(/\.tsx?$/, "");
+  return `./dist/${stem}${kind === "types" ? ".d.ts" : ".js"}`;
+}
+
+function assertBuiltExportTargets(pkg: WorkspacePackage): void {
+  const exports = (pkg.packageJson as PackageJson & { exports?: Record<string, unknown> }).exports;
+  if (!exports || typeof exports !== "object") return;
+
+  for (const [subpath, entry] of Object.entries(exports)) {
+    const targets: Array<{ kind: "runtime" | "types"; source: string }> = [];
+    if (typeof entry === "string") {
+      targets.push({ kind: "runtime", source: entry });
+    } else if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+      const conditions = entry as { types?: unknown; import?: unknown; default?: unknown };
+      if (typeof conditions.types === "string") {
+        targets.push({ kind: "types", source: conditions.types });
+      }
+      const runtime = conditions.import ?? conditions.default;
+      if (typeof runtime === "string") {
+        targets.push({ kind: "runtime", source: runtime });
+      }
+    }
+
+    for (const target of targets) {
+      const compiled = compiledTarget(target.source, target.kind);
+      if (!compiled) continue;
+      if (!existsSync(join(repoRoot, pkg.dir, compiled))) {
+        failures.push(
+          `${pkg.name} export ${subpath} compiles from ${target.source} but is missing ${compiled}.`,
+        );
+      }
+    }
+  }
+}
+
+for (const pkg of publishable) {
+  const pkgDir = pkg.dir;
   ensureBuilt(pkgDir);
+  assertBuiltExportTargets(pkg);
 }
 
 const workerWorkflowBundlePath = join(repoRoot, "apps/worker/dist/workflow-bundle.js");


### PR DESCRIPTION
## Summary
- expose `@opengeni/worker-bundle/host-export` as a lightweight package subpath
- keep the existing root export compatible while routing it through the new entrypoint
- build and publish declarations for the subpath
- prove the subpath graph does not pull in Temporal or the worker root

## Why
Embedded API processes need the durable host event/usage pump, but importing the worker package root eagerly loads Temporal's native worker bridge. That unnecessarily imposes the worker runtime's libc/native dependency contract on hosts that only consume the projector.

## Verification
- `bun test apps/worker/test/host-export-entrypoint.test.ts`
- `bun run --cwd apps/worker typecheck`
- `bun run --cwd apps/worker build`
