### PR TITLE
fix(release): follow immutable asset redirects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,6 +302,7 @@ jobs:
           mkdir -p evidence
           curl \
             --fail \
+            --location \
             --silent \
             --show-error \
             --proto '=https' \
@@ -313,6 +314,7 @@ jobs:
             "$ACCEPTANCE_BUNDLE_URL"
           curl \
             --fail \
+            --location \
             --silent \
             --show-error \
             --proto '=https' \
@@ -356,6 +358,7 @@ jobs:
           mkdir -p evidence
           curl \
             --fail \
+            --location \
             --silent \
             --show-error \
             --proto '=https' \
@@ -589,6 +592,7 @@ jobs:
           mkdir -p evidence
           curl \
             --fail \
+            --location \
             --silent \
             --show-error \
             --proto '=https' \

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -692,4 +692,8 @@ describe("workflow contracts", () => {
     expect(releaseText).toContain("bun run build:packages");
     expect(releaseText).toContain("bun scripts/publish-closure-guard.ts");
   });
+
+  test("follows immutable release-asset redirects before hashing", () => {
+    expect(releaseText.match(/--location/g)).toHaveLength(4);
+  });
 });


### PR DESCRIPTION
GitHub release assets redirect to object storage. Follow those redirects before hashing candidate and acceptance receipts; otherwise the workflow hashes the redirect body and fails every release.