### PR TITLE
fix(slack): preserve linked user model for inbound tasks

### DIFF
--- a/.changeset/slack-inbound-model-admission.md
+++ b/.changeset/slack-inbound-model-admission.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/db": patch
+---
+
+Preserve the linked Slack user's latest session model for inbound tasks and surface bounded session admission failures in Slack.

--- a/.changeset/slack-inbound-model-admission.md
+++ b/.changeset/slack-inbound-model-admission.md
@@ -3,4 +3,4 @@
 "@opengeni/db": patch
 ---
 
-Preserve the linked Slack user's latest session model for inbound tasks and surface bounded session admission failures in Slack.
+Preserve the linked Slack user's latest effective browser-selected turn model for inbound tasks and surface bounded session admission failures in Slack.

--- a/apps/api/src/integrations/slack-interactions.ts
+++ b/apps/api/src/integrations/slack-interactions.ts
@@ -18,6 +18,7 @@ import {
   deleteSlackBotUserLink,
   enqueueSlackInteractionInbox,
   getOrCreateSlackInteraction,
+  getLatestSessionModelForSubject,
   getSlackBotUserLink,
   getSlackInteractionByRoute,
   getWorkspaceGrant,
@@ -344,6 +345,14 @@ export async function drainSlackInteractionsOnce(deps: ApiRouteDeps): Promise<bo
       });
     } catch (error) {
       const code = safeErrorCode(error);
+      console.error("[slack-interactions] inbox processing failed", {
+        workspaceId: entry.workspaceId,
+        connectionId: entry.connectionId,
+        providerEventId: entry.providerEventId,
+        triggerKind: entry.triggerKind,
+        attemptCount: entry.attemptCount,
+        errorCode: code,
+      });
       if (
         entry.attemptCount >= 5 ||
         permanentSlackInteractionError(error) ||
@@ -492,14 +501,35 @@ async function processSlackInboxEntry(deps: ApiRouteDeps, entry: SlackInteractio
     await continueSlackSession(deps, grant, interaction, entry);
     return;
   }
-  const session = await createSessionForRequest(deps, grant, entry.workspaceId, {
-    requestedSessionId: interaction.sessionReservationId,
-    initialMessage: entry.text,
-    turnInstructions: SLACK_TASK_INSTRUCTIONS,
-    firstPartyMcpTools: [...SLACK_TASK_FIRST_PARTY_MCP_TOOLS],
-    idempotencyKey: `slack:${entry.connectionId}:${entry.providerEventId}`,
-    clientEventId: `slack:${entry.providerEventId}`,
-  });
+  const preferredModel = await getLatestSessionModelForSubject(
+    deps.db,
+    entry.workspaceId,
+    grant.subjectId,
+  );
+  let session: Awaited<ReturnType<typeof createSessionForRequest>>;
+  try {
+    session = await createSessionForRequest(deps, grant, entry.workspaceId, {
+      requestedSessionId: interaction.sessionReservationId,
+      initialMessage: entry.text,
+      turnInstructions: SLACK_TASK_INSTRUCTIONS,
+      firstPartyMcpTools: [...SLACK_TASK_FIRST_PARTY_MCP_TOOLS],
+      ...(preferredModel ? { model: preferredModel } : {}),
+      idempotencyKey: `slack:${entry.connectionId}:${entry.providerEventId}`,
+      clientEventId: `slack:${entry.providerEventId}`,
+    });
+  } catch (error) {
+    if (error instanceof HTTPException) {
+      await client.postMessage({
+        operationId: deterministicUuid(`slack-admission-failed:${interaction.id}`),
+        channelId: entry.slackChannelId,
+        ...(entry.triggerKind === "slash_command"
+          ? {}
+          : { threadTimestamp: entry.slackThreadTs ?? entry.slackMessageTs }),
+        text: slackAdmissionFailureText(error),
+      });
+    }
+    throw error;
+  }
   const bound = await bindSlackInteractionSession(deps.db, {
     ...interaction,
     owningSubjectId: grant.subjectId,
@@ -982,6 +1012,7 @@ function safePayloadText(payload: unknown, field: string) {
 
 function safeErrorCode(error: unknown) {
   if (error instanceof SlackBotProviderError) return error.code.slice(0, 128);
+  if (error instanceof HTTPException) return `http_${error.status}`;
   const raw = error instanceof Error ? error.name : "slack_interaction_error";
   return (
     raw
@@ -989,6 +1020,16 @@ function safeErrorCode(error: unknown) {
       .replace(/[^a-z0-9_-]/g, "_")
       .slice(0, 128) || "error"
   );
+}
+
+function slackAdmissionFailureText(error: HTTPException) {
+  if (error.status === 402) {
+    return "OpenGeni could not start this task because the selected model has no available billing source. Open OpenGeni, select a connected subscription model, and try again.";
+  }
+  if (error.status === 429) {
+    return "OpenGeni could not start this task because this workspace has reached a usage limit. Try again later or review the workspace limits in OpenGeni.";
+  }
+  return "OpenGeni could not start this task because the workspace rejected the session settings. Open OpenGeni, select an available model, and try again.";
 }
 
 class SlackInteractionPermanentError extends Error {}

--- a/apps/api/test/slack-interactions-integration.test.ts
+++ b/apps/api/test/slack-interactions-integration.test.ts
@@ -17,7 +17,11 @@ import {
   saveSlackBotUserLink,
   type DbClient,
 } from "@opengeni/db";
-import type { ApiRouteDeps, SessionWorkflowClient } from "@opengeni/core";
+import {
+  createSessionForRequest,
+  type ApiRouteDeps,
+  type SessionWorkflowClient,
+} from "@opengeni/core";
 import {
   acquireSharedTestDatabase,
   MemoryEventBus,
@@ -197,6 +201,7 @@ async function fixture(
     deniedChannels?: string[];
     linkOther?: boolean;
     failAfterAcceptTexts?: string[];
+    managedBilling?: boolean;
   } = {},
 ) {
   const suffix = crypto.randomUUID();
@@ -232,6 +237,7 @@ async function fixture(
   const otherSlackUserId = `U_OTHER_${suffix}`;
   const settings = testSettings({
     productAccessMode: "managed",
+    ...(options.managedBilling ? { usageLimitsMode: "managed", billingMode: "stripe" } : {}),
     environmentsEncryptionKey: encryptionKey,
     slackSigningSecret: signingMaterial,
     publicBaseUrl: "https://app.example.test",
@@ -506,6 +512,69 @@ describe("Slack-to-OpenGeni real PostgreSQL acceptance", () => {
         (select count(*)::int from documents where workspace_id = ${value.owner.workspaceId}) as documents,
         (select count(*)::int from knowledge_memories where workspace_id = ${value.owner.workspaceId}) as memories`;
     expect(persistence).toEqual({ documents: 0, memories: 0 });
+  });
+
+  test("new Slack tasks preserve the linked subject's latest session model", async () => {
+    if (!available) return;
+    const value = await fixture();
+    await createSessionForRequest(value.deps, value.owner, value.owner.workspaceId, {
+      initialMessage: "Previously selected model",
+      model: "gpt-5.6-terra",
+      sandboxBackend: "none",
+    });
+
+    expect(
+      (
+        await postEvent(value.app, {
+          teamId: value.teamId,
+          eventId: `E_PREFERRED_MODEL_${crypto.randomUUID()}`,
+          event: {
+            type: "message",
+            channel_type: "im",
+            user: value.ownerSlackUserId,
+            channel: "D_PRIVATE",
+            ts: "1710000002.000001",
+            text: "Use my current OpenGeni model",
+          },
+        })
+      ).status,
+    ).toBe(200);
+    await drainAll(value.deps);
+
+    const [route] = await interactions(value.owner.workspaceId);
+    const [session] = await shared!.admin<{ model: string }[]>`
+      select model from sessions
+      where workspace_id = ${value.owner.workspaceId}
+        and id = ${route!.session_id}`;
+    expect(session!.model).toBe("gpt-5.6-terra");
+  });
+
+  test("permanent session admission failures are visible in Slack and retain a useful code", async () => {
+    if (!available) return;
+    const value = await fixture({ managedBilling: true });
+    expect(
+      (
+        await postEvent(value.app, {
+          teamId: value.teamId,
+          eventId: `E_NO_CREDIT_${crypto.randomUUID()}`,
+          event: {
+            type: "app_mention",
+            user: value.ownerSlackUserId,
+            channel: "C_TEAM",
+            ts: "1710000002.000001",
+            text: `<@${value.botUserId}> start a task`,
+          },
+        })
+      ).status,
+    ).toBe(200);
+    await drainAll(value.deps);
+
+    expect(value.slack.posts.at(-1)?.text).toContain("no available billing source");
+    const [inbox] = await shared!.admin<{ status: string; last_error_code: string }[]>`
+      select status, last_error_code
+      from slack_interaction_inbox
+      where workspace_id = ${value.owner.workspaceId}`;
+    expect(inbox).toEqual({ status: "failed", last_error_code: "http_402" });
   });
 
   test("channel mentions adopt existing threads and any linked workspace participant can continue", async () => {

--- a/apps/api/test/slack-interactions-integration.test.ts
+++ b/apps/api/test/slack-interactions-integration.test.ts
@@ -13,11 +13,14 @@ import {
   createConnection,
   createDb,
   encryptVariableSetValue,
+  getLatestSessionModelForSubject,
+  getWorkspaceGrant,
   grantWorkspaceAccess,
   saveSlackBotUserLink,
   type DbClient,
 } from "@opengeni/db";
 import {
+  acceptSessionUserMessage,
   createSessionForRequest,
   type ApiRouteDeps,
   type SessionWorkflowClient,
@@ -202,6 +205,7 @@ async function fixture(
     linkOther?: boolean;
     failAfterAcceptTexts?: string[];
     managedBilling?: boolean;
+    codexSubscriptionEnabled?: boolean;
   } = {},
 ) {
   const suffix = crypto.randomUUID();
@@ -238,6 +242,7 @@ async function fixture(
   const settings = testSettings({
     productAccessMode: "managed",
     ...(options.managedBilling ? { usageLimitsMode: "managed", billingMode: "stripe" } : {}),
+    ...(options.codexSubscriptionEnabled ? { codexSubscriptionEnabled: true } : {}),
     environmentsEncryptionKey: encryptionKey,
     slackSigningSecret: signingMaterial,
     publicBaseUrl: "https://app.example.test",
@@ -514,7 +519,272 @@ describe("Slack-to-OpenGeni real PostgreSQL acceptance", () => {
     expect(persistence).toEqual({ documents: 0, memories: 0 });
   });
 
-  test("new Slack tasks preserve the linked subject's latest session model", async () => {
+  test("new Slack tasks preserve a later browser-selected turn model", async () => {
+    if (!available) return;
+    const value = await fixture({ codexSubscriptionEnabled: true });
+    const browserSession = await createSessionForRequest(
+      value.deps,
+      value.owner,
+      value.owner.workspaceId,
+      {
+        initialMessage: "Initially selected Terra",
+        model: "gpt-5.6-terra",
+        sandboxBackend: "none",
+      },
+    );
+    await acceptSessionUserMessage(
+      value.deps,
+      value.owner,
+      value.owner.workspaceId,
+      browserSession.id,
+      {
+        text: "Switch this session to my connected Codex model",
+        model: "codex/gpt-5.6-sol",
+        clientEventId: `browser-model-switch-${crypto.randomUUID()}`,
+      },
+    );
+
+    expect(
+      (
+        await postEvent(value.app, {
+          teamId: value.teamId,
+          eventId: `E_PREFERRED_MODEL_${crypto.randomUUID()}`,
+          event: {
+            type: "message",
+            channel_type: "im",
+            user: value.ownerSlackUserId,
+            channel: "D_PRIVATE",
+            ts: "1710000002.000001",
+            text: "Use my current OpenGeni model",
+          },
+        })
+      ).status,
+    ).toBe(200);
+    await drainAll(value.deps);
+
+    const [route] = await interactions(value.owner.workspaceId);
+    const [session] = await shared!.admin<{ model: string }[]>`
+      select model from sessions
+      where workspace_id = ${value.owner.workspaceId}
+        and id = ${route!.session_id}`;
+    expect(session!.model).toBe("codex/gpt-5.6-sol");
+  });
+
+  test("subject model lookup orders turns across sessions, resolves ties, and falls back without turns", async () => {
+    if (!available) return;
+    const value = await fixture({ codexSubscriptionEnabled: true });
+    const olderSession = await createSessionForRequest(
+      value.deps,
+      value.owner,
+      value.owner.workspaceId,
+      {
+        initialMessage: "Older Terra session",
+        model: "gpt-5.6-terra",
+        sandboxBackend: "none",
+      },
+    );
+    await acceptSessionUserMessage(
+      value.deps,
+      value.owner,
+      value.owner.workspaceId,
+      olderSession.id,
+      {
+        text: "Choose Codex later in the older session",
+        model: "codex/gpt-5.6-sol",
+        clientEventId: `older-session-model-switch-${crypto.randomUUID()}`,
+      },
+    );
+    const newerSession = await createSessionForRequest(
+      value.deps,
+      value.owner,
+      value.owner.workspaceId,
+      {
+        initialMessage: "Newer Luna session",
+        model: "gpt-5.6-luna",
+        sandboxBackend: "none",
+      },
+    );
+
+    await shared!.admin`
+      update sessions
+      set created_at = '2026-08-02T10:00:00Z'::timestamptz
+      where workspace_id = ${value.owner.workspaceId}
+        and id = ${olderSession.id}`;
+    await shared!.admin`
+      update session_turns
+      set created_at = case
+        when model = 'codex/gpt-5.6-sol' then '2026-08-02T13:00:00Z'::timestamptz
+        else '2026-08-02T10:00:00Z'::timestamptz
+      end
+      where workspace_id = ${value.owner.workspaceId}
+        and session_id = ${olderSession.id}`;
+    await shared!.admin`
+      update sessions
+      set created_at = '2026-08-02T12:00:00Z'::timestamptz
+      where workspace_id = ${value.owner.workspaceId}
+        and id = ${newerSession.id}`;
+    await shared!.admin`
+      update session_turns
+      set created_at = '2026-08-02T12:00:00Z'::timestamptz
+      where workspace_id = ${value.owner.workspaceId}
+        and session_id = ${newerSession.id}`;
+
+    expect(
+      await getLatestSessionModelForSubject(
+        client.db,
+        value.owner.workspaceId,
+        value.owner.subjectId,
+      ),
+    ).toBe("codex/gpt-5.6-sol");
+
+    await shared!.admin`
+      update session_turns
+      set created_at = '2026-08-02T14:00:00Z'::timestamptz
+      where workspace_id = ${value.owner.workspaceId}
+        and session_id = ${olderSession.id}`;
+    expect(
+      await getLatestSessionModelForSubject(
+        client.db,
+        value.owner.workspaceId,
+        value.owner.subjectId,
+      ),
+    ).toBe("codex/gpt-5.6-sol");
+
+    const fallbackSession = await createSessionForRequest(
+      value.deps,
+      value.owner,
+      value.owner.workspaceId,
+      {
+        initialMessage: "Fallback-only session",
+        model: "gpt-5.6-luna",
+        sandboxBackend: "none",
+      },
+    );
+    await shared!.admin`
+      delete from session_turns
+      where workspace_id = ${value.owner.workspaceId}
+        and session_id = ${fallbackSession.id}`;
+    await shared!.admin`
+      update sessions
+      set created_at = '2026-08-02T15:00:00Z'::timestamptz
+      where workspace_id = ${value.owner.workspaceId}
+        and id = ${fallbackSession.id}`;
+    expect(
+      await getLatestSessionModelForSubject(
+        client.db,
+        value.owner.workspaceId,
+        value.owner.subjectId,
+      ),
+    ).toBe("gpt-5.6-luna");
+  });
+
+  test("subject model lookup ignores other users and workspaces", async () => {
+    if (!available) return;
+    const value = await fixture({ codexSubscriptionEnabled: true });
+    const ownerSession = await createSessionForRequest(
+      value.deps,
+      value.owner,
+      value.owner.workspaceId,
+      {
+        initialMessage: "Owner Terra session",
+        model: "gpt-5.6-terra",
+        sandboxBackend: "none",
+      },
+    );
+    const otherGrant = await getWorkspaceGrant(
+      client.db,
+      value.otherSubjectId,
+      value.owner.workspaceId,
+    );
+    if (!otherGrant) throw new Error("other subject grant was not created");
+    await acceptSessionUserMessage(
+      value.deps,
+      otherGrant,
+      value.owner.workspaceId,
+      ownerSession.id,
+      {
+        text: "Another user chooses Luna",
+        model: "gpt-5.6-luna",
+        clientEventId: `other-subject-model-switch-${crypto.randomUUID()}`,
+      },
+    );
+    const otherSubjectSession = await createSessionForRequest(
+      value.deps,
+      otherGrant,
+      value.owner.workspaceId,
+      {
+        initialMessage: "Other subject Codex session",
+        model: "codex/gpt-5.6-sol",
+        sandboxBackend: "none",
+      },
+    );
+
+    const crossWorkspace = await bootstrapWorkspace(client.db, {
+      accountExternalSource: "slack-interactions-cross-workspace-test",
+      accountExternalId: `account-${crypto.randomUUID()}`,
+      accountName: "Slack interactions cross-workspace",
+      workspaceExternalSource: "slack-interactions-cross-workspace-test",
+      workspaceExternalId: `workspace-${crypto.randomUUID()}`,
+      workspaceName: "Slack interactions cross-workspace",
+      subjectId: value.owner.subjectId,
+    });
+    const crossWorkspaceGrant = crossWorkspace.workspaceGrants[0]!;
+    const crossWorkspaceSession = await createSessionForRequest(
+      value.deps,
+      crossWorkspaceGrant,
+      crossWorkspaceGrant.workspaceId,
+      {
+        initialMessage: "Same subject in another workspace",
+        model: "codex/gpt-5.6-sol",
+        sandboxBackend: "none",
+      },
+    );
+
+    await shared!.admin`
+      update sessions
+      set created_at = '2026-08-02T10:00:00Z'::timestamptz
+      where workspace_id = ${value.owner.workspaceId}
+        and id = ${ownerSession.id}`;
+    await shared!.admin`
+      update session_turns
+      set created_at = case
+        when initiator_subject_id = ${value.otherSubjectId}
+          then '2026-08-02T20:00:00Z'::timestamptz
+        else '2026-08-02T10:00:00Z'::timestamptz
+      end
+      where workspace_id = ${value.owner.workspaceId}
+        and session_id = ${ownerSession.id}`;
+    await shared!.admin`
+      update sessions
+      set created_at = '2026-08-02T21:00:00Z'::timestamptz
+      where workspace_id = ${value.owner.workspaceId}
+        and id = ${otherSubjectSession.id}`;
+    await shared!.admin`
+      update session_turns
+      set created_at = '2026-08-02T21:00:00Z'::timestamptz
+      where workspace_id = ${value.owner.workspaceId}
+        and session_id = ${otherSubjectSession.id}`;
+    await shared!.admin`
+      update sessions
+      set created_at = '2026-08-02T22:00:00Z'::timestamptz
+      where workspace_id = ${crossWorkspaceGrant.workspaceId}
+        and id = ${crossWorkspaceSession.id}`;
+    await shared!.admin`
+      update session_turns
+      set created_at = '2026-08-02T22:00:00Z'::timestamptz
+      where workspace_id = ${crossWorkspaceGrant.workspaceId}
+        and session_id = ${crossWorkspaceSession.id}`;
+
+    expect(
+      await getLatestSessionModelForSubject(
+        client.db,
+        value.owner.workspaceId,
+        value.owner.subjectId,
+      ),
+    ).toBe("gpt-5.6-terra");
+  });
+
+  test("new Slack tasks preserve the linked subject's latest session default", async () => {
     if (!available) return;
     const value = await fixture();
     await createSessionForRequest(value.deps, value.owner, value.owner.workspaceId, {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17693,10 +17693,12 @@ export async function listSessions(
 }
 
 /**
- * Return the model most recently chosen by one human subject in a workspace.
- * Host-initiated surfaces such as Slack use this to preserve the user's model
- * and billing principal instead of silently falling back to the deployment
- * default. The workspace filter remains authoritative under FORCE RLS.
+ * Return the model most recently chosen by one human subject in their own
+ * workspace sessions. A later subject-initiated turn supersedes the session's
+ * creation-time default; sessions with no such turn fall back to sessions.model.
+ * Turn timestamp ties use queue position then UUID, and session ties use the
+ * immutable session timestamp/UUID. Other subjects' turns never influence the
+ * result. The workspace filter remains authoritative under FORCE RLS.
  */
 export async function getLatestSessionModelForSubject(
   db: Database,
@@ -17704,18 +17706,39 @@ export async function getLatestSessionModelForSubject(
   subjectId: string,
 ): Promise<string | null> {
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
-    const [row] = await scopedDb
-      .select({ model: schema.sessions.model })
-      .from(schema.sessions)
-      .where(
-        and(
-          eq(schema.sessions.workspaceId, workspaceId),
-          eq(schema.sessions.createdBySubjectId, subjectId),
-        ),
-      )
-      .orderBy(desc(schema.sessions.createdAt), desc(schema.sessions.id))
-      .limit(1);
-    return row?.model ?? null;
+    const rows = await scopedDb.execute<{ model: string }>(sql`
+      select coalesce(latest_subject_turn.model, subject_session.model) as model
+      from ${schema.sessions} subject_session
+      left join lateral (
+        select
+          subject_turn.id,
+          subject_turn.model,
+          subject_turn.position,
+          subject_turn.created_at
+        from ${schema.sessionTurns} subject_turn
+        where subject_turn.workspace_id = ${workspaceId}
+          and subject_turn.session_id = subject_session.id
+          and subject_turn.initiator_kind = 'subject'
+          and subject_turn.initiator_subject_id = ${subjectId}
+        order by
+          subject_turn.created_at desc,
+          subject_turn.position desc,
+          subject_turn.id desc
+        limit 1
+      ) latest_subject_turn on true
+      where subject_session.workspace_id = ${workspaceId}
+        and subject_session.created_by_kind = 'subject'
+        and subject_session.created_by_subject_id = ${subjectId}
+      order by
+        coalesce(latest_subject_turn.created_at, subject_session.created_at) desc,
+        (latest_subject_turn.id is not null) desc,
+        subject_session.created_at desc,
+        subject_session.id desc,
+        latest_subject_turn.position desc nulls last,
+        latest_subject_turn.id desc nulls last
+      limit 1
+    `);
+    return rows[0]?.model ?? null;
   });
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17692,6 +17692,33 @@ export async function listSessions(
   });
 }
 
+/**
+ * Return the model most recently chosen by one human subject in a workspace.
+ * Host-initiated surfaces such as Slack use this to preserve the user's model
+ * and billing principal instead of silently falling back to the deployment
+ * default. The workspace filter remains authoritative under FORCE RLS.
+ */
+export async function getLatestSessionModelForSubject(
+  db: Database,
+  workspaceId: string,
+  subjectId: string,
+): Promise<string | null> {
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const [row] = await scopedDb
+      .select({ model: schema.sessions.model })
+      .from(schema.sessions)
+      .where(
+        and(
+          eq(schema.sessions.workspaceId, workspaceId),
+          eq(schema.sessions.createdBySubjectId, subjectId),
+        ),
+      )
+      .orderBy(desc(schema.sessions.createdAt), desc(schema.sessions.id))
+      .limit(1);
+    return row?.model ?? null;
+  });
+}
+
 export type SessionDiscoveryOrderBy = "createdAt" | "updatedAt";
 export type SessionDiscoveryCursor = {
   orderBy: SessionDiscoveryOrderBy;


### PR DESCRIPTION
## Summary

- preserve a linked Slack user’s latest effective browser-selected turn model for new inbound Slack tasks
- return bounded admission failures to the originating Slack surface instead of failing silently
- retain actionable bounded inbox error codes such as `http_402` and emit structured diagnostics

## Staging root cause

Staging Slack ingress and identity linking succeeded, but task admission omitted a model and fell back to deployment default `gpt-5.6-sol`. Staging uses managed Stripe billing and the test account has zero OpenGeni credits, while the same user’s browser sessions use `codex/gpt-5.6-sol` through a connected Codex subscription. The resulting HTTP 402 was collapsed to `error` and no Slack failure reply was posted.

## Independent review finding and correction — August 2, 2026

Independent review blocked head `80088a4e1157dae7d5ba0ff9439e448172d5b764` because `getLatestSessionModelForSubject` read `sessions.model` from the newest subject-created session even though browser follow-up model choices are persisted in `session_turns.model` without updating the session default. An in-session switch from `gpt-5.6-terra` to `codex/gpt-5.6-sol` could therefore leave new Slack tasks on stale Terra and reproduce HTTP 402.

The corrected helper now:

- resolves the newest turn initiated by the target subject within that subject’s own sessions in the target workspace
- orders turn timestamp ties deterministically by queue position and immutable turn UUID
- compares effective selection timestamps across newer and older sessions with stable session tie-breakers
- falls back to `sessions.model` only for sessions with no qualifying subject turn
- excludes service turns, other subjects’ turns/sessions, and the same subject’s sessions in other workspaces
- retains the existing workspace-scoped FORCE-RLS transaction boundary

## Corrected-head verification

- corrected head: `001e7291a046ad1d0ca56f1ce3a0f6264dc58a78`
- corrected tree: `f30b140f64e05b4d370da676ab395ef8a14cf3e6`
- PostgreSQL 16.14 + pgvector 0.8.5 acceptance: 13/13 tests in `slack-interactions-integration.test.ts`
- full focused Slack suite: 101/101 tests across 12 files, 631 assertions, with `OPENGENI_REQUIRE_REAL_DB=1`
- `@opengeni/db` and `@opengeni/api-router` typechecks
- repository-wide lint and format checks
- docs-reference, public-hygiene, and diff checks
- current-main synthetic merge against `0c4c96f8340302dbfcf13da6130feb8738814de4`: clean four-path merge, synthetic tree `c2833d4799517eb9fa299f32a8e7bf693905a059`, DB/API typechecks and 101/101 focused Slack tests pass

Fresh immutable-head review is requested for `001e7291a046ad1d0ca56f1ce3a0f6264dc58a78`. Source work stops before review or merge.

Linear: OPE-141
