### PR TITLE
Remove obsolete session tool-path residue

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -2653,12 +2653,6 @@ function optionalEventSequence(raw: string | undefined): number | undefined {
   return Math.floor(sequence);
 }
 
-function hasOwnProperty(value: unknown, key: string): boolean {
-  return Boolean(
-    value && typeof value === "object" && Object.prototype.hasOwnProperty.call(value, key),
-  );
-}
-
 /** Stable, value-free JSON errors for only the create-session boundary. */
 export function sessionCreateErrorResponse(c: Context, error: unknown): Response {
   if (error instanceof SessionSpawnDeniedError) {

--- a/apps/web/src/components/pickers.tsx
+++ b/apps/web/src/components/pickers.tsx
@@ -192,7 +192,8 @@ export function SessionToolPicker(props: {
       mcpServerIds: new Set(props.selection.mcpServerIds),
       firstPartyToolIds: new Set(props.selection.firstPartyToolIds),
     };
-    next.mcpServerIds.has(id) ? next.mcpServerIds.delete(id) : next.mcpServerIds.add(id);
+    if (next.mcpServerIds.has(id)) next.mcpServerIds.delete(id);
+    else next.mcpServerIds.add(id);
     props.onChange(next);
   };
   const toggleFirstParty = (id: FirstPartyMcpToolName) => {
@@ -200,9 +201,8 @@ export function SessionToolPicker(props: {
       mcpServerIds: new Set(props.selection.mcpServerIds),
       firstPartyToolIds: new Set(props.selection.firstPartyToolIds),
     };
-    next.firstPartyToolIds.has(id)
-      ? next.firstPartyToolIds.delete(id)
-      : next.firstPartyToolIds.add(id);
+    if (next.firstPartyToolIds.has(id)) next.firstPartyToolIds.delete(id);
+    else next.firstPartyToolIds.add(id);
     props.onChange(next);
   };
   const setAll = (enabled: boolean) =>

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -106,7 +106,6 @@ import {
   validateFileResources,
   validateGitHubRepositorySelection,
   validateToolRefs,
-  validateToolRefsForSessionPolicy,
   withDefaultEnabledCapabilityMcpTools,
 } from "./resources";
 
@@ -1659,11 +1658,6 @@ export async function acceptSessionUserMessage(
     operation: input.delivery === "steer" ? "session.steer" : "session.append",
     surface: "core",
   });
-  const capabilityRuntimeSettings = await settingsWithEnabledCapabilityMcpServers(
-    db,
-    workspaceId,
-    settings,
-  );
   // Hoisted above requireLimit so the codex-billed predicate can resolve the
   // turn's effective model (a follow-up turn inherits the session's model). A
   // pure read with no side effects.
@@ -1686,10 +1680,6 @@ export async function acceptSessionUserMessage(
     reasoningEffort: effectiveReasoningEffort,
     reasoningSource: input.reasoningEffort == null ? "session" : "explicit",
   });
-  const runtimeSettings = settingsWithSessionMcpServerMetadata(
-    capabilityRuntimeSettings,
-    existingSession.mcpServers,
-  );
   const requestedResources = normalizeResources(input.resources ?? []);
   await requireLimit(deps, {
     accountId: grant.accountId,

--- a/packages/db/src/session-queue-commands.ts
+++ b/packages/db/src/session-queue-commands.ts
@@ -1,12 +1,9 @@
 import {
   metadataWithTurnExecutionPolicyV1,
   mergeResourceRefs,
-  mergeToolRefs,
   turnExecutionPolicyAuditMetadata,
   type ReasoningEffort,
   type ResourceRef,
-  type SessionToolPolicy,
-  type ToolRef,
   type TurnExecutionPolicyV1,
 } from "@opengeni/contracts";
 import { and, asc, eq, inArray, sql } from "drizzle-orm";


### PR DESCRIPTION
Remove unused imports/helpers left by the clean session-tool cutover and replace expression-only toggles with explicit branches.

Verified: lint, 23-project typecheck, and focused policy/queue/picker tests.