### PR TITLE
fix(release): require live acceptance before publication

### DIFF
--- a/.changeset/steady-release-contract.md
+++ b/.changeset/steady-release-contract.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/config": patch
+---
+
+Cut a release checkpoint that requires staging, production, and the complete
+72-hour canary evidence chain before public package and image publication.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,9 @@ name: Release
 
 # A push to main may open/update the changesets Version PR, but it can NEVER
 # publish. Publication is a separate, explicit workflow_dispatch after the
-# exact source revision has passed either the normal staging/production canary
-# path or the explicit maintainer fast path. The fast path still requires an
-# immutable candidate, exact package identity, and the complete deterministic
-# package gates; it skips only the live environment soak.
+# exact source revision has passed staging, production, and the production
+# canary window described in docs/workbench-acceptance.md. The dispatch is bound
+# to the selected git ref and records the retained acceptance evidence.
 #
 # Release images are built once by release-candidate.yml before staging. The
 # final GHCR job only promotes the exact accepted manifests to release tags and
@@ -21,6 +20,10 @@ name: Release
 #      and approve pull requests". The scoped per-run GITHUB_TOKEN deliberately
 #      authors Version PRs as github-actions[bot], leaving exact-head approval to
 #      a distinct trusted human reviewer.
+#   4. Set the api, worker, web, relay, and sandbox GHCR container packages to
+#      Public once in each package's settings. GitHub has no supported REST API
+#      for changing package visibility; the workflow verifies anonymous access
+#      after promotion and fails closed while any package remains private.
 #   - GHCR image publishing needs no extra secret (built-in GITHUB_TOKEN) and
 #     runs only when a release actually publishes.
 
@@ -31,7 +34,7 @@ on:
   workflow_dispatch:
     inputs:
       source_sha:
-        description: Exact 40-character release source SHA.
+        description: Exact 40-character source SHA that passed acceptance; dispatch this workflow from that same ref.
         required: true
         type: string
       expected_packages:
@@ -48,32 +51,27 @@ on:
         type: string
       staging_evidence_url:
         description: Retained staging acceptance/soak evidence URL for this exact SHA and image digests.
-        required: false
+        required: true
         type: string
       production_evidence_url:
         description: Retained production promotion and immediate acceptance evidence URL.
-        required: false
+        required: true
         type: string
       production_canary_evidence_url:
         description: Retained 72-hour zero-failure production canary evidence URL.
-        required: false
+        required: true
         type: string
       acceptance_bundle_url:
         description: Direct HTTPS URL for the sanitized machine-readable acceptance bundle.
-        required: false
+        required: true
         type: string
       acceptance_bundle_sha256:
         description: SHA-256 of the exact bytes downloaded from acceptance_bundle_url.
-        required: false
+        required: true
         type: string
       confirm_zero_gaps:
         description: Confirm zero known defects, skipped checks, failed/late canary cycles, and unverified acceptance rows.
-        required: false
-        default: false
-        type: boolean
-      maintainer_fast_path:
-        description: Publish an exact immutable candidate after deterministic gates without the live environment soak.
-        required: false
+        required: true
         default: false
         type: boolean
 
@@ -206,7 +204,6 @@ jobs:
           CANDIDATE_RECEIPT_URL: ${{ inputs.candidate_receipt_url }}
           CANDIDATE_RECEIPT_SHA256: ${{ inputs.candidate_receipt_sha256 }}
           CONFIRM_ZERO_GAPS: ${{ inputs.confirm_zero_gaps }}
-          MAINTAINER_FAST_PATH: ${{ inputs.maintainer_fast_path }}
         run: |
           set -euo pipefail
           [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
@@ -217,53 +214,46 @@ jobs:
             echo "checked-out source does not match source_sha" >&2
             exit 1
           }
