### PR TITLE
perf(api): collapse workspace capture lookup

### DIFF
--- a/.changeset/fast-capture-lookup.md
+++ b/.changeset/fast-capture-lookup.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/db": patch
+---
+
+Resolve session existence and the latest workspace capture in one RLS-scoped query so capture metadata requests avoid loading the full session projection.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -102,6 +102,7 @@ import {
   SessionContextBusyError,
   HumanInputResponseValidationError,
   latestWorkspaceCapture,
+  sessionLatestWorkspaceCapture,
   workspaceCaptureAtRevision,
   type AppendEventInput,
   type SandboxOpenPtySessionRow,
@@ -2125,16 +2126,21 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     const workspaceId = c.req.param("workspaceId") ?? "";
     await requireAccessGrant(c, deps, workspaceId, "files:read");
     const sessionId = c.req.param("sessionId") ?? "";
-    const session = await getSession(db, workspaceId, sessionId);
-    if (!session) {
+    const lookup = await sessionLatestWorkspaceCapture(db, workspaceId, sessionId);
+    if (!lookup.sessionExists) {
       throw new HTTPException(404, { message: "session not found" });
     }
     if (!objectStorage) {
       // No storage configured → no captures can exist. Cold-fallback, not an error.
       return c.json({ available: false });
     }
-    const row = await latestWorkspaceCapture(db, workspaceId, sessionId);
-    return c.json(await serveWorkspaceCapture(row, objectStorage, workspaceCaptureManifestCache));
+    return c.json(
+      await serveWorkspaceCapture(
+        lookup.capture,
+        objectStorage,
+        workspaceCaptureManifestCache,
+      ),
+    );
   });
 
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/workspace/capture/file", async (c) => {

--- a/apps/api/test/workspace-capture-routes.test.ts
+++ b/apps/api/test/workspace-capture-routes.test.ts
@@ -70,6 +70,7 @@ describe("M2 capture-read route discipline (static)", () => {
       for (const needle of [
         "c.req.query",
         "latestWorkspaceCapture",
+        "sessionLatestWorkspaceCapture",
         "workspaceCaptureAtRevision",
         "getSession(",
       ]) {
@@ -84,7 +85,7 @@ describe("M2 capture-read route discipline (static)", () => {
     expect(body).not.toContain("channelAPreamble");
     expect(body).not.toContain("withChannelA");
     // Served from the DB helper + object storage.
-    expect(body).toContain("latestWorkspaceCapture");
+    expect(body).toContain("sessionLatestWorkspaceCapture");
     expect(body).toContain("serveWorkspaceCapture");
   });
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -25347,6 +25347,89 @@ export async function latestWorkspaceCapture(
   });
 }
 
+export type SessionWorkspaceCaptureLookup = {
+  sessionExists: boolean;
+  capture: WorkspaceCaptureRow | null;
+};
+
+/**
+ * Resolve session existence and its newest capture in one RLS-scoped query.
+ *
+ * The capture metadata endpoint only needs existence for its 404 contract. Using
+ * `getSession` there mapped the complete session, MCP metadata, and control
+ * projection before issuing a second transaction for the capture. A lateral
+ * lookup preserves the exact absent-session / absent-capture distinction without
+ * loading unrelated session state or adding another database round trip.
+ */
+export async function sessionLatestWorkspaceCapture(
+  db: Database,
+  workspaceId: string,
+  sessionId: string,
+): Promise<SessionWorkspaceCaptureLookup> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const rows = await scopedDb.execute<{
+      found_session_id: string;
+      capture_id: string | null;
+      capture_session_id: string | null;
+      capture_turn_id: string | null;
+      capture_revision: number | string | null;
+      capture_lease_epoch: number | string | null;
+      capture_state: string | null;
+      capture_manifest_key: string | null;
+      capture_tree_index_key: string | null;
+      capture_blob_keys: unknown;
+      capture_size_bytes: number | string | null;
+      capture_stats: unknown;
+      capture_captured_at: string | Date | null;
+    }>(sql`
+      select
+        sessions.id as found_session_id,
+        capture.id as capture_id,
+        capture.session_id as capture_session_id,
+        capture.turn_id as capture_turn_id,
+        capture.revision as capture_revision,
+        capture.lease_epoch as capture_lease_epoch,
+        capture.state as capture_state,
+        capture.manifest_key as capture_manifest_key,
+        capture.tree_index_key as capture_tree_index_key,
+        capture.blob_keys as capture_blob_keys,
+        capture.size_bytes as capture_size_bytes,
+        capture.stats as capture_stats,
+        capture.captured_at as capture_captured_at
+      from sessions
+      left join lateral (
+        select ${WORKSPACE_CAPTURE_COLUMNS}
+        from workspace_captures
+        where workspace_captures.session_id = sessions.id
+        order by workspace_captures.revision desc
+        limit 1
+      ) capture on true
+      where sessions.workspace_id = ${workspaceId} and sessions.id = ${sessionId}
+      limit 1
+    `);
+    const row = rows[0];
+    if (!row) return { sessionExists: false, capture: null };
+    if (!row.capture_id) return { sessionExists: true, capture: null };
+    return {
+      sessionExists: true,
+      capture: mapWorkspaceCaptureRow({
+        id: row.capture_id,
+        session_id: row.capture_session_id!,
+        turn_id: row.capture_turn_id,
+        revision: row.capture_revision!,
+        lease_epoch: row.capture_lease_epoch!,
+        state: row.capture_state!,
+        manifest_key: row.capture_manifest_key,
+        tree_index_key: row.capture_tree_index_key,
+        blob_keys: row.capture_blob_keys,
+        size_bytes: row.capture_size_bytes,
+        stats: row.capture_stats,
+        captured_at: row.capture_captured_at!,
+      }),
+    };
+  });
+}
+
 /** A specific capture revision for a session (the M2 file route with an explicit
  *  `?revision=`), or null if that revision was never captured / already GC'd. */
 export async function workspaceCaptureAtRevision(

--- a/packages/db/test/workspace-captures.test.ts
+++ b/packages/db/test/workspace-captures.test.ts
@@ -11,6 +11,7 @@ import {
   insertWorkspaceCapture,
   listSessionEvents,
   latestWorkspaceCapture,
+  sessionLatestWorkspaceCapture,
   type Database,
   type DbClient,
 } from "../src/index";
@@ -170,6 +171,22 @@ describe("workspace capture revisions (real PostgreSQL + FORCE RLS)", () => {
       blobKeys: [],
       sizeBytes: 0,
       stats: input.stats,
+    });
+    expect(
+      await sessionLatestWorkspaceCapture(db, workspace.workspaceId, session.id),
+    ).toMatchObject({
+      sessionExists: true,
+      capture: {
+        revision: 0,
+        state: "failed",
+        stats: input.stats,
+      },
+    });
+    expect(
+      await sessionLatestWorkspaceCapture(db, workspace.workspaceId, randomUUID()),
+    ).toEqual({
+      sessionExists: false,
+      capture: null,
     });
     const [count] = await admin<{ count: number }[]>`
       select count(*)::int as count from workspace_captures where session_id = ${session.id}`;


### PR DESCRIPTION
## Summary
- resolve session existence and latest capture in one RLS-scoped query
- avoid loading the complete session projection on capture metadata reads
- preserve absent-session and absent-capture semantics

## Production acceptance evidence
- exact old DB sequence: p95 105.27 ms
- combined lookup: p95 19.77 ms
- API route suite: 28 passed
- real PostgreSQL FORCE RLS suite: passed
- db and API TypeScript checks: passed