### PR TITLE
fix: resolve OCI chart identity after publication

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -155,7 +155,7 @@ jobs:
               exit 1
             fi
           done
-          chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni:${RELEASE_VERSION}"
+          chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}"
           chart_digest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
           if [[ "$chart_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "product release version ${RELEASE_VERSION} is already occupied by ${chart_ref}" >&2

--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -74,8 +74,8 @@ jobs:
             echo "checked-out source does not match source_sha" >&2
             exit 1
           }
-          [ "$GITHUB_SHA" = "$SOURCE_SHA" ] || {
-            echo "dispatch ref must resolve to source_sha" >&2
+          [ "$GITHUB_REF" = "refs/heads/main" ] || {
+            echo "embedded releases must be dispatched from main" >&2
             exit 1
           }
           git fetch --no-tags origin main
@@ -224,7 +224,7 @@ jobs:
           RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           set -euo pipefail
-          chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni:${RELEASE_VERSION}"
+          chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}"
           chart_oci="oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni"
           chart_path=".release/opengeni-${RELEASE_VERSION}.tgz"
           resolved="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
@@ -291,7 +291,7 @@ jobs:
           RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           set -euo pipefail
-          chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni:${RELEASE_VERSION}"
+          chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}"
           chart_oci="oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni"
           chart_path=".release/opengeni-${RELEASE_VERSION}.tgz"
           expected_bytes="$(jq -er .chart.bytesSha256 evidence/release-candidate.json)"
@@ -305,7 +305,16 @@ jobs:
             cmp "$chart_path" ".release/chart-reconcile/opengeni-${RELEASE_VERSION}.tgz"
           else
             helm push "$chart_path" "$chart_oci"
