### PR TITLE
fix(release): validate embedded candidate package plans

### DIFF
--- a/scripts/release-candidate.test.ts
+++ b/scripts/release-candidate.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   buildReleaseCandidateReceipt,
   deploymentImageDigests,
+  parseReleaseCandidateArgs,
   RELEASE_IMAGE_NAMES,
   RELEASE_IMAGE_ROLES,
   releaseImageNames,
   releaseBomImages,
   validateReleaseCandidateReceipt,
+  verifyReceiptFile,
   type ReleaseCandidateReceipt,
   type ReleaseImageRole,
 } from "./release-candidate";
@@ -36,6 +41,82 @@ const producer = buildReleaseProducerMetadata({
 });
 
 describe("release candidate receipt", () => {
+  test("parses the embedded-distribution package expectation, including an empty plan", () => {
+    expect(
+      parseReleaseCandidateArgs([
+        "--verify",
+        "evidence/release-candidate.json",
+        "--source-sha",
+        sourceSha,
+        "--expected-packages",
+        "@opengeni/react@0.18.0,@opengeni/sdk@0.18.0",
+      ]),
+    ).toEqual({
+      verifyPath: "evidence/release-candidate.json",
+      sourceSha,
+      expectedPackages: "@opengeni/react@0.18.0,@opengeni/sdk@0.18.0",
+    });
+    expect(
+      parseReleaseCandidateArgs([
+        "--verify",
+        "evidence/release-candidate.json",
+        "--source-sha",
+        sourceSha,
+        "--expected-packages",
+        "",
+      ]),
+    ).toEqual({
+      verifyPath: "evidence/release-candidate.json",
+      sourceSha,
+      expectedPackages: "",
+    });
+    expect(() => parseReleaseCandidateArgs(["--expected-packages", ""])).toThrow(
+      "--expected-packages requires --verify",
+    );
+    expect(() =>
+      parseReleaseCandidateArgs([
+        "--verify",
+        "evidence/release-candidate.json",
+        "--source-sha",
+        sourceSha,
+        "--expected-packages",
+      ]),
+    ).toThrow("--expected-packages requires a value");
+  });
+
+  test("binds the CLI package expectation to the receipt", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "opengeni-release-candidate-"));
+    const path = join(directory, "release-candidate.json");
+    const receipt = buildReleaseCandidateReceipt({
+      sourceSha,
+      sourceTreeSha,
+      packages,
+      imageDigests,
+      chart,
+      producer,
+    });
+    await writeFile(path, `${JSON.stringify(receipt)}\n`, "utf8");
+
+    try {
+      await expect(
+        verifyReceiptFile({
+          path,
+          sourceSha,
+          expectedPackages: "@opengeni/react@0.18.0,@opengeni/sdk@0.18.0",
+        }),
+      ).resolves.toBeUndefined();
+      await expect(
+        verifyReceiptFile({
+          path,
+          sourceSha,
+          expectedPackages: "@opengeni/sdk@0.19.0",
+        }),
+      ).rejects.toThrow("package plan");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   test("uses the product chart version independently of the npm package plan", () => {
     const receipt = buildReleaseCandidateReceipt({
       sourceSha,

--- a/scripts/release-candidate.ts
+++ b/scripts/release-candidate.ts
@@ -353,52 +353,70 @@ async function writeReceiptFromEnvironment(): Promise<void> {
   console.log(JSON.stringify({ path: outputPath, sha256, receipt }));
 }
 
-async function verifyReceiptFile(args: { path: string; sourceSha: string }): Promise<void> {
+export async function verifyReceiptFile(args: {
+  path: string;
+  sourceSha: string;
+  expectedPackages: string | null;
+}): Promise<void> {
   const raw = await readFile(resolve(args.path), "utf8");
   if (raw.length > 1024 * 1024) {
     throw new Error("release candidate receipt exceeds 1 MiB");
   }
+  const packageExpectation =
+    args.expectedPackages === null
+      ? {}
+      : { packages: parseExpectedPackages(args.expectedPackages) };
   const receipt = validateReleaseCandidateReceipt(
     parseJson<unknown>("release candidate receipt", raw),
     {
       sourceSha: args.sourceSha,
       ociPrefix: releaseOciPrefixFromEnvironment(),
+      ...packageExpectation,
     },
   );
   console.log(JSON.stringify({ ok: true, receipt }));
 }
 
-function parseArgs(values: string[]): {
+export function parseReleaseCandidateArgs(values: string[]): {
   verifyPath: string | null;
   sourceSha: string;
+  expectedPackages: string | null;
 } {
   const output = {
     verifyPath: null as string | null,
     sourceSha: "",
+    expectedPackages: null as string | null,
   };
   for (let index = 0; index < values.length; index += 1) {
     const flag = values[index];
-    const next = () => {
-      const value = values[++index];
-      if (!value) throw new Error(`${flag} requires a value`);
+    const next = (allowEmpty = false) => {
+      index += 1;
+      if (index >= values.length) throw new Error(`${flag} requires a value`);
+      const value = values[index] ?? "";
+      if (!allowEmpty && !value) throw new Error(`${flag} requires a value`);
       return value;
     };
     if (flag === "--verify") output.verifyPath = next();
     else if (flag === "--source-sha") output.sourceSha = next();
+    else if (flag === "--expected-packages") output.expectedPackages = next(true);
     else throw new Error(`unknown argument: ${flag}`);
   }
   if (output.verifyPath && !output.sourceSha) {
     throw new Error("--verify requires --source-sha");
   }
+  if (output.expectedPackages !== null && !output.verifyPath) {
+    throw new Error("--expected-packages requires --verify");
+  }
   return output;
 }
 
 if (import.meta.main) {
-  const args = parseArgs(process.argv.slice(2));
+  const args = parseReleaseCandidateArgs(process.argv.slice(2));
   if (args.verifyPath) {
     await verifyReceiptFile({
       path: args.verifyPath,
       sourceSha: args.sourceSha,
+      expectedPackages: args.expectedPackages,
     });
   } else {
     await writeReceiptFromEnvironment();


### PR DESCRIPTION
## Summary

- accept the `--expected-packages` flag already used by `release-embedded.yml`
- bind the declared package plan to candidate-receipt validation
- support the documented empty package set for application-only embedded releases
- add parser and receipt-verification regressions

## Failure reproduced

Embedded distribution run `30691946865` failed before publication because `scripts/release-candidate.ts` rejected `--expected-packages` as unknown. No npm, OCI, chart, BOM, or GitHub release mutation occurred.

## Validation

- `bun test scripts/release-candidate.test.ts scripts/release-image-workflow-contract.test.ts`
- `bun run typecheck`
- targeted `oxlint --deny-warnings`
- targeted `oxfmt --check`
- `git diff --check`
- exact failed workflow command replayed successfully against candidate run `30690820095` and its 14-package plan