### PR TITLE
fix(release): separate product version and harden embedded distribution

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -13,8 +13,9 @@ on:
         required: true
         type: string
       expected_packages:
-        description: Exact comma-separated package set intended for the evidence-bound npm release.
-        required: true
+        description: Exact comma-separated package set intended for npm publication; leave empty for an application-only release.
+        required: false
+        default: ""
         type: string
 
 concurrency:
@@ -111,11 +112,7 @@ jobs:
           SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
           set -euo pipefail
-          version="$(jq -er '((.packages | map(select(.name == "@opengeni/sdk"))) + (.packages | sort_by(.name)))[0].version' evidence/release-packages-plan.json)"
-          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]] || {
-            echo "resolved release version is not exact semver: $version" >&2
-            exit 1
-          }
+          version="$(bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml)"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "candidate_tag=candidate-$SOURCE_SHA" >> "$GITHUB_OUTPUT"
           echo "source_tree_sha=$(git rev-parse "$SOURCE_SHA^{tree}")" >> "$GITHUB_OUTPUT"
@@ -130,13 +127,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Refuse an occupied product release version
+        env:
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          for role in api worker web relay sandbox; do
+            ref="ghcr.io/cloudgeni-ai/opengeni-${role}:${RELEASE_VERSION}"
+            digest="$(bun scripts/resolve-optional-oci-manifest.ts "$ref")"
+            if [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "product release version ${RELEASE_VERSION} is already occupied by ${ref}" >&2
+              exit 1
+            fi
+          done
+          chart_ref="ghcr.io/cloudgeni-ai/charts/opengeni:${RELEASE_VERSION}"
+          chart_digest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
+          if [[ "$chart_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "product release version ${RELEASE_VERSION} is already occupied by ${chart_ref}" >&2
+            exit 1
+          fi
+
       - name: Resolve existing API candidate
         id: existing-api
         env:
           IMAGE_REF: ghcr.io/cloudgeni-ai/opengeni-api:${{ steps.meta.outputs.candidate_tag }}
         run: |
           set -euo pipefail
-          digest="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+          digest="$(bun scripts/resolve-optional-oci-manifest.ts "$IMAGE_REF")"
           if [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "digest=$digest" >> "$GITHUB_OUTPUT"
@@ -191,7 +208,7 @@ jobs:
           IMAGE_REF: ghcr.io/cloudgeni-ai/opengeni-worker:${{ steps.meta.outputs.candidate_tag }}
         run: |
           set -euo pipefail
-          digest="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+          digest="$(bun scripts/resolve-optional-oci-manifest.ts "$IMAGE_REF")"
           if [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -230,7 +247,7 @@ jobs:
           IMAGE_REF: ghcr.io/cloudgeni-ai/opengeni-web:${{ steps.meta.outputs.candidate_tag }}
         run: |
           set -euo pipefail
-          digest="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+          digest="$(bun scripts/resolve-optional-oci-manifest.ts "$IMAGE_REF")"
           if [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -270,7 +287,7 @@ jobs:
           IMAGE_REF: ghcr.io/cloudgeni-ai/opengeni-sandbox:${{ steps.meta.outputs.candidate_tag }}
         run: |
           set -euo pipefail
-          digest="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+          digest="$(bun scripts/resolve-optional-oci-manifest.ts "$IMAGE_REF")"
           if [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -306,7 +323,7 @@ jobs:
           IMAGE_REF: ghcr.io/cloudgeni-ai/opengeni-relay:${{ steps.meta.outputs.candidate_tag }}
         run: |
           set -euo pipefail
-          digest="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+          digest="$(bun scripts/resolve-optional-oci-manifest.ts "$IMAGE_REF")"
           if [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -13,15 +13,12 @@ on:
         required: true
         type: string
       expected_packages:
-        description: Exact comma-separated @opengeni package@version set.
-        required: true
+        description: Exact comma-separated @opengeni package@version set, or empty for an application-only release.
+        required: false
+        default: ""
         type: string
-      candidate_receipt_url:
-        description: Direct HTTPS URL for the immutable release-candidate.json asset.
-        required: true
-        type: string
-      candidate_receipt_sha256:
-        description: SHA-256 of the exact candidate receipt bytes.
+      candidate_run_id:
+        description: Completed run ID of the canonical release-candidate workflow for source_sha.
         required: true
         type: string
       confirm_distribution:
@@ -39,13 +36,14 @@ permissions:
 
 jobs:
   release:
-    name: Publish packages and promote exact images
+    name: Publish exact packages, chart, images, and BOM
     runs-on: ubuntu-latest
     if: ${{ vars.RELEASE_ENABLED == 'true' && inputs.confirm_distribution }}
     permissions:
       contents: write
       id-token: write
       packages: write
+      actions: read
     steps:
       - name: Check out evidence-bound source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -57,24 +55,23 @@ jobs:
       - name: Validate exact released source
         env:
           SOURCE_SHA: ${{ inputs.source_sha }}
-          CANDIDATE_RECEIPT_URL: ${{ inputs.candidate_receipt_url }}
-          CANDIDATE_RECEIPT_SHA256: ${{ inputs.candidate_receipt_sha256 }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
         run: |
           set -euo pipefail
           [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
             echo "source_sha must be a 40-character lowercase git SHA" >&2
             exit 1
           }
-          [[ "$CANDIDATE_RECEIPT_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
-            echo "candidate_receipt_sha256 must be a lowercase SHA-256" >&2
-            exit 1
-          }
-          [[ "$CANDIDATE_RECEIPT_URL" =~ ^https://[^[:space:]?#]+$ ]] || {
-            echo "candidate_receipt_url must be a stable absolute HTTPS URL" >&2
+          [[ "$CANDIDATE_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]] || {
+            echo "candidate_run_id must be a positive workflow run ID" >&2
             exit 1
           }
           [ "$(git rev-parse HEAD)" = "$SOURCE_SHA" ] || {
             echo "checked-out source does not match source_sha" >&2
+            exit 1
+          }
+          [ "$GITHUB_SHA" = "$SOURCE_SHA" ] || {
+            echo "dispatch ref must resolve to source_sha" >&2
             exit 1
           }
           git fetch --no-tags origin main
@@ -95,35 +92,71 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Resolve trusted candidate provenance
+        id: candidate
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p evidence
+          bun scripts/verify-release-provenance.ts \
+            --kind candidate \
+            --source-sha "$SOURCE_SHA" \
+            --run-id "$CANDIDATE_RUN_ID" \
+            --output evidence/candidate-provenance.json \
+            --output-prefix candidate
+
       - name: Download and validate immutable candidate
         env:
           SOURCE_SHA: ${{ inputs.source_sha }}
           EXPECTED_PACKAGES: ${{ inputs.expected_packages }}
-          CANDIDATE_RECEIPT_URL: ${{ inputs.candidate_receipt_url }}
-          CANDIDATE_RECEIPT_SHA256: ${{ inputs.candidate_receipt_sha256 }}
+          GITHUB_TOKEN: ${{ github.token }}
+          CANDIDATE_ARTIFACT_ID: ${{ steps.candidate.outputs.candidate_artifact_id }}
+          CANDIDATE_ARTIFACT_DIGEST: ${{ steps.candidate.outputs.candidate_artifact_digest }}
+          CANDIDATE_SOURCE_TREE_SHA: ${{ steps.candidate.outputs.candidate_source_tree_sha }}
         run: |
           set -euo pipefail
-          mkdir -p evidence
-          curl \
-            --fail \
-            --location \
-            --silent \
-            --show-error \
-            --proto '=https' \
-            --connect-timeout 10 \
-            --max-time 120 \
-            --retry 2 \
-            --retry-all-errors \
-            --output evidence/release-candidate.json \
-            "$CANDIDATE_RECEIPT_URL"
+          mkdir -p evidence .release/candidate-artifact .release
+          gh api \
+            --header 'Accept: application/vnd.github+json' \
+            --output .release/candidate-artifact.zip \
+            "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${CANDIDATE_ARTIFACT_ID}/zip"
           printf '%s  %s\n' \
-            "$CANDIDATE_RECEIPT_SHA256" \
-            evidence/release-candidate.json \
+            "${CANDIDATE_ARTIFACT_DIGEST#sha256:}" \
+            .release/candidate-artifact.zip \
             | sha256sum --check --strict -
+          unzip -q .release/candidate-artifact.zip -d .release/candidate-artifact
+          candidate_path="$(find .release/candidate-artifact -type f -name release-candidate.json -print -quit)"
+          receipt_sidecar_path="$(find .release/candidate-artifact -type f -name release-candidate.sha256 -print -quit)"
+          chart_sidecar_path="$(find .release/candidate-artifact -type f -name release-chart.sha256 -print -quit)"
+          test -n "$candidate_path" -a -n "$receipt_sidecar_path" -a -n "$chart_sidecar_path"
+          cp "$candidate_path" evidence/release-candidate.json
+          chart_artifact="$(jq -er '.chart.artifact' evidence/release-candidate.json)"
+          chart_path="$(find .release/candidate-artifact -type f -name "$chart_artifact" -print -quit)"
+          test -n "$chart_path"
+          cp "$chart_path" ".release/$chart_artifact"
+          receipt_sha256="$(sha256sum evidence/release-candidate.json | awk '{print $1}')"
+          [ "$(awk 'NF { print $1; exit }' "$receipt_sidecar_path")" = "$receipt_sha256" ]
+          chart_sha256="$(sha256sum ".release/$chart_artifact" | awk '{print $1}')"
+          [ "$(awk 'NF { print $1; exit }' "$chart_sidecar_path")" = "$chart_sha256" ]
+          [ "$chart_sha256" = "$(jq -er '.chart.bytesSha256' evidence/release-candidate.json)" ]
+          jq -e \
+            --arg sourceSha "$SOURCE_SHA" \
+            --arg sourceTreeSha "$CANDIDATE_SOURCE_TREE_SHA" \
+            --slurpfile producer evidence/candidate-provenance.json \
+            '.sourceSha == $sourceSha and .sourceTreeSha == $sourceTreeSha and .producer == $producer[0].producer' \
+            evidence/release-candidate.json >/dev/null
           bun scripts/release-candidate.ts \
             --verify evidence/release-candidate.json \
             --source-sha "$SOURCE_SHA" \
             --expected-packages "$EXPECTED_PACKAGES"
+          release_version="$(jq -er '.releaseVersion' evidence/release-candidate.json)"
+          [ "$release_version" = "$(bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml)" ] || {
+            echo "candidate release version differs from the source-controlled chart version" >&2
+            exit 1
+          }
 
       - name: Re-run public package gates
         run: |
@@ -134,6 +167,73 @@ jobs:
           bun scripts/publish-closure-guard.ts
           bun run test:runtime-embedding-consumer
           bun run test:publish-consumer
+
+      - name: Resolve distribution version
+        id: meta
+        run: |
+          set -euo pipefail
+          version="$(jq -er .releaseVersion evidence/release-candidate.json)"
+          [ "$version" = "$(bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml)" ] || {
+            echo "candidate release version differs from the source-controlled chart version" >&2
+            exit 1
+          }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reconcile existing distribution aliases before publication
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          for role in api worker web relay sandbox; do
+            name="$(jq -er --arg role "$role" '.images[$role].name' evidence/release-candidate.json)"
+            expected="$(jq -er --arg role "$role" '.images[$role].digest' evidence/release-candidate.json)"
+            for tag in "$RELEASE_VERSION" "sha-${SOURCE_SHA}"; do
+              resolved="$(bun scripts/resolve-optional-oci-manifest.ts "${name}:${tag}")"
+              if [ -n "$resolved" ] && [ "$resolved" != "$expected" ]; then
+                echo "${name}:${tag} resolves to ${resolved}, not accepted ${expected}" >&2
+                exit 1
+              fi
+            done
+          done
+
+      - name: Reconcile an existing distribution chart before publication
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+          GHCR_USERNAME: ${{ github.actor }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "$GHCR_TOKEN" | helm registry login ghcr.io \
+            --username "$GHCR_USERNAME" \
+            --password-stdin
+          chart_ref="ghcr.io/cloudgeni-ai/charts/opengeni:${RELEASE_VERSION}"
+          chart_oci="oci://ghcr.io/cloudgeni-ai/charts/opengeni"
+          chart_path=".release/opengeni-${RELEASE_VERSION}.tgz"
+          resolved="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
+          if [ -n "$resolved" ]; then
+            mkdir -p .release/chart-preflight
+            helm pull "$chart_oci" \
+              --version "$RELEASE_VERSION" \
+              --destination .release/chart-preflight
+            cmp "$chart_path" ".release/chart-preflight/opengeni-${RELEASE_VERSION}.tgz" || {
+              echo "existing distribution chart bytes differ from the accepted candidate" >&2
+              exit 1
+            }
+          fi
 
       - name: Plan exact package publication
         id: package-plan
@@ -170,29 +270,113 @@ jobs:
           OPENGENI_RELEASE_PACKAGE_RECEIPT: evidence/release-packages-verified.json
         run: bun scripts/verify-release-packages.ts
 
-      - name: Resolve distribution version
-        id: meta
+      - name: Verify complete package evidence
         env:
           VERIFIED_PACKAGES: ${{ steps.registry.outputs.verified_packages }}
+          BOM_PACKAGES: ${{ steps.registry.outputs.bom_packages }}
         run: |
           set -euo pipefail
-          version="$(printf '%s' "$VERIFIED_PACKAGES" \
-            | jq -er '(map(select(.name == "@opengeni/sdk")) + sort_by(.name))[0].version')"
-          [ "$(jq -er .releaseVersion evidence/release-candidate.json)" = "$version" ] || {
-            echo "candidate release version differs from published packages" >&2
+          jq -e 'type == "array" and all(.[]; .state == "published" and (.integrity | startswith("sha512-")))' \
+            <<<"$VERIFIED_PACKAGES" >/dev/null
+          jq -e 'type == "array" and length > 0 and all(.[]; .state == "published" and (.integrity | startswith("sha512-")))' \
+            <<<"$BOM_PACKAGES" >/dev/null
+
+      - name: Publish or reconcile the exact candidate chart
+        id: release-chart
+        env:
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          chart_ref="ghcr.io/cloudgeni-ai/charts/opengeni:${RELEASE_VERSION}"
+          chart_oci="oci://ghcr.io/cloudgeni-ai/charts/opengeni"
+          chart_path=".release/opengeni-${RELEASE_VERSION}.tgz"
+          expected_bytes="$(jq -er .chart.bytesSha256 evidence/release-candidate.json)"
+          printf '%s  %s\n' "$expected_bytes" "$chart_path" | sha256sum --check --strict -
+          resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
+          if [ -n "$resolved_manifest" ]; then
+            mkdir -p .release/chart-reconcile
+            helm pull "$chart_oci" \
+              --version "$RELEASE_VERSION" \
+              --destination .release/chart-reconcile
+            cmp "$chart_path" ".release/chart-reconcile/opengeni-${RELEASE_VERSION}.tgz"
+          else
+            helm push "$chart_path" "$chart_oci"
+            resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
+          fi
+          [[ "$resolved_manifest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "official OCI chart manifest digest was not resolved" >&2
             exit 1
           }
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          chart_json="$(jq -cn \
+            --arg version "$RELEASE_VERSION" \
+            --arg manifestDigest "$resolved_manifest" \
+            --arg bytesSha256 "$expected_bytes" \
+            --arg artifact "opengeni-${RELEASE_VERSION}.tgz" \
+            '{reference:"oci://ghcr.io/cloudgeni-ai/charts/opengeni",version:$version,manifestDigest:$manifestDigest,bytesSha256:$bytesSha256,artifact:$artifact}')"
+          {
+            echo 'json<<RELEASE_CHART_JSON'
+            echo "$chart_json"
+            echo 'RELEASE_CHART_JSON'
+            echo "manifest_digest=$resolved_manifest"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Write complete source-bound BOM
+        id: release-bom
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+          BOM_PACKAGES: ${{ steps.registry.outputs.bom_packages }}
+          RELEASE_CHART: ${{ steps.release-chart.outputs.json }}
+        run: |
+          set -euo pipefail
+          images="$(jq -c '[.images | to_entries[] | .value]' evidence/release-candidate.json)"
+          OPENGENI_RELEASE_BOM_SOURCE_SHA="$SOURCE_SHA" \
+          OPENGENI_RELEASE_BOM_VERSION="$RELEASE_VERSION" \
+          OPENGENI_RELEASE_BOM_PACKAGES="$BOM_PACKAGES" \
+          OPENGENI_RELEASE_BOM_IMAGES="$images" \
+          OPENGENI_RELEASE_BOM_CHART="$RELEASE_CHART" \
+          bun scripts/release-bom.ts
+          printf '%s  %s\n' \
+            "$(sha256sum evidence/release-bom.json | awk '{print $1}')" \
+            release-bom.json \
+            > evidence/release-bom.sha256
 
-      - name: Log in to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compare an existing immutable distribution before image mutation
+        id: release-preflight
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          tag="opengeni-embedded-release-${SOURCE_SHA}"
+          mkdir -p .release/existing-release
+          if gh api \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
+            > .release/existing-release/metadata.json \
+            2> .release/existing-release/error.log; then
+            resolved="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq .sha)"
+            [ "$resolved" = "$SOURCE_SHA" ] || {
+              echo "existing release tag resolves to ${resolved}, expected ${SOURCE_SHA}" >&2
+              exit 1
+            }
+            gh release download "$tag" \
+              --dir .release/existing-release/assets \
+              --pattern release-bom.json \
+              --pattern release-bom.sha256 \
+              --pattern "opengeni-${RELEASE_VERSION}.tgz"
+            cmp evidence/release-bom.json .release/existing-release/assets/release-bom.json
+            cmp evidence/release-bom.sha256 .release/existing-release/assets/release-bom.sha256
+            cmp ".release/opengeni-${RELEASE_VERSION}.tgz" \
+              ".release/existing-release/assets/opengeni-${RELEASE_VERSION}.tgz"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif grep -q 'HTTP 404' .release/existing-release/error.log; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          else
+            cat .release/existing-release/error.log >&2
+            echo "failed to determine whether the immutable distribution exists" >&2
+            exit 1
+          fi
 
       - name: Promote exact candidate manifests
         env:
@@ -218,55 +402,52 @@ jobs:
             done
           done
 
-      - name: Verify anonymous image pulls
+      - name: Verify anonymous distribution pulls
         env:
           RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          CHART_MANIFEST_DIGEST: ${{ steps.release-chart.outputs.manifest_digest }}
         run: |
           set -euo pipefail
           docker logout ghcr.io
           for role in api worker web relay sandbox; do
             name="$(jq -er --arg role "$role" '.images[$role].name' evidence/release-candidate.json)"
             expected="$(jq -er --arg role "$role" '.images[$role].digest' evidence/release-candidate.json)"
-            resolved=""
-            for attempt in 1 2 3 4 5; do
-              resolved="$(docker buildx imagetools inspect "${name}:${RELEASE_VERSION}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
-              [ "$resolved" = "$expected" ] && break
-              sleep "$((attempt * 2))"
+            for tag in "$RELEASE_VERSION" "sha-${SOURCE_SHA}"; do
+              resolved=""
+              for attempt in 1 2 3 4 5; do
+                resolved="$(docker buildx imagetools inspect "${name}:${tag}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+                [ "$resolved" = "$expected" ] && break
+                sleep "$((attempt * 2))"
+              done
+              [ "$resolved" = "$expected" ] || {
+                echo "anonymous pull failed for ${name}:${tag}" >&2
+                exit 1
+              }
             done
-            [ "$resolved" = "$expected" ] || {
-              echo "anonymous pull failed for ${name}:${RELEASE_VERSION}" >&2
-              exit 1
-            }
           done
-
-      - name: Write complete source-bound BOM
-        id: release-bom
-        env:
-          SOURCE_SHA: ${{ inputs.source_sha }}
-          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
-          BOM_PACKAGES: ${{ steps.registry.outputs.bom_packages }}
-        run: |
-          images="$(jq -c '[.images | to_entries[] | .value]' evidence/release-candidate.json)"
-          OPENGENI_RELEASE_BOM_SOURCE_SHA="$SOURCE_SHA" \
-          OPENGENI_RELEASE_BOM_VERSION="$RELEASE_VERSION" \
-          OPENGENI_RELEASE_BOM_PACKAGES="$BOM_PACKAGES" \
-          OPENGENI_RELEASE_BOM_IMAGES="$images" \
-          bun scripts/release-bom.ts
-
-      - name: Write release BOM checksum
-        env:
-          BOM_SHA256: ${{ steps.release-bom.outputs.sha256 }}
-        run: printf '%s  %s\n' "$BOM_SHA256" release-bom.json > evidence/release-bom.sha256
+          helm registry logout ghcr.io
+          mkdir -p .release/anonymous-chart
+          helm pull "oci://ghcr.io/cloudgeni-ai/charts/opengeni" \
+            --version "$RELEASE_VERSION" \
+            --destination .release/anonymous-chart
+          cmp ".release/opengeni-${RELEASE_VERSION}.tgz" \
+            ".release/anonymous-chart/opengeni-${RELEASE_VERSION}.tgz"
+          [ "$(docker buildx imagetools inspect \
+            "ghcr.io/cloudgeni-ai/charts/opengeni:${RELEASE_VERSION}" \
+            --format '{{.Manifest.Digest}}')" = "$CHART_MANIFEST_DIGEST" ]
 
       - name: Upload release BOM
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0 # v7
         with:
           name: embedded-release-bom-${{ inputs.source_sha }}
           path: |
-            release-bom.json
+            evidence/release-bom.json
             evidence/release-bom.sha256
             evidence/release-candidate.json
+            evidence/candidate-provenance.json
             evidence/release-packages-verified.json
+            .release/opengeni-${{ steps.meta.outputs.version }}.tgz
           if-no-files-found: error
           retention-days: 90
 
@@ -275,21 +456,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCE_SHA: ${{ inputs.source_sha }}
           RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+          RELEASE_EXISTS: ${{ steps.release-preflight.outputs.exists }}
         run: |
           set -euo pipefail
           tag="opengeni-embedded-release-${SOURCE_SHA}"
-          if gh release view "$tag" >/dev/null 2>&1; then
+          if [ "$RELEASE_EXISTS" = "true" ]; then
             resolved="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq .sha)"
             [ "$resolved" = "$SOURCE_SHA" ] || {
               echo "existing release tag resolves to ${resolved}, expected ${SOURCE_SHA}" >&2
               exit 1
             }
-          else
+          elif [ "$RELEASE_EXISTS" = "false" ]; then
             gh release create "$tag" \
-              release-bom.json \
+              evidence/release-bom.json \
               evidence/release-bom.sha256 \
+              ".release/opengeni-${RELEASE_VERSION}.tgz" \
               --target "$SOURCE_SHA" \
               --title "OpenGeni embedded distribution ${RELEASE_VERSION} (${SOURCE_SHA::12})" \
-              --notes "Source-bound npm packages and self-hosted images for embedded consumers." \
+              --notes "Source-bound npm packages, Helm chart, images, and BOM for embedded consumers." \
               --latest=false
+          else
+            echo "immutable distribution preflight produced an invalid state" >&2
+            exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,9 @@ on:
         required: true
         type: string
       expected_packages:
-        description: Exact comma-separated package set, for example @opengeni/react@0.15.0.
-        required: true
+        description: Exact comma-separated package set, or empty when this release publishes no npm package changes.
+        required: false
+        default: ""
         type: string
       candidate_run_id:
         description: Completed run ID of the canonical release-candidate workflow for source_sha.
@@ -443,7 +444,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p evidence
-          jq -e 'type == "array" and length > 0 and all(.[]; .state == "published" and (.integrity | startswith("sha512-")))' \
+          jq -e 'type == "array" and all(.[]; .state == "published" and (.integrity | startswith("sha512-")))' \
             <<<"$VERIFIED_PACKAGES" >/dev/null
           jq -e 'type == "array" and length > 0 and all(.[]; .state == "published" and (.integrity | startswith("sha512-")))' \
             <<<"$BOM_PACKAGES" >/dev/null
@@ -498,19 +499,8 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Resolve image version
-        id: meta
-        env:
-          PUBLISHED_PACKAGES: ${{ needs.publish.outputs.verifiedPackages }}
-          SOURCE_SHA: ${{ needs.publish.outputs.sourceSha }}
-        run: |
-          # Resolve the same package-plan version frozen into the candidate
-          # receipt: prefer SDK and otherwise use the first expected package.
-          version="$(printf '%s' "$PUBLISHED_PACKAGES" \
-            | jq -er '(map(select(.name == "@opengeni/sdk")) + sort_by(.name))[0].version')"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
       - name: Download and validate accepted candidate receipt
+        id: meta
         env:
           GITHUB_TOKEN: ${{ github.token }}
           CANDIDATE_ARTIFACT_ID: ${{ needs.publish.outputs.candidateArtifactId }}
@@ -519,7 +509,6 @@ jobs:
           CANDIDATE_SOURCE_TREE_SHA: ${{ needs.publish.outputs.candidateSourceTreeSha }}
           SOURCE_SHA: ${{ needs.publish.outputs.sourceSha }}
           EXPECTED_PACKAGES: ${{ inputs.expected_packages }}
-          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           set -euo pipefail
           mkdir -p evidence .release/candidate-artifact
@@ -548,15 +537,22 @@ jobs:
             --verify evidence/release-candidate.json \
             --source-sha "$SOURCE_SHA" \
             --expected-packages "$EXPECTED_PACKAGES"
+          release_version="$(jq -er '.releaseVersion' evidence/release-candidate.json)"
+          source_release_version="$(bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml)"
+          [ "$release_version" = "$source_release_version" ] || {
+            echo "candidate release version differs from the source-controlled chart version" >&2
+            exit 1
+          }
           jq -e \
             --arg sourceSha "$SOURCE_SHA" \
             --arg sourceTreeSha "$CANDIDATE_SOURCE_TREE_SHA" \
-            --arg releaseVersion "$RELEASE_VERSION" \
-            '.sourceSha == $sourceSha and .sourceTreeSha == $sourceTreeSha and .chart.version == $releaseVersion' \
+            --arg releaseVersion "$release_version" \
+            '.sourceSha == $sourceSha and .sourceTreeSha == $sourceTreeSha and .releaseVersion == $releaseVersion and .chart.version == $releaseVersion' \
             evidence/release-candidate.json >/dev/null || {
-            echo "candidate release version differs from the published package plan" >&2
+            echo "candidate release identity is inconsistent" >&2
             exit 1
           }
+          echo "version=$release_version" >> "$GITHUB_OUTPUT"
 
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
@@ -570,6 +566,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reconcile existing product image aliases before mutation
+        env:
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          for role in api worker web relay sandbox; do
+            name="$(jq -er --arg role "$role" '.images[$role].name' evidence/release-candidate.json)"
+            expected="$(jq -er --arg role "$role" '.images[$role].digest' evidence/release-candidate.json)"
+            resolved="$(bun scripts/resolve-optional-oci-manifest.ts "${name}:${RELEASE_VERSION}")"
+            if [ -n "$resolved" ] && [ "$resolved" != "$expected" ]; then
+              echo "${name}:${RELEASE_VERSION} resolves to ${resolved}, not accepted ${expected}" >&2
+              exit 1
+            fi
+          done
 
       - name: Publish or reconcile the exact accepted Helm chart
         id: release-chart
@@ -591,8 +602,7 @@ jobs:
           mkdir -p .release/chart-pull
           chart_ref="ghcr.io/${org}/charts/opengeni:${RELEASE_VERSION}"
           chart_oci="oci://ghcr.io/${org}/charts/opengeni"
-          resolved_manifest="$(docker buildx imagetools inspect \
-            "$chart_ref" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+          resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
           if [[ "$resolved_manifest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             helm pull "$chart_oci" \
               --version "$RELEASE_VERSION" \

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.22.0
+appVersion: "0.22.0"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -197,11 +197,14 @@ anonymously against the accepted bytes and digests.
 
 Self-hosted embedding consumers have a narrower distribution boundary:
 `.github/workflows/release-embedded.yml` publishes only an exact versioned
-source that already has an immutable candidate receipt. It re-runs the public
-package gates, verifies npm `gitHead` and integrity, and promotes the receipt's
-unchanged manifests to version and full-source-SHA tags. It deliberately does
-not create or update `latest`, and its release receipt makes no hosted
-Workbench, staging, production, or canary claim.
+source that already has an immutable candidate receipt from the canonical
+candidate workflow. Its dispatcher supplies the trusted candidate run ID, not a
+caller-selected receipt URL or digest. The workflow re-runs the public package
+gates, verifies npm `gitHead` and integrity, publishes or reconciles the exact
+candidate chart, promotes the receipt's unchanged manifests to version and
+full-source-SHA tags, and writes one source-bound package/image/chart BOM. It
+deliberately does not create or update `latest`, and its immutable distribution
+receipt makes no hosted Workbench, staging, production, or canary claim.
 
 After staging, production, and the 72-hour canary have consumed those exact
 digests and chart bytes, the protected operator-controlled
@@ -309,10 +312,12 @@ helm upgrade --install opengeni oci://ghcr.io/cloudgeni-ai/charts/opengeni \
 
 Use the repo checkout chart path only for development, chart edits, local
 rendering, or smoke tests against locally built images. `deploy/helm/opengeni`
-keeps a source-tree `Chart.yaml` version for development; releases do not commit
-Chart.yaml bumps. If you install from a clone instead of the OCI chart, set
-`api.image.tag`, `worker.image.tag`, `web.image.tag`, `migrations.image.tag`,
-and, when enabled, `relay.image.tag` to the image tag you intend to run.
+keeps the canonical product release identity in the exact SemVer
+`version`/`appVersion` pair in `Chart.yaml`; bump both together before producing
+a candidate for a new product release, even when no npm package changed. If you
+install from a clone instead of the OCI chart, set `api.image.tag`,
+`worker.image.tag`, `web.image.tag`, `migrations.image.tag`, and, when enabled,
+`relay.image.tag` to the image tag you intend to run.
 
 Render the development chart path with an existing secret:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -226,9 +226,15 @@ GitHub API and requires the canonical repository/workflow, a completed
 successful `workflow_dispatch` run, exact commit/tree SHA and run attempt, one
 owned unexpired Actions artifact with its provider digest, and the expected
 artifact name. URLs and archive digests are derived only after those checks. The
-same exact expected package set and an explicit zero-gap confirmation are still
-required; the selected dispatch ref, `source_sha`, checked-out commit, and a
-commit reachable from `main` must identify the same revision.
+same exact expected package set (including an empty set for an application-only
+release) and an explicit zero-gap confirmation are still required. The product
+release identity comes from the exact SemVer `version`/`appVersion` pair
+committed in `deploy/helm/opengeni/Chart.yaml`; it is independent of whichever
+npm packages changed. The selected dispatch ref, `source_sha`, checked-out
+commit, and a commit reachable from `main` must identify the same revision.
+Candidate admission rejects a product version already occupied by any official
+image or chart. A final-release retry permits only aliases that already resolve
+to the exact accepted digest.
 
 The dispatch downloads the validated candidate and acceptance artifacts,
 verifies their provider ZIP digests and retained sidecars, rejects any changed,

--- a/docs/workbench-acceptance.md
+++ b/docs/workbench-acceptance.md
@@ -74,7 +74,10 @@ kubeconfigs, customer data, conversation content outside the deterministic
 fixture, or unredacted provider responses.
 
 The manually dispatched release-candidate workflow accepts the exact package
-plan, requires the current versioned `main` SHA with no pending changesets,
+plan (which is empty for an application-only release), takes the product release
+version from the source-controlled Helm chart rather than inferring it from an
+unrelated npm package version, requires the current versioned `main` SHA with no
+pending changesets,
 builds each physical image at most once under a full-SHA candidate tag, and
 publishes an immutable `opengeni-candidate-<sourceSha>` receipt. A retry reuses
 an already-present manifest instead of rebuilding it.

--- a/scripts/release-candidate.test.ts
+++ b/scripts/release-candidate.test.ts
@@ -35,6 +35,20 @@ const producer = buildReleaseProducerMetadata({
 });
 
 describe("release candidate receipt", () => {
+  test("uses the product chart version independently of the npm package plan", () => {
+    const receipt = buildReleaseCandidateReceipt({
+      sourceSha,
+      sourceTreeSha,
+      packages: [],
+      imageDigests,
+      chart,
+      producer,
+    });
+    expect(receipt.releaseVersion).toBe(chart.version);
+    expect(receipt.packages).toEqual([]);
+    expect(validateReleaseCandidateReceipt(receipt, { packages: [] })).toEqual(receipt);
+  });
+
   test("normalizes the exact package and physical image inventory", () => {
     const receipt = buildReleaseCandidateReceipt({
       sourceSha,
@@ -92,7 +106,10 @@ describe("release candidate receipt", () => {
     expect(() => validateReleaseCandidateReceipt(missing)).toThrow("exactly");
 
     const extra = structuredClone(valid) as any;
-    extra.images.desktop = { name: "ghcr.io/example/desktop", digest: imageDigests.api };
+    extra.images.desktop = {
+      name: "ghcr.io/example/desktop",
+      digest: imageDigests.api,
+    };
     expect(() => validateReleaseCandidateReceipt(extra)).toThrow("exactly");
 
     const mutable = structuredClone(valid) as any;
@@ -144,7 +161,7 @@ describe("release candidate receipt", () => {
 
     const wrongVersion = structuredClone(valid) as any;
     wrongVersion.releaseVersion = "0.19.0";
-    expect(() => validateReleaseCandidateReceipt(wrongVersion)).toThrow("package plan");
+    expect(() => validateReleaseCandidateReceipt(wrongVersion)).toThrow("chart version");
 
     const wrongAlias = structuredClone(valid) as any;
     wrongAlias.aliases.migration = "worker";

--- a/scripts/release-candidate.ts
+++ b/scripts/release-candidate.ts
@@ -54,19 +54,6 @@ const versionPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
 const digestPattern = /^sha256:[0-9a-f]{64}$/;
 const hashPattern = /^[0-9a-f]{64}$/;
 
-export function resolveReleaseVersion(packages: PublishablePackage[]): string {
-  if (packages.length === 0) {
-    throw new Error("release candidate packages must not be empty");
-  }
-  const preferred =
-    packages.find((pkg) => pkg.name === "@opengeni/sdk") ??
-    [...packages].sort((left, right) => left.name.localeCompare(right.name))[0]!;
-  if (!versionPattern.test(preferred.version)) {
-    throw new Error(`release candidate version is invalid: ${preferred.version}`);
-  }
-  return preferred.version;
-}
-
 export function buildReleaseCandidateReceipt(input: {
   sourceSha: string;
   sourceTreeSha: string;
@@ -87,12 +74,9 @@ export function buildReleaseCandidateReceipt(input: {
   if (input.producer.sourceTreeSha !== input.sourceTreeSha) {
     throw new Error("release candidate producer sourceTreeSha must equal sourceTreeSha");
   }
-  const packages = normalizePackages(input.packages);
-  const releaseVersion = resolveReleaseVersion(packages);
   const chart = normalizeChart(input.chart);
-  if (chart.version !== releaseVersion) {
-    throw new Error("release candidate chart version must equal releaseVersion");
-  }
+  const releaseVersion = chart.version;
+  const packages = normalizePackages(input.packages);
   const images = {} as Record<ReleaseImageRole, ReleaseCandidateImage>;
   for (const role of RELEASE_IMAGE_ROLES) {
     const digest = input.imageDigests[role];
@@ -158,10 +142,6 @@ export function validateReleaseCandidateReceipt(
   }
 
   const packages = normalizePackages(receipt.packages);
-  const releaseVersion = resolveReleaseVersion(packages);
-  if (receipt.releaseVersion !== releaseVersion) {
-    throw new Error("release candidate releaseVersion does not match its package plan");
-  }
 
   const rawImages = object(receipt.images, "release candidate images");
   exactKeys(rawImages, RELEASE_IMAGE_ROLES, "release candidate images");
@@ -242,8 +222,8 @@ export function releaseBomImages(receipt: ReleaseCandidateReceipt): ReleaseCandi
 }
 
 function normalizePackages(value: unknown): PublishablePackage[] {
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error("release candidate packages must be a non-empty array");
+  if (!Array.isArray(value)) {
+    throw new Error("release candidate packages must be an array");
   }
   const specs = value.map((item, index) => {
     const pkg = object(item, `release candidate packages[${index}]`);
@@ -364,7 +344,11 @@ function parseArgs(values: string[]): {
   sourceSha: string;
   expectedPackages: string;
 } {
-  const output = { verifyPath: null as string | null, sourceSha: "", expectedPackages: "" };
+  const output = {
+    verifyPath: null as string | null,
+    sourceSha: "",
+    expectedPackages: "",
+  };
   for (let index = 0; index < values.length; index += 1) {
     const flag = values[index];
     const next = () => {
@@ -374,11 +358,14 @@ function parseArgs(values: string[]): {
     };
     if (flag === "--verify") output.verifyPath = next();
     else if (flag === "--source-sha") output.sourceSha = next();
-    else if (flag === "--expected-packages") output.expectedPackages = next();
-    else throw new Error(`unknown argument: ${flag}`);
+    else if (flag === "--expected-packages") {
+      const value = values[++index];
+      if (value === undefined) throw new Error(`${flag} requires a value`);
+      output.expectedPackages = value;
+    } else throw new Error(`unknown argument: ${flag}`);
   }
-  if (output.verifyPath && (!output.sourceSha || !output.expectedPackages)) {
-    throw new Error("--verify requires --source-sha and --expected-packages");
+  if (output.verifyPath && !output.sourceSha) {
+    throw new Error("--verify requires --source-sha");
   }
   return output;
 }

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -36,6 +36,9 @@ describe("release image workflow contract", () => {
       "docker buildx imagetools inspect",
     );
     expect(candidate).toContain("bun scripts/package-release-chart.ts");
+    expect(candidate).toContain("bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml");
+    expect(candidate).not.toContain('map(select(.name == "@opengeni/sdk"))');
+    expect(candidate).toContain("Refuse an occupied product release version");
     expect(candidate.match(/bun scripts\/package-release-chart\.ts/g)).toHaveLength(2);
     expect(candidate).not.toContain("helm push");
     expect(candidate).toContain("release-chart.sha256");
@@ -53,6 +56,15 @@ describe("release image workflow contract", () => {
     expect(finalJob).toContain("--prefer-index=false");
     expect(finalJob).toContain("evidence/release-candidate.json");
     expect(finalJob).toContain("bun scripts/release-bom.ts");
+    expect(finalJob).toContain("release_version=\"$(jq -er '.releaseVersion'");
+    expect(finalJob).toContain(
+      'source_release_version="$(bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml)"',
+    );
+    expect(finalJob).not.toContain("PUBLISHED_PACKAGES:");
+    expect(finalJob).toContain("Reconcile existing product image aliases before mutation");
+    expect(
+      finalJob.indexOf("Reconcile existing product image aliases before mutation"),
+    ).toBeLessThan(finalJob.indexOf("Publish or reconcile the exact accepted Helm chart"));
     expect(finalJob).toContain("Verify official images support anonymous pull");
     expect(finalJob).toContain("docker logout ghcr.io");
     expect(finalJob).toContain("docker buildx imagetools inspect");

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -121,24 +121,48 @@ describe("release image workflow contract", () => {
   test("embedded release publishes only a verified candidate without hosted acceptance claims", async () => {
     const release = await workflow("release-embedded.yml");
     const registryReconcile = release.indexOf("Reconcile npm package identity");
+    const existingReleasePreflight = release.indexOf(
+      "Compare an existing immutable distribution before image mutation",
+    );
     const imagePromotion = release.indexOf("Promote exact candidate manifests");
 
+    expect(release).toContain("candidate_run_id:");
+    expect(release).toContain("bun scripts/verify-release-provenance.ts");
+    expect(release).toContain("CANDIDATE_ARTIFACT_ID:");
+    expect(release).toContain("CANDIDATE_ARTIFACT_DIGEST:");
+    expect(release).toContain("CANDIDATE_SOURCE_TREE_SHA:");
     expect(release).toContain("bun scripts/release-candidate.ts");
+    expect(release).toContain("bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml");
+    expect(release).not.toContain('map(select(.name == "@opengeni/sdk"))');
     expect(release).toContain("bun run test:runtime-embedding-consumer");
     expect(release).toContain("bun run test:publish-consumer");
     expect(release).toContain("uses: changesets/action@");
     expect(release).toContain("OPENGENI_RELEASE_PACKAGE_PHASE: verify");
+    expect(release).toContain("Publish or reconcile the exact candidate chart");
+    expect(release).toContain('OPENGENI_RELEASE_BOM_CHART="$RELEASE_CHART"');
     expect(release).toContain("bun scripts/release-bom.ts");
+    expect(release).toContain("evidence/release-bom.json");
     expect(release).toContain("docker logout ghcr.io");
     expect(registryReconcile).toBeGreaterThan(-1);
+    expect(existingReleasePreflight).toBeGreaterThan(registryReconcile);
     expect(imagePromotion).toBeGreaterThan(registryReconcile);
+    expect(imagePromotion).toBeGreaterThan(existingReleasePreflight);
+    expect(release.slice(0, imagePromotion)).toContain(
+      "Reconcile existing distribution aliases before publication",
+    );
+    expect(release.slice(0, imagePromotion)).toContain(
+      "Reconcile an existing distribution chart before publication",
+    );
     expect(release.slice(imagePromotion)).toContain('--tag "${name}:${RELEASE_VERSION}"');
     expect(release.slice(imagePromotion)).toContain('--tag "${name}:sha-${SOURCE_SHA}"');
     expect(release.slice(imagePromotion)).not.toContain('--tag "${name}:latest"');
+    expect(release).not.toContain("candidate_receipt_url:");
+    expect(release).not.toContain("candidate_receipt_sha256:");
     expect(release).not.toContain("staging_evidence_url");
     expect(release).not.toContain("production_canary_evidence_url");
     expect(release).not.toContain("docker/build-push-action");
     expect(release).not.toContain("docker build ");
+    expect(release).not.toContain('--tag "${name}:latest"');
   });
 
   test("ordinary CI builds the same five physical image roles", async () => {

--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+import { readReleaseVersion } from "./release-version";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function chart(source: string): Promise<string> {
+  const root = await mkdtemp(resolve(tmpdir(), "opengeni-release-version-"));
+  roots.push(root);
+  const path = resolve(root, "Chart.yaml");
+  await writeFile(path, source);
+  return path;
+}
+
+describe("source-controlled product release version", () => {
+  test("reads one exact chart/app version", async () => {
+    await expect(
+      readReleaseVersion(
+        await chart("apiVersion: v2\nname: opengeni\nversion: 0.22.0\nappVersion: 0.22.0\n"),
+      ),
+    ).resolves.toBe("0.22.0");
+  });
+
+  test("rejects package-style, mutable, or divergent product identity", async () => {
+    await expect(
+      readReleaseVersion(
+        await chart("apiVersion: v2\nname: opengeni\nversion: latest\nappVersion: latest\n"),
+      ),
+    ).rejects.toThrow("exact semver");
+    await expect(
+      readReleaseVersion(
+        await chart("apiVersion: v2\nname: opengeni\nversion: 0.22.0\nappVersion: 0.21.0\n"),
+      ),
+    ).rejects.toThrow("must equal");
+    await expect(
+      readReleaseVersion(
+        await chart("apiVersion: v2\nname: another-chart\nversion: 0.22.0\nappVersion: 0.22.0\n"),
+      ),
+    ).rejects.toThrow("named opengeni");
+  });
+});

--- a/scripts/release-version.ts
+++ b/scripts/release-version.ts
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const versionPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+export async function readReleaseVersion(chartPath: string): Promise<string> {
+  const source = await readFile(resolve(chartPath), "utf8");
+  const chart = Bun.YAML.parse(source) as Record<string, unknown> | null;
+  if (!chart || chart.name !== "opengeni") {
+    throw new Error("release chart must be named opengeni");
+  }
+  if (typeof chart.version !== "string" || !versionPattern.test(chart.version)) {
+    throw new Error("release chart version must be exact semver");
+  }
+  if (chart.appVersion !== chart.version) {
+    throw new Error("source chart appVersion must equal its release version");
+  }
+  return chart.version;
+}
+
+if (import.meta.main) {
+  const [chartPath, ...extra] = process.argv.slice(2);
+  if (!chartPath || extra.length > 0) {
+    throw new Error("usage: bun scripts/release-version.ts <Chart.yaml>");
+  }
+  console.log(await readReleaseVersion(chartPath));
+}

--- a/scripts/resolve-optional-oci-manifest.test.ts
+++ b/scripts/resolve-optional-oci-manifest.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveOptionalOciManifest } from "./resolve-optional-oci-manifest";
+
+const digest = `sha256:${"a".repeat(64)}`;
+
+describe("optional OCI manifest resolution", () => {
+  test("returns only an exact immutable digest", async () => {
+    await expect(
+      resolveOptionalOciManifest("registry.example/image:1.0.0", async () => ({
+        exitCode: 0,
+        stdout: `${digest}\n`,
+        stderr: "",
+      })),
+    ).resolves.toBe(digest);
+    await expect(
+      resolveOptionalOciManifest("registry.example/image:1.0.0", async () => ({
+        exitCode: 0,
+        stdout: "latest\n",
+        stderr: "",
+      })),
+    ).rejects.toThrow("invalid manifest digest");
+  });
+
+  test("classifies only an explicit missing manifest as absent", async () => {
+    for (const stderr of [
+      "manifest unknown",
+      "code: MANIFEST_UNKNOWN",
+      "unexpected status: 404 Not Found",
+    ]) {
+      await expect(
+        resolveOptionalOciManifest("registry.example/image:1.0.0", async () => ({
+          exitCode: 1,
+          stdout: "",
+          stderr,
+        })),
+      ).resolves.toBeNull();
+    }
+  });
+
+  test("fails closed on authorization, network, and malformed-reference errors", async () => {
+    for (const stderr of ["403 Forbidden", "connection reset", "no such host"]) {
+      await expect(
+        resolveOptionalOciManifest("registry.example/image:1.0.0", async () => ({
+          exitCode: 1,
+          stdout: "",
+          stderr,
+        })),
+      ).rejects.toThrow(stderr);
+    }
+    await expect(resolveOptionalOciManifest("registry.example/image:bad tag")).rejects.toThrow(
+      "reference is invalid",
+    );
+  });
+});

--- a/scripts/resolve-optional-oci-manifest.ts
+++ b/scripts/resolve-optional-oci-manifest.ts
@@ -1,0 +1,63 @@
+type CommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+type Run = (argv: string[]) => Promise<CommandResult>;
+
+const digestPattern = /^sha256:[0-9a-f]{64}$/;
+const missingPattern = /(?:manifest unknown|MANIFEST_UNKNOWN|404 Not Found)/;
+
+export async function resolveOptionalOciManifest(
+  reference: string,
+  run: Run = runCommand,
+): Promise<string | null> {
+  if (reference.length === 0 || reference.length > 512 || /[\u0000-\u0020\u007f]/.test(reference)) {
+    throw new Error("OCI manifest reference is invalid");
+  }
+  const result = await run([
+    "docker",
+    "buildx",
+    "imagetools",
+    "inspect",
+    reference,
+    "--format",
+    "{{.Manifest.Digest}}",
+  ]);
+  const digest = result.stdout.trim();
+  if (result.exitCode === 0) {
+    if (!digestPattern.test(digest)) {
+      throw new Error(`OCI registry returned an invalid manifest digest for ${reference}`);
+    }
+    return digest;
+  }
+  if (missingPattern.test(result.stderr)) {
+    return null;
+  }
+  throw new Error(
+    `OCI manifest lookup failed for ${reference}: ${result.stderr.trim() || `exit ${result.exitCode}`}`,
+  );
+}
+
+async function runCommand(argv: string[]): Promise<CommandResult> {
+  const child = Bun.spawn(argv, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+if (import.meta.main) {
+  const [reference, ...extra] = process.argv.slice(2);
+  if (!reference || extra.length > 0) {
+    throw new Error("usage: bun scripts/resolve-optional-oci-manifest.ts <reference>");
+  }
+  console.log((await resolveOptionalOciManifest(reference)) ?? "");
+}

--- a/scripts/verify-release-packages.test.ts
+++ b/scripts/verify-release-packages.test.ts
@@ -30,6 +30,7 @@ describe("release package evidence", () => {
   });
 
   test("parses a bounded comma/newline package set and rejects duplicates", () => {
+    expect(parseExpectedPackages("")).toEqual([]);
     expect(parseExpectedPackages("@opengeni/react@0.14.0,\n@opengeni/sdk@0.13.0")).toEqual([
       react,
       sdk,
@@ -38,6 +39,38 @@ describe("release package evidence", () => {
       "duplicate expected package",
     );
     expect(() => parseExpectedPackages("react@latest")).toThrow("invalid expected package spec");
+  });
+
+  test("supports an application-only release with a complete published package BOM", () => {
+    const result = reconcileReleasePackages({
+      sourceSha: sha,
+      phase: "verify",
+      publishable: [react, sdk],
+      expected: [],
+      registry: new Map([
+        [react.name, published(react, "b".repeat(40))],
+        [sdk.name, published(sdk, "c".repeat(40))],
+      ]),
+    });
+    expect(result).toEqual({
+      needsPublish: false,
+      releaseReady: true,
+      packages: [],
+      bomPackages: [
+        {
+          ...react,
+          state: "published",
+          gitHead: "b".repeat(40),
+          integrity: "sha512-release-integrity",
+        },
+        {
+          ...sdk,
+          state: "published",
+          gitHead: "c".repeat(40),
+          integrity: "sha512-release-integrity",
+        },
+      ],
+    });
   });
 
   test("plans exactly the declared missing package and ignores unchanged published packages", () => {
@@ -117,7 +150,11 @@ describe("release package evidence", () => {
     });
     expect(result.needsPublish).toBe(false);
     expect(result.releaseReady).toBe(true);
-    expect(result.packages[0]).toMatchObject({ ...react, state: "published", gitHead: sha });
+    expect(result.packages[0]).toMatchObject({
+      ...react,
+      state: "published",
+      gitHead: sha,
+    });
     expect(result.bomPackages).toHaveLength(2);
     expect(result.bomPackages.every((pkg) => pkg.state === "published")).toBe(true);
   });

--- a/scripts/verify-release-packages.ts
+++ b/scripts/verify-release-packages.ts
@@ -30,10 +30,6 @@ export function parseExpectedPackages(value: string): PublishablePackage[] {
     .map((item) => item.trim())
     .filter(Boolean);
 
-  if (specs.length === 0) {
-    throw new Error("expected_packages must name at least one @opengeni package version");
-  }
-
   const seen = new Set<string>();
   return specs.map((spec) => {
     const separator = spec.lastIndexOf("@");
@@ -121,7 +117,12 @@ export function reconcileReleasePackages(options: {
     if (!remote.integrity?.startsWith("sha512-")) {
       throw new Error(`registry integrity is missing or invalid for ${item.name}@${item.version}`);
     }
-    return { ...item, state: "published", gitHead: remote.gitHead, integrity: remote.integrity };
+    return {
+      ...item,
+      state: "published",
+      gitHead: remote.gitHead,
+      integrity: remote.integrity,
+    };
   };
 
   const bomPackages = [...publishable]


### PR DESCRIPTION
## Summary

- make the exact Helm `version`/`appVersion` pair the canonical OpenGeni product release identity, independent of npm package publication
- fail closed on occupied or unreadable image/chart aliases and support application-only releases
- require canonical candidate-run provenance for embedded distribution publication
- publish/reconcile one exact package, image, Helm chart, and source-SHA BOM without making hosted acceptance or `latest` claims
- make retries compare immutable release assets before image mutation

## Verification

- `bun test`: 3,980 pass, 0 fail, 3 documented opt-in Modal skips
- `bun run typecheck`: 22 projects clean
- `bun run lint`
- `bun run format:check`
- focused release workflow/package/BOM tests
- UBS fresh-eyes scan; only critical was a confirmed false positive treating public OCI digest validation as a secret-token comparison
