### PR TITLE
fix: correct PR 526 audit findings

### DIFF
--- a/.changeset/pr526-audit-correction.md
+++ b/.changeset/pr526-audit-correction.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/core": patch
+"@opengeni/db": patch
+---
+
+Restore immutable concurrent-index migration history, stage populated-table migrations safely, and reject goal-bearing child sessions whose resulting first-party authority lacks `goals:manage`.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -1536,11 +1536,13 @@ function registerWorkspaceOrchestrationTools(
           idempotencyKey: z4.string().min(1).max(200).optional(),
           // First-party MCP token permissions for the spawned session; every
           // permission must be held by this grant (validated in the domain).
+          // A goal requires goals:manage in the resulting set; it is never
+          // silently added beyond the inherited or explicit authority.
           firstPartyMcpPermissions: z4
             .array(z4.string())
             .optional()
             .describe(
-              "Optional first-party capability set for the child. Omit to inherit this session's effective permissions. An explicit set may only narrow capabilities held by this session.",
+              "Optional first-party capability set for the child. Omit to inherit this session's effective permissions. An explicit set may only narrow capabilities held by this session. A goal-bearing child requires goals:manage in the resulting set; creation fails rather than adding it implicitly.",
             ),
           // Shared-sandbox placement (addendum 05 §D). OMIT (default) to SHARE the
           // creator's box — one filesystem/repo/desktop, N independent conversations;

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -123,9 +123,13 @@ The goal tools are session-scoped first-party MCP tools. The worker signs the
 session id into the delegated access token it uses for first-party MCP calls
 (HMAC, worker-asserted — not agent-controlled), and the API registers
 `goal_set`/`goal_update`/`goal_complete`/`goal_pause` only for grants carrying
-that claim plus the `goals:manage` permission. Goal-bearing sessions, turns,
-and scheduled dispatches force-merge the `opengeni` tool ref so these tools are
-reachable even when the session was created with an empty tool list.
+that claim plus the `goals:manage` permission. A top-level session with no
+first-party permission override uses the worker default. A child inherits its
+creator's exact effective permissions, and an explicit set may only narrow
+them; goal-bearing creation is rejected when that resulting set omits
+`goals:manage` rather than silently broadening the child. Goal-bearing sessions,
+turns, and scheduled dispatches force-merge the `opengeni` tool ref so these
+tools are reachable even when the session was created with an empty tool list.
 
 ## Settings
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -6100,6 +6100,8 @@ export const CreateSessionRequest = withVariableSetIdAlias({
   // omission uses the deployment's worker default; a child omission inherits
   // the creating session's effective grant. An explicit set is capped at
   // creation: every requested permission must be held by the creating grant.
+  // A goal-bearing session whose explicit/effective set omits goals:manage is
+  // rejected; creation never silently expands a child beyond that set.
   firstPartyMcpPermissions: z.array(Permission).optional(),
   // Third-party MCP servers attached only to this session. For an agent-created
   // child, omission snapshots its trusted immediate parent's server definitions,

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1067,21 +1067,21 @@ export async function createSessionForRequest(
       });
     }
   }
-  // Invariant: a goal-bearing session always carries goals:manage in its
-  // effective first-party permissions. Without it the worker's delegated
-  // token never sees the goal tools (goal_complete/goal_pause/...), so the
-  // agent cannot stop its own goal and the continuation loop runs until an
-  // operator intervenes. The auto-added permission is deliberately exempt
-  // from the creating-grant check above: goal tools are scoped to the
-  // spawned session itself via the worker-signed sessionId claim, so a
-  // worker managing its OWN goal is not an escalation of the spawner's
-  // authority.
+  // A goal-bearing session with an explicit/effective permission set must
+  // already carry goals:manage. Without it the worker cannot stop its own
+  // continuation loop, but silently adding it would violate the child
+  // authority contract: a child inherits or narrows its creator's exact grant
+  // and never gains an unrequested permission. Top-level omission remains the
+  // deployment's worker default, which includes the goal tools.
   if (
     payload.goal &&
     firstPartyMcpPermissions &&
     !firstPartyMcpPermissions.includes("goals:manage")
   ) {
-    firstPartyMcpPermissions = [...firstPartyMcpPermissions, "goals:manage"];
+    throw new HTTPException(422, {
+      message:
+        "goal-bearing sessions require goals:manage in the resulting first-party MCP permission set",
+    });
   }
   // Parent linkage: a worker is linked to its manager ONLY from the
   // worker-signed sessionId claim on the creating grant — the manager

--- a/packages/db/drizzle/0066_session_interruption_attempt_lookup.sql
+++ b/packages/db/drizzle/0066_session_interruption_attempt_lookup.sql
@@ -1,4 +1,4 @@
 -- deployment-mode: rolling
 -- opengeni:concurrent-index lock-timeout=5s
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "session_attempt_interruptions_attempt_lookup_idx"
+CREATE INDEX CONCURRENTLY "session_attempt_interruptions_attempt_lookup_idx"
   ON "session_attempt_interruptions" ("workspace_id", "session_id", "attempt_id", "requested_at" DESC);

