### PR TITLE
Polish Northstar agent panel

### DIFF
--- a/.changeset/calm-panels-expand.md
+++ b/.changeset/calm-panels-expand.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/example-northstar-support": patch
+---
+
+Add an expandable embedded-agent panel, a compact host-composed OpenGeni experience, and SDK-native file attachments to the Northstar demo.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -379,9 +379,17 @@ bun run deployment:conformance -- \
 
 The object-storage check performs a browser-style `OPTIONS` preflight before
 the signed `PUT`. Managed and external buckets must allow direct upload CORS
-for the deployed web origin. Prefer exact HTTPS origins in production; use `*`
-only for disposable private evaluation stacks where signed URLs and the
-OpenGeni access key are the real access boundaries.
+from `*` because the OpenGeni browser SDK is designed to run inside arbitrary
+customer products, whose origins are not known to the OpenGeni operator. CORS
+is transport policy, not upload authorization: the API first authenticates the
+workspace request, then returns a short-lived, object-scoped signed URL. The
+storage account/container remains private and browser PUTs carry no storage
+credentials or cookies beyond that signed URL.
+
+For Azure Blob, the blob-service CORS rule must allow origin `*`, method `PUT`
+(plus `GET`, `HEAD`, and `OPTIONS` for the complete file flow), and all request
+and exposed headers. S3/GCS equivalents must express the same wildcard-origin
+contract. Do not add each embedding application to an origin allowlist.
 
 For S3-compatible storage on a split network, keep
 `OPENGENI_OBJECT_STORAGE_ENDPOINT` browser-reachable and set

--- a/examples/northstar-support/README.md
+++ b/examples/northstar-support/README.md
@@ -28,6 +28,11 @@ component source rather than a stale published copy.
 Requirements: Bun, an OpenGeni workspace API key, and a public HTTPS tunnel for
 the MCP endpoint.
 
