### PR TITLE
fix(deploy): keep safe reads available during control outages

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -308,6 +308,12 @@ export function createApp(deps: AppDependencies): Hono {
     return c.json(result, result.ok ? 200 : 503);
   });
 
+  app.get("/traffic-readyz", async (c) => {
+    const { db } = readinessChecks(deps);
+    const result = await runReadinessChecks({ db }, 2_000);
+    return c.json(result, result.ok ? 200 : 503);
+  });
+
   app.get("/metrics", async (c) =>
     c.text(await observability.prometheusMetrics(), 200, {
       "content-type": "text/plain; version=0.0.4; charset=utf-8",
@@ -576,7 +582,9 @@ function boundedCorrelationId(value: string | undefined): string | null {
 }
 
 type ReadinessCheckName = "db" | "nats" | "temporal";
-type ReadinessChecks = Record<ReadinessCheckName, () => Promise<void> | void>;
+type ReadinessCheck = () => Promise<void> | void;
+type ReadinessChecks = Record<ReadinessCheckName, ReadinessCheck>;
+type ReadinessCheckResult = { ok: boolean; error?: string };
 
 function readinessChecks(deps: AppDependencies): ReadinessChecks {
   return {
@@ -601,35 +609,30 @@ function readinessChecks(deps: AppDependencies): ReadinessChecks {
   };
 }
 
-async function runReadinessChecks(
-  checks: ReadinessChecks,
+async function runReadinessChecks<const Checks extends Readonly<Record<string, ReadinessCheck>>>(
+  checks: Checks,
   timeoutMs: number,
 ): Promise<{
   ok: boolean;
-  checks: Record<ReadinessCheckName, { ok: boolean; error?: string }>;
+  checks: { [Name in keyof Checks]: ReadinessCheckResult };
 }> {
   const entries = await Promise.all(
-    (Object.entries(checks) as Array<[ReadinessCheckName, () => Promise<void> | void]>).map(
-      async ([name, check]) => {
-        try {
-          await withTimeout(Promise.resolve().then(check), timeoutMs);
-          return [name, { ok: true }] as const;
-        } catch (error) {
-          return [
-            name,
-            {
-              ok: false,
-              error: error instanceof Error ? error.message : String(error),
-            },
-          ] as const;
-        }
-      },
-    ),
+    (Object.entries(checks) as Array<[keyof Checks, ReadinessCheck]>).map(async ([name, check]) => {
+      try {
+        await withTimeout(Promise.resolve().then(check), timeoutMs);
+        return [name, { ok: true }] as const;
+      } catch (error) {
+        return [
+          name,
+          {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        ] as const;
+      }
+    }),
   );
-  const result = Object.fromEntries(entries) as Record<
-    ReadinessCheckName,
-    { ok: boolean; error?: string }
-  >;
+  const result = Object.fromEntries(entries) as { [Name in keyof Checks]: ReadinessCheckResult };
   return {
     ok: Object.values(result).every((check) => check.ok),
     checks: result,
@@ -658,6 +661,7 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T
 const routeLabelPatterns: Array<{ pattern: RegExp; label: string }> = [
   { pattern: /^\/healthz$/, label: "/healthz" },
   { pattern: /^\/readyz$/, label: "/readyz" },
+  { pattern: /^\/traffic-readyz$/, label: "/traffic-readyz" },
   {
     pattern: /^\/v1\/workspaces\/[^/]+\/codex\/connect\/start$/,
     label: "/v1/workspaces/:workspaceId/codex/connect/start",

--- a/apps/api/src/http/auth.ts
+++ b/apps/api/src/http/auth.ts
@@ -77,7 +77,10 @@ function isAuthExempt(c: Context, settings: Settings): boolean {
   if (installExactPaths.has(path) || isInstallRedirectPath(path)) {
     return true;
   }
-  if (settings.authAllowHealth && (path === "/healthz" || path === "/readyz")) {
+  if (
+    settings.authAllowHealth &&
+    (path === "/healthz" || path === "/readyz" || path === "/traffic-readyz")
+  ) {
     return true;
   }
   if (settings.authAllowMetrics && path === "/metrics") {

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -450,6 +450,7 @@ describe("API helpers", () => {
     );
     expect(routeLabel("/v1/unregistered/resource-1")).toBe("/v1/unknown");
     expect(routeLabel("/readyz")).toBe("/readyz");
+    expect(routeLabel("/traffic-readyz")).toBe("/traffic-readyz");
   });
 
   test("preserves HTTPException status codes in error metrics", () => {
@@ -539,6 +540,65 @@ describe("API helpers", () => {
     expect(body.ok).toBe(false);
     expect(body.checks.nats.ok).toBe(false);
     expect(body.checks.nats.error).toContain("nats down");
+  });
+
+  test("traffic-readyz stays routable through a NATS or Temporal outage", async () => {
+    let natsChecks = 0;
+    let temporalChecks = 0;
+    const app = createApp({
+      settings: {
+        ...testSettings(),
+        authRequired: true,
+        accessKey: "deployment-key",
+        authAllowHealth: true,
+      },
+      db: {} as never,
+      bus: { isConnected: () => false } as never,
+      workflowClient: {} as never,
+      managedAuth: null,
+      readinessChecks: {
+        db: async () => {},
+        nats: () => {
+          natsChecks += 1;
+          throw new Error("nats down");
+        },
+        temporal: async () => {
+          temporalChecks += 1;
+          throw new Error("temporal down");
+        },
+      },
+    });
+
+    const response = await app.request("/traffic-readyz");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, checks: { db: { ok: true } } });
+    expect(natsChecks).toBe(0);
+    expect(temporalChecks).toBe(0);
+  });
+
+  test("traffic-readyz stops routing when the durable database is unavailable", async () => {
+    const app = createApp({
+      settings: testSettings(),
+      db: {} as never,
+      bus: {} as never,
+      workflowClient: {} as never,
+      managedAuth: null,
+      readinessChecks: {
+        db: async () => {
+          throw new Error("database down");
+        },
+      },
+    });
+
+    const response = await app.request("/traffic-readyz");
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as {
+      ok: boolean;
+      checks: { db: { ok: boolean; error?: string } };
+    };
+    expect(body.ok).toBe(false);
+    expect(body.checks.db.ok).toBe(false);
+    expect(body.checks.db.error).toContain("database down");
   });
 
   test("rejects oversized streamed request bodies before route parsing", async () => {

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.5
-appVersion: "0.22.5"
+version: 0.22.6
+appVersion: "0.22.6"

--- a/deploy/helm/opengeni/values.single-node.example.yaml
+++ b/deploy/helm/opengeni/values.single-node.example.yaml
@@ -17,6 +17,11 @@ api:
     enabled: false
   autoscaling:
     enabled: false
+  probes:
+    # Keep safe database-backed API traffic available when restartable
+    # orchestration or machine-control plumbing is temporarily unavailable.
+    readiness:
+      path: /traffic-readyz
   service:
     type: NodePort
     port: 8000

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -64,6 +64,13 @@ threshold when overriding `eviction-hard`; Kubernetes otherwise zeroes omitted
 defaults. This preserves elastic sharing while giving the kubelet room to
 enforce the intended order.
 
+The API's single-node readiness probe uses `/traffic-readyz`, which checks only
+Postgres. If NATS or Temporal restarts, Kubernetes keeps routing safe
+database-backed reads while commands that need the unavailable dependency fail
+explicitly and recover after reconnect. `/readyz` remains the complete
+Postgres/NATS/Temporal dependency report, so the outage is still visible to
+operators. Losing Postgres fails both readiness paths.
+
 The ordinary dependency services remain private `ClusterIP` services. Five
 one-port NodePort services are the complete private-edge surface:
 
@@ -79,9 +86,10 @@ The NATS client/monitor ports and MinIO admin console are not exposed. On K3s,
 bind NodePorts to loopback with
 `--kube-proxy-arg=nodeport-addresses=127.0.0.0/8`, then publish only the five
 loopback listeners through a private edge such as Tailscale Serve. Route `/` to
-web and route `/v1`, `/healthz`, `/metrics`, `/install.sh`, `/install.ps1`,
-`/uninstall.sh`, `/opengeni-agent-minisign.pub`, and `/agent` to the API. Give
-the NATS websocket, relay, and MinIO API their own private TLS ports. Set
+web and route `/v1`, `/healthz`, `/readyz`, `/traffic-readyz`, `/metrics`,
+`/install.sh`, `/install.ps1`, `/uninstall.sh`,
+`/opengeni-agent-minisign.pub`, and `/agent` to the API. Give the NATS
+websocket, relay, and MinIO API their own private TLS ports. Set
 `selfhosted.natsUrl`, `selfhosted.relayUrl`, and `minio.publicEndpoint` to those
 private URLs. Also set `OPENGENI_PUBLIC_BASE_URL` to the browser/API origin. The
 API uses it when serving the installer, so an enrolled machine downloads the
@@ -1186,7 +1194,7 @@ OpenGeni emits Prometheus-native metrics. Scrape `/metrics` directly; do not rou
 
 Service endpoints:
 
-- API: `GET /metrics` and `GET /healthz` on `OPENGENI_API_PORT` (default `8000`); `GET /readyz` checks Postgres, NATS, and Temporal with bounded timeouts.
+- API: `GET /metrics` and `GET /healthz` on `OPENGENI_API_PORT` (default `8000`); `GET /traffic-readyz` checks Postgres for traffic routing, while `GET /readyz` reports Postgres, NATS, and Temporal with bounded timeouts.
 - Worker: `GET /metrics`, `GET /healthz`, and `GET /readyz` on `OPENGENI_WORKER_HTTP_PORT` (default `8001`); readiness requires lifecycle state `ready` plus healthy Postgres, NATS, and Temporal checks. A draining worker stays live but becomes unready before polling stops.
 - Relay: `GET /metrics` and `GET /healthz` on the relay port when the relay is enabled.
 
@@ -1195,7 +1203,7 @@ Useful settings:
 - `OPENGENI_OBSERVABILITY_STRUCTURED_LOGS=true` for JSON logs.
 - `OPENGENI_OBSERVABILITY_METRICS_ENABLED=true` to expose process and domain metrics.
 - `OPENGENI_WORKER_HTTP_PORT=8001` for the worker metrics/health listener.
-- `OPENGENI_AUTH_ALLOW_HEALTH=true` allows both `/healthz` and `/readyz` through the deployment-key gate.
+- `OPENGENI_AUTH_ALLOW_HEALTH=true` allows `/healthz`, `/traffic-readyz`, and `/readyz` through the deployment-key gate.
 - `OPENGENI_AUTH_ALLOW_METRICS=true` allows API `/metrics` through the deployment-key gate for an internal scraper path.
 - `OPENGENI_DISABLE_OPENAI_TRACING=true` disables OpenAI Agents SDK tracing; tracing also defaults off when no OTLP endpoint is configured.
 - `OPENGENI_OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318` to export spans to an OpenTelemetry Collector.

--- a/scripts/helm-upgrade-contract.test.ts
+++ b/scripts/helm-upgrade-contract.test.ts
@@ -64,6 +64,7 @@ describe("Helm database upgrade contract", () => {
     expect(values).not.toContain("autoscaling:\n    enabled: true");
     expect(values).toContain("resources: null");
     expect(values).toContain("priorityClasses:\n  enabled: true");
+    expect(values).toContain("path: /traffic-readyz");
     for (const tier of ["presentation", "execution", "control", "durable"]) {
       expect(defaults).toContain(`    ${tier}:`);
     }


### PR DESCRIPTION
## What
- add a database-only `/traffic-readyz` endpoint for traffic routing
- keep `/readyz` as the full Postgres/NATS/Temporal dependency report
- use layered readiness in the non-HA single-node profile
- document the failure behavior and private-edge route
- bump the Helm chart to 0.22.6

## Why
NATS and Temporal are restartable live control/orchestration dependencies. Their outage should stop commands that need them, but should not remove safe database-backed reads from service. Postgres remains the traffic-critical durable dependency.

## Verification
- `bun test apps/api/test/app.test.ts scripts/helm-upgrade-contract.test.ts`
- `bun run --cwd apps/api typecheck`
- `bun run format:check`
- `bun run check:docs-refs`
- `bun run check:public-hygiene`
- `helm lint deploy/helm/opengeni --values deploy/helm/opengeni/values.single-node.example.yaml`