### PR TITLE
fix(ci): admit immutable heads across moving main

### DIFF
--- a/.github/workflows/seal-release-head.yml
+++ b/.github/workflows/seal-release-head.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
       reviewed_base_sha:
-        description: Exact current main SHA admitted by the base-owned source verifier.
+        description: Exact current main SHA owning the trusted sealing workflow; it may postdate the PR event base.
         required: true
         type: string
       reviewed_head_sha:

--- a/.github/workflows/source-admission.yml
+++ b/.github/workflows/source-admission.yml
@@ -2,9 +2,10 @@ name: Source Admission
 
 # This required PR check executes only base-owned workflow/helper bytes. It never
 # checks out, executes, or grants credentials to candidate content. The helper
-# reads provider metadata and Git objects, reconciles the provider file
-# projection with a direct tree-object manifest, and fences both refs with
-# terminal readbacks.
+# reads provider metadata and Git objects, reconciles the immutable candidate
+# against its provider merge-base tree, and fences the head plus canonical
+# base-owned workflow ancestry without requiring continuously moving main to
+# equal the pull-request event base.
 on:
   pull_request_target:
     branches:
@@ -26,8 +27,8 @@ jobs:
     timeout-minutes: 5
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      OPENGENI_SOURCE_ADMISSION_ACTION: verify_current_base_head
-      ADMISSION_HELPER_SHA256: 87de508b0c10151c052d2a57f846a342461c18b1a3dee5382d36e058292ecda7
+      OPENGENI_SOURCE_ADMISSION_ACTION: verify_immutable_pr_head
+      ADMISSION_HELPER_SHA256: f9d769efe7e36b68b5c20d874ea4d3c6f5a0b92bb11d535c7d3cd0d0debe6370
     steps:
       - name: Execute the exact base-owned admission verifier
         shell: bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -578,8 +578,8 @@ object with the top-level keys sorted in ascending ASCII order:
 `id` is the live positive release ID and `publishedAt` is the provider
 `published_at` value normalized through `new Date(value).toISOString()`. If an
 existing release differs from this identity after a retention check exists,
-sealing fails rather than creating a second proof; push a new head based on
-current `main`, let source admission pass, and seal that new head.
+sealing fails rather than creating a second proof; publish and seal a fresh
+exact head. Do not rebase an unchanged candidate solely because `main` moved.
 Trusted Version-PR admission publishes the same check. This gives downstream
 release operators a provider-owned proof of immutable source retention without
 requiring a credential that crosses repository boundaries. A tag and immutable
@@ -616,8 +616,19 @@ discontinuous range fails closed.
 
 The exact reviewed head must still resolve directly from its canonical
 `opengeni-release-head-<sha>` tag and have one successful GitHub Actions
-`Current-base source admission` check. The exact source must separately have
-one successful GitHub Actions result for each required candidate check:
+`Current-base source admission` check. The legacy context name is retained for
+the repository ruleset, but the check admits the immutable provider event head
+against the PR's provider merge-base tree; it does not require the event base
+to equal continuously moving `main`. The base-owned workflow/helper SHA must
+remain in protected `main` ancestry, and the provider base/head/repository,
+direct tree manifest, file projection, helper digest, read-only permissions,
+and terminal head identity remain fail-closed. Exact-head review stays bound to
+the candidate. The merge authority separately performs the fresh latest-main
+conflict, canonical patch-equivalence, protected-path, generated/migration,
+identity/manifest, security, and evidence checks immediately before merge.
+
+The exact source must separately have one successful GitHub Actions result for
+each required candidate check:
 `Typecheck and unit tests`, `Deployment artifacts`, and `Workload image
 builds`. Missing, moved, indirect, duplicated, failed, wrong-head, or
 foreign-app evidence is rejected. Check history is read with `filter=all`, and

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -587,7 +587,7 @@ function syntheticSourceAdmissionContext(context, pull) {
         `${RELEASE_AUTOMATION_CONTRACT.sourceAdmissionWorkflowPath}@refs/heads/` +
         RELEASE_AUTOMATION_CONTRACT.defaultBranch,
       GITHUB_WORKFLOW_SHA: context.baseSha,
-      OPENGENI_SOURCE_ADMISSION_ACTION: "verify_current_base_head",
+      OPENGENI_SOURCE_ADMISSION_ACTION: "verify_immutable_pr_head",
     },
     event: {
       action: "synchronize",
@@ -626,7 +626,10 @@ export async function validateVersionPrCiAdmission(options = {}) {
     fetchImpl,
     logger,
   });
-  invariant(admission.baseSha === context.baseSha, "source admission returned another base SHA");
+  invariant(
+    admission.workflowSha === context.baseSha,
+    "source admission returned another workflow SHA",
+  );
   invariant(admission.headSha === context.headSha, "source admission returned another head SHA");
   await terminalVersionIdentity(api, context);
   logger.log(`Automation dispatch admitted Version PR #${context.prNumber} at ${context.headSha}.`);
