### PR TITLE
fix: budget immutable web deployment revisions

### DIFF
--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -14,7 +14,7 @@ const budgets = {
   initialGzip: 210 * kib,
   initialFileGzip: 70 * kib,
   directSessionRaw: 1900 * kib,
-  directSessionGzip: 544 * kib,
+  directSessionGzip: 546 * kib,
   lazyChunkRaw: 800 * kib,
   lazyChunkGzip: 240 * kib,
   cssGzip: 30 * kib,


### PR DESCRIPTION
Allow the web bundle budget to cover the existing direct-session graph when an immutable candidate deployment revision is embedded. The allowance increases by 2 KiB (about 0.36%) and all other bundle budgets remain unchanged.\n\nValidation: production web build with a candidate-<40-char SHA> revision passed; direct-session graph 557,077 bytes against the new 559,104-byte limit.