### PR TITLE
fix(web): prevent pin-triggered React #185 render loop

### DIFF
--- a/apps/web/src/lib/session-context.test.tsx
+++ b/apps/web/src/lib/session-context.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { createElement, useEffect, useState } from "react";
+
+import { registerDom, renderComponent } from "../../../../packages/react/test/render-hook";
+import type { Session } from "@/types";
+import { sameSessionForContext } from "./session-context";
+import { applySessionPinProjection, mergeSessionContextProjection } from "./session-pins";
+
+registerDom();
+
+const effectiveControl: Session["effectiveControl"] = {
+  state: "active",
+  controlVersion: 0,
+  controlEtag: "active-0",
+  directState: "active",
+  primaryBlocker: null,
+  additionalBlockerCount: 0,
+  blockers: [],
+  resumeOptions: [],
+  override: null,
+  settlement: null,
+};
+
+function session(pinned: boolean, pinVersion: number): Session {
+  return {
+    id: "00000000-0000-4000-8000-000000000101",
+    workspaceId: "00000000-0000-4000-8000-000000000001",
+    pinned,
+    pinnedAt: pinned ? "2026-07-28T00:00:00.000Z" : null,
+    pinVersion,
+    effectiveControl,
+  } as Session;
+}
+
+describe("session context equality", () => {
+  test("treats freshly allocated equivalent effective controls as unchanged", () => {
+    const current = session(false, 0);
+    const next = { ...current, effectiveControl: { ...effectiveControl } };
+
+    expect(sameSessionForContext(current, next)).toBe(true);
+  });
+
+  test("detects meaningful nested effective-control changes", () => {
+    const current = session(false, 0);
+    const next = {
+      ...current,
+      effectiveControl: {
+        ...effectiveControl,
+        controlVersion: 1,
+        controlEtag: "active-1",
+      },
+    };
+
+    expect(sameSessionForContext(current, next)).toBe(false);
+  });
+
+  test("bounds route and rail reconciliation after an optimistic pin", async () => {
+    const staleDetail = session(false, 0);
+    const authoritativeRail = session(true, 1);
+    let renders = 0;
+    let writes = 0;
+
+    function Probe() {
+      const [current, setCurrent] = useState<Session | null>(staleDetail);
+      renders += 1;
+
+      useEffect(() => {
+        if (!current) return;
+        writes += 1;
+        const routeProjection = { ...staleDetail, effectiveControl: { ...effectiveControl } };
+        setCurrent((previous) => {
+          const next = mergeSessionContextProjection(previous, routeProjection);
+          return !next || sameSessionForContext(previous, next) ? previous : next;
+        });
+      }, [current]);
+      useEffect(() => {
+        if (!current) return;
+        writes += 1;
+        const railProjection = {
+          ...authoritativeRail,
+          effectiveControl: { ...effectiveControl },
+        };
+        setCurrent((previous) => {
+          const next = applySessionPinProjection(previous, railProjection) ?? previous;
+          return sameSessionForContext(previous, next) ? previous : next;
+        });
+      }, [current]);
+
+      return createElement("output", { "data-pinned": String(current?.pinned) });
+    }
+
+    const rendered = await renderComponent(createElement(Probe));
+
+    expect(rendered.container.querySelector("output")?.dataset.pinned).toBe("true");
+    expect(renders).toBeLessThanOrEqual(4);
+    expect(writes).toBeLessThanOrEqual(8);
+    await rendered.unmount();
+  });
+});

--- a/apps/web/src/lib/session-context.ts
+++ b/apps/web/src/lib/session-context.ts
@@ -1,5 +1,95 @@
 import type { Session } from "@/types";
 
