### PR TITLE
fix(files): omit credentials for signed uploads

### DIFF
--- a/.changeset/omit-signed-upload-credentials.md
+++ b/.changeset/omit-signed-upload-credentials.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/sdk": patch
+---
+
+Keep signed object-storage uploads credential-free so browser integrations can use provider CORS safely without sending ambient API or session credentials.

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -194,4 +194,57 @@ describe("createOpenGeniClient", () => {
 
     expect(seenKeys).toEqual(["first-key", "second-key"]);
   });
+
+  test("preserves credential-free signed object-storage uploads", async () => {
+    const restoreLocalStorage = installTestLocalStorage();
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ input: Parameters<typeof fetch>[0]; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      requests.push({ input, init });
+      const url = String(input);
+      if (url.endsWith("/files/uploads")) {
+        return Response.json(
+          {
+            fileId: "55555555-5555-4555-8555-555555555555",
+            uploadId: "66666666-6666-4666-8666-666666666666",
+            putUrl: "https://storage.example.test/container/file.txt?sig=opaque",
+            requiredHeaders: { "content-type": "text/plain" },
+            expiresAt: "2026-08-01T12:00:00.000Z",
+            maxSizeBytes: 1024,
+          },
+          { status: 201 },
+        );
+      }
+      if (url.startsWith("https://storage.example.test/")) {
+        return new Response(null, { status: 201 });
+      }
+      if (url.endsWith("/files/uploads/66666666-6666-4666-8666-666666666666/complete")) {
+        return Response.json({
+          file: {
+            id: "55555555-5555-4555-8555-555555555555",
+            status: "ready",
+            filename: "file.txt",
+          },
+        });
+      }
+      throw new Error(`unexpected request: ${url}`);
+    }) as unknown as typeof fetch;
+
+    try {
+      const client = createOpenGeniClient();
+      await client.uploadFile("workspace-id", {
+        filename: "file.txt",
+        contentType: "text/plain",
+        data: "hello",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreLocalStorage();
+    }
+
+    expect(requests).toHaveLength(3);
+    expect(requests[0]!.init?.credentials).toBe("include");
+    expect(requests[1]!.init?.credentials).toBe("omit");
+    expect(requests[2]!.init?.credentials).toBe("include");
+  });
 });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -50,7 +50,13 @@ export function createOpenGeniClient(): OpenGeniCoreClient {
     baseUrl: apiBaseUrl,
     headers: () => authHeaders(),
     fetch: async (input, init) => {
-      const response = await fetch(input, { ...init, credentials: "include" });
+      const response = await fetch(input, {
+        ...init,
+        // API requests need managed-session cookies. The SDK explicitly marks
+        // signed object-storage requests as credential-free; preserve that
+        // narrower policy instead of overriding it at the console boundary.
+        credentials: init?.credentials ?? "include",
+      });
       handleApiContractResponse(response);
       return response;
     },

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2366,6 +2366,11 @@ export class OpenGeniClient {
     });
     const putResponse = await this.fetchImpl(upload.putUrl, {
       method: "PUT",
+      // Signed object-storage URLs carry their own short-lived authority.
+      // Browser cookies and HTTP auth must never accompany this cross-origin
+      // request: credentialed fetches are incompatible with wildcard CORS and
+      // can leak ambient credentials to a caller-selected storage endpoint.
+      credentials: "omit",
       // The backend's requiredHeaders already carry the canonical lowercase
       // `content-type` for every storage backend (Azure/S3/GCS). Do NOT also set
       // a `Content-Type` key here: WHATWG Headers treats the two casings as the

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -21,6 +21,7 @@ const TURN_B = "99999999-9999-4999-8999-999999999992";
 type RecordedRequest = {
   url: string;
   method: string;
+  credentials: RequestCredentials;
   headers: Record<string, string>;
   body: string | null;
   signal: AbortSignal;
@@ -36,6 +37,9 @@ function recordingFetch(responder: (request: RecordedRequest) => Response): {
     const recorded: RecordedRequest = {
       url: request.url,
       method: request.method,
+      // Bun's Request currently reports `include` regardless of the supplied
+      // RequestInit value, so record the caller's explicit policy directly.
+      credentials: init?.credentials ?? request.credentials,
       headers: Object.fromEntries(request.headers.entries()),
       body:
         init?.body !== undefined && init?.body !== null
@@ -431,6 +435,7 @@ describe("OpenGeniClient files", () => {
     const put = requests[1]!;
     expect(put.method).toBe("PUT");
     expect(put.url).toBe(begin.putUrl);
+    expect(put.credentials).toBe("omit");
     expect(put.headers["x-ms-blob-type"]).toBe("BlockBlob");
     // Regression guard: the PUT must send exactly ONE content-type value. If the
     // SDK redundantly sets a `Content-Type` key alongside the backend's lowercase


### PR DESCRIPTION
## Summary
- make signed object-storage PUTs explicitly credential-free in the public SDK
- preserve that request policy in the first-party console while retaining cookies for API calls
- add SDK and console regression coverage for the full begin/PUT/complete flow

## Why
Signed URLs are the complete short-lived authority for object storage. Sending browser credentials makes wildcard CORS unusable and risks forwarding ambient credentials to a separate storage origin.

## Verification
- focused SDK and console tests (42 passing)
- lint
- typecheck (23 projects)
- public repository hygiene
- formatting check
- SDK build
- web production build and bundle budget