### PR TITLE
Fix release artifact downloads for gh 2.95

### DIFF
--- a/.github/workflows/release-acceptance.yml
+++ b/.github/workflows/release-acceptance.yml
@@ -117,8 +117,7 @@ jobs:
           zip=".release/candidate/artifact.zip"
           gh api \
             --header 'Accept: application/vnd.github+json' \
-            --output "$zip" \
-            "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${CANDIDATE_ARTIFACT_ID}/zip"
+            "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${CANDIDATE_ARTIFACT_ID}/zip" > "$zip"
           printf '%s  %s\n' "${CANDIDATE_ARTIFACT_DIGEST#sha256:}" "$zip" \
             | sha256sum --check --strict -
           mapfile -t receipts < <(unzip -Z1 "$zip" | grep -E '(^|/)release-candidate\.json$')
@@ -142,8 +141,7 @@ jobs:
           zip=".release/operator/artifact.zip"
           gh api \
             --header 'Accept: application/vnd.github+json' \
-            --output "$zip" \
-            "/repos/${OPERATOR_REPOSITORY}/actions/artifacts/${OPERATOR_ARTIFACT_ID}/zip"
+            "/repos/${OPERATOR_REPOSITORY}/actions/artifacts/${OPERATOR_ARTIFACT_ID}/zip" > "$zip"
           printf '%s  %s\n' "${OPERATOR_ARTIFACT_DIGEST#sha256:}" "$zip" \
             | sha256sum --check --strict -
           mapfile -t entries < <(unzip -Z1 "$zip" | sort)

--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -125,8 +125,8 @@ jobs:
           mkdir -p evidence .release/candidate-artifact .release
           gh api \
             --header 'Accept: application/vnd.github+json' \
-            --output .release/candidate-artifact.zip \
-            "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${CANDIDATE_ARTIFACT_ID}/zip"
+            "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${CANDIDATE_ARTIFACT_ID}/zip" \
+            > .release/candidate-artifact.zip
           printf '%s  %s\n' \
             "${CANDIDATE_ARTIFACT_DIGEST#sha256:}" \
             .release/candidate-artifact.zip \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,8 +272,7 @@ jobs:
             local zip="$destination/artifact.zip"
             gh api \
               --header 'Accept: application/vnd.github+json' \
-              --output "$zip" \
-              "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip"
+              "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > "$zip"
             printf '%s  %s\n' "${digest#sha256:}" "$zip" | sha256sum --check --strict -
             unzip -q "$zip" -d "$destination/files"
           }
@@ -520,8 +519,8 @@ jobs:
           set -euo pipefail
           mkdir -p evidence .release/candidate-artifact
           gh api --header 'Accept: application/vnd.github+json' \
-            --output .release/candidate-artifact.zip \
-            "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${CANDIDATE_ARTIFACT_ID}/zip"
+            "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${CANDIDATE_ARTIFACT_ID}/zip" \
+            > .release/candidate-artifact.zip
           printf '%s  %s\n' "${CANDIDATE_ARTIFACT_DIGEST#sha256:}" .release/candidate-artifact.zip \
             | sha256sum --check --strict -
           unzip -q .release/candidate-artifact.zip -d .release/candidate-artifact

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -13,7 +13,42 @@ async function action(name: string): Promise<string> {
   return readFile(resolve(root, ".github/actions", name, "action.yml"), "utf8");
 }
 
+function ghApiCommands(source: string): string[] {
+  const commands: string[] = [];
+  let command = "";
+
+  for (const line of source.split("\n")) {
+    const start = line.search(/\bgh api\b/);
+    if (!command && start >= 0) command = line.slice(start);
+    else if (command) command += `\n${line}`;
+
+    if (command && !/\\\s*$/.test(line)) {
+      commands.push(command);
+      command = "";
+    }
+  }
+
+  if (command) commands.push(command);
+  return commands;
+}
+
 describe("release image workflow contract", () => {
+  test("downloads artifact ZIPs through portable gh api stdout redirection", async () => {
+    const workflows = await Promise.all(
+      ["release-acceptance.yml", "release.yml", "release-embedded.yml"].map(workflow),
+    );
+    const commands = workflows.flatMap(ghApiCommands);
+    expect(commands.filter((command) => command.includes("--output"))).toHaveLength(0);
+    const artifactDownloads = commands.filter(
+      (command) => command.includes("/actions/artifacts/") && command.includes("/zip"),
+    );
+
+    expect(artifactDownloads).toHaveLength(5);
+    for (const command of artifactDownloads) {
+      expect(command).toMatch(/\/zip["']?\s*\\?\s*(?:\n\s*)?>\s*[^\s]+/);
+    }
+  });
+
   test("candidate builds every physical image and freezes a full-SHA receipt", async () => {
     const candidate = await workflow("release-candidate.yml");
 


### PR DESCRIPTION
## Summary

- replace all five unsupported `gh api --output` artifact downloads in the release, acceptance, and embedded workflows with portable raw-stdout redirection
- preserve fail-closed shell behavior, provider digest verification before unzip, existing artifact paths, repository/run/SHA bindings, and mutation ordering
- add a deterministic workflow-contract regression test covering every `gh api` invocation in the three release workflows and all five artifact ZIP downloads

## Evidence

- Base: `6eccbff255dcb8841918a9c214fd95ece60b8009`
- Head: `b34e99b811f7403c01ac3cebe9bb61206271216b`
- Tree: `c79b61223d6988e220fdef6c04397c0499c5d54d`
- Changed paths: `.github/workflows/release-acceptance.yml`, `.github/workflows/release.yml`, `.github/workflows/release-embedded.yml`, `scripts/release-image-workflow-contract.test.ts`
- Linear: OPE-92

## Checks

- `gh --version`: 2.95.0
- Reproduced the old command failure: `unknown flag: --output`
- Verified the corrected stdout-redirection form is accepted by `gh` 2.95.0 against an intentionally unreachable loopback host, with no GitHub mutation
- YAML parse: pass for all three changed workflows
- `bash -n`: pass for all six affected workflow shell blocks
- Static workflow/provenance audit: pass; five artifact downloads, digest check precedes unzip, and no `gh api --output` remains repository-wide
- `git diff --check`: pass
- Bun/Node/oxfmt/oxlint are unavailable in the source-owner sandbox, so the repository Bun test, typecheck, lint, and formatter commands are deferred to CI

## Risk

No release provenance semantics or mutation ordering were broadened. Natural CI should run the repository's focused contract/release checks.
