### PR TITLE
feat(gateway): pin approved provider fallback routes

### DIFF
--- a/.changeset/gateway-provider-fallbacks.md
+++ b/.changeset/gateway-provider-fallbacks.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/config": patch
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Pin DeepSeek V4 Flash and Kimi K3 to ordered, approved Vercel AI Gateway
+provider routes, meter managed usage from Gateway-reported cost, and preserve
+Kimi Responses tool continuity without exposing provider details in the UI.

--- a/.changeset/gpt56-max-reasoning.md
+++ b/.changeset/gpt56-max-reasoning.md
@@ -1,7 +1,6 @@
 ---
 "@opengeni/config": patch
 "@opengeni/contracts": patch
-"@opengeni/deployment": patch
 "@opengeni/react": patch
 "@opengeni/sdk": patch
 ---

--- a/.changeset/gpt56-max-reasoning.md
+++ b/.changeset/gpt56-max-reasoning.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/config": patch
+"@opengeni/contracts": patch
+"@opengeni/deployment": patch
+"@opengeni/react": patch
+"@opengeni/sdk": patch
+---
+
+Expose GPT-5.6 Max reasoning end to end for managed and connected Codex models.

--- a/.env.example
+++ b/.env.example
@@ -164,7 +164,7 @@ OPENGENI_OPENAI_PROVIDER=openai
 OPENGENI_OPENAI_MODEL=gpt-5.6-sol
 OPENGENI_OPENAI_REASONING_EFFORT=low
 OPENGENI_OPENAI_ALLOWED_MODELS=gpt-5.6-sol,gpt-5.6-terra,gpt-5.6-luna
-OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS=low,medium,high,xhigh
+OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS=low,medium,high,xhigh,max
 OPENGENI_OPENAI_API_KEY=your-key
 # Optional OpenGeni-managed AI Gateway key. Adds the curated DeepSeek and Kimi
 # models; workspace-owned Gateway keys are connected encrypted in Settings.

--- a/apps/api/CHANGELOG.md
+++ b/apps/api/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - 9c4d73d: Add curated OpenGeni-credit and workspace-key Vercel AI Gateway model paths for
-  DeepSeek V4 Flash and Kimi K3 Fast, including exact provider routing, cache-aware
+  DeepSeek V4 Flash and Kimi K3, including exact provider routing, cache-aware
   pricing and metering, Responses tool continuity, provider-blind catalog UX, and
   stable remote-compaction cache prefixes.
 - Updated dependencies [9c4d73d]

--- a/apps/api/test/model-catalog.test.ts
+++ b/apps/api/test/model-catalog.test.ts
@@ -27,9 +27,16 @@ describe("workspace model catalog availability", () => {
     });
     expect(managed.deployment).toBeUndefined();
     expect(managed.credentialSource).toBeUndefined();
-    expect(JSON.stringify(managed)).not.toContain("deepinfra");
-    expect(JSON.stringify(managed)).not.toContain("baseten");
-    expect(JSON.stringify(managed)).not.toContain("ai-gateway.vercel.sh");
+    const publicManagedModel = JSON.stringify(managed);
+    for (const internalName of [
+      "baseten",
+      "novita",
+      "deepinfra",
+      "fireworks",
+      "ai-gateway.vercel.sh",
+    ]) {
+      expect(publicManagedModel).not.toContain(internalName);
+    }
 
     const workspaceModel = disconnected.models.find(
       (model) => model.id === "workspace-gateway/deepseek-v4-flash-0731",

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1258,7 +1258,7 @@ describe("composer reasoning-effort picker (full host enum)", () => {
       allowedModels: ["gpt-5.6-sol"],
       models: [],
       defaultReasoningEffort: "none",
-      allowedReasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh"],
+      allowedReasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
       mcpServers: [],
       fileUploads: { enabled: false, maxSizeBytes: 0 },
       productAccessMode: "local",
@@ -1293,6 +1293,7 @@ describe("composer reasoning-effort picker (full host enum)", () => {
       "medium",
       "high",
       "xhigh",
+      "max",
     ]);
   });
 
@@ -1314,6 +1315,7 @@ describe("composer reasoning-effort picker (full host enum)", () => {
       "Medium",
       "High",
       "Extra high",
+      "Max",
     ]);
   });
 });

