### PR TITLE
fix(react): make Markdown scroll regions keyboard accessible

### DIFF
--- a/.changeset/bright-scrolls-focus.md
+++ b/.changeset/bright-scrolls-focus.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Make horizontally scrollable Markdown code blocks and tables reachable from the keyboard.

--- a/packages/react/src/components/markdown.tsx
+++ b/packages/react/src/components/markdown.tsx
@@ -248,7 +248,10 @@ function MarkdownCodeBlock({ children }: { children?: ReactNode }) {
           <CopyButton text={code} label="Copy code" reveal="group-hover" />
         </div>
       </div>
-      <pre className="overflow-x-auto overflow-y-hidden rounded-og-md bg-og-surface-1/70 px-3 py-2.5 font-og-mono text-og-sm leading-5 text-og-fg-muted [scrollbar-gutter:stable] [&>code]:block [&>code]:border-0 [&>code]:bg-transparent [&>code]:p-0 [&>code]:leading-5 [&>code]:text-inherit">
+      <pre
+        tabIndex={0}
+        className="overflow-x-auto overflow-y-hidden rounded-og-md bg-og-surface-1/70 px-3 py-2.5 font-og-mono text-og-sm leading-5 text-og-fg-muted [scrollbar-gutter:stable] [&>code]:block [&>code]:border-0 [&>code]:bg-transparent [&>code]:p-0 [&>code]:leading-5 [&>code]:text-inherit"
+      >
         {children}
       </pre>
     </div>
@@ -268,7 +271,7 @@ function MarkdownTable({ children, className, ...props }: ComponentPropsWithoutR
           />
         </div>
       </div>
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto" tabIndex={0}>
         <table
           ref={tableRef}
           className={cn("w-full min-w-0 border-collapse text-og-base", className)}

--- a/packages/react/test/copy-button.test.tsx
+++ b/packages/react/test/copy-button.test.tsx
@@ -53,7 +53,9 @@ describe("Markdown copy chrome", () => {
     const source = "```ts\nconst x = 1;\n```";
     const r = await renderComponent(<Markdown>{source}</Markdown>);
     const button = r.container.querySelector('button[data-og-copy][aria-label="Copy code"]');
+    const codeBlock = r.container.querySelector("pre");
     expect(button).not.toBeNull();
+    expect(codeBlock?.getAttribute("tabindex")).toBe("0");
     // Ghost control: no bordered "Copy code" pill chrome.
     expect(button?.textContent?.trim() ?? "").toBe("");
     expect(button?.className ?? "").not.toContain("border-og-border");
@@ -79,7 +81,9 @@ describe("Markdown copy chrome", () => {
     const source = `| A | B |\n| --- | --- |\n| 1 | 2 |`;
     const r = await renderComponent(<Markdown>{source}</Markdown>);
     const button = r.container.querySelector('button[data-og-copy][aria-label="Copy table"]');
+    const scrollRegion = r.container.querySelector("table")?.parentElement;
     expect(button).not.toBeNull();
+    expect(scrollRegion?.getAttribute("tabindex")).toBe("0");
     expect(button?.textContent?.trim() ?? "").toBe("");
     await act(async () => {
       button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));


### PR DESCRIPTION
## Summary

- make horizontally scrollable Markdown code blocks keyboard-focusable
- make horizontally scrollable Markdown tables keyboard-focusable
- cover both scroll regions with regression tests

## Validation

- `bun test packages/react/test/copy-button.test.tsx`
- `bun run --cwd packages/react typecheck`
- `bun run format:check`
- `bun run lint`
- repository-wide test run: 5,618 passed; 26 unrelated local-platform fixture failures (Linux CI is authoritative)