### PR TITLE
fix(web): bound MCP OAuth startup

### DIFF
--- a/.changeset/calm-mcp-oauth-timeouts.md
+++ b/.changeset/calm-mcp-oauth-timeouts.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/sdk": patch
+---
+
+Allow callers to cancel MCP OAuth-start requests so capability activation can fail visibly instead of spinning forever when browser transport stalls.

--- a/apps/web/src/lib/mcp-oauth.test.ts
+++ b/apps/web/src/lib/mcp-oauth.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import { startMcpOAuthWithTimeout } from "./mcp-oauth";
+
+const request = {
+  mcpUrl: "https://mcp.linear.app/mcp",
+  providerDomain: "linear.app",
+  returnPath: "/capabilities?connect_item=linear",
+};
+
+describe("startMcpOAuthWithTimeout", () => {
+  test("returns the provider authorization URL and clears the deadline", async () => {
+    let signal: AbortSignal | undefined;
+    const result = await startMcpOAuthWithTimeout(
+      {
+        startConnectionOAuth: async (_workspaceId, _request, options) => {
+          signal = options?.signal;
+          return {
+            state: "signed-state",
+            authorizationUrl: "https://mcp.linear.app/authorize",
+            expiresAt: "2026-07-31T05:30:00.000Z",
+          };
+        },
+      },
+      "workspace-1",
+      request,
+      10,
+    );
+
+    expect(result.authorizationUrl).toBe("https://mcp.linear.app/authorize");
+    await Bun.sleep(20);
+    expect(signal?.aborted).toBe(false);
+  });
+
+  test("aborts a stalled browser request and returns actionable copy", async () => {
+    let signal: AbortSignal | undefined;
+    const stalled = startMcpOAuthWithTimeout(
+      {
+        startConnectionOAuth: (_workspaceId, _request, options) => {
+          signal = options?.signal;
+          return new Promise((_resolve, reject) => {
+            options?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted")), {
+              once: true,
+            });
+          });
+        },
+      },
+      "workspace-1",
+      request,
+      5,
+    );
+
+    await expect(stalled).rejects.toThrow(
+      "Connection setup timed out. Check your network and try again.",
+    );
+    expect(signal?.aborted).toBe(true);
+  });
+
+  test("preserves a real API error before the deadline", async () => {
+    const failure = new Error("integrations are not enabled");
+    await expect(
+      startMcpOAuthWithTimeout(
+        {
+          startConnectionOAuth: async () => {
+            throw failure;
+          },
+        },
+        "workspace-1",
+        request,
+        50,
+      ),
+    ).rejects.toBe(failure);
+  });
+});

