### PR TITLE
fix(deploy): render worker storage endpoint once

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.7
-appVersion: "0.22.7"
+version: 0.22.8
+appVersion: "0.22.8"

--- a/deploy/helm/opengeni/templates/_helpers.tpl
+++ b/deploy/helm/opengeni/templates/_helpers.tpl
@@ -132,46 +132,54 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "opengeni.generatedRuntimeEnv" -}}
-{{- if .Values.postgres.enabled }}
-{{- if .Values.postgres.runtime.existingSecret }}
+{{- $root := . -}}
+{{- $objectStorageEndpoint := "" -}}
+{{- if hasKey . "root" -}}
+{{- $root = .root -}}
+{{- $objectStorageEndpoint = .objectStorageEndpoint -}}
+{{- else if $root.Values.minio.enabled -}}
+{{- $objectStorageEndpoint = include "opengeni.minioEndpoint" $root -}}
+{{- end -}}
+{{- if $root.Values.postgres.enabled }}
+{{- if $root.Values.postgres.runtime.existingSecret }}
 - name: OPENGENI_DATABASE_URL
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.postgres.runtime.existingSecret }}
-      key: {{ .Values.postgres.runtime.databaseUrlKey }}
+      name: {{ $root.Values.postgres.runtime.existingSecret }}
+      key: {{ $root.Values.postgres.runtime.databaseUrlKey }}
 {{- else }}
 - name: OPENGENI_POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ include "opengeni.postgresSecretName" . }}
-      key: {{ .Values.postgres.auth.passwordKey }}
+      name: {{ include "opengeni.postgresSecretName" $root }}
+      key: {{ $root.Values.postgres.auth.passwordKey }}
 - name: OPENGENI_DATABASE_URL
-  value: {{ printf "postgres://%s:$(OPENGENI_POSTGRES_PASSWORD)@%s:%d/%s" .Values.postgres.auth.username (include "opengeni.postgresHost" .) (.Values.postgres.service.port | int) .Values.postgres.auth.database | quote }}
+  value: {{ printf "postgres://%s:$(OPENGENI_POSTGRES_PASSWORD)@%s:%d/%s" $root.Values.postgres.auth.username (include "opengeni.postgresHost" $root) ($root.Values.postgres.service.port | int) $root.Values.postgres.auth.database | quote }}
 {{- end }}
 {{- end }}
-{{- if .Values.temporal.enabled }}
+{{- if $root.Values.temporal.enabled }}
 - name: OPENGENI_TEMPORAL_HOST
-  value: {{ printf "%s-temporal:%d" (include "opengeni.fullname" .) (.Values.temporal.service.port | int) | quote }}
+  value: {{ printf "%s-temporal:%d" (include "opengeni.fullname" $root) ($root.Values.temporal.service.port | int) | quote }}
 {{- end }}
-{{- if .Values.minio.enabled }}
+{{- if $root.Values.minio.enabled }}
 - name: OPENGENI_OBJECT_STORAGE_ENDPOINT
-  value: {{ include "opengeni.minioEndpoint" . | quote }}
+  value: {{ $objectStorageEndpoint | quote }}
 - name: OPENGENI_OBJECT_STORAGE_SANDBOX_ENDPOINT
-  value: {{ include "opengeni.minioSandboxEndpoint" . | quote }}
+  value: {{ include "opengeni.minioSandboxEndpoint" $root | quote }}
 - name: OPENGENI_OBJECT_STORAGE_BACKEND
   value: s3-compatible
 - name: OPENGENI_OBJECT_STORAGE_BUCKET
-  value: {{ .Values.minio.bucket | quote }}
+  value: {{ $root.Values.minio.bucket | quote }}
 - name: OPENGENI_OBJECT_STORAGE_ACCESS_KEY_ID
   valueFrom:
     secretKeyRef:
-      name: {{ include "opengeni.minioSecretName" . }}
-      key: {{ .Values.minio.auth.accessKeyKey }}
+      name: {{ include "opengeni.minioSecretName" $root }}
+      key: {{ $root.Values.minio.auth.accessKeyKey }}
 - name: OPENGENI_OBJECT_STORAGE_SECRET_ACCESS_KEY
   valueFrom:
     secretKeyRef:
-      name: {{ include "opengeni.minioSecretName" . }}
-      key: {{ .Values.minio.auth.secretKeyKey }}
+      name: {{ include "opengeni.minioSecretName" $root }}
+      key: {{ $root.Values.minio.auth.secretKeyKey }}
 {{- end }}
 {{- end -}}
 

