### PR TITLE
fix(release): prove GitHub merge provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,7 @@ jobs:
             --output-prefix acceptance
           echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
 
-      - name: Verify exact-head approval provenance
+      - name: Verify provider-proved merge and exact-head approval provenance
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ steps.preflight.outputs.source_sha }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -205,6 +205,36 @@ bun scripts/release-review.ts \
 Regenerate the body and verdict after every head or base movement. Do not edit a
 submitted review after merge to manufacture evidence retroactively.
 
+Release admission derives the merge outcome exclusively from GitHub records; a
+workflow caller cannot assert a merge method. The exact current `main` SHA is
+fenced before and after admission, must be associated with exactly one merged
+PR, and must retain the PR's provider-recorded base, head, merge SHA, actors,
+commit count, and exact reviewed-head tree. Supported provider-derived outcomes
+are:
+
+- an exact two-parent merge commit with parents `[reviewed base, reviewed head]`;
+- an exact one-commit squash on the reviewed base when the PR had multiple
+  commits;
+- an exact linear multi-commit rebase from the reviewed base with the same
+  provider commit count as the PR; and
+- a one-commit squash/rebase equivalence class when both the PR and rewritten
+  result contain one commit.
+
+GitHub does not retain a distinct manual UI method field for that final
+one-commit case. Admission therefore records the truthful equivalence class
+rather than guessing from mutable commit text or accepting caller metadata.
+Both possible operations have the same admitted security identity: one exact PR,
+base, head, reviewed tree, source tree, and provider merge SHA. Any nonlinear or
+discontinuous range fails closed.
+
+The exact reviewed head must have one successful GitHub Actions `Current-base
+source admission` check. The exact source must separately have one successful
+GitHub Actions result for each required candidate check: `Typecheck and unit
+tests`, `Deployment artifacts`, and `Workload image builds`. Missing,
+duplicated, failed, or foreign-app check runs are rejected. This admission
+metadata does not alter the reproducible schema-v2 candidate receipt or any
+chart, manifest, SBOM, provenance, or workload digest.
+
 That workflow requires the exact current `main` SHA, no pending changesets, and
 the exact expected package set (for example, `@opengeni/react@0.15.0`). It
 builds API, worker, web, relay, and stock headless-sandbox images under

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -209,8 +209,10 @@ Release admission derives the merge outcome exclusively from GitHub records; a
 workflow caller cannot assert a merge method. The exact current `main` SHA is
 fenced before and after admission, must be associated with exactly one merged
 PR, and must retain the PR's provider-recorded base, head, merge SHA, actors,
-commit count, and exact reviewed-head tree. Supported provider-derived outcomes
-are:
+commit count, and exact reviewed-head tree. A matching GitHub `merged` timeline
+event must independently bind the source commit, merge actor, and merge time;
+association and topology alone do not admit a direct fast-forward push.
+Supported provider-derived outcomes are:
 
 - an exact two-parent merge commit with parents `[reviewed base, reviewed head]`;
 - an exact one-commit squash on the reviewed base when the PR had multiple
@@ -231,9 +233,11 @@ The exact reviewed head must have one successful GitHub Actions `Current-base
 source admission` check. The exact source must separately have one successful
 GitHub Actions result for each required candidate check: `Typecheck and unit
 tests`, `Deployment artifacts`, and `Workload image builds`. Missing,
-duplicated, failed, or foreign-app check runs are rejected. This admission
-metadata does not alter the reproducible schema-v2 candidate receipt or any
-chart, manifest, SBOM, provenance, or workload digest.
+duplicated, failed, wrong-head, or foreign-app check runs are rejected. Check
+history is read with `filter=all`, and every accepted record must bind the exact
+commit and the official GitHub Actions app identity (`github-actions`, app ID
+`15368`). This admission metadata does not alter the reproducible schema-v2
+candidate receipt or any chart, manifest, SBOM, provenance, or workload digest.
 
 That workflow requires the exact current `main` SHA, no pending changesets, and
 the exact expected package set (for example, `@opengeni/react@0.15.0`). It

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { appendFileSync } from "node:fs";
 import { verifySourceAdmission } from "./check-source-admission.mjs";
 
@@ -25,6 +26,11 @@ export const RELEASE_AUTOMATION_CONTRACT = Object.freeze({
   checks: Object.freeze({
     sourceAdmission: "Current-base source admission",
     automationCi: "Automation PR CI",
+    requiredSource: Object.freeze([
+      "Typecheck and unit tests",
+      "Deployment artifacts",
+      "Workload image builds",
+    ]),
   }),
 });
 
@@ -658,6 +664,196 @@ async function paginatedArray(api, path, label) {
   throw new Error(`${label} exceeded ${maximumPages * recordsPerPage} records`);
 }
 
