### PR TITLE
fix(sandbox): reconcile missing drain providers

### DIFF
--- a/.changeset/clean-missing-sandboxes.md
+++ b/.changeset/clean-missing-sandboxes.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/worker-bundle": patch
+---
+
+Reconcile expired draining sandboxes after their exact provider instance has disappeared.

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -232,6 +232,9 @@ export type SandboxLeaseActivityOptions = {
   /** Observe a historical Modal box after its lease row has advanced to a
    * successor identity. Lifecycle-only; a live box remains ambiguous. */
   inspectHistoricalModalSandbox?: HistoricalModalSandboxLifecycleProbeFn;
+  /** Override the read-only exact-instance readiness probe used before the
+   * reaper settles blockers for a provider that has definitively vanished. */
+  probeDrainableProvider?: DrainableProviderProbeFn;
 };
 
 export type RetainedProcessProbeResult =
@@ -263,6 +266,11 @@ export type RetainedProcessProbeFn = (
 
 export type HistoricalModalSandboxLifecycleProbeFn = typeof inspectModalSandboxLifecycle;
 
+export type DrainableProviderProbeFn = (
+  settings: ActivityServices["settings"],
+  lease: LeaseSnapshot,
+) => Promise<"ready" | "missing">;
+
 export const RETAINED_PROCESS_RECONCILIATION_LIMIT = 20;
 export const RETAINED_PROCESS_RECONCILIATION_CLAIM_TTL_MS = 5 * 60_000;
 export const RETAINED_PROCESS_PROVIDER_PROBE_TIMEOUT_MS = 5_000;
@@ -275,6 +283,7 @@ export function createSandboxLeaseActivities(
   const sweepModalOrphans: SweepModalOrphansFn =
     options.sweepModalOrphans ?? sweepModalOrphansForConfiguredBackend;
   const probeRetainedProcess = options.probeRetainedProcess ?? probeRetainedProcessAtProvider;
+  const probeDrainableProvider = options.probeDrainableProvider ?? probeDrainableProviderReadiness;
   /**
    * The one global reaper sweep. Idempotent; concurrency-safe with itself.
    * Gated by the caller (the Schedule is only registered when
@@ -409,6 +418,7 @@ export function createSandboxLeaseActivities(
           row,
           observability,
           terminateBox,
+          probeDrainableProvider,
         );
         if (drainedCold) {
           terminated += 1;
@@ -1387,7 +1397,7 @@ async function sweepModalOrphansForConfiguredBackend(
  * missing provider is returned as typed loss; every ambiguous error preserves
  * the old claim for the next sweep.
  */
-async function probeExpiredArchiveCaptureProvider(
+async function probeDrainableProviderReadiness(
   settings: ActivityServices["settings"],
   lease: LeaseSnapshot,
 ): Promise<"ready" | "missing"> {
@@ -1473,6 +1483,7 @@ async function terminateDrainableBox(
   row: ReapDrainable,
   observability: ActivityServices["observability"],
   terminateBox: TerminateBoxFn,
+  probeDrainableProvider: DrainableProviderProbeFn,
 ): Promise<boolean> {
   // Resolve the account for the RLS-scoped confirmDrainCold (the global sweep
   // returns no account_id; the workspace->account map is the bootstrap read).
@@ -1513,7 +1524,7 @@ async function terminateDrainableBox(
       // stopped. Without an exact resume envelope there is no safe way to prove
       // the attributed provider is command-ready, so preserve the gate.
       if (!lease.resumeState) return false;
-      const providerState = await probeExpiredArchiveCaptureProvider(settings, lease);
+      const providerState = await probeDrainableProvider(settings, lease);
       if (providerState === "missing") {
         providerMissingBeforeCapture = true;
         captureClaim = {
@@ -1550,8 +1561,21 @@ async function terminateDrainableBox(
         captureTimeoutMs,
         minIntervalMs: 0,
       });
-      if (claimed.status !== "claimed") return false;
-      captureClaim = claimed.claim;
+      if (claimed.status === "claimed") {
+        captureClaim = claimed.claim;
+      } else if (claimed.status === "mutation_in_progress") {
+        // An admission is normally authoritative proof that a provider
+        // operation may still be running. It cannot, however, pin a draining
+        // lease forever after the exact provider has disappeared. Probe the
+        // attributed instance without replacement. Only typed NotFound permits
+        // the cold commit to reject the exact stale admissions; a live or
+        // ambiguous provider remains fenced for a later sweep.
+        const providerState = await probeDrainableProvider(settings, lease);
+        if (providerState !== "missing") return false;
+        providerMissingBeforeCapture = true;
+      } else {
+        return false;
+      }
     }
   }
 

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -3653,6 +3653,92 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     expect(created).toBe(1); // still exactly one Schedule.
   });
 
+  test("(5a) a missing exact provider settles stale mutation blockers and drains cold", async () => {
+    if (!available) return;
+
+    const ws = await freshWorkspace();
+    const attempt = await freshWarmSnapshotAttempt(ws);
+    ws.groupId = attempt.sandboxGroupId;
+    const leaseId = await insertLease(ws, {
+      liveness: "warm",
+      refcount: 1,
+      turnHolders: 1,
+      leaseEpoch: 15,
+      expiresInMs: 60_000,
+      instanceId: "sb-missing-with-stale-admission",
+      backend: "modal",
+      resumeBackendId: "modal",
+      resumeState: {
+        backendId: "modal",
+        sessionState: {
+          providerState: { sandboxId: "sb-missing-with-stale-admission" },
+        },
+      },
+    });
+    await insertHolder(ws, leaseId, "turn", attempt.holderId, 0, attempt.sessionId);
+    const admission = await advanceWorkspaceGeneration(db, {
+      accountId: ws.accountId,
+      workspaceId: ws.workspaceId,
+      ...attempt,
+      sandboxGroupId: ws.groupId,
+      expectedEpoch: 15,
+      expectedInstanceId: "sb-missing-with-stale-admission",
+      operation: "providerOperationLostWithInstance",
+    });
+
+    // Model a worker/provider loss after admission: the holder is gone, the
+    // lease has passed its drain deadline, but the provider outcome is unknown.
+    await admin`
+      delete from sandbox_lease_holders
+      where lease_id = ${leaseId}
+        and kind = 'turn'
+        and holder_id = ${attempt.holderId}`;
+    await admin`
+      update sandbox_leases set
+        liveness = 'draining',
+        refcount = 0,
+        turn_holders = 0,
+        expires_at = now() - interval '1 second'
+      where id = ${leaseId}`;
+
+    let probes = 0;
+    let terminations = 0;
+    const { reapSandboxLeases } = createSandboxLeaseActivities(reaperServices(), {
+      probeDrainableProvider: async (_settings, lease) => {
+        probes += 1;
+        expect(lease.id).toBe(leaseId);
+        expect(lease.instanceId).toBe("sb-missing-with-stale-admission");
+        return "missing";
+      },
+      terminateBox: async () => {
+        terminations += 1;
+        throw new Error("A definitively missing provider must not be terminated again");
+      },
+    });
+    const result = await reapSandboxLeases();
+
+    expect(probes).toBe(1);
+    expect(terminations).toBe(0);
+    expect(result.terminated).toBeGreaterThanOrEqual(1);
+    const lease = await readLease(db, ws.workspaceId, ws.groupId);
+    expect(lease).toMatchObject({
+      liveness: "cold",
+      instanceId: null,
+      recovery: {
+        provider: {
+          status: "missing",
+          instanceId: "sb-missing-with-stale-admission",
+        },
+      },
+    });
+    const [settled] = await admin<{ provider_outcome: string | null; settled_at: Date | null }[]>`
+      select provider_outcome, settled_at
+      from sandbox_workspace_mutation_admissions
+      where id = ${admission.id}`;
+    expect(settled?.provider_outcome).toBe("rejected");
+    expect(settled?.settled_at).not.toBeNull();
+  }, 60_000);
+
   // ── FINDING 1: even a test/legacy no-archive termination seam must remain
   // epoch/refcount fenced. Production cloud teardown now refuses to delete a
   // resumable box without a verified capture; this lower-level test preserves

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -25096,6 +25096,38 @@ export async function confirmDrainCold(
         // -> resume_state is nulled as before. The archive then rides the COLD lease's
         // resume_state until the next spawner reads + hydrates it; it is re-superseded
         // (GC'd) on the next drain and finally cleared on workspace teardown.
+        const observedRows = await tx.execute<LeaseRow>(sql`
+          select * from sandbox_leases
+          where workspace_id = ${input.workspaceId}
+            and sandbox_group_id = ${input.sandboxGroupId}
+        `);
+        const observed = observedRows[0];
+        if (
+          !observed ||
+          observed.liveness !== "draining" ||
+          observed.refcount !== 0 ||
+          Number(observed.lease_epoch) !== input.expectedEpoch
+        ) {
+          return { wentCold: false };
+        }
+        const blockerScope =
+          input.providerMissingBeforeCapture && observed.instance_id
+            ? {
+                accountId: input.accountId,
+                workspaceId: input.workspaceId,
+                leaseId: observed.id,
+                sandboxGroupId: input.sandboxGroupId,
+                lostEpoch: input.expectedEpoch,
+                lostInstanceId: observed.instance_id,
+              }
+            : null;
+        // Provider loss settles process/admission/PTY rows before taking the
+        // lease lock, matching the canonical blocker -> lease lock order used
+        // by retained-process settlement. Revalidate the lease after locking
+        // the entire exact provider-owned blocker set.
+        if (blockerScope) {
+          await lockExactLostProviderWorkspaceBlockersTx(tx, blockerScope);
+        }
         const locked = await tx.execute<LeaseRow>(sql`
           select * from sandbox_leases
           where workspace_id = ${input.workspaceId}
@@ -25105,11 +25137,16 @@ export async function confirmDrainCold(
         const row = locked[0];
         if (
           !row ||
+          row.id !== observed.id ||
           row.liveness !== "draining" ||
           row.refcount !== 0 ||
-          Number(row.lease_epoch) !== input.expectedEpoch
+          Number(row.lease_epoch) !== input.expectedEpoch ||
+          (blockerScope && row.instance_id !== blockerScope.lostInstanceId)
         ) {
           return { wentCold: false };
+        }
+        if (blockerScope) {
+          await settleExactLostProviderWorkspaceBlockersTx(tx, blockerScope);
         }
         const current = recoveryStateFromLeaseRow(row);
         const hasArchive = current.archive.status !== "none";


### PR DESCRIPTION
## Summary
- probe an exact draining provider when stale mutation admissions block capture
- settle only exact provider-scoped blockers after definitive NotFound
- preserve the fence for live or ambiguous providers

## Validation
- `OPENGENI_REQUIRE_REAL_DB=1 bun test apps/worker/test/sandbox-lease.test.ts packages/db/test/sandbox-leases.test.ts` (72 pass, 624 assertions)
- `bun run typecheck` (23 projects clean)
- `git diff --check`