### PR TITLE
feat(react): extend collapsed turn summaries

### DIFF
--- a/.changeset/extensible-turn-summary-facets.md
+++ b/.changeset/extensible-turn-summary-facets.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Add per-timeline `add`, `remove`, and `replace` customization for collapsed turn summary facets while preserving the existing defaults.

--- a/.changeset/normalize-mcp-output.md
+++ b/.changeset/normalize-mcp-output.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/sdk": patch
+"@opengeni/react": patch
+---
+
+Expose transport-tolerant MCP output normalization from the SDK and reuse it in the React timeline parser.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -298,6 +298,38 @@ per-tool renderers, and the rendering primitives (`ActivityDisclosure`,
 `ScreenshotFigure`, `TermBlock`, `LightboxProvider`, …) compose custom rows with
 the same semantics.
 
+Collapsed turn summaries can also be customized per `MessageTimeline` instance.
+Omit `turnSummary` to keep the built-in facets unchanged, use `add`/`remove` for
+small modifications, or `replace` for a complete ordered summary:
+
+```tsx
+import type { TurnSummaryFacet } from "@opengeni/react";
+
+const updatedRecordsFacet: TurnSummaryFacet = {
+  id: "updated-records",
+  summarize: ({ toolCalls }) => {
+    const count = toolCalls.filter((call) => call.name === "records.update").length;
+    return count > 0 ? { content: `${count} records updated` } : null;
+  },
+};
+
+<MessageTimeline
+  items={timeline}
+  turnSummary={{
+    facets: {
+      remove: ["memories"],
+      add: [updatedRecordsFacet],
+    },
+  }}
+/>;
+```
+
+Custom facets receive an immutable normalized activity snapshot, including
+ordered tool arguments, outputs, status, and timing. Added facets follow the
+remaining built-ins in supplied order. Duplicate IDs keep their first
+definition; remove a built-in before adding a custom facet with the same ID.
+`replace` is type-exclusive with `add` and `remove`.
+
 ## Sandbox surfacing
 
 An opt-in workbench that surfaces a session's live sandbox — files, terminal,

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -46,6 +46,7 @@ import {
   type TimelineGroup,
   type TimelineItem,
   type ToolRegistry,
+  type TurnSummaryOptions,
   type UserMessageItem,
   type WorkerCompletionItem,
   TurnSummary,
@@ -97,6 +98,8 @@ export type MessageTimelineProps = {
    * `createDefaultToolRegistry({ entries })` to add custom tool renderers.
    */
   toolRegistry?: ToolRegistry | undefined;
+  /** Customize collapsed turn facets for this timeline instance. */
+  turnSummary?: TurnSummaryOptions | undefined;
   /** Follow new events when pinned to the bottom. Defaults to true. */
   autoFollow?: boolean | undefined;
   /** Older durable history exists above the current window (see useSessionEvents). */
@@ -127,6 +130,7 @@ export function MessageTimeline({
   onReconnect,
   resolveProviderLogo,
   toolRegistry = defaultToolRegistry,
+  turnSummary,
   autoFollow = true,
   hasOlder = false,
   loadingOlder = false,
@@ -414,6 +418,7 @@ export function MessageTimeline({
                     onReconnect={onReconnect}
                     resolveProviderLogo={resolveProviderLogo}
                     toolRegistry={toolRegistry}
+                    turnSummary={turnSummary}
                     foldLiveCluster={isAgentProgress(groups[index + 1]?.group)}
                   />
                 </div>
@@ -621,6 +626,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
   onReconnect,
   resolveProviderLogo,
   toolRegistry,
+  turnSummary,
   insideTurn = false,
   foldLiveCluster = false,
 }: {
@@ -633,6 +639,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
   onReconnect?: ((item: AuthNeededItem) => void | Promise<void>) | undefined;
   resolveProviderLogo?: ((providerDomain: string) => string | null | undefined) | undefined;
   toolRegistry: ToolRegistry;
+  turnSummary?: TurnSummaryOptions | undefined;
   /** A completed cluster of a still-RUNNING turn (not the live tail) folds
       behind a neutral chip — the one place activity without an outcome still
       folds, bounding the DOM of days-long autonomous turns. */
@@ -651,6 +658,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
           failureText={insideTurn ? undefined : group.failureText}
           defaultOpen={!insideTurn && group.outcome === "failed" ? true : undefined}
           bare={insideTurn}
+          facets={turnSummary?.facets}
         >
           <ActivityRail
             items={group.items}
@@ -683,6 +691,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
           onReconnect={onReconnect}
           resolveProviderLogo={resolveProviderLogo}
           toolRegistry={toolRegistry}
+          turnSummary={turnSummary}
           insideTurn
         />
       ));
@@ -697,6 +706,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
           durationMs={durationBetween(group.startedAt, group.endedAt)}
           defaultOpen={!insideTurn && group.outcome === "failed" ? true : undefined}
           bare={insideTurn}
+          facets={turnSummary?.facets}
         >
           {insideTurn ? (
             // A nested turn is already on an ancestor rail — its body just stacks

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -286,6 +286,7 @@ export {
   TermBlock,
   Thumbnail,
   TurnSummary,
+  BUILT_IN_TURN_SUMMARY_FACET_IDS,
   useLightbox,
   useLightboxOptional,
 } from "./timeline";
@@ -293,7 +294,13 @@ export type {
   ActivityDisclosureProps,
   ActivityRailProps,
   DisclosureChip,
+  BuiltInTurnSummaryFacetId,
   TurnOutcome,
+  TurnSummaryContext,
+  TurnSummaryFacet,
+  TurnSummaryFacetConfiguration,
+  TurnSummaryFacetResult,
+  TurnSummaryOptions,
   TurnSummaryProps,
 } from "./timeline";
 

--- a/packages/react/src/session-ui.ts
+++ b/packages/react/src/session-ui.ts
@@ -9,5 +9,14 @@ export type {
 } from "./components/human-input-form";
 export { MessageTimeline, TimelineRow } from "./components/message-timeline";
 export type { MessageTimelineProps } from "./components/message-timeline";
+export { BUILT_IN_TURN_SUMMARY_FACET_IDS } from "./timeline/turn-summary";
+export type {
+  BuiltInTurnSummaryFacetId,
+  TurnSummaryContext,
+  TurnSummaryFacet,
+  TurnSummaryFacetConfiguration,
+  TurnSummaryFacetResult,
+  TurnSummaryOptions,
+} from "./timeline/turn-summary";
 export { QueueSurface } from "./components/queue-surface";
 export type { QueueSurfaceProps } from "./components/queue-surface";

--- a/packages/react/src/timeline/index.ts
+++ b/packages/react/src/timeline/index.ts
@@ -84,8 +84,17 @@ export { LightboxProvider, useLightbox, useLightboxOptional } from "./screenshot
 export { DisclosureDefaultsProvider, useForcedDefaultOpen } from "./disclosure-context";
 
 // turn-collapse summary chip
-export { TurnSummary } from "./turn-summary";
-export type { TurnOutcome, TurnSummaryProps } from "./turn-summary";
+export { BUILT_IN_TURN_SUMMARY_FACET_IDS, TurnSummary } from "./turn-summary";
+export type {
+  BuiltInTurnSummaryFacetId,
+  TurnOutcome,
+  TurnSummaryContext,
+  TurnSummaryFacet,
+  TurnSummaryFacetConfiguration,
+  TurnSummaryFacetResult,
+  TurnSummaryOptions,
+  TurnSummaryProps,
+} from "./turn-summary";
 
 // parsers (pure, reusable by custom renderers)
 export {

--- a/packages/react/src/timeline/parsers.ts
+++ b/packages/react/src/timeline/parsers.ts
@@ -1,4 +1,4 @@
-import type { GitFileDiff } from "@opengeni/sdk";
+import { normalizeMcpOutput, type GitFileDiff } from "@opengeni/sdk";
 import { tryParseJson } from "../lib/format";
 
 /* ----------------------------------------------------------------------------
@@ -288,36 +288,8 @@ export function unwrapMcpOutput(output: unknown): {
   text: string;
   isError: boolean;
 } {
-  // Managed MCP events persist a normalized single text part as
-  // `{ type: "text", text }`; accept it alongside the SDK-native content array.
-  if (
-    output &&
-    typeof output === "object" &&
-    (output as { type?: unknown }).type === "text" &&
-    typeof (output as { text?: unknown }).text === "string"
-  ) {
-    const record = output as { text: string; isError?: unknown };
-    return { text: record.text, isError: Boolean(record.isError) };
-  }
-  if (output && typeof output === "object" && "content" in output) {
-    const record = output as { content?: unknown; isError?: unknown };
-    const isError = Boolean(record.isError);
-    if (Array.isArray(record.content)) {
-      const textPart = record.content.find(
-        (part): part is { type: string; text: string } =>
-          !!part && typeof part === "object" && (part as { type?: unknown }).type === "text",
-      );
-      return {
-        text: textPart ? String(textPart.text) : JSON.stringify(output),
-        isError,
-      };
-    }
-    return { text: JSON.stringify(output), isError };
-  }
-  return {
-    text: typeof output === "string" ? output : output == null ? "" : JSON.stringify(output),
-    isError: false,
-  };
+  const normalized = normalizeMcpOutput(output);
+  return { text: normalized.text, isError: normalized.isError };
 }
 
 /* --- computer-use screenshot extraction ------------------------------------- */

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -1,12 +1,12 @@
 import { CheckIcon, ChevronRightIcon, CircleSlashIcon, TriangleAlertIcon } from "lucide-react";
-import { useState } from "react";
+import { Component, useMemo, useState, type ReactNode } from "react";
 import { Collapsible } from "radix-ui";
 import { cn } from "../lib/cn";
 import { useForcedDefaultOpen } from "./disclosure-context";
 import { useEntranceAnimation } from "./entrance";
 import { applyPatchOps, isApplyPatch, mediaPreviewFact, screenshotDataUrl } from "./parsers";
 import { rawTypeOf } from "./registry";
-import type { ActivityItem, TurnOutcome } from "./types";
+import type { ActivityItem, ToolCallItem, TurnOutcome } from "./types";
 export type { TurnOutcome } from "./types";
 
 /* ----------------------------------------------------------------------------
@@ -20,6 +20,67 @@ export type { TurnOutcome } from "./types";
    This keeps the timeline calm: a finished turn is a single line until the
    reader chooses to look inside it.
    -------------------------------------------------------------------------- */
+
+export const BUILT_IN_TURN_SUMMARY_FACET_IDS = [
+  "steps",
+  "files",
+  "commands",
+  "screenshots",
+  "memories",
+  "duration",
+] as const;
+
+export type BuiltInTurnSummaryFacetId = (typeof BUILT_IN_TURN_SUMMARY_FACET_IDS)[number];
+
+export type TurnSummaryContext = Readonly<{
+  /** Every normalized activity item folded into this summary. */
+  items: readonly ActivityItem[];
+  /** Tool calls from `items`, retained in timeline order for convenient aggregation. */
+  toolCalls: readonly ToolCallItem[];
+  /** The settled turn verdict, or absent for a neutral/incomplete cluster. */
+  outcome: TurnOutcome | undefined;
+  /** The bounded failure reason rendered by the enclosing summary, when present. */
+  failureText: string | undefined;
+  /** Total turn duration when the enclosing group has both valid timestamps. */
+  durationMs: number | undefined;
+  /** False when any projected activity is still running or streaming. */
+  settled: boolean;
+}>;
+
+export type TurnSummaryFacetResult = Readonly<{
+  icon?: ReactNode;
+  content: ReactNode;
+  ariaLabel?: string;
+  title?: string;
+}>;
+
+export type TurnSummaryFacet = Readonly<{
+  /** Stable identity used for removal and deterministic de-duplication. */
+  id: string;
+  /** Return null when this facet has nothing useful to show. */
+  summarize(context: TurnSummaryContext): TurnSummaryFacetResult | null;
+}>;
+
+type ModifyTurnSummaryFacets = Readonly<{
+  /** Appended after the remaining built-ins, in supplied order. */
+  add?: readonly TurnSummaryFacet[];
+  /** Built-ins to omit before custom facets are appended. */
+  remove?: readonly BuiltInTurnSummaryFacetId[];
+  replace?: never;
+}>;
+
+type ReplaceTurnSummaryFacets = Readonly<{
+  /** The complete ordered facet list. Mutually exclusive with add/remove. */
+  replace: readonly TurnSummaryFacet[];
+  add?: never;
+  remove?: never;
+}>;
+
+export type TurnSummaryFacetConfiguration = ModifyTurnSummaryFacets | ReplaceTurnSummaryFacets;
+
+export type TurnSummaryOptions = Readonly<{
+  facets?: TurnSummaryFacetConfiguration;
+}>;
 
 export type TurnSummaryProps = {
   /** The activity items in the turn (used only to compute the facet counts). */
@@ -43,8 +104,10 @@ export type TurnSummaryProps = {
    * of nodes, never a stack of boxes-in-boxes. The top-level fold stays a chip.
    */
   bare?: boolean | undefined;
+  /** Per-instance facet customization. Omit to preserve the built-in summary exactly. */
+  facets?: TurnSummaryFacetConfiguration | undefined;
   /** The rendered activity rail revealed on expand. */
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 export function TurnSummary({
@@ -54,6 +117,7 @@ export function TurnSummary({
   durationMs,
   defaultOpen,
   bare,
+  facets: facetConfiguration,
   children,
 }: TurnSummaryProps) {
   // An explicit `defaultOpen` always wins; otherwise an ancestor may seed it
@@ -61,7 +125,28 @@ export function TurnSummary({
   const forcedDefaultOpen = useForcedDefaultOpen();
   const [open, setOpen] = useState(defaultOpen ?? forcedDefaultOpen ?? false);
   const enter = useEntranceAnimation();
-  const facets = summarizeTurn(items, durationMs);
+  const context = useMemo(
+    () => createTurnSummaryContext(items, outcome, failureText, durationMs),
+    [items, outcome, failureText, durationMs],
+  );
+  const facetDefinitions = useMemo(
+    () => resolveTurnSummaryFacets(facetConfiguration),
+    [facetConfiguration],
+  );
+  const facets = useMemo(
+    () =>
+      facetDefinitions.flatMap((facet) => {
+        try {
+          const result = facet.summarize(context);
+          return result && hasFacetContent(result.content) ? [{ facet, result }] : [];
+        } catch {
+          // A host extension is presentation-only. It must never take down the
+          // durable timeline or hide the remaining built-in evidence.
+          return [];
+        }
+      }),
+    [context, facetDefinitions],
+  );
 
   return (
     <Collapsible.Root
@@ -117,7 +202,21 @@ export function TurnSummary({
           )}
         </span>
         <span className={cn("min-w-0 flex-1 truncate", bare ? "text-og-sm" : "text-og-fg-muted")}>
-          {facets}
+          {facets.map(({ facet, result }, index) => (
+            <FacetRenderBoundary key={facet.id}>
+              <>
+                {index > 0 ? " · " : null}
+                <span aria-label={result.ariaLabel} title={result.title}>
+                  {result.icon ? (
+                    <span aria-hidden className="mr-1 inline-flex align-[-0.125em]">
+                      {result.icon}
+                    </span>
+                  ) : null}
+                  {result.content}
+                </span>
+              </>
+            </FacetRenderBoundary>
+          ))}
           {outcome === "failed" && failureText ? (
             <span className="text-og-status-failed"> · {failureText}</span>
           ) : null}
@@ -150,63 +249,154 @@ export function TurnSummary({
   );
 }
 
-/** Compose the facet summary line ("14 steps · 3 files · 2 commands · 1 screenshot · 4m"). */
-function summarizeTurn(items: ActivityItem[], durationMs?: number): string {
-  let files = 0;
-  let commands = 0;
-  let screenshots = 0;
-  let memoriesSaved = 0;
-  let memoriesUpdated = 0;
-  for (const item of items) {
-    if (item.kind === "memory") {
-      // A memory write is a first-class facet — the "wrote 1 memory" signal the
-      // fold should make prominent — counted saved vs updated separately.
-      if (item.variant === "corrected") {
-        memoriesUpdated += 1;
-      } else {
-        memoriesSaved += 1;
+function createTurnSummaryContext(
+  items: ActivityItem[],
+  outcome: TurnOutcome | undefined,
+  failureText: string | undefined,
+  durationMs: number | undefined,
+): TurnSummaryContext {
+  const itemSnapshot = Object.freeze([...items]);
+  const toolCalls = Object.freeze(
+    itemSnapshot.filter((item): item is ToolCallItem => item.kind === "tool-call"),
+  );
+  const settled = itemSnapshot.every((item) => {
+    if (item.kind === "reasoning") {
+      return !item.streaming;
+    }
+    if (item.kind === "tool-call" || item.kind === "worker" || item.kind === "sandbox") {
+      return item.status !== "running";
+    }
+    return true;
+  });
+  return Object.freeze({
+    items: itemSnapshot,
+    toolCalls,
+    outcome,
+    failureText,
+    durationMs,
+    settled,
+  });
+}
+
+const BUILT_IN_TURN_SUMMARY_FACETS: readonly TurnSummaryFacet[] = Object.freeze([
+  {
+    id: "steps",
+    summarize: ({ items }) => ({
+      content: `${items.length} ${items.length === 1 ? "step" : "steps"}`,
+    }),
+  },
+  {
+    id: "files",
+    summarize: ({ toolCalls }) => {
+      let files = 0;
+      for (const item of toolCalls) {
+        if (isApplyPatch(item)) {
+          files += applyPatchOps(item.raw).length;
+        }
       }
-      continue;
-    }
-    if (item.kind !== "tool-call") {
-      continue;
-    }
-    // `item` is narrowed to ToolCallItem by the guard above — no cast needed.
-    if (isApplyPatch(item)) {
-      files += applyPatchOps(item.raw).length;
-    } else if (item.name === "exec_command") {
-      commands += 1;
-    } else if (
-      rawTypeOf(item) === "computer_call" ||
-      item.name === "computer_call" ||
-      item.name === "computer_screenshot"
-    ) {
-      if (screenshotDataUrl(item.output) !== null || mediaPreviewFact(item.output) !== null) {
-        screenshots += 1;
+      return files ? { content: `${files} ${files === 1 ? "file" : "files"} edited` } : null;
+    },
+  },
+  {
+    id: "commands",
+    summarize: ({ toolCalls }) => {
+      const commands = toolCalls.filter((item) => item.name === "exec_command").length;
+      return commands
+        ? { content: `${commands} ${commands === 1 ? "command" : "commands"}` }
+        : null;
+    },
+  },
+  {
+    id: "screenshots",
+    summarize: ({ toolCalls }) => {
+      let screenshots = 0;
+      for (const item of toolCalls) {
+        if (
+          (rawTypeOf(item) === "computer_call" ||
+            item.name === "computer_call" ||
+            item.name === "computer_screenshot") &&
+          (screenshotDataUrl(item.output) !== null || mediaPreviewFact(item.output) !== null)
+        ) {
+          screenshots += 1;
+        }
       }
+      return screenshots
+        ? {
+            content: `${screenshots} ${screenshots === 1 ? "screenshot" : "screenshots"}`,
+          }
+        : null;
+    },
+  },
+  {
+    id: "memories",
+    summarize: ({ items }) => {
+      let saved = 0;
+      let updated = 0;
+      for (const item of items) {
+        if (item.kind !== "memory") {
+          continue;
+        }
+        if (item.variant === "corrected") {
+          updated += 1;
+        } else {
+          saved += 1;
+        }
+      }
+      const parts: string[] = [];
+      if (saved) {
+        parts.push(`${saved} ${saved === 1 ? "memory" : "memories"} saved`);
+      }
+      if (updated) {
+        parts.push(`${updated} ${updated === 1 ? "memory" : "memories"} updated`);
+      }
+      return parts.length > 0 ? { content: parts.join(" · ") } : null;
+    },
+  },
+  {
+    id: "duration",
+    summarize: ({ durationMs }) => {
+      const duration = formatDurationFacet(durationMs);
+      return duration ? { content: duration } : null;
+    },
+  },
+]);
+
+function resolveTurnSummaryFacets(
+  configuration: TurnSummaryFacetConfiguration | undefined,
+): readonly TurnSummaryFacet[] {
+  const requested =
+    configuration && "replace" in configuration
+      ? configuration.replace
+      : [
+          ...BUILT_IN_TURN_SUMMARY_FACETS.filter(
+            (facet) => !configuration?.remove?.includes(facet.id as BuiltInTurnSummaryFacetId),
+          ),
+          ...(configuration?.add ?? []),
+        ];
+  const seen = new Set<string>();
+  return requested.filter((facet) => {
+    if (!facet.id || seen.has(facet.id)) {
+      return false;
     }
+    seen.add(facet.id);
+    return true;
+  });
+}
+
+function hasFacetContent(content: ReactNode): boolean {
+  return content !== null && content !== undefined && content !== false && content !== "";
+}
+
+class FacetRenderBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true };
   }
-  const parts = [`${items.length} ${items.length === 1 ? "step" : "steps"}`];
-  if (files) {
-    parts.push(`${files} ${files === 1 ? "file" : "files"} edited`);
+
+  render(): ReactNode {
+    return this.state.failed ? null : this.props.children;
   }
-  if (commands) {
-    parts.push(`${commands} ${commands === 1 ? "command" : "commands"}`);
-  }
-  if (screenshots) {
-    parts.push(`${screenshots} ${screenshots === 1 ? "screenshot" : "screenshots"}`);
-  }
-  if (memoriesSaved) {
-    parts.push(`${memoriesSaved} ${memoriesSaved === 1 ? "memory" : "memories"} saved`);
-  }
-  if (memoriesUpdated) {
-    parts.push(`${memoriesUpdated} ${memoriesUpdated === 1 ? "memory" : "memories"} updated`);
-  }
-  const duration = formatDurationFacet(durationMs);
-  if (duration) {
-    parts.push(duration);
-  }
-  return parts.join(" · ");
 }
 
 function formatDurationFacet(durationMs: number | undefined): string | null {

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -364,15 +364,12 @@ const BUILT_IN_TURN_SUMMARY_FACETS: readonly TurnSummaryFacet[] = Object.freeze(
 function resolveTurnSummaryFacets(
   configuration: TurnSummaryFacetConfiguration | undefined,
 ): readonly TurnSummaryFacet[] {
-  const requested =
-    configuration && "replace" in configuration
-      ? configuration.replace
-      : [
-          ...BUILT_IN_TURN_SUMMARY_FACETS.filter(
-            (facet) => !configuration?.remove?.includes(facet.id as BuiltInTurnSummaryFacetId),
-          ),
-          ...(configuration?.add ?? []),
-        ];
+  const requested: readonly TurnSummaryFacet[] = configuration?.replace ?? [
+    ...BUILT_IN_TURN_SUMMARY_FACETS.filter(
+      (facet) => !configuration?.remove?.includes(facet.id as BuiltInTurnSummaryFacetId),
+    ),
+    ...(configuration?.add ?? []),
+  ];
   const seen = new Set<string>();
   return requested.filter((facet) => {
     if (!facet.id || seen.has(facet.id)) {

--- a/packages/react/test/timeline-parsers.test.ts
+++ b/packages/react/test/timeline-parsers.test.ts
@@ -334,4 +334,15 @@ describe("MCP output unwrap", () => {
   test("unwrapMcpOutput handles nullish output", () => {
     expect(unwrapMcpOutput(null)).toEqual({ text: "", isError: false });
   });
+
+  test("unwrapMcpOutput uses the shared normalizer for structured and nested envelopes", () => {
+    expect(
+      unwrapMcpOutput({
+        result: {
+          structuredContent: { id: "record-1" },
+          content: [{ type: "text", text: "Record updated" }],
+        },
+      }),
+    ).toEqual({ text: "Record updated", isError: false });
+  });
 });

--- a/packages/react/test/turn-summary-facets.test.tsx
+++ b/packages/react/test/turn-summary-facets.test.tsx
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MessageTimeline,
+  TurnSummary,
+  type TimelineItem,
+  type ToolCallItem,
+  type TurnSummaryFacet,
+  type TurnSummaryFacetConfiguration,
+} from "../src";
+import type { MemoryItem } from "../src/timeline";
+import { flush, registerDom, renderComponent } from "./render-hook";
+
+registerDom();
+
+function toolCall(
+  id: string,
+  name: string,
+  status: ToolCallItem["status"] = "complete",
+): ToolCallItem {
+  return {
+    kind: "tool-call",
+    id,
+    turnId: "turn-1",
+    callId: `call-${id}`,
+    name,
+    arguments: { id },
+    output: { id, status },
+    raw: undefined,
+    status,
+    occurredAt: new Date(Number(id) * 1000).toISOString(),
+  };
+}
+
+function memory(id: string): MemoryItem {
+  return {
+    kind: "memory",
+    id,
+    turnId: "turn-1",
+    variant: "saved",
+    memoryKind: "semantic",
+    preview: "A durable fact",
+    memoryId: `memory-${id}`,
+    occurredAt: new Date(Number(id) * 1000).toISOString(),
+  };
+}
+
+function summaryText(container: HTMLElement): string {
+  const value = container.querySelector("button .min-w-0");
+  return value?.textContent ?? "";
+}
+
+function customFacet(id: string, content: string, ariaLabel?: string): TurnSummaryFacet {
+  return {
+    id,
+    summarize: () => (ariaLabel ? { content, ariaLabel } : { content }),
+  };
+}
+
+describe("TurnSummary facets", () => {
+  test("omitted configuration preserves the exact built-in summary", async () => {
+    const items = [toolCall("1", "exec_command"), memory("2")];
+    const rendered = await renderComponent(
+      <TurnSummary items={items} outcome="complete" durationMs={5_000}>
+        details
+      </TurnSummary>,
+    );
+
+    expect(summaryText(rendered.container)).toBe("2 steps · 1 command · 1 memory saved · 5s");
+    await rendered.unmount();
+  });
+
+  test("add appends custom facets without changing defaults", async () => {
+    const rendered = await renderComponent(
+      <TurnSummary
+        items={[toolCall("1", "exec_command")]}
+        outcome="complete"
+        facets={{ add: [customFacet("records", "2 records")] }}
+      >
+        details
+      </TurnSummary>,
+    );
+
+    expect(summaryText(rendered.container)).toBe("1 step · 1 command · 2 records");
+    await rendered.unmount();
+  });
+
+  test("remove omits only the selected built-in facet", async () => {
+    const rendered = await renderComponent(
+      <TurnSummary
+        items={[toolCall("1", "exec_command"), memory("2")]}
+        outcome="complete"
+        facets={{ remove: ["memories"] }}
+      >
+        details
+      </TurnSummary>,
+    );
+
+    expect(summaryText(rendered.container)).toBe("2 steps · 1 command");
+    await rendered.unmount();
+  });
+
+  test("replace renders only custom facets in supplied order", async () => {
+    const rendered = await renderComponent(
+      <TurnSummary
+        items={[toolCall("1", "exec_command")]}
+        outcome="complete"
+        facets={{
+          replace: [customFacet("records", "3 records"), customFacet("tasks", "1 task")],
+        }}
+      >
+        details
+      </TurnSummary>,
+    );
+
+    expect(summaryText(rendered.container)).toBe("3 records · 1 task");
+    await rendered.unmount();
+  });
+
+  test("null, empty, duplicate, and throwing facets are isolated", async () => {
+    const rendered = await renderComponent(
+      <TurnSummary
+        items={[toolCall("1", "exec_command")]}
+        outcome="complete"
+        facets={{
+          replace: [
+            { id: "null", summarize: () => null },
+            { id: "empty", summarize: () => ({ content: "" }) },
+            customFacet("kept", "kept"),
+            customFacet("kept", "duplicate"),
+            {
+              id: "broken",
+              summarize: () => {
+                throw new Error("host facet failed");
+              },
+            },
+          ],
+        }}
+      >
+        details
+      </TurnSummary>,
+    );
+
+    expect(summaryText(rendered.container)).toBe("kept");
+    await rendered.unmount();
+  });
+
+  test("a facet aggregates normalized tool calls and sees incomplete state", async () => {
+    let observedStatuses: ToolCallItem["status"][] = [];
+    const aggregate: TurnSummaryFacet = {
+      id: "aggregate",
+      summarize: (context) => {
+        observedStatuses = context.toolCalls.map((call) => call.status);
+        return {
+          content: `${context.toolCalls.length} calls, ${context.settled ? "settled" : "working"}`,
+        };
+      },
+    };
+    const rendered = await renderComponent(
+      <TurnSummary
+        items={[toolCall("1", "tasks.create"), toolCall("2", "records.update", "running")]}
+        facets={{ replace: [aggregate] }}
+      >
+        details
+      </TurnSummary>,
+    );
+
+    expect(observedStatuses).toEqual(["complete", "running"]);
+    expect(summaryText(rendered.container)).toBe("2 calls, working");
+    await rendered.unmount();
+  });
+
+  test("accessible labels and titles are applied to the facet", async () => {
+    const rendered = await renderComponent(
+      <TurnSummary
+        items={[]}
+        outcome="complete"
+        facets={{
+          replace: [
+            {
+              id: "records",
+              summarize: () => ({
+                content: "2 records",
+                ariaLabel: "Two records updated",
+                title: "Updated records",
+              }),
+            },
+          ],
+        }}
+      >
+        details
+      </TurnSummary>,
+    );
+
+    const facet = rendered.container.querySelector('[aria-label="Two records updated"]');
+    expect(facet?.getAttribute("title")).toBe("Updated records");
+    await rendered.unmount();
+  });
+
+  test("MessageTimeline forwards one configuration to its collapsed turns", async () => {
+    const items: TimelineItem[] = [
+      toolCall("1", "exec_command"),
+      {
+        kind: "turn-end",
+        id: "end-1",
+        turnId: "turn-1",
+        outcome: "complete",
+        failureText: null,
+        occurredAt: new Date(1_500).toISOString(),
+      },
+    ];
+    const rendered = await renderComponent(
+      <MessageTimeline items={items} turnSummary={{ facets: { remove: ["commands"] } }} />,
+    );
+    await flush();
+
+    expect(summaryText(rendered.container)).toBe("1 step");
+    await rendered.unmount();
+  });
+});
+
+const validModification: TurnSummaryFacetConfiguration = {
+  add: [customFacet("records", "records")],
+  remove: ["memories"],
+};
+const validReplacement: TurnSummaryFacetConfiguration = {
+  replace: [customFacet("records", "records")],
+};
+// @ts-expect-error replacement is deliberately mutually exclusive with modification.
+const invalidMixedConfiguration: TurnSummaryFacetConfiguration = {
+  replace: [customFacet("records", "records")],
+  add: [customFacet("tasks", "tasks")],
+};
+void validModification;
+void validReplacement;
+void invalidMixedConfiguration;

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -30,6 +30,28 @@ for await (const event of client.streamEvents(workspaceId, session.id)) {
 }
 ```
 
+## MCP tool output normalization
+
+MCP transports and event stores can represent the same tool result as a direct
+object, JSON text, a text content block, or nested `result`,
+`structuredContent`, and `content` envelopes. Use the shared zero-dependency
+normalizer when an embedding host needs one stable interpretation:
+
+```ts
+import { normalizeMcpOutput } from "@opengeni/sdk";
+
+const normalized = normalizeMcpOutput(toolOutput);
+
+normalized.value; // canonical machine-readable value
+normalized.text; // presentation text
+normalized.isError; // preserved across recognized nested envelopes
+normalized.raw; // original evidence
+```
+
+Malformed text and unknown objects pass through without throwing. Envelope
+recognition is deliberately conservative: an ordinary domain object is not
+unwrapped merely because it has a field named `result`.
+
 ## Error handling
 
 Non-2xx responses throw `OpenGeniApiError` with stable transport metadata:

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -24,6 +24,8 @@ export {
 export type { ProxySessionEventStreamOptions, SseReStreamOptions } from "./proxy";
 export { parseSseStream } from "./sse";
 export type { SseMessage } from "./sse";
+export { normalizeMcpOutput } from "./mcp-output";
+export type { NormalizedMcpOutput } from "./mcp-output";
 // Desktop (noVNC) transport contract — pure, zero-dep (the RFB import lives in
 // @opengeni/react). URL assembler + connection state machine + rotation fence.
 export { desktopSocketUrl, nextDesktopState, applyUrlRotation } from "./desktop";

--- a/packages/sdk/src/mcp-output.ts
+++ b/packages/sdk/src/mcp-output.ts
@@ -1,0 +1,161 @@
+/**
+ * A transport-tolerant MCP tool result.
+ *
+ * `value` is the canonical machine-readable payload after recognized MCP/JSON
+ * envelopes are removed. `text` is the best presentation string without
+ * discarding structured data. `raw` always retains the original evidence.
+ */
+export type NormalizedMcpOutput = Readonly<{
+  raw: unknown;
+  value: unknown;
+  text: string;
+  isError: boolean;
+}>;
+
+const MAX_MCP_OUTPUT_DEPTH = 8;
+const RESULT_ENVELOPE_KEYS = new Set(["result", "isError", "jsonrpc", "id", "_meta"]);
+
+/** Normalize common direct, JSON, and standard MCP result envelopes without throwing. */
+export function normalizeMcpOutput(output: unknown): NormalizedMcpOutput {
+  const normalized = normalizeValue(output, 0, new Set<object>());
+  return {
+    raw: output,
+    value: normalized.value,
+    text: normalized.text,
+    isError: normalized.isError,
+  };
+}
+
+type NormalizedValue = Omit<NormalizedMcpOutput, "raw">;
+
+function normalizeValue(value: unknown, depth: number, ancestors: Set<object>): NormalizedValue {
+  if (value === null || value === undefined) {
+    return { value, text: "", isError: false };
+  }
+  if (typeof value === "string") {
+    return normalizeText(value, depth, ancestors);
+  }
+  if (typeof value !== "object") {
+    return { value, text: String(value), isError: false };
+  }
+  if (depth >= MAX_MCP_OUTPUT_DEPTH || ancestors.has(value)) {
+    return { value, text: safeStringify(value), isError: false };
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return { value, text: safeStringify(value), isError: false };
+    }
+
+    const record = value as Record<string, unknown>;
+    const envelopeError = record.isError === true;
+
+    if (record.type === "text" && typeof record.text === "string") {
+      const normalized = normalizeText(record.text, depth + 1, ancestors);
+      return {
+        value: normalized.value,
+        text: record.text,
+        isError: envelopeError || normalized.isError,
+      };
+    }
+
+    if ("structuredContent" in record) {
+      const normalized = normalizeValue(record.structuredContent, depth + 1, ancestors);
+      return {
+        value: normalized.value,
+        text: firstMcpText(record.content) ?? normalized.text,
+        isError: envelopeError || normalized.isError,
+      };
+    }
+
+    if (isMcpContent(record.content)) {
+      const text = firstMcpText(record.content);
+      if (text !== null) {
+        const normalized = normalizeText(text, depth + 1, ancestors);
+        return {
+          value: normalized.value,
+          text,
+          isError: envelopeError || normalized.isError,
+        };
+      }
+      return {
+        value,
+        text: safeStringify(value),
+        isError: envelopeError,
+      };
+    }
+
+    if (isResultEnvelope(record)) {
+      const normalized = normalizeValue(record.result, depth + 1, ancestors);
+      return {
+        value: normalized.value,
+        text: normalized.text,
+        isError: envelopeError || normalized.isError,
+      };
+    }
+
+    return {
+      value,
+      text: safeStringify(value),
+      isError: envelopeError,
+    };
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function normalizeText(text: string, depth: number, ancestors: Set<object>): NormalizedValue {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    const normalized = normalizeValue(parsed, depth + 1, ancestors);
+    return {
+      value: normalized.value,
+      text,
+      isError: normalized.isError,
+    };
+  } catch {
+    return { value: text, text, isError: false };
+  }
+}
+
+function isMcpContent(value: unknown): value is readonly Record<string, unknown>[] {
+  return (
+    Array.isArray(value) &&
+    value.some(
+      (part) =>
+        part !== null &&
+        typeof part === "object" &&
+        typeof (part as { type?: unknown }).type === "string",
+    )
+  );
+}
+
+function firstMcpText(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  for (const part of value) {
+    if (
+      part !== null &&
+      typeof part === "object" &&
+      (part as { type?: unknown }).type === "text" &&
+      typeof (part as { text?: unknown }).text === "string"
+    ) {
+      return (part as { text: string }).text;
+    }
+  }
+  return null;
+}
+
+function isResultEnvelope(record: Record<string, unknown>): boolean {
+  return "result" in record && Object.keys(record).every((key) => RESULT_ENVELOPE_KEYS.has(key));
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/sdk/test/mcp-output.test.ts
+++ b/packages/sdk/test/mcp-output.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeMcpOutput } from "../src";
+
+describe("normalizeMcpOutput", () => {
+  test("preserves a direct result object as canonical value", () => {
+    const output = { id: "record-1", status: "updated" };
+    expect(normalizeMcpOutput(output)).toEqual({
+      raw: output,
+      value: output,
+      text: '{"id":"record-1","status":"updated"}',
+      isError: false,
+    });
+  });
+
+  test("parses a JSON string while preserving its presentation text", () => {
+    expect(normalizeMcpOutput('{"id":"record-1"}')).toEqual({
+      raw: '{"id":"record-1"}',
+      value: { id: "record-1" },
+      text: '{"id":"record-1"}',
+      isError: false,
+    });
+  });
+
+  test("normalizes a direct persisted MCP text block", () => {
+    const output = { type: "text", text: '{"id":"record-1"}' };
+    expect(normalizeMcpOutput(output)).toEqual({
+      raw: output,
+      value: { id: "record-1" },
+      text: '{"id":"record-1"}',
+      isError: false,
+    });
+  });
+
+  test("normalizes standard MCP content and preserves isError", () => {
+    const output = {
+      isError: true,
+      content: [
+        { type: "image", data: "..." },
+        { type: "text", text: '{"code":"CONFLICT"}' },
+      ],
+    };
+    expect(normalizeMcpOutput(output)).toEqual({
+      raw: output,
+      value: { code: "CONFLICT" },
+      text: '{"code":"CONFLICT"}',
+      isError: true,
+    });
+  });
+
+  test("prefers structuredContent for value and content text for presentation", () => {
+    const output = {
+      structuredContent: { id: "record-1", status: "updated" },
+      content: [{ type: "text", text: "Record updated" }],
+    };
+    expect(normalizeMcpOutput(output)).toEqual({
+      raw: output,
+      value: { id: "record-1", status: "updated" },
+      text: "Record updated",
+      isError: false,
+    });
+  });
+
+  test("unwraps bounded nested result and MCP envelopes", () => {
+    const output = {
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        result: {
+          content: [{ type: "text", text: '{"id":"record-1"}' }],
+        },
+      },
+    };
+    expect(normalizeMcpOutput(output)).toEqual({
+      raw: output,
+      value: { id: "record-1" },
+      text: '{"id":"record-1"}',
+      isError: false,
+    });
+  });
+
+  test("does not unwrap an ordinary domain object that happens to have a result field", () => {
+    const output = { operation: "check", result: { allowed: true } };
+    expect(normalizeMcpOutput(output).value).toBe(output);
+  });
+
+  test("malformed or non-JSON text passes through without throwing", () => {
+    expect(normalizeMcpOutput("{not json")).toEqual({
+      raw: "{not json",
+      value: "{not json",
+      text: "{not json",
+      isError: false,
+    });
+  });
+
+  test("non-text MCP content and cyclic objects remain safe", () => {
+    const imageOnly = { content: [{ type: "image", data: "..." }] };
+    expect(normalizeMcpOutput(imageOnly).value).toBe(imageOnly);
+    expect(normalizeMcpOutput(imageOnly).text).toBe('{"content":[{"type":"image","data":"..."}]}');
+
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => normalizeMcpOutput(cyclic)).not.toThrow();
+    expect(normalizeMcpOutput(cyclic).value).toBe(cyclic);
+  });
+
+  test("nullish and primitive values normalize predictably", () => {
+    expect(normalizeMcpOutput(null)).toEqual({
+      raw: null,
+      value: null,
+      text: "",
+      isError: false,
+    });
+    expect(normalizeMcpOutput(42)).toEqual({
+      raw: 42,
+      value: 42,
+      text: "42",
+      isError: false,
+    });
+  });
+});

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -14,7 +14,7 @@ const budgets = {
   initialGzip: 210 * kib,
   initialFileGzip: 70 * kib,
   directSessionRaw: 1900 * kib,
-  directSessionGzip: 546 * kib,
+  directSessionGzip: 547 * kib,
   lazyChunkRaw: 800 * kib,
   lazyChunkGzip: 240 * kib,
   cssGzip: 30 * kib,


### PR DESCRIPTION
## Summary
- add typed per-`MessageTimeline` turn-summary facet configuration with `add`, `remove`, and `replace`
- preserve the existing built-in summary order and appearance by default
- expose stable built-in IDs and immutable normalized facet context
- add a zero-dependency SDK normalizer for direct, JSON, and standard MCP tool-output envelopes
- reuse the SDK normalizer from the React timeline parser

## Verification
- SDK + React tests: 955 passed, 0 failed
- `@opengeni/sdk` typecheck and build
- `@opengeni/react` typecheck and build
- targeted oxlint and formatting checks
- documentation reference guard

The two concerns are kept in separate commits and contain only generic public integration concepts.