### PR TITLE
fix(release): accept compact workbench evidence

### DIFF
--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -6,7 +6,9 @@ import {
   assertFixtureCapture,
   assertDedicatedCanaryEmail,
   assertAcceptancePrincipalScopes,
+  assertChangedFileLabelsContainRepositoryRoots,
   assertChangesDefaultVisible,
+  assertRepositoryChangesVisible,
   controlCancellationDurationMs,
   fixturePrompt,
   openWorkspaceIfCollapsed,
@@ -67,6 +69,45 @@ describe("workbench live acceptance preflight", () => {
     await assertChangesDefaultVisible(page);
 
     expect(calls).toEqual(["tab.wait", "selected-changes.wait", "layout.wait"]);
+  });
+
+  test("accepts repository evidence from the compact changed-file picker", async () => {
+    const calls: string[] = [];
+    const page = {
+      locator(selector: string) {
+        if (selector === "[data-workbench-changes-layout]") {
+          return {
+            getAttribute: async () => "compact",
+          };
+        }
+        expect(selector).toBe("[data-compact-file-picker]");
+        return {
+          waitFor: async (options: { state?: string; timeout?: number }) => {
+            expect(options).toEqual({ state: "visible", timeout: 20_000 });
+            calls.push("picker.wait");
+          },
+          locator(optionSelector: string) {
+            expect(optionSelector).toBe("option");
+            return {
+              allTextContents: async () => ["M · server.ts — api/", "M · app.tsx — web/src/"],
+            };
+          },
+        };
+      },
+      getByText() {
+        throw new Error("compact mode must not require hidden repository group labels");
+      },
+    } as never;
+
+    await assertRepositoryChangesVisible(page, ["api", "web"]);
+
+    expect(calls).toEqual(["picker.wait"]);
+  });
+
+  test("fails closed when compact changes omit an expected repository", () => {
+    expect(() =>
+      assertChangedFileLabelsContainRepositoryRoots(["M · server.ts — api/"], ["api", "web"]),
+    ).toThrow("compact workbench changes omitted repository web");
   });
 
   test("rejects the protected manually used production account", () => {

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -1835,8 +1835,7 @@ async function selectTreeFile(page: Page, directory: string, file: string): Prom
 
 async function assertColdReview(page: Page, marker: string): Promise<void> {
   await assertChangesDefaultVisible(page);
-  await page.getByText("api", { exact: true }).first().waitFor();
-  await page.getByText("web", { exact: true }).first().waitFor();
+  await assertRepositoryChangesVisible(page, ["api", "web"]);
 
   await page.getByRole("tab", { name: "Files", exact: true }).click();
   await selectTreeFile(page, "api", "server.ts");
@@ -1845,6 +1844,41 @@ async function assertColdReview(page: Page, marker: string): Promise<void> {
   await selectTreeFile(page, "api", "base.txt");
   await page.getByText("On machine", { exact: true }).waitFor();
   await page.getByRole("button", { name: "Open live file" }).waitFor();
+}
+
+export async function assertRepositoryChangesVisible(
+  page: Page,
+  repositoryRoots: readonly string[],
+): Promise<void> {
+  const layout = page.locator(CHANGES_LAYOUT_SELECTOR);
+  const mode = await layout.getAttribute("data-workbench-changes-layout");
+  if (mode === "rail") {
+    for (const root of repositoryRoots) {
+      await page.getByText(root, { exact: true }).first().waitFor();
+    }
+    return;
+  }
+  if (mode === "compact") {
+    const picker = page.locator("[data-compact-file-picker]");
+    await picker.waitFor({ state: "visible", timeout: 20_000 });
+    assertChangedFileLabelsContainRepositoryRoots(
+      await picker.locator("option").allTextContents(),
+      repositoryRoots,
+    );
+    return;
+  }
+  throw new Error(`unsupported workbench changes layout: ${mode ?? "missing"}`);
+}
+
+export function assertChangedFileLabelsContainRepositoryRoots(
+  labels: readonly string[],
+  repositoryRoots: readonly string[],
+): void {
+  for (const root of repositoryRoots) {
+    if (!labels.some((label) => label.includes(`${root}/`))) {
+      throw new Error(`compact workbench changes omitted repository ${root}`);
+    }
+  }
 }
 
 async function assertAccessibility(page: Page): Promise<void> {


### PR DESCRIPTION
## Summary
- verify captured repository changes through visible repository groups in rail layouts
- verify the same evidence through changed-file options in compact layouts
- fail closed when either expected repository is absent

## Validation
- `bun test scripts/workbench-live-acceptance.test.ts`
- `bun run typecheck`
- `bun run format:check scripts/workbench-live-acceptance.ts scripts/workbench-live-acceptance.test.ts`
- `git diff --check`