### PR TITLE
feat(release): publish multi-architecture images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,9 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.sha }}
           persist-credentials: false
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -533,7 +536,7 @@ jobs:
           context: .
           file: docker/opengeni.Dockerfile
           target: api
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: false
           tags: opengeni-api:ci
 
@@ -543,7 +546,7 @@ jobs:
           context: .
           file: docker/opengeni.Dockerfile
           target: worker
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: false
           tags: opengeni-worker:ci
 
@@ -553,7 +556,7 @@ jobs:
           context: .
           file: docker/opengeni.Dockerfile
           target: web
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: false
           tags: opengeni-web:ci
 
@@ -562,7 +565,7 @@ jobs:
         with:
           context: .
           file: docker/sandbox.Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: false
           tags: opengeni-sandbox:ci
 
@@ -571,7 +574,7 @@ jobs:
         with:
           context: agent
           file: agent/crates/opengeni-relay/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: false
           tags: opengeni-relay:ci
 

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -124,6 +124,9 @@ jobs:
           echo "candidate_tag=candidate-$SOURCE_SHA" >> "$GITHUB_OUTPUT"
           echo "source_tree_sha=$(git rev-parse "$SOURCE_SHA^{tree}")" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
@@ -196,7 +199,7 @@ jobs:
           context: .
           file: docker/opengeni.Dockerfile
           target: api
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             OPENGENI_SERVER_VERSION=${{ steps.meta.outputs.version }}
@@ -238,7 +241,7 @@ jobs:
           context: .
           file: docker/opengeni.Dockerfile
           target: worker
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             OPENGENI_SERVER_VERSION=${{ steps.meta.outputs.version }}
@@ -277,7 +280,7 @@ jobs:
           context: .
           file: docker/opengeni.Dockerfile
           target: web
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             OPENGENI_DEPLOYMENT_REVISION=${{ steps.meta.outputs.version }}
@@ -316,7 +319,7 @@ jobs:
         with:
           context: .
           file: docker/sandbox.Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.OPENGENI_RELEASE_OCI_PREFIX }}/opengeni-sandbox:${{ steps.meta.outputs.candidate_tag }}
 
@@ -352,7 +355,7 @@ jobs:
         with:
           context: agent
           file: agent/crates/opengeni-relay/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.OPENGENI_RELEASE_OCI_PREFIX }}/opengeni-relay:${{ steps.meta.outputs.candidate_tag }}
 

--- a/agent/crates/opengeni-relay/Dockerfile
+++ b/agent/crates/opengeni-relay/Dockerfile
@@ -10,29 +10,35 @@
 # (build context = the `agent/` Cargo workspace; the relay shares the
 # opengeni-agent-stream codec, so the whole workspace must be in context.)
 
+# syntax=docker/dockerfile:1
+
 # ---- build stage ----------------------------------------------------------------
-FROM rust:1.82-alpine AS build
+# BuildKit normally runs each build stage as the target architecture. That makes
+# an arm64 Rust release build crawl through QEMU on an amd64 CI runner. `xx`
+# configures clang/lld + Cargo for the requested target while this stage remains
+# native to the builder, so both OCI variants compile at native speed.
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx
+FROM --platform=$BUILDPLATFORM rust:1.82-alpine AS build
 
-ARG TARGETARCH
+COPY --from=xx / /
 
-# musl-dev + the build essentials for a fully-static link. protoc is NOT needed:
-# the proto crate compiles the .proto via the pure-Rust `protox` (build.rs).
-RUN apk add --no-cache musl-dev
+# clang/lld are native cross-compilers. protoc is NOT needed: the proto crate
+# compiles the .proto via the pure-Rust `protox` (build.rs).
+RUN apk add --no-cache clang lld
 
 WORKDIR /build
 # The build context is the agent/ workspace root.
 COPY . .
 
 # Build the relay binary for the requested OCI architecture as a static musl
-# target. The workspace profile already strips + LTOs the release build.
+# target without emulation. The workspace profile already strips + LTOs the
+# release build; `xx-verify` fails if the output architecture drifts.
+ARG TARGETPLATFORM
 RUN set -eux; \
-    case "${TARGETARCH}" in \
-      amd64) rust_target="x86_64-unknown-linux-musl" ;; \
-      arm64) rust_target="aarch64-unknown-linux-musl" ;; \
-      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
-    esac; \
+    rust_target="$(xx-cargo --print-target-triple)"; \
     rustup target add "${rust_target}"; \
