### PR TITLE
fix(ci): harden privileged automation checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,27 +52,30 @@ jobs:
       AUTOMATION_BASE_SHA: ${{ inputs.automation_base_sha }}
       AUTOMATION_SOURCE_RUN_ID: ${{ inputs.source_release_run_id }}
       AUTOMATION_SOURCE_RUN_ATTEMPT: ${{ inputs.source_release_run_attempt }}
-      GITHUB_TOKEN: ${{ github.token }}
     steps:
       # workflow_dispatch is sent to ref=main. Pin the checkout again so helper
       # and dependency bytes are the exact trusted base, never candidate bytes.
       - name: Check out trusted workflow source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Begin exact-head automation checks
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/check-release-pr-automation.mjs begin-version-checks
 
       - name: Admit trusted dispatch and exact source tree
         id: admission
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/check-release-pr-automation.mjs admit-version-ci
 
       - name: Set up Bun
         if: ${{ steps.admission.outcome == 'success' }}
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
@@ -116,6 +119,7 @@ jobs:
         env:
           AUTOMATION_CHECK_KIND: source-admission
           AUTOMATION_CHECK_CONCLUSION: ${{ steps.admission.outcome == 'success' && steps.version_tree.outcome == 'success' && 'success' || 'failure' }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/check-release-pr-automation.mjs complete-version-check
 
   test:
@@ -516,10 +520,9 @@ jobs:
       AUTOMATION_BASE_SHA: ${{ inputs.automation_base_sha }}
       AUTOMATION_SOURCE_RUN_ID: ${{ inputs.source_release_run_id }}
       AUTOMATION_SOURCE_RUN_ATTEMPT: ${{ inputs.source_release_run_attempt }}
-      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Check out trusted workflow source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
@@ -528,4 +531,5 @@ jobs:
         env:
           AUTOMATION_CHECK_KIND: automation-ci
           AUTOMATION_CHECK_CONCLUSION: ${{ needs.automation-admission.result == 'success' && needs.test.result == 'success' && needs.deployment.result == 'success' && needs.images.result == 'success' && 'success' || 'failure' }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/check-release-pr-automation.mjs complete-version-check

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -182,6 +182,27 @@ function assertVersionPull(pull, expected) {
   return headSha;
 }
 
+function versionBranchProjection(value) {
+  invariant(
+    value?.ref === `refs/heads/${RELEASE_AUTOMATION_CONTRACT.versionBranch}`,
+    "Version branch ref changed",
+  );
+  invariant(value?.object?.type === "commit", "Version branch is not a direct commit ref");
+  return assertSha(value.object.sha, "Version branch SHA");
+}
+
+function versionHeadParent(value, expectedHeadSha) {
+  invariant(
+    assertSha(value?.sha, "Version head commit SHA") === expectedHeadSha,
+    "Version head changed",
+  );
+  invariant(
+    Array.isArray(value?.parents) && value.parents.length === 1,
+    "Version head is not one commit",
+  );
+  return assertSha(value.parents[0]?.sha, "Version head parent SHA");
+}
+
 function baseGithubContext(env, workflowPath, eventName) {
   requiredEnvironment(env, [
     "GITHUB_API_URL",
@@ -274,12 +295,22 @@ function repositoryPath(path) {
 }
 
 async function terminalVersionIdentity(api, context) {
-  const [main, pull] = await Promise.all([
+  const [main, pull, versionBranch, headCommit] = await Promise.all([
     api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
     api.get(repositoryPath(`/pulls/${context.prNumber}`)),
+    api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.versionBranch}`)),
+    api.get(repositoryPath(`/git/commits/${context.headSha}`)),
   ]);
   assertMainRef(main, context.baseSha, "terminal default branch");
   assertVersionPull(pull, context);
+  invariant(
+    versionBranchProjection(versionBranch) === context.headSha,
+    "terminal Version branch changed",
+  );
+  invariant(
+    versionHeadParent(headCommit, context.headSha) === context.baseSha,
+    "terminal Version head parent changed",
+  );
   return pull;
 }
 
@@ -307,14 +338,30 @@ async function convergedVersionHeadSha(api, context, options = {}) {
     // A moving main is never eventual-consistency lag. Fail immediately instead
     // of waiting against a source run that is no longer current.
     assertMainRef(main, context.baseSha);
+    let headSha;
     try {
-      return assertVersionPull(pull, context);
+      headSha = assertVersionPull(pull, context);
     } catch (error) {
       const retryable =
         error instanceof Error && retryableVersionProjectionErrors.has(error.message);
       if (!retryable || attempt === attempts) throw error;
       await sleep(delayMs);
+      continue;
     }
+
+    const [versionBranch, headCommit] = await Promise.all([
+      api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.versionBranch}`)),
+      api.get(repositoryPath(`/git/commits/${headSha}`)),
+    ]);
+    const branchSha = versionBranchProjection(versionBranch);
+    const parentSha = versionHeadParent(headCommit, headSha);
+    if (branchSha === headSha && parentSha === context.baseSha) return headSha;
+    if (attempt === attempts) {
+      throw new Error(
+        `Version PR #${context.prNumber} base/head topology did not converge after ${attempts} attempts`,
+      );
+    }
+    await sleep(delayMs);
   }
   throw new Error("Version PR projection did not converge");
 }
@@ -331,8 +378,8 @@ export async function validateVersionPrDispatch(options = {}) {
   const repository = await api.get(repositoryPath(""));
   assertRepository(repository);
   // changesets/action can finish updating the branch before GitHub's PR
-  // projection reflects the new base/head pair. Wait only for those two exact
-  // projection fields; every identity or ownership mismatch still fails fast.
+  // projection reflects the new base/head pair. Wait only for otherwise valid
+  // projection/topology drift; every identity or ownership mismatch fails fast.
   const headSha = await convergedVersionHeadSha(
     api,
     { prNumber, baseSha: context.sha },

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -127,11 +127,14 @@ function dispatchFixture(
     author?: Record<string, unknown>;
     headRepository?: string;
     mainSha?: string;
+    pullBases?: string[];
+    pullHeads?: string[];
     stalePullReads?: number;
   } = {},
 ) {
   const requests: RequestRecord[] = [];
   let pullReads = 0;
+  let projectedHead = headSha;
   async function fetchImpl(input: string | URL | Request, init?: RequestInit) {
     const url = new URL(String(input));
     const method = init?.method ?? "GET";
@@ -142,15 +145,35 @@ function dispatchFixture(
     if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/main`)
       return response(mainRef(options.mainSha));
     if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}`) {
+      const readIndex = pullReads;
       pullReads += 1;
+      const pullBases = options.pullBases;
+      const base = pullBases
+        ? pullBases[Math.min(readIndex, pullBases.length - 1)]
+        : pullReads <= (options.stalePullReads ?? 0)
+          ? "a".repeat(40)
+          : baseSha;
+      const pullHeads = options.pullHeads ?? [headSha];
+      projectedHead = pullHeads[Math.min(readIndex, pullHeads.length - 1)];
       return response(
         versionPull({
           author: options.author,
-          base: pullReads <= (options.stalePullReads ?? 0) ? "a".repeat(40) : baseSha,
+          base,
+          head: projectedHead,
           headRepository: options.headRepository,
         }),
       );
     }
+    if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/changeset-release/main`)
+      return response({
+        ref: "refs/heads/changeset-release/main",
+        object: { type: "commit", sha: projectedHead },
+      });
+    if (method === "GET" && url.pathname === `${prefix}/git/commits/${projectedHead}`)
+      return response({
+        sha: projectedHead,
+        parents: [{ sha: projectedHead === headSha ? baseSha : "7".repeat(40) }],
+      });
     if (method === "POST" && url.pathname === `${prefix}/actions/workflows/ci.yml/dispatches`)
       return response(null, 204);
     return response({ message: `unexpected ${method} ${url.pathname}` }, 404);
@@ -215,13 +238,50 @@ describe("Version PR dispatch identity", () => {
     expect(fixture.requests.some((request) => request.method === "POST")).toBe(false);
   });
 
+  test("waits for the Version PR head and direct branch topology to converge", async () => {
+    const oldHeadSha = "8".repeat(40);
+    const fixture = dispatchFixture({
+      pullBases: ["9".repeat(40), baseSha, baseSha, baseSha],
+      pullHeads: [oldHeadSha, oldHeadSha, headSha, headSha],
+    });
+    const sleeps: number[] = [];
+    await expect(
+      validateVersionPrDispatch({
+        env: releasePushEnv(),
+        fetchImpl: fixture.fetchImpl,
+        logger: { log() {} },
+        projectionAttempts: 3,
+        projectionDelayMs: 7,
+        projectionSleep: async (milliseconds: number) => {
+          sleeps.push(milliseconds);
+        },
+      }),
+    ).resolves.toEqual({ prNumber: pullNumber, headSha, baseSha });
+    expect(sleeps).toEqual([7, 7]);
+    expect(
+      fixture.requests.filter((request) => request.path.endsWith(`/pulls/${pullNumber}`)),
+    ).toHaveLength(4);
+    expect(fixture.requests.filter((request) => request.method === "POST")).toHaveLength(1);
+  });
+
   test("rejects a human-authored Version PR without dispatching", async () => {
     const fixture = dispatchFixture({
       author: { login: "jorgensandhaug", id: 55702375, type: "User" },
+      stalePullReads: 3,
     });
+    const sleeps: number[] = [];
     await expect(
-      validateVersionPrDispatch({ env: releasePushEnv(), fetchImpl: fixture.fetchImpl }),
+      validateVersionPrDispatch({
+        env: releasePushEnv(),
+        fetchImpl: fixture.fetchImpl,
+        projectionAttempts: 3,
+        projectionDelayMs: 7,
+        projectionSleep: async (milliseconds: number) => {
+          sleeps.push(milliseconds);
+        },
+      }),
     ).rejects.toThrow("Version PR author login changed");
+    expect(sleeps).toEqual([]);
     expect(fixture.requests.some((request) => request.method === "POST")).toBe(false);
   });
 
@@ -283,6 +343,11 @@ function admissionFixture(
         sha: headSha,
         tree: { sha: headTreeSha },
         parents: [{ sha: baseSha }],
+      });
+    if (url.pathname === `${prefix}/git/ref/heads/changeset-release/main`)
+      return response({
+        ref: "refs/heads/changeset-release/main",
+        object: { type: "commit", sha: headSha },
       });
     if (url.pathname === `${prefix}/compare/${baseSha}...${headSha}`)
       return response({
@@ -373,6 +438,13 @@ function checksFixture() {
       return response(mainRef());
     if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}`)
       return response(versionPull());
+    if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/changeset-release/main`)
+      return response({
+        ref: "refs/heads/changeset-release/main",
+        object: { type: "commit", sha: headSha },
+      });
+    if (method === "GET" && url.pathname === `${prefix}/git/commits/${headSha}`)
+      return response({ sha: headSha, parents: [{ sha: baseSha }] });
     if (method === "GET" && url.pathname === `${prefix}/commits/${headSha}/check-runs`)
       return response({
         total_count: checks.length,
@@ -555,7 +627,9 @@ describe("workflow contracts", () => {
 
   test("keeps admission least-privilege and candidate execution exact-head-bound", () => {
     expect(ci.permissions).toEqual({ contents: "read" });
-    expect(ci.jobs["automation-admission"].permissions).toEqual({
+    const admission = ci.jobs["automation-admission"];
+    const report = ci.jobs["automation-report"];
+    expect(admission.permissions).toEqual({
       actions: "read",
       checks: "write",
       contents: "read",
@@ -567,7 +641,33 @@ describe("workflow contracts", () => {
       expect(
         ci.jobs[jobName].steps.find((step: any) => step.uses === "actions/checkout@v6").with.ref,
       ).toContain("inputs.automation_head_sha");
-    expect(ci.jobs["automation-admission"].steps[0].with.ref).toBe("${{ github.sha }}");
+    expect(admission.steps[0].uses).toBe(
+      "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+    );
+    expect(admission.steps[0].with).toEqual(
+      expect.objectContaining({ ref: "${{ github.sha }}", "persist-credentials": false }),
+    );
+    expect(admission.steps.find((step: any) => step.name === "Set up Bun").uses).toBe(
+      "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
+    );
+    expect(report.steps[0].uses).toBe("actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10");
+    expect(report.steps[0].with["persist-credentials"]).toBe(false);
+    expect(admission.env).not.toHaveProperty("GITHUB_TOKEN");
+    expect(report.env).not.toHaveProperty("GITHUB_TOKEN");
+    expect(
+      admission.steps
+        .filter((step: any) => step.env?.GITHUB_TOKEN)
+        .map((step: any) => [step.name, step.env.GITHUB_TOKEN]),
+    ).toEqual([
+      ["Begin exact-head automation checks", "${{ github.token }}"],
+      ["Admit trusted dispatch and exact source tree", "${{ github.token }}"],
+      ["Complete exact-head source-admission check", "${{ github.token }}"],
+    ]);
+    expect(
+      report.steps
+        .filter((step: any) => step.env?.GITHUB_TOKEN)
+        .map((step: any) => [step.name, step.env.GITHUB_TOKEN]),
+    ).toEqual([["Complete exact-head automation CI check", "${{ github.token }}"]]);
   });
 
   test("binds explicit source-admission and aggregate reports to the exact head", () => {


### PR DESCRIPTION
Follow-up source/security hardening for OPE-88's bot-authored Version PR path.

## Exact candidate

- base / direct parent: `5baad6ddfa88b1704a9430bb2c588e94ed5d346e`
- head: `ef3dd6efc1e9a2a6c74d8b5470bd4647379c738a`
- tree: `e4a565e0f41ab3c0355121e323daa22943f39cec`
- stable patch ID: `370a3d394149bc9a28d1da2cdbc76e759fca9761`

## What changed

- pin `actions/checkout` and `oven-sh/setup-bun` to reviewed immutable upstream commit SHAs in the two `checks: write` jobs
- remove the job-wide explicit `GITHUB_TOKEN` environment and expose `${{ github.token }}` only to the trusted API-helper steps
- preserve `persist-credentials: false` and add static regressions for the privileged action/token boundary
- tolerate only bounded post-Changesets provider projection lag: 30 attempts, one second apart
- on every attempt, re-read current `main`; fail immediately if it moves
- before dispatch, require PR base/head, the direct `changeset-release/main` ref, and a single-parent projected head whose parent is exact current `main`
- terminally re-read main, PR base/head, direct branch ref, and topology immediately before the one exact-head dispatch
- keep author, repository/fork, branch, state, draft, commit/file count, and other identity violations immediate and fail closed

## Live provenance path

PR #569 introduced scoped `${{ github.token }}` Version PR creation and merged as `29c17b05488f7c146c34dddcd533f1eb882b63b8`. The first organic Release run, `29997621063`, regenerated Version PR #571 but failed at `Dispatch exact-head Version PR CI` with `Version PR base SHA changed`, demonstrating a bounded GitHub projection race rather than an invalid generated commit.

PR #573 added the bounded convergence behavior and merged as `e16995c45ec520104e35a61c6daa3277c080202d`. Organic Release run `29999424965` then succeeded, and its trusted exact-head workflow-dispatch CI run `29999682165` succeeded.

The resulting Version PR #571 proves the intended distinct-author path:

- native PR author: `github-actions[bot]` (GitHub ID `41898282`)
- exact head: `a96e8460d8d7ba1c1ef154dfbf105302e95c90d3`
- native trusted-human approval: review `4763351920`, submitted by `jorgensandhaug` against that exact head
- signed two-parent merge: `b1d17b683a668a7c0247cab38a19102ed3083e1d`, tree `5a769c006e18385454599b018a4f8f064a6e9aaa`
- post-merge Release run `30000960073`: success; publish/image promotion correctly skipped

This preserves GitHub's `GITHUB_TOKEN` event-suppression boundary: the base-owned helper explicitly dispatches trusted CI only after exact identity/topology convergence; it does not depend on an untrusted PR event firing.

## Main-delta compatibility

The candidate's three validated blobs remained byte-identical through both legitimate main advances:

- `.github/workflows/ci.yml`: `7192d06be92781909c59e9058b12e747ef870ea1`
- `scripts/check-release-pr-automation.mjs`: `8420109a86279a80818ec8d079ec9b849c3e48a8`
- `scripts/check-release-pr-automation.test.ts`: `da604352a786cbb7b27171f0628eded498d6880e`

For #571 and #574, ancestry/path-overlap audits found zero overlap with these three paths; isolated no-commit synthetic merges had zero unmerged entries. The final #574 audit compared 14 main-delta paths with three candidate paths, produced exact synthetic tree `e4a565e0f41ab3c0355121e323daa22943f39cec`, and preserved stable patch ID `370a3d394149bc9a28d1da2cdbc76e759fca9761`.

## Validation

Previously completed against these exact three blob IDs:

- `bun test scripts/check-release-pr-automation.test.ts`: 18 passed, 0 failed, 66 expectations
- `bun x oxlint@1.73.0 --deny-warnings scripts/check-release-pr-automation.mjs scripts/check-release-pr-automation.test.ts`
- `bun x oxfmt@0.58.0 --check .github/workflows/ci.yml scripts/check-release-pr-automation.mjs scripts/check-release-pr-automation.test.ts`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- PyYAML workflow parse
- `git diff --check`

The recovered sandbox did not contain Bun, Node, or actionlint, so those local toolchain checks were not misleadingly claimed as rerun after rebase; blob identity proves the earlier results apply unchanged. Final-rebase `git diff --check` and PyYAML parsing of both workflows were rerun successfully.

Organic GitHub evidence on the final exact head:

- Source Admission run `30002148986`: success, attempt 1
- CI run `30002150320`: success, attempt 1

The older organic CI run `30000584343` also completed successfully on pre-rebase head `4008ba873e8c25b22d331054935c22513d2acb4e`; the three tested blobs are identical to the final head.

## Operational dependency and boundary

Repository Actions settings currently read `default_workflow_permissions: write` and `can_approve_pull_request_reviews: true`. Scoped `${{ github.token }}` Version PR creation depends on the repository continuing to grant the workflow its declared write capability. The workflow does not self-approve: private ordinary-release provenance still requires a distinct trusted human's native exact-head pre-merge approval.

No approval, merge, manual workflow dispatch/rerun/cancellation, release, deploy, or ruleset mutation was performed by this repair lane.
