### PR TITLE
fix(db): preserve forward-only Slack migration order

### DIFF
--- a/.changeset/forward-slack-migration-order.md
+++ b/.changeset/forward-slack-migration-order.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/db": patch
+---
+
+Move the unapplied Slack delete-operation migration after the already-deployed
+sandbox migration history, while accepting only the exact legacy staging
+receipt for an idempotent replay.

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.35
-appVersion: "0.22.35"
+version: 0.22.36
+appVersion: "0.22.36"

--- a/packages/db/drizzle/0146_slack_bot_delete_idempotency.sql
+++ b/packages/db/drizzle/0146_slack_bot_delete_idempotency.sql
@@ -3,8 +3,28 @@
 -- principal, connection, tool, target, and protected request digest before the
 -- mutation; an abandoned provider_started claim becomes outcome_unknown and is
 -- reconciled before another delete is admitted.
+--
+-- This migration originally landed as 0141 after 0142 was already deployed.
+-- Never rewrite that production history. A staging database may have applied
+-- the withdrawn 0141 name before the ordering defect was caught; only that
+-- exact committed legacy receipt may make an existing table idempotent here.
 
-CREATE TABLE "slack_bot_delete_operations" (
+DO $migration$
+BEGIN
+  IF to_regclass('slack_bot_delete_operations') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM "schema_migrations"
+       WHERE "name" = '0141_slack_bot_delete_idempotency.sql'
+     )
+  THEN
+    RAISE EXCEPTION
+      'slack_bot_delete_operations exists without the exact withdrawn 0141 migration receipt';
+  END IF;
+END
+$migration$;
+
+CREATE TABLE IF NOT EXISTS "slack_bot_delete_operations" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   "account_id" uuid NOT NULL REFERENCES "managed_accounts"("id") ON DELETE CASCADE,
   "workspace_id" uuid NOT NULL REFERENCES "workspaces"("id") ON DELETE CASCADE,
@@ -63,11 +83,23 @@ CREATE TABLE "slack_bot_delete_operations" (
     )
 );
 
-CREATE INDEX "slack_bot_delete_operations_workspace_status_idx"
+CREATE INDEX IF NOT EXISTS "slack_bot_delete_operations_workspace_status_idx"
   ON "slack_bot_delete_operations" ("workspace_id", "status", "updated_at");
 
 ALTER TABLE "slack_bot_delete_operations" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "slack_bot_delete_operations" FORCE ROW LEVEL SECURITY;
-CREATE POLICY workspace_isolation ON "slack_bot_delete_operations"
-  USING (opengeni_private.workspace_rls_visible("account_id", "workspace_id"))
-  WITH CHECK (opengeni_private.workspace_rls_visible("account_id", "workspace_id"));
+DO $migration$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policy
+    WHERE polrelid = 'slack_bot_delete_operations'::regclass
+      AND polname = 'workspace_isolation'
+  )
+  THEN
+    CREATE POLICY workspace_isolation ON "slack_bot_delete_operations"
+      USING (opengeni_private.workspace_rls_visible("account_id", "workspace_id"))
+      WITH CHECK (opengeni_private.workspace_rls_visible("account_id", "workspace_id"));
+  END IF;
+END
+$migration$;