@@ -664,7 +667,7 @@ function releaseHeadSealContext(env, suppliedInputs) {
   };
 }
 
-function assertOpenReleasePull(pull, context) {
+function assertOpenReleasePull(pull, context, expectedBaseSha) {
   invariant(pull?.number === context.prNumber, "release-head pull-request number changed");
   invariant(
     pull?.state === "open" && pull?.merged === false,
@@ -673,13 +676,17 @@ function assertOpenReleasePull(pull, context) {
   invariant(pull?.draft === false, "release-head pull request is a draft");
   invariant(
     pull?.base?.ref === RELEASE_AUTOMATION_CONTRACT.defaultBranch &&
-      pull.base.repo?.full_name === RELEASE_AUTOMATION_CONTRACT.repository &&
-      pull.base.sha === context.baseSha,
+      pull.base.repo?.full_name === RELEASE_AUTOMATION_CONTRACT.repository,
     "release-head pull-request base changed",
   );
+  const baseSha = assertSha(pull.base.sha, "release-head pull-request base SHA");
+  if (expectedBaseSha !== undefined) {
+    invariant(baseSha === expectedBaseSha, "release-head pull-request base changed");
+  }
   invariant(pull?.head?.sha === context.headSha, "release-head pull-request head changed");
   assertString(pull?.head?.ref, "release-head pull-request head branch");
   assertString(pull?.head?.repo?.full_name, "release-head pull-request head repository");
+  return baseSha;
 }
 
 function releaseHeadRecoveryContext(env, suppliedInputs) {
@@ -933,14 +940,18 @@ export async function sealReleaseHeadEvidence(options = {}) {
   ]);
   assertRepository(repository);
   assertMainRef(main, context.baseSha, "release-head default branch");
-  assertOpenReleasePull(pull, context);
+  const pullBaseSha = assertOpenReleasePull(pull, context);
 
   const admission = await verifySourceAdmission({
     ...syntheticSourceAdmissionContext(context, pull),
     fetchImpl,
     logger,
   });
-  invariant(admission.baseSha === context.baseSha, "source admission returned another base SHA");
+  invariant(
+    admission.workflowSha === context.baseSha,
+    "source admission returned another workflow SHA",
+  );
+  invariant(admission.baseSha === pullBaseSha, "source admission returned another PR base SHA");
   invariant(admission.headSha === context.headSha, "source admission returned another head SHA");
   const sourceAdmission = assertSuccessfulCheck(
     await paginatedCheckRuns(api, context.headSha),
@@ -967,7 +978,7 @@ export async function sealReleaseHeadEvidence(options = {}) {
     api.get(repositoryPath(`/pulls/${context.prNumber}`)),
   ]);
   assertMainRef(terminalMain, context.baseSha, "terminal release-head default branch");
-  assertOpenReleasePull(terminalPull, context);
+  assertOpenReleasePull(terminalPull, context, pullBaseSha);
   const terminalReleaseHeadName = assertReleaseHeadRef(
     await api.get(repositoryPath(`/git/ref/tags/${releaseHead.name}`)),
     context.headSha,

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -22,6 +22,10 @@ const mergeSha = "d".repeat(40);
 const currentMainSha = "9".repeat(40);
 const baseTreeSha = "e".repeat(40);
 const headTreeSha = "f".repeat(40);
+const staleEventBaseSha = "8".repeat(40);
+const staleMergeBaseSha = "7".repeat(40);
+const staleEventBaseTreeSha = "6".repeat(40);
+const staleMergeBaseTreeSha = "5".repeat(40);
 const rebasedFirstSha = "a".repeat(40);
 const pullNumber = 88;
 const runId = 123456;
@@ -334,6 +338,10 @@ function admissionFixture(
     sourceConclusion?: string | null;
     sourceEvent?: string;
     sourceStatus?: string;
+    pullBaseSha?: string;
+    pullBaseTreeSha?: string;
+    pullMergeBaseSha?: string;
+    pullMergeBaseTreeSha?: string;
     terminalMainSha?: string;
   } = {},
 ) {
@@ -343,6 +351,10 @@ function admissionFixture(
   let mainReads = 0;
   let retainedHeadSha = options.releaseHeadRefSha;
   let retainedRelease = options.release ?? null;
+  const pullBaseSha = options.pullBaseSha ?? baseSha;
+  const pullBaseTreeSha = options.pullBaseTreeSha ?? baseTreeSha;
+  const pullMergeBaseSha = options.pullMergeBaseSha ?? pullBaseSha;
+  const pullMergeBaseTreeSha = options.pullMergeBaseTreeSha ?? pullBaseTreeSha;
   const prefix = `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}`;
   async function fetchImpl(input: string | URL | Request, init?: RequestInit) {
     const url = new URL(String(input));
@@ -385,7 +397,8 @@ function admissionFixture(
       mainReads += 1;
       return response(mainRef(mainReads > 2 ? (options.terminalMainSha ?? baseSha) : baseSha));
     }
-    if (url.pathname === `${prefix}/pulls/${pullNumber}`) return response(versionPull());
+    if (url.pathname === `${prefix}/pulls/${pullNumber}`)
+      return response(versionPull({ base: pullBaseSha }));
     if (url.pathname === `${prefix}/actions/runs/${runId}`)
       return response({
         id: runId,
@@ -399,17 +412,26 @@ function admissionFixture(
         repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
         head_repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
       });
-    if (url.pathname === `${prefix}/git/commits/${baseSha}`)
+    if (url.pathname === `${prefix}/git/commits/${pullBaseSha}`)
       return response({
-        sha: baseSha,
-        tree: { sha: baseTreeSha },
+        sha: pullBaseSha,
+        tree: { sha: pullBaseTreeSha },
         parents: [{ sha: "a".repeat(40) }],
+      });
+    if (
+      pullMergeBaseSha !== pullBaseSha &&
+      url.pathname === `${prefix}/git/commits/${pullMergeBaseSha}`
+    )
+      return response({
+        sha: pullMergeBaseSha,
+        tree: { sha: pullMergeBaseTreeSha },
+        parents: [{ sha: "4".repeat(40) }],
       });
     if (url.pathname === `${prefix}/git/commits/${headSha}`)
       return response({
         sha: headSha,
         tree: { sha: headTreeSha },
-        parents: [{ sha: baseSha }],
+        parents: [{ sha: pullMergeBaseSha }],
       });
     if (url.pathname === `${prefix}/git/ref/heads/changeset-release/main`)
       return response({
@@ -458,20 +480,20 @@ function admissionFixture(
           ),
         ],
       });
-    if (url.pathname === `${prefix}/compare/${baseSha}...${headSha}`)
+    if (url.pathname === `${prefix}/compare/${pullBaseSha}...${headSha}`)
       return response({
-        status: "ahead",
-        base_commit: { sha: baseSha },
-        merge_base_commit: { sha: baseSha },
+        status: pullMergeBaseSha === pullBaseSha ? "ahead" : "diverged",
+        base_commit: { sha: pullBaseSha },
+        merge_base_commit: { sha: pullMergeBaseSha },
         commits: [{ sha: headSha }],
-        behind_by: 0,
+        behind_by: pullMergeBaseSha === pullBaseSha ? 0 : 4,
         ahead_by: 1,
       });
     if (url.pathname === `${prefix}/pulls/${pullNumber}/files`)
       return response([{ filename: "package.json", status: "modified" }]);
-    if (url.pathname === `${prefix}/git/trees/${baseTreeSha}`)
+    if (url.pathname === `${prefix}/git/trees/${pullMergeBaseTreeSha}`)
       return response({
-        sha: baseTreeSha,
+        sha: pullMergeBaseTreeSha,
         truncated: false,
         tree: [{ path: "package.json", mode: "100644", type: "blob", sha: "1".repeat(40) }],
       });
@@ -632,6 +654,36 @@ describe("release head evidence retention", () => {
       ),
     ).toHaveLength(1);
     expect(fixture.requests.filter((request) => request.method === "PATCH")).toHaveLength(3);
+  });
+
+  test("retains an immutable stale-event head without equating its PR base to current main", async () => {
+    const fixture = admissionFixture({
+      seal: true,
+      pullBaseSha: staleEventBaseSha,
+      pullBaseTreeSha: staleEventBaseTreeSha,
+      pullMergeBaseSha: staleMergeBaseSha,
+      pullMergeBaseTreeSha: staleMergeBaseTreeSha,
+    });
+    const result = await sealReleaseHeadEvidence({
+      env: sealReleaseHeadEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+    });
+
+    expect(result.admission).toMatchObject({
+      baseSha: staleEventBaseSha,
+      baseTreeSha: staleMergeBaseTreeSha,
+      currentMainSha: baseSha,
+      headSha,
+      patchBaseSha: staleMergeBaseSha,
+      workflowSha: baseSha,
+    });
+    expect(result.releaseHead.sha).toBe(headSha);
+    expect(result.sourceAdmission).toEqual({
+      name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      appSlug: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.slug,
+      appId: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.id,
+    });
   });
 
   test("fails before mutation when the exact-head source-admission check is not successful", async () => {
@@ -1392,9 +1444,9 @@ describe("release approval provenance", () => {
         },
       }),
     );
-    expect(result.requiredSourceChecks.map((check: { name: string }) => check.name)).toEqual(
-      RELEASE_AUTOMATION_CONTRACT.checks.requiredSource,
-    );
+    expect(result.requiredSourceChecks.map((check: { name: string }) => check.name)).toEqual([
+      ...RELEASE_AUTOMATION_CONTRACT.checks.requiredSource,
+    ]);
     expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
   });
 

--- a/scripts/check-source-admission.mjs
+++ b/scripts/check-source-admission.mjs
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
 export const CONTRACT = Object.freeze({
-  action: "verify_current_base_head",
+  action: "verify_immutable_pr_head",
   apiUrl: "https://api.github.com",
   serverUrl: "https://github.com",
   repository: "Cloudgeni-ai/opengeni",
@@ -349,8 +349,9 @@ function assertFileProjection(files, manifest, expectedCount) {
   );
 }
 
-function assertComparison(value, baseSha, headSha) {
-  invariant(value?.base_commit?.sha === baseSha, "comparison base differs from current main");
+function assertComparison(value, eventBaseSha, headSha) {
+  invariant(value?.base_commit?.sha === eventBaseSha, "comparison base differs from event base");
+  const mergeBaseSha = assertSha(value?.merge_base_commit?.sha, "comparison merge-base SHA");
   invariant(
     Array.isArray(value?.commits) && value.commits.length > 0,
     "comparison commits are missing",
@@ -359,6 +360,24 @@ function assertComparison(value, baseSha, headSha) {
   invariant(
     Number.isSafeInteger(value?.ahead_by) && value.ahead_by > 0,
     "candidate head has no admitted commits",
+  );
+  return mergeBaseSha;
+}
+
+async function assertWorkflowRetainedByCurrentMain(api, workflowSha, currentMainSha) {
+  if (currentMainSha === workflowSha) return;
+  const value = await api(
+    `/repos/${CONTRACT.repository}/compare/${workflowSha}...${currentMainSha}`,
+  );
+  invariant(
+    value?.status === "ahead" &&
+      value?.base_commit?.sha === workflowSha &&
+      value?.merge_base_commit?.sha === workflowSha &&
+      Number.isSafeInteger(value?.ahead_by) &&
+      value.ahead_by > 0 &&
+      value?.behind_by === 0 &&
+      value?.total_commits === value.ahead_by,
+    "current main no longer retains the base-owned workflow SHA",
   );
 }
 
@@ -369,59 +388,58 @@ export async function verifySourceAdmission(options = {}) {
   const api = apiClient(options.fetchImpl ?? globalThis.fetch, context.token);
   const expectedRef = `refs/heads/${CONTRACT.defaultBranch}`;
 
-  const [repository, initialMainRef, initialPull] = await Promise.all([
+  const [repository, initialPull] = await Promise.all([
     api(`/repos/${CONTRACT.repository}`),
-    api(`/repos/${CONTRACT.repository}/git/ref/heads/${CONTRACT.defaultBranch}`),
     api(`/repos/${CONTRACT.repository}/pulls/${context.number}`),
   ]);
   assertRepository(repository);
-  const baseSha = assertRef(initialMainRef, expectedRef, "default branch");
-  invariant(
-    baseSha === context.workflowSha,
-    "current main differs from the base-owned workflow SHA",
-  );
-  invariant(context.eventBaseSha === baseSha, "event base SHA differs from current main");
   const headRef = assertString(context.event.pull_request.head.ref, "event head ref");
   assertPullRequest(initialPull, {
     number: context.number,
-    baseSha,
+    baseSha: context.eventBaseSha,
     headRef,
     headRepository: context.headRepository,
     headSha: context.eventHeadSha,
   });
 
-  const [baseCommit, headCommit, comparison, files] = await Promise.all([
-    api(`/repos/${CONTRACT.repository}/git/commits/${baseSha}`),
+  const [eventBaseCommit, headCommit, comparison, files] = await Promise.all([
+    api(`/repos/${CONTRACT.repository}/git/commits/${context.eventBaseSha}`),
     api(`/repos/${CONTRACT.repository}/git/commits/${context.eventHeadSha}`),
-    api(`/repos/${CONTRACT.repository}/compare/${baseSha}...${context.eventHeadSha}`),
+    api(`/repos/${CONTRACT.repository}/compare/${context.eventBaseSha}...${context.eventHeadSha}`),
     listPullRequestFiles(api, context.number),
   ]);
-  const baseTreeSha = assertCommit(baseCommit, baseSha, "current main commit");
+  const eventBaseTreeSha = assertCommit(eventBaseCommit, context.eventBaseSha, "event base commit");
   const headTreeSha = assertCommit(headCommit, context.eventHeadSha, "candidate head commit");
-  assertComparison(comparison, baseSha, context.eventHeadSha);
+  const patchBaseSha = assertComparison(comparison, context.eventBaseSha, context.eventHeadSha);
+  const baseTreeSha =
+    patchBaseSha === context.eventBaseSha
+      ? eventBaseTreeSha
+      : assertCommit(
+          await api(`/repos/${CONTRACT.repository}/git/commits/${patchBaseSha}`),
+          patchBaseSha,
+          "pull-request merge-base commit",
+        );
 
   const [baseTree, headTree] = await Promise.all([
     api(`/repos/${CONTRACT.repository}/git/trees/${baseTreeSha}?recursive=1`),
     api(`/repos/${CONTRACT.repository}/git/trees/${headTreeSha}?recursive=1`),
   ]);
   const manifest = directTreeManifest(
-    canonicalLeafMap(baseTree, baseTreeSha, "current main tree"),
+    canonicalLeafMap(baseTree, baseTreeSha, "pull-request merge-base tree"),
     canonicalLeafMap(headTree, headTreeSha, "candidate head tree"),
   );
-  invariant(manifest.length > 0, "candidate tree does not differ from current main");
+  invariant(manifest.length > 0, "candidate tree does not differ from its merge base");
   assertFileProjection(files, manifest, initialPull.changed_files);
 
   const [terminalMainRef, terminalPull] = await Promise.all([
     api(`/repos/${CONTRACT.repository}/git/ref/heads/${CONTRACT.defaultBranch}`),
     api(`/repos/${CONTRACT.repository}/pulls/${context.number}`),
   ]);
-  invariant(
-    assertRef(terminalMainRef, expectedRef, "terminal default branch") === baseSha,
-    "default branch drifted during admission",
-  );
+  const currentMainSha = assertRef(terminalMainRef, expectedRef, "terminal default branch");
+  await assertWorkflowRetainedByCurrentMain(api, context.workflowSha, currentMainSha);
   assertPullRequest(terminalPull, {
     number: context.number,
-    baseSha,
+    baseSha: context.eventBaseSha,
     headRef,
     headRepository: context.headRepository,
     headSha: context.eventHeadSha,
@@ -434,14 +452,19 @@ export async function verifySourceAdmission(options = {}) {
   const manifestText = `${manifest.map(({ line }) => line).join("\n")}\n`;
   const manifestSha256 = createHash("sha256").update(manifestText).digest("hex");
   logger.log(
-    `Source admission verified ${context.eventHeadSha} on current main ${baseSha}: ` +
+    `Source admission verified ${context.eventHeadSha} from event base ${context.eventBaseSha} ` +
+      `at patch merge base ${patchBaseSha}; base-owned workflow ${context.workflowSha} ` +
+      `remains retained by current main ${currentMainSha}: ` +
       `${manifest.length} direct tree paths, manifest sha256 ${manifestSha256}.`,
   );
   return {
-    baseSha,
+    baseSha: context.eventBaseSha,
     headSha: context.eventHeadSha,
     baseTreeSha,
     headTreeSha,
+    workflowSha: context.workflowSha,
+    currentMainSha,
+    patchBaseSha,
     manifest,
     manifestSha256,
   };

--- a/scripts/check-source-admission.test.ts
+++ b/scripts/check-source-admission.test.ts
@@ -15,6 +15,11 @@ const readmeBaseBlob = "1".repeat(40);
 const readmeHeadBlob = "2".repeat(40);
 const helperBlob = "3".repeat(40);
 const pullNumber = 7;
+const staleEventBaseSha = "8".repeat(40);
+const staleMergeBaseSha = "7".repeat(40);
+const staleEventBaseTreeSha = "6".repeat(40);
+const staleMergeBaseTreeSha = "5".repeat(40);
+const advancedMainSha = "9".repeat(40);
 
 type FixtureOptions = {
   apiBaseSha?: string;
@@ -24,13 +29,18 @@ type FixtureOptions = {
   comparisonMergeBaseSha?: string;
   comparisonBehindBy?: number;
   comparisonStatus?: string;
+  currentMainComparisonBehindBy?: number;
+  currentMainComparisonMergeBaseSha?: string;
+  currentMainComparisonStatus?: string;
   eventBaseSha?: string;
+  eventBaseTreeSha?: string;
   eventHeadSha?: string;
   fileRows?: Array<Record<string, unknown>>;
   headTreeTruncated?: boolean;
-  terminalBaseSha?: string;
+  mergeBaseTreeSha?: string;
   terminalHeadSha?: string;
   terminalHeadRepository?: string;
+  terminalMainSha?: string;
 };
 
 function event(overrides: Record<string, unknown> = {}): Record<string, any> {
@@ -75,13 +85,19 @@ function context(overrides: Record<string, string> = {}): Record<string, string>
 }
 
 function fixture(options: FixtureOptions = {}) {
-  let mainReads = 0;
   let pullReads = 0;
   const methods: string[] = [];
   const requestedPaths: string[] = [];
   const logs: string[] = [];
   const apiBaseSha = options.apiBaseSha ?? baseSha;
   const apiHeadSha = options.apiHeadSha ?? headSha;
+  const patchBaseSha = options.comparisonMergeBaseSha ?? apiBaseSha;
+  const eventBaseCommitTreeSha =
+    options.eventBaseTreeSha ?? (apiBaseSha === baseSha ? baseTreeSha : staleEventBaseTreeSha);
+  const patchBaseTreeSha =
+    options.mergeBaseTreeSha ??
+    (patchBaseSha === apiBaseSha ? eventBaseCommitTreeSha : staleMergeBaseTreeSha);
+  const terminalMainSha = options.terminalMainSha ?? baseSha;
   const rows =
     options.fileRows ??
     ([
@@ -90,7 +106,7 @@ function fixture(options: FixtureOptions = {}) {
     ] satisfies Array<Record<string, unknown>>);
 
   const baseTree = {
-    sha: baseTreeSha,
+    sha: patchBaseTreeSha,
     truncated: false,
     tree: [{ path: "README.md", mode: "100644", type: "blob", sha: readmeBaseBlob }],
   };
@@ -143,12 +159,11 @@ function fixture(options: FixtureOptions = {}) {
         private: false,
       };
     } else if (path === `/repos/${CONTRACT.repository}/git/ref/heads/${CONTRACT.defaultBranch}`) {
-      mainReads += 1;
       value = {
         ref: `refs/heads/${CONTRACT.defaultBranch}`,
         object: {
           type: "commit",
-          sha: mainReads > 1 ? (options.terminalBaseSha ?? baseSha) : baseSha,
+          sha: terminalMainSha,
         },
       };
     } else if (path === `/repos/${CONTRACT.repository}/pulls/${pullNumber}`) {
@@ -159,32 +174,56 @@ function fixture(options: FixtureOptions = {}) {
           ? (options.terminalHeadRepository ?? "contributor/opengeni")
           : "contributor/opengeni",
       );
-    } else if (path === `/repos/${CONTRACT.repository}/git/commits/${baseSha}`) {
+    } else if (path === `/repos/${CONTRACT.repository}/git/commits/${apiBaseSha}`) {
       value = {
-        sha: baseSha,
-        tree: { sha: baseTreeSha },
+        sha: apiBaseSha,
+        tree: { sha: eventBaseCommitTreeSha },
         parents: [{ sha: "a".repeat(40) }],
       };
-    } else if (path === `/repos/${CONTRACT.repository}/git/commits/${headSha}`) {
+    } else if (path === `/repos/${CONTRACT.repository}/git/commits/${apiHeadSha}`) {
       value = {
-        sha: headSha,
+        sha: apiHeadSha,
         tree: { sha: headTreeSha },
-        parents: [{ sha: baseSha }],
+        parents: [{ sha: patchBaseSha }],
       };
-    } else if (path === `/repos/${CONTRACT.repository}/compare/${baseSha}...${headSha}`) {
+    } else if (
+      patchBaseSha !== apiBaseSha &&
+      path === `/repos/${CONTRACT.repository}/git/commits/${patchBaseSha}`
+    ) {
+      value = {
+        sha: patchBaseSha,
+        tree: { sha: patchBaseTreeSha },
+        parents: [{ sha: "4".repeat(40) }],
+      };
+    } else if (path === `/repos/${CONTRACT.repository}/compare/${apiBaseSha}...${apiHeadSha}`) {
       value = {
         status: options.comparisonStatus ?? "ahead",
-        base_commit: { sha: options.comparisonBaseSha ?? baseSha },
-        merge_base_commit: { sha: options.comparisonMergeBaseSha ?? baseSha },
-        commits: [{ sha: options.comparisonHeadSha ?? headSha }],
+        base_commit: { sha: options.comparisonBaseSha ?? apiBaseSha },
+        merge_base_commit: { sha: patchBaseSha },
+        commits: [{ sha: options.comparisonHeadSha ?? apiHeadSha }],
         behind_by: options.comparisonBehindBy ?? 0,
         ahead_by: 1,
+      };
+    } else if (
+      terminalMainSha !== baseSha &&
+      path === `/repos/${CONTRACT.repository}/compare/${baseSha}...${terminalMainSha}`
+    ) {
+      value = {
+        status: options.currentMainComparisonStatus ?? "ahead",
+        base_commit: { sha: baseSha },
+        merge_base_commit: {
+          sha: options.currentMainComparisonMergeBaseSha ?? baseSha,
+        },
+        commits: [{ sha: terminalMainSha }],
+        behind_by: options.currentMainComparisonBehindBy ?? 0,
+        ahead_by: 1,
+        total_commits: 1,
       };
     } else if (
       path === `/repos/${CONTRACT.repository}/pulls/${pullNumber}/files?per_page=100&page=1`
     ) {
       value = rows;
-    } else if (path === `/repos/${CONTRACT.repository}/git/trees/${baseTreeSha}?recursive=1`) {
+    } else if (path === `/repos/${CONTRACT.repository}/git/trees/${patchBaseTreeSha}?recursive=1`) {
       value = baseTree;
     } else if (path === `/repos/${CONTRACT.repository}/git/trees/${headTreeSha}?recursive=1`) {
       value = headTree;
@@ -208,7 +247,7 @@ function fixture(options: FixtureOptions = {}) {
 }
 
 describe("source admission", () => {
-  test("admits one exact current-base head and emits a deterministic direct-tree manifest", async () => {
+  test("admits one immutable head and emits a deterministic merge-base manifest", async () => {
     const api = fixture();
     const result = await verifySourceAdmission({
       env: context(),
@@ -222,12 +261,15 @@ describe("source admission", () => {
       headSha,
       baseTreeSha,
       headTreeSha,
+      workflowSha: baseSha,
+      currentMainSha: baseSha,
+      patchBaseSha: baseSha,
     });
     expect(result.manifest.map(({ path }) => path)).toEqual(["README.md", CONTRACT.helperPath]);
     expect(result.manifestSha256).toMatch(/^[0-9a-f]{64}$/);
     expect(api.methods.every((method) => method === "GET")).toBe(true);
     expect(api.logs).toEqual([
-      `Source admission verified ${headSha} on current main ${baseSha}: 2 direct tree paths, manifest sha256 ${result.manifestSha256}.`,
+      `Source admission verified ${headSha} from event base ${baseSha} at patch merge base ${baseSha}; base-owned workflow ${baseSha} remains retained by current main ${baseSha}: 2 direct tree paths, manifest sha256 ${result.manifestSha256}.`,
     ]);
   });
 
@@ -271,10 +313,10 @@ describe("source admission", () => {
     expect(api.requestedPaths).toEqual([]);
   });
 
-  test("rejects an event base that is not the exact current main", async () => {
+  test("rejects an event base that differs from the provider pull identity", async () => {
     const api = fixture();
     const stale = event();
-    stale.pull_request.base.sha = "8".repeat(40);
+    stale.pull_request.base.sha = staleEventBaseSha;
     await expect(
       verifySourceAdmission({
         env: context(),
@@ -282,7 +324,7 @@ describe("source admission", () => {
         fetchImpl: api.fetchImpl,
         logger: api.logger,
       }),
-    ).rejects.toThrow("event base SHA differs from current main");
+    ).rejects.toThrow("pull-request base SHA changed");
   });
 
   test("rejects a provider head that moved after the event", async () => {
@@ -297,20 +339,68 @@ describe("source admission", () => {
     ).rejects.toThrow("pull-request head SHA changed");
   });
 
-  test("admits a genuinely behind and diverged candidate head", async () => {
+  test("admits a stale event base and roots a diverged candidate manifest at its merge base", async () => {
     const api = fixture({
-      comparisonBehindBy: 2,
-      comparisonMergeBaseSha: "8".repeat(40),
+      apiBaseSha: staleEventBaseSha,
+      comparisonBaseSha: staleEventBaseSha,
+      comparisonBehindBy: 42,
+      comparisonMergeBaseSha: staleMergeBaseSha,
       comparisonStatus: "diverged",
+      eventBaseTreeSha: staleEventBaseTreeSha,
+      mergeBaseTreeSha: staleMergeBaseTreeSha,
+      terminalMainSha: advancedMainSha,
     });
+    const stale = event();
+    stale.pull_request.base.sha = staleEventBaseSha;
     const result = await verifySourceAdmission({
       env: context(),
-      event: event(),
+      event: stale,
       fetchImpl: api.fetchImpl,
       logger: api.logger,
     });
 
+    expect(result).toMatchObject({
+      baseSha: staleEventBaseSha,
+      baseTreeSha: staleMergeBaseTreeSha,
+      currentMainSha: advancedMainSha,
+      patchBaseSha: staleMergeBaseSha,
+      workflowSha: baseSha,
+    });
     expect(result.manifest.map(({ path }) => path)).toEqual(["README.md", CONTRACT.helperPath]);
+    expect(api.requestedPaths).toContain(
+      `/repos/${CONTRACT.repository}/compare/${baseSha}...${advancedMainSha}`,
+    );
+  });
+
+  test("admits many stale-event heads concurrently while protected main advances", async () => {
+    const results = await Promise.all(
+      Array.from({ length: 32 }, async () => {
+        const api = fixture({
+          apiBaseSha: staleEventBaseSha,
+          comparisonBaseSha: staleEventBaseSha,
+          comparisonBehindBy: 42,
+          comparisonMergeBaseSha: staleMergeBaseSha,
+          comparisonStatus: "diverged",
+          eventBaseTreeSha: staleEventBaseTreeSha,
+          mergeBaseTreeSha: staleMergeBaseTreeSha,
+          terminalMainSha: advancedMainSha,
+        });
+        const stale = event();
+        stale.pull_request.base.sha = staleEventBaseSha;
+        const result = await verifySourceAdmission({
+          env: context(),
+          event: stale,
+          fetchImpl: api.fetchImpl,
+          logger: api.logger,
+        });
+        expect(api.methods.every((method) => method === "GET")).toBe(true);
+        return result;
+      }),
+    );
+
+    expect(results).toHaveLength(32);
+    expect(results.every((result) => result.currentMainSha === advancedMainSha)).toBe(true);
+    expect(results.every((result) => result.patchBaseSha === staleMergeBaseSha)).toBe(true);
   });
 
   test("rejects truncated recursive trees", async () => {
@@ -339,8 +429,13 @@ describe("source admission", () => {
     ).rejects.toThrow("provider file projection differs from the direct tree delta");
   });
 
-  test("rejects terminal main movement", async () => {
-    const api = fixture({ terminalBaseSha: "8".repeat(40) });
+  test("rejects a current main rewrite that no longer retains the base-owned workflow", async () => {
+    const api = fixture({
+      currentMainComparisonBehindBy: 1,
+      currentMainComparisonMergeBaseSha: staleMergeBaseSha,
+      currentMainComparisonStatus: "diverged",
+      terminalMainSha: advancedMainSha,
+    });
     await expect(
       verifySourceAdmission({
         env: context(),
@@ -348,7 +443,7 @@ describe("source admission", () => {
         fetchImpl: api.fetchImpl,
         logger: api.logger,
       }),
-    ).rejects.toThrow("default branch drifted during admission");
+    ).rejects.toThrow("current main no longer retains the base-owned workflow SHA");
   });
 
   test("rejects terminal head movement", async () => {


### PR DESCRIPTION
## Summary

- remove the residual `event base SHA differs from current main` admission failure while retaining the required-check context `Current-base source admission`
- bind immutable candidate admission to the provider event base/head and build the direct-tree manifest from the provider PR merge base
- retain fail-closed repository/pull identity, exact-head, recursive-tree, file-projection, helper-digest, read-only permission, terminal-head, and protected-current-main workflow-ancestry fences
- update release sealing so the trusted workflow SHA may postdate the PR event base without weakening exact-head evidence

Linear: OPE-92, OPE-25

## Root cause

Merged PR #694 (`aeffe4761125592d517bfd34a06ae2cd53998226`) removed the earlier `status === ahead` / `behind_by === 0` ancestry restriction, but the public `pull_request_target` verifier still required the event base SHA to equal current `main` and rooted its tree manifest at current `main`. GitHub Actions workflow `317138434` therefore remained the exact producer of the obsolete failure. The official GitHub Actions App (integration ID `15368`) produced the sole failed marker; no custom/deployed duplicate producer was found. Private ops consumes this provider evidence but does not produce the check.

The live ruleset `Protection` (`16435119`) still requires the legacy context `Current-base source admission`, so this candidate preserves that job/check name and changes only its immutable-head semantics. No live rule or setting is changed.

## Affected evidence

PR #796 exact provider evidence:

- head: `2a7900f268badc9a66818041f93e4b945a4ba438`
- event/provider base: `57ac751786bce9b9598bee17a6548a2fb41e2a09`
- provider merge base: `da8cacc92b5fe60009a5a7d47bae8fa4504a991b`
- failed run/job: `30541580786` / `90867381426`
- sole marker: `event base SHA differs from current main`

A read-only execution of the corrected verifier admitted that exact head after current `main` advanced to `9af1d09f8ef13fb9eb4c1954478822a11f82c6ab`. It matched all five provider paths and produced manifest SHA-256 `e4fd41af1812af6a065b89820987fa3fbf48c9be524f4a45ab62357d1bd8ef79`.

## Preserved gates

This does not replace merge-time admission. Merge authority still performs a fresh latest-main conflict and semantic-overlap check and retains canonical patch-equivalence, protected-path, generated/migration-ledger, identity/manifest, security, and evidence gates immediately before merge.

Private `opengeni-ops` source is unchanged. Its targeted merge-authority tests continue to reject overlapping/conflicting main movement and substantive, mixed, missing, duplicate, identity, ancestry, head, and step drift while accepting only the narrowly typed historical moving-main base-drift receipt.

## Validation

- stable non-preview TypeScript `7.0.2` strict compile over the affected test surface
- `bun test scripts/check-source-admission.test.ts scripts/check-release-pr-automation.test.ts` — 61 pass, 0 fail
- deterministic 32-way concurrent stale-event admission while protected `main` advances
- private targeted merge-authority tests — 4 pass, 0 fail
- `bun run check:docs-refs`
- focused `oxlint` and `oxfmt --check`
- `node --check` for both changed `.mjs` files
- `git diff --check`
- helper SHA-256 matches the pinned workflow digest
- latest-main read-only snapshot: no changed-path overlap and no legacy merge-tree conflict markers against `9af1d09f8ef13fb9eb4c1954478822a11f82c6ab`

## Review boundary

Candidate head is immutable and is intentionally not rebased merely because `main` moved. Stop here for independent exact-head review. Not self-reviewed, merged, deployed, or applied to live rules/settings.
