### PR TITLE
feat(deploy): add a persistent elastic single-node profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,7 @@ jobs:
           bun run deployment:preflight -- --profile aws-managed --json
           bun run deployment:preflight -- --profile gcp-existing-services --json
           bun run deployment:preflight -- --profile gcp-managed --json
+          bun run deployment:preflight -- --profile single-node-kubernetes --json
           bun run deployment:preflight -- --profile preview-pr --json
           bun run deployment:preflight -- --profile preview-branch --json
 
@@ -477,6 +478,27 @@ jobs:
             --namespace opengeni-preview \
             -f deploy/helm/opengeni/values.preview-managed.example.yaml \
             >/tmp/opengeni-preview-rendered.yaml
+          helm template opengeni-single deploy/helm/opengeni \
+            --namespace opengeni \
+            -f deploy/helm/opengeni/values.single-node.example.yaml \
+            >/tmp/opengeni-single-rendered.yaml
+          if grep -qE '^kind: (HorizontalPodAutoscaler|PodDisruptionBudget)$' /tmp/opengeni-single-rendered.yaml; then
+            echo "single-node profile rendered an autoscaler or disruption budget" >&2
+            exit 1
+          fi
+          if grep -q '^          resources:' /tmp/opengeni-single-rendered.yaml; then
+            echo "single-node profile rendered container resource partitions" >&2
+            exit 1
+          fi
+          if grep -q 'OPENGENI_POSTGRES_PASSWORD' /tmp/opengeni-single-rendered.yaml; then
+            echo "single-node workloads received the Postgres owner password" >&2
+            exit 1
+          fi
+          test "$(grep -c '^  replicas: 1$' /tmp/opengeni-single-rendered.yaml)" -eq 9
+          test "$(grep -c '^      nodePort:' /tmp/opengeni-single-rendered.yaml)" -eq 5
+          for node_port in 30080 30081 30222 30443 30900; do
+            grep -q "^      nodePort: $node_port$" /tmp/opengeni-single-rendered.yaml
+          done
           for component in api worker-control worker-turns web; do
             if awk -v name="opengeni-preview-$component" '
               $1 == "kind:" && $2 == "PodDisruptionBudget" { pdb = 1; next }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,11 @@ jobs:
             echo "single-node workloads received the Postgres owner password" >&2
             exit 1
           fi
+          test "$(grep -c '^kind: PriorityClass$' /tmp/opengeni-single-rendered.yaml)" -eq 4
+          test "$(grep -c '^      priorityClassName: \"opengeni-single-presentation\"$' /tmp/opengeni-single-rendered.yaml)" -eq 2
+          test "$(grep -c '^      priorityClassName: \"opengeni-single-execution\"$' /tmp/opengeni-single-rendered.yaml)" -eq 1
+          test "$(grep -c '^      priorityClassName: \"opengeni-single-control\"$' /tmp/opengeni-single-rendered.yaml)" -eq 3
+          test "$(grep -c '^      priorityClassName: \"opengeni-single-durable\"$' /tmp/opengeni-single-rendered.yaml)" -eq 5
           test "$(grep -c '^  replicas: 1$' /tmp/opengeni-single-rendered.yaml)" -eq 9
           test "$(grep -c '^      nodePort:' /tmp/opengeni-single-rendered.yaml)" -eq 5
           for node_port in 30080 30081 30222 30443 30900; do

--- a/README.md
+++ b/README.md
@@ -229,7 +229,9 @@ The operator guide is in `docs/deployment.md`.
 Current deployment artifacts include:
 
 - A repo-owned deployment contract in `packages/deployment`.
-- A Helm chart for API, web, worker, migrations, and disposable local/smoke fixtures at `deploy/helm/opengeni`.
+- A Helm chart for API, web, worker, migrations, a persistent non-HA
+  single-machine profile, and disposable local/smoke fixtures at
+  `deploy/helm/opengeni`.
 - An Azure reference Terraform substrate at `deploy/terraform/azure`.
 - AWS and GCP reference Terraform substrates at `deploy/terraform/aws` and `deploy/terraform/gcp`.
 - Stack-wrapper plans that can install official upstream NATS and Temporal Helm charts outside the OpenGeni application chart.
