### PR TITLE
fix(react): stabilize composer draft loading

### DIFF
--- a/.changeset/steady-composer-drafts.md
+++ b/.changeset/steady-composer-drafts.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Prevent live session and policy rerenders from repeatedly fetching the same composer draft while preserving target, explicit, and event-driven reloads.

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -107,7 +107,11 @@ export function useComposer(
   const lastSavedSignature = useRef<string | null>(null);
   const saveChain = useRef<Promise<void>>(Promise.resolve());
   const onSent = options.onSent;
-  const onDraftApplied = options.onDraftApplied;
+  // Read through a ref so live session/policy projections can replace their
+  // apply callback without invalidating the draft loader and re-running its
+  // initial-load effect.
+  const onDraftAppliedRef = useRef(options.onDraftApplied);
+  onDraftAppliedRef.current = options.onDraftApplied;
   // Read through a ref so a new extras closure (created every render by
   // callers passing inline functions) does not invalidate `send`.
   const sendExtrasRef = useRef(options.sendExtras);
@@ -172,9 +176,9 @@ export function useComposer(
       setValue(next.text);
       setRestoredResources(next.resources);
       setDraftConflict(null);
-      onDraftApplied?.(next);
+      onDraftAppliedRef.current?.(next);
     },
-    [durableDrafts, onDraftApplied, targetKey],
+    [durableDrafts, targetKey],
   );
 
   const loadDraft = useCallback(
@@ -227,7 +231,7 @@ export function useComposer(
             lastSavedSignature.current = draftSignature(draftPayload(fetched));
             setValue(fetched.text);
             setRestoredResources(fetched.resources);
-            onDraftApplied?.(fetched);
+            onDraftAppliedRef.current?.(fetched);
           }
         }
       } catch (cause) {
@@ -248,7 +252,7 @@ export function useComposer(
         }
       }
     },
