### PR TITLE
fix: preserve approval details and worker runtime closure

### DIFF
--- a/.changeset/approval-projection-shape.md
+++ b/.changeset/approval-projection-shape.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Preserve tool names and arguments when projecting serialized approval items through the session-only React API.

--- a/.changeset/worker-runtime-closure.md
+++ b/.changeset/worker-runtime-closure.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Declare the externalized GitHub and agent-protocol packages required by the published worker bundle.

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -35,6 +35,7 @@
     "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
+    "@opengeni/agent-proto": "workspace:*",
     "@opengeni/codex": "workspace:*",
     "@opengeni/config": "workspace:*",
     "@opengeni/contracts": "workspace:*",
@@ -42,6 +43,7 @@
     "@opengeni/db": "workspace:*",
     "@opengeni/documents": "workspace:*",
     "@opengeni/events": "workspace:*",
+    "@opengeni/github": "workspace:*",
     "@opengeni/observability": "workspace:*",
     "@opengeni/runtime": "workspace:*",
     "@opengeni/storage": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -126,6 +126,7 @@
       "name": "@opengeni/worker-bundle",
       "version": "0.7.5",
       "dependencies": {
+        "@opengeni/agent-proto": "workspace:*",
         "@opengeni/codex": "workspace:*",
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -133,6 +134,7 @@
         "@opengeni/db": "workspace:*",
         "@opengeni/documents": "workspace:*",
         "@opengeni/events": "workspace:*",
+        "@opengeni/github": "workspace:*",
         "@opengeni/observability": "workspace:*",
         "@opengeni/runtime": "workspace:*",
         "@opengeni/storage": "workspace:*",

--- a/packages/react/src/approvals.ts
+++ b/packages/react/src/approvals.ts
@@ -51,8 +51,8 @@ export function approvalsFromRequiresAction(payload: unknown): PendingApproval[]
         : {};
     return {
       id: String(raw.id ?? raw.callId ?? rawItem.callId ?? index),
-      name: String(raw.name ?? "approval"),
-      arguments: raw.arguments,
+      name: String(raw.name ?? raw.toolName ?? rawItem.name ?? "approval"),
+      arguments: raw.arguments ?? rawItem.arguments,
       raw: approval,
     };
   });

