### PR TITLE
fix(worker): settle malformed scheduled workflow replays

### DIFF
--- a/apps/worker/src/activities/scheduled-tasks.ts
+++ b/apps/worker/src/activities/scheduled-tasks.ts
@@ -50,6 +50,12 @@ export function createScheduledTaskActivities(services: () => Promise<ActivitySe
       input: DispatchScheduledTaskRunInput,
     ): Promise<DispatchScheduledTaskRunResult> => {
       const { settings, db, bus, wakeSessionWorkflow } = await services();
+      // Histories created before the manual-initiator workflow patch already
+      // contain this activity command. Reject their incomplete wire input here
+      // so replay consumes the recorded command and the retry loop settles.
+      if (input.triggerType === "manual" && !input.initiator) {
+        return { action: "blocked", reason: "malformed_manual_trigger" };
+      }
       const task = await getScheduledTask(db, input.workspaceId, input.taskId);
       // Deleting a schedule is authoritative. A fire workflow that was already
       // created may still start afterward; completing it as a no-op prevents an

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -257,7 +257,11 @@ export type DispatchScheduledTaskRunResult =
   | { action: "deleted" }
   | {
       action: "blocked";
-      reason: "insufficient_credits" | "monthly_model_cost_limit" | "monthly_agent_run_limit";
+      reason:
+        | "insufficient_credits"
+        | "monthly_model_cost_limit"
+        | "monthly_agent_run_limit"
+        | "malformed_manual_trigger";
     }
   | {
       action: "start" | "signal";

--- a/apps/worker/src/workflows/scheduled-tasks.ts
+++ b/apps/worker/src/workflows/scheduled-tasks.ts
@@ -1,4 +1,4 @@
-import { workflowInfo } from "@temporalio/workflow";
+import { patched, workflowInfo } from "@temporalio/workflow";
 import type { TurnInitiator } from "@opengeni/contracts";
 import { scheduledTaskActivity } from "./activities";
 
@@ -28,7 +28,11 @@ export async function scheduledTaskFireWorkflow(
   // Old malformed manual histories must terminate rather than retrying a usage
   // conflict forever. All current producers are statically required to provide
   // the exact charging identity.
-  if (input.triggerType === "manual" && (!input.agentRunUsageIdempotencyKey || !input.initiator)) {
+  if (
+    patched("scheduled-task-manual-initiator-v1") &&
+    input.triggerType === "manual" &&
+    (!input.agentRunUsageIdempotencyKey || !input.initiator)
+  ) {
     return;
   }
   const base = {

--- a/apps/worker/test/scheduled-task-slack-routing.test.ts
+++ b/apps/worker/test/scheduled-task-slack-routing.test.ts
@@ -283,6 +283,18 @@ describe("scheduled OpenGeni Slack bot routing", () => {
     ).toEqual({ action: "deleted" });
   });
 
+  test("settles a replayed malformed manual trigger before usage or task lookup", async () => {
+    if (!available) return;
+    expect(
+      await activities().dispatchScheduledTaskRun({
+        workspaceId: crypto.randomUUID(),
+        taskId: crypto.randomUUID(),
+        triggerType: "manual",
+        agentRunUsageIdempotencyKey: "historical-missing-initiator",
+      } as never),
+    ).toEqual({ action: "blocked", reason: "malformed_manual_trigger" });
+  });
+
   test("manual dispatch reuses the API charge identity without an idempotency conflict", async () => {
     if (!available) return;
     const workspace = await workspaceFixture();


### PR DESCRIPTION
## Summary
- preserve old scheduled-task workflow command order behind a Temporal patch marker
- settle historical manual triggers with missing initiator identity inside the already-recorded activity
- prevent the old usage-identity retry loop without a replay compatibility failure

## Verification
- focused scheduled-task, activity-lease, and session-state tests (19 pass)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`