### PR TITLE
fix(react): preserve latency during draft hydration

### DIFF
--- a/.changeset/fence-draft-latency.md
+++ b/.changeset/fence-draft-latency.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Preserve a latency-mode selection made while a durable composer draft is loading.

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -538,13 +538,15 @@ export function useComposer(
             replaceLocal ||
             (!localWasDirtyAtStart && localAtStart === localEditRevision.current)
           ) {
-            // Model/effort ride in sendExtras (outside localEditRevision). If
+            // Model/effort/latency ride in sendExtras (outside
+            // localEditRevision). If
             // the picker changed during this fetch, skip onDraftApplied so a
-            // stale server model/effort cannot undo the operator's pick.
+            // stale server policy cannot undo the operator's pick.
             const extrasNow = resolveSendExtras(sendExtrasRef.current);
             const pickerChangedDuringFetch =
               extrasNow.model !== extrasAtStart.model ||
-              extrasNow.reasoningEffort !== extrasAtStart.reasoningEffort;
+              extrasNow.reasoningEffort !== extrasAtStart.reasoningEffort ||
+              extrasNow.latencyMode !== extrasAtStart.latencyMode;
             valueRef.current = fetched.text;
             restoredResourcesRef.current = fetched.resources;
             lastSavedSignature.current = draftSignature(draftPayload(fetched));

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1965,6 +1965,48 @@ describe("useComposer durable draft and control binding", () => {
     await hook.unmount();
   });
 
+  test("draft hydration cannot overwrite a latency selection made while the read is in flight", async () => {
+    let resolveDraft!: (draft: ComposerDraft) => void;
+    const client = fakeClient({
+      getComposerDraft: async () =>
+        await new Promise<ComposerDraft>((resolve) => {
+          resolveDraft = resolve;
+        }),
+    });
+    const applied: ComposerDraft[] = [];
+    const hook = await renderHook<ReturnType<typeof useComposer>, "standard" | "fast">(
+      (latencyMode: "standard" | "fast") =>
+        useComposer(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          sendExtras: { model: "model-x", reasoningEffort: "medium", latencyMode },
+          onDraftApplied: (draft) => applied.push(draft),
+        }),
+      "standard",
+    );
+
+    await flush();
+    await hook.rerender("fast");
+    await flushing(async () => {
+      resolveDraft({
+        revision: 1,
+        text: "restored text",
+        resources: [],
+        model: "model-x",
+        reasoningEffort: "medium",
+        latencyMode: "standard",
+        sourceTurnId: null,
+        sourceTurnVersion: null,
+        updatedAt: new Date().toISOString(),
+      });
+      await Promise.resolve();
+    });
+
+    expect(hook.result.current.value).toBe("restored text");
+    expect(applied).toEqual([]);
+    await hook.unmount();
+  });
+
   test("history already present at mount is treated as a projection, not live traffic", async () => {
     let reads = 0;
     const client = fakeClient({


### PR DESCRIPTION
## Summary
- fence durable draft hydration against an in-flight latency-mode change
- keep text/resource hydration while preserving the operator-selected policy
- add a focused regression test and patch changeset

## Validation
- `bun test packages/react/test/hooks.test.tsx --timeout 30000`
- `bun run typecheck`
- `bun run lint`
- `bun run format --check`