### PR TITLE
perf(api): cache immutable workspace capture manifests

### DIFF
--- a/.changeset/faster-capture-manifests.md
+++ b/.changeset/faster-capture-manifests.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Cache validated immutable workspace-capture manifests within strict process-local memory bounds.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -167,12 +167,17 @@ import {
 } from "@opengeni/core";
 import { assertSessionExists, boundedLimit } from "../http/common";
 import { sseSessionStream } from "../http/sse";
-import { serveWorkspaceCapture, serveWorkspaceCaptureFile } from "./workspace-capture";
+import {
+  serveWorkspaceCapture,
+  serveWorkspaceCaptureFile,
+  WorkspaceCaptureManifestCache,
+} from "./workspace-capture";
 
 type SessionRouteDeps = ApiRouteDeps & Pick<ViewerServices, "establishSandboxSession">;
 
 export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   const { settings, db, bus, workflowClient, objectStorage } = deps;
+  const workspaceCaptureManifestCache = new WorkspaceCaptureManifestCache();
   const ptyIdentity = (pty: SandboxOpenPtySessionRow): SandboxPtyProcessIdentity => ({
     leaseId: pty.leaseId,
     sandboxGroupId: pty.sandboxGroupId,
@@ -2129,7 +2134,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       return c.json({ available: false });
     }
     const row = await latestWorkspaceCapture(db, workspaceId, sessionId);
-    return c.json(await serveWorkspaceCapture(row, objectStorage));
+    return c.json(await serveWorkspaceCapture(row, objectStorage, workspaceCaptureManifestCache));
   });
 
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/workspace/capture/file", async (c) => {

--- a/apps/api/src/routes/workspace-capture.ts
+++ b/apps/api/src/routes/workspace-capture.ts
@@ -38,6 +38,73 @@ export type CaptureStoragePort = {
   }) => Promise<{ url: string; expiresAt: Date }>;
 };
 
+type LoadedManifest = {
+  manifest: WorkspaceCaptureManifest;
+  byteLength: number;
+  stats: WorkspaceCaptureStats;
+};
+
+type ManifestCacheEntry = LoadedManifest & {
+  identity: string;
+};
+
+/**
+ * Process-local cache for immutable capture manifests. Capture rows point at a
+ * revision-specific object key, so a successfully validated blob is safe to
+ * reuse as long as the row identity still matches. Both entry count and bytes
+ * are bounded; large signed-manifest responses bypass the cache.
+ */
+export class WorkspaceCaptureManifestCache {
+  readonly #entries = new Map<string, ManifestCacheEntry>();
+  #retainedBytes = 0;
+
+  constructor(
+    readonly maxEntries = 64,
+    readonly maxBytes = 16 * 1024 * 1024,
+  ) {}
+
+  get(row: WorkspaceCaptureRow): LoadedManifest | null {
+    const key = row.manifestKey;
+    if (!key) return null;
+    const entry = this.#entries.get(key);
+    if (!entry || entry.identity !== manifestIdentity(row)) return null;
+    this.#entries.delete(key);
+    this.#entries.set(key, entry);
+    return entry;
+  }
+
+  set(row: WorkspaceCaptureRow, loaded: LoadedManifest): void {
+    const key = row.manifestKey;
+    if (
+      !key ||
+      this.maxEntries <= 0 ||
+      this.maxBytes <= 0 ||
+      loaded.byteLength > CAPTURE_INLINE_MANIFEST_MAX_BYTES ||
+      loaded.byteLength > this.maxBytes
+    ) {
+      return;
+    }
+    const previous = this.#entries.get(key);
+    if (previous) {
+      this.#retainedBytes -= previous.byteLength;
+      this.#entries.delete(key);
+    }
+    this.#entries.set(key, { ...loaded, identity: manifestIdentity(row) });
+    this.#retainedBytes += loaded.byteLength;
+    while (this.#entries.size > this.maxEntries || this.#retainedBytes > this.maxBytes) {
+      const oldestKey = this.#entries.keys().next().value;
+      if (oldestKey === undefined) break;
+      const oldest = this.#entries.get(oldestKey);
+      this.#entries.delete(oldestKey);
+      if (oldest) this.#retainedBytes -= oldest.byteLength;
+    }
+  }
+}
+
+function manifestIdentity(row: WorkspaceCaptureRow): string {
+  return `${row.sessionId}\0${row.turnId}\0${row.revision}\0${row.leaseEpoch}\0${row.capturedAt}`;
+}
+
 function signedUrl(signed: { url: string; expiresAt: Date }): { url: string; expiresAt: string } {
   return { url: signed.url, expiresAt: signed.expiresAt.toISOString() };
 }
