### PR TITLE
fix(sandbox): isolate turn-end workspace capture

### DIFF
--- a/.changeset/clean-modal-capture-handles.md
+++ b/.changeset/clean-modal-capture-handles.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Reopen turn-end workspace capture through an exact-instance, non-owning sandbox read handle and allow a production-realistic capture deadline.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -301,7 +301,7 @@ import {
   prepareRecordingForSettlement,
   type ActiveRecording,
 } from "./recording";
-import { captureWorkspaceRevision } from "./workspace-capture";
+import { captureWorkspaceRevision, openFreshWorkspaceCaptureSession } from "./workspace-capture";
 import type { ChannelASession } from "@opengeni/runtime/sandbox";
 import { createObjectStorage, type ObjectStorage } from "@opengeni/storage";
 import {
@@ -2538,6 +2538,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // the atomic DB throttle discard the fresher one). Interval throttling
     // itself lives in maybePersistWarmWorkspaceSnapshot / persistWarmSnapshot.
     let snapshotInFlight: Promise<void> | null = null;
+    // Turn-end capture needs the lease heartbeat to keep its holder alive, but
+    // must prevent that same timer from starting another periodic snapshot
+    // while it reads. This gate separates those two responsibilities.
+    let turnEndCaptureInProgress = false;
     // Computer-use-only recording. Ordinary shell/filesystem turns leave this
     // null; the first actual computer action starts it after :0 is ready.
     let activeRecording: ActiveRecording | null = null;
@@ -2781,7 +2785,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // single-flight; throttling lives in the helper.
         const snapshotSession = setupBoxSession;
         const snapshotTurnId = turnId;
-        if (snapshotSession && snapshotTurnId && !snapshotInFlight) {
+        if (snapshotSession && snapshotTurnId && !snapshotInFlight && !turnEndCaptureInProgress) {
           snapshotInFlight = maybePersistWarmWorkspaceSnapshot(
             { db, settings },
             {
@@ -8077,7 +8081,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // gives capture the full live-box margin instead of racing the teardown
         // tail, which was dropping 100% of captures on real Modal desktop boxes
         // ("request cancelled due to container exiting", 0 rows). External module:
-        // self-capped at 60s, best-effort (never throws past its boundary),
+        // self-capped at 120s, best-effort (never throws past its boundary),
         // epoch-fenced, and it NEVER closes the box. The emitted
         // workspace.revision.captured event is ANNOUNCE-ONLY (metadata, never
         // content).
@@ -8097,13 +8101,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           setupBoxSession &&
           sandboxGroupId
         ) {
-          // Stop new heartbeat snapshot/meter ticks so a mid-turn snapshot cannot
-          // start concurrently with capture, then drain any in-flight snapshot
-          // (bounded) — capture and the warm snapshot both exec on the box, so
-          // sequence them, exactly as the turn-end snapshot placement did.
-          if (leaseHeartbeatTimer) {
-            stopLeaseHeartbeat();
-          }
+          // Block new periodic snapshots, then drain any one already in flight.
+          // Keep the lease heartbeat itself running: capture may legitimately
+          // exceed the 90s holder TTL, and the reaper must remain unable to drain
+          // the exact box while this holder still reads it.
+          turnEndCaptureInProgress = true;
           if (snapshotInFlight) {
             await waitForWarmSnapshot(
               snapshotInFlight,
@@ -8111,6 +8113,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               finalizerSignal,
             );
           }
+          const captureEstablished = resolvedSandbox.established;
           await captureWorkspaceRevision({
             db,
             objectStorage,
@@ -8119,6 +8122,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               await publishDurableSessionEvents(bus, input.workspaceId, input.sessionId, events);
             },
             session: setupBoxSession as ChannelASession,
+            openReadSession: async () =>
+              await openFreshWorkspaceCaptureSession({
+                backendId: captureEstablished.backendId,
+                client: captureEstablished.client,
+                session: setupBoxSession as ChannelASession,
+                expectedInstanceId: captureEstablished.instanceId,
+              }),
             leaseEpoch: resolvedSandbox.leaseEpoch,
             sandboxGroupId,
             accountId: input.accountId,

--- a/apps/worker/src/activities/workspace-capture.ts
+++ b/apps/worker/src/activities/workspace-capture.ts
@@ -14,7 +14,7 @@
 //   • This module NEVER calls close()/terminate()/kill() on the session handle.
 //     session.close() == terminate() on Modal and would kill the user's box.
 //     Only the reaper terminates. We drop references, nothing more.
-//   • The whole capture is time-capped (60s) and best-effort: ANY failure logs
+//   • The whole capture is time-capped (120s) and best-effort: ANY failure logs
 //     "workspace capture failed — turn outcome unaffected" and returns; nothing
 //     throws past captureWorkspaceRevision.
 //   • The DB write is fenced on the exact attempt, accepted control requests,
@@ -62,7 +62,12 @@ import type {
 } from "@opengeni/contracts";
 
 // ─── Guards & constants for pathological cases; configurable ─────
-export const CAPTURE_TIMEOUT_MS = 60_000;
+// Production Modal captures of the acceptance workspace normally take ~30s:
+// repository diff framing deliberately trades provider round-trips for bounded
+// output and symlink-safe reads. Sixty seconds gave that healthy path only a 2x
+// margin and repeatedly timed it out under ordinary provider variance. The turn
+// holder keeps the exact lease pinned for this whole window.
+export const CAPTURE_TIMEOUT_MS = 120_000;
 export const PER_FILE_CONTENT_GUARD_BYTES = 5 * 1024 * 1024; // after-image; over → tooLarge marker
 export const PER_FILE_DIFF_GUARD_BYTES = 10 * 1024 * 1024; // per-file diff; over → truncated marker
 export const WHOLE_CAPTURE_GUARD_BYTES = 200 * 1024 * 1024; // total → skip, fall back to live
@@ -185,6 +190,14 @@ export type CaptureWorkspaceRevisionInput = {
   publish: CaptureEventPublisher | null;
   /** The un-proxied setupBoxSession (NOT the routing veneer). */
   session: ChannelASession;
+  /**
+   * Reopen the exact live provider instance as a fresh, non-owning read handle.
+   * Modal sessions keep mutable exec-process bookkeeping; reusing the handle
+   * that just drove model tools can strand a later capture command behind stale
+   * provider state. The lease still owns the box. Capture drops this handle
+   * without calling close(), which would terminate Modal's sandbox.
+   */
+  openReadSession?: () => Promise<ChannelASession>;
   leaseEpoch: number;
   sandboxGroupId: string;
   accountId: string;
@@ -210,6 +223,68 @@ type CaptureRepositoryReadResult =
       diff: Awaited<ReturnType<SandboxChannelAService["gitDiff"]>>;
     }
   | { complete: false; degradedReason: "repository_read_unavailable" };
+
+type ResumableCaptureClient = {
+  resume?: (state: unknown) => Promise<unknown>;
+};
+
+type StatefulCaptureSession = ChannelASession & {
+  state?: unknown;
+};
+
+function captureSessionInstanceId(session: unknown): string | null {
+  const state =
+    session && typeof session === "object"
+      ? (session as { state?: Record<string, unknown> }).state
+      : undefined;
+  if (!state || typeof state !== "object") return null;
+  for (const value of [
+    state.sandboxId,
+    state.instanceId,
+    state.id,
+    state.hostId,
+    state.containerId,
+    state.workspaceRootPath,
+  ]) {
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return null;
+}
+
+/**
+ * Reattach a clean SDK handle to the exact already-live Modal sandbox. Modal's
+ * resume contract is a pure from-id reattach. Other providers keep the original
+ * session because their generic resume contract may restore or replace a dead
+ * instance, which capture does not own.
+ */
+export async function openFreshWorkspaceCaptureSession(input: {
+  backendId: string;
+  client: unknown;
+  session: ChannelASession;
+  expectedInstanceId: string;
+}): Promise<ChannelASession> {
+  if (input.backendId !== "modal") {
+    return input.session;
+  }
+  const client = input.client as ResumableCaptureClient;
+  const state = (input.session as StatefulCaptureSession).state;
+  if (typeof client.resume !== "function" || state === undefined) {
+    return input.session;
+  }
+  // The lease—not this temporary reader—owns provider teardown. Preserve the
+  // exact state while explicitly removing close/terminate authority from
+  // providers (Modal) that encode it in the resumed state.
+  const readState =
+    state !== null && typeof state === "object" ? { ...state, ownsSandbox: false } : state;
+  const reopened = await client.resume(readState);
+  const actualInstanceId = captureSessionInstanceId(reopened);
+  if (input.expectedInstanceId.length > 0 && actualInstanceId !== input.expectedInstanceId) {
+    throw new Error(
+      `workspace capture reopened provider instance ${actualInstanceId ?? "unknown"}, expected ${input.expectedInstanceId}`,
+    );
+  }
+  return reopened as ChannelASession;
+}
 
 /** One discovered repository is all-or-nothing capture authority. A provider
  * transport failure must never be represented as an authoritative empty diff. */
@@ -250,7 +325,7 @@ let loggedStorageNullOnce = false;
 
 /**
  * Turn-end entrypoint. Gates on the flag + configured object storage, races the
- * whole capture against a 60s cap, and swallows every failure ("turn outcome
+ * whole capture against a 120s cap, and swallows every failure ("turn outcome
  * unaffected"). Returns void — the caller awaits it (it self-caps) and moves on
  * to release() regardless.
  */
@@ -258,6 +333,7 @@ export async function captureWorkspaceRevision(
   input: CaptureWorkspaceRevisionInput,
 ): Promise<void> {
   const { observability } = input;
+  const stage = { value: "preflight" };
   if (input.signal?.aborted) {
     observability.incrementCounter({
       name: "opengeni_workspace_capture_total",
@@ -305,6 +381,7 @@ export async function captureWorkspaceRevision(
     { ...input, objectStorage: input.objectStorage },
     startedAt,
     controller.signal,
+    stage,
   ).finally(() => {
     observability.incrementGauge({
       name: "opengeni_workspace_captures_inflight",
@@ -339,6 +416,7 @@ export async function captureWorkspaceRevision(
       "opengeni.turn_id": input.turnId ?? "",
       "error.message": error instanceof Error ? error.message : String(error),
       "workspace_capture.duration_ms": Date.now() - startedAt,
+      "workspace_capture.stage": stage.value,
     });
     observability.incrementCounter({
       name: "opengeni_workspace_capture_total",
@@ -357,22 +435,28 @@ async function runCapture(
   ctx: CaptureWorkspaceRevisionInput & { objectStorage: ObjectStorage },
   startedAt: number,
   signal: AbortSignal,
+  stage: { value: string },
 ): Promise<void> {
   const { observability } = input;
   const storage = ctx.objectStorage;
   const keepN = input.keepLatest ?? KEEP_LATEST_REVISIONS;
+  stage.value = "open_read_session";
+  const readSession = input.openReadSession ? await input.openReadSession() : input.session;
+  throwIfCaptureAborted(signal);
   // Reads only — no emitter (we publish the announce ourselves after commit).
-  const svc = new SandboxChannelAService({ session: input.session, leaseEpoch: input.leaseEpoch });
+  const svc = new SandboxChannelAService({ session: readSession, leaseEpoch: input.leaseEpoch });
 
   // Resolve the previous revision before discovery so even a failed discovery
   // can commit a monotonic, explicit degraded marker. That marker becomes the
   // newest read result and prevents an older successful capture from being
   // mistaken for the current turn's authoritative workspace state.
+  stage.value = "load_previous_capture";
   const prev = await latestWorkspaceCapture(input.db, input.workspaceId, input.sessionId);
   throwIfCaptureAborted(signal);
   const revision = (prev?.revision ?? -1) + 1;
 
   // ── 1. per-repo status + diff, union the touched set ──────────────────────
+  stage.value = "repository_discovery";
   const discovery = await svc.detectReposDetailed();
   throwIfCaptureAborted(signal);
   if (process.env.OPENGENI_TEST_SCENARIO === "sandbox") {
@@ -400,6 +484,7 @@ async function runCapture(
   let deletions = 0;
 
   for (const root of repoRoots) {
+    stage.value = "repository_read";
     throwIfCaptureAborted(signal);
     // Repository discovery defines the authoritative set. Once a root is in
     // that set, status/diff failure must degrade the entire revision rather than
@@ -475,6 +560,7 @@ async function runCapture(
   let binaryCount = 0;
 
   for (const [wsPath, info] of touched) {
+    stage.value = "file_read";
     throwIfCaptureAborted(signal);
     if (info.deleted) {
       files.push({
@@ -580,6 +666,7 @@ async function runCapture(
   }
 
   // ── 5. tree index (one bounded listing; residue dirs pruned at source) ─────
+  stage.value = "tree_index";
   const tree = await buildTreeIndex(svc, startedAt, signal);
   throwIfCaptureAborted(signal);
 
@@ -602,6 +689,7 @@ async function runCapture(
   let refreshedFiles = 0;
   const omittedFiles = new Set<string>();
   for (const file of files) {
+    stage.value = "content_upload";
     throwIfCaptureAborted(signal);
     if (file.deleted || file.tooLarge || !file.contentRef || !file.hash) {
       continue;
@@ -730,10 +818,12 @@ async function runCapture(
       entryCount: tree.entryCount,
     }),
   );
+  stage.value = "tree_upload";
   await storage.putObject({ key: treeKey, contentType: "application/json", body: treeBytes });
   throwIfCaptureAborted(signal);
   stats.durationMs = Date.now() - startedAt;
   const manifestBytes = utf8(JSON.stringify(manifest));
+  stage.value = "manifest_upload";
   await storage.putObject({
     key: manifestKey,
     contentType: "application/json",
@@ -743,6 +833,7 @@ async function runCapture(
   const sizeBytes = totalBytes + treeBytes.byteLength + manifestBytes.byteLength;
 
   // ── 8. epoch-fenced insert (superseded lease → zero rows) ─────────────────
+  stage.value = "database_commit";
   const inserted = await insertWorkspaceCapture(input.db, {
     accountId: input.accountId,
     workspaceId: input.workspaceId,

--- a/apps/worker/test/workspace-capture.test.ts
+++ b/apps/worker/test/workspace-capture.test.ts
@@ -27,6 +27,7 @@ import {
   isUnderResidueDir,
   joinRepoPath,
   KEEP_LATEST_REVISIONS,
+  openFreshWorkspaceCaptureSession,
   PER_FILE_CONTENT_GUARD_BYTES,
   PER_FILE_DIFF_GUARD_BYTES,
   readCaptureRepository,
@@ -519,6 +520,77 @@ describe("workspace-capture — pre-service skip gates", () => {
         session: throwingSession,
       }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("workspace-capture — fresh provider read handle", () => {
+  test("resumes the same instance with the current exact provider state", async () => {
+    const state = { sandboxId: "sb-exact" };
+    const original = { state } as unknown as ChannelASession;
+    const reopened = { state: { sandboxId: "sb-exact" } } as unknown as ChannelASession;
+    let receivedState: unknown;
+    const selected = await openFreshWorkspaceCaptureSession({
+      backendId: "modal",
+      client: {
+        resume: async (value: unknown) => {
+          receivedState = value;
+          return reopened;
+        },
+      },
+      session: original,
+      expectedInstanceId: "sb-exact",
+    });
+    expect(receivedState).toEqual({ sandboxId: "sb-exact", ownsSandbox: false });
+    expect(receivedState).not.toBe(state);
+    expect(selected).toBe(reopened);
+  });
+
+  test("fails closed when resume returns a different provider instance", async () => {
+    const original = {
+      state: { sandboxId: "sb-expected" },
+    } as unknown as ChannelASession;
+    await expect(
+      openFreshWorkspaceCaptureSession({
+        backendId: "modal",
+        client: {
+          resume: async () => ({ state: { sandboxId: "sb-rival" } }),
+        },
+        session: original,
+        expectedInstanceId: "sb-expected",
+      }),
+    ).rejects.toThrow(
+      "workspace capture reopened provider instance sb-rival, expected sb-expected",
+    );
+  });
+
+  test("uses the existing handle when its provider cannot resume", async () => {
+    const original = {} as ChannelASession;
+    await expect(
+      openFreshWorkspaceCaptureSession({
+        backendId: "modal",
+        client: {},
+        session: original,
+        expectedInstanceId: "selfhosted-agent",
+      }),
+    ).resolves.toBe(original);
+  });
+
+  test("never invokes a non-Modal provider's potentially mutating resume contract", async () => {
+    const original = { state: { containerId: "container-exact" } } as unknown as ChannelASession;
+    let resumeCalled = false;
+    const selected = await openFreshWorkspaceCaptureSession({
+      backendId: "docker",
+      client: {
+        resume: async () => {
+          resumeCalled = true;
+          return { state: { containerId: "container-replacement" } };
+        },
+      },
+      session: original,
+      expectedInstanceId: "container-exact",
+    });
+    expect(selected).toBe(original);
+    expect(resumeCalled).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Problem

Production workbench acceptance on both 0.22.36 and 0.22.37 completed the real Modal turn and durable filesystem snapshot, but produced no `workspace_captures` row. The worker timed out after 60 seconds while the inner provider operation remained resident. Exact snapshot replay proves the workspace, restore, repository discovery, Git status/diff, file reads, tree, and Azure storage are healthy; the full capture finishes in about 29 seconds through a clean provider handle.

The turn-end capture reused the mutable Modal SDK session object that had just driven model tools. That handle retains exec-process bookkeeping and is the only material difference at the failure boundary. The 60-second budget also provided only a 2x margin over the production-real acceptance fixture.

## Fix

- Reopen the exact live sandbox ID as a fresh read-only/non-owning provider handle before capture.
- Fail closed if the resumed handle does not prove the same provider instance.
- Keep the turn lease heartbeat alive while blocking periodic snapshots during capture, so the 90-second holder TTL cannot expire under the new 120-second capture budget.
- Extend the bounded capture budget to 120 seconds and report the exact failing stage.
- Never close or terminate the fresh handle; the durable lease remains the sole owner.

## Evidence

- Production snapshot replay: 4 repositories, full acceptance diff/content/tree capture in ~29.5s.
- Focused worker tests: 152/152 pass.
- Workspace-capture unit tests: 26/26 pass.
- Repository typecheck: 23/23 projects clean.
- Worker typecheck, formatting, and diff hygiene clean.
- The local docker/API integration suite was attempted but its required local API was not running (`127.0.0.1:8000` connection refused); this is preserved as unavailable rather than reported green.
- UBS pre-commit scan was triaged against changed hunks; reported findings were pre-existing whole-file heuristics, with no changed-hunk defect found.