### PR TITLE
fix: separate Helm chart push and pull identities

### DIFF
--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -327,7 +327,7 @@ jobs:
             --arg manifestDigest "$resolved_manifest" \
             --arg bytesSha256 "$expected_bytes" \
             --arg artifact "opengeni-${RELEASE_VERSION}.tgz" \
-            --arg reference "$chart_oci" \
+            --arg reference "$chart_pull_oci" \
             '{reference:$reference,version:$version,manifestDigest:$manifestDigest,bytesSha256:$bytesSha256,artifact:$artifact}')"
           {
             echo 'json<<RELEASE_CHART_JSON'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -644,7 +644,7 @@ jobs:
             --arg manifestDigest "$resolved_manifest" \
             --arg bytesSha256 "$expected_bytes" \
             --arg artifact "opengeni-${RELEASE_VERSION}.tgz" \
-            --arg reference "$chart_oci" \
+            --arg reference "$chart_pull_oci" \
             '{reference:$reference,version:$version,manifestDigest:$manifestDigest,bytesSha256:$bytesSha256,artifact:$artifact}')"
           echo "manifest_digest=$resolved_manifest" >> "$GITHUB_OUTPUT"
           {

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.1
-appVersion: "0.22.1"
+version: 0.22.2
+appVersion: "0.22.2"

--- a/scripts/release-bom.test.ts
+++ b/scripts/release-bom.test.ts
@@ -11,7 +11,7 @@ const images = [
   { name: "ghcr.io/cloudgeni-ai/opengeni-worker", digest: `sha256:${"5".repeat(64)}` },
 ];
 const chart = {
-  reference: "oci://ghcr.io/cloudgeni-ai/charts/opengeni" as const,
+  reference: "oci://ghcr.io/cloudgeni-ai/charts/opengeni/opengeni" as const,
   version: "0.16.0",
   manifestDigest: `sha256:${"6".repeat(64)}`,
   bytesSha256: "7".repeat(64),
@@ -80,7 +80,7 @@ describe("release BOM", () => {
     }));
     const portableChart = {
       ...chart,
-      reference: `oci://${prefix}/charts/opengeni`,
+      reference: `oci://${prefix}/charts/opengeni/opengeni`,
     };
 
     const bom = buildReleaseBom({
@@ -132,7 +132,7 @@ describe("release BOM", () => {
     expect(() =>
       buildReleaseBom({
         ...valid,
-        chart: { ...chart, reference: "oci://registry.example/charts/opengeni" },
+        chart: { ...chart, reference: "oci://registry.example/charts/opengeni/opengeni" },
       }),
     ).toThrow("official OCI chart");
   });

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -127,6 +127,8 @@ describe("release image workflow contract", () => {
     expect(finalJob).toContain(
       'helm pull "oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni"',
     );
+    expect(finalJob).toContain('helm push "$chart_path" "$chart_oci"');
+    expect(finalJob).toContain('--arg reference "$chart_pull_oci"');
     expect(finalJob).toContain("for attempt in $(seq 1 10)");
     expect(finalJob).toContain(
       'resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"',
@@ -206,6 +208,8 @@ describe("release image workflow contract", () => {
     expect(release).toContain(
       'helm pull "oci://${OPENGENI_RELEASE_OCI_PREFIX}/charts/opengeni/opengeni"',
     );
+    expect(release).toContain('helm push "$chart_path" "$chart_oci"');
+    expect(release).toContain('--arg reference "$chart_pull_oci"');
     expect(release).toContain("for attempt in $(seq 1 10)");
     expect(release).toContain(
       'resolved_manifest="$(bun scripts/resolve-optional-oci-manifest.ts "$chart_ref")"',

--- a/scripts/release-registry.test.ts
+++ b/scripts/release-registry.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_RELEASE_OCI_PREFIX,
   isExactSha256Digest,
   normalizeReleaseOciPrefix,
+  releaseChartPushTarget,
   releaseChartReference,
   releaseImageName,
   releaseRegistryHost,
@@ -17,6 +18,9 @@ describe("release registry identity", () => {
       "ghcr.io/cloudgeni-ai/opengeni-api",
     );
     expect(releaseChartReference(DEFAULT_RELEASE_OCI_PREFIX)).toBe(
+      "oci://ghcr.io/cloudgeni-ai/charts/opengeni/opengeni",
+    );
+    expect(releaseChartPushTarget(DEFAULT_RELEASE_OCI_PREFIX)).toBe(
       "oci://ghcr.io/cloudgeni-ai/charts/opengeni",
     );
   });

--- a/scripts/release-registry.ts
+++ b/scripts/release-registry.ts
@@ -31,6 +31,10 @@ export function releaseImageName(prefix: string, role: string): string {
 }
 
 export function releaseChartReference(prefix: string): string {
+  return `oci://${normalizeReleaseOciPrefix(prefix)}/charts/opengeni/opengeni`;
+}
+
+export function releaseChartPushTarget(prefix: string): string {
   return `oci://${normalizeReleaseOciPrefix(prefix)}/charts/opengeni`;
 }
 


### PR DESCRIPTION
## Summary

- keep `helm push` on the parent namespace `oci://opengenipublicneuacr.azurecr.io/charts/opengeni`
- publish, reconcile, pull/install, anonymously verify, and record the actual chart identity `oci://opengenipublicneuacr.azurecr.io/charts/opengeni/opengeni`
- separate `releaseChartPushTarget()` from `releaseChartReference()` and emit `chart_pull_oci` into chart/BOM data
- keep the standard and embedded release workflows in parity, and bump chart `version`/`appVersion` to `0.22.2` so the corrected contract produces a fresh immutable candidate

## Ownership

Tracks [OPE-95 — Bind releases to trusted immutable evidence and candidate Helm bytes](https://linear.app/cloudgeni/issue/OPE-95/bind-releases-to-trusted-immutable-evidence-and-candidate-helm-bytes), the durable owner of the candidate/BOM contract introduced by PR #591. This correction is required by the broader OPE-25 production cutover. Both issues remain In Progress pending production acceptance.

## Exact admission fence

- base: `71e9a78cc822ca69c392a16737efd4c424154829`
- base tree: `2701fcc55cf9cb1a32cc948379f70e39d0b95854`
- head: `ac05260616956d2f709e242d7fa9176b956aed15`
- head tree: `dcee56ce1c9b7ae0a08d9e78c147ad0b91823d47`
- change: 7 files, +19/-7 — both release workflows, release registry implementation/tests, BOM/workflow contract tests, and `deploy/helm/opengeni/Chart.yaml`

## Validation

All substantive provider checks completed successfully on the exact head:

- Current-base source admission — run `30247501000`
- Typecheck and unit tests — run `30247502020`
- Deployment artifacts — run `30247502020`
- Workload image builds — run `30247502020`

Focused deterministic release validation: **28 pass, 0 fail, 269 expectations** across registry, BOM, workflow-contract, candidate, version, and chart-packaging suites; `git diff --check` passed.

PR #651 compatibility: clean synthetic merge, tree `b16e289785c3df66ea980d2454e0d023c92de2bd`, zero unmerged entries, merged workflow-contract suite **10 pass, 0 fail**. The only shared path has separate additive test hunks.

## Immutable candidate requirement

The already-published exact-base 0.22.1 BOM is immutable and records the unusable parent OCI reference. It must not be overwritten, reused, or treated as rollback authority. The 0.22.2 bump intentionally requires a fresh exact-head candidate/BOM; staging and production must consume the identical chart bytes with `rebuild:false` before live acceptance.

## Independent review

Independent exact-head admission verdict: **APPROVED**, no blocking findings. Durable evidence is recorded on OPE-95 in Linear comment `510f4124-5f6d-4cd7-9ae9-8c9400f60f9b`. Native GitHub approval is unavailable because the authenticated identity is also the PR author.
