### PR TITLE
fix: make session tool policy durable

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -42,6 +42,7 @@ import {
   UpdateSessionGoalRequest,
   UpdateSessionMcpApprovalPolicyRequest,
   UpdateSessionRequest,
+  UpdateSessionToolPolicyRequest,
   ViewerHeartbeatRequest,
   WORKSPACE_CONTROL_ACTOR_MAX_BYTES,
   workspaceControlUtf8Bytes,
@@ -97,6 +98,7 @@ import {
   NewSessionDraftConflictError,
   SessionCommandIdempotencyError,
   SessionControlConflictError,
+  SessionToolPolicyVersionConflictError,
   SessionContextBusyError,
   HumanInputResponseValidationError,
   latestWorkspaceCapture,
@@ -156,6 +158,7 @@ import {
   sessionSpawnDenialEnvelope,
   steerHumanQueuePrompt,
   updateSessionMcpApprovalPolicy,
+  updateSessionToolPolicy,
   updateSessionTitle,
   workflowIdForSession,
   sessionWithEffectiveToolPolicy,
@@ -670,6 +673,29 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       );
     },
   );
+
+  app.put("/v1/workspaces/:workspaceId/sessions/:sessionId/tool-policy", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "sessions:control");
+    const sessionId = c.req.param("sessionId");
+    const payload = UpdateSessionToolPolicyRequest.parse(await c.req.json().catch(() => null));
+    try {
+      const session = await updateSessionToolPolicy(deps, grant, sessionId, payload);
+      return c.json(await withEffectivePolicy(deps, workspaceId, session));
+    } catch (error) {
+      if (error instanceof SessionToolPolicyVersionConflictError) {
+        return c.json(
+          {
+            code: error.code,
+            message: error.message,
+            currentVersion: error.currentVersion,
+          },
+          409,
+        );
+      }
+      throw error;
+    }
+  });
 
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/goal", async (c) => {
     const workspaceId = c.req.param("workspaceId");
@@ -2406,6 +2432,7 @@ export function sessionAuthorizationOperationForHttp(
     return null;
   }
   if (suffix === "/pin" && verb === "PUT") return "session.pin.write";
+  if (suffix === "/tool-policy" && verb === "PUT") return "session.tool_policy.write";
   if (/^\/mcp-servers\/[^/]+\/approval-policy$/.test(suffix) && verb === "PATCH") {
     return "session.mcp.approval_policy.write";
   }

--- a/apps/api/test/session-authorization-routes.test.ts
+++ b/apps/api/test/session-authorization-routes.test.ts
@@ -282,6 +282,57 @@ describe("embedding host session authorization routes", () => {
     });
   });
 
