### PR TITLE
perf(web): reduce session route request fanout

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -18,6 +18,25 @@ export default defineConfig({
     // initial graph and every chunk by gzip size; 800 kB remains a hard raw cap.
     chunkSizeWarningLimit: 800,
     manifest: true,
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            {
+              // The session workbench is the primary interactive route. Keep
+              // its static graph route-aware, but coalesce tiny shared groups
+              // so a cold navigation does not fan out into dozens of requests.
+              name: "session",
+              test: /src[\\/]routes[\\/]session\.tsx$/,
+              includeDependenciesRecursively: true,
+              entriesAware: true,
+              entriesAwareMergeThreshold: 128 * 1024,
+              priority: 2,
+            },
+          ],
+        },
+      },
+    },
   },
   server: {
     port: 3000,

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -15,8 +15,10 @@ const budgets = {
   initialRaw: 773 * kib,
   initialGzip: 210 * kib,
   initialFileGzip: 70 * kib,
+  initialFiles: 12,
   directSessionRaw: 1900 * kib,
   directSessionGzip: 552 * kib,
+  directSessionFiles: 20,
   lazyChunkRaw: 800 * kib,
   lazyChunkGzip: 240 * kib,
   cssGzip: 30 * kib,
@@ -132,8 +134,10 @@ function enforce(label: string, actual: number, limit: number): void {
 enforce("initial raw graph", initialTotal.raw, budgets.initialRaw);
 enforce("initial gzip graph", initialTotal.gzip, budgets.initialGzip);
 enforce("largest initial gzip asset", largestInitial.gzip, budgets.initialFileGzip);
+enforce("initial graph file count", initialMetrics.length, budgets.initialFiles);
 enforce("direct session raw graph", directSessionTotal.raw, budgets.directSessionRaw);
 enforce("direct session gzip graph", directSessionTotal.gzip, budgets.directSessionGzip);
+enforce("direct session graph file count", directSessionMetrics.length, budgets.directSessionFiles);
 enforce("largest lazy raw chunk", largestLazyRaw.raw, budgets.lazyChunkRaw);
 enforce("largest lazy gzip chunk", largestLazyGzip.gzip, budgets.lazyChunkGzip);
 enforce("largest CSS gzip asset", largestCss.gzip, budgets.cssGzip);


### PR DESCRIPTION
## Summary
- coalesce small entries-aware chunks in the session route static graph
- reduce the direct session graph from 75 files to 16 without increasing transferred bytes
- add file-count budgets for the initial shell and direct session graph

## Measured result
- initial graph: 16 -> 9 files; 210,708 -> 207,855 gzip bytes
- direct session graph: 75 -> 16 files; 494,058 -> 481,485 gzip bytes

## Validation
- `bun run lint`
- public repository hygiene
- all 23 TypeScript projects
- unit suite except the existing BSD/GNU tar portability mismatch in `package-release-chart.test.ts` (`tar --sort` is unavailable on this macOS host)
- SDK package build
- React package and demo builds
- production web build and bundle budgets
- example consumer build