### PR TITLE
fix(deploy): route initial machine commands directly

### DIFF
--- a/.changeset/route-machine-home-directly.md
+++ b/.changeset/route-machine-home-directly.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/core": patch
+---
+
+Route direct file, Git, and terminal calls to a machine-targeted session from the first request without creating a phantom provider lease, and make token-driven agent installation replace stale enrollment credentials.

--- a/agent/install/install.ps1
+++ b/agent/install/install.ps1
@@ -24,7 +24,8 @@
                              Point at a local mock (http://localhost/...) to test offline.
   OPENGENI_AGENT_VERSION     Pin a version (default "latest").
   OPENGENI_INSTALL_DIR       Install dir (default %LOCALAPPDATA%\OpenGeni\bin).
-  OPENGENI_ENROLL_TOKEN      Non-interactive enroll token (CI/automation).
+  OPENGENI_ENROLL_TOKEN      Non-interactive fresh-enrollment token
+                             (CI/automation); replaces an existing enrollment.
   OPENGENI_NO_RUN            "1" => do not start a foreground run; just print the command.
   OPENGENI_API_URL           Control-plane API base URL for enrollment.
 
@@ -219,7 +220,9 @@ function Complete-Install($bin) {
   $enrollToken = [Environment]::GetEnvironmentVariable('OPENGENI_ENROLL_TOKEN')
   if (-not [string]::IsNullOrEmpty($enrollToken)) {
     Log "non-interactive enroll (OPENGENI_ENROLL_TOKEN set)"
-    & $bin enroll --token $enrollToken --non-interactive
+    # Supplying a token explicitly requests this enrollment. Never silently
+    # retain credentials for a previous control plane.
+    & $bin enroll --token $enrollToken --non-interactive --force
     Log "enrolled. Start the agent (foreground) with:  $bin run"
     return
   }

--- a/agent/install/install.sh
+++ b/agent/install/install.sh
@@ -32,8 +32,10 @@
 #   OPENGENI_SYSTEM=1          Install to /usr/local/bin (needs sudo/root).
 #   OPENGENI_ENROLL_TOKEN      Non-interactive enroll token (CI/automation/fleet):
 #                              the script runs `enroll --token <tok>
-#                              --non-interactive` itself — the token IS the grant,
-#                              so there is NO device-approve step. The workspace is
+#                              --non-interactive --force` itself — the token IS
+#                              the requested fresh grant, so it replaces any
+#                              enrollment already present on the machine and
+#                              needs NO device-approve step. The workspace is
 #                              encoded in the token; OPENGENI_WORKSPACE_ID is not
 #                              needed on this path.
 #   OPENGENI_NO_RUN=1          Do not start a foreground run; just print the
@@ -672,11 +674,13 @@ finish() {
     # (not the api.opengeni.ai default) even when the agent's env-inherit path is
     # ever bypassed. The agent also reads $OPENGENI_API_URL via clap, so the env
     # alone would suffice — this is belt-and-suspenders. The workspace is encoded
-    # in the token, so no --workspace-id is needed on this path.
+    # in the token, so no --workspace-id is needed on this path. A supplied token
+    # is an explicit request for this enrollment; --force prevents a previous
+    # control-plane credential from being silently reused.
     if [ -n "${OPENGENI_API_URL:-}" ]; then
-      "$_bin" --api-url "$OPENGENI_API_URL" enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive
+      "$_bin" --api-url "$OPENGENI_API_URL" enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive --force
     else
-      "$_bin" enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive
+      "$_bin" enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive --force
     fi
     log "enrolled. Start the agent (foreground) with:  $_bin run"
     return 0

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -191,6 +191,11 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     handle: ChannelAHandle,
     pty: SandboxOpenPtySessionRow,
   ): Promise<SandboxRetainedProcess> => {
+    if (!handle.lease) {
+      throw new HTTPException(409, {
+        message: "durable interactive terminals require a session-home provider lease",
+      });
+    }
     const process = await getRetainedProcess(db, {
       workspaceId: ctx.workspaceId,
       sessionId: ctx.session.id,
@@ -2183,6 +2188,11 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     }
     const ptyId = crypto.randomUUID();
     const out = await withChannelA({ db, settings, bus }, ctx, async (handle) => {
+      if (!handle.lease) {
+        throw new HTTPException(409, {
+          message: "durable interactive terminals require a session-home provider lease",
+        });
+      }
       const { service } = handle;
       const opened = await service.ptyOpen(req, ptyId);
       const execSessionId = opened.execSessionId;

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -3,16 +3,16 @@
 // The structured services (FileSystem / Git / Terminal) are SYNCHRONOUS point
 // queries served client -> API -> box IN-PROCESS. Each call:
 //
-//   1. acquires an exact direct-request lease holder (warming the box when cold — the
-//      same cold->warming CAS attachViewer runs; a Postgres txn the API OWNS),
-//   2. resumes the box BY ID from the group lease's resume_state envelope,
-//   3. builds ONE SandboxChannelAService around the live `session` handle,
-//   4. runs the op (fsList/gitDiff/ptyWrite/...), returns inline JSON,
-//   5. releases the viewer holder + drops the live handle.
+// For a provider-backed home it acquires an exact direct-request lease holder,
+// resumes the box by id, and releases the holder after the operation. For a
+// Connected Machine home it follows the durable active pointer directly and
+// uses its NATS request/reply control channel; it creates no phantom cloud lease.
+// Both paths build one SandboxChannelAService, run the operation, and return the
+// result inline.
 //
-// NO Temporal, NO worker RPC, NO NATS round-trip in this path — reads never ride
-// the bus (which would corrupt SSE gap-fill). Only the side-effect NOTIFICATIONS
-// (fs.changed/git.changed/terminal.pty.*) ride A1 via appendAndPublishEvents.
+// NO Temporal or worker RPC sits in this path. Provider-backed reads remain
+// process-local; Connected Machine operations necessarily ride NATS. Side-effect
+// notifications (fs.changed/git.changed/terminal.pty.*) ride A1.
 //
 // IMPORT DISCIPLINE: sandbox symbols come ONLY from @opengeni/runtime/sandbox
 // (the agent-loop-free leaf) — enforced by sandbox-access-import-guard.test.ts.
@@ -29,8 +29,10 @@ import type { Session } from "@opengeni/contracts";
 import {
   acquireLease,
   getSandboxSessionEnvelope,
+  getSandbox,
   loadWorkspaceEnvironmentForRun,
   markWarmLeaseInstanceLost,
+  readActiveSandbox,
   readLease,
   releaseLeaseHolder,
   type Database,
@@ -40,9 +42,11 @@ import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
 import { HTTPException } from "hono/http-exception";
 
 import {
+  buildSelfhostedBackendSession,
   establishSandboxSessionFromEnvelope,
   isProviderSandboxNotFoundError,
   SandboxChannelAService,
+  NatsControlRpc,
   ChannelAConflictError,
   ChannelANotFoundError,
   ChannelAUnsupportedError,
@@ -55,7 +59,7 @@ import {
   type EstablishedSandboxSession,
   type RoutingSandboxSession,
 } from "@opengeni/runtime/sandbox";
-import { wrapChannelABoxWithRouting } from "@opengeni/core";
+import { relayConfigFromSettings, wrapChannelABoxWithRouting } from "@opengeni/core";
 import { establishApiSandboxSpawner } from "./rematerialize";
 
 export type ChannelAServices = {
@@ -76,7 +80,9 @@ export type ChannelAContext = {
 // (for the pty exec-session epoch fence + revision seeding).
 export type ChannelAHandle = {
   service: SandboxChannelAService;
-  lease: LeaseSnapshot;
+  /** Connected Machine homes deliberately have no cloud lease. Durable PTYs
+   * require a real home-provider lease and reject this null case. */
+  lease: LeaseSnapshot | null;
   routingSession: RoutingSandboxSession;
   requestId: string;
 };
@@ -106,6 +112,117 @@ export async function withChannelA<T>(
   const requestId = crypto.randomUUID();
   const holderId = `direct:${requestId}`;
   const leaseTtlMs = settings.sandboxLeaseTtlMs;
+
+  // The STABLE run-environment used by both a cloud home and a machine home.
+  // It also carries the per-session Toolspace pointer selected below.
+  const workspaceEnvironment = await loadWorkspaceEnvironmentForRun(
+    db,
+    settings,
+    workspaceId,
+    session.environmentId,
+  );
+  const settingsForSession =
+    session.sandboxBackend !== settings.sandboxBackend
+      ? { ...settings, sandboxBackend: session.sandboxBackend }
+      : settings;
+  const environment = stableSandboxEnvironmentForRun(
+    settingsForSession,
+    workspaceEnvironment?.values ?? {},
+    { workspaceId },
+  );
+  if (hasGitCredentialRepositorySelection(session.resources)) {
+    applyGitAuthPointerEnvironment(
+      environment,
+      hasGitHubRepositorySelection(session.resources) ? githubAppBotIdentity(settings) : null,
+    );
+  }
+
+  const runEstablished = async (
+    routed: EstablishedSandboxSession,
+    lease: LeaseSnapshot | null,
+  ): Promise<T> => {
+    const emit = async (events: { type: string; payload: unknown }[]): Promise<void> => {
+      await appendAndPublishEvents(
+        db,
+        bus,
+        workspaceId,
+        session.id,
+        events.map((e) => ({ type: e.type as never, payload: e.payload })),
+      );
+    };
+    const routingSession = routed.session as RoutingSandboxSession;
+    const credentialSession = withRunCredentialsSession(routingSession as object, session.id);
+    const scopedSession = environment.OPENGENI_TOOLSPACE_TOKEN_FILE
+      ? withToolspaceTokenSession(
+          credentialSession,
+          toolspaceTokenFileFromEnvironment(environment, session.id),
+        )
+      : credentialSession;
+    const service = new SandboxChannelAService({
+      session: scopedSession as ChannelASession,
+      leaseEpoch: lease?.leaseEpoch ?? session.activeEpoch,
+      emit,
+    });
+    return await fn({ service, lease, routingSession, requestId });
+  };
+
+  // A machine-targeted top-level session has an honest selfhosted HOME label.
+  // It has no cloud provider box and therefore must not acquire or establish a
+  // phantom home lease before following its active machine pointer.
+  if (session.sandboxBackend === "selfhosted") {
+    let established: EstablishedSandboxSession | undefined;
+    try {
+      const pointer = await readActiveSandbox(db, workspaceId, session.id);
+      if (!pointer?.activeSandboxId) {
+        throw new HTTPException(409, {
+          message: "machine-home session has no active Connected Machine",
+        });
+      }
+      const sandbox = await getSandbox(db, workspaceId, pointer.activeSandboxId);
+      if (sandbox?.kind !== "selfhosted" || !sandbox.enrollmentId) {
+        throw new HTTPException(409, {
+          message: "machine-home session points to an unavailable Connected Machine",
+        });
+      }
+      const built = await buildSelfhostedBackendSession({
+        workspaceId,
+        agentId: sandbox.enrollmentId,
+        relay: relayConfigFromSettings(settings),
+        controlRpcFactory: () => new NatsControlRpc(async () => bus.getRequestConnection()),
+        epoch: pointer.activeEpoch,
+        environment,
+        workingDir: pointer.workingDir,
+        timeoutMs: settings.sandboxSelfhostedControlTimeoutMs,
+        execTimeoutMs: settings.sandboxSelfhostedExecTimeoutMs,
+      });
+      established = {
+        client: built.client,
+        session: built.session,
+        sessionState: { agentId: sandbox.enrollmentId },
+        instanceId: sandbox.enrollmentId,
+        backendId: "selfhosted",
+      };
+      const routed = wrapChannelABoxWithRouting(
+        { db, settings, bus },
+        {
+          accountId,
+          workspaceId,
+          sessionId: session.id,
+          pinnedSelfhosted: {
+            sandboxId: sandbox.id,
+            epoch: pointer.activeEpoch,
+          },
+          directRequest: { requestId, holderId },
+        },
+        established,
+      );
+      return await runEstablished(routed, null);
+    } catch (error) {
+      throw mapChannelAError(error);
+    } finally {
+      await dropEstablishedHandle(established);
+    }
+  }
 
   const release = async (): Promise<void> => {
     await releaseLeaseHolder(db, {
@@ -150,36 +267,6 @@ export async function withChannelA<T>(
 
   try {
     const envelope = await getSandboxSessionEnvelope(db, workspaceId, session.id);
-    // The STABLE run-environment a COLD box must be created with so a later worker
-    // turn's agent-manifest apply finds an EMPTY env delta (config base + git
-    // identity + decrypted workspace env + HOME + — for a repo-attached session —
-    // the stable git-auth pointers the turn declares). Only the rotating token
-    // VALUE stays off (it lives in the box file the clone hook seeds). Keyed off
-    // the SESSION's backend (the establish below passes backendOverride:
-    // session.sandboxBackend, and HOME/token-file/askpass are backend-derived),
-    // NOT the deployment default — mirrors sessionAttachEnvironment.
-    const workspaceEnvironment = await loadWorkspaceEnvironmentForRun(
-      db,
-      settings,
-      workspaceId,
-      session.environmentId,
-    );
-    const settingsForSession =
-      session.sandboxBackend !== settings.sandboxBackend
-        ? { ...settings, sandboxBackend: session.sandboxBackend }
-        : settings;
-    const environment = stableSandboxEnvironmentForRun(
-      settingsForSession,
-      workspaceEnvironment?.values ?? {},
-      { workspaceId },
-    );
-    if (hasGitCredentialRepositorySelection(session.resources)) {
-      applyGitAuthPointerEnvironment(
-        environment,
-        hasGitHubRepositorySelection(session.resources) ? githubAppBotIdentity(settings) : null,
-      );
-    }
-
     if (acquired.role === "spawner") {
       // We won the cold->warming CAS: establish the box from the envelope, then
       // commit warm. The established handle IS our live handle for the op.
@@ -261,22 +348,10 @@ export async function withChannelA<T>(
       }
     }
 
-    const emit = async (events: { type: string; payload: unknown }[]): Promise<void> => {
-      await appendAndPublishEvents(
-        db,
-        bus,
-        workspaceId,
-        session.id,
-        // SessionEventType is a string enum at the contract; the producer parses
-        // the payload, so this cast is the same shape the worker emits.
-        events.map((e) => ({ type: e.type as never, payload: e.payload })),
-      );
-    };
-
     // Route every call through the same proxy, even when hot-swap is disabled:
     // routing may be dormant, but its direct mutation admission is mandatory for
     // every persistable provider write.
-    const routedSession = wrapChannelABoxWithRouting(
+    const routed = wrapChannelABoxWithRouting(
       { db, settings, bus },
       {
         accountId,
@@ -291,22 +366,8 @@ export async function withChannelA<T>(
         directRequest: { requestId, holderId },
       },
       established,
-    ).session as RoutingSandboxSession;
-    const credentialSession = withRunCredentialsSession(routedSession as object, session.id);
-    const scopedSession = environment.OPENGENI_TOOLSPACE_TOKEN_FILE
-      ? withToolspaceTokenSession(
-          credentialSession,
-          toolspaceTokenFileFromEnvironment(environment, session.id),
-        )
-      : credentialSession;
-
-    const service = new SandboxChannelAService({
-      session: scopedSession as ChannelASession,
-      leaseEpoch: leaseSnapshot.leaseEpoch,
-      emit,
-    });
-
-    return await fn({ service, lease: leaseSnapshot, routingSession: routedSession, requestId });
+    );
+    return await runEstablished(routed, leaseSnapshot);
   } catch (error) {
     throw mapChannelAError(error);
   } finally {

--- a/apps/api/test/install.test.ts
+++ b/apps/api/test/install.test.ts
@@ -40,6 +40,7 @@ describe("get.<domain> install routes", () => {
     // The real committed install.sh body (no secrets; curl|sh entrypoint).
     expect(body).toContain("OPENGENI_INSTALL_BASE_URL");
     expect(body).toContain("opengeni-agent");
+    expect(body).toContain('enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive --force');
   });
 
   // "The agent ships inside the control-plane": a DEPLOYED control plane self-serves
@@ -77,6 +78,7 @@ describe("get.<domain> install routes", () => {
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body.length).toBeGreaterThan(0);
+    expect(body).toContain("enroll --token $enrollToken --non-interactive --force");
   });
 
   test("GET /uninstall.sh serves the uninstall script", async () => {

--- a/apps/api/test/machine-home-backend.test.ts
+++ b/apps/api/test/machine-home-backend.test.ts
@@ -34,6 +34,7 @@ import { subjectFor } from "@opengeni/runtime";
 import type { AccessGrant } from "@opengeni/contracts";
 import { createSessionForRequest } from "@opengeni/core";
 import type { ApiRouteDeps, SessionWorkflowClient } from "@opengeni/core";
+import { withChannelA } from "../src/sandbox/channel-a";
 
 let available = true;
 let shared: SharedTestDatabase | null = null;
@@ -68,15 +69,29 @@ function busWithAgent(opts: { workspaceId: string; agentId: string }): MemoryEve
             requestId: req.requestId,
             result: { $case: "ping", ping: { nonce: op.ping.nonce, agentMonotonicMs: "0" } },
           }
-        : {
-            requestId: req.requestId,
-            error: {
-              code: ErrorCode.ERROR_CODE_UNSUPPORTED,
-              message: "unsupported",
-              retryable: false,
-              detail: {},
-            },
-          };
+        : op?.$case === "exec"
+          ? {
+              requestId: req.requestId,
+              result: {
+                $case: "exec",
+                exec: {
+                  exitCode: 0,
+                  stdout: new TextEncoder().encode("machine-home-ok\n"),
+                  stderr: new Uint8Array(0),
+                  timedOut: false,
+                  durationMs: "1",
+                },
+              },
+            }
+          : {
+              requestId: req.requestId,
+              error: {
+                code: ErrorCode.ERROR_CODE_UNSUPPORTED,
+                message: "unsupported",
+                retryable: false,
+                detail: {},
+              },
+            };
     return ControlResponse.encode(res).finish();
   });
   return bus;
@@ -213,6 +228,52 @@ describe("Stage-D honest label: machine-targeted home sandbox_backend", () => {
     const [turnRow] = await admin<{ sandbox_backend: string }[]>`
       select sandbox_backend from session_turns where session_id = ${session.id} limit 1`;
     expect(turnRow?.sandbox_backend).toBe("selfhosted");
+  }, 60_000);
+
+  test("the first direct terminal command routes to a machine home without a phantom lease", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, sandboxId, bus } = await seedMachine();
+    const session = await createSessionForRequest(
+      deps(bus),
+      grant(accountId, workspaceId),
+      workspaceId,
+      {
+        initialMessage: "run direct commands on my laptop",
+        targetSandboxId: sandboxId,
+      },
+    );
+
+    const result = await withChannelA(
+      { db, settings, bus },
+      {
+        accountId,
+        workspaceId,
+        session,
+        subjectId: "subject",
+      },
+      async ({ service, lease }) => {
+        expect(lease).toBeNull();
+        return await service.terminalExec({
+          command: "echo machine-home-ok",
+          cwd: "",
+          timeoutMs: 1_000,
+          emitStream: false,
+        });
+      },
+    );
+
+    expect(result).toMatchObject({
+      running: false,
+      exitCode: 0,
+      stdout: "machine-home-ok\n",
+      stderr: "",
+    });
+    const [leaseCount] = await admin<{ count: string }[]>`
+      select count(*)::text as count
+      from sandbox_leases
+      where workspace_id = ${workspaceId}
+        and sandbox_group_id = ${session.sandboxGroupId}`;
+    expect(leaseCount?.count).toBe("0");
   }, 60_000);
 
   test("a macOS machine target ⇒ home sandbox_os 'macos' (derived from the enrollment)", async () => {

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.4
-appVersion: "0.22.4"
+version: 0.22.5
+appVersion: "0.22.5"

--- a/deploy/helm/opengeni/values.single-node.example.yaml
+++ b/deploy/helm/opengeni/values.single-node.example.yaml
@@ -93,6 +93,9 @@ config:
   OPENGENI_AUTH_REQUIRED: "false"
   OPENGENI_AUTH_ALLOW_HEALTH: "true"
   OPENGENI_AUTH_ALLOW_METRICS: "false"
+  # Set this in the private overlay to the browser/API origin exposed by the
+  # private edge. It makes enrollment installers fetch this deployment's agent.
+  # OPENGENI_PUBLIC_BASE_URL: https://node.example-tailnet.ts.net
   OPENGENI_PRODUCT_ACCESS_MODE: local
   OPENGENI_BILLING_MODE: disabled
   OPENGENI_ENTITLEMENTS_MODE: none
@@ -102,6 +105,7 @@ config:
   OPENGENI_OBJECT_STORAGE_REGION: us-east-1
   OPENGENI_OBJECT_STORAGE_S3_PROVIDER: Minio
   OPENGENI_OBJECT_STORAGE_FORCE_PATH_STYLE: "true"
+  OPENGENI_SANDBOX_OWNERSHIP_ENABLED: "true"
   OPENGENI_SANDBOX_BACKEND: selfhosted
   OPENGENI_SANDBOX_PREPARATION_PROFILES: none
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -83,7 +83,10 @@ web and route `/v1`, `/healthz`, `/metrics`, `/install.sh`, `/install.ps1`,
 `/uninstall.sh`, `/opengeni-agent-minisign.pub`, and `/agent` to the API. Give
 the NATS websocket, relay, and MinIO API their own private TLS ports. Set
 `selfhosted.natsUrl`, `selfhosted.relayUrl`, and `minio.publicEndpoint` to those
-private URLs.
+private URLs. Also set `OPENGENI_PUBLIC_BASE_URL` to the browser/API origin. The
+API uses it when serving the installer, so an enrolled machine downloads the
+agent version baked into this deployment rather than falling back to the public
+archive.
 
 For a tailnet-only deployment, `OPENGENI_AUTH_REQUIRED=false` and
 `OPENGENI_PRODUCT_ACCESS_MODE=local` mean there is no shared deployment access
@@ -341,8 +344,11 @@ bun run deployment:connected-machine-load -- \
 
 The command runs a harmless marker command, warms every supplied session route,
 then applies a concurrency staircase. It reports request throughput, p50/p95/p99
-latency, and typed failure counts. Pass multiple `--session-id` values to spread
-the test over several machine-backed sessions. Use
+latency, and typed failure counts. Before the first write, it reads one supplied
+session to discover the target's `X-OpenGeni-Api-Contract` revision and sends
+that revision on every terminal probe; older targets that do not advertise a
+contract remain supported. Pass multiple `--session-id` values to spread the
+test over several machine-backed sessions. Use
 `--deployment-access-key` or `--product-token` only when the deployment enables
 that boundary; neither credential is printed.
 
@@ -353,6 +359,11 @@ memory, or useful development-task throughput. Use
 run a smaller representative set of real development tasks before choosing an
 active-turn concurrency target. A large number of durable idle sessions is not
 equivalent to the same number of simultaneously executing turns.
+
+Direct file, Git, and synchronous terminal APIs follow a machine-targeted
+session's active pointer from the first request. They use API → NATS → enrolled
+agent request/reply and do not need a preceding model turn, a turn worker, or a
+cloud-sandbox lease.
 
 For Azure Blob-backed deployments, no object host rewrite should be needed because upload/download URLs are public Azure Blob SAS URLs:
 

--- a/packages/core/src/sandbox/routing.ts
+++ b/packages/core/src/sandbox/routing.ts
@@ -2,11 +2,10 @@
 // real DB pointer + the live NATS control plane for the API-DIRECT Channel-A path
 // (M7). Symmetric with apps/worker/src/sandbox-routing.ts (the turn path).
 //
-// A Channel-A op resumes the group box by id and runs ONE op against it. With
-// hot-swap, the op must land on the session's CURRENTLY-active sandbox, not
-// always the group box: if the session swapped to a selfhosted machine, an
-// fs.read / git.status / exec from the API must reach THAT machine. So the
-// established group session is wrapped in a `RoutingSandboxSession` that re-reads
+// A Channel-A op runs against one established home: either a lease-owned provider
+// box or a Connected Machine home that intentionally has no cloud lease. With
+// hot-swap, the op must land on the session's CURRENTLY-active sandbox. The
+// established session is wrapped in a `RoutingSandboxSession` that re-reads
 // (active_sandbox_id, active_epoch) and dispatches to the active backend.
 //
 // The DB-coupled glue (readActiveSandbox / getSandbox / the selfhosted ControlRpc
@@ -112,11 +111,10 @@ export function routingEnabled(settings: Settings): boolean {
 }
 
 /**
- * Wrap an established group-box session in a `RoutingSandboxSession` so a
- * Channel-A op routes to the session's currently-active sandbox. Returns the
- * established handle with its `session` replaced by the stable proxy. With the
- * default pointer (active_sandbox_id == null) this routes to the group box
- * unchanged; a selfhosted active pointer routes the op to the machine.
+ * Wrap an established home session in a `RoutingSandboxSession` so a Channel-A
+ * op routes to the session's currently-active sandbox. Provider homes supply a
+ * lease; machine homes supply a pinned selfhosted identity and no lease. Returns
+ * the established handle with its `session` replaced by the stable proxy.
  */
 export function wrapChannelABoxWithRouting(
   services: ChannelARoutingServices,
@@ -124,11 +122,18 @@ export function wrapChannelABoxWithRouting(
     accountId: string;
     workspaceId: string;
     sessionId: string;
-    homeLease: {
+    homeLease?: {
       sandboxGroupId: string;
       leaseEpoch: number;
       instanceId: string;
       backend: string;
+    };
+    /** A machine-home Channel-A request has no cloud/home lease. Its already
+     * established SelfhostedSession is pinned to the durable active pointer so
+     * the first command uses the exact machine instance and epoch. */
+    pinnedSelfhosted?: {
+      sandboxId: string;
+      epoch: number;
     };
     directRequest: {
       requestId: string;
@@ -138,199 +143,212 @@ export function wrapChannelABoxWithRouting(
   established: EstablishedSandboxSession,
 ): EstablishedSandboxSession {
   const { db, settings, bus } = services;
-  const beforeMutation = async ({
-    op,
-    backend,
-  }: {
-    op: string;
-    backend: ResolvedActiveBackend;
-  }): Promise<SandboxWorkspaceMutationAdmission | null> => {
-    // Connected Machines and other non-persistable targets intentionally do
-    // not dirty or advance the cloud-home archive generation.
-    if (
-      backend.sandboxId !== null ||
-      backend.leaseEpoch === undefined ||
-      backend.providerInstanceId === undefined
-    ) {
-      return null;
-    }
-    if (backend.activeEpoch === undefined) {
-      throw new Error("API-direct workspace mutation resolved without an active route epoch");
-    }
-    return await advanceWorkspaceGenerationForDirectRequest(db, {
-      accountId: ids.accountId,
-      workspaceId: ids.workspaceId,
-      sessionId: ids.sessionId,
-      requestId: ids.directRequest.requestId,
-      holderId: ids.directRequest.holderId,
-      sandboxGroupId: ids.homeLease.sandboxGroupId,
-      expectedEpoch: backend.leaseEpoch,
-      expectedInstanceId: backend.providerInstanceId,
-      routeTargetId: backend.sandboxId,
-      routeEpoch: backend.activeEpoch,
-      operation: op,
-    });
-  };
-  const afterMutation = async ({
-    op,
-    backend,
-    admission,
-    outcome,
-    retainedProcess,
-  }: {
-    op: string;
-    backend: ResolvedActiveBackend;
-    admission: unknown;
-    outcome: "resolved" | "rejected";
-    result?: unknown;
-    retainedProcess?: RoutingRetainedProcess;
-  }): Promise<void> => {
-    if (admission === null) return;
-    if (
-      !admission ||
-      typeof admission !== "object" ||
-      typeof (admission as Partial<SandboxWorkspaceMutationAdmission>).id !== "string" ||
-      typeof (admission as Partial<SandboxWorkspaceMutationAdmission>).workspaceGeneration !==
-        "number" ||
-      backend.leaseEpoch === undefined ||
-      backend.providerInstanceId === undefined ||
-      backend.activeEpoch === undefined
-    ) {
-      throw new Error("API-direct workspace mutation settlement lacked its exact admission");
-    }
-    const exactAdmission = admission as SandboxWorkspaceMutationAdmission;
-    if (outcome === "resolved" && retainedProcess) {
-      await retainWorkspaceMutationProcess(db, {
-        accountId: ids.accountId,
-        workspaceId: ids.workspaceId,
-        sessionId: ids.sessionId,
-        processId: retainedProcess.id,
-        providerSessionId: retainedProcess.providerSessionId,
-        admissionId: exactAdmission.id,
-        admittedWorkspaceGeneration: exactAdmission.workspaceGeneration,
-        operation: op,
-        owner: {
-          kind: "direct",
+  const homeLease = ids.homeLease;
+  const beforeMutation = homeLease
+    ? async ({
+        op,
+        backend,
+      }: {
+        op: string;
+        backend: ResolvedActiveBackend;
+      }): Promise<SandboxWorkspaceMutationAdmission | null> => {
+        // Connected Machines and other non-persistable targets intentionally do
+        // not dirty or advance the cloud-home archive generation.
+        if (
+          backend.sandboxId !== null ||
+          backend.leaseEpoch === undefined ||
+          backend.providerInstanceId === undefined
+        ) {
+          return null;
+        }
+        if (backend.activeEpoch === undefined) {
+          throw new Error("API-direct workspace mutation resolved without an active route epoch");
+        }
+        return await advanceWorkspaceGenerationForDirectRequest(db, {
+          accountId: ids.accountId,
+          workspaceId: ids.workspaceId,
+          sessionId: ids.sessionId,
           requestId: ids.directRequest.requestId,
           holderId: ids.directRequest.holderId,
-          sandboxGroupId: ids.homeLease.sandboxGroupId,
+          sandboxGroupId: homeLease.sandboxGroupId,
+          expectedEpoch: backend.leaseEpoch,
+          expectedInstanceId: backend.providerInstanceId,
+          routeTargetId: backend.sandboxId,
+          routeEpoch: backend.activeEpoch,
+          operation: op,
+        });
+      }
+    : undefined;
+  const afterMutation = homeLease
+    ? async ({
+        op,
+        backend,
+        admission,
+        outcome,
+        retainedProcess,
+      }: {
+        op: string;
+        backend: ResolvedActiveBackend;
+        admission: unknown;
+        outcome: "resolved" | "rejected";
+        result?: unknown;
+        retainedProcess?: RoutingRetainedProcess;
+      }): Promise<void> => {
+        if (admission === null) return;
+        if (
+          !admission ||
+          typeof admission !== "object" ||
+          typeof (admission as Partial<SandboxWorkspaceMutationAdmission>).id !== "string" ||
+          typeof (admission as Partial<SandboxWorkspaceMutationAdmission>).workspaceGeneration !==
+            "number" ||
+          backend.leaseEpoch === undefined ||
+          backend.providerInstanceId === undefined ||
+          backend.activeEpoch === undefined
+        ) {
+          throw new Error("API-direct workspace mutation settlement lacked its exact admission");
+        }
+        const exactAdmission = admission as SandboxWorkspaceMutationAdmission;
+        if (outcome === "resolved" && retainedProcess) {
+          await retainWorkspaceMutationProcess(db, {
+            accountId: ids.accountId,
+            workspaceId: ids.workspaceId,
+            sessionId: ids.sessionId,
+            processId: retainedProcess.id,
+            providerSessionId: retainedProcess.providerSessionId,
+            admissionId: exactAdmission.id,
+            admittedWorkspaceGeneration: exactAdmission.workspaceGeneration,
+            operation: op,
+            owner: {
+              kind: "direct",
+              requestId: ids.directRequest.requestId,
+              holderId: ids.directRequest.holderId,
+              sandboxGroupId: homeLease.sandboxGroupId,
+              expectedEpoch: backend.leaseEpoch,
+              expectedInstanceId: backend.providerInstanceId,
+              routeTargetId: exactAdmission.routeTargetId,
+              routeEpoch: exactAdmission.routeEpoch,
+            },
+          });
+          return;
+        }
+        await verifyDirectWorkspaceMutationSettlement(db, {
+          accountId: ids.accountId,
+          workspaceId: ids.workspaceId,
+          sessionId: ids.sessionId,
+          requestId: ids.directRequest.requestId,
+          holderId: ids.directRequest.holderId,
+          sandboxGroupId: homeLease.sandboxGroupId,
           expectedEpoch: backend.leaseEpoch,
           expectedInstanceId: backend.providerInstanceId,
           routeTargetId: exactAdmission.routeTargetId,
           routeEpoch: exactAdmission.routeEpoch,
-        },
-      });
-      return;
-    }
-    await verifyDirectWorkspaceMutationSettlement(db, {
-      accountId: ids.accountId,
-      workspaceId: ids.workspaceId,
-      sessionId: ids.sessionId,
-      requestId: ids.directRequest.requestId,
-      holderId: ids.directRequest.holderId,
-      sandboxGroupId: ids.homeLease.sandboxGroupId,
-      expectedEpoch: backend.leaseEpoch,
-      expectedInstanceId: backend.providerInstanceId,
-      routeTargetId: exactAdmission.routeTargetId,
-      routeEpoch: exactAdmission.routeEpoch,
-      admission: exactAdmission,
-      operation: op,
-      outcome,
-    });
-  };
-  const beforeProcessMutation = async ({
-    op,
-    process,
-  }: {
-    op: string;
-    backend: ResolvedActiveBackend;
-    process: RoutingRetainedProcess;
-  }): Promise<SandboxWorkspaceMutationAdmission> =>
-    await advanceWorkspaceGenerationForRetainedProcess(db, {
-      accountId: ids.accountId,
-      workspaceId: ids.workspaceId,
-      sessionId: ids.sessionId,
-      processId: process.id,
-      operation: op,
-    });
-  const afterProcessMutation = async ({
-    op,
-    process,
-    admission,
-    outcome,
-  }: {
-    op: string;
-    backend: ResolvedActiveBackend;
-    process: RoutingRetainedProcess;
-    admission: unknown;
-    outcome: "resolved" | "rejected";
-    result?: unknown;
-  }): Promise<void> => {
-    if (
-      !admission ||
-      typeof admission !== "object" ||
-      typeof (admission as Partial<SandboxWorkspaceMutationAdmission>).id !== "string" ||
-      typeof (admission as Partial<SandboxWorkspaceMutationAdmission>).workspaceGeneration !==
-        "number"
-    ) {
-      throw new Error("API retained-process mutation settlement lacked its exact admission");
-    }
-    await verifyRetainedProcessMutationSettlement(db, {
-      accountId: ids.accountId,
-      workspaceId: ids.workspaceId,
-      sessionId: ids.sessionId,
-      processId: process.id,
-      admission: admission as SandboxWorkspaceMutationAdmission,
-      operation: op,
-      outcome,
-    });
-  };
-  const settleProcess = async ({
-    backend,
-    process,
-    proof,
-  }: {
-    backend: ResolvedActiveBackend;
-    process: RoutingRetainedProcess;
-    proof: RoutingRetainedProcessTerminalProof;
-  }): Promise<void> => {
-    if (
-      backend.sandboxId !== null ||
-      backend.leaseEpoch === undefined ||
-      backend.providerInstanceId === undefined ||
-      backend.activeEpoch === undefined
-    ) {
-      return;
-    }
-    const durable = await getRetainedProcess(db, {
-      workspaceId: ids.workspaceId,
-      sessionId: ids.sessionId,
-      processId: process.id,
-    });
-    if (
-      !durable ||
-      durable.providerSessionId !== process.providerSessionId ||
-      durable.providerBackend !== backend.kind ||
-      durable.providerInstanceId !== backend.providerInstanceId ||
-      durable.leaseEpoch !== backend.leaseEpoch ||
-      durable.routeKind !== (backend.sandboxId === null ? "home" : "active") ||
-      durable.routeTargetId !== backend.sandboxId ||
-      durable.routeEpoch !== backend.activeEpoch
-    ) {
-      throw new Error("API retained-process settlement lost its exact durable backend identity");
-    }
-    await settleRetainedProcess(db, {
-      accountId: ids.accountId,
-      workspaceId: ids.workspaceId,
-      sessionId: ids.sessionId,
-      processId: process.id,
-      expected: retainedProcessSettlementIdentity(durable),
-      outcome: proof.outcome,
-      exitCode: proof.exitCode,
-      reason: proof.reason,
-      idleGraceMs: settings.sandboxIdleGraceMs,
-    });
-  };
+          admission: exactAdmission,
+          operation: op,
+          outcome,
+        });
+      }
+    : undefined;
+  const beforeProcessMutation = homeLease
+    ? async ({
+        op,
+        process,
+      }: {
+        op: string;
+        backend: ResolvedActiveBackend;
+        process: RoutingRetainedProcess;
+      }): Promise<SandboxWorkspaceMutationAdmission> =>
+        await advanceWorkspaceGenerationForRetainedProcess(db, {
+          accountId: ids.accountId,
+          workspaceId: ids.workspaceId,
+          sessionId: ids.sessionId,
+          processId: process.id,
+          operation: op,
+        })
+    : undefined;
+  const afterProcessMutation = homeLease
+    ? async ({
+        op,
+        process,
+        admission,
+        outcome,
+      }: {
+        op: string;
+        backend: ResolvedActiveBackend;
+        process: RoutingRetainedProcess;
+        admission: unknown;
+        outcome: "resolved" | "rejected";
+        result?: unknown;
+      }): Promise<void> => {
+        if (
+          !admission ||
+          typeof admission !== "object" ||
+          typeof (admission as Partial<SandboxWorkspaceMutationAdmission>).id !== "string" ||
+          typeof (admission as Partial<SandboxWorkspaceMutationAdmission>).workspaceGeneration !==
+            "number"
+        ) {
+          throw new Error("API retained-process mutation settlement lacked its exact admission");
+        }
+        await verifyRetainedProcessMutationSettlement(db, {
+          accountId: ids.accountId,
+          workspaceId: ids.workspaceId,
+          sessionId: ids.sessionId,
+          processId: process.id,
+          admission: admission as SandboxWorkspaceMutationAdmission,
+          operation: op,
+          outcome,
+        });
+      }
+    : undefined;
+  const settleProcess = homeLease
+    ? async ({
+        backend,
+        process,
+        proof,
+      }: {
+        backend: ResolvedActiveBackend;
+        process: RoutingRetainedProcess;
+        proof: RoutingRetainedProcessTerminalProof;
+      }): Promise<void> => {
+        if (
+          backend.sandboxId !== null ||
+          backend.leaseEpoch === undefined ||
+          backend.providerInstanceId === undefined ||
+          backend.activeEpoch === undefined
+        ) {
+          return;
+        }
+        const durable = await getRetainedProcess(db, {
+          workspaceId: ids.workspaceId,
+          sessionId: ids.sessionId,
+          processId: process.id,
+        });
+        if (
+          !durable ||
+          durable.providerSessionId !== process.providerSessionId ||
+          durable.providerBackend !== backend.kind ||
+          durable.providerInstanceId !== backend.providerInstanceId ||
+          durable.leaseEpoch !== backend.leaseEpoch ||
+          durable.routeKind !== (backend.sandboxId === null ? "home" : "active") ||
+          durable.routeTargetId !== backend.sandboxId ||
+          durable.routeEpoch !== backend.activeEpoch
+        ) {
+          throw new Error(
+            "API retained-process settlement lost its exact durable backend identity",
+          );
+        }
+        await settleRetainedProcess(db, {
+          accountId: ids.accountId,
+          workspaceId: ids.workspaceId,
+          sessionId: ids.sessionId,
+          processId: process.id,
+          expected: retainedProcessSettlementIdentity(durable),
+          outcome: proof.outcome,
+          exitCode: proof.exitCode,
+          reason: proof.reason,
+          idleGraceMs: settings.sandboxIdleGraceMs,
+        });
+      }
+    : undefined;
   const resolver = makeActiveBackendResolver({
     workspaceId: ids.workspaceId,
     defaultBackend: established.session as RoutableBackendSession,
@@ -348,13 +366,28 @@ export function wrapChannelABoxWithRouting(
     },
     controlRpcFactory: controlRpcFactory(bus),
     relay: relayConfigFromSettings(settings),
-    resolveDefaultBackend: async () => ({
-      session: established.session as RoutableBackendSession,
-      sandboxId: null,
-      kind: established.backendId,
-      leaseEpoch: ids.homeLease.leaseEpoch,
-      providerInstanceId: ids.homeLease.instanceId,
-    }),
+    selfhostedTimeoutMs: settings.sandboxSelfhostedControlTimeoutMs,
+    selfhostedExecTimeoutMs: settings.sandboxSelfhostedExecTimeoutMs,
+    ...(ids.pinnedSelfhosted
+      ? {
+          pinnedSelfhosted: {
+            sandboxId: ids.pinnedSelfhosted.sandboxId,
+            epoch: ids.pinnedSelfhosted.epoch,
+            session: established.session as RoutableBackendSession,
+          },
+        }
+      : {}),
+    ...(homeLease
+      ? {
+          resolveDefaultBackend: async () => ({
+            session: established.session as RoutableBackendSession,
+            sandboxId: null,
+            kind: established.backendId,
+            leaseEpoch: homeLease.leaseEpoch,
+            providerInstanceId: homeLease.instanceId,
+          }),
+        }
+      : {}),
   });
 
   const proxy = new RoutingSandboxSession({
@@ -362,8 +395,12 @@ export function wrapChannelABoxWithRouting(
       session: established.session as RoutableBackendSession,
       sandboxId: null,
       kind: established.backendId,
-      leaseEpoch: ids.homeLease.leaseEpoch,
-      providerInstanceId: ids.homeLease.instanceId,
+      ...(homeLease
+        ? {
+            leaseEpoch: homeLease.leaseEpoch,
+            providerInstanceId: homeLease.instanceId,
+          }
+        : {}),
     },
     readPointer: async () => {
       if (!routingEnabled(settings)) {
@@ -373,43 +410,47 @@ export function wrapChannelABoxWithRouting(
       return pointer ?? { activeSandboxId: null, activeEpoch: 0 };
     },
     resolveActiveBackend: resolver,
-    beforeMutation,
-    afterMutation,
-    beforeProcessMutation,
-    afterProcessMutation,
-    settleProcess,
-    onDefaultBackendError: async ({ error }) => {
-      if (!isProviderSandboxGoneDuringRoutedOperation(ids.homeLease.backend, error)) return null;
-      const marked = await markWarmLeaseInstanceLost(db, {
-        accountId: ids.accountId,
-        workspaceId: ids.workspaceId,
-        sandboxGroupId: ids.homeLease.sandboxGroupId,
-        expectedEpoch: ids.homeLease.leaseEpoch,
-        expectedInstanceId: ids.homeLease.instanceId,
-        diagnostic: "provider_not_found_during_routed_operation",
-      });
-      if (marked.status === "marked" && bus) {
-        await appendAndPublishEvents(db, bus, ids.workspaceId, ids.sessionId, [
-          {
-            type: "sandbox.box.lost",
-            payload: { sandboxId: ids.homeLease.instanceId },
+    ...(beforeMutation ? { beforeMutation } : {}),
+    ...(afterMutation ? { afterMutation } : {}),
+    ...(beforeProcessMutation ? { beforeProcessMutation } : {}),
+    ...(afterProcessMutation ? { afterProcessMutation } : {}),
+    ...(settleProcess ? { settleProcess } : {}),
+    ...(homeLease
+      ? {
+          onDefaultBackendError: async ({ error }: { error: unknown }) => {
+            if (!isProviderSandboxGoneDuringRoutedOperation(homeLease.backend, error)) return null;
+            const marked = await markWarmLeaseInstanceLost(db, {
+              accountId: ids.accountId,
+              workspaceId: ids.workspaceId,
+              sandboxGroupId: homeLease.sandboxGroupId,
+              expectedEpoch: homeLease.leaseEpoch,
+              expectedInstanceId: homeLease.instanceId,
+              diagnostic: "provider_not_found_during_routed_operation",
+            });
+            if (marked.status === "marked" && bus) {
+              await appendAndPublishEvents(db, bus, ids.workspaceId, ids.sessionId, [
+                {
+                  type: "sandbox.box.lost",
+                  payload: { sandboxId: homeLease.instanceId },
+                },
+              ]).catch(() => undefined);
+            }
+            const lease = marked.lease;
+            const restore = lease?.recovery.restore.status;
+            return {
+              leaseEpoch: lease?.leaseEpoch ?? homeLease.leaseEpoch,
+              recovery:
+                marked.status === "stale"
+                  ? ("superseded" as const)
+                  : restore === "pending"
+                    ? ("pending" as const)
+                    : restore === "degraded"
+                      ? ("degraded" as const)
+                      : ("unrecoverable" as const),
+            };
           },
-        ]).catch(() => undefined);
-      }
-      const lease = marked.lease;
-      const restore = lease?.recovery.restore.status;
-      return {
-        leaseEpoch: lease?.leaseEpoch ?? ids.homeLease.leaseEpoch,
-        recovery:
-          marked.status === "stale"
-            ? ("superseded" as const)
-            : restore === "pending"
-              ? ("pending" as const)
-              : restore === "degraded"
-                ? ("degraded" as const)
-                : ("unrecoverable" as const),
-      };
-    },
+        }
+      : {}),
   });
 
   return { ...established, session: proxy };

--- a/scripts/operator/connected-machine-load-profile.test.ts
+++ b/scripts/operator/connected-machine-load-profile.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  discoverApiContract,
   executeBounded,
   parseConnectedMachineLoadArgs,
   percentile,
@@ -80,5 +81,54 @@ describe("Connected Machine load profile", () => {
 
     expect(completed).toBe(31);
     expect(peak).toBe(4);
+  });
+
+  test("discovers the target API contract through an authenticated read", async () => {
+    const args = parseConnectedMachineLoadArgs(
+      [
+        "--base-url",
+        "https://opengeni.example.test",
+        "--workspace-id",
+        "workspace-1",
+        "--session-id",
+        "session-1",
+      ],
+      {},
+    );
+    let requestedUrl = "";
+    let requestedHeaders: HeadersInit | undefined;
+    const contract = await discoverApiContract(
+      args,
+      { authorization: "Bearer product-token" },
+      async (input, init) => {
+        requestedUrl = String(input);
+        requestedHeaders = init?.headers;
+        return new Response("{}", {
+          headers: { "x-opengeni-api-contract": "contract-v2" },
+        });
+      },
+    );
+
+    expect(contract).toBe("contract-v2");
+    expect(requestedUrl).toBe(
+      "https://opengeni.example.test/v1/workspaces/workspace-1/sessions/session-1",
+    );
+    expect(requestedHeaders).toEqual({ authorization: "Bearer product-token" });
+  });
+
+  test("supports older targets that do not advertise an API contract", async () => {
+    const args = parseConnectedMachineLoadArgs(
+      [
+        "--base-url",
+        "https://opengeni.example.test",
+        "--workspace-id",
+        "workspace-1",
+        "--session-id",
+        "session-1",
+      ],
+      {},
+    );
+
+    expect(await discoverApiContract(args, {}, async () => new Response("{}"))).toBeNull();
   });
 });

--- a/scripts/operator/connected-machine-load-profile.ts
+++ b/scripts/operator/connected-machine-load-profile.ts
@@ -41,6 +41,8 @@ interface StageResult {
   failureCounts: Record<string, number>;
 }
 
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
 export function parseConnectedMachineLoadArgs(
   values: string[],
   env: Record<string, string | undefined> = process.env,
@@ -168,10 +170,15 @@ export async function executeBounded(
 
 async function main(): Promise<void> {
   const args = parseConnectedMachineLoadArgs(process.argv.slice(2));
-  const headers = {
+  const baseHeaders = {
     "content-type": "application/json",
     ...(args.deploymentAccessKey ? { "x-opengeni-access-key": args.deploymentAccessKey } : {}),
     ...(args.productToken ? { authorization: `Bearer ${args.productToken}` } : {}),
+  };
+  const apiContract = await discoverApiContract(args, baseHeaders);
+  const headers = {
+    ...baseHeaders,
+    ...(apiContract ? { "x-opengeni-api-contract": apiContract } : {}),
   };
 
   await warmUp(args, headers);
@@ -208,6 +215,28 @@ async function main(): Promise<void> {
     printHumanResult(result);
   }
   if (!result.verdict.passed) process.exitCode = 2;
+}
+
+export async function discoverApiContract(
+  args: ConnectedMachineLoadArgs,
+  headers: Record<string, string>,
+  fetchImpl: FetchLike = fetch,
+): Promise<string | null> {
+  const endpoint = new URL(
+    `/v1/workspaces/${encodeURIComponent(args.workspaceId)}/sessions/${encodeURIComponent(args.sessionIds[0]!)}`,
+    args.baseUrl,
+  );
+  const response = await fetchImpl(endpoint, {
+    method: "GET",
+    headers,
+    signal: AbortSignal.timeout(args.requestTimeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`API contract discovery failed: ${await httpFailure(response)}`);
+  }
+  const contract = response.headers.get("x-opengeni-api-contract")?.trim() || null;
+  await response.arrayBuffer();
+  return contract;
 }
 
 async function warmUp(


### PR DESCRIPTION
## Summary

- route the first direct terminal/filesystem command for a session whose durable home is an enrolled machine straight through the active machine pointer
- avoid creating a cloud/provider lease for that machine-home path while retaining machine and epoch fencing
- make the Connected Machine load profiler discover and send the live API contract revision
- force non-interactive re-enrollment when an operator supplies a new enrollment token so stale credentials cannot silently win
- enable sandbox ownership and document the deployment public base URL in the generic single-node profile
- bump the chart to 0.22.5 and add patch changesets for the affected packages

## Verification

- API and core typechecks passed
- focused machine-home, installer, Channel-A routing, load-profiler, Helm upgrade/version, shared sandbox, and routing-proxy tests passed
- regression coverage proves the first direct machine command creates no provider sandbox lease
- public-repository hygiene and formatting checks passed
- full local check completed with 4,741 passing and 37 failures confined to existing macOS real-local-box/process-group substrate plus one shared hook timeout; protected Linux CI is the authoritative full signal