### PR TITLE
fix(api): prefer OAuth well-known metadata

### DIFF
--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -515,9 +515,14 @@ async function discoverAuthorizationServerMetadata(
     "OAuth authorization server",
   ).replace(/\/+$/, "");
   const candidates = uniqueStrings([
-    safeAuthorizationServer,
+    // Prefer the RFC metadata locations before probing the issuer itself. Some
+    // providers (including Linear) redirect their issuer root to a human docs
+    // page; following that redirect can leave discovery waiting on an unrelated
+    // streaming response even though the well-known metadata is immediately
+    // available.
     ...wellKnownCandidates(safeAuthorizationServer, "oauth-authorization-server"),
     ...wellKnownCandidates(safeAuthorizationServer, "openid-configuration"),
+    safeAuthorizationServer,
   ]);
   for (const candidate of candidates) {
     const payload = await fetchJsonObject(candidate, settings).catch((error) => {

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -161,6 +161,7 @@ async function bearer(
 
 type FakeAuthorizationServer = {
   url: string;
+  issuerRootRequests: string[];
   tokenRequests: URLSearchParams[];
   tokenRequestAuthHeaders: Array<string | null>;
   registrations: Record<string, unknown>[];
@@ -184,12 +185,17 @@ function startFakeAuthorizationServer(
   const tokenRequests: URLSearchParams[] = [];
   const tokenRequestAuthHeaders: Array<string | null> = [];
   const registrations: Record<string, unknown>[] = [];
+  const issuerRootRequests: string[] = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
     async fetch(request) {
       const url = new URL(request.url);
       const origin = `http://127.0.0.1:${server.port}`;
+      if (url.pathname === "/") {
+        issuerRootRequests.push(url.toString());
+        return new Response("human documentation", { status: 200 });
+      }
       if (url.pathname === "/.well-known/oauth-protected-resource") {
         return Response.json({
           resource: "urn:test:mcp",
@@ -261,6 +267,7 @@ function startFakeAuthorizationServer(
   });
   return {
     url: `http://127.0.0.1:${server.port}`,
+    issuerRootRequests,
     tokenRequests,
     tokenRequestAuthHeaders,
     registrations,
@@ -664,6 +671,7 @@ describe("connections routes", () => {
       expect(authUrl.searchParams.get("resource")).toBe("urn:test:mcp");
       expect(authUrl.searchParams.get("scope")).toBe("documents:read");
       expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+      expect(as.issuerRootRequests).toEqual([]);
       expect(authUrl.searchParams.has("code_verifier")).toBe(false);
 
       const state = readSignedState(body.state, STATE_SECRET) as Record<string, unknown> | null;
@@ -1195,7 +1203,18 @@ describe("connections routes", () => {
       const responseText = await response.text();
       expect(response.status, responseText).toBe(422);
       expect(responseText).toContain("may not follow redirects");
-      expect(hits).toEqual(["/mcp", "/prm", "/as", "/register"]);
+      expect(hits).toEqual([
+        "/mcp",
+        "/prm",
+        "/.well-known/oauth-authorization-server/as",
+        "/as/.well-known/oauth-authorization-server",
+        "/.well-known/oauth-authorization-server",
+        "/.well-known/openid-configuration/as",
+        "/as/.well-known/openid-configuration",
+        "/.well-known/openid-configuration",
+        "/as",
+        "/register",
+      ]);
       expect(registrations).toEqual([
         {
           method: "POST",


### PR DESCRIPTION
## Problem

Some MCP authorization servers expose valid OAuth metadata at the standard well-known endpoints while redirecting the issuer root to a human documentation page. Linear does this:

- `https://mcp.linear.app` redirects to `https://linear.app/docs/mcp`
- `https://mcp.linear.app/.well-known/oauth-authorization-server` returns valid metadata immediately

OAuth discovery currently probes the issuer root first and follows that redirect. A slow or streaming documentation response can therefore block OAuth startup even though standards-based metadata is available.

## Fix

Try RFC well-known authorization-server/OpenID metadata candidates before falling back to the raw issuer URL.

The fallback remains for providers that serve metadata directly from their issuer root.

## Regression coverage

The fake authorization server now records issuer-root requests. The CIMD OAuth start/callback integration test requires a successful well-known response to complete without probing the human-facing root.

## Validation

- focused `connections-routes` OAuth integration test: passed
- repository typecheck: all 23 projects clean
- `git diff --check`: passed
- live reproduction established that Linear's issuer root redirects to a documentation response that stalls under the pinned transport, while its well-known metadata responds immediately
