### PR TITLE
fix(ui): keep workbench controls accessible

### DIFF
--- a/.changeset/accessible-workbench-controls.md
+++ b/.changeset/accessible-workbench-controls.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Keep captured-file actions legible and ensure the hosted voice-options control meets its minimum target size.

--- a/apps/web/src/components/session/codex-realtime-control.test.tsx
+++ b/apps/web/src/components/session/codex-realtime-control.test.tsx
@@ -208,9 +208,11 @@ describe("ordinary session Codex realtime control", () => {
     );
     expect(region).not.toBeNull();
     expect(container.querySelector('[role="status"]')?.textContent).toContain("Start voice");
-    expect(
-      container.querySelector('button[aria-label="Choose voice model and options"]'),
-    ).not.toBeNull();
+    const voiceOptions = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Choose voice model and options"]',
+    );
+    expect(voiceOptions).not.toBeNull();
+    expect(voiceOptions?.classList.contains("w-6")).toBe(true);
     expect(container.textContent).not.toContain("Realtime diagnostics");
     expect(start?.disabled).toBe(false);
     await act(async () => start?.click());

--- a/apps/web/src/components/session/codex-realtime-control.tsx
+++ b/apps/web/src/components/session/codex-realtime-control.tsx
@@ -658,7 +658,7 @@ export function CodexRealtimeControl(props: {
             title={`Voice model: ${selectedModel.label}`}
             disabled={props.selectionDisabled}
             className={cn(
-              "inline-flex h-8 w-5 items-center justify-center rounded-r-og-md border border-l-0 outline-none",
+              "inline-flex h-8 w-6 items-center justify-center rounded-r-og-md border border-l-0 outline-none",
               "transition-[background-color,border-color,color] duration-200 ease-og-out",
               "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-og-accent/45",
               "pointer-coarse:h-11 pointer-coarse:w-7",

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -382,7 +382,7 @@ function WakeButton({ children, onClick }: { children: ReactNode; onClick: () =>
     <button
       type="button"
       onClick={onClick}
-      className="mt-1 inline-flex min-h-11 items-center justify-center rounded-og-md bg-og-accent px-3 py-2 text-og-sm font-medium text-og-on-accent shadow-sm transition-colors hover:bg-og-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent focus-visible:ring-offset-2 focus-visible:ring-offset-og-bg"
+      className="mt-1 inline-flex min-h-11 items-center justify-center rounded-og-md bg-og-accent-deep px-3 py-2 text-og-sm font-medium text-og-accent-fg shadow-sm transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent focus-visible:ring-offset-2 focus-visible:ring-offset-og-bg"
     >
       {children}
     </button>

--- a/packages/react/styles/index.css
+++ b/packages/react/styles/index.css
@@ -44,6 +44,7 @@
 
   --color-og-accent: var(--og-color-accent);
   --color-og-accent-strong: var(--og-color-accent-strong);
+  --color-og-accent-deep: var(--og-color-accent-deep);
   --color-og-accent-fg: var(--og-color-accent-fg);
   --color-og-accent-soft: var(--og-color-accent-soft);
 

--- a/packages/react/test/sandbox-components.test.tsx
+++ b/packages/react/test/sandbox-components.test.tsx
@@ -217,6 +217,8 @@ describe("SandboxFiles guarded-file routing", () => {
       button.textContent?.includes("Open live file"),
     );
     expect(openLive).toBeDefined();
+    expect(openLive?.classList.contains("bg-og-accent-deep")).toBe(true);
+    expect(openLive?.classList.contains("text-og-accent-fg")).toBe(true);
     await actRun(() => openLive!.click());
     expect(wakeCalls).toBe(1);
     expect(r.container.textContent).toContain("Waking workspace");


### PR DESCRIPTION
## Summary
- keep captured-file wake actions legible against the primary surface
- expose the deep accent token through the React styling contract
- meet the minimum target size for hosted voice options

## Verification
- targeted React and web tests (28 passing)
- full TypeScript project typecheck
- lint
- format check
- production web build

## Release
- patch changeset for `@opengeni/react`