--- a/apps/web/src/lib/session-tools.ts
+++ b/apps/web/src/lib/session-tools.ts
@@ -64,6 +64,7 @@ export const reasoningEffortOrder: IntelligenceEffort[] = [
   "medium",
   "high",
   "xhigh",
+  "max",
 ];
 
 export function isIntelligenceEffort(value: unknown): value is IntelligenceEffort {

--- a/apps/worker/CHANGELOG.md
+++ b/apps/worker/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - 9c4d73d: Add curated OpenGeni-credit and workspace-key Vercel AI Gateway model paths for
-  DeepSeek V4 Flash and Kimi K3 Fast, including exact provider routing, cache-aware
+  DeepSeek V4 Flash and Kimi K3, including exact provider routing, cache-aware
   pricing and metering, Responses tool continuity, provider-blind catalog UX, and
   stable remote-compaction cache prefixes.
 - Updated dependencies [9c4d73d]

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -142,6 +142,7 @@ import {
 import { connectionTokenResolverForTurn } from "./mcp-credentials";
 import {
   assertTurnExecutionPolicyMatchesConfigV1,
+  calculateGatewayReportedCostMicros,
   calculateModelUsageCostMicros,
   configuredModelPricing,
   configuredStaticUsageLimits,
@@ -151,6 +152,8 @@ import {
   serviceTierForLatencyMode,
   settingsWithResolvedModelContext,
   resolveTurnExecutionPolicyV1,
+  OPENGENI_GATEWAY_MODELS,
+  OPENGENI_GATEWAY_PROVIDER_ID,
   type ModelUsageInput,
   type ModelProviderApi,
   type RegistryProviderKind,
@@ -1186,6 +1189,8 @@ export async function processModelResponseUsageEvent(input: {
         externallyBilled: input.externallyBilled,
         usage: responseUsage.usage,
         normalizedUsage,
+        gatewayManaged: input.provider === OPENGENI_GATEWAY_PROVIDER_ID,
+        gatewayBilling: responseUsage.gatewayBilling,
         sourceKey,
         ...(input.latencyMode ? { latencyMode: input.latencyMode } : {}),
         observability: input.observability,
@@ -1312,6 +1317,8 @@ export async function processCompactionModelUsageEvent(input: {
         externallyBilled: input.externallyBilled,
         usage: input.usage.usage,
         normalizedUsage,
+        gatewayManaged: input.provider === OPENGENI_GATEWAY_PROVIDER_ID,
+        gatewayBilling: input.usage.gatewayBilling,
         sourceKey,
         observability: input.observability,
       });
@@ -9211,6 +9218,7 @@ export type ModelUsageBillingRecord = {
   /** Same quantity written to usage_events.model.cost when present; else 0. */
   pricedCostMicros: number;
   normalizedUsage: ModelCallUsageNormalization;
+  upstreamProvider?: string;
 };
 
 // Exported for unit testing the external-billing bypass; not part of the activity surface.
@@ -9225,6 +9233,8 @@ export async function recordModelUsageAndDebitCredits(
     turnAttemptId: string;
     model: string;
     externallyBilled: boolean;
+    gatewayManaged?: boolean;
+    gatewayBilling?: ModelResponseUsage["gatewayBilling"];
     usage?: ModelUsageInput | ModelCallUsageInput | null;
     normalizedUsage?: ModelCallUsageNormalization;
     sourceKey: string;
@@ -9240,6 +9250,20 @@ export async function recordModelUsageAndDebitCredits(
   const inputTokens = sanitizedUsage.inputTokens ?? 0;
   const outputTokens = sanitizedUsage.outputTokens ?? 0;
   const totalTokens = sanitizedUsage.totalTokens ?? 0;
+  const gatewayBilling = input.gatewayManaged ? input.gatewayBilling : undefined;
+  if (gatewayBilling) {
+    const gatewayModel = Object.values(OPENGENI_GATEWAY_MODELS).find(
+      (candidate) => candidate.productId === input.model,
+    );
+    if (
+      !gatewayModel ||
+      !(gatewayModel.providers as readonly string[]).includes(gatewayBilling.finalProvider)
+    ) {
+      throw new Error(
+        `AI Gateway reported unapproved provider ${gatewayBilling.finalProvider} for ${input.model}`,
+      );
+    }
+  }
   // An externally billed turn is paid outside OpenGeni, so it
   // consumes ZERO OpenGeni credits and must never feed an OpenGeni cap. A
   // codex/<slug> model has no entry in configuredModelPricing, so the normal path
@@ -9285,19 +9309,24 @@ export async function recordModelUsageAndDebitCredits(
     });
   }
   const shouldDebit = settings.billingMode === "stripe" || settings.usageLimitsMode === "managed";
-  if (!shouldDebit || totalTokens === 0) {
+  if (!shouldDebit || (totalTokens === 0 && !gatewayBilling)) {
     return {
       billingPath: "opengeni_credits",
       pricedCostMicros: 0,
       normalizedUsage,
+      ...(gatewayBilling ? { upstreamProvider: gatewayBilling.finalProvider } : {}),
     };
   }
   if (!configuredModelPricing(settings)[input.model]) {
     throw new Error(`Missing model pricing for ${input.model}`);
   }
-  const costMicros = calculateModelUsageCostMicros(settings, input.model, sanitizedUsage, {
-    latencyMode: input.latencyMode ?? "standard",
-  });
+  const costMicros = gatewayBilling
+    ? calculateGatewayReportedCostMicros(settings, input.model, gatewayBilling.inferenceCostUsd, {
+        inputTokens,
+      })
+    : calculateModelUsageCostMicros(settings, input.model, sanitizedUsage, {
+        latencyMode: input.latencyMode ?? "standard",
+      });
   await recordUsageEvent(db, {
     accountId: input.accountId,
     workspaceId: input.workspaceId,
@@ -9333,6 +9362,7 @@ export async function recordModelUsageAndDebitCredits(
         // per-call debit record carries cache efficiency alongside the token
         // counts. 0 when the provider did not report cached tokens.
         cachedTokens: normalizedUsage.telemetry.cachedTokens ?? 0,
+        ...(gatewayBilling ? { gatewayProvider: gatewayBilling.finalProvider } : {}),
       },
     });
     recordCreditMicros(input.observability, "usage", result.debitedMicros);
@@ -9341,6 +9371,7 @@ export async function recordModelUsageAndDebitCredits(
     billingPath: "opengeni_credits",
     pricedCostMicros: costMicros,
     normalizedUsage,
+    ...(gatewayBilling ? { upstreamProvider: gatewayBilling.finalProvider } : {}),
   };
 }
 
@@ -9368,7 +9399,7 @@ export async function recordAuthoritativeModelCallFact(input: {
       turnId: input.turnId,
       turnAttemptId: input.turnAttemptId,
       sourceKey: input.sourceKey,
-      provider: input.provider,
+      provider: input.billing.upstreamProvider ?? input.provider,
       providerApi: input.providerApi,
       model: input.model,
       billingPath: input.billing.billingPath,

--- a/apps/worker/test/codex-billing.test.ts
+++ b/apps/worker/test/codex-billing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, spyOn, test } from "bun:test";
+import { OPENGENI_GATEWAY_MODELS } from "@opengeni/config";
 import * as opengeniDb from "@opengeni/db";
 import { testSettings } from "@opengeni/testing";
 import type { Database } from "@opengeni/db";
@@ -56,6 +57,90 @@ describe("worker ensureRunAllowed — codex bypass", () => {
 });
 
 describe("worker recordModelUsageAndDebitCredits — codex usage recording", () => {
+  test("managed Gateway uses exact reported cost and records the serving provider", async () => {
+    const recorded: Array<{ eventType: string; quantity: number }> = [];
+    const recordSpy = spyOn(opengeniDb, "recordUsageEvent").mockImplementation(
+      async (_db, input) => {
+        recorded.push({ eventType: input.eventType, quantity: input.quantity });
+      },
+    );
+    const debitInputs: Array<Record<string, any>> = [];
+    const debitSpy = spyOn(opengeniDb, "applyCreditDebitUpToBalance").mockImplementation(
+      async (_db, input) => {
+        debitInputs.push(input);
+        return {
+          balance: {
+            accountId: ACCOUNT,
+            balanceMicros: 1_000_000,
+            currency: "usd",
+            updatedAt: new Date().toISOString(),
+          },
+          debitedMicros: input.requestedAmountMicros,
+        };
+      },
+    );
+    try {
+      const billing = await recordModelUsageAndDebitCredits(billedSettings(), db, {
+        accountId: ACCOUNT,
+        workspaceId: WORKSPACE,
+        sessionId: "sess-gateway",
+        turnId: "turn-gateway",
+        turnAttemptId: "attempt-gateway",
+        model: OPENGENI_GATEWAY_MODELS.deepseek.productId,
+        externallyBilled: false,
+        gatewayManaged: true,
+        gatewayBilling: { finalProvider: "baseten", inferenceCostUsd: "0.00000325" },
+        usage: {
+          inputTokens: 9,
+          outputTokens: 8,
+          totalTokens: 17,
+          inputTokensDetails: { cached_tokens: 3 },
+        },
+        sourceKey: "response-gateway",
+      });
+
+      expect(recorded).toContainEqual({ eventType: "model.cost", quantity: 5 });
+      expect(debitInputs).toHaveLength(1);
+      expect(debitInputs[0]).toMatchObject({
+        requestedAmountMicros: 5,
+        metadata: { gatewayProvider: "baseten", cachedTokens: 3 },
+      });
+      expect(billing).toMatchObject({ pricedCostMicros: 5, upstreamProvider: "baseten" });
+    } finally {
+      recordSpy.mockRestore();
+      debitSpy.mockRestore();
+    }
+  });
+
+  test("managed Gateway rejects an unapproved reported provider before recording usage", async () => {
+    const recordSpy = spyOn(opengeniDb, "recordUsageEvent").mockResolvedValue(undefined);
+    const debitSpy = spyOn(opengeniDb, "applyCreditDebitUpToBalance").mockResolvedValue(
+      undefined as never,
+    );
+    try {
+      await expect(
+        recordModelUsageAndDebitCredits(billedSettings(), db, {
+          accountId: ACCOUNT,
+          workspaceId: WORKSPACE,
+          sessionId: "sess-gateway",
+          turnId: "turn-gateway-rejected",
+          turnAttemptId: "attempt-gateway-rejected",
+          model: OPENGENI_GATEWAY_MODELS.deepseek.productId,
+          externallyBilled: false,
+          gatewayManaged: true,
+          gatewayBilling: { finalProvider: "unapproved", inferenceCostUsd: "0.01" },
+          usage: { inputTokens: 9, outputTokens: 8, totalTokens: 17 },
+          sourceKey: "response-gateway-rejected",
+        }),
+      ).rejects.toThrow("AI Gateway reported unapproved provider");
+      expect(recordSpy).not.toHaveBeenCalled();
+      expect(debitSpy).not.toHaveBeenCalled();
+    } finally {
+      recordSpy.mockRestore();
+      debitSpy.mockRestore();
+    }
+  });
+
   test("(d) codex turn records model.cost=0, does NOT throw 'Missing model pricing', and never debits", async () => {
     const recorded: Array<{ eventType: string; quantity: number; unit: string }> = [];
     const recordSpy = spyOn(opengeniDb, "recordUsageEvent").mockImplementation(

--- a/apps/worker/test/model-call-fact.test.ts
+++ b/apps/worker/test/model-call-fact.test.ts
@@ -64,6 +64,49 @@ describe("recordAuthoritativeModelCallFact", () => {
     expect(factSpy).toHaveBeenCalledTimes(1);
   });
 
+  test("records the endpoint provider reported by managed Gateway billing", async () => {
+    const facts: Array<Record<string, unknown>> = [];
+    const factSpy = spyOn(opengeniDb, "recordModelCallFact").mockImplementation(
+      async (_db, input) => {
+        facts.push(input);
+      },
+    );
+    restores.push(() => factSpy.mockRestore());
+
+    await recordAuthoritativeModelCallFact({
+      db,
+      observability: { warn: () => undefined } as never,
+      accountId: ACCOUNT,
+      workspaceId: WORKSPACE,
+      sessionId: "sess-gateway",
+      turnId: "turn-gateway",
+      turnAttemptId: "attempt-gateway",
+      sourceKey: "response-gateway",
+      provider: "opengeni-gateway",
+      providerApi: "responses",
+      model: "deepseek-v4-flash-0731",
+      billing: {
+        billingPath: "opengeni_credits",
+        pricedCostMicros: 5,
+        upstreamProvider: "baseten",
+        normalizedUsage: {
+          telemetry: {
+            inputTokens: 9,
+            outputTokens: 8,
+            cachedTokens: 0,
+            cacheWriteTokens: null,
+            reasoningTokens: null,
+          },
+          totalTokens: 17,
+          rejectedFields: [],
+        },
+      },
+    });
+
+    expect(facts).toHaveLength(1);
+    expect(facts[0]).toMatchObject({ provider: "baseten", pricedCostMicros: 5 });
+  });
+
   test("external billing returns pricedCostMicros 0 for facts", async () => {
     const recordSpy = spyOn(opengeniDb, "recordUsageEvent").mockResolvedValue(undefined as never);
     restores.push(() => recordSpy.mockRestore());

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -122,39 +122,35 @@ models. They are siblings of the built-in GPT-5.6 family in the OpenGeni picker
 rail; the client never receives the Gateway hostname, upstream model slug, or
 endpoint provider.
 
-| Product | Exact route | Supplier input / cache read / output | OpenGeni retail (+25%) |
+| Product | Approved provider order | Supplier input / cache read / output | Conservative retail fallback (+25%) |
 | --- | --- | --- | --- |
-| DeepSeek V4 Flash 0731 | `deepseek/deepseek-v4-flash-0731` → DeepInfra only | $0.09 / $0.018 / $0.18 per 1M | $0.1125 / $0.0225 / $0.225 per 1M |
-| Kimi K3 Fast | `moonshotai/kimi-k3-fast` → Wafer only | $4.50 / $0.45 / $22.50 per 1M | $5.625 / $0.5625 / $28.125 per 1M |
+| DeepSeek V4 Flash 0731 | Baseten → Novita → DeepInfra | Baseten $0.13 / $0.028 / $0.26; Novita $0.14 / $0.028 / $0.28; DeepInfra $0.09 / $0.018 / $0.18 per 1M | $0.175 / $0.035 / $0.35 per 1M (highest approved route) |
+| Kimi K3 | Baseten → Fireworks | $3 / $0.30 / $15 per 1M on both routes | $3.75 / $0.375 / $18.75 per 1M |
 
-Prices are a reviewed 2026-08-02 snapshot from the public Gateway endpoint
-metadata. DeepInfra replaced Baseten for DeepSeek after both supported API
-surfaces and both DeepSeek slugs returned a provider-pinned 503 from Baseten;
-DeepInfra passed Responses text, two parallel tool calls, continuation, and
-implicit cache reporting. Prices are intentionally static: adding a model or changing a route
-requires reviewing its Responses tool-call transport and updating its
-definition, price, and tests together. Wafer's discovery boolean currently
-conflicts with its live response: a provider-pinned continuation returned
-`cached_tokens` and charged $0.45/M cached input. OpenGeni therefore preserves
-and bills that reported cache-read slice. Kimi may emit parallel function calls;
-before the next Responses request, OpenGeni interleaves each complete call/result
-batch without changing any item. Without that wire-order normalization, Gateway
-returns a 400 whose error metadata unexpectedly names base Kimi. The internal
-cause is not observable; the Wafer-only fence prevents any fallback.
+Prices are a reviewed 2026-08-03 snapshot from public Gateway endpoint metadata.
+Managed turns normally debit the exact Gateway-reported inference cost for the
+provider that actually served the response, plus 25%. The static token rates
+above are only a conservative fallback if that response metadata is absent.
+Adding or changing a model requires reviewing the provider order, Responses
+tool/vision transport, cache reporting, pricing, definition, and tests together.
+Kimi's Gateway Responses adapter rejects grouped parallel call/result history.
+At the post-serialization fence, OpenGeni pairs only complete call/result batches
+by `call_id`. This preserves all fields and parallel execution; it does not
+change the model or provider route. Grouped, name-annotated, and Chat Completions
+continuations were probed on 2026-08-03; only the paired Responses shape kept
+full tool continuity plus Gateway route/cost metadata.
 
-Every Gateway request replaces caller routing options with an exact one-item
-`only` and `order` list, sends no model fallback list, and disables OpenAI SDK
-retries. Unknown Gateway model slugs fail before network I/O. Keep Gateway account-level
-rewrite rules disabled for the managed key because those rules operate outside
-the request body.
+Every Gateway request replaces caller routing options with the reviewed provider
+list in both `only` and `order`, sends no model fallback list, and disables OpenAI
+SDK retries. Gateway may advance only through that ordered allowlist. Unknown
+Gateway model slugs fail before network I/O. Keep Gateway account-level rewrite
+rules disabled for the managed key because those rules operate outside the
+request body.
 
-Both models request Gateway automatic caching. Kimi Fast remains catalogued as
+Both models request Gateway automatic caching. Kimi remains catalogued as
 image-capable. OpenGeni verifies finalized attachment bytes and checksums, then
-sends images inline as data URLs; it never gives Gateway or Wafer an object-store
-URL. A 2026-08-02 provider-pinned data-URL probe returned a Gateway 400 whose
-metadata named base Kimi, while an HTTPS-image probe succeeded on Wafer. That is
-recorded as an unresolved Gateway compatibility defect, not worked around by
-granting the provider storage access.
+sends images inline as data URLs through the standard Responses input surface;
+it never gives an endpoint provider an object-store URL.
 
 A workspace admin can instead connect **Vercel AI Gateway** in workspace Settings.
 The key is stored in the encrypted workspace connection table, resolved only in

--- a/packages/codex/test/normalize.test.ts
+++ b/packages/codex/test/normalize.test.ts
@@ -43,6 +43,13 @@ describe("normalizeCodexRequestBody", () => {
         }
       ).effort,
     ).toBe("high");
+    expect(
+      (
+        normalizeCodexRequestBody({ reasoning: { effort: "max" } }, identity).reasoning as {
+          effort: string;
+        }
+      ).effort,
+    ).toBe("max");
   });
 
   test("strips every item id but PRESERVES call_id", () => {

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - 9c4d73d: Add curated OpenGeni-credit and workspace-key Vercel AI Gateway model paths for
-  DeepSeek V4 Flash and Kimi K3 Fast, including exact provider routing, cache-aware
+  DeepSeek V4 Flash and Kimi K3, including exact provider routing, cache-aware
   pricing and metering, Responses tool continuity, provider-blind catalog UX, and
   stable remote-compaction cache prefixes.
 - Updated dependencies [9c4d73d]

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -432,7 +432,7 @@ const SettingsSchema = z.object({
   // match the UI danger flip (UsageBar danger at pct >= 90). OPENGENI_CODEX_ROTATION_NEAR_EXHAUSTION_PCT.
   codexRotationNearExhaustionPct: z.coerce.number().int().min(1).max(100).default(90),
   openaiReasoningEffort: ReasoningEffort.default("low"),
-  openaiAllowedReasoningEfforts: z.string().default("low,medium,high,xhigh"),
+  openaiAllowedReasoningEfforts: z.string().default("low,medium,high,xhigh,max"),
   openaiResponsesTransport: z.enum(["http", "websocket"]).default("http"),
   // Provider-assigned item ids (rs_/msg_/fc_…) in Responses API input are
   // resolved against the provider's server-side response store. That store is

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1415,7 +1415,7 @@ export interface ConfiguredModel {
   capabilities: ModelCapabilitiesV1;
   requestPolicy?: {
     gateway: {
-      only: [string];
+      only: [string, ...string[]];
       caching: "auto" | "none";
     };
   };
@@ -1442,15 +1442,15 @@ export const OPENGENI_GATEWAY_MODELS = {
     workspaceProductId: `${WORKSPACE_GATEWAY_MODEL_ID_PREFIX}deepseek-v4-flash-0731`,
     upstreamModelId: "deepseek/deepseek-v4-flash-0731",
     label: "DeepSeek V4 Flash 0731",
-    provider: "deepinfra",
+    providers: ["baseten", "novita", "deepinfra"],
     implicitCaching: true,
   },
   kimi: {
-    productId: "kimi-k3-fast",
-    workspaceProductId: `${WORKSPACE_GATEWAY_MODEL_ID_PREFIX}kimi-k3-fast`,
-    upstreamModelId: "moonshotai/kimi-k3-fast",
-    label: "Kimi K3 Fast",
-    provider: "wafer",
+    productId: "kimi-k3",
+    workspaceProductId: `${WORKSPACE_GATEWAY_MODEL_ID_PREFIX}kimi-k3`,
+    upstreamModelId: "moonshotai/kimi-k3",
+    label: "Kimi K3",
+    providers: ["baseten", "fireworks"],
     implicitCaching: true,
   },
 } as const;
@@ -1529,24 +1529,24 @@ export const defaultModelPricing: Record<string, ModelPricingScheduleV1> = {
       },
     ],
   },
-  // Vercel AI Gateway endpoint prices, provider-pinned in the runtime.
-  // Snapshot: 2026-08-02. Both pinned routes returned discounted implicit
-  // cache reads in live Gateway responses. Wafer/Kimi reported $0.45/M even
-  // though the provider-discovery flag currently says otherwise; bill from
-  // the response-backed rate, not that inconsistent boolean.
+  // Conservative Vercel AI Gateway fallback prices. Normal managed Gateway
+  // billing uses the exact response Gateway `cost` / `inferenceCost` and applies
+  // the same margin. These token rates are used only if that
+  // metadata is absent. DeepSeek therefore carries the highest approved route
+  // (Novita); both approved Kimi routes have the same list price.
   [OPENGENI_GATEWAY_MODELS.deepseek.productId]: {
     default: {
-      inputMicrosPerMillionTokens: 90_000,
-      cachedInputMicrosPerMillionTokens: 18_000,
-      outputMicrosPerMillionTokens: 180_000,
+      inputMicrosPerMillionTokens: 140_000,
+      cachedInputMicrosPerMillionTokens: 28_000,
+      outputMicrosPerMillionTokens: 280_000,
       marginBps: 2_500,
     },
   },
   [OPENGENI_GATEWAY_MODELS.kimi.productId]: {
     default: {
-      inputMicrosPerMillionTokens: 4_500_000,
-      cachedInputMicrosPerMillionTokens: 450_000,
-      outputMicrosPerMillionTokens: 22_500_000,
+      inputMicrosPerMillionTokens: 3_000_000,
+      cachedInputMicrosPerMillionTokens: 300_000,
+      outputMicrosPerMillionTokens: 15_000_000,
       marginBps: 2_500,
     },
   },
@@ -2279,7 +2279,7 @@ export function gatewayRequestPolicyForUpstreamModel(
   }
   return {
     gateway: {
-      only: [model.provider],
+      only: [...model.providers] as [string, ...string[]],
       caching: model.implicitCaching ? "auto" : "none",
     },
   };
@@ -2304,8 +2304,8 @@ function gatewayModelCapabilities(
     promptCaching: input.implicitCaching
       ? { upstream: "supported", runnable: true, mode: "implicit" }
       : { upstream: "unsupported", runnable: false, mode: "none" },
-    // "Fast" is part of Kimi's product name, not OpenGeni's separately billed
-    // latency mode. Both Gateway products expose only standard here.
+    // Both Gateway products expose one reviewed route policy and no separately
+    // billed latency mode.
     latencyModes: [{ id: "standard", upstream: "supported", runnable: true }],
   });
 }
@@ -2317,19 +2317,22 @@ function gatewayRegistryProvider(
     | { kind: "vercel-gateway-workspace"; apiKey?: string },
 ): RegistryProvider {
   const workspace = input.kind === "vercel-gateway-workspace";
-  const models = [OPENGENI_GATEWAY_MODELS.deepseek, OPENGENI_GATEWAY_MODELS.kimi].map((model) => ({
-    id: workspace ? model.workspaceProductId : model.productId,
-    upstreamModelId: model.upstreamModelId,
-    label: model.label,
-    capabilities: gatewayModelCapabilities(settings, {
-      implicitCaching: model.implicitCaching,
-      vision: model === OPENGENI_GATEWAY_MODELS.kimi,
-    }),
-    contextWindowTokens: 1_000_000,
-    effectiveContextWindowTokens: 900_000,
-    autoCompactTokenLimit: 850_000,
-    toolOutputTruncationTokens: settings.modelToolOutputTruncationTokens,
-  }));
+  const models = [OPENGENI_GATEWAY_MODELS.deepseek, OPENGENI_GATEWAY_MODELS.kimi].map((model) => {
+    const kimi = model === OPENGENI_GATEWAY_MODELS.kimi;
+    return {
+      id: workspace ? model.workspaceProductId : model.productId,
+      upstreamModelId: model.upstreamModelId,
+      label: model.label,
+      capabilities: gatewayModelCapabilities(settings, {
+        implicitCaching: model.implicitCaching,
+        vision: kimi,
+      }),
+      contextWindowTokens: 1_000_000,
+      effectiveContextWindowTokens: 900_000,
+      autoCompactTokenLimit: 850_000,
+      toolOutputTruncationTokens: settings.modelToolOutputTruncationTokens,
+    };
+  });
   return {
     kind: input.kind,
     id: workspace ? WORKSPACE_GATEWAY_PROVIDER_ID : OPENGENI_GATEWAY_PROVIDER_ID,
@@ -3314,6 +3317,39 @@ export function calculateModelUsageCostMicros(
     }
   }
   return total;
+}
+
+/**
+ * Convert AI Gateway's exact USD inference cost to OpenGeni credit micros and
+ * apply the configured model margin. Decimal arithmetic is integer-only so a
+ * sub-micro provider charge cannot be lost to floating-point rounding.
+ */
+export function calculateGatewayReportedCostMicros(
+  settings: Settings,
+  model: string,
+  inferenceCostUsd: string,
+  options?: { inputTokens?: number },
+): number {
+  const schedule = configuredModelPricingSchedules(settings)[model];
+  if (!schedule) {
+    throw new Error(`Missing model pricing for ${model}`);
+  }
+  const pricing = selectModelPricing(schedule, positiveInt(options?.inputTokens));
+  const match = /^(0|[1-9]\d*)(?:\.(\d{1,18}))?$/.exec(inferenceCostUsd);
+  if (!match) {
+    throw new Error("Invalid AI Gateway inference cost");
+  }
+  const fraction = match[2] ?? "";
+  const decimalDigits = BigInt(`${match[1]}${fraction}`);
+  const decimalScale = 10n ** BigInt(fraction.length);
+  const marginBps = BigInt(10_000 + (pricing.marginBps ?? 0));
+  const numerator = decimalDigits * 1_000_000n * marginBps;
+  const denominator = decimalScale * 10_000n;
+  const micros = (numerator + denominator - 1n) / denominator;
+  if (micros > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("AI Gateway inference cost exceeds the supported billing range");
+  }
+  return Number(micros);
 }
 
 export function configuredAllowedReasoningEfforts(

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -403,6 +403,17 @@ describe("sandbox preparation profiles", () => {
     expect(sandboxLifecycleHookIds(settings)).toEqual([]);
   });
 
+  test("offers GPT-5.6 max reasoning by default", () => {
+    const settings = withEnv({}, () => getSettings());
+    expect(configuredAllowedReasoningEfforts(settings)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+  });
+
   test("returns client model and reasoning options with current defaults included", () => {
     const settings = {
       ...withEnv({}, () => getSettings()),

--- a/packages/config/test/model-providers.test.ts
+++ b/packages/config/test/model-providers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   assertTurnExecutionPolicyMatchesConfigV1,
+  calculateGatewayReportedCostMicros,
   calculateModelUsageCostMicros,
   canonicalizeConfiguredModelId,
   configuredAllowedModels,
@@ -82,14 +83,19 @@ describe("curated AI Gateway catalogue", () => {
     const kimi = models.find((model) => model.id === OPENGENI_GATEWAY_MODELS.kimi.productId)!;
     expect(deepseek.upstreamModelId).toBe(OPENGENI_GATEWAY_MODELS.deepseek.upstreamModelId);
     expect(deepseek.requestPolicy).toEqual({
-      gateway: { only: ["deepinfra"], caching: "auto" },
+      gateway: { only: ["baseten", "novita", "deepinfra"], caching: "auto" },
     });
     expect(deepseek.capabilities.promptCaching).toEqual({
       upstream: "supported",
       runnable: true,
       mode: "implicit",
     });
-    expect(kimi.requestPolicy).toEqual({ gateway: { only: ["wafer"], caching: "auto" } });
+    expect(kimi.upstreamModelId).toBe("moonshotai/kimi-k3");
+    expect(kimi.label).toBe("Kimi K3");
+    expect(kimi.aliases).toEqual([]);
+    expect(kimi.requestPolicy).toEqual({
+      gateway: { only: ["baseten", "fireworks"], caching: "auto" },
+    });
     expect(kimi.capabilities.promptCaching).toEqual({
       upstream: "supported",
       runnable: true,
@@ -98,15 +104,15 @@ describe("curated AI Gateway catalogue", () => {
     expect(kimi.capabilities.latencyModes.map((mode) => mode.id)).toEqual(["standard"]);
 
     expect(configuredModelPricing(settings)[deepseek.id]).toEqual({
-      inputMicrosPerMillionTokens: 90_000,
-      cachedInputMicrosPerMillionTokens: 18_000,
-      outputMicrosPerMillionTokens: 180_000,
+      inputMicrosPerMillionTokens: 140_000,
+      cachedInputMicrosPerMillionTokens: 28_000,
+      outputMicrosPerMillionTokens: 280_000,
       marginBps: 2_500,
     });
     expect(configuredModelPricing(settings)[kimi.id]).toEqual({
-      inputMicrosPerMillionTokens: 4_500_000,
-      cachedInputMicrosPerMillionTokens: 450_000,
-      outputMicrosPerMillionTokens: 22_500_000,
+      inputMicrosPerMillionTokens: 3_000_000,
+      cachedInputMicrosPerMillionTokens: 300_000,
+      outputMicrosPerMillionTokens: 15_000_000,
       marginBps: 2_500,
     });
   });
@@ -133,7 +139,7 @@ describe("curated AI Gateway catalogue", () => {
     ).toBe("vck_workspace");
   });
 
-  test("managed debit applies DeepInfra cache-read price and the existing 25% margin", () => {
+  test("managed debit fallback uses the highest approved DeepSeek route", () => {
     const settings = {
       ...getSettings(),
       modelProvidersJson: "[]",
@@ -145,10 +151,10 @@ describe("curated AI Gateway catalogue", () => {
         outputTokens: 1_000_000,
         inputTokensDetails: { cached_tokens: 1_000_000 },
       }),
-    ).toBe(247_500);
+    ).toBe(385_000);
   });
 
-  test("managed debit applies Wafer's response-backed cache-read price", () => {
+  test("managed debit fallback applies normal Kimi cache-read pricing", () => {
     const settings = {
       ...getSettings(),
       modelProvidersJson: "[]",
@@ -160,7 +166,37 @@ describe("curated AI Gateway catalogue", () => {
         outputTokens: 0,
         inputTokensDetails: { cached_tokens: 1_000_000 },
       }),
-    ).toBe(562_500);
+    ).toBe(375_000);
+  });
+
+  test("managed debit converts exact Gateway cost before applying margin", () => {
+    const settings = {
+      ...getSettings(),
+      modelProvidersJson: "[]",
+      vercelAiGatewayApiKey: "vck_test",
+    };
+    expect(
+      calculateGatewayReportedCostMicros(
+        settings,
+        OPENGENI_GATEWAY_MODELS.deepseek.productId,
+        "0.00000325",
+        { inputTokens: 9 },
+      ),
+    ).toBe(5);
+    expect(
+      calculateGatewayReportedCostMicros(
+        settings,
+        OPENGENI_GATEWAY_MODELS.deepseek.productId,
+        "1.23456789",
+      ),
+    ).toBe(1_543_210);
+    expect(() =>
+      calculateGatewayReportedCostMicros(
+        settings,
+        OPENGENI_GATEWAY_MODELS.deepseek.productId,
+        "NaN",
+      ),
+    ).toThrow("Invalid AI Gateway inference cost");
   });
 });
 

--- a/packages/config/test/model-providers.test.ts
+++ b/packages/config/test/model-providers.test.ts
@@ -1138,7 +1138,7 @@ describe("turn execution policy V1", () => {
       modelId: "codex/gpt-5.6-sol",
       requestedModelId: null,
       modelSource: "session",
-      reasoningEffort: "xhigh",
+      reasoningEffort: "max",
       reasoningSource: "session",
     });
     expect(policy).toMatchObject({
@@ -1148,6 +1148,7 @@ describe("turn execution policy V1", () => {
       credentialSource: { kind: "connected_subscription", provider: "codex" },
       billing: { upstreamPayer: "connected_subscription", metering: "external" },
     });
+    expect(policy.reasoningEffort).toBe("max");
   });
 });
 describe("Grok 4.5 explicit xAI registry contract", () => {

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - 9c4d73d: Add curated OpenGeni-credit and workspace-key Vercel AI Gateway model paths for
-  DeepSeek V4 Flash and Kimi K3 Fast, including exact provider routing, cache-aware
+  DeepSeek V4 Flash and Kimi K3, including exact provider routing, cache-aware
   pricing and metering, Responses tool continuity, provider-blind catalog UX, and
   stable remote-compaction cache prefixes.
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -503,7 +503,7 @@ export const CAPABILITY_DESCRIPTORS: Record<SandboxBackend, CapabilityDescriptor
   },
 };
 
-export const ReasoningEffort = z.enum(["none", "minimal", "low", "medium", "high", "xhigh"]);
+export const ReasoningEffort = z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"]);
 
 /** Provider service-tier / latency mode selected for a turn or session default. */
 export const LatencyMode = z.enum(["standard", "priority", "fast"]);
@@ -3604,7 +3604,8 @@ export function reasoningEffortForMetadata(
     value === "low" ||
     value === "medium" ||
     value === "high" ||
-    value === "xhigh"
+    value === "xhigh" ||
+    value === "max"
     ? value
     : fallback;
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - 9c4d73d: Add curated OpenGeni-credit and workspace-key Vercel AI Gateway model paths for
-  DeepSeek V4 Flash and Kimi K3 Fast, including exact provider routing, cache-aware
+  DeepSeek V4 Flash and Kimi K3, including exact provider routing, cache-aware
   pricing and metering, Responses tool continuity, provider-blind catalog UX, and
   stable remote-compaction cache prefixes.
 - Updated dependencies [9c4d73d]

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - 9c4d73d: Add curated OpenGeni-credit and workspace-key Vercel AI Gateway model paths for
-  DeepSeek V4 Flash and Kimi K3 Fast, including exact provider routing, cache-aware
+  DeepSeek V4 Flash and Kimi K3, including exact provider routing, cache-aware
   pricing and metering, Responses tool continuity, provider-blind catalog UX, and
   stable remote-compaction cache prefixes.
 - Updated dependencies [9c4d73d]

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -2149,7 +2149,7 @@ function runtimeEnvValues(
     valueEnv("OPENGENI_OPENAI_REASONING_EFFORT", env.OPENGENI_OPENAI_REASONING_EFFORT ?? "low"),
     valueEnv(
       "OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS",
-      env.OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS ?? "low,medium,high,xhigh",
+      env.OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS ?? "low,medium,high,xhigh,max",
     ),
     ...(inferredOpenAiProvider(env) === "azure"
       ? [
@@ -2464,7 +2464,7 @@ function addRuntimeConfigHelmValues(
     "gpt-5.6-sol,gpt-5.6-terra,gpt-5.6-luna";
   values["config.OPENGENI_OPENAI_REASONING_EFFORT"] = env.OPENGENI_OPENAI_REASONING_EFFORT ?? "low";
   values["config.OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS"] =
-    env.OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS ?? "low,medium,high,xhigh";
+    env.OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS ?? "low,medium,high,xhigh,max";
   for (const key of [
     "OPENGENI_ANALYTICS_ENABLED",
     "OPENGENI_ANALYTICS_CONSENT_REQUIRED",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - 9c4d73d: Add curated OpenGeni-credit and workspace-key Vercel AI Gateway model paths for
-  DeepSeek V4 Flash and Kimi K3 Fast, including exact provider routing, cache-aware
+  DeepSeek V4 Flash and Kimi K3, including exact provider routing, cache-aware
   pricing and metering, Responses tool continuity, provider-blind catalog UX, and
   stable remote-compaction cache prefixes.
 - Updated dependencies [9c4d73d]

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -1911,7 +1911,7 @@ const CLIENT_CONFIG: ClientConfig = {
     },
   ],
   defaultReasoningEffort: "medium",
-  allowedReasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh"],
+  allowedReasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
   mcpServers: [{ id: "opengeni", name: "OpenGeni" }],
   fileUploads: { enabled: true, maxSizeBytes: 25 * 1024 * 1024 },
   productAccessMode: "managed",

--- a/packages/react/src/model-policy.ts
+++ b/packages/react/src/model-policy.ts
@@ -78,7 +78,7 @@ export function effortOptionsForModel(model: ClientModel): ReasoningEffort[] {
   if (!efforts || efforts.length === 0) {
     return ["low"];
   }
-  const order: ReasoningEffort[] = ["none", "minimal", "low", "medium", "high", "xhigh"];
+  const order: ReasoningEffort[] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
   return order.filter((effort) => efforts.includes(effort));
 }
 

--- a/packages/react/test/model-policy.test.ts
+++ b/packages/react/test/model-policy.test.ts
@@ -102,7 +102,7 @@ describe("model-policy", () => {
         reasoning: {
           upstream: "supported",
           runnable: true,
-          efforts: ["low", "high"],
+          efforts: ["low", "high", "max"],
           defaultEffort: "low",
           required: false,
         },
@@ -123,7 +123,7 @@ describe("model-policy", () => {
         latencyModes: [{ id: "standard", upstream: "supported", runnable: true }],
       },
     });
-    expect(effortOptionsForModel(model)).toEqual(["low", "high"]);
+    expect(effortOptionsForModel(model)).toEqual(["low", "high", "max"]);
     expect(coerceReasoningEffortForModel(model, "xhigh")).toBe("low");
     expect(billingClassForModel(model)).toBe("opengeni_credits");
   });

--- a/packages/react/test/model-policy.test.ts
+++ b/packages/react/test/model-policy.test.ts
@@ -65,8 +65,8 @@ describe("model-policy", () => {
   test("labels a connected workspace Gateway as Your Gateway", () => {
     const rows = projectPickerRows([
       catalogModel({
-        id: "workspace-gateway/kimi-k3-fast",
-        label: "Kimi K3 Fast",
+        id: "workspace-gateway/kimi-k3",
+        label: "Kimi K3",
         source: "workspace_gateway",
       }),
     ]);

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - 9c4d73d: Add curated OpenGeni-credit and workspace-key Vercel AI Gateway model paths for
-  DeepSeek V4 Flash and Kimi K3 Fast, including exact provider routing, cache-aware
+  DeepSeek V4 Flash and Kimi K3, including exact provider routing, cache-aware
   pricing and metering, Responses tool continuity, provider-blind catalog UX, and
   stable remote-compaction cache prefixes.
 - Updated dependencies [9c4d73d]

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -357,6 +357,10 @@ export type NormalizedRuntimeEvent = {
 export type ModelResponseUsage = {
   responseId?: string;
   serviceTier?: string;
+  gatewayBilling?: {
+    finalProvider: string;
+    inferenceCostUsd: string;
+  };
   usage: {
     inputTokens?: number;
     outputTokens?: number;
@@ -697,21 +701,16 @@ export class WorkspaceGatewayUnavailableError extends Error {
 }
 
 /**
- * Kimi Fast/Wafer currently returns parallel function calls, but Gateway
- * rejects a Responses continuation containing the canonical
- * `call A, call B, result A, result B` batch with error metadata that names the
- * base Kimi model. Whether that is internal normalization or incorrect error
- * metadata is not observable. The exact-provider fence correctly prevents any
- * fallback.
- * Interleave only complete, contiguous batches into
- * `call A, result A, call B, result B`: same calls, ids, arguments, outputs,
- * and order; no item is dropped or invented. Partial/ambiguous batches remain
- * untouched and fail closed upstream.
+ * Gateway's Kimi Responses adapter rejects the standard grouped parallel-tool
+ * continuation (`call A, call B, result A, result B`) even though it accepts
+ * the exact same complete items when each result follows its call. Pair only
+ * complete contiguous batches by `call_id`; preserve every item and field,
+ * parallel execution, model, and provider route. Partial or ambiguous batches
+ * stay untouched and fail closed upstream.
  */
-export function interleaveParallelFunctionCallResults(body: Record<string, unknown>): boolean {
+function pairKimiParallelFunctionCallResults(body: Record<string, unknown>): void {
   const input = body.input;
-  if (!Array.isArray(input)) return false;
-  let changed = false;
+  if (!Array.isArray(input)) return;
   let index = 0;
   while (index < input.length) {
     const item = input[index];
@@ -751,41 +750,38 @@ export function interleaveParallelFunctionCallResults(body: Record<string, unkno
       index = resultEnd;
       continue;
     }
-    const byCallId = new Map<string, Record<string, unknown>>();
-    let valid = true;
+    const resultsByCallId = new Map<string, Record<string, unknown>>();
     for (const result of results) {
       const callId = result.call_id;
-      if (typeof callId !== "string" || byCallId.has(callId)) {
-        valid = false;
+      if (typeof callId !== "string" || resultsByCallId.has(callId)) {
+        resultsByCallId.clear();
         break;
       }
-      byCallId.set(callId, result);
+      resultsByCallId.set(callId, result);
     }
-    const interleaved: Array<Record<string, unknown>> = [];
+    const paired: Array<Record<string, unknown>> = [];
     for (const call of calls) {
       const callId = call.call_id;
-      const result = typeof callId === "string" ? byCallId.get(callId) : undefined;
+      const result = typeof callId === "string" ? resultsByCallId.get(callId) : undefined;
       if (!result) {
-        valid = false;
+        paired.length = 0;
         break;
       }
-      interleaved.push(call, result);
+      paired.push(call, result);
     }
-    if (!valid) {
+    if (paired.length === calls.length * 2) {
+      input.splice(index, paired.length, ...paired);
+      index += paired.length;
+    } else {
       index = resultEnd;
-      continue;
     }
-    input.splice(index, calls.length + results.length, ...interleaved);
-    changed = true;
-    index += interleaved.length;
   }
-  return changed;
 }
 
 /**
  * Inject the reviewed route after SDK serialization, replacing any caller
- * gateway options. There is exactly one allowed endpoint provider and no model
- * fallback list. Unknown models/body shapes fail before network I/O.
+ * gateway options. Only the ordered, reviewed endpoint providers are allowed;
+ * no model fallback list is sent. Unknown models/body shapes fail before I/O.
  */
 export function vercelGatewayRoutingFetch(
   kind: Extract<
@@ -829,7 +825,7 @@ export function vercelGatewayRoutingFetch(
     };
     body.providerOptions = providerOptions;
     if (model === OPENGENI_GATEWAY_MODELS.kimi.upstreamModelId) {
-      interleaveParallelFunctionCallResults(body);
+      pairKimiParallelFunctionCallResults(body);
     }
     const response = await inner(input, { ...init, body: JSON.stringify(body) });
     if (response.ok) {
@@ -5820,11 +5816,63 @@ export function modelResponseUsageFromResponse(response: unknown): ModelResponse
         ? (response as { responseId: string }).responseId
         : undefined;
   const serviceTier = modelResponseServiceTierFromResponse(response);
+  const gatewayBilling = gatewayBillingFromResponse(response);
   return {
     ...(responseId ? { responseId } : {}),
     ...(serviceTier ? { serviceTier } : {}),
+    ...(gatewayBilling ? { gatewayBilling } : {}),
     usage,
   };
+}
+
+/** Extract only the bounded, non-secret Gateway billing facts we consume. */
+function gatewayBillingFromResponse(
+  response: unknown,
+): ModelResponseUsage["gatewayBilling"] | null {
+  if (!response || typeof response !== "object" || Array.isArray(response)) {
+    return null;
+  }
+  const record = response as Record<string, unknown>;
+  const providerData =
+    record.providerData &&
+    typeof record.providerData === "object" &&
+    !Array.isArray(record.providerData)
+      ? (record.providerData as Record<string, unknown>)
+      : null;
+  const metadataCandidate =
+    record.provider_metadata ??
+    record.providerMetadata ??
+    providerData?.provider_metadata ??
+    providerData?.providerMetadata;
+  if (
+    !metadataCandidate ||
+    typeof metadataCandidate !== "object" ||
+    Array.isArray(metadataCandidate)
+  ) {
+    return null;
+  }
+  const gateway = (metadataCandidate as Record<string, unknown>).gateway;
+  if (!gateway || typeof gateway !== "object" || Array.isArray(gateway)) {
+    return null;
+  }
+  const gatewayRecord = gateway as Record<string, unknown>;
+  const routing = gatewayRecord.routing;
+  const routingRecord =
+    routing && typeof routing === "object" && !Array.isArray(routing)
+      ? (routing as Record<string, unknown>)
+      : null;
+  const finalProvider = routingRecord?.finalProvider ?? routingRecord?.final_provider;
+  const inferenceCostUsd =
+    gatewayRecord.inferenceCost ?? gatewayRecord.inference_cost ?? gatewayRecord.cost;
+  if (
+    typeof finalProvider !== "string" ||
+    !/^[a-z0-9][a-z0-9-]{0,63}$/.test(finalProvider) ||
+    typeof inferenceCostUsd !== "string" ||
+    !/^(0|[1-9]\d*)(?:\.\d{1,18})?$/.test(inferenceCostUsd)
+  ) {
+    return null;
+  }
+  return { finalProvider, inferenceCostUsd };
 }
 
 export type ModelResponseServiceTierEvent = {

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -28,27 +28,12 @@ import {
   buildProviderClient,
   CodexSubscriptionUnavailableError,
   HUMAN_INPUT_TOOL_NAME,
-  interleaveParallelFunctionCallResults,
   MultiProviderModelProvider,
   resolveTurnModel,
   vercelGatewayRoutingFetch,
 } from "../src/index";
 
 describe("Vercel AI Gateway request fence", () => {
-  test("interleaves only complete parallel function-call batches without changing items", () => {
-    const callA = { type: "function_call", call_id: "a", name: "a", arguments: "{}" };
-    const callB = { type: "function_call", call_id: "b", name: "b", arguments: "{}" };
-    const resultB = { type: "function_call_output", call_id: "b", output: "B" };
-    const resultA = { type: "function_call_output", call_id: "a", output: "A" };
-    const body = { input: [{ role: "user", content: "go" }, callA, callB, resultB, resultA] };
-    expect(interleaveParallelFunctionCallResults(body)).toBe(true);
-    expect(body.input).toEqual([{ role: "user", content: "go" }, callA, resultA, callB, resultB]);
-
-    const partial = { input: [callA, callB, resultA] };
-    expect(interleaveParallelFunctionCallResults(partial)).toBe(false);
-    expect(partial.input).toEqual([callA, callB, resultA]);
-  });
-
   test("replaces caller routing for both Gateway billing paths", async () => {
     for (const kind of ["vercel-gateway-managed", "vercel-gateway-workspace"] as const) {
       let captured: Record<string, unknown> | null = null;
@@ -71,13 +56,17 @@ describe("Vercel AI Gateway request fence", () => {
         }),
       });
       expect(captured?.providerOptions).toEqual({
-        gateway: { only: ["deepinfra"], order: ["deepinfra"], caching: "auto" },
+        gateway: {
+          only: ["baseten", "novita", "deepinfra"],
+          order: ["baseten", "novita", "deepinfra"],
+          caching: "auto",
+        },
         deepseek: { includeReasoning: true },
       });
     }
   });
 
-  test("pins Kimi to Wafer with its live-proven implicit cache policy", async () => {
+  test("orders normal Kimi across only the approved Baseten and Fireworks routes", async () => {
     let captured: Record<string, unknown> | null = null;
     const routed = vercelGatewayRoutingFetch("vercel-gateway-managed", (async (
       _input: RequestInfo | URL,
@@ -88,11 +77,105 @@ describe("Vercel AI Gateway request fence", () => {
     }) as typeof fetch);
     await routed("https://ai-gateway.vercel.sh/v1/responses", {
       method: "POST",
-      body: JSON.stringify({ model: "moonshotai/kimi-k3-fast" }),
+      body: JSON.stringify({ model: "moonshotai/kimi-k3" }),
     });
     expect(captured?.providerOptions).toEqual({
-      gateway: { only: ["wafer"], order: ["wafer"], caching: "auto" },
+      gateway: {
+        only: ["baseten", "fireworks"],
+        order: ["baseten", "fireworks"],
+        caching: "auto",
+      },
     });
+  });
+
+  test("pairs only complete Kimi parallel call/result batches without changing their fields", async () => {
+    let captured: Record<string, unknown> | null = null;
+    const routed = vercelGatewayRoutingFetch("vercel-gateway-managed", (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      captured = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch);
+    const callA = {
+      type: "function_call",
+      call_id: "call-a",
+      name: "alpha",
+      arguments: "{}",
+      status: "completed",
+    };
+    const callB = {
+      type: "function_call",
+      call_id: "call-b",
+      name: "beta",
+      arguments: "{}",
+      status: "completed",
+    };
+    const resultA = {
+      type: "function_call_output",
+      call_id: "call-a",
+      output: "alpha-result",
+      status: "completed",
+    };
+    const resultB = {
+      type: "function_call_output",
+      call_id: "call-b",
+      output: "beta-result",
+      status: "completed",
+    };
+    await routed("https://ai-gateway.vercel.sh/v1/responses", {
+      method: "POST",
+      body: JSON.stringify({
+        model: "moonshotai/kimi-k3",
+        parallel_tool_calls: true,
+        input: [{ type: "reasoning", summary: [] }, callA, callB, resultA, resultB],
+      }),
+    });
+
+    expect(captured?.parallel_tool_calls).toBe(true);
+    expect(captured?.input).toEqual([
+      { type: "reasoning", summary: [] },
+      callA,
+      resultA,
+      callB,
+      resultB,
+    ]);
+  });
+
+  test("does not alter incomplete Kimi or complete DeepSeek call/result batches", async () => {
+    for (const value of [
+      {
+        model: "moonshotai/kimi-k3",
+        input: [
+          { type: "function_call", call_id: "a", name: "alpha", arguments: "{}" },
+          { type: "function_call", call_id: "b", name: "beta", arguments: "{}" },
+          { type: "function_call_output", call_id: "a", output: "done" },
+        ],
+      },
+      {
+        model: "deepseek/deepseek-v4-flash-0731",
+        input: [
+          { type: "function_call", call_id: "a", name: "alpha", arguments: "{}" },
+          { type: "function_call", call_id: "b", name: "beta", arguments: "{}" },
+          { type: "function_call_output", call_id: "a", output: "one" },
+          { type: "function_call_output", call_id: "b", output: "two" },
+        ],
+      },
+    ]) {
+      let captured: Record<string, unknown> | null = null;
+      const routed = vercelGatewayRoutingFetch("vercel-gateway-managed", (async (
+        _input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        captured = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return new Response("{}", { status: 200 });
+      }) as typeof fetch);
+      await routed("https://ai-gateway.vercel.sh/v1/responses", {
+        method: "POST",
+        body: JSON.stringify(value),
+      });
+      expect(captured?.input).toEqual(value.input);
+    }
   });
 
   test("unknown models fail before network I/O", async () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -66,6 +66,7 @@ import {
   normalizeModelCallUsage,
   modelResponseServiceTierFromSdkEvent,
   modelResponseUsageFromSdkEvent,
+  modelResponseUsageFromResponse,
   normalizeSdkEvent,
   normalizeToolOutputForEvent,
   prepareRunInput,
@@ -404,6 +405,61 @@ describe("runtime event normalization", () => {
       serviceTier: "priority",
     });
     expect(normalizeSdkEvent(event)).toEqual([]);
+  });
+
+  test("extracts bounded Gateway route billing from raw and normalized responses", () => {
+    const metadata = {
+      gateway: {
+        routing: { finalProvider: "novita" },
+        inferenceCost: "0.00000325",
+      },
+    };
+    const direct = modelResponseUsageFromResponse({
+      id: "resp-gateway-raw",
+      usage: {
+        input_tokens: 405,
+        output_tokens: 4,
+        input_tokens_details: { cached_tokens: 331 },
+      },
+      provider_metadata: {
+        gateway: {
+          routing: { finalProvider: "novita" },
+          cost: "0.00000325",
+        },
+      },
+    });
+    const normalized = modelResponseUsageFromResponse({
+      id: "resp-gateway-normalized",
+      usage: { inputTokens: 9, outputTokens: 8 },
+      providerData: { provider_metadata: metadata },
+    });
+
+    expect(direct?.gatewayBilling).toEqual({
+      finalProvider: "novita",
+      inferenceCostUsd: "0.00000325",
+    });
+    expect(normalized?.gatewayBilling).toEqual(direct?.gatewayBilling);
+    expect(direct?.usage).toMatchObject({
+      inputTokens: 405,
+      outputTokens: 4,
+      inputTokensDetails: { cached_tokens: 331 },
+    });
+  });
+
+  test("drops malformed Gateway billing metadata without dropping token usage", () => {
+    const usage = modelResponseUsageFromResponse({
+      id: "resp-gateway-invalid",
+      usage: { input_tokens: 9, output_tokens: 8 },
+      provider_metadata: {
+        gateway: {
+          routing: { finalProvider: "../../not-a-provider" },
+          inferenceCost: "NaN",
+        },
+      },
+    });
+
+    expect(usage?.gatewayBilling).toBeUndefined();
+    expect(usage?.usage).toMatchObject({ inputTokens: 9, outputTokens: 8 });
   });
 
   test("normalizes model-call usage telemetry fields and supported aliases", () => {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - 9c4d73d: Add curated OpenGeni-credit and workspace-key Vercel AI Gateway model paths for
-  DeepSeek V4 Flash and Kimi K3 Fast, including exact provider routing, cache-aware
+  DeepSeek V4 Flash and Kimi K3, including exact provider routing, cache-aware
   pricing and metering, Responses tool continuity, provider-blind catalog UX, and
   stable remote-compaction cache prefixes.
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -228,7 +228,7 @@ export type AcknowledgeStreamResponse = {
 export type ViewerHeartbeatRequest = { leaseEpoch: number };
 export type ViewerHeartbeatResponse = { alive: boolean };
 
-export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 export type LatencyMode = "standard" | "priority" | "fast";
 export type GitCredentialProvider = "github" | "gitlab" | "azure_devops";
 export type GitCredentialBindingId = string;

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -134,7 +134,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     codexProductSku: undefined,
     codexRotationNearExhaustionPct: 90,
     openaiReasoningEffort: "high",
-    openaiAllowedReasoningEfforts: "low,medium,high,xhigh",
+    openaiAllowedReasoningEfforts: "low,medium,high,xhigh,max",
     openaiResponsesTransport: "http",
     openaiProviderItemIds: "strip",
     openaiReasoningEncryptedContent: true,

--- a/scripts/check-model-pricing.ts
+++ b/scripts/check-model-pricing.ts
@@ -66,11 +66,11 @@ const NON_LLM_PRICES_MODELS = [
   },
   {
     id: "deepseek-v4-flash-0731",
-    reason: "provider-pinned Baseten snapshot; covered by catalogue tests",
+    reason: "reviewed Gateway routes; exact-cost billing and conservative fallback are tested",
   },
   {
-    id: "kimi-k3-fast",
-    reason: "provider-pinned Wafer snapshot; covered by catalogue tests",
+    id: "kimi-k3",
+    reason: "reviewed Gateway routes; exact-cost billing and conservative fallback are tested",
   },
 ] as const;
 


### PR DESCRIPTION
## Summary

- route DeepSeek V4 Flash through Baseten → Novita → DeepInfra, with an exact ordered allowlist
- expose one Kimi K3 product routed through Baseten → Fireworks; remove all Fast/Wafer IDs and naming
- preserve Kimi parallel tool-call continuity on the Responses API without changing tool semantics
- meter managed Gateway usage from the exact reported inference cost and actual approved endpoint provider
- keep conservative static pricing only as the missing-metadata fallback
- keep provider details internal and preserve cache-token telemetry
- expose GPT-5.6 `max` reasoning across managed and connected Codex models; Ultra remains out of scope because it is a separate multi-agent mode

## Verification

- Gateway-focused tests: 333 pass, 0 fail
- Max-reasoning affected tests: 395 pass, 0 fail
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`: 23 projects clean
- `bun run check:model-pricing`
- live low-cost Gateway canaries: DeepSeek and Kimi text, image, parallel tools, continuation, cache metadata, and every configured fallback endpoint
- full local unit suite before the Max-only addition: 5,672 pass / 8 skip / 26 unrelated macOS local-box process/filesystem fixture failures; representative failures reproduce when run alone
