### PR TITLE
perf(ci): run core verification lanes in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/check-release-pr-automation.mjs complete-version-check
 
-  test:
-    name: Typecheck and unit tests
+  source-contracts:
+    name: Source and type contracts
     needs: automation-admission
     if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
@@ -220,6 +220,44 @@ jobs:
 
       - name: Format check
         run: bun run format:check
+
+      - name: Workspace auth/billing static guard
+        run: bun scripts/check-workspace-billing-static.ts
+
+      - name: Docs reference freshness guard
+        run: bun scripts/check-docs-refs.ts
+
+      - name: Public repository hygiene guard
+        run: bun run check:public-hygiene
+
+  test-suite:
+    name: Real tests and browser acceptance
+    needs: automation-admission
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Test
         env:
@@ -357,14 +395,34 @@ jobs:
             'forced overflow compaction proves shrink against active history, not stale input tokens' \
             ./apps/worker/test/context-compaction-activity.test.ts
 
-      - name: Workspace auth/billing static guard
-        run: bun scripts/check-workspace-billing-static.ts
+  package-contracts:
+    name: Package and bundle contracts
+    needs: automation-admission
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Docs reference freshness guard
-        run: bun scripts/check-docs-refs.ts
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
 
-      - name: Public repository hygiene guard
-        run: bun run check:public-hygiene
+      - name: Cache Bun dependencies
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Build client packages (contracts + SDK + React)
         run: bun run build:packages
@@ -386,6 +444,31 @@ jobs:
 
       - name: Web bundle budget
         run: bun run --cwd apps/web build
+
+  test:
+    name: Typecheck and unit tests
+    needs: [source-contracts, test-suite, package-contracts]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every split CI lane
+        env:
+          SOURCE_CONTRACTS_RESULT: ${{ needs.source-contracts.result }}
+          TEST_SUITE_RESULT: ${{ needs.test-suite.result }}
+          PACKAGE_CONTRACTS_RESULT: ${{ needs.package-contracts.result }}
+        run: |
+          set -euo pipefail
+          failed=0
+          for lane in SOURCE_CONTRACTS TEST_SUITE PACKAGE_CONTRACTS; do
+            result_variable="${lane}_RESULT"
+            result="${!result_variable}"
+            printf '%s=%s\n' "${lane,,}" "$result"
+            if [ "$result" != "success" ]; then
+              echo "::error::${lane,,} concluded $result"
+              failed=1
+            fi
+          done
+          exit "$failed"
 
   deployment:
     name: Deployment artifacts

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2633,7 +2633,13 @@ describe("workflow contracts", () => {
     });
     expect(ciText).not.toContain("pull-requests: write");
     expect(ciText).not.toMatch(/pulls\/.+\/reviews/);
-    for (const jobName of ["test", "deployment", "images"])
+    for (const jobName of [
+      "source-contracts",
+      "test-suite",
+      "package-contracts",
+      "deployment",
+      "images",
+    ])
       expect(
         ci.jobs[jobName].steps.find((step: any) => step.uses === "actions/checkout@v6").with.ref,
       ).toContain("inputs.automation_head_sha");
