### PR TITLE
fix(release): separate Version PR automation identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,131 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+    inputs:
+      automation_pr_number:
+        description: Exact github-actions[bot] Version PR number.
+        required: true
+        type: string
+      automation_head_sha:
+        description: Exact Version PR head SHA to admit and test.
+        required: true
+        type: string
+      automation_base_sha:
+        description: Exact current main SHA from which the Version PR was generated.
+        required: true
+        type: string
+      source_release_run_id:
+        description: Push-triggered Release run that created or updated the Version PR.
+        required: true
+        type: string
+      source_release_run_attempt:
+        description: Exact attempt of the source Release run.
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.event_name == 'workflow_dispatch' && format('ci-automation-{0}-{1}', inputs.automation_pr_number, inputs.automation_head_sha) || format('ci-{0}', github.run_id) }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
+  automation-admission:
+    name: Admit automation Version PR
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read # authenticate the exact push-triggered Release run
+      checks: write # publish idempotent checks on the candidate head SHA
+      contents: read # inspect immutable commits and direct Git trees
+      pull-requests: read # authenticate the bot PR and provider projection
+    env:
+      AUTOMATION_PR_NUMBER: ${{ inputs.automation_pr_number }}
+      AUTOMATION_HEAD_SHA: ${{ inputs.automation_head_sha }}
+      AUTOMATION_BASE_SHA: ${{ inputs.automation_base_sha }}
+      AUTOMATION_SOURCE_RUN_ID: ${{ inputs.source_release_run_id }}
+      AUTOMATION_SOURCE_RUN_ATTEMPT: ${{ inputs.source_release_run_attempt }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      # workflow_dispatch is sent to ref=main. Pin the checkout again so helper
+      # and dependency bytes are the exact trusted base, never candidate bytes.
+      - name: Check out trusted workflow source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Begin exact-head automation checks
+        run: node scripts/check-release-pr-automation.mjs begin-version-checks
+
+      - name: Admit trusted dispatch and exact source tree
+        id: admission
+        run: node scripts/check-release-pr-automation.mjs admit-version-ci
+
+      - name: Set up Bun
+        if: ${{ steps.admission.outcome == 'success' }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install trusted-base dependencies
+        if: ${{ steps.admission.outcome == 'success' }}
+        run: bun install --frozen-lockfile
+
+      # The Changesets action force-resets its branch from the source run SHA.
+      # Reproduce the version command using only admitted-base code and compare
+      # complete Git trees before any candidate checkout or script execution.
+      - name: Reproduce deterministic Version PR tree
+        id: version_tree
+        if: ${{ steps.admission.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ "$GITHUB_SHA" = "$AUTOMATION_BASE_SHA" ]
+          git fetch --no-tags origin "$AUTOMATION_HEAD_SHA"
+          [ "$(git rev-parse HEAD)" = "$AUTOMATION_BASE_SHA" ]
+
+          expected="$RUNNER_TEMP/changeset-version-expected"
+          git worktree add --detach "$expected" "$AUTOMATION_BASE_SHA"
+          trap 'git worktree remove --force "$expected"' EXIT
+          (
+            cd "$expected"
+            bun "$GITHUB_WORKSPACE/node_modules/@changesets/cli/bin.js" version
+            git add -A
+            git diff --cached --check
+          )
+
+          expected_tree="$(git -C "$expected" write-tree)"
+          actual_tree="$(git rev-parse "$AUTOMATION_HEAD_SHA^{tree}")"
+          if [ "$actual_tree" != "$expected_tree" ]; then
+            echo "::error::Version PR tree does not exactly reproduce 'changeset version' from admitted main"
+            git diff --stat "$expected_tree" "$actual_tree"
+            exit 1
+          fi
+
+      - name: Complete exact-head source-admission check
+        if: ${{ always() }}
+        env:
+          AUTOMATION_CHECK_KIND: source-admission
+          AUTOMATION_CHECK_CONCLUSION: ${{ steps.admission.outcome == 'success' && steps.version_tree.outcome == 'success' && 'success' || 'failure' }}
+        run: node scripts/check-release-pr-automation.mjs complete-version-check
+
   test:
     name: Typecheck and unit tests
+    needs: automation-admission
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -34,6 +149,9 @@ jobs:
 
       - name: Validate changeset release plan
         shell: bash
+        env:
+          AUTOMATION_BASE_SHA: ${{ inputs.automation_base_sha }}
+          AUTOMATION_HEAD_SHA: ${{ inputs.automation_head_sha }}
         run: |
           set -euo pipefail
           plan="$RUNNER_TEMP/changeset-status.json"
@@ -45,7 +163,15 @@ jobs:
           # gone. Prove that special branch by reproducing `changeset version`
           # from the exact base tree and comparing complete Git trees instead
           # of skipping release-plan validation.
+          is_version_pr=false
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ "${GITHUB_HEAD_REF:-}" = "changeset-release/main" ]; then
+            is_version_pr=true
+          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            [ "$(git rev-parse refs/remotes/origin/main)" = "$AUTOMATION_BASE_SHA" ]
+            [ "$(git rev-parse HEAD)" = "$AUTOMATION_HEAD_SHA" ]
+            is_version_pr=true
+          fi
+          if [ "$is_version_pr" = "true" ]; then
             expected="$RUNNER_TEMP/changeset-version-expected"
             git worktree add --detach "$expected" refs/remotes/origin/main
             trap 'git worktree remove --force "$expected"' EXIT
@@ -201,10 +327,15 @@ jobs:
 
   deployment:
     name: Deployment artifacts
+    needs: automation-admission
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.sha }}
+          persist-credentials: false
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -299,6 +430,8 @@ jobs:
 
   images:
     name: Workload image builds
+    needs: automation-admission
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -306,6 +439,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.sha }}
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -355,3 +491,32 @@ jobs:
           platforms: linux/amd64
           push: false
           tags: opengeni-sandbox:ci
