### PR TITLE
fix(db): retain bootstrapped workspace grants

### DIFF
--- a/.changeset/retain-local-workspaces.md
+++ b/.changeset/retain-local-workspaces.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Keep every account-scoped workspace grant in bootstrapped access contexts so newly created workspaces remain available after an access refresh.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1338,6 +1338,24 @@ export async function bootstrapWorkspace(
         })
         .where(eq(schema.workspaceMemberships.id, membership.id));
     }
+    // Access refreshes must retain workspaces created or granted after the
+    // default workspace. Restore account-scoped RLS before listing them.
+    await setRlsContext(tx as unknown as Database, {
+      accountId: workspace.accountId,
+      workspaceId: null,
+    });
+    const memberships = await tx
+      .select({
+        membership: schema.workspaceMemberships,
+        workspace: schema.workspaces,
+      })
+      .from(schema.workspaceMemberships)
+      .innerJoin(
+        schema.workspaces,
+        eq(schema.workspaceMemberships.workspaceId, schema.workspaces.id),
+      )
+      .where(eq(schema.workspaceMemberships.subjectId, input.subjectId))
+      .orderBy(desc(schema.workspaces.createdAt));
     return {
       mode: input.accountExternalSource === "opengeni:local" ? "local" : "configured",
       subjectId: input.subjectId,
@@ -1351,15 +1369,13 @@ export async function bootstrapWorkspace(
           permissions: input.accountPermissions ?? allAccountPermissions,
         },
       ],
-      workspaceGrants: [
-        {
-          workspaceId: workspace.id,
-          accountId: account.id,
-          subjectId: input.subjectId,
-          ...(input.subjectLabel ? { subjectLabel: input.subjectLabel } : {}),
-          permissions: workspacePermissions,
-        },
-      ],
+      workspaceGrants: memberships.map((row) => ({
+        workspaceId: row.workspace.id,
+        accountId: row.workspace.accountId,
+        subjectId: input.subjectId,
+        ...(input.subjectLabel ? { subjectLabel: input.subjectLabel } : {}),
+        permissions: row.membership.permissions as Permission[],
+      })),
       defaultAccountId: account.id,
       defaultWorkspaceId: workspace.id,
     };

--- a/test/integration/db.integration.ts
+++ b/test/integration/db.integration.ts
@@ -9,6 +9,7 @@ import {
   applySessionTurnSettlement,
   bootstrapWorkspace,
   claimSessionWorkForAttempt,
+  createWorkspace,
   createKnowledgeMemory,
   getKnowledgeMemory,
   saveWorkspaceMemory,
@@ -35,6 +36,7 @@ import {
   ensureManagedAccessForUser,
   evaluateGoalContinuation,
   findActiveApiKeyByHash,
+  grantWorkspaceAccess,
   getSession,
   getSessionGoal,
   setSessionGoalStatus,
@@ -127,6 +129,41 @@ describe("DB integration", () => {
     );
     expect(await readUpdatedAt()).toEqual(before);
   }, 60_000);
+
+  test("access bootstrap retains additional workspace grants", async () => {
+    const suffix = crypto.randomUUID();
+    const input = {
+      accountExternalSource: "test:multi-workspace-bootstrap",
+      accountExternalId: `account:${suffix}`,
+      accountName: "Multi-workspace account",
+      workspaceExternalSource: "test:multi-workspace-bootstrap",
+      workspaceExternalId: `workspace:${suffix}`,
+      workspaceName: "Default workspace",
+      subjectId: `configured:${suffix}`,
+      subjectLabel: "Workspace owner",
+    };
+    const initial = await bootstrapWorkspace(dbClient.db, input);
+    const defaultGrant = initial.workspaceGrants[0]!;
+    const additionalWorkspace = await createWorkspace(dbClient.db, {
+      accountId: defaultGrant.accountId,
+      name: "Additional workspace",
+    });
+    await grantWorkspaceAccess(dbClient.db, {
+      accountId: defaultGrant.accountId,
+      workspaceId: additionalWorkspace.id,
+      subjectId: input.subjectId,
+      subjectLabel: input.subjectLabel,
+      role: "owner",
+      permissions: defaultGrant.permissions,
+    });
+
+    const refreshed = await bootstrapWorkspace(dbClient.db, input);
+
+    expect(refreshed.defaultWorkspaceId).toBe(defaultGrant.workspaceId);
+    expect(refreshed.workspaceGrants.map((grant) => grant.workspaceId).sort()).toEqual(
+      [defaultGrant.workspaceId, additionalWorkspace.id].sort(),
+    );
+  });
 
   test("migrates, creates sessions, and replays ordered events", async () => {
     const grant = await testGrant(dbClient.db);


### PR DESCRIPTION
## Summary

- reload every account-scoped workspace membership when constructing a bootstrapped access context
- preserve the default workspace while retaining workspaces created or granted later
- add a regression test for refreshing access after creating an additional workspace

## Testing

- [x] `bun run typecheck`
- [ ] `bun test`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] Transactional regression verification against PostgreSQL

## Notes

- Access refresh previously reconstructed a single default-workspace grant even when additional memberships existed. Workspace enumeration therefore omitted valid workspaces after refresh.
- The membership reload remains account-scoped under RLS and matches managed-user access resolution.
