### PR TITLE
fix(web): prevent duplicate session rename commits

### DIFF
--- a/apps/web/src/lib/session-rename.test.ts
+++ b/apps/web/src/lib/session-rename.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { actRun, registerDom, renderHook } from "../../../../packages/react/test/render-hook";
 
 import {
   SESSION_TITLE_MAX_LENGTH,
@@ -6,8 +7,11 @@ import {
   renameSeedValue,
   resolveRenameSubmission,
   sessionDisplayTitle,
+  useInlineRename,
 } from "./session-rename";
 import type { Session } from "../types";
+
+registerDom();
 
 // The three rename surfaces (header pencil, rail-row context menu, rail-row
 // hover overflow) all funnel through these pure helpers and the `useInlineRename`
@@ -173,6 +177,46 @@ describe("performRename (the commit every rename surface runs)", () => {
     // Unchanged from the initial-message fallback display.
     expect(await performRename(session({ title: null }), "Inspect the repo", rename.fn)).toBeNull();
     expect(rename.calls).toEqual([]);
+  });
+});
+
+describe("useInlineRename commit fencing", () => {
+  test("Enter followed by blur only persists one title while the first request is pending", async () => {
+    let resolveRename!: (result: Session | null) => void;
+    const renameResponse = new Promise<Session | null>((resolve) => {
+      resolveRename = resolve;
+    });
+    const calls: string[] = [];
+    const hook = await renderHook(
+      () =>
+        useInlineRename(session({ title: "Old" }), async (_workspaceId, _sessionId, title) => {
+          calls.push(title);
+          return await renameResponse;
+        }),
+      undefined,
+    );
+
+    await actRun(() => hook.result.current.startEditing());
+    await actRun(() => hook.result.current.setDraft("New"));
+
+    // Both handlers retain the same pre-update closure in a real Enter+blur
+    // sequence. The ref fence must win before React commits `saving=true`.
+    const commit = hook.result.current.commit;
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    await actRun(() => {
+      first = commit();
+      second = commit();
+    });
+
+    expect(calls).toEqual(["New"]);
+
+    resolveRename(session({ title: "New", titleSource: "user" }));
+    await actRun(async () => {
+      await Promise.all([first, second]);
+    });
+    expect(calls).toHaveLength(1);
+    await hook.unmount();
   });
 });
 

--- a/apps/web/src/lib/session-rename.ts
+++ b/apps/web/src/lib/session-rename.ts
@@ -95,6 +95,11 @@ export function useInlineRename(session: Session, onRename: RenameFn): InlineRen
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(display);
   const [saving, setSaving] = useState(false);