+async function paginatedCheckRuns(api, sha) {
+  const rows = [];
+  for (let page = 1; page <= maximumPages; page += 1) {
+    const value = await api.get(
+      repositoryPath(`/commits/${sha}/check-runs?per_page=${recordsPerPage}&page=${page}`),
+    );
+    invariant(Array.isArray(value?.check_runs), "check-run listing is invalid");
+    rows.push(...value.check_runs);
+    if (value.check_runs.length < recordsPerPage) return rows;
+  }
+  throw new Error(`check-run listing exceeded ${maximumPages * recordsPerPage} records`);
+}
+
+function assertSuccessfulCheck(checks, name, sha) {
+  const selected = checks.filter((check) => check?.name === name);
+  invariant(selected.length === 1, `${name} is not represented by exactly one check run on ${sha}`);
+  const check = selected[0];
+  invariant(check?.app?.slug === "github-actions", `${name} is not owned by GitHub Actions`);
+  invariant(
+    check.status === "completed" && check.conclusion === "success",
+    `${name} did not complete successfully`,
+  );
+  return Object.freeze({ name, appSlug: "github-actions" });
+}
+
+function assertCommit(value, expectedSha, label) {
+  invariant(value?.sha === expectedSha, `${label} identity changed`);
+  const treeSha = assertSha(value?.tree?.sha, `${label} tree SHA`);
+  invariant(Array.isArray(value?.parents), `${label} parents are missing`);
+  const parents = value.parents.map((parent, index) =>
+    assertSha(parent?.sha, `${label} parent ${index}`),
+  );
+  return { sha: expectedSha, treeSha, parents };
+}
+
+function assertMergedPull(value, expected) {
+  invariant(value?.number === expected.pullNumber, "associated pull-request number changed");
+  invariant(
+    value?.state === "closed" && value?.merged === true,
+    "associated pull request is not merged",
+  );
+  invariant(value?.merge_commit_sha === expected.sourceSha, "pull-request merge SHA changed");
+  invariant(
+    value?.html_url ===
+      `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}/pull/${expected.pullNumber}`,
+    "pull-request URL changed",
+  );
+  invariant(
+    value?.base?.ref === RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+    "pull-request base changed",
+  );
+  invariant(
+    value?.base?.repo?.full_name === RELEASE_AUTOMATION_CONTRACT.repository,
+    "pull-request base repository changed",
+  );
+  const baseSha = assertSha(value?.base?.sha, "pull-request base SHA");
+  const headSha = assertSha(value?.head?.sha, "pull-request head SHA");
+  invariant(baseSha !== headSha, "pull-request base and head are identical");
+  invariant(
+    Number.isSafeInteger(value?.commits) && value.commits > 0 && value.commits <= 250,
+    "pull-request commit count is invalid",
+  );
+  invariant(
+    Array.isArray(value?.requested_reviewers),
+    "pull-request requested reviewers are missing",
+  );
+  const mergedAt = assertTimestamp(value?.merged_at, "pull-request merge timestamp");
+  const author = record(value?.user, "pull-request author");
+  assertString(author.login, "pull-request author login");
+  assertPositiveInteger(author.id, "pull-request author ID");
+  invariant(author.type === "User" || author.type === "Bot", "pull-request author type is invalid");
+  const merger = record(value?.merged_by, "pull-request merge actor");
+  assertString(merger.login, "pull-request merge actor login");
+  assertPositiveInteger(merger.id, "pull-request merge actor ID");
+  invariant(
+    merger.type === "User" || merger.type === "Bot",
+    "pull-request merge actor type is invalid",
+  );
+  return { baseSha, headSha, mergedAt, author, merger, commitCount: value.commits };
+}
+
+function exactHeadReviewArtifact(baseSha, headSha) {
+  return {
+    version: 3,
+    kind: "opengeni-exact-head-release-review",
+    repository: RELEASE_AUTOMATION_CONTRACT.repository,
+    reviewedBaseSha: baseSha,
+    reviewedHeadSha: headSha,
+    reviewerLogin: RELEASE_AUTOMATION_CONTRACT.releaseApprover.login,
+    reviewProfile: "exact-head-maintainer-v1",
+    verdict: "PASS",
+  };
+}
+
+function canonicalSha256(value) {
+  const canonical = Object.fromEntries(
+    Object.entries(value).sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0)),
+  );
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+function verifyAdminPassBody(body, artifact) {
+  const match =
+    /^<!-- opengeni-exact-head-release-review:v3 -->\n\n?```json\n([\s\S]+)\n```\s*$/.exec(body);
+  invariant(match !== null, "single-maintainer admin PASS body is not canonical");
+  let parsed;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch {
+    throw new Error("single-maintainer admin PASS body is not valid JSON");
+  }
+  invariant(
+    JSON.stringify(parsed) === JSON.stringify(artifact),
+    "single-maintainer admin PASS does not bind the exact base/head/reviewer",
+  );
+  invariant(
+    body ===
+      `<!-- opengeni-exact-head-release-review:v3 -->\n\n\u0060\u0060\u0060json\n${JSON.stringify(artifact, null, 2)}\n\u0060\u0060\u0060`,
+    "single-maintainer admin PASS body is not canonical",
+  );
+  return canonicalSha256(artifact);
+}
+
+function sameProviderReview(left, right) {
+  return (
+    left?.id === right?.id &&
+    left?.state === right?.state &&
+    left?.commit_id === right?.commit_id &&
+    left?.html_url === right?.html_url &&
+    left?.submitted_at === right?.submitted_at &&
+    left?.body === right?.body &&
+    left?.user?.login === right?.user?.login &&
+    left?.user?.id === right?.user?.id &&
+    left?.user?.type === right?.user?.type
+  );
+}
+
+function validateLinearCompare(value, baseSha, sourceSha, expectedCommitCount) {
+  invariant(
+    value?.status === "ahead",
+    "rewritten release source is not strictly ahead of its PR base",
+  );
+  invariant(value?.base_commit?.sha === baseSha, "compare response base commit changed");
+  invariant(value?.merge_base_commit?.sha === baseSha, "compare response merge base changed");
+  invariant(value?.behind_by === 0, "rewritten release source is behind its PR base");
+  invariant(
+    value?.ahead_by === expectedCommitCount && value?.total_commits === expectedCommitCount,
+    "rewritten release source commit count differs from provider PR evidence",
+  );
+  invariant(
+    Array.isArray(value?.commits) && value.commits.length === expectedCommitCount,
+    "compare response does not contain the complete rewritten commit range",
+  );
+  let parent = baseSha;
+  for (const [index, commit] of value.commits.entries()) {
+    invariant(
+      Array.isArray(commit?.parents) && commit.parents.length === 1,
+      "rewritten release range is not linear",
+    );
+    invariant(commit.parents[0]?.sha === parent, "rewritten release range has a discontinuity");
+    parent = assertSha(commit?.sha, `rewritten release commit ${index}`);
+  }
+  invariant(parent === sourceSha, "rewritten release range does not terminate at the source SHA");
+}
+
+async function classifyMergeOutcome(api, source, pullIdentity) {
+  const exactMerge =
+    source.parents.length === 2 &&
+    source.parents[0] === pullIdentity.baseSha &&
+    source.parents[1] === pullIdentity.headSha;
+  if (exactMerge) return "merge";
+
+  const compare = await api.get(repositoryPath(`/compare/${pullIdentity.baseSha}...${source.sha}`));
+  const sourceCommitCount = Number(compare?.ahead_by);
+  validateLinearCompare(compare, pullIdentity.baseSha, source.sha, sourceCommitCount);
+  invariant(
+    sourceCommitCount === 1 || sourceCommitCount === pullIdentity.commitCount,
+    "rewritten release source is neither an exact squash nor an exact rebase",
+  );
+  if (sourceCommitCount === 1) {
+    invariant(
+      source.parents.length === 1 && source.parents[0] === pullIdentity.baseSha,
+      "squashed release source is not one commit on its exact PR base",
+    );
+    return pullIdentity.commitCount === 1 ? "single-commit-squash-or-rebase" : "squash";
+  }
+  invariant(sourceCommitCount > 1, "rebased release source is empty");
+  return "rebase";
+}
+
 function releaseApprovalContext(env, suppliedSourceSha) {
   requiredEnvironment(env, [
     "GITHUB_API_URL",
@@ -693,13 +889,13 @@ export async function verifyApprovedMerge(options = {}) {
   const logger = options.logger ?? console;
   const context = releaseApprovalContext(env, options.sourceSha);
   const api = githubClient(options.fetchImpl ?? globalThis.fetch, context.token);
-  const commit = await api.get(repositoryPath(`/git/commits/${context.sourceSha}`));
-  invariant(commit?.sha === context.sourceSha, "release source commit changed");
-  invariant(Array.isArray(commit?.parents), "release source parents are missing");
-  invariant(commit.parents.length === 2, "release source is not a two-parent PR merge");
-  const baseSha = assertSha(commit.parents[0]?.sha, "release merge first parent");
-  const headSha = assertSha(commit.parents[1]?.sha, "release merge second parent");
-  invariant(baseSha !== headSha, "release merge parents are identical");
+  const initialMain = await api.get(repositoryPath("/git/ref/heads/main"));
+  assertMainRef(initialMain, context.sourceSha, "initial release main");
+  const source = assertCommit(
+    await api.get(repositoryPath(`/git/commits/${context.sourceSha}`)),
+    context.sourceSha,
+    "release source commit",
+  );
 
   const pulls = await paginatedArray(
     api,
@@ -707,29 +903,32 @@ export async function verifyApprovedMerge(options = {}) {
     "associated pull requests",
   );
   invariant(pulls.length === 1, "release source is not associated with exactly one pull request");
-  const pull = record(pulls[0], "associated pull request");
-  invariant(pull.state === "closed", "associated pull request is not closed");
-  invariant(pull.merge_commit_sha === context.sourceSha, "pull-request merge SHA changed");
+  const associatedPull = record(pulls[0], "associated pull request");
+  const pullNumber = assertPositiveInteger(associatedPull.number, "associated pull-request number");
   invariant(
-    pull.base?.ref === RELEASE_AUTOMATION_CONTRACT.defaultBranch,
-    "pull-request base changed",
+    associatedPull.merge_commit_sha === context.sourceSha,
+    "associated pull summary merge SHA changed",
   );
+  const pull = record(await api.get(repositoryPath(`/pulls/${pullNumber}`)), "pull-request detail");
+  const pullIdentity = assertMergedPull(pull, { pullNumber, sourceSha: context.sourceSha });
   invariant(
-    pull.base?.repo?.full_name === RELEASE_AUTOMATION_CONTRACT.repository,
-    "pull-request base repository changed",
+    associatedPull.base?.sha === pullIdentity.baseSha &&
+      associatedPull.head?.sha === pullIdentity.headSha,
+    "associated pull summary differs from pull-request detail",
   );
-  invariant(pull.base?.sha === baseSha, "pull-request base is not merge parent one");
-  invariant(pull.head?.sha === headSha, "pull-request head is not merge parent two");
-  const pullNumber = assertPositiveInteger(pull.number, "associated pull-request number");
-  const author = record(pull.user, "pull-request author");
-  assertString(author.login, "pull-request author login");
-  const authorId = assertPositiveInteger(author.id, "pull-request author ID");
-  invariant(author.type === "User" || author.type === "Bot", "pull-request author type is invalid");
+  const [base, head] = await Promise.all([
+    api
+      .get(repositoryPath(`/git/commits/${pullIdentity.baseSha}`))
+      .then((value) => assertCommit(value, pullIdentity.baseSha, "reviewed base commit")),
+    api
+      .get(repositoryPath(`/git/commits/${pullIdentity.headSha}`))
+      .then((value) => assertCommit(value, pullIdentity.headSha, "reviewed head commit")),
+  ]);
   invariant(
-    authorId !== RELEASE_AUTOMATION_CONTRACT.releaseApprover.id,
-    "trusted reviewer authored the pull request",
+    source.treeSha === head.treeSha,
+    "release source tree differs from the exact reviewed head",
   );
-  const mergedAt = assertTimestamp(pull.merged_at, "pull-request merge timestamp");
+  const mergeMethod = await classifyMergeOutcome(api, source, pullIdentity);
 
   const reviews = await paginatedArray(
     api,
@@ -742,8 +941,10 @@ export async function verifyApprovedMerge(options = {}) {
         review?.user?.login === RELEASE_AUTOMATION_CONTRACT.releaseApprover.login &&
         review.user.id === RELEASE_AUTOMATION_CONTRACT.releaseApprover.id &&
         review.user.type === RELEASE_AUTOMATION_CONTRACT.releaseApprover.type &&
-        review.commit_id === headSha &&
-        decisiveReviewStates.has(review.state),
+        review.commit_id === pullIdentity.headSha &&
+        (decisiveReviewStates.has(review.state) ||
+          (review.state === "COMMENTED" &&
+            review.body?.startsWith("<!-- opengeni-exact-head-release-review:v3 -->"))),
     )
     .map((review) => ({
       id: assertPositiveInteger(review.id, "trusted review ID"),
@@ -754,23 +955,108 @@ export async function verifyApprovedMerge(options = {}) {
   invariant(decisions.length > 0, "trusted reviewer did not review the exact PR head");
   const decision = decisions.at(-1);
   invariant(
-    decision.review.state === "APPROVED",
-    "trusted review does not currently approve the exact head",
+    decision.submittedAt <= pullIdentity.mergedAt,
+    "trusted approval was not submitted before merge",
   );
-  invariant(decision.submittedAt < mergedAt, "trusted approval was not submitted before merge");
   assertIdentity(
     decision.review.user,
     RELEASE_AUTOMATION_CONTRACT.releaseApprover,
     "trusted reviewer",
   );
-  logger.log(`Verified PR #${pullNumber} exact-head approval before merge ${context.sourceSha}.`);
-  return {
+  const reviewUrl =
+    `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+    `/pull/${pullNumber}#pullrequestreview-${decision.id}`;
+  invariant(decision.review.html_url === reviewUrl, "trusted review URL changed");
+  const reviewDetail = await api.get(repositoryPath(`/pulls/${pullNumber}/reviews/${decision.id}`));
+  invariant(
+    sameProviderReview(decision.review, reviewDetail),
+    "trusted review detail differs from provider review history",
+  );
+  invariant(
+    !pull.requested_reviewers.some(
+      (candidate) =>
+        candidate?.login?.toLowerCase() ===
+        RELEASE_AUTOMATION_CONTRACT.releaseApprover.login.toLowerCase(),
+    ),
+    "trusted review is no longer effective because review was re-requested",
+  );
+
+  let reviewType;
+  let reviewEvidenceSha256;
+  if (decision.review.state === "APPROVED") {
+    invariant(
+      pullIdentity.author.id !== RELEASE_AUTOMATION_CONTRACT.releaseApprover.id,
+      "trusted reviewer authored the independently approved pull request",
+    );
+    reviewType = "independent-approval";
+    reviewEvidenceSha256 = canonicalSha256({
+      version: 1,
+      repository: RELEASE_AUTOMATION_CONTRACT.repository,
+      pullRequestNumber: pullNumber,
+      reviewedBaseSha: pullIdentity.baseSha,
+      reviewedHeadSha: pullIdentity.headSha,
+      reviewerLogin: RELEASE_AUTOMATION_CONTRACT.releaseApprover.login,
+      reviewId: decision.id,
+      verdict: "APPROVED",
+    });
+  } else {
+    invariant(
+      decision.review.state === "COMMENTED" &&
+        pullIdentity.author.id === RELEASE_AUTOMATION_CONTRACT.releaseApprover.id &&
+        pullIdentity.merger.id === RELEASE_AUTOMATION_CONTRACT.releaseApprover.id &&
+        pullIdentity.author.type === "User" &&
+        pullIdentity.merger.type === "User",
+      "trusted review is neither independent approval nor a provider-bound single-maintainer admin PASS",
+    );
+    reviewType = "single-maintainer-admin-pass";
+    reviewEvidenceSha256 = verifyAdminPassBody(
+      decision.review.body ?? "",
+      exactHeadReviewArtifact(pullIdentity.baseSha, pullIdentity.headSha),
+    );
+  }
+
+  const [headChecks, sourceChecks] = await Promise.all([
+    paginatedCheckRuns(api, pullIdentity.headSha),
+    paginatedCheckRuns(api, context.sourceSha),
+  ]);
+  const sourceAdmission = assertSuccessfulCheck(
+    headChecks,
+    RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+    pullIdentity.headSha,
+  );
+  const requiredSourceChecks = RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name) =>
+    assertSuccessfulCheck(sourceChecks, name, context.sourceSha),
+  );
+  const terminalMain = await api.get(repositoryPath("/git/ref/heads/main"));
+  assertMainRef(terminalMain, context.sourceSha, "terminal release main");
+
+  const provenance = {
+    version: 1,
+    repository: RELEASE_AUTOMATION_CONTRACT.repository,
     sourceSha: context.sourceSha,
-    baseSha,
-    headSha,
-    pullNumber,
-    reviewId: decision.id,
+    sourceTreeSha: source.treeSha,
+    sourceParents: source.parents,
+    pullRequestNumber: pullNumber,
+    mergeMethod,
+    providerPullCommitCount: pullIdentity.commitCount,
+    mergedAt: new Date(pullIdentity.mergedAt).toISOString(),
+    reviewedBaseSha: pullIdentity.baseSha,
+    reviewedBaseTreeSha: base.treeSha,
+    reviewedHeadSha: pullIdentity.headSha,
+    reviewedHeadTreeSha: head.treeSha,
+    review: {
+      type: reviewType,
+      id: decision.id,
+      url: reviewUrl,
+      evidenceSha256: reviewEvidenceSha256,
+    },
+    sourceAdmission,
+    requiredSourceChecks,
   };
+  logger.log(
+    `Verified PR #${pullNumber} ${mergeMethod} provenance and exact checks for ${context.sourceSha}.`,
+  );
+  return provenance;
 }
 
 function writeOutputs(values, env) {

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -23,6 +23,10 @@ export const RELEASE_AUTOMATION_CONTRACT = Object.freeze({
     id: 55702375,
     type: "User",
   }),
+  githubActionsApp: Object.freeze({
+    slug: "github-actions",
+    id: 15368,
+  }),
   checks: Object.freeze({
     sourceAdmission: "Current-base source admission",
     automationCi: "Automation PR CI",
@@ -300,6 +304,10 @@ function repositoryPath(path) {
   return `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}${path}`;
 }
 
+function repositoryApiUrl(path) {
+  return `${RELEASE_AUTOMATION_CONTRACT.apiUrl}${repositoryPath(path)}`;
+}
+
 async function terminalVersionIdentity(api, context) {
   const [main, pull, versionBranch, headCommit] = await Promise.all([
     api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
@@ -536,7 +544,7 @@ async function findCheckRun(api, context, identity) {
     for (const check of response.check_runs) {
       if (check?.external_id !== identity.externalId) continue;
       invariant(check?.head_sha === context.headSha, "existing check run is bound to another head");
-      invariant(check?.app?.slug === "github-actions", "existing check run has another owner app");
+      assertGitHubActionsApp(check?.app, "existing check run");
       invariant(
         Number.isSafeInteger(check?.id) && check.id > 0,
         "existing check-run ID is invalid",
@@ -668,7 +676,9 @@ async function paginatedCheckRuns(api, sha) {
   const rows = [];
   for (let page = 1; page <= maximumPages; page += 1) {
     const value = await api.get(
-      repositoryPath(`/commits/${sha}/check-runs?per_page=${recordsPerPage}&page=${page}`),
+      repositoryPath(
+        `/commits/${sha}/check-runs?filter=all&per_page=${recordsPerPage}&page=${page}`,
+      ),
     );
     invariant(Array.isArray(value?.check_runs), "check-run listing is invalid");
     rows.push(...value.check_runs);
@@ -677,16 +687,29 @@ async function paginatedCheckRuns(api, sha) {
   throw new Error(`check-run listing exceeded ${maximumPages * recordsPerPage} records`);
 }
 
+function assertGitHubActionsApp(app, label) {
+  invariant(
+    app?.slug === RELEASE_AUTOMATION_CONTRACT.githubActionsApp.slug &&
+      app?.id === RELEASE_AUTOMATION_CONTRACT.githubActionsApp.id,
+    `${label} is not owned by the official GitHub Actions app`,
+  );
+}
+
 function assertSuccessfulCheck(checks, name, sha) {
   const selected = checks.filter((check) => check?.name === name);
   invariant(selected.length === 1, `${name} is not represented by exactly one check run on ${sha}`);
   const check = selected[0];
-  invariant(check?.app?.slug === "github-actions", `${name} is not owned by GitHub Actions`);
+  invariant(check?.head_sha === sha, `${name} is bound to another commit`);
+  assertGitHubActionsApp(check?.app, name);
   invariant(
     check.status === "completed" && check.conclusion === "success",
     `${name} did not complete successfully`,
   );
-  return Object.freeze({ name, appSlug: "github-actions" });
+  return Object.freeze({
+    name,
+    appSlug: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.slug,
+    appId: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.id,
+  });
 }
 
 function assertCommit(value, expectedSha, label) {
@@ -743,6 +766,32 @@ function assertMergedPull(value, expected) {
     "pull-request merge actor type is invalid",
   );
   return { baseSha, headSha, mergedAt, author, merger, commitCount: value.commits };
+}
+
+function assertProviderMergeEvent(events, sourceSha, pullIdentity) {
+  const matching = events.filter(
+    (event) => event?.event === "merged" && event?.commit_id === sourceSha,
+  );
+  invariant(
+    matching.length === 1,
+    "release source is not represented by exactly one provider merge event",
+  );
+  const event = record(matching[0], "provider merge event");
+  invariant(
+    event.commit_url === repositoryApiUrl(`/commits/${sourceSha}`),
+    "provider merge event commit URL changed",
+  );
+  invariant(
+    assertTimestamp(event.created_at, "provider merge event timestamp") === pullIdentity.mergedAt,
+    "provider merge event timestamp differs from pull-request merge time",
+  );
+  assertIdentity(event.actor, pullIdentity.merger, "provider merge actor");
+  assertString(event.node_id, "provider merge event node ID");
+  const eventId = assertPositiveInteger(event.id, "provider merge event ID");
+  invariant(
+    event.url === repositoryApiUrl(`/issues/events/${eventId}`),
+    "provider merge event URL changed",
+  );
 }
 
 function exactHeadReviewArtifact(baseSha, headSha) {
@@ -916,6 +965,12 @@ export async function verifyApprovedMerge(options = {}) {
       associatedPull.head?.sha === pullIdentity.headSha,
     "associated pull summary differs from pull-request detail",
   );
+  const timeline = await paginatedArray(
+    api,
+    repositoryPath(`/issues/${pullNumber}/timeline`),
+    "pull-request timeline",
+  );
+  assertProviderMergeEvent(timeline, context.sourceSha, pullIdentity);
   const [base, head] = await Promise.all([
     api
       .get(repositoryPath(`/git/commits/${pullIdentity.baseSha}`))
@@ -1104,9 +1159,9 @@ async function runCommand(env = process.env) {
     const result = await verifyApprovedMerge({ env });
     writeOutputs(
       {
-        approved_pr_number: result.pullNumber,
-        approved_pr_head_sha: result.headSha,
-        approved_review_id: result.reviewId,
+        approved_pr_number: result.pullRequestNumber,
+        approved_pr_head_sha: result.reviewedHeadSha,
+        approved_review_id: result.review.id,
       },
       env,
     );

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -12,6 +12,7 @@ import {
 const root = join(import.meta.dir, "..");
 const releaseWorkflowPath = join(root, RELEASE_AUTOMATION_CONTRACT.releaseWorkflowPath);
 const ciWorkflowPath = join(root, RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath);
+const releaseAutomationPath = join(root, "scripts/check-release-pr-automation.mjs");
 const baseSha = "b".repeat(40);
 const headSha = "c".repeat(40);
 const mergeSha = "d".repeat(40);
@@ -452,7 +453,11 @@ function checksFixture() {
         check_runs: checks.filter((check) => check.name === url.searchParams.get("check_name")),
       });
     if (method === "POST" && url.pathname === `${prefix}/check-runs`) {
-      const check = { ...body, id: nextId++, app: { slug: "github-actions" } };
+      const check = {
+        ...body,
+        id: nextId++,
+        app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+      };
       checks.push(check);
       return response(check, 201);
     }
@@ -519,7 +524,10 @@ function approvalFixture(
     requestedReview?: boolean;
     headChecks?: Array<Record<string, unknown>>;
     sourceChecks?: Array<Record<string, unknown>>;
+    historicalHeadChecks?: Array<Record<string, unknown>>;
+    historicalSourceChecks?: Array<Record<string, unknown>>;
     discontinuousCompare?: boolean;
+    mergeEvent?: Record<string, unknown> | null;
   } = {},
 ) {
   const requests: RequestRecord[] = [];
@@ -566,12 +574,28 @@ function approvalFixture(
     body: reviewBody,
     user: RELEASE_AUTOMATION_CONTRACT.releaseApprover,
   };
-  const successfulCheck = (name: string) => ({
+  const successfulCheck = (name: string, sha: string) => ({
     name,
+    head_sha: sha,
     status: "completed",
     conclusion: "success",
-    app: { slug: "github-actions" },
+    app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
   });
+  const mergeEvent =
+    options.mergeEvent === null
+      ? []
+      : [
+          options.mergeEvent ?? {
+            id: 7001,
+            node_id: "ME_fixture",
+            url: `${RELEASE_AUTOMATION_CONTRACT.apiUrl}${prefix}/issues/events/7001`,
+            event: "merged",
+            actor: merger,
+            commit_id: mergeSha,
+            commit_url: `${RELEASE_AUTOMATION_CONTRACT.apiUrl}${prefix}/commits/${mergeSha}`,
+            created_at: "2026-07-23T12:00:00Z",
+          },
+        ];
   let mainReads = 0;
   async function fetchImpl(input: string | URL | Request, init?: RequestInit) {
     const url = new URL(String(input));
@@ -629,6 +653,8 @@ function approvalFixture(
           ? [RELEASE_AUTOMATION_CONTRACT.releaseApprover]
           : [],
       });
+    if (method === "GET" && url.pathname === `${prefix}/issues/${pullNumber}/timeline`)
+      return response(mergeEvent);
     if (method === "GET" && url.pathname === `${prefix}/compare/${baseSha}...${mergeSha}`) {
       const commits =
         mergeMethod === "rebase"
@@ -656,15 +682,24 @@ function approvalFixture(
       return response(review);
     if (method === "GET" && url.pathname === `${prefix}/commits/${pullHeadSha}/check-runs`)
       return response({
-        check_runs: options.headChecks ?? [
-          successfulCheck(RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission),
+        check_runs: [
+          ...(options.headChecks ?? [
+            successfulCheck(RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission, pullHeadSha),
+          ]),
+          ...(url.searchParams.get("filter") === "all" ? (options.historicalHeadChecks ?? []) : []),
         ],
       });
     if (method === "GET" && url.pathname === `${prefix}/commits/${mergeSha}/check-runs`)
       return response({
-        check_runs:
-          options.sourceChecks ??
-          RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map(successfulCheck),
+        check_runs: [
+          ...(options.sourceChecks ??
+            RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name) =>
+              successfulCheck(name, mergeSha),
+            )),
+          ...(url.searchParams.get("filter") === "all"
+            ? (options.historicalSourceChecks ?? [])
+            : []),
+        ],
       });
     return response({ message: `unexpected ${method} ${url.pathname}` }, 404);
   }
@@ -700,6 +735,7 @@ describe("release approval provenance", () => {
         sourceAdmission: {
           name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
           appSlug: "github-actions",
+          appId: 15368,
         },
       }),
     );
@@ -770,6 +806,15 @@ describe("release approval provenance", () => {
     ).rejects.toThrow("is not merged");
   });
 
+  test("rejects an associated direct fast-forward with matching provider topology", async () => {
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ mergeMethod: "single", mergeEvent: null }).fetchImpl,
+      }),
+    ).rejects.toThrow("exactly one provider merge event");
+  });
+
   test("rejects tree, head, topology, effective-review, and terminal-main drift", async () => {
     await expect(
       verifyApprovedMerge({
@@ -805,11 +850,12 @@ describe("release approval provenance", () => {
   });
 
   test("rejects missing, duplicate, failed, or foreign source-admission and source checks", async () => {
-    const success = (name: string, appSlug = "github-actions") => ({
+    const success = (name: string, sha = headSha, appSlug = "github-actions", appId = 15368) => ({
       name,
+      head_sha: sha,
       status: "completed",
       conclusion: "success",
-      app: { slug: appSlug },
+      app: { slug: appSlug, id: appId },
     });
     await expect(
       verifyApprovedMerge({
@@ -832,27 +878,75 @@ describe("release approval provenance", () => {
       verifyApprovedMerge({
         env: approvalEnv(),
         fetchImpl: approvalFixture({
-          headChecks: [success(RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission, "forged-app")],
+          headChecks: [
+            success(RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission, headSha, "forged-app"),
+          ],
         }).fetchImpl,
       }),
-    ).rejects.toThrow("not owned by GitHub Actions");
+    ).rejects.toThrow("not owned by the official GitHub Actions app");
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          headChecks: [
+            success(
+              RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+              headSha,
+              "github-actions",
+              999,
+            ),
+          ],
+        }).fetchImpl,
+      }),
+    ).rejects.toThrow("not owned by the official GitHub Actions app");
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          headChecks: [success(RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission, mergeSha)],
+        }).fetchImpl,
+      }),
+    ).rejects.toThrow("bound to another commit");
     await expect(
       verifyApprovedMerge({
         env: approvalEnv(),
         fetchImpl: approvalFixture({
           sourceChecks: RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name, index) => ({
-            ...success(name),
+            ...success(name, mergeSha),
             conclusion: index === 0 ? "failure" : "success",
           })),
         }).fetchImpl,
       }),
     ).rejects.toThrow("did not complete successfully");
   });
+
+  test("uses all check runs so a failed run hidden by a successful rerequest is rejected", async () => {
+    const successful = {
+      name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      head_sha: headSha,
+      status: "completed",
+      conclusion: "success",
+      app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+    };
+    const fixture = approvalFixture({
+      headChecks: [successful],
+      historicalHeadChecks: [{ ...successful, conclusion: "failure" }],
+    });
+    await expect(
+      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: fixture.fetchImpl }),
+    ).rejects.toThrow("exactly one check run");
+    expect(
+      fixture.requests
+        .filter((request) => request.path.endsWith("/check-runs"))
+        .every((request) => request.query.get("filter") === "all"),
+    ).toBe(true);
+  });
 });
 
 describe("workflow contracts", () => {
   const releaseText = readFileSync(releaseWorkflowPath, "utf8");
   const ciText = readFileSync(ciWorkflowPath, "utf8");
+  const releaseAutomationText = readFileSync(releaseAutomationPath, "utf8");
   const release = Bun.YAML.parse(releaseText) as any;
   const ci = Bun.YAML.parse(ciText) as any;
 
@@ -944,6 +1038,12 @@ describe("workflow contracts", () => {
     expect(ciText).toContain("AUTOMATION_CHECK_KIND: source-admission");
     expect(ciText).toContain("AUTOMATION_CHECK_KIND: automation-ci");
     expect(releaseText).toContain("verify-approved-merge");
+  });
+
+  test("writes approved provenance outputs from the provider result field names", () => {
+    expect(releaseAutomationText).toContain("approved_pr_number: result.pullRequestNumber");
+    expect(releaseAutomationText).toContain("approved_pr_head_sha: result.reviewedHeadSha");
+    expect(releaseAutomationText).toContain("approved_review_id: result.review.id");
   });
 
   test("requires complete live acceptance before any publication", () => {

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -17,6 +17,7 @@ const headSha = "c".repeat(40);
 const mergeSha = "d".repeat(40);
 const baseTreeSha = "e".repeat(40);
 const headTreeSha = "f".repeat(40);
+const rebasedFirstSha = "a".repeat(40);
 const pullNumber = 88;
 const runId = 123456;
 const runAttempt = 2;
@@ -502,62 +503,226 @@ function approvalEnv(overrides: Record<string, string> = {}) {
 
 function approvalFixture(
   options: {
+    mergeMethod?: "merge" | "squash" | "rebase" | "single";
+    associatedPullCount?: number;
     authorId?: number;
+    pullState?: string;
+    merged?: boolean;
+    mergeCommitSha?: string;
+    pullHeadSha?: string;
+    sourceTreeSha?: string;
+    terminalMainSha?: string;
     reviewCommit?: string;
     reviewState?: string;
     reviewTime?: string;
+    reviewBody?: string;
+    requestedReview?: boolean;
+    headChecks?: Array<Record<string, unknown>>;
+    sourceChecks?: Array<Record<string, unknown>>;
+    discontinuousCompare?: boolean;
   } = {},
 ) {
   const requests: RequestRecord[] = [];
   const prefix = `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}`;
+  const mergeMethod = options.mergeMethod ?? "merge";
+  const pullHeadSha = options.pullHeadSha ?? headSha;
+  const pullCommitCount = mergeMethod === "single" ? 1 : 2;
+  const sourceParents =
+    mergeMethod === "merge"
+      ? [{ sha: baseSha }, { sha: pullHeadSha }]
+      : mergeMethod === "rebase"
+        ? [{ sha: rebasedFirstSha }]
+        : [{ sha: baseSha }];
+  const author =
+    options.authorId === RELEASE_AUTOMATION_CONTRACT.releaseApprover.id ||
+    (options.reviewState === "COMMENTED" && options.authorId === undefined)
+      ? RELEASE_AUTOMATION_CONTRACT.releaseApprover
+      : { login: "release-bot", id: options.authorId ?? 41898282, type: "Bot" };
+  const merger =
+    options.reviewState === "COMMENTED"
+      ? RELEASE_AUTOMATION_CONTRACT.releaseApprover
+      : { login: "merge-maintainer", id: 1234567, type: "User" };
+  const artifact = {
+    version: 3,
+    kind: "opengeni-exact-head-release-review",
+    repository: RELEASE_AUTOMATION_CONTRACT.repository,
+    reviewedBaseSha: baseSha,
+    reviewedHeadSha: pullHeadSha,
+    reviewerLogin: RELEASE_AUTOMATION_CONTRACT.releaseApprover.login,
+    reviewProfile: "exact-head-maintainer-v1",
+    verdict: "PASS",
+  };
+  const reviewBody =
+    options.reviewBody ??
+    `<!-- opengeni-exact-head-release-review:v3 -->\n\n\`\`\`json\n${JSON.stringify(artifact, null, 2)}\n\`\`\``;
+  const review = {
+    id: 9001,
+    state: options.reviewState ?? "APPROVED",
+    commit_id: options.reviewCommit ?? pullHeadSha,
+    submitted_at: options.reviewTime ?? "2026-07-23T11:59:00Z",
+    html_url:
+      `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+      `/pull/${pullNumber}#pullrequestreview-9001`,
+    body: reviewBody,
+    user: RELEASE_AUTOMATION_CONTRACT.releaseApprover,
+  };
+  const successfulCheck = (name: string) => ({
+    name,
+    status: "completed",
+    conclusion: "success",
+    app: { slug: "github-actions" },
+  });
+  let mainReads = 0;
   async function fetchImpl(input: string | URL | Request, init?: RequestInit) {
     const url = new URL(String(input));
     const method = init?.method ?? "GET";
     requests.push({ method, path: url.pathname, query: url.searchParams });
+    if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/main`) {
+      mainReads += 1;
+      return response(mainRef(mainReads === 1 ? mergeSha : (options.terminalMainSha ?? mergeSha)));
+    }
     if (method === "GET" && url.pathname === `${prefix}/git/commits/${mergeSha}`)
-      return response({ sha: mergeSha, parents: [{ sha: baseSha }, { sha: headSha }] });
+      return response({
+        sha: mergeSha,
+        tree: { sha: options.sourceTreeSha ?? headTreeSha },
+        parents: sourceParents,
+      });
+    if (method === "GET" && url.pathname === `${prefix}/git/commits/${baseSha}`)
+      return response({
+        sha: baseSha,
+        tree: { sha: baseTreeSha },
+        parents: [{ sha: "1".repeat(40) }],
+      });
+    if (method === "GET" && url.pathname === `${prefix}/git/commits/${pullHeadSha}`)
+      return response({
+        sha: pullHeadSha,
+        tree: { sha: headTreeSha },
+        parents: [{ sha: baseSha }],
+      });
     if (method === "GET" && url.pathname === `${prefix}/commits/${mergeSha}/pulls`)
-      return response([
-        {
-          number: pullNumber,
-          state: "closed",
-          merge_commit_sha: mergeSha,
-          merged_at: "2026-07-23T12:00:00Z",
-          user: { login: "release-bot", id: options.authorId ?? 41898282, type: "Bot" },
-          base: {
-            ref: "main",
-            sha: baseSha,
-            repo: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
-          },
-          head: { sha: headSha },
+      return response(
+        Array.from({ length: options.associatedPullCount ?? 1 }, (_, index) => ({
+          number: pullNumber + index,
+          merge_commit_sha: options.mergeCommitSha ?? mergeSha,
+          base: { sha: baseSha },
+          head: { sha: pullHeadSha },
+        })),
+      );
+    if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}`)
+      return response({
+        number: pullNumber,
+        html_url: `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}/pull/${pullNumber}`,
+        state: options.pullState ?? "closed",
+        merged: options.merged ?? true,
+        merge_commit_sha: options.mergeCommitSha ?? mergeSha,
+        merged_at: "2026-07-23T12:00:00Z",
+        user: author,
+        merged_by: merger,
+        base: {
+          ref: "main",
+          sha: baseSha,
+          repo: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
         },
-      ]);
+        head: { sha: pullHeadSha },
+        commits: pullCommitCount,
+        requested_reviewers: options.requestedReview
+          ? [RELEASE_AUTOMATION_CONTRACT.releaseApprover]
+          : [],
+      });
+    if (method === "GET" && url.pathname === `${prefix}/compare/${baseSha}...${mergeSha}`) {
+      const commits =
+        mergeMethod === "rebase"
+          ? [
+              { sha: rebasedFirstSha, parents: [{ sha: baseSha }] },
+              {
+                sha: mergeSha,
+                parents: [{ sha: options.discontinuousCompare ? baseSha : rebasedFirstSha }],
+              },
+            ]
+          : [{ sha: mergeSha, parents: [{ sha: baseSha }] }];
+      return response({
+        status: "ahead",
+        base_commit: { sha: baseSha },
+        merge_base_commit: { sha: baseSha },
+        ahead_by: commits.length,
+        behind_by: 0,
+        total_commits: commits.length,
+        commits,
+      });
+    }
     if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}/reviews`)
-      return response([
-        {
-          id: 9001,
-          state: options.reviewState ?? "APPROVED",
-          commit_id: options.reviewCommit ?? headSha,
-          submitted_at: options.reviewTime ?? "2026-07-23T11:59:00Z",
-          user: RELEASE_AUTOMATION_CONTRACT.releaseApprover,
-        },
-      ]);
+      return response([review]);
+    if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}/reviews/9001`)
+      return response(review);
+    if (method === "GET" && url.pathname === `${prefix}/commits/${pullHeadSha}/check-runs`)
+      return response({
+        check_runs: options.headChecks ?? [
+          successfulCheck(RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission),
+        ],
+      });
+    if (method === "GET" && url.pathname === `${prefix}/commits/${mergeSha}/check-runs`)
+      return response({
+        check_runs:
+          options.sourceChecks ??
+          RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map(successfulCheck),
+      });
     return response({ message: `unexpected ${method} ${url.pathname}` }, 404);
   }
   return { fetchImpl, requests };
 }
 
 describe("release approval provenance", () => {
-  test("accepts a distinct trusted user's native exact-head approval before merge", async () => {
-    const fixture = approvalFixture();
+  test.each([
+    ["merge", "merge"],
+    ["squash", "squash"],
+    ["rebase", "rebase"],
+    ["single", "single-commit-squash-or-rebase"],
+  ] as const)("accepts provider-proved %s provenance", async (fixtureMethod, expectedMethod) => {
+    const fixture = approvalFixture({ mergeMethod: fixtureMethod });
+    const result = await verifyApprovedMerge({
+      env: approvalEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+      mergeMethod: "forged-caller-value",
+    } as any);
+    expect(result).toEqual(
+      expect.objectContaining({
+        version: 1,
+        repository: RELEASE_AUTOMATION_CONTRACT.repository,
+        sourceSha: mergeSha,
+        sourceTreeSha: headTreeSha,
+        pullRequestNumber: pullNumber,
+        mergeMethod: expectedMethod,
+        reviewedBaseSha: baseSha,
+        reviewedBaseTreeSha: baseTreeSha,
+        reviewedHeadSha: headSha,
+        reviewedHeadTreeSha: headTreeSha,
+        sourceAdmission: {
+          name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+          appSlug: "github-actions",
+        },
+      }),
+    );
+    expect(result.requiredSourceChecks.map((check: { name: string }) => check.name)).toEqual(
+      RELEASE_AUTOMATION_CONTRACT.checks.requiredSource,
+    );
+    expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  test("accepts the provider-bound structured single-maintainer admin PASS", async () => {
+    const fixture = approvalFixture({ mergeMethod: "single", reviewState: "COMMENTED" });
     await expect(
       verifyApprovedMerge({
         env: approvalEnv(),
         fetchImpl: fixture.fetchImpl,
         logger: { log() {} },
       }),
-    ).resolves.toEqual({ sourceSha: mergeSha, baseSha, headSha, pullNumber, reviewId: 9001 });
-    expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
+    ).resolves.toEqual(
+      expect.objectContaining({
+        mergeMethod: "single-commit-squash-or-rebase",
+        review: expect.objectContaining({ type: "single-maintainer-admin-pass" }),
+      }),
+    );
   });
 
   test("rejects stale-head and post-merge approvals", async () => {
@@ -575,11 +740,113 @@ describe("release approval provenance", () => {
     const self = approvalFixture({ authorId: RELEASE_AUTOMATION_CONTRACT.releaseApprover.id });
     await expect(
       verifyApprovedMerge({ env: approvalEnv(), fetchImpl: self.fetchImpl }),
-    ).rejects.toThrow("trusted reviewer authored the pull request");
+    ).rejects.toThrow("trusted reviewer authored the independently approved pull request");
     const requested = approvalFixture({ reviewState: "CHANGES_REQUESTED" });
     await expect(
       verifyApprovedMerge({ env: approvalEnv(), fetchImpl: requested.fetchImpl }),
-    ).rejects.toThrow("does not currently approve the exact head");
+    ).rejects.toThrow(
+      "neither independent approval nor a provider-bound single-maintainer admin PASS",
+    );
+  });
+
+  test("rejects direct pushes, ambiguous associations, and reopened or unmerged PRs", async () => {
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ associatedPullCount: 0 }).fetchImpl,
+      }),
+    ).rejects.toThrow("exactly one pull request");
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ associatedPullCount: 2 }).fetchImpl,
+      }),
+    ).rejects.toThrow("exactly one pull request");
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ pullState: "open", merged: false }).fetchImpl,
+      }),
+    ).rejects.toThrow("is not merged");
+  });
+
+  test("rejects tree, head, topology, effective-review, and terminal-main drift", async () => {
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ sourceTreeSha: "9".repeat(40) }).fetchImpl,
+      }),
+    ).rejects.toThrow("tree differs");
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ pullHeadSha: "8".repeat(40), reviewCommit: headSha })
+          .fetchImpl,
+      }),
+    ).rejects.toThrow("did not review the exact PR head");
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ mergeMethod: "rebase", discontinuousCompare: true }).fetchImpl,
+      }),
+    ).rejects.toThrow("discontinuity");
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ requestedReview: true }).fetchImpl,
+      }),
+    ).rejects.toThrow("review was re-requested");
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ terminalMainSha: "7".repeat(40) }).fetchImpl,
+      }),
+    ).rejects.toThrow("terminal release main differs");
+  });
+
+  test("rejects missing, duplicate, failed, or foreign source-admission and source checks", async () => {
+    const success = (name: string, appSlug = "github-actions") => ({
+      name,
+      status: "completed",
+      conclusion: "success",
+      app: { slug: appSlug },
+    });
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ headChecks: [] }).fetchImpl,
+      }),
+    ).rejects.toThrow("exactly one check run");
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          headChecks: [
+            success(RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission),
+            success(RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission),
+          ],
+        }).fetchImpl,
+      }),
+    ).rejects.toThrow("exactly one check run");
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          headChecks: [success(RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission, "forged-app")],
+        }).fetchImpl,
+      }),
+    ).rejects.toThrow("not owned by GitHub Actions");
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          sourceChecks: RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name, index) => ({
+            ...success(name),
+            conclusion: index === 0 ? "failure" : "success",
+          })),
+        }).fetchImpl,
+      }),
+    ).rejects.toThrow("did not complete successfully");
   });
 });
 


