### PR TITLE
chore: apply pinned formatter to four files

### DIFF
--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -393,9 +393,7 @@ export class Observability {
                   startTimeUnixNano: millisToNanos(span.startMs),
                   endTimeUnixNano: millisToNanos(span.endMs),
                   attributes: otlpAttributes(span.attributes),
-                  status: span.error
-                    ? { code: 2, message: span.error.statusMessage }
-                    : { code: 1 },
+                  status: span.error ? { code: 2, message: span.error.statusMessage } : { code: 1 },
                 },
               ],
             },

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -113,7 +113,12 @@ function readStoredPendingComposerOperation(
     const record = parsed as Record<string, unknown>;
     const input = record.input;
     const shadow = record.newerShadow;
-    if (typeof input !== "object" || input === null || typeof shadow !== "object" || shadow === null) {
+    if (
+      typeof input !== "object" ||
+      input === null ||
+      typeof shadow !== "object" ||
+      shadow === null
+    ) {
       return null;
     }
     const inputRecord = input as Record<string, unknown>;
@@ -152,9 +157,7 @@ function writePendingComposerOperation(
   }
 }
 
-function restorePendingComposerOperation(
-  key: string | null,
-): PendingComposerOperation | null {
+function restorePendingComposerOperation(key: string | null): PendingComposerOperation | null {
   const stored =
     (key && pendingComposerOperations.get(key)) ?? readStoredPendingComposerOperation(key);
   if (!stored) return null;
@@ -591,7 +594,14 @@ export function useComposer(
       }
       return;
     }
-    if (!durableDrafts || !sessionId || draftLoading || sending || !draftRef.current || draftConflict)
+    if (
+      !durableDrafts ||
+      !sessionId ||
+      draftLoading ||
+      sending ||
+      !draftRef.current ||
+      draftConflict
+    )
       return;
     const payload = currentDraftPayload();
     if (!payload || draftSignature(payload) === lastSavedSignature.current) return;
@@ -614,8 +624,7 @@ export function useComposer(
       const ownedTargetKey = targetKey;
       const ownedGeneration = targetGeneration.current;
       const operationKey = pendingComposerOperationKey(workspaceId, sessionId);
-      const pending =
-        pendingOperationRef.current ?? restorePendingComposerOperation(operationKey);
+      const pending = pendingOperationRef.current ?? restorePendingComposerOperation(operationKey);
       if (pending && !pendingOperationRef.current) {
         pendingOperationRef.current = pending;
         pendingClientEventId.current = pending.input.clientEventId ?? null;
@@ -628,7 +637,7 @@ export function useComposer(
       const extras = pending ? {} : resolveSendExtras(sendExtrasRef.current);
       const hasResources = restoredResources.length > 0 || (extras.resources?.length ?? 0) > 0;
       if (
-        (!pending && (!hasText && !hasResources)) ||
+        (!pending && !hasText && !hasResources) ||
         !sessionId ||
         sending ||
         sendBlockedRef.current?.() === true ||

--- a/packages/react/src/session.ts
+++ b/packages/react/src/session.ts
@@ -46,7 +46,10 @@ export type {
 export { useGoal, isGoalEvent } from "./hooks/use-goal";
 export type { UseGoalOptions, UseGoalResult } from "./hooks/use-goal";
 export { useSessionLineage, isLineageRefreshEvent } from "./hooks/use-session-lineage";
-export type { UseSessionLineageOptions, UseSessionLineageResult } from "./hooks/use-session-lineage";
+export type {
+  UseSessionLineageOptions,
+  UseSessionLineageResult,
+} from "./hooks/use-session-lineage";
 export { useSessionControl } from "./hooks/use-session-control";
 export type {
   UseSessionControlOptions,

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -23,7 +23,13 @@ const external = [
 ];
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/composer.ts", "src/session.ts", "src/session-ui.ts", "src/machines.ts"],
+  entry: [
+    "src/index.ts",
+    "src/composer.ts",
+    "src/session.ts",
+    "src/session-ui.ts",
+    "src/machines.ts",
+  ],
   format: ["esm"],
   target: "es2022",
   dts: true,


### PR DESCRIPTION
## Summary

- Apply the pinned `oxfmt@0.58.0` formatter to exactly four files that failed release preflight.
- This is a formatter-only repair: whitespace, line wrapping, and formatter-introduced trailing commas only.

## Verification

- `bun run format:check`
- `git diff --check`
- Targeted `tsgo --noEmit` for the four changed files
- TypeScript parse diagnostics: zero for before and after text
- Position/trivia-normalized TypeScript AST: identical for all four files
- No dependency, lockfile, workflow, generated metadata, or changeset changes

Parent: `656015cd66cd2a129613e0a8416faa1cdbb3bf25`

No changeset is included because this changes no runtime or published behavior.
