### PR TITLE
fix(release): tolerate excluded-output stat races

### DIFF
--- a/scripts/build-publishable-packages.test.ts
+++ b/scripts/build-publishable-packages.test.ts
@@ -227,6 +227,44 @@ test("invalidates warm builds for complete nested and non-regular dist entries",
   expect(modeChange.stdout).not.toContain("cached");
 });
 
+test("rejects unattributed watcher notifications even when snapshots look stable", async () => {
+  const root = createFixture();
+  const environment = {
+    OPENGENI_BUILD_VARIANT: "BASE",
+    OPENGENI_BUILD_CACHE_INJECT_UNATTRIBUTED_EVENT: "1",
+  };
+
+  const result = await runBuilder(root, environment);
+  expect(result.code).toBe(1);
+  expect(result.stdout).toContain(
+    "source changed during @opengeni/demo (watch:unattributed-notification)",
+  );
+  expect(result.stderr).toContain(
+    "Build inputs changed during @opengeni/demo build (watch:unattributed-notification)",
+  );
+});
+
+test("tolerates an excluded directory removed between readdir and lstat", async () => {
+  const root = createFixture();
+  const dist = join(root, "packages", "demo", "dist");
+  const pausePath = join(root, "excluded-entry-stat-pause");
+  mkdirSync(dist, { recursive: true });
+  writeFileSync(join(dist, "stale.txt"), "stale\n");
+
+  const builder = startBuilder(root, {
+    OPENGENI_BUILD_VARIANT: "BASE",
+    OPENGENI_BUILD_CACHE_PAUSE_BEFORE_EXCLUDED_ENTRY_STAT: pausePath,
+  });
+  expect(await waitForPath(`${pausePath}.ready`, 5_000)).toBe(true);
+  rmSync(dist, { recursive: true, force: true });
+  writeFileSync(`${pausePath}.release`, "release\n");
+
+  const result = await builder.result;
+  expect(result.code).toBe(0);
+  expect(result.stdout).not.toContain("source changed during @opengeni/demo");
+  expect(readFileSync(outputPath(root), "utf8")).toBe("BASE|A|644\n");
+});
+
 test("serializes concurrent builders and keeps environment keys bound to their bytes", async () => {
   const root = createFixture();
   const gate = join(root, "build-gate");

--- a/scripts/build-publishable-packages.ts
+++ b/scripts/build-publishable-packages.ts
@@ -15,7 +15,9 @@ import {
   renameSync,
   unlinkSync,
   writeFileSync,
+  type Dirent,
   type FSWatcher,
+  type Stats,
 } from "node:fs";
 import { arch, platform } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
@@ -108,7 +110,11 @@ type PackageLock = {
 
 type InputMutationMonitor = {
   changed: () => boolean;
-  finish: () => Promise<{ changed: boolean; inputSha256: string }>;
+  finish: () => Promise<{
+    changed: boolean;
+    inputSha256: string;
+    reasons: string[];
+  }>;
 };
 
 function packageCachePath(pkg: WorkspacePackage): string {
@@ -731,6 +737,26 @@ function inputEntry(path: string): BuildInput {
   throw new Error(`Unsupported build input type at ${relativePath}`);
 }
 
+function inputChildStats(entry: Dirent, path: string): Stats | null {
+  const isExcludedDirectory = entry.isDirectory() && INPUT_EXCLUDED_DIRECTORY_NAMES.has(entry.name);
+  if (isExcludedDirectory) {
+    pauseForFailureInjection("OPENGENI_BUILD_CACHE_PAUSE_BEFORE_EXCLUDED_ENTRY_STAT");
+  }
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    // A build legitimately removes/recreates an excluded directory such as
+    // dist after readdir() has returned its Dirent. Treat only that exact
+    // stale-directory ENOENT as excluded-output churn. A missing ordinary
+    // input, or an excluded path replaced by a symlink/file, remains
+    // visible/fail-closed.
+    if (isExcludedDirectory && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
 function inputEntriesUnder(directory: string): BuildInput[] {
   let rootEntry: BuildInput;
   try {
@@ -754,7 +780,10 @@ function inputEntriesUnder(directory: string): BuildInput[] {
   const visit = (current: string): void => {
     for (const entry of readdirSync(current, { withFileTypes: true })) {
       const path = join(current, entry.name);
-      const stats = lstatSync(path);
+      const stats = inputChildStats(entry, path);
+      if (!stats) {
+        continue;
+      }
       if (stats.isDirectory() && INPUT_EXCLUDED_DIRECTORY_NAMES.has(entry.name)) {
         continue;
       }
@@ -832,7 +861,10 @@ function inputGenerationEntriesUnder(directory: string): BuildInputGeneration[] 
   const visit = (current: string): void => {
     for (const entry of readdirSync(current, { withFileTypes: true })) {
       const path = join(current, entry.name);
-      const stats = lstatSync(path);
+      const stats = inputChildStats(entry, path);
+      if (!stats) {
+        continue;
+      }
       if (stats.isDirectory() && INPUT_EXCLUDED_DIRECTORY_NAMES.has(entry.name)) {
         continue;
       }
@@ -1017,8 +1049,16 @@ function startInputMutationMonitor(
 ): InputMutationMonitor {
   let dirty = false;
   let checking = false;
+  const reasons = new Set<string>();
   const initialInputGenerationSha256 = packageInputGenerationSha256(pkg);
   const watchers: FSWatcher[] = [];
+  const markDirty = (reason: string): void => {
+    dirty = true;
+    reasons.add(reason);
+  };
+  const observeUnattributedNotification = (): void => {
+    markDirty("watch:unattributed-notification");
+  };
   const watchDirectories = inputWatchDirectories(pkg);
   for (const directory of watchDirectories) {
     try {
@@ -1034,7 +1074,12 @@ function startInputMutationMonitor(
           // the queued notification still proves the build did not observe one
           // stable input generation.
           if (!filename) {
-            dirty = true;
+            // A transient input can be created and deleted between content /
+            // generation snapshots, while parent-directory timestamps are
+            // intentionally excluded to tolerate dist churn. With no path we
+            // cannot prove the notification belongs to an excluded output, so
+            // preserve it as fail-closed generation evidence.
+            observeUnattributedNotification();
             return;
           }
           const changedPath = join(directory, filename.toString());
@@ -1052,13 +1097,13 @@ function startInputMutationMonitor(
           if (!isBuildInputPath(pkg, changedPath)) {
             return;
           }
-          dirty = true;
+          markDirty(`watch:${changedRelativePath}`);
         }),
       );
     } catch {
       // A source directory that disappears while the build is running is a
       // mutation. Fail closed rather than publishing an unobserved key.
-      dirty = true;
+      markDirty(`watch-unavailable:${relative(repoRoot, directory)}`);
     }
   }
 
@@ -1072,15 +1117,18 @@ function startInputMutationMonitor(
         packageInputGenerationSha256(pkg) !== initialInputGenerationSha256 ||
         packageInputSha256(pkg) !== initialInputSha256
       ) {
-        dirty = true;
+        markDirty("poll:input-state-changed");
       }
     } catch {
-      dirty = true;
+      markDirty("poll:input-state-unreadable");
     } finally {
       checking = false;
     }
   }, BUILD_SOURCE_POLL_MS);
   pauseForFailureInjection("OPENGENI_BUILD_CACHE_PAUSE_AFTER_INPUT_MONITOR_START");
+  if (process.env.OPENGENI_BUILD_CACHE_INJECT_UNATTRIBUTED_EVENT === "1") {
+    observeUnattributedNotification();
+  }
 
   return {
     changed: () => dirty,
@@ -1097,16 +1145,16 @@ function startInputMutationMonitor(
       let inputSha256 = initialInputSha256;
       try {
         if (packageInputGenerationSha256(pkg) !== initialInputGenerationSha256) {
-          dirty = true;
+          markDirty("finish:input-generation-changed");
         }
         inputSha256 = packageInputSha256(pkg);
       } catch {
-        dirty = true;
+        markDirty("finish:input-state-unreadable");
       }
       if (inputSha256 !== initialInputSha256) {
-        dirty = true;
+        markDirty("finish:input-content-changed");
       }
-      return { changed: dirty, inputSha256 };
+      return { changed: dirty, inputSha256, reasons: [...reasons].sort() };
     },
   };
 }
@@ -1303,13 +1351,17 @@ async function main(): Promise<void> {
             if (recorded) {
               removeCacheRecordIfMatches(pkg, inputSha256);
             }
+            const reason =
+              observation.reasons.length > 0
+                ? ` (${observation.reasons.join(", ")})`
+                : " (input hash changed during cache publication)";
             if (attempt === MAX_SOURCE_MUTATION_RETRIES) {
               throw new Error(
-                `Build inputs changed during ${pkg.name} build; refusing to publish a cache record`,
+                `Build inputs changed during ${pkg.name} build${reason}; refusing to publish a cache record`,
               );
             }
             process.stdout.write(
-              `[build:packages] source changed during ${pkg.name}; retrying (${attempt}/${MAX_SOURCE_MUTATION_RETRIES})\n`,
+              `[build:packages] source changed during ${pkg.name}${reason}; retrying (${attempt}/${MAX_SOURCE_MUTATION_RETRIES})\n`,
             );
             continue;
           }


### PR DESCRIPTION
## Outcome

Keep publishable-package input monitoring fail-closed while tolerating one legitimate race: an excluded build-output directory such as `dist` can disappear after `readdir()` returns its directory entry but before `lstat()` runs.

## Root cause

The embedded release failed with `poll:input-state-unreadable`. Reproducing the release command under Bun 1.3.14 showed that `tsup --clean` could remove an excluded `dist` directory during input traversal. The prior traversal treated that expected excluded-output ENOENT as an unreadable source tree, retried, and eventually failed the release.

## Change

- Ignore ENOENT only when the stale `Dirent` itself identified an excluded directory.
- Continue to fail closed for ordinary inputs, excluded paths replaced by a file/symlink, and filename-less watcher notifications.
- Attach mutation reasons to retry/refusal diagnostics.
- Add deterministic regressions for both the legitimate excluded-output race and the fail-closed unattributed-event case.

## Evidence

- `bun test scripts/build-publishable-packages.test.ts`: 13 pass, 0 fail, 91 assertions.
- Exact Bun 1.3.14 publishable-package build completed without a source-change retry after the correction.
- `git diff --check` and focused formatting are clean.

Closes #741