### PR TITLE
chore(release): reserve chart 0.22.45

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.44
-appVersion: "0.22.44"
+version: 0.22.45
+appVersion: "0.22.45"


### PR DESCRIPTION
## Summary

- reserve product release version `0.22.45`
- leave package versions and release contents unchanged
- avoid reusing the occupied immutable `0.22.44` coordinates

## Collision gate

- API, worker, web, relay, sandbox, and chart `0.22.45` OCI coordinates are unoccupied
- no matching GitHub release, open reservation PR, or remote reservation branch existed before push

## Validation

- `bun test scripts/release-version.test.ts scripts/release-candidate.test.ts` — 9 pass / 0 fail / 30 assertions
- `helm lint deploy/helm/opengeni` — 1 chart linted / 0 failed
- structured YAML parse verifies chart/app version equality at `0.22.45`
- `git diff --check`

This is the release-version reservation required before merging generated Version PR #923. Cloudgeni PR #1577 remains unmerged.