### PR TITLE
fix(release): bind recovered checks to workflow runs

### DIFF
--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -722,7 +722,7 @@ function releaseHeadRecoveryContext(env, suppliedInputs) {
     RELEASE_AUTOMATION_CONTRACT.sealWorkflowPath,
     "workflow_dispatch",
   );
-  requiredEnvironment(env, ["GITHUB_RUN_ID"]);
+  requiredEnvironment(env, ["GITHUB_RUN_ATTEMPT", "GITHUB_RUN_ID"]);
   const values = suppliedInputs ?? {
     prNumber: env.RELEASE_HEAD_PR_NUMBER,
     baseSha: env.RELEASE_HEAD_BASE_SHA,
@@ -736,6 +736,7 @@ function releaseHeadRecoveryContext(env, suppliedInputs) {
     headSha: assertSha(values.headSha, "release-head SHA"),
     sourceSha: assertSha(values.sourceSha, "release-head merged source SHA"),
     workflowRunId: assertPositiveInteger(env.GITHUB_RUN_ID, "seal workflow run ID"),
+    workflowRunAttempt: assertPositiveInteger(env.GITHUB_RUN_ATTEMPT, "seal workflow run attempt"),
   };
   invariant(context.headSha !== context.baseSha, "release head SHA equals its base SHA");
   invariant(
@@ -889,7 +890,7 @@ export async function recoverReleaseHeadEvidence(options = {}) {
   await upsertCheckRun(
     api,
     checkContext,
-    "source-admission",
+    "source-admission-recovery",
     {
       status: "in_progress",
       title: "Recovering exact historical source admission",
@@ -902,7 +903,7 @@ export async function recoverReleaseHeadEvidence(options = {}) {
   await upsertCheckRun(
     api,
     checkContext,
-    "source-admission",
+    "source-admission-recovery",
     {
       status: "completed",
       conclusion: "success",
@@ -913,7 +914,7 @@ export async function recoverReleaseHeadEvidence(options = {}) {
     },
     now,
   );
-  const sourceAdmissionIdentity = checkIdentity("source-admission", checkContext);
+  const sourceAdmissionIdentity = checkIdentity("source-admission-recovery", checkContext);
   const sourceAdmission = assertSuccessfulCheckRun(
     await findCheckRun(api, checkContext, sourceAdmissionIdentity),
     RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
@@ -1078,11 +1079,14 @@ export async function sealReleaseHeadEvidence(options = {}) {
 
 function checkIdentity(kind, context) {
   invariant(
-    kind === "source-admission" || kind === "automation-ci" || kind === "release-head-retention",
+    kind === "source-admission" ||
+      kind === "source-admission-recovery" ||
+      kind === "automation-ci" ||
+      kind === "release-head-retention",
     "check kind is invalid",
   );
   const name =
-    kind === "source-admission"
+    kind === "source-admission" || kind === "source-admission-recovery"
       ? RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission
       : kind === "automation-ci"
         ? RELEASE_AUTOMATION_CONTRACT.checks.automationCi
@@ -1093,6 +1097,35 @@ function checkIdentity(kind, context) {
           record(context.releaseHeadRelease, "release head immutable release check identity"),
         )}`
       : "";
+  if (kind === "source-admission-recovery") {
+    const workflowRunId = assertPositiveInteger(
+      context.workflowRunId,
+      "source-admission recovery workflow run ID",
+    );
+    const workflowRunAttempt = assertPositiveInteger(
+      context.workflowRunAttempt,
+      "source-admission recovery workflow run attempt",
+    );
+    return {
+      name,
+      exclusive: false,
+      externalId:
+        `opengeni:release-automation:source-admission-recovery:v2:` +
+        `pr:${context.prNumber}:head:${context.headSha}:` +
+        `run:${workflowRunId}:attempt:${workflowRunAttempt}`,
+      migrationExternalIds: [
+        `opengeni:release-automation:source-admission:v1:` +
+          `pr:${context.prNumber}:head:${context.headSha}`,
+      ],
+      migrationExternalIdPatterns: [
+        new RegExp(
+          `^opengeni:release-automation:source-admission-recovery:v2:` +
+            `pr:${context.prNumber}:head:${context.headSha}:` +
+            `run:[1-9][0-9]*:attempt:[1-9][0-9]*$`,
+        ),
+      ],
+    };
+  }
   return {
     name,
     exclusive: kind === "release-head-retention",
@@ -1104,6 +1137,11 @@ function checkIdentity(kind, context) {
 
 async function findCheckRun(api, context, identity) {
   const matches = [];
+  const acceptedExternalIds = new Set([
+    identity.externalId,
+    ...(identity.migrationExternalIds ?? []),
+  ]);
+  const acceptedExternalIdPatterns = identity.migrationExternalIdPatterns ?? [];
   for (let page = 1; page <= maximumPages; page += 1) {
     const response = record(
       await api.get(
@@ -1116,7 +1154,11 @@ async function findCheckRun(api, context, identity) {
     );
     invariant(Array.isArray(response.check_runs), "check-run records are missing");
     for (const check of response.check_runs) {
-      if (check?.external_id !== identity.externalId) {
+      const externalId = check?.external_id;
+      if (
+        !acceptedExternalIds.has(externalId) &&
+        !acceptedExternalIdPatterns.some((pattern) => pattern.test(externalId ?? ""))
+      ) {
         if (!identity.exclusive) continue;
         invariant(
           check?.head_sha === context.headSha,
@@ -1345,10 +1387,17 @@ async function verifyDurableSourceAdmission({
   const matching = checks.filter(
     (check) => check?.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
   );
-  const canonicalExternalId = `opengeni:release-automation:source-admission:v1:pr:${pullNumber}:head:${headSha}`;
-  const canonical = matching.filter((check) => check?.external_id === canonicalExternalId);
+  const canonicalPrefix =
+    `opengeni:release-automation:source-admission-recovery:v2:` +
+    `pr:${pullNumber}:head:${headSha}:run:`;
+  const canonicalPattern = new RegExp(`^${canonicalPrefix}([1-9][0-9]*):attempt:([1-9][0-9]*)$`);
+  const canonical = matching.filter((check) => canonicalPattern.test(check?.external_id ?? ""));
   invariant(canonical.length <= 1, "canonical recovered source-admission check is not unique");
   if (canonical.length === 1) {
+    const canonicalExternalId = assertString(
+      canonical[0]?.external_id,
+      "canonical recovered source-admission external ID",
+    );
     return assertSuccessfulCheckRun(
       canonical[0],
       RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -30,7 +30,19 @@ const rebasedFirstSha = "a".repeat(40);
 const pullNumber = 88;
 const runId = 123456;
 const runAttempt = 2;
+const recoveryRunId = 790;
+const recoveryRunAttempt = 3;
 const releaseHeadReleaseId = 7654321;
+
+function recoveredSourceAdmissionExternalId(
+  workflowRunId = recoveryRunId,
+  workflowRunAttempt = recoveryRunAttempt,
+) {
+  return (
+    `opengeni:release-automation:source-admission-recovery:v2:` +
+    `pr:${pullNumber}:head:${headSha}:run:${workflowRunId}:attempt:${workflowRunAttempt}`
+  );
+}
 
 type RequestRecord = {
   method: string;
@@ -799,7 +811,8 @@ function recoverySealEnv(overrides: Record<string, string> = {}) {
     GITHUB_SERVER_URL: RELEASE_AUTOMATION_CONTRACT.serverUrl,
     GITHUB_SHA: currentMainSha,
     GITHUB_TOKEN: "fixture-token",
-    GITHUB_RUN_ID: "790",
+    GITHUB_RUN_ATTEMPT: String(recoveryRunAttempt),
+    GITHUB_RUN_ID: String(recoveryRunId),
     GITHUB_WORKFLOW_REF:
       `${RELEASE_AUTOMATION_CONTRACT.repository}/` +
       `${RELEASE_AUTOMATION_CONTRACT.sealWorkflowPath}@refs/heads/main`,
@@ -820,6 +833,7 @@ function recoverySealFixture(
     headRepositories?: string[];
     pullAuthors?: Array<Record<string, unknown>>;
     originalSourceAdmissions?: Array<Record<string, unknown>>;
+    existingRecoveryChecks?: Array<Record<string, unknown>>;
     releaseHeadRef?: Record<string, unknown> | null;
     release?: Record<string, unknown> | null;
     refCreateStatus?: number;
@@ -831,6 +845,7 @@ function recoverySealFixture(
 ) {
   const requests: RequestRecord[] = [];
   const checks: Array<Record<string, any>> = [];
+  checks.push(...(options.existingRecoveryChecks ?? []));
   const prefix = `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}`;
   const releaseTag = `${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${headSha}`;
   const merger = { login: "merge-maintainer", id: 1234567, type: "User" };
@@ -1092,10 +1107,122 @@ describe("release head retention recovery", () => {
       fixture.checks.filter(
         (check) =>
           check.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission &&
-          check.external_id ===
-            `opengeni:release-automation:source-admission:v1:pr:${pullNumber}:head:${headSha}`,
+          check.external_id === recoveredSourceAdmissionExternalId(),
       ),
     ).toHaveLength(1);
+  });
+
+  test("migrates the prior deterministic recovery check in place", async () => {
+    const legacyExternalId = String.raw`opengeni:release-automation:source-admission:v1:pr:${pullNumber}:head:${headSha}`;
+    const fixture = recoverySealFixture({
+      existingRecoveryChecks: [
+        {
+          id: 777,
+          name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+          head_sha: headSha,
+          status: "completed",
+          conclusion: "success",
+          external_id: legacyExternalId,
+          app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+        },
+      ],
+    });
+
+    await recoverReleaseHeadEvidence({
+      env: recoverySealEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+      now: () => new Date("2026-07-27T09:30:00Z"),
+    });
+
+    expect(
+      fixture.checks.filter(
+        (check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        id: 777,
+        external_id: recoveredSourceAdmissionExternalId(),
+        status: "completed",
+        conclusion: "success",
+      }),
+    ]);
+    expect(
+      fixture.requests.filter(
+        (request) =>
+          request.method === "POST" &&
+          request.path.endsWith("/check-runs") &&
+          request.body?.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      ),
+    ).toHaveLength(0);
+  });
+
+  test("moves one prior v2 recovery check to the current seal run without duplicating it", async () => {
+    const fixture = recoverySealFixture();
+    const options = {
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+      now: () => new Date("2026-07-27T09:30:00Z"),
+    };
+
+    await recoverReleaseHeadEvidence({
+      ...options,
+      env: recoverySealEnv(),
+    });
+    await recoverReleaseHeadEvidence({
+      ...options,
+      env: recoverySealEnv({
+        GITHUB_RUN_ID: String(recoveryRunId + 1),
+        GITHUB_RUN_ATTEMPT: String(recoveryRunAttempt + 1),
+      }),
+    });
+
+    expect(
+      fixture.checks.filter(
+        (check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        external_id: recoveredSourceAdmissionExternalId(recoveryRunId + 1, recoveryRunAttempt + 1),
+        status: "completed",
+        conclusion: "success",
+      }),
+    ]);
+    expect(
+      fixture.requests.filter(
+        (request) =>
+          request.method === "POST" &&
+          request.path.endsWith("/check-runs") &&
+          request.body?.name === RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("rejects duplicate prior v2 recovery checks before mutation", async () => {
+    const canonical = (id: number, workflowRunId: number) => ({
+      id,
+      name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      head_sha: headSha,
+      status: "completed",
+      conclusion: "success",
+      external_id: recoveredSourceAdmissionExternalId(workflowRunId, 1),
+      app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+    });
+    const fixture = recoverySealFixture({
+      existingRecoveryChecks: [
+        canonical(777, recoveryRunId - 2),
+        canonical(778, recoveryRunId - 1),
+      ],
+    });
+
+    await expect(
+      recoverReleaseHeadEvidence({
+        env: recoverySealEnv(),
+        fetchImpl: fixture.fetchImpl,
+        logger: { log() {} },
+      }),
+    ).rejects.toThrow("multiple check runs share the idempotency marker");
+    expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
   });
 
   test("creates a clean absent retained pair after every pre-mutation gate and replays idempotently", async () => {
@@ -1983,7 +2110,7 @@ describe("release approval provenance", () => {
         original(102),
         {
           ...original(103),
-          external_id: `opengeni:release-automation:source-admission:v1:pr:${pullNumber}:head:${headSha}`,
+          external_id: recoveredSourceAdmissionExternalId(),
         },
       ],
     });
@@ -2004,7 +2131,7 @@ describe("release approval provenance", () => {
   });
 
   test("rejects duplicate canonical recovered admissions", async () => {
-    const externalId = `opengeni:release-automation:source-admission:v1:pr:${pullNumber}:head:${headSha}`;
+    const externalId = recoveredSourceAdmissionExternalId();
     const canonical = {
       name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
       head_sha: headSha,


### PR DESCRIPTION
Fixes the provider-owned details_url failure in recovered source-admission checks. Recovery now writes a run/attempt-bound v2 external ID, migrates prior v1 and prior-v2 receipts in place, rejects duplicate prior receipts before mutation, and keeps ordinary source-admission checks unchanged.\n\nValidation: 60/60 focused release automation tests; 23-project typecheck; lint/format/diff clean.