+  // Enter and blur can fire back-to-back while the first commit is still
+  // awaiting the PATCH response. A ref closes that window synchronously;
+  // `saving` is deliberately retained as render state for consumers but is
+  // not authoritative for event handlers from the previous render.
+  const commitInFlightRef = useRef(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   // Reseed the draft whenever the displayed title changes while not editing
@@ -122,7 +127,7 @@ export function useInlineRename(session: Session, onRename: RenameFn): InlineRen
   }, [display]);
 
   const commit = useCallback(async () => {
-    if (saving) {
+    if (commitInFlightRef.current || saving) {
       return;
     }
     const next = resolveRenameSubmission(draft, display);
@@ -130,12 +135,14 @@ export function useInlineRename(session: Session, onRename: RenameFn): InlineRen
     if (next === null) {
       return;
     }
+    commitInFlightRef.current = true;
     setSaving(true);
     try {
       // Same resolve-and-persist as performRename; the draft is already
       // resolved here so we skip straight to the call.
       await onRename(session.workspaceId, session.id, next);
     } finally {
+      commitInFlightRef.current = false;
       setSaving(false);
     }
   }, [saving, draft, display, onRename, session.workspaceId, session.id]);

--- a/packages/react/src/hooks/use-session.ts
+++ b/packages/react/src/hooks/use-session.ts
@@ -1,5 +1,5 @@
 import type { Session, SessionEvent } from "@opengeni/sdk";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useOpenGeni, type ClientOverride } from "../provider";
 import {
   useMutationRunner,
@@ -66,10 +66,13 @@ export function useSession(
   const base = data ?? null;
   // The override only ever carries title/titleSource patches; it is reset on
   // every fresh load so it can never go stale against the server snapshot.
-  const session =
-    base && override && override.id === base.id
-      ? { ...base, title: override.title, titleSource: override.titleSource }
-      : base;
+  const session = useMemo(
+    () =>
+      base && override && override.id === base.id
+        ? { ...base, title: override.title, titleSource: override.titleSource }
+        : base,
+    [base, override],
+  );
 
   // Live-patch the title on auto (agent) + cross-client (user/agent) renames so
   // the UI reflects the new title without polling or a full re-fetch.

--- a/packages/react/test/use-session.test.tsx
+++ b/packages/react/test/use-session.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import type { Session, SessionEvent } from "@opengeni/sdk";
+
+import { registerDom, renderHook, flush } from "./render-hook";
+import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
+import { useSession } from "../src/hooks/use-session";
+
+registerDom();
+
+const serverSession = {
+  id: SESSION_ID,
+  workspaceId: WORKSPACE_ID,
+  lastSequence: 0,
+  title: null,
+  titleSource: null,
+} as Session;
+
+function titleEvent(title: string): SessionEvent {
+  return {
+    id: "title-event-1",
+    workspaceId: WORKSPACE_ID,
+    sessionId: SESSION_ID,
+    sequence: 1,
+    type: "session.title_set",
+    payload: { title, source: "user" },
+    occurredAt: "2026-07-27T00:00:00.000Z",
+    clientEventId: null,
+    turnId: null,
+  };
+}
+
+describe("useSession", () => {
+  test("keeps its live title projection identity stable between parent renders", async () => {
+    const client = fakeClient({ getSession: async () => serverSession });
+    const hook = await renderHook(
+      (events: SessionEvent[]) =>
+        useSession(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          events,
+        }),
+      [] as SessionEvent[],
+    );
+    await flush();
+
+    await hook.rerender([titleEvent("Renamed")]);
+    await flush();
+    const renamed = hook.result.current.session;
+    expect(renamed?.title).toBe("Renamed");
+
+    // The route/context bridge may re-render the hook after applying the
+    // title. Reusing the projection prevents that render from retriggering its
+    // session synchronization effect indefinitely.
+    await hook.rerender([titleEvent("Renamed")]);
+    expect(hook.result.current.session).toBe(renamed);
+    await hook.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- synchronously fence inline session rename commits so Enter followed by blur cannot issue two PATCH requests before React commits `saving`
- memoize the React session title override projection so the route/context synchronization bridge receives stable identity between parent renders
- add deterministic regression coverage for the Enter+blur race and live title projection identity

## Root cause
The inline rename `saving` guard was render state. Enter and the input's blur/unmount handler can retain the same pre-update closure and both pass the guard while the first PATCH is pending. Separately, `useSession` spread the title override into a new object on every render; that made the route/context bridge re-submit equivalent session state on provider-triggered renders. The fix uses a ref as the synchronous commit authority and `useMemo` keyed to the actual base/override inputs.

## Validation
- `bun test --timeout 30000 apps/web/src/lib/session-rename.test.ts packages/react/test/use-session.test.tsx` — 13 passed, 0 failed
- `bun test --timeout 30000 apps/web/src/App.test.ts packages/react/test/hooks.test.tsx packages/react/test/use-session-events.test.tsx` — 186 passed, 0 failed
- `cd packages/react && bun run typecheck` — passed
- `cd apps/web && bun run typecheck` — passed
- `bun x oxlint --deny-warnings` on changed files — passed
- `bun x oxfmt --check` on changed files — passed
- `cd apps/web && bun run build` — passed, bundle budgets passed
- real Chromium temporary Vite harness — desktop/mobile × light/dark all persisted exactly one save, showed the renamed title, and reported no page errors; scrubbed screenshots are in `/tmp/ope101-browser-evidence/`

## Scope
No API, navigation, deployment, or unrelated cleanup changes. Authenticated full-stack staging/production verification remains for the release owner.
