### PR TITLE
fix(deploy): isolate turn density profiling

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.8
-appVersion: "0.22.8"
+version: 0.22.9
+appVersion: "0.22.9"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -375,6 +375,12 @@ run a smaller representative set of real development tasks before choosing an
 active-turn concurrency target. A large number of durable idle sessions is not
 equivalent to the same number of simultaneously executing turns.
 
+The density profile uses a scripted model and an in-process first-party MCP
+endpoint, so it exercises turn setup without a model-provider key or the
+deployment's user-facing access mode. It creates a run-scoped account and
+workspace, removes both before exit, and prints one
+`OPENGENI_DENSITY_RESULT=...` record for automation.
+
 Direct file, Git, and synchronous terminal APIs follow a machine-targeted
 session's active pointer from the first request. They use API → NATS → enrolled
 agent request/reply and do not need a preceding model turn, a turn worker, or a

--- a/scripts/operator/turn-density-profile.ts
+++ b/scripts/operator/turn-density-profile.ts
@@ -9,7 +9,7 @@ import {
 } from "@opengeni/db";
 import * as schema from "@opengeni/db/schema";
 import { createProductionAgentRuntime } from "@opengeni/runtime";
-import { MemoryEventBus, ScriptedModel } from "@opengeni/testing";
+import { MemoryEventBus, ScriptedModel, startTestMcpServer } from "@opengeni/testing";
 import { eq } from "drizzle-orm";
 import { createTurnActivities } from "../../apps/worker/src/activities";
 
@@ -29,6 +29,13 @@ const profileInitiator = {
 };
 
 const productionSettings = getSettings();
+// The profile creates an isolated workspace that is intentionally absent from
+// the running deployment's user-facing access mode. Keep first-party MCP setup
+// in the measured turn, but terminate it locally so local/configured/managed
+// deployments all exercise the same density workload without borrowing a
+// production principal or access secret.
+const densityMcp = startTestMcpServer();
+const densityMcpUrl = `${densityMcp.url}?workspace={workspaceId}`;
 const settings: Settings = {
   ...productionSettings,
   environment: `${productionSettings.environment}-density-profile`,
@@ -58,6 +65,15 @@ const settings: Settings = {
   workspaceCaptureEnabled: false,
   integrationsEnabled: false,
   toolspaceEnabled: false,
+  opengeniMcpUrl: densityMcpUrl,
+  mcpServers: [
+    {
+      id: "opengeni",
+      name: "OpenGeni density profile",
+      url: densityMcpUrl,
+      cacheToolsList: false,
+    },
+  ],
 };
 
 const searchPath = dbSearchPath(settings);
@@ -78,6 +94,7 @@ const activities = createTurnActivities({
 let workspaceId: string | null = null;
 let accountId: string | null = null;
 let runs: Array<Promise<unknown>> = [];
+let runFailure: unknown = null;
 
 try {
   const access = await bootstrapWorkspace(dbClient.db, {
@@ -210,6 +227,8 @@ try {
   };
   console.log(`OPENGENI_DENSITY_RESULT=${JSON.stringify(result)}`);
   if (!result.thresholds.hardLimitMet) process.exitCode = 2;
+} catch (error) {
+  runFailure = error;
 } finally {
   model.release();
   await Promise.allSettled(runs);
@@ -229,7 +248,14 @@ try {
     process.exitCode = 1;
   }
   await dbClient.close();
+  densityMcp.close();
 }
+
+if (runFailure) throw runFailure;
+// MCP clients retain keep-alive sockets after a successful run. All durable
+// cleanup and DB shutdown have completed above, so terminate this one-shot
+// operator process explicitly instead of idling until those sockets expire.
+process.exit(process.exitCode ?? 0);
 
 async function seedHistory(input: {
   accountId: string;

--- a/scripts/turn-density-profile-contract.test.ts
+++ b/scripts/turn-density-profile-contract.test.ts
@@ -14,3 +14,18 @@ test("uses the granted workspace subject for synthetic turn execution", async ()
   expect(source).toContain(".delete(schema.managedAccounts)");
   expect(source).toContain(".where(eq(schema.managedAccounts.id, accountId))");
 });
+
+test("isolates first-party MCP setup from the deployment access mode", async () => {
+  const source = await readFile(
+    resolve(import.meta.dir, "operator/turn-density-profile.ts"),
+    "utf8",
+  );
+
+  expect(source).toContain("const densityMcp = startTestMcpServer();");
+  expect(source).toContain("const densityMcpUrl = `${densityMcp.url}?workspace={workspaceId}`;");
+  expect(source).toContain("opengeniMcpUrl: densityMcpUrl");
+  expect(source).toContain('id: "opengeni"');
+  expect(source).toContain("densityMcp.close();");
+  expect(source).toContain("if (runFailure) throw runFailure;");
+  expect(source).toContain("process.exit(process.exitCode ?? 0);");
+});


### PR DESCRIPTION
## Summary
- run the synthetic density profile against an in-process first-party MCP endpoint so every product access mode behaves identically
- preserve MCP connection/setup overhead without borrowing a production principal or access secret
- clean temporary state, close resources, and exit deterministically after successful profiling
- document the isolated workload and publish it as chart 0.22.9

## Verification
- `bun run format:check`
- `bun run lint`
- `bun test scripts/turn-density-profile-contract.test.ts`
- `bun x tsc --noEmit -p scripts/operator/tsconfig.json`
- `helm lint deploy/helm/opengeni`
- rendered the single-node profile with `helm template`
- live synthetic proof: 16 concurrent turns reached the scripted model gate and cleanup left zero run-scoped accounts/workspaces
- lifecycle proof: a small run completed cleanup and exited in under eight seconds