### PR TITLE
fix(release): preserve expanded file selection

### DIFF
--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -16,6 +16,7 @@ import {
   parseLiveAcceptanceArgs,
   parseProtectedEmails,
   sanitizeDiagnostic,
+  selectTreeFile,
   waitForSandboxLiveness,
 } from "./workbench-live-acceptance";
 
@@ -69,6 +70,36 @@ describe("workbench live acceptance preflight", () => {
     await assertChangesDefaultVisible(page);
 
     expect(calls).toEqual(["tab.wait", "selected-changes.wait", "layout.wait"]);
+  });
+
+  test("keeps an expanded file-tree directory open when selecting another file", async () => {
+    const clicks: string[] = [];
+    const directoryButton = { click: async () => clicks.push("directory") };
+    const fileButton = { click: async () => clicks.push("file") };
+    const directoryItem = {
+      getAttribute: async (name: string) => {
+        expect(name).toBe("aria-expanded");
+        return "true";
+      },
+      getByRole: () => ({ first: () => directoryButton }),
+    };
+    const fileItem = {
+      getByRole: () => fileButton,
+    };
+    const page = {
+      getByRole(role: string) {
+        expect(role).toBe("treeitem");
+        return {
+          filter({ hasText }: { hasText: string }) {
+            return { first: () => (hasText === "api" ? directoryItem : fileItem) };
+          },
+        };
+      },
+    } as never;
+
+    await selectTreeFile(page, "api", "base.txt");
+
+    expect(clicks).toEqual(["file"]);
   });
 
   test("accepts repository evidence from the compact changed-file picker", async () => {

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -1824,10 +1824,10 @@ async function selectChangesTab(page: Page): Promise<void> {
   });
 }
 
-async function selectTreeFile(page: Page, directory: string, file: string): Promise<void> {
+export async function selectTreeFile(page: Page, directory: string, file: string): Promise<void> {
   const directoryItem = page.getByRole("treeitem").filter({ hasText: directory }).first();
   const directoryButton = directoryItem.getByRole("button").first();
-  if ((await directoryButton.getAttribute("aria-expanded")) !== "true") {
+  if ((await directoryItem.getAttribute("aria-expanded")) !== "true") {
     await directoryButton.click();
   }
   await page.getByRole("treeitem").filter({ hasText: file }).first().getByRole("button").click();


### PR DESCRIPTION
## Summary
- read folder expansion state from the accessible tree item
- avoid collapsing an already-expanded directory when selecting a second file
- add a focused regression test for repeated file selection

## Verification
- `bun test scripts/workbench-live-acceptance.test.ts`
- `oxlint --deny-warnings scripts/workbench-live-acceptance.ts scripts/workbench-live-acceptance.test.ts`
- `bun run typecheck` (via the full local gate)
- public repository hygiene and builds (via the full local gate)