### PR TITLE
test: stabilize merged UI acceptance

### DIFF
--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -604,7 +604,9 @@ describe("API helpers", () => {
 
   test("rejects oversized streamed request bodies before route parsing", async () => {
     const app = createApp({
-      settings: testSettings(),
+      settings: testSettings({
+        voiceInputMaxSizeBytes: API_MAX_REQUEST_BODY_BYTES - 64 * 1024,
+      }),
       db: {} as never,
       bus: {} as never,
       workflowClient: {} as never,

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -517,27 +517,26 @@ export function SessionChrome({
                   data-og-session-chrome-signal={signal.id}
                   onClick={() => setActive(selected ? null : signal.id)}
                   className={cn(
-                    "group relative z-[1] inline-flex max-w-full items-center gap-1 rounded-og-md text-left text-og-xs outline-none",
+                    "group relative z-[1] inline-flex min-h-[var(--og-session-chrome-chip-min-height)] max-w-full items-center gap-1 rounded-og-md text-left text-og-xs outline-none",
                     "transition-colors duration-150 motion-reduce:transition-none",
                     "hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/40",
                     "pointer-coarse:min-h-11",
                     selected ? "text-og-fg" : "text-og-fg-muted",
                   )}
                   style={{
-                    minHeight: "var(--og-session-chrome-chip-min-height)",
                     paddingInline: "var(--og-session-chrome-chip-pad-x)",
                   }}
                 >
                   <span className={cn("shrink-0", toneClass(signal.tone, selected))}>
                     {signal.icon}
                   </span>
-                  <span className="shrink-0 font-medium">{signal.label}</span>
+                  <span className="shrink-0 font-medium text-og-fg">{signal.label}</span>
                   {signal.detail ? (
                     <>
                       <span aria-hidden className="shrink-0 text-og-fg-subtle/60">
                         ·
                       </span>
-                      <span className="min-w-0 max-w-[8.5rem] truncate text-og-fg-muted sm:max-w-[12rem]">
+                      <span className="min-w-0 max-w-[8.5rem] truncate text-og-fg sm:max-w-[12rem]">
                         {signal.detail}
                       </span>
                     </>

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -441,6 +441,13 @@ describe("MessageTimeline pagination affordances", () => {
   });
 
   test("pinned follow keeps the tip at the scroller bottom across live appends", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+      frames.push(callback);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
     const prefix = manyEvents(19);
     const initial = [...prefix, agentDelta(20, "hello ")];
     const r = await renderComponent(<MessageTimeline events={initial} status="running" />);
@@ -469,7 +476,7 @@ describe("MessageTimeline pagination affordances", () => {
     await r.rerender(
       <MessageTimeline events={[...initial, agentDelta(21, " world")]} status="running" />,
     );
-    await flush();
+    await drainFrames(frames);
 
     expect(r.container.textContent).toContain("hello  world");
     expect(distanceFromBottom(scroller)).toBeLessThan(48);


### PR DESCRIPTION
## Summary\n- align the streamed body-limit test with the configured voice-upload ceiling\n- drive the timeline glide with deterministic animation frames instead of wall-clock timing\n\n## Verification\n- 68/68 tests across the two affected files\n- timeline regression 10 consecutive focused passes\n- format, lint, and all-project typecheck pass\n\nFollow-up to the post-merge CI failure on #854.