### PR TITLE
Bound event-lineage cleanup and harden the headless sandbox runtime

### DIFF
--- a/.changeset/complete-retryable-sandbox-recovery.md
+++ b/.changeset/complete-retryable-sandbox-recovery.md
@@ -1,5 +1,5 @@
 ---
-"@opengeni/worker": patch
+"@opengeni/worker-bundle": patch
 ---
 
 Retry transient sandbox archive restore failures through both lazy provisioning and concurrent warmup waiters.

--- a/.changeset/fast-event-duplicate-cleanup.md
+++ b/.changeset/fast-event-duplicate-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+---
+
+Index duplicate-event lineage so foreign-key validation and exact session cleanup remain bounded at
+production event-table cardinality.

--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -1,9 +1,10 @@
+FROM node:22.22.0-bookworm-slim AS node-runtime
+
 FROM python:3.12-slim
 
 ARG TERRAFORM_VERSION=1.13.3
 ARG CHECKOV_VERSION=3.2.526
 ARG TTYD_VERSION=1.7.7
-ARG NODE_MAJOR=20
 ARG TARGETARCH
 
 RUN set -eux; \
@@ -15,6 +16,8 @@ RUN set -eux; \
         gpg \
         git \
         jq \
+        libatomic1 \
+        libstdc++6 \
         openssh-client \
         procps \
         fuse3 \
