### PR TITLE
fix(deploy): align density profile subject grant

### DIFF
--- a/scripts/operator/turn-density-profile.ts
+++ b/scripts/operator/turn-density-profile.ts
@@ -21,9 +21,10 @@ const plateauSeconds = positiveInteger("OPENGENI_DENSITY_PLATEAU_SECONDS", 15);
 const hardLimitMiB = positiveNumber("OPENGENI_DENSITY_HARD_LIMIT_MIB_PER_TURN", 100);
 const targetMiB = positiveNumber("OPENGENI_DENSITY_TARGET_MIB_PER_TURN", 50);
 const runId = crypto.randomUUID();
+const profileSubjectId = `operator:turn-density-profile:${runId}`;
 const profileInitiator = {
   kind: "service" as const,
-  subjectId: "turn-density-profile",
+  subjectId: profileSubjectId,
   label: "Turn density profile",
 };
 
@@ -86,7 +87,7 @@ try {
     workspaceExternalSource: "operator:turn-density-profile",
     workspaceExternalId: runId,
     workspaceName: `Turn density profile ${runId}`,
-    subjectId: `operator:turn-density-profile:${runId}`,
+    subjectId: profileSubjectId,
     subjectLabel: "Turn density profile",
   });
   const grant = access.workspaceGrants[0];

--- a/scripts/operator/turn-density-profile.ts
+++ b/scripts/operator/turn-density-profile.ts
@@ -4,13 +4,13 @@ import {
   bootstrapWorkspace,
   createDb,
   createSession,
-  deleteWorkspace,
   enqueueSessionTurn,
   withWorkspaceRls,
 } from "@opengeni/db";
 import * as schema from "@opengeni/db/schema";
 import { createProductionAgentRuntime } from "@opengeni/runtime";
 import { MemoryEventBus, ScriptedModel } from "@opengeni/testing";
+import { eq } from "drizzle-orm";
 import { createTurnActivities } from "../../apps/worker/src/activities";
 
 const MIB = 1024 * 1024;
@@ -213,11 +213,20 @@ try {
 } finally {
   model.release();
   await Promise.allSettled(runs);
-  if (workspaceId) {
-    await deleteWorkspace(dbClient.db, workspaceId).catch((error) => {
-      console.error(`Density workspace cleanup failed: ${errorMessage(error)}`);
-      process.exitCode = 1;
-    });
+  if (accountId) {
+    await dbClient.db
+      .delete(schema.managedAccounts)
+      .where(eq(schema.managedAccounts.id, accountId))
+      .catch((error) => {
+        console.error(`Density account cleanup failed: ${errorMessage(error)}`);
+        process.exitCode = 1;
+      });
+  } else if (workspaceId) {
+    // accountId and workspaceId are assigned from the same bootstrap result.
+    // Keep the branch explicit so a future partial-bootstrap refactor cannot
+    // silently leave a workspace behind.
+    console.error("Density profile cannot clean a workspace without its managed account");
+    process.exitCode = 1;
   }
   await dbClient.close();
 }

--- a/scripts/turn-density-profile-contract.test.ts
+++ b/scripts/turn-density-profile-contract.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+test("uses the granted workspace subject for synthetic turn execution", async () => {
+  const source = await readFile(
+    resolve(import.meta.dir, "operator/turn-density-profile.ts"),
+    "utf8",
+  );
+
+  expect(source).toContain(
+    "const profileSubjectId = `operator:turn-density-profile:${runId}`;",
+  );
+  expect(source.match(/subjectId: profileSubjectId/g)).toHaveLength(2);
+  expect(source).not.toContain('subjectId: "turn-density-profile"');
+});

--- a/scripts/turn-density-profile-contract.test.ts
+++ b/scripts/turn-density-profile-contract.test.ts
@@ -8,9 +8,9 @@ test("uses the granted workspace subject for synthetic turn execution", async ()
     "utf8",
   );
 
-  expect(source).toContain(
-    "const profileSubjectId = `operator:turn-density-profile:${runId}`;",
-  );
+  expect(source).toContain("const profileSubjectId = `operator:turn-density-profile:${runId}`;");
   expect(source.match(/subjectId: profileSubjectId/g)).toHaveLength(2);
   expect(source).not.toContain('subjectId: "turn-density-profile"');
+  expect(source).toContain(".delete(schema.managedAccounts)");
+  expect(source).toContain(".where(eq(schema.managedAccounts.id, accountId))");
 });


### PR DESCRIPTION
## What
- use one run-scoped subject id for both the density profile workspace grant and synthetic turn initiator
- delete the run-scoped managed account after the profile, cascading its temporary workspace
- add regression contracts for identity and cleanup

## Why
The documented density profiler worked in isolated test postures but failed in a deployed image: synthetic turns attached the first-party MCP server as `turn-density-profile`, while the temporary workspace granted `operator:turn-density-profile:<run-id>`. The MCP access check correctly returned 403, so the profile never reached its model gate. The failed live reproduction also showed that deleting only the workspace retained one run-scoped account.

## Verification
- reproduced the 403 in the official Linux arm64 worker image
- confirmed the temporary workspace was removed
- `bun test scripts/turn-density-profile-contract.test.ts`
- `bunx tsgo --project scripts/operator/tsconfig.json`