### PR TITLE
chore(release): reserve 0.22.29

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.28
-appVersion: "0.22.28"
+version: 0.22.29
+appVersion: "0.22.29"


### PR DESCRIPTION
Reserve a new immutable Helm/app release identity for the provider-artifact recovery train. The already-live 0.22.28 identity must not be reused for new chart or workload bytes.