### PR TITLE
fix(release): validate public OCI action manifest

### DIFF
--- a/.github/actions/public-oci-login/action.yml
+++ b/.github/actions/public-oci-login/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Registry host plus optional repository namespace.
     required: true
   auth:
-    description: Authentication mode: github or azure-oidc.
+    description: "Authentication mode: github or azure-oidc."
     required: true
   github-username:
     description: GitHub registry username when auth is github.

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -182,6 +182,10 @@ describe("release image workflow contract", () => {
     const release = await workflow("release.yml");
     const embedded = await workflow("release-embedded.yml");
     const login = await action("public-oci-login");
+    const loginManifest = Bun.YAML.parse(login) as {
+      name?: unknown;
+      runs?: { using?: unknown; steps?: unknown };
+    };
 
     for (const source of [candidate, release, embedded]) {
       expect(source).toContain("uses: ./.github/actions/public-oci-login");
@@ -189,6 +193,9 @@ describe("release image workflow contract", () => {
       expect(source).toContain("OPENGENI_RELEASE_REGISTRY_AUTH");
       expect(source).toContain("id-token: write");
     }
+    expect(loginManifest.name).toBe("Public OCI registry login");
+    expect(loginManifest.runs?.using).toBe("composite");
+    expect(Array.isArray(loginManifest.runs?.steps)).toBe(true);
     expect(login).toContain("azure-oidc");
     expect(login).toContain("github");
     expect(login).toContain("azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43");


### PR DESCRIPTION
## Summary

- quote the public OCI composite action description whose colon made the GitHub action manifest invalid YAML
- parse the composite action manifest in the release workflow contract test so this fails before a hosted release

## Evidence

- failed candidate run: https://github.com/Cloudgeni-ai/opengeni/actions/runs/30074078411
- `bun test scripts/release-image-workflow-contract.test.ts` (7 pass)
- focused oxfmt and oxlint pass

No candidate images or immutable release artifacts were published by the failed run.