### PR TITLE
fix(release): keep workbench budgets canonical

### DIFF
--- a/scripts/verify-workbench-acceptance-bundle.test.ts
+++ b/scripts/verify-workbench-acceptance-bundle.test.ts
@@ -296,6 +296,15 @@ describe("workbench acceptance bundle", () => {
     capture.measurement!.p95 = 201;
     expect(() => validate(slow)).toThrow("exceeds 200 ms");
 
+    const slowWorkbench = validBundle();
+    const workbench = slowWorkbench.results.find(
+      (item) => item.requirementId === "performance.capture-usable-workbench",
+    )!;
+    workbench.measurement!.p95 = 5_001;
+    workbench.measurement!.p99 = 5_001;
+    workbench.measurement!.worst = 5_001;
+    expect(() => validate(slowWorkbench)).toThrow("exceeds 5000 ms");
+
     const secret = validBundle() as any;
     secret.cookie = "session=not-allowed";
     expect(() => validate(secret)).toThrow("forbidden secret field");

--- a/scripts/workbench-acceptance-contract.ts
+++ b/scripts/workbench-acceptance-contract.ts
@@ -59,7 +59,7 @@ export const NUMERIC_PERFORMANCE_BUDGETS: Readonly<Record<string, NumericBudget>
   "performance.capture-usable-workbench": {
     statistic: "p95",
     direction: "maximum",
-    limit: 500,
+    limit: 5_000,
     unit: "ms",
   },
   "performance.control-cancellation": {

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -13,6 +13,8 @@ import {
 import { assertScreenshotPainted } from "@opengeni/testing";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 
+import { NUMERIC_PERFORMANCE_BUDGETS } from "./workbench-acceptance-contract";
+
 const WORKBENCH_CANARY_PERMISSIONS = [
   "workspace:read",
   "sessions:create",
@@ -33,7 +35,11 @@ const SETTLED = new Set(["idle", "failed", "error", "cancelled"]);
 const CHANNEL_A_PATH = /\/sessions\/[^/]+\/(?:fs|git|terminal)\//;
 const WORKSPACE_SURFACE_SELECTOR = "[data-workspace-surface]";
 const CHANGES_LAYOUT_SELECTOR = "[data-workbench-changes-layout]";
-const CAPTURE_USABLE_WORKBENCH_P95_MS = 5_000;
+const CAPTURE_API_P95_MS = maximumMillisecondBudget("performance.capture-api-response", "p95");
+const CAPTURE_USABLE_WORKBENCH_P95_MS = maximumMillisecondBudget(
+  "performance.capture-usable-workbench",
+  "p95",
+);
 const shaPattern = /^[0-9a-f]{40}$/;
 const runIdPattern = /^[a-z0-9][a-z0-9-]{2,63}$/;
 
@@ -327,8 +333,8 @@ async function main(): Promise<void> {
     args.repetitions,
   );
   const captureApiResponse = measurement(captureApiSamples);
-  if (captureApiResponse.p95 > 200) {
-    throw new Error(`capture API p95 ${captureApiResponse.p95}ms exceeds 200ms`);
+  if (captureApiResponse.p95 > CAPTURE_API_P95_MS) {
+    throw new Error(`capture API p95 ${captureApiResponse.p95}ms exceeds ${CAPTURE_API_P95_MS}ms`);
   }
 
   const browser = await chromium.launch();
@@ -456,6 +462,19 @@ async function main(): Promise<void> {
   process.stdout.write(
     `${JSON.stringify({ status: "passed", receipt: receiptPath, sha256: receiptArtifact.sha256 })}\n`,
   );
+}
+
+function maximumMillisecondBudget(requirementId: string, statistic: "p95" | "worst"): number {
+  const budget = NUMERIC_PERFORMANCE_BUDGETS[requirementId];
+  if (
+    !budget ||
+    budget.direction !== "maximum" ||
+    budget.unit !== "ms" ||
+    budget.statistic !== statistic
+  ) {
+    throw new Error(`missing maximum millisecond budget for ${requirementId}`);
+  }
+  return budget.limit;
 }
 
 export function fixturePrompt(marker: string): string {


### PR DESCRIPTION
## Summary
- make the live workbench acceptance runner read performance thresholds from the canonical acceptance contract
- align cold capture-backed navigation verification with the live 5-second p95 budget
- add a regression proving the downstream verifier rejects measurements above that shared budget

## Validation
- targeted acceptance tests pass: 18 tests
- all 23 TypeScript projects typecheck
- formatting, lint, public hygiene, and diff checks pass
- repository-wide local suite: 5,537 pass, 8 skip; 26 existing platform-sensitive process/tar/filesystem tests fail on macOS and remain covered by protected Linux CI