### PR TITLE
fix(release): separate dogfood image aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,7 +683,7 @@ jobs:
           target: api
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
-          tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-api:sha-{0}', github.sha) || 'opengeni-api:ci' }}
+          tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-api:dogfood-sha-{0}', github.sha) || 'opengeni-api:ci' }}
           build-args: |
             OPENGENI_SERVER_VERSION=sha-${{ github.sha }}
 
@@ -696,7 +696,7 @@ jobs:
           target: worker
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
-          tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-worker:sha-{0}', github.sha) || 'opengeni-worker:ci' }}
+          tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-worker:dogfood-sha-{0}', github.sha) || 'opengeni-worker:ci' }}
           build-args: |
             OPENGENI_SERVER_VERSION=sha-${{ github.sha }}
 
@@ -709,7 +709,7 @@ jobs:
           target: web
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
-          tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-web:sha-{0}', github.sha) || 'opengeni-web:ci' }}
+          tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-web:dogfood-sha-{0}', github.sha) || 'opengeni-web:ci' }}
           build-args: |
             OPENGENI_SERVER_VERSION=sha-${{ github.sha }}
             OPENGENI_DEPLOYMENT_REVISION=${{ github.sha }}
@@ -722,7 +722,7 @@ jobs:
           file: docker/sandbox.Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
-          tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-sandbox:sha-{0}', github.sha) || 'opengeni-sandbox:ci' }}
+          tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-sandbox:dogfood-sha-{0}', github.sha) || 'opengeni-sandbox:ci' }}
 
       - name: Build relay image
         id: relay_image
@@ -732,7 +732,7 @@ jobs:
           file: agent/crates/opengeni-relay/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
-          tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-relay:sha-{0}', github.sha) || 'opengeni-relay:ci' }}
+          tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-relay:dogfood-sha-{0}', github.sha) || 'opengeni-relay:ci' }}
 
       - name: Write exact-main-SHA dogfood receipt
         if: ${{ github.event_name == 'push' }}
@@ -763,7 +763,7 @@ jobs:
             --arg runId "${GITHUB_RUN_ID}" \
             --arg runAttempt "${GITHUB_RUN_ATTEMPT}" \
             --arg chartVersion "$chart_version" \
-            --arg tag "sha-${GITHUB_SHA}" \
+            --arg tag "dogfood-sha-${GITHUB_SHA}" \
             --arg apiDigest "$API_DIGEST" \
             --arg workerDigest "$WORKER_DIGEST" \
             --arg webDigest "$WEB_DIGEST" \

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -133,11 +133,14 @@ describe("release image workflow contract", () => {
     expect(() => Bun.YAML.parse(ci)).not.toThrow();
     expect(images).toContain("packages: write");
     expect(images.match(/push: \$\{\{ github\.event_name == 'push' \}\}/g)).toHaveLength(5);
-    expect(images.match(/:sha-\{0\}', github\.sha\)/g)).toHaveLength(5);
+    expect(images.match(/:dogfood-sha-\{0\}', github\.sha\)/g)).toHaveLength(5);
+    expect(images).not.toMatch(/format\('ghcr\.io\/cloudgeni-ai\/opengeni-[^']+:sha-\{0\}'/);
     expect(images.match(/OPENGENI_SERVER_VERSION=sha-\$\{\{ github\.sha \}\}/g)).toHaveLength(3);
     expect(images).toContain("OPENGENI_DEPLOYMENT_REVISION=${{ github.sha }}");
     expect(images).toContain("Write exact-main-SHA dogfood receipt");
     expect(images).toContain("Upload exact-main-SHA dogfood receipt");
+    expect(images).toContain('--arg tag "dogfood-sha-${GITHUB_SHA}"');
+    expect(images).not.toContain('--arg tag "sha-${GITHUB_SHA}"');
     expect(images).toContain("dogfood-images-${{ github.sha }}");
     expect(images).toContain("dogfood-images.sha256");
     expect(images).toContain("'^sha256:[0-9a-f]{64}$'");


### PR DESCRIPTION
## Summary

- give exact-main dogfood images a dedicated `dogfood-sha-*` tag namespace
- preserve `sha-*` for immutable release-distribution aliases
- add a workflow-contract regression that prevents the two artifact classes from colliding

## Why

Main CI and release publication intentionally embed different runtime versions, so their manifests can differ even at the same source commit. Sharing one tag made the release preflight correctly fail closed. Separate namespaces make both artifact identities unambiguous.

## Validation

- `bun test scripts/release-image-workflow-contract.test.ts`
- workflow YAML parses in the contract test
- `git diff --check`