### PR TITLE
chore(db): format session start repair

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -27948,8 +27948,7 @@ export async function initializeSessionStartAtomically(
           )
           .orderBy(asc(schema.sessionEvents.sequence))
           .limit(1);
-        let userEvent: typeof schema.sessionEvents.$inferSelect | undefined =
-          existingUserEvents[0];
+        let userEvent: typeof schema.sessionEvents.$inferSelect | undefined = existingUserEvents[0];
         let sequence = session.lastSequence;
         const insertedEvents: Array<typeof schema.sessionEvents.$inferSelect> = [];
         const runnable = effectiveControl.state === "active";


### PR DESCRIPTION
Formats the optional existing-user-event annotation added by #683. This is a format-only follow-up to restore the main CI format gate; runtime behavior is unchanged.