### PR TITLE
fix(runtime): resolve Connected Machine Toolspace paths from HOME

### DIFF
--- a/.changeset/selfhosted-toolspace-home.md
+++ b/.changeset/selfhosted-toolspace-home.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/config": patch
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Resolve Connected Machine Toolspace token files against the machine user's real
+home directory instead of the selfhosted capability root.

--- a/apps/worker/test/sandbox-attach-env-parity.test.ts
+++ b/apps/worker/test/sandbox-attach-env-parity.test.ts
@@ -91,13 +91,14 @@ describe("attach-vs-turn manifest-environment parity (no repo attached)", () => 
     expect(attachEnv.HOME).toBe("/workspace");
   });
 
-  test("selfhosted stable env does not gain managed-sandbox git helper pointers", async () => {
+  test("selfhosted stable env preserves the machine HOME without managed-sandbox git helpers", async () => {
     const settings = testSettings({ sandboxBackend: "selfhosted" });
     const { environment: turnEnv } = await sandboxEnvironmentForRun(settings, [], {});
     const attachEnv = stableSandboxEnvironmentForRun(settings, {});
 
-    expect(turnEnv).toEqual({ HOME: "/" });
+    expect(turnEnv).toEqual({});
     expect(attachEnv).toEqual(turnEnv);
+    expect(turnEnv.HOME).toBeUndefined();
     expect(turnEnv.OPENGENI_GIT_CREDENTIALS_DIR).toBeUndefined();
     expect(turnEnv.OPENGENI_GIT_TOKEN_FILE).toBeUndefined();
     expect(turnEnv.OPENGENI_GIT_CLI_WRAPPER_DIR).toBeUndefined();

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -42,7 +42,10 @@ workspace/session, and expires after one hour; the worker renews it while an
 attempt is active. Every request resolves the session's current active turn and
 uses that turn's exact attempt fence and budget, so the same session bearer can
 serve later turns without authorizing work while no turn is running. Platform
-git and model credentials remain excluded.
+git and model credentials remain excluded. The stable manifest pointer is
+`$HOME/.opengeni/toolspace-token`: seed, renewal, and session commands expand it
+in the machine's own shell. OpenGeni never substitutes the Connected Machine
+descriptor root (`/`) for the user's home.
 
 ## Create a session on a machine
 

--- a/docs/design/toolspace.md
+++ b/docs/design/toolspace.md
@@ -165,6 +165,13 @@ base (`OPENGENI_MCP_URL`) the machine enrolled against — the same URL every re
 backend uses — never a loopback or cluster-internal address the machine could not
 reach.
 
+The Connected Machine manifest uses the trusted shell-relative pointer
+`$HOME/.opengeni/toolspace-token`. Runtime derives the per-session sibling while
+retaining that prefix, then expands it in the machine's shell for seed, renewal,
+and every session command. The control plane must not set `HOME` from the
+selfhosted capability descriptor: that descriptor's `/` means “the whole
+machine is addressable,” not “the agent user's home is `/`.”
+
 When the flag is off, behavior is byte-identical to the current tree: no
 permission is minted, no file path appears, no URL appears, and no toolspace
 surface is added.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2787,9 +2787,14 @@ export function stableSandboxEnvironmentForRun(
   };
   // Backend-aware HOME: a provisioned box (docker + every cloud provider) runs the
   // agent under the descriptor's workspaceRoot. `local` runs in-process as the host
-  // unix user (keep its real $HOME); `none` has no box.
+  // unix user (keep its real $HOME); `selfhosted` runs on a user's machine and must
+  // likewise preserve that machine's real HOME; `none` has no box.
   const descriptor = CAPABILITY_DESCRIPTORS[settings.sandboxBackend];
-  if (settings.sandboxBackend !== "none" && settings.sandboxBackend !== "local") {
+  if (
+    settings.sandboxBackend !== "none" &&
+    settings.sandboxBackend !== "local" &&
+    settings.sandboxBackend !== "selfhosted"
+  ) {
     environment.HOME ??= descriptor.workspaceRoot;
   }
   // TOKEN-BROKER (B1): the STABLE credential FILE PATHS and CLI wrapper PATH for
@@ -2810,7 +2815,15 @@ export function stableSandboxEnvironmentForRun(
     environment.PATH = prependPathEntry(environment.PATH, environment.OPENGENI_GIT_CLI_WRAPPER_DIR);
   }
   if (settings.toolspaceEnabled) {
-    environment.OPENGENI_TOOLSPACE_TOKEN_FILE ??= `${environment.HOME ?? descriptor.workspaceRoot}/.opengeni/toolspace-token`;
+    // Connected Machines do not share one control-plane-known home path. Keep a
+    // stable shell-resolved pointer in the manifest; runtime expands this trusted
+    // marker against the machine's own HOME for seed, renewal, and every command.
+    // Never derive it from the selfhosted descriptor root (`/`), which would try
+    // to write `/.opengeni` as an ordinary machine user.
+    environment.OPENGENI_TOOLSPACE_TOKEN_FILE ??=
+      settings.sandboxBackend === "selfhosted"
+        ? "$HOME/.opengeni/toolspace-token"
+        : `${environment.HOME ?? descriptor.workspaceRoot}/.opengeni/toolspace-token`;
     if (settings.ogtoolPackageSpec) {
       environment.OPENGENI_OGTOOL_PACKAGE_SPEC ??= settings.ogtoolPackageSpec;
     }

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -774,11 +774,27 @@ describe("sandbox preparation profiles", () => {
     const settings = withEnv({ OPENGENI_SANDBOX_BACKEND: "selfhosted" }, () => getSettings());
     const env = stableSandboxEnvironmentForRun(settings, {}, { workspaceId: "ws-1" });
 
-    expect(env).toEqual({ HOME: "/" });
+    expect(env).toEqual({});
     expect(env.OPENGENI_GIT_CREDENTIALS_DIR).toBeUndefined();
     expect(env.OPENGENI_GIT_TOKEN_FILE).toBeUndefined();
     expect(env.OPENGENI_GIT_CLI_WRAPPER_DIR).toBeUndefined();
     expect(env.PATH).toBeUndefined();
+  });
+
+  test("preserves machine HOME and uses a shell-resolved Toolspace pointer for selfhosted", () => {
+    const settings = withEnv(
+      {
+        OPENGENI_SANDBOX_BACKEND: "selfhosted",
+        OPENGENI_TOOLSPACE_ENABLED: "true",
+        OPENGENI_DELEGATION_SECRET: "delegation-secret",
+      },
+      () => getSettings(),
+    );
+    const env = stableSandboxEnvironmentForRun(settings, {}, { workspaceId: "ws-1" });
+
+    expect(env.HOME).toBeUndefined();
+    expect(env.OPENGENI_TOOLSPACE_TOKEN_FILE).toBe("$HOME/.opengeni/toolspace-token");
+    expect(env.OPENGENI_TOOLSPACE_URL).toBe("http://127.0.0.1:8000/v1/workspaces/ws-1/mcp");
   });
 
   test("requires a delegation secret when toolspace is enabled", () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -177,6 +177,7 @@ import {
   type RunCredentialSessionReady,
 } from "./sandbox";
 import { runWithToolCallCorrelation } from "./sandbox/op-correlation";
+import { shellToolspacePath } from "./sandbox/toolspace-token";
 import {
   createTurnToolCancellationController,
   TurnSandboxCommandCancelledError,
@@ -6812,10 +6813,10 @@ export function toolspaceTokenSeedCommand(
     '  seed_umask="$(umask)"',
     "  umask 077",
     options.tokenFile
-      ? `  token_file=${shellQuote(options.tokenFile)}`
+      ? `  token_file=${shellToolspacePath(options.tokenFile)}`
       : '  token_file="${OPENGENI_TOOLSPACE_TOKEN_FILE:-$HOME/.opengeni/toolspace-token}"',
     options.legacyTokenFile
-      ? `  legacy_token_file=${shellQuote(options.legacyTokenFile)}`
+      ? `  legacy_token_file=${shellToolspacePath(options.legacyTokenFile)}`
       : '  legacy_token_file=""',
     '  mkdir -p "$(dirname "$token_file")"',
     '  printf \'%s\' "$OPENGENI_TOOLSPACE_TOKEN_SEED" > "$token_file.tmp.$$"',

--- a/packages/runtime/src/sandbox/toolspace-token.ts
+++ b/packages/runtime/src/sandbox/toolspace-token.ts
@@ -9,6 +9,7 @@ import type {
 } from "@openai/agents/sandbox";
 
 const MAX_TOOLSPACE_SESSION_ID_BYTES = 512;
+const HOME_RELATIVE_TOOLSPACE_PREFIX = "$HOME/";
 
 export class ToolspaceTokenPathError extends Error {
   constructor(message: string) {
@@ -33,6 +34,36 @@ function assertToolspaceSessionId(sessionId: string): string {
   return sessionId;
 }
 
+function isHomeRelativeToolspacePath(value: string): boolean {
+  if (!value.startsWith(HOME_RELATIVE_TOOLSPACE_PREFIX)) return false;
+  const relative = value.slice(HOME_RELATIVE_TOOLSPACE_PREFIX.length);
+  const segments = relative.split("/");
+  return (
+    relative.length > 0 &&
+    !relative.includes("\0") &&
+    segments.every(
+      (segment) => segment !== "." && segment !== ".." && /^[A-Za-z0-9._-]+$/.test(segment),
+    ) &&
+    posixPath.normalize(relative) === relative
+  );
+}
+
+function assertToolspaceFilePath(value: string, label: string): string {
+  if (
+    !value ||
+    value.includes("\0") ||
+    (!posixPath.isAbsolute(value) && !isHomeRelativeToolspacePath(value))
+  ) {
+    throw new ToolspaceTokenPathError(`${label} must be absolute or use the trusted $HOME/ prefix`);
+  }
+  return posixPath.isAbsolute(value) ? posixPath.normalize(value) : value;
+}
+
+export function shellToolspacePath(value: string): string {
+  const validated = assertToolspaceFilePath(value, "Toolspace token file");
+  return isHomeRelativeToolspacePath(validated) ? `"${validated}"` : shellQuote(validated);
+}
+
 /**
  * Derive the per-session token file beside the legacy manifest pointer.
  *
@@ -44,14 +75,10 @@ function assertToolspaceSessionId(sessionId: string): string {
  * authority boundary for Toolspace calls.
  */
 export function toolspaceTokenFileForSession(manifestTokenFile: string, sessionId: string): string {
-  if (
-    !manifestTokenFile ||
-    manifestTokenFile.includes("\0") ||
-    !posixPath.isAbsolute(manifestTokenFile)
-  ) {
-    throw new ToolspaceTokenPathError("Toolspace manifest token file must be absolute");
-  }
-  const normalizedManifestFile = posixPath.normalize(manifestTokenFile);
+  const normalizedManifestFile = assertToolspaceFilePath(
+    manifestTokenFile,
+    "Toolspace manifest token file",
+  );
   const digest = createHash("sha256").update(assertToolspaceSessionId(sessionId)).digest("hex");
   return posixPath.join(posixPath.dirname(normalizedManifestFile), "toolspace-tokens", digest);
 }
@@ -68,10 +95,7 @@ export function toolspaceTokenFileFromEnvironment(
 
 /** Prefix one sandbox command with its session-specific Toolspace pointer. */
 export function withToolspaceTokenEnvironment(cmd: string, tokenFile: string): string {
-  if (!tokenFile || tokenFile.includes("\0") || !posixPath.isAbsolute(tokenFile)) {
-    throw new ToolspaceTokenPathError("Toolspace token file must be absolute");
-  }
-  return [`export OPENGENI_TOOLSPACE_TOKEN_FILE=${shellQuote(tokenFile)}`, cmd].join("\n");
+  return [`export OPENGENI_TOOLSPACE_TOKEN_FILE=${shellToolspacePath(tokenFile)}`, cmd].join("\n");
 }
 
 /** Preserve provider identity/capabilities while decorating command creation. */

--- a/packages/runtime/test/toolspace-session-pointer.test.ts
+++ b/packages/runtime/test/toolspace-session-pointer.test.ts
@@ -72,6 +72,38 @@ describe("session-specific Toolspace token pointers", () => {
     );
   });
 
+  test("derives and expands Connected Machine pointers against the machine HOME", async () => {
+    const home = mkdtempSync(join(tmpdir(), "opengeni-toolspace-home-"));
+    try {
+      const manifestFile = "$HOME/.opengeni/toolspace-token";
+      const tokenFile = toolspaceTokenFileForSession(manifestFile, "session-a");
+      expect(tokenFile).toMatch(/^\$HOME\/\.opengeni\/toolspace-tokens\/[a-f0-9]{64}$/);
+      expect(() => toolspaceTokenFileForSession("$HOME/../escaped/token", "session-a")).toThrow(
+        "absolute or use the trusted $HOME/ prefix",
+      );
+      expect(() => toolspaceTokenFileForSession("$HOME/$(touch owned)/token", "session-a")).toThrow(
+        "absolute or use the trusted $HOME/ prefix",
+      );
+
+      const session = shellSession(home);
+      await runToolspaceTokenSeedHook(session as never, {
+        environment: { OPENGENI_TOOLSPACE_TOKEN_FILE: manifestFile },
+        toolspaceTokenSeed: "ogd_machine",
+        toolspaceTokenFile: tokenFile,
+      });
+
+      const selected = withToolspaceTokenSession(session, tokenFile);
+      const result = await selected.exec({
+        cmd: 'printf "%s:" "$OPENGENI_TOOLSPACE_TOKEN_FILE"; cat "$OPENGENI_TOOLSPACE_TOKEN_FILE"',
+      });
+      const expectedFile = tokenFile.replace("$HOME", home);
+      expect(result.stdout).toBe(`${expectedFile}:ogd_machine`);
+      expect(existsSync(join(home, ".opengeni", "toolspace-token"))).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   test("decorates client create/resume sessions and preserves lifecycle methods", async () => {
     const tokenFile = "/workspace/.opengeni/toolspace-tokens/" + "a".repeat(64);
     const commands: string[] = [];


### PR DESCRIPTION
## Summary
- preserve the Connected Machine user environment instead of deriving `HOME` from the whole-machine capability root
- use a narrowly validated `$HOME/` Toolspace pointer expanded inside the machine shell
- cover path derivation, seed, renewal, command selection, traversal, and shell-injection rejection

## Validation
- focused config/runtime/Connected Machine tests
- config, runtime, and worker typechecks
- targeted lint and formatting checks

This is a generic OpenGeni runtime correction.