### PR TITLE
fix(release): advance occupied product version

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.11
-appVersion: "0.22.11"
+version: 0.22.12
+appVersion: "0.22.12"


### PR DESCRIPTION
## Summary

- advance the source-controlled OpenGeni product/chart identity from `0.22.11` to `0.22.12`
- keep Helm `version` and `appVersion` equal as required by the release contract
- preserve the canonical 13-package plan already landed; no package version, changelog, Changeset, product source, Mobbin source, workflow, tag, image, release, ledger, or environment change

## Immutable boundary

- base/main: `300eb880b99d8a161ef6e5e91b8083fe8f3490bd`
- base tree: `82a3fb68cce163a5984d18aea0d885b074ecf0d7`
- head: `f57b8817badaa47e38b4dce24af89a08712f0f78`
- head tree: `fa4e93989173bcaf4e402f2c836949db6779d2d2`
- one commit; one file; `deploy/helm/opengeni/Chart.yaml`; 2 additions / 2 deletions

The consented connected-Mac checkout reconciled `origin/main` exactly once before source effect and found the required commit/tree and equal Chart `0.22.11` identity. Repository source truth defines the equal Chart.yaml SemVer pair as the complete independent product identity; `0.22.11` occurs nowhere else in the direct patch.

## Read-only occupancy proof

Pre-push checks found `0.22.12` fully unoccupied:

- all five official GHCR image tags (API, worker, web, relay, sandbox) absent through authoritative anonymous GHCR manifest requests; known occupied `opengeni-api:0.22.9` validated the same method
- official OCI chart tag absent through the same authenticated-anonymous manifest method
- no remote branch/tag ref contains `0.22.12`
- no GitHub release tag/name contains `0.22.12`, and zero assets named `opengeni-0.22.12.tgz`, across 332 releases
- exact-head `opengeni-candidate-<head>` Git ref and GitHub release absent (authenticated HTTP 404)
- exact-head `opengeni-release-<head>` Git ref and GitHub release absent (authenticated HTTP 404)
- exact-head `opengeni-release-head-<head>` Git ref and GitHub release absent (authenticated HTTP 404)

The repository OCI resolver itself was also attempted with pinned Bun but the connected Mac's Buildx registry client stalled; the bounded authoritative GHCR API proof above failed closed and returned explicit `MANIFEST_UNKNOWN` for every target.

## Package plan

The repository's exact publication verifier passes at head `f57b8817badaa47e38b4dce24af89a08712f0f78`: 13 expected packages, all 13 pending, complete 18-package BOM, `needsPublish=true`, `releaseReady=false`. No new Changeset or package wave was introduced.

## Verification

- focused release/admission suite: **117 pass / 0 fail** across 14 files (589 expectations)
- separate Helm upgrade contract: **3 pass / 0 fail** (43 expectations)
- all nine static deployment profile/preflight checks: **pass**
- Helm `v4.2.3` lint plus all eight canonical CI renders and single-node/preview invariants: **pass**
- `bun run format:check`: **pass** (1,112 files)
- `bun run lint`: **pass** (0 warnings/errors across 1,052 files)
- `git diff --check`: **pass**
- stable non-preview `typescript@7.0.2`: **23/23 projects pass**; TypeScript 6 and native-preview were not invoked for this matrix
- exact package plan: **pass** (13 pending / 18 BOM)

An additional broad local attempt included `scripts/package-release-chart.test.ts`; its deterministic-packaging case could not start because the human Mac provides BSD tar, which rejects GNU-only `--sort=name`. No source assertion failed. The canonical Ubuntu CI environment supplies GNU tar and will exercise that test naturally.

## Review and release handoff

Do not self-review or merge. Root must commission one independent substantive/canonical v3 review pinned to the exact base/head above. While this PR remains open and current-base, sole release operator `2b9ff33b-272f-4249-9050-0ea4f5fe0cae` must run successful **Seal Release Head** without `merged_source_sha`; only after that retained-head success may root merge and authorize exactly one build.

This source owner did not self-review, merge, seal a head, dispatch or perform a build, create a ledger, release, deploy, mutate tags/assets/environments/credentials, use a GitHub connector, or perform Azure inference.
