### PR TITLE
fix(web): refresh GitHub after history restore

### DIFF
--- a/apps/web/src/lib/use-github-history-refresh.test.tsx
+++ b/apps/web/src/lib/use-github-history-refresh.test.tsx
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { actRun, registerDom, renderHook } from "../../../../packages/react/test/render-hook";
+import { useGitHubHistoryRefresh } from "./use-github-history-refresh";
+
+registerDom();
+afterEach(() => document.body.replaceChildren());
+
+function pageShow(persisted: boolean): Event {
+  const event = new Event("pageshow");
+  Object.defineProperty(event, "persisted", { value: persisted });
+  return event;
+}
+
+describe("useGitHubHistoryRefresh", () => {
+  test("refreshes GitHub state when browser history restores a workspace page", async () => {
+    const refreshGitHub = mock(async () => {});
+    const hook = await renderHook(
+      ({ workspaceId }: { workspaceId: string }) =>
+        useGitHubHistoryRefresh(workspaceId, true, refreshGitHub),
+      { workspaceId: "workspace-1" },
+    );
+
+    await actRun(() => window.dispatchEvent(pageShow(true)));
+
+    expect(refreshGitHub).toHaveBeenCalledTimes(1);
+    expect(refreshGitHub).toHaveBeenCalledWith("workspace-1");
+    await hook.unmount();
+  });
+
+  test("ignores ordinary page loads and disabled workspace shells", async () => {
+    const refreshGitHub = mock(async () => {});
+    const hook = await renderHook(
+      () => useGitHubHistoryRefresh("workspace-1", false, refreshGitHub),
+      undefined,
+    );
+
+    await actRun(() => window.dispatchEvent(pageShow(false)));
+    await actRun(() => window.dispatchEvent(pageShow(true)));
+
+    expect(refreshGitHub).not.toHaveBeenCalled();
+    await hook.unmount();
+  });
+});

--- a/apps/web/src/lib/use-github-history-refresh.ts
+++ b/apps/web/src/lib/use-github-history-refresh.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+
+type RefreshGitHub = (
+  workspaceId: string,
+  signal?: AbortSignal,
+  options?: { sync?: boolean },
+) => Promise<void>;
+
+export function useGitHubHistoryRefresh(
+  workspaceId: string,
+  enabled: boolean,
+  refreshGitHub: RefreshGitHub,
+): void {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const onPageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        void refreshGitHub(workspaceId);
+      }
+    };
+    window.addEventListener("pageshow", onPageShow);
+    return () => window.removeEventListener("pageshow", onPageShow);
+  }, [enabled, refreshGitHub, workspaceId]);
+}

--- a/apps/web/src/routes/workspace.tsx
+++ b/apps/web/src/routes/workspace.tsx
@@ -11,6 +11,7 @@ import { RailProvider } from "@/components/rail/rail-context";
 import { RailShell } from "@/components/rail/rail-shell";
 import { Button } from "@/components/ui/button";
 import { useAppContext } from "@/context";
+import { useGitHubHistoryRefresh } from "@/lib/use-github-history-refresh";
 import { isAbortError } from "@/lib/session-tools";
 
 export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
@@ -28,6 +29,7 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
     refreshWorkspaceMcpServers,
   } = context;
   const previousWorkspaceId = useRef<string | null>(null);
+  useGitHubHistoryRefresh(workspaceId, activeWorkspaceId !== null, refreshGitHub);
 
   useEffect(() => {
     if (!activeWorkspaceId) {


### PR DESCRIPTION
Refresh authoritative GitHub binding state when a workspace page is restored from the browser back/forward cache. This prevents a completed OAuth connection from continuing to display the pre-connect `unverified` snapshot.\n\nVerified: focused regression test; all 23 typecheck projects; lint; format check.