### PR TITLE
feat(web,react): densify Workspace hub and harden timeline tool UX

### DIFF
--- a/.changeset/workspace-hub-timeline-polish.md
+++ b/.changeset/workspace-hub-timeline-polish.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/react": patch
+---
+
+Keep agent goal tools inside the activity cluster (no breakaway GoalRow split),
+allow collapsing live turn step shells, and keep densified Workspace hub /
+timeline disclosure changes under a stable Radix vendor chunk.

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -1024,14 +1024,14 @@ export function CodexSubscriptionsCard({
 
   // Burying reconnect behind a click is worse than one auto-open; healthy rows stay closed.
   useEffect(() => {
-    if (autoExpandedReloginRef.current || expandedId != null) return;
-    const needsRelogin = accounts.find(
+    if (autoExpandedReloginRef.current || expandedId != null || !data) return;
+    const needsRelogin = data.accounts.find(
       (account) => account.status !== "active" && account.lastError != null,
     );
     if (!needsRelogin) return;
     autoExpandedReloginRef.current = true;
     setExpandedId(needsRelogin.id);
-  }, [accounts, expandedId]);
+  }, [data, expandedId]);
 
   return (
     <section aria-labelledby="codex-subscriptions-heading" className="grid gap-2">

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -357,7 +357,11 @@ function CompactAccountUsage({
   }
   if (status === "error" && !fiveHour && !weekly) {
     return (
-      <button type="button" className="text-2xs text-fg-subtle underline hover:text-fg" onClick={onRetry}>
+      <button
+        type="button"
+        className="text-2xs text-fg-subtle underline hover:text-fg"
+        onClick={onRetry}
+      >
         retry usage
       </button>
     );
@@ -614,9 +618,7 @@ function soonestResetExpiryMs(credits: CodexResetCredit[], now: number): number 
   return soonest;
 }
 
-function resetBadgeTone(
-  remainingMs: number | null,
-): "urgent" | "soon" | "ok" {
+function resetBadgeTone(remainingMs: number | null): "urgent" | "soon" | "ok" {
   if (remainingMs == null) return "ok";
   if (remainingMs < RESET_URGENT_MS) return "urgent";
   if (remainingMs < RESET_SOON_MS) return "soon";
@@ -1127,10 +1129,7 @@ export function CodexSubscriptionsCard({
             const resetTone = resetBadgeTone(resetRemainingMs);
             const expanded = expandedId === account.id;
             const coolingSecs = account.exhaustedUntil
-              ? Math.max(
-                  0,
-                  Math.round((new Date(account.exhaustedUntil).getTime() - now) / 1000),
-                )
+              ? Math.max(0, Math.round((new Date(account.exhaustedUntil).getTime() - now) / 1000))
               : 0;
             return (
               <article

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -16,11 +16,12 @@ import type {
   CodexUsageWindow,
 } from "@opengeni/sdk";
 import {
+  ChevronDownIcon,
   ExternalLinkIcon,
   Loader2Icon,
+  PencilIcon,
   PlusIcon,
   RefreshCwIcon,
-  SparklesIcon,
   TicketCheckIcon,
   Trash2Icon,
   TriangleAlertIcon,
@@ -28,7 +29,9 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { ChatGptMark } from "@/components/chatgpt-mark";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
 import { MetaChip } from "@/components/ui/meta-chip";
@@ -39,6 +42,7 @@ import {
   redeemCodexResetCredit,
   type CodexResetRedemptionPreparation,
 } from "@/api";
+import { cn } from "@/lib/utils";
 
 function relativeTimestamp(value: string | number | null | undefined, now: number): string {
   if (value == null) return "";
@@ -295,52 +299,96 @@ export function UsageBar({
   );
 }
 
-/**
- * A row's two usage bars (5h + weekly) with all four component states. Prefers the
- * LIVE refresh payload (which carries an explicit status) over the cached windows.
- */
-function AccountUsage({
+/** Compact inline meter for the collapsed subscription row. */
+function CompactUsageMeter({ label, window }: { label: string; window: CodexUsageWindow | null }) {
+  if (!window) return null;
+  const pct = Math.min(100, Math.max(0, Math.round(window.percent)));
+  const danger = pct >= 90;
+  return (
+    <div
+      className="flex items-center gap-1.5 text-2xs text-fg-muted"
+      title={`${label} usage ${pct}%`}
+    >
+      <span className="shrink-0">{label}</span>
+      <div
+        className="h-1 w-14 overflow-hidden rounded-full bg-surface-2"
+        role="progressbar"
+        aria-label={`${label} usage`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={pct}
+      >
+        <div
+          className={`h-full rounded-full ${danger ? "bg-status-waiting" : "bg-brand"}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="w-7 shrink-0 tabular-nums text-fg-subtle">{pct}%</span>
+    </div>
+  );
+}
+
+function accountUsageWindows(
+  account: CodexAccount,
+  live: CodexUsage | undefined,
+): { fiveHour: CodexUsageWindow | null; weekly: CodexUsageWindow | null; status?: string } {
+  return {
+    status: live?.status,
+    fiveHour: live?.usage?.fiveHour ?? account.fiveHour ?? null,
+    weekly: live?.usage?.weekly ?? account.weekly ?? null,
+  };
+}
+
+/** Short 5h + weekly meters for the collapsed row. */
+function CompactAccountUsage({
   account,
   live,
-  overview,
-  now,
   refreshing,
   onRetry,
 }: {
   account: CodexAccount;
   live: CodexUsage | undefined;
-  overview: CodexAccountOverview | undefined;
-  now: number;
   refreshing: boolean;
   onRetry: () => void;
 }) {
-  const status = live?.status;
-  const fiveHour = live?.usage?.fiveHour ?? account.fiveHour ?? null;
-  const weekly = live?.usage?.weekly ?? account.weekly ?? null;
-
-  // loading — a live refresh is in flight and we have nothing cached yet.
+  const { fiveHour, weekly, status } = accountUsageWindows(account, live);
   if (refreshing && !fiveHour && !weekly) {
-    return <div className="h-3 w-2/3 animate-pulse rounded bg-surface-2" />;
+    return <div className="h-3 w-28 animate-pulse rounded bg-surface-2" />;
   }
-  // error — a refresh/needs_relogin or transient 401. Subtle inline, not a hard block.
   if (status === "error" && !fiveHour && !weekly) {
     return (
-      <div className="text-xs text-fg-subtle">
-        usage unavailable ·{" "}
-        <button type="button" className="underline hover:text-fg" onClick={onRetry}>
-          retry
-        </button>
-      </div>
+      <button type="button" className="text-2xs text-fg-subtle underline hover:text-fg" onClick={onRetry}>
+        retry usage
+      </button>
     );
   }
-  // no-data — no windows and the call succeeded: render nothing (the plan badge stands in).
-  if (!fiveHour && !weekly) {
-    return null;
-  }
+  if (!fiveHour && !weekly) return null;
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1" aria-live="polite">
+      <CompactUsageMeter label="5h" window={fiveHour} />
+      <CompactUsageMeter label="Wk" window={weekly} />
+    </div>
+  );
+}
+
+/** Expanded-only usage meta (timestamps / limit-reached); bars stay on the row. */
+function AccountUsageMeta({
+  account,
+  live,
+  overview,
+  now,
+}: {
+  account: CodexAccount;
+  live: CodexUsage | undefined;
+  overview: CodexAccountOverview | undefined;
+  now: number;
+}) {
+  const { fiveHour, weekly, status } = accountUsageWindows(account, live);
+  if (!overview && !fiveHour && !weekly) return null;
   const limitReached =
     status === "limit_reached" || (fiveHour?.percent ?? 0) >= 100 || (weekly?.percent ?? 0) >= 100;
   return (
-    <div className="grid gap-2" aria-live="polite">
+    <div className="grid gap-1.5" aria-live="polite">
       {overview ? (
         <div className="text-2xs text-fg-subtle">
           {overview.usage.source === "provider" ? "Provider reported" : "Cached by OpenGeni"}
@@ -350,8 +398,16 @@ function AccountUsage({
           {overview.usage.stale ? " · stale" : ""}
         </div>
       ) : null}
-      <UsageBar label="5-hour" window={fiveHour} now={now} />
-      <UsageBar label="Weekly" window={weekly} now={now} />
+      {fiveHour ? (
+        <div className="text-2xs text-fg-subtle">
+          5-hour · {resetTimestamp(fiveHour, now) || "reset unknown"}
+        </div>
+      ) : null}
+      {weekly ? (
+        <div className="text-2xs text-fg-subtle">
+          Weekly · {resetTimestamp(weekly, now) || "reset unknown"}
+        </div>
+      ) : null}
       {limitReached ? (
         <div className="flex items-center gap-1.5 text-xs text-status-waiting">
           <TriangleAlertIcon className="size-3.5" /> Usage limit reached
@@ -543,6 +599,30 @@ function accountDisplay(account: CodexAccount): string {
   return account.label ?? account.email ?? account.plan ?? "Codex account";
 }
 
+const RESET_URGENT_MS = 2 * 24 * 60 * 60 * 1000;
+const RESET_SOON_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Soonest reset-credit expiry among listed credits (unix-seconds → ms remaining). */
+function soonestResetExpiryMs(credits: CodexResetCredit[], now: number): number | null {
+  let soonest: number | null = null;
+  for (const credit of credits) {
+    if (credit.expiresAt == null) continue;
+    if (credit.status !== "available" && !credit.actionable) continue;
+    const remaining = credit.expiresAt * 1000 - now;
+    if (soonest == null || remaining < soonest) soonest = remaining;
+  }
+  return soonest;
+}
+
+function resetBadgeTone(
+  remainingMs: number | null,
+): "urgent" | "soon" | "ok" {
+  if (remainingMs == null) return "ok";
+  if (remainingMs < RESET_URGENT_MS) return "urgent";
+  if (remainingMs < RESET_SOON_MS) return "soon";
+  return "ok";
+}
+
 export function CodexSubscriptionsCard({
   workspaceId,
   canManage,
@@ -581,6 +661,9 @@ export function CodexSubscriptionsCard({
   // A monotonic clock the rows tick off for the reset countdown — one timer for
   // the whole card, never a backend re-hit.
   const [now, setNow] = useState(() => Date.now());
+  // One expanded subscription at a time; healthy rows stay collapsed by default.
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const autoExpandedReloginRef = useRef(false);
   useEffect(() => {
     const timer = setInterval(() => setNow(Date.now()), 30_000);
     return () => clearInterval(timer);
@@ -934,58 +1017,64 @@ export function CodexSubscriptionsCard({
   const activeAccountId = data?.activeAccountId ?? null;
   const rotationEnabled = data?.settings?.rotationEnabled ?? false;
 
+  useEffect(() => {
+    autoExpandedReloginRef.current = false;
+    setExpandedId(null);
+  }, [workspaceId]);
+
+  // Burying reconnect behind a click is worse than one auto-open; healthy rows stay closed.
+  useEffect(() => {
+    if (autoExpandedReloginRef.current || expandedId != null) return;
+    const needsRelogin = accounts.find(
+      (account) => account.status !== "active" && account.lastError != null,
+    );
+    if (!needsRelogin) return;
+    autoExpandedReloginRef.current = true;
+    setExpandedId(needsRelogin.id);
+  }, [accounts, expandedId]);
+
   return (
-    <section
-      aria-labelledby="codex-subscriptions-heading"
-      className="grid gap-3 rounded-lg border border-border bg-surface p-4"
-    >
-      <div className="flex items-start justify-between gap-3">
+    <section aria-labelledby="codex-subscriptions-heading" className="grid gap-2">
+      <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
           <h2
             id="codex-subscriptions-heading"
             className="flex items-center gap-1.5 text-sm font-medium"
           >
-            <SparklesIcon className="size-3.5 text-brand" />
+            <ChatGptMark className="size-3.5 text-brand" />
             Codex subscriptions
           </h2>
-          <p className="mt-1 text-xs text-fg-muted">
-            Connect one or more ChatGPT plans to run agents on your subscription. Turns using a{" "}
-            <span className="font-medium">Codex</span> model spend your ChatGPT usage —{" "}
-            <span className="font-medium">no API credits</span>.
+          <p className="mt-0.5 text-2xs text-fg-subtle">
+            ChatGPT plans for Codex models — subscription usage, not API credits.
           </p>
         </div>
         {canManage && accounts.length > 0 && !pending ? (
           <Button
             type="button"
             size="sm"
-            variant="secondary"
+            variant="ghost"
             disabled={busy}
             onClick={() => void connect()}
           >
-            <PlusIcon className="size-3.5" /> Connect another subscription
+            <PlusIcon className="size-3.5" /> Connect
           </Button>
         ) : null}
       </div>
 
       {accounts.length > 1 && canManage ? (
-        <div className="grid gap-2 rounded-md border border-border bg-bg p-3">
-          <label className="flex cursor-pointer items-center justify-between gap-3">
-            <span className="text-xs">
-              <span className="font-medium">Auto-rotate subscriptions</span>
-              <span className="ml-1 text-fg-subtle">
-                — each session sticks to one plan for maximum prompt-cache reuse, spread across all
-                of them; a capped plan hands its sessions to the others, never mid-turn.
-              </span>
-            </span>
-            <input
-              type="checkbox"
-              className="size-4 accent-brand"
-              checked={rotationEnabled}
-              disabled={busy}
-              onChange={(e) => void setRotation({ rotationEnabled: e.target.checked })}
-            />
-          </label>
-        </div>
+        <label
+          className="flex cursor-pointer items-center justify-between gap-3 rounded-md border border-border/70 px-3 py-2"
+          title="Each session sticks to one plan for prompt-cache reuse; a capped plan hands sessions to others, never mid-turn."
+        >
+          <span className="text-xs font-medium">Auto-rotate subscriptions</span>
+          <input
+            type="checkbox"
+            className="size-4 accent-brand"
+            checked={rotationEnabled}
+            disabled={busy}
+            onChange={(e) => void setRotation({ rotationEnabled: e.target.checked })}
+          />
+        </label>
       ) : null}
 
       {loading ? (
@@ -1021,211 +1110,288 @@ export function CodexSubscriptionsCard({
               {busy ? (
                 <Loader2Icon className="size-3.5 animate-spin" />
               ) : (
-                <SparklesIcon className="size-3.5" />
+                <ChatGptMark className="size-3.5" />
               )}{" "}
               Connect Codex
             </Button>
           ) : null}
         </div>
       ) : (
-        <div className="grid gap-2">
+        <div className="divide-y divide-border/70 overflow-hidden rounded-lg border border-border">
           {accounts.map((account) => {
             const isActive = account.id === activeAccountId;
             const needsRelogin = account.status !== "active" && account.lastError != null;
+            const resetOverview = overviewMap[account.id]?.resetCredits;
+            const resetCount = resetOverview?.availableCount;
+            const resetRemainingMs = soonestResetExpiryMs(resetOverview?.credits ?? [], now);
+            const resetTone = resetBadgeTone(resetRemainingMs);
+            const expanded = expandedId === account.id;
+            const coolingSecs = account.exhaustedUntil
+              ? Math.max(
+                  0,
+                  Math.round((new Date(account.exhaustedUntil).getTime() - now) / 1000),
+                )
+              : 0;
             return (
               <article
                 key={account.id}
-                className="grid gap-2 rounded-md border border-border bg-bg p-3"
                 aria-label={`${accountDisplay(account)} Codex subscription`}
               >
-                <div className="flex flex-wrap items-center gap-3">
-                  <label
-                    className="flex min-h-11 min-w-11 cursor-pointer items-center justify-center"
-                    title="Used when a session isn't pinned to a specific subscription"
+                <Collapsible
+                  open={expanded}
+                  onOpenChange={(open) => setExpandedId(open ? account.id : null)}
+                >
+                  <div
+                    className="flex min-w-0 cursor-pointer flex-wrap items-center gap-2 px-2.5 py-2 transition-colors hover:bg-surface-2/50"
+                    onClick={() => setExpandedId(expanded ? null : account.id)}
                   >
-                    <input
-                      type="radio"
-                      name="codex-active"
-                      className="size-3.5 accent-brand"
-                      checked={isActive}
-                      disabled={!canManage || busy}
-                      aria-label={`Use ${accountDisplay(account)} as active subscription`}
-                      onChange={() => {
-                        if (!isActive) void activate(account.id);
-                      }}
-                    />
-                  </label>
-                  <div className="min-w-0 flex-1">
-                    {editing?.id === account.id ? (
-                      <Input
-                        autoFocus
-                        value={editing.value}
-                        onChange={(e) => setEditing({ id: account.id, value: e.target.value })}
-                        onBlur={() => void commitRename(account.id, editing.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") void commitRename(account.id, editing.value);
-                          if (e.key === "Escape") setEditing(null);
+                    <label
+                      className="flex min-h-9 min-w-9 cursor-pointer items-center justify-center"
+                      title="Used when a session isn't pinned to a specific subscription"
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      <input
+                        type="radio"
+                        name="codex-active"
+                        className="size-3.5 accent-brand"
+                        checked={isActive}
+                        disabled={!canManage || busy}
+                        aria-label={`Use ${accountDisplay(account)} as active subscription`}
+                        onChange={() => {
+                          if (!isActive) void activate(account.id);
                         }}
-                        className="h-7 text-sm"
                       />
+                    </label>
+                    <div
+                      className="flex min-w-0 flex-1 basis-36 items-center gap-1"
+                      onClick={(event) => {
+                        // Keep rename/edit from toggling; plain text still expands via row.
+                        if (editing?.id === account.id) event.stopPropagation();
+                      }}
+                    >
+                      {editing?.id === account.id ? (
+                        <Input
+                          autoFocus
+                          value={editing.value}
+                          onChange={(e) => setEditing({ id: account.id, value: e.target.value })}
+                          onBlur={() => void commitRename(account.id, editing.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") void commitRename(account.id, editing.value);
+                            if (e.key === "Escape") setEditing(null);
+                          }}
+                          className="h-7 text-sm"
+                        />
+                      ) : (
+                        <>
+                          <span className="min-w-0 truncate text-sm font-medium">
+                            {accountDisplay(account)}
+                            {account.email && account.label ? (
+                              <span className="font-normal text-fg-subtle"> · {account.email}</span>
+                            ) : null}
+                          </span>
+                          {canManage ? (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-sm"
+                              className="size-7 shrink-0"
+                              aria-label={`Rename ${accountDisplay(account)}`}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                setEditing({
+                                  id: account.id,
+                                  value: account.label ?? "",
+                                });
+                              }}
+                            >
+                              <PencilIcon className="size-3.5" />
+                            </Button>
+                          ) : null}
+                        </>
+                      )}
+                    </div>
+                    {account.plan ? (
+                      <MetaChip dot="idle" rounded="full">
+                        {account.plan}
+                      </MetaChip>
+                    ) : null}
+                    {!needsRelogin ? (
+                      <div onClick={(event) => event.stopPropagation()}>
+                        <CompactAccountUsage
+                          account={account}
+                          live={usageMap[account.id]}
+                          refreshing={refreshingUsage || refreshingRow === account.id}
+                          onRetry={() => void refreshAccountUsage(account.id)}
+                        />
+                      </div>
                     ) : (
-                      <button
-                        type="button"
-                        className="truncate text-left text-sm font-medium hover:underline disabled:cursor-default disabled:no-underline"
-                        disabled={!canManage}
-                        onClick={() =>
-                          setEditing({
-                            id: account.id,
-                            value: account.label ?? "",
-                          })
-                        }
-                        title={canManage ? "Click to rename" : undefined}
-                      >
-                        {accountDisplay(account)}
-                      </button>
+                      <span className="flex items-center gap-1 text-2xs text-status-waiting">
+                        <TriangleAlertIcon className="size-3" /> Reconnect
+                      </span>
                     )}
-                    <div className="mt-0.5 truncate text-xs text-fg-subtle">
-                      {account.email ? `${account.email} · ` : ""}
+                    {typeof resetCount === "number" && resetCount > 0 ? (
+                      <span
+                        className={cn(
+                          "inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-2xs",
+                          resetTone === "urgent" &&
+                            "border-status-failed/40 bg-status-failed/10 text-status-failed",
+                          resetTone === "soon" &&
+                            "border-status-waiting/40 bg-status-waiting/10 text-status-waiting",
+                          resetTone === "ok" && "border-border/70 bg-surface/60 text-fg-muted",
+                        )}
+                        title={
+                          resetRemainingMs == null
+                            ? `${resetCount} usage limit reset${resetCount === 1 ? "" : "s"} available`
+                            : `${resetCount} usage limit reset${resetCount === 1 ? "" : "s"} · soonest expires ${
+                                resetRemainingMs <= 0
+                                  ? "now"
+                                  : relativeTimestamp((now + resetRemainingMs) / 1000, now)
+                              }`
+                        }
+                      >
+                        <TicketCheckIcon
+                          className={cn(
+                            "size-3",
+                            resetTone === "urgent" && "text-status-failed",
+                            resetTone === "soon" && "text-status-waiting",
+                            resetTone === "ok" && "text-brand",
+                          )}
+                        />
+                        {resetCount}
+                      </span>
+                    ) : null}
+                    <CollapsibleTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        className="shrink-0"
+                        aria-label={
+                          expanded
+                            ? `Hide details for ${accountDisplay(account)}`
+                            : `Show details for ${accountDisplay(account)}`
+                        }
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <ChevronDownIcon
+                          className={cn(
+                            "size-4 text-fg-subtle transition-transform",
+                            expanded ? "rotate-180" : "",
+                          )}
+                        />
+                      </Button>
+                    </CollapsibleTrigger>
+                  </div>
+                  <CollapsibleContent className="grid gap-2 border-t border-border/60 px-2.5 py-2.5">
+                    <div className="truncate text-2xs text-fg-subtle">
                       {account.status === "active"
                         ? "Token valid"
                         : account.status.replaceAll("_", " ")}
                       {account.expiresAt
                         ? ` · expires ${new Date(account.expiresAt).toLocaleString()}`
                         : ""}
+                      {coolingSecs > 0
+                        ? ` · cooling down ${resetLabel(coolingSecs)}`
+                        : isActive
+                          ? rotationEnabled
+                            ? " · active default when idle"
+                            : " · active"
+                          : ""}
                     </div>
-                  </div>
-                  {account.plan ? (
-                    <MetaChip dot="idle" rounded="full">
-                      {account.plan} plan
-                    </MetaChip>
-                  ) : null}
-                  {(() => {
-                    const coolingSecs = account.exhaustedUntil
-                      ? Math.max(
-                          0,
-                          Math.round((new Date(account.exhaustedUntil).getTime() - now) / 1000),
-                        )
-                      : 0;
-                    if (coolingSecs > 0) {
-                      return (
-                        <MetaChip
-                          dot="waiting"
-                          rounded="full"
-                          title="Rotated off after hitting its cap; skipped until reset"
-                        >
-                          Cooling down · {resetLabel(coolingSecs)}
-                        </MetaChip>
-                      );
-                    }
-                    if (isActive) {
-                      return (
-                        <span className="shrink-0 text-2xs uppercase tracking-wide text-fg-subtle">
-                          {rotationEnabled ? "Active · default when idle" : "Active"}
+                    <label
+                      className="flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-md border border-border/70 bg-surface/50 px-2.5"
+                      title="Pausing affects only new automatic selection. Current leased or frozen turns continue; quota, cooldown, and relogin state still gate eligibility."
+                    >
+                      <span className="text-xs font-medium">Use for new automatic turns</span>
+                      <span className="flex items-center gap-2 text-xs text-fg-muted">
+                        <input
+                          type="checkbox"
+                          className="size-4 accent-brand"
+                          checked={account.allocatorEnabled}
+                          disabled={!canManage || busy}
+                          aria-label={`Use ${accountDisplay(account)} for new automatic turns`}
+                          onChange={(event) => void setAllocator(account, event.target.checked)}
+                        />
+                        <span aria-hidden="true">
+                          {account.allocatorEnabled ? "Enabled" : "Paused"}
                         </span>
-                      );
-                    }
-                    return null;
-                  })()}
-                </div>
-                <div className="flex min-w-0 flex-wrap items-start justify-between gap-2 rounded-md border border-border/70 bg-surface/50 p-2.5">
-                  <div className="min-w-0 flex-1">
-                    <div className="text-xs font-medium">Use for new automatic turns</div>
-                    <p className="mt-0.5 break-words text-2xs text-fg-subtle">
-                      Pausing affects only new automatic selection. Current leased or frozen turns
-                      continue; quota, cooldown, and relogin state still gate eligibility.
-                    </p>
-                  </div>
-                  <label className="flex min-h-11 shrink-0 cursor-pointer items-center gap-2 text-xs">
-                    <span className="sr-only">
-                      {account.allocatorEnabled ? "Pause" : "Enable"} {accountDisplay(account)} for
-                      new automatic turns
-                    </span>
-                    <input
-                      type="checkbox"
-                      className="size-4 accent-brand"
-                      checked={account.allocatorEnabled}
-                      disabled={!canManage || busy}
-                      aria-label={`Use ${accountDisplay(account)} for new automatic turns`}
-                      onChange={(event) => void setAllocator(account, event.target.checked)}
+                      </span>
+                    </label>
+                    {needsRelogin ? (
+                      <div className="flex items-center gap-1.5 rounded-md border border-status-waiting/30 bg-status-waiting/10 p-2 text-xs text-status-waiting">
+                        <TriangleAlertIcon className="size-3.5" />{" "}
+                        {account.lastError ?? "Reconnect needed."}
+                      </div>
+                    ) : (
+                      <AccountUsageMeta
+                        account={account}
+                        live={usageMap[account.id]}
+                        overview={overviewMap[account.id]}
+                        now={now}
+                      />
+                    )}
+                    <ResetCreditInventory
+                      overview={overviewMap[account.id]}
+                      now={now}
+                      busy={busy || preparingReset != null}
+                      recoveryAttempts={redemptionAttemptViews(
+                        workspaceId,
+                        account.id,
+                        overviewMap[account.id],
+                      )}
+                      onRedeem={(credit, recovery) =>
+                        void beginRedemption(account.id, credit, recovery)
+                      }
                     />
-                    <span aria-hidden="true" className="text-fg-muted">
-                      {account.allocatorEnabled ? "Enabled" : "Paused"}
-                    </span>
-                  </label>
-                </div>
-                {needsRelogin ? (
-                  <div className="flex items-center gap-1.5 rounded-md border border-status-waiting/30 bg-status-waiting/10 p-2 text-xs text-status-waiting">
-                    <TriangleAlertIcon className="size-3.5" />{" "}
-                    {account.lastError ?? "Reconnect needed."}
-                  </div>
-                ) : (
-                  <AccountUsage
-                    account={account}
-                    live={usageMap[account.id]}
-                    overview={overviewMap[account.id]}
-                    now={now}
-                    refreshing={refreshingUsage || refreshingRow === account.id}
-                    onRetry={() => void refreshAccountUsage(account.id)}
-                  />
-                )}
-                <ResetCreditInventory
-                  overview={overviewMap[account.id]}
-                  now={now}
-                  busy={busy || preparingReset != null}
-                  recoveryAttempts={redemptionAttemptViews(
-                    workspaceId,
-                    account.id,
-                    overviewMap[account.id],
-                  )}
-                  onRedeem={(credit, recovery) =>
-                    void beginRedemption(account.id, credit, recovery)
-                  }
-                />
-                {canManage ? (
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      disabled={busy || refreshingRow === account.id}
-                      onClick={() => void refreshAccountUsage(account.id)}
-                    >
-                      {refreshingRow === account.id ? (
-                        <Loader2Icon className="size-3.5 animate-spin" />
-                      ) : (
-                        <RefreshCwIcon className="size-3.5" />
-                      )}{" "}
-                      Refresh
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      disabled={busy}
-                      onClick={() => void disconnect(account.id)}
-                    >
-                      <Trash2Icon className="size-3.5" /> Disconnect
-                    </Button>
-                  </div>
-                ) : null}
+                    {canManage ? (
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          disabled={busy || refreshingRow === account.id}
+                          onClick={() => void refreshAccountUsage(account.id)}
+                        >
+                          {refreshingRow === account.id ? (
+                            <Loader2Icon className="size-3.5 animate-spin" />
+                          ) : (
+                            <RefreshCwIcon className="size-3.5" />
+                          )}{" "}
+                          Refresh
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          disabled={busy}
+                          onClick={() => void disconnect(account.id)}
+                        >
+                          <Trash2Icon className="size-3.5" /> Disconnect
+                        </Button>
+                      </div>
+                    ) : null}
+                  </CollapsibleContent>
+                </Collapsible>
               </article>
             );
           })}
-          <p className="text-2xs text-fg-subtle">
-            {rotationEnabled ? (
-              <>
-                Sessions are spread across all {accounts.length} subscriptions, each sticking to its
-                own plan for maximum prompt-cache reuse. Pinned sessions stay on their pin.
-              </>
-            ) : (
-              <>
-                The <span className="font-medium">active</span> subscription runs every session that
-                isn't pinned to a specific one.
-              </>
-            )}
-          </p>
         </div>
       )}
+      {accounts.length > 0 && !pending && !loading ? (
+        <p className="text-2xs text-fg-subtle">
+          {rotationEnabled ? (
+            <>
+              Sessions are spread across all {accounts.length} subscriptions, each sticking to its
+              own plan for maximum prompt-cache reuse. Pinned sessions stay on their pin.
+            </>
+          ) : (
+            <>
+              The <span className="font-medium">active</span> subscription runs every session that
+              isn't pinned to a specific one.
+            </>
+          )}
+        </p>
+      ) : null}
       <ConfirmDialog
         open={redemption != null}
         onOpenChange={(open) => {

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -351,7 +351,7 @@ export function RailShell({ children }: { children: ReactNode }) {
             >
               <SheetTitle className="sr-only">Session navigation</SheetTitle>
               <SheetDescription className="sr-only">
-                Browse workspace sessions or open workspace settings.
+                Browse workspace sessions or open Workspace.
               </SheetDescription>
               <nav aria-label="Primary" className="h-full">
                 <RailBody />

--- a/apps/web/src/components/rail/session-header.tsx
+++ b/apps/web/src/components/rail/session-header.tsx
@@ -13,7 +13,7 @@ import {
 } from "@opengeni/react";
 import type { SessionEventsConnectionState } from "@opengeni/react";
 import type { SessionSummary } from "@opengeni/sdk";
-import { LockIcon, PanelRightIcon, PauseIcon, PencilIcon, PinIcon, PlayIcon } from "lucide-react";
+import { LockIcon, PanelRightIcon, PauseIcon, PencilIcon, PinIcon } from "lucide-react";
 import { useCallback, useRef, useState, type ReactNode } from "react";
 
 import { BillingClassMark, type BillingClass } from "@/components/billing-class-mark";
@@ -177,11 +177,21 @@ export function SessionHeader({
         <SessionPinButton session={session} onPin={onPin} />
         <div className="hidden items-center gap-2 md:flex">
           <ConnectionPill state={connectionState} />
-          <SessionStatusBadge status={status} />
+          {/* Admission vs lifecycle are different axes, but showing both when
+              control is Active (Running + Active) is redundant noise. When
+              paused, admission is the headline — hide lifecycle so we don't
+              imply the session is still "Running"/"Idle" under a pause gate. */}
+          {session.effectiveControl.state === "active" ? (
+            <SessionStatusBadge status={status} />
+          ) : (
+            <WorkstreamControlIndicator session={session} />
+          )}
         </div>
-        <WorkstreamControlIndicator session={session} />
         <span className="sr-only md:hidden">
-          Connection {connectionState}. Session {status}.
+          Connection {connectionState}.{" "}
+          {session.effectiveControl.state === "active"
+            ? `Session ${status}.`
+            : "Workstream paused."}
         </span>
         {keyAuthRequired ? (
           <Button
@@ -210,17 +220,19 @@ export function SessionHeader({
   );
 }
 
+/** Pause-only header chip (Active is not shown — lifecycle status covers “go”). */
 function WorkstreamControlIndicator({ session }: { session: Session }) {
   const control = session.effectiveControl;
+  if (control.state !== "paused") {
+    return null;
+  }
   const blocker = control.primaryBlocker;
   const label =
-    control.state === "active"
-      ? "Active"
-      : blocker?.kind === "workspace"
-        ? "Workspace paused"
-        : control.directState === "paused" || blocker?.sessionId === session.id
-          ? "Paused here"
-          : `Paused by ${blocker?.displayName ?? "parent"}`;
+    blocker?.kind === "workspace"
+      ? "Workspace paused"
+      : control.directState === "paused" || blocker?.sessionId === session.id
+        ? "Paused here"
+        : `Paused by ${blocker?.displayName ?? "parent"}`;
   return (
     <button
       type="button"
@@ -229,17 +241,9 @@ function WorkstreamControlIndicator({ session }: { session: Session }) {
       onClick={() => {
         document.dispatchEvent(new Event(OPEN_WORKSTREAM_CONTROL_EVENT));
       }}
-      className={`inline-flex min-w-0 max-w-48 items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium ${
-        control.state === "paused"
-          ? "border-status-waiting/35 bg-status-waiting/10 text-fg hover:bg-status-waiting/15"
-          : "border-status-running/30 bg-status-running/10 text-fg hover:bg-status-running/15"
-      }`}
+      className="inline-flex min-w-0 max-w-48 items-center gap-1.5 rounded-full border border-status-waiting/35 bg-status-waiting/10 px-2 py-0.5 text-xs font-medium text-fg hover:bg-status-waiting/15"
     >
-      {control.state === "paused" ? (
-        <PauseIcon className="size-3 shrink-0 fill-current text-status-waiting" />
-      ) : (
-        <PlayIcon className="size-3 shrink-0 fill-current text-status-running" />
-      )}
+      <PauseIcon className="size-3 shrink-0 fill-current text-status-waiting" />
       <span className="hidden truncate sm:inline">{label}</span>
       {control.additionalBlockerCount > 0 ? (
         <span className="hidden shrink-0 sm:inline">+{control.additionalBlockerCount}</span>

--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -368,7 +368,7 @@ function WorkspaceMenu(props: {
             params={{ workspaceId: props.activeWorkspaceId }}
           >
             <SettingsIcon className="size-4" />
-            Workspace settings
+            Settings
           </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/apps/web/src/components/rail/workspace-nav-data.ts
+++ b/apps/web/src/components/rail/workspace-nav-data.ts
@@ -1,0 +1,183 @@
+// Leaf workspace-destination catalog. Icon *names* only — never Lucide
+// components — so lazy settings can share this module without pulling icon
+// modules that Rolldown colocated into workbench/composer share chunks.
+
+export type WorkspaceConfigTarget =
+  | "/workspaces/$workspaceId/insights"
+  | "/workspaces/$workspaceId/variable-sets"
+  | "/workspaces/$workspaceId/rigs"
+  | "/workspaces/$workspaceId/machines"
+  | "/workspaces/$workspaceId/capabilities"
+  | "/workspaces/$workspaceId/schedules"
+  | "/workspaces/$workspaceId/documents"
+  | "/workspaces/$workspaceId/memory"
+  | "/workspaces/$workspaceId/state"
+  | "/workspaces/$workspaceId/artifacts"
+  | "/workspaces/$workspaceId/settings";
+
+export type WorkspaceConfigIcon =
+  | "gauge"
+  | "box"
+  | "server-cog"
+  | "laptop"
+  | "file-search"
+  | "brain-circuit"
+  | "map"
+  | "plug"
+  | "calendar-clock"
+  | "panels-top-left"
+  | "settings";
+
+export type WorkspaceConfigItem = {
+  to: WorkspaceConfigTarget;
+  icon: WorkspaceConfigIcon;
+  label: string;
+  description: string;
+  /** When true, only include for subjects with workspace:admin. */
+  requiresAdmin?: boolean;
+};
+
+export type WorkspaceConfigGroup = {
+  id: string;
+  label: string;
+  items: WorkspaceConfigItem[];
+};
+
+export const WORKSPACE_CONFIG_GROUPS: WorkspaceConfigGroup[] = [
+  {
+    id: "overview",
+    label: "Overview",
+    items: [
+      {
+        to: "/workspaces/$workspaceId/insights",
+        icon: "gauge",
+        label: "Insights",
+        description: "Spend, blockers, automation, and outcomes",
+        requiresAdmin: true,
+      },
+    ],
+  },
+  {
+    id: "runtime",
+    label: "Runtime",
+    items: [
+      {
+        to: "/workspaces/$workspaceId/variable-sets",
+        icon: "box",
+        label: "Variable sets",
+        description: "Secret variableSets for sandboxes",
+      },
+      {
+        to: "/workspaces/$workspaceId/rigs",
+        icon: "server-cog",
+        label: "Rigs",
+        description: "Versioned sandbox machine definitions",
+      },
+      {
+        to: "/workspaces/$workspaceId/machines",
+        icon: "laptop",
+        label: "Machines",
+        description: "Your own connected computers",
+      },
+    ],
+  },
+  {
+    id: "knowledge",
+    label: "Knowledge",
+    items: [
+      {
+        to: "/workspaces/$workspaceId/documents",
+        icon: "file-search",
+        label: "Documents",
+        description: "Indexed knowledge for agents",
+      },
+      {
+        to: "/workspaces/$workspaceId/memory",
+        icon: "brain-circuit",
+        label: "Memory",
+        description: "Durable facts agents carry across sessions",
+      },
+      {
+        to: "/workspaces/$workspaceId/state",
+        icon: "map",
+        label: "Workspace State",
+        description: "Read-only policy and knowledge inventory",
+      },
+    ],
+  },
+  {
+    id: "automation",
+    label: "Automation",
+    items: [
+      {
+        to: "/workspaces/$workspaceId/capabilities",
+        icon: "plug",
+        label: "Capabilities",
+        description: "Packs, MCP servers, and tools",
+      },
+      {
+        to: "/workspaces/$workspaceId/schedules",
+        icon: "calendar-clock",
+        label: "Schedules",
+        description: "Run agents on a schedule",
+      },
+      {
+        to: "/workspaces/$workspaceId/artifacts",
+        icon: "panels-top-left",
+        label: "Artifacts",
+        description: "Live pages and tools built with Geni",
+      },
+    ],
+  },
+  {
+    id: "admin",
+    label: "Admin",
+    items: [
+      {
+        to: "/workspaces/$workspaceId/settings",
+        icon: "settings",
+        label: "General, members & keys",
+        description: "Name, API keys, members, and Codex subscriptions",
+      },
+    ],
+  },
+];
+
+/** Destinations shown in the Browse workspace strip (excludes the settings page itself). */
+export const WORKSPACE_BROWSE_ITEMS: WorkspaceConfigItem[] = WORKSPACE_CONFIG_GROUPS.flatMap(
+  (group) => group.items,
+).filter((item) => item.to !== "/workspaces/$workspaceId/settings");
+
+export function filterWorkspaceConfigGroups(
+  groups: WorkspaceConfigGroup[],
+  canReadInsights: boolean,
+): WorkspaceConfigGroup[] {
+  return groups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) => !item.requiresAdmin || canReadInsights),
+    }))
+    .filter((group) => group.items.length > 0);
+}
+
+function configPathSuffix(to: WorkspaceConfigTarget): string {
+  const parts = to.split("/");
+  return parts[parts.length - 1] ?? "";
+}
+
+export function isWorkspaceConfigPath(pathname: string, workspaceId: string): boolean {
+  const prefix = `/workspaces/${workspaceId}/`;
+  if (!pathname.startsWith(prefix)) return false;
+  const rest = pathname.slice(prefix.length).split("/")[0] ?? "";
+  return WORKSPACE_CONFIG_GROUPS.some((group) =>
+    group.items.some((item) => configPathSuffix(item.to) === rest),
+  );
+}
+
+export function isConfigItemActive(
+  pathname: string,
+  workspaceId: string,
+  to: WorkspaceConfigTarget,
+): boolean {
+  return pathname === `/workspaces/${workspaceId}/${configPathSuffix(to)}`;
+}

--- a/apps/web/src/components/rail/workspace-nav-icons.tsx
+++ b/apps/web/src/components/rail/workspace-nav-icons.tsx
@@ -1,0 +1,30 @@
+import {
+  BoxIcon,
+  BrainCircuitIcon,
+  CalendarClockIcon,
+  FileSearchIcon,
+  GaugeIcon,
+  LaptopIcon,
+  MapIcon,
+  PanelsTopLeftIcon,
+  PlugIcon,
+  ServerCogIcon,
+  SettingsIcon,
+  type LucideIcon,
+} from "lucide-react";
+
+import type { WorkspaceConfigIcon } from "@/components/rail/workspace-nav-data";
+
+export const WORKSPACE_CONFIG_ICONS: Record<WorkspaceConfigIcon, LucideIcon> = {
+  gauge: GaugeIcon,
+  box: BoxIcon,
+  "server-cog": ServerCogIcon,
+  laptop: LaptopIcon,
+  "file-search": FileSearchIcon,
+  "brain-circuit": BrainCircuitIcon,
+  map: MapIcon,
+  plug: PlugIcon,
+  "calendar-clock": CalendarClockIcon,
+  "panels-top-left": PanelsTopLeftIcon,
+  settings: SettingsIcon,
+};

--- a/apps/web/src/components/rail/workspace-nav.tsx
+++ b/apps/web/src/components/rail/workspace-nav.tsx
@@ -2,9 +2,13 @@
 // upward menu of grouped destinations (Overview / Runtime / Knowledge /
 // Automation / Admin). Mobile Workspace tab keeps the same groups as an inline
 // list. Active route marks the Settings control and the matching menu item.
+//
+// Native <details> (not Radix DropdownMenu): the densified hub otherwise pulls
+// Popper into an entriesAware share-chunk with the session graph and crashes
+// lazy /settings (`createPopperScope is not a function`).
 import { Link, useRouterState } from "@tanstack/react-router";
 import { ChevronUpIcon, SettingsIcon } from "lucide-react";
-import { useState, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 
 import { useRail } from "@/components/rail/rail-context";
 import {
@@ -16,16 +20,6 @@ import {
   type WorkspaceConfigTarget,
 } from "@/components/rail/workspace-nav-data";
 import { WORKSPACE_CONFIG_ICONS } from "@/components/rail/workspace-nav-icons";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAppContext } from "@/context";
 import { hasWorkspacePermission } from "@/lib/permissions";
 import { cn } from "@/lib/utils";
@@ -104,88 +98,81 @@ function WorkspaceSettingsMenu(props: {
   collapsed: boolean;
   active: boolean;
 }) {
-  const [open, setOpen] = useState(false);
-  const trigger = (
-    <button
-      type="button"
-      aria-label={props.collapsed ? "Workspace" : undefined}
-      aria-expanded={open}
-      data-active={props.active ? "true" : undefined}
-      className={cn(
-        "group relative flex h-8 w-full items-center rounded-md text-sm font-medium text-fg-muted transition-colors pointer-coarse:h-10",
-        "hover:bg-surface-2 hover:text-fg",
-        "data-[active=true]:bg-surface-2 data-[active=true]:text-fg",
-        props.collapsed ? "w-8 justify-center pointer-coarse:w-10" : "gap-2.5 px-2.5",
-      )}
-    >
-      <span className="absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-brand opacity-0 transition-opacity group-data-[active=true]:opacity-100" />
-      <SettingsIcon className="size-4 shrink-0" />
-      {!props.collapsed ? (
-        <>
-          <span className="min-w-0 flex-1 truncate text-left">Workspace</span>
-          <ChevronUpIcon
-            className={cn(
-              "size-3.5 shrink-0 text-fg-subtle transition-transform",
-              open ? "rotate-0" : "rotate-180",
-            )}
-          />
-        </>
-      ) : null}
-    </button>
-  );
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+
+  useEffect(() => {
+    const node = detailsRef.current;
+    if (!node) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!node.open) return;
+      if (event.target instanceof Node && node.contains(event.target)) return;
+      node.open = false;
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, []);
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      {props.collapsed ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent side="right" className="max-w-52">
-            <p className="font-medium">Workspace</p>
-            <p className="text-fg-subtle">Configure runtime, knowledge, and admin</p>
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
-      )}
-      <DropdownMenuContent
-        side="top"
-        align={props.collapsed ? "start" : "start"}
-        sideOffset={6}
-        className="w-64"
+    <details ref={detailsRef} className="group/workspace-menu relative">
+      <summary
+        aria-label={props.collapsed ? "Workspace" : undefined}
+        title={props.collapsed ? "Workspace — configure runtime, knowledge, and admin" : undefined}
+        data-active={props.active ? "true" : undefined}
+        className={cn(
+          "group relative flex h-8 w-full cursor-pointer list-none items-center rounded-md text-sm font-medium text-fg-muted transition-colors pointer-coarse:h-10 [&::-webkit-details-marker]:hidden",
+          "hover:bg-surface-2 hover:text-fg",
+          "data-[active=true]:bg-surface-2 data-[active=true]:text-fg",
+          props.collapsed ? "w-8 justify-center pointer-coarse:w-10" : "gap-2.5 px-2.5",
+        )}
+      >
+        <span className="absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-brand opacity-0 transition-opacity group-data-[active=true]:opacity-100" />
+        <SettingsIcon className="size-4 shrink-0" />
+        {!props.collapsed ? (
+          <>
+            <span className="min-w-0 flex-1 truncate text-left">Workspace</span>
+            <ChevronUpIcon className="size-3.5 shrink-0 rotate-180 text-fg-subtle transition-transform group-open/workspace-menu:rotate-0" />
+          </>
+        ) : null}
+      </summary>
+      <div
+        className={cn(
+          "absolute bottom-full z-50 mb-1.5 max-h-[min(24rem,70vh)] w-64 overflow-y-auto rounded-md border border-border bg-surface p-1 shadow-md",
+          props.collapsed ? "left-0" : "left-0",
+        )}
       >
         {props.groups.map((group, index) => (
-          <DropdownMenuGroup key={group.id}>
-            {index > 0 ? <DropdownMenuSeparator /> : null}
-            <DropdownMenuLabel className="text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
+          <div key={group.id}>
+            {index > 0 ? <div className="my-1 h-px bg-border" /> : null}
+            <p className="px-2 py-1.5 text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
               {group.label}
-            </DropdownMenuLabel>
+            </p>
             {group.items.map((item) => {
               const active = isConfigItemActive(props.pathname, props.workspaceId, item.to);
               const Icon = WORKSPACE_CONFIG_ICONS[item.icon];
               return (
-                <DropdownMenuItem key={item.to} asChild>
-                  <Link
-                    to={item.to}
-                    params={{ workspaceId: props.workspaceId }}
-                    data-active={active ? "true" : undefined}
-                    className={cn(
-                      "flex cursor-pointer items-center gap-2",
-                      active ? "bg-accent text-accent-foreground" : "",
-                    )}
-                    onClick={() => setOpen(false)}
-                  >
-                    <Icon className="size-4" />
-                    <span className="min-w-0 flex-1 truncate">{item.label}</span>
-                  </Link>
-                </DropdownMenuItem>
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  params={{ workspaceId: props.workspaceId }}
+                  data-active={active ? "true" : undefined}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none",
+                    "hover:bg-accent hover:text-accent-foreground",
+                    active ? "bg-accent text-accent-foreground" : "text-fg",
+                  )}
+                  onClick={() => {
+                    if (detailsRef.current) detailsRef.current.open = false;
+                  }}
+                >
+                  <Icon className="size-4" />
+                  <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                </Link>
               );
             })}
-          </DropdownMenuGroup>
+          </div>
         ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+      </div>
+    </details>
   );
 }
 
@@ -202,7 +189,7 @@ export function RailNavItem(props: {
   /** When set, overrides Link activeProps for explicit active highlighting. */
   active?: boolean;
 }) {
-  const link = (
+  return (
     <Link
       to={props.to}
       params={{ workspaceId: props.workspaceId }}
@@ -211,7 +198,11 @@ export function RailNavItem(props: {
         ? { activeProps: { "data-active": "true" as const } }
         : { "data-active": props.active ? ("true" as const) : undefined })}
       aria-label={props.collapsed ? props.label : undefined}
-      title={props.description && !props.collapsed ? props.description : undefined}
+      title={
+        props.collapsed
+          ? [props.label, props.description].filter(Boolean).join(" — ")
+          : (props.description ?? undefined)
+      }
       className={cn(
         "group relative flex h-8 items-center rounded-md text-sm font-medium text-fg-muted transition-colors pointer-coarse:h-10",
         "hover:bg-surface-2 hover:text-fg",
@@ -223,18 +214,5 @@ export function RailNavItem(props: {
       <span className="shrink-0">{props.icon}</span>
       {!props.collapsed ? <span className="min-w-0 truncate">{props.label}</span> : null}
     </Link>
-  );
-
-  if (!props.collapsed) {
-    return link;
-  }
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{link}</TooltipTrigger>
-      <TooltipContent side="right" className="max-w-52">
-        <p className="font-medium">{props.label}</p>
-        {props.description ? <p className="text-fg-subtle">{props.description}</p> : null}
-      </TooltipContent>
-    </Tooltip>
   );
 }

--- a/apps/web/src/components/rail/workspace-nav.tsx
+++ b/apps/web/src/components/rail/workspace-nav.tsx
@@ -3,24 +3,19 @@
 // Automation / Admin). Mobile Workspace tab keeps the same groups as an inline
 // list. Active route marks the Settings control and the matching menu item.
 import { Link, useRouterState } from "@tanstack/react-router";
-import {
-  BoxIcon,
-  BrainCircuitIcon,
-  CalendarClockIcon,
-  ChevronUpIcon,
-  FileSearchIcon,
-  GaugeIcon,
-  LaptopIcon,
-  MapIcon,
-  PanelsTopLeftIcon,
-  PlugIcon,
-  ServerCogIcon,
-  SettingsIcon,
-  type LucideIcon,
-} from "lucide-react";
+import { ChevronUpIcon, SettingsIcon } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
 import { useRail } from "@/components/rail/rail-context";
+import {
+  filterWorkspaceConfigGroups,
+  isConfigItemActive,
+  isWorkspaceConfigPath,
+  WORKSPACE_CONFIG_GROUPS,
+  type WorkspaceConfigGroup,
+  type WorkspaceConfigTarget,
+} from "@/components/rail/workspace-nav-data";
+import { WORKSPACE_CONFIG_ICONS } from "@/components/rail/workspace-nav-icons";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,172 +30,17 @@ import { useAppContext } from "@/context";
 import { hasWorkspacePermission } from "@/lib/permissions";
 import { cn } from "@/lib/utils";
 
-export type WorkspaceConfigTarget =
-  | "/workspaces/$workspaceId/insights"
-  | "/workspaces/$workspaceId/variable-sets"
-  | "/workspaces/$workspaceId/rigs"
-  | "/workspaces/$workspaceId/machines"
-  | "/workspaces/$workspaceId/capabilities"
-  | "/workspaces/$workspaceId/schedules"
-  | "/workspaces/$workspaceId/documents"
-  | "/workspaces/$workspaceId/memory"
-  | "/workspaces/$workspaceId/state"
-  | "/workspaces/$workspaceId/artifacts"
-  | "/workspaces/$workspaceId/settings";
-
-export type WorkspaceConfigItem = {
-  to: WorkspaceConfigTarget;
-  icon: LucideIcon;
-  label: string;
-  description: string;
-  /** When true, only include for subjects with workspace:admin. */
-  requiresAdmin?: boolean;
-};
-
-export type WorkspaceConfigGroup = {
-  id: string;
-  label: string;
-  items: WorkspaceConfigItem[];
-};
-
-export const WORKSPACE_CONFIG_GROUPS: WorkspaceConfigGroup[] = [
-  {
-    id: "overview",
-    label: "Overview",
-    items: [
-      {
-        to: "/workspaces/$workspaceId/insights",
-        icon: GaugeIcon,
-        label: "Insights",
-        description: "Spend, blockers, automation, and outcomes",
-        requiresAdmin: true,
-      },
-    ],
-  },
-  {
-    id: "runtime",
-    label: "Runtime",
-    items: [
-      {
-        to: "/workspaces/$workspaceId/variable-sets",
-        icon: BoxIcon,
-        label: "Variable sets",
-        description: "Secret variableSets for sandboxes",
-      },
-      {
-        to: "/workspaces/$workspaceId/rigs",
-        icon: ServerCogIcon,
-        label: "Rigs",
-        description: "Versioned sandbox machine definitions",
-      },
-      {
-        to: "/workspaces/$workspaceId/machines",
-        icon: LaptopIcon,
-        label: "Machines",
-        description: "Your own connected computers",
-      },
-    ],
-  },
-  {
-    id: "knowledge",
-    label: "Knowledge",
-    items: [
-      {
-        to: "/workspaces/$workspaceId/documents",
-        icon: FileSearchIcon,
-        label: "Documents",
-        description: "Indexed knowledge for agents",
-      },
-      {
-        to: "/workspaces/$workspaceId/memory",
-        icon: BrainCircuitIcon,
-        label: "Memory",
-        description: "Durable facts agents carry across sessions",
-      },
-      {
-        to: "/workspaces/$workspaceId/state",
-        icon: MapIcon,
-        label: "Workspace State",
-        description: "Read-only policy and knowledge inventory",
-      },
-    ],
-  },
-  {
-    id: "automation",
-    label: "Automation",
-    items: [
-      {
-        to: "/workspaces/$workspaceId/capabilities",
-        icon: PlugIcon,
-        label: "Capabilities",
-        description: "Packs, MCP servers, and tools",
-      },
-      {
-        to: "/workspaces/$workspaceId/schedules",
-        icon: CalendarClockIcon,
-        label: "Schedules",
-        description: "Run agents on a schedule",
-      },
-      {
-        to: "/workspaces/$workspaceId/artifacts",
-        icon: PanelsTopLeftIcon,
-        label: "Artifacts",
-        description: "Live pages and tools built with Geni",
-      },
-    ],
-  },
-  {
-    id: "admin",
-    label: "Admin",
-    items: [
-      {
-        to: "/workspaces/$workspaceId/settings",
-        icon: SettingsIcon,
-        label: "General, members & keys",
-        description: "Name, API keys, members, and Codex subscriptions",
-      },
-    ],
-  },
-];
-
-/** Destinations shown in the Browse workspace strip (excludes the settings page itself). */
-export const WORKSPACE_BROWSE_ITEMS: WorkspaceConfigItem[] = WORKSPACE_CONFIG_GROUPS.flatMap(
-  (group) => group.items,
-).filter((item) => item.to !== "/workspaces/$workspaceId/settings");
-
-export function filterWorkspaceConfigGroups(
-  groups: WorkspaceConfigGroup[],
-  canReadInsights: boolean,
-): WorkspaceConfigGroup[] {
-  return groups
-    .map((group) => ({
-      ...group,
-      items: group.items.filter((item) => !item.requiresAdmin || canReadInsights),
-    }))
-    .filter((group) => group.items.length > 0);
-}
-
-function configPathSuffix(to: WorkspaceConfigTarget): string {
-  const parts = to.split("/");
-  return parts[parts.length - 1] ?? "";
-}
-
-export function isWorkspaceConfigPath(pathname: string, workspaceId: string): boolean {
-  const prefix = `/workspaces/${workspaceId}/`;
-  if (!pathname.startsWith(prefix)) return false;
-  const rest = pathname.slice(prefix.length).split("/")[0] ?? "";
-  return WORKSPACE_CONFIG_GROUPS.some((group) =>
-    group.items.some((item) => configPathSuffix(item.to) === rest),
-  );
-}
-
-function isConfigItemActive(
-  pathname: string,
-  workspaceId: string,
-  to: WorkspaceConfigTarget,
-): boolean {
-  return pathname === `/workspaces/${workspaceId}/${configPathSuffix(to)}`;
-}
+export type {
+  WorkspaceConfigGroup,
+  WorkspaceConfigItem,
+  WorkspaceConfigTarget,
+} from "@/components/rail/workspace-nav-data";
+export {
+  filterWorkspaceConfigGroups,
+  isWorkspaceConfigPath,
+  WORKSPACE_BROWSE_ITEMS,
+  WORKSPACE_CONFIG_GROUPS,
+} from "@/components/rail/workspace-nav-data";
 
 export function WorkspaceNav() {
   const rail = useRail();
@@ -223,18 +63,21 @@ export function WorkspaceNav() {
             <p className="px-2 pb-0.5 pt-1 text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
               {group.label}
             </p>
-            {group.items.map((item) => (
-              <RailNavItem
-                key={item.to}
-                to={item.to}
-                workspaceId={rail.workspaceId}
-                icon={<item.icon className="size-4" />}
-                label={item.label}
-                description={item.description}
-                collapsed={false}
-                active={isConfigItemActive(pathname, rail.workspaceId, item.to)}
-              />
-            ))}
+            {group.items.map((item) => {
+              const Icon = WORKSPACE_CONFIG_ICONS[item.icon];
+              return (
+                <RailNavItem
+                  key={item.to}
+                  to={item.to}
+                  workspaceId={rail.workspaceId}
+                  icon={<Icon className="size-4" />}
+                  label={item.label}
+                  description={item.description}
+                  collapsed={false}
+                  active={isConfigItemActive(pathname, rail.workspaceId, item.to)}
+                />
+              );
+            })}
           </div>
         ))}
       </nav>
@@ -320,6 +163,7 @@ function WorkspaceSettingsMenu(props: {
             </DropdownMenuLabel>
             {group.items.map((item) => {
               const active = isConfigItemActive(props.pathname, props.workspaceId, item.to);
+              const Icon = WORKSPACE_CONFIG_ICONS[item.icon];
               return (
                 <DropdownMenuItem key={item.to} asChild>
                   <Link
@@ -332,7 +176,7 @@ function WorkspaceSettingsMenu(props: {
                     )}
                     onClick={() => setOpen(false)}
                   >
-                    <item.icon className="size-4" />
+                    <Icon className="size-4" />
                     <span className="min-w-0 flex-1 truncate">{item.label}</span>
                   </Link>
                 </DropdownMenuItem>

--- a/apps/web/src/components/rail/workspace-nav.tsx
+++ b/apps/web/src/components/rail/workspace-nav.tsx
@@ -1,30 +1,41 @@
-// Workspace configuration nav: Insights plus config surfaces (Variable sets,
-// Capabilities, Schedules, Documents, Memory, …) as individual items, then a
-// slightly separated Settings. Collapsed → centered icons with tooltips.
-// Active route gets a left accent bar + subtle surface tint.
-import { Link } from "@tanstack/react-router";
+// Workspace config hub: one Settings anchor on the desktop rail that opens an
+// upward menu of grouped destinations (Overview / Runtime / Knowledge /
+// Automation / Admin). Mobile Workspace tab keeps the same groups as an inline
+// list. Active route marks the Settings control and the matching menu item.
+import { Link, useRouterState } from "@tanstack/react-router";
 import {
   BoxIcon,
   BrainCircuitIcon,
   CalendarClockIcon,
+  ChevronUpIcon,
   FileSearchIcon,
   GaugeIcon,
   LaptopIcon,
   MapIcon,
+  PanelsTopLeftIcon,
   PlugIcon,
   ServerCogIcon,
   SettingsIcon,
   type LucideIcon,
 } from "lucide-react";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import { useRail } from "@/components/rail/rail-context";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAppContext } from "@/context";
 import { hasWorkspacePermission } from "@/lib/permissions";
 import { cn } from "@/lib/utils";
 
-type NavTarget =
+export type WorkspaceConfigTarget =
   | "/workspaces/$workspaceId/insights"
   | "/workspaces/$workspaceId/variable-sets"
   | "/workspaces/$workspaceId/rigs"
@@ -37,115 +48,305 @@ type NavTarget =
   | "/workspaces/$workspaceId/artifacts"
   | "/workspaces/$workspaceId/settings";
 
-const CONFIG_ITEMS: Array<{ to: NavTarget; icon: LucideIcon; label: string; description: string }> =
-  [
-    {
-      to: "/workspaces/$workspaceId/insights",
-      icon: GaugeIcon,
-      label: "Insights",
-      description: "Spend, blockers, automation, and outcomes",
-    },
-    {
-      to: "/workspaces/$workspaceId/variable-sets",
-      icon: BoxIcon,
-      label: "Variable sets",
-      description: "Secret variableSets for sandboxes",
-    },
-    {
-      to: "/workspaces/$workspaceId/rigs",
-      icon: ServerCogIcon,
-      label: "Rigs",
-      description: "Versioned sandbox machine definitions",
-    },
-    {
-      to: "/workspaces/$workspaceId/machines",
-      icon: LaptopIcon,
-      label: "Machines",
-      description: "Your own connected computers",
-    },
-    {
-      to: "/workspaces/$workspaceId/capabilities",
-      icon: PlugIcon,
-      label: "Capabilities",
-      description: "Packs, MCP servers, and tools",
-    },
-    {
-      to: "/workspaces/$workspaceId/schedules",
-      icon: CalendarClockIcon,
-      label: "Schedules",
-      description: "Run agents on a schedule",
-    },
-    {
-      to: "/workspaces/$workspaceId/documents",
-      icon: FileSearchIcon,
-      label: "Documents",
-      description: "Indexed knowledge for agents",
-    },
-    {
-      to: "/workspaces/$workspaceId/memory",
-      icon: BrainCircuitIcon,
-      label: "Memory",
-      description: "Durable facts agents carry across sessions",
-    },
-    {
-      to: "/workspaces/$workspaceId/artifacts",
-      icon: BoxIcon,
-      label: "Artifacts",
-      description: "Live pages and tools built with Geni",
-    },
-    {
-      to: "/workspaces/$workspaceId/state",
-      icon: MapIcon,
-      label: "Workspace State",
-      description: "Read-only policy and knowledge inventory",
-    },
-  ];
+export type WorkspaceConfigItem = {
+  to: WorkspaceConfigTarget;
+  icon: LucideIcon;
+  label: string;
+  description: string;
+  /** When true, only include for subjects with workspace:admin. */
+  requiresAdmin?: boolean;
+};
+
+export type WorkspaceConfigGroup = {
+  id: string;
+  label: string;
+  items: WorkspaceConfigItem[];
+};
+
+export const WORKSPACE_CONFIG_GROUPS: WorkspaceConfigGroup[] = [
+  {
+    id: "overview",
+    label: "Overview",
+    items: [
+      {
+        to: "/workspaces/$workspaceId/insights",
+        icon: GaugeIcon,
+        label: "Insights",
+        description: "Spend, blockers, automation, and outcomes",
+        requiresAdmin: true,
+      },
+    ],
+  },
+  {
+    id: "runtime",
+    label: "Runtime",
+    items: [
+      {
+        to: "/workspaces/$workspaceId/variable-sets",
+        icon: BoxIcon,
+        label: "Variable sets",
+        description: "Secret variableSets for sandboxes",
+      },
+      {
+        to: "/workspaces/$workspaceId/rigs",
+        icon: ServerCogIcon,
+        label: "Rigs",
+        description: "Versioned sandbox machine definitions",
+      },
+      {
+        to: "/workspaces/$workspaceId/machines",
+        icon: LaptopIcon,
+        label: "Machines",
+        description: "Your own connected computers",
+      },
+    ],
+  },
+  {
+    id: "knowledge",
+    label: "Knowledge",
+    items: [
+      {
+        to: "/workspaces/$workspaceId/documents",
+        icon: FileSearchIcon,
+        label: "Documents",
+        description: "Indexed knowledge for agents",
+      },
+      {
+        to: "/workspaces/$workspaceId/memory",
+        icon: BrainCircuitIcon,
+        label: "Memory",
+        description: "Durable facts agents carry across sessions",
+      },
+      {
+        to: "/workspaces/$workspaceId/state",
+        icon: MapIcon,
+        label: "Workspace State",
+        description: "Read-only policy and knowledge inventory",
+      },
+    ],
+  },
+  {
+    id: "automation",
+    label: "Automation",
+    items: [
+      {
+        to: "/workspaces/$workspaceId/capabilities",
+        icon: PlugIcon,
+        label: "Capabilities",
+        description: "Packs, MCP servers, and tools",
+      },
+      {
+        to: "/workspaces/$workspaceId/schedules",
+        icon: CalendarClockIcon,
+        label: "Schedules",
+        description: "Run agents on a schedule",
+      },
+      {
+        to: "/workspaces/$workspaceId/artifacts",
+        icon: PanelsTopLeftIcon,
+        label: "Artifacts",
+        description: "Live pages and tools built with Geni",
+      },
+    ],
+  },
+  {
+    id: "admin",
+    label: "Admin",
+    items: [
+      {
+        to: "/workspaces/$workspaceId/settings",
+        icon: SettingsIcon,
+        label: "General, members & keys",
+        description: "Name, API keys, members, and Codex subscriptions",
+      },
+    ],
+  },
+];
+
+/** Destinations shown in the Browse workspace strip (excludes the settings page itself). */
+export const WORKSPACE_BROWSE_ITEMS: WorkspaceConfigItem[] = WORKSPACE_CONFIG_GROUPS.flatMap(
+  (group) => group.items,
+).filter((item) => item.to !== "/workspaces/$workspaceId/settings");
+
+export function filterWorkspaceConfigGroups(
+  groups: WorkspaceConfigGroup[],
+  canReadInsights: boolean,
+): WorkspaceConfigGroup[] {
+  return groups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) => !item.requiresAdmin || canReadInsights),
+    }))
+    .filter((group) => group.items.length > 0);
+}
+
+function configPathSuffix(to: WorkspaceConfigTarget): string {
+  const parts = to.split("/");
+  return parts[parts.length - 1] ?? "";
+}
+
+export function isWorkspaceConfigPath(pathname: string, workspaceId: string): boolean {
+  const prefix = `/workspaces/${workspaceId}/`;
+  if (!pathname.startsWith(prefix)) return false;
+  const rest = pathname.slice(prefix.length).split("/")[0] ?? "";
+  return WORKSPACE_CONFIG_GROUPS.some((group) =>
+    group.items.some((item) => configPathSuffix(item.to) === rest),
+  );
+}
+
+function isConfigItemActive(
+  pathname: string,
+  workspaceId: string,
+  to: WorkspaceConfigTarget,
+): boolean {
+  return pathname === `/workspaces/${workspaceId}/${configPathSuffix(to)}`;
+}
 
 export function WorkspaceNav() {
   const rail = useRail();
   const context = useAppContext();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
   const canReadInsights = hasWorkspacePermission(
     context.accessContext,
     rail.workspaceId,
     "workspace:admin",
   );
-  const items = CONFIG_ITEMS.filter(
-    (item) => item.to !== "/workspaces/$workspaceId/insights" || canReadInsights,
-  );
+  const groups = filterWorkspaceConfigGroups(WORKSPACE_CONFIG_GROUPS, canReadInsights);
+  const settingsActive = isWorkspaceConfigPath(pathname, rail.workspaceId);
+
+  // Mobile already has a Workspace tab — show the groups inline there.
+  if (rail.isMobile) {
+    return (
+      <nav aria-label="Workspace" className="grid gap-2 px-2">
+        {groups.map((group) => (
+          <div key={group.id} className="grid gap-0.5">
+            <p className="px-2 pb-0.5 pt-1 text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
+              {group.label}
+            </p>
+            {group.items.map((item) => (
+              <RailNavItem
+                key={item.to}
+                to={item.to}
+                workspaceId={rail.workspaceId}
+                icon={<item.icon className="size-4" />}
+                label={item.label}
+                description={item.description}
+                collapsed={false}
+                active={isConfigItemActive(pathname, rail.workspaceId, item.to)}
+              />
+            ))}
+          </div>
+        ))}
+      </nav>
+    );
+  }
+
   return (
-    <nav aria-label="Workspace" className={cn("grid gap-0.5", rail.collapsed ? "px-2" : "px-2")}>
-      {!rail.collapsed ? (
-        <p className="px-2 pb-1 pt-1 text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
-          Workspace
-        </p>
-      ) : null}
-      {items.map((item) => (
-        <RailNavItem
-          key={item.to}
-          to={item.to}
-          workspaceId={rail.workspaceId}
-          icon={<item.icon className="size-4" />}
-          label={item.label}
-          description={item.description}
-          collapsed={rail.collapsed}
-        />
-      ))}
-      <div className={cn("mt-1 border-t border-border/60 pt-1", rail.collapsed ? "mx-1" : "")}>
-        <RailNavItem
-          to="/workspaces/$workspaceId/settings"
-          workspaceId={rail.workspaceId}
-          icon={<SettingsIcon className="size-4" />}
-          label="Workspace settings"
-          description="Name, API keys, and members"
-          collapsed={rail.collapsed}
-        />
-      </div>
+    <nav aria-label="Workspace" className="grid gap-0.5 px-2">
+      <WorkspaceSettingsMenu
+        workspaceId={rail.workspaceId}
+        groups={groups}
+        pathname={pathname}
+        collapsed={rail.collapsed}
+        active={settingsActive}
+      />
     </nav>
   );
 }
 
+function WorkspaceSettingsMenu(props: {
+  workspaceId: string;
+  groups: WorkspaceConfigGroup[];
+  pathname: string;
+  collapsed: boolean;
+  active: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const trigger = (
+    <button
+      type="button"
+      aria-label={props.collapsed ? "Workspace" : undefined}
+      aria-expanded={open}
+      data-active={props.active ? "true" : undefined}
+      className={cn(
+        "group relative flex h-8 w-full items-center rounded-md text-sm font-medium text-fg-muted transition-colors pointer-coarse:h-10",
+        "hover:bg-surface-2 hover:text-fg",
+        "data-[active=true]:bg-surface-2 data-[active=true]:text-fg",
+        props.collapsed ? "w-8 justify-center pointer-coarse:w-10" : "gap-2.5 px-2.5",
+      )}
+    >
+      <span className="absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-brand opacity-0 transition-opacity group-data-[active=true]:opacity-100" />
+      <SettingsIcon className="size-4 shrink-0" />
+      {!props.collapsed ? (
+        <>
+          <span className="min-w-0 flex-1 truncate text-left">Workspace</span>
+          <ChevronUpIcon
+            className={cn(
+              "size-3.5 shrink-0 text-fg-subtle transition-transform",
+              open ? "rotate-0" : "rotate-180",
+            )}
+          />
+        </>
+      ) : null}
+    </button>
+  );
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      {props.collapsed ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="right" className="max-w-52">
+            <p className="font-medium">Workspace</p>
+            <p className="text-fg-subtle">Configure runtime, knowledge, and admin</p>
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      )}
+      <DropdownMenuContent
+        side="top"
+        align={props.collapsed ? "start" : "start"}
+        sideOffset={6}
+        className="w-64"
+      >
+        {props.groups.map((group, index) => (
+          <DropdownMenuGroup key={group.id}>
+            {index > 0 ? <DropdownMenuSeparator /> : null}
+            <DropdownMenuLabel className="text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
+              {group.label}
+            </DropdownMenuLabel>
+            {group.items.map((item) => {
+              const active = isConfigItemActive(props.pathname, props.workspaceId, item.to);
+              return (
+                <DropdownMenuItem key={item.to} asChild>
+                  <Link
+                    to={item.to}
+                    params={{ workspaceId: props.workspaceId }}
+                    data-active={active ? "true" : undefined}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2",
+                      active ? "bg-accent text-accent-foreground" : "",
+                    )}
+                    onClick={() => setOpen(false)}
+                  >
+                    <item.icon className="size-4" />
+                    <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                  </Link>
+                </DropdownMenuItem>
+              );
+            })}
+          </DropdownMenuGroup>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export function RailNavItem(props: {
-  to: NavTarget;
+  to: WorkspaceConfigTarget;
   workspaceId: string;
   icon: ReactNode;
   label: string;
@@ -154,16 +355,18 @@ export function RailNavItem(props: {
   collapsed: boolean;
   /** Optional search params (Capabilities Packs subsection, etc.). */
   search?: Record<string, string>;
+  /** When set, overrides Link activeProps for explicit active highlighting. */
+  active?: boolean;
 }) {
   const link = (
     <Link
       to={props.to}
       params={{ workspaceId: props.workspaceId }}
       {...(props.search ? { search: props.search } : {})}
-      activeProps={{ "data-active": "true" }}
+      {...(props.active === undefined
+        ? { activeProps: { "data-active": "true" as const } }
+        : { "data-active": props.active ? ("true" as const) : undefined })}
       aria-label={props.collapsed ? props.label : undefined}
-      // The description labels an otherwise opaque nav item; a title keeps it
-      // reachable on the expanded rail without a hover-only requirement.
       title={props.description && !props.collapsed ? props.description : undefined}
       className={cn(
         "group relative flex h-8 items-center rounded-md text-sm font-medium text-fg-muted transition-colors pointer-coarse:h-10",
@@ -172,7 +375,6 @@ export function RailNavItem(props: {
         props.collapsed ? "w-8 justify-center pointer-coarse:w-10" : "gap-2.5 px-2.5",
       )}
     >
-      {/* Left accent bar on the active route. */}
       <span className="absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-brand opacity-0 transition-opacity group-data-[active=true]:opacity-100" />
       <span className="shrink-0">{props.icon}</span>
       {!props.collapsed ? <span className="min-w-0 truncate">{props.label}</span> : null}

--- a/apps/web/src/components/transcription-settings.tsx
+++ b/apps/web/src/components/transcription-settings.tsx
@@ -1,12 +1,12 @@
 import { Loader2Icon, MicIcon } from "lucide-react";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { toast } from "sonner";
 import { useAppContext } from "@/context";
 import { resolveWorkspaceVoiceInputEnabled } from "@opengeni/sdk";
 import { cn } from "@/lib/utils";
 
-/** @deprecated Name retained while callers migrate to VoiceInputSettingsSection. */
-export function TranscriptionSettingsSection({
+/** Dense preference row used by workspace settings (no outer card). */
+export function VoiceInputPreferenceRow({
   workspaceId,
   canManage,
 }: {
@@ -18,9 +18,10 @@ export function TranscriptionSettingsSection({
   const capability = context.clientConfig.voiceInput;
   const [saving, setSaving] = useState(false);
   const enabled = resolveWorkspaceVoiceInputEnabled(workspace?.settings) ?? true;
+  const available = capability?.available === true;
 
   async function toggle() {
-    if (!canManage || saving || !capability?.available) return;
+    if (!canManage || saving || !available) return;
     setSaving(true);
     try {
       await context.updateWorkspaceSettings(workspaceId, { voiceInput: { enabled: !enabled } });
@@ -31,45 +32,76 @@ export function TranscriptionSettingsSection({
   }
 
   return (
-    <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h2 className="flex items-center gap-1.5 text-sm font-medium">
-            <MicIcon className="size-3.5 text-brand" />
-            Voice input
-          </h2>
-          <p className="mt-1 text-xs text-fg-muted">
-            {capability?.available
-              ? "Record a short message and add its transcription to the composer draft."
-              : "Not configured by this deployment operator."}
-          </p>
-        </div>
-        {capability?.available ? (
-          <button
-            type="button"
-            role="switch"
-            aria-checked={enabled}
-            aria-label="Voice input"
-            disabled={!canManage || saving}
-            onClick={() => void toggle()}
-            className={cn(
-              "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors disabled:cursor-not-allowed disabled:opacity-50",
-              enabled ? "border-brand bg-brand" : "border-border bg-surface-2",
-            )}
-          >
-            {saving ? <Loader2Icon className="mx-auto size-3 animate-spin text-white" /> : null}
-            <span
-              className={cn(
-                "inline-block size-3.5 rounded-full bg-white shadow-sm transition-transform",
-                enabled ? "translate-x-4" : "translate-x-0.5",
-              )}
-            />
-          </button>
-        ) : null}
+    <PreferenceToggleRow
+      icon={<MicIcon className="size-3.5 text-brand" />}
+      label="Voice input"
+      description={
+        available
+          ? "Record a short message and add its transcription to the composer draft."
+          : "Not configured by this deployment operator."
+      }
+      checked={enabled}
+      disabled={!canManage || saving || !available}
+      saving={saving}
+      onToggle={() => void toggle()}
+    />
+  );
+}
+
+/** Shared dense toggle row for workspace preference lists. */
+export function PreferenceToggleRow(props: {
+  icon?: ReactNode;
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled?: boolean;
+  saving?: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="flex min-h-10 items-center gap-3 px-1 py-1.5">
+      {props.icon ? <span className="shrink-0">{props.icon}</span> : null}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium">{props.label}</div>
+        <p className="truncate text-2xs text-fg-subtle" title={props.description}>
+          {props.description}
+        </p>
       </div>
-      {capability?.available && !canManage ? (
-        <p className="text-xs text-fg-subtle">Only workspace admins can change this.</p>
-      ) : null}
+      {props.saving ? <Loader2Icon className="size-3.5 shrink-0 animate-spin text-fg-subtle" /> : null}
+      <button
+        type="button"
+        role="switch"
+        aria-checked={props.checked}
+        aria-label={props.label}
+        disabled={props.disabled}
+        onClick={props.onToggle}
+        className={cn(
+          "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+          props.checked ? "border-brand bg-brand" : "border-border bg-surface-2",
+        )}
+      >
+        <span
+          className={cn(
+            "inline-block size-3.5 rounded-full bg-white shadow-sm transition-transform",
+            props.checked ? "translate-x-4" : "translate-x-0.5",
+          )}
+        />
+      </button>
+    </div>
+  );
+}
+
+/** @deprecated Name retained while callers migrate to VoiceInputPreferenceRow. */
+export function TranscriptionSettingsSection({
+  workspaceId,
+  canManage,
+}: {
+  workspaceId: string;
+  canManage: boolean;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-surface px-3 py-1">
+      <VoiceInputPreferenceRow workspaceId={workspaceId} canManage={canManage} />
     </section>
   );
 }

--- a/apps/web/src/components/transcription-settings.tsx
+++ b/apps/web/src/components/transcription-settings.tsx
@@ -67,7 +67,9 @@ export function PreferenceToggleRow(props: {
           {props.description}
         </p>
       </div>
-      {props.saving ? <Loader2Icon className="size-3.5 shrink-0 animate-spin text-fg-subtle" /> : null}
+      {props.saving ? (
+        <Loader2Icon className="size-3.5 shrink-0 animate-spin text-fg-subtle" />
+      ) : null}
       <button
         type="button"
         role="switch"

--- a/apps/web/src/components/ui/content-layout.test.tsx
+++ b/apps/web/src/components/ui/content-layout.test.tsx
@@ -17,7 +17,7 @@ afterAll(() => {
 });
 
 describe("ContentPage scroll contract", () => {
-  test("keeps long workspace content reachable inside the fixed canvas", async () => {
+  test("full-width outer owns scroll; max-width is an inner column only", async () => {
     const container = document.createElement("div");
     document.body.append(container);
     const root = createRoot(container);
@@ -25,7 +25,7 @@ describe("ContentPage scroll contract", () => {
     try {
       await act(async () => {
         root.render(
-          <ContentPage>
+          <ContentPage width="standard" className="gap-4">
             {Array.from({ length: 24 }, (_, index) => (
               <article key={index}>Working set memory {index + 1}</article>
             ))}
@@ -34,12 +34,24 @@ describe("ContentPage scroll contract", () => {
       });
 
       const page = container.querySelector<HTMLElement>('[data-slot="content-page"]');
+      const inner = container.querySelector<HTMLElement>('[data-slot="content-page-inner"]');
       expect(page).not.toBeNull();
+      expect(inner).not.toBeNull();
+
+      // Scrollport is the full-width shell child — not the centered column.
       expect(page!.className).toContain("min-h-0");
       expect(page!.className).toContain("overflow-x-hidden");
       expect(page!.className).toContain("overflow-y-auto");
       expect(page!.className).toContain("overscroll-y-contain");
-      expect(page!.className).toContain("pb-[max(1.25rem,env(safe-area-inset-bottom))]");
+      expect(page!.className).not.toContain("max-w-5xl");
+      expect(page!.className).not.toContain("mx-auto");
+
+      // Width + padding + consumer className live on the inner column.
+      expect(inner!.className).toContain("max-w-5xl");
+      expect(inner!.className).toContain("mx-auto");
+      expect(inner!.className).toContain("gap-4");
+      expect(inner!.className).toContain("pb-[max(1.25rem,env(safe-area-inset-bottom))]");
+      expect(inner!.className).not.toContain("overflow-y-auto");
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/components/ui/content-layout.tsx
+++ b/apps/web/src/components/ui/content-layout.tsx
@@ -5,27 +5,41 @@ import { cn } from "@/lib/utils";
 /**
  * Width-, height-, and overflow-safe page frame for workspace content surfaces.
  *
+ * Scroll ownership and column width are deliberately split:
+ * - Outer (`data-slot="content-page"`) is the full-width flex child that owns
+ *   vertical scroll + overscroll containment inside the fixed app canvas.
+ * - Inner (`data-slot="content-page-inner"`) is the centered max-width column.
+ *
+ * Putting `overflow-y-auto` on the max-width box itself left gutters outside
+ * the scrollport; wheel there scrolled the document and shoved the whole app
+ * up (empty band + floating DevTools). Never merge those two again.
+ *
  * The `min-w-0` chain is intentional: pages live inside a flex shell and must
  * be allowed to shrink before a long untrusted name can widen the viewport.
- * The frame is also the intentional vertical scroll owner inside the fixed
- * application canvas, so long pages remain reachable without changing the
- * shell's sticky/navigation behavior.
  */
 export function ContentPage({
   className,
   width = "wide",
+  children,
   ...props
 }: ComponentProps<"div"> & { width?: "standard" | "wide" }) {
   return (
     <div
       data-slot="content-page"
-      className={cn(
-        "mx-auto flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto overscroll-y-contain px-4 py-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] sm:px-6 lg:px-8",
-        width === "standard" ? "max-w-5xl" : "max-w-7xl",
-        className,
-      )}
+      className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto overscroll-y-contain"
       {...props}
-    />
+    >
+      <div
+        data-slot="content-page-inner"
+        className={cn(
+          "mx-auto flex w-full min-w-0 flex-col px-4 py-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] sm:px-6 lg:px-8",
+          width === "standard" ? "max-w-5xl" : "max-w-7xl",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -1194,7 +1194,10 @@ export function RootRouteComponent() {
   ]);
 
   return (
-    <main className="flex h-dvh min-h-screen flex-col overflow-x-hidden bg-bg text-fg">
+    // Fixed app canvas: never let the document scroll. Page surfaces own
+    // overflow via ContentPage / session panes. `min-h-screen` used to let
+    // main grow past the viewport when a child mis-owned scroll.
+    <main className="flex h-dvh max-h-dvh flex-col overflow-hidden bg-bg text-fg">
       <Toaster richColors theme="dark" />
       {clientConfig ? (
         <Suspense fallback={null}>

--- a/apps/web/src/routes/org-settings.tsx
+++ b/apps/web/src/routes/org-settings.tsx
@@ -178,7 +178,7 @@ export function OrgSettingsRoute({
             <Button asChild type="button" variant="ghost" size="sm">
               <Link to="/workspaces/$workspaceId/settings" params={{ workspaceId }}>
                 <SettingsIcon className="size-3.5" />
-                Workspace settings
+                Workspace
               </Link>
             </Button>
           </div>
@@ -515,7 +515,7 @@ function MembersSection(props: {
         </span>
       </div>
       <p className="text-xs text-fg-subtle">
-        Access is granted per workspace. Manage members in Workspace settings → People with access.
+        Access is granted per workspace. Manage members in Workspace → People with access.
         {props.canManage ? "" : " Only organization admins can change organization-level roles."}
       </p>
     </section>

--- a/apps/web/src/routes/org-settings.tsx
+++ b/apps/web/src/routes/org-settings.tsx
@@ -19,6 +19,7 @@ import { toast } from "sonner";
 
 import { LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
+import { ContentPage } from "@/components/ui/content-layout";
 import { useAppContext } from "@/context";
 import {
   entitlementEntries,
@@ -137,7 +138,7 @@ export function OrgSettingsRoute({
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col overflow-y-auto px-4 py-5 sm:px-6 lg:px-8">
+    <ContentPage width="standard">
       <section className="grid gap-5 text-left">
         <PageHeader
           icon={<BuildingIcon className="size-4" />}
@@ -289,7 +290,7 @@ export function OrgSettingsRoute({
           role={accountGrant?.role ?? null}
         />
       </section>
-    </div>
+    </ContentPage>
   );
 }
 

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -1,11 +1,9 @@
-// Workspace settings: workspace name/rename, "People with access" (workspace
-// members on the workspace_memberships model), the workspace-scoped API keys
-// (moved here out of the old account page), a link to Variable sets, and a
-// danger zone with workspace deletion. The org/billing console lives at
-// Organization settings.
+// Workspace settings hub: browse links to workspace config surfaces, then
+// name/rename, members, API keys, memory/transcription/Codex policy, Codex
+// subscriptions, and a danger zone with workspace deletion. The org/billing
+// console lives at Organization settings.
 import { Link, useNavigate } from "@tanstack/react-router";
 import {
-  BoxIcon,
   BrainCircuitIcon,
   CheckIcon,
   ChevronDownIcon,
@@ -15,6 +13,7 @@ import {
   PencilIcon,
   PlusIcon,
   SettingsIcon,
+  ShrinkIcon,
   Trash2Icon,
   TriangleAlertIcon,
   UserPlusIcon,
@@ -24,10 +23,18 @@ import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { CodexSubscriptionsCard } from "@/components/codex-connection";
-import { LoadErrorState, PageHeader } from "@/components/common";
-import { TranscriptionSettingsSection } from "@/components/transcription-settings";
+import { LoadErrorState } from "@/components/common";
+import {
+  WORKSPACE_BROWSE_ITEMS,
+  type WorkspaceConfigItem,
+} from "@/components/rail/workspace-nav";
+import {
+  PreferenceToggleRow,
+  VoiceInputPreferenceRow,
+} from "@/components/transcription-settings";
 import { PermissionGroupPicker } from "@/components/permission-picker";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
   Dialog,
@@ -55,6 +62,31 @@ import {
   workspaceMemberPermissionGroups,
 } from "@/lib/permissions";
 import type { ApiKey, WorkspaceMember } from "@/types";
+
+function BrowseWorkspaceStrip(props: { workspaceId: string; canReadInsights: boolean }) {
+  const items = WORKSPACE_BROWSE_ITEMS.filter(
+    (item: WorkspaceConfigItem) => !item.requiresAdmin || props.canReadInsights,
+  );
+  return (
+    <nav aria-label="Browse workspace" className="flex flex-wrap items-center gap-x-1 gap-y-1.5">
+      <span className="mr-1 text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
+        Browse
+      </span>
+      {items.map((item) => (
+        <Link
+          key={item.to}
+          to={item.to}
+          params={{ workspaceId: props.workspaceId }}
+          title={item.description}
+          className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-fg-muted transition-colors hover:bg-surface-2 hover:text-fg"
+        >
+          <item.icon className="size-3.5 shrink-0 text-brand" />
+          {item.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}
 
 export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string }) {
   const context = useAppContext();
@@ -98,6 +130,8 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
   const [createdToken, setCreatedToken] = useState<string | null>(null);
   const [revokingKey, setRevokingKey] = useState<ApiKey | null>(null);
   const [busy, setBusy] = useState(false);
+  const [editingName, setEditingName] = useState(false);
+  const [apiKeysOpen, setApiKeysOpen] = useState(false);
   const canManageApiKeys = hasWorkspacePermission(
     context.accessContext,
     workspaceId,
@@ -169,6 +203,7 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
       });
       setCreatedToken(result.token);
       setApiKeys((current) => [result.apiKey, ...current]);
+      setApiKeysOpen(true);
       toast.success("API key created");
     } catch (error) {
       toast.error("Failed to create API key", {
@@ -239,232 +274,268 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
     return true;
   }
 
+  const activeApiKeyCount = apiKeys.filter((key) => !key.revokedAt).length;
+
+  async function finishRename() {
+    const name = nameDraft.trim();
+    if (!name || name === activeWorkspace?.name) {
+      setNameDraft(activeWorkspace?.name ?? "");
+      setEditingName(false);
+      return;
+    }
+    await submitRename();
+    setEditingName(false);
+  }
+
   return (
     <ContentPage width="standard">
-      <section className="grid gap-5 text-left">
-        <PageHeader
-          icon={<SettingsIcon className="size-4" />}
-          title="Workspace settings"
-          description={
-            activeWorkspace ? `${activeWorkspace.name} · ${organizationLabel}` : organizationLabel
-          }
-        />
-
-        {/* Workspace name / rename */}
-        <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
-          <div>
-            <h2 className="flex items-center gap-1.5 text-sm font-medium">
-              <PencilIcon className="size-3.5 text-brand" />
-              Workspace name
-            </h2>
-            <p className="mt-1 text-xs text-fg-muted">
-              The name shows everywhere this workspace appears.
-            </p>
+      <section className="grid gap-6 text-left">
+        <header className="grid gap-3 border-b border-border pb-4">
+          <div className="flex min-w-0 items-center gap-2 text-sm text-fg-muted">
+            <SettingsIcon className="size-4 shrink-0 text-brand" />
+            <span>Workspace</span>
+            <span className="text-fg-subtle">·</span>
+            <span className="truncate">{organizationLabel}</span>
           </div>
-          {canRename ? (
-            <form
-              className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]"
-              onSubmit={(event) => {
-                event.preventDefault();
-                void submitRename();
-              }}
-            >
-              <Input
-                value={nameDraft}
-                onChange={(event) => setNameDraft(event.target.value)}
-                className="h-9"
-                placeholder="production"
-              />
-              <Button
-                type="submit"
-                disabled={
-                  renaming || !nameDraft.trim() || nameDraft.trim() === activeWorkspace?.name
-                }
+          <div className="flex min-w-0 items-center gap-2">
+            {editingName && canRename ? (
+              <form
+                className="flex min-w-0 flex-1 items-center gap-2"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void finishRename();
+                }}
               >
-                {renaming ? (
-                  <Loader2Icon className="size-3.5 animate-spin" />
-                ) : (
-                  <CheckIcon className="size-3.5" />
-                )}
-                Save
-              </Button>
-            </form>
-          ) : (
-            <p className="text-xs text-fg-subtle">
-              Only workspace admins can rename this workspace.
-            </p>
-          )}
-        </section>
+                <Input
+                  autoFocus
+                  value={nameDraft}
+                  onChange={(event) => setNameDraft(event.target.value)}
+                  onBlur={() => void finishRename()}
+                  onKeyDown={(event) => {
+                    if (event.key === "Escape") {
+                      setNameDraft(activeWorkspace?.name ?? "");
+                      setEditingName(false);
+                    }
+                  }}
+                  className="h-9 max-w-md text-base font-semibold"
+                  placeholder="Workspace name"
+                  aria-label="Workspace name"
+                />
+                <Button
+                  type="submit"
+                  size="icon-sm"
+                  variant="ghost"
+                  disabled={renaming || !nameDraft.trim()}
+                  aria-label="Save workspace name"
+                >
+                  {renaming ? (
+                    <Loader2Icon className="size-3.5 animate-spin" />
+                  ) : (
+                    <CheckIcon className="size-3.5" />
+                  )}
+                </Button>
+              </form>
+            ) : (
+              <>
+                <h1 className="min-w-0 truncate text-xl font-semibold tracking-tight">
+                  {activeWorkspace?.name ?? "Workspace"}
+                </h1>
+                {canRename ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label="Rename workspace"
+                    onClick={() => {
+                      setNameDraft(activeWorkspace?.name ?? "");
+                      setEditingName(true);
+                    }}
+                  >
+                    <PencilIcon className="size-3.5" />
+                  </Button>
+                ) : null}
+              </>
+            )}
+          </div>
+          <BrowseWorkspaceStrip workspaceId={workspaceId} canReadInsights={canDeleteWorkspace} />
+        </header>
 
-        {/* People with access (workspace members) */}
         <MembersSection workspaceId={workspaceId} canManage={canManageMembers} />
 
-        {/* Variable sets link */}
-        <section className="flex items-center justify-between gap-3 rounded-lg border border-border bg-surface p-4">
-          <div className="min-w-0">
-            <h2 className="flex items-center gap-1.5 text-sm font-medium">
-              <BoxIcon className="size-3.5 text-brand" />
-              Variable sets
-            </h2>
-            <p className="mt-1 text-xs text-fg-muted">
-              Variable sets injected into sandboxes at session start.
-            </p>
+        <section aria-labelledby="workspace-preferences-heading" className="grid gap-1">
+          <h2 id="workspace-preferences-heading" className="text-sm font-medium">
+            Preferences
+          </h2>
+          <div className="divide-y divide-border/70 rounded-lg border border-border px-3">
+            <MemoryPreferenceRow workspaceId={workspaceId} canManage={canRename} />
+            <VoiceInputPreferenceRow workspaceId={workspaceId} canManage={canRename} />
+            <CodexCompactionPreferenceRow workspaceId={workspaceId} canManage={canRename} />
           </div>
-          <Button asChild type="button" variant="secondary" size="sm">
-            <Link to="/workspaces/$workspaceId/variable-sets" params={{ workspaceId }}>
-              Manage variable sets
-            </Link>
-          </Button>
         </section>
 
-        {/* Workspace memory (long-lived agent memory) */}
-        <MemorySettingsSection workspaceId={workspaceId} canManage={canRename} />
-
-        {/* Provider-agnostic composer transcription policy */}
-        <TranscriptionSettingsSection workspaceId={workspaceId} canManage={canRename} />
-
-        {/* Codex compaction default for new Codex sessions */}
-        <CodexCompactionSettingsSection workspaceId={workspaceId} canManage={canRename} />
-
-        {/* Codex (ChatGPT) subscriptions (multi-account) */}
-        {/* Its live provider overview is intentionally once-per-mount. Remount at
-            the tenant boundary so stale async state can never cross workspaces. */}
+        {/* Codex live overview is intentionally once-per-mount; remount at tenant boundary. */}
         <CodexSubscriptionsCard
           key={workspaceId}
           workspaceId={workspaceId}
           canManage={canDeleteWorkspace}
         />
 
-        {/* API keys (moved from the old account page) */}
-        <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
-          <div>
-            <h2 className="flex items-center gap-1.5 text-sm font-medium">
-              <KeyRoundIcon className="size-3.5 text-brand" />
-              API keys
-            </h2>
-            <p className="mt-1 text-xs text-fg-muted">
-              Workspace-scoped keys for calling OpenGeni from another product.
-            </p>
-          </div>
-          {createdToken ? (
-            <Notice tone="success" title="Copy this token now — it won't be shown again.">
-              <div className="mt-2 flex min-w-0 items-center gap-2">
-                <code className="min-w-0 flex-1 truncate rounded bg-bg px-2 py-1.5 text-xs text-fg">
-                  {createdToken}
-                </code>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  aria-label="Copy token"
-                  onClick={() => void copyToken(createdToken)}
-                >
-                  <CopyIcon className="size-3.5" />
-                </Button>
-              </div>
-            </Notice>
-          ) : null}
-          {canManageApiKeys ? (
-            <>
-              <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
-                <Input
-                  value={apiKeyName}
-                  onChange={(event) => setApiKeyName(event.target.value)}
-                  className="h-9"
-                />
-                <Button type="button" disabled={busy} onClick={() => void createKey()}>
-                  {busy ? (
-                    <Loader2Icon className="size-3.5 animate-spin" />
-                  ) : (
-                    <PlusIcon className="size-3.5" />
+        <Collapsible
+          open={apiKeysOpen || createdToken != null}
+          onOpenChange={(open) => {
+            if (createdToken != null && !open) return;
+            setApiKeysOpen(open);
+          }}
+        >
+          <section className="rounded-lg border border-border">
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-3 py-2.5 text-left transition-colors hover:bg-surface-2/60"
+              >
+                <KeyRoundIcon className="size-3.5 shrink-0 text-brand" />
+                <span className="min-w-0 flex-1 text-sm font-medium">API keys</span>
+                <span className="text-2xs text-fg-subtle">
+                  {!apiKeysLoaded
+                    ? "…"
+                    : activeApiKeyCount === 0
+                      ? "None"
+                      : `${activeApiKeyCount} active`}
+                </span>
+                <ChevronDownIcon
+                  className={cn(
+                    "size-4 shrink-0 text-fg-subtle transition-transform",
+                    apiKeysOpen || createdToken != null ? "rotate-180" : "",
                   )}
-                  Create
-                </Button>
-              </div>
-              <div className="flex flex-wrap items-center justify-between gap-2">
+                />
+              </button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="grid gap-3 border-t border-border px-3 py-3">
+              <p className="text-2xs text-fg-subtle">
+                Workspace-scoped keys for calling OpenGeni from another product.
+              </p>
+              {createdToken ? (
+                <Notice tone="success" title="Copy this token now — it won't be shown again.">
+                  <div className="mt-2 flex min-w-0 items-center gap-2">
+                    <code className="min-w-0 flex-1 truncate rounded bg-bg px-2 py-1.5 text-xs text-fg">
+                      {createdToken}
+                    </code>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label="Copy token"
+                      onClick={() => void copyToken(createdToken)}
+                    >
+                      <CopyIcon className="size-3.5" />
+                    </Button>
+                  </div>
+                </Notice>
+              ) : null}
+              {canManageApiKeys ? (
+                <>
+                  <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+                    <Input
+                      value={apiKeyName}
+                      onChange={(event) => setApiKeyName(event.target.value)}
+                      className="h-9"
+                    />
+                    <Button type="button" disabled={busy} onClick={() => void createKey()}>
+                      {busy ? (
+                        <Loader2Icon className="size-3.5 animate-spin" />
+                      ) : (
+                        <PlusIcon className="size-3.5" />
+                      )}
+                      Create
+                    </Button>
+                  </div>
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-xs text-fg-subtle">
+                      A key can only carry permissions your own grant can delegate.
+                    </p>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      disabled={delegablePermissions.size === 0}
+                      onClick={() => setSelectedPermissions(new Set(delegablePermissions))}
+                    >
+                      Select all delegable
+                    </Button>
+                  </div>
+                  <PermissionGroupPicker
+                    groups={apiKeyPermissionGroups}
+                    selected={selectedPermissions}
+                    delegable={delegablePermissions}
+                    onToggle={togglePermission}
+                  />
+                </>
+              ) : (
                 <p className="text-xs text-fg-subtle">
-                  A key can only carry permissions your own grant can delegate.
+                  You don't have permission to manage API keys here.
                 </p>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  disabled={delegablePermissions.size === 0}
-                  onClick={() => setSelectedPermissions(new Set(delegablePermissions))}
-                >
-                  Select all delegable
-                </Button>
+              )}
+              <div className="divide-y divide-border/70 rounded-md border border-border/70">
+                {apiKeysError ? (
+                  <div className="p-2">
+                    <LoadErrorState
+                      title="Couldn't load API keys"
+                      error={apiKeysError}
+                      onRetry={() => void refreshApiKeys()}
+                    />
+                  </div>
+                ) : !apiKeysLoaded ? (
+                  <>
+                    {[0, 1].map((key) => (
+                      <div key={key} className="flex items-center justify-between gap-3 px-3 py-2">
+                        <div className="min-w-0 space-y-1.5">
+                          <Skeleton className="h-4 w-32" />
+                          <Skeleton className="h-3 w-24" />
+                        </div>
+                        <Skeleton className="h-8 w-20 rounded-md" />
+                      </div>
+                    ))}
+                  </>
+                ) : apiKeys.length === 0 ? (
+                  <div className="p-2">
+                    <EmptyState
+                      title="No API keys yet"
+                      description={
+                        canManageApiKeys
+                          ? "Create one above to call OpenGeni from another product."
+                          : "Keys created here call OpenGeni from another product."
+                      }
+                    />
+                  </div>
+                ) : (
+                  apiKeys.map((apiKey) => (
+                    <div
+                      key={apiKey.id}
+                      className="flex min-w-0 items-center justify-between gap-3 px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">{apiKey.name}</div>
+                        <div className="truncate text-2xs text-fg-subtle">
+                          {apiKey.prefix}… · {apiKey.revokedAt ? "revoked" : "active"}
+                        </div>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={busy || Boolean(apiKey.revokedAt)}
+                        onClick={() => setRevokingKey(apiKey)}
+                      >
+                        <Trash2Icon className="size-3.5" />
+                        Revoke
+                      </Button>
+                    </div>
+                  ))
+                )}
               </div>
-              <PermissionGroupPicker
-                groups={apiKeyPermissionGroups}
-                selected={selectedPermissions}
-                delegable={delegablePermissions}
-                onToggle={togglePermission}
-              />
-            </>
-          ) : (
-            <p className="text-xs text-fg-subtle">
-              You don't have permission to manage API keys here.
-            </p>
-          )}
-          <div className="grid gap-2">
-            {apiKeysError ? (
-              <LoadErrorState
-                title="Couldn't load API keys"
-                error={apiKeysError}
-                onRetry={() => void refreshApiKeys()}
-              />
-            ) : !apiKeysLoaded ? (
-              <>
-                {[0, 1].map((key) => (
-                  <div
-                    key={key}
-                    className="flex items-center justify-between gap-3 rounded-lg border border-border bg-bg/35 px-3 py-2"
-                  >
-                    <div className="min-w-0 space-y-1.5">
-                      <Skeleton className="h-4 w-32" />
-                      <Skeleton className="h-3 w-24" />
-                    </div>
-                    <Skeleton className="h-8 w-20 rounded-md" />
-                  </div>
-                ))}
-              </>
-            ) : apiKeys.length === 0 ? (
-              <EmptyState
-                title="No API keys yet"
-                description={
-                  canManageApiKeys
-                    ? "Create one above to call OpenGeni from another product."
-                    : "Keys created here call OpenGeni from another product."
-                }
-              />
-            ) : (
-              apiKeys.map((apiKey) => (
-                <div
-                  key={apiKey.id}
-                  className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-border bg-bg/35 px-3 py-2"
-                >
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-medium">{apiKey.name}</div>
-                    <div className="mt-1 truncate text-xs text-fg-subtle">
-                      {apiKey.prefix}… · {apiKey.revokedAt ? "revoked" : "active"}
-                    </div>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    disabled={busy || Boolean(apiKey.revokedAt)}
-                    onClick={() => setRevokingKey(apiKey)}
-                  >
-                    <Trash2Icon className="size-3.5" />
-                    Revoke
-                  </Button>
-                </div>
-              ))
-            )}
-          </div>
-        </section>
+            </CollapsibleContent>
+          </section>
+        </Collapsible>
 
         <ConfirmDialog
           open={revokingKey !== null}
@@ -475,7 +546,6 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
           onConfirm={() => (revokingKey ? revokeKey(revokingKey.id) : false)}
         />
 
-        {/* Danger zone */}
         <DangerZone
           workspaceName={activeWorkspace?.name ?? ""}
           canDelete={canDeleteWorkspace}
@@ -612,15 +682,19 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
   }
 
   return (
-    <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
-      <div>
+    <section className="grid gap-2">
+      <div className="flex items-baseline justify-between gap-3">
         <h2 className="flex items-center gap-1.5 text-sm font-medium">
           <UsersIcon className="size-3.5 text-brand" />
           People with access
         </h2>
-        <p className="mt-1 text-xs text-fg-muted">
-          People who can act in this workspace, and what each one can do.
-        </p>
+        <span className="text-2xs text-fg-subtle">
+          {!loaded
+            ? ""
+            : userMembers.length === 0
+              ? "just you"
+              : `${userMembers.length} member${userMembers.length === 1 ? "" : "s"}`}
+        </span>
       </div>
 
       {canManage ? (
@@ -645,40 +719,31 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
             ) : (
               <UserPlusIcon className="size-3.5" />
             )}
-            Add member
+            Add
           </Button>
         </form>
-      ) : (
-        <p className="text-xs text-fg-subtle">
-          Only members who can manage people can add or remove access.
-        </p>
-      )}
+      ) : null}
 
-      <div className="grid gap-2">
-        {error ? (
-          <LoadErrorState
-            title="Couldn't load members"
-            error={error}
-            onRetry={() => void refresh()}
-          />
-        ) : !loaded ? (
-          <div className="flex items-center gap-2 text-xs text-fg-muted">
-            <Loader2Icon className="size-3.5 animate-spin" />
-            Loading members
-          </div>
-        ) : userMembers.length === 0 ? (
-          <EmptyState
-            title="Only you have access"
-            description={
-              canManage ? "Add a teammate by email above to share this workspace." : undefined
-            }
-          />
-        ) : (
-          userMembers.map((member) => (
-            <div
-              key={member.subjectId}
-              className="grid gap-2 rounded-lg border border-border bg-bg/35 px-3 py-2"
-            >
+      {error ? (
+        <LoadErrorState
+          title="Couldn't load members"
+          error={error}
+          onRetry={() => void refresh()}
+        />
+      ) : !loaded ? (
+        <div className="flex items-center gap-2 text-xs text-fg-muted">
+          <Loader2Icon className="size-3.5 animate-spin" />
+          Loading members
+        </div>
+      ) : userMembers.length === 0 ? (
+        <p className="text-2xs text-fg-subtle">
+          Only you right now
+          {canManage ? " — add a teammate above." : "."}
+        </p>
+      ) : (
+        <div className="divide-y divide-border/70 overflow-hidden rounded-lg border border-border">
+          {userMembers.map((member) => (
+            <div key={member.subjectId} className="grid gap-2 px-3 py-2">
               <div className="flex min-w-0 items-center justify-between gap-3">
                 <div className="min-w-0">
                   <div className="truncate text-sm font-medium">
@@ -687,7 +752,7 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
                       <span className="ml-1.5 text-fg-subtle">(you)</span>
                     ) : null}
                   </div>
-                  <div className="mt-1 truncate text-xs text-fg-subtle">
+                  <div className="truncate text-2xs text-fg-subtle">
                     {member.role} · {member.permissions.length} permission
                     {member.permissions.length === 1 ? "" : "s"}
                   </div>
@@ -711,18 +776,18 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
                     <Button
                       type="button"
                       variant="ghost"
-                      size="sm"
+                      size="icon-sm"
                       disabled={busy || member.subjectId === callerSubjectId}
+                      aria-label={`Remove ${member.subjectLabel ?? member.subjectId}`}
                       onClick={() => setRemovingMember(member)}
                     >
                       <Trash2Icon className="size-3.5" />
-                      Remove
                     </Button>
                   </div>
                 ) : null}
               </div>
               {canManage && editing === member.subjectId ? (
-                <div className="grid gap-3 border-t border-border pt-3">
+                <div className="grid gap-3 border-t border-border pt-2">
                   <PermissionGroupPicker
                     groups={workspaceMemberPermissionGroups}
                     selected={editPermissions}
@@ -749,15 +814,15 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
                       ) : (
                         <CheckIcon className="size-3.5" />
                       )}
-                      Save permissions
+                      Save
                     </Button>
                   </div>
                 </div>
               ) : null}
             </div>
-          ))
-        )}
-      </div>
+          ))}
+        </div>
+      )}
 
       <ConfirmDialog
         open={removingMember !== null}
@@ -771,8 +836,7 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
   );
 }
 
-/** Workspace memory: a per-workspace toggle for the long-lived agent memory. */
-function MemorySettingsSection({
+function MemoryPreferenceRow({
   workspaceId,
   canManage,
 }: {
@@ -797,55 +861,23 @@ function MemorySettingsSection({
   }
 
   return (
-    <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <h2 className="flex items-center gap-1.5 text-sm font-medium">
-            <BrainCircuitIcon className="size-3.5 text-brand" />
-            Workspace memory
-          </h2>
-          <p className="mt-1 text-xs text-fg-muted">
-            Lets agents remember durable facts — preferences, environment details, decisions —
-            across sessions in this workspace. Everything saved is visible and editable on the
-            Documents page.
-          </p>
-        </div>
-        <div className="flex shrink-0 items-center gap-2 pt-0.5">
-          {saving ? <Loader2Icon className="size-3.5 animate-spin text-fg-subtle" /> : null}
-          <button
-            type="button"
-            role="switch"
-            aria-checked={enabled}
-            aria-label="Workspace memory"
-            disabled={saving || !canManage}
-            onClick={() => void toggle(!enabled)}
-            className={cn(
-              "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors disabled:cursor-not-allowed disabled:opacity-50",
-              enabled ? "border-brand bg-brand" : "border-border bg-surface-2",
-            )}
-          >
-            <span
-              className={cn(
-                "inline-block size-3.5 rounded-full bg-white shadow-sm transition-transform",
-                enabled ? "translate-x-4" : "translate-x-0.5",
-              )}
-            />
-          </button>
-        </div>
-      </div>
-      {!canManage ? (
-        <p className="text-xs text-fg-subtle">Only workspace admins can change this.</p>
-      ) : null}
-    </section>
+    <PreferenceToggleRow
+      icon={<BrainCircuitIcon className="size-3.5 text-brand" />}
+      label="Workspace memory"
+      description="Durable facts agents carry across sessions — editable on Documents."
+      checked={enabled}
+      disabled={saving || !canManage}
+      saving={saving}
+      onToggle={() => void toggle(!enabled)}
+    />
   );
 }
 
 /**
- * Default compaction strategy for NEW Codex sessions. Off (= remote_v2) keeps
- * Codex remote compaction and locks the session to Codex models; on (= portable)
- * uses plaintext compaction and allows mid-session provider switches.
+ * Default for NEW Codex sessions. Off (= remote_v2): best ChatGPT compaction,
+ * Codex-only. On (= portable): can switch to other models mid-session.
  */
-function CodexCompactionSettingsSection({
+function CodexCompactionPreferenceRow({
   workspaceId,
   canManage,
 }: {
@@ -866,8 +898,8 @@ function CodexCompactionSettingsSection({
       if (updated) {
         toast.success(
           nextPortable
-            ? "New Codex sessions will use portable compaction"
-            : "New Codex sessions will use remote compaction v2",
+            ? "New Codex sessions can switch to other providers"
+            : "New Codex sessions stay on Codex",
         );
       }
     } finally {
@@ -876,42 +908,15 @@ function CodexCompactionSettingsSection({
   }
 
   return (
-    <section className="grid gap-3 rounded-lg border border-border bg-surface p-4">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <h2 className="flex items-center gap-1.5 text-sm font-medium">Codex compaction</h2>
-          <p className="mt-1 text-xs text-fg-muted">
-            Use portable Codex compaction (allows switching away from Codex mid-session). When off,
-            new Codex sessions use remote compaction v2 and stay locked to Codex models.
-          </p>
-        </div>
-        <div className="flex shrink-0 items-center gap-2 pt-0.5">
-          {saving ? <Loader2Icon className="size-3.5 animate-spin text-fg-subtle" /> : null}
-          <button
-            type="button"
-            role="switch"
-            aria-checked={portable}
-            aria-label="Use portable Codex compaction"
-            disabled={saving || !canManage}
-            onClick={() => void toggle(!portable)}
-            className={cn(
-              "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors disabled:cursor-not-allowed disabled:opacity-50",
-              portable ? "border-brand bg-brand" : "border-border bg-surface-2",
-            )}
-          >
-            <span
-              className={cn(
-                "inline-block size-3.5 rounded-full bg-white shadow-sm transition-transform",
-                portable ? "translate-x-4" : "translate-x-0.5",
-              )}
-            />
-          </button>
-        </div>
-      </div>
-      {!canManage ? (
-        <p className="text-xs text-fg-subtle">Only workspace admins can change this.</p>
-      ) : null}
-    </section>
+    <PreferenceToggleRow
+      icon={<ShrinkIcon className="size-3.5 text-brand" />}
+      label="Allow other providers (Codex only)"
+      description="On: switch from Codex models to other providers mid-session. Off (recommended): better compaction."
+      checked={portable}
+      disabled={saving || !canManage}
+      saving={saving}
+      onToggle={() => void toggle(!portable)}
+    />
   );
 }
 
@@ -950,7 +955,7 @@ function DangerZone(props: {
   }
 
   return (
-    <section className="grid gap-3 rounded-lg border border-status-failed/30 bg-status-failed/5 p-4">
+    <section className="grid gap-2 rounded-lg border border-status-failed/30 bg-status-failed/5 px-3 py-3">
       <div>
         <h2 className="flex items-center gap-1.5 text-sm font-medium text-status-failed">
           <TriangleAlertIcon className="size-3.5" />

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -41,6 +41,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Notice } from "@/components/ui/notice";
+import { ContentPage } from "@/components/ui/content-layout";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAppContext } from "@/context";
 import { orgLabel } from "@/lib/org";
@@ -239,7 +240,7 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col overflow-y-auto px-4 py-5 sm:px-6 lg:px-8">
+    <ContentPage width="standard">
       <section className="grid gap-5 text-left">
         <PageHeader
           icon={<SettingsIcon className="size-4" />}
@@ -482,7 +483,7 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
           onDelete={deleteWorkspace}
         />
       </section>
-    </div>
+    </ContentPage>
   );
 }
 

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -4,6 +4,7 @@
 // console lives at Organization settings.
 import { Link, useNavigate } from "@tanstack/react-router";
 import {
+  BoxIcon,
   BrainCircuitIcon,
   CheckIcon,
   ChevronDownIcon,
@@ -27,14 +28,10 @@ import { LoadErrorState } from "@/components/common";
 import {
   WORKSPACE_BROWSE_ITEMS,
   type WorkspaceConfigItem,
-} from "@/components/rail/workspace-nav";
-import {
-  PreferenceToggleRow,
-  VoiceInputPreferenceRow,
-} from "@/components/transcription-settings";
+} from "@/components/rail/workspace-nav-data";
+import { PreferenceToggleRow, VoiceInputPreferenceRow } from "@/components/transcription-settings";
 import { PermissionGroupPicker } from "@/components/permission-picker";
 import { Button } from "@/components/ui/button";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
   Dialog,
@@ -67,6 +64,10 @@ function BrowseWorkspaceStrip(props: { workspaceId: string; canReadInsights: boo
   const items = WORKSPACE_BROWSE_ITEMS.filter(
     (item: WorkspaceConfigItem) => !item.requiresAdmin || props.canReadInsights,
   );
+  // Leaf catalog only (workspace-nav-data). Do not import workspace-nav.tsx or
+  // workspace-nav-icons — that Lucide map shares into the shell and blows the
+  // initial bundle. Keep a single BoxIcon use so Rolldown's Lucide grouping
+  // stays aligned with the previous Variable-sets card.
   return (
     <nav aria-label="Browse workspace" className="flex flex-wrap items-center gap-x-1 gap-y-1.5">
       <span className="mr-1 text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
@@ -80,7 +81,7 @@ function BrowseWorkspaceStrip(props: { workspaceId: string; canReadInsights: boo
           title={item.description}
           className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-fg-muted transition-colors hover:bg-surface-2 hover:text-fg"
         >
-          <item.icon className="size-3.5 shrink-0 text-brand" />
+          {item.icon === "box" ? <BoxIcon className="size-3.5 shrink-0 text-brand" /> : null}
           {item.label}
         </Link>
       ))}
@@ -380,162 +381,160 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
           canManage={canDeleteWorkspace}
         />
 
-        <Collapsible
+        <details
+          className="rounded-lg border border-border"
           open={apiKeysOpen || createdToken != null}
-          onOpenChange={(open) => {
-            if (createdToken != null && !open) return;
-            setApiKeysOpen(open);
+          onToggle={(event) => {
+            const next = event.currentTarget.open;
+            if (createdToken != null && !next) {
+              event.currentTarget.open = true;
+              return;
+            }
+            setApiKeysOpen(next);
           }}
         >
-          <section className="rounded-lg border border-border">
-            <CollapsibleTrigger asChild>
-              <button
-                type="button"
-                className="flex w-full items-center gap-2 px-3 py-2.5 text-left transition-colors hover:bg-surface-2/60"
-              >
-                <KeyRoundIcon className="size-3.5 shrink-0 text-brand" />
-                <span className="min-w-0 flex-1 text-sm font-medium">API keys</span>
-                <span className="text-2xs text-fg-subtle">
-                  {!apiKeysLoaded
-                    ? "…"
-                    : activeApiKeyCount === 0
-                      ? "None"
-                      : `${activeApiKeyCount} active`}
-                </span>
-                <ChevronDownIcon
-                  className={cn(
-                    "size-4 shrink-0 text-fg-subtle transition-transform",
-                    apiKeysOpen || createdToken != null ? "rotate-180" : "",
-                  )}
+          <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2.5 text-left transition-colors hover:bg-surface-2/60 [&::-webkit-details-marker]:hidden">
+            <KeyRoundIcon className="size-3.5 shrink-0 text-brand" />
+            <span className="min-w-0 flex-1 text-sm font-medium">API keys</span>
+            <span className="text-2xs text-fg-subtle">
+              {!apiKeysLoaded
+                ? "…"
+                : activeApiKeyCount === 0
+                  ? "None"
+                  : `${activeApiKeyCount} active`}
+            </span>
+            <ChevronDownIcon
+              className={cn(
+                "size-4 shrink-0 text-fg-subtle transition-transform",
+                apiKeysOpen || createdToken != null ? "rotate-180" : "",
+              )}
+            />
+          </summary>
+          <div className="grid gap-3 border-t border-border px-3 py-3">
+            <p className="text-2xs text-fg-subtle">
+              Workspace-scoped keys for calling OpenGeni from another product.
+            </p>
+            {createdToken ? (
+              <Notice tone="success" title="Copy this token now — it won't be shown again.">
+                <div className="mt-2 flex min-w-0 items-center gap-2">
+                  <code className="min-w-0 flex-1 truncate rounded bg-bg px-2 py-1.5 text-xs text-fg">
+                    {createdToken}
+                  </code>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label="Copy token"
+                    onClick={() => void copyToken(createdToken)}
+                  >
+                    <CopyIcon className="size-3.5" />
+                  </Button>
+                </div>
+              </Notice>
+            ) : null}
+            {canManageApiKeys ? (
+              <>
+                <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+                  <Input
+                    value={apiKeyName}
+                    onChange={(event) => setApiKeyName(event.target.value)}
+                    className="h-9"
+                  />
+                  <Button type="button" disabled={busy} onClick={() => void createKey()}>
+                    {busy ? (
+                      <Loader2Icon className="size-3.5 animate-spin" />
+                    ) : (
+                      <PlusIcon className="size-3.5" />
+                    )}
+                    Create
+                  </Button>
+                </div>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className="text-xs text-fg-subtle">
+                    A key can only carry permissions your own grant can delegate.
+                  </p>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={delegablePermissions.size === 0}
+                    onClick={() => setSelectedPermissions(new Set(delegablePermissions))}
+                  >
+                    Select all delegable
+                  </Button>
+                </div>
+                <PermissionGroupPicker
+                  groups={apiKeyPermissionGroups}
+                  selected={selectedPermissions}
+                  delegable={delegablePermissions}
+                  onToggle={togglePermission}
                 />
-              </button>
-            </CollapsibleTrigger>
-            <CollapsibleContent className="grid gap-3 border-t border-border px-3 py-3">
-              <p className="text-2xs text-fg-subtle">
-                Workspace-scoped keys for calling OpenGeni from another product.
+              </>
+            ) : (
+              <p className="text-xs text-fg-subtle">
+                You don't have permission to manage API keys here.
               </p>
-              {createdToken ? (
-                <Notice tone="success" title="Copy this token now — it won't be shown again.">
-                  <div className="mt-2 flex min-w-0 items-center gap-2">
-                    <code className="min-w-0 flex-1 truncate rounded bg-bg px-2 py-1.5 text-xs text-fg">
-                      {createdToken}
-                    </code>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      aria-label="Copy token"
-                      onClick={() => void copyToken(createdToken)}
-                    >
-                      <CopyIcon className="size-3.5" />
-                    </Button>
-                  </div>
-                </Notice>
-              ) : null}
-              {canManageApiKeys ? (
+            )}
+            <div className="divide-y divide-border/70 rounded-md border border-border/70">
+              {apiKeysError ? (
+                <div className="p-2">
+                  <LoadErrorState
+                    title="Couldn't load API keys"
+                    error={apiKeysError}
+                    onRetry={() => void refreshApiKeys()}
+                  />
+                </div>
+              ) : !apiKeysLoaded ? (
                 <>
-                  <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
-                    <Input
-                      value={apiKeyName}
-                      onChange={(event) => setApiKeyName(event.target.value)}
-                      className="h-9"
-                    />
-                    <Button type="button" disabled={busy} onClick={() => void createKey()}>
-                      {busy ? (
-                        <Loader2Icon className="size-3.5 animate-spin" />
-                      ) : (
-                        <PlusIcon className="size-3.5" />
-                      )}
-                      Create
-                    </Button>
-                  </div>
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <p className="text-xs text-fg-subtle">
-                      A key can only carry permissions your own grant can delegate.
-                    </p>
+                  {[0, 1].map((key) => (
+                    <div key={key} className="flex items-center justify-between gap-3 px-3 py-2">
+                      <div className="min-w-0 space-y-1.5">
+                        <Skeleton className="h-4 w-32" />
+                        <Skeleton className="h-3 w-24" />
+                      </div>
+                      <Skeleton className="h-8 w-20 rounded-md" />
+                    </div>
+                  ))}
+                </>
+              ) : apiKeys.length === 0 ? (
+                <div className="p-2">
+                  <EmptyState
+                    title="No API keys yet"
+                    description={
+                      canManageApiKeys
+                        ? "Create one above to call OpenGeni from another product."
+                        : "Keys created here call OpenGeni from another product."
+                    }
+                  />
+                </div>
+              ) : (
+                apiKeys.map((apiKey) => (
+                  <div
+                    key={apiKey.id}
+                    className="flex min-w-0 items-center justify-between gap-3 px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium">{apiKey.name}</div>
+                      <div className="truncate text-2xs text-fg-subtle">
+                        {apiKey.prefix}… · {apiKey.revokedAt ? "revoked" : "active"}
+                      </div>
+                    </div>
                     <Button
                       type="button"
                       variant="ghost"
                       size="sm"
-                      disabled={delegablePermissions.size === 0}
-                      onClick={() => setSelectedPermissions(new Set(delegablePermissions))}
+                      disabled={busy || Boolean(apiKey.revokedAt)}
+                      onClick={() => setRevokingKey(apiKey)}
                     >
-                      Select all delegable
+                      <Trash2Icon className="size-3.5" />
+                      Revoke
                     </Button>
                   </div>
-                  <PermissionGroupPicker
-                    groups={apiKeyPermissionGroups}
-                    selected={selectedPermissions}
-                    delegable={delegablePermissions}
-                    onToggle={togglePermission}
-                  />
-                </>
-              ) : (
-                <p className="text-xs text-fg-subtle">
-                  You don't have permission to manage API keys here.
-                </p>
+                ))
               )}
-              <div className="divide-y divide-border/70 rounded-md border border-border/70">
-                {apiKeysError ? (
-                  <div className="p-2">
-                    <LoadErrorState
-                      title="Couldn't load API keys"
-                      error={apiKeysError}
-                      onRetry={() => void refreshApiKeys()}
-                    />
-                  </div>
-                ) : !apiKeysLoaded ? (
-                  <>
-                    {[0, 1].map((key) => (
-                      <div key={key} className="flex items-center justify-between gap-3 px-3 py-2">
-                        <div className="min-w-0 space-y-1.5">
-                          <Skeleton className="h-4 w-32" />
-                          <Skeleton className="h-3 w-24" />
-                        </div>
-                        <Skeleton className="h-8 w-20 rounded-md" />
-                      </div>
-                    ))}
-                  </>
-                ) : apiKeys.length === 0 ? (
-                  <div className="p-2">
-                    <EmptyState
-                      title="No API keys yet"
-                      description={
-                        canManageApiKeys
-                          ? "Create one above to call OpenGeni from another product."
-                          : "Keys created here call OpenGeni from another product."
-                      }
-                    />
-                  </div>
-                ) : (
-                  apiKeys.map((apiKey) => (
-                    <div
-                      key={apiKey.id}
-                      className="flex min-w-0 items-center justify-between gap-3 px-3 py-2"
-                    >
-                      <div className="min-w-0">
-                        <div className="truncate text-sm font-medium">{apiKey.name}</div>
-                        <div className="truncate text-2xs text-fg-subtle">
-                          {apiKey.prefix}… · {apiKey.revokedAt ? "revoked" : "active"}
-                        </div>
-                      </div>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        disabled={busy || Boolean(apiKey.revokedAt)}
-                        onClick={() => setRevokingKey(apiKey)}
-                      >
-                        <Trash2Icon className="size-3.5" />
-                        Revoke
-                      </Button>
-                    </div>
-                  ))
-                )}
-              </div>
-            </CollapsibleContent>
-          </section>
-        </Collapsible>
+            </div>
+          </div>
+        </details>
 
         <ConfirmDialog
           open={revokingKey !== null}

--- a/apps/web/src/routes/workspace-state.tsx
+++ b/apps/web/src/routes/workspace-state.tsx
@@ -310,7 +310,7 @@ function ExistingSources({ workspaceId }: { workspaceId: string }) {
     },
     {
       to: "/workspaces/$workspaceId/settings" as const,
-      label: "Workspace settings",
+      label: "Workspace",
       icon: SettingsIcon,
     },
   ];

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -122,8 +122,8 @@ body {
   padding: 0;
   background-color: var(--color-bg);
   color: var(--color-fg);
-  min-height: 100vh;
-  overflow-x: hidden;
+  height: 100%;
+  overflow: hidden;
   font-family: var(--font-sans);
   font-feature-settings: "cv11", "ss01", "ss03";
   -webkit-font-smoothing: antialiased;

--- a/apps/web/src/workspace-state-surface.test.ts
+++ b/apps/web/src/workspace-state-surface.test.ts
@@ -8,7 +8,7 @@ describe("read-only Workspace State surface", () => {
   test("registers a first-class workspace route and rail destination", async () => {
     const [app, navigation] = await Promise.all([
       source("App.tsx"),
-      source("components/rail/workspace-nav.tsx"),
+      source("components/rail/workspace-nav-data.ts"),
     ]);
     expect(app).toContain('path: "state"');
     expect(app).toContain('import("@/routes/workspace-state")');

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -23,6 +23,15 @@ export default defineConfig({
         codeSplitting: {
           groups: [
             {
+              // Keep every Radix package in one chunk. entriesAware session
+              // merging otherwise splits Popper scopes across lazy route
+              // share-chunks and crashes /settings
+              // (`createPopperScope is not a function`).
+              name: "radix",
+              test: /(?:node_modules|\.bun)[\\/](?:@radix-ui(?:\+|\/)|radix-ui(?:@|\/))/,
+              priority: 15,
+            },
+            {
               // The session workbench is the primary interactive route. Keep
               // its static graph route-aware, but coalesce tiny shared groups
               // so a cold navigation does not fan out into dozens of requests.
@@ -50,6 +59,7 @@ export default defineConfig({
     alias: {
       "@": path.resolve(dirname, "src"),
     },
+    dedupe: ["react", "react-dom", "radix-ui"],
   },
   plugins: [
     tanstackRouter({ target: "react", enableRouteGeneration: false }),

--- a/packages/react/src/components/chat-composer.tsx
+++ b/packages/react/src/components/chat-composer.tsx
@@ -4,6 +4,7 @@ import type { SlashCommand } from "../commands/types";
 import type { ComposerState } from "../hooks/use-composer";
 import type { UseFileAttachmentsResult } from "../hooks/use-file-attachments";
 import type { SlashCommandContext } from "../hooks/use-slash-commands";
+import { OPEN_WORKSTREAM_CONTROL_EVENT } from "../workstream-control-event";
 import {
   Actions,
   AttachButton,
@@ -17,7 +18,6 @@ import {
   Hint,
   Input,
   ModelPicker,
-  OPEN_WORKSTREAM_CONTROL_EVENT,
   PauseButton,
   PausedState,
   RestoredResources,

--- a/packages/react/src/components/composer-transcription-control.tsx
+++ b/packages/react/src/components/composer-transcription-control.tsx
@@ -6,10 +6,20 @@ import type {
 } from "@opengeni/sdk";
 import { LoaderCircleIcon, MicIcon, SquareIcon, XIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useEffect, useState, type MouseEvent } from "react";
+import { useEffect, useState, type MouseEvent, type ReactElement } from "react";
 import { cn } from "../lib/cn";
 import { useVoiceInput } from "../hooks/use-voice-input";
 import { useChatComposer } from "./composer";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
+
+function Tip({ tip, children }: { tip: string; children: ReactElement }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side="top">{tip}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 export type ComposerTranscriptionMessages = {
   start: string;
@@ -161,33 +171,35 @@ export function ComposerTranscriptionControl({
             )}
             {status === "recording" ? (
               <>
-                <button
-                  type="button"
-                  onClick={() => transcription.cancel()}
-                  aria-label={messages.cancel}
-                  aria-keyshortcuts="Escape"
-                  title={messages.cancel}
-                  className={cn(
-                    "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
-                    "text-og-fg-muted transition-colors duration-150 motion-reduce:transition-none",
-                    "hover:bg-og-surface-3 hover:text-og-fg pointer-coarse:size-9",
-                  )}
-                >
-                  <XIcon className="size-3.5" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => transcription.stop()}
-                  aria-label={messages.stop}
-                  title={messages.stop}
-                  className={cn(
-                    "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
-                    "bg-og-fg text-og-bg transition-colors duration-150 motion-reduce:transition-none",
-                    "hover:bg-og-fg-muted pointer-coarse:size-9",
-                  )}
-                >
-                  <SquareIcon className="size-2.5 fill-current" />
-                </button>
+                <Tip tip={messages.cancel}>
+                  <button
+                    type="button"
+                    onClick={() => transcription.cancel()}
+                    aria-label={messages.cancel}
+                    aria-keyshortcuts="Escape"
+                    className={cn(
+                      "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
+                      "text-og-fg-muted transition-colors duration-150 motion-reduce:transition-none",
+                      "hover:bg-og-surface-3 hover:text-og-fg pointer-coarse:size-9",
+                    )}
+                  >
+                    <XIcon className="size-3.5" />
+                  </button>
+                </Tip>
+                <Tip tip={messages.stop}>
+                  <button
+                    type="button"
+                    onClick={() => transcription.stop()}
+                    aria-label={messages.stop}
+                    className={cn(
+                      "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
+                      "bg-og-fg text-og-bg transition-colors duration-150 motion-reduce:transition-none",
+                      "hover:bg-og-fg-muted pointer-coarse:size-9",
+                    )}
+                  >
+                    <SquareIcon className="size-2.5 fill-current" />
+                  </button>
+                </Tip>
               </>
             ) : status === "transcribing" ? (
               <span className="og-shimmer-text px-1.5 text-og-xs font-medium whitespace-nowrap">
@@ -200,38 +212,39 @@ export function ComposerTranscriptionControl({
             )}
           </motion.span>
         ) : (
-          <motion.button
-            key="idle"
-            type="button"
-            initial={{ opacity: 0, scale: 0.96 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.96 }}
-            transition={{ duration: 0.14, ease: [0.22, 1, 0.36, 1] }}
-            onClick={start}
-            aria-label={idleLabel}
-            aria-pressed={false}
-            aria-disabled={unavailableMessage !== null}
-            title={idleLabel}
-            className={cn(
-              "inline-flex size-8 shrink-0 items-center justify-center rounded-og-md pointer-coarse:size-11",
-              "text-og-fg-muted transition-colors duration-150 motion-reduce:transition-none",
-              unavailableMessage
-                ? "cursor-not-allowed opacity-45"
-                : "hover:bg-og-surface-2 hover:text-og-fg",
-            )}
-          >
-            <MicIcon className="size-4" />
-          </motion.button>
+          <Tip key="idle" tip={idleLabel}>
+            <motion.button
+              type="button"
+              initial={{ opacity: 0, scale: 0.96 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.96 }}
+              transition={{ duration: 0.14, ease: [0.22, 1, 0.36, 1] }}
+              onClick={start}
+              aria-label={idleLabel}
+              aria-pressed={false}
+              aria-disabled={unavailableMessage !== null}
+              className={cn(
+                "inline-flex size-8 shrink-0 items-center justify-center rounded-og-md pointer-coarse:size-11",
+                "text-og-fg-muted transition-colors duration-150 motion-reduce:transition-none",
+                unavailableMessage
+                  ? "cursor-not-allowed opacity-45"
+                  : "hover:bg-og-surface-2 hover:text-og-fg",
+              )}
+            >
+              <MicIcon className="size-4" />
+            </motion.button>
+          </Tip>
         )}
       </AnimatePresence>
       {status === "error" && errorMessage ? (
-        <span
-          aria-hidden="true"
-          title={errorMessage}
-          className="max-w-40 truncate text-og-xs text-og-status-failed max-sm:max-w-24"
-        >
-          {errorMessage}
-        </span>
+        <Tip tip={errorMessage}>
+          <span
+            aria-hidden="true"
+            className="max-w-40 truncate text-og-xs text-og-status-failed max-sm:max-w-24"
+          >
+            {errorMessage}
+          </span>
+        </Tip>
       ) : null}
       <span className="sr-only" role={status === "error" ? "alert" : "status"} aria-live="polite">
         {announcement}

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -46,9 +46,12 @@ import {
 import { cn } from "../lib/cn";
 import { composerSubmissionErrorMessage, formatBytes, formatRelativeTime } from "../lib/format";
 import type { PickerModelRow } from "../model-policy";
+import { OPEN_WORKSTREAM_CONTROL_EVENT } from "../workstream-control-event";
 import { CommandPalette as CommandPaletteView } from "./command-palette";
 import { ModelPicker as ModelPickerView } from "./model-picker";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip";
+
+export { OPEN_WORKSTREAM_CONTROL_EVENT };
 
 /** Radix tip for icon/chrome controls — never native `title` (browser ugly). */
 function ComposerTip({ tip, children }: { tip: string; children: ReactElement }) {
@@ -62,8 +65,6 @@ function ComposerTip({ tip, children }: { tip: string; children: ReactElement })
     </Tooltip>
   );
 }
-
-export const OPEN_WORKSTREAM_CONTROL_EVENT = "opengeni:open-workstream-control";
 
 export type ComposerDelivery = Pick<
   ComposerState,
@@ -1107,9 +1108,7 @@ export const SendButton = forwardRef<HTMLButtonElement, ComposerSendButtonProps>
     const controller = useComposerController();
     const tip =
       title ??
-      (controller.paused
-        ? controller.messages.sendAndResumeTitle
-        : controller.messages.sendTitle);
+      (controller.paused ? controller.messages.sendAndResumeTitle : controller.messages.sendTitle);
     return (
       <ComposerTip tip={tip}>
         <button
@@ -1118,6 +1117,7 @@ export const SendButton = forwardRef<HTMLButtonElement, ComposerSendButtonProps>
           type="button"
           onClick={() => void controller.submit("queue")}
           disabled={!controller.canSubmit}
+          data-og-tip={tip}
           aria-label={
             ariaLabel ??
             (controller.paused
@@ -1342,7 +1342,10 @@ function WorkstreamPausedStrip({
           {broaderOptions.length > 0 ? (
             <div className="mt-2 flex flex-wrap gap-1.5">
               {broaderOptions.map((option) => (
-                <ComposerTip key={`${option.scope}-${option.targetId ?? "selected"}`} tip={option.impactCopy}>
+                <ComposerTip
+                  key={`${option.scope}-${option.targetId ?? "selected"}`}
+                  tip={option.impactCopy}
+                >
                   <button
                     type="button"
                     disabled={busy}

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import {
+  cloneElement,
   createContext,
   forwardRef,
   useCallback,
@@ -49,21 +50,12 @@ import type { PickerModelRow } from "../model-policy";
 import { OPEN_WORKSTREAM_CONTROL_EVENT } from "../workstream-control-event";
 import { CommandPalette as CommandPaletteView } from "./command-palette";
 import { ModelPicker as ModelPickerView } from "./model-picker";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip";
 
 export { OPEN_WORKSTREAM_CONTROL_EVENT };
 
-/** Radix tip for icon/chrome controls — never native `title` (browser ugly). */
 function ComposerTip({ tip, children }: { tip: string; children: ReactElement }) {
-  if (!tip) {
-    return children;
-  }
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{children}</TooltipTrigger>
-      <TooltipContent side="top">{tip}</TooltipContent>
-    </Tooltip>
-  );
+  if (!tip) return children;
+  return cloneElement(children, { title: tip });
 }
 
 export type ComposerDelivery = Pick<
@@ -693,18 +685,16 @@ export const Root = forwardRef<HTMLDivElement, ComposerRootProps>(function Compo
 ) {
   return (
     <ComposerContext.Provider value={controller}>
-      <TooltipProvider delayDuration={300}>
-        <div
-          {...props}
-          ref={mergeRefs(controller.rootRef, forwardedRef)}
-          data-og-composer-id={controller.id}
-          className={cn("og-root", className)}
-          style={{ paddingBottom: "env(safe-area-inset-bottom)", ...style }}
-        >
-          {children}
-          <ComposerAnnouncements />
-        </div>
-      </TooltipProvider>
+      <div
+        {...props}
+        ref={mergeRefs(controller.rootRef, forwardedRef)}
+        data-og-composer-id={controller.id}
+        className={cn("og-root", className)}
+        style={{ paddingBottom: "env(safe-area-inset-bottom)", ...style }}
+      >
+        {children}
+        <ComposerAnnouncements />
+      </div>
     </ComposerContext.Provider>
   );
 });

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -28,6 +28,7 @@ import {
   type ComponentPropsWithoutRef,
   type DragEvent,
   type KeyboardEvent,
+  type ReactElement,
   type ReactNode,
   type Ref,
   type RefObject,
@@ -47,6 +48,20 @@ import { composerSubmissionErrorMessage, formatBytes, formatRelativeTime } from 
 import type { PickerModelRow } from "../model-policy";
 import { CommandPalette as CommandPaletteView } from "./command-palette";
 import { ModelPicker as ModelPickerView } from "./model-picker";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip";
+
+/** Radix tip for icon/chrome controls — never native `title` (browser ugly). */
+function ComposerTip({ tip, children }: { tip: string; children: ReactElement }) {
+  if (!tip) {
+    return children;
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side="top">{tip}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 export const OPEN_WORKSTREAM_CONTROL_EVENT = "opengeni:open-workstream-control";
 
@@ -226,6 +241,31 @@ export type UseChatComposerControllerOptions = {
 };
 
 /**
+ * Autosize a composer textarea up to `maxPx` without the classic height→0
+ * measure collapse (that flash expands the timeline flex sibling and yanks
+ * tip-follow while a stream is pinned).
+ */
+export function applyComposerTextareaHeight(
+  textarea: HTMLTextAreaElement,
+  maxPx: number = 220,
+): void {
+  // Grow path: content already overflows — raise height, no measure collapse.
+  if (textarea.scrollHeight > textarea.clientHeight + 1) {
+    textarea.style.height = `${Math.min(textarea.scrollHeight, maxPx)}px`;
+    return;
+  }
+  // Shrink / steady: `auto` measures natural height without flashing empty.
+  const before = textarea.offsetHeight;
+  textarea.style.height = "auto";
+  const nextPx = Math.min(textarea.scrollHeight, maxPx);
+  if (Math.abs(nextPx - before) < 1) {
+    textarea.style.height = `${before}px`;
+    return;
+  }
+  textarea.style.height = `${nextPx}px`;
+}
+
+/**
  * Headless interaction layer for a chat composer. It is the single owner of
  * delivery guards, keyboard routing, command interception, drag/drop, focus,
  * confirmation, and feedback state used by both the preset and primitives.
@@ -347,13 +387,33 @@ export function useChatComposerController({
     [],
   );
 
+  // Autosize without collapsing the composer to 0 on every keystroke. The old
+  // height→0→content pattern briefly expanded the timeline scroller and yanked
+  // tip-follow while streams were live (pin/unpin flicker when typing fast).
+  const resizeInputRafRef = useRef<number | null>(null);
   const resizeInput = useCallback(() => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-    textarea.style.height = "0px";
-    textarea.style.height = `${Math.min(textarea.scrollHeight, 220)}px`;
+    if (resizeInputRafRef.current !== null) {
+      return;
+    }
+    resizeInputRafRef.current = requestAnimationFrame(() => {
+      resizeInputRafRef.current = null;
+      const textarea = textareaRef.current;
+      if (!textarea) {
+        return;
+      }
+      applyComposerTextareaHeight(textarea, 220);
+    });
   }, []);
   useEffect(() => resizeInput(), [delivery.value, resizeInput]);
+  useEffect(
+    () => () => {
+      if (resizeInputRafRef.current !== null) {
+        cancelAnimationFrame(resizeInputRafRef.current);
+        resizeInputRafRef.current = null;
+      }
+    },
+    [],
+  );
 
   const handlers = useMemo(
     () => ({
@@ -632,16 +692,18 @@ export const Root = forwardRef<HTMLDivElement, ComposerRootProps>(function Compo
 ) {
   return (
     <ComposerContext.Provider value={controller}>
-      <div
-        {...props}
-        ref={mergeRefs(controller.rootRef, forwardedRef)}
-        data-og-composer-id={controller.id}
-        className={cn("og-root", className)}
-        style={{ paddingBottom: "env(safe-area-inset-bottom)", ...style }}
-      >
-        {children}
-        <ComposerAnnouncements />
-      </div>
+      <TooltipProvider delayDuration={300}>
+        <div
+          {...props}
+          ref={mergeRefs(controller.rootRef, forwardedRef)}
+          data-og-composer-id={controller.id}
+          className={cn("og-root", className)}
+          style={{ paddingBottom: "env(safe-area-inset-bottom)", ...style }}
+        >
+          {children}
+          <ComposerAnnouncements />
+        </div>
+      </TooltipProvider>
     </ComposerContext.Provider>
   );
 });
@@ -919,6 +981,7 @@ export const AttachButton = forwardRef<HTMLButtonElement, ComposerAttachButtonPr
   ) {
     const controller = useComposerController();
     if (!controller.attachments) return null;
+    const tip = title ?? controller.messages.attachFiles;
     return (
       <>
         <input
@@ -929,23 +992,24 @@ export const AttachButton = forwardRef<HTMLButtonElement, ComposerAttachButtonPr
           className="hidden"
           onChange={controller.handleFileChange}
         />
-        <button
-          {...props}
-          ref={ref}
-          type="button"
-          disabled={controller.disabled}
-          onClick={() => controller.fileInputRef.current?.click()}
-          aria-label={ariaLabel ?? controller.messages.attachFiles}
-          title={title ?? controller.messages.attachFiles}
-          className={cn(
-            "inline-flex size-8 items-center justify-center rounded-og-md",
-            "text-og-fg-muted transition-colors duration-150 hover:bg-og-surface-2 hover:text-og-fg",
-            "disabled:cursor-not-allowed disabled:opacity-50 pointer-coarse:size-11",
-            className,
-          )}
-        >
-          {children ?? <PaperclipIcon className="size-4" />}
-        </button>
+        <ComposerTip tip={tip}>
+          <button
+            {...props}
+            ref={ref}
+            type="button"
+            disabled={controller.disabled}
+            onClick={() => controller.fileInputRef.current?.click()}
+            aria-label={ariaLabel ?? tip}
+            className={cn(
+              "inline-flex size-8 items-center justify-center rounded-og-md",
+              "text-og-fg-muted transition-colors duration-150 hover:bg-og-surface-2 hover:text-og-fg",
+              "disabled:cursor-not-allowed disabled:opacity-50 pointer-coarse:size-11",
+              className,
+            )}
+          >
+            {children ?? <PaperclipIcon className="size-4" />}
+          </button>
+        </ComposerTip>
       </>
     );
   },
@@ -1000,30 +1064,32 @@ export const PauseButton = forwardRef<HTMLButtonElement, ComposerPauseButtonProp
     const controller = useComposerController();
     if (!controller.effectiveControl || controller.paused || !controller.hasControl) return null;
     const busy = controller.pausing || controller.resuming;
+    const tip = title ?? controller.messages.pauseTitle;
     return (
-      <button
-        {...props}
-        ref={mergeRefs(controller.pauseButtonRef, ref)}
-        type="button"
-        onClick={() => void controller.pause()}
-        disabled={busy}
-        aria-label={ariaLabel ?? controller.messages.pauseAriaLabel}
-        title={title ?? controller.messages.pauseTitle}
-        className={cn(
-          "inline-flex size-8 items-center justify-center rounded-og-md border border-og-border pointer-coarse:size-11",
-          "bg-og-surface-2 text-og-fg-muted transition-colors duration-150",
-          "hover:border-og-status-waiting/50 hover:text-og-status-waiting",
-          "disabled:opacity-50",
-          className,
-        )}
-      >
-        {children ??
-          (busy ? (
-            <LoaderCircleIcon className="size-3.5 animate-og-spin" />
-          ) : (
-            <PauseIcon className="size-3.5 fill-current" />
-          ))}
-      </button>
+      <ComposerTip tip={tip}>
+        <button
+          {...props}
+          ref={mergeRefs(controller.pauseButtonRef, ref)}
+          type="button"
+          onClick={() => void controller.pause()}
+          disabled={busy}
+          aria-label={ariaLabel ?? controller.messages.pauseAriaLabel}
+          className={cn(
+            "inline-flex size-8 items-center justify-center rounded-og-md border border-og-border pointer-coarse:size-11",
+            "bg-og-surface-2 text-og-fg-muted transition-colors duration-150",
+            "hover:border-og-status-waiting/50 hover:text-og-status-waiting",
+            "disabled:opacity-50",
+            className,
+          )}
+        >
+          {children ??
+            (busy ? (
+              <LoaderCircleIcon className="size-3.5 animate-og-spin" />
+            ) : (
+              <PauseIcon className="size-3.5 fill-current" />
+            ))}
+        </button>
+      </ComposerTip>
     );
   },
 );
@@ -1039,41 +1105,42 @@ export const SendButton = forwardRef<HTMLButtonElement, ComposerSendButtonProps>
     ref,
   ) {
     const controller = useComposerController();
+    const tip =
+      title ??
+      (controller.paused
+        ? controller.messages.sendAndResumeTitle
+        : controller.messages.sendTitle);
     return (
-      <button
-        {...props}
-        ref={ref}
-        type="button"
-        onClick={() => void controller.submit("queue")}
-        disabled={!controller.canSubmit}
-        aria-label={
-          ariaLabel ??
-          (controller.paused
-            ? controller.messages.sendAndResumeAriaLabel
-            : controller.messages.sendMessageAriaLabel)
-        }
-        title={
-          title ??
-          (controller.paused
-            ? controller.messages.sendAndResumeTitle
-            : controller.messages.sendTitle)
-        }
-        className={cn(
-          "inline-flex size-8 items-center justify-center rounded-og-md pointer-coarse:size-11",
-          "bg-og-accent text-og-accent-fg shadow-og-sm",
-          "transition-[background-color,transform,opacity] duration-150 ease-og-spring",
-          "hover:bg-og-accent-strong active:scale-95",
-          "disabled:cursor-not-allowed disabled:bg-og-surface-3 disabled:text-og-fg-subtle disabled:shadow-none",
-          className,
-        )}
-      >
-        {children ??
-          (controller.sending ? (
-            <LoaderCircleIcon className="size-4 animate-og-spin" />
-          ) : (
-            <ArrowUpIcon className="size-4" />
-          ))}
-      </button>
+      <ComposerTip tip={tip}>
+        <button
+          {...props}
+          ref={ref}
+          type="button"
+          onClick={() => void controller.submit("queue")}
+          disabled={!controller.canSubmit}
+          aria-label={
+            ariaLabel ??
+            (controller.paused
+              ? controller.messages.sendAndResumeAriaLabel
+              : controller.messages.sendMessageAriaLabel)
+          }
+          className={cn(
+            "inline-flex size-8 items-center justify-center rounded-og-md pointer-coarse:size-11",
+            "bg-og-accent text-og-accent-fg shadow-og-sm",
+            "transition-[background-color,transform,opacity] duration-150 ease-og-spring",
+            "hover:bg-og-accent-strong active:scale-95",
+            "disabled:cursor-not-allowed disabled:bg-og-surface-3 disabled:text-og-fg-subtle disabled:shadow-none",
+            className,
+          )}
+        >
+          {children ??
+            (controller.sending ? (
+              <LoaderCircleIcon className="size-4 animate-og-spin" />
+            ) : (
+              <ArrowUpIcon className="size-4" />
+            ))}
+        </button>
+      </ComposerTip>
     );
   },
 );
@@ -1275,27 +1342,27 @@ function WorkstreamPausedStrip({
           {broaderOptions.length > 0 ? (
             <div className="mt-2 flex flex-wrap gap-1.5">
               {broaderOptions.map((option) => (
-                <button
-                  key={`${option.scope}-${option.targetId ?? "selected"}`}
-                  type="button"
-                  disabled={busy}
-                  title={option.impactCopy}
-                  onClick={() => onResumeOption(option)}
-                  className="rounded-og-md border border-og-border bg-og-surface-1 px-2 py-1 text-og-xs text-og-fg-muted hover:bg-og-surface-2 hover:text-og-fg pointer-coarse:min-h-10"
-                >
-                  <span className="block font-medium">
-                    {option.scope === "workspace"
-                      ? messages.resumeWorkspace
-                      : messages.resumeFromSession}
-                  </span>
-                  <span className="block text-[10px] text-og-fg-subtle">
-                    {option.selectedStateAfter === "active"
-                      ? messages.sessionCanRun
-                      : messages.stillPausedBy(
-                          option.remainingPrimaryBlocker?.displayName ?? messages.narrowerPause,
-                        )}
-                  </span>
-                </button>
+                <ComposerTip key={`${option.scope}-${option.targetId ?? "selected"}`} tip={option.impactCopy}>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => onResumeOption(option)}
+                    className="rounded-og-md border border-og-border bg-og-surface-1 px-2 py-1 text-og-xs text-og-fg-muted hover:bg-og-surface-2 hover:text-og-fg pointer-coarse:min-h-10"
+                  >
+                    <span className="block font-medium">
+                      {option.scope === "workspace"
+                        ? messages.resumeWorkspace
+                        : messages.resumeFromSession}
+                    </span>
+                    <span className="block text-[10px] text-og-fg-subtle">
+                      {option.selectedStateAfter === "active"
+                        ? messages.sessionCanRun
+                        : messages.stillPausedBy(
+                            option.remainingPrimaryBlocker?.displayName ?? messages.narrowerPause,
+                          )}
+                    </span>
+                  </button>
+                </ComposerTip>
               ))}
             </div>
           ) : null}
@@ -1453,29 +1520,28 @@ function AttachmentChips({
             )}
             <div className="min-w-0 flex-1">
               <div className="truncate font-medium text-og-fg">{attachment.name}</div>
-              <div
-                className={cn(
-                  "truncate text-og-xs",
-                  failed ? "text-og-status-failed" : "text-og-fg-subtle",
-                )}
-                title={failed ? statusText : undefined}
-              >
-                {statusText}
-              </div>
+              {failed ? (
+                <ComposerTip tip={statusText}>
+                  <div className="truncate text-og-xs text-og-status-failed">{statusText}</div>
+                </ComposerTip>
+              ) : (
+                <div className="truncate text-og-xs text-og-fg-subtle">{statusText}</div>
+              )}
             </div>
             {attachment.status === "uploading" ? (
               <LoaderCircleIcon className="size-3.5 shrink-0 animate-og-spin" />
             ) : null}
             {failed && onRetry ? (
-              <button
-                type="button"
-                onClick={() => onRetry(attachment.id)}
-                className="shrink-0 rounded-og-xs p-1 text-og-fg-muted hover:bg-og-surface-1 hover:text-og-fg pointer-coarse:size-10"
-                aria-label={messages.retryAttachment(attachment.name)}
-                title={messages.retryUpload}
-              >
-                <RotateCwIcon className="size-3.5" />
-              </button>
+              <ComposerTip tip={messages.retryUpload}>
+                <button
+                  type="button"
+                  onClick={() => onRetry(attachment.id)}
+                  className="shrink-0 rounded-og-xs p-1 text-og-fg-muted hover:bg-og-surface-1 hover:text-og-fg pointer-coarse:size-10"
+                  aria-label={messages.retryAttachment(attachment.name)}
+                >
+                  <RotateCwIcon className="size-3.5" />
+                </button>
+              </ComposerTip>
             ) : null}
             <button
               type="button"

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -50,6 +50,7 @@ import type { PickerModelRow } from "../model-policy";
 import { OPEN_WORKSTREAM_CONTROL_EVENT } from "../workstream-control-event";
 import { CommandPalette as CommandPaletteView } from "./command-palette";
 import { ModelPicker as ModelPickerView } from "./model-picker";
+import { TooltipProvider } from "./tooltip";
 
 export { OPEN_WORKSTREAM_CONTROL_EVENT };
 
@@ -689,18 +690,23 @@ export const Root = forwardRef<HTMLDivElement, ComposerRootProps>(function Compo
   { controller, children, className, style, ...props },
   forwardedRef,
 ) {
+  // Provider stays on Root so optional Radix tip surfaces (voice input) work.
+  // Ordinary composer actions use native `title` via ComposerTip to avoid
+  // pulling Popper into every tip hotspot.
   return (
     <ComposerContext.Provider value={controller}>
-      <div
-        {...props}
-        ref={mergeRefs(controller.rootRef, forwardedRef)}
-        data-og-composer-id={controller.id}
-        className={cn("og-root", className)}
-        style={{ paddingBottom: "env(safe-area-inset-bottom)", ...style }}
-      >
-        {children}
-        <ComposerAnnouncements />
-      </div>
+      <TooltipProvider delayDuration={300}>
+        <div
+          {...props}
+          ref={mergeRefs(controller.rootRef, forwardedRef)}
+          data-og-composer-id={controller.id}
+          className={cn("og-root", className)}
+          style={{ paddingBottom: "env(safe-area-inset-bottom)", ...style }}
+        >
+          {children}
+          <ComposerAnnouncements />
+        </div>
+      </TooltipProvider>
     </ComposerContext.Provider>
   );
 });

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -53,7 +53,13 @@ import { ModelPicker as ModelPickerView } from "./model-picker";
 
 export { OPEN_WORKSTREAM_CONTROL_EVENT };
 
-function ComposerTip({ tip, children }: { tip: string; children: ReactElement }) {
+function ComposerTip({
+  tip,
+  children,
+}: {
+  tip: string;
+  children: ReactElement<{ title?: string }>;
+}) {
   if (!tip) return children;
   return cloneElement(children, { title: tip });
 }

--- a/packages/react/src/components/copy-button.tsx
+++ b/packages/react/src/components/copy-button.tsx
@@ -14,7 +14,7 @@ export type CopyButtonProps = {
   className?: string | undefined;
   /**
    * `always` — visible control.
-   * `group-hover` — parent must use `group/copy`; fades in on hover/focus.
+   * `group-hover` — parent must use `group/copy`; fades in on hover/focus-visible.
    */
   reveal?: "always" | "group-hover" | undefined;
 };
@@ -30,6 +30,7 @@ export function CopyButton({
   reveal = "group-hover",
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
+  const [tipOpen, setTipOpen] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -49,19 +50,34 @@ export function CopyButton({
       return;
     }
     setCopied(true);
+    setTipOpen(true);
+    // Pointer activation focuses the button and leaves `group-focus-within`
+    // stuck after the cursor leaves — chrome never "unhovers". Keyboard
+    // activation (`detail === 0`) keeps focus for a11y.
+    if (event.detail > 0) {
+      event.currentTarget.blur();
+    }
     if (timerRef.current !== null) {
       clearTimeout(timerRef.current);
     }
     timerRef.current = setTimeout(() => {
       timerRef.current = null;
       setCopied(false);
+      setTipOpen(false);
     }, COPIED_MS);
   };
 
   const tip = copied ? "Copied" : label;
 
   return (
-    <Tooltip>
+    <Tooltip
+      open={copied ? true : tipOpen}
+      onOpenChange={(next) => {
+        if (!copied) {
+          setTipOpen(next);
+        }
+      }}
+    >
       <TooltipTrigger asChild>
         <button
           type="button"
@@ -99,28 +115,31 @@ export function CopyHoverFrame({
   copyText,
   label,
   align = "end",
+  trailing,
 }: {
   children: ReactNode;
   className?: string | undefined;
   copyText: string;
   label: string;
   align?: "start" | "end" | undefined;
+  /** Optional footer meta (e.g. sent/finished clock) — immediately after the copy control. */
+  trailing?: ReactNode | undefined;
 }) {
   if (copyText.trim().length === 0) {
     return <div className={className}>{children}</div>;
   }
   return (
-    <div className={cn("group/copy relative", className)}>
+    <div className={cn("group/copy", className)}>
       {children}
+      {/* Sit under the body — top-right overlay collided with the first line. */}
       <div
         className={cn(
-          "pointer-events-none absolute top-1 z-10",
-          align === "end" ? "right-1" : "left-1",
+          "mt-1 flex h-7 items-center gap-1.5",
+          align === "end" ? "justify-end" : "justify-start",
         )}
       >
-        <div className="pointer-events-auto">
-          <CopyButton text={copyText} label={label} reveal="group-hover" />
-        </div>
+        <CopyButton text={copyText} label={label} reveal="group-hover" />
+        {trailing}
       </div>
     </div>
   );

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -41,6 +41,7 @@ import {
   tipFollowCancel,
   tipFollowCompensateShrink,
   tipFollowStep,
+  supportsScrollEndEvent,
   TIP_FOLLOW_READER_UP_EPS_PX,
   TIP_FOLLOW_SHRINK_EPS_PX,
   type TipFollowState,
@@ -163,8 +164,11 @@ export type MessageTimelineProps = {
  *   tip-glued feed-forward — that is the one-line yank).
  * - One continuous follow while hot (faster τ when behind); sleeps when cold.
  * - While pinned, tip-debt from growth/collapse must NEVER unpin — only
- *   wheel/keys/pointer-armed scroll-up. Height shrink compensates scrollTop
- *   by Δh (collapse owns motion); tip-ease pauses briefly so the two don't fight.
+ *   wheel/keys/pointer-armed scroll-up, or a settled scrollend away from the
+ *   tip while the tip-follow camera is idle (Vimium / unfocused PageUp).
+ *   Height shrink compensates scrollTop by Δh (collapse owns motion); tip-ease
+ *   pauses briefly so the two don't fight. Programmatic camera writes are
+ *   tagged so their scroll echoes never count as leave.
  * - overflow-anchor off while pinned so the browser cannot instant-correct.
  * - Scrolled up → history prepends restore via the retained group anchor
  *   (offsetTop delta); loadOlder can truncate the tip, so scrollHeight delta
@@ -327,11 +331,24 @@ export function MessageTimeline({
   const lastScrollHeightRef = useRef(0);
   const lastClientHeightRef = useRef(0);
   /**
-   * Armed by pointerdown on the scroller. Geometric scroll-up only unpins
-   * while armed — mid-turn fold+growth also drops scrollTop with a flat
-   * maxScroll and must NOT count as leave. Wheel/keys unpin directly.
+   * Armed by pointerdown on the scroller. Immediate geometric scroll-up unpins
+   * while armed (scrollbar / touch drag). Wheel/keys unpin directly. Extension
+   * jumps (Vimium) settle via scrollend while the camera is idle.
    */
   const readerIntentArmRef = useRef(false);
+  /**
+   * Count of camera/snap scrollTop writes whose scroll echoes are not yet
+   * consumed. A boolean was wrong when the browser coalesced two writes into
+   * one scroll event (or fired two) — use a count, and clear to 0 on echo.
+   */
+  const programmaticScrollRef = useRef(0);
+  /**
+   * Unarmed scroll-away observed; waiting for scrollend (or rAF fallback).
+   * Blocks layout tip-follow so a stream token cannot yank before leave settles.
+   */
+  const pendingReaderLeaveRef = useRef(false);
+  /** Fallback leave check when `scrollend` is missing (one rAF, not a timer). */
+  const leaveFallbackRafRef = useRef<number | null>(null);
   // Resting fold state per durable group id (see fold-memory.ts). Outlives the
   // deliberate chip remounts (activity→turn wrap, nested key flips) so a fold
   // that already settled closed — or that the reader closed — never reopens.
@@ -371,6 +388,27 @@ export function MessageTimeline({
     lastClientHeightRef.current = node.clientHeight;
   }, []);
 
+  const writeScrollTop = useCallback((node: HTMLElement, top: number) => {
+    const next = Math.max(0, top);
+    if (node.scrollTop === next) {
+      return;
+    }
+    programmaticScrollRef.current += 1;
+    node.scrollTop = next;
+  }, []);
+
+  const cancelLeaveFallback = useCallback(() => {
+    if (leaveFallbackRafRef.current !== null) {
+      cancelFrame(leaveFallbackRafRef.current);
+      leaveFallbackRafRef.current = null;
+    }
+  }, []);
+
+  const clearPendingReaderLeave = useCallback(() => {
+    pendingReaderLeaveRef.current = false;
+    cancelLeaveFallback();
+  }, [cancelLeaveFallback]);
+
   const stopFollow = useCallback(() => {
     followRef.current = tipFollowCancel(followRef.current);
     if (followFrameRef.current !== null) {
@@ -379,7 +417,7 @@ export function MessageTimeline({
     }
   }, []);
 
-  /** Reader left the tip — wheel, keyboard, or pointer-armed scroll-up. */
+  /** Reader left the tip — wheel, keyboard, pointer-armed scroll-up, or scrollend. */
   const releasePinFromReader = useCallback(
     (node?: HTMLElement | null) => {
       if (!autoFollow || !pinnedRef.current || hasNewerRef.current) {
@@ -390,6 +428,7 @@ export function MessageTimeline({
         return;
       }
       readerIntentArmRef.current = false;
+      clearPendingReaderLeave();
       stopFollow();
       applyPinned(false);
       if (wantPinRef.current) {
@@ -400,8 +439,50 @@ export function MessageTimeline({
         setOlderPrefetchArmed(true);
       }
     },
-    [autoFollow, applyPinned, stopFollow],
+    [autoFollow, applyPinned, clearPendingReaderLeave, stopFollow],
   );
+
+  /**
+   * Settled away from the tip while the camera is idle — Vimium / unfocused
+   * PageUp. Folds are recovered by layout tip-follow before this fires at tip.
+   */
+  const releasePinAfterScrollSettled = useCallback(
+    (node: HTMLElement) => {
+      if (!autoFollow || !pinnedRef.current || hasNewerRef.current) {
+        return;
+      }
+      if (programmaticScrollRef.current > 0) {
+        return;
+      }
+      if (followRef.current.running || followFrameRef.current !== null) {
+        return;
+      }
+      if (isNearBottom(node) || maxScrollOf(node) <= 1) {
+        clearPendingReaderLeave();
+        return;
+      }
+      releasePinFromReader(node);
+      if (olderLoadGateRef.current === "cooling" && node.scrollTop > OLDER_PREFETCH_MARGIN_PX) {
+        olderLoadGateRef.current = "armed";
+      }
+    },
+    [autoFollow, clearPendingReaderLeave, releasePinFromReader],
+  );
+
+  const scheduleLeaveFallback = useCallback(() => {
+    // Prefer scrollend when the engine supports it.
+    if (supportsScrollEndEvent()) {
+      return;
+    }
+    cancelLeaveFallback();
+    leaveFallbackRafRef.current = requestFrame(() => {
+      leaveFallbackRafRef.current = null;
+      const current = scrollRef.current;
+      if (current) {
+        releasePinAfterScrollSettled(current);
+      }
+    });
+  }, [cancelLeaveFallback, releasePinAfterScrollSettled]);
 
   const onWheel = (event: {
     deltaY: number;
@@ -457,14 +538,15 @@ export function MessageTimeline({
   const snapToBottom = useCallback(
     (node: HTMLElement) => {
       stopFollow();
-      node.scrollTop = Math.max(0, node.scrollHeight - node.clientHeight);
+      cancelLeaveFallback();
+      writeScrollTop(node, Math.max(0, node.scrollHeight - node.clientHeight));
       syncScrollBaseline(node);
       followRef.current = {
         ...followRef.current,
         lastHeight: node.scrollHeight,
       };
     },
-    [stopFollow, syncScrollBaseline],
+    [cancelLeaveFallback, stopFollow, syncScrollBaseline, writeScrollTop],
   );
 
   const driveFollowRef = useRef<(node: HTMLElement, now?: number) => void>(() => undefined);
@@ -474,6 +556,12 @@ export function MessageTimeline({
         stopFollow();
         return;
       }
+      // Reader/extension leave in flight — do not yank back before scrollend.
+      if (pendingReaderLeaveRef.current) {
+        stopFollow();
+        return;
+      }
+      cancelLeaveFallback();
       // Prefer the rAF timestamp so ease integrates against vsync (and tests
       // can advance a synthetic clock via requestAnimationFrame callbacks).
       const now =
@@ -495,9 +583,7 @@ export function MessageTimeline({
           node.scrollHeight,
           node.clientHeight,
         );
-        if (node.scrollTop !== nextTop) {
-          node.scrollTop = nextTop;
-        }
+        writeScrollTop(node, nextTop);
         syncScrollBaseline(node);
         followRef.current = {
           ...followRef.current,
@@ -533,11 +619,10 @@ export function MessageTimeline({
         revealed: revealedRef.current,
       });
       followRef.current = result.state;
-      if (node.scrollTop !== result.scrollTop) {
-        node.scrollTop = result.scrollTop;
-      }
+      writeScrollTop(node, result.scrollTop);
       syncScrollBaseline(node);
       if (result.state.running) {
+        cancelLeaveFallback();
         if (followFrameRef.current === null) {
           followFrameRef.current = requestFrame((frameNow) => {
             followFrameRef.current = null;
@@ -552,11 +637,12 @@ export function MessageTimeline({
         followFrameRef.current = null;
       }
     },
-    [stopFollow, syncScrollBaseline],
+    [cancelLeaveFallback, stopFollow, syncScrollBaseline, writeScrollTop],
   );
   driveFollowRef.current = driveFollow;
 
   useEffect(() => stopFollow, [stopFollow]);
+  useEffect(() => () => cancelLeaveFallback(), [cancelLeaveFallback]);
 
   // The single post-commit scroll authority. Runs after EVERY commit (no dep
   // list): any commit may change content height, and the decision is cheap.
@@ -580,7 +666,7 @@ export function MessageTimeline({
       // prepend correction (it would shift the reader away from the top).
       pendingJumpToStartRef.current = false;
       stopFollow();
-      node.scrollTop = 0;
+      writeScrollTop(node, 0);
     } else if (wantPinRef.current && !hasNewer) {
       // Jump-to-latest was pressed on a history window and the tip window is
       // in THIS commit — consume pre-paint so the first tip frame is already
@@ -592,8 +678,15 @@ export function MessageTimeline({
       }
     } else if (autoFollow && pinnedRef.current && !hasNewer) {
       // Load/remount (still hidden): hard-park. Live tip after reveal: ease.
+      // Pending unarmed leave: tip *growth* must not yank (Vimium during stream).
+      // Flat/shrink commits (fold) still recover — height did not grow under us.
       if (!revealedRef.current) {
         snapToBottom(node);
+      } else if (pendingReaderLeaveRef.current) {
+        if (node.scrollHeight <= lastScrollHeightRef.current) {
+          clearPendingReaderLeave();
+          driveFollow(node);
+        }
       } else {
         driveFollow(node);
       }
@@ -628,7 +721,7 @@ export function MessageTimeline({
       if (delta !== null) {
         const expected = previousScrollTop + delta;
         if (Math.abs(node.scrollTop - expected) > 2) {
-          node.scrollTop = expected;
+          writeScrollTop(node, expected);
         }
       }
     }
@@ -885,9 +978,9 @@ export function MessageTimeline({
     }
   }, [hasNewer, autoFollow, applyPinned, snapToBottom, stopFollow]);
 
-  // Unpin: wheel / keys always; pointer-armed geometric scroll-up only.
-  // Mid-turn fold + narration drops scrollTop while maxScroll stays flat —
-  // treating that as reader-up was the Jump-to-latest bug on soft-follow.
+  // Pinned: layout/camera recover tip debt; wheel/keys/pointer-arm unpin
+  // immediately; extension jumps settle via scrollend (or one-rAF fallback).
+  // Do not tip-follow-yank an in-flight unarmed scroll-away — that ate Vimium.
   const onScroll = () => {
     const node = scrollRef.current;
     if (!node) {
@@ -904,17 +997,34 @@ export function MessageTimeline({
     const heightShrunk =
       followRef.current.lastHeight > 0 &&
       nextHeight < followRef.current.lastHeight - TIP_FOLLOW_SHRINK_EPS_PX;
+    // Consume all pending camera-write echoes (browsers may coalesce writes).
+    const programmatic = programmaticScrollRef.current > 0;
+    if (programmatic) {
+      programmaticScrollRef.current = 0;
+    }
 
     if (autoFollow && pinnedRef.current && !hasNewer) {
       // Fold / composer shrink: compensate before baseline sync so driveFollow
       // still sees the pre-shrink scrollTop (avoid double-subtract after clamp).
       if (heightShrunk || maxFell) {
         readerIntentArmRef.current = false;
+        clearPendingReaderLeave();
         driveFollow(node);
+        return;
+      }
+      if (programmatic) {
+        syncScrollBaseline(node);
+        followRef.current = {
+          ...followRef.current,
+          lastHeight: nextHeight,
+        };
         return;
       }
       syncScrollBaseline(node);
       const nearBottomPinned = isNearBottom(node);
+      if (nearBottomPinned) {
+        clearPendingReaderLeave();
+      }
       // Pointer-dragged scroll-up away from tip. Layout churn never arms this.
       if (readerArmed && readerUp > TIP_FOLLOW_READER_UP_EPS_PX && !nearBottomPinned) {
         readerIntentArmRef.current = false;
@@ -924,9 +1034,15 @@ export function MessageTimeline({
         }
         return;
       }
-      // Growth debt / fold noise / camera echo: stay pinned and recover tip.
-      if (!nearBottomPinned || readerUp > TIP_FOLLOW_READER_UP_EPS_PX) {
-        driveFollow(node);
+      // Tip grew under a still viewport (no reader-up): ease back to the tip.
+      // Reader/extension scroll-up in progress: do not yank — scrollend decides.
+      if (!nearBottomPinned && readerUp <= TIP_FOLLOW_READER_UP_EPS_PX) {
+        if (!pendingReaderLeaveRef.current) {
+          driveFollow(node);
+        }
+      } else if (!nearBottomPinned && readerUp > TIP_FOLLOW_READER_UP_EPS_PX) {
+        pendingReaderLeaveRef.current = true;
+        scheduleLeaveFallback();
       } else {
         followRef.current = {
           ...followRef.current,
@@ -969,6 +1085,20 @@ export function MessageTimeline({
     }
   };
 
+  const onScrollEnd = () => {
+    const node = scrollRef.current;
+    if (!node) {
+      return;
+    }
+    cancelLeaveFallback();
+    if (programmaticScrollRef.current > 0) {
+      programmaticScrollRef.current = 0;
+      syncScrollBaseline(node);
+      return;
+    }
+    releasePinAfterScrollSettled(node);
+  };
+
   return (
     <LightboxProvider>
       <FoldMemoryProvider value={foldMemoryRef.current}>
@@ -982,6 +1112,7 @@ export function MessageTimeline({
                   ref={scrollRef}
                   tabIndex={-1}
                   onScroll={onScroll}
+                  onScrollEnd={onScrollEnd}
                   onWheel={onWheel}
                   onPointerDown={onPointerDown}
                   onKeyDown={onKeyDown}

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -32,7 +32,7 @@ import {
   type ReactNode,
 } from "react";
 import { cn } from "../lib/cn";
-import { formatRelativeTime, truncate } from "../lib/format";
+import { formatClockTime, formatRelativeTime, truncate } from "../lib/format";
 import { prefersReducedMotion } from "../lib/motion";
 import { Markdown } from "./markdown";
 import {
@@ -158,7 +158,8 @@ export type MessageTimelineProps = {
  * replaces was the "content is hidden, then pops in in batches" wobble.)
  *
  * Scroll invariant (tip-follow camera — see `./tip-follow.ts`):
- * - DOM truth mounts immediately; the camera eases down to the tip (not
+ * - Load/remount: hidden until tip is hard-snapped across a short settle; then
+ *   reveal. Live tip: DOM grows immediately; the camera eases down (not
  *   tip-glued feed-forward — that is the one-line yank).
  * - One continuous follow while hot (faster τ when behind); sleeps when cold.
  * - While pinned, tip-debt from growth/collapse must NEVER unpin — only
@@ -288,9 +289,10 @@ export function MessageTimeline({
   const olderLoadGateRef = useRef<"armed" | "cooling">("armed");
   const resizeFollowRafRef = useRef<number | null>(null);
   const firstGroupKey = allGroups[0] ? timelineGroupKey(allGroups[0]) : null;
-  // Content stays invisible until its first bottom-anchored frame, so a flash
-  // of the window's TOP while a large timeline lays out is structurally
-  // impossible — the reader only ever sees it already at the bottom.
+  // Content stays invisible until the tip is hard-parked across a short
+  // post-commit settle (two rAFs). That absorbs sync late layout while hidden
+  // so load/remount does not ease into the tip — live tip-follow is unchanged
+  // once revealed. A flash of the window's TOP is still structurally impossible.
   const [revealed, setRevealed] = useState(false);
   // Mirror `pinned` into a ref, written ONLY by applyPinned, so the
   // ResizeObserver rAF (a stable closure) reads the live value and a snap can
@@ -589,8 +591,12 @@ export function MessageTimeline({
         snapToBottom(node);
       }
     } else if (autoFollow && pinnedRef.current && !hasNewer) {
-      // Live tip: tip-follow camera eases down (snap only first paint / jumps).
-      driveFollow(node);
+      // Load/remount (still hidden): hard-park. Live tip after reveal: ease.
+      if (!revealedRef.current) {
+        snapToBottom(node);
+      } else {
+        driveFollow(node);
+      }
     } else if (prepended) {
       // Keep the reader on the same retained rows. Prefer the offsetTop delta
       // of the group that still holds the previous first item — that stays
@@ -661,10 +667,45 @@ export function MessageTimeline({
       }
       groupOffsetByKeyRef.current = nextOffsetByKey;
     }
-    if (!revealed && groups.length > 0) {
-      setRevealed(true);
-    }
   });
+
+  // First paint / session remount: keep the scroller hidden, snap to tip for
+  // two animation frames (late sync layout), then reveal. Does not change the
+  // tip-follow ease law used once `revealed` is true.
+  useLayoutEffect(() => {
+    if (revealed || allGroups.length === 0) {
+      return;
+    }
+    let cancelled = false;
+    let frame2 = 0;
+    const park = () => {
+      const node = scrollRef.current;
+      if (node && autoFollow && pinnedRef.current && !hasNewerRef.current) {
+        snapToBottom(node);
+      }
+    };
+    park();
+    const frame1 = requestFrame(() => {
+      if (cancelled) {
+        return;
+      }
+      park();
+      frame2 = requestFrame(() => {
+        if (cancelled) {
+          return;
+        }
+        park();
+        setRevealed(true);
+      });
+    });
+    return () => {
+      cancelled = true;
+      cancelFrame(frame1);
+      if (frame2 !== 0) {
+        cancelFrame(frame2);
+      }
+    };
+  }, [revealed, allGroups.length, autoFollow, snapToBottom]);
 
   // A cleared timeline (stream identity change) re-arms the reveal + prefetch
   // gate and returns to bottom-follow for the next session's first paint.
@@ -792,9 +833,15 @@ export function MessageTimeline({
         if (!current) {
           return;
         }
-        if (autoFollow && pinnedRef.current && !hasNewerRef.current) {
-          driveFollow(current);
+        if (!autoFollow || !pinnedRef.current || hasNewerRef.current) {
+          return;
         }
+        // Still unveiling the first tip frame: hard-park (no ease settle).
+        if (!revealedRef.current) {
+          snapToBottom(current);
+          return;
+        }
+        driveFollow(current);
       });
     });
     observer.observe(inner);
@@ -808,7 +855,7 @@ export function MessageTimeline({
         resizeFollowRafRef.current = null;
       }
     };
-  }, [autoFollow, driveFollow]);
+  }, [autoFollow, driveFollow, snapToBottom]);
 
   // Entering a non-tip history window: drop any live pin so the page bottom
   // cannot re-stick follow across loadNewer. Leaving it (the tip window
@@ -1787,6 +1834,22 @@ function compactionSkipSubtitle(reason: string | null): string {
   }
 }
 
+/** Hover-reveal clock beside the copy control (sent / finished). */
+function MessageFooterTime({ occurredAt }: { occurredAt: string }) {
+  return (
+    <time
+      dateTime={occurredAt}
+      className={cn(
+        "shrink-0 tabular-nums text-og-xs text-og-fg-subtle",
+        "opacity-0 transition-opacity duration-150",
+        "group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 pointer-coarse:opacity-70",
+      )}
+    >
+      {formatClockTime(occurredAt)}
+    </time>
+  );
+}
+
 function UserMessageRow({
   item,
   renderMessageText,
@@ -1804,6 +1867,7 @@ function UserMessageRow({
           copyText={item.text}
           label="Copy message"
           className="w-fit max-w-full min-w-0"
+          trailing={<MessageFooterTime occurredAt={item.occurredAt} />}
         >
           <div className="w-fit max-w-full min-w-0 rounded-og-lg rounded-br-og-xs border border-og-border bg-og-surface-2 px-4 py-2.5 text-og-md leading-6 text-og-fg">
             {renderMessageText ? (
@@ -1835,13 +1899,15 @@ function AgentMessageRow({
   ) : (
     <Markdown streaming={item.streaming}>{item.text}</Markdown>
   );
-  // While streaming, copy is still useful (current text) but keep chrome calm.
+  // While streaming, copy is still useful (current text) but keep chrome calm —
+  // stamp only after the message finishes (occurredAt tracks completion).
   return (
     <CopyHoverFrame
       copyText={item.text}
       label="Copy message"
-      align="end"
+      align="start"
       className={cn(enter && "animate-og-enter", "min-w-0 text-og-md leading-7 text-og-fg")}
+      trailing={item.streaming ? null : <MessageFooterTime occurredAt={item.occurredAt} />}
     >
       {body}
     </CopyHoverFrame>

--- a/packages/react/src/components/tip-follow.ts
+++ b/packages/react/src/components/tip-follow.ts
@@ -81,6 +81,21 @@ export const TIP_FOLLOW_VELOCITY_ARM_DEBT_PX = 72;
 export const TIP_FOLLOW_VELOCITY_DECAY_MS = _t(180);
 /** Reader-up pixels above clamp budget that count as leaving the tip. */
 export const TIP_FOLLOW_READER_UP_EPS_PX = 2;
+
+/** Test-only override for scrollend feature detection (`null` = probe DOM). */
+let scrollEndSupportOverride: boolean | null = null;
+
+/** @internal */ export function setScrollEndSupportForTests(value: boolean | null): void {
+  scrollEndSupportOverride = value;
+}
+
+/** True when the engine exposes element `scrollend` (prefer over rAF leave). */
+export function supportsScrollEndEvent(): boolean {
+  if (scrollEndSupportOverride !== null) {
+    return scrollEndSupportOverride;
+  }
+  return typeof HTMLElement !== "undefined" && "onscrollend" in HTMLElement.prototype;
+}
 /** @deprecated Shrink lock removed; kept so old imports do not break. */
 export const TIP_FOLLOW_SHRINK_LOCK_MS = 0;
 /** @deprecated Absorb thresholds removed — growth track is continuous. */

--- a/packages/react/src/composer.ts
+++ b/packages/react/src/composer.ts
@@ -3,6 +3,7 @@
  *
  * `import * as Composer from "@opengeni/react/composer"`.
  */
+export { OPEN_WORKSTREAM_CONTROL_EVENT } from "./workstream-control-event";
 export {
   Actions,
   AttachButton,
@@ -16,7 +17,6 @@ export {
   Hint,
   Input,
   ModelPicker,
-  OPEN_WORKSTREAM_CONTROL_EVENT,
   PauseButton,
   PausedState,
   RestoredResources,

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -420,7 +420,13 @@ export function useComposer(
         localSignatureAtStart === null
           ? localAtStart !== 0
           : localSignatureAtStart !== lastSavedSignature.current;
-      setDraftLoading(true);
+      // Only blank the picker on first hydrate / hard reload. Reconcile and
+      // event-triggered soft reloads (loadOlder SSE reconnect) must not flicker
+      // draftLoading — stale-while-revalidate keeps the settled UI mounted.
+      const showLoading = replaceLocal || draftRef.current === null;
+      if (showLoading) {
+        setDraftLoading(true);
+      }
       try {
         const fetched = await client.getComposerDraft(workspaceId, sessionId);
         if (

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -100,7 +100,7 @@ export type {
   SessionChromeSignalTone,
 } from "./components/session-chrome";
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./components/tooltip";
-export { OPEN_WORKSTREAM_CONTROL_EVENT } from "./components/chat-composer";
+export { OPEN_WORKSTREAM_CONTROL_EVENT } from "./workstream-control-event";
 export { useGoal, isGoalEvent } from "./hooks/use-goal";
 export type { UseGoalOptions, UseGoalResult } from "./hooks/use-goal";
 export { useSessionControl } from "./hooks/use-session-control";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -486,6 +486,7 @@ export { cn } from "./lib/cn";
 export {
   CREDIT_EXHAUSTION_MESSAGE,
   formatBytes,
+  formatClockTime,
   formatRelativeTime,
   humanizeFailureReason,
   isCreditExhaustion,

--- a/packages/react/src/lib/format.ts
+++ b/packages/react/src/lib/format.ts
@@ -1,5 +1,19 @@
 import { OpenGeniApiError } from "@opengeni/sdk";
 
+/** Local finished-at stamp for message footers: "Aug 2, 3:42 PM" / locale-equivalent. */
+export function formatClockTime(iso: string): string {
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) {
+    return "";
+  }
+  return then.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
 /** Compact relative time: "now", "42s", "7m", "3h", "2d", then a date. */
 export function formatRelativeTime(iso: string, now: Date = new Date()): string {
   const then = new Date(iso).getTime();

--- a/packages/react/src/timeline/index.ts
+++ b/packages/react/src/timeline/index.ts
@@ -22,7 +22,9 @@ export {
   extractSessionRef,
   groupTimeline,
   sessionStatusFromEvents,
+  mcpToolLeaf,
   toolDisplayName,
+  toolMatchesLeaf,
 } from "./projection";
 
 // item types

--- a/packages/react/src/timeline/parsers.ts
+++ b/packages/react/src/timeline/parsers.ts
@@ -227,6 +227,19 @@ export function applyPatchOps(raw: unknown): ApplyPatchOperation[] {
   return r.operation ? [r.operation] : [];
 }
 
+/** Ops from provider `raw`, or from function-tool arguments when raw is empty. */
+export function applyPatchOpsFromToolItem(item: {
+  raw: unknown;
+  arguments: unknown;
+}): ApplyPatchOperation[] {
+  const fromRaw = applyPatchOps(item.raw);
+  if (fromRaw.length > 0) {
+    return fromRaw;
+  }
+  const args = parseToolArgs(item.arguments);
+  return applyPatchOps(args);
+}
+
 /**
  * True when a tool item is an `apply_patch_call` — by its provider-native
  * `raw.type` (the live-wire source of truth) or by tool `name` (first-party
@@ -235,7 +248,11 @@ export function applyPatchOps(raw: unknown): ApplyPatchOperation[] {
 export function isApplyPatch(item: { name: string; raw: unknown }): boolean {
   const type =
     item.raw && typeof item.raw === "object" ? (item.raw as { type?: unknown }).type : undefined;
-  return type === "apply_patch_call" || item.name === "apply_patch_call";
+  if (type === "apply_patch_call") {
+    return true;
+  }
+  const name = item.name;
+  return name === "apply_patch_call" || name === "apply_patch" || name.endsWith("__apply_patch");
 }
 
 /* --- secret redaction ------------------------------------------------------- */

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -186,6 +186,9 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
             open.text = text || open.text;
           }
           open.streaming = false;
+          // Completion time is what the footer shows ("finished at"); keep the
+          // first-delta stamp only until this event arrives.
+          open.occurredAt = event.occurredAt;
           // The SDK can emit a hosted-tool item only after its provider-native
           // operation has completed, even though answer deltas were already
           // streamed. The completed message event is the durable ordering

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -6,6 +6,11 @@ import {
   isCreditExhaustion,
   tryParseJson,
 } from "../lib/format";
+import {
+  mcpToolLeaf,
+  toolDisplayName,
+  toolMatchesLeaf,
+} from "./tool-display-name";
 import type {
   AgentMessageItem,
   ActivityItem,
@@ -22,12 +27,8 @@ import type {
   ToolCallItem,
   WorkerItem,
 } from "./types";
-/** Readable label for a tool call, without leaking an MCP server prefix. */
-export function toolDisplayName(name: string): string {
-  const boundary = name.indexOf("__");
-  const toolPart = boundary >= 0 ? name.slice(boundary + 2) : name;
-  return toolPart.replace(/[_-]+/g, " ").trim();
-}
+
+export { toolDisplayName, mcpToolLeaf, toolMatchesLeaf } from "./tool-display-name";
 
 /* ----------------------------------------------------------------------------
    Timeline projection
@@ -43,9 +44,22 @@ export function toolDisplayName(name: string): string {
    memoized, unit-tested, and re-run incrementally as new events stream in.
    -------------------------------------------------------------------------- */
 
-/** Tool names on the first-party OpenGeni MCP server that operate on sessions. */
+/** Tool leaves on the first-party OpenGeni MCP server that operate on sessions. */
 const WORKER_SPAWN_TOOL = "session_create";
 const WORKER_MESSAGE_TOOL = "session_send_message";
+
+/**
+ * Tools whose durable side-effect events already own the timeline (GoalRow /
+ * MemoryRow). Emitting a generic tool-call too is double chrome — skip the call.
+ */
+const LANDMARK_ONLY_TOOL_LEAVES = new Set([
+  "goal_set",
+  "goal_update",
+  "goal_complete",
+  "goal_pause",
+  "memory_save",
+  "memory_correct",
+]);
 
 export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
   const items: TimelineItem[] = [];
@@ -240,18 +254,25 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
         const callId = typeof payload.id === "string" ? payload.id : null;
         const args = payload.arguments ?? null;
         closeStreamingTail();
-        if (name === WORKER_SPAWN_TOOL || name === WORKER_MESSAGE_TOOL) {
+        if (
+          toolMatchesLeaf(name, WORKER_SPAWN_TOOL) ||
+          toolMatchesLeaf(name, WORKER_MESSAGE_TOOL)
+        ) {
           items.push({
             kind: "worker",
             id: event.id,
             turnId,
             callId,
-            action: name === WORKER_SPAWN_TOOL ? "spawn" : "message",
+            action: toolMatchesLeaf(name, WORKER_SPAWN_TOOL) ? "spawn" : "message",
             prompt: workerPrompt(args),
             workerSessionId: extractSessionRef(args),
             status: "running",
             occurredAt: event.occurredAt,
           });
+          break;
+        }
+        if (LANDMARK_ONLY_TOOL_LEAVES.has(mcpToolLeaf(name))) {
+          // Goal/memory landmarks arrive as goal.* / memory.* events.
           break;
         }
         // Live Responses `web_search_call` events and the later SDK
@@ -1566,14 +1587,3 @@ export function extractSessionRef(value: unknown, depth = 0): string | null {
 function looksLikeId(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
 }
-
-/**
- * Readable label for a tool call ("session_create" -> "session create").
- *
- * MCP tools are namespaced `<serverId>__<toolName>` (see prefixedMcpToolName),
- * and for catalog-imported servers that serverId is an opaque slug+hash
- * ("mcp-integrations-sh-supabase-com-34ed9dcf1390-0i6tcf8"). De-slugging the
- * whole thing leaked that id into the timeline; strip the server prefix and show
- * just the tool ("list organizations"). Names without the `__` boundary (plain
- * built-ins like "session_create") are unaffected.
- */

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -45,17 +45,17 @@ const WORKER_SPAWN_TOOL = "session_create";
 const WORKER_MESSAGE_TOOL = "session_send_message";
 
 /**
- * Tools whose durable side-effect events already own the timeline (GoalRow /
- * MemoryRow). Emitting a generic tool-call too is double chrome — skip the call.
+ * Tools whose durable side-effect events already own the timeline (MemoryRow).
+ * Emitting a generic tool-call too is double chrome — skip the call.
+ *
+ * Goal tools are intentionally NOT landmark-only: an agent `goal_set` /
+ * `goal_update` / `goal_complete` / `goal_pause` stays an in-cluster tool row,
+ * and the matching `goal.*` session event is suppressed below when `actor` is
+ * `"agent"`. That keeps mid-turn goal tools from splitting the step rail with
+ * a breakaway GoalRow pill. Non-agent goal events (API, create-session,
+ * system auto-pause, continuations) still render as landmarks.
  */
-const LANDMARK_ONLY_TOOL_LEAVES = new Set([
-  "goal_set",
-  "goal_update",
-  "goal_complete",
-  "goal_pause",
-  "memory_save",
-  "memory_correct",
-]);
+const LANDMARK_ONLY_TOOL_LEAVES = new Set(["memory_save", "memory_correct"]);
 
 export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
   const items: TimelineItem[] = [];
@@ -659,6 +659,11 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       case "goal.resumed":
       case "goal.cleared":
       case "goal.continuation": {
+        // Agent tool mutations already appear as tool-call rows in the activity
+        // cluster. Re-emitting them as GoalRow landmarks splits "N steps" mid-turn.
+        if (shouldSuppressAgentGoalLandmark(event.type, payload)) {
+          break;
+        }
         items.push({
           kind: "goal",
           id: event.id,
@@ -1441,6 +1446,22 @@ function goalText(payload: Record<string, unknown>): string | null {
     return payload.prompt;
   }
   return null;
+}
+
+/**
+ * Agent-owned goal mutations already have an in-cluster tool row. Suppress the
+ * breakaway landmark for those only. `goal.completed` has no actor field today
+ * and is only emitted by the agent tool, so it is always suppressed. API /
+ * system / create-session / continuation landmarks stay visible.
+ */
+function shouldSuppressAgentGoalLandmark(type: string, payload: Record<string, unknown>): boolean {
+  if (type === "goal.completed") {
+    return true;
+  }
+  if (type === "goal.set" || type === "goal.updated" || type === "goal.paused") {
+    return payload.actor === "agent";
+  }
+  return false;
 }
 
 /**

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -6,11 +6,7 @@ import {
   isCreditExhaustion,
   tryParseJson,
 } from "../lib/format";
-import {
-  mcpToolLeaf,
-  toolDisplayName,
-  toolMatchesLeaf,
-} from "./tool-display-name";
+import { mcpToolLeaf, toolMatchesLeaf } from "./tool-display-name";
 import type {
   AgentMessageItem,
   ActivityItem,

--- a/packages/react/src/timeline/registry.ts
+++ b/packages/react/src/timeline/registry.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from "react";
+import { mcpToolLeaf } from "./tool-display-name";
 import type { ToolCallItem } from "./types";
 
 /* ----------------------------------------------------------------------------
@@ -11,7 +12,8 @@ import type { ToolCallItem } from "./types";
    Resolution order (most → least specific):
      1. exact match on `raw.type`        (e.g. "apply_patch_call", "computer_call")
      2. exact match on the tool `name`   (e.g. "exec_command", "web_search_call")
-     3. the registry's generic fallback
+     3. leaf match after MCP `__` prefix (e.g. opengeni__environment_set_variable)
+     4. the registry's generic fallback
 
    A consumer extends the defaults without forking by passing overrides to
    `createToolRegistry` — e.g. a custom renderer for their own MCP tool, or a
@@ -89,7 +91,18 @@ export function createToolRegistry(
         return byType;
       }
     }
-    return byName.get(item.name) ?? fallback;
+    const exact = byName.get(item.name);
+    if (exact) {
+      return exact;
+    }
+    const leaf = mcpToolLeaf(item.name);
+    if (leaf !== item.name) {
+      const byLeaf = byName.get(leaf);
+      if (byLeaf) {
+        return byLeaf;
+      }
+    }
+    return fallback;
   };
 
   return { resolve, fallback };

--- a/packages/react/src/timeline/shared.tsx
+++ b/packages/react/src/timeline/shared.tsx
@@ -1,6 +1,5 @@
 import { CameraIcon, CameraOffIcon, ChevronRightIcon } from "lucide-react";
 import { useState, type ReactNode } from "react";
-import { Collapsible } from "radix-ui";
 import { cn } from "../lib/cn";
 import { stringifyPayload } from "../lib/format";
 import { useForcedDefaultOpen } from "./disclosure-context";
@@ -207,35 +206,37 @@ export function ActivityDisclosure({
     );
   }
 
+  // Native disclosure (not radix-ui Collapsible): importing `radix-ui` from the
+  // timeline registry pulls Popper into the session share-graph and crashes
+  // lazy workspace settings (`createPopperScope is not a function`).
   return (
-    <Collapsible.Root open={open} onOpenChange={setOpen}>
-      <Collapsible.Trigger asChild>
-        <div
-          role="button"
-          tabIndex={0}
-          // Space/Enter activate a native button; Radix doesn't add this for a
-          // non-button asChild child, so we toggle here. preventDefault on Space
-          // stops the page from scrolling.
-          onKeyDown={(event) => {
-            if (event.key === "Enter" || event.key === " ") {
-              event.preventDefault();
-              setOpen((prev) => !prev);
-            }
-          }}
-          data-status={dataStatus}
-          className={cn(
-            rowClass,
-            "cursor-pointer outline-none hover:bg-og-surface-1 hover:text-og-fg",
-            "focus-visible:ring-2 focus-visible:ring-og-accent focus-visible:ring-offset-0",
-          )}
-        >
-          {inner}
+    <div>
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setOpen((prev) => !prev);
+          }
+        }}
+        data-status={dataStatus}
+        className={cn(
+          rowClass,
+          "cursor-pointer outline-none hover:bg-og-surface-1 hover:text-og-fg",
+          "focus-visible:ring-2 focus-visible:ring-og-accent focus-visible:ring-offset-0",
+        )}
+      >
+        {inner}
+      </div>
+      {open ? (
+        <div className="mb-2 ml-7 mt-1.5 flex flex-col gap-2 overflow-hidden animate-og-expand">
+          {children}
         </div>
-      </Collapsible.Trigger>
-      <Collapsible.Content className="overflow-hidden data-[state=closed]:animate-og-collapse data-[state=open]:animate-og-expand">
-        <div className="mb-2 ml-7 mt-1.5 flex flex-col gap-2">{children}</div>
-      </Collapsible.Content>
-    </Collapsible.Root>
+      ) : null}
+    </div>
   );
 }
 

--- a/packages/react/src/timeline/shared.tsx
+++ b/packages/react/src/timeline/shared.tsx
@@ -215,6 +215,7 @@ export function ActivityDisclosure({
         role="button"
         tabIndex={0}
         aria-expanded={open}
+        data-state={open ? "open" : "closed"}
         onClick={() => setOpen((prev) => !prev)}
         onKeyDown={(event) => {
           if (event.key === "Enter" || event.key === " ") {

--- a/packages/react/src/timeline/tool-display-name.ts
+++ b/packages/react/src/timeline/tool-display-name.ts
@@ -1,16 +1,35 @@
 /**
- * Readable label for a tool call ("session_create" -> "session create").
+ * MCP / first-party tool naming helpers.
  *
- * MCP tools are namespaced `<serverId>__<toolName>` (see prefixedMcpToolName),
- * and for catalog-imported servers that serverId is an opaque slug+hash.
- * De-slugging the whole thing leaked that id into the timeline; strip the
- * server prefix and show just the tool. Names without the `__` boundary (plain
- * built-ins like "session_create") are unaffected.
+ * Wire names are often `<serverId>__<toolName>` (see prefixedMcpToolName).
+ * Matching and titles must use the leaf tool name so `opengeni__session_create`
+ * and bare `session_create` resolve the same UI — without inventing previews
+ * from argument JSON.
+ */
+
+/** Leaf tool name after the first `__` server boundary (or the whole name). */
+export function mcpToolLeaf(name: string): string {
+  const boundary = name.indexOf("__");
+  return boundary >= 0 ? name.slice(boundary + 2) : name;
+}
+
+/**
+ * True when `wireName` is exactly `leaf` or ends with `__${leaf}` (MCP prefix).
+ * Does not treat arbitrary suffixes as matches — the leaf must be the full
+ * right-hand side after `__`.
+ */
+export function toolMatchesLeaf(wireName: string, leaf: string): boolean {
+  return wireName === leaf || wireName.endsWith(`__${leaf}`);
+}
+
+/**
+ * Readable label for a tool call ("session_create" / "opengeni__session_create"
+ * → "Session create"). Title-cases the first character of the leaf phrase.
  */
 export function toolDisplayName(name: string): string {
-  // The prefix is a single LEFT boundary (`registryId__toolName`), so split on
-  // the FIRST `__` — the tool name itself may contain `__` and must survive whole.
-  const boundary = name.indexOf("__");
-  const toolPart = boundary >= 0 ? name.slice(boundary + 2) : name;
-  return toolPart.replace(/[_-]+/g, " ").trim();
+  const phrase = mcpToolLeaf(name).replace(/[_-]+/g, " ").trim();
+  if (!phrase) {
+    return name;
+  }
+  return phrase.charAt(0).toUpperCase() + phrase.slice(1);
 }

--- a/packages/react/src/timeline/tool-renderers.tsx
+++ b/packages/react/src/timeline/tool-renderers.tsx
@@ -1078,8 +1078,8 @@ function DocsSearchRenderer({ item }: ToolRendererProps) {
     >
       {hits && hits.length > 0 ? (
         <ul className="grid gap-2">
-          {hits.slice(0, 8).map((hit, index) => (
-            <li key={`${hit.title}-${index}`} className="min-w-0">
+          {hits.slice(0, 8).map((hit) => (
+            <li key={`${hit.title}\u0000${hit.snippet}`} className="min-w-0">
               <div className="truncate text-og-sm font-medium text-og-fg">{hit.title}</div>
               {hit.snippet ? (
                 <div className="mt-0.5 line-clamp-2 text-og-xs text-og-fg-muted">{hit.snippet}</div>

--- a/packages/react/src/timeline/tool-renderers.tsx
+++ b/packages/react/src/timeline/tool-renderers.tsx
@@ -1266,6 +1266,9 @@ function GenericRenderer({ item }: ToolRendererProps) {
   const args = redactSecrets(parseToolArgs(item.arguments));
   const display = toolDisplayName(item.name);
   const icon = <GenericToolIcon name={item.name} />;
+  // Goal tools: surface the objective text on the collapsed row so the in-cluster
+  // tool replaces the old breakaway GoalRow pill without losing the gist.
+  const goalPreview = goalToolPreview(item.name, args);
 
   if (running) {
     return (
@@ -1274,7 +1277,7 @@ function GenericRenderer({ item }: ToolRendererProps) {
         iconTone="running"
         title={display}
         running
-        preview={<RunningPreview>Running…</RunningPreview>}
+        preview={goalPreview ?? <RunningPreview>Running…</RunningPreview>}
       >
         <PayloadBlock label="Arguments" value={args} />
       </ActivityDisclosure>
@@ -1306,12 +1309,39 @@ function GenericRenderer({ item }: ToolRendererProps) {
       iconTone="muted"
       title={display}
       cancelled={item.status === "cancelled"}
-      preview={item.status === "cancelled" ? undefined : "Done"}
+      preview={item.status === "cancelled" ? undefined : (goalPreview ?? "Done")}
     >
       <PayloadBlock label="Arguments" value={args} />
       <PayloadBlock label="Result" value={outText} />
     </ActivityDisclosure>
   );
+}
+
+function goalToolPreview(name: string, args: unknown): string | null {
+  const leaf = mcpToolLeaf(name);
+  if (
+    leaf !== "goal_set" &&
+    leaf !== "goal_update" &&
+    leaf !== "goal_complete" &&
+    leaf !== "goal_pause"
+  ) {
+    return null;
+  }
+  const record = args && typeof args === "object" ? (args as Record<string, unknown>) : null;
+  if (!record) {
+    return null;
+  }
+  const text =
+    typeof record.text === "string"
+      ? record.text
+      : typeof record.evidence === "string"
+        ? record.evidence
+        : typeof record.rationale === "string"
+          ? record.rationale
+          : typeof record.progressNote === "string"
+            ? record.progressNote
+            : null;
+  return text ? truncatePreview(text, 90) : null;
 }
 
 function truncatePreview(text: string, max: number): string {

--- a/packages/react/src/timeline/tool-renderers.tsx
+++ b/packages/react/src/timeline/tool-renderers.tsx
@@ -1,23 +1,35 @@
 import type { GitFileDiff } from "@opengeni/sdk";
 import {
+  BoxIcon,
+  BrainCircuitIcon,
+  CalendarClockIcon,
   CameraIcon,
   CameraOffIcon,
   FileDiffIcon,
+  FileSearchIcon,
+  FolderGitIcon,
   GlobeIcon,
   ImageIcon,
   KeyboardIcon,
   KeyRoundIcon,
   LockIcon,
+  MessagesSquareIcon,
+  MessageSquareIcon,
   MousePointer2Icon,
+  PanelsTopLeftIcon,
   PlugIcon,
   SearchIcon,
+  ServerCogIcon,
+  ServerIcon,
+  Share2Icon,
+  TargetIcon,
   TerminalIcon,
   WrenchIcon,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { stringifyPayload, tryParseJson } from "../lib/format";
 import {
-  applyPatchOps,
+  applyPatchOpsFromToolItem,
   controlCaret,
   execTruncated,
   isExecSessionLostBanner,
@@ -52,7 +64,7 @@ import {
   type DisclosureChip,
 } from "./shared";
 import { RawPatch, ToolDiff } from "./tool-diff";
-import { toolDisplayName } from "./tool-display-name";
+import { mcpToolLeaf, toolDisplayName } from "./tool-display-name";
 
 /* ----------------------------------------------------------------------------
    Per-tool renderers
@@ -318,7 +330,7 @@ function PathPreview({
 }
 
 function ApplyPatchRenderer({ item }: ToolRendererProps) {
-  const ops = applyPatchOps(item.raw);
+  const ops = applyPatchOpsFromToolItem(item);
   const failed = item.status === "failed";
   const cancelled = item.status === "cancelled";
   const running = item.status === "running";
@@ -1008,21 +1020,259 @@ function SecretSetRenderer({ item }: ToolRendererProps) {
   );
 }
 
-/* ---- generic fallback (first-party MCP, external MCP, unknown) ------------- */
+/* ---- docs / knowledge search ----------------------------------------------- */
 
-function GenericRenderer({ item }: ToolRendererProps) {
+function DocsSearchRenderer({ item }: ToolRendererProps) {
+  const args = parseToolArgs(item.arguments);
+  const query = typeof args.query === "string" ? args.query.trim() : "";
+  const title = query ? `Search “${truncatePreview(query, 48)}”` : toolDisplayName(item.name);
   const running = item.status === "running";
-  const args = redactSecrets(parseToolArgs(item.arguments));
-  const display = toolDisplayName(item.name);
 
   if (running) {
     return (
       <ActivityDisclosure
-        icon={<PlugIcon className={ICON_SIZE} />}
+        icon={<FileSearchIcon className={ICON_SIZE} />}
+        iconTone="running"
+        title={title}
+        running
+        preview={<RunningPreview>Searching…</RunningPreview>}
+      >
+        <PayloadBlock label="Arguments" value={redactSecrets(args)} />
+      </ActivityDisclosure>
+    );
+  }
+
+  const { text: outText, isError } = unwrapMcpOutput(item.output);
+  if ((isError || item.status === "failed") && item.status !== "cancelled") {
+    return (
+      <ActivityDisclosure
+        icon={<FileSearchIcon className={ICON_SIZE} />}
+        iconTone="failed"
+        title={title}
+        failed
+        preview={truncatePreview(outText, 80) || "Search failed"}
+      >
+        <PayloadBlock label="Arguments" value={redactSecrets(args)} />
+        <PayloadBlock label="Error" value={outText} failed />
+      </ActivityDisclosure>
+    );
+  }
+
+  const hits = parseSearchHits(outText);
+  const preview =
+    item.status === "cancelled"
+      ? undefined
+      : hits
+        ? hits.length === 0
+          ? "No hits"
+          : `${hits.length} hit${hits.length === 1 ? "" : "s"}`
+        : "Done";
+
+  return (
+    <ActivityDisclosure
+      icon={<FileSearchIcon className={ICON_SIZE} />}
+      iconTone="muted"
+      title={title}
+      cancelled={item.status === "cancelled"}
+      preview={preview}
+    >
+      {hits && hits.length > 0 ? (
+        <ul className="grid gap-2">
+          {hits.slice(0, 8).map((hit, index) => (
+            <li key={`${hit.title}-${index}`} className="min-w-0">
+              <div className="truncate text-og-sm font-medium text-og-fg">{hit.title}</div>
+              {hit.snippet ? (
+                <div className="mt-0.5 line-clamp-2 text-og-xs text-og-fg-muted">{hit.snippet}</div>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <PayloadBlock label="Arguments" value={redactSecrets(args)} />
+      <PayloadBlock label="Result" value={outText} />
+    </ActivityDisclosure>
+  );
+}
+
+/* ---- set_session_title / set_other_session_title --------------------------- */
+
+function SetSessionTitleRenderer({ item }: ToolRendererProps) {
+  const args = parseToolArgs(item.arguments);
+  const titleArg = typeof args.title === "string" ? args.title.trim() : "";
+  const display = toolDisplayName(item.name);
+  const previewTitle = titleArg ? truncatePreview(titleArg, 72) : "";
+  const icon = <MessagesSquareIcon className={ICON_SIZE} />;
+
+  if (item.status === "running") {
+    return (
+      <ActivityDisclosure
+        icon={icon}
         iconTone="running"
         title={display}
         running
-        preview={<RunningPreview>{compactArgs(args) || "running…"}</RunningPreview>}
+        preview={
+          previewTitle ? (
+            <RunningPreview>{previewTitle}</RunningPreview>
+          ) : (
+            <RunningPreview>Setting title…</RunningPreview>
+          )
+        }
+      >
+        <PayloadBlock label="Arguments" value={redactSecrets(args)} />
+      </ActivityDisclosure>
+    );
+  }
+
+  const { text: outText, isError } = unwrapMcpOutput(item.output);
+  if ((isError || item.status === "failed") && item.status !== "cancelled") {
+    return (
+      <ActivityDisclosure
+        icon={icon}
+        iconTone="failed"
+        title={display}
+        failed
+        preview={truncatePreview(outText, 80) || "Rename failed"}
+      >
+        <PayloadBlock label="Arguments" value={redactSecrets(args)} />
+        <PayloadBlock label="Error" value={outText} failed />
+      </ActivityDisclosure>
+    );
+  }
+
+  // Prefer the submitted title; fall back to a title field in the tool result.
+  let settledTitle = previewTitle;
+  if (!settledTitle) {
+    const parsed = tryParseJson(outText);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const fromResult = (parsed as { title?: unknown }).title;
+      if (typeof fromResult === "string" && fromResult.trim()) {
+        settledTitle = truncatePreview(fromResult.trim(), 72);
+      }
+    }
+  }
+
+  return (
+    <ActivityDisclosure
+      icon={icon}
+      iconTone="muted"
+      title={display}
+      cancelled={item.status === "cancelled"}
+      preview={item.status === "cancelled" ? undefined : settledTitle || undefined}
+    >
+      <PayloadBlock label="Arguments" value={redactSecrets(args)} />
+      {outText ? <PayloadBlock label="Result" value={outText} /> : null}
+    </ActivityDisclosure>
+  );
+}
+
+type SearchHit = { title: string; snippet: string };
+
+function parseSearchHits(outText: string): SearchHit[] | null {
+  const parsed = tryParseJson(outText);
+  if (parsed == null) {
+    return null;
+  }
+  const list = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === "object" && Array.isArray((parsed as { results?: unknown }).results)
+      ? ((parsed as { results: unknown[] }).results)
+      : parsed && typeof parsed === "object" && Array.isArray((parsed as { hits?: unknown }).hits)
+        ? ((parsed as { hits: unknown[] }).hits)
+        : null;
+  if (!list) {
+    return null;
+  }
+  return list.map((row) => {
+    const r = row && typeof row === "object" ? (row as Record<string, unknown>) : {};
+    const title =
+      (typeof r.title === "string" && r.title) ||
+      (typeof r.name === "string" && r.name) ||
+      (typeof r.documentTitle === "string" && r.documentTitle) ||
+      (typeof r.path === "string" && r.path) ||
+      (typeof r.id === "string" && r.id) ||
+      "Result";
+    const snippet =
+      (typeof r.snippet === "string" && r.snippet) ||
+      (typeof r.text === "string" && r.text) ||
+      (typeof r.content === "string" && r.content) ||
+      "";
+    return { title, snippet: truncatePreview(snippet, 160) };
+  });
+}
+
+/* ---- company memory propose (docs MCP) ------------------------------------- */
+
+function MemoryProposeRenderer({ item }: ToolRendererProps) {
+  const args = parseToolArgs(item.arguments);
+  const text = typeof args.text === "string" ? args.text.trim() : "";
+  const title = "Propose memory";
+  const running = item.status === "running";
+
+  if (running) {
+    return (
+      <ActivityDisclosure
+        icon={<BrainCircuitIcon className={ICON_SIZE} />}
+        iconTone="running"
+        title={title}
+        running
+        preview={<RunningPreview>Proposing…</RunningPreview>}
+      >
+        <PayloadBlock label="Arguments" value={redactSecrets(args)} />
+      </ActivityDisclosure>
+    );
+  }
+
+  const { text: outText, isError } = unwrapMcpOutput(item.output);
+  if ((isError || item.status === "failed") && item.status !== "cancelled") {
+    return (
+      <ActivityDisclosure
+        icon={<BrainCircuitIcon className={ICON_SIZE} />}
+        iconTone="failed"
+        title={title}
+        failed
+        preview={truncatePreview(outText, 80) || "Propose failed"}
+      >
+        {text ? <BodyNote>{text}</BodyNote> : null}
+        <PayloadBlock label="Error" value={outText} failed />
+      </ActivityDisclosure>
+    );
+  }
+
+  return (
+    <ActivityDisclosure
+      icon={<BrainCircuitIcon className={ICON_SIZE} />}
+      iconTone="muted"
+      title={title}
+      cancelled={item.status === "cancelled"}
+      preview={text ? truncatePreview(text, 90) : "Done"}
+    >
+      {text ? <BodyNote>{text}</BodyNote> : null}
+      <PayloadBlock label="Result" value={outText} />
+    </ActivityDisclosure>
+  );
+}
+
+/* ---- generic fallback (first-party MCP, external MCP, unknown) ------------- */
+
+/**
+ * Baseline craft for unmatched tools: family icon + title-cased leaf + honest
+ * status preview (Running… / Done / error snippet). No argument-field sniffing —
+ * JSON stays in the expandable body only.
+ */
+function GenericRenderer({ item }: ToolRendererProps) {
+  const running = item.status === "running";
+  const args = redactSecrets(parseToolArgs(item.arguments));
+  const display = toolDisplayName(item.name);
+  const icon = <GenericToolIcon name={item.name} />;
+
+  if (running) {
+    return (
+      <ActivityDisclosure
+        icon={icon}
+        iconTone="running"
+        title={display}
+        running
+        preview={<RunningPreview>Running…</RunningPreview>}
       >
         <PayloadBlock label="Arguments" value={args} />
       </ActivityDisclosure>
@@ -1036,11 +1286,11 @@ function GenericRenderer({ item }: ToolRendererProps) {
   if ((isError || item.status === "failed") && item.status !== "cancelled") {
     return (
       <ActivityDisclosure
-        icon={<WrenchIcon className={ICON_SIZE} />}
+        icon={icon}
         iconTone="failed"
         title={display}
         chip={{ tone: "bad", text: "error" }}
-        preview={outText.slice(0, 80)}
+        preview={truncatePreview(outText, 80) || "Error"}
       >
         <PayloadBlock label="Arguments" value={args} />
         <PayloadBlock label="Error" value={outText} failed />
@@ -1050,11 +1300,11 @@ function GenericRenderer({ item }: ToolRendererProps) {
 
   return (
     <ActivityDisclosure
-      icon={<WrenchIcon className={ICON_SIZE} />}
+      icon={icon}
       iconTone="muted"
       title={display}
       cancelled={item.status === "cancelled"}
-      preview={compactArgs(args)}
+      preview={item.status === "cancelled" ? undefined : "Done"}
     >
       <PayloadBlock label="Arguments" value={args} />
       <PayloadBlock label="Result" value={outText} />
@@ -1062,9 +1312,51 @@ function GenericRenderer({ item }: ToolRendererProps) {
   );
 }
 
-function compactArgs(args: unknown): string {
-  const text = stringifyPayload(args).replace(/\s+/g, " ").trim();
-  return text === "{}" ? "" : text.length > 90 ? `${text.slice(0, 89)}…` : text;
+function truncatePreview(text: string, max: number): string {
+  const cleaned = text.replace(/\s+/g, " ").trim();
+  if (!cleaned) {
+    return "";
+  }
+  return cleaned.length > max ? `${cleaned.slice(0, max - 1)}…` : cleaned;
+}
+
+/** Explicit first-party leaf/prefix → canonical product icons (match nav/pages). */
+function GenericToolIcon({ name }: { name: string }) {
+  const leaf = mcpToolLeaf(name);
+  const Icon =
+    leaf.startsWith("goal_")
+      ? TargetIcon
+      : leaf.startsWith("memory_") || leaf === "preference_registry_summary" || leaf === "preference_registry_get"
+        ? BrainCircuitIcon
+      : leaf.startsWith("session_") ||
+          leaf === "sessions_list" ||
+          leaf === "set_session_title" ||
+          leaf === "set_other_session_title"
+        ? MessagesSquareIcon
+      : leaf.startsWith("sandbox") || leaf === "sandboxes_list" || leaf === "run_on"
+        ? ServerIcon
+      : leaf.startsWith("rig_")
+        ? ServerCogIcon
+      : leaf.startsWith("scheduled_")
+        ? CalendarClockIcon
+      : leaf.startsWith("artifacts_")
+        ? PanelsTopLeftIcon
+      : leaf.startsWith("social_")
+        ? Share2Icon
+      : leaf.startsWith("slack_")
+        ? MessageSquareIcon
+      : leaf.startsWith("github_")
+        ? FolderGitIcon
+      : leaf.startsWith("variable_")
+        ? BoxIcon
+      : leaf.startsWith("environment_")
+        ? KeyRoundIcon
+      : leaf.includes("document") || leaf.includes("knowledge") || leaf === "list_document_bases"
+        ? FileSearchIcon
+      : leaf === "tool_search" || leaf === "load_skill"
+        ? PlugIcon
+      : WrenchIcon;
+  return <Icon className={ICON_SIZE} />;
 }
 
 /* ---- the default registry -------------------------------------------------- */
@@ -1075,13 +1367,11 @@ const BASE_ENTRIES: ToolRegistryEntry[] = [
   { match: "rawType", type: "apply_patch_call", render: ApplyPatchRenderer },
   { match: "rawType", type: "computer_call", render: ComputerCallRenderer },
   { match: "rawType", type: "hosted_tool_call", render: WebSearchRenderer },
-  // First-party sandbox + MCP tools resolve by name. `apply_patch_call` /
-  // `computer_call` are intentionally repeated by name as a fallback only for
-  // first-party replays that omit `raw` (the rawType entries above win whenever
-  // `raw.type` is present, which is the live-wire case).
+  // First-party sandbox + MCP tools resolve by name (exact or MCP leaf).
   { match: "name", name: "exec_command", render: ExecRenderer },
   { match: "name", name: "write_stdin", render: WriteStdinRenderer },
   { match: "name", name: "apply_patch_call", render: ApplyPatchRenderer },
+  { match: "name", name: "apply_patch", render: ApplyPatchRenderer },
   { match: "name", name: "computer_call", render: ComputerCallRenderer },
   // Function-mode computer tools (codex / chat-wire transports).
   { match: "name", name: "computer_screenshot", render: ComputerCallRenderer },
@@ -1095,6 +1385,12 @@ const BASE_ENTRIES: ToolRegistryEntry[] = [
   { match: "name", name: "web_search_call", render: WebSearchRenderer },
   { match: "name", name: "view_image", render: ViewImageRenderer },
   { match: "name", name: "environment_set_variable", render: SecretSetRenderer },
+  { match: "name", name: "variable_set_set_variable", render: SecretSetRenderer },
+  { match: "name", name: "search_documents", render: DocsSearchRenderer },
+  { match: "name", name: "knowledge_search", render: DocsSearchRenderer },
+  { match: "name", name: "memory_propose", render: MemoryProposeRenderer },
+  { match: "name", name: "set_session_title", render: SetSessionTitleRenderer },
+  { match: "name", name: "set_other_session_title", render: SetSessionTitleRenderer },
 ];
 
 /** The built-in tool renderer registry: every first-party tool plus a fallback. */

--- a/packages/react/src/timeline/tool-renderers.tsx
+++ b/packages/react/src/timeline/tool-renderers.tsx
@@ -1174,10 +1174,12 @@ function parseSearchHits(outText: string): SearchHit[] | null {
   }
   const list = Array.isArray(parsed)
     ? parsed
-    : parsed && typeof parsed === "object" && Array.isArray((parsed as { results?: unknown }).results)
-      ? ((parsed as { results: unknown[] }).results)
+    : parsed &&
+        typeof parsed === "object" &&
+        Array.isArray((parsed as { results?: unknown }).results)
+      ? (parsed as { results: unknown[] }).results
       : parsed && typeof parsed === "object" && Array.isArray((parsed as { hits?: unknown }).hits)
-        ? ((parsed as { hits: unknown[] }).hits)
+        ? (parsed as { hits: unknown[] }).hits
         : null;
   if (!list) {
     return null;
@@ -1323,39 +1325,42 @@ function truncatePreview(text: string, max: number): string {
 /** Explicit first-party leaf/prefix → canonical product icons (match nav/pages). */
 function GenericToolIcon({ name }: { name: string }) {
   const leaf = mcpToolLeaf(name);
-  const Icon =
-    leaf.startsWith("goal_")
-      ? TargetIcon
-      : leaf.startsWith("memory_") || leaf === "preference_registry_summary" || leaf === "preference_registry_get"
-        ? BrainCircuitIcon
+  const Icon = leaf.startsWith("goal_")
+    ? TargetIcon
+    : leaf.startsWith("memory_") ||
+        leaf === "preference_registry_summary" ||
+        leaf === "preference_registry_get"
+      ? BrainCircuitIcon
       : leaf.startsWith("session_") ||
           leaf === "sessions_list" ||
           leaf === "set_session_title" ||
           leaf === "set_other_session_title"
         ? MessagesSquareIcon
-      : leaf.startsWith("sandbox") || leaf === "sandboxes_list" || leaf === "run_on"
-        ? ServerIcon
-      : leaf.startsWith("rig_")
-        ? ServerCogIcon
-      : leaf.startsWith("scheduled_")
-        ? CalendarClockIcon
-      : leaf.startsWith("artifacts_")
-        ? PanelsTopLeftIcon
-      : leaf.startsWith("social_")
-        ? Share2Icon
-      : leaf.startsWith("slack_")
-        ? MessageSquareIcon
-      : leaf.startsWith("github_")
-        ? FolderGitIcon
-      : leaf.startsWith("variable_")
-        ? BoxIcon
-      : leaf.startsWith("environment_")
-        ? KeyRoundIcon
-      : leaf.includes("document") || leaf.includes("knowledge") || leaf === "list_document_bases"
-        ? FileSearchIcon
-      : leaf === "tool_search" || leaf === "load_skill"
-        ? PlugIcon
-      : WrenchIcon;
+        : leaf.startsWith("sandbox") || leaf === "sandboxes_list" || leaf === "run_on"
+          ? ServerIcon
+          : leaf.startsWith("rig_")
+            ? ServerCogIcon
+            : leaf.startsWith("scheduled_")
+              ? CalendarClockIcon
+              : leaf.startsWith("artifacts_")
+                ? PanelsTopLeftIcon
+                : leaf.startsWith("social_")
+                  ? Share2Icon
+                  : leaf.startsWith("slack_")
+                    ? MessageSquareIcon
+                    : leaf.startsWith("github_")
+                      ? FolderGitIcon
+                      : leaf.startsWith("variable_")
+                        ? BoxIcon
+                        : leaf.startsWith("environment_")
+                          ? KeyRoundIcon
+                          : leaf.includes("document") ||
+                              leaf.includes("knowledge") ||
+                              leaf === "list_document_bases"
+                            ? FileSearchIcon
+                            : leaf === "tool_search" || leaf === "load_skill"
+                              ? PlugIcon
+                              : WrenchIcon;
   return <Icon className={ICON_SIZE} />;
 }
 

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -375,7 +375,10 @@ export function TurnSummary({
   );
 
   // Live open shell: keep the chip in-flow (so settle never inserts layout)
-  // but quiet it until there is an outcome or a settle beat.
+  // and quieter until there is an outcome or a settle beat — but still
+  // clickable. `pointer-events-none` here trapped readers who expanded (or
+  // who landed on the default-open live rail) with no way to collapse while
+  // the turn was still running.
   const liveShell = outcome === undefined && open && !settlePhase && !bare;
   // Settle CSS phase OR cancel-close latch — see useTurnSettleOpen.
   // Nested chips stay force-open for this window (stable height).
@@ -419,7 +422,7 @@ export function TurnSummary({
               outcome === "failed"
                 ? "hover:bg-og-status-failed/[0.06] hover:text-og-fg"
                 : "hover:bg-og-surface-1 hover:text-og-fg",
-              liveShell && "pointer-events-none text-og-fg-subtle",
+              liveShell && "text-og-fg-subtle",
             )}
           >
             {/* Disclosure grammar matches the rows: chevron leads (far left), then any

--- a/packages/react/src/workstream-control-event.ts
+++ b/packages/react/src/workstream-control-event.ts
@@ -1,0 +1,6 @@
+/**
+ * Document event hosts dispatch to open the workstream Pause/Resume surface.
+ * Kept in a leaf module so session chrome can import the name without pulling
+ * the ChatComposer / Radix tooltip graph into the app shell.
+ */
+export const OPEN_WORKSTREAM_CONTROL_EVENT = "opengeni:open-workstream-control";

--- a/packages/react/test/chat-composer-controls.test.tsx
+++ b/packages/react/test/chat-composer-controls.test.tsx
@@ -200,8 +200,9 @@ describe("ChatComposer delivery and lifecycle controls", () => {
     const send = mounted.container.querySelector<HTMLButtonElement>(
       'button[aria-label="Send message"]',
     );
-    expect(send?.title).toContain("Queue message");
-    expect(send?.title).toContain("Cmd/Ctrl+Enter");
+    // Tips are Radix tooltips (not native `title`); tip copy is on data-og-tip.
+    expect(send?.getAttribute("data-og-tip")).toContain("Queue message");
+    expect(send?.getAttribute("data-og-tip")).toContain("Cmd/Ctrl+Enter");
     await act(async () => send?.click());
     expect(spy.sends).toEqual(["send"]);
   });

--- a/packages/react/test/composer-autosize.test.ts
+++ b/packages/react/test/composer-autosize.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { applyComposerTextareaHeight } from "../src/components/composer";
+import { registerDom } from "./render-hook";
+
+registerDom();
+
+describe("applyComposerTextareaHeight", () => {
+  test("grows from overflow without writing height 0", () => {
+    const el = document.createElement("textarea");
+    Object.defineProperty(el, "clientHeight", { configurable: true, get: () => 40 });
+    Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => 96 });
+    Object.defineProperty(el, "offsetHeight", { configurable: true, get: () => 40 });
+    el.style.height = "40px";
+
+    const writes: string[] = [];
+    const desc = Object.getOwnPropertyDescriptor(CSSStyleDeclaration.prototype, "height");
+    Object.defineProperty(el.style, "height", {
+      configurable: true,
+      get() {
+        return desc?.get?.call(this) ?? "";
+      },
+      set(value: string) {
+        writes.push(value);
+        desc?.set?.call(this, value);
+      },
+    });
+
+    applyComposerTextareaHeight(el, 220);
+    expect(writes).not.toContain("0px");
+    expect(writes.at(-1)).toBe("96px");
+  });
+
+  test("restores prior height when auto measure matches", () => {
+    const el = document.createElement("textarea");
+    Object.defineProperty(el, "clientHeight", { configurable: true, get: () => 40 });
+    Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => 40 });
+    Object.defineProperty(el, "offsetHeight", { configurable: true, get: () => 40 });
+    el.style.height = "40px";
+
+    applyComposerTextareaHeight(el, 220);
+    expect(el.style.height).toBe("40px");
+  });
+
+  test("caps at maxPx on grow", () => {
+    const el = document.createElement("textarea");
+    Object.defineProperty(el, "clientHeight", { configurable: true, get: () => 40 });
+    Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => 400 });
+    Object.defineProperty(el, "offsetHeight", { configurable: true, get: () => 40 });
+
+    applyComposerTextareaHeight(el, 220);
+    expect(el.style.height).toBe("220px");
+  });
+});

--- a/packages/react/test/format.test.ts
+++ b/packages/react/test/format.test.ts
@@ -3,6 +3,7 @@ import {
   COMPOSER_PAYMENT_REQUIRED_MESSAGE,
   CREDIT_EXHAUSTION_MESSAGE,
   composerSubmissionErrorMessage,
+  formatClockTime,
   formatRelativeTime,
   humanizeFailureReason,
   isCreditExhaustion,
@@ -11,6 +12,16 @@ import {
   tryParseJson,
 } from "../src/lib/format";
 import { OpenGeniApiError } from "@opengeni/sdk";
+
+describe("formatClockTime", () => {
+  test("formats date + time and rejects invalid input", () => {
+    expect(formatClockTime("not-a-date")).toBe("");
+    const formatted = formatClockTime("2026-07-15T08:04:00");
+    expect(formatted.toLowerCase()).toMatch(/jul/);
+    expect(formatted).toMatch(/15/);
+    expect(formatted).toMatch(/\d/);
+  });
+});
 
 describe("formatRelativeTime", () => {
   const now = new Date("2026-06-12T12:00:00Z");

--- a/packages/react/test/golden/snapshots/01-plain-settled-turn.json
+++ b/packages/react/test/golden/snapshots/01-plain-settled-turn.json
@@ -23,7 +23,7 @@
       "kind": "agent-message",
       "id": "00000000-0000-4000-8000-000000000106",
       "turnId": "aaaaaaaa-0000-4000-8000-000000000001",
-      "occurredAt": "2026-01-02T10:00:06.000Z",
+      "occurredAt": "2026-01-02T10:00:08.000Z",
       "text": "I will run the package tests now.",
       "streaming": false
     },
@@ -91,7 +91,7 @@
       "kind": "turn",
       "id": "turn-aaaaaaaa-0000-4000-8000-000000000001",
       "outcome": "complete",
-      "startedAt": "2026-01-02T10:00:06.000Z",
+      "startedAt": "2026-01-02T10:00:08.000Z",
       "endedAt": "2026-01-02T10:00:12.000Z",
       "groupCount": 2,
       "groups": [
@@ -101,7 +101,7 @@
             "kind": "agent-message",
             "id": "00000000-0000-4000-8000-000000000106",
             "turnId": "aaaaaaaa-0000-4000-8000-000000000001",
-            "occurredAt": "2026-01-02T10:00:06.000Z",
+            "occurredAt": "2026-01-02T10:00:08.000Z",
             "text": "I will run the package tests now.",
             "streaming": false
           }

--- a/packages/react/test/golden/snapshots/02-narration-heavy-turn.json
+++ b/packages/react/test/golden/snapshots/02-narration-heavy-turn.json
@@ -20,7 +20,7 @@
       "kind": "agent-message",
       "id": "00000000-0000-4000-8000-000000000206",
       "turnId": "aaaaaaaa-0000-4000-8000-000000000002",
-      "occurredAt": "2026-01-02T11:00:06.000Z",
+      "occurredAt": "2026-01-02T11:00:07.000Z",
       "text": "First I will inspect the helper.",
       "streaming": false
     },
@@ -48,7 +48,7 @@
       "kind": "agent-message",
       "id": "00000000-0000-4000-8000-000000000210",
       "turnId": "aaaaaaaa-0000-4000-8000-000000000002",
-      "occurredAt": "2026-01-02T11:00:10.000Z",
+      "occurredAt": "2026-01-02T11:00:11.000Z",
       "text": "The helper still imports the legacy session.",
       "streaming": false
     },
@@ -105,7 +105,7 @@
       "kind": "agent-message",
       "id": "00000000-0000-4000-8000-000000000217",
       "turnId": "aaaaaaaa-0000-4000-8000-000000000002",
-      "occurredAt": "2026-01-02T11:00:17.000Z",
+      "occurredAt": "2026-01-02T11:00:18.000Z",
       "text": "The login page renders after the patch.",
       "streaming": false
     },
@@ -163,7 +163,7 @@
             "kind": "agent-message",
             "id": "00000000-0000-4000-8000-000000000206",
             "turnId": "aaaaaaaa-0000-4000-8000-000000000002",
-            "occurredAt": "2026-01-02T11:00:06.000Z",
+            "occurredAt": "2026-01-02T11:00:07.000Z",
             "text": "First I will inspect the helper.",
             "streaming": false
           }
@@ -205,7 +205,7 @@
             "kind": "agent-message",
             "id": "00000000-0000-4000-8000-000000000210",
             "turnId": "aaaaaaaa-0000-4000-8000-000000000002",
-            "occurredAt": "2026-01-02T11:00:10.000Z",
+            "occurredAt": "2026-01-02T11:00:11.000Z",
             "text": "The helper still imports the legacy session.",
             "streaming": false
           }
@@ -279,7 +279,7 @@
         "kind": "agent-message",
         "id": "00000000-0000-4000-8000-000000000217",
         "turnId": "aaaaaaaa-0000-4000-8000-000000000002",
-        "occurredAt": "2026-01-02T11:00:17.000Z",
+        "occurredAt": "2026-01-02T11:00:18.000Z",
         "text": "The login page renders after the patch.",
         "streaming": false
       }

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1777,9 +1777,8 @@ describe("useComposer durable draft and control binding", () => {
     expect(reads).toBe(2);
     expect(hook.result.current.draftLoading).toBe(false);
     expect(releaseSecond).not.toBeNull();
-    await flushing(() => {
-      releaseSecond!();
-    });
+    releaseSecond!();
+    await flush();
     expect(hook.result.current.draftLoading).toBe(false);
     expect(hook.result.current.value).toBe("read-2");
     await hook.unmount();

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1777,8 +1777,9 @@ describe("useComposer durable draft and control binding", () => {
     expect(reads).toBe(2);
     expect(hook.result.current.draftLoading).toBe(false);
     expect(releaseSecond).not.toBeNull();
-    releaseSecond!();
-    await flush();
+    await flushing(() => {
+      releaseSecond!();
+    });
     expect(hook.result.current.draftLoading).toBe(false);
     expect(hook.result.current.value).toBe("read-2");
     await hook.unmount();

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1777,14 +1777,13 @@ describe("useComposer durable draft and control binding", () => {
     expect(reads).toBe(2);
     expect(hook.result.current.draftLoading).toBe(false);
     expect(releaseSecond).not.toBeNull();
-    // Soft reload must not flip draftLoading. Keep the deferred read's state
-    // commits inside act — on slower CI hosts a bare resolve can land after
-    // the synchronous act callback returns and trip the warning-free gate.
+    // Soft reload must not flip draftLoading. Resolve + settle under one act so
+    // the deferred read's setState commits never escape the warning-free gate.
     await flushing(async () => {
       releaseSecond!();
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await Promise.resolve();
+      await Promise.resolve();
     });
-    await flush();
     expect(hook.result.current.draftLoading).toBe(false);
     expect(hook.result.current.value).toBe("read-2");
     await hook.unmount();
@@ -1828,8 +1827,11 @@ describe("useComposer durable draft and control binding", () => {
     expect(hook.result.current.draftLoading).toBe(true);
     expect(reads).toBe(2);
     expect(releaseReload).not.toBeNull();
-    releaseReload!();
-    await flushing(async () => await reloadDone);
+    // Resolving outside act was the clean-gate failure: draft setState escaped.
+    await flushing(async () => {
+      releaseReload!();
+      await reloadDone;
+    });
     expect(hook.result.current.draftLoading).toBe(false);
     await hook.unmount();
   });

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1739,6 +1739,95 @@ describe("useComposer durable draft and control binding", () => {
     await hook.unmount();
   });
 
+  test("soft draft reload after settle does not assert draftLoading", async () => {
+    let reads = 0;
+    let releaseSecond: (() => void) | null = null;
+    const client = fakeClient({
+      getComposerDraft: async () => {
+        reads += 1;
+        if (reads === 2) {
+          await new Promise<void>((resolve) => {
+            releaseSecond = resolve;
+          });
+        }
+        return {
+          revision: reads,
+          text: `read-${reads}`,
+          resources: [],
+          model: "model-x",
+          reasoningEffort: "medium",
+          sourceTurnId: null,
+          sourceTurnVersion: null,
+          updatedAt: new Date().toISOString(),
+        } satisfies ComposerDraft;
+      },
+    });
+    const hook = await renderHook(
+      (events: SessionEvent[]) =>
+        useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID, events }),
+      noEvents,
+    );
+    await flush();
+    expect(reads).toBe(1);
+    expect(hook.result.current.draftLoading).toBe(false);
+
+    // Reconcile / queue-changed soft reload (loadOlder SSE reconnect path).
+    await hook.rerender([makeEvent(1, "session.queue.changed", { operation: "edit" })]);
+    await flush();
+    expect(reads).toBe(2);
+    expect(hook.result.current.draftLoading).toBe(false);
+    expect(releaseSecond).not.toBeNull();
+    releaseSecond!();
+    await flush();
+    expect(hook.result.current.draftLoading).toBe(false);
+    expect(hook.result.current.value).toBe("read-2");
+    await hook.unmount();
+  });
+
+  test("explicit reloadDraft still asserts draftLoading while in flight", async () => {
+    let reads = 0;
+    let releaseReload: (() => void) | null = null;
+    const client = fakeClient({
+      getComposerDraft: async () => {
+        reads += 1;
+        if (reads === 2) {
+          await new Promise<void>((resolve) => {
+            releaseReload = resolve;
+          });
+        }
+        return {
+          revision: reads,
+          text: `read-${reads}`,
+          resources: [],
+          model: "model-x",
+          reasoningEffort: "medium",
+          sourceTurnId: null,
+          sourceTurnVersion: null,
+          updatedAt: new Date().toISOString(),
+        } satisfies ComposerDraft;
+      },
+    });
+    const hook = await renderHook(
+      () => useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+    await flush();
+    expect(hook.result.current.draftLoading).toBe(false);
+
+    let reloadDone: Promise<void> = Promise.resolve();
+    await flushing(() => {
+      reloadDone = hook.result.current.reloadDraft();
+    });
+    // In-flight hard reload must blank the picker (unlike soft reconcile).
+    expect(hook.result.current.draftLoading).toBe(true);
+    expect(reads).toBe(2);
+    expect(releaseReload).not.toBeNull();
+    releaseReload!();
+    await flushing(async () => await reloadDone);
+    expect(hook.result.current.draftLoading).toBe(false);
+    await hook.unmount();
+  });
+
   test("history already present at mount is treated as a projection, not live traffic", async () => {
     let reads = 0;
     const client = fakeClient({

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1777,8 +1777,10 @@ describe("useComposer durable draft and control binding", () => {
     expect(reads).toBe(2);
     expect(hook.result.current.draftLoading).toBe(false);
     expect(releaseSecond).not.toBeNull();
-    releaseSecond!();
-    await flush();
+    // Soft reload must not flip draftLoading; settle the deferred read under act.
+    await flushing(() => {
+      releaseSecond!();
+    });
     expect(hook.result.current.draftLoading).toBe(false);
     expect(hook.result.current.value).toBe("read-2");
     await hook.unmount();

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1777,10 +1777,14 @@ describe("useComposer durable draft and control binding", () => {
     expect(reads).toBe(2);
     expect(hook.result.current.draftLoading).toBe(false);
     expect(releaseSecond).not.toBeNull();
-    // Soft reload must not flip draftLoading; settle the deferred read under act.
-    await flushing(() => {
+    // Soft reload must not flip draftLoading. Keep the deferred read's state
+    // commits inside act — on slower CI hosts a bare resolve can land after
+    // the synchronous act callback returns and trip the warning-free gate.
+    await flushing(async () => {
       releaseSecond!();
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
+    await flush();
     expect(hook.result.current.draftLoading).toBe(false);
     expect(hook.result.current.value).toBe("read-2");
     await hook.unmount();

--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { SessionEvent } from "@opengeni/sdk";
 import { MessageTimeline, type TimelineItem } from "../src";
+import { setScrollEndSupportForTests } from "../src/components/tip-follow";
 import { actRun, registerDom, renderComponent, flush } from "./render-hook";
 
 registerDom();
@@ -657,7 +658,8 @@ describe("MessageTimeline pagination affordances", () => {
 
   test("mid-turn fold + tip growth does not unpin when maxScroll stays flat", async () => {
     // tools→message→tools: cluster collapse and narration growth cancel in
-    // maxScroll while scrollTop still drops — old conservation false-unpinned.
+    // maxScroll while scrollTop still drops — layout tip-follow recovers;
+    // scrollend must not treat that as a reader leave.
     const frames: FrameRequestCallback[] = [];
     globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
       frames.push(cb);
@@ -685,18 +687,127 @@ describe("MessageTimeline pagination affordances", () => {
     expect(r.container.textContent).not.toContain("Jump to latest");
 
     // Same scrollHeight + same maxScroll, but scrollTop drops (fold above +
-    // growth below). Must stay pinned and recover tip — not Jump to latest.
+    // growth below). Production folds co-occur with a commit — layout
+    // tip-follow recovers before scrollend settles at the tip.
     await actRun(() => {
       scroller.scrollTop = 1400;
       scroller.dispatchEvent(new Event("scroll"));
     });
+    layout.setContentHeight(2000);
+    await r.rerender(
+      <MessageTimeline events={[...initial, agentDelta(21, "x")]} status="running" />,
+    );
     await drainFrames(frames);
+    await flush();
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scrollend"));
+    });
     await flush();
     expect(r.container.textContent).not.toContain("Jump to latest");
     expect(distanceFromBottom(scroller)).toBeLessThan(48);
 
     layout.restore();
     await r.unmount();
+  });
+
+  test("unarmed scroll settle away from tip unpins (Vimium / PageUp)", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+
+    const prefix = manyEvents(19);
+    const initial = [...prefix, agentDelta(20, "hello ")];
+    const r = await renderComponent(<MessageTimeline events={initial} status="running" />);
+    const scroller = r.container.querySelector(".overflow-y-auto");
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error("expected timeline scroller");
+    }
+    const layout = mockScrollerLayout(scroller, {
+      clientHeight: 400,
+      contentHeight: 2000,
+      tipHeight: 80,
+      paddingBottom: 24,
+    });
+    layout.syncTipAtBottom();
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    await drainFrames(frames);
+    expect(r.container.textContent).not.toContain("Jump to latest");
+
+    // Extension-style jump: no wheel, no pointer arm — scrollend decides leave.
+    await actRun(() => {
+      scroller.scrollTop = 200;
+      layout.placeTipAt(120);
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    // Stream token while leave is pending must not yank back to the tip.
+    layout.setContentHeight(2400);
+    await r.rerender(
+      <MessageTimeline events={[...initial, agentDelta(21, "world")]} status="running" />,
+    );
+    await drainFrames(frames);
+    await flush();
+    expect(scroller.scrollTop).toBe(200);
+
+    await actRun(() => {
+      scroller.dispatchEvent(new Event("scrollend"));
+    });
+    await flush();
+    expect(r.container.textContent).toContain("Jump to latest");
+    expect(scroller.scrollTop).toBe(200);
+    expect(distanceFromBottom(scroller)).toBeGreaterThan(48);
+
+    layout.restore();
+    await r.unmount();
+  });
+
+  test("unarmed scroll-away falls back to one rAF leave when scrollend is missing", async () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      frames.push(cb);
+      return frames.length;
+    };
+    globalThis.cancelAnimationFrame = () => undefined;
+    setScrollEndSupportForTests(false);
+    try {
+      const prefix = manyEvents(19);
+      const initial = [...prefix, agentDelta(20, "hello ")];
+      const r = await renderComponent(<MessageTimeline events={initial} status="running" />);
+      const scroller = r.container.querySelector(".overflow-y-auto");
+      if (!(scroller instanceof HTMLElement)) {
+        throw new Error("expected timeline scroller");
+      }
+      const layout = mockScrollerLayout(scroller, {
+        clientHeight: 400,
+        contentHeight: 2000,
+        tipHeight: 80,
+        paddingBottom: 24,
+      });
+      layout.syncTipAtBottom();
+      await actRun(() => {
+        scroller.dispatchEvent(new Event("scroll"));
+      });
+      // Drain reveal/tip-follow frames so they cannot cancel the leave rAF.
+      await drainFrames(frames);
+
+      await actRun(() => {
+        scroller.scrollTop = 200;
+        layout.placeTipAt(120);
+        scroller.dispatchEvent(new Event("scroll"));
+      });
+      await drainFrames(frames);
+      await flush();
+      expect(r.container.textContent).toContain("Jump to latest");
+
+      layout.restore();
+      await r.unmount();
+    } finally {
+      setScrollEndSupportForTests(null);
+    }
   });
 
   test("layout height shrink while pinned does not unpin (settle-fold / scenario spawn)", async () => {

--- a/packages/react/test/session-entry.test.ts
+++ b/packages/react/test/session-entry.test.ts
@@ -95,7 +95,7 @@ describe("session-only entry", () => {
     expect(reactSources.some((id) => id.includes("/src/commands/"))).toBe(false);
     // Keep the session-only closure explicit: adding a source requires reviewing
     // whether it belongs to this provider-neutral public subpath.
-    expect(reactSources.length).toBe(18);
+    expect(reactSources.length).toBe(19);
 
     const chunks = result.output.filter((item) => item.type === "chunk");
     expect(chunks).toHaveLength(1);

--- a/packages/react/test/settle-fold.test.tsx
+++ b/packages/react/test/settle-fold.test.tsx
@@ -128,6 +128,25 @@ describe("TurnSummary settle fold", () => {
     await r.unmount();
   });
 
+  test("a live-open shell stays clickable so the reader can collapse mid-turn", async () => {
+    const memory = new Map<string, FoldRestingState>();
+    const r = await renderComponent(
+      <FoldMemoryProvider value={memory}>
+        <TurnSummary items={[]} defaultOpen foldKey="live-1">
+          <div data-testid="body">the rows</div>
+        </TurnSummary>
+      </FoldMemoryProvider>,
+    );
+    const trigger = r.container.querySelector("button");
+    expect(trigger?.getAttribute("data-state")).toBe("open");
+    // Quieter live chrome must not disable the disclosure trigger.
+    expect(trigger?.className).not.toContain("pointer-events-none");
+    await actRun(() => trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(trigger?.getAttribute("data-state")).toBe("closed");
+    expect(memory.get("live-1")).toBe("closed");
+    await r.unmount();
+  });
+
   test("after auto-settle, a manual reopen uses the fast expand class", async () => {
     const r = await renderComponent(
       <TurnSummary items={[]} outcome="complete" settleFold>

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -21,21 +21,21 @@ import {
 } from "../src/timeline";
 
 describe("toolDisplayName", () => {
-  test("strips the MCP server-id prefix and shows only the tool", () => {
+  test("strips the MCP server-id prefix and title-cases the leaf", () => {
     // Catalog-imported MCP server: <opaque slug+hash>__<tool>.
     expect(
       toolDisplayName("mcp-integrations-sh-supabase-com-34ed9dcf1390-0i6tcf8__list_organizations"),
-    ).toBe("list organizations");
-    expect(toolDisplayName("opengeni__set_session_title")).toBe("set session title");
+    ).toBe("List organizations");
+    expect(toolDisplayName("opengeni__set_session_title")).toBe("Set session title");
   });
 
-  test("plain built-in tool names (no __ boundary) are just de-slugged", () => {
-    expect(toolDisplayName("session_create")).toBe("session create");
-    expect(toolDisplayName("bash")).toBe("bash");
+  test("plain built-in tool names (no __ boundary) are de-slugged and title-cased", () => {
+    expect(toolDisplayName("session_create")).toBe("Session create");
+    expect(toolDisplayName("bash")).toBe("Bash");
   });
 
   test("splits on the FIRST __ so a tool name containing __ survives whole", () => {
-    expect(toolDisplayName("mcp-supabase-abc123__do__thing")).toBe("do thing");
+    expect(toolDisplayName("mcp-supabase-abc123__do__thing")).toBe("Do thing");
   });
 });
 
@@ -2310,17 +2310,44 @@ describe("buildTimeline — memory writes", () => {
     expect(items).toEqual([]);
   });
 
-  test("clusters memory writes as activity steps alongside tool calls", () => {
+  test("memory_save tool calls are suppressed; the memory.* landmark owns the row", () => {
     reset();
     const groups = groupTimeline(
       buildTimeline([
-        event("agent.toolCall.created", { id: "call-1", name: "memory_save", arguments: {} }),
+        event("agent.toolCall.created", {
+          id: "call-1",
+          name: "opengeni__memory_save",
+          arguments: {},
+        }),
         event("agent.toolCall.output", { id: "call-1", output: "ok" }),
         event("memory.saved", { memoryId: "mem-1", kind: "preference", preview: "A preference." }),
       ]),
     );
     const activities = collectActivityGroups(groups);
     expect(activities).toHaveLength(1);
-    expect(activities[0]!.items.map((item) => item.kind)).toEqual(["tool-call", "memory"]);
+    expect(activities[0]!.items.map((item) => item.kind)).toEqual(["memory"]);
+  });
+
+  test("prefixed opengeni__session_create projects as a worker item", () => {
+    reset();
+    const worker = {
+      id: "0b3ba745-1111-4222-8333-9c76ad9e0000",
+      workspaceId: "ws-1",
+      status: "queued",
+    };
+    const items = buildTimeline([
+      event("agent.toolCall.created", {
+        id: "call-1",
+        name: "opengeni__session_create",
+        arguments: JSON.stringify({ initialMessage: "Run the drift check on prod" }),
+      }),
+      event("agent.toolCall.output", {
+        id: "call-1",
+        output: { content: [{ type: "text", text: JSON.stringify(worker) }] },
+      }),
+    ]);
+    expect(items).toHaveLength(1);
+    expect((items[0] as WorkerItem).kind).toBe("worker");
+    expect((items[0] as WorkerItem).workerSessionId).toBe(worker.id);
   });
 });

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -1499,6 +1499,88 @@ describe("buildTimeline", () => {
     expect(items[0]).toMatchObject({ kind: "goal", action: "set", text: "Keep staging green" });
   });
 
+  test("agent goal tool stays in the activity cluster; landmark is suppressed", () => {
+    reset();
+    const groups = groupTimeline(
+      buildTimeline([
+        event("agent.toolCall.created", {
+          id: "call-mem",
+          name: "opengeni__memory_search",
+          arguments: { query: "tokens" },
+        }),
+        event("agent.toolCall.output", { id: "call-mem", output: "ok" }),
+        event("agent.toolCall.created", {
+          id: "call-goal",
+          name: "opengeni__goal_set",
+          arguments: { text: "Explain the MCP token flow" },
+        }),
+        event("agent.toolCall.output", { id: "call-goal", output: "ok" }),
+        event("goal.set", {
+          goalId: "goal-1",
+          text: "Explain the MCP token flow",
+          actor: "agent",
+          version: 1,
+        }),
+        event("agent.toolCall.created", {
+          id: "call-box",
+          name: "opengeni__sandboxes_list",
+          arguments: {},
+        }),
+        event("agent.toolCall.output", { id: "call-box", output: "[]" }),
+      ]),
+    );
+    expect(groups.filter((group) => group.kind === "item")).toHaveLength(0);
+    const activities = collectActivityGroups(groups);
+    expect(activities).toHaveLength(1);
+    expect(activities[0]!.items.map((item) => item.kind)).toEqual([
+      "tool-call",
+      "tool-call",
+      "tool-call",
+    ]);
+    expect(
+      activities[0]!.items
+        .filter((item): item is ToolCallItem => item.kind === "tool-call")
+        .map((item) => item.name),
+    ).toEqual(["opengeni__memory_search", "opengeni__goal_set", "opengeni__sandboxes_list"]);
+  });
+
+  test("non-agent goal.set still renders a landmark (API / create-session)", () => {
+    reset();
+    const items = buildTimeline([
+      event("goal.set", {
+        goalId: "goal-1",
+        text: "Keep staging green",
+        actor: "api",
+        version: 1,
+      }),
+    ]);
+    expect(items[0]).toMatchObject({ kind: "goal", action: "set", text: "Keep staging green" });
+  });
+
+  test("system goal.paused still renders a landmark", () => {
+    reset();
+    const items = buildTimeline([
+      event("goal.paused", {
+        goalId: "goal-1",
+        actor: "system",
+        reason: "no_progress",
+      }),
+    ]);
+    expect(items[0]).toMatchObject({ kind: "goal", action: "paused" });
+  });
+
+  test("goal.continuation still renders a landmark", () => {
+    reset();
+    const items = buildTimeline([
+      event("goal.continuation", { text: "still working toward the goal" }),
+    ]);
+    expect(items[0]).toMatchObject({
+      kind: "goal",
+      action: "continuation",
+      text: "still working toward the goal",
+    });
+  });
+
   test("goal.cleared is tolerated as a goal landmark", () => {
     reset();
     const items = buildTimeline([event("goal.cleared", { goalId: "goal-1" })]);

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -361,16 +361,18 @@ describe("buildTimeline", () => {
 
   test("accumulates streaming deltas into one agent message and finalizes on completed", () => {
     reset();
-    const items = buildTimeline([
-      event("user.message", { text: "Deploy staging" }),
-      event("agent.message.delta", { text: "On it — " }),
-      event("agent.message.delta", { text: "checking the cluster." }),
-      event("agent.message.completed", { text: "On it — checking the cluster." }),
-    ]);
+    const user = event("user.message", { text: "Deploy staging" });
+    const deltaA = event("agent.message.delta", { text: "On it — " });
+    const deltaB = event("agent.message.delta", { text: "checking the cluster." });
+    const done = event("agent.message.completed", { text: "On it — checking the cluster." });
+    const items = buildTimeline([user, deltaA, deltaB, done]);
     expect(items.map((item) => item.kind)).toEqual(["user-message", "agent-message"]);
     const message = items[1] as AgentMessageItem;
     expect(message.text).toBe("On it — checking the cluster.");
     expect(message.streaming).toBe(false);
+    // Footer "finished at" uses the completed event time, not the first delta.
+    expect(message.occurredAt).toBe(done.occurredAt);
+    expect(message.occurredAt).not.toBe(deltaA.occurredAt);
   });
 
   test("keeps accumulated text when completed text does not extend it", () => {

--- a/packages/react/test/tool-registry.test.ts
+++ b/packages/react/test/tool-registry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultToolRegistry } from "../src/timeline/tool-renderers";
+import { mcpToolLeaf, toolMatchesLeaf } from "../src/timeline/tool-display-name";
+import type { ToolCallItem } from "../src/timeline/types";
+
+function tool(partial: Partial<ToolCallItem> & Pick<ToolCallItem, "name">): ToolCallItem {
+  return {
+    kind: "tool-call",
+    id: "t1",
+    turnId: null,
+    callId: "c1",
+    arguments: null,
+    output: undefined,
+    raw: undefined,
+    status: "complete",
+    occurredAt: "2026-01-01T00:00:00.000Z",
+    ...partial,
+  };
+}
+
+describe("mcpToolLeaf / toolMatchesLeaf", () => {
+  test("leaf after first __", () => {
+    expect(mcpToolLeaf("opengeni__environment_set_variable")).toBe("environment_set_variable");
+    expect(mcpToolLeaf("apply_patch")).toBe("apply_patch");
+  });
+
+  test("matches exact or prefixed leaf only", () => {
+    expect(toolMatchesLeaf("opengeni__session_create", "session_create")).toBe(true);
+    expect(toolMatchesLeaf("session_create", "session_create")).toBe(true);
+    expect(toolMatchesLeaf("not_session_create", "session_create")).toBe(false);
+  });
+});
+
+describe("defaultToolRegistry leaf resolution", () => {
+  const registry = createDefaultToolRegistry();
+
+  test("resolves SecretSet for prefixed environment_set_variable", () => {
+    const a = registry.resolve(tool({ name: "environment_set_variable" }));
+    const b = registry.resolve(tool({ name: "opengeni__environment_set_variable" }));
+    const c = registry.resolve(tool({ name: "opengeni__variable_set_set_variable" }));
+    expect(a).toBe(b);
+    expect(a).toBe(c);
+    expect(a.name).toBe("SecretSetRenderer");
+  });
+
+  test("resolves ApplyPatch for function apply_patch name", () => {
+    const renderer = registry.resolve(tool({ name: "apply_patch" }));
+    expect(renderer.name).toBe("ApplyPatchRenderer");
+  });
+
+  test("resolves DocsSearch for knowledge_search leaf", () => {
+    const renderer = registry.resolve(tool({ name: "docs__knowledge_search" }));
+    expect(renderer.name).toBe("DocsSearchRenderer");
+  });
+});

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -11,9 +11,12 @@ type ManifestEntry = {
 const kib = 1024;
 const budgets = {
   // Shared consent, connector, and response-deduplication code remains in the
-  // application shell while provider SDKs stay lazy. Keep the measured ceiling.
-  initialRaw: 773 * kib,
-  initialGzip: 210 * kib,
+  // application shell while provider SDKs stay lazy. The Workspace hub densifies
+  // rail + settings against the session graph; a dedicated Radix vendor chunk
+  // keeps Popper scopes intact (otherwise /settings crashes) and lands ~885–905
+  // KiB initial raw — raise the ceiling to the measured densified shell.
+  initialRaw: 910 * kib,
+  initialGzip: 245 * kib,
   initialFileGzip: 70 * kib,
   initialFiles: 11,
   directSessionRaw: 1900 * kib,

--- a/test/e2e/codex-overview.e2e.ts
+++ b/test/e2e/codex-overview.e2e.ts
@@ -706,7 +706,20 @@ describe("Codex quota real browser/API/Postgres reset overview", () => {
     await completedPage.goto(`http://127.0.0.1:${publicPort}/workspaces/${workspaceId}/settings`, {
       waitUntil: "domcontentloaded",
     });
-    await completedPage
+    const completedSubscriptionsHeading = completedPage.locator("#codex-subscriptions-heading");
+    await completedSubscriptionsHeading.waitFor({ timeout: 20_000 });
+    await completedSubscriptionsHeading.scrollIntoViewIfNeeded();
+    // Dense rows keep reset outcomes inside collapsed details.
+    const completedDetailed = completedPage.getByRole("article", {
+      name: "Detailed account Codex subscription",
+    });
+    const completedShow = completedDetailed.getByRole("button", {
+      name: "Show details for Detailed account",
+    });
+    if (await completedShow.isVisible()) {
+      await completedShow.click();
+    }
+    await completedDetailed
       .getByText("The earlier redemption succeeded; usage was refreshed.")
       .waitFor({ timeout: 20_000 });
     expect(

--- a/test/e2e/codex-overview.e2e.ts
+++ b/test/e2e/codex-overview.e2e.ts
@@ -418,7 +418,9 @@ describe("Codex quota real browser/API/Postgres reset overview", () => {
     await page.goto(`http://127.0.0.1:${publicPort}/workspaces/${workspaceId}/settings`, {
       waitUntil: "domcontentloaded",
     });
-    await page.getByRole("heading", { name: "Codex subscriptions" }).waitFor({ timeout: 20_000 });
+    const subscriptionsHeading = page.locator("#codex-subscriptions-heading");
+    await subscriptionsHeading.waitFor({ timeout: 20_000 });
+    await subscriptionsHeading.scrollIntoViewIfNeeded();
     const accountCard = (name: string) =>
       page.getByRole("article", { name: `${name} Codex subscription` });
     const expandAccount = async (name: string) => {
@@ -512,7 +514,9 @@ describe("Codex quota real browser/API/Postgres reset overview", () => {
     await mobile.goto(`http://127.0.0.1:${publicPort}/workspaces/${workspaceId}/settings`, {
       waitUntil: "domcontentloaded",
     });
-    await mobile.getByRole("heading", { name: "Codex subscriptions" }).waitFor({ timeout: 20_000 });
+    const mobileSubscriptionsHeading = mobile.locator("#codex-subscriptions-heading");
+    await mobileSubscriptionsHeading.waitFor({ timeout: 20_000 });
+    await mobileSubscriptionsHeading.scrollIntoViewIfNeeded();
     const mobileDetailed = mobile.getByRole("article", {
       name: "Detailed account Codex subscription",
     });
@@ -625,9 +629,9 @@ describe("Codex quota real browser/API/Postgres reset overview", () => {
     await recoveryPage.goto(`http://127.0.0.1:${publicPort}/workspaces/${workspaceId}/settings`, {
       waitUntil: "domcontentloaded",
     });
-    await recoveryPage
-      .getByRole("heading", { name: "Codex subscriptions" })
-      .waitFor({ timeout: 20_000 });
+    const recoverySubscriptionsHeading = recoveryPage.locator("#codex-subscriptions-heading");
+    await recoverySubscriptionsHeading.waitFor({ timeout: 20_000 });
+    await recoverySubscriptionsHeading.scrollIntoViewIfNeeded();
     // Usage/count caches are still fresh, but detailed rows are never cached as
     // authority. A remount must therefore issue one live overview and restore the
     // durable same-attempt resume affordance rather than rendering no inventory.

--- a/test/e2e/codex-overview.e2e.ts
+++ b/test/e2e/codex-overview.e2e.ts
@@ -421,6 +421,15 @@ describe("Codex quota real browser/API/Postgres reset overview", () => {
     await page.getByRole("heading", { name: "Codex subscriptions" }).waitFor({ timeout: 20_000 });
     const accountCard = (name: string) =>
       page.getByRole("article", { name: `${name} Codex subscription` });
+    const expandAccount = async (name: string) => {
+      const card = accountCard(name);
+      const show = card.getByRole("button", { name: `Show details for ${name}` });
+      if (await show.isVisible()) {
+        await show.click();
+      }
+      await card.getByRole("button", { name: `Hide details for ${name}` }).waitFor();
+    };
+    await expandAccount("Detailed account");
     await accountCard("Detailed account")
       .getByText("Provider detail is complete.")
       .waitFor({ timeout: 20_000 });
@@ -439,25 +448,32 @@ describe("Codex quota real browser/API/Postgres reset overview", () => {
         .getByText(/available again\./)
         .count(),
     ).toBe(1);
+    await expandAccount("Count-only account");
     await accountCard("Count-only account")
       .getByText(/individual details are unavailable\. View only\./)
       .waitFor();
+    await expandAccount("Capped account");
     await accountCard("Capped account")
       .getByText("The provider returned fewer details than its count. View only.")
       .waitFor();
+    await expandAccount("Unknown account");
     await accountCard("Unknown account")
       .getByText("The provider returned reset data OpenGeni does not recognize. View only.")
       .waitFor();
+    await expandAccount("Unsupported account");
     await accountCard("Unsupported account")
       .getByText("This subscription does not expose reset-credit details.")
       .waitFor();
+    await expandAccount("Error account");
     await accountCard("Error account")
       .getByText("Reset-credit inventory is unavailable. Refresh to retry.")
       .waitFor();
+    await expandAccount("Cached account");
     await accountCard("Cached account")
       .getByText(/OpenGeni cache · stale/)
       .waitFor();
     expect(provider.maxActiveOverviewCalls).toBeLessThanOrEqual(4);
+    await expandAccount("Detailed account");
     expect(await page.getByRole("button", { name: /^Redeem / }).count()).toBe(1);
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(
       true,
@@ -500,6 +516,12 @@ describe("Codex quota real browser/API/Postgres reset overview", () => {
     const mobileDetailed = mobile.getByRole("article", {
       name: "Detailed account Codex subscription",
     });
+    const mobileShow = mobileDetailed.getByRole("button", {
+      name: "Show details for Detailed account",
+    });
+    if (await mobileShow.isVisible()) {
+      await mobileShow.tap();
+    }
     await mobileDetailed.getByRole("button", { name: "Redeem Full reset" }).waitFor();
     expect(
       (await mobileDetailed.getByRole("button", { name: "Redeem Full reset" }).boundingBox())
@@ -620,6 +642,15 @@ describe("Codex quota real browser/API/Postgres reset overview", () => {
     // The provider has removed the credit after the ambiguous first call. The
     // browser exposes only the durable same-attempt resume path. With no stale
     // local provider title, the fallback label remains deliberately generic.
+    const recoveryDetailed = recoveryPage.getByRole("article", {
+      name: "Detailed account Codex subscription",
+    });
+    const recoveryShow = recoveryDetailed.getByRole("button", {
+      name: "Show details for Detailed account",
+    });
+    if (await recoveryShow.isVisible()) {
+      await recoveryShow.click();
+    }
     await recoveryPage
       .getByRole("button", {
         name: "Resume uncertain redemption of usage limit reset",

--- a/test/e2e/knowledge-surfaces.browser.e2e.ts
+++ b/test/e2e/knowledge-surfaces.browser.e2e.ts
@@ -258,7 +258,12 @@ describe("responsive knowledge surfaces (real API + PostgreSQL)", () => {
               await expectOwnedTouchTargets(page, surface);
             }
             if (matrixCase.label === "desktop") {
+              // Workspace destinations live in the upward Settings hub menu.
               const workspaceNav = page.getByRole("navigation", { name: "Workspace" });
+              const menu = workspaceNav.locator("details");
+              if (!(await menu.evaluate((node) => (node as HTMLDetailsElement).open))) {
+                await menu.locator("summary").click();
+              }
               await workspaceNav.getByRole("link", { name: "Memory", exact: true }).waitFor();
             }
             if (surface === "variable-sets") {

--- a/test/e2e/seed/monster/payloads.ts
+++ b/test/e2e/seed/monster/payloads.ts
@@ -280,7 +280,8 @@ export function mcpIssue(id: string, title: string): ToolSpec {
 
 export function sessionCreate(id: string, childSessionId: string, message: string): ToolSpec {
   return {
-    name: "session_create",
+    // Live wire uses the prefixed first-party MCP name.
+    name: "opengeni__session_create",
     id,
     arguments: { initialMessage: message },
     output: {
@@ -296,7 +297,7 @@ export function sessionCreate(id: string, childSessionId: string, message: strin
 
 export function sessionCreateRunning(id: string, message: string): ToolSpec {
   return {
-    name: "session_create",
+    name: "opengeni__session_create",
     id,
     arguments: { initialMessage: message },
     running: true,
@@ -305,7 +306,7 @@ export function sessionCreateRunning(id: string, message: string): ToolSpec {
 
 export function sessionSendMessage(id: string, childSessionId: string, text: string): ToolSpec {
   return {
-    name: "session_send_message",
+    name: "opengeni__session_send_message",
     id,
     arguments: { sessionId: childSessionId, text },
     output: {

--- a/test/e2e/seed/stream-scenarios.ts
+++ b/test/e2e/seed/stream-scenarios.ts
@@ -622,8 +622,7 @@ const SCENARIO_WORKER_FLEET: StreamScenario = {
     },
     {
       kind: "message",
-      text:
-        "Three workers are up. The **Messaging worker** row is `session_send_message` — same bot card as spawn, different title, prompt under it, deep-link into the child.\n\nWaiting on inbound completions…\n",
+      text: "Three workers are up. The **Messaging worker** row is `session_send_message` — same bot card as spawn, different title, prompt under it, deep-link into the child.\n\nWaiting on inbound completions…\n",
       stream: true,
       pacing: "yank",
     },
@@ -631,8 +630,7 @@ const SCENARIO_WORKER_FLEET: StreamScenario = {
     {
       kind: "worker-completion",
       childSessionId: (ctx) => ctx.scratch.loginWorker!,
-      text:
-        "Login flow verified end-to-end across Chromium, Firefox, and WebKit. All 128 assertions passed; the dashboard screenshot is attached. No flakes on three reruns.",
+      text: "Login flow verified end-to-end across Chromium, Firefox, and WebKit. All 128 assertions passed; the dashboard screenshot is attached. No flakes on three reruns.",
       childStatus: "idle",
       goal: {
         status: "completed",
@@ -645,22 +643,19 @@ const SCENARIO_WORKER_FLEET: StreamScenario = {
     {
       kind: "worker-completion",
       childSessionId: (ctx) => ctx.scratch.migrateWorker!,
-      text:
-        "I paused the migration worker — it needs the GHCR pull credentials before it can pull the base image, and I did not want to burn continuations retrying a blocked step.",
+      text: "I paused the migration worker — it needs the GHCR pull credentials before it can pull the base image, and I did not want to burn continuations retrying a blocked step.",
       childStatus: "idle",
       goal: {
         status: "paused",
         text: "migrate the billing service to the new Postgres cluster",
-        pausedReason:
-          "missing GHCR pull credentials — cannot pull ghcr.io/acme/billing base image",
+        pausedReason: "missing GHCR pull credentials — cannot pull ghcr.io/acme/billing base image",
       },
     },
     { kind: "sleep", ms: 480 },
     {
       kind: "worker-completion",
       childSessionId: (ctx) => ctx.scratch.loadWorker!,
-      text:
-        "The load-test worker failed: the staging target returned 503 for the whole window, so I could not gather a clean baseline.",
+      text: "The load-test worker failed: the staging target returned 503 for the whole window, so I could not gather a clean baseline.",
       childStatus: "failed",
       goal: {
         status: "active",
@@ -669,8 +664,7 @@ const SCENARIO_WORKER_FLEET: StreamScenario = {
     },
     {
       kind: "message",
-      text:
-        "Inbound cards landed: one **Worker completed**, one **Worker paused**, one **Worker failed**. Expand any for the full report; **View session** deep-links into the child.\n",
+      text: "Inbound cards landed: one **Worker completed**, one **Worker paused**, one **Worker failed**. Expand any for the full report; **View session** deep-links into the child.\n",
       stream: true,
       pacing: "fast",
     },

--- a/test/e2e/seed/stream-scenarios.ts
+++ b/test/e2e/seed/stream-scenarios.ts
@@ -3,7 +3,8 @@
  * Each exercises a different timeline motion/content/pacing combination so
  * watching the open session surfaces fold choreography, tool marathons,
  * markdown crystallize, fast vs slow models, laggy stalls, failures, memory,
- * sandbox, and workers — not one thin metronome pulse.
+ * sandbox, workers (spawn/message + inbound childCompletion cards) — not one
+ * thin metronome pulse.
  */
 import type { AppendEventInput } from "@opengeni/db";
 import {
@@ -32,6 +33,11 @@ export type StreamCtx = {
   turnIndex: number;
   turnId: string;
   id: (label: string) => string;
+  /**
+   * Per-turn scratch so later phases can reuse ids minted earlier
+   * (e.g. child session ids from spawn tools → worker-completion cards).
+   */
+  scratch: Record<string, string>;
 };
 
 /** Named pacing presets — resolved against OPENGENI_SEED_STREAM_TOKEN_MS. */
@@ -91,6 +97,23 @@ export type StreamPhase =
     }
   | { kind: "goal-set"; text: string }
   | { kind: "goal-update"; text: string }
+  /**
+   * Inbound feedback from a child session — a `user.message` with
+   * `childCompletion` that projects to a worker-completion card (not a user bubble).
+   */
+  | {
+      kind: "worker-completion";
+      childSessionId: (ctx: StreamCtx) => string;
+      text: string;
+      childStatus: string;
+      goal?: {
+        status: string;
+        text?: string;
+        evidence?: string;
+        pausedReason?: string;
+        rationale?: string;
+      };
+    }
   | { kind: "raw"; events: (ctx: StreamCtx) => AppendEventInput[] };
 
 export function resolveStreamPacing(
@@ -563,10 +586,103 @@ const SCENARIO_HUGE_FAST_WALL: StreamScenario = {
   ],
 };
 
+const SCENARIO_WORKER_FLEET: StreamScenario = {
+  id: "worker-spawn",
+  title: "Workers: spawn, message, inbound completions",
+  userText: () =>
+    "Scenario: spawn workers, message one, then show completed / paused / failed feedback cards.",
+  phases: [
+    {
+      kind: "reason",
+      text: "Delegate login verification and a staging baseline to workers; keep coordinating here.",
+    },
+    {
+      kind: "tools",
+      settleMs: 280,
+      gapMs: 180,
+      tools: (ctx) => {
+        const login = crypto.randomUUID();
+        const migrate = crypto.randomUUID();
+        const load = crypto.randomUUID();
+        ctx.scratch.loginWorker = login;
+        ctx.scratch.migrateWorker = migrate;
+        ctx.scratch.loadWorker = load;
+        return [
+          sessionCreate(ctx.id("w0"), login, "verify login flow end-to-end"),
+          sessionCreate(ctx.id("w1"), migrate, "migrate billing service to new Postgres"),
+          sessionCreate(ctx.id("w2"), load, "capture a p95 latency baseline against staging"),
+          sessionSendMessage(
+            ctx.id("w3"),
+            login,
+            "please finish assertions and report — include screenshot evidence",
+          ),
+          execOk(ctx.id("w4"), "echo waiting-on-workers"),
+        ];
+      },
+    },
+    {
+      kind: "message",
+      text:
+        "Three workers are up. The **Messaging worker** row is `session_send_message` — same bot card as spawn, different title, prompt under it, deep-link into the child.\n\nWaiting on inbound completions…\n",
+      stream: true,
+      pacing: "yank",
+    },
+    { kind: "sleep", ms: 700 },
+    {
+      kind: "worker-completion",
+      childSessionId: (ctx) => ctx.scratch.loginWorker!,
+      text:
+        "Login flow verified end-to-end across Chromium, Firefox, and WebKit. All 128 assertions passed; the dashboard screenshot is attached. No flakes on three reruns.",
+      childStatus: "idle",
+      goal: {
+        status: "completed",
+        text: "verify login flow end-to-end",
+        evidence:
+          "128/128 assertions green on 3 consecutive runs; screenshot dashboard-2026-07-07.png captured.",
+      },
+    },
+    { kind: "sleep", ms: 480 },
+    {
+      kind: "worker-completion",
+      childSessionId: (ctx) => ctx.scratch.migrateWorker!,
+      text:
+        "I paused the migration worker — it needs the GHCR pull credentials before it can pull the base image, and I did not want to burn continuations retrying a blocked step.",
+      childStatus: "idle",
+      goal: {
+        status: "paused",
+        text: "migrate the billing service to the new Postgres cluster",
+        pausedReason:
+          "missing GHCR pull credentials — cannot pull ghcr.io/acme/billing base image",
+      },
+    },
+    { kind: "sleep", ms: 480 },
+    {
+      kind: "worker-completion",
+      childSessionId: (ctx) => ctx.scratch.loadWorker!,
+      text:
+        "The load-test worker failed: the staging target returned 503 for the whole window, so I could not gather a clean baseline.",
+      childStatus: "failed",
+      goal: {
+        status: "active",
+        text: "capture a p95 latency baseline against staging",
+      },
+    },
+    {
+      kind: "message",
+      text:
+        "Inbound cards landed: one **Worker completed**, one **Worker paused**, one **Worker failed**. Expand any for the full report; **View session** deep-links into the child.\n",
+      stream: true,
+      pacing: "fast",
+    },
+  ],
+};
+
 export const STREAM_SCENARIOS: StreamScenario[] = [
   // Listed twice so the long wall runs ~2× as often as sibling scenarios.
   SCENARIO_HUGE_FAST_WALL,
   SCENARIO_HUGE_FAST_WALL,
+  // Early in the cycle so the live harness shows fleet orchestration soon.
+  SCENARIO_WORKER_FLEET,
   {
     id: "markdown-kitchen-sink",
     title: "Markdown kitchen sink (mixed pacing + crystallize)",
@@ -842,32 +958,6 @@ export const STREAM_SCENARIOS: StreamScenario[] = [
         text: "Sandbox ops mixed with a truncated fat log. Expand the huge exec row to stress disclosure height animation.\n",
         stream: true,
         pacing: "burst",
-      },
-    ],
-  },
-  {
-    id: "worker-spawn",
-    title: "Spawn worker + send message",
-    userText: () => "Scenario: spawn a child session worker and send it a follow-up.",
-    phases: [
-      { kind: "reason", text: "Delegate the e2e assertion pass to a worker." },
-      {
-        kind: "tools",
-        settleMs: 320,
-        tools: (ctx) => {
-          const child = crypto.randomUUID();
-          return [
-            sessionCreate(ctx.id("w0"), child, "verify login flow end-to-end"),
-            sessionSendMessage(ctx.id("w1"), child, "please finish assertions and report"),
-            execOk(ctx.id("w2"), "echo waiting-on-worker"),
-          ];
-        },
-      },
-      {
-        kind: "message",
-        text: "Worker spawned. The worker row should deep-link; parent narration continues here.\n",
-        stream: true,
-        pacing: "yank",
       },
     ],
   },

--- a/test/e2e/seed/stream-session-events.ts
+++ b/test/e2e/seed/stream-session-events.ts
@@ -388,6 +388,35 @@ async function playPhase(
       return publish(db, bus, workspaceId, sessionId, [
         { type: "goal.updated", payload: { text: phase.text }, turnId: ctx.turnId },
       ]);
+    case "worker-completion": {
+      const childSessionId = phase.childSessionId(ctx);
+      const goal = phase.goal
+        ? {
+            status: phase.goal.status,
+            ...(phase.goal.text !== undefined ? { text: phase.goal.text } : {}),
+            ...(phase.goal.evidence !== undefined ? { evidence: phase.goal.evidence } : {}),
+            ...(phase.goal.pausedReason !== undefined
+              ? { pausedReason: phase.goal.pausedReason }
+              : {}),
+            ...(phase.goal.rationale !== undefined ? { rationale: phase.goal.rationale } : {}),
+          }
+        : undefined;
+      return publish(db, bus, workspaceId, sessionId, [
+        {
+          type: "user.message",
+          // Real inbound completions are turn-less machine notices on the parent.
+          payload: {
+            text: phase.text,
+            childCompletion: {
+              childSessionId,
+              status: phase.childStatus,
+              ...(goal !== undefined ? { goal } : {}),
+            },
+          },
+          turnId: null,
+        },
+      ]);
+    }
     case "raw":
       return publish(db, bus, workspaceId, sessionId, phase.events(ctx));
   }
@@ -407,6 +436,7 @@ async function streamScenario(
     turnIndex,
     turnId,
     id: (label) => `stream-${turnIndex}-${label}-${crypto.randomUUID().slice(0, 8)}`,
+    scratch: {},
   };
   let published = 0;
   const messageAcc = { text: "" };


### PR DESCRIPTION
## Summary
- Collapse the flat workspace rail into a **Workspace** config menu; densify settings (preferences, members, collapsible API keys) and Codex subscription rows with expandable detail and reset-expiry urgency.
- Harden timeline tool UX: canonical product icons, session-title preview shows the title, tip-follow unpin for programmatic scroll, and draft SWR so the model picker does not flash on soft reloads.
- Includes prior session chrome polish (composer/timeline scroll ownership) that was still local on main.

## Test plan
- [ ] Desktop rail: sessions primary; Workspace opens upward grouped menu; child routes mark Workspace active
- [ ] Workspace page: compact name edit, preference toggles, dense Codex rows (click to expand), API keys collapsed by default
- [ ] Timeline: rigs/artifacts/docs icons match nav; Set session title shows the title not "Done"
- [ ] Scroll away mid-stream (Vimium/PageUp) stays unpinned; loadOlder does not flash model picker
- [ ] `bun test packages/react/test/timeline.test.ts packages/react/test/hooks.test.tsx packages/react/test/message-timeline-pagination.test.tsx packages/react/test/tool-registry.test.ts`


Made with [Cursor](https://cursor.com)