### PR TITLE
style: format capture latency fix

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -2135,11 +2135,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       return c.json({ available: false });
     }
     return c.json(
-      await serveWorkspaceCapture(
-        lookup.capture,
-        objectStorage,
-        workspaceCaptureManifestCache,
-      ),
+      await serveWorkspaceCapture(lookup.capture, objectStorage, workspaceCaptureManifestCache),
     );
   });
 

--- a/packages/db/test/workspace-captures.test.ts
+++ b/packages/db/test/workspace-captures.test.ts
@@ -182,9 +182,7 @@ describe("workspace capture revisions (real PostgreSQL + FORCE RLS)", () => {
         stats: input.stats,
       },
     });
-    expect(
-      await sessionLatestWorkspaceCapture(db, workspace.workspaceId, randomUUID()),
-    ).toEqual({
+    expect(await sessionLatestWorkspaceCapture(db, workspace.workspaceId, randomUUID())).toEqual({
       sessionExists: false,
       capture: null,
     });


### PR DESCRIPTION
Fix the two oxfmt findings in the merged capture-latency change. No behavior changes. Local Checking formatting...

All matched files use the correct format.
Finished in 424ms on 1128 files using 20 threads. now passes.