### PR TITLE
fix: pull Helm charts from their artifact path

### DIFF
--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -226,11 +226,12 @@ jobs:
           set -euo pipefail
           chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}"
           chart_oci="oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni"
+          chart_pull_oci="${chart_oci}/opengeni"
           chart_path=".release/opengeni-${RELEASE_VERSION}.tgz"
           resolved="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
           if [ -n "$resolved" ]; then
             mkdir -p .release/chart-preflight
-            helm pull "$chart_oci" \
+            helm pull "$chart_pull_oci" \
               --version "$RELEASE_VERSION" \
               --destination .release/chart-preflight
             cmp "$chart_path" ".release/chart-preflight/opengeni-${RELEASE_VERSION}.tgz" || {
@@ -293,13 +294,14 @@ jobs:
           set -euo pipefail
           chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}"
           chart_oci="oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni"
+          chart_pull_oci="${chart_oci}/opengeni"
           chart_path=".release/opengeni-${RELEASE_VERSION}.tgz"
           expected_bytes="$(jq -er .chart.bytesSha256 evidence/release-candidate.json)"
           printf '%s  %s\n' "$expected_bytes" "$chart_path" | sha256sum --check --strict -
           resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
           if [ -n "$resolved_manifest" ]; then
             mkdir -p .release/chart-reconcile
-            helm pull "$chart_oci" \
+            helm pull "$chart_pull_oci" \
               --version "$RELEASE_VERSION" \
               --destination .release/chart-reconcile
             cmp "$chart_path" ".release/chart-reconcile/opengeni-${RELEASE_VERSION}.tgz"
@@ -441,7 +443,7 @@ jobs:
           done
           helm registry logout "$REGISTRY"
           mkdir -p .release/anonymous-chart
-          helm pull "oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni" \
+          helm pull "oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni" \
             --version "$RELEASE_VERSION" \
             --destination .release/anonymous-chart
           cmp ".release/opengeni-${RELEASE_VERSION}.tgz" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -606,9 +606,10 @@ jobs:
           mkdir -p .release/chart-pull
           chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}"
           chart_oci="oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni"
+          chart_pull_oci="${chart_oci}/opengeni"
           resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"
           if [[ "$resolved_manifest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            helm pull "$chart_oci" \
+            helm pull "$chart_pull_oci" \
               --version "$RELEASE_VERSION" \
               --destination .release/chart-pull
             cmp "$chart_path" ".release/chart-pull/opengeni-${RELEASE_VERSION}.tgz" || {
@@ -634,7 +635,7 @@ jobs:
           fi
           rm -rf .release/chart-pull
           mkdir -p .release/chart-pull
-          helm pull "$chart_oci" \
+          helm pull "$chart_pull_oci" \
             --version "$RELEASE_VERSION" \
             --destination .release/chart-pull
           cmp "$chart_path" ".release/chart-pull/opengeni-${RELEASE_VERSION}.tgz"
@@ -749,7 +750,7 @@ jobs:
           done
           helm registry logout "$REGISTRY"
           mkdir -p .release/anonymous-chart
-          helm pull "oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni" \
+          helm pull "oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni" \
             --version "$RELEASE_VERSION" \
             --destination .release/anonymous-chart
           cmp ".release/opengeni-${RELEASE_VERSION}.tgz" \

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -122,6 +122,11 @@ describe("release image workflow contract", () => {
     expect(finalJob).toContain(
       'chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}"',
     );
+    expect(finalJob).toContain('chart_pull_oci="${chart_oci}/opengeni"');
+    expect(finalJob).toContain('helm pull "$chart_pull_oci"');
+    expect(finalJob).toContain(
+      'helm pull "oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni"',
+    );
     expect(finalJob).toContain("for attempt in $(seq 1 10)");
     expect(finalJob).toContain(
       'resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"',
@@ -195,6 +200,11 @@ describe("release image workflow contract", () => {
     expect(release).not.toContain('[ "$GITHUB_SHA" = "$SOURCE_SHA" ]');
     expect(release).toContain(
       'chart_ref="${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni:${RELEASE_VERSION}"',
+    );
+    expect(release).toContain('chart_pull_oci="${chart_oci}/opengeni"');
+    expect(release).toContain('helm pull "$chart_pull_oci"');
+    expect(release).toContain(
+      'helm pull "oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni"',
     );
     expect(release).toContain("for attempt in $(seq 1 10)");
     expect(release).toContain(


### PR DESCRIPTION
## Summary

- distinguish the Helm push namespace from the resulting chart artifact path
- pull and anonymously verify the published chart at its exact OCI repository
- cover both embedded and full release workflows with contract assertions

## Evidence

- reproduced against the public 0.22.0 chart
- `bun test scripts/release-image-workflow-contract.test.ts`
- `bun run format:check -- .github/workflows/release-embedded.yml .github/workflows/release.yml scripts/release-image-workflow-contract.test.ts`