### PR TITLE
release: attest retained source heads

### DIFF
--- a/.github/workflows/seal-release-head.yml
+++ b/.github/workflows/seal-release-head.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      checks: read
+      checks: write
       contents: write
       pull-requests: read
     steps:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -215,9 +215,42 @@ will be used directly as a release source, dispatch
 `.github/workflows/seal-release-head.yml` from exact current `main` with the PR
 number and exact base/head SHAs before merging. The base-owned workflow reruns
 the complete source-admission verifier, requires the existing successful
-exact-head admission check, then creates or verifies the tag idempotently. A
-tag is retention evidence, not approval: the native pre-merge review and every
-later source/acceptance gate remain mandatory. A missing, moved, indirect, or
+exact-head admission check, then creates or verifies the tag idempotently. Once
+the complete tag/ruleset/PR identity has been re-read without drift, it
+idempotently publishes a successful `Release-head retention` check on the
+exact head with external identity
+`opengeni:release-automation:release-head-retention:v1:pr:<number>:head:<sha>:protection-sha256:<digest>`.
+The digest binds the provider ruleset ID and revision, exact ref pattern and
+rules, and the authenticated no-bypass result. An anonymous downstream
+operator can therefore compare the current visible ruleset revision and
+configuration with the check without receiving a cross-repository credential.
+Its byte contract is SHA-256 over newline-free UTF-8 `JSON.stringify` of this
+object with the top-level keys sorted in ascending ASCII order:
+
+```json
+{
+  "bypassActorCount": 0,
+  "enforcement": "active",
+  "id": 123,
+  "name": "Immutable OpenGeni release heads",
+  "refPattern": "refs/tags/opengeni-release-head-*",
+  "rules": ["deletion", "update"],
+  "target": "tag",
+  "updatedAt": "2026-07-26T23:16:17.229Z"
+}
+```
+
+`id` is the live positive ruleset ID and `updatedAt` is the live provider
+`updated_at` value normalized through `new Date(value).toISOString()`. The
+array order shown above is canonical. If the ruleset revision changes after a
+retention check exists, sealing fails rather than creating a second proof; push
+a new head based on current `main`, let source admission pass, and seal that new
+head.
+Trusted Version-PR admission publishes the same check. This gives downstream
+release operators a provider-owned proof of the full ruleset contract without
+requiring a credential that crosses repository boundaries. A tag is retention
+evidence, not approval: the native pre-merge review and every later
+source/acceptance gate remain mandatory. A missing, moved, indirect, or
 post-hoc substitute ref fails release provenance.
 
 The repository must keep one active tag ruleset named

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -33,6 +33,7 @@ export const RELEASE_AUTOMATION_CONTRACT = Object.freeze({
   checks: Object.freeze({
     sourceAdmission: "Current-base source admission",
     automationCi: "Automation PR CI",
+    releaseHeadRetention: "Release-head retention",
     requiredSource: Object.freeze([
       "Typecheck and unit tests",
       "Deployment artifacts",
@@ -237,6 +238,9 @@ async function verifyReleaseHeadProtection(api) {
     Array.isArray(ruleset.bypass_actors) && ruleset.bypass_actors.length === 0,
     "release head protection must not have bypass actors",
   );
+  const updatedAt = new Date(
+    assertTimestamp(ruleset.updated_at, "release head protection ruleset update time"),
+  ).toISOString();
   return {
     id,
     name: RELEASE_AUTOMATION_CONTRACT.releaseHeadRulesetName,
@@ -245,6 +249,7 @@ async function verifyReleaseHeadProtection(api) {
     refPattern: expectedPattern,
     rules: ruleTypes,
     bypassActorCount: 0,
+    updatedAt,
   };
 }
 
@@ -396,7 +401,7 @@ function automationCiContext(env, suppliedInputs) {
   return {
     ...context,
     ...inputs,
-    ciRunId: assertPositiveInteger(env.GITHUB_RUN_ID, "CI run ID"),
+    workflowRunId: assertPositiveInteger(env.GITHUB_RUN_ID, "CI run ID"),
   };
 }
 
@@ -637,9 +642,14 @@ function releaseHeadSealContext(env, suppliedInputs) {
     RELEASE_AUTOMATION_CONTRACT.sealWorkflowPath,
     "workflow_dispatch",
   );
+  requiredEnvironment(env, ["GITHUB_RUN_ID"]);
   const inputs = releaseHeadSealInputs(env, suppliedInputs);
   invariant(github.sha === inputs.baseSha, "release-head workflow SHA differs from its base SHA");
-  return { ...github, ...inputs };
+  return {
+    ...github,
+    ...inputs,
+    workflowRunId: assertPositiveInteger(env.GITHUB_RUN_ID, "seal workflow run ID"),
+  };
 }
 
 function assertOpenReleasePull(pull, context) {
@@ -690,12 +700,56 @@ export async function sealReleaseHeadEvidence(options = {}) {
   const releaseHeadProtection = await verifyReleaseHeadProtection(api);
   const releaseHead = await ensureReleaseHeadRef(api, context.headSha);
 
+  const now = options.now ?? (() => new Date());
+  await upsertCheckRun(
+    api,
+    { ...context, releaseHeadProtection },
+    "release-head-retention",
+    {
+      status: "in_progress",
+      title: "Verifying immutable release-head retention",
+      summary: `Verifying retained release head ${context.headSha} for PR #${context.prNumber}.`,
+    },
+    now,
+  );
   const [terminalMain, terminalPull] = await Promise.all([
     api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
     api.get(repositoryPath(`/pulls/${context.prNumber}`)),
   ]);
   assertMainRef(terminalMain, context.baseSha, "terminal release-head default branch");
   assertOpenReleasePull(terminalPull, context);
+  const terminalProtection = await verifyReleaseHeadProtection(api);
+  const terminalReleaseHeadName = assertReleaseHeadRef(
+    await api.get(repositoryPath(`/git/ref/tags/${releaseHead.name}`)),
+    context.headSha,
+  );
+  const terminalReleaseHead = {
+    name: terminalReleaseHeadName,
+    ref: `refs/tags/${terminalReleaseHeadName}`,
+    sha: context.headSha,
+  };
+  invariant(
+    JSON.stringify(terminalProtection) === JSON.stringify(releaseHeadProtection),
+    "release head protection moved during sealing",
+  );
+  invariant(
+    JSON.stringify(terminalReleaseHead) === JSON.stringify(releaseHead),
+    "release head ref moved during sealing",
+  );
+  await upsertCheckRun(
+    api,
+    { ...context, releaseHeadProtection: terminalProtection },
+    "release-head-retention",
+    {
+      status: "completed",
+      conclusion: "success",
+      title: "Release head retained immutably",
+      summary:
+        `PR #${context.prNumber} exact head ${context.headSha} is retained at ${releaseHead.ref} ` +
+        `under ruleset ${releaseHeadProtection.id}.`,
+    },
+    now,
+  );
   logger.log(
     `Sealed release head ${context.headSha} for PR #${context.prNumber} at ${releaseHead.ref}.`,
   );
@@ -709,14 +763,28 @@ export async function sealReleaseHeadEvidence(options = {}) {
 }
 
 function checkIdentity(kind, context) {
-  invariant(kind === "source-admission" || kind === "automation-ci", "check kind is invalid");
+  invariant(
+    kind === "source-admission" || kind === "automation-ci" || kind === "release-head-retention",
+    "check kind is invalid",
+  );
   const name =
     kind === "source-admission"
       ? RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission
-      : RELEASE_AUTOMATION_CONTRACT.checks.automationCi;
+      : kind === "automation-ci"
+        ? RELEASE_AUTOMATION_CONTRACT.checks.automationCi
+        : RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention;
+  const protectionIdentity =
+    kind === "release-head-retention"
+      ? `:protection-sha256:${canonicalSha256(
+          record(context.releaseHeadProtection, "release head protection check identity"),
+        )}`
+      : "";
   return {
     name,
-    externalId: `opengeni:release-automation:${kind}:v1:pr:${context.prNumber}:head:${context.headSha}`,
+    exclusive: kind === "release-head-retention",
+    externalId:
+      `opengeni:release-automation:${kind}:v1:pr:${context.prNumber}:head:${context.headSha}` +
+      protectionIdentity,
   };
 }
 
@@ -734,7 +802,15 @@ async function findCheckRun(api, context, identity) {
     );
     invariant(Array.isArray(response.check_runs), "check-run records are missing");
     for (const check of response.check_runs) {
-      if (check?.external_id !== identity.externalId) continue;
+      if (check?.external_id !== identity.externalId) {
+        if (!identity.exclusive) continue;
+        invariant(
+          check?.head_sha === context.headSha,
+          "conflicting check run is bound to another head",
+        );
+        assertGitHubActionsApp(check?.app, "conflicting check run");
+        throw new Error("existing check run conflicts with the exact idempotency identity");
+      }
       invariant(check?.head_sha === context.headSha, "existing check run is bound to another head");
       assertGitHubActionsApp(check?.app, "existing check run");
       invariant(
@@ -755,7 +831,7 @@ async function upsertCheckRun(api, context, kind, state, now) {
   const existing = await findCheckRun(api, context, identity);
   const detailsUrl =
     `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
-    `/actions/runs/${context.ciRunId}`;
+    `/actions/runs/${context.workflowRunId}`;
   const completed = state.status === "completed";
   const body = {
     name: identity.name,
@@ -791,6 +867,20 @@ export async function beginVersionPrChecks(options = {}) {
   const releaseHead = await ensureReleaseHeadRef(api, context.headSha);
   await terminalVersionIdentity(api, context);
   const now = options.now ?? (() => new Date());
+  await upsertCheckRun(
+    api,
+    { ...context, releaseHeadProtection },
+    "release-head-retention",
+    {
+      status: "completed",
+      conclusion: "success",
+      title: "Release head retained immutably",
+      summary:
+        `Version PR #${context.prNumber} exact head ${context.headSha} is retained at ` +
+        `${releaseHead.ref} under ruleset ${releaseHeadProtection.id}.`,
+    },
+    now,
+  );
   await upsertCheckRun(
     api,
     context,

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -53,6 +53,7 @@ function releaseHeadRuleset() {
     source: RELEASE_AUTOMATION_CONTRACT.repository,
     enforcement: "active",
     bypass_actors: [],
+    updated_at: "2026-07-26T23:16:17.229Z",
     conditions: {
       ref_name: {
         include: [`refs/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}*`],
@@ -334,6 +335,8 @@ function admissionFixture(
   } = {},
 ) {
   const requests: RequestRecord[] = [];
+  const checks: Array<Record<string, any>> = [];
+  let nextCheckId = 850;
   let mainReads = 0;
   let retainedHeadSha = options.releaseHeadRefSha;
   const prefix = `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}`;
@@ -351,6 +354,22 @@ function admissionFixture(
         },
         201,
       );
+    }
+    if (method === "POST" && options.seal && url.pathname === `${prefix}/check-runs`) {
+      const check = {
+        ...body,
+        id: nextCheckId++,
+        app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+      };
+      checks.push(check);
+      return response(check, 201);
+    }
+    const checkMatch = url.pathname.match(new RegExp(`^${prefix}/check-runs/(\\d+)$`));
+    if (method === "PATCH" && options.seal && checkMatch) {
+      const check = checks.find((candidate) => candidate.id === Number(checkMatch[1]));
+      if (!check) return response({ message: "missing check" }, 404);
+      Object.assign(check, body);
+      return response(check);
     }
     if (method !== "GET") return response({ message: "read-only fixture" }, 405);
     if (url.pathname === prefix) return response(repository());
@@ -412,13 +431,23 @@ function admissionFixture(
     if (options.seal && url.pathname === `${prefix}/commits/${headSha}/check-runs`)
       return response({
         check_runs: [
-          {
-            name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
-            head_sha: headSha,
-            status: "completed",
-            conclusion: options.sourceAdmissionConclusion ?? "success",
-            app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
-          },
+          ...(!url.searchParams.get("check_name") ||
+          url.searchParams.get("check_name") === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission
+            ? [
+                {
+                  name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+                  head_sha: headSha,
+                  status: "completed",
+                  conclusion: options.sourceAdmissionConclusion ?? "success",
+                  app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+                },
+              ]
+            : []),
+          ...checks.filter(
+            (check) =>
+              !url.searchParams.get("check_name") ||
+              check.name === url.searchParams.get("check_name"),
+          ),
         ],
       });
     if (url.pathname === `${prefix}/compare/${baseSha}...${headSha}`)
@@ -446,7 +475,7 @@ function admissionFixture(
       });
     return response({ message: `unexpected GET ${url.pathname}` }, 404);
   }
-  return { fetchImpl, requests };
+  return { checks, fetchImpl, requests };
 }
 
 describe("automation CI admission", () => {
@@ -505,6 +534,7 @@ function sealReleaseHeadEnv(overrides: Record<string, string> = {}) {
     GITHUB_SERVER_URL: RELEASE_AUTOMATION_CONTRACT.serverUrl,
     GITHUB_SHA: baseSha,
     GITHUB_TOKEN: "fixture-token",
+    GITHUB_RUN_ID: "789",
     GITHUB_WORKFLOW_REF:
       `${RELEASE_AUTOMATION_CONTRACT.repository}/` +
       `${RELEASE_AUTOMATION_CONTRACT.sealWorkflowPath}@refs/heads/main`,
@@ -554,6 +584,25 @@ describe("release head evidence retention", () => {
         (request) => request.method === "POST" && request.path.endsWith("/git/refs"),
       ),
     ).toHaveLength(1);
+    expect(fixture.checks).toHaveLength(1);
+    expect(fixture.checks[0]).toMatchObject({
+      name: RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention,
+      head_sha: headSha,
+      status: "completed",
+      conclusion: "success",
+    });
+    expect(fixture.checks[0]?.external_id).toMatch(
+      new RegExp(
+        `^opengeni:release-automation:release-head-retention:v1:` +
+          `pr:${pullNumber}:head:${headSha}:protection-sha256:[0-9a-f]{64}$`,
+      ),
+    );
+    expect(
+      fixture.requests.filter(
+        (request) => request.method === "POST" && request.path.endsWith("/check-runs"),
+      ),
+    ).toHaveLength(1);
+    expect(fixture.requests.filter((request) => request.method === "PATCH")).toHaveLength(3);
   });
 
   test("fails before mutation when the exact-head source-admission check is not successful", async () => {
@@ -687,8 +736,18 @@ test("exact-head check markers update idempotently instead of duplicating", asyn
   };
   await beginVersionPrChecks(options);
   await beginVersionPrChecks(options);
-  expect(fixture.checks).toHaveLength(2);
-  expect(new Set(fixture.checks.map((check) => check.external_id)).size).toBe(2);
+  expect(fixture.checks).toHaveLength(3);
+  expect(new Set(fixture.checks.map((check) => check.external_id)).size).toBe(3);
+  expect(
+    fixture.checks.find(
+      (check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention,
+    )?.external_id,
+  ).toMatch(
+    new RegExp(
+      `^opengeni:release-automation:release-head-retention:v1:` +
+        `pr:${pullNumber}:head:${headSha}:protection-sha256:[0-9a-f]{64}$`,
+    ),
+  );
   expect(
     fixture.checks.every(
       (check) => check.head_sha === headSha && check.external_id.includes(`head:${headSha}`),
@@ -703,8 +762,8 @@ test("exact-head check markers update idempotently instead of duplicating", asyn
     fixture.requests.filter(
       (request) => request.method === "POST" && request.path.endsWith("/check-runs"),
     ),
-  ).toHaveLength(2);
-  expect(fixture.requests.filter((request) => request.method === "PATCH")).toHaveLength(2);
+  ).toHaveLength(3);
+  expect(fixture.requests.filter((request) => request.method === "PATCH")).toHaveLength(3);
 });
 
 test("exact-head check creation rejects a conflicting retained release head", async () => {
@@ -732,6 +791,31 @@ test("exact-head check creation rejects missing immutable tag protection", async
       (request) => request.method === "POST" && request.path.endsWith("/git/refs"),
     ),
   ).toBe(false);
+});
+
+test("release-head retention refuses to reuse or duplicate a changed protection revision", async () => {
+  const fixtureOptions = { ruleset: releaseHeadRuleset() };
+  const fixture = checksFixture(fixtureOptions);
+  await beginVersionPrChecks({
+    env: automationCiEnv(),
+    fetchImpl: fixture.fetchImpl,
+  });
+  fixtureOptions.ruleset = {
+    ...releaseHeadRuleset(),
+    updated_at: "2026-07-27T00:00:00.000Z",
+  };
+
+  await expect(
+    beginVersionPrChecks({
+      env: automationCiEnv(),
+      fetchImpl: fixture.fetchImpl,
+    }),
+  ).rejects.toThrow("conflicts with the exact idempotency identity");
+  expect(
+    fixture.checks.filter(
+      (check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention,
+    ),
+  ).toHaveLength(1);
 });
 
 function approvalEnv(overrides: Record<string, string> = {}) {
@@ -1006,6 +1090,7 @@ describe("release approval provenance", () => {
           refPattern: `refs/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}*`,
           rules: ["deletion", "update"],
           bypassActorCount: 0,
+          updatedAt: "2026-07-26T23:16:17.229Z",
         },
         releaseHead: {
           name: `${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${headSha}`,
@@ -1366,7 +1451,7 @@ describe("workflow contracts", () => {
     });
     expect(seal.permissions).toEqual({ contents: "read" });
     expect(seal.jobs.seal.permissions).toEqual({
-      checks: "read",
+      checks: "write",
       contents: "write",
       "pull-requests": "read",
     });


### PR DESCRIPTION
## Summary

- publish a provider-owned `Release-head retention` check whenever a reviewed release head is sealed
- bind that check to the exact immutable tag-ruleset revision and no-bypass result with a canonical SHA-256 digest
- make manual sealing and trusted Version-PR admission share the same idempotent, conflict-fenced attestation path
- document the exact byte contract and the deliberate new-head recovery procedure for a changed protection revision

## Why

Downstream release operators need to prove that the exact reviewed source head is still retained by the repository's immutable tag contract without receiving a cross-repository credential. The existing direct tag remains the source anchor; this check adds an independently retrievable, provider-owned attestation of the authenticated protection details that anonymous ruleset responses omit.

## Validation

- `bun test scripts/check-release-pr-automation.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:docs-refs`
- `git diff --check`

Fable reviewed the exact final head and returned PASS with no P0/P1/P2 findings.
