### PR TITLE
Advance production release chart to 0.22.24

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.23
-appVersion: "0.22.23"
+version: 0.22.24
+appVersion: "0.22.24"


### PR DESCRIPTION
Create a fresh reviewed immutable release identity on top of the concurrently merged Slack intent fix; 0.22.23 was abandoned before an immutable receipt.