### PR TITLE
feat(examples): productionize Northstar agent demo

### DIFF
--- a/.changeset/clean-northstar-demo.md
+++ b/.changeset/clean-northstar-demo.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/example-northstar-support": patch
+---
+
+Redesign the Northstar example as a functional multi-ticket support product with a clear manual workflow, an explicit OpenGeni embedding switch, and live MCP-driven product updates.

--- a/docker/opengeni.Dockerfile
+++ b/docker/opengeni.Dockerfile
@@ -40,6 +40,14 @@ RUN apt-get update \
 ENV NODE_ENV=production
 USER bun
 
+FROM base AS northstar-demo-build
+RUN bun run --cwd examples/northstar-support build
+
+FROM northstar-demo-build AS northstar-demo
+ENV PORT=8080
+EXPOSE 8080
+CMD ["bun", "run", "--cwd", "examples/northstar-support", "start"]
+
 FROM base AS api
 # "The agent ships inside the control-plane": the SIGNED per-SHA opengeni-agent
 # Linux musl binaries (+ .sha256/.minisig) are staged into agent/install/baked/ by
@@ -82,11 +90,3 @@ RUN bun run --cwd apps/web build
 FROM web-build AS web
 EXPOSE 3000
 CMD ["bun", "run", "--cwd", "apps/web", "start"]
-
-FROM base AS northstar-demo-build
-RUN bun run --cwd examples/northstar-support build
-
-FROM northstar-demo-build AS northstar-demo
-ENV PORT=8080
-EXPOSE 8080
-CMD ["bun", "run", "--cwd", "examples/northstar-support", "start"]

--- a/docker/opengeni.Dockerfile
+++ b/docker/opengeni.Dockerfile
@@ -82,3 +82,11 @@ RUN bun run --cwd apps/web build
 FROM web-build AS web
 EXPOSE 3000
 CMD ["bun", "run", "--cwd", "apps/web", "start"]
+
+FROM base AS northstar-demo-build
+RUN bun run --cwd examples/northstar-support build
+
+FROM northstar-demo-build AS northstar-demo
+ENV PORT=8080
+EXPOSE 8080
+CMD ["bun", "run", "--cwd", "examples/northstar-support", "start"]

--- a/examples/northstar-support/.env.example
+++ b/examples/northstar-support/.env.example
@@ -4,7 +4,7 @@ OPENGENI_WORKSPACE_ID=replace_with_your_workspace_id
 OPENGENI_API_KEY=ogk_replace_me
 
 # Leave blank to use the workspace default model.
-OPENGENI_MODEL=
+OPENGENI_MODEL=gpt-5.6-luna
 
 # Shared only by OpenGeni's encrypted per-session MCP credentials and this
 # example backend. Generate a long random value.
@@ -13,3 +13,7 @@ OPENGENI_DEMO_MCP_TOKEN=replace_with_a_long_random_value
 # Optional. Set to the public HTTPS origin or full /mcp URL. When omitted, the
 # server auto-detects an ngrok tunnel forwarding local port 4101.
 OPENGENI_DEMO_MCP_URL=
+
+# Production-only. PORT enables one same-origin server for UI, API, and MCP.
+# PORT=8080
+# OPENGENI_DEMO_APP_ORIGIN=https://demo.opengeni.ai

--- a/examples/northstar-support/README.md
+++ b/examples/northstar-support/README.md
@@ -1,18 +1,27 @@
 # Northstar support agent example
 
-A small fictional SaaS product showing the complete OpenGeni integration:
+A small fictional customer-support SaaS showing the complete OpenGeni
+integration as a clear before/after:
 
-1. The browser renders product UI plus `@opengeni/react` session components.
-2. The product backend creates OpenGeni sessions and proxies workspace-scoped
+1. Open the product with OpenGeni off and use it as a small support SaaS:
+   search and filter the queue, switch between four tickets, inspect customer
+   signals, change fields, add internal notes, and reply.
+2. Turn on the frontend-only **OpenGeni** switch to embed the agent workspace in
+   the same product.
+3. The product backend creates OpenGeni sessions and proxies workspace-scoped
    API/SSE traffic, keeping the OpenGeni API key server-side.
-3. OpenGeni calls the product's authenticated Streamable HTTP MCP server.
-4. MCP tools read and mutate product data.
-5. Product SSE updates the ticket immediately while OpenGeni SSE updates the
+4. OpenGeni calls the product's authenticated Streamable HTTP MCP server.
+5. MCP tools read and mutate the same ticket data used by the human workflow.
+6. Product SSE updates the ticket immediately while OpenGeni SSE updates the
    agent timeline independently.
 
-The demo deliberately exposes four tools over one ticket: `get_ticket`,
+The demo deliberately exposes four tools over the selected ticket: `get_ticket`,
 `get_customer`, `update_ticket`, and `add_internal_note`. Mutations are
 pre-approved and idempotent so the full loop is easy to demonstrate.
+
+The example depends on `@opengeni/sdk` and `@opengeni/react` through
+`workspace:*`, so a repository checkout always runs against the current SDK and
+component source rather than a stale published copy.
 
 ## Run against managed OpenGeni
 

--- a/examples/northstar-support/package.json
+++ b/examples/northstar-support/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1 --port 3101",
     "server": "bun --env-file=.env.local src/server.ts",
+    "start": "bun src/server.ts",
     "build": "vite build",
     "typecheck": "tsc --noEmit"
   },

--- a/examples/northstar-support/src/main.tsx
+++ b/examples/northstar-support/src/main.tsx
@@ -1,10 +1,13 @@
+import { OpenGeniProvider } from "@opengeni/react";
 import { OpenGeniClient } from "@opengeni/sdk";
-import { LifeBuoyIcon, SearchIcon, Settings2Icon } from "lucide-react";
+import { CheckIcon, LifeBuoyIcon, RotateCcwIcon, SparklesIcon } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { OpenGeniProvider } from "@opengeni/react";
 import { SupportAgentPanel } from "./support-agent-panel";
+import { SupportInbox } from "./support-inbox";
 import { SupportTicketView } from "./support-ticket";
+import type { SupportCase } from "./types";
 import { useSupportDemo } from "./use-support-demo";
 import "./styles.css";
 
@@ -16,13 +19,11 @@ declare global {
   }
 }
 
