### PR TITLE
fix(worker): restore policy-gated native web search

### DIFF
--- a/.changeset/restore-native-web-search.md
+++ b/.changeset/restore-native-web-search.md
@@ -1,0 +1,10 @@
+---
+"@opengeni/worker-bundle": patch
+"@opengeni/config": patch
+"@opengeni/contracts": patch
+"@opengeni/core": patch
+"@opengeni/sdk": patch
+---
+
+Restore provider-native web search for workspace-default Codex sessions while preserving explicit
+tool narrowing, child policy ceilings, version-fenced policy adoption, and structured URL citations.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -184,7 +184,11 @@ import {
   type CodexUsageHeaderSnapshot,
 } from "@opengeni/codex";
 import { mergeResourceRefs } from "./common";
-import { enabledCapabilityMcpToolRefs, resolveSessionToolPolicy } from "@opengeni/core";
+import {
+  enabledCapabilityMcpToolRefs,
+  resolveSessionToolPolicy,
+  sessionToolPolicyAllowsDefaultNativeTools,
+} from "@opengeni/core";
 import { maybeCompactContext } from "./context-compaction";
 import { TurnAttemptFencedError } from "./turn-attempt-fenced";
 import {
@@ -1656,6 +1660,22 @@ export function computerToolModeForTurn(
 }
 
 /**
+ * Native web search requires two independent grants: the resolved provider
+ * must advertise runnable support, and the immutable session/turn policy must
+ * still track workspace defaults. The null model is the legacy built-in
+ * Responses path, whose deployment flag is its provider capability gate.
+ * There is deliberately no cross-provider or sandbox/curl fallback.
+ */
+export function hostedWebSearchForTurn(
+  resolvedModel: { configured: { hostedWebSearch: boolean } } | null,
+  deploymentWebSearchEnabled: boolean,
+  defaultNativeToolsAllowed: boolean,
+): boolean {
+  if (!defaultNativeToolsAllowed) return false;
+  return resolvedModel?.configured.hostedWebSearch ?? deploymentWebSearchEnabled;
+}
+
+/**
  * Decide whether this turn's provider accepts typed file/image content in a
  * user message. The legacy built-in client and registry Responses clients use
  * the Agents SDK Responses converter, which supports `input_image` and
@@ -2340,6 +2360,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       await current?.flush().catch(() => undefined);
     };
     let preparedTools: Awaited<ReturnType<OpenGeniRuntime["prepareTools"]>> | null = null;
+    // Resolved with the MCP policy at the immutable turn boundary. Provider
+    // capability is checked separately when buildAgent is called; this flag is
+    // only the durable omission/narrowing entitlement.
+    let defaultNativeToolsAllowed = false;
     const toolCancellationFenceRef: {
       current: TurnToolCancellationFence | null;
     } = {
@@ -4051,7 +4075,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // materialized allow-list. `withCodexAppsTool` below keeps the existing
       // single Codex lazy router/connector overlay; it is not a second policy
       // or discovery path.
-      const effectivePolicyTools = resolveSessionToolPolicy({
+      const resolvedToolPolicy = resolveSessionToolPolicy({
         ...(session.toolPolicy ? { toolPolicy: session.toolPolicy } : {}),
         sessionTools: session.tools,
         turnTools: turn.tools,
@@ -4060,7 +4084,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         defaultMcpServerIds: enabledCapabilityMcpToolRefs(settings, mcpSettings).map(
           (tool) => tool.id,
         ),
-      }).toolRefs;
+      });
+      const effectivePolicyTools = resolvedToolPolicy.toolRefs;
+      defaultNativeToolsAllowed = sessionToolPolicyAllowsDefaultNativeTools(
+        resolvedToolPolicy.effectivePolicy,
+      );
       const turnTools = withCodexAppsTool(
         runSettings,
         withFirstPartyTools(runSettings, effectivePolicyTools),
@@ -5007,6 +5035,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               },
             }
           : {};
+      const hostedWebSearch = hostedWebSearchForTurn(
+        resolvedModel,
+        runSettings.webSearchEnabled,
+        defaultNativeToolsAllowed,
+      );
       const agent = runtime.buildAgent(modelRunSettings, turnResources, {
         reasoningEffort: turn.reasoningEffort,
         ...(humanInputResume ? { humanInputResponse: humanInputResume } : {}),
@@ -5066,11 +5099,12 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // store/compaction follow the provider's compaction mode (registry
         // providers resolve to "client"); encrypted reasoning is only
         // round-tripped on the Responses wire API; hosted web search is attached
-        // only when the model opts in; the effective context window drives the
-        // compaction threshold.
+        // only when BOTH the model opts in and this immutable turn still tracks
+        // workspace defaults (an explicit session/turn remains narrowed); the
+        // effective context window drives the compaction threshold.
+        hostedWebSearch,
         ...(resolvedModel
           ? {
-              hostedWebSearch: resolvedModel.configured.hostedWebSearch,
               encryptedReasoning:
                 resolvedModel.provider.api === "responses" &&
                 runSettings.openaiReasoningEncryptedContent,

--- a/apps/worker/src/activities/capabilities.ts
+++ b/apps/worker/src/activities/capabilities.ts
@@ -1,8 +1,7 @@
 import {
   environmentsEncryptionKeyBytes,
-  parseModelProvidersJson,
-  type RegistryProvider,
   type Settings,
+  withCodexCatalogProvider,
 } from "@opengeni/config";
 import { settingsWithMcpCapabilityServers } from "@opengeni/core";
 import {
@@ -10,14 +9,6 @@ import {
   CODEX_APPS_MCP_SERVER_NAME,
   CODEX_APPS_MCP_URL,
   CODEX_APPS_STARTUP_TIMEOUT_MS,
-  CODEX_FALLBACK_MODEL_SLUGS,
-  CODEX_MODEL_CONTEXT_WINDOW_TOKENS,
-  CODEX_MODEL_EFFECTIVE_CONTEXT_WINDOW_TOKENS,
-  CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT,
-  CODEX_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS,
-  CODEX_MODEL_ID_PREFIX,
-  CODEX_PROVIDER_BASE_URL,
-  CODEX_PROVIDER_ID,
 } from "@opengeni/codex";
 import {
   listEnabledMcpCapabilityServers,
@@ -176,28 +167,5 @@ export function withCodexAppsMcpServer(settings: Settings): Settings {
 
 /** Pure: append the synthetic codex-subscription provider, idempotently. */
 export function withCodexProvider(settings: Settings): Settings {
-  const providers = parseModelProvidersJson(settings.modelProvidersJson);
-  if (providers.some((provider) => provider.id === CODEX_PROVIDER_ID)) {
-    return settings; // already injected
-  }
-  const codexProvider: RegistryProvider = {
-    kind: "codex-subscription",
-    id: CODEX_PROVIDER_ID,
-    label: "Codex (ChatGPT subscription)",
-    api: "responses",
-    baseUrl: CODEX_PROVIDER_BASE_URL,
-    models: CODEX_FALLBACK_MODEL_SLUGS.map((slug) => ({
-      id: `${CODEX_MODEL_ID_PREFIX}${slug}`,
-      upstreamModelId: slug,
-      label: slug,
-      reasoningEffort: true,
-      // These three values are the live Codex CLI catalog policy, kept distinct
-      // so proactive compaction and the effective input guard match Codex core.
-      contextWindowTokens: CODEX_MODEL_CONTEXT_WINDOW_TOKENS,
-      effectiveContextWindowTokens: CODEX_MODEL_EFFECTIVE_CONTEXT_WINDOW_TOKENS,
-      autoCompactTokenLimit: CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT,
-      toolOutputTruncationTokens: CODEX_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS,
-    })),
-  };
-  return { ...settings, modelProvidersJson: JSON.stringify([...providers, codexProvider]) };
+  return withCodexCatalogProvider(settings);
 }

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -46,6 +46,7 @@ import {
   filterUnmaterializedSandboxFileDownloads,
   headerSecretRedactions,
   historyRowsToAppend,
+  hostedWebSearchForTurn,
   isLazySandboxProvisionRetryable,
   isTransientProviderError,
   isWorkerShutdownCancellation,
@@ -102,6 +103,30 @@ function functionResult(callId: string) {
     callId,
     status: "completed",
     output: { type: "text", text: "ok" },
+  };
+}
+
+function citedAssistantMessage() {
+  return {
+    type: "message",
+    role: "assistant",
+    content: [
+      {
+        type: "output_text",
+        text: "OpenGeni is documented here [1].",
+        providerData: {
+          annotations: [
+            {
+              type: "url_citation",
+              start_index: 28,
+              end_index: 31,
+              url: "https://docs.opengeni.example/search",
+              title: "OpenGeni search documentation",
+            },
+          ],
+        },
+      },
+    ],
   };
 }
 
@@ -234,6 +259,24 @@ describe("turn secret-redaction boundaries", () => {
 
     expect(JSON.stringify(result.rows)).not.toContain(syntheticSecret);
     expect(JSON.stringify(result.rows)).toContain("[redacted:TURN_SECRET]");
+  });
+
+  test("preserves provider citations in the structured durable assistant item", () => {
+    const cited = citedAssistantMessage();
+    const result = historyRowsToAppend([cited], 0);
+
+    expect(result.rows).toEqual([{ position: 0, item: cited }]);
+    expect(
+      (
+        (result.rows[0]!.item.content as Array<Record<string, unknown>>)[0]!.providerData as {
+          annotations: Array<Record<string, unknown>>;
+        }
+      ).annotations[0],
+    ).toMatchObject({
+      type: "url_citation",
+      url: "https://docs.opengeni.example/search",
+      title: "OpenGeni search documentation",
+    });
   });
 
   test("redacts replayed and current items at the literal model-call seam", async () => {
@@ -2966,6 +3009,26 @@ describe("computerToolModeForTurn (explicit computer-use transport derivation)",
 
   test("the LEGACY global-client fallback (resolveTurnModel → null) → hosted EXPLICITLY", () => {
     expect(computerToolModeForTurn(null)).toBe("hosted");
+  });
+});
+
+describe("hostedWebSearchForTurn (provider support × durable policy)", () => {
+  const resolved = (hostedWebSearch: boolean) =>
+    ({ configured: { hostedWebSearch } }) as Parameters<typeof hostedWebSearchForTurn>[0];
+
+  test("enables a supported provider only for workspace-default turns", () => {
+    expect(hostedWebSearchForTurn(resolved(true), true, true)).toBe(true);
+    expect(hostedWebSearchForTurn(resolved(true), true, false)).toBe(false);
+  });
+
+  test("does not invent a fallback for an unsupported resolved provider", () => {
+    expect(hostedWebSearchForTurn(resolved(false), true, true)).toBe(false);
+  });
+
+  test("applies the deployment capability gate to the legacy built-in path", () => {
+    expect(hostedWebSearchForTurn(null, true, true)).toBe(true);
+    expect(hostedWebSearchForTurn(null, false, true)).toBe(false);
+    expect(hostedWebSearchForTurn(null, true, false)).toBe(false);
   });
 });
 

--- a/apps/worker/test/codex-overlay.test.ts
+++ b/apps/worker/test/codex-overlay.test.ts
@@ -11,7 +11,7 @@ import {
   CODEX_MODEL_CONTEXT_WINDOW_TOKENS,
   CODEX_MODEL_EFFECTIVE_CONTEXT_WINDOW_TOKENS,
 } from "@opengeni/codex";
-import { compactionThresholdTokens } from "@opengeni/runtime";
+import { buildOpenGeniAgent, compactionThresholdTokens } from "@opengeni/runtime";
 import { testSettings } from "@opengeni/testing";
 import type { Database } from "@opengeni/db";
 import {
@@ -35,6 +35,42 @@ describe("withCodexProvider", () => {
     expect(codex?.models.every((m) => m.upstreamModelId === m.id.slice("codex/".length))).toBe(
       true,
     );
+    expect(codex?.models.every((m) => m.hostedWebSearch === true)).toBe(true);
+    expect(
+      configuredModels(result)
+        .filter((model) => model.providerId === "codex-subscription")
+        .every(
+          (model) =>
+            model.hostedWebSearch === true &&
+            model.capabilities.hostedTools.webSearch.upstream === "supported" &&
+            model.capabilities.hostedTools.webSearch.runnable === true,
+        ),
+    ).toBe(true);
+  });
+
+  test("builds the bounded native web-search manifest only when the turn policy allows it", () => {
+    const settings = withCodexProvider(testSettings({ modelProvidersJson: "[]" }));
+    const resolved = resolveModelProvider(settings, "codex/gpt-5.6-sol")!;
+    const webSearchTools = (allowed: boolean) => {
+      const agent = buildOpenGeniAgent(settings, [], {
+        model: resolved.model.upstreamModelId,
+        hostedWebSearch: resolved.model.hostedWebSearch && allowed,
+      });
+      return agent.tools.filter(
+        (tool) =>
+          tool.type === "hosted_tool" &&
+          (tool.providerData as { type?: unknown } | undefined)?.type === "web_search",
+      );
+    };
+
+    const workspaceDefault = webSearchTools(true);
+    expect(workspaceDefault).toHaveLength(1);
+    expect(workspaceDefault[0]?.providerData).toMatchObject({
+      type: "web_search",
+      name: "web_search",
+      search_context_size: "medium",
+    });
+    expect(webSearchTools(false)).toHaveLength(0);
   });
 
   test("declares Codex CLI's raw, effective, and auto-compact token limits", () => {

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -174,6 +174,45 @@ until OpenGeni has the request, recovery, and billing contracts to use it
 safely. Capability metadata also never authorizes an OpenGeni tool; tool
 discovery and authorization remain independent.
 
+### Native web search follows the durable session tool policy
+
+Provider-native `web_search` is part of the workspace-default capability set,
+not an MCP catalog entry. A fresh session whose `tools` field is omitted gets
+native search when its resolved Responses provider declares hosted web search
+runnable. An ordinary child that omits `tools` continues to track a
+workspace-default parent. Explicit, inherited-fixed, and legacy session
+policies remain narrowed, and an explicit per-turn tool replacement disables
+default native search for that turn.
+
+`tool_search` is a different capability: it searches bounded deferred tool
+schemas so the model can discover MCP tools without preloading every schema. It
+does not search the public web and must not be presented as a fallback for
+native `web_search`.
+
+The native tool uses the Agents SDK's bounded `medium` search-context setting
+and preserves provider URL-citation annotations in structured conversation
+history. It does not need a sandbox. If the resolved provider does not support
+hosted search, or the provider search call fails, OpenGeni does not switch
+providers, invoke an MCP connector, or run `curl` in a sandbox as a silent
+fallback.
+
+Existing explicit sessions are never widened automatically. An authorized
+client can explicitly adopt the current workspace defaults through the
+version-fenced session tool-policy endpoint; the change is audited and applies
+from the next attempt:
+
+```ts
+const session = await client.getSession(workspaceId, sessionId);
+await client.updateSessionToolPolicy(workspaceId, sessionId, {
+  mode: "workspace_default",
+  expectedVersion: session.toolPolicyVersion ?? 1,
+});
+```
+
+A child may make this transition only while its immediate parent still tracks
+workspace defaults. Use the original `{ tools, expectedVersion }` request when
+the intent is an explicit fixed allow-list instead.
+
 ## Static catalog and workspace availability
 
 `GET /v1/config/client` is public deployment bootstrap configuration. Its

--- a/packages/codex/test/normalize.test.ts
+++ b/packages/codex/test/normalize.test.ts
@@ -172,6 +172,24 @@ describe("normalizeCodexRequestBody", () => {
     expect(tools.map((t) => t.name)).toEqual(["keep_me", "keep_me_too"]);
   });
 
+  test("preserves the provider-native web_search tool while dropping hosted MCP", () => {
+    const webSearch = {
+      type: "web_search",
+      search_context_size: "medium",
+    };
+    const body = normalizeCodexRequestBody(
+      {
+        tools: [
+          webSearch,
+          { type: "mcp", server_label: "unsupported", server_url: "https://example.com/mcp" },
+        ],
+      },
+      identity,
+    );
+
+    expect(body.tools).toEqual([webSearch]);
+  });
+
   test("applies the model resolver to body.model", () => {
     const body = normalizeCodexRequestBody(
       { model: "gpt-5.2-codex-high" },

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2040,6 +2040,11 @@ export function withCodexCatalogProvider(settings: Settings): Settings {
       upstreamModelId: slug,
       label: slug,
       reasoningEffort: true,
+      // The ChatGPT/Codex Responses backend accepts the native web_search
+      // hosted tool (unlike hosted apply_patch/computer transports). Declaring
+      // this here makes provider resolution truthful; the worker still applies
+      // the durable session/turn policy gate before attaching it.
+      hostedWebSearch: true,
       contextWindowTokens: CODEX_MODEL_CONTEXT_WINDOW_TOKENS,
       effectiveContextWindowTokens: CODEX_MODEL_EFFECTIVE_CONTEXT_WINDOW_TOKENS,
       autoCompactTokenLimit: CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3134,11 +3134,27 @@ export const UpdateSessionRequest = z.object({
 });
 export type UpdateSessionRequest = z.infer<typeof UpdateSessionRequest>;
 
-/** Replace an existing session's durable MCP tool policy. */
-export const UpdateSessionToolPolicyRequest = z.object({
-  tools: z.array(ToolRef).max(64),
-  expectedVersion: z.number().int().positive(),
-});
+/**
+ * Replace an existing session's durable tool policy, or explicitly opt back in
+ * to the current workspace defaults. The mode-less explicit shape is retained
+ * for compatibility with clients released before workspace-default adoption
+ * was supported.
+ */
+export const UpdateSessionToolPolicyRequest = z.union([
+  z
+    .object({
+      mode: z.literal("workspace_default"),
+      expectedVersion: z.number().int().positive(),
+    })
+    .strict(),
+  z
+    .object({
+      mode: z.literal("explicit").optional(),
+      tools: z.array(ToolRef).max(64),
+      expectedVersion: z.number().int().positive(),
+    })
+    .strict(),
+]);
 export type UpdateSessionToolPolicyRequest = z.infer<typeof UpdateSessionToolPolicyRequest>;
 
 /**

--- a/packages/contracts/test/session-tool-policy.test.ts
+++ b/packages/contracts/test/session-tool-policy.test.ts
@@ -17,6 +17,22 @@ describe("session tool policy contracts", () => {
     expect(() => UpdateSessionToolPolicyRequest.parse({ tools: [], expectedVersion: 0 })).toThrow();
   });
 
+  test("supports an explicit, version-fenced return to workspace defaults", () => {
+    expect(
+      UpdateSessionToolPolicyRequest.parse({
+        mode: "workspace_default",
+        expectedVersion: 3,
+      }),
+    ).toEqual({ mode: "workspace_default", expectedVersion: 3 });
+    expect(() =>
+      UpdateSessionToolPolicyRequest.parse({
+        mode: "workspace_default",
+        tools: [],
+        expectedVersion: 3,
+      }),
+    ).toThrow();
+  });
+
   test("accepts the durable policy modes and rejects invalid inheritance", () => {
     expect(SessionToolPolicy.parse({ mode: "legacy", inheritedFromSessionId: null })).toEqual({
       mode: "legacy",

--- a/packages/core/src/domain/session-tool-policy.ts
+++ b/packages/core/src/domain/session-tool-policy.ts
@@ -169,6 +169,19 @@ export function resolveSessionToolPolicy(input: SessionToolPolicyInput): Resolve
   };
 }
 
+/**
+ * Native provider tools that belong to the workspace-default capability set
+ * follow the same omission/narrowing fence as deferred MCP tools. A durable
+ * workspace-default policy receives them; fixed historical policies and an
+ * explicit per-turn replacement do not. Provider support remains a separate
+ * runtime gate and must also be true before a native tool is attached.
+ */
+export function sessionToolPolicyAllowsDefaultNativeTools(
+  policy: SessionEffectiveToolPolicy,
+): boolean {
+  return policy.mode === "workspace_default" && policy.lazyRouter.state === "required";
+}
+
 /** Current full runtime registry IDs, including configured static servers. */
 export async function workspaceSessionToolPolicyServerIds(
   db: Database,

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1935,13 +1935,25 @@ export async function updateSessionToolPolicy(
     capabilityRuntimeSettings,
     existingSession.mcpServers,
   );
-  const validatedTools = validateToolRefs(request.tools, runtimeSettings);
-  const validatedIds = new Set(validatedTools.map((tool) => `${tool.kind}:${tool.id}`));
-  const unknown = request.tools.find((tool) => !validatedIds.has(`${tool.kind}:${tool.id}`));
-  if (unknown) {
-    throw new HTTPException(422, { message: `unknown MCP server id: ${unknown.id}` });
-  }
-  const requestedTools = withFirstPartyTools(validatedTools, runtimeSettings);
+  const explicitRequest = request.mode === "workspace_default" ? null : request;
+  const requestedMode = explicitRequest ? "explicit" : "workspace_default";
+  const explicitRequestedTools = explicitRequest
+    ? (() => {
+        const validatedTools = validateToolRefs(explicitRequest.tools, runtimeSettings);
+        const validatedIds = new Set(validatedTools.map((tool) => `${tool.kind}:${tool.id}`));
+        const unknown = explicitRequest.tools.find(
+          (tool) => !validatedIds.has(`${tool.kind}:${tool.id}`),
+        );
+        if (unknown) {
+          throw new HTTPException(422, { message: `unknown MCP server id: ${unknown.id}` });
+        }
+        return withFirstPartyTools(validatedTools, runtimeSettings);
+      })()
+    : null;
+  const workspaceDefaultTools = withFirstPartyTools(
+    withDefaultEnabledCapabilityMcpTools([], deps.settings, capabilityRuntimeSettings),
+    runtimeSettings,
+  );
   const events = await appendSessionEventsWithLockedSessionUpdate(
     deps.db,
     grant.workspaceId,
@@ -1952,11 +1964,8 @@ export async function updateSessionToolPolicy(
         throw new SessionToolPolicyVersionConflictError(currentVersion);
       }
 
-      const nextTools = requestedTools;
-      let nextPolicy: SessionToolPolicy = {
-        mode: "explicit",
-        inheritedFromSessionId: session.parentSessionId,
-      };
+      let nextTools: ToolRef[];
+      let nextPolicy: SessionToolPolicy;
       if (session.parentSessionId) {
         const parent = await context.getLockedSession(session.parentSessionId);
         if (!parent) {
@@ -1973,13 +1982,34 @@ export async function updateSessionToolPolicy(
             : parent.tools,
           runtimeSettings,
         );
-        assertToolRefsSubset(
-          nextTools,
-          parentEffective,
-          "session tools may only narrow the parent session tool policy",
-        );
+        if (requestedMode === "workspace_default") {
+          if (!parentTracksWorkspaceDefaults) {
+            throw new HTTPException(403, {
+              message:
+                "a child may adopt workspace defaults only while its parent tracks workspace defaults",
+            });
+          }
+          nextTools = parentEffective;
+          nextPolicy = {
+            mode: "workspace_default",
+            inheritedFromSessionId: parent.id,
+          };
+        } else {
+          nextTools = explicitRequestedTools!;
+          assertToolRefsSubset(
+            nextTools,
+            parentEffective,
+            "session tools may only narrow the parent session tool policy",
+          );
+          nextPolicy = {
+            mode: "explicit",
+            inheritedFromSessionId: parent.id,
+          };
+        }
       } else {
-        nextPolicy = { mode: "explicit", inheritedFromSessionId: null };
+        nextTools =
+          requestedMode === "workspace_default" ? workspaceDefaultTools : explicitRequestedTools!;
+        nextPolicy = { mode: requestedMode, inheritedFromSessionId: null };
       }
 
       const currentPolicy = session.toolPolicy ?? {

--- a/packages/core/test/session-tool-policy-update.test.ts
+++ b/packages/core/test/session-tool-policy-update.test.ts
@@ -240,6 +240,82 @@ describe("durable session tool-policy updates", () => {
     });
   }, 180_000);
 
+  test("lets an existing top-level explicit session explicitly adopt workspace defaults", async () => {
+    if (!available) return;
+    const owner = await workspace("adopt-workspace-defaults");
+    const created = await session(firstDb, {
+      ...owner,
+      tools: [OPENGENI, DOCS],
+    });
+    const bus = new MemoryEventBus();
+
+    const updated = await updateSessionToolPolicy(
+      deps(firstDb, bus),
+      grant(owner.workspaceId, owner.accountId),
+      created.id,
+      { mode: "workspace_default", expectedVersion: 1 },
+    );
+
+    expect(updated.tools).toEqual([OPENGENI]);
+    expect(updated.toolPolicy).toEqual({
+      mode: "workspace_default",
+      inheritedFromSessionId: null,
+    });
+    expect(updated.toolPolicyVersion).toBe(2);
+    expect(bus.published[0]![0]).toMatchObject({
+      type: "session.tool_policy.updated",
+      payload: {
+        before: { mode: "explicit", toolIds: ["docs", "opengeni"] },
+        after: { mode: "workspace_default", toolIds: ["opengeni"] },
+        version: 2,
+        effectiveFrom: "next_attempt",
+      },
+    });
+  }, 180_000);
+
+  test("allows default adoption only through a workspace-default parent ceiling", async () => {
+    if (!available) return;
+    const owner = await workspace("child-adopt-workspace-defaults");
+    const defaultParent = await session(firstDb, {
+      ...owner,
+      tools: [OPENGENI],
+      toolPolicy: { mode: "workspace_default", inheritedFromSessionId: null },
+    });
+    const defaultChild = await session(firstDb, {
+      ...owner,
+      tools: [OPENGENI],
+      parentSessionId: defaultParent.id,
+      toolPolicy: { mode: "explicit", inheritedFromSessionId: defaultParent.id },
+    });
+
+    const adopted = await updateSessionToolPolicy(
+      deps(firstDb, new MemoryEventBus()),
+      grant(owner.workspaceId, owner.accountId),
+      defaultChild.id,
+      { mode: "workspace_default", expectedVersion: 1 },
+    );
+    expect(adopted.toolPolicy).toEqual({
+      mode: "workspace_default",
+      inheritedFromSessionId: defaultParent.id,
+    });
+
+    const explicitParent = await session(firstDb, { ...owner, tools: [OPENGENI] });
+    const explicitChild = await session(firstDb, {
+      ...owner,
+      tools: [OPENGENI],
+      parentSessionId: explicitParent.id,
+      toolPolicy: { mode: "inherited", inheritedFromSessionId: explicitParent.id },
+    });
+    await expect(
+      updateSessionToolPolicy(
+        deps(firstDb, new MemoryEventBus()),
+        grant(owner.workspaceId, owner.accountId),
+        explicitChild.id,
+        { mode: "workspace_default", expectedVersion: 1 },
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+  }, 180_000);
+
   test("records the inherited to explicit policy transition in the audit snapshot", async () => {
     if (!available) return;
     const owner = await workspace("audit-inherited-transition");

--- a/packages/core/test/session-tool-policy.test.ts
+++ b/packages/core/test/session-tool-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   resolveSessionToolPolicy,
+  sessionToolPolicyAllowsDefaultNativeTools,
   type SessionToolPolicyInput,
 } from "../src/domain/session-tool-policy";
 import type { ToolRef } from "@opengeni/contracts";
@@ -86,6 +87,18 @@ describe("session tool policy resolution", () => {
       state: "disabled",
       deferredIds: [],
     });
+    expect(sessionToolPolicyAllowsDefaultNativeTools(omitted.effectivePolicy)).toBe(true);
+    expect(sessionToolPolicyAllowsDefaultNativeTools(explicitEmpty.effectivePolicy)).toBe(false);
+  });
+
+  test("fixed historical policies exclude workspace-default native tools", () => {
+    for (const mode of ["explicit", "inherited", "legacy"] as const) {
+      const result = resolve({
+        toolPolicy: { mode, inheritedFromSessionId: null },
+        sessionTools: [mcp("cap-docs")],
+      });
+      expect(sessionToolPolicyAllowsDefaultNativeTools(result.effectivePolicy)).toBe(false);
+    }
   });
 
   test("an explicit follow-up replaces rather than merges the session selection", () => {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -151,6 +151,30 @@ await client.resumeSession(workspaceId, sessionId, {
 await client.sendApprovalDecision(workspaceId, sessionId, { approvalId, decision: "approve" });
 ```
 
+## Session tool policy and native web search
+
+Omitting `tools` when creating a top-level session selects the current
+workspace-default capability policy. Supported Responses providers can then
+attach their native bounded web-search tool without requiring a sandbox.
+Passing `tools`, including `[]`, is an intentional fixed narrowing.
+
+Existing explicit sessions are not widened when a new default capability is
+introduced. Opt one in explicitly with the current optimistic-concurrency
+version; the audited change takes effect on its next attempt:
+
+```ts
+const session = await client.getSession(workspaceId, sessionId);
+const updated = await client.updateSessionToolPolicy(workspaceId, sessionId, {
+  mode: "workspace_default",
+  expectedVersion: session.toolPolicyVersion ?? 1,
+});
+```
+
+To keep a fixed MCP allow-list instead, use the backward-compatible explicit
+shape `{ tools, expectedVersion }`. `tool_search` discovers deferred MCP
+schemas; it is not public web search. Unsupported providers do not receive a
+cross-provider, MCP, or sandbox fallback.
+
 ## Goals
 
 ```ts

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -324,7 +324,7 @@ export class OpenGeniClient {
     );
   }
 
-  /** Replace the durable session MCP tool policy with an optimistic version fence. */
+  /** Replace the durable tool policy or explicitly adopt workspace defaults. */
   async updateSessionToolPolicy(
     workspaceId: string,
     sessionId: string,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -276,10 +276,17 @@ export type SessionToolPolicy = {
   inheritedFromSessionId: string | null;
 };
 
-export type UpdateSessionToolPolicyRequest = {
-  tools: ToolRef[];
-  expectedVersion: number;
-};
+export type UpdateSessionToolPolicyRequest =
+  | {
+      mode: "workspace_default";
+      expectedVersion: number;
+    }
+  | {
+      /** Omitted for compatibility with the original explicit-only API. */
+      mode?: "explicit" | undefined;
+      tools: ToolRef[];
+      expectedVersion: number;
+    };
 
 export type SessionEffectiveToolPolicy = {
   mode: SessionToolPolicy["mode"];

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -252,6 +252,28 @@ describe("OpenGeniClient", () => {
     });
   });
 
+  test("opts an existing session back in to workspace-default tools", async () => {
+    const response = {
+      id: SESSION_ID,
+      toolPolicy: { mode: "workspace_default", inheritedFromSessionId: null },
+      toolPolicyVersion: 4,
+    } as unknown as Session;
+    const { client, requests } = makeClient(() => jsonResponse(response));
+
+    expect(
+      await client.updateSessionToolPolicy(WORKSPACE_ID, SESSION_ID, {
+        mode: "workspace_default",
+        expectedVersion: 3,
+      }),
+    ).toEqual(response);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.method).toBe("PUT");
+    expect(JSON.parse(requests[0]!.body!)).toEqual({
+      mode: "workspace_default",
+      expectedVersion: 3,
+    });
+  });
+
   test("listEventPage round-trips monitoring filters and exact page headers", async () => {
     const event = makeEvent(42, "turn.completed", { result: "authoritative" });
     const body = JSON.stringify([event]);


### PR DESCRIPTION
## Summary

- restore provider-native Responses `web_search` for Codex subscription turns whose durable session policy tracks workspace defaults
- centralize the synthetic Codex provider overlay so API capability projection and worker execution both declare `hostedWebSearch: true`
- preserve explicit narrowing, inherited child ceilings, legacy-session behavior, and explicit per-turn replacement semantics
- add a version-fenced, audited `workspace_default` policy adoption path for existing explicit sessions, plus SDK/docs coverage
- retain structured provider URL citations; add a patch Changeset for all affected published packages

## Root cause

OpenGeni already builds the native `webSearchTool()`, but the worker gates it with `resolvedModel.configured.hostedWebSearch`. Both synthetic Codex catalog overlays omitted that capability, so the generic registry default resolved it to `false` and suppressed the native tool on Codex subscription turns.

The existing first-party `tool_search` is only the bounded lazy BM25 router for deferred `codex_apps` connector schemas. It is not a public-web search provider, and this change does not turn it into one.

## Supported contract

- Native `web_search` is a provider capability, not an MCP/catalog entry.
- Fresh top-level sessions with omitted `tools`, and ordinary omitted-tools children that inherit a workspace-default policy, receive native search only when the resolved Responses provider supports it.
- Explicit, inherited-fixed, and legacy policies—and explicit per-turn tool replacement—are not silently widened.
- An existing explicit session can deliberately adopt workspace defaults for its next attempt via `updateSessionToolPolicy({ mode: "workspace_default", expectedVersion })`; authorization, parent ceiling, optimistic concurrency, audit, and policy-version behavior remain enforced.
- There is no MCP, cross-provider, sandbox, `curl`, or silent fallback. Provider failures remain provider failures.
- Provider URL-citation annotations remain structured conversation history.

## Exact source truth

- base / merge-base: `83e4679074e69dbc77f667b0c049da636d10a42e`
- head: `d70e7dd810ed178de79122d2f9577afaf772dc5c`
- tree: `464070bb9b7b12681edd75fd058bf26d7507e362`
- one commit; 18 files; clean tree

Legacy PR #486 is not a native-search duplicate: its current diff contains policy/lazy-connector work but no `hostedWebSearch` or provider-native `web_search` repair, and it is not based on the current merged policy source.

## Provider and deployment evidence

Pinned upstream OpenAI Codex source `fd41e813cb5939029acab29cb5f2fb8ac8d8286d` exposes `--search`, declares provider `web_search` support by default, emits the exact hosted `{"type":"web_search"}` Responses descriptor, and models `web_search_call` history.

Read-only production reconciliation shows the live turn/control worker image is still:

`opengeni-worker@sha256:d3eb6bb6d842bd122ef048c8dc4ea285e5237f2b4316e2f7d86eeddf65bbeb22`

ACR binds that digest to tag `emergency-sandbox-recovery-bc6c535e` (source `bc6c535ebe3253849786934c53afa12533a639b3`), behind both current main and this branch. The root live canary therefore correctly has no native `web_search`; `tool_search("search the public web")` returned zero tools.

## Verification

- focused matrix on the code-identical pre-amend head: **333 passed, 0 failed** across 11 config/contracts/core/SDK/worker/runtime/Codex files
- head-only Codex normalizer regression: **17 passed, 0 failed**
- `bun run typecheck`: **23/23 projects clean**
- `bun run lint`: **0 warnings, 0 errors**
- `bun run format:check`: clean
- `bunx changeset status`: valid patch release plan
- `git diff --check`: clean

The FORCE-RLS PostgreSQL policy-update test cannot execute in this Modal sandbox: Docker bridge/NAT initialization is denied by the host kernel (`iptables ... Protocol not supported`), so the harness would skip. Natural CI with a real Docker/PostgreSQL runner is a mandatory merge gate.

## Live acceptance boundary

This source owner did not merge or deploy. A real positive provider canary requires this exact head (or its reviewed merge) in a trusted staging/canary worker with a sanctioned Codex subscription. Acceptance must prove native manifest presence, current-fact retrieval with URL citations, no sandbox/`curl` fallback, omitted-child inheritance, and continued narrowing of an old explicit session.

Linear: OPE-16 (keep In Progress through deployment and live acceptance)
