### PR TITLE
fix(worker): keep native web search always available

### DIFF
--- a/.changeset/native-web-search-runtime-capability.md
+++ b/.changeset/native-web-search-runtime-capability.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/core": minor
+"@opengeni/worker-bundle": patch
+---
+
+Treat provider-native web search as an always-on runtime capability whenever
+the selected provider supports it. Session MCP selection no longer disables
+native search.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -183,11 +183,7 @@ import {
   type CodexUsageHeaderSnapshot,
 } from "@opengeni/codex";
 import { mergeResourceRefs } from "./common";
-import {
-  enabledCapabilityMcpToolRefs,
-  resolveSessionToolPolicy,
-  sessionToolPolicyAllowsDefaultNativeTools,
-} from "@opengeni/core";
+import { enabledCapabilityMcpToolRefs, resolveSessionToolPolicy } from "@opengeni/core";
 import { maybeCompactContext } from "./context-compaction";
 import { TurnAttemptFencedError } from "./turn-attempt-fenced";
 import {
@@ -1678,18 +1674,16 @@ export function computerToolModeForTurn(
 }
 
 /**
- * Native web search requires two independent grants: the resolved provider
- * must advertise runnable support, and the immutable session/turn policy must
- * still track workspace defaults. The null model is the legacy built-in
- * Responses path, whose deployment flag is its provider capability gate.
- * There is deliberately no cross-provider or sandbox/curl fallback.
+ * Native web search is a runtime capability, not part of the session's MCP
+ * allow-list. Attach it whenever the resolved provider advertises runnable
+ * support. The null model is the legacy built-in Responses path, whose
+ * deployment flag is its provider capability gate. There is deliberately no
+ * cross-provider or sandbox/curl fallback.
  */
 export function hostedWebSearchForTurn(
   resolvedModel: { configured: { hostedWebSearch: boolean } } | null,
   deploymentWebSearchEnabled: boolean,
-  defaultNativeToolsAllowed: boolean,
 ): boolean {
-  if (!defaultNativeToolsAllowed) return false;
   return resolvedModel?.configured.hostedWebSearch ?? deploymentWebSearchEnabled;
 }
 
@@ -2378,10 +2372,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       await current?.flush().catch(() => undefined);
     };
     let preparedTools: Awaited<ReturnType<OpenGeniRuntime["prepareTools"]>> | null = null;
-    // Resolved with the MCP policy at the immutable turn boundary. Provider
-    // capability is checked separately when buildAgent is called; this flag is
-    // only the durable omission/narrowing entitlement.
-    let defaultNativeToolsAllowed = false;
     const toolCancellationFenceRef: {
       current: TurnToolCancellationFence | null;
     } = {
@@ -4096,9 +4086,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         ),
       });
       const effectivePolicyTools = resolvedToolPolicy.toolRefs;
-      defaultNativeToolsAllowed = sessionToolPolicyAllowsDefaultNativeTools(
-        resolvedToolPolicy.effectivePolicy,
-      );
       const turnTools = withFirstPartyTools(runSettings, effectivePolicyTools);
       // §7.6 connection-credential provider — load (and decrypt) the variable set via the host
       // `sandboxSecrets` provider when bound; unset → today's local decrypt.
@@ -5045,11 +5032,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               },
             }
           : {};
