### PR TITLE
feat(web): resolve workspace-less session links

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@
 //   /workspaces/:id/agent                    → sessions redirect (legacy URL)
 //   /workspaces/:id/sessions                 → sessions index + create
 //   /workspaces/:id/sessions/:sessionId      → session view (queue/goal rail)
+//   /sessions/:sessionId                     → authorized compatibility redirect
 //   /workspaces/:id/variable-sets            → variable sets + variables
 //   /workspaces/:id/rigs                     → rigs list + create
 //   /workspaces/:id/rigs/:rigId              → rig detail (overview/setup/versions/changes)
@@ -60,6 +61,10 @@ const LazyRigDetailRoute = lazyRouteComponent(
 );
 const LazySchedulesRoute = lazyRouteComponent(() => import("@/routes/schedules"), "SchedulesRoute");
 const LazySessionRoute = lazyRouteComponent(() => import("@/routes/session"), "SessionRoute");
+const LazySessionDeepLinkRoute = lazyRouteComponent(
+  () => import("@/routes/session-deep-link"),
+  "SessionDeepLinkRoute",
+);
 const LazySessionsIndexRoute = lazyRouteComponent(
   () => import("@/routes/sessions-index"),
   "SessionsIndexRoute",
@@ -81,6 +86,11 @@ const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/",
   component: RootIndexRoute,
+});
+const sessionDeepLinkRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "sessions/$sessionId",
+  component: SessionDeepLink,
 });
 // Stripe checkout return target. The API bakes `/billing?checkout=…` into every
 // checkout session's success_url/cancel_url; this top-level route forwards the
@@ -239,6 +249,7 @@ const workspaceAccountRoute = createRoute({
 });
 const routeTree = rootRoute.addChildren([
   indexRoute,
+  sessionDeepLinkRoute,
   billingReturnRoute,
   deviceRoute,
   resetPasswordRoute,
@@ -309,6 +320,11 @@ function SessionsIndex() {
 function SessionView() {
   const { workspaceId, sessionId } = workspaceSessionRoute.useParams();
   return <LazySessionRoute workspaceId={workspaceId} sessionId={sessionId} />;
+}
+
+function SessionDeepLink() {
+  const { sessionId } = sessionDeepLinkRoute.useParams();
+  return <LazySessionDeepLinkRoute sessionId={sessionId} />;
 }
 
 function VariableSets() {

--- a/apps/web/src/lib/session-deep-link.test.ts
+++ b/apps/web/src/lib/session-deep-link.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  canonicalSessionDeepLinkTarget,
+  resolveAuthorizedSessionWorkspace,
+  sessionDeepLinkReturnPath,
+  shouldRedirectSessionDeepLink,
+  type SessionReadGrant,
+} from "./session-deep-link";
+
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_SESSION_ID = "22222222-2222-4222-8222-222222222222";
+
+function grant(workspaceId: string, permissions: string[]): SessionReadGrant {
+  return { workspaceId, permissions } as SessionReadGrant;
+}
+
+function reader(
+  responses: Record<string, unknown>,
+  calls: string[],
+): { getSession: (workspaceId: string, sessionId: string) => Promise<unknown> } {
+  return {
+    async getSession(workspaceId, sessionId) {
+      calls.push(`${workspaceId}/${sessionId}`);
+      const response = responses[workspaceId];
+      if (response instanceof Error) {
+        throw response;
+      }
+      if (response && typeof response === "object" && "status" in response) {
+        throw response;
+      }
+      return response ?? { id: sessionId };
+    },
+  };
+}
+
+describe("workspace-less session deep-link resolver", () => {
+  test("redirect resolution uses only authorized session-read workspace paths", async () => {
+    const calls: string[] = [];
+    const result = await resolveAuthorizedSessionWorkspace(
+      reader(
+        {
+          "workspace-a": { status: 404 },
+          "workspace-b": { id: SESSION_ID },
+          "workspace-c": { id: OTHER_SESSION_ID },
+        },
+        calls,
+      ),
+      [
+        grant("workspace-a", ["sessions:read"]),
+        grant("workspace-b", ["workspace:admin"]),
+        grant("workspace-c", ["sessions:control"]),
+      ],
+      SESSION_ID,
+    );
+
+    expect(result).toEqual({ status: "resolved", workspaceId: "workspace-b" });
+    expect(calls).toEqual([`workspace-a/${SESSION_ID}`, `workspace-b/${SESSION_ID}`]);
+  });
+
+  test("signed-out return state remains the original deep link", () => {
+    expect(
+      sessionDeepLinkReturnPath({
+        pathname: `/sessions/${SESSION_ID}`,
+        search: "?from=agent&tab=timeline",
+        hash: "#latest",
+      }),
+    ).toBe(`/sessions/${SESSION_ID}?from=agent&tab=timeline#latest`);
+  });
+
+  test("unauthorized and cross-tenant misses stay indistinguishable", async () => {
+    const calls: string[] = [];
+    const result = await resolveAuthorizedSessionWorkspace(
+      reader(
+        {
+          "workspace-a": { status: 403 },
+          "workspace-b": { status: 404 },
+        },
+        calls,
+      ),
+      [grant("workspace-a", ["sessions:read"]), grant("workspace-b", ["sessions:read"])],
+      SESSION_ID,
+    );
+
+    expect(result).toEqual({ status: "not-found" });
+    expect(calls).toHaveLength(2);
+  });
+
+  test("nonexistent and malformed IDs do not disclose or probe", async () => {
+    const nonexistentCalls: string[] = [];
+    await expect(
+      resolveAuthorizedSessionWorkspace(
+        reader({ "workspace-a": { status: 404 } }, nonexistentCalls),
+        [grant("workspace-a", ["sessions:read"])],
+        OTHER_SESSION_ID,
+      ),
+    ).resolves.toEqual({ status: "not-found" });
+    expect(nonexistentCalls).toEqual([`workspace-a/${OTHER_SESSION_ID}`]);
+
+    const malformedCalls: string[] = [];
+    await expect(
+      resolveAuthorizedSessionWorkspace(
+        reader({ "workspace-a": { id: SESSION_ID } }, malformedCalls),
+        [grant("workspace-a", ["sessions:read"])],
+        "not-a-session-id",
+      ),
+    ).resolves.toEqual({ status: "not-found" });
+    expect(malformedCalls).toEqual([]);
+  });
+
+  test("preserves query/hash state and never redirects a canonical pathname", () => {
+    const location = {
+      pathname: `/sessions/${SESSION_ID}`,
+      search: "?focus=queue",
+      hash: "#composer",
+    };
+    expect(canonicalSessionDeepLinkTarget("workspace-a", SESSION_ID, location)).toBe(
+      `/workspaces/workspace-a/sessions/${SESSION_ID}?focus=queue#composer`,
+    );
+    expect(
+      shouldRedirectSessionDeepLink(
+        location.pathname,
+        `/workspaces/workspace-a/sessions/${SESSION_ID}`,
+      ),
+    ).toBe(true);
+    expect(
+      shouldRedirectSessionDeepLink(
+        `/workspaces/workspace-a/sessions/${SESSION_ID}`,
+        `/workspaces/workspace-a/sessions/${SESSION_ID}`,
+      ),
+    ).toBe(false);
+  });
+
+  test("surfaces non-authorization failures as a safe unavailable state", async () => {
+    const result = await resolveAuthorizedSessionWorkspace(
+      reader({ "workspace-a": { status: 503 } }, []),
+      [grant("workspace-a", ["sessions:read"])],
+      SESSION_ID,
+    );
+
+    expect(result.status).toBe("error");
+  });
+});

--- a/apps/web/src/lib/session-deep-link.ts
+++ b/apps/web/src/lib/session-deep-link.ts
@@ -1,0 +1,100 @@
+import type { AccessContext } from "@opengeni/sdk";
+
+import { workspaceSessionPath } from "./routes";
+
+const SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type SessionDeepLinkLocation = Pick<Location, "pathname" | "search" | "hash">;
+export type SessionReadGrant = Pick<
+  AccessContext["workspaceGrants"][number],
+  "workspaceId" | "permissions"
+>;
+
+export type SessionDeepLinkResolution =
+  | { status: "resolved"; workspaceId: string }
+  | { status: "not-found" }
+  | { status: "error"; error: unknown };
+
+// Keep the resolver's dependency structural so it can reuse the SDK client
+// without adding a second API surface or coupling this helper to the client
+// implementation in tests.
+export type AuthorizedSessionReader = {
+  getSession: (workspaceId: string, sessionId: string) => Promise<unknown>;
+};
+
+export function isSessionId(value: string): boolean {
+  return SESSION_ID_PATTERN.test(value);
+}
+
+export function sessionReadWorkspaceIds(grants: readonly SessionReadGrant[]): string[] {
+  return [
+    ...new Set(
+      grants
+        .filter(
+          (grant) =>
+            grant.permissions.includes("sessions:read") ||
+            grant.permissions.includes("workspace:admin"),
+        )
+        .map((grant) => grant.workspaceId),
+    ),
+  ];
+}
+
+/**
+ * Resolve only through workspace-scoped session reads that the caller already
+ * has permission to make. A 401/403/404 is intentionally indistinguishable
+ * from a miss so foreign, inaccessible, and nonexistent sessions do not gain
+ * a discovery oracle. Other failures remain a generic unavailable state for
+ * the route to render safely.
+ */
+export async function resolveAuthorizedSessionWorkspace(
+  client: AuthorizedSessionReader,
+  grants: readonly SessionReadGrant[],
+  sessionId: string,
+): Promise<SessionDeepLinkResolution> {
+  if (!isSessionId(sessionId)) {
+    return { status: "not-found" };
+  }
+
+  let unavailableError: unknown = null;
+  for (const workspaceId of sessionReadWorkspaceIds(grants)) {
+    try {
+      await client.getSession(workspaceId, sessionId);
+      return { status: "resolved", workspaceId };
+    } catch (error) {
+      if (isAuthorizationOrNotFound(error)) {
+        continue;
+      }
+      unavailableError ??= error;
+    }
+  }
+
+  return unavailableError ? { status: "error", error: unavailableError } : { status: "not-found" };
+}
+
+export function sessionDeepLinkReturnPath(location: SessionDeepLinkLocation): string {
+  return `${location.pathname}${location.search}${location.hash}`;
+}
+
+export function canonicalSessionDeepLinkTarget(
+  workspaceId: string,
+  sessionId: string,
+  location: SessionDeepLinkLocation,
+): string {
+  return `${workspaceSessionPath(workspaceId, sessionId)}${location.search}${location.hash}`;
+}
+
+export function shouldRedirectSessionDeepLink(
+  pathname: string,
+  canonicalPathname: string,
+): boolean {
+  return pathname !== canonicalPathname;
+}
+
+function isAuthorizationOrNotFound(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("status" in error)) {
+    return false;
+  }
+  const status = (error as { status?: unknown }).status;
+  return status === 401 || status === 403 || status === 404;
+}

--- a/apps/web/src/routes/session-deep-link.tsx
+++ b/apps/web/src/routes/session-deep-link.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+
+import { LoadingPanel, ProblemPanel } from "@/components/common";
+import { useAppContext } from "@/context";
+import {
+  canonicalSessionDeepLinkTarget,
+  resolveAuthorizedSessionWorkspace,
+  shouldRedirectSessionDeepLink,
+} from "@/lib/session-deep-link";
+
+export function SessionDeepLinkRoute({ sessionId }: { sessionId: string }) {
+  const context = useAppContext();
+  const [attempt, setAttempt] = useState(0);
+  const [state, setState] = useState<"loading" | "not-found" | "error">("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    setState("loading");
+
+    void resolveAuthorizedSessionWorkspace(
+      context.client,
+      context.accessContext.workspaceGrants,
+      sessionId,
+    ).then((resolution) => {
+      if (cancelled) {
+        return;
+      }
+      if (resolution.status === "resolved") {
+        const targetPath = canonicalSessionDeepLinkTarget(
+          resolution.workspaceId,
+          sessionId,
+          window.location,
+        );
+        const targetPathname = targetPath.split(/[?#]/, 1)[0] ?? targetPath;
+        if (shouldRedirectSessionDeepLink(window.location.pathname, targetPathname)) {
+          // A full-document replace keeps the compatibility URL out of the
+          // back stack and preserves the original query/hash for the canonical
+          // session view. The canonical route never renders this component,
+          // so a successful redirect cannot loop.
+          window.location.replace(targetPath);
+          return;
+        }
+      }
+      setState(resolution.status === "error" ? "error" : "not-found");
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [attempt, context.accessContext.workspaceGrants, context.client, sessionId]);
+
+  if (state === "loading") {
+    return <LoadingPanel label="Opening session" />;
+  }
+  if (state === "error") {
+    return (
+      <ProblemPanel
+        title="Session unavailable"
+        description="We couldn't verify this session right now. Try again in a moment."
+        action={
+          <button
+            type="button"
+            className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm font-medium hover:bg-surface-3"
+            onClick={() => setAttempt((value) => value + 1)}
+          >
+            Try again
+          </button>
+        }
+      />
+    );
+  }
+  return (
+    <ProblemPanel
+      title="Session not found"
+      description="This session doesn't exist or you don't have access to it."
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add the workspace-less `/sessions/:sessionId` compatibility route
- resolve only through the caller's existing workspace session-read/admin grants
- replace the URL with `/workspaces/:workspaceId/sessions/:sessionId`, preserving query/hash state
- keep unauthorized, cross-tenant, nonexistent, and malformed IDs indistinguishable from not found
- preserve the existing signed-out auth gate/return URL behavior without changing canonical links

## Validation
- `bun test apps/web/src/lib/session-deep-link.test.ts --timeout 30000`
- `bun test apps/web/src/App.test.ts --timeout 30000`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web build`
- `./node_modules/.bin/oxfmt --check apps/web/src/App.tsx apps/web/src/lib/session-deep-link.ts apps/web/src/routes/session-deep-link.tsx apps/web/src/lib/session-deep-link.test.ts`
- `git diff --check`

The local Vite browser smoke test rendered the safe app-level failure state for a malformed deep link, but authenticated redirect/refresh/back-forward and responsive/theme/accessibility checks could not run because this isolated sandbox had no API backend/session and the config request fell through to Vite HTML.

Refs OPE-117
