### PR TITLE
fix(mcp): separate request timeouts from auth

### DIFF
--- a/.changeset/fair-carrots-auth.md
+++ b/.changeset/fair-carrots-auth.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/runtime": patch
+---
+
+Keep MCP request timeouts distinct from recoverable connection authentication errors.

--- a/apps/api/src/mcp/toolspace.ts
+++ b/apps/api/src/mcp/toolspace.ts
@@ -76,9 +76,12 @@ type McpTool = {
 };
 
 const APPROVAL_REQUIRED_MESSAGE = "requires approval - invoke via the agent";
-const TOOLSPACE_AUTH_NEEDED_ERROR_CODE = -32001;
-const TOOLSPACE_AUTH_NEEDED_MESSAGE =
-  "Authentication required - a connection link was posted to the session.";
+const TOOLSPACE_AUTH_NEEDED_ERROR = {
+  // OpenGeni application-defined JSON-RPC code. Keep this positive so it cannot
+  // collide with MCP SDK transport errors such as RequestTimeout (-32001).
+  code: 40_101,
+  message: "Authentication required - a connection link was posted to the session.",
+} as const;
 const TOOLSPACE_NO_ACTIVE_TURN_MESSAGE =
   "no active turn - toolspace calls require an in-flight turn";
 // First-party OpenGeni MCP proxies (files/docs) route back through the same
@@ -721,7 +724,7 @@ async function callRemoteTool(
       return mcpError("upstream tool result exceeded the safety limit");
     }
     if (isToolspaceAuthNeededError(error)) {
-      return mcpError(TOOLSPACE_AUTH_NEEDED_MESSAGE);
+      return mcpError(TOOLSPACE_AUTH_NEEDED_ERROR.message);
     }
     // The raw upstream error can carry provider-specific detail; log it
     // server-side and return only a generic result to the sandbox so no header
@@ -1037,8 +1040,8 @@ async function authNeededFetchResponse(
         jsonrpc: "2.0",
         id: request.id ?? null,
         error: {
-          code: TOOLSPACE_AUTH_NEEDED_ERROR_CODE,
-          message: TOOLSPACE_AUTH_NEEDED_MESSAGE,
+          code: TOOLSPACE_AUTH_NEEDED_ERROR.code,
+          message: TOOLSPACE_AUTH_NEEDED_ERROR.message,
         },
       }),
       {
@@ -1110,9 +1113,14 @@ function fetchInputForAttempt(input: string | URL | Request): string | URL | Req
 }
 
 function isToolspaceAuthNeededError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const code = (error as { code?: unknown }).code;
   return (
-    error instanceof Error &&
-    ((error as { code?: unknown }).code === TOOLSPACE_AUTH_NEEDED_ERROR_CODE ||
-      error.message.includes(TOOLSPACE_AUTH_NEEDED_MESSAGE))
+    code === TOOLSPACE_AUTH_NEEDED_ERROR.code &&
+    (error.message === TOOLSPACE_AUTH_NEEDED_ERROR.message ||
+      error.message ===
+        `MCP error ${TOOLSPACE_AUTH_NEEDED_ERROR.code}: ${TOOLSPACE_AUTH_NEEDED_ERROR.message}`)
   );
 }

--- a/apps/api/test/toolspace-surface.test.ts
+++ b/apps/api/test/toolspace-surface.test.ts
@@ -439,11 +439,12 @@ describe("prepareToolspaceMcpSurface", () => {
     }
   });
 
