### PR TITLE
chore(release): advance product version to 0.22.51

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.50
-appVersion: "0.22.50"
+version: 0.22.51
+appVersion: "0.22.51"


### PR DESCRIPTION
## Summary

Advance the canonical OpenGeni Helm chart and application release identity from 0.22.50 to 0.22.51 for the next immutable release candidate.

## Validation

- release version contract tests
- release image workflow contract tests
- Helm lint
- no pending Changesets
- diff validation

This change contains only the source-controlled product version reservation.