### PR TITLE
fix(sandbox): make run_on deadlines truthful

### DIFF
--- a/.changeset/truthful-run-on-deadlines.md
+++ b/.changeset/truthful-run-on-deadlines.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/core": patch
+"@opengeni/runtime": patch
+---
+
+Thread the configured Connected Machine control and exec deadlines through
+`run_on`, and return truthful typed timeout/deadline command receipts without
+replaying ambiguous execution.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -1349,7 +1349,7 @@ function registerFleetTools(
     "run_on",
     {
       description:
-        "Run a ONE-OFF op on a SPECIFIC enrolled selfhosted machine WITHOUT changing this session's active sandbox (a side-channel to another machine). Ops: exec (run a command), read (read a file), write (write a file). `target` = a selfhosted sandboxes_list `id`. To make a machine the active sandbox instead, use sandbox_swap.",
+        "Run a ONE-OFF op on a SPECIFIC enrolled selfhosted machine WITHOUT changing this session's active sandbox (a side-channel to another machine). Ops: exec (run a command), read (read a file), write (write a file). Exec returns exact exitCode plus typed timedOut and the effective deadlineMs; a deadline kill or missing exit proof is never ok:true, and an ambiguous transport loss is not replayed. `target` = a selfhosted sandboxes_list `id`. To make a machine the active sandbox instead, use sandbox_swap.",
       inputSchema: {
         target: z4.string().min(1),
         op: z4.discriminatedUnion("kind", [

--- a/apps/api/test/fleet-tools.test.ts
+++ b/apps/api/test/fleet-tools.test.ts
@@ -401,6 +401,9 @@ describe("M7 fleet service — list / attach / swap / run_on / provision", () =>
     });
     expect(exec.ok).toBe(true);
     expect(exec.stdout?.trim()).toBe("runon-vm");
+    expect(exec.exitCode).toBe(0);
+    expect(exec.timedOut).toBe(false);
+    expect(exec.deadlineMs).toBe(settings.sandboxSelfhostedExecTimeoutMs);
 
     // The active pointer is UNCHANGED (run_on is a side-channel, not a swap).
     const after = (await readActiveSandbox(db, ctx.workspaceId, ctx.sessionId))!;

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -156,6 +156,16 @@ cannot exit and leave invisible same-group work behind.
 An oversized reply is likewise returned as typed `PAYLOAD_TOO_LARGE`; neither
 backpressure nor a reply-size failure changes the machine's heartbeat state.
 
+The agent-facing `run_on` MCP tool is intentionally a one-off side channel to a
+specific enrolled machine and never changes the session's active route. Its
+`exec` receipt reports the exact `exitCode`, typed `timedOut`, and effective
+`deadlineMs`. A process killed at the deadline, or a response with no terminal
+exit proof, is never reported as `ok: true`; a transport loss after dispatch is
+ambiguous and is not replayed. `run_on` uses the deployment's separate
+`OPENGENI_SANDBOX_SELFHOSTED_CONTROL_TIMEOUT_MS` and
+`OPENGENI_SANDBOX_SELFHOSTED_EXEC_TIMEOUT_MS` settings (30 seconds and 120
+seconds by default), while preserving the active sandbox pointer and epoch.
+
 ### Streaming exec (op-stream)
 
 Runners that advertise the `op_stream` capability can serve exec over the

--- a/packages/core/src/sandbox/fleet.ts
+++ b/packages/core/src/sandbox/fleet.ts
@@ -33,6 +33,7 @@ import {
   type BackendUnresolvableCode,
   type ControlRpc,
   type NatsRequestConnection,
+  type SelfhostedRelayConfig,
 } from "@opengeni/runtime/sandbox";
 import { HTTPException } from "hono/http-exception";
 import { relayConfigFromSettings } from "./routing";
@@ -512,10 +513,93 @@ export type RunOnResult = {
   stdout?: string;
   stderr?: string;
   exitCode?: number | null;
+  /** Exec only: whether the machine killed the child at its process deadline. */
+  timedOut?: boolean;
+  /** Exec only: the effective clamped process deadline enforced by the machine. */
+  deadlineMs?: number;
   content?: string;
   bytesWritten?: number;
   reason?: string;
 };
+
+export type RunOnSelfhostedMachine = {
+  workspaceId: string;
+  agentId: string;
+  controlRpc: ControlRpc;
+  relay: SelfhostedRelayConfig;
+  /** Short request/reply deadline for read/write and other control operations. */
+  controlTimeoutMs: number;
+  /** Longer agent-side process deadline for exec. */
+  execTimeoutMs: number;
+};
+
+/**
+ * Execute the one-off machine operation once the workspace/enrollment lookup has
+ * succeeded. Kept separate from {@link runOnSandbox} so the command/deadline
+ * contract is deterministic against an in-memory ControlRpc without weakening
+ * the production ownership lookup or requiring a real machine.
+ */
+export async function executeRunOnSelfhostedMachine(
+  machine: RunOnSelfhostedMachine,
+  target: string,
+  op: RunOnOp,
+): Promise<RunOnResult> {
+  const session = new SelfhostedSession({
+    workspaceId: machine.workspaceId,
+    agentId: machine.agentId,
+    controlRpc: machine.controlRpc,
+    relay: machine.relay,
+    timeoutMs: machine.controlTimeoutMs,
+    execTimeoutMs: machine.execTimeoutMs,
+  });
+
+  try {
+    if (op.kind === "exec") {
+      const deadlineMs = session.effectiveExecDeadlineMs;
+      const res = await session.exec({
+        cmd: op.cmd,
+        ...(op.workdir ? { workdir: op.workdir } : {}),
+      });
+      const timedOut = res.timedOut === true;
+      const hasTerminalExit = res.exitCode !== null;
+      return {
+        target,
+        kind: "exec",
+        // `ok` means the one-off operation reached a terminal response. Preserve
+        // the established non-zero-exit behavior, but never claim success when
+        // the machine killed the child or returned no terminal exit proof.
+        ok: !timedOut && hasTerminalExit,
+        stdout: res.stdout,
+        stderr: res.stderr,
+        exitCode: res.exitCode,
+        timedOut,
+        deadlineMs,
+        ...(timedOut
+          ? { reason: `command exceeded the ${deadlineMs} ms execution deadline` }
+          : !hasTerminalExit
+            ? { reason: "machine returned no terminal exit code" }
+            : {}),
+      };
+    }
+    if (op.kind === "read") {
+      const bytes = await session.readFile({ path: op.path });
+      return { target, kind: "read", ok: true, content: new TextDecoder().decode(bytes) };
+    }
+    const bytesWritten = await session.writeFile({ path: op.path, content: op.content });
+    return { target, kind: "write", ok: true, bytesWritten };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return {
+      target,
+      kind: op.kind,
+      ok: false,
+      reason,
+      // A transport failure is not evidence that the process itself timed out,
+      // so leave `timedOut` absent while still reporting the enforced deadline.
+      ...(op.kind === "exec" ? { deadlineMs: session.effectiveExecDeadlineMs } : {}),
+    };
+  }
+}
 
 /**
  * Run a ONE-OFF op against a SPECIFIC target WITHOUT changing the active pointer
@@ -554,39 +638,18 @@ export async function runOnSandbox(
     return { target, kind: op.kind, ok: false, reason: `sandbox ${target} is not enrolled/active` };
   }
 
-  const session = new SelfhostedSession({
-    workspaceId: ctx.workspaceId,
-    agentId: sandbox.enrollmentId,
-    controlRpc: controlRpc(services.bus),
-    relay: relayConfigFromSettings(services.settings),
-  });
-
-  try {
-    if (op.kind === "exec") {
-      const res = await session.exec({
-        cmd: op.cmd,
-        ...(op.workdir ? { workdir: op.workdir } : {}),
-      });
-      return {
-        target,
-        kind: "exec",
-        ok: true,
-        stdout: res.stdout,
-        stderr: res.stderr,
-        exitCode: res.exitCode,
-      };
-    }
-    if (op.kind === "read") {
-      const bytes = await session.readFile({ path: op.path });
-      return { target, kind: "read", ok: true, content: new TextDecoder().decode(bytes) };
-    }
-    // write
-    const bytesWritten = await session.writeFile({ path: op.path, content: op.content });
-    return { target, kind: "write", ok: true, bytesWritten };
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
-    return { target, kind: op.kind, ok: false, reason };
-  }
+  return executeRunOnSelfhostedMachine(
+    {
+      workspaceId: ctx.workspaceId,
+      agentId: sandbox.enrollmentId,
+      controlRpc: controlRpc(services.bus),
+      relay: relayConfigFromSettings(services.settings),
+      controlTimeoutMs: services.settings.sandboxSelfhostedControlTimeoutMs,
+      execTimeoutMs: services.settings.sandboxSelfhostedExecTimeoutMs,
+    },
+    target,
+    op,
+  );
 }
 
 export type ProvisionResult =

--- a/packages/core/test/run-on-exec.test.ts
+++ b/packages/core/test/run-on-exec.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ControlRequest,
+  ControlResponse,
+  ErrorCode,
+  type ExecResponse,
+} from "@opengeni/agent-proto";
+import { type ControlRpc } from "@opengeni/runtime/sandbox";
+import {
+  executeRunOnSelfhostedMachine,
+  type RunOnOp,
+  type RunOnResult,
+} from "../src/sandbox/fleet";
+
+const encoder = new TextEncoder();
+const TARGET = "33333333-3333-4333-8333-333333333333";
+const WORKSPACE = "11111111-1111-4111-8111-111111111111";
+const AGENT = "22222222-2222-4222-8222-222222222222";
+
+type ExecPlan = {
+  durationMs: number;
+  exitCode: number | null;
+  stdout?: string;
+  stderr?: string;
+  transportLoss?: boolean;
+  sideEffect?: boolean;
+};
+
+/**
+ * A deterministic in-memory Connected Machine runner. Duration is logical, not
+ * wall-clock time: a plan longer than ExecRequest.timeoutMs returns the exact
+ * typed deadline-kill response the Rust runner produces and suppresses the
+ * planned side effect. It also simulates the monolithic transport's output cap
+ * and a post-dispatch transport loss without a real broker or machine.
+ */
+class InMemoryMachineRunner implements ControlRpc {
+  readonly requests: Array<{ req: ControlRequest; wireTimeoutMs: number }> = [];
+  executions = 0;
+  completedSideEffects = 0;
+
+  constructor(
+    private readonly plans: Record<string, ExecPlan>,
+    private readonly outputCapBytes = 1_048_576,
+  ) {}
+
+  async request(
+    _subject: string,
+    req: ControlRequest,
+    opts: { timeoutMs: number },
+  ): Promise<ControlResponse> {
+    this.requests.push({ req, wireTimeoutMs: opts.timeoutMs });
+    const op = req.op;
+    if (op?.$case === "fsRead") {
+      const content = encoder.encode("machine-file");
+      return {
+        requestId: req.requestId,
+        result: {
+          $case: "fsRead",
+          fsRead: { content, totalSize: String(content.length) },
+        },
+      };
+    }
+    if (op?.$case !== "exec") {
+      return {
+        requestId: req.requestId,
+        error: {
+          code: ErrorCode.ERROR_CODE_UNSUPPORTED,
+          message: "test runner supports exec and fsRead only",
+          retryable: false,
+          detail: {},
+        },
+      };
+    }
+
+    this.executions += 1;
+    const command = op.exec.command.join(" ");
+    const plan = this.plans[command];
+    if (!plan) {
+      throw new Error(`missing test plan for ${command}`);
+    }
+    if (plan.transportLoss) {
+      return {
+        requestId: req.requestId,
+        error: {
+          code: ErrorCode.ERROR_CODE_TIMEOUT,
+          message: "machine link was lost after dispatch; execution outcome is unknown",
+          retryable: true,
+          detail: {},
+        },
+      };
+    }
+
+    const stdout = encoder.encode(plan.stdout ?? "");
+    const stderr = encoder.encode(plan.stderr ?? "");
+    const encodedBytes = stdout.length + stderr.length;
+    if (encodedBytes > this.outputCapBytes) {
+      return {
+        requestId: req.requestId,
+        error: {
+          code: ErrorCode.ERROR_CODE_PAYLOAD_TOO_LARGE,
+          message: "reply exceeded the runner output cap",
+          retryable: false,
+          detail: {
+            op: "exec",
+            encoded_bytes: String(encodedBytes),
+            max_payload: String(this.outputCapBytes),
+          },
+        },
+      };
+    }
+
+    if (plan.durationMs > op.exec.timeoutMs) {
+      return this.execResponse(req, {
+        // The generated proto surface represents this as int32, while the live
+        // Rust deadline-kill response is intentionally decoded as null by the
+        // structural session contract. Keep the fake at that public boundary.
+        exitCode: null,
+        stdout,
+        stderr,
+        timedOut: true,
+        durationMs: String(op.exec.timeoutMs),
+      });
+    }
+    if (plan.sideEffect) {
+      this.completedSideEffects += 1;
+    }
+    return this.execResponse(req, {
+      exitCode: plan.exitCode,
+      stdout,
+      stderr,
+      timedOut: false,
+      durationMs: String(plan.durationMs),
+    });
+  }
+
+  private execResponse(
+    req: ControlRequest,
+    result: Omit<ExecResponse, "exitCode"> & { exitCode: number | null },
+  ): ControlResponse {
+    return {
+      requestId: req.requestId,
+      result: {
+        $case: "exec",
+        exec: result as ExecResponse,
+      },
+    };
+  }
+}
+
+async function run(
+  runner: InMemoryMachineRunner,
+  op: RunOnOp,
+  timeouts: { controlTimeoutMs?: number; execTimeoutMs?: number } = {},
+): Promise<RunOnResult> {
+  return executeRunOnSelfhostedMachine(
+    {
+      workspaceId: WORKSPACE,
+      agentId: AGENT,
+      controlRpc: runner,
+      relay: { host: "relay.test", tls: true },
+      controlTimeoutMs: timeouts.controlTimeoutMs ?? 30_000,
+      execTimeoutMs: timeouts.execTimeoutMs ?? 120_000,
+    },
+    TARGET,
+    op,
+  );
+}
+
+describe("run_on Connected Machine exec receipts", () => {
+  test("<deadline exit 0 and nonzero preserve exact terminal status", async () => {
+    const runner = new InMemoryMachineRunner({
+      clean: { durationMs: 119_999, exitCode: 0, stdout: "clean\n" },
+      nonzero: { durationMs: 1, exitCode: 7, stderr: "failed\n" },
+    });
+
+    const clean = await run(runner, { kind: "exec", cmd: "clean" });
+    expect(clean).toMatchObject({
+      target: TARGET,
+      kind: "exec",
+      ok: true,
+      exitCode: 0,
+      timedOut: false,
+      deadlineMs: 120_000,
+      stdout: "clean\n",
+    });
+
+    const nonzero = await run(runner, { kind: "exec", cmd: "nonzero" });
+    expect(nonzero).toMatchObject({
+      kind: "exec",
+      ok: true,
+      exitCode: 7,
+      timedOut: false,
+      deadlineMs: 120_000,
+      stderr: "failed\n",
+    });
+    expect(runner.executions).toBe(2);
+  });
+
+  test("configured 120s exec deadline is distinct from the 30s control deadline", async () => {
+    const runner = new InMemoryMachineRunner({
+      build: { durationMs: 31_000, exitCode: 0, stdout: "built\n" },
+    });
+
+    const exec = await run(runner, { kind: "exec", cmd: "build" });
+    expect(exec.deadlineMs).toBe(120_000);
+    const execRequest = runner.requests[0];
+    expect(execRequest?.req.op?.$case).toBe("exec");
+    if (execRequest?.req.op?.$case !== "exec") throw new Error("expected exec request");
+    expect(execRequest.req.op.exec.timeoutMs).toBe(120_000);
+    expect(execRequest.wireTimeoutMs).toBe(125_000);
+
+    const read = await run(runner, { kind: "read", path: "/tmp/result" });
+    expect(read).toMatchObject({ kind: "read", ok: true, content: "machine-file" });
+    const readRequest = runner.requests[1];
+    expect(readRequest?.req.op?.$case).toBe("fsRead");
+    expect(readRequest?.wireTimeoutMs).toBe(30_000);
+  });
+
+  test(">deadline execution is killed, typed, and never ok:true", async () => {
+    const runner = new InMemoryMachineRunner({
+      delayed: {
+        durationMs: 120_001,
+        exitCode: 0,
+        stdout: "partial\n",
+        sideEffect: true,
+      },
+    });
+
+    const result = await run(runner, { kind: "exec", cmd: "delayed" });
+    expect(result).toMatchObject({
+      kind: "exec",
+      ok: false,
+      exitCode: null,
+      timedOut: true,
+      deadlineMs: 120_000,
+      stdout: "partial\n",
+    });
+    expect(result.stderr).toContain("120-second execution limit");
+    expect(result.reason).toContain("120000 ms execution deadline");
+    expect(runner.executions).toBe(1);
+    expect(runner.completedSideEffects).toBe(0);
+  });
+
+  test("transport loss is failed as ambiguous and the exec is not duplicated", async () => {
+    const runner = new InMemoryMachineRunner({
+      ambiguous: { durationMs: 1, exitCode: 0, transportLoss: true },
+    });
+
+    const result = await run(runner, { kind: "exec", cmd: "ambiguous" });
+    expect(result).toMatchObject({
+      kind: "exec",
+      ok: false,
+      deadlineMs: 120_000,
+    });
+    expect(result.timedOut).toBeUndefined();
+    expect(result.reason).toMatch(/lost after dispatch|outcome is unknown/i);
+    expect(runner.executions).toBe(1);
+    expect(runner.requests).toHaveLength(1);
+  });
+
+  test("a non-timeout null exit is failed instead of reported ok:true", async () => {
+    const runner = new InMemoryMachineRunner({
+      nullExit: { durationMs: 1, exitCode: null, stdout: "orphaned status\n" },
+    });
+
+    const result = await run(runner, { kind: "exec", cmd: "nullExit" });
+    expect(result).toMatchObject({
+      kind: "exec",
+      ok: false,
+      exitCode: null,
+      timedOut: false,
+      deadlineMs: 120_000,
+      reason: "machine returned no terminal exit code",
+    });
+    expect(runner.executions).toBe(1);
+  });
+
+  test("output over the monolithic transport cap fails typed and is not duplicated", async () => {
+    const runner = new InMemoryMachineRunner(
+      {
+        capped: { durationMs: 1, exitCode: 0, stdout: "123456789" },
+      },
+      8,
+    );
+
+    const result = await run(runner, { kind: "exec", cmd: "capped" });
+    expect(result).toMatchObject({ kind: "exec", ok: false, deadlineMs: 120_000 });
+    expect(result.reason).toContain("9 bytes");
+    expect(result.reason).toContain("8-byte");
+    expect(result.reason).toContain("/tmp/out.log");
+    expect(runner.executions).toBe(1);
+    expect(runner.requests).toHaveLength(1);
+  });
+});

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -569,10 +569,11 @@ export class SelfhostedSession {
     }
   }
 
-  /** The clamped exec process deadline (ms): the exec-specific budget when threaded,
-   *  else the control timeout. Shared by `exec()` (the wire deadline) and
-   *  `execCommand()` (the timed-out hint's "N-second limit"), so the two never drift. */
-  private execDeadlineMs(): number {
+  /** The effective clamped exec process deadline (ms): the exec-specific budget
+   *  when threaded, else the control timeout. Public so adapters that project a
+   *  structured command receipt can report the exact deadline the agent enforces
+   *  instead of repeating (and potentially drifting from) this normalization. */
+  get effectiveExecDeadlineMs(): number {
     // exec gets its OWN (much larger) deadline distinct from the short control
     // timeout — a real command routinely outlives 30s. Falls back to `timeoutMs`
     // when no exec deadline is threaded (unchanged for those callers).
@@ -587,7 +588,7 @@ export class SelfhostedSession {
     // Keep the process deadline inside the request/reply deadline. Previously the
     // wire carried timeoutMs=0 (unbounded) while the caller stopped waiting after
     // ~30s, leaving accepted work invisible and able to starve control liveness.
-    const executionTimeoutMs = this.execDeadlineMs();
+    const executionTimeoutMs = this.effectiveExecDeadlineMs;
     const execReq: ExecRequest = {
       // The agent does NOT shell-interpret unless `shell` — Channel-A passes a
       // single shell command string, so run it through the platform shell.
@@ -736,7 +737,7 @@ export class SelfhostedSession {
   async execCommand(args: { cmd: string; workdir?: string; runAs?: string }): Promise<string> {
     const result = await this.exec({ cmd: args.cmd, workdir: args.workdir, runAs: args.runAs });
     if (result.timedOut) {
-      const hint = execDeadlineHint(Math.round(this.execDeadlineMs() / 1000));
+      const hint = execDeadlineHint(Math.round(this.effectiveExecDeadlineMs / 1000));
       return result.output ? `${result.output}\n${hint}` : hint;
     }
     return result.output;


### PR DESCRIPTION
## Summary

- thread the configured Connected Machine control and exec deadlines into the one-off `run_on` side-channel while preserving their separate meanings
- return truthful exec receipts with effective `deadlineMs` and typed `timedOut`; deadline kills and missing terminal exit proof are never `ok: true`, while ambiguous transport loss is invoked once and not replayed
- add a deterministic in-memory runner matrix plus DB-backed pointer/epoch stability coverage, public tool copy, docs, and patch Changesets

## Testing

- [x] `bun run typecheck`
- [ ] `bun test` (full monorepo suite left to natural CI)
- `bun test packages/runtime/test/selfhosted-{capabilities,fault-legibility,op-observer,resilience,session}.test.ts packages/core/test/run-on-exec.test.ts apps/api/test/fleet-tools.test.ts` — 157 pass, 0 fail, 631 assertions against PostgreSQL 16 + pgvector 0.8.1
- stable non-preview `typescript@7.0.2` — runtime, core, and API clean
- `bun run build` in `packages/runtime`, `packages/core`, and `apps/api`
- `bun run lint`; `bun run format:check`; `bun run check:docs-refs`; `git diff --check`
- controlled Modal foreground probe: 31.005382 s, exit 0 (confirms managed exec is not killed at 30 s)

## Notes

- OPE-14 Candidate A only. `run_on` remains a one-off side channel: it does not change the active route/pointer/epoch and does not gain durable-job semantics.
- Existing nonzero-exit behavior is preserved: `ok` means a terminal machine response, while `exitCode` carries command success/failure. Timeout or `exitCode: null` is now `ok: false`.
- Transport loss remains acceptance-ambiguous and is never replayed.
- Candidate B (agent-facing exec handle/wait/status/cancel contract) is intentionally excluded because active PR #478 owns durable waits/background jobs and the change would span a broader tool surface.
