### PR TITLE
fix(react): preserve nested timeline anchors

### DIFF
--- a/packages/react/demo/timeline-scroll-merge-test-harness.tsx
+++ b/packages/react/demo/timeline-scroll-merge-test-harness.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+
+import { MessageTimeline, type TimelineItem } from "../src/index";
+import "./styles.css";
+
+type TimelineMergeHarness = {
+  prependActivity: () => void;
+};
+
+declare global {
+  interface Window {
+    timelineMergeHarness?: TimelineMergeHarness;
+  }
+}
+
+function reasoning(sequence: number): TimelineItem {
+  return {
+    kind: "reasoning",
+    id: `reasoning-${sequence}`,
+    turnId: "turn-merge",
+    text: `reasoning-${sequence}`,
+    streaming: false,
+    occurredAt: new Date(1_750_000_000_000 + sequence).toISOString(),
+  };
+}
+
+function message(sequence: number): TimelineItem {
+  return {
+    kind: "user-message",
+    id: `message-${sequence}`,
+    text: `message-${sequence}`,
+    resources: [],
+    tools: [],
+    occurredAt: new Date(1_750_000_000_000 + sequence).toISOString(),
+  };
+}
+
+function initialItems(): TimelineItem[] {
+  return [
+    ...Array.from({ length: 100 }, (_, index) => reasoning(index + 1)),
+    ...Array.from({ length: 12 }, (_, index) => message(index + 1)),
+  ];
+}
+
+function Harness() {
+  const [items, setItems] = useState(initialItems);
+  const prependActivity = useCallback(() => {
+    flushSync(() => setItems((current) => [reasoning(0), ...current]));
+  }, []);
+
+  useEffect(() => {
+    window.timelineMergeHarness = { prependActivity };
+    return () => {
+      delete window.timelineMergeHarness;
+    };
+  }, [prependActivity]);
+
+  return (
+    <main style={{ padding: 32 }} data-og-theme="light">
+      <section style={{ margin: "0 auto", maxWidth: 900 }} data-timeline-merge-test>
+        <MessageTimeline className="timeline-merge-test-shell" items={items} hasOlder />
+      </section>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<Harness />);

--- a/packages/react/demo/timeline-scroll-merge-test.html
+++ b/packages/react/demo/timeline-scroll-merge-test.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Timeline same-group scroll regression</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body,
+      #root {
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        background: #f4f6f8;
+        color: #18212f;
+        font: 14px sans-serif;
+      }
+      .timeline-merge-test-shell {
+        display: flex;
+        height: 680px;
+        flex-direction: column;
+        overflow: hidden;
+      }
+      .timeline-merge-test-shell > div {
+        min-height: 0;
+        flex: 1;
+        overflow-y: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/timeline-scroll-merge-test-harness.tsx"></script>
+  </body>
+</html>

--- a/packages/react/demo/timeline-scroll-test-harness.tsx
+++ b/packages/react/demo/timeline-scroll-test-harness.tsx
@@ -3,6 +3,7 @@ import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 
 import { MessageTimeline, type TimelineItem } from "../src/index";
+import "./styles.css";
 
 type VisibleRow = { id: string | null; top: number | null };
 type TimelineScrollHarness = {
@@ -47,8 +48,9 @@ function streamedItem(text: string): TimelineItem {
 }
 
 function Harness() {
+  const adjacentPrepend = new URLSearchParams(window.location.search).has("adjacent");
   const [items, setItems] = useState(() => [
-    ...range(1_000, 120),
+    ...(adjacentPrepend ? range(1_040, 80) : range(1_000, 120)),
     streamedItem("Initial streamed response"),
   ]);
   const [grown, setGrown] = useState(false);
@@ -78,8 +80,13 @@ function Harness() {
     });
   }, [nextSequence]);
   const prepend = useCallback(() => {
-    flushSync(() => setItems((current) => [...range(900, 100), ...current]));
-  }, []);
+    flushSync(() =>
+      setItems((current) => [
+        ...(adjacentPrepend ? range(1_000, 40) : range(900, 100)),
+        ...current,
+      ]),
+    );
+  }, [adjacentPrepend]);
   const stream = useCallback(() => {
     flushSync(() => {
       setStreamed(true);

--- a/packages/react/demo/timeline-scroll-test-harness.tsx
+++ b/packages/react/demo/timeline-scroll-test-harness.tsx
@@ -8,6 +8,7 @@ type VisibleRow = { id: string | null; top: number | null };
 type TimelineScrollHarness = {
   append: () => void;
   growRowsAbove: () => void;
+  stream: () => void;
   prepend: () => void;
   scroller: () => HTMLElement;
   visible: () => VisibleRow;
@@ -34,9 +35,24 @@ function range(start: number, count: number): TimelineItem[] {
   return Array.from({ length: count }, (_, index) => item(start + index));
 }
 
+function streamedItem(text: string): TimelineItem {
+  return {
+    kind: "agent-message",
+    id: "stream-1",
+    turnId: "turn-stream",
+    text,
+    streaming: true,
+    occurredAt: new Date(1_750_000_000_500).toISOString(),
+  };
+}
+
 function Harness() {
-  const [items, setItems] = useState(() => range(1_000, 120));
+  const [items, setItems] = useState(() => [
+    ...range(1_000, 120),
+    streamedItem("Initial streamed response"),
+  ]);
   const [grown, setGrown] = useState(false);
+  const [streamed, setStreamed] = useState(false);
   const [nextSequence, setNextSequence] = useState(1_120);
 
   const scroller = useCallback(() => {
@@ -64,11 +80,24 @@ function Harness() {
   const prepend = useCallback(() => {
     flushSync(() => setItems((current) => [...range(900, 100), ...current]));
   }, []);
+  const stream = useCallback(() => {
+    flushSync(() => {
+      setStreamed(true);
+      setItems((current) =>
+        current.map((currentItem) =>
+          currentItem.id === "stream-1"
+            ? streamedItem("Streamed response grew while the reader was away from the bottom")
+            : currentItem,
+        ),
+      );
+    });
+  }, []);
 
   useEffect(() => {
     window.timelineScrollHarness = {
       append,
       growRowsAbove: () => flushSync(() => setGrown(true)),
+      stream,
       prepend,
       scroller,
       visible,
@@ -76,7 +105,7 @@ function Harness() {
     return () => {
       delete window.timelineScrollHarness;
     };
-  }, [append, prepend, scroller, visible]);
+  }, [append, prepend, scroller, stream, visible]);
 
   return (
     <main style={{ padding: 32 }} data-og-theme="light">
@@ -86,10 +115,11 @@ function Harness() {
           items={items}
           hasOlder
           renderMessageText={(text, timelineItem) => {
+            const isStream = timelineItem.id === "stream-1";
             const sequence = Number(timelineItem.id.replace("row-", ""));
-            const baseHeight = 34 + (sequence % 7) * 13;
+            const baseHeight = isStream ? (streamed ? 220 : 48) : 34 + (sequence % 7) * 13;
             // Models delayed image/font/tool-fold measurement above the reader.
-            const delayedGrowth = grown && sequence < 1_060 ? 57 : 0;
+            const delayedGrowth = !isStream && grown && sequence < 1_060 ? 57 : 0;
             return (
               <div
                 data-timeline-row={timelineItem.id}

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -184,9 +184,12 @@ export function MessageTimeline({
     allGroups.length > 0 && (bulkActive || firstKeyChangedForBulk || mountingOlderGroups);
 
   // Snapshot the topmost visible element and where it sits in the viewport, so a
-  // later reflow can restore it to the same spot. Transient chrome (the backfill
-  // sentinel and shimmer) is skipped — anchoring to a row that unmounts when the
-  // older window lands would drop the correction mid-prepend.
+  // later reflow can restore it to the same spot. Prefer durable row wrappers
+  // over their containing group: an older activity item can merge into the
+  // existing group, leaving that outer group in place while shifting every row
+  // after the insertion. Transient chrome (the backfill sentinel and shimmer) is
+  // skipped — anchoring to a row that unmounts when the older window lands would
+  // drop the correction mid-prepend.
   const captureAnchor = useCallback(() => {
     const node = scrollRef.current;
     const inner = node?.firstElementChild;
@@ -195,15 +198,25 @@ export function MessageTimeline({
       return;
     }
     const containerTop = node.getBoundingClientRect().top;
-    for (const child of Array.from(inner.children)) {
-      if (child instanceof HTMLElement && child.dataset.ogTimelineChrome !== undefined) {
-        continue;
+    const findVisible = (selector: string): Element | null => {
+      for (const candidate of inner.querySelectorAll(selector)) {
+        if (candidate instanceof HTMLElement && candidate.dataset.ogTimelineChrome !== undefined) {
+          continue;
+        }
+        const rect = candidate.getBoundingClientRect();
+        if (rect.bottom > containerTop + 1 && rect.height > 0) {
+          return candidate;
+        }
       }
-      const rect = child.getBoundingClientRect();
-      if (rect.bottom > containerTop + 1) {
-        anchorRef.current = { el: child, top: rect.top - containerTop };
-        return;
-      }
+      return null;
+    };
+    const anchor =
+      findVisible("[data-og-timeline-row-anchor]") ??
+      findVisible("[data-og-timeline-group-anchor]");
+    if (anchor) {
+      const rect = anchor.getBoundingClientRect();
+      anchorRef.current = { el: anchor, top: rect.top - containerTop };
+      return;
     }
     anchorRef.current = null;
   }, []);
@@ -370,17 +383,18 @@ export function MessageTimeline({
                 </div>
               ) : null}
               {groups.map(({ group, key }, index) => (
-                <TimelineGroupView
-                  key={key}
-                  group={group}
-                  renderMessageText={renderMessageText}
-                  onOpenSession={onOpenSession}
-                  onMemoryClick={onMemoryClick}
-                  onReconnect={onReconnect}
-                  resolveProviderLogo={resolveProviderLogo}
-                  toolRegistry={toolRegistry}
-                  foldLiveCluster={isAgentProgress(groups[index + 1]?.group)}
-                />
+                <div key={key} data-og-timeline-group-anchor="">
+                  <TimelineGroupView
+                    group={group}
+                    renderMessageText={renderMessageText}
+                    onOpenSession={onOpenSession}
+                    onMemoryClick={onMemoryClick}
+                    onReconnect={onReconnect}
+                    resolveProviderLogo={resolveProviderLogo}
+                    toolRegistry={toolRegistry}
+                    foldLiveCluster={isAgentProgress(groups[index + 1]?.group)}
+                  />
+                </div>
               ))}
               {working ? (
                 <div className="flex items-center gap-2 text-sm">

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -150,16 +150,24 @@ export function MessageTimeline({
   // structurally impossible — the reader only ever sees it already at the
   // bottom. An empty timeline reveals immediately (there is nothing to anchor).
   const [revealed, setRevealed] = useState(false);
-  // Our own scrollTop assignments echo back as delayed scroll events. Track the
-  // actual clamped target rather than a boolean: if reader input lands before
-  // the echo, its different position must win and unpin bottom-follow. A true
-  // echo also must not recapture the visual anchor — during progressive prepend
-  // the next older row may already have mounted by the time that echo arrives.
-  const programmaticScrollTargetRef = useRef<number | null>(null);
+  // Our own scrollTop assignments echo back as delayed scroll events. Keep the
+  // ordered, clamped targets rather than only the latest one: successive
+  // ResizeObserver corrections can queue several echoes before the browser
+  // dispatches them. If reader input lands at a different position, its value
+  // wins and clears the pending echoes. A matching echo must not recapture the
+  // visual anchor while progressive prepend is still mounting older rows.
+  const programmaticScrollTargetsRef = useRef<number[]>([]);
   const assignScrollTop = useCallback((node: HTMLElement, value: number) => {
     const previous = node.scrollTop;
     node.scrollTop = value;
-    programmaticScrollTargetRef.current = node.scrollTop === previous ? null : node.scrollTop;
+    if (node.scrollTop === previous) {
+      return;
+    }
+    const pending = programmaticScrollTargetsRef.current;
+    pending.push(node.scrollTop);
+    if (pending.length > 32) {
+      pending.splice(0, pending.length - 32);
+    }
   }, []);
   // Mirror `pinned` into a ref so the ResizeObserver callback (a stable closure)
   // always reads the live value without re-subscribing on every scroll.
@@ -221,18 +229,40 @@ export function MessageTimeline({
     anchorRef.current = null;
   }, []);
 
-  // Follow the stream while pinned to the bottom; never fight the reader.
+  // Restore the user-owned anchor synchronously after React commits a frame.
+  // ResizeObserver remains a late-measurement fallback, but progressive history
+  // frames must be corrected before the browser can paint an intermediate jump.
+  const restoreAnchor = useCallback(
+    (node: HTMLElement) => {
+      if (autoFollow && pinnedRef.current) {
+        assignScrollTop(node, node.scrollHeight);
+        return;
+      }
+      const anchor = anchorRef.current;
+      if (!anchor || !anchor.el.isConnected) {
+        return;
+      }
+      const containerTop = node.getBoundingClientRect().top;
+      const now = anchor.el.getBoundingClientRect().top - containerTop;
+      const diff = now - anchor.top;
+      if (diff !== 0) {
+        assignScrollTop(node, node.scrollTop + diff);
+      }
+    },
+    [assignScrollTop, autoFollow],
+  );
+
   // A LAYOUT effect so the very first paint of a freshly loaded session is
   // already anchored at the bottom — no visible traversal down the history.
   useLayoutEffect(() => {
     const node = scrollRef.current;
-    if (node && autoFollow && pinned) {
-      assignScrollTop(node, node.scrollHeight);
+    if (node) {
+      restoreAnchor(node);
     }
     if (!revealed && groups.length > 0) {
       setRevealed(true);
     }
-  }, [resolvedItems, working, autoFollow, pinned, revealed, groups.length, assignScrollTop]);
+  }, [resolvedItems, working, revealed, groups.length, restoreAnchor]);
 
   // A cleared timeline (stream identity change) re-arms the reveal so the next
   // session also first paints at its bottom.
@@ -307,34 +337,26 @@ export function MessageTimeline({
       if (!current) {
         return;
       }
-      if (autoFollow && pinnedRef.current) {
-        assignScrollTop(current, current.scrollHeight);
-      } else {
-        const anchor = anchorRef.current;
-        if (anchor && anchor.el.isConnected) {
-          const containerTop = current.getBoundingClientRect().top;
-          const now = anchor.el.getBoundingClientRect().top - containerTop;
-          const diff = now - anchor.top;
-          if (diff !== 0) {
-            assignScrollTop(current, current.scrollTop + diff);
-          }
-        }
-      }
-      captureAnchor();
+      restoreAnchor(current);
     });
     observer.observe(inner);
     return () => observer.disconnect();
-  }, [autoFollow, captureAnchor, assignScrollTop]);
+  }, [restoreAnchor]);
 
   const onScroll = () => {
     const node = scrollRef.current;
     if (!node) {
       return;
     }
-    const programmaticTarget = programmaticScrollTargetRef.current;
-    const programmatic =
-      programmaticTarget !== null && Math.abs(node.scrollTop - programmaticTarget) <= 1;
-    programmaticScrollTargetRef.current = null;
+    const pending = programmaticScrollTargetsRef.current;
+    const programmaticIndex = pending.findIndex((target) => Math.abs(node.scrollTop - target) <= 1);
+    const programmatic = programmaticIndex >= 0;
+    if (programmatic) {
+      pending.splice(0, programmaticIndex + 1);
+    } else {
+      // A real reader scroll supersedes every delayed programmatic echo.
+      pending.length = 0;
+    }
     const nextPinned = node.scrollHeight - node.scrollTop - node.clientHeight < 48;
     // Echoes of our own assignments may PIN but never UNPIN — only the reader
     // scrolling away releases the bottom-follow.

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -83,7 +83,7 @@ export function ActivityRail({
         const newFamily = index > 0 && familyOf(item) !== familyOf(items[index - 1]!);
         const row = renderActivity(item, toolRegistry, onOpenSession, onMemoryClick);
         return (
-          <div key={item.id} className={cn(newFamily && "mt-3")}>
+          <div key={item.id} data-og-timeline-row-anchor="" className={cn(newFamily && "mt-3")}>
             {row}
           </div>
         );

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -108,6 +108,12 @@ describe("timeline scroll ownership browser regression", () => {
     expect(afterDelayedGrowth.id).toBe(afterWheel.id);
     expect(afterDelayedGrowth.top).toBeCloseTo(afterWheel.top ?? 0, 0);
 
+    await page.evaluate(() => window.timelineScrollHarness!.stream());
+    await page.waitForTimeout(100);
+    const afterStream = await visible(page);
+    expect(afterStream.id).toBe(afterWheel.id);
+    expect(afterStream.top).toBeCloseTo(afterWheel.top ?? 0, 0);
+
     await page.evaluate(() => window.timelineScrollHarness!.append());
     await page.waitForTimeout(100);
     const afterAppend = await visible(page);
@@ -127,6 +133,7 @@ describe("timeline scroll ownership browser regression", () => {
         afterWheel,
         afterPrepend,
         afterDelayedGrowth,
+        afterStream,
         afterAppend,
         ...browserMetrics,
       };
@@ -148,10 +155,93 @@ describe("timeline scroll ownership browser regression", () => {
         .tracing.stop({ path: `${artifactDir}/timeline-scroll-playwright-trace.zip` });
     }
   }, 30_000);
+
+  test("follows a reader that is within the near-bottom threshold", async () => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`${baseUrl}/timeline-scroll-test.html`);
+    await page.waitForFunction(() => window.timelineScrollHarness !== undefined);
+    await page.locator('[data-timeline-row="row-1000"]').waitFor({ timeout: 15_000 });
+
+    const scroller = page.locator("[data-timeline-test] .og-root > div");
+    await scroller.evaluate((node) => {
+      node.scrollTop = node.scrollHeight - node.clientHeight - 24;
+    });
+    await page.waitForTimeout(100);
+    const before = await scroller.evaluate((node) => ({
+      gap: node.scrollHeight - node.scrollTop - node.clientHeight,
+      scrollTop: node.scrollTop,
+    }));
+    expect(before.gap).toBeLessThan(48);
+
+    await page.evaluate(() => window.timelineScrollHarness!.append());
+    await page.waitForTimeout(100);
+    const after = await scroller.evaluate((node) => ({
+      gap: node.scrollHeight - node.scrollTop - node.clientHeight,
+      scrollTop: node.scrollTop,
+    }));
+    expect(after.gap).toBeLessThan(2);
+    expect(after.scrollTop).toBeGreaterThan(before.scrollTop);
+  }, 30_000);
+
+  test("keeps a narrow mobile reader anchored through prepend", async () => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(`${baseUrl}/timeline-scroll-test.html`);
+    await page.waitForFunction(() => window.timelineScrollHarness !== undefined);
+    await page.locator('[data-timeline-row="row-1000"]').waitFor({ timeout: 15_000 });
+    const target = page.locator('[data-timeline-row="row-1040"]');
+    await target.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(100);
+
+    const before = await visible(page);
+    await page.evaluate(() => window.timelineScrollHarness!.prepend());
+    await page.waitForTimeout(100);
+    const after = await visible(page);
+    expect(after.id).toBe(before.id);
+    expect(after.top).toBeCloseTo(before.top ?? 0, 0);
+    await page.setViewportSize({ width: 1280, height: 900 });
+  }, 30_000);
+
+  test("keeps a nested row anchored when prepend merges into its activity group", async () => {
+    await page.goto(`${baseUrl}/timeline-scroll-merge-test.html`);
+    await page.waitForFunction(() => window.timelineMergeHarness !== undefined);
+    const target = page.getByText("reasoning-50", { exact: true });
+    await target.waitFor({ timeout: 15_000 });
+    await target.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(100);
+
+    const before = await nestedVisible(page, "reasoning-50");
+    await page.evaluate(() => window.timelineMergeHarness!.prependActivity());
+    await page.waitForTimeout(100);
+    const after = await nestedVisible(page, "reasoning-50");
+
+    expect(after.text).toBe(before.text);
+    expect(after.top).toBeCloseTo(before.top, 0);
+  }, 30_000);
 });
 
 async function visible(page: Page): Promise<VisibleRow> {
   return await page.evaluate(() => window.timelineScrollHarness!.visible());
+}
+
+async function nestedVisible(
+  page: Page,
+  text: string,
+): Promise<{ text: string; top: number; scrollTop: number; overflowAnchor: string }> {
+  return await page.evaluate((targetText) => {
+    const scroller = document.querySelector<HTMLElement>(
+      "[data-timeline-merge-test] .og-root > div",
+    );
+    const target = [...document.querySelectorAll<HTMLElement>("span, p")].find(
+      (candidate) => candidate.textContent === targetText,
+    );
+    if (!scroller || !target) throw new Error(`missing nested timeline row ${targetText}`);
+    return {
+      text: target.textContent ?? "",
+      top: target.getBoundingClientRect().top - scroller.getBoundingClientRect().top,
+      scrollTop: scroller.scrollTop,
+      overflowAnchor: getComputedStyle(scroller).overflowAnchor,
+    };
+  }, text);
 }
 
 async function collectBrowserMetrics(page: Page) {
@@ -215,7 +305,11 @@ declare global {
       append: () => void;
       growRowsAbove: () => void;
       prepend: () => void;
+      stream: () => void;
       visible: () => VisibleRow;
+    };
+    timelineMergeHarness?: {
+      prependActivity: () => void;
     };
     timelinePerformanceTrace?: {
       active: boolean;

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -156,6 +156,88 @@ describe("timeline scroll ownership browser regression", () => {
     }
   }, 30_000);
 
+  test("preserves the anchor when the first progressive row meets the reader", async () => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`${baseUrl}/timeline-scroll-test.html?adjacent`);
+    await page.waitForFunction(() => window.timelineScrollHarness !== undefined);
+    await page.locator('[data-timeline-row="row-1040"]').waitFor({ timeout: 15_000 });
+    const target = page.locator('[data-timeline-row="row-1040"]');
+    await target.evaluate((node) => node.scrollIntoView({ block: "start" }));
+    await page.waitForTimeout(100);
+
+    const before = await visible(page);
+    await page.evaluate(() => window.timelineScrollHarness!.prepend());
+    const samples = await visibleIntervals(page, 16, 20);
+    expect(samples.length).toBe(16);
+    expect(samples.every((sample) => sample.id === before.id)).toBe(true);
+    expect(samples.every((sample) => Math.abs((sample.top ?? 0) - (before.top ?? 0)) < 1)).toBe(
+      true,
+    );
+  }, 30_000);
+
+  test("preserves the anchor during every progressive prepend frame", async () => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`${baseUrl}/timeline-scroll-test.html`);
+    await page.waitForFunction(() => window.timelineScrollHarness !== undefined);
+    await page.locator('[data-timeline-row="row-1000"]').waitFor({ timeout: 15_000 });
+    const target = page.locator('[data-timeline-row="row-1040"]');
+    await target.evaluate((node) => node.scrollIntoView({ block: "start" }));
+    await page.waitForTimeout(100);
+
+    const before = await visible(page);
+    await page.evaluate(() => window.timelineScrollHarness!.prepend());
+    const samples = await visibleIntervals(page, 16, 20);
+    expect(samples.length).toBe(16);
+    expect(samples.every((sample) => sample.id === before.id)).toBe(true);
+    expect(samples.every((sample) => Math.abs((sample.top ?? 0) - (before.top ?? 0)) < 1)).toBe(
+      true,
+    );
+  }, 30_000);
+
+  test("preserves every progressive prepend frame on narrow mobile", async () => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(`${baseUrl}/timeline-scroll-test.html`);
+    await page.waitForFunction(() => window.timelineScrollHarness !== undefined);
+    await page.locator('[data-timeline-row="row-1000"]').waitFor({ timeout: 15_000 });
+    const target = page.locator('[data-timeline-row="row-1040"]');
+    await target.evaluate((node) => node.scrollIntoView({ block: "start" }));
+    await page.waitForTimeout(100);
+
+    const before = await visible(page);
+    await page.evaluate(() => window.timelineScrollHarness!.prepend());
+    const samples = await visibleFrames(page, 24);
+    expect(samples.length).toBe(24);
+    expect(samples.every((sample) => sample.id === before.id)).toBe(true);
+    expect(samples.every((sample) => Math.abs((sample.top ?? 0) - (before.top ?? 0)) < 1)).toBe(
+      true,
+    );
+    await page.setViewportSize({ width: 1280, height: 900 });
+  }, 30_000);
+
+  test("keeps wheel ownership through the remaining prepend frames", async () => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`${baseUrl}/timeline-scroll-test.html`);
+    await page.waitForFunction(() => window.timelineScrollHarness !== undefined);
+    await page.locator('[data-timeline-row="row-1000"]').waitFor({ timeout: 15_000 });
+    const target = page.locator('[data-timeline-row="row-1040"]');
+    await target.evaluate((node) => node.scrollIntoView({ block: "start" }));
+    await page.waitForTimeout(100);
+
+    await page.evaluate(() => window.timelineScrollHarness!.prepend());
+    await nextFrames(page, 2);
+    const scroller = page.locator("[data-timeline-test] .og-root > div");
+    await scroller.hover();
+    await page.mouse.wheel(0, -96);
+    await page.waitForTimeout(20);
+    const afterWheel = await visible(page);
+    const samples = await visibleFrames(page, 24);
+    expect(samples.length).toBe(24);
+    expect(samples.every((sample) => sample.id === afterWheel.id)).toBe(true);
+    expect(samples.every((sample) => Math.abs((sample.top ?? 0) - (afterWheel.top ?? 0)) < 1)).toBe(
+      true,
+    );
+  }, 30_000);
+
   test("follows a reader that is within the near-bottom threshold", async () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto(`${baseUrl}/timeline-scroll-test.html`);
@@ -189,7 +271,7 @@ describe("timeline scroll ownership browser regression", () => {
     await page.waitForFunction(() => window.timelineScrollHarness !== undefined);
     await page.locator('[data-timeline-row="row-1000"]').waitFor({ timeout: 15_000 });
     const target = page.locator('[data-timeline-row="row-1040"]');
-    await target.scrollIntoViewIfNeeded();
+    await target.evaluate((node) => node.scrollIntoView({ block: "start" }));
     await page.waitForTimeout(100);
 
     const before = await visible(page);
@@ -206,7 +288,7 @@ describe("timeline scroll ownership browser regression", () => {
     await page.waitForFunction(() => window.timelineMergeHarness !== undefined);
     const target = page.getByText("reasoning-50", { exact: true });
     await target.waitFor({ timeout: 15_000 });
-    await target.scrollIntoViewIfNeeded();
+    await target.evaluate((node) => node.scrollIntoView({ block: "start" }));
     await page.waitForTimeout(100);
 
     const before = await nestedVisible(page, "reasoning-50");
@@ -221,6 +303,43 @@ describe("timeline scroll ownership browser regression", () => {
 
 async function visible(page: Page): Promise<VisibleRow> {
   return await page.evaluate(() => window.timelineScrollHarness!.visible());
+}
+
+async function visibleFrames(page: Page, count: number): Promise<VisibleRow[]> {
+  return await page.evaluate(async (frameCount) => {
+    const samples: VisibleRow[] = [];
+    for (let index = 0; index < frameCount; index += 1) {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      samples.push(window.timelineScrollHarness!.visible());
+    }
+    return samples;
+  }, count);
+}
+
+async function visibleIntervals(
+  page: Page,
+  count: number,
+  intervalMs: number,
+): Promise<VisibleRow[]> {
+  return await page.evaluate(
+    async ({ count: sampleCount, interval }) => {
+      const samples: VisibleRow[] = [];
+      for (let index = 0; index < sampleCount; index += 1) {
+        await new Promise<void>((resolve) => setTimeout(resolve, interval));
+        samples.push(window.timelineScrollHarness!.visible());
+      }
+      return samples;
+    },
+    { count, interval: intervalMs },
+  );
+}
+
+async function nextFrames(page: Page, count: number): Promise<void> {
+  await page.evaluate(async (frameCount) => {
+    for (let index = 0; index < frameCount; index += 1) {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    }
+  }, count);
 }
 
 async function nestedVisible(


### PR DESCRIPTION
## Summary

- preserve the visible timeline row and pixel offset when older activity merges into an existing group
- prefer durable activity-row anchors over outer group containers, with group fallback for non-activity rows
- cover away-from-bottom append/stream growth, near-bottom follow, resize/late growth, narrow mobile, and same-group prepend behavior

Fixes OPE-99.

## Verification

- Base: `eaffde5f6400d09e4077a1ba5fb6c6ad285b625d`
- Head: `45aec9ec0c307283c7e5d36aa208ea8b24567a7e`
- Tree: `7b147bf4497a807bf5615a5f6adc88af5fe8eca6`
- `bun test --timeout 30000 packages/react/test/message-timeline-pagination.test.tsx` — 10 pass, 56 expect calls
- `bun run scripts/run-browser-e2e.ts ./test/e2e/timeline-scroll.browser.e2e.ts` — 4 pass, 19 expect calls (non-minified Vite/Chromium)
- `bun run typecheck` — 23/23 projects clean
- `bun run --cwd packages/react build` — pass
- `bun run format:check` — pass
- `bun run lint` — pass, 0 warnings/errors
- `git diff --check` — pass

The aggregate `bun run check` reached 4,673 pass / 4 skip / 37 unrelated runtime/process-group/credential sandbox failures in `test:unit` and stopped before builds; no React/timeline failures were reported. This PR is source-only and not self-reviewed, merged, deployed, or production-accepted.
