### PR TITLE
chore: reserve chart 0.22.37

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.36
-appVersion: "0.22.36"
+version: 0.22.37
+appVersion: "0.22.37"


### PR DESCRIPTION
Reserve chart/app 0.22.37 for the sandbox provider-loss reconciliation release.

Validation:
- `helm lint deploy/helm/opengeni`
- `bun test scripts/release-schema-contract.test.ts`