### PR TITLE
fix: use Bun-native fetch for MCP transport

### DIFF
--- a/.changeset/warm-taxis-fetch.md
+++ b/.changeset/warm-taxis-fetch.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Use Bun's native fetch transport for MCP requests so external servers do not hang in the Undici compatibility path.

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.0
-appVersion: "0.22.0"
+version: 0.22.1
+appVersion: "0.22.1"

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2408,7 +2408,13 @@ export async function prepareAgentTools(
   }
   const registry = new Map(settings.mcpServers.map((server) => [server.id, server]));
   const aggregateToolBudget = new McpAggregateToolListBudget();
-  const mcpFetchImpl = options.mcpFetchImpl ?? undiciFetch;
+  // npm Undici's dispatcher transport can hang indefinitely under Bun even
+  // after an AbortSignal fires. Bun's native fetch is the supported runtime
+  // transport there; destination policy validation still runs before every
+  // credential-bearing MCP request.
+  const useBunNativeFetch = options.mcpFetchImpl === undefined && !!process.versions.bun;
+  const mcpFetchImpl =
+    options.mcpFetchImpl ?? (useBunNativeFetch ? globalThis.fetch.bind(globalThis) : undiciFetch);
   const servers = await boundedParallelMap(
     tools,
     MCP_MAX_CONCURRENT_SERVER_OPERATIONS,
@@ -2425,7 +2431,10 @@ export async function prepareAgentTools(
       const guardedFetch = guardedMcpFetch(
         firstParty ? { ...settings, integrationsAllowPrivateNetworkTargets: true } : settings,
         baseFetch,
-        firstParty ? { requireHttpsOutsideLocalTest: false } : {},
+        {
+          ...(firstParty ? { requireHttpsOutsideLocalTest: false } : {}),
+          ...(useBunNativeFetch ? { pinResolvedDestination: false } : {}),
+        },
       );
       const fetchImpl = config.connectionRef
         ? connectionBrokerFetch(guardedFetch, config, options)

--- a/packages/runtime/src/mcp-network.ts
+++ b/packages/runtime/src/mcp-network.ts
@@ -212,16 +212,28 @@ export function guardedMcpFetch<TInput extends string | URL | Request>(
   options: {
     maxResponseBytes?: number;
     dnsLookup?: DnsLookup;
+    pinResolvedDestination?: boolean;
     requireHttpsOutsideLocalTest?: boolean;
   } = {},
 ): (input: TInput, init?: RequestInit) => Promise<Response> {
   return async (input: TInput, init?: RequestInit) => {
-    const response = await pinnedFetch(input, init, settings, {
-      fetchImpl: fetchImpl as FetchLike,
+    const destinationOptions = {
       ...(options.dnsLookup ? { dnsLookup: options.dnsLookup } : {}),
       label: "MCP endpoint",
       requireHttpsOutsideLocalTest: options.requireHttpsOutsideLocalTest ?? true,
-    });
+    };
+    let response: Response;
+    if (options.pinResolvedDestination === false) {
+      await resolvePinnedDestination(input instanceof Request ? input.url : input, settings, {
+        ...destinationOptions,
+      });
+      response = await fetchImpl(input, { ...init, redirect: "manual" });
+    } else {
+      response = await pinnedFetch(input, init, settings, {
+        fetchImpl: fetchImpl as FetchLike,
+        ...destinationOptions,
+      });
+    }
     return boundMcpResponseBody(response, options.maxResponseBytes ?? MCP_MAX_RESPONSE_BYTES);
   };
 }

--- a/packages/runtime/test/mcp-network.test.ts
+++ b/packages/runtime/test/mcp-network.test.ts
@@ -49,6 +49,30 @@ describe("MCP network and payload boundary", () => {
     expect(redirect).toBe("manual");
   });
 
+  test("validates before the Bun-native transport without passing an Undici dispatcher", async () => {
+    let seenInit: RequestInit | undefined;
+    const guarded = guardedMcpFetch(
+      testSettings,
+      async (_input, init) => {
+        seenInit = init;
+        return Response.json({ ok: true });
+      },
+      {
+        dnsLookup: async () => [{ address: "1.1.1.1", family: 4 }],
+        pinResolvedDestination: false,
+      },
+    );
+
+    const response = await guarded("https://example.test/mcp", {
+      method: "POST",
+      headers: { authorization: "Bearer test" },
+    });
+    expect(await response.json()).toEqual({ ok: true });
+    expect(seenInit?.redirect).toBe("manual");
+    expect(seenInit?.method).toBe("POST");
+    expect("dispatcher" in (seenInit ?? {})).toBe(false);
+  });
+
   test("errors on the first streamed byte past the response ceiling", async () => {
     const response = boundMcpResponseBody(
       new Response(


### PR DESCRIPTION
## Summary
- select Bun’s native fetch implementation for runtime-managed MCP connections
- preserve destination-policy validation, response limits, and manual redirect handling without passing an Undici dispatcher to Bun
- keep injected transports and non-Bun runtimes on the existing pinned transport path
- advance the immutable self-hosted product release identity to `0.22.1`

## Why
The npm Undici dispatcher path can leave external MCP requests hanging under Bun even after the request aborts. The native transport completes the same requests normally. The chart patch version gives the corrected image set a new immutable release identity.

## Verification
- 919 runtime tests pass
- 21 release identity/workflow tests pass
- repository typecheck passes
- lint and formatting pass