### PR TITLE
fix: use full upload-artifact action pin

### DIFF
--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -442,7 +442,7 @@ jobs:
             --format '{{.Manifest.Digest}}')" = "$CHART_MANIFEST_DIGEST" ]
 
       - name: Upload release BOM
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0 # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: embedded-release-bom-${{ inputs.source_sha }}
           path: |


### PR DESCRIPTION
Fix the embedded distribution workflow startup by using the complete pinned actions/upload-artifact commit SHA. No release bytes were published by the failed run.\n\nValidation: focused release workflow contract and provenance tests (15 passed); Prettier check.