### PR TITLE
test(db): fence capacity claim lock detection (OPE-21)

### DIFF
--- a/packages/db/test/codex-capacity-waiters.test.ts
+++ b/packages/db/test/codex-capacity-waiters.test.ts
@@ -180,7 +180,7 @@ async function arm(scenario: CapacityScenario, resetAt: Date | null = null) {
   });
 }
 
-async function waitForAppSessionLockWait(): Promise<void> {
+async function waitForAppSessionLockWait(blockerPid: number): Promise<void> {
   const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
     const [row] = await monitor<{ waiting: number }[]>`
@@ -188,8 +188,9 @@ async function waitForAppSessionLockWait(): Promise<void> {
       from pg_stat_activity
       where datname = current_database()
         and usename = 'opengeni_app'
+        and state = 'active'
         and wait_event_type = 'Lock'
-        and query ilike '%sessions%'`;
+        and ${blockerPid} = any(pg_blocking_pids(pid))`;
     if ((row?.waiting ?? 0) > 0) {
       return;
     }
@@ -337,8 +338,11 @@ describe("credential allocator durable Codex capacity waits", () => {
         select id from sessions
         where workspace_id = ${scenario.workspaceId} and id = ${scenario.sessionId}
         for update`;
+      const [blocker] = await lockTx<{ pid: number }[]>`
+        select pg_backend_pid()::int as pid`;
+      if (!blocker) throw new Error("expected blocker backend");
       claim = claimTestTurn(claimDb, scenario.workspaceId, scenario.sessionId, scenario.workflowId);
-      await waitForAppSessionLockWait();
+      await waitForAppSessionLockWait(blocker.pid);
 
       // If claim took the pending update before waiting for the session, this
       // statement forms update -> session / session -> update and times out.


### PR DESCRIPTION
## Summary

- fence the capacity-claim lock-order regression to the exact PostgreSQL backend holding the session row
- detect the app-role waiter through `pg_blocking_pids(pid)` instead of truncated `pg_stat_activity.query` text
- preserve the production claim path and the existing 250 ms pending-update lock assertion unchanged

## Root cause

The production claim already takes the canonical control → workspace → session → turn → attempt order. The test timed out because PostgreSQL's default `track_activity_query_size` truncates the generated Drizzle session `SELECT` before its `FROM sessions` clause, so the waiter's `query ilike '%sessions%'` detector could not observe a real transaction-id lock wait.

The blocker transaction has acquired only the target session row when its backend PID is captured. Requiring an active `opengeni_app` lock waiter in the same database whose `pg_blocking_pids(pid)` contains that PID proves the claim reached the intended session lock without relying on query text.

Production allocator state transitions, transaction/RLS boundaries, timeouts, retries, and schemas are unchanged.

Linear: OPE-21

## Immutable candidate

- base: `8d2ac94e9511ca890d530b4f628f8b2fe53d6d86`
- head: `f11cd5289fa097c014ce3b405ec03cdad621a406`
- tree: `1d2d591ccd4b93708137c8c6b0cfd008e2840610`
- changed path: `packages/db/test/codex-capacity-waiters.test.ts` only

## Verification

### Real PostgreSQL 16

- unchanged current-main control: exact case reproduced `0 pass / 1 fail`
- repaired exact case: 30/30 fresh runs
- complete capacity-waiter file: 10/10
- adjacent concurrency/replay/RLS matrix: 145/145 across 8 files

### Repository checks

- workspace typecheck: 23/23 projects
- lint: 989 files, 0 warnings/errors
- changed-file `oxfmt --check`: pass
- schema contract: pass
- release BOM/workflow contract tests: 13/13
- full local unit command: 4,449 pass / 4 opt-in skips / 1 unrelated harness failure; the repaired target passed, while the sole failure was the existing OPE-75 production fixture because the native-PostgreSQL Docker shim intentionally has no Compose/image/inspect support

### Natural CI

Run: https://github.com/Cloudgeni-ai/opengeni/actions/runs/30213427060

Passed:

- Source Admission
- Deployment artifacts
- Workload image builds
- typecheck, lint, format, full `Test`, React warning gate
- all browser acceptance and recovery integration steps
- workspace auth/billing and docs guards

The run's sole failure is `Public repository hygiene guard`, reporting internal issue references in:

- `docs/design/steer-cancellation-settlement-2026-07-19.md`
- `test/integration/steer-cancellation-deadlock.fixture.test.ts`

Both files are outside this PR, are present unchanged in the exact base, and have identical base/head blob IDs. Downstream package-consumer steps were skipped after that guard. This focused OPE-21 candidate does not modify unrelated OPE-75 material merely to green the branch.

## Current-main compatibility

`origin/main` remains the exact base. The merge base equals current main, there is no intervening-main path overlap, the synthetic three-tree merge is clean, and GitHub reports the PR mergeable.

## Residual scope

No live provider inference was exercised; this repair changes test observation only and was validated at the PostgreSQL lock/wait graph boundary. Independent review remains required before merge. OPE-21 must remain In Progress until production deployment and live acceptance.