@@ -51,12 +118,11 @@ function signedUrl(signed: { url: string; expiresAt: Date }): { url: string; exp
 async function loadManifest(
   row: WorkspaceCaptureRow,
   storage: CaptureStoragePort,
-): Promise<{
-  manifest: WorkspaceCaptureManifest;
-  byteLength: number;
-  stats: WorkspaceCaptureStats;
-} | null> {
+  cache?: WorkspaceCaptureManifestCache,
+): Promise<LoadedManifest | null> {
   if (!row.manifestKey) return null;
+  const cached = cache?.get(row);
+  if (cached) return cached;
   const stats = WorkspaceCaptureStats.safeParse(row.stats);
   if (!stats.success) {
     console.warn(
@@ -114,7 +180,9 @@ async function loadManifest(
     );
     return null;
   }
-  return { manifest, byteLength: blob.bytes.byteLength, stats: servedStats };
+  const loaded = { manifest, byteLength: blob.bytes.byteLength, stats: servedStats };
+  cache?.set(row, loaded);
+  return loaded;
 }
 
 /**
@@ -126,6 +194,7 @@ async function loadManifest(
 export async function serveWorkspaceCapture(
   row: WorkspaceCaptureRow | null,
   storage: CaptureStoragePort,
+  cache?: WorkspaceCaptureManifestCache,
 ): Promise<GetWorkspaceCaptureResponse> {
   if (!row) {
     return { available: false };
@@ -152,7 +221,7 @@ export async function serveWorkspaceCapture(
   // path. Previously that branch signed arbitrary bytes merely because they
   // exceeded the inline cap, allowing a poison/mis-keyed blob to bypass both the
   // schema and row-identity checks.
-  const loaded = await loadManifest(row, storage);
+  const loaded = await loadManifest(row, storage, cache);
   if (!loaded) return { available: false };
   const meta = {
     available: true as const,

--- a/apps/api/test/workspace-capture-routes.test.ts
+++ b/apps/api/test/workspace-capture-routes.test.ts
@@ -10,6 +10,7 @@ import {
   CAPTURE_INLINE_MANIFEST_MAX_BYTES,
   serveWorkspaceCapture,
   serveWorkspaceCaptureFile,
+  WorkspaceCaptureManifestCache,
   type CaptureStoragePort,
 } from "../src/routes/workspace-capture";
 
@@ -181,11 +182,14 @@ function makeRow(overrides: Partial<WorkspaceCaptureRow> = {}): WorkspaceCapture
 // In-memory storage: byte map for reads, a stub signer that records the key.
 function fakeStorage(
   objects: Record<string, Uint8Array>,
-): CaptureStoragePort & { signed: string[] } {
+): CaptureStoragePort & { reads: string[]; signed: string[] } {
+  const reads: string[] = [];
   const signed: string[] = [];
   return {
+    reads,
     signed,
     async getObjectBytes(key) {
+      reads.push(key);
       const bytes = objects[key];
       return bytes ? { bytes } : null;
     },
@@ -306,6 +310,54 @@ describe("serveWorkspaceCapture (manifest response)", () => {
     expect(res.manifestUrl).toBeNull();
     expect(res.manifest?.files[0]?.path).toBe("src/app.ts");
     expect(storage.signed).toEqual([]); // one round-trip; no second blob hop
+  });
+
+  test("validated inline manifests are reused from the bounded revision cache", async () => {
+    const manifest = makeManifest([fileEntry({})]);
+    const storage = fakeStorage({
+      [MANIFEST_KEY]: new TextEncoder().encode(JSON.stringify(manifest)),
+    });
+    const cache = new WorkspaceCaptureManifestCache();
+    const row = makeRow();
+
+    expect((await serveWorkspaceCapture(row, storage, cache)).available).toBe(true);
+    expect((await serveWorkspaceCapture(row, storage, cache)).available).toBe(true);
+    expect(storage.reads).toEqual([MANIFEST_KEY]);
+  });
+
+  test("a changed row identity cannot reuse a cached manifest", async () => {
+    const manifest = makeManifest([fileEntry({})]);
+    const storage = fakeStorage({
+      [MANIFEST_KEY]: new TextEncoder().encode(JSON.stringify(manifest)),
+    });
+    const cache = new WorkspaceCaptureManifestCache();
+
+    expect((await serveWorkspaceCapture(makeRow(), storage, cache)).available).toBe(true);
+    expect(
+      (await serveWorkspaceCapture(makeRow({ leaseEpoch: 6 }), storage, cache)).available,
+    ).toBe(false);
+    expect(storage.reads).toEqual([MANIFEST_KEY, MANIFEST_KEY]);
+  });
+
+  test("the manifest cache evicts least-recently-used entries at its byte bound", async () => {
+    const manifest = makeManifest([fileEntry({})]);
+    const bytes = new TextEncoder().encode(JSON.stringify(manifest));
+    const secondKey = `${MANIFEST_KEY}.second`;
+    const storage = fakeStorage({ [MANIFEST_KEY]: bytes, [secondKey]: bytes });
+    const cache = new WorkspaceCaptureManifestCache(2, bytes.byteLength);
+
+    expect((await serveWorkspaceCapture(makeRow(), storage, cache)).available).toBe(true);
+    expect(
+      (
+        await serveWorkspaceCapture(
+          makeRow({ id: "row-2", manifestKey: secondKey }),
+          storage,
+          cache,
+        )
+      ).available,
+    ).toBe(true);
+    expect((await serveWorkspaceCapture(makeRow(), storage, cache)).available).toBe(true);
+    expect(storage.reads).toEqual([MANIFEST_KEY, secondKey, MANIFEST_KEY]);
   });
 
   test("manifest above the inline cap → signed URL, manifest omitted", async () => {


### PR DESCRIPTION
## Summary

- cache successfully validated inline workspace-capture manifests per API process
- bind cache hits to the full durable capture-row identity
- bound retained data to 64 entries / 16 MiB with LRU eviction
- keep large signed manifests and invalid data out of the cache

## Evidence

- `bun test apps/api/test/workspace-capture-routes.test.ts`
- `bun run --filter @opengeni/api-router typecheck`
- release acceptance reproduced capture API p95 at 203.37 ms and 206.34 ms against a 200 ms bound because every sample fetched and reparsed the same immutable object