### PR TITLE
ci: shard unit tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,10 +230,49 @@ jobs:
       - name: Public repository hygiene guard
         run: bun run check:public-hygiene
 
-  test-suite:
-    name: Unit and real-service tests
+  unit-shards:
+    name: Unit tests (shard ${{ matrix.shard }}/4)
     needs: automation-admission
-    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Unit test shard
+        env:
+          # The per-subject FORCE-RLS/OCC suite remains fail-closed on every shard.
+          OPENGENI_REQUIRE_REAL_DB: "1"
+        run: bun run test:unit:shard -- --shard=${{ matrix.shard }}/4
+
+  unit-safety:
+    name: Unit tests (monolithic safety)
+    needs: automation-admission
+    if: ${{ always() && github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -261,10 +300,38 @@ jobs:
 
       - name: Test
         env:
-          # The per-subject FORCE-RLS/OCC suite is a required security gate.
-          # Never turn a missing Docker/PostgreSQL runner into green skipped tests.
+          # Main pushes and trusted dispatches retain the complete monolithic safety net.
           OPENGENI_REQUIRE_REAL_DB: "1"
         run: bun run test:unit
+
+  test-suite:
+    name: Real-service and recovery tests
+    needs: automation-admission
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: React warning-free test gate
         run: bun run test:react:clean
@@ -476,13 +543,16 @@ jobs:
 
   test:
     name: Typecheck and unit tests
-    needs: [source-contracts, test-suite, browser-acceptance, package-contracts]
+    needs: [source-contracts, unit-shards, unit-safety, test-suite, browser-acceptance, package-contracts]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require every split CI lane
         env:
+          EVENT_NAME: ${{ github.event_name }}
           SOURCE_CONTRACTS_RESULT: ${{ needs.source-contracts.result }}
+          UNIT_SHARDS_RESULT: ${{ needs.unit-shards.result }}
+          UNIT_SAFETY_RESULT: ${{ needs.unit-safety.result }}
           TEST_SUITE_RESULT: ${{ needs.test-suite.result }}
           BROWSER_ACCEPTANCE_RESULT: ${{ needs.browser-acceptance.result }}
           PACKAGE_CONTRACTS_RESULT: ${{ needs.package-contracts.result }}
@@ -498,6 +568,32 @@ jobs:
               failed=1
             fi
           done
+
+          require_result() {
+            lane="$1"
+            result="$2"
+            expected="$3"
+            printf '%s=%s (expected %s)\n' "$lane" "$result" "$expected"
+            if [ "$result" != "$expected" ]; then
+              echo "::error::$lane concluded $result; expected $expected for $EVENT_NAME"
+              failed=1
+            fi
+          }
+
+          case "$EVENT_NAME" in
+            pull_request)
+              require_result unit-shards "$UNIT_SHARDS_RESULT" success
+              require_result unit-safety "$UNIT_SAFETY_RESULT" skipped
+              ;;
+            push|workflow_dispatch|schedule)
+              require_result unit-shards "$UNIT_SHARDS_RESULT" skipped
+              require_result unit-safety "$UNIT_SAFETY_RESULT" success
+              ;;
+            *)
+              echo "::error::unsupported CI event $EVENT_NAME"
+              failed=1
+              ;;
+          esac
           exit "$failed"
 
   deployment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: "0 3 * * *"
   workflow_dispatch:
     inputs:
       automation_pr_number:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "format:check": "oxfmt --check",
     "test": "bun test --max-concurrency=8 --timeout=30000",
     "test:unit": "bun test --max-concurrency=8 --timeout=30000",
+    "test:unit:shard": "bun test --max-concurrency=8 --timeout=30000",
     "test:react:clean": "bun scripts/test-react-clean.ts",
     "test:control-algebra": "OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/session-control-algebra.test.ts packages/db/test/session-control-plane.test.ts packages/db/test/session-control-mega-migration.test.ts",
     "test:control-concurrency": "OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/session-control-plane.test.ts packages/db/test/queue-mutations.test.ts packages/db/test/agent-session-commands.test.ts packages/db/test/session-workflow-wake-outbox.test.ts",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "format:check": "oxfmt --check",
     "test": "bun test --max-concurrency=8 --timeout=30000",
     "test:unit": "bun test --max-concurrency=8 --timeout=30000",