+The product API key needs `workspace:read`, `sessions:create`, `sessions:read`,
+`sessions:control`, `mcp_servers:attach`, `files:upload`, and `files:read`.
+These are workspace capabilities, not browser-origin registrations; file bytes
+still travel through short-lived signed storage URLs.
+
 ```bash
 cd examples/northstar-support
 cp .env.example .env.local

--- a/examples/northstar-support/src/main.tsx
+++ b/examples/northstar-support/src/main.tsx
@@ -22,6 +22,7 @@ declare global {
 function NorthstarApp() {
   const demo = useSupportDemo();
   const [agentEnabled, setAgentEnabled] = useState(false);
+  const [agentPanelExpanded, setAgentPanelExpanded] = useState(false);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [selectedTicketId, setSelectedTicketId] = useState("TKT-2847");
 
@@ -47,8 +48,10 @@ function NorthstarApp() {
       <div
         className={
           agentEnabled
-            ? "northstar grid h-dvh min-w-[1120px] grid-cols-[260px_minmax(460px,1fr)_420px] overflow-hidden bg-[#f7f7f5]"
-            : "northstar grid h-dvh min-w-[980px] grid-cols-[320px_minmax(0,1fr)] overflow-hidden bg-[#f7f7f5]"
+            ? agentPanelExpanded
+              ? "northstar grid h-dvh min-w-[1120px] grid-cols-[240px_minmax(360px,1fr)_620px] overflow-hidden bg-[#f7f7f5] transition-[grid-template-columns] duration-300 ease-out"
+              : "northstar grid h-dvh min-w-[1120px] grid-cols-[260px_minmax(460px,1fr)_420px] overflow-hidden bg-[#f7f7f5] transition-[grid-template-columns] duration-300 ease-out"
+            : "northstar grid h-dvh min-w-[980px] grid-cols-[320px_minmax(0,1fr)] overflow-hidden bg-[#f7f7f5] transition-[grid-template-columns] duration-300 ease-out"
         }
         data-agent-enabled={agentEnabled}
         data-og-theme="light"
@@ -69,6 +72,7 @@ function NorthstarApp() {
             agentEnabled={agentEnabled}
             onAgentEnabledChange={(enabled) => {
               setAgentEnabled(enabled);
+              if (!enabled) setAgentPanelExpanded(false);
               setSessionId(null);
             }}
             onReset={() => {
@@ -102,6 +106,8 @@ function NorthstarApp() {
                 health={demo.health}
                 supportCase={selectedCase}
                 sessionId={sessionId}
+                expanded={agentPanelExpanded}
+                onExpandedChange={setAgentPanelExpanded}
                 onSessionCreated={setSessionId}
                 onClearSession={() => setSessionId(null)}
               />

--- a/examples/northstar-support/src/styles.css
+++ b/examples/northstar-support/src/styles.css
@@ -61,3 +61,34 @@ body {
   outline: 2px solid color-mix(in oklch, var(--og-color-accent) 65%, white);
   outline-offset: 2px;
 }
+
+/* The embedded agent is deliberately denser than OpenGeni's full-page UI.
+   These are host-owned presentation choices; behavior stays in the SDK. */
+.northstar-agent-timeline > div:first-child {
+  padding: 18px 20px;
+}
+
+.northstar-agent-timeline > div:first-child > div {
+  gap: 14px;
+}
+
+.northstar-agent-copy {
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.northstar-agent-copy p,
+.northstar-agent-copy li {
+  line-height: 1.6;
+}
+
+.northstar-agent-copy p,
+.northstar-agent-copy ul,
+.northstar-agent-copy ol {
+  margin-top: 7px;
+  margin-bottom: 7px;
+}
+
+.northstar-agent-composer textarea:focus-visible {
+  outline: none;
+}

--- a/examples/northstar-support/src/support-agent-panel.tsx
+++ b/examples/northstar-support/src/support-agent-panel.tsx
@@ -1,13 +1,25 @@
-import { ArrowRightIcon, LoaderCircleIcon, ShieldCheckIcon, SparklesIcon } from "lucide-react";
+import {
+  ArrowRightIcon,
+  LoaderCircleIcon,
+  Maximize2Icon,
+  Minimize2Icon,
+  ShieldCheckIcon,
+  SparklesIcon,
+} from "lucide-react";
 import { useState } from "react";
 import {
-  ChatComposer,
+  Markdown,
   MessageTimeline,
   SessionStatus,
   useComposer,
+  useFileAttachments,
   useSession,
   useSessionEvents,
+  type ComposerState,
+  type UseFileAttachmentsResult,
 } from "@opengeni/react";
+import * as Composer from "@opengeni/react/composer";
+import type { EffectiveSessionControl } from "@opengeni/sdk";
 import type { DemoHealth, SupportCase } from "./types";
 import { createDemoSession } from "./use-support-demo";
 import { supportToolRegistry } from "./support-tool-renderers";
@@ -17,16 +29,24 @@ function demoPrompt(supportCase: SupportCase): string {
   return `Investigate ${ticket.id} for ${customer.name} using the Northstar support tools. Read the ticket and customer signals, decide whether its priority or status should change, apply justified changes, and add an internal note with the evidence and next step.`;
 }
 
+function renderNorthstarMessage(text: string) {
+  return <Markdown className="northstar-agent-copy">{text}</Markdown>;
+}
+
 export function SupportAgentPanel({
   health,
   supportCase,
   sessionId,
+  expanded,
+  onExpandedChange,
   onSessionCreated,
   onClearSession,
 }: {
   health: DemoHealth | null;
   supportCase: SupportCase;
   sessionId: string | null;
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
   onSessionCreated: (sessionId: string) => void;
   onClearSession: () => void;
 }) {
@@ -47,7 +67,7 @@ export function SupportAgentPanel({
   }
 
   return (
-    <aside className="flex h-full min-h-0 flex-col border-l border-[#302a40] bg-white text-og-fg">
+    <aside className="northstar-agent-panel flex h-full min-h-0 flex-col border-l border-[#302a40] bg-white text-og-fg">
       <header className="flex h-[72px] shrink-0 items-center justify-between gap-4 border-b border-white/10 bg-[#252131] px-5 text-white">
         <div className="flex min-w-0 items-center gap-3">
           <div className="relative grid size-8 shrink-0 place-items-center rounded-lg bg-[#6759ce] text-white">
@@ -63,21 +83,37 @@ export function SupportAgentPanel({
             </p>
           </div>
         </div>
-        {sessionId ? (
+        <div className="flex shrink-0 items-center gap-1.5">
+          {sessionId ? (
+            <button
+              type="button"
+              onClick={onClearSession}
+              className="rounded-lg px-2.5 py-2 text-[11px] font-semibold text-white/60 transition hover:bg-white/10 hover:text-white"
+            >
+              New run
+            </button>
+          ) : (
+            <McpIndicator health={health} />
+          )}
           <button
             type="button"
-            onClick={onClearSession}
-            className="rounded-xl px-3 py-2 text-[11px] font-semibold text-white/60 transition hover:bg-white/10 hover:text-white"
+            aria-label={expanded ? "Collapse OpenGeni panel" : "Expand OpenGeni panel"}
+            aria-pressed={expanded}
+            title={expanded ? "Collapse panel" : "Expand panel"}
+            onClick={() => onExpandedChange(!expanded)}
+            className="grid size-8 place-items-center rounded-lg text-white/55 transition hover:bg-white/10 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
           >
-            New run
+            {expanded ? (
+              <Minimize2Icon className="size-3.5" />
+            ) : (
+              <Maximize2Icon className="size-3.5" />
+            )}
           </button>
-        ) : (
-          <McpIndicator health={health} />
-        )}
+        </div>
       </header>
 
       {sessionId ? (
-        <LiveAgentSession sessionId={sessionId} />
+        <LiveAgentSession sessionId={sessionId} expanded={expanded} />
       ) : (
         <div className="flex min-h-0 flex-1 flex-col justify-between overflow-y-auto bg-[#f7f7f7] px-7 py-7">
           <div>
@@ -188,11 +224,21 @@ function McpIndicator({ health }: { health: DemoHealth | null }) {
   );
 }
 
-function LiveAgentSession({ sessionId }: { sessionId: string }) {
+function LiveAgentSession({ sessionId, expanded }: { sessionId: string; expanded: boolean }) {
   const { session } = useSession(sessionId, { pollIntervalMs: 4_000 });
   const { timeline, sessionStatus, connectionState, hasOlder, loadingOlder, loadOlder, error } =
     useSessionEvents(sessionId);
-  const composer = useComposer(sessionId);
+  const attachments = useFileAttachments();
+  const composer = useComposer(sessionId, {
+    sendExtras: () => ({ resources: attachments.readyResources }),
+    sendBlocked: () => attachments.hasUnresolved,
+    onSent: (_text, input) =>
+      attachments.removeReadyFiles(
+        (input.resources ?? []).flatMap((resource) =>
+          resource.kind === "file" ? [resource.fileId] : [],
+        ),
+      ),
+  });
   const status = sessionStatus ?? session?.status ?? null;
 
   return (
@@ -226,16 +272,75 @@ function LiveAgentSession({ sessionId }: { sessionId: string }) {
         hasOlder={hasOlder}
         loadingOlder={loadingOlder}
         onLoadOlder={() => void loadOlder()}
-        className="min-h-0 flex-1"
+        renderMessageText={renderNorthstarMessage}
+        className="northstar-agent-timeline min-h-0 flex-1"
       />
 
-      <div className="shrink-0 border-t border-og-border/70 bg-white px-4 pb-4 pt-3">
-        <ChatComposer
+      <div className="shrink-0 border-t border-og-border/70 bg-white px-4 pb-3 pt-3">
+        <NorthstarComposer
           composer={composer}
           effectiveControl={session?.effectiveControl}
-          placeholder="Ask a follow-up…"
+          attachments={attachments}
+          expanded={expanded}
         />
       </div>
     </div>
+  );
+}
+
+function NorthstarComposer({
+  composer,
+  effectiveControl,
+  attachments,
+  expanded,
+}: {
+  composer: ComposerState;
+  effectiveControl: EffectiveSessionControl | null | undefined;
+  attachments: UseFileAttachmentsResult;
+  expanded: boolean;
+}) {
+  const controller = Composer.useChatComposerController({
+    delivery: composer,
+    draft: composer,
+    control: composer,
+    effectiveControl,
+    attachments,
+  });
+
+  return (
+    <Composer.Root controller={controller} className="northstar-agent-composer">
+      <Composer.Frame>
+        <Composer.CommandPalette />
+        <Composer.Surface className="rounded-[11px] border-[#dedce5] shadow-none focus-within:border-[#8b7fe1] focus-within:shadow-[0_0_0_3px_rgba(103,89,206,0.10)]">
+          <Composer.PausedState />
+          <Composer.RestoredResources />
+          <Composer.Attachments />
+          <Composer.Input
+            placeholder="Ask OpenGeni…"
+            className="min-h-[42px] px-3.5 pb-1 pt-2.5 !text-[13px] !leading-5"
+          />
+          {controller.confirmState ? (
+            <Composer.Confirmation />
+          ) : (
+            <Composer.Footer className="items-center px-2.5 pb-2 pt-0.5">
+              <Composer.Controls className="flex-nowrap gap-1">
+                <Composer.AttachButton className="size-7 rounded-lg pointer-coarse:size-10" />
+                <span className="min-w-0 flex-1 truncate px-1 text-[10px] text-og-fg-subtle">
+                  {expanded
+                    ? "Add context · Enter to send · Shift+Enter for a new line"
+                    : "Add context"}
+                </span>
+              </Composer.Controls>
+              <Composer.Actions className="gap-1">
+                <Composer.PauseButton className="size-7 rounded-lg pointer-coarse:size-10" />
+                <Composer.SendButton className="size-7 rounded-lg pointer-coarse:size-10" />
+              </Composer.Actions>
+            </Composer.Footer>
+          )}
+        </Composer.Surface>
+      </Composer.Frame>
+      <Composer.Help />
+      <Composer.Status />
+    </Composer.Root>
   );
 }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -258,6 +258,11 @@ await client.resumeGoal(workspaceId, sessionId); // resets counters, re-arms con
 `uploadFile` wraps the three-step flow (begin → signed PUT → complete) in one
 call; the lower-level steps are exported for resumable/custom flows.
 
+Browser hosts need no storage credentials or per-application registration.
+OpenGeni authorizes the workspace request and returns a short-lived,
+object-scoped signed URL; operators must configure the private object store to
+allow CORS from `*` so any product embedding the SDK can use that URL.
+
 ```ts
 const file = await client.uploadFile(workspaceId, {
   filename: "incident-notes.md",

--- a/scripts/deployment-conformance.ts
+++ b/scripts/deployment-conformance.ts
@@ -266,7 +266,10 @@ if (args.skipStorage) {
     const headers = recordField(upload, "requiredHeaders");
     await preflightObjectPut(
       putUrl,
-      new URL(args.baseUrl).origin,
+      // The browser SDK is embeddable in arbitrary products. Storage CORS must
+      // therefore accept an origin that is unrelated to the OpenGeni web app;
+      // the short-lived signed URL remains the upload authorization boundary.
+      "https://sdk-conformance.invalid",
       Object.keys(headers),
       args.objectConnectTo,
     );
@@ -425,9 +428,9 @@ async function preflightObjectPut(
     );
   }
   const allowedOrigin = response.headers.get("access-control-allow-origin");
-  if (allowedOrigin !== "*" && allowedOrigin !== origin) {
+  if (allowedOrigin !== "*") {
     throw new Error(
-      `browser upload CORS preflight allowed origin ${allowedOrigin ?? "<missing>"}, expected ${origin} or *`,
+      `browser upload CORS preflight allowed origin ${allowedOrigin ?? "<missing>"}, expected * for the embeddable SDK`,
     );
   }
   const allowedMethods = (response.headers.get("access-control-allow-methods") ?? "")


### PR DESCRIPTION
## Summary
- add collapsed and expanded OpenGeni panel layouts
- compose a compact branded footer from public React SDK primitives
- tighten embedded timeline typography through the SDK message renderer
- add SDK-native file attachments with picker, paste/drag-drop, upload chips, and fail-closed sending
- remove the duplicate textarea focus ring while preserving accessible surface focus

## Verification
- `bun x oxlint --deny-warnings examples/northstar-support/src/main.tsx examples/northstar-support/src/support-agent-panel.tsx`
- `bun run --cwd examples/northstar-support typecheck`
- `bun run --cwd examples/northstar-support build`
- local in-app browser: real session/tool stream, 420px/620px layouts, composer focus, real signed file upload
- production Azure Blob CORS now permits app, demo, and local demo origins