### PR TITLE
chore: make release review evidence reproducible

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -7,6 +7,10 @@ on:
         description: "Exact versioned main commit to publish"
         required: true
         type: string
+      expected_packages:
+        description: "Exact comma-separated package@version set intended for publication"
+        required: true
+        type: string
       confirm:
         description: "Publish every unpublished package version at this commit"
         required: true
@@ -19,6 +23,7 @@ concurrency:
 
 permissions:
   contents: read
+  checks: read
 
 jobs:
   publish:
@@ -26,9 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      checks: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.source_sha }}
           fetch-depth: 0
@@ -37,9 +43,11 @@ jobs:
       - name: Verify exact versioned main
         env:
           SOURCE_SHA: ${{ inputs.source_sha }}
+          EXPECTED_PACKAGES: ${{ inputs.expected_packages }}
         run: |
           set -euo pipefail
           [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test -n "$EXPECTED_PACKAGES"
           test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
           git fetch --no-tags origin main
           test "$(git rev-parse origin/main)" = "$SOURCE_SHA"
@@ -48,7 +56,29 @@ jobs:
             exit 1
           fi
 
-      - uses: oven-sh/setup-bun@v2
+      - name: Require successful protected source CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          checks="$(gh api \
+            --header 'Accept: application/vnd.github+json' \
+            "/repos/${GITHUB_REPOSITORY}/commits/${SOURCE_SHA}/check-runs?filter=latest&per_page=100")"
+          for name in "Typecheck and unit tests" "Deployment artifacts" "Workload image builds"; do
+            jq -e \
+              --arg name "$name" \
+              '[.check_runs[]
+                | select(.name == $name and .app.slug == "github-actions"
+                    and .status == "completed" and .conclusion == "success")]
+                | length == 1' \
+              <<<"$checks" >/dev/null || {
+                echo "required exact-source check is not successful: $name" >&2
+                exit 1
+              }
+          done
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
@@ -62,12 +92,31 @@ jobs:
           bun run test:publish-consumer
           bun run test:runtime-embedding-consumer
 
