### PR TITLE
fix(release): fail closed on immutable artifact lookup

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -69,6 +69,11 @@ jobs:
             exit 1
           fi
 
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
       # The receipt includes the exact producer run attempt. Once the immutable
       # candidate release exists, a later rerun cannot safely rewrite that
       # receipt with a different attempt while retaining the same source-SHA
@@ -82,20 +87,17 @@ jobs:
         run: |
           set -euo pipefail
           tag="opengeni-candidate-${SOURCE_SHA}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            resolved="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq .sha)"
-            [ "$resolved" = "$SOURCE_SHA" ] || {
-              echo "existing candidate tag resolves to ${resolved}, expected ${SOURCE_SHA}" >&2
-              exit 1
-            }
+          state="$(bun scripts/resolve-github-release-state.ts "$tag")"
+          release_exists="$(jq -er .releaseExists <<<"$state")"
+          tag_sha="$(jq -r '.tagSha // ""' <<<"$state")"
+          [ -z "$tag_sha" ] || [ "$tag_sha" = "$SOURCE_SHA" ] || {
+            echo "existing candidate tag resolves to ${tag_sha}, expected ${SOURCE_SHA}" >&2
+            exit 1
+          }
+          if [ "$release_exists" = "true" ]; then
             echo "immutable candidate ${tag} already exists; use its original successful producer run ID" >&2
             exit 1
           fi
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: 1.3.14
 
       - name: Plan exact package publication
         id: package-plan
@@ -496,12 +498,14 @@ jobs:
         run: |
           set -euo pipefail
           tag="opengeni-candidate-${SOURCE_SHA}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            resolved="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq .sha)"
-            [ "$resolved" = "$SOURCE_SHA" ] || {
-              echo "existing candidate tag resolves to ${resolved}, expected ${SOURCE_SHA}" >&2
-              exit 1
-            }
+          state="$(bun scripts/resolve-github-release-state.ts "$tag")"
+          release_exists="$(jq -er .releaseExists <<<"$state")"
+          tag_sha="$(jq -r '.tagSha // ""' <<<"$state")"
+          [ -z "$tag_sha" ] || [ "$tag_sha" = "$SOURCE_SHA" ] || {
+            echo "existing candidate tag resolves to ${tag_sha}, expected ${SOURCE_SHA}" >&2
+            exit 1
+          }
+          if [ "$release_exists" = "true" ]; then
             mkdir -p /tmp/opengeni-release-candidate-existing
             gh release download "$tag" \
               --dir /tmp/opengeni-release-candidate-existing \
@@ -514,11 +518,6 @@ jobs:
             cmp evidence/release-chart.sha256 /tmp/opengeni-release-candidate-existing/release-chart.sha256
             cmp ".release/charts/opengeni-${RELEASE_VERSION}.tgz" "/tmp/opengeni-release-candidate-existing/opengeni-${RELEASE_VERSION}.tgz"
           else
-            existing_tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq .sha 2>/dev/null || true)"
-            if [ -n "$existing_tag_sha" ] && [ "$existing_tag_sha" != "$SOURCE_SHA" ]; then
-              echo "existing candidate tag resolves to ${existing_tag_sha}, expected ${SOURCE_SHA}" >&2
-              exit 1
-            fi
             gh release create "$tag" \
               evidence/release-candidate.json \
               evidence/release-candidate.sha256 \

--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -350,16 +350,15 @@ jobs:
         run: |
           set -euo pipefail
           tag="opengeni-embedded-release-${SOURCE_SHA}"
-          mkdir -p .release/existing-release
-          if gh api \
-            "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
-            > .release/existing-release/metadata.json \
-            2> .release/existing-release/error.log; then
-            resolved="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq .sha)"
-            [ "$resolved" = "$SOURCE_SHA" ] || {
-              echo "existing release tag resolves to ${resolved}, expected ${SOURCE_SHA}" >&2
-              exit 1
-            }
+          state="$(bun scripts/resolve-github-release-state.ts "$tag")"
+          release_exists="$(jq -er .releaseExists <<<"$state")"
+          tag_sha="$(jq -r '.tagSha // ""' <<<"$state")"
+          [ -z "$tag_sha" ] || [ "$tag_sha" = "$SOURCE_SHA" ] || {
+            echo "existing release tag resolves to ${tag_sha}, expected ${SOURCE_SHA}" >&2
+            exit 1
+          }
+          if [ "$release_exists" = "true" ]; then
+            mkdir -p .release/existing-release
             gh release download "$tag" \
               --dir .release/existing-release/assets \
               --pattern release-bom.json \
