### PR TITLE
fix(worker): preserve escaped MCP timeout recovery (OPE-137)

### DIFF
--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -36,6 +36,8 @@ export type {
   ReconcileCodexCapacityWaitResult,
   RecoverDispatchInput,
   RecoverDispatchResult,
+  RecoverEscapedMcpTimeoutInput,
+  RecoverEscapedMcpTimeoutResult,
   PersistSessionAttemptQuiescenceInput,
   ReconcileSessionAttemptQuiescenceInput,
   ReconcileSessionAttemptQuiescenceResult,
@@ -167,6 +169,7 @@ export const persistSessionAttemptQuiescence =
 export const reconcileSessionAttemptQuiescence =
   defaultControlActivities.reconcileSessionAttemptQuiescence;
 export const recoverDispatch = defaultControlActivities.recoverDispatch;
+export const recoverEscapedMcpTimeout = defaultControlActivities.recoverEscapedMcpTimeout;
 export const peekSessionWork = defaultControlActivities.peekSessionWork;
 export const expireSessionHumanInput = defaultControlActivities.expireSessionHumanInput;
 export const markSessionIdle = defaultControlActivities.markSessionIdle;

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -141,7 +141,7 @@ import {
   type RegistryProviderKind,
   type Settings,
 } from "@opengeni/config";
-import { CancelledFailure } from "@temporalio/activity";
+import { ApplicationFailure, CancelledFailure } from "@temporalio/activity";
 import {
   settingsWithCodexCredential,
   settingsWithEnabledCapabilityMcpServers,
@@ -246,9 +246,14 @@ import {
 } from "./streaming";
 import type {
   ActivityServices,
+  EscapedMcpTimeoutRecoveryDetail,
   RunAgentTurnInput,
   RunAgentTurnResult,
   SessionAttemptQuiescenceProof,
+} from "./types";
+import {
+  ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_MESSAGE,
+  ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_TYPE,
 } from "./types";
 import {
   resumeBoxForTurn,
@@ -404,6 +409,35 @@ export function providerRecoveryResult(): {
     status: "recovering",
     continueDelayMs: PROVIDER_BACKPRESSURE_DELAY_MS,
   };
+}
+
+/**
+ * Preserve one precise recovery obligation across Temporal's activity boundary.
+ * This is intentionally narrower than the ordinary retryable-provider path:
+ * only a recovered turn (generation > 1) whose MCP timeout happened before a
+ * model request may ask the workflow's DB-only control activity to finish the
+ * same-turn checkpoint. The original transport/recovery errors are excluded
+ * from details so raw MCP response data can never enter workflow history.
+ */
+export function escapedMcpTimeoutRecoveryFailure(input: {
+  failureCode: string | undefined;
+  modelRequestStarted: boolean;
+  detail: EscapedMcpTimeoutRecoveryDetail;
+}): ApplicationFailure | null {
+  if (
+    input.failureCode !== "mcp_transport_timeout" ||
+    input.modelRequestStarted ||
+    !Number.isSafeInteger(input.detail.executionGeneration) ||
+    input.detail.executionGeneration <= 1
+  ) {
+    return null;
+  }
+  return ApplicationFailure.create({
+    message: ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_MESSAGE,
+    type: ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_TYPE,
+    nonRetryable: true,
+    details: [input.detail],
+  });
 }
 
 /**
@@ -2163,6 +2197,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     let isCodexTurn = false;
     let isExternallyBilledTurn = false;
     let executionGeneration = 0;
+    let modelRequestStarted = false;
     // Still required by credential-loss/capacity settlements, whose own
     // recovery transactions fence against worker-death redispatches.
     let redispatchesAtDispatch = 0;
@@ -5946,6 +5981,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               initialGitCredentials,
             );
           }
+          // Conservative request boundary: once control enters runStream, the
+          // provider may have accepted work even if no response/event follows.
+          // Escaped MCP setup timeouts are automatically recoverable only
+          // before this line.
+          modelRequestStarted = true;
           return await runtime.runStream(agent, runInput!, modelRunSettings, {
             signal: runtimeCancellationSignal,
             sandboxEnvironment,
@@ -7518,31 +7558,55 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         });
       }
       if (failure.retryable && publish && turnId && turnStartedPublished) {
-        const recoveryResult = providerRecoveryResult();
-        await flushRuntimeBatcher();
-        await reconcileConversationTruth({ requireDurable: true });
-        const recovery = await requestSessionTurnRecovery(db, input.workspaceId, {
-          sessionId: input.sessionId,
-          turnId,
-          triggerEventId: triggerEventId!,
-          attemptId: input.attemptId,
-          reason: failure.code ?? "provider_unavailable",
-          detail: {
-            ...failure,
-            continueDelayMs: recoveryResult.continueDelayMs,
-          },
-        });
-        if (recovery.action === "stale") {
-          acknowledgeLostAttemptOwnership();
-          activityStatus = "cancelled";
-          turnMetricOutcome = "cancelled";
-          return claimedResult({ status: "cancelled" });
+        try {
+          const recoveryResult = providerRecoveryResult();
+          await flushRuntimeBatcher();
+          await reconcileConversationTruth({ requireDurable: true });
+          const recovery = await requestSessionTurnRecovery(db, input.workspaceId, {
+            sessionId: input.sessionId,
+            turnId,
+            triggerEventId: triggerEventId!,
+            attemptId: input.attemptId,
+            reason: failure.code ?? "provider_unavailable",
+            detail: {
+              ...failure,
+              continueDelayMs: recoveryResult.continueDelayMs,
+            },
+          });
+          if (recovery.action === "stale") {
+            acknowledgeLostAttemptOwnership();
+            activityStatus = "cancelled";
+            turnMetricOutcome = "cancelled";
+            return claimedResult({ status: "cancelled" });
+          }
+          await publishDurableSessionEvents(
+            bus,
+            input.workspaceId,
+            input.sessionId,
+            recovery.events,
+          );
+          turnMetricOutcome = "recovering";
+          activityStatus = "recovering";
+          activityError = error;
+          return claimedResult(recoveryResult);
+        } catch (recoveryError) {
+          const escaped = escapedMcpTimeoutRecoveryFailure({
+            failureCode: failure.code,
+            modelRequestStarted,
+            detail: {
+              turnId,
+              triggerEventId: triggerEventId!,
+              executionGeneration,
+            },
+          });
+          if (escaped) {
+            activityStatus = "recovering";
+            turnMetricOutcome = "recovering";
+            activityError = error;
+            throw escaped;
+          }
+          throw recoveryError;
         }
-        await publishDurableSessionEvents(bus, input.workspaceId, input.sessionId, recovery.events);
-        turnMetricOutcome = "recovering";
-        activityStatus = "recovering";
-        activityError = error;
-        return claimedResult(recoveryResult);
       }
       activityStatus = "failed";
       activityError = error;

--- a/apps/worker/src/activities/session-state.ts
+++ b/apps/worker/src/activities/session-state.ts
@@ -1,6 +1,7 @@
 import {
   settleSessionAttemptInterruptions,
   applySessionTurnSettlement,
+  requestSessionTurnRecovery,
   recoverSessionDispatch,
   reconcileSessionAttemptQuiescence,
   peekSessionWork as peekSessionWorkDb,
@@ -29,11 +30,14 @@ import type {
   ReconcileSessionAttemptQuiescenceResult,
   RecoverDispatchInput,
   RecoverDispatchResult,
+  RecoverEscapedMcpTimeoutInput,
+  RecoverEscapedMcpTimeoutResult,
 } from "./types";
 
 export type SessionStateActivityOverrides = Partial<{
   settleSessionAttemptInterruptions: typeof settleSessionAttemptInterruptions;
   applySessionTurnSettlement: typeof applySessionTurnSettlement;
+  requestSessionTurnRecovery: typeof requestSessionTurnRecovery;
   recoverSessionDispatch: typeof recoverSessionDispatch;
   reconcileSessionAttemptQuiescence: typeof reconcileSessionAttemptQuiescence;
   peekSessionWork: typeof peekSessionWorkDb;
@@ -65,6 +69,8 @@ export function createSessionStateActivities(
     overrides.settleSessionAttemptInterruptions ?? settleSessionAttemptInterruptions;
   const applySessionTurnSettlementFn =
     overrides.applySessionTurnSettlement ?? applySessionTurnSettlement;
+  const requestSessionTurnRecoveryFn =
+    overrides.requestSessionTurnRecovery ?? requestSessionTurnRecovery;
   const recoverSessionDispatchFn = overrides.recoverSessionDispatch ?? recoverSessionDispatch;
   const reconcileSessionAttemptQuiescenceFn =
     overrides.reconcileSessionAttemptQuiescence ?? reconcileSessionAttemptQuiescence;
@@ -271,6 +277,55 @@ export function createSessionStateActivities(
     };
   }
 
+  /**
+   * Finish a retryable MCP timeout checkpoint that escaped a recovered turn's
+   * activity before any model request. Temporal carries the immutable turn
+   * identity in ApplicationFailure details; this activity re-reads and fences
+   * every field before mutating the exact still-owned attempt. A checkpoint
+   * that committed before event fanout failed is already recovering and
+   * therefore returns stale without another event or child callback.
+   */
+  async function recoverEscapedMcpTimeout(
+    input: RecoverEscapedMcpTimeoutInput,
+  ): Promise<RecoverEscapedMcpTimeoutResult> {
+    const { db, bus, observability } = await services();
+    const turn = await getSessionTurnForAttemptFn(
+      db,
+      input.workspaceId,
+      input.sessionId,
+      input.attemptId,
+    );
+    if (!turn) return { action: "stale" };
+    if (
+      turn.id !== input.turnId ||
+      turn.triggerEventId !== input.triggerEventId ||
+      turn.executionGeneration !== input.executionGeneration ||
+      input.executionGeneration <= 1
+    ) {
+      return { action: "ineligible" };
+    }
+    const recovery = await requestSessionTurnRecoveryFn(db, input.workspaceId, {
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      triggerEventId: input.triggerEventId,
+      attemptId: input.attemptId,
+      reason: "mcp_transport_timeout",
+      detail: {
+        code: "mcp_transport_timeout",
+        retryable: true,
+        continueDelayMs: 60_000,
+        recoverySource: "workflow_activity_failure",
+      },
+      fromStatuses: ["running"],
+    });
+    if (recovery.action !== "recovering") {
+      return { action: "stale" };
+    }
+    await publishDurableSessionEventsFn(bus, input.workspaceId, input.sessionId, recovery.events);
+    await refreshQueuedTurnsGauge(db, observability, countQueuedTurnsFn, recordTurnsQueuedGaugeFn);
+    return { action: "recovering" };
+  }
+
   async function peekSessionWork(input: PeekSessionWorkInput) {
     const { db, observability } = await services();
     const peek = await peekSessionWorkFn(db, input.workspaceId, input.sessionId);
@@ -325,6 +380,7 @@ export function createSessionStateActivities(
     persistSessionAttemptQuiescence,
     reconcileSessionAttemptQuiescence: reconcileSessionAttemptQuiescenceActivity,
     recoverDispatch,
+    recoverEscapedMcpTimeout,
     peekSessionWork,
     expireSessionHumanInput,
     markSessionIdle,

--- a/apps/worker/src/activities/types.ts
+++ b/apps/worker/src/activities/types.ts
@@ -202,6 +202,27 @@ export type RecoverDispatchResult =
   // ceiling), so the failed attempt was worker death number redispatches + 1.
   | { action: "exceeded"; turnId: string; redispatches: number };
 
+export const ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_TYPE = "EscapedMcpTimeoutRecoveryFailure";
+export const ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_MESSAGE =
+  "MCP request timeout recovery checkpoint failed before model request";
+
+export type EscapedMcpTimeoutRecoveryDetail = {
+  turnId: string;
+  triggerEventId: string;
+  executionGeneration: number;
+};
+
+export type RecoverEscapedMcpTimeoutInput = EscapedMcpTimeoutRecoveryDetail & {
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+  attemptId: string;
+};
+
+export type RecoverEscapedMcpTimeoutResult = {
+  action: "recovering" | "stale" | "ineligible";
+};
+
 export type PeekSessionWorkInput = {
   workspaceId: string;
   sessionId: string;

--- a/apps/worker/src/workflows/activities.ts
+++ b/apps/worker/src/workflows/activities.ts
@@ -13,6 +13,7 @@ type WorkflowControlActivities = Pick<
   | "reconcileSessionAttemptQuiescence"
   | "reconcileCodexCapacityWait"
   | "recoverDispatch"
+  | "recoverEscapedMcpTimeout"
   | "settleSessionInterruptions"
 >;
 

--- a/apps/worker/src/workflows/session.ts
+++ b/apps/worker/src/workflows/session.ts
@@ -14,6 +14,11 @@ import {
 } from "@temporalio/workflow";
 import type * as activities from "../activities";
 import {
+  ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_MESSAGE,
+  ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_TYPE,
+  type EscapedMcpTimeoutRecoveryDetail,
+} from "../activities/types";
+import {
   activity,
   goalActivity,
   turnActivityForTaskQueue,
@@ -36,6 +41,7 @@ import {
 const TURNS_PER_RUN_BACKSTOP = 2_000;
 const CODEX_CAPACITY_CHECKS_PER_RUN_BACKSTOP = 512;
 const HUMAN_INPUT_EXPIRY_STALE_RETRY_MS = 1_000;
+const ESCAPED_MCP_TIMEOUT_RECOVERY_DELAY_MS = 60_000;
 
 /**
  * The minimum hold for a rotation all-capped idle (`idleUntilReset`). A MANDATORY
@@ -117,6 +123,46 @@ function workerDeathFailure(
     return null;
   }
   return { timeoutType: cause.timeoutType };
+}
+
+/**
+ * Parse only the explicit activity wire contract emitted when a recovered
+ * turn's MCP setup timeout could not finish its DB checkpoint. Numeric -32001
+ * and generic MCP messages remain deliberately insufficient: the activity
+ * writes this non-retryable ApplicationFailure only before any model request,
+ * with immutable turn identity in payload-converted details.
+ */
+export function escapedMcpTimeoutRecoveryDetail(
+  error: unknown,
+): EscapedMcpTimeoutRecoveryDetail | null {
+  if (!(error instanceof ActivityFailure) || error.activityType !== "runAgentTurn") {
+    return null;
+  }
+  const cause = error.cause;
+  if (
+    !(cause instanceof ApplicationFailure) ||
+    cause.type !== ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_TYPE ||
+    cause.message !== ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_MESSAGE
+  ) {
+    return null;
+  }
+  const detail = cause.details?.[0] as Partial<EscapedMcpTimeoutRecoveryDetail> | undefined;
+  if (
+    !detail ||
+    typeof detail.turnId !== "string" ||
+    detail.turnId.length === 0 ||
+    typeof detail.triggerEventId !== "string" ||
+    detail.triggerEventId.length === 0 ||
+    !Number.isSafeInteger(detail.executionGeneration) ||
+    (detail.executionGeneration ?? 0) <= 1
+  ) {
+    return null;
+  }
+  return {
+    turnId: detail.turnId,
+    triggerEventId: detail.triggerEventId,
+    executionGeneration: detail.executionGeneration!,
+  };
 }
 
 /**
@@ -628,6 +674,30 @@ export async function sessionWorkflow(input: SessionWorkflowInput): Promise<void
         });
         if (capacityWait) {
           await waitForCodexCapacity(capacityWait, capacityWaitEntryBaseline);
+          return true;
+        }
+      }
+      // The turn activity already classified a precise MCP request timeout,
+      // but its DB checkpoint/fanout path itself failed before any model
+      // request. Finish that exact generation-2+ recovery through the bounded
+      // control-activity lane instead of terminalizing the turn and arming a
+      // fresh goal continuation from unchanged history.
+      const escapedMcpTimeout = escapedMcpTimeoutRecoveryDetail(outcome.error);
+      if (escapedMcpTimeout) {
+        const recovery = await activity.recoverEscapedMcpTimeout({
+          accountId,
+          workspaceId,
+          sessionId,
+          attemptId,
+          ...escapedMcpTimeout,
+        });
+        if (recovery.action !== "ineligible") {
+          const seenWakeups = wakeups;
+          const seenInterruptionWakeups = interruptionWakeups;
+          await condition(
+            () => interruptionWakeups !== seenInterruptionWakeups || wakeups !== seenWakeups,
+            ESCAPED_MCP_TIMEOUT_RECOVERY_DELAY_MS,
+          );
           return true;
         }
       }

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
-import { CancelledFailure } from "@temporalio/activity";
+import { ApplicationFailure, CancelledFailure } from "@temporalio/activity";
 import { RunRawModelStreamEvent, Usage } from "@openai/agents-core";
 import { ModelItem } from "@openai/agents-core/types";
 import type { Settings } from "@opengeni/config";
@@ -46,6 +46,7 @@ import {
   drainAttemptOwnedSandboxWriters,
   emitModelCallUsage,
   ensureTurnModalRegistryImage,
+  escapedMcpTimeoutRecoveryFailure,
   filterUnmaterializedSandboxFileDownloads,
   headerSecretRedactions,
   historyRowsToAppend,
@@ -2676,6 +2677,47 @@ describe("escaped MCP transport timeout classifier", () => {
     ).toBeNull();
     expect(classifyMcpTransportTimeoutError(new Error("sandbox creation timed out"))).toBeNull();
     expect(classifyMcpTransportTimeoutError(new Error("Too Many Requests"))).toBeNull();
+  });
+
+  test("emits a typed workflow recovery obligation only before a generation-2 model request", () => {
+    const detail = {
+      turnId: "turn-2",
+      triggerEventId: "trigger-1",
+      executionGeneration: 2,
+    };
+    const escaped = escapedMcpTimeoutRecoveryFailure({
+      failureCode: "mcp_transport_timeout",
+      modelRequestStarted: false,
+      detail,
+    });
+    expect(escaped).toBeInstanceOf(ApplicationFailure);
+    expect(escaped).toMatchObject({
+      type: "EscapedMcpTimeoutRecoveryFailure",
+      nonRetryable: true,
+      details: [detail],
+    });
+
+    expect(
+      escapedMcpTimeoutRecoveryFailure({
+        failureCode: "mcp_transport_timeout",
+        modelRequestStarted: false,
+        detail: { ...detail, executionGeneration: 1 },
+      }),
+    ).toBeNull();
+    expect(
+      escapedMcpTimeoutRecoveryFailure({
+        failureCode: "mcp_transport_timeout",
+        modelRequestStarted: true,
+        detail,
+      }),
+    ).toBeNull();
+    expect(
+      escapedMcpTimeoutRecoveryFailure({
+        failureCode: "provider_unavailable",
+        modelRequestStarted: false,
+        detail,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/worker/test/session-activity-cancellation.test.ts
+++ b/apps/worker/test/session-activity-cancellation.test.ts
@@ -5,7 +5,14 @@ import {
   CancelledFailure,
   TimeoutFailure,
 } from "@temporalio/workflow";
-import { isTurnActivityFenceCancellation } from "../src/workflows/session";
+import {
+  escapedMcpTimeoutRecoveryDetail,
+  isTurnActivityFenceCancellation,
+} from "../src/workflows/session";
+import {
+  ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_MESSAGE,
+  ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_TYPE,
+} from "../src/activities/types";
 
 function activityFailure(cause: Error): ActivityFailure {
   return new ActivityFailure(
@@ -64,5 +71,73 @@ describe("turn activity fence-cancellation arbitration", () => {
         activityFailure(new Error("wrapper", { cause: new CancelledFailure("hidden") })),
       ),
     ).toBe(false);
+  });
+});
+
+describe("escaped MCP timeout activity-failure recovery", () => {
+  const detail = {
+    turnId: "turn-2",
+    triggerEventId: "trigger-1",
+    executionGeneration: 2,
+  };
+  const escaped = () =>
+    activityFailure(
+      ApplicationFailure.create({
+        message: ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_MESSAGE,
+        type: ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_TYPE,
+        nonRetryable: true,
+        details: [detail],
+      }),
+    );
+
+  test("accepts only the explicit generation-2 runAgentTurn wire contract", () => {
+    expect(escapedMcpTimeoutRecoveryDetail(escaped())).toEqual(detail);
+    expect(
+      escapedMcpTimeoutRecoveryDetail(
+        new ActivityFailure(
+          "Activity task failed",
+          "someOtherActivity",
+          "activity-1",
+          "IN_PROGRESS",
+          "worker-1",
+          (escaped().cause as ApplicationFailure) ?? undefined,
+        ),
+      ),
+    ).toBeNull();
+    expect(
+      escapedMcpTimeoutRecoveryDetail(
+        activityFailure(
+          ApplicationFailure.create({
+            message: ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_MESSAGE,
+            type: ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_TYPE,
+            details: [{ ...detail, executionGeneration: 1 }],
+          }),
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  test("does not infer recovery from ambiguous -32001 or altered marker fields", () => {
+    expect(
+      escapedMcpTimeoutRecoveryDetail(
+        activityFailure(
+          ApplicationFailure.create({
+            message: "MCP transport operation failed (McpError -32001)",
+            type: "Error",
+          }),
+        ),
+      ),
+    ).toBeNull();
+    expect(
+      escapedMcpTimeoutRecoveryDetail(
+        activityFailure(
+          ApplicationFailure.create({
+            message: "different message",
+            type: ESCAPED_MCP_TIMEOUT_RECOVERY_FAILURE_TYPE,
+            details: [detail],
+          }),
+        ),
+      ),
+    ).toBeNull();
   });
 });

--- a/apps/worker/test/session-state-mcp-timeout-recovery.test.ts
+++ b/apps/worker/test/session-state-mcp-timeout-recovery.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createSessionStateActivities } from "../src/activities/session-state";
+
+const publishedEvents: unknown[] = [];
+const recoveryCalls: unknown[] = [];
+const parentWakeCalls: unknown[] = [];
+let turn: {
+  id: string;
+  triggerEventId: string;
+  executionGeneration: number;
+} | null;
+let recoveryResult:
+  | { action: "recovering"; events: unknown[] }
+  | { action: "stale"; events: []; turnStatus: string | null; activeTurnId: string | null };
+
+function makeActivities() {
+  return createSessionStateActivities(
+    async () =>
+      ({
+        db: {},
+        bus: { publish: async () => undefined },
+        settings: {},
+        observability: {},
+        wakeSessionWorkflow: null,
+      }) as any,
+    {
+      getSessionTurnForAttempt: mock(async () => turn as any),
+      requestSessionTurnRecovery: mock(async (...args: unknown[]) => {
+        recoveryCalls.push(args[2]);
+        return recoveryResult as any;
+      }),
+      countQueuedTurns: mock(async () => 0),
+      publishDurableSessionEvents: mock(
+        async (_bus, _workspaceId, _sessionId, events: unknown[]) => {
+          publishedEvents.push(...events);
+        },
+      ),
+      deliverFailedChildTurnToParent: mock(async (...args: unknown[]) => {
+        parentWakeCalls.push(args);
+      }),
+      recordTurnsQueuedGauge: mock(() => undefined),
+    },
+  );
+}
+
+const input = {
+  accountId: "account-1",
+  workspaceId: "workspace-1",
+  sessionId: "session-1",
+  attemptId: "attempt-2",
+  turnId: "turn-1",
+  triggerEventId: "trigger-1",
+  executionGeneration: 2,
+};
+
+describe("recoverEscapedMcpTimeout", () => {
+  test("keeps the exact generation-2 turn recovering without a child terminal callback", async () => {
+    publishedEvents.length = 0;
+    recoveryCalls.length = 0;
+    parentWakeCalls.length = 0;
+    turn = {
+      id: input.turnId,
+      triggerEventId: input.triggerEventId,
+      executionGeneration: input.executionGeneration,
+    };
+    recoveryResult = {
+      action: "recovering",
+      events: [{ id: "recovery-2", type: "turn.recovery.requested" }],
+    };
+
+    expect(await makeActivities().recoverEscapedMcpTimeout(input)).toEqual({
+      action: "recovering",
+    });
+    expect(recoveryCalls).toEqual([
+      {
+        sessionId: input.sessionId,
+        turnId: input.turnId,
+        triggerEventId: input.triggerEventId,
+        attemptId: input.attemptId,
+        reason: "mcp_transport_timeout",
+        detail: {
+          code: "mcp_transport_timeout",
+          retryable: true,
+          continueDelayMs: 60_000,
+          recoverySource: "workflow_activity_failure",
+        },
+        fromStatuses: ["running"],
+      },
+    ]);
+    expect(publishedEvents).toEqual([{ id: "recovery-2", type: "turn.recovery.requested" }]);
+    expect(parentWakeCalls).toHaveLength(0);
+  });
+
+  test("rejects generation 1 or mismatched immutable identity without mutation", async () => {
+    recoveryCalls.length = 0;
+    publishedEvents.length = 0;
+    turn = {
+      id: input.turnId,
+      triggerEventId: input.triggerEventId,
+      executionGeneration: 1,
+    };
+    expect(
+      await makeActivities().recoverEscapedMcpTimeout({
+        ...input,
+        executionGeneration: 1,
+      }),
+    ).toEqual({ action: "ineligible" });
+
+    turn = {
+      id: input.turnId,
+      triggerEventId: "different-trigger",
+      executionGeneration: input.executionGeneration,
+    };
+    expect(await makeActivities().recoverEscapedMcpTimeout(input)).toEqual({
+      action: "ineligible",
+    });
+    expect(recoveryCalls).toHaveLength(0);
+    expect(publishedEvents).toHaveLength(0);
+  });
+
+  test("treats a checkpoint already committed by the turn activity as stale and side-effect free", async () => {
+    recoveryCalls.length = 0;
+    publishedEvents.length = 0;
+    parentWakeCalls.length = 0;
+    turn = null;
+    expect(await makeActivities().recoverEscapedMcpTimeout(input)).toEqual({ action: "stale" });
+    expect(recoveryCalls).toHaveLength(0);
+    expect(publishedEvents).toHaveLength(0);
+    expect(parentWakeCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve durable conversation truth when a 60-second MCP transport timeout escapes after successful tool output
- settle the affected turn as retryable/idle and recover through the active goal without replaying the completed tool call or full turn
- add focused workflow, activity, cancellation, and session-state coverage for the recovery path

## Validation

- 147 focused and adjacent tests passed
- worker typecheck and build passed
- Temporal workflow bundle passed
- `oxfmt` passed
- `oxlint --deny-warnings` passed
- diff check passed

Linear: OPE-137