### PR TITLE
fix(worker): recover pre-model upstream connectivity failures

### DIFF
--- a/.changeset/upstream-connectivity-recovery.md
+++ b/.changeset/upstream-connectivity-recovery.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Classify the platform's generic pre-model upstream connectivity failure as a typed, retryable same-turn recovery instead of terminating fresh no-rig sessions.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -7498,7 +7498,7 @@ export function isTransientProviderError(error: unknown): boolean {
     return true;
   }
   const message = error instanceof Error ? error.message : String(error);
-  return /overloaded|an error occurred while processing your request|connection error|service unavailable|bad gateway|gateway timeout/i.test(
+  return /overloaded|an error occurred while processing your request|connection error|unable to connect\. is the computer able to access the url\?|service unavailable|bad gateway|gateway timeout/i.test(
     message,
   );
 }
@@ -7624,6 +7624,14 @@ export function agentRunFailurePayload(
   // retryable so a goal-bearing session idles and auto-continues instead of going
   // terminal on a provider's bad minute. See isTransientProviderError.
   if (isTransientProviderError(error)) {
+    if (/^unable to connect\. is the computer able to access the url\?$/i.test(message.trim())) {
+      return {
+        error:
+          "OpenGeni could not reach an upstream service. The same turn will retry after a short delay.",
+        code: "upstream_connectivity_unavailable",
+        retryable: true,
+      };
+    }
     return { error: message, code: "provider_unavailable", retryable: true };
   }
   return { error: message };

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -7477,6 +7477,13 @@ async function assertGitHubTokenMintSelectionAuthorized(
  * that will NOT clear on retry) is classified and returned BEFORE this in
  * agentRunFailurePayload, so it never reaches here.
  */
+const STATUSLESS_UPSTREAM_CONNECTIVITY_MESSAGE =
+  "unable to connect. is the computer able to access the url?";
+
+function isExactStatuslessUpstreamConnectivityMessage(message: string): boolean {
+  return message.trim().toLowerCase() === STATUSLESS_UPSTREAM_CONNECTIVITY_MESSAGE;
+}
+
 export function isTransientProviderError(error: unknown): boolean {
   const status =
     typeof error === "object" && error !== null && "status" in error
@@ -7498,7 +7505,10 @@ export function isTransientProviderError(error: unknown): boolean {
     return true;
   }
   const message = error instanceof Error ? error.message : String(error);
-  return /overloaded|an error occurred while processing your request|connection error|unable to connect\. is the computer able to access the url\?|service unavailable|bad gateway|gateway timeout/i.test(
+  if (isExactStatuslessUpstreamConnectivityMessage(message)) {
+    return true;
+  }
+  return /overloaded|an error occurred while processing your request|connection error|service unavailable|bad gateway|gateway timeout/i.test(
     message,
   );
 }
@@ -7624,7 +7634,7 @@ export function agentRunFailurePayload(
   // retryable so a goal-bearing session idles and auto-continues instead of going
   // terminal on a provider's bad minute. See isTransientProviderError.
   if (isTransientProviderError(error)) {
-    if (/^unable to connect\. is the computer able to access the url\?$/i.test(message.trim())) {
+    if (isExactStatuslessUpstreamConnectivityMessage(message)) {
       return {
         error:
           "OpenGeni could not reach an upstream service. The same turn will retry after a short delay.",

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -2598,6 +2598,28 @@ describe("transient provider error classifier", () => {
     expect(isTransientProviderError(new Error("Connection error."))).toBe(true);
   });
 
+  test("classifies the exact fresh no-rig pre-model connectivity failure as typed recovery", () => {
+    const observed = new Error("Unable to connect. Is the computer able to access the url?");
+
+    expect(isTransientProviderError(observed)).toBe(true);
+    expect(agentRunFailurePayload(observed)).toEqual({
+      error:
+        "OpenGeni could not reach an upstream service. The same turn will retry after a short delay.",
+      code: "upstream_connectivity_unavailable",
+      retryable: true,
+    });
+    expect(providerRecoveryResult()).toEqual({
+      status: "recovering",
+      continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS,
+    });
+
+    // HTTP status remains authoritative: a request-owned 4xx with the same body
+    // must not be mistaken for platform connectivity and retried forever.
+    const rejectedRequest = Object.assign(new Error(observed.message), { status: 400 });
+    expect(isTransientProviderError(rejectedRequest)).toBe(false);
+    expect(agentRunFailurePayload(rejectedRequest)).toEqual({ error: observed.message });
+  });
+
   test("classifies node/undici network fault codes as transient", () => {
     for (const code of ["ECONNRESET", "ETIMEDOUT", "EAI_AGAIN", "ECONNREFUSED", "EPIPE"]) {
       expect(isTransientProviderError(Object.assign(new Error("socket"), { code }))).toBe(true);

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -2618,6 +2618,14 @@ describe("transient provider error classifier", () => {
     const rejectedRequest = Object.assign(new Error(observed.message), { status: 400 });
     expect(isTransientProviderError(rejectedRequest)).toBe(false);
     expect(agentRunFailurePayload(rejectedRequest)).toEqual({ error: observed.message });
+
+    for (const nearMatch of [
+      `Authentication failed: ${observed.message}`,
+      `${observed.message} Unexpected suffix`,
+    ]) {
+      expect(isTransientProviderError(new Error(nearMatch))).toBe(false);
+      expect(agentRunFailurePayload(new Error(nearMatch))).toEqual({ error: nearMatch });
+    }
   });
 
   test("classifies node/undici network fault codes as transient", () => {


### PR DESCRIPTION
## Summary

- Classify the exact bare pre-model connectivity failure observed in a fresh no-rig session as a typed, retryable upstream failure.
- Return a safe `upstream_connectivity_unavailable` payload and use the existing same-accepted-turn recovery path instead of terminally failing the session.
- Keep an available HTTP status authoritative: the same prose with a 4xx remains terminal and is never auto-retried.
- Add a patch changeset for `@opengeni/worker-bundle`.

Linear: [OPE-60](https://linear.app/cloudgeni/issue/OPE-60/make-sandbox-liveness-and-archive-rematerialization-truthful)

## Forensic boundary

The July 27 observations are two distinct classes:

1. Missing-provider / degraded-restore observations are already truthful fail-closed behavior inherited from #628. The latest typed state had a missing provider, cold lease, attached logical route, unverified/incomplete archive, degraded restore/workspace, and a workspace generation not covered by any verified archive. The rejected no-op command did not execute. This PR does not rematerialize from an unverified archive, advertise readiness, or replay an operation.
2. A fresh no-rig attempt failed before any model request, sandbox operation, rig setup, or external tool effect with the bare message `Unable to connect. Is the computer able to access the url?`; one retry in the same session then reached the provider successfully. Current source did not classify that exact bare transport failure, so it terminally failed instead of entering the existing fenced same-turn recovery path. This PR closes only that classification gap.

No lease, route, archive, workspace-generation, epoch, provider-input, resource-profile, or Modal field-plumbing semantics are changed. Stack order remains: **OPE-60 truthful recovery/error boundary → OPE-90 immutable provider-neutral resource profiles → OPE-80 final Modal CPU/memory plumbing**.

## Validation

- `bun test apps/worker/test/agent-turn.test.ts` — 105 pass, 0 fail, 329 assertions
- `bun test packages/runtime/test/routing-proxy.test.ts` — 44 pass
- `bun test apps/worker/test/sandbox-routing.test.ts` — 9 pass
- `bun test apps/worker/test/sandbox-resume.test.ts` — 12 pass
- `bun test apps/worker/test/sandbox-resume-readiness.test.ts` — 6 pass
- `bun test apps/api/test/fleet-tools.test.ts` — 10 pass
- `bun test packages/db/test/sandbox-leases.test.ts` — 33 pass
- `bun run typecheck` — pass
- `bun run lint` — pass, 0 warnings/errors across 1,002 files
- `bun run format:check` — pass across 1,060 files
- `git diff --check` — pass
- `bun test ./test/integration/worker-restart.integration.ts` — environment-blocked before assertions because Docker is unavailable in the no-rig sandbox
- `bun run check:public-hygiene` — candidate-owned paths clean; the command remains red on the current-main tracked `.changeset/ope-79-runtime-rls-posture.md` filename

The real provider evidence is the production no-rig failure followed by a successful single retry in the same session. No destructive Modal canary was run because this recovery assignment forbids production mutation and the affected unverified archive must remain fail-closed.
