### PR TITLE
fix(db): retain optional initial user event type

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -27936,7 +27936,7 @@ export async function initializeSessionStartAtomically(
           if (!goal) throw new Error("Failed to create initial session goal");
         }
 
-        let [userEvent] = await tx
+        const existingUserEvents = await tx
           .select()
           .from(schema.sessionEvents)
           .where(
@@ -27948,6 +27948,8 @@ export async function initializeSessionStartAtomically(
           )
           .orderBy(asc(schema.sessionEvents.sequence))
           .limit(1);
+        let userEvent: typeof schema.sessionEvents.$inferSelect | undefined =
+          existingUserEvents[0];
         let sequence = session.lastSequence;
         const insertedEvents: Array<typeof schema.sessionEvents.$inferSelect> = [];
         const runnable = effectiveControl.state === "active";


### PR DESCRIPTION
Fix the post-Version-PR TypeScript regression in `initializeSessionStartAtomically`.

The first-row destructuring was inferred as a required event, but the later idempotent repair branch assigns the result of `Array.find`, which is legitimately optional until the existing failure guard. Preserve that optionality explicitly without changing runtime behavior.

Validation: `bun run typecheck` passes all 23 projects.