### PR TITLE
fix(db): make human steer win admission races

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -29588,6 +29588,12 @@ export async function claimSessionWorkForAttempt(
             and(
               eq(schema.sessionAttemptInterruptions.workspaceId, workspaceId),
               eq(schema.sessionAttemptInterruptions.sessionId, sessionId),
+              inArray(schema.sessionAttemptInterruptions.state, [
+                "pending",
+                "delivered",
+                "acknowledged",
+                "settled",
+              ]),
               isNull(schema.sessionTurnAttempts.quiescedAt),
             ),
           )
@@ -29879,20 +29885,27 @@ export async function claimSessionWorkForAttempt(
           )
           .limit(1)
           .for("update");
-        const rows = pendingAgentSteer
-          ? []
-          : await rawRows<{
-              id: string;
-              trigger_event_id: string;
-              metadata: Record<string, unknown>;
-            }>(
-              tx as unknown as Database,
-              sql`select id, trigger_event_id, metadata from session_turns
+        // A human/API Steer is the newest explicit replacement direction. It
+        // must claim next even when an older Agent Steer is pending; the
+        // internal instruction is delivered as context on that same human turn
+        // instead of manufacturing another system inference ahead of it.
+        // Ordinary queued sends retain the established Agent-Steer priority.
+        const rows = await rawRows<{
+          id: string;
+          trigger_event_id: string;
+          metadata: Record<string, unknown>;
+        }>(
+          tx as unknown as Database,
+          sql`select id, trigger_event_id, metadata from session_turns
               where workspace_id = ${workspaceId} and session_id = ${sessionId}
                 and status = 'queued' and source in ('user', 'api')
+                and (
+                  ${Boolean(pendingAgentSteer)} = false
+                  or metadata->>'delivery' = 'steer'
+                )
               order by position asc, created_at asc, id asc
               limit 1`,
-            );
+        );
         const queuedTurnPreview = rows[0];
         const queuedLocks = queuedTurnPreview
           ? await lockSessionEventWriteRows(tx as unknown as Database, {
@@ -33455,7 +33468,9 @@ export async function getSessionQueueSnapshot(
       version: session.queueVersion,
       effectiveControl: serializeEffectiveSessionControl(effectiveControl),
       stoppingPreviousAttempt:
-        latestInterruption !== null && latestInterruption.quiescedAt === null,
+        latestInterruption !== null &&
+        latestInterruption.interruptionState !== "rejected_stale" &&
+        latestInterruption.quiescedAt === null,
       items: rows.map(mapSessionTurn),
     };
   });

--- a/packages/db/test/agent-session-commands.test.ts
+++ b/packages/db/test/agent-session-commands.test.ts
@@ -827,4 +827,75 @@ describe("attempt-fenced Agent session commands", () => {
     if (humanClaim.action !== "claimed") throw new Error("Human queue did not resume");
     expect(humanClaim.turn.id).toBe(queued.turnId);
   });
+
+  test("a human Steer claims ahead of an older pending Agent Steer and carries it as context", async () => {
+    const grant = await fixture();
+    const caller = await activeAgent(grant);
+    const target = await makeSession(grant);
+    await submit(grant, target.id, "currently running");
+    const targetAttemptId = crypto.randomUUID();
+    const targetClaim = await claimSessionWorkForAttempt(client.db, grant.workspaceId!, {
+      sessionId: target.id,
+      workflowId: `session-${target.id}`,
+      workflowRunId: crypto.randomUUID(),
+      attemptId: targetAttemptId,
+      dispatchId: crypto.randomUUID(),
+      trigger: { kind: "next" },
+    });
+    if (targetClaim.action !== "claimed") throw new Error("Target was not claimed");
+
+    const agentSteer = await withWorkspaceRls(client.db, grant.workspaceId!, (db) =>
+      db.transaction((tx) =>
+        steerAgentSessionInTransaction(tx as typeof db, {
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId!,
+          targetSessionId: target.id,
+          actor: caller.actor,
+          operationKey: crypto.randomUUID(),
+          instruction: "inspect the older agent direction",
+        }),
+      ),
+    );
+    const humanSteer = await submit(grant, target.id, "the human replacement direction", "steer");
+
+    await settleSessionAttemptInterruptions(
+      client.db,
+      grant.workspaceId!,
+      target.id,
+      targetAttemptId,
+    );
+    await markSessionAttemptQuiesced(client.db, {
+      workspaceId: grant.workspaceId!,
+      sessionId: target.id,
+      attemptId: targetAttemptId,
+      temporalWorkflowId: `session-${target.id}`,
+    });
+
+    const replacement = await claimSessionWorkForAttempt(client.db, grant.workspaceId!, {
+      sessionId: target.id,
+      workflowId: `session-${target.id}`,
+      workflowRunId: crypto.randomUUID(),
+      attemptId: crypto.randomUUID(),
+      dispatchId: crypto.randomUUID(),
+      trigger: { kind: "next" },
+    });
+    if (replacement.action !== "claimed") throw new Error("Human Steer was not claimed");
+    expect(replacement.turn.id).toBe(humanSteer.turnId);
+    expect(replacement.turn.source).toBe("user");
+    expect(
+      await listSessionSystemUpdatesForTurn(
+        client.db,
+        grant.workspaceId!,
+        target.id,
+        replacement.turn.id,
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: agentSteer.updateId,
+          kind: "agent_steer_instruction",
+        }),
+      ]),
+    );
+  });
 });


### PR DESCRIPTION
Fixes the production Steer failure observed in session `2b9ff33b-272f-4249-9050-0ea4f5fe0cae`.

- ignores `rejected_stale` interruptions as admission/quiescence fences
- lets an explicit human/API Steer claim ahead of an older pending Agent Steer
- attaches that internal steer to the human replacement turn
- adds a database regression test for the ordering race

Verification:
- `bun run --cwd packages/db typecheck`
- focused regression: `bun test packages/db/test/agent-session-commands.test.ts -t "a human Steer claims" --timeout 30000`
- formatting and lint on changed files