### PR TITLE
fix(core): preserve local worker delegation

### DIFF
--- a/.changeset/preserve-local-worker-delegation.md
+++ b/.changeset/preserve-local-worker-delegation.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/core": patch
+---
+
+Honor valid delegated worker access in local mode so signed session and turn metadata, along with narrowed permissions, reach first-party MCP tools.

--- a/deploy/helm/opengeni/values.yaml
+++ b/deploy/helm/opengeni/values.yaml
@@ -89,7 +89,9 @@ secret:
   create: false
   existingSecret: opengeni-runtime
   # Provide OPENGENI_ACCESS_KEY for deployment shared-key access.
-  # Provide OPENGENI_DELEGATION_SECRET for configured/managed product access.
+  # Provide OPENGENI_DELEGATION_SECRET in every access mode. API and workers
+  # share it to preserve narrowed permissions and signed session/turn identity
+  # on first-party MCP requests, including in local mode.
   # Provide Better Auth, Resend, Stripe, GitHub App, model-provider, database,
   # NATS, Temporal, sandbox, and object-storage secrets through this secret or
   # an ExternalSecret. Never commit real secrets in values.

--- a/packages/core/src/access/index.ts
+++ b/packages/core/src/access/index.ts
@@ -86,6 +86,10 @@ export function hasPermission(permissions: Permission[], permission: Permission)
 
 async function resolveAccessContext(c: Context, deps: AccessDeps): Promise<AccessContext | null> {
   if (deps.settings.productAccessMode === "local") {
+    const delegated = await delegatedAccessContext(c, deps, "local");
+    if (delegated) {
+      return delegated;
+    }
     return await bootstrapWorkspace(deps.db, {
       accountExternalSource: "opengeni:local",
       accountExternalId: "default",
@@ -198,7 +202,7 @@ async function apiKeyAccessContext(
 async function delegatedAccessContext(
   c: Context,
   deps: AccessDeps,
-  mode: "configured" | "managed",
+  mode: "local" | "configured" | "managed",
   token = bearerToken(c),
 ): Promise<AccessContext | null> {
   if (!token || !deps.settings.delegationSecret) {

--- a/scripts/generate-single-node-secrets.test.ts
+++ b/scripts/generate-single-node-secrets.test.ts
@@ -34,6 +34,7 @@ describe("single-node secret bootstrap", () => {
       expect(
         Buffer.from(runtime.OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY ?? "", "base64"),
       ).toHaveLength(32);
+      expect(runtime.OPENGENI_DELEGATION_SECRET?.length).toBeGreaterThanOrEqual(32);
       expect(migrations.OPENGENI_MIGRATIONS_DATABASE_URL).toContain("postgres://opengeni:");
       expect(migrations.OPENGENI_MIGRATIONS_DATABASE_URL).toContain(
         encodeURIComponent(postgres.POSTGRES_PASSWORD ?? ""),

--- a/scripts/generate-single-node-secrets.ts
+++ b/scripts/generate-single-node-secrets.ts
@@ -108,6 +108,7 @@ export async function generateSingleNodeSecretFiles(
             database: databaseName,
           }),
           OPENGENI_ENVIRONMENTS_ENCRYPTION_KEY: environmentsEncryptionKey,
+          OPENGENI_DELEGATION_SECRET: secret(),
           OPENGENI_ENROLLMENT_SIGNING_SECRET: enrollmentSigningSecret,
           OPENGENI_STREAM_TOKEN_SECRET: streamTokenSecret,
           OPENGENI_SELFHOSTED_RELAY_TOKEN_SECRET: streamTokenSecret,

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1080,6 +1080,101 @@ describe("API component integration", () => {
     expect(deniedOtherAccountBilling.status).toBe(403);
   });
 
+  test("local access preserves valid worker delegation and falls back for ordinary requests", async () => {
+    const delegationSecret = "test-local-delegation-secret";
+    const settings = testSettings({
+      databaseUrl: services.databaseUrl,
+      productAccessMode: "local",
+      delegationSecret,
+    });
+    const app = createApp({
+      settings,
+      db: dbClient.db,
+      bus: new MemoryEventBus(),
+      workflowClient: new FakeWorkflowClient(),
+    });
+    const delegatedWorkspace = await bootstrapWorkspace(dbClient.db, {
+      accountExternalSource: "test:local-delegation",
+      accountExternalId: crypto.randomUUID(),
+      accountName: "Local delegation test",
+      workspaceExternalSource: "test:local-delegation",
+      workspaceExternalId: crypto.randomUUID(),
+      workspaceName: "Local delegation workspace",
+      subjectId: `test:local-delegation:${crypto.randomUUID()}`,
+    });
+    const sessionId = crypto.randomUUID();
+    const token = await signDelegatedAccessToken(delegationSecret, {
+      accountId: delegatedWorkspace.defaultAccountId!,
+      workspaceId: delegatedWorkspace.defaultWorkspaceId!,
+      subjectId: "test:local-delegated-worker",
+      permissions: ["workspace:read"],
+      sessionId,
+      exp: Math.floor(Date.now() / 1000) + 60,
+    });
+
+    const delegatedResponse = await app.request("/v1/access/me", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(delegatedResponse.status).toBe(200);
+    const delegated = (await delegatedResponse.json()) as AccessContext;
+    expect(delegated).toMatchObject({
+      mode: "local",
+      subjectId: "test:local-delegated-worker",
+      defaultAccountId: delegatedWorkspace.defaultAccountId,
+      defaultWorkspaceId: delegatedWorkspace.defaultWorkspaceId,
+    });
+    expect(delegated.workspaceGrants).toEqual([
+      expect.objectContaining({
+        permissions: ["workspace:read"],
+        metadata: expect.objectContaining({ delegated: true, sessionId }),
+      }),
+    ]);
+
+    const fallbackResponse = await app.request("/v1/access/me", {
+      headers: { authorization: "Bearer invalid-token" },
+    });
+    expect(fallbackResponse.status).toBe(200);
+    const fallback = (await fallbackResponse.json()) as AccessContext;
+    expect(fallback.mode).toBe("local");
+    expect(fallback.subjectId).toBe("dev");
+    expect(fallback.workspaceGrants[0]?.metadata).toBeUndefined();
+
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: app.fetch,
+    });
+    let prepared: Awaited<ReturnType<typeof prepareAgentTools>> | null = null;
+    try {
+      prepared = await prepareAgentTools(
+        {
+          ...settings,
+          mcpServers: [
+            {
+              id: "opengeni",
+              name: "OpenGeni",
+              url: `http://127.0.0.1:${server.port}/v1/workspaces/{workspaceId}/mcp`,
+              timeoutMs: undefined,
+              cacheToolsList: false,
+            },
+          ],
+        },
+        [{ kind: "mcp", id: "opengeni" }],
+        {
+          accountId: delegatedWorkspace.defaultAccountId!,
+          workspaceId: delegatedWorkspace.defaultWorkspaceId!,
+          sessionId,
+        },
+      );
+      const toolNames = (await prepared.mcpServers[0]!.listTools()).map((tool) => tool.name);
+      expect(toolNames).toContain("opengeni__set_session_title");
+      expect(toolNames).toContain("opengeni__goal_set");
+    } finally {
+      await prepared?.close().catch(() => undefined);
+      server.stop(true);
+    }
+  });
+
   test("managed session cookie still authenticates when an invalid bearer header is present", async () => {
     const userId = `managed-user-${crypto.randomUUID()}`;
     const email = `managed-cookie-${crypto.randomUUID()}@example.com`;


### PR DESCRIPTION
## Summary
- verify delegated bearer tokens before local access falls back to its bootstrap principal
- preserve signed session/turn metadata and delegated permission narrowing in local mode
- generate the shared delegation secret in single-node deployment bootstrapping and document that every access mode needs it
- cover ordinary and invalid-token local fallback behavior
- verify session-bound first-party MCP tools are exposed end to end

## Validation
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test scripts/generate-single-node-secrets.test.ts`
- API integration regression included for CI (the local test-services harness requires Docker, which was unavailable in the authoring environment)