### PR TITLE
fix(release): preserve live package lock requesters

### DIFF
--- a/scripts/build-publishable-packages.test.ts
+++ b/scripts/build-publishable-packages.test.ts
@@ -474,6 +474,29 @@ test("admits one builder when many waiters reclaim a dead-owner lock", async () 
   expect(readFileSync(outputPath(root), "utf8")).toBe("BASE|A|644\n");
 });
 
+test("does not reclaim a live requester after its build supervisor exits", async () => {
+  const root = createFixture();
+  const pausePath = join(root, "requester-publish-pause");
+  const countPath = join(root, "build-count.txt");
+  const environment = {
+    OPENGENI_BUILD_VARIANT: "BASE",
+    BUILD_FIXTURE_COUNT: countPath,
+    OPENGENI_BUILD_CACHE_PAUSE_BEFORE_REQUESTER_PUBLISH: pausePath,
+  };
+  const owner = startBuilder(root, environment);
+  expect(await waitForPath(`${pausePath}.ready`)).toBe(true);
+
+  const waiters = Array.from({ length: 12 }, () => runBuilder(root, environment));
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(readFileSync(countPath, "utf8").trim().split("\n")).toEqual(["BASE"]);
+
+  writeFileSync(`${pausePath}.release`, "release\n");
+  const results = await Promise.all([owner.result, ...waiters]);
+  expect(results.filter((result) => result.code !== 0)).toEqual([]);
+  expect(readFileSync(countPath, "utf8").trim().split("\n")).toEqual(["BASE"]);
+  expect(readFileSync(outputPath(root), "utf8")).toBe("BASE|A|644\n");
+});
+
 test("drains a killed builder's detached child before admitting its successor", async () => {
   const root = createFixture();
   const gate = join(root, "orphan-gate");

--- a/scripts/build-publishable-packages.ts
+++ b/scripts/build-publishable-packages.ts
@@ -395,8 +395,8 @@ function quarantineLegacyReclaimer(lockPath: string): void {
 
 function staleLockCanBeReclaimed(lockPath: string, owner: LockOwner | null): boolean {
   if (owner) {
-    if (owner.requesterPid && !processIsAlive(owner.requesterPid)) {
-      return true;
+    if (owner.requesterPid) {
+      return !processIsAlive(owner.requesterPid);
     }
     return !processIsAlive(owner.pid);
   }
@@ -634,6 +634,7 @@ function publishPackageLock(lockPath: string, pkg: WorkspacePackage): PackageLoc
       },
       waitForBuild: () => supervisorResult,
       markPublishing: () => {
+        pauseForFailureInjection("OPENGENI_BUILD_CACHE_PAUSE_BEFORE_REQUESTER_PUBLISH");
         const owner = readLockOwner(lockPath);
         if (owner?.token !== token) {
           throw new Error(`Package build lock ownership changed: ${lockPath}`);


### PR DESCRIPTION
## Summary
- treat a live requester PID as the authoritative package-build lock owner after its supervisor exits
- retain supervisor-PID fallback for older lock records without requester identity
- add a deterministic concurrent regression for the supervisor-exit/publication gap

## Verification
- `bun test scripts/build-publishable-packages.test.ts --timeout 30000` repeated 5x (70/70) plus one post-format run (14/14)
- `bun run typecheck` (23/23 projects)
- `git diff --check`