### PR TITLE
chore: advance fresh knowledge release identities

### DIFF
--- a/.changeset/fresh-knowledge-identities.md
+++ b/.changeset/fresh-knowledge-identities.md
@@ -1,0 +1,11 @@
+---
+"@opengeni/config": patch
+"@opengeni/contracts": patch
+"@opengeni/github": patch
+"@opengeni/react": patch
+"@opengeni/runtime": patch
+"@opengeni/sdk": patch
+"@opengeni/storage": patch
+---
+
+Advance the reviewed knowledge release package graph to fresh publishable identities after the previous version projection was invalidated. This changes release metadata only and does not alter runtime behavior.

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.31
-appVersion: "0.22.31"
+version: 0.22.32
+appVersion: "0.22.32"


### PR DESCRIPTION
## Summary

- add a fresh patch changeset for the reviewed knowledge package graph
- advance the source-controlled Helm chart and app version from `0.22.31` to `0.22.32`
- change release metadata only; runtime behavior is unchanged

## Projected release manifest

- `@opengeni/api-router` `0.13.4`
- `@opengeni/worker-bundle` `0.12.19`
- `@opengeni/config` `0.7.18`
- `@opengeni/contracts` `0.24.2`
- `@opengeni/core` `0.13.8`
- `@opengeni/db` `0.15.4`
- `@opengeni/documents` `0.2.54`
- `@opengeni/events` `0.3.45`
- `@opengeni/github` `0.4.5`
- `@opengeni/react` `0.30.2`
- `@opengeni/runtime` `0.14.10`
- `@opengeni/sdk` `0.30.2`
- `@opengeni/storage` `0.2.42`
- private `@opengeni/example-northstar-support` `0.0.36`
- chart/appVersion `0.22.32`

## Validation

- frozen install: Bun `1.3.14`, Changesets `2.31.0`, stable TypeScript `7.0.2`
- root `package.json` and `bun.lock` unchanged
- authoritative Changesets status/version projection completed
- targeted release suite: 93 passed, 0 failed across 5 files
- registry occupancy: all 13 npm identities absent; all 5 GHCR image tags and the chart tag absent
- candidate is a one-commit direct child of fenced `main` and changes only the two release-source metadata paths
- forbidden PR head SHAs and the excluded planner commit are not incorporated
