### PR TITLE
chore(release): reserve chart 0.22.41

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.40
-appVersion: "0.22.40"
+version: 0.22.41
+appVersion: "0.22.41"


### PR DESCRIPTION
## Summary

- reserve product release version `0.22.41`
- leave package versions and release contents unchanged
- avoid reusing the already occupied immutable `0.22.40` coordinates

## Validation

- verified the API, worker, web, relay, sandbox, and chart `0.22.41` registry coordinates are unoccupied using the repository-configured OCI prefix
- verified no matching Git tag, GitHub release, open reservation PR, or remote reservation branch exists
- `bun test scripts/release-version.test.ts scripts/release-candidate.test.ts`
- `helm lint deploy/helm/opengeni`
- `git diff --check`
