### PR TITLE
fix(ci): account for response deduplication bundle cost

### DIFF
--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -10,9 +10,9 @@ type ManifestEntry = {
 
 const kib = 1024;
 const budgets = {
-  // The consent manager and social connector types join the shared application
-  // shell while provider SDKs remain lazy. Keep a measured 2 KiB allowance.
-  initialRaw: 772 * kib,
+  // Shared consent, connector, and response-deduplication code remains in the
+  // application shell while provider SDKs stay lazy. Keep the measured ceiling.
+  initialRaw: 773 * kib,
   initialGzip: 210 * kib,
   initialFileGzip: 70 * kib,
   directSessionRaw: 1900 * kib,


### PR DESCRIPTION
The production response-deduplication path intentionally adds 153 bytes to the initial raw graph. Raise only that raw ceiling by 1 KiB while keeping the compressed, per-file, direct-session, lazy-chunk, and CSS budgets unchanged.

Validation:
- focused single-flight tests pass
- production web build passes
- all bundle budgets pass
- no product-specific or deployment-specific information