### PR TITLE
fix(web): prevent variable credential autofill

### DIFF
--- a/apps/web/src/routes/variable-sets.test.tsx
+++ b/apps/web/src/routes/variable-sets.test.tsx
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { VariableSetCard } from "./variable-sets";
+import type { WorkspaceVariableSet } from "@/types";
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  GlobalRegistrator.unregister();
+});
+
+const VARIABLE_SET: WorkspaceVariableSet = {
+  id: "variable-set-1",
+  accountId: "account-1",
+  workspaceId: "workspace-1",
+  name: "staging",
+  description: "Test-only metadata",
+  variables: [
+    {
+      name: "API_TOKEN",
+      version: 2,
+      createdAt: "2026-07-28T00:00:00.000Z",
+      updatedAt: "2026-07-28T00:00:00.000Z",
+    },
+  ],
+  createdAt: "2026-07-28T00:00:00.000Z",
+  updatedAt: "2026-07-28T00:00:00.000Z",
+};
+
+describe("Variable Sets credential-autofill boundaries", () => {
+  test("uses neutral key/value semantics for add and rotate forms", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <VariableSetCard
+            workspaceId="workspace-1"
+            variableSet={VARIABLE_SET}
+            attachedSessions={[]}
+            attachedTasks={[]}
+            attachmentsUnknown={false}
+            mutating={false}
+            onUpdate={async () => VARIABLE_SET}
+            onDelete={async () => true}
+            onSetVariable={async () => ({})}
+            onDeleteVariable={async () => true}
+          />,
+        );
+      });
+
+      await act(async () => {
+        container
+          .querySelector<HTMLButtonElement>('button[aria-label="Show variables for staging"]')!
+          .click();
+      });
+
+      const addForm = container.querySelector<HTMLFormElement>(
+        'form[aria-label="Add variable to staging"]',
+      );
+      expect(addForm).not.toBeNull();
+      expect(addForm!.getAttribute("autocomplete")).toBe("off");
+      expect(addForm!.closest("form")?.getAttribute("aria-label")).toBe("Add variable to staging");
+      expect(
+        [...addForm!.querySelectorAll<HTMLInputElement>("input")].map((input) => ({
+          name: input.name,
+          type: input.type,
+          autocomplete: input.autocomplete,
+        })),
+      ).toEqual([
+        { name: "variable-name", type: "text", autocomplete: "off" },
+        { name: "variable-value", type: "password", autocomplete: "new-password" },
+      ]);
+
+      await act(async () => {
+        [...container.querySelectorAll<HTMLButtonElement>("button")]
+          .find((button) => button.textContent?.trim() === "Rotate")!
+          .click();
+      });
+
+      const rotateForm = container.querySelector<HTMLFormElement>(
+        'form[aria-label="Rotate variable API_TOKEN"]',
+      );
+      expect(rotateForm).not.toBeNull();
+      expect(rotateForm!.getAttribute("autocomplete")).toBe("off");
+      expect(rotateForm!.closest("form")?.getAttribute("aria-label")).toBe(
+        "Rotate variable API_TOKEN",
+      );
+      const rotateValue = rotateForm!.querySelector<HTMLInputElement>("input");
+      expect(rotateValue).not.toBeNull();
+      expect({
+        name: rotateValue!.name,
+        type: rotateValue!.type,
+        autocomplete: rotateValue!.autocomplete,
+      }).toEqual({ name: "variable-value", type: "password", autocomplete: "new-password" });
+
+      const variableInputs = [...container.querySelectorAll<HTMLInputElement>("input")];
+      expect(variableInputs.map((input) => input.autocomplete)).not.toContain("email");
+      expect(variableInputs.map((input) => input.autocomplete)).not.toContain("current-password");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("keeps the managed sign-in fields on their credential autocomplete tokens", async () => {
+    const authSource = await Bun.file(`${import.meta.dir}/../context.tsx`).text();
+
+    expect(authSource).toContain('autoComplete="email"');
+    expect(authSource).toContain(
+      'autoComplete={mode === "signin" ? "current-password" : "new-password"}',
+    );
+  });
+});

