### PR TITLE
fix(release): accept clean retained-head absence

### DIFF
--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -878,6 +878,16 @@ export async function recoverReleaseHeadEvidence(options = {}) {
       ),
       "release head retention check exists without retained evidence",
     );
+  } else {
+    const retentionContext = {
+      ...context,
+      releaseHeadRelease: initialEvidence.releaseHeadRelease,
+    };
+    await findCheckRun(
+      api,
+      retentionContext,
+      checkIdentity("release-head-retention", retentionContext),
+    );
   }
 
   const { releaseHead, releaseHeadRelease } = initialEvidence ?? {

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -1360,6 +1360,56 @@ describe("release head retention recovery", () => {
     ).toBe(false);
   });
 
+  test("rejects a conflicting retention check for an exact retained pair before mutation", async () => {
+    const fixture = recoverySealFixture();
+    const options = {
+      env: recoverySealEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+      now: () => new Date("2026-07-27T09:30:00Z"),
+    };
+    await recoverReleaseHeadEvidence(options);
+    const retentionCheck = fixture.checks.find(
+      (check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention,
+    );
+    expect(retentionCheck).toBeDefined();
+    fixture.checks.splice(0, fixture.checks.length, {
+      ...retentionCheck,
+      external_id: "attacker-preclaim",
+    });
+    fixture.requests.length = 0;
+
+    await expect(recoverReleaseHeadEvidence(options)).rejects.toThrow(
+      "existing check run conflicts with the exact idempotency identity",
+    );
+    expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  test("rejects duplicate exact retention checks for an exact retained pair before mutation", async () => {
+    const fixture = recoverySealFixture();
+    const options = {
+      env: recoverySealEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+      now: () => new Date("2026-07-27T09:30:00Z"),
+    };
+    await recoverReleaseHeadEvidence(options);
+    const retentionCheck = fixture.checks.find(
+      (check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention,
+    );
+    expect(retentionCheck).toBeDefined();
+    fixture.checks.splice(0, fixture.checks.length, retentionCheck!, {
+      ...retentionCheck,
+      id: Number(retentionCheck?.id) + 1,
+    });
+    fixture.requests.length = 0;
+
+    await expect(recoverReleaseHeadEvidence(options)).rejects.toThrow(
+      "multiple check runs share the idempotency marker",
+    );
+    expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
   test("fails closed on recovery author identity substitution or missing identity", async () => {
     for (const [author, message] of [
       [


### PR DESCRIPTION
## Summary

- normalize GitHub `404` only for the paired retained-head tag/release lookup used by merged-source recovery
- allow a stable clean state where both retained artifacts and the retention check are absent, then create the exact tag and immutable prerelease only after every historical source, identity, topology, ancestry, and provider-read gate passes
- preserve checks-only replay for an existing exact immutable pair; reject partial/preclaimed evidence, non-404 provider failures, create races, identity/provenance drift, and terminal movement without takeover
- update the seal workflow input descriptions and deployment contract for this fenced recovery state

## Testing

- [x] `bun run typecheck` — all 23 projects clean
- [ ] `bun test` — full repository suite not required for this script/workflow-only correction
- [x] 130 release/provenance tests across 13 files — 0 failed, 683 assertions
- [x] focused `oxlint --deny-warnings` — 0 warnings/errors
- [x] focused `oxfmt --check`
- [x] Bun YAML parse of `.github/workflows/seal-release-head.yml`
- [x] `bun run release:schema-contract` — SHA-256 `4c4ee567eb9b458c5d5931ad1daccb6efc88e44d0a22485a10297149e8dd8397`
- [x] `bun run check:docs-refs`
- [x] `bun run check:public-hygiene`
- [x] `node --check scripts/check-release-pr-automation.mjs`
- [x] `git diff --check`

## Notes

- Fixes the sole residual defect exposed by official Seal Release Head run `30579318955` / run 28: historical admission passed, then the expected-absent retained tag GET failed with HTTP 404 because recovery used a strict existing-evidence read.
- Preserves source `c353af9be9d3fe4c8023f6157bad0ecac9c44e41`, build run `30539457136`, artifact `8758818242`, candidate release `362408308`, and ZIP digest `ba730bec64b9241b340143999af9f03cf959a35983062f1c11b05752497668dd`; nothing was rebuilt, resealed, dispatched, released, deployed, or mutated.
- OPE-25 remains In Progress.