-  test("uses the host MCP credential port with the active turn's frozen initiator", async () => {
+  test("uses host MCP credentials and preserves legitimate auth-needed results", async () => {
     if (!available) return;
     const server = startTestMcpServer({ requiredAuthorization: "Bearer cloud-connection" });
     const connectionId = crypto.randomUUID();
     const requests: McpCredentialsRequest[] = [];
+    let authRequired = false;
     const settings = testSettings({
       toolspaceEnabled: true,
       toolspaceMaxCallsPerTurn: 200,
@@ -477,6 +478,24 @@ describe("prepareToolspaceMcpSurface", () => {
       connectionCredentials: {
         mcpCredentials: async (request: McpCredentialsRequest) => {
           requests.push(request);
+          if (authRequired && request.toolName) {
+            return {
+              status: "auth_needed" as const,
+              accountId: request.accountId,
+              workspaceId: request.workspaceId,
+              sessionId: request.sessionId,
+              reason: "missing_connection" as const,
+              connectionId,
+              providerDomain: request.connectionRef.providerDomain,
+              ...(request.connectionRef.provider
+                ? { provider: request.connectionRef.provider }
+                : {}),
+              ...(request.connectionRef.selectedResources
+                ? { selectedResources: request.connectionRef.selectedResources }
+                : {}),
+              authorizationUrl: "https://example.com/connect",
+            };
+          }
           return {
             status: "ok" as const,
             accountId: request.accountId,
@@ -503,6 +522,31 @@ describe("prepareToolspaceMcpSurface", () => {
     expect(tool).toBeDefined();
     const result = await tool!.call({ query: "host credential" });
     expect(result.isError).toBeFalsy();
+    authRequired = true;
+    const authResult = await tool!.call({ query: "reauthenticate" });
+    expect(authResult).toMatchObject({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Authentication required - a connection link was posted to the session.",
+        },
+      ],
+    });
+    expect(server.calls).toHaveLength(1);
+    const events = await listSessionEvents(db, seeded.workspaceId, seeded.sessionId, 0, 100);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool.auth_needed",
+        payload: expect.objectContaining({
+          serverId: "host-github",
+          toolName: "search_documents",
+          reason: "missing_connection",
+          connectionId,
+          authorizationUrl: "https://example.com/connect",
+        }),
+      }),
+    );
     expect(requests.length).toBeGreaterThan(0);
     expect(requests.every((request) => request.surface === "toolspace")).toBe(true);
     expect(requests.every((request) => request.accountId === seeded.accountId)).toBe(true);
@@ -792,5 +836,68 @@ describe("prepareToolspaceMcpSurface", () => {
     const text = (result.content?.[0] as { text?: string } | undefined)?.text;
     expect(text).toBe("upstream tool failed: flaky__search_documents");
     await surface!.close();
+  }, 60_000);
+
+  test("never turns an MCP request timeout into a connection-auth result", async () => {
+    if (!available) return;
+    let markStarted: (() => void) | null = null;
+    let releaseCall: (() => void) | null = null;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      releaseCall = resolve;
+    });
+    const server = startTestMcpServer({
+      beforeToolCall: async () => {
+        markStarted?.();
+        await gate;
+      },
+    });
+    const deps = {
+      settings: testSettings({
+        toolspaceEnabled: true,
+        toolspaceMaxCallsPerTurn: 200,
+        mcpServers: [
+          {
+            id: "timeout",
+            url: server.url,
+            cacheToolsList: false,
+            timeoutMs: 1_000,
+          },
+        ],
+      }),
+      db,
+      bus: new MemoryEventBus(),
+      observability,
+    } as unknown as ApiRouteDeps;
+    const seeded = await seedSession({
+      selects: ["timeout"],
+      withActiveTurn: true,
+    });
+    let surface: ToolspaceMcpSurface | null = null;
+    try {
+      surface = await prepareToolspaceMcpSurface({
+        deps,
+        grant: grantFor(seeded),
+      });
+      const tool = surface!.tools.find(
+        (candidate) => candidate.name === "timeout__search_documents",
+      );
+      expect(tool).toBeDefined();
+      const pending = tool!.call({ query: "wait" });
+      await started;
+      const result = await pending;
+      expect(result).toMatchObject({
+        isError: true,
+        content: [{ type: "text", text: "upstream tool failed: timeout__search_documents" }],
+      });
+      const events = await listSessionEvents(db, seeded.workspaceId, seeded.sessionId, 0, 100);
+      expect(events.some((event) => event.type === "tool.auth_needed")).toBe(false);
+    } finally {
+      releaseCall?.();
+      await surface?.close();
+      server.close();
+    }
   }, 60_000);
 });

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -762,7 +762,7 @@ export function classifyContextWindowOverflowError(
  * next-loop transport work can reject the stream iterator after a prior tool
  * output was already published. That is transient external backpressure, not a
  * terminal session error. Match MCP-qualified timeout text only: an unrelated
- * sandbox/model timeout and MCP's `-32001 Authentication required` signal must
+ * sandbox/model timeout and MCP's application-defined Authentication required signal must
  * retain their existing semantics.
  */
 export function classifyMcpTransportTimeoutError(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2993,9 +2993,12 @@ function parseWwwAuthenticate(header: string | null): {
 // content, erasing the failure. A JSON-RPC error survives the shim as a thrown
 // McpError, which PrefixedMcpServer.callTool converts back into an MCP-shaped
 // `{ isError: true }` output for the model.
-const MCP_AUTH_NEEDED_ERROR_CODE = -32001;
-const MCP_AUTH_NEEDED_MESSAGE =
-  "Authentication required - a connection link was posted to the session.";
+const MCP_AUTH_NEEDED_ERROR = {
+  // OpenGeni application-defined JSON-RPC code. Keep this positive so it cannot
+  // collide with MCP SDK transport errors such as RequestTimeout (-32001).
+  code: 40_101,
+  message: "Authentication required - a connection link was posted to the session.",
+} as const;
 
 function mcpToolAuthNeededResponse(id: string | number | null | undefined): Response {
   return new Response(
@@ -3003,8 +3006,8 @@ function mcpToolAuthNeededResponse(id: string | number | null | undefined): Resp
       jsonrpc: "2.0",
       id: id ?? null,
       error: {
-        code: MCP_AUTH_NEEDED_ERROR_CODE,
-        message: MCP_AUTH_NEEDED_MESSAGE,
+        code: MCP_AUTH_NEEDED_ERROR.code,
+        message: MCP_AUTH_NEEDED_ERROR.message,
       },
     }),
     {
@@ -3019,7 +3022,11 @@ function isAuthNeededMcpError(error: unknown): boolean {
     return false;
   }
   const code = (error as { code?: unknown }).code;
-  return code === MCP_AUTH_NEEDED_ERROR_CODE || error.message.includes(MCP_AUTH_NEEDED_MESSAGE);
+  return (
+    code === MCP_AUTH_NEEDED_ERROR.code &&
+    (error.message === MCP_AUTH_NEEDED_ERROR.message ||
+      error.message === `MCP error ${MCP_AUTH_NEEDED_ERROR.code}: ${MCP_AUTH_NEEDED_ERROR.message}`)
+  );
 }
 
 // Model-facing text for a best-effort server whose tool call failed for a
@@ -3469,7 +3476,7 @@ class PrefixedMcpServer implements MCPServer {
       if (isAuthNeededMcpError(error)) {
         return {
           isError: true,
-          content: [{ type: "text", text: MCP_AUTH_NEEDED_MESSAGE }],
+          content: [{ type: "text", text: MCP_AUTH_NEEDED_ERROR.message }],
         };
       }
       // Best-effort INVOCATION isolation (sibling to the listTools guard). When

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -20,6 +20,7 @@ import {
   invalidateServerToolsCache,
 } from "@openai/agents";
 import { Usage } from "@openai/agents-core";
+import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import {
   AGENT_INSTRUCTIONS_CORE_PLACEHOLDER,
   DEFAULT_AGENT_INSTRUCTIONS,
@@ -3787,8 +3788,15 @@ describe("runtime event normalization", () => {
       const result = await prepared.mcpServers[0]!.callTool("cap-auth-needed__search_documents", {
         query: "auth",
       });
-      expect(result).toMatchObject({ isError: true });
-      expect(JSON.stringify(result)).toContain("Authentication required");
+      expect(result).toMatchObject({
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "Authentication required - a connection link was posted to the session.",
+          },
+        ],
+      });
       expect(mcp.calls).toEqual([]);
       expect(authNeeded).toContainEqual(
         expect.objectContaining({
@@ -3803,6 +3811,66 @@ describe("runtime event normalization", () => {
       mcp.close();
     }
   });
+
+  test("never classifies the MCP SDK request-timeout code as connection auth", async () => {
+    let markStarted: (() => void) | null = null;
+    let releaseCall: (() => void) | null = null;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      releaseCall = resolve;
+    });
+    const mcp = startTestMcpServer({
+      beforeToolCall: async () => {
+        markStarted?.();
+        await gate;
+      },
+    });
+    const authNeeded: unknown[] = [];
+    const prepared = await prepareAgentTools(
+      testSettings({
+        mcpServers: [
+          {
+            id: "request-timeout",
+            name: "Request timeout",
+            url: mcp.url,
+            cacheToolsList: false,
+            timeoutMs: 1_000,
+          },
+        ],
+      }),
+      [{ kind: "mcp", id: "request-timeout" }],
+      {
+        onAuthNeeded: (payload) => {
+          authNeeded.push(payload);
+        },
+      },
+    );
+    try {
+      await prepared.mcpServers[0]!.listTools();
+      const pending = prepared.mcpServers[0]!.callTool("request-timeout__search_documents", {
+        query: "wait",
+      });
+      await started;
+      let failure: unknown;
+      try {
+        await pending;
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toBeInstanceOf(Error);
+      expect(failure).toMatchObject({ code: ErrorCode.RequestTimeout });
+      expect((failure as Error).message).toBe(
+        `MCP error ${ErrorCode.RequestTimeout}: Request timed out`,
+      );
+      expect(authNeeded).toEqual([]);
+    } finally {
+      releaseCall?.();
+      await prepared.close();
+      mcp.close();
+    }
+  }, 10_000);
 
   test("skips brokered MCP servers at connect time when auth is missing and emits auth-needed", async () => {
     const authNeeded: unknown[] = [];

--- a/scripts/test-publish-consumer.ts
+++ b/scripts/test-publish-consumer.ts
@@ -319,6 +319,8 @@ try {
         "    () => ({",
         "      snapshot: null,",
         '      queue: [{ id: "turn-proof", workspaceId: "workspace-proof", sessionId: "session-proof", triggerEventId: "event-proof", temporalWorkflowId: "workflow-proof", status: "queued", source: "user", position: 1, prompt: "Review the queued host request", resources: [], tools: [], model: "host-model", reasoningEffort: "medium", sandboxBackend: "none", sandboxOs: null, metadata: {}, version: 1, executionGeneration: 0, activeAttemptId: null, lineage: {}, initiator: { kind: "service", subjectId: "host:proof" }, initiatorContext: {}, startedAt: null, finishedAt: null, createdAt: "2026-07-23T00:00:00.000Z", updatedAt: "2026-07-23T00:00:00.000Z" }],',
+        "      pendingInputs: [],",
+        "      pendingInputAttachment: null,",
         "      effectiveControl: null,",
         "      stoppingPreviousAttempt: false,",
         "      loading: false,",
@@ -375,7 +377,7 @@ try {
     ),
     writeFile(
       join(consumerRoot, "ssr.tsx"),
-      'import { renderToStaticMarkup } from "react-dom/server";\nimport { HostEmbeddedSurfaces } from "./presentation";\nconst markup = renderToStaticMarkup(<HostEmbeddedSurfaces />);\nfor (const expected of ["Open host entity", "1 queued prompt", "entity-proof", "What should change?", "Host model"]) { if (!markup.includes(expected)) throw new Error(`SSR output lost populated host surface: ${expected}`); }\nconsole.log(`SSR_OK bytes=${new TextEncoder().encode(markup).byteLength}`);\n',
+      'import { renderToStaticMarkup } from "react-dom/server";\nimport { HostEmbeddedSurfaces } from "./presentation";\nconst markup = renderToStaticMarkup(<HostEmbeddedSurfaces />);\nfor (const expected of ["Open host entity", "Loading inputs…", "entity-proof", "What should change?", "Host model"]) { if (!markup.includes(expected)) throw new Error(`SSR output lost populated host surface: ${expected}`); }\nconsole.log(`SSR_OK bytes=${new TextEncoder().encode(markup).byteLength}`);\n',
     ),
     writeFile(
       join(consumerRoot, "runtime-proof.ts"),


### PR DESCRIPTION
## Summary

- allocate OpenGeni application JSON-RPC code `40101` for connection auth-needed errors instead of colliding with MCP SDK `RequestTimeout = -32001`
- require the intended code plus the exact auth-needed message shape in both runtime and Toolspace classifiers
- preserve legitimate broker OAuth behavior while allowing real MCP request timeouts to reach existing retryable recovery

## Validation

- `bun test packages/runtime/test/runtime.test.ts` — 187 passed
- `bun test apps/api/test/toolspace-surface.test.ts` — 15 passed against the dedicated PostgreSQL fixture
- worker timeout classifier — 2 passed
- worker timeout recovery integration — 1 passed
- stable TypeScript 7.0.2 — runtime, API router, and worker passed
- touched-file oxlint/oxfmt, diff check, and changeset plan passed

Linear: OPE-18