-    "test:unit:shard": "bun test --max-concurrency=8 --timeout=30000",
+    "test:unit:shard": "bun test --max-concurrency=1 --timeout=30000",
     "test:react:clean": "bun scripts/test-react-clean.ts",
     "test:control-algebra": "OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/session-control-algebra.test.ts packages/db/test/session-control-plane.test.ts packages/db/test/session-control-mega-migration.test.ts",
     "test:control-concurrency": "OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/session-control-plane.test.ts packages/db/test/queue-mutations.test.ts packages/db/test/agent-session-commands.test.ts packages/db/test/session-workflow-wake-outbox.test.ts",

--- a/packages/react/test/render-hook.tsx
+++ b/packages/react/test/render-hook.tsx
@@ -17,26 +17,18 @@ declare global {
 }
 
 let registered = false;
-let registrationCount = 0;
 
 /** Register DOM globals for this test file; unregisters after the file. */
 export function registerDom(): void {
-  registrationCount += 1;
-  if (!registered) {
-    registered = true;
-    GlobalRegistrator.register();
-    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  if (registered) {
+    return;
   }
-
-  // Bun may execute several DOM test files concurrently in one shard. Every
-  // file that calls registerDom() owns one reference; the first file to finish
-  // must not tear down globals while sibling files are still rendering.
+  registered = true;
+  GlobalRegistrator.register();
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
   afterAll(async () => {
-    registrationCount -= 1;
-    if (registrationCount === 0) {
-      registered = false;
-      await GlobalRegistrator.unregister();
-    }
+    registered = false;
+    await GlobalRegistrator.unregister();
   });
 }
 

--- a/packages/react/test/render-hook.tsx
+++ b/packages/react/test/render-hook.tsx
@@ -17,18 +17,26 @@ declare global {
 }
 
 let registered = false;
+let registrationCount = 0;
 
 /** Register DOM globals for this test file; unregisters after the file. */
 export function registerDom(): void {
-  if (registered) {
-    return;
+  registrationCount += 1;
+  if (!registered) {
+    registered = true;
+    GlobalRegistrator.register();
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
   }
-  registered = true;
-  GlobalRegistrator.register();
-  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+  // Bun may execute several DOM test files concurrently in one shard. Every
+  // file that calls registerDom() owns one reference; the first file to finish
+  // must not tear down globals while sibling files are still rendering.
   afterAll(async () => {
-    registered = false;
-    await GlobalRegistrator.unregister();
+    registrationCount -= 1;
+    if (registrationCount === 0) {
+      registered = false;
+      await GlobalRegistrator.unregister();
+    }
   });
 }
 

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2581,6 +2581,7 @@ describe("workflow contracts", () => {
   const ciText = readFileSync(ciWorkflowPath, "utf8");
   const sealText = readFileSync(sealWorkflowPath, "utf8");
   const releaseAutomationText = readFileSync(releaseAutomationPath, "utf8");
+  const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
   const release = Bun.YAML.parse(releaseText) as any;
   const ci = Bun.YAML.parse(ciText) as any;
   const seal = Bun.YAML.parse(sealText) as any;
@@ -2635,6 +2636,8 @@ describe("workflow contracts", () => {
     expect(ciText).not.toMatch(/pulls\/.+\/reviews/);
     for (const jobName of [
       "source-contracts",
+      "unit-shards",
+      "unit-safety",
       "test-suite",
       "browser-acceptance",
       "package-contracts",
@@ -2676,7 +2679,7 @@ describe("workflow contracts", () => {
     ).toEqual([["Complete exact-head automation CI check", "${{ github.token }}"]]);
   });
 
-  test("runs all 29 source, test, browser, and package gates once behind a fail-closed aggregate", () => {
+  test("shards PR unit tests while preserving every non-unit gate and a monolithic non-PR safety net", () => {
     const laneNames = ["source-contracts", "test-suite", "browser-acceptance", "package-contracts"];
     const expectedGateNames = {
       "source-contracts": [
@@ -2690,7 +2693,6 @@ describe("workflow contracts", () => {
         "Public repository hygiene guard",
       ],
       "test-suite": [
-        "Test",
         "React warning-free test gate",
         "Real workspace capture acceptance",
         "Recovery integration regressions",
@@ -2718,8 +2720,8 @@ describe("workflow contracts", () => {
       ],
     } as const;
     const expectedGates = Object.values(expectedGateNames).flat();
-    expect(expectedGates).toHaveLength(29);
-    expect(new Set(expectedGates)).toHaveProperty("size", 29);
+    expect(expectedGates).toHaveLength(28);
+    expect(new Set(expectedGates)).toHaveProperty("size", 28);
     const allLaneSteps = laneNames.flatMap((jobName) =>
       ci.jobs[jobName].steps.map((step: any) => step.name).filter(Boolean),
     );
@@ -2732,9 +2734,9 @@ describe("workflow contracts", () => {
         expect(allLaneSteps.filter((stepName) => stepName === gateName)).toHaveLength(1);
       }
     }
-    expect(allLaneSteps.filter((stepName) => expectedGates.includes(stepName))).toHaveLength(29);
+    expect(allLaneSteps.filter((stepName) => expectedGates.includes(stepName))).toHaveLength(28);
 
-    const expensiveLaneNames = ["test-suite", "browser-acceptance"];
+    const expensiveLaneNames = ["unit-shards", "unit-safety", "test-suite", "browser-acceptance"];
     for (const jobName of expensiveLaneNames) {
       const lane = ci.jobs[jobName];
       const checkout = lane.steps.find((step: any) => step.name === "Check out repository");
@@ -2768,9 +2770,33 @@ describe("workflow contracts", () => {
       });
     }
 
-    const testStep = ci.jobs["test-suite"].steps.find((step: any) => step.name === "Test");
-    expect(testStep.env).toEqual({ OPENGENI_REQUIRE_REAL_DB: "1" });
-    expect(testStep.run).toBe("bun run test:unit");
+    expect(ci.jobs["test-suite"].name).toBe("Real-service and recovery tests");
+    expect(ci.jobs["test-suite"].steps.some((step: any) => step.name === "Test")).toBe(false);
+
+    const shards = ci.jobs["unit-shards"];
+    expect(shards.name).toBe("Unit tests (shard ${{ matrix.shard }}/4)");
+    expect(shards.needs).toBe("automation-admission");
+    expect(shards.if).toBe("${{ always() && github.event_name == 'pull_request' }}");
+    expect(shards.strategy).toEqual({
+      "fail-fast": false,
+      matrix: { shard: [1, 2, 3, 4] },
+    });
+    const shardStep = shards.steps.find((step: any) => step.name === "Unit test shard");
+    expect(shardStep.env).toEqual({ OPENGENI_REQUIRE_REAL_DB: "1" });
+    expect(shardStep.run).toBe("bun run test:unit:shard -- --shard=${{ matrix.shard }}/4");
+    expect(packageJson.scripts["test:unit:shard"]).toBe(
+      "bun test --max-concurrency=8 --timeout=30000",
+    );
+
+    const safety = ci.jobs["unit-safety"];
+    expect(safety.name).toBe("Unit tests (monolithic safety)");
+    expect(safety.needs).toBe("automation-admission");
+    expect(safety.if).toBe(
+      "${{ always() && github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
+    );
+    const safetyStep = safety.steps.find((step: any) => step.name === "Test");
+    expect(safetyStep.env).toEqual({ OPENGENI_REQUIRE_REAL_DB: "1" });
+    expect(safetyStep.run).toBe("bun run test:unit");
 
     const browser = ci.jobs["browser-acceptance"];
     expect(
@@ -2849,34 +2875,85 @@ describe("workflow contracts", () => {
 
     const aggregate = ci.jobs.test;
     expect(aggregate.name).toBe("Typecheck and unit tests");
-    expect(aggregate.needs).toEqual(laneNames);
+    expect(aggregate.needs).toEqual([
+      "source-contracts",
+      "unit-shards",
+      "unit-safety",
+      "test-suite",
+      "browser-acceptance",
+      "package-contracts",
+    ]);
     expect(aggregate.if).toBe("${{ always() }}");
     const requireLanes = aggregate.steps.find(
       (step: any) => step.name === "Require every split CI lane",
     );
     expect(requireLanes.env).toEqual({
+      EVENT_NAME: "${{ github.event_name }}",
       SOURCE_CONTRACTS_RESULT: "${{ needs.source-contracts.result }}",
+      UNIT_SHARDS_RESULT: "${{ needs.unit-shards.result }}",
+      UNIT_SAFETY_RESULT: "${{ needs.unit-safety.result }}",
       TEST_SUITE_RESULT: "${{ needs.test-suite.result }}",
       BROWSER_ACCEPTANCE_RESULT: "${{ needs.browser-acceptance.result }}",
       PACKAGE_CONTRACTS_RESULT: "${{ needs.package-contracts.result }}",
     });
     expect(requireLanes.run).toContain('if [ "$result" != "success" ]');
-    const aggregateResult = (results: Record<string, string>) =>
+    const aggregateResult = (eventName: string, results: Record<string, string>) =>
       Bun.spawnSync(["bash", "-c", requireLanes.run], {
-        env: { ...process.env, ...results },
+        env: { ...process.env, EVENT_NAME: eventName, ...results },
       }).exitCode;
-    const successfulResults = {
+    const fixedResults = {
       SOURCE_CONTRACTS_RESULT: "success",
       TEST_SUITE_RESULT: "success",
       BROWSER_ACCEPTANCE_RESULT: "success",
       PACKAGE_CONTRACTS_RESULT: "success",
     };
-    expect(aggregateResult(successfulResults)).toBe(0);
+    const pullRequestResults = {
+      ...fixedResults,
+      UNIT_SHARDS_RESULT: "success",
+      UNIT_SAFETY_RESULT: "skipped",
+    };
+    const nonPullRequestResults = {
+      ...fixedResults,
+      UNIT_SHARDS_RESULT: "skipped",
+      UNIT_SAFETY_RESULT: "success",
+    };
+    expect(aggregateResult("pull_request", pullRequestResults)).toBe(0);
+    for (const eventName of ["push", "workflow_dispatch", "schedule"])
+      expect(aggregateResult(eventName, nonPullRequestResults)).toBe(0);
     for (const result of ["failure", "skipped", "cancelled", ""]) {
-      for (const variable of Object.keys(successfulResults)) {
-        expect(aggregateResult({ ...successfulResults, [variable]: result })).not.toBe(0);
+      for (const variable of Object.keys(fixedResults)) {
+        expect(
+          aggregateResult("pull_request", { ...pullRequestResults, [variable]: result }),
+        ).not.toBe(0);
+        expect(aggregateResult("push", { ...nonPullRequestResults, [variable]: result })).not.toBe(
+          0,
+        );
       }
     }
+    for (const result of ["failure", "skipped", "cancelled", ""])
+      expect(
+        aggregateResult("pull_request", { ...pullRequestResults, UNIT_SHARDS_RESULT: result }),
+      ).not.toBe(0);
+    for (const result of ["success", "failure", "cancelled", ""])
+      expect(
+        aggregateResult("pull_request", { ...pullRequestResults, UNIT_SAFETY_RESULT: result }),
+      ).not.toBe(0);
+    for (const result of ["failure", "skipped", "cancelled", ""])
+      expect(
+        aggregateResult("push", { ...nonPullRequestResults, UNIT_SAFETY_RESULT: result }),
+      ).not.toBe(0);
+    for (const result of ["success", "failure", "cancelled", ""])
+      expect(
+        aggregateResult("push", { ...nonPullRequestResults, UNIT_SHARDS_RESULT: result }),
+      ).not.toBe(0);
+    expect(
+      aggregateResult("pull_request", {
+        ...pullRequestResults,
+        UNIT_SHARDS_RESULT: "skipped",
+        UNIT_SAFETY_RESULT: "skipped",
+      }),
+    ).not.toBe(0);
+    expect(aggregateResult("", nonPullRequestResults)).not.toBe(0);
     expect(ci.jobs["automation-report"].needs).toEqual([
       "automation-admission",
       "test",

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2604,13 +2604,14 @@ describe("workflow contracts", () => {
     expect(release.jobs.publish.permissions["pull-requests"]).toBe("read");
   });
 
-  test("dispatches trusted main CI and preserves ordinary CI events", () => {
+  test("dispatches trusted main CI and preserves ordinary plus scheduled safety events", () => {
     const dispatch = release.jobs.version.steps.find(
       (step: any) => step.name === "Dispatch exact-head Version PR CI",
     );
     expect(dispatch.run).toContain("dispatch-version-ci");
     expect(ci.on.push.branches).toEqual(["main"]);
     expect(ci.on.pull_request).not.toBeUndefined();
+    expect(ci.on.schedule).toEqual([{ cron: "0 3 * * *" }]);
     expect(ci.on.workflow_dispatch.inputs).toEqual(
       expect.objectContaining({
         automation_pr_number: expect.objectContaining({ required: true }),
@@ -2620,6 +2621,13 @@ describe("workflow contracts", () => {
         source_release_run_attempt: expect.objectContaining({ required: true }),
       }),
     );
+    expect(release.on.schedule).toBeUndefined();
+    expect(ci.jobs.deployment.if).toBe(
+      "${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
+    );
+    expect(ci.jobs.images.if).toBe(ci.jobs.deployment.if);
+    for (const imageStep of ci.jobs.images.steps.filter((candidate: any) => candidate.with?.push))
+      expect(imageStep.with.push).toBe("${{ github.event_name == 'push' }}");
   });
 
   test("keeps admission least-privilege and candidate execution exact-head-bound", () => {
@@ -2794,6 +2802,7 @@ describe("workflow contracts", () => {
     expect(safety.if).toBe(
       "${{ always() && github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
     );
+    expect(safety.if).not.toContain("github.event_name != 'schedule'");
     const safetyStep = safety.steps.find((step: any) => step.name === "Test");
     expect(safetyStep.env).toEqual({ OPENGENI_REQUIRE_REAL_DB: "1" });
     expect(safetyStep.run).toBe("bun run test:unit");
@@ -2920,6 +2929,12 @@ describe("workflow contracts", () => {
     expect(aggregateResult("pull_request", pullRequestResults)).toBe(0);
     for (const eventName of ["push", "workflow_dispatch", "schedule"])
       expect(aggregateResult(eventName, nonPullRequestResults)).toBe(0);
+    expect(
+      aggregateResult("schedule", { ...nonPullRequestResults, UNIT_SHARDS_RESULT: "success" }),
+    ).not.toBe(0);
+    expect(
+      aggregateResult("schedule", { ...nonPullRequestResults, UNIT_SAFETY_RESULT: "skipped" }),
+    ).not.toBe(0);
     for (const result of ["failure", "skipped", "cancelled", ""]) {
       for (const variable of Object.keys(fixedResults)) {
         expect(

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2793,7 +2793,7 @@ describe("workflow contracts", () => {
     expect(shardStep.env).toEqual({ OPENGENI_REQUIRE_REAL_DB: "1" });
     expect(shardStep.run).toBe("bun run test:unit:shard -- --shard=${{ matrix.shard }}/4");
     expect(packageJson.scripts["test:unit:shard"]).toBe(
-      "bun test --max-concurrency=8 --timeout=30000",
+      "bun test --max-concurrency=1 --timeout=30000",
     );
 
     const safety = ci.jobs["unit-safety"];


### PR DESCRIPTION
## Summary

- run the native Bun 1.3.14 unit suite as four deterministic `--shard=i/4` matrix jobs on ordinary pull requests, with isolated `ubuntu-latest` runners and `fail-fast: false`
- retain the full monolithic unit suite on main pushes, trusted workflow dispatches, and a daily `0 3 * * *` UTC default-branch safety run
- keep React warning checks, real workspace capture, MCP-timeout recovery, and forced-overflow/real-PostgreSQL regressions in their existing real-service lane
- keep the required `test` / `Typecheck and unit tests` aggregate fail-closed with event-exclusive shard-versus-safety results
- preserve admission, permissions, concurrency, release, deployment, image-push, package-contract, and automation-report semantics

## Validation

- `bun install --frozen-lockfile`
- YAML parse: 11 jobs and daily `0 3 * * *` schedule
- workflow/release contracts: 63 passed, 0 failed, 435 expectations
- native fixed-tree shard proof: 490 `.test.*` paths partitioned `123/123/122/122`, with zero omissions or duplicates and 13 tier-named fixtures represented
- TypeScript 7: all 23 projects clean
- lint: 0 warnings and 0 errors across 1,227 files
- format: 1,287 files correctly formatted
- generated-font, workspace/billing, docs-reference, and public-hygiene guards passed
- structured proof: schedule is the only runtime follow-up; all jobs, permissions, concurrency, release, deployment, and image-push behavior are unchanged

No changeset is required for the private root test script. No lockfile, application source, publishable package, or package-consumer behavior changed.
