### PR TITLE
chore: advance corrective knowledge release identities

### DIFF
--- a/.changeset/fresh-corrective-knowledge-identities.md
+++ b/.changeset/fresh-corrective-knowledge-identities.md
@@ -1,0 +1,11 @@
+---
+"@opengeni/config": patch
+"@opengeni/contracts": patch
+"@opengeni/github": patch
+"@opengeni/react": patch
+"@opengeni/runtime": patch
+"@opengeni/sdk": patch
+"@opengeni/storage": patch
+---
+
+Advance the merged knowledge release train to fresh publication identities without changing runtime behavior. This corrective source is derived from current main and does not reuse generated release output.

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.33
-appVersion: "0.22.33"
+version: 0.22.35
+appVersion: "0.22.35"


### PR DESCRIPTION
## Summary

- add one source-only Changeset covering the merged knowledge train packages
- advance the Helm chart and appVersion from `0.22.33` to `0.22.35`
- derive the correction from current `origin/main` without including generated release output or runtime changes

## Projected identities

- `@opengeni/api-router@0.13.6`
- `@opengeni/worker-bundle@0.12.21`
- `@opengeni/config@0.7.20`
- `@opengeni/contracts@0.24.4`
- `@opengeni/core@0.13.10`
- `@opengeni/db@0.15.6`
- `@opengeni/documents@0.2.56`
- `@opengeni/events@0.3.47`
- `@opengeni/github@0.4.7`
- `@opengeni/react@0.30.3`
- `@opengeni/runtime@0.14.12`
- `@opengeni/sdk@0.30.3`
- `@opengeni/storage@0.2.44`
- private `@opengeni/example-northstar-support@0.0.38`
- Helm chart/appVersion `0.22.35`

## Validation

- current-main provenance and source-only diff gates
- Changesets projection using a fresh temporary index created after versioning
- repository-equivalent typecheck: 23/23 projects
- focused release, provenance, workflow, image, and Helm tests: 134 tests across 15 files
- source lint/format/static guards and generated-font freshness
- projected frozen install, 18-package build and publish closure, dependency rewrites, consumer/runtime/portable-package checks
- deterministic Helm archives and source/archive lint/render equivalence, including the deployment render matrix
- explicit npm `E404` for every projected public identity and explicit GHCR `404 MANIFEST_UNKNOWN` for every projected image
- forbidden ancestry/source/output identities and blocked versions excluded
- safe remote branch/open-PR tree, blob, version, and changed-path collision scan completed with no exact candidate collision