### PR TITLE
Advance production release chart to 0.22.25

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.24
-appVersion: "0.22.24"
+version: 0.22.25
+appVersion: "0.22.25"


### PR DESCRIPTION
Advances the Helm chart and app version for the exact production release train containing the tool-policy, web-search timeline settlement, citation-display, input-batch UI, and current main fixes.