### PR TITLE
fix(release): prepare sealed product version

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.18
-appVersion: "0.22.18"
+version: 0.22.19
+appVersion: "0.22.19"


### PR DESCRIPTION
Advances the Helm chart/app version to 0.22.19 so the exact reviewed head can be sealed before merge and released through the ordinary production train.