### PR TITLE
fix(release): ignore benign browser cancellations

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.51
-appVersion: "0.22.51"
+version: 0.22.52
+appVersion: "0.22.52"

--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -12,7 +12,7 @@ import {
   assertRepositoryChangesVisible,
   controlCancellationDurationMs,
   fixturePrompt,
-  isExpectedCaptureFileCancellation,
+  isExpectedBrowserCancellation,
   openWorkspaceIfCollapsed,
   parseCookieHeader,
   parseLiveAcceptanceArgs,
@@ -23,11 +23,16 @@ import {
 } from "./workbench-live-acceptance";
 
 describe("workbench live acceptance preflight", () => {
-  test("ignores only an explicitly aborted superseded capture-file read", () => {
+  test("ignores only expected browser-cancelled background reads", () => {
     const path = "/v1/workspaces/workspace/sessions/session/workspace/capture/file";
-    expect(isExpectedCaptureFileCancellation(path, "net::ERR_ABORTED")).toBe(true);
-    expect(isExpectedCaptureFileCancellation(path, "net::ERR_FAILED")).toBe(false);
-    expect(isExpectedCaptureFileCancellation("/v1/config/client", "net::ERR_ABORTED")).toBe(false);
+    expect(isExpectedBrowserCancellation(path, "net::ERR_ABORTED")).toBe(true);
+    expect(
+      isExpectedBrowserCancellation("/assets/analytics-consent-aB_09.js", "net::ERR_ABORTED"),
+    ).toBe(true);
+    expect(isExpectedBrowserCancellation("/v1/auth/get-session", "net::ERR_ABORTED")).toBe(true);
+    expect(isExpectedBrowserCancellation(path, "net::ERR_FAILED")).toBe(false);
+    expect(isExpectedBrowserCancellation("/assets/index-aB_09.js", "net::ERR_ABORTED")).toBe(false);
+    expect(isExpectedBrowserCancellation("/v1/config/client", "net::ERR_ABORTED")).toBe(false);
   });
 
   test("keeps an open workspace open when Files hides the Changes panel", async () => {

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -35,6 +35,8 @@ const OBSERVABILITY_PROBE_PERMISSIONS = [
 const SETTLED = new Set(["idle", "failed", "error", "cancelled"]);
 const CHANNEL_A_PATH = /\/sessions\/[^/]+\/(?:fs|git|terminal)\//;
 const CAPTURE_FILE_PATH = /\/sessions\/[^/]+\/workspace\/capture\/file$/;
+const OPTIONAL_ANALYTICS_CHUNK_PATH = /^\/assets\/analytics-consent-[A-Za-z0-9_-]+\.js$/;
+const MANAGED_SESSION_PATH = /^\/v1\/auth\/get-session$/;
 const WORKSPACE_SURFACE_SELECTOR = "[data-workspace-surface]";
 const CHANGES_LAYOUT_SELECTOR = "[data-workbench-changes-layout]";
 const CAPTURE_API_P95_MS = maximumMillisecondBudget("performance.capture-api-response", "p95");
@@ -1810,7 +1812,7 @@ function observePage(page: Page): BrowserProblems {
   page.on("requestfailed", (request) => {
     const path = safePath(request.url());
     const errorText = request.failure()?.errorText ?? "unknown request failure";
-    if (isExpectedCaptureFileCancellation(path, errorText)) return;
+    if (isExpectedBrowserCancellation(path, errorText)) return;
     problems.failedRequests.push(`${sanitizeDiagnostic(errorText)} ${path}`);
   });
   page.on("response", (response) => {
@@ -1821,8 +1823,13 @@ function observePage(page: Page): BrowserProblems {
   return problems;
 }
 
-export function isExpectedCaptureFileCancellation(path: string, errorText: string): boolean {
-  return errorText === "net::ERR_ABORTED" && CAPTURE_FILE_PATH.test(path);
+export function isExpectedBrowserCancellation(path: string, errorText: string): boolean {
+  if (errorText !== "net::ERR_ABORTED") return false;
+  return (
+    CAPTURE_FILE_PATH.test(path) ||
+    OPTIONAL_ANALYTICS_CHUNK_PATH.test(path) ||
+    MANAGED_SESSION_PATH.test(path)
+  );
 }
 
 function assertNoProblems(problems: BrowserProblems, requireZeroChannelA: boolean): void {


### PR DESCRIPTION
## Summary
- ignore only Chromium-aborted optional analytics chunks and managed-session background reads
- retain fail-closed handling for all other failed requests and asset chunks
- cover the exact allowlist and negative cases
- bump the Helm release to 0.22.52 for the corrected immutable candidate

## Verification
- `bun test scripts/workbench-live-acceptance.test.ts`
- `bun run typecheck`
- targeted format and lint checks
- `helm lint deploy/helm/opengeni`