### PR TITLE
fix(release): derive package and recovery evidence

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -12,11 +12,6 @@ on:
         description: Exact current versioned main SHA; dispatch this workflow from that same ref.
         required: true
         type: string
-      expected_packages:
-        description: Exact comma-separated package set intended for npm publication; leave empty for an application-only release.
-        required: false
-        default: ""
-        type: string
 
 concurrency:
   group: release-candidate-${{ inputs.source_sha }}
@@ -108,7 +103,7 @@ jobs:
         id: package-plan
         env:
           OPENGENI_RELEASE_SOURCE_SHA: ${{ inputs.source_sha }}
-          OPENGENI_EXPECTED_PACKAGES: ${{ inputs.expected_packages }}
+          OPENGENI_RELEASE_PACKAGE_DERIVE_EXPECTED: "true"
           OPENGENI_RELEASE_PACKAGE_PHASE: plan
           OPENGENI_RELEASE_PACKAGE_RECEIPT: evidence/release-packages-plan.json
         run: bun scripts/verify-release-packages.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,6 @@ on:
         description: Exact 40-character source SHA that passed acceptance; dispatch this workflow from that same ref.
         required: true
         type: string
-      expected_packages:
-        description: Exact comma-separated package set, or empty when this release publishes no npm package changes.
-        required: false
-        default: ""
-        type: string
       candidate_run_id:
         description: Completed run ID of the canonical release-candidate workflow for source_sha.
         required: true
