### PR TITLE
perf(api): cache validated capture responses

### DIFF
--- a/.changeset/calm-captures-cache.md
+++ b/.changeset/calm-captures-cache.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Reuse the already-validated inline workspace-capture response for an immutable capture revision instead of repeating full manifest schema validation on every poll.

--- a/apps/api/src/routes/workspace-capture.ts
+++ b/apps/api/src/routes/workspace-capture.ts
@@ -46,6 +46,7 @@ type LoadedManifest = {
 
 type ManifestCacheEntry = LoadedManifest & {
   identity: string;
+  inlineResponse?: Extract<GetWorkspaceCaptureResponse, { available: true }>;
 };
 
 /**
@@ -71,6 +72,29 @@ export class WorkspaceCaptureManifestCache {
     this.#entries.delete(key);
     this.#entries.set(key, entry);
     return entry;
+  }
+
+  getInlineResponse(
+    row: WorkspaceCaptureRow,
+  ): Extract<GetWorkspaceCaptureResponse, { available: true }> | null {
+    const key = row.manifestKey;
+    if (!key) return null;
+    const entry = this.#entries.get(key);
+    if (!entry || entry.identity !== manifestIdentity(row) || !entry.inlineResponse) return null;
+    this.#entries.delete(key);
+    this.#entries.set(key, entry);
+    return entry.inlineResponse;
+  }
+
+  setInlineResponse(
+    row: WorkspaceCaptureRow,
+    response: Extract<GetWorkspaceCaptureResponse, { available: true }>,
+  ): void {
+    const key = row.manifestKey;
+    if (!key) return;
+    const entry = this.#entries.get(key);
+    if (!entry || entry.identity !== manifestIdentity(row)) return;
+    entry.inlineResponse = response;
   }
 
   set(row: WorkspaceCaptureRow, loaded: LoadedManifest): void {
@@ -217,6 +241,8 @@ export async function serveWorkspaceCapture(
     });
   }
   if (row.state !== "available" || !row.manifestKey) return { available: false };
+  const cachedResponse = cache?.getInlineResponse(row);
+  if (cachedResponse) return cachedResponse;
   // Validate every manifest before serving it, including the rare >2MB signed
   // path. Previously that branch signed arbitrary bytes merely because they
   // exceeded the inline cap, allowing a poison/mis-keyed blob to bypass both the
@@ -233,11 +259,16 @@ export async function serveWorkspaceCapture(
     stats: loaded.stats,
   };
   if (loaded.byteLength <= CAPTURE_INLINE_MANIFEST_MAX_BYTES) {
-    return GetWorkspaceCaptureResponse.parse({
+    const response = GetWorkspaceCaptureResponse.parse({
       ...meta,
       manifest: loaded.manifest,
       manifestUrl: null,
     });
+    if (!response.available) {
+      throw new Error("validated inline capture response lost its available discriminator");
+    }
+    cache?.setInlineResponse(row, response);
+    return response;
   }
   const signed = await storage.createGetUrl({
     key: row.manifestKey,

--- a/apps/api/test/workspace-capture-routes.test.ts
+++ b/apps/api/test/workspace-capture-routes.test.ts
@@ -321,8 +321,10 @@ describe("serveWorkspaceCapture (manifest response)", () => {
     const cache = new WorkspaceCaptureManifestCache();
     const row = makeRow();
 
-    expect((await serveWorkspaceCapture(row, storage, cache)).available).toBe(true);
-    expect((await serveWorkspaceCapture(row, storage, cache)).available).toBe(true);
+    const first = await serveWorkspaceCapture(row, storage, cache);
+    const second = await serveWorkspaceCapture(row, storage, cache);
+    expect(first.available).toBe(true);
+    expect(second).toBe(first);
     expect(storage.reads).toEqual([MANIFEST_KEY]);
   });
 


### PR DESCRIPTION
## Summary
- cache the fully validated inline capture response under the existing immutable revision identity
- avoid re-running full manifest schema validation on every capture poll
- retain existing byte/entry bounds and identity invalidation

## Verification
- `bun test apps/api/test/workspace-capture-routes.test.ts` (28 passed)
- `bun run --filter @opengeni/api-router typecheck`
- `git diff --check`

## Production evidence
The exact-main live gate measured capture API p95 at 200.28 ms against the 200 ms SLO after the DB round-trip fix. This removes the remaining repeated CPU work without relaxing that SLO.