### PR TITLE
fix: inherit child session capabilities

### DIFF
--- a/.changeset/child-permission-inheritance.md
+++ b/.changeset/child-permission-inheritance.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/core": patch
+---
+
+Preserve narrowed first-party MCP capability boundaries by inheriting the creating session's effective permissions for child sessions that omit an explicit override.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -1490,7 +1490,12 @@ function registerWorkspaceOrchestrationTools(
           idempotencyKey: z4.string().min(1).max(200).optional(),
           // First-party MCP token permissions for the spawned session; every
           // permission must be held by this grant (validated in the domain).
-          firstPartyMcpPermissions: z4.array(z4.string()).optional(),
+          firstPartyMcpPermissions: z4
+            .array(z4.string())
+            .optional()
+            .describe(
+              "Optional first-party capability set for the child. Omit to inherit this session's effective permissions. An explicit set may only narrow capabilities held by this session.",
+            ),
           // Shared-sandbox placement (addendum 05 §D). OMIT (default) to SHARE the
           // creator's box — one filesystem/repo/desktop, N independent conversations;
           // this is the SAFE DEFAULT. Pass "new" for a fresh isolated box (a different

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -366,7 +366,7 @@ Critical route discipline (canonical: `routes/sessions.ts`):
 - `requireAccessGrant` **before** any Zod parse; explicit `HTTPException(400)` on parse failure (never a raw `ZodError` → 500); `HTTPException(409)` on an epoch fence.
 - The desktop-stream **consent gate** must match exactly between the `GET /stream-capabilities` read path and the `POST /viewers` attach path — drift is an un-redacted-pixel-plane bypass.
 - `parentSessionId` comes only from the worker-signed grant claim, never caller-supplied (cross-session write escalation otherwise).
-- `firstPartyMcpPermissions` can never out-rank the creating grant.
+- `firstPartyMcpPermissions` can never out-rank the creating grant. A child omission inherits that grant; it never re-expands to the deployment's standalone worker defaults.
 
 ### 7.2 `apps/worker` — orchestration + execution
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -119,6 +119,15 @@ check.
 
 Unset legs fall back independently to standalone self-mint/decrypt. This port does **not** supply the first-party MCP delegated token: `firstPartyMcpRequestInit` in `packages/runtime/src/index.ts` self-mints the `ogd_` bearer with `signDelegatedAccessToken(settings.delegationSecret, ...)`.
 
+An embedded host can narrow a root session with
+`CreateSessionRequest.firstPartyMcpPermissions`. Agent-created descendants
+inherit the creating session's effective first-party permission set when
+`session_create` omits an override; an explicit override must still be a subset
+of the creating grant. This preserves a host's capability boundary across the
+session tree while top-level omissions continue to use the deployment's normal
+standalone worker defaults. The inherited set is frozen on the child at
+creation; later deployment-default changes do not rewrite existing sessions.
+
 ### Persistence
 
 Canonical sources: `packages/db/src/index.ts`, `packages/db/src/migrate.ts`, `packages/db/src/provision-roles.ts`, and `dbSearchPath` in `packages/config/src/index.ts`.

--- a/docs/variable-sets.md
+++ b/docs/variable-sets.md
@@ -110,7 +110,8 @@ The invariant that sandboxed agents cannot reach workspace secrets is unchanged:
 
 ### Manager sessions: per-session first-party MCP permissions
 
-`CreateSessionRequest.firstPartyMcpPermissions` (REST `POST /sessions` and the MCP `session_create` tool) lets an operator create a session whose first-party MCP token carries a **non-default permission set** — this is how a manager-style session sees the orchestration (`sessions:*`), variable set, and `github:use` tools. Two rules keep this safe:
+`CreateSessionRequest.firstPartyMcpPermissions` (REST `POST /sessions` and the MCP `session_create` tool) lets an operator create a session whose first-party MCP token carries a **non-default permission set** — this is how a manager-style session sees the orchestration (`sessions:*`), variable set, and `github:use` tools. Three rules keep this safe:
 
 1. **Capped at creation.** Every requested permission must be held by the creating grant (`workspace:admin` covers all); otherwise the request is rejected with 403. A session can never out-rank its creator, and a manager spawning workers via `session_create` can only delegate a subset of what it was itself granted.
-2. **Fixed for the session's lifetime.** Like variable set attachment, the permission set is fixed at creation; there is no way for a running agent to widen its own token.
+2. **Inherited by default for children.** A top-level omission uses the deployment's normal worker defaults. A child created from a worker-signed session claim instead inherits a creation-time snapshot of the creator's effective set, so omission cannot widen a narrowed manager into the standalone defaults or drift when deployment defaults change later.
+3. **Fixed for the session's lifetime.** Like variable set attachment, the permission set is fixed at creation; there is no way for a running agent to widen its own token.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5165,10 +5165,10 @@ export const CreateSessionRequest = withVariableSetIdAlias({
   // creation of a brand-new session. Absent means no create-dedup (each call
   // is an independent create).
   idempotencyKey: z.string().min(1).max(200).optional(),