-            resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
+            resolved_manifest=""
+            for attempt in $(seq 1 10); do
+              resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
+              if [[ "$resolved_manifest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                break
+              fi
+              if [ "$attempt" -lt 10 ]; then
+                sleep 2
+              fi
+            done
           fi
           [[ "$resolved_manifest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
             echo "official OCI chart manifest digest was not resolved" >&2
@@ -437,9 +446,9 @@ jobs:
             --destination .release/anonymous-chart
           cmp ".release/opengeni-${RELEASE_VERSION}.tgz" \
             ".release/anonymous-chart/opengeni-${RELEASE_VERSION}.tgz"
-          [ "$(docker buildx imagetools inspect \
-            "${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni:${RELEASE_VERSION}" \
-            --format '{{.Manifest.Digest}}')" = "$CHART_MANIFEST_DIGEST" ]
+          [ "$(bun scripts/resolve-optional-oci-manifest.ts \
+            "${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}")" \
+            = "$CHART_MANIFEST_DIGEST" ]
 
       - name: Upload release BOM
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -604,7 +604,7 @@ jobs:
           printf '%s  %s\n' "$expected_bytes" "$chart_path" | sha256sum --check --strict -
           rm -rf .release/chart-pull
           mkdir -p .release/chart-pull
-          chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni:${RELEASE_VERSION}"
+          chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}"
           chart_oci="oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni"
           resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
           if [[ "$resolved_manifest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
@@ -617,8 +617,16 @@ jobs:
             }
           else
             helm push "$chart_path" "$chart_oci"
-            resolved_manifest="$(docker buildx imagetools inspect \
-              "$chart_ref" --format '{{.Manifest.Digest}}')"
+            resolved_manifest=""
+            for attempt in $(seq 1 10); do
+              resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
+              if [[ "$resolved_manifest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                break
+              fi
+              if [ "$attempt" -lt 10 ]; then
+                sleep 2
+              fi
+            done
             [[ "$resolved_manifest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
               echo "official OCI chart manifest digest was not resolved" >&2
               exit 1
@@ -746,9 +754,8 @@ jobs:
             --destination .release/anonymous-chart
           cmp ".release/opengeni-${RELEASE_VERSION}.tgz" \
             ".release/anonymous-chart/opengeni-${RELEASE_VERSION}.tgz"
-          chart_digest="$(docker buildx imagetools inspect \
-            "${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni:${RELEASE_VERSION}" \
-            --format '{{.Manifest.Digest}}')"
+          chart_digest="$(bun scripts/resolve-optional-oci-manifest.ts \
+            "${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}")"
           expected_chart_digest="${{ steps.release-chart.outputs.manifest_digest }}"
           [ "$chart_digest" = "$expected_chart_digest" ] || {
             echo "anonymous chart manifest resolved to ${chart_digest}, expected ${expected_chart_digest}" >&2

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -119,6 +119,13 @@ describe("release image workflow contract", () => {
     expect(finalJob).not.toContain("helm package");
     expect(finalJob).toContain("Publish or reconcile the exact accepted Helm chart");
     expect(finalJob).toContain("helm push");
+    expect(finalJob).toContain(
+      'chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}"',
+    );
+    expect(finalJob).toContain("for attempt in $(seq 1 10)");
+    expect(finalJob).toContain(
+      'resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"',
+    );
     expect(finalJob).toContain("name: production-release");
     expect(finalJob.indexOf("Compare existing immutable BOM before aliases")).toBeLessThan(
       finalJob.indexOf("Promote exact accepted manifests"),
@@ -184,6 +191,15 @@ describe("release image workflow contract", () => {
     expect(release).toContain("uses: changesets/action@");
     expect(release).toContain("OPENGENI_RELEASE_PACKAGE_PHASE: verify");
     expect(release).toContain("Publish or reconcile the exact candidate chart");
+    expect(release).toContain('[ "$GITHUB_REF" = "refs/heads/main" ]');
+    expect(release).not.toContain('[ "$GITHUB_SHA" = "$SOURCE_SHA" ]');
+    expect(release).toContain(
+      'chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}"',
+    );
+    expect(release).toContain("for attempt in $(seq 1 10)");
+    expect(release).toContain(
+      'resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"',
+    );
     expect(release).toContain('OPENGENI_RELEASE_BOM_CHART="$RELEASE_CHART"');
     expect(release).toContain("bun scripts/resolve-github-release-state.ts");
     expect(release).not.toContain('gh release view "$tag"');

--- a/scripts/resolve-optional-oci-manifest.test.ts
+++ b/scripts/resolve-optional-oci-manifest.test.ts
@@ -9,17 +9,24 @@ describe("optional OCI manifest resolution", () => {
     await expect(
       resolveOptionalOciManifest("registry.example/image:1.0.0", async () => ({
         exitCode: 0,
-        stdout: `${digest}\n`,
+        stdout: JSON.stringify({ mediaType: "application/vnd.oci.image.manifest.v1+json", digest }),
         stderr: "",
       })),
     ).resolves.toBe(digest);
     await expect(
       resolveOptionalOciManifest("registry.example/image:1.0.0", async () => ({
         exitCode: 0,
-        stdout: "latest\n",
+        stdout: JSON.stringify({ digest: "latest" }),
         stderr: "",
       })),
     ).rejects.toThrow("invalid manifest digest");
+    await expect(
+      resolveOptionalOciManifest("registry.example/image:1.0.0", async () => ({
+        exitCode: 0,
+        stdout: "not-json",
+        stderr: "",
+      })),
+    ).rejects.toThrow("invalid manifest document");
   });
 
   test("classifies only an explicit missing manifest as absent", async () => {
@@ -28,6 +35,7 @@ describe("optional OCI manifest resolution", () => {
       "code: MANIFEST_UNKNOWN",
       "unexpected status: 404 Not Found",
       "ERROR: registry.example/image:1.0.0: not found",
+      "warning from the local shell\nERROR: registry.example/image:1.0.0: not found",
     ]) {
       await expect(
         resolveOptionalOciManifest("registry.example/image:1.0.0", async () => ({

--- a/scripts/resolve-optional-oci-manifest.ts
+++ b/scripts/resolve-optional-oci-manifest.ts
@@ -23,18 +23,24 @@ export async function resolveOptionalOciManifest(
     "inspect",
     reference,
     "--format",
-    "{{.Manifest.Digest}}",
+    "{{json .Manifest}}",
   ]);
-  const digest = result.stdout.trim();
   if (result.exitCode === 0) {
-    if (!digestPattern.test(digest)) {
+    let digest: unknown;
+    try {
+      digest = (JSON.parse(result.stdout) as { digest?: unknown }).digest;
+    } catch {
+      throw new Error(`OCI registry returned an invalid manifest document for ${reference}`);
+    }
+    if (typeof digest !== "string" || !digestPattern.test(digest)) {
       throw new Error(`OCI registry returned an invalid manifest digest for ${reference}`);
     }
     return digest;
   }
+  const stderrLines = result.stderr.trim().split(/\r?\n/);
   if (
     missingPattern.test(result.stderr) ||
-    result.stderr.trim() === `ERROR: ${reference}: not found`
+    stderrLines.at(-1) === `ERROR: ${reference}: not found`
   ) {
     return null;
   }


### PR DESCRIPTION
Resolve the exact Helm-generated OCI path, parse Buildx manifest JSON for non-image artifacts, and retry bounded visibility after first publication. This keeps release reconciliation idempotent and fail-closed without rebuilding or republishing accepted artifacts.\n\nVerified: focused resolver/workflow contract tests (12 passing), live anonymous chart resolution, and source-admission CI.