--- a/deploy/helm/opengeni/templates/worker-deployment.yaml
+++ b/deploy/helm/opengeni/templates/worker-deployment.yaml
@@ -68,20 +68,7 @@ spec:
             - name: OPENGENI_WORKER_ROLE
               value: control
             {{- if or .Values.postgres.enabled .Values.temporal.enabled .Values.minio.enabled }}
-            {{- include "opengeni.generatedRuntimeEnv" . | nindent 12 }}
-            {{- if .Values.minio.enabled }}
-            # Worker-only override: the worker performs SERVER-SIDE object-storage
-            # PUTs in-cluster (e.g. recording uploads) and mints NO browser-facing
-            # presigned URLs, so it must reach MinIO over the in-cluster Service. The
-            # shared OPENGENI_OBJECT_STORAGE_ENDPOINT emitted by generatedRuntimeEnv is
-            # the PUBLIC endpoint that api/web sign browser presigned URLs against; on
-            # managed deployments that host has no MinIO ingress route, so a server-side
-            # PUT there 401s (the recording-upload bug). A later duplicate env entry
-            # wins in a container env list, so this overrides ONLY the worker — api/web
-            # keep the public endpoint for browser uploads.
-            - name: OPENGENI_OBJECT_STORAGE_ENDPOINT
-              value: {{ include "opengeni.minioInternalEndpoint" . | quote }}
-            {{- end }}
+            {{- include "opengeni.generatedRuntimeEnv" (dict "root" . "objectStorageEndpoint" (include "opengeni.minioInternalEndpoint" .)) | nindent 12 }}
             {{- end }}
           {{- if (((.Values.worker).probes).readiness).enabled }}
           readinessProbe:

--- a/deploy/helm/opengeni/templates/worker-turns-deployment.yaml
+++ b/deploy/helm/opengeni/templates/worker-turns-deployment.yaml
@@ -68,11 +68,7 @@ spec:
             - name: OPENGENI_WORKER_ROLE
               value: turn
             {{- if or .Values.postgres.enabled .Values.temporal.enabled .Values.minio.enabled }}
-            {{- include "opengeni.generatedRuntimeEnv" . | nindent 12 }}
-            {{- if .Values.minio.enabled }}
-            - name: OPENGENI_OBJECT_STORAGE_ENDPOINT
-              value: {{ include "opengeni.minioInternalEndpoint" . | quote }}
-            {{- end }}
+            {{- include "opengeni.generatedRuntimeEnv" (dict "root" . "objectStorageEndpoint" (include "opengeni.minioInternalEndpoint" .)) | nindent 12 }}
             {{- end }}
           {{- if (((.Values.worker).probes).readiness).enabled }}
           readinessProbe:

--- a/scripts/helm-upgrade-contract.test.ts
+++ b/scripts/helm-upgrade-contract.test.ts
@@ -42,13 +42,22 @@ describe("Helm database upgrade contract", () => {
       expect(workload).not.toContain('name: {{ include "opengeni.migrationSecretName" . }}');
     }
 
-    const restrictedRuntime = helpers.indexOf("{{- if .Values.postgres.runtime.existingSecret }}");
+    const restrictedRuntime = helpers.indexOf(
+      "{{- if $root.Values.postgres.runtime.existingSecret }}",
+    );
     const ownerPassword = helpers.indexOf("- name: OPENGENI_POSTGRES_PASSWORD");
     expect(restrictedRuntime).toBeGreaterThan(-1);
     expect(ownerPassword).toBeGreaterThan(restrictedRuntime);
     expect(helpers.slice(restrictedRuntime, ownerPassword)).toContain(
       "- name: OPENGENI_DATABASE_URL",
     );
+
+    for (const worker of [workerDeployment, turnWorkerDeployment]) {
+      expect(worker).toContain(
+        '"objectStorageEndpoint" (include "opengeni.minioInternalEndpoint" .)',
+      );
+      expect(worker).not.toContain("- name: OPENGENI_OBJECT_STORAGE_ENDPOINT");
+    }
   });
 
   test("ships a non-HA single-node profile with narrow private-edge services", async () => {


### PR DESCRIPTION
## What
- render the worker object-storage endpoint as a helper parameter instead of a duplicate env entry
- keep API/migration consumers on the public endpoint and workers on the internal MinIO service
- add a regression contract and bump the chart to 0.22.8

## Why
Kubernetes warned that the worker templates declared `OPENGENI_OBJECT_STORAGE_ENDPOINT` twice and could drop the overriding entry during apply. The current values happened to work through last-entry-wins semantics, but that is not a stable deployment contract.

## Verification
- `bun test scripts/helm-upgrade-contract.test.ts`
- `helm lint deploy/helm/opengeni`
- rendered single-node chart has unique env names
- both worker deployments render `http://<release>-minio:9000` exactly once