### PR TITLE
fix(session): make tool and web-search state truthful

### DIFF
--- a/.changeset/truthful-session-tool-policy.md
+++ b/.changeset/truthful-session-tool-policy.md
@@ -1,0 +1,12 @@
+---
+"@opengeni/core": minor
+"@opengeni/react": patch
+"@opengeni/worker-bundle": patch
+---
+
+Default workspace-tracking sessions to every configured MCP server while
+preserving exact explicit API allow-lists. Keep OpenGeni's internal carrier and
+default-on Files surface out of the web picker's visible choices and counts.
+Settle provider-native web searches from their own terminal status, render each
+web action truthfully, keep completed searches before the answer they informed,
+and hide unresolved private citation handles from the human timeline.

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -64,6 +64,7 @@ import {
   rehydrateRepositoryResources,
   repositorySelectionFromResources,
   reasoningEffortOrder,
+  selectableMcpServers,
   selectedAvailableCapabilityToolIds,
 } from "./lib/session-tools";
 import {
@@ -1106,17 +1107,9 @@ describe("buildTools", () => {
     ]);
   });
 
-  test("pulls in the file download helper whenever document search is selected", () => {
-    expect(buildTools(undefined, ["docs"])).toEqual([
-      { kind: "mcp", id: "docs" },
-      { kind: "mcp", id: "files" },
-    ]);
+  test("does not manufacture runtime infrastructure from a user selection", () => {
+    expect(buildTools(undefined, ["docs"])).toEqual([{ kind: "mcp", id: "docs" }]);
     expect(buildTools([{ kind: "mcp", id: "docs" }], ["docs"])).toEqual([
-      { kind: "mcp", id: "docs" },
-      { kind: "mcp", id: "files" },
-    ]);
-    expect(buildTools([{ kind: "mcp", id: "files" }], ["docs"])).toEqual([
-      { kind: "mcp", id: "files" },
       { kind: "mcp", id: "docs" },
     ]);
   });
@@ -1131,7 +1124,6 @@ describe("buildTools", () => {
     expect(buildTools(undefined, ["opengeni", "docs"])).toEqual([
       { kind: "mcp", id: "opengeni" },
       { kind: "mcp", id: "docs" },
-      { kind: "mcp", id: "files" },
     ]);
   });
 
@@ -1212,6 +1204,21 @@ describe("buildTools", () => {
         }),
       ]),
     ).toEqual([{ id: "cap-ready", name: "Ready MCP" }]);
