### PR TITLE
chore(release): reserve 0.22.30

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.29
-appVersion: "0.22.29"
+version: 0.22.30
+appVersion: "0.22.30"


### PR DESCRIPTION
## Summary
- reserve OpenGeni product release 0.22.30
- keep Helm chart and application version aligned

## Validation
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `helm lint deploy/helm/opengeni`
- `git diff --check`

This reservation precedes version PR #832 so the immutable release candidate containing MCP OAuth fix #831 receives a fresh, unoccupied product version.