@@ -2667,6 +2673,79 @@ describe("workflow contracts", () => {
         .filter((step: any) => step.env?.GITHUB_TOKEN)
         .map((step: any) => [step.name, step.env.GITHUB_TOKEN]),
     ).toEqual([["Complete exact-head automation CI check", "${{ github.token }}"]]);
+  });
+
+  test("runs preserved source, test, and package gates in parallel behind a fail-closed aggregate", () => {
+    const laneNames = ["source-contracts", "test-suite", "package-contracts"];
+    const expectedGateNames = {
+      "source-contracts": [
+        "Validate changeset release plan",
+        "Generated font manifest freshness",
+        "Typecheck",
+        "Lint",
+        "Format check",
+        "Workspace auth/billing static guard",
+        "Docs reference freshness guard",
+        "Public repository hygiene guard",
+      ],
+      "test-suite": [
+        "Test",
+        "React warning-free test gate",
+        "Install pinned Playwright Chromium runtime",
+        "Codex quota Codex quota and entitlement browser acceptance",
+        "Queue surface browser acceptance",
+        "Session pin browser acceptance",
+        "Responsive knowledge surfaces browser acceptance",
+        "Workbench browser acceptance",
+        "Real workspace capture acceptance",
+        "Upload session pin visual evidence",
+        "Upload Codex quota visual evidence",
+        "Upload responsive knowledge-surface evidence",
+        "Upload workbench visual evidence",
+        "Recovery integration regressions",
+      ],
+      "package-contracts": [
+        "Build client packages (contracts + SDK + React)",
+        "Publish closure guard",
+        "Clean published consumer",
+        "Runtime embedding consumer",
+        "Portable ogtool package",
+        "Build React demo harness",
+        "Web bundle budget",
+      ],
+    } as const;
+    const allLaneSteps = laneNames.flatMap((jobName) =>
+      ci.jobs[jobName].steps.map((step: any) => step.name).filter(Boolean),
+    );
+
+    for (const [jobName, gateNames] of Object.entries(expectedGateNames)) {
+      expect(ci.jobs[jobName].needs).toBe("automation-admission");
+      expect(ci.jobs[jobName].if).toContain("always()");
+      for (const gateName of gateNames) {
+        expect(ci.jobs[jobName].steps.some((step: any) => step.name === gateName)).toBe(true);
+        expect(allLaneSteps.filter((stepName) => stepName === gateName)).toHaveLength(1);
+      }
+    }
+
+    const aggregate = ci.jobs.test;
+    expect(aggregate.name).toBe("Typecheck and unit tests");
+    expect(aggregate.needs).toEqual(laneNames);
+    expect(aggregate.if).toBe("${{ always() }}");
+    const requireLanes = aggregate.steps.find(
+      (step: any) => step.name === "Require every split CI lane",
+    );
+    expect(requireLanes.env).toEqual({
+      SOURCE_CONTRACTS_RESULT: "${{ needs.source-contracts.result }}",
+      TEST_SUITE_RESULT: "${{ needs.test-suite.result }}",
+      PACKAGE_CONTRACTS_RESULT: "${{ needs.package-contracts.result }}",
+    });
+    expect(requireLanes.run).toContain('if [ "$result" != "success" ]');
+    expect(ci.jobs["automation-report"].needs).toEqual([
+      "automation-admission",
+      "test",
+      "deployment",
+      "images",
+    ]);
   });
 
   test("keeps release-head retention base-owned, explicit, and narrowly authorized", () => {


### PR DESCRIPTION
## Summary

- split the serial CI mega-job into independent **Source and type contracts**, **Real tests and browser acceptance**, and **Package and bundle contracts** lanes
- keep the required check name **Typecheck and unit tests** as a fail-closed aggregate over all three lanes
- preserve exact automation-head checkout and every existing source, real-service, browser/visual/mobile, recovery, package, generated, security, and evidence gate exactly once
- keep deployment/image checks and exact-head automation reporting dependencies unchanged

## Why this increment

The frozen natural-run baseline is recorded in Linear OPE-27. The previous required job dominated every sampled main and PR run at roughly 24–25 minutes. This focused DAG change removes unnecessary serialization without skipping or weakening any gate. Natural CI on this PR will be used for the first realized before/after measurement.

## Safety contracts

- each candidate-executing lane checks out the exact automation head with full history
- aggregate fails on failed, skipped, or cancelled lanes
- required check name remains stable
- automation report still requires admission, aggregate test, deployment, and images
- workflow contract tests assert all prior mega-job gates are present exactly once

## Validation

- `git diff --check`
- Bun YAML parse of `.github/workflows/ci.yml`
- `bun install --frozen-lockfile`
- `bun run typecheck` — all 23 TS7 projects clean
- `bun run lint` — 0 warnings/errors across 1,119 files
- `bunx oxfmt --check .github/workflows/ci.yml scripts/check-release-pr-automation.test.ts`
- `bun test scripts/check-release-pr-automation.test.ts scripts/release-image-workflow-contract.test.ts` — 75 tests, 552 assertions, 0 failures

Part of OPE-27; does not close the continuing performance program.