### PR TITLE
fix(release): gate candidate receipts on public images

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -311,6 +311,39 @@ jobs:
           [ -z "$BUILT_DIGEST" ] || [ "$digest" = "$BUILT_DIGEST" ] || exit 1
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
+      - name: Verify candidate images support anonymous pull
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          API_DIGEST: ${{ steps.api.outputs.digest }}
+          WORKER_DIGEST: ${{ steps.worker.outputs.digest }}
+          WEB_DIGEST: ${{ steps.web.outputs.digest }}
+          RELAY_DIGEST: ${{ steps.relay.outputs.digest }}
+          SANDBOX_DIGEST: ${{ steps.sandbox.outputs.digest }}
+        run: |
+          set -euo pipefail
+          org="$(printf '%s' "$REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+
+          # Candidate receipts are public deployment authority. Drop the
+          # publishing credential before creating one so a private package can
+          # never produce a receipt that the ordinary release operator cannot
+          # consume.
+          docker logout ghcr.io
+          for role in api worker web relay sandbox; do
+            digest_var="$(printf '%s_DIGEST' "$role" | tr '[:lower:]' '[:upper:]')"
+            expected="${!digest_var}"
+            image="ghcr.io/${org}/opengeni-${role}@${expected}"
+            resolved=""
+            for attempt in 1 2 3 4 5; do
+              resolved="$(docker buildx imagetools inspect "$image" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+              [ "$resolved" = "$expected" ] && break
+              sleep "$((attempt * 2))"
+            done
+            [ "$resolved" = "$expected" ] || {
+              echo "anonymous candidate pull proof failed for ${image}: resolved ${resolved:-nothing}, expected ${expected}" >&2
+              exit 1
+            }
+          done
+
       - name: Write immutable candidate receipt
         id: receipt
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ name: Release
 #      a distinct trusted human reviewer.
 #   4. Set the api, worker, web, relay, and sandbox GHCR container packages to
 #      Public once in each package's settings. GitHub has no supported REST API
-#      for changing package visibility; the workflow verifies anonymous access
-#      after promotion and fails closed while any package remains private.
+#      for changing package visibility; candidate publication and final
+#      promotion both fail closed while any package remains private.
 #   - GHCR image publishing needs no extra secret (built-in GITHUB_TOKEN) and
 #     runs only when a release actually publishes.
 

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -25,6 +25,16 @@ describe("release image workflow contract", () => {
     expect(candidate).toContain("opengeni-candidate-${SOURCE_SHA}");
     expect(candidate).toContain("evidence/release-candidate.json");
     expect(candidate).toContain("cmp evidence/release-candidate.json");
+    const anonymousGate = candidate.indexOf("Verify candidate images support anonymous pull");
+    const receiptWrite = candidate.indexOf("Write immutable candidate receipt");
+    const receiptPublish = candidate.indexOf("Publish immutable source-SHA candidate receipt");
+    expect(anonymousGate).toBeGreaterThan(-1);
+    expect(anonymousGate).toBeLessThan(receiptWrite);
+    expect(anonymousGate).toBeLessThan(receiptPublish);
+    expect(candidate.slice(anonymousGate, receiptWrite)).toContain("docker logout ghcr.io");
+    expect(candidate.slice(anonymousGate, receiptWrite)).toContain(
+      "docker buildx imagetools inspect",
+    );
   });
 
   test("final release promotes accepted manifests and has no image build boundary", async () => {


### PR DESCRIPTION
## Summary

- prove every candidate image is anonymously pullable before writing or publishing release-candidate evidence
- fail closed while the one-time GHCR package visibility setup is incomplete
- pin the gate ordering in the release workflow contract test

## Verification

- `bun test scripts/release-candidate.test.ts scripts/release-image-workflow-contract.test.ts scripts/release-schema-contract.test.ts`
- actionlint on both edited workflows
- Prettier check
- UBS changed-file scan: 0 critical, 0 warning