--- a/apps/web/src/lib/mcp-oauth.ts
+++ b/apps/web/src/lib/mcp-oauth.ts
@@ -1,0 +1,40 @@
+import type { OAuthStartRequest, OAuthStartResponse } from "@/types";
+
+export const MCP_OAUTH_START_TIMEOUT_MS = 20_000;
+
+type OAuthStartClient = {
+  startConnectionOAuth: (
+    workspaceId: string,
+    request: OAuthStartRequest,
+    options?: { signal?: AbortSignal },
+  ) => Promise<OAuthStartResponse>;
+};
+
+/**
+ * Bound the pre-redirect MCP OAuth request. Browser fetch can otherwise remain
+ * pending indefinitely before the API sees a request, leaving the capability
+ * sheet's busy state spinning forever with no provider page and no error.
+ */
+export async function startMcpOAuthWithTimeout(
+  client: OAuthStartClient,
+  workspaceId: string,
+  request: OAuthStartRequest,
+  timeoutMs = MCP_OAUTH_START_TIMEOUT_MS,
+): Promise<OAuthStartResponse> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await client.startConnectionOAuth(workspaceId, request, {
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error("Connection setup timed out. Check your network and try again.", {
+        cause: error,
+      });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -54,6 +54,7 @@ import {
   type SheetSelection,
 } from "@/lib/capabilities";
 import { listViewState } from "@/lib/load-state";
+import { startMcpOAuthWithTimeout } from "@/lib/mcp-oauth";
 import {
   openGeniSlackBotConnections,
   openGeniSlackBotInstallInput,
@@ -325,7 +326,7 @@ export function CapabilitiesRoute({
         const mcpUrl =
           plan.mode === "oauth" ? plan.mcpUrl : (item.mcpUrl ?? item.endpointUrl ?? null);
         const returnPath = `${window.location.pathname}?connect_item=${encodeURIComponent(item.id)}`;
-        const response = await client.startConnectionOAuth(workspaceId, {
+        const response = await startMcpOAuthWithTimeout(client, workspaceId, {
           ...(mcpUrl ? { mcpUrl } : {}),
           ...(providerDomain ? { providerDomain } : {}),
           // Reuse the existing row when it survives; a null id means the row was
@@ -381,7 +382,7 @@ export function CapabilitiesRoute({
 
       if (action.type === "oauth" && plan.mode === "oauth") {
         const returnPath = `${window.location.pathname}?connect_item=${encodeURIComponent(persisted.id)}`;
-        const response = await client.startConnectionOAuth(workspaceId, {
+        const response = await startMcpOAuthWithTimeout(client, workspaceId, {
           ...(plan.mcpUrl ? { mcpUrl: plan.mcpUrl } : {}),
           ...(plan.providerDomain ? { providerDomain: plan.providerDomain } : {}),
           returnPath,

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -248,7 +248,7 @@ export type OpenGeniClientOptions = {
   fetch?: FetchLike;
 };
 
-/** Per-request cancellation for identity-scoped, side-effect-free reads. */
+/** Per-request cancellation for operations whose caller owns an AbortSignal. */
 export type OpenGeniRequestOptions = {
   signal?: AbortSignal | undefined;
 };
@@ -2627,11 +2627,14 @@ export class OpenGeniClient {
   async startConnectionOAuth(
     workspaceId: string,
     request: OAuthStartRequest,
+    options: OpenGeniRequestOptions = {},
   ): Promise<OAuthStartResponse> {
     return await this.requestJson<OAuthStartResponse>(
       "POST",
       `/v1/workspaces/${workspaceId}/connections/oauth/start`,
       request,
+      {},
+      options,
     );
   }
 

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -23,6 +23,7 @@ type RecordedRequest = {
   method: string;
   headers: Record<string, string>;
   body: string | null;
+  signal: AbortSignal;
 };
 
 function recordingFetch(responder: (request: RecordedRequest) => Response): {
@@ -42,6 +43,7 @@ function recordingFetch(responder: (request: RecordedRequest) => Response): {
             ? init.body
             : await new Response(init.body as BodyInit).text()
           : null,
+      signal: request.signal,
     };
     requests.push(recorded);
     return responder(recorded);
@@ -1020,6 +1022,27 @@ describe("OpenGeniClient connections", () => {
       mcpUrl: "https://mcp.example.com/mcp",
       returnPath: "/integrations",
     });
+  });
+
+  test("startConnectionOAuth forwards caller cancellation to fetch", async () => {
+    const { client, requests } = makeClient(() =>
+      jsonResponse({
+        state: "state-token",
+        authorizationUrl: "https://as.example.com/authorize",
+        expiresAt: "2026-06-12T00:10:00.000Z",
+      }),
+    );
+    const controller = new AbortController();
+
+    await client.startConnectionOAuth(
+      WORKSPACE_ID,
+      { mcpUrl: "https://mcp.example.com/mcp" },
+      { signal: controller.signal },
+    );
+
+    expect(requests[0]!.signal.aborted).toBe(false);
+    controller.abort();
+    expect(requests[0]!.signal.aborted).toBe(true);
   });
 
   test("startOpenGeniSlackBotInstall POSTs the optional replacement connection", async () => {


### PR DESCRIPTION
## Summary
- abort MCP OAuth startup after 20 seconds instead of leaving capability activation spinning forever
- use the same bounded path for first connect and reconnect while preserving real API errors
- let SDK callers pass an AbortSignal to `startConnectionOAuth` and cover signal propagation

## Production evidence
- Linear's catalog row is the current `https://mcp.linear.app/mcp` streamable-HTTP resource
- the API pod reaches its OAuth challenge and metadata in milliseconds
- the affected browser attempt produced capability/connection reads but no completed `connections/oauth/start` request
- prior UI/SDK code had no request deadline, so a stalled browser transport left `busyId` set forever

## Verification
- repository typecheck: all 23 projects clean
- 94 capability/SDK regression tests pass
- targeted oxlint and oxfmt checks pass
- SDK build passes
- web production build and bundle-budget check pass

No live deployment, restart, database mutation, or provider authorization was performed.
