### PR TITLE
OPE-99: preserve timeline and session rail scroll

### DIFF
--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -56,6 +56,8 @@ import {
   visualTreeDepth,
 } from "@/lib/session-rail";
 import {
+  cancelSessionRowRevealIntent,
+  consumeSessionRowRevealIntent,
   sessionFocusAttribute,
   shouldRecordSessionRowFocusIntent,
   shouldMoveSessionRowFocus,
@@ -76,6 +78,7 @@ import {
   visibleTreeRows,
   type SessionTreeNode,
 } from "@/lib/sessions-group";
+import { sessionDescendantCountAria, sessionDescendantCountText } from "@/lib/session-tree-count";
 import { cn } from "@/lib/utils";
 import type { Session } from "@/types";
 
@@ -397,6 +400,10 @@ export function SessionList() {
       return match?.[1] ?? null;
     },
   });
+  // Only a route transition, keyboard navigation, or the explicit "Show path"
+  // action may reveal a row. Polls and pagination replace `flat` too, so a
+  // derived focus index is not itself permission to move this scroll container.
+  const rowRevealIntent = useRef<string | null>(activeSessionId);
 
   // Search results are deliberately flat: a partial match set is not a tree.
   // Normal navigation contains only true roots, lazily loaded children, and
@@ -533,13 +540,14 @@ export function SessionList() {
     [childPages, expanded, hierarchyMode, loadChildPage, nodesById],
   );
   const revealActivePath = useCallback(() => {
+    rowRevealIntent.current = activeSessionId;
     setManualExpanded((current) => new Set([...current, ...activeAncestorIds]));
     setManualCollapsed((current) => {
       const next = new Set(current);
       for (const sessionId of activeAncestorIds) next.delete(sessionId);
       return next;
     });
-  }, [activeAncestorIds]);
+  }, [activeAncestorIds, activeSessionId]);
 
   const visibleRows = useMemo(() => {
     const seen = new Set<string>();
@@ -800,6 +808,9 @@ export function SessionList() {
   useEffect(() => {
     const routeChanged = previousActiveSessionId.current !== activeSessionId;
     previousActiveSessionId.current = activeSessionId;
+    if (routeChanged) {
+      rowRevealIntent.current = activeSessionId;
+    }
     setFocusedSessionId((current) => {
       if (!routeChanged && current && flat.some((session) => session.id === current)) {
         return current;
@@ -848,30 +859,44 @@ export function SessionList() {
     [flat, focusIndex],
   );
 
-  // Scroll the keyboard-focused row into view.
+  // Consume an explicit reveal/focus intent once. Data churn can rerun this
+  // effect, but with no intent it owns neither DOM focus nor rail scroll.
   useEffect(() => {
-    if (focusIndex < 0 || !listRef.current) {
+    const root = listRef.current;
+    if (focusIndex < 0 || !root) {
       return;
     }
-    const row = listRef.current.querySelector<HTMLElement>(
-      `[data-session-index="${focusIndex}"][data-session-focus]`,
+    const requestedFocusId = rowFocusIntent.current;
+    const requestedRevealId = rowRevealIntent.current;
+    const requestedSessionId = requestedFocusId ?? requestedRevealId;
+    if (!requestedSessionId) {
+      return;
+    }
+    const row = [...root.querySelectorAll<HTMLElement>("[data-session-row]")].find(
+      (candidate) => candidate.dataset.sessionRow === requestedSessionId,
     );
-    row?.scrollIntoView({ block: "nearest" });
+    if (!row) {
+      return;
+    }
     // Arrow/Home/End navigation must move real DOM focus, not just paint a
     // visual highlight. A route/poll/pin reorder has no such intent and must
     // never steal focus from an actions trigger or another active control.
-    const requestedSessionId = rowFocusIntent.current;
-    const renderedSessionId = flat[focusIndex]?.id ?? null;
-    if (
-      pendingPinFocus.current ||
-      !listRef.current.contains(document.activeElement) ||
-      !shouldMoveSessionRowFocus(requestedSessionId, renderedSessionId)
-    ) {
+    if (requestedFocusId) {
+      const renderedSessionId = flat[focusIndex]?.id ?? null;
+      if (
+        pendingPinFocus.current ||
+        !root.contains(document.activeElement) ||
+        !shouldMoveSessionRowFocus(requestedFocusId, renderedSessionId)
+      ) {
+        rowFocusIntent.current = null;
+        return;
+      }
       rowFocusIntent.current = null;
-      return;
+      row.scrollIntoView({ block: "nearest" });
+      row.focus();
+    } else {
+      consumeSessionRowRevealIntent(root, rowRevealIntent);
     }
-    row?.focus();
-    rowFocusIntent.current = null;
   }, [flat, focusIndex]);
 
   useEffect(() => {
@@ -932,6 +957,18 @@ export function SessionList() {
         aria-label={hierarchyMode ? "Workstreams" : "Session search results"}
         data-sessionpin-session-list
         onKeyDown={onKeyDown}
+        onPointerDown={() => {
+          // Direct reader input cancels a reveal whose target has not mounted
+          // yet. A generic scroll handler cannot distinguish that input from
+          // browser anchoring caused by page merges and other DOM reflow.
+          cancelSessionRowRevealIntent(rowRevealIntent);
+        }}
+        onTouchStart={() => {
+          cancelSessionRowRevealIntent(rowRevealIntent);
+        }}
+        onWheel={() => {
+          cancelSessionRowRevealIntent(rowRevealIntent);
+        }}
         className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-2 pb-2"
       >
         <p className="sr-only" aria-live="polite" aria-atomic="true">
@@ -1140,6 +1177,7 @@ function SessionTreeRow(props: {
   const index = props.flat.indexOf(node.session);
   const directChildCount = node.session.treeStats?.directChildren ?? node.children.length;
   const childCount = node.session.treeStats?.totalDescendants ?? node.children.length;
+  const childCountTruncated = node.session.treeStats?.truncated ?? false;
   const hasChildren = directChildCount > 0 || node.children.length > 0;
   const treeHasActiveDescendant = Boolean(
     node.session.treeStats &&
@@ -1167,6 +1205,7 @@ function SessionTreeRow(props: {
         index={index}
         depth={props.depth}
         childCount={childCount}
+        childCountTruncated={childCountTruncated}
         hasChildren={hasChildren}
         expanded={isExpanded}
         hasActiveDescendant={node.hasActiveDescendant || treeHasActiveDescendant}
@@ -1312,6 +1351,8 @@ function SessionRow(props: {
   depth: number;
   /** Spawned-child count; a chevron + badge appear when > 0. */
   childCount: number;
+  /** True when childCount is a server traversal lower bound. */
+  childCountTruncated: boolean;
   hasChildren: boolean;
   expanded: boolean;
   /** A descendant is live — a collapsed parent shows a quiet activity dot. */
@@ -1332,6 +1373,8 @@ function SessionRow(props: {
   const hasChildren = props.hasChildren;
   const stateLabel = sessionStateLabel(props.session);
   const descendantLabel = sessionDescendantLabel(props.session);
+  const childCountText = sessionDescendantCountText(props.childCount, props.childCountTruncated);
+  const childCountAria = sessionDescendantCountAria(props.childCount, props.childCountTruncated);
   const depthLabel = props.depth > MAX_VISUAL_TREE_DEPTH ? `Level ${props.depth + 1}` : null;
   const relativeTime = relativeTimeLabel(props.session.updatedAt);
   // Indent nested rows; the leading affordance is a chevron for parents, else a
@@ -1424,7 +1467,7 @@ function SessionRow(props: {
             aria-current={props.active ? "page" : undefined}
             aria-label={`Open ${title}. ${stateLabel}${
               props.session.pinned ? ". Pinned" : ""
-            }${hasChildren ? `. ${props.childCount} spawned sessions` : ""}`}
+            }${hasChildren ? `. ${childCountAria.replace("descendant", "spawned")}` : ""}`}
             onFocus={props.onFocus}
             onClick={() => props.onSelect(props.session.id)}
             className="flex h-full min-w-0 flex-1 items-center gap-1.5 rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
@@ -1453,9 +1496,7 @@ function SessionRow(props: {
                     <span className="absolute inset-0 animate-og-pulse rounded-full bg-status-running" />
                   </span>
                 ) : null}
-                <span aria-label={`${props.childCount} descendant sessions`}>
-                  {props.childCount}
-                </span>
+                <span aria-label={childCountAria}>{childCountText}</span>
               </span>
             ) : null}
             {/* Relative time is visible at rest (the list is grouped by recency),
@@ -1508,7 +1549,7 @@ function sessionDescendantLabel(session: Session): string | null {
   const stats = session.treeStats;
   if (!stats || stats.totalDescendants === 0) return null;
   const live = stats.runningDescendants + stats.queuedDescendants;
-  const total = `${stats.totalDescendants}${stats.truncated ? "+" : ""}`;
+  const total = sessionDescendantCountText(stats.totalDescendants, stats.truncated);
   if (stats.attentionDescendants > 0) {
     return `${stats.attentionDescendants} need you · ${total} total`;
   }

--- a/apps/web/src/lib/session-focus.test.ts
+++ b/apps/web/src/lib/session-focus.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  cancelSessionRowRevealIntent,
+  consumeSessionRowRevealIntent,
   shouldMoveSessionRowFocus,
   shouldRecordSessionRowFocusIntent,
   shouldRestoreSessionFocus,
@@ -25,6 +27,56 @@ function fakeElement(
 }
 
 describe("session pin focus restoration", () => {
+  test("consumes one explicit row reveal without turning repeated data churn into scrolling", () => {
+    let scrollCalls = 0;
+    const rows = Array.from({ length: 3_800 }, (_, index) => ({
+      dataset: { sessionRow: `session-${index}` },
+      scrollIntoView: () => {
+        scrollCalls += 1;
+      },
+    })) as unknown as HTMLElement[];
+    const root = {
+      querySelectorAll: () => rows,
+    } as unknown as HTMLElement;
+    const intent = { current: "session-2_400" };
+
+    // A target that is not mounted remains pending without moving the rail.
+    expect(consumeSessionRowRevealIntent(root, intent)).toBeNull();
+    expect(scrollCalls).toBe(0);
+
+    intent.current = "session-2400";
+    expect(consumeSessionRowRevealIntent(root, intent)).toBe(rows[2400]!);
+    expect(intent.current).toBeNull();
+    expect(scrollCalls).toBe(1);
+
+    // Polls, title/status churn, pin reconciliation, and page merges may all
+    // rerun the effect; no new explicit intent means the offset stays owned by
+    // the reader.
+    for (let update = 0; update < 1_000; update += 1) {
+      expect(consumeSessionRowRevealIntent(root, intent)).toBeNull();
+    }
+    expect(scrollCalls).toBe(1);
+  });
+
+  test("lets manual scrolling cancel a reveal before its row mounts", () => {
+    let scrollCalls = 0;
+    const root = {
+      querySelectorAll: () => [
+        {
+          dataset: { sessionRow: "session-late" },
+          scrollIntoView: () => {
+            scrollCalls += 1;
+          },
+        },
+      ],
+    } as unknown as HTMLElement;
+    const intent = { current: "session-late" as string | null };
+
+    cancelSessionRowRevealIntent(intent);
+    expect(consumeSessionRowRevealIntent(root, intent)).toBeNull();
+    expect(scrollCalls).toBe(0);
+  });
+
   test("does not retain intent for boundary navigation that is already current", () => {
     expect(shouldRecordSessionRowFocusIntent(0, 0)).toBe(false);
     expect(shouldRecordSessionRowFocusIntent(2, 2)).toBe(false);

--- a/apps/web/src/lib/session-focus.ts
+++ b/apps/web/src/lib/session-focus.ts
@@ -1,4 +1,30 @@
 export type SessionFocusTarget = "row" | "actions";
+export type SessionRowRevealIntent = { current: string | null };
+
+/** Reader-owned rail movement supersedes an unfulfilled programmatic reveal. */
+export function cancelSessionRowRevealIntent(intent: SessionRowRevealIntent): void {
+  intent.current = null;
+}
+
+/**
+ * Reveal one explicitly requested row and consume the request. Re-running this
+ * during polling, pagination, or title/status churn is a no-op until a caller
+ * records a new route/"Show path" intent.
+ */
+export function consumeSessionRowRevealIntent(
+  root: HTMLElement,
+  intent: SessionRowRevealIntent,
+): HTMLElement | null {
+  const sessionId = intent.current;
+  if (!sessionId) return null;
+  const row = [...root.querySelectorAll<HTMLElement>("[data-session-row]")].find(
+    (candidate) => candidate.dataset.sessionRow === sessionId,
+  );
+  if (!row) return null;
+  intent.current = null;
+  row.scrollIntoView({ block: "nearest" });
+  return row;
+}
 
 /**
  * Boundary navigation is a visual no-op when the requested index is already

--- a/apps/web/src/lib/session-pagination.test.ts
+++ b/apps/web/src/lib/session-pagination.test.ts
@@ -75,6 +75,28 @@ describe("session continuation pagination", () => {
     });
   });
 
+  test("retains thousands of rows across repeated pages, overlaps, and cursor rebases", () => {
+    let state = emptySessionContinuation(12);
+    const expected = new Set<string>();
+    for (let page = 0; page < 80; page += 1) {
+      const start = page === 0 ? 0 : page * 50 - 1;
+      const sessions = Array.from({ length: 51 }, (_, index) => row(`session-${start + index}`));
+      for (const session of sessions) expected.add(session.id);
+      state = mergeSessionContinuation(state, 12, 12, {
+        sessions,
+        nextCursor: page === 79 ? null : `cursor-${page + 1}`,
+      });
+      if (page > 0 && page % 10 === 0) {
+        state = rebaseSessionContinuation(state, 12, 12, `rebased-${page}`);
+      }
+    }
+
+    expect(state.sessions).toHaveLength(expected.size);
+    expect(state.sessions.map((session) => session.id)).toEqual([...expected]);
+    expect(state.nextCursor).toBeNull();
+    expect(state.failed).toBe(false);
+  });
+
   test("rejects a delayed cursor rebase after the query generation changes", () => {
     const current = {
       generation: 9,

--- a/apps/web/src/lib/session-tree-count.test.ts
+++ b/apps/web/src/lib/session-tree-count.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { sessionDescendantCountAria, sessionDescendantCountText } from "./session-tree-count";
+
+describe("session tree descendant counts", () => {
+  test("renders an exact aggregate as exact visible and accessible text", () => {
+    expect(sessionDescendantCountText(3_834, false)).toBe("3,834");
+    expect(sessionDescendantCountAria(3_834, false)).toBe("3,834 descendant sessions");
+    expect(sessionDescendantCountAria(1, false)).toBe("1 descendant session");
+  });
+
+  test("renders a bounded thousand-descendant traversal as a lower bound", () => {
+    expect(sessionDescendantCountText(1_000, true)).toBe("1,000+");
+    expect(sessionDescendantCountAria(1_000, true)).toBe("At least 1,000 descendant sessions");
+  });
+});

--- a/apps/web/src/lib/session-tree-count.ts
+++ b/apps/web/src/lib/session-tree-count.ts
@@ -1,0 +1,13 @@
+const countFormatter = new Intl.NumberFormat("en-US");
+
+/** Visible count text. A capped traversal is a lower bound, never an exact total. */
+export function sessionDescendantCountText(count: number, truncated: boolean): string {
+  return `${countFormatter.format(count)}${truncated ? "+" : ""}`;
+}
+
+/** Screen-reader text that preserves the same exact-vs-lower-bound contract. */
+export function sessionDescendantCountAria(count: number, truncated: boolean): string {
+  const formatted = countFormatter.format(count);
+  if (truncated) return `At least ${formatted} descendant sessions`;
+  return `${formatted} descendant session${count === 1 ? "" : "s"}`;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14513,21 +14513,24 @@ export async function listSessionsForSubject(
           if (ordinaryIds.length > limit) {
             let snapshot = reusableSnapshot;
             if (!snapshot) {
-              const activeSnapshots = await tx
-                .select({ id: schema.sessionListSnapshots.id })
-                .from(schema.sessionListSnapshots)
-                .where(
-                  and(
-                    eq(schema.sessionListSnapshots.workspaceId, workspaceId),
-                    eq(schema.sessionListSnapshots.subjectId, options.subjectId),
-                  ),
-                )
-                .limit(SESSION_LIST_SNAPSHOT_MAX_ACTIVE_PER_SUBJECT);
-              if (activeSnapshots.length >= SESSION_LIST_SNAPSHOT_MAX_ACTIVE_PER_SUBJECT) {
-                throw new SessionListSnapshotLimitError(
-                  "too many active session list snapshots; retry after an existing cursor expires",
-                );
-              }
+              // Creation is serialized by the subject advisory lock above.
+              // Retain only the newest N-1 before inserting so polling and
+              // search identity churn cannot turn this bounded cache into a
+              // user-visible 429. A continuation for an evicted row retains
+              // the existing typed expiry/410 + client rebase contract.
+              await tx.execute(sql`
+                delete from ${schema.sessionListSnapshots} snapshot
+                where snapshot.workspace_id = ${workspaceId}
+                  and snapshot.subject_id = ${options.subjectId}
+                  and snapshot.id in (
+                    select evicted.id
+                    from ${schema.sessionListSnapshots} evicted
+                    where evicted.workspace_id = ${workspaceId}
+                      and evicted.subject_id = ${options.subjectId}
+                    order by evicted.created_at desc, evicted.id desc
+                    offset ${SESSION_LIST_SNAPSHOT_MAX_ACTIVE_PER_SUBJECT - 1}
+                  )
+              `);
               const [workspace] = await tx
                 .select({ accountId: schema.workspaces.accountId })
                 .from(schema.workspaces)

--- a/packages/db/test/session-pins.test.ts
+++ b/packages/db/test/session-pins.test.ts
@@ -1468,7 +1468,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
     expect(count).toEqual({ count: 1, maxIds: 128 });
   }, 60_000);
 
-  test("rejects oversized and over-quota subject snapshots before unbounded storage", async () => {
+  test("rejects oversized subject snapshots before unbounded storage", async () => {
     if (!available) return;
     const oversized = await freshWorkspace();
     const oversizedSubject = "user:oversized-list";
@@ -1494,35 +1494,95 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       select count(*)::int as count from session_list_snapshots
       where workspace_id = ${oversized.workspaceId} and subject_id = ${oversizedSubject}`;
     expect(oversizedCount?.count).toBe(0);
+  }, 60_000);
 
+  test("evicts oldest same-subject snapshots across more than 32 searches and clear", async () => {
+    if (!available) return;
     const quota = await freshWorkspace();
     const quotaSubject = "user:snapshot-quota";
+    const retainedSubject = "user:snapshot-quota-retained";
     await grantMember(quota, quotaSubject);
-    const first = await session({ ...quota, message: "snapshot quota first" });
-    const second = await session({
-      ...quota,
-      message: "snapshot quota second",
-    });
+    await grantMember(quota, retainedSubject);
     await admin`
-      insert into session_list_snapshots (
-        account_id, workspace_id, subject_id, parent_session_filter,
-        search, ordinary_session_ids, expires_at, created_at
+      insert into sessions (
+        id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id
       )
-      select ${quota.accountId}, ${quota.workspaceId}, ${quotaSubject}, 'all',
-        'occupied-' || series, array[${first.id}::uuid, ${second.id}::uuid],
-        now() + interval '10 minutes', now() - interval '1 minute'
-      from generate_series(1, ${SESSION_LIST_SNAPSHOT_MAX_ACTIVE_PER_SUBJECT}) series`;
+      select generated.id, ${quota.accountId}, ${quota.workspaceId},
+        'snapshot query-' || lpad(((generated.ordinality - 1) / 2)::text, 2, '0'),
+        'test-model', 'none', generated.id
+      from (
+        select gen_random_uuid() as id, ordinality
+        from generate_series(1, 68) with ordinality
+      ) generated`;
+
+    const retainedPage = await listSessionsForSubject(db, quota.workspaceId, {
+      subjectId: retainedSubject,
+      search: "snapshot query-00",
+      limit: 1,
+    });
+    const retainedCursor = decodeSessionListCursor(retainedPage.nextCursor!);
+    expect(retainedCursor).not.toBeNull();
+
+    const searchCursors = [];
+    for (let index = 0; index < SESSION_LIST_SNAPSHOT_MAX_ACTIVE_PER_SUBJECT + 2; index += 1) {
+      const search = `snapshot query-${String(index).padStart(2, "0")}`;
+      const page = await listSessionsForSubject(db, quota.workspaceId, {
+        subjectId: quotaSubject,
+        search,
+        limit: 1,
+      });
+      expect(page.sessions).toHaveLength(1);
+      const cursor = decodeSessionListCursor(page.nextCursor!);
+      expect(cursor).not.toBeNull();
+      searchCursors.push(cursor!);
+    }
+
+    // Clearing search creates another first page instead of reproducing the
+    // production 429/empty-state trap.
+    const cleared = await listSessionsForSubject(db, quota.workspaceId, {
+      subjectId: quotaSubject,
+      limit: 1,
+    });
+    const clearedCursor = decodeSessionListCursor(cleared.nextCursor!);
+    expect(cleared.sessions).toHaveLength(1);
+    expect(clearedCursor).not.toBeNull();
+    const clearedContinuation = await listSessionsForSubject(db, quota.workspaceId, {
+      subjectId: quotaSubject,
+      cursor: clearedCursor!,
+      limit: 1,
+    });
+    expect(clearedContinuation.sessions).toHaveLength(1);
+    expect(clearedContinuation.sessions[0]!.id).not.toBe(cleared.sessions[0]!.id);
+
+    const [counts] = await admin<{ quota: number; retained: number }[]>`
+      select
+        count(*) filter (where subject_id = ${quotaSubject})::int as quota,
+        count(*) filter (where subject_id = ${retainedSubject})::int as retained
+      from session_list_snapshots
+      where workspace_id = ${quota.workspaceId}`;
+    expect(counts).toEqual({
+      quota: SESSION_LIST_SNAPSHOT_MAX_ACTIVE_PER_SUBJECT,
+      retained: 1,
+    });
+
+    // The oldest same-subject cursor was evicted into the existing typed
+    // expiry path; another subject's snapshot is isolated and remains usable.
     await expect(
       listSessionsForSubject(db, quota.workspaceId, {
         subjectId: quotaSubject,
-        search: "snapshot quota",
+        search: "snapshot query-00",
+        cursor: searchCursors[0]!,
         limit: 1,
       }),
-    ).rejects.toBeInstanceOf(SessionListSnapshotLimitError);
-    const [quotaCount] = await admin<{ count: number }[]>`
-      select count(*)::int as count from session_list_snapshots
-      where workspace_id = ${quota.workspaceId} and subject_id = ${quotaSubject}`;
-    expect(quotaCount?.count).toBe(SESSION_LIST_SNAPSHOT_MAX_ACTIVE_PER_SUBJECT);
+    ).rejects.toBeInstanceOf(SessionListCursorExpiredError);
+    await expect(
+      listSessionsForSubject(db, quota.workspaceId, {
+        subjectId: retainedSubject,
+        search: "snapshot query-00",
+        cursor: retainedCursor!,
+        limit: 1,
+      }),
+    ).resolves.toMatchObject({ sessions: [{ initialMessage: "snapshot query-00" }] });
   }, 60_000);
 
   test("rejects a stale pin mutation after removal wins the personal-state fence", async () => {

--- a/packages/react/demo/timeline-scroll-test-harness.tsx
+++ b/packages/react/demo/timeline-scroll-test-harness.tsx
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useState } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+
+import { MessageTimeline, type TimelineItem } from "../src/index";
+
+type VisibleRow = { id: string | null; top: number | null };
+type TimelineScrollHarness = {
+  append: () => void;
+  growRowsAbove: () => void;
+  prepend: () => void;
+  scroller: () => HTMLElement;
+  visible: () => VisibleRow;
+};
+
+declare global {
+  interface Window {
+    timelineScrollHarness?: TimelineScrollHarness;
+  }
+}
+
+function item(sequence: number): TimelineItem {
+  return {
+    kind: "user-message",
+    id: `row-${sequence}`,
+    text: `Timeline row ${sequence}`,
+    resources: [],
+    tools: [],
+    occurredAt: new Date(1_750_000_000_000 + sequence).toISOString(),
+  };
+}
+
+function range(start: number, count: number): TimelineItem[] {
+  return Array.from({ length: count }, (_, index) => item(start + index));
+}
+
+function Harness() {
+  const [items, setItems] = useState(() => range(1_000, 120));
+  const [grown, setGrown] = useState(false);
+  const [nextSequence, setNextSequence] = useState(1_120);
+
+  const scroller = useCallback(() => {
+    const node = document.querySelector<HTMLElement>("[data-timeline-test] .og-root > div");
+    if (!node) throw new Error("timeline scroller is unavailable");
+    return node;
+  }, []);
+  const visible = useCallback((): VisibleRow => {
+    const node = scroller();
+    const containerTop = node.getBoundingClientRect().top;
+    const row = [...document.querySelectorAll<HTMLElement>("[data-timeline-row]")].find(
+      (candidate) => candidate.getBoundingClientRect().bottom > containerTop + 1,
+    );
+    return {
+      id: row?.dataset.timelineRow ?? null,
+      top: row ? row.getBoundingClientRect().top - containerTop : null,
+    };
+  }, [scroller]);
+  const append = useCallback(() => {
+    flushSync(() => {
+      setItems((current) => [...current, item(nextSequence)]);
+      setNextSequence((current) => current + 1);
+    });
+  }, [nextSequence]);
+  const prepend = useCallback(() => {
+    flushSync(() => setItems((current) => [...range(900, 100), ...current]));
+  }, []);
+
+  useEffect(() => {
+    window.timelineScrollHarness = {
+      append,
+      growRowsAbove: () => flushSync(() => setGrown(true)),
+      prepend,
+      scroller,
+      visible,
+    };
+    return () => {
+      delete window.timelineScrollHarness;
+    };
+  }, [append, prepend, scroller, visible]);
+
+  return (
+    <main style={{ padding: 32 }} data-og-theme="light">
+      <section data-timeline-test style={{ margin: "0 auto", maxWidth: 900 }}>
+        <MessageTimeline
+          className="timeline-test-shell"
+          items={items}
+          hasOlder
+          renderMessageText={(text, timelineItem) => {
+            const sequence = Number(timelineItem.id.replace("row-", ""));
+            const baseHeight = 34 + (sequence % 7) * 13;
+            // Models delayed image/font/tool-fold measurement above the reader.
+            const delayedGrowth = grown && sequence < 1_060 ? 57 : 0;
+            return (
+              <div
+                data-timeline-row={timelineItem.id}
+                style={{ minHeight: baseHeight + delayedGrowth }}
+              >
+                {text}
+              </div>
+            );
+          }}
+        />
+      </section>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<Harness />);

--- a/packages/react/demo/timeline-scroll-test.html
+++ b/packages/react/demo/timeline-scroll-test.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Timeline scroll regression</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body,
+      #root {
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        background: #f4f6f8;
+        color: #18212f;
+        font: 14px sans-serif;
+      }
+      .timeline-test-shell {
+        display: flex;
+        height: 680px;
+        flex-direction: column;
+        overflow: hidden;
+      }
+      .timeline-test-shell > div {
+        min-height: 0;
+        flex: 1;
+        overflow-y: auto;
+      }
+      [data-timeline-row] {
+        border: 1px solid #d7dde5;
+        border-radius: 12px;
+        padding: 8px;
+      }
+      button {
+        font: inherit;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/timeline-scroll-test-harness.tsx"></script>
+  </body>
+</html>

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -150,19 +150,16 @@ export function MessageTimeline({
   // structurally impossible — the reader only ever sees it already at the
   // bottom. An empty timeline reveals immediately (there is nothing to anchor).
   const [revealed, setRevealed] = useState(false);
-  // Our own scrollTop assignments echo back as scroll events; those must never
-  // UNPIN the reader (they are not reader intent). Marked around every
-  // programmatic assignment and consumed by onScroll. When an assignment is a
-  // NO-OP (already at the target) no scroll event will fire, so the mark must
-  // self-clear — a stale mark would eat the reader's next real scroll-up.
-  const programmaticScrollRef = useRef(false);
+  // Our own scrollTop assignments echo back as delayed scroll events. Track the
+  // actual clamped target rather than a boolean: if reader input lands before
+  // the echo, its different position must win and unpin bottom-follow. A true
+  // echo also must not recapture the visual anchor — during progressive prepend
+  // the next older row may already have mounted by the time that echo arrives.
+  const programmaticScrollTargetRef = useRef<number | null>(null);
   const assignScrollTop = useCallback((node: HTMLElement, value: number) => {
     const previous = node.scrollTop;
-    programmaticScrollRef.current = true;
     node.scrollTop = value;
-    if (node.scrollTop === previous) {
-      programmaticScrollRef.current = false;
-    }
+    programmaticScrollTargetRef.current = node.scrollTop === previous ? null : node.scrollTop;
   }, []);
   // Mirror `pinned` into a ref so the ResizeObserver callback (a stable closure)
   // always reads the live value without re-subscribing on every scroll.
@@ -321,8 +318,10 @@ export function MessageTimeline({
     if (!node) {
       return;
     }
-    const programmatic = programmaticScrollRef.current;
-    programmaticScrollRef.current = false;
+    const programmaticTarget = programmaticScrollTargetRef.current;
+    const programmatic =
+      programmaticTarget !== null && Math.abs(node.scrollTop - programmaticTarget) <= 1;
+    programmaticScrollTargetRef.current = null;
     const nextPinned = node.scrollHeight - node.scrollTop - node.clientHeight < 48;
     // Echoes of our own assignments may PIN but never UNPIN — only the reader
     // scrolling away releases the bottom-follow.
@@ -330,7 +329,12 @@ export function MessageTimeline({
       pinnedRef.current = nextPinned;
       setPinned(nextPinned);
     }
-    captureAnchor();
+    // The assignment site already captured the corrected anchor. Recapturing
+    // it from a delayed echo can observe the next prepended row before that
+    // row's ResizeObserver correction and make the viewport walk up the page.
+    if (!programmatic) {
+      captureAnchor();
+    }
   };
 
   return (

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -9,6 +9,7 @@ const testFiles =
         "./test/e2e/codex-overview.e2e.ts",
         "./test/e2e/queue-surface.browser.e2e.ts",
         "./test/e2e/session-pins.browser.e2e.ts",
+        "./test/e2e/timeline-scroll.browser.e2e.ts",
         "./test/e2e/workbench.browser.e2e.ts",
       ];
 

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -1,0 +1,226 @@
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+import { chromium, type Browser, type Page } from "playwright";
+
+const repoRoot = new URL("../..", import.meta.url).pathname;
+const demoRoot = `${repoRoot}/packages/react/demo`;
+const artifactDir = process.env.OPE99_ARTIFACT_DIR;
+
+type VisibleRow = { id: string | null; top: number | null };
+
+describe("timeline scroll ownership browser regression", () => {
+  let web: StartedProcess;
+  let browser: Browser;
+  let page: Page;
+  let baseUrl: string;
+  let networkRequests = 0;
+
+  beforeAll(async () => {
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    web = await startProcess(
+      ["bun", "run", "vite", ".", "--port", String(port), "--strictPort", "--host", "127.0.0.1"],
+      {
+        cwd: demoRoot,
+        ready: async () =>
+          (await fetch(baseUrl, { signal: AbortSignal.timeout(2_000) }).catch(() => null))?.ok ===
+          true,
+        timeoutMs: 45_000,
+      },
+    );
+    const executablePath = [
+      process.env.CHROMIUM_EXECUTABLE_PATH,
+      "/opt/google/chrome/chrome",
+      "/usr/local/bin/chromium",
+    ].find((candidate): candidate is string => Boolean(candidate && existsSync(candidate)));
+    browser = await chromium.launch({
+      ...(executablePath ? { executablePath } : {}),
+      args: ["--no-sandbox", "--disable-dev-shm-usage"],
+    });
+    page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+    page.on("request", () => {
+      networkRequests += 1;
+    });
+    await page.goto(`${baseUrl}/timeline-scroll-test.html`);
+    await page.waitForFunction(() => window.timelineScrollHarness !== undefined);
+    await page.locator('[data-timeline-row="row-1000"]').waitFor({ timeout: 15_000 });
+  }, 60_000);
+
+  afterAll(async () => {
+    await Promise.allSettled([browser?.close(), web?.stop()]);
+  });
+
+  test("keeps the reader's row and pixel anchor through prepend, wheel, resize, and append", async () => {
+    if (artifactDir) {
+      await mkdir(artifactDir, { recursive: true });
+      await page.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
+    }
+    await page.evaluate(() => {
+      const trace = { active: true, frames: [] as number[], longTasks: [] as number[] };
+      window.timelinePerformanceTrace = trace;
+      const sampleFrame = (timestamp: number) => {
+        trace.frames.push(timestamp);
+        if (trace.active) requestAnimationFrame(sampleFrame);
+      };
+      requestAnimationFrame(sampleFrame);
+      if (typeof PerformanceObserver !== "undefined") {
+        const observer = new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) trace.longTasks.push(entry.duration);
+        });
+        try {
+          observer.observe({ type: "longtask", buffered: true });
+        } catch {
+          // Chrome without the optional long-task entry still reports frame timings.
+        }
+      }
+      document.querySelector<HTMLElement>('[data-timeline-row="row-1040"]')!.scrollIntoView({
+        block: "start",
+      });
+    });
+    networkRequests = 0;
+    const startedAt = performance.now();
+    await page.waitForTimeout(100);
+    const beforePrepend = await visible(page);
+
+    await page.evaluate(() => window.timelineScrollHarness!.prepend());
+    await page.waitForTimeout(100);
+    const duringPrepend = await visible(page);
+    expect(duringPrepend.id).toBe(beforePrepend.id);
+    expect(duringPrepend.top).toBeCloseTo(beforePrepend.top ?? 0, 0);
+
+    const scroller = page.locator("[data-timeline-test] .og-root > div");
+    await scroller.hover();
+    await page.mouse.wheel(0, -96);
+    await page.waitForTimeout(100);
+    const afterWheel = await visible(page);
+
+    await page.locator('[data-timeline-row="row-900"]').waitFor({ timeout: 15_000 });
+    await page.waitForTimeout(100);
+    const afterPrepend = await visible(page);
+    expect(afterPrepend.id).toBe(afterWheel.id);
+    expect(afterPrepend.top).toBeCloseTo(afterWheel.top ?? 0, 0);
+
+    await page.evaluate(() => window.timelineScrollHarness!.growRowsAbove());
+    await page.waitForTimeout(100);
+    const afterDelayedGrowth = await visible(page);
+    expect(afterDelayedGrowth.id).toBe(afterWheel.id);
+    expect(afterDelayedGrowth.top).toBeCloseTo(afterWheel.top ?? 0, 0);
+
+    await page.evaluate(() => window.timelineScrollHarness!.append());
+    await page.waitForTimeout(100);
+    const afterAppend = await visible(page);
+    expect(afterAppend.id).toBe(afterWheel.id);
+    expect(afterAppend.top).toBeCloseTo(afterWheel.top ?? 0, 0);
+
+    expect(Number(afterAppend.id?.replace("row-", ""))).toBeGreaterThanOrEqual(1_038);
+    expect(await page.getByRole("button", { name: "Jump to latest" }).count()).toBe(1);
+
+    if (artifactDir) {
+      const browserMetrics = await collectBrowserMetrics(page);
+      const evidence = {
+        elapsedMs: Math.round((performance.now() - startedAt) * 100) / 100,
+        networkRequests,
+        beforePrepend,
+        duringPrepend,
+        afterWheel,
+        afterPrepend,
+        afterDelayedGrowth,
+        afterAppend,
+        ...browserMetrics,
+      };
+      await writeFile(
+        `${artifactDir}/timeline-scroll-metrics.json`,
+        JSON.stringify(evidence, null, 2),
+      );
+      await page.evaluate((result) => {
+        const overlay = document.createElement("pre");
+        overlay.dataset.timelineEvidence = "";
+        overlay.style.cssText =
+          "position:fixed;left:16px;top:16px;z-index:9999;max-width:620px;padding:14px;background:#fff;color:#111;border:3px solid #17803d;font:13px/1.35 monospace;white-space:pre-wrap";
+        overlay.textContent = `OPE-99 repaired progressive prepend\nAnchor preserved: ${result.afterWheel.id} @ ${result.afterWheel.top}px through prepend, delayed growth, and append.\nFrames: ${result.frameCount}; p95 ${result.frameIntervalP95Ms}ms; max ${result.maxFrameIntervalMs}ms; long tasks ${result.longTaskCount}; network ${result.networkRequests}.`;
+        document.body.append(overlay);
+      }, evidence);
+      await captureEvidenceMatrix(page, artifactDir);
+      await page
+        .context()
+        .tracing.stop({ path: `${artifactDir}/timeline-scroll-playwright-trace.zip` });
+    }
+  }, 30_000);
+});
+
+async function visible(page: Page): Promise<VisibleRow> {
+  return await page.evaluate(() => window.timelineScrollHarness!.visible());
+}
+
+async function collectBrowserMetrics(page: Page) {
+  const frameMetrics = await page.evaluate(() => {
+    const trace = window.timelinePerformanceTrace!;
+    trace.active = false;
+    const intervals = trace.frames
+      .slice(1)
+      .map((timestamp, index) => timestamp - trace.frames[index]!)
+      .sort((left, right) => left - right);
+    const percentile =
+      intervals[Math.min(intervals.length - 1, Math.floor(intervals.length * 0.95))];
+    return {
+      frameCount: trace.frames.length,
+      frameIntervalP95Ms: Math.round((percentile ?? 0) * 100) / 100,
+      maxFrameIntervalMs: Math.round((intervals.at(-1) ?? 0) * 100) / 100,
+      estimatedDroppedFrames: intervals.reduce(
+        (total, interval) => total + Math.max(0, Math.round(interval / 16.67) - 1),
+        0,
+      ),
+      longTaskCount: trace.longTasks.length,
+      longTaskTotalMs:
+        Math.round(trace.longTasks.reduce((total, duration) => total + duration, 0) * 100) / 100,
+      renderedRows: document.querySelectorAll("[data-timeline-row]").length,
+    };
+  });
+  const session = await page.context().newCDPSession(page);
+  await session.send("Performance.enable");
+  const cdpMetrics = await session.send("Performance.getMetrics");
+  const values = new Map(cdpMetrics.metrics.map((metric) => [metric.name, metric.value]));
+  await session.detach();
+  return {
+    ...frameMetrics,
+    jsHeapUsedBytes: values.get("JSHeapUsedSize") ?? null,
+    domNodeCount: values.get("Nodes") ?? null,
+    layoutCount: values.get("LayoutCount") ?? null,
+  };
+}
+
+async function captureEvidenceMatrix(page: Page, outputDir: string): Promise<void> {
+  const states = [
+    { name: "desktop-light", width: 1280, height: 900, dark: false },
+    { name: "desktop-dark", width: 1280, height: 900, dark: true },
+    { name: "mobile-light", width: 390, height: 844, dark: false },
+    { name: "mobile-dark", width: 390, height: 844, dark: true },
+  ];
+  for (const state of states) {
+    await page.setViewportSize({ width: state.width, height: state.height });
+    await page.evaluate((dark) => {
+      document.documentElement.style.colorScheme = dark ? "dark" : "light";
+      document.body.style.background = dark ? "#10141c" : "#f4f6f8";
+      document.body.style.color = dark ? "#f4f7fb" : "#18212f";
+    }, state.dark);
+    await page.screenshot({ path: `${outputDir}/timeline-${state.name}.png`, fullPage: true });
+  }
+}
+
+declare global {
+  interface Window {
+    timelineScrollHarness?: {
+      append: () => void;
+      growRowsAbove: () => void;
+      prepend: () => void;
+      visible: () => VisibleRow;
+    };
+    timelinePerformanceTrace?: {
+      active: boolean;
+      frames: number[];
+      longTasks: number[];
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- preserve the first visible timeline row and pixel offset while older groups progressively mount, delayed content changes height, and new events append
- stop session-rail polling, title/status churn, pin reconciliation, and pagination from scrolling; reveal only for route changes, **Show path**, or keyboard navigation
- render a server-truncated descendant traversal as a lower bound (`1,000+`, accessible text: `At least 1,000 descendant sessions`) instead of an exact count
- at the 32-active-snapshots-per-subject cap, evict the oldest same-subject snapshot(s) before inserting a new first page instead of returning HTTP 429; evicted continuations retain the existing typed 410/rebase path
- add thousand-row pagination/focus regressions, more than 32 search identities plus search→clear recovery, and a real-Chromium timeline harness

## Production evidence

- workspace sessions observed: **4,597** (incident follow-up: 4,604)
- exact root descendants: **3,834**; direct children: **120**
- current API tree stats: `totalDescendants: 1000`, `truncated: true`
- no missing parents; production `sessions` has no archive columns
- incident window 11:25–11:30 UTC: **38 HTTP 429s** from the session-list route after valid access grants; the workspace was below the 5,000-ID hard bound, isolating the failure to the 32-active-snapshot cap

The count drop was a bounded traversal presented as exact, not deleted lineage. The search/clear outage was the bounded snapshot cache returning 429, not auth, membership, RLS, or deleted sessions. This PR preserves the OPE-65/OPE-77 traversal, pagination, 32-snapshot, and 5,000-ID bounds plus OPE-61 absence/archive semantics. It changes only the at-cap policy from rejection to serialized oldest-same-subject eviction. No database schema or migration changes are included.

The current-main Chromium reproduction showed a small trusted `-96px` upward wheel during progressive prepend move the viewport from `row-1040 @ 0px` to `row-987 @ 30px`. The repaired harness keeps `row-1038 @ -37px` exact through the remaining prepend, delayed variable-height growth, and append.

## Verification

- focused timeline/rail/pagination/count units — **26 pass, 0 fail, 1,098 assertions**
- real PostgreSQL 16 + pgvector 0.8.1, full migrations, non-superuser `opengeni_app`, FORCE RLS — `session-pins`: **28 pass, 0 fail, 179 assertions**; includes 34 search identities, search→clear continuation, exact 32-row retention, same-subject oldest eviction, other-subject isolation, typed stale-cursor expiry, and 5,001-ID rejection
- `bun scripts/run-browser-e2e.ts ./test/e2e/timeline-scroll.browser.e2e.ts` — **1 pass, 0 fail, 10 assertions** in real Chromium
- `bun run typecheck` — **23/23 projects clean**
- `bun run format:check` — pass
- `bun run lint` — **0 warnings, 0 errors**
- `git diff --check` — pass
- `bun run test` — **4,413 pass, 4 skip, 28 fail** in the no-Docker sandbox; 8 failures were the known injected credential-path fixture issue and reran **15/15 clean** with `OPENGENI_GIT_TOKEN_FILE`, `OPENGENI_GIT_CREDENTIALS_DIR`, and `OPENGENI_GIT_CLI_WRAPPER_DIR` unset. The remaining 20 are Docker-backed infrastructure failures (19 shared-PostgreSQL acquisitions and one Docker Compose fixture). The changed database suite was separately proven clean against disposable real PG16/FORCE RLS as above.

Browser interaction metrics: 139 frames, p95 frame interval 16.7ms, max 16.8ms, estimated dropped frames 0, one 95ms long task, 0 interaction network requests, ~38MB JS heap. Scrubbed before/after screenshots for desktop/mobile and light/dark, JSON metrics, and the Playwright trace are attached to Linear OPE-99.

## Immutable candidate

- base: `41f37eeb7870a49e6dafacf76a5f0a9487f129e2`
- head: `7281b0079be3e246527b022b24e4474ce72da804`
- tree: `62049e5f1818839152be690e0a7749cf1263adb4`
- commits over base: **1**
- migration risk: **none** (no migration/schema change; bounded transactional row eviction only)

Not merged or deployed; OPE-99 must remain In Progress until production deployment and live verification. The separate composer request-amplification/OOM repair remains owned by OPE-44 and is intentionally not duplicated here.
