### PR TITLE
fix(release): recognize exact missing commit response

### DIFF
--- a/scripts/resolve-github-release-state.test.ts
+++ b/scripts/resolve-github-release-state.test.ts
@@ -57,6 +57,40 @@ describe("GitHub release state resolution", () => {
     ).resolves.toEqual({ releaseExists: false, tagSha: sha });
   });
 
+  test("accepts only GitHub's exact 422 missing-ref response as an absent tag", async () => {
+    const exactMissing = {
+      message: `No commit found for SHA: ${tag}`,
+      status: "422",
+    };
+    await expect(
+      resolveGitHubReleaseState({
+        repository,
+        tag,
+        api: api({
+          [releasePath]: { status: 404 },
+          [commitPath]: { status: 422, body: exactMissing },
+        }),
+      }),
+    ).resolves.toEqual({ releaseExists: false, tagSha: null });
+
+    for (const body of [
+      { ...exactMissing, message: "Validation Failed" },
+      { ...exactMissing, message: "No commit found for SHA: another-tag" },
+      { ...exactMissing, status: 422 },
+    ]) {
+      await expect(
+        resolveGitHubReleaseState({
+          repository,
+          tag,
+          api: api({
+            [releasePath]: { status: 404 },
+            [commitPath]: { status: 422, body },
+          }),
+        }),
+      ).rejects.toThrow("HTTP 422");
+    }
+  });
+
   test("fails closed on authorization, transport-shaped status, and malformed authority", async () => {
     for (const status of [401, 403, 429, 500]) {
       await expect(
@@ -89,15 +123,26 @@ describe("GitHub release state resolution", () => {
   });
 
   test("rejects an existing release whose tag cannot resolve to an exact commit", async () => {
-    await expect(
-      resolveGitHubReleaseState({
-        repository,
-        tag,
-        api: api({
-          [releasePath]: { status: 200, body: { tag_name: tag } },
-          [commitPath]: { status: 404 },
+    for (const commit of [
+      { status: 404 },
+      {
+        status: 422,
+        body: {
+          message: `No commit found for SHA: ${tag}`,
+          status: "422",
+        },
+      },
+    ]) {
+      await expect(
+        resolveGitHubReleaseState({
+          repository,
+          tag,
+          api: api({
+            [releasePath]: { status: 200, body: { tag_name: tag } },
+            [commitPath]: commit,
+          }),
         }),
-      }),
-    ).rejects.toThrow("without a resolvable tag commit");
+      ).rejects.toThrow("without a resolvable tag commit");
+    }
   });
 });

--- a/scripts/resolve-github-release-state.ts
+++ b/scripts/resolve-github-release-state.ts
@@ -54,7 +54,10 @@ export async function resolveGitHubReleaseState(input: {
       throw new Error("GitHub tag commit response has an invalid SHA");
     }
     tagSha = value.sha;
-  } else if (commit.status === 404) {
+  } else if (
+    commit.status === 404 ||
+    (commit.status === 422 && isExactMissingCommitResponse(commit.body, input.tag))
+  ) {
     if (releaseExists) {
       throw new Error("GitHub release exists without a resolvable tag commit");
     }
@@ -71,6 +74,12 @@ function record(value: unknown, label: string): Record<string, unknown> {
     throw new Error(`${label} response must be an object`);
   }
   return value as Record<string, unknown>;
+}
+
+function isExactMissingCommitResponse(value: unknown, tag: string): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const response = value as Record<string, unknown>;
+  return response.message === `No commit found for SHA: ${tag}` && response.status === "422";
 }
 
 function githubApi(token: string, baseUrl: string): GitHubReleaseApi {


### PR DESCRIPTION
## Summary

- recognize GitHub commit lookup HTTP 422 as a missing tag only for the exact documented response tied to the requested tag
- keep every other 422, malformed response, authentication failure, and existing-release inconsistency fail-closed
- cover the live provider response and negative classifications with contract tests

## Evidence

- reproduced the GitHub API response against the exact absent candidate tag
- release-state unit tests: 10 passed
- all package typechecks passed
- lint and repository formatting passed
- UBS reported no warnings; its one critical is a false positive on comparison with GitHub public error-message text, not a credential