### PR TITLE
chore: reserve chart 0.22.38

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.37
-appVersion: "0.22.37"
+version: 0.22.38
+appVersion: "0.22.38"


### PR DESCRIPTION
Reserves Helm chart/app version 0.22.38 for the merged sandbox workspace-capture fix in main commit `472b4d1e69c3913f2f2dbb9c1067dd1eddd5caa2`.