### PR TITLE
Fix retryable sandbox restore dead-end

### DIFF
--- a/.changeset/retry-recoverable-sandbox-restores.md
+++ b/.changeset/retry-recoverable-sandbox-restores.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Allow a cold sandbox lease to elect a new rematerialization attempt after a restore failure explicitly marked retryable, while continuing to block non-retryable degraded and unrecoverable archives.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -19437,7 +19437,7 @@ export async function acquireLease(
         if (liveness === "cold") {
           const recovery = recoveryStateFromLeaseRow(row);
           if (
-            recovery.restore.status === "degraded" ||
+            (recovery.restore.status === "degraded" && recovery.restore.retryable !== true) ||
             recovery.restore.status === "unrecoverable"
           ) {
             return {

--- a/packages/db/test/sandbox-leases.test.ts
+++ b/packages/db/test/sandbox-leases.test.ts
@@ -7,6 +7,7 @@ import {
   commitWarmingToWarm,
   confirmDrainCold,
   createDb,
+  failSandboxRematerialization,
   failWarmingToCold,
   getMaterializedSandboxFileResources,
   heartbeatLeaseHolder,
@@ -592,6 +593,102 @@ describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
       leaseTtlMs: 45_000,
     });
     expect(late.recorded).toBe(false);
+  }, 60_000);
+
+  test("(1b-4) a retryable degraded restore can elect one new rematerialization attempt", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    const archive = Buffer.from("retryable-restore-archive").toString("base64");
+    const archiveHash = "a".repeat(64);
+    const descriptor = {
+      version: 1 as const,
+      revision: `wa1:1900000003000:${archiveHash}`,
+      archiveSha256: archiveHash,
+      archiveBytes: Buffer.from(archive, "base64").length,
+      capturedAt: "2030-03-17T17:46:43.000Z",
+      workspace: {
+        algorithm: "sha256" as const,
+        sha256: "b".repeat(64),
+        entryCount: 3,
+        fileCount: 2,
+        totalFileBytes: 41,
+      },
+    };
+    const first = await acquireLease(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "turn",
+      holderId: "first-restore",
+      backend: "modal",
+      leaseTtlMs: 45_000,
+    });
+    expect(first.role).toBe("spawner");
+    const firstAttempt = crypto.randomUUID();
+    const begun = await beginSandboxRematerialization(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      expectedEpoch: first.lease.leaseEpoch,
+      rematerializationId: firstAttempt,
+      archiveSource: {
+        backendId: "modal",
+        sessionState: { workspaceArchive: archive, workspaceArchiveMeta: descriptor },
+      },
+    });
+    expect(begun.status).toBe("started");
+
+    const failed = await failSandboxRematerialization(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      expectedEpoch: first.lease.leaseEpoch,
+      rematerializationId: firstAttempt,
+      failureCode: "workspace_fingerprint_unavailable",
+      retryable: true,
+    });
+    expect(failed.failed).toBe(true);
+    expect(failed.lease).toMatchObject({
+      liveness: "cold",
+      recovery: {
+        archive: { status: "available", current: { revision: descriptor.revision } },
+        restore: {
+          status: "degraded",
+          failureCode: "workspace_fingerprint_unavailable",
+          retryable: true,
+        },
+      },
+    });
+
+    const successor = await acquireLease(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "turn",
+      holderId: "second-restore",
+      backend: "modal",
+      leaseTtlMs: 45_000,
+    });
+    expect(successor.role).toBe("spawner");
+    expect(successor.lease.leaseEpoch).toBe(first.lease.leaseEpoch + 1);
+
+    const successorAttempt = crypto.randomUUID();
+    const successorBegun = await beginSandboxRematerialization(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      expectedEpoch: successor.lease.leaseEpoch,
+      rematerializationId: successorAttempt,
+    });
+    expect(successorBegun.status).toBe("started");
+    if (successorBegun.status === "started") {
+      expect(successorBegun.lease.recovery.restore).toMatchObject({
+        status: "restoring",
+        rematerializationId: successorAttempt,
+        selectedRevision: descriptor.revision,
+      });
+      expect(successorBegun.lease.archiveComplete).toBe(true);
+    }
   }, 60_000);
 
   test("(1d) invalidated warming epochs fence a late create and its cleanup from a successor", async () => {


### PR DESCRIPTION
## What
- allow retryable degraded cold restores to re-enter the existing single-spawner rematerialization path
- preserve blocking for non-retryable degraded and unrecoverable states
- add a real-Postgres regression test proving the exact archive revision is retained and selected by the successor attempt

## Production incident
The master session has a complete archive at generation 44, but a Modal fingerprint parser failure persisted `restore.status=degraded` with `retryable=true`. Admission ignored the retryable bit and permanently blocked recovery. Current main already includes the Modal output parser fix; this change closes the state-machine dead-end.

## Verification
- `bun test packages/db/test/sandbox-leases.test.ts -t "retryable degraded restore"`
- `bun run --cwd packages/db typecheck`
- `bunx oxfmt --check ...`
- `git diff --check`

Linear: OPE-60