+type EffectiveControl = Session["effectiveControl"];
+type EffectiveControlBlocker = NonNullable<EffectiveControl["primaryBlocker"]>;
+type EffectiveControlResumeOption = EffectiveControl["resumeOptions"][number];
+
+function sameBlocker(
+  a: EffectiveControlBlocker | null | undefined,
+  b: EffectiveControlBlocker | null | undefined,
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return (
+    a.kind === b.kind &&
+    Object.is(a.sessionId, b.sessionId) &&
+    a.displayName === b.displayName &&
+    Object.is(a.actor, b.actor) &&
+    Object.is(a.reason, b.reason) &&
+    Object.is(a.changedAt, b.changedAt) &&
+    a.revision === b.revision
+  );
+}
+
+function sameResumeOption(
+  a: EffectiveControlResumeOption,
+  b: EffectiveControlResumeOption,
+): boolean {
+  return (
+    a.scope === b.scope &&
+    Object.is(a.targetId, b.targetId) &&
+    a.selectedStateAfter === b.selectedStateAfter &&
+    sameBlocker(a.remainingPrimaryBlocker, b.remainingPrimaryBlocker) &&
+    a.impactCopy === b.impactCopy
+  );
+}
+
+function sameEffectiveControl(a: EffectiveControl, b: EffectiveControl): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (
+    a.state !== b.state ||
+    a.controlVersion !== b.controlVersion ||
+    a.controlEtag !== b.controlEtag ||
+    a.directState !== b.directState ||
+    a.additionalBlockerCount !== b.additionalBlockerCount ||
+    !sameBlocker(a.primaryBlocker, b.primaryBlocker) ||
+    a.blockers.length !== b.blockers.length ||
+    a.resumeOptions.length !== b.resumeOptions.length
+  ) {
+    return false;
+  }
+  if (!a.blockers.every((blocker, index) => sameBlocker(blocker, b.blockers[index]))) {
+    return false;
+  }
+  for (const [index, option] of a.resumeOptions.entries()) {
+    const other = b.resumeOptions[index];
+    if (!other || !sameResumeOption(option, other)) {
+      return false;
+    }
+  }
+  if (a.override !== b.override) {
+    if (!a.override || !b.override) {
+      return false;
+    }
+    if (
+      a.override.rootSessionId !== b.override.rootSessionId ||
+      a.override.revision !== b.override.revision
+    ) {
+      return false;
+    }
+  }
+  if (a.settlement !== b.settlement) {
+    if (!a.settlement || !b.settlement) {
+      return false;
+    }
+    if (
+      a.settlement.state !== b.settlement.state ||
+      a.settlement.attemptCount !== b.settlement.attemptCount ||
+      a.settlement.interruptionPendingCount !== b.settlement.interruptionPendingCount ||
+      a.settlement.quiescencePendingCount !== b.settlement.quiescencePendingCount
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function sameSessionForContext(a: Session | null, b: Session | null): boolean {
   if (a === b) {
     return true;
@@ -13,7 +103,16 @@ export function sameSessionForContext(a: Session | null, b: Session | null): boo
     return false;
   }
   for (const key of aKeys) {
-    if (!Object.prototype.hasOwnProperty.call(b, key) || !Object.is(a[key], b[key])) {
+    if (!Object.prototype.hasOwnProperty.call(b, key)) {
+      return false;
+    }
+    if (key === "effectiveControl") {
+      if (!sameEffectiveControl(a.effectiveControl, b.effectiveControl)) {
+        return false;
+      }
+      continue;
+    }
+    if (!Object.is(a[key], b[key])) {
       return false;
     }
   }

--- a/apps/web/src/lib/session-pins.test.ts
+++ b/apps/web/src/lib/session-pins.test.ts
@@ -5,7 +5,9 @@ import {
   applySessionPinProjection,
   applySessionRailProjection,
   mergeSessionContextProjection,
+  notifySessionPinChanged,
   reconcileFailedSessionPin,
+  subscribeToSessionPinChanges,
 } from "./session-pins";
 
 const session = {
@@ -160,6 +162,23 @@ describe("session pin reconciliation", () => {
     });
   });
 
+  test("preserves rail identity when a fresh equal tree summary is returned", () => {
+    const treeStats = {
+      directChildren: 2,
+      totalDescendants: 4,
+      runningDescendants: 1,
+      queuedDescendants: 0,
+      attentionDescendants: 0,
+      pausedDescendants: 0,
+      failedDescendants: 0,
+      truncated: false,
+    };
+    const current = { ...session, treeStats } as Session;
+    const refreshed = { ...current, treeStats: { ...treeStats } };
+
+    expect(applySessionRailProjection(current, refreshed)).toBe(current);
+  });
+
   test("keeps a newer context pin while adopting detail content", () => {
     const current = {
       ...session,
@@ -204,5 +223,102 @@ describe("session pin reconciliation", () => {
     const merged = mergeSessionContextProjection(current, detail);
 
     expect(merged).toBe(detail);
+  });
+
+  test("carries a title_set detail update through a rail pin projection", () => {
+    const titleSetDetail = {
+      ...session,
+      title: "Title from session.title_set",
+      effectiveControl: { ...session.effectiveControl },
+    } as Session;
+    const afterTitle = mergeSessionContextProjection(null, titleSetDetail);
+    const afterPin = applySessionPinProjection(afterTitle, {
+      id: session.id,
+      workspaceId: session.workspaceId,
+      pinned: true,
+      pinnedAt: "2026-07-10T00:08:00.000Z",
+      pinVersion: 1,
+    });
+
+    expect(afterPin).toMatchObject({
+      title: "Title from session.title_set",
+      pinned: true,
+      pinnedAt: "2026-07-10T00:08:00.000Z",
+      pinVersion: 1,
+    });
+  });
+
+  test("preserves identity when failed reconciliation already matches authoritative state", () => {
+    const optimistic = {
+      ...session,
+      pinned: true,
+      pinnedAt: "2026-07-10T00:09:00.000Z",
+      pinVersion: 1,
+    } as Session;
+    const authoritative = {
+      id: session.id,
+      workspaceId: session.workspaceId,
+      pinned: true,
+      pinnedAt: optimistic.pinnedAt,
+      pinVersion: 1,
+    };
+
+    expect(reconcileFailedSessionPin(optimistic, optimistic, authoritative)).toBe(optimistic);
+  });
+
+  test("deduplicates BroadcastChannel delivery for one cross-tab mutation", () => {
+    type Listener = (event: { data: unknown }) => void;
+    class FakeBroadcastChannel {
+      static readonly instances: FakeBroadcastChannel[] = [];
+      readonly name: string;
+      readonly listeners = new Set<Listener>();
+
+      constructor(name: string) {
+        this.name = name;
+        FakeBroadcastChannel.instances.push(this);
+      }
+
+      addEventListener(_type: "message", listener: Listener): void {
+        this.listeners.add(listener);
+      }
+
+      postMessage(data: unknown): void {
+        for (const instance of FakeBroadcastChannel.instances) {
+          if (instance === this || instance.name !== this.name) continue;
+          for (const listener of instance.listeners) {
+            listener({ data });
+            listener({ data });
+          }
+        }
+      }
+
+      close(): void {
+        this.listeners.clear();
+      }
+    }
+
+    const original = globalThis.BroadcastChannel;
+    Object.defineProperty(globalThis, "BroadcastChannel", {
+      configurable: true,
+      value: FakeBroadcastChannel,
+      writable: true,
+    });
+    try {
+      const changes: string[] = [];
+      const cleanup = subscribeToSessionPinChanges("workspace-1", (sessionId) => {
+        changes.push(sessionId);
+      });
+
+      notifySessionPinChanged("workspace-1", session.id);
+
+      expect(changes).toEqual([session.id]);
+      cleanup();
+    } finally {
+      Object.defineProperty(globalThis, "BroadcastChannel", {
+        configurable: true,
+        value: original,
+        writable: true,
+      });
+    }
   });
 });

--- a/apps/web/src/lib/session-pins.test.ts
+++ b/apps/web/src/lib/session-pins.test.ts
@@ -4,6 +4,7 @@ import type { Session } from "@/types";
 import {
   applySessionPinProjection,
   applySessionRailProjection,
+  mergeSessionContextProjection,
   reconcileFailedSessionPin,
 } from "./session-pins";
 
@@ -157,5 +158,51 @@ describe("session pin reconciliation", () => {
       pinVersion: 5,
       treeStats: projected.treeStats,
     });
+  });
+
+  test("keeps a newer context pin while adopting detail content", () => {
+    const current = {
+      ...session,
+      title: "Renamed in the open route",
+      pinned: true,
+      pinnedAt: "2026-07-10T00:06:00.000Z",
+      pinVersion: 2,
+    } as Session;
+    const staleDetail = {
+      ...session,
+      title: "Stale detail title",
+      status: "failed",
+      pinned: false,
+      pinnedAt: null,
+      pinVersion: 1,
+    } as Session;
+
+    const merged = mergeSessionContextProjection(current, staleDetail);
+
+    expect(merged).toMatchObject({
+      title: "Stale detail title",
+      status: "failed",
+      pinned: true,
+      pinnedAt: "2026-07-10T00:06:00.000Z",
+      pinVersion: 2,
+    });
+    expect(merged).not.toBe(staleDetail);
+  });
+
+  test("preserves identity when the detail and context pin triples are equal", () => {
+    const current = {
+      ...session,
+      pinned: true,
+      pinnedAt: "2026-07-10T00:07:00.000Z",
+      pinVersion: 3,
+    } as Session;
+    const detail = {
+      ...current,
+      effectiveControl: { ...current.effectiveControl },
+    };
+
+    const merged = mergeSessionContextProjection(current, detail);
+
+    expect(merged).toBe(detail);
   });
 });

