### PR TITLE
Assert complete default OpenGeni tool catalog

### DIFF
--- a/packages/core/test/first-party-mcp-tools.test.ts
+++ b/packages/core/test/first-party-mcp-tools.test.ts
@@ -3,8 +3,10 @@ import { DEFAULT_FIRST_PARTY_MCP_TOOLS } from "@opengeni/contracts";
 import { resolveFirstPartyMcpToolsForCreate } from "../src/domain/sessions";
 
 describe("first-party MCP tool selection at session creation", () => {
-  test("top-level omission stores the minimal-default sentinel", () => {
-    expect(resolveFirstPartyMcpToolsForCreate(undefined, undefined)).toBeNull();
+  test("top-level omission stores the complete default catalog", () => {
+    expect(resolveFirstPartyMcpToolsForCreate(undefined, undefined)).toEqual([
+      ...DEFAULT_FIRST_PARTY_MCP_TOOLS,
+    ]);
   });
 
   test("explicit empty remains authoritative", () => {


### PR DESCRIPTION
Replace the final stale minimal-sentinel assertion with the clean-cutover contract: omitted top-level selection persists the complete default catalog.