### PR TITLE
test: bind ogtool version assertion to package metadata

### DIFF
--- a/packages/ogtool/test/cli.test.ts
+++ b/packages/ogtool/test/cli.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const cli = join(import.meta.dir, "..", "bin", "ogtool.cjs");
+const packageVersion = (
+  (await Bun.file(join(import.meta.dir, "..", "package.json")).json()) as { version: string }
+).version;
 const temporaryRoots: string[] = [];
 
 afterEach(async () => {
@@ -98,7 +101,7 @@ describe("ogtool CLI", () => {
   test("reports its package version without requiring Toolspace", async () => {
     const result = await run(["--version"]);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout.trim()).toBe("0.0.0");
+    expect(result.stdout.trim()).toBe(packageVersion);
     expect(result.stderr).toBe("");
   });
 


### PR DESCRIPTION
## Summary

- read the expected CLI version from `packages/ogtool/package.json`
- keep the version test valid on Changesets release branches

## Verification

- `bun test packages/ogtool/test/cli.test.ts` (8 passed)