### PR TITLE
test(web): tighten initial request budget

### DIFF
--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -15,7 +15,7 @@ const budgets = {
   initialRaw: 773 * kib,
   initialGzip: 210 * kib,
   initialFileGzip: 70 * kib,
-  initialFiles: 12,
+  initialFiles: 11,
   directSessionRaw: 1900 * kib,
   directSessionGzip: 552 * kib,
   directSessionFiles: 18,


### PR DESCRIPTION
Tightens the initial static request-count ceiling from 12 to 11 after the route-aware bundle measured 9 files. This preserves two files of headroom while preventing regressions toward the prior fragmented request graph.\n\nValidation:\n- web bundle budget (initial: 9 files; direct session: 16 files)