### PR TITLE
fix(runtime): preserve routed exec results

### DIFF
--- a/.changeset/curly-mails-rest.md
+++ b/.changeset/curly-mails-rest.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Preserve structured exec results when routing to execCommand-only sandbox backends so file, Git, and PTY operations retain provider output and process authority.

--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -30,7 +30,7 @@
 import type { ExposedPortEndpoint } from "../stream-port";
 import { SelfhostedControlError } from "../selfhosted/control-rpc";
 import { renderSelfhostedFault } from "../selfhosted/fault-rendering";
-import { isExecSessionLostBanner } from "../channel-a";
+import { isExecSessionLostBanner, stripExecBanner } from "../channel-a";
 import { parseExecBannerExitCode, parseExecBannerSessionId } from "../exec-banner";
 import { withSandboxProviderOperation } from "../provider-operation-gate";
 
@@ -428,6 +428,34 @@ function formatExecResult(result: unknown): string {
     return `Process exited with code ${exitCode}\n\nOutput:\n${output}`;
   }
   throw new Error("sandbox process-control exec reported neither session id nor exit code");
+}
+
+/** Preserve the structural `exec()` contract when the active backend exposes
+ * only the SDK's banner-returning `execCommand()` surface (Modal's current
+ * shape). The routing proxy itself always exposes `exec()`, so returning the
+ * raw banner string from that fallback makes downstream structural consumers
+ * treat a string as `SandboxExecResult` and silently lose stdout, exit status,
+ * and a yielded PTY's provider session id. */
+function structuredExecResultFromBanner(result: string): {
+  output: string;
+  stdout: string;
+  stderr: string;
+  wallTimeSeconds: number;
+  exitCode?: number | null;
+  sessionId?: number;
+} {
+  const output = stripExecBanner(result);
+  const sessionId = positiveProviderSessionId(parseExecBannerSessionId(result));
+  if (sessionId !== null) {
+    return { output, stdout: output, stderr: "", wallTimeSeconds: 0, sessionId };
+  }
+  return {
+    output,
+    stdout: output,
+    stderr: "",
+    wallTimeSeconds: 0,
+    exitCode: parseExecBannerExitCode(result),
+  };
 }
 
 /**
@@ -1123,7 +1151,7 @@ export class RoutingSandboxSession implements RoutableBackendSession {
       }
       // Some backends (selfhosted) only expose exec; others only execCommand.
       if (s.execCommand) {
-        return s.execCommand(args);
+        return structuredExecResultFromBanner(await s.execCommand(args));
       }
       throw new RoutingUnsupportedError("exec", this.cached?.kind ?? "unknown");
     });

--- a/packages/runtime/test/routing-proxy.test.ts
+++ b/packages/runtime/test/routing-proxy.test.ts
@@ -174,6 +174,42 @@ describe("RoutingSandboxSession — per-call re-read + per-epoch dispatch", () =
     });
   });
 
+  test("exec preserves structured output and PTY authority on an execCommand-only backend", async () => {
+    const promotions: Array<number | null> = [];
+    const backend: RoutableBackendSession = {
+      async execCommand(args) {
+        return (args as { tty?: boolean }).tty
+          ? "Chunk ID: pty\nWall time: 0.25 seconds\nProcess running with session ID 81\nOutput:\nroot@box:/workspace# "
+          : "Chunk ID: read\nWall time: 0.01 seconds\nProcess exited with code 7\nOutput:\nstructured output";
+      },
+    };
+    const proxy = new RoutingSandboxSession({
+      readPointer: async () => ({ activeSandboxId: null, activeEpoch: 0 }),
+      resolveActiveBackend: async () => ({ session: backend, sandboxId: null, kind: "modal" }),
+      beforeMutation: async () => "admission",
+      afterMutation: async ({ retainedProcess }) => {
+        promotions.push(retainedProcess?.providerSessionId ?? null);
+      },
+    });
+
+    await expect(proxy.exec({ cmd: "read" })).resolves.toEqual({
+      output: "structured output",
+      stdout: "structured output",
+      stderr: "",
+      wallTimeSeconds: 0,
+      exitCode: 7,
+    });
+    await expect(proxy.exec({ cmd: "/bin/bash", tty: true })).resolves.toEqual({
+      output: "root@box:/workspace# ",
+      stdout: "root@box:/workspace# ",
+      stderr: "",
+      wallTimeSeconds: 0,
+      sessionId: 81,
+    });
+    expect(promotions).toEqual([null, 81]);
+    expect(proxy.retainedProcessIdentity(81)).toMatchObject({ providerSessionId: 81 });
+  });
+
   test("a fenced read retry produces one observation per physical attempt", async () => {
     const pointer = mutablePointer({ activeSandboxId: "old", activeEpoch: 1 });
     const observations: Array<{ backend: string; outcome: string }> = [];


### PR DESCRIPTION
## Summary

- preserve the structured `exec()` contract when the routing proxy targets an `execCommand()`-only backend such as Modal
- retain stdout, terminal exit status, and yielded provider session IDs instead of returning a raw SDK banner string
- restore Channel-A Files/Git framing and durable PTY process authority through the routed Modal session
- add a runtime patch changeset and a regression covering both completed commands and a live PTY

## Root cause

`RoutingSandboxSession` always exposes `exec()`. On Modal, the underlying session exposes only `execCommand()`, so the proxy fallback returned its formatted banner string directly. `SandboxChannelAService` selected the proxy's structural `exec()` method and treated that string as a `SandboxExecResult`, silently losing output, exit status, and `sessionId`. The provider process still ran and could be durably retained, but Files/Git received no trusted frame and PTY open could not adopt its process authority.

## Validation

- `bun test --isolate --parallel 1 packages/runtime/test/routing-proxy.test.ts --test-name-pattern 'exec preserves structured output and PTY authority'`
- routing proxy suite produced `51 pass / 0 fail / 206 expect()`
- `bun run typecheck` — all 23 projects clean
- `bun run --cwd packages/runtime typecheck`
- targeted Oxfmt and Oxlint — zero findings
- `git diff --check`

A pre-existing local performance test (`fsListPruned indexes a production-sized tree`) exceeded its 10-second yield guard on this Mac at ~23 seconds. The same isolated failure reproduced on untouched `0c4c96f`, so it is not caused by this change; protected CI remains authoritative for that host-sensitive test.