--- a/apps/web/src/lib/session-pins.ts
+++ b/apps/web/src/lib/session-pins.ts
@@ -74,6 +74,22 @@ export function applySessionPinProjection(
 }
 
 /**
+ * Merge a detail/SSE projection into the root context without allowing a
+ * slower detail read to erase a newer list or optimistic pin projection.
+ * Detail remains authoritative for every non-pin field; the current context
+ * contributes only its pin fields when that projection is newer or equal.
+ */
+export function mergeSessionContextProjection(
+  current: Session | null,
+  projected: Session | null,
+): Session | null {
+  if (!projected) {
+    return null;
+  }
+  return applySessionPinProjection(projected, current ?? projected) ?? projected;
+}
+
+/**
  * Merge list-owned personal pin and hierarchy fields into route-owned session
  * content. A route/SSE object must never overwrite a newer cross-device unpin,
  * while a list poll must never regress lifecycle state or message content.

--- a/apps/web/src/lib/session-pins.ts
+++ b/apps/web/src/lib/session-pins.ts
@@ -8,6 +8,8 @@ const SESSION_PIN_CHANNEL_PREFIX = "opengeni.session-pins";
 const SESSION_PIN_STORAGE_PREFIX = "opengeni.session-pins.changed";
 const outboundChannels = new Map<string, BroadcastChannel>();
 
+type SessionTreeStats = NonNullable<Session["treeStats"]>;
+
 type SessionPinChangeMessage = {
   type: "session-pin.changed";
   sessionId: string;
@@ -38,6 +40,25 @@ function sessionPinChangeMessage(value: unknown): SessionPinChangeMessage | null
     message.messageId.length > 0
     ? (message as SessionPinChangeMessage)
     : null;
+}
+
+function sameTreeStats(a: SessionTreeStats | undefined, b: SessionTreeStats | undefined): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return (
+    a.directChildren === b.directChildren &&
+    a.totalDescendants === b.totalDescendants &&
+    a.runningDescendants === b.runningDescendants &&
+    a.queuedDescendants === b.queuedDescendants &&
+    a.attentionDescendants === b.attentionDescendants &&
+    a.pausedDescendants === b.pausedDescendants &&
+    a.failedDescendants === b.failedDescendants &&
+    a.truncated === b.truncated
+  );
 }
 
 /**
@@ -96,6 +117,9 @@ export function mergeSessionContextProjection(
  */
 export function applySessionRailProjection(current: Session, projected: Session): Session {
   const merged = applySessionPinProjection(current, projected) ?? current;
+  if (sameTreeStats(merged.treeStats, projected.treeStats)) {
+    return merged;
+  }
   return projected.treeStats ? { ...merged, treeStats: projected.treeStats } : merged;
 }
 
