### PR TITLE
fix(db): preserve private turn instructions across queue edits

### DIFF
--- a/.changeset/preserve-private-turn-instructions.md
+++ b/.changeset/preserve-private-turn-instructions.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Preserve private per-turn instructions when queue-edited prompts are resubmitted.

--- a/packages/db/src/session-queue-commands.ts
+++ b/packages/db/src/session-queue-commands.ts
@@ -39,7 +39,8 @@ export type QueueCommandConflictCode =
   | "QUEUE_ANCHOR_CHANGED"
   | "PROMPT_CHANGED"
   | "DRAFT_CHANGED"
-  | "DRAFT_NOT_EMPTY";
+  | "DRAFT_NOT_EMPTY"
+  | "EDIT_SOURCE_CHANGED";
 
 export class QueueCommandConflictError extends Error {
   readonly name = "QueueCommandConflictError";
@@ -1293,6 +1294,52 @@ export async function submitHumanPromptInTransaction(
     }
   }
 
+  let editedSourceTurn: QueuedTurnRow | undefined;
+  let editedSourceTurnInstructions: string | null | undefined;
+  if (draft?.sourceTurnId) {
+    const sourceLocks = await lockSessionEventWriteRows(db, {
+      workspaceId: input.workspaceId,
+      controlLock: "already_locked",
+      workspaceLock: "already_locked",
+      turnIds: [draft.sourceTurnId],
+    });
+    const sourceTurn = sourceLocks.turns[0];
+    const sourceTurnVersion = draft.sourceTurnVersion;
+    const sourceMetadata = sourceTurn?.metadata ?? {};
+    const sourceIsExactWithdrawnRevision =
+      sourceTurn !== undefined &&
+      sourceTurn.accountId === input.accountId &&
+      sourceTurn.workspaceId === input.workspaceId &&
+      sourceTurn.sessionId === input.sessionId &&
+      (sourceTurn.source === "user" || sourceTurn.source === "api") &&
+      sourceTurn.status === "withdrawn_for_edit" &&
+      sourceTurnVersion !== null &&
+      sourceTurn.version === sourceTurnVersion + 1 &&
+      sourceTurn.cancelledBy === input.subjectId &&
+      sourceTurn.cancelReason === "withdrawn_for_edit" &&
+      sourceTurn.activeAttemptId === null &&
+      sourceMetadata.delivery !== "steer";
+    if (!sourceIsExactWithdrawnRevision) {
+      throw new QueueCommandConflictError(
+        "EDIT_SOURCE_CHANGED",
+        "Edited prompt source changed or is no longer withdrawn for edit",
+        {
+          queueVersion: session.queueVersion,
+          draftRevision: draft.revision,
+          ...(sourceTurn ? { turnVersion: sourceTurn.version } : {}),
+        },
+      );
+    }
+    // This is the sole private-instruction source for an edited replacement.
+    // It is deliberately held separately from the public draft and event
+    // projections below. The public draft is expected to differ after editing;
+    // source identity is fenced by its exact withdrawn row version, not by
+    // comparing the replacement content with the old prompt. A client-supplied
+    // instruction value must never override the private source value.
+    editedSourceTurn = sourceTurn;
+    editedSourceTurnInstructions = sourceTurn.turnInstructions ?? null;
+  }
+
   for (const update of input.mcpCredentialUpdates ?? []) {
     const [server] = await db
       .update(schema.sessionMcpServers)
@@ -1315,22 +1362,7 @@ export async function submitHumanPromptInTransaction(
   const now = new Date();
   let frozenInitiator: FrozenTurnInitiator;
   if (input.delivery === "send" && draft?.sourceTurnId) {
-    const [sourceTurn] = await db
-      .select({
-        sessionId: schema.sessionTurns.sessionId,
-        initiatorKind: schema.sessionTurns.initiatorKind,
-        initiatorSubjectId: schema.sessionTurns.initiatorSubjectId,
-        initiatorContext: schema.sessionTurns.initiatorContext,
-      })
-      .from(schema.sessionTurns)
-      .where(
-        and(
-          eq(schema.sessionTurns.workspaceId, input.workspaceId),
-          eq(schema.sessionTurns.sessionId, input.sessionId),
-          eq(schema.sessionTurns.id, draft.sourceTurnId),
-        ),
-      )
-      .limit(1);
+    const sourceTurn = editedSourceTurn;
     if (!sourceTurn) {
       throw new SessionControlInvariantError("Edited prompt source turn is missing");
     }
@@ -1389,7 +1421,10 @@ export async function submitHumanPromptInTransaction(
       source: input.source,
       position: input.delivery === "steer" ? 0 : existingQueued.length + 1,
       prompt: input.text,
-      turnInstructions: input.turnInstructions ?? null,
+      turnInstructions:
+        editedSourceTurnInstructions !== undefined
+          ? editedSourceTurnInstructions
+          : (input.turnInstructions ?? null),
       resources: input.resources,
       tools: input.tools,
       model: input.model ?? session.model,

--- a/packages/db/test/queue-mutations.test.ts
+++ b/packages/db/test/queue-mutations.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { ReasoningEffort, ResourceRef, ToolRef } from "@opengeni/contracts";
 import { and, asc, eq, inArray } from "drizzle-orm";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
 import {
@@ -10,12 +11,15 @@ import {
   deleteSessionQueueItemInTransaction,
   editQueuedTurnInTransaction,
   evaluateSessionControl,
+  getSessionTurn,
   getSessionQueueSnapshot,
+  listSessionTurns,
   markSessionAttemptQuiesced,
   moveQueuedTurnInTransaction,
   mutateSessionControlInTransaction,
   peekSessionWork,
   QueueCommandConflictError,
+  saveComposerDraftInTransaction,
   SessionCommandIdempotencyError,
   SessionControlConflictError,
   settleSessionAttemptInterruptions,
@@ -256,6 +260,229 @@ describe("canonical queue commands", () => {
         .where(eq(schema.sessionTurns.id, value.turns[1]!.id)),
     );
     expect(withdrawn).toEqual({ status: "withdrawn_for_edit", reason: "withdrawn_for_edit" });
+  });
+
+  test("Edit then Send copies private source instructions without exposing them or accepting an override", async () => {
+    const value = await fixture();
+    const privateInstructions = "host-only record context: source-42";
+    await withWorkspaceRls(client.db, value.grant.workspaceId!, async (db) => {
+      await db
+        .update(schema.sessionTurns)
+        .set({ turnInstructions: privateInstructions })
+        .where(eq(schema.sessionTurns.id, value.turns[1]!.id));
+    });
+    const edited = await withWorkspaceSubjectRls(
+      client.db,
+      value.grant.workspaceId!,
+      value.grant.subjectId,
+      (db) =>
+        db.transaction((tx) =>
+          editQueuedTurnInTransaction(tx as typeof db, {
+            accountId: value.grant.accountId,
+            workspaceId: value.grant.workspaceId!,
+            sessionId: value.session.id,
+            turnId: value.turns[1]!.id,
+            subjectId: value.grant.subjectId,
+            expectedTurnVersion: value.turns[1]!.version,
+            expectedDraftRevision: 0,
+            replaceDraft: false,
+            actor: value.actor,
+            operationKey: crypto.randomUUID(),
+          }),
+        ),
+    );
+    const savedEdit = await withWorkspaceSubjectRls(
+      client.db,
+      value.grant.workspaceId!,
+      value.grant.subjectId,
+      (db) =>
+        db.transaction((tx) =>
+          saveComposerDraftInTransaction(tx as typeof db, {
+            accountId: value.grant.accountId,
+            workspaceId: value.grant.workspaceId!,
+            sessionId: value.session.id,
+            subjectId: value.grant.subjectId,
+            expectedRevision: edited.draft.revision,
+            text: "edited prompt with replacement content",
+            resources: [],
+            tools: [],
+            model: "edited-model",
+            reasoningEffort: "medium",
+          }),
+        ),
+    );
+    const command = {
+      accountId: value.grant.accountId,
+      workspaceId: value.grant.workspaceId!,
+      sessionId: value.session.id,
+      subjectId: value.grant.subjectId,
+      actor: value.actor,
+      operationKey: crypto.randomUUID(),
+      delivery: "send" as const,
+      expectedDraftRevision: savedEdit.revision,
+      text: savedEdit.text,
+      resources: savedEdit.resources as ResourceRef[],
+      tools: savedEdit.tools as ToolRef[],
+      model: savedEdit.model,
+      reasoningEffort: savedEdit.reasoningEffort as ReasoningEffort,
+      reasoningEffortFallback: "medium" as const,
+      source: "user" as const,
+      turnInstructions: "client must not replace source instructions",
+    };
+    const submitted = await withWorkspaceSubjectRls(
+      client.db,
+      value.grant.workspaceId!,
+      value.grant.subjectId,
+      (db) => db.transaction((tx) => submitHumanPromptInTransaction(tx as typeof db, command)),
+    );
+    const [stored] = await withWorkspaceRls(client.db, value.grant.workspaceId!, (db) =>
+      db
+        .select({
+          turnInstructions: schema.sessionTurns.turnInstructions,
+          prompt: schema.sessionTurns.prompt,
+        })
+        .from(schema.sessionTurns)
+        .where(eq(schema.sessionTurns.id, submitted.turnId)),
+    );
+    expect(stored).toEqual({
+      turnInstructions: privateInstructions,
+      prompt: savedEdit.text,
+    });
+
+    const publicTurn = await getSessionTurn(client.db, value.grant.workspaceId!, submitted.turnId);
+    expect(publicTurn).not.toHaveProperty("turnInstructions");
+    const publicTurns = await listSessionTurns(
+      client.db,
+      value.grant.workspaceId!,
+      value.session.id,
+    );
+    expect(publicTurns.find((turn) => turn.id === submitted.turnId)).not.toHaveProperty(
+      "turnInstructions",
+    );
+    const queue = await getSessionQueueSnapshot(
+      client.db,
+      value.grant.workspaceId!,
+      value.session.id,
+    );
+    expect(queue?.items.find((turn) => turn.id === submitted.turnId)).not.toHaveProperty(
+      "turnInstructions",
+    );
+    const events = await storedEvents(value.grant.workspaceId!, submitted.eventIds);
+    expect(
+      events.every((event) => !JSON.stringify(event.payload).includes(privateInstructions)),
+    ).toBe(true);
+    expect(
+      events.every(
+        (event) =>
+          typeof event.payload !== "object" ||
+          event.payload === null ||
+          !Object.hasOwn(event.payload, "turnInstructions"),
+      ),
+    ).toBe(true);
+
+    const replay = await withWorkspaceSubjectRls(
+      client.db,
+      value.grant.workspaceId!,
+      value.grant.subjectId,
+      (db) => db.transaction((tx) => submitHumanPromptInTransaction(tx as typeof db, command)),
+    );
+    expect(replay).toMatchObject({ replay: true, turnId: submitted.turnId });
+  });
+
+  test("an edited source must still be the exact withdrawn revision, while direct Send keeps explicit instructions", async () => {
+    const value = await fixture();
+    const direct = await withWorkspaceSubjectRls(
+      client.db,
+      value.grant.workspaceId!,
+      value.grant.subjectId,
+      (db) =>
+        db.transaction((tx) =>
+          submitHumanPromptInTransaction(tx as typeof db, {
+            accountId: value.grant.accountId,
+            workspaceId: value.grant.workspaceId!,
+            sessionId: value.session.id,
+            subjectId: value.grant.subjectId,
+            actor: value.actor,
+            operationKey: crypto.randomUUID(),
+            delivery: "send",
+            text: "direct prompt",
+            turnInstructions: "direct explicit context",
+            resources: [],
+            tools: [],
+            reasoningEffortFallback: "medium",
+            source: "user",
+          }),
+        ),
+    );
+    const [directStored] = await withWorkspaceRls(client.db, value.grant.workspaceId!, (db) =>
+      db
+        .select({ turnInstructions: schema.sessionTurns.turnInstructions })
+        .from(schema.sessionTurns)
+        .where(eq(schema.sessionTurns.id, direct.turnId)),
+    );
+    expect(directStored?.turnInstructions).toBe("direct explicit context");
+
+    const edited = await withWorkspaceSubjectRls(
+      client.db,
+      value.grant.workspaceId!,
+      value.grant.subjectId,
+      (db) =>
+        db.transaction((tx) =>
+          editQueuedTurnInTransaction(tx as typeof db, {
+            accountId: value.grant.accountId,
+            workspaceId: value.grant.workspaceId!,
+            sessionId: value.session.id,
+            turnId: value.turns[1]!.id,
+            subjectId: value.grant.subjectId,
+            expectedTurnVersion: value.turns[1]!.version,
+            expectedDraftRevision: 0,
+            replaceDraft: false,
+            actor: value.actor,
+            operationKey: crypto.randomUUID(),
+          }),
+        ),
+    );
+    await withWorkspaceRls(client.db, value.grant.workspaceId!, async (db) => {
+      await db
+        .update(schema.sessionTurns)
+        .set({ status: "queued" })
+        .where(eq(schema.sessionTurns.id, value.turns[1]!.id));
+    });
+    await expect(
+      withWorkspaceSubjectRls(client.db, value.grant.workspaceId!, value.grant.subjectId, (db) =>
+        db.transaction((tx) =>
+          submitHumanPromptInTransaction(tx as typeof db, {
+            accountId: value.grant.accountId,
+            workspaceId: value.grant.workspaceId!,
+            sessionId: value.session.id,
+            subjectId: value.grant.subjectId,
+            actor: value.actor,
+            operationKey: crypto.randomUUID(),
+            delivery: "send",
+            expectedDraftRevision: edited.draft.revision,
+            text: edited.draft.text,
+            resources: edited.draft.resources as ResourceRef[],
+            tools: edited.draft.tools as ToolRef[],
+            model: edited.draft.model,
+            reasoningEffort: edited.draft.reasoningEffort as ReasoningEffort,
+            reasoningEffortFallback: "medium",
+            source: "user",
+            turnInstructions: "must be ignored",
+          }),
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "EDIT_SOURCE_CHANGED" });
+    const [draft] = await withWorkspaceSubjectRls(
+      client.db,
+      value.grant.workspaceId!,
+      value.grant.subjectId,
+      (db) =>
+        db
+          .select({ revision: schema.composerDrafts.revision })
+          .from(schema.composerDrafts)
+          .where(eq(schema.composerDrafts.sessionId, value.session.id)),
+    );
+    expect(draft?.revision).toBe(edited.draft.revision);
   });
 
   test("Edit never overwrites a dirty draft without exact replacement consent", async () => {


### PR DESCRIPTION
## Summary
- preserve authoritative `turnInstructions` when a queued prompt is edited and resubmitted
- validate the exact withdrawn source under canonical row locks and reject changed/invalid sources
- keep private instructions out of drafts, public turn/queue projections, and durable event payloads; direct sends retain explicit instructions

## Validation
- `bun run typecheck` ✅
- `bun run format:check -- packages/db/src/session-queue-commands.ts packages/db/test/queue-mutations.test.ts` ✅
- `oxlint --deny-warnings` on changed files ✅
- `git diff --check` ✅
- focused real-PostgreSQL test attempted with `OPENGENI_REQUIRE_REAL_DB=1`, but this sandbox has no Docker executable, so the shared PostgreSQL harness could not start

Refs OPE-96

Commit: `fb68df0e832f8abdf4c6ee91629a3c20e28f8e68`
Tree: `d4969dda6ce0e41e16e790ad8d58bb882e73f851`