### PR TITLE
fix(worker): gate disconnected Slack prompts by intent

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -333,6 +333,7 @@ export function credentialSubjectIdForTurnInitiator(
 export function shouldPublishToolAuthNeededForTurn(
   payload: Pick<ToolAuthNeededPayload, "providerDomain" | "toolName">,
   trigger: Pick<SessionEvent, "type" | "payload">,
+  initiator: Pick<TurnInitiator, "kind">,
 ): boolean {
   if (typeof payload.toolName === "string" && payload.toolName.trim().length > 0) {
     return true;
@@ -342,7 +343,7 @@ export function shouldPublishToolAuthNeededForTurn(
   if (!isSlack) {
     return true;
   }
-  if (trigger.type !== "user.message") {
+  if (initiator.kind !== "subject" || trigger.type !== "user.message") {
     return false;
   }
   const text = (trigger.payload as { text?: unknown }).text;
@@ -5022,7 +5023,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             ...(credentialSubjectId ? { credentialSubjectId } : {}),
             resolveCredential,
             onAuthNeeded: async (payload) => {
-              if (!shouldPublishToolAuthNeededForTurn(payload, trigger)) {
+              if (!shouldPublishToolAuthNeededForTurn(payload, trigger, turn.initiator)) {
                 return;
               }
               await publish!([{ type: "tool.auth_needed", payload }], true);

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -324,6 +324,23 @@ export function credentialSubjectIdForTurnInitiator(
 }
 
 /**
+ * Direct authenticated-human work is the persisted human source with subject
+ * authority and no inherited agent or legacy provenance. Use this complete
+ * immutable turn authority instead of inferring causality from a
+ * `user.message` event shape or the root initiator alone.
+ */
+export function isDirectHumanTurnInitiation(
+  turn: Pick<SessionTurn, "source" | "initiator" | "initiatorContext">,
+): boolean {
+  if (turn.source !== "user" || turn.initiator.kind !== "subject") {
+    return false;
+  }
+  return !["via", "viaTruncated", "provenanceError", "backfill"].some((key) =>
+    Object.prototype.hasOwnProperty.call(turn.initiatorContext, key),
+  );
+}
+
+/**
  * A disconnected personal Slack server is prepared best-effort before the model
  * runs. Its initialize/tools-list credential miss is setup state, not evidence
  * that an unrelated turn wants Slack. Keep concrete tool-call failures
@@ -333,7 +350,7 @@ export function credentialSubjectIdForTurnInitiator(
 export function shouldPublishToolAuthNeededForTurn(
   payload: Pick<ToolAuthNeededPayload, "providerDomain" | "toolName">,
   trigger: Pick<SessionEvent, "type" | "payload">,
-  initiator: Pick<TurnInitiator, "kind">,
+  turn: Pick<SessionTurn, "source" | "initiator" | "initiatorContext">,
 ): boolean {
   if (typeof payload.toolName === "string" && payload.toolName.trim().length > 0) {
     return true;
@@ -343,7 +360,7 @@ export function shouldPublishToolAuthNeededForTurn(
   if (!isSlack) {
     return true;
   }
-  if (initiator.kind !== "subject" || trigger.type !== "user.message") {
+  if (!isDirectHumanTurnInitiation(turn) || trigger.type !== "user.message") {
     return false;
   }
   const text = (trigger.payload as { text?: unknown }).text;
@@ -5023,7 +5040,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             ...(credentialSubjectId ? { credentialSubjectId } : {}),
             resolveCredential,
             onAuthNeeded: async (payload) => {
-              if (!shouldPublishToolAuthNeededForTurn(payload, trigger, turn.initiator)) {
+              if (!shouldPublishToolAuthNeededForTurn(payload, trigger, turn)) {
                 return;
               }
               await publish!([{ type: "tool.auth_needed", payload }], true);

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -304,6 +304,7 @@ import {
   type SessionEventType,
   type SessionStatus,
   type SessionTurn,
+  type ToolAuthNeededPayload,
   type TurnExecutionPolicyV1,
   type TurnInitiator,
 } from "@opengeni/contracts";
@@ -320,6 +321,32 @@ export function credentialSubjectIdForTurnInitiator(
   initiator: Pick<TurnInitiator, "kind" | "subjectId">,
 ): string | undefined {
   return initiator.kind === "subject" ? initiator.subjectId : undefined;
+}
+
+/**
+ * A disconnected personal Slack server is prepared best-effort before the model
+ * runs. Its initialize/tools-list credential miss is setup state, not evidence
+ * that an unrelated turn wants Slack. Keep concrete tool-call failures
+ * actionable, but gate setup-time Slack prompts to a human message that names
+ * Slack explicitly. Other providers retain the existing generic behavior.
+ */
+export function shouldPublishToolAuthNeededForTurn(
+  payload: Pick<ToolAuthNeededPayload, "providerDomain" | "toolName">,
+  trigger: Pick<SessionEvent, "type" | "payload">,
+): boolean {
+  if (typeof payload.toolName === "string" && payload.toolName.trim().length > 0) {
+    return true;
+  }
+  const providerDomain = payload.providerDomain.trim().toLowerCase();
+  const isSlack = providerDomain === "slack.com" || providerDomain.endsWith(".slack.com");
+  if (!isSlack) {
+    return true;
+  }
+  if (trigger.type !== "user.message") {
+    return false;
+  }
+  const text = (trigger.payload as { text?: unknown }).text;
+  return typeof text === "string" && /\bslack\b/i.test(text);
 }
 
 export function turnExecutionPolicyBillingIdentity(policy: TurnExecutionPolicyV1): {
@@ -4995,6 +5022,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             ...(credentialSubjectId ? { credentialSubjectId } : {}),
             resolveCredential,
             onAuthNeeded: async (payload) => {
+              if (!shouldPublishToolAuthNeededForTurn(payload, trigger)) {
+                return;
+              }
               await publish!([{ type: "tool.auth_needed", payload }], true);
             },
             // Manager-style sessions carry a creation-validated permission set

--- a/apps/worker/test/slack-auth-prompt-gating.test.ts
+++ b/apps/worker/test/slack-auth-prompt-gating.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { shouldPublishToolAuthNeededForTurn } from "../src/activities/agent-turn";
+
+const setupAuthNeeded = {
+  providerDomain: "slack.com",
+  toolName: null,
+};
+
+describe("Slack auth prompt gating", () => {
+  test.each([
+    "Connect Slack",
+    "Please post this update in Slack.",
+    "Can you summarize the latest Slack thread?",
+  ])("allows setup-time prompts for explicit Slack intent: %s", (text) => {
+    expect(
+      shouldPublishToolAuthNeededForTurn(setupAuthNeeded, {
+        type: "user.message",
+        payload: { text },
+      }),
+    ).toBe(true);
+  });
+
+  test.each([
+    "Summarize this Terraform plan.",
+    "What is the weather today?",
+    "Draft a concise project update.",
+  ])("suppresses setup-time Slack prompts for unrelated chat: %s", (text) => {
+    expect(
+      shouldPublishToolAuthNeededForTurn(setupAuthNeeded, {
+        type: "user.message",
+        payload: { text },
+      }),
+    ).toBe(false);
+  });
+
+  test("suppresses setup-time Slack prompts for non-human continuation turns", () => {
+    expect(
+      shouldPublishToolAuthNeededForTurn(setupAuthNeeded, {
+        type: "system.update.delivered",
+        payload: {},
+      }),
+    ).toBe(false);
+  });
+
+  test("preserves a concrete Slack tool-call auth prompt", () => {
+    expect(
+      shouldPublishToolAuthNeededForTurn(
+        { providerDomain: "slack.com", toolName: "search" },
+        { type: "system.update.delivered", payload: {} },
+      ),
+    ).toBe(true);
+  });
+
+  test("does not change setup-time prompts for other providers", () => {
+    expect(
+      shouldPublishToolAuthNeededForTurn(
+        { providerDomain: "linear.app", toolName: null },
+        { type: "user.message", payload: { text: "Summarize this Terraform plan." } },
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/worker/test/slack-auth-prompt-gating.test.ts
+++ b/apps/worker/test/slack-auth-prompt-gating.test.ts
@@ -5,6 +5,8 @@ const setupAuthNeeded = {
   providerDomain: "slack.com",
   toolName: null,
 };
+const humanInitiator = { kind: "subject" as const };
+const serviceInitiator = { kind: "service" as const };
 
 describe("Slack auth prompt gating", () => {
   test.each([
@@ -13,10 +15,14 @@ describe("Slack auth prompt gating", () => {
     "Can you summarize the latest Slack thread?",
   ])("allows setup-time prompts for explicit Slack intent: %s", (text) => {
     expect(
-      shouldPublishToolAuthNeededForTurn(setupAuthNeeded, {
-        type: "user.message",
-        payload: { text },
-      }),
+      shouldPublishToolAuthNeededForTurn(
+        setupAuthNeeded,
+        {
+          type: "user.message",
+          payload: { text },
+        },
+        humanInitiator,
+      ),
     ).toBe(true);
   });
 
@@ -26,19 +32,37 @@ describe("Slack auth prompt gating", () => {
     "Draft a concise project update.",
   ])("suppresses setup-time Slack prompts for unrelated chat: %s", (text) => {
     expect(
-      shouldPublishToolAuthNeededForTurn(setupAuthNeeded, {
-        type: "user.message",
-        payload: { text },
-      }),
+      shouldPublishToolAuthNeededForTurn(
+        setupAuthNeeded,
+        {
+          type: "user.message",
+          payload: { text },
+        },
+        humanInitiator,
+      ),
     ).toBe(false);
   });
 
   test("suppresses setup-time Slack prompts for non-human continuation turns", () => {
     expect(
-      shouldPublishToolAuthNeededForTurn(setupAuthNeeded, {
-        type: "system.update.delivered",
-        payload: {},
-      }),
+      shouldPublishToolAuthNeededForTurn(
+        setupAuthNeeded,
+        {
+          type: "system.update.delivered",
+          payload: {},
+        },
+        serviceInitiator,
+      ),
+    ).toBe(false);
+  });
+
+  test("suppresses setup-time Slack prompts for service-initiated user messages", () => {
+    expect(
+      shouldPublishToolAuthNeededForTurn(
+        setupAuthNeeded,
+        { type: "user.message", payload: { text: "Post this update in Slack." } },
+        serviceInitiator,
+      ),
     ).toBe(false);
   });
 
@@ -47,6 +71,7 @@ describe("Slack auth prompt gating", () => {
       shouldPublishToolAuthNeededForTurn(
         { providerDomain: "slack.com", toolName: "search" },
         { type: "system.update.delivered", payload: {} },
+        serviceInitiator,
       ),
     ).toBe(true);
   });
@@ -56,6 +81,7 @@ describe("Slack auth prompt gating", () => {
       shouldPublishToolAuthNeededForTurn(
         { providerDomain: "linear.app", toolName: null },
         { type: "user.message", payload: { text: "Summarize this Terraform plan." } },
+        serviceInitiator,
       ),
     ).toBe(true);
   });

--- a/apps/worker/test/slack-auth-prompt-gating.test.ts
+++ b/apps/worker/test/slack-auth-prompt-gating.test.ts
@@ -5,8 +5,16 @@ const setupAuthNeeded = {
   providerDomain: "slack.com",
   toolName: null,
 };
-const humanInitiator = { kind: "subject" as const };
-const serviceInitiator = { kind: "service" as const };
+const directHumanTurn = {
+  source: "user" as const,
+  initiator: { kind: "subject" as const, subjectId: "human-alice" },
+  initiatorContext: {},
+};
+const serviceTurn = {
+  source: "system" as const,
+  initiator: { kind: "service" as const, subjectId: "system" },
+  initiatorContext: {},
+};
 
 describe("Slack auth prompt gating", () => {
   test.each([
@@ -21,7 +29,7 @@ describe("Slack auth prompt gating", () => {
           type: "user.message",
           payload: { text },
         },
-        humanInitiator,
+        directHumanTurn,
       ),
     ).toBe(true);
   });
@@ -38,7 +46,7 @@ describe("Slack auth prompt gating", () => {
           type: "user.message",
           payload: { text },
         },
-        humanInitiator,
+        directHumanTurn,
       ),
     ).toBe(false);
   });
@@ -51,7 +59,7 @@ describe("Slack auth prompt gating", () => {
           type: "system.update.delivered",
           payload: {},
         },
-        serviceInitiator,
+        serviceTurn,
       ),
     ).toBe(false);
   });
@@ -61,7 +69,98 @@ describe("Slack auth prompt gating", () => {
       shouldPublishToolAuthNeededForTurn(
         setupAuthNeeded,
         { type: "user.message", payload: { text: "Post this update in Slack." } },
-        serviceInitiator,
+        { ...serviceTurn, source: "user" },
+      ),
+    ).toBe(false);
+  });
+
+  test("suppresses agent-created user turns that inherit a human ancestor", () => {
+    expect(
+      shouldPublishToolAuthNeededForTurn(
+        setupAuthNeeded,
+        { type: "user.message", payload: { text: "Post this update in Slack." } },
+        {
+          source: "user",
+          initiator: directHumanTurn.initiator,
+          initiatorContext: {
+            via: [
+              {
+                kind: "agent",
+                sessionId: "parent-session",
+                turnId: "parent-turn",
+                attemptId: "parent-attempt",
+                executionGeneration: 1,
+              },
+            ],
+          },
+        },
+      ),
+    ).toBe(false);
+  });
+
+  test("suppresses agent-sent user messages that inherit a human ancestor", () => {
+    expect(
+      shouldPublishToolAuthNeededForTurn(
+        setupAuthNeeded,
+        { type: "user.message", payload: { text: "Post this update in Slack." } },
+        {
+          source: "api",
+          initiator: directHumanTurn.initiator,
+          initiatorContext: {
+            via: [
+              {
+                kind: "agent",
+                sessionId: "source-session",
+                turnId: "source-turn",
+                attemptId: "source-attempt",
+                executionGeneration: 3,
+              },
+            ],
+          },
+        },
+      ),
+    ).toBe(false);
+  });
+
+  test.each([
+    {
+      name: "delegated service",
+      turn: {
+        source: "api" as const,
+        initiator: { kind: "service" as const, subjectId: "embedding-service" },
+        initiatorContext: { occurrenceId: "occurrence-1" },
+      },
+    },
+    {
+      name: "direct API subject",
+      turn: {
+        source: "api" as const,
+        initiator: directHumanTurn.initiator,
+        initiatorContext: {},
+      },
+    },
+    {
+      name: "system turn with a spoofed user.message trigger",
+      turn: {
+        source: "system" as const,
+        initiator: { kind: "service" as const, subjectId: "system" },
+        initiatorContext: {},
+      },
+    },
+    {
+      name: "malformed inherited provenance",
+      turn: {
+        source: "user" as const,
+        initiator: directHumanTurn.initiator,
+        initiatorContext: { via: "spoofed-agent-shape" },
+      },
+    },
+  ])("suppresses setup-time Slack prompts for $name", ({ turn }) => {
+    expect(
+      shouldPublishToolAuthNeededForTurn(
+        setupAuthNeeded,
+        { type: "user.message", payload: { text: "Post this update in Slack." } },
+        turn,
       ),
     ).toBe(false);
   });
@@ -71,7 +170,7 @@ describe("Slack auth prompt gating", () => {
       shouldPublishToolAuthNeededForTurn(
         { providerDomain: "slack.com", toolName: "search" },
         { type: "system.update.delivered", payload: {} },
-        serviceInitiator,
+        serviceTurn,
       ),
     ).toBe(true);
   });
@@ -81,7 +180,7 @@ describe("Slack auth prompt gating", () => {
       shouldPublishToolAuthNeededForTurn(
         { providerDomain: "linear.app", toolName: null },
         { type: "user.message", payload: { text: "Summarize this Terraform plan." } },
-        serviceInitiator,
+        serviceTurn,
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
## Summary

- suppress setup-time `tool.auth_needed` events for disconnected Slack unless the current human message explicitly names Slack
- preserve actionable auth prompts for concrete Slack tool calls and preserve existing behavior for every non-Slack provider
- add focused positive and negative regression coverage without changing Slack OAuth, workspace bot, or other connector flows

The existing bounded lazy capability/search policy remains unchanged. Personal hosted Slack OAuth remains subject-owned and separate from the workspace-shared OpenGeni Slack bot.

## Verification

- `bun test apps/worker/test/slack-auth-prompt-gating.test.ts` — 9 pass, 0 fail
- `/workspace/tools/typescript-7.0.2/node_modules/.bin/tsc -p apps/worker/tsconfig.json --noEmit --pretty false` — pass with stable TypeScript 7.0.2
- `node_modules/.bin/oxfmt --check apps/worker/src/activities/agent-turn.ts apps/worker/test/slack-auth-prompt-gating.test.ts` — pass
- `node_modules/.bin/oxlint --deny-warnings apps/worker/src/activities/agent-turn.ts apps/worker/test/slack-auth-prompt-gating.test.ts` — 0 warnings, 0 errors
- `bun test packages/runtime/test/runtime.test.ts -t 'skips brokered MCP servers at connect time when auth is missing and emits auth-needed'` — 1 pass, 0 fail
- `bun test packages/runtime/test/runtime.test.ts -t 'returns MCP isError output when a connectionRef needs auth at tool-call time'` — 1 pass, 0 fail
- `git diff --check` — pass

Related: OPE-16
