### PR TITLE
chore: stage stable session SDK release

### DIFF
--- a/.changeset/session-sdk-stable.md
+++ b/.changeset/session-sdk-stable.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/react": patch
+"@opengeni/sdk": patch
+---
+
+Publish the session-only React entry point and typed session control surface in a stable registry release.


### PR DESCRIPTION
## Summary

- queue a patch registry release for the session-only React entry point
- release the matching typed SDK session control surface in the same package set

## Scope

Release metadata only; no runtime code changes.