### PR TITLE
fix(worker): include PTY bridge runtime

### DIFF
--- a/docker/opengeni.Dockerfile
+++ b/docker/opengeni.Dockerfile
@@ -56,17 +56,21 @@ CMD ["bun", "run", "--cwd", "apps/api", "start"]
 
 FROM base AS worker
 # The docker sandbox backend needs the Docker CLI to talk to the mounted host
-# daemon socket. Install the client only; the daemon remains outside this image.
+# daemon socket. Interactive/cancellable commands use the Agents SDK's
+# host-side Python PTY bridge, so Python must live in this worker image rather
+# than only inside the sandbox. The daemon remains outside this image.
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+  && apt-get install -y --no-install-recommends ca-certificates curl gnupg python3 \
   && install -m 0755 -d /etc/apt/keyrings \
   && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
   && chmod a+r /etc/apt/keyrings/docker.asc \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list \
   && apt-get update \
   && apt-get install -y --no-install-recommends docker-ce-cli \
+  && /usr/bin/python3 -c 'import pty' \
   && rm -rf /var/lib/apt/lists/*
+ENV OPENAI_AGENTS_PYTHON=/usr/bin/python3
 USER bun
 CMD ["bun", "run", "--cwd", "apps/worker", "start"]
 


### PR DESCRIPTION
## Summary

- install Python 3 in the worker image for the Agents SDK host-side PTY bridge
- pin `OPENAI_AGENTS_PYTHON` to the installed interpreter
- fail the image build if the required `pty` standard-library module is unavailable

## Why

Docker-backed interactive and cancellation-safe shell commands launch the PTY bridge from the worker process. The sandbox image already contains Python, but that cannot satisfy a host-side bridge dependency. Without Python in the worker image, these commands fail with `SandboxConfigurationError` before `docker exec` starts.

## Verification

- built `docker/opengeni.Dockerfile` target `worker` for `linux/amd64`
- ran the exact Agents SDK `spawnInPseudoTerminal` implementation inside the built image and verified command output
- verified the image exposes `/usr/bin/python3`, imports `pty`, and retains the Docker CLI