@@ -242,7 +244,12 @@ bun run deployment:preflight -- --profile azure-existing-services
 bun run deployment:stack -- --profile gcp-managed
 ```
 
-Production operators should use managed services, existing endpoints, or official upstream charts/operators for Postgres, Temporal, NATS, secret delivery, ingress/TLS, and observability. The in-chart Postgres, Temporal, NATS, and MinIO templates are only for local, CI, and smoke verification. Keep cloud resource inventories, generated credentials, kubeconfigs, Terraform state, and filled tfvars in private operator-controlled storage outside the repository.
+The in-chart Postgres, Temporal, NATS, and MinIO templates support a persistent
+non-HA single-machine deployment as well as disposable local, CI, and smoke
+verification. Multi-node operators should use managed services, existing
+endpoints, or official upstream charts/operators. Keep cloud resource
+inventories, generated credentials, kubeconfigs, Terraform state, and filled
+tfvars in private operator-controlled storage outside the repository.
 
 ## Web App
 

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.3
-appVersion: "0.22.3"
+version: 0.22.4
+appVersion: "0.22.4"

--- a/deploy/helm/opengeni/templates/_helpers.tpl
+++ b/deploy/helm/opengeni/templates/_helpers.tpl
@@ -36,6 +36,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "opengeni.priorityClassName" -}}
+{{- $explicit := .explicit | default "" -}}
+{{- if $explicit -}}
+{{- $explicit -}}
+{{- else if .root.Values.priorityClasses.enabled -}}
+{{- printf "%s-%s" (include "opengeni.fullname" .root) .tier | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "opengeni.image" -}}
 {{- $registry := .root.Values.global.imageRegistry -}}
 {{- $repository := .image.repository -}}

--- a/deploy/helm/opengeni/templates/_helpers.tpl
+++ b/deploy/helm/opengeni/templates/_helpers.tpl
@@ -124,6 +124,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "opengeni.generatedRuntimeEnv" -}}
 {{- if .Values.postgres.enabled }}
+{{- if .Values.postgres.runtime.existingSecret }}
+- name: OPENGENI_DATABASE_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.postgres.runtime.existingSecret }}
+      key: {{ .Values.postgres.runtime.databaseUrlKey }}
+{{- else }}
 - name: OPENGENI_POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -131,6 +138,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       key: {{ .Values.postgres.auth.passwordKey }}
 - name: OPENGENI_DATABASE_URL
   value: {{ printf "postgres://%s:$(OPENGENI_POSTGRES_PASSWORD)@%s:%d/%s" .Values.postgres.auth.username (include "opengeni.postgresHost" .) (.Values.postgres.service.port | int) .Values.postgres.auth.database | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.temporal.enabled }}
 - name: OPENGENI_TEMPORAL_HOST

--- a/deploy/helm/opengeni/templates/api-deployment.yaml
+++ b/deploy/helm/opengeni/templates/api-deployment.yaml
@@ -74,8 +74,10 @@ spec:
           livenessProbe:
             {{- include "opengeni.httpProbe" (dict "probe" .Values.api.probes.liveness) | nindent 12 }}
           {{- end }}
+          {{- with .Values.api.resources }}
           resources:
-            {{- toYaml .Values.api.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- if .Values.api.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
         {{- include "opengeni.topologySpreadConstraints" (dict "root" . "component" "api" "values" .Values.api) | nindent 8 }}

--- a/deploy/helm/opengeni/templates/api-deployment.yaml
+++ b/deploy/helm/opengeni/templates/api-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.api.enabled }}
+{{- $priorityClassName := include "opengeni.priorityClassName" (dict "root" . "explicit" .Values.api.priorityClassName "tier" "control") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,8 +34,8 @@ spec:
       serviceAccountName: {{ include "opengeni.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       terminationGracePeriodSeconds: {{ .Values.api.terminationGracePeriodSeconds }}
-      {{- if .Values.api.priorityClassName }}
-      priorityClassName: {{ .Values.api.priorityClassName | quote }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.api.podSecurityContext | nindent 8 }}

--- a/deploy/helm/opengeni/templates/api-service.yaml
+++ b/deploy/helm/opengeni/templates/api-service.yaml
@@ -19,6 +19,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- with .Values.api.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "opengeni.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: api

--- a/deploy/helm/opengeni/templates/migration-job.yaml
+++ b/deploy/helm/opengeni/templates/migration-job.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.migrations.enabled .Values.api.enabled }}
+{{- $priorityClassName := include "opengeni.priorityClassName" (dict "root" . "explicit" .Values.migrations.priorityClassName "tier" "durable") }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -17,6 +18,9 @@ spec:
         app.kubernetes.io/component: migration
     spec:
       restartPolicy: Never
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
+      {{- end }}
       serviceAccountName: {{ include "opengeni.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.global.imagePullSecrets }}

--- a/deploy/helm/opengeni/templates/migration-job.yaml
+++ b/deploy/helm/opengeni/templates/migration-job.yaml
@@ -31,13 +31,19 @@ spec:
             {{- toYaml .Values.migrations.command | nindent 12 }}
           envFrom:
             - secretRef:
+                name: {{ include "opengeni.secretName" . }}
+            {{- if ne (include "opengeni.migrationSecretName" .) (include "opengeni.secretName" .) }}
+            - secretRef:
                 name: {{ include "opengeni.migrationSecretName" . }}
+            {{- end }}
             - configMapRef:
                 name: {{ include "opengeni.fullname" . }}-config
           {{- if or .Values.postgres.enabled .Values.temporal.enabled .Values.minio.enabled }}
           env:
             {{- include "opengeni.generatedRuntimeEnv" . | nindent 12 }}
           {{- end }}
+          {{- with .Values.migrations.resources }}
           resources:
-            {{- toYaml .Values.migrations.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/deploy/helm/opengeni/templates/minio-bucket-job.yaml
+++ b/deploy/helm/opengeni/templates/minio-bucket-job.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.minio.enabled }}
+{{- $priorityClassName := include "opengeni.priorityClassName" (dict "root" . "explicit" .Values.minio.priorityClassName "tier" "durable") }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -19,6 +20,9 @@ spec:
         app.kubernetes.io/component: minio-bucket
     spec:
       restartPolicy: Never
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: mc
           image: {{ printf "%s:%s" .Values.minio.mcImage.repository .Values.minio.mcImage.tag | quote }}

--- a/deploy/helm/opengeni/templates/minio-edge-service.yaml
+++ b/deploy/helm/opengeni/templates/minio-edge-service.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.minio.enabled .Values.minio.edgeService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opengeni.fullname" . }}-minio-edge
+  labels:
+    {{- include "opengeni.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  type: {{ .Values.minio.edgeService.type }}
+  ports:
+    - name: api
+      port: {{ .Values.minio.service.apiPort }}
+      targetPort: api
+      {{- with .Values.minio.edgeService.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+  selector:
+    {{- include "opengeni.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+{{- end }}

--- a/deploy/helm/opengeni/templates/minio-statefulset.yaml
+++ b/deploy/helm/opengeni/templates/minio-statefulset.yaml
@@ -60,8 +60,10 @@ spec:
               port: api
             initialDelaySeconds: 30
             periodSeconds: 20
+          {{- with .Values.minio.resources }}
           resources:
-            {{- toYaml .Values.minio.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data

--- a/deploy/helm/opengeni/templates/minio-statefulset.yaml
+++ b/deploy/helm/opengeni/templates/minio-statefulset.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.minio.enabled }}
+{{- $priorityClassName := include "opengeni.priorityClassName" (dict "root" . "explicit" .Values.minio.priorityClassName "tier" "durable") }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -19,6 +20,9 @@ spec:
         {{- include "opengeni.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: minio
     spec:
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: minio
           image: {{ printf "%s:%s" .Values.minio.image.repository .Values.minio.image.tag | quote }}

--- a/deploy/helm/opengeni/templates/nats-deployment.yaml
+++ b/deploy/helm/opengeni/templates/nats-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.nats.enabled }}
+{{- $priorityClassName := include "opengeni.priorityClassName" (dict "root" . "explicit" .Values.nats.priorityClassName "tier" "control") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +23,9 @@ spec:
         checksum/nats-config: {{ include (print $.Template.BasePath "/nats-configmap.yaml") . | sha256sum }}
       {{- end }}
     spec:
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: nats
           image: {{ printf "%s:%s" .Values.nats.image.repository .Values.nats.image.tag | quote }}

--- a/deploy/helm/opengeni/templates/nats-deployment.yaml
+++ b/deploy/helm/opengeni/templates/nats-deployment.yaml
@@ -77,8 +77,10 @@ spec:
               port: monitor
             initialDelaySeconds: 20
             periodSeconds: 20
+          {{- with .Values.nats.resources }}
           resources:
-            {{- toYaml .Values.nats.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.nats.authCallout.enabled }}
           volumeMounts:
             - name: nats-config

--- a/deploy/helm/opengeni/templates/nats-websocket-edge-service.yaml
+++ b/deploy/helm/opengeni/templates/nats-websocket-edge-service.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.nats.enabled .Values.nats.authCallout.enabled .Values.nats.websocketEdgeService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opengeni.fullname" . }}-nats-websocket-edge
+  labels:
+    {{- include "opengeni.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nats
+spec:
+  type: {{ .Values.nats.websocketEdgeService.type }}
+  ports:
+    - name: websocket
+      port: {{ .Values.nats.authCallout.websocketPort }}
+      targetPort: websocket
+      {{- with .Values.nats.websocketEdgeService.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+  selector:
+    {{- include "opengeni.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: nats
+{{- end }}

--- a/deploy/helm/opengeni/templates/postgres-statefulset.yaml
+++ b/deploy/helm/opengeni/templates/postgres-statefulset.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.postgres.enabled }}
+{{- $priorityClassName := include "opengeni.priorityClassName" (dict "root" . "explicit" .Values.postgres.priorityClassName "tier" "durable") }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -19,6 +20,9 @@ spec:
         {{- include "opengeni.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: postgres
     spec:
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.postgres.podSecurityContext | nindent 8 }}
       containers:

--- a/deploy/helm/opengeni/templates/postgres-statefulset.yaml
+++ b/deploy/helm/opengeni/templates/postgres-statefulset.yaml
@@ -58,8 +58,10 @@ spec:
                 - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
             initialDelaySeconds: 30
             periodSeconds: 20
+          {{- with .Values.postgres.resources }}
           resources:
-            {{- toYaml .Values.postgres.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data

--- a/deploy/helm/opengeni/templates/priority-classes.yaml
+++ b/deploy/helm/opengeni/templates/priority-classes.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.priorityClasses.enabled }}
+{{- range $tier, $class := .Values.priorityClasses.tiers }}
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ printf "%s-%s" (include "opengeni.fullname" $) $tier | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "opengeni.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: pod-priority
+value: {{ $class.value }}
+globalDefault: false
+preemptionPolicy: {{ $.Values.priorityClasses.preemptionPolicy }}
+description: {{ $class.description | quote }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/opengeni/templates/relay-deployment.yaml
+++ b/deploy/helm/opengeni/templates/relay-deployment.yaml
@@ -121,8 +121,10 @@ spec:
               sleep:
                 seconds: {{ .Values.relay.preStopDrainSeconds }}
           {{- end }}
+          {{- with .Values.relay.resources }}
           resources:
-            {{- toYaml .Values.relay.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- if .Values.relay.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
         {{- include "opengeni.topologySpreadConstraints" (dict "root" . "component" "relay" "values" .Values.relay) | nindent 8 }}

--- a/deploy/helm/opengeni/templates/relay-deployment.yaml
+++ b/deploy/helm/opengeni/templates/relay-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.relay.enabled }}
+{{- $priorityClassName := include "opengeni.priorityClassName" (dict "root" . "explicit" .Values.relay.priorityClassName "tier" "presentation") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,8 +33,8 @@ spec:
       serviceAccountName: {{ include "opengeni.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       terminationGracePeriodSeconds: {{ .Values.relay.terminationGracePeriodSeconds }}
-      {{- if .Values.relay.priorityClassName }}
-      priorityClassName: {{ .Values.relay.priorityClassName | quote }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.relay.podSecurityContext | nindent 8 }}

--- a/deploy/helm/opengeni/templates/relay-service.yaml
+++ b/deploy/helm/opengeni/templates/relay-service.yaml
@@ -19,6 +19,9 @@ spec:
       targetPort: wss
       protocol: TCP
       name: wss
+      {{- with .Values.relay.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "opengeni.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: relay

--- a/deploy/helm/opengeni/templates/temporal-deployment.yaml
+++ b/deploy/helm/opengeni/templates/temporal-deployment.yaml
@@ -65,6 +65,8 @@ spec:
               port: grpc
             initialDelaySeconds: 60
             periodSeconds: 20
+          {{- with .Values.temporal.resources }}
           resources:
-            {{- toYaml .Values.temporal.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/deploy/helm/opengeni/templates/temporal-deployment.yaml
+++ b/deploy/helm/opengeni/templates/temporal-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.temporal.enabled }}
+{{- $priorityClassName := include "opengeni.priorityClassName" (dict "root" . "explicit" .Values.temporal.priorityClassName "tier" "durable") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,6 +19,9 @@ spec:
         {{- include "opengeni.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: temporal
     spec:
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.temporal.podSecurityContext | nindent 8 }}
       containers:

--- a/deploy/helm/opengeni/templates/web-deployment.yaml
+++ b/deploy/helm/opengeni/templates/web-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.web.enabled }}
+{{- $priorityClassName := include "opengeni.priorityClassName" (dict "root" . "explicit" .Values.web.priorityClassName "tier" "presentation") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,8 +31,8 @@ spec:
       serviceAccountName: {{ include "opengeni.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       terminationGracePeriodSeconds: {{ .Values.web.terminationGracePeriodSeconds }}
-      {{- if .Values.web.priorityClassName }}
-      priorityClassName: {{ .Values.web.priorityClassName | quote }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.web.podSecurityContext | nindent 8 }}

--- a/deploy/helm/opengeni/templates/web-deployment.yaml
+++ b/deploy/helm/opengeni/templates/web-deployment.yaml
@@ -64,8 +64,10 @@ spec:
           livenessProbe:
             {{- include "opengeni.httpProbe" (dict "probe" .Values.web.probes.liveness) | nindent 12 }}
           {{- end }}
+          {{- with .Values.web.resources }}
           resources:
-            {{- toYaml .Values.web.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- if .Values.web.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
         {{- include "opengeni.topologySpreadConstraints" (dict "root" . "component" "web" "values" .Values.web) | nindent 8 }}

--- a/deploy/helm/opengeni/templates/web-service.yaml
+++ b/deploy/helm/opengeni/templates/web-service.yaml
@@ -13,6 +13,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- with .Values.web.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "opengeni.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: web

--- a/deploy/helm/opengeni/templates/worker-deployment.yaml
+++ b/deploy/helm/opengeni/templates/worker-deployment.yaml
@@ -90,8 +90,10 @@ spec:
           livenessProbe:
             {{- include "opengeni.httpProbe" (dict "probe" ((.Values.worker).probes).liveness) | nindent 12 }}
           {{- end }}
+          {{- with .Values.worker.control.resources }}
           resources:
-            {{- toYaml .Values.worker.control.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- if ((.Values.worker).topologySpreadConstraints).enabled }}
       topologySpreadConstraints:
         {{- include "opengeni.topologySpreadConstraints" (dict "root" . "component" "worker-control" "values" .Values.worker) | nindent 8 }}

--- a/deploy/helm/opengeni/templates/worker-deployment.yaml
+++ b/deploy/helm/opengeni/templates/worker-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.worker.enabled }}
+{{- $priorityClassName := include "opengeni.priorityClassName" (dict "root" . "explicit" (.Values.worker.control.priorityClassName | default .Values.worker.priorityClassName) "tier" "control") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,8 +35,8 @@ spec:
       serviceAccountName: {{ include "opengeni.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
-      {{- if .Values.worker.priorityClassName }}
-      priorityClassName: {{ .Values.worker.priorityClassName | quote }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}

--- a/deploy/helm/opengeni/templates/worker-turns-deployment.yaml
+++ b/deploy/helm/opengeni/templates/worker-turns-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.worker.enabled }}
+{{- $priorityClassName := include "opengeni.priorityClassName" (dict "root" . "explicit" (.Values.worker.turns.priorityClassName | default .Values.worker.priorityClassName) "tier" "execution") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,8 +35,8 @@ spec:
       serviceAccountName: {{ include "opengeni.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
-      {{- if .Values.worker.priorityClassName }}
-      priorityClassName: {{ .Values.worker.priorityClassName | quote }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}

--- a/deploy/helm/opengeni/templates/worker-turns-deployment.yaml
+++ b/deploy/helm/opengeni/templates/worker-turns-deployment.yaml
@@ -81,8 +81,10 @@ spec:
           livenessProbe:
             {{- include "opengeni.httpProbe" (dict "probe" ((.Values.worker).probes).liveness) | nindent 12 }}
           {{- end }}
+          {{- with .Values.worker.turns.resources }}
           resources:
-            {{- toYaml .Values.worker.turns.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- if ((.Values.worker).topologySpreadConstraints).enabled }}
       topologySpreadConstraints:
         {{- include "opengeni.topologySpreadConstraints" (dict "root" . "component" "worker-turns" "values" .Values.worker) | nindent 8 }}

--- a/deploy/helm/opengeni/values.local-kubernetes.example.yaml
+++ b/deploy/helm/opengeni/values.local-kubernetes.example.yaml
@@ -57,6 +57,9 @@ migrations:
     tag: local-k8s
     pullPolicy: IfNotPresent
   backoffLimit: 12
+  secret:
+    # This disposable profile keeps all DB identities in one test-only Secret.
+    existingSecret: opengeni-runtime-local-k8s
 
 secret:
   create: false
@@ -72,6 +75,9 @@ config:
 
 postgres:
   enabled: true
+  runtime:
+    existingSecret: opengeni-runtime-local-k8s
+    databaseUrlKey: OPENGENI_DATABASE_URL
   persistence:
     size: 2Gi
 

--- a/deploy/helm/opengeni/values.preview-managed.example.yaml
+++ b/deploy/helm/opengeni/values.preview-managed.example.yaml
@@ -46,6 +46,8 @@ web:
 
 migrations:
   backoffLimit: 12
+  secret:
+    existingSecret: opengeni-migrations
 
 secret:
   create: false
@@ -72,6 +74,9 @@ config:
 
 postgres:
   enabled: true
+  runtime:
+    existingSecret: opengeni-runtime
+    databaseUrlKey: OPENGENI_DATABASE_URL
   persistence:
     size: 2Gi
 

--- a/deploy/helm/opengeni/values.single-node.example.yaml
+++ b/deploy/helm/opengeni/values.single-node.example.yaml
@@ -5,6 +5,9 @@
 # Bootstrap in two phases so Postgres/Temporal/NATS/MinIO are healthy before the
 # pre-upgrade migration/role/posture gate runs. See docs/deployment.md.
 
+priorityClasses:
+  enabled: true
+
 api:
   replicaCount: 1
   resources: null

--- a/deploy/helm/opengeni/values.single-node.example.yaml
+++ b/deploy/helm/opengeni/values.single-node.example.yaml
@@ -1,0 +1,178 @@
+# Supported non-HA, single-machine profile. Every process has one replica and
+# shares the host dynamically: no HPA, topology spreading, PDB, CPU quota, or
+# per-pod memory partition. Excess turns remain durable in Temporal.
+#
+# Bootstrap in two phases so Postgres/Temporal/NATS/MinIO are healthy before the
+# pre-upgrade migration/role/posture gate runs. See docs/deployment.md.
+
+api:
+  replicaCount: 1
+  resources: null
+  topologySpreadConstraints:
+    enabled: false
+  podDisruptionBudget:
+    enabled: false
+  autoscaling:
+    enabled: false
+  service:
+    type: NodePort
+    port: 8000
+    nodePort: 30081
+
+worker:
+  control:
+    replicaCount: 1
+    resources: null
+    podDisruptionBudget:
+      enabled: false
+    autoscaling:
+      enabled: false
+  turns:
+    replicaCount: 1
+    resources: null
+    podDisruptionBudget:
+      enabled: false
+    autoscaling:
+      enabled: false
+  topologySpreadConstraints:
+    enabled: false
+
+web:
+  replicaCount: 1
+  resources: null
+  topologySpreadConstraints:
+    enabled: false
+  podDisruptionBudget:
+    enabled: false
+  autoscaling:
+    enabled: false
+  service:
+    type: NodePort
+    port: 3000
+    nodePort: 30080
+
+relay:
+  enabled: true
+  replicaCount: 1
+  resources: null
+  topologySpreadConstraints:
+    enabled: false
+  podDisruptionBudget:
+    enabled: false
+  autoscaling:
+    enabled: false
+  service:
+    type: NodePort
+    port: 8443
+    nodePort: 30443
+
+migrations:
+  resources: null
+  secret:
+    existingSecret: opengeni-migrations
+
+secret:
+  create: false
+  existingSecret: opengeni-runtime
+
+config:
+  OPENGENI_SERVICE_NAME: opengeni
+  OPENGENI_ENVIRONMENT: single-node
+  OPENGENI_DEPLOYMENT_REVISION: single-node
+  OPENGENI_API_HOST: 0.0.0.0
+  OPENGENI_API_PORT: "8000"
+  OPENGENI_WORKER_HTTP_PORT: "8001"
+  OPENGENI_TEMPORAL_NAMESPACE: default
+  OPENGENI_TEMPORAL_TASK_QUEUE: opengeni-runs-ts
+  OPENGENI_STARTUP_DEPENDENCY_RETRY_ATTEMPTS: "30"
+  OPENGENI_STARTUP_DEPENDENCY_RETRY_INITIAL_DELAY_MS: "1000"
+  OPENGENI_STARTUP_DEPENDENCY_RETRY_MAX_DELAY_MS: "5000"
+  OPENGENI_AUTH_REQUIRED: "false"
+  OPENGENI_AUTH_ALLOW_HEALTH: "true"
+  OPENGENI_AUTH_ALLOW_METRICS: "false"
+  OPENGENI_PRODUCT_ACCESS_MODE: local
+  OPENGENI_BILLING_MODE: disabled
+  OPENGENI_ENTITLEMENTS_MODE: none
+  OPENGENI_USAGE_LIMITS_MODE: none
+  OPENGENI_OBJECT_STORAGE_BACKEND: s3-compatible
+  OPENGENI_OBJECT_STORAGE_BUCKET: opengeni-files
+  OPENGENI_OBJECT_STORAGE_REGION: us-east-1
+  OPENGENI_OBJECT_STORAGE_S3_PROVIDER: Minio
+  OPENGENI_OBJECT_STORAGE_FORCE_PATH_STYLE: "true"
+  OPENGENI_SANDBOX_BACKEND: selfhosted
+  OPENGENI_SANDBOX_PREPARATION_PROFILES: none
+
+postgres:
+  enabled: true
+  auth:
+    database: opengeni
+    username: opengeni
+    existingSecret: opengeni-postgres
+    passwordKey: POSTGRES_PASSWORD
+  runtime:
+    existingSecret: opengeni-runtime
+    databaseUrlKey: OPENGENI_DATABASE_URL
+  resources: null
+  persistence:
+    enabled: true
+    size: 20Gi
+
+temporal:
+  enabled: true
+  resources: null
+
+nats:
+  enabled: true
+  resources: null
+  authCallout:
+    enabled: true
+  websocketEdgeService:
+    enabled: true
+    type: NodePort
+    nodePort: 30222
+
+minio:
+  enabled: true
+  auth:
+    existingSecret: opengeni-minio
+    accessKeyKey: MINIO_ROOT_USER
+    secretKeyKey: MINIO_ROOT_PASSWORD
+  # Set this to the private edge URL browsers use for signed file transfers.
+  # Example: https://node.example-tailnet.ts.net:9443
+  publicEndpoint: ""
+  resources: null
+  service:
+    apiPort: 9000
+    consolePort: 9001
+  edgeService:
+    enabled: true
+    type: NodePort
+    nodePort: 30900
+  persistence:
+    enabled: true
+    size: 20Gi
+
+selfhosted:
+  enabled: true
+  # Set these to private wss URLs exposed by the deployment edge.
+  natsUrl: ""
+  relayUrl: ""
+  natsCalloutAccountName: APP
+  natsControlUser: control
+  natsCalloutUser: auth
+
+ingress:
+  enabled: false
+
+observability:
+  structuredLogs: true
+  metrics:
+    enabled: true
+  serviceMonitor:
+    enabled: false
+  prometheusRule:
+    enabled: false
+  otel:
+    enabled: false
+  collector:
+    enabled: false

--- a/deploy/helm/opengeni/values.yaml
+++ b/deploy/helm/opengeni/values.yaml
@@ -15,6 +15,27 @@ serviceAccount:
   annotations: {}
   automountServiceAccountToken: false
 
+# Optional release-local Pod priority tiers. They do not reserve or cap CPU or
+# memory. They tell the kubelet which OpenGeni roles to evict first when the
+# node is under pressure. `Never` keeps priority from preempting a running pod
+# merely to admit another one.
+priorityClasses:
+  enabled: false
+  preemptionPolicy: Never
+  tiers:
+    presentation:
+      value: 1000
+      description: Restartable browser and live-stream presentation.
+    execution:
+      value: 2000
+      description: Restartable turn execution with durable Temporal recovery.
+    control:
+      value: 3000
+      description: API, machine transport, and orchestration control.
+    durable:
+      value: 4000
+      description: Durable database, workflow, object storage, and upgrade gates.
+
 networkPolicy:
   enabled: false
   egress:
@@ -201,6 +222,7 @@ worker:
   containerPort: 8001
   control:
     replicaCount: 2
+    priorityClassName: ""
     strategy:
       type: RollingUpdate
       rollingUpdate:
@@ -226,6 +248,7 @@ worker:
       behavior: {}
   turns:
     replicaCount: 4
+    priorityClassName: ""
     strategy:
       type: RollingUpdate
       rollingUpdate:
@@ -487,6 +510,7 @@ relay:
 
 migrations:
   enabled: true
+  priorityClassName: ""
   image:
     repository: opengeni-api
     # Empty tag resolves to the chart appVersion via the opengeni.image helper.
@@ -525,6 +549,7 @@ migrations:
 # an existing database, or an upstream Postgres operator.
 postgres:
   enabled: false
+  priorityClassName: ""
   image:
     repository: pgvector/pgvector
     tag: pg17
@@ -562,6 +587,7 @@ postgres:
 # existing Temporal endpoint, or the official Temporal chart.
 temporal:
   enabled: false
+  priorityClassName: ""
   image:
     repository: temporalio/auto-setup
     tag: "1.28"
@@ -594,6 +620,7 @@ temporal:
 # GCS, or another external object store.
 minio:
   enabled: false
+  priorityClassName: ""
   image:
     repository: minio/minio
     tag: RELEASE.2025-09-07T16-13-09Z
@@ -731,6 +758,7 @@ ingress:
 # endpoint or the official NATS chart.
 nats:
   enabled: false
+  priorityClassName: ""
   url: ""
   image:
     repository: nats

--- a/deploy/helm/opengeni/values.yaml
+++ b/deploy/helm/opengeni/values.yaml
@@ -181,6 +181,8 @@ api:
   service:
     type: ClusterIP
     port: 8000
+    # Optional fixed NodePort for single-node/private-edge deployments.
+    nodePort: null
   autoscaling:
     enabled: false
     minReplicas: 2
@@ -364,6 +366,8 @@ web:
   service:
     type: ClusterIP
     port: 3000
+    # Optional fixed NodePort for single-node/private-edge deployments.
+    nodePort: null
   autoscaling:
     enabled: false
     minReplicas: 2
@@ -467,6 +471,8 @@ relay:
   service:
     type: ClusterIP
     port: 8443
+    # Optional fixed NodePort for single-node/private-edge deployments.
+    nodePort: null
   autoscaling:
     enabled: true
     minReplicas: 2
@@ -494,7 +500,13 @@ migrations:
     # runtime Secret here; API/worker receive only the restricted runtime URL.
     # Empty reuse is retained only for disposable conformance fixtures.
     existingSecret: ""
-  command: ["bun", "run", "db:migrate"]
+  # The pre-upgrade hook is the rollout gate: schema first, then exact runtime
+  # grants, then a connection through the restricted runtime identity. Helm
+  # does not begin replacing API/worker pods unless all three steps succeed.
+  command:
+    - /bin/sh
+    - -ec
+    - bun run db:migrate && bun run db:provision-roles && bun run db:assert-runtime-posture
   backoffLimit: 6
   annotations:
     helm.sh/hook: post-install,pre-upgrade
@@ -508,8 +520,9 @@ migrations:
       cpu: 500m
       memory: 512Mi
 
-# Disposable dependency fixture for local Kubernetes, CI, previews, and smoke tests.
-# Use managed Postgres, an existing database, or an upstream Postgres operator for production.
+# Embedded Postgres for disposable conformance stacks and the persistent non-HA
+# single-machine profile. Multi-node deployments should use managed Postgres,
+# an existing database, or an upstream Postgres operator.
 postgres:
   enabled: false
   image:
@@ -522,6 +535,11 @@ postgres:
     password: opengeni
     existingSecret: ""
     passwordKey: POSTGRES_PASSWORD
+  runtime:
+    # When set, API/worker/migration Jobs read the restricted runtime URL from
+    # this Secret instead of constructing an owner URL from postgres.auth.
+    existingSecret: ""
+    databaseUrlKey: OPENGENI_DATABASE_URL
   service:
     port: 5432
   persistence:
@@ -539,8 +557,9 @@ postgres:
     fsGroup: 999
   securityContext: {}
 
-# Disposable dependency fixture for local Kubernetes, CI, previews, and smoke tests.
-# Use Temporal Cloud, an existing Temporal endpoint, or the official Temporal chart for production.
+# Embedded Temporal for disposable conformance stacks and the persistent non-HA
+# single-machine profile. Multi-node deployments should use Temporal Cloud, an
+# existing Temporal endpoint, or the official Temporal chart.
 temporal:
   enabled: false
   image:
@@ -570,8 +589,9 @@ temporal:
       drop:
         - ALL
 
-# Disposable dependency fixture for local Kubernetes, CI, previews, and smoke tests.
-# Use Azure Blob, AWS S3, GCS, or another production object-store integration for production.
+# Embedded MinIO for disposable conformance stacks and the persistent non-HA
+# single-machine profile. Multi-node deployments should use Azure Blob, AWS S3,
+# GCS, or another external object store.
 minio:
   enabled: false
   image:
@@ -595,6 +615,12 @@ minio:
   service:
     apiPort: 9000
     consolePort: 9001
+  # Optional one-port edge service. Keep the ordinary MinIO service private;
+  # this exposes only the signed object API, never the admin console.
+  edgeService:
+    enabled: false
+    type: ClusterIP
+    nodePort: null
   persistence:
     enabled: true
     size: 20Gi
@@ -700,8 +726,9 @@ ingress:
             service: api
     tls: []
 
-# Disposable dependency fixture for local Kubernetes, CI, previews, and smoke tests.
-# Use an existing NATS endpoint or the official NATS chart for production.
+# Embedded NATS for disposable conformance stacks and the persistent non-HA
+# single-machine profile. Multi-node deployments should use an existing NATS
+# endpoint or the official NATS chart.
 nats:
   enabled: false
   url: ""
@@ -712,6 +739,12 @@ nats:
   replicaCount: 1
   clientPort: 4222
   monitorPort: 8222
+  # Optional one-port edge service. Keep the ordinary NATS client and monitor
+  # ports private; connected machines need only the websocket listener.
+  websocketEdgeService:
+    enabled: false
+    type: ClusterIP
+    nodePort: null
   resources:
     requests:
       cpu: 100m
@@ -729,9 +762,9 @@ nats:
   # JWT. The secret VALUES (callout issuer public key, control/auth passwords)
   # come from the runtime secret via env-var expansion — never the configmap.
   #
-  # Production typically runs NATS outside this chart (nats.enabled=false) and
-  # folds the SAME auth-callout.conf into the platform NATS StatefulSet. This
-  # block is the in-chart fixture for preview/smoke + the documented config shape.
+  # Multi-node deployments typically run NATS outside this chart
+  # (nats.enabled=false) and fold the SAME auth-callout.conf into the platform
+  # NATS StatefulSet. This block is also the supported single-machine broker.
   authCallout:
     enabled: false
     # The websocket listener port (TLS terminates at the ingress; no_tls here).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,12 +52,25 @@ Core value props in one line: **durable + recoverable + streamable + multi-tenan
 
 These are the load-bearing, cross-cutting rules. Breaking one tends to be a subtle correctness or security bug, not a compile error. Each is stated as an imperative rule with its canonical anchor.
 
-### 3.1 Postgres is the durable source of truth; NATS is realtime fanout only
+### 3.1 Postgres is durable truth; NATS is an ephemeral transport
 
-> Postgres remembers, NATS broadcasts.
+> Postgres remembers; NATS transports.
 
-- **Write durable, then publish best-effort.** `appendAndPublishEvents` writes the DB (system of record) **then** best-effort-publishes to NATS. _"The DB append above is the durable system of record; the publish is only a best-effort LIVE fan-out."_ **Never publish without a prior durable append; never reverse the order.**
-- **A NATS blip must never kill an in-flight turn.** `publish()` must not throw the run to death; consumers reconcile missed live events from the durable log.
+- **Session-event fanout is best-effort.** `appendAndPublishEvents` writes the DB
+  (system of record) **then** best-effort-publishes to NATS. Never publish an
+  authoritative session event without a prior durable append; never reverse the
+  order. A fanout failure must not kill an in-flight turn because consumers
+  reconcile missed events from the durable log.
+- **Connected-machine commands also use NATS.** Agent request/reply, streamed
+  operation frames, heartbeats, and enrollment auth callout all cross the same
+  broker. They are live transport, not durable broker state. A broker restart
+  loses no session history, but connected machines are unreachable until
+  clients reconnect; affected operations surface typed offline/timeout outcomes.
+- **NATS is therefore restartable, not optional.** API and worker startup require
+  a connection and readiness turns unhealthy during a disconnect. Already
+  committed state and queued Temporal work survive, while new or active
+  connected-machine execution waits, retries at its owning boundary, or fails
+  visibly.
 - **Missed events are backfilled from Postgres by `sequence`.** The SSE stream replays durable events in bounded pages, subscribes live, and on a sequence gap **backfills from the DB**, deduping by sequence. During replay or slow-client delivery it retains only the newest live notification and then gap-fills, so a hot producer cannot create an unbounded API or NATS-client buffer. Each session and workspace-control HTTP body queues at most one complete frame of at most 96 KiB. A second write waits on `desiredSize` for at most 30 seconds; a still-stalled reader is disconnected, its upstream subscription is released, and the SDK reconnects from the last sequence it actually observed. Fixed-cardinality `stream`/`reason` counters expose queue pressure, timeout, and impossible oversized-frame failures without tenant identifiers. The streaming core _refuses to deliver with a gap or without monotonic cursor progress_ (it throws rather than skip or spin).
 - **Reads never ride the bus.** Channel-A point reads go client→API→box in-process; only side-effect notifications (`fs.changed`/`git.changed`/`terminal.pty.*`) are appended+published. Putting reads on the bus would corrupt SSE gap-fill.
 - **Gateway failures cross one bounded typed boundary.** The browser/SDK sends a bounded safe `x-opengeni-correlation-id`; the API validates or replaces it, returns it, and emits typed JSON error envelopes. The SDK retains only structured JSON error bodies up to 16 KiB and discards raw proxy HTML/plain text. A raw `502`/`503`/`504` or unexpected successful non-JSON response to a mutation is outcome-unknown: callers reconcile before retrying and reuse the exact idempotency key rather than manufacturing a new operation. The React composer preserves draft text/resources through these failures and reuses the same Send/Steer `clientEventId`. Error metrics use only fixed-cardinality route/status/code labels, never tenant or correlation identifiers.
@@ -225,7 +238,7 @@ The web bundle ships no production adapter and therefore fails closed.
 
 ## 4. System architecture
 
-Public clients talk only to the **Hono API**. The API authenticates/authorizes at the workspace boundary, persists durable state to **Postgres**, drives orchestration via **Temporal**, and fans out live events over **NATS Core**. A **Temporal worker** runs each agent turn as a non-retryable activity — inside a provisioned **sandbox backend**, or **directly on a Connected Machine** (the `selfhosted` primary-compute path, §3.8).
+Public clients talk only to the **Hono API**. The API authenticates/authorizes at the workspace boundary, persists durable state to **Postgres**, drives orchestration via **Temporal**, and uses **NATS Core** for live event fanout and Connected Machine transport. A **Temporal worker** runs each agent turn as a non-retryable activity — inside a provisioned **sandbox backend**, or **directly on a Connected Machine** (the `selfhosted` primary-compute path, §3.8).
 
 ### 4.1 Live path vs durable path
 
@@ -238,8 +251,9 @@ flowchart LR
   PG[("Postgres<br/>DURABLE truth")]
   TQ["Temporal<br/>session workflow"]
   W["Worker (apps/worker)<br/>runAgentTurn activity"]
-  SB["Sandbox backend<br/>11 backends"]
-  NATS(["NATS Core<br/>LIVE fanout only"])
+  SB["Provisioned sandbox backend"]
+  CM["Connected Machine"]
+  NATS(["NATS Core<br/>ephemeral live transport"])
 
   Client -->|"POST events / GET stream"| API
   API ==>|"1. durable append (system of record)"| PG
@@ -247,6 +261,8 @@ flowchart LR
   API -->|"signalWithStart"| TQ
   TQ -->|"dispatch turn"| W
   W <-->|"exec / fs / git"| SB
+  W <-->|"request/reply + op stream"| NATS
+  NATS <-->|"workspace-scoped agent transport"| CM
   W ==>|"appendAndPublishEvents: durable first"| PG
   W -.->|"then best-effort live"| NATS
   NATS -.->|"live SSE"| API
@@ -258,7 +274,10 @@ flowchart LR
 ```
 
 - **Thick arrows (`==>`) are the durable path** — the system of record. Everything else can be lost and rebuilt from it.
