### PR TITLE
fix(api): support Codex subscription defaults

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import {
   configuredAllowedModels,
   configuredAllowedReasoningEfforts,
   configuredModels,
+  withCodexCatalogProvider,
 } from "@opengeni/config";
 import {
   ClientConfig,
@@ -322,18 +323,21 @@ export function createApp(deps: AppDependencies): Hono {
 
   app.get("/v1/config/client", (c) => {
     c.header("cache-control", "no-store");
+    const catalogSettings = deps.settings.codexSubscriptionEnabled
+      ? withCodexCatalogProvider(deps.settings)
+      : deps.settings;
     return c.json(
       ClientConfig.parse({
         deploymentRevision: deps.settings.deploymentRevision,
         apiContractRevision: OPENGENI_API_CONTRACT_REVISION,
         ...(deps.settings.serverVersion ? { serverVersion: deps.settings.serverVersion } : {}),
-        defaultModel: canonicalizeConfiguredModelId(deps.settings, deps.settings.openaiModel),
-        allowedModels: configuredAllowedModels(deps.settings),
+        defaultModel: canonicalizeConfiguredModelId(catalogSettings, catalogSettings.openaiModel),
+        allowedModels: configuredAllowedModels(catalogSettings),
         // Provider-grouped model list for the picker. configuredModels() carries the
         // union of the built-in allow-list and every registry provider's models, in
         // selection order (default model first); project each to the client-safe
         // ClientModel shape (ConfiguredModel.providerId → ClientModel.provider).
-        models: configuredModels(deps.settings).map(projectClientModel),
+        models: configuredModels(catalogSettings).map(projectClientModel),
         defaultReasoningEffort: deps.settings.openaiReasoningEffort,
         allowedReasoningEfforts: configuredAllowedReasoningEfforts(deps.settings),
         mcpServers: deps.settings.mcpServers.map((server) => ({

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -1253,6 +1253,23 @@ describe("GET /v1/config/client", () => {
     expect(defaultModel).toMatchObject({ provider: "openai", api: "responses" });
   });
 
+  test("supports a Codex subscription model as the client default", async () => {
+    const settings = testSettings({
+      codexSubscriptionEnabled: true,
+      openaiModel: "codex/gpt-5.6-sol",
+      openaiAllowedModels: "codex/gpt-5.6-sol",
+    });
+    const config = await fetchClientConfig(settings);
+
+    expect(config.defaultModel).toBe("codex/gpt-5.6-sol");
+    expect(config.allowedModels).toContain("codex/gpt-5.6-sol");
+    expect(config.models.find((model) => model.id === config.defaultModel)).toMatchObject({
+      provider: "codex-subscription",
+      credentialSource: { kind: "connected_subscription", provider: "codex" },
+      billing: { upstreamPayer: "connected_subscription", metering: "external" },
+    });
+  });
+
   test("includes a registry model when OPENGENI_MODEL_PROVIDERS_JSON is set", async () => {
     const settings = testSettings({
       modelProvidersJson: JSON.stringify([


### PR DESCRIPTION
## What
- inject the synthetic Codex subscription catalog into `/v1/config/client` when the deployment enables subscription routing
- allow `codex/...` to be the deployment-wide default without crashing client config validation
- cover the subscription-only default path with an API test

## Why
A subscription-only deployment can connect and execute Codex successfully, but configuring `OPENGENI_OPENAI_MODEL=codex/gpt-5.6-sol` made `/v1/config/client` return HTTP 500. The workspace catalog already overlays Codex definitions; the global client catalog did not.

## Verification
- `bun test apps/api/test/app.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`