### PR TITLE
fix(release): tolerate superseded capture reads

### DIFF
--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -12,6 +12,7 @@ import {
   assertRepositoryChangesVisible,
   controlCancellationDurationMs,
   fixturePrompt,
+  isExpectedCaptureFileCancellation,
   openWorkspaceIfCollapsed,
   parseCookieHeader,
   parseLiveAcceptanceArgs,
@@ -22,6 +23,13 @@ import {
 } from "./workbench-live-acceptance";
 
 describe("workbench live acceptance preflight", () => {
+  test("ignores only an explicitly aborted superseded capture-file read", () => {
+    const path = "/v1/workspaces/workspace/sessions/session/workspace/capture/file";
+    expect(isExpectedCaptureFileCancellation(path, "net::ERR_ABORTED")).toBe(true);
+    expect(isExpectedCaptureFileCancellation(path, "net::ERR_FAILED")).toBe(false);
+    expect(isExpectedCaptureFileCancellation("/v1/config/client", "net::ERR_ABORTED")).toBe(false);
+  });
+
   test("keeps an open workspace open when Files hides the Changes panel", async () => {
     const selectors: string[] = [];
     let lookedUpCollapseControl = false;

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -34,6 +34,7 @@ const OBSERVABILITY_PROBE_PERMISSIONS = [
 ] as const;
 const SETTLED = new Set(["idle", "failed", "error", "cancelled"]);
 const CHANNEL_A_PATH = /\/sessions\/[^/]+\/(?:fs|git|terminal)\//;
+const CAPTURE_FILE_PATH = /\/sessions\/[^/]+\/workspace\/capture\/file$/;
 const WORKSPACE_SURFACE_SELECTOR = "[data-workspace-surface]";
 const CHANGES_LAYOUT_SELECTOR = "[data-workbench-changes-layout]";
 const CAPTURE_API_P95_MS = maximumMillisecondBudget("performance.capture-api-response", "p95");
@@ -1806,13 +1807,22 @@ function observePage(page: Page): BrowserProblems {
     const path = safePath(request.url());
     if (CHANNEL_A_PATH.test(path)) problems.channelA.push(path);
   });
-  page.on("requestfailed", (request) => problems.failedRequests.push(safePath(request.url())));
+  page.on("requestfailed", (request) => {
+    const path = safePath(request.url());
+    const errorText = request.failure()?.errorText ?? "unknown request failure";
+    if (isExpectedCaptureFileCancellation(path, errorText)) return;
+    problems.failedRequests.push(`${sanitizeDiagnostic(errorText)} ${path}`);
+  });
   page.on("response", (response) => {
     if (response.status() >= 400) {
       problems.badResponses.push(`${response.status()} ${safePath(response.url())}`);
     }
   });
   return problems;
+}
+
+export function isExpectedCaptureFileCancellation(path: string, errorText: string): boolean {
+  return errorText === "net::ERR_ABORTED" && CAPTURE_FILE_PATH.test(path);
 }
 
 function assertNoProblems(problems: BrowserProblems, requireZeroChannelA: boolean): void {


### PR DESCRIPTION
## Summary
- ignore only browser-aborted workspace-capture file reads during rapid file selection
- retain fail-closed handling for all other request failures
- include the failure reason in diagnostics

## Validation
- `bun test scripts/workbench-live-acceptance.test.ts`
- `bun run typecheck`
- `bun run check` reached the full unit suite; the macOS host lacks GNU tar `--sort=name`, while the dedicated acceptance tests and typecheck pass
