### PR TITLE
fix(release): harden production recovery and liveness

### DIFF
--- a/.changeset/steady-mcp-cursors.md
+++ b/.changeset/steady-mcp-cursors.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/react": patch
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Seed shared session-event cursors from loaded history to prevent historical replay storms, and preserve the MCP SDK's exact request-timeout classification through safe transport-error sanitization.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -101,6 +101,7 @@ import {
   toolspaceTokenFileFromEnvironment,
   sandboxFileDownloadFailureNote,
   SUMMARY_BUFFER_TOKENS,
+  isMcpRequestTimeoutError,
   runOwnedSandboxSetup,
   RoutingMutationOutcomeUnknownError,
   WorkspaceArchiveIntegrityError,
@@ -810,7 +811,7 @@ export function classifyMcpTransportTimeoutError(
   error: unknown,
 ): { message: string; detail?: string } | null {
   const fields = collectErrorStrings(error);
-  const matched = fields.find(
+  const matchedText = fields.find(
     (value) =>
       /\bmcp\b/i.test(value) &&
       /(?:request\s+timed\s+out|request\s+timeout|\btimed\s+out\b|\btimeout\b|ETIMEDOUT)/i.test(
@@ -818,13 +819,15 @@ export function classifyMcpTransportTimeoutError(
       ) &&
       !/authentication\s+required/i.test(value),
   );
-  if (!matched) {
+  const sanitizedSdkTimeout = isMcpRequestTimeoutError(error);
+  if (!matchedText && !sanitizedSdkTimeout) {
     return null;
   }
   const message = error instanceof Error ? error.message : String(error);
+  const matched = matchedText ?? fields.find((value) => /\bmcp\b/i.test(value));
   return {
     message,
-    ...(matched !== message ? { detail: matched } : {}),
+    ...(matched && matched !== message ? { detail: matched } : {}),
   };
 }
 

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -25,6 +25,7 @@ import {
   WorkspaceArchiveIntegrityError,
   contextRobustnessFilterForSettings,
   modelResponseUsageFromResponse,
+  safeMcpTransportError,
   sanitizeHistoryItemsForModel,
 } from "@opengeni/runtime";
 import { testSettings } from "@opengeni/testing";
@@ -2564,6 +2565,29 @@ describe("escaped MCP transport timeout classifier", () => {
     const exact = new Error("MCP error -32001: Request timed out");
     expect(classifyMcpTransportTimeoutError(exact)?.message).toBe(exact.message);
 
+    const sdkTimeoutMessages = [
+      "Request timed out",
+      "MCP error -32001: Request timed out",
+      "Maximum total timeout exceeded",
+      "MCP error -32001: Maximum total timeout exceeded",
+    ];
+    for (const message of sdkTimeoutMessages) {
+      const sanitized = safeMcpTransportError(
+        Object.assign(new Error(message), {
+          name: "McpError",
+          code: -32_001,
+        }),
+      );
+      expect(classifyMcpTransportTimeoutError(sanitized)?.message).toBe(sanitized.message);
+      expect(agentRunFailurePayload(sanitized)).toEqual({
+        error:
+          "An MCP server request timed out. Any completed tool output was checkpointed; the session can continue safely.",
+        code: "mcp_transport_timeout",
+        retryable: true,
+        detail: sanitized.message,
+      });
+    }
+
     const nested = {
       error: { message: "MCP transport request timeout while listing tools" },
     };
@@ -2576,6 +2600,19 @@ describe("escaped MCP transport timeout classifier", () => {
       retryable: true,
       detail: exact.message,
     });
+
+    for (const message of [
+      "MCP error -32001: Session not found",
+      "MCP error -32001: operator cancelled this request",
+    ]) {
+      const ambiguous = safeMcpTransportError(
+        Object.assign(new Error(message), {
+          name: "McpError",
+          code: -32_001,
+        }),
+      );
+      expect(classifyMcpTransportTimeoutError(ambiguous)).toBeNull();
+    }
   });
 
   test("does not absorb auth-needed or unrelated timeout failures", () => {

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.26
-appVersion: "0.22.26"
+version: 0.22.27
+appVersion: "0.22.27"

--- a/packages/react/src/hooks/internal.ts
+++ b/packages/react/src/hooks/internal.ts
@@ -236,6 +236,7 @@ export function useSessionEventTrigger(
   }, [match, onEvent, reconcileBeforeLive]);
   const consumedRef = useRef(0);
   const feedKeyRef = useRef<string | null>(null);
+  const sharedFeedHasEventsRef = useRef(false);
 
   // Shared-log mode: scan only the unseen tail on every append.
   useEffect(() => {
@@ -244,12 +245,37 @@ export function useSessionEventTrigger(
     }
     const feedKey = `${workspaceId}\u0000${sessionId}`;
     const firstSequence = events[0]?.sequence ?? 0;
-    // A new session target or a log reset (sequence restarted below the
-    // cursor) restarts consumption from the top of the shared log.
-    if (feedKeyRef.current !== feedKey || firstSequence > consumedRef.current + 1) {
+    if (feedKeyRef.current !== feedKey) {
       feedKeyRef.current = feedKey;
-      consumedRef.current = 0;
+      sharedFeedHasEventsRef.current = events.length > 0;
+      // The caller has already loaded its authoritative initial projection.
+      // Seed from the shared log's current tail so mounting a large historical
+      // session cannot replay every old event as a new live trigger.
+      consumedRef.current = events.at(-1)?.sequence ?? 0;
+      return;
     }
+    const firstNonEmptyBatch = !sharedFeedHasEventsRef.current && events.length > 0;
+    if (firstNonEmptyBatch || firstSequence > consumedRef.current + 1) {
+      // The usual shared feed mounts empty, then receives a historical tail.
+      // A later discontinuity can likewise replace the retained browser
+      // window. In either case, reconcile once from the latest relevant event
+      // instead of replaying the whole retained window as live traffic.
+      sharedFeedHasEventsRef.current = events.length > 0;
+      consumedRef.current = events.at(-1)?.sequence ?? consumedRef.current;
+      let latestMatch: SessionEvent | undefined;
+      for (let index = events.length - 1; index >= 0; index -= 1) {
+        const event = events[index];
+        if (event && matchRef.current(event)) {
+          latestMatch = event;
+          break;
+        }
+      }
+      if (latestMatch) {
+        onEventRef.current(latestMatch);
+      }
+      return;
+    }
+    sharedFeedHasEventsRef.current ||= events.length > 0;
     for (const event of events) {
       if (event.sequence <= consumedRef.current) {
         continue;

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1698,6 +1698,77 @@ describe("useComposer queue-vs-steer", () => {
 });
 
 describe("useComposer durable draft and control binding", () => {
+  test("historical feed hydration reconciles once without replaying every old event", async () => {
+    let reads = 0;
+    const client = fakeClient({
+      getComposerDraft: async () => {
+        reads += 1;
+        return {
+          revision: reads,
+          text: `read-${reads}`,
+          resources: [],
+          model: "model-x",
+          reasoningEffort: "medium",
+          sourceTurnId: null,
+          sourceTurnVersion: null,
+          updatedAt: new Date().toISOString(),
+        } satisfies ComposerDraft;
+      },
+    });
+    const historical = Array.from({ length: 1_000 }, (_, index) =>
+      makeEvent(index + 1, "session.queue.changed", { operation: "edit" }),
+    );
+    const hook = await renderHook(
+      (events: SessionEvent[]) =>
+        useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID, events }),
+      noEvents,
+    );
+    await flush();
+    expect(reads).toBe(1);
+
+    await hook.rerender(historical);
+    await flush();
+    expect(reads).toBe(2);
+
+    await hook.rerender([
+      ...historical,
+      makeEvent(1_001, "session.queue.changed", { operation: "edit" }),
+    ]);
+    await flush();
+    expect(reads).toBe(3);
+    await hook.unmount();
+  });
+
+  test("history already present at mount is treated as a projection, not live traffic", async () => {
+    let reads = 0;
+    const client = fakeClient({
+      getComposerDraft: async () => {
+        reads += 1;
+        return {
+          revision: reads,
+          text: `read-${reads}`,
+          resources: [],
+          model: "model-x",
+          reasoningEffort: "medium",
+          sourceTurnId: null,
+          sourceTurnVersion: null,
+          updatedAt: new Date().toISOString(),
+        } satisfies ComposerDraft;
+      },
+    });
+    const historical = Array.from({ length: 1_000 }, (_, index) =>
+      makeEvent(index + 1, "session.queue.changed", { operation: "edit" }),
+    );
+    const hook = await renderHook(
+      (events: SessionEvent[]) =>
+        useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID, events }),
+      historical,
+    );
+    await flush();
+    expect(reads).toBe(1);
+    await hook.unmount();
+  });
+
   test("callback churn does not reload drafts outside target, explicit, or event triggers", async () => {
     const sessionB: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
     const reads: string[] = [];

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3060,18 +3060,58 @@ function safeMcpErrorFields(error: unknown): {
   return { errorClass, status };
 }
 
-function safeMcpTransportError(error: unknown): Error & { status?: number; code?: number } {
+type SafeMcpTransportError = Error & {
+  status?: number;
+  code?: number;
+  mcpTransportFailureKind?: "request_timeout";
+};
+
+/**
+ * Preserve the MCP SDK's exact request-timeout meaning without retaining or
+ * exposing a raw HTTP response body. The numeric code is not sufficient:
+ * Streamable HTTP also uses -32001 for "Session not found" and arbitrary
+ * AbortSignal reasons, so only the SDK's two owned timeout messages qualify.
+ */
+export function isMcpRequestTimeoutError(error: unknown, seen = new WeakSet<object>()): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  if (seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+  const record = error as Record<string, unknown>;
+  if (record.mcpTransportFailureKind === "request_timeout") {
+    return true;
+  }
+  const code = typeof record.code === "number" ? record.code : record.status;
+  const message = typeof record.message === "string" ? record.message : "";
+  const sdkTimeoutMessages = new Set([
+    "Request timed out",
+    "MCP error -32001: Request timed out",
+    "Maximum total timeout exceeded",
+    "MCP error -32001: Maximum total timeout exceeded",
+  ]);
+  if (code === -32_001 && sdkTimeoutMessages.has(message)) {
+    return true;
+  }
+  return ["error", "cause", "response", "data"].some((key) =>
+    isMcpRequestTimeoutError(record[key], seen),
+  );
+}
+
+export function safeMcpTransportError(error: unknown): SafeMcpTransportError {
   const fields = safeMcpErrorFields(error);
   const safeError = new Error(
     `MCP transport operation failed (${mcpErrorReason(fields)})`,
-  ) as Error & {
-    status?: number;
-    code?: number;
-  };
+  ) as SafeMcpTransportError;
   safeError.name = "McpTransportError";
   if (fields.status !== undefined) {
     safeError.status = fields.status;
     safeError.code = fields.status;
+  }
+  if (isMcpRequestTimeoutError(error)) {
+    safeError.mcpTransportFailureKind = "request_timeout";
   }
   return safeError;
 }

--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -12,6 +12,7 @@ import {
   parseLiveAcceptanceArgs,
   parseProtectedEmails,
   sanitizeDiagnostic,
+  waitForSandboxLiveness,
 } from "./workbench-live-acceptance";
 
 describe("workbench live acceptance preflight", () => {
@@ -86,6 +87,36 @@ describe("workbench live acceptance preflight", () => {
     expect(controlCancellationDurationMs(1_000, 1_125)).toBe(125);
     expect(() => controlCancellationDurationMs(1_000, 999)).toThrow("before its control commit");
     expect(() => controlCancellationDurationMs(Number.NaN, 1_000)).toThrow("must be finite");
+  });
+
+  test("liveness polling bounds and retries a transient transport failure", async () => {
+    const signals: AbortSignal[] = [];
+    let calls = 0;
+    const client = {
+      async getStreamCapabilities(
+        _workspaceId: string,
+        _sessionId: string,
+        options: { signal?: AbortSignal } = {},
+      ) {
+        if (options.signal) signals.push(options.signal);
+        calls += 1;
+        if (calls === 1) throw new DOMException("request timed out", "TimeoutError");
+        return { liveness: "cold" } as never;
+      },
+    };
+
+    await waitForSandboxLiveness(
+      client,
+      "10000000-0000-4000-8000-000000000001",
+      "20000000-0000-4000-8000-000000000002",
+      new Set(["cold"]),
+      1_000,
+      0,
+      50,
+    );
+
+    expect(calls).toBe(2);
+    expect(signals).toHaveLength(2);
   });
 
   test("requires interactive scopes only from the dedicated canary principal", () => {

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -838,19 +838,46 @@ async function verifySignedFileExpiry(
     throw new Error("refreshed capture bytes failed integrity check");
 }
 
+export async function waitForSandboxLiveness(
+  client: Pick<OpenGeniClient, "getStreamCapabilities">,
+  workspaceId: string,
+  sessionId: string,
+  accepted: ReadonlySet<string>,
+  timeoutMs: number,
+  pollIntervalMs = 2_000,
+  requestTimeoutMs = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastTransportError: string | undefined;
+  while (Date.now() < deadline) {
+    const remainingMs = deadline - Date.now();
+    try {
+      const capabilities = await client.getStreamCapabilities(workspaceId, sessionId, {
+        signal: AbortSignal.timeout(Math.max(1, Math.min(requestTimeoutMs, remainingMs))),
+      });
+      lastTransportError = undefined;
+      if (accepted.has(capabilities.liveness)) return;
+    } catch (error) {
+      lastTransportError = sanitizeDiagnostic(
+        error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+      );
+    }
+    const sleepMs = Math.min(pollIntervalMs, Math.max(0, deadline - Date.now()));
+    if (sleepMs > 0) await Bun.sleep(sleepMs);
+  }
+  throw new Error(
+    `sandbox did not reach ${[...accepted].join("/")} before timeout` +
+      (lastTransportError ? ` (last transport error: ${lastTransportError})` : ""),
+  );
+}
+
 async function waitForCold(
   client: OpenGeniClient,
   workspaceId: string,
   sessionId: string,
   timeoutMs: number,
 ): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const capabilities = await client.getStreamCapabilities(workspaceId, sessionId);
-    if (capabilities.liveness === "cold") return;
-    await Bun.sleep(2_000);
-  }
-  throw new Error("real sandbox did not drain to cold before timeout");
+  await waitForSandboxLiveness(client, workspaceId, sessionId, new Set(["cold"]), timeoutMs);
 }
 
 async function waitForWarm(
@@ -859,13 +886,14 @@ async function waitForWarm(
   sessionId: string,
   timeoutMs = 90_000,
 ): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const capabilities = await client.getStreamCapabilities(workspaceId, sessionId);
-    if (capabilities.liveness === "warm" || capabilities.liveness === "draining") return;
-    await Bun.sleep(1_000);
-  }
-  throw new Error("explicit live intent did not warm the sandbox before timeout");
+  await waitForSandboxLiveness(
+    client,
+    workspaceId,
+    sessionId,
+    new Set(["warm", "draining"]),
+    timeoutMs,
+    1_000,
+  );
 }
 
 async function runLiveWorkspaceFlow(input: {


### PR DESCRIPTION
Bounds every sandbox-liveness probe independently and retries transient transport failures inside the existing overall deadline. This prevents one hung stream-capabilities GET from bypassing the acceptance timeout and producing an opaque Bun TimeoutError. Advances the Helm chart/app version to 0.22.27 while preserving the 1Gi/2Gi API memory contract.\n\nVerified: focused workbench/Helm tests and repository typecheck.