### PR TITLE
fix(release): advance occupied product version

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.12
-appVersion: "0.22.12"
+version: 0.22.13
+appVersion: "0.22.13"


### PR DESCRIPTION
Advance the immutable Helm product identity from `0.22.12` to `0.22.13` so the merged Steer hotfix can produce a new source-bound candidate.