+  });
+
+  test("keeps mandatory OpenGeni infrastructure out of selectable server catalogs", () => {
+    const config = {
+      mcpServers: [
+        { id: "opengeni", name: "OpenGeni", url: "https://example.test/opengeni" },
+        { id: "files", name: "Files", url: "https://example.test/files" },
+        { id: "docs", name: "Document Search", url: "https://example.test/docs" },
+        { id: "linear", name: "Linear", url: "https://example.test/linear" },
+      ],
+    } as unknown as Parameters<typeof selectableMcpServers>[0];
+    expect(selectableMcpServers(config)).toEqual([
+      expect.objectContaining({ id: "docs" }),
+      expect.objectContaining({ id: "linear" }),
+    ]);
   });
 
   test("merges configured and workspace MCP options without duplicates", () => {
@@ -1681,7 +1688,7 @@ describe("GitHub repository resources", () => {
 });
 
 describe("new-session draft tool policy", () => {
-  test("keeps omitted defaults distinct from explicit empty and narrowed policies", () => {
+  test("keeps omitted defaults distinct from the UI's Files-only and narrowed policies", () => {
     expect(
       newSessionDraftToolPolicy({
         selectedMcpServerIds: ["opengeni", "docs"],
@@ -1697,7 +1704,7 @@ describe("new-session draft tool policy", () => {
         catalogReady: true,
         explicit: true,
       }),
-    ).toEqual({ tools: [], toolsProvided: true });
+    ).toEqual({ tools: [{ kind: "mcp", id: "files" }], toolsProvided: true });
     expect(
       newSessionDraftToolPolicy({
         selectedMcpServerIds: ["opengeni"],
@@ -1705,7 +1712,7 @@ describe("new-session draft tool policy", () => {
         catalogReady: true,
         explicit: false,
       }),
-    ).toEqual({ tools: [{ kind: "mcp", id: "opengeni" }], toolsProvided: true });
+    ).toEqual({ tools: [{ kind: "mcp", id: "files" }], toolsProvided: true });
     expect(
       newSessionDraftToolPolicy({
         selectedMcpServerIds: ["opengeni"],

--- a/apps/web/src/components/pickers.tsx
+++ b/apps/web/src/components/pickers.tsx
@@ -175,6 +175,21 @@ export type SessionToolSelection = {
   firstPartyToolIds: Set<FirstPartyMcpToolName>;
 };
 
+export function visibleSessionToolSelection(
+  selection: SessionToolSelection,
+  servers: ReadonlyArray<Pick<McpServerOption, "id">>,
+  firstPartyTools: ReadonlyArray<Pick<{ id: FirstPartyMcpToolName }, "id">>,
+): SessionToolSelection {
+  const visibleMcpIds = new Set(servers.map((server) => server.id));
+  const visibleFirstPartyIds = new Set(firstPartyTools.map((tool) => tool.id));
+  return {
+    mcpServerIds: new Set([...selection.mcpServerIds].filter((id) => visibleMcpIds.has(id))),
+    firstPartyToolIds: new Set(
+      [...selection.firstPartyToolIds].filter((id) => visibleFirstPartyIds.has(id)),
+    ),
+  };
+}
+
 export function SessionToolPicker(props: {
   servers: McpServerOption[];
   firstPartyTools: ReadonlyArray<{ id: FirstPartyMcpToolName; name: string }>;
@@ -183,14 +198,21 @@ export function SessionToolPicker(props: {
   saving?: boolean;
   onChange: (selection: SessionToolSelection) => void;
 }) {
+  const visibleSelection = visibleSessionToolSelection(
+    props.selection,
+    props.servers,
+    props.firstPartyTools,
+  );
   const total = props.servers.length + props.firstPartyTools.length;
-  const selected = props.selection.mcpServerIds.size + props.selection.firstPartyToolIds.size;
+  const selectedMcpIds = visibleSelection.mcpServerIds;
+  const selectedFirstPartyIds = visibleSelection.firstPartyToolIds;
+  const selected = selectedMcpIds.size + selectedFirstPartyIds.size;
   if (total === 0) return null;
 
   const toggleMcp = (id: string) => {
     const next: SessionToolSelection = {
-      mcpServerIds: new Set(props.selection.mcpServerIds),
-      firstPartyToolIds: new Set(props.selection.firstPartyToolIds),
+      mcpServerIds: selectedMcpIds,
+      firstPartyToolIds: selectedFirstPartyIds,
     };
     if (next.mcpServerIds.has(id)) next.mcpServerIds.delete(id);
     else next.mcpServerIds.add(id);
@@ -198,8 +220,8 @@ export function SessionToolPicker(props: {
   };
   const toggleFirstParty = (id: FirstPartyMcpToolName) => {
     const next: SessionToolSelection = {
-      mcpServerIds: new Set(props.selection.mcpServerIds),
-      firstPartyToolIds: new Set(props.selection.firstPartyToolIds),
+      mcpServerIds: selectedMcpIds,
+      firstPartyToolIds: selectedFirstPartyIds,
     };
     if (next.firstPartyToolIds.has(id)) next.firstPartyToolIds.delete(id);
     else next.firstPartyToolIds.add(id);

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -50,7 +50,7 @@ import {
 } from "@/lib/session-pins";
 import {
   buildResources,
-  buildTools,
+  buildOpenGeniUiTools,
   enabledWorkspaceCapabilityMcpServers,
   groupRepositories,
   initialReasoningEffort,
@@ -736,7 +736,7 @@ export function RootRouteComponent() {
         });
         return null;
       }
-      const selectedTools = buildTools(submission.tools, [...selectedCapabilityToolIds]);
+      const selectedTools = buildOpenGeniUiTools(submission.tools, selectedCapabilityToolIds);
       const freshIdempotencyKey = crypto.randomUUID();
       const attempt = prepareCreateSessionAttempt({
         pending: pendingCreateAttempt.current,
@@ -752,10 +752,7 @@ export function RootRouteComponent() {
           defaultReasoningEffort: reasoningEffort,
           clientEventId: crypto.randomUUID(),
           idempotencyKey: freshIdempotencyKey,
-          workspaceDefaultMcpServerIds: [
-            "opengeni",
-            ...workspaceMcpServers.map((server) => server.id),
-          ],
+          workspaceDefaultMcpServerIds: ["files", ...toolMcpServers.map((server) => server.id)],
           workspaceMcpCatalogReady,
           targetSandboxId: options?.targetSandboxId,
           workingDir: options?.workingDir,
@@ -1003,7 +1000,7 @@ export function RootRouteComponent() {
           selectedInstallationId,
           repositoryGroups,
           toolMcpServers,
-          workspaceDefaultToolIds: workspaceMcpServers.map((server) => server.id),
+          workspaceDefaultToolIds: toolMcpServers.map((server) => server.id),
           workspaceMcpCatalogReady,
           currentResources,
           addManualRepository: contextAddManualRepository,
@@ -1081,7 +1078,6 @@ export function RootRouteComponent() {
     setSession,
     toolMcpServers,
     workspaceMcpCatalogReady,
-    workspaceMcpServers,
     workspaces,
   ]);
 

--- a/apps/web/src/lib/session-create-request.test.ts
+++ b/apps/web/src/lib/session-create-request.test.ts
@@ -25,7 +25,7 @@ function build(
   return buildCreateSessionRequest({
     currentResources,
     submission: { text: "start", resources: submissionResources },
-    selectedTools: [{ kind: "mcp", id: "opengeni" }],
+    selectedTools: [],
     defaultModel: "gpt-5.4",
     defaultReasoningEffort: "medium",
     clientEventId: "event-1",
@@ -115,12 +115,8 @@ describe("buildCreateSessionRequest", () => {
 
   test("omits tools only when the ready catalog selection equals workspace defaults", () => {
     const result = build([], [], {
-      selectedTools: [
-        { kind: "mcp", id: "opengeni" },
-        { kind: "mcp", id: "docs" },
-        { kind: "mcp", id: "files" },
-      ],
-      workspaceDefaultMcpServerIds: ["files", "docs", "opengeni"],
+      selectedTools: [{ kind: "mcp", id: "docs" }],
+      workspaceDefaultMcpServerIds: ["docs"],
       workspaceMcpCatalogReady: true,
     });
 
@@ -129,7 +125,7 @@ describe("buildCreateSessionRequest", () => {
 
   test("keeps explicit empty, subset, and partially hydrated selections on the wire", () => {
     const common = {
-      workspaceDefaultMcpServerIds: ["docs", "opengeni"],
+      workspaceDefaultMcpServerIds: ["docs"],
       workspaceMcpCatalogReady: true,
     };
     expect(
@@ -141,24 +137,16 @@ describe("buildCreateSessionRequest", () => {
     expect(
       build([], [], {
         ...common,
-        selectedTools: [{ kind: "mcp", id: "opengeni" }],
+        selectedTools: [{ kind: "mcp", id: "linear" }],
       }).tools,
-    ).toEqual([{ kind: "mcp", id: "opengeni" }]);
+    ).toEqual([{ kind: "mcp", id: "linear" }]);
     expect(
       build([], [], {
         ...common,
-        selectedTools: [
-          { kind: "mcp", id: "opengeni" },
-          { kind: "mcp", id: "docs" },
-          { kind: "mcp", id: "files" },
-        ],
+        selectedTools: [{ kind: "mcp", id: "docs" }],
         workspaceMcpCatalogReady: false,
       }).tools,
-    ).toEqual([
-      { kind: "mcp", id: "opengeni" },
-      { kind: "mcp", id: "docs" },
-      { kind: "mcp", id: "files" },
-    ]);
+    ).toEqual([{ kind: "mcp", id: "docs" }]);
   });
 
   test("omits workspace resources for a connected machine but keeps attachments", () => {

--- a/apps/web/src/lib/session-tools.ts
+++ b/apps/web/src/lib/session-tools.ts
@@ -22,6 +22,23 @@ export type RepoDraft = { id: number; url: string; ref: string };
 export type IntelligenceEffort = ReasoningEffort;
 export type McpServerOption = { id: string; name: string };
 
+const NON_SELECTABLE_SESSION_MCP_SERVER_IDS = new Set(["opengeni", "files"]);
+
+/**
+ * Runtime infrastructure is not user policy:
+ * - `opengeni` is the mandatory carrier for the individually selected
+ *   first-party tools.
+ * - `files` is OpenGeni's hidden-on-by-default file/download capability.
+ *   The public API may still omit it from an explicit session policy.
+ */
+export function isSelectableSessionMcpServerId(id: string): boolean {
+  return !NON_SELECTABLE_SESSION_MCP_SERVER_IDS.has(id);
+}
+
+export function selectableSessionMcpServerIds(ids: Iterable<string>): Set<string> {
+  return new Set([...ids].filter(isSelectableSessionMcpServerId));
+}
+
 const FIRST_PARTY_ACTION_LABELS: Partial<Record<FirstPartyMcpToolName, string>> = {
   set_session_title: "Rename this session",
   set_other_session_title: "Rename another session",
@@ -81,18 +98,25 @@ export function buildTools(
   mcpServerIds: string[] = [],
 ): ToolRef[] {
   const out = [...(existing ?? [])];
-  const ids = [...mcpServerIds];
-  // Document Search is one user-facing tool but needs its file-download helper
-  // ("files") alongside it; pull it in whenever "docs" is selected.
-  if (ids.includes("docs") && !ids.includes("files")) {
-    ids.push("files");
-  }
-  for (const id of ids) {
+  for (const id of mcpServerIds) {
     if (id && !out.some((tool) => tool.kind === "mcp" && tool.id === id)) {
       out.push({ kind: "mcp", id });
     }
   }
   return out;
+}
+
+/**
+ * OpenGeni's product UI keeps file access enabled without exposing an
+ * implementation-level Files checkbox. This is deliberately a UI default, not
+ * a server mandate: API and embedded clients can still submit an explicit
+ * policy without `files`.
+ */
+export function buildOpenGeniUiTools(
+  existing: ToolRef[] | undefined,
+  selectedMcpServerIds: Iterable<string>,
+): ToolRef[] {
+  return buildTools(existing, ["files", ...selectableSessionMcpServerIds(selectedMcpServerIds)]);
 }
 
 function canonicalToolIds(tools: ToolRef[]): string[] {
@@ -101,9 +125,9 @@ function canonicalToolIds(tools: ToolRef[]): string[] {
 
 /**
  * Materialize the picker's selection only when it narrows/pins the inherited
- * baseline. `undefined` is the wire-level omitted-tools contract; `[]` is an
- * intentional empty selection. Canonicalization includes hidden helpers such
- * as docs → files, so UI-only representation differences do not pin a turn.
+ * baseline. `undefined` is the wire-level omitted-tools contract. The product
+ * UI's hidden Files default is materialized when it writes an explicit policy;
+ * API clients that need a truly empty allow-list submit `[]` directly.
  */
 export function toolsForPolicySelection(input: {
   existing?: ToolRef[];
@@ -111,11 +135,11 @@ export function toolsForPolicySelection(input: {
   baselineMcpServerIds: Iterable<string>;
   forceExplicit?: boolean;
 }): ToolRef[] | undefined {
-  const selected = buildTools(input.existing, [...input.selectedMcpServerIds]);
+  const selected = buildOpenGeniUiTools(input.existing, input.selectedMcpServerIds);
   if (input.forceExplicit === true) {
     return selected;
   }
-  const baseline = buildTools(undefined, [...input.baselineMcpServerIds]);
+  const baseline = buildOpenGeniUiTools(undefined, input.baselineMcpServerIds);
   return canonicalToolIds(selected).join("\u0000") === canonicalToolIds(baseline).join("\u0000")
     ? undefined
     : selected;
@@ -129,8 +153,8 @@ export function newSessionDraftToolPolicy(input: {
   explicit: boolean;
 }): { tools: ToolRef[]; toolsProvided: boolean } {
   if (!input.catalogReady) return { tools: [], toolsProvided: false };
-  const selected = buildTools(undefined, [...input.selectedMcpServerIds]);
-  const baseline = buildTools(undefined, [...input.workspaceDefaultMcpServerIds]);
+  const selected = buildOpenGeniUiTools(undefined, input.selectedMcpServerIds);
+  const baseline = buildOpenGeniUiTools(undefined, input.workspaceDefaultMcpServerIds);
   const equal =
     canonicalToolIds(selected).join("\u0000") === canonicalToolIds(baseline).join("\u0000");
   return input.explicit || !equal
@@ -353,12 +377,7 @@ export function selectableMcpServers(config: ClientConfig | null): McpServerOpti
   if (!config) {
     return [];
   }
-  // "files" is the document-search download helper, attached automatically with
-  // "docs" (see buildTools) — it is not a tool the user picks on its own, so
-  // hide it. Everything else, including the first-party "opengeni" and "docs",
-  // is selectable from the unified Tools dropdown.
-  const hidden = new Set(["files"]);
-  return config.mcpServers.filter((server) => !hidden.has(server.id));
+  return config.mcpServers.filter((server) => isSelectableSessionMcpServerId(server.id));
 }
 
 export function enabledWorkspaceCapabilityMcpServers(
@@ -373,7 +392,9 @@ export function enabledWorkspaceCapabilityMcpServers(
     ) {
       return [];
     }
-    return [{ id: item.runtime.mcpServerId, name: item.name }];
+    return isSelectableSessionMcpServerId(item.runtime.mcpServerId)
+      ? [{ id: item.runtime.mcpServerId, name: item.name }]
+      : [];
   });
 }
 

--- a/apps/web/src/pickers.test.tsx
+++ b/apps/web/src/pickers.test.tsx
@@ -4,7 +4,11 @@ import type { FirstPartyMcpToolName } from "@opengeni/contracts";
 import { act, useState } from "react";
 import { createRoot } from "react-dom/client";
 
-import { SessionToolPicker, type SessionToolSelection } from "@/components/pickers";
+import {
+  SessionToolPicker,
+  visibleSessionToolSelection,
+  type SessionToolSelection,
+} from "@/components/pickers";
 
 beforeAll(() => {
   GlobalRegistrator.register();
@@ -58,6 +62,47 @@ describe("unified session tool picker", () => {
       expect(container.textContent).not.toContain("Tools for this turn");
       expect(latest.mcpServerIds).toEqual(new Set(["linear"]));
       expect(latest.firstPartyToolIds).toEqual(new Set(FIRST_PARTY.map((tool) => tool.id)));
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("never counts or preserves non-rendered runtime infrastructure", async () => {
+    let latest: SessionToolSelection = {
+      mcpServerIds: new Set(["docs", "opengeni", "files"]),
+      firstPartyToolIds: new Set(FIRST_PARTY.map((tool) => tool.id)),
+    };
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    function Harness() {
+      const [selection, setSelection] = useState(latest);
+      return (
+        <SessionToolPicker
+          servers={[{ id: "docs", name: "Document Search" }]}
+          firstPartyTools={FIRST_PARTY}
+          selection={selection}
+          onChange={(next) => {
+            latest = next;
+            setSelection(next);
+          }}
+        />
+      );
+    }
+
+    try {
+      await act(async () => root.render(<Harness />));
+      const trigger = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Session tools"]',
+      );
+      expect(trigger?.textContent).toContain("Tools · All");
+      expect(trigger?.textContent).not.toContain("5/3");
+      expect(visibleSessionToolSelection(latest, [{ id: "docs" }], FIRST_PARTY)).toEqual({
+        mcpServerIds: new Set(["docs"]),
+        firstPartyToolIds: new Set(FIRST_PARTY.map((tool) => tool.id)),
+      });
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -578,10 +578,7 @@ function SessionChatPane(props: {
   // the workspaceId, so the hook needs no positional argument.
   const attachments = useFileAttachments();
   const { reasoningEffort } = context;
-  const selectableSessionMcpServers = useMemo(
-    () => context.toolMcpServers.filter((server) => server.id !== "opengeni"),
-    [context.toolMcpServers],
-  );
+  const selectableSessionMcpServers = context.toolMcpServers;
   const selectableToolIds = useMemo(
     () => selectableSessionMcpServers.map((server) => server.id),
     [selectableSessionMcpServers],

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -69,6 +69,7 @@ import {
 } from "@/lib/session-create";
 import {
   firstPartySessionToolOptions,
+  selectableSessionMcpServerIds,
   newSessionDraftToolPolicy,
   rehydrateRepositoryResources,
   repositorySelectionFromResources,
@@ -111,23 +112,19 @@ function SessionsIndexRouteContent({ workspaceId }: { workspaceId: string }) {
   }, [resetSessionView, workspaceId]);
 
   const computeReady = isSessionDraftComputeReady(draft);
-  const workspaceDefaultToolIds = useMemo(
-    () => ["opengeni", ...context.workspaceDefaultToolIds],
-    [context.workspaceDefaultToolIds],
-  );
   const persistedToolPolicy = useMemo(
     () =>
       newSessionDraftToolPolicy({
         selectedMcpServerIds: context.selectedCapabilityToolIds,
-        workspaceDefaultMcpServerIds: workspaceDefaultToolIds,
+        workspaceDefaultMcpServerIds: context.workspaceDefaultToolIds,
         catalogReady: context.workspaceMcpCatalogReady,
         explicit: toolSelectionExplicit,
       }),
     [
       context.selectedCapabilityToolIds,
       context.workspaceMcpCatalogReady,
+      context.workspaceDefaultToolIds,
       toolSelectionExplicit,
-      workspaceDefaultToolIds,
     ],
   );
   const persistedValue = useMemo(
@@ -171,12 +168,9 @@ function SessionsIndexRouteContent({ workspaceId }: { workspaceId: string }) {
       const selected = new Set(
         remote.toolsProvided
           ? remote.tools.map((tool) => tool.id)
-          : ["opengeni", ...workspaceDefaultToolIdsForHydration],
+          : workspaceDefaultToolIdsForHydration,
       );
-      // `files` is the hidden download helper automatically paired with the
-      // visible Document Search selection, not a standalone picker choice.
-      if (selected.has("docs")) selected.delete("files");
-      setSelectedCapabilityToolIds(selected);
+      setSelectedCapabilityToolIds(selectableSessionMcpServerIds(selected));
       const repositorySelection = repositorySelectionFromResources(remote.resources, githubRepos);
       setManualRepos(repositorySelection.manualRepos);
       setSelectedRepoIds(repositorySelection.selectedRepoIds);
@@ -515,7 +509,7 @@ function SessionControlStrip({
         onEffortChange={context.setReasoningEffort}
       />
       <SessionToolPicker
-        servers={context.toolMcpServers.filter((server) => server.id !== "opengeni")}
+        servers={context.toolMcpServers}
         firstPartyTools={firstPartySessionToolOptions}
         selection={selection}
         disabled={disabled}

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -183,7 +183,7 @@ import {
   type CodexUsageHeaderSnapshot,
 } from "@opengeni/codex";
 import { mergeResourceRefs } from "./common";
-import { enabledCapabilityMcpToolRefs, resolveSessionToolPolicy } from "@opengeni/core";
+import { defaultSessionMcpServerIds, resolveSessionToolPolicy } from "@opengeni/core";
 import { maybeCompactContext } from "./context-compaction";
 import { TurnAttemptFencedError } from "./turn-attempt-fenced";
 import {
@@ -4074,16 +4074,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // narrowed by the session's exact firstPartyMcpTools selection and
       // authorization. Idempotent: mergeToolRefs dedupes if already present.
       // Resolve the durable policy at the turn boundary. Workspace-default
-      // sessions may discover newly enabled capability MCPs and Codex Apps,
+      // sessions follow the current configured MCP set,
       // while explicit, inherited-fixed, and legacy sessions remain narrowed
       // to their stored materialized allow-list.
       const resolvedToolPolicy = resolveSessionToolPolicy({
         toolPolicy: session.toolPolicy,
         sessionTools: session.tools,
         availableMcpServerIds: runSettings.mcpServers.map((server) => server.id),
-        defaultMcpServerIds: enabledCapabilityMcpToolRefs(settings, mcpSettings).map(
-          (tool) => tool.id,
-        ),
+        defaultMcpServerIds: defaultSessionMcpServerIds(capabilitySettings.mcpServers),
       });
       const effectivePolicyTools = resolvedToolPolicy.toolRefs;
       const turnTools = withFirstPartyTools(runSettings, effectivePolicyTools);

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -18,7 +18,9 @@ Remote MCP capabilities with a streamable HTTP endpoint are executable. Enabling
 Tool selection is durable session state. The session tool picker atomically
 updates connected MCP servers and individual OpenGeni tools under one version;
 the next attempt reads that selection. Follow-up Send and Steer requests do not
-carry a private one-turn tool list.
+carry a private one-turn tool list. OpenGeni's web picker hides its internal
+`opengeni` carrier and the default-on `files` server from the visible count.
+The public API remains exact: an explicit session policy may omit `files`.
 
 MCP tool refs are strict by default. A bare `{ "kind": "mcp", "id": "docs" }` must name a server configured for this deployment, and a runtime connect/list failure fails the turn. A client or pack can mark a ref `{ "kind": "mcp", "id": "context7", "optional": true }` to make it portable: if the deployment does not configure that server the ref is skipped during validation, and if the server is configured but unavailable at runtime it is skipped for that turn with a warning.
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -465,7 +465,7 @@ creation; later deployment-default changes do not rewrite existing sessions.
 
 Model-visible first-party tool selection is a separate field:
 `CreateSessionRequest.firstPartyMcpTools`. It accepts only names from
-`FIRST_PARTY_MCP_TOOL_NAMES`; omission uses the minimal self-management default,
+`FIRST_PARTY_MCP_TOOL_NAMES`; omission uses the complete catalog,
 while explicit `[]` remains empty. A child omission snapshots its parent's exact
 effective selection. Tool selection never grants a permission, and permissions
 never implicitly select a tool. This separation lets a host keep a broad
@@ -475,7 +475,9 @@ one embedded session.
 Resources are unaffected by that selection. File/document/repository
 attachments still materialize when `firstPartyMcpTools` is empty or contains
 only `set_session_title`; the dedicated `files` and `docs` MCP servers are
-selected independently through `tools`.
+selected independently through `tools`. Omitted top-level `tools` policy keeps
+Files enabled by default; an explicit list, including `[]`, is exact and can
+disable it for embedded products that require a narrower model-visible surface.
 
 ### Child execution context
 

--- a/docs/mcp-surfaces.md
+++ b/docs/mcp-surfaces.md
@@ -8,8 +8,8 @@ page exists so you pick the right one in one read.
 | --- | --- | --- | --- | --- |
 | **First-party OpenGeni MCP** (`/v1/workspaces/:id/mcp`) | Embedding host selects tool names per session | Always attached; the model sees the session's exact catalog selection intersected with its authorization grant | The caller's own bearer; internally delegated `ogd_` tokens carry permissions and the separate tool-name selection | An agent should use selected OpenGeni-native orchestration or self-management tools |
 | **Toolspace MCP** (`/v1/workspaces/:id/mcp` with `toolspace:call` + `sessionId`) | OpenGeni worker, when `OPENGENI_TOOLSPACE_ENABLED=true` | One running session turn; session-selected safe first-party tools plus selected capability/per-session MCP tools, minus approval-required tools | Narrow `ogd_` token written to a sandbox file; upstream credentials resolve server-side through the same standalone/host broker as normal MCP | Sandbox code needs to list/call the session's tools programmatically without a model round-trip |
-| **Docs MCP** (`/mcp/docs`) | Nobody — built in | Always available | Caller's bearer | An agent should search the workspace's documents store |
-| **Files MCP** (`/mcp/files`) | Nobody — built in | Dedicated download-materialization surface selected through the `files` server ref | Caller's bearer with `files:read` | An agent needs a short-lived download URL for a ready file |
+| **Docs MCP** (`/mcp/docs`) | Nobody — built in | Built in; selected through the `docs` server ref | Caller's bearer | An agent should search the workspace's documents store |
+| **Files MCP** (`/mcp/files`) | Nobody — built in | Default-on download-materialization surface selected through the `files` server ref; an explicit API policy may omit it | Caller's bearer with `files:read` | An agent needs a short-lived download URL for a ready file, including an original file identified by document search |
 | **Capability MCP servers** | Workspace admin (capabilities settings) | Workspace-wide; on for every session while enabled | Admin-supplied headers, encrypted, write-only | A third-party tool (e.g. a SaaS MCP) should be available to *all* sessions in a workspace |
 | **Per-session MCP servers** (`mcpServers` on session create) | The embedding host, per session | One session; static headers rotatable on every user turn; host connection refs resolved per request | Encrypted write-only headers or a non-secret opaque `connectionRef` resolved by the standalone/host broker | An embedding host injects its own tool server or binds an existing provider connection without duplicating it |
 | **Codex Apps MCP** | Deployment enables the registry; workspace-default or explicit session policy selects it | Workspace-default sessions receive it as an optional MCP; explicit/fixed sessions see it only when selected | Workspace's Codex tokens, resolved independently from visibility | A Codex-backed session should use connected ChatGPT apps without silently widening an exact tool allowlist |
@@ -35,7 +35,10 @@ runs on calls. Child omission inherits the parent's exact effective selection.
 File and document resources are independent from this broad-server selection.
 Attaching a resource still materializes it for the session when
 `firstPartyMcpTools` is `[]` or title-only; selecting the dedicated `files` or
-`docs` MCP server is a separate `tools` decision.
+`docs` MCP server is a separate `tools` decision. Document search results carry
+the backing `fileId`; reading an indexed chunk stays within Docs MCP, while
+downloading the complete original uses Files MCP. Workspace-default policy
+includes Files, but an explicit API/embedding policy may omit it.
 
 Codex Apps follows that same separation. Enabling
 `OPENGENI_CODEX_CONNECTED_APPS_ENABLED` registers `codex_apps` as a selectable

--- a/packages/core/src/domain/session-tool-policy.ts
+++ b/packages/core/src/domain/session-tool-policy.ts
@@ -10,7 +10,6 @@ import {
 } from "@opengeni/contracts";
 import type { Database } from "@opengeni/db";
 import { settingsWithEnabledCapabilityMcpServers } from "./capabilities";
-import { enabledCapabilityMcpToolRefs } from "./resources";
 
 const MANDATORY_SESSION_MCP_SERVER_IDS = ["opengeni"] as const;
 const PROJECTABLE_REGISTRY_ID = /^[A-Za-z0-9_-]+$/;
@@ -32,6 +31,12 @@ function sortedIds(ids: Iterable<string>): string[] {
   return [...new Set(ids)].sort();
 }
 
+/** Every configured runtime MCP defaults on; mandatory carrier IDs are separate. */
+export function defaultSessionMcpServerIds(servers: Iterable<{ id: string }>): string[] {
+  const mandatory = new Set<string>(MANDATORY_SESSION_MCP_SERVER_IDS);
+  return sortedIds([...servers].map((server) => server.id).filter((id) => !mandatory.has(id)));
+}
+
 function projectIds(ids: readonly string[]): { ids: string[]; truncated: boolean } {
   const projectable = ids.filter(
     (id) =>
@@ -49,13 +54,11 @@ function projectIds(ids: readonly string[]): { ids: string[]; truncated: boolean
  * Resolve the same ID-only policy used by API projections and worker turns.
  * This function never receives endpoint URLs, credentials, schemas, or live
  * probe results. `availableMcpServerIds` is the resolved runtime registry;
- * `defaultMcpServerIds` is the capability-only omitted-tools set.
+ * `defaultMcpServerIds` is the current configured omitted-tools default.
  */
 export function resolveSessionToolPolicy(input: SessionToolPolicyInput): ResolvedSessionToolPolicy {
   const policy = input.toolPolicy;
   const availableIds = new Set(input.availableMcpServerIds);
-  // Never infer omitted-tools defaults from the full runtime registry: static
-  // MCPs are explicit-only unless they are capability-derived defaults.
   const defaultIds = new Set(input.defaultMcpServerIds ?? []);
   const mandatoryIds: string[] = MANDATORY_SESSION_MCP_SERVER_IDS.filter((id) =>
     availableIds.has(id),
@@ -169,14 +172,14 @@ export async function workspaceSessionToolPolicyServerIds(
   return sortedIds(runtimeSettings.mcpServers.map((server) => server.id));
 }
 
-/** Current omitted-tools defaults; this preserves capability-first behavior. */
+/** Current omitted-tools defaults: every configured runtime MCP is on. */
 export async function workspaceSessionToolPolicyDefaultServerIds(
   db: Database,
   workspaceId: string,
   settings: Settings,
 ): Promise<string[]> {
   const runtimeSettings = await settingsWithEnabledCapabilityMcpServers(db, workspaceId, settings);
-  return sortedIds(enabledCapabilityMcpToolRefs(settings, runtimeSettings).map((tool) => tool.id));
+  return defaultSessionMcpServerIds(runtimeSettings.mcpServers);
 }
 
 /** Add a bounded, secret-safe effective projection to a session response. */

--- a/packages/core/test/session-tool-policy.test.ts
+++ b/packages/core/test/session-tool-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  defaultSessionMcpServerIds,
   resolveSessionToolPolicy,
   type SessionToolPolicyInput,
 } from "../src/domain/session-tool-policy";
@@ -15,32 +16,44 @@ function resolve(overrides: Partial<SessionToolPolicyInput> = {}) {
   return resolveSessionToolPolicy({
     toolPolicy: { mode: "workspace_default", inheritedFromSessionId: null },
     sessionTools: [],
-    availableMcpServerIds: ["opengeni", "cap-docs", "static-configured"],
-    defaultMcpServerIds: ["cap-docs"],
+    availableMcpServerIds: ["opengeni", "files", "cap-docs", "static-configured"],
+    defaultMcpServerIds: ["cap-docs", "files"],
     ...overrides,
   });
 }
 
 describe("session tool policy resolution", () => {
-  test("workspace defaults are capability-only and add the mandatory first-party server", () => {
+  test("workspace defaults add mandatory first-party and default file infrastructure", () => {
     const result = resolve();
 
-    expect(result.toolRefs).toEqual([mcp("cap-docs", true), mcp("opengeni")]);
+    expect(result.toolRefs).toEqual([mcp("cap-docs", true), mcp("files", true), mcp("opengeni")]);
     expect(result.effectivePolicy.selectedIds).toEqual([]);
-    expect(result.effectivePolicy.effectiveIds).toEqual(["cap-docs", "opengeni"]);
+    expect(result.effectivePolicy.effectiveIds).toEqual(["cap-docs", "files", "opengeni"]);
     expect(result.effectivePolicy.mandatoryIds).toEqual(["opengeni"]);
     expect(result.effectivePolicy.lazyRouter).toEqual({
       state: "required",
-      deferredIds: ["cap-docs"],
+      deferredIds: ["cap-docs", "files"],
     });
     expect(result.effectivePolicy.counts).toEqual({
       selected: 0,
-      effective: 2,
+      effective: 3,
       mandatory: 1,
-      deferred: 1,
-      configured: 2,
+      deferred: 2,
+      configured: 3,
       dropped: 0,
     });
+  });
+
+  test("defaults every configured server except the mandatory carrier", () => {
+    expect(
+      defaultSessionMcpServerIds([
+        { id: "linear" },
+        { id: "files" },
+        { id: "opengeni" },
+        { id: "docs" },
+        { id: "linear" },
+      ]),
+    ).toEqual(["docs", "files", "linear"]);
   });
 
   test("does not infer static MCPs when the capability default set is omitted", () => {
@@ -56,7 +69,7 @@ describe("session tool policy resolution", () => {
       const result = resolve({
         toolPolicy: { mode, inheritedFromSessionId: null },
         sessionTools: [mcp("cap-selected")],
-        availableMcpServerIds: ["opengeni", "cap-selected"],
+        availableMcpServerIds: ["opengeni", "files", "cap-selected"],
       });
       expect(result.toolRefs).toEqual([mcp("cap-selected"), mcp("opengeni")]);
       expect(result.effectivePolicy.effectiveIds).toEqual(["cap-selected", "opengeni"]);

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -165,12 +165,17 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
         // Reconcile the most recent same-turn agent message — even when
         // activity (tool calls, reasoning) landed after its deltas — so the
         // completed text never duplicates the streamed one.
-        const open = [...items]
-          .reverse()
-          .find(
-            (item): item is AgentMessageItem =>
-              item.kind === "agent-message" && item.turnId === turnId,
-          );
+        let openIndex = -1;
+        for (let index = items.length - 1; index >= 0; index -= 1) {
+          const candidate = items[index];
+          if (candidate?.kind === "agent-message" && candidate.turnId === turnId) {
+            openIndex = index;
+            break;
+          }
+        }
+        const candidate = openIndex >= 0 ? items[openIndex] : undefined;
+        const open: AgentMessageItem | undefined =
+          candidate?.kind === "agent-message" ? candidate : undefined;
         if (
           open &&
           (open.streaming || !open.text || text === open.text || text.startsWith(open.text))
@@ -180,6 +185,15 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
             open.text = text || open.text;
           }
           open.streaming = false;
+          // The SDK can emit a hosted-tool item only after its provider-native
+          // operation has completed, even though answer deltas were already
+          // streamed. The completed message event is the durable ordering
+          // authority, so move the reconciled row after any intervening tool
+          // activity instead of leaving completed web searches below the answer.
+          if (openIndex < items.length - 1) {
+            items.splice(openIndex, 1);
+            items.push(open);
+          }
           break;
         }
         if (text) {
@@ -247,7 +261,7 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
           // The provider-native item drives the per-tool renderers (apply_patch
           // operation, computer_call action, web_search providerData, …).
           raw: payload.raw,
-          status: "running",
+          status: providerNativeToolStatus(payload.raw),
           occurredAt: event.occurredAt,
         });
         break;
@@ -607,7 +621,40 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
     }
   }
 
+  for (const item of items) {
+    if (item.kind === "agent-message") {
+      item.text = stripOpaqueCitationTokens(item.text);
+    }
+  }
   return items;
+}
+
+function providerNativeToolStatus(rawValue: unknown): ToolCallItem["status"] {
+  const raw = asRecord(rawValue);
+  if (raw.type !== "hosted_tool_call") {
+    return "running";
+  }
+  switch (raw.status) {
+    case "completed":
+      return "complete";
+    case "failed":
+    case "incomplete":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    default:
+      return "running";
+  }
+}
+
+/**
+ * Codex subscription web search can return private citation handles without
+ * the URL annotation table that would make them resolvable. Keep the canonical
+ * model-history item untouched, but never expose those unusable handles in the
+ * human timeline. Ordinary markdown links and structured URL citations remain.
+ */
+export function stripOpaqueCitationTokens(text: string): string {
+  return text.replace(/\s*cite(?:[^]+)+/gu, "");
 }
 
 /** The turn-end payload shape, as `isCreditExhaustion` wants it. */

--- a/packages/react/src/timeline/tool-renderers.tsx
+++ b/packages/react/src/timeline/tool-renderers.tsx
@@ -700,13 +700,41 @@ type WebSearchResult = { title: string; domain: string; snippet: string };
 
 function WebSearchRenderer({ item }: ToolRendererProps) {
   const raw = (item.raw ?? {}) as {
-    providerData?: { action?: { query?: string; queries?: string[] } };
+    providerData?: {
+      action?: {
+        type?: string;
+        query?: string;
+        queries?: string[];
+        url?: string;
+        pattern?: string;
+      };
+    };
   };
   const action = raw.providerData?.action ?? {};
-  const query = action.query ?? "(query unavailable)";
+  const actionType = action.type ?? "search";
+  const query =
+    actionType === "open_page"
+      ? (action.url ?? "(page unavailable)")
+      : actionType === "find_in_page"
+        ? action.pattern && action.url
+          ? `"${action.pattern}" in ${action.url}`
+          : (action.pattern ?? action.url ?? "(page unavailable)")
+        : (action.query ?? "(query unavailable)");
   const queries = action.queries ?? [];
   const variants = queries.length > 1 ? ` +${queries.length - 1} variants` : "";
   const running = item.status === "running";
+  const runningTitle =
+    actionType === "open_page"
+      ? "Opening web page"
+      : actionType === "find_in_page"
+        ? "Searching within page"
+        : "Searching the web";
+  const completedTitle =
+    actionType === "open_page"
+      ? "Opened web page"
+      : actionType === "find_in_page"
+        ? "Searched within page"
+        : "Searched the web";
   // web_search may surface a results array on the output when the host enriches it.
   // Filter out null/undefined/non-object entries before casting: host-provided
   // data is untrusted and a null element would throw on result.title access.
@@ -727,7 +755,7 @@ function WebSearchRenderer({ item }: ToolRendererProps) {
       <ActivityDisclosure
         icon={<SearchIcon className={ICON_SIZE} />}
         iconTone="running"
-        title="Searching the web"
+        title={runningTitle}
         running
         preview={<RunningPreview>{`${query}${variants}`}</RunningPreview>}
       >
@@ -740,7 +768,7 @@ function WebSearchRenderer({ item }: ToolRendererProps) {
     <ActivityDisclosure
       icon={<SearchIcon className={ICON_SIZE} />}
       iconTone="muted"
-      title="Searched the web"
+      title={completedTitle}
       preview={`${query}${variants}`}
       failed={item.status === "failed"}
       cancelled={item.status === "cancelled"}

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -831,6 +831,30 @@ describe("ExecRenderer — failed+empty-output distinction", () => {
 /* ---- Finding A: WebSearchRenderer — null entry in results array --------- */
 
 describe("WebSearchRenderer — null/undefined entries in results array", () => {
+  test("renders a completed open-page action as settled page activity", async () => {
+    const item = toolItem({
+      name: "web_search_call",
+      raw: {
+        type: "hosted_tool_call",
+        status: "completed",
+        providerData: {
+          action: { type: "open_page", url: "https://openai.com/research" },
+        },
+      },
+      status: "complete",
+    });
+    const Renderer = defaultToolRegistry.resolve(item);
+    const r = await renderComponent(<Renderer item={item} />);
+    await flush();
+
+    const text = r.container.textContent ?? "";
+    expect(text).toContain("Opened web page");
+    expect(text).toContain("https://openai.com/research");
+    expect(text).not.toContain("query unavailable");
+
+    await r.unmount();
+  });
+
   test("renders without throwing when results contains a null entry", async () => {
     // Simulate a host-enriched output where one entry is null (untrusted data).
     const item = toolItem({

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -782,6 +782,56 @@ describe("buildTimeline", () => {
     expect(second.output).toBe("resource {}");
   });
 
+  test("a completed hosted web-search item settles without a separate output event", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.toolCall.created", {
+        id: "ws-1",
+        name: "web_search_call",
+        raw: {
+          type: "hosted_tool_call",
+          status: "completed",
+          providerData: {
+            action: { type: "search", query: "OpenAI official website" },
+          },
+        },
+      }),
+    ]);
+
+    expect((items[0] as ToolCallItem).status).toBe("complete");
+  });
+
+  test("completed message ordering follows intervening hosted search activity", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.message.delta", { text: "Answer" }),
+      event("agent.toolCall.created", {
+        id: "ws-1",
+        name: "web_search_call",
+        raw: {
+          type: "hosted_tool_call",
+          status: "completed",
+          providerData: { action: { type: "search", query: "source" } },
+        },
+      }),
+      event("agent.message.completed", { text: "Answer with sources." }),
+    ]);
+
+    expect(items.map((item) => item.kind)).toEqual(["tool-call", "agent-message"]);
+    expect((items[1] as AgentMessageItem).text).toBe("Answer with sources.");
+  });
+
+  test("removes unresolved private citation handles from timeline text", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.message.completed", {
+        text: "OpenAI docs. citeturn1search3turn2view0",
+      }),
+    ]);
+
+    expect((items[0] as AgentMessageItem).text).toBe("OpenAI docs.");
+  });
+
   test("session_create becomes a worker item with prompt and spawned session id from MCP output", () => {
     reset();
     const worker = {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -32,7 +32,7 @@ for await (const event of client.streamEvents(workspaceId, session.id)) {
 }
 ```
 
-Omit `firstPartyMcpTools` for the minimal self-management default. An explicit
+Omit `firstPartyMcpTools` for the complete OpenGeni tool catalog. An explicit
 `[]` exposes no broad first-party tools; attached resources and separately
 selected `files`/`docs` MCP servers are unaffected.
 
@@ -210,9 +210,12 @@ await client.sendApprovalDecision(workspaceId, sessionId, { approvalId, decision
 ## Session tool policy and native web search
 
 Omitting `tools` when creating a top-level session selects the current
-workspace-default capability policy. Supported Responses providers can then
-attach their native bounded web-search tool without requiring a sandbox.
-Passing `tools`, including `[]`, is an intentional fixed narrowing.
+workspace-default capability policy, including the built-in `files` server.
+Passing `tools`, including `[]`, is an intentional fixed narrowing and can
+therefore disable file-download access for that session. OpenGeni's own web UI
+keeps `files` enabled as a hidden default, while API and embedded clients retain
+exact control over the explicit list. Supported Responses providers attach
+their native bounded web-search tool independently of this MCP policy.
 
 Existing explicit sessions are not widened when a new default capability is
 introduced. Opt one in explicitly with the current optimistic-concurrency


### PR DESCRIPTION
## Summary
- replace the duplicate/per-turn tool-policy semantics with one truthful session-wide selection
- keep runtime-native web search available; default configured MCP servers on while preserving exact explicit API allow-lists
- hide OpenGeni carrier and default-on Files infrastructure from visible picker counts without coupling Files to Document Search
- settle hosted web searches from their provider-native terminal status, render search/open/find actions correctly, and keep completed searches before the answer
- remove unresolved private citation handles only from the human timeline while preserving canonical model history

## Verification
- web: 118 focused tests + typecheck
- react: 154 timeline/renderer tests + typecheck
- core: 8 policy tests + typecheck
- worker: 14 overlay/default tests + typecheck
- production web build + bundle budgets