### PR TITLE
fix(release): prepare deployable 0.22.16 train

### DIFF
--- a/.changeset/reviewed-client-release.md
+++ b/.changeset/reviewed-client-release.md
@@ -1,6 +1,0 @@
----
-"@opengeni/react": patch
-"@opengeni/sdk": patch
----
-
-Publish the current client surfaces from one exact reviewed source revision.

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.15
-appVersion: "0.22.15"
+version: 0.22.16
+appVersion: "0.22.16"

--- a/examples/northstar-support/CHANGELOG.md
+++ b/examples/northstar-support/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @opengeni/example-northstar-support
 
+## 0.0.28
+
+### Patch Changes
+
+- Updated dependencies [c1dcccc]
+  - @opengeni/react@0.28.2
+  - @opengeni/sdk@0.28.2
+
 ## 0.0.27
 
 ### Patch Changes

--- a/examples/northstar-support/package.json
+++ b/examples/northstar-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/example-northstar-support",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @opengeni/react
 
+## 0.28.2
+
+### Patch Changes
+
+- c1dcccc: Publish the current client surfaces from one exact reviewed source revision.
+- Updated dependencies [c1dcccc]
+  - @opengeni/sdk@0.28.2
+
 ## 0.28.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/react",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "React hooks and styled components for OpenGeni: live session streaming, chat composer, message timeline, session status, and fleet views — token-themed (CSS variables), dark-first, built on Tailwind v4 + Radix + Motion.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opengeni/sdk
 
+## 0.28.2
+
+### Patch Changes
+
+- c1dcccc: Publish the current client surfaces from one exact reviewed source revision.
+
 ## 0.28.1
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/sdk",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "Framework-agnostic TypeScript SDK for the OpenGeni API: typed client, session lifecycle, SSE event streaming with reconnect + replay-by-sequence, and proxy re-streaming helpers.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Consumes the final pending client changeset and advances the occupied product chart identity to 0.22.16, producing one exact reviewed source for immediate production deployment.