### PR TITLE
perf(web): compress production responses

### DIFF
--- a/.changeset/fast-production-responses.md
+++ b/.changeset/fast-production-responses.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Compress large JSON API responses and serve the production web application with precompressed, immutable hashed assets.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -27,6 +27,7 @@ import { createObjectStorage } from "@opengeni/storage";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
+import { compress } from "hono/compress";
 import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -232,6 +233,20 @@ export function createAppComposition(deps: AppDependencies): {
         c.json({ code: "PAYLOAD_TOO_LARGE", message: "Request body is too large." }, 413),
     }),
   );
+
+  // Large catalog, capture, and session-list responses are on the browser's
+  // critical path. Compress JSON at the API boundary while leaving SSE and
+  // other streaming transports byte-for-byte unchanged.
+  const compressJson = compress({
+    encoding: "gzip",
+    contentTypeFilter: /^application\/json(?:;|$)/i,
+  });
+  app.use("/v1/*", async (c, next) => {
+    await compressJson(c, next);
+    if (/^application\/json(?:;|$)/i.test(c.res.headers.get("content-type") ?? "")) {
+      c.res.headers.set("vary", appendVary(c.res.headers.get("vary"), "Accept-Encoding"));
+    }
+  });
 
   app.use("*", async (c, next) => {
     const url = new URL(c.req.url);
@@ -541,6 +556,17 @@ export function createAppComposition(deps: AppDependencies): {
   });
 
   return { app, routeDeps };
+}
+
+export function appendVary(current: string | null, value: string): string {
+  const values = (current ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (!values.some((entry) => entry.toLowerCase() === value.toLowerCase())) {
+    values.push(value);
+  }
+  return values.join(", ");
 }
 
 async function requireMcpAccessGrant(

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -5,6 +5,7 @@ import { HTTPException } from "hono/http-exception";
 import {
   apiRequestBodyLimitBytes,
   allowedCorsOrigin,
+  appendVary,
   createApp,
   errorCodeForStatus,
   httpStatusForError,
@@ -45,6 +46,14 @@ import {
 } from "@opengeni/contracts";
 
 describe("API helpers", () => {
+  test("appends response negotiation without duplicating Vary fields", () => {
+    expect(appendVary(null, "Accept-Encoding")).toBe("Accept-Encoding");
+    expect(appendVary("Origin", "Accept-Encoding")).toBe("Origin, Accept-Encoding");
+    expect(appendVary("Origin, accept-encoding", "Accept-Encoding")).toBe(
+      "Origin, accept-encoding",
+    );
+  });
+
   test("protects product mutations while leaving external protocol callbacks alone", () => {
     expect(isApiContractProtectedMutation("POST", "/v1/workspaces/ws/sessions/s/events")).toBe(
       true,
@@ -1288,6 +1297,24 @@ describe("GET /v1/config/client", () => {
     expect(response.headers.get(OPENGENI_API_CONTRACT_HEADER)).toBe(OPENGENI_API_CONTRACT_REVISION);
     return ClientConfig.parse(await response.json());
   }
+
+  test("compresses JSON responses without changing their decoded contract", async () => {
+    const response = await appFor(testSettings()).request("/v1/config/client", {
+      headers: { "accept-encoding": "gzip" },
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-encoding")).toBe("gzip");
+    expect(response.headers.get("vary")?.toLowerCase().split(/,\s*/)).toContain("accept-encoding");
+    expect(response.body).not.toBeNull();
+    const decoded = new Response(response.body!.pipeThrough(new DecompressionStream("gzip")));
+    expect(ClientConfig.parse(await decoded.json()).apiContractRevision).toBe(
+      OPENGENI_API_CONTRACT_REVISION,
+    );
+
+    const identity = await appFor(testSettings()).request("/v1/config/client");
+    expect(identity.headers.get("content-encoding")).toBeNull();
+    expect(identity.headers.get("vary")?.toLowerCase().split(/,\s*/)).toContain("accept-encoding");
+  });
 
   test("rejects a stale production mutation before route state can change", async () => {
     const settings = testSettings({ environment: "production" });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3000 --host 0.0.0.0",
-    "build": "vite build && bun ../../scripts/check-web-bundle-budget.ts",
-    "start": "vite preview --port 3000 --host 0.0.0.0",
+    "build": "vite build && bun ../../scripts/precompress-web-dist.ts dist && bun ../../scripts/check-web-bundle-budget.ts",
+    "start": "bun src/server.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -40,6 +40,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { sameSessionForContext } from "@/lib/session-context";
+import { runSingleFlight } from "@/lib/single-flight";
 import {
   buildCreateSessionRequest,
   prepareCreateSessionAttempt,
@@ -69,6 +70,8 @@ import { upsertWorkspace } from "@/lib/workspaces";
 import type {
   AccessContext,
   AuthSession,
+  CapabilityCatalogItem,
+  CapabilityCatalogResponse,
   ClientConfig,
   CreateWorkspaceRequest,
   GitHubAppInfo,
@@ -153,6 +156,8 @@ export type AppContextValue = {
   workspaceDefaultToolIds: string[];
   /** True once the workspace capability catalog has completed its authoritative load. */
   workspaceMcpCatalogReady: boolean;
+  /** The authoritative workspace catalog, shared by tool policy and timeline presentation. */
+  workspaceCapabilityCatalog: CapabilityCatalogItem[];
   currentResources: ResourceRef[];
   addManualRepository: () => void;
   forgetAccessKey: () => void;
@@ -273,6 +278,9 @@ export function RootRouteComponent() {
   const [githubAppOpen, setGithubAppOpen] = useState(false);
   const [githubOrg, setGithubOrg] = useState("");
   const [workspaceMcpServers, setWorkspaceMcpServers] = useState<McpServerOption[]>([]);
+  const [workspaceCapabilityCatalog, setWorkspaceCapabilityCatalog] = useState<
+    CapabilityCatalogItem[]
+  >([]);
   const [workspaceMcpCatalogReady, setWorkspaceMcpCatalogReady] = useState(false);
   const [selectedCapabilityToolIds, setSelectedCapabilityToolIds] = useState<Set<string>>(
     () => new Set(),
@@ -282,6 +290,7 @@ export function RootRouteComponent() {
   const previousCapabilityToolIds = useRef<Set<string>>(new Set());
   const githubRefreshId = useRef(0);
   const mcpRefreshId = useRef(0);
+  const mcpCatalogRequests = useRef(new Map<string, Promise<CapabilityCatalogResponse>>());
   // Stable CREATE idempotency key for the in-flight session create. Generated
   // lazily and reused across retries (and across a double-click that re-enters
   // startSession before busy flips), so duplicate creates collapse to one
@@ -749,14 +758,20 @@ export function RootRouteComponent() {
     async (workspaceId: string, signal?: AbortSignal) => {
       const refreshId = mcpRefreshId.current + 1;
       mcpRefreshId.current = refreshId;
-      const catalog = await client.listCapabilities(workspaceId);
+      const requestKey = `${accessKeyVersion}:${workspaceId}`;
+      const catalog = await runSingleFlight(
+        mcpCatalogRequests.current,
+        requestKey,
+        async () => await client.listCapabilities(workspaceId),
+      );
       if (signal?.aborted || mcpRefreshId.current !== refreshId) {
         return;
       }
       setWorkspaceMcpServers(enabledWorkspaceCapabilityMcpServers(catalog.items));
+      setWorkspaceCapabilityCatalog(catalog.items);
       setWorkspaceMcpCatalogReady(true);
     },
-    [client],
+    [accessKeyVersion, client],
   );
 
   async function startSession(
@@ -1015,6 +1030,7 @@ export function RootRouteComponent() {
     setGithubRepos([]);
     setGithubCatalogReady(false);
     setWorkspaceMcpServers([]);
+    setWorkspaceCapabilityCatalog([]);
     setWorkspaceMcpCatalogReady(false);
   }, []);
 
@@ -1091,6 +1107,7 @@ export function RootRouteComponent() {
           toolMcpServers,
           workspaceDefaultToolIds: toolMcpServers.map((server) => server.id),
           workspaceMcpCatalogReady,
+          workspaceCapabilityCatalog,
           currentResources,
           addManualRepository: contextAddManualRepository,
           forgetAccessKey: contextForgetAccessKey,
@@ -1172,6 +1189,7 @@ export function RootRouteComponent() {
     setSession,
     toolMcpServers,
     workspaceMcpCatalogReady,
+    workspaceCapabilityCatalog,
     workspaces,
   ]);
 

--- a/apps/web/src/lib/single-flight.test.ts
+++ b/apps/web/src/lib/single-flight.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { runSingleFlight } from "./single-flight";
+
+describe("runSingleFlight", () => {
+  test("coalesces concurrent reads and refreshes after settlement", async () => {
+    const pending = new Map<string, Promise<string>>();
+    let loads = 0;
+    let resolve!: (value: string) => void;
+    const load = () => {
+      loads += 1;
+      return new Promise<string>((done) => {
+        resolve = done;
+      });
+    };
+
+    const first = runSingleFlight(pending, "workspace", load);
+    const duplicate = runSingleFlight(pending, "workspace", load);
+    expect(duplicate).toBe(first);
+    expect(loads).toBe(1);
+
+    resolve("catalog");
+    expect(await first).toBe("catalog");
+    expect(await duplicate).toBe("catalog");
+
+    const refreshed = runSingleFlight(pending, "workspace", async () => {
+      loads += 1;
+      return "fresh";
+    });
+    expect(await refreshed).toBe("fresh");
+    expect(loads).toBe(2);
+  });
+
+  test("clears failed reads so a retry can run", async () => {
+    const pending = new Map<string, Promise<string>>();
+    const failed = runSingleFlight(pending, "workspace", async () => {
+      throw new Error("offline");
+    });
+    await expect(failed).rejects.toThrow("offline");
+    expect(await runSingleFlight(pending, "workspace", async () => "recovered")).toBe("recovered");
+  });
+});

--- a/apps/web/src/lib/single-flight.ts
+++ b/apps/web/src/lib/single-flight.ts
@@ -1,0 +1,21 @@
+/**
+ * Reuse one in-flight read for one identity. The entry is removed as soon as
+ * the request settles, so this coalesces concurrent callers without caching
+ * stale data.
+ */
+export function runSingleFlight<Key, Value>(
+  pending: Map<Key, Promise<Value>>,
+  key: Key,
+  load: () => Promise<Value>,
+): Promise<Value> {
+  const existing = pending.get(key);
+  if (existing) return existing;
+
+  const request = load();
+  pending.set(key, request);
+  const clear = () => {
+    if (pending.get(key) === request) pending.delete(key);
+  };
+  void request.then(clear, clear);
+  return request;
+}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -259,70 +259,26 @@ export function SessionRoute({
     [context.client, workspaceId],
   );
 
-  // One lazy catalog fetch feeds two timeline resolvers: provider logos for any
-  // inline reconnect card, and real capability names for the tool chips on user
-  // messages. Both resolve only through the workspace catalog, so fetch it once —
-  // when EITHER an auth-needed card OR a message carrying tool chips is in view —
-  // and reuse the single response. Logos serve from our own catalog-assets route
-  // via `catalogAssetUrl`, never an off-origin favicon (the CSP forbids it and it
-  // would leak which providers are connected).
-  const hasAuthNeeded = useMemo(
-    () => timeline.some((item) => item.kind === "auth-needed"),
-    [timeline],
-  );
-  const hasToolChips = useMemo(
-    () => timeline.some((item) => item.kind === "user-message" && item.tools.length > 0),
-    [timeline],
-  );
-  const [providerLogos, setProviderLogos] = useState<Map<string, string>>(() => new Map());
-  // mcpServerId -> human capability name, so a chip reads "Linear" instead of a
-  // best-effort parse of the raw server id.
-  const [capabilityNames, setCapabilityNames] = useState<Map<string, string>>(() => new Map());
-  const catalogRequestedRef = useRef(false);
-  useEffect(() => {
-    if ((!hasAuthNeeded && !hasToolChips) || catalogRequestedRef.current) {
-      return;
+  // The workspace shell already needs the capability catalog for session tool
+  // policy. Reuse that authoritative read for timeline names and logos instead
+  // of downloading the same large catalog again from the session route.
+  const { providerLogos, capabilityNames } = useMemo(() => {
+    const logos = new Map<string, string>();
+    const names = new Map<string, string>();
+    for (const capability of context.workspaceCapabilityCatalog) {
+      const domain = capability.providerDomain ?? capability.connectionRef?.providerDomain ?? null;
+      const url = context.client.catalogAssetUrl(capability.logoAssetPath);
+      if (domain && url) {
+        const key = normalizeProviderDomain(domain);
+        if (!logos.has(key)) logos.set(key, url);
+      }
+      const mcpServerId = capability.runtime.mcpServerId;
+      if (mcpServerId && capability.name && !names.has(mcpServerId)) {
+        names.set(mcpServerId, capability.name);
+      }
     }
-    catalogRequestedRef.current = true;
-    let cancelled = false;
-    void context.client
-      .listCapabilities(workspaceId)
-      .then((catalog) => {
-        if (cancelled) {
-          return;
-        }
-        const logos = new Map<string, string>();
-        const names = new Map<string, string>();
-        for (const cap of catalog.items) {
-          const domain = cap.providerDomain ?? cap.connectionRef?.providerDomain ?? null;
-          const url = context.client.catalogAssetUrl(cap.logoAssetPath);
-          if (domain && url) {
-            const key = normalizeProviderDomain(domain);
-            if (!logos.has(key)) {
-              logos.set(key, url);
-            }
-          }
-          // A chip's tool.id IS the capability's runtime mcpServerId — map it to
-          // the item's human name so the chip resolves to the real label.
-          const mcpServerId = cap.runtime.mcpServerId;
-          if (mcpServerId && cap.name && !names.has(mcpServerId)) {
-            names.set(mcpServerId, cap.name);
-          }
-        }
-        setProviderLogos(logos);
-        setCapabilityNames(names);
-      })
-      .catch(() => {
-        // Leave the card on its monogram fallback and the chips on their
-        // best-effort labels, and allow a later retry.
-        if (!cancelled) {
-          catalogRequestedRef.current = false;
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [hasAuthNeeded, hasToolChips, context.client, workspaceId]);
+    return { providerLogos: logos, capabilityNames: names };
+  }, [context.client, context.workspaceCapabilityCatalog]);
   const resolveProviderLogo = useCallback(
     (domain: string) => providerLogos.get(normalizeProviderDomain(domain)) ?? null,
     [providerLogos],

--- a/apps/web/src/server.test.ts
+++ b/apps/web/src/server.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createWebHandler } from "./server";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("production web handler", () => {
+  test("serves compressed immutable assets and revalidating SPA fallbacks", async () => {
+    const root = await fixture();
+    const handler = createWebHandler(root);
+    const asset = await handler(
+      new Request("https://example.test/assets/app-abc123.js", {
+        headers: { "accept-encoding": "br, gzip" },
+      }),
+    );
+    expect(asset.status).toBe(200);
+    expect(asset.headers.get("content-encoding")).toBe("gzip");
+    expect(asset.headers.get("vary")).toBe("Accept-Encoding");
+    expect(asset.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+    expect(
+      await new Response(asset.body!.pipeThrough(new DecompressionStream("gzip"))).text(),
+    ).toBe("export const ready = true;\n");
+
+    const route = await handler(new Request("https://example.test/workspaces/ws/sessions/id"));
+    expect(route.headers.get("cache-control")).toBe("no-cache");
+    expect(await route.text()).toContain("OpenGeni");
+  });
+
+  test("does not turn missing assets or path traversal into the SPA shell", async () => {
+    const root = await fixture();
+    const handler = createWebHandler(root);
+    expect((await handler(new Request("https://example.test/assets/missing.js"))).status).toBe(404);
+    expect((await handler(new Request("https://example.test/%2e%2e%2fsecret"))).status).toBe(400);
+  });
+});
+
+async function fixture(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "opengeni-web-handler-"));
+  roots.push(root);
+  await mkdir(join(root, "assets"), { recursive: true });
+  await Bun.write(join(root, "index.html"), "<!doctype html><title>OpenGeni</title>");
+  await Bun.write(join(root, "assets/app-abc123.js"), "export const ready = true;\n");
+  await Bun.write(
+    join(root, "assets/app-abc123.js.gz"),
+    Bun.gzipSync("export const ready = true;\n"),
+  );
+  return root;
+}

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,0 +1,100 @@
+import { extname, resolve, sep } from "node:path";
+
+const DEFAULT_PORT = 3000;
+const DEFAULT_HOST = "0.0.0.0";
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const REVALIDATE_CACHE_CONTROL = "no-cache";
+const SHORT_CACHE_CONTROL = "public, max-age=3600";
+
+export function createWebHandler(root = resolve(import.meta.dir, "../dist")) {
+  const distRoot = resolve(root);
+  const indexPath = resolve(distRoot, "index.html");
+
+  return async function webHandler(request: Request): Promise<Response> {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: { allow: "GET, HEAD" },
+      });
+    }
+
+    const url = new URL(request.url);
+    let pathname: string;
+    try {
+      pathname = decodeURIComponent(url.pathname);
+    } catch {
+      return new Response("Bad Request", { status: 400 });
+    }
+
+    const requestedPath = safePath(distRoot, pathname);
+    if (!requestedPath) {
+      return new Response("Bad Request", { status: 400 });
+    }
+
+    const requestedFile = Bun.file(requestedPath);
+    if (await requestedFile.exists()) {
+      return serveFile(request, requestedPath, cacheControlFor(pathname));
+    }
+    if (pathname.startsWith("/assets/")) {
+      return new Response("Not Found", { status: 404 });
+    }
+    return serveFile(request, indexPath, REVALIDATE_CACHE_CONTROL);
+  };
+}
+
+function safePath(root: string, pathname: string): string | null {
+  const candidate = resolve(root, `.${pathname}`);
+  return candidate === root || candidate.startsWith(`${root}${sep}`) ? candidate : null;
+}
+
+function cacheControlFor(pathname: string): string {
+  if (pathname.startsWith("/assets/")) return IMMUTABLE_CACHE_CONTROL;
+  if (extname(pathname) === ".html" || pathname === "/") return REVALIDATE_CACHE_CONTROL;
+  return SHORT_CACHE_CONTROL;
+}
+
+async function serveFile(request: Request, path: string, cacheControl: string): Promise<Response> {
+  const source = Bun.file(path);
+  if (!(await source.exists())) {
+    return new Response("Not Found", { status: 404 });
+  }
+  const acceptsGzip =
+    !request.headers.has("range") &&
+    acceptsEncoding(request.headers.get("accept-encoding"), "gzip");
+  const gzip = Bun.file(`${path}.gz`);
+  const encoded = acceptsGzip && (await gzip.exists()) ? gzip : null;
+  const body = encoded ?? source;
+  const headers = new Headers({
+    "cache-control": cacheControl,
+    "content-type": source.type || "application/octet-stream",
+    vary: "Accept-Encoding",
+  });
+  if (encoded) headers.set("content-encoding", "gzip");
+  if (request.method === "HEAD") {
+    headers.set("content-length", String(body.size));
+    return new Response(null, { headers });
+  }
+  return new Response(body, { headers });
+}
+
+function acceptsEncoding(header: string | null, encoding: string): boolean {
+  if (!header) return false;
+  for (const entry of header.split(",")) {
+    const segments = entry.trim().split(";");
+    const name = segments[0]?.toLowerCase();
+    if (name !== encoding.toLowerCase() && name !== "*") continue;
+    const parameters = segments.slice(1);
+    const quality = parameters
+      .map((parameter) => parameter.trim())
+      .find((parameter) => parameter.startsWith("q="));
+    return quality ? Number(quality.slice(2)) > 0 : true;
+  }
+  return false;
+}
+
+if (import.meta.main) {
+  const port = Number(process.env.PORT ?? DEFAULT_PORT);
+  const hostname = process.env.HOST ?? DEFAULT_HOST;
+  Bun.serve({ hostname, port, fetch: createWebHandler() });
+  console.log(`OpenGeni web listening on http://${hostname}:${port}`);
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -500,6 +500,12 @@ filesystems even though Docker accepts the mount.
 
 ## Build Images
 
+The production web image serves the built SPA through the repository-owned Bun
+server, not Vite's preview server. The build precompresses text assets;
+content-hashed `/assets/*` responses are served with immutable one-year caching,
+while the HTML shell revalidates. The API compresses JSON responses and leaves
+SSE and other streaming transports uncompressed.
+
 Build local OpenGeni workload images:
 
 ```bash

--- a/scripts/precompress-web-dist.test.ts
+++ b/scripts/precompress-web-dist.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { precompressWebDist } from "./precompress-web-dist";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("web asset precompression", () => {
+  test("writes deterministic gzip siblings only for useful text assets", async () => {
+    const root = await mkdtemp(join(tmpdir(), "opengeni-precompress-"));
+    roots.push(root);
+    await Bun.write(join(root, "app.js"), "export const value = 1;\n".repeat(200));
+    await Bun.write(join(root, "small.css"), "x{}");
+    await Bun.write(join(root, "binary.bin"), new Uint8Array(2_048));
+
+    expect(await precompressWebDist(root)).toBe(1);
+    const first = new Uint8Array(await Bun.file(join(root, "app.js.gz")).arrayBuffer());
+    expect(await precompressWebDist(root)).toBe(1);
+    const second = new Uint8Array(await Bun.file(join(root, "app.js.gz")).arrayBuffer());
+    expect(first).toEqual(second);
+    expect(await Bun.file(join(root, "small.css.gz")).exists()).toBe(false);
+    expect(await Bun.file(join(root, "binary.bin.gz")).exists()).toBe(false);
+  });
+});

--- a/scripts/precompress-web-dist.ts
+++ b/scripts/precompress-web-dist.ts
@@ -1,0 +1,46 @@
+import { readdir } from "node:fs/promises";
+import { extname, join, resolve } from "node:path";
+
+const COMPRESSIBLE_EXTENSIONS = new Set([
+  ".css",
+  ".html",
+  ".js",
+  ".json",
+  ".map",
+  ".svg",
+  ".txt",
+  ".xml",
+]);
+const MINIMUM_BYTES = 1_024;
+
+export async function precompressWebDist(root: string): Promise<number> {
+  const files = await listFiles(resolve(root));
+  let written = 0;
+  for (const path of files) {
+    if (!COMPRESSIBLE_EXTENSIONS.has(extname(path)) || path.endsWith(".gz")) continue;
+    const source = new Uint8Array(await Bun.file(path).arrayBuffer());
+    if (source.byteLength < MINIMUM_BYTES) continue;
+    const compressed = Bun.gzipSync(source, { level: 9 });
+    if (compressed.byteLength >= source.byteLength) continue;
+    await Bun.write(`${path}.gz`, compressed);
+    written += 1;
+  }
+  return written;
+}
+
+async function listFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) files.push(...(await listFiles(path)));
+    else if (entry.isFile()) files.push(path);
+  }
+  return files;
+}
+
+if (import.meta.main) {
+  const root = resolve(process.argv[2] ?? "apps/web/dist");
+  const written = await precompressWebDist(root);
+  console.log(`Precompressed ${written} web assets.`);
+}


### PR DESCRIPTION
## Summary
- compress large JSON API responses while preserving streaming transports
- serve precompressed, immutable hashed web assets from the production image
- coalesce identity-equivalent capability reads and reuse the workspace catalog

## Verification
- focused API and web tests
- full repository typecheck
- lint
- production web build and bundle budgets
- runtime header checks for compressed assets, SPA fallback, and missing assets
- public repository hygiene guard