### PR TITLE
fix(composer): dedupe reconnected ready files

### DIFF
--- a/.changeset/calm-drafts-reconnect.md
+++ b/.changeset/calm-drafts-reconnect.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/react": patch
+---
+
+Prevent a ready file restored during reconnect from being counted twice across the durable composer draft and the still-live attachment card. Canonical duplicate refs are removed before draft persistence and composer submission while custom mounts and exact draft revision/content conflict protection remain intact.

--- a/packages/db/src/session-queue-commands.ts
+++ b/packages/db/src/session-queue-commands.ts
@@ -3,6 +3,7 @@ import {
   mergeResourceRefs,
   ResourceRef,
   resourceMountPath,
+  stableJson,
   turnExecutionPolicyAuditMetadata,
   type ReasoningEffort,
   type TurnExecutionPolicyV1,
@@ -369,14 +370,24 @@ function draftIsNonEmpty(draft: ComposerDraftRow): boolean {
 }
 
 function withCanonicalResourceMountPaths(resources: readonly unknown[]): unknown[] {
-  return resources.map((value) => {
+  const seen = new Set<string>();
+  const canonical: unknown[] = [];
+  for (const value of resources) {
     const parsed = ResourceRef.safeParse(value);
-    if (!parsed.success) return value;
-    return {
+    if (!parsed.success) {
+      canonical.push(value);
+      continue;
+    }
+    const normalized = {
       ...(value as Record<string, unknown>),
       mountPath: resourceMountPath(parsed.data),
     };
-  });
+    const key = stableJson(normalized);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    canonical.push(normalized);
+  }
+  return canonical;
 }
 
 export async function getComposerDraftInTransaction(

--- a/packages/db/test/queue-mutations.test.ts
+++ b/packages/db/test/queue-mutations.test.ts
@@ -989,6 +989,83 @@ describe("canonical queue commands", () => {
     });
   }
 
+  test("Send and Steer admit and replay one reconnected ready file across bare/canonical forms", async () => {
+    for (const delivery of ["send", "steer"] as const) {
+      const value = await fixture(1);
+      const fileId = crypto.randomUUID();
+      const bareResource = { kind: "file" as const, fileId };
+      const canonicalResource = {
+        ...bareResource,
+        mountPath: `files/${fileId}`,
+      };
+      const draft = await withWorkspaceSubjectRls(
+        client.db,
+        value.grant.workspaceId!,
+        value.grant.subjectId,
+        (db) =>
+          db.transaction((tx) =>
+            saveComposerDraftInTransaction(tx as typeof db, {
+              accountId: value.grant.accountId,
+              workspaceId: value.grant.workspaceId!,
+              sessionId: value.session.id,
+              subjectId: value.grant.subjectId,
+              expectedRevision: 0,
+              text: `inspect the reconnected attachment via ${delivery}`,
+              // The durable reload owns the canonical ref while the still-live
+              // upload card owns the bare ref for the same finalized file.
+              resources: [canonicalResource, bareResource],
+              model: "scripted-model",
+              reasoningEffort: "low",
+            }),
+          ),
+      );
+      expect(draft.resources).toEqual([canonicalResource]);
+
+      const operationKey = crypto.randomUUID();
+      const command = {
+        accountId: value.grant.accountId,
+        workspaceId: value.grant.workspaceId!,
+        sessionId: value.session.id,
+        subjectId: value.grant.subjectId,
+        actor: value.actor,
+        operationKey,
+        delivery,
+        expectedDraftRevision: draft.revision,
+        text: draft.text,
+        // Core admission has already normalized the command to one ref.
+        resources: [canonicalResource],
+        model: "scripted-model",
+        reasoningEffort: "low" as const,
+        reasoningEffortFallback: "medium" as const,
+        source: "user" as const,
+      };
+      const submitted = await withWorkspaceSubjectRls(
+        client.db,
+        value.grant.workspaceId!,
+        value.grant.subjectId,
+        (db) => db.transaction((tx) => submitHumanPromptInTransaction(tx as typeof db, command)),
+      );
+      expect(submitted.replay).toBe(false);
+      expect(
+        (await getSessionTurn(client.db, value.grant.workspaceId!, submitted.turnId))?.resources,
+      ).toEqual([canonicalResource]);
+
+      const replay = await withWorkspaceSubjectRls(
+        client.db,
+        value.grant.workspaceId!,
+        value.grant.subjectId,
+        (db) =>
+          db.transaction((tx) =>
+            submitHumanPromptInTransaction(tx as typeof db, {
+              ...command,
+              resources: [bareResource],
+            }),
+          ),
+      );
+      expect(replay).toMatchObject({ replay: true, turnId: submitted.turnId });
+    }
+  });
+
   test("Send keeps custom file mounts distinct and rejects genuinely changed drafts", async () => {
     const value = await fixture(1);
     const fileId = crypto.randomUUID();

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -1220,7 +1220,16 @@ function draftSignature(payload: SaveComposerDraftRequest): string {
 function mergeResources(base: ResourceRef[], additions: ResourceRef[]): ResourceRef[] {
   const seen = new Set<string>();
   return [...base, ...additions].filter((resource) => {
-    const key = JSON.stringify(resource);
+    // Reconnect reconciliation can restore the canonical server form while
+    // the still-mounted upload card supplies the same ready file without its
+    // default mount. Treat those two wire shapes as one selected attachment;
+    // preserving the first representation keeps custom mounts and ordering
+    // intact while preventing the draft and command paths from seeing
+    // different duplicate counts after server normalization.
+    const key =
+      resource.kind === "file"
+        ? `file:${resource.fileId}\u0000${resource.mountPath ?? `files/${resource.fileId}`}`
+        : JSON.stringify(resource);
     if (seen.has(key)) return false;
     seen.add(key);
     return true;

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1934,6 +1934,118 @@ describe("useComposer durable draft and control binding", () => {
     await hook.unmount();
   });
 
+  test("a reconnect does not duplicate a ready file across the durable draft and live attachment", async () => {
+    const fileId = "33333333-3333-4333-8333-333333333333";
+    const canonicalFile = {
+      kind: "file" as const,
+      mountPath: `files/${fileId}`,
+      fileId,
+    };
+    let serverDraft: ComposerDraft = {
+      revision: 0,
+      text: "",
+      resources: [],
+      model: "model-x",
+      reasoningEffort: "medium",
+      sourceTurnId: null,
+      sourceTurnVersion: null,
+      updatedAt: null,
+    };
+    const canonicalizeResources = (
+      resources: ComposerDraft["resources"],
+    ): ComposerDraft["resources"] =>
+      resources.map((resource) =>
+        resource.kind === "file"
+          ? {
+              kind: "file" as const,
+              mountPath: resource.mountPath ?? `files/${resource.fileId}`,
+              fileId: resource.fileId,
+            }
+          : resource,
+      );
+    const admissionMismatches: string[] = [];
+    const client = fakeClient({
+      getComposerDraft: async () => serverDraft,
+      saveComposerDraft: async (_workspaceId, _sessionId, request) => {
+        expect(request.expectedRevision).toBe(serverDraft.revision);
+        serverDraft = {
+          ...serverDraft,
+          ...request,
+          revision: serverDraft.revision + 1,
+          resources: canonicalizeResources(request.resources),
+          updatedAt: new Date().toISOString(),
+        };
+        return serverDraft;
+      },
+      sendMessage: async (_workspaceId, _sessionId, input) => {
+        const submitted = input as SendMessageInput;
+        const normalizedResources = canonicalizeResources(submitted.resources ?? []).filter(
+          (resource, index, resources) =>
+            resources.findIndex(
+              (candidate) => JSON.stringify(candidate) === JSON.stringify(resource),
+            ) === index,
+        );
+        const savedContent = JSON.stringify({
+          text: serverDraft.text,
+          resources: serverDraft.resources,
+          model: serverDraft.model,
+          reasoningEffort: serverDraft.reasoningEffort,
+        });
+        const submittedContent = JSON.stringify({
+          text: submitted.text,
+          resources: normalizedResources,
+          model: submitted.model ?? "model-x",
+          reasoningEffort: submitted.reasoningEffort ?? "medium",
+        });
+        if (
+          submitted.expectedDraftRevision === serverDraft.revision &&
+          savedContent !== submittedContent
+        ) {
+          admissionMismatches.push("Submitted content is not the saved draft");
+          throw new Error("Submitted content is not the saved draft");
+        }
+        return makeEvent(1, "user.message");
+      },
+    });
+    const hook = await renderHook(
+      () =>
+        useComposer(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          sendExtras: () => ({
+            resources: [{ kind: "file", fileId }],
+            model: "model-x",
+            reasoningEffort: "medium",
+          }),
+        }),
+      undefined,
+    );
+    await flush();
+
+    await flushing(() => hook.result.current.setValue("Inspect the attached image."));
+    await flush(600);
+    expect(serverDraft).toMatchObject({
+      revision: 1,
+      resources: [canonicalFile],
+    });
+
+    // Reconnect reconciliation reloads the canonical server resource while
+    // the browser-local ready attachment card still supplies its bare ref.
+    await flushing(async () => await hook.result.current.reloadDraft());
+    expect(hook.result.current.restoredResources).toEqual([canonicalFile]);
+
+    let accepted = false;
+    await flushing(async () => {
+      accepted = await hook.result.current.send();
+    });
+
+    expect({ accepted, admissionMismatches }).toEqual({
+      accepted: true,
+      admissionMismatches: [],
+    });
+    await hook.unmount();
+  });
+
   for (const delivery of ["send", "steer"] as const) {
     test(`${delivery} preserves the exact autosaved draft text`, async () => {
       const submitted: string[] = [];


### PR DESCRIPTION
Fixes OPE-82

## Product behavior fixed
Reconnect could retain both the bare and canonical default-mount references for one uploaded file. The durable draft kept two references while submission normalized to one, producing an equal-revision HTTP 409.

This fix semantically deduplicates default-mount equivalents across the React and database save/admission/replay paths while preserving custom mounts and optimistic-concurrency (OCC) fences.

## Validation evidence
- All 23 typechecks
- Lint and format checks
- Full build and budgets
- Deterministic React reproduction
- PostgreSQL 17 non-superuser FORCE-RLS Send + Steer coverage
- Prior React, contracts, SDK, worker, provider, API, PostgreSQL 17, and MinIO suites
- Four visually inspected browser screenshots

The portable recovery bundle was verified independently: exact bundle and full-index patch hashes, `git bundle verify`, expected ref/head/tree/parent, live-main conflict check, and no changed-path semantic overlap with current `main`.
