### PR TITLE
chore(release): advance product version to 0.22.44

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.43
-appVersion: "0.22.43"
+version: 0.22.44
+appVersion: "0.22.44"


### PR DESCRIPTION
## Summary

- advance the source-controlled Helm chart and application release identity to 0.22.44
- preserve the one-version/one-artifact invariant after 0.22.43 was distributed

## Verification

- `helm lint deploy/helm/opengeni`
- `bun test scripts/release-version.test.ts scripts/release-candidate.test.ts scripts/release-image-workflow-contract.test.ts`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun scripts/check-public-repo-hygiene.ts`