### PR TITLE
fix(release): advance occupied product version

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.9
-appVersion: "0.22.9"
+version: 0.22.10
+appVersion: "0.22.10"


### PR DESCRIPTION
## Summary

- advance the source-controlled OpenGeni product/chart identity from `0.22.9` to `0.22.10`
- keep Helm `version` and `appVersion` equal as required by the release contract
- preserve the already-merged Changesets/package plan; no package versions, changelogs, Changesets, product source, workflows, tags, images, releases, ledgers, or environments change

## Why

Canonical source `c6267c1528b05410139162b3309d13369197975f` cannot produce a candidate at `0.22.9`: obsolete pre-#712 candidate run `30412476091` immutably occupied that product version before cancellation completed. Run `30414353036` correctly stopped at `Refuse an occupied product release version` before any current-source image build.

Repository policy defines the independent product release identity as the equal SemVer pair in `deploy/helm/opengeni/Chart.yaml`, including application-only product releases. Canonical history advances this pair patchwise; the next identity is `0.22.10`.

At `2026-07-29T01:58:44Z`, publication-time read-only checks found:

- all five official image tags and the official chart tag for `0.22.10` absent via `scripts/resolve-optional-oci-manifest.ts`
- exact-head candidate and final GitHub tags/releases absent (404)
- no GitHub release asset named `opengeni-0.22.10.tgz`
- zero active release/deploy/staging/production/artifact workflows
- `main` still exactly `c6267c1528b05410139162b3309d13369197975f`

## Package plan

The exact existing 13-package plan from run `30414353036` passes unchanged at this PR head: `needsPublish=true`, all 13 expected versions remain `pending`, and the full BOM contains 18 packages. There is no new Changeset or second package wave.

## Verification

- `bun test` focused release/admission suite: **116 pass, 0 fail** across 14 files
- `bun run lint`: **pass** (0 warnings/errors; 1,052 files)
- `bun run format:check`: **pass** (1,112 files)
- all static deployment profile/preflight checks: **pass**
- Helm `v4.2.3` lint plus canonical CI renders/invariants: **pass**
- `git diff --check`: **pass**
- exact package publication plan at head `8c608dad341769771bd6459a11861309eca49aa0`: **pass**
- stable `typescript@7.0.2` full-workspace check: **22/23 projects pass**; unchanged `packages/db/test/session-event-writer-audit.test.ts` fails because stable TS7 no longer exports the compiler API from `typescript`. Release/deployment projects and all applications pass. This baseline toolchain migration is intentionally outside this urgent two-line correction.

## Release handoff

Root should commission one independent review pinned to exact head `8c608dad341769771bd6459a11861309eca49aa0`, then control merge and any candidate/release operation. This source owner did not build, release, deploy, review, or merge.