-- **Dotted arrows (`-.->`) are the live path** — best-effort, fast, never load-bearing for correctness.
+- **Dotted fanout arrows (`-.->`) are reconstructible live notifications.**
+  Connected-machine arrows are also ephemeral, but they carry real commands:
+  losing them does not lose durable history, yet execution cannot continue until
+  transport recovers.
 - The SSE stream **starts** from durable replay (`after` cursor), **subscribes** live, and on a sequence gap **backfills** from Postgres — so a client that misses live events never sees a gap.
 
 ### 4.2 How a request becomes an agent run (narration)
@@ -404,7 +423,7 @@ A Cargo workspace building the box-side binary for the `selfhosted` backend. `ag
 
 ### 6.4 Deployment (`deploy/`)
 
-`deploy/helm/opengeni` (the chart — owns api/web/worker/relay/migrations plus the optional Terraform Registry MCP docs service; in-chart Postgres/Temporal/NATS/MinIO are **disposable fixtures**), `deploy/terraform/{azure,aws,gcp}` (per-cloud roots), `deploy/stacks` (wrappers for deps managed outside the chart), `deploy/nats/auth-callout.conf` (BYO-compute tenancy boundary). See §12.
+`deploy/helm/opengeni` (the chart — owns api/web/worker/relay/migrations plus the optional Terraform Registry MCP docs service; its in-chart Postgres/Temporal/NATS/MinIO support disposable conformance stacks and the explicit persistent non-HA single-machine profile), `deploy/terraform/{azure,aws,gcp}` (per-cloud roots), `deploy/stacks` (wrappers for deps managed outside the chart), `deploy/nats/auth-callout.conf` (BYO-compute tenancy boundary). See §12.
 
 ### 6.5 Docs, scripts, test
 
@@ -635,9 +654,9 @@ The current map:
 
 ## 12. Deployment
 
-A typed `DeploymentContract` (`@opengeni/deployment`) turns an abstract profile into validated deploy plans: required env, preflight checks, Terraform/Helm targets, and generated artifacts. **12 built-in profiles** (local-compose, local-kubernetes, kubernetes-external, {azure,aws,gcp}-{managed,existing-services}, preview-pr, preview-branch, self-contained-kubernetes) + **product overlays** (none / managed-saas-staging / managed-saas-production, which hard-override sandbox→modal and access→externalGateway).
+A typed `DeploymentContract` (`@opengeni/deployment`) turns an abstract profile into validated deploy plans: required env, preflight checks, Terraform/Helm targets, and generated artifacts. The built-in profile registry lives in `packages/deployment/src/index.ts`; product overlays hard-override sandbox and access posture for managed SaaS staging/production.
 
-- **What OpenGeni owns vs disposable fixtures.** The chart (`deploy/helm/opengeni`) owns **api/web/worker/relay/migrations**, plus optional app-adjacent integrations such as the Terraform Registry MCP docs service. The in-chart **Postgres/Temporal/NATS/MinIO are disposable conformance fixtures** (default `enabled:false`) — _not production services_. Official NATS/Temporal are lifecycle-managed by the stack wrappers (`deploy/stacks`), outside the app chart; official Temporal needs an **existing** Postgres.
+- **What OpenGeni owns.** The chart (`deploy/helm/opengeni`) owns **api/web/worker/relay/migrations**, plus optional app-adjacent integrations such as the Terraform Registry MCP docs service. In-chart **Postgres/Temporal/NATS/MinIO** serve both disposable conformance stacks (default `enabled:false`) and the explicit persistent non-HA single-machine profile. Multi-node profiles keep platform dependencies outside the app chart through managed/existing services or the stack wrappers (`deploy/stacks`).
 - **Secrets never reach Helm values.** `generateRuntimeArtifacts` puts sensitive Terraform outputs only into `runtime.env` (and records them in `sensitiveTerraformOutputsUsed`); generated files carry "Do not commit generated copies."
 - **Parity (not import).** `@opengeni/deployment`'s `SANDBOX_REQUIRED_ENV` and `SandboxBackend` _mirror_ `@opengeni/config`/`@opengeni/contracts` — enforced by **tests, not the type system**. Edit one side without the other and it compiles but the parity test goes red.
 - **Conformance.** `scripts/deployment-conformance.ts` black-box-verifies a running deployment (health, access boundary, session run, SSE replay, MCP-tool session, scheduled task, storage round-trip). Preflight is `scripts/deployment-preflight.ts`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -51,10 +51,18 @@ supervisor. It is not an autoscaling or failover layer in this profile.
 The profile renders one API, web, control worker, turn worker, relay, Postgres,
 Temporal, NATS, and MinIO process. It disables HPAs, disruption budgets, and
 topology spreading. Container resource requests and limits are omitted, so a
-busy role may use otherwise-idle CPU and memory on the machine. This does not
-create a deterministic memory-pressure failure order; any protection or
-priority policy must be based on measured load evidence rather than assumed
-per-service allocations.
+busy role may use otherwise-idle CPU and memory on the machine.
+
+The profile creates four non-preempting Pod priority tiers. Under
+kubelet-managed node pressure, presentation (web and relay) is evicted before
+turn execution, then live control (API, control worker, and NATS), while
+durable services and the migration gate are retained longest. Priority is not a
+CPU or memory partition, and it cannot order a kernel OOM that happens before
+kubelet reacts. Configure a node-wide `memory.available` eviction threshold
+with enough measured OS/Kubernetes headroom, and include every disk/inode
+threshold when overriding `eviction-hard`; Kubernetes otherwise zeroes omitted
+defaults. This preserves elastic sharing while giving the kubelet room to
+enforce the intended order.
 
 The ordinary dependency services remain private `ClusterIP` services. Five
 one-port NodePort services are the complete private-edge surface:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -41,6 +41,138 @@ kubectl -n opengeni create secret generic opengeni-runtime \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
+### Single-machine Kubernetes
+
+`deploy/helm/opengeni/values.single-node.example.yaml` is the supported
+persistent, non-HA profile for running the complete control plane on one
+machine. Kubernetes is used only as the process, restart, volume, and upgrade
+supervisor. It is not an autoscaling or failover layer in this profile.
+
+The profile renders one API, web, control worker, turn worker, relay, Postgres,
+Temporal, NATS, and MinIO process. It disables HPAs, disruption budgets, and
+topology spreading. Container resource requests and limits are omitted, so a
+busy role may use otherwise-idle CPU and memory on the machine. This does not
+create a deterministic memory-pressure failure order; any protection or
+priority policy must be based on measured load evidence rather than assumed
+per-service allocations.
+
+The ordinary dependency services remain private `ClusterIP` services. Five
+one-port NodePort services are the complete private-edge surface:
+
+| NodePort | Destination | Purpose |
+| --- | --- | --- |
+| `30080` | web | browser application |
+| `30081` | API | API, SSE, enrollment, and agent distribution |
+| `30222` | NATS websocket | enrolled-machine command/event transport |
+| `30443` | relay | live terminal/desktop byte streams |
+| `30900` | MinIO API | signed browser file transfer only |
+
+The NATS client/monitor ports and MinIO admin console are not exposed. On K3s,
+bind NodePorts to loopback with
+`--kube-proxy-arg=nodeport-addresses=127.0.0.0/8`, then publish only the five
+loopback listeners through a private edge such as Tailscale Serve. Route `/` to
+web and route `/v1`, `/healthz`, `/metrics`, `/install.sh`, `/install.ps1`,
+`/uninstall.sh`, `/opengeni-agent-minisign.pub`, and `/agent` to the API. Give
+the NATS websocket, relay, and MinIO API their own private TLS ports. Set
+`selfhosted.natsUrl`, `selfhosted.relayUrl`, and `minio.publicEndpoint` to those
+private URLs.
+
+For a tailnet-only deployment, `OPENGENI_AUTH_REQUIRED=false` and
+`OPENGENI_PRODUCT_ACCESS_MODE=local` mean there is no shared deployment access
+key; tailnet membership is the outer access boundary. Internal database, NATS,
+enrollment-signing, relay-token, object-storage, and model-provider credentials
+remain required because services must still authenticate to each other. They
+are not an additional user-facing gateway.
+
+Create the four Secrets before installation:
+
+- `opengeni-postgres`: the Postgres owner `POSTGRES_PASSWORD`;
+- `opengeni-minio`: `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD`;
+- `opengeni-runtime`: the restricted `opengeni_app`
+  `OPENGENI_DATABASE_URL`, object-storage credentials, model-provider
+  credentials, and Connected Machine signing/NATS/relay secrets;
+- `opengeni-migrations`: the owner
+  `OPENGENI_MIGRATIONS_DATABASE_URL`,
+  `OPENGENI_APP_DATABASE_USER=opengeni_app`, and
+  `OPENGENI_APP_DATABASE_PASSWORD`.
+
+Generate the matched database and NATS credentials locally. The command creates
+a new mode-`0700` directory containing four mode-`0600` env files, refuses to
+overwrite an existing directory, and prints no secret values:
+
+```bash
+bun run deployment:single-node-secrets -- \
+  --out-dir .agent/generated/single-node/secrets
+
+kubectl create namespace opengeni --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n opengeni create secret generic opengeni-postgres \
+  --from-env-file=.agent/generated/single-node/secrets/postgres.env
+
+kubectl -n opengeni create secret generic opengeni-minio \
+  --from-env-file=.agent/generated/single-node/secrets/minio.env
+
+test -n "$OPENGENI_OPENAI_API_KEY"
+kubectl -n opengeni create secret generic opengeni-runtime \
+  --from-env-file=.agent/generated/single-node/secrets/runtime.env \
+  --from-literal=OPENGENI_OPENAI_API_KEY="$OPENGENI_OPENAI_API_KEY"
+
+kubectl -n opengeni create secret generic opengeni-migrations \
+  --from-env-file=.agent/generated/single-node/secrets/migrations.env
+```
+
+Use the corresponding model-provider keys instead of
+`OPENGENI_OPENAI_API_KEY` when the deployment selects another configured
+provider. Keep the generated directory as a private recovery artifact or move
+the values into a secret manager; never commit it.
+
+Bootstrap a new machine in two phases. First install only the persistent
+dependencies and wait until they are healthy:
+
+```bash
+helm upgrade --install opengeni deploy/helm/opengeni \
+  --namespace opengeni --create-namespace \
+  --values deploy/helm/opengeni/values.single-node.example.yaml \
+  --set api.enabled=false \
+  --set worker.enabled=false \
+  --set web.enabled=false \
+  --set relay.enabled=false \
+  --set migrations.enabled=false \
+  --wait --timeout 10m
+```
+
+Then enable the application. Because this is an upgrade, the pre-upgrade
+database Job can reach the already-running Postgres. It applies forward
+migrations, converges the restricted runtime role, and proves a connection
+through that role before Helm replaces application pods:
+
+```bash
+helm upgrade opengeni deploy/helm/opengeni \
+  --namespace opengeni \
+  --values deploy/helm/opengeni/values.single-node.example.yaml \
+  --wait --timeout 15m
+```
+
+Future versions use the same second command with a new official chart/image
+version or digest. Postgres and MinIO PVCs remain attached. Database migrations
+are forward-only: if the migration gate fails, the old application stays in
+place; after a migration succeeds, roll the application forward unless the
+older image is explicitly proven compatible with the new schema.
+
+Failure behavior is intentionally uneven:
+
+- web and relay hold no durable product state; losing them removes the browser
+  UI or live terminal/desktop streams;
+- a turn worker can restart while queued work remains in Temporal/Postgres;
+- NATS stores no authoritative history, but losing it disconnects enrolled
+  machines and pauses their command path as well as live fanout;
+- MinIO owns uploaded file bytes;
+- Temporal owns durable orchestration state;
+- Postgres owns the durable product record and database migration ledger.
+
+This profile promises restart and persistence on one machine, not service
+continuity while that machine is down.
+
 ### Database identities and runtime posture
 
 Standalone deployments using the default `OPENGENI_RLS_STRATEGY=force` require
@@ -54,12 +186,20 @@ two distinct secret paths:
   database but authenticating as `opengeni_app`; this is the only database URL
   available to API and worker containers.
 
-After every migration and before rolling workloads, run:
+After every migration and before rolling workloads, the Helm migration hook runs:
 
 ```bash
 bun run db:provision-roles
 bun run db:assert-runtime-posture
 ```
+
+The Job receives the ordinary runtime Secret first and the separate
+migration-only Secret second. This gives the assertion the restricted
+`OPENGENI_DATABASE_URL` while keeping the owner URL and provisioning password
+out of API and worker pods. Its default command serializes `db:migrate`,
+`db:provision-roles`, and `db:assert-runtime-posture`; any failure aborts
+`helm upgrade` before workload replacement begins. Operators running without
+Helm must preserve the same order explicitly.
 
 The provisioner converges `opengeni_app` to `LOGIN NOSUPERUSER NOBYPASSRLS
 NOCREATEROLE NOCREATEDB NOREPLICATION NOINHERIT`, refuses to guess through any
@@ -192,6 +332,7 @@ Current profiles:
 
 - `local-compose`: existing Docker Compose development stack.
 - `local-kubernetes`: local Kubernetes cluster running the Helm chart with in-cluster dependencies.
+- `single-node-kubernetes`: persistent non-HA Kubernetes stack on one machine, using official images and a private edge.
 - `kubernetes-external`: Kubernetes workloads connected to existing customer services.
 - `azure-managed`: AKS plus Azure-managed substrate where supported, provider-native object storage, and stack-wrapper managed upstream NATS/Temporal charts unless you replace them with existing endpoints.
 - `azure-existing-services`: Azure Kubernetes workloads connected to existing Postgres, Temporal, and object storage.
@@ -870,10 +1011,10 @@ ingress and secret wiring:
   ingress.
 - **NATS with auth-callout**: the machine's agent dials a NATS websocket to reach
   the request/reply control plane, authenticated per workspace by a NATS
-  auth-callout responder. Use the chart-managed NATS fixture with
-  `nats.authCallout.enabled=true` for preview/smoke, or fold the same
-  `deploy/nats/auth-callout.conf` config into an external/production NATS
-  deployment (`nats.enabled=false`).
+  auth-callout responder. Use chart-managed NATS with
+  `nats.authCallout.enabled=true` for the single-machine profile and
+  preview/smoke stacks, or fold the same `deploy/nats/auth-callout.conf` config
+  into an external multi-node NATS deployment (`nats.enabled=false`).
 
 Both the relay and the NATS websocket need public wss ingress hosts (for example
 `relay.<domain>` and `nats.<domain>`) with the long-lived-stream ingress

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -328,6 +328,32 @@ skipping storage conformance leaves both upload and orphan cleanup unproven.
 
 The conformance command verifies API health, Prometheus metrics exposure, a real session run, event replay, SSE replay, manual scheduled-task dispatch, and file upload/download unless the corresponding `--skip-observability`, `--skip-agent`, `--skip-scheduled-tasks`, or `--skip-storage` flag is set. Skipped checks are explicit verification gaps, not proof that the skipped subsystem works.
 
+Profile the live API → NATS → Connected Machine → process → reply path with an
+existing idle machine-backed session:
+
+```bash
+bun run deployment:connected-machine-load -- \
+  --base-url https://opengeni.example.com \
+  --workspace-id 00000000-0000-0000-0000-000000000000 \
+  --session-id 00000000-0000-0000-0000-000000000000 \
+  --stages 1,10,25,50,100,200
+```
+
+The command runs a harmless marker command, warms every supplied session route,
+then applies a concurrency staircase. It reports request throughput, p50/p95/p99
+latency, and typed failure counts. Pass multiple `--session-id` values to spread
+the test over several machine-backed sessions. Use
+`--deployment-access-key` or `--product-token` only when the deployment enables
+that boundary; neither credential is printed.
+
+This test measures the Connected Machine control transport and host command
+admission. It does **not** measure model-provider capacity, full agent-turn
+memory, or useful development-task throughput. Use
+`scripts/operator/turn-density-profile.ts` for isolated turn-worker memory, and
+run a smaller representative set of real development tasks before choosing an
+active-turn concurrency target. A large number of durable idle sessions is not
+equivalent to the same number of simultaneously executing turns.
+
 For Azure Blob-backed deployments, no object host rewrite should be needed because upload/download URLs are public Azure Blob SAS URLs:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "deployment:preflight": "bun scripts/deployment-preflight.ts",
     "deployment:stack": "bun scripts/deployment-stack.ts",
     "deployment:runtime-artifacts": "bun scripts/deployment-runtime-artifacts.ts",
+    "deployment:single-node-secrets": "bun scripts/generate-single-node-secrets.ts",
     "deployment:temporal-values": "bun scripts/deployment-temporal-values.ts",
     "deployment:conformance": "bun scripts/deployment-conformance.ts",
     "acceptance:workbench-live": "bun scripts/workbench-live-acceptance.ts",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "deployment:single-node-secrets": "bun scripts/generate-single-node-secrets.ts",
     "deployment:temporal-values": "bun scripts/deployment-temporal-values.ts",
     "deployment:conformance": "bun scripts/deployment-conformance.ts",
+    "deployment:connected-machine-load": "bun scripts/operator/connected-machine-load-profile.ts",
     "acceptance:workbench-live": "bun scripts/workbench-live-acceptance.ts",
     "check:generated-fonts": "bun scripts/generate-noto-jp-loader.ts --check",
     "image:build:api": "docker build --platform ${OPENGENI_IMAGE_PLATFORM:-linux/amd64} -f docker/opengeni.Dockerfile --target api -t opengeni-api:local .",

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const DeploymentProfileId = z.enum([
   "local-compose",
   "local-kubernetes",
+  "single-node-kubernetes",
   "kubernetes-external",
   "azure-managed",
   "azure-existing-services",
@@ -130,6 +131,18 @@ export const SANDBOX_SURFACING_PASSTHROUGH_ENV: readonly string[] = [
   "OPENGENI_STREAM_CONTROL_ENABLED",
   "OPENGENI_SANDBOX_OWNERSHIP_ENABLED",
   "OPENGENI_SANDBOX_DESKTOP_ENABLED",
+];
+
+/** Control-plane secrets needed for a complete Connected Machine deployment.
+ * The config layer permits graceful degradation when these are absent; a
+ * deployment whose primary backend is selfhosted cannot. */
+export const SELFHOSTED_CONTROL_PLANE_REQUIRED_ENV: readonly string[] = [
+  "OPENGENI_ENROLLMENT_SIGNING_SECRET",
+  "OPENGENI_STREAM_TOKEN_SECRET",
+  "OPENGENI_SELFHOSTED_NATS_CALLOUT_ACCOUNT_SEED",
+  "OPENGENI_SELFHOSTED_NATS_CALLOUT_PUBLIC_KEY",
+  "OPENGENI_SELFHOSTED_NATS_CONTROL_PASSWORD",
+  "OPENGENI_SELFHOSTED_NATS_CALLOUT_PASSWORD",
 ];
 
 export const SecretDeliveryMode = z.enum([
@@ -624,6 +637,39 @@ export const deploymentProfiles: Record<DeploymentProfileId, DeploymentContract>
       requireStructuredLogs: true,
     },
     sandbox: { backend: "none", preparationProfiles: ["none"], envAllowlist: [] },
+  }),
+  "single-node-kubernetes": parseDeploymentContract({
+    profile: "single-node-kubernetes",
+    runtime: {
+      platform: "kubernetes",
+      cloud: "generic",
+      namespace: "opengeni",
+      releaseName: "opengeni",
+    },
+    database: { mode: "inCluster", engine: "postgres", pgvectorRequired: true },
+    temporal: { mode: "inCluster", namespace: "default", taskQueue: "opengeni-runs-ts" },
+    nats: { mode: "inCluster" },
+    objectStorage: { mode: "inCluster", api: "s3-compatible", bucket: "opengeni-files" },
+    secrets: { mode: "kubernetesSecret" },
+    ingress: { enabled: false, tls: false, sseTimeoutSeconds: 3600 },
+    access: {
+      mode: "disabled",
+      allowUnauthenticatedHealth: true,
+      allowUnauthenticatedMetrics: false,
+    },
+    product: {
+      accessMode: "local",
+      billingMode: "disabled",
+      entitlementsMode: "none",
+      usageLimitsMode: "none",
+    },
+    observability: {
+      backend: "none",
+      requireTraces: false,
+      requireMetrics: false,
+      requireStructuredLogs: true,
+    },
+    sandbox: { backend: "selfhosted", preparationProfiles: ["none"], envAllowlist: [] },
   }),
   "kubernetes-external": parseDeploymentContract({
     profile: "kubernetes-external",
@@ -1305,7 +1351,7 @@ export function requiredRuntimeEnvVars(
   } else {
     vars.push("OPENGENI_OPENAI_API_KEY");
   }
-  if (contract.database.mode !== "inCluster") {
+  if (runtimeDatabaseUrlRequired(contract)) {
     vars.push("OPENGENI_DATABASE_URL");
   }
   if (contract.temporal.mode !== "inCluster") {
@@ -1374,6 +1420,9 @@ export function requiredRuntimeEnvVars(
   }
   // Backend-gated: only the active backend's required creds enter the manifest.
   vars.push(...SANDBOX_REQUIRED_ENV[contract.sandbox.backend].required);
+  if (contract.sandbox.backend === "selfhosted") {
+    vars.push(...SELFHOSTED_CONTROL_PLANE_REQUIRED_ENV);
+  }
   return [...new Set(vars)].sort();
 }
 
@@ -1397,6 +1446,7 @@ export function stackPlanFor(
   const requiredSecretKeys = [
     ...requiredRuntimeEnvVars(contract, env).filter((name) => secretLikeRuntimeEnv(name)),
     ...platformDependencies.flatMap((dependency) => dependency.requiredSecretKeys),
+    ...profileRequiredSecretKeys(contract),
   ];
   return {
     profile: contract.profile,
@@ -1480,6 +1530,8 @@ function terraformRootFor(contract: DeploymentContract): string | null {
 function helmValuesFileFor(contract: DeploymentContract): string | null {
   if (contract.profile === "local-kubernetes")
     return "deploy/helm/opengeni/values.local-kubernetes.example.yaml";
+  if (contract.profile === "single-node-kubernetes")
+    return "deploy/helm/opengeni/values.single-node.example.yaml";
   if (contract.profile === "preview-pr" || contract.profile === "preview-branch")
     return "deploy/helm/opengeni/values.preview-managed.example.yaml";
   if (contract.profile === "azure-managed")
@@ -1526,6 +1578,8 @@ function createdResourceClasses(contract: DeploymentContract): string[] {
       "IAM service accounts and bindings",
       "optional Cloud SQL PostgreSQL",
     );
+  } else if (contract.profile === "single-node-kubernetes") {
+    out.push("persistent single-node Postgres/Temporal/NATS/MinIO services and local volumes");
   } else if (
     contract.database.mode === "inCluster" ||
     contract.temporal.mode === "inCluster" ||
@@ -1572,6 +1626,22 @@ function deployCommands(
   if (contract.profile === "local-compose") {
     return ["bun run dev"];
   }
+  if (contract.profile === "single-node-kubernetes") {
+    const namespace = contract.runtime.namespace ?? "opengeni";
+    const release = contract.runtime.releaseName;
+    const values = helmValuesFile ?? "deploy/helm/opengeni/values.single-node.example.yaml";
+    return [
+      `kubectl create namespace ${namespace} --dry-run=client -o yaml | kubectl apply -f -`,
+      "bun run deployment:single-node-secrets -- --out-dir .agent/generated/single-node/secrets",
+      `kubectl -n ${namespace} create secret generic opengeni-postgres --from-env-file=.agent/generated/single-node/secrets/postgres.env --dry-run=client -o yaml | kubectl apply -f -`,
+      `kubectl -n ${namespace} create secret generic opengeni-minio --from-env-file=.agent/generated/single-node/secrets/minio.env --dry-run=client -o yaml | kubectl apply -f -`,
+      'test -n "$OPENGENI_OPENAI_API_KEY"',
+      `kubectl -n ${namespace} create secret generic opengeni-runtime --from-env-file=.agent/generated/single-node/secrets/runtime.env --from-literal=OPENGENI_OPENAI_API_KEY="$OPENGENI_OPENAI_API_KEY" --dry-run=client -o yaml | kubectl apply -f -`,
+      `kubectl -n ${namespace} create secret generic opengeni-migrations --from-env-file=.agent/generated/single-node/secrets/migrations.env --dry-run=client -o yaml | kubectl apply -f -`,
+      `helm upgrade --install ${release} deploy/helm/opengeni --namespace ${namespace} --values ${values} --set api.enabled=false --set worker.enabled=false --set web.enabled=false --set relay.enabled=false --set migrations.enabled=false --wait --timeout 10m`,
+      `helm upgrade ${release} deploy/helm/opengeni --namespace ${namespace} --values ${values} --wait --timeout 15m`,
+    ];
+  }
   if (contract.profile === "local-kubernetes") {
     return [
       "docker build --platform linux/amd64 -f docker/opengeni.Dockerfile --target api -t opengeni-api:local-k8s .",
@@ -1579,7 +1649,7 @@ function deployCommands(
       "OPENGENI_DEPLOYMENT_REVISION=${OPENGENI_DEPLOYMENT_REVISION:-local-k8s} docker build --platform linux/amd64 -f docker/opengeni.Dockerfile --target web --build-arg OPENGENI_DEPLOYMENT_REVISION -t opengeni-web:local-k8s .",
       "kind load docker-image opengeni-api:local-k8s opengeni-worker:local-k8s opengeni-web:local-k8s --name ${KIND_CLUSTER_NAME:-opengeni-local}",
       `kubectl create namespace ${contract.runtime.namespace ?? "opengeni-local"} --dry-run=client -o yaml | kubectl apply -f -`,
-      `kubectl -n ${contract.runtime.namespace ?? "opengeni-local"} create secret generic opengeni-runtime-local-k8s --from-literal=OPENGENI_ACCESS_KEY="$OPENGENI_ACCESS_KEY" --dry-run=client -o yaml | kubectl apply -f -`,
+      `kubectl -n ${contract.runtime.namespace ?? "opengeni-local"} create secret generic opengeni-runtime-local-k8s --from-literal=OPENGENI_ACCESS_KEY="$OPENGENI_ACCESS_KEY" --from-literal=OPENGENI_DATABASE_URL="postgres://opengeni_app:opengeni_app@opengeni-local-postgres:5432/opengeni" --from-literal=OPENGENI_MIGRATIONS_DATABASE_URL="postgres://opengeni:opengeni@opengeni-local-postgres:5432/opengeni" --from-literal=OPENGENI_APP_DATABASE_USER=opengeni_app --from-literal=OPENGENI_APP_DATABASE_PASSWORD=opengeni_app --dry-run=client -o yaml | kubectl apply -f -`,
       `helm upgrade --install ${contract.runtime.releaseName} deploy/helm/opengeni --namespace ${contract.runtime.namespace ?? "opengeni-local"} --values ${helmValuesFile ?? "deploy/helm/opengeni/values.local-kubernetes.example.yaml"}`,
     ];
   }
@@ -1827,6 +1897,13 @@ function planNotes(contract: DeploymentContract): string[] {
       "Temporal is intentionally outside the OpenGeni app chart; use Temporal Cloud, an existing endpoint, or the official Temporal Helm chart.",
     );
   }
+  if (contract.profile === "single-node-kubernetes") {
+    notes.push(
+      "This profile is one persistent machine with no service redundancy; Kubernetes owns restart, volume, and upgrade sequencing only.",
+      "Bind NodePorts to loopback and expose only the documented edge ports through the private network boundary.",
+      "Create the runtime, migration, Postgres, and MinIO Secrets before the two-phase Helm bootstrap.",
+    );
+  }
   return notes;
 }
 
@@ -1836,9 +1913,33 @@ function secretLikeRuntimeEnv(name: string): boolean {
     name.includes("SECRET") ||
     name.includes("TOKEN") ||
     name.includes("PASSWORD") ||
+    name.includes("SEED") ||
     name.includes("CONNECTION_STRING") ||
     name === "OPENGENI_DATABASE_URL"
   );
+}
+
+function runtimeDatabaseUrlRequired(contract: DeploymentContract): boolean {
+  return (
+    contract.database.mode !== "inCluster" ||
+    contract.profile === "single-node-kubernetes" ||
+    contract.profile.startsWith("preview")
+  );
+}
+
+function profileRequiredSecretKeys(contract: DeploymentContract): string[] {
+  if (contract.profile !== "single-node-kubernetes") {
+    return [];
+  }
+  return [
+    "opengeni-postgres/POSTGRES_PASSWORD",
+    "opengeni-minio/MINIO_ROOT_USER",
+    "opengeni-minio/MINIO_ROOT_PASSWORD",
+    "opengeni-runtime/OPENGENI_DATABASE_URL",
+    "opengeni-migrations/OPENGENI_MIGRATIONS_DATABASE_URL",
+    "opengeni-migrations/OPENGENI_APP_DATABASE_USER",
+    "opengeni-migrations/OPENGENI_APP_DATABASE_PASSWORD",
+  ];
 }
 
 function runtimeEnvFileValue(value: string | undefined): string {
@@ -1893,7 +1994,7 @@ function runtimeEnvValues(
     envOrRequiredRuntime(
       "OPENGENI_DATABASE_URL",
       env.OPENGENI_DATABASE_URL,
-      contract.database.mode !== "inCluster",
+      runtimeDatabaseUrlRequired(contract),
     ),
     valueEnv("OPENGENI_AUTH_REQUIRED", String(contract.access.mode === "sharedKey")),
     ...(contract.access.mode === "sharedKey"
@@ -2140,6 +2241,11 @@ function runtimeEnvValues(
   for (const key of sandboxEnv.optional) {
     entries.push(valueEnv(key, env[key]));
   }
+  if (contract.sandbox.backend === "selfhosted") {
+    for (const key of SELFHOSTED_CONTROL_PLANE_REQUIRED_ENV) {
+      entries.push(requiredEnv(key, env[key]));
+    }
+  }
 
   // sandbox workspace passthroughs (the desktop/Channel-A feature rollout). These are
   // recognized runtime env vars so a surfacing-enabled deployment carries them
@@ -2219,9 +2325,21 @@ function dedupeRuntimeEnv(entries: RuntimeEnvEntry[]): RuntimeEnvEntry[] {
   const byKey = new Map<string, RuntimeEnvEntry>();
   for (const entry of entries) {
     const existing = byKey.get(entry.key);
-    if (!existing || (!existing.value && entry.value)) {
+    if (!existing) {
       byKey.set(entry.key, entry);
+      continue;
     }
+    byKey.set(entry.key, {
+      ...existing,
+      value: existing.value || entry.value,
+      required: existing.required || entry.required,
+      ...(existing.fromSensitiveTerraformOutput || entry.fromSensitiveTerraformOutput
+        ? {
+            fromSensitiveTerraformOutput:
+              existing.fromSensitiveTerraformOutput ?? entry.fromSensitiveTerraformOutput,
+          }
+        : {}),
+    });
   }
   return [...byKey.values()].sort((a, b) => a.key.localeCompare(b.key));
 }
@@ -2308,9 +2426,13 @@ function addRuntimeConfigHelmValues(
   ) {
     values["minio.publicEndpoint"] = publicBaseUrl;
   }
-  if (contract.database.mode !== "inCluster") {
+  if (runtimeDatabaseUrlRequired(contract)) {
     values["migrations.secret.existingSecret"] =
       env.OPENGENI_MIGRATIONS_SECRET_NAME ?? "opengeni-migrations";
+  }
+  if (contract.database.mode === "inCluster" && runtimeDatabaseUrlRequired(contract)) {
+    values["postgres.runtime.existingSecret"] = "opengeni-runtime";
+    values["postgres.runtime.databaseUrlKey"] = "OPENGENI_DATABASE_URL";
   }
 }
 

--- a/packages/deployment/test/deployment.test.ts
+++ b/packages/deployment/test/deployment.test.ts
@@ -88,6 +88,34 @@ describe("deployment contract", () => {
     ).toBe(true);
   });
 
+  test("models a persistent non-HA single-machine deployment without local image builds", () => {
+    const contract = deploymentProfiles["single-node-kubernetes"];
+    const plan = stackPlanFor(contract);
+
+    expect(contract.runtime.platform).toBe("kubernetes");
+    expect(contract.database.mode).toBe("inCluster");
+    expect(contract.temporal.mode).toBe("inCluster");
+    expect(contract.nats.mode).toBe("inCluster");
+    expect(contract.objectStorage.mode).toBe("inCluster");
+    expect(contract.ingress.enabled).toBe(false);
+    expect(contract.access.mode).toBe("disabled");
+    expect(contract.sandbox.backend).toBe("selfhosted");
+    expect(plan.helmValuesFile).toBe("deploy/helm/opengeni/values.single-node.example.yaml");
+    expect(plan.creates).toContain(
+      "persistent single-node Postgres/Temporal/NATS/MinIO services and local volumes",
+    );
+    expect(plan.deployCommands.filter((command) => command.includes("helm upgrade"))).toHaveLength(
+      2,
+    );
+    expect(plan.deployCommands.some((command) => command.includes("docker build"))).toBe(false);
+    expect(plan.requiredSecretKeys).toContain("OPENGENI_ENROLLMENT_SIGNING_SECRET");
+    expect(plan.requiredSecretKeys).toContain("OPENGENI_SELFHOSTED_NATS_CALLOUT_ACCOUNT_SEED");
+    expect(plan.requiredSecretKeys).toContain("opengeni-postgres/POSTGRES_PASSWORD");
+    expect(plan.requiredSecretKeys).toContain(
+      "opengeni-migrations/OPENGENI_MIGRATIONS_DATABASE_URL",
+    );
+  });
+
   test("models Azure managed profile with external Temporal/NATS and Azure Blob storage", () => {
     const contract = deploymentProfiles["azure-managed"];
 
@@ -741,7 +769,7 @@ describe("deployment contract", () => {
     expect(artifacts.runtimeEnv).not.toContain("OPENGENI_AZURE_OPENAI_API_VERSION=");
   });
 
-  test("generates preview managed runtime artifacts without external fixture secrets", () => {
+  test("generates preview runtime artifacts with a restricted DB identity", () => {
     const contract = contractForProfile("preview-pr");
     const artifacts = generateRuntimeArtifacts(
       contract,
@@ -749,6 +777,8 @@ describe("deployment contract", () => {
         helm_set_values: { value: {} },
       },
       {
+        OPENGENI_DATABASE_URL:
+          "postgres://opengeni_app:runtime-password@opengeni-preview-postgres:5432/opengeni",
         OPENGENI_PUBLIC_BASE_URL: "https://preview-123.app.opengeni.ai",
         OPENGENI_DELEGATION_SECRET: "delegation",
         OPENGENI_BETTER_AUTH_SECRET: "better-auth",
@@ -792,7 +822,9 @@ describe("deployment contract", () => {
     // The sandbox workspace HMAC secret is NEVER required (graceful-degrade /
     // delegation-secret fallback) — it must not enter missingEnvVars.
     expect(artifacts.missingEnvVars).not.toContain("OPENGENI_STREAM_TOKEN_SECRET");
-    expect(artifacts.runtimeEnv).not.toContain("OPENGENI_DATABASE_URL=");
+    expect(artifacts.runtimeEnv).toContain(
+      "OPENGENI_DATABASE_URL=postgres://opengeni_app:runtime-password@opengeni-preview-postgres:5432/opengeni",
+    );
     expect(artifacts.runtimeEnv).not.toContain("OPENGENI_OBJECT_STORAGE_ENDPOINT=");
     expect(artifacts.runtimeEnv).not.toContain("OPENGENI_OBJECT_STORAGE_ACCESS_KEY_ID=");
     expect(artifacts.runtimeEnv).toContain(
@@ -814,6 +846,8 @@ describe("deployment contract", () => {
     );
     expect(artifacts.helmValuesYaml).toContain('tag: "preview-123"');
     expect(artifacts.helmValuesYaml).toContain('digest: "sha256:worker"');
+    expect(artifacts.helmValuesYaml).toContain('existingSecret: "opengeni-migrations"');
+    expect(artifacts.helmValuesYaml).toContain('existingSecret: "opengeni-runtime"');
   });
 
   test("escapes multiline runtime env values for kubectl env-file secrets", () => {

--- a/scripts/generate-single-node-secrets.test.ts
+++ b/scripts/generate-single-node-secrets.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { nkeys } from "@opengeni/events";
+import { generateSingleNodeSecretFiles } from "./generate-single-node-secrets";
+
+function parseEnv(source: string): Record<string, string> {
+  return Object.fromEntries(
+    source
+      .trim()
+      .split("\n")
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return [line.slice(0, separator), line.slice(separator + 1)];
+      }),
+  );
+}
+
+describe("single-node secret bootstrap", () => {
+  test("generates matched, separated credentials without overwriting an existing directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "opengeni-single-node-test-"));
+    const outDir = join(root, "secrets");
+    try {
+      const files = await generateSingleNodeSecretFiles({ outDir });
+      const [postgres, minio, runtime, migrations] = await Promise.all([
+        readFile(files.postgres, "utf8").then(parseEnv),
+        readFile(files.minio, "utf8").then(parseEnv),
+        readFile(files.runtime, "utf8").then(parseEnv),
+        readFile(files.migrations, "utf8").then(parseEnv),
+      ]);
+
+      expect(runtime.OPENGENI_DATABASE_URL).toContain("postgres://opengeni_app:");
+      expect(migrations.OPENGENI_MIGRATIONS_DATABASE_URL).toContain("postgres://opengeni:");
+      expect(migrations.OPENGENI_MIGRATIONS_DATABASE_URL).toContain(
+        encodeURIComponent(postgres.POSTGRES_PASSWORD ?? ""),
+      );
+      expect(minio.MINIO_ROOT_PASSWORD?.length).toBeGreaterThanOrEqual(32);
+
+      const accountSeed = runtime.OPENGENI_SELFHOSTED_NATS_CALLOUT_ACCOUNT_SEED;
+      expect(accountSeed).toBeDefined();
+      expect(nkeys.fromSeed(Buffer.from(accountSeed ?? "")).getPublicKey()).toBe(
+        runtime.OPENGENI_SELFHOSTED_NATS_CALLOUT_PUBLIC_KEY,
+      );
+
+      expect((await stat(files.directory)).mode & 0o777).toBe(0o700);
+      for (const path of [files.postgres, files.minio, files.runtime, files.migrations]) {
+        expect((await stat(path)).mode & 0o777).toBe(0o600);
+      }
+
+      await expect(generateSingleNodeSecretFiles({ outDir })).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/generate-single-node-secrets.ts
+++ b/scripts/generate-single-node-secrets.ts
@@ -1,0 +1,171 @@
+import { randomBytes } from "node:crypto";
+import { chmod, mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
+import { nkeys } from "@opengeni/events";
+
+const decoder = new TextDecoder();
+
+export interface SingleNodeSecretFiles {
+  directory: string;
+  postgres: string;
+  minio: string;
+  runtime: string;
+  migrations: string;
+}
+
+export interface GenerateSingleNodeSecretsOptions {
+  outDir: string;
+  releaseName?: string;
+  databaseName?: string;
+  databaseOwner?: string;
+  runtimeDatabaseUser?: string;
+}
+
+function secret(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function envFile(values: Record<string, string>): string {
+  return `${Object.entries(values)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n")}\n`;
+}
+
+function postgresUrl(input: {
+  user: string;
+  password: string;
+  host: string;
+  database: string;
+}): string {
+  return `postgres://${encodeURIComponent(input.user)}:${encodeURIComponent(input.password)}@${input.host}:5432/${encodeURIComponent(input.database)}`;
+}
+
+export async function generateSingleNodeSecretFiles(
+  options: GenerateSingleNodeSecretsOptions,
+): Promise<SingleNodeSecretFiles> {
+  const directory = resolve(options.outDir);
+  const parent = dirname(directory);
+  const releaseName = options.releaseName ?? "opengeni";
+  const databaseName = options.databaseName ?? "opengeni";
+  const databaseOwner = options.databaseOwner ?? "opengeni";
+  const runtimeDatabaseUser = options.runtimeDatabaseUser ?? "opengeni_app";
+  const databaseHost = `${releaseName}-postgres`;
+
+  const ownerPassword = secret();
+  const runtimePassword = secret();
+  const minioPassword = secret();
+  const enrollmentSigningSecret = secret();
+  const streamTokenSecret = secret();
+  const natsControlPassword = secret();
+  const natsCalloutPassword = secret();
+  const natsAccount = nkeys.createAccount();
+  const natsAccountSeed = decoder.decode(natsAccount.getSeed());
+  const natsAccountPublicKey = natsAccount.getPublicKey();
+
+  await mkdir(parent, { recursive: true, mode: 0o700 });
+  const temporaryDirectory = await mkdtemp(join(parent, `.${basename(directory)}-`));
+  await chmod(temporaryDirectory, 0o700);
+
+  const files: SingleNodeSecretFiles = {
+    directory,
+    postgres: join(directory, "postgres.env"),
+    minio: join(directory, "minio.env"),
+    runtime: join(directory, "runtime.env"),
+    migrations: join(directory, "migrations.env"),
+  };
+
+  try {
+    const temporaryFiles = {
+      postgres: join(temporaryDirectory, "postgres.env"),
+      minio: join(temporaryDirectory, "minio.env"),
+      runtime: join(temporaryDirectory, "runtime.env"),
+      migrations: join(temporaryDirectory, "migrations.env"),
+    };
+    await Promise.all([
+      writeFile(
+        temporaryFiles.postgres,
+        envFile({
+          POSTGRES_PASSWORD: ownerPassword,
+        }),
+        { mode: 0o600, flag: "wx" },
+      ),
+      writeFile(
+        temporaryFiles.minio,
+        envFile({
+          MINIO_ROOT_USER: "opengeni",
+          MINIO_ROOT_PASSWORD: minioPassword,
+        }),
+        { mode: 0o600, flag: "wx" },
+      ),
+      writeFile(
+        temporaryFiles.runtime,
+        envFile({
+          OPENGENI_DATABASE_URL: postgresUrl({
+            user: runtimeDatabaseUser,
+            password: runtimePassword,
+            host: databaseHost,
+            database: databaseName,
+          }),
+          OPENGENI_ENROLLMENT_SIGNING_SECRET: enrollmentSigningSecret,
+          OPENGENI_STREAM_TOKEN_SECRET: streamTokenSecret,
+          OPENGENI_SELFHOSTED_RELAY_TOKEN_SECRET: streamTokenSecret,
+          OPENGENI_SELFHOSTED_NATS_CALLOUT_ACCOUNT_SEED: natsAccountSeed,
+          OPENGENI_SELFHOSTED_NATS_CALLOUT_PUBLIC_KEY: natsAccountPublicKey,
+          OPENGENI_SELFHOSTED_NATS_CONTROL_PASSWORD: natsControlPassword,
+          OPENGENI_SELFHOSTED_NATS_CALLOUT_PASSWORD: natsCalloutPassword,
+        }),
+        { mode: 0o600, flag: "wx" },
+      ),
+      writeFile(
+        temporaryFiles.migrations,
+        envFile({
+          OPENGENI_MIGRATIONS_DATABASE_URL: postgresUrl({
+            user: databaseOwner,
+            password: ownerPassword,
+            host: databaseHost,
+            database: databaseName,
+          }),
+          OPENGENI_APP_DATABASE_USER: runtimeDatabaseUser,
+          OPENGENI_APP_DATABASE_PASSWORD: runtimePassword,
+        }),
+        { mode: 0o600, flag: "wx" },
+      ),
+    ]);
+    await rename(temporaryDirectory, directory);
+  } catch (error) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+    throw error;
+  }
+
+  return files;
+}
+
+function parseArgs(argv: string[]): GenerateSingleNodeSecretsOptions {
+  let outDir = "";
+  let releaseName: string | undefined;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--out-dir") {
+      outDir = argv[index + 1] ?? "";
+      index += 1;
+    } else if (arg === "--release-name") {
+      releaseName = argv[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!outDir) {
+    throw new Error("--out-dir is required");
+  }
+  return {
+    outDir,
+    ...(releaseName ? { releaseName } : {}),
+  };
+}
+
+if (import.meta.main) {
+  const files = await generateSingleNodeSecretFiles(parseArgs(process.argv.slice(2)));
+  console.log(`Generated single-node secret env files in ${files.directory}`);
+  console.log("No secret values were printed. Keep this directory private and do not commit it.");
+}