--- a/packages/db/drizzle/0070_session_event_type_sequence_lookup.sql
+++ b/packages/db/drizzle/0070_session_event_type_sequence_lookup.sql
@@ -1,4 +1,4 @@
 -- deployment-mode: rolling
 -- opengeni:concurrent-index lock-timeout=5s
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "session_events_workspace_session_type_sequence_idx"
+CREATE INDEX CONCURRENTLY "session_events_workspace_session_type_sequence_idx"
   ON "session_events" ("workspace_id", "session_id", "type", "sequence" DESC);

--- a/packages/db/drizzle/0071_session_event_monitoring_tail.sql
+++ b/packages/db/drizzle/0071_session_event_monitoring_tail.sql
@@ -1,6 +1,6 @@
 -- deployment-mode: rolling
 -- opengeni:concurrent-index lock-timeout=5s
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "session_events_workspace_session_monitoring_tail_idx"
+CREATE INDEX CONCURRENTLY "session_events_workspace_session_monitoring_tail_idx"
   ON "session_events" ("workspace_id", "session_id", "sequence" DESC)
   WHERE "type" NOT IN (
     'agent.message.delta',

--- a/packages/db/drizzle/0072_sessions_workspace_created_id_idx.sql
+++ b/packages/db/drizzle/0072_sessions_workspace_created_id_idx.sql
@@ -1,4 +1,4 @@
 -- deployment-mode: rolling
 -- opengeni:concurrent-index lock-timeout=5s
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "sessions_workspace_created_id_idx"
+CREATE INDEX CONCURRENTLY "sessions_workspace_created_id_idx"
   ON "sessions" ("workspace_id", "created_at" DESC, "id" DESC);

--- a/packages/db/drizzle/0073_sessions_workspace_updated_id_idx.sql
+++ b/packages/db/drizzle/0073_sessions_workspace_updated_id_idx.sql
@@ -1,4 +1,4 @@
 -- deployment-mode: rolling
 -- opengeni:concurrent-index lock-timeout=5s
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "sessions_workspace_updated_id_idx"
+CREATE INDEX CONCURRENTLY "sessions_workspace_updated_id_idx"
   ON "sessions" ("workspace_id", "updated_at" DESC, "id" DESC);

--- a/packages/db/drizzle/0075_sessions_workspace_activity_revision_idx.sql
+++ b/packages/db/drizzle/0075_sessions_workspace_activity_revision_idx.sql
@@ -1,4 +1,4 @@
 -- deployment-mode: rolling
 -- opengeni:concurrent-index lock-timeout=5s
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "sessions_workspace_activity_revision_idx"
+CREATE INDEX CONCURRENTLY "sessions_workspace_activity_revision_idx"
   ON "sessions" ("workspace_id", "activity_revision" DESC, "updated_at" DESC, "id" DESC);

--- a/packages/db/drizzle/0077_session_attempt_latest_lookup.sql
+++ b/packages/db/drizzle/0077_session_attempt_latest_lookup.sql
@@ -1,4 +1,4 @@
 -- deployment-mode: rolling
 -- opengeni:concurrent-index lock-timeout=5s
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "session_turn_attempts_latest_session_idx"
+CREATE INDEX CONCURRENTLY "session_turn_attempts_latest_session_idx"
   ON "session_turn_attempts" ("workspace_id", "session_id", "started_at" DESC, "id" DESC);

--- a/packages/db/drizzle/0102_session_command_receipt_service_actor.sql
+++ b/packages/db/drizzle/0102_session_command_receipt_service_actor.sql
@@ -1,3 +1,6 @@
+-- deployment-mode: rolling
+SET LOCAL lock_timeout = '5s';
+
 ALTER TABLE "session_command_receipts"
   DROP CONSTRAINT "session_command_receipts_actor_check",
   ADD CONSTRAINT "session_command_receipts_actor_check"
@@ -7,4 +10,7 @@ ALTER TABLE "session_command_receipts"
       OR ("actor_type" IN ('human', 'operator', 'service')
         AND "actor_subject_id" IS NOT NULL
         AND "actor_attempt_id" IS NULL)
-    );
+    ) NOT VALID;
+
+ALTER TABLE "session_command_receipts"
+  VALIDATE CONSTRAINT "session_command_receipts_actor_check";

--- a/packages/db/drizzle/0103_host_export_root_session.sql
+++ b/packages/db/drizzle/0103_host_export_root_session.sql
@@ -1,3 +1,4 @@
+-- deployment-mode: rolling
 -- Preserve immutable session lineage in durable host exports. The outbox owns
 -- the captured root so a later session deletion cannot change an unacknowledged
 -- export. Legacy rows whose source session is already gone remain explicitly
@@ -163,27 +164,3 @@ BEGIN
     );
   END LOOP;
 END $migration$;
