### PR TITLE
chore(release): bump chart to 0.22.21

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.20
-appVersion: "0.22.20"
+version: 0.22.21
+appVersion: "0.22.21"


### PR DESCRIPTION
Bump the Helm chart and app version to `0.22.21` for the immutable production release containing the capture hot-path fixes.

The package version plan is `@opengeni/api-router@0.12.10`.