-    [client, durableDrafts, onDraftApplied, sessionId, targetKey, workspaceId],
+    [client, durableDrafts, sessionId, targetKey, workspaceId],
   );
 
   useEffect(() => {

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -107,11 +107,15 @@ export function useComposer(
   const lastSavedSignature = useRef<string | null>(null);
   const saveChain = useRef<Promise<void>>(Promise.resolve());
   const onSent = options.onSent;
+  const onDraftApplied = options.onDraftApplied;
   // Read through a ref so live session/policy projections can replace their
   // apply callback without invalidating the draft loader and re-running its
-  // initial-load effect.
-  const onDraftAppliedRef = useRef(options.onDraftApplied);
-  onDraftAppliedRef.current = options.onDraftApplied;
+  // initial-load effect. Publish only committed callbacks: a suspended target
+  // render must not retarget an in-flight read owned by the committed session.
+  const onDraftAppliedRef = useRef(onDraftApplied);
+  useLayoutEffect(() => {
+    onDraftAppliedRef.current = onDraftApplied;
+  }, [onDraftApplied]);
   // Read through a ref so a new extras closure (created every render by
   // callers passing inline functions) does not invalidate `send`.
   const sendExtrasRef = useRef(options.sendExtras);

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -2234,6 +2234,80 @@ describe("session hook concurrent target ownership", () => {
       globalThis.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
     }
   });
+
+  test("a suspended target render cannot retarget a committed draft callback", async () => {
+    const sessionA: string = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const sessionB: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const draftA: ComposerDraft = {
+      revision: 1,
+      text: "A draft",
+      resources: [],
+      tools: [],
+      toolsProvided: false,
+      model: "model-a",
+      reasoningEffort: "medium",
+      sourceTurnId: null,
+      sourceTurnVersion: null,
+      updatedAt: new Date().toISOString(),
+    };
+    let resolveA!: (draft: ComposerDraft) => void;
+    const client = fakeClient({
+      getComposerDraft: async (_workspaceId, sessionId) => {
+        if (sessionId !== sessionA) throw new Error("uncommitted B must not read");
+        return await new Promise<ComposerDraft>((resolve) => {
+          resolveA = resolve;
+        });
+      },
+    });
+    const applied: string[] = [];
+    let setTarget!: (target: string) => void;
+    let renderedB = false;
+    const suspended = new Promise<never>(() => {});
+
+    function Harness() {
+      const [target, setTargetState] = useState(sessionA);
+      setTarget = setTargetState;
+      useComposer(target, {
+        client,
+        workspaceId: WORKSPACE_ID,
+        events: noEvents,
+        onDraftApplied: (draft) => applied.push(`${target}:${draft.text}`),
+      });
+      if (target === sessionB) {
+        renderedB = true;
+        throw suspended;
+      }
+      return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const previousActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT;
+    globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+    try {
+      flushSync(() => {
+        root.render(
+          <Suspense fallback={null}>
+            <Harness />
+          </Suspense>,
+        );
+      });
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      startTransition(() => setTarget(sessionB));
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(renderedB).toBe(true);
+
+      resolveA(draftA);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(applied).toEqual([`${sessionA}:A draft`]);
+    } finally {
+      flushSync(() => root.unmount());
+      container.remove();
+      globalThis.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
 });
 
 describe("useComposer file-only send", () => {

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1671,6 +1671,73 @@ describe("useComposer queue-vs-steer", () => {
 });
 
 describe("useComposer durable draft and control binding", () => {
+  test("callback churn does not reload drafts outside target, explicit, or event triggers", async () => {
+    const sessionB: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const reads: string[] = [];
+    const applied: string[] = [];
+    const client = fakeClient({
+      getComposerDraft: async (_workspaceId, sessionId) => {
+        reads.push(sessionId);
+        return {
+          revision: reads.length,
+          text: `${sessionId}:read-${reads.length}`,
+          resources: [],
+          tools: [],
+          toolsProvided: false,
+          model: "model-x",
+          reasoningEffort: "medium",
+          sourceTurnId: null,
+          sourceTurnVersion: null,
+          updatedAt: new Date().toISOString(),
+        } satisfies ComposerDraft;
+      },
+    });
+    type Props = {
+      sessionId: string;
+      policyVersion: number;
+      events: SessionEvent[];
+    };
+    const hook = await renderHook(
+      (props: Props) =>
+        useComposer(props.sessionId, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          events: props.events,
+          onDraftApplied: (draft) => {
+            applied.push(`${props.policyVersion}:${draft.text}`);
+          },
+        }),
+      { sessionId: SESSION_ID, policyVersion: 0, events: noEvents },
+    );
+    await flush();
+    expect(reads).toEqual([SESSION_ID]);
+    expect(applied).toEqual([`0:${SESSION_ID}:read-1`]);
+
+    await hook.rerender({ sessionId: SESSION_ID, policyVersion: 1, events: noEvents });
+    await hook.rerender({ sessionId: SESSION_ID, policyVersion: 2, events: noEvents });
+    await flush();
+    expect(reads).toEqual([SESSION_ID]);
+
+    await flushing(async () => await hook.result.current.reloadDraft());
+    expect(reads).toEqual([SESSION_ID, SESSION_ID]);
+    expect(applied.at(-1)).toBe(`2:${SESSION_ID}:read-2`);
+
+    await hook.rerender({
+      sessionId: SESSION_ID,
+      policyVersion: 3,
+      events: [makeEvent(1, "session.queue.changed", { operation: "edit" })],
+    });
+    await flush();
+    expect(reads).toEqual([SESSION_ID, SESSION_ID, SESSION_ID]);
+    expect(applied.at(-1)).toBe(`3:${SESSION_ID}:read-3`);
+
+    await hook.rerender({ sessionId: sessionB, policyVersion: 4, events: noEvents });
+    await flush();
+    expect(reads).toEqual([SESSION_ID, SESSION_ID, SESSION_ID, sessionB]);
+    expect(applied.at(-1)).toBe(`4:${sessionB}:read-4`);
+    await hook.unmount();
+  });
+
   test("a live queue mutation reloads the authoritative draft in another tab", async () => {
     let current: ComposerDraft = {
       revision: 1,


### PR DESCRIPTION
## Summary

- keep the latest `onDraftApplied` callback in a ref so live session/policy callback churn cannot recreate `loadDraft`
- stop callback-only rerenders from refiring the initial composer-draft load effect
- preserve one initial read per session target plus explicit `reloadDraft()` and relevant `user.message` / `session.queue.changed` event reloads
- add a patch changeset for `@opengeni/react`

## Production evidence

During the 2026-07-27 production incident, two 1 GiB API replicas were OOMKilled at 11:26:32Z and 11:28:34Z. Their preserved previous containers served 14,078 successful composer-draft GETs in about 13 minutes; draft reads were 84–85% of API traffic, approximately 1,500–1,982 requests/minute near the incident.

The regression reproduced the source amplifier before the fix: an inline `onDraftApplied` callback caused a draft read, state update, new callback identity, new `loadDraft`, and another initial-load effect until the test timed out at 5 seconds. After the ref stabilization, the same test completes in under 30 ms and asserts the exact allowed read triggers.

## Verification

- `bun test --timeout 30000 packages/react/test/hooks.test.tsx` — 61 pass, 243 assertions
- focused callback-churn regression — 1 pass, 9 assertions
- `bun test --timeout 30000 packages/react/test/use-composer-embedding.test.tsx` — 1 pass, 8 assertions
- `cd packages/react && bun run typecheck` — pass
- `cd packages/react && bun run build` — ESM and DTS pass
- targeted `oxfmt --check`, `oxlint --deny-warnings`, and `git diff --check` — pass

## Scope

This is the narrow OPE-44 composer-draft request-amplifier repair only. It does not include or modify OPE-99 session snapshot, rail search, history, scrolling, or count work. No merge, deployment, production mutation, or Done transition is included.
