### PR TITLE
fix: fence session state by active target

### DIFF
--- a/.changeset/session-target-isolation.md
+++ b/.changeset/session-target-isolation.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/react": patch
+"@opengeni/contracts": patch
+---
+
+Fence queue, composer, and control hook state to the active workspace and session so target switches cannot expose or accept stale private state.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5196,6 +5196,23 @@ export const CreateSessionRequest = withVariableSetIdAlias({
 });
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequest>;
 
+/**
+ * Extract the stable approval identity used by both durable admission and
+ * runtime resume. Serialized SDK interruptions may place it on the wrapper or
+ * its raw item; malformed entries fail closed instead of inventing an id.
+ */
+export function approvalIdentifier(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const approval = value as Record<string, unknown>;
+  const rawItem =
+    approval.rawItem && typeof approval.rawItem === "object"
+      ? (approval.rawItem as Record<string, unknown>)
+      : null;
+  const candidate = rawItem?.callId ?? rawItem?.id ?? approval.id ?? approval.name;
+  if (typeof candidate !== "string" && typeof candidate !== "number") return null;
+  return String(candidate);
+}
+
 export const ClientSessionEvent = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("user.message"),

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   AddDocumentRequest,
+  approvalIdentifier,
   CapabilityCatalogResponse,
   evaluateWorkspaceModelPolicy,
   CapabilityPack,