@@ -132,11 +156,21 @@ export function reconcileFailedSessionPin(
   if (!stillExactOptimistic) {
     return applySessionPinProjection(current, authoritative);
   }
+  const authoritativePinned = Boolean(authoritative.pinned);
+  const authoritativePinnedAt = authoritative.pinnedAt ?? null;
+  const authoritativeVersion = authoritative.pinVersion ?? 0;
+  if (
+    Boolean(current.pinned) === authoritativePinned &&
+    (current.pinnedAt ?? null) === authoritativePinnedAt &&
+    (current.pinVersion ?? 0) === authoritativeVersion
+  ) {
+    return current;
+  }
   return {
     ...current,
-    pinned: Boolean(authoritative.pinned),
-    pinnedAt: authoritative.pinnedAt ?? null,
-    pinVersion: authoritative.pinVersion ?? 0,
+    pinned: authoritativePinned,
+    pinnedAt: authoritativePinnedAt,
+    pinVersion: authoritativeVersion,
   };
 }
 

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -51,6 +51,7 @@ import {
   projectSessionTimeline,
   summarizeSessionFailure,
 } from "@/lib/events";
+import { mergeSessionContextProjection } from "@/lib/session-pins";
 import { sessionPolicyPickerIds, toolsForPolicySelection } from "@/lib/session-tools";
 import type { ComposerDraft, LineageNode } from "@opengeni/sdk";
 import type { ConnectionMetadata, Session, SessionEvent } from "@/types";
