### PR TITLE
fix(release): allow versioned ancestor publication

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -49,8 +49,12 @@ jobs:
           [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
           test -n "$EXPECTED_PACKAGES"
           test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          test "$GITHUB_REF" = "refs/heads/main"
           git fetch --no-tags origin main
-          test "$(git rev-parse origin/main)" = "$SOURCE_SHA"
+          git merge-base --is-ancestor "$SOURCE_SHA" origin/main || {
+            echo "source_sha must be reachable from current main" >&2
+            exit 1
+          }
           if find .changeset -maxdepth 1 -type f -name '*.md' ! -name README.md -print -quit | grep -q .; then
             echo "Version PR has not consumed every changeset" >&2
             exit 1

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -257,6 +257,9 @@ describe("release image workflow contract", () => {
     expect(publish).toContain("expected_packages:");
     expect(publish).toContain("checks: read");
     expect(publish).toContain("filter=latest&per_page=100");
+    expect(publish).toContain('test "$GITHUB_REF" = "refs/heads/main"');
+    expect(publish).toContain('git merge-base --is-ancestor "$SOURCE_SHA" origin/main');
+    expect(publish).not.toContain('test "$(git rev-parse origin/main)" = "$SOURCE_SHA"');
     for (const required of [
       "Typecheck and unit tests",
       "Deployment artifacts",


### PR DESCRIPTION
## Why

Package publication currently fails if another PR reaches `main` after an exact versioned source commit passes CI but before its explicit publish dispatch begins. That leaves a tested, unpublished package set stranded unless the repository is frozen.

## What

- Require the workflow itself to be dispatched from trusted `main`.
- Check out and verify the exact requested source SHA.
- Require that SHA to remain an ancestor of current `main`, instead of requiring it to remain the tip.
- Preserve the no-pending-changesets gate, exact protected-source checks, exact expected package list, pre-publication receipt, and post-publication registry reconciliation.
- Lock the rule in the release workflow contract test.

## Verification

- `bun test scripts/release-image-workflow-contract.test.ts`
- `bun run format:check`
- `bun run check:public-hygiene`
- `git diff --check`