### PR TITLE
fix(release): advance occupied product version

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.17
-appVersion: "0.22.17"
+version: 0.22.18
+appVersion: "0.22.18"


### PR DESCRIPTION
## Summary

Advance the Helm application/chart release identity from occupied 0.22.17 to 0.22.18 for the already-merged workspace-capture latency release.

## Evidence

- `helm lint deploy/helm/opengeni`