### PR TITLE
fix(api): support browser SDK origins safely

### DIFF
--- a/.changeset/browser-sdk-api-cors.md
+++ b/.changeset/browser-sdk-api-cors.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/config": patch
+"@opengeni/sdk": patch
+---
+
+Allow browser SDK clients to call the public API from arbitrary origins with explicit bearer credentials while keeping cross-origin cookie sessions limited to operator-configured trusted origins.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -195,28 +195,34 @@ export function createAppComposition(deps: AppDependencies): {
     await next();
   });
 
-  app.use(
-    "*",
-    cors({
-      credentials: true,
-      allowHeaders: [
-        "Accept",
-        "Authorization",
-        "Content-Type",
-        "X-OpenGeni-Access-Key",
-        "X-OpenGeni-Api-Contract",
-        "X-OpenGeni-Correlation-Id",
-        "X-OpenGeni-Subject",
-      ],
-      exposeHeaders: ["X-OpenGeni-Api-Contract", "X-OpenGeni-Correlation-Id"],
-      origin: (origin) => {
-        if (!origin) {
-          return null;
-        }
-        return allowedCorsOrigin(deps.settings.corsAllowOriginRegex, origin) ? origin : null;
-      },
-    }),
-  );
+  const corsHeaders = {
+    allowHeaders: [
+      "Accept",
+      "Authorization",
+      "Content-Type",
+      "X-OpenGeni-Access-Key",
+      "X-OpenGeni-Api-Contract",
+      "X-OpenGeni-Correlation-Id",
+      "X-OpenGeni-Subject",
+    ],
+    exposeHeaders: ["X-OpenGeni-Api-Contract", "X-OpenGeni-Correlation-Id"],
+  };
+  const publicApiCors = cors({ ...corsHeaders, credentials: false, origin: "*" });
+  const credentialedCors = cors({
+    ...corsHeaders,
+    credentials: true,
+    origin: (origin) =>
+      allowedCorsOrigin(deps.settings.corsAllowOriginRegex, origin) ? origin : null,
+  });
+
+  app.use("*", (c, next) => {
+    const origin = c.req.header("origin");
+    const middleware =
+      origin && allowedCorsOrigin(deps.settings.corsAllowOriginRegex, origin)
+        ? credentialedCors
+        : publicApiCors;
+    return middleware(c, next);
+  });
 
   app.use(
     "*",

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -357,6 +357,43 @@ describe("API helpers", () => {
     expect(allowedCorsOrigin(pattern, "https://evil.com/http://localhost:3000")).toBe(false);
   });
 
+  test("allows public bearer CORS without exposing credentialed browser sessions", async () => {
+    const app = createApp({
+      settings: testSettings(),
+      db: {} as never,
+      bus: {} as never,
+      workflowClient: {} as never,
+      managedAuth: null,
+    });
+    const preflight = (origin: string) =>
+      app.request("http://localhost/v1/config/client", {
+        method: "OPTIONS",
+        headers: {
+          origin,
+          "access-control-request-method": "GET",
+          "access-control-request-headers": "authorization",
+        },
+      });
+
+    const external = await preflight("https://product.example");
+    expect(external.status).toBe(204);
+    expect(external.headers.get("access-control-allow-origin")).toBe("*");
+    expect(external.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(external.headers.get("access-control-allow-headers")).toContain("Authorization");
+
+    const externalResponse = await app.request("http://localhost/v1/config/client", {
+      headers: { origin: "https://product.example" },
+    });
+    expect(externalResponse.status).toBe(200);
+    expect(externalResponse.headers.get("access-control-allow-origin")).toBe("*");
+    expect(externalResponse.headers.get("access-control-allow-credentials")).toBeNull();
+
+    const trusted = await preflight("http://localhost:5173");
+    expect(trusted.status).toBe(204);
+    expect(trusted.headers.get("access-control-allow-origin")).toBe("http://localhost:5173");
+    expect(trusted.headers.get("access-control-allow-credentials")).toBe("true");
+  });
+
   test("normalizes dynamic route labels for metrics", () => {
     const workspace = "00000000-0000-4000-8000-000000000001";
     expect(routeLabel(`/v1/workspaces/${workspace}/sessions/session-1/events/stream`)).toBe(

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -386,6 +386,13 @@ workspace request, then returns a short-lived, object-scoped signed URL. The
 storage account/container remains private and browser PUTs carry no storage
 credentials or cookies beyond that signed URL.
 
+API CORS has a separate trust boundary. Public API requests are available from
+any browser origin with explicit bearer credentials, so the SDK can be embedded
+without per-application origin registration. `OPENGENI_CORS_ALLOW_ORIGIN_REGEX`
+is only the allowlist for origins that may send browser cookies cross-origin.
+Keep that regex narrow; unlisted origins receive wildcard, non-credentialed
+CORS responses and therefore cannot use a managed-login session cookie.
+
 For Azure Blob, the blob-service CORS rule must allow origin `*`, method `PUT`
 (plus `GET`, `HEAD`, and `OPTIONS` for the complete file flow), and all request
 and exposed headers. S3/GCS equivalents must express the same wildcard-origin
@@ -1399,8 +1406,8 @@ It supports:
 - Managed Azure Blob storage when `object_storage.mode = "managed"` and `object_storage.api = "azure-blob"`.
 - Existing Azure Blob or S3-compatible object storage through runtime secrets.
 
-Set `object_storage.cors_allowed_origins` to every browser origin that will
-directly upload files to signed Blob URLs.
+Set `object_storage.cors_allowed_origins` to `["*"]` so browser SDK hosts can
+upload files to signed Blob URLs without per-application registration.
 
 Before applying anything in Azure:
 
@@ -1422,8 +1429,8 @@ The AWS Terraform root lives at `deploy/terraform/aws`.
 
 It supports EKS, ECR, S3, AWS Secrets Manager, optional RDS PostgreSQL, and existing Postgres/Temporal endpoints. Use `deploy/helm/opengeni/values.aws-managed.example.yaml` as the non-secret Helm values shape.
 
-Set `object_storage.cors_allowed_origins` to every browser origin that will
-directly upload files to signed S3 URLs.
+Set `object_storage.cors_allowed_origins` to `["*"]` so browser SDK hosts can
+upload files to signed S3 URLs without per-application registration.
 
 Before applying anything in AWS:
 
@@ -1445,8 +1452,8 @@ The GCP Terraform root lives at `deploy/terraform/gcp`.
 
 It supports GKE, Artifact Registry, GCS, Secret Manager, workload identity, optional Cloud SQL PostgreSQL, and existing Postgres/Temporal endpoints. Use `deploy/helm/opengeni/values.gcp-managed.example.yaml` as the non-secret Helm values shape.
 
-Set `object_storage.cors_allowed_origins` to every browser origin that will
-directly upload files to signed GCS URLs.
+Set `object_storage.cors_allowed_origins` to `["*"]` so browser SDK hosts can
+upload files to signed GCS URLs without per-application registration.
 
 Before applying anything in GCP:
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -329,6 +329,9 @@ const SettingsSchema = z.object({
   apiPort: z.coerce.number().int().positive().default(8000),
   workerHttpPort: z.coerce.number().int().positive().default(8001),
   opengeniMcpUrl: z.string().url().optional(),
+  // Origins allowed to send browser cookies cross-origin. Other origins may
+  // call the public API with bearer credentials, but never receive credentialed
+  // CORS responses.
   corsAllowOriginRegex: z.string().default(String.raw`^https?://(localhost|127\.0\.0\.1)(:\d+)?$`),
   openaiProvider: z.enum(["openai", "azure"]).default("openai"),
   openaiApiKey: z.string().optional(),

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -8,6 +8,11 @@ helpers for proxying the stream through your own API.
 Zero runtime dependencies. Needs only WHATWG `fetch` and streams, so it runs in
 Node 18+, Bun, Deno, browsers, and edge runtimes.
 
+Browser clients may call the public API from any origin with an API key or
+other bearer credential. Browser cookies are accepted cross-origin only from
+operator-configured trusted origins; arbitrary embedding origins never receive
+credentialed CORS responses.
+
 ## Quick start
 
 ```ts

--- a/scripts/deployment-conformance.ts
+++ b/scripts/deployment-conformance.ts
@@ -264,15 +264,11 @@ if (args.skipStorage) {
     const uploadId = stringField(upload, "uploadId");
     const fileId = stringField(upload, "fileId");
     const headers = recordField(upload, "requiredHeaders");
-    await preflightObjectPut(
-      putUrl,
-      // The browser SDK is embeddable in arbitrary products. Storage CORS must
-      // therefore accept an origin that is unrelated to the OpenGeni web app;
-      // the short-lived signed URL remains the upload authorization boundary.
-      "https://sdk-conformance.invalid",
-      Object.keys(headers),
-      args.objectConnectTo,
-    );
+    // The browser SDK is embeddable in arbitrary products. Use an unpredictable
+    // unrelated origin so a deployment cannot pass by allowlisting a fixed
+    // conformance hostname; the signed URL remains the authorization boundary.
+    const browserOrigin = `https://${crypto.randomUUID()}.sdk-conformance.invalid`;
+    await preflightObjectPut(putUrl, browserOrigin, Object.keys(headers), args.objectConnectTo);
     await putObject(putUrl, content, headers, args.objectConnectTo);
     await postJson(workspaceUrl(`/files/uploads/${uploadId}/complete`), {});
     const download = await postJson(workspaceUrl(`/files/${fileId}/download-url`), {});
@@ -428,9 +424,12 @@ async function preflightObjectPut(
     );
   }
   const allowedOrigin = response.headers.get("access-control-allow-origin");
-  if (allowedOrigin !== "*") {
+  // Some object stores preserve the literal wildcard while others echo the
+  // requesting origin after matching a wildcard rule. Both are valid browser
+  // CORS responses; deployment automation separately verifies provider config.
+  if (allowedOrigin !== "*" && allowedOrigin !== origin) {
     throw new Error(
-      `browser upload CORS preflight allowed origin ${allowedOrigin ?? "<missing>"}, expected * for the embeddable SDK`,
+      `browser upload CORS preflight allowed origin ${allowedOrigin ?? "<missing>"}, expected ${origin} or * for the embeddable SDK`,
     );
   }
   const allowedMethods = (response.headers.get("access-control-allow-methods") ?? "")


### PR DESCRIPTION
## Summary
- allow public bearer-authenticated API calls from arbitrary browser origins
- preserve credentialed CORS only for operator-configured trusted origins
- document the separate API and signed-object storage trust boundaries
- make wildcard object-storage CORS guidance consistent across clouds

## Verification
- `bun test apps/api/test/app.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bunx oxlint --deny-warnings apps/api/src/app.ts apps/api/test/app.test.ts packages/config/src/index.ts`
- `git diff --check`