+          [ "$GITHUB_SHA" = "$SOURCE_SHA" ] || {
+            echo "dispatch ref must resolve to source_sha; select the pinned release-candidate ref" >&2
+            exit 1
+          }
           git fetch --no-tags origin main
           git merge-base --is-ancestor "$SOURCE_SHA" origin/main || {
             echo "source_sha must be reachable from origin/main" >&2
+            exit 1
+          }
+          [ "$CONFIRM_ZERO_GAPS" = "true" ] || {
+            echo "confirm_zero_gaps must be explicitly true" >&2
+            exit 1
+          }
+          [[ "$ACCEPTANCE_BUNDLE_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "acceptance_bundle_sha256 must be a lowercase SHA-256" >&2
             exit 1
           }
           [[ "$CANDIDATE_RECEIPT_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
             echo "candidate_receipt_sha256 must be a lowercase SHA-256" >&2
             exit 1
           }
+          [[ "$ACCEPTANCE_BUNDLE_URL" != *\?* && "$ACCEPTANCE_BUNDLE_URL" != *\#* ]] || {
+            echo "acceptance_bundle_url must be a stable retained URL without a query or fragment" >&2
+            exit 1
+          }
           [[ "$CANDIDATE_RECEIPT_URL" != *\?* && "$CANDIDATE_RECEIPT_URL" != *\#* ]] || {
             echo "candidate_receipt_url must be a stable retained URL without a query or fragment" >&2
             exit 1
           }
-          for value in "$CANDIDATE_RECEIPT_URL"; do
+          for value in \
+            "$CANDIDATE_RECEIPT_URL" \
+            "$STAGING_EVIDENCE_URL" \
+            "$PRODUCTION_EVIDENCE_URL" \
+            "$PRODUCTION_CANARY_EVIDENCE_URL" \
+            "$ACCEPTANCE_BUNDLE_URL"; do
             [[ "$value" =~ ^https://[^[:space:]]+$ ]] || {
-              echo "candidate receipt URL must be absolute HTTPS" >&2
+              echo "every evidence URL must be an absolute HTTPS URL" >&2
               exit 1
             }
           done
-          if [ "$MAINTAINER_FAST_PATH" != "true" ]; then
-            [ "$GITHUB_SHA" = "$SOURCE_SHA" ] || {
-              echo "normal release dispatch ref must resolve to source_sha" >&2
-              exit 1
-            }
-            [ "$CONFIRM_ZERO_GAPS" = "true" ] || {
-              echo "confirm_zero_gaps must be explicitly true" >&2
-              exit 1
-            }
-            [[ "$ACCEPTANCE_BUNDLE_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
-              echo "acceptance_bundle_sha256 must be a lowercase SHA-256" >&2
-              exit 1
-            }
-            [[ "$ACCEPTANCE_BUNDLE_URL" != *\?* && "$ACCEPTANCE_BUNDLE_URL" != *\#* ]] || {
-              echo "acceptance_bundle_url must be a stable retained URL" >&2
-              exit 1
-            }
-            for value in \
-              "$STAGING_EVIDENCE_URL" \
-              "$PRODUCTION_EVIDENCE_URL" \
-              "$PRODUCTION_CANARY_EVIDENCE_URL" \
-              "$ACCEPTANCE_BUNDLE_URL"; do
-              [[ "$value" =~ ^https://[^[:space:]]+$ ]] || {
-                echo "every acceptance URL must be absolute HTTPS" >&2
-                exit 1
-              }
-            done
-          fi
           if find .changeset -maxdepth 1 -type f -name '*.md' ! -name README.md -print -quit | grep -q .; then
             echo "pending changesets remain; merge the generated Version PR before release acceptance" >&2
             exit 1
@@ -271,7 +261,6 @@ jobs:
           echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Verify exact-head approval provenance
-        if: ${{ inputs.maintainer_fast_path != true }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ steps.preflight.outputs.source_sha }}
@@ -286,7 +275,6 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Download and validate the complete acceptance bundle
-        if: ${{ inputs.maintainer_fast_path != true }}
         env:
           SOURCE_SHA: ${{ steps.preflight.outputs.source_sha }}
           STAGING_EVIDENCE_URL: ${{ inputs.staging_evidence_url }}
@@ -346,39 +334,8 @@ jobs:
             --production-evidence-url "$PRODUCTION_EVIDENCE_URL" \
             --production-canary-evidence-url "$PRODUCTION_CANARY_EVIDENCE_URL"
 
-      - name: Download and validate the immutable release candidate
-        if: ${{ inputs.maintainer_fast_path == true }}
-        env:
-          SOURCE_SHA: ${{ steps.preflight.outputs.source_sha }}
-          CANDIDATE_RECEIPT_URL: ${{ inputs.candidate_receipt_url }}
-          CANDIDATE_RECEIPT_SHA256: ${{ inputs.candidate_receipt_sha256 }}
-          EXPECTED_PACKAGES: ${{ inputs.expected_packages }}
-        run: |
-          set -euo pipefail
-          mkdir -p evidence
-          curl \
-            --fail \
-            --location \
-            --silent \
-            --show-error \
-            --proto '=https' \
-            --connect-timeout 10 \
-            --max-time 120 \
-            --retry 2 \
-            --retry-all-errors \
-            --output evidence/release-candidate.json \
-            "$CANDIDATE_RECEIPT_URL"
-          printf '%s  %s\n' \
-            "$CANDIDATE_RECEIPT_SHA256" \
-            evidence/release-candidate.json \
-            | sha256sum --check --strict -
-          bun scripts/release-candidate.ts \
-            --verify evidence/release-candidate.json \
-            --source-sha "$SOURCE_SHA" \
-            --expected-packages "$EXPECTED_PACKAGES"
-
       # Re-run deterministic package gates at the exact accepted source before
-      # bytes leave the repository. Live acceptance is bound above, not replaced.
+      # bytes leave the repository. Live acceptance is bound above.
       - name: Typecheck
         run: bun run typecheck
 
@@ -413,11 +370,9 @@ jobs:
           ACCEPTANCE_BUNDLE_SHA256: ${{ inputs.acceptance_bundle_sha256 }}
           CANDIDATE_RECEIPT_URL: ${{ inputs.candidate_receipt_url }}
           CANDIDATE_RECEIPT_SHA256: ${{ inputs.candidate_receipt_sha256 }}
-          MAINTAINER_FAST_PATH: ${{ inputs.maintainer_fast_path }}
         run: |
           jq -n \
             --arg sourceSha "$SOURCE_SHA" \
-            --arg fastPath "$MAINTAINER_FAST_PATH" \
             --arg stagingEvidenceUrl "$STAGING_EVIDENCE_URL" \
             --arg productionEvidenceUrl "$PRODUCTION_EVIDENCE_URL" \
             --arg productionCanaryEvidenceUrl "$PRODUCTION_CANARY_EVIDENCE_URL" \
@@ -430,15 +385,14 @@ jobs:
               schemaVersion: 1,
               sourceSha: $sourceSha,
               acceptance: {
-                mode: (if $fastPath == "true" then "maintainer-fast-path" else "production-canary" end),
                 candidateReceiptUrl: $candidateReceiptUrl,
                 candidateReceiptSha256: $candidateReceiptSha256,
-                stagingEvidenceUrl: (if $fastPath == "true" then null else $stagingEvidenceUrl end),
-                productionEvidenceUrl: (if $fastPath == "true" then null else $productionEvidenceUrl end),
-                productionCanaryEvidenceUrl: (if $fastPath == "true" then null else $productionCanaryEvidenceUrl end),
-                bundleUrl: (if $fastPath == "true" then null else $acceptanceBundleUrl end),
-                bundleSha256: (if $fastPath == "true" then null else $acceptanceBundleSha256 end),
-                zeroKnownDefectsAndGapsConfirmed: (if $fastPath == "true" then null else true end)
+                stagingEvidenceUrl: $stagingEvidenceUrl,
+                productionEvidenceUrl: $productionEvidenceUrl,
+                productionCanaryEvidenceUrl: $productionCanaryEvidenceUrl,
+                bundleUrl: $acceptanceBundleUrl,
+                bundleSha256: $acceptanceBundleSha256,
+                zeroKnownDefectsAndGapsConfirmed: true
               },
               packagePlan: $packagePlan[0]
             }' > evidence/verified-release-plan.json
@@ -496,7 +450,6 @@ jobs:
           ACCEPTANCE_BUNDLE_SHA256: ${{ inputs.acceptance_bundle_sha256 }}
           CANDIDATE_RECEIPT_URL: ${{ inputs.candidate_receipt_url }}
           CANDIDATE_RECEIPT_SHA256: ${{ inputs.candidate_receipt_sha256 }}
-          MAINTAINER_FAST_PATH: ${{ inputs.maintainer_fast_path }}
         run: |
           set -euo pipefail
           mkdir -p evidence
@@ -506,7 +459,6 @@ jobs:
             <<<"$BOM_PACKAGES" >/dev/null
           jq -n \
             --arg sourceSha "$SOURCE_SHA" \
-            --arg fastPath "$MAINTAINER_FAST_PATH" \
             --arg stagingEvidenceUrl "$STAGING_EVIDENCE_URL" \
             --arg productionEvidenceUrl "$PRODUCTION_EVIDENCE_URL" \
             --arg productionCanaryEvidenceUrl "$PRODUCTION_CANARY_EVIDENCE_URL" \
@@ -520,15 +472,14 @@ jobs:
               schemaVersion: 1,
               sourceSha: $sourceSha,
               acceptance: {
-                mode: (if $fastPath == "true" then "maintainer-fast-path" else "production-canary" end),
                 candidateReceiptUrl: $candidateReceiptUrl,
                 candidateReceiptSha256: $candidateReceiptSha256,
-                stagingEvidenceUrl: (if $fastPath == "true" then null else $stagingEvidenceUrl end),
-                productionEvidenceUrl: (if $fastPath == "true" then null else $productionEvidenceUrl end),
-                productionCanaryEvidenceUrl: (if $fastPath == "true" then null else $productionCanaryEvidenceUrl end),
-                bundleUrl: (if $fastPath == "true" then null else $acceptanceBundleUrl end),
-                bundleSha256: (if $fastPath == "true" then null else $acceptanceBundleSha256 end),
-                zeroKnownDefectsAndGapsConfirmed: (if $fastPath == "true" then null else true end)
+                stagingEvidenceUrl: $stagingEvidenceUrl,
+                productionEvidenceUrl: $productionEvidenceUrl,
+                productionCanaryEvidenceUrl: $productionCanaryEvidenceUrl,
+                bundleUrl: $acceptanceBundleUrl,
+                bundleSha256: $acceptanceBundleSha256,
+                zeroKnownDefectsAndGapsConfirmed: true
               },
               publishedPackages: $publishedPackages,
               bomPackages: $bomPackages

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -176,6 +176,15 @@ Each manifest is built at most once; retries reuse existing partial results.
 The immutable GitHub release tag `opengeni-candidate-<full-source-sha>` retains
 `release-candidate.json` plus its SHA-256 sidecar.
 
+Before the first public image release, an organization package administrator
+must set the `opengeni-api`, `opengeni-worker`, `opengeni-web`,
+`opengeni-relay`, and `opengeni-sandbox` container packages to **Public** in
+their GitHub package settings. GitHub does not expose a supported REST endpoint
+for changing package visibility. The release workflow therefore treats this as
+one-time operator setup: after promotion it removes its GHCR login and fails
+closed unless every public release tag resolves anonymously to the exact
+candidate digest.
+
 After staging, production, and the 72-hour canary have consumed those exact
 digests, public release is an explicit dispatch of
 `.github/workflows/release.yml` from a ref pinned to the accepted source SHA.

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -679,21 +679,19 @@ describe("workflow contracts", () => {
     expect(releaseText).toContain("verify-approved-merge");
   });
 
-  test("keeps the maintainer fast path explicit and evidence-honest", () => {
-    expect(releaseText).toContain("maintainer_fast_path:");
-    expect(releaseText).toContain("Download and validate the immutable release candidate");
-    expect(releaseText).toContain(
-      'mode: (if $fastPath == "true" then "maintainer-fast-path" else "production-canary" end)',
-    );
-    expect(releaseText).toContain(
-      'zeroKnownDefectsAndGapsConfirmed: (if $fastPath == "true" then null else true end)',
-    );
+  test("requires complete live acceptance before any publication", () => {
+    expect(releaseText).not.toContain("maintainer_fast_path");
+    expect(releaseText).not.toContain("maintainer-fast-path");
+    expect(releaseText).toContain("Download and validate the complete acceptance bundle");
+    expect(releaseText).toContain("bun scripts/verify-workbench-acceptance-bundle.ts");
+    expect(releaseText).toContain("confirm_zero_gaps must be explicitly true");
+    expect(releaseText).toContain("zeroKnownDefectsAndGapsConfirmed: true");
     expect(releaseText).toContain("bun run typecheck");
     expect(releaseText).toContain("bun run build:packages");
     expect(releaseText).toContain("bun scripts/publish-closure-guard.ts");
   });
 
   test("follows immutable release-asset redirects before hashing", () => {
-    expect(releaseText.match(/--location/g)).toHaveLength(4);
+    expect(releaseText.match(/--location/g)).toHaveLength(3);
   });
 });

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -39,6 +39,7 @@ describe("release image workflow contract", () => {
     expect(finalJob).toContain("Verify official images support anonymous pull");
     expect(finalJob).toContain("docker logout ghcr.io");
     expect(finalJob).toContain("docker buildx imagetools inspect");
+    expect(release).toContain("GitHub has no supported REST API");
     expect(finalJob).not.toContain("--method PATCH");
     expect(finalJob).not.toContain("docker/build-push-action");
     expect(finalJob).not.toContain("docker build ");


### PR DESCRIPTION
## Summary

- remove the release path that could publish before staging, production, and the 72-hour canary
- require exact-source approval and a complete retained acceptance bundle for every publication
- document and verify the one-time public GHCR package visibility prerequisite

## Validation

- `bun test scripts/check-release-pr-automation.test.ts scripts/release-image-workflow-contract.test.ts`
- `bun run typecheck`
- `bun scripts/check-docs-refs.ts`

A full local `bun run check` completed hygiene, all 22 typecheck projects, and a large passing portion of the unit suite before the host terminated it with SIGTERM; protected CI is the authoritative complete gate.