### PR TITLE
fix(worker): use pack image for sandbox creation

### DIFF
--- a/.changeset/pack-sandbox-provider-settings.md
+++ b/.changeset/pack-sandbox-provider-settings.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Pass pack- and rig-resolved sandbox image settings into eager and lazy provider creation.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -5234,7 +5234,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             resumeBoxForTurn(
               {
                 db,
-                settings,
+                settings: runSettings,
                 cancellationSignal: sandboxResumeSignal,
                 sandboxMetrics: runtimeMetricsHooksForObservability(observability),
                 onSandboxLost: publishSandboxLost,
@@ -5640,7 +5640,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             const provisioned = await resumeBoxForTurn(
               {
                 db,
-                settings,
+                settings: runSettings,
                 cancellationSignal: sandboxResumeSignal,
                 sandboxMetrics: runtimeMetricsHooksForObservability(observability),
                 onSandboxLost: publishSandboxLost,

--- a/apps/worker/test/pack-sandbox-runtime-settings.test.ts
+++ b/apps/worker/test/pack-sandbox-runtime-settings.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+describe("pack sandbox image runtime settings", () => {
+  const source = readFileSync(
+    join(import.meta.dir, "..", "src", "activities", "agent-turn.ts"),
+    "utf8",
+  );
+
+  test("passes run-scoped image settings to eager and lazy provider creation", () => {
+    const scopedCallSites = source.match(/resumeBoxForTurn\(\s*\{\s*db,\s*settings: runSettings,/g);
+    expect(scopedCallSites).toHaveLength(2);
+    expect(source).not.toMatch(/resumeBoxForTurn\(\s*\{\s*db,\s*settings,/);
+  });
+});


### PR DESCRIPTION
## Summary

- pass pack- and rig-resolved `runSettings` into both eager and lazy `resumeBoxForTurn` provider-creation paths
- preserve the deployment-wide fallback when no pack/rig image is configured
- add a focused guard for both call sites and a worker-bundle patch changeset

## Why

Authenticated Gecko validation for the Cloudgeni OpenGeni embed proved that the session resolved and leased the exact pack sandbox digest, but Modal created its default minimal image. The lease therefore claimed the configured custom digest while the actual sandbox lacked `curl`, `ogtool`, `az`, `exo`, `git`/`gh`, Terraform, Python, and Node.

The turn activity derived the correct run-scoped image settings and warmed the private image, then discarded those settings at provider creation by passing deployment-global `settings` to `resumeBoxForTurn`. Gecko deliberately has no global `OPENGENI_MODAL_IMAGE_REF`, so the provider received no image ref.

## Testing

- [x] `bun run typecheck` (all 23 projects)
- [x] `bun run lint` (zero warnings/errors)
- [x] focused pack/Modal/runtime tests, including the new regression test
- [x] `git diff --check`
- [ ] `bun test`

A larger targeted worker run completed with 147 passing tests and two failures in existing `sandbox-resume.test.ts` cases F3-b/F3-c. Both failures reproduce unchanged at the exact `origin/main` base (`3035b59f91901f70faf2b4ce2cbba3ae05634242`) with the same `workspace_fingerprint_unavailable` error, so they are classified as baseline/environment failures rather than regressions from this patch.

## Notes

- Source base: `3035b59f91901f70faf2b4ce2cbba3ae05634242`
- Live consumer validation will be repeated after the corrected worker bundle is released and pinned by Cloudgeni PR #1577.
