### PR TITLE
chore(release): advance product version to 0.22.49

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.48
-appVersion: "0.22.48"
+version: 0.22.49
+appVersion: "0.22.49"


### PR DESCRIPTION
## Summary

- advance the product and chart version to 0.22.49
- keep the chart and application versions identical

## Verification

- release-version contract
- source diff validation

This is a generic OpenGeni release metadata change.