### PR TITLE
fix(release): make live acceptance deterministic

### DIFF
--- a/.changeset/deterministic-rigless-acceptance.md
+++ b/.changeset/deterministic-rigless-acceptance.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/core": patch
+"@opengeni/sdk": patch
+---
+
+Allow session creators to explicitly opt out of a workspace default rig, and make live release acceptance prove its fixture command completed before waiting for a workspace capture.

--- a/apps/api/test/rig-session-binding.test.ts
+++ b/apps/api/test/rig-session-binding.test.ts
@@ -172,7 +172,7 @@ describe("M3 rig binding: freeze at create", () => {
     expect(s1Reloaded?.rigVersionId).toBe(v1);
   }, 60_000);
 
-  test("falls back to the workspace default rig when no rigId is given; explicit rigId overrides the default", async () => {
+  test("omission inherits the workspace default while an explicit rig or null overrides it", async () => {
     if (!available) return;
     const bus = new MemoryEventBus();
     const { accountId, workspaceId } = await freshWorkspace();
@@ -201,6 +201,18 @@ describe("M3 rig binding: freeze at create", () => {
       },
     );
     expect(overridden.rigId).toBe(other.rigId);
+
+    const rigless = await createSessionForRequest(
+      deps(bus),
+      grant(accountId, workspaceId),
+      workspaceId,
+      {
+        initialMessage: "no rig",
+        rigId: null,
+      },
+    );
+    expect(rigless.rigId).toBeNull();
+    expect(rigless.rigVersionId).toBeNull();
   }, 60_000);
 
   test("a session with no rig and no workspace default is rig-less (both null)", async () => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -8103,10 +8103,10 @@ export const CreateSessionRequest = withVariableSetIdAlias({
   variableSetId: z.string().uuid().optional(),
   environmentId: z.string().uuid().optional(),
   // The rig to bind this session to (M3). Its ACTIVE version is resolved and
-  // FROZEN onto the session at create. Omitted ⇒ the workspace's default rig
-  // (workspaces.default_rig_id) when set, else a rig-less session (today's
-  // behavior). An id that does not name a rig in the workspace is a 422.
-  rigId: z.string().uuid().optional(),
+  // FROZEN onto the session at create. Omitted ⇒ inherit the workspace default;
+  // null ⇒ explicitly create a rig-less session; UUID ⇒ bind that exact rig.
+  // An id that does not name a rig in the workspace is a 422.
+  rigId: z.string().uuid().nullable().optional(),
   goal: GoalSpec.optional(),
   clientEventId: SessionOperationKey.optional(),
   // Workspace-scoped CREATE idempotency key: collapses concurrent/retried

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -477,6 +477,14 @@ describe("contracts", () => {
     expect(payload.metadata).toEqual({});
   });
 
+  test("accepts an explicit rig-less session", () => {
+    const payload = CreateSessionRequest.parse({
+      initialMessage: "inspect repo",
+      rigId: null,
+    });
+    expect(payload.rigId).toBeNull();
+  });
+
   test("accepts validated inline session skills", () => {
     const parsed = CreateSessionRequest.parse({
       initialMessage: "prepare release",

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1255,9 +1255,10 @@ export async function createSessionForRequest(
         payload.variableSetId,
       )
     : null;
-  // RIG BINDING (M3). Resolve the rig this session rides — the EXPLICIT payload
-  // rigId when given, else the workspace default rig (workspaces.default_rig_id)
-  // — and FREEZE both the rig id and its currently-ACTIVE version onto the row.
+  // RIG BINDING (M3). Resolve the rig this session rides — a UUID binds that
+  // rig, null explicitly opts out, and omission inherits the workspace default
+  // (workspaces.default_rig_id) — then FREEZE both the rig id and its currently-
+  // ACTIVE version onto the row.
   // The session then rides that exact version for its whole life; a later
   // promote never moves it. Rig-less (both null) when neither resolves, which is
   // byte-for-byte today's behavior (zero extra work, zero row change).
@@ -1265,7 +1266,8 @@ export async function createSessionForRequest(
   //   - A stale workspace-default rig (deleted → FK-nulled, or somehow with no
   //     active version) degrades SILENTLY to rig-less: an operator-side default
   //     must never brick every create in the workspace.
-  const requestedRigId = payload.rigId ?? (await getWorkspaceDefaultRigId(db, workspaceId));
+  const requestedRigId =
+    payload.rigId === undefined ? await getWorkspaceDefaultRigId(db, workspaceId) : payload.rigId;
   let frozenRigId: string | null = null;
   let frozenRigVersionId: string | null = null;
   if (requestedRigId) {

--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -4,6 +4,7 @@ import type { AccessContext, WorkspaceCaptureManifest } from "@opengeni/sdk";
 
 import {
   assertFixtureCapture,
+  assertFixtureToolOutput,
   assertDedicatedCanaryEmail,
   assertAcceptancePrincipalScopes,
   assertChangedFileLabelsContainRepositoryRoots,
@@ -309,6 +310,21 @@ describe("workbench live acceptance preflight", () => {
       .find((repo) => repo.root === "web")!
       .status.filter((item) => item.path !== "renamed.txt");
     expect(() => assertFixtureCapture(manifest, marker)).toThrow("renamed fixture status drifted");
+  });
+
+  test("requires the exact fixture marker in a tool output", () => {
+    const marker = "OPENGENI_WORKBENCH_ACCEPTANCE_001";
+    const event = {
+      type: "agent.toolCall.output",
+      payload: { output: `setup complete\n${marker}\n` },
+    } as never;
+    expect(() => assertFixtureToolOutput([event], marker)).not.toThrow();
+    expect(() =>
+      assertFixtureToolOutput(
+        [{ type: "agent.message.completed", payload: { text: marker } } as never],
+        marker,
+      ),
+    ).toThrow("acceptance fixture command did not emit its exact marker");
   });
 });
 

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -8,6 +8,7 @@ import {
   type AccessContext,
   type GetWorkspaceCaptureResponse,
   type Session,
+  type SessionEvent,
   type WorkspaceCaptureManifest,
 } from "@opengeni/sdk";
 import { assertScreenshotPainted } from "@opengeni/testing";
@@ -284,6 +285,9 @@ async function main(): Promise<void> {
     reasoningEffort: "low",
     sandboxBackend: args.backend,
     sandbox: "new",
+    // Acceptance owns its complete execution fixture and must not inherit a
+    // mutable workspace-default rig with unrelated setup work.
+    rigId: null,
     idempotencyKey: `workbench-acceptance:${args.environment}:${args.sourceSha}:${args.runId}`,
     metadata: {
       origin: "workbench-live-acceptance",
@@ -300,6 +304,8 @@ async function main(): Promise<void> {
   if (settled.status !== "idle") {
     throw new Error(`acceptance fixture turn ended in ${settled.status}`);
   }
+  const fixtureToolOutputs = await listAllToolOutputEvents(cookieClient, workspaceId, session.id);
+  assertFixtureToolOutput(fixtureToolOutputs, marker);
   pass(checks, "functional.real-turn", "A real authenticated Modal turn settled successfully.");
 
   const captureResponse = await waitForCapture(
@@ -635,6 +641,39 @@ async function waitForCapture(
     await Bun.sleep(1_000);
   }
   throw new Error("capture did not become available before timeout");
+}
+
+async function listAllToolOutputEvents(
+  client: OpenGeniClient,
+  workspaceId: string,
+  sessionId: string,
+): Promise<SessionEvent[]> {
+  const collected: SessionEvent[] = [];
+  let cursor = 0;
+  while (true) {
+    const page = await client.listEvents(workspaceId, sessionId, {
+      after: cursor,
+      limit: 500,
+      mode: "forensic",
+      payloadMode: "full",
+      includeTypes: ["agent.toolCall.output"],
+    });
+    collected.push(...page);
+    const lastSequence = page.at(-1)?.sequence;
+    if (lastSequence !== undefined) cursor = lastSequence;
+    if (page.length < 500) return collected;
+  }
+}
+
+export function assertFixtureToolOutput(events: readonly SessionEvent[], marker: string): void {
+  const observed = events.some(
+    (event) =>
+      event.type === "agent.toolCall.output" &&
+      JSON.stringify(event.payload ?? {}).includes(marker),
+  );
+  if (!observed) {
+    throw new Error("acceptance fixture command did not emit its exact marker");
+  }
 }
 
 async function loadManifest(


### PR DESCRIPTION
## Summary
- add an explicit rig-less session-create request alongside workspace-default inheritance
- make live workbench acceptance opt out of mutable workspace rig setup
- require the exact fixture marker in a real tool output before waiting for capture

## Verification
- contracts tests
- live acceptance unit tests
- rig binding integration tests against PostgreSQL
- lint
- public repository hygiene
- all 23 TypeScript projects
- diff check