### PR TITLE
test(react): stabilize native unit shard settle coverage

### DIFF
--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -728,12 +728,13 @@ describe("MessageTimeline — settled turn folding", () => {
     expect(r.container.textContent).toContain("Mid-turn checkpoint");
     expect(r.container.textContent).toContain("step one");
 
-    // The outer fold must close after its beat. Do not assert the transient
-    // nested DOM at a real-time boundary here: a loaded shard may resume this
-    // timer after the full collapse has elapsed. The dedicated settle-fold
-    // suite covers the nest latch deterministically through user interaction.
+    // The outer fold closes after its beat but remains in settle choreography
+    // through the slow collapse. Assert that durable state on the trigger, not
+    // Radix Presence's transient nested DOM: Bun's native shard runner may
+    // release happy-dom's CSS-only exit subtree immediately.
     await flush(1150);
     expect(outer?.getAttribute("data-state")).toBe("closed");
+    expect(outer?.className ?? "").toContain("animate-og-settle-chip");
 
     // Settle chrome clears after the slow collapse; nested remount closed.
     await flush(900);


### PR DESCRIPTION
## Intent

Stabilize settled-turn coverage under Bun's native unit-shard runner by asserting the durable outer trigger state during the slow settle collapse, rather than relying on Radix Presence's transient nested DOM at a CSS-only exit boundary.

## Safety

- Changes one React test path only; no production code, workflow, package, or lockfile changes.
- Bun 1.3.14 four-way discovery is exact: 497 monolithic files, 497 unique shard files, zero duplicates, omissions, or extras.
- Timeline renderer: 52 passed; native `--shard=1/1`: 52 passed.
- React warning-free gate: 928 passed.
- Workflow/release contracts: 63 passed; focused governance contracts: 29 passed.
- TypeScript 7 typecheck, lint, format, generated-font, workspace, docs, public-hygiene, YAML, and publishable-package build checks passed.