-
--- Keep data conversion last: no later table/function DDL should run while a
--- populated database may have pending constraint triggers from this update.
-WITH distinct_sessions AS MATERIALIZED (
-  SELECT DISTINCT "workspace_id", "session_id"
-  FROM "host_export_outbox"
-  WHERE "session_id" IS NOT NULL
-    AND "root_session_id" IS NULL
-), resolved_roots AS MATERIALIZED (
-  SELECT
-    "workspace_id",
-    "session_id",
-    opengeni_private.host_export_session_root(
-      "workspace_id",
-      "session_id"
-    ) AS "root_session_id"
-  FROM distinct_sessions
-)
-UPDATE "host_export_outbox" o
-SET "root_session_id" = roots."root_session_id"
-FROM resolved_roots roots
-WHERE o."workspace_id" = roots."workspace_id"
-  AND o."session_id" = roots."session_id"
-  AND o."root_session_id" IS NULL;

--- a/packages/db/drizzle/0104_host_export_root_session_backfill.sql
+++ b/packages/db/drizzle/0104_host_export_root_session_backfill.sql
@@ -1,0 +1,27 @@
+-- deployment-mode: maintenance
+-- Backfill immutable root lineage for the pre-0103 durable outbox population.
+-- Migration 0103 already captures every new row, so this unbounded rewrite is
+-- isolated to an explicitly reviewed maintenance step instead of hiding in the
+-- rolling expand migration. Deleted source sessions remain unresolved (NULL).
+
+WITH distinct_sessions AS MATERIALIZED (
+  SELECT DISTINCT "workspace_id", "session_id"
+  FROM "host_export_outbox"
+  WHERE "session_id" IS NOT NULL
+    AND "root_session_id" IS NULL
+), resolved_roots AS MATERIALIZED (
+  SELECT
+    "workspace_id",
+    "session_id",
+    opengeni_private.host_export_session_root(
+      "workspace_id",
+      "session_id"
+    ) AS "root_session_id"
+  FROM distinct_sessions
+)
+UPDATE "host_export_outbox" o
+SET "root_session_id" = roots."root_session_id"
+FROM resolved_roots roots
+WHERE o."workspace_id" = roots."workspace_id"
+  AND o."session_id" = roots."session_id"
+  AND o."root_session_id" IS NULL;

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -6,7 +6,23 @@ import postgres from "postgres";
 const DEFAULT_DATABASE_URL = "postgres://opengeni:opengeni@127.0.0.1:5432/opengeni";
 const concurrentIndexDirective = /^-- opengeni:concurrent-index lock-timeout=(\d+(?:ms|s|min))$/;
 const concurrentIndexStatement =
