### PR TITLE
fix(release): wait for Version PR projection convergence

### DIFF
--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -31,6 +31,10 @@ export const RELEASE_AUTOMATION_CONTRACT = Object.freeze({
 const shaPattern = /^[0-9a-f]{40}$/;
 const positiveIntegerPattern = /^[1-9][0-9]*$/;
 const decisiveReviewStates = new Set(["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]);
+const retryableVersionProjectionErrors = new Set([
+  "Version PR base SHA changed",
+  "Version PR head SHA changed",
+]);
 const maximumPages = 30;
 const recordsPerPage = 100;
 
@@ -279,6 +283,42 @@ async function terminalVersionIdentity(api, context) {
   return pull;
 }
 
+async function convergedVersionHeadSha(api, context, options = {}) {
+  const attempts = options.attempts ?? 30;
+  const delayMs = options.delayMs ?? 1_000;
+  const sleep =
+    options.sleep ??
+    ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  invariant(
+    Number.isSafeInteger(attempts) && attempts > 0,
+    "Version PR projection attempts are invalid",
+  );
+  invariant(
+    Number.isSafeInteger(delayMs) && delayMs >= 0,
+    "Version PR projection delay is invalid",
+  );
+  invariant(typeof sleep === "function", "Version PR projection sleep is invalid");
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const [main, pull] = await Promise.all([
+      api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
+      api.get(repositoryPath(`/pulls/${context.prNumber}`)),
+    ]);
+    // A moving main is never eventual-consistency lag. Fail immediately instead
+    // of waiting against a source run that is no longer current.
+    assertMainRef(main, context.baseSha);
+    try {
+      return assertVersionPull(pull, context);
+    } catch (error) {
+      const retryable =
+        error instanceof Error && retryableVersionProjectionErrors.has(error.message);
+      if (!retryable || attempt === attempts) throw error;
+      await sleep(delayMs);
+    }
+  }
+  throw new Error("Version PR projection did not converge");
+}
+
 export async function validateVersionPrDispatch(options = {}) {
   const env = options.env ?? process.env;
   const logger = options.logger ?? console;
@@ -288,14 +328,20 @@ export async function validateVersionPrDispatch(options = {}) {
     "Version PR number",
   );
   const api = githubClient(options.fetchImpl ?? globalThis.fetch, context.token);
-  const [repository, main, pull] = await Promise.all([
-    api.get(repositoryPath("")),
-    api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
-    api.get(repositoryPath(`/pulls/${prNumber}`)),
-  ]);
+  const repository = await api.get(repositoryPath(""));
   assertRepository(repository);
-  assertMainRef(main, context.sha);
-  const headSha = assertVersionPull(pull, { number: prNumber, baseSha: context.sha });
+  // changesets/action can finish updating the branch before GitHub's PR
+  // projection reflects the new base/head pair. Wait only for those two exact
+  // projection fields; every identity or ownership mismatch still fails fast.
+  const headSha = await convergedVersionHeadSha(
+    api,
+    { prNumber, baseSha: context.sha },
+    {
+      attempts: options.projectionAttempts,
+      delayMs: options.projectionDelayMs,
+      sleep: options.projectionSleep,
+    },
+  );
 
   await terminalVersionIdentity(api, {
     prNumber,

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -127,9 +127,11 @@ function dispatchFixture(
     author?: Record<string, unknown>;
     headRepository?: string;
     mainSha?: string;
+    stalePullReads?: number;
   } = {},
 ) {
   const requests: RequestRecord[] = [];
+  let pullReads = 0;
   async function fetchImpl(input: string | URL | Request, init?: RequestInit) {
     const url = new URL(String(input));
     const method = init?.method ?? "GET";
@@ -139,10 +141,16 @@ function dispatchFixture(
     if (method === "GET" && url.pathname === prefix) return response(repository());
     if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/main`)
       return response(mainRef(options.mainSha));
-    if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}`)
+    if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}`) {
+      pullReads += 1;
       return response(
-        versionPull({ author: options.author, headRepository: options.headRepository }),
+        versionPull({
+          author: options.author,
+          base: pullReads <= (options.stalePullReads ?? 0) ? "a".repeat(40) : baseSha,
+          headRepository: options.headRepository,
+        }),
       );
+    }
     if (method === "POST" && url.pathname === `${prefix}/actions/workflows/ci.yml/dispatches`)
       return response(null, 204);
     return response({ message: `unexpected ${method} ${url.pathname}` }, 404);
@@ -170,6 +178,41 @@ describe("Version PR dispatch identity", () => {
         source_release_run_attempt: String(runAttempt),
       },
     });
+  });
+
+  test("waits for the exact Version PR base projection before dispatching", async () => {
+    const fixture = dispatchFixture({ stalePullReads: 1 });
+    const sleeps: number[] = [];
+    const result = await validateVersionPrDispatch({
+      env: releasePushEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+      projectionAttempts: 2,
+      projectionDelayMs: 7,
+      projectionSleep: async (milliseconds: number) => {
+        sleeps.push(milliseconds);
+      },
+    });
+    expect(result).toEqual({ prNumber: pullNumber, headSha, baseSha });
+    expect(sleeps).toEqual([7]);
+    expect(
+      fixture.requests.filter((request) => request.path.endsWith(`/pulls/${pullNumber}`)),
+    ).toHaveLength(3);
+    expect(fixture.requests.filter((request) => request.method === "POST")).toHaveLength(1);
+  });
+
+  test("fails closed when the Version PR projection never converges", async () => {
+    const fixture = dispatchFixture({ stalePullReads: 3 });
+    await expect(
+      validateVersionPrDispatch({
+        env: releasePushEnv(),
+        fetchImpl: fixture.fetchImpl,
+        projectionAttempts: 2,
+        projectionDelayMs: 0,
+        projectionSleep: async () => {},
+      }),
+    ).rejects.toThrow("Version PR base SHA changed");
+    expect(fixture.requests.some((request) => request.method === "POST")).toBe(false);
   });
 
   test("rejects a human-authored Version PR without dispatching", async () => {


### PR DESCRIPTION
## Summary
- tolerate bounded GitHub PR base/head projection lag immediately after `changesets/action` updates the Version PR
- re-read the exact current `main` on every attempt and fail immediately if it moves
- continue failing immediately for author, repository, fork, branch, and ownership drift
- prove convergence and fail-closed exhaustion with deterministic tests

## Production evidence
Release run 29997621063 generated the correct bot head for #571, then failed because the first PR projection read still exposed the previous base SHA. The provider projection converged moments later without another write.

## Validation
- `bun test scripts/check-release-pr-automation.test.ts` (17 pass)
- `bun run typecheck` (22 projects clean)
- `bunx oxfmt --check scripts/check-release-pr-automation.mjs scripts/check-release-pr-automation.test.ts`
- UBS triaged: only public SHA/protocol comparisons, placeholder fixture tokens, controlled mock JSON parsing, and intentional fail-closed promise propagation; no actionable finding.