### PR TITLE
fix(db): avoid durable input backfill position collisions

### DIFF
--- a/packages/db/drizzle/0135_durable_machine_input_batches.sql
+++ b/packages/db/drizzle/0135_durable_machine_input_batches.sql
@@ -163,7 +163,8 @@ gap_ranked AS (
         workspace_id,
         session_id,
         preserve_active,
-        (user_position IS NULL AND turn_first_position IS NULL),
+        user_position,
+        turn_first_position,
         previous_active_position,
         next_active_position
       ORDER BY turn_position, turn_created_at, turn_order_id
@@ -173,7 +174,8 @@ gap_ranked AS (
         workspace_id,
         session_id,
         preserve_active,
-        (user_position IS NULL AND turn_first_position IS NULL),
+        user_position,
+        turn_first_position,
         previous_active_position,
         next_active_position
     ) AS gap_count
@@ -185,33 +187,44 @@ positioned AS (
     CASE
       WHEN NOT preserve_active THEN audit_tail_position + turn_ordinal
       WHEN user_position IS NOT NULL THEN
-        (
-          user_position + coalesce(
+        user_position
+          + (
+            coalesce(
             (
               SELECT min(history.position)
               FROM "session_history_items" history
               WHERE history.workspace_id = gap_ranked.workspace_id
                 AND history.session_id = gap_ranked.session_id
-                AND history.active
                 AND history.position > user_position
             ),
             user_position + 1
           )
-        ) / 2
+            - user_position
+          ) * gap_ordinal / (gap_count + 1)
       WHEN turn_first_position IS NOT NULL THEN
-        (
-          turn_first_position + coalesce(
+        coalesce(
             (
               SELECT max(history.position)
               FROM "session_history_items" history
               WHERE history.workspace_id = gap_ranked.workspace_id
                 AND history.session_id = gap_ranked.session_id
-                AND history.active
                 AND history.position < turn_first_position
             ),
             turn_first_position - 2
           )
-        ) / 2
+          + (
+            turn_first_position
+            - coalesce(
+              (
+                SELECT max(history.position)
+                FROM "session_history_items" history
+                WHERE history.workspace_id = gap_ranked.workspace_id
+                  AND history.session_id = gap_ranked.session_id
+                  AND history.position < turn_first_position
+              ),
+              turn_first_position - 2
+            )
+          ) * gap_ordinal / (gap_count + 1)
       WHEN previous_active_position IS NOT NULL AND next_active_position IS NOT NULL THEN
         previous_active_position
           + (next_active_position - previous_active_position) * gap_ordinal / (gap_count + 1)
@@ -222,6 +235,55 @@ positioned AS (
       ELSE active_tail_position + gap_ordinal
     END AS history_position
   FROM gap_ranked
+),
+existing_gaps AS (
+  SELECT
+    positioned.*,
+    coalesce(
+      (
+        SELECT max(history.position)
+        FROM "session_history_items" history
+        WHERE history.workspace_id = positioned.workspace_id
+          AND history.session_id = positioned.session_id
+          AND history.position < positioned.history_position
+      ),
+      positioned.history_position - 1
+    ) AS existing_gap_left,
+    coalesce(
+      (
+        SELECT min(history.position)
+        FROM "session_history_items" history
+        WHERE history.workspace_id = positioned.workspace_id
+          AND history.session_id = positioned.session_id
+          AND history.position > positioned.history_position
+      ),
+      positioned.history_position + 1
+    ) AS existing_gap_right
+  FROM positioned
+),
+final_positioned AS (
+  SELECT
+    existing_gaps.*,
+    existing_gap_left
+      + (existing_gap_right - existing_gap_left)
+        * row_number() OVER (
+          PARTITION BY
+            workspace_id,
+            session_id,
+            existing_gap_left,
+            existing_gap_right
+          ORDER BY history_position, turn_position, turn_created_at, turn_order_id
+        )
+        / (
+          count(*) OVER (
+            PARTITION BY
+              workspace_id,
+              session_id,
+              existing_gap_left,
+              existing_gap_right
+          ) + 1
+        ) AS final_history_position
+  FROM existing_gaps
 ),
 inserted AS (
   INSERT INTO "session_history_items" (
@@ -242,12 +304,12 @@ inserted AS (
     workspace_id,
     session_id,
     turn_id,
-    history_position,
+    final_history_position,
     item,
     preserve_active,
     NULL,
     coalesce(delivered_at, now())
-  FROM positioned
+  FROM final_positioned
   RETURNING id, workspace_id, session_id, turn_id
 )
 UPDATE "session_system_updates" updates

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -152,7 +152,7 @@ describe("release schema contract", () => {
         (migrations.has("0135_durable_machine_input_batches.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(
-      "f5c90efae4e1d618b534ab43ea07688d227d0c82fdd10aa7aef4a630e417d337",
+      "495f69d6d8cb46e94b632161b4a6721e491a764fb869e511b1c9f1183666b036",
     );
     expect(contract.latestMigration).toBe("0135_durable_machine_input_batches.sql");
     expect(migrations.get("0128_github_installation_authority.sql")).toMatchObject({
@@ -172,7 +172,7 @@ describe("release schema contract", () => {
       deploymentMode: "rolling",
     });
     expect(migrations.get("0135_durable_machine_input_batches.sql")).toMatchObject({
-      sha256: "1af5da88274443738378d543432a000ba0603f74771c45cfa479fc974e3b6e8f",
+      sha256: "c2d642594077a74956fd2eaa64fee8fafcd748ad432d2c9c6f4450019970617c",
       deploymentMode: "maintenance",
     });
     expect(migrations.get("0122_codex_capacity_same_turn.sql")).toMatchObject({


### PR DESCRIPTION
Production-populated migration evidence exposed two delivered batches resolving to the same causal midpoint. Rank every reconstructed batch within its actual existing-history gap so positions remain ordered and unique. The patched migration completed successfully against production before workloads were restored.