### PR TITLE
chore: reissue linked client release boundary

### DIFF
--- a/.changeset/fresh-client-release-boundary.md
+++ b/.changeset/fresh-client-release-boundary.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/sdk": patch
+---
+
+Materialize the linked SDK and React model-provider readiness APIs from a fresh immutable release revision.


### PR DESCRIPTION
## Summary

- add a patch changeset for the linked SDK and React packages
- materialize the model-provider readiness client APIs on a fresh immutable release revision
- supersede the prior release source whose maintainer PASS was human-readable but not encoded as the operator's canonical exact-head artifact

## Validation

- `bun install --frozen-lockfile`
- `bunx changeset status --output /tmp/opengeni-reissue-plan.json`
- `git diff --check`

No runtime source is changed by this PR.