### PR TITLE
fix(worker): enforce exact Codex Apps tool policy

### DIFF
--- a/.changeset/exact-codex-app-policy.md
+++ b/.changeset/exact-codex-app-policy.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/core": patch
+"@opengeni/worker-bundle": patch
+---
+
+Route Codex Apps through the durable per-session MCP tool policy so exact
+allowlists cannot be widened by a runtime credential overlay.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -221,7 +221,7 @@ import {
   runCredentialAuthNeededPayloads,
   runCredentialModelNote,
 } from "./run-credentials";
-import { withCodexAppsTool, withFirstPartyTools } from "./goals";
+import { withFirstPartyTools } from "./goals";
 import {
   mergeRigDefaultVariableSetEnvironment,
   resolveWorkspaceAgentInstructions,
@@ -4083,17 +4083,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // whose stored tools predate this). The server registration is then
       // narrowed by the session's exact firstPartyMcpTools selection and
       // authorization. Idempotent: mergeToolRefs dedupes if already present.
-      // Attach codex_apps (the ChatGPT/Codex connectors MCP) when the codex
-      // overlay injected it into runSettings.mcpServers (active subscription +
-      // connector scopes); no-op for every other turn. Its refreshing bearer is
-      // resolved at connect time from the codex ALS (see the withCodex-wrapped
-      // prepareTools call below).
       // Resolve the durable policy at the turn boundary. Workspace-default
-      // sessions may discover newly enabled capability MCPs, while explicit,
-      // inherited-fixed, and legacy sessions remain narrowed to their stored
-      // materialized allow-list. `withCodexAppsTool` below keeps the existing
-      // single Codex lazy router/connector overlay; it is not a second policy
-      // or discovery path.
+      // sessions may discover newly enabled capability MCPs and Codex Apps,
+      // while explicit, inherited-fixed, and legacy sessions remain narrowed
+      // to their stored materialized allow-list.
       const resolvedToolPolicy = resolveSessionToolPolicy({
         ...(session.toolPolicy ? { toolPolicy: session.toolPolicy } : {}),
         sessionTools: session.tools,
@@ -4108,10 +4101,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       defaultNativeToolsAllowed = sessionToolPolicyAllowsDefaultNativeTools(
         resolvedToolPolicy.effectivePolicy,
       );
-      const turnTools = withCodexAppsTool(
-        runSettings,
-        withFirstPartyTools(runSettings, effectivePolicyTools),
-      );
+      const turnTools = withFirstPartyTools(runSettings, effectivePolicyTools);
       // §7.6 connection-credential provider — load (and decrypt) the variable set via the host
       // `sandboxSecrets` provider when bound; unset → today's local decrypt.
       const connectionScope = {

--- a/apps/worker/src/activities/capabilities.ts
+++ b/apps/worker/src/activities/capabilities.ts
@@ -3,15 +3,8 @@ import {
   type Settings,
   withCodexCatalogProvider,
 } from "@opengeni/config";
-import { settingsWithMcpCapabilityServers } from "@opengeni/core";
+import { settingsWithEnabledCapabilityMcpServers } from "@opengeni/core";
 import {
-  CODEX_APPS_MCP_SERVER_ID,
-  CODEX_APPS_MCP_SERVER_NAME,
-  CODEX_APPS_MCP_URL,
-  CODEX_APPS_STARTUP_TIMEOUT_MS,
-} from "@opengeni/codex";
-import {
-  listEnabledMcpCapabilityServers,
   listSessionMcpServerMetadata,
   listSessionMcpServersForRun,
   workspaceCodexSubscriptionActive,
@@ -19,14 +12,7 @@ import {
   type SessionMcpServerForRun,
 } from "@opengeni/db";
 
-export async function settingsWithEnabledCapabilityMcpServers(
-  db: Database,
-  workspaceId: string,
-  settings: Settings,
-): Promise<Settings> {
-  const enabled = await listEnabledMcpCapabilityServers(db, workspaceId);
-  return settingsWithMcpCapabilityServers(settings, enabled);
-}
+export { settingsWithEnabledCapabilityMcpServers };
 
 export async function settingsWithSessionMcpServersForRun(
   db: Database,
@@ -117,52 +103,7 @@ export async function settingsWithCodexCredential(
     return settings; // disabled / not connected / needs_relogin / error -> leave settings unchanged
   }
   const withProvider = withCodexProvider(settings);
-  if (!settings.codexConnectedAppsEnabled) {
-    return withProvider;
-  }
-  // Additive: append the synthetic codex_apps connectors MCP server for ANY
-  // active credential. Connector access is gated SERVER-SIDE per ChatGPT account
-  // (via chatgpt-account-id), NOT by token scopes — confirmed live: a `pro` token
-  // whose only scopes are openid/profile/email/offline_access still lists all 217
-  // connector tools at .../ps/mcp. So we inject unconditionally and let
-  // runtime-discovery decide: an account with no connectors yields an empty
-  // tools/list, and a connect failure best-effort-drops the server without
-  // failing the turn. The bearer is injected dynamically at connect time
-  // (runtime/codexAppsMcpRequestInit).
-  return withCodexAppsMcpServer(withProvider);
-}
-
-/**
- * Pure: append the synthetic codex_apps MCP server, idempotently. Connector
- * access is gated SERVER-SIDE per ChatGPT account (chatgpt-account-id), not by
- * token scopes, so we inject for any active credential and let runtime-discovery
- * resolve the actual tool set (empty list / dropped server when unavailable).
- * No secrets here — the refreshing bearer is injected at connect time from
- * codexRequestStorage (runtime/codexAppsMcpRequestInit). The connectors backend
- * tolerates serial and parallel tool invocation, so no per-server serialization
- * is enforced (the SDK exposes no per-server parallel-tool-calls flag in
- * @openai/agents 0.11.6).
- */
-export function withCodexAppsMcpServer(settings: Settings): Settings {
-  if (settings.mcpServers.some((server) => server.id === CODEX_APPS_MCP_SERVER_ID)) {
-    return settings; // already injected
-  }
-  return {
-    ...settings,
-    mcpServers: [
-      ...settings.mcpServers,
-      {
-        id: CODEX_APPS_MCP_SERVER_ID,
-        name: CODEX_APPS_MCP_SERVER_NAME,
-        url: CODEX_APPS_MCP_URL,
-        timeoutMs: CODEX_APPS_STARTUP_TIMEOUT_MS,
-        // Connector availability is per-credential and must re-discover each
-        // run; never poison a process-global tools-list cache.
-        cacheToolsList: false,
-        // deliberately NO `headers` — the refreshing bearer is dynamic
-      },
-    ],
-  };
+  return withProvider;
 }
 
 /** Pure: append the synthetic codex-subscription provider, idempotently. */

--- a/apps/worker/src/activities/goals.ts
+++ b/apps/worker/src/activities/goals.ts
@@ -170,20 +170,6 @@ export function withFirstPartyTools(settings: Settings, tools: ToolRef[]): ToolR
 }
 
 /**
- * Ensures a turn references the synthetic codex_apps connectors MCP server when
- * the codex overlay injected it (active subscription + connector scopes). A
- * registry entry is inert until a ToolRef references its id, so this wires the
- * server into the run. No-op when the server is not configured (every non-codex
- * turn), and idempotent via mergeToolRefs.
- */
-export function withCodexAppsTool(settings: Settings, tools: ToolRef[]): ToolRef[] {
-  if (!settings.mcpServers.some((server) => server.id === "codex_apps")) {
-    return tools;
-  }
-  return mergeToolRefs(tools, [{ kind: "mcp", id: "codex_apps" }]);
-}
-
-/**
  * Non-throwing variant of the scheduled-run admission check: returns a human
  * readable reason when balance or monthly caps block another agent run.
  */

--- a/apps/worker/test/codex-overlay.test.ts
+++ b/apps/worker/test/codex-overlay.test.ts
@@ -15,10 +15,11 @@ import { buildOpenGeniAgent, compactionThresholdTokens } from "@opengeni/runtime
 import { testSettings } from "@opengeni/testing";
 import type { Database } from "@opengeni/db";
 import {
-  settingsWithCodexCredential,
-  withCodexAppsMcpServer,
-  withCodexProvider,
-} from "../src/activities/capabilities";
+  enabledCapabilityMcpToolRefs,
+  resolveSessionToolPolicy,
+  settingsWithCodexAppsMcpServer,
+} from "@opengeni/core";
+import { settingsWithCodexCredential, withCodexProvider } from "../src/activities/capabilities";
 
 describe("withCodexProvider", () => {
   test("appends one codex-subscription provider with namespaced models", () => {
@@ -127,12 +128,11 @@ describe("withCodexProvider", () => {
 });
 
 describe("withCodexAppsMcpServer", () => {
-  // Connector access is gated SERVER-SIDE per ChatGPT account (chatgpt-account-id),
-  // NOT by token scopes — so injection is unconditional for any active credential
-  // and the actual tool set is discovered at runtime.
+  // Registration is deployment-controlled. Session policy controls visibility,
+  // while credentials independently control whether calls authenticate.
   test("appends exactly one codex_apps entry with the right metadata and NO headers", () => {
-    const settings = testSettings({ mcpServers: [] });
-    const result = withCodexAppsMcpServer(settings);
+    const settings = testSettings({ codexConnectedAppsEnabled: true, mcpServers: [] });
+    const result = settingsWithCodexAppsMcpServer(settings);
     const apps = result.mcpServers.filter((s) => s.id === "codex_apps");
     expect(apps).toHaveLength(1);
     const entry = apps[0]!;
@@ -144,22 +144,83 @@ describe("withCodexAppsMcpServer", () => {
   });
 
   test("is idempotent — a second call does not double-inject", () => {
-    const once = withCodexAppsMcpServer(testSettings({ mcpServers: [] }));
-    const twice = withCodexAppsMcpServer(once);
+    const once = settingsWithCodexAppsMcpServer(
+      testSettings({ codexConnectedAppsEnabled: true, mcpServers: [] }),
+    );
+    const twice = settingsWithCodexAppsMcpServer(once);
     expect(twice).toBe(once); // same reference, no change
     expect(twice.mcpServers.filter((s) => s.id === "codex_apps")).toHaveLength(1);
   });
 
   test("preserves pre-existing mcp servers", () => {
     const settings = testSettings({
+      codexConnectedAppsEnabled: true,
       mcpServers: [
         { id: "opengeni", name: "OpenGeni", url: "http://x/mcp", cacheToolsList: false },
       ],
     });
-    const result = withCodexAppsMcpServer(settings);
+    const result = settingsWithCodexAppsMcpServer(settings);
     const ids = result.mcpServers.map((s) => s.id);
     expect(ids).toContain("opengeni");
     expect(ids).toContain("codex_apps");
+  });
+
+  test("is a no-op when connected apps are disabled", () => {
+    const settings = testSettings({ codexConnectedAppsEnabled: false, mcpServers: [] });
+    expect(settingsWithCodexAppsMcpServer(settings)).toBe(settings);
+  });
+
+  test("uses workspace defaults without widening explicit session policies", () => {
+    const settings = testSettings({
+      codexConnectedAppsEnabled: true,
+      mcpServers: [
+        {
+          id: "opengeni",
+          name: "OpenGeni",
+          url: "http://localhost/mcp",
+          cacheToolsList: false,
+        },
+        {
+          id: "host-tools",
+          name: "Host tools",
+          url: "http://localhost/host-tools",
+          cacheToolsList: false,
+        },
+      ],
+    });
+    const runtimeSettings = settingsWithCodexAppsMcpServer(settings);
+    const defaultRefs = enabledCapabilityMcpToolRefs(settings, runtimeSettings);
+    expect(defaultRefs).toEqual([{ kind: "mcp", id: "codex_apps", optional: true }]);
+
+    const availableMcpServerIds = runtimeSettings.mcpServers.map((server) => server.id);
+    const defaultMcpServerIds = defaultRefs.map((tool) => tool.id);
+    const workspaceDefault = resolveSessionToolPolicy({
+      toolPolicy: { mode: "workspace_default", inheritedFromSessionId: null },
+      sessionTools: defaultRefs,
+      availableMcpServerIds,
+      defaultMcpServerIds,
+    });
+    expect(workspaceDefault.toolRefs).toContainEqual({
+      kind: "mcp",
+      id: "codex_apps",
+      optional: true,
+    });
+
+    const explicit = resolveSessionToolPolicy({
+      toolPolicy: { mode: "explicit", inheritedFromSessionId: null },
+      sessionTools: [{ kind: "mcp", id: "host-tools" }],
+      availableMcpServerIds,
+      defaultMcpServerIds,
+    });
+    expect(explicit.toolRefs.map((tool) => tool.id)).toEqual(["host-tools", "opengeni"]);
+
+    const explicitApps = resolveSessionToolPolicy({
+      toolPolicy: { mode: "explicit", inheritedFromSessionId: null },
+      sessionTools: [{ kind: "mcp", id: "codex_apps" }],
+      availableMcpServerIds,
+      defaultMcpServerIds,
+    });
+    expect(explicitApps.toolRefs.map((tool) => tool.id)).toEqual(["codex_apps", "opengeni"]);
   });
 });
 
@@ -192,7 +253,7 @@ describe("settingsWithCodexCredential", () => {
     expect(result.mcpServers.some((s) => s.id === "codex_apps")).toBe(false);
   });
 
-  test("active credential exposes connected apps only when explicitly enabled", async () => {
+  test("credential resolution does not widen the MCP registry", async () => {
     const settings = testSettings({
       codexSubscriptionEnabled: true,
       codexConnectedAppsEnabled: true,
@@ -208,9 +269,7 @@ describe("settingsWithCodexCredential", () => {
     expect(
       parseModelProvidersJson(result.modelProvidersJson).some((p) => p.id === "codex-subscription"),
     ).toBe(true);
-    // Connector access is account-gated server-side; the explicit deployment
-    // switch controls whether OpenGeni exposes that surface at all.
-    expect(result.mcpServers.some((s) => s.id === "codex_apps")).toBe(true);
+    expect(result.mcpServers.some((s) => s.id === "codex_apps")).toBe(false);
   });
 
   test("inactive credential => nothing new (no codex_apps server)", async () => {

--- a/apps/worker/test/goals.test.ts
+++ b/apps/worker/test/goals.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { testSettings } from "@opengeni/testing";
-import type { ToolRef } from "@opengeni/contracts";
-import { goalContinuationPrompt, withCodexAppsTool } from "../src/activities/goals";
+import { goalContinuationPrompt } from "../src/activities/goals";
 
 describe("goalContinuationPrompt", () => {
   test("continues from durable context instead of restarting turn housekeeping", () => {
@@ -18,34 +16,5 @@ describe("goalContinuationPrompt", () => {
     expect(prompt).toContain(
       "Do not repeat completed session setup, persistent metadata settings, or context checks",
     );
-  });
-});
-
-describe("withCodexAppsTool", () => {
-  const appsServer = {
-    id: "codex_apps",
-    name: "codex_apps",
-    url: "https://chatgpt.com/backend-api/ps/mcp",
-    cacheToolsList: false,
-  };
-
-  test("appends the codex_apps ToolRef when the server is configured", () => {
-    const settings = testSettings({ mcpServers: [appsServer] });
-    const result = withCodexAppsTool(settings, []);
-    expect(result).toContainEqual({ kind: "mcp", id: "codex_apps" });
-  });
-
-  test("is a no-op when the codex_apps server is not configured (every non-codex turn)", () => {
-    const settings = testSettings({ mcpServers: [] });
-    const tools: ToolRef[] = [{ kind: "mcp", id: "opengeni" }];
-    const result = withCodexAppsTool(settings, tools);
-    expect(result).toBe(tools); // same reference, untouched
-  });
-
-  test("is idempotent — does not double-add when already present", () => {
-    const settings = testSettings({ mcpServers: [appsServer] });
-    const once = withCodexAppsTool(settings, []);
-    const twice = withCodexAppsTool(settings, once);
-    expect(twice.filter((t) => t.kind === "mcp" && t.id === "codex_apps")).toHaveLength(1);
   });
 });

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -28,6 +28,12 @@ separately blocked. Follow the activation and rollback sequence in
 
 MCP tool refs are strict by default. A bare `{ "kind": "mcp", "id": "docs" }` must name a server configured for this deployment, and a runtime connect/list failure fails the turn. A client or pack can mark a ref `{ "kind": "mcp", "id": "context7", "optional": true }` to make it portable: if the deployment does not configure that server the ref is skipped during validation, and if the server is configured but unavailable at runtime it is skipped for that turn with a warning.
 
+The deployment-provided `codex_apps` registry follows the same durable policy
+when connected apps are enabled. Workspace-default sessions receive it as an
+optional MCP. Explicit and inherited fixed policies include it only when
+selected. Codex authentication is resolved separately and never widens the
+model-visible tool policy.
+
 ### Credential headers
 
 MCP servers that require request headers (for example an `Authorization` bearer token) are enabled by passing the headers in the enable request:

--- a/docs/mcp-surfaces.md
+++ b/docs/mcp-surfaces.md
@@ -12,7 +12,7 @@ page exists so you pick the right one in one read.
 | **Files MCP** (`/mcp/files`) | Nobody — built in | Dedicated download-materialization surface selected through the `files` server ref | Caller's bearer with `files:read` | An agent needs a short-lived download URL for a ready file |
 | **Capability MCP servers** | Workspace admin (capabilities settings) | Workspace-wide; on for every session while enabled | Admin-supplied headers, encrypted, write-only | A third-party tool (e.g. a SaaS MCP) should be available to *all* sessions in a workspace |
 | **Per-session MCP servers** (`mcpServers` on session create) | The embedding host, per session | One session; static headers rotatable on every user turn; host connection refs resolved per request | Encrypted write-only headers or a non-secret opaque `connectionRef` resolved by the standalone/host broker | An embedding host injects its own tool server or binds an existing provider connection without duplicating it |
-| **Codex Apps MCP** | Automatic for Codex-subscription runs | Per turn, only on the ChatGPT/Codex model path | Workspace's Codex tokens | You don't — it rides along with the Codex subscription provider |
+| **Codex Apps MCP** | Deployment enables the registry; workspace-default or explicit session policy selects it | Workspace-default sessions receive it as an optional MCP; explicit/fixed sessions see it only when selected | Workspace's Codex tokens, resolved independently from visibility | A Codex-backed session should use connected ChatGPT apps without silently widening an exact tool allowlist |
 
 First-party OpenGeni MCP memory tools:
 
@@ -37,6 +37,14 @@ File and document resources are independent from this broad-server selection.
 Attaching a resource still materializes it for the session when
 `firstPartyMcpTools` is `[]` or title-only; selecting the dedicated `files` or
 `docs` MCP server is a separate `tools` decision.
+
+Codex Apps follows that same separation. Enabling
+`OPENGENI_CODEX_CONNECTED_APPS_ENABLED` registers `codex_apps` as a selectable
+runtime MCP; it does not bypass the durable session tool policy. Omitted
+session tools use the workspace default and include it as optional. Explicit,
+inherited-fixed, and legacy policies remain exact. A usable Codex credential is
+still required at call time, but authentication never changes which tools the
+model is allowed to see.
 
 Docs MCP also has a `memory_search`, but it is the curated documents surface, not
 the first-party turn tool. It now reads both `active` and `approved` memory records

--- a/packages/core/src/domain/capabilities.ts
+++ b/packages/core/src/domain/capabilities.ts
@@ -13,6 +13,12 @@ import {
   type McpServerConnectionRef,
 } from "@opengeni/contracts";
 import {
+  CODEX_APPS_MCP_SERVER_ID,
+  CODEX_APPS_MCP_SERVER_NAME,
+  CODEX_APPS_MCP_URL,
+  CODEX_APPS_STARTUP_TIMEOUT_MS,
+} from "@opengeni/codex";
+import {
   decryptVariableSetValue,
   decryptedCapabilityHeaders,
   disableCapabilityInstallation,
@@ -711,7 +717,36 @@ export async function settingsWithEnabledCapabilityMcpServers(
   settings: Settings,
 ): Promise<Settings> {
   const enabled = await listEnabledMcpCapabilityServers(db, workspaceId);
-  return settingsWithMcpCapabilityServers(settings, enabled);
+  return settingsWithCodexAppsMcpServer(settingsWithMcpCapabilityServers(settings, enabled));
+}
+
+/**
+ * Register Codex Apps as an optional runtime MCP when the deployment enables
+ * it. Registration only makes the server selectable; the session tool policy
+ * decides whether the model sees it, and Codex credential resolution
+ * independently decides whether calls can authenticate.
+ */
+export function settingsWithCodexAppsMcpServer(settings: Settings): Settings {
+  if (
+    !settings.codexConnectedAppsEnabled ||
+    settings.mcpServers.some((server) => server.id === CODEX_APPS_MCP_SERVER_ID)
+  ) {
+    return settings;
+  }
+  return {
+    ...settings,
+    mcpServers: [
+      ...settings.mcpServers,
+      {
+        id: CODEX_APPS_MCP_SERVER_ID,
+        name: CODEX_APPS_MCP_SERVER_NAME,
+        url: CODEX_APPS_MCP_URL,
+        timeoutMs: CODEX_APPS_STARTUP_TIMEOUT_MS,
+        // Availability is credential-specific, so discover on every run.
+        cacheToolsList: false,
+      },
+    ],
+  };
 }
 
 export function settingsWithMcpCapabilityServers(


### PR DESCRIPTION
## Summary
- register Codex Apps as a selectable runtime MCP when enabled
- route workspace-default and explicit visibility through the durable session tool policy
- keep credential resolution independent from the model-visible tool allowlist
- remove the post-policy runtime append that widened explicit sessions

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run check:public-hygiene`
- focused worker and core policy tests (25 passing)
- full unit suite reaches one pre-existing macOS BSD tar portability failure (`tar --sort=name` unsupported)