+
+  automation-report:
+    name: Report exact-head automation CI
+    needs: [automation-admission, test, deployment, images]
+    if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: read
+    env:
+      AUTOMATION_PR_NUMBER: ${{ inputs.automation_pr_number }}
+      AUTOMATION_HEAD_SHA: ${{ inputs.automation_head_sha }}
+      AUTOMATION_BASE_SHA: ${{ inputs.automation_base_sha }}
+      AUTOMATION_SOURCE_RUN_ID: ${{ inputs.source_release_run_id }}
+      AUTOMATION_SOURCE_RUN_ATTEMPT: ${{ inputs.source_release_run_attempt }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out trusted workflow source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Complete exact-head automation CI check
+        env:
+          AUTOMATION_CHECK_KIND: automation-ci
+          AUTOMATION_CHECK_CONCLUSION: ${{ needs.automation-admission.result == 'success' && needs.test.result == 'success' && needs.deployment.result == 'success' && needs.images.result == 'success' && 'success' || 'failure' }}
+        run: node scripts/check-release-pr-automation.mjs complete-version-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ name: Release
 #      (Settings -> Secrets and variables -> Actions -> Variables).
 #   2. Claim the @opengeni npm org and set the NPM_TOKEN secret to an
 #      automation/granular token with publish rights (provenance via OIDC).
-#   3. Let the Version PR be opened: EITHER enable Settings -> Actions -> General
-#      -> "Allow GitHub Actions to create and approve pull requests", OR set a
-#      RELEASE_PAT secret (a PAT with repo + pull-requests scope) — this workflow
-#      prefers RELEASE_PAT over the default GITHUB_TOKEN for exactly that reason.
+#   3. Enable Settings -> Actions -> General -> "Allow GitHub Actions to create
+#      and approve pull requests". The scoped per-run GITHUB_TOKEN deliberately
+#      authors Version PRs as github-actions[bot], leaving exact-head approval to
+#      a distinct trusted human reviewer.
 #   - GHCR image publishing needs no extra secret (built-in GITHUB_TOKEN) and
 #     runs only when a release actually publishes.
 
@@ -81,6 +81,7 @@ jobs:
     permissions:
       contents: write # changesets commits package versions to its release branch
       pull-requests: write # changesets opens/updates the Version PR
+      actions: write # dispatch trusted main CI for the token-authored Version PR
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -136,6 +137,7 @@ jobs:
           fi
 
       - name: Create or update Version PR
+        id: changesets
         if: ${{ steps.release_plan.outputs.has_releases == 'true' }}
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
@@ -143,10 +145,19 @@ jobs:
           commit: "chore: version packages"
           title: "chore: version packages"
         env:
-          # Prefer a PAT (repo + pull-requests scope) so the Version PR can be
-          # opened even if the org keeps "Actions may create PRs" disabled;
-          # falls back to the default token when the org setting is enabled.
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          # Keep the automation author distinct from the trusted human reviewer.
+          GITHUB_TOKEN: ${{ github.token }}
+
+      # GITHUB_TOKEN-created pull requests intentionally do not recursively
+      # trigger pull_request workflows. Dispatch the trusted CI definition from
+      # main instead; its admission job binds candidate execution and checks to
+      # the exact bot-authored head only after base-owned validation succeeds.
+      - name: Dispatch exact-head Version PR CI
+        if: ${{ steps.release_plan.outputs.has_releases == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          VERSION_PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+        run: node scripts/check-release-pr-automation.mjs dispatch-version-ci
 
   publish:
     name: Publish verified release
@@ -155,6 +166,7 @@ jobs:
     permissions:
       id-token: write # npm provenance (OIDC)
       contents: write # changesets creates and pushes immutable package tags
+      pull-requests: read # verify exact-head native approval before publication
     outputs:
       releaseReady: ${{ steps.registry.outputs.release_ready }}
       verifiedPackages: ${{ steps.registry.outputs.verified_packages }}
@@ -225,6 +237,12 @@ jobs:
             exit 1
           fi
           echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Verify exact-head approval provenance
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.preflight.outputs.source_sha }}
+        run: node scripts/check-release-pr-automation.mjs verify-approved-merge
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -351,7 +369,7 @@ jobs:
           version: bun run changeset:version
           publish: bun run release:publish
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -1,0 +1,744 @@
+import { appendFileSync } from "node:fs";
+import { verifySourceAdmission } from "./check-source-admission.mjs";
+
+export const RELEASE_AUTOMATION_CONTRACT = Object.freeze({
+  apiUrl: "https://api.github.com",
+  serverUrl: "https://github.com",
+  repository: "Cloudgeni-ai/opengeni",
+  owner: "Cloudgeni-ai",
+  defaultBranch: "main",
+  versionBranch: "changeset-release/main",
+  releaseWorkflowPath: ".github/workflows/release.yml",
+  ciWorkflowPath: ".github/workflows/ci.yml",
+  ciWorkflowFile: "ci.yml",
+  sourceAdmissionWorkflowPath: ".github/workflows/source-admission.yml",
+  versionAuthor: Object.freeze({
+    login: "github-actions[bot]",
+    id: 41898282,
+    type: "Bot",
+  }),
+  releaseApprover: Object.freeze({
+    login: "jorgensandhaug",
+    id: 55702375,
+    type: "User",
+  }),
+  checks: Object.freeze({
+    sourceAdmission: "Current-base source admission",
+    automationCi: "Automation PR CI",
+  }),
+});
+
+const shaPattern = /^[0-9a-f]{40}$/;
+const positiveIntegerPattern = /^[1-9][0-9]*$/;
+const decisiveReviewStates = new Set(["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]);
+const maximumPages = 30;
+const recordsPerPage = 100;
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function record(value, label) {
+  invariant(
+    value !== null && typeof value === "object" && !Array.isArray(value),
+    `${label} is invalid`,
+  );
+  return value;
+}
+
+function assertString(value, label) {
+  invariant(typeof value === "string" && value.length > 0, `${label} is missing`);
+  return value;
+}
+
+function assertSha(value, label) {
+  invariant(
+    typeof value === "string" && shaPattern.test(value),
+    `${label} is not a lowercase Git SHA`,
+  );
+  return value;
+}
+
+function assertPositiveInteger(value, label) {
+  const text = String(value ?? "");
+  invariant(positiveIntegerPattern.test(text), `${label} is not a positive integer`);
+  const parsed = Number(text);
+  invariant(Number.isSafeInteger(parsed), `${label} is outside the safe integer range`);
+  return parsed;
+}
+
+function assertTimestamp(value, label) {
+  const timestamp = Date.parse(assertString(value, label));
+  invariant(Number.isFinite(timestamp), `${label} is invalid`);
+  return timestamp;
+}
+
+function requiredEnvironment(env, names) {
+  for (const name of names) assertString(env[name], name);
+}
+
+function githubClient(fetchImpl, token) {
+  invariant(typeof fetchImpl === "function", "fetch implementation is missing");
+  const request = async (method, path, body) => {
+    invariant(typeof path === "string" && path.startsWith("/"), "GitHub API path is invalid");
+    const response = await fetchImpl(`${RELEASE_AUTOMATION_CONTRACT.apiUrl}${path}`, {
+      method,
+      redirect: "error",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "opengeni-release-pr-automation",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    invariant(
+      response?.ok === true,
+      `GitHub API ${method} ${path} failed with HTTP ${response?.status ?? "unknown"}`,
+    );
+    if (response.status === 204) return null;
+    return response.json();
+  };
+  return {
+    get: (path) => request("GET", path),
+    patch: (path, body) => request("PATCH", path, body),
+    post: (path, body) => request("POST", path, body),
+  };
+}
+
+function assertRepository(value) {
+  invariant(value?.full_name === RELEASE_AUTOMATION_CONTRACT.repository, "repository changed");
+  invariant(
+    value?.owner?.login === RELEASE_AUTOMATION_CONTRACT.owner &&
+      value.owner.type === "Organization",
+    "repository owner changed",
+  );
+  invariant(
+    value?.default_branch === RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+    "default branch changed",
+  );
+  invariant(
+    value?.archived === false && value?.disabled === false && value?.private === false,
+    "repository is not an active public repository",
+  );
+}
+
+function assertMainRef(value, expectedSha, label = "default branch") {
+  invariant(
+    value?.ref === `refs/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`,
+    `${label} ref changed`,
+  );
+  invariant(value?.object?.type === "commit", `${label} is not a direct commit ref`);
+  const actualSha = assertSha(value.object.sha, `${label} SHA`);
+  invariant(actualSha === expectedSha, `${label} differs from the admitted base SHA`);
+}
+
+function assertIdentity(actual, expected, label) {
+  invariant(actual?.login === expected.login, `${label} login changed`);
+  invariant(actual?.id === expected.id, `${label} numeric identity changed`);
+  invariant(actual?.type === expected.type, `${label} account type changed`);
+}
+
+function assertVersionPull(pull, expected) {
+  const expectedNumber = expected.prNumber ?? expected.number;
+  invariant(pull?.number === expectedNumber, "Version PR number changed");
+  invariant(pull?.state === "open" && pull?.merged === false, "Version PR is not open");
+  invariant(pull?.draft === false, "Version PR is a draft");
+  assertIdentity(pull?.user, RELEASE_AUTOMATION_CONTRACT.versionAuthor, "Version PR author");
+  invariant(
+    pull?.base?.ref === RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+    "Version PR base branch changed",
+  );
+  invariant(
+    pull?.base?.repo?.full_name === RELEASE_AUTOMATION_CONTRACT.repository,
+    "Version PR base repository changed",
+  );
+  invariant(pull?.base?.sha === expected.baseSha, "Version PR base SHA changed");
+  invariant(
+    pull?.head?.ref === RELEASE_AUTOMATION_CONTRACT.versionBranch,
+    "Version PR head branch changed",
+  );
+  invariant(
+    pull?.head?.repo?.full_name === RELEASE_AUTOMATION_CONTRACT.repository,
+    "Version PR is not from the base repository",
+  );
+  const headSha = assertSha(pull?.head?.sha, "Version PR head SHA");
+  invariant(headSha !== expected.baseSha, "Version PR head does not differ from its base");
+  if (expected.headSha !== undefined)
+    invariant(headSha === expected.headSha, "Version PR head SHA changed");
+  invariant(
+    Number.isSafeInteger(pull?.commits) && pull.commits > 0,
+    "Version PR commit count is invalid",
+  );
+  invariant(
+    Number.isSafeInteger(pull?.changed_files) && pull.changed_files > 0,
+    "Version PR changed-file count is invalid",
+  );
+  return headSha;
+}
+
+function baseGithubContext(env, workflowPath, eventName) {
+  requiredEnvironment(env, [
+    "GITHUB_API_URL",
+    "GITHUB_EVENT_NAME",
+    "GITHUB_REF",
+    "GITHUB_REPOSITORY",
+    "GITHUB_SERVER_URL",
+    "GITHUB_SHA",
+    "GITHUB_TOKEN",
+    "GITHUB_WORKFLOW_REF",
+    "GITHUB_WORKFLOW_SHA",
+  ]);
+  invariant(
+    env.GITHUB_API_URL === RELEASE_AUTOMATION_CONTRACT.apiUrl,
+    "unexpected GitHub API origin",
+  );
+  invariant(
+    env.GITHUB_SERVER_URL === RELEASE_AUTOMATION_CONTRACT.serverUrl,
+    "unexpected GitHub server origin",
+  );
+  invariant(
+    env.GITHUB_REPOSITORY === RELEASE_AUTOMATION_CONTRACT.repository,
+    "unexpected repository",
+  );
+  invariant(env.GITHUB_EVENT_NAME === eventName, "unexpected workflow event");
+  invariant(
+    env.GITHUB_REF === `refs/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`,
+    "workflow is not running on the default branch ref",
+  );
+  invariant(
+    env.GITHUB_WORKFLOW_REF ===
+      `${RELEASE_AUTOMATION_CONTRACT.repository}/${workflowPath}@refs/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`,
+    "workflow source is not the trusted default branch",
+  );
+  const sha = assertSha(env.GITHUB_SHA, "GITHUB_SHA");
+  invariant(
+    assertSha(env.GITHUB_WORKFLOW_SHA, "GITHUB_WORKFLOW_SHA") === sha,
+    "workflow source SHA differs from its event SHA",
+  );
+  return { sha, token: env.GITHUB_TOKEN };
+}
+
+function releasePushContext(env) {
+  const context = baseGithubContext(env, RELEASE_AUTOMATION_CONTRACT.releaseWorkflowPath, "push");
+  requiredEnvironment(env, ["GITHUB_RUN_ATTEMPT", "GITHUB_RUN_ID"]);
+  return {
+    ...context,
+    runAttempt: assertPositiveInteger(env.GITHUB_RUN_ATTEMPT, "GITHUB_RUN_ATTEMPT"),
+    runId: assertPositiveInteger(env.GITHUB_RUN_ID, "GITHUB_RUN_ID"),
+  };
+}
+
+function automationInputs(env, suppliedInputs) {
+  const values = suppliedInputs ?? {
+    prNumber: env.AUTOMATION_PR_NUMBER,
+    headSha: env.AUTOMATION_HEAD_SHA,
+    baseSha: env.AUTOMATION_BASE_SHA,
+    sourceRunId: env.AUTOMATION_SOURCE_RUN_ID,
+    sourceRunAttempt: env.AUTOMATION_SOURCE_RUN_ATTEMPT,
+  };
+  const inputs = {
+    prNumber: assertPositiveInteger(values.prNumber, "automation PR number"),
+    headSha: assertSha(values.headSha, "automation head SHA"),
+    baseSha: assertSha(values.baseSha, "automation base SHA"),
+    sourceRunId: assertPositiveInteger(values.sourceRunId, "source Release run ID"),
+    sourceRunAttempt: assertPositiveInteger(values.sourceRunAttempt, "source Release run attempt"),
+  };
+  invariant(inputs.headSha !== inputs.baseSha, "automation head SHA equals its base SHA");
+  return inputs;
+}
+
+function automationCiContext(env, suppliedInputs) {
+  const context = baseGithubContext(
+    env,
+    RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath,
+    "workflow_dispatch",
+  );
+  requiredEnvironment(env, ["GITHUB_RUN_ID"]);
+  const inputs = automationInputs(env, suppliedInputs);
+  invariant(context.sha === inputs.baseSha, "CI workflow SHA differs from the admitted base SHA");
+  return {
+    ...context,
+    ...inputs,
+    ciRunId: assertPositiveInteger(env.GITHUB_RUN_ID, "CI run ID"),
+  };
+}
+
+function repositoryPath(path) {
+  return `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}${path}`;
+}
+
+async function terminalVersionIdentity(api, context) {
+  const [main, pull] = await Promise.all([
+    api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
+    api.get(repositoryPath(`/pulls/${context.prNumber}`)),
+  ]);
+  assertMainRef(main, context.baseSha, "terminal default branch");
+  assertVersionPull(pull, context);
+  return pull;
+}
+
+export async function validateVersionPrDispatch(options = {}) {
+  const env = options.env ?? process.env;
+  const logger = options.logger ?? console;
+  const context = releasePushContext(env);
+  const prNumber = assertPositiveInteger(
+    options.prNumber ?? env.VERSION_PR_NUMBER,
+    "Version PR number",
+  );
+  const api = githubClient(options.fetchImpl ?? globalThis.fetch, context.token);
+  const [repository, main, pull] = await Promise.all([
+    api.get(repositoryPath("")),
+    api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
+    api.get(repositoryPath(`/pulls/${prNumber}`)),
+  ]);
+  assertRepository(repository);
+  assertMainRef(main, context.sha);
+  const headSha = assertVersionPull(pull, { number: prNumber, baseSha: context.sha });
+
+  await terminalVersionIdentity(api, {
+    prNumber,
+    baseSha: context.sha,
+    headSha,
+  });
+  await api.post(
+    repositoryPath(`/actions/workflows/${RELEASE_AUTOMATION_CONTRACT.ciWorkflowFile}/dispatches`),
+    {
+      ref: RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+      inputs: {
+        automation_pr_number: String(prNumber),
+        automation_head_sha: headSha,
+        automation_base_sha: context.sha,
+        source_release_run_id: String(context.runId),
+        source_release_run_attempt: String(context.runAttempt),
+      },
+    },
+  );
+  logger.log(
+    `Dispatched trusted CI for Version PR #${prNumber} at ${headSha} on current main ${context.sha}.`,
+  );
+  return { prNumber, headSha, baseSha: context.sha };
+}
+
+function assertSourceRun(run, context) {
+  invariant(run?.id === context.sourceRunId, "source Release run ID changed");
+  invariant(run?.run_attempt === context.sourceRunAttempt, "source Release run attempt changed");
+  invariant(run?.event === "push", "source Release run was not triggered by a push");
+  invariant(
+    (run?.status === "in_progress" && run.conclusion === null) ||
+      (run?.status === "completed" && run.conclusion === "success"),
+    "source Release run is neither in progress nor successfully completed",
+  );
+  invariant(
+    run?.path === RELEASE_AUTOMATION_CONTRACT.releaseWorkflowPath,
+    "source run did not execute the Release workflow",
+  );
+  invariant(
+    run?.head_branch === RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+    "source Release run branch changed",
+  );
+  invariant(run?.head_sha === context.baseSha, "source Release run SHA changed");
+  invariant(
+    run?.repository?.full_name === RELEASE_AUTOMATION_CONTRACT.repository &&
+      run?.head_repository?.full_name === RELEASE_AUTOMATION_CONTRACT.repository,
+    "source Release run repository changed",
+  );
+}
+
+function syntheticSourceAdmissionContext(context, pull) {
+  return {
+    env: {
+      GITHUB_API_URL: RELEASE_AUTOMATION_CONTRACT.apiUrl,
+      GITHUB_BASE_REF: RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+      GITHUB_EVENT_NAME: "pull_request_target",
+      GITHUB_HEAD_REF: RELEASE_AUTOMATION_CONTRACT.versionBranch,
+      GITHUB_REF: `refs/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`,
+      GITHUB_REPOSITORY: RELEASE_AUTOMATION_CONTRACT.repository,
+      GITHUB_SERVER_URL: RELEASE_AUTOMATION_CONTRACT.serverUrl,
+      GITHUB_SHA: context.baseSha,
+      GITHUB_TOKEN: context.token,
+      GITHUB_WORKFLOW_REF:
+        `${RELEASE_AUTOMATION_CONTRACT.repository}/` +
+        `${RELEASE_AUTOMATION_CONTRACT.sourceAdmissionWorkflowPath}@refs/heads/` +
+        RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+      GITHUB_WORKFLOW_SHA: context.baseSha,
+      OPENGENI_SOURCE_ADMISSION_ACTION: "verify_current_base_head",
+    },
+    event: {
+      action: "synchronize",
+      number: context.prNumber,
+      repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+      pull_request: {
+        number: context.prNumber,
+        state: "open",
+        base: pull.base,
+        head: pull.head,
+      },
+    },
+  };
+}
+
+export async function validateVersionPrCiAdmission(options = {}) {
+  const env = options.env ?? process.env;
+  const logger = options.logger ?? console;
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const context = automationCiContext(env, options.inputs);
+  const api = githubClient(fetchImpl, context.token);
+  const [repository, main, pull, sourceRun] = await Promise.all([
+    api.get(repositoryPath("")),
+    api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
+    api.get(repositoryPath(`/pulls/${context.prNumber}`)),
+    api.get(repositoryPath(`/actions/runs/${context.sourceRunId}`)),
+  ]);
+  assertRepository(repository);
+  assertMainRef(main, context.baseSha);
+  assertVersionPull(pull, context);
+  assertSourceRun(sourceRun, context);
+
+  const sourceContext = syntheticSourceAdmissionContext(context, pull);
+  const admission = await verifySourceAdmission({
+    ...sourceContext,
+    fetchImpl,
+    logger,
+  });
+  invariant(admission.baseSha === context.baseSha, "source admission returned another base SHA");
+  invariant(admission.headSha === context.headSha, "source admission returned another head SHA");
+  await terminalVersionIdentity(api, context);
+  logger.log(`Automation dispatch admitted Version PR #${context.prNumber} at ${context.headSha}.`);
+  return { ...context, admission };
+}
+
+function checkIdentity(kind, context) {
+  invariant(kind === "source-admission" || kind === "automation-ci", "check kind is invalid");
+  const name =
+    kind === "source-admission"
+      ? RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission
+      : RELEASE_AUTOMATION_CONTRACT.checks.automationCi;
+  return {
+    name,
+    externalId: `opengeni:release-automation:${kind}:v1:pr:${context.prNumber}:head:${context.headSha}`,
+  };
+}
+
+async function findCheckRun(api, context, identity) {
+  const matches = [];
+  for (let page = 1; page <= maximumPages; page += 1) {
+    const response = record(
+      await api.get(
+        repositoryPath(
+          `/commits/${context.headSha}/check-runs?check_name=${encodeURIComponent(identity.name)}` +
+            `&filter=all&per_page=${recordsPerPage}&page=${page}`,
+        ),
+      ),
+      "check-run listing",
+    );
+    invariant(Array.isArray(response.check_runs), "check-run records are missing");
+    for (const check of response.check_runs) {
+      if (check?.external_id !== identity.externalId) continue;
+      invariant(check?.head_sha === context.headSha, "existing check run is bound to another head");
+      invariant(check?.app?.slug === "github-actions", "existing check run has another owner app");
+      invariant(
+        Number.isSafeInteger(check?.id) && check.id > 0,
+        "existing check-run ID is invalid",
+      );
+      matches.push(check);
+    }
+    if (response.check_runs.length < recordsPerPage) break;
+    invariant(page < maximumPages, "check-run listing exceeded its page limit");
+  }
+  invariant(matches.length <= 1, "multiple check runs share the idempotency marker");
+  return matches[0];
+}
+
+async function upsertCheckRun(api, context, kind, state, now) {
+  const identity = checkIdentity(kind, context);
+  const existing = await findCheckRun(api, context, identity);
+  const detailsUrl =
+    `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+    `/actions/runs/${context.ciRunId}`;
+  const completed = state.status === "completed";
+  const body = {
+    name: identity.name,
+    head_sha: context.headSha,
+    status: state.status,
+    external_id: identity.externalId,
+    details_url: detailsUrl,
+    ...(completed
+      ? {
+          conclusion: state.conclusion,
+          completed_at: now().toISOString(),
+        }
+      : { started_at: now().toISOString() }),
+    output: {
+      title: state.title,
+      summary: state.summary,
+    },
+  };
+  if (existing)
+    return api.patch(repositoryPath(`/check-runs/${existing.id}`), {
+      ...body,
+      head_sha: undefined,
+    });
+  return api.post(repositoryPath("/check-runs"), body);
+}
+
+export async function beginVersionPrChecks(options = {}) {
+  const env = options.env ?? process.env;
+  const context = automationCiContext(env, options.inputs);
+  const api = githubClient(options.fetchImpl ?? globalThis.fetch, context.token);
+  await terminalVersionIdentity(api, context);
+  const now = options.now ?? (() => new Date());
+  await upsertCheckRun(
+    api,
+    context,
+    "source-admission",
+    {
+      status: "in_progress",
+      title: "Validating trusted automation source",
+      summary: `Validating Version PR #${context.prNumber} at exact head ${context.headSha}.`,
+    },
+    now,
+  );
+  await upsertCheckRun(
+    api,
+    context,
+    "automation-ci",
+    {
+      status: "in_progress",
+      title: "Running exact-head automation CI",
+      summary: `CI is running for Version PR #${context.prNumber} at exact head ${context.headSha}.`,
+    },
+    now,
+  );
+  return context;
+}
+
+export async function completeVersionPrChecks(options = {}) {
+  const env = options.env ?? process.env;
+  const context = automationCiContext(env, options.inputs);
+  const kind = options.kind ?? env.AUTOMATION_CHECK_KIND;
+  const requestedConclusion = options.conclusion ?? env.AUTOMATION_CHECK_CONCLUSION;
+  invariant(
+    requestedConclusion === "success" || requestedConclusion === "failure",
+    "check conclusion is invalid",
+  );
+  const api = githubClient(options.fetchImpl ?? globalThis.fetch, context.token);
+  let conclusion = requestedConclusion;
+  let terminalError;
+  if (conclusion === "success") {
+    try {
+      await terminalVersionIdentity(api, context);
+    } catch (error) {
+      conclusion = "failure";
+      terminalError = error;
+    }
+  }
+  const label = kind === "source-admission" ? "Source admission" : "Automation CI";
+  await upsertCheckRun(
+    api,
+    context,
+    kind,
+    {
+      status: "completed",
+      conclusion,
+      title: `${label} ${conclusion === "success" ? "passed" : "failed"}`,
+      summary:
+        `${label} ${conclusion === "success" ? "passed" : "failed"} for Version PR ` +
+        `#${context.prNumber} at exact head ${context.headSha}.`,
+    },
+    options.now ?? (() => new Date()),
+  );
+  if (terminalError) throw terminalError;
+  return { ...context, kind, conclusion };
+}
+
+async function paginatedArray(api, path, label) {
+  const rows = [];
+  for (let page = 1; page <= maximumPages; page += 1) {
+    const separator = path.includes("?") ? "&" : "?";
+    const value = await api.get(`${path}${separator}per_page=${recordsPerPage}&page=${page}`);
+    invariant(Array.isArray(value), `${label} is invalid`);
+    rows.push(...value);
+    if (value.length < recordsPerPage) return rows;
+  }
+  throw new Error(`${label} exceeded ${maximumPages * recordsPerPage} records`);
+}
+
+function releaseApprovalContext(env, suppliedSourceSha) {
+  requiredEnvironment(env, [
+    "GITHUB_API_URL",
+    "GITHUB_EVENT_NAME",
+    "GITHUB_REPOSITORY",
+    "GITHUB_SERVER_URL",
+    "GITHUB_SHA",
+    "GITHUB_TOKEN",
+  ]);
+  invariant(
+    env.GITHUB_API_URL === RELEASE_AUTOMATION_CONTRACT.apiUrl,
+    "unexpected GitHub API origin",
+  );
+  invariant(
+    env.GITHUB_SERVER_URL === RELEASE_AUTOMATION_CONTRACT.serverUrl,
+    "unexpected GitHub server origin",
+  );
+  invariant(
+    env.GITHUB_REPOSITORY === RELEASE_AUTOMATION_CONTRACT.repository,
+    "unexpected repository",
+  );
+  invariant(env.GITHUB_EVENT_NAME === "workflow_dispatch", "unexpected workflow event");
+  const sourceSha = assertSha(suppliedSourceSha ?? env.SOURCE_SHA, "release source SHA");
+  invariant(
+    assertSha(env.GITHUB_SHA, "GITHUB_SHA") === sourceSha,
+    "dispatch ref differs from source SHA",
+  );
+  return { sourceSha, token: env.GITHUB_TOKEN };
+}
+
+export async function verifyApprovedMerge(options = {}) {
+  const env = options.env ?? process.env;
+  const logger = options.logger ?? console;
+  const context = releaseApprovalContext(env, options.sourceSha);
+  const api = githubClient(options.fetchImpl ?? globalThis.fetch, context.token);
+  const commit = await api.get(repositoryPath(`/git/commits/${context.sourceSha}`));
+  invariant(commit?.sha === context.sourceSha, "release source commit changed");
+  invariant(Array.isArray(commit?.parents), "release source parents are missing");
+  invariant(commit.parents.length === 2, "release source is not a two-parent PR merge");
+  const baseSha = assertSha(commit.parents[0]?.sha, "release merge first parent");
+  const headSha = assertSha(commit.parents[1]?.sha, "release merge second parent");
+  invariant(baseSha !== headSha, "release merge parents are identical");
+
+  const pulls = await paginatedArray(
+    api,
+    repositoryPath(`/commits/${context.sourceSha}/pulls`),
+    "associated pull requests",
+  );
+  invariant(pulls.length === 1, "release source is not associated with exactly one pull request");
+  const pull = record(pulls[0], "associated pull request");
+  invariant(pull.state === "closed", "associated pull request is not closed");
+  invariant(pull.merge_commit_sha === context.sourceSha, "pull-request merge SHA changed");
+  invariant(
+    pull.base?.ref === RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+    "pull-request base changed",
+  );
+  invariant(
+    pull.base?.repo?.full_name === RELEASE_AUTOMATION_CONTRACT.repository,
+    "pull-request base repository changed",
+  );
+  invariant(pull.base?.sha === baseSha, "pull-request base is not merge parent one");
+  invariant(pull.head?.sha === headSha, "pull-request head is not merge parent two");
+  const pullNumber = assertPositiveInteger(pull.number, "associated pull-request number");
+  const author = record(pull.user, "pull-request author");
+  assertString(author.login, "pull-request author login");
+  const authorId = assertPositiveInteger(author.id, "pull-request author ID");
+  invariant(author.type === "User" || author.type === "Bot", "pull-request author type is invalid");
+  invariant(
+    authorId !== RELEASE_AUTOMATION_CONTRACT.releaseApprover.id,
+    "trusted reviewer authored the pull request",
+  );
+  const mergedAt = assertTimestamp(pull.merged_at, "pull-request merge timestamp");
+
+  const reviews = await paginatedArray(
+    api,
+    repositoryPath(`/pulls/${pullNumber}/reviews`),
+    "pull-request reviews",
+  );
+  const decisions = reviews
+    .filter(
+      (review) =>
+        review?.user?.login === RELEASE_AUTOMATION_CONTRACT.releaseApprover.login &&
+        review.user.id === RELEASE_AUTOMATION_CONTRACT.releaseApprover.id &&
+        review.user.type === RELEASE_AUTOMATION_CONTRACT.releaseApprover.type &&
+        review.commit_id === headSha &&
+        decisiveReviewStates.has(review.state),
+    )
+    .map((review) => ({
+      id: assertPositiveInteger(review.id, "trusted review ID"),
+      review,
+      submittedAt: assertTimestamp(review.submitted_at, "trusted review timestamp"),
+    }))
+    .sort((left, right) => left.submittedAt - right.submittedAt || left.id - right.id);
+  invariant(decisions.length > 0, "trusted reviewer did not review the exact PR head");
+  const decision = decisions.at(-1);
+  invariant(
+    decision.review.state === "APPROVED",
+    "trusted review does not currently approve the exact head",
+  );
+  invariant(decision.submittedAt < mergedAt, "trusted approval was not submitted before merge");
+  assertIdentity(
+    decision.review.user,
+    RELEASE_AUTOMATION_CONTRACT.releaseApprover,
+    "trusted reviewer",
+  );
+  logger.log(`Verified PR #${pullNumber} exact-head approval before merge ${context.sourceSha}.`);
+  return {
+    sourceSha: context.sourceSha,
+    baseSha,
+    headSha,
+    pullNumber,
+    reviewId: decision.id,
+  };
+}
+
+function writeOutputs(values, env) {
+  const path = env.GITHUB_OUTPUT;
+  if (!path) return;
+  for (const [name, value] of Object.entries(values)) appendFileSync(path, `${name}=${value}\n`);
+}
+
+async function runCommand(env = process.env) {
+  const command = process.argv[2];
+  if (command === "dispatch-version-ci") {
+    const result = await validateVersionPrDispatch({ env });
+    writeOutputs(
+      {
+        automation_pr_number: result.prNumber,
+        automation_head_sha: result.headSha,
+        automation_base_sha: result.baseSha,
+      },
+      env,
+    );
+    return;
+  }
+  if (command === "begin-version-checks") {
+    await beginVersionPrChecks({ env });
+    return;
+  }
+  if (command === "admit-version-ci") {
+    const result = await validateVersionPrCiAdmission({ env });
+    writeOutputs(
+      {
+        automation_pr_number: result.prNumber,
+        automation_head_sha: result.headSha,
+        automation_base_sha: result.baseSha,
+        automation_head_tree: result.admission.headTreeSha,
+      },
+      env,
+    );
+    return;
+  }
+  if (command === "complete-version-check") {
+    await completeVersionPrChecks({ env });
+    return;
+  }
+  if (command === "verify-approved-merge") {
+    const result = await verifyApprovedMerge({ env });
+    writeOutputs(
+      {
+        approved_pr_number: result.pullNumber,
+        approved_pr_head_sha: result.headSha,
+        approved_review_id: result.reviewId,
+      },
+      env,
+    );
+    return;
+  }
+  throw new Error(`unknown release automation command: ${command ?? "(missing)"}`);
+}
+
+if (import.meta.main) {
+  runCommand().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -1,0 +1,538 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  RELEASE_AUTOMATION_CONTRACT,
+  beginVersionPrChecks,
+  validateVersionPrCiAdmission,
+  validateVersionPrDispatch,
+  verifyApprovedMerge,
+} from "./check-release-pr-automation.mjs";
+
+const root = join(import.meta.dir, "..");
+const releaseWorkflowPath = join(root, RELEASE_AUTOMATION_CONTRACT.releaseWorkflowPath);
+const ciWorkflowPath = join(root, RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath);
+const baseSha = "b".repeat(40);
+const headSha = "c".repeat(40);
+const mergeSha = "d".repeat(40);
+const baseTreeSha = "e".repeat(40);
+const headTreeSha = "f".repeat(40);
+const pullNumber = 88;
+const runId = 123456;
+const runAttempt = 2;
+
+type RequestRecord = {
+  method: string;
+  path: string;
+  query: URLSearchParams;
+  body?: Record<string, any>;
+};
+
+function repository() {
+  return {
+    full_name: RELEASE_AUTOMATION_CONTRACT.repository,
+    owner: { login: RELEASE_AUTOMATION_CONTRACT.owner, type: "Organization" },
+    default_branch: RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+    archived: false,
+    disabled: false,
+    private: false,
+  };
+}
+
+function mainRef(sha = baseSha) {
+  return { ref: "refs/heads/main", object: { type: "commit", sha } };
+}
+
+function versionPull(
+  overrides: {
+    author?: Record<string, unknown>;
+    base?: string;
+    head?: string;
+    headRepository?: string;
+  } = {},
+) {
+  return {
+    number: pullNumber,
+    state: "open",
+    merged: false,
+    draft: false,
+    user: overrides.author ?? RELEASE_AUTOMATION_CONTRACT.versionAuthor,
+    base: {
+      ref: "main",
+      sha: overrides.base ?? baseSha,
+      repo: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+    },
+    head: {
+      ref: "changeset-release/main",
+      sha: overrides.head ?? headSha,
+      repo: {
+        full_name: overrides.headRepository ?? RELEASE_AUTOMATION_CONTRACT.repository,
+      },
+    },
+    commits: 1,
+    changed_files: 1,
+  };
+}
+
+function releasePushEnv(overrides: Record<string, string> = {}) {
+  return {
+    GITHUB_API_URL: RELEASE_AUTOMATION_CONTRACT.apiUrl,
+    GITHUB_EVENT_NAME: "push",
+    GITHUB_REF: "refs/heads/main",
+    GITHUB_REPOSITORY: RELEASE_AUTOMATION_CONTRACT.repository,
+    GITHUB_RUN_ATTEMPT: String(runAttempt),
+    GITHUB_RUN_ID: String(runId),
+    GITHUB_SERVER_URL: RELEASE_AUTOMATION_CONTRACT.serverUrl,
+    GITHUB_SHA: baseSha,
+    GITHUB_TOKEN: "fixture-token",
+    GITHUB_WORKFLOW_REF:
+      `${RELEASE_AUTOMATION_CONTRACT.repository}/` +
+      `${RELEASE_AUTOMATION_CONTRACT.releaseWorkflowPath}@refs/heads/main`,
+    GITHUB_WORKFLOW_SHA: baseSha,
+    VERSION_PR_NUMBER: String(pullNumber),
+    ...overrides,
+  };
+}
+
+function automationCiEnv(overrides: Record<string, string> = {}) {
+  return {
+    GITHUB_API_URL: RELEASE_AUTOMATION_CONTRACT.apiUrl,
+    GITHUB_EVENT_NAME: "workflow_dispatch",
+    GITHUB_REF: "refs/heads/main",
+    GITHUB_REPOSITORY: RELEASE_AUTOMATION_CONTRACT.repository,
+    GITHUB_RUN_ID: "987654",
+    GITHUB_SERVER_URL: RELEASE_AUTOMATION_CONTRACT.serverUrl,
+    GITHUB_SHA: baseSha,
+    GITHUB_TOKEN: "fixture-token",
+    GITHUB_WORKFLOW_REF:
+      `${RELEASE_AUTOMATION_CONTRACT.repository}/` +
+      `${RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath}@refs/heads/main`,
+    GITHUB_WORKFLOW_SHA: baseSha,
+    AUTOMATION_PR_NUMBER: String(pullNumber),
+    AUTOMATION_HEAD_SHA: headSha,
+    AUTOMATION_BASE_SHA: baseSha,
+    AUTOMATION_SOURCE_RUN_ID: String(runId),
+    AUTOMATION_SOURCE_RUN_ATTEMPT: String(runAttempt),
+    ...overrides,
+  };
+}
+
+function response(value: unknown, status = 200) {
+  if (status === 204) return new Response(null, { status });
+  return Response.json(value, { status });
+}
+
+function dispatchFixture(
+  options: {
+    author?: Record<string, unknown>;
+    headRepository?: string;
+    mainSha?: string;
+  } = {},
+) {
+  const requests: RequestRecord[] = [];
+  async function fetchImpl(input: string | URL | Request, init?: RequestInit) {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    requests.push({ method, path: url.pathname, query: url.searchParams, body });
+    const prefix = `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}`;
+    if (method === "GET" && url.pathname === prefix) return response(repository());
+    if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/main`)
+      return response(mainRef(options.mainSha));
+    if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}`)
+      return response(
+        versionPull({ author: options.author, headRepository: options.headRepository }),
+      );
+    if (method === "POST" && url.pathname === `${prefix}/actions/workflows/ci.yml/dispatches`)
+      return response(null, 204);
+    return response({ message: `unexpected ${method} ${url.pathname}` }, 404);
+  }
+  return { fetchImpl, requests };
+}
+
+describe("Version PR dispatch identity", () => {
+  test("dispatches trusted main CI for an exact github-actions[bot] Version PR", async () => {
+    const fixture = dispatchFixture();
+    const result = await validateVersionPrDispatch({
+      env: releasePushEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+    });
+    expect(result).toEqual({ prNumber: pullNumber, headSha, baseSha });
+    const dispatch = fixture.requests.find((request) => request.method === "POST");
+    expect(dispatch?.body).toEqual({
+      ref: "main",
+      inputs: {
+        automation_pr_number: String(pullNumber),
+        automation_head_sha: headSha,
+        automation_base_sha: baseSha,
+        source_release_run_id: String(runId),
+        source_release_run_attempt: String(runAttempt),
+      },
+    });
+  });
+
+  test("rejects a human-authored Version PR without dispatching", async () => {
+    const fixture = dispatchFixture({
+      author: { login: "jorgensandhaug", id: 55702375, type: "User" },
+    });
+    await expect(
+      validateVersionPrDispatch({ env: releasePushEnv(), fetchImpl: fixture.fetchImpl }),
+    ).rejects.toThrow("Version PR author login changed");
+    expect(fixture.requests.some((request) => request.method === "POST")).toBe(false);
+  });
+
+  test("rejects fork identity and stale main before dispatch", async () => {
+    const fork = dispatchFixture({ headRepository: "attacker/opengeni" });
+    await expect(
+      validateVersionPrDispatch({ env: releasePushEnv(), fetchImpl: fork.fetchImpl }),
+    ).rejects.toThrow("Version PR is not from the base repository");
+    const stale = dispatchFixture({ mainSha: "9".repeat(40) });
+    await expect(
+      validateVersionPrDispatch({ env: releasePushEnv(), fetchImpl: stale.fetchImpl }),
+    ).rejects.toThrow("default branch differs from the admitted base SHA");
+  });
+});
+
+function admissionFixture(
+  options: {
+    sourceConclusion?: string | null;
+    sourceEvent?: string;
+    sourceStatus?: string;
+    terminalMainSha?: string;
+  } = {},
+) {
+  const requests: RequestRecord[] = [];
+  let mainReads = 0;
+  const prefix = `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}`;
+  async function fetchImpl(input: string | URL | Request, init?: RequestInit) {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    requests.push({ method, path: url.pathname, query: url.searchParams });
+    if (method !== "GET") return response({ message: "read-only fixture" }, 405);
+    if (url.pathname === prefix) return response(repository());
+    if (url.pathname === `${prefix}/git/ref/heads/main`) {
+      mainReads += 1;
+      return response(mainRef(mainReads > 2 ? (options.terminalMainSha ?? baseSha) : baseSha));
+    }
+    if (url.pathname === `${prefix}/pulls/${pullNumber}`) return response(versionPull());
+    if (url.pathname === `${prefix}/actions/runs/${runId}`)
+      return response({
+        id: runId,
+        run_attempt: runAttempt,
+        event: options.sourceEvent ?? "push",
+        status: options.sourceStatus ?? "completed",
+        conclusion: options.sourceConclusion === undefined ? "success" : options.sourceConclusion,
+        path: RELEASE_AUTOMATION_CONTRACT.releaseWorkflowPath,
+        head_branch: "main",
+        head_sha: baseSha,
+        repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+        head_repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+      });
+    if (url.pathname === `${prefix}/git/commits/${baseSha}`)
+      return response({
+        sha: baseSha,
+        tree: { sha: baseTreeSha },
+        parents: [{ sha: "a".repeat(40) }],
+      });
+    if (url.pathname === `${prefix}/git/commits/${headSha}`)
+      return response({
+        sha: headSha,
+        tree: { sha: headTreeSha },
+        parents: [{ sha: baseSha }],
+      });
+    if (url.pathname === `${prefix}/compare/${baseSha}...${headSha}`)
+      return response({
+        status: "ahead",
+        base_commit: { sha: baseSha },
+        merge_base_commit: { sha: baseSha },
+        commits: [{ sha: headSha }],
+        behind_by: 0,
+        ahead_by: 1,
+      });
+    if (url.pathname === `${prefix}/pulls/${pullNumber}/files`)
+      return response([{ filename: "package.json", status: "modified" }]);
+    if (url.pathname === `${prefix}/git/trees/${baseTreeSha}`)
+      return response({
+        sha: baseTreeSha,
+        truncated: false,
+        tree: [{ path: "package.json", mode: "100644", type: "blob", sha: "1".repeat(40) }],
+      });
+    if (url.pathname === `${prefix}/git/trees/${headTreeSha}`)
+      return response({
+        sha: headTreeSha,
+        truncated: false,
+        tree: [{ path: "package.json", mode: "100644", type: "blob", sha: "2".repeat(40) }],
+      });
+    return response({ message: `unexpected GET ${url.pathname}` }, 404);
+  }
+  return { fetchImpl, requests };
+}
+
+describe("automation CI admission", () => {
+  test("reuses exact current-base source admission for the trusted source run", async () => {
+    const fixture = admissionFixture();
+    const result = await validateVersionPrCiAdmission({
+      env: automationCiEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+    });
+    expect(result).toMatchObject({ prNumber: pullNumber, baseSha, headSha });
+    expect(result.admission).toMatchObject({ baseSha, headSha, baseTreeSha, headTreeSha });
+    expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  test("rejects a source run that was not an exact push-triggered Release run", async () => {
+    const fixture = admissionFixture({ sourceEvent: "workflow_dispatch" });
+    await expect(
+      validateVersionPrCiAdmission({
+        env: automationCiEnv(),
+        fetchImpl: fixture.fetchImpl,
+        logger: { log() {} },
+      }),
+    ).rejects.toThrow("source Release run was not triggered by a push");
+  });
+
+  test("rejects a failed source Release run", async () => {
+    const fixture = admissionFixture({ sourceConclusion: "failure" });
+    await expect(
+      validateVersionPrCiAdmission({
+        env: automationCiEnv(),
+        fetchImpl: fixture.fetchImpl,
+        logger: { log() {} },
+      }),
+    ).rejects.toThrow("neither in progress nor successfully completed");
+  });
+
+  test("rejects dispatch context drift before reading provider state", async () => {
+    const fixture = admissionFixture();
+    await expect(
+      validateVersionPrCiAdmission({
+        env: automationCiEnv({ GITHUB_WORKFLOW_SHA: "9".repeat(40) }),
+        fetchImpl: fixture.fetchImpl,
+      }),
+    ).rejects.toThrow("workflow source SHA differs from its event SHA");
+    expect(fixture.requests).toHaveLength(0);
+  });
+});
+
+function checksFixture() {
+  const requests: RequestRecord[] = [];
+  const checks: Array<Record<string, any>> = [];
+  let nextId = 700;
+  const prefix = `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}`;
+  async function fetchImpl(input: string | URL | Request, init?: RequestInit) {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    requests.push({ method, path: url.pathname, query: url.searchParams, body });
+    if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/main`)
+      return response(mainRef());
+    if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}`)
+      return response(versionPull());
+    if (method === "GET" && url.pathname === `${prefix}/commits/${headSha}/check-runs`)
+      return response({
+        total_count: checks.length,
+        check_runs: checks.filter((check) => check.name === url.searchParams.get("check_name")),
+      });
+    if (method === "POST" && url.pathname === `${prefix}/check-runs`) {
+      const check = { ...body, id: nextId++, app: { slug: "github-actions" } };
+      checks.push(check);
+      return response(check, 201);
+    }
+    const checkMatch = url.pathname.match(new RegExp(`^${prefix}/check-runs/(\\d+)$`));
+    if (method === "PATCH" && checkMatch) {
+      const check = checks.find((candidate) => candidate.id === Number(checkMatch[1]));
+      if (!check) return response({ message: "missing check" }, 404);
+      Object.assign(check, body);
+      return response(check);
+    }
+    return response({ message: `unexpected ${method} ${url.pathname}` }, 404);
+  }
+  return { checks, fetchImpl, requests };
+}
+
+test("exact-head check markers update idempotently instead of duplicating", async () => {
+  const fixture = checksFixture();
+  const options = {
+    env: automationCiEnv(),
+    fetchImpl: fixture.fetchImpl,
+    now: () => new Date("2026-07-23T12:00:00Z"),
+  };
+  await beginVersionPrChecks(options);
+  await beginVersionPrChecks(options);
+  expect(fixture.checks).toHaveLength(2);
+  expect(new Set(fixture.checks.map((check) => check.external_id)).size).toBe(2);
+  expect(
+    fixture.checks.every(
+      (check) => check.head_sha === headSha && check.external_id.includes(`head:${headSha}`),
+    ),
+  ).toBe(true);
+  expect(fixture.requests.filter((request) => request.method === "POST")).toHaveLength(2);
+  expect(fixture.requests.filter((request) => request.method === "PATCH")).toHaveLength(2);
+});
+
+function approvalEnv(overrides: Record<string, string> = {}) {
+  return {
+    GITHUB_API_URL: RELEASE_AUTOMATION_CONTRACT.apiUrl,
+    GITHUB_EVENT_NAME: "workflow_dispatch",
+    GITHUB_REPOSITORY: RELEASE_AUTOMATION_CONTRACT.repository,
+    GITHUB_SERVER_URL: RELEASE_AUTOMATION_CONTRACT.serverUrl,
+    GITHUB_SHA: mergeSha,
+    GITHUB_TOKEN: "fixture-token",
+    SOURCE_SHA: mergeSha,
+    ...overrides,
+  };
+}
+
+function approvalFixture(
+  options: {
+    authorId?: number;
+    reviewCommit?: string;
+    reviewState?: string;
+    reviewTime?: string;
+  } = {},
+) {
+  const requests: RequestRecord[] = [];
+  const prefix = `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}`;
+  async function fetchImpl(input: string | URL | Request, init?: RequestInit) {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    requests.push({ method, path: url.pathname, query: url.searchParams });
+    if (method === "GET" && url.pathname === `${prefix}/git/commits/${mergeSha}`)
+      return response({ sha: mergeSha, parents: [{ sha: baseSha }, { sha: headSha }] });
+    if (method === "GET" && url.pathname === `${prefix}/commits/${mergeSha}/pulls`)
+      return response([
+        {
+          number: pullNumber,
+          state: "closed",
+          merge_commit_sha: mergeSha,
+          merged_at: "2026-07-23T12:00:00Z",
+          user: { login: "release-bot", id: options.authorId ?? 41898282, type: "Bot" },
+          base: {
+            ref: "main",
+            sha: baseSha,
+            repo: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+          },
+          head: { sha: headSha },
+        },
+      ]);
+    if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}/reviews`)
+      return response([
+        {
+          id: 9001,
+          state: options.reviewState ?? "APPROVED",
+          commit_id: options.reviewCommit ?? headSha,
+          submitted_at: options.reviewTime ?? "2026-07-23T11:59:00Z",
+          user: RELEASE_AUTOMATION_CONTRACT.releaseApprover,
+        },
+      ]);
+    return response({ message: `unexpected ${method} ${url.pathname}` }, 404);
+  }
+  return { fetchImpl, requests };
+}
+
+describe("release approval provenance", () => {
+  test("accepts a distinct trusted user's native exact-head approval before merge", async () => {
+    const fixture = approvalFixture();
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: fixture.fetchImpl,
+        logger: { log() {} },
+      }),
+    ).resolves.toEqual({ sourceSha: mergeSha, baseSha, headSha, pullNumber, reviewId: 9001 });
+    expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  test("rejects stale-head and post-merge approvals", async () => {
+    const stale = approvalFixture({ reviewCommit: "9".repeat(40) });
+    await expect(
+      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: stale.fetchImpl }),
+    ).rejects.toThrow("did not review the exact PR head");
+    const late = approvalFixture({ reviewTime: "2026-07-23T12:01:00Z" });
+    await expect(
+      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: late.fetchImpl }),
+    ).rejects.toThrow("was not submitted before merge");
+  });
+
+  test("rejects self-approval and a non-approval decision", async () => {
+    const self = approvalFixture({ authorId: RELEASE_AUTOMATION_CONTRACT.releaseApprover.id });
+    await expect(
+      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: self.fetchImpl }),
+    ).rejects.toThrow("trusted reviewer authored the pull request");
+    const requested = approvalFixture({ reviewState: "CHANGES_REQUESTED" });
+    await expect(
+      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: requested.fetchImpl }),
+    ).rejects.toThrow("does not currently approve the exact head");
+  });
+});
+
+describe("workflow contracts", () => {
+  const releaseText = readFileSync(releaseWorkflowPath, "utf8");
+  const ciText = readFileSync(ciWorkflowPath, "utf8");
+  const release = Bun.YAML.parse(releaseText) as any;
+  const ci = Bun.YAML.parse(ciText) as any;
+
+  test("uses only the scoped token for Changesets and grants narrow dispatch rights", () => {
+    expect(releaseText).not.toContain("RELEASE_PAT");
+    const versionChangesets = release.jobs.version.steps.find(
+      (step: any) => step.uses === "changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d",
+    );
+    const publishChangesets = release.jobs.publish.steps.find(
+      (step: any) => step.id === "changesets",
+    );
+    expect(versionChangesets.env.GITHUB_TOKEN).toBe("${{ github.token }}");
+    expect(publishChangesets.env.GITHUB_TOKEN).toBe("${{ github.token }}");
+    expect(release.jobs.version.permissions).toEqual({
+      contents: "write",
+      "pull-requests": "write",
+      actions: "write",
+    });
+    expect(release.jobs.publish.permissions["pull-requests"]).toBe("read");
+  });
+
+  test("dispatches trusted main CI and preserves ordinary CI events", () => {
+    const dispatch = release.jobs.version.steps.find(
+      (step: any) => step.name === "Dispatch exact-head Version PR CI",
+    );
+    expect(dispatch.run).toContain("dispatch-version-ci");
+    expect(ci.on.push.branches).toEqual(["main"]);
+    expect(ci.on.pull_request).not.toBeUndefined();
+    expect(ci.on.workflow_dispatch.inputs).toEqual(
+      expect.objectContaining({
+        automation_pr_number: expect.objectContaining({ required: true }),
+        automation_head_sha: expect.objectContaining({ required: true }),
+        automation_base_sha: expect.objectContaining({ required: true }),
+        source_release_run_id: expect.objectContaining({ required: true }),
+        source_release_run_attempt: expect.objectContaining({ required: true }),
+      }),
+    );
+  });
+
+  test("keeps admission least-privilege and candidate execution exact-head-bound", () => {
+    expect(ci.permissions).toEqual({ contents: "read" });
+    expect(ci.jobs["automation-admission"].permissions).toEqual({
+      actions: "read",
+      checks: "write",
+      contents: "read",
+      "pull-requests": "read",
+    });
+    expect(ciText).not.toContain("pull-requests: write");
+    expect(ciText).not.toMatch(/pulls\/.+\/reviews/);
+    for (const jobName of ["test", "deployment", "images"])
+      expect(
+        ci.jobs[jobName].steps.find((step: any) => step.uses === "actions/checkout@v6").with.ref,
+      ).toContain("inputs.automation_head_sha");
+    expect(ci.jobs["automation-admission"].steps[0].with.ref).toBe("${{ github.sha }}");
+  });
+
+  test("binds explicit source-admission and aggregate reports to the exact head", () => {
+    expect(ciText).toContain("begin-version-checks");
+    expect(ciText).toContain("admit-version-ci");
+    expect(ciText).toContain("complete-version-check");
+    expect(ciText).toContain("AUTOMATION_CHECK_KIND: source-admission");
+    expect(ciText).toContain("AUTOMATION_CHECK_KIND: automation-ci");
+    expect(releaseText).toContain("verify-approved-merge");
+  });
+});


### PR DESCRIPTION
## Summary

- author Changesets Version PRs with the scoped per-run `github.token` as `github-actions[bot]`, never the trusted reviewer PAT
- dispatch the trusted `main` CI workflow through the supported `workflow_dispatch` exception after exact bot/PR/base/head/source-run validation
- admit the candidate with the existing GET-only source verifier, reproduce the complete Changesets tree before candidate execution, and publish idempotent exact-head checks
- require one native exact-head `APPROVED` review from the trusted human, submitted before a distinct author’s two-parent PR merge, before package publication

## Security properties

- no App private key or long-lived release PAT is read, stored, or exposed
- dispatch executes base-owned helper/dependency bytes; candidate code runs only after current-main admission and deterministic tree equality
- CI receives read-only defaults; only admission/report jobs receive `checks: write`, and no CI job can approve a PR
- ordinary push and developer `pull_request` CI paths remain present and use their normal candidate ref
- replays update stable PR/head check markers rather than creating duplicate checks

## Validation

- `bun test scripts/check-release-pr-automation.test.ts scripts/check-source-admission.test.ts` (33 pass)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- workflow YAML parsed with Bun; `git diff --check`
- fixture-level only: no release workflow, tag, publication, deployment, ruleset change, or manual CI dispatch was performed

Linear: OPE-88