### PR TITLE
chore(release): advance product version to 0.22.50

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.49
-appVersion: "0.22.49"
+version: 0.22.50
+appVersion: "0.22.50"


### PR DESCRIPTION
## Summary

Advance the OpenGeni product and chart version to `0.22.50` for the next immutable release candidate.

## Validation

- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`