-      const hostedWebSearch = hostedWebSearchForTurn(
-        resolvedModel,
-        runSettings.webSearchEnabled,
-        defaultNativeToolsAllowed,
-      );
+      const hostedWebSearch = hostedWebSearchForTurn(resolvedModel, runSettings.webSearchEnabled);
       const agent = runtime.buildAgent(modelRunSettings, turnResources, {
         reasoningEffort: turn.reasoningEffort,
         ...(humanInputResume ? { humanInputResponse: humanInputResume } : {}),
@@ -5109,9 +5092,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // store/compaction follow the provider's compaction mode (registry
         // providers resolve to "client"); encrypted reasoning is only
         // round-tripped on the Responses wire API; hosted web search is attached
-        // only when BOTH the model opts in and this immutable turn still tracks
-        // workspace defaults (an explicit session/turn remains narrowed); the
-        // effective context window drives the compaction threshold.
+        // whenever the provider declares it runnable and is independent of the
+        // session's MCP allow-list; the effective context window drives the
+        // compaction threshold.
         hostedWebSearch,
         ...(resolvedModel
           ? {

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -3052,23 +3052,21 @@ describe("computerToolModeForTurn (explicit computer-use transport derivation)",
   });
 });
 
-describe("hostedWebSearchForTurn (provider support × durable policy)", () => {
+describe("hostedWebSearchForTurn (provider support)", () => {
   const resolved = (hostedWebSearch: boolean) =>
     ({ configured: { hostedWebSearch } }) as Parameters<typeof hostedWebSearchForTurn>[0];
 
-  test("enables a supported provider only for workspace-default turns", () => {
-    expect(hostedWebSearchForTurn(resolved(true), true, true)).toBe(true);
-    expect(hostedWebSearchForTurn(resolved(true), true, false)).toBe(false);
+  test("enables a supported provider without consulting the session MCP policy", () => {
+    expect(hostedWebSearchForTurn(resolved(true), true)).toBe(true);
   });
 
   test("does not invent a fallback for an unsupported resolved provider", () => {
-    expect(hostedWebSearchForTurn(resolved(false), true, true)).toBe(false);
+    expect(hostedWebSearchForTurn(resolved(false), true)).toBe(false);
   });
 
   test("applies the deployment capability gate to the legacy built-in path", () => {
-    expect(hostedWebSearchForTurn(null, true, true)).toBe(true);
-    expect(hostedWebSearchForTurn(null, false, true)).toBe(false);
-    expect(hostedWebSearchForTurn(null, true, false)).toBe(false);
+    expect(hostedWebSearchForTurn(null, true)).toBe(true);
+    expect(hostedWebSearchForTurn(null, false)).toBe(false);
   });
 });
 

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -174,15 +174,14 @@ until OpenGeni has the request, recovery, and billing contracts to use it
 safely. Capability metadata also never authorizes an OpenGeni tool; tool
 discovery and authorization remain independent.
 
-### Native web search follows the durable session tool policy
+### Native web search is a runtime capability
 
-Provider-native `web_search` is part of the workspace-default capability set,
-not an MCP catalog entry. A fresh session whose `tools` field is omitted gets
-native search when its resolved Responses provider declares hosted web search
-runnable. An ordinary child that omits `tools` continues to track a
-workspace-default parent. Explicit and inherited-fixed session policies remain
-narrowed. Tool selection is session-level; follow-up messages cannot replace it
-for only one turn.
+Provider-native `web_search` is not an MCP catalog entry and is not governed by
+the session's MCP allow-list. OpenGeni attaches native search whenever the
+resolved provider declares hosted web search runnable, regardless of whether
+the session uses workspace defaults or an explicit/inherited MCP policy.
+Changing a session's connected or OpenGeni tools therefore cannot silently
+disable web search.
 
 `tool_search` is a different capability: it searches bounded deferred tool
 schemas so the model can discover MCP tools without preloading every schema. It

--- a/packages/core/src/domain/session-tool-policy.ts
+++ b/packages/core/src/domain/session-tool-policy.ts
@@ -159,19 +159,6 @@ export function resolveSessionToolPolicy(input: SessionToolPolicyInput): Resolve
   };
 }
 
-/**
- * Native provider tools that belong to the workspace-default capability set
- * follow the same omission/narrowing fence as deferred MCP tools. A durable
- * workspace-default policy receives them; fixed historical policies and an
- * explicit per-turn replacement do not. Provider support remains a separate
- * runtime gate and must also be true before a native tool is attached.
- */
-export function sessionToolPolicyAllowsDefaultNativeTools(
-  policy: SessionEffectiveToolPolicy,
-): boolean {
-  return policy.mode === "workspace_default" && policy.lazyRouter.state === "required";
-}
-
 /** Current full runtime registry IDs, including configured static servers. */
 export async function workspaceSessionToolPolicyServerIds(
   db: Database,

--- a/packages/core/test/session-tool-policy.test.ts
+++ b/packages/core/test/session-tool-policy.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   resolveSessionToolPolicy,
-  sessionToolPolicyAllowsDefaultNativeTools,
   type SessionToolPolicyInput,
 } from "../src/domain/session-tool-policy";
 import type { ToolRef } from "@opengeni/contracts";
@@ -84,17 +83,6 @@ describe("session tool policy resolution", () => {
       deferredIds: [slackId],
     });
     expect(result.toolRefs.map((tool) => tool.id)).toEqual([slackId, "opengeni"]);
-    expect(sessionToolPolicyAllowsDefaultNativeTools(result.effectivePolicy)).toBe(false);
-  });
-
-  test("fixed historical policies exclude workspace-default native tools", () => {
-    for (const mode of ["explicit", "inherited"] as const) {
-      const result = resolve({
-        toolPolicy: { mode, inheritedFromSessionId: null },
-        sessionTools: [mcp("cap-docs")],
-      });
-      expect(sessionToolPolicyAllowsDefaultNativeTools(result.effectivePolicy)).toBe(false);
-    }
   });
 
   test("drops unavailable optional history without hiding it from policy truth", () => {


### PR DESCRIPTION
## Summary
- remove the obsolete session-policy gate from provider-native web search
- keep provider capability as the sole runtime gate
- remove the old policy helper and update the durable architecture contract

## Verification
- `bun test packages/core/test/session-tool-policy.test.ts apps/worker/test/agent-turn.test.ts`
- `bun run typecheck` in `packages/core` and `apps/worker`
- focused oxlint and oxfmt checks