### PR TITLE
fix(release): advance occupied product version

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.14
-appVersion: "0.22.14"
+version: 0.22.15
+appVersion: "0.22.15"


### PR DESCRIPTION
Advances the product chart identity from occupied 0.22.14 to 0.22.15 so the current reviewed main train can produce immutable candidate artifacts.