### PR TITLE
Preserve API OOM mitigation in release chart 0.22.26

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.25
-appVersion: "0.22.25"
+version: 0.22.26
+appVersion: "0.22.26"

--- a/deploy/helm/opengeni/values.yaml
+++ b/deploy/helm/opengeni/values.yaml
@@ -152,10 +152,10 @@ api:
   resources:
     requests:
       cpu: 250m
-      memory: 512Mi
+      memory: 1Gi
     limits:
       cpu: "1"
-      memory: 1Gi
+      memory: 2Gi
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 1000


### PR DESCRIPTION
Persists the already-live production API memory mitigation (1Gi request / 2Gi limit) so the ordinary Helm release cannot revert it, and advances the chart/app version for the exact production train. No sandbox migration or provider-lifetime changes are included.