### PR TITLE
fix(release): verify public image visibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -671,20 +671,13 @@ jobs:
             done
           done
 
-      - name: Publish official images for anonymous pull
+      - name: Verify official images support anonymous pull
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ steps.meta.outputs.version }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
           org="$(printf '%s' "$REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
-          for role in api worker web relay sandbox; do
-            gh api \
-              --method PATCH \
-              "/orgs/${REPOSITORY_OWNER}/packages/container/opengeni-${role}" \
-              -f visibility=public
-          done
 
           # Remove the publishing credential before proving the documented
           # public-consumer path. Registry visibility can take a few seconds to

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -36,10 +36,10 @@ describe("release image workflow contract", () => {
     expect(finalJob).toContain("--prefer-index=false");
     expect(finalJob).toContain("evidence/release-candidate.json");
     expect(finalJob).toContain("bun scripts/release-bom.ts");
-    expect(finalJob).toContain("Publish official images for anonymous pull");
-    expect(finalJob).toContain("-f visibility=public");
+    expect(finalJob).toContain("Verify official images support anonymous pull");
     expect(finalJob).toContain("docker logout ghcr.io");
     expect(finalJob).toContain("docker buildx imagetools inspect");
+    expect(finalJob).not.toContain("--method PATCH");
     expect(finalJob).not.toContain("docker/build-push-action");
     expect(finalJob).not.toContain("docker build ");
     expect(finalJob).not.toContain("bake-agent.sh");


### PR DESCRIPTION
Keep GHCR package visibility as an explicit one-time package-admin setting and make the release workflow verification-only. After manifest promotion, the job logs out and fails closed unless every 0.20.0 release image resolves anonymously to the accepted candidate digest.

This removes the unsupported package-visibility REST mutation that failed release run 30045067471 while retaining the public-consumer proof.

Verification:
- `bun test scripts/release-image-workflow-contract.test.ts`
- release workflow YAML parse
- `git diff --check`