### PR TITLE
Bump production release chart to 0.22.23

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.22
-appVersion: "0.22.22"
+version: 0.22.23
+appVersion: "0.22.23"


### PR DESCRIPTION
Advance the immutable Helm/application release version after 0.22.22 was consumed by the superseded candidate.