### PR TITLE
fix(db): enforce session event lock contracts

### DIFF
--- a/.changeset/session-event-lock-contracts.md
+++ b/.changeset/session-event-lock-contracts.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Enforce explicit session-event lock contracts and preserve sanitized PostgreSQL failure classification without replaying external effects.

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -167,7 +167,8 @@ Generic appends and operation-keyed Agent Message/Steer commands retry PostgreSQ
 Provider inference, tools, live event publication, and workflow wakes remain after
 that boundary and are never replayed. An exhausted or non-retryable database
 failure surfaces as sanitized typed truth with SQLSTATE, stage, one correlation
-ID, and allowlisted catalog identifiers—never raw SQL text or bound parameters.
+ID, an equally sanitized typed cause, and allowlisted catalog identifiers—never
+raw SQL text, a raw driver cause, or bound parameters.
 
 After a reviewed release reaches staging, run the dry-by-default event-ordering invariant canary
 with `bun run canary:session-event-ordering`. Execution requires

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14449,6 +14449,7 @@ export async function acceptSessionHumanInputResponse(
       await scopedDb.transaction(async (tx) => {
         const locks = await lockSessionEventWriteRows(tx as unknown as Database, {
           workspaceId: input.workspaceId,
+          controlLock: "none",
           sessionIds: [input.sessionId],
         });
         const session = locks.sessions[0];
@@ -14521,6 +14522,7 @@ export async function acceptSessionHumanInputResponse(
           ? (
               await lockSessionEventWriteRows(tx as unknown as Database, {
                 workspaceId: input.workspaceId,
+                controlLock: "already_locked",
                 workspaceLock: "already_locked",
                 turnIds: [turnPreview.id],
               })
@@ -20558,6 +20560,7 @@ export async function clearSessionGoal(
       await scopedDb.transaction(async (tx) => {
         const locks = await lockSessionEventWriteRows(tx as unknown as Database, {
           workspaceId,
+          controlLock: "none",
           sessionIds: [sessionId],
         });
         const session = locks.sessions[0];
@@ -21506,6 +21509,7 @@ export async function initializeSessionStartAtomically(
         }
         await lockSessionEventWriteRows(tx as unknown as Database, {
           workspaceId: input.workspaceId,
+          controlLock: "already_locked",
           workspaceLock: "already_locked",
           turnIds: [turn.id],
         });
@@ -21971,6 +21975,7 @@ export async function claimSessionWorkForAttempt(
             .limit(1);
           const activeLocks = await lockSessionEventWriteRows(tx as unknown as Database, {
             workspaceId,
+            controlLock: "already_locked",
             workspaceLock: "already_locked",
             turnIds: [session.activeTurnId],
             attemptIds: activeTurnPreview?.activeAttemptId
@@ -22162,6 +22167,7 @@ export async function claimSessionWorkForAttempt(
         const detachedLocks = detachedLiveAttemptPreview
           ? await lockSessionEventWriteRows(tx as unknown as Database, {
               workspaceId,
+              controlLock: "already_locked",
               workspaceLock: "already_locked",
               turnIds: [detachedLiveAttemptPreview.turnId],
               attemptIds: [detachedLiveAttemptPreview.id],
@@ -22225,6 +22231,7 @@ export async function claimSessionWorkForAttempt(
         const queuedLocks = queuedTurnPreview
           ? await lockSessionEventWriteRows(tx as unknown as Database, {
               workspaceId,
+              controlLock: "already_locked",
               workspaceLock: "already_locked",
               turnIds: [queuedTurnPreview.id],
             })
@@ -23044,6 +23051,7 @@ export async function settleSessionAttemptInterruptions(
       }
       const exact = await lockSessionEventWriteRows(tx as unknown as Database, {
         workspaceId,
+        controlLock: "already_locked",
         workspaceLock: "already_locked",
         turnIds: [attemptPreview.turnId],
         attemptIds: [attemptId],
@@ -26129,6 +26137,7 @@ export async function getOrCreateSessionSystemUpdateOutbox(
   return await retryRlsPersistence(db, context, persistence, async (scopedDb) => {
     const locks = await lockSessionEventWriteRows(scopedDb, {
       workspaceId: input.workspaceId,
+      controlLock: "none",
       sessionIds: [input.sourceSessionId, input.targetSessionId],
     });
     const expectedSessionIds = new Set([input.sourceSessionId, input.targetSessionId]);
@@ -26599,6 +26608,7 @@ export async function appendSessionEvents(
         .filter((id): id is string => typeof id === "string");
       const locks = await lockSessionEventWriteRows(tx as unknown as Database, {
         workspaceId,
+        controlLock: "none",
         sessionIds: [sessionId],
         turnIds,
         attemptIds,
@@ -26672,6 +26682,7 @@ export async function acceptSessionApprovalDecision(
       await scopedDb.transaction(async (tx) => {
         const locks = await lockSessionEventWriteRows(tx as unknown as Database, {
           workspaceId: input.workspaceId,
+          controlLock: "none",
           sessionIds: [input.sessionId],
         });
         const session = locks.sessions[0];
@@ -26727,6 +26738,7 @@ export async function acceptSessionApprovalDecision(
           ? (
               await lockSessionEventWriteRows(tx as unknown as Database, {
                 workspaceId: input.workspaceId,
+                controlLock: "already_locked",
                 workspaceLock: "already_locked",
                 turnIds: [turnPreview.id],
               })
@@ -26993,6 +27005,7 @@ export async function appendSessionEventToSandboxGroup(
       await scopedDb.transaction(async (tx) => {
         await lockSessionEventWriteRows(tx as unknown as Database, {
           workspaceId,
+          controlLock: "none",
         });
         const sessionIds = await tx
           .select({ id: schema.sessions.id })
@@ -27006,6 +27019,7 @@ export async function appendSessionEventToSandboxGroup(
           .orderBy(asc(schema.sessions.id));
         const locks = await lockSessionEventWriteRows(tx as unknown as Database, {
           workspaceId,
+          controlLock: "already_locked",
           workspaceLock: "already_locked",
           sessionIds: sessionIds.map((row) => row.id),
           turnIds: input.turnId ? [input.turnId] : [],
@@ -27085,6 +27099,7 @@ export async function appendSessionEventsAndUpdateSession(
           .filter((id): id is string => typeof id === "string");
         const locks = await lockSessionEventWriteRows(tx as unknown as Database, {
           workspaceId,
+          controlLock: "none",
           sessionIds: [sessionId],
           turnIds,
           attemptIds,
@@ -27208,6 +27223,7 @@ export async function appendSessionEventsWithLockedSessionUpdate(
         }
         await lockSessionEventWriteRows(tx as unknown as Database, {
           workspaceId,
+          controlLock: "already_locked",
           workspaceLock: "already_locked",
           turnIds: built.events
             .map((input) => input.turnId)

--- a/packages/db/src/persistence-errors.ts
+++ b/packages/db/src/persistence-errors.ts
@@ -156,13 +156,26 @@ export function safeDatabaseErrorFacts(error: unknown): SafeDatabaseErrorFacts {
   return facts;
 }
 
+/** Public-safe cause that preserves database classification without driver data. */
+export class SanitizedDatabasePersistenceCause extends Error {
+  readonly name = "SanitizedDatabasePersistenceCause";
+
+  constructor(
+    readonly sqlState: string | null,
+    readonly database: SafeDatabaseErrorFacts,
+  ) {
+    super(sqlState === null ? "Database driver failure" : `PostgreSQL failure ${sqlState}`);
+  }
+}
+
 /**
- * Public-safe replacement for a raw Drizzle/postgres-js failure. It deliberately
- * has no `cause`: driver causes can contain the full SQL statement and bound
- * parameters, which must never enter a session event or operator log payload.
+ * Public-safe replacement for a raw Drizzle/postgres-js failure. Its `cause`
+ * is a newly constructed sanitized projection; the original driver cause can
+ * contain full SQL and bound parameters and is never retained.
  */
 export class SessionEventPersistenceError extends Error {
   readonly name = "SessionEventPersistenceError";
+  readonly cause: SanitizedDatabasePersistenceCause;
 
   constructor(readonly details: PersistenceFailureDetails) {
     const label =
@@ -172,6 +185,7 @@ export class SessionEventPersistenceError extends Error {
           ? "Database serialization failure"
           : "Database failure";
     super(`${label} while persisting ${details.eventTypes.join(", ") || "session events"}`);
+    this.cause = new SanitizedDatabasePersistenceCause(details.sqlState, details.database);
   }
 
   get code(): DatabaseFailureCode {

--- a/packages/db/src/session-control.ts
+++ b/packages/db/src/session-control.ts
@@ -373,9 +373,9 @@ export type SessionEventWriteLockInput = {
   /**
    * Control-aware writes take this lock first. Callers that already hold the
    * workspace control row (for example a Pause mutation under FOR UPDATE) say
-   * `already_locked`; ordinary audit/title appends use `none`.
+   * `already_locked`; ordinary audit/title appends explicitly use `none`.
    */
-  controlLock?: WorkspaceControlLockMode | "already_locked" | "none";
+  controlLock: WorkspaceControlLockMode | "already_locked" | "none";
   /** Used only when a staged caller already established the workspace prefix. */
   workspaceLock?: "key_share" | "already_locked";
   sessionIds?: string[];
@@ -414,7 +414,7 @@ export async function lockSessionEventWriteRows(
   db: Database,
   input: SessionEventWriteLockInput,
 ): Promise<SessionEventWriteLocks> {
-  const controlLock = input.controlLock ?? "none";
+  const controlLock = input.controlLock;
   const control =
     controlLock === "share" || controlLock === "update"
       ? await lockWorkspaceInferenceControl(db, input.workspaceId, controlLock)

--- a/packages/db/test/persistence-errors.test.ts
+++ b/packages/db/test/persistence-errors.test.ts
@@ -4,6 +4,7 @@ import {
   nestedPostgresSqlState,
   runIdempotentPersistenceTransaction,
   safeDatabaseErrorFacts,
+  SanitizedDatabasePersistenceCause,
   SessionEventPersistenceError,
 } from "../src";
 
@@ -96,6 +97,14 @@ describe("session event persistence failure truth", () => {
       correlationId: "stable-correlation",
       database: { table: "session_events" },
     });
+    expect((error as SessionEventPersistenceError).cause).toBeInstanceOf(
+      SanitizedDatabasePersistenceCause,
+    );
+    expect((error as SessionEventPersistenceError).cause).toMatchObject({
+      sqlState: "40P01",
+      database: { table: "session_events" },
+    });
+    expect(nestedPostgresSqlState(error)).toBe("40P01");
     expect(JSON.stringify((error as SessionEventPersistenceError).details)).not.toContain(
       "private-token",
     );
@@ -139,12 +148,16 @@ describe("session event persistence failure truth", () => {
       retryOutcome: "not_retryable",
       database: { table: "session_events" },
     });
-    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect((error as SessionEventPersistenceError).cause).toMatchObject({
+      name: "SanitizedDatabasePersistenceCause",
+      sqlState: null,
+      database: { table: "session_events" },
+    });
     const observable = JSON.stringify({
       message: (error as Error).message,
       stack: (error as Error).stack,
       details: (error as SessionEventPersistenceError).details,
-      cause: (error as Error & { cause?: unknown }).cause,
+      cause: (error as SessionEventPersistenceError).cause,
     });
     expect(observable).not.toContain("private-token");
     expect(observable).not.toContain("insert into");
@@ -227,12 +240,21 @@ describe("session event persistence failure truth", () => {
         constraint: "session_command_receipts_operation_uq",
       },
     });
-    expect((caught as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect((caught as SessionEventPersistenceError).cause).toMatchObject({
+      name: "SanitizedDatabasePersistenceCause",
+      sqlState: "23505",
+      database: {
+        severity: "ERROR",
+        table: "session_command_receipts",
+        constraint: "session_command_receipts_operation_uq",
+      },
+    });
+    expect(nestedPostgresSqlState(caught)).toBe("23505");
     const observable = JSON.stringify({
       message: (caught as Error).message,
       stack: (caught as Error).stack,
       details: (caught as SessionEventPersistenceError).details,
-      cause: (caught as Error & { cause?: unknown }).cause,
+      cause: (caught as SessionEventPersistenceError).cause,
     });
     expect(observable).not.toContain("private-token");
     expect(observable).not.toContain("insert into");

--- a/packages/db/test/session-event-lock-order.test.ts
+++ b/packages/db/test/session-event-lock-order.test.ts
@@ -891,6 +891,55 @@ afterAll(async () => {
 }, 60_000);
 
 describe("event-ordering invariant canonical session-event lock order", () => {
+  test("runs the lock-order races through a non-superuser without RLS bypass", async () => {
+    const appProbe = postgres(shared.appUrl, { max: 1 });
+    try {
+      const [identity] = await appProbe<{ currentUser: string; rowSecurity: string }[]>`
+        select current_user as "currentUser", current_setting('row_security') as "rowSecurity"`;
+      expect(identity).toEqual({ currentUser: "opengeni_app", rowSecurity: "on" });
+
+      const tenantSession = await seedRunningSession();
+      const otherTenant = await freshWorkspace();
+      const crossTenantRows = await appProbe.begin(async (tx) => {
+        await tx`
+          select
+            set_config('opengeni.account_id', ${otherTenant.accountId}, true),
+            set_config('opengeni.workspace_id', ${otherTenant.workspaceId}, true)`;
+        return await tx<{ id: string }[]>`
+          select id from sessions where id = ${tenantSession.sessionId}`;
+      });
+      expect(Array.from(crossTenantRows)).toEqual([]);
+    } finally {
+      await appProbe.end().catch(() => undefined);
+    }
+
+    const [role] = await admin<{ rolsuper: boolean; rolbypassrls: boolean }[]>`
+      select rolsuper, rolbypassrls from pg_roles where rolname = 'opengeni_app'`;
+    expect(role).toEqual({ rolsuper: false, rolbypassrls: false });
+
+    const lockedTables = await admin<
+      { relname: string; relrowsecurity: boolean; relforcerowsecurity: boolean }[]
+    >`
+      select c.relname, c.relrowsecurity, c.relforcerowsecurity
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = 'public'
+        and c.relname in (
+          'workspace_inference_controls', 'sessions',
+          'session_turns', 'session_turn_attempts', 'session_events'
+        )
+      order by c.relname`;
+    expect(Array.from(lockedTables)).toEqual(
+      [
+        "session_events",
+        "session_turn_attempts",
+        "session_turns",
+        "sessions",
+        "workspace_inference_controls",
+      ].map((relname) => ({ relname, relrowsecurity: true, relforcerowsecurity: true })),
+    );
+  });
+
   test("serializes every generic writer with usage and streamed activity in both arrival orders", async () => {
     for (const generic of genericWriters) {
       for (const activityType of ["agent.model.usage", "agent.message.delta"] as const) {

--- a/packages/db/test/session-event-writer-audit.test.ts
+++ b/packages/db/test/session-event-writer-audit.test.ts
@@ -8,7 +8,6 @@ type LockContract = "canonical" | "turn_attempt_fence" | "owned_suffix";
 type ExpectedWriter = {
   inserts: number;
   contract: LockContract;
-  requiresControlShare?: boolean;
   requiresControlRevalidation?: boolean;
 };
 
@@ -18,7 +17,6 @@ const expectedWriters: Record<string, ExpectedWriter> = {
   "packages/db/src/index.ts#armCodexCapacityWait": {
     inserts: 1,
     contract: "canonical",
-    requiresControlShare: true,
     requiresControlRevalidation: true,
   },
   "packages/db/src/index.ts#supersedeCodexCapacityWaitInTransaction": {
@@ -28,7 +26,6 @@ const expectedWriters: Record<string, ExpectedWriter> = {
   "packages/db/src/index.ts#reconcileCodexCapacityWait": {
     inserts: 1,
     contract: "canonical",
-    requiresControlShare: true,
     requiresControlRevalidation: true,
   },
   "packages/db/src/index.ts#applyContextCompaction": {
@@ -152,8 +149,26 @@ const expectedWriters: Record<string, ExpectedWriter> = {
   },
 };
 
+const genericControlWriters = new Set([
+  "packages/db/src/index.ts#acceptSessionApprovalDecision",
+  "packages/db/src/index.ts#acceptSessionHumanInputResponse",
+  "packages/db/src/index.ts#appendSessionEvents",
+  "packages/db/src/index.ts#appendSessionEventsAndUpdateSession",
+  "packages/db/src/index.ts#appendSessionEventToSandboxGroup",
+  "packages/db/src/index.ts#clearSessionGoal",
+]);
+
+const callerOwnedControlWriters = new Set([
+  "packages/db/src/session-queue-commands.ts#supersedeSessionCurrentDirectionInTransaction",
+]);
+
 const expectedOwnedSuffixCallers: Record<string, string[]> = {
   supersedeCodexCapacityWaitInTransaction: ["reconcileCodexCapacityWait"],
+  supersedeSessionCurrentDirectionInTransaction: [
+    "steerAgentSessionInTransaction",
+    "steerQueuedTurnInTransaction",
+    "submitHumanPromptInTransaction",
+  ],
   closePendingSessionToolCallsInTransaction: [
     "armCodexCapacityWait",
     "supersedeSessionCurrentDirectionInTransaction",
@@ -267,16 +282,31 @@ function functionCalls(functionNode: ts.FunctionLikeDeclaration, expectedName: s
   return found;
 }
 
-function functionCallsWithStringProperty(
+function callHasProperty(node: ts.CallExpression, propertyName: string): boolean {
+  return node.arguments.some(
+    (argument) =>
+      ts.isObjectLiteralExpression(argument) &&
+      argument.properties.some(
+        (property) =>
+          ts.isPropertyAssignment(property) &&
+          ((ts.isIdentifier(property.name) && property.name.text === propertyName) ||
+            (ts.isStringLiteral(property.name) && property.name.text === propertyName)),
+      ),
+  );
+}
+
+function callPositionsWithStringProperty(
   functionNode: ts.FunctionLikeDeclaration,
   expectedName: string,
   propertyName: string,
   propertyValue: string,
-): boolean {
-  let found = false;
+): number[] {
+  const positions: number[] = [];
   const visit = (node: ts.Node): void => {
-    if (ts.isCallExpression(node) && callName(node) === expectedName) {
-      found = node.arguments.some(
+    if (
+      ts.isCallExpression(node) &&
+      callName(node) === expectedName &&
+      node.arguments.some(
         (argument) =>
           ts.isObjectLiteralExpression(argument) &&
           argument.properties.some(
@@ -287,12 +317,67 @@ function functionCallsWithStringProperty(
               ts.isStringLiteral(property.initializer) &&
               property.initializer.text === propertyValue,
           ),
-      );
+      )
+    ) {
+      positions.push(node.getStart());
     }
-    if (!found) ts.forEachChild(node, visit);
+    ts.forEachChild(node, visit);
   };
   ts.forEachChild(functionNode, visit);
-  return found;
+  return positions.sort((left, right) => left - right);
+}
+
+function callPositionsWithStringArgument(
+  functionNode: ts.FunctionLikeDeclaration,
+  expectedName: string,
+  argumentIndex: number,
+  argumentValue: string,
+): number[] {
+  const positions: number[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && callName(node) === expectedName) {
+      const argument = node.arguments[argumentIndex];
+      if (
+        argument !== undefined &&
+        ts.isStringLiteral(argument) &&
+        argument.text === argumentValue
+      ) {
+        positions.push(node.getStart());
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(functionNode, visit);
+  return positions.sort((left, right) => left - right);
+}
+
+function controlAwarePrefixPositions(functionNode: ts.FunctionLikeDeclaration): number[] {
+  return [
+    ...callPositionsWithStringProperty(
+      functionNode,
+      "lockSessionEventWriteRows",
+      "controlLock",
+      "share",
+    ),
+    ...callPositionsWithStringProperty(
+      functionNode,
+      "lockSessionEventWriteRows",
+      "controlLock",
+      "update",
+    ),
+    ...callPositionsWithStringArgument(functionNode, "lockWorkspaceInferenceControl", 2, "share"),
+    ...callPositionsWithStringArgument(functionNode, "lockWorkspaceInferenceControl", 2, "update"),
+    ...callPositions(functionNode, "lockChildLifecycleOutboxWriteRowsTx"),
+  ].sort((left, right) => left - right);
+}
+
+function genericPrefixPositions(functionNode: ts.FunctionLikeDeclaration): number[] {
+  return callPositionsWithStringProperty(
+    functionNode,
+    "lockSessionEventWriteRows",
+    "controlLock",
+    "none",
+  );
 }
 
 function callPositions(functionNode: ts.FunctionLikeDeclaration, expectedName: string): number[] {
@@ -326,6 +411,7 @@ describe("session_events writer inventory", () => {
       { count: number; sourceFile: ts.SourceFile; functionNode: ts.FunctionLikeDeclaration }
     >();
     const rawSqlWriters: string[] = [];
+    const implicitControlLockCalls: string[] = [];
     const functionDefinitions = new Map<
       string,
       Array<{ sourceFile: ts.SourceFile; functionNode: ts.FunctionLikeDeclaration }>
@@ -381,6 +467,11 @@ describe("session_events writer inventory", () => {
             });
           }
           const called = callName(node);
+          if (called === "lockSessionEventWriteRows" && !callHasProperty(node, "controlLock")) {
+            implicitControlLockCalls.push(
+              `${file}:${sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1}`,
+            );
+          }
           if (called && ownedSuffixCallers.has(called) && enclosing) {
             ownedSuffixCallers.get(called)!.add(enclosing.name);
           }
@@ -402,6 +493,7 @@ describe("session_events writer inventory", () => {
     }
 
     expect(rawSqlWriters).toEqual([]);
+    expect(implicitControlLockCalls).toEqual([]);
     expect(Object.fromEntries([...writers].map(([key, value]) => [key, value.count]))).toEqual(
       Object.fromEntries(
         Object.entries(expectedWriters).map(([key, value]) => [key, value.inserts]),
@@ -417,16 +509,19 @@ describe("session_events writer inventory", () => {
         ].sort((left, right) => left - right);
         expect(canonicalLocks.length).toBeGreaterThan(0);
         const firstLock = canonicalLocks[0];
-        expect(firstLock).toBeLessThan(insertPositions(writer.functionNode)[0]!);
-        if (expected.requiresControlShare) {
-          expect(
-            functionCallsWithStringProperty(
-              writer.functionNode,
-              "lockSessionEventWriteRows",
-              "controlLock",
-              "share",
-            ),
-          ).toBe(true);
+        const firstInsert = insertPositions(writer.functionNode)[0]!;
+        expect(firstLock).toBeLessThan(firstInsert);
+        if (genericControlWriters.has(key)) {
+          const prefixes = genericPrefixPositions(writer.functionNode);
+          expect(prefixes.length).toBeGreaterThan(0);
+          expect(prefixes[0]).toBeLessThan(firstInsert);
+        } else if (callerOwnedControlWriters.has(key)) {
+          const writerName = key.slice(key.lastIndexOf("#") + 1);
+          expect(Object.hasOwn(expectedOwnedSuffixCallers, writerName)).toBe(true);
+        } else {
+          const prefixes = controlAwarePrefixPositions(writer.functionNode);
+          expect(prefixes.length).toBeGreaterThan(0);
+          expect(prefixes[0]).toBeLessThan(firstInsert);
         }
         if (expected.requiresControlRevalidation) {
           expect(functionCalls(writer.functionNode, "evaluateSessionControl")).toBe(true);
@@ -461,6 +556,11 @@ describe("session_events writer inventory", () => {
           ...callPositions(callerNode, "lockChildLifecycleOutboxWriteRowsTx"),
         ].sort((left, right) => left - right);
         expect(canonicalLocks.length).toBeGreaterThan(0);
+        expect(
+          controlAwarePrefixPositions(callerNode).length > 0 ||
+            genericPrefixPositions(callerNode).length > 0 ||
+            Object.hasOwn(expectedOwnedSuffixCallers, caller),
+        ).toBe(true);
         const firstLock = canonicalLocks[0];
         const delegatedCalls = [...ownedSuffixCallers.keys()].flatMap((ownedWriter) =>
           callPositions(callerNode, ownedWriter),
@@ -491,6 +591,9 @@ describe("session_events writer inventory", () => {
         expect(functionCalls(writer.functionNode, "retryRlsPersistence")).toBe(true);
         const firstLock = callPositions(writer.functionNode, "lockSessionEventWriteRows")[0];
         expect(firstLock).toBeLessThan(callPositions(writer.functionNode, "insert")[0]!);
+        const genericPrefixes = genericPrefixPositions(writer.functionNode);
+        expect(genericPrefixes.length).toBeGreaterThan(0);
+        expect(genericPrefixes[0]).toBeLessThan(callPositions(writer.functionNode, "insert")[0]!);
       }
     }
     for (const caller of expectedFailedChildOutboxCallers) {
@@ -503,6 +606,19 @@ describe("session_events writer inventory", () => {
       const enqueue = callPositions(callerNode, "enqueueFailedChildOutboxForTurnTx")[0];
       expect(firstLock).toBeLessThan(enqueue!);
     }
+
+    const turnAttemptFence = functionDefinitions.get("lockTurnAttemptWriteFenceTx") ?? [];
+    expect(turnAttemptFence).toHaveLength(1);
+    expect(controlAwarePrefixPositions(turnAttemptFence[0]!.functionNode).length).toBeGreaterThan(
+      0,
+    );
+
+    const childLifecyclePrefix =
+      functionDefinitions.get("lockChildLifecycleOutboxWriteRowsTx") ?? [];
+    expect(childLifecyclePrefix).toHaveLength(1);
+    expect(
+      controlAwarePrefixPositions(childLifecyclePrefix[0]!.functionNode).length,
+    ).toBeGreaterThan(0);
   });
 
   test("generic append and Agent commands keep external effects outside bounded retry", () => {


### PR DESCRIPTION
## Summary

- make every session-event writer state its workspace-control lock contract explicitly, preserving the canonical control → workspace → UUID-ordered session/turn/attempt lock order
- strengthen the AST writer inventory so generic writers may skip only the control row while staged/control-aware writers must prove their prefix and caller-owned suffix contracts
- retain retry classification through a newly constructed sanitized database cause without retaining raw driver errors, SQL text, or bound parameters

## Testing

- [x] `bun run typecheck` (22 projects)
- [x] `bun test` (3,839 pass, 3 gated live-service skips, 0 fail; 17,722 assertions across 308 files)
- [x] nine-file DB/control suite (126 pass, 0 fail; 1,279 assertions)
- [x] real PostgreSQL 16 lock-order suite (21 pass, 0 fail; 508 assertions) as `opengeni_app` with `rolsuper=false`, `rolbypassrls=false`, `row_security=on`, and FORCE RLS on tenant event/control tables
- [x] `bunx changeset status` (patch release plan for `@opengeni/db` and dependents)
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] docs-reference guard and public-repository hygiene guard
- [x] `git diff --check`

## Notes

- Linear: OPE-63
- Current-main successor to the historical semantic evidence in #507; it does not rebase that stale branch.
- Candidate base: `b901fd59219053124824acbb4c2db9db065a190b`
- Candidate head: `00e1cdc41ff4e30ff513dfaa2cf13262afc07a74`
- Candidate tree: `7241759422c4c0849e2775e31b29d1a02fd266a6`
- The second commit is only the required `@opengeni/db` Changesets release note; code and tests are unchanged from `bcf1c380425f2abbbe1ebb6cf8dffae756a25028`.
- Provider inference, tools, publication, workflow wakes, and other external effects remain outside the bounded persistence retry closure and are never replayed.
- This PR does not modify migrations or the active #526 correction paths called out for coordination.