### PR TITLE
fix(react): keep session entry provider-free

### DIFF
--- a/.changeset/provider-free-session-entry.md
+++ b/.changeset/provider-free-session-entry.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Keep the session-only React entry provider-free by resolving session hooks through the session context, preserving the exclusion of provider and workbench dependencies.

--- a/packages/react/src/hooks/use-file-attachments.ts
+++ b/packages/react/src/hooks/use-file-attachments.ts
@@ -1,6 +1,6 @@
 import type { FileAsset, FileResourceRef } from "@opengeni/sdk";
 import { useCallback, useRef, useState } from "react";
-import { useOpenGeni, type ClientOverride } from "../provider";
+import { useOpenGeni, type ClientOverride } from "../session-context";
 
 export type UseFileAttachmentsOptions = ClientOverride & {
   /**

--- a/packages/react/src/hooks/use-goal.ts
+++ b/packages/react/src/hooks/use-goal.ts
@@ -1,6 +1,6 @@
 import { OpenGeniApiError, type SessionEvent, type SessionGoal } from "@opengeni/sdk";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useOpenGeni, type ClientOverride } from "../provider";
+import { useOpenGeni, type ClientOverride } from "../session-context";
 import {
   useDebouncedCallback,
   useMutationRunner,

--- a/packages/react/src/hooks/use-session-lineage.ts
+++ b/packages/react/src/hooks/use-session-lineage.ts
@@ -1,6 +1,6 @@
 import type { SessionEvent, SessionLineageResponse } from "@opengeni/sdk";
 import { useCallback, useEffect, useRef } from "react";
-import { useOpenGeni, type ClientOverride } from "../provider";
+import { useOpenGeni, type ClientOverride } from "../session-context";
 import { useDebouncedCallback, usePolledValue, useSessionEventTrigger } from "./internal";
 
 export type UseSessionLineageOptions = ClientOverride & {

--- a/packages/react/src/hooks/use-session.ts
+++ b/packages/react/src/hooks/use-session.ts
@@ -1,6 +1,6 @@
 import type { Session, SessionEvent } from "@opengeni/sdk";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useOpenGeni, type ClientOverride } from "../provider";
+import { useOpenGeni, type ClientOverride } from "../session-context";
 import {
   useMutationRunner,
   usePolledValue,

--- a/packages/react/test/session-entry.test.ts
+++ b/packages/react/test/session-entry.test.ts
@@ -93,7 +93,9 @@ describe("session-only entry", () => {
     expect(reactSources.some((id) => id.endsWith("/src/session-context.ts"))).toBe(true);
     expect(reactSources.some((id) => id.includes("/src/components/"))).toBe(false);
     expect(reactSources.some((id) => id.includes("/src/commands/"))).toBe(false);
-    expect(reactSources.length).toBeLessThanOrEqual(14);
+    // Keep the session-only closure explicit: adding a source requires reviewing
+    // whether it belongs to this provider-neutral public subpath.
+    expect(reactSources.length).toBe(18);
 
     const chunks = result.output.filter((item) => item.type === "chunk");
     expect(chunks).toHaveLength(1);


### PR DESCRIPTION
## Summary
- keep session-only hooks on the provider-neutral `session-context` path
- preserve the explicit provider/workbench exclusion regression guard

## Root cause
The four session-entry-reachable hooks (`useSession`, `useFileAttachments`, `useGoal`, and `useSessionLineage`) imported `useOpenGeni` through `../provider`, pulling `provider.tsx` into `@opengeni/react/session`. The public session subpath is documented to exclude that workbench provider graph. The closure-size guard was also stale after later documented session-only exports increased the legitimate closure from 14 to 18 sources.

## Verification
- focused session-entry test: 2 pass, 0 fail
- React package tests: 802 pass, 0 fail across 48 files
- root typecheck: all projects clean
- root lint: 0 warnings, 0 errors
- root format check: passed
- diff check: passed

Base: current `main` at `ded522ca90a98dd266bbed278a80ab105b34772f`.
