### PR TITLE
fix(runtime): preserve connected-machine materialization semantics

### DIFF
--- a/.changeset/preserve-connected-machine-materialization.md
+++ b/.changeset/preserve-connected-machine-materialization.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/runtime": patch
+---
+
+Preserve the intentional connected-machine manifest no-op while retaining
+in-provider materialization visibility checks for managed sandboxes.

--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -924,7 +924,7 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   private async dispatch<T>(
     op: string,
     mutatesWorkspace: boolean,
-    fn: (session: RoutableBackendSession) => Promise<T>,
+    fn: (session: RoutableBackendSession, backend: ResolvedActiveBackend) => Promise<T>,
   ): Promise<T> {
     let attempt = 0;
     let lastError: unknown;
@@ -938,7 +938,9 @@ export class RoutingSandboxSession implements RoutableBackendSession {
         : undefined;
       let result: T;
       try {
-        result = await this.invokeProviderOperation(op, backend, () => fn(backend.session));
+        result = await this.invokeProviderOperation(op, backend, () =>
+          fn(backend.session, backend),
+        );
       } catch (error) {
         if (mutatesWorkspace && this.deps.afterMutation) {
           try {
@@ -1305,7 +1307,7 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   }
 
   async materializeEntry(args: unknown): Promise<void> {
-    return this.dispatch("materializeEntry", true, async (s) => {
+    return this.dispatch("materializeEntry", true, async (s, backend) => {
       if (!s.materializeEntry) {
         throw new RoutingUnsupportedError("materializeEntry", this.cached?.kind ?? "unknown");
       }
@@ -1322,7 +1324,11 @@ export class RoutingSandboxSession implements RoutableBackendSession {
         args && typeof args === "object" && typeof (args as { path?: unknown }).path === "string"
           ? (args as { path: string }).path
           : null;
-      if (path) {
+      // A connected machine intentionally treats manifest materialization as a
+      // no-op: its filesystem is user-owned and is not a platform staging
+      // target. Do not reinterpret that documented contract as a failed write.
+      // Provider-managed sandboxes still need the in-provider visibility proof.
+      if (path && backend.kind !== "selfhosted") {
         await assertProviderCanSeeMaterializedPath(s, path);
       }
     });

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -807,8 +807,9 @@ export class SelfhostedSession {
    *  filesystem and is prepared by the agent itself, so there is nothing to stage.
    *  Present (not absent) so the SDK's provided-session manifest apply path — which
    *  requires `applyManifest()` OR `materializeEntry()` when the agent declares
-   *  entries — is satisfied without error. The selfhosted manifest declares no
-   *  entries, so in practice this is never invoked with a real entry. */
+   *  entries — is satisfied without error. A session swapped from a managed
+   *  sandbox can still present managed-only manifest entries here; they remain
+   *  intentionally unstaged on the user-owned machine. */
   async materializeEntry(_args: { path: string; entry: unknown; runAs?: string }): Promise<void> {
     return;
   }

--- a/packages/runtime/test/routing-proxy.test.ts
+++ b/packages/runtime/test/routing-proxy.test.ts
@@ -292,6 +292,35 @@ describe("RoutingSandboxSession — per-call re-read + per-epoch dispatch", () =
     );
   });
 
+  test("materializeEntry preserves the connected-machine no-op contract", async () => {
+    const calls: string[] = [];
+    const backend: RoutableBackendSession = {
+      async materializeEntry() {
+        calls.push("materialize");
+      },
+      async execCommand() {
+        calls.push("verify");
+        return "";
+      },
+    };
+    const proxy = new RoutingSandboxSession({
+      readPointer: async () => ({ activeSandboxId: "machine", activeEpoch: 3 }),
+      resolveActiveBackend: async () => ({
+        session: backend,
+        sandboxId: "machine",
+        kind: "selfhosted",
+        activeEpoch: 3,
+        leaseEpoch: 7,
+        providerInstanceId: "enrollment-1",
+      }),
+    });
+
+    await expect(
+      proxy.materializeEntry({ path: "files/example", entry: {} }),
+    ).resolves.toBeUndefined();
+    expect(calls).toEqual(["materialize"]);
+  });
+
   test("mutation admission runs after exact route resolution and before the provider", async () => {
     const events: string[] = [];
     const backend: RoutableBackendSession = {


### PR DESCRIPTION
## Summary
- preserve the intentional no-op manifest-materialization contract on connected machines
- retain in-provider destination visibility checks for managed sandboxes
- cover the routed connected-machine case with a regression test

## Validation
- `bun test packages/runtime/test/routing-proxy.test.ts`
- `bun run --cwd packages/runtime typecheck`
- `bun run lint`
- `bun run check:public-hygiene`
- `git diff --check`