### PR TITLE
chore(release): advance product version to 0.22.45

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.44
-appVersion: "0.22.44"
+version: 0.22.45
+appVersion: "0.22.45"


### PR DESCRIPTION
## Summary
- advance the immutable OpenGeni chart and application version to 0.22.45
- keep the replacement release artifacts distinct from the prior terminal train

## Validation
- `bun test scripts/release-version.test.ts scripts/release-candidate.test.ts`
- `git diff --check`