### PR TITLE
fix(runtime): honor MCP connect timeout budgets

### DIFF
--- a/.changeset/slow-mice-connect.md
+++ b/.changeset/slow-mice-connect.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Honor configured MCP transport budgets during the outer Agents SDK connection lifecycle.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -49,6 +49,7 @@ import {
   boundedParallelMap,
   cancelMcpResponseBody,
   guardedMcpFetch,
+  mcpOuterConnectTimeoutMs,
   undiciFetch,
 } from "./mcp-network";
 import {
@@ -2342,7 +2343,7 @@ export type ConnectedMcpServerBatches = {
  */
 export async function connectMcpServersInBatches(
   servers: MCPServer[],
-  options: { strict: boolean },
+  options: { strict: boolean; connectTimeoutMs?: number },
 ): Promise<ConnectedMcpServerBatches> {
   assertMcpServerSelectionWithinBounds(servers);
   const batches: ConnectedMcpServerBatch[] = [];
@@ -2352,6 +2353,9 @@ export async function connectMcpServersInBatches(
         await connectMcpServers(
           servers.slice(offset, offset + MCP_MAX_CONCURRENT_SERVER_OPERATIONS),
           {
+            ...(options.connectTimeoutMs === undefined
+              ? {}
+              : { connectTimeoutMs: options.connectTimeoutMs }),
             connectInParallel: true,
             strict: options.strict,
           },
@@ -2478,24 +2482,33 @@ export async function prepareAgentTools(
         server,
         bestEffort,
         optional,
+        timeoutMs: config.timeoutMs,
       };
     },
   );
-  const requiredServers = servers.filter((entry) => !entry.bestEffort).map((entry) => entry.server);
-  const bestEffortServers = servers
-    .filter((entry) => entry.bestEffort)
-    .map((entry) => entry.server);
+  const requiredEntries = servers.filter((entry) => !entry.bestEffort);
+  const bestEffortEntries = servers.filter((entry) => entry.bestEffort);
+  const requiredServers = requiredEntries.map((entry) => entry.server);
+  const bestEffortServers = bestEffortEntries.map((entry) => entry.server);
   // Names of the OPTIONAL servers (not codex_apps) so a drop is surfaced as a
   // warning; codex_apps keeps its historically-quiet drop (a not-logged-in
   // ChatGPT plan is a normal, non-noteworthy state).
   const optionalServerNames = new Set(
     servers.filter((entry) => entry.optional).map((entry) => entry.server.name),
   );
-  const connectedRequired = await connectMcpServersInBatches(requiredServers, { strict: true });
+  const connectedRequired = await connectMcpServersInBatches(requiredServers, {
+    strict: true,
+    connectTimeoutMs: mcpOuterConnectTimeoutMs(requiredEntries.map((entry) => entry.timeoutMs)),
+  });
   let connectedBestEffort: ConnectedMcpServerBatches | null = null;
   try {
     connectedBestEffort = bestEffortServers.length
-      ? await connectMcpServersInBatches(bestEffortServers, { strict: false })
+      ? await connectMcpServersInBatches(bestEffortServers, {
+          strict: false,
+          connectTimeoutMs: mcpOuterConnectTimeoutMs(
+            bestEffortEntries.map((entry) => entry.timeoutMs),
+          ),
+        })
       : null;
   } catch (error) {
     await connectedRequired.close().catch(() => undefined);

--- a/packages/runtime/src/mcp-network.ts
+++ b/packages/runtime/src/mcp-network.ts
@@ -18,6 +18,10 @@ export const MCP_MAX_TOOL_RESULT_BYTES = 1024 * 1024;
 export const MCP_MAX_TOOL_SEARCH_DISCLOSURE_BYTES = 256 * 1024;
 export const MCP_MAX_SELECTED_SERVERS = 64;
 export const MCP_MAX_CONCURRENT_SERVER_OPERATIONS = 8;
+// @openai/agents has a separate lifecycle fence around MCPServer.connect().
+// It defaults to 10 seconds and can otherwise preempt a larger per-server
+// transport timeout before that server finishes its own handshake.
+export const MCP_DEFAULT_OUTER_CONNECT_TIMEOUT_MS = 10_000;
 export const MCP_MAX_AGGREGATE_TOOL_LIST_ENTRIES = 4_096;
 export const MCP_MAX_AGGREGATE_TOOL_LIST_BYTES = 16 * 1024 * 1024;
 export const MCP_MAX_TOOL_SEARCH_SOURCES = 64;
@@ -85,6 +89,15 @@ export function assertMcpServerSelectionWithinBounds<T>(servers: readonly T[]): 
     );
   }
   return servers;
+}
+
+export function mcpOuterConnectTimeoutMs(
+  configuredTimeouts: readonly (number | undefined)[],
+): number {
+  return Math.max(
+    MCP_DEFAULT_OUTER_CONNECT_TIMEOUT_MS,
+    ...configuredTimeouts.flatMap((timeoutMs) => (timeoutMs === undefined ? [] : [timeoutMs])),
+  );
 }
 
 type McpToolListContribution = {

--- a/packages/runtime/test/mcp-network.test.ts
+++ b/packages/runtime/test/mcp-network.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
 import {
+  MCP_DEFAULT_OUTER_CONNECT_TIMEOUT_MS,
   MCP_MAX_INBOUND_REQUEST_BYTES,
   MCP_MAX_SELECTED_SERVERS,
   MCP_MAX_TOOL_RESULT_BYTES,
@@ -13,6 +14,7 @@ import {
   boundedParallelMap,
   boundMcpResponseBody,
   guardedMcpFetch,
+  mcpOuterConnectTimeoutMs,
 } from "../src/mcp-network";
 
 const testSettings = {
@@ -21,6 +23,12 @@ const testSettings = {
 };
 
 describe("MCP network and payload boundary", () => {
+  test("keeps the outer Agents SDK connect fence at least as large as configured transports", () => {
+    expect(mcpOuterConnectTimeoutMs([])).toBe(MCP_DEFAULT_OUTER_CONNECT_TIMEOUT_MS);
+    expect(mcpOuterConnectTimeoutMs([5_000, undefined])).toBe(MCP_DEFAULT_OUTER_CONNECT_TIMEOUT_MS);
+    expect(mcpOuterConnectTimeoutMs([30_000, 15_000, undefined])).toBe(30_000);
+  });
+
   test("pins the final transport, forces manual redirects, and rejects declared oversize", async () => {
     let redirect: RequestRedirect | undefined;
     const guarded = guardedMcpFetch(

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -34,6 +34,7 @@ import {
   HUMAN_INPUT_TOOL_NAME,
   buildManifest,
   composeAgentInstructions,
+  connectMcpServersInBatches,
   coreInstructions,
   appendPersistentSessionSettings,
   appendTurnInstructions,
@@ -118,6 +119,23 @@ const CODEX_APPS_ENTRY = (url: string) => ({
   name: "codex_apps",
   url,
   cacheToolsList: false,
+});
+
+test("forwards an explicit outer MCP connect timeout to the Agents SDK lifecycle", async () => {
+  const slowServer = {
+    name: "slow-connect",
+    connect: async () => {
+      await Bun.sleep(50);
+    },
+    close: async () => {},
+  } as unknown as MCPServer;
+
+  await expect(
+    connectMcpServersInBatches([slowServer], {
+      strict: true,
+      connectTimeoutMs: 5,
+    }),
+  ).rejects.toThrow("MCP server connect timed out after 5ms");
 });
 
 describe("structured human-input runtime boundary", () => {


### PR DESCRIPTION
## What changed
- propagate configured MCP transport budgets to the Agents SDK connection lifecycle
- preserve the existing 10-second outer default when transports use shorter/default budgets
- cover both timeout derivation and lifecycle forwarding with regressions

## Verification
- lint
- typecheck
- focused runtime: 187 passed
- full unit suite: 4,544 passed; 14 local-box cases initially failed because the Nix Python executable is outside the SDK sanitized PATH
- affected local-box suite rerun with `OPENAI_AGENTS_PYTHON` set: 61 passed