### PR TITLE
fix(release): keep clean queue consumer current

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.16
-appVersion: "0.22.16"
+version: 0.22.17
+appVersion: "0.22.17"

--- a/scripts/test-publish-consumer.ts
+++ b/scripts/test-publish-consumer.ts
@@ -319,6 +319,8 @@ try {
         "    () => ({",
         "      snapshot: null,",
         '      queue: [{ id: "turn-proof", workspaceId: "workspace-proof", sessionId: "session-proof", triggerEventId: "event-proof", temporalWorkflowId: "workflow-proof", status: "queued", source: "user", position: 1, prompt: "Review the queued host request", resources: [], tools: [], model: "host-model", reasoningEffort: "medium", sandboxBackend: "none", sandboxOs: null, metadata: {}, version: 1, executionGeneration: 0, activeAttemptId: null, lineage: {}, initiator: { kind: "service", subjectId: "host:proof" }, initiatorContext: {}, startedAt: null, finishedAt: null, createdAt: "2026-07-23T00:00:00.000Z", updatedAt: "2026-07-23T00:00:00.000Z" }],',
+        "      pendingInputs: [],",
+        "      pendingInputAttachment: null,",
         "      effectiveControl: null,",
         "      stoppingPreviousAttempt: false,",
         "      loading: false,",
@@ -375,7 +377,7 @@ try {
     ),
     writeFile(
       join(consumerRoot, "ssr.tsx"),
-      'import { renderToStaticMarkup } from "react-dom/server";\nimport { HostEmbeddedSurfaces } from "./presentation";\nconst markup = renderToStaticMarkup(<HostEmbeddedSurfaces />);\nfor (const expected of ["Open host entity", "1 queued prompt", "entity-proof", "What should change?", "Host model"]) { if (!markup.includes(expected)) throw new Error(`SSR output lost populated host surface: ${expected}`); }\nconsole.log(`SSR_OK bytes=${new TextEncoder().encode(markup).byteLength}`);\n',
+      'import { renderToStaticMarkup } from "react-dom/server";\nimport { HostEmbeddedSurfaces } from "./presentation";\nconst markup = renderToStaticMarkup(<HostEmbeddedSurfaces />);\nfor (const expected of ["Open host entity", "Loading inputs…", "entity-proof", "What should change?", "Host model"]) { if (!markup.includes(expected)) throw new Error(`SSR output lost populated host surface: ${expected}`); }\nconsole.log(`SSR_OK bytes=${new TextEncoder().encode(markup).byteLength}`);\n',
     ),
     writeFile(
       join(consumerRoot, "runtime-proof.ts"),


### PR DESCRIPTION
## Summary

- populate the current turn-queue hook fields in the release-shaped external consumer
- verify the lazy queue surface SSR fallback instead of asserting content that is not rendered synchronously
- advance the product chart identity to 0.22.17 so a new exact-source candidate cannot collide with older-source artifacts

## Verification

- `bun run build:packages`
- `bun run test:publish-consumer`
- `bun run release:schema-contract`
- `bun test scripts/release-image-workflow-contract.test.ts scripts/release-schema-contract.test.ts`
- `bun run typecheck`
- `bun test` (4,868 passed; 37 macOS local-sandbox tests fail because BSD `realpath` does not support the GNU `-e` flag; reproduced unchanged in the isolated test file)