### PR DESCRIPTION
## Summary

- derive release admission from exact GitHub PR, commit, tree, review, actor, timeline, and compare records
- support exact merge commits, squashes, rebases, and the truthful one-commit squash/rebase equivalence class
- require unique successful exact-head source admission and exact-source candidate checks
- fence current `main` before and after admission while preserving schema-v2 candidate receipts and immutable artifact digests

## Accepted review deltas

- require a unique provider `merged` timeline event that binds the exact source commit URL, merge actor, merge time, event ID, node ID, and canonical event URL; association/topology alone cannot admit an associated direct fast-forward push
- paginate check runs with `filter=all` and bind every accepted run to its exact commit plus the official GitHub Actions identity (`github-actions`, app ID `15368`)
- emit action outputs from `pullRequestNumber`, `reviewedHeadSha`, and `review.id`

Hostile regressions cover a topology-matching associated direct fast-forward with no provider merge event, a failed historical run hidden by a successful rerequest, wrong head/app slug/app ID, and exact output field names.

## Exact candidate

- head: `676300cceedf137c0792a7119d792c4d8874278b`
- tree: `371794e5a749df0a4a803962ae9c4116c6de875c`

## Rollout order (mandatory)

1. Merge **this public PR first using GitHub `merge_method=MERGE`**. The legacy two-parent producer can therefore admit this exact repair revision before broader method support is relied upon.
2. Only after this public merge may the paired private verifier/operator PR be merged.
3. Do not dispatch a release or change an environment as part of either merge.

## Validation

- `bun test scripts/check-release-pr-automation.test.ts` — 30 pass / 0 fail / 108 assertions
- `bun run format:check`
- `bun run lint`
- `bun run typecheck` — all 23 projects clean
- live read-only GitHub API validation of PR #623/source `8718aac5c53a76333261d69026d837168b9b1ccc`, including provider merge event `28472253465`
- natural exact-head CI run [`30205584273`](https://github.com/Cloudgeni-ai/opengeni/actions/runs/30205584273) — success; all three substantive jobs green
- separate current-base source-admission run [`30205583393`](https://github.com/Cloudgeni-ai/opengeni/actions/runs/30205583393) fails exactly with `event base SHA differs from current main` because this immutable reviewed branch is intentionally unre-based
- compatibility against current public main `5c1d50ae517f6f304a7aadae91b5f4b78f7223cf`: intervening main movement has zero changed-path overlap, and a legacy three-tree merge scan has no conflict markers

Exact-new-head delta review remains pending. Tracks OPE-25 / OPE-93; both remain In Progress until production convergence and live verification. No release, ledger, environment, deployment, production, ruleset, or repository-setting action is part of this PR.