--- a/packages/db/test/migration-0146-slack-delete-order.test.ts
+++ b/packages/db/test/migration-0146-slack-delete-order.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { acquireBlankTestDatabase, type BlankTestDatabase } from "@opengeni/testing";
+import postgres from "postgres";
+import { migrate } from "../src/migrate";
+
+const currentMigration = "0146_slack_bot_delete_idempotency.sql";
+const withdrawnMigration = "0141_slack_bot_delete_idempotency.sql";
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+
+let blank: BlankTestDatabase | null = null;
+let available = true;
+
+beforeAll(async () => {
+  blank = await acquireBlankTestDatabase("migration-0146-slack-delete-order");
+  if (!blank) {
+    if (requireRealDatabase) {
+      throw new Error(
+        "[migration-0146-slack-delete-order] OPENGENI_REQUIRE_REAL_DB=1 but the real PostgreSQL harness is unavailable",
+      );
+    }
+    available = false;
+  }
+}, 180_000);
+
+afterAll(async () => {
+  await blank?.release();
+}, 180_000);
+
+describe("migration 0146 (forward-only Slack delete-operation history)", () => {
+  test("creates a fresh schema, rejects unexplained state, and accepts only the exact withdrawn staging receipt", async () => {
+    if (!available || !blank) return;
+
+    await migrate(blank.databaseUrl);
+    const admin = postgres(blank.databaseUrl, { max: 1 });
+    try {
+      const fresh = await admin<
+        {
+          migration_recorded: boolean;
+          table_exists: boolean;
+          index_count: number;
+          policy_count: number;
+        }[]
+      >`
+        select
+          exists(
+            select 1 from schema_migrations where name = ${currentMigration}
+          ) as migration_recorded,
+          to_regclass('slack_bot_delete_operations') is not null as table_exists,
+          (
+            select count(*)::int
+            from pg_class
+            where relname = 'slack_bot_delete_operations_workspace_status_idx'
+              and relkind = 'i'
+          ) as index_count,
+          (
+            select count(*)::int
+            from pg_policy
+            where polrelid = 'slack_bot_delete_operations'::regclass
+              and polname = 'workspace_isolation'
+          ) as policy_count
+      `;
+      expect(fresh[0]).toEqual({
+        migration_recorded: true,
+        table_exists: true,
+        index_count: 1,
+        policy_count: 1,
+      });
+
+      // Recreate the exact state the staging database had after the withdrawn
+      // migration name committed: the complete table is present, but 0146 is
+      // not recorded. Without the historical receipt this must fail closed.
+      await admin`delete from schema_migrations where name = ${currentMigration}`;
+      let unexplainedStateError: unknown;
+      try {
+        await migrate(blank.databaseUrl);
+      } catch (error) {
+        unexplainedStateError = error;
+      }
+      expect(unexplainedStateError).toBeInstanceOf(Error);
+      expect((unexplainedStateError as Error).message).toContain(
+        "exists without the exact withdrawn 0141 migration receipt",
+      );
+
+      await admin`
+        insert into schema_migrations (name)
+        values (${withdrawnMigration})
+        on conflict do nothing
+      `;
+      await migrate(blank.databaseUrl);
+
+      const reconciled = await admin<
+        {
+          current_recorded: boolean;
+          legacy_recorded: boolean;
+          index_count: number;
+          policy_count: number;
+        }[]
+      >`
+        select
+          exists(
+            select 1 from schema_migrations where name = ${currentMigration}
+          ) as current_recorded,
+          exists(
+            select 1 from schema_migrations where name = ${withdrawnMigration}
+          ) as legacy_recorded,
+          (
+            select count(*)::int
+            from pg_class
+            where relname = 'slack_bot_delete_operations_workspace_status_idx'
+              and relkind = 'i'
+          ) as index_count,
+          (
+            select count(*)::int
+            from pg_policy
+            where polrelid = 'slack_bot_delete_operations'::regclass
+              and polname = 'workspace_isolation'
+          ) as policy_count
+      `;
+      expect(reconciled[0]).toEqual({
+        current_recorded: true,
+        legacy_recorded: true,
+        index_count: 1,
+        policy_count: 1,
+      });
+    } finally {
+      await admin.end();
+    }
+  }, 180_000);
+});

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -155,16 +155,16 @@ describe("release schema contract", () => {
         (migrations.has("0138_sandbox_checkpoint_artifacts_and_deadlines.sql") ? 1 : 0) +
         (migrations.has("0139_codex_provider_artifact_invalidations.sql") ? 1 : 0) +
         (migrations.has("0140_sandbox_restore_and_reaper_fences.sql") ? 1 : 0) +
-        (migrations.has("0141_slack_bot_delete_idempotency.sql") ? 1 : 0) +
         (migrations.has("0142_sandbox_archive_capture_gate.sql") ? 1 : 0) +
         (migrations.has("0143_session_codex_compaction_mode.sql") ? 1 : 0) +
         (migrations.has("0144_sandbox_viewer_force_drain_gate.sql") ? 1 : 0) +
-        (migrations.has("0145_model_call_facts.sql") ? 1 : 0),
+        (migrations.has("0145_model_call_facts.sql") ? 1 : 0) +
+        (migrations.has("0146_slack_bot_delete_idempotency.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(
-      "22013ed9478981fc7fd9c97d3beec264198f4e8a82de61f9dbb23960ca8d82a2",
+      "0bc0b4c83d95301f3c29daca63c79d9aebe655292582642a82c1837d8c98ace5",
     );
-    expect(contract.latestMigration).toBe("0145_model_call_facts.sql");
+    expect(contract.latestMigration).toBe("0146_slack_bot_delete_idempotency.sql");
     expect(migrations.get("0128_github_installation_authority.sql")).toMatchObject({
       sha256: "365793b2a204a70e214adb90298b522acbb6dcfae22a46681a58f41a6938e6f0",
       deploymentMode: "rolling",
@@ -240,11 +240,11 @@ describe("release schema contract", () => {
       "0138_sandbox_checkpoint_artifacts_and_deadlines.sql",
       "0139_codex_provider_artifact_invalidations.sql",
       "0140_sandbox_restore_and_reaper_fences.sql",
-      "0141_slack_bot_delete_idempotency.sql",
       "0142_sandbox_archive_capture_gate.sql",
       "0143_session_codex_compaction_mode.sql",
       "0144_sandbox_viewer_force_drain_gate.sql",
       "0145_model_call_facts.sql",
+      "0146_slack_bot_delete_idempotency.sql",
     ]);
     expect(migrations.get("0143_session_codex_compaction_mode.sql")).toMatchObject({
       sha256: "574cfe6fc5ab24135e84d3932fd936e134ebe28bce8ac3cb5db97a549683906f",
@@ -349,10 +349,6 @@ describe("release schema contract", () => {
       sha256: "fe8441b669fd99fa0463378c34dd75ceca3077af7529c85c552a534c530828d8",
       deploymentMode: "rolling",
     });
-    expect(migrations.get("0141_slack_bot_delete_idempotency.sql")).toMatchObject({
-      sha256: "cebd9cde4909e3c6b7f8d11f5b75353d9f0370600acead6e6b31d01c4ebaf847",
-      deploymentMode: "rolling",
-    });
     expect(migrations.get("0142_sandbox_archive_capture_gate.sql")).toMatchObject({
       sha256: "48546fe4f106da0b36edf8a47da56e35b123fd0a63dc9c2eaed887756d35144f",
       deploymentMode: "maintenance",
@@ -363,6 +359,10 @@ describe("release schema contract", () => {
     });
     expect(migrations.get("0145_model_call_facts.sql")).toMatchObject({
       sha256: "93bb3f262f465ca2128b6dadc5e166bfdc78ded610e57a803ce1d3e6a8599dde",
+      deploymentMode: "rolling",
+    });
+    expect(migrations.get("0146_slack_bot_delete_idempotency.sql")).toMatchObject({
+      sha256: "9084b0cd13c1924dd23af09b80d65b58223721259a23b1240e75f5af91b8cfb5",
       deploymentMode: "rolling",
     });
   });


### PR DESCRIPTION
## Summary
- move the unapplied Slack delete idempotency migration from 0141 to forward-only 0146
- reconcile only the exact withdrawn staging receipt while failing closed on unexplained existing state
- add real-PostgreSQL coverage for fresh, invalid, and legacy-staging paths
- reserve chart/app 0.22.36

## Validation
- `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 180000 scripts/release-schema-contract.test.ts packages/db/test/migration-0146-slack-delete-order.test.ts` (6 pass)
- `bun run typecheck` (23/23)
- `bun run lint`
- `bun run format:check`
- `ubs --staged` (0 warnings/errors)
- `git diff --check`

## Production context
The 0.22.35 production child correctly failed before maintenance acquisition or mutation because production already contains 0142 but not the later-merged 0141. This change never rewrites or fabricates production migration history; it appends the feature as 0146.