-  // Permissions the session's first-party MCP token should carry instead of
-  // the fixed worker default — how an operator hands a manager-style session
-  // the orchestration/variableSet/github tools. Capped at creation: every
-  // requested permission must be held by the creating grant (no escalation).
+  // Permissions the session's first-party MCP token should carry. A top-level
+  // omission uses the deployment's worker default; a child omission inherits
+  // the creating session's effective grant. An explicit set is capped at
+  // creation: every requested permission must be held by the creating grant.
   firstPartyMcpPermissions: z.array(Permission).optional(),
   // Third-party MCP servers attached only to this session. Credential headers are
   // write-only: create responses and events expose only SessionMcpServerMetadata.

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -813,11 +813,23 @@ export async function createSessionForRequest(
   );
   const model = payload.model ?? settings.openaiModel;
   const reasoningEffort = payload.reasoningEffort ?? settings.openaiReasoningEffort;
+  // Parent linkage comes only from the worker-signed session claim. Resolve it
+  // before first-party permissions because a child with no explicit override
+  // inherits the creating session's effective grant instead of silently
+  // expanding to the standalone worker defaults.
+  const parentSessionId =
+    typeof grant.metadata?.["sessionId"] === "string"
+      ? (grant.metadata["sessionId"] as string)
+      : null;
   // A session's first-party MCP token can carry a non-default permission set
   // (how an operator hands a manager-style session the orchestration tools),
   // but never one out-ranking its creator: every requested permission must be
-  // held by the creating grant.
-  let firstPartyMcpPermissions = payload.firstPartyMcpPermissions ?? null;
+  // held by the creating grant. A top-level omission keeps the deployment's
+  // normal worker defaults. A child omission inherits its creator's exact
+  // effective grant, preserving a host/operator's narrowed capability boundary
+  // through the whole session tree.
+  let firstPartyMcpPermissions =
+    payload.firstPartyMcpPermissions ?? (parentSessionId ? [...new Set(grant.permissions)] : null);
   if (firstPartyMcpPermissions && firstPartyMcpPermissions.length === 0) {
     // An empty set would sign an unusable zero-permission token; the default
     // worker set is expressed by omitting the field.
@@ -860,10 +872,6 @@ export async function createSessionForRequest(
   // its completion wake injects a user.message + queued turn into that session
   // without holding sessions:control on it (a cross-session write escalation).
   // The claim is the only trustworthy parent source.
-  const parentSessionId =
-    typeof grant.metadata?.["sessionId"] === "string"
-      ? (grant.metadata["sessionId"] as string)
-      : null;
   // Shared-sandbox placement (addendum 05 §D.2/§D.3, decision I10/OD-S1).
   //
   // The DEFAULT rule is context-dependent and resolved server-side from the

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -7041,6 +7041,28 @@ describe("API component integration", () => {
     expect(spawned.firstPartyMcpPermissions).toEqual(["sessions:read"]);
     expect(spawned.sandboxBackend).toBe("none");
 
+    // A worker-signed parent claim makes this a child create. Omitting the
+    // override must inherit the manager's effective grant instead of widening
+    // the child to OpenGeni's full standalone worker defaults.
+    const childMcp = buildOpenGeniMcpServer(mcpDeps, {
+      ...managerGrant,
+      // Delegated permission arrays are semantically sets. Inheritance stores
+      // one canonical copy even if an issuer supplied a duplicate.
+      permissions: [...managerGrant.permissions, "sessions:read"],
+      metadata: { sessionId: managerSession.id },
+    });
+    const inheritedChild = await callMcpTool<{
+      id: string;
+      parentSessionId: string | null;
+      firstPartyMcpPermissions: string[] | null;
+    }>(childMcp, "session_create", {
+      initialMessage: "inherit the manager boundary",
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    expect(inheritedChild.parentSessionId).toBe(managerSession.id);
+    expect(inheritedChild.firstPartyMcpPermissions).toEqual(managerGrant.permissions);
+
     // The delegated token the runtime mints for a session's first-party MCP
     // connection carries the session's permission set, which gates manager
     // tool visibility end to end; the default set stays worker-shaped.


### PR DESCRIPTION
## Summary
- inherit a creating session's effective first-party permissions when an agent-created child omits an override
- preserve the existing standalone defaults for top-level sessions and the existing cap for explicit subsets
- document the embedding contract and describe inheritance in the agent-visible `session_create` schema

## Why
A deliberately narrowed manager could otherwise create a child without `firstPartyMcpPermissions`, causing that child to fall back to the deployment's full standalone worker defaults. Embedded hosts need capability boundaries to remain stable across the complete session tree.

## Verification
- `bun run typecheck` (20/20 projects)
- `bun run lint`
- `bun run format:check`
- `git diff --check`
- `OPENGENI_TEST_REQUIRE_REAL_SERVICES=true bun test ./test/integration/api.integration.ts --test-name-pattern "per-session first-party MCP permissions"`
- Fable review: ACCEPT, no P0-P2 findings; contract wording, agent-visible description, snapshot semantics, and duplicate canonicalization follow-ups incorporated
