### PR TITLE
Complete unified tool-policy clean cutover

### DIFF
--- a/apps/api/test/delegated-service-initiator.test.ts
+++ b/apps/api/test/delegated-service-initiator.test.ts
@@ -148,7 +148,6 @@ describe("delegated service initiator API", () => {
           payload: {
             text: "Run the follow-up check",
             resources: [],
-            tools: [],
           },
         }),
       },
@@ -180,7 +179,6 @@ describe("delegated service initiator API", () => {
     const steerBody = JSON.stringify({
       text: "Replace queued work with the urgent service instruction",
       resources: [],
-      tools: [],
       clientEventId: steerClientEventId,
     });
     const steerResponse = await app.request(

--- a/apps/api/test/first-party-mcp-tool-policy.test.ts
+++ b/apps/api/test/first-party-mcp-tool-policy.test.ts
@@ -61,8 +61,8 @@ function registeredToolNames(server: unknown): string[] {
 }
 
 describe("first-party MCP tool visibility policy", () => {
-  test("omission exposes only the intentional minimal default", () => {
-    const server = buildOpenGeniMcpServer(deps(), grant([...DEFAULT_FIRST_PARTY_MCP_PERMISSIONS]), {
+  test("omission selects the complete catalog when the grant authorizes every tool", () => {
+    const server = buildOpenGeniMcpServer(deps(), grant([...Permission.options]), {
       workspaceMemoryEnabled: true,
     });
 

--- a/apps/api/test/rig-session-binding.test.ts
+++ b/apps/api/test/rig-session-binding.test.ts
@@ -347,8 +347,15 @@ describe("M3 rig binding: rig-aware shared-sandbox gate", () => {
     // A's group directly. Today the create gate must compare the joiner against
     // ALL members, not just parent A.
     await admin`
-      insert into sessions (account_id, workspace_id, initial_message, rig_id, rig_version_id, sandbox_group_id, model, sandbox_backend)
-      values (${accountId}, ${workspaceId}, 'legacy mixed-rig member', ${rigB.rigId}, ${rigB.activeVersionId}, ${a.sandboxGroupId}, 'gpt-test', 'modal')`;
+      insert into sessions (
+        account_id, workspace_id, initial_message, rig_id, rig_version_id,
+        sandbox_group_id, model, sandbox_backend, tool_policy
+      )
+      values (
+        ${accountId}, ${workspaceId}, 'legacy mixed-rig member', ${rigB.rigId},
+        ${rigB.activeVersionId}, ${a.sandboxGroupId}, 'gpt-test', 'modal',
+        jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
+      )`;
     await expect(
       createSessionForRequest(deps(bus), grant(accountId, workspaceId, a.id), workspaceId, {
         initialMessage: "joiner matching parent only",

--- a/apps/api/test/rigs-routes.test.ts
+++ b/apps/api/test/rigs-routes.test.ts
@@ -210,8 +210,15 @@ describe("rig route permission matrix", () => {
     const rig = await created.json();
 
     const [session] = await shared!.admin<{ id: string }[]>`
-      insert into sessions (account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id, rig_id)
-      values (${ws.accountId}, ${ws.workspaceId}, 'hi', 'gpt-5.6-sol', 'none', gen_random_uuid(), ${rig.id})
+      insert into sessions (
+        account_id, workspace_id, initial_message, model, sandbox_backend,
+        sandbox_group_id, rig_id, tool_policy
+      )
+      values (
+        ${ws.accountId}, ${ws.workspaceId}, 'hi', 'gpt-5.6-sol', 'none',
+        gen_random_uuid(), ${rig.id},
+        jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
+      )
       returning id`;
 
     const blocked = await app().request(`${base}/${rig.id}`, { method: "DELETE", headers: manage });

--- a/apps/api/test/sandbox-shared-and-viewer.test.ts
+++ b/apps/api/test/sandbox-shared-and-viewer.test.ts
@@ -752,8 +752,15 @@ describe("P1.4 shared-sandbox create resolution (real createSessionForRequest + 
     // Simulate a LEGACY env-blind share: force an env-carrying member row into
     // A's group directly (the env-aware check would refuse this today).
     await admin`
-      insert into sessions (account_id, workspace_id, initial_message, variable_set_id, sandbox_group_id, model, sandbox_backend)
-      values (${accountId}, ${workspaceId}, 'legacy env-blind member', ${environmentId}, ${a.sandboxGroupId}, 'gpt-test', 'modal')`;
+      insert into sessions (
+        account_id, workspace_id, initial_message, variable_set_id,
+        sandbox_group_id, model, sandbox_backend, tool_policy
+      )
+      values (
+        ${accountId}, ${workspaceId}, 'legacy env-blind member', ${environmentId},
+        ${a.sandboxGroupId}, 'gpt-test', 'modal',
+        jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
+      )`;
     const g = {
       ...grant(accountId, workspaceId),
       permissions: [

--- a/packages/db/drizzle/0136_unified_session_tool_policy.sql
+++ b/packages/db/drizzle/0136_unified_session_tool_policy.sql
@@ -1,4 +1,4 @@
--- deployment-mode: downtime
+-- deployment-mode: maintenance
 -- One durable session-level tool policy. OpenGeni-native tools are selected by
 -- default, and historical NULL/legacy shapes are eliminated before the new
 -- API starts.

--- a/packages/db/test/codex-capacity-waiters.test.ts
+++ b/packages/db/test/codex-capacity-waiters.test.ts
@@ -131,10 +131,11 @@ async function seedScenario(
   await admin`
     insert into sessions (
       id, account_id, workspace_id, initial_message, model,
-      sandbox_backend, sandbox_group_id, status, temporal_workflow_id
+      sandbox_backend, sandbox_group_id, status, temporal_workflow_id, tool_policy
     ) values (
       ${sessionId}, ${ws.accountId}, ${ws.workspaceId}, 'capacity test',
-      'codex/gpt-5.6-sol', 'modal', ${sessionId}, 'running', ${workflowId}
+      'codex/gpt-5.6-sol', 'modal', ${sessionId}, 'running', ${workflowId},
+      jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
     )`;
   await admin.begin(async (tx) => {
     await tx`

--- a/packages/db/test/codex-credential-leases.test.ts
+++ b/packages/db/test/codex-credential-leases.test.ts
@@ -99,10 +99,11 @@ async function seedTurn(ws: Workspace, position = 1): Promise<string> {
   await admin`
     insert into sessions (
       id, account_id, workspace_id, initial_message, model,
-      sandbox_backend, sandbox_group_id, status
+      sandbox_backend, sandbox_group_id, status, tool_policy
     ) values (
       ${sessionId}, ${ws.accountId}, ${ws.workspaceId}, 'test',
-      'codex/gpt-5.6-sol', 'modal', ${sessionId}, 'running'
+      'codex/gpt-5.6-sol', 'modal', ${sessionId}, 'running',
+      jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
     )`;
   await admin.begin(async (transaction) => {
     await transaction`

--- a/packages/db/test/codex-pin-source.test.ts
+++ b/packages/db/test/codex-pin-source.test.ts
@@ -36,8 +36,14 @@ async function freshWorkspace(): Promise<{ accountId: string; workspaceId: strin
 async function seedSession(ws: { accountId: string; workspaceId: string }): Promise<string> {
   const id = crypto.randomUUID();
   await admin`
-    insert into sessions (id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id)
-    values (${id}, ${ws.accountId}, ${ws.workspaceId}, 'go', 'gpt', 'modal', ${id})`;
+    insert into sessions (
+      id, account_id, workspace_id, initial_message, model,
+      sandbox_backend, sandbox_group_id, tool_policy
+    )
+    values (
+      ${id}, ${ws.accountId}, ${ws.workspaceId}, 'go', 'gpt', 'modal', ${id},
+      jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
+    )`;
   return id;
 }
 

--- a/packages/db/test/codex-subscription-overview.test.ts
+++ b/packages/db/test/codex-subscription-overview.test.ts
@@ -122,10 +122,11 @@ async function seedCapacityWaiter(ws: Workspace): Promise<{
     await tx`
       insert into sessions (
         id, account_id, workspace_id, initial_message, model,
-        sandbox_backend, sandbox_group_id, status, temporal_workflow_id
+        sandbox_backend, sandbox_group_id, status, temporal_workflow_id, tool_policy
       ) values (
         ${sessionId}, ${ws.accountId}, ${ws.workspaceId}, 'Codex quota capacity wake',
-        'codex/gpt-5.6-sol', 'modal', ${sessionId}, 'idle', ${workflowId}
+        'codex/gpt-5.6-sol', 'modal', ${sessionId}, 'idle', ${workflowId},
+        jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
       )`;
     await tx`
       insert into session_turns (

--- a/packages/db/test/migration-0020.test.ts
+++ b/packages/db/test/migration-0020.test.ts
@@ -116,8 +116,15 @@ describe("migration 0020 (session_recordings)", () => {
       // since 0018 — supply both from one uuid.
       const sessionId = (
         await sql<{ id: string }[]>`
-        INSERT INTO "sessions" ("id", "account_id", "workspace_id", "status", "sandbox_backend", "initial_message", "model", "sandbox_group_id")
-        VALUES (gen_random_uuid(), ${accountId}, ${workspaceId}, 'idle', 'modal', 'hi', 'gpt-5', gen_random_uuid()) RETURNING "id"`
+        INSERT INTO "sessions" (
+          "id", "account_id", "workspace_id", "status", "sandbox_backend",
+          "initial_message", "model", "sandbox_group_id", "tool_policy"
+        )
+        VALUES (
+          gen_random_uuid(), ${accountId}, ${workspaceId}, 'idle', 'modal',
+          'hi', 'gpt-5', gen_random_uuid(),
+          jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
+        ) RETURNING "id"`
       )[0]!.id;
 
       // --- The CHECK constraints reject a bad state/mode/codec. Each negative

--- a/packages/db/test/migration-0117-sandbox-recovery-generations.test.ts
+++ b/packages/db/test/migration-0117-sandbox-recovery-generations.test.ts
@@ -521,10 +521,11 @@ async function seedScope(admin: postgres.Sql, label: string, schema?: string): P
   await admin`
     insert into sessions (
       id, account_id, workspace_id, initial_message, model,
-      sandbox_backend, sandbox_group_id
+      sandbox_backend, sandbox_group_id, tool_policy
     ) values (
       ${sessionId}, ${account!.id}, ${workspace!.id}, 'migration test',
-      'scripted-model', 'modal', ${sessionId}
+      'scripted-model', 'modal', ${sessionId},
+      jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
     )`;
   return { accountId: account!.id, workspaceId: workspace!.id, sessionId };
 }

--- a/packages/db/test/reactive-rotation-boundedness.test.ts
+++ b/packages/db/test/reactive-rotation-boundedness.test.ts
@@ -46,8 +46,14 @@ async function freshWorkspace(): Promise<{ accountId: string; workspaceId: strin
 async function seedSession(ws: { accountId: string; workspaceId: string }): Promise<string> {
   const id = crypto.randomUUID();
   await admin`
-    insert into sessions (id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id)
-    values (${id}, ${ws.accountId}, ${ws.workspaceId}, 'go', 'gpt', 'modal', ${id})`;
+    insert into sessions (
+      id, account_id, workspace_id, initial_message, model,
+      sandbox_backend, sandbox_group_id, tool_policy
+    )
+    values (
+      ${id}, ${ws.accountId}, ${ws.workspaceId}, 'go', 'gpt', 'modal', ${id},
+      jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
+    )`;
   return id;
 }
 

--- a/packages/db/test/rigs.test.ts
+++ b/packages/db/test/rigs.test.ts
@@ -66,8 +66,15 @@ async function insertSessionForRig(
   rigId: string,
 ): Promise<string> {
   const [row] = await shared!.admin<{ id: string }[]>`
-    insert into sessions (account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id, rig_id)
-    values (${ws.accountId}, ${ws.workspaceId}, 'hello', 'gpt-5.6-sol', 'none', gen_random_uuid(), ${rigId})
+    insert into sessions (
+      account_id, workspace_id, initial_message, model, sandbox_backend,
+      sandbox_group_id, rig_id, tool_policy
+    )
+    values (
+      ${ws.accountId}, ${ws.workspaceId}, 'hello', 'gpt-5.6-sol', 'none',
+      gen_random_uuid(), ${rigId},
+      jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
+    )
     returning id`;
   return row!.id;
 }

--- a/packages/db/test/schema-isolation.test.ts
+++ b/packages/db/test/schema-isolation.test.ts
@@ -185,9 +185,12 @@ describe("embedded dedicated-schema isolation", () => {
       const [session] = await sql<{ id: string }[]>`
         WITH ids AS (SELECT gen_random_uuid() AS id)
         INSERT INTO opengeni.sessions (
-          id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id
+          id, account_id, workspace_id, initial_message, model, sandbox_backend,
+          sandbox_group_id, tool_policy
         )
-        SELECT id, ${account!.id}, ${workspace!.id}, 'hello', 'gpt-4.1', 'none', id FROM ids
+        SELECT id, ${account!.id}, ${workspace!.id}, 'hello', 'gpt-4.1', 'none', id,
+          jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
+        FROM ids
         RETURNING id`;
       await sql.unsafe(`
         CREATE TABLE opengeni.default_privilege_probe (

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -701,11 +701,11 @@ describe("clean session control plane", () => {
     await shared.admin`
       insert into sessions (
         account_id, workspace_id, initial_message, resources, tools, metadata,
-        model, sandbox_backend, sandbox_group_id, created_at, updated_at
+        model, sandbox_backend, sandbox_group_id, tool_policy, created_at, updated_at
       )
       select ${grant.accountId}, ${grant.workspaceId!}, 'plan-' || n::text,
         '[]'::jsonb, '[]'::jsonb, '{}'::jsonb, 'scripted-model', 'none',
-        gen_random_uuid(),
+        gen_random_uuid(), jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null),
         statement_timestamp() - make_interval(secs => n),
         statement_timestamp() - make_interval(secs => 5001 - n)
       from generate_series(1, 5000) as generated(n)`;

--- a/packages/db/test/session-depth-policy.test.ts
+++ b/packages/db/test/session-depth-policy.test.ts
@@ -174,10 +174,11 @@ describe("nested-agent depth database admission", () => {
       const rows = await sql<{ id: string }[]>`
         insert into sessions (
           account_id, workspace_id, initial_message, model, sandbox_backend,
-          sandbox_group_id, create_idempotency_key
+          sandbox_group_id, create_idempotency_key, tool_policy
         ) values (
           ${workspace.accountId}, ${workspace.workspaceId}, 'old writer',
-          'depth-policy-test', 'none', gen_random_uuid(), ${key}
+          'depth-policy-test', 'none', gen_random_uuid(), ${key},
+          jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
         )
         returning id`;
       await sql`select pg_sleep(0.1)`;
@@ -256,10 +257,11 @@ describe("nested-agent depth database admission", () => {
     const sessionRows = await admin<{ id: string }[]>`
       insert into sessions (
         account_id, workspace_id, initial_message, model, sandbox_backend,
-        sandbox_group_id, create_idempotency_key
+        sandbox_group_id, create_idempotency_key, tool_policy
       ) values (
         ${workspace.accountId}, ${workspace.workspaceId}, 'old success',
-        'depth-policy-test', 'none', gen_random_uuid(), ${key}
+        'depth-policy-test', 'none', gen_random_uuid(), ${key},
+        jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
       )
       returning id`;
     expect(sessionRows).toHaveLength(0);
@@ -289,10 +291,14 @@ describe("nested-agent depth database admission", () => {
     const duplicateRows = await admin<{ id: string }[]>`
       insert into sessions (
         account_id, workspace_id, initial_message, model, sandbox_backend,
-        sandbox_group_id, parent_session_id, create_idempotency_key
+        sandbox_group_id, parent_session_id, create_idempotency_key, tool_policy
       ) values (
         ${workspace.accountId}, ${workspace.workspaceId}, 'duplicate',
-        'depth-policy-test', 'none', gen_random_uuid(), ${deepestParent.id}, ${key}
+        'depth-policy-test', 'none', gen_random_uuid(), ${deepestParent.id}, ${key},
+        jsonb_build_object(
+          'mode', 'explicit',
+          'inheritedFromSessionId', ${deepestParent.id}::uuid
+        )
       )
       returning id`;
     expect(duplicateRows).toHaveLength(0);

--- a/packages/db/test/session-event-lock-order.test.ts
+++ b/packages/db/test/session-event-lock-order.test.ts
@@ -109,11 +109,15 @@ async function seedRunningSession(
     insert into sessions (
       id, account_id, workspace_id, initial_message, model,
       sandbox_backend, sandbox_group_id, status, temporal_workflow_id,
-      parent_session_id
+      parent_session_id, tool_policy
     ) values (
       ${sessionId}, ${owner.accountId}, ${owner.workspaceId}, 'event-ordering invariant race',
       'codex/gpt-5.6-sol', 'modal', ${sandboxGroupId}, 'running', ${workflowId},
-      ${options.parentSessionId ?? null}
+      ${options.parentSessionId ?? null},
+      jsonb_build_object(
+        'mode', 'explicit',
+        'inheritedFromSessionId', ${options.parentSessionId ?? null}::uuid
+      )
     )
   `;
   await admin.begin(async (tx) => {
@@ -163,11 +167,15 @@ async function seedIdleChild(
     insert into sessions (
       id, account_id, workspace_id, initial_message, model,
       sandbox_backend, sandbox_group_id, status, temporal_workflow_id,
-      parent_session_id
+      parent_session_id, tool_policy
     ) values (
       ${sessionId}, ${workspace.accountId}, ${workspace.workspaceId}, 'event-ordering invariant idle child',
       'codex/gpt-5.6-sol', 'modal', ${sessionId}, 'running', ${`session-${sessionId}`},
-      ${parentSessionId}
+      ${parentSessionId},
+      jsonb_build_object(
+        'mode', 'explicit',
+        'inheritedFromSessionId', ${parentSessionId}::uuid
+      )
     )
   `;
   return { ...workspace, sessionId };
@@ -192,11 +200,12 @@ async function seedSandboxGroupMember(
   await admin`
     insert into sessions (
       id, account_id, workspace_id, initial_message, model,
-      sandbox_backend, sandbox_group_id, status, temporal_workflow_id
+      sandbox_backend, sandbox_group_id, status, temporal_workflow_id, tool_policy
     ) values (
       ${sessionId}, ${fixture.accountId}, ${fixture.workspaceId}, 'event-ordering invariant group join',
       'codex/gpt-5.6-sol', 'modal', ${fixture.sandboxGroupId}, 'idle',
-      ${`session-${sessionId}`}
+      ${`session-${sessionId}`},
+      jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
     )
   `;
   return sessionId;

--- a/packages/db/test/session-pins.test.ts
+++ b/packages/db/test/session-pins.test.ts
@@ -237,11 +237,13 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
     await admin`
       insert into sessions (
         id, account_id, workspace_id, status, initial_message, model,
-        sandbox_backend, sandbox_group_id, parent_session_id, temporal_workflow_id
+        sandbox_backend, sandbox_group_id, parent_session_id, temporal_workflow_id,
+        tool_policy
       )
       select
         node.id, ${workspace.accountId}, ${workspace.workspaceId}, 'running', node.message,
-        'test-model', 'none', node.id, node."parentId", 'tree-deep-' || node.id::text
+        'test-model', 'none', node.id, node."parentId", 'tree-deep-' || node.id::text,
+        jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', node."parentId")
       from jsonb_to_recordset(${admin.json(deepRows)}::jsonb)
         as node(id uuid, "parentId" uuid, message text)`;
 
@@ -252,12 +254,17 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       )
       insert into sessions (
         id, account_id, workspace_id, status, initial_message, model,
-        sandbox_backend, sandbox_group_id, parent_session_id, temporal_workflow_id
+        sandbox_backend, sandbox_group_id, parent_session_id, temporal_workflow_id,
+        tool_policy
       )
       select
         id, ${workspace.accountId}, ${workspace.workspaceId}, 'idle',
         'wide-' || ordinal::text, 'test-model', 'none', id, ${wideRoot.id},
-        'tree-wide-' || id::text
+        'tree-wide-' || id::text,
+        jsonb_build_object(
+          'mode', 'explicit',
+          'inheritedFromSessionId', ${wideRoot.id}::uuid
+        )
       from nodes`;
 
     for (const sessionId of [deepRoot.id, deepIds[0]!, wideRoot.id]) {
@@ -319,12 +326,13 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       ), inserted as (
         insert into sessions (
           id, account_id, workspace_id, status, initial_message, model,
-          sandbox_backend, sandbox_group_id, temporal_workflow_id
+          sandbox_backend, sandbox_group_id, temporal_workflow_id, tool_policy
         )
         select
           id, ${workspace.accountId}, ${workspace.workspaceId}, 'idle',
           'pinned-root-' || ordinal::text, 'test-model', 'none', id,
-          'bounded-pinned-root-' || id::text
+          'bounded-pinned-root-' || id::text,
+          jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
         from nodes
         returning id
       )
@@ -1437,11 +1445,13 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
     await grantMember(workspace, subjectId);
     await admin`
       insert into sessions (
-        id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id
+        id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id,
+        tool_policy
       )
       select generated.id, ${workspace.accountId}, ${workspace.workspaceId},
         'bounded concurrent session ' || generated.ordinality,
-        'test-model', 'none', generated.id
+        'test-model', 'none', generated.id,
+        jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
       from (
         select gen_random_uuid() as id, ordinality
         from generate_series(1, 128) with ordinality
@@ -1475,11 +1485,13 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
     await grantMember(oversized, oversizedSubject);
     await admin`
       insert into sessions (
-        id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id
+        id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id,
+        tool_policy
       )
       select generated.id, ${oversized.accountId}, ${oversized.workspaceId},
         'oversized session ' || generated.ordinality,
-        'test-model', 'none', generated.id
+        'test-model', 'none', generated.id,
+        jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
       from (
         select gen_random_uuid() as id, ordinality
         from generate_series(1, ${SESSION_LIST_SNAPSHOT_MAX_IDS + 1}) with ordinality
@@ -1505,11 +1517,13 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
     await grantMember(quota, retainedSubject);
     await admin`
       insert into sessions (
-        id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id
+        id, account_id, workspace_id, initial_message, model, sandbox_backend, sandbox_group_id,
+        tool_policy
       )
       select generated.id, ${quota.accountId}, ${quota.workspaceId},
         'snapshot query-' || lpad(((generated.ordinality - 1) / 2)::text, 2, '0'),
-        'test-model', 'none', generated.id
+        'test-model', 'none', generated.id,
+        jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
       from (
         select gen_random_uuid() as id, ordinality
         from generate_series(1, 68) with ordinality

--- a/packages/db/test/session-sandbox-os.test.ts
+++ b/packages/db/test/session-sandbox-os.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Session, SessionTurn } from "@opengeni/contracts";
+import { DEFAULT_FIRST_PARTY_MCP_TOOLS, Session, SessionTurn } from "@opengeni/contracts";
 
 // Pure (no-postgres) spec for the 0018 read-side shape: the contract Session
 // carries sandboxOs (enum, default linux) + sandboxGroupId (uuid), and
@@ -45,7 +45,9 @@ function baseSession() {
     activeEpoch: 0,
     environmentId: null,
     firstPartyMcpPermissions: null,
-    firstPartyMcpTools: null,
+    firstPartyMcpTools: [...DEFAULT_FIRST_PARTY_MCP_TOOLS],
+    toolPolicy: { mode: "explicit" as const, inheritedFromSessionId: null },
+    toolPolicyVersion: 1,
     parentSessionId: null,
     createIdempotencyKey: null,
     temporalWorkflowId: null,

--- a/scripts/bench-session-control.ts
+++ b/scripts/bench-session-control.ts
@@ -50,12 +50,13 @@ try {
     insert into sessions (
       id, account_id, workspace_id, status, initial_message, title,
       resources, tools, metadata, model, sandbox_backend, sandbox_group_id,
-      temporal_workflow_id
+      temporal_workflow_id, tool_policy
     ) values (
       ${rootId}::uuid, ${accountId}::uuid, ${workspaceId}::uuid, 'idle',
       'benchmark root', 'Benchmark root', '[]'::jsonb, '[]'::jsonb,
       jsonb_build_object('bench_index', 0), 'benchmark-model', 'none',
-      ${rootId}::uuid, ${`session-${rootId}`}
+      ${rootId}::uuid, ${`session-${rootId}`},
+      jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
     )
   `;
   if (sessionCount > 1) {
@@ -63,7 +64,7 @@ try {
       insert into sessions (
         id, account_id, workspace_id, status, initial_message, title,
         resources, tools, metadata, model, sandbox_backend, sandbox_group_id,
-        parent_session_id, temporal_workflow_id
+        parent_session_id, temporal_workflow_id, tool_policy
       )
       select
         md5(${workspaceId} || ':' || generated.i::text)::uuid,
@@ -84,7 +85,17 @@ try {
             then md5(${workspaceId} || ':' || (generated.i - 1)::text)::uuid
           else md5(${workspaceId} || ':' || (1 + ((generated.i - ${depth} - 1) % ${depth}))::text)::uuid
         end,
-        'session-' || md5(${workspaceId} || ':' || generated.i::text)::uuid::text
+        'session-' || md5(${workspaceId} || ':' || generated.i::text)::uuid::text,
+        jsonb_build_object(
+          'mode', 'explicit',
+          'inheritedFromSessionId',
+          case
+            when generated.i = 1 then ${rootId}::uuid
+            when generated.i <= ${depth}
+              then md5(${workspaceId} || ':' || (generated.i - 1)::text)::uuid
+            else md5(${workspaceId} || ':' || (1 + ((generated.i - ${depth} - 1) % ${depth}))::text)::uuid
+          end
+        )
       from generate_series(1, ${sessionCount - 1}) as generated(i)
     `;
   }

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -149,12 +149,13 @@ describe("release schema contract", () => {
         (migrations.has("0132_connection_subject_isolation.sql") ? 1 : 0) +
         (migrations.has("0133_session_skills.sql") ? 1 : 0) +
         (migrations.has("0134_session_first_party_mcp_tools.sql") ? 1 : 0) +
-        (migrations.has("0135_durable_machine_input_batches.sql") ? 1 : 0),
+        (migrations.has("0135_durable_machine_input_batches.sql") ? 1 : 0) +
+        (migrations.has("0136_unified_session_tool_policy.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(
-      "495f69d6d8cb46e94b632161b4a6721e491a764fb869e511b1c9f1183666b036",
+      "a422f332b21e3478afb9d4ff7c78cfcff6c1b9a0d08b407bd7ca584a9e329824",
     );
-    expect(contract.latestMigration).toBe("0135_durable_machine_input_batches.sql");
+    expect(contract.latestMigration).toBe("0136_unified_session_tool_policy.sql");
     expect(migrations.get("0128_github_installation_authority.sql")).toMatchObject({
       sha256: "365793b2a204a70e214adb90298b522acbb6dcfae22a46681a58f41a6938e6f0",
       deploymentMode: "rolling",


### PR DESCRIPTION
## Summary
- classify the unified tool-policy migration as maintenance and advance the release schema contract
- migrate every current raw session writer/fixture to provide the canonical tool policy explicitly
- remove stale one-turn tool overrides from API fixtures and align complete-catalog defaults

## Verification
- all 88 tests that failed canonical main CI were rerun in focused groups after repair
- real-PostgreSQL migration, RLS, concurrency, queue, capacity, pin, and event-ordering suites pass
- @opengeni/db typecheck: /run/current-system/sw/bin/bash: warning: setlocale: LC_ALL: cannot change locale (C.UTF-8): No such file or directory
@opengeni/db typecheck: Exited with code 0
- Checking formatting...

All matched files use the correct format.
Finished in 306ms on 1134 files using 20 threads.

No compatibility default or legacy payload path is restored.