-      - uses: actions/setup-node@v6
+      - name: Plan exact package publication
+        id: package-plan
+        env:
+          OPENGENI_RELEASE_SOURCE_SHA: ${{ inputs.source_sha }}
+          OPENGENI_EXPECTED_PACKAGES: ${{ inputs.expected_packages }}
+          OPENGENI_RELEASE_PACKAGE_PHASE: plan
+          OPENGENI_RELEASE_PACKAGE_RECEIPT: evidence/release-packages-plan.json
+        run: bun scripts/verify-release-packages.ts
+
+      - name: Retain pre-publication package plan
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: package-publication-plan-${{ inputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: evidence/release-packages-plan.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.package-plan.outputs.needs_publish == 'true'
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Publish unpublished package versions
+        if: steps.package-plan.outputs.needs_publish == 'true'
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d
         with:
           publish: bun run release:publish
@@ -76,25 +125,18 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 
-      - name: Verify SDK and React registry identity
+      - name: Reconcile exact registry package identity
         env:
-          SOURCE_SHA: ${{ inputs.source_sha }}
-        run: |
-          set -euo pipefail
-          for package in sdk react; do
-            version="$(jq -r .version "packages/$package/package.json")"
-            for attempt in $(seq 1 24); do
-              metadata="$(npm view "@opengeni/$package@$version" --json 2>/dev/null || true)"
-              git_head="$(jq -r '.gitHead // empty' <<<"$metadata")"
-              integrity="$(jq -r '.dist.integrity // empty' <<<"$metadata")"
-              if [ "$git_head" = "$SOURCE_SHA" ] && [[ "$integrity" == sha512-* ]]; then
-                break
-              fi
-              if [ "$attempt" -eq 24 ]; then
-                echo "@opengeni/$package@$version did not settle to $SOURCE_SHA" >&2
-                exit 1
-              fi
-              sleep 5
-            done
-            test "$(npm view "@opengeni/$package" version)" = "$version"
-          done
+          OPENGENI_RELEASE_SOURCE_SHA: ${{ inputs.source_sha }}
+          OPENGENI_EXPECTED_PACKAGES: ${{ inputs.expected_packages }}
+          OPENGENI_RELEASE_PACKAGE_PHASE: verify
+          OPENGENI_RELEASE_PACKAGE_RECEIPT: evidence/release-packages-verified.json
+        run: bun scripts/verify-release-packages.ts
+
+      - name: Retain verified package identity
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: package-publication-verified-${{ inputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: evidence/release-packages-verified.json
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -184,6 +184,27 @@ Candidate or operator admission must fail closed when those provider identities
 do not match; do not weaken the provenance check or recreate approval from a
 comment, commit message, or local record.
 
+For a single-maintainer source PR, generate the exact structured review body
+before merging. Submit the result as a native `COMMENTED` pull-request review;
+the formatter can also print the canonical SHA-256 needed by an external
+operator to bind the same artifact:
+
+```bash
+bun scripts/release-review.ts \
+  --base <exact-current-main-sha> \
+  --head <exact-reviewed-pr-head-sha> \
+  --reviewer <trusted-maintainer-login>
+
+bun scripts/release-review.ts \
+  --base <exact-current-main-sha> \
+  --head <exact-reviewed-pr-head-sha> \
+  --reviewer <trusted-maintainer-login> \
+  --digest
+```
+
+Regenerate the body and verdict after every head or base movement. Do not edit a
+submitted review after merge to manufacture evidence retroactively.
+
 That workflow requires the exact current `main` SHA, no pending changesets, and
 the exact expected package set (for example, `@opengeni/react@0.15.0`). It
 builds API, worker, web, relay, and stock headless-sandbox images under

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -212,6 +212,39 @@ describe("release image workflow contract", () => {
     expect(release).not.toContain('--tag "${name}:latest"');
   });
 
+  test("package-only publication is exact-source, CI-gated, and evidence-bound", async () => {
+    const publish = await workflow("publish-packages.yml");
+    const sourceGate = publish.indexOf("Require successful protected source CI");
+    const plan = publish.indexOf("Plan exact package publication");
+    const retainedPlan = publish.indexOf("Retain pre-publication package plan");
+    const mutation = publish.indexOf("Publish unpublished package versions");
+    const reconciliation = publish.indexOf("Reconcile exact registry package identity");
+
+    expect(publish).toContain("expected_packages:");
+    expect(publish).toContain("checks: read");
+    expect(publish).toContain("filter=latest&per_page=100");
+    for (const required of [
+      "Typecheck and unit tests",
+      "Deployment artifacts",
+      "Workload image builds",
+    ]) {
+      expect(publish).toContain(required);
+    }
+    expect(publish).toContain("OPENGENI_RELEASE_PACKAGE_PHASE: plan");
+    expect(publish).toContain("OPENGENI_RELEASE_PACKAGE_PHASE: verify");
+    expect(publish).toContain("bun scripts/verify-release-packages.ts");
+    expect(publish).toContain("actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10");
+    expect(publish).toContain("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6");
+    expect(publish).toContain("actions/setup-node@820762786026740c76f36085b0efc47a31fe5020");
+    expect(publish).not.toMatch(/actions\/(?:checkout|setup-node)@v[0-9]/);
+    expect(publish).not.toMatch(/oven-sh\/setup-bun@v[0-9]/);
+    expect(sourceGate).toBeGreaterThan(-1);
+    expect(plan).toBeGreaterThan(sourceGate);
+    expect(retainedPlan).toBeGreaterThan(plan);
+    expect(mutation).toBeGreaterThan(retainedPlan);
+    expect(reconciliation).toBeGreaterThan(mutation);
+  });
+
   test("public registry authentication is portable, short-lived, and version-bound", async () => {
     const candidate = await workflow("release-candidate.yml");
     const release = await workflow("release.yml");

--- a/scripts/release-review.test.ts
+++ b/scripts/release-review.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  exactHeadReleaseReview,
+  exactHeadReleaseReviewSha256,
+  formatExactHeadReleaseReview,
+} from "./release-review";
+
+const base = "1".repeat(40);
+const head = "2".repeat(40);
+
+describe("exact-head release review formatter", () => {
+  test("emits one closed, provider-independent PASS artifact", () => {
+    const review = exactHeadReleaseReview({
+      reviewedBaseSha: base,
+      reviewedHeadSha: head,
+      reviewerLogin: "release-maintainer",
+    });
+
+    expect(review).toEqual({
+      version: 3,
+      kind: "opengeni-exact-head-release-review",
+      repository: "Cloudgeni-ai/opengeni",
+      reviewedBaseSha: base,
+      reviewedHeadSha: head,
+      reviewerLogin: "release-maintainer",
+      reviewProfile: "exact-head-maintainer-v1",
+      verdict: "PASS",
+    });
+    expect(formatExactHeadReleaseReview(review)).toBe(
+      `<!-- opengeni-exact-head-release-review:v3 -->\n\n\`\`\`json\n${JSON.stringify(review, null, 2)}\n\`\`\``,
+    );
+    expect(exactHeadReleaseReviewSha256(review)).toBe(
+      "5ddaa413ac98b2782e4b86b9b324816bb247dbbb8e5d4288f97131a350f50a45",
+    );
+  });
+
+  test("rejects mutable or ambiguous review identity", () => {
+    expect(() =>
+      exactHeadReleaseReview({
+        reviewedBaseSha: "ABC",
+        reviewedHeadSha: head,
+        reviewerLogin: "release-maintainer",
+      }),
+    ).toThrow("reviewed base");
+    expect(() =>
+      exactHeadReleaseReview({
+        reviewedBaseSha: base,
+        reviewedHeadSha: base,
+        reviewerLogin: "release-maintainer",
+      }),
+    ).toThrow("must differ");
+    expect(() =>
+      exactHeadReleaseReview({
+        reviewedBaseSha: base,
+        reviewedHeadSha: head,
+        reviewerLogin: "-invalid",
+      }),
+    ).toThrow("reviewer");
+  });
+});

--- a/scripts/release-review.ts
+++ b/scripts/release-review.ts
@@ -1,0 +1,85 @@
+import { createHash } from "node:crypto";
+
+export interface ExactHeadReleaseReview {
+  version: 3;
+  kind: "opengeni-exact-head-release-review";
+  repository: "Cloudgeni-ai/opengeni";
+  reviewedBaseSha: string;
+  reviewedHeadSha: string;
+  reviewerLogin: string;
+  reviewProfile: "exact-head-maintainer-v1";
+  verdict: "PASS";
+}
+
+const shaPattern = /^[0-9a-f]{40}$/;
+const loginPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+
+export function exactHeadReleaseReview(input: {
+  reviewedBaseSha: string;
+  reviewedHeadSha: string;
+  reviewerLogin: string;
+}): ExactHeadReleaseReview {
+  if (!shaPattern.test(input.reviewedBaseSha)) {
+    throw new Error("reviewed base must be a 40-character lowercase Git SHA");
+  }
+  if (!shaPattern.test(input.reviewedHeadSha)) {
+    throw new Error("reviewed head must be a 40-character lowercase Git SHA");
+  }
+  if (input.reviewedBaseSha === input.reviewedHeadSha) {
+    throw new Error("reviewed base and head must differ");
+  }
+  if (!loginPattern.test(input.reviewerLogin)) {
+    throw new Error("reviewer must be a valid GitHub login");
+  }
+  return {
+    version: 3,
+    kind: "opengeni-exact-head-release-review",
+    repository: "Cloudgeni-ai/opengeni",
+    reviewedBaseSha: input.reviewedBaseSha,
+    reviewedHeadSha: input.reviewedHeadSha,
+    reviewerLogin: input.reviewerLogin,
+    reviewProfile: "exact-head-maintainer-v1",
+    verdict: "PASS",
+  };
+}
+
+export function formatExactHeadReleaseReview(review: ExactHeadReleaseReview): string {
+  return `<!-- opengeni-exact-head-release-review:v3 -->\n\n\`\`\`json\n${JSON.stringify(review, null, 2)}\n\`\`\``;
+}
+
+export function exactHeadReleaseReviewSha256(review: ExactHeadReleaseReview): string {
+  const canonical = Object.fromEntries(
+    Object.entries(review).sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0)),
+  );
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+function option(args: string[], name: string): string {
+  const index = args.indexOf(name);
+  const value = index === -1 ? undefined : args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${name} is required`);
+  return value;
+}
+
+function main(args: string[]): void {
+  const review = exactHeadReleaseReview({
+    reviewedBaseSha: option(args, "--base"),
+    reviewedHeadSha: option(args, "--head"),
+    reviewerLogin: option(args, "--reviewer"),
+  });
+  const format = args.includes("--digest") ? "digest" : "comment";
+  process.stdout.write(
+    format === "digest"
+      ? `${exactHeadReleaseReviewSha256(review)}\n`
+      : `${formatExactHeadReleaseReview(review)}\n`,
+  );
+}
+
+if (import.meta.main) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release/tsconfig.json
+++ b/scripts/release/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["../release-bom.ts", "../verify-release-packages.ts"]
+  "include": ["../release-bom.ts", "../release-review.ts", "../verify-release-packages.ts"]
 }


### PR DESCRIPTION
Adds a generic exact-head release-review formatter and digest helper so a single-maintainer release can produce provider-bound review evidence before merge instead of relying on prose or mutable post-merge records.

Also hardens the npm-only publication workflow added in #622: mutation now requires successful protected exact-source CI, an explicit package/version plan, retained pre-publication evidence, full registry reconciliation, and immutable action pins.

No product-specific or private deployment details are included.