### PR TITLE
fix(react): smooth timeline tip-follow and streaming motion

### DIFF
--- a/.changeset/smooth-tip-follow-timeline.md
+++ b/.changeset/smooth-tip-follow-timeline.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Smooth tip-follow camera and streaming timeline motion (settle folds, tool enter, fence soft-close).

--- a/packages/react/src/components/copy-button.tsx
+++ b/packages/react/src/components/copy-button.tsx
@@ -2,7 +2,7 @@ import { CheckIcon, CopyIcon } from "lucide-react";
 import { useEffect, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import { cn } from "../lib/cn";
 import { copyTextToClipboard } from "../lib/clipboard";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 
 const COPIED_MS = 1600;
 
@@ -61,36 +61,34 @@ export function CopyButton({
   const tip = copied ? "Copied" : label;
 
   return (
-    <TooltipProvider delayDuration={400}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            data-og-copy=""
-            data-state={copied ? "copied" : "idle"}
-            aria-label={tip}
-            onClick={onClick}
-            className={cn(
-              "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
-              "text-og-fg-subtle transition-[opacity,color,background-color] duration-150",
-              "hover:bg-og-surface-2/80 hover:text-og-fg",
-              "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent/40",
-              reveal === "group-hover" &&
-                "opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 pointer-coarse:opacity-70",
-              copied && "opacity-100 text-og-accent",
-              className,
-            )}
-          >
-            {copied ? (
-              <CheckIcon className="size-3.5" aria-hidden />
-            ) : (
-              <CopyIcon className="size-3.5" aria-hidden />
-            )}
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="top">{tip}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          data-og-copy=""
+          data-state={copied ? "copied" : "idle"}
+          aria-label={tip}
+          onClick={onClick}
+          className={cn(
+            "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
+            "text-og-fg-subtle transition-[opacity,color,background-color] duration-150",
+            "hover:bg-og-surface-2/80 hover:text-og-fg",
+            "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent/40",
+            reveal === "group-hover" &&
+              "opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 pointer-coarse:opacity-70",
+            copied && "opacity-100 text-og-accent",
+            className,
+          )}
+        >
+          {copied ? (
+            <CheckIcon className="size-3.5" aria-hidden />
+          ) : (
+            <CopyIcon className="size-3.5" aria-hidden />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">{tip}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/packages/react/src/components/markdown.tsx
+++ b/packages/react/src/components/markdown.tsx
@@ -17,6 +17,7 @@ import { prefersReducedMotion } from "../lib/motion";
 import { CopyButton } from "./copy-button";
 import { softenStreamingMarkdown } from "./soften-streaming-markdown";
 import { createStreamReveal, rehypeStreamReveal, type StreamReveal } from "./stream-reveal";
+import { TooltipProvider } from "./tooltip";
 
 /**
  * The default renderer for chat message bodies in {@link MessageTimeline}.
@@ -365,25 +366,27 @@ function MarkdownImpl({ children, className, streaming = false }: MarkdownProps)
   // Reveal identity still tracks the true source (`children`).
   const parseText = streaming || revealActive ? softenStreamingMarkdown(children) : children;
 
+  // `min-w-0` lets the prose shrink inside flex parents (message bubbles) so
+  // long links and code blocks wrap/scroll instead of forcing overflow.
   return (
-    // `min-w-0` lets the prose shrink inside flex parents (message bubbles) so
-    // long links and code blocks wrap/scroll instead of forcing overflow.
-    <div
-      ref={bodyRef}
-      className={cn(
-        "og-markdown-body min-w-0 break-words",
-        settling && "og-markdown-settle",
-        className,
-      )}
-    >
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        rehypePlugins={rehypePlugins}
-        components={components}
+    <TooltipProvider delayDuration={400}>
+      <div
+        ref={bodyRef}
+        className={cn(
+          "og-markdown-body min-w-0 break-words",
+          settling && "og-markdown-settle",
+          className,
+        )}
       >
-        {parseText}
-      </ReactMarkdown>
-    </div>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          rehypePlugins={rehypePlugins}
+          components={components}
+        >
+          {parseText}
+        </ReactMarkdown>
+      </div>
+    </TooltipProvider>
   );
 }
 

--- a/packages/react/src/components/markdown.tsx
+++ b/packages/react/src/components/markdown.tsx
@@ -14,6 +14,7 @@ import remarkGfm from "remark-gfm";
 import { cn } from "../lib/cn";
 import { tableElementToTsv } from "../lib/clipboard";
 import { prefersReducedMotion } from "../lib/motion";
+import { MOTION_INSPECT_SCALE } from "../lib/motion-inspect";
 import { CopyButton } from "./copy-button";
 import { softenStreamingMarkdown } from "./soften-streaming-markdown";
 import { createStreamReveal, rehypeStreamReveal, type StreamReveal } from "./stream-reveal";
@@ -156,13 +157,13 @@ const components: Components = {
   // the `pre` renderer), so a `code` reaching here is treated as inline.
   code: ({ children, className: _className, ...props }) => (
     <code
-      className="rounded-og-xs border border-og-border bg-og-surface-1 px-1 py-0.5 font-og-mono text-og-sm text-og-fg"
+      className="rounded-og-xs bg-og-surface-1 px-1 py-0.5 font-og-mono text-og-sm text-og-fg"
       {...props}
     >
       {children}
     </code>
   ),
-  // Fenced code — bordered mono block with language chip + copy.
+  // Fenced code — quiet mono block (no card / no nested vertical scroll).
   pre: ({ children }) => <MarkdownCodeBlock>{children}</MarkdownCodeBlock>,
   // Tables stay unboxed (hairline rules); hover reveals a TSV copy control.
   table: ({ children, ...props }) => <MarkdownTable {...props}>{children}</MarkdownTable>,
@@ -193,9 +194,10 @@ const components: Components = {
 };
 
 /** How long after the stream ends the reveal pipeline stays for trailing animations. */
-const REVEAL_LINGER_MS = 900;
+/** Trailing ink window after stream end — keep ≥ {@link INK_FADE_MS}. */
+const REVEAL_LINGER_MS = 480 * MOTION_INSPECT_SCALE;
 /** Keep in sync with `--og-duration-markdown-crystallize` / view-transition CSS. */
-const MARKDOWN_SETTLE_MS = 480;
+const MARKDOWN_SETTLE_MS = 480 * MOTION_INSPECT_SCALE;
 
 function nodeText(node: ReactNode): string {
   if (node == null || typeof node === "boolean") {
@@ -230,9 +232,12 @@ function fenceLanguage(children: ReactNode): string | null {
 function MarkdownCodeBlock({ children }: { children?: ReactNode }) {
   const code = nodeText(children).replace(/\n$/, "");
   const language = fenceLanguage(children);
+  // mt-only (no mb / last:mb-0): next sibling streaming in used to flip a
+  // previous block's bottom margin on and yank tip-follow. Copy is overlay-only.
+  // Fixed leading + overflow-x:auto with stable block chrome so wide ASCII lines
+  // don't pop a scrollbar gutters mid-stream (another tip bob).
   return (
-    <div className="group/copy relative my-3 first:mt-0 last:mb-0">
-      {/* Overlay only — no reserved header row / extra vertical space. */}
+    <div className="group/copy relative mt-3 first:mt-0">
       <div className="pointer-events-none absolute top-1.5 right-1.5 z-10 flex items-center gap-1">
         {language ? (
           <span className="rounded px-1 py-0.5 font-og-mono text-[10px] uppercase tracking-wide text-og-fg-subtle/80 opacity-0 transition-opacity group-hover/copy:opacity-100 pointer-coarse:opacity-70">
@@ -243,7 +248,7 @@ function MarkdownCodeBlock({ children }: { children?: ReactNode }) {
           <CopyButton text={code} label="Copy code" reveal="group-hover" />
         </div>
       </div>
-      <pre className="max-h-96 overflow-auto rounded-og-md border border-og-border bg-og-bg/60 p-3 font-og-mono text-og-sm text-og-fg-muted [&>code]:border-0 [&>code]:bg-transparent [&>code]:p-0 [&>code]:text-inherit">
+      <pre className="overflow-x-auto overflow-y-hidden rounded-og-md bg-og-surface-1/70 px-3 py-2.5 font-og-mono text-og-sm leading-5 text-og-fg-muted [scrollbar-gutter:stable] [&>code]:block [&>code]:border-0 [&>code]:bg-transparent [&>code]:p-0 [&>code]:leading-5 [&>code]:text-inherit">
         {children}
       </pre>
     </div>
@@ -253,7 +258,7 @@ function MarkdownCodeBlock({ children }: { children?: ReactNode }) {
 function MarkdownTable({ children, className, ...props }: ComponentPropsWithoutRef<"table">) {
   const tableRef = useRef<HTMLTableElement | null>(null);
   return (
-    <div className="group/copy relative my-3 max-w-full first:mt-0 last:mb-0">
+    <div className="group/copy relative mt-3 max-w-full first:mt-0">
       <div className="pointer-events-none absolute top-0 right-0 z-10">
         <div className="pointer-events-auto">
           <CopyButton

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -486,10 +486,7 @@ export function MessageTimeline({
       // alive so when collapse ends (or stream resumes) we ease instead of a
       // hard stop → flick. Do NOT tip-ease on the same frame as a real shrink
       // (that fight was the top-of-viewport flicker).
-      if (
-        previousHeight > 0 &&
-        node.scrollHeight < previousHeight - TIP_FOLLOW_SHRINK_EPS_PX
-      ) {
+      if (previousHeight > 0 && node.scrollHeight < previousHeight - TIP_FOLLOW_SHRINK_EPS_PX) {
         const nextTop = tipFollowCompensateShrink(
           lastScrollTopRef.current,
           previousHeight,
@@ -653,8 +650,7 @@ export function MessageTimeline({
       }
     }
     groupKeyByItemIdRef.current = nextKeyByItemId;
-    const needOffsets =
-      prepended || firstItemChanged || !pinnedRef.current || Boolean(hasNewer);
+    const needOffsets = prepended || firstItemChanged || !pinnedRef.current || Boolean(hasNewer);
     if (needOffsets) {
       const nextOffsetByKey = new Map<string, number>();
       for (const { key } of groups) {
@@ -873,11 +869,7 @@ export function MessageTimeline({
       syncScrollBaseline(node);
       const nearBottomPinned = isNearBottom(node);
       // Pointer-dragged scroll-up away from tip. Layout churn never arms this.
-      if (
-        readerArmed &&
-        readerUp > TIP_FOLLOW_READER_UP_EPS_PX &&
-        !nearBottomPinned
-      ) {
+      if (readerArmed && readerUp > TIP_FOLLOW_READER_UP_EPS_PX && !nearBottomPinned) {
         readerIntentArmRef.current = false;
         releasePinFromReader(node);
         if (olderLoadGateRef.current === "cooling" && node.scrollTop > OLDER_PREFETCH_MARGIN_PX) {
@@ -933,242 +925,246 @@ export function MessageTimeline({
   return (
     <LightboxProvider>
       <FoldMemoryProvider value={foldMemoryRef.current}>
-      <SeenActivityIdsProvider value={seenActivityIdsRef.current}>
-      <EntranceAnimationProvider value={!bulkRender}>
-        <TooltipProvider delayDuration={400}>
-        <div className={cn("og-root relative flex min-h-0 flex-col", className)}>
-          {/* Pinned: anchoring off so the tip-follow camera owns the motion.
+        <SeenActivityIdsProvider value={seenActivityIdsRef.current}>
+          <EntranceAnimationProvider value={!bulkRender}>
+            <TooltipProvider delayDuration={400}>
+              <div className={cn("og-root relative flex min-h-0 flex-col", className)}>
+                {/* Pinned: anchoring off so the tip-follow camera owns the motion.
           Unpinned: native scroll anchoring holds the reader's place. */}
-          <div
-            ref={scrollRef}
-            tabIndex={-1}
-            onScroll={onScroll}
-            onWheel={onWheel}
-            onPointerDown={onPointerDown}
-            onKeyDown={onKeyDown}
-            style={groups.length > 0 && !revealed ? { visibility: "hidden" } : undefined}
-            className={cn(
-              // tabIndex=-1 is programmatic only — never paint a focus ring on
-              // the whole scroller (click + Shift used to flash a blue outline).
-              "min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-6 sm:px-6 outline-none",
-              autoFollow && pinned && !hasNewer
-                ? "[overflow-anchor:none]"
-                : "[overflow-anchor:auto]",
-            )}
-          >
-            <div className="relative mx-auto flex w-full max-w-3xl flex-col gap-5">
-              {groups.length === 0
-                ? (emptyState ?? (
-                    <p className="py-10 text-center text-sm text-og-fg-subtle">No activity yet.</p>
-                  ))
-                : null}
-              {hasOlder && olderPrefetchArmed ? (
-                // Overlaid, not a layout row: mounting/unmounting the sentinel
-                // must never shift content (that shift was itself a wobble).
                 <div
-                  ref={topSentinelRef}
-                  data-og-top-sentinel=""
-                  data-og-timeline-chrome=""
-                  aria-hidden="true"
-                  className="pointer-events-none absolute inset-x-0 top-0 h-px"
-                />
-              ) : null}
-              {groups.map(({ group, key }, index) => {
-                const next = groups[index + 1]?.group;
-                const contextCompactionCount =
-                  group.kind === "turn"
-                    ? (group.contextCompactionCount ?? 0)
-                    : group.kind === "activity" &&
-                        next?.kind === "item" &&
-                        next.item.kind === "context-compaction" &&
-                        next.item.phase === "compacted"
-                      ? 1
-                      : 0;
-                return (
-                  <div key={key} data-og-timeline-group-anchor="" data-og-group-key={key}>
-                    <TimelineGroupView
-                      group={group}
-                      renderMessageText={renderMessageText}
-                      onOpenSession={onOpenSession}
-                      onMemoryClick={onMemoryClick}
-                      onReconnect={onReconnect}
-                      resolveProviderLogo={resolveProviderLogo}
-                      toolRegistry={toolRegistry}
-                      turnSummary={turnSummary}
-                      foldLiveCluster={isAgentProgress(next)}
-                      trailingAgentText={trailingAgentTextAfterTurn(group, next)}
-                      contextCompactionCount={
-                        contextCompactionCount > 0 ? contextCompactionCount : undefined
-                      }
-                    />
-                  </div>
-                );
-              })}
-              {hasNewer ? (
-                <div
-                  ref={bottomSentinelRef}
-                  data-og-bottom-sentinel=""
-                  data-og-timeline-chrome=""
-                  aria-hidden="true"
-                  className="h-px w-full"
-                />
-              ) : null}
-            </div>
-          </div>
-          <AnimatePresence>
-            {loadingOlder || loadingOldest || (hasOlder && onJumpToStart && olderPrefetchArmed) ? (
-              // Floating over the scroller (not a timeline row) so showing and
-              // hiding it never reflows history under the reader.
-              <motion.div
-                initial={{ opacity: 0, y: -6 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -6 }}
-                transition={{ duration: 0.15, ease: "easeOut" }}
-                data-og-loading-older=""
-                aria-live="polite"
-                className="absolute inset-x-0 top-3 z-10 flex justify-center gap-2"
-              >
-                {loadingOlder || loadingOldest ? (
-                  <span className="pointer-events-none inline-flex items-center rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1 text-xs font-medium shadow-og-md backdrop-blur">
-                    <span className="og-shimmer-text">
-                      {loadingOldest ? "Jumping to start…" : "Loading earlier activity…"}
-                    </span>
-                  </span>
-                ) : null}
-                {hasOlder && onJumpToStart && !loadingOldest ? (
-                  <button
-                    type="button"
-                    data-og-jump-to-start=""
-                    disabled={loadingOlder}
-                    onClick={() => {
-                      applyPinned(false);
-                      pendingJumpToStartRef.current = true;
-                      const seq = ++jumpToStartSeqRef.current;
-                      const node = scrollRef.current;
-                      void Promise.resolve(onJumpToStart()).then(
-                        () => {
-                          // The commit that swaps in the oldest window consumes
-                          // the flag against the new DOM; this write covers the
-                          // already-committed order and the no-window-change
-                          // case (jumping within the current window).
-                          const scroller = scrollRef.current ?? node;
-                          if (scroller) {
-                            scroller.scrollTop = 0;
-                          }
-                          // A host may resolve without ever changing the
-                          // window (already on the oldest page). Any swap
-                          // commit runs its layout effect before the next
-                          // frame, so a flag still armed by then is the
-                          // no-change case — clear it, or a LATER prepend
-                          // would spuriously jump the reader to the top.
-                          requestFrame(() => {
-                            if (jumpToStartSeqRef.current === seq) {
-                              pendingJumpToStartRef.current = false;
+                  ref={scrollRef}
+                  tabIndex={-1}
+                  onScroll={onScroll}
+                  onWheel={onWheel}
+                  onPointerDown={onPointerDown}
+                  onKeyDown={onKeyDown}
+                  style={groups.length > 0 && !revealed ? { visibility: "hidden" } : undefined}
+                  className={cn(
+                    // tabIndex=-1 is programmatic only — never paint a focus ring on
+                    // the whole scroller (click + Shift used to flash a blue outline).
+                    "min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-6 sm:px-6 outline-none",
+                    autoFollow && pinned && !hasNewer
+                      ? "[overflow-anchor:none]"
+                      : "[overflow-anchor:auto]",
+                  )}
+                >
+                  <div className="relative mx-auto flex w-full max-w-3xl flex-col gap-5">
+                    {groups.length === 0
+                      ? (emptyState ?? (
+                          <p className="py-10 text-center text-sm text-og-fg-subtle">
+                            No activity yet.
+                          </p>
+                        ))
+                      : null}
+                    {hasOlder && olderPrefetchArmed ? (
+                      // Overlaid, not a layout row: mounting/unmounting the sentinel
+                      // must never shift content (that shift was itself a wobble).
+                      <div
+                        ref={topSentinelRef}
+                        data-og-top-sentinel=""
+                        data-og-timeline-chrome=""
+                        aria-hidden="true"
+                        className="pointer-events-none absolute inset-x-0 top-0 h-px"
+                      />
+                    ) : null}
+                    {groups.map(({ group, key }, index) => {
+                      const next = groups[index + 1]?.group;
+                      const contextCompactionCount =
+                        group.kind === "turn"
+                          ? (group.contextCompactionCount ?? 0)
+                          : group.kind === "activity" &&
+                              next?.kind === "item" &&
+                              next.item.kind === "context-compaction" &&
+                              next.item.phase === "compacted"
+                            ? 1
+                            : 0;
+                      return (
+                        <div key={key} data-og-timeline-group-anchor="" data-og-group-key={key}>
+                          <TimelineGroupView
+                            group={group}
+                            renderMessageText={renderMessageText}
+                            onOpenSession={onOpenSession}
+                            onMemoryClick={onMemoryClick}
+                            onReconnect={onReconnect}
+                            resolveProviderLogo={resolveProviderLogo}
+                            toolRegistry={toolRegistry}
+                            turnSummary={turnSummary}
+                            foldLiveCluster={isAgentProgress(next)}
+                            trailingAgentText={trailingAgentTextAfterTurn(group, next)}
+                            contextCompactionCount={
+                              contextCompactionCount > 0 ? contextCompactionCount : undefined
                             }
-                          });
-                        },
-                        () => {
-                          if (jumpToStartSeqRef.current === seq) {
-                            pendingJumpToStartRef.current = false;
-                          }
-                        },
+                          />
+                        </div>
                       );
-                    }}
-                    className={cn(
-                      "inline-flex items-center gap-1.5 rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1.5",
-                      "text-xs font-medium text-og-fg shadow-og-md backdrop-blur",
-                      "hover:border-og-border-strong disabled:opacity-60",
-                    )}
-                  >
-                    <ArrowUpToLineIcon className="size-3.5" />
-                    Jump to start
-                  </button>
-                ) : null}
-              </motion.div>
-            ) : null}
-          </AnimatePresence>
-          <AnimatePresence>
-            {loadingNewer ? (
-              <motion.div
-                initial={{ opacity: 0, y: 6 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 6 }}
-                transition={{ duration: 0.15, ease: "easeOut" }}
-                data-og-loading-newer=""
-                aria-live="polite"
-                className="pointer-events-none absolute inset-x-0 bottom-14 z-10 flex justify-center"
-              >
-                <span className="inline-flex items-center rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1 text-xs font-medium shadow-og-md backdrop-blur">
-                  <span className="og-shimmer-text">Loading later activity…</span>
-                </span>
-              </motion.div>
-            ) : null}
-          </AnimatePresence>
-          <AnimatePresence>
-            {((!pinned && autoFollow) || hasNewer) && autoFollow ? (
-              <motion.button
-                type="button"
-                initial={{ opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 8 }}
-                transition={{ duration: 0.15, ease: "easeOut" }}
-                onClick={() => {
-                  if (hasNewer) {
-                    // Do not pin against the current history page — its bottom
-                    // is not the tip. The pin + snap run when the tip window
-                    // actually lands (`hasNewer` flips false).
-                    wantPinRef.current = true;
-                    const node = scrollRef.current;
-                    if (onJumpToLatest) {
-                      void Promise.resolve(onJumpToLatest()).then(
-                        () => {
-                          // Covers a host that flipped hasNewer before
-                          // resolving; otherwise the tip-window commit
-                          // consumes the flag.
-                          const current = scrollRef.current;
-                          if (current && wantPinRef.current && !hasNewerRef.current) {
-                            wantPinRef.current = false;
-                            applyPinned(true);
-                            snapToBottom(current);
+                    })}
+                    {hasNewer ? (
+                      <div
+                        ref={bottomSentinelRef}
+                        data-og-bottom-sentinel=""
+                        data-og-timeline-chrome=""
+                        aria-hidden="true"
+                        className="h-px w-full"
+                      />
+                    ) : null}
+                  </div>
+                </div>
+                <AnimatePresence>
+                  {loadingOlder ||
+                  loadingOldest ||
+                  (hasOlder && onJumpToStart && olderPrefetchArmed) ? (
+                    // Floating over the scroller (not a timeline row) so showing and
+                    // hiding it never reflows history under the reader.
+                    <motion.div
+                      initial={{ opacity: 0, y: -6 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -6 }}
+                      transition={{ duration: 0.15, ease: "easeOut" }}
+                      data-og-loading-older=""
+                      aria-live="polite"
+                      className="absolute inset-x-0 top-3 z-10 flex justify-center gap-2"
+                    >
+                      {loadingOlder || loadingOldest ? (
+                        <span className="pointer-events-none inline-flex items-center rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1 text-xs font-medium shadow-og-md backdrop-blur">
+                          <span className="og-shimmer-text">
+                            {loadingOldest ? "Jumping to start…" : "Loading earlier activity…"}
+                          </span>
+                        </span>
+                      ) : null}
+                      {hasOlder && onJumpToStart && !loadingOldest ? (
+                        <button
+                          type="button"
+                          data-og-jump-to-start=""
+                          disabled={loadingOlder}
+                          onClick={() => {
+                            applyPinned(false);
+                            pendingJumpToStartRef.current = true;
+                            const seq = ++jumpToStartSeqRef.current;
+                            const node = scrollRef.current;
+                            void Promise.resolve(onJumpToStart()).then(
+                              () => {
+                                // The commit that swaps in the oldest window consumes
+                                // the flag against the new DOM; this write covers the
+                                // already-committed order and the no-window-change
+                                // case (jumping within the current window).
+                                const scroller = scrollRef.current ?? node;
+                                if (scroller) {
+                                  scroller.scrollTop = 0;
+                                }
+                                // A host may resolve without ever changing the
+                                // window (already on the oldest page). Any swap
+                                // commit runs its layout effect before the next
+                                // frame, so a flag still armed by then is the
+                                // no-change case — clear it, or a LATER prepend
+                                // would spuriously jump the reader to the top.
+                                requestFrame(() => {
+                                  if (jumpToStartSeqRef.current === seq) {
+                                    pendingJumpToStartRef.current = false;
+                                  }
+                                });
+                              },
+                              () => {
+                                if (jumpToStartSeqRef.current === seq) {
+                                  pendingJumpToStartRef.current = false;
+                                }
+                              },
+                            );
+                          }}
+                          className={cn(
+                            "inline-flex items-center gap-1.5 rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1.5",
+                            "text-xs font-medium text-og-fg shadow-og-md backdrop-blur",
+                            "hover:border-og-border-strong disabled:opacity-60",
+                          )}
+                        >
+                          <ArrowUpToLineIcon className="size-3.5" />
+                          Jump to start
+                        </button>
+                      ) : null}
+                    </motion.div>
+                  ) : null}
+                </AnimatePresence>
+                <AnimatePresence>
+                  {loadingNewer ? (
+                    <motion.div
+                      initial={{ opacity: 0, y: 6 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: 6 }}
+                      transition={{ duration: 0.15, ease: "easeOut" }}
+                      data-og-loading-newer=""
+                      aria-live="polite"
+                      className="pointer-events-none absolute inset-x-0 bottom-14 z-10 flex justify-center"
+                    >
+                      <span className="inline-flex items-center rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1 text-xs font-medium shadow-og-md backdrop-blur">
+                        <span className="og-shimmer-text">Loading later activity…</span>
+                      </span>
+                    </motion.div>
+                  ) : null}
+                </AnimatePresence>
+                <AnimatePresence>
+                  {((!pinned && autoFollow) || hasNewer) && autoFollow ? (
+                    <motion.button
+                      type="button"
+                      initial={{ opacity: 0, y: 8 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: 8 }}
+                      transition={{ duration: 0.15, ease: "easeOut" }}
+                      onClick={() => {
+                        if (hasNewer) {
+                          // Do not pin against the current history page — its bottom
+                          // is not the tip. The pin + snap run when the tip window
+                          // actually lands (`hasNewer` flips false).
+                          wantPinRef.current = true;
+                          const node = scrollRef.current;
+                          if (onJumpToLatest) {
+                            void Promise.resolve(onJumpToLatest()).then(
+                              () => {
+                                // Covers a host that flipped hasNewer before
+                                // resolving; otherwise the tip-window commit
+                                // consumes the flag.
+                                const current = scrollRef.current;
+                                if (current && wantPinRef.current && !hasNewerRef.current) {
+                                  wantPinRef.current = false;
+                                  applyPinned(true);
+                                  snapToBottom(current);
+                                }
+                              },
+                              () => {
+                                // The tip reload failed (ordinary network error):
+                                // an armed latch would fire a surprise snap when
+                                // the reader later pages to the tip themselves.
+                                wantPinRef.current = false;
+                              },
+                            );
+                          } else if (node) {
+                            // No tip reload available: jump within the in-memory
+                            // window so the newer sentinel can page forward; the
+                            // latch pins if the tip window eventually lands.
+                            snapToBottom(node);
                           }
-                        },
-                        () => {
-                          // The tip reload failed (ordinary network error):
-                          // an armed latch would fire a surprise snap when
-                          // the reader later pages to the tip themselves.
-                          wantPinRef.current = false;
-                        },
-                      );
-                    } else if (node) {
-                      // No tip reload available: jump within the in-memory
-                      // window so the newer sentinel can page forward; the
-                      // latch pins if the tip window eventually lands.
-                      snapToBottom(node);
-                    }
-                    return;
-                  }
-                  const node = scrollRef.current;
-                  if (node) {
-                    applyPinned(true);
-                    snapToBottom(node);
-                  }
-                }}
-                className={cn(
-                  "absolute bottom-4 left-1/2 -translate-x-1/2",
-                  "inline-flex items-center gap-1.5 rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1.5",
-                  "text-xs font-medium text-og-fg shadow-og-md backdrop-blur",
-                  "hover:border-og-border-strong",
-                )}
-              >
-                <ArrowDownIcon className="size-3.5" />
-                Jump to latest
-              </motion.button>
-            ) : null}
-          </AnimatePresence>
-        </div>
-        </TooltipProvider>
-      </EntranceAnimationProvider>
-      </SeenActivityIdsProvider>
+                          return;
+                        }
+                        const node = scrollRef.current;
+                        if (node) {
+                          applyPinned(true);
+                          snapToBottom(node);
+                        }
+                      }}
+                      className={cn(
+                        "absolute bottom-4 left-1/2 -translate-x-1/2",
+                        "inline-flex items-center gap-1.5 rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1.5",
+                        "text-xs font-medium text-og-fg shadow-og-md backdrop-blur",
+                        "hover:border-og-border-strong",
+                      )}
+                    >
+                      <ArrowDownIcon className="size-3.5" />
+                      Jump to latest
+                    </motion.button>
+                  ) : null}
+                </AnimatePresence>
+              </div>
+            </TooltipProvider>
+          </EntranceAnimationProvider>
+        </SeenActivityIdsProvider>
       </FoldMemoryProvider>
     </LightboxProvider>
   );

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -33,6 +33,7 @@ import {
 } from "react";
 import { cn } from "../lib/cn";
 import { formatRelativeTime, truncate } from "../lib/format";
+import { prefersReducedMotion } from "../lib/motion";
 import { Markdown } from "./markdown";
 import {
   ActivityRail,
@@ -141,30 +142,25 @@ export type MessageTimelineProps = {
  * rows are memoized, so a full mount is cheap; the drip-feed machinery this
  * replaces was the "content is hidden, then pops in in batches" wobble.)
  *
- * The whole invariant is one sentence: pinned means we snap to the bottom
- * after every content change, and a scroll event that lands far from the
- * bottom unpins. Because every programmatic write lands AT the bottom, its
- * echo scroll event reads gap ≈ 0 and stays pinned — so there is no need to
- * count echoes, model glide physics, or reverse-engineer reader intent from
- * wheel/touch/pointer/key events. Any far-from-bottom scroll event is
- * necessarily the reader (or something acting for them, like find-in-page),
- * and unpinning is then the correct response. The previous scripted-glide +
- * echo-debt + intent-detection design is deliberately gone; the "flow in"
- * feel lives in the row entrance CSS, not in scripted scrollTop motion.
- *
- * - Pinned at the tip → snap: `scrollTop = scrollHeight - clientHeight` after
- *   every commit (layout effect) and every observed resize. Native scroll
- *   anchoring is off while pinned so it cannot fight the snap. Shrink-clamps
- *   land at the bottom too, so settle-fold collapses stay pinned by the same
- *   rule.
- * - Scrolled up reading → native scroll anchoring helps with late layout, but
- *   history prepends are restored in script: loadOlder can also truncate the
- *   tip (oldest-directed window), so scrollHeight delta alone is wrong, and
- *   anchoring often fails near y=0. We re-anchor on the retained group that
- *   held the previous first item (stable React key + offsetTop delta), falling
- *   back to scrollHeight growth when no anchor node is measurable.
+ * Scroll invariant:
+ * - A far-from-bottom scroll event unpins (reader left the tip).
+ * - Pinned at the live tip → soft-follow: ease `scrollTop` toward the bottom
+ *   so each new line/tool shifts the viewport smoothly instead of ratcheting
+ *   one line-height per append. Hard snap only for first paint, Jump to
+ *   latest, reduced motion, and oversized jumps. Native overflow-anchor is
+ *   off while pinned so the browser cannot instant-correct (that IS the tick).
+ * - Mid-glide scroll echoes must not unpin (gap is temporarily large). An
+ *   upward scrollTop while gliding is the reader — cancel + unpin. Downward
+ *   glide writes and settle-fold clamps (still near-bottom) stay pinned.
+ * - Scrolled up → history prepends restore via the retained group anchor
+ *   (offsetTop delta); loadOlder can truncate the tip, so scrollHeight delta
+ *   alone is wrong. Late layout while unpinned stays browser-owned.
  */
 const PIN_THRESHOLD_PX = 48;
+/** Tip-follow ease: remaining distance shrinks ~63% every tau ms. */
+const TIP_GLIDE_TAU_MS = 200;
+/** Larger than this snaps (session switch / huge fold), not eases. */
+const TIP_GLIDE_MAX_DISTANCE_PX = 480;
 /**
  * Prefetch older history when the top sentinel is this far from the viewport.
  * After a page loads we stay cool until the reader leaves this band (scrolls
@@ -306,11 +302,94 @@ export function MessageTimeline({
     }
   }, []);
 
-  // Every programmatic scroll is this one snap. Its echo scroll event lands
-  // with gap ≈ 0, so it re-reads as pinned — no echo accounting needed.
-  const snapToBottom = useCallback((node: HTMLElement) => {
-    node.scrollTop = Math.max(0, node.scrollHeight - node.clientHeight);
+  const revealedRef = useRef(revealed);
+  revealedRef.current = revealed;
+
+  // Soft tip-follow glide. While active, onScroll must not treat the temporary
+  // tip-debt as a reader unpin (see onScroll). Cancelled on upward scroll or
+  // when the pin drops.
+  const glideFrameRef = useRef<number | null>(null);
+  const glideLastTsRef = useRef(0);
+  const glidingRef = useRef(false);
+
+  const stopGlide = useCallback(() => {
+    glidingRef.current = false;
+    if (glideFrameRef.current !== null) {
+      cancelFrame(glideFrameRef.current);
+      glideFrameRef.current = null;
+    }
   }, []);
+
+  const snapToBottom = useCallback(
+    (node: HTMLElement) => {
+      stopGlide();
+      node.scrollTop = Math.max(0, node.scrollHeight - node.clientHeight);
+      lastScrollTopRef.current = node.scrollTop;
+    },
+    [stopGlide],
+  );
+
+  const glideStep = useCallback(() => {
+    glideFrameRef.current = null;
+    const node = scrollRef.current;
+    if (!node || !pinnedRef.current || hasNewerRef.current) {
+      glidingRef.current = false;
+      return;
+    }
+    const target = Math.max(0, node.scrollHeight - node.clientHeight);
+    const delta = target - node.scrollTop;
+    if (Math.abs(delta) <= 1) {
+      if (delta !== 0) {
+        node.scrollTop = target;
+      }
+      lastScrollTopRef.current = node.scrollTop;
+      glidingRef.current = false;
+      return;
+    }
+    const nowTs = typeof performance !== "undefined" ? performance.now() : Date.now();
+    const dt =
+      glideLastTsRef.current === 0
+        ? 16
+        : Math.min(64, Math.max(8, nowTs - glideLastTsRef.current));
+    glideLastTsRef.current = nowTs;
+    const alpha = 1 - Math.exp(-dt / TIP_GLIDE_TAU_MS);
+    const step = delta * alpha;
+    node.scrollTop = node.scrollTop + (Math.abs(step) < 0.5 ? Math.sign(delta) : step);
+    lastScrollTopRef.current = node.scrollTop;
+    glidingRef.current = true;
+    glideFrameRef.current = requestFrame(glideStep);
+  }, []);
+
+  const startGlide = useCallback(() => {
+    glidingRef.current = true;
+    if (glideFrameRef.current === null) {
+      glideLastTsRef.current = 0;
+      glideFrameRef.current = requestFrame(glideStep);
+    }
+  }, [glideStep]);
+
+  useEffect(() => stopGlide, [stopGlide]);
+
+  /** Soft tip-follow while pinned; hard snap for first paint / big jumps. */
+  const followTip = useCallback(
+    (node: HTMLElement) => {
+      const target = Math.max(0, node.scrollHeight - node.clientHeight);
+      const delta = target - node.scrollTop;
+      if (Math.abs(delta) <= 1) {
+        return;
+      }
+      if (
+        !revealedRef.current ||
+        Math.abs(delta) > TIP_GLIDE_MAX_DISTANCE_PX ||
+        prefersReducedMotion()
+      ) {
+        snapToBottom(node);
+        return;
+      }
+      startGlide();
+    },
+    [snapToBottom, startGlide],
+  );
 
   // The single post-commit scroll authority. Runs after EVERY commit (no dep
   // list): any commit may change content height, and the decision is cheap.
@@ -333,6 +412,7 @@ export function MessageTimeline({
       // The oldest window landed — jump against the NEW DOM, and skip the
       // prepend correction (it would shift the reader away from the top).
       pendingJumpToStartRef.current = false;
+      stopGlide();
       node.scrollTop = 0;
     } else if (wantPinRef.current && !hasNewer) {
       // Jump-to-latest was pressed on a history window and the tip window is
@@ -344,10 +424,8 @@ export function MessageTimeline({
         snapToBottom(node);
       }
     } else if (autoFollow && pinnedRef.current && !hasNewer) {
-      // Live tip only. A history-page bottom (`hasNewer`) must not follow
-      // appends from loadNewer — that path leaves scrollTop alone, like an
-      // unpinned reader watching growth below the viewport.
-      snapToBottom(node);
+      // Live tip: ease toward the bottom (hard snap only first paint / jumps).
+      followTip(node);
     } else if (prepended) {
       // Keep the reader on the same retained rows. Prefer the offsetTop delta
       // of the group that still holds the previous first item — that stays
@@ -517,10 +595,9 @@ export function MessageTimeline({
   }, [hasNewer, loadingNewer, onLoadNewer, firstGroupKey]);
 
   // Late layout that React commits cannot see (images decoding, fonts, code
-  // blocks) grows content without a commit. While pinned we keep snapping to
-  // the bottom; while unpinned we deliberately do NOTHING — chasing those
-  // shifts with scroll corrections was the wobble. Coalesce RO into one rAF so
-  // a tool/markdown reflow storm re-snaps at most once per frame.
+  // blocks) grows content without a commit. While pinned, soft-follow the tip;
+  // unpinned: do nothing — chasing those shifts was the wobble. Coalesce RO
+  // into one rAF.
   useEffect(() => {
     const node = scrollRef.current;
     const inner = node?.firstElementChild;
@@ -538,7 +615,7 @@ export function MessageTimeline({
           return;
         }
         if (autoFollow && pinnedRef.current && !hasNewerRef.current) {
-          snapToBottom(current);
+          followTip(current);
         }
       });
     });
@@ -553,7 +630,7 @@ export function MessageTimeline({
         resizeFollowRafRef.current = null;
       }
     };
-  }, [autoFollow, snapToBottom]);
+  }, [autoFollow, followTip]);
 
   // Entering a non-tip history window: drop any live pin so the page bottom
   // cannot re-stick follow across loadNewer. Leaving it (the tip window
@@ -562,6 +639,7 @@ export function MessageTimeline({
   // strand them unpinned watching new content grow below.
   useEffect(() => {
     if (hasNewer) {
+      stopGlide();
       applyPinned(false);
       return;
     }
@@ -580,26 +658,46 @@ export function MessageTimeline({
     if (autoFollow && !pinnedRef.current && isNearBottom(node)) {
       applyPinned(true);
     }
-  }, [hasNewer, autoFollow, applyPinned, snapToBottom]);
+  }, [hasNewer, autoFollow, applyPinned, snapToBottom, stopGlide]);
 
-  // The one unpin/repin decision, purely geometric. Our own writes always land
-  // at the bottom, so their echoes stay pinned; any far-from-bottom scroll
-  // event is necessarily the reader moving and unpins. Settle-fold shrinks are
-  // safe by the same rule: the browser clamps scrollTop to the new max, which
-  // IS the bottom. No wheel/touch/pointer/key/gutter inference exists anymore.
+  // Unpin/repin. Hard snaps land at the bottom so their echoes stay pinned.
+  // Soft tip-follow temporarily leaves a tip-debt: while gliding, ignore that
+  // gap — only an upward scrollTop (reader) cancels. Settle-fold clamps shrink
+  // scrollTop but land near-bottom, so they stay pinned.
   const onScroll = () => {
     const node = scrollRef.current;
     if (!node) {
       return;
     }
-    lastScrollTopRef.current = node.scrollTop;
+    const previousTop = lastScrollTopRef.current;
+    const nextTop = node.scrollTop;
+    lastScrollTopRef.current = nextTop;
+
+    if (glidingRef.current) {
+      if (nextTop < previousTop - 1 && !isNearBottom(node)) {
+        stopGlide();
+        applyPinned(false);
+        if (wantPinRef.current) {
+          wantPinRef.current = false;
+        }
+        if (!olderPrefetchArmedRef.current) {
+          olderPrefetchArmedRef.current = true;
+          setOlderPrefetchArmed(true);
+        }
+      }
+      return;
+    }
+
     const nearBottom = isNearBottom(node);
     const nextPinned = !hasNewer && nearBottom;
+    if (!nextPinned) {
+      stopGlide();
+    }
     applyPinned(nextPinned);
     // A far-from-bottom scroll while a Jump-to-latest is pending is the reader
     // changing their mind: drop the latch, or a stale one (host rejected or
     // never flipped hasNewer) would fire a surprise pin + snap whenever the
-    // reader later pages to the tip themselves. Our own writes land AT the
+    // reader later pages to the tip themselves. Our own snaps land AT the
     // bottom, so their echoes read nearBottom and keep a live latch.
     if (wantPinRef.current && !nearBottom) {
       wantPinRef.current = false;
@@ -623,9 +721,8 @@ export function MessageTimeline({
       <EntranceAnimationProvider value={!bulkRender}>
         <TooltipProvider delayDuration={400}>
         <div className={cn("og-root relative flex min-h-0 flex-col", className)}>
-          {/* Pinned: anchoring off so it cannot fight the bottom snap.
-          Unpinned: native scroll anchoring holds the reader's place through
-          prepends and late layout — the wobble-free path. */}
+          {/* Pinned: anchoring off so the soft tip-follow owns the motion.
+          Unpinned: native scroll anchoring holds the reader's place. */}
           <div
             ref={scrollRef}
             tabIndex={-1}

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -33,7 +33,6 @@ import {
 } from "react";
 import { cn } from "../lib/cn";
 import { formatRelativeTime, truncate } from "../lib/format";
-import { prefersReducedMotion } from "../lib/motion";
 import { Markdown } from "./markdown";
 import {
   ActivityRail,
@@ -60,6 +59,7 @@ import {
 import { CopyHoverFrame } from "./copy-button";
 import { SESSION_STATUS_META, StatusDot } from "./session-status";
 import { EntranceAnimationProvider, useEntranceAnimation } from "../timeline/entrance";
+import { TooltipProvider } from "./tooltip";
 
 export type MessageTimelineProps = {
   /** Raw session events (projected internally) … */
@@ -141,54 +141,61 @@ export type MessageTimelineProps = {
  * rows are memoized, so a full mount is cheap; the drip-feed machinery this
  * replaces was the "content is hidden, then pops in in batches" wobble.)
  *
- * Exactly one authority writes scrollTop, depending on mode:
- * - Pinned at the tip → we own it: ease toward the bottom after every commit
- *   (and on ResizeObserver ticks for late layout like images). Native scroll
- *   anchoring is disabled in this mode so it cannot fight the glide.
- * - Scrolled up reading → the BROWSER owns it: native scroll anchoring
- *   (`overflow-anchor: auto`) holds the reader's viewport through history
- *   prepends, image/font late layout, and fold reflows at the compositor
- *   level — no script, nothing to wobble. Where the engine lacks scroll
- *   anchoring, the one scripted exception is a history prepend, corrected
- *   once per commit by the exact scrollHeight delta.
+ * The whole invariant is one sentence: pinned means we snap to the bottom
+ * after every content change, and a scroll event that lands far from the
+ * bottom unpins. Because every programmatic write lands AT the bottom, its
+ * echo scroll event reads gap ≈ 0 and stays pinned — so there is no need to
+ * count echoes, model glide physics, or reverse-engineer reader intent from
+ * wheel/touch/pointer/key events. Any far-from-bottom scroll event is
+ * necessarily the reader (or something acting for them, like find-in-page),
+ * and unpinning is then the correct response. The previous scripted-glide +
+ * echo-debt + intent-detection design is deliberately gone; the "flow in"
+ * feel lives in the row entrance CSS, not in scripted scrollTop motion.
+ *
+ * - Pinned at the tip → snap: `scrollTop = scrollHeight - clientHeight` after
+ *   every commit (layout effect) and every observed resize. Native scroll
+ *   anchoring is off while pinned so it cannot fight the snap. Shrink-clamps
+ *   land at the bottom too, so settle-fold collapses stay pinned by the same
+ *   rule.
+ * - Scrolled up reading → native scroll anchoring helps with late layout, but
+ *   history prepends are restored in script: loadOlder can also truncate the
+ *   tip (oldest-directed window), so scrollHeight delta alone is wrong, and
+ *   anchoring often fails near y=0. We re-anchor on the retained group that
+ *   held the previous first item (stable React key + offsetTop delta), falling
+ *   back to scrollHeight growth when no anchor node is measurable.
  */
 const PIN_THRESHOLD_PX = 48;
+/**
+ * Prefetch older history when the top sentinel is this far from the viewport.
+ * After a page loads we stay cool until the reader leaves this band (scrolls
+ * down into content) — never re-fire from continued scroll toward y=0.
+ */
+const OLDER_PREFETCH_MARGIN_PX = 400;
+const OLDER_PREFETCH_ROOT_MARGIN = `${OLDER_PREFETCH_MARGIN_PX}px 0px 0px 0px`;
 
 /**
- * Adaptive tip-follow glide. Remaining distance shrinks by ~63% every tau ms.
- * Tau is dynamic:
- * - Slow / sparse growth → longer tau (calm float; no strange laggy chase
- *   after a single line).
- * - Fast bursts or stacked debt → shorter tau (catch up without rattling).
- * Velocity is an EMA of scrollHeight growth; debt is distance-to-bottom.
+ * Pinned = the viewport bottom is within PIN_THRESHOLD_PX of the content
+ * bottom. When the scroll range itself is shorter than the threshold, the
+ * whole range would count as "at the bottom" and the reader could never unpin
+ * to reach older history — so the effective threshold shrinks to the range,
+ * making the very top of a short window count as scrolled up. A window that
+ * cannot scroll at all is always pinned.
  */
-const GLIDE_TAU_MIN_MS = 100;
-const GLIDE_TAU_MAX_MS = 420;
-/** At this tip-debt, urgency saturates toward the fast tau. */
-const GLIDE_CATCHUP_DEBT_PX = 140;
-/** Growth speed (px/s) that saturates urgency toward the fast tau. */
-const GLIDE_VELOCITY_REF_PX_S = 380;
-/** Idle this long without growth → velocity decays (slow stream calms). */
-const GLIDE_VELOCITY_IDLE_MS = 180;
-/** Growth beyond this snaps instead of gliding (session switches, huge folds). */
-const GLIDE_MAX_DISTANCE_PX = 600;
-
-function glideTauMs(debtPx: number, velocityPxPerSec: number): number {
-  const debtT = Math.min(1, Math.abs(debtPx) / GLIDE_CATCHUP_DEBT_PX);
-  const velT = Math.min(1, Math.max(0, velocityPxPerSec) / GLIDE_VELOCITY_REF_PX_S);
-  const urgency = Math.max(debtT, velT);
-  return GLIDE_TAU_MAX_MS + (GLIDE_TAU_MIN_MS - GLIDE_TAU_MAX_MS) * urgency;
+function isNearBottom(node: HTMLElement): boolean {
+  const maxScroll = node.scrollHeight - node.clientHeight;
+  if (maxScroll <= 1) {
+    return true;
+  }
+  const gap = maxScroll - node.scrollTop;
+  return gap < Math.min(PIN_THRESHOLD_PX, maxScroll);
 }
 
-/** Detects native scroll anchoring; a hook so tests can exercise the fallback. */
-function useNativeScrollAnchoring(): boolean {
-  return useMemo(
-    () =>
-      typeof CSS !== "undefined" &&
-      typeof CSS.supports === "function" &&
-      CSS.supports("overflow-anchor: auto"),
-    [],
-  );
+/** Escape a value for use inside a CSS attribute selector. */
+function cssEscapeAttribute(value: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(value);
+  }
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 /**
@@ -235,13 +242,19 @@ export function MessageTimeline({
   // history forever while the reader sits at the tip. Arm on first scroll-up.
   const olderPrefetchArmedRef = useRef(false);
   const [olderPrefetchArmed, setOlderPrefetchArmed] = useState(false);
+  // One loadOlder per visit to the top band. Re-arm only after the reader
+  // leaves that band (scrolls down / sentinel exits) — never from scrolling
+  // further toward y=0 (that was the batch-top load loop).
+  const olderLoadGateRef = useRef<"armed" | "cooling">("armed");
+  const resizeFollowRafRef = useRef<number | null>(null);
   const firstGroupKey = allGroups[0] ? timelineGroupKey(allGroups[0]) : null;
   // Content stays invisible until its first bottom-anchored frame, so a flash
   // of the window's TOP while a large timeline lays out is structurally
   // impossible — the reader only ever sees it already at the bottom.
   const [revealed, setRevealed] = useState(false);
-  // Mirror `pinned` into a ref so ResizeObserver/layout callbacks (stable
-  // closures) always read the live value without re-subscribing.
+  // Mirror `pinned` into a ref, written ONLY by applyPinned, so the
+  // ResizeObserver rAF (a stable closure) reads the live value and a snap can
+  // never race a just-unpinned reader across a pending React commit.
   const pinnedRef = useRef(true);
   // History windows (`hasNewer`) have a bottom that is not the live tip.
   // Pin/follow must ignore that floor — otherwise loadNewer appends yank the
@@ -249,19 +262,26 @@ export function MessageTimeline({
   // the reader is unpinned and scroll anchoring / delta correction owns place.
   const hasNewerRef = useRef(hasNewer);
   hasNewerRef.current = hasNewer;
-  // Our own scrollTop writes echo back as delayed scroll events. We only ever
-  // write "to the bottom" while pinned (echo reads as pinned — harmless) or a
-  // prepend delta while unpinned (echo reads as unpinned — harmless), so no
-  // target bookkeeping is needed; a small counter just stops a late echo of a
-  // bottom-follow from unpinning a reader who has not touched the wheel.
-  const pendingEchoesRef = useRef(0);
+  // Jump-to-latest pressed while a history window is showing: the pin must
+  // wait for the tip window to actually land (`hasNewer` → false) — pinning
+  // immediately would snap to the bottom of the CURRENT history page and
+  // page-crawl forward through the gap.
+  const wantPinRef = useRef(false);
+  // Jump-to-start pressed: consume on the commit that swaps the window so the
+  // scroll-to-top write races neither the old DOM nor the prepend correction.
+  const pendingJumpToStartRef = useRef(false);
+  // Identifies the newest Jump-to-start click so a settling promise callback
+  // from an earlier click can never clear a re-click's pending flag.
+  const jumpToStartSeqRef = useRef(0);
   // Prepend detection: the oldest loaded item's id changes exactly when older
   // history lands (including the merge-into-first-group case where the first
   // GROUP key is retained). Item ids, not group keys, are the durable signal.
-  // Only consulted where the engine lacks native scroll anchoring.
-  const nativeScrollAnchoring = useNativeScrollAnchoring();
   const previousFirstItemIdRef = useRef<string | null>(null);
   const previousScrollHeightRef = useRef(0);
+  // Per-commit place memory for unpinned prepend restore (see layout effect).
+  const lastScrollTopRef = useRef(0);
+  const groupKeyByItemIdRef = useRef<Map<string, string>>(new Map());
+  const groupOffsetByKeyRef = useRef<Map<string, number>>(new Map());
   const firstItemId = resolvedItems[0]?.id ?? null;
   const lastItem = resolvedItems[resolvedItems.length - 1];
   const streaming =
@@ -276,121 +296,26 @@ export function MessageTimeline({
     previousBulkFirstKeyRef.current !== firstGroupKey;
   const bulkRender = allGroups.length > 0 && (bulkActive || firstKeyChangedForBulk);
 
-  // Mirrors `revealed` for the stable follow callbacks: the very first
-  // bottom-anchored frame must SNAP (the reader hasn't seen anything yet);
-  // everything after it may glide.
-  const revealedRef = useRef(false);
-
-  const writeScrollTop = useCallback((node: HTMLElement, value: number) => {
-    const previous = node.scrollTop;
-    node.scrollTop = value;
-    if (node.scrollTop !== previous) {
-      pendingEchoesRef.current = Math.min(pendingEchoesRef.current + 1, 32);
+  // The ONLY writer of the pinned flag. Ref and state move together, so
+  // behavior (refs read by rAF callbacks) and rendering (the anchor class,
+  // the Jump-to-latest button) can never desync.
+  const applyPinned = useCallback((value: boolean) => {
+    if (pinnedRef.current !== value) {
+      pinnedRef.current = value;
+      setPinned(value);
     }
   }, []);
 
-  // Soft follow glide: while pinned, the tip eases toward the bottom with an
-  // exponential approach (frame-rate independent) instead of teleporting per
-  // commit. Tau adapts to recent growth velocity + tip debt — slow streams
-  // stay calm, fast bursts catch up. Target re-read every frame so mid-glide
-  // growth extends the same motion. Self-terminates when the pin releases.
-  const glideFrameRef = useRef<number | null>(null);
-  const glideLastTsRef = useRef(0);
-  const growthTrackerRef = useRef({ height: 0, at: 0, velocity: 0 });
-
-  const noteContentGrowth = useCallback((height: number) => {
-    const tracker = growthTrackerRef.current;
-    const nowTs = typeof performance !== "undefined" ? performance.now() : Date.now();
-    if (tracker.height > 0 && nowTs > tracker.at) {
-      const dh = height - tracker.height;
-      const dt = nowTs - tracker.at;
-      if (dh > 0 && dt > 0) {
-        const instant = (dh / dt) * 1000;
-        tracker.velocity = tracker.velocity * 0.65 + instant * 0.35;
-      } else if (dt > GLIDE_VELOCITY_IDLE_MS) {
-        // Sparse stream: forget burst urgency so the next line floats calmly.
-        tracker.velocity *= 0.45;
-      }
-    }
-    tracker.height = height;
-    tracker.at = nowTs;
+  // Every programmatic scroll is this one snap. Its echo scroll event lands
+  // with gap ≈ 0, so it re-reads as pinned — no echo accounting needed.
+  const snapToBottom = useCallback((node: HTMLElement) => {
+    node.scrollTop = Math.max(0, node.scrollHeight - node.clientHeight);
   }, []);
-
-  const stopGlide = useCallback(() => {
-    if (glideFrameRef.current !== null) {
-      cancelFrame(glideFrameRef.current);
-      glideFrameRef.current = null;
-    }
-  }, []);
-
-  const glideStep = useCallback(() => {
-    glideFrameRef.current = null;
-    const node = scrollRef.current;
-    if (!node || !pinnedRef.current) {
-      return;
-    }
-    noteContentGrowth(node.scrollHeight);
-    const target = node.scrollHeight - node.clientHeight;
-    const delta = target - node.scrollTop;
-    if (Math.abs(delta) <= 1) {
-      if (delta !== 0) {
-        writeScrollTop(node, target);
-      }
-      return;
-    }
-    const nowTs = typeof performance !== "undefined" ? performance.now() : Date.now();
-    const dt =
-      glideLastTsRef.current === 0 ? 16 : Math.min(64, Math.max(8, nowTs - glideLastTsRef.current));
-    glideLastTsRef.current = nowTs;
-    // Decay velocity while gliding without new growth so catch-up eases out.
-    const tracker = growthTrackerRef.current;
-    if (nowTs - tracker.at > GLIDE_VELOCITY_IDLE_MS) {
-      tracker.velocity *= 0.85;
-      tracker.at = nowTs;
-    }
-    const tau = glideTauMs(delta, tracker.velocity);
-    const alpha = 1 - Math.exp(-dt / tau);
-    const step = delta * alpha;
-    writeScrollTop(node, node.scrollTop + (Math.abs(step) < 1 ? Math.sign(delta) : step));
-    glideFrameRef.current = requestFrame(glideStep);
-  }, [noteContentGrowth, writeScrollTop]);
-
-  const startGlide = useCallback(() => {
-    if (glideFrameRef.current === null) {
-      glideLastTsRef.current = 0;
-      glideFrameRef.current = requestFrame(glideStep);
-    }
-  }, [glideStep]);
-
-  useEffect(() => stopGlide, [stopGlide]);
-
-  const followTip = useCallback(
-    (node: HTMLElement) => {
-      noteContentGrowth(node.scrollHeight);
-      const target = node.scrollHeight - node.clientHeight;
-      const delta = target - node.scrollTop;
-      if (Math.abs(delta) <= 1) {
-        return;
-      }
-      // Glide only for ordinary streaming-scale growth after the first paint.
-      // The initial reveal, session switches, and layout jumps larger than a
-      // viewport-ish distance snap — animating those would feel like lag.
-      if (
-        revealedRef.current &&
-        Math.abs(delta) <= GLIDE_MAX_DISTANCE_PX &&
-        !prefersReducedMotion()
-      ) {
-        startGlide();
-      } else {
-        stopGlide();
-        writeScrollTop(node, target);
-      }
-    },
-    [noteContentGrowth, startGlide, stopGlide, writeScrollTop],
-  );
 
   // The single post-commit scroll authority. Runs after EVERY commit (no dep
   // list): any commit may change content height, and the decision is cheap.
+  // Also the ONLY writer of the prepend-correction baselines
+  // (previousFirstItemIdRef / previousScrollHeightRef / group offset maps).
   // oxlint-disable-next-line react-hooks/exhaustive-deps -- Deliberately runs after every commit.
   useLayoutEffect(() => {
     const node = scrollRef.current;
@@ -398,29 +323,94 @@ export function MessageTimeline({
       return;
     }
     const previousFirstItemId = previousFirstItemIdRef.current;
+    const previousGroupKeyByItemId = groupKeyByItemIdRef.current;
+    const previousGroupOffsetByKey = groupOffsetByKeyRef.current;
+    const previousScrollTop = lastScrollTopRef.current;
+    const firstItemChanged = previousFirstItemId !== null && firstItemId !== previousFirstItemId;
     const prepended =
-      previousFirstItemId !== null &&
-      firstItemId !== previousFirstItemId &&
-      resolvedItems.some((item) => item.id === previousFirstItemId);
-    // Live tip only. A history-page bottom (`hasNewer`) must not follow appends
-    // from loadNewer — that path should leave scrollTop alone, like an unpinned
-    // reader watching growth below the viewport.
-    if (autoFollow && pinnedRef.current && !hasNewerRef.current) {
-      followTip(node);
-    } else if (prepended && !nativeScrollAnchoring) {
-      // Fallback engines only: one exact correction per prepend commit, whole
-      // pixels. Anchoring engines already adjusted during layout — correcting
-      // again here would double-shift. Growth below the viewport (a live tip
-      // streaming while the reader is up in history) never lands here.
-      const delta = Math.round(node.scrollHeight - previousScrollHeightRef.current);
-      if (delta > 0) {
-        writeScrollTop(node, node.scrollTop + delta);
+      firstItemChanged && resolvedItems.some((item) => item.id === previousFirstItemId);
+    if (pendingJumpToStartRef.current && firstItemChanged) {
+      // The oldest window landed — jump against the NEW DOM, and skip the
+      // prepend correction (it would shift the reader away from the top).
+      pendingJumpToStartRef.current = false;
+      node.scrollTop = 0;
+    } else if (wantPinRef.current && !hasNewer) {
+      // Jump-to-latest was pressed on a history window and the tip window is
+      // in THIS commit — consume pre-paint so the first tip frame is already
+      // at the bottom (post-paint consumption flashed one clamped frame).
+      wantPinRef.current = false;
+      if (autoFollow) {
+        applyPinned(true);
+        snapToBottom(node);
       }
+    } else if (autoFollow && pinnedRef.current && !hasNewer) {
+      // Live tip only. A history-page bottom (`hasNewer`) must not follow
+      // appends from loadNewer — that path leaves scrollTop alone, like an
+      // unpinned reader watching growth below the viewport.
+      snapToBottom(node);
+    } else if (prepended) {
+      // Keep the reader on the same retained rows. Prefer the offsetTop delta
+      // of the group that still holds the previous first item — that stays
+      // correct when loadOlder also truncates the tip (height delta then lies).
+      // If native anchoring already applied the same shift, leave scrollTop.
+      const anchorKey =
+        previousFirstItemId !== null
+          ? previousGroupKeyByItemId.get(previousFirstItemId)
+          : undefined;
+      const previousAnchorTop =
+        anchorKey !== undefined ? previousGroupOffsetByKey.get(anchorKey) : undefined;
+      const anchorEl =
+        anchorKey !== undefined
+          ? node.querySelector(`[data-og-group-key="${cssEscapeAttribute(anchorKey)}"]`)
+          : null;
+      let delta: number | null = null;
+      if (anchorEl instanceof HTMLElement && previousAnchorTop !== undefined) {
+        const moved = Math.round(anchorEl.offsetTop - previousAnchorTop);
+        if (moved !== 0) {
+          delta = moved;
+        }
+      }
+      if (delta === null) {
+        const heightDelta = Math.round(node.scrollHeight - previousScrollHeightRef.current);
+        if (heightDelta > 0) {
+          delta = heightDelta;
+        }
+      }
+      if (delta !== null) {
+        const expected = previousScrollTop + delta;
+        if (Math.abs(node.scrollTop - expected) > 2) {
+          node.scrollTop = expected;
+        }
+      }
+    }
+    // After a prepend, if restore left us below the top prefetch band,
+    // re-arm so a later approach can load again. Still cooling while parked
+    // inside the band (short pages) — that stops the y=0 load loop.
+    if (
+      prepended &&
+      !pinnedRef.current &&
+      olderLoadGateRef.current === "cooling" &&
+      node.scrollTop > OLDER_PREFETCH_MARGIN_PX
+    ) {
+      olderLoadGateRef.current = "armed";
     }
     previousFirstItemIdRef.current = firstItemId;
     previousScrollHeightRef.current = node.scrollHeight;
+    lastScrollTopRef.current = node.scrollTop;
+    const nextKeyByItemId = new Map<string, string>();
+    const nextOffsetByKey = new Map<string, number>();
+    for (const { group, key } of groups) {
+      for (const itemId of timelineGroupItemIds(group)) {
+        nextKeyByItemId.set(itemId, key);
+      }
+      const el = node.querySelector(`[data-og-group-key="${cssEscapeAttribute(key)}"]`);
+      if (el instanceof HTMLElement) {
+        nextOffsetByKey.set(key, el.offsetTop);
+      }
+    }
+    groupKeyByItemIdRef.current = nextKeyByItemId;
+    groupOffsetByKeyRef.current = nextOffsetByKey;
     if (!revealed && groups.length > 0) {
-      revealedRef.current = true;
       setRevealed(true);
     }
   });
@@ -431,8 +421,6 @@ export function MessageTimeline({
     if (allGroups.length > 0) {
       return;
     }
-    stopGlide();
-    revealedRef.current = false;
     if (revealed) {
       setRevealed(false);
     }
@@ -440,11 +428,16 @@ export function MessageTimeline({
       olderPrefetchArmedRef.current = false;
       setOlderPrefetchArmed(false);
     }
-    if (!pinnedRef.current) {
-      pinnedRef.current = true;
-      setPinned(true);
-    }
-  }, [allGroups.length, revealed, stopGlide]);
+    olderLoadGateRef.current = "armed";
+    wantPinRef.current = false;
+    pendingJumpToStartRef.current = false;
+    previousFirstItemIdRef.current = null;
+    previousScrollHeightRef.current = 0;
+    lastScrollTopRef.current = 0;
+    groupKeyByItemIdRef.current = new Map();
+    groupOffsetByKeyRef.current = new Map();
+    applyPinned(true);
+  }, [allGroups.length, revealed, applyPinned]);
 
   // Clear the bulk-paint marker a frame after it renders, so rows appended
   // live (streams, new turns) animate exactly as before.
@@ -459,8 +452,9 @@ export function MessageTimeline({
   }, [bulkRender, firstGroupKey]);
 
   // Prefetch older history only after the reader scrolls up from the tip.
-  // Once armed, the sentinel trips 1600px early so backfill is usually
-  // rendered (and its scroll delta corrected) before the reader reaches it.
+  // Once armed, the sentinel trips early so backfill is usually rendered
+  // (and its scroll delta corrected) before the reader reaches it. Gated so
+  // a short prepend that leaves the sentinel intersecting cannot loop.
   useEffect(() => {
     const root = scrollRef.current;
     const target = topSentinelRef.current;
@@ -477,11 +471,19 @@ export function MessageTimeline({
     }
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          onLoadOlder();
+        const intersecting = entries.some((entry) => entry.isIntersecting);
+        if (!intersecting) {
+          // Left the top band — next approach may load once.
+          olderLoadGateRef.current = "armed";
+          return;
         }
+        if (olderLoadGateRef.current !== "armed") {
+          return;
+        }
+        olderLoadGateRef.current = "cooling";
+        onLoadOlder();
       },
-      { root, rootMargin: "1600px 0px 0px 0px" },
+      { root, rootMargin: OLDER_PREFETCH_ROOT_MARGIN },
     );
     observer.observe(target);
     return () => observer.disconnect();
@@ -515,10 +517,10 @@ export function MessageTimeline({
   }, [hasNewer, loadingNewer, onLoadNewer, firstGroupKey]);
 
   // Late layout that React commits cannot see (images decoding, fonts, code
-  // blocks) grows content without a commit. While pinned we keep following the
-  // bottom; while unpinned we deliberately do NOTHING — chasing those shifts
-  // with scroll corrections was the wobble. We only refresh the height
-  // baseline so the next prepend delta stays exact.
+  // blocks) grows content without a commit. While pinned we keep snapping to
+  // the bottom; while unpinned we deliberately do NOTHING — chasing those
+  // shifts with scroll corrections was the wobble. Coalesce RO into one rAF so
+  // a tool/markdown reflow storm re-snaps at most once per frame.
   useEffect(() => {
     const node = scrollRef.current;
     const inner = node?.firstElementChild;
@@ -526,181 +528,108 @@ export function MessageTimeline({
       return;
     }
     const observer = new ResizeObserver(() => {
-      const current = scrollRef.current;
-      if (!current) {
+      if (resizeFollowRafRef.current !== null) {
         return;
       }
-      if (autoFollow && pinnedRef.current && !hasNewerRef.current) {
-        followTip(current);
-      }
-      previousScrollHeightRef.current = current.scrollHeight;
+      resizeFollowRafRef.current = requestFrame(() => {
+        resizeFollowRafRef.current = null;
+        const current = scrollRef.current;
+        if (!current) {
+          return;
+        }
+        if (autoFollow && pinnedRef.current && !hasNewerRef.current) {
+          snapToBottom(current);
+        }
+      });
     });
     observer.observe(inner);
-    return () => observer.disconnect();
-  }, [autoFollow, followTip]);
+    // The scroller's own box moves the bottom too (window resize, composer
+    // growing): clientHeight changes with no inner resize and no commit.
+    observer.observe(node);
+    return () => {
+      observer.disconnect();
+      if (resizeFollowRafRef.current !== null) {
+        cancelFrame(resizeFollowRafRef.current);
+        resizeFollowRafRef.current = null;
+      }
+    };
+  }, [autoFollow, snapToBottom]);
 
   // Entering a non-tip history window: drop any live pin so the page bottom
-  // cannot re-stick follow across loadNewer.
+  // cannot re-stick follow across loadNewer. Leaving it (the tip window
+  // landed): honor a pending Jump-to-latest, or re-pin a reader already parked
+  // at what just became the live bottom — paging forward to the tip must not
+  // strand them unpinned watching new content grow below.
   useEffect(() => {
-    if (!hasNewer) {
+    if (hasNewer) {
+      applyPinned(false);
       return;
     }
-    stopGlide();
-    if (pinnedRef.current) {
-      pinnedRef.current = false;
-      setPinned(false);
-    }
-  }, [hasNewer, stopGlide]);
-
-  // While the glide is writing scrollTop every frame, its echoes could mask
-  // the reader's own upward scroll events — so upward INTENT (wheel up, finger
-  // drag down, scrollbar gutter, keys) releases the pin directly. Layout
-  // scrolls during settle-fold / scenario spawns must NEVER unpin from
-  // onScroll alone — that was the recurring "Jump to latest" trap.
-  const releasePin = useCallback(() => {
     const node = scrollRef.current;
-    if (!node || node.scrollHeight - node.clientHeight <= 1) {
-      return; // nothing to scroll — no pin to release
+    if (!node) {
+      return;
     }
-    stopGlide();
-    if (pinnedRef.current) {
-      pinnedRef.current = false;
-      setPinned(false);
+    if (wantPinRef.current) {
+      wantPinRef.current = false;
+      if (autoFollow) {
+        applyPinned(true);
+        snapToBottom(node);
+      }
+      return;
     }
-    if (!olderPrefetchArmedRef.current) {
-      olderPrefetchArmedRef.current = true;
-      setOlderPrefetchArmed(true);
+    if (autoFollow && !pinnedRef.current && isNearBottom(node)) {
+      applyPinned(true);
     }
-  }, [stopGlide]);
+  }, [hasNewer, autoFollow, applyPinned, snapToBottom]);
 
-  const scrollbarDragRef = useRef(false);
-  const touchYRef = useRef<number | null>(null);
-
+  // The one unpin/repin decision, purely geometric. Our own writes always land
+  // at the bottom, so their echoes stay pinned; any far-from-bottom scroll
+  // event is necessarily the reader moving and unpins. Settle-fold shrinks are
+  // safe by the same rule: the browser clamps scrollTop to the new max, which
+  // IS the bottom. No wheel/touch/pointer/key/gutter inference exists anymore.
   const onScroll = () => {
     const node = scrollRef.current;
     if (!node) {
       return;
     }
-    const echo = pendingEchoesRef.current > 0;
-    if (echo) {
-      pendingEchoesRef.current -= 1;
+    lastScrollTopRef.current = node.scrollTop;
+    const nearBottom = isNearBottom(node);
+    const nextPinned = !hasNewer && nearBottom;
+    applyPinned(nextPinned);
+    // A far-from-bottom scroll while a Jump-to-latest is pending is the reader
+    // changing their mind: drop the latch, or a stale one (host rejected or
+    // never flipped hasNewer) would fire a surprise pin + snap whenever the
+    // reader later pages to the tip themselves. Our own writes land AT the
+    // bottom, so their echoes read nearBottom and keep a live latch.
+    if (wantPinRef.current && !nearBottom) {
+      wantPinRef.current = false;
     }
-    const gap = node.scrollHeight - node.scrollTop - node.clientHeight;
-    // Near-bottom (re)pins only for the live tip. History-window bottoms are
-    // loadNewer triggers, not follow targets.
-    const nextPinned = !hasNewerRef.current && gap < PIN_THRESHOLD_PX;
-    previousScrollHeightRef.current = node.scrollHeight;
-    // Near-bottom always (re)pins — including echoes of our own writes.
     if (nextPinned) {
-      if (!pinnedRef.current) {
-        pinnedRef.current = true;
-        setPinned(true);
-      }
-      return;
-    }
-    if (echo) {
-      return;
-    }
-    // Still pinned but far from the tip. Either layout moved the floor
-    // (collapse / append / images) or the reader is dragging the scrollbar.
-    // Wheel/touch/keys already called releasePin. Scrollbar sets the drag
-    // flag below. Everything else is layout — re-stick, never drop the pin.
-    // History mode never re-sticks: drop the pin instead.
-    if (pinnedRef.current) {
-      if (hasNewerRef.current || scrollbarDragRef.current) {
-        releasePin();
-        return;
-      }
-      followTip(node);
       return;
     }
     if (!olderPrefetchArmedRef.current) {
       olderPrefetchArmedRef.current = true;
       setOlderPrefetchArmed(true);
     }
-  };
-
-  // Native wheel listener: React's onWheel is unreliable under some test
-  // doms, and we want the same intent path in production.
-  useEffect(() => {
-    const node = scrollRef.current;
-    if (!node) {
-      return;
+    // Re-arm older prefetch only after leaving the top band (scroll down into
+    // content). Never re-arm/load from continued scroll toward y=0.
+    if (olderLoadGateRef.current === "cooling" && node.scrollTop > OLDER_PREFETCH_MARGIN_PX) {
+      olderLoadGateRef.current = "armed";
     }
-    const onWheelNative = (event: WheelEvent) => {
-      if (event.deltaY < 0) {
-        releasePin();
-      }
-    };
-    const onKeyDownNative = (event: KeyboardEvent) => {
-      if (event.key === "ArrowUp" || event.key === "PageUp" || event.key === "Home") {
-        releasePin();
-      }
-    };
-    node.addEventListener("wheel", onWheelNative, { passive: true });
-    node.addEventListener("keydown", onKeyDownNative);
-    return () => {
-      node.removeEventListener("wheel", onWheelNative);
-      node.removeEventListener("keydown", onKeyDownNative);
-    };
-  }, [releasePin]);
-
-  const onWheel = (event: React.WheelEvent) => {
-    if (event.deltaY < 0) {
-      releasePin();
-    }
-  };
-  const onPointerDown = (event: React.PointerEvent) => {
-    const node = scrollRef.current;
-    if (!node) {
-      return;
-    }
-    // Only the classic overlay scrollbar gutter counts as reader intent —
-    // clicks on fold chevrons / messages must not arm unpin.
-    const gutter = node.offsetWidth - node.clientWidth;
-    if (gutter <= 0) {
-      return;
-    }
-    const rect = node.getBoundingClientRect();
-    if (event.clientX >= rect.right - gutter - 2) {
-      scrollbarDragRef.current = true;
-    }
-  };
-  const onPointerUp = () => {
-    scrollbarDragRef.current = false;
-  };
-  const onTouchStart = (event: React.TouchEvent) => {
-    touchYRef.current = event.touches[0]?.clientY ?? null;
-  };
-  const onTouchMove = (event: React.TouchEvent) => {
-    const y = event.touches[0]?.clientY;
-    if (y === undefined) {
-      return;
-    }
-    const previous = touchYRef.current;
-    if (previous !== null && y - previous > 6) {
-      releasePin();
-    }
-    touchYRef.current = y;
   };
 
   return (
     <LightboxProvider>
       <EntranceAnimationProvider value={!bulkRender}>
+        <TooltipProvider delayDuration={400}>
         <div className={cn("og-root relative flex min-h-0 flex-col", className)}>
-          {/* Pinned: anchoring off so the soft tip-follow glide is the only
-          authority. Unpinned: native scroll anchoring holds the reader's
-          place through prepends and late layout — the wobble-free path. */}
+          {/* Pinned: anchoring off so it cannot fight the bottom snap.
+          Unpinned: native scroll anchoring holds the reader's place through
+          prepends and late layout — the wobble-free path. */}
           <div
             ref={scrollRef}
             tabIndex={-1}
             onScroll={onScroll}
-            onWheel={onWheel}
-            onPointerDown={onPointerDown}
-            onPointerUp={onPointerUp}
-            onPointerCancel={onPointerUp}
-            onTouchStart={onTouchStart}
-            onTouchMove={onTouchMove}
             style={groups.length > 0 && !revealed ? { visibility: "hidden" } : undefined}
             className={cn(
               // tabIndex=-1 is programmatic only — never paint a focus ring on
@@ -740,7 +669,7 @@ export function MessageTimeline({
                       ? 1
                       : 0;
                 return (
-                  <div key={key} data-og-timeline-group-anchor="">
+                  <div key={key} data-og-timeline-group-anchor="" data-og-group-key={key}>
                     <TimelineGroupView
                       group={group}
                       renderMessageText={renderMessageText}
@@ -801,16 +730,38 @@ export function MessageTimeline({
                     data-og-jump-to-start=""
                     disabled={loadingOlder}
                     onClick={() => {
-                      stopGlide();
-                      pinnedRef.current = false;
-                      setPinned(false);
+                      applyPinned(false);
+                      pendingJumpToStartRef.current = true;
+                      const seq = ++jumpToStartSeqRef.current;
                       const node = scrollRef.current;
-                      void Promise.resolve(onJumpToStart()).then(() => {
-                        const scroller = scrollRef.current ?? node;
-                        if (scroller) {
-                          writeScrollTop(scroller, 0);
-                        }
-                      });
+                      void Promise.resolve(onJumpToStart()).then(
+                        () => {
+                          // The commit that swaps in the oldest window consumes
+                          // the flag against the new DOM; this write covers the
+                          // already-committed order and the no-window-change
+                          // case (jumping within the current window).
+                          const scroller = scrollRef.current ?? node;
+                          if (scroller) {
+                            scroller.scrollTop = 0;
+                          }
+                          // A host may resolve without ever changing the
+                          // window (already on the oldest page). Any swap
+                          // commit runs its layout effect before the next
+                          // frame, so a flag still armed by then is the
+                          // no-change case — clear it, or a LATER prepend
+                          // would spuriously jump the reader to the top.
+                          requestFrame(() => {
+                            if (jumpToStartSeqRef.current === seq) {
+                              pendingJumpToStartRef.current = false;
+                            }
+                          });
+                        },
+                        () => {
+                          if (jumpToStartSeqRef.current === seq) {
+                            pendingJumpToStartRef.current = false;
+                          }
+                        },
+                      );
                     }}
                     className={cn(
                       "inline-flex items-center gap-1.5 rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1.5",
@@ -851,27 +802,45 @@ export function MessageTimeline({
                 exit={{ opacity: 0, y: 8 }}
                 transition={{ duration: 0.15, ease: "easeOut" }}
                 onClick={() => {
-                  const finish = () => {
-                    // Re-pin, then let the glide carry the trip: its writes are
-                    // echo-counted (a native smooth scrollTo's are not, and its
-                    // mid-flight events would read as the reader unpinning).
-                    pinnedRef.current = true;
-                    setPinned(true);
+                  if (hasNewer) {
+                    // Do not pin against the current history page — its bottom
+                    // is not the tip. The pin + snap run when the tip window
+                    // actually lands (`hasNewer` flips false).
+                    wantPinRef.current = true;
                     const node = scrollRef.current;
-                    if (!node) {
-                      return;
+                    if (onJumpToLatest) {
+                      void Promise.resolve(onJumpToLatest()).then(
+                        () => {
+                          // Covers a host that flipped hasNewer before
+                          // resolving; otherwise the tip-window commit
+                          // consumes the flag.
+                          const current = scrollRef.current;
+                          if (current && wantPinRef.current && !hasNewerRef.current) {
+                            wantPinRef.current = false;
+                            applyPinned(true);
+                            snapToBottom(current);
+                          }
+                        },
+                        () => {
+                          // The tip reload failed (ordinary network error):
+                          // an armed latch would fire a surprise snap when
+                          // the reader later pages to the tip themselves.
+                          wantPinRef.current = false;
+                        },
+                      );
+                    } else if (node) {
+                      // No tip reload available: jump within the in-memory
+                      // window so the newer sentinel can page forward; the
+                      // latch pins if the tip window eventually lands.
+                      snapToBottom(node);
                     }
-                    if (prefersReducedMotion()) {
-                      writeScrollTop(node, node.scrollHeight - node.clientHeight);
-                    } else {
-                      startGlide();
-                    }
-                  };
-                  if (onJumpToLatest && hasNewer) {
-                    void Promise.resolve(onJumpToLatest()).then(finish);
                     return;
                   }
-                  finish();
+                  const node = scrollRef.current;
+                  if (node) {
+                    applyPinned(true);
+                    snapToBottom(node);
+                  }
                 }}
                 className={cn(
                   "absolute bottom-4 left-1/2 -translate-x-1/2",
@@ -886,6 +855,7 @@ export function MessageTimeline({
             ) : null}
           </AnimatePresence>
         </div>
+        </TooltipProvider>
       </EntranceAnimationProvider>
     </LightboxProvider>
   );
@@ -1287,11 +1257,36 @@ function collectAgentMessageText(groups: readonly TimelineGroup[]): string {
   return parts.join("\n\n");
 }
 
+/** Non-null turnIds projected into a turn body (activity + nested messages). */
+function collectTurnIdsFromGroups(groups: readonly TimelineGroup[]): Set<string> {
+  const ids = new Set<string>();
+  for (const group of groups) {
+    if (group.kind === "item") {
+      const turnId = "turnId" in group.item ? group.item.turnId : null;
+      if (typeof turnId === "string" && turnId.length > 0) {
+        ids.add(turnId);
+      }
+    } else if (group.kind === "activity") {
+      for (const item of group.items) {
+        if (item.turnId) {
+          ids.add(item.turnId);
+        }
+      }
+    } else if (group.kind === "turn") {
+      for (const nested of collectTurnIdsFromGroups(group.groups)) {
+        ids.add(nested);
+      }
+    }
+  }
+  return ids;
+}
+
 /**
  * Settled turns lift the final agent answer out as a sibling group. Include it
  * in "Copy turn" when present so the chip copies the full assistant reply.
+ * Fenced by turnId so the next turn's answer is never stolen.
  */
-function trailingAgentTextAfterTurn(
+export function trailingAgentTextAfterTurn(
   group: TimelineGroup,
   next: TimelineGroup | undefined,
 ): string | undefined {
@@ -1299,6 +1294,14 @@ function trailingAgentTextAfterTurn(
     return undefined;
   }
   if (next?.kind === "item" && next.item.kind === "agent-message") {
+    const turnIds = collectTurnIdsFromGroups(group.groups);
+    // Degenerate body with no turnIds: do not guess — safer than lifting wrong.
+    if (turnIds.size === 0) {
+      return undefined;
+    }
+    if (!next.item.turnId || !turnIds.has(next.item.turnId)) {
+      return undefined;
+    }
     const text = next.item.text.trim();
     return text.length > 0 ? text : undefined;
   }
@@ -1473,7 +1476,7 @@ function UserMessageRow({
           label="Copy message"
           className="w-fit max-w-full min-w-0"
         >
-          <div className="w-fit max-w-full min-w-0 rounded-og-lg rounded-br-og-xs border border-og-border bg-og-surface-2 px-4 py-2.5 pr-10 text-og-md leading-6 text-og-fg">
+          <div className="w-fit max-w-full min-w-0 rounded-og-lg rounded-br-og-xs border border-og-border bg-og-surface-2 px-4 py-2.5 text-og-md leading-6 text-og-fg">
             {renderMessageText ? (
               renderMessageText(item.text, item)
             ) : (
@@ -1510,7 +1513,7 @@ function AgentMessageRow({
       copyText={item.text}
       label="Copy message"
       align="end"
-      className={cn(enter && "animate-og-enter", "min-w-0 pr-9 text-og-md leading-7 text-og-fg")}
+      className={cn(enter && "animate-og-enter", "min-w-0 text-og-md leading-7 text-og-fg")}
     >
       {body}
     </CopyHoverFrame>

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -36,6 +36,16 @@ import { formatRelativeTime, truncate } from "../lib/format";
 import { prefersReducedMotion } from "../lib/motion";
 import { Markdown } from "./markdown";
 import {
+  createTipFollowState,
+  readerScrollUpPx,
+  tipFollowCancel,
+  tipFollowCompensateShrink,
+  tipFollowStep,
+  TIP_FOLLOW_READER_UP_EPS_PX,
+  TIP_FOLLOW_SHRINK_EPS_PX,
+  type TipFollowState,
+} from "./tip-follow";
+import {
   ActivityRail,
   buildTimeline,
   defaultToolRegistry,
@@ -53,13 +63,18 @@ import {
   type ToolRegistry,
   type TurnSummaryOptions,
   type UserMessageItem,
+  type FoldRestingState,
   type WorkerCompletionItem,
+  FoldMemoryProvider,
+  inheritFoldRestingState,
   TurnSummary,
+  useFoldMemory,
   useTurnSettleOpen,
 } from "../timeline";
 import { CopyHoverFrame } from "./copy-button";
 import { SESSION_STATUS_META, StatusDot } from "./session-status";
 import { EntranceAnimationProvider, useEntranceAnimation } from "../timeline/entrance";
+import { SeenActivityIdsProvider } from "../timeline/seen-activity-ids";
 import { TooltipProvider } from "./tooltip";
 
 export type MessageTimelineProps = {
@@ -67,7 +82,7 @@ export type MessageTimelineProps = {
   events?: SessionEvent[] | undefined;
   /** … or pre-projected items (e.g. from `useSessionEvents().timeline`). */
   items?: TimelineItem[] | undefined;
-  /** Current session status; drives the live "working" indicator. */
+  /** Current session status (reserved; tip "Working…" chrome removed for now). */
   status?: SessionStatus | null | undefined;
   /** Plug a markdown renderer for message bodies (e.g. streamdown). */
   renderMessageText?:
@@ -142,25 +157,19 @@ export type MessageTimelineProps = {
  * rows are memoized, so a full mount is cheap; the drip-feed machinery this
  * replaces was the "content is hidden, then pops in in batches" wobble.)
  *
- * Scroll invariant:
- * - A far-from-bottom scroll event unpins (reader left the tip).
- * - Pinned at the live tip → soft-follow: ease `scrollTop` toward the bottom
- *   so each new line/tool shifts the viewport smoothly instead of ratcheting
- *   one line-height per append. Hard snap only for first paint, Jump to
- *   latest, reduced motion, and oversized jumps. Native overflow-anchor is
- *   off while pinned so the browser cannot instant-correct (that IS the tick).
- * - Mid-glide scroll echoes must not unpin (gap is temporarily large). An
- *   upward scrollTop while gliding is the reader — cancel + unpin. Downward
- *   glide writes and settle-fold clamps (still near-bottom) stay pinned.
+ * Scroll invariant (tip-follow camera — see `./tip-follow.ts`):
+ * - DOM truth mounts immediately; the camera eases down to the tip (not
+ *   tip-glued feed-forward — that is the one-line yank).
+ * - One continuous follow while hot (faster τ when behind); sleeps when cold.
+ * - While pinned, tip-debt from growth/collapse must NEVER unpin — only
+ *   wheel/keys/pointer-armed scroll-up. Height shrink compensates scrollTop
+ *   by Δh (collapse owns motion); tip-ease pauses briefly so the two don't fight.
+ * - overflow-anchor off while pinned so the browser cannot instant-correct.
  * - Scrolled up → history prepends restore via the retained group anchor
  *   (offsetTop delta); loadOlder can truncate the tip, so scrollHeight delta
  *   alone is wrong. Late layout while unpinned stays browser-owned.
  */
 const PIN_THRESHOLD_PX = 48;
-/** Tip-follow ease: remaining distance shrinks ~63% every tau ms. */
-const TIP_GLIDE_TAU_MS = 200;
-/** Larger than this snaps (session switch / huge fold), not eases. */
-const TIP_GLIDE_MAX_DISTANCE_PX = 480;
 /**
  * Prefetch older history when the top sentinel is this far from the viewport.
  * After a page loads we stay cool until the reader leaves this band (scrolls
@@ -177,8 +186,43 @@ const OLDER_PREFETCH_ROOT_MARGIN = `${OLDER_PREFETCH_MARGIN_PX}px 0px 0px 0px`;
  * making the very top of a short window count as scrolled up. A window that
  * cannot scroll at all is always pinned.
  */
+function maxScrollOf(node: HTMLElement): number {
+  return Math.max(0, node.scrollHeight - node.clientHeight);
+}
+
+/**
+ * Wheel bubbled from a nested overflow scroller that can still move up — not
+ * timeline intent (code blocks / notice `<pre>`).
+ */
+function wheelConsumedByNestedScrollable(event: {
+  deltaY: number;
+  target: EventTarget | null;
+  currentTarget: EventTarget | null;
+}): boolean {
+  if (event.deltaY >= 0) {
+    return false;
+  }
+  let el = event.target instanceof Element ? event.target : null;
+  const root = event.currentTarget instanceof Element ? event.currentTarget : null;
+  while (el && el !== root) {
+    if (el instanceof HTMLElement) {
+      const style = getComputedStyle(el);
+      const overflowY = style.overflowY;
+      if (
+        (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+        el.scrollHeight > el.clientHeight + 1 &&
+        el.scrollTop > 0
+      ) {
+        return true;
+      }
+    }
+    el = el.parentElement;
+  }
+  return false;
+}
+
 function isNearBottom(node: HTMLElement): boolean {
-  const maxScroll = node.scrollHeight - node.clientHeight;
+  const maxScroll = maxScrollOf(node);
   if (maxScroll <= 1) {
     return true;
   }
@@ -203,7 +247,7 @@ function cssEscapeAttribute(value: string): string {
 export function MessageTimeline({
   events,
   items,
-  status,
+  status: _status,
   renderMessageText,
   onOpenSession,
   onMemoryClick,
@@ -275,16 +319,25 @@ export function MessageTimeline({
   const previousFirstItemIdRef = useRef<string | null>(null);
   const previousScrollHeightRef = useRef(0);
   // Per-commit place memory for unpinned prepend restore (see layout effect).
+  // Paired with max/height/client for clamp-conservation reader-intent math.
   const lastScrollTopRef = useRef(0);
+  const lastMaxScrollRef = useRef(0);
+  const lastScrollHeightRef = useRef(0);
+  const lastClientHeightRef = useRef(0);
+  /**
+   * Armed by pointerdown on the scroller. Geometric scroll-up only unpins
+   * while armed — mid-turn fold+growth also drops scrollTop with a flat
+   * maxScroll and must NOT count as leave. Wheel/keys unpin directly.
+   */
+  const readerIntentArmRef = useRef(false);
+  // Resting fold state per durable group id (see fold-memory.ts). Outlives the
+  // deliberate chip remounts (activity→turn wrap, nested key flips) so a fold
+  // that already settled closed — or that the reader closed — never reopens.
+  const foldMemoryRef = useRef<Map<string, FoldRestingState>>(new Map());
+  const seenActivityIdsRef = useRef<Set<string>>(new Set());
   const groupKeyByItemIdRef = useRef<Map<string, string>>(new Map());
   const groupOffsetByKeyRef = useRef<Map<string, number>>(new Map());
   const firstItemId = resolvedItems[0]?.id ?? null;
-  const lastItem = resolvedItems[resolvedItems.length - 1];
-  const streaming =
-    lastItem !== undefined &&
-    (lastItem.kind === "agent-message" || lastItem.kind === "reasoning") &&
-    lastItem.streaming;
-  const working = status === "running" && !streaming;
   // Bulk paints (the initial tail window, a prepended older window — detected
   // by the first group key changing) must not run per-row entrance animations.
   const firstKeyChangedForBulk =
@@ -305,91 +358,206 @@ export function MessageTimeline({
   const revealedRef = useRef(revealed);
   revealedRef.current = revealed;
 
-  // Soft tip-follow glide. While active, onScroll must not treat the temporary
-  // tip-debt as a reader unpin (see onScroll). Cancelled on upward scroll or
-  // when the pin drops.
-  const glideFrameRef = useRef<number | null>(null);
-  const glideLastTsRef = useRef(0);
-  const glidingRef = useRef(false);
+  // Pure tip-follow camera. Pin intent uses clamp conservation, not timers.
+  const followRef = useRef<TipFollowState>(createTipFollowState());
+  const followFrameRef = useRef<number | null>(null);
 
-  const stopGlide = useCallback(() => {
-    glidingRef.current = false;
-    if (glideFrameRef.current !== null) {
-      cancelFrame(glideFrameRef.current);
-      glideFrameRef.current = null;
+  const syncScrollBaseline = useCallback((node: HTMLElement) => {
+    lastScrollTopRef.current = node.scrollTop;
+    lastMaxScrollRef.current = maxScrollOf(node);
+    lastScrollHeightRef.current = node.scrollHeight;
+    lastClientHeightRef.current = node.clientHeight;
+  }, []);
+
+  const stopFollow = useCallback(() => {
+    followRef.current = tipFollowCancel(followRef.current);
+    if (followFrameRef.current !== null) {
+      cancelFrame(followFrameRef.current);
+      followFrameRef.current = null;
     }
   }, []);
+
+  /** Reader left the tip — wheel, keyboard, or pointer-armed scroll-up. */
+  const releasePinFromReader = useCallback(
+    (node?: HTMLElement | null) => {
+      if (!autoFollow || !pinnedRef.current || hasNewerRef.current) {
+        return;
+      }
+      // Unscrollable window: unpin strands Jump-to-latest with no way back.
+      if (node && maxScrollOf(node) <= 1) {
+        return;
+      }
+      readerIntentArmRef.current = false;
+      stopFollow();
+      applyPinned(false);
+      if (wantPinRef.current) {
+        wantPinRef.current = false;
+      }
+      if (!olderPrefetchArmedRef.current) {
+        olderPrefetchArmedRef.current = true;
+        setOlderPrefetchArmed(true);
+      }
+    },
+    [autoFollow, applyPinned, stopFollow],
+  );
+
+  const onWheel = (event: {
+    deltaY: number;
+    deltaX: number;
+    target: EventTarget | null;
+    currentTarget: EventTarget | null;
+  }) => {
+    // Nested overflow (code / notice pre) or mostly-horizontal pan: not tip leave.
+    if (event.deltaY >= 0) {
+      return;
+    }
+    if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) {
+      return;
+    }
+    if (wheelConsumedByNestedScrollable(event)) {
+      return;
+    }
+    const node =
+      event.currentTarget instanceof HTMLElement ? event.currentTarget : scrollRef.current;
+    releasePinFromReader(node);
+  };
+
+  /** Touch / stylus / mouse drag on the scroller — explicit leave (not layout). */
+  const onPointerDown = (event: {
+    button: number;
+    pointerType: string;
+    target: EventTarget | null;
+  }) => {
+    // Primary button / touch / pen only. Ignore right-click etc.
+    if (event.button !== 0 && event.pointerType === "mouse") {
+      return;
+    }
+    // Clicks on chips/buttons/links must not arm — their settle collapse
+    // also drops scrollTop and would false-unpin. Drag on prose/scroller may.
+    if (
+      event.target instanceof Element &&
+      event.target.closest("button, a, input, textarea, select, [role='button']")
+    ) {
+      return;
+    }
+    readerIntentArmRef.current = true;
+  };
+
+  const onKeyDown = (event: { key: string; currentTarget: EventTarget | null }) => {
+    if (event.key !== "ArrowUp" && event.key !== "PageUp" && event.key !== "Home") {
+      return;
+    }
+    const node =
+      event.currentTarget instanceof HTMLElement ? event.currentTarget : scrollRef.current;
+    releasePinFromReader(node);
+  };
 
   const snapToBottom = useCallback(
     (node: HTMLElement) => {
-      stopGlide();
+      stopFollow();
       node.scrollTop = Math.max(0, node.scrollHeight - node.clientHeight);
-      lastScrollTopRef.current = node.scrollTop;
+      syncScrollBaseline(node);
+      followRef.current = {
+        ...followRef.current,
+        lastHeight: node.scrollHeight,
+      };
     },
-    [stopGlide],
+    [stopFollow, syncScrollBaseline],
   );
 
-  const glideStep = useCallback(() => {
-    glideFrameRef.current = null;
-    const node = scrollRef.current;
-    if (!node || !pinnedRef.current || hasNewerRef.current) {
-      glidingRef.current = false;
-      return;
-    }
-    const target = Math.max(0, node.scrollHeight - node.clientHeight);
-    const delta = target - node.scrollTop;
-    if (Math.abs(delta) <= 1) {
-      if (delta !== 0) {
-        node.scrollTop = target;
-      }
-      lastScrollTopRef.current = node.scrollTop;
-      glidingRef.current = false;
-      return;
-    }
-    const nowTs = typeof performance !== "undefined" ? performance.now() : Date.now();
-    const dt =
-      glideLastTsRef.current === 0
-        ? 16
-        : Math.min(64, Math.max(8, nowTs - glideLastTsRef.current));
-    glideLastTsRef.current = nowTs;
-    const alpha = 1 - Math.exp(-dt / TIP_GLIDE_TAU_MS);
-    const step = delta * alpha;
-    node.scrollTop = node.scrollTop + (Math.abs(step) < 0.5 ? Math.sign(delta) : step);
-    lastScrollTopRef.current = node.scrollTop;
-    glidingRef.current = true;
-    glideFrameRef.current = requestFrame(glideStep);
-  }, []);
-
-  const startGlide = useCallback(() => {
-    glidingRef.current = true;
-    if (glideFrameRef.current === null) {
-      glideLastTsRef.current = 0;
-      glideFrameRef.current = requestFrame(glideStep);
-    }
-  }, [glideStep]);
-
-  useEffect(() => stopGlide, [stopGlide]);
-
-  /** Soft tip-follow while pinned; hard snap for first paint / big jumps. */
-  const followTip = useCallback(
-    (node: HTMLElement) => {
-      const target = Math.max(0, node.scrollHeight - node.clientHeight);
-      const delta = target - node.scrollTop;
-      if (Math.abs(delta) <= 1) {
+  const driveFollowRef = useRef<(node: HTMLElement, now?: number) => void>(() => undefined);
+  const driveFollow = useCallback(
+    (node: HTMLElement, nowMs?: number) => {
+      if (!pinnedRef.current || hasNewerRef.current) {
+        stopFollow();
         return;
       }
+      // Prefer the rAF timestamp so ease integrates against vsync (and tests
+      // can advance a synthetic clock via requestAnimationFrame callbacks).
+      const now =
+        typeof nowMs === "number"
+          ? nowMs
+          : typeof performance !== "undefined"
+            ? performance.now()
+            : Date.now();
+      const previousHeight = followRef.current.lastHeight;
+      // Settle-collapse: compensate Δh from the pre-shrink baseline (browser
+      // may already have clamped — don't double-subtract). Keep the follow rAF
+      // alive so when collapse ends (or stream resumes) we ease instead of a
+      // hard stop → flick. Do NOT tip-ease on the same frame as a real shrink
+      // (that fight was the top-of-viewport flicker).
       if (
-        !revealedRef.current ||
-        Math.abs(delta) > TIP_GLIDE_MAX_DISTANCE_PX ||
-        prefersReducedMotion()
+        previousHeight > 0 &&
+        node.scrollHeight < previousHeight - TIP_FOLLOW_SHRINK_EPS_PX
       ) {
-        snapToBottom(node);
+        const nextTop = tipFollowCompensateShrink(
+          lastScrollTopRef.current,
+          previousHeight,
+          node.scrollHeight,
+          node.clientHeight,
+        );
+        if (node.scrollTop !== nextTop) {
+          node.scrollTop = nextTop;
+        }
+        syncScrollBaseline(node);
+        followRef.current = {
+          ...followRef.current,
+          lastHeight: node.scrollHeight,
+          running: true,
+          lastTs: now,
+        };
+        if (followFrameRef.current === null) {
+          followFrameRef.current = requestFrame((frameNow) => {
+            followFrameRef.current = null;
+            const current = scrollRef.current;
+            if (current) {
+              driveFollowRef.current(current, frameNow);
+            }
+          });
+        }
         return;
       }
-      startGlide();
+      // Sub-eps height noise: adopt height without moving the camera.
+      if (previousHeight > 0 && node.scrollHeight < previousHeight) {
+        followRef.current = {
+          ...followRef.current,
+          lastHeight: node.scrollHeight,
+        };
+      }
+      const result = tipFollowStep(followRef.current, {
+        scrollTop: node.scrollTop,
+        scrollHeight: node.scrollHeight,
+        clientHeight: node.clientHeight,
+        now,
+        pinned: true,
+        reducedMotion: prefersReducedMotion(),
+        revealed: revealedRef.current,
+      });
+      followRef.current = result.state;
+      if (node.scrollTop !== result.scrollTop) {
+        node.scrollTop = result.scrollTop;
+      }
+      syncScrollBaseline(node);
+      if (result.state.running) {
+        if (followFrameRef.current === null) {
+          followFrameRef.current = requestFrame((frameNow) => {
+            followFrameRef.current = null;
+            const current = scrollRef.current;
+            if (current) {
+              driveFollowRef.current(current, frameNow);
+            }
+          });
+        }
+      } else if (followFrameRef.current !== null) {
+        cancelFrame(followFrameRef.current);
+        followFrameRef.current = null;
+      }
     },
-    [snapToBottom, startGlide],
+    [stopFollow, syncScrollBaseline],
   );
+  driveFollowRef.current = driveFollow;
+
+  useEffect(() => stopFollow, [stopFollow]);
 
   // The single post-commit scroll authority. Runs after EVERY commit (no dep
   // list): any commit may change content height, and the decision is cheap.
@@ -412,7 +580,7 @@ export function MessageTimeline({
       // The oldest window landed — jump against the NEW DOM, and skip the
       // prepend correction (it would shift the reader away from the top).
       pendingJumpToStartRef.current = false;
-      stopGlide();
+      stopFollow();
       node.scrollTop = 0;
     } else if (wantPinRef.current && !hasNewer) {
       // Jump-to-latest was pressed on a history window and the tip window is
@@ -424,8 +592,8 @@ export function MessageTimeline({
         snapToBottom(node);
       }
     } else if (autoFollow && pinnedRef.current && !hasNewer) {
-      // Live tip: ease toward the bottom (hard snap only first paint / jumps).
-      followTip(node);
+      // Live tip: tip-follow camera eases down (snap only first paint / jumps).
+      driveFollow(node);
     } else if (prepended) {
       // Keep the reader on the same retained rows. Prefer the offsetTop delta
       // of the group that still holds the previous first item — that stays
@@ -474,20 +642,29 @@ export function MessageTimeline({
     }
     previousFirstItemIdRef.current = firstItemId;
     previousScrollHeightRef.current = node.scrollHeight;
-    lastScrollTopRef.current = node.scrollTop;
+    syncScrollBaseline(node);
+    // Item→group keys are cheap (data only). offsetTop queries are O(groups)
+    // layout reads — skip while pinned at the live tip (every stream token
+    // used to remeasure the whole timeline; that was the long-run lag).
     const nextKeyByItemId = new Map<string, string>();
-    const nextOffsetByKey = new Map<string, number>();
     for (const { group, key } of groups) {
       for (const itemId of timelineGroupItemIds(group)) {
         nextKeyByItemId.set(itemId, key);
       }
-      const el = node.querySelector(`[data-og-group-key="${cssEscapeAttribute(key)}"]`);
-      if (el instanceof HTMLElement) {
-        nextOffsetByKey.set(key, el.offsetTop);
-      }
     }
     groupKeyByItemIdRef.current = nextKeyByItemId;
-    groupOffsetByKeyRef.current = nextOffsetByKey;
+    const needOffsets =
+      prepended || firstItemChanged || !pinnedRef.current || Boolean(hasNewer);
+    if (needOffsets) {
+      const nextOffsetByKey = new Map<string, number>();
+      for (const { key } of groups) {
+        const el = node.querySelector(`[data-og-group-key="${cssEscapeAttribute(key)}"]`);
+        if (el instanceof HTMLElement) {
+          nextOffsetByKey.set(key, el.offsetTop);
+        }
+      }
+      groupOffsetByKeyRef.current = nextOffsetByKey;
+    }
     if (!revealed && groups.length > 0) {
       setRevealed(true);
     }
@@ -512,8 +689,13 @@ export function MessageTimeline({
     previousFirstItemIdRef.current = null;
     previousScrollHeightRef.current = 0;
     lastScrollTopRef.current = 0;
+    lastMaxScrollRef.current = 0;
+    lastScrollHeightRef.current = 0;
+    lastClientHeightRef.current = 0;
     groupKeyByItemIdRef.current = new Map();
     groupOffsetByKeyRef.current = new Map();
+    foldMemoryRef.current.clear();
+    seenActivityIdsRef.current.clear();
     applyPinned(true);
   }, [allGroups.length, revealed, applyPinned]);
 
@@ -615,7 +797,7 @@ export function MessageTimeline({
           return;
         }
         if (autoFollow && pinnedRef.current && !hasNewerRef.current) {
-          followTip(current);
+          driveFollow(current);
         }
       });
     });
@@ -630,7 +812,7 @@ export function MessageTimeline({
         resizeFollowRafRef.current = null;
       }
     };
-  }, [autoFollow, followTip]);
+  }, [autoFollow, driveFollow]);
 
   // Entering a non-tip history window: drop any live pin so the page bottom
   // cannot re-stick follow across loadNewer. Leaving it (the tip window
@@ -639,7 +821,7 @@ export function MessageTimeline({
   // strand them unpinned watching new content grow below.
   useEffect(() => {
     if (hasNewer) {
-      stopGlide();
+      stopFollow();
       applyPinned(false);
       return;
     }
@@ -658,40 +840,72 @@ export function MessageTimeline({
     if (autoFollow && !pinnedRef.current && isNearBottom(node)) {
       applyPinned(true);
     }
-  }, [hasNewer, autoFollow, applyPinned, snapToBottom, stopGlide]);
+  }, [hasNewer, autoFollow, applyPinned, snapToBottom, stopFollow]);
 
-  // Unpin/repin. Hard snaps land at the bottom so their echoes stay pinned.
-  // Soft tip-follow temporarily leaves a tip-debt: while gliding, ignore that
-  // gap — only an upward scrollTop (reader) cancels. Settle-fold clamps shrink
-  // scrollTop but land near-bottom, so they stay pinned.
+  // Unpin: wheel / keys always; pointer-armed geometric scroll-up only.
+  // Mid-turn fold + narration drops scrollTop while maxScroll stays flat —
+  // treating that as reader-up was the Jump-to-latest bug on soft-follow.
   const onScroll = () => {
     const node = scrollRef.current;
     if (!node) {
       return;
     }
     const previousTop = lastScrollTopRef.current;
+    const previousMaxScroll = lastMaxScrollRef.current;
     const nextTop = node.scrollTop;
-    lastScrollTopRef.current = nextTop;
+    const nextMaxScroll = maxScrollOf(node);
+    const nextHeight = node.scrollHeight;
+    const readerUp = readerScrollUpPx(previousTop, nextTop, previousMaxScroll, nextMaxScroll);
+    const maxFell = nextMaxScroll < previousMaxScroll - 1;
+    const readerArmed = readerIntentArmRef.current;
+    const heightShrunk =
+      followRef.current.lastHeight > 0 &&
+      nextHeight < followRef.current.lastHeight - TIP_FOLLOW_SHRINK_EPS_PX;
 
-    if (glidingRef.current) {
-      if (nextTop < previousTop - 1 && !isNearBottom(node)) {
-        stopGlide();
-        applyPinned(false);
-        if (wantPinRef.current) {
-          wantPinRef.current = false;
+    if (autoFollow && pinnedRef.current && !hasNewer) {
+      // Fold / composer shrink: compensate before baseline sync so driveFollow
+      // still sees the pre-shrink scrollTop (avoid double-subtract after clamp).
+      if (heightShrunk || maxFell) {
+        readerIntentArmRef.current = false;
+        driveFollow(node);
+        return;
+      }
+      syncScrollBaseline(node);
+      const nearBottomPinned = isNearBottom(node);
+      // Pointer-dragged scroll-up away from tip. Layout churn never arms this.
+      if (
+        readerArmed &&
+        readerUp > TIP_FOLLOW_READER_UP_EPS_PX &&
+        !nearBottomPinned
+      ) {
+        readerIntentArmRef.current = false;
+        releasePinFromReader(node);
+        if (olderLoadGateRef.current === "cooling" && node.scrollTop > OLDER_PREFETCH_MARGIN_PX) {
+          olderLoadGateRef.current = "armed";
         }
-        if (!olderPrefetchArmedRef.current) {
-          olderPrefetchArmedRef.current = true;
-          setOlderPrefetchArmed(true);
-        }
+        return;
+      }
+      // Growth debt / fold noise / camera echo: stay pinned and recover tip.
+      if (!nearBottomPinned || readerUp > TIP_FOLLOW_READER_UP_EPS_PX) {
+        driveFollow(node);
+      } else {
+        followRef.current = {
+          ...followRef.current,
+          lastHeight: nextHeight,
+        };
       }
       return;
     }
 
+    syncScrollBaseline(node);
     const nearBottom = isNearBottom(node);
-    const nextPinned = !hasNewer && nearBottom;
+
+    // Re-pin only when the reader moved toward/at the tip — not when a fold
+    // clamp dragged scrollTop down onto nearBottom.
+    const nextPinned =
+      !hasNewer && nearBottom && nextTop >= previousTop - TIP_FOLLOW_READER_UP_EPS_PX;
     if (!nextPinned) {
-      stopGlide();
+      stopFollow();
     }
     applyPinned(nextPinned);
     // A far-from-bottom scroll while a Jump-to-latest is pending is the reader
@@ -718,15 +932,20 @@ export function MessageTimeline({
 
   return (
     <LightboxProvider>
+      <FoldMemoryProvider value={foldMemoryRef.current}>
+      <SeenActivityIdsProvider value={seenActivityIdsRef.current}>
       <EntranceAnimationProvider value={!bulkRender}>
         <TooltipProvider delayDuration={400}>
         <div className={cn("og-root relative flex min-h-0 flex-col", className)}>
-          {/* Pinned: anchoring off so the soft tip-follow owns the motion.
+          {/* Pinned: anchoring off so the tip-follow camera owns the motion.
           Unpinned: native scroll anchoring holds the reader's place. */}
           <div
             ref={scrollRef}
             tabIndex={-1}
             onScroll={onScroll}
+            onWheel={onWheel}
+            onPointerDown={onPointerDown}
+            onKeyDown={onKeyDown}
             style={groups.length > 0 && !revealed ? { visibility: "hidden" } : undefined}
             className={cn(
               // tabIndex=-1 is programmatic only — never paint a focus ring on
@@ -738,7 +957,7 @@ export function MessageTimeline({
             )}
           >
             <div className="relative mx-auto flex w-full max-w-3xl flex-col gap-5">
-              {groups.length === 0 && !working
+              {groups.length === 0
                 ? (emptyState ?? (
                     <p className="py-10 text-center text-sm text-og-fg-subtle">No activity yet.</p>
                   ))
@@ -793,11 +1012,6 @@ export function MessageTimeline({
                   aria-hidden="true"
                   className="h-px w-full"
                 />
-              ) : null}
-              {working ? (
-                <div className="flex items-center gap-2 text-sm">
-                  <span className="og-shimmer-text font-medium">Working…</span>
-                </div>
               ) : null}
             </div>
           </div>
@@ -954,6 +1168,8 @@ export function MessageTimeline({
         </div>
         </TooltipProvider>
       </EntranceAnimationProvider>
+      </SeenActivityIdsProvider>
+      </FoldMemoryProvider>
     </LightboxProvider>
   );
 }
@@ -1071,7 +1287,8 @@ const TimelineGroupView = memo(function TimelineGroupView({
   /**
    * Parent turn has ≥2 foldable activity clusters. Only then do we wrap settled
    * clusters in nested chips — a single cluster under "N steps" is redundant.
-   * Suppressed while the outer settle beat is open so collapse is one layer.
+   * During outer settle chrome, nested chips stay force-open (structure kept,
+   * height stable) instead of flat-mapping to bare rails.
    */
   nestClusterChips?: boolean;
   /**
@@ -1084,7 +1301,8 @@ const TimelineGroupView = memo(function TimelineGroupView({
   contextCompactionCount?: number | undefined;
 }) {
   const enter = useEntranceAnimation();
-  const settleOpen = useTurnSettleOpen();
+  const settleChrome = useTurnSettleOpen();
+  const foldMemory = useFoldMemory();
   // Settled (or live-fold) activity clusters get a chip. Inside an expanded
   // turn that is the second layer — quiet nested chips under the outer turn
   // summary when contiguous activity naturally clusters (≥2 only).
@@ -1095,16 +1313,31 @@ const TimelineGroupView = memo(function TimelineGroupView({
   // start the settle beat without remounting bare rail → wrapper.
   const liveActivitySettle = useLiveSettleFold(activityShouldFold && !insideTurn);
   const turnDefaultOpen = !insideTurn && group.kind === "turn" && group.outcome === "failed";
+  // activity-* → turn-* remount: carry resting state so settleFold does not
+  // re-open a chip the reader already watched collapse.
+  if (group.kind === "turn" && foldMemory && !insideTurn) {
+    inheritFoldRestingState(
+      foldMemory,
+      group.id,
+      group.groups.flatMap((child) => (child.kind === "activity" ? [child.id] : [])),
+    );
+  }
   const settleFold =
     group.kind === "turn" ? Boolean(enter && !insideTurn && !turnDefaultOpen) : liveActivitySettle;
   switch (group.kind) {
     case "activity":
       if (insideTurn) {
-        // Nested chips only when the parent has ≥2 clusters AND the outer
-        // settle choreography is done. While settling (beat + collapse) the
-        // body stays a flat rail — one height to animate. Remounting closed
-        // nested chips when `open` flips false was the mid-collapse snap.
-        const useNestedChip = nestClusterChips && activityShouldFold && !settleOpen;
+        // Nested chips whenever the parent has ≥2 clusters. During outer settle
+        // chrome they stay force-open so structure is visible and height stays
+        // stable through collapse — never flat-map to bare rails (that flash
+        // was the "inner steps vanish then reappear nested" bug). Key flips
+        // when chrome clears so they remount closed inside the already-hidden
+        // parent (safe; mid-collapse remount of closed chips was the snap).
+        // foldKey memory overrides the force-open: a cluster that already
+        // settled closed pre-wrap was showing as a CHIP, so mounting it closed
+        // is both the stable height and the honest state — force-opening it
+        // was the "already-collapsed cluster auto-expands at the end" reopen.
+        const useNestedChip = nestClusterChips && activityShouldFold;
         if (!useNestedChip) {
           return (
             <ActivityRail
@@ -1118,10 +1351,13 @@ const TimelineGroupView = memo(function TimelineGroupView({
         }
         return (
           <TurnSummary
+            key={settleChrome ? "settle" : "rest"}
             items={group.items}
             outcome={group.outcome}
             failureText={undefined}
             bare
+            defaultOpen={settleChrome ? true : undefined}
+            foldKey={group.id}
             facets={turnSummary?.facets}
             contextCompactionCount={contextCompactionCount}
           >
@@ -1143,6 +1379,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
           outcome={group.outcome}
           failureText={group.failureText}
           defaultOpen={!activityShouldFold || group.outcome === "failed" ? true : undefined}
+          foldKey={group.id}
           facets={turnSummary?.facets}
           settleFold={settleFold}
           contextCompactionCount={contextCompactionCount}
@@ -1190,6 +1427,7 @@ const TimelineGroupView = memo(function TimelineGroupView({
           durationMs={durationBetween(group.startedAt, group.endedAt)}
           defaultOpen={turnDefaultOpen ? true : undefined}
           bare={insideTurn}
+          foldKey={group.id}
           facets={turnSummary?.facets}
           settleFold={settleFold}
           copyText={insideTurn ? undefined : turnCopyText}
@@ -1221,14 +1459,12 @@ const TimelineGroupView = memo(function TimelineGroupView({
 });
 
 /**
- * Rows revealed by a disclosure — expanding a chip, or the settle-fold beat —
- * must not run per-row entrance animations: the disclosure's height animation
- * owns the motion, and rows that were ALREADY visible when a live cluster
- * folds would otherwise flash as they remount inside the summary. Entrance
- * stays reserved for rows arriving in the live timeline flow.
+ * Body under a turn/activity chip. Remount flashes are gated by the timeline
+ * seen-activity-id map (not by killing entrance): FoldBody used to force
+ * entrance off, which made every live tool pop with no fade.
  */
 function FoldBody({ children }: { children: ReactNode }) {
-  return <EntranceAnimationProvider value={false}>{children}</EntranceAnimationProvider>;
+  return <>{children}</>;
 }
 
 /** Stable left rule for turn/activity bodies — always present so settle wrap
@@ -1597,8 +1833,7 @@ function AgentMessageRow({
 }) {
   const enter = useEntranceAnimation();
   // No streaming caret: it fought the trailing block layout (inline ↔ block)
-  // and snapped on exit. Live text already carries the stream via word-entrance
-  // + "Working…" when the tip isn't a streaming message.
+  // and snapped on exit. Live text carries the stream via tip ink.
   const body = renderMessageText ? (
     renderMessageText(item.text, item)
   ) : (

--- a/packages/react/src/components/soften-streaming-markdown.ts
+++ b/packages/react/src/components/soften-streaming-markdown.ts
@@ -18,10 +18,16 @@ export function softenStreamingMarkdown(source: string): string {
   let text = source;
 
   // Unclosed fenced code block: an odd count of ``` line-openers means the
-  // trailing fence is still in flight. Close it so the body paints as a code
-  // block instead of leaking ``` into prose.
+  // trailing fence is still in flight. Always soft-close — including an empty
+  // opener — so code chrome (padding/tint) appears once at ``` and lines only
+  // grow the body. Stripping empty openers deferred chrome until the first
+  // body line, which landed as one fat height spike (yank around fences).
+  //
+  // If the body already ends with `\n`, append only ``` — a second `\n``` would
+  // invent a blank line that vanishes when the real closer lands (height shrink
+  // → tip-follow compensate + mid soft-rise cancel = up/down flicker).
   if (countFences(text) % 2 === 1) {
-    text += "\n```";
+    text += text.endsWith("\n") ? "```" : "\n```";
   }
 
   // Work outside fenced blocks so we don't "fix" markers that are literal
@@ -59,11 +65,22 @@ function splitByFences(text: string): Segment[] {
   const lines = text.split("\n");
   let buf: string[] = [];
   let inFence = false;
-  const flush = (kind: Segment["kind"]) => {
+  /**
+   * `boundary`: prose → fence. `join` alone drops a blank line before ```
+   * (`["a",""].join` → `"a\n"`, need `"a\n\n"`), so append an extra `\n`.
+   * `end`: final segment. Trailing `""` from `split("\n")` already encodes a
+   * terminating newline — do NOT append another (that was inventing `\n\n`
+   * on every streamed line and shrinking it away at crystallize).
+   */
+  const flush = (kind: Segment["kind"], mode: "boundary" | "end") => {
     if (buf.length === 0) {
       return;
     }
-    segments.push({ kind, value: buf.join("\n") });
+    let value = buf.join("\n");
+    if (mode === "boundary") {
+      value += "\n";
+    }
+    segments.push({ kind, value });
     buf = [];
   };
   for (const line of lines) {
@@ -71,10 +88,10 @@ function splitByFences(text: string): Segment[] {
     if (isFence) {
       if (inFence) {
         buf.push(line);
-        flush("fence");
+        flush("fence", "end");
         inFence = false;
       } else {
-        flush("prose");
+        flush("prose", "boundary");
         buf.push(line);
         inFence = true;
       }
@@ -82,7 +99,7 @@ function splitByFences(text: string): Segment[] {
     }
     buf.push(line);
   }
-  flush(inFence ? "fence" : "prose");
+  flush(inFence ? "fence" : "prose", "end");
   return segments;
 }
 
@@ -117,7 +134,16 @@ function closeDelimiter(text: string, delimiter: string): string {
     }
     i += 1;
   }
-  return count % 2 === 1 ? text + delimiter : text;
+  return count % 2 === 1 ? insertBeforeTrailingNewlines(text, delimiter) : text;
+}
+
+/** Soft closers belong before trailing `\n`s so restore/round-trip stay stable. */
+function insertBeforeTrailingNewlines(text: string, suffix: string): string {
+  let end = text.length;
+  while (end > 0 && text[end - 1] === "\n") {
+    end -= 1;
+  }
+  return text.slice(0, end) + suffix + text.slice(end);
 }
 
 function closeSingleBackticks(text: string): string {
@@ -138,7 +164,7 @@ function closeSingleBackticks(text: string): string {
       count += 1;
     }
   }
-  return count % 2 === 1 ? `${text}\`` : text;
+  return count % 2 === 1 ? insertBeforeTrailingNewlines(text, "`") : text;
 }
 
 function closeSingleAsterisks(text: string): string {
@@ -157,7 +183,7 @@ function closeSingleAsterisks(text: string): string {
       count += 1;
     }
   }
-  return count % 2 === 1 ? `${text}*` : text;
+  return count % 2 === 1 ? insertBeforeTrailingNewlines(text, "*") : text;
 }
 
 function closeUnfinishedLink(text: string): string {
@@ -175,5 +201,5 @@ function closeUnfinishedLink(text: string): string {
   if (after.includes("[")) {
     return text;
   }
-  return `${text})`;
+  return insertBeforeTrailingNewlines(text, ")");
 }

--- a/packages/react/src/components/stream-reveal.ts
+++ b/packages/react/src/components/stream-reveal.ts
@@ -17,8 +17,10 @@
    Runs settle back to plain text once age ≥ INK_FADE_MS (zero span cost).
    -------------------------------------------------------------------------- */
 
+import { MOTION_INSPECT_SCALE } from "../lib/motion-inspect";
+
 /** Keep in sync with `--og-duration-stream` / `.og-stream-ink` in styles. */
-export const INK_FADE_MS = 1100;
+export const INK_FADE_MS = 420 * MOTION_INSPECT_SCALE;
 /** @deprecated Use {@link INK_FADE_MS}. */
 export const WORD_ANIMATION_MS = INK_FADE_MS;
 

--- a/packages/react/src/components/tip-follow.ts
+++ b/packages/react/src/components/tip-follow.ts
@@ -238,10 +238,7 @@ export function tipFollowMaxStepPx(
   }
   if (hot && growthVelocityPxPerSec > TIP_FOLLOW_CALM_MAX_PX_S) {
     // Live stream: slightly outrun the EMA so tip-debt cannot ratchet forever.
-    maxPxS = Math.max(
-      maxPxS,
-      Math.min(TIP_FOLLOW_BURST_MAX_PX_S, growthVelocityPxPerSec * 1.25),
-    );
+    maxPxS = Math.max(maxPxS, Math.min(TIP_FOLLOW_BURST_MAX_PX_S, growthVelocityPxPerSec * 1.25));
   }
   if (hot && absDebt > 8) {
     // Continuous debt horizon (no catch-up cliff at CATCHUP_DEBT).

--- a/packages/react/src/components/tip-follow.ts
+++ b/packages/react/src/components/tip-follow.ts
@@ -1,0 +1,462 @@
+/* ----------------------------------------------------------------------------
+   Tip-follow camera (pure)
+
+   DOM truth is immediate; the camera eases down toward the layout tip.
+   No React, no DOM — the shell reads metrics, calls step, writes scrollTop.
+
+   One law while pinned — second-order camera (no hard first bite):
+
+     desiredVel = debt / τ
+     scrollVel  → exponential approach to desiredVel (accel τ = k·τ)
+     scrollTop += scrollVel · dt   (clamp: no overshoot past tip)
+
+   - Debt jumps with layout; velocity cannot — so motion eases in, then as
+     debt falls desiredVel→0 and velocity eases out (soft settle).
+   - τ still adapts (calm / catch-up / line / idle settle).
+   - maxStep is a speed ceiling only, never a one-frame glue.
+   - Shrink is separate: compensate Δh so collapse doesn't fight the ease
+   - Snap only for first paint / reduced motion / cold oversized jumps
+   -------------------------------------------------------------------------- */
+
+import { MOTION_INSPECT_SCALE } from "../lib/motion-inspect";
+
+const _t = (ms: number) => ms * MOTION_INSPECT_SCALE;
+const _s = (pxPerSec: number) => pxPerSec / MOTION_INSPECT_SCALE;
+
+/** Calm ease while live: remaining debt shrinks ~63% every τ_max ms. */
+export const TIP_FOLLOW_TAU_MAX_MS = _t(720);
+/** Catch-up ease under large tip-debt (reader far behind / big paste). */
+export const TIP_FOLLOW_TAU_MIN_MS = _t(200);
+/**
+ * Idle settle τ — stream quiet, soft landing into the tip. Longer than live
+ * calm so the last pixels decelerate instead of linear-crawling then stopping.
+ */
+export const TIP_FOLLOW_SETTLE_TAU_MS = _t(960);
+/** Debt that saturates urgency toward τ_min. */
+export const TIP_FOLLOW_CATCHUP_DEBT_PX = 240;
+/** Keep the rAF alive this long after the last height growth. */
+export const TIP_FOLLOW_HOT_IDLE_MS = _t(320);
+/** Cold oversized debt snaps (session switch / huge fold), not eases. */
+export const TIP_FOLLOW_SNAP_PX = 480;
+/** Soft speed floor while live with tiny debt (px/s). */
+export const TIP_FOLLOW_CALM_MAX_PX_S = _s(42);
+/** Soft speed ceiling while catching a fast stream / modest tip-debt (px/s). */
+export const TIP_FOLLOW_BURST_MAX_PX_S = _s(420);
+/** Ceiling for huge tip-debt / large single-frame walls (px/s). */
+export const TIP_FOLLOW_SURGE_MAX_PX_S = _s(1800);
+/**
+ * @deprecated Position growth-track removed — camera is velocity-smoothed.
+ * Kept so older tests/imports do not break.
+ */
+export const TIP_FOLLOW_GROWTH_TRACK = 0;
+/** @deprecated */
+export const TIP_FOLLOW_LINE_TRACK = 0;
+/** @deprecated Sub-line special-case removed with growth-track. */
+export const TIP_FOLLOW_TOKEN_GROWTH_PX = 10;
+/** Hot line-sized tip-debt uses the short {@link TIP_FOLLOW_LINE_TAU_MS}. */
+export const TIP_FOLLOW_LINE_GROWTH_PX = 48;
+/** Hot τ ceiling while closing a line-sized tip-debt (ms). */
+export const TIP_FOLLOW_LINE_TAU_MS = _t(140);
+/**
+ * Velocity ease-in/out: scrollVel approaches desiredVel with this fraction of τ.
+ * Lower → snappier accel; higher → softer start (and slower reaction).
+ */
+export const TIP_FOLLOW_ACCEL_TAU_FRAC = 0.45;
+/** @deprecated Soft-rise FLIP removed — line glue was the bug. */
+export const TIP_FOLLOW_SOFT_RISE_MS = 0;
+/** @deprecated */
+export const TIP_FOLLOW_SOFT_RISE_MAX_PX = 96;
+/** @deprecated */
+export const TIP_FOLLOW_SOFT_RISE_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
+/** Ignore sub-pixel / reflow height noise for shrink compensate. */
+export const TIP_FOLLOW_SHRINK_EPS_PX = 4;
+/** Growth speed (px/s) that saturates velocity urgency. */
+export const TIP_FOLLOW_VELOCITY_REF_PX_S = _s(420);
+/**
+ * Tip-debt below which growth velocity must not tighten τ.
+ * Sparse tokens are high-velocity by nature; only arm once actually behind.
+ */
+export const TIP_FOLLOW_VELOCITY_ARM_DEBT_PX = 72;
+/** EMA decay τ for growthVelocity when height is flat (ms). */
+export const TIP_FOLLOW_VELOCITY_DECAY_MS = _t(180);
+/** Reader-up pixels above clamp budget that count as leaving the tip. */
+export const TIP_FOLLOW_READER_UP_EPS_PX = 2;
+/** @deprecated Shrink lock removed; kept so old imports do not break. */
+export const TIP_FOLLOW_SHRINK_LOCK_MS = 0;
+/** @deprecated Absorb thresholds removed — growth track is continuous. */
+export const TIP_FOLLOW_GROWTH_ABSORB_PX = 96;
+
+/**
+ * ScrollTop decrease not explained by a maxScroll clamp (fold / composer
+ * shrink). Fold clamp: top falls by ≈ maxScroll fall → 0. Real scroll-up:
+ * top falls while maxScroll holds → positive. No timers.
+ */
+export function readerScrollUpPx(
+  prevTop: number,
+  nextTop: number,
+  prevMaxScroll: number,
+  nextMaxScroll: number,
+): number {
+  const topDelta = prevTop - nextTop;
+  const clampBudget = Math.max(0, prevMaxScroll - nextMaxScroll);
+  return topDelta - clampBudget;
+}
+
+export type TipFollowState = {
+  running: boolean;
+  hotUntil: number;
+  lastTs: number;
+  lastHeight: number;
+  lastGrowthAt: number;
+  /** EMA of recent height growth (px/s); nudges τ / ceiling under bursts. */
+  growthVelocity: number;
+  /** Camera velocity toward tip (px/s). Smoothed — never jumps with debt. */
+  scrollVelocity: number;
+};
+
+export type TipFollowStepInput = {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  now: number;
+  pinned: boolean;
+  reducedMotion: boolean;
+  revealed: boolean;
+};
+
+export type TipFollowStepResult = {
+  scrollTop: number;
+  state: TipFollowState;
+};
+
+export function createTipFollowState(): TipFollowState {
+  return {
+    running: false,
+    hotUntil: 0,
+    lastTs: 0,
+    lastHeight: 0,
+    lastGrowthAt: 0,
+    growthVelocity: 0,
+    scrollVelocity: 0,
+  };
+}
+
+export function tipFollowCancel(state: TipFollowState): TipFollowState {
+  return {
+    ...state,
+    running: false,
+    lastTs: 0,
+    scrollVelocity: 0,
+  };
+}
+
+/**
+ * Record content height. Positive growth extends the hot window so sparse
+ * lines do not tear down the follow loop between appends.
+ */
+export function tipFollowNoteGrowth(
+  state: TipFollowState,
+  height: number,
+  now: number,
+): TipFollowState {
+  const previous = state.lastHeight;
+  if (previous <= 0) {
+    return { ...state, lastHeight: height };
+  }
+  if (height <= previous) {
+    return { ...state, lastHeight: height };
+  }
+  const dt = state.lastGrowthAt > 0 ? now - state.lastGrowthAt : 0;
+  let growthVelocity = state.growthVelocity;
+  if (dt > 0) {
+    const instant = ((height - previous) / dt) * 1000;
+    growthVelocity = growthVelocity * 0.65 + instant * 0.35;
+  }
+  return {
+    ...state,
+    lastHeight: height,
+    lastGrowthAt: now,
+    growthVelocity,
+    hotUntil: now + TIP_FOLLOW_HOT_IDLE_MS,
+  };
+}
+
+/**
+ * Adaptive τ: small debt → calm; large debt / armed velocity → catch-up.
+ * While hot, floor urgency so live streams are not stuck on calm τ.
+ * Idle settle uses the longer settle τ.
+ */
+export function tipFollowTauMs(
+  debtPx: number,
+  growthVelocityPxPerSec = 0,
+  settling = false,
+  hot = false,
+): number {
+  if (settling) {
+    return TIP_FOLLOW_SETTLE_TAU_MS;
+  }
+  const absDebt = Math.abs(debtPx);
+  const debtT = Math.min(1, absDebt / TIP_FOLLOW_CATCHUP_DEBT_PX);
+  let velUrgency = 0;
+  if (absDebt >= TIP_FOLLOW_VELOCITY_ARM_DEBT_PX) {
+    const velT = Math.min(1, Math.max(0, growthVelocityPxPerSec) / TIP_FOLLOW_VELOCITY_REF_PX_S);
+    velUrgency = velT * 0.55;
+  }
+  const hotUrgency = hot ? 0.65 : 0;
+  const urgency = Math.min(1, Math.max(debtT, velUrgency, hotUrgency));
+  let tau = TIP_FOLLOW_TAU_MAX_MS + (TIP_FOLLOW_TAU_MIN_MS - TIP_FOLLOW_TAU_MAX_MS) * urgency;
+  // Line-sized live debt: close over ~LINE_TAU so the glide finishes before
+  // the next newline without needing 1:1 tip-glue.
+  if (hot && absDebt > 0 && absDebt <= TIP_FOLLOW_LINE_GROWTH_PX) {
+    tau = Math.min(tau, TIP_FOLLOW_LINE_TAU_MS);
+  }
+  return tau;
+}
+
+/**
+ * Soft speed ceiling from continuous signals (debt, velocity EMA, this-frame
+ * growth). No mode switches — larger inputs raise the ceiling smoothly.
+ */
+export function tipFollowMaxStepPx(
+  debtPx: number,
+  growthVelocityPxPerSec: number,
+  dtMs: number,
+  frameGrowthPx = 0,
+  hot = false,
+): number {
+  const absDebt = Math.abs(debtPx);
+  const debtT = Math.min(1, absDebt / TIP_FOLLOW_CATCHUP_DEBT_PX);
+  const velT = Math.min(1, Math.max(0, growthVelocityPxPerSec) / TIP_FOLLOW_VELOCITY_REF_PX_S);
+  const armed = absDebt >= TIP_FOLLOW_VELOCITY_ARM_DEBT_PX;
+  const blend = Math.max(debtT, armed ? velT : 0, hot ? 0.35 : 0);
+  let maxPxS =
+    TIP_FOLLOW_CALM_MAX_PX_S +
+    (TIP_FOLLOW_BURST_MAX_PX_S - TIP_FOLLOW_CALM_MAX_PX_S) * blend * blend;
+  if (hot && frameGrowthPx > 0 && dtMs > 0) {
+    // Allow tracking this frame's growth rate (growthTrack uses a fraction).
+    maxPxS = Math.max(maxPxS, (frameGrowthPx / dtMs) * 1000);
+  }
+  if (hot && growthVelocityPxPerSec > TIP_FOLLOW_CALM_MAX_PX_S) {
+    // Live stream: slightly outrun the EMA so tip-debt cannot ratchet forever.
+    maxPxS = Math.max(
+      maxPxS,
+      Math.min(TIP_FOLLOW_BURST_MAX_PX_S, growthVelocityPxPerSec * 1.25),
+    );
+  }
+  if (hot && absDebt > 8) {
+    // Continuous debt horizon (no catch-up cliff at CATCHUP_DEBT).
+    maxPxS = Math.max(maxPxS, Math.min(TIP_FOLLOW_SURGE_MAX_PX_S, absDebt / 0.2));
+  } else if (absDebt >= TIP_FOLLOW_CATCHUP_DEBT_PX) {
+    maxPxS = Math.max(maxPxS, Math.min(TIP_FOLLOW_SURGE_MAX_PX_S, absDebt / 0.12));
+  }
+  return (maxPxS / 1000) * dtMs;
+}
+
+function targetScrollTop(scrollHeight: number, clientHeight: number): number {
+  return Math.max(0, scrollHeight - clientHeight);
+}
+
+/**
+ * Counter-offset for soft-rise after tip-glue: start from the mid-flight
+ * translateY (if any) plus this frame's glued scroll delta, capped.
+ * Shell applies translateY(from) → 0 over {@link TIP_FOLLOW_SOFT_RISE_MS}.
+ */
+export function tipFollowSoftRiseFrom(
+  currentTranslateY: number,
+  gluedScrollDelta: number,
+  maxPx: number = TIP_FOLLOW_SOFT_RISE_MAX_PX,
+): number {
+  const stacked = Math.max(0, currentTranslateY) + Math.max(0, gluedScrollDelta);
+  return Math.min(maxPx, stacked);
+}
+
+/** Read live translateY from a transformed content column (mid soft-rise). */
+export function readTranslateY(el: HTMLElement): number {
+  const raw = getComputedStyle(el).transform;
+  if (!raw || raw === "none") {
+    return 0;
+  }
+  try {
+    return new DOMMatrixReadOnly(raw).m42;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Cancel the tip-glue pop: start at translateY(+δ) and ease to 0.
+ * Uses WAAPI — a same-frame CSS transition never paints the counter-offset,
+ * so the scroll jump stays an instant one-line pop.
+ */
+export function tipFollowPlaySoftRise(
+  el: HTMLElement,
+  gluedScrollDelta: number,
+  opts?: {
+    durationMs?: number;
+    maxPx?: number;
+    easing?: string;
+  },
+): void {
+  if (gluedScrollDelta <= 0.5) {
+    return;
+  }
+  const durationMs = opts?.durationMs ?? TIP_FOLLOW_SOFT_RISE_MS;
+  const maxPx = opts?.maxPx ?? TIP_FOLLOW_SOFT_RISE_MAX_PX;
+  const easing = opts?.easing ?? TIP_FOLLOW_SOFT_RISE_EASING;
+  const from = tipFollowSoftRiseFrom(readTranslateY(el), gluedScrollDelta, maxPx);
+  if (from <= 0.5) {
+    return;
+  }
+  // Drop any in-flight rise / leftover CSS transition before starting clean.
+  if (typeof el.getAnimations === "function") {
+    for (const animation of el.getAnimations()) {
+      animation.cancel();
+    }
+  }
+  el.style.transition = "";
+  // Hold the counter-offset in style until WAAPI’s first keyframe applies.
+  // Clearing to "" here painted one frame of hard tip-glue (the pop).
+  el.style.transform = `translateY(${from}px)`;
+  if (typeof el.animate !== "function") {
+    return;
+  }
+  const animation = el.animate(
+    [{ transform: `translateY(${from}px)` }, { transform: "translateY(0px)" }],
+    // `backwards`: first keyframe applies immediately (no gap after cancel).
+    { duration: durationMs, easing, fill: "backwards" },
+  );
+  const clearHold = () => {
+    if (el.style.transform === `translateY(${from}px)`) {
+      el.style.transform = "";
+    }
+  };
+  animation.addEventListener("finish", clearHold, { once: true });
+  animation.addEventListener("cancel", clearHold, { once: true });
+}
+
+/** Stop soft-rise and clear any CSS transform residue. */
+export function tipFollowClearSoftRise(el: HTMLElement): void {
+  if (typeof el.getAnimations === "function") {
+    for (const animation of el.getAnimations()) {
+      animation.cancel();
+    }
+  }
+  el.style.transition = "";
+  el.style.transform = "";
+}
+
+/**
+ * Height left the document (settle collapse / composer). Keep the same pixels
+ * on screen: scrollTop -= Δh, clamped to the new max.
+ */
+export function tipFollowCompensateShrink(
+  scrollTop: number,
+  previousHeight: number,
+  nextHeight: number,
+  clientHeight: number,
+  epsPx: number = TIP_FOLLOW_SHRINK_EPS_PX,
+): number {
+  const delta = previousHeight - nextHeight;
+  if (delta <= epsPx) {
+    return scrollTop;
+  }
+  const maxScroll = Math.max(0, nextHeight - clientHeight);
+  return Math.max(0, Math.min(maxScroll, scrollTop - delta));
+}
+
+/**
+ * One camera step. Shell schedules the next rAF while `result.state.running`.
+ */
+export function tipFollowStep(
+  state: TipFollowState,
+  input: TipFollowStepInput,
+): TipFollowStepResult {
+  const { scrollTop, scrollHeight, clientHeight, now, pinned, reducedMotion, revealed } = input;
+  const previousHeight = state.lastHeight;
+  const frameGrowth =
+    previousHeight > 0 && scrollHeight > previousHeight ? scrollHeight - previousHeight : 0;
+  const grew = frameGrowth > 0;
+  let noted = tipFollowNoteGrowth(state, scrollHeight, now);
+  const target = targetScrollTop(scrollHeight, clientHeight);
+  const debt = target - scrollTop;
+  const hot = now < noted.hotUntil;
+  const settling = !hot && Math.abs(debt) < TIP_FOLLOW_CATCHUP_DEBT_PX;
+
+  if (!pinned) {
+    return {
+      scrollTop,
+      state: tipFollowCancel(noted),
+    };
+  }
+
+  if (!revealed || reducedMotion) {
+    return {
+      scrollTop: target,
+      state: tipFollowCancel(noted),
+    };
+  }
+
+  if (Math.abs(debt) > TIP_FOLLOW_SNAP_PX && !hot) {
+    return {
+      scrollTop: target,
+      state: tipFollowCancel(noted),
+    };
+  }
+
+  const dt = noted.lastTs === 0 ? 16 : Math.min(64, Math.max(8, now - noted.lastTs));
+  if (!grew && noted.growthVelocity > 0) {
+    const decayed = noted.growthVelocity * Math.exp(-dt / TIP_FOLLOW_VELOCITY_DECAY_MS);
+    noted = {
+      ...noted,
+      growthVelocity: decayed < 1 ? 0 : decayed,
+    };
+  }
+
+  if (Math.abs(debt) <= 0.75) {
+    return {
+      scrollTop: Math.abs(debt) > 0 ? target : scrollTop,
+      state: {
+        ...tipFollowCancel(noted),
+        growthVelocity: hot ? noted.growthVelocity : 0,
+      },
+    };
+  }
+
+  const tau = tipFollowTauMs(debt, noted.growthVelocity, settling, hot);
+  const dtSec = dt / 1000;
+  const tauSec = Math.max(tau / 1000, 1e-3);
+  // P-gain: held desiredVel would close debt in ~τ. Velocity cannot jump —
+  // it eases toward desiredVel, so a new line accelerates in then settles out.
+  const desiredVel = debt / tauSec;
+  const accelTauSec = Math.max(tauSec * TIP_FOLLOW_ACCEL_TAU_FRAC, 0.02);
+  const velAlpha = 1 - Math.exp(-dtSec / accelTauSec);
+  let scrollVelocity =
+    (noted.scrollVelocity ?? 0) + (desiredVel - (noted.scrollVelocity ?? 0)) * velAlpha;
+
+  const maxStep = tipFollowMaxStepPx(debt, noted.growthVelocity, dt, frameGrowth, hot);
+  const maxVel = maxStep / dtSec;
+  if (Math.abs(scrollVelocity) > maxVel) {
+    scrollVelocity = Math.sign(scrollVelocity) * maxVel;
+  }
+
+  let next = scrollTop + scrollVelocity * dtSec;
+  // Never overshoot the tip — stop and kill velocity on arrival.
+  if (debt > 0 && next >= target - 0.35) {
+    next = target;
+    scrollVelocity = 0;
+  } else if (debt < 0 && next <= target + 0.35) {
+    next = target;
+    scrollVelocity = 0;
+  }
+  next = Math.max(0, next);
+
+  return {
+    scrollTop: next,
+    state: {
+      ...noted,
+      scrollVelocity,
+      running: Math.abs(target - next) > 0.35 || Math.abs(scrollVelocity) > 1,
+      lastTs: now,
+    },
+  };
+}

--- a/packages/react/src/lib/motion-inspect.ts
+++ b/packages/react/src/lib/motion-inspect.ts
@@ -1,0 +1,5 @@
+/**
+ * TEMP eyeball scale for vertical motion (tip-follow, settle fold, CSS).
+ * Set back to `1` before landing — not a product knob.
+ */
+export const MOTION_INSPECT_SCALE = 1;

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -11,8 +11,9 @@ import { Markdown } from "../components/markdown";
 import { cn } from "../lib/cn";
 import { truncate } from "../lib/format";
 import { defaultToolRegistry } from "./tool-renderers";
-import { useEntranceAnimation } from "./entrance";
+import { useEntranceAnimation, useEntranceAnimationLive } from "./entrance";
 import type { ToolRegistry } from "./registry";
+import { useSeenActivityIds } from "./seen-activity-ids";
 import { BodyNote, PayloadBlock, ActivityDisclosure } from "./shared";
 import { toolDisplayName } from "./tool-display-name";
 import type { ActivityItem, MemoryItem, ReasoningItem, SandboxItem, WorkerItem } from "./types";
@@ -67,23 +68,33 @@ export function ActivityRail({
   bare,
   className,
 }: ActivityRailProps) {
-  const enter = useEntranceAnimation();
-  // Per-row soft entrance for items that APPEND while this rail is live.
-  // First paint of the rail (history, bulk hydrate, settle-fold remount)
-  // must NOT animate every row — that was the hard "outer steps snap"
-  // when a whole cluster remounted. Only ids that appear after the rail
-  // already had a previous commit earn the row-enter breath.
+  const enterMounted = useEntranceAnimation();
+  // Live gate: rails born during bulk capture enter=false forever; with a
+  // seen-id map we still want later live appends to fade (ids gate remounts).
+  const enterLive = useEntranceAnimationLive();
+  const seenIds = useSeenActivityIds();
+  const enter = seenIds ? enterLive : enterMounted;
   const previousIdsRef = useRef<Set<string> | null>(null);
   const enteringIds = new Set<string>();
-  if (enter && previousIdsRef.current !== null) {
+  if (enter) {
     for (const item of items) {
-      if (!previousIdsRef.current.has(item.id)) {
+      if (seenIds) {
+        if (!seenIds.has(item.id)) {
+          enteringIds.add(item.id);
+        }
+      } else if (previousIdsRef.current !== null && !previousIdsRef.current.has(item.id)) {
+        // Standalone ActivityRail (tests / demo): append-only, no remount map.
         enteringIds.add(item.id);
       }
     }
   }
   useLayoutEffect(() => {
     previousIdsRef.current = new Set(items.map((item) => item.id));
+    if (seenIds) {
+      for (const item of items) {
+        seenIds.add(item.id);
+      }
+    }
   });
   return (
     <div
@@ -93,9 +104,9 @@ export function ActivityRail({
         // so a long rail reads as a few clusters, not a metronome of rows.
         "flex flex-col gap-0.5",
         !bare && "border-l-2 border-og-border pl-3 sm:pl-4",
-        // Whole-rail enter only on the rail's first live paint (no prior ids).
-        // Subsequent appends animate the new row alone — softer, no re-flash.
-        !bare && enter && previousIdsRef.current === null && "animate-og-enter",
+        // Whole-rail enter: standalone rails only (no seen-id map). Inside
+        // MessageTimeline, unknown ids take per-row enter — remounts stay quiet.
+        !bare && enter && !seenIds && previousIdsRef.current === null && "animate-og-enter",
         className,
       )}
     >

--- a/packages/react/src/timeline/entrance.tsx
+++ b/packages/react/src/timeline/entrance.tsx
@@ -19,6 +19,16 @@ const EntranceAnimationContext = createContext(true);
 export const EntranceAnimationProvider = EntranceAnimationContext.Provider;
 
 /**
+ * Live entrance gate from the nearest provider. Prefer
+ * {@link useEntranceAnimation} for elements that must freeze the decision at
+ * mount; use this when a stable parent (e.g. ActivityRail) needs to animate
+ * later appends after a bulk window clears.
+ */
+export function useEntranceAnimationLive(): boolean {
+  return useContext(EntranceAnimationContext);
+}
+
+/**
  * Whether this element should wear the entrance animation. Captured at mount
  * from the nearest provider (true outside any provider) and stable for the
  * element's lifetime — see the module doctrine above.

--- a/packages/react/src/timeline/fold-memory.ts
+++ b/packages/react/src/timeline/fold-memory.ts
@@ -1,0 +1,52 @@
+import { createContext, useContext } from "react";
+
+/* ----------------------------------------------------------------------------
+   Fold memory
+
+   Remembers, per durable timeline group id, that a fold reached a RESTING
+   state: "closed" when the settle choreography finished its collapse or the
+   reader closed the chip by hand, "open" when the reader explicitly expanded
+   it. The map lives OUTSIDE the component tree because the timeline
+   deliberately remounts chips with fresh keys (the activity→turn wrap, the
+   nested-chip key flip around settle chrome) — and a remount must never
+   forget that the reader already watched this cluster fold. Re-opening an
+   already-settled fold reads as the timeline undoing its own choreography.
+
+   With no provider the hook returns null and every fold keeps its
+   author-chosen default — standalone TurnSummary usage is unchanged.
+   -------------------------------------------------------------------------- */
+
+export type FoldRestingState = "open" | "closed";
+
+const FoldMemoryContext = createContext<Map<string, FoldRestingState> | null>(null);
+
+/** Provide a per-timeline resting-state map (MessageTimeline owns one). */
+export const FoldMemoryProvider = FoldMemoryContext.Provider;
+
+/** The ancestor fold-memory map, or null when none is mounted (inert). */
+export function useFoldMemory(): Map<string, FoldRestingState> | null {
+  return useContext(FoldMemoryContext);
+}
+
+/**
+ * Single-cluster activity→turn wrap: copy the activity resting state onto the
+ * new turn-* key. Those ids differ across the wrap; without this the turn
+ * remounts settleFold and re-opens a chip the reader already watched collapse.
+ *
+ * Multi-cluster wraps deliberately do NOT inherit — the outer turn chip is new
+ * and still takes one settle beat; nested clusters keep their own activity-*
+ * memory so they stay closed under that beat.
+ */
+export function inheritFoldRestingState(
+  memory: Map<string, FoldRestingState>,
+  targetKey: string,
+  sourceKeys: readonly string[],
+): void {
+  if (memory.has(targetKey) || sourceKeys.length !== 1) {
+    return;
+  }
+  const state = memory.get(sourceKeys[0]!);
+  if (state !== undefined) {
+    memory.set(targetKey, state);
+  }
+}

--- a/packages/react/src/timeline/index.ts
+++ b/packages/react/src/timeline/index.ts
@@ -86,6 +86,17 @@ export { LightboxProvider, useLightbox, useLightboxOptional } from "./screenshot
 // disclosure defaults (opt-in initial-open seed; for screenshot/test instrumentation)
 export { DisclosureDefaultsProvider, useForcedDefaultOpen } from "./disclosure-context";
 
+// fold memory (cross-remount resting state so wraps never reopen settled folds)
+export {
+  FoldMemoryProvider,
+  inheritFoldRestingState,
+  useFoldMemory,
+} from "./fold-memory";
+export type { FoldRestingState } from "./fold-memory";
+
+// seen activity ids (live tool enter across rail remounts)
+export { SeenActivityIdsProvider, useSeenActivityIds } from "./seen-activity-ids";
+
 // turn-collapse summary chip
 export { BUILT_IN_TURN_SUMMARY_FACET_IDS, TurnSummary, useTurnSettleOpen } from "./turn-summary";
 export type {

--- a/packages/react/src/timeline/index.ts
+++ b/packages/react/src/timeline/index.ts
@@ -87,11 +87,7 @@ export { LightboxProvider, useLightbox, useLightboxOptional } from "./screenshot
 export { DisclosureDefaultsProvider, useForcedDefaultOpen } from "./disclosure-context";
 
 // fold memory (cross-remount resting state so wraps never reopen settled folds)
-export {
-  FoldMemoryProvider,
-  inheritFoldRestingState,
-  useFoldMemory,
-} from "./fold-memory";
+export { FoldMemoryProvider, inheritFoldRestingState, useFoldMemory } from "./fold-memory";
 export type { FoldRestingState } from "./fold-memory";
 
 // seen activity ids (live tool enter across rail remounts)

--- a/packages/react/src/timeline/seen-activity-ids.ts
+++ b/packages/react/src/timeline/seen-activity-ids.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+
+/* ----------------------------------------------------------------------------
+   Seen activity ids
+
+   ActivityRails remount across fold wraps / settle key flips. A per-rail
+   previousIds set resets on remount, so either every row re-fades (flash) or
+   the first live tool never animates (pop). This map lives on MessageTimeline
+   and records every activity id that has already painted — live appends of
+   unknown ids earn row-enter; remounts of known ids stay quiet.
+   -------------------------------------------------------------------------- */
+
+const SeenActivityIdsContext = createContext<Set<string> | null>(null);
+
+export const SeenActivityIdsProvider = SeenActivityIdsContext.Provider;
+
+export function useSeenActivityIds(): Set<string> | null {
+  return useContext(SeenActivityIdsContext);
+}

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -35,10 +35,11 @@ export type { TurnOutcome } from "./types";
 const TurnSettleChromeContext = createContext(false);
 
 /**
- * True for the whole settle choreography — open beat AND the slow collapse.
- * Nested cluster chips must stay suppressed until this clears: the moment
- * collapse starts (`open` flips false) used to remount closed inner chips and
- * yank the content height mid-animation (the ugly snap).
+ * Suppress nested cluster chips while the settle choreography (or a latch
+ * after cancel-close) is flattening the body. Nested chips must not remount
+ * when `open` flips false mid-collapse — that remount yanked height (snap).
+ * Also stays true briefly after the reader cancels settle, through the fast
+ * collapse window, so cancel does not reintroduce the same remount.
  */
 export function useTurnSettleOpen(): boolean {
   return useContext(TurnSettleChromeContext);
@@ -160,6 +161,8 @@ export type TurnSummaryProps = {
 const SETTLE_FOLD_BEAT_MS = 1100;
 /** Keep in sync with `--og-duration-disclose-settle`. */
 const SETTLE_COLLAPSE_MS = 820;
+/** Keep in sync with `--og-duration-disclose` (manual / cancel-close). */
+const DISCLOSE_MS = 120;
 
 export function TurnSummary({
   items,
@@ -185,14 +188,24 @@ export function TurnSummary({
   // auto-collapse finishes (or on first user interaction) so later manual
   // closes are the fast disclose pair.
   const [settlePhase, setSettlePhase] = useState(initialSettle);
+  // Separate from settlePhase CSS: keep nested chips flat through cancel-close
+  // (fast collapse) without forcing the slow settle-collapse animation.
+  const [nestSuppressLatch, setNestSuppressLatch] = useState(initialSettle);
   // Expand animation must NOT run on the settle mount (rows were already
   // visible — a height sweep would flash them). Armed once we leave that
   // initial open, so a later manual reopen animates instead of snapping.
   const [expandReady, setExpandReady] = useState(!initialSettle);
   const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const settleCloseDoneRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const nestLatchClearRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const settleFoldSeenRef = useRef(Boolean(settleFold));
   const settleArmedRef = useRef(false);
+  const clearNestLatchTimer = () => {
+    if (nestLatchClearRef.current !== null) {
+      clearTimeout(nestLatchClearRef.current);
+      nestLatchClearRef.current = null;
+    }
+  };
   const clearSettleTimers = () => {
     if (settleTimerRef.current !== null) {
       clearTimeout(settleTimerRef.current);
@@ -202,6 +215,7 @@ export function TurnSummary({
       clearTimeout(settleCloseDoneRef.current);
       settleCloseDoneRef.current = null;
     }
+    clearNestLatchTimer();
   };
   const armSettleCollapse = () => {
     if (settleArmedRef.current) {
@@ -210,6 +224,7 @@ export function TurnSummary({
     settleArmedRef.current = true;
     setSettling(true);
     setSettlePhase(true);
+    setNestSuppressLatch(true);
     setExpandReady(false);
     setOpen(true);
     clearSettleTimers();
@@ -222,6 +237,7 @@ export function TurnSummary({
         settleArmedRef.current = false;
         setSettlePhase(false);
         setSettling(false);
+        setNestSuppressLatch(false);
       }, SETTLE_COLLAPSE_MS);
     }, SETTLE_FOLD_BEAT_MS);
   };
@@ -249,12 +265,29 @@ export function TurnSummary({
   }, [settleFold]);
   const onOpenChange = (next: boolean) => {
     // The reader took over — cancel the pending auto-collapse for good.
+    // Clear settle CSS phase immediately (fast collapse) but keep nest latch
+    // through the disclose window so nested chips do not remount mid-close.
+    const wasNestFlat = settling || settlePhase || nestSuppressLatch;
     clearSettleTimers();
     settleArmedRef.current = false;
     setExpandReady(true);
     setSettlePhase(false);
     setSettling(false);
-    setOpen(next);
+    if (next) {
+      setNestSuppressLatch(false);
+      setOpen(true);
+      return;
+    }
+    setOpen(false);
+    if (wasNestFlat) {
+      setNestSuppressLatch(true);
+      nestLatchClearRef.current = setTimeout(() => {
+        nestLatchClearRef.current = null;
+        setNestSuppressLatch(false);
+      }, DISCLOSE_MS);
+    } else {
+      setNestSuppressLatch(false);
+    }
   };
   const enter = useEntranceAnimation();
   // Capture once: after a settle choreography the chip is already on screen.
@@ -299,9 +332,9 @@ export function TurnSummary({
   // Live open shell: keep the chip in-flow (so settle never inserts layout)
   // but quiet it until there is an outcome or a settle beat.
   const liveShell = outcome === undefined && open && !settlePhase && !bare;
-  // Full settle window (beat + collapse), not merely while open — see
-  // useTurnSettleOpen. Nested chips must not remount when open flips false.
-  const settleChrome = settling || settlePhase;
+  // Settle CSS phase OR cancel-close latch — see useTurnSettleOpen.
+  // Nested chips must not remount when open flips false mid-collapse.
+  const settleChrome = settling || settlePhase || nestSuppressLatch;
 
   // Copy only on the collapsed chip — when open, per-message copy is enough
   // and a second control on the summary row felt crowded / off.

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -12,8 +12,10 @@ import {
 import { Collapsible } from "radix-ui";
 import { CopyButton } from "../components/copy-button";
 import { cn } from "../lib/cn";
+import { MOTION_INSPECT_SCALE } from "../lib/motion-inspect";
 import { useForcedDefaultOpen } from "./disclosure-context";
 import { useEntranceAnimation } from "./entrance";
+import { useFoldMemory, type FoldRestingState } from "./fold-memory";
 import { applyPatchOps, isApplyPatch, mediaPreviewFact, screenshotDataUrl } from "./parsers";
 import { rawTypeOf } from "./registry";
 import type { ActivityItem, ToolCallItem, TurnOutcome } from "./types";
@@ -35,11 +37,10 @@ export type { TurnOutcome } from "./types";
 const TurnSettleChromeContext = createContext(false);
 
 /**
- * Suppress nested cluster chips while the settle choreography (or a latch
- * after cancel-close) is flattening the body. Nested chips must not remount
- * when `open` flips false mid-collapse — that remount yanked height (snap).
- * Also stays true briefly after the reader cancels settle, through the fast
- * collapse window, so cancel does not reintroduce the same remount.
+ * True while settle chrome is active (open beat, slow collapse, or the short
+ * cancel-close latch). Nested cluster chips stay mounted and forced OPEN for
+ * this window so the body keeps a stable height — never flat-map to bare
+ * rails, and never remount closed nested chips mid-collapse (that yanked).
  */
 export function useTurnSettleOpen(): boolean {
   return useContext(TurnSettleChromeContext);
@@ -146,6 +147,17 @@ export type TurnSummaryProps = {
    */
   settleFold?: boolean | undefined;
   /**
+   * Durable identity (timeline group id) for cross-remount fold memory. When
+   * an ancestor provides a {@link FoldMemoryProvider} map, reaching a resting
+   * state is recorded under this key: "closed" when the settle choreography
+   * completes its collapse or the reader closes the chip, "open" when the
+   * reader expands it. A later remount under the same key restores that
+   * resting state and never replays the open settle beat — the activity→turn
+   * wrap and the nested force-open during settle chrome must not re-expand a
+   * fold that already settled closed.
+   */
+  foldKey?: string | undefined;
+  /**
    * When set, a hover/focus copy control sits on the chip row (outside the
    * disclosure trigger) so the reader can copy the turn's assistant prose
    * without toggling the fold.
@@ -158,11 +170,11 @@ export type TurnSummaryProps = {
 };
 
 /** How long a settling fold stays open before gliding closed. */
-const SETTLE_FOLD_BEAT_MS = 1100;
+const SETTLE_FOLD_BEAT_MS = 1100 * MOTION_INSPECT_SCALE;
 /** Keep in sync with `--og-duration-disclose-settle`. */
-const SETTLE_COLLAPSE_MS = 820;
+const SETTLE_COLLAPSE_MS = 820 * MOTION_INSPECT_SCALE;
 /** Keep in sync with `--og-duration-disclose` (manual / cancel-close). */
-const DISCLOSE_MS = 120;
+const DISCLOSE_MS = 120 * MOTION_INSPECT_SCALE;
 
 export function TurnSummary({
   items,
@@ -173,6 +185,7 @@ export function TurnSummary({
   bare,
   facets: facetConfiguration,
   settleFold,
+  foldKey,
   copyText,
   contextCompactionCount,
   children,
@@ -180,16 +193,27 @@ export function TurnSummary({
   // An explicit `defaultOpen` always wins; otherwise an ancestor may seed it
   // (screenshot instrumentation); otherwise the turn starts folded.
   const forcedDefaultOpen = useForcedDefaultOpen();
-  const restingOpen = defaultOpen ?? forcedDefaultOpen ?? false;
-  const initialSettle = Boolean(settleFold) && !restingOpen;
+  const foldMemory = useFoldMemory();
+  // A remembered resting state outranks author defaults: a fold that already
+  // finished its settle collapse (or that the reader closed) mounts closed
+  // even when a remount asks for the settle beat or a forced defaultOpen —
+  // and one the reader expanded mounts open instead of snapping shut.
+  const remembered = foldKey !== undefined ? foldMemory?.get(foldKey) : undefined;
+  const restingOpen =
+    remembered === "closed"
+      ? false
+      : remembered === "open"
+        ? true
+        : (defaultOpen ?? forcedDefaultOpen ?? false);
+  const initialSettle = Boolean(settleFold) && !restingOpen && remembered === undefined;
   const [settling, setSettling] = useState(initialSettle);
   const [open, setOpen] = useState(initialSettle ? true : restingOpen);
   // While true, a close uses the slow settle collapse. Cleared after that
   // auto-collapse finishes (or on first user interaction) so later manual
   // closes are the fast disclose pair.
   const [settlePhase, setSettlePhase] = useState(initialSettle);
-  // Separate from settlePhase CSS: keep nested chips flat through cancel-close
-  // (fast collapse) without forcing the slow settle-collapse animation.
+  // Separate from settlePhase CSS: keep nested chips force-open through
+  // cancel-close (fast collapse) without forcing the slow settle-collapse.
   const [nestSuppressLatch, setNestSuppressLatch] = useState(initialSettle);
   // Expand animation must NOT run on the settle mount (rows were already
   // visible — a height sweep would flash them). Armed once we leave that
@@ -217,6 +241,11 @@ export function TurnSummary({
     }
     clearNestLatchTimer();
   };
+  const rememberResting = (state: FoldRestingState) => {
+    if (foldKey !== undefined && foldMemory) {
+      foldMemory.set(foldKey, state);
+    }
+  };
   const armSettleCollapse = () => {
     if (settleArmedRef.current) {
       return;
@@ -232,6 +261,9 @@ export function TurnSummary({
       settleTimerRef.current = null;
       setExpandReady(true);
       setOpen(false);
+      // The glide toward closed IS the choreography completing — record it
+      // now, so a wrap that lands mid-collapse still remounts this fold shut.
+      rememberResting("closed");
       settleCloseDoneRef.current = setTimeout(() => {
         settleCloseDoneRef.current = null;
         settleArmedRef.current = false;
@@ -260,16 +292,24 @@ export function TurnSummary({
     const was = settleFoldSeenRef.current;
     settleFoldSeenRef.current = Boolean(settleFold);
     if (!was && settleFold) {
+      // A remembered resting state means this fold's story already resolved
+      // once (choreography closed it, or the reader chose a state). Replaying
+      // the open beat would re-expand it — the exact reopen this guards.
+      if (foldKey !== undefined && foldMemory?.get(foldKey) !== undefined) {
+        return;
+      }
       armSettleCollapse();
     }
   }, [settleFold]);
   const onOpenChange = (next: boolean) => {
     // The reader took over — cancel the pending auto-collapse for good.
     // Clear settle CSS phase immediately (fast collapse) but keep nest latch
-    // through the disclose window so nested chips do not remount mid-close.
+    // through the disclose window so nested chips stay force-open mid-close
+    // (remounting them closed here yanks height).
     const wasNestFlat = settling || settlePhase || nestSuppressLatch;
     clearSettleTimers();
     settleArmedRef.current = false;
+    rememberResting(next ? "open" : "closed");
     setExpandReady(true);
     setSettlePhase(false);
     setSettling(false);
@@ -333,7 +373,7 @@ export function TurnSummary({
   // but quiet it until there is an outcome or a settle beat.
   const liveShell = outcome === undefined && open && !settlePhase && !bare;
   // Settle CSS phase OR cancel-close latch — see useTurnSettleOpen.
-  // Nested chips must not remount when open flips false mid-collapse.
+  // Nested chips stay force-open for this window (stable height).
   const settleChrome = settling || settlePhase || nestSuppressLatch;
 
   // Copy only on the collapsed chip — when open, per-message copy is enough

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -275,6 +275,8 @@ export function TurnSummary({
   };
   const mountSettleRef = useRef(initialSettle);
   // Mount-time settle (new turn wrap).
+  // Mount-once settle arm + unmount timer cleanup — re-running on foldMemory
+  // identity churn would restart the beat mid-choreography.
   useEffect(() => {
     if (mountSettleRef.current) {
       armSettleCollapse();
@@ -283,11 +285,13 @@ export function TurnSummary({
       clearSettleTimers();
       settleArmedRef.current = false;
     };
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   // Live shell already open: settleFold rises later without remounting.
   // Do not require !restingOpen — live shells mount with defaultOpen and
   // only later receive settleFold. Failed turns mount with both at once
   // (seen=true), so they never take this edge.
+  // Edge-trigger on settleFold only; foldMemory/foldKey are reopen guards.
   useEffect(() => {
     const was = settleFoldSeenRef.current;
     settleFoldSeenRef.current = Boolean(settleFold);
@@ -300,6 +304,7 @@ export function TurnSummary({
       }
       armSettleCollapse();
     }
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [settleFold]);
   const onOpenChange = (next: boolean) => {
     // The reader took over — cancel the pending auto-collapse for good.

--- a/packages/react/styles/index.css
+++ b/packages/react/styles/index.css
@@ -191,16 +191,14 @@
   }
 }
 
-/* Live activity rows: soft rise into the tip as scroll eases them into view.
-   Keep the offset small — large translateY fought scroll and felt like ticks. */
+/* Live activity rows: opacity only. translateY stacked with tip stick and
+   read as a second one-line tick on every tool/message append. */
 @keyframes og-row-enter {
   from {
     opacity: 0;
-    transform: translateY(6px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 .animate-og-row-enter {

--- a/packages/react/styles/index.css
+++ b/packages/react/styles/index.css
@@ -191,19 +191,16 @@
   }
 }
 
-/* Live activity rows appended mid-turn: softer than og-enter so a tool
-   marathon doesn't tick-tick-tick as hard pops. Blur stays subtle — filter
-   on a short row is cheap and reads as "arriving", not as a glitch. */
+/* Live activity rows: soft rise into the tip as scroll eases them into view.
+   Keep the offset small — large translateY fought scroll and felt like ticks. */
 @keyframes og-row-enter {
   from {
     opacity: 0;
-    transform: translateY(10px);
-    filter: blur(3px);
+    transform: translateY(6px);
   }
   to {
     opacity: 1;
     transform: translateY(0);
-    filter: blur(0);
   }
 }
 .animate-og-row-enter {

--- a/packages/react/styles/index.css
+++ b/packages/react/styles/index.css
@@ -81,7 +81,8 @@
   --animate-og-collapse: og-collapse var(--og-duration-disclose) var(--og-ease-in-out);
   /* Auto-fold the reader did not ask for: ~7× manual so it reads as choreography. */
   --animate-og-settle-chip: og-settle-chip var(--og-duration-slow) var(--og-ease-out) both;
-  --animate-og-settle-collapse: og-collapse var(--og-duration-disclose-settle) var(--og-ease-in-out);
+  /* Ease-out: settle lands softly (slow tail), not a symmetric ease-in-out stop. */
+  --animate-og-settle-collapse: og-collapse var(--og-duration-disclose-settle) var(--og-ease-out);
   /* Live tool rows arriving mid-turn — soft, not tied to manual disclose speed. */
   --animate-og-row-enter: og-row-enter var(--og-duration-slow) var(--og-ease-stream) both;
   /* Stream end fallback breath when View Transitions are unavailable. */
@@ -143,14 +144,12 @@
   }
 }
 
-/* Streaming tip ink: age-window opacity wash (no blur — blur read as muddy
-   glitter at speed). One continuous run per append batch; fast arrival keeps
-   a large young band soft, slow arrival keeps only the tip soft. Starts at a
-   readable low opacity (not 0) so the tip reads as wet ink, not missing text.
-   Inline, no transform — typography/selection untouched. */
+/* Streaming tip ink: short age-window wash. Fast arrival still keeps a soft
+   band (many young batches); slow arrival is only a tight tip breath — a long
+   linear fade read as 2–3× too much wash on sparse tokens. Inline, no transform. */
 @keyframes og-stream-ink {
   from {
-    opacity: 0.28;
+    opacity: 0.3;
   }
   to {
     opacity: 1;
@@ -158,7 +157,7 @@
 }
 .og-stream-ink {
   display: inline;
-  animation: og-stream-ink var(--og-duration-stream) var(--og-ease-stream) both;
+  animation: og-stream-ink var(--og-duration-stream) var(--og-ease-out) both;
 }
 
 /* Stream-end remount fallback when View Transitions are unavailable.
@@ -179,15 +178,13 @@
    document root and read as a full-page blink at stream end. Local
    `.og-markdown-settle` on the body is enough. */
 
-/* Entry: messages and timeline rows slide in just enough to feel placed. */
+/* Entry: opacity only — translateY fought the tip-follow camera and ticked. */
 @keyframes og-enter {
   from {
     opacity: 0;
-    transform: translateY(4px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 

--- a/packages/react/styles/tokens.css
+++ b/packages/react/styles/tokens.css
@@ -29,17 +29,19 @@
   --og-radius-full: 9999px;
 
   /* Motion — communicates state; never decorates ---------------------------- */
-  --og-duration-fast: 120ms;
-  --og-duration-base: 180ms;
-  --og-duration-slow: 320ms;
+  /* TEMP: set to 1 before landing — slows vertical CSS motion for eyeballing. */
+  --og-motion-inspect-scale: 1;
+  --og-duration-fast: calc(120ms * var(--og-motion-inspect-scale));
+  --og-duration-base: calc(180ms * var(--og-motion-inspect-scale));
+  --og-duration-slow: calc(320ms * var(--og-motion-inspect-scale));
   /* Timeline disclose: MANUAL expand/collapse stays chrome-fast; AUTOMATIC
      settle-fold is ~5–7× slower so the reader can register a change they
      did not ask for. Stream tip ink is an age window (same ms as fade). */
-  --og-duration-disclose: 120ms;
-  --og-duration-disclose-settle: 820ms;
-  --og-duration-stream: 1100ms;
+  --og-duration-disclose: calc(120ms * var(--og-motion-inspect-scale));
+  --og-duration-disclose-settle: calc(820ms * var(--og-motion-inspect-scale));
+  --og-duration-stream: calc(420ms * var(--og-motion-inspect-scale));
   /* Softened/partial markdown → final GFM (View Transition + settle breath). */
-  --og-duration-markdown-crystallize: 480ms;
+  --og-duration-markdown-crystallize: calc(480ms * var(--og-motion-inspect-scale));
   --og-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
   --og-ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
   --og-ease-stream: cubic-bezier(0.16, 1, 0.3, 1);

--- a/packages/react/test/activity-row-enter.test.tsx
+++ b/packages/react/test/activity-row-enter.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { ActivityRail } from "../src/timeline/activity-rail";
+import { EntranceAnimationProvider } from "../src/timeline/entrance";
+import { SeenActivityIdsProvider } from "../src/timeline/seen-activity-ids";
+import type { ActivityItem } from "../src/timeline/types";
+import { actRun, flush, registerDom, renderComponent } from "./render-hook";
+
+registerDom();
+
+function tool(id: string, status: "running" | "completed" = "running"): ActivityItem {
+  return {
+    kind: "tool-call",
+    id,
+    name: "exec_command",
+    status,
+    occurredAt: "2026-01-01T00:00:00.000Z",
+    arguments: { command: `echo ${id}` },
+  };
+}
+
+describe("ActivityRail row enter", () => {
+  test("with seen-id map, first live tool fades in (not a hard pop)", async () => {
+    const seen = new Set<string>();
+    const r = await renderComponent(
+      <SeenActivityIdsProvider value={seen}>
+        <EntranceAnimationProvider value={true}>
+          <ActivityRail items={[tool("t1")]} bare />
+        </EntranceAnimationProvider>
+      </SeenActivityIdsProvider>,
+    );
+    expect(r.container.querySelector(".animate-og-row-enter")).not.toBeNull();
+    expect(seen.has("t1")).toBe(true);
+    await r.unmount();
+  });
+
+  test("remount of a known tool does not re-fade", async () => {
+    const seen = new Set<string>(["t1"]);
+    const r = await renderComponent(
+      <SeenActivityIdsProvider value={seen}>
+        <EntranceAnimationProvider value={true}>
+          <ActivityRail items={[tool("t1", "completed")]} bare />
+        </EntranceAnimationProvider>
+      </SeenActivityIdsProvider>,
+    );
+    expect(r.container.querySelector(".animate-og-row-enter")).toBeNull();
+    await r.unmount();
+  });
+
+  test("append after bulk gate clears still fades the new tool", async () => {
+    const seen = new Set<string>();
+    const shell = (enter: boolean, items: ActivityItem[]) => (
+      <SeenActivityIdsProvider value={seen}>
+        <EntranceAnimationProvider value={enter}>
+          <ActivityRail items={items} bare />
+        </EntranceAnimationProvider>
+      </SeenActivityIdsProvider>
+    );
+    const r = await renderComponent(shell(false, [tool("t1")]));
+    expect(r.container.querySelector(".animate-og-row-enter")).toBeNull();
+    expect(seen.has("t1")).toBe(true);
+
+    await actRun(() => undefined);
+    await r.rerender(shell(true, [tool("t1"), tool("t2")]));
+    await flush();
+    const entering = Array.from(r.container.querySelectorAll(".animate-og-row-enter"));
+    expect(entering).toHaveLength(1);
+    expect(entering[0]?.getAttribute("data-og-timeline-row-anchor")).not.toBeNull();
+    await r.unmount();
+  });
+});

--- a/packages/react/test/activity-row-enter.test.tsx
+++ b/packages/react/test/activity-row-enter.test.tsx
@@ -7,14 +7,18 @@ import { actRun, flush, registerDom, renderComponent } from "./render-hook";
 
 registerDom();
 
-function tool(id: string, status: "running" | "completed" = "running"): ActivityItem {
+function tool(id: string, status: "running" | "complete" = "running"): ActivityItem {
   return {
     kind: "tool-call",
     id,
+    turnId: "turn-1",
+    callId: `call-${id}`,
     name: "exec_command",
     status,
     occurredAt: "2026-01-01T00:00:00.000Z",
     arguments: { command: `echo ${id}` },
+    output: undefined,
+    raw: undefined,
   };
 }
 
@@ -38,7 +42,7 @@ describe("ActivityRail row enter", () => {
     const r = await renderComponent(
       <SeenActivityIdsProvider value={seen}>
         <EntranceAnimationProvider value={true}>
-          <ActivityRail items={[tool("t1", "completed")]} bare />
+          <ActivityRail items={[tool("t1", "complete")]} bare />
         </EntranceAnimationProvider>
       </SeenActivityIdsProvider>,
     );

--- a/packages/react/test/copy-button.test.tsx
+++ b/packages/react/test/copy-button.test.tsx
@@ -4,6 +4,7 @@ import { registerDom, renderComponent, flush } from "./render-hook";
 import { CopyButton } from "../src/components/copy-button";
 import { Markdown } from "../src/components/markdown";
 import { tableElementToTsv } from "../src/lib/clipboard";
+import { TooltipProvider } from "../src/components/tooltip";
 
 registerDom();
 
@@ -19,7 +20,11 @@ describe("CopyButton", () => {
       },
     });
 
-    const r = await renderComponent(<CopyButton text="hello there" label="Copy message" />);
+    const r = await renderComponent(
+      <TooltipProvider delayDuration={400}>
+        <CopyButton text="hello there" label="Copy message" />
+      </TooltipProvider>,
+    );
     const button = r.container.querySelector("button[data-og-copy]");
     expect(button).not.toBeNull();
     await act(async () => {

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -64,10 +64,9 @@ function manyEvents(count: number): SessionEvent[] {
 }
 
 async function readerScrollUp(scroller: HTMLElement, scrollTop = 0): Promise<void> {
-  // Pin release is intent-only (wheel/touch/scrollbar/keys). A bare scrollTop
-  // jump looks like settle-fold layout and must re-stick, not unpin.
+  // Unpinning is purely geometric: a scroll event landing far from the bottom
+  // IS the reader moving — no synthetic wheel/touch intent is needed.
   await actRun(() => {
-    scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }));
     scroller.scrollTop = scrollTop;
     scroller.dispatchEvent(new Event("scroll"));
   });
@@ -333,16 +332,13 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 
-  test("unpinned fallback (no native anchoring): only a genuine prepend moves scrollTop, by one exact delta", async () => {
+  test("unpinned prepend restores place by height delta when group offsets are unavailable", async () => {
     const frames: FrameRequestCallback[] = [];
     globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
       frames.push(cb);
       return frames.length;
     };
     globalThis.cancelAnimationFrame = () => undefined;
-    // Force the manual-correction path: engines WITH native scroll anchoring
-    // never script scrollTop while unpinned (the browser holds the anchor).
-    stubNativeScrollAnchoringUnsupported();
 
     const settled = manyEvents(12).map((evt) => event(evt.sequence + 8)); // 9..20
     const r = await renderComponent(
@@ -357,7 +353,8 @@ describe("MessageTimeline pagination affordances", () => {
     }
 
     // Reader is near the top — the historical wobble zone while the next
-    // older page inserts.
+    // older page inserts. Happy-dom group offsetTops are 0, so restore uses
+    // the scrollHeight-delta fallback.
     let contentHeight = 2000;
     const clientHeight = 400;
     let currentScrollTop = 24;
@@ -420,6 +417,73 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 
+  test("near-top prepend restores place when scrollHeight is unchanged (tip truncated)", async () => {
+    // loadOlder uses an oldest-directed window: older rows prepend AND the live
+    // tip can be evicted. Net scrollHeight may not grow, so height-delta restore
+    // alone leaves scrollTop at 0 — the "jumped to top of materialised page" bug.
+    // Anchor the previous first group's offsetTop instead.
+    const settled = manyEvents(12).map((evt) => event(evt.sequence + 8)); // 9..20
+    const r = await renderComponent(
+      <MessageTimeline events={settled} hasOlder loadingOlder={false} />,
+    );
+    await armOlderPrefetch(r.container);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    let height = 2000;
+    let top = 0;
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      get: () => 400,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      get: () => height,
+    });
+    Object.defineProperty(scroller, "scrollTop", {
+      configurable: true,
+      get: () => top,
+      set: (value: number) => {
+        top = Math.max(0, Math.min(height - 400, value));
+      },
+    });
+    await actRun(() => {
+      scroller.scrollTop = 0;
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await r.rerender(<MessageTimeline events={settled} hasOlder loadingOlder={false} />);
+    await flush();
+
+    const originalOffset = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetTop");
+    Object.defineProperty(HTMLElement.prototype, "offsetTop", {
+      configurable: true,
+      get(this: HTMLElement) {
+        if (this.getAttribute("data-og-group-key") !== "evt-9") {
+          return 0;
+        }
+        // Post-prepend DOM includes older rows (evt-1); that is when the
+        // retained evt-9 group has shifted down.
+        return scroller.querySelector('[data-og-group-key="evt-1"]') ? 600 : 0;
+      },
+    });
+    try {
+      height = 2000; // tip truncated — no net growth
+      await r.rerender(
+        <MessageTimeline events={manyEvents(20)} hasOlder loadingOlder={false} status="running" />,
+      );
+      await flush();
+      expect(scroller.scrollTop).toBe(600);
+    } finally {
+      if (originalOffset) {
+        Object.defineProperty(HTMLElement.prototype, "offsetTop", originalOffset);
+      } else {
+        delete (HTMLElement.prototype as { offsetTop?: unknown }).offsetTop;
+      }
+    }
+    await r.unmount();
+  });
+
   test("native scroll anchoring owns unpinned mode; the bottom-snap owns pinned mode", async () => {
     const r = await renderComponent(<MessageTimeline events={manyEvents(6)} />);
     await flush();
@@ -470,13 +534,14 @@ describe("MessageTimeline pagination affordances", () => {
     expect(layout.tipBottomGap()).toBeLessThan(2);
 
     // Grow content first (stale scrollTop leaves tip above the bottom), then
-    // let the live append's soft-follow glide settle to the tip.
+    // let the live append's commit snap the tip back to the bottom.
     layout.setContentHeight(2080);
     expect(layout.tipBottomGap()).toBeGreaterThan(2);
     await r.rerender(
       <MessageTimeline events={[...initial, agentDelta(21, " world")]} status="running" />,
     );
     await drainFrames(frames);
+    await flush();
 
     expect(r.container.textContent).toContain("hello  world");
     expect(distanceFromBottom(scroller)).toBeLessThan(48);
@@ -639,7 +704,7 @@ describe("MessageTimeline pagination affordances", () => {
     const observed: Element[] = [];
     globalThis.IntersectionObserver = class implements IntersectionObserver {
       readonly root: Element | Document | null = null;
-      readonly rootMargin = "1600px 0px 0px 0px";
+      readonly rootMargin = "400px 0px 0px 0px";
       readonly scrollMargin = "0px 0px 0px 0px";
       readonly thresholds = [0];
       constructor(cb: IntersectionObserverCallback) {
@@ -683,6 +748,281 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 
+  test("older prefetch does not loop at the batch top", async () => {
+    let callback: IntersectionObserverCallback = () => undefined;
+    let instance: IntersectionObserver | null = null;
+    const observed: Element[] = [];
+    globalThis.IntersectionObserver = class implements IntersectionObserver {
+      readonly root: Element | Document | null = null;
+      readonly rootMargin = "400px 0px 0px 0px";
+      readonly scrollMargin = "0px 0px 0px 0px";
+      readonly thresholds = [0];
+      constructor(cb: IntersectionObserverCallback) {
+        callback = cb;
+        instance = this;
+      }
+      observe(target: Element): void {
+        observed.push(target);
+      }
+      unobserve(): void {}
+      disconnect(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    };
+
+    let calls = 0;
+    const r = await renderComponent(
+      <MessageTimeline
+        events={manyEvents(4)}
+        hasOlder
+        onLoadOlder={() => {
+          calls += 1;
+        }}
+      />,
+    );
+    await armOlderPrefetch(r.container);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    scroller.scrollTop = 200;
+
+    const hit = async () => {
+      await actRun(() =>
+        callback(
+          [{ isIntersecting: true, target: observed[0]! } as IntersectionObserverEntry],
+          instance!,
+        ),
+      );
+    };
+    await hit();
+    expect(calls).toBe(1);
+    // Still intersecting / scrolling toward y=0 must not chain-load.
+    await hit();
+    await hit();
+    expect(calls).toBe(1);
+    await actRun(() => {
+      scroller.scrollTop = 0;
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
+    await hit();
+    expect(calls).toBe(1);
+
+    // Leave the top band (scroll down into content) re-arms.
+    await actRun(() => {
+      scroller.scrollTop = 500;
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
+    await hit();
+    expect(calls).toBe(2);
+
+    // Sentinel exit also re-arms.
+    await actRun(() =>
+      callback(
+        [{ isIntersecting: false, target: observed[0]! } as IntersectionObserverEntry],
+        instance!,
+      ),
+    );
+    await hit();
+    expect(calls).toBe(3);
+    await r.unmount();
+  });
+
+  test("pinned scroll-up intent releases pin instead of yanking back to tip", async () => {
+    const r = await renderComponent(<MessageTimeline events={manyEvents(8)} status="running" />);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    layout.syncTipAtBottom();
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    expect(distanceFromBottom(scroller)).toBeLessThan(48);
+
+    // Scroll event with decreasing scrollTop (no wheel) must unpin — the old
+    // path called followTip and fought the reader back to the tip.
+    await actRun(() => {
+      scroller.scrollTop = 1200;
+      layout.placeTipAt(1200);
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
+    expect(r.container.textContent).toContain("Jump to latest");
+    expect(scroller.scrollTop).toBe(1200);
+    layout.restore();
+    await r.unmount();
+  });
+
+  test("pinned appends snap in the same commit; a later scroll-up wins with no echoes to fight", async () => {
+    // Overlay scrollbars / coalesced trackpad deliver scroll-only events (no
+    // wheel). Unpinning is purely geometric now, so a mid-stream scroll-up is
+    // honored immediately — there is no glide write queue that could swallow
+    // it as an echo and yank the reader back to the tip.
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const prefix = manyEvents(19);
+    const initial = [...prefix, agentDelta(20, "hello ")];
+    const r = await renderComponent(<MessageTimeline events={initial} status="running" />);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    layout.syncTipAtBottom();
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    // Tip growth + commit snap to the bottom synchronously — no animation
+    // frames needed, nothing left in flight afterwards.
+    layout.setContentHeight(2300);
+    await r.rerender(
+      <MessageTimeline events={[...initial, agentDelta(21, "world")]} status="running" />,
+    );
+    expect(distanceFromBottom(scroller)).toBeLessThan(2);
+
+    const freedTop = 900;
+    await actRun(() => {
+      scroller.scrollTop = freedTop;
+      layout.placeTipAt(freedTop + 200);
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
+
+    expect(r.container.textContent).toContain("Jump to latest");
+    expect(scroller.scrollTop).toBe(freedTop);
+
+    // Further streaming must not re-stick / yank.
+    const before = scroller.scrollTop;
+    layout.setContentHeight(2600);
+    await r.rerender(
+      <MessageTimeline
+        events={[...initial, agentDelta(21, "world"), agentDelta(22, "!")]}
+        status="running"
+      />,
+    );
+    await drainFrames(frames);
+    await flush();
+    expect(scroller.scrollTop).toBe(before);
+    expect(r.container.textContent).toContain("Jump to latest");
+
+    layout.restore();
+    await r.unmount();
+  });
+
+  test("Jump to latest with hasNewer pins only when the tip window lands", async () => {
+    // Pinning against the current history page would snap to ITS bottom and
+    // page-crawl forward through the gap; the pin must wait for hasNewer to
+    // flip false.
+    let jumps = 0;
+    const onJumpToLatest = () => {
+      jumps += 1;
+    };
+    const initial = manyEvents(20);
+    const r = await renderComponent(
+      <MessageTimeline events={initial} hasNewer onJumpToLatest={onJumpToLatest} />,
+    );
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    scroller.scrollTop = 1000;
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
+
+    const button = Array.from(r.container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Jump to latest"),
+    );
+    if (!button) {
+      throw new Error("expected Jump to latest button");
+    }
+    await actRun(() => {
+      button.click();
+    });
+    await flush();
+    expect(jumps).toBe(1);
+    // History window still showing: no snap to the page bottom.
+    expect(scroller.scrollTop).toBe(1000);
+
+    // The tip window lands (hasNewer false): pin + snap. (The button itself
+    // may linger through its exit animation under happy-dom, so assert the
+    // pinned mode via the anchor class.)
+    layout.setContentHeight(2400);
+    await r.rerender(<MessageTimeline events={initial} onJumpToLatest={onJumpToLatest} />);
+    await flush();
+    expect(distanceFromBottom(scroller)).toBeLessThan(2);
+    expect(scroller.className).toContain("[overflow-anchor:none]");
+    layout.restore();
+    await r.unmount();
+  });
+
+  test("paging forward to the tip re-pins a reader parked at the bottom", async () => {
+    const initial = manyEvents(20);
+    const r = await renderComponent(
+      <MessageTimeline events={initial} hasNewer onLoadNewer={() => undefined} />,
+    );
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    // Parked at the bottom of the last history page.
+    scroller.scrollTop = 1600;
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
+    expect(r.container.textContent).toContain("Jump to latest");
+
+    // The last page merges into the live tip: hasNewer flips false and the
+    // reader at the bottom is following again — no stranded unpinned state
+    // with new content growing below. (Pinned mode shows as the anchor class;
+    // the button may linger through its exit animation under happy-dom.)
+    await r.rerender(<MessageTimeline events={initial} />);
+    await flush();
+    expect(scroller.className).toContain("[overflow-anchor:none]");
+
+    layout.setContentHeight(2100);
+    await r.rerender(<MessageTimeline events={[...initial, event(21)]} />);
+    await flush();
+    expect(distanceFromBottom(scroller)).toBeLessThan(2);
+    layout.restore();
+    await r.unmount();
+  });
+
   test("rows born in the initial bulk paint never animate; rows appended live do", async () => {
     const frames: FrameRequestCallback[] = [];
     globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
@@ -711,6 +1051,271 @@ describe("MessageTimeline pagination affordances", () => {
     const animated = Array.from(r.container.querySelectorAll(".animate-og-enter"));
     expect(animated).toHaveLength(1);
     expect(animated[0]?.textContent).toContain("message 2");
+    await r.unmount();
+  });
+
+  test("a rejected onJumpToLatest clears the pending pin latch", async () => {
+    // A rejecting tip reload is an ordinary network failure. The latch must
+    // not survive it: minutes later, when the reader pages to the tip
+    // themselves, a stale latch would force pin + snap from wherever they are.
+    const initial = manyEvents(20);
+    const r = await renderComponent(
+      <MessageTimeline
+        events={initial}
+        hasNewer
+        onJumpToLatest={() => Promise.reject(new Error("tip reload failed"))}
+      />,
+    );
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    scroller.scrollTop = 1000;
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
+
+    const button = Array.from(r.container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Jump to latest"),
+    );
+    if (!button) {
+      throw new Error("expected Jump to latest button");
+    }
+    await actRun(() => {
+      button.click();
+    });
+    await flush();
+    expect(scroller.scrollTop).toBe(1000);
+
+    // The reader later reaches the tip window on their own: no surprise snap.
+    await r.rerender(
+      <MessageTimeline
+        events={initial}
+        onJumpToLatest={() => Promise.reject(new Error("tip reload failed"))}
+      />,
+    );
+    await flush();
+    expect(scroller.scrollTop).toBe(1000);
+    expect(scroller.className).toContain("[overflow-anchor:auto]");
+    layout.restore();
+    await r.unmount();
+  });
+
+  test("Jump to latest without a reload handler: scrolls the window; a scroll away expires the latch", async () => {
+    const initial = manyEvents(20);
+    const r = await renderComponent(
+      <MessageTimeline events={initial} hasNewer onLoadNewer={() => undefined} />,
+    );
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    scroller.scrollTop = 1000;
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
+
+    const button = Array.from(r.container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Jump to latest"),
+    );
+    if (!button) {
+      throw new Error("expected Jump to latest button");
+    }
+    // Without onJumpToLatest the click still jumps within the in-memory
+    // window (its bottom is where the newer sentinel pages forward from).
+    await actRun(() => {
+      button.click();
+    });
+    await flush();
+    expect(scroller.scrollTop).toBe(1600);
+
+    // The reader changes their mind and scrolls back into history: the
+    // pending latch expires with them.
+    await readerScrollUp(scroller, 200);
+
+    // The tip window lands much later: no stale force pin + snap.
+    await r.rerender(<MessageTimeline events={initial} onLoadNewer={() => undefined} />);
+    await flush();
+    expect(scroller.scrollTop).toBe(200);
+    expect(scroller.className).toContain("[overflow-anchor:auto]");
+    layout.restore();
+    await r.unmount();
+  });
+
+  test("Jump to start consumes its pending flag on the window-swap commit, once", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+    // The fallback prepend-correction path is the observable alternative to
+    // the jump: a leaked flag shows up as scrollTop 0 instead of a correction.
+    stubNativeScrollAnchoringUnsupported();
+
+    const settled = manyEvents(12).map((evt) => event(evt.sequence + 8)); // 9..20
+    const r = await renderComponent(
+      <MessageTimeline events={settled} hasOlder onJumpToStart={() => undefined} />,
+    );
+    await armOlderPrefetch(r.container);
+    await drainFrames(frames);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    let contentHeight = 2000;
+    const clientHeight = 400;
+    let currentScrollTop = 600;
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      get: () => clientHeight,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      get: () => contentHeight,
+    });
+    Object.defineProperty(scroller, "scrollTop", {
+      configurable: true,
+      get: () => currentScrollTop,
+      set: (value: number) => {
+        const max = Math.max(0, contentHeight - clientHeight);
+        currentScrollTop = Math.max(0, Math.min(max, value));
+      },
+    });
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    // Sync the height baseline at the mocked 2000.
+    await r.rerender(<MessageTimeline events={settled} hasOlder onJumpToStart={() => undefined} />);
+    await flush();
+
+    const button = Array.from(r.container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Jump to start"),
+    );
+    if (!button) {
+      throw new Error("expected Jump to start button");
+    }
+    await actRun(() => {
+      button.click();
+    });
+    await flush();
+
+    // The oldest window lands (first item id changes): jump to the top of the
+    // NEW DOM — the prepend correction (which would land at 600) must not run.
+    contentHeight = 2600;
+    await r.rerender(
+      <MessageTimeline events={manyEvents(20)} hasOlder onJumpToStart={() => undefined} />,
+    );
+    await flush();
+    expect(scroller.scrollTop).toBe(0);
+    await drainFrames(frames);
+
+    // Consumed exactly once: a LATER prepend gets the ordinary correction, not
+    // a spurious jump back to the top.
+    await readerScrollUp(scroller, 24);
+    await r.rerender(
+      <MessageTimeline events={manyEvents(20)} hasOlder onJumpToStart={() => undefined} />,
+    );
+    await flush();
+    contentHeight = 3000;
+    await r.rerender(
+      <MessageTimeline
+        events={[event(0), ...manyEvents(20)]}
+        hasOlder
+        onJumpToStart={() => undefined}
+      />,
+    );
+    await flush();
+    expect(scroller.scrollTop).toBe(424); // 24 + (3000 - 2600)
+    await drainFrames(frames);
+    await r.unmount();
+  });
+
+  test("Jump to start resolving without a window change clears the pending flag", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+    stubNativeScrollAnchoringUnsupported();
+
+    const settled = manyEvents(12).map((evt) => event(evt.sequence + 8)); // 9..20
+    const r = await renderComponent(
+      <MessageTimeline events={settled} hasOlder onJumpToStart={() => undefined} />,
+    );
+    await armOlderPrefetch(r.container);
+    await drainFrames(frames);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    let contentHeight = 2000;
+    const clientHeight = 400;
+    let currentScrollTop = 600;
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      get: () => clientHeight,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      get: () => contentHeight,
+    });
+    Object.defineProperty(scroller, "scrollTop", {
+      configurable: true,
+      get: () => currentScrollTop,
+      set: (value: number) => {
+        const max = Math.max(0, contentHeight - clientHeight);
+        currentScrollTop = Math.max(0, Math.min(max, value));
+      },
+    });
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await r.rerender(<MessageTimeline events={settled} hasOlder onJumpToStart={() => undefined} />);
+    await flush();
+
+    const button = Array.from(r.container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Jump to start"),
+    );
+    if (!button) {
+      throw new Error("expected Jump to start button");
+    }
+    await actRun(() => {
+      button.click();
+    });
+    await flush();
+    // Resolved against the CURRENT window: scrolled to its top…
+    expect(scroller.scrollTop).toBe(0);
+    // …and the pending flag expires by the next frame (no swap commit came).
+    await drainFrames(frames);
+
+    // The next genuine prepend must get the ordinary correction — a leaked
+    // flag would consume it as a spurious jump to the top.
+    await readerScrollUp(scroller, 24);
+    await r.rerender(<MessageTimeline events={settled} hasOlder onJumpToStart={() => undefined} />);
+    await flush();
+    contentHeight = 2500;
+    await r.rerender(
+      <MessageTimeline events={manyEvents(20)} hasOlder onJumpToStart={() => undefined} />,
+    );
+    await flush();
+    expect(scroller.scrollTop).toBe(524); // 24 + (2500 - 2000)
+    await drainFrames(frames);
     await r.unmount();
   });
 });

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -484,14 +484,14 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 
-  test("native scroll anchoring owns unpinned mode; the bottom-snap owns pinned mode", async () => {
+  test("native scroll anchoring is off while pinned; on when unpinned", async () => {
     const r = await renderComponent(<MessageTimeline events={manyEvents(6)} />);
     await flush();
     const scroller = r.container.querySelector(".overflow-y-auto");
     if (!(scroller instanceof HTMLElement)) {
       throw new Error("expected timeline scroller");
     }
-    // Pinned (default): anchoring disabled so it cannot fight the snap.
+    // Pinned: anchoring off so soft tip-follow owns the motion.
     expect(scroller.className).toContain("[overflow-anchor:none]");
     expect(scroller.className).not.toContain("[overflow-anchor:auto]");
 
@@ -534,7 +534,7 @@ describe("MessageTimeline pagination affordances", () => {
     expect(layout.tipBottomGap()).toBeLessThan(2);
 
     // Grow content first (stale scrollTop leaves tip above the bottom), then
-    // let the live append's commit snap the tip back to the bottom.
+    // let the live append's soft tip-follow ease back to the bottom.
     layout.setContentHeight(2080);
     expect(layout.tipBottomGap()).toBeGreaterThan(2);
     await r.rerender(
@@ -863,11 +863,10 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 
-  test("pinned appends snap in the same commit; a later scroll-up wins with no echoes to fight", async () => {
-    // Overlay scrollbars / coalesced trackpad deliver scroll-only events (no
-    // wheel). Unpinning is purely geometric now, so a mid-stream scroll-up is
-    // honored immediately — there is no glide write queue that could swallow
-    // it as an echo and yank the reader back to the tip.
+  test("pinned appends soft-follow the tip; a later scroll-up cancels the glide", async () => {
+    // Soft tip-follow eases toward the bottom. Mid-glide upward scrollTop is
+    // treated as the reader and unpins immediately — glide echoes (downward)
+    // must not swallow that intent.
     const frames: FrameRequestCallback[] = [];
     globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
       frames.push(cb);
@@ -893,12 +892,12 @@ describe("MessageTimeline pagination affordances", () => {
       scroller.dispatchEvent(new Event("scroll"));
     });
 
-    // Tip growth + commit snap to the bottom synchronously — no animation
-    // frames needed, nothing left in flight afterwards.
+    // Tip growth + soft follow reaches the bottom after glide frames drain.
     layout.setContentHeight(2300);
     await r.rerender(
       <MessageTimeline events={[...initial, agentDelta(21, "world")]} status="running" />,
     );
+    await drainFrames(frames);
     expect(distanceFromBottom(scroller)).toBeLessThan(2);
 
     const freedTop = 900;
@@ -973,8 +972,8 @@ describe("MessageTimeline pagination affordances", () => {
     expect(scroller.scrollTop).toBe(1000);
 
     // The tip window lands (hasNewer false): pin + snap. (The button itself
-    // may linger through its exit animation under happy-dom, so assert the
-    // pinned mode via the anchor class.)
+    // may linger through its exit animation under happy-dom, so assert pin via
+    // overflow-anchor:none + near-bottom.)
     layout.setContentHeight(2400);
     await r.rerender(<MessageTimeline events={initial} onJumpToLatest={onJumpToLatest} />);
     await flush();
@@ -985,6 +984,13 @@ describe("MessageTimeline pagination affordances", () => {
   });
 
   test("paging forward to the tip re-pins a reader parked at the bottom", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
     const initial = manyEvents(20);
     const r = await renderComponent(
       <MessageTimeline events={initial} hasNewer onLoadNewer={() => undefined} />,
@@ -1009,14 +1015,15 @@ describe("MessageTimeline pagination affordances", () => {
 
     // The last page merges into the live tip: hasNewer flips false and the
     // reader at the bottom is following again — no stranded unpinned state
-    // with new content growing below. (Pinned mode shows as the anchor class;
-    // the button may linger through its exit animation under happy-dom.)
+    // with new content growing below. (Pin = overflow-anchor:none; the Jump
+    // button may linger through its exit animation under happy-dom.)
     await r.rerender(<MessageTimeline events={initial} />);
     await flush();
     expect(scroller.className).toContain("[overflow-anchor:none]");
 
     layout.setContentHeight(2100);
     await r.rerender(<MessageTimeline events={[...initial, event(21)]} />);
+    await drainFrames(frames);
     await flush();
     expect(distanceFromBottom(scroller)).toBeLessThan(2);
     layout.restore();

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -880,9 +880,7 @@ describe("MessageTimeline pagination affordances", () => {
     }) as typeof window.getComputedStyle;
 
     await actRun(() => {
-      nested.dispatchEvent(
-        new WheelEvent("wheel", { deltaY: -40, deltaX: 0, bubbles: true }),
-      );
+      nested.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, deltaX: 0, bubbles: true }));
     });
     await flush();
     expect(r.container.textContent).not.toContain("Jump to latest");

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -64,9 +64,10 @@ function manyEvents(count: number): SessionEvent[] {
 }
 
 async function readerScrollUp(scroller: HTMLElement, scrollTop = 0): Promise<void> {
-  // Unpinning is purely geometric: a scroll event landing far from the bottom
-  // IS the reader moving — no synthetic wheel/touch intent is needed.
+  // Wheel marks reader intent (fold clamps never synthesize wheel). Scroll
+  // position then lands far from the tip.
   await actRun(() => {
+    scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }));
     scroller.scrollTop = scrollTop;
     scroller.dispatchEvent(new Event("scroll"));
   });
@@ -80,6 +81,13 @@ async function armOlderPrefetch(container: HTMLElement): Promise<void> {
   }
   Object.defineProperty(scroller, "scrollHeight", { configurable: true, value: 2400 });
   Object.defineProperty(scroller, "clientHeight", { configurable: true, value: 400 });
+  // Park at the tip first so scroll-up is a real upward delta. (Pinned + tall
+  // mock height with scrollTop already 0 is tip-debt recovery, not reader intent.)
+  await actRun(() => {
+    scroller.scrollTop = 2000;
+    scroller.dispatchEvent(new Event("scroll"));
+  });
+  await flush();
   await readerScrollUp(scroller, 0);
 }
 
@@ -109,6 +117,7 @@ afterEach(() => {
   if (originalCssDescriptor) {
     Object.defineProperty(globalThis, "CSS", originalCssDescriptor);
   }
+  frameClockMs = 0;
 });
 
 describe("MessageTimeline pagination affordances", () => {
@@ -491,12 +500,17 @@ describe("MessageTimeline pagination affordances", () => {
     if (!(scroller instanceof HTMLElement)) {
       throw new Error("expected timeline scroller");
     }
-    // Pinned: anchoring off so soft tip-follow owns the motion.
+    // Pinned: anchoring off so the tip-follow camera owns the motion.
     expect(scroller.className).toContain("[overflow-anchor:none]");
     expect(scroller.className).not.toContain("[overflow-anchor:auto]");
 
     Object.defineProperty(scroller, "scrollHeight", { configurable: true, value: 2400 });
     Object.defineProperty(scroller, "clientHeight", { configurable: true, value: 400 });
+    await actRun(() => {
+      scroller.scrollTop = 2000;
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await flush();
     await readerScrollUp(scroller, 0);
     // Unpinned: the browser holds the reader's place.
     expect(scroller.className).toContain("[overflow-anchor:auto]");
@@ -534,7 +548,7 @@ describe("MessageTimeline pagination affordances", () => {
     expect(layout.tipBottomGap()).toBeLessThan(2);
 
     // Grow content first (stale scrollTop leaves tip above the bottom), then
-    // let the live append's soft tip-follow ease back to the bottom.
+    // let the tip-follow camera ease back to the bottom.
     layout.setContentHeight(2080);
     expect(layout.tipBottomGap()).toBeGreaterThan(2);
     await r.rerender(
@@ -641,6 +655,50 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 
+  test("mid-turn fold + tip growth does not unpin when maxScroll stays flat", async () => {
+    // tools→message→tools: cluster collapse and narration growth cancel in
+    // maxScroll while scrollTop still drops — old conservation false-unpinned.
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const prefix = manyEvents(19);
+    const initial = [...prefix, agentDelta(20, "hello ")];
+    const r = await renderComponent(<MessageTimeline events={initial} status="running" />);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    layout.syncTipAtBottom();
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    expect(r.container.textContent).not.toContain("Jump to latest");
+
+    // Same scrollHeight + same maxScroll, but scrollTop drops (fold above +
+    // growth below). Must stay pinned and recover tip — not Jump to latest.
+    await actRun(() => {
+      scroller.scrollTop = 1400;
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await drainFrames(frames);
+    await flush();
+    expect(r.container.textContent).not.toContain("Jump to latest");
+    expect(distanceFromBottom(scroller)).toBeLessThan(48);
+
+    layout.restore();
+    await r.unmount();
+  });
+
   test("layout height shrink while pinned does not unpin (settle-fold / scenario spawn)", async () => {
     const frames: FrameRequestCallback[] = [];
     globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
@@ -670,15 +728,15 @@ describe("MessageTimeline pagination affordances", () => {
     expect(distanceFromBottom(scroller)).toBeLessThan(48);
     expect(r.container.textContent).not.toContain("Jump to latest");
 
-    // Settle-fold collapse: content above the tip shrinks. A transient
-    // far-from-tip scroll (including the ResizeObserver race where height
-    // baseline already matches) must re-stick, not show Jump to latest.
+    // Settle-fold collapse: content above the tip shrinks. Browser clamp
+    // lowers scrollTop to the new max (not below — that would be reader intent).
+    // Clamp conservation: top fall ≈ maxScroll fall → stay pinned.
     layout.setContentHeight(1500);
     await actRun(() => {
+      scroller.scrollTop = 1100; // new max = 1500 - 400
       scroller.dispatchEvent(new Event("scroll"));
     });
-    // Same-height second scroll: baseline already matches, gap still large —
-    // the old height-delta guard missed this and unpinned.
+    // Same-height second scroll after stick: still pinned at tip.
     await actRun(() => {
       scroller.dispatchEvent(new Event("scroll"));
     });
@@ -694,6 +752,142 @@ describe("MessageTimeline pagination affordances", () => {
     await flush();
     expect(r.container.textContent).not.toContain("Jump to latest");
     expect(distanceFromBottom(scroller)).toBeLessThan(48);
+    layout.restore();
+    await r.unmount();
+  });
+
+  test("pointer-armed scroll-up during growth unpins without a wheel event", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const prefix = manyEvents(19);
+    const initial = [...prefix, agentDelta(20, "hello ")];
+    const r = await renderComponent(<MessageTimeline events={initial} status="running" />);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    layout.syncTipAtBottom();
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    expect(r.container.textContent).not.toContain("Jump to latest");
+
+    // Streaming growth, then pointer-drag the scroller up (scrollbar / touch).
+    // Bare scroll without pointer arm must NOT unpin — that's mid-turn fold noise.
+    layout.setContentHeight(2400);
+    await actRun(() => {
+      scroller.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          button: 0,
+          pointerType: "mouse",
+          bubbles: true,
+        }),
+      );
+      scroller.scrollTop = 1200;
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await drainFrames(frames);
+    await flush();
+    expect(r.container.textContent).toContain("Jump to latest");
+    layout.restore();
+    await r.unmount();
+  });
+
+  test("settle-fold clamp does not re-pin an unpinned reader", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const prefix = manyEvents(19);
+    const initial = [...prefix, agentDelta(20, "hello ")];
+    const r = await renderComponent(<MessageTimeline events={initial} status="running" />);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    layout.syncTipAtBottom();
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await readerScrollUp(scroller, 1300);
+    expect(r.container.textContent).toContain("Jump to latest");
+
+    // Fold removes content below the reader → clamp onto nearBottom. Must
+    // stay unpinned (not silently re-stick and yank on the next delta).
+    layout.setContentHeight(1500);
+    await actRun(() => {
+      scroller.scrollTop = 1100;
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await drainFrames(frames);
+    await flush();
+    expect(r.container.textContent).toContain("Jump to latest");
+    layout.restore();
+    await r.unmount();
+  });
+
+  test("wheel over a nested overflow scroller does not unpin the timeline", async () => {
+    const r = await renderComponent(
+      <MessageTimeline events={[...manyEvents(19), agentDelta(20, "hello ")]} status="running" />,
+    );
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    layout.syncTipAtBottom();
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    const nested = document.createElement("pre");
+    nested.className = "max-h-64 overflow-auto";
+    Object.defineProperty(nested, "scrollHeight", { configurable: true, value: 800 });
+    Object.defineProperty(nested, "clientHeight", { configurable: true, value: 200 });
+    nested.scrollTop = 120;
+    scroller.appendChild(nested);
+
+    window.getComputedStyle = ((el: Element) => {
+      if (el === nested) {
+        return { overflowY: "auto" } as CSSStyleDeclaration;
+      }
+      return originalGetComputedStyle(el);
+    }) as typeof window.getComputedStyle;
+
+    await actRun(() => {
+      nested.dispatchEvent(
+        new WheelEvent("wheel", { deltaY: -40, deltaX: 0, bubbles: true }),
+      );
+    });
+    await flush();
+    expect(r.container.textContent).not.toContain("Jump to latest");
+    window.getComputedStyle = originalGetComputedStyle;
+    nested.remove();
     layout.restore();
     await r.unmount();
   });
@@ -849,9 +1043,10 @@ describe("MessageTimeline pagination affordances", () => {
     });
     expect(distanceFromBottom(scroller)).toBeLessThan(48);
 
-    // Scroll event with decreasing scrollTop (no wheel) must unpin — the old
-    // path called followTip and fought the reader back to the tip.
+    // Wheel toward older history unpins — fold clamps never synthesize wheel,
+    // so this is the reliable reader-intent edge.
     await actRun(() => {
+      scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }));
       scroller.scrollTop = 1200;
       layout.placeTipAt(1200);
       scroller.dispatchEvent(new Event("scroll"));
@@ -863,10 +1058,7 @@ describe("MessageTimeline pagination affordances", () => {
     await r.unmount();
   });
 
-  test("pinned appends soft-follow the tip; a later scroll-up cancels the glide", async () => {
-    // Soft tip-follow eases toward the bottom. Mid-glide upward scrollTop is
-    // treated as the reader and unpins immediately — glide echoes (downward)
-    // must not swallow that intent.
+  test("pinned tip-debt from growth does not unpin without a reader scroll-up", async () => {
     const frames: FrameRequestCallback[] = [];
     globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
       frames.push(cb);
@@ -892,7 +1084,49 @@ describe("MessageTimeline pagination affordances", () => {
       scroller.dispatchEvent(new Event("scroll"));
     });
 
-    // Tip growth + soft follow reaches the bottom after glide frames drain.
+    // Content grew under a pinned reader; scrollTop stale ⇒ tip-debt. A scroll
+    // echo must keep the pin and recover — not show Jump to latest.
+    layout.setContentHeight(2300);
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await drainFrames(frames);
+    await flush();
+    expect(r.container.textContent).not.toContain("Jump to latest");
+    expect(distanceFromBottom(scroller)).toBeLessThan(48);
+    layout.restore();
+    await r.unmount();
+  });
+
+  test("pinned appends soft-follow the tip; a later scroll-up cancels the camera", async () => {
+    // Tip-follow eases toward the bottom. Mid-follow wheel-up unpins —
+    // camera echoes (downward scrollTop) must not swallow that intent.
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const prefix = manyEvents(19);
+    const initial = [...prefix, agentDelta(20, "hello ")];
+    const r = await renderComponent(<MessageTimeline events={initial} status="running" />);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    layout.syncTipAtBottom();
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    // Tip growth + tip-follow reaches the bottom after camera frames drain.
     layout.setContentHeight(2300);
     await r.rerender(
       <MessageTimeline events={[...initial, agentDelta(21, "world")]} status="running" />,
@@ -902,6 +1136,7 @@ describe("MessageTimeline pagination affordances", () => {
 
     const freedTop = 900;
     await actRun(() => {
+      scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }));
       scroller.scrollTop = freedTop;
       layout.placeTipAt(freedTop + 200);
       scroller.dispatchEvent(new Event("scroll"));
@@ -1327,12 +1562,22 @@ describe("MessageTimeline pagination affordances", () => {
   });
 });
 
+/**
+ * Synthetic vsync clock for tip-follow. Seeded from performance.now() so it
+ * stays on the same timeline as layout/RO driveFollow calls.
+ */
+let frameClockMs = 0;
+
 async function runNextFrame(frames: FrameRequestCallback[]): Promise<void> {
   const frame = frames.shift();
   if (!frame) {
     throw new Error("expected a scheduled animation frame");
   }
-  await actRun(() => frame(performance.now()));
+  if (frameClockMs === 0) {
+    frameClockMs = performance.now();
+  }
+  frameClockMs += 16;
+  await actRun(() => frame(frameClockMs));
 }
 
 async function drainFrames(frames: FrameRequestCallback[]): Promise<void> {
@@ -1340,7 +1585,8 @@ async function drainFrames(frames: FrameRequestCallback[]): Promise<void> {
   while (frames.length > 0) {
     await runNextFrame(frames);
     count += 1;
-    if (count > 100) {
+    // Calm tip-follow (~42 px/s) needs headroom for multi-hundred-px debt.
+    if (count > 800) {
       throw new Error("animation-frame queue did not settle");
     }
   }

--- a/packages/react/test/settle-fold.test.tsx
+++ b/packages/react/test/settle-fold.test.tsx
@@ -1,10 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { registerDom, renderComponent, actRun, flush } from "./render-hook";
-import { TurnSummary } from "../src/timeline/turn-summary";
+import { TurnSummary, useTurnSettleOpen } from "../src/timeline/turn-summary";
 
 registerDom();
 
 const BEAT_AND_MARGIN_MS = 1400;
+/** Keep in sync with `--og-duration-disclose` / TurnSummary DISCLOSE_MS. */
+const DISCLOSE_MS = 120;
+
+function NestFlatProbe() {
+  const nestFlat = useTurnSettleOpen();
+  return <span data-testid="nest-flat">{nestFlat ? "flat" : "nested"}</span>;
+}
 
 describe("TurnSummary settle fold", () => {
   test("mounts open, holds the beat, then auto-collapses", async () => {
@@ -42,6 +49,30 @@ describe("TurnSummary settle fold", () => {
     expect(trigger?.getAttribute("data-state")).toBe("open");
     await flush(BEAT_AND_MARGIN_MS);
     expect(trigger?.getAttribute("data-state")).toBe("open");
+    await r.unmount();
+  });
+
+  test("cancel-close keeps nest-flat through fast collapse; reopen clears it", async () => {
+    const r = await renderComponent(
+      <TurnSummary items={[]} outcome="complete" settleFold>
+        <NestFlatProbe />
+      </TurnSummary>,
+    );
+    const probe = () => r.container.querySelector("[data-testid='nest-flat']")?.textContent;
+    expect(probe()).toBe("flat");
+    const trigger = r.container.querySelector("button");
+    expect(trigger?.getAttribute("data-state")).toBe("open");
+    // Cancel mid-beat: settle CSS phase clears, but nest latch must hold
+    // through the fast collapse so nested chips do not remount mid-height.
+    await actRun(() => trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(trigger?.getAttribute("data-state")).toBe("closed");
+    expect(probe()).toBe("flat");
+    await flush(DISCLOSE_MS + 40);
+    expect(probe()).toBe("nested");
+    // Reader reopens: nested chrome may appear immediately.
+    await actRun(() => trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(trigger?.getAttribute("data-state")).toBe("open");
+    expect(probe()).toBe("nested");
     await r.unmount();
   });
 

--- a/packages/react/test/settle-fold.test.tsx
+++ b/packages/react/test/settle-fold.test.tsx
@@ -1,16 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { registerDom, renderComponent, actRun, flush } from "./render-hook";
 import { TurnSummary, useTurnSettleOpen } from "../src/timeline/turn-summary";
+import {
+  FoldMemoryProvider,
+  inheritFoldRestingState,
+  type FoldRestingState,
+} from "../src/timeline/fold-memory";
+import { MOTION_INSPECT_SCALE } from "../src/lib/motion-inspect";
 
 registerDom();
 
-const BEAT_AND_MARGIN_MS = 1400;
+const BEAT_AND_MARGIN_MS = 1400 * MOTION_INSPECT_SCALE;
 /** Keep in sync with `--og-duration-disclose` / TurnSummary DISCLOSE_MS. */
-const DISCLOSE_MS = 120;
+const DISCLOSE_MS = 120 * MOTION_INSPECT_SCALE;
+const SETTLE_FULL_MS = 2200 * MOTION_INSPECT_SCALE;
 
 function NestFlatProbe() {
-  const nestFlat = useTurnSettleOpen();
-  return <span data-testid="nest-flat">{nestFlat ? "flat" : "nested"}</span>;
+  // settle chrome = force nested chips open (not bare-rail flat-map).
+  const settleChrome = useTurnSettleOpen();
+  return <span data-testid="nest-flat">{settleChrome ? "flat" : "nested"}</span>;
 }
 
 describe("TurnSummary settle fold", () => {
@@ -125,7 +133,7 @@ describe("TurnSummary settle fold", () => {
       </TurnSummary>,
     );
     // Wait for beat + slow collapse + settlePhase clear (1100 + 820).
-    await flush(2200);
+    await flush(SETTLE_FULL_MS);
     const trigger = r.container.querySelector("button");
     expect(trigger?.getAttribute("data-state")).toBe("closed");
     const panel = r.container.querySelector("[data-og-fold-content]");
@@ -145,10 +153,154 @@ describe("TurnSummary settle fold", () => {
     );
     const root = r.container.firstElementChild;
     expect(root?.className ?? "").not.toContain("animate-og-enter");
-    await flush(2200);
+    await flush(SETTLE_FULL_MS);
     expect(r.container.querySelector("button")?.getAttribute("data-state")).toBe("closed");
     // The bug: settling cleared → animate-og-enter toggled on → opacity replay.
     expect(root?.className ?? "").not.toContain("animate-og-enter");
+    await r.unmount();
+  });
+
+  test("fold memory: a completed settle collapse never replays the open beat on remount", async () => {
+    const memory = new Map<string, FoldRestingState>();
+    const chip = (
+      <FoldMemoryProvider value={memory}>
+        <TurnSummary items={[]} outcome="complete" settleFold foldKey="cluster-1">
+          <div>the rows</div>
+        </TurnSummary>
+      </FoldMemoryProvider>
+    );
+    const first = await renderComponent(chip);
+    // Full choreography: beat + slow collapse; resting state is recorded.
+    await flush(SETTLE_FULL_MS);
+    expect(first.container.querySelector("button")?.getAttribute("data-state")).toBe("closed");
+    expect(memory.get("cluster-1")).toBe("closed");
+    await first.unmount();
+
+    // Remount with the same key (activity→turn wrap / key flip): mounts
+    // CLOSED, no settle beat, and the beat window never reopens it.
+    const remount = await renderComponent(chip);
+    const trigger = remount.container.querySelector("button");
+    expect(trigger?.getAttribute("data-state")).toBe("closed");
+    expect(trigger?.className ?? "").not.toContain("animate-og-settle-chip");
+    expect(remount.container.textContent).not.toContain("the rows");
+    await flush(BEAT_AND_MARGIN_MS);
+    expect(trigger?.getAttribute("data-state")).toBe("closed");
+    await remount.unmount();
+  });
+
+  test("fold memory: nest force-open (defaultOpen) cannot reopen a remembered-closed fold", async () => {
+    const memory = new Map<string, FoldRestingState>([["cluster-1", "closed"]]);
+    const r = await renderComponent(
+      <FoldMemoryProvider value={memory}>
+        <TurnSummary items={[]} outcome="complete" defaultOpen bare foldKey="cluster-1">
+          <div>the rows</div>
+        </TurnSummary>
+      </FoldMemoryProvider>,
+    );
+    expect(r.container.querySelector("button")?.getAttribute("data-state")).toBe("closed");
+    expect(r.container.textContent).not.toContain("the rows");
+    await r.unmount();
+  });
+
+  test("fold memory: a reader-closed fold stays closed across a settleFold remount", async () => {
+    const memory = new Map<string, FoldRestingState>();
+    const chip = (
+      <FoldMemoryProvider value={memory}>
+        <TurnSummary items={[]} outcome="complete" settleFold foldKey="cluster-1">
+          <div>the rows</div>
+        </TurnSummary>
+      </FoldMemoryProvider>
+    );
+    const first = await renderComponent(chip);
+    const trigger = first.container.querySelector("button");
+    expect(trigger?.getAttribute("data-state")).toBe("open");
+    // Reader closes mid-beat — their resolution, remembered as closed.
+    await actRun(() => trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(memory.get("cluster-1")).toBe("closed");
+    await first.unmount();
+
+    const remount = await renderComponent(chip);
+    expect(remount.container.querySelector("button")?.getAttribute("data-state")).toBe("closed");
+    await flush(BEAT_AND_MARGIN_MS);
+    expect(remount.container.querySelector("button")?.getAttribute("data-state")).toBe("closed");
+    await remount.unmount();
+  });
+
+  test("fold memory: a reader-opened fold remounts open and is not auto-collapsed", async () => {
+    const memory = new Map<string, FoldRestingState>();
+    const chip = (
+      <FoldMemoryProvider value={memory}>
+        <TurnSummary items={[]} outcome="complete" settleFold foldKey="cluster-1">
+          <div>the rows</div>
+        </TurnSummary>
+      </FoldMemoryProvider>
+    );
+    const first = await renderComponent(chip);
+    await flush(SETTLE_FULL_MS);
+    const trigger = first.container.querySelector("button");
+    expect(trigger?.getAttribute("data-state")).toBe("closed");
+    // Reader reopens after the settle: remembered as open.
+    await actRun(() => trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(memory.get("cluster-1")).toBe("open");
+    await first.unmount();
+
+    const remount = await renderComponent(chip);
+    const reTrigger = remount.container.querySelector("button");
+    expect(reTrigger?.getAttribute("data-state")).toBe("open");
+    await flush(BEAT_AND_MARGIN_MS);
+    expect(reTrigger?.getAttribute("data-state")).toBe("open");
+    await remount.unmount();
+  });
+
+  test("fold memory: activity→turn key inheritance keeps the chip closed", async () => {
+    const memory = new Map<string, FoldRestingState>();
+    const activity = (
+      <FoldMemoryProvider value={memory}>
+        <TurnSummary items={[]} outcome="complete" settleFold foldKey="activity-tool-1">
+          <div>the rows</div>
+        </TurnSummary>
+      </FoldMemoryProvider>
+    );
+    const first = await renderComponent(activity);
+    await flush(SETTLE_FULL_MS);
+    expect(memory.get("activity-tool-1")).toBe("closed");
+    await first.unmount();
+
+    inheritFoldRestingState(memory, "turn-abc", ["activity-tool-1"]);
+    expect(memory.get("turn-abc")).toBe("closed");
+
+    const turn = await renderComponent(
+      <FoldMemoryProvider value={memory}>
+        <TurnSummary items={[]} outcome="complete" settleFold foldKey="turn-abc">
+          <div>the rows</div>
+        </TurnSummary>
+      </FoldMemoryProvider>,
+    );
+    const trigger = turn.container.querySelector("button");
+    expect(trigger?.getAttribute("data-state")).toBe("closed");
+    expect(trigger?.className ?? "").not.toContain("animate-og-settle-chip");
+    await flush(BEAT_AND_MARGIN_MS);
+    expect(trigger?.getAttribute("data-state")).toBe("closed");
+    await turn.unmount();
+  });
+
+  test("fold memory: a settleFold rising edge is inert once remembered closed", async () => {
+    const memory = new Map<string, FoldRestingState>([["cluster-1", "closed"]]);
+    const shell = (settleFold: boolean) => (
+      <FoldMemoryProvider value={memory}>
+        <TurnSummary items={[]} outcome="complete" settleFold={settleFold} foldKey="cluster-1">
+          <div>the rows</div>
+        </TurnSummary>
+      </FoldMemoryProvider>
+    );
+    const r = await renderComponent(shell(false));
+    const trigger = r.container.querySelector("button");
+    expect(trigger?.getAttribute("data-state")).toBe("closed");
+    await r.rerender(shell(true));
+    // No open beat: the fold already resolved once.
+    expect(trigger?.getAttribute("data-state")).toBe("closed");
+    await flush(BEAT_AND_MARGIN_MS);
+    expect(trigger?.getAttribute("data-state")).toBe("closed");
     await r.unmount();
   });
 
@@ -161,7 +313,7 @@ describe("TurnSummary settle fold", () => {
     const trigger = r.container.querySelector("button");
     expect(trigger?.getAttribute("data-state")).toBe("open");
     expect(trigger?.textContent ?? "").not.toContain("8s");
-    await flush(2200);
+    await flush(SETTLE_FULL_MS);
     expect(trigger?.getAttribute("data-state")).toBe("closed");
     expect(trigger?.textContent ?? "").toContain("8s");
     await r.unmount();

--- a/packages/react/test/soften-streaming-markdown.test.ts
+++ b/packages/react/test/soften-streaming-markdown.test.ts
@@ -14,11 +14,30 @@ describe("softenStreamingMarkdown", () => {
     );
   });
 
-  test("closes an open fence", () => {
+  test("closes an open fence that already has a body", () => {
     const open = "Intro\n\n```ts\nconst x = 1;";
     const softened = softenStreamingMarkdown(open);
     expect(softened.endsWith("\n```")).toBe(true);
     expect(countFences(softened) % 2).toBe(0);
+  });
+
+  test("soft-close does not invent a blank line when body already ends with \\n", () => {
+    // Real closer is almost always `\n```` after a body newline. A soft `\n```
+    // would add an empty code line that vanishes on close → height flicker.
+    const open = "```ts\nconst x = 1;\n";
+    const softened = softenStreamingMarkdown(open);
+    expect(softened).toBe("```ts\nconst x = 1;\n```");
+    const closed = "```ts\nconst x = 1;\n```";
+    expect(softenStreamingMarkdown(closed)).toBe(closed);
+  });
+
+  test("soft-closes an empty fence opener so chrome appears once at ```", () => {
+    const open = "## Architecture sketch\n\n```\n";
+    const softened = softenStreamingMarkdown(open);
+    expect(countFences(softened) % 2).toBe(0);
+    // Blank line before the opener must survive soft-close (split/join used to
+    // eat it and shift the heading when ``` chrome appeared).
+    expect(softened).toBe("## Architecture sketch\n\n```\n```");
   });
 
   test("does not invent closers inside a finished fence", () => {
@@ -36,6 +55,14 @@ describe("softenStreamingMarkdown", () => {
   test("closing chunk that completes bold needs no extra softener", () => {
     const full = "this phrase is **bold mid-stream** until the closer lands.";
     expect(softenStreamingMarkdown(full)).toBe(full);
+  });
+
+  test("does not invent an extra trailing newline on ordinary prose", () => {
+    // Regression: end-flush used to append `\n` on top of split's trailing
+    // `""`, turning every `hello\n` into `hello\n\n` (blank line flicker).
+    expect(softenStreamingMarkdown("hello\n")).toBe("hello\n");
+    expect(softenStreamingMarkdown("a\n\nb\n")).toBe("a\n\nb\n");
+    expect(softenStreamingMarkdown("**bold\n")).toBe("**bold**\n");
   });
 });
 

--- a/packages/react/test/stream-reveal.test.tsx
+++ b/packages/react/test/stream-reveal.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { registerDom, renderComponent, flush } from "./render-hook";
 import { createStreamReveal, INK_FADE_MS } from "../src/components/stream-reveal";
+import { MOTION_INSPECT_SCALE } from "../src/lib/motion-inspect";
+
+/** Keep in sync with markdown.tsx REVEAL_LINGER_MS / MARKDOWN_SETTLE_MS. */
+const REVEAL_LINGER_MS = 480 * MOTION_INSPECT_SCALE;
+const MARKDOWN_SETTLE_MS = 480 * MOTION_INSPECT_SCALE;
 import { Markdown } from "../src/components/markdown";
 
 registerDom();
@@ -15,8 +20,7 @@ describe("createStreamReveal", () => {
     expect(first).not.toBeNull();
     expect(last).toBe(first);
 
-    // A later append animates only the new suffix (still inside the first
-    // batch's age window at +900ms with the current fade length).
+    // A later append animates only the new suffix.
     reveal.observe("hello world and beyond", 1900);
     expect(reveal.delayFor(12, 1900)).not.toBeNull();
 
@@ -98,15 +102,19 @@ describe("Markdown streaming tip ink", () => {
     await r.unmount();
   });
 
-  test("after streaming ends, the body unwinds to plain markdown", async () => {
-    const r = await renderComponent(<Markdown streaming>hello world</Markdown>);
-    expect(r.container.querySelector(".og-stream-ink")).not.toBeNull();
-    await r.rerender(<Markdown streaming={false}>hello world</Markdown>);
-    await flush(1000);
-    expect(r.container.querySelector(".og-stream-ink")).toBeNull();
-    expect(r.container.textContent).toContain("hello world");
-    await r.unmount();
-  });
+  test(
+    "after streaming ends, the body unwinds to plain markdown",
+    async () => {
+      const r = await renderComponent(<Markdown streaming>hello world</Markdown>);
+      expect(r.container.querySelector(".og-stream-ink")).not.toBeNull();
+      await r.rerender(<Markdown streaming={false}>hello world</Markdown>);
+      await flush(REVEAL_LINGER_MS + 100);
+      expect(r.container.querySelector(".og-stream-ink")).toBeNull();
+      expect(r.container.textContent).toContain("hello world");
+      await r.unmount();
+    },
+    15_000,
+  );
 
   test("non-streaming bodies never carry ink spans", async () => {
     const r = await renderComponent(<Markdown>hello world</Markdown>);
@@ -114,15 +122,19 @@ describe("Markdown streaming tip ink", () => {
     await r.unmount();
   });
 
-  test("stream end crystallizes when the reveal pipeline tears down", async () => {
-    const r = await renderComponent(<Markdown streaming>**bold** text</Markdown>);
-    expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
-    await r.rerender(<Markdown streaming={false}>**bold** text</Markdown>);
-    expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
-    await flush(950);
-    expect(r.container.querySelector(".og-markdown-settle")).not.toBeNull();
-    await flush(600);
-    expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
-    await r.unmount();
-  });
+  test(
+    "stream end crystallizes when the reveal pipeline tears down",
+    async () => {
+      const r = await renderComponent(<Markdown streaming>**bold** text</Markdown>);
+      expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
+      await r.rerender(<Markdown streaming={false}>**bold** text</Markdown>);
+      expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
+      await flush(REVEAL_LINGER_MS + 100);
+      expect(r.container.querySelector(".og-markdown-settle")).not.toBeNull();
+      await flush(MARKDOWN_SETTLE_MS + 100);
+      expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
+      await r.unmount();
+    },
+    15_000,
+  );
 });

--- a/packages/react/test/stream-reveal.test.tsx
+++ b/packages/react/test/stream-reveal.test.tsx
@@ -102,19 +102,15 @@ describe("Markdown streaming tip ink", () => {
     await r.unmount();
   });
 
-  test(
-    "after streaming ends, the body unwinds to plain markdown",
-    async () => {
-      const r = await renderComponent(<Markdown streaming>hello world</Markdown>);
-      expect(r.container.querySelector(".og-stream-ink")).not.toBeNull();
-      await r.rerender(<Markdown streaming={false}>hello world</Markdown>);
-      await flush(REVEAL_LINGER_MS + 100);
-      expect(r.container.querySelector(".og-stream-ink")).toBeNull();
-      expect(r.container.textContent).toContain("hello world");
-      await r.unmount();
-    },
-    15_000,
-  );
+  test("after streaming ends, the body unwinds to plain markdown", async () => {
+    const r = await renderComponent(<Markdown streaming>hello world</Markdown>);
+    expect(r.container.querySelector(".og-stream-ink")).not.toBeNull();
+    await r.rerender(<Markdown streaming={false}>hello world</Markdown>);
+    await flush(REVEAL_LINGER_MS + 100);
+    expect(r.container.querySelector(".og-stream-ink")).toBeNull();
+    expect(r.container.textContent).toContain("hello world");
+    await r.unmount();
+  }, 15_000);
 
   test("non-streaming bodies never carry ink spans", async () => {
     const r = await renderComponent(<Markdown>hello world</Markdown>);
@@ -122,19 +118,15 @@ describe("Markdown streaming tip ink", () => {
     await r.unmount();
   });
 
-  test(
-    "stream end crystallizes when the reveal pipeline tears down",
-    async () => {
-      const r = await renderComponent(<Markdown streaming>**bold** text</Markdown>);
-      expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
-      await r.rerender(<Markdown streaming={false}>**bold** text</Markdown>);
-      expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
-      await flush(REVEAL_LINGER_MS + 100);
-      expect(r.container.querySelector(".og-markdown-settle")).not.toBeNull();
-      await flush(MARKDOWN_SETTLE_MS + 100);
-      expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
-      await r.unmount();
-    },
-    15_000,
-  );
+  test("stream end crystallizes when the reveal pipeline tears down", async () => {
+    const r = await renderComponent(<Markdown streaming>**bold** text</Markdown>);
+    expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
+    await r.rerender(<Markdown streaming={false}>**bold** text</Markdown>);
+    expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
+    await flush(REVEAL_LINGER_MS + 100);
+    expect(r.container.querySelector(".og-markdown-settle")).not.toBeNull();
+    await flush(MARKDOWN_SETTLE_MS + 100);
+    expect(r.container.querySelector(".og-markdown-settle")).toBeNull();
+    await r.unmount();
+  }, 15_000);
 });

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -757,9 +757,7 @@ describe("MessageTimeline — settled turn folding", () => {
     await r.unmount();
   });
 
-  test(
-    "a cluster that finished its settle fold stays closed as siblings append and the turn wraps",
-    async () => {
+  test("a cluster that finished its settle fold stays closed as siblings append and the turn wraps", async () => {
     resetTimelineEvents();
     // Grand finale choreography, streamed live: tool marathon → narration
     // (cluster one settle-folds) → more tools → finale text (cluster two
@@ -839,9 +837,7 @@ describe("MessageTimeline — settled turn folding", () => {
     expect(triggers.slice(1).every((t) => t.getAttribute("data-state") === "closed")).toBe(true);
 
     await r.unmount();
-  },
-    15_000,
-  );
+  }, 15_000);
 
   test("a failed turn keeps nested cluster chips quiet under the outer failure", async () => {
     resetTimelineEvents();

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -676,8 +676,9 @@ describe("MessageTimeline — settled turn folding", () => {
     await flush();
 
     const triggers = turnSummaryTriggers(r.container);
-    // One settled OUTER chip. Successful summaries are intentionally quiet, so
-    // only the disclosure chevron remains; the final answer sits outside it.
+    // Bulk/history paint: no settle beat — one settled OUTER chip. Successful
+    // summaries are intentionally quiet, so only the disclosure chevron remains;
+    // the final answer sits outside it.
     expect(triggers).toHaveLength(1);
     expect(triggers[0]?.querySelectorAll("svg")).toHaveLength(1);
     expect(r.container.textContent).toContain("All finished.");
@@ -720,22 +721,27 @@ describe("MessageTimeline — settled turn folding", () => {
     // Fresh turn key + settleFold: open during the beat, not snapped shut.
     expect(outer?.getAttribute("data-state")).toBe("open");
     expect(outer?.className ?? "").toContain("animate-og-settle-chip");
-    // Settle beat stays ONE layer — nested chips wait until the reader expands
-    // after collapse (so we never flash "N steps" over closed "1 step" rows).
-    expect(triggers).toHaveLength(1);
+    // Settle beat keeps nested structure (force-open) — never flat-map to bare
+    // rails (that flash made clusters look unordered then re-nest on expand).
+    expect(triggers).toHaveLength(3);
+    expect(triggers.slice(1).every((t) => t.getAttribute("data-state") === "open")).toBe(true);
     expect(r.container.textContent).toContain("Mid-turn checkpoint");
     expect(r.container.textContent).toContain("step one");
 
-    // Mid-collapse (beat done, slow close still running): body must stay flat.
-    // Nested chips remounting here yank height and read as a hard snap.
+    // Mid-collapse: nested chips stay force-open (same height) — remounting
+    // them closed here would yank height and read as a hard snap.
     await flush(1150);
     expect(outer?.getAttribute("data-state")).toBe("closed");
-    expect(turnSummaryTriggers(r.container)).toHaveLength(1);
+    expect(turnSummaryTriggers(r.container)).toHaveLength(3);
     expect(r.container.textContent).toContain("step one");
 
-    // Settle chrome clears after the slow collapse; expand then nests.
+    // Settle chrome clears after the slow collapse; nested remount closed.
     await flush(900);
     expect(outer?.getAttribute("data-state")).toBe("closed");
+    const afterChrome = turnSummaryTriggers(r.container);
+    // Presence may keep closed content mounted briefly — nested must be closed.
+    expect(afterChrome[0]).toBe(outer);
+    expect(afterChrome.slice(1).every((t) => t.getAttribute("data-state") === "closed")).toBe(true);
 
     await act(async () => {
       outer?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -750,6 +756,92 @@ describe("MessageTimeline — settled turn folding", () => {
 
     await r.unmount();
   });
+
+  test(
+    "a cluster that finished its settle fold stays closed as siblings append and the turn wraps",
+    async () => {
+    resetTimelineEvents();
+    // Grand finale choreography, streamed live: tool marathon → narration
+    // (cluster one settle-folds) → more tools → finale text (cluster two
+    // settle-folds) → turn.completed (wrap). Nothing that already settled
+    // closed may reopen at any point.
+    const phase1 = [
+      timelineEvent("user.message", { text: "Grand finale" }),
+      timelineEvent("agent.toolCall.created", {
+        id: "call-1",
+        name: "exec_command",
+        arguments: { cmd: "step one" },
+      }),
+      timelineEvent("agent.toolCall.output", { id: "call-1", output: "ok" }),
+    ];
+    const r = await renderComponent(<MessageTimeline events={phase1} status="running" />);
+    await flush();
+    let triggers = turnSummaryTriggers(r.container);
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0]?.getAttribute("data-state")).toBe("open");
+
+    // Narration arrives → cluster one runs its full settle choreography.
+    const phase2 = [
+      ...phase1,
+      timelineEvent("agent.message.completed", { text: "Mid-turn checkpoint" }),
+    ];
+    await r.rerender(<MessageTimeline events={phase2} status="running" />);
+    await flush(2200);
+    triggers = turnSummaryTriggers(r.container);
+    expect(triggers[0]?.getAttribute("data-state")).toBe("closed");
+
+    // More tools append below: the settled cluster must stay closed.
+    const phase3 = [
+      ...phase2,
+      timelineEvent("agent.toolCall.created", {
+        id: "call-2",
+        name: "exec_command",
+        arguments: { cmd: "step two" },
+      }),
+      timelineEvent("agent.toolCall.output", { id: "call-2", output: "ok" }),
+    ];
+    await r.rerender(<MessageTimeline events={phase3} status="running" />);
+    await flush();
+    triggers = turnSummaryTriggers(r.container);
+    expect(triggers).toHaveLength(2);
+    expect(triggers[0]?.getAttribute("data-state")).toBe("closed");
+    expect(triggers[1]?.getAttribute("data-state")).toBe("open");
+
+    // Finale text folds cluster two the same way.
+    const phase4 = [...phase3, timelineEvent("agent.message.completed", { text: "All finished." })];
+    await r.rerender(<MessageTimeline events={phase4} status="running" />);
+    await flush(2200);
+    triggers = turnSummaryTriggers(r.container);
+    expect(triggers.every((t) => t.getAttribute("data-state") === "closed")).toBe(true);
+
+    // Snappy close: the turn wraps. The NEW outer chip takes its one settle
+    // beat, but the clusters that already settled closed must not reopen —
+    // force-opening them here was the "already-collapsed cluster auto-expands
+    // at the end" bug.
+    await r.rerender(
+      <MessageTimeline events={[...phase4, timelineEvent("turn.completed", {})]} status="idle" />,
+    );
+    await flush();
+    triggers = turnSummaryTriggers(r.container);
+    expect(triggers).toHaveLength(3);
+    const outer = triggers[0];
+    expect(outer?.getAttribute("data-state")).toBe("open");
+    expect(outer?.className ?? "").toContain("animate-og-settle-chip");
+    expect(triggers.slice(1).every((t) => t.getAttribute("data-state") === "closed")).toBe(true);
+    // Narration (visible pre-wrap) rides the beat; folded step rows do not.
+    expect(r.container.textContent).toContain("Mid-turn checkpoint");
+    expect(r.container.textContent).not.toContain("step one");
+
+    // Through the collapse and after chrome clears: everything stays closed.
+    await flush(2200);
+    triggers = turnSummaryTriggers(r.container);
+    expect(triggers[0]?.getAttribute("data-state")).toBe("closed");
+    expect(triggers.slice(1).every((t) => t.getAttribute("data-state") === "closed")).toBe(true);
+
+    await r.unmount();
+  },
+    15_000,
+  );
 
   test("a failed turn keeps nested cluster chips quiet under the outer failure", async () => {
     resetTimelineEvents();

--- a/packages/react/test/tip-follow.test.ts
+++ b/packages/react/test/tip-follow.test.ts
@@ -1,0 +1,468 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createTipFollowState,
+  readerScrollUpPx,
+  tipFollowCancel,
+  tipFollowCompensateShrink,
+  tipFollowNoteGrowth,
+  tipFollowStep,
+  tipFollowTauMs,
+  TIP_FOLLOW_HOT_IDLE_MS,
+  TIP_FOLLOW_LINE_GROWTH_PX,
+  TIP_FOLLOW_LINE_TAU_MS,
+  TIP_FOLLOW_SETTLE_TAU_MS,
+  TIP_FOLLOW_SNAP_PX,
+  TIP_FOLLOW_TAU_MAX_MS,
+  TIP_FOLLOW_TAU_MIN_MS,
+  TIP_FOLLOW_VELOCITY_ARM_DEBT_PX,
+} from "../src/components/tip-follow";
+import { MOTION_INSPECT_SCALE } from "../src/lib/motion-inspect";
+
+describe("tipFollowCompensateShrink", () => {
+  test("at tip, shrink keeps the tip glued (same as maxScroll fall)", () => {
+    expect(tipFollowCompensateShrink(1600, 2000, 1500, 400)).toBe(1100);
+  });
+
+  test("mid-document shrink preserves on-screen pixels", () => {
+    expect(tipFollowCompensateShrink(1000, 2000, 1500, 400)).toBe(500);
+  });
+
+  test("non-shrink leaves scrollTop alone", () => {
+    expect(tipFollowCompensateShrink(1600, 2000, 2000, 400)).toBe(1600);
+  });
+
+  test("tiny reflow shrink is ignored (no micro bob)", () => {
+    expect(tipFollowCompensateShrink(1600, 2000, 1998, 400)).toBe(1600);
+  });
+});
+
+describe("readerScrollUpPx", () => {
+  test("fold/composer clamp is not reader intent", () => {
+    expect(readerScrollUpPx(1600, 1100, 1600, 1100)).toBe(0);
+  });
+
+  test("real scroll-up while maxScroll holds is reader intent", () => {
+    expect(readerScrollUpPx(1600, 1400, 1600, 1600)).toBe(200);
+  });
+
+  test("growth increasing maxScroll does not invent reader-up", () => {
+    expect(readerScrollUpPx(1600, 1600, 1600, 1900)).toBe(0);
+  });
+});
+
+describe("tipFollowTauMs", () => {
+  test("small debt is calm; large debt catches up", () => {
+    expect(tipFollowTauMs(8, 0)).toBeGreaterThan(tipFollowTauMs(120, 0));
+    expect(tipFollowTauMs(0, 0)).toBe(TIP_FOLLOW_TAU_MAX_MS);
+    expect(tipFollowTauMs(10_000, 0)).toBe(TIP_FOLLOW_TAU_MIN_MS);
+  });
+
+  test("velocity does not yank near the tip; arms once tip-debt piles up", () => {
+    expect(tipFollowTauMs(28, 800)).toBe(tipFollowTauMs(28, 0));
+    const behind = TIP_FOLLOW_VELOCITY_ARM_DEBT_PX + 40;
+    expect(tipFollowTauMs(behind, 800)).toBeLessThan(tipFollowTauMs(behind, 0));
+  });
+
+  test("hot floors urgency above calm; idle settle uses longer τ", () => {
+    expect(tipFollowTauMs(28, 0, false, true)).toBeLessThan(tipFollowTauMs(28, 0, false, false));
+    expect(tipFollowTauMs(28, 0, true)).toBe(TIP_FOLLOW_SETTLE_TAU_MS);
+    expect(TIP_FOLLOW_SETTLE_TAU_MS).toBeGreaterThan(TIP_FOLLOW_TAU_MAX_MS);
+  });
+
+  test("hot line-sized debt uses the short line τ", () => {
+    expect(tipFollowTauMs(28, 0, false, true)).toBe(TIP_FOLLOW_LINE_TAU_MS);
+  });
+});
+
+describe("tipFollowNoteGrowth", () => {
+  test("positive growth extends the hot window", () => {
+    let state = createTipFollowState();
+    state = tipFollowNoteGrowth(state, 1000, 1000);
+    state = tipFollowNoteGrowth(state, 1024, 1100);
+    expect(state.hotUntil).toBe(1100 + TIP_FOLLOW_HOT_IDLE_MS);
+    expect(state.lastHeight).toBe(1024);
+  });
+});
+
+describe("tipFollowStep", () => {
+  test("line growth eases in — first frame is not a hard bite of Δh", () => {
+    expect(28).toBeLessThanOrEqual(TIP_FOLLOW_LINE_GROWTH_PX);
+    let state = createTipFollowState();
+    state = tipFollowNoteGrowth(state, 2000, 0);
+    const first = tipFollowStep(state, {
+      scrollTop: 1600,
+      scrollHeight: 2028,
+      clientHeight: 400,
+      now: 10,
+      pinned: true,
+      reducedMotion: false,
+      revealed: true,
+    });
+    const moved = first.scrollTop - 1600;
+    // Soft accel: well under half a line on frame 0; velocity is armed.
+    expect(moved).toBeGreaterThan(0);
+    expect(moved).toBeLessThan(28 * 0.35);
+    expect(first.state.scrollVelocity).toBeGreaterThan(0);
+    expect(first.state.running).toBe(true);
+
+    // Later frames move more as velocity rises (ease-in), then settle.
+    let scrollTop = first.scrollTop;
+    state = first.state;
+    let peakStep = moved;
+    for (let i = 0; i < 8; i += 1) {
+      const next = tipFollowStep(state, {
+        scrollTop,
+        scrollHeight: 2028,
+        clientHeight: 400,
+        now: 10 + (i + 1) * 16,
+        pinned: true,
+        reducedMotion: false,
+        revealed: true,
+      });
+      peakStep = Math.max(peakStep, next.scrollTop - scrollTop);
+      scrollTop = next.scrollTop;
+      state = next.state;
+    }
+    expect(peakStep).toBeGreaterThan(moved);
+  });
+
+  test("camera never overshoots the tip", () => {
+    let state = createTipFollowState();
+    state = tipFollowNoteGrowth(state, 2000, 0);
+    state = { ...state, scrollVelocity: 2000 }; // huge leftover velocity
+    const next = tipFollowStep(state, {
+      scrollTop: 1610,
+      scrollHeight: 2020,
+      clientHeight: 400,
+      now: 20,
+      pinned: true,
+      reducedMotion: false,
+      revealed: true,
+    });
+    expect(next.scrollTop).toBeLessThanOrEqual(1620);
+    if (next.scrollTop === 1620) {
+      expect(next.state.scrollVelocity).toBe(0);
+    }
+  });
+
+  test("sparse line while behind still eases without a one-frame snap", () => {
+    let state = createTipFollowState();
+    state = tipFollowNoteGrowth(state, 2000, 0);
+    const first = tipFollowStep(state, {
+      scrollTop: 1400,
+      scrollHeight: 2028,
+      clientHeight: 400,
+      now: 10,
+      pinned: true,
+      reducedMotion: false,
+      revealed: true,
+    });
+    expect(first.scrollTop).toBeGreaterThan(1400);
+    expect(first.scrollTop).toBeLessThan(1628);
+    expect(first.state.running).toBe(true);
+  });
+
+  test("idle settle decelerates into the tip; growth breaks out to catch-up", () => {
+    let state = createTipFollowState();
+    state = tipFollowNoteGrowth(state, 2000, 0);
+    state = {
+      ...state,
+      lastHeight: 2040,
+      hotUntil: 0,
+      lastTs: 5_000,
+      scrollVelocity: 0,
+    };
+    const settle = tipFollowStep(state, {
+      scrollTop: 1620,
+      scrollHeight: 2040,
+      clientHeight: 400,
+      now: 5_000 + 16,
+      pinned: true,
+      reducedMotion: false,
+      revealed: true,
+    });
+    const settleDelta = settle.scrollTop - 1620;
+    expect(settleDelta).toBeGreaterThan(0);
+    expect(settleDelta).toBeLessThan(8);
+
+    let scrollTop = settle.scrollTop;
+    const breakout = tipFollowStep(settle.state, {
+      scrollTop,
+      scrollHeight: 2100,
+      clientHeight: 400,
+      now: 5_000 + 37 * 16,
+      pinned: true,
+      reducedMotion: false,
+      revealed: true,
+    });
+    expect(breakout.scrollTop - scrollTop).toBeGreaterThan(0);
+  });
+
+  test("growthVelocity decays when height is flat", () => {
+    let state = {
+      ...createTipFollowState(),
+      lastHeight: 2000,
+      hotUntil: 0,
+      growthVelocity: 200,
+      lastTs: 1000,
+    };
+    const next = tipFollowStep(state, {
+      scrollTop: 1580,
+      scrollHeight: 2000,
+      clientHeight: 400,
+      now: 1080,
+      pinned: true,
+      reducedMotion: false,
+      revealed: true,
+    });
+    expect(next.state.growthVelocity).toBeLessThan(200);
+    expect(next.state.growthVelocity).toBeGreaterThan(0);
+  });
+
+  test("large tip-debt catches up faster than a calm one-line debt", () => {
+    const run = (debt: number) => {
+      let state = createTipFollowState();
+      const height = 400 + 1600 + debt;
+      state = tipFollowNoteGrowth(state, height - debt, 0);
+      state = tipFollowNoteGrowth(state, height, 5);
+      const stepped = tipFollowStep(state, {
+        scrollTop: 1600,
+        scrollHeight: height,
+        clientHeight: 400,
+        now: 5,
+        pinned: true,
+        reducedMotion: false,
+        revealed: true,
+      });
+      // Compare after a short accel window so velocity has risen.
+      let scrollTop = stepped.scrollTop;
+      state = stepped.state;
+      for (let i = 0; i < 6; i += 1) {
+        const next = tipFollowStep(state, {
+          scrollTop,
+          scrollHeight: height,
+          clientHeight: 400,
+          now: 5 + (i + 1) * 16,
+          pinned: true,
+          reducedMotion: false,
+          revealed: true,
+        });
+        scrollTop = next.scrollTop;
+        state = next.state;
+      }
+      return scrollTop - 1600;
+    };
+    expect(run(280)).toBeGreaterThan(run(28));
+  });
+
+  test("large wall eases in then reaches tip without a one-frame glue", () => {
+    let state = createTipFollowState();
+    state = tipFollowNoteGrowth(state, 2000, 0);
+    const wall = tipFollowStep(state, {
+      scrollTop: 1600,
+      scrollHeight: 2000 + 320,
+      clientHeight: 400,
+      now: 26,
+      pinned: true,
+      reducedMotion: false,
+      revealed: true,
+    });
+    expect(wall.scrollTop - 1600).toBeLessThan(80);
+    expect(wall.state.running).toBe(true);
+
+    let scrollTop = wall.scrollTop;
+    state = wall.state;
+    const easeFrames = 50 * MOTION_INSPECT_SCALE;
+    for (let i = 0; i < easeFrames; i += 1) {
+      const next = tipFollowStep(state, {
+        scrollTop,
+        scrollHeight: 2320,
+        clientHeight: 400,
+        now: 26 + (i + 1) * 16,
+        pinned: true,
+        reducedMotion: false,
+        revealed: true,
+      });
+      scrollTop = next.scrollTop;
+      state = next.state;
+    }
+    expect(2320 - 400 - scrollTop).toBeLessThan(48);
+  });
+
+  test("token stream stays near tip without hard line snaps", () => {
+    let state = createTipFollowState();
+    let height = 2000;
+    let scrollTop = 1600;
+    state = tipFollowNoteGrowth(state, height, 0);
+    let maxFrameStep = 0;
+    for (let i = 0; i < 90; i += 1) {
+      height += 3;
+      const next = tipFollowStep(state, {
+        scrollTop,
+        scrollHeight: height,
+        clientHeight: 400,
+        now: 16 + i * 16,
+        pinned: true,
+        reducedMotion: false,
+        revealed: true,
+      });
+      maxFrameStep = Math.max(maxFrameStep, next.scrollTop - scrollTop);
+      scrollTop = next.scrollTop;
+      state = next.state;
+    }
+    const tip = height - 400;
+    // Spring lags a little under inspect scale; must not snap whole lines.
+    expect(tip - scrollTop).toBeLessThan(80 * MOTION_INSPECT_SCALE);
+    expect(maxFrameStep).toBeLessThan(24);
+  });
+
+  test("line-sized frames: accel then settle, never a full-line snap", () => {
+    let state = createTipFollowState();
+    let height = 2000;
+    let scrollTop = 1600;
+    state = tipFollowNoteGrowth(state, height, 0);
+    const line = 24;
+    let maxFrameStep = 0;
+    for (let i = 0; i < 8; i += 1) {
+      height += line;
+      const next = tipFollowStep(state, {
+        scrollTop,
+        scrollHeight: height,
+        clientHeight: 400,
+        now: 16 + i * 40 * MOTION_INSPECT_SCALE,
+        pinned: true,
+        reducedMotion: false,
+        revealed: true,
+      });
+      maxFrameStep = Math.max(maxFrameStep, next.scrollTop - scrollTop);
+      scrollTop = next.scrollTop;
+      state = next.state;
+      for (let j = 0; j < 48 * MOTION_INSPECT_SCALE; j += 1) {
+        const ease = tipFollowStep(state, {
+          scrollTop,
+          scrollHeight: height,
+          clientHeight: 400,
+          now: 16 + i * 40 * MOTION_INSPECT_SCALE + (j + 1) * 16,
+          pinned: true,
+          reducedMotion: false,
+          revealed: true,
+        });
+        maxFrameStep = Math.max(maxFrameStep, ease.scrollTop - scrollTop);
+        scrollTop = ease.scrollTop;
+        state = ease.state;
+      }
+    }
+    expect(maxFrameStep).toBeLessThan(line);
+    expect(maxFrameStep).toBeGreaterThan(0);
+    expect(height - 400 - scrollTop).toBeLessThan(12 * MOTION_INSPECT_SCALE);
+  });
+
+  test("parks at debt≈0 and clears camera velocity", () => {
+    let state = createTipFollowState();
+    state = tipFollowNoteGrowth(state, 2000, 0);
+    state = tipFollowNoteGrowth(state, 2024, 100);
+    state = { ...state, scrollVelocity: 40 };
+    const atTip = tipFollowStep(state, {
+      scrollTop: 1624,
+      scrollHeight: 2024,
+      clientHeight: 400,
+      now: 100,
+      pinned: true,
+      reducedMotion: false,
+      revealed: true,
+    });
+    expect(atTip.state.running).toBe(false);
+    expect(atTip.state.scrollVelocity).toBe(0);
+    expect(atTip.state.hotUntil).toBe(100 + TIP_FOLLOW_HOT_IDLE_MS);
+  });
+
+  test("reduced motion and unrevealed snap to the tip", () => {
+    let state = createTipFollowState();
+    state = tipFollowNoteGrowth(state, 2400, 0);
+    const reduced = tipFollowStep(state, {
+      scrollTop: 900,
+      scrollHeight: 2400,
+      clientHeight: 400,
+      now: 20,
+      pinned: true,
+      reducedMotion: true,
+      revealed: true,
+    });
+    expect(reduced.scrollTop).toBe(2000);
+    expect(reduced.state.running).toBe(false);
+    expect(reduced.state.scrollVelocity).toBe(0);
+
+    const hidden = tipFollowStep(state, {
+      scrollTop: 900,
+      scrollHeight: 2400,
+      clientHeight: 400,
+      now: 20,
+      pinned: true,
+      reducedMotion: false,
+      revealed: false,
+    });
+    expect(hidden.scrollTop).toBe(2000);
+  });
+
+  test("cold oversized debt snaps; hot oversized growth eases", () => {
+    const tall = 2000 + TIP_FOLLOW_SNAP_PX + 80;
+    const cold = {
+      ...createTipFollowState(),
+      lastHeight: tall,
+      hotUntil: 0,
+    };
+    const coldSnap = tipFollowStep(cold, {
+      scrollTop: 1600,
+      scrollHeight: tall,
+      clientHeight: 400,
+      now: 10_000,
+      pinned: true,
+      reducedMotion: false,
+      revealed: true,
+    });
+    expect(coldSnap.scrollTop).toBe(tall - 400);
+    expect(coldSnap.state.running).toBe(false);
+
+    let hot = createTipFollowState();
+    hot = tipFollowNoteGrowth(hot, 2000, 0);
+    const tracked = tipFollowStep(hot, {
+      scrollTop: 1600,
+      scrollHeight: tall,
+      clientHeight: 400,
+      now: 20,
+      pinned: true,
+      reducedMotion: false,
+      revealed: true,
+    });
+    expect(tracked.scrollTop).toBeGreaterThan(1600);
+    expect(tracked.scrollTop).toBeLessThan(tall - 400);
+    expect(tracked.state.running).toBe(true);
+  });
+
+  test("cancel clears running and camera velocity", () => {
+    let state = createTipFollowState();
+    state = { ...state, running: true, lastTs: 12, scrollVelocity: 90 };
+    state = tipFollowCancel(state);
+    expect(state.running).toBe(false);
+    expect(state.lastTs).toBe(0);
+    expect(state.scrollVelocity).toBe(0);
+  });
+
+  test("unpinned leaves scrollTop alone and stops", () => {
+    let state = createTipFollowState();
+    state = tipFollowNoteGrowth(state, 2400, 0);
+    state = { ...state, running: true, hotUntil: 500, scrollVelocity: 30 };
+    const next = tipFollowStep(state, {
+      scrollTop: 900,
+      scrollHeight: 2400,
+      clientHeight: 400,
+      now: 100,
+      pinned: false,
+      reducedMotion: false,
+      revealed: true,
+    });
+    expect(next.scrollTop).toBe(900);
+    expect(next.state.running).toBe(false);
+    expect(next.state.scrollVelocity).toBe(0);
+  });
+});

--- a/packages/react/test/trailing-agent-text.test.ts
+++ b/packages/react/test/trailing-agent-text.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { trailingAgentTextAfterTurn } from "../src/components/message-timeline";
+import type { TimelineGroup } from "../src/timeline/types";
+
+function turnWithActivity(turnId: string): TimelineGroup {
+  return {
+    kind: "turn",
+    id: `turn-${turnId}`,
+    outcome: "complete",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    endedAt: "2026-01-01T00:00:01.000Z",
+    groups: [
+      {
+        kind: "activity",
+        id: `activity-${turnId}`,
+        items: [
+          {
+            kind: "reasoning",
+            id: `r-${turnId}`,
+            turnId,
+            text: "thinking",
+            streaming: false,
+            occurredAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function agentMessage(turnId: string | null, text: string): TimelineGroup {
+  return {
+    kind: "item",
+    item: {
+      kind: "agent-message",
+      id: `a-${text}`,
+      turnId,
+      text,
+      streaming: false,
+      occurredAt: "2026-01-01T00:00:01.000Z",
+    },
+  };
+}
+
+describe("trailingAgentTextAfterTurn", () => {
+  test("lifts matching turnId trailing answer", () => {
+    const turn = turnWithActivity("t1");
+    expect(trailingAgentTextAfterTurn(turn, agentMessage("t1", "final answer"))).toBe(
+      "final answer",
+    );
+  });
+
+  test("does not steal the next turn's agent message", () => {
+    const turn = turnWithActivity("t1");
+    expect(trailingAgentTextAfterTurn(turn, agentMessage("t2", "next turn"))).toBeUndefined();
+  });
+
+  test("does not lift when the turn body has no turnIds", () => {
+    const emptyTurn: TimelineGroup = {
+      kind: "turn",
+      id: "turn-orphan",
+      outcome: "complete",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      endedAt: "2026-01-01T00:00:01.000Z",
+      groups: [],
+    };
+    expect(trailingAgentTextAfterTurn(emptyTurn, agentMessage("t1", "answer"))).toBeUndefined();
+  });
+
+  test("does not lift when trailing message has null turnId", () => {
+    const turn = turnWithActivity("t1");
+    expect(trailingAgentTextAfterTurn(turn, agentMessage(null, "answer"))).toBeUndefined();
+  });
+});

--- a/test/e2e/seed/stream-scenarios.ts
+++ b/test/e2e/seed/stream-scenarios.ts
@@ -73,7 +73,14 @@ export type StreamPhase =
       /** Per-section pacing; omit for baseline env token delay. */
       pacing?: StreamPacingInput;
     }
-  | { kind: "tools"; tools: (ctx: StreamCtx) => ToolSpec[]; settleMs?: number }
+  | {
+      kind: "tools";
+      tools: (ctx: StreamCtx) => ToolSpec[];
+      /** Delay from tool created → output. Number or per-index. */
+      settleMs?: number | ((index: number) => number);
+      /** Pause after each tool settles, before the next. Number or per-index. */
+      gapMs?: number | ((index: number) => number);
+    }
   | { kind: "memory-save"; kindLabel: string; preview: string }
   | { kind: "memory-correct"; kindLabel: string; oldPreview: string; preview: string }
   | {
@@ -437,6 +444,104 @@ function mixedToolTour(ctx: StreamCtx): ToolSpec[] {
     writeStdin(ctx.id("t-stdin")),
   ];
 }
+
+/** Temporary: tools only, free-varying cadence — scrub tip-follow / row enter. */
+function verticalScrutinyTools(ctx: StreamCtx, count: number): ToolSpec[] {
+  const cmds = [
+    "git status -sb",
+    "bun install",
+    "bun run typecheck",
+    "rg -n SameSite apps packages",
+    "cat src/auth/middleware.ts | head -40",
+    "mkdir -p artifacts/stream",
+    "curl -fsS http://127.0.0.1:3000/healthz || true",
+    "docker ps --format '{{.Names}}'",
+    "bun test packages/react/test/tip-follow-glide.test.ts",
+    "git diff --stat",
+    "ls -la artifacts/stream",
+    "bun run lint",
+  ];
+  const out: ToolSpec[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const id = ctx.id(`v-${i}`);
+    switch (i % 10) {
+      case 0:
+        out.push(execOk(id, cmds[i % cmds.length]!));
+        break;
+      case 1:
+        out.push(applyPatch(id, `src/stream/row-${i}.ts`, ctx.turnIndex + i));
+        break;
+      case 2:
+        out.push(webSearch(id, `vertical scroll scrutiny pulse ${i}`));
+        break;
+      case 3:
+        out.push(mcpOk(id));
+        break;
+      case 4:
+        out.push(genericTool(id));
+        break;
+      case 5:
+        out.push(writeStdin(id));
+        break;
+      case 6:
+        out.push(execFail(id, "curl -fsS http://missing.invalid/healthz"));
+        break;
+      case 7:
+        out.push(envSecret(id));
+        break;
+      case 8:
+        out.push(mcpIssue(id, `Scrutiny note ${i}`));
+        break;
+      default:
+        out.push(viewImage(id, i % 20 !== 19));
+        break;
+    }
+  }
+  return out;
+}
+
+/** Free-form settle: mix snappy, medium, and laggy tool completions. */
+function freeToolSettleMs(index: number): number {
+  const band = index % 7;
+  if (band === 0) return 35 + (index % 3) * 12;
+  if (band === 1) return 90 + (index % 5) * 18;
+  if (band === 2) return 160 + (index % 4) * 40;
+  if (band === 3) return 280 + (index % 3) * 60;
+  if (band === 4) return 420 + (index % 4) * 80;
+  if (band === 5) return 60 + ((index * 37) % 200);
+  return 520 + ((index * 53) % 380);
+}
+
+/** Free-form gap between tools (after settle). */
+function freeToolGapMs(index: number): number {
+  const band = index % 5;
+  if (band === 0) return 15 + (index % 4) * 8;
+  if (band === 1) return 80 + (index % 6) * 25;
+  if (band === 2) return 180 + (index % 5) * 45;
+  if (band === 3) return 40 + ((index * 41) % 160);
+  return 300 + ((index * 29) % 450);
+}
+
+/**
+ * TEMPORARY scrutiny scenario: only tool rows, one after another, free speed.
+ * Enable with `--tools-only` or `OPENGENI_SEED_STREAM_MODE=tools`.
+ */
+export const SCENARIO_TOOL_VERTICAL_SCRUTINY: StreamScenario = {
+  id: "tool-vertical-scrutiny",
+  title: "TEMP tools-only vertical scrutiny (free varying speed)",
+  userText: (ctx) =>
+    `TEMP scrutiny ${ctx.turnIndex}: stream tools only — watch tip-follow / row enter smoothness.`,
+  phases: [
+    { kind: "reason", text: "Tool marathon only — no prose wall. Varying settle + gap." },
+    { kind: "sleep", ms: 220 },
+    {
+      kind: "tools",
+      tools: (ctx) => verticalScrutinyTools(ctx, 36),
+      settleMs: freeToolSettleMs,
+      gapMs: freeToolGapMs,
+    },
+  ],
+};
 
 const SCENARIO_HUGE_FAST_WALL: StreamScenario = {
   id: "markdown-huge-fast-wall",
@@ -836,6 +941,24 @@ export const STREAM_SCENARIOS: StreamScenario[] = [
 
 export const SCENARIO_COUNT = STREAM_SCENARIOS.length;
 
-export function scenarioForTurn(turnIndex: number): StreamScenario {
+export type StreamScenarioMode = "all" | "tools";
+
+export function resolveStreamScenarioMode(
+  raw: string | undefined = process.env.OPENGENI_SEED_STREAM_MODE,
+): StreamScenarioMode {
+  const value = (raw ?? "all").trim().toLowerCase();
+  if (value === "tools" || value === "tools-only" || value === "tool") {
+    return "tools";
+  }
+  return "all";
+}
+
+export function scenarioForTurn(
+  turnIndex: number,
+  mode: StreamScenarioMode = resolveStreamScenarioMode(),
+): StreamScenario {
+  if (mode === "tools") {
+    return SCENARIO_TOOL_VERTICAL_SCRUTINY;
+  }
   return STREAM_SCENARIOS[(turnIndex - 1) % STREAM_SCENARIOS.length]!;
 }

--- a/test/e2e/seed/stream-session-events.ts
+++ b/test/e2e/seed/stream-session-events.ts
@@ -109,7 +109,11 @@ Default cycles ${SCENARIO_COUNT} rich scenarios (DB append + NATS) until Ctrl+C.
   return { workspaceId, sessionId, mode };
 }
 
-function resolveMs(value: number | ((index: number) => number) | undefined, index: number, fallback: number): number {
+function resolveMs(
+  value: number | ((index: number) => number) | undefined,
+  index: number,
+  fallback: number,
+): number {
   if (value === undefined) return fallback;
   return typeof value === "function" ? value(index) : value;
 }

--- a/test/e2e/seed/stream-session-events.ts
+++ b/test/e2e/seed/stream-session-events.ts
@@ -21,6 +21,8 @@
 //   OPENGENI_SEED_STREAM_TOKEN_MS   baseline delay between token deltas (default 28)
 //   OPENGENI_SEED_STREAM_BURST_MS   pause between phase beats (default 160)
 //   OPENGENI_SEED_STREAM_TURN_MS    pause between scenarios (default 900)
+//   OPENGENI_SEED_STREAM_MODE=tools  TEMP: only the tools-only vertical scrutiny loop
+// Flags: --tools-only
 // Per-message pacing presets (fast/slow/crawl/laggy/burst/yank) override the
 // baseline so one loop exercises fast models, slow models, and stalling streams.
 import {
@@ -36,11 +38,13 @@ import { BASE_URL, WEB_URL } from "./harness";
 import {
   SCENARIO_COUNT,
   resolveStreamPacing,
+  resolveStreamScenarioMode,
   scenarioForTurn,
   type StreamCtx,
   type StreamPacing,
   type StreamPhase,
   type StreamScenario,
+  type StreamScenarioMode,
 } from "./stream-scenarios.ts";
 import type { ToolSpec } from "./monster/payloads.ts";
 
@@ -63,7 +67,11 @@ function resolveNatsUrl(): string {
   return process.env.OPENGENI_NATS_URL ?? "nats://127.0.0.1:4222";
 }
 
-function parseArgs(argv: string[]): { workspaceId: string; sessionId: string } {
+function parseArgs(argv: string[]): {
+  workspaceId: string;
+  sessionId: string;
+  mode: StreamScenarioMode;
+} {
   let workspaceId =
     process.env.OPENGENI_SEED_WORKSPACE_ID ??
     process.env.OPENGENI_STREAM_WORKSPACE_ID ??
@@ -72,6 +80,7 @@ function parseArgs(argv: string[]): { workspaceId: string; sessionId: string } {
     process.env.OPENGENI_SEED_SESSION_ID ??
     process.env.OPENGENI_STREAM_SESSION_ID ??
     DEFAULT_SESSION;
+  let mode = resolveStreamScenarioMode();
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i]!;
     const next = argv[i + 1];
@@ -81,13 +90,28 @@ function parseArgs(argv: string[]): { workspaceId: string; sessionId: string } {
     } else if ((arg === "--session" || arg === "-s") && next) {
       sessionId = next;
       i += 1;
+    } else if (arg === "--tools-only" || arg === "--tools") {
+      mode = "tools";
+    } else if ((arg === "--mode" || arg === "-m") && next) {
+      mode = resolveStreamScenarioMode(next);
+      i += 1;
     } else if (arg === "--help" || arg === "-h") {
-      console.log(`Usage: bun test/e2e/seed/stream-session-events.ts [--workspace UUID] [--session UUID]
-Cycles ${SCENARIO_COUNT} rich scenarios with mixed pacing (DB append + NATS) until Ctrl+C.`);
+      console.log(`Usage: bun test/e2e/seed/stream-session-events.ts [options]
+  --workspace UUID / -w   target workspace
+  --session UUID / -s     target session
+  --tools-only            TEMP: loop tools-only vertical scrutiny (free varying speed)
+  --mode all|tools        same as OPENGENI_SEED_STREAM_MODE
+
+Default cycles ${SCENARIO_COUNT} rich scenarios (DB append + NATS) until Ctrl+C.`);
       process.exit(0);
     }
   }
-  return { workspaceId, sessionId };
+  return { workspaceId, sessionId, mode };
+}
+
+function resolveMs(value: number | ((index: number) => number) | undefined, index: number, fallback: number): number {
+  if (value === undefined) return fallback;
+  return typeof value === "function" ? value(index) : value;
 }
 
 function sleep(ms: number, signal: AbortSignal): Promise<void> {
@@ -268,20 +292,26 @@ async function playPhase(
     case "tools": {
       let published = 0;
       const tools = phase.tools(ctx);
-      const settleMs = phase.settleMs ?? TOOL_SETTLE_DEFAULT_MS;
-      for (const tool of tools) {
+      for (let i = 0; i < tools.length; i += 1) {
         if (signal.aborted) return published;
+        const settleMs = Math.max(20, resolveMs(phase.settleMs, i, TOOL_SETTLE_DEFAULT_MS));
+        const gapMs = Math.max(
+          0,
+          resolveMs(phase.gapMs, i, Math.max(80, Math.floor(settleMs * 0.6))),
+        );
         published += await streamTool(
           db,
           bus,
           workspaceId,
           sessionId,
           ctx.turnId,
-          tool,
+          tools[i]!,
           signal,
           settleMs,
         );
-        await sleep(Math.max(80, Math.floor(settleMs * 0.6)), signal);
+        if (i < tools.length - 1) {
+          await sleep(gapMs, signal);
+        }
       }
       return published;
     }
@@ -431,7 +461,7 @@ async function streamScenario(
 }
 
 async function main(): Promise<void> {
-  const { workspaceId, sessionId } = parseArgs(process.argv.slice(2));
+  const { workspaceId, sessionId, mode } = parseArgs(process.argv.slice(2));
   const databaseUrl = resolveDatabaseUrl();
   const natsUrl = resolveNatsUrl();
   const dbClient = createDb(databaseUrl);
@@ -450,7 +480,9 @@ async function main(): Promise<void> {
   console.log(`[stream] session=${sessionId} status=${session.status}`);
   console.log(`[stream] open: ${link}`);
   console.log(
-    `[stream] ${SCENARIO_COUNT} scenarios · token=${TOKEN_MS}ms burst=${BURST_MS}ms turn=${TURN_MS}ms — Ctrl+C to stop`,
+    mode === "tools"
+      ? `[stream] MODE=tools (TEMP vertical scrutiny) · burst=${BURST_MS}ms turn=${TURN_MS}ms — Ctrl+C to stop`
+      : `[stream] ${SCENARIO_COUNT} scenarios · token=${TOKEN_MS}ms burst=${BURST_MS}ms turn=${TURN_MS}ms — Ctrl+C to stop`,
   );
 
   const ac = new AbortController();
@@ -468,7 +500,7 @@ async function main(): Promise<void> {
   try {
     while (!ac.signal.aborted) {
       turnIndex += 1;
-      const scenario = scenarioForTurn(turnIndex);
+      const scenario = scenarioForTurn(turnIndex, mode);
       console.log(`[stream] ▶ ${scenario.id} — ${scenario.title}`);
       const n = await streamScenario(
         dbClient.db,

--- a/test/e2e/timeline-scroll.browser.e2e.ts
+++ b/test/e2e/timeline-scroll.browser.e2e.ts
@@ -256,9 +256,9 @@ describe("timeline scroll ownership browser regression", () => {
     expect(before.gap).toBeLessThan(48);
 
     await page.evaluate(() => window.timelineScrollHarness!.append());
-    // The follow is a soft glide (an exponential approach, ~80ms time
-    // constant), not an instant snap — wait for it to settle at the bottom
-    // instead of sampling mid-flight.
+    // The follow snaps to the bottom on the commit (and on the next frame
+    // for resize-observed growth) — wait for it to land instead of sampling
+    // between the append and the snap.
     await page.waitForFunction(
       () => {
         const node = document.querySelector("[data-timeline-test] .og-root > div");


### PR DESCRIPTION
## Summary
- Replace hard tip-snap scrolling with a velocity-smoothed tip-follow camera so streaming growth eases in rather than popping one line at a time.
- Keep settle folds from reopening across activity→turn remounts; fade first-live tools without replaying entrance on remount.
- Soften streaming markdown fence closes so crystallize does not flicker blank lines or closers.

## Test plan
- [x] `bun test` tip-follow / settle-fold / soften-streaming-markdown / stream-reveal / activity-row-enter / message-timeline-pagination
- [ ] Open a streaming session and confirm tip-follow feels continuous while tokens arrive
- [ ] Confirm settled tool/activity folds stay collapsed after turn summary settles
- [ ] Confirm unfinished fences soft-close without a flash of an empty line before the real close


Made with [Cursor](https://cursor.com)