@@ -35,27 +38,10 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends $packages; \
     rm -rf /var/lib/apt/lists/*
 
-# Node.js LTS from NodeSource. The distro `nodejs` package is far too old for
-# ogtool (Debian bookworm ships 18, Ubuntu jammy ships 12); pin the 20.x LTS
-# line via the NodeSource apt repo, mirroring the gh keyring+repo layer below.
-RUN set -eux; \
-    mkdir -p -m 755 /etc/apt/keyrings; \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
-    chmod go+r /etc/apt/keyrings/nodesource.gpg; \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
-        > /etc/apt/sources.list.d/nodesource.list; \
-    for attempt in 1 2 3; do \
-        rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/partial/*; \
-        apt-get update \
-        && apt-get install -y --download-only --no-install-recommends nodejs \
-        && break; \
-        if [ "$attempt" = "3" ]; then exit 1; fi; \
-        sleep $((attempt * 5)); \
-    done; \
-    apt-get install -y --no-install-recommends nodejs; \
-    rm -rf /var/lib/apt/lists/*; \
-    node --version
+# ogtool is dependency-free but requires a supported Node runtime. Copy the
+# exact official LTS binary instead of trusting a mutable third-party apt key.
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+RUN test "$(node --version)" = "v22.22.0"
 
 RUN set -eux; \
     arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \

--- a/packages/db/drizzle/0124_session_event_duplicate_lookup.sql
+++ b/packages/db/drizzle/0124_session_event_duplicate_lookup.sql
@@ -1,0 +1,4 @@
+-- deployment-mode: rolling
+-- opengeni:concurrent-index lock-timeout=5s
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "session_events_duplicate_of_event_idx"
+  ON "session_events" ("duplicate_of_event_id");

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2122,6 +2122,7 @@ export const sessionEvents = pgTable(
       .where(
         sql`${table.type} not in ('agent.message.delta', 'agent.reasoning.delta', 'sandbox.command.output.delta', 'terminal.pty.output.delta')`,
       ),
+    duplicateOfEvent: index("session_events_duplicate_of_event_idx").on(table.duplicateOfEventId),
     payloadBytes: check(
       "session_events_payload_bytes_check",
       sql`octet_length(${table.payload}::text) <= 65536`,

--- a/packages/db/test/migration-0124-session-event-duplicate-lookup.test.ts
+++ b/packages/db/test/migration-0124-session-event-duplicate-lookup.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseConcurrentIndexMigration } from "../src/migrate";
+
+const migrationPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../drizzle/0124_session_event_duplicate_lookup.sql",
+);
+
+describe("migration 0124 (session event duplicate lookup)", () => {
+  test("builds the self-referential foreign-key lookup index online", async () => {
+    const sql = await readFile(migrationPath, "utf8");
+
+    expect(sql.split(/\r?\n/, 1)[0]).toBe("-- deployment-mode: rolling");
+    expect(
+      parseConcurrentIndexMigration("0124_session_event_duplicate_lookup.sql", sql),
+    ).toMatchObject({
+      indexName: "session_events_duplicate_of_event_idx",
+      lockTimeout: "5s",
+      skipWhenValid: false,
+    });
+    expect(sql).toContain('ON "session_events" ("duplicate_of_event_id");');
+  });
+});

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -131,12 +131,13 @@ describe("release schema contract", () => {
         (migrations.has("0120_durable_goal_wake.sql") ? 1 : 0) +
         (migrations.has("0121_goal_update_idempotency.sql") ? 1 : 0) +
         (migrations.has("0122_codex_capacity_same_turn.sql") ? 1 : 0) +
-        (migrations.has("0123_session_tool_policy_version.sql") ? 1 : 0),
+        (migrations.has("0123_session_tool_policy_version.sql") ? 1 : 0) +
+        (migrations.has("0124_session_event_duplicate_lookup.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(
-      "462ac183560fbea0afd625cd11fdd3e8e6d488437c4844d6281455265b957026",
+      "07738b1c68e7acc8030fc53e9334e7aab5e7abdda0ba54560c78d162eb2b25b4",
     );
-    expect(contract.latestMigration).toBe("0123_session_tool_policy_version.sql");
+    expect(contract.latestMigration).toBe("0124_session_event_duplicate_lookup.sql");
     expect(migrations.get("0122_codex_capacity_same_turn.sql")).toMatchObject({
       sha256: "84e97abff7394d9fcca110012d9ceaede9ae683280a8a4a7335bcf9ec5d52d4e",
       deploymentMode: "maintenance",
@@ -162,7 +163,7 @@ describe("release schema contract", () => {
     expect(
       contract.migrations
         .map((migration) => migration.path)
-        .filter((path) => /^(?:010[3-9]|011[0-9]|012[0-3])_/.test(path)),
+        .filter((path) => /^(?:010[3-9]|011[0-9]|012[0-4])_/.test(path)),
     ).toEqual([
       "0103_host_export_root_session.sql",
       "0104_host_export_root_session_backfill.sql",
@@ -175,6 +176,7 @@ describe("release schema contract", () => {
       "0121_goal_update_idempotency.sql",
       "0122_codex_capacity_same_turn.sql",
       "0123_session_tool_policy_version.sql",
+      "0124_session_event_duplicate_lookup.sql",
     ]);
     expect(new Set(contract.migrations.map((migration) => migration.path)).size).toBe(
       contract.fileCount,
@@ -225,6 +227,10 @@ describe("release schema contract", () => {
     });
     expect(migrations.get("0123_session_tool_policy_version.sql")).toMatchObject({
       sha256: "d23abd0ea9ac21c114a397eaa2a6a524652b9554683dd8e68937ee232e22711e",
+      deploymentMode: "rolling",
+    });
+    expect(migrations.get("0124_session_event_duplicate_lookup.sql")).toMatchObject({
+      sha256: "115dbd71c528c78d340cf3be476f2973db273740e8bcbf47196da96c2d9f94c1",
       deploymentMode: "rolling",
     });
   });


### PR DESCRIPTION
Adds a rolling concurrent index on session_events.duplicate_of_event_id, the referencing side of the self-referential lineage foreign key, so FK validation and exact session/event deletion stay bounded at production cardinality. Also repairs an already-merged changeset package name and replaces the failing mutable NodeSource apt-key path in the canonical headless sandbox with an exact official Node 22 LTS runtime stage. The desktop image is intentionally unchanged. Includes schema parity, migration contract coverage, focused tests, package typechecking, and format verification.