### PR TITLE
chore(release): bump chart to 0.22.22

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.21
-appVersion: "0.22.21"
+version: 0.22.22
+appVersion: "0.22.22"


### PR DESCRIPTION
Advance the immutable product release identity after candidate admission correctly found that 0.22.21 is already occupied. No runtime behavior changes.