### PR TITLE
fix(release): accept an absent GitHub release

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -93,7 +93,7 @@ jobs:
           set -euo pipefail
           tag="opengeni-candidate-${SOURCE_SHA}"
           state="$(bun scripts/resolve-github-release-state.ts "$tag")"
-          release_exists="$(jq -er .releaseExists <<<"$state")"
+          release_exists="$(jq -er '.releaseExists | if type == "boolean" then tostring else error("releaseExists must be boolean") end' <<<"$state")"
           tag_sha="$(jq -r '.tagSha // ""' <<<"$state")"
           [ -z "$tag_sha" ] || [ "$tag_sha" = "$SOURCE_SHA" ] || {
             echo "existing candidate tag resolves to ${tag_sha}, expected ${SOURCE_SHA}" >&2
@@ -509,7 +509,7 @@ jobs:
           set -euo pipefail
           tag="opengeni-candidate-${SOURCE_SHA}"
           state="$(bun scripts/resolve-github-release-state.ts "$tag")"
-          release_exists="$(jq -er .releaseExists <<<"$state")"
+          release_exists="$(jq -er '.releaseExists | if type == "boolean" then tostring else error("releaseExists must be boolean") end' <<<"$state")"
           tag_sha="$(jq -r '.tagSha // ""' <<<"$state")"
           [ -z "$tag_sha" ] || [ "$tag_sha" = "$SOURCE_SHA" ] || {
             echo "existing candidate tag resolves to ${tag_sha}, expected ${SOURCE_SHA}" >&2

--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -356,7 +356,7 @@ jobs:
           set -euo pipefail
           tag="opengeni-embedded-release-${SOURCE_SHA}"
           state="$(bun scripts/resolve-github-release-state.ts "$tag")"
-          release_exists="$(jq -er .releaseExists <<<"$state")"
+          release_exists="$(jq -er '.releaseExists | if type == "boolean" then tostring else error("releaseExists must be boolean") end' <<<"$state")"
           tag_sha="$(jq -r '.tagSha // ""' <<<"$state")"
           [ -z "$tag_sha" ] || [ "$tag_sha" = "$SOURCE_SHA" ] || {
             echo "existing release tag resolves to ${tag_sha}, expected ${SOURCE_SHA}" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -674,7 +674,7 @@ jobs:
           set -euo pipefail
           tag="opengeni-release-${SOURCE_SHA}"
           state="$(bun scripts/resolve-github-release-state.ts "$tag")"
-          release_exists="$(jq -er .releaseExists <<<"$state")"
+          release_exists="$(jq -er '.releaseExists | if type == "boolean" then tostring else error("releaseExists must be boolean") end' <<<"$state")"
           tag_sha="$(jq -r '.tagSha // ""' <<<"$state")"
           [ -z "$tag_sha" ] || [ "$tag_sha" = "$SOURCE_SHA" ] || {
             echo "existing BOM release tag resolves to ${tag_sha}, expected ${SOURCE_SHA}" >&2
@@ -775,7 +775,7 @@ jobs:
           set -euo pipefail
           tag="opengeni-release-${SOURCE_SHA}"
           state="$(bun scripts/resolve-github-release-state.ts "$tag")"
-          release_exists="$(jq -er .releaseExists <<<"$state")"
+          release_exists="$(jq -er '.releaseExists | if type == "boolean" then tostring else error("releaseExists must be boolean") end' <<<"$state")"
           tag_sha="$(jq -r '.tagSha // ""' <<<"$state")"
           [ -z "$tag_sha" ] || [ "$tag_sha" = "$SOURCE_SHA" ] || {
             echo "existing BOM release tag resolves to ${tag_sha}, expected ${SOURCE_SHA}" >&2

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
@@ -197,6 +198,48 @@ describe("release image workflow contract", () => {
     expect(login).toContain("--expose-token");
     expect(login).not.toContain("client-secret");
     expect(login).not.toContain("admin-password");
+  });
+
+  test("release-state parsing accepts a valid absent release without weakening type checks", async () => {
+    const candidate = await workflow("release-candidate.yml");
+    const release = await workflow("release.yml");
+    const embedded = await workflow("release-embedded.yml");
+    const parser =
+      `release_exists="$(jq -er '.releaseExists | if type == "boolean" ` +
+      `then tostring else error("releaseExists must be boolean") end' <<<"$state")"`;
+
+    expect(candidate.match(/release_exists=/g)).toHaveLength(2);
+    expect(release.match(/release_exists=/g)).toHaveLength(2);
+    expect(embedded.match(/release_exists=/g)).toHaveLength(1);
+    for (const source of [candidate, release, embedded]) {
+      expect(source).toContain(parser);
+      expect(source).not.toContain("jq -er .releaseExists");
+    }
+
+    const falseResult = spawnSync(
+      "bash",
+      [
+        "-c",
+        `set -euo pipefail
+state='{"releaseExists":false}'
+${parser}
+test "$release_exists" = "false"`,
+      ],
+      { encoding: "utf8" },
+    );
+    expect(falseResult.status, falseResult.stderr).toBe(0);
+
+    const invalidResult = spawnSync(
+      "bash",
+      [
+        "-c",
+        `set -euo pipefail
+state='{"releaseExists":"false"}'
+${parser}`,
+      ],
+      { encoding: "utf8" },
+    );
+    expect(invalidResult.status).not.toBe(0);
   });
 
   test("ordinary CI builds the same five physical image roles", async () => {


### PR DESCRIPTION
## Summary
- parse `releaseExists: false` as a valid boolean in all candidate, embedded, and final release workflows
- retain fail-closed rejection for missing or non-boolean release state
- execute the exact jq expression against both valid-false and invalid-string fixtures

## Live evidence
Candidate run 30071912768 failed before registry login because `jq -e` interprets JSON `false` as process failure. The TypeScript resolver returned the correct absent state; no image, chart, package, tag, or release was published.

## Verification
- 17 focused release tests pass
- all 22 TypeScript projects pass
- lint and repository-wide format check pass
- direct shell regression proves boolean false exits zero and string false fails
- UBS: 0 critical, 0 warnings