@@ -31,6 +32,15 @@ import {
 } from "../src";
 
 describe("contracts", () => {
+  test("extracts approval identity from every serialized interruption shape", () => {
+    expect(approvalIdentifier({ id: "approval-direct" })).toBe("approval-direct");
+    expect(approvalIdentifier({ rawItem: { callId: "approval-call" } })).toBe("approval-call");
+    expect(approvalIdentifier({ rawItem: { id: 42 } })).toBe("42");
+    expect(approvalIdentifier({ name: "approval-name" })).toBe("approval-name");
+    expect(approvalIdentifier({ approvalId: "unsupported-shape" })).toBeNull();
+    expect(approvalIdentifier(null)).toBeNull();
+  });
+
   test("accepts create session defaults", () => {
     const payload = CreateSessionRequest.parse({ initialMessage: "inspect repo" });
     expect(payload.resources).toEqual([]);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -80,6 +80,7 @@ import type {
   RigCheck,
 } from "@opengeni/contracts";
 import {
+  approvalIdentifier,
   boundWorkspaceControlEvent,
   workspaceControlUtf8Bytes,
   SESSION_EVENT_RAW_DELTA_TYPES,
@@ -24878,6 +24879,32 @@ export async function acceptSessionApprovalDecision(
           )
           .limit(1);
         if (alreadyAccepted) {
+          return {
+            action: "conflict",
+            sessionStatus: "requires_action",
+          } as const;
+        }
+        const approvalId = input.payload.approvalId;
+        const [runState] = await tx
+          .select({
+            turnId: schema.agentRunStates.turnId,
+            pendingApprovals: schema.agentRunStates.pendingApprovals,
+          })
+          .from(schema.agentRunStates)
+          .where(
+            and(
+              eq(schema.agentRunStates.workspaceId, input.workspaceId),
+              eq(schema.agentRunStates.sessionId, input.sessionId),
+              eq(schema.agentRunStates.turnId, turn.id),
+            ),
+          )
+          .orderBy(desc(schema.agentRunStates.stateVersion))
+          .limit(1);
+        if (
+          typeof approvalId !== "string" ||
+          !runState ||
+          !runState.pendingApprovals.some((pending) => approvalIdentifier(pending) === approvalId)
+        ) {
           return {
             action: "conflict",
             sessionStatus: "requires_action",

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -54,6 +54,7 @@ import {
   recordPendingSessionToolCallResult,
   recordUsageEvent,
   recordSkippedContextCompaction,
+  saveRunState,
   setSessionLastInputTokensForTurnAttempt,
   settleSessionIdleWithParentOutbox,
   settleSessionAttemptInterruptions,
@@ -3770,6 +3771,18 @@ describe("clean session control plane", () => {
       { attemptId: firstAttemptId },
     );
     if (!turn) throw new Error("approval test turn was not claimed");
+    expect(
+      await saveRunState(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn.id,
+        expectedExecutionGeneration: turn.executionGeneration,
+        expectedAttemptId: firstAttemptId,
+        serializedRunState: "approval-race-state",
+        pendingApprovals: [{ id: "approval-race" }],
+      }),
+    ).toBe(true);
     await applySessionTurnSettlement(client.db, grant.workspaceId!, {
       sessionId: session.id,
       turnId: turn.id,
@@ -3831,6 +3844,66 @@ describe("clean session control plane", () => {
       triggerEventId: accepted.event.id,
       executionGeneration: turn.executionGeneration + 1,
     });
+  });
+
+  test("approval admission rejects an id outside the current saved run boundary", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "wait for the exact approval");
+    const attemptId = crypto.randomUUID();
+    const turn = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      `session-${session.id}`,
+      { attemptId },
+    );
+    if (!turn) throw new Error("approval identity test turn was not claimed");
+    expect(
+      await saveRunState(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn.id,
+        expectedExecutionGeneration: turn.executionGeneration,
+        expectedAttemptId: attemptId,
+        serializedRunState: "approval-identity-state",
+        pendingApprovals: [{ id: "approval-current" }, { rawItem: { callId: "approval-second" } }],
+      }),
+    ).toBe(true);
+    await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: turn.id,
+      triggerEventId: turn.triggerEventId,
+      attemptId,
+      turnStatus: "requires_action",
+      sessionStatus: "requires_action",
+      activeTurnId: turn.id,
+      events: [
+        {
+          type: "session.requiresAction",
+          payload: { approvals: [{ id: "approval-current" }] },
+        },
+      ],
+    });
+
+    expect(
+      await acceptSessionApprovalDecision(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        payload: { approvalId: "approval-stale", decision: "approve" },
+        clientEventId: crypto.randomUUID(),
+      }),
+    ).toEqual({ action: "conflict", sessionStatus: "requires_action" });
+
+    const accepted = await acceptSessionApprovalDecision(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      payload: { approvalId: "approval-current", decision: "approve" },
+      clientEventId: crypto.randomUUID(),
+    });
+    expect(accepted.action).toBe("accepted");
   });
 
   test("a committed session control command replays before its stale control fence is checked", async () => {

--- a/packages/react/src/hooks/internal.ts
+++ b/packages/react/src/hooks/internal.ts
@@ -1,5 +1,5 @@
 import type { SessionEvent } from "@opengeni/sdk";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { EmbeddedSessionClientLike } from "../client";
 
 export type AsyncListState<T> = {
@@ -24,7 +24,9 @@ export function usePolledValue<T>(
   const [error, setError] = useState<Error | null>(null);
   const generation = useRef(0);
   const activeLoadRef = useRef(load);
-  activeLoadRef.current = load;
+  useLayoutEffect(() => {
+    activeLoadRef.current = load;
+  }, [load]);
   const requestAbortRef = useRef<AbortController | null>(null);
   const [stateIdentity, setStateIdentity] = useState<{ load: typeof load }>(() => ({ load }));
 
@@ -123,11 +125,12 @@ export function useMutationRunner(identity: unknown = undefined): MutationState 
   const inFlight = useRef(0);
   const generation = useRef(0);
   const identityRef = useRef(identity);
-  if (!Object.is(identityRef.current, identity)) {
+  useLayoutEffect(() => {
+    if (Object.is(identityRef.current, identity)) return;
     identityRef.current = identity;
     generation.current += 1;
     inFlight.current = 0;
-  }
+  }, [identity]);
   const mounted = useRef(true);
   useEffect(() => {
     mounted.current = true;
@@ -153,7 +156,15 @@ export function useMutationRunner(identity: unknown = undefined): MutationState 
         setMutationError(null);
       }
       try {
-        return await operation();
+        const result = await operation();
+        if (
+          !mounted.current ||
+          generation.current !== ownedGeneration ||
+          !Object.is(identityRef.current, ownedIdentity)
+        ) {
+          return null;
+        }
+        return result;
       } catch (cause) {
         if (
           mounted.current &&
@@ -216,11 +227,13 @@ export function useSessionEventTrigger(
   const events = options.events;
   const sharedFeed = events !== undefined;
   const matchRef = useRef(match);
-  matchRef.current = match;
   const onEventRef = useRef(onEvent);
-  onEventRef.current = onEvent;
   const reconcileBeforeLiveRef = useRef(reconcileBeforeLive);
-  reconcileBeforeLiveRef.current = reconcileBeforeLive;
+  useLayoutEffect(() => {
+    matchRef.current = match;
+    onEventRef.current = onEvent;
+    reconcileBeforeLiveRef.current = reconcileBeforeLive;
+  }, [match, onEvent, reconcileBeforeLive]);
   const consumedRef = useRef(0);
   const feedKeyRef = useRef<string | null>(null);
 
@@ -284,7 +297,9 @@ export function useSessionEventTrigger(
 /** Debounce rapid event bursts into one trailing call (default 150ms). */
 export function useDebouncedCallback(callback: () => void, delayMs = 150): () => void {
   const callbackRef = useRef(callback);
-  callbackRef.current = callback;
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     return () => {

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -7,7 +7,7 @@ import type {
   SendMessageInput,
   SessionEvent,
 } from "@opengeni/sdk";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useEmbeddedSession, type EmbeddedSessionClientOverride } from "../session-context";
 import { useSessionEventTrigger, type SessionEventFeedOptions } from "./internal";
 
@@ -70,7 +70,9 @@ export function useComposer(
   options: UseComposerOptions = {},
 ): ComposerState {
   const { client, workspaceId, registerSessionReconciler } = useEmbeddedSession(options);
+  const targetKey = `${workspaceId}\u0000${sessionId ?? ""}`;
   const [value, setValue] = useState("");
+  const [stateTargetKey, setStateTargetKey] = useState(targetKey);
   const [sending, setSending] = useState(false);
   const [pausing, setPausing] = useState(false);
   const [resuming, setResuming] = useState(false);
@@ -93,33 +95,46 @@ export function useComposer(
   // Read through a ref so a new extras closure (created every render by
   // callers passing inline functions) does not invalidate `send`.
   const sendExtrasRef = useRef(options.sendExtras);
-  sendExtrasRef.current = options.sendExtras;
-  const liveExtrasVersion = JSON.stringify(resolveSendExtras(options.sendExtras));
+  useLayoutEffect(() => {
+    sendExtrasRef.current = options.sendExtras;
+  }, [options.sendExtras]);
+  const liveExtras = resolveSendExtras(options.sendExtras);
+  const liveExtrasVersion = JSON.stringify(liveExtras);
 
   // A composer is bound to one session: switching targets must not leak the
-  // previous session's draft, error, or retry idempotency key.
-  const targetKey = `${workspaceId}\u0000${sessionId ?? ""}`;
+  // previous session's draft, error, or retry idempotency key. Revoke the old
+  // target only when the new render commits: a suspended transition must leave
+  // the still-visible composer fully interactive.
   const targetKeyRef = useRef(targetKey);
-  useEffect(() => {
-    if (targetKeyRef.current !== targetKey) {
-      targetKeyRef.current = targetKey;
-      targetGeneration.current += 1;
-      pendingClientEventId.current = null;
-      localEditRevision.current = 0;
-      draftReadGeneration.current += 1;
-      draftRef.current = null;
-      draftLoadErrorRef.current = null;
-      lastSavedSignature.current = null;
-      setValue("");
-      setError(null);
-      setDraft(null);
-      setDraftConflict(null);
-      setRestoredResources([]);
-    }
-  }, [targetKey]);
+  useLayoutEffect(() => {
+    if (targetKeyRef.current === targetKey) return;
+    targetKeyRef.current = targetKey;
+    targetGeneration.current += 1;
+    pendingClientEventId.current = null;
+    localEditRevision.current = 0;
+    draftReadGeneration.current += 1;
+    draftRef.current = null;
+    draftLoadErrorRef.current = null;
+    lastSavedSignature.current = null;
+    // An unresolved save for the old target must neither block nor join the
+    // new target's autosave chain. Its own generation fence drops settlement.
+    saveChain.current = Promise.resolve();
+    setStateTargetKey(targetKey);
+    setValue("");
+    setSending(false);
+    setPausing(false);
+    setResuming(false);
+    setError(null);
+    setDraft(null);
+    setDraftLoading(Boolean(sessionId));
+    setDraftSaving(false);
+    setDraftConflict(null);
+    setRestoredResources([]);
+  }, [sessionId, targetKey]);
 
   const applyDraft = useCallback(
     (next: ComposerDraft): void => {
+      if (targetKeyRef.current !== targetKey) return;
       draftRef.current = next;
       lastSavedSignature.current = draftSignature(draftPayload(next));
       localEditRevision.current += 1;
@@ -130,19 +145,21 @@ export function useComposer(
       setDraftConflict(null);
       onDraftApplied?.(next);
     },
-    [onDraftApplied],
+    [onDraftApplied, targetKey],
   );
 
   const loadDraft = useCallback(
     async (replaceLocal: boolean, rejectOnFailure = false): Promise<void> => {
-      if (!sessionId) return;
+      if (!sessionId || targetKeyRef.current !== targetKey) return;
       const generation = targetGeneration.current;
       const readTicket = ++draftReadGeneration.current;
       const localAtStart = localEditRevision.current;
       setDraftLoading(true);
       try {
         const fetched = await client.getComposerDraft(workspaceId, sessionId);
-        if (generation !== targetGeneration.current) return;
+        if (generation !== targetGeneration.current || targetKeyRef.current !== targetKey) {
+          return;
+        }
         const ownsLatestRead = readTicket === draftReadGeneration.current;
         const currentRevision = draftRef.current?.revision ?? -1;
         if ((ownsLatestRead || rejectOnFailure) && fetched.revision >= currentRevision) {
@@ -170,6 +187,7 @@ export function useComposer(
       } catch (cause) {
         if (
           generation === targetGeneration.current &&
+          targetKeyRef.current === targetKey &&
           (readTicket === draftReadGeneration.current || rejectOnFailure)
         ) {
           const failure = asError(cause);
@@ -178,12 +196,16 @@ export function useComposer(
         }
         if (rejectOnFailure) throw cause;
       } finally {
-        if (generation === targetGeneration.current && readTicket === draftReadGeneration.current) {
+        if (
+          generation === targetGeneration.current &&
+          targetKeyRef.current === targetKey &&
+          readTicket === draftReadGeneration.current
+        ) {
           setDraftLoading(false);
         }
       }
     },
-    [client, onDraftApplied, sessionId, workspaceId],
+    [client, onDraftApplied, sessionId, targetKey, workspaceId],
   );
 
   useEffect(() => {
@@ -211,6 +233,7 @@ export function useComposer(
   );
 
   const currentDraftPayload = useCallback((): SaveComposerDraftRequest | null => {
+    if (targetKeyRef.current !== targetKey) return null;
     const base = draftRef.current;
     if (!base) return null;
     const extras = resolveSendExtras(sendExtrasRef.current);
@@ -222,13 +245,21 @@ export function useComposer(
       model: extras.model ?? base.model,
       reasoningEffort: extras.reasoningEffort ?? base.reasoningEffort,
     };
-  }, [restoredResources, value]);
+  }, [restoredResources, targetKey, value]);
 
   const persistPayload = useCallback(
     async (payload: SaveComposerDraftRequest): Promise<boolean> => {
-      if (!sessionId) return false;
+      const ownedTargetKey = targetKey;
+      const ownedGeneration = targetGeneration.current;
+      if (!sessionId || targetKeyRef.current !== ownedTargetKey) return false;
       let success = false;
       const run = async () => {
+        if (
+          targetKeyRef.current !== ownedTargetKey ||
+          targetGeneration.current !== ownedGeneration
+        ) {
+          return;
+        }
         const current = draftRef.current;
         if (!current) return;
         const request = { ...payload, expectedRevision: current.revision };
@@ -240,24 +271,40 @@ export function useComposer(
         setDraftSaving(true);
         try {
           const saved = await client.saveComposerDraft(workspaceId, sessionId, request);
+          if (
+            targetKeyRef.current !== ownedTargetKey ||
+            targetGeneration.current !== ownedGeneration
+          ) {
+            return;
+          }
           draftRef.current = saved;
           setDraft(saved);
           lastSavedSignature.current = signature;
           setDraftConflict(null);
           success = true;
         } catch (cause) {
-          const problem = asError(cause);
-          setDraftConflict(problem);
-          setError(problem);
+          if (
+            targetKeyRef.current === ownedTargetKey &&
+            targetGeneration.current === ownedGeneration
+          ) {
+            const problem = asError(cause);
+            setDraftConflict(problem);
+            setError(problem);
+          }
         } finally {
-          setDraftSaving(false);
+          if (
+            targetKeyRef.current === ownedTargetKey &&
+            targetGeneration.current === ownedGeneration
+          ) {
+            setDraftSaving(false);
+          }
         }
       };
       saveChain.current = saveChain.current.then(run, run);
       await saveChain.current;
       return success;
     },
-    [client, sessionId, workspaceId],
+    [client, sessionId, targetKey, workspaceId],
   );
 
   // Private durable autosave. A newer local edit is never replaced by an older
@@ -280,6 +327,8 @@ export function useComposer(
 
   const dispatch = useCallback(
     async (delivery: "send" | "steer", explicit?: string): Promise<boolean> => {
+      const ownedTargetKey = targetKey;
+      const ownedGeneration = targetGeneration.current;
       const draftAtSend = value;
       const rawText = explicit ?? draftAtSend;
       const hasText = rawText.trim().length > 0;
@@ -287,7 +336,12 @@ export function useComposer(
       // resource) is legitimate, so we must not bail on empty text alone.
       const extras = resolveSendExtras(sendExtrasRef.current);
       const hasResources = restoredResources.length > 0 || (extras.resources?.length ?? 0) > 0;
-      if ((!hasText && !hasResources) || !sessionId || sending) {
+      if (
+        (!hasText && !hasResources) ||
+        !sessionId ||
+        sending ||
+        targetKeyRef.current !== ownedTargetKey
+      ) {
         return false;
       }
       // Reuse the clientEventId across retries of the same draft so a
@@ -305,6 +359,12 @@ export function useComposer(
         const currentPayload = currentDraftPayload();
         const payload = currentPayload ? { ...currentPayload, text: sendText } : null;
         if (payload && !(await persistPayload(payload))) return false;
+        if (
+          targetKeyRef.current !== ownedTargetKey ||
+          targetGeneration.current !== ownedGeneration
+        ) {
+          return false;
+        }
         const input = composeSendInput(sendText, pendingClientEventId.current, extras, {
           ...(options.effectiveControl?.controlEtag
             ? { controlEtag: options.effectiveControl.controlEtag }
@@ -316,6 +376,12 @@ export function useComposer(
           await client.steerMessage(workspaceId, sessionId, input);
         } else {
           await client.sendMessage(workspaceId, sessionId, input);
+        }
+        if (
+          targetKeyRef.current !== ownedTargetKey ||
+          targetGeneration.current !== ownedGeneration
+        ) {
+          return false;
         }
         pendingClientEventId.current = null;
         const previousDraft = draftRef.current;
@@ -342,10 +408,20 @@ export function useComposer(
         onSent?.(sendText);
         return true;
       } catch (cause) {
-        setError(cause instanceof Error ? cause : new Error(String(cause)));
+        if (
+          targetKeyRef.current === ownedTargetKey &&
+          targetGeneration.current === ownedGeneration
+        ) {
+          setError(cause instanceof Error ? cause : new Error(String(cause)));
+        }
         return false;
       } finally {
-        setSending(false);
+        if (
+          targetKeyRef.current === ownedTargetKey &&
+          targetGeneration.current === ownedGeneration
+        ) {
+          setSending(false);
+        }
       }
     },
     [
@@ -357,6 +433,7 @@ export function useComposer(
       restoredResources,
       sending,
       sessionId,
+      targetKey,
       value,
       workspaceId,
     ],
@@ -370,13 +447,13 @@ export function useComposer(
   // — keeping useComposer attachment-agnostic while still lighting up the send
   // affordance the moment a file is ready. ChatComposer additionally gates this
   // on its `attachments.uploading` flag so a message never departs mid-upload.
-  const hasReadyResources =
-    restoredResources.length > 0 ||
-    (resolveSendExtras(sendExtrasRef.current).resources?.length ?? 0) > 0;
+  const hasReadyResources = restoredResources.length > 0 || (liveExtras.resources?.length ?? 0) > 0;
 
   const pause = useCallback(
     async (reason?: string): Promise<void> => {
-      if (!sessionId || pausing) {
+      const ownedTargetKey = targetKey;
+      const ownedGeneration = targetGeneration.current;
+      if (!sessionId || pausing || targetKeyRef.current !== ownedTargetKey) {
         return;
       }
       setPausing(true);
@@ -389,17 +466,29 @@ export function useComposer(
             : {}),
         });
       } catch (cause) {
-        setError(cause instanceof Error ? cause : new Error(String(cause)));
+        if (
+          targetKeyRef.current === ownedTargetKey &&
+          targetGeneration.current === ownedGeneration
+        ) {
+          setError(cause instanceof Error ? cause : new Error(String(cause)));
+        }
       } finally {
-        setPausing(false);
+        if (
+          targetKeyRef.current === ownedTargetKey &&
+          targetGeneration.current === ownedGeneration
+        ) {
+          setPausing(false);
+        }
       }
     },
-    [client, workspaceId, sessionId, pausing, options.effectiveControl?.controlEtag],
+    [client, workspaceId, sessionId, pausing, options.effectiveControl?.controlEtag, targetKey],
   );
 
   const resume = useCallback(
     async (reason?: string): Promise<void> => {
-      if (!sessionId || resuming) return;
+      const ownedTargetKey = targetKey;
+      const ownedGeneration = targetGeneration.current;
+      if (!sessionId || resuming || targetKeyRef.current !== ownedTargetKey) return;
       setResuming(true);
       setError(null);
       try {
@@ -410,17 +499,29 @@ export function useComposer(
             : {}),
         });
       } catch (cause) {
-        setError(cause instanceof Error ? cause : new Error(String(cause)));
+        if (
+          targetKeyRef.current === ownedTargetKey &&
+          targetGeneration.current === ownedGeneration
+        ) {
+          setError(cause instanceof Error ? cause : new Error(String(cause)));
+        }
       } finally {
-        setResuming(false);
+        if (
+          targetKeyRef.current === ownedTargetKey &&
+          targetGeneration.current === ownedGeneration
+        ) {
+          setResuming(false);
+        }
       }
     },
-    [client, workspaceId, sessionId, resuming, options.effectiveControl?.controlEtag],
+    [client, workspaceId, sessionId, resuming, options.effectiveControl?.controlEtag, targetKey],
   );
 
   const resumeScope = useCallback(
     async (option: EffectiveControlResumeOption): Promise<void> => {
-      if (!sessionId || resuming) return;
+      const ownedTargetKey = targetKey;
+      const ownedGeneration = targetGeneration.current;
+      if (!sessionId || resuming || targetKeyRef.current !== ownedTargetKey) return;
       setResuming(true);
       setError(null);
       try {
@@ -438,6 +539,12 @@ export function useComposer(
           });
         } else if (option.scope === "session" && option.targetId) {
           const target = await client.getQueue(workspaceId, option.targetId);
+          if (
+            targetKeyRef.current !== ownedTargetKey ||
+            targetGeneration.current !== ownedGeneration
+          ) {
+            return;
+          }
           await client.resumeSession(workspaceId, option.targetId, {
             expectedControlEtag: target.effectiveControl.controlEtag,
           });
@@ -449,29 +556,52 @@ export function useComposer(
           });
         }
       } catch (cause) {
-        setError(asError(cause));
+        if (
+          targetKeyRef.current === ownedTargetKey &&
+          targetGeneration.current === ownedGeneration
+        ) {
+          setError(asError(cause));
+        }
       } finally {
-        setResuming(false);
+        if (
+          targetKeyRef.current === ownedTargetKey &&
+          targetGeneration.current === ownedGeneration
+        ) {
+          setResuming(false);
+        }
       }
     },
-    [client, options.effectiveControl, resuming, sessionId, workspaceId],
+    [client, options.effectiveControl, resuming, sessionId, targetKey, workspaceId],
   );
 
-  const updateValue = useCallback((next: string) => {
-    pendingClientEventId.current = null;
-    localEditRevision.current += 1;
-    setValue(next);
-  }, []);
+  const updateValue = useCallback(
+    (next: string) => {
+      if (targetKeyRef.current !== targetKey) return;
+      pendingClientEventId.current = null;
+      localEditRevision.current += 1;
+      setValue(next);
+    },
+    [targetKey],
+  );
 
-  const removeRestoredResource = useCallback((index: number) => {
-    localEditRevision.current += 1;
-    setRestoredResources((current) => current.filter((_, candidate) => candidate !== index));
-  }, []);
+  const removeRestoredResource = useCallback(
+    (index: number) => {
+      if (targetKeyRef.current !== targetKey) return;
+      localEditRevision.current += 1;
+      setRestoredResources((current) => current.filter((_, candidate) => candidate !== index));
+    },
+    [targetKey],
+  );
 
   const resolveDraftConflict = useCallback(
     async (choice: "keep_mine" | "use_remote"): Promise<void> => {
-      if (!sessionId) return;
+      const ownedTargetKey = targetKey;
+      const ownedGeneration = targetGeneration.current;
+      if (!sessionId || targetKeyRef.current !== ownedTargetKey) return;
       const remote = await client.getComposerDraft(workspaceId, sessionId);
+      if (targetKeyRef.current !== ownedTargetKey || targetGeneration.current !== ownedGeneration) {
+        return;
+      }
       if (choice === "use_remote") {
         applyDraft(remote);
         return;
@@ -482,36 +612,45 @@ export function useComposer(
       const payload = currentDraftPayload();
       if (payload) await persistPayload({ ...payload, expectedRevision: remote.revision });
     },
-    [applyDraft, client, currentDraftPayload, persistPayload, sessionId, workspaceId],
+    [applyDraft, client, currentDraftPayload, persistPayload, sessionId, targetKey, workspaceId],
   );
 
+  const identityMatches = stateTargetKey === targetKey;
+  const reloadDraft = useCallback(async () => await loadDraft(true), [loadDraft]);
+  const clearError = useCallback(() => {
+    if (targetKeyRef.current !== targetKey) return;
+    setError(null);
+    setDraftConflict(null);
+  }, [targetKey]);
+
   return {
-    value,
+    value: identityMatches ? value : "",
     setValue: updateValue,
     send,
     steer,
-    sending,
-    canSend: Boolean(sessionId) && !sending && (value.trim().length > 0 || hasReadyResources),
+    sending: identityMatches ? sending : false,
+    canSend:
+      identityMatches &&
+      Boolean(sessionId) &&
+      !sending &&
+      (value.trim().length > 0 || hasReadyResources),
     pause,
-    pausing,
+    pausing: identityMatches ? pausing : false,
     resume,
     resumeScope,
-    resuming,
-    draft,
-    draftRevision: draft?.revision ?? 0,
-    draftLoading,
-    draftSaving,
-    draftConflict,
+    resuming: identityMatches ? resuming : false,
+    draft: identityMatches ? draft : null,
+    draftRevision: identityMatches ? (draft?.revision ?? 0) : 0,
+    draftLoading: identityMatches ? draftLoading : Boolean(sessionId),
+    draftSaving: identityMatches ? draftSaving : false,
+    draftConflict: identityMatches ? draftConflict : null,
     applyDraft,
-    reloadDraft: useCallback(async () => await loadDraft(true), [loadDraft]),
+    reloadDraft,
     resolveDraftConflict,
-    restoredResources,
+    restoredResources: identityMatches ? restoredResources : [],
     removeRestoredResource,
-    error,
-    clearError: useCallback(() => {
-      setError(null);
-      setDraftConflict(null);
-    }, []),
+    error: identityMatches ? error : null,
+    clearError,
   };
 }
 

--- a/packages/react/src/hooks/use-session-control.ts
+++ b/packages/react/src/hooks/use-session-control.ts
@@ -1,5 +1,5 @@
 import type { SessionControlResponse, SessionEvent } from "@opengeni/sdk";
-import { useCallback, useRef } from "react";
+import { useCallback, useLayoutEffect, useRef } from "react";
 import { useEmbeddedSession, type EmbeddedSessionClientOverride } from "../session-context";
 import { useMutationRunner } from "./internal";
 
@@ -35,21 +35,23 @@ export function useSessionControl(
     decisionKey: string;
     clientEventId: string;
   } | null>(null);
-  if (pendingApproval.current?.targetKey !== approvalTargetKey) {
-    pendingApproval.current = null;
-  }
+  useLayoutEffect(() => {
+    if (pendingApproval.current?.targetKey !== approvalTargetKey) {
+      pendingApproval.current = null;
+    }
+  }, [approvalTargetKey]);
   const {
     run: runControl,
     mutating: controlling,
     mutationError: controlError,
     clearMutationError: clearControlError,
-  } = useMutationRunner();
+  } = useMutationRunner(approvalTargetKey);
   const {
     run: runApproval,
     mutating: responding,
     mutationError: approvalError,
     clearMutationError: clearApprovalError,
-  } = useMutationRunner();
+  } = useMutationRunner(approvalTargetKey);
 
   const pause = useCallback(
     async (reason?: string): Promise<SessionControlResponse | null> => {

--- a/packages/react/src/hooks/use-turn-queue.ts
+++ b/packages/react/src/hooks/use-turn-queue.ts
@@ -6,7 +6,7 @@ import type {
   SessionQueueSnapshot,
   SessionTurn,
 } from "@opengeni/sdk";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useEmbeddedSession, type EmbeddedSessionClientOverride } from "../session-context";
 import {
   useDebouncedCallback,
@@ -36,6 +36,7 @@ function queueSnapshotCovers(
 }
 
 export type QueueMutationKind = "move" | "edit" | "steer" | "delete";
+const EMPTY_PENDING_BY_TURN: Readonly<Record<string, QueueMutationKind>> = {};
 
 export type UseTurnQueueOptions = EmbeddedSessionClientOverride &
   SessionEventFeedOptions & {
@@ -80,55 +81,78 @@ export function useTurnQueue(
   const { client, workspaceId, workspaceControlEvent, registerSessionReconciler } =
     useEmbeddedSession(options);
   const enabled = (options.enabled ?? true) && Boolean(sessionId);
+  const targetKey = `${workspaceId}\u0000${sessionId ?? ""}`;
   const [snapshot, setSnapshot] = useState<SessionQueueSnapshot | null>(null);
+  const [stateTargetKey, setStateTargetKey] = useState(targetKey);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<Error | null>(null);
   const [mutationError, setMutationError] = useState<Error | null>(null);
   const [pendingByTurn, setPendingByTurn] = useState<Record<string, QueueMutationKind>>({});
   const pendingRef = useRef<Record<string, QueueMutationKind>>({});
   const readGeneration = useRef(0);
-  const targetKeyRef = useRef<string | null>(null);
+  const targetKeyRef = useRef(targetKey);
   const snapshotRef = useRef<SessionQueueSnapshot | null>(null);
 
-  const acceptSnapshot = useCallback((next: SessionQueueSnapshot | null): boolean => {
-    const current = snapshotRef.current;
-    if (
-      next &&
-      current &&
-      (next.version < current.version ||
-        next.effectiveControl.controlVersion < current.effectiveControl.controlVersion)
-    ) {
-      return false;
-    }
-    snapshotRef.current = next;
-    setSnapshot(next);
-    return true;
-  }, []);
+  // Revoke the old target only when the new one commits. A concurrent render
+  // may suspend while the previous target remains visible and interactive.
+  useLayoutEffect(() => {
+    if (targetKeyRef.current === targetKey) return;
+    targetKeyRef.current = targetKey;
+    readGeneration.current += 1;
+    snapshotRef.current = null;
+    pendingRef.current = {};
+    setStateTargetKey(targetKey);
+    setSnapshot(null);
+    setLoading(enabled);
+    setError(null);
+    setMutationError(null);
+    setPendingByTurn({});
+  }, [enabled, targetKey]);
+
+  const acceptSnapshot = useCallback(
+    (ownedTargetKey: string, next: SessionQueueSnapshot | null): boolean => {
+      if (targetKeyRef.current !== ownedTargetKey) return false;
+      const current = snapshotRef.current;
+      if (
+        next &&
+        current &&
+        (next.version < current.version ||
+          next.effectiveControl.controlVersion < current.effectiveControl.controlVersion)
+      ) {
+        return false;
+      }
+      snapshotRef.current = next;
+      setStateTargetKey(ownedTargetKey);
+      setSnapshot(next);
+      return true;
+    },
+    [],
+  );
 
   const load = useCallback(
     async (rejectOnFailure = false): Promise<void> => {
       if (!sessionId) return;
-      const targetKey = `${workspaceId}\u0000${sessionId}`;
+      const ownedTargetKey = `${workspaceId}\u0000${sessionId}`;
       const ticket = ++readGeneration.current;
       try {
         const fetched = await client.getQueue(workspaceId, sessionId);
-        if (targetKeyRef.current !== targetKey) return;
+        if (targetKeyRef.current !== ownedTargetKey) return;
         const ownsLatestRead = ticket === readGeneration.current;
         if (rejectOnFailure) {
-          const committed = acceptSnapshot(fetched);
+          const committed = acceptSnapshot(ownedTargetKey, fetched);
           if (!committed && !queueSnapshotCovers(snapshotRef.current, fetched)) {
             throw new TypeError("Queue reconciliation did not commit authoritative state");
           }
           setError(null);
           if (ownsLatestRead) setLoading(false);
         } else if (ownsLatestRead) {
-          acceptSnapshot(fetched);
+          acceptSnapshot(ownedTargetKey, fetched);
           setError(null);
           setLoading(false);
         }
       } catch (cause) {
         if (
-          targetKeyRef.current === targetKey &&
+          targetKeyRef.current === ownedTargetKey &&
           (ticket === readGeneration.current || rejectOnFailure)
         ) {
           setError(asError(cause));
@@ -141,16 +165,6 @@ export function useTurnQueue(
   );
 
   useEffect(() => {
-    const targetKey = `${workspaceId}\u0000${sessionId ?? ""}`;
-    if (targetKeyRef.current !== targetKey) {
-      targetKeyRef.current = targetKey;
-      readGeneration.current += 1;
-      acceptSnapshot(null);
-      setError(null);
-      setMutationError(null);
-      setPendingByTurn({});
-      pendingRef.current = {};
-    }
     if (!enabled) {
       setLoading(false);
       return;
@@ -168,7 +182,7 @@ export function useTurnQueue(
       clearInterval(timer);
       readGeneration.current += 1;
     };
-  }, [load, enabled, workspaceId, sessionId, options.pollIntervalMs, acceptSnapshot]);
+  }, [load, enabled, options.pollIntervalMs]);
 
   useEffect(() => {
     if (enabled && workspaceControlEvent) void load();
@@ -201,23 +215,30 @@ export function useTurnQueue(
         turn: SessionTurn,
       ) => Promise<SessionQueueMutationResponse>,
     ): Promise<SessionQueueMutationResponse | null> => {
-      if (!sessionId || pendingRef.current[turnId]) return null;
+      const ownedTargetKey = targetKey;
+      if (!sessionId || targetKeyRef.current !== ownedTargetKey || pendingRef.current[turnId]) {
+        return null;
+      }
       const current = snapshotRef.current;
       const turn = current?.items.find((candidate) => candidate.id === turnId);
       if (!current || !turn) return null;
       pendingRef.current = { ...pendingRef.current, [turnId]: kind };
+      setStateTargetKey(ownedTargetKey);
       setPendingByTurn(pendingRef.current);
       setMutationError(null);
       try {
         const result = await command(current, turn);
-        acceptSnapshot(result.snapshot);
+        if (targetKeyRef.current !== ownedTargetKey) return null;
+        acceptSnapshot(ownedTargetKey, result.snapshot);
         return result;
       } catch (cause) {
-        setMutationError(asError(cause));
-        await load();
+        if (targetKeyRef.current === ownedTargetKey) {
+          setMutationError(asError(cause));
+          await load();
+        }
         return null;
       } finally {
-        if (turnId in pendingRef.current) {
+        if (targetKeyRef.current === ownedTargetKey && turnId in pendingRef.current) {
           const next = { ...pendingRef.current };
           delete next[turnId];
           pendingRef.current = next;
@@ -225,7 +246,7 @@ export function useTurnQueue(
         }
       }
     },
-    [acceptSnapshot, load, sessionId],
+    [acceptSnapshot, load, sessionId, targetKey],
   );
 
   const moveTurn = useCallback(
@@ -288,29 +309,37 @@ export function useTurnQueue(
     [client, mutate, sessionId, workspaceId],
   );
 
-  const mutationFor = useCallback(
-    (turnId: string): QueueMutationKind | null => pendingByTurn[turnId] ?? null,
-    [pendingByTurn],
+  const identityMatches = stateTargetKey === targetKey;
+  const visibleSnapshot = identityMatches ? snapshot : null;
+  const visiblePendingByTurn = identityMatches ? pendingByTurn : EMPTY_PENDING_BY_TURN;
+  const mutating = useMemo(
+    () => Object.keys(visiblePendingByTurn).length > 0,
+    [visiblePendingByTurn],
   );
-  const mutating = useMemo(() => Object.keys(pendingByTurn).length > 0, [pendingByTurn]);
+  const mutationFor = useCallback(
+    (turnId: string): QueueMutationKind | null => visiblePendingByTurn[turnId] ?? null,
+    [visiblePendingByTurn],
+  );
 
   return {
-    snapshot,
-    queue: snapshot?.items ?? [],
-    effectiveControl: snapshot?.effectiveControl ?? null,
-    stoppingPreviousAttempt: snapshot?.stoppingPreviousAttempt ?? false,
-    loading,
-    error,
+    snapshot: visibleSnapshot,
+    queue: visibleSnapshot?.items ?? [],
+    effectiveControl: visibleSnapshot?.effectiveControl ?? null,
+    stoppingPreviousAttempt: visibleSnapshot?.stoppingPreviousAttempt ?? false,
+    loading: identityMatches ? loading : enabled,
+    error: identityMatches ? error : null,
     refresh: load,
     moveTurn,
     editTurn,
     steerTurn,
     removeTurn,
-    pendingByTurn,
+    pendingByTurn: visiblePendingByTurn,
     mutationFor,
     mutating,
-    mutationError,
-    clearMutationError: useCallback(() => setMutationError(null), []),
+    mutationError: identityMatches ? mutationError : null,
+    clearMutationError: useCallback(() => {
+      if (targetKeyRef.current === targetKey) setMutationError(null);
+    }, [targetKey]),
   };
 }
 

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -5,9 +5,13 @@
    needs them and restored afterwards.
    -------------------------------------------------------------------------- */
 import { describe, expect, test } from "bun:test";
+import { startTransition, Suspense, useState } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
 import type {
   ComposerDraft,
   SessionEvent,
+  SessionControlResponse,
   SessionQueueMutationResponse,
   SessionQueueSnapshot,
   SessionTurn,
@@ -522,6 +526,67 @@ describe("useTurnQueue", () => {
     expect(hook.result.current.queue.map((turn) => turn.id)).toEqual([queued.id]);
     await hook.unmount();
   });
+
+  test("a session switch hides the old queue and drops its delayed mutation settlement", async () => {
+    const sessionA: string = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const sessionB: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const turnA = fakeTurn({ id: "aaaaaaaa-0000-4000-8000-000000000001", prompt: "A PRIVATE" });
+    const turnB = fakeTurn({ id: "bbbbbbbb-0000-4000-8000-000000000001", prompt: "B PRIVATE" });
+    let resolveBRead!: (snapshot: SessionQueueSnapshot) => void;
+    let resolveAMutation!: (result: SessionQueueMutationResponse) => void;
+    const client = fakeClient({
+      getQueue: async (_workspaceId, sessionId) => {
+        if (sessionId === sessionA) return queueSnapshot([turnA]);
+        return await new Promise<SessionQueueSnapshot>((resolve) => {
+          resolveBRead = resolve;
+        });
+      },
+      deleteQueueItem: async () =>
+        await new Promise<SessionQueueMutationResponse>((resolve) => {
+          resolveAMutation = resolve;
+        }),
+    });
+    const hook = await renderHook(
+      (sessionId: string) =>
+        useTurnQueue(sessionId, { client, workspaceId: WORKSPACE_ID, events: noEvents }),
+      sessionA,
+    );
+    await flush();
+    expect(hook.result.current.queue.map((turn) => turn.prompt)).toEqual(["A PRIVATE"]);
+
+    let staleMutation!: Promise<boolean>;
+    await flushing(() => {
+      staleMutation = hook.result.current.removeTurn(turnA.id);
+    });
+    await hook.rerender(sessionB);
+    expect(hook.result.current.queue).toEqual([]);
+    expect(hook.result.current.loading).toBe(true);
+
+    await flushing(() => resolveBRead(queueSnapshot([turnB])));
+    expect(hook.result.current.queue.map((turn) => turn.prompt)).toEqual(["B PRIVATE"]);
+
+    await flushing(async () => {
+      resolveAMutation({
+        receipt: {
+          id: crypto.randomUUID(),
+          action: "queue.delete",
+          operationKey: "stale-a-delete",
+          targetSessionId: sessionA,
+          targetTurnId: turnA.id,
+          appliedControlRevision: null,
+          appliedQueueVersion: 2,
+          appliedTurnVersion: 2,
+          appliedDraftRevision: null,
+          createdAt: new Date().toISOString(),
+        },
+        snapshot: queueSnapshot([], { version: 2 }),
+      });
+      expect(await staleMutation).toBe(false);
+    });
+    expect(hook.result.current.queue.map((turn) => turn.prompt)).toEqual(["B PRIVATE"]);
+    expect(hook.result.current.mutationError).toBeNull();
+    await hook.unmount();
+  });
 });
 
 describe("useSessionLineage", () => {
@@ -868,6 +933,88 @@ describe("useSessionControl", () => {
     expect(clientEventIds).toHaveLength(2);
     expect(clientEventIds[0]).not.toBe("");
     expect(clientEventIds[1]).toBe(clientEventIds[0]);
+    await hook.unmount();
+  });
+
+  test("a session switch drops stale control loading and error settlement", async () => {
+    const sessionA: string = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const sessionB: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    let rejectPause!: (cause: Error) => void;
+    const client = fakeClient({
+      pauseSession: async () =>
+        await new Promise((_resolve, reject) => {
+          rejectPause = reject;
+        }),
+    });
+    const hook = await renderHook(
+      (sessionId: string) => useSessionControl(sessionId, { client, workspaceId: WORKSPACE_ID }),
+      sessionA,
+    );
+
+    let stalePause!: Promise<unknown>;
+    await flushing(() => {
+      stalePause = hook.result.current.pause();
+    });
+    expect(hook.result.current.controlling).toBe(true);
+    await hook.rerender(sessionB);
+    expect(hook.result.current.controlling).toBe(false);
+    expect(hook.result.current.error).toBeNull();
+
+    await flushing(async () => {
+      rejectPause(new Error("A PRIVATE CONTROL ERROR"));
+      expect(await stalePause).toBeNull();
+    });
+    expect(hook.result.current.controlling).toBe(false);
+    expect(hook.result.current.error).toBeNull();
+    await hook.unmount();
+  });
+
+  test("a session switch returns null for a successful stale control settlement", async () => {
+    const sessionA: string = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const sessionB: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    let resolvePause!: (response: SessionControlResponse) => void;
+    const client = fakeClient({
+      pauseSession: async () =>
+        await new Promise<SessionControlResponse>((resolve) => {
+          resolvePause = resolve;
+        }),
+    });
+    const hook = await renderHook(
+      (sessionId: string) => useSessionControl(sessionId, { client, workspaceId: WORKSPACE_ID }),
+      sessionA,
+    );
+
+    let stalePause!: Promise<SessionControlResponse | null>;
+    await flushing(() => {
+      stalePause = hook.result.current.pause();
+    });
+    await hook.rerender(sessionB);
+    await flushing(async () => {
+      resolvePause({
+        receipt: {
+          id: crypto.randomUUID(),
+          action: "session.paused",
+          operationKey: crypto.randomUUID(),
+          targetSessionId: sessionA,
+          targetTurnId: null,
+          appliedControlRevision: 1,
+          appliedQueueVersion: null,
+          appliedTurnVersion: null,
+          appliedDraftRevision: null,
+          createdAt: new Date().toISOString(),
+        },
+        effectiveControl: {
+          ...queueSnapshot([]).effectiveControl,
+          state: "paused",
+          directState: "paused",
+        },
+        interruptionCount: 1,
+        wakeCount: 0,
+      });
+      expect(await stalePause).toBeNull();
+    });
+    expect(hook.result.current.controlling).toBe(false);
+    expect(hook.result.current.error).toBeNull();
     await hook.unmount();
   });
 });
@@ -1310,6 +1457,250 @@ describe("useComposer durable draft and control binding", () => {
     expect(hook.result.current.draftConflict?.message).toContain("409");
     await hook.unmount();
   });
+
+  test("a session switch hides the old draft and drops its delayed autosave settlement", async () => {
+    const sessionA: string = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const sessionB: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const makeDraft = (text: string): ComposerDraft => ({
+      revision: 1,
+      text,
+      resources: [],
+      tools: [],
+      model: "model-x",
+      reasoningEffort: "medium",
+      sourceTurnId: null,
+      sourceTurnVersion: null,
+      updatedAt: new Date().toISOString(),
+    });
+    let resolveBRead!: (value: ComposerDraft) => void;
+    let resolveASave!: (value: ComposerDraft) => void;
+    let savedARequest: { text: string } | null = null;
+    const client = fakeClient({
+      getComposerDraft: async (_workspaceId, sessionId) => {
+        if (sessionId === sessionA) return makeDraft("A PRIVATE");
+        return await new Promise<ComposerDraft>((resolve) => {
+          resolveBRead = resolve;
+        });
+      },
+      saveComposerDraft: async (_workspaceId, sessionId, request) => {
+        if (sessionId !== sessionA) throw new Error("unexpected B autosave");
+        savedARequest = request;
+        return await new Promise<ComposerDraft>((resolve) => {
+          resolveASave = resolve;
+        });
+      },
+    });
+    const hook = await renderHook(
+      (sessionId: string) => useComposer(sessionId, { client, workspaceId: WORKSPACE_ID }),
+      sessionA,
+    );
+    await flush();
+    expect(hook.result.current.value).toBe("A PRIVATE");
+
+    await flushing(() => hook.result.current.setValue("A PRIVATE EDIT"));
+    await flush(600);
+    expect(savedARequest).toMatchObject({ text: "A PRIVATE EDIT" });
+
+    await hook.rerender(sessionB);
+    expect(hook.result.current.value).toBe("");
+    expect(hook.result.current.draft).toBeNull();
+    await flushing(() => resolveBRead(makeDraft("B PRIVATE")));
+    expect(hook.result.current.value).toBe("B PRIVATE");
+
+    await flushing(() =>
+      resolveASave({
+        ...makeDraft("A PRIVATE EDIT"),
+        revision: 2,
+      }),
+    );
+    expect(hook.result.current.value).toBe("B PRIVATE");
+    expect(hook.result.current.draft?.text).toBe("B PRIVATE");
+    expect(hook.result.current.draftConflict).toBeNull();
+    await hook.unmount();
+  });
+
+  test("a session switch drops stale composer control settlement", async () => {
+    const sessionA: string = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const sessionB: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    let rejectPause!: (cause: Error) => void;
+    const client = fakeClient({
+      pauseSession: async () =>
+        await new Promise((_resolve, reject) => {
+          rejectPause = reject;
+        }),
+    });
+    const hook = await renderHook(
+      (sessionId: string) => useComposer(sessionId, { client, workspaceId: WORKSPACE_ID }),
+      sessionA,
+    );
+    await flush();
+
+    let stalePause!: Promise<void>;
+    await flushing(() => {
+      stalePause = hook.result.current.pause();
+    });
+    expect(hook.result.current.pausing).toBe(true);
+    await hook.rerender(sessionB);
+    expect(hook.result.current.pausing).toBe(false);
+    expect(hook.result.current.error).toBeNull();
+
+    await flushing(async () => {
+      rejectPause(new Error("A PRIVATE CONTROL ERROR"));
+      await stalePause;
+    });
+    expect(hook.result.current.pausing).toBe(false);
+    expect(hook.result.current.error).toBeNull();
+    await hook.unmount();
+  });
+
+  test("a session switch stops a stale scoped resume before its follow-up write", async () => {
+    const sessionA: string = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const sessionB: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const scopedSession: string = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    let resolveScopedQueue!: (value: SessionQueueSnapshot) => void;
+    const resumedSessions: string[] = [];
+    const client = fakeClient({
+      getQueue: async (_workspaceId, sessionId) => {
+        if (sessionId !== scopedSession) return queueSnapshot([]);
+        return await new Promise<SessionQueueSnapshot>((resolve) => {
+          resolveScopedQueue = resolve;
+        });
+      },
+      resumeSession: async (_workspaceId, sessionId) => {
+        resumedSessions.push(sessionId);
+        throw new Error("unexpected stale resume");
+      },
+    });
+    const hook = await renderHook(
+      (sessionId: string) => useComposer(sessionId, { client, workspaceId: WORKSPACE_ID }),
+      sessionA,
+    );
+    await flush();
+
+    let staleResume!: Promise<void>;
+    await flushing(() => {
+      staleResume = hook.result.current.resumeScope({
+        scope: "session",
+        targetId: scopedSession,
+        selectedStateAfter: "active",
+        impactCopy: "Resume scoped session",
+      });
+    });
+    await hook.rerender(sessionB);
+    expect(hook.result.current.resuming).toBe(false);
+
+    await flushing(async () => {
+      resolveScopedQueue(queueSnapshot([]));
+      await staleResume;
+    });
+    expect(resumedSessions).toEqual([]);
+    expect(hook.result.current.error).toBeNull();
+    await hook.unmount();
+  });
+});
+
+describe("session hook concurrent target ownership", () => {
+  test("a suspended target transition leaves the committed session fully interactive", async () => {
+    const sessionA: string = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const sessionB: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const turn = fakeTurn({
+      id: "aaaaaaaa-0000-4000-8000-000000000001",
+      prompt: "A queue item",
+    });
+    const draft: ComposerDraft = {
+      revision: 1,
+      text: "A draft",
+      resources: [],
+      tools: [],
+      model: "model-x",
+      reasoningEffort: "medium",
+      sourceTurnId: null,
+      sourceTurnVersion: null,
+      updatedAt: new Date().toISOString(),
+    };
+    let deleteCalls = 0;
+    let pauseCalls = 0;
+    const client = fakeClient({
+      getQueue: async () => queueSnapshot([turn]),
+      getComposerDraft: async () => draft,
+      deleteQueueItem: async () => {
+        deleteCalls += 1;
+        throw new Error("expected test rollback");
+      },
+      pauseSession: async () => {
+        pauseCalls += 1;
+        throw new Error("expected test rollback");
+      },
+    });
+    let setTarget!: (target: string) => void;
+    let renderedSessionB = false;
+    let committed:
+      | {
+          queue: ReturnType<typeof useTurnQueue>;
+          composer: ReturnType<typeof useComposer>;
+          control: ReturnType<typeof useSessionControl>;
+        }
+      | undefined;
+    const suspended = new Promise<never>(() => {});
+
+    function Harness() {
+      const [target, setTargetState] = useState(sessionA);
+      setTarget = setTargetState;
+      const queue = useTurnQueue(target, {
+        client,
+        workspaceId: WORKSPACE_ID,
+        events: noEvents,
+      });
+      const composer = useComposer(target, {
+        client,
+        workspaceId: WORKSPACE_ID,
+        events: noEvents,
+      });
+      const control = useSessionControl(target, { client, workspaceId: WORKSPACE_ID });
+      if (target === sessionB) {
+        renderedSessionB = true;
+        throw suspended;
+      }
+      committed = { queue, composer, control };
+      return <div>{`${composer.value}|${queue.queue.map((item) => item.prompt).join(",")}`}</div>;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const previousActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT;
+    globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+    try {
+      flushSync(() => {
+        root.render(
+          <Suspense fallback={<div>Loading B</div>}>
+            <Harness />
+          </Suspense>,
+        );
+      });
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(committed?.composer.value).toBe("A draft");
+      expect(committed?.queue.queue.map((item) => item.prompt)).toEqual(["A queue item"]);
+
+      startTransition(() => setTarget(sessionB));
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(renderedSessionB).toBe(true);
+      expect(container.textContent).toBe("A draft|A queue item");
+
+      committed?.composer.setValue("A edited while B waits");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await committed?.queue.removeTurn(turn.id);
+      await committed?.control.pause();
+
+      expect(committed?.composer.value).toBe("A edited while B waits");
+      expect(deleteCalls).toBe(1);
+      expect(pauseCalls).toBe(1);
+    } finally {
+      flushSync(() => root.unmount());
+      container.remove();
+      globalThis.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
 });
 
 describe("useComposer file-only send", () => {
@@ -1327,6 +1718,27 @@ describe("useComposer file-only send", () => {
     // Empty draft, but a resource is attached → sendable.
     expect(hook.result.current.value).toBe("");
     expect(hook.result.current.canSend).toBe(true);
+    await hook.unmount();
+  });
+
+  test("canSend follows attachment additions and removals in the same session render", async () => {
+    const client = fakeClient({});
+    const hook = await renderHook(
+      (attached: boolean) =>
+        useComposer(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          sendExtras: () => ({
+            resources: attached ? [{ kind: "file", fileId: "file-1" }] : [],
+          }),
+        }),
+      false as boolean,
+    );
+    expect(hook.result.current.canSend).toBe(false);
+    await hook.rerender(true);
+    expect(hook.result.current.canSend).toBe(true);
+    await hook.rerender(false);
+    expect(hook.result.current.canSend).toBe(false);
     await hook.unmount();
   });
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -12,6 +12,7 @@ import {
   sandboxLifecycleHookIds,
 } from "@opengeni/config";
 import {
+  approvalIdentifier,
   CAPABILITY_DESCRIPTORS,
   isClearedRunStateBlob,
   prefixedMcpToolName as sharedPrefixedMcpToolName,
@@ -4613,7 +4614,7 @@ export function serializeApprovals(interruptions: unknown[]): unknown[] {
       return item.toJSON();
     }
     return {
-      id: approvalIdentifier(item),
+      id: approvalIdentifier(item) ?? "approval",
       name: item?.name ?? item?.rawItem?.name ?? "tool",
       arguments: item?.arguments ?? item?.rawItem?.arguments ?? null,
       raw: item,
@@ -6208,8 +6209,4 @@ function sortJson(value: unknown): unknown {
     );
   }
   return value;
-}
-
-function approvalIdentifier(item: any): string {
-  return String(item?.rawItem?.callId ?? item?.rawItem?.id ?? item?.id ?? item?.name ?? "approval");
 }


### PR DESCRIPTION
## Summary

- isolate queue and composer state across workspace/session target changes
- discard stale mutation/control settlements and stop stale multi-step resume writes
- validate approval decisions against the current saved run state using the runtime approval identity

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run check:public-hygiene`
- `bun run test:unit` (3,599 passed, 3 gated live-service tests skipped, 0 failed)
- `bun run build`