--- a/apps/web/src/routes/variable-sets.tsx
+++ b/apps/web/src/routes/variable-sets.tsx
@@ -122,9 +122,11 @@ export function VariableSetsRoute({ workspaceId }: { workspaceId: string }) {
             <Label htmlFor="variableSet-name">Name</Label>
             <Input
               id="variableSet-name"
+              name="variable-set-name"
               value={createName}
               onChange={(event) => setCreateName(event.target.value)}
               placeholder="staging-aws"
+              autoComplete="off"
               className="h-9 pointer-coarse:min-h-10"
               autoFocus
             />
@@ -133,9 +135,11 @@ export function VariableSetsRoute({ workspaceId }: { workspaceId: string }) {
             <Label htmlFor="variableSet-description">Description</Label>
             <Input
               id="variableSet-description"
+              name="variable-set-description"
               value={createDescription}
               onChange={(event) => setCreateDescription(event.target.value)}
               placeholder="What these credentials reach"
+              autoComplete="off"
               className="h-9 pointer-coarse:min-h-10"
             />
           </div>
@@ -238,7 +242,7 @@ export function VariableSetsRoute({ workspaceId }: { workspaceId: string }) {
   );
 }
 
-function VariableSetCard(props: {
+export function VariableSetCard(props: {
   workspaceId: string;
   variableSet: WorkspaceVariableSet;
   attachedSessions: Session[];
@@ -319,16 +323,20 @@ function VariableSetCard(props: {
           {editing ? (
             <div className="grid min-w-0 gap-2 md:grid-cols-2">
               <Input
+                name="variable-set-name"
                 value={nameDraft}
                 onChange={(event) => setNameDraft(event.target.value)}
                 aria-label="Variable set name"
+                autoComplete="off"
                 className="h-8 text-sm"
               />
               <Input
+                name="variable-set-description"
                 value={descriptionDraft}
                 onChange={(event) => setDescriptionDraft(event.target.value)}
                 placeholder="Description"
                 aria-label="Variable set description"
+                autoComplete="off"
                 className="h-8 text-sm"
               />
             </div>
@@ -486,61 +494,81 @@ function VariableSetCard(props: {
                     </div>
                   </div>
                   {rotatingName === variable.name ? (
-                    <div className="mt-2 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+                    <form
+                      aria-label={`Rotate variable ${variable.name}`}
+                      autoComplete="off"
+                      className="mt-2 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]"
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        void rotateVariable(variable.name);
+                      }}
+                    >
                       <Input
+                        name="variable-value"
                         type="password"
                         value={rotateValue}
                         onChange={(event) => setRotateValue(event.target.value)}
                         placeholder="New value (write-only)"
                         aria-label={`New value for ${variable.name}`}
+                        autoComplete="new-password"
                         className="h-8 flex-1 text-xs pointer-coarse:min-h-10"
                         autoFocus
                       />
                       <Button
-                        type="button"
+                        type="submit"
                         size="sm"
                         className="h-8 pointer-coarse:min-h-10"
                         disabled={props.mutating || !rotateValue}
-                        onClick={() => void rotateVariable(variable.name)}
                       >
                         <CheckIcon className="size-3.5" />
                         Set
                       </Button>
-                    </div>
+                    </form>
                   ) : null}
                 </div>
               ))
             )}
           </div>
 
-          <div className="mt-2 grid gap-2 sm:grid-cols-[12rem_minmax(0,1fr)_auto]">
+          <form
+            aria-label={`Add variable to ${variableSet.name}`}
+            autoComplete="off"
+            className="mt-2 grid gap-2 sm:grid-cols-[12rem_minmax(0,1fr)_auto]"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void addVariable();
+            }}
+          >
             <Input
+              name="variable-name"
               value={variableName}
               onChange={(event) => setVariableName(event.target.value)}
               placeholder="VARIABLE_NAME"
               aria-label="New variable name"
+              autoComplete="off"
               className="h-8 font-mono text-xs pointer-coarse:min-h-10"
             />
             <Input
+              name="variable-value"
               type="password"
               value={variableValue}
               onChange={(event) => setVariableValue(event.target.value)}
               placeholder="Value (write-only)"
               aria-label="New variable value"
+              autoComplete="new-password"
               className="h-8 text-xs pointer-coarse:min-h-10"
             />
             <Button
-              type="button"
+              type="submit"
               variant="secondary"
               size="sm"
               className="h-8 pointer-coarse:min-h-10"
               disabled={props.mutating || !variableName.trim() || !variableValue}
-              onClick={() => void addVariable()}
             >
               <PlusIcon className="size-3.5" />
               Set variable
             </Button>
-          </div>
+          </form>
 
           {attachmentCount > 0 ? (
             <div className="mt-3 border-t border-border/70 pt-2">


### PR DESCRIPTION
## Summary
- prevent browser/password-manager credential heuristics from treating Variable Sets key/value inputs as account credentials
- give add/rotate controls explicit neutral names, autocomplete semantics, and separate accessible form boundaries
- add DOM regression coverage while preserving managed sign-in email/password autocomplete tokens

## Scope
- Linear: OPE-104
- Parent: OPE-15
- No API, secret-storage, authentication, merge, or deployment changes.
- No variable values are read, logged, snapshotted, or included in evidence.

## Verification
- `bun test apps/web/src` — 245 pass, 0 fail
- `bun run typecheck` — 23 projects clean
- `bun run lint` — 0 warnings, 0 errors
- `bunx oxfmt --check apps/web/src/routes/variable-sets.tsx apps/web/src/routes/variable-sets.test.tsx` — pass
- `bun run format:check` — pass
- `cd apps/web && bun run build` — pass, bundle budgets pass
- rendered production `VariableSetCard` browser pass — add and rotate forms empty; keyboard Tab reaches the value field; manual entry enables submit; successful submit clears the fields; Axe reports 0 violations at desktop/mobile light/dark

## Head and CI
- Head: `ff3510f4368c88a9944998203dce570db63f1549`
- Base: `origin/main` at `33cf389c937159cc991221d784e40b0ef72b07e2`
- Tree: `459965f6fe85362222679239e20536887d16ada2`
- Current-base source admission — success
- Deployment artifacts — success
- Workload image builds — success
- Required provider `Typecheck and unit tests` — failure after the long Test step; setup, changeset validation, typecheck, lint, and format portions completed successfully
- Local `bun run test:unit` — 4500 pass, 4 skipped, 22 fail in existing unrelated cancellation-settlement, context-compaction, and session-only package entry/closure suites; the OPE-104 Variable Sets tests passed

The isolated headless Chromium profile did not expose stored-login autofill despite clean-profile attempts, so native stored-login autofill remains an environment limitation of this verification. No secrets, variable values, credentials, or screenshots containing them were retained or reported.

This PR is intentionally narrow and is not merged or deployed.
