### PR TITLE
chore: version policy administration packages

### DIFF
--- a/.changeset/policy-administration.md
+++ b/.changeset/policy-administration.md
@@ -1,0 +1,10 @@
+---
+"@opengeni/api-router": minor
+"@opengeni/contracts": minor
+"@opengeni/db": minor
+"@opengeni/sdk": minor
+---
+
+Add replay-safe workspace instruction policy administration across the API,
+contracts, database, and SDK, including immutable operation receipts that reject
+changed requests reusing the same operation identifier.


### PR DESCRIPTION
## Summary

Declare the package releases required for the replay-safe workspace instruction policy administration capability already merged on `main`.

## Release impact

- `@opengeni/api-router`: minor
- `@opengeni/contracts`: minor
- `@opengeni/db`: minor
- `@opengeni/sdk`: minor

This pull request contains release metadata only; it does not change runtime behavior.