-  /^CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+IF\s+NOT\s+EXISTS\s+(?:"((?:[^"]|"")+)"|([A-Za-z_][A-Za-z0-9_]*))\s+ON\b/is;
+  /^CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+(?:(IF\s+NOT\s+EXISTS)\s+)?(?:"((?:[^"]|"")+)"|([A-Za-z_][A-Za-z0-9_]*))\s+ON\b/is;
+const governedLegacyConcurrentIndexMigrations = new Set([
+  "0066_session_interruption_attempt_lookup.sql",
+  "0070_session_event_type_sequence_lookup.sql",
+  "0071_session_event_monitoring_tail.sql",
+  "0072_sessions_workspace_created_id_idx.sql",
+  "0073_sessions_workspace_updated_id_idx.sql",
+  "0075_sessions_workspace_activity_revision_idx.sql",
+  "0077_session_attempt_latest_lookup.sql",
+]);
+
+export interface ConcurrentIndexMigration {
+  indexName: string;
+  lockTimeout: string;
+  skipWhenValid: boolean;
+  statement: string;
+}
 
 /** A bare Postgres identifier (schema/role name) safe to interpolate into DDL. */
 function assertIdentifier(name: string, value: string): string {
@@ -27,14 +43,17 @@ function assertIdentifier(name: string, value: string): string {
  * The directive is deliberately not a generic "no transaction" escape hatch:
  * only one idempotent concurrent-index statement is accepted, lock acquisition
  * is always bounded, and an invalid artifact left by a failed concurrent build
- * is removed before retry. This keeps additive large-table indexes online
- * without making arbitrary partially-applied migration scripts possible.
+ * is removed before retry. Seven governed historical migrations predate the
+ * IF NOT EXISTS rule; only those exact filenames may use their immutable bare
+ * statements, and the runner makes their retries idempotent by skipping an
+ * already-valid index. This keeps additive large-table indexes online without
+ * rewriting shipped history or making arbitrary partially-applied migration
+ * scripts possible.
  */
-async function executeMigrationFile(
-  sql: postgres.Sql,
+export function parseConcurrentIndexMigration(
   file: string,
   sqlText: string,
-): Promise<void> {
+): ConcurrentIndexMigration | null {
   const lines = sqlText.replaceAll("\r\n", "\n").split("\n");
   const firstLine = lines[0]?.trim() ?? "";
   const deploymentPrefixed = /^-- deployment-mode: (?:rolling|maintenance)$/.test(firstLine);
@@ -45,8 +64,7 @@ async function executeMigrationFile(
     if (directiveLine.startsWith("-- opengeni:")) {
       throw new Error(`Unsupported OpenGeni migration directive in ${file}`);
     }
-    await sql.unsafe(sqlText);
-    return;
+    return null;
   }
 
   const lockTimeout = directive[1]!;
@@ -63,22 +81,47 @@ async function executeMigrationFile(
       `${file}: opengeni:concurrent-index requires exactly one CREATE [UNIQUE] INDEX CONCURRENTLY IF NOT EXISTS statement with an unqualified index name`,
     );
   }
-  const indexName = (parsedStatement[1] ?? parsedStatement[2]!).replaceAll('""', '"');
+  const idempotentInSql = parsedStatement[1] !== undefined;
+  if (!idempotentInSql && !governedLegacyConcurrentIndexMigrations.has(file)) {
+    throw new Error(
+      `${file}: opengeni:concurrent-index requires IF NOT EXISTS; bare statements are supported only for governed historical migrations`,
+    );
+  }
+  return {
+    indexName: (parsedStatement[2] ?? parsedStatement[3]!).replaceAll('""', '"'),
+    lockTimeout,
+    skipWhenValid: !idempotentInSql,
+    statement,
+  };
+}
 
-  await sql`select set_config('lock_timeout', ${lockTimeout}, false)`;
+async function executeMigrationFile(
+  sql: postgres.Sql,
+  file: string,
+  sqlText: string,
+): Promise<void> {
+  const concurrentIndex = parseConcurrentIndexMigration(file, sqlText);
+  if (!concurrentIndex) {
+    await sql.unsafe(sqlText);
+    return;
+  }
+
+  await sql`select set_config('lock_timeout', ${concurrentIndex.lockTimeout}, false)`;
   try {
     const [existing] = await sql<Array<{ valid: boolean; ready: boolean }>>`
       select i.indisvalid as valid, i.indisready as ready
       from pg_catalog.pg_class c
       join pg_catalog.pg_namespace n on n.oid = c.relnamespace
       join pg_catalog.pg_index i on i.indexrelid = c.oid
-      where n.nspname = current_schema() and c.relname = ${indexName}
+      where n.nspname = current_schema() and c.relname = ${concurrentIndex.indexName}
     `;
     if (existing && (!existing.valid || !existing.ready)) {
-      const quotedIndexName = `"${indexName.replaceAll('"', '""')}"`;
+      const quotedIndexName = `"${concurrentIndex.indexName.replaceAll('"', '""')}"`;
       await sql.unsafe(`DROP INDEX CONCURRENTLY ${quotedIndexName}`);
+    } else if (existing && concurrentIndex.skipWhenValid) {
+      return;
     }
-    await sql.unsafe(statement);
+    await sql.unsafe(concurrentIndex.statement);
   } finally {
     await sql`select set_config('lock_timeout', '0', false)`;
   }

--- a/packages/db/test/migrate-concurrent-index.test.ts
+++ b/packages/db/test/migrate-concurrent-index.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { parseConcurrentIndexMigration } from "../src/migrate";
+
+const header = "-- deployment-mode: rolling\n-- opengeni:concurrent-index lock-timeout=5s\n";
+
+describe("concurrent-index migration parsing", () => {
+  test("supports the immutable bare statement only for its governed historical filename", () => {
+    const statement =
+      'CREATE INDEX CONCURRENTLY "sessions_workspace_created_id_idx"\n' +
+      '  ON "sessions" ("workspace_id", "created_at" DESC, "id" DESC);';
+
+    expect(
+      parseConcurrentIndexMigration(
+        "0072_sessions_workspace_created_id_idx.sql",
+        header + statement,
+      ),
+    ).toEqual({
+      indexName: "sessions_workspace_created_id_idx",
+      lockTimeout: "5s",
+      skipWhenValid: true,
+      statement,
+    });
+    expect(() => parseConcurrentIndexMigration("0105_new_index.sql", header + statement)).toThrow(
+      "bare statements are supported only for governed historical migrations",
+    );
+  });
+
+  test("requires future migrations to be idempotent in SQL", () => {
+    const statement =
+      'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "new_index" ON "records" ("id");';
+    expect(parseConcurrentIndexMigration("0105_new_index.sql", header + statement)).toEqual({
+      indexName: "new_index",
+      lockTimeout: "5s",
+      skipWhenValid: false,
+      statement,
+    });
+  });
+
+  test("rejects multiple statements and unsupported directives", () => {
+    expect(() =>
+      parseConcurrentIndexMigration(
+        "0105_new_index.sql",
+        `${header}CREATE INDEX CONCURRENTLY IF NOT EXISTS "one" ON "records" ("id");\nSELECT 1;`,
+      ),
+    ).toThrow("requires exactly one");
+    expect(() =>
+      parseConcurrentIndexMigration(
+        "0105_new_index.sql",
+        "-- deployment-mode: rolling\n-- opengeni:no-transaction\nSELECT 1;",
+      ),
+    ).toThrow("Unsupported OpenGeni migration directive");
+  });
+});

--- a/packages/db/test/migration-0072-session-monitoring-indexes.test.ts
+++ b/packages/db/test/migration-0072-session-monitoring-indexes.test.ts
@@ -22,7 +22,7 @@ describe("migrations 0072/0073 (session monitoring keysets)", () => {
       const sql = await readFile(join(migrationsDir, file), "utf8");
       expect(sql.split(/\r?\n/, 1)[0]).toBe("-- deployment-mode: rolling");
       expect(sql).toContain("-- opengeni:concurrent-index lock-timeout=5s");
-      expect(sql).toContain(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "${index}"`);
+      expect(sql).toContain(`CREATE INDEX CONCURRENTLY "${index}"`);
       expect(sql).toContain(`ON "sessions" ("workspace_id", "${timestamp}" DESC, "id" DESC);`);
     });
   }
@@ -34,9 +34,7 @@ describe("migrations 0072/0073 (session monitoring keysets)", () => {
     );
     expect(sql.split(/\r?\n/, 1)[0]).toBe("-- deployment-mode: rolling");
     expect(sql).toContain("-- opengeni:concurrent-index lock-timeout=5s");
-    expect(sql).toContain(
-      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "sessions_workspace_activity_revision_idx"',
-    );
+    expect(sql).toContain('CREATE INDEX CONCURRENTLY "sessions_workspace_activity_revision_idx"');
     expect(sql).toContain(
       'ON "sessions" ("workspace_id", "activity_revision" DESC, "updated_at" DESC, "id" DESC);',
     );

--- a/packages/db/test/migration-0102-service-command-receipts.test.ts
+++ b/packages/db/test/migration-0102-service-command-receipts.test.ts
@@ -36,6 +36,11 @@ describe("0102 service command receipt actors (real PostgreSQL)", () => {
     if (!available || !blank) return;
     const sql = postgres(blank.databaseUrl, { max: 1 });
     try {
+      const migrationSql = await readFile(join(migrationsDir, migration), "utf8");
+      expect(migrationSql.split(/\r?\n/, 1)[0]).toBe("-- deployment-mode: rolling");
+      expect(migrationSql).toContain(
+        ') NOT VALID;\n\nALTER TABLE "session_command_receipts"\n  VALIDATE CONSTRAINT "session_command_receipts_actor_check";',
+      );
       const files = (await readdir(migrationsDir)).filter((file) => file.endsWith(".sql")).sort();
       for (const migrationFile of files.filter((entry) => entry.localeCompare(migration) < 0)) {
         await sql.unsafe(await readFile(join(migrationsDir, migrationFile), "utf8"));
@@ -58,7 +63,14 @@ describe("0102 service command receipt actors (real PostgreSQL)", () => {
           'prompt.send', 'before-migration', 'existing-hash'
         )`;
 
-      await sql.unsafe(await readFile(join(migrationsDir, migration), "utf8"));
+      await sql.unsafe(migrationSql);
+
+      const [constraint] = await sql<Array<{ validated: boolean }>>`
+        select convalidated as validated
+        from pg_catalog.pg_constraint
+        where conrelid = 'session_command_receipts'::regclass
+          and conname = 'session_command_receipts_actor_check'`;
+      expect(constraint?.validated).toBe(true);
 
       await sql`
         insert into session_command_receipts (

--- a/packages/db/test/migration-0103-host-export-root-session.test.ts
+++ b/packages/db/test/migration-0103-host-export-root-session.test.ts
@@ -7,7 +7,8 @@ import { provisionRoles } from "../src/provision-roles";
 import postgres from "postgres";
 
 const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), "../drizzle");
-const migration = "0103_host_export_root_session.sql";
+const expandMigration = "0103_host_export_root_session.sql";
+const backfillMigration = "0104_host_export_root_session_backfill.sql";
 const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
 
 let blank: BlankTestDatabase | null = null;
@@ -27,15 +28,21 @@ afterAll(async () => {
   await blank?.release();
 });
 
-describe("0103 host-export root session lineage (real PostgreSQL)", () => {
-  test("backfills valid lineages, preserves unresolved legacy rows, and captures new children", async () => {
+describe("0103/0104 host-export root session lineage (real PostgreSQL)", () => {
+  test("captures new children before the maintenance backfill resolves legacy lineages", async () => {
     if (!available || !blank) return;
     const sql = postgres(blank.databaseUrl, { max: 1, prepare: false });
     const hostExportRole = `og_export_${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`;
     let roleCreated = false;
     try {
+      const expandSql = await readFile(join(migrationsDir, expandMigration), "utf8");
+      const backfillSql = await readFile(join(migrationsDir, backfillMigration), "utf8");
+      expect(expandSql.split(/\r?\n/, 1)[0]).toBe("-- deployment-mode: rolling");
+      expect(backfillSql.split(/\r?\n/, 1)[0]).toBe("-- deployment-mode: maintenance");
       const files = (await readdir(migrationsDir)).filter((file) => file.endsWith(".sql")).sort();
-      for (const migrationFile of files.filter((entry) => entry.localeCompare(migration) < 0)) {
+      for (const migrationFile of files.filter(
+        (entry) => entry.localeCompare(expandMigration) < 0,
+      )) {
         await sql.unsafe(await readFile(join(migrationsDir, migrationFile), "utf8"));
       }
 
@@ -102,9 +109,9 @@ describe("0103 host-export root session lineage (real PostgreSQL)", () => {
         REVOKE ALL ON FUNCTION opengeni_host_export.default_acl_probe() FROM PUBLIC;
       `);
 
-      await sql.unsafe(await readFile(join(migrationsDir, migration), "utf8"));
+      await sql.unsafe(expandSql);
 
-      const backfilled = await sql<Array<{ sourceId: string; rootSessionId: string | null }>>`
+      const beforeBackfill = await sql<Array<{ sourceId: string; rootSessionId: string | null }>>`
         select source_id as "sourceId", root_session_id as "rootSessionId"
         from host_export_outbox
         where source_id in (
@@ -114,14 +121,14 @@ describe("0103 host-export root session lineage (real PostgreSQL)", () => {
         )
         order by idempotency_key`;
       expect(
-        backfilled.map((row) => ({
+        beforeBackfill.map((row) => ({
           sourceId: row.sourceId,
           rootSessionId: row.rootSessionId,
         })),
       ).toEqual([
-        { sourceId: childSourceId, rootSessionId: rootId },
+        { sourceId: childSourceId, rootSessionId: null },
         { sourceId: orphanSourceId, rootSessionId: null },
-        { sourceId: rootSourceId, rootSessionId: rootId },
+        { sourceId: rootSourceId, rootSessionId: null },
       ]);
 
       const newSourceId = crypto.randomUUID();
@@ -159,6 +166,27 @@ describe("0103 host-export root session lineage (real PostgreSQL)", () => {
       expect((missingCurrentSessionError as Error).message).toContain(
         "does not exist in workspace",
       );
+
+      await sql.unsafe(backfillSql);
+      const backfilled = await sql<Array<{ sourceId: string; rootSessionId: string | null }>>`
+        select source_id as "sourceId", root_session_id as "rootSessionId"
+        from host_export_outbox
+        where source_id in (
+          ${rootSourceId}::uuid,
+          ${childSourceId}::uuid,
+          ${orphanSourceId}::uuid
+        )
+        order by idempotency_key`;
+      expect(
+        backfilled.map((row) => ({
+          sourceId: row.sourceId,
+          rootSessionId: row.rootSessionId,
+        })),
+      ).toEqual([
+        { sourceId: childSourceId, rootSessionId: rootId },
+        { sourceId: orphanSourceId, rootSessionId: null },
+        { sourceId: rootSourceId, rootSessionId: rootId },
+      ]);
 
       const exporterUrl = new URL(blank.databaseUrl);
       exporterUrl.username = hostExportRole;

--- a/packages/db/test/migration-history-integrity.test.ts
+++ b/packages/db/test/migration-history-integrity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), "../drizzle");
+const governedHashes = [
+  [
+    "0066_session_interruption_attempt_lookup.sql",
+    "0403a927f7e80e1ec8ca6e0d0a698d02f6602a6a499da4174bc278e696374028",
+  ],
+  [
+    "0070_session_event_type_sequence_lookup.sql",
+    "5938e8f2c02b15bd403346e58b2c5d13168e2f016ee9577f3991cf73b8555e4d",
+  ],
+  [
+    "0071_session_event_monitoring_tail.sql",
+    "b26beba717aab13ea2a91ec5f4e349461b448c86821f2ad597fdee04fffc81ed",
+  ],
+  [
+    "0072_sessions_workspace_created_id_idx.sql",
+    "fd34a7d68ab68d397234bfea98998d3de7b709474f26cba5d7817596dba3a7a5",
+  ],
+  [
+    "0073_sessions_workspace_updated_id_idx.sql",
+    "2902316ad06aae7e42c3bb43bcedebcd16bddfe21370b3d7062738debb502a9f",
+  ],
+  [
+    "0075_sessions_workspace_activity_revision_idx.sql",
+    "139b13a478ef0d7fcb306e4ff8a8db15b8f6dead2d21fdc41bf9a3ba56d97e55",
+  ],
+  [
+    "0077_session_attempt_latest_lookup.sql",
+    "093c75b5969dc7a1f26085e1696169e936ed4171c44baf88d13ab9907b258064",
+  ],
+] as const;
+
+describe("governed migration history", () => {
+  for (const [file, expectedHash] of governedHashes) {
+    test(`${file} retains its shipped bytes`, async () => {
+      const content = await readFile(join(migrationsDir, file));
+      expect(createHash("sha256").update(content).digest("hex")).toBe(expectedHash);
+    });
+  }
+});

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -44,6 +44,17 @@ describe("release schema contract", () => {
     expect((await buildSchemaContract(changedContent)).sha256).not.toBe(baselineHash);
     expect((await buildSchemaContract(changedPath)).sha256).not.toBe(baselineHash);
   });
+
+  test("rejects an unclassified migration in the governed deployment-mode era", async () => {
+    const directory = await fixture([
+      ["0062_historical.sql", "select 1;"],
+      ["0063_classified.sql", "select 2;"],
+    ]);
+
+    await expect(buildSchemaContract(directory)).rejects.toThrow(
+      "0063_classified.sql: classified migrations require -- deployment-mode: rolling or -- deployment-mode: maintenance on the first line",
+    );
+  });
 });
 
 async function fixture(files: Array<[string, string]>): Promise<string> {

--- a/scripts/release-schema-contract.ts
+++ b/scripts/release-schema-contract.ts
@@ -35,7 +35,7 @@ export async function buildSchemaContract(
     migrations.push({
       path,
       sha256: createHash("sha256").update(content).digest("hex"),
-      deploymentMode: deploymentMode(content.toString("utf8")),
+      deploymentMode: deploymentMode(path, content.toString("utf8")),
     });
   }
   return {
@@ -47,10 +47,16 @@ export async function buildSchemaContract(
   };
 }
 
-function deploymentMode(content: string): MigrationDeploymentMode {
+function deploymentMode(path: string, content: string): MigrationDeploymentMode {
   const firstLine = content.replaceAll("\r\n", "\n").split("\n", 1)[0]?.trim();
   if (firstLine === "-- deployment-mode: rolling") return "rolling";
   if (firstLine === "-- deployment-mode: maintenance") return "maintenance";
+  const ordinal = /^(\d{4})_/.exec(path)?.[1];
+  if (ordinal && Number(ordinal) >= 63) {
+    throw new Error(
+      `${path}: classified migrations require -- deployment-mode: rolling or -- deployment-mode: maintenance on the first line`,
+    );
+  }
   return "historical";
 }
 

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -7971,7 +7971,7 @@ describe("API component integration", () => {
     expect(wf.wakeups.length).toBe(wakeupsBefore);
   });
 
-  test("goal-bearing sessions always hold goals:manage in their first-party MCP permissions", async () => {
+  test("goal-bearing child permissions never expand beyond explicit creator authority", async () => {
     const wf = new FakeWorkflowClient();
     const grant = await bootstrapMcpGrant(dbClient.db);
     const delegationSecret = "test-delegation-secret";
@@ -7986,11 +7986,9 @@ describe("API component integration", () => {
       bus: new MemoryEventBus(),
       workflowClient: wf,
     });
-    // The creating grant deliberately lacks goals:manage: the auto-added
-    // permission is exempt from the creator-holds-it check because goal
-    // tools are scoped to the spawned session itself via the worker-signed
-    // sessionId claim - a worker managing its OWN goal is not an escalation
-    // of the spawner's authority.
+    // The creating grant deliberately lacks goals:manage. Asking for it
+    // explicitly must fail the same creator-holds-it check as every other
+    // permission; supplying a goal never creates a hidden exception.
     const creatorToken = await signDelegatedAccessToken(delegationSecret, {
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
@@ -7999,38 +7997,32 @@ describe("API component integration", () => {
       exp: Math.floor(Date.now() / 1000) + 300,
     });
 
-    // REST create with a goal: goals:manage is unioned into the explicit
-    // set, otherwise the agent could never call goal_complete/goal_pause and
-    // the goal continuation loop would run until an operator intervenes.
-    const withGoal = await app.request(workspacePath(grant.workspaceId, "/sessions"), {
+    const unauthorizedGoal = await app.request(workspacePath(grant.workspaceId, "/sessions"), {
       method: "POST",
       body: JSON.stringify({
         initialMessage: "take repo zero-to-one",
         model: "scripted-model",
         goal: { text: "repo deployed to staging" },
-        firstPartyMcpPermissions: ["workspace:read"],
+        firstPartyMcpPermissions: ["workspace:read", "goals:manage"],
       }),
       headers: {
         "content-type": "application/json",
         authorization: `Bearer ${creatorToken}`,
       },
     });
-    expect(withGoal.status).toBe(202);
-    const goalSession = (await withGoal.json()) as {
-      id: string;
-      firstPartyMcpPermissions: string[] | null;
-    };
-    expect(goalSession.firstPartyMcpPermissions).toEqual(["workspace:read", "goals:manage"]);
-    expect(
-      (await getSession(dbClient.db, grant.workspaceId, goalSession.id))?.firstPartyMcpPermissions,
-    ).toEqual(["workspace:read", "goals:manage"] as Permission[]);
+    expect(unauthorizedGoal.status).toBe(403);
+    expect(await unauthorizedGoal.text()).toContain(
+      "cannot grant first-party MCP permission beyond the creating grant: goals:manage",
+    );
 
-    // Without a goal the explicit permission set is stored untouched.
+    // A goalless session can retain the creator's narrower explicit set and
+    // becomes the trusted parent for the child cases below.
     const withoutGoal = await app.request(workspacePath(grant.workspaceId, "/sessions"), {
       method: "POST",
       body: JSON.stringify({
         initialMessage: "no goal here",
         model: "scripted-model",
+        sandboxBackend: "none",
         firstPartyMcpPermissions: ["workspace:read"],
       }),
       headers: {
@@ -8048,8 +8040,6 @@ describe("API component integration", () => {
       (await getSession(dbClient.db, grant.workspaceId, plainSession.id))?.firstPartyMcpPermissions,
     ).toEqual(["workspace:read"] as Permission[]);
 
-    // Same invariant through the MCP session_create tool, from a manager
-    // grant that also lacks goals:manage.
     const mcpDeps = {
       settings: appSettings,
       db: dbClient.db,
@@ -8066,22 +8056,54 @@ describe("API component integration", () => {
     const managerGrant = {
       ...grant,
       permissions: ["workspace:read", "sessions:create", "sessions:read"] as Permission[],
+      metadata: { sessionId: plainSession.id },
     };
     const managerMcp = buildOpenGeniMcpServer(mcpDeps, managerGrant);
+
+    // Omission inherits the manager's exact effective set. If that set lacks
+    // goals:manage, a goal-bearing child is rejected instead of being widened.
+    await expect(
+      callMcpTool(managerMcp, "session_create", {
+        initialMessage: "spawn an under-authorized goal worker",
+        model: "scripted-model",
+        sandboxBackend: "none",
+        sandbox: "new",
+        goal: { text: "fleet healthy" },
+      }),
+    ).rejects.toThrow("goal-bearing sessions require goals:manage");
+
+    const authorizedGrant = {
+      ...managerGrant,
+      permissions: [...managerGrant.permissions, "goals:manage"] as Permission[],
+    };
+    const authorizedMcp = buildOpenGeniMcpServer(mcpDeps, authorizedGrant);
     const spawned = await callMcpTool<{
       id: string;
       firstPartyMcpPermissions: string[] | null;
-    }>(managerMcp, "session_create", {
+    }>(authorizedMcp, "session_create", {
       initialMessage: "spawn a goal-bearing worker",
       model: "scripted-model",
       sandboxBackend: "none",
+      sandbox: "new",
       goal: { text: "fleet healthy" },
-      firstPartyMcpPermissions: ["workspace:read"],
     });
-    expect(spawned.firstPartyMcpPermissions).toEqual(["workspace:read", "goals:manage"]);
+    expect(spawned.firstPartyMcpPermissions).toEqual(authorizedGrant.permissions);
     expect(
       (await getSession(dbClient.db, grant.workspaceId, spawned.id))?.firstPartyMcpPermissions,
-    ).toEqual(["workspace:read", "goals:manage"] as Permission[]);
+    ).toEqual(authorizedGrant.permissions);
+
+    // Even an authorized creator cannot ask for a goal while explicitly
+    // narrowing goals:manage out of the child token.
+    await expect(
+      callMcpTool(authorizedMcp, "session_create", {
+        initialMessage: "narrow away goal authority",
+        model: "scripted-model",
+        sandboxBackend: "none",
+        sandbox: "new",
+        goal: { text: "fleet healthy" },
+        firstPartyMcpPermissions: ["workspace:read"],
+      }),
+    ).rejects.toThrow("goal-bearing sessions require goals:manage");
   });
 
   test("manager MCP session tools enforce environment attachment permission and billing limits", async () => {


### PR DESCRIPTION
## Summary

Smallest safe correction for the three proven post-merge PR #526 audit findings:

- restore seven governed concurrent-index migrations byte-for-byte from historical parent `c31b38ea4d2bc85dd088a33a38312743ff8f259a`; retain retry compatibility in the runner through an exact-filename allowlist, valid-index skip, and invalid-artifact rebuild
- classify `0102` as rolling and replace its populated-table CHECK with bounded lock acquisition plus `NOT VALID` / separate `VALIDATE`; split `0103` into rolling expand/capture DDL and append-only maintenance backfill `0104`
- preserve least privilege for goal-bearing child sessions: creation now rejects a resulting permission set without `goals:manage` rather than silently adding authority
- require deployment-mode classification for governed migration ordinals `0063+`

## Exact candidate

- Base: `b901fd59219053124824acbb4c2db9db065a190b`
- Head: `1f0ed18dbc54a9274fc636d10116faa2da5b8522`
- Tree: `df44705ef63cbdbb3decf2ec8c98ee2b4dfd92c7`
- Schema contract: `93bdc7403394b2b9da69f0b81b28cea61009f4482e457ec87896fa68ccc845d5` (95 files; latest `0104_host_export_root_session_backfill.sql`)

## Validation

- governed historical bytes: exact parent comparison and all seven SHA-256 checks passed
- disposable PostgreSQL 17.10 + pgvector 0.8.5: all 95 migrations applied twice; zero invalid/not-ready indexes; live retry of restored `0066` skipped the valid immutable index and repaired the migration ledger
- focused migration/schema suite: 18 pass, 0 fail after rebase
- exact child-authority API integration: 1 pass, 9 assertions
- broader relevant suite: 66 pass, 0 fail, 194 assertions
- full unit suite with real-PostgreSQL shim: 3,849 pass, 3 intentional live-Modal skips, 0 fail, 17,648 assertions
- full 22-project typecheck, lint, format check, docs-reference guard, public-hygiene guard, changeset status, and staged diff check passed after rebase
- package build, publish-consumer, and runtime-embedding consumer passed; release-shaped consumers were rerun after rebase under strict types/browser/session bundles/CSS/SSR and Bun+Node with host Zod 3
- read-only synthetic merge of the correction with the intervening release-only main delta was conflict-free; the final candidate tree equals that synthetic merged tree

## Operational note / residual risk

`0104` is intentionally classified as **maintenance** because its legacy durable-outbox rewrite is unbounded. Production operators must schedule and review that maintenance migration for the actual table size; deleted-session rows intentionally remain `NULL`. `0103` captures roots for new rows before the backfill.

This PR is **not merged and not deployed**. No release branch, deployment, cloud, or production state was changed.
