### PR TITLE
fix(release): prepare sealed product version

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.19
-appVersion: "0.22.19"
+version: 0.22.20
+appVersion: "0.22.20"


### PR DESCRIPTION
Advance the Helm chart and app version to 0.22.20 so the merged capture-latency release can be sealed as a new immutable candidate rather than colliding with occupied 0.22.19.