### PR TITLE
fix(release): advance occupied product version

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.10
-appVersion: "0.22.10"
+version: 0.22.11
+appVersion: "0.22.11"


### PR DESCRIPTION
## Summary

- advance the source-controlled OpenGeni product/chart identity from `0.22.10` to `0.22.11`
- keep Helm `version` and `appVersion` equal as required by the release contract
- preserve the canonical 13-package plan already landed; no package version, changelog, Changeset, product source, Mobbin source, workflow, tag, image, release, ledger, or environment change

## Immutable boundary

- base/main: `7d1cbd3abfd1f8d9242bd4d990985c5068cfe237`
- base tree: `25c9c39d02b103511ab121fc40c09460d66d6ce7`
- head: `cccf88c5368ab0c4498c3813190f62f5abccc7b0`
- head tree: `82a3fb68cce163a5984d18aea0d885b074ecf0d7`
- one commit; one file; `deploy/helm/opengeni/Chart.yaml`; 2 additions / 2 deletions

The managed-cloud checkout reconciled `origin/main` once before source effect and found the exact required commit and tree. Repository source truth defines the equal Chart.yaml SemVer pair as the complete independent product identity; `0.22.10` occurred nowhere else in source.

## Read-only occupancy proof

Pre-push checks found `0.22.11` fully unoccupied:

- all five official GHCR image tags (API, worker, web, relay, sandbox) absent through `scripts/resolve-optional-oci-manifest.ts`
- official OCI chart tag absent through the same resolver
- exact-head `opengeni-candidate-<head>` Git tag and GitHub release absent (HTTP 404)
- exact-head `opengeni-release-<head>` Git tag and GitHub release absent (HTTP 404)
- zero assets named `opengeni-0.22.11.tgz` across 332 GitHub releases

## Package plan

The repository's exact publication verifier passes at head `cccf88c5368ab0c4498c3813190f62f5abccc7b0`: 13 expected packages, all 13 pending, complete 18-package BOM, `needsPublish=true`, `releaseReady=false`. No new Changeset or package wave was added.

## Verification

- focused release/admission suite: **116 pass / 0 fail** across 14 files (581 expectations)
- separate Helm upgrade contract: **3 pass / 0 fail** (43 expectations)
- all nine static deployment profile/preflight checks: **pass**
- Helm `v4.2.3` lint plus all eight canonical CI renders and single-node/preview invariants: **pass**
- `bun run format:check`: **pass** (1,112 files)
- `bun run lint`: **pass** (0 warnings/errors across 1,052 files)
- `git diff --check`: **pass**
- stable non-preview `typescript@7.0.2`: **23/23 projects pass**; no preview compiler was used for this validation
- exact package plan: **pass** (13 pending / 18 BOM)

## Review and release handoff

Do not self-review or merge. Root will commission an independent substantive reviewer pinned to the exact base/head above. Because the trusted GitHub login is also the PR author, the reviewer must submit the repository's canonical provider-owned `COMMENTED` v3 single-maintainer admin PASS review object rather than attempt impossible self-approval. Root owns merge and all later candidate/release/deployment authority.

This source owner did not self-review, merge, dispatch a build, build images, seal a head, create a ledger, release, deploy, mutate tags/assets/environments/credentials, or perform Azure inference.