@@ -370,11 +369,10 @@ jobs:
             cmp ".release/opengeni-${RELEASE_VERSION}.tgz" \
               ".release/existing-release/assets/opengeni-${RELEASE_VERSION}.tgz"
             echo "exists=true" >> "$GITHUB_OUTPUT"
-          elif grep -q 'HTTP 404' .release/existing-release/error.log; then
+          elif [ "$release_exists" = "false" ]; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
           else
-            cat .release/existing-release/error.log >&2
-            echo "failed to determine whether the immutable distribution exists" >&2
+            echo "GitHub release-state resolver returned an invalid state" >&2
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -667,12 +667,14 @@ jobs:
         run: |
           set -euo pipefail
           tag="opengeni-release-${SOURCE_SHA}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            resolved="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq .sha)"
-            [ "$resolved" = "$SOURCE_SHA" ] || {
-              echo "existing BOM release tag resolves to ${resolved}, expected ${SOURCE_SHA}" >&2
-              exit 1
-            }
+          state="$(bun scripts/resolve-github-release-state.ts "$tag")"
+          release_exists="$(jq -er .releaseExists <<<"$state")"
+          tag_sha="$(jq -r '.tagSha // ""' <<<"$state")"
+          [ -z "$tag_sha" ] || [ "$tag_sha" = "$SOURCE_SHA" ] || {
+            echo "existing BOM release tag resolves to ${tag_sha}, expected ${SOURCE_SHA}" >&2
+            exit 1
+          }
+          if [ "$release_exists" = "true" ]; then
             mkdir -p /tmp/opengeni-release-bom-existing
             gh release download "$tag" \
               --dir /tmp/opengeni-release-bom-existing \
@@ -767,12 +769,14 @@ jobs:
         run: |
           set -euo pipefail
           tag="opengeni-release-${SOURCE_SHA}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            resolved="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq .sha)"
-            [ "$resolved" = "$SOURCE_SHA" ] || {
-              echo "existing BOM release tag resolves to ${resolved}, expected ${SOURCE_SHA}" >&2
-              exit 1
-            }
+          state="$(bun scripts/resolve-github-release-state.ts "$tag")"
+          release_exists="$(jq -er .releaseExists <<<"$state")"
+          tag_sha="$(jq -r '.tagSha // ""' <<<"$state")"
+          [ -z "$tag_sha" ] || [ "$tag_sha" = "$SOURCE_SHA" ] || {
+            echo "existing BOM release tag resolves to ${tag_sha}, expected ${SOURCE_SHA}" >&2
+            exit 1
+          }
+          if [ "$release_exists" = "true" ]; then
             mkdir -p /tmp/opengeni-release-bom-existing
             gh release download "$tag" \
               --dir /tmp/opengeni-release-bom-existing \
@@ -781,11 +785,6 @@ jobs:
             cmp evidence/release-bom.json /tmp/opengeni-release-bom-existing/release-bom.json
             cmp evidence/release-bom.sha256 /tmp/opengeni-release-bom-existing/release-bom.sha256
           else