--- a/packages/react/src/approvals.ts
+++ b/packages/react/src/approvals.ts
@@ -50,7 +50,9 @@ export function approvalsFromRequiresAction(payload: unknown): PendingApproval[]
         ? (raw.rawItem as Record<string, unknown>)
         : {};
     return {
-      id: String(raw.id ?? raw.callId ?? rawItem.callId ?? index),
+      // Mirror the runtime's canonical interruption identity before retaining
+      // the legacy top-level callId fallback for already-normalized payloads.
+      id: String(rawItem.callId ?? rawItem.id ?? raw.id ?? raw.callId ?? raw.name ?? index),
       name: String(raw.name ?? raw.toolName ?? rawItem.name ?? "approval"),
       arguments: raw.arguments ?? rawItem.arguments,
       raw: approval,

--- a/packages/react/test/approvals.test.ts
+++ b/packages/react/test/approvals.test.ts
@@ -49,6 +49,31 @@ describe("approvalsFromRequiresAction", () => {
     expect(approvals[3]!.name).toBe("approval");
   });
 
+  test("normalizes the serialized OpenAI Agents tool-approval shape", () => {
+    const approvals = approvalsFromRequiresAction({
+      approvals: [
+        {
+          type: "tool_approval_item",
+          rawItem: {
+            type: "function_call",
+            callId: "call-123",
+            name: "delete_everything",
+            arguments: '{"scope":"workspace"}',
+          },
+          agent: { name: "reviewer" },
+          toolName: "delete_everything",
+        },
+      ],
+    });
+
+    expect(approvals).toHaveLength(1);
+    expect(approvals[0]).toMatchObject({
+      id: "call-123",
+      name: "delete_everything",
+      arguments: '{"scope":"workspace"}',
+    });
+  });
+
   test("tolerates malformed payloads", () => {
     expect(approvalsFromRequiresAction(null)).toEqual([]);
     expect(approvalsFromRequiresAction("nope")).toEqual([]);

--- a/packages/react/test/approvals.test.ts
+++ b/packages/react/test/approvals.test.ts
@@ -32,21 +32,28 @@ const decision = (approvalId: string, decisionType: "approve" | "reject" = "appr
   event("user.approvalDecision", { approvalId, decision: decisionType }, { turnId: null });
 
 describe("approvalsFromRequiresAction", () => {
-  test("maps id/name/arguments and falls back to callId, rawItem.callId, then index", () => {
+  test("maps id/name/arguments and mirrors canonical raw-item identity precedence", () => {
     const approvals = approvalsFromRequiresAction({
       approvals: [
         { id: "appr-1", name: "run_command", arguments: { cmd: "rm -rf /tmp/x" } },
         { callId: "call-2", name: "push_branch" },
         { rawItem: { callId: "raw-3" } },
+        { id: "outer-4", rawItem: { callId: "raw-4" } },
         {},
       ],
     });
-    expect(approvals.map((approval) => approval.id)).toEqual(["appr-1", "call-2", "raw-3", "3"]);
+    expect(approvals.map((approval) => approval.id)).toEqual([
+      "appr-1",
+      "call-2",
+      "raw-3",
+      "raw-4",
+      "4",
+    ]);
     expect(approvals[0]).toMatchObject({
       name: "run_command",
       arguments: { cmd: "rm -rf /tmp/x" },
     });
-    expect(approvals[3]!.name).toBe("approval");
+    expect(approvals[4]!.name).toBe("approval");
   });
 
   test("normalizes the serialized OpenAI Agents tool-approval shape", () => {
@@ -71,6 +78,30 @@ describe("approvalsFromRequiresAction", () => {
       id: "call-123",
       name: "delete_everything",
       arguments: '{"scope":"workspace"}',
+    });
+  });
+
+  test("uses rawItem.id for serialized hosted-tool approvals", () => {
+    const approvals = approvalsFromRequiresAction({
+      approvals: [
+        {
+          type: "tool_approval_item",
+          rawItem: {
+            type: "hosted_tool_call",
+            id: "hosted-42",
+            name: "web_search",
+            arguments: '{"query":"release safety"}',
+          },
+          agent: { name: "reviewer" },
+          toolName: "web_search",
+        },
+      ],
+    });
+
+    expect(approvals[0]).toMatchObject({
+      id: "hosted-42",
+      name: "web_search",
+      arguments: '{"query":"release safety"}',
     });
   });
 

--- a/scripts/publish-closure-guard.ts
+++ b/scripts/publish-closure-guard.ts
@@ -12,6 +12,8 @@
  *       the SDK remains zero-runtime-dep, and React only depends on SDK among
  *       @opengeni/* packages.
  *   (d) the BUILT sdk/react dist bundles reference any server/embed package.
+ *   (e) a built package imports an @opengeni/* runtime package that its
+ *       published manifest does not declare.
  *
  * Wired into the release gate and safe to run locally without publishing.
  */
@@ -225,6 +227,35 @@ function builtContractFiles(dir: string): string[] {
     else if (entry.name.endsWith(".js") || entry.name.endsWith(".d.ts")) files.push(path);
   }
   return files;
+}
+
+// Workspace hoisting can make an undeclared direct dependency appear healthy
+// in this monorepo while the published tarball fails under strict/isolated
+// resolution. Inspect the actual built import graph and require every external
+// @opengeni/* specifier to be present in a published dependency map.
+const builtImportScanner = new Bun.Transpiler({ loader: "js" });
+for (const pkg of publishable) {
+  const distDir = join(repoRoot, pkg.dir, "dist");
+  if (!existsSync(distDir)) continue;
+  const declaredRuntimePackages = new Set(workspaceDependencyNames(pkg, PUBLISHED_DEP_FIELDS));
+  for (const path of builtContractFiles(distDir).filter((file) => file.endsWith(".js"))) {
+    const text = readFileSync(path, "utf8");
+    const scan = await builtImportScanner.scan(text);
+    for (const imported of scan.imports) {
+      const match = imported.path.match(/^(@opengeni\/[^/]+)(?:\/|$)/u);
+      const importedPackage = match?.[1];
+      if (
+        importedPackage &&
+        importedPackage !== pkg.name &&
+        !declaredRuntimePackages.has(importedPackage)
+      ) {
+        failures.push(
+          `${path.slice(repoRoot.length + 1)} imports undeclared runtime workspace package ${importedPackage}. ` +
+            `${pkg.name} must declare every externalized direct import in dependencies, peerDependencies, or optionalDependencies.`,
+        );
+      }
+    }
+  }
 }
 
 for (const pkgDir of ["packages/sdk", "packages/react"]) {

--- a/scripts/publish-closure-guard.ts
+++ b/scripts/publish-closure-guard.ts
@@ -229,18 +229,37 @@ function builtContractFiles(dir: string): string[] {
   return files;
 }
 
+function shippedSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...shippedSourceFiles(path));
+    else if (/\.(?:js|jsx|ts|tsx)$/u.test(entry.name) && !entry.name.endsWith(".d.ts")) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
 // Workspace hoisting can make an undeclared direct dependency appear healthy
 // in this monorepo while the published tarball fails under strict/isolated
-// resolution. Inspect the actual built import graph and require every external
+// resolution. Inspect both the built import graph and the shipped source graph
+// (the worker gives Temporal its workflow source) and require every external
 // @opengeni/* specifier to be present in a published dependency map.
-const builtImportScanner = new Bun.Transpiler({ loader: "js" });
 for (const pkg of publishable) {
   const distDir = join(repoRoot, pkg.dir, "dist");
-  if (!existsSync(distDir)) continue;
+  const sourceDir = join(repoRoot, pkg.dir, "src");
   const declaredRuntimePackages = new Set(workspaceDependencyNames(pkg, PUBLISHED_DEP_FIELDS));
-  for (const path of builtContractFiles(distDir).filter((file) => file.endsWith(".js"))) {
+  const importSurfaces = [
+    ...(existsSync(distDir)
+      ? builtContractFiles(distDir).filter((file) => file.endsWith(".js"))
+      : []),
+    ...(existsSync(sourceDir) ? shippedSourceFiles(sourceDir) : []),
+  ];
+  for (const path of importSurfaces) {
     const text = readFileSync(path, "utf8");
-    const scan = await builtImportScanner.scan(text);
+    const loader = path.endsWith(".tsx") ? "tsx" : path.endsWith(".ts") ? "ts" : "js";
+    const scan = await new Bun.Transpiler({ loader }).scan(text);
     for (const imported of scan.imports) {
       const match = imported.path.match(/^(@opengeni\/[^/]+)(?:\/|$)/u);
       const importedPackage = match?.[1];

--- a/scripts/publish-closure-guard.ts
+++ b/scripts/publish-closure-guard.ts
@@ -266,7 +266,7 @@ for (const pkg of publishable) {
     const text = readFileSync(path, "utf8");
     const moduleSpecifiers = path.endsWith(".d.ts")
       ? declarationModuleSpecifiers(text, path)
-      : runtimeModuleSpecifiers(
+      : await runtimeModuleSpecifiers(
           text,
           (path.endsWith(".tsx")
             ? "tsx"

--- a/scripts/publish-closure-guard.ts
+++ b/scripts/publish-closure-guard.ts
@@ -12,14 +12,20 @@
  *       the SDK remains zero-runtime-dep, and React only depends on SDK among
  *       @opengeni/* packages.
  *   (d) the BUILT sdk/react dist bundles reference any server/embed package.
- *   (e) a built package imports an @opengeni/* runtime package that its
- *       published manifest does not declare.
+ *   (e) a package's built runtime, shipped source, or emitted declarations
+ *       reference an @opengeni/* package that its published manifest does not
+ *       declare.
  *
  * Wired into the release gate and safe to run locally without publishing.
  */
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import {
+  declarationModuleSpecifiers,
+  runtimeModuleSpecifiers,
+  type RuntimeLoader,
+} from "./publish-closure-imports";
 import {
   PUBLISHED_DEP_FIELDS,
   changesetIgnoreSet,
@@ -234,7 +240,7 @@ function shippedSourceFiles(dir: string): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const path = join(dir, entry.name);
     if (entry.isDirectory()) files.push(...shippedSourceFiles(path));
-    else if (/\.(?:js|jsx|ts|tsx)$/u.test(entry.name) && !entry.name.endsWith(".d.ts")) {
+    else if (/\.(?:js|jsx|ts|tsx)$/u.test(entry.name)) {
       files.push(path);
     }
   }
@@ -243,25 +249,35 @@ function shippedSourceFiles(dir: string): string[] {
 
 // Workspace hoisting can make an undeclared direct dependency appear healthy
 // in this monorepo while the published tarball fails under strict/isolated
-// resolution. Inspect both the built import graph and the shipped source graph
-// (the worker gives Temporal its workflow source) and require every external
-// @opengeni/* specifier to be present in a published dependency map.
+// resolution. Inspect the built runtime and declaration graphs plus the shipped
+// source graph (the worker gives Temporal its workflow source), and require
+// every external @opengeni/* specifier to be present in a published dependency
+// map. Runtime discovery includes ESM, dynamic import, and CommonJS require;
+// declaration discovery includes type-only imports/exports and reference types.
 for (const pkg of publishable) {
   const distDir = join(repoRoot, pkg.dir, "dist");
   const sourceDir = join(repoRoot, pkg.dir, "src");
   const declaredRuntimePackages = new Set(workspaceDependencyNames(pkg, PUBLISHED_DEP_FIELDS));
   const importSurfaces = [
-    ...(existsSync(distDir)
-      ? builtContractFiles(distDir).filter((file) => file.endsWith(".js"))
-      : []),
+    ...(existsSync(distDir) ? builtContractFiles(distDir) : []),
     ...(existsSync(sourceDir) ? shippedSourceFiles(sourceDir) : []),
   ];
   for (const path of importSurfaces) {
     const text = readFileSync(path, "utf8");
-    const loader = path.endsWith(".tsx") ? "tsx" : path.endsWith(".ts") ? "ts" : "js";
-    const scan = await new Bun.Transpiler({ loader }).scan(text);
-    for (const imported of scan.imports) {
-      const match = imported.path.match(/^(@opengeni\/[^/]+)(?:\/|$)/u);
+    const moduleSpecifiers = path.endsWith(".d.ts")
+      ? declarationModuleSpecifiers(text, path)
+      : runtimeModuleSpecifiers(
+          text,
+          (path.endsWith(".tsx")
+            ? "tsx"
+            : path.endsWith(".ts")
+              ? "ts"
+              : path.endsWith(".jsx")
+                ? "jsx"
+                : "js") satisfies RuntimeLoader,
+        );
+    for (const imported of moduleSpecifiers) {
+      const match = imported.match(/^(@opengeni\/[^/]+)(?:\/|$)/u);
       const importedPackage = match?.[1];
       if (
         importedPackage &&

--- a/scripts/publish-closure-imports.test.ts
+++ b/scripts/publish-closure-imports.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { declarationModuleSpecifiers, runtimeModuleSpecifiers } from "./publish-closure-imports";
+
+describe("publish closure import discovery", () => {
+  test("finds static, dynamic, and CommonJS runtime imports", () => {
+    const source = `
+      import "@opengeni/static";
+      const commonjs = require("@opengeni/commonjs");
+      const dynamic = import("@opengeni/dynamic");
+    `;
+
+    expect(runtimeModuleSpecifiers(source, "ts").sort()).toEqual([
+      "@opengeni/commonjs",
+      "@opengeni/dynamic",
+      "@opengeni/static",
+    ]);
+  });
+
+  test("finds every dependency-bearing declaration form", () => {
+    const source = `
+      /// <reference types="@opengeni/reference" />
+      import type { A } from "@opengeni/imported";
+      export type { B } from "@opengeni/exported";
+      import C = require("@opengeni/import-equals");
+      export type D = import("@opengeni/import-type").D;
+    `;
+
+    expect(declarationModuleSpecifiers(source, "index.d.ts").sort()).toEqual([
+      "@opengeni/exported",
+      "@opengeni/import-equals",
+      "@opengeni/import-type",
+      "@opengeni/imported",
+      "@opengeni/reference",
+    ]);
+  });
+});

--- a/scripts/publish-closure-imports.test.ts
+++ b/scripts/publish-closure-imports.test.ts
@@ -2,16 +2,18 @@ import { describe, expect, test } from "bun:test";
 import { declarationModuleSpecifiers, runtimeModuleSpecifiers } from "./publish-closure-imports";
 
 describe("publish closure import discovery", () => {
-  test("finds static, dynamic, and CommonJS runtime imports", () => {
+  test("finds static, dynamic, and CommonJS runtime imports", async () => {
     const source = `
       import "@opengeni/static";
       const commonjs = require("@opengeni/commonjs");
+      const resolved = require.resolve("@opengeni/resolved");
       const dynamic = import("@opengeni/dynamic");
     `;
 
-    expect(runtimeModuleSpecifiers(source, "ts").sort()).toEqual([
+    expect((await runtimeModuleSpecifiers(source, "ts")).sort()).toEqual([
       "@opengeni/commonjs",
       "@opengeni/dynamic",
+      "@opengeni/resolved",
       "@opengeni/static",
     ]);
   });

--- a/scripts/publish-closure-imports.ts
+++ b/scripts/publish-closure-imports.ts
@@ -2,8 +2,14 @@ import ts from "typescript";
 
 export type RuntimeLoader = "js" | "jsx" | "ts" | "tsx";
 
-export function runtimeModuleSpecifiers(source: string, loader: RuntimeLoader): string[] {
-  return new Bun.Transpiler({ loader }).scanImports(source).map((entry) => entry.path);
+export async function runtimeModuleSpecifiers(
+  source: string,
+  loader: RuntimeLoader,
+): Promise<string[]> {
+  const transpiler = new Bun.Transpiler({ loader });
+  const imports = transpiler.scanImports(source);
+  const scan = await transpiler.scan(source);
+  return [...new Set([...scan.imports, ...imports].map((entry) => entry.path))];
 }
 
 export function declarationModuleSpecifiers(source: string, fileName: string): string[] {

--- a/scripts/publish-closure-imports.ts
+++ b/scripts/publish-closure-imports.ts
@@ -1,0 +1,49 @@
+import ts from "typescript";
+
+export type RuntimeLoader = "js" | "jsx" | "ts" | "tsx";
+
+export function runtimeModuleSpecifiers(source: string, loader: RuntimeLoader): string[] {
+  return new Bun.Transpiler({ loader }).scanImports(source).map((entry) => entry.path);
+}
+
+export function declarationModuleSpecifiers(source: string, fileName: string): string[] {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const specifiers = new Set<string>();
+
+  for (const directive of sourceFile.typeReferenceDirectives) {
+    specifiers.add(directive.fileName);
+  }
+
+  function visit(node: ts.Node): void {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      specifiers.add(node.moduleSpecifier.text);
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      node.moduleReference.expression &&
+      ts.isStringLiteralLike(node.moduleReference.expression)
+    ) {
+      specifiers.add(node.moduleReference.expression.text);
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteralLike(node.argument.literal)
+    ) {
+      specifiers.add(node.argument.literal.text);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return [...specifiers];
+}


### PR DESCRIPTION
## Summary

- project tool names and arguments from the real serialized approval shape
- declare every externalized OpenGeni package imported by the published worker bundle
- fail the publish-closure gate when a built package has an undeclared OpenGeni runtime import
- cover the OpenAI Agents tool-approval serialization shape

## Verification

- full local `bun run check` passed before the packaging follow-up
- all 20 TypeScript projects pass after both corrections
- focused approval/session tests pass
- the strengthened publish-closure guard first reproduced both undeclared worker imports, then passed after the manifest fix
- `bun install --frozen-lockfile`, lint, and format pass