--- a/scripts/helm-upgrade-contract.test.ts
+++ b/scripts/helm-upgrade-contract.test.ts
@@ -53,6 +53,10 @@ describe("Helm database upgrade contract", () => {
 
   test("ships a non-HA single-node profile with narrow private-edge services", async () => {
     const values = await source("deploy/helm/opengeni/values.single-node.example.yaml");
+    const defaults = await source("deploy/helm/opengeni/values.yaml");
+    const priorityClasses = await source(
+      "deploy/helm/opengeni/templates/priority-classes.yaml",
+    );
     const natsEdge = await source(
       "deploy/helm/opengeni/templates/nats-websocket-edge-service.yaml",
     );
@@ -61,6 +65,12 @@ describe("Helm database upgrade contract", () => {
     expect(values).toContain("replicaCount: 1");
     expect(values).not.toContain("autoscaling:\n    enabled: true");
     expect(values).toContain("resources: null");
+    expect(values).toContain("priorityClasses:\n  enabled: true");
+    for (const tier of ["presentation", "execution", "control", "durable"]) {
+      expect(defaults).toContain(`    ${tier}:`);
+    }
+    expect(priorityClasses).toContain("$tier");
+    expect(priorityClasses).toContain("preemptionPolicy:");
     for (const nodePort of [30080, 30081, 30222, 30443, 30900]) {
       expect(values).toContain(`nodePort: ${nodePort}`);
     }

--- a/scripts/helm-upgrade-contract.test.ts
+++ b/scripts/helm-upgrade-contract.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dir, "..");
+
+async function source(path: string): Promise<string> {
+  return readFile(resolve(root, path), "utf8");
+}
+
+describe("Helm database upgrade contract", () => {
+  test("gates workload replacement on schema, role, and runtime-posture convergence", async () => {
+    const values = await source("deploy/helm/opengeni/values.yaml");
+
+    const migrate = values.indexOf("bun run db:migrate");
+    const provision = values.indexOf("bun run db:provision-roles");
+    const assertPosture = values.indexOf("bun run db:assert-runtime-posture");
+
+    expect(migrate).toBeGreaterThan(-1);
+    expect(provision).toBeGreaterThan(migrate);
+    expect(assertPosture).toBeGreaterThan(provision);
+    expect(values).toContain("helm.sh/hook: post-install,pre-upgrade");
+  });
+
+  test("mounts runtime credentials without exposing migration credentials to workloads", async () => {
+    const helpers = await source("deploy/helm/opengeni/templates/_helpers.tpl");
+    const migrationJob = await source("deploy/helm/opengeni/templates/migration-job.yaml");
+    const apiDeployment = await source("deploy/helm/opengeni/templates/api-deployment.yaml");
+    const workerDeployment = await source("deploy/helm/opengeni/templates/worker-deployment.yaml");
+    const turnWorkerDeployment = await source(
+      "deploy/helm/opengeni/templates/worker-turns-deployment.yaml",
+    );
+
+    expect(migrationJob).toContain('name: {{ include "opengeni.secretName" . }}');
+    expect(migrationJob).toContain(
+      '{{- if ne (include "opengeni.migrationSecretName" .) (include "opengeni.secretName" .) }}',
+    );
+    expect(migrationJob).toContain('name: {{ include "opengeni.migrationSecretName" . }}');
+
+    for (const workload of [apiDeployment, workerDeployment, turnWorkerDeployment]) {
+      expect(workload).toContain('name: {{ include "opengeni.secretName" . }}');
+      expect(workload).not.toContain('name: {{ include "opengeni.migrationSecretName" . }}');
+    }
+
+    const restrictedRuntime = helpers.indexOf("{{- if .Values.postgres.runtime.existingSecret }}");
+    const ownerPassword = helpers.indexOf("- name: OPENGENI_POSTGRES_PASSWORD");
+    expect(restrictedRuntime).toBeGreaterThan(-1);
+    expect(ownerPassword).toBeGreaterThan(restrictedRuntime);
+    expect(helpers.slice(restrictedRuntime, ownerPassword)).toContain(
+      "- name: OPENGENI_DATABASE_URL",
+    );
+  });
+
+  test("ships a non-HA single-node profile with narrow private-edge services", async () => {
+    const values = await source("deploy/helm/opengeni/values.single-node.example.yaml");
+    const natsEdge = await source(
+      "deploy/helm/opengeni/templates/nats-websocket-edge-service.yaml",
+    );
+    const minioEdge = await source("deploy/helm/opengeni/templates/minio-edge-service.yaml");
+
+    expect(values).toContain("replicaCount: 1");
+    expect(values).not.toContain("autoscaling:\n    enabled: true");
+    expect(values).toContain("resources: null");
+    for (const nodePort of [30080, 30081, 30222, 30443, 30900]) {
+      expect(values).toContain(`nodePort: ${nodePort}`);
+    }
+
+    expect(natsEdge).toContain("targetPort: websocket");
+    expect(natsEdge).not.toContain("targetPort: client");
+    expect(natsEdge).not.toContain("targetPort: monitor");
+    expect(minioEdge).toContain("targetPort: api");
+    expect(minioEdge).not.toContain("targetPort: console");
+  });
+});

--- a/scripts/helm-upgrade-contract.test.ts
+++ b/scripts/helm-upgrade-contract.test.ts
@@ -54,9 +54,7 @@ describe("Helm database upgrade contract", () => {
   test("ships a non-HA single-node profile with narrow private-edge services", async () => {
     const values = await source("deploy/helm/opengeni/values.single-node.example.yaml");
     const defaults = await source("deploy/helm/opengeni/values.yaml");
-    const priorityClasses = await source(
-      "deploy/helm/opengeni/templates/priority-classes.yaml",
-    );
+    const priorityClasses = await source("deploy/helm/opengeni/templates/priority-classes.yaml");
     const natsEdge = await source(
       "deploy/helm/opengeni/templates/nats-websocket-edge-service.yaml",
     );

--- a/scripts/operator/connected-machine-load-profile.test.ts
+++ b/scripts/operator/connected-machine-load-profile.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  executeBounded,
+  parseConnectedMachineLoadArgs,
+  percentile,
+} from "./connected-machine-load-profile";
+
+describe("Connected Machine load profile", () => {
+  test("parses a generic staircase without retaining duplicate session ids", () => {
+    const args = parseConnectedMachineLoadArgs(
+      [
+        "--base-url",
+        "https://opengeni.example.test",
+        "--workspace-id",
+        "workspace-1",
+        "--session-id",
+        "session-1,session-2",
+        "--session-id",
+        "session-1",
+        "--stages",
+        "2,20,200",
+        "--requests-per-stage",
+        "400",
+      ],
+      {},
+    );
+
+    expect(args.sessionIds).toEqual(["session-1", "session-2"]);
+    expect(args.stages).toEqual([2, 20, 200]);
+    expect(args.requestsPerStage).toBe(400);
+    expect(args.command).toBe("echo opengeni-load-probe");
+  });
+
+  test("requires the outer HTTP timeout to exceed the machine command timeout", () => {
+    expect(() =>
+      parseConnectedMachineLoadArgs(
+        [
+          "--base-url",
+          "https://opengeni.example.test",
+          "--workspace-id",
+          "workspace-1",
+          "--session-id",
+          "session-1",
+          "--timeout-ms",
+          "30000",
+          "--request-timeout-ms",
+          "30000",
+        ],
+        {},
+      ),
+    ).toThrow("--request-timeout-ms must be greater");
+  });
+
+  test("computes nearest-rank percentiles", () => {
+    expect(percentile([1, 2, 3, 4, 5], 50)).toBe(3);
+    expect(percentile([1, 2, 3, 4, 5], 95)).toBe(5);
+    expect(percentile([], 99)).toBe(0);
+  });
+
+  test("never exceeds requested concurrency", async () => {
+    let active = 0;
+    let peak = 0;
+    let completed = 0;
+    await executeBounded(31, 4, async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await Bun.sleep(2);
+      active -= 1;
+      completed += 1;
+    });
+
+    expect(completed).toBe(31);
+    expect(peak).toBe(4);
+  });
+});

--- a/scripts/operator/connected-machine-load-profile.test.ts
+++ b/scripts/operator/connected-machine-load-profile.test.ts
@@ -51,6 +51,15 @@ describe("Connected Machine load profile", () => {
     ).toThrow("--request-timeout-ms must be greater");
   });
 
+  test("rejects an invalid base URL", () => {
+    expect(() =>
+      parseConnectedMachineLoadArgs(
+        ["--base-url", "not a URL", "--workspace-id", "workspace-1", "--session-id", "session-1"],
+        {},
+      ),
+    ).toThrow("--base-url must be a valid URL");
+  });
+
   test("computes nearest-rank percentiles", () => {
     expect(percentile([1, 2, 3, 4, 5], 50)).toBe(3);
     expect(percentile([1, 2, 3, 4, 5], 95)).toBe(5);

--- a/scripts/operator/connected-machine-load-profile.ts
+++ b/scripts/operator/connected-machine-load-profile.ts
@@ -1,0 +1,416 @@
+const DEFAULT_MARKER = "opengeni-load-probe";
+
+export interface ConnectedMachineLoadArgs {
+  baseUrl: string;
+  workspaceId: string;
+  sessionIds: string[];
+  stages: number[];
+  requestsPerStage: number | null;
+  timeoutMs: number;
+  requestTimeoutMs: number;
+  pauseMs: number;
+  maxErrorRate: number;
+  command: string;
+  expectedOutput: string | null;
+  deploymentAccessKey: string | null;
+  productToken: string | null;
+  json: boolean;
+}
+
+interface RequestResult {
+  ok: boolean;
+  latencyMs: number;
+  failure: string | null;
+}
+
+interface StageResult {
+  concurrency: number;
+  requests: number;
+  successes: number;
+  failures: number;
+  errorRate: number;
+  wallTimeMs: number;
+  throughputPerSecond: number;
+  latencyMs: {
+    min: number;
+    p50: number;
+    p95: number;
+    p99: number;
+    max: number;
+  };
+  failureCounts: Record<string, number>;
+}
+
+export function parseConnectedMachineLoadArgs(
+  values: string[],
+  env: Record<string, string | undefined> = process.env,
+): ConnectedMachineLoadArgs {
+  const out: ConnectedMachineLoadArgs = {
+    baseUrl: env.OPENGENI_LOAD_BASE_URL ?? "",
+    workspaceId: env.OPENGENI_LOAD_WORKSPACE_ID ?? "",
+    sessionIds: splitList(env.OPENGENI_LOAD_SESSION_IDS),
+    stages: [1, 10, 25, 50, 100, 200],
+    requestsPerStage: null,
+    timeoutMs: 30_000,
+    requestTimeoutMs: 45_000,
+    pauseMs: 1_000,
+    maxErrorRate: 0,
+    command: `echo ${DEFAULT_MARKER}`,
+    expectedOutput: DEFAULT_MARKER,
+    deploymentAccessKey: env.OPENGENI_LOAD_DEPLOYMENT_ACCESS_KEY ?? null,
+    productToken: env.OPENGENI_LOAD_PRODUCT_TOKEN ?? null,
+    json: false,
+  };
+
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    if (value === "--json") {
+      out.json = true;
+      continue;
+    }
+    if (value === "--no-output-check") {
+      out.expectedOutput = null;
+      continue;
+    }
+    if (value === "--base-url") {
+      out.baseUrl = requiredNext(values, ++index, value);
+      continue;
+    }
+    if (value === "--workspace-id") {
+      out.workspaceId = requiredNext(values, ++index, value);
+      continue;
+    }
+    if (value === "--session-id") {
+      out.sessionIds.push(...splitList(requiredNext(values, ++index, value)));
+      continue;
+    }
+    if (value === "--stages") {
+      out.stages = parsePositiveIntegerList(requiredNext(values, ++index, value), value);
+      continue;
+    }
+    if (value === "--requests-per-stage") {
+      out.requestsPerStage = positiveInteger(requiredNext(values, ++index, value), value);
+      continue;
+    }
+    if (value === "--timeout-ms") {
+      out.timeoutMs = positiveInteger(requiredNext(values, ++index, value), value);
+      continue;
+    }
+    if (value === "--request-timeout-ms") {
+      out.requestTimeoutMs = positiveInteger(requiredNext(values, ++index, value), value);
+      continue;
+    }
+    if (value === "--pause-ms") {
+      out.pauseMs = nonnegativeInteger(requiredNext(values, ++index, value), value);
+      continue;
+    }
+    if (value === "--max-error-rate") {
+      out.maxErrorRate = boundedRate(requiredNext(values, ++index, value), value);
+      continue;
+    }
+    if (value === "--command") {
+      out.command = requiredNext(values, ++index, value);
+      continue;
+    }
+    if (value === "--expected-output") {
+      out.expectedOutput = requiredNext(values, ++index, value);
+      continue;
+    }
+    if (value === "--deployment-access-key") {
+      out.deploymentAccessKey = requiredNext(values, ++index, value);
+      continue;
+    }
+    if (value === "--product-token") {
+      out.productToken = requiredNext(values, ++index, value);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${value}`);
+  }
+
+  if (!out.baseUrl) throw new Error("Set --base-url or OPENGENI_LOAD_BASE_URL");
+  if (!out.workspaceId) throw new Error("Set --workspace-id or OPENGENI_LOAD_WORKSPACE_ID");
+  if (out.sessionIds.length === 0) {
+    throw new Error("Pass at least one --session-id or set OPENGENI_LOAD_SESSION_IDS");
+  }
+  out.sessionIds = [...new Set(out.sessionIds)];
+  new URL(out.baseUrl);
+  if (out.timeoutMs > 120_000) {
+    throw new Error("--timeout-ms cannot exceed the terminal exec API maximum of 120000");
+  }
+  if (out.requestTimeoutMs <= out.timeoutMs) {
+    throw new Error("--request-timeout-ms must be greater than --timeout-ms");
+  }
+  return out;
+}
+
+export function percentile(sortedValues: number[], percentileValue: number): number {
+  if (sortedValues.length === 0) return 0;
+  const index = Math.ceil((percentileValue / 100) * sortedValues.length) - 1;
+  return sortedValues[Math.max(0, Math.min(sortedValues.length - 1, index))] ?? 0;
+}
+
+export async function executeBounded(
+  total: number,
+  concurrency: number,
+  task: (index: number) => Promise<void>,
+): Promise<void> {
+  let next = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = next;
+      next += 1;
+      if (index >= total) return;
+      await task(index);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(total, concurrency) }, () => worker()));
+}
+
+async function main(): Promise<void> {
+  const args = parseConnectedMachineLoadArgs(process.argv.slice(2));
+  const headers = {
+    "content-type": "application/json",
+    ...(args.deploymentAccessKey ? { "x-opengeni-access-key": args.deploymentAccessKey } : {}),
+    ...(args.productToken ? { authorization: `Bearer ${args.productToken}` } : {}),
+  };
+
+  await warmUp(args, headers);
+  const stages: StageResult[] = [];
+  for (const concurrency of args.stages) {
+    if (stages.length > 0 && args.pauseMs > 0) await Bun.sleep(args.pauseMs);
+    const requests = args.requestsPerStage ?? Math.max(20, concurrency * 2);
+    stages.push(await runStage(args, headers, concurrency, requests));
+  }
+
+  const result = {
+    schemaVersion: 1,
+    target: {
+      baseUrl: new URL(args.baseUrl).origin,
+      workspaceId: args.workspaceId,
+      sessionCount: args.sessionIds.length,
+    },
+    workload: {
+      stages: args.stages,
+      requestsPerStage: args.requestsPerStage ?? "2x concurrency (minimum 20)",
+      commandTimeoutMs: args.timeoutMs,
+      requestTimeoutMs: args.requestTimeoutMs,
+    },
+    stages,
+    verdict: {
+      maxErrorRate: args.maxErrorRate,
+      passed: stages.every((stage) => stage.failures / stage.requests <= args.maxErrorRate),
+    },
+  };
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printHumanResult(result);
+  }
+  if (!result.verdict.passed) process.exitCode = 2;
+}
+
+async function warmUp(
+  args: ConnectedMachineLoadArgs,
+  headers: Record<string, string>,
+): Promise<void> {
+  const results: RequestResult[] = [];
+  await executeBounded(
+    args.sessionIds.length,
+    Math.min(4, args.sessionIds.length),
+    async (index) => {
+      results.push(await executeProbe(args, headers, args.sessionIds[index]!));
+    },
+  );
+  const failure = results.find((result) => !result.ok);
+  if (failure) {
+    throw new Error(`Connected Machine warm-up failed: ${failure.failure ?? "unknown failure"}`);
+  }
+}
+
+async function runStage(
+  args: ConnectedMachineLoadArgs,
+  headers: Record<string, string>,
+  concurrency: number,
+  requests: number,
+): Promise<StageResult> {
+  const results: RequestResult[] = new Array(requests);
+  const started = performance.now();
+  await executeBounded(requests, concurrency, async (index) => {
+    const sessionId = args.sessionIds[index % args.sessionIds.length]!;
+    results[index] = await executeProbe(args, headers, sessionId);
+  });
+  const wallTimeMs = performance.now() - started;
+  const successes = results.filter((result) => result.ok);
+  const failures = results.filter((result) => !result.ok);
+  const latencies = successes.map((result) => result.latencyMs).sort((a, b) => a - b);
+  const failureCounts: Record<string, number> = {};
+  for (const failure of failures) {
+    const key = failure.failure ?? "unknown";
+    failureCounts[key] = (failureCounts[key] ?? 0) + 1;
+  }
+  return {
+    concurrency,
+    requests,
+    successes: successes.length,
+    failures: failures.length,
+    errorRate: rounded(failures.length / requests, 4),
+    wallTimeMs: rounded(wallTimeMs),
+    throughputPerSecond: rounded((requests * 1_000) / wallTimeMs),
+    latencyMs: {
+      min: rounded(latencies[0] ?? 0),
+      p50: rounded(percentile(latencies, 50)),
+      p95: rounded(percentile(latencies, 95)),
+      p99: rounded(percentile(latencies, 99)),
+      max: rounded(latencies.at(-1) ?? 0),
+    },
+    failureCounts,
+  };
+}
+
+async function executeProbe(
+  args: ConnectedMachineLoadArgs,
+  headers: Record<string, string>,
+  sessionId: string,
+): Promise<RequestResult> {
+  const started = performance.now();
+  try {
+    const endpoint = new URL(
+      `/v1/workspaces/${encodeURIComponent(args.workspaceId)}/sessions/${encodeURIComponent(sessionId)}/terminal/exec`,
+      args.baseUrl,
+    );
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        command: args.command,
+        timeoutMs: args.timeoutMs,
+        emitStream: false,
+      }),
+      signal: AbortSignal.timeout(args.requestTimeoutMs),
+    });
+    if (!response.ok) {
+      return failed(started, await httpFailure(response));
+    }
+    const payload: unknown = await response.json();
+    if (!isRecord(payload)) return failed(started, "invalid-response");
+    if (payload.running !== false) return failed(started, "response-still-running");
+    if (payload.exitCode !== 0) return failed(started, `exit:${String(payload.exitCode)}`);
+    if (
+      args.expectedOutput !== null &&
+      (typeof payload.stdout !== "string" || payload.stdout.trim() !== args.expectedOutput)
+    ) {
+      return failed(started, "unexpected-output");
+    }
+    return { ok: true, latencyMs: performance.now() - started, failure: null };
+  } catch (error) {
+    const name = error instanceof Error ? error.name : "Error";
+    return failed(started, `transport:${name}`);
+  }
+}
+
+async function httpFailure(response: Response): Promise<string> {
+  let code = "";
+  try {
+    const payload: unknown = await response.json();
+    if (isRecord(payload)) {
+      const errorCode =
+        typeof payload.code === "string"
+          ? payload.code
+          : isRecord(payload.error) && typeof payload.error.code === "string"
+            ? payload.error.code
+            : null;
+      if (errorCode) code = `:${errorCode}`;
+    }
+  } catch {
+    // The status is sufficient; never echo arbitrary response bodies.
+  }
+  return `http:${response.status}${code}`;
+}
+
+function failed(started: number, failure: string): RequestResult {
+  return { ok: false, latencyMs: performance.now() - started, failure };
+}
+
+function printHumanResult(result: {
+  target: { baseUrl: string; sessionCount: number };
+  stages: StageResult[];
+  verdict: { maxErrorRate: number; passed: boolean };
+}): void {
+  console.log(
+    `OpenGeni Connected Machine load profile: ${result.target.baseUrl} (${result.target.sessionCount} session route${result.target.sessionCount === 1 ? "" : "s"})`,
+  );
+  for (const stage of result.stages) {
+    console.log(
+      [
+        `  concurrency ${stage.concurrency}`,
+        `${stage.successes}/${stage.requests} succeeded`,
+        `${stage.throughputPerSecond} req/s`,
+        `p50 ${stage.latencyMs.p50}ms`,
+        `p95 ${stage.latencyMs.p95}ms`,
+        `p99 ${stage.latencyMs.p99}ms`,
+      ].join(" | "),
+    );
+    for (const [failure, count] of Object.entries(stage.failureCounts)) {
+      console.log(`    ${failure}: ${count}`);
+    }
+  }
+  console.log(
+    `Verdict: ${result.verdict.passed ? "passed" : "failed"} (max error rate ${result.verdict.maxErrorRate})`,
+  );
+}
+
+function splitList(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parsePositiveIntegerList(value: string, flag: string): number[] {
+  const parsed = splitList(value).map((item) => positiveInteger(item, flag));
+  if (parsed.length === 0) throw new Error(`${flag} requires at least one integer`);
+  if (new Set(parsed).size !== parsed.length) throw new Error(`${flag} cannot contain duplicates`);
+  return parsed;
+}
+
+function positiveInteger(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function nonnegativeInteger(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${flag} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function boundedRate(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    throw new Error(`${flag} must be between 0 and 1`);
+  }
+  return parsed;
+}
+
+function requiredNext(values: string[], index: number, flag: string): string {
+  const next = values[index];
+  if (!next) throw new Error(`${flag} requires a value`);
+  return next;
+}
+
+function rounded(value: number, digits = 2): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+if (import.meta.main) await main();

--- a/scripts/operator/connected-machine-load-profile.ts
+++ b/scripts/operator/connected-machine-load-profile.ts
@@ -133,7 +133,7 @@ export function parseConnectedMachineLoadArgs(
     throw new Error("Pass at least one --session-id or set OPENGENI_LOAD_SESSION_IDS");
   }
   out.sessionIds = [...new Set(out.sessionIds)];
-  new URL(out.baseUrl);
+  if (!URL.canParse(out.baseUrl)) throw new Error("--base-url must be a valid URL");
   if (out.timeoutMs > 120_000) {
     throw new Error("--timeout-ms cannot exceed the terminal exec API maximum of 120000");
   }

--- a/scripts/operator/tsconfig.json
+++ b/scripts/operator/tsconfig.json
@@ -3,5 +3,10 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["turn-density-profile.ts", "reconcile-cold-lost-sandbox-blockers.ts"]
+  "include": [
+    "connected-machine-load-profile.ts",
+    "connected-machine-load-profile.test.ts",
+    "turn-density-profile.ts",
+    "reconcile-cold-lost-sandbox-blockers.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

- add a generic, persistent, non-HA single-machine Kubernetes profile using only official prebuilt images
- run exactly one API, web, control worker, turn worker, relay, Postgres, Temporal, NATS, and MinIO instance without fixed CPU/RAM partitions
- gate upgrades on forward-only migrations, restricted runtime-role provisioning, and database posture validation
- add Tailscale/private-edge NodePorts without an application shared-secret layer
- prioritize pressure shedding from presentation to execution to live control to durable state
- add a real API -> NATS -> Connected Machine -> process -> reply staircase load profiler

## Validation

- `bun test packages/deployment/test/deployment.test.ts scripts/generate-single-node-secrets.test.ts scripts/helm-upgrade-contract.test.ts scripts/operator/connected-machine-load-profile.test.ts` (44 pass)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- all deployment preflight profiles
- Helm lint and render validation for all example profiles
- single-node resource/replica/priority/credential contract checks
- `kubectl apply --dry-run=client` on the rendered single-node manifests
