### PR TITLE
fix(release): advance occupied product version

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.13
-appVersion: "0.22.13"
+version: 0.22.14
+appVersion: "0.22.14"


### PR DESCRIPTION
## Summary

- advance the immutable OpenGeni product/chart release identity from 0.22.13 to 0.22.14
- keep chart version and appVersion identical
- avoid reusing an occupied distribution version for a different source tree

## Verification

- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `bun test scripts/release-version.test.ts scripts/release-image-workflow-contract.test.ts`
- `git diff --check`