### PR TITLE
fix(db): support managed Postgres role administrators

### DIFF
--- a/.changeset/managed-postgres-role-administration.md
+++ b/.changeset/managed-postgres-role-administration.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/db": patch
+---
+
+Allow PostgreSQL 16+ managed-database role creators to normalize an application
+role when its only relationship is the server-generated, non-inheriting,
+non-settable creator administration edge.

--- a/packages/db/src/provision-roles.ts
+++ b/packages/db/src/provision-roles.ts
@@ -262,6 +262,9 @@ async function assertAppRoleSafeToNormalize(sql: postgres.Sql, role: string): Pr
     return;
   }
 
+  // PostgreSQL 16 added per-grant INHERIT and SET options. Reading through
+  // to_jsonb keeps this inspection compatible with PostgreSQL 14/15; missing
+  // options default to true so every legacy membership remains unsafe.
   const memberships = await sql<
     {
       relationship: string;
@@ -278,8 +281,14 @@ async function assertAppRoleSafeToNormalize(sql: postgres.Sql, role: string): Pr
       parent.rolname::text as parent_role,
       member.rolname::text as member_role,
       membership.admin_option,
-      membership.inherit_option,
-      membership.set_option,
+      coalesce(
+        (to_jsonb(membership) ->> 'inherit_option')::boolean,
+        true
+      ) as inherit_option,
+      coalesce(
+        (to_jsonb(membership) ->> 'set_option')::boolean,
+        true
+      ) as set_option,
       current_user::text as session_role
     from pg_auth_members membership
     join pg_roles member on member.oid = membership.member
@@ -291,8 +300,14 @@ async function assertAppRoleSafeToNormalize(sql: postgres.Sql, role: string): Pr
       parent.rolname::text as parent_role,
       member.rolname::text as member_role,
       membership.admin_option,
-      membership.inherit_option,
-      membership.set_option,
+      coalesce(
+        (to_jsonb(membership) ->> 'inherit_option')::boolean,
+        true
+      ) as inherit_option,
+      coalesce(
+        (to_jsonb(membership) ->> 'set_option')::boolean,
+        true
+      ) as set_option,
       current_user::text as session_role
     from pg_auth_members membership
     join pg_roles member on member.oid = membership.member

--- a/packages/db/src/provision-roles.ts
+++ b/packages/db/src/provision-roles.ts
@@ -181,12 +181,60 @@ async function ensureRestrictedAppLoginRole(
   role: string,
   password: string,
 ): Promise<void> {
+  const existing = await sql<
+    {
+      superuser: boolean;
+      bypass_rls: boolean;
+      create_role: boolean;
+      create_database: boolean;
+      replication: boolean;
+      session_superuser: boolean;
+    }[]
+  >`
+    select
+      target.rolsuper as superuser,
+      target.rolbypassrls as bypass_rls,
+      target.rolcreaterole as create_role,
+      target.rolcreatedb as create_database,
+      target.rolreplication as replication,
+      actor.rolsuper as session_superuser
+    from pg_roles target
+    cross join pg_roles actor
+    where target.rolname = ${role}
+      and actor.rolname = current_user
+  `;
+  const state = existing[0];
+  if (
+    state &&
+    !state.session_superuser &&
+    (state.superuser ||
+      state.bypass_rls ||
+      state.create_role ||
+      state.create_database ||
+      state.replication)
+  ) {
+    throw new Error(
+      `Refusing to normalize app role ${role}: a non-superuser role administrator cannot remove existing privileged attributes`,
+    );
+  }
+
   await sql.unsafe(`
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = ${literal(role)}) THEN
     EXECUTE format(
       'CREATE ROLE %I WITH LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEROLE NOCREATEDB NOREPLICATION NOINHERIT PASSWORD %L',
+      ${literal(role)},
+      ${literal(password)}
+    );
+  ELSIF NOT (SELECT rolsuper FROM pg_roles WHERE rolname = current_user) THEN
+    -- PostgreSQL 16+ gives a non-superuser CREATEROLE actor an ADMIN-only,
+    -- non-inheriting, non-settable edge to each role it creates. That actor may
+    -- administer ordinary fields, but only a superuser may mention SUPERUSER
+    -- or REPLICATION attributes in ALTER ROLE, even when setting them false.
+    -- The query above already proved every privileged attribute is false.
+    EXECUTE format(
+      'ALTER ROLE %I WITH LOGIN NOINHERIT PASSWORD %L',
       ${literal(role)},
       ${literal(password)}
     );
@@ -214,23 +262,57 @@ async function assertAppRoleSafeToNormalize(sql: postgres.Sql, role: string): Pr
     return;
   }
 
-  const memberships = await sql<{ relationship: string }[]>`
-    select ('inherits:' || parent.rolname)::text as relationship
+  const memberships = await sql<
+    {
+      relationship: string;
+      parent_role: string;
+      member_role: string;
+      admin_option: boolean;
+      inherit_option: boolean;
+      set_option: boolean;
+      session_role: string;
+    }[]
+  >`
+    select
+      ('inherits:' || parent.rolname)::text as relationship,
+      parent.rolname::text as parent_role,
+      member.rolname::text as member_role,
+      membership.admin_option,
+      membership.inherit_option,
+      membership.set_option,
+      current_user::text as session_role
     from pg_auth_members membership
     join pg_roles member on member.oid = membership.member
     join pg_roles parent on parent.oid = membership.roleid
     where member.rolname = ${role}
     union all
-    select ('member:' || member.rolname)::text as relationship
+    select
+      ('member:' || member.rolname)::text as relationship,
+      parent.rolname::text as parent_role,
+      member.rolname::text as member_role,
+      membership.admin_option,
+      membership.inherit_option,
+      membership.set_option,
+      current_user::text as session_role
     from pg_auth_members membership
     join pg_roles member on member.oid = membership.member
     join pg_roles parent on parent.oid = membership.roleid
     where parent.rolname = ${role}
     order by relationship
   `;
-  if (memberships.length > 0) {
+  const unsafeMemberships = memberships.filter(
+    (membership) =>
+      !(
+        membership.parent_role === role &&
+        membership.member_role === membership.session_role &&
+        membership.admin_option &&
+        !membership.inherit_option &&
+        !membership.set_option
+      ),
+  );
+  if (unsafeMemberships.length > 0) {
     throw new Error(
-      `Refusing to normalize app role ${role}: remove role relationships first (${memberships
+      `Refusing to normalize app role ${role}: remove role relationships first (${unsafeMemberships
         .map((row) => row.relationship)
         .join(", ")})`,
     );

--- a/packages/db/test/provision-roles-managed-admin.test.ts
+++ b/packages/db/test/provision-roles-managed-admin.test.ts
@@ -11,7 +11,7 @@ const ADMIN_PASSWORD = "adminpw";
 const DATABASE = "managed_role_test";
 const APP_ROLE = "opengeni_app";
 const APP_PASSWORD = "apppw";
-const IMAGE = "pgvector/pgvector:pg17";
+const IMAGE = process.env.OPENGENI_MANAGED_ROLE_TEST_IMAGE ?? "pgvector/pgvector:pg17";
 const SUPERUSER_URL = `postgres://postgres:${SUPERUSER_PASSWORD}@127.0.0.1:${PORT}/postgres`;
 const ADMIN_URL = `postgres://${ADMIN_ROLE}:${ADMIN_PASSWORD}@127.0.0.1:${PORT}/${DATABASE}`;
 const APP_URL = `postgres://${APP_ROLE}:${APP_PASSWORD}@127.0.0.1:${PORT}/${DATABASE}`;
@@ -117,6 +117,9 @@ describe("managed Postgres role provisioning", () => {
 
     const control = postgres(SUPERUSER_URL, { max: 1 });
     try {
+      const version = await control<{ server_version_num: number }[]>`
+        select current_setting('server_version_num')::integer as server_version_num
+      `;
       const creatorEdges = await control<
         {
           member_role: string;
@@ -128,21 +131,31 @@ describe("managed Postgres role provisioning", () => {
         select
           member.rolname::text as member_role,
           membership.admin_option,
-          membership.inherit_option,
-          membership.set_option
+          coalesce(
+            (to_jsonb(membership) ->> 'inherit_option')::boolean,
+            true
+          ) as inherit_option,
+          coalesce(
+            (to_jsonb(membership) ->> 'set_option')::boolean,
+            true
+          ) as set_option
         from pg_auth_members membership
         join pg_roles member on member.oid = membership.member
         join pg_roles parent on parent.oid = membership.roleid
         where parent.rolname = ${APP_ROLE}
       `;
-      expect([...creatorEdges]).toEqual([
-        {
-          member_role: ADMIN_ROLE,
-          admin_option: true,
-          inherit_option: false,
-          set_option: false,
-        },
-      ]);
+      if ((version[0]?.server_version_num ?? 0) >= 160_000) {
+        expect([...creatorEdges]).toEqual([
+          {
+            member_role: ADMIN_ROLE,
+            admin_option: true,
+            inherit_option: false,
+            set_option: false,
+          },
+        ]);
+      } else {
+        expect([...creatorEdges]).toEqual([]);
+      }
 
       await control.unsafe(`create role "unexpected_app_member"`);
       await control.unsafe(`grant "${APP_ROLE}" to "unexpected_app_member"`);

--- a/packages/db/test/provision-roles-managed-admin.test.ts
+++ b/packages/db/test/provision-roles-managed-admin.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import postgres from "postgres";
+import { provisionRoles } from "../src/provision-roles";
+
+const PORT = 61445;
+const CONTAINER = `ogverify-pg-managed-role-${PORT}`;
+const SUPERUSER_PASSWORD = "superpw";
+const ADMIN_ROLE = "managed_admin";
+const ADMIN_PASSWORD = "adminpw";
+const DATABASE = "managed_role_test";
+const APP_ROLE = "opengeni_app";
+const APP_PASSWORD = "apppw";
+const IMAGE = "pgvector/pgvector:pg17";
+const SUPERUSER_URL = `postgres://postgres:${SUPERUSER_PASSWORD}@127.0.0.1:${PORT}/postgres`;
+const ADMIN_URL = `postgres://${ADMIN_ROLE}:${ADMIN_PASSWORD}@127.0.0.1:${PORT}/${DATABASE}`;
+const APP_URL = `postgres://${APP_ROLE}:${APP_PASSWORD}@127.0.0.1:${PORT}/${DATABASE}`;
+
+function docker(args: string[]): string {
+  return execFileSync("docker", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function removeContainer(): void {
+  try {
+    docker(["rm", "-f", "-v", CONTAINER]);
+  } catch {
+    // already gone
+  }
+}
+
+async function waitForReady(): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  while (true) {
+    try {
+      const probe = postgres(SUPERUSER_URL, { max: 1, connect_timeout: 2 });
+      try {
+        await probe`select 1`;
+        return;
+      } finally {
+        await probe.end();
+      }
+    } catch (error) {
+      if (Date.now() > deadline) {
+        throw new Error(`postgres did not become ready in time: ${String(error)}`, {
+          cause: error,
+        });
+      }
+      await Bun.sleep(500);
+    }
+  }
+}
+
+let available = true;
+let dockerStarted = false;
+
+beforeAll(async () => {
+  try {
+    removeContainer();
+    docker([
+      "run",
+      "--rm",
+      "-d",
+      "-e",
+      `POSTGRES_PASSWORD=${SUPERUSER_PASSWORD}`,
+      "-p",
+      `${PORT}:5432`,
+      "--name",
+      CONTAINER,
+      IMAGE,
+    ]);
+    dockerStarted = true;
+  } catch (error) {
+    available = false;
+    console.warn(`[managed-role] docker unavailable, skipping: ${String(error)}`);
+    return;
+  }
+
+  await waitForReady();
+  const control = postgres(SUPERUSER_URL, { max: 1 });
+  try {
+    await control.unsafe(
+      `create role "${ADMIN_ROLE}" with login createrole password '${ADMIN_PASSWORD}'`,
+    );
+    await control.unsafe(`create database "${DATABASE}" owner "${ADMIN_ROLE}"`);
+  } finally {
+    await control.end();
+  }
+}, 90_000);
+
+afterAll(() => {
+  if (dockerStarted) {
+    removeContainer();
+  }
+});
+
+describe("managed Postgres role provisioning", () => {
+  test("accepts only the implicit PostgreSQL 16+ creator administration edge", async () => {
+    if (!available) return;
+
+    const options = {
+      targetSchema: "opengeni",
+      rlsStrategy: "force" as const,
+      appRole: APP_ROLE,
+      appPassword: APP_PASSWORD,
+    };
+
+    await provisionRoles(ADMIN_URL, options);
+    await provisionRoles(ADMIN_URL, options);
+
+    const app = postgres(APP_URL, { max: 1 });
+    try {
+      const identity = await app<{ current_user: string }[]>`select current_user::text`;
+      expect(identity[0]?.current_user).toBe(APP_ROLE);
+    } finally {
+      await app.end();
+    }
+
+    const control = postgres(SUPERUSER_URL, { max: 1 });
+    try {
+      const creatorEdges = await control<
+        {
+          member_role: string;
+          admin_option: boolean;
+          inherit_option: boolean;
+          set_option: boolean;
+        }[]
+      >`
+        select
+          member.rolname::text as member_role,
+          membership.admin_option,
+          membership.inherit_option,
+          membership.set_option
+        from pg_auth_members membership
+        join pg_roles member on member.oid = membership.member
+        join pg_roles parent on parent.oid = membership.roleid
+        where parent.rolname = ${APP_ROLE}
+      `;
+      expect([...creatorEdges]).toEqual([
+        {
+          member_role: ADMIN_ROLE,
+          admin_option: true,
+          inherit_option: false,
+          set_option: false,
+        },
+      ]);
+
+      await control.unsafe(`create role "unexpected_app_member"`);
+      await control.unsafe(`grant "${APP_ROLE}" to "unexpected_app_member"`);
+    } finally {
+      await control.end();
+    }
+
+    await expect(provisionRoles(ADMIN_URL, options)).rejects.toThrow(
+      "remove role relationships first (member:unexpected_app_member)",
+    );
+
+    const privilegedControl = postgres(SUPERUSER_URL, { max: 1 });
+    try {
+      await privilegedControl.unsafe(`revoke "${APP_ROLE}" from "unexpected_app_member"`);
+      await privilegedControl.unsafe(`alter role "${APP_ROLE}" with createrole`);
+    } finally {
+      await privilegedControl.end();
+    }
+
+    await expect(provisionRoles(ADMIN_URL, options)).rejects.toThrow(
+      "a non-superuser role administrator cannot remove existing privileged attributes",
+    );
+  }, 90_000);
+});

--- a/packages/db/test/provision-roles-managed-admin.test.ts
+++ b/packages/db/test/provision-roles-managed-admin.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import postgres from "postgres";
 import { provisionRoles } from "../src/provision-roles";
 
-const PORT = 61445;
+const PORT = 61446;
 const CONTAINER = `ogverify-pg-managed-role-${PORT}`;
 const SUPERUSER_PASSWORD = "superpw";
 const ADMIN_ROLE = "managed_admin";


### PR DESCRIPTION
## Summary

- accept PostgreSQL 16+ creator administration membership only when it is the exact `ADMIN TRUE, INHERIT FALSE, SET FALSE` edge from the app role to the current session role
- keep every other role relationship fail-closed
- let a non-superuser role administrator rotate and normalize an already-restricted app login without mentioning superuser-only attributes
- reject pre-existing privileged app-role attributes that the current administrator cannot safely remove

## Why

CloudGeni PR Cloudgeni-ai/cloudgeni#1577 embeds OpenGeni into an Azure managed PostgreSQL deployment. Its exact Gecko deployment is blocked because PostgreSQL automatically grants a non-superuser `CREATEROLE` actor this administration-only relationship when it creates `opengeni_app`. The existing guard treats that server-generated edge as unsafe, and the normalization statement also mentions attributes that only a superuser may alter.

The administration edge does not confer inherited privileges and cannot be used with `SET ROLE`; revoking it would prevent the managed database administrator from maintaining or rotating the application role.

## Verification

- real `pgvector/pgvector:pg17` integration test reproducing the managed-admin role graph
- provisioning and password rotation are idempotent
- unexpected members remain rejected
- privileged pre-existing role attributes remain rejected for non-superuser administrators
- existing dedicated-schema isolation suite
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run check:public-hygiene`

## Consumer

Unblocks the next exact OpenGeni embedded release and Gecko deployment proof required by Cloudgeni-ai/cloudgeni#1577.
