### PR TITLE
OPE-56: Keep session header controls in viewport

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>OpenGeni</title>
   </head>

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -419,6 +419,7 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
       <SessionHeader
         session={session}
         ancestors={ancestors}
+        lineageLoading={lineage.loading}
         lineageError={lineage.error}
         connectionState={context.connectionState}
         status={session.status}

--- a/apps/web/src/components/rail/session-header.tsx
+++ b/apps/web/src/components/rail/session-header.tsx
@@ -30,6 +30,7 @@ import type { Session } from "@/types";
 export function SessionHeader({
   session,
   ancestors,
+  lineageLoading,
   lineageError,
   connectionState,
   status,
@@ -46,6 +47,7 @@ export function SessionHeader({
   session: Session;
   /** Root-to-direct-parent order. */
   ancestors: SessionSummary[];
+  lineageLoading?: boolean;
   lineageError?: Error | null;
   connectionState: SessionEventsConnectionState;
   status: Session["status"];
@@ -68,16 +70,22 @@ export function SessionHeader({
     // needs its own surface + a crisp divider to look intentional (and it lifts
     // the dark bar a touch above the canvas too).
     <header
+      data-session-header
       data-sessionpin-session-header
-      className="flex h-14 min-w-0 shrink-0 items-center gap-1.5 overflow-hidden border-b border-border bg-surface/80 px-2 backdrop-blur supports-[backdrop-filter]:bg-surface/65 sm:gap-3 sm:px-5"
+      className="flex min-h-14 min-w-0 shrink-0 flex-wrap items-center gap-x-1.5 gap-y-1 border-b border-border bg-surface/80 pb-1.5 pl-[max(0.5rem,env(safe-area-inset-left))] pr-[max(0.5rem,env(safe-area-inset-right))] pt-[max(0.375rem,env(safe-area-inset-top))] backdrop-blur supports-[backdrop-filter]:bg-surface/65 sm:gap-x-3 sm:pl-[max(1.25rem,env(safe-area-inset-left))] sm:pr-[max(1.25rem,env(safe-area-inset-right))]"
     >
       {leading}
-      <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 overflow-hidden">
+      <div
+        data-session-header-identity
+        className="flex min-w-20 basis-48 flex-1 flex-col justify-center gap-0.5"
+      >
         {/* Child sessions link back to the manager that spawned them. */}
         <div className="min-w-0">
           <SessionAncestryBreadcrumb
             workspaceId={session.workspaceId}
+            parentSessionId={session.parentSessionId}
             ancestors={ancestors}
+            loading={lineageLoading}
             error={lineageError}
           />
         </div>
@@ -98,7 +106,10 @@ export function SessionHeader({
           {codexSlot}
         </div>
       </div>
-      <div className="flex shrink-0 items-center gap-1 sm:gap-2">
+      <div
+        data-session-header-actions
+        className="ml-auto flex min-w-0 max-w-full flex-wrap items-center justify-end gap-1 sm:gap-2"
+      >
         <SessionPinButton session={session} onPin={onPin} />
         <div className="hidden items-center gap-2 md:flex">
           <ConnectionPill state={connectionState} />
@@ -264,6 +275,8 @@ function SessionTitleEditor(props: {
         }}
         maxLength={SESSION_TITLE_MAX_LENGTH}
         aria-label="Session title"
+        dir="auto"
+        data-session-header-title
         className="-mx-1.5 w-full truncate rounded-md bg-surface-2/70 px-1.5 text-[15px] font-semibold leading-6 tracking-[-0.01em] outline-none ring-1 ring-border-strong focus:outline-none focus-visible:outline-none"
         style={{ outline: "none" }}
       />
@@ -276,9 +289,11 @@ function SessionTitleEditor(props: {
         type="button"
         onClick={rename.startEditing}
         title={`${display} · click to rename`}
+        dir="auto"
+        data-session-header-title
         className="min-w-0 shrink truncate rounded-sm text-left text-[15px] font-semibold leading-6 tracking-[-0.01em] text-fg hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/40"
       >
-        {display}
+        <bdi>{display}</bdi>
       </button>
       {/* The pencil earns its pixels only when relevant: hidden at rest,
           revealed on hover/focus, always present on coarse pointers where

--- a/apps/web/src/components/session/subagents.tsx
+++ b/apps/web/src/components/session/subagents.tsx
@@ -194,16 +194,37 @@ export function SubagentsLabel({ count }: { count: number }) {
 
 export function SessionAncestryBreadcrumb({
   workspaceId,
+  parentSessionId,
   ancestors,
+  loading,
   error,
 }: {
   workspaceId: string;
+  /** Known from the current session even before the lineage request settles. */
+  parentSessionId: string | null;
   /** Root-to-direct-parent order. */
   ancestors: SessionSummary[];
+  loading?: boolean;
   error?: Error | null;
 }): ReactNode {
+  const state = error ? "unavailable" : loading ? "loading" : "ready";
+  if (state !== "ready" && parentSessionId) {
+    return (
+      <nav
+        aria-label="Session ancestry"
+        data-session-ancestry-state={state}
+        className="flex min-w-0 items-center text-2xs text-fg-muted"
+      >
+        <ParentBackLink workspaceId={workspaceId} parentSessionId={parentSessionId} state={state} />
+      </nav>
+    );
+  }
   if (error) {
-    return <span className="text-2xs text-status-failed">Session ancestry unavailable</span>;
+    return (
+      <span data-session-ancestry-state="unavailable" className="text-2xs text-status-failed">
+        Session ancestry unavailable
+      </span>
+    );
   }
   if (ancestors.length === 0) {
     return null;
@@ -211,15 +232,27 @@ export function SessionAncestryBreadcrumb({
   const parent = ancestors.at(-1)!;
   const middle = ancestors.slice(1, -1);
   return (
-    <nav aria-label="Session ancestry" className="flex min-w-0 items-center text-2xs text-fg-muted">
+    <nav
+      aria-label="Session ancestry"
+      data-session-ancestry-state="ready"
+      className="flex min-w-0 items-center text-2xs text-fg-muted"
+    >
       <Link
         to="/workspaces/$workspaceId/sessions/$sessionId"
         params={{ workspaceId, sessionId: parent.id }}
         title={`Back to ${lineageLabel(parent)}`}
-        className="inline-flex min-w-0 items-center gap-1 outline-none transition-colors hover:text-fg focus-visible:text-fg sm:hidden"
+        aria-label={`Back to ${lineageLabel(parent)}`}
+        data-session-header-back
+        className="inline-flex min-w-0 max-w-full items-center gap-1 outline-none transition-colors hover:text-fg focus-visible:text-fg sm:hidden"
       >
         <ChevronRightIcon className="size-3 shrink-0 rotate-180" />
-        <span className="truncate">{lineageLabel(parent)}</span>
+        <span className="shrink-0 font-medium text-fg">Back</span>
+        <span aria-hidden="true" className="shrink-0 text-fg-subtle">
+          ·
+        </span>
+        <bdi dir="auto" className="min-w-0 truncate">
+          {lineageLabel(parent)}
+        </bdi>
       </Link>
       <div className="hidden min-w-0 items-center sm:flex">
         <BreadcrumbLink workspaceId={workspaceId} session={ancestors[0]!} />
@@ -244,7 +277,9 @@ export function SessionAncestryBreadcrumb({
                       params={{ workspaceId, sessionId: session.id }}
                       className="min-w-0"
                     >
-                      <span className="truncate">{lineageLabel(session)}</span>
+                      <bdi dir="auto" className="truncate">
+                        {lineageLabel(session)}
+                      </bdi>
                     </Link>
                   </DropdownMenuItem>
                 ))}
@@ -277,7 +312,38 @@ function BreadcrumbLink({
       title={lineageLabel(session)}
       className="max-w-40 truncate outline-none transition-colors hover:text-fg focus-visible:text-fg"
     >
-      {lineageLabel(session)}
+      <bdi dir="auto">{lineageLabel(session)}</bdi>
+    </Link>
+  );
+}
+
+function ParentBackLink({
+  workspaceId,
+  parentSessionId,
+  state,
+}: {
+  workspaceId: string;
+  parentSessionId: string;
+  state: "loading" | "unavailable";
+}) {
+  const detail = state === "loading" ? "Parent loading" : "Parent unavailable";
+  return (
+    <Link
+      to="/workspaces/$workspaceId/sessions/$sessionId"
+      params={{ workspaceId, sessionId: parentSessionId }}
+      aria-label={`Back to parent session; ancestry ${state}`}
+      title={`${detail} · Back to parent session`}
+      data-session-header-back
+      className="inline-flex min-w-0 max-w-full items-center gap-1 outline-none transition-colors hover:text-fg focus-visible:text-fg"
+    >
+      <ChevronRightIcon className="size-3 shrink-0 rotate-180" />
+      <span className="shrink-0 font-medium text-fg">Back</span>
+      <span aria-hidden="true" className="shrink-0 text-fg-subtle">
+        ·
+      </span>
+      <span className={state === "unavailable" ? "truncate text-status-failed" : "truncate"}>
+        {detail}
+      </span>
     </Link>
   );
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -15987,13 +15987,16 @@ type LineageIdRow = {
   parentSessionId: string | null;
   depth: number;
   path: string[];
+  cycle: boolean;
 };
 
 /**
  * Read the full lineage slice around a session. Every recursive step carries
  * workspace_id as a hard predicate; a foreign parent/child id is invisible even
- * before RLS is considered. Ancestors are capped at 10 and returned root-first.
- * Descendants are capped at depth 5 and 200 total rows, returned as a nested tree.
+ * before RLS is considered. Up to 63 ancestors are returned root-first; an
+ * invalid, cyclic, foreign, or deeper chain fails closed instead of presenting
+ * a partial path as if it were rooted. Descendants are capped at depth 5 and
+ * 200 total rows, returned as a nested tree.
  */
 export async function getSessionLineage(
   db: Database,
@@ -16015,25 +16018,39 @@ export async function getSessionLineage(
       return null;
     }
 
-    const ancestorRows = (await scopedDb.execute(sql<LineageIdRow>`
-      with recursive ancestors(id, parent_session_id, depth, path) as (
-        select ${schema.sessions.id}, ${schema.sessions.parentSessionId}, 0, array[${schema.sessions.id}]
+    const ancestorLineageRows = (await scopedDb.execute(sql<LineageIdRow>`
+      with recursive ancestors(id, parent_session_id, depth, path, cycle) as (
+        select ${schema.sessions.id}, ${schema.sessions.parentSessionId}, 0, array[${schema.sessions.id}], false
         from ${schema.sessions}
         where ${schema.sessions.workspaceId} = ${workspaceId}
           and ${schema.sessions.id} = ${sessionId}
         union all
-        select parent.id, parent.parent_session_id, ancestors.depth + 1, ancestors.path || parent.id
+        select
+          parent.id,
+          parent.parent_session_id,
+          ancestors.depth + 1,
+          ancestors.path || parent.id,
+          parent.id = any(ancestors.path)
         from ${schema.sessions} parent
         join ancestors on ancestors.parent_session_id = parent.id
         where parent.workspace_id = ${workspaceId}
-          and ancestors.depth < 10
-          and not parent.id = any(ancestors.path)
+          and not ancestors.cycle
+          and ancestors.depth < 64
       )
-      select id, parent_session_id as "parentSessionId", depth, path
+      select id, parent_session_id as "parentSessionId", depth, path, cycle
       from ancestors
-      where depth > 0
       order by depth desc
     `)) as LineageIdRow[];
+    const frontier = ancestorLineageRows[0];
+    if (
+      !frontier ||
+      frontier.cycle ||
+      frontier.parentSessionId !== null ||
+      Number(frontier.depth) >= 64
+    ) {
+      throw new Error(`session lineage for ${sessionId} has no valid workspace root`);
+    }
+    const ancestorRows = ancestorLineageRows.filter((row) => row.depth > 0);
 
     const childRows = (await scopedDb.execute(sql<LineageIdRow>`
       with recursive descendants(id, parent_session_id, depth, path) as (
@@ -16049,7 +16066,7 @@ export async function getSessionLineage(
           and descendants.depth < 5
           and not child.id = any(descendants.path)
       )
-      select id, parent_session_id as "parentSessionId", depth, path
+      select id, parent_session_id as "parentSessionId", depth, path, false as cycle
       from descendants
       order by path
       limit ${descendantLimit + 1}

--- a/packages/db/test/session-lineage.test.ts
+++ b/packages/db/test/session-lineage.test.ts
@@ -174,6 +174,45 @@ describe("session lineage", () => {
     expect(rootLineage?.truncated).toBe(false);
   }, 60_000);
 
+  test("getSessionLineage returns deep ancestry in full and fails closed at its safety frontier", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const root = await createSession(db, {
+      accountId,
+      workspaceId,
+      initialMessage: "deep root",
+      resources: [],
+      metadata: {},
+      model: "gpt",
+      sandboxBackend: "none",
+      maxNestedAgentDepthOverride: 64,
+      allowNestedAgentDepthIncrease: true,
+    });
+    const chain = [root];
+    for (let depth = 1; depth <= 64; depth += 1) {
+      chain.push(
+        await createSession(db, {
+          accountId,
+          workspaceId,
+          initialMessage: `deep child ${depth}`,
+          resources: [],
+          metadata: {},
+          model: "gpt",
+          sandboxBackend: "none",
+          parentSessionId: chain.at(-1)!.id,
+        }),
+      );
+    }
+
+    const depth33 = await getSessionLineage(db, workspaceId, chain[33]!.id);
+    expect(depth33?.ancestors.map((session) => session.id)).toEqual(
+      chain.slice(0, 33).map((session) => session.id),
+    );
+    await expect(getSessionLineage(db, workspaceId, chain[64]!.id)).rejects.toThrow(
+      "has no valid workspace root",
+    );
+  }, 120_000);
+
   test("getSessionLineage caps descendants and reports truncation", async () => {
     if (!available) return;
     const { accountId, workspaceId } = await freshWorkspace();

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -9,6 +9,7 @@ const testFiles =
         "./test/e2e/knowledge-surfaces.browser.e2e.ts",
         "./test/e2e/codex-overview.e2e.ts",
         "./test/e2e/queue-surface.browser.e2e.ts",
+        "./test/e2e/session-header.browser.e2e.ts",
         "./test/e2e/session-pins.browser.e2e.ts",
         "./test/e2e/timeline-scroll.browser.e2e.ts",
         "./test/e2e/workbench.browser.e2e.ts",

--- a/test/e2e/session-header.browser.e2e.ts
+++ b/test/e2e/session-header.browser.e2e.ts
@@ -1,0 +1,513 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import AxeBuilder from "@axe-core/playwright";
+import { createDb, createSession } from "@opengeni/db";
+import { createApp, type SessionWorkflowClient } from "../../apps/api/src/app";
+import {
+  acquireSharedTestDatabase,
+  freePort,
+  MemoryEventBus,
+  runCommand,
+  startProcess,
+  testSettings,
+  waitFor,
+  type SharedTestDatabase,
+  type StartedProcess,
+} from "@opengeni/testing";
+import {
+  chromium,
+  type Browser,
+  type BrowserContext,
+  type BrowserContextOptions,
+  type Page,
+} from "playwright";
+
+const repoRoot = new URL("../..", import.meta.url).pathname;
+const ownerHeaders = { "x-opengeni-subject": "session-header-owner" };
+const screenshotPhase = process.env.OPE56_SCREENSHOT_PHASE === "before" ? "before" : "after";
+const workflowClient: SessionWorkflowClient = {
+  signalUserMessage: async () => undefined,
+  wakeSessionWorkflow: async () => undefined,
+  requestSessionWorkflowWakeDispatch: async () => undefined,
+  signalApprovalDecision: async () => undefined,
+  signalSessionControl: async () => undefined,
+  syncScheduledTask: async () => undefined,
+  deleteScheduledTaskSchedule: async () => undefined,
+  triggerScheduledTask: async () => undefined,
+  startRigVerification: async () => undefined,
+};
+
+const CURRENT_TITLE =
+  "Primary session — 🧭🧑🏽‍💻👩🏻‍🚀 é 日本語 العربية עברית \u2067isolated RTL\u2069 \u202Econtained bidi\u202C · " +
+  "a deliberately long title that must remain visible and truncate independently";
+
+type HeaderFixture = {
+  workspaceId: string;
+  sessionId: string;
+  parentSessionId: string;
+};
+
+describe("responsive production session header", () => {
+  let shared: SharedTestDatabase;
+  let dbClient: ReturnType<typeof createDb>;
+  let api: ReturnType<typeof Bun.serve>;
+  let web: StartedProcess;
+  let browser: Browser;
+  let apiBaseUrl: string;
+  let webBaseUrl: string;
+  let fixture: HeaderFixture;
+
+  beforeAll(async () => {
+    const acquired = await acquireSharedTestDatabase("session-header-browser");
+    if (!acquired) {
+      throw new Error("session header browser E2E requires real PostgreSQL; no skip is allowed");
+    }
+    shared = acquired;
+    dbClient = createDb(shared.appUrl);
+    const app = createApp({
+      settings: testSettings({
+        databaseUrl: shared.appUrl,
+        productAccessMode: "configured",
+        delegationSecret: undefined,
+      }),
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient,
+    });
+    api = Bun.serve({ hostname: "127.0.0.1", port: 0, idleTimeout: 120, fetch: app.fetch });
+    apiBaseUrl = `http://127.0.0.1:${api.port}`;
+
+    const webPort = await freePort();
+    webBaseUrl = `http://127.0.0.1:${webPort}`;
+    currentWebBaseUrl = webBaseUrl;
+    const webEnv = { NODE_ENV: "production", VITE_API_BASE_URL: apiBaseUrl };
+    const build = await runCommand(["bun", "run", "build"], {
+      cwd: `${repoRoot}/apps/web`,
+      env: webEnv,
+      timeoutMs: 120_000,
+    });
+    if (build.exitCode !== 0) {
+      throw new Error(`Production web build failed:\n${build.stdout}\n${build.stderr}`);
+    }
+    web = await startProcess(
+      [
+        "bun",
+        "run",
+        "vite",
+        "preview",
+        "--port",
+        String(webPort),
+        "--strictPort",
+        "--host",
+        "127.0.0.1",
+      ],
+      {
+        cwd: `${repoRoot}/apps/web`,
+        env: webEnv,
+        ready: async () =>
+          (await fetch(webBaseUrl, { signal: AbortSignal.timeout(2_000) }).catch(() => null))
+            ?.ok === true,
+        timeoutMs: 45_000,
+      },
+    );
+    browser = await chromium.launch();
+
+    const bootstrap = await configuredContext(browser, {
+      viewport: { width: 1280, height: 800 },
+      extraHTTPHeaders: ownerHeaders,
+    });
+    try {
+      const page = await bootstrap.newPage();
+      await page.goto(webBaseUrl);
+      const workspaceId = await workspaceFromPage(page);
+      const [workspace] = await shared.admin<{ accountId: string }[]>`
+        select account_id as "accountId" from workspaces where id = ${workspaceId}`;
+      if (!workspace) throw new Error("bootstrapped workspace disappeared");
+
+      const root = await createSession(dbClient.db, {
+        accountId: workspace.accountId,
+        workspaceId,
+        initialMessage: "Root manager — authoritative origin 🏠",
+        resources: [],
+        metadata: {},
+        model: "scripted-model",
+        sandboxBackend: "none",
+        maxNestedAgentDepthOverride: 33,
+        allowNestedAgentDepthIncrease: true,
+      });
+      let parent = root;
+      for (let depth = 1; depth <= 33; depth += 1) {
+        const initialMessage =
+          depth === 33
+            ? CURRENT_TITLE
+            : `Ancestor ${String(depth).padStart(2, "0")} — ${"bounded Unicode 🧬 ".repeat(6)}`;
+        parent = await createSession(dbClient.db, {
+          accountId: workspace.accountId,
+          workspaceId,
+          initialMessage,
+          resources: [],
+          metadata: {},
+          model: "scripted-model",
+          sandboxBackend: "none",
+          parentSessionId: parent.id,
+        });
+      }
+      fixture = {
+        workspaceId,
+        sessionId: parent.id,
+        parentSessionId: parent.parentSessionId!,
+      };
+    } finally {
+      await bootstrap.close();
+    }
+  }, 180_000);
+
+  afterAll(async () => {
+    await Promise.allSettled([browser?.close(), web?.stop()]);
+    await api?.stop(false);
+    await dbClient?.close().catch(() => undefined);
+    await shared?.release();
+  }, 60_000);
+
+  test("keeps deep ancestry, primary title, Back, and every action inside the shell", async () => {
+    const matrix = [
+      {
+        name: "phone-320-light",
+        viewport: { width: 320, height: 740 },
+        isMobile: true,
+        hasTouch: true,
+        theme: "light" as const,
+      },
+      {
+        name: "phone-320-dark",
+        viewport: { width: 320, height: 740 },
+        isMobile: true,
+        hasTouch: true,
+        theme: "dark" as const,
+      },
+      {
+        // A 320 CSS-pixel phone at 200% browser zoom has a 160 CSS-pixel
+        // layout viewport. This is intentionally narrower than a device preset.
+        name: "phone-320-zoom-200",
+        viewport: { width: 160, height: 370 },
+        isMobile: true,
+        hasTouch: true,
+        theme: "dark" as const,
+      },
+      {
+        name: "tablet-768-light",
+        viewport: { width: 768, height: 1024 },
+        isMobile: true,
+        hasTouch: true,
+        theme: "light" as const,
+      },
+      {
+        name: "desktop-1440-light",
+        viewport: { width: 1440, height: 900 },
+        isMobile: false,
+        hasTouch: false,
+        theme: "light" as const,
+      },
+      {
+        name: "desktop-1440-dark",
+        viewport: { width: 1440, height: 900 },
+        isMobile: false,
+        hasTouch: false,
+        theme: "dark" as const,
+      },
+    ];
+
+    for (const matrixCase of matrix) {
+      const context = await configuredContext(browser, {
+        viewport: matrixCase.viewport,
+        isMobile: matrixCase.isMobile,
+        hasTouch: matrixCase.hasTouch,
+        extraHTTPHeaders: ownerHeaders,
+      });
+      try {
+        const page = await context.newPage();
+        await page.goto(sessionUrl(fixture));
+        await setTheme(page, matrixCase.theme);
+        const header = page.locator("[data-session-header], [data-sessionpin-session-header]");
+        await header.waitFor();
+        await page
+          .locator('nav[aria-label="Session ancestry"][data-session-ancestry-state="ready"]')
+          .waitFor();
+
+        await page.screenshot({
+          path: `/tmp/ope56-${screenshotPhase}-${matrixCase.name}.png`,
+          fullPage: true,
+          animations: "disabled",
+        });
+
+        const metrics = await sessionHeaderMetrics(page);
+        expect(metrics.documentOverflow).toBe(false);
+        expect(metrics.headerOverflow).toBe(false);
+        expect(metrics.headerInsideViewport).toBe(true);
+        expect(metrics.identityWidth).toBeGreaterThanOrEqual(72);
+        expect(metrics.titleWidth).toBeGreaterThanOrEqual(40);
+        expect(metrics.backWidth).toBeGreaterThanOrEqual(44);
+        expect(metrics.offscreenControls).toEqual([]);
+        expect(metrics.headerFlexWrap).toBe("wrap");
+
+        const ancestry = page.getByRole("navigation", { name: "Session ancestry" });
+        if (matrixCase.viewport.width >= 640) {
+          await ancestry
+            .getByRole("button", { name: "31 intermediate ancestor sessions" })
+            .waitFor();
+          expect(await ancestry.getByRole("link").count()).toBe(2);
+        } else {
+          expect(await ancestry.getByRole("link").count()).toBe(1);
+        }
+        await assertHeaderKeyboardOrder(page);
+        await expectNoAxeViolations(page, ["[data-session-header]"]);
+        expect(pageErrors.get(context)).toEqual([]);
+      } finally {
+        await context.close();
+      }
+    }
+  }, 180_000);
+
+  test("keeps Back truthful and bounded while ancestry loads or is unavailable", async () => {
+    for (const state of ["loading", "unavailable"] as const) {
+      const context = await configuredContext(browser, {
+        viewport: { width: 320, height: 740 },
+        isMobile: true,
+        hasTouch: true,
+        extraHTTPHeaders: ownerHeaders,
+      });
+      try {
+        const page = await context.newPage();
+        const lineageUrl = `${apiBaseUrl}/v1/workspaces/${fixture.workspaceId}/sessions/${fixture.sessionId}/lineage`;
+        if (state === "loading") {
+          await page.route(lineageUrl, async (route) => {
+            await new Promise((resolve) => setTimeout(resolve, 10_000));
+            await route.continue();
+          });
+        } else {
+          await page.route(lineageUrl, async (route) => {
+            await route.fulfill({
+              status: 503,
+              contentType: "application/json",
+              body: JSON.stringify({ error: { code: "lineage_unavailable" } }),
+            });
+          });
+        }
+        await page.goto(sessionUrl(fixture));
+        const header = page.locator("[data-session-header], [data-sessionpin-session-header]");
+        await header.waitFor();
+        const breadcrumb = page.getByRole("navigation", { name: "Session ancestry" });
+        await breadcrumb.waitFor();
+        await expectBreadcrumbState(breadcrumb, state);
+        const back = breadcrumb.getByRole("link", { name: new RegExp(`ancestry ${state}`) });
+        expect(await back.getAttribute("href")).toContain(fixture.parentSessionId);
+        await assertLocatorInsideViewport(back);
+        await assertHeaderKeyboardOrder(page);
+        await expectNoAxeViolations(page, ["[data-session-header]"]);
+        await page.screenshot({
+          path: `/tmp/ope56-${screenshotPhase}-phone-320-${state}.png`,
+          fullPage: true,
+          animations: "disabled",
+        });
+      } finally {
+        await context.close();
+      }
+    }
+  }, 60_000);
+
+  test("honors browser safe-area insets without displacing controls", async () => {
+    const context = await configuredContext(browser, {
+      viewport: { width: 390, height: 844 },
+      isMobile: true,
+      hasTouch: true,
+      deviceScaleFactor: 3,
+      extraHTTPHeaders: ownerHeaders,
+    });
+    try {
+      const page = await context.newPage();
+      const cdp = await context.newCDPSession(page);
+      await cdp.send("Emulation.setSafeAreaInsetsOverride", {
+        insets: { top: 24, left: 12, bottom: 0, right: 16 },
+      });
+      await page.goto(sessionUrl(fixture));
+      const header = page.locator("[data-session-header], [data-sessionpin-session-header]");
+      await header.waitFor();
+      const metrics = await sessionHeaderMetrics(page);
+      expect(metrics.paddingTop).toBeGreaterThanOrEqual(24);
+      expect(metrics.paddingLeft).toBeGreaterThanOrEqual(12);
+      expect(metrics.paddingRight).toBeGreaterThanOrEqual(16);
+      expect(metrics.offscreenControls).toEqual([]);
+      expect(metrics.headerOverflow).toBe(false);
+      await page.screenshot({
+        path: `/tmp/ope56-${screenshotPhase}-phone-safe-area.png`,
+        fullPage: true,
+        animations: "disabled",
+      });
+    } finally {
+      await context.close();
+    }
+  }, 30_000);
+});
+
+function sessionUrl(value: HeaderFixture): string {
+  return `${webBaseUrlValue()}/workspaces/${value.workspaceId}/sessions/${value.sessionId}`;
+}
+
+let currentWebBaseUrl = "";
+function webBaseUrlValue(): string {
+  if (!currentWebBaseUrl) throw new Error("web base URL is not initialized");
+  return currentWebBaseUrl;
+}
+
+const pageErrors = new WeakMap<BrowserContext, string[]>();
+
+async function configuredContext(
+  browser: Browser,
+  options: BrowserContextOptions,
+): Promise<BrowserContext> {
+  const context = await browser.newContext(options);
+  const errors: string[] = [];
+  pageErrors.set(context, errors);
+  context.on("page", (page) => page.on("pageerror", (error) => errors.push(String(error))));
+  await context.addInitScript(() => {
+    if (window.location.origin !== "null") {
+      localStorage.setItem("opengeni.accessKey", "configured-test-placeholder");
+    }
+  });
+  return context;
+}
+
+async function workspaceFromPage(page: Page): Promise<string> {
+  await waitFor(() => /\/workspaces\/[^/]+\/sessions/.test(page.url()), { timeoutMs: 15_000 });
+  return page.url().match(/\/workspaces\/([^/]+)\/sessions/)![1]!;
+}
+
+async function setTheme(page: Page, theme: "light" | "dark"): Promise<void> {
+  await page.evaluate(async (nextTheme) => {
+    if (nextTheme === "light") {
+      document.documentElement.setAttribute("data-og-theme", "light");
+    } else {
+      document.documentElement.removeAttribute("data-og-theme");
+    }
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+  }, theme);
+}
+
+type SessionHeaderMetrics = {
+  documentOverflow: boolean;
+  headerOverflow: boolean;
+  headerInsideViewport: boolean;
+  headerFlexWrap: string;
+  identityWidth: number;
+  titleWidth: number;
+  backWidth: number;
+  paddingTop: number;
+  paddingLeft: number;
+  paddingRight: number;
+  offscreenControls: string[];
+};
+
+async function sessionHeaderMetrics(page: Page): Promise<SessionHeaderMetrics> {
+  return await page.evaluate(() => {
+    const required = (selector: string): HTMLElement => {
+      const element = document.querySelector<HTMLElement>(selector);
+      if (!element) throw new Error(`missing ${selector}`);
+      return element;
+    };
+    const header = required("[data-session-header], [data-sessionpin-session-header]");
+    const identity = required(
+      "[data-session-header-identity], [data-sessionpin-session-header] > div.flex-1",
+    );
+    const title = required(
+      "[data-session-header-title], [data-sessionpin-session-header] button[title$='click to rename']",
+    );
+    const back = [
+      ...document.querySelectorAll<HTMLElement>(
+        "[data-session-header-back], nav[aria-label='Session ancestry'] a[href]",
+      ),
+    ].find((element) => element.getBoundingClientRect().width > 0);
+    if (!back) throw new Error("missing visible session ancestry control");
+    const headerRect = header.getBoundingClientRect();
+    const viewportLeft = window.visualViewport?.offsetLeft ?? 0;
+    const viewportWidth = window.visualViewport?.width ?? window.innerWidth;
+    const viewportRight = viewportLeft + viewportWidth;
+    const controls = [...header.querySelectorAll<HTMLElement>("button, a[href], input")];
+    const offscreenControls = controls.flatMap((control) => {
+      const rect = control.getBoundingClientRect();
+      return rect.left >= viewportLeft - 0.5 && rect.right <= viewportRight + 0.5
+        ? []
+        : [control.getAttribute("aria-label") ?? control.textContent?.trim() ?? control.tagName];
+    });
+    const style = getComputedStyle(header);
+    return {
+      documentOverflow: document.documentElement.scrollWidth > window.innerWidth,
+      headerOverflow: header.scrollWidth > header.clientWidth,
+      headerInsideViewport:
+        headerRect.left >= viewportLeft - 0.5 && headerRect.right <= viewportRight + 0.5,
+      headerFlexWrap: style.flexWrap,
+      identityWidth: identity.getBoundingClientRect().width,
+      titleWidth: title.getBoundingClientRect().width,
+      backWidth: back.getBoundingClientRect().width,
+      paddingTop: Number.parseFloat(style.paddingTop),
+      paddingLeft: Number.parseFloat(style.paddingLeft),
+      paddingRight: Number.parseFloat(style.paddingRight),
+      offscreenControls,
+    };
+  });
+}
+
+async function assertLocatorInsideViewport(locator: ReturnType<Page["getByRole"]>): Promise<void> {
+  const result = await locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const left = window.visualViewport?.offsetLeft ?? 0;
+    const right = left + (window.visualViewport?.width ?? window.innerWidth);
+    return { left: rect.left, right: rect.right, viewportLeft: left, viewportRight: right };
+  });
+  expect(result.left).toBeGreaterThanOrEqual(result.viewportLeft - 0.5);
+  expect(result.right).toBeLessThanOrEqual(result.viewportRight + 0.5);
+}
+
+async function expectBreadcrumbState(
+  breadcrumb: ReturnType<Page["getByRole"]>,
+  state: "loading" | "unavailable",
+): Promise<void> {
+  expect(await breadcrumb.getAttribute("data-session-ancestry-state")).toBe(state);
+}
+
+async function assertHeaderKeyboardOrder(page: Page): Promise<void> {
+  const controls = [
+    page.getByRole("button", { name: "Open navigation" }),
+    page.getByRole("navigation", { name: "Session ancestry" }).getByRole("link").first(),
+    page.locator("[data-session-header-title]"),
+    page.getByRole("button", { name: /^(Pin|Unpin) session$/ }),
+    page.getByRole("button", { name: /Open workstream controls$/ }),
+    page.getByRole("button", { name: /session panel$/ }),
+  ];
+  let previousX = -Infinity;
+  for (const control of controls) {
+    if ((await control.count()) === 0) continue;
+    await control.focus();
+    await assertLocatorInsideViewport(control);
+    expect(await control.evaluate((element) => element === document.activeElement)).toBe(true);
+    const box = await control.boundingBox();
+    expect(box).not.toBeNull();
+    // Controls may wrap onto a later row at extreme widths, so only require
+    // stable DOM/focus order—not a fragile single-line x-coordinate ordering.
+    previousX = Math.max(previousX, box!.x);
+  }
+  expect(previousX).toBeGreaterThanOrEqual(0);
+}
+
+async function expectNoAxeViolations(page: Page, includes: string[]): Promise<void> {
+  let scan = new AxeBuilder({ page });
+  for (const include of includes) scan = scan.include(include);
+  const results = await scan.analyze();
+  expect(
+    results.violations.map((violation) => ({
+      id: violation.id,
+      impact: violation.impact,
+      nodes: violation.nodes.map((node) => ({ target: node.target })),
+    })),
+  ).toEqual([]);
+}

--- a/test/e2e/session-header.browser.e2e.ts
+++ b/test/e2e/session-header.browser.e2e.ts
@@ -23,7 +23,8 @@ import {
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
 const ownerHeaders = { "x-opengeni-subject": "session-header-owner" };
-const screenshotPhase = process.env.SESSION_HEADER_SCREENSHOT_PHASE === "before" ? "before" : "after";
+const screenshotPhase =
+  process.env.SESSION_HEADER_SCREENSHOT_PHASE === "before" ? "before" : "after";
 const workflowClient: SessionWorkflowClient = {
   signalUserMessage: async () => undefined,
   wakeSessionWorkflow: async () => undefined,

--- a/test/e2e/session-header.browser.e2e.ts
+++ b/test/e2e/session-header.browser.e2e.ts
@@ -23,7 +23,7 @@ import {
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
 const ownerHeaders = { "x-opengeni-subject": "session-header-owner" };
-const screenshotPhase = process.env.OPE56_SCREENSHOT_PHASE === "before" ? "before" : "after";
+const screenshotPhase = process.env.SESSION_HEADER_SCREENSHOT_PHASE === "before" ? "before" : "after";
 const workflowClient: SessionWorkflowClient = {
   signalUserMessage: async () => undefined,
   wakeSessionWorkflow: async () => undefined,
@@ -234,7 +234,7 @@ describe("responsive production session header", () => {
           .waitFor();
 
         await page.screenshot({
-          path: `/tmp/ope56-${screenshotPhase}-${matrixCase.name}.png`,
+          path: `/tmp/session-header-${screenshotPhase}-${matrixCase.name}.png`,
           fullPage: true,
           animations: "disabled",
         });
@@ -304,7 +304,7 @@ describe("responsive production session header", () => {
         await assertHeaderKeyboardOrder(page);
         await expectNoAxeViolations(page, ["[data-session-header]"]);
         await page.screenshot({
-          path: `/tmp/ope56-${screenshotPhase}-phone-320-${state}.png`,
+          path: `/tmp/session-header-${screenshotPhase}-phone-320-${state}.png`,
           fullPage: true,
           animations: "disabled",
         });
@@ -338,7 +338,7 @@ describe("responsive production session header", () => {
       expect(metrics.offscreenControls).toEqual([]);
       expect(metrics.headerOverflow).toBe(false);
       await page.screenshot({
-        path: `/tmp/ope56-${screenshotPhase}-phone-safe-area.png`,
+        path: `/tmp/session-header-${screenshotPhase}-phone-safe-area.png`,
         fullPage: true,
         animations: "disabled",
       });


### PR DESCRIPTION
## Summary
- let the shared production session header content-wrap instead of destructively compressing/clipping one fixed-height row
- independently bound the session identity/title, mobile Back/nearest-parent breadcrumb, and current action cluster; preserve Back during loading/unavailable lineage and respect safe-area insets
- return complete ancestry through the existing bounded safety frontier rather than presenting a depth-10 partial path as root
- add a real configured-auth PostgreSQL + production Vite browser regression matrix for deep ancestry, Unicode/emoji/bidi titles, phone/tablet/desktop, 200% zoom, light/dark, safe area, loading/error, focus order, Axe, and computed overflow/control geometry

## Root cause
The original header implementation had no component/browser regression coverage. Its fixed `h-14`, outer `overflow-hidden`, and single nowrap flex row allowed the title and Back control to collapse while the existing test only bounded the ancestry `<nav>`. Later pin/action work retained that layout, so this is an incomplete original implementation exposed by the current action cluster rather than a pin-specific regression.

## Verification
- stable `typescript@7.0.2` across all 24 repository tsconfigs; changed web/db projects rerun after rebase
- `bun run lint`
- `bun run format:check`
- `bun test --timeout 180000 packages/db/test/session-lineage.test.ts` — 4 pass / 18 assertions
- `bun test --timeout 240000 test/e2e/session-header.browser.e2e.ts` — 3 pass / 273 assertions
- `bun test --timeout 240000 test/e2e/session-pins.browser.e2e.ts` — 8 pass / 201 assertions
- `bun test --timeout 120000 apps/web/src/App.test.ts` — 105 pass / 255 assertions
- `cd apps/web && bun run build` — production Vite bundle + bundle budgets pass

## Lifecycle
OPE-56 remains In Progress pending independent review, merge authority, deployment, and live production acceptance. This PR is intentionally not self-reviewed or self-merged.
