### PR TITLE
fix(web): hide fleet switcher for unboxed sessions

### DIFF
--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -28,7 +28,10 @@ import {
 } from "@/components/rail/rail-context";
 import { CollapsedSessionsButton, SessionList } from "@/components/rail/session-list";
 import { SwitcherBlock } from "@/components/rail/switcher-block";
-import { SessionSandboxSwitcher } from "@/components/session/sandbox-switcher";
+import {
+  SessionSandboxSwitcher,
+  sessionSupportsFleetSwitching,
+} from "@/components/session/sandbox-switcher";
 import { CodexAccountIndicator } from "@/components/session/codex-account-indicator";
 import { WorkspaceNav } from "@/components/rail/workspace-nav";
 import { Button } from "@/components/ui/button";
@@ -436,7 +439,9 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
         }
         leading={hamburger}
         sandboxSlot={
-          <SessionSandboxSwitcher workspaceId={session.workspaceId} sessionId={session.id} />
+          sessionSupportsFleetSwitching(session.sandboxBackend) ? (
+            <SessionSandboxSwitcher workspaceId={session.workspaceId} sessionId={session.id} />
+          ) : null
         }
         // Codex-prefix-gated inside the component: absent for host-credit sessions.
         codexSlot={

--- a/apps/web/src/components/session/sandbox-switcher.test.ts
+++ b/apps/web/src/components/session/sandbox-switcher.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { sessionSupportsFleetSwitching } from "./sandbox-switcher";
+
+describe("sessionSupportsFleetSwitching", () => {
+  test("does not offer post-create fleet swaps for an unboxed session", () => {
+    expect(sessionSupportsFleetSwitching("none")).toBe(false);
+  });
+
+  test("keeps the switcher for sessions with an actual home sandbox", () => {
+    expect(sessionSupportsFleetSwitching("modal")).toBe(true);
+    expect(sessionSupportsFleetSwitching("selfhosted")).toBe(true);
+  });
+});

--- a/apps/web/src/components/session/sandbox-switcher.tsx
+++ b/apps/web/src/components/session/sandbox-switcher.tsx
@@ -8,6 +8,7 @@
 // `fleet.machines` is empty and this falls back to a static "Run on: Cloud
 // sandbox" label with no actionable dropdown.
 import { useMachines, type MachineView } from "@opengeni/react/machines";
+import type { SandboxBackend } from "@opengeni/sdk";
 import { CheckIcon, ChevronDownIcon, Loader2Icon, ServerIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -21,6 +22,10 @@ import {
 import { isMachineComputeSelectable } from "@/lib/machine-selectability";
 
 const CLOUD_SANDBOX_LABEL = "Cloud sandbox";
+
+export function sessionSupportsFleetSwitching(sandboxBackend: SandboxBackend): boolean {
+  return sandboxBackend !== "none";
+}
 
 /** Whether a machine can be a swap target right now (the active one always can,
  *  since selecting it is a harmless no-op; otherwise it must be compute-selectable). */


### PR DESCRIPTION
## Summary
- do not render the in-session fleet switcher when a session was created with `sandboxBackend: none`
- keep the switcher for sessions that have an actual managed or connected-machine home sandbox
- add a focused regression test for the backend eligibility rule

## Why
The machines list can legitimately include workspace machines for an unboxed session, but the swap endpoint rejects that session because it has no home sandbox. Rendering those entries as selectable makes the UI advertise an operation the API cannot perform and creates a fake active “session sandbox.” Machine-targeted creation remains the supported way to start directly on a Connected Machine.

## Verification
- `bun test apps/web/src/components/session/sandbox-switcher.test.ts`
- `bun run --cwd apps/web typecheck`
- `bun run format`
- `bun run lint`