@@ -160,7 +161,7 @@ export function SessionRoute({
   // Keep the workspace header (title, status badge, connection pill) in sync.
   const { setSession: setContextSession, setConnectionState: setContextConnectionState } = context;
   useEffect(() => {
-    setContextSession(session);
+    setContextSession((current) => mergeSessionContextProjection(current, session));
   }, [session, setContextSession]);
   useEffect(() => {
     setContextConnectionState(connectionState);

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -80,8 +80,13 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
 
     const webPort = await freePort();
     webBaseUrl = `http://127.0.0.1:${webPort}`;
+    const webEnv = {
+      NODE_ENV: "production",
+      VITE_API_BASE_URL: apiBaseUrl,
+    };
     const build = await runCommand(["bun", "run", "build"], {
       cwd: `${repoRoot}/apps/web`,
+      env: webEnv,
       timeoutMs: 120_000,
     });
     if (build.exitCode !== 0) {
@@ -101,7 +106,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       ],
       {
         cwd: `${repoRoot}/apps/web`,
-        env: { VITE_API_BASE_URL: apiBaseUrl },
+        env: webEnv,
         ready: async () =>
           (
             await fetch(webBaseUrl, {
@@ -1562,6 +1567,12 @@ async function configuredContext(
   // principal fallback; the placeholder merely satisfies the real console
   // gate and is never treated as a credential or persisted outside context.
   await context.addInitScript(() => {
+    // Playwright runs init scripts for the initial opaque about:blank document
+    // too. That document has no storage origin; avoid turning this test-owned
+    // setup into a pageerror that obscures application failures.
+    if (window.location.origin === "null") {
+      return;
+    }
     localStorage.setItem("opengeni.accessKey", "configured-test-placeholder");
   });
   return context;

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -7,6 +7,7 @@ import {
   acquireSharedTestDatabase,
   freePort,
   MemoryEventBus,
+  runCommand,
   startProcess,
   testSettings,
   waitFor,
@@ -79,12 +80,19 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
 
     const webPort = await freePort();
     webBaseUrl = `http://127.0.0.1:${webPort}`;
+    const build = await runCommand(["bun", "run", "build"], {
+      cwd: `${repoRoot}/apps/web`,
+      timeoutMs: 120_000,
+    });
+    if (build.exitCode !== 0) {
+      throw new Error(`Production web build failed:\n${build.stdout}\n${build.stderr}`);
+    }
     web = await startProcess(
       [
         "bun",
         "run",
         "vite",
-        "dev",
+        "preview",
         "--port",
         String(webPort),
         "--strictPort",
@@ -139,6 +147,8 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
     );
 
     const targetUrl = `${webBaseUrl}/workspaces/${workspaceId}/sessions/${target.id}`;
+    const initialCommits = await reactCommitCount(pageA);
+    expect(initialCommits).toBeGreaterThan(0);
     const successfulTargetPinMutation = (response: PlaywrightResponse): boolean => {
       const url = new URL(response.url());
       return (
@@ -162,6 +172,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
     await pageA.keyboard.press("Enter");
     await initialPinMutation;
     await pageA.getByRole("button", { name: "Unpin session" }).waitFor();
+    expect((await reactCommitCount(pageA)) - initialCommits).toBeLessThanOrEqual(64);
     const pinnedA = pageA.getByRole("group", { name: "Pinned" });
     await pinnedA.getByRole("button", { name: /^Open Master pin target/ }).waitFor();
     await pageA.waitForFunction(() =>
@@ -205,6 +216,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
     await pageA.getByRole("button", { name: "Unpin session" }).waitFor();
     await Promise.all([repinMutation, sameTabRepinRefresh]);
     await sameTabPinnedTarget.waitFor();
+    expect((await reactCommitCount(pageA)) - initialCommits).toBeLessThanOrEqual(128);
 
     // A genuinely separate browser context represents another device: it owns
     // independent document, cache, BroadcastChannel, and focus state, while the
@@ -386,6 +398,10 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
     await otherPage.reload();
     await otherPage.getByRole("button", { name: "Pin session" }).waitFor();
     expect(await otherPage.getByRole("group", { name: "Pinned" }).count()).toBe(0);
+
+    expect(browserPageErrors.get(deviceA)).toEqual([]);
+    expect(browserPageErrors.get(deviceB)).toEqual([]);
+    expect(browserPageErrors.get(otherMember)).toEqual([]);
 
     await otherMember.close();
     await deviceB.close();
@@ -1109,8 +1125,11 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       `Mobile pin ${"long title ".repeat(20)}`.slice(0, 200),
     );
     await page.goto(`${webBaseUrl}/workspaces/${workspaceId}/sessions/${target.id}`);
+    const initialCommits = await reactCommitCount(page);
+    expect(initialCommits).toBeGreaterThan(0);
     await page.getByRole("button", { name: "Pin session" }).click();
     await page.getByRole("button", { name: "Unpin session" }).waitFor();
+    expect((await reactCommitCount(page)) - initialCommits).toBeLessThanOrEqual(64);
 
     // Stress the compact pinned section with many long rows through the normal
     // browser-authenticated API. No direct DB mutation is used.
@@ -1190,6 +1209,7 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
         );
       }
     }
+    expect(browserPageErrors.get(context)).toEqual([]);
     await context.close();
   }, 90_000);
 
@@ -1484,6 +1504,7 @@ function decodeBrowserSessionCursor(cursor: string): { snapshotId: string } {
 }
 
 const browserDiagnostics = new WeakMap<BrowserContext, string[]>();
+const browserPageErrors = new WeakMap<BrowserContext, string[]>();
 
 async function configuredContext(
   browser: Browser,
@@ -1491,7 +1512,9 @@ async function configuredContext(
 ): Promise<BrowserContext> {
   const context = await browser.newContext(options);
   const diagnostics: string[] = [];
+  const pageErrors: string[] = [];
   browserDiagnostics.set(context, diagnostics);
+  browserPageErrors.set(context, pageErrors);
   context.on("requestfailed", (request) => {
     diagnostics.push(
       `request failed: ${request.method()} ${request.url()} (${request.failure()?.errorText ?? "unknown"})`,
@@ -1509,6 +1532,30 @@ async function configuredContext(
       diagnostics.push(`console ${message.type()}: ${message.text()}`);
     }
   });
+  context.on("page", (page) => {
+    page.on("pageerror", (error) => pageErrors.push(String(error)));
+  });
+  await context.addInitScript(() => {
+    const windowWithReactProbe = window as Window & {
+      __opengeniReactCommitCount?: number;
+      __REACT_DEVTOOLS_GLOBAL_HOOK__?: {
+        supportsFiber?: boolean;
+        inject?: (renderer: unknown) => number;
+        onCommitFiberRoot?: (...args: unknown[]) => void;
+        onCommitFiberUnmount?: (...args: unknown[]) => void;
+      };
+    };
+    windowWithReactProbe.__opengeniReactCommitCount = 0;
+    const hook = windowWithReactProbe.__REACT_DEVTOOLS_GLOBAL_HOOK__ ?? {};
+    hook.supportsFiber = true;
+    hook.inject ??= () => 1;
+    hook.onCommitFiberRoot = () => {
+      windowWithReactProbe.__opengeniReactCommitCount =
+        (windowWithReactProbe.__opengeniReactCommitCount ?? 0) + 1;
+    };
+    hook.onCommitFiberUnmount ??= () => undefined;
+    windowWithReactProbe.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook;
+  });
   // The console's configured-token panel stores the supplied value under this
   // key. In this test-only configured deployment there is intentionally no
   // delegation secret, so the API uses its supported x-opengeni-subject
@@ -1518,6 +1565,13 @@ async function configuredContext(
     localStorage.setItem("opengeni.accessKey", "configured-test-placeholder");
   });
   return context;
+}
+
+async function reactCommitCount(page: Page): Promise<number> {
+  return await page.evaluate(
+    () =>
+      (window as Window & { __opengeniReactCommitCount?: number }).__opengeniReactCommitCount ?? 0,
+  );
 }
 
 async function workspaceFromPage(page: Page): Promise<string> {


### PR DESCRIPTION
## Summary

- Preserve session context identity for structurally equal effective-control projections.
- Keep route/SSE title and lifecycle writeback authoritative while retaining newer pin projections.
- Avoid replacement objects for equal tree summaries and already-reconciled rollback state.
- Add focused and production-mode browser regressions for pin/header/row flows, `session.title_set` writeback, cross-tab delivery, rollback, equal refreshes, page errors, and bounded React commits.

## Validation

- 35 focused web tests passed across session pin/context/rename/focus suites.
- 201 broader UI tests passed across hooks, session, queue, App, and control-surface suites.
- `bun run typecheck` passed for all 23 projects.
- `bun run lint`, `bun run format:check`, and `bun run check:docs-refs` passed.
- Production web build and bundle budgets passed.
- Real-PostgreSQL production browser E2E was attempted and failed closed because no PostgreSQL test database was available; it ran 0 tests. No deterministic pin-specific React #185 reproduction was available in this sandbox.

Relates to OPE-101 and OPE-26.