@@ -254,6 +249,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Download and validate the complete acceptance bundle
+        id: acceptance-bundle
         env:
           SOURCE_SHA: ${{ steps.preflight.outputs.source_sha }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -263,7 +259,6 @@ jobs:
           ACCEPTANCE_ARTIFACT_ID: ${{ steps.preflight.outputs.acceptance_artifact_id }}
           ACCEPTANCE_ARTIFACT_DIGEST: ${{ steps.preflight.outputs.acceptance_artifact_digest }}
           ACCEPTANCE_ARTIFACT_URL: ${{ steps.preflight.outputs.acceptance_artifact_url }}
-          EXPECTED_PACKAGES: ${{ inputs.expected_packages }}
         run: |
           set -euo pipefail
           mkdir -p evidence .release/candidate-artifact .release/acceptance-artifact
@@ -312,8 +307,10 @@ jobs:
             evidence/release-candidate.json >/dev/null
           bun scripts/release-candidate.ts \
             --verify evidence/release-candidate.json \
-            --source-sha "$SOURCE_SHA" \
-            --expected-packages "$EXPECTED_PACKAGES"
+            --source-sha "$SOURCE_SHA"
+          expected_packages="$(jq -r '.packages | map(.name + "@" + .version) | join(",")' \
+            evidence/release-candidate.json)"
+          echo "expected_packages=$expected_packages" >> "$GITHUB_OUTPUT"
           bun scripts/verify-workbench-acceptance-bundle.ts \
             --bundle evidence/workbench-acceptance.json \
             --source-sha "$SOURCE_SHA" \
@@ -344,10 +341,14 @@ jobs:
         id: package-plan
         env:
           OPENGENI_RELEASE_SOURCE_SHA: ${{ steps.preflight.outputs.source_sha }}
-          OPENGENI_EXPECTED_PACKAGES: ${{ inputs.expected_packages }}
+          OPENGENI_EXPECTED_PACKAGES: ${{ steps.acceptance-bundle.outputs.expected_packages }}
           OPENGENI_RELEASE_PACKAGE_PHASE: plan
           OPENGENI_RELEASE_PACKAGE_RECEIPT: evidence/release-packages-plan.json
-        run: bun scripts/verify-release-packages.ts
+        run: |
+          bun scripts/verify-release-packages.ts
+          jq -e --slurpfile candidate evidence/release-candidate.json \
+            '(.packages | map({name, version})) == $candidate[0].packages' \
+            evidence/release-packages-plan.json >/dev/null
 
       - name: Write pre-publication release plan
         env:
@@ -433,7 +434,7 @@ jobs:
         id: registry
         env:
           OPENGENI_RELEASE_SOURCE_SHA: ${{ steps.preflight.outputs.source_sha }}
-          OPENGENI_EXPECTED_PACKAGES: ${{ inputs.expected_packages }}
+          OPENGENI_EXPECTED_PACKAGES: ${{ steps.acceptance-bundle.outputs.expected_packages }}
           OPENGENI_RELEASE_PACKAGE_PHASE: verify
           OPENGENI_RELEASE_PACKAGE_RECEIPT: evidence/release-packages-verified.json
         run: bun scripts/verify-release-packages.ts
@@ -514,7 +515,6 @@ jobs:
           CANDIDATE_ARTIFACT_URL: ${{ needs.publish.outputs.candidateArtifactUrl }}
           CANDIDATE_SOURCE_TREE_SHA: ${{ needs.publish.outputs.candidateSourceTreeSha }}
           SOURCE_SHA: ${{ needs.publish.outputs.sourceSha }}
-          EXPECTED_PACKAGES: ${{ inputs.expected_packages }}
         run: |
           set -euo pipefail
           mkdir -p evidence .release/candidate-artifact
@@ -541,8 +541,7 @@ jobs:
           [ "$chart_sha256" = "$(jq -er '.chart.bytesSha256' evidence/release-candidate.json)" ]
           bun scripts/release-candidate.ts \
             --verify evidence/release-candidate.json \
-            --source-sha "$SOURCE_SHA" \
-            --expected-packages "$EXPECTED_PACKAGES"
+            --source-sha "$SOURCE_SHA"
           release_version="$(jq -er '.releaseVersion' evidence/release-candidate.json)"
           source_release_version="$(bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml)"
           [ "$release_version" = "$source_release_version" ] || {

--- a/.github/workflows/seal-release-head.yml
+++ b/.github/workflows/seal-release-head.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       pull_request_number:
-        description: Open pull request whose exact head may become a release source.
+        description: Pull request whose exact head may become a release source.
         required: true
         type: string
       reviewed_base_sha:
@@ -17,7 +17,7 @@ on:
         required: true
         type: string
       merged_source_sha:
-        description: Optional exact merged source SHA when recovering missing exact-head checks for an already-immutable head.
+        description: Optional exact merged source SHA when recovering historical retention evidence for an already-merged head.
         required: false
         default: ""
         type: string

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -575,7 +575,10 @@ first provider read's PR-author numeric ID/account type and exact head
 branch/repository across its pre-mutation and terminal reads; it supports both
 Version and explicitly sealed non-Version release PRs without substituting a
 hard-coded author or branch. Successful replay reuses the exact immutable pair
-and idempotently restores only whichever exact provider checks are absent.
+and always upserts one deterministic historical source-admission receipt before
+restoring retention. Original pull-request workflow checks are historical
+evidence only: a normal draft-to-ready lifecycle may leave more than one, while
+the deterministic recovery receipt remains unique and authoritative.
 
 Before the first seal, a repository administrator must enable the provider
 feature with the API version that introduced its management endpoint:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -692,9 +692,10 @@ Actions app identity (`github-actions`, app ID `15368`). This admission
 metadata does not alter the reproducible schema-v2 candidate receipt or any
 chart, manifest, SBOM, provenance, or workload digest.
 
-That workflow requires the exact current `main` SHA, no pending changesets, and
-the exact expected package set (for example, `@opengeni/react@0.15.0`). It
-builds API, worker, web, relay, and stock headless-sandbox images under
+That workflow requires the exact current `main` SHA and no pending changesets.
+It derives every unpublished publishable workspace package directly from the
+exact checkout and npm registry, so a caller-maintained list cannot omit a
+package. It builds API, worker, web, relay, and stock headless-sandbox images under
 full-source-SHA candidate tags. Migrations explicitly reuse the API manifest.
 Each manifest is built at most once; retries reuse existing partial results.
 Before acceptance, the same workflow packages the Helm chart twice through the
@@ -789,8 +790,9 @@ GitHub API and requires the canonical repository/workflow, a completed
 successful `workflow_dispatch` run, exact commit/tree SHA and run attempt, one
 owned unexpired Actions artifact with its provider digest, and the expected
 artifact name. URLs and archive digests are derived only after those checks. The
-same exact expected package set (including an empty set for an application-only
-release) and an explicit zero-gap confirmation are still required. The product
+exact package set is carried from the immutable candidate receipt and
+re-derived from registry state immediately before publication; the dispatch
+caller cannot add or omit packages. An explicit zero-gap confirmation is still required. The product
 release identity comes from the exact SemVer `version`/`appVersion` pair
 committed in `deploy/helm/opengeni/Chart.yaml`; it is independent of whichever
 npm packages changed. The selected dispatch ref, `source_sha`, checked-out

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -558,19 +558,24 @@ provider response must identify the GitHub Actions bot as author and report the
 published prerelease as `immutable: true`, or sealing fails closed. GitHub then
 locks the tag and emits its native release attestation.
 
-If a seal creates and publishes that immutable tag/release but is interrupted
-before its source-admission and retention checks complete, dispatch the same
-workflow from current `main` with `merged_source_sha` set to the exact accepted
-PR merge source. This is recovery, not a late seal: it refuses to create either
-retained artifact. Before the first check mutation it reconstructs the complete
-historical base-to-head tree/file admission, proves the original PR
-base/head/merge and tree, re-reads the unchanged GitHub Actions-owned immutable
-release, and proves the merged source's ancestry into current `main`. Recovery
-pins the first provider read's PR-author numeric ID/account type and exact head
+If a seal fails before merge or is interrupted and the reviewed PR has since
+merged, dispatch the same workflow from current `main` with `merged_source_sha`
+set to the exact accepted PR merge source. Before its first mutation, recovery
+reconstructs the complete historical base-to-head tree/file admission, proves
+the original PR base/head/merge and tree, proves the merged source's ancestry
+into current `main`, and reads the retained tag/release as one paired state. It
+accepts either an unchanged GitHub Actions-owned immutable pair or a pair that
+is still completely absent through the pre-mutation fence. In the absent case,
+there must also be no pre-existing retention check; recovery then creates the
+exact tag and immutable prerelease before restoring checks. A partial pair,
+preclaimed check, non-404 provider read error, identity drift, or evidence
+movement fails before mutation. A create conflict or provider error is never
+normalized or followed by takeover of the competing state. Recovery pins the
+first provider read's PR-author numeric ID/account type and exact head
 branch/repository across its pre-mutation and terminal reads; it supports both
 Version and explicitly sealed non-Version release PRs without substituting a
-hard-coded author or branch. It then idempotently restores only whichever exact
-provider checks are absent.
+hard-coded author or branch. Successful replay reuses the exact immutable pair
+and idempotently restores only whichever exact provider checks are absent.
 
 Before the first seal, a repository administrator must enable the provider
 feature with the API version that introduced its management endpoint:
@@ -640,10 +645,10 @@ release operators a provider-owned proof of immutable source retention without
 requiring a credential that crosses repository boundaries. A tag and immutable
 prerelease are retention evidence, not approval: the native pre-merge review
 and every later source/acceptance gate remain mandatory. A missing, moved,
-indirect, mutable, non-provider-authored, or post-hoc substitute fails release
-provenance. Retained-head prereleases and their tags intentionally accumulate
-for the lifetime of their release evidence; never include them in routine
-release or tag cleanup.
+indirect, mutable, non-provider-authored, or post-hoc substitute outside the
+fenced merged-source recovery above fails release provenance. Retained-head
+prereleases and their tags intentionally accumulate for the lifetime of their
+release evidence; never include them in routine release or tag cleanup.
 
 Release admission derives the merge outcome exclusively from GitHub records; a
 workflow caller cannot assert a merge method. The exact current `main` SHA is

--- a/docs/workbench-acceptance.md
+++ b/docs/workbench-acceptance.md
@@ -73,11 +73,11 @@ Evidence MUST NOT contain raw credentials, cookies, signed object URLs,
 kubeconfigs, customer data, conversation content outside the deterministic
 fixture, or unredacted provider responses.
 
-The manually dispatched release-candidate workflow accepts the exact package
-plan (which is empty for an application-only release), takes the product release
-version from the source-controlled Helm chart rather than inferring it from an
-unrelated npm package version, requires the current versioned `main` SHA with no
-pending changesets,
+The manually dispatched release-candidate workflow derives the complete package
+plan from the exact checkout and npm registry state (which is empty for an
+application-only release), takes the product release version from the
+source-controlled Helm chart rather than inferring it from an unrelated npm
+package version, requires the current versioned `main` SHA with no pending changesets,
 builds each physical image at most once under a full-SHA candidate tag, and
 publishes an immutable `opengeni-candidate-<sourceSha>` receipt. A retry reuses
 an already-present manifest instead of rebuilding it. Image and chart

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -870,16 +870,6 @@ export async function recoverReleaseHeadEvidence(options = {}) {
     JSON.stringify(preMutationEvidence) === JSON.stringify(initialEvidence),
     "release head evidence moved before recovery mutation",
   );
-  const sourceChecks = preMutationChecks.filter(
-    (check) => check?.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
-  );
-  if (sourceChecks.length > 0) {
-    assertSuccessfulCheck(
-      preMutationChecks,
-      RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
-      context.headSha,
-    );
-  }
   if (initialEvidence === null) {
     invariant(
       preMutationChecks.every(
@@ -896,39 +886,39 @@ export async function recoverReleaseHeadEvidence(options = {}) {
 
   const now = options.now ?? (() => new Date());
   const checkContext = { ...context, releaseHeadRelease };
-  if (sourceChecks.length === 0) {
-    await upsertCheckRun(
-      api,
-      checkContext,
-      "source-admission",
-      {
-        status: "in_progress",
-        title: "Recovering exact historical source admission",
-        summary:
-          `Reconstructing base ${context.baseSha} to head ${context.headSha}; ` +
-          `manifest ${historicalAdmission.manifestSha256}.`,
-      },
-      now,
-    );
-    await upsertCheckRun(
-      api,
-      checkContext,
-      "source-admission",
-      {
-        status: "completed",
-        conclusion: "success",
-        title: "Historical source admission recovered",
-        summary:
-          `PR #${context.prNumber} exact base/head tree delta is provider-complete; ` +
-          `manifest ${historicalAdmission.manifestSha256}.`,
-      },
-      now,
-    );
-  }
-  const sourceAdmission = assertSuccessfulCheck(
-    await paginatedCheckRuns(api, context.headSha),
+  await upsertCheckRun(
+    api,
+    checkContext,
+    "source-admission",
+    {
+      status: "in_progress",
+      title: "Recovering exact historical source admission",
+      summary:
+        `Reconstructing base ${context.baseSha} to head ${context.headSha}; ` +
+        `manifest ${historicalAdmission.manifestSha256}.`,
+    },
+    now,
+  );
+  await upsertCheckRun(
+    api,
+    checkContext,
+    "source-admission",
+    {
+      status: "completed",
+      conclusion: "success",
+      title: "Historical source admission recovered",
+      summary:
+        `PR #${context.prNumber} exact base/head tree delta is provider-complete; ` +
+        `manifest ${historicalAdmission.manifestSha256}.`,
+    },
+    now,
+  );
+  const sourceAdmissionIdentity = checkIdentity("source-admission", checkContext);
+  const sourceAdmission = assertSuccessfulCheckRun(
+    await findCheckRun(api, checkContext, sourceAdmissionIdentity),
     RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
     context.headSha,
+    sourceAdmissionIdentity.externalId,
   );
   await upsertCheckRun(
     api,
@@ -1313,6 +1303,26 @@ function assertSuccessfulCheck(checks, name, sha) {
   invariant(
     check.status === "completed" && check.conclusion === "success",
     `${name} did not complete successfully`,
+  );
+  return Object.freeze({
+    name,
+    appSlug: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.slug,
+    appId: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.id,
+  });
+}
+
+function assertSuccessfulCheckRun(check, name, sha, externalId) {
+  invariant(check !== undefined, `${name} canonical check run is missing on ${sha}`);
+  invariant(check?.name === name, `${name} canonical check has another name`);
+  invariant(check?.head_sha === sha, `${name} canonical check is bound to another commit`);
+  invariant(
+    check?.external_id === externalId,
+    `${name} canonical check has another idempotency identity`,
+  );
+  assertGitHubActionsApp(check?.app, `${name} canonical check`);
+  invariant(
+    check.status === "completed" && check.conclusion === "success",
+    `${name} canonical check did not complete successfully`,
   );
   return Object.freeze({
     name,

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -185,13 +185,22 @@ async function ensureReleaseHeadRef(api, headSha) {
   const path = repositoryPath(`/git/ref/tags/${tag}`);
   const existing = await api.getOptional(path);
   if (existing === null) {
-    await api.post(repositoryPath("/git/refs"), {
-      ref: `refs/tags/${tag}`,
-      sha: headSha,
-    });
+    return createReleaseHeadRef(api, headSha);
   } else {
     assertReleaseHeadRef(existing, headSha);
   }
+  const terminal = await api.get(path);
+  assertReleaseHeadRef(terminal, headSha);
+  return { name: tag, ref: `refs/tags/${tag}`, sha: headSha };
+}
+
+async function createReleaseHeadRef(api, headSha) {
+  const tag = releaseHeadTagName(headSha);
+  const path = repositoryPath(`/git/ref/tags/${tag}`);
+  await api.post(repositoryPath("/git/refs"), {
+    ref: `refs/tags/${tag}`,
+    sha: headSha,
+  });
   const terminal = await api.get(path);
   assertReleaseHeadRef(terminal, headSha);
   return { name: tag, ref: `refs/tags/${tag}`, sha: headSha };
@@ -249,19 +258,26 @@ async function ensureReleaseHeadRelease(api, headSha) {
   const path = repositoryPath(`/releases/tags/${tagName}`);
   const existing = await api.getOptional(path);
   if (existing === null) {
-    await api.post(repositoryPath("/releases"), {
-      tag_name: tagName,
-      name: releaseHeadReleaseName(headSha),
-      body:
-        `Provider-retained exact release-source head ${headSha}. ` +
-        "This prerelease exists only as immutable source-retention evidence.",
-      draft: false,
-      prerelease: true,
-      make_latest: "false",
-    });
+    return createReleaseHeadRelease(api, headSha);
   } else {
     assertReleaseHeadRelease(existing, headSha);
   }
+  return assertReleaseHeadRelease(await api.get(path), headSha);
+}
+
+async function createReleaseHeadRelease(api, headSha) {
+  const tagName = releaseHeadTagName(headSha);
+  const path = repositoryPath(`/releases/tags/${tagName}`);
+  await api.post(repositoryPath("/releases"), {
+    tag_name: tagName,
+    name: releaseHeadReleaseName(headSha),
+    body:
+      `Provider-retained exact release-source head ${headSha}. ` +
+      "This prerelease exists only as immutable source-retention evidence.",
+    draft: false,
+    prerelease: true,
+    make_latest: "false",
+  });
   return assertReleaseHeadRelease(await api.get(path), headSha);
 }
 
@@ -770,21 +786,30 @@ async function assertSourceAncestorOfCurrentMain(api, sourceSha, currentMainSha)
   );
 }
 
-async function readExistingReleaseHeadEvidence(api, headSha) {
+async function readOptionalReleaseHeadEvidence(api, headSha) {
   const name = releaseHeadTagName(headSha);
   const ref = `refs/tags/${name}`;
-  const retainedName = assertReleaseHeadRef(
-    await api.get(repositoryPath(`/git/ref/tags/${name}`)),
-    headSha,
+  const [retainedRef, retainedRelease] = await Promise.all([
+    api.getOptional(repositoryPath(`/git/ref/tags/${name}`)),
+    api.getOptional(repositoryPath(`/releases/tags/${name}`)),
+  ]);
+  invariant(
+    (retainedRef === null) === (retainedRelease === null),
+    "release head recovery evidence is only partially present",
   );
-  const release = assertReleaseHeadRelease(
-    await api.get(repositoryPath(`/releases/tags/${name}`)),
-    headSha,
-  );
+  if (retainedRef === null) return null;
+  const retainedName = assertReleaseHeadRef(retainedRef, headSha);
+  const release = assertReleaseHeadRelease(retainedRelease, headSha);
   return {
     releaseHead: { name: retainedName, ref, sha: headSha },
     releaseHeadRelease: release,
   };
+}
+
+async function readExistingReleaseHeadEvidence(api, headSha) {
+  const evidence = await readOptionalReleaseHeadEvidence(api, headSha);
+  invariant(evidence !== null, "release head recovery evidence is absent");
+  return evidence;
 }
 
 export async function recoverReleaseHeadEvidence(options = {}) {
@@ -831,28 +856,46 @@ export async function recoverReleaseHeadEvidence(options = {}) {
     fetchImpl,
     logger,
   });
-  const { releaseHead, releaseHeadRelease } = await readExistingReleaseHeadEvidence(
-    api,
-    context.headSha,
-  );
-  const [preMutationMain, preMutationPull, preMutationEvidence] = await Promise.all([
-    api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
-    api.get(repositoryPath(`/pulls/${context.prNumber}`)),
-    readExistingReleaseHeadEvidence(api, context.headSha),
-  ]);
+  const initialEvidence = await readOptionalReleaseHeadEvidence(api, context.headSha);
+  const [preMutationMain, preMutationPull, preMutationEvidence, preMutationChecks] =
+    await Promise.all([
+      api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
+      api.get(repositoryPath(`/pulls/${context.prNumber}`)),
+      readOptionalReleaseHeadEvidence(api, context.headSha),
+      paginatedCheckRuns(api, context.headSha),
+    ]);
   assertMainRef(preMutationMain, context.sha, "pre-mutation release-head recovery default branch");
   assertRecoveryReleasePull(preMutationPull, context, pullIdentity);
   invariant(
-    JSON.stringify(preMutationEvidence.releaseHead) === JSON.stringify(releaseHead) &&
-      JSON.stringify(preMutationEvidence.releaseHeadRelease) === JSON.stringify(releaseHeadRelease),
+    JSON.stringify(preMutationEvidence) === JSON.stringify(initialEvidence),
     "release head evidence moved before recovery mutation",
   );
+  const sourceChecks = preMutationChecks.filter(
+    (check) => check?.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+  );
+  if (sourceChecks.length > 0) {
+    assertSuccessfulCheck(
+      preMutationChecks,
+      RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      context.headSha,
+    );
+  }
+  if (initialEvidence === null) {
+    invariant(
+      preMutationChecks.every(
+        (check) => check?.name !== RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention,
+      ),
+      "release head retention check exists without retained evidence",
+    );
+  }
+
+  const { releaseHead, releaseHeadRelease } = initialEvidence ?? {
+    releaseHead: await createReleaseHeadRef(api, context.headSha),
+    releaseHeadRelease: await createReleaseHeadRelease(api, context.headSha),
+  };
 
   const now = options.now ?? (() => new Date());
   const checkContext = { ...context, releaseHeadRelease };
-  const sourceChecks = (await paginatedCheckRuns(api, context.headSha)).filter(
-    (check) => check?.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
-  );
   if (sourceChecks.length === 0) {
     await upsertCheckRun(
       api,

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -1345,6 +1345,17 @@ async function verifyDurableSourceAdmission({
   const matching = checks.filter(
     (check) => check?.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
   );
+  const canonicalExternalId = `opengeni:release-automation:source-admission:v1:pr:${pullNumber}:head:${headSha}`;
+  const canonical = matching.filter((check) => check?.external_id === canonicalExternalId);
+  invariant(canonical.length <= 1, "canonical recovered source-admission check is not unique");
+  if (canonical.length === 1) {
+    return assertSuccessfulCheckRun(
+      canonical[0],
+      RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      headSha,
+      canonicalExternalId,
+    );
+  }
   if (matching.length > 0) {
     return assertSuccessfulCheck(
       checks,

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -1278,6 +1278,61 @@ function assertSuccessfulCheck(checks, name, sha) {
   });
 }
 
+async function verifyDurableSourceAdmission({
+  api,
+  checks,
+  pull,
+  pullNumber,
+  baseSha,
+  headSha,
+  token,
+  fetchImpl,
+  logger,
+}) {
+  const matching = checks.filter(
+    (check) => check?.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+  );
+  if (matching.length > 0) {
+    return assertSuccessfulCheck(
+      checks,
+      RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      headSha,
+    );
+  }
+
+  // GitHub may discard every check-run projection for a merged head when its
+  // source branch is deleted. The retained commit/release and the provider PR
+  // objects remain authoritative, so reconstruct the same admission directly
+  // instead of making a post-merge release depend on disposable UI state.
+  const historical = await verifyHistoricalSourceAdmission({
+    number: pullNumber,
+    baseSha,
+    headSha,
+    headRef: assertString(pull?.head?.ref, "historical source-admission head ref"),
+    headRepository: assertString(
+      pull?.head?.repo?.full_name,
+      "historical source-admission head repository",
+    ),
+    token,
+    fetchImpl,
+    logger,
+  });
+  const terminalChecks = await paginatedCheckRuns(api, headSha);
+  invariant(
+    terminalChecks.every(
+      (check) => check?.name !== RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+    ),
+    "source-admission check projection changed during historical reconstruction",
+  );
+  return Object.freeze({
+    name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+    appSlug: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.slug,
+    appId: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.id,
+    reconstructed: true,
+    manifestSha256: historical.manifestSha256,
+  });
+}
+
 function assertCommit(value, expectedSha, label) {
   invariant(value?.sha === expectedSha, `${label} identity changed`);
   const treeSha = assertSha(value?.tree?.sha, `${label} tree SHA`);
@@ -1331,7 +1386,14 @@ function assertMergedPull(value, expected) {
     merger.type === "User" || merger.type === "Bot",
     "pull-request merge actor type is invalid",
   );
-  return { baseSha, headSha, mergedAt, author, merger, commitCount: value.commits };
+  return {
+    baseSha,
+    headSha,
+    mergedAt,
+    author,
+    merger,
+    commitCount: value.commits,
+  };
 }
 
 function assertProviderMergeEvent(events, sourceSha, pullIdentity) {
@@ -1529,7 +1591,10 @@ export async function verifyApprovedMerge(options = {}) {
     "associated pull summary merge SHA changed",
   );
   const pull = record(await api.get(repositoryPath(`/pulls/${pullNumber}`)), "pull-request detail");
-  const pullIdentity = assertMergedPull(pull, { pullNumber, sourceSha: context.sourceSha });
+  const pullIdentity = assertMergedPull(pull, {
+    pullNumber,
+    sourceSha: context.sourceSha,
+  });
   invariant(
     associatedPull.base?.sha === pullIdentity.baseSha &&
       associatedPull.head?.sha === pullIdentity.headSha,
@@ -1649,11 +1714,17 @@ export async function verifyApprovedMerge(options = {}) {
     releaseHeadReleaseValue,
     pullIdentity.headSha,
   );
-  const sourceAdmission = assertSuccessfulCheck(
-    headChecks,
-    RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
-    pullIdentity.headSha,
-  );
+  const sourceAdmission = await verifyDurableSourceAdmission({
+    api,
+    checks: headChecks,
+    pull,
+    pullNumber,
+    baseSha: pullIdentity.baseSha,
+    headSha: pullIdentity.headSha,
+    token: context.token,
+    fetchImpl: options.fetchImpl ?? globalThis.fetch,
+    logger,
+  });
   const requiredSourceChecks = RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name) =>
     assertSuccessfulCheck(sourceChecks, name, context.sourceSha),
   );

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -1967,6 +1967,67 @@ describe("release approval provenance", () => {
     ).toHaveLength(2);
   });
 
+  test("prefers one canonical recovered admission over duplicate draft-to-ready originals", async () => {
+    const original = (id: number) => ({
+      id,
+      name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      head_sha: headSha,
+      status: "completed",
+      conclusion: "success",
+      external_id: `ordinary-${id}`,
+      app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+    });
+    const fixture = approvalFixture({
+      headChecks: [
+        original(101),
+        original(102),
+        {
+          ...original(103),
+          external_id: `opengeni:release-automation:source-admission:v1:pr:${pullNumber}:head:${headSha}`,
+        },
+      ],
+    });
+
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: fixture.fetchImpl,
+        logger: { log() {} },
+      }),
+    ).resolves.toMatchObject({
+      sourceAdmission: {
+        name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+        appSlug: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.slug,
+        appId: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.id,
+      },
+    });
+  });
+
+  test("rejects duplicate canonical recovered admissions", async () => {
+    const externalId = `opengeni:release-automation:source-admission:v1:pr:${pullNumber}:head:${headSha}`;
+    const canonical = {
+      name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      head_sha: headSha,
+      status: "completed",
+      conclusion: "success",
+      external_id: externalId,
+      app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+    };
+    const fixture = approvalFixture({
+      headChecks: [
+        { ...canonical, id: 201 },
+        { ...canonical, id: 202 },
+      ],
+    });
+
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: fixture.fetchImpl,
+      }),
+    ).rejects.toThrow("canonical recovered source-admission check is not unique");
+  });
+
   test("accepts reviewer login movement while preserving stable provider identity", async () => {
     const reviewer = {
       ...RELEASE_AUTOMATION_CONTRACT.releaseApprover,

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -819,6 +819,7 @@ function recoverySealFixture(
     headRefs?: string[];
     headRepositories?: string[];
     pullAuthors?: Array<Record<string, unknown>>;
+    originalSourceAdmissions?: Array<Record<string, unknown>>;
     releaseHeadRef?: Record<string, unknown> | null;
     release?: Record<string, unknown> | null;
     refCreateStatus?: number;
@@ -1022,10 +1023,13 @@ function recoverySealFixture(
       });
     if (url.pathname === `${prefix}/commits/${headSha}/check-runs`) {
       const checkName = url.searchParams.get("check_name");
+      const originalSourceAdmissions =
+        options.originalSourceAdmissions ??
+        (options.existingSourceAdmission ? [sourceAdmission] : []);
       return response({
         check_runs: checkName
           ? checks.filter((check) => check.name === checkName)
-          : [...(options.existingSourceAdmission ? [sourceAdmission] : []), ...checks],
+          : [...originalSourceAdmissions, ...checks],
       });
     }
     if (url.pathname === `${prefix}/git/ref/tags/${releaseTag}`) {
@@ -1048,6 +1052,52 @@ function recoverySealFixture(
 }
 
 describe("release head retention recovery", () => {
+  test("creates one canonical recovery receipt when draft-to-ready emitted duplicate original admissions", async () => {
+    const fixture = recoverySealFixture({
+      originalSourceAdmissions: [
+        {
+          id: 101,
+          name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+          head_sha: headSha,
+          status: "completed",
+          conclusion: "success",
+          external_id: "draft-source-admission",
+          app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+        },
+        {
+          id: 102,
+          name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+          head_sha: headSha,
+          status: "completed",
+          conclusion: "success",
+          external_id: "ready-source-admission",
+          app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+        },
+      ],
+    });
+
+    const result = await recoverReleaseHeadEvidence({
+      env: recoverySealEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+      now: () => new Date("2026-07-27T09:30:00Z"),
+    });
+
+    expect(result.sourceAdmission).toEqual({
+      name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      appSlug: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.slug,
+      appId: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.id,
+    });
+    expect(
+      fixture.checks.filter(
+        (check) =>
+          check.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission &&
+          check.external_id ===
+            `opengeni:release-automation:source-admission:v1:pr:${pullNumber}:head:${headSha}`,
+      ),
+    ).toHaveLength(1);
+  });
+
   test("creates a clean absent retained pair after every pre-mutation gate and replays idempotently", async () => {
     const fixture = recoverySealFixture({ releaseHeadRef: null, release: null });
     const options = {

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -171,7 +171,12 @@ function dispatchFixture(
     const url = new URL(String(input));
     const method = init?.method ?? "GET";
     const body = init?.body ? JSON.parse(String(init.body)) : undefined;
-    requests.push({ method, path: url.pathname, query: url.searchParams, body });
+    requests.push({
+      method,
+      path: url.pathname,
+      query: url.searchParams,
+      body,
+    });
     const prefix = `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}`;
     if (method === "GET" && url.pathname === prefix) return response(repository());
     if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/main`)
@@ -338,11 +343,17 @@ describe("Version PR dispatch identity", () => {
   test("rejects fork identity and stale main before dispatch", async () => {
     const fork = dispatchFixture({ headRepository: "attacker/opengeni" });
     await expect(
-      validateVersionPrDispatch({ env: releasePushEnv(), fetchImpl: fork.fetchImpl }),
+      validateVersionPrDispatch({
+        env: releasePushEnv(),
+        fetchImpl: fork.fetchImpl,
+      }),
     ).rejects.toThrow("Version PR is not from the base repository");
     const stale = dispatchFixture({ mainSha: "9".repeat(40) });
     await expect(
-      validateVersionPrDispatch({ env: releasePushEnv(), fetchImpl: stale.fetchImpl }),
+      validateVersionPrDispatch({
+        env: releasePushEnv(),
+        fetchImpl: stale.fetchImpl,
+      }),
     ).rejects.toThrow("default branch differs from the admitted base SHA");
   });
 });
@@ -378,7 +389,12 @@ function admissionFixture(
     const url = new URL(String(input));
     const method = init?.method ?? "GET";
     const body = init?.body ? JSON.parse(String(init.body)) : undefined;
-    requests.push({ method, path: url.pathname, query: url.searchParams, body });
+    requests.push({
+      method,
+      path: url.pathname,
+      query: url.searchParams,
+      body,
+    });
     if (method === "POST" && options.seal && url.pathname === `${prefix}/git/refs`) {
       retainedHeadSha = body?.sha;
       return response(
@@ -513,13 +529,27 @@ function admissionFixture(
       return response({
         sha: pullMergeBaseTreeSha,
         truncated: false,
-        tree: [{ path: "package.json", mode: "100644", type: "blob", sha: "1".repeat(40) }],
+        tree: [
+          {
+            path: "package.json",
+            mode: "100644",
+            type: "blob",
+            sha: "1".repeat(40),
+          },
+        ],
       });
     if (url.pathname === `${prefix}/git/trees/${headTreeSha}`)
       return response({
         sha: headTreeSha,
         truncated: false,
-        tree: [{ path: "package.json", mode: "100644", type: "blob", sha: "2".repeat(40) }],
+        tree: [
+          {
+            path: "package.json",
+            mode: "100644",
+            type: "blob",
+            sha: "2".repeat(40),
+          },
+        ],
       });
     return response({ message: `unexpected GET ${url.pathname}` }, 404);
   }
@@ -535,7 +565,12 @@ describe("automation CI admission", () => {
       logger: { log() {} },
     });
     expect(result).toMatchObject({ prNumber: pullNumber, baseSha, headSha });
-    expect(result.admission).toMatchObject({ baseSha, headSha, baseTreeSha, headTreeSha });
+    expect(result.admission).toMatchObject({
+      baseSha,
+      headSha,
+      baseTreeSha,
+      headTreeSha,
+    });
     expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
   });
 
@@ -734,7 +769,10 @@ describe("release head evidence retention", () => {
   });
 
   test("rejects a conflicting retained head and workflow/base drift", async () => {
-    const fixture = admissionFixture({ seal: true, releaseHeadRefSha: "9".repeat(40) });
+    const fixture = admissionFixture({
+      seal: true,
+      releaseHeadRefSha: "9".repeat(40),
+    });
     await expect(
       sealReleaseHeadEvidence({
         env: sealReleaseHeadEnv(),
@@ -831,7 +869,12 @@ function recoverySealFixture(
     const url = new URL(String(input));
     const method = init?.method ?? "GET";
     const body = init?.body ? JSON.parse(String(init.body)) : undefined;
-    requests.push({ method, path: url.pathname, query: url.searchParams, body });
+    requests.push({
+      method,
+      path: url.pathname,
+      query: url.searchParams,
+      body,
+    });
     if (method === "POST" && url.pathname === `${prefix}/check-runs`) {
       const check = {
         ...body,
@@ -926,13 +969,27 @@ function recoverySealFixture(
       return response({
         sha: baseTreeSha,
         truncated: false,
-        tree: [{ path: "package.json", mode: "100644", type: "blob", sha: "1".repeat(40) }],
+        tree: [
+          {
+            path: "package.json",
+            mode: "100644",
+            type: "blob",
+            sha: "1".repeat(40),
+          },
+        ],
       });
     if (url.pathname === `${prefix}/git/trees/${headTreeSha}`)
       return response({
         sha: headTreeSha,
         truncated: false,
-        tree: [{ path: "package.json", mode: "100644", type: "blob", sha: "2".repeat(40) }],
+        tree: [
+          {
+            path: "package.json",
+            mode: "100644",
+            type: "blob",
+            sha: "2".repeat(40),
+          },
+        ],
       });
     if (url.pathname === `${prefix}/commits/${headSha}/check-runs`) {
       const checkName = url.searchParams.get("check_name");
@@ -1134,7 +1191,12 @@ function checksFixture(
     const url = new URL(String(input));
     const method = init?.method ?? "GET";
     const body = init?.body ? JSON.parse(String(init.body)) : undefined;
-    requests.push({ method, path: url.pathname, query: url.searchParams, body });
+    requests.push({
+      method,
+      path: url.pathname,
+      query: url.searchParams,
+      body,
+    });
     if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/main`)
       return response(mainRef());
     if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}`)
@@ -1408,6 +1470,7 @@ function approvalFixture(
       mainReads += 1;
       return response(mainRef(mainReads === 1 ? mergeSha : (options.terminalMainSha ?? mergeSha)));
     }
+    if (method === "GET" && url.pathname === prefix) return response(repository());
     if (method === "GET" && url.pathname === `${prefix}/git/commits/${mergeSha}`)
       return response({
         sha: mergeSha,
@@ -1450,11 +1513,54 @@ function approvalFixture(
           sha: baseSha,
           repo: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
         },
-        head: { sha: pullHeadSha },
+        head: {
+          ref: "changeset-release/main",
+          sha: pullHeadSha,
+          repo: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+        },
         commits: pullCommitCount,
+        changed_files: 1,
         requested_reviewers: options.requestedReview
           ? [options.requestedReviewer ?? RELEASE_AUTOMATION_CONTRACT.releaseApprover]
           : [],
+      });
+    if (method === "GET" && url.pathname === `${prefix}/compare/${baseSha}...${pullHeadSha}`)
+      return response({
+        status: "ahead",
+        base_commit: { sha: baseSha },
+        merge_base_commit: { sha: baseSha },
+        ahead_by: pullCommitCount,
+        behind_by: 0,
+        total_commits: pullCommitCount,
+        commits: [{ sha: pullHeadSha }],
+      });
+    if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}/files`)
+      return response([{ filename: "package.json", status: "modified" }]);
+    if (method === "GET" && url.pathname === `${prefix}/git/trees/${baseTreeSha}`)
+      return response({
+        sha: baseTreeSha,
+        truncated: false,
+        tree: [
+          {
+            path: "package.json",
+            mode: "100644",
+            type: "blob",
+            sha: "1".repeat(40),
+          },
+        ],
+      });
+    if (method === "GET" && url.pathname === `${prefix}/git/trees/${headTreeSha}`)
+      return response({
+        sha: headTreeSha,
+        truncated: false,
+        tree: [
+          {
+            path: "package.json",
+            mode: "100644",
+            type: "blob",
+            sha: "2".repeat(40),
+          },
+        ],
       });
     if (method === "GET" && url.pathname === `${prefix}/issues/${pullNumber}/timeline`)
       return response(mergeEvent);
@@ -1465,7 +1571,11 @@ function approvalFixture(
               { sha: rebasedFirstSha, parents: [{ sha: baseSha }] },
               {
                 sha: mergeSha,
-                parents: [{ sha: options.discontinuousCompare ? baseSha : rebasedFirstSha }],
+                parents: [
+                  {
+                    sha: options.discontinuousCompare ? baseSha : rebasedFirstSha,
+                  },
+                ],
               },
             ]
           : [{ sha: mergeSha, parents: [{ sha: baseSha }] }];
@@ -1595,7 +1705,10 @@ describe("release approval provenance", () => {
   });
 
   test("accepts the provider-bound structured single-maintainer admin PASS", async () => {
-    const fixture = approvalFixture({ mergeMethod: "single", reviewState: "COMMENTED" });
+    const fixture = approvalFixture({
+      mergeMethod: "single",
+      reviewState: "COMMENTED",
+    });
     await expect(
       verifyApprovedMerge({
         env: approvalEnv(),
@@ -1605,9 +1718,34 @@ describe("release approval provenance", () => {
     ).resolves.toEqual(
       expect.objectContaining({
         mergeMethod: "single-commit-squash-or-rebase",
-        review: expect.objectContaining({ type: "single-maintainer-admin-pass" }),
+        review: expect.objectContaining({
+          type: "single-maintainer-admin-pass",
+        }),
       }),
     );
+  });
+
+  test("reconstructs source admission when GitHub deletes merged-head check projections", async () => {
+    const fixture = approvalFixture({ headChecks: [] });
+    const result = await verifyApprovedMerge({
+      env: approvalEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+    });
+    expect(result.sourceAdmission).toEqual({
+      name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      appSlug: "github-actions",
+      appId: 15368,
+      reconstructed: true,
+      manifestSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+    });
+    expect(
+      fixture.requests.filter(
+        (request) =>
+          request.path ===
+          `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}/commits/${headSha}/check-runs`,
+      ),
+    ).toHaveLength(2);
   });
 
   test("accepts reviewer login movement while preserving stable provider identity", async () => {
@@ -1653,7 +1791,9 @@ describe("release approval provenance", () => {
     });
     expect(result).toEqual(
       expect.objectContaining({
-        review: expect.objectContaining({ type: "single-maintainer-admin-pass" }),
+        review: expect.objectContaining({
+          type: "single-maintainer-admin-pass",
+        }),
       }),
     );
   });
@@ -1678,7 +1818,10 @@ describe("release approval provenance", () => {
     ] as const) {
       const fixture = approvalFixture({ reviewDetailReviewer });
       await expect(
-        verifyApprovedMerge({ env: approvalEnv(), fetchImpl: fixture.fetchImpl }),
+        verifyApprovedMerge({
+          env: approvalEnv(),
+          fetchImpl: fixture.fetchImpl,
+        }),
       ).rejects.toThrow(message);
     }
 
@@ -1688,7 +1831,10 @@ describe("release approval provenance", () => {
       reviewerLoginSnapshot: "",
     });
     await expect(
-      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: missingSnapshot.fetchImpl }),
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: missingSnapshot.fetchImpl,
+      }),
     ).rejects.toThrow("single-maintainer admin PASS reviewer login snapshot is missing");
   });
 
@@ -1704,13 +1850,18 @@ describe("release approval provenance", () => {
   });
 
   test("rejects self-approval and a non-approval decision", async () => {
-    const self = approvalFixture({ authorId: RELEASE_AUTOMATION_CONTRACT.releaseApprover.id });
+    const self = approvalFixture({
+      authorId: RELEASE_AUTOMATION_CONTRACT.releaseApprover.id,
+    });
     await expect(
       verifyApprovedMerge({ env: approvalEnv(), fetchImpl: self.fetchImpl }),
     ).rejects.toThrow("trusted reviewer authored the independently approved pull request");
     const requested = approvalFixture({ reviewState: "CHANGES_REQUESTED" });
     await expect(
-      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: requested.fetchImpl }),
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: requested.fetchImpl,
+      }),
     ).rejects.toThrow(
       "neither independent approval nor a provider-bound single-maintainer admin PASS",
     );
@@ -1756,14 +1907,19 @@ describe("release approval provenance", () => {
     await expect(
       verifyApprovedMerge({
         env: approvalEnv(),
-        fetchImpl: approvalFixture({ pullHeadSha: "8".repeat(40), reviewCommit: headSha })
-          .fetchImpl,
+        fetchImpl: approvalFixture({
+          pullHeadSha: "8".repeat(40),
+          reviewCommit: headSha,
+        }).fetchImpl,
       }),
     ).rejects.toThrow("did not review the exact PR head");
     await expect(
       verifyApprovedMerge({
         env: approvalEnv(),
-        fetchImpl: approvalFixture({ mergeMethod: "rebase", discontinuousCompare: true }).fetchImpl,
+        fetchImpl: approvalFixture({
+          mergeMethod: "rebase",
+          discontinuousCompare: true,
+        }).fetchImpl,
       }),
     ).rejects.toThrow("discontinuity");
     await expect(
@@ -1786,7 +1942,7 @@ describe("release approval provenance", () => {
     ).rejects.toThrow("terminal release main differs");
   });
 
-  test("rejects missing, duplicate, failed, or foreign source-admission and source checks", async () => {
+  test("rejects duplicate, failed, or foreign source-admission and source checks", async () => {
     const success = (name: string, sha = headSha, appSlug = "github-actions", appId = 15368) => ({
       name,
       head_sha: sha,
@@ -1794,12 +1950,6 @@ describe("release approval provenance", () => {
       conclusion: "success",
       app: { slug: appSlug, id: appId },
     });
-    await expect(
-      verifyApprovedMerge({
-        env: approvalEnv(),
-        fetchImpl: approvalFixture({ headChecks: [] }).fetchImpl,
-      }),
-    ).rejects.toThrow("exactly one check run");
     await expect(
       verifyApprovedMerge({
         env: approvalEnv(),
@@ -2034,7 +2184,10 @@ describe("workflow contracts", () => {
       "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
     );
     expect(admission.steps[0].with).toEqual(
-      expect.objectContaining({ ref: "${{ github.sha }}", "persist-credentials": false }),
+      expect.objectContaining({
+        ref: "${{ github.sha }}",
+        "persist-credentials": false,
+      }),
     );
     expect(admission.steps.find((step: any) => step.name === "Set up Bun").uses).toBe(
       "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
@@ -2064,7 +2217,10 @@ describe("workflow contracts", () => {
       pull_request_number: expect.objectContaining({ required: true }),
       reviewed_base_sha: expect.objectContaining({ required: true }),
       reviewed_head_sha: expect.objectContaining({ required: true }),
-      merged_source_sha: expect.objectContaining({ required: false, default: "" }),
+      merged_source_sha: expect.objectContaining({
+        required: false,
+        default: "",
+      }),
     });
     expect(seal.permissions).toEqual({ contents: "read" });
     expect(seal.jobs.seal.permissions).toEqual({
@@ -2081,7 +2237,10 @@ describe("workflow contracts", () => {
       "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
     );
     expect(seal.jobs.seal.steps[0].with).toEqual(
-      expect.objectContaining({ ref: "${{ github.sha }}", "persist-credentials": false }),
+      expect.objectContaining({
+        ref: "${{ github.sha }}",
+        "persist-credentials": false,
+      }),
     );
   });
 

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -819,7 +819,12 @@ function recoverySealFixture(
     headRefs?: string[];
     headRepositories?: string[];
     pullAuthors?: Array<Record<string, unknown>>;
+    releaseHeadRef?: Record<string, unknown> | null;
     release?: Record<string, unknown> | null;
+    refCreateStatus?: number;
+    retentionCheck?: Record<string, unknown>;
+    tagLookupStatus?: number;
+    releaseLookupStatus?: number;
     sourceTreeSha?: string;
   } = {},
 ) {
@@ -865,6 +870,15 @@ function recoverySealFixture(
     conclusion: "success",
     app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
   };
+  let releaseHeadRef =
+    options.releaseHeadRef === undefined
+      ? {
+          ref: `refs/tags/${releaseTag}`,
+          object: { type: "commit", sha: headSha },
+        }
+      : options.releaseHeadRef;
+  let release = options.release === undefined ? releaseHeadRelease() : options.release;
+  if (options.retentionCheck) checks.push(options.retentionCheck);
   async function fetchImpl(input: string | URL | Request, init?: RequestInit) {
     const url = new URL(String(input));
     const method = init?.method ?? "GET";
@@ -890,6 +904,21 @@ function recoverySealFixture(
       if (!check) return response({ message: "missing check" }, 404);
       Object.assign(check, body);
       return response(check);
+    }
+    if (method === "POST" && url.pathname === `${prefix}/git/refs`) {
+      if (options.refCreateStatus !== undefined)
+        return response({ message: "ref create rejected" }, options.refCreateStatus);
+      if (releaseHeadRef !== null) return response({ message: "ref already exists" }, 422);
+      releaseHeadRef = {
+        ref: body?.ref,
+        object: { type: "commit", sha: body?.sha },
+      };
+      return response(releaseHeadRef, 201);
+    }
+    if (method === "POST" && url.pathname === `${prefix}/releases`) {
+      if (release !== null) return response({ message: "release already exists" }, 422);
+      release = releaseHeadRelease();
+      return response(release, 201);
     }
     if (method !== "GET") return response({ message: "unexpected mutation" }, 405);
     if (url.pathname === prefix) return response(repository());
@@ -999,21 +1028,89 @@ function recoverySealFixture(
           : [...(options.existingSourceAdmission ? [sourceAdmission] : []), ...checks],
       });
     }
-    if (url.pathname === `${prefix}/git/ref/tags/${releaseTag}`)
-      return response({
-        ref: `refs/tags/${releaseTag}`,
-        object: { type: "commit", sha: headSha },
-      });
-    if (url.pathname === `${prefix}/releases/tags/${releaseTag}`)
-      return options.release === null
+    if (url.pathname === `${prefix}/git/ref/tags/${releaseTag}`) {
+      if (options.tagLookupStatus !== undefined)
+        return response({ message: "tag lookup failed" }, options.tagLookupStatus);
+      return releaseHeadRef === null
+        ? response({ message: "missing release head ref" }, 404)
+        : response(releaseHeadRef);
+    }
+    if (url.pathname === `${prefix}/releases/tags/${releaseTag}`) {
+      if (options.releaseLookupStatus !== undefined)
+        return response({ message: "release lookup failed" }, options.releaseLookupStatus);
+      return release === null
         ? response({ message: "missing immutable release" }, 404)
-        : response(options.release ?? releaseHeadRelease());
+        : response(release);
+    }
     return response({ message: `unexpected GET ${url.pathname}` }, 404);
   }
   return { checks, fetchImpl, requests };
 }
 
 describe("release head retention recovery", () => {
+  test("creates a clean absent retained pair after every pre-mutation gate and replays idempotently", async () => {
+    const fixture = recoverySealFixture({ releaseHeadRef: null, release: null });
+    const options = {
+      env: recoverySealEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+      now: () => new Date("2026-07-27T09:30:00Z"),
+    };
+    const result = await recoverReleaseHeadEvidence(options);
+    const replay = await recoverReleaseHeadEvidence(options);
+
+    expect(result.releaseHead).toEqual({
+      name: `${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${headSha}`,
+      ref: `refs/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${headSha}`,
+      sha: headSha,
+    });
+    expect(replay.releaseHead).toEqual(result.releaseHead);
+    expect(replay.releaseHeadRelease).toEqual(result.releaseHeadRelease);
+    expect(
+      fixture.requests.filter(
+        (request) => request.method === "POST" && request.path.endsWith("/git/refs"),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        body: {
+          ref: `refs/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${headSha}`,
+          sha: headSha,
+        },
+      }),
+    ]);
+    expect(
+      fixture.requests.filter(
+        (request) => request.method === "POST" && request.path.endsWith("/releases"),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        body: expect.objectContaining({
+          tag_name: `${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${headSha}`,
+          name: `${RELEASE_AUTOMATION_CONTRACT.releaseHeadReleaseNamePrefix}${headSha}`,
+          draft: false,
+          prerelease: true,
+          make_latest: "false",
+        }),
+      }),
+    ]);
+    const firstMutation = fixture.requests.findIndex((request) => request.method !== "GET");
+    expect(firstMutation).toBeGreaterThan(0);
+    expect(
+      fixture.requests.slice(0, firstMutation).every((request) => request.method === "GET"),
+    ).toBe(true);
+    expect(
+      fixture.requests
+        .slice(0, firstMutation)
+        .filter((request) => request.path.endsWith(`/git/ref/tags/${result.releaseHead.name}`)),
+    ).toHaveLength(2);
+    expect(
+      fixture.requests
+        .slice(0, firstMutation)
+        .filter((request) => request.path.endsWith(`/releases/tags/${result.releaseHead.name}`)),
+    ).toHaveLength(2);
+    expect(fixture.checks).toHaveLength(2);
+  });
+
   test("replays recovery idempotently for a reviewed non-Version release head", async () => {
     const fixture = recoverySealFixture({
       pullAuthors: [
@@ -1148,15 +1245,29 @@ describe("release head retention recovery", () => {
     expect(movedRepository.checks).toHaveLength(0);
   });
 
-  test("fails closed before check mutation when retained evidence is absent or main lost ancestry", async () => {
+  test("fails closed before mutation on partial retained evidence or main lost ancestry", async () => {
     const missing = recoverySealFixture({ release: null });
     await expect(
       recoverReleaseHeadEvidence({
         env: recoverySealEnv(),
         fetchImpl: missing.fetchImpl,
       }),
-    ).rejects.toThrow("failed with HTTP 404");
+    ).rejects.toThrow("release head recovery evidence is only partially present");
     expect(missing.checks).toHaveLength(0);
+    expect(missing.requests.every((request) => request.method === "GET")).toBe(true);
+
+    const missingTag = recoverySealFixture({
+      releaseHeadRef: null,
+      release: releaseHeadRelease(),
+    });
+    await expect(
+      recoverReleaseHeadEvidence({
+        env: recoverySealEnv(),
+        fetchImpl: missingTag.fetchImpl,
+      }),
+    ).rejects.toThrow("release head recovery evidence is only partially present");
+    expect(missingTag.checks).toHaveLength(0);
+    expect(missingTag.requests.every((request) => request.method === "GET")).toBe(true);
 
     const diverged = recoverySealFixture({ currentMainContainsSource: false });
     await expect(
@@ -1166,6 +1277,64 @@ describe("release head retention recovery", () => {
       }),
     ).rejects.toThrow("current main is not ahead of the merged source");
     expect(diverged.checks).toHaveLength(0);
+  });
+
+  test("fails closed before mutation when absent evidence has a preclaimed retention check", async () => {
+    const fixture = recoverySealFixture({
+      releaseHeadRef: null,
+      release: null,
+      retentionCheck: {
+        id: 991,
+        name: RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention,
+        head_sha: headSha,
+        status: "completed",
+        conclusion: "success",
+        external_id: "attacker-preclaim",
+        app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+      },
+    });
+    await expect(
+      recoverReleaseHeadEvidence({
+        env: recoverySealEnv(),
+        fetchImpl: fixture.fetchImpl,
+      }),
+    ).rejects.toThrow("release head retention check exists without retained evidence");
+    expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  test("does not normalize non-404 retained-evidence provider failures or mutate", async () => {
+    for (const [fixtureOptions, message] of [
+      [{ releaseHeadRef: null, release: null, tagLookupStatus: 500 }, "failed with HTTP 500"],
+      [{ releaseHeadRef: null, release: null, releaseLookupStatus: 503 }, "failed with HTTP 503"],
+    ] as const) {
+      const fixture = recoverySealFixture(fixtureOptions);
+      await expect(
+        recoverReleaseHeadEvidence({
+          env: recoverySealEnv(),
+          fetchImpl: fixture.fetchImpl,
+        }),
+      ).rejects.toThrow(message);
+      expect(fixture.checks).toHaveLength(0);
+      expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
+    }
+  });
+
+  test("does not take over a tag claimed after the clean absence fence", async () => {
+    const fixture = recoverySealFixture({
+      releaseHeadRef: null,
+      release: null,
+      refCreateStatus: 422,
+    });
+    await expect(
+      recoverReleaseHeadEvidence({
+        env: recoverySealEnv(),
+        fetchImpl: fixture.fetchImpl,
+      }),
+    ).rejects.toThrow("GitHub API POST /repos/Cloudgeni-ai/opengeni/git/refs failed with HTTP 422");
+    expect(fixture.checks).toHaveLength(0);
+    expect(
+      fixture.requests.filter((request) => request.method !== "GET").map((request) => request.path),
+    ).toEqual([`/repos/${RELEASE_AUTOMATION_CONTRACT.repository}/git/refs`]);
   });
 });
 

--- a/scripts/release-candidate.ts
+++ b/scripts/release-candidate.ts
@@ -353,11 +353,7 @@ async function writeReceiptFromEnvironment(): Promise<void> {
   console.log(JSON.stringify({ path: outputPath, sha256, receipt }));
 }
 
-async function verifyReceiptFile(args: {
-  path: string;
-  sourceSha: string;
-  expectedPackages: string;
-}): Promise<void> {
+async function verifyReceiptFile(args: { path: string; sourceSha: string }): Promise<void> {
   const raw = await readFile(resolve(args.path), "utf8");
   if (raw.length > 1024 * 1024) {
     throw new Error("release candidate receipt exceeds 1 MiB");
@@ -366,7 +362,6 @@ async function verifyReceiptFile(args: {
     parseJson<unknown>("release candidate receipt", raw),
     {
       sourceSha: args.sourceSha,
-      packages: parseExpectedPackages(args.expectedPackages),
       ociPrefix: releaseOciPrefixFromEnvironment(),
     },
   );
@@ -376,12 +371,10 @@ async function verifyReceiptFile(args: {
 function parseArgs(values: string[]): {
   verifyPath: string | null;
   sourceSha: string;
-  expectedPackages: string;
 } {
   const output = {
     verifyPath: null as string | null,
     sourceSha: "",
-    expectedPackages: "",
   };
   for (let index = 0; index < values.length; index += 1) {
     const flag = values[index];
@@ -392,11 +385,7 @@ function parseArgs(values: string[]): {
     };
     if (flag === "--verify") output.verifyPath = next();
     else if (flag === "--source-sha") output.sourceSha = next();
-    else if (flag === "--expected-packages") {
-      const value = values[++index];
-      if (value === undefined) throw new Error(`${flag} requires a value`);
-      output.expectedPackages = value;
-    } else throw new Error(`unknown argument: ${flag}`);
+    else throw new Error(`unknown argument: ${flag}`);
   }
   if (output.verifyPath && !output.sourceSha) {
     throw new Error("--verify requires --source-sha");
@@ -410,7 +399,6 @@ if (import.meta.main) {
     await verifyReceiptFile({
       path: args.verifyPath,
       sourceSha: args.sourceSha,
-      expectedPackages: args.expectedPackages,
     });
   } else {
     await writeReceiptFromEnvironment();

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -52,6 +52,9 @@ describe("release image workflow contract", () => {
   test("candidate builds every physical image and freezes a full-SHA receipt", async () => {
     const candidate = await workflow("release-candidate.yml");
 
+    expect(candidate).not.toContain("expected_packages:");
+    expect(candidate).not.toContain("OPENGENI_EXPECTED_PACKAGES");
+    expect(candidate).toContain('OPENGENI_RELEASE_PACKAGE_DERIVE_EXPECTED: "true"');
     for (const identity of [
       "target: api",
       "target: worker",
@@ -95,6 +98,10 @@ describe("release image workflow contract", () => {
     const release = await workflow("release.yml");
     const finalJob = release.slice(release.indexOf("\n  images:\n"));
 
+    expect(release).not.toContain("inputs.expected_packages");
+    expect(release).toContain("steps.acceptance-bundle.outputs.expected_packages");
+    expect(release).toContain('map(.name + "@" + .version)');
+    expect(release).toContain("map({name, version})");
     expect(finalJob).toContain("Promote exact accepted manifests");
     expect(finalJob).toContain("docker buildx imagetools create");
     expect(finalJob).toContain("--prefer-index=false");
@@ -201,6 +208,7 @@ describe("release image workflow contract", () => {
     expect(release).toContain("bun run test:publish-consumer");
     expect(release).toContain("uses: changesets/action@");
     expect(release).toContain("OPENGENI_RELEASE_PACKAGE_PHASE: verify");
+    expect(release).not.toContain("OPENGENI_RELEASE_PACKAGE_DERIVE_EXPECTED");
     expect(release).toContain("Publish or reconcile the exact candidate chart");
     expect(release).toContain('[ "$GITHUB_REF" = "refs/heads/main" ]');
     expect(release).not.toContain('[ "$GITHUB_SHA" = "$SOURCE_SHA" ]');
@@ -255,6 +263,7 @@ describe("release image workflow contract", () => {
     const reconciliation = publish.indexOf("Reconcile exact registry package identity");
 
     expect(publish).toContain("expected_packages:");
+    expect(publish).not.toContain("OPENGENI_RELEASE_PACKAGE_DERIVE_EXPECTED");
     expect(publish).toContain("checks: read");
     expect(publish).toContain("filter=latest&per_page=100");
     expect(publish).toContain('test "$GITHUB_REF" = "refs/heads/main"');

--- a/scripts/verify-release-packages.test.ts
+++ b/scripts/verify-release-packages.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  deriveExpectedReleasePackages,
   loadPublishablePackages,
   parseExpectedPackages,
   reconcileReleasePackages,
+  resolveExpectedReleasePackages,
   type PublishablePackage,
   type RegistryPackage,
 } from "./verify-release-packages";
@@ -97,6 +99,88 @@ describe("release package evidence", () => {
         gitHead: "b".repeat(40),
         integrity: "sha512-release-integrity",
       },
+    ]);
+  });
+
+  test("derives the complete unpublished package set without caller-maintained input", () => {
+    expect(
+      deriveExpectedReleasePackages(
+        [react, sdk],
+        new Map([
+          [react.name, null],
+          [sdk.name, published(sdk, "b".repeat(40))],
+        ]),
+      ),
+    ).toEqual([react]);
+  });
+
+  test("derivation fails closed when registry coverage is incomplete", () => {
+    expect(() => deriveExpectedReleasePackages([react], new Map())).toThrow(
+      "registry state was not loaded",
+    );
+  });
+
+  test("automatic derivation is explicit and cannot change other empty-input callers", () => {
+    const registry = new Map<string, RegistryPackage | null>([[react.name, null]]);
+    expect(
+      resolveExpectedReleasePackages({
+        phase: "plan",
+        deriveExpected: false,
+        declaredExpected: [],
+        publishable: [react],
+        registry,
+      }),
+    ).toEqual([]);
+    expect(
+      resolveExpectedReleasePackages({
+        phase: "plan",
+        deriveExpected: true,
+        declaredExpected: [],
+        publishable: [react],
+        registry,
+      }),
+    ).toEqual([react]);
+    expect(() =>
+      resolveExpectedReleasePackages({
+        phase: "verify",
+        deriveExpected: true,
+        declaredExpected: [],
+        publishable: [react],
+        registry,
+      }),
+    ).toThrow("only during planning");
+    expect(() =>
+      resolveExpectedReleasePackages({
+        phase: "plan",
+        deriveExpected: true,
+        declaredExpected: [react],
+        publishable: [react],
+        registry,
+      }),
+    ).toThrow("cannot be combined");
+  });
+
+  test("a frozen candidate package set makes partial-publication retries idempotent", () => {
+    const result = reconcileReleasePackages({
+      sourceSha: sha,
+      phase: "plan",
+      publishable: [react, sdk],
+      expected: [react, sdk],
+      registry: new Map([
+        [react.name, published(react)],
+        [sdk.name, null],
+      ]),
+    });
+
+    expect(result.needsPublish).toBe(true);
+    expect(result.packages).toEqual([
+      {
+        ...react,
+        state: "published",
+        gitHead: sha,
+        integrity: "sha512-release-integrity",
+      },
+      { ...sdk, state: "pending", gitHead: null, integrity: null },
     ]);
   });
 

--- a/scripts/verify-release-packages.ts
+++ b/scripts/verify-release-packages.ts
@@ -46,6 +46,36 @@ export function parseExpectedPackages(value: string): PublishablePackage[] {
   });
 }
 
+export function deriveExpectedReleasePackages(
+  publishable: PublishablePackage[],
+  registry: Map<string, RegistryPackage | null>,
+): PublishablePackage[] {
+  return publishable.filter((pkg) => {
+    const remote = registry.get(pkg.name);
+    if (remote === undefined) {
+      throw new Error(`registry state was not loaded for ${pkg.name}`);
+    }
+    return remote === null;
+  });
+}
+
+export function resolveExpectedReleasePackages(options: {
+  phase: "plan" | "verify";
+  deriveExpected: boolean;
+  declaredExpected: PublishablePackage[];
+  publishable: PublishablePackage[];
+  registry: Map<string, RegistryPackage | null>;
+}): PublishablePackage[] {
+  if (!options.deriveExpected) return options.declaredExpected;
+  if (options.phase !== "plan") {
+    throw new Error("automatic package derivation is valid only during planning");
+  }
+  if (options.declaredExpected.length !== 0) {
+    throw new Error("automatic package derivation cannot be combined with a declared package set");
+  }
+  return deriveExpectedReleasePackages(options.publishable, options.registry);
+}
+
 export function reconcileReleasePackages(options: {
   sourceSha: string;
   phase: "plan" | "verify";
@@ -215,14 +245,18 @@ async function readRegistryPackage(
 async function main(): Promise<void> {
   const root = resolve(import.meta.dir, "..");
   const sourceSha = process.env.OPENGENI_RELEASE_SOURCE_SHA ?? "";
-  const expected = parseExpectedPackages(process.env.OPENGENI_EXPECTED_PACKAGES ?? "");
   const phaseValue = process.env.OPENGENI_RELEASE_PACKAGE_PHASE ?? "";
   if (phaseValue !== "plan" && phaseValue !== "verify") {
     throw new Error("OPENGENI_RELEASE_PACKAGE_PHASE must be plan or verify");
   }
 
   const publishable = loadPublishablePackages();
-  const expectedNames = new Set(expected.map((pkg) => pkg.name));
+  const declaredExpected = parseExpectedPackages(process.env.OPENGENI_EXPECTED_PACKAGES ?? "");
+  const deriveExpectedValue = process.env.OPENGENI_RELEASE_PACKAGE_DERIVE_EXPECTED ?? "";
+  if (deriveExpectedValue !== "" && deriveExpectedValue !== "true") {
+    throw new Error("OPENGENI_RELEASE_PACKAGE_DERIVE_EXPECTED must be true or unset");
+  }
+  const expectedNames = new Set(declaredExpected.map((pkg) => pkg.name));
   const registryEntries = await Promise.all(
     publishable.map(
       async (pkg) =>
@@ -232,12 +266,20 @@ async function main(): Promise<void> {
         ] as const,
     ),
   );
+  const registry = new Map(registryEntries);
+  const expected = resolveExpectedReleasePackages({
+    phase: phaseValue,
+    deriveExpected: deriveExpectedValue === "true",
+    declaredExpected,
+    publishable,
+    registry,
+  });
   const result = reconcileReleasePackages({
     sourceSha,
     phase: phaseValue,
     publishable,
     expected,
-    registry: new Map(registryEntries),
+    registry,
   });
 
   const receipt = {


### PR DESCRIPTION
## Summary

- derive the complete npm publication set from repository/registry truth and freeze it in the candidate receipt
- carry that immutable set through final release and idempotent partial-publication retries
- reconstruct source admission from immutable PR/commit/tree evidence when GitHub removes merged-head check projections
- remove caller-maintained package inputs from candidate and product release workflows

## Verification

- `bun test scripts/verify-release-packages.test.ts scripts/check-release-pr-automation.test.ts scripts/release-image-workflow-contract.test.ts` (73 pass)
- `bun run typecheck` (23/23 clean)
- `git diff --check`

Tracks OPE-95.