-function WorkspaceChatApp() {
+function NorthstarApp() {
   const demo = useSupportDemo();
+  const [agentEnabled, setAgentEnabled] = useState(false);
   const [sessionId, setSessionId] = useState<string | null>(null);
-
-  function selectSession(next: string | null) {
-    setSessionId(next);
-  }
+  const [selectedTicketId, setSelectedTicketId] = useState("TKT-2847");
 
   if (demo.loading && !demo.state) {
     return <LoadingScreen />;
@@ -31,74 +32,184 @@ function WorkspaceChatApp() {
   if (!demo.state) {
     return <BackendError message={demo.error?.message ?? "Demo backend unavailable."} />;
   }
+  if (!Array.isArray(demo.state.cases)) {
+    return <LoadingScreen />;
+  }
+  const selectedCase =
+    demo.state.cases.find(({ ticket }) => ticket.id === selectedTicketId) ?? demo.state.cases[0];
+  if (!selectedCase) {
+    return <BackendError message="The demo ticket queue is empty." />;
+  }
+  const selectedState = { revision: demo.state.revision, ...selectedCase };
 
   return (
     <OpenGeniProvider client={client} workspaceId={demo.health?.workspaceId ?? "unconfigured"}>
-      <div className="northstar og-root h-dvh overflow-hidden bg-[#f7f7f9]" data-og-theme="light">
-        <TopNavigation />
-        <div className="grid h-[calc(100dvh-57px)] min-h-0 grid-cols-[minmax(520px,1fr)_minmax(390px,42%)] max-lg:grid-cols-[minmax(460px,1fr)_420px] max-md:block max-md:overflow-y-auto">
-          <SupportTicketView state={demo.state} lastEvent={demo.lastEvent} onReset={demo.reset} />
-          <div className="min-h-0 max-md:h-[780px]">
-            <SupportAgentPanel
-              health={demo.health}
-              sessionId={sessionId}
-              onSessionCreated={(id) => selectSession(id)}
-              onClearSession={() => selectSession(null)}
-            />
-          </div>
-        </div>
+      <div
+        className={
+          agentEnabled
+            ? "northstar grid h-dvh min-w-[1120px] grid-cols-[260px_minmax(460px,1fr)_420px] overflow-hidden bg-[#f7f7f5]"
+            : "northstar grid h-dvh min-w-[980px] grid-cols-[320px_minmax(0,1fr)] overflow-hidden bg-[#f7f7f5]"
+        }
+        data-agent-enabled={agentEnabled}
+        data-og-theme="light"
+      >
+        <SupportInbox
+          state={demo.state}
+          selectedTicketId={selectedCase.ticket.id}
+          agentEnabled={agentEnabled}
+          onSelectTicket={(ticketId) => {
+            setSelectedTicketId(ticketId);
+            setSessionId(null);
+          }}
+        />
+
+        <main className="flex min-h-0 min-w-0 flex-col bg-[#f7f7f5]">
+          <ProductHeader
+            supportCase={selectedCase}
+            agentEnabled={agentEnabled}
+            onAgentEnabledChange={(enabled) => {
+              setAgentEnabled(enabled);
+              setSessionId(null);
+            }}
+            onReset={() => {
+              setSessionId(null);
+              setSelectedTicketId("TKT-2847");
+              void demo.reset();
+            }}
+          />
+          <SupportTicketView
+            key={selectedCase.ticket.id}
+            state={selectedState}
+            lastEvent={demo.lastEvent?.ticketId === selectedCase.ticket.id ? demo.lastEvent : null}
+            agentEnabled={agentEnabled}
+            onUpdateTicket={(changes) => demo.updateTicket(selectedCase.ticket.id, changes)}
+            onAddNote={(body) => demo.addNote(selectedCase.ticket.id, body)}
+            onSendReply={(body) => demo.sendReply(selectedCase.ticket.id, body)}
+          />
+        </main>
+
+        <AnimatePresence initial={false}>
+          {agentEnabled ? (
+            <motion.div
+              key="opengeni-panel"
+              initial={{ opacity: 0, x: 56 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: 56 }}
+              transition={{ duration: 0.34, ease: [0.22, 1, 0.36, 1] }}
+              className="min-h-0 min-w-0 overflow-hidden"
+            >
+              <SupportAgentPanel
+                health={demo.health}
+                supportCase={selectedCase}
+                sessionId={sessionId}
+                onSessionCreated={setSessionId}
+                onClearSession={() => setSessionId(null)}
+              />
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
       </div>
     </OpenGeniProvider>
   );
 }
 
-function TopNavigation() {
+function ProductHeader({
+  supportCase,
+  agentEnabled,
+  onAgentEnabledChange,
+  onReset,
+}: {
+  supportCase: SupportCase;
+  agentEnabled: boolean;
+  onAgentEnabledChange: (enabled: boolean) => void;
+  onReset: () => void;
+}) {
   return (
-    <nav className="flex h-[57px] items-center justify-between border-b border-black/[0.07] bg-white px-5 text-[#242631]">
-      <div className="flex items-center gap-7">
-        <div className="flex items-center gap-2.5">
-          <div className="grid size-8 place-items-center rounded-[10px] bg-[#6762df] text-[13px] font-bold text-white shadow-[0_4px_10px_rgba(103,98,223,0.25)]">
-            N
-          </div>
-          <span className="text-sm font-semibold tracking-[-0.015em]">Northstar</span>
+    <header className="flex h-[72px] shrink-0 items-center justify-between border-b border-[#deded9] bg-white px-7">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 text-[11px] font-medium text-[#85857f]">
+          <span>Inbox</span>
+          <span className="text-[#c1beb5]">/</span>
+          <span>{supportCase.ticket.id}</span>
         </div>
-        <div className="flex items-center gap-1 max-sm:hidden">
-          <span className="rounded-lg bg-[#f1f1f5] px-3 py-1.5 text-xs font-semibold text-[#40434d]">
-            Inbox
+        <div className="mt-1 flex items-center gap-2.5">
+          <span
+            className={
+              supportCase.ticket.unread
+                ? "size-2 rounded-full bg-[#d86c4f]"
+                : "size-2 rounded-full bg-[#59917e]"
+            }
+          />
+          <p className="truncate text-[14px] font-semibold tracking-[-0.01em] text-[#252a27]">
+            {supportCase.customer.name} · {supportCase.ticket.subject}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          onClick={onReset}
+          className="inline-flex h-9 items-center gap-2 px-1 text-[12px] font-medium text-[#777771] transition hover:text-[#30332f]"
+        >
+          <RotateCcwIcon className="size-3.5" />
+          Reset
+        </button>
+
+        <button
+          type="button"
+          role="switch"
+          aria-checked={agentEnabled}
+          onClick={() => onAgentEnabledChange(!agentEnabled)}
+          className={
+            agentEnabled
+              ? "group flex h-10 items-center gap-3 border-l border-[#d9d8d3] pl-5 text-left transition"
+              : "group flex h-10 items-center gap-3 border-l border-[#d9d8d3] pl-5 text-left transition"
+          }
+        >
+          <SparklesIcon
+            className={agentEnabled ? "size-4 text-[#5f50c7]" : "size-4 text-[#96938e]"}
+          />
+          <span className="min-w-[88px]">
+            <span className="block text-[12px] font-semibold text-[#333632]">OpenGeni</span>
+            <span
+              className={
+                agentEnabled
+                  ? "mt-0.5 block text-[10px] font-medium text-[#5f50c7]"
+                  : "mt-0.5 block text-[10px] text-[#92918b]"
+              }
+            >
+              {agentEnabled ? "Active" : "Off"}
+            </span>
           </span>
-          <span className="px-3 py-1.5 text-xs text-[#868a95]">Customers</span>
-          <span className="px-3 py-1.5 text-xs text-[#868a95]">Reports</span>
-        </div>
-      </div>
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          aria-label="Search"
-          className="grid size-8 place-items-center rounded-lg text-[#898c96] hover:bg-[#f3f3f5]"
-        >
-          <SearchIcon className="size-4" />
+          <span
+            aria-hidden="true"
+            className={
+              agentEnabled
+                ? "relative h-6 w-10 rounded-full bg-[#6254c7]"
+                : "relative h-6 w-10 rounded-full bg-[#d2d2ce]"
+            }
+          >
+            <motion.span
+              className="absolute top-1 grid size-4 place-items-center rounded-full bg-white shadow-sm"
+              animate={{ left: agentEnabled ? 20 : 4 }}
+              transition={{ type: "spring", stiffness: 500, damping: 34 }}
+            >
+              {agentEnabled ? <CheckIcon className="size-2.5 text-[#6255d0]" /> : null}
+            </motion.span>
+          </span>
         </button>
-        <button
-          type="button"
-          aria-label="Settings"
-          className="grid size-8 place-items-center rounded-lg text-[#898c96] hover:bg-[#f3f3f5]"
-        >
-          <Settings2Icon className="size-4" />
-        </button>
-        <div className="ml-1 grid size-8 place-items-center rounded-full bg-[#e8e4db] text-[10px] font-bold text-[#6c6455]">
-          MC
-        </div>
       </div>
-    </nav>
+    </header>
   );
 }
 
 function LoadingScreen() {
   return (
-    <div className="grid h-dvh place-items-center bg-[#f7f7f9] text-[#242631]">
+    <div className="grid h-dvh place-items-center bg-[#f4f6f7] text-[#242b31]">
       <div className="text-center">
-        <div className="mx-auto size-7 animate-spin rounded-full border-2 border-[#d8d8e4] border-t-[#6762df]" />
-        <p className="mt-4 text-sm text-[#7c808b]">Loading Northstar…</p>
+        <div className="mx-auto size-7 animate-spin rounded-full border-2 border-[#d7dce0] border-t-[#28715f]" />
+        <p className="mt-4 text-sm text-[#7c848b]">Opening Northstar…</p>
       </div>
     </div>
   );
@@ -106,12 +217,12 @@ function LoadingScreen() {
 
 function BackendError({ message }: { message: string }) {
   return (
-    <div className="grid h-dvh place-items-center bg-[#f7f7f9] px-6 text-[#242631]">
+    <div className="grid h-dvh place-items-center bg-[#f4f6f7] px-6 text-[#242b31]">
       <div className="max-w-md rounded-2xl border border-black/[0.07] bg-white p-6 text-center shadow-sm">
-        <LifeBuoyIcon className="mx-auto size-6 text-[#6762df]" />
-        <h1 className="mt-3 text-lg font-semibold">Start the demo backend</h1>
-        <p className="mt-2 text-sm leading-6 text-[#757985]">{message}</p>
-        <code className="mt-4 block rounded-xl bg-[#f4f4f6] px-3 py-2 text-xs">bun run server</code>
+        <LifeBuoyIcon className="mx-auto size-6 text-[#28715f]" />
+        <h1 className="mt-3 text-lg font-semibold">Start the Northstar backend</h1>
+        <p className="mt-2 text-sm leading-6 text-[#757d84]">{message}</p>
+        <code className="mt-4 block rounded-xl bg-[#f4f5f6] px-3 py-2 text-xs">bun run server</code>
       </div>
     </div>
   );
@@ -120,4 +231,4 @@ function BackendError({ message }: { message: string }) {
 const container = document.getElementById("root")!;
 const root = window.__northstarDemoRoot ?? createRoot(container);
 window.__northstarDemoRoot = root;
-root.render(<WorkspaceChatApp />);
+root.render(<NorthstarApp />);

--- a/examples/northstar-support/src/server.ts
+++ b/examples/northstar-support/src/server.ts
@@ -1,19 +1,25 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { OpenGeniClient, type CreateSessionRequest } from "@opengeni/sdk";
+import { join, normalize } from "node:path";
 import * as z from "zod/v4";
 import type {
+  SupportCase,
   DemoHealth,
-  SupportCustomer,
-  SupportDemoState,
   SupportDomainEvent,
   SupportTicket,
+  SupportWorkspaceState,
   TicketPriority,
   TicketStatus,
 } from "./types";
 
-const PRODUCT_PORT = 4100;
-const MCP_PORT = 4101;
+const PRODUCT_PORT = Number(process.env.PORT ?? 4100);
+const MCP_PORT = Number(process.env.OPENGENI_DEMO_MCP_PORT ?? 4101);
+const UNIFIED_SERVER = Boolean(process.env.PORT);
+const PRODUCT_APP_ORIGIN = (
+  process.env.OPENGENI_DEMO_APP_ORIGIN ?? "http://127.0.0.1:3101"
+).replace(/\/+$/, "");
+const STATIC_ROOT = join(import.meta.dir, "../dist");
 const MCP_SERVER_ID = "northstar_support";
 const MCP_TOOLS = ["get_ticket", "get_customer", "update_ticket", "add_internal_note"];
 const encoder = new TextEncoder();
@@ -28,81 +34,268 @@ const mcpToken = process.env.OPENGENI_DEMO_MCP_TOKEN?.trim() ?? "";
 const model = process.env.OPENGENI_MODEL?.trim() ?? "";
 const openGeni = new OpenGeniClient({ baseUrl: apiBaseUrl, apiKey });
 
-const initialCustomer: SupportCustomer = {
-  id: "cus_aster_01",
-  name: "Aster Labs",
-  initials: "AL",
-  plan: "Scale",
-  arr: 48_000,
-  healthScore: 82,
-  joinedAt: "2024-09-18T10:00:00.000Z",
-  primaryContact: {
-    name: "Nora Lind",
-    role: "Operations lead",
-    email: "nora@asterlabs.example",
-  },
-  recentUsage: {
-    activeSeats: 37,
-    totalSeats: 45,
-    exportsLast30Days: 186,
-    failedExportsLast7Days: 14,
-  },
-};
+function minutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * 60_000).toISOString();
+}
 
-const initialTicket: SupportTicket = {
-  id: "TKT-2847",
-  customerId: initialCustomer.id,
-  subject: "Monthly export stalls at 87%",
-  body: "Hi team — our monthly finance export has stopped at exactly 87% three times today. We need the report for tomorrow's board meeting. Can someone take a look?",
-  status: "open",
-  priority: "normal",
-  assignee: "Maya Chen",
-  channel: "email",
-  createdAt: "2026-07-15T08:42:00.000Z",
-  slaDueAt: "2026-07-15T16:42:00.000Z",
-  tags: ["exports", "finance"],
-  notes: [
-    {
-      id: "note_seed",
-      author: "Maya Chen",
-      authorKind: "human",
-      body: "No platform incident showing. Customer has retried from two browsers.",
-      createdAt: "2026-07-15T09:03:00.000Z",
-    },
-  ],
-  activity: [
-    {
-      id: "activity_seed",
-      actor: "Nora Lind",
-      summary: "Created the ticket by email",
-      createdAt: "2026-07-15T08:42:00.000Z",
-    },
-  ],
-};
+function minutesFromNow(minutes: number): string {
+  return new Date(Date.now() + minutes * 60_000).toISOString();
+}
 
-let state: SupportDemoState = freshState();
+const initialCases: SupportCase[] = [
+  {
+    customer: {
+      id: "cus_aster_01",
+      name: "Aster Labs",
+      initials: "AL",
+      plan: "Scale",
+      arr: 48_000,
+      healthScore: 82,
+      joinedAt: "2024-09-18T10:00:00.000Z",
+      primaryContact: {
+        name: "Nora Lind",
+        role: "Operations lead",
+        email: "nora@asterlabs.example",
+      },
+      recentUsage: {
+        activeSeats: 37,
+        totalSeats: 45,
+        exportsLast30Days: 186,
+        failedExportsLast7Days: 14,
+      },
+    },
+    ticket: {
+      id: "TKT-2847",
+      customerId: "cus_aster_01",
+      subject: "Monthly export stalls at 87%",
+      body: "Hi team — our monthly finance export has stopped at exactly 87% three times today. We need the report for tomorrow's board meeting. Can someone take a look?",
+      status: "open",
+      priority: "normal",
+      assignee: "Maya Chen",
+      channel: "email",
+      createdAt: minutesAgo(12),
+      slaDueAt: minutesFromNow(108),
+      tags: ["exports", "finance"],
+      inbox: "mine",
+      unread: true,
+      notes: [
+        {
+          id: "note_seed_aster",
+          author: "Maya Chen",
+          authorKind: "human",
+          body: "No platform incident showing. Customer has retried from two browsers.",
+          createdAt: minutesAgo(8),
+        },
+      ],
+      replies: [],
+      activity: [
+        {
+          id: "activity_seed_aster",
+          actor: "Nora Lind",
+          summary: "Created the ticket by email",
+          createdAt: minutesAgo(12),
+        },
+      ],
+    },
+  },
+  {
+    customer: {
+      id: "cus_pine_01",
+      name: "Pine & Co.",
+      initials: "PC",
+      plan: "Growth",
+      arr: 18_000,
+      healthScore: 91,
+      joinedAt: "2025-02-11T10:00:00.000Z",
+      primaryContact: {
+        name: "Elias Berg",
+        role: "IT manager",
+        email: "elias@pine.example",
+      },
+      recentUsage: {
+        activeSeats: 21,
+        totalSeats: 25,
+        exportsLast30Days: 64,
+        failedExportsLast7Days: 1,
+      },
+    },
+    ticket: {
+      id: "TKT-2841",
+      customerId: "cus_pine_01",
+      subject: "Invite emails are delayed",
+      body: "Three new teammates have been waiting more than 20 minutes for invite emails. Resending did not help. Could you check the delivery queue?",
+      status: "investigating",
+      priority: "high",
+      assignee: "Maya Chen",
+      channel: "email",
+      createdAt: minutesAgo(18),
+      slaDueAt: minutesFromNow(72),
+      tags: ["email", "invites"],
+      inbox: "mine",
+      unread: true,
+      notes: [],
+      replies: [],
+      activity: [
+        {
+          id: "activity_seed_pine",
+          actor: "Elias Berg",
+          summary: "Created the ticket by email",
+          createdAt: minutesAgo(18),
+        },
+      ],
+    },
+  },
+  {
+    customer: {
+      id: "cus_cinder_01",
+      name: "Cinder",
+      initials: "CI",
+      plan: "Enterprise",
+      arr: 96_000,
+      healthScore: 96,
+      joinedAt: "2023-11-05T10:00:00.000Z",
+      primaryContact: {
+        name: "Sofia Reyes",
+        role: "Security lead",
+        email: "sofia@cinder.example",
+      },
+      recentUsage: {
+        activeSeats: 118,
+        totalSeats: 140,
+        exportsLast30Days: 412,
+        failedExportsLast7Days: 0,
+      },
+    },
+    ticket: {
+      id: "TKT-2839",
+      customerId: "cus_cinder_01",
+      subject: "Question about SSO setup",
+      body: "We are ready to enforce SSO next week. Can you confirm whether existing sessions are revoked immediately when enforcement is enabled?",
+      status: "open",
+      priority: "normal",
+      assignee: "Maya Chen",
+      channel: "email",
+      createdAt: minutesAgo(42),
+      slaDueAt: minutesFromNow(198),
+      tags: ["sso", "security"],
+      inbox: "mine",
+      unread: false,
+      notes: [],
+      replies: [],
+      activity: [
+        {
+          id: "activity_seed_cinder",
+          actor: "Sofia Reyes",
+          summary: "Created the ticket by email",
+          createdAt: minutesAgo(42),
+        },
+      ],
+    },
+  },
+  {
+    customer: {
+      id: "cus_northwind_01",
+      name: "Northwind",
+      initials: "NW",
+      plan: "Starter",
+      arr: 7_200,
+      healthScore: 75,
+      joinedAt: "2025-08-22T10:00:00.000Z",
+      primaryContact: {
+        name: "Ava Cole",
+        role: "Finance manager",
+        email: "ava@northwind.example",
+      },
+      recentUsage: {
+        activeSeats: 8,
+        totalSeats: 10,
+        exportsLast30Days: 22,
+        failedExportsLast7Days: 2,
+      },
+    },
+    ticket: {
+      id: "TKT-2835",
+      customerId: "cus_northwind_01",
+      subject: "Update billing contact",
+      body: "Please change our billing contact to finance@northwind.example before the next invoice is generated.",
+      status: "open",
+      priority: "low",
+      assignee: "Unassigned",
+      channel: "email",
+      createdAt: minutesAgo(67),
+      slaDueAt: minutesFromNow(413),
+      tags: ["billing"],
+      inbox: "unassigned",
+      unread: false,
+      notes: [],
+      replies: [],
+      activity: [
+        {
+          id: "activity_seed_northwind",
+          actor: "Ava Cole",
+          summary: "Created the ticket by email",
+          createdAt: minutesAgo(67),
+        },
+      ],
+    },
+  },
+];
+
+let state: SupportWorkspaceState = freshState();
 const subscribers = new Set<ReadableStreamDefaultController<Uint8Array>>();
 
-function freshState(): SupportDemoState {
+function freshState(): SupportWorkspaceState {
   return {
     revision: 1,
-    customer: structuredClone(initialCustomer),
-    ticket: structuredClone(initialTicket),
+    cases: structuredClone(initialCases),
   };
+}
+
+function getCase(ticketId: string): SupportCase | null {
+  return state.cases.find((supportCase) => supportCase.ticket.id === ticketId) ?? null;
 }
 
 function json(value: unknown, status = 200): Response {
   return Response.json(value, {
     status,
-    headers: { "cache-control": "no-store" },
+    headers: {
+      "cache-control": "no-store",
+      "access-control-allow-origin": PRODUCT_APP_ORIGIN,
+    },
   });
 }
 
-function emit(type: SupportDomainEvent["type"], summary: string): SupportDomainEvent {
+function staticResponse(pathname: string): Response {
+  const requested = pathname === "/" ? "index.html" : pathname.replace(/^\/+/, "");
+  const safePath = normalize(requested);
+  if (safePath.startsWith("..") || safePath.includes("/../")) {
+    return new Response("Not found", { status: 404 });
+  }
+  const asset = Bun.file(join(STATIC_ROOT, safePath));
+  if (asset.size > 0) {
+    return new Response(asset, {
+      headers: {
+        "cache-control":
+          safePath === "index.html" ? "no-cache" : "public, max-age=31536000, immutable",
+      },
+    });
+  }
+  const index = Bun.file(join(STATIC_ROOT, "index.html"));
+  return index.size > 0
+    ? new Response(index, { headers: { "cache-control": "no-cache" } })
+    : new Response("Not found", { status: 404 });
+}
+
+function emit(
+  type: SupportDomainEvent["type"],
+  summary: string,
+  ticketId: string,
+): SupportDomainEvent {
   state.revision += 1;
   const event: SupportDomainEvent = {
     id: crypto.randomUUID(),
     type,
+    ticketId,
     revision: state.revision,
     summary,
     occurredAt: new Date().toISOString(),
@@ -120,8 +313,8 @@ function emit(type: SupportDomainEvent["type"], summary: string): SupportDomainE
   return event;
 }
 
-function addActivity(actor: string, summary: string): void {
-  state.ticket.activity.unshift({
+function addActivity(ticket: SupportTicket, actor: string, summary: string): void {
+  ticket.activity.unshift({
     id: crypto.randomUUID(),
     actor,
     summary,
@@ -167,6 +360,7 @@ function domainEventStream(request: Request): Response {
       "content-type": "text/event-stream",
       "cache-control": "no-cache, no-transform",
       connection: "keep-alive",
+      "access-control-allow-origin": PRODUCT_APP_ORIGIN,
     },
   });
 }
@@ -231,11 +425,18 @@ async function createAgentSession(request: Request): Promise<Response> {
   }
   const input = (await request.json().catch(() => ({}))) as {
     initialMessage?: unknown;
+    ticketId?: unknown;
   };
+  const ticketId = typeof input.ticketId === "string" ? input.ticketId : "";
+  const supportCase = getCase(ticketId);
+  if (!supportCase) {
+    return json({ error: `Ticket ${ticketId || "unknown"} not found.` }, 404);
+  }
+  const { ticket, customer } = supportCase;
   const initialMessage =
     typeof input.initialMessage === "string" && input.initialMessage.trim()
       ? input.initialMessage.trim()
-      : "Investigate this support ticket. Use the available support tools, explain the evidence, and take the appropriate actions.";
+      : `Investigate ${ticket.id}. Use the available support tools, explain the evidence, and take the appropriate actions.`;
 
   const mcpServer = {
     id: MCP_SERVER_ID,
@@ -249,12 +450,12 @@ async function createAgentSession(request: Request): Promise<Response> {
   };
   const sessionRequest: CreateSessionRequest = {
     initialMessage,
-    instructions: `You are the embedded support copilot inside Northstar, a fictional SaaS product. You are working only on ticket TKT-2847 for Aster Labs. Always inspect the ticket and customer with Northstar Support tools before drawing conclusions. The failed-export evidence is important. When evidence warrants action, call update_ticket and add_internal_note immediately. Product actions are pre-approved for this demo, so execute them without asking for confirmation. Never invent customer data. Keep the final answer brief and operational.`,
+    instructions: `You are the embedded support copilot inside Northstar, a fictional SaaS product. You are working only on ticket ${ticket.id} for ${customer.name}. Always inspect the ticket and customer with Northstar Support tools before drawing conclusions. When evidence warrants action, call update_ticket and add_internal_note immediately. Product actions are pre-approved for this demo, so execute them without asking for confirmation. Never invent customer data. Keep the final answer brief and operational.`,
     ...(model ? { model } : {}),
-    reasoningEffort: "low",
+    reasoningEffort: "high",
     tools: [{ kind: "mcp", id: MCP_SERVER_ID }],
     mcpServers: [mcpServer] as CreateSessionRequest["mcpServers"],
-    metadata: { demo: "northstar-support", ticketId: state.ticket.id },
+    metadata: { demo: "northstar-support", ticketId: ticket.id },
     clientEventId: crypto.randomUUID(),
     idempotencyKey: crypto.randomUUID(),
   };
@@ -270,8 +471,12 @@ async function proxyOpenGeni(request: Request): Promise<Response> {
   const incoming = new URL(request.url);
   const upstreamPath = incoming.pathname.replace(/^\/api\/opengeni/, "");
   const workspacePrefix = `/v1/workspaces/${workspaceId}`;
-  if (upstreamPath !== workspacePrefix && !upstreamPath.startsWith(`${workspacePrefix}/`)) {
-    return json({ error: "Workspace path is outside this demo's scope." }, 403);
+  const isWorkspacePath =
+    upstreamPath === workspacePrefix || upstreamPath.startsWith(`${workspacePrefix}/`);
+  const isClientConfigRead = request.method === "GET" && upstreamPath === "/v1/config/client";
+
+  if (!isWorkspacePath && !isClientConfigRead) {
+    return json({ error: "API path is outside this demo's scope." }, 403);
   }
 
   const headers = new Headers(request.headers);
@@ -299,6 +504,17 @@ async function proxyOpenGeni(request: Request): Promise<Response> {
 
 async function productRequest(request: Request): Promise<Response> {
   const url = new URL(request.url);
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "access-control-allow-origin": PRODUCT_APP_ORIGIN,
+        "access-control-allow-methods": "GET, POST, PATCH, OPTIONS",
+        "access-control-allow-headers": "content-type",
+        "access-control-max-age": "86400",
+      },
+    });
+  }
   if (url.pathname.startsWith("/api/opengeni/")) {
     try {
       return await proxyOpenGeni(request);
@@ -317,11 +533,101 @@ async function productRequest(request: Request): Promise<Response> {
       return json({ error: error instanceof Error ? error.message : String(error) }, 502);
     }
   }
-  if (url.pathname === "/api/demo/reset" && request.method === "POST") {
-    state = freshState();
-    emit("demo.reset", "Demo data reset");
+  if (url.pathname === "/api/demo/ticket" && request.method === "PATCH") {
+    const input = (await request.json().catch(() => ({}))) as {
+      ticketId?: unknown;
+      priority?: unknown;
+      status?: unknown;
+    };
+    const ticketId = typeof input.ticketId === "string" ? input.ticketId : "";
+    const supportCase = getCase(ticketId);
+    if (!supportCase) return json({ error: `Ticket ${ticketId || "unknown"} not found.` }, 404);
+    const { ticket } = supportCase;
+    const priorities: TicketPriority[] = ["low", "normal", "high", "urgent"];
+    const statuses: TicketStatus[] = ["open", "investigating", "waiting_on_customer", "resolved"];
+    const changes: string[] = [];
+    if (
+      typeof input.priority === "string" &&
+      priorities.includes(input.priority as TicketPriority) &&
+      input.priority !== ticket.priority
+    ) {
+      changes.push(`priority to ${input.priority}`);
+      ticket.priority = input.priority as TicketPriority;
+    }
+    if (
+      typeof input.status === "string" &&
+      statuses.includes(input.status as TicketStatus) &&
+      input.status !== ticket.status
+    ) {
+      changes.push(`status to ${input.status.replaceAll("_", " ")}`);
+      ticket.status = input.status as TicketStatus;
+    }
+    if (changes.length > 0) {
+      const summary = `Maya changed ${changes.join(" and ")}`;
+      addActivity(ticket, "Maya Chen", summary);
+      emit("ticket.updated", summary, ticket.id);
+    }
     return json(state);
   }
+  if (url.pathname === "/api/demo/notes" && request.method === "POST") {
+    const input = (await request.json().catch(() => ({}))) as {
+      ticketId?: unknown;
+      body?: unknown;
+    };
+    const ticketId = typeof input.ticketId === "string" ? input.ticketId : "";
+    const supportCase = getCase(ticketId);
+    if (!supportCase) return json({ error: `Ticket ${ticketId || "unknown"} not found.` }, 404);
+    const { ticket } = supportCase;
+    const body = typeof input.body === "string" ? input.body.trim() : "";
+    if (body.length < 2 || body.length > 1_000) {
+      return json({ error: "Internal note must be between 2 and 1,000 characters." }, 422);
+    }
+    ticket.notes.unshift({
+      id: crypto.randomUUID(),
+      author: "Maya Chen",
+      authorKind: "human",
+      body,
+      createdAt: new Date().toISOString(),
+    });
+    addActivity(ticket, "Maya Chen", "Added an internal note");
+    emit("ticket.note_added", "Maya added an internal note", ticket.id);
+    return json(state);
+  }
+  if (url.pathname === "/api/demo/replies" && request.method === "POST") {
+    const input = (await request.json().catch(() => ({}))) as {
+      ticketId?: unknown;
+      body?: unknown;
+    };
+    const ticketId = typeof input.ticketId === "string" ? input.ticketId : "";
+    const supportCase = getCase(ticketId);
+    if (!supportCase) return json({ error: `Ticket ${ticketId || "unknown"} not found.` }, 404);
+    const { ticket, customer } = supportCase;
+    const body = typeof input.body === "string" ? input.body.trim() : "";
+    if (body.length < 2 || body.length > 2_000) {
+      return json({ error: "Reply must be between 2 and 2,000 characters." }, 422);
+    }
+    ticket.replies.push({
+      id: crypto.randomUUID(),
+      author: "Maya Chen",
+      body,
+      createdAt: new Date().toISOString(),
+    });
+    ticket.status = "waiting_on_customer";
+    ticket.unread = false;
+    addActivity(
+      ticket,
+      "Maya Chen",
+      `Replied to ${customer.primaryContact.name} and set the ticket to waiting on customer`,
+    );
+    emit("ticket.replied", `Reply sent to ${customer.primaryContact.name}`, ticket.id);
+    return json(state);
+  }
+  if (url.pathname === "/api/demo/reset" && request.method === "POST") {
+    state = freshState();
+    emit("demo.reset", "Demo data reset", "all");
+    return json(state);
+  }
+  if (UNIFIED_SERVER && request.method === "GET") return staticResponse(url.pathname);
   return new Response("Not found", { status: 404 });
 }
 
@@ -337,16 +643,18 @@ function buildMcpServer(): McpServer {
       description:
         "Get the complete support ticket, including priority, status, SLA, customer message, internal notes, and activity.",
       inputSchema: {
-        ticketId: z.string().describe("Ticket id, normally TKT-2847"),
+        ticketId: z.string().describe("Ticket id from the active Northstar session"),
       },
     },
-    async ({ ticketId }) =>
-      ticketId === state.ticket.id
-        ? toolResult(state.ticket)
+    async ({ ticketId }) => {
+      const supportCase = getCase(ticketId);
+      return supportCase
+        ? toolResult(supportCase.ticket)
         : {
             ...toolResult({ error: `Ticket ${ticketId} not found` }),
             isError: true,
-          },
+          };
+    },
   );
   server.registerTool(
     "get_customer",
@@ -357,13 +665,16 @@ function buildMcpServer(): McpServer {
         customerId: z.string().describe("Customer id from the ticket"),
       },
     },
-    async ({ customerId }) =>
-      customerId === state.customer.id
-        ? toolResult(state.customer)
+    async ({ customerId }) => {
+      const customer =
+        state.cases.find((supportCase) => supportCase.customer.id === customerId)?.customer ?? null;
+      return customer
+        ? toolResult(customer)
         : {
             ...toolResult({ error: `Customer ${customerId} not found` }),
             isError: true,
-          },
+          };
+    },
   );
   server.registerTool(
     "update_ticket",
@@ -379,33 +690,35 @@ function buildMcpServer(): McpServer {
       },
     },
     async ({ ticketId, priority, status, assignee, reason }) => {
-      if (ticketId !== state.ticket.id) {
+      const supportCase = getCase(ticketId);
+      if (!supportCase) {
         return {
           ...toolResult({ error: `Ticket ${ticketId} not found` }),
           isError: true,
         };
       }
+      const { ticket } = supportCase;
       const changes: string[] = [];
-      if (priority && priority !== state.ticket.priority) {
-        changes.push(`priority ${state.ticket.priority} → ${priority}`);
-        state.ticket.priority = priority as TicketPriority;
+      if (priority && priority !== ticket.priority) {
+        changes.push(`priority ${ticket.priority} → ${priority}`);
+        ticket.priority = priority as TicketPriority;
       }
-      if (status && status !== state.ticket.status) {
-        changes.push(`status ${state.ticket.status} → ${status}`);
-        state.ticket.status = status as TicketStatus;
+      if (status && status !== ticket.status) {
+        changes.push(`status ${ticket.status} → ${status}`);
+        ticket.status = status as TicketStatus;
       }
-      if (assignee && assignee !== state.ticket.assignee) {
-        changes.push(`assignee ${state.ticket.assignee} → ${assignee}`);
-        state.ticket.assignee = assignee;
+      if (assignee && assignee !== ticket.assignee) {
+        changes.push(`assignee ${ticket.assignee} → ${assignee}`);
+        ticket.assignee = assignee;
       }
       const summary = changes.length
         ? `Updated ${changes.join(", ")}`
         : "Reviewed ticket; no field changes";
       if (changes.length > 0) {
-        addActivity("OpenGeni agent", `${summary}. Reason: ${reason}`);
-        emit("ticket.updated", summary);
+        addActivity(ticket, "OpenGeni agent", `${summary}. Reason: ${reason}`);
+        emit("ticket.updated", summary, ticket.id);
       }
-      return toolResult({ ok: true, summary, ticket: state.ticket });
+      return toolResult({ ok: true, summary, ticket });
     },
   );
   server.registerTool(
@@ -419,13 +732,15 @@ function buildMcpServer(): McpServer {
       },
     },
     async ({ ticketId, body }) => {
-      if (ticketId !== state.ticket.id) {
+      const supportCase = getCase(ticketId);
+      if (!supportCase) {
         return {
           ...toolResult({ error: `Ticket ${ticketId} not found` }),
           isError: true,
         };
       }
-      const existing = state.ticket.notes.find(
+      const { ticket } = supportCase;
+      const existing = ticket.notes.find(
         (note) => note.authorKind === "agent" && note.body === body,
       );
       if (existing) {
@@ -438,9 +753,9 @@ function buildMcpServer(): McpServer {
         body,
         createdAt: new Date().toISOString(),
       };
-      state.ticket.notes.unshift(note);
-      addActivity("OpenGeni agent", "Added an internal investigation note");
-      emit("ticket.note_added", "Agent added an internal note");
+      ticket.notes.unshift(note);
+      addActivity(ticket, "OpenGeni agent", "Added an internal investigation note");
+      emit("ticket.note_added", "Agent added an internal note", ticket.id);
       return toolResult({ ok: true, note });
     },
   );
@@ -462,17 +777,24 @@ async function mcpRequest(request: Request): Promise<Response> {
 }
 
 const productServer = Bun.serve({
-  hostname: "127.0.0.1",
+  hostname: UNIFIED_SERVER ? "0.0.0.0" : "127.0.0.1",
   port: PRODUCT_PORT,
   idleTimeout: 255,
-  fetch: productRequest,
+  fetch: async (request) => {
+    if (UNIFIED_SERVER && new URL(request.url).pathname === "/mcp") {
+      return await mcpRequest(request);
+    }
+    return await productRequest(request);
+  },
 });
-const mcpServer = Bun.serve({
-  hostname: "127.0.0.1",
-  port: MCP_PORT,
-  idleTimeout: 255,
-  fetch: mcpRequest,
-});
+const mcpServer = UNIFIED_SERVER
+  ? productServer
+  : Bun.serve({
+      hostname: "127.0.0.1",
+      port: MCP_PORT,
+      idleTimeout: 255,
+      fetch: mcpRequest,
+    });
 
 console.log(`Northstar product API  http://127.0.0.1:${productServer.port}/api/demo/health`);
 console.log(`Northstar MCP server   http://127.0.0.1:${mcpServer.port}/mcp`);

--- a/examples/northstar-support/src/styles.css
+++ b/examples/northstar-support/src/styles.css
@@ -7,23 +7,30 @@ body,
 #root {
   margin: 0;
   min-height: 100%;
+  overflow: hidden;
   font-family: var(--og-font-sans);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background: #f7f7f5;
 }
 
 .northstar {
-  --og-color-accent: oklch(0.56 0.18 288);
-  --og-color-accent-strong: oklch(0.49 0.2 288);
-  --og-color-accent-deep: oklch(0.44 0.2 288);
+  --og-color-accent: oklch(0.58 0.19 288);
+  --og-color-accent-strong: oklch(0.52 0.2 288);
+  --og-color-accent-deep: oklch(0.46 0.2 288);
   --og-color-accent-soft: color-mix(in oklch, var(--og-color-accent) 10%, transparent);
-  --og-color-bg: #f7f7f9;
+  --og-color-bg: #f8f8fb;
   --og-color-surface-1: #ffffff;
-  --og-color-surface-2: #f5f5f8;
-  --og-color-surface-3: #eeeeF3;
+  --og-color-surface-2: #f6f5fa;
+  --og-color-surface-3: #efedf5;
   --og-color-border: rgba(31, 34, 45, 0.08);
   --og-color-border-strong: rgba(31, 34, 45, 0.17);
-  --og-color-fg: #242631;
-  --og-color-fg-muted: #666a75;
-  --og-color-fg-subtle: #9699a3;
+  --og-color-fg: #292735;
+  --og-color-fg-muted: #6c6877;
+  --og-color-fg-subtle: #9a95a5;
 }
 
 .northstar ::selection {
@@ -33,4 +40,24 @@ body,
 .northstar * {
   scrollbar-width: thin;
   scrollbar-color: rgba(45, 48, 60, 0.15) transparent;
+}
+
+.northstar button,
+.northstar select,
+.northstar input,
+.northstar textarea {
+  font: inherit;
+}
+
+.northstar button,
+.northstar select {
+  cursor: pointer;
+}
+
+.northstar button:focus-visible,
+.northstar select:focus-visible,
+.northstar input:focus-visible,
+.northstar textarea:focus-visible {
+  outline: 2px solid color-mix(in oklch, var(--og-color-accent) 65%, white);
+  outline-offset: 2px;
 }

--- a/examples/northstar-support/src/support-agent-panel.tsx
+++ b/examples/northstar-support/src/support-agent-panel.tsx
@@ -8,20 +8,24 @@ import {
   useSession,
   useSessionEvents,
 } from "@opengeni/react";
-import type { DemoHealth } from "./types";
+import type { DemoHealth, SupportCase } from "./types";
 import { createDemoSession } from "./use-support-demo";
 import { supportToolRegistry } from "./support-tool-renderers";
 
-const DEMO_PROMPT =
-  "Investigate TKT-2847 using the support tools. If the evidence warrants it, mark it urgent and investigating, then add an internal note with the evidence and next step.";
+function demoPrompt(supportCase: SupportCase): string {
+  const { ticket, customer } = supportCase;
+  return `Investigate ${ticket.id} for ${customer.name} using the Northstar support tools. Read the ticket and customer signals, decide whether its priority or status should change, apply justified changes, and add an internal note with the evidence and next step.`;
+}
 
 export function SupportAgentPanel({
   health,
+  supportCase,
   sessionId,
   onSessionCreated,
   onClearSession,
 }: {
   health: DemoHealth | null;
+  supportCase: SupportCase;
   sessionId: string | null;
   onSessionCreated: (sessionId: string) => void;
   onClearSession: () => void;
@@ -33,7 +37,7 @@ export function SupportAgentPanel({
     setStarting(true);
     setStartError(null);
     try {
-      const session = await createDemoSession(DEMO_PROMPT);
+      const session = await createDemoSession(supportCase.ticket.id, demoPrompt(supportCase));
       onSessionCreated(session.id);
     } catch (cause) {
       setStartError(cause instanceof Error ? cause : new Error(String(cause)));
@@ -43,17 +47,19 @@ export function SupportAgentPanel({
   }
 
   return (
-    <aside className="flex h-full min-h-0 flex-col border-l border-black/[0.07] bg-white text-og-fg">
-      <header className="flex h-[73px] shrink-0 items-center justify-between gap-4 border-b border-og-border px-5">
+    <aside className="flex h-full min-h-0 flex-col border-l border-[#302a40] bg-white text-og-fg">
+      <header className="flex h-[72px] shrink-0 items-center justify-between gap-4 border-b border-white/10 bg-[#252131] px-5 text-white">
         <div className="flex min-w-0 items-center gap-3">
-          <div className="relative grid size-9 shrink-0 place-items-center rounded-xl bg-[#20222b] text-white shadow-sm">
+          <div className="relative grid size-8 shrink-0 place-items-center rounded-lg bg-[#6759ce] text-white">
             <SparklesIcon className="size-4" />
-            <span className="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border-2 border-white bg-[#47b881]" />
+            <span className="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border-2 border-[#252131] bg-[#54b987]" />
           </div>
           <div className="min-w-0">
-            <h2 className="truncate text-sm font-semibold text-[#242631]">Northstar Copilot</h2>
-            <p className="mt-0.5 truncate text-[11px] text-[#8f929c]">
-              OpenGeni · live product tools
+            <h2 className="truncate text-[14px] font-semibold tracking-[-0.01em] text-white">
+              OpenGeni
+            </h2>
+            <p className="mt-0.5 truncate text-[10px] text-white/55">
+              Live inside Northstar · {supportCase.ticket.id}
             </p>
           </div>
         </div>
@@ -61,7 +67,7 @@ export function SupportAgentPanel({
           <button
             type="button"
             onClick={onClearSession}
-            className="text-[11px] font-medium text-[#8b8e98] transition hover:text-[#3f424c]"
+            className="rounded-xl px-3 py-2 text-[11px] font-semibold text-white/60 transition hover:bg-white/10 hover:text-white"
           >
             New run
           </button>
@@ -73,39 +79,64 @@ export function SupportAgentPanel({
       {sessionId ? (
         <LiveAgentSession sessionId={sessionId} />
       ) : (
-        <div className="flex min-h-0 flex-1 flex-col justify-between overflow-y-auto px-6 py-7">
+        <div className="flex min-h-0 flex-1 flex-col justify-between overflow-y-auto bg-[#f7f7f7] px-7 py-7">
           <div>
-            <div className="inline-flex items-center gap-1.5 rounded-full bg-[#f0efff] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-[#625ed3]">
-              <ShieldCheckIcon className="size-3" /> Live product actions
+            <div className="inline-flex items-center gap-2 text-[11px] font-semibold text-[#5c50bf]">
+              <ShieldCheckIcon className="size-3.5" /> Connected to Northstar
             </div>
-            <h3 className="mt-5 max-w-sm text-[25px] font-semibold leading-[1.15] tracking-[-0.035em] text-[#20222b]">
-              Let the agent investigate inside your product.
+            <h3 className="mt-5 max-w-sm text-[27px] font-semibold leading-[1.12] tracking-[-0.04em] text-[#25222c]">
+              Investigate with OpenGeni
             </h3>
-            <p className="mt-3 max-w-sm text-[13px] leading-6 text-[#717581]">
-              It reads this ticket and customer through MCP, then its actions appear in the product
-              instantly.
+            <p className="mt-3 max-w-sm text-[13px] leading-5 text-[#6d6973]">
+              The agent reads this case, uses Northstar’s tools, and writes each result back here.
             </p>
 
-            <div className="mt-7 space-y-2.5">
-              {[
-                ["1", "Read ticket and customer context"],
-                ["2", "Find the failed-export risk signal"],
-                ["3", "Update priority, status, and internal notes"],
-              ].map(([step, label]) => (
-                <div
-                  key={step}
-                  className="flex items-center gap-3 rounded-xl border border-black/[0.06] bg-[#fafafb] px-3.5 py-3 text-xs text-[#5f626d]"
-                >
-                  <span className="grid size-5 shrink-0 place-items-center rounded-full bg-white text-[10px] font-semibold text-[#6864dc] shadow-sm">
-                    {step}
-                  </span>
-                  {label}
-                </div>
-              ))}
+            <div className="mt-7 overflow-hidden rounded-xl border border-[#dedce5] bg-white">
+              <div className="border-b border-[#e8e7eb] px-4 py-3.5">
+                <p className="text-[11px] font-semibold text-[#514d59]">Available product tools</p>
+                <p className="mt-1 text-[10px] text-[#96929c]">
+                  Four MCP tools, scoped to {supportCase.ticket.id}
+                </p>
+              </div>
+              <div className="divide-y divide-[#ecebee] px-4">
+                {[
+                  ["Read", "Ticket details", "The case, message, tags, status"],
+                  ["Read", "Customer signals", "Plan, usage, health, failures"],
+                  ["Write", "Update the case", "Priority and workflow status"],
+                  ["Write", "Document the work", "Evidence-backed internal notes"],
+                ].map(([access, label, detail]) => (
+                  <div key={label} className="flex items-center gap-3 py-3">
+                    <span
+                      className={
+                        access === "Read"
+                          ? "w-11 text-[9px] font-bold uppercase tracking-[0.08em] text-[#3f8069]"
+                          : "w-11 text-[9px] font-bold uppercase tracking-[0.08em] text-[#6558cd]"
+                      }
+                    >
+                      {access}
+                    </span>
+                    <div className="min-w-0">
+                      <p className="text-[12px] font-semibold text-[#3d3948]">{label}</p>
+                      <p className="mt-0.5 truncate text-[10px] text-[#9994a4]">{detail}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="mt-6 border-t border-[#dedde2] pt-4">
+              <p className="text-[10px] font-medium text-[#918e96]">Investigation sequence</p>
+              <div className="mt-2 flex items-center gap-2 text-[11px] font-medium text-[#5d5963]">
+                <span>Understand</span>
+                <ArrowRightIcon className="size-3 text-[#aaa7ae]" />
+                <span>Reason</span>
+                <ArrowRightIcon className="size-3 text-[#aaa7ae]" />
+                <span>Act</span>
+              </div>
             </div>
           </div>
 
-          <div className="mt-8">
+          <div className="sticky bottom-0 z-10 mt-8 border-t border-[#dedde2] bg-[#f7f7f7] pb-1 pt-4">
             {startError ? (
               <p className="mb-3 rounded-xl bg-[#fff0ed] px-3 py-2 text-xs text-[#b44835]">
                 {startError.message}
@@ -115,20 +146,20 @@ export function SupportAgentPanel({
               type="button"
               onClick={() => void startDemo()}
               disabled={starting || !health?.ok}
-              className="group flex w-full items-center justify-between rounded-[16px] bg-[#252732] px-4 py-3.5 text-left text-sm font-semibold text-white shadow-[0_10px_25px_rgba(36,38,49,0.16)] transition hover:-translate-y-0.5 hover:bg-[#30323e] disabled:cursor-not-allowed disabled:opacity-45"
+              className="group flex w-full items-center justify-between rounded-lg bg-[#5f52c5] px-4 py-3 text-left text-[12px] font-semibold text-white transition hover:bg-[#5448b2] disabled:cursor-not-allowed disabled:opacity-45"
             >
               <span className="flex items-center gap-2.5">
                 {starting ? (
                   <LoaderCircleIcon className="size-4 animate-spin" />
                 ) : (
-                  <SparklesIcon className="size-4 text-[#aaa7ff]" />
+                  <SparklesIcon className="size-4 text-[#d8d4ff]" />
                 )}
-                {starting ? "Starting agent…" : "Run the investigation"}
+                {starting ? "Starting agent…" : "Start agent investigation"}
               </span>
               <ArrowRightIcon className="size-4 transition-transform group-hover:translate-x-0.5" />
             </button>
-            <p className="mt-3 text-center text-[10px] text-[#9da0a9]">
-              OpenGeni session · authenticated product MCP · live product SSE
+            <p className="mt-3.5 text-center text-[10px] text-[#9792a1]">
+              Authenticated session · MCP tools · live product updates
             </p>
           </div>
         </div>
@@ -143,8 +174,8 @@ function McpIndicator({ health }: { health: DemoHealth | null }) {
     <span
       className={
         connected
-          ? "inline-flex items-center gap-1.5 rounded-full bg-[#eef9f4] px-2.5 py-1 text-[10px] font-semibold text-[#2e7a5d]"
-          : "inline-flex items-center gap-1.5 rounded-full bg-[#fff4e5] px-2.5 py-1 text-[10px] font-semibold text-[#94671f]"
+          ? "inline-flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1.5 text-[10px] font-semibold text-[#8de0ba]"
+          : "inline-flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1.5 text-[10px] font-semibold text-[#e8bc75]"
       }
     >
       <span
@@ -159,7 +190,7 @@ function McpIndicator({ health }: { health: DemoHealth | null }) {
 
 function LiveAgentSession({ sessionId }: { sessionId: string }) {
   const { session } = useSession(sessionId, { pollIntervalMs: 4_000 });
-  const { timeline, sessionStatus, connectionState, hasOlder, loadingOlder, loadOlder } =
+  const { timeline, sessionStatus, connectionState, hasOlder, loadingOlder, loadOlder, error } =
     useSessionEvents(sessionId);
   const composer = useComposer(sessionId);
   const status = sessionStatus ?? session?.status ?? null;
@@ -167,7 +198,11 @@ function LiveAgentSession({ sessionId }: { sessionId: string }) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex shrink-0 items-center justify-between border-b border-og-border/70 px-5 py-2.5">
-        <span className="inline-flex items-center gap-1.5 text-[10px] text-og-fg-subtle">
+        <span
+          className="inline-flex items-center gap-1.5 text-[10px] text-og-fg-subtle"
+          data-stream-error={error?.message}
+          title={error?.message}
+        >
           <span
             className={
               connectionState === "live"
@@ -175,7 +210,11 @@ function LiveAgentSession({ sessionId }: { sessionId: string }) {
                 : "size-1.5 rounded-full bg-og-status-waiting"
             }
           />
-          {connectionState === "live" ? "Live session" : connectionState}
+          {connectionState === "live"
+            ? "Live session"
+            : connectionState === "error"
+              ? "Reconnecting timeline"
+              : connectionState}
         </span>
         {status ? <SessionStatus status={status} size="sm" /> : null}
       </div>

--- a/examples/northstar-support/src/support-inbox.tsx
+++ b/examples/northstar-support/src/support-inbox.tsx
@@ -1,0 +1,264 @@
+import { InboxIcon, SearchIcon, SparklesIcon } from "lucide-react";
+import { useDeferredValue, useState } from "react";
+import type { SupportCase, SupportWorkspaceState } from "./types";
+
+type InboxFilter = "mine" | "unassigned";
+
+function relativeTime(value: string): string {
+  const minutes = Math.max(1, Math.round((Date.now() - Date.parse(value)) / 60_000));
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.round(minutes / 60)}h`;
+}
+
+function priorityLabel(priority: SupportCase["ticket"]["priority"]): string {
+  if (priority === "urgent") return "Urgent";
+  if (priority === "high") return "High";
+  return "";
+}
+
+export function SupportInbox({
+  state,
+  selectedTicketId,
+  agentEnabled,
+  onSelectTicket,
+}: {
+  state: SupportWorkspaceState;
+  selectedTicketId: string;
+  agentEnabled: boolean;
+  onSelectTicket: (ticketId: string) => void;
+}) {
+  const [filter, setFilter] = useState<InboxFilter>("mine");
+  const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query.trim().toLowerCase());
+  const mineCount = state.cases.filter(({ ticket }) => ticket.inbox === "mine").length;
+  const unassignedCount = state.cases.filter(({ ticket }) => ticket.inbox === "unassigned").length;
+  const visibleCases = state.cases.filter(({ customer, ticket }) => {
+    if (ticket.inbox !== filter) return false;
+    if (!deferredQuery) return true;
+    return [ticket.id, ticket.subject, customer.name, customer.primaryContact.name].some((value) =>
+      value.toLowerCase().includes(deferredQuery),
+    );
+  });
+
+  function switchFilter(nextFilter: InboxFilter) {
+    setFilter(nextFilter);
+    setQuery("");
+    const selectedCase = state.cases.find(({ ticket }) => ticket.id === selectedTicketId);
+    if (selectedCase?.ticket.inbox === nextFilter) return;
+    const firstCase = state.cases.find(({ ticket }) => ticket.inbox === nextFilter);
+    if (firstCase) onSelectTicket(firstCase.ticket.id);
+  }
+
+  return (
+    <aside className="flex h-dvh min-h-0 flex-col border-r border-[#d9d9d4] bg-[#f1f1ee] text-[#1f2421]">
+      <header className="shrink-0 px-5 pb-4 pt-5">
+        <div className="flex items-center gap-3">
+          <div className="grid size-9 place-items-center rounded-lg bg-[#173f35] text-[13px] font-bold text-white">
+            N
+          </div>
+          <div>
+            <p className="text-[14px] font-bold tracking-[-0.01em]">Northstar</p>
+            <p className="mt-0.5 text-[11px] text-[#77766f]">Customer support</p>
+          </div>
+          <div className="ml-auto flex items-center gap-1.5 text-[10px] font-medium text-[#507166]">
+            <span className="size-1.5 rounded-full bg-[#31926f]" /> Online
+          </div>
+        </div>
+
+        <div className="mt-7 flex items-end justify-between">
+          <div>
+            <p className="text-[11px] font-medium text-[#85857f]">Support queue</p>
+            <h1 className="mt-1 text-[24px] font-semibold tracking-[-0.035em]">Inbox</h1>
+          </div>
+          <div className="mb-0.5 grid size-8 place-items-center text-[#356a59]">
+            <InboxIcon className="size-4" />
+          </div>
+        </div>
+
+        <label className="mt-4 flex h-10 items-center gap-2.5 rounded-lg border border-[#d7d7d2] bg-white px-3 text-[#8a8982] focus-within:border-[#6c9185]">
+          <SearchIcon className="size-4" />
+          <span className="sr-only">Search tickets</span>
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            aria-label="Search tickets"
+            placeholder="Search customers or tickets"
+            className="min-w-0 flex-1 bg-transparent text-[13px] text-[#242b28] outline-none placeholder:text-[#9a9992]"
+          />
+          {query ? (
+            <button
+              type="button"
+              onClick={() => setQuery("")}
+              className="text-[11px] font-semibold text-[#587468]"
+            >
+              Clear
+            </button>
+          ) : null}
+        </label>
+
+        <div className="mt-3 grid grid-cols-2 border-b border-[#d9d9d4]">
+          <InboxFilterButton
+            active={filter === "mine"}
+            label="My inbox"
+            count={mineCount}
+            onClick={() => switchFilter("mine")}
+          />
+          <InboxFilterButton
+            active={filter === "unassigned"}
+            label="Unassigned"
+            count={unassignedCount}
+            onClick={() => switchFilter("unassigned")}
+          />
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-4">
+        <div className="mb-1 mt-1 flex items-center justify-between px-3 text-[10px] font-medium text-[#8d8b84]">
+          <span>{filter === "mine" ? "Assigned to Maya" : "Needs an owner"}</span>
+          <span>{visibleCases.length}</span>
+        </div>
+
+        <div className="space-y-1.5">
+          {visibleCases.map((supportCase) => (
+            <TicketRow
+              key={supportCase.ticket.id}
+              supportCase={supportCase}
+              selected={supportCase.ticket.id === selectedTicketId}
+              agentConnected={agentEnabled && supportCase.ticket.id === selectedTicketId}
+              onClick={() => onSelectTicket(supportCase.ticket.id)}
+            />
+          ))}
+          {visibleCases.length === 0 ? (
+            <div className="rounded-[18px] border border-dashed border-black/15 px-4 py-10 text-center">
+              <SearchIcon className="mx-auto size-5 text-[#96948d]" />
+              <p className="mt-3 text-[13px] font-semibold text-[#5a5b56]">No matching tickets</p>
+              <p className="mt-1 text-[11px] text-[#92918b]">Try another search or inbox.</p>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <footer className="flex shrink-0 items-center gap-3 border-t border-[#d9d9d4] px-5 py-4">
+        <div className="grid size-8 place-items-center rounded-full bg-[#cbbdaa] text-[10px] font-bold text-[#594c3e]">
+          MC
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-[12px] font-semibold">Maya Chen</p>
+          <p className="mt-0.5 text-[10px] text-[#818078]">Support lead</p>
+        </div>
+        <span className="size-2 rounded-full bg-[#31926f]" />
+      </footer>
+    </aside>
+  );
+}
+
+function TicketRow({
+  supportCase,
+  selected,
+  agentConnected,
+  onClick,
+}: {
+  supportCase: SupportCase;
+  selected: boolean;
+  agentConnected: boolean;
+  onClick: () => void;
+}) {
+  const { customer, ticket } = supportCase;
+  const priority = priorityLabel(ticket.priority);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-current={selected ? "page" : undefined}
+      className={
+        selected
+          ? "group relative w-full overflow-hidden rounded-xl border border-[#d5d5d0] bg-white px-3.5 py-3.5 text-left"
+          : "group w-full rounded-xl border border-transparent px-3.5 py-3.5 text-left transition hover:bg-white/60"
+      }
+    >
+      {selected ? <span className="absolute inset-y-3 left-0 w-[3px] bg-[#27715e]" /> : null}
+      <div className="flex items-start gap-3.5">
+        <div
+          className={
+            selected
+              ? "grid size-9 shrink-0 place-items-center rounded-lg bg-[#1d2925] text-[10px] font-bold text-white"
+              : "grid size-9 shrink-0 place-items-center rounded-lg bg-black/[0.055] text-[9px] font-bold text-[#67706a]"
+          }
+        >
+          {customer.initials}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-[#555b57]">
+              {customer.name}
+            </span>
+            {ticket.unread ? <span className="size-2 rounded-full bg-[#d86c4f]" /> : null}
+            <span className="shrink-0 text-[10px] text-[#999992]">
+              {relativeTime(ticket.createdAt)}
+            </span>
+          </div>
+          <p
+            className={
+              selected
+                ? "mt-1.5 line-clamp-2 text-[13px] font-semibold leading-[1.4] tracking-[-0.01em] text-[#202622]"
+                : "mt-1.5 line-clamp-2 text-[13px] leading-[1.4] text-[#666a66]"
+            }
+          >
+            {ticket.subject}
+          </p>
+          <div className="mt-3 flex min-h-5 items-center justify-between gap-2">
+            {priority ? (
+              <span
+                className={
+                  ticket.priority === "urgent"
+                    ? "rounded-full bg-[#ffede6] px-2 py-1 text-[9px] font-bold uppercase tracking-[0.06em] text-[#b74e34]"
+                    : "rounded-full bg-[#fff0d5] px-2 py-1 text-[9px] font-bold uppercase tracking-[0.06em] text-[#93621e]"
+                }
+              >
+                {priority}
+              </span>
+            ) : (
+              <span className="text-[10px] font-medium capitalize text-[#91918b]">
+                {ticket.status.replaceAll("_", " ")}
+              </span>
+            )}
+            {agentConnected ? (
+              <span className="inline-flex items-center gap-1.5 text-[10px] font-bold text-[#6558cc]">
+                <SparklesIcon className="size-3" /> OpenGeni
+              </span>
+            ) : (
+              <span className="text-[10px] text-[#9c9b95]">{ticket.id}</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function InboxFilterButton({
+  active,
+  label,
+  count,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  count: number;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={
+        active
+          ? "border-b-2 border-[#2c725f] px-3 py-2.5 text-[11px] font-semibold text-[#285e4f]"
+          : "border-b-2 border-transparent px-3 py-2.5 text-[11px] font-medium text-[#7d7c76] transition hover:text-[#494c49]"
+      }
+    >
+      {label} <span className="ml-1.5 opacity-55">{count}</span>
+    </button>
+  );
+}

--- a/examples/northstar-support/src/support-ticket.tsx
+++ b/examples/northstar-support/src/support-ticket.tsx
@@ -3,30 +3,38 @@ import {
   Building2Icon,
   CalendarClockIcon,
   CheckCircle2Icon,
+  ChevronDownIcon,
   CircleUserRoundIcon,
-  Clock3Icon,
+  FileTextIcon,
   MailIcon,
-  RotateCcwIcon,
+  MessageSquareTextIcon,
+  SendIcon,
   SparklesIcon,
   TagIcon,
   UsersIcon,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
+import { useState } from "react";
 import type { SupportDemoState, SupportDomainEvent, TicketPriority, TicketStatus } from "./types";
 
-const priorityLabel: Record<TicketPriority, string> = {
-  low: "Low",
-  normal: "Normal",
-  high: "High",
-  urgent: "Urgent",
-};
+const moneyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+const monthYearFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  year: "numeric",
+});
 
-const statusLabel: Record<TicketStatus, string> = {
-  open: "Open",
-  investigating: "Investigating",
-  waiting_on_customer: "Waiting on customer",
-  resolved: "Resolved",
-};
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
 
 function relativeTime(value: string): string {
   const minutes = Math.round((Date.now() - Date.parse(value)) / 60_000);
@@ -37,90 +45,112 @@ function relativeTime(value: string): string {
   return `${Math.round(hours / 24)}d ago`;
 }
 
-function money(value: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  }).format(value);
-}
-
-function Metric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="min-w-0 rounded-2xl border border-black/[0.055] bg-white/80 px-4 py-3 shadow-[0_1px_2px_rgba(31,35,48,0.03)]">
-      <div className="text-[11px] font-medium text-[#8b8f9b]">{label}</div>
-      <div className="mt-1 truncate text-sm font-semibold text-[#242631]">{value}</div>
-    </div>
-  );
+function slaLabel(value: string): string {
+  const minutes = Math.round((Date.parse(value) - Date.now()) / 60_000);
+  if (minutes <= 0) return `Overdue by ${Math.max(1, Math.abs(minutes))}m`;
+  if (minutes < 60) return `Due in ${minutes}m`;
+  return `Due in ${Math.round(minutes / 60)}h`;
 }
 
 export function SupportTicketView({
   state,
   lastEvent,
-  onReset,
+  agentEnabled,
+  onUpdateTicket,
+  onAddNote,
+  onSendReply,
 }: {
   state: SupportDemoState;
   lastEvent: SupportDomainEvent | null;
-  onReset: () => Promise<void>;
+  agentEnabled: boolean;
+  onUpdateTicket: (changes: { priority?: TicketPriority; status?: TicketStatus }) => Promise<void>;
+  onAddNote: (body: string) => Promise<void>;
+  onSendReply: (body: string) => Promise<void>;
 }) {
-  const { ticket, customer } = state;
-  const failureRate = Math.round(
-    (customer.recentUsage.failedExportsLast7Days / customer.recentUsage.exportsLast30Days) * 100,
-  );
+  const { ticket } = state;
+  const [updatingField, setUpdatingField] = useState<"status" | "priority" | null>(null);
+
+  async function updateField(field: "status" | "priority", value: TicketStatus | TicketPriority) {
+    setUpdatingField(field);
+    try {
+      await onUpdateTicket(
+        field === "status"
+          ? { status: value as TicketStatus }
+          : { priority: value as TicketPriority },
+      );
+    } finally {
+      setUpdatingField(null);
+    }
+  }
 
   return (
-    <article className="flex h-full min-h-0 flex-col bg-[#f7f7f9] text-[#242631]">
-      <header className="shrink-0 border-b border-black/[0.06] bg-white px-7 py-5 max-sm:px-4">
-        <div className="flex items-start justify-between gap-5">
+    <article className="flex min-h-0 flex-1 flex-col text-[#252c32]">
+      <header className="shrink-0 border-b border-[#deded9] bg-white px-8 py-5">
+        <div className={agentEnabled ? "space-y-4" : "flex items-start justify-between gap-8"}>
           <div className="min-w-0">
-            <div className="flex items-center gap-2 text-xs font-medium text-[#888c98]">
-              <span>Support</span>
-              <span className="text-[#c4c6cd]">/</span>
+            <div className="flex items-center gap-2 text-[10px] font-medium tracking-[0.06em] text-[#8b8b85]">
               <span>{ticket.id}</span>
+              <span className="text-[#c3c7ca]">·</span>
+              <span>Email</span>
+              <span className="text-[#c3c7ca]">·</span>
+              <span>Opened {relativeTime(ticket.createdAt)}</span>
             </div>
-            <h1 className="mt-2 truncate text-[22px] font-semibold tracking-[-0.025em] text-[#20222b]">
+            <h2 className="mt-2 truncate text-[27px] font-semibold tracking-[-0.04em] text-[#1e2421]">
               {ticket.subject}
-            </h1>
-            <div className="mt-3 flex flex-wrap items-center gap-2">
-              <motion.span
-                key={ticket.status}
-                initial={{ scale: 0.9, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                className="inline-flex items-center gap-1.5 rounded-full bg-[#eef0ff] px-2.5 py-1 text-[11px] font-semibold text-[#5653cf]"
-              >
-                <span className="size-1.5 rounded-full bg-[#6965e8]" />
-                {statusLabel[ticket.status]}
-              </motion.span>
-              <motion.span
-                key={ticket.priority}
-                initial={{ scale: 0.9, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                className={
-                  ticket.priority === "urgent"
-                    ? "rounded-full bg-[#fff0ed] px-2.5 py-1 text-[11px] font-semibold text-[#c34b36]"
-                    : "rounded-full bg-[#f1f2f4] px-2.5 py-1 text-[11px] font-semibold text-[#686c77]"
-                }
-              >
-                {priorityLabel[ticket.priority]} priority
-              </motion.span>
+            </h2>
+            <div
+              className={
+                agentEnabled
+                  ? "mt-2 flex flex-wrap items-center gap-1.5"
+                  : "mt-2.5 flex flex-wrap items-center gap-1.5"
+              }
+            >
               {ticket.tags.map((tag) => (
                 <span
                   key={tag}
-                  className="inline-flex items-center gap-1 rounded-full border border-black/[0.07] bg-white px-2.5 py-1 text-[11px] text-[#737782]"
+                  className="inline-flex items-center gap-1.5 rounded-md bg-[#f2f2ef] px-2 py-1 text-[10px] font-medium text-[#747670]"
                 >
-                  <TagIcon className="size-3" />
+                  <TagIcon className="size-2.5" />
                   {tag}
                 </span>
               ))}
             </div>
           </div>
-          <button
-            type="button"
-            onClick={() => void onReset()}
-            className="inline-flex shrink-0 items-center gap-1.5 rounded-xl border border-black/[0.08] bg-white px-3 py-2 text-xs font-medium text-[#666a75] shadow-sm transition hover:border-black/[0.14] hover:text-[#30323b]"
+
+          <div
+            className={
+              agentEnabled
+                ? "flex shrink-0 items-center gap-2 border-t border-black/[0.07] pt-4"
+                : "flex shrink-0 items-center gap-2"
+            }
           >
-            <RotateCcwIcon className="size-3.5" /> Reset demo
-          </button>
+            <ControlSelect
+              label="Priority"
+              value={ticket.priority}
+              busy={updatingField === "priority"}
+              tone={ticket.priority === "urgent" ? "urgent" : "neutral"}
+              options={[
+                ["low", "Low priority"],
+                ["normal", "Normal priority"],
+                ["high", "High priority"],
+                ["urgent", "Urgent priority"],
+              ]}
+              onChange={(value) => void updateField("priority", value as TicketPriority)}
+            />
+            <ControlSelect
+              label="Status"
+              value={ticket.status}
+              busy={updatingField === "status"}
+              tone="green"
+              options={[
+                ["open", "Open"],
+                ["investigating", "Investigating"],
+                ["waiting_on_customer", "Waiting on customer"],
+                ["resolved", "Resolved"],
+              ]}
+              onChange={(value) => void updateField("status", value as TicketStatus)}
+            />
+          </div>
         </div>
       </header>
 
@@ -129,157 +159,472 @@ export function SupportTicketView({
           {lastEvent ? (
             <motion.div
               key={lastEvent.id}
-              initial={{ opacity: 0, y: -8 }}
+              initial={{ opacity: 0, y: -6 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0 }}
-              className="mx-7 mt-5 flex items-center gap-2 rounded-xl border border-[#cfe9de] bg-[#effaf5] px-3.5 py-2.5 text-xs font-medium text-[#237455] max-sm:mx-4"
+              className="mx-8 mt-5 flex items-center gap-2.5 rounded-lg border border-[#c9dfd5] bg-[#eef6f2] px-4 py-3 text-[12px] font-medium text-[#2e715a]"
               role="status"
             >
-              <CheckCircle2Icon className="size-4" />
-              Live product update · {lastEvent.summary}
+              <CheckCircle2Icon className="size-3.5" />
+              {lastEvent.summary}
             </motion.div>
           ) : null}
         </AnimatePresence>
 
-        <div className="grid gap-5 p-7 max-sm:p-4 xl:grid-cols-[minmax(0,1fr)_280px]">
-          <div className="space-y-5">
-            <section className="overflow-hidden rounded-[20px] border border-black/[0.06] bg-white shadow-[0_1px_3px_rgba(28,31,42,0.04)]">
-              <div className="flex items-center justify-between border-b border-black/[0.055] px-5 py-4">
-                <div className="flex items-center gap-3">
-                  <div className="grid size-9 place-items-center rounded-full bg-[#e9f1ff] text-xs font-bold text-[#486d9e]">
-                    NL
-                  </div>
-                  <div>
-                    <div className="text-sm font-semibold">Nora Lind</div>
-                    <div className="mt-0.5 text-[11px] text-[#9599a3]">
-                      {customer.primaryContact.role} · {relativeTime(ticket.createdAt)}
-                    </div>
-                  </div>
-                </div>
-                <MailIcon className="size-4 text-[#a3a6ae]" />
-              </div>
-              <div className="px-5 py-5 text-[14px] leading-7 text-[#4e515c]">{ticket.body}</div>
-            </section>
+        <ModeBanner agentEnabled={agentEnabled} />
 
-            <section>
-              <div className="mb-3 flex items-center justify-between">
-                <h2 className="text-xs font-semibold uppercase tracking-[0.09em] text-[#858995]">
-                  Internal notes
-                </h2>
-                <span className="text-[11px] text-[#a0a3ac]">{ticket.notes.length} notes</span>
-              </div>
-              <div className="space-y-3">
-                {ticket.notes.map((note) => (
-                  <motion.div
-                    layout
-                    key={note.id}
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    className={
-                      note.authorKind === "agent"
-                        ? "rounded-[18px] border border-[#dcdcff] bg-[#f4f4ff] p-4"
-                        : "rounded-[18px] border border-black/[0.06] bg-white p-4"
-                    }
-                  >
-                    <div className="flex items-center justify-between gap-4">
-                      <div className="flex items-center gap-2 text-xs font-semibold">
-                        {note.authorKind === "agent" ? (
-                          <SparklesIcon className="size-3.5 text-[#6561dc]" />
-                        ) : (
-                          <CircleUserRoundIcon className="size-3.5 text-[#8c909b]" />
-                        )}
-                        {note.author}
-                      </div>
-                      <time className="text-[10px] text-[#9a9da6]">
-                        {relativeTime(note.createdAt)}
-                      </time>
-                    </div>
-                    <p className="mt-2 text-[13px] leading-6 text-[#555965]">{note.body}</p>
-                  </motion.div>
-                ))}
-              </div>
-            </section>
-
-            <section>
-              <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.09em] text-[#858995]">
-                Activity
-              </h2>
-              <div className="space-y-1">
-                {ticket.activity.slice(0, 5).map((item) => (
-                  <div
-                    key={item.id}
-                    className="flex gap-3 rounded-xl px-2 py-2.5 text-xs text-[#696d78]"
-                  >
-                    <ActivityIcon className="mt-0.5 size-3.5 shrink-0 text-[#9da0aa]" />
-                    <p className="min-w-0 flex-1">
-                      <span className="font-semibold text-[#484b55]">{item.actor}</span> ·{" "}
-                      {item.summary}
-                    </p>
-                    <time className="shrink-0 text-[10px] text-[#a0a3ac]">
-                      {relativeTime(item.createdAt)}
-                    </time>
-                  </div>
-                ))}
-              </div>
-            </section>
+        <div
+          className={
+            agentEnabled
+              ? "mx-auto grid w-full max-w-[900px] gap-6 px-8 pb-12"
+              : "mx-auto grid w-full max-w-[1280px] gap-7 px-8 pb-12 xl:grid-cols-[minmax(0,1fr)_340px]"
+          }
+        >
+          <div className="min-w-0 space-y-6">
+            <Conversation state={state} />
+            <ResponseComposer
+              contactName={state.customer.primaryContact.name}
+              subject={state.ticket.subject}
+              onAddNote={onAddNote}
+              onSendReply={onSendReply}
+            />
+            {agentEnabled ? <InternalNotes state={state} /> : null}
           </div>
 
-          <aside className="space-y-4">
-            <section className="rounded-[20px] border border-black/[0.06] bg-white p-5 shadow-[0_1px_3px_rgba(28,31,42,0.04)]">
-              <div className="flex items-center gap-3">
-                <div className="grid size-10 place-items-center rounded-xl bg-[#242631] text-xs font-bold text-white">
-                  {customer.initials}
-                </div>
-                <div className="min-w-0">
-                  <h2 className="truncate text-sm font-semibold">{customer.name}</h2>
-                  <p className="mt-0.5 text-[11px] text-[#92959f]">
-                    {customer.plan} plan · {money(customer.arr)} ARR
-                  </p>
-                </div>
-              </div>
-              <div className="mt-5 grid grid-cols-2 gap-2">
-                <Metric label="Health" value={`${customer.healthScore}/100`} />
-                <Metric
-                  label="Seats"
-                  value={`${customer.recentUsage.activeSeats}/${customer.recentUsage.totalSeats}`}
-                />
-                <Metric label="Exports" value={String(customer.recentUsage.exportsLast30Days)} />
-                <Metric label="Failures" value={`${failureRate}%`} />
-              </div>
-              <div className="mt-4 rounded-xl bg-[#fff7eb] px-3.5 py-3 text-[11px] leading-5 text-[#8a6228]">
-                <span className="font-semibold">Signal:</span> 14 failed exports in 7 days,
-                concentrated around month-end reporting.
-              </div>
-            </section>
-
-            <section className="rounded-[20px] border border-black/[0.06] bg-white p-5">
-              <h2 className="text-xs font-semibold uppercase tracking-[0.09em] text-[#858995]">
-                Details
-              </h2>
-              <dl className="mt-4 space-y-3.5 text-xs">
-                <Detail icon={<UsersIcon />} label="Assignee" value={ticket.assignee} />
-                <Detail icon={<CalendarClockIcon />} label="SLA due" value="Today, 16:42" />
-                <Detail
-                  icon={<Clock3Icon />}
-                  label="Opened"
-                  value={relativeTime(ticket.createdAt)}
-                />
-                <Detail icon={<Building2Icon />} label="Customer since" value="Sep 2024" />
-              </dl>
-            </section>
-          </aside>
+          {agentEnabled ? null : (
+            <aside className="h-fit space-y-0 overflow-hidden rounded-xl border border-[#dfdfda] bg-white [&>section]:rounded-none [&>section]:border-0 [&>section+section]:border-t [&>section+section]:border-[#e4e4df]">
+              <CustomerContext state={state} />
+              <InternalNotes state={state} />
+              <ActivityLog state={state} />
+            </aside>
+          )}
         </div>
       </div>
     </article>
   );
 }
 
+function ModeBanner({ agentEnabled }: { agentEnabled: boolean }) {
+  return (
+    <div
+      className={
+        agentEnabled
+          ? "mx-8 my-5 border-y border-[#d9d5ed] py-3.5 text-[#312d43]"
+          : "mx-8 my-5 border-y border-[#d8dcd9] py-3.5 text-[#29332f]"
+      }
+    >
+      <div className={agentEnabled ? "relative" : "relative flex items-center gap-5"}>
+        <div className={agentEnabled ? "flex items-center gap-3" : "contents"}>
+          <div
+            className={
+              agentEnabled
+                ? "grid size-7 shrink-0 place-items-center text-[#6658cb]"
+                : "grid size-7 shrink-0 place-items-center text-[#4b7666]"
+            }
+          >
+            {agentEnabled ? (
+              <SparklesIcon className="size-5" />
+            ) : (
+              <CircleUserRoundIcon className="size-5" />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-[11px] font-semibold">
+              {agentEnabled ? "Agent-assisted workflow" : "Human-led workflow"}
+            </p>
+            <p className="mt-0.5 text-[11px] text-[#85857f]">
+              {agentEnabled
+                ? "OpenGeni can read and update this case through your product tools."
+                : "Maya reviews the customer context and takes each action manually."}
+            </p>
+          </div>
+        </div>
+        <div
+          className={
+            agentEnabled
+              ? "mt-3 flex items-center gap-2 text-[10px] font-medium text-[#77728d]"
+              : "flex items-center gap-2 text-[10px] font-medium text-[#7f827e]"
+          }
+        >
+          {[
+            agentEnabled ? "Agent reads" : "You read",
+            agentEnabled ? "Agent reasons" : "You decide",
+            agentEnabled ? "Tools act" : "You act",
+          ].map((step, index) => (
+            <div key={step} className="flex items-center gap-2">
+              {index > 0 ? <span className="text-[#b6b6b0]">→</span> : null}
+              <span>{step}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Conversation({ state }: { state: SupportDemoState }) {
+  const { ticket, customer } = state;
+  return (
+    <section className="overflow-hidden rounded-xl border border-[#dfdfda] bg-white">
+      <div className="flex items-center justify-between border-b border-black/[0.07] px-6 py-4.5">
+        <div className="flex items-center gap-2">
+          <MessageSquareTextIcon className="size-3.5 text-[#6f787f]" />
+          <h3 className="text-[13px] font-semibold text-[#343b37]">Conversation</h3>
+        </div>
+        <span className="inline-flex items-center gap-1.5 text-[11px] text-[#94958f]">
+          <MailIcon className="size-3" /> Email thread
+        </span>
+      </div>
+      <div className="p-6">
+        <div className="flex gap-4">
+          <div className="grid size-11 shrink-0 place-items-center rounded-full bg-[#e4edf5] text-[11px] font-bold text-[#4e6a89]">
+            {initials(customer.primaryContact.name)}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-[13px] font-semibold text-[#303733]">
+                  {customer.primaryContact.name}
+                </p>
+                <p className="mt-0.5 text-[11px] text-[#94958f]">{customer.primaryContact.email}</p>
+              </div>
+              <time className="text-[11px] text-[#a09f99]">{relativeTime(ticket.createdAt)}</time>
+            </div>
+            <p className="mt-4 max-w-2xl text-[15px] leading-7 text-[#4e5651]">{ticket.body}</p>
+          </div>
+        </div>
+
+        {ticket.replies.map((reply) => (
+          <motion.div
+            layout
+            key={reply.id}
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mt-6 flex gap-4 border-t border-black/[0.07] pt-6"
+          >
+            <div className="grid size-11 shrink-0 place-items-center rounded-full bg-[#e9e2d8] text-[11px] font-bold text-[#705f4c]">
+              MC
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-[13px] font-semibold text-[#303733]">{reply.author}</p>
+                  <p className="mt-0.5 text-[11px] text-[#94958f]">Northstar support</p>
+                </div>
+                <time className="text-[11px] text-[#a09f99]">{relativeTime(reply.createdAt)}</time>
+              </div>
+              <p className="mt-4 max-w-2xl text-[15px] leading-7 text-[#4e5651]">{reply.body}</p>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ResponseComposer({
+  contactName,
+  subject,
+  onAddNote,
+  onSendReply,
+}: {
+  contactName: string;
+  subject: string;
+  onAddNote: (body: string) => Promise<void>;
+  onSendReply: (body: string) => Promise<void>;
+}) {
+  const [mode, setMode] = useState<"reply" | "note">("reply");
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+
+  const savedReply =
+    mode === "reply"
+      ? `Hi ${contactName.split(" ")[0]} — I’m looking into “${subject}” now. I’ll update you shortly with what we find and the next step.`
+      : `Reviewing “${subject}” alongside the customer’s account signals before taking action.`;
+
+  async function submit() {
+    const body = draft.trim();
+    if (!body || sending) return;
+    setSending(true);
+    try {
+      if (mode === "reply") {
+        await onSendReply(body);
+      } else {
+        await onAddNote(body);
+      }
+      setDraft("");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <section className="overflow-hidden rounded-xl border border-[#dcdcd7] bg-white">
+      <div className="flex items-center justify-between border-b border-black/[0.07] px-5">
+        <div className="flex">
+          <ComposerTab label="Reply" active={mode === "reply"} onClick={() => setMode("reply")} />
+          <ComposerTab
+            label="Internal note"
+            active={mode === "note"}
+            onClick={() => setMode("note")}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => setDraft(savedReply)}
+          className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-[11px] font-semibold text-[#7d7d76] transition hover:bg-black/[0.04] hover:text-[#434a46]"
+        >
+          <FileTextIcon className="size-3" />
+          Use saved template
+        </button>
+      </div>
+      <div className={mode === "note" ? "bg-[#fffaf0] p-5" : "p-5"}>
+        <textarea
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          rows={3}
+          aria-label={mode === "reply" ? "Reply to customer" : "Internal note"}
+          placeholder={
+            mode === "reply"
+              ? `Write a reply to ${contactName.split(" ")[0]}…`
+              : "Add context only your team can see…"
+          }
+          className="w-full resize-none bg-transparent text-[14px] leading-7 text-[#3f4743] outline-none placeholder:text-[#9f9f98]"
+        />
+        <div className="mt-4 flex items-center justify-between border-t border-black/[0.07] pt-4">
+          <p className="text-[11px] text-[#92928b]">
+            {mode === "reply" ? `Sends by email to ${contactName}` : "Visible only to your team"}
+          </p>
+          <button
+            type="button"
+            onClick={() => void submit()}
+            disabled={!draft.trim() || sending}
+            className={
+              mode === "reply"
+                ? "inline-flex items-center gap-2 rounded-[13px] bg-[#236f5c] px-4 py-2.5 text-[12px] font-semibold text-white shadow-sm transition hover:bg-[#1b604f] disabled:cursor-not-allowed disabled:opacity-40"
+                : "inline-flex items-center gap-2 rounded-[13px] bg-[#806a36] px-4 py-2.5 text-[12px] font-semibold text-white shadow-sm transition hover:bg-[#6e5a2d] disabled:cursor-not-allowed disabled:opacity-40"
+            }
+          >
+            <SendIcon className="size-3" />
+            {sending ? "Saving…" : mode === "reply" ? "Send reply" : "Add note"}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ComposerTab({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        active
+          ? "border-b-2 border-[#2d7562] px-3 py-4 text-[12px] font-semibold text-[#2d6657]"
+          : "border-b-2 border-transparent px-3 py-4 text-[12px] font-medium text-[#8d8e87] transition hover:text-[#59605c]"
+      }
+    >
+      {label}
+    </button>
+  );
+}
+
+function CustomerContext({ state }: { state: SupportDemoState }) {
+  const { customer, ticket } = state;
+  const failureRate = Math.round(
+    (customer.recentUsage.failedExportsLast7Days / customer.recentUsage.exportsLast30Days) * 100,
+  );
+  const failedExports = customer.recentUsage.failedExportsLast7Days;
+  return (
+    <section className="rounded-xl border border-[#dfdfda] bg-white p-5">
+      <div className="flex items-center gap-3">
+        <div className="grid size-11 place-items-center rounded-lg bg-[#1d2925] text-[10px] font-bold text-white">
+          {customer.initials}
+        </div>
+        <div className="min-w-0">
+          <h3 className="truncate text-[14px] font-semibold text-[#303733]">{customer.name}</h3>
+          <p className="mt-1 text-[11px] text-[#92928b]">
+            {customer.plan} · {moneyFormatter.format(customer.arr)} ARR
+          </p>
+        </div>
+      </div>
+      <div className="mt-5 grid grid-cols-2 gap-2.5">
+        <Metric label="Health" value={`${customer.healthScore}/100`} />
+        <Metric
+          label="Seats"
+          value={`${customer.recentUsage.activeSeats}/${customer.recentUsage.totalSeats}`}
+        />
+        <Metric label="Exports" value={String(customer.recentUsage.exportsLast30Days)} />
+        <Metric label="Failures" value={`${failureRate}%`} tone="warning" />
+      </div>
+      <div
+        className={
+          failedExports > 5
+            ? "mt-4 border-l-2 border-[#d8a34c] bg-[#fff9ee] px-3.5 py-3 text-[11px] leading-5 text-[#86612d]"
+            : "mt-4 border-l-2 border-[#6a9b87] bg-[#f3f7f5] px-3.5 py-3 text-[11px] leading-5 text-[#467361]"
+        }
+      >
+        <span className="font-semibold">Account signal:</span>{" "}
+        {failedExports > 0
+          ? `${failedExports} failed ${failedExports === 1 ? "export" : "exports"} in the last 7 days across ${customer.recentUsage.exportsLast30Days} monthly exports.`
+          : `No failed exports in the last 7 days across ${customer.recentUsage.exportsLast30Days} monthly exports.`}
+      </div>
+      <dl className="mt-5 space-y-3.5 border-t border-black/[0.07] pt-5">
+        <Detail icon={<UsersIcon />} label="Assignee" value={ticket.assignee} />
+        <Detail icon={<CalendarClockIcon />} label="SLA" value={slaLabel(ticket.slaDueAt)} />
+        <Detail
+          icon={<Building2Icon />}
+          label="Customer since"
+          value={monthYearFormatter.format(new Date(customer.joinedAt))}
+        />
+      </dl>
+    </section>
+  );
+}
+
+function InternalNotes({ state }: { state: SupportDemoState }) {
+  return (
+    <section className="rounded-xl border border-[#dfdfda] bg-white p-5">
+      <div className="flex items-center justify-between">
+        <h3 className="text-[11px] font-bold uppercase tracking-[0.12em] text-[#85877f]">
+          Internal notes
+        </h3>
+        <span className="text-[9px] text-[#a1a7ac]">{state.ticket.notes.length}</span>
+      </div>
+      <div className="mt-3 space-y-3">
+        {state.ticket.notes.map((note) => (
+          <motion.div
+            layout
+            key={note.id}
+            initial={{ opacity: 0, y: 5 }}
+            animate={{ opacity: 1, y: 0 }}
+            className={
+              note.authorKind === "agent"
+                ? "border-l-2 border-[#776bd5] bg-[#f7f6fc] p-3.5"
+                : "border-l-2 border-[#d5d5d0] bg-[#f7f7f5] p-3.5"
+            }
+          >
+            <div className="flex items-center justify-between gap-3">
+              <span className="inline-flex items-center gap-1.5 text-[11px] font-semibold text-[#525954]">
+                {note.authorKind === "agent" ? (
+                  <SparklesIcon className="size-3 text-[#6b5ed3]" />
+                ) : (
+                  <CircleUserRoundIcon className="size-3 text-[#818990]" />
+                )}
+                {note.author}
+              </span>
+              <time className="text-[10px] text-[#a19f99]">{relativeTime(note.createdAt)}</time>
+            </div>
+            <p className="mt-2 text-[12px] leading-5 text-[#626964]">{note.body}</p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ActivityLog({ state }: { state: SupportDemoState }) {
+  return (
+    <section className="rounded-xl border border-[#dfdfda] bg-white p-5">
+      <h3 className="text-[11px] font-bold uppercase tracking-[0.12em] text-[#85877f]">Activity</h3>
+      <div className="mt-3 space-y-1">
+        {state.ticket.activity.slice(0, 4).map((item) => (
+          <div key={item.id} className="flex gap-2.5 py-2.5 text-[11px] text-[#737872]">
+            <ActivityIcon className="mt-0.5 size-3 shrink-0 text-[#a0a6ab]" />
+            <p className="min-w-0 flex-1 leading-4">
+              <span className="font-semibold text-[#515960]">{item.actor}</span> · {item.summary}
+            </p>
+            <time className="shrink-0 text-[9px] text-[#a5aaaf]">
+              {relativeTime(item.createdAt)}
+            </time>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ControlSelect({
+  label,
+  value,
+  busy,
+  tone,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  busy: boolean;
+  tone: "neutral" | "urgent" | "green";
+  options: ReadonlyArray<readonly [string, string]>;
+  onChange: (value: string) => void;
+}) {
+  const toneClass =
+    tone === "urgent"
+      ? "border-[#f0d5cc] bg-[#fff5f1] text-[#a8523b]"
+      : tone === "green"
+        ? "border-[#d5e5df] bg-[#f3f8f6] text-[#346d5d]"
+        : "border-[#e0e4e7] bg-white text-[#5e666d]";
+  return (
+    <label className="relative">
+      <span className="sr-only">{label}</span>
+      <select
+        value={value}
+        disabled={busy}
+        onChange={(event) => onChange(event.target.value)}
+        className={`h-11 appearance-none rounded-[13px] border py-0 pl-3.5 pr-9 text-[11px] font-semibold outline-none transition focus:ring-2 focus:ring-[#6d60d2]/20 ${toneClass}`}
+      >
+        {options.map(([optionValue, optionLabel]) => (
+          <option key={optionValue} value={optionValue}>
+            {optionLabel}
+          </option>
+        ))}
+      </select>
+      <ChevronDownIcon className="pointer-events-none absolute right-2.5 top-1/2 size-3 -translate-y-1/2 opacity-60" />
+    </label>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  tone = "default",
+}: {
+  label: string;
+  value: string;
+  tone?: "default" | "warning";
+}) {
+  return (
+    <div className="border-t border-[#e5e5e1] px-0 py-3">
+      <div className="text-[10px] font-semibold text-[#92928b]">{label}</div>
+      <div
+        className={
+          tone === "warning"
+            ? "mt-1 text-[14px] font-semibold text-[#b0673e]"
+            : "mt-1 text-[14px] font-semibold text-[#3d4540]"
+        }
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
 function Detail({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
   return (
-    <div className="flex items-center gap-3">
-      <span className="text-[#a0a3ac] [&>svg]:size-3.5">{icon}</span>
-      <dt className="min-w-0 flex-1 text-[#888b96]">{label}</dt>
-      <dd className="max-w-[135px] truncate font-medium text-[#4a4d57]">{value}</dd>
+    <div className="flex items-center gap-2.5 text-[11px]">
+      <span className="text-[#9ba2a8] [&>svg]:size-3">{icon}</span>
+      <dt className="min-w-0 flex-1 text-[#8b9298]">{label}</dt>
+      <dd className="max-w-[125px] truncate font-medium text-[#555e65]">{value}</dd>
     </div>
   );
 }

--- a/examples/northstar-support/src/types.ts
+++ b/examples/northstar-support/src/types.ts
@@ -16,6 +16,13 @@ export type SupportActivity = {
   createdAt: string;
 };
 
+export type SupportReply = {
+  id: string;
+  author: string;
+  body: string;
+  createdAt: string;
+};
+
 export type SupportCustomer = {
   id: string;
   name: string;
@@ -50,18 +57,28 @@ export type SupportTicket = {
   slaDueAt: string;
   tags: string[];
   notes: SupportNote[];
+  replies: SupportReply[];
   activity: SupportActivity[];
+  inbox: "mine" | "unassigned";
+  unread: boolean;
 };
 
-export type SupportDemoState = {
-  revision: number;
+export type SupportCase = {
   ticket: SupportTicket;
   customer: SupportCustomer;
 };
 
+export type SupportWorkspaceState = {
+  revision: number;
+  cases: SupportCase[];
+};
+
+export type SupportDemoState = SupportCase & Pick<SupportWorkspaceState, "revision">;
+
 export type SupportDomainEvent = {
   id: string;
-  type: "ticket.updated" | "ticket.note_added" | "demo.reset";
+  type: "ticket.updated" | "ticket.note_added" | "ticket.replied" | "demo.reset";
+  ticketId: string;
   revision: number;
   summary: string;
   occurredAt: string;

--- a/examples/northstar-support/src/use-support-demo.ts
+++ b/examples/northstar-support/src/use-support-demo.ts
@@ -1,18 +1,34 @@
 import { useCallback, useEffect, useState } from "react";
-import type { DemoHealth, SupportDemoState, SupportDomainEvent } from "./types";
+import type {
+  DemoHealth,
+  SupportDomainEvent,
+  SupportWorkspaceState,
+  TicketPriority,
+  TicketStatus,
+} from "./types";
 
 type SupportDemoResult = {
-  state: SupportDemoState | null;
+  state: SupportWorkspaceState | null;
   health: DemoHealth | null;
   loading: boolean;
   error: Error | null;
   lastEvent: SupportDomainEvent | null;
   refresh: () => Promise<void>;
   reset: () => Promise<void>;
+  updateTicket: (
+    ticketId: string,
+    changes: { priority?: TicketPriority; status?: TicketStatus },
+  ) => Promise<void>;
+  addNote: (ticketId: string, body: string) => Promise<void>;
+  sendReply: (ticketId: string, body: string) => Promise<void>;
 };
 
+// Relative URLs work through Vite's local proxy and become same-origin in the
+// production container. No deployment hostname is compiled into the browser.
+const PRODUCT_API_ORIGIN = "";
+
 async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(path, init);
+  const response = await fetch(`${PRODUCT_API_ORIGIN}${path}`, init);
   if (!response.ok) {
     const body = await response.json().catch(() => ({ error: response.statusText }));
     throw new Error(
@@ -23,7 +39,7 @@ async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export function useSupportDemo(): SupportDemoResult {
-  const [state, setState] = useState<SupportDemoState | null>(null);
+  const [state, setState] = useState<SupportWorkspaceState | null>(null);
   const [health, setHealth] = useState<DemoHealth | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -32,7 +48,7 @@ export function useSupportDemo(): SupportDemoResult {
   const refresh = useCallback(async () => {
     try {
       const [nextState, nextHealth] = await Promise.all([
-        fetchJson<SupportDemoState>("/api/demo/state"),
+        fetchJson<SupportWorkspaceState>("/api/demo/state"),
         fetchJson<DemoHealth>("/api/demo/health"),
       ]);
       setState(nextState);
@@ -47,9 +63,9 @@ export function useSupportDemo(): SupportDemoResult {
 
   useEffect(() => {
     void refresh();
-    const events = new EventSource("/api/demo/events");
+    const events = new EventSource(`${PRODUCT_API_ORIGIN}/api/demo/events`);
     const reconcile = window.setInterval(() => {
-      void fetchJson<SupportDemoState>("/api/demo/state")
+      void fetchJson<SupportWorkspaceState>("/api/demo/state")
         .then((nextState) => {
           setState(nextState);
           setError(null);
@@ -69,6 +85,7 @@ export function useSupportDemo(): SupportDemoResult {
     };
     events.addEventListener("ticket.updated", onDomainEvent as EventListener);
     events.addEventListener("ticket.note_added", onDomainEvent as EventListener);
+    events.addEventListener("ticket.replied", onDomainEvent as EventListener);
     events.addEventListener("demo.reset", onDomainEvent as EventListener);
     events.onerror = () => setError(new Error("Product update stream disconnected."));
     return () => {
@@ -78,20 +95,151 @@ export function useSupportDemo(): SupportDemoResult {
   }, [refresh]);
 
   const reset = useCallback(async () => {
-    const next = await fetchJson<SupportDemoState>("/api/demo/reset", {
+    const next = await fetchJson<SupportWorkspaceState>("/api/demo/reset", {
       method: "POST",
     });
     setState(next);
     setLastEvent(null);
   }, []);
 
-  return { state, health, loading, error, lastEvent, refresh, reset };
+  const updateTicket = useCallback(
+    async (ticketId: string, changes: { priority?: TicketPriority; status?: TicketStatus }) => {
+      setState((current) =>
+        current
+          ? {
+              ...current,
+              cases: current.cases.map((supportCase) =>
+                supportCase.ticket.id === ticketId
+                  ? { ...supportCase, ticket: { ...supportCase.ticket, ...changes } }
+                  : supportCase,
+              ),
+            }
+          : current,
+      );
+      const request = fetchJson<SupportWorkspaceState>("/api/demo/ticket", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ticketId, ...changes }),
+      });
+      void request
+        .then((next) => setState(next))
+        .catch((cause: unknown) => {
+          setError(cause instanceof Error ? cause : new Error(String(cause)));
+          void refresh();
+        });
+    },
+    [refresh],
+  );
+
+  const addNote = useCallback(
+    async (ticketId: string, body: string) => {
+      const createdAt = new Date().toISOString();
+      setState((current) =>
+        current
+          ? {
+              ...current,
+              cases: current.cases.map((supportCase) =>
+                supportCase.ticket.id === ticketId
+                  ? {
+                      ...supportCase,
+                      ticket: {
+                        ...supportCase.ticket,
+                        notes: [
+                          {
+                            id: `optimistic-note-${crypto.randomUUID()}`,
+                            author: "Maya Chen",
+                            authorKind: "human",
+                            body,
+                            createdAt,
+                          },
+                          ...supportCase.ticket.notes,
+                        ],
+                      },
+                    }
+                  : supportCase,
+              ),
+            }
+          : current,
+      );
+      const request = fetchJson<SupportWorkspaceState>("/api/demo/notes", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ticketId, body }),
+      });
+      void request
+        .then((next) => setState(next))
+        .catch((cause: unknown) => {
+          setError(cause instanceof Error ? cause : new Error(String(cause)));
+          void refresh();
+        });
+    },
+    [refresh],
+  );
+
+  const sendReply = useCallback(
+    async (ticketId: string, body: string) => {
+      const createdAt = new Date().toISOString();
+      setState((current) =>
+        current
+          ? {
+              ...current,
+              cases: current.cases.map((supportCase) =>
+                supportCase.ticket.id === ticketId
+                  ? {
+                      ...supportCase,
+                      ticket: {
+                        ...supportCase.ticket,
+                        status: "waiting_on_customer",
+                        unread: false,
+                        replies: [
+                          ...supportCase.ticket.replies,
+                          {
+                            id: `optimistic-reply-${crypto.randomUUID()}`,
+                            author: "Maya Chen",
+                            body,
+                            createdAt,
+                          },
+                        ],
+                      },
+                    }
+                  : supportCase,
+              ),
+            }
+          : current,
+      );
+      const request = fetchJson<SupportWorkspaceState>("/api/demo/replies", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ticketId, body }),
+      });
+      void request
+        .then((next) => setState(next))
+        .catch((cause: unknown) => {
+          setError(cause instanceof Error ? cause : new Error(String(cause)));
+          void refresh();
+        });
+    },
+    [refresh],
+  );
+
+  return {
+    state,
+    health,
+    loading,
+    error,
+    lastEvent,
+    refresh,
+    reset,
+    updateTicket,
+    addNote,
+    sendReply,
+  };
 }
 
-export async function createDemoSession(initialMessage: string) {
+export async function createDemoSession(ticketId: string, initialMessage: string) {
   return await fetchJson<{ id: string }>("/api/demo/sessions", {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ initialMessage }),
+    body: JSON.stringify({ ticketId, initialMessage }),
   });
 }


### PR DESCRIPTION
## Summary
- turn Northstar into a functional support SaaS before/after demo
- embed current OpenGeni React timeline and composer
- expose authenticated MCP tools that mutate the same product state
- add a production container target with same-origin UI, API, and MCP

## Verification
- `bun run --cwd examples/northstar-support typecheck`
- `bun run --cwd examples/northstar-support build`
- targeted oxlint and formatting checks
- production-mode static/API smoke on port 4300