+  test("updates the durable session tool policy and returns a version conflict", async () => {
+    if (!available) return;
+    const value = await fixture();
+    const decisions: Array<{ operation: string; surface: string }> = [];
+    const app = appWith({
+      authorizeSession: async ({ operation, surface }) => {
+        decisions.push({ operation, surface });
+        return { allowed: true, relatedSessionAccess: "root" };
+      },
+      resolveListScope: async () => ({ kind: "all" }),
+    });
+    const path = `/v1/workspaces/${value.grant.workspaceId}/sessions/${value.child.id}/tool-policy`;
+    const request = (expectedVersion: number) =>
+      app.request(path, {
+        method: "PUT",
+        headers: {
+          authorization: value.authorization,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ tools: [], expectedVersion }),
+      });
+
+    const response = await request(1);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      id: value.child.id,
+      tools: [],
+      toolPolicy: { mode: "explicit", inheritedFromSessionId: value.root.id },
+      toolPolicyVersion: 2,
+    });
+    expect(decisions).toContainEqual({
+      operation: "session.tool_policy.write",
+      surface: "http",
+    });
+    expect(decisions).toContainEqual({
+      operation: "session.tool_policy.write",
+      surface: "core",
+    });
+
+    const conflict = await request(1);
+    expect(conflict.status).toBe(409);
+    expect(await conflict.json()).toMatchObject({
+      code: "SESSION_TOOL_POLICY_CONFLICT",
+      currentVersion: 2,
+    });
+    const policyEvents = (
+      await listSessionEvents(client.db, value.grant.workspaceId, value.child.id)
+    ).filter((event) => event.type === "session.tool_policy.updated");
+    expect(policyEvents).toHaveLength(1);
+  });
+
   test("classifies approval-policy requests before returning precise 400 and 404 responses", async () => {
     if (!available) return;
     const value = await fixture();

--- a/apps/api/test/session-authorization.test.ts
+++ b/apps/api/test/session-authorization.test.ts
@@ -9,6 +9,7 @@ const cases: Array<[string, string, SessionAuthorizationOperation]> = [
   ["GET", "", "session.read"],
   ["PATCH", "", "session.title.write"],
   ["PUT", "/pin", "session.pin.write"],
+  ["PUT", "/tool-policy", "session.tool_policy.write"],
   ["GET", "/lineage", "session.lineage.read"],
   ["POST", "/codex-account", "session.codex_account.write"],
   ["GET", "/goal", "session.goal.read"],

--- a/apps/web/src/components/pickers.tsx
+++ b/apps/web/src/components/pickers.tsx
@@ -173,6 +173,7 @@ export function EnabledMcpToolPicker(props: {
   servers: McpServerOption[];
   selectedIds: Set<string>;
   disabled?: boolean;
+  label?: string;
   onChange: (ids: Set<string>) => void;
 }) {
   if (props.servers.length === 0) {
@@ -196,12 +197,14 @@ export function EnabledMcpToolPicker(props: {
           variant={selectedCount > 0 ? "secondary" : "ghost"}
           size="sm"
           disabled={props.disabled}
-          aria-label="Enabled MCP tools"
+          aria-label={props.label ?? "Enabled MCP tools"}
           className={pillClass(selectedCount > 0)}
         >
           <PlugIcon className="size-3.5" />
           <span className="truncate">
-            {selectedCount > 0 ? `${selectedCount} tool${selectedCount === 1 ? "" : "s"}` : "Tools"}
+            {selectedCount > 0
+              ? `${props.label ?? "Tools"} (${selectedCount})`
+              : (props.label ?? "Tools")}
           </span>
           <ChevronDownIcon className="size-3 shrink-0" />
         </Button>

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -129,6 +129,8 @@ export type AppContextValue = {
   toolMcpServers: McpServerOption[];
   /** Capability MCP servers currently enabled as the workspace default. */
   workspaceDefaultToolIds: string[];
+  /** True once the workspace capability catalog has completed its authoritative load. */
+  workspaceMcpCatalogReady: boolean;
   currentResources: ResourceRef[];
   addManualRepository: () => void;
   forgetAccessKey: () => void;
@@ -246,13 +248,14 @@ export function RootRouteComponent() {
   const [githubAppOpen, setGithubAppOpen] = useState(false);
   const [githubOrg, setGithubOrg] = useState("");
   const [workspaceMcpServers, setWorkspaceMcpServers] = useState<McpServerOption[]>([]);
+  const [workspaceMcpCatalogReady, setWorkspaceMcpCatalogReady] = useState(false);
   const [selectedCapabilityToolIds, setSelectedCapabilityToolIds] = useState<Set<string>>(
     () => new Set(),
   );
   // Seed "docs" as already-seen so Document Search is not auto-selected on first
   // load (it stays opt-in, as the old Docs toggle was). Every other tool server,
   // including the first-party "opengeni", is auto-selected when it first appears.
-  const previousCapabilityToolIds = useRef<Set<string>>(new Set(["docs"]));
+  const previousCapabilityToolIds = useRef<Set<string>>(new Set(["docs", "files"]));
   const githubRefreshId = useRef(0);
   const mcpRefreshId = useRef(0);
   // Stable CREATE idempotency key for the in-flight session create. Generated
@@ -704,6 +707,7 @@ export function RootRouteComponent() {
         return;
       }
       setWorkspaceMcpServers(enabledWorkspaceCapabilityMcpServers(catalog.items));
+      setWorkspaceMcpCatalogReady(true);
     },
     [client],
   );
@@ -720,6 +724,12 @@ export function RootRouteComponent() {
   ): Promise<Session | null> {
     setBusy(true);
     try {
+      if (!workspaceMcpCatalogReady) {
+        toast.error("Tools are still loading", {
+          description: "Wait for the workspace tool catalog to finish loading, then try again.",
+        });
+        return null;
+      }
       const selectedTools = buildTools(submission.tools, [...selectedCapabilityToolIds]);
       const freshIdempotencyKey = crypto.randomUUID();
       const attempt = prepareCreateSessionAttempt({
@@ -736,6 +746,11 @@ export function RootRouteComponent() {
           defaultReasoningEffort: reasoningEffort,
           clientEventId: crypto.randomUUID(),
           idempotencyKey: freshIdempotencyKey,
+          workspaceDefaultMcpServerIds: [
+            "opengeni",
+            ...workspaceMcpServers.map((server) => server.id),
+          ],
+          workspaceMcpCatalogReady,
           targetSandboxId: options?.targetSandboxId,
           workingDir: options?.workingDir,
           expectedNewSessionDraftRevision: options?.expectedNewSessionDraftRevision,
@@ -913,6 +928,7 @@ export function RootRouteComponent() {
     setGithubStatus(null);
     setGithubRepos([]);
     setWorkspaceMcpServers([]);
+    setWorkspaceMcpCatalogReady(false);
   }, []);
 
   // Context actions keep one identity while reading the newest committed state
@@ -980,6 +996,7 @@ export function RootRouteComponent() {
           repositoryGroups,
           toolMcpServers,
           workspaceDefaultToolIds: workspaceMcpServers.map((server) => server.id),
+          workspaceMcpCatalogReady,
           currentResources,
           addManualRepository: contextAddManualRepository,
           forgetAccessKey: contextForgetAccessKey,
@@ -1054,6 +1071,7 @@ export function RootRouteComponent() {
     setModelForSession,
     setSession,
     toolMcpServers,
+    workspaceMcpCatalogReady,
     workspaceMcpServers,
     workspaces,
   ]);

--- a/apps/web/src/lib/session-create-request.test.ts
+++ b/apps/web/src/lib/session-create-request.test.ts
@@ -113,6 +113,54 @@ describe("buildCreateSessionRequest", () => {
     expect(result.tools).not.toBe(tools);
   });
 
+  test("omits tools only when the ready catalog selection equals workspace defaults", () => {
+    const result = build([], [], {
+      selectedTools: [
+        { kind: "mcp", id: "opengeni" },
+        { kind: "mcp", id: "docs" },
+        { kind: "mcp", id: "files" },
+      ],
+      workspaceDefaultMcpServerIds: ["files", "docs", "opengeni"],
+      workspaceMcpCatalogReady: true,
+    });
+
+    expect(result).not.toHaveProperty("tools");
+  });
+
+  test("keeps explicit empty, subset, and partially hydrated selections on the wire", () => {
+    const common = {
+      workspaceDefaultMcpServerIds: ["docs", "opengeni"],
+      workspaceMcpCatalogReady: true,
+    };
+    expect(
+      build([], [], {
+        ...common,
+        selectedTools: [],
+      }).tools,
+    ).toEqual([]);
+    expect(
+      build([], [], {
+        ...common,
+        selectedTools: [{ kind: "mcp", id: "opengeni" }],
+      }).tools,
+    ).toEqual([{ kind: "mcp", id: "opengeni" }]);
+    expect(
+      build([], [], {
+        ...common,
+        selectedTools: [
+          { kind: "mcp", id: "opengeni" },
+          { kind: "mcp", id: "docs" },
+          { kind: "mcp", id: "files" },
+        ],
+        workspaceMcpCatalogReady: false,
+      }).tools,
+    ).toEqual([
+      { kind: "mcp", id: "opengeni" },
+      { kind: "mcp", id: "docs" },
+      { kind: "mcp", id: "files" },
+    ]);
+  });
+
   test("omits workspace resources for a connected machine but keeps attachments", () => {
     const attachment: ResourceRef = {
       kind: "file",

--- a/apps/web/src/lib/session-create.ts
+++ b/apps/web/src/lib/session-create.ts
@@ -30,6 +30,7 @@ import type {
   ToolRef,
   TurnSubmission,
 } from "@/types";
+import { buildTools } from "./session-tools";
 
 // ── Compute target — the promoted top-level "Where should this run?" choice ──
 
@@ -115,6 +116,10 @@ export type BuildCreateSessionRequestInput = {
   targetSandboxId?: string | null;
   workingDir?: string | null;
   expectedNewSessionDraftRevision?: number;
+  /** Server-authoritative omitted-tools defaults, including mandatory opengeni. */
+  workspaceDefaultMcpServerIds?: string[];
+  /** Prevent a partially hydrated capability catalog from becoming a pin. */
+  workspaceMcpCatalogReady?: boolean;
 };
 
 export type PendingCreateAttempt = {
@@ -138,10 +143,28 @@ export function buildCreateSessionRequest(
     [...baseResources, ...(input.submission.resources ?? [])],
     { rejectConflicts: true },
   );
+  const selectedToolIds = [
+    ...new Set(
+      buildTools(
+        [],
+        input.selectedTools.map((tool) => tool.id),
+      ).map((tool) => tool.id),
+    ),
+  ].sort();
+  const defaultToolIds = input.workspaceDefaultMcpServerIds
+    ? [...new Set(input.workspaceDefaultMcpServerIds)].sort()
+    : null;
+  const tools =
+    input.workspaceMcpCatalogReady === true &&
+    defaultToolIds &&
+    selectedToolIds.join("\u0000") ===
+      [...new Set(buildTools([], defaultToolIds).map((tool) => tool.id))].sort().join("\u0000")
+      ? undefined
+      : [...input.selectedTools];
   return {
     initialMessage: input.submission.text,
     resources,
-    tools: [...input.selectedTools],
+    ...(tools === undefined ? {} : { tools }),
     model: input.submission.model ?? input.defaultModel,
     reasoningEffort: input.submission.reasoningEffort ?? input.defaultReasoningEffort,
     clientEventId: input.clientEventId,

--- a/apps/web/src/pickers.test.tsx
+++ b/apps/web/src/pickers.test.tsx
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+import { EnabledMcpToolPicker } from "@/components/pickers";
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  GlobalRegistrator.unregister();
+});
+
+const SERVERS = [
+  { id: "opengeni", name: "OpenGeni" },
+  { id: "linear", name: "Linear" },
+];
+
+describe("session turn tool picker hydration fence", () => {
+  test("fences the Linear picker trigger until delayed draft hydration completes", async () => {
+    let releaseDraft!: () => void;
+    const draftHydrated = new Promise<void>((resolve) => {
+      releaseDraft = resolve;
+    });
+    let selected = new Set(["opengeni"]);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    function Harness() {
+      const [draftLoading, setDraftLoading] = useState(true);
+      const [selectedIds, setSelectedIds] = useState(() => new Set(selected));
+      useEffect(() => {
+        void draftHydrated.then(() => setDraftLoading(false));
+      }, []);
+      return (
+        <EnabledMcpToolPicker
+          servers={SERVERS}
+          selectedIds={selectedIds}
+          disabled={draftLoading}
+          label="Tools for this turn"
+          onChange={(next) => {
+            selected = next;
+            setSelectedIds(next);
+          }}
+        />
+      );
+    }
+
+    try {
+      await act(async () => root.render(<Harness />));
+      const trigger = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Tools for this turn"]',
+      );
+      expect(trigger).not.toBeNull();
+      expect(trigger!.disabled).toBe(true);
+
+      await act(async () => {
+        trigger!.click();
+      });
+      expect(selected).toEqual(new Set(["opengeni"]));
+      expect(container.querySelector('[role="menu"]')).toBeNull();
+
+      await act(async () => releaseDraft());
+      expect(trigger!.disabled).toBe(false);
+      // The pending server response did not get an opportunity to replace a
+      // local picker edit: the trigger was fenced for the entire delay, and
+      // the controlled selection remains authoritative when it becomes usable.
+      expect(selected).toEqual(new Set(["opengeni"]));
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+});

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -579,6 +579,16 @@ function SessionChatPane(props: {
   const [selectedSessionToolIds, setSelectedSessionToolIds] = useState<Set<string>>(
     () => new Set(policyToolIds),
   );
+  const [durableSessionToolIds, setDurableSessionToolIds] = useState<Set<string>>(
+    () => new Set(policyToolIds),
+  );
+  const [durableToolPolicyVersion, setDurableToolPolicyVersion] = useState(
+    () => props.session.toolPolicyVersion ?? 1,
+  );
+  const [durableToolsHydrated, setDurableToolsHydrated] = useState(false);
+  const durableToolsSessionId = useRef(props.session.id);
+  const [durableToolsSaving, setDurableToolsSaving] = useState(false);
+  const [durableToolsError, setDurableToolsError] = useState<string | null>(null);
   const [toolSelectionExplicit, setToolSelectionExplicit] = useState(false);
   // The model is session-scoped: this session remembers its own pick (falling
   // back to the deployment default), so a switch here doesn't bleed into others.
@@ -589,6 +599,88 @@ function SessionChatPane(props: {
       setSelectedSessionToolIds(new Set(policyToolIds));
     }
   }, [policyToolIds, toolSelectionExplicit]);
+  useEffect(() => {
+    if (durableToolsSessionId.current !== props.session.id) {
+      durableToolsSessionId.current = props.session.id;
+      setDurableToolsHydrated(false);
+      return;
+    }
+    if (!context.workspaceMcpCatalogReady) {
+      if (durableToolsHydrated) {
+        setDurableToolsHydrated(false);
+      }
+      return;
+    }
+    if (durableToolsHydrated) {
+      return;
+    }
+    setDurableSessionToolIds(new Set(policyToolIds));
+    setDurableToolPolicyVersion(props.session.toolPolicyVersion ?? 1);
+    setDurableToolsHydrated(true);
+  }, [
+    context.workspaceMcpCatalogReady,
+    durableToolsHydrated,
+    policyToolIds,
+    props.session.id,
+    props.session.toolPolicyVersion,
+  ]);
+  const saveDurableToolPolicy = useCallback(
+    async (next: Set<string>) => {
+      setDurableSessionToolIds(new Set(next));
+      setDurableToolsSaving(true);
+      setDurableToolsError(null);
+      try {
+        const tools = toolsForPolicySelection({
+          selectedMcpServerIds: next,
+          baselineMcpServerIds: [],
+          forceExplicit: true,
+        });
+        const updated = await context.client.updateSessionToolPolicy(
+          props.session.workspaceId,
+          props.session.id,
+          {
+            tools: tools ?? [],
+            expectedVersion: durableToolPolicyVersion,
+          },
+        );
+        const selectable = context.toolMcpServers.map((server) => server.id);
+        setDurableSessionToolIds(
+          sessionPolicyPickerIds(updated, selectable, context.workspaceDefaultToolIds),
+        );
+        setDurableToolPolicyVersion(updated.toolPolicyVersion ?? durableToolPolicyVersion + 1);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setDurableToolsError(message);
+        toast.error("Failed to save session tools", { description: message });
+        // Reconcile with the server after both a 409 and a transport failure;
+        // the failed local click must never be presented as durable truth.
+        try {
+          const refreshed = await context.client.getSession(
+            props.session.workspaceId,
+            props.session.id,
+          );
+          const selectable = context.toolMcpServers.map((server) => server.id);
+          setDurableSessionToolIds(
+            sessionPolicyPickerIds(refreshed, selectable, context.workspaceDefaultToolIds),
+          );
+          setDurableToolPolicyVersion(refreshed.toolPolicyVersion ?? 1);
+        } catch {
+          // Keep the last authoritative selection when reconciliation is also
+          // unavailable; the visible error makes the state non-silent.
+        }
+      } finally {
+        setDurableToolsSaving(false);
+      }
+    },
+    [
+      context.client,
+      context.toolMcpServers,
+      context.workspaceDefaultToolIds,
+      durableToolPolicyVersion,
+      props.session.id,
+      props.session.workspaceId,
+    ],
+  );
   const applyComposerSettings = useCallback(
     (draft: ComposerDraft) => {
       setModelForSession(props.session.id, draft.model);
@@ -861,11 +953,32 @@ function SessionChatPane(props: {
                   servers={context.toolMcpServers}
                   selectedIds={selectedSessionToolIds}
                   disabled={composer.sending || terminal}
+                  label="Tools for this turn"
                   onChange={(next) => {
                     setToolSelectionExplicit(true);
                     setSelectedSessionToolIds(next);
                   }}
                 />
+                <EnabledMcpToolPicker
+                  servers={context.toolMcpServers}
+                  selectedIds={durableSessionToolIds}
+                  disabled={
+                    composer.sending || terminal || durableToolsSaving || !durableToolsHydrated
+                  }
+                  label={
+                    durableToolsSaving
+                      ? "Saving session tools"
+                      : durableToolsHydrated
+                        ? "Session tools"
+                        : "Loading session tools"
+                  }
+                  onChange={(next) => void saveDurableToolPolicy(next)}
+                />
+                {durableToolsError ? (
+                  <span className="sr-only" role="alert">
+                    {durableToolsError}
+                  </span>
+                ) : null}
               </div>
             }
           />

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -952,7 +952,11 @@ function SessionChatPane(props: {
                 <EnabledMcpToolPicker
                   servers={context.toolMcpServers}
                   selectedIds={selectedSessionToolIds}
-                  disabled={composer.sending || terminal}
+                  // Draft hydration applies the authoritative server draft to
+                  // this external picker. Keep the trigger fenced until that
+                  // apply has settled; otherwise a click can be overwritten by
+                  // the delayed draft response immediately afterward.
+                  disabled={composer.sending || composer.draftLoading || terminal}
                   label="Tools for this turn"
                   onChange={(next) => {
                     setToolSelectionExplicit(true);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3134,6 +3134,13 @@ export const UpdateSessionRequest = z.object({
 });
 export type UpdateSessionRequest = z.infer<typeof UpdateSessionRequest>;
 
+/** Replace an existing session's durable MCP tool policy. */
+export const UpdateSessionToolPolicyRequest = z.object({
+  tools: z.array(ToolRef).max(64),
+  expectedVersion: z.number().int().positive(),
+});
+export type UpdateSessionToolPolicyRequest = z.infer<typeof UpdateSessionToolPolicyRequest>;
+
 /**
  * A member's personal pin preference for a session. `expectedVersion` is
  * optional: ordinary pin/unpin actions are idempotent last-write-wins, while a
@@ -3275,6 +3282,7 @@ export const SessionAuthorizationOperation = z.enum([
   "session.human_input.write",
   "session.title.write",
   "session.mcp.approval_policy.write",
+  "session.tool_policy.write",
   "session.goal.read",
   "session.goal.write",
   "session.child.create",
@@ -4853,6 +4861,10 @@ export const Session = z.object({
   // Origin of the persisted tool allow-list. Optional for rolling client
   // compatibility; current servers emit it and legacy rows map to `legacy`.
   toolPolicy: SessionToolPolicy.optional(),
+  // Optimistic-concurrency fence for durable policy mutations. Optional for
+  // older clients/fixtures; current servers always emit the authoritative
+  // value.
+  toolPolicyVersion: z.number().int().positive().optional(),
   // Secret-safe current resolution, computed at an API/read or execution
   // boundary from IDs only. Optional because internal DB readers need not load
   // the workspace runtime registry.
@@ -5103,6 +5115,7 @@ export const SessionEventType = z.enum([
   "terminal.pty.exited", // PTY session ended (exitCode/reason)
   "session.title_set",
   "session.mcp.approval_policy.updated",
+  "session.tool_policy.updated",
   // Multi-account Codex (P1): the account a session's turn runs on changed
   // (manual switch in P1; failover/rotation in P3 reuse the same event). Drives
   // the in-session "Running on:" indicator's live flip.
@@ -5268,6 +5281,7 @@ export const SESSION_EVENT_SEMANTIC_CLASS_TYPES = {
     "session.queue.changed",
     "session.queue.prompt.cancelled",
     "session.mcp.approval_policy.updated",
+    "session.tool_policy.updated",
   ],
   terminal: [
     "turn.completed",

--- a/packages/contracts/test/session-tool-policy.test.ts
+++ b/packages/contracts/test/session-tool-policy.test.ts
@@ -3,9 +3,20 @@ import {
   capabilityCatalogItemIsTrustedForExposure,
   SessionEffectiveToolPolicy,
   SessionToolPolicy,
+  UpdateSessionToolPolicyRequest,
 } from "../src";
 
 describe("session tool policy contracts", () => {
+  test("requires a positive optimistic version and preserves explicit empty tools", () => {
+    expect(
+      UpdateSessionToolPolicyRequest.parse({
+        tools: [],
+        expectedVersion: 1,
+      }),
+    ).toEqual({ tools: [], expectedVersion: 1 });
+    expect(() => UpdateSessionToolPolicyRequest.parse({ tools: [], expectedVersion: 0 })).toThrow();
+  });
+
   test("accepts the durable policy modes and rejects invalid inheritance", () => {
     expect(SessionToolPolicy.parse({ mode: "legacy", inheritedFromSessionId: null })).toEqual({
       mode: "legacy",

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1862,8 +1862,11 @@ export async function updateSessionMcpApprovalPolicy(
   };
 }
 
-function toolPolicyAuditSnapshot(session: Session, tools: ToolRef[]) {
-  const policy = session.toolPolicy ?? { mode: "legacy" as const, inheritedFromSessionId: null };
+function toolPolicyAuditSnapshot(
+  session: Session,
+  tools: ToolRef[],
+  policy = session.toolPolicy ?? { mode: "legacy" as const, inheritedFromSessionId: null },
+) {
   // Tool policy refs contain only public server ids and the optional/strict
   // execution mode; they never carry URLs, names, headers, credentials,
   // schemas, or arguments. The request is capped at 64 refs and the mandatory
@@ -2000,8 +2003,8 @@ export async function updateSessionToolPolicy(
           {
             type: "session.tool_policy.updated" as const,
             payload: {
-              before: toolPolicyAuditSnapshot(session, session.tools),
-              after: toolPolicyAuditSnapshot(session, nextTools),
+              before: toolPolicyAuditSnapshot(session, session.tools, currentPolicy),
+              after: toolPolicyAuditSnapshot(session, nextTools, nextPolicy),
               version: nextVersion,
               effectiveFrom: "next_attempt",
             },

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -27,6 +27,7 @@ import {
   type SessionMcpServerInput,
   type SessionMcpServerMetadata,
   type UpdateSessionMcpApprovalPolicyResponse,
+  type UpdateSessionToolPolicyRequest,
   type SessionAuthorizationPort,
   type SessionToolPolicy,
   type SessionTurn,
@@ -69,6 +70,7 @@ import {
   AgentCommandAuthorityError,
   SessionSpawnDeniedDbError,
   SessionControlConflictError,
+  SessionToolPolicyVersionConflictError,
   type SessionCommandActor,
 } from "@opengeni/db";
 import {
@@ -1854,6 +1856,137 @@ export async function updateSessionMcpApprovalPolicy(
     server: updatedServer,
     effectiveFrom: "next_attempt",
   };
+}
+
+function toolPolicyAuditSnapshot(session: Session, tools: ToolRef[]) {
+  const policy = session.toolPolicy ?? { mode: "legacy" as const, inheritedFromSessionId: null };
+  return {
+    mode: policy.mode,
+    inheritedFromSessionId: policy.inheritedFromSessionId,
+    // IDs only: no MCP URLs, names, headers, credentials, schemas, or args.
+    toolIds: [...new Set(tools.map((tool) => tool.id))].sort().slice(0, 64),
+  };
+}
+
+/**
+ * Replace the durable session tool policy. The target and its parent (when
+ * present) are locked by the DB event-writer helper, and the update/event are
+ * committed under one version-fenced transaction. An already claimed turn
+ * keeps its immutable snapshot; the next attempt observes this policy.
+ */
+export async function updateSessionToolPolicy(
+  deps: {
+    db: Database;
+    bus: EventBus;
+    settings: Settings;
+    sessionAuthorization?: SessionAuthorizationPort | null;
+  },
+  grant: AccessGrant,
+  sessionId: string,
+  request: UpdateSessionToolPolicyRequest,
+): Promise<Session> {
+  await requireSessionAuthorization(deps, grant, {
+    sessionId,
+    operation: "session.tool_policy.write",
+    surface: "core",
+  });
+  requirePermission(grant, "sessions:control");
+
+  const existingSession = await requireSession(deps.db, grant.workspaceId, sessionId);
+  const capabilityRuntimeSettings = await settingsWithEnabledCapabilityMcpServers(
+    deps.db,
+    grant.workspaceId,
+    deps.settings,
+  );
+  const runtimeSettings = settingsWithSessionMcpServerMetadata(
+    capabilityRuntimeSettings,
+    existingSession.mcpServers,
+  );
+  const validatedTools = validateToolRefs(request.tools, runtimeSettings);
+  const validatedIds = new Set(validatedTools.map((tool) => `${tool.kind}:${tool.id}`));
+  const unknown = request.tools.find((tool) => !validatedIds.has(`${tool.kind}:${tool.id}`));
+  if (unknown) {
+    throw new HTTPException(422, { message: `unknown MCP server id: ${unknown.id}` });
+  }
+  const requestedTools = withFirstPartyTools(validatedTools, runtimeSettings);
+  const events = await appendSessionEventsWithLockedSessionUpdate(
+    deps.db,
+    grant.workspaceId,
+    sessionId,
+    async (session, context) => {
+      const currentVersion = session.toolPolicyVersion ?? 1;
+      if (request.expectedVersion !== currentVersion) {
+        throw new SessionToolPolicyVersionConflictError(currentVersion);
+      }
+
+      const nextTools = requestedTools;
+      let nextPolicy: SessionToolPolicy = {
+        mode: "explicit",
+        inheritedFromSessionId: session.parentSessionId,
+      };
+      if (session.parentSessionId) {
+        const parent = await context.getLockedSession(session.parentSessionId);
+        if (!parent) {
+          throw new HTTPException(409, { message: "parent session is no longer available" });
+        }
+        const parentTracksWorkspaceDefaults = parent.toolPolicy?.mode === "workspace_default";
+        const parentEffective = withFirstPartyTools(
+          parentTracksWorkspaceDefaults
+            ? withDefaultEnabledCapabilityMcpTools(
+                availableToolRefs(parent.tools, runtimeSettings),
+                deps.settings,
+                runtimeSettings,
+              )
+            : parent.tools,
+          runtimeSettings,
+        );
+        assertToolRefsSubset(
+          nextTools,
+          parentEffective,
+          "session tools may only narrow the parent session tool policy",
+        );
+      } else {
+        nextPolicy = { mode: "explicit", inheritedFromSessionId: null };
+      }
+
+      const currentPolicy = session.toolPolicy ?? {
+        mode: "legacy" as const,
+        inheritedFromSessionId: null,
+      };
+      const unchanged =
+        JSON.stringify({ tools: session.tools, policy: currentPolicy }) ===
+        JSON.stringify({ tools: nextTools, policy: nextPolicy });
+      if (unchanged) {
+        return { events: [] };
+      }
+
+      const nextVersion = currentVersion + 1;
+      return {
+        events: [
+          {
+            type: "session.tool_policy.updated" as const,
+            payload: {
+              before: toolPolicyAuditSnapshot(session, session.tools),
+              after: toolPolicyAuditSnapshot(session, nextTools),
+              version: nextVersion,
+              effectiveFrom: "next_attempt",
+            },
+          },
+        ],
+        update: {
+          tools: nextTools,
+          toolPolicy: nextPolicy,
+          toolPolicyVersion: nextVersion,
+          expectedToolPolicyVersion: request.expectedVersion,
+        },
+      };
+    },
+    { lockParentSession: true },
+  );
+  if (events.length > 0) {
+    await publishDurableSessionEvents(deps.bus, grant.workspaceId, sessionId, events);
+  }
+  return await requireSession(deps.db, grant.workspaceId, sessionId);
 }
 
 export async function readSessionLineage(

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -14,6 +14,7 @@ import {
   ServiceTurnInitiatorContext,
   evaluateWorkspaceModelPolicy,
   reasoningEffortForMetadata,
+  stableJson,
   type AccessGrant,
   type CreateSessionResponse,
   type GoalSpec,
@@ -106,6 +107,9 @@ import {
 const reservedSessionMcpServerIds = new Set(["opengeni", "files", "docs", "codex_apps"]);
 const maxSessionMcpCredentialHeaders = 16;
 const maxSessionMcpCredentialHeaderValueLength = 4096;
+// Keep the durable snapshot below the shared event-preview array boundary so
+// the generic lossy projection cannot silently rewrite this audit fact.
+const maxToolPolicyAuditRefs = 40;
 // RFC 9110 field-name token characters.
 const sessionMcpCredentialHeaderName = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
 
@@ -1860,11 +1864,37 @@ export async function updateSessionMcpApprovalPolicy(
 
 function toolPolicyAuditSnapshot(session: Session, tools: ToolRef[]) {
   const policy = session.toolPolicy ?? { mode: "legacy" as const, inheritedFromSessionId: null };
+  // Tool policy refs contain only public server ids and the optional/strict
+  // execution mode; they never carry URLs, names, headers, credentials,
+  // schemas, or arguments. The request is capped at 64 refs and the mandatory
+  // first-party server can add one more, so the complete snapshot remains a
+  // small bounded payload rather than silently dropping security-relevant
+  // optional/strict changes.
+  const allToolRefs = mergeToolRefs([], tools)
+    .sort((left, right) => {
+      // Keep the mandatory first-party authority visible even when the
+      // bounded audit preview has to omit the middle of a large selection.
+      const leftMandatory = left.kind === "mcp" && left.id === "opengeni";
+      const rightMandatory = right.kind === "mcp" && right.id === "opengeni";
+      if (leftMandatory !== rightMandatory) return leftMandatory ? -1 : 1;
+      return `${left.kind}:${left.id}`.localeCompare(`${right.kind}:${right.id}`);
+    })
+    .map((tool) => ({
+      kind: tool.kind,
+      id: tool.id,
+      ...(tool.optional === undefined ? {} : { optional: tool.optional }),
+    }));
+  const toolRefs = allToolRefs.slice(0, maxToolPolicyAuditRefs);
   return {
     mode: policy.mode,
     inheritedFromSessionId: policy.inheritedFromSessionId,
     // IDs only: no MCP URLs, names, headers, credentials, schemas, or args.
-    toolIds: [...new Set(tools.map((tool) => tool.id))].sort().slice(0, 64),
+    toolIds: [...toolRefs]
+      .sort((left, right) => `${left.kind}:${left.id}`.localeCompare(`${right.kind}:${right.id}`))
+      .map((tool) => tool.id),
+    toolRefs,
+    toolCount: allToolRefs.length,
+    truncated: allToolRefs.length > toolRefs.length,
   };
 }
 
@@ -1953,9 +1983,13 @@ export async function updateSessionToolPolicy(
         mode: "legacy" as const,
         inheritedFromSessionId: null,
       };
+      // JSONB normalizes object-key order on the round trip, so plain
+      // JSON.stringify would turn an identical retry into a second mutation
+      // (and version bump) merely because the persisted key order differs from
+      // the request object. Compare canonical JSON instead.
       const unchanged =
-        JSON.stringify({ tools: session.tools, policy: currentPolicy }) ===
-        JSON.stringify({ tools: nextTools, policy: nextPolicy });
+        stableJson({ tools: session.tools, policy: currentPolicy }) ===
+        stableJson({ tools: nextTools, policy: nextPolicy });
       if (unchanged) {
         return { events: [] };
       }

--- a/packages/core/test/session-tool-policy-update.test.ts
+++ b/packages/core/test/session-tool-policy-update.test.ts
@@ -18,6 +18,7 @@ import { updateSessionToolPolicy } from "../src/domain/sessions";
 
 const OPENGENI: ToolRef = { kind: "mcp", id: "opengeni" };
 const DOCS: ToolRef = { kind: "mcp", id: "docs" };
+const OPTIONAL_DOCS: ToolRef = { kind: "mcp", id: "docs", optional: true };
 const FILES: ToolRef = { kind: "mcp", id: "files" };
 const EXPLICIT: SessionToolPolicy = {
   mode: "explicit",
@@ -105,8 +106,8 @@ function grant(workspaceId: string, accountId: string): AccessGrant {
   };
 }
 
-function deps(db: Database, bus: MemoryEventBus) {
-  return { db, bus, settings };
+function deps(db: Database, bus: MemoryEventBus, settingsOverride = settings) {
+  return { db, bus, settings: settingsOverride };
 }
 
 describe("durable session tool-policy updates", () => {
@@ -177,6 +178,73 @@ describe("durable session tool-policy updates", () => {
         },
       ),
     ).rejects.toMatchObject({ status: 422 });
+  }, 180_000);
+
+  test("keeps optional-to-strict changes visible in the durable audit snapshot", async () => {
+    if (!available) return;
+    const owner = await workspace("optional-to-strict");
+    const created = await session(firstDb, {
+      ...owner,
+      tools: [OPENGENI, OPTIONAL_DOCS],
+    });
+    const bus = new MemoryEventBus();
+
+    await updateSessionToolPolicy(
+      deps(firstDb, bus),
+      grant(owner.workspaceId, owner.accountId),
+      created.id,
+      { tools: [OPENGENI, DOCS], expectedVersion: 1 },
+    );
+
+    const payload = bus.published[0]![0]!.payload as {
+      before: { toolRefs: ToolRef[]; toolCount: number; truncated: boolean };
+      after: { toolRefs: ToolRef[]; toolCount: number; truncated: boolean };
+    };
+    expect(payload.before.toolRefs).toContainEqual(OPTIONAL_DOCS);
+    expect(payload.before.toolCount).toBe(2);
+    expect(payload.before.truncated).toBe(false);
+    expect(payload.after.toolRefs).toContainEqual(DOCS);
+    expect(payload.after.toolRefs).not.toContainEqual(OPTIONAL_DOCS);
+    expect(payload.after.toolCount).toBe(2);
+    expect(payload.after.truncated).toBe(false);
+  }, 180_000);
+
+  test("records the mandatory first-party ref beyond the 64-ref request cap", async () => {
+    if (!available) return;
+    const extraServers = Array.from({ length: 64 }, (_, index) => ({
+      id: `audit-server-${index.toString().padStart(2, "0")}`,
+      url: `https://audit-${index}.example/mcp`,
+      cacheToolsList: false,
+    }));
+    const largeSettings = testSettings({
+      mcpServers: [
+        {
+          id: "opengeni",
+          url: "https://opengeni.example/mcp",
+          cacheToolsList: false,
+        },
+        ...extraServers,
+      ],
+    });
+    const owner = await workspace("audit-cap");
+    const created = await session(firstDb, { ...owner, tools: [OPENGENI] });
+    const bus = new MemoryEventBus();
+    const requestedTools = extraServers.map(({ id }) => ({ kind: "mcp" as const, id }));
+
+    await updateSessionToolPolicy(
+      deps(firstDb, bus, largeSettings),
+      grant(owner.workspaceId, owner.accountId),
+      created.id,
+      { tools: requestedTools, expectedVersion: 1 },
+    );
+
+    const payload = bus.published[0]![0]!.payload as {
+      after: { toolRefs: ToolRef[]; toolCount: number; truncated: boolean };
+    };
+    expect(payload.after.toolCount).toBe(65);
+    expect(payload.after.toolRefs).toHaveLength(40);
+    expect(payload.after.toolRefs).toContainEqual(OPENGENI);
+    expect(payload.after.truncated).toBe(true);
   }, 180_000);
 
   test("enforces the immediate parent ceiling while allowing a parent-approved child update", async () => {

--- a/packages/core/test/session-tool-policy-update.test.ts
+++ b/packages/core/test/session-tool-policy-update.test.ts
@@ -1,0 +1,297 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { AccessGrant, SessionToolPolicy, ToolRef } from "@opengeni/contracts";
+import {
+  MemoryEventBus,
+  acquireSharedTestDatabase,
+  testSettings,
+  type SharedTestDatabase,
+} from "@opengeni/testing";
+import {
+  createDb,
+  createSession,
+  getSession,
+  SessionToolPolicyVersionConflictError,
+  type Database,
+  type DbClient,
+} from "@opengeni/db";
+import { updateSessionToolPolicy } from "../src/domain/sessions";
+
+const OPENGENI: ToolRef = { kind: "mcp", id: "opengeni" };
+const DOCS: ToolRef = { kind: "mcp", id: "docs" };
+const FILES: ToolRef = { kind: "mcp", id: "files" };
+const EXPLICIT: SessionToolPolicy = {
+  mode: "explicit",
+  inheritedFromSessionId: null,
+};
+
+const settings = testSettings({
+  mcpServers: [
+    {
+      id: "opengeni",
+      url: "https://opengeni.example/mcp",
+      cacheToolsList: false,
+    },
+    { id: "docs", url: "https://docs.example/mcp", cacheToolsList: false },
+    { id: "files", url: "https://files.example/mcp", cacheToolsList: false },
+  ],
+});
+
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let firstClient: DbClient | null = null;
+let secondClient: DbClient | null = null;
+let firstDb: Database;
+let secondDb: Database;
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("session-tool-policy-update");
+  if (!shared) {
+    available = false;
+    return;
+  }
+  firstClient = createDb(shared.appUrl);
+  secondClient = createDb(shared.appUrl);
+  firstDb = firstClient.db;
+  secondDb = secondClient.db;
+}, 180_000);
+
+afterAll(async () => {
+  await Promise.all([firstClient?.close(), secondClient?.close()]);
+  await shared?.release();
+}, 180_000);
+
+async function workspace(label: string): Promise<{ accountId: string; workspaceId: string }> {
+  const [account] = await shared!.admin<{ id: string }[]>`
+    insert into managed_accounts (name) values (${`${label} account`}) returning id`;
+  const [created] = await shared!.admin<{ id: string }[]>`
+    insert into workspaces (account_id, name)
+    values (${account!.id}, ${`${label} workspace`}) returning id`;
+  await shared!.admin`
+    insert into workspace_inference_controls (workspace_id, account_id)
+    values (${created!.id}, ${account!.id})`;
+  return { accountId: account!.id, workspaceId: created!.id };
+}
+
+async function session(
+  db: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    tools: ToolRef[];
+    toolPolicy?: SessionToolPolicy;
+    parentSessionId?: string;
+  },
+) {
+  return await createSession(db, {
+    accountId: input.accountId,
+    workspaceId: input.workspaceId,
+    initialMessage: "tool-policy test",
+    resources: [],
+    tools: input.tools,
+    toolPolicy: input.toolPolicy ?? EXPLICIT,
+    metadata: {},
+    model: "test-model",
+    sandboxBackend: "none",
+    ...(input.parentSessionId ? { parentSessionId: input.parentSessionId } : {}),
+  });
+}
+
+function grant(workspaceId: string, accountId: string): AccessGrant {
+  return {
+    accountId,
+    workspaceId,
+    subjectId: "user:session-tool-policy-test",
+    permissions: ["sessions:control"],
+  };
+}
+
+function deps(db: Database, bus: MemoryEventBus) {
+  return { db, bus, settings };
+}
+
+describe("durable session tool-policy updates", () => {
+  test("persists the policy/version, publishes a bounded audit event, and treats a repeat as a no-op", async () => {
+    if (!available) return;
+    const owner = await workspace("policy-update");
+    const created = await session(firstDb, { ...owner, tools: [OPENGENI] });
+    const bus = new MemoryEventBus();
+
+    const updated = await updateSessionToolPolicy(
+      deps(firstDb, bus),
+      grant(owner.workspaceId, owner.accountId),
+      created.id,
+      { tools: [OPENGENI, DOCS], expectedVersion: 1 },
+    );
+
+    expect(updated.tools).toEqual([OPENGENI, DOCS]);
+    expect(updated.toolPolicy).toEqual(EXPLICIT);
+    expect(updated.toolPolicyVersion).toBe(2);
+    expect(bus.published).toHaveLength(1);
+    expect(bus.published[0]).toHaveLength(1);
+    expect(bus.published[0]![0]).toMatchObject({
+      type: "session.tool_policy.updated",
+      payload: {
+        before: {
+          mode: "explicit",
+          inheritedFromSessionId: null,
+          toolIds: ["opengeni"],
+        },
+        after: {
+          mode: "explicit",
+          inheritedFromSessionId: null,
+          toolIds: ["docs", "opengeni"],
+        },
+        version: 2,
+        effectiveFrom: "next_attempt",
+      },
+    });
+    expect(JSON.stringify(bus.published[0])).not.toContain("https://");
+
+    const repeated = await updateSessionToolPolicy(
+      deps(firstDb, bus),
+      grant(owner.workspaceId, owner.accountId),
+      created.id,
+      { tools: [OPENGENI, DOCS], expectedVersion: 2 },
+    );
+    expect(repeated.toolPolicyVersion).toBe(2);
+    expect(bus.published).toHaveLength(1);
+
+    const persisted = await getSession(firstDb, owner.workspaceId, created.id);
+    expect(persisted?.toolPolicyVersion).toBe(2);
+    expect(persisted?.tools).toEqual([OPENGENI, DOCS]);
+  }, 180_000);
+
+  test("rejects unknown optional refs instead of silently dropping them", async () => {
+    if (!available) return;
+    const owner = await workspace("unknown-optional");
+    const created = await session(firstDb, { ...owner, tools: [OPENGENI] });
+
+    await expect(
+      updateSessionToolPolicy(
+        deps(firstDb, new MemoryEventBus()),
+        grant(owner.workspaceId, owner.accountId),
+        created.id,
+        {
+          tools: [{ kind: "mcp", id: "not-configured", optional: true }],
+          expectedVersion: 1,
+        },
+      ),
+    ).rejects.toMatchObject({ status: 422 });
+  }, 180_000);
+
+  test("enforces the immediate parent ceiling while allowing a parent-approved child update", async () => {
+    if (!available) return;
+    const owner = await workspace("parent-ceiling");
+    const parent = await session(firstDb, { ...owner, tools: [OPENGENI] });
+    const child = await session(firstDb, {
+      ...owner,
+      tools: [OPENGENI],
+      parentSessionId: parent.id,
+      toolPolicy: { mode: "inherited", inheritedFromSessionId: parent.id },
+    });
+    const bus = new MemoryEventBus();
+
+    await expect(
+      updateSessionToolPolicy(
+        deps(firstDb, bus),
+        grant(owner.workspaceId, owner.accountId),
+        child.id,
+        { tools: [OPENGENI, DOCS], expectedVersion: 1 },
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+    expect((await getSession(firstDb, owner.workspaceId, child.id))?.toolPolicyVersion).toBe(1);
+
+    await updateSessionToolPolicy(
+      deps(firstDb, bus),
+      grant(owner.workspaceId, owner.accountId),
+      parent.id,
+      { tools: [OPENGENI, DOCS], expectedVersion: 1 },
+    );
+    const widenedWithinParent = await updateSessionToolPolicy(
+      deps(firstDb, bus),
+      grant(owner.workspaceId, owner.accountId),
+      child.id,
+      { tools: [OPENGENI, DOCS], expectedVersion: 1 },
+    );
+    expect(widenedWithinParent.tools).toEqual([OPENGENI, DOCS]);
+    expect(widenedWithinParent.toolPolicy?.inheritedFromSessionId).toBe(parent.id);
+
+    const raceParent = await session(firstDb, { ...owner, tools: [OPENGENI] });
+    const raceChild = await session(firstDb, {
+      ...owner,
+      tools: [OPENGENI],
+      parentSessionId: raceParent.id,
+      toolPolicy: { mode: "inherited", inheritedFromSessionId: raceParent.id },
+    });
+    const [parentUpdate, childUpdate] = await Promise.all([
+      updateSessionToolPolicy(
+        deps(firstDb, bus),
+        grant(owner.workspaceId, owner.accountId),
+        raceParent.id,
+        { tools: [OPENGENI, DOCS], expectedVersion: 1 },
+      ),
+      updateSessionToolPolicy(
+        deps(secondDb, bus),
+        grant(owner.workspaceId, owner.accountId),
+        raceChild.id,
+        { tools: [OPENGENI], expectedVersion: 1 },
+      ),
+    ]);
+    expect(parentUpdate.toolPolicyVersion).toBe(2);
+    expect(childUpdate.toolPolicyVersion).toBe(2);
+  }, 180_000);
+
+  test("serializes concurrent writers and returns one version conflict under FORCE RLS", async () => {
+    if (!available) return;
+    const owner = await workspace("concurrent-cas");
+    const created = await session(firstDb, { ...owner, tools: [OPENGENI] });
+    const firstBus = new MemoryEventBus();
+    const secondBus = new MemoryEventBus();
+    const access = grant(owner.workspaceId, owner.accountId);
+
+    const results = await Promise.allSettled([
+      updateSessionToolPolicy(deps(firstDb, firstBus), access, created.id, {
+        tools: [OPENGENI, DOCS],
+        expectedVersion: 1,
+      }),
+      updateSessionToolPolicy(deps(secondDb, secondBus), access, created.id, {
+        tools: [OPENGENI, FILES],
+        expectedVersion: 1,
+      }),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejected = results.find((result) => result.status === "rejected");
+    expect(rejected?.status).toBe("rejected");
+    expect((rejected as PromiseRejectedResult).reason).toBeInstanceOf(
+      SessionToolPolicyVersionConflictError,
+    );
+    expect((rejected as PromiseRejectedResult).reason.currentVersion).toBe(2);
+
+    const persisted = await getSession(firstDb, owner.workspaceId, created.id);
+    expect(persisted?.toolPolicyVersion).toBe(2);
+    expect([DOCS.id, FILES.id]).toContain(
+      persisted?.tools.find((tool) => tool.id !== "opengeni")?.id,
+    );
+    expect(firstBus.published.length + secondBus.published.length).toBe(1);
+  }, 180_000);
+
+  test("does not expose a session from another workspace through the update path", async () => {
+    if (!available) return;
+    const firstOwner = await workspace("tenant-a");
+    const secondOwner = await workspace("tenant-b");
+    const foreign = await session(secondDb, {
+      ...secondOwner,
+      tools: [OPENGENI],
+    });
+
+    await expect(
+      updateSessionToolPolicy(
+        deps(firstDb, new MemoryEventBus()),
+        grant(firstOwner.workspaceId, firstOwner.accountId),
+        foreign.id,
+        { tools: [OPENGENI, DOCS], expectedVersion: 1 },
+      ),
+    ).rejects.toThrow(`Session not found: ${foreign.id}`);
+  }, 180_000);
+});

--- a/packages/core/test/session-tool-policy-update.test.ts
+++ b/packages/core/test/session-tool-policy-update.test.ts
@@ -209,6 +209,73 @@ describe("durable session tool-policy updates", () => {
     expect(payload.after.truncated).toBe(false);
   }, 180_000);
 
+  test("records the workspace-default to explicit policy transition in the audit snapshot", async () => {
+    if (!available) return;
+    const owner = await workspace("audit-workspace-default-transition");
+    const created = await session(firstDb, {
+      ...owner,
+      tools: [OPENGENI],
+      toolPolicy: { mode: "workspace_default", inheritedFromSessionId: null },
+    });
+    const bus = new MemoryEventBus();
+
+    await updateSessionToolPolicy(
+      deps(firstDb, bus),
+      grant(owner.workspaceId, owner.accountId),
+      created.id,
+      { tools: [OPENGENI, DOCS], expectedVersion: 1 },
+    );
+
+    const payload = bus.published[0]![0]!.payload as {
+      before: { mode: string; inheritedFromSessionId: string | null };
+      after: { mode: string; inheritedFromSessionId: string | null };
+    };
+    expect(payload.before).toMatchObject({
+      mode: "workspace_default",
+      inheritedFromSessionId: null,
+    });
+    expect(payload.after).toMatchObject({
+      mode: "explicit",
+      inheritedFromSessionId: null,
+    });
+  }, 180_000);
+
+  test("records the inherited to explicit policy transition in the audit snapshot", async () => {
+    if (!available) return;
+    const owner = await workspace("audit-inherited-transition");
+    const parent = await session(firstDb, {
+      ...owner,
+      tools: [OPENGENI, DOCS],
+    });
+    const child = await session(firstDb, {
+      ...owner,
+      tools: [OPENGENI],
+      parentSessionId: parent.id,
+      toolPolicy: { mode: "inherited", inheritedFromSessionId: parent.id },
+    });
+    const bus = new MemoryEventBus();
+
+    await updateSessionToolPolicy(
+      deps(firstDb, bus),
+      grant(owner.workspaceId, owner.accountId),
+      child.id,
+      { tools: [OPENGENI, DOCS], expectedVersion: 1 },
+    );
+
+    const payload = bus.published[0]![0]!.payload as {
+      before: { mode: string; inheritedFromSessionId: string | null };
+      after: { mode: string; inheritedFromSessionId: string | null };
+    };
+    expect(payload.before).toMatchObject({
+      mode: "inherited",
+      inheritedFromSessionId: parent.id,
+    });
+    expect(payload.after).toMatchObject({
+      mode: "explicit",
+      inheritedFromSessionId: parent.id,
+    });
+  }, 180_000);
+
   test("records the mandatory first-party ref beyond the 64-ref request cap", async () => {
     if (!available) return;
     const extraServers = Array.from({ length: 64 }, (_, index) => ({

--- a/packages/db/drizzle/0123_session_tool_policy_version.sql
+++ b/packages/db/drizzle/0123_session_tool_policy_version.sql
@@ -1,0 +1,14 @@
+-- deployment-mode: rolling
+
+-- A durable policy mutation is fenced independently from the global event
+-- sequence. The default keeps old writers safe during the rolling upgrade;
+-- the policy update command advances this value with a locked SQL CAS.
+ALTER TABLE "sessions"
+  ADD COLUMN IF NOT EXISTS "tool_policy_version" integer NOT NULL DEFAULT 1;
+
+ALTER TABLE "sessions"
+  DROP CONSTRAINT IF EXISTS "sessions_tool_policy_version_check";
+
+ALTER TABLE "sessions"
+  ADD CONSTRAINT "sessions_tool_policy_version_check"
+  CHECK ("tool_policy_version" >= 1) NOT VALID;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -261,6 +261,16 @@ export * from "./memory-domain";
 // unaffected.
 export type Database = PgDatabase<any, typeof schema>;
 
+/** Raised when a durable session tool-policy write lost its version fence. */
+export class SessionToolPolicyVersionConflictError extends Error {
+  readonly code = "SESSION_TOOL_POLICY_CONFLICT";
+
+  constructor(readonly currentVersion: number) {
+    super("The session tool policy changed in another client");
+    this.name = "SessionToolPolicyVersionConflictError";
+  }
+}
+
 export type DbClient = {
   db: Database;
   close: () => Promise<void>;
@@ -32944,6 +32954,9 @@ function sessionEventTypesAdvanceActivity(inputs: ReadonlyArray<{ type: string }
 function sessionMutationAdvancesActivity(update: {
   resources?: ResourceRef[];
   tools?: ToolRef[];
+  toolPolicy?: SessionToolPolicy;
+  toolPolicyVersion?: number;
+  expectedToolPolicyVersion?: number;
   model?: string;
   metadata?: Record<string, unknown>;
   status?: SessionStatus;
@@ -33532,6 +33545,7 @@ type LockedSessionUpdateContext = {
     requireApproval: SessionMcpApprovalPolicy,
   ) => Promise<UpdateSessionMcpApprovalPolicyResult>;
   listPendingSessionTurns: () => Promise<SessionTurn[]>;
+  getLockedSession: (sessionId: string) => Promise<Session | null>;
 };
 
 type LockedSessionUpdateResult = {
@@ -33539,6 +33553,9 @@ type LockedSessionUpdateResult = {
   update?: {
     resources?: ResourceRef[];
     tools?: ToolRef[];
+    toolPolicy?: SessionToolPolicy;
+    toolPolicyVersion?: number;
+    expectedToolPolicyVersion?: number;
     model?: string;
     metadata?: Record<string, unknown>;
     status?: SessionStatus;
@@ -33554,18 +33571,39 @@ export async function appendSessionEventsWithLockedSessionUpdate(
     session: Session,
     context: LockedSessionUpdateContext,
   ) => LockedSessionUpdateResult | Promise<LockedSessionUpdateResult>,
+  options: { lockParentSession?: boolean } = {},
 ): Promise<SessionEvent[]> {
   return await withWorkspaceRls(
     db,
     workspaceId,
     async (scopedDb) =>
       await scopedDb.transaction(async (tx) => {
-        const locks = await lockSessionEventWriteRows(tx as unknown as Database, {
+        const firstLocks = await lockSessionEventWriteRows(tx as unknown as Database, {
           workspaceId,
           controlLock: "share",
           sessionIds: [sessionId],
         });
-        const sessionRow = locks.sessions[0];
+        const firstSessionRow = firstLocks.sessions.find((row) => row.id === sessionId);
+        if (!firstSessionRow) {
+          throw new Error(`Session not found: ${sessionId}`);
+        }
+        // Child-policy updates must serialize with a concurrent parent-policy
+        // update. The target lock establishes the parent id, then the second
+        // call acquires the complete UUID-ordered set under the already-held
+        // workspace/control prefix.
+        const lockSessionIds = options.lockParentSession
+          ? [sessionId, firstSessionRow.parentSessionId].filter((id): id is string => Boolean(id))
+          : [sessionId];
+        const locks =
+          lockSessionIds.length === 1
+            ? firstLocks
+            : await lockSessionEventWriteRows(tx as unknown as Database, {
+                workspaceId,
+                controlLock: "already_locked",
+                workspaceLock: "already_locked",
+                sessionIds: lockSessionIds,
+              });
+        const sessionRow = locks.sessions.find((row) => row.id === sessionId);
         if (!sessionRow) {
           throw new Error(`Session not found: ${sessionId}`);
         }
@@ -33604,6 +33642,18 @@ export async function appendSessionEventsWithLockedSessionUpdate(
               .orderBy(asc(schema.sessionTurns.position), asc(schema.sessionTurns.createdAt));
             return rows.map(mapSessionTurn);
           },
+          getLockedSession: async (lockedSessionId) => {
+            const row = locks.sessions.find((candidate) => candidate.id === lockedSessionId);
+            return row
+              ? await mapSessionWithControl(
+                  tx as unknown as Database,
+                  row,
+                  [],
+                  undefined,
+                  locks.control ?? undefined,
+                )
+              : null;
+          },
         });
         if (built.events.length === 0) {
           return [];
@@ -33641,12 +33691,16 @@ export async function appendSessionEventsWithLockedSessionUpdate(
         const update = built.update ?? {};
         const advancesActivity =
           sessionMutationAdvancesActivity(update) || sessionEventTypesAdvanceActivity(values);
-        await tx
+        const updated = await tx
           .update(schema.sessions)
           .set({
             lastSequence: sequence,
             ...(update.resources !== undefined ? { resources: update.resources } : {}),
             ...(update.tools !== undefined ? { tools: update.tools } : {}),
+            ...(update.toolPolicy !== undefined ? { toolPolicy: update.toolPolicy } : {}),
+            ...(update.toolPolicyVersion !== undefined
+              ? { toolPolicyVersion: update.toolPolicyVersion }
+              : {}),
             ...(update.model !== undefined ? { model: update.model } : {}),
             ...(update.metadata !== undefined ? { metadata: update.metadata } : {}),
             ...(update.status !== undefined ? { status: update.status } : {}),
@@ -33654,8 +33708,27 @@ export async function appendSessionEventsWithLockedSessionUpdate(
             ...(advancesActivity ? { updatedAt: now } : {}),
           })
           .where(
-            and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)),
+            and(
+              eq(schema.sessions.workspaceId, workspaceId),
+              eq(schema.sessions.id, sessionId),
+              ...(update.expectedToolPolicyVersion !== undefined
+                ? [eq(schema.sessions.toolPolicyVersion, update.expectedToolPolicyVersion)]
+                : []),
+            ),
+          )
+          .returning({ id: schema.sessions.id });
+        if (updated.length === 0) {
+          const [current] = await tx
+            .select({ toolPolicyVersion: schema.sessions.toolPolicyVersion })
+            .from(schema.sessions)
+            .where(
+              and(eq(schema.sessions.workspaceId, workspaceId), eq(schema.sessions.id, sessionId)),
+            )
+            .limit(1);
+          throw new SessionToolPolicyVersionConflictError(
+            Number(current?.toolPolicyVersion ?? update.expectedToolPolicyVersion ?? 1),
           );
+        }
         return inserted.map(mapEvent);
       }),
   );
@@ -33716,6 +33789,7 @@ function mapSession(
       mode: "legacy",
       inheritedFromSessionId: null,
     },
+    toolPolicyVersion: Number(row.toolPolicyVersion ?? 1),
     metadata: row.metadata,
     createdBy: initiatorFromStorage(
       row.createdByKind,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -756,6 +756,8 @@ export const sessions = pgTable(
     // mapSession exposes those rows as `legacy` instead of guessing omitted vs
     // explicit [].
     toolPolicy: jsonb("tool_policy").$type<SessionToolPolicy>(),
+    // Optimistic-concurrency fence for durable session tool-policy writes.
+    toolPolicyVersion: integer("tool_policy_version").notNull().default(1),
     // The manager session that spawned this one via session_create. Set only
     // when the creating grant carried a worker-signed sessionId claim (a session
     // spawning a worker); null for direct API creates and scheduled-task runs.

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -170,6 +170,7 @@ import type {
   UpdateScheduledTaskRequest,
   UpdateSessionGoalRequest,
   UpdateSessionRequest,
+  UpdateSessionToolPolicyRequest,
   UpdateVariableSetRequest,
   UpdateRigRequest,
   UpdateWorkspaceMemberRequest,
@@ -319,6 +320,19 @@ export class OpenGeniClient {
     return await this.requestJson<Session>(
       "PATCH",
       `/v1/workspaces/${workspaceId}/sessions/${sessionId}`,
+      request,
+    );
+  }
+
+  /** Replace the durable session MCP tool policy with an optimistic version fence. */
+  async updateSessionToolPolicy(
+    workspaceId: string,
+    sessionId: string,
+    request: UpdateSessionToolPolicyRequest,
+  ): Promise<Session> {
+    return await this.requestJson<Session>(
+      "PUT",
+      `/v1/workspaces/${workspaceId}/sessions/${sessionId}/tool-policy`,
       request,
     );
   }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -411,6 +411,7 @@ export type {
   UpdateSessionMcpApprovalPolicyResponse,
   UpdateSessionPinRequest,
   UpdateSessionRequest,
+  UpdateSessionToolPolicyRequest,
   UpdateVariableSetRequest,
   UpdateWorkspaceEnvironmentRequest,
   UpdateWorkspaceMemberRequest,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -276,6 +276,11 @@ export type SessionToolPolicy = {
   inheritedFromSessionId: string | null;
 };
 
+export type UpdateSessionToolPolicyRequest = {
+  tools: ToolRef[];
+  expectedVersion: number;
+};
+
 export type SessionEffectiveToolPolicy = {
   mode: SessionToolPolicy["mode"];
   inheritedFromSessionId: string | null;
@@ -472,6 +477,7 @@ export type Session = {
   resources: ResourceRef[];
   tools: ToolRef[];
   toolPolicy?: SessionToolPolicy | undefined;
+  toolPolicyVersion?: number | undefined;
   effectiveToolPolicy?: SessionEffectiveToolPolicy | undefined;
   metadata: Record<string, unknown>;
   /** Frozen creator fact; later turns carry their own independent initiator. */
@@ -762,6 +768,7 @@ export const SESSION_EVENT_TYPES = [
   "terminal.pty.exited",
   "session.title_set",
   "session.mcp.approval_policy.updated",
+  "session.tool_policy.updated",
   // Multi-account Codex (P1): the session's inference account changed.
   "codex.account.switched",
   // credential allocator metadata-only per-turn credential selection audit.

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -5,7 +5,11 @@ import {
   OpenGeniApiError,
   OpenGeniSessionListCursorError,
 } from "../src/errors";
-import { OPENGENI_API_CONTRACT_HEADER, OPENGENI_API_CONTRACT_REVISION } from "../src/types";
+import {
+  OPENGENI_API_CONTRACT_HEADER,
+  OPENGENI_API_CONTRACT_REVISION,
+  type Session,
+} from "../src/types";
 import { collect, makeEvent, SESSION_ID, sseBlock, WORKSPACE_ID } from "./helpers";
 
 type RecordedRequest = {
@@ -225,6 +229,26 @@ describe("OpenGeniClient", () => {
     );
     expect(JSON.parse(requests[0]!.body!)).toEqual({
       requireApproval: ["write_record"],
+    });
+  });
+
+  test("updates an existing session tool policy through the dedicated route", async () => {
+    const response = { id: SESSION_ID, toolPolicyVersion: 2 } as unknown as Session;
+    const { client, requests } = makeClient(() => jsonResponse(response));
+    expect(
+      await client.updateSessionToolPolicy(WORKSPACE_ID, SESSION_ID, {
+        tools: [],
+        expectedVersion: 1,
+      }),
+    ).toEqual(response);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.method).toBe("PUT");
+    expect(requests[0]!.url).toBe(
+      `https://api.example.test/v1/workspaces/${WORKSPACE_ID}/sessions/${SESSION_ID}/tool-policy`,
+    );
+    expect(JSON.parse(requests[0]!.body!)).toEqual({
+      tools: [],
+      expectedVersion: 1,
     });
   });
 

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -130,12 +130,13 @@ describe("release schema contract", () => {
         (migrations.has("0119_pending_tool_output_policy.sql") ? 1 : 0) +
         (migrations.has("0120_durable_goal_wake.sql") ? 1 : 0) +
         (migrations.has("0121_goal_update_idempotency.sql") ? 1 : 0) +
-        (migrations.has("0122_codex_capacity_same_turn.sql") ? 1 : 0),
+        (migrations.has("0122_codex_capacity_same_turn.sql") ? 1 : 0) +
+        (migrations.has("0123_session_tool_policy_version.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(
-      "2e64c61719e544e2a154b25cfa5c17481e22b30f36af4de9ec0ca61d7fe97f0c",
+      "REPLACE_AFTER_CONTRACT_REBUILD",
     );
-    expect(contract.latestMigration).toBe("0122_codex_capacity_same_turn.sql");
+    expect(contract.latestMigration).toBe("0123_session_tool_policy_version.sql");
     expect(migrations.get("0122_codex_capacity_same_turn.sql")).toMatchObject({
       sha256: "84e97abff7394d9fcca110012d9ceaede9ae683280a8a4a7335bcf9ec5d52d4e",
       deploymentMode: "maintenance",
@@ -161,7 +162,7 @@ describe("release schema contract", () => {
     expect(
       contract.migrations
         .map((migration) => migration.path)
-        .filter((path) => /^(?:010[3-9]|011[0-9]|012[0-2])_/.test(path)),
+        .filter((path) => /^(?:010[3-9]|011[0-9]|012[0-3])_/.test(path)),
     ).toEqual([
       "0103_host_export_root_session.sql",
       "0104_host_export_root_session_backfill.sql",
@@ -173,6 +174,7 @@ describe("release schema contract", () => {
       "0120_durable_goal_wake.sql",
       "0121_goal_update_idempotency.sql",
       "0122_codex_capacity_same_turn.sql",
+      "0123_session_tool_policy_version.sql",
     ]);
     expect(new Set(contract.migrations.map((migration) => migration.path)).size).toBe(
       contract.fileCount,
@@ -219,6 +221,10 @@ describe("release schema contract", () => {
     });
     expect(migrations.get("0121_goal_update_idempotency.sql")).toMatchObject({
       sha256: "e90f030e9dfb3c2dc040b2192cdd874fad264020f06b9c82f1c3dcd30a9769ca",
+      deploymentMode: "rolling",
+    });
+    expect(migrations.get("0123_session_tool_policy_version.sql")).toMatchObject({
+      sha256: "d23abd0ea9ac21c114a397eaa2a6a524652b9554683dd8e68937ee232e22711e",
       deploymentMode: "rolling",
     });
   });

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -134,7 +134,7 @@ describe("release schema contract", () => {
         (migrations.has("0123_session_tool_policy_version.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(
-      "REPLACE_AFTER_CONTRACT_REBUILD",
+      "462ac183560fbea0afd625cd11fdd3e8e6d488437c4844d6281455265b957026",
     );
     expect(contract.latestMigration).toBe("0123_session_tool_policy_version.sql");
     expect(migrations.get("0122_codex_capacity_same_turn.sql")).toMatchObject({


### PR DESCRIPTION
## Summary

- Make session tool policy updates durable across API, SDK, domain, database, events, and projections.
- Preserve optimistic versioning, authorization, parent anti-widening, tenant/RLS boundaries, and bounded secret-safe audit events.
- Distinguish durable Session tools from narrowing-only per-turn Tools for this turn, including hydration and failure handling.
- Omit creation tools when canonical selections equal authoritative workspace defaults while preserving explicit empty, subset, and pinned choices.

## Validation

- Full repository typecheck: passed (23 projects).
- Lint: passed with zero warnings/errors.
- Format check and git diff --check: passed.
- Focused OPE-16 suite: 68 passed, 0 failed, including API authorization/update, PostgreSQL/FORCE-RLS, concurrency/CAS, contracts, SDK, web create-request, and migration release-schema checks.
- Full `bun test`: 4,409 tests run; 4,356 passed, 4 skipped, 49 failed due to unavailable Docker/Node/PostgreSQL shared-test infrastructure and dependent unrelated fixtures.

Linear: OPE-16

Merge and deployment are intentionally pending review and production verification.