### PR TITLE
fix(mcp): authorize session controls once

### DIFF
--- a/.changeset/calm-wolves-control-auth.md
+++ b/.changeset/calm-wolves-control-auth.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/core": patch
+---
+
+Authorize first-party MCP Pause, Resume, and Agent Steer commands exactly once at the canonical command boundary instead of repeating the embedding host authorization call before persistence.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -21,6 +21,7 @@ import {
   type Permission,
   type ResourceRef,
   type SessionAuthorizationOperation,
+  type SessionAuthorizationSurface,
   type Session,
   UpdateScheduledTaskRequest,
 } from "@opengeni/contracts";
@@ -1566,6 +1567,7 @@ function registerRigTools(
 function exactAgentCommandContext(
   grant: AccessGrant,
   callerSessionId: string,
+  authorizationSurface?: SessionAuthorizationSurface,
 ): AgentSessionCommandContext {
   const turnId = grant.metadata?.["turnId"];
   const attemptId = grant.metadata?.["attemptId"];
@@ -1587,6 +1589,7 @@ function exactAgentCommandContext(
     callerTurnId: turnId,
     callerAttemptId: attemptId,
     callerExecutionGeneration: executionGeneration,
+    ...(authorizationSurface ? { authorizationSurface } : {}),
   };
 }
 
@@ -1976,16 +1979,10 @@ function registerWorkspaceOrchestrationTools(
         },
       },
       async ({ sessionId, idempotencyKey, reason }) => {
-        const authorization = await authorizeFirstPartySession(
-          deps,
-          grant,
-          sessionId,
-          "session.control",
-        );
         if (callerSessionId !== null) {
           const controlled = await controlAgentSessionWorkstream(
             deps,
-            exactAgentCommandContext(grant, callerSessionId),
+            exactAgentCommandContext(grant, callerSessionId, "first_party_mcp"),
             {
               targetSessionId: sessionId,
               action: "pause",
@@ -1998,7 +1995,7 @@ function registerWorkspaceOrchestrationTools(
             effectiveControl: projectEffectiveControlForRelatedAccess(
               serializeEffectiveSessionControl(controlled.control),
               sessionId,
-              authorization?.relatedSessionAccess ?? "root",
+              controlled.authorization?.relatedSessionAccess ?? "root",
             ),
             interruptionCount: controlled.interruptionCount,
             replay: controlled.replay,
@@ -2011,6 +2008,7 @@ function registerWorkspaceOrchestrationTools(
             workspaceId: grant.workspaceId,
             sessionId,
             subjectId: grant.subjectId,
+            authorizationSurface: "first_party_mcp",
           },
           {
             action: "pause",
@@ -2018,14 +2016,7 @@ function registerWorkspaceOrchestrationTools(
             ...(reason ? { reason } : {}),
           },
         );
-        return json({
-          ...controlled,
-          effectiveControl: projectEffectiveControlForRelatedAccess(
-            controlled.effectiveControl,
-            sessionId,
-            authorization?.relatedSessionAccess ?? "root",
-          ),
-        });
+        return json(controlled);
       },
     );
 
@@ -2041,16 +2032,10 @@ function registerWorkspaceOrchestrationTools(
         },
       },
       async ({ sessionId, idempotencyKey, reason }) => {
-        const authorization = await authorizeFirstPartySession(
-          deps,
-          grant,
-          sessionId,
-          "session.control",
-        );
         if (callerSessionId !== null) {
           const controlled = await controlAgentSessionWorkstream(
             deps,
-            exactAgentCommandContext(grant, callerSessionId),
+            exactAgentCommandContext(grant, callerSessionId, "first_party_mcp"),
             {
               targetSessionId: sessionId,
               action: "resume",
@@ -2063,7 +2048,7 @@ function registerWorkspaceOrchestrationTools(
             effectiveControl: projectEffectiveControlForRelatedAccess(
               serializeEffectiveSessionControl(controlled.control),
               sessionId,
-              authorization?.relatedSessionAccess ?? "root",
+              controlled.authorization?.relatedSessionAccess ?? "root",
             ),
             interruptionCount: controlled.interruptionCount,
             replay: controlled.replay,
@@ -2076,6 +2061,7 @@ function registerWorkspaceOrchestrationTools(
             workspaceId: grant.workspaceId,
             sessionId,
             subjectId: grant.subjectId,
+            authorizationSurface: "first_party_mcp",
           },
           {
             action: "resume",
@@ -2083,14 +2069,7 @@ function registerWorkspaceOrchestrationTools(
             ...(reason ? { reason } : {}),
           },
         );
-        return json({
-          ...controlled,
-          effectiveControl: projectEffectiveControlForRelatedAccess(
-            controlled.effectiveControl,
-            sessionId,
-            authorization?.relatedSessionAccess ?? "root",
-          ),
-        });
+        return json(controlled);
       },
     );
 
@@ -2107,10 +2086,9 @@ function registerWorkspaceOrchestrationTools(
           },
         },
         async ({ sessionId, instruction, idempotencyKey }) => {
-          await authorizeFirstPartySession(deps, grant, sessionId, "session.steer");
           const result = await steerAgentSession(
             deps,
-            exactAgentCommandContext(grant, callerSessionId),
+            exactAgentCommandContext(grant, callerSessionId, "first_party_mcp"),
             { targetSessionId: sessionId, instruction, idempotencyKey },
           );
           return json({

--- a/apps/api/test/session-authorization-routes.test.ts
+++ b/apps/api/test/session-authorization-routes.test.ts
@@ -731,6 +731,139 @@ describe("embedding host session authorization routes", () => {
     ]);
   });
 
+  test("authorizes first-party MCP Pause, Resume, and Agent Steer exactly once", async () => {
+    if (!available) return;
+    const value = await fixture();
+    const started = await initializeSessionStartAtomically(client.db, {
+      accountId: value.grant.accountId,
+      workspaceId: value.grant.workspaceId,
+      sessionId: value.child.id,
+      reasoningEffortFallback: "low",
+      createdEventPayload: {},
+      goal: null,
+    });
+    if (!started.turn) throw new Error("test caller did not create an initial turn");
+    const attemptId = crypto.randomUUID();
+    const claimed = await claimSessionWorkForAttempt(client.db, value.grant.workspaceId, {
+      sessionId: value.child.id,
+      workflowId: `session-${value.child.id}`,
+      workflowRunId: crypto.randomUUID(),
+      attemptId,
+      dispatchId: crypto.randomUUID(),
+      trigger: { kind: "next" },
+    });
+    if (claimed.action !== "claimed") throw new Error(`test caller was not claimed`);
+    const target = await createSession(client.db, {
+      accountId: value.grant.accountId,
+      workspaceId: value.grant.workspaceId,
+      parentSessionId: value.root.id,
+      initialMessage: "control target",
+      resources: [],
+      metadata: {},
+      model: "test-model",
+      sandboxBackend: "modal",
+      createdBy: { kind: "subject", subjectId: value.grant.subjectId, label: "Test owner" },
+      createdByContext: {},
+    });
+    const decisions: Array<{ operation: string; surface: string; sessionId: string }> = [];
+    const port = {
+      authorizeSession: async ({ operation, surface, target: authorizationTarget }) => {
+        decisions.push({
+          operation,
+          surface,
+          sessionId: authorizationTarget.sessionId,
+        });
+        if (surface === "core") {
+          throw new Error("duplicate core authorization");
+        }
+        return { allowed: true, relatedSessionAccess: "root" };
+      },
+      resolveListScope: async () => ({ kind: "all" }),
+    } satisfies SessionAuthorizationPort;
+    const noop = async () => undefined;
+    const mcpDeps = {
+      settings: testSettings(),
+      db: client.db,
+      bus: new MemoryEventBus(),
+      workflowClient: {
+        wakeSessionWorkflow: noop,
+        requestSessionWorkflowWakeDispatch: noop,
+      } as unknown as SessionWorkflowClient,
+      objectStorage: null,
+      githubStateSecret: "test",
+      documentIndexer: { indexDocument: noop },
+      getDocumentServices: () => ({}) as never,
+      sessionAuthorization: port,
+    } as unknown as ApiRouteDeps;
+    const server = buildOpenGeniMcpServer(mcpDeps, {
+      ...value.grant,
+      permissions: ["workspace:read", "sessions:read", "sessions:control"],
+      metadata: {
+        sessionId: value.child.id,
+        turnId: claimed.turn.id,
+        attemptId,
+        executionGeneration: claimed.turn.executionGeneration,
+        firstPartyMcpTools: ["session_pause", "session_resume", "session_steer"],
+      },
+    });
+
+    const paused = await callMcpTool<{ effectiveControl: { state: string } }>(
+      server,
+      "session_pause",
+      {
+        sessionId: target.id,
+        idempotencyKey: crypto.randomUUID(),
+      },
+    );
+    expect(paused.effectiveControl.state).toBe("paused");
+    const resumed = await callMcpTool<{ effectiveControl: { state: string } }>(
+      server,
+      "session_resume",
+      {
+        sessionId: target.id,
+        idempotencyKey: crypto.randomUUID(),
+      },
+    );
+    expect(resumed.effectiveControl.state).toBe("active");
+    const steered = await callMcpTool<{ updateId: string }>(server, "session_steer", {
+      sessionId: target.id,
+      instruction: "Take the newest direction exactly once",
+      idempotencyKey: crypto.randomUUID(),
+    });
+    expect(steered.updateId).toEqual(expect.any(String));
+
+    const operatorServer = buildOpenGeniMcpServer(mcpDeps, {
+      ...value.grant,
+      permissions: ["workspace:read", "sessions:read", "sessions:control"],
+    });
+    const operatorPaused = await callMcpTool<{ effectiveControl: { state: string } }>(
+      operatorServer,
+      "session_pause",
+      {
+        sessionId: target.id,
+        idempotencyKey: crypto.randomUUID(),
+      },
+    );
+    expect(operatorPaused.effectiveControl.state).toBe("paused");
+    const operatorResumed = await callMcpTool<{ effectiveControl: { state: string } }>(
+      operatorServer,
+      "session_resume",
+      {
+        sessionId: target.id,
+        idempotencyKey: crypto.randomUUID(),
+      },
+    );
+    expect(operatorResumed.effectiveControl.state).toBe("active");
+
+    expect(decisions).toEqual([
+      { operation: "session.control", surface: "first_party_mcp", sessionId: target.id },
+      { operation: "session.control", surface: "first_party_mcp", sessionId: target.id },
+      { operation: "session.steer", surface: "first_party_mcp", sessionId: target.id },
+      { operation: "session.control", surface: "first_party_mcp", sessionId: target.id },
+      { operation: "session.control", surface: "first_party_mcp", sessionId: target.id },
+    ]);
+  });
+
   test("reconstructs live agent-attempt authority and rejects the same token after settlement", async () => {
     if (!available || !shared) return;
     const value = await fixture();

--- a/packages/core/src/application/session-commands.ts
+++ b/packages/core/src/application/session-commands.ts
@@ -7,6 +7,7 @@ import type {
   AccessGrant,
   SessionAuthorizationOperation,
   SessionAuthorizationPort,
+  SessionAuthorizationSurface,
   SessionCommandReceipt,
   SessionControlRequest,
   SessionControlResponse,
@@ -55,6 +56,8 @@ export type HumanSessionCommandContext = {
   workspaceId: string;
   sessionId: string;
   subjectId: string;
+  /** See AgentSessionCommandContext.authorizationSurface. */
+  authorizationSurface?: SessionAuthorizationSurface;
 };
 
 export type AgentSessionCommandContext = {
@@ -65,6 +68,13 @@ export type AgentSessionCommandContext = {
   callerTurnId: string;
   callerAttemptId: string;
   callerExecutionGeneration: number;
+  /**
+   * The trusted adapter surface that owns this command's one authorization
+   * decision. Direct core callers omit it and retain the canonical `core`
+   * surface; adapters that delegate the complete command set it explicitly so
+   * they do not authorize once at the edge and then repeat the host call here.
+   */
+  authorizationSurface?: SessionAuthorizationSurface;
 };
 
 type SessionAuthorizationCommandDeps = {
@@ -104,7 +114,7 @@ async function authorizeHumanSessionCommand(
   return await requireSessionAuthorization(deps, humanAccessGrant(context), {
     sessionId: context.sessionId,
     operation,
-    surface: "core",
+    surface: context.authorizationSurface ?? "core",
   });
 }
 
@@ -117,7 +127,7 @@ async function authorizeAgentSessionCommand(
   return await requireSessionAuthorization(deps, agentAccessGrant(context), {
     sessionId: targetSessionId,
     operation,
-    surface: "core",
+    surface: context.authorizationSurface ?? "core",
   });
 }
 
@@ -339,7 +349,12 @@ export async function controlAgentSessionWorkstream(
     reason?: string | null;
   },
 ) {
-  await authorizeAgentSessionCommand(deps, context, input.targetSessionId, "session.control");
+  const authorization = await authorizeAgentSessionCommand(
+    deps,
+    context,
+    input.targetSessionId,
+    "session.control",
+  );
   const result = await withWorkspaceRls(deps.db, context.workspaceId, (scoped) =>
     scoped.transaction((tx) =>
       mutateSessionControlInTransaction(tx as unknown as Database, {
@@ -358,7 +373,7 @@ export async function controlAgentSessionWorkstream(
   ]);
   await publishWorkspaceControlEvent(deps, context.workspaceId, result.workspaceControlEventId);
   await requestControlWakeDispatch(deps, result.wakeCount);
-  return result;
+  return { ...result, authorization };
 }
 
 function receipt(row: SessionCommandReceiptRow): SessionCommandReceipt {


### PR DESCRIPTION
## Summary

- remove the duplicate embedding-host authorization call from first-party MCP Pause, Resume, and Agent Steer
- authorize each command once at the canonical core command boundary while preserving the originating `first_party_mcp` surface
- keep direct/off-HTTP core callers defaulted to the `core` surface
- return the one resolved authorization decision for the existing related-session control projection

## Root cause and scope

The host-session authorization change added an authorization call in the first-party MCP handler and another in the core command invoked by that handler. Every Pause/Resume/Steer therefore reconstructed caller/target authority and invoked the external `SessionAuthorizationPort` twice before any command receipt or control mutation. This is the shared pre-commit stage across the three timed-out production controls.

This PR removes that repeated control-path call. It does not change timeout duration, workspace/session control semantics, idempotency keys, transactional receipts, recursive Pause/Resume behavior, Temporal signaling, or PR #754's separate timeout/auth classifier fix.

## Validation

- real PostgreSQL first-party authorization regression: 1/1
- full real PostgreSQL API session-authorization suite: 13/13
- real PostgreSQL session-control plane: 61/61
- real PostgreSQL event lock-order/concurrency suite: 21/21
- stable TypeScript 7.0.2: `@opengeni/core`, `@opengeni/api-router`
- builds: core, API router
- touched-file Oxlint and Oxfmt: clean
- changeset plan and `git diff --check`: clean
- exact current-main merge-tree compatibility: clean

Linear: OPE-18. Keep the issue open pending independent review, accepted merge/release, and live production acceptance.