-            existing_tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq .sha 2>/dev/null || true)"
-            if [ -n "$existing_tag_sha" ] && [ "$existing_tag_sha" != "$SOURCE_SHA" ]; then
-              echo "existing BOM tag resolves to ${existing_tag_sha}, expected ${SOURCE_SHA}" >&2
-              exit 1
-            fi
             gh release create "$tag" \
               evidence/release-bom.json \
               evidence/release-bom.sha256 \

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -44,7 +44,9 @@ describe("release image workflow contract", () => {
     expect(candidate).toContain("release-chart.sha256");
     expect(candidate).toContain("Refuse to rerun a completed immutable candidate");
     expect(candidate).toContain("use its original successful producer run ID");
-    expect(candidate).toContain("existing_tag_sha");
+    expect(candidate).toContain("bun scripts/resolve-github-release-state.ts");
+    expect(candidate).not.toContain('gh release view "$tag"');
+    expect(candidate).not.toContain('existing_tag_sha="$(gh api');
   });
 
   test("final release promotes accepted manifests and has no image build boundary", async () => {
@@ -80,7 +82,9 @@ describe("release image workflow contract", () => {
     expect(finalJob.indexOf("Compare existing immutable BOM before aliases")).toBeLessThan(
       finalJob.indexOf("Promote exact accepted manifests"),
     );
-    expect(finalJob).toContain("existing_tag_sha");
+    expect(finalJob).toContain("bun scripts/resolve-github-release-state.ts");
+    expect(finalJob).not.toContain('gh release view "$tag"');
+    expect(finalJob).not.toContain('existing_tag_sha="$(gh api');
     expect(release).toContain("candidate_run_id:");
     expect(release).toContain("acceptance_run_id:");
     for (const forbidden of [
@@ -140,6 +144,8 @@ describe("release image workflow contract", () => {
     expect(release).toContain("OPENGENI_RELEASE_PACKAGE_PHASE: verify");
     expect(release).toContain("Publish or reconcile the exact candidate chart");
     expect(release).toContain('OPENGENI_RELEASE_BOM_CHART="$RELEASE_CHART"');
+    expect(release).toContain("bun scripts/resolve-github-release-state.ts");
+    expect(release).not.toContain('gh release view "$tag"');
     expect(release).toContain("bun scripts/release-bom.ts");
     expect(release).toContain("evidence/release-bom.json");
     expect(release).toContain("docker logout ghcr.io");

--- a/scripts/resolve-github-release-state.test.ts
+++ b/scripts/resolve-github-release-state.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveGitHubReleaseState, type GitHubReleaseApi } from "./resolve-github-release-state";
+
+const repository = "Cloudgeni-ai/opengeni";
+const tag = `opengeni-release-${"a".repeat(40)}`;
+const sha = "a".repeat(40);
+
+function api(responses: Record<string, { status: number; body?: unknown }>): GitHubReleaseApi {
+  return {
+    async get(path) {
+      const response = responses[path];
+      if (!response) throw new Error(`unexpected path: ${path}`);
+      return { status: response.status, body: response.body ?? null };
+    },
+  };
+}
+
+const releasePath = `/repos/${repository}/releases/tags/${tag}`;
+const commitPath = `/repos/${repository}/commits/${tag}`;
+
+describe("GitHub release state resolution", () => {
+  test("distinguishes an absent release and tag from an immutable existing release", async () => {
+    await expect(
+      resolveGitHubReleaseState({
+        repository,
+        tag,
+        api: api({
+          [releasePath]: { status: 404 },
+          [commitPath]: { status: 404 },
+        }),
+      }),
+    ).resolves.toEqual({ releaseExists: false, tagSha: null });
+
+    await expect(
+      resolveGitHubReleaseState({
+        repository,
+        tag,
+        api: api({
+          [releasePath]: { status: 200, body: { tag_name: tag } },
+          [commitPath]: { status: 200, body: { sha } },
+        }),
+      }),
+    ).resolves.toEqual({ releaseExists: true, tagSha: sha });
+  });
+
+  test("retains an existing tag even when no GitHub release exists", async () => {
+    await expect(
+      resolveGitHubReleaseState({
+        repository,
+        tag,
+        api: api({
+          [releasePath]: { status: 404 },
+          [commitPath]: { status: 200, body: { sha } },
+        }),
+      }),
+    ).resolves.toEqual({ releaseExists: false, tagSha: sha });
+  });
+
+  test("fails closed on authorization, transport-shaped status, and malformed authority", async () => {
+    for (const status of [401, 403, 429, 500]) {
+      await expect(
+        resolveGitHubReleaseState({
+          repository,
+          tag,
+          api: api({
+            [releasePath]: { status },
+          }),
+        }),
+      ).rejects.toThrow(`HTTP ${status}`);
+    }
+
+    await expect(
+      resolveGitHubReleaseState({
+        repository,
+        tag,
+        api: api({
+          [releasePath]: { status: 200, body: { tag_name: "different" } },
+        }),
+      }),
+    ).rejects.toThrow("does not match");
+    await expect(
+      resolveGitHubReleaseState({
+        repository: "not a repository",
+        tag,
+        api: api({}),
+      }),
+    ).rejects.toThrow("owner/name");
+  });
+
+  test("rejects an existing release whose tag cannot resolve to an exact commit", async () => {
+    await expect(
+      resolveGitHubReleaseState({
+        repository,
+        tag,
+        api: api({
+          [releasePath]: { status: 200, body: { tag_name: tag } },
+          [commitPath]: { status: 404 },
+        }),
+      }),
+    ).rejects.toThrow("without a resolvable tag commit");
+  });
+});

--- a/scripts/resolve-github-release-state.ts
+++ b/scripts/resolve-github-release-state.ts
@@ -1,0 +1,116 @@
+type GitHubApiResponse = {
+  status: number;
+  body: unknown;
+};
+
+export type GitHubReleaseApi = {
+  get(path: string): Promise<GitHubApiResponse>;
+};
+
+export type GitHubReleaseState = {
+  releaseExists: boolean;
+  tagSha: string | null;
+};
+
+const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const tagPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,200}$/;
+const sourceShaPattern = /^[0-9a-f]{40}$/;
+
+export async function resolveGitHubReleaseState(input: {
+  repository: string;
+  tag: string;
+  api: GitHubReleaseApi;
+}): Promise<GitHubReleaseState> {
+  if (!repositoryPattern.test(input.repository)) {
+    throw new Error("GitHub repository must be an exact owner/name pair");
+  }
+  if (!tagPattern.test(input.tag)) {
+    throw new Error("GitHub release tag is invalid");
+  }
+
+  const release = await input.api.get(
+    `/repos/${input.repository}/releases/tags/${encodeURIComponent(input.tag)}`,
+  );
+  let releaseExists: boolean;
+  if (release.status === 200) {
+    const value = record(release.body, "GitHub release");
+    if (value.tag_name !== input.tag) {
+      throw new Error("GitHub release response tag does not match the requested tag");
+    }
+    releaseExists = true;
+  } else if (release.status === 404) {
+    releaseExists = false;
+  } else {
+    throw new Error(`GitHub release lookup failed with HTTP ${release.status}`);
+  }
+
+  const commit = await input.api.get(
+    `/repos/${input.repository}/commits/${encodeURIComponent(input.tag)}`,
+  );
+  let tagSha: string | null;
+  if (commit.status === 200) {
+    const value = record(commit.body, "GitHub tag commit");
+    if (typeof value.sha !== "string" || !sourceShaPattern.test(value.sha)) {
+      throw new Error("GitHub tag commit response has an invalid SHA");
+    }
+    tagSha = value.sha;
+  } else if (commit.status === 404) {
+    if (releaseExists) {
+      throw new Error("GitHub release exists without a resolvable tag commit");
+    }
+    tagSha = null;
+  } else {
+    throw new Error(`GitHub tag commit lookup failed with HTTP ${commit.status}`);
+  }
+
+  return { releaseExists, tagSha };
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} response must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function githubApi(token: string, baseUrl: string): GitHubReleaseApi {
+  const base = baseUrl.replace(/\/$/, "");
+  return {
+    async get(path: string): Promise<GitHubApiResponse> {
+      const response = await fetch(`${base}${path}`, {
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${token}`,
+          "x-github-api-version": "2022-11-28",
+        },
+        redirect: "error",
+        signal: AbortSignal.timeout(30_000),
+      });
+      let body: unknown = null;
+      if (response.status !== 404) {
+        try {
+          body = await response.json();
+        } catch {
+          throw new Error(`GitHub API returned non-JSON HTTP ${response.status}`);
+        }
+      }
+      return { status: response.status, body };
+    },
+  };
+}
+
+if (import.meta.main) {
+  const [tag, ...extra] = process.argv.slice(2);
+  if (!tag || extra.length > 0) {
+    throw new Error("usage: bun scripts/resolve-github-release-state.ts <tag>");
+  }
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  if (!token) throw new Error("GITHUB_TOKEN or GH_TOKEN is required");
+  const repository = process.env.GITHUB_REPOSITORY ?? "";
+  const state = await resolveGitHubReleaseState({
+    repository,
+    tag,
+    api: githubApi(token, process.env.GITHUB_API_URL ?? "https://api.github.com"),
+  });
+  console.log(JSON.stringify(state));
+}

--- a/scripts/resolve-optional-oci-manifest.test.ts
+++ b/scripts/resolve-optional-oci-manifest.test.ts
@@ -27,6 +27,7 @@ describe("optional OCI manifest resolution", () => {
       "manifest unknown",
       "code: MANIFEST_UNKNOWN",
       "unexpected status: 404 Not Found",
+      "ERROR: registry.example/image:1.0.0: not found",
     ]) {
       await expect(
         resolveOptionalOciManifest("registry.example/image:1.0.0", async () => ({

--- a/scripts/resolve-optional-oci-manifest.ts
+++ b/scripts/resolve-optional-oci-manifest.ts
@@ -32,7 +32,10 @@ export async function resolveOptionalOciManifest(
     }
     return digest;
   }
-  if (missingPattern.test(result.stderr)) {
+  if (
+    missingPattern.test(result.stderr) ||
+    result.stderr.trim() === `ERROR: ${reference}: not found`
+  ) {
     return null;
   }
   throw new Error(


### PR DESCRIPTION
## Summary
- classify GitHub releases and tag commits through a tested status-aware resolver instead of treating every CLI failure as absence
- accept the exact Buildx missing-manifest response observed in the immutable candidate workflow while continuing to fail closed on auth, network, and malformed errors
- cover candidate, embedded, and hosted release workflow contracts

## Validation
- focused Bun regression suite: 12 pass
- typecheck: 22 projects clean
- lint and repository-wide format check clean
- changed workflow YAML parses
- UBS: 0 critical, 0 warnings