### PR TITLE
test(web): tighten session request budget

### DIFF
--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -18,7 +18,7 @@ const budgets = {
   initialFiles: 12,
   directSessionRaw: 1900 * kib,
   directSessionGzip: 552 * kib,
-  directSessionFiles: 20,
+  directSessionFiles: 18,
   lazyChunkRaw: 800 * kib,
   lazyChunkGzip: 240 * kib,
   cssGzip: 30 * kib,


### PR DESCRIPTION
Tightens the direct-session static request-count ceiling from 20 to 18 after the route-aware bundle measured 16 files. This preserves two files of headroom while preventing regressions toward the prior fragmented request graph.\n\nValidation:\n- production web build\n- web bundle budget (direct session: 16 files)