-    cargo build --release --target "${rust_target}" -p opengeni-relay; \
+    xx-cargo build --release --target-dir /build/target -p opengeni-relay; \
+    xx-verify "/build/target/${rust_target}/release/opengeni-relay"; \
     cp "target/${rust_target}/release/opengeni-relay" /opengeni-relay
 
 # ---- runtime stage --------------------------------------------------------------

--- a/agent/crates/opengeni-relay/Dockerfile
+++ b/agent/crates/opengeni-relay/Dockerfile
@@ -1,6 +1,6 @@
 # opengeni-relay — the stateless stream-relay edge image.
 #
-# Multi-stage: build a fully-static x86_64 musl binary, then ship it in a distroless
+# Multi-stage: build a fully-static native musl binary, then ship it in a distroless
 # (effectively scratch) runtime so the image is tiny, has no shell/package surface,
 # and runs as a non-root user. The GHCR build wiring (release.yml) is M11; this
 # Dockerfile just produces a buildable, production-shaped image.
@@ -13,6 +13,8 @@
 # ---- build stage ----------------------------------------------------------------
 FROM rust:1.82-alpine AS build
 
+ARG TARGETARCH
+
 # musl-dev + the build essentials for a fully-static link. protoc is NOT needed:
 # the proto crate compiles the .proto via the pure-Rust `protox` (build.rs).
 RUN apk add --no-cache musl-dev
@@ -21,11 +23,17 @@ WORKDIR /build
 # The build context is the agent/ workspace root.
 COPY . .
 
-# Build the relay binary as a static musl target. The workspace profile already
-# strips + LTOs the release build.
-RUN rustup target add x86_64-unknown-linux-musl \
- && cargo build --release --target x86_64-unknown-linux-musl -p opengeni-relay \
- && cp target/x86_64-unknown-linux-musl/release/opengeni-relay /opengeni-relay
+# Build the relay binary for the requested OCI architecture as a static musl
+# target. The workspace profile already strips + LTOs the release build.
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) rust_target="x86_64-unknown-linux-musl" ;; \
+      arm64) rust_target="aarch64-unknown-linux-musl" ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    rustup target add "${rust_target}"; \
+    cargo build --release --target "${rust_target}" -p opengeni-relay; \
+    cp "target/${rust_target}/release/opengeni-relay" /opengeni-relay
 
 # ---- runtime stage --------------------------------------------------------------
 # Distroless static: no shell, no package manager, a nonroot user — minimal attack

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.2
-appVersion: "0.22.2"
+version: 0.22.3
+appVersion: "0.22.3"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -431,6 +431,10 @@ the published image aliases and chart bytes. A private or inconsistently
 configured registry therefore fails closed before becoming distribution
 authority. The candidate receipt records the full image repository names, and
 every later workflow verifies them against the same source-controlled prefix.
+Each official workload image is one OCI index containing both `linux/amd64`
+and `linux/arm64`; candidate creation builds both variants before freezing the
+index digest, so downstream hosts select their native architecture without
+building OpenGeni locally.
 
 For the default GHCR location, the owning organization must allow public
 package creation and each existing `opengeni-*` container package must be made

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -61,6 +61,8 @@ describe("release image workflow contract", () => {
     ]) {
       expect(candidate).toContain(identity);
     }
+    expect(candidate).toContain("docker/setup-qemu-action@");
+    expect(candidate.match(/platforms: linux\/amd64,linux\/arm64/g)).toHaveLength(5);
     expect(candidate).toContain("candidate-$SOURCE_SHA");
     expect(candidate).toContain("opengeni-candidate-${SOURCE_SHA}");
     expect(candidate).toContain("evidence/release-candidate.json");
@@ -376,5 +378,7 @@ ${parser}`,
     ]) {
       expect(imagesJob).toContain(identity);
     }
+    expect(imagesJob).toContain("docker/setup-qemu-action@");
+    expect(imagesJob.match(/platforms: linux\/amd64,linux\/arm64/g)).toHaveLength(5);
   });
 });


### PR DESCRIPTION
## What

Publish every official OpenGeni workload image as a Linux AMD64/ARM64 OCI index in ordinary CI and candidate releases. Make the relay Dockerfile select the correct Rust musl target from BuildKit `TARGETARCH`.

## Why

Official prebuilt images should run natively on common x86_64 and ARM64 hosts. Operators should not need private mirror builds or builds on deployment machines.

## Verification

- `bun test scripts/release-image-workflow-contract.test.ts scripts/release-version.test.ts`
- `helm lint deploy/helm/opengeni`
- `helm template opengeni deploy/helm/opengeni`
- `docker buildx build --platform linux/arm64 --output=type=cacheonly -f agent/crates/opengeni-relay/Dockerfile agent`