### PR TITLE
feat: publish public realtime SDKs

### DIFF
--- a/.changeset/public-realtime-sdks.md
+++ b/.changeset/public-realtime-sdks.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/sdk": minor
+"@opengeni/react": minor
+---
+
+Publish the provider-neutral realtime controller and the exact OpenGeni realtime composer experience at `@opengeni/sdk/realtime` and `@opengeni/react/realtime`, including proxy-friendly client contracts, batteries-included existing/new-session controls, and the public reference demo.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,11 @@ jobs:
         id: queue_surface_browser
         run: bun scripts/run-browser-e2e.ts ./test/e2e/queue-surface.browser.e2e.ts
 
+      - name: Public realtime SDK demo browser acceptance
+        env:
+          OPENGENI_REALTIME_DEMO_EVIDENCE_DIR: /tmp/opengeni-realtime-demo-evidence
+        run: bun scripts/run-browser-e2e.ts ./test/e2e/realtime-demo.browser.e2e.ts
+
       - name: Session pin browser acceptance
         id: session_pin_browser
         env:

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,3 +1,8 @@
 # Leave empty for same-origin deployments where ingress routes /v1 and /healthz
 # to the API service. Local dev stack exports this automatically.
 VITE_API_BASE_URL=http://127.0.0.1:8000
+
+# Optional server-side proxy for the deployed @opengeni/react reference demo.
+# The browser calls /demo-api; credentials below are read only by src/server.ts.
+OPENGENI_DEMO_API_URL=http://127.0.0.1:8000
+# Configure OPENGENI_DEMO_API_KEY or OPENGENI_DEMO_ACCESS_KEY only in the server environment.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -5,4 +5,5 @@ VITE_API_BASE_URL=http://127.0.0.1:8000
 # Optional server-side proxy for the deployed @opengeni/react reference demo.
 # The browser calls /demo-api; credentials below are read only by src/server.ts.
 OPENGENI_DEMO_API_URL=http://127.0.0.1:8000
-# Configure OPENGENI_DEMO_API_KEY or OPENGENI_DEMO_ACCESS_KEY only in the server environment.
+# Prefer normal browser auth. Otherwise configure a dedicated least-privilege
+# OPENGENI_DEMO_API_KEY or OPENGENI_DEMO_ACCESS_KEY only in the server environment.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3000 --host 0.0.0.0",
-    "build": "vite build && bun ../../scripts/precompress-web-dist.ts dist && bun ../../scripts/check-web-bundle-budget.ts",
+    "build": "vite build && bun run --cwd ../../packages/react demo:build:deployed && bun ../../scripts/precompress-web-dist.ts dist && bun ../../scripts/check-web-bundle-budget.ts",
     "start": "bun src/server.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -72,8 +72,8 @@ const LazySessionInspector = lazy(() =>
 );
 
 const LazyCodexRealtimeControl = lazy(() =>
-  import("@/components/session/codex-realtime-control").then(({ SessionCodexRealtimeControl }) => ({
-    default: SessionCodexRealtimeControl,
+  import("@opengeni/react/realtime").then(({ SessionRealtimeControl }) => ({
+    default: SessionRealtimeControl,
   })),
 );
 

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -23,6 +23,7 @@ import {
   type ComposerState,
 } from "@opengeni/react";
 import { useMachines, type MachineView } from "@opengeni/react/machines";
+import { NewSessionRealtimeControl } from "@opengeni/react/realtime";
 import { OpenGeniApiError, type SessionRealtimeModel } from "@opengeni/sdk";
 import { Link, useNavigate } from "@tanstack/react-router";
 import {
@@ -39,7 +40,6 @@ import { BillingClassMark } from "@/components/billing-class-mark";
 import { ConsoleComposer, useDraftAttachments } from "@/components/Composer";
 import { ComposerMobilePlus } from "@/components/composer-mobile-plus";
 import { ModelPicker, SessionToolPicker, type SessionToolSelection } from "@/components/pickers";
-import { NewSessionRealtimeControl } from "@/components/session/codex-realtime-control";
 import { RepositoryContextPicker } from "@/components/repository-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/apps/web/src/server.test.ts
+++ b/apps/web/src/server.test.ts
@@ -62,11 +62,14 @@ describe("production web handler", () => {
     expect(
       await (await handler(new Request("https://example.test/react-demo/realtime.html"))).text(),
     ).toContain("Realtime demo");
+    expect(
+      (await handler(new Request("https://example.test/react-demo/assets/missing.js"))).status,
+    ).toBe(404);
   });
 
   test("proxies only demo API routes and keeps credentials server-side", async () => {
     const root = await fixture();
-    const seen: { input?: string; init?: RequestInit } = {};
+    const seen: { input?: string; init?: RequestInit; body?: string } = {};
     const serverApiValue = ["server", "api", "value"].join("-");
     const serverAccessValue = ["server", "access", "value"].join("-");
     const credentialHeaders = new Headers();
@@ -79,14 +82,18 @@ describe("production web handler", () => {
         fetch: async (input, init) => {
           seen.input = String(input);
           seen.init = init;
+          seen.body = init?.body ? await new Response(init.body).text() : "";
           return Response.json({ ok: true }, { status: 201 });
         },
       },
     });
     const browserHeaders = new Headers({
       "content-type": "application/json",
+      forwarded: "for=spoofed;host=evil.example",
       origin: "https://example.test",
+      "x-forwarded-port": "4444",
       "x-opengeni-access-key": "browser-access-value-that-must-be-replaced",
+      "x-real-ip": "203.0.113.10",
     });
     browserHeaders.set("authorization", "browser-value-that-must-be-replaced");
     const response = await handler(
@@ -103,8 +110,12 @@ describe("production web handler", () => {
     const headers = new Headers(seen.init?.headers);
     expect(headers.get("authorization")).toBe(["Bearer", serverApiValue].join(" "));
     expect(headers.get("x-opengeni-access-key")).toBe(serverAccessValue);
+    expect(headers.get("forwarded")).toBeNull();
     expect(headers.get("x-forwarded-host")).toBe("example.test");
-    expect(new TextDecoder().decode(seen.init?.body as Uint8Array)).toContain("realtime");
+    expect(headers.get("x-forwarded-port")).toBeNull();
+    expect(headers.get("x-real-ip")).toBeNull();
+    expect(seen.init?.redirect).toBe("manual");
+    expect(seen.body).toContain("realtime");
 
     expect(
       (
@@ -124,10 +135,22 @@ describe("production web handler", () => {
         )
       ).status,
     ).toBe(403);
+    expect(
+      (
+        await handler(
+          new Request("https://example.test/demo-api/v1/%252e%252e/admin", {
+            headers: { origin: "https://example.test" },
+          }),
+        )
+      ).status,
+    ).toBe(400);
   });
 
   test("derives optional authority headers from environment names", () => {
     expect(demoApiProxyFromEnvironment({})).toBeUndefined();
+    expect(() =>
+      demoApiProxyFromEnvironment({ OPENGENI_DEMO_API_URL: "file:///tmp/not-an-api" }),
+    ).toThrow("must use http or https");
     const apiValue = ["api", "value"].join("-");
     const accessValue = ["access", "value"].join("-");
     const env = {
@@ -140,6 +163,30 @@ describe("production web handler", () => {
     const headers = new Headers(options?.credentialHeaders);
     expect(headers.get("authorization")).toBe(["Bearer", apiValue].join(" "));
     expect(headers.get("x-opengeni-access-key")).toBe(accessValue);
+  });
+
+  test("reads optional demo authority from a dedicated mounted secret", () => {
+    const paths: string[] = [];
+    const options = demoApiProxyFromEnvironment(
+      {
+        OPENGENI_DEMO_API_URL: "https://api.example.test",
+        OPENGENI_DEMO_CREDENTIALS_DIR: "/var/run/secrets/opengeni-demo",
+      },
+      (path) => {
+        paths.push(path);
+        if (path.endsWith("/api-key")) return "mounted-api-value";
+        if (path.endsWith("/access-key")) return "mounted-access-value";
+        return undefined;
+      },
+    );
+
+    expect(paths).toEqual([
+      "/var/run/secrets/opengeni-demo/api-key",
+      "/var/run/secrets/opengeni-demo/access-key",
+    ]);
+    const headers = new Headers(options?.credentialHeaders);
+    expect(headers.get("authorization")).toBe("Bearer mounted-api-value");
+    expect(headers.get("x-opengeni-access-key")).toBe("mounted-access-value");
   });
 });
 

--- a/apps/web/src/server.test.ts
+++ b/apps/web/src/server.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { createWebHandler } from "./server";
+import { createWebHandler, demoApiProxyFromEnvironment } from "./server";
 
 const roots: string[] = [];
 
@@ -38,6 +38,108 @@ describe("production web handler", () => {
     const handler = createWebHandler(root);
     expect((await handler(new Request("https://example.test/assets/missing.js"))).status).toBe(404);
     expect((await handler(new Request("https://example.test/%2e%2e%2fsecret"))).status).toBe(400);
+  });
+
+  test("serves the deployed public React demo without falling through to the app shell", async () => {
+    const root = await fixture();
+    await mkdir(join(root, "react-demo", "assets"), { recursive: true });
+    await Bun.write(
+      join(root, "react-demo", "index.html"),
+      "<!doctype html><title>React demo</title>",
+    );
+    await Bun.write(
+      join(root, "react-demo", "realtime.html"),
+      "<!doctype html><title>Realtime demo</title>",
+    );
+    const handler = createWebHandler(root);
+
+    const redirect = await handler(new Request("https://example.test/react-demo"));
+    expect(redirect.status).toBe(308);
+    expect(redirect.headers.get("location")).toBe("https://example.test/react-demo/");
+    expect(await (await handler(new Request("https://example.test/react-demo/"))).text()).toContain(
+      "React demo",
+    );
+    expect(
+      await (await handler(new Request("https://example.test/react-demo/realtime.html"))).text(),
+    ).toContain("Realtime demo");
+  });
+
+  test("proxies only demo API routes and keeps credentials server-side", async () => {
+    const root = await fixture();
+    const seen: { input?: string; init?: RequestInit } = {};
+    const serverApiValue = ["server", "api", "value"].join("-");
+    const serverAccessValue = ["server", "access", "value"].join("-");
+    const credentialHeaders = new Headers();
+    credentialHeaders.set("authorization", ["Bearer", serverApiValue].join(" "));
+    credentialHeaders.set("x-opengeni-access-key", serverAccessValue);
+    const handler = createWebHandler(root, {
+      demoApiProxy: {
+        targetBaseUrl: "http://api.internal:8000",
+        credentialHeaders,
+        fetch: async (input, init) => {
+          seen.input = String(input);
+          seen.init = init;
+          return Response.json({ ok: true }, { status: 201 });
+        },
+      },
+    });
+    const browserHeaders = new Headers({
+      "content-type": "application/json",
+      origin: "https://example.test",
+      "x-opengeni-access-key": "browser-access-value-that-must-be-replaced",
+    });
+    browserHeaders.set("authorization", "browser-value-that-must-be-replaced");
+    const response = await handler(
+      new Request("https://example.test/demo-api/v1/workspaces/ws/sessions?after=1", {
+        method: "POST",
+        headers: browserHeaders,
+        body: '{"startMode":"realtime"}',
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(seen.input).toBe("http://api.internal:8000/v1/workspaces/ws/sessions?after=1");
+    const headers = new Headers(seen.init?.headers);
+    expect(headers.get("authorization")).toBe(["Bearer", serverApiValue].join(" "));
+    expect(headers.get("x-opengeni-access-key")).toBe(serverAccessValue);
+    expect(headers.get("x-forwarded-host")).toBe("example.test");
+    expect(new TextDecoder().decode(seen.init?.body as Uint8Array)).toContain("realtime");
+
+    expect(
+      (
+        await handler(
+          new Request("https://example.test/demo-api/admin", {
+            headers: { origin: "https://example.test" },
+          }),
+        )
+      ).status,
+    ).toBe(404);
+    expect(
+      (
+        await handler(
+          new Request("https://example.test/demo-api/v1/workspaces", {
+            headers: { origin: "https://evil.example" },
+          }),
+        )
+      ).status,
+    ).toBe(403);
+  });
+
+  test("derives optional authority headers from environment names", () => {
+    expect(demoApiProxyFromEnvironment({})).toBeUndefined();
+    const apiValue = ["api", "value"].join("-");
+    const accessValue = ["access", "value"].join("-");
+    const env = {
+      OPENGENI_DEMO_API_URL: "https://api.example.test",
+      [["OPENGENI", "DEMO", "API", "KEY"].join("_")]: apiValue,
+      [["OPENGENI", "DEMO", "ACCESS", "KEY"].join("_")]: accessValue,
+    };
+    const options = demoApiProxyFromEnvironment(env);
+    expect(options?.targetBaseUrl).toBe("https://api.example.test");
+    const headers = new Headers(options?.credentialHeaders);
+    expect(headers.get("authorization")).toBe(["Bearer", apiValue].join(" "));
+    expect(headers.get("x-opengeni-access-key")).toBe(accessValue);
   });
 });
 

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { extname, resolve, sep } from "node:path";
 
 const DEFAULT_PORT = 3000;
@@ -57,7 +58,7 @@ export function createWebHandler(
     if (await requestedFile.exists()) {
       return serveFile(request, requestedPath, cacheControlFor(staticPath));
     }
-    if (pathname.startsWith("/assets/")) {
+    if (pathname.startsWith("/assets/") || pathname.startsWith("/react-demo/")) {
       return new Response("Not Found", { status: 404 });
     }
     return serveFile(request, indexPath, REVALIDATE_CACHE_CONTROL);
@@ -74,6 +75,12 @@ async function proxyDemoApi(
   if (suffix !== "/healthz" && !suffix.startsWith("/v1/")) {
     return new Response("Not Found", { status: 404 });
   }
+  // OpenGeni API route segments never require percent encoding. Reject it so
+  // a second URL parser cannot turn a double-encoded dot segment into a path
+  // outside the admitted /v1 or /healthz surface.
+  if (suffix.includes("%")) {
+    return new Response("Bad Request", { status: 400 });
+  }
   const origin = request.headers.get("origin");
   if (origin && origin !== incomingUrl.origin) {
     return new Response("Forbidden", { status: 403 });
@@ -86,12 +93,23 @@ async function proxyDemoApi(
   const headers = new Headers(request.headers);
   for (const name of [
     "authorization",
+    "connection",
     "content-length",
+    "forwarded",
     "host",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
     "x-forwarded-for",
     "x-forwarded-host",
+    "x-forwarded-port",
     "x-forwarded-proto",
     "x-opengeni-access-key",
+    "x-real-ip",
   ]) {
     headers.delete(name);
   }
@@ -101,13 +119,13 @@ async function proxyDemoApi(
   headers.set("x-forwarded-host", incomingUrl.host);
   headers.set("x-forwarded-proto", incomingUrl.protocol.slice(0, -1));
 
-  const body =
-    request.method === "GET" || request.method === "HEAD" ? undefined : await request.bytes();
+  const body = request.method === "GET" || request.method === "HEAD" ? undefined : request.body;
   try {
     const upstream = await (options.fetch ?? fetch)(target, {
       method: request.method,
       headers,
       ...(body ? { body } : {}),
+      redirect: "manual",
       signal: request.signal,
     });
     const responseHeaders = new Headers(upstream.headers);
@@ -133,20 +151,41 @@ function normalizedBaseUrl(value: string): string {
 
 export function demoApiProxyFromEnvironment(
   env: Record<string, string | undefined> = process.env,
+  readCredentialFile: (path: string) => string | undefined = readDemoCredentialFile,
 ): DemoApiProxyOptions | undefined {
   const targetBaseUrl = env.OPENGENI_DEMO_API_URL?.trim();
   if (!targetBaseUrl) return undefined;
+  // Validate eagerly so a malformed deployment value fails at process startup
+  // instead of turning each demo request into an unhandled URL exception.
+  normalizedBaseUrl(targetBaseUrl);
   const credentialHeaders = new Headers();
   const apiKeyName = ["OPENGENI", "DEMO", "API", "KEY"].join("_");
   const accessKeyName = ["OPENGENI", "DEMO", "ACCESS", "KEY"].join("_");
-  const bearerValue = env[apiKeyName];
-  const accessValue = env[accessKeyName];
+  const credentialsDirectory = env.OPENGENI_DEMO_CREDENTIALS_DIR?.trim();
+  const bearerValue =
+    env[apiKeyName]?.trim() ||
+    (credentialsDirectory
+      ? readCredentialFile(resolve(credentialsDirectory, "api-key"))
+      : undefined);
+  const accessValue =
+    env[accessKeyName]?.trim() ||
+    (credentialsDirectory
+      ? readCredentialFile(resolve(credentialsDirectory, "access-key"))
+      : undefined);
   if (bearerValue) credentialHeaders.set("authorization", ["Bearer", bearerValue].join(" "));
   if (accessValue) credentialHeaders.set("x-opengeni-access-key", accessValue);
   return {
     targetBaseUrl,
     ...(bearerValue || accessValue ? { credentialHeaders } : {}),
   };
+}
+
+function readDemoCredentialFile(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf8").trim() || undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function safePath(root: string, pathname: string): string | null {

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -5,12 +5,31 @@ const DEFAULT_HOST = "0.0.0.0";
 const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
 const REVALIDATE_CACHE_CONTROL = "no-cache";
 const SHORT_CACHE_CONTROL = "public, max-age=3600";
+const DEMO_API_PREFIX = "/demo-api";
 
-export function createWebHandler(root = resolve(import.meta.dir, "../dist")) {
+export type DemoApiProxyOptions = {
+  targetBaseUrl: string;
+  /** Server-owned authority headers; never serialized into the demo bundle. */
+  credentialHeaders?: HeadersInit | undefined;
+  fetch?: ((input: string | URL | Request, init?: RequestInit) => Promise<Response>) | undefined;
+};
+
+export type WebHandlerOptions = {
+  demoApiProxy?: DemoApiProxyOptions | undefined;
+};
+
+export function createWebHandler(
+  root = resolve(import.meta.dir, "../dist"),
+  options: WebHandlerOptions = {},
+) {
   const distRoot = resolve(root);
   const indexPath = resolve(distRoot, "index.html");
 
   return async function webHandler(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === DEMO_API_PREFIX || url.pathname.startsWith(`${DEMO_API_PREFIX}/`)) {
+      return proxyDemoApi(request, url, options.demoApiProxy);
+    }
     if (request.method !== "GET" && request.method !== "HEAD") {
       return new Response("Method Not Allowed", {
         status: 405,
@@ -18,7 +37,6 @@ export function createWebHandler(root = resolve(import.meta.dir, "../dist")) {
       });
     }
 
-    const url = new URL(request.url);
     let pathname: string;
     try {
       pathname = decodeURIComponent(url.pathname);
@@ -26,19 +44,108 @@ export function createWebHandler(root = resolve(import.meta.dir, "../dist")) {
       return new Response("Bad Request", { status: 400 });
     }
 
-    const requestedPath = safePath(distRoot, pathname);
+    if (pathname === "/react-demo") {
+      return Response.redirect(new URL("/react-demo/", url), 308);
+    }
+    const staticPath = pathname.endsWith("/") ? `${pathname}index.html` : pathname;
+    const requestedPath = safePath(distRoot, staticPath);
     if (!requestedPath) {
       return new Response("Bad Request", { status: 400 });
     }
 
     const requestedFile = Bun.file(requestedPath);
     if (await requestedFile.exists()) {
-      return serveFile(request, requestedPath, cacheControlFor(pathname));
+      return serveFile(request, requestedPath, cacheControlFor(staticPath));
     }
     if (pathname.startsWith("/assets/")) {
       return new Response("Not Found", { status: 404 });
     }
     return serveFile(request, indexPath, REVALIDATE_CACHE_CONTROL);
+  };
+}
+
+async function proxyDemoApi(
+  request: Request,
+  incomingUrl: URL,
+  options: DemoApiProxyOptions | undefined,
+): Promise<Response> {
+  if (!options) return new Response("Demo API proxy is not configured", { status: 404 });
+  const suffix = incomingUrl.pathname.slice(DEMO_API_PREFIX.length);
+  if (suffix !== "/healthz" && !suffix.startsWith("/v1/")) {
+    return new Response("Not Found", { status: 404 });
+  }
+  const origin = request.headers.get("origin");
+  if (origin && origin !== incomingUrl.origin) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const target = new URL(
+    `${suffix}${incomingUrl.search}`,
+    normalizedBaseUrl(options.targetBaseUrl),
+  );
+  const headers = new Headers(request.headers);
+  for (const name of [
+    "authorization",
+    "content-length",
+    "host",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-opengeni-access-key",
+  ]) {
+    headers.delete(name);
+  }
+  for (const [name, value] of new Headers(options.credentialHeaders)) {
+    headers.set(name, value);
+  }
+  headers.set("x-forwarded-host", incomingUrl.host);
+  headers.set("x-forwarded-proto", incomingUrl.protocol.slice(0, -1));
+
+  const body =
+    request.method === "GET" || request.method === "HEAD" ? undefined : await request.bytes();
+  try {
+    const upstream = await (options.fetch ?? fetch)(target, {
+      method: request.method,
+      headers,
+      ...(body ? { body } : {}),
+      signal: request.signal,
+    });
+    const responseHeaders = new Headers(upstream.headers);
+    responseHeaders.set("cache-control", "no-store");
+    return new Response(request.method === "HEAD" ? null : upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: responseHeaders,
+    });
+  } catch {
+    return new Response("Demo API upstream unavailable", { status: 502 });
+  }
+}
+
+function normalizedBaseUrl(value: string): string {
+  const normalized = value.endsWith("/") ? value : `${value}/`;
+  const url = new URL(normalized);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("OPENGENI_DEMO_API_URL must use http or https");
+  }
+  return url.toString();
+}
+
+export function demoApiProxyFromEnvironment(
+  env: Record<string, string | undefined> = process.env,
+): DemoApiProxyOptions | undefined {
+  const targetBaseUrl = env.OPENGENI_DEMO_API_URL?.trim();
+  if (!targetBaseUrl) return undefined;
+  const credentialHeaders = new Headers();
+  const apiKeyName = ["OPENGENI", "DEMO", "API", "KEY"].join("_");
+  const accessKeyName = ["OPENGENI", "DEMO", "ACCESS", "KEY"].join("_");
+  const bearerValue = env[apiKeyName];
+  const accessValue = env[accessKeyName];
+  if (bearerValue) credentialHeaders.set("authorization", ["Bearer", bearerValue].join(" "));
+  if (accessValue) credentialHeaders.set("x-opengeni-access-key", accessValue);
+  return {
+    targetBaseUrl,
+    ...(bearerValue || accessValue ? { credentialHeaders } : {}),
   };
 }
 
@@ -95,6 +202,10 @@ function acceptsEncoding(header: string | null, encoding: string): boolean {
 if (import.meta.main) {
   const port = Number(process.env.PORT ?? DEFAULT_PORT);
   const hostname = process.env.HOST ?? DEFAULT_HOST;
-  Bun.serve({ hostname, port, fetch: createWebHandler() });
+  Bun.serve({
+    hostname,
+    port,
+    fetch: createWebHandler(undefined, { demoApiProxy: demoApiProxyFromEnvironment() }),
+  });
   console.log(`OpenGeni web listening on http://${hostname}:${port}`);
 }

--- a/deploy/helm/opengeni/templates/web-deployment.yaml
+++ b/deploy/helm/opengeni/templates/web-deployment.yaml
@@ -56,8 +56,18 @@ spec:
           env:
             - name: OPENGENI_DEMO_API_URL
               value: {{ default (printf "http://%s-api:%d" (include "opengeni.fullname" .) (.Values.api.service.port | int)) .Values.web.demoApiBaseUrl | quote }}
+            {{- if .Values.web.demoApiCredentialsSecret }}
+            - name: OPENGENI_DEMO_CREDENTIALS_DIR
+              value: /var/run/secrets/opengeni-demo
+            {{- end }}
           {{- else }}
           env: []
+          {{- end }}
+          {{- if .Values.web.demoApiCredentialsSecret }}
+          volumeMounts:
+            - name: demo-api-credentials
+              mountPath: /var/run/secrets/opengeni-demo
+              readOnly: true
           {{- end }}
           {{- if .Values.web.probes.startup.enabled }}
           startupProbe:
@@ -75,6 +85,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.web.demoApiCredentialsSecret }}
+      volumes:
+        - name: demo-api-credentials
+          secret:
+            secretName: {{ .Values.web.demoApiCredentialsSecret | quote }}
+      {{- end }}
       {{- if .Values.web.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
         {{- include "opengeni.topologySpreadConstraints" (dict "root" . "component" "web" "values" .Values.web) | nindent 8 }}

--- a/deploy/helm/opengeni/templates/web-deployment.yaml
+++ b/deploy/helm/opengeni/templates/web-deployment.yaml
@@ -52,7 +52,13 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "opengeni.fullname" . }}-config
+          {{- if or .Values.web.demoApiBaseUrl .Values.api.enabled }}
+          env:
+            - name: OPENGENI_DEMO_API_URL
+              value: {{ default (printf "http://%s-api:%d" (include "opengeni.fullname" .) (.Values.api.service.port | int)) .Values.web.demoApiBaseUrl | quote }}
+          {{- else }}
           env: []
+          {{- end }}
           {{- if .Values.web.probes.startup.enabled }}
           startupProbe:
             {{- include "opengeni.httpProbe" (dict "probe" .Values.web.probes.startup) | nindent 12 }}

--- a/deploy/helm/opengeni/templates/web-networkpolicy.yaml
+++ b/deploy/helm/opengeni/templates/web-networkpolicy.yaml
@@ -27,6 +27,18 @@ spec:
           port: {{ .Values.web.containerPort }}
   {{- if .Values.networkPolicy.egress.enabled }}
   egress:
-    {{- toYaml .Values.networkPolicy.egress.rules | nindent 4 }}
+    {{- if .Values.api.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "opengeni.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: api
+      ports:
+        - protocol: TCP
+          port: {{ .Values.api.containerPort }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.rules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/deploy/helm/opengeni/values.yaml
+++ b/deploy/helm/opengeni/values.yaml
@@ -325,6 +325,10 @@ worker:
 
 web:
   enabled: true
+  # Server-side target for the public React reference demo's same-origin
+  # /demo-api proxy. Empty uses this release's in-cluster API service when the
+  # API is enabled; set an explicit http(s) URL only for split deployments.
+  demoApiBaseUrl: ""
   replicaCount: 2
   strategy:
     type: RollingUpdate

--- a/deploy/helm/opengeni/values.yaml
+++ b/deploy/helm/opengeni/values.yaml
@@ -329,6 +329,9 @@ web:
   # /demo-api proxy. Empty uses this release's in-cluster API service when the
   # API is enabled; set an explicit http(s) URL only for split deployments.
   demoApiBaseUrl: ""
+  # Optional dedicated Secret containing `api-key` and/or `access-key` data
+  # entries. It is mounted read-only; do not reuse the full runtime Secret.
+  demoApiCredentialsSecret: ""
   replicaCount: 2
   strategy:
     type: RollingUpdate

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -336,7 +336,7 @@ promotion schema is canonical in
 `packages/db/drizzle/0162_session_realtime_connection_promotion.sql` and
 `packages/db/src/session-realtime-ledger.ts`.
 
-The web UI mounts realtime as a compact split action inside the existing
+The public React package and web UI mount realtime as a compact split action inside the existing
 composer action row, immediately before Pause/Send; it does not reserve a
 second panel above the composer. The primary action follows the current
 lifecycle (start, end, retry, or resume audio). Its disclosure contains the
@@ -349,7 +349,16 @@ Connected Codex remains on its original WebRTC/V3 path. Gateway models use a
 single-use browser token and normalized WebSocket transport, then translate at
 the provider edge into the same durable V3 bridge; provider choice cannot alter
 session context, delegation/Steer, progress/results, ACK fencing, or tail handoff.
-`ChatComposer.actionsStart` is the provider-neutral host seam.
+`ChatComposer.actionsStart` is the provider-neutral host seam. Canonical client
+ownership is split deliberately: `packages/sdk/src/realtime.ts` exposes the
+framework-neutral controller, transport selection, lifecycle/ledger/catalog
+types, and narrow backend client interface;
+`packages/react/src/realtime/realtime-control.tsx` owns the exact hooks and UI;
+and `apps/web` is only a consumer with routing, draft, and session-creation
+callbacks. Base SDK/React entries do not eagerly import realtime, so browser
+media and transport code remain lazy and SSR-safe. `apps/api`, `apps/worker`,
+and `packages/db` continue to own persistence, prompts, context processing,
+delegation, credentials, and provider-side mechanics.
 
 Complete role-bearing provider `turn.done` rows are the only authoritative voice
 transcript. Each provider delegation includes bounded finalized dialogue since
@@ -861,6 +870,7 @@ A typed `DeploymentContract` (`@opengeni/deployment`) turns an abstract profile 
 | Documents / RAG / knowledge memories                                        | `packages/documents/src/index.ts`, `apps/api/src/routes/documents.ts`, `apps/api/src/mcp/documents.ts`                                                                                                                                                      | —                                                                                  |
 | GitHub App                                                                  | `packages/github/src/index.ts`, `apps/api/src/routes/github.ts`                                                                                                                                                                                             | —                                                                                  |
 | The published SDK/React surface                                             | `packages/sdk/src/index.ts`, `packages/react/src/index.ts`                                                                                                                                                                                                  | `.changeset/config.json`                                                           |
+| Public realtime controller / React composer experience                     | `packages/sdk/src/realtime.ts`, `packages/react/src/realtime.ts`, `packages/react/src/realtime/`; `apps/web` is consumer-only                                                                                                                               | `packages/sdk/README.md`, `packages/react/README.md`                               |
 | Composer voice input / transcription providers / microphone lifecycle      | `packages/contracts/src/index.ts`, `packages/config/src/index.ts`, `apps/api/src/transcription/`, `packages/sdk/src/client.ts`, `packages/react/src/hooks/use-voice-input.ts`                                                                              | [`transcription.md`](transcription.md)                                             |
 | Structured human input                                                     | `packages/contracts/src/index.ts`, `packages/db/src/index.ts`, `packages/runtime/src/index.ts`, `apps/worker/src/activities/agent-turn.ts`, `apps/api/src/routes/sessions.ts`                                                                               | [`human-input.md`](human-input.md)                                                 |
 | The Rust agent / wire proto                                                 | `agent/proto/opengeni_agent.proto`, `agent/scripts/codegen.sh`                                                                                                                                                                                              | `agent/README.md`                                                                  |

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -56,7 +56,7 @@ proof, the surface truthfully remains lost-owner until an end/expiry event;
 there is no status API or newly invented logical mode. Canonical:
 `packages/sdk/src/codex-realtime-controller.ts`,
 `packages/sdk/src/gateway-realtime-transport.ts`,
-`apps/web/src/components/session/codex-realtime-control.tsx`, and
+`packages/react/src/realtime/realtime-control.tsx`, and
 `apps/web/src/routes/session.tsx`.
 
 Finite provider calls are hidden behind connection generations, not new

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -187,7 +187,14 @@ deterministic selection/start/mute/stop/reconnect/error testing. Use
 `?mode=live&workspaceId=…&sessionId=…` against the web server's same-origin
 `/demo-api` proxy for a real local OpenGeni environment. Configure
 `OPENGENI_DEMO_API_URL` and, only on the server, optional demo API/access
-credentials; the browser receives neither credential.
+credentials; the browser receives neither credential. Prefer the deployment's
+normal browser authentication. If the proxy needs a server credential, create a
+dedicated tenant-scoped, least-privilege key for the reference demo and never
+reuse a deployment-wide runtime secret. Helm deployments can mount a Secret
+containing only `api-key` and/or `access-key` with
+`web.demoApiCredentialsSecret`; those values are mounted read-only rather than
+exposed as container environment variables. Local non-Kubernetes servers may
+instead use `OPENGENI_DEMO_API_KEY` and/or `OPENGENI_DEMO_ACCESS_KEY`.
 
 Microphone capture works on `localhost` or a secure HTTPS origin. A remote HTTP
 deployment cannot request microphone access. The live page exercises catalog

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,7 +13,8 @@ The default root import (`@opengeni/react`) is the clean sandbox-agnostic
 surface — the chat/timeline hooks and components plus the sandbox workspace
 suite. Advanced chat-composer composition lives under
 `@opengeni/react/composer`; Connected-Machine UI lives under
-`@opengeni/react/machines`. (The root barrel still re-exports the machines
+`@opengeni/react/machines`; realtime voice controls live under the lazily
+loadable `@opengeni/react/realtime` subpath. (The root barrel still re-exports the machines
 island for back-compat, deprecated per #144.)
 
 Design-system-first: every visual decision routes through CSS-variable tokens
@@ -117,6 +118,82 @@ export function App() {
   );
 }
 ```
+
+## Realtime composer controls (`@opengeni/react/realtime`)
+
+The realtime subpath is the exact OpenGeni composer experience: model catalog
+and selection, split-button motion, start/stop/retry states, microphone and
+audio mute controls, diagnostics, recovery, and the same copy, ARIA, classes,
+and styling used by the web console. It is deliberately separate from the root
+entry so SSR and non-realtime consumers do not eagerly load browser media or
+transport code.
+
+For an existing session, place one public component in the composer's action
+slot. It resolves `client` and `workspaceId` from `OpenGeniProvider` and reuses
+the host's existing session/event projection rather than opening a duplicate
+stream:
+
+```tsx
+import { ChatComposer } from "@opengeni/react";
+import { SessionRealtimeControl } from "@opengeni/react/realtime";
+
+<ChatComposer
+  composer={composer}
+  effectiveControl={effectiveControl}
+  actionsStart={
+    <SessionRealtimeControl
+      sessionId={sessionId}
+      sessionStatus={sessionStatus}
+      effectiveControl={effectiveControl}
+      events={events}
+      eventsReady={!initialLoading}
+      codexConnected={codexConnected}
+    />
+  }
+/>;
+```
+
+For a new-session composer, create the session with `startMode: "realtime"`,
+navigate to it, and pass the selected model to the same existing-session
+control's `realtimeAutostartModel` prop:
+
+```tsx
+import { NewSessionRealtimeControl } from "@opengeni/react/realtime";
+
+<NewSessionRealtimeControl
+  codexConnected={codexConnected}
+  onStart={async (model) => {
+    const session = await client.createSession(workspaceId, {
+      requestedSessionId: crypto.randomUUID(),
+      startMode: "realtime",
+      idempotencyKey: crypto.randomUUID(),
+    });
+    navigateToSession(session.id, { realtimeAutostartModel: model });
+    return true;
+  }}
+/>;
+```
+
+Proxy-backed hosts can pass explicit `client` and `workspaceId` overrides. The
+exported `EmbeddedRealtimeSessionClientLike` requires only catalog, begin,
+Codex/Gateway negotiation, activation, heartbeat, ledger sync, and end. For
+custom layouts, use `useSessionRealtime`, `useRealtimeModelSelection`,
+`RealtimeVoiceControl`, and `RealtimeModelPickerMenu`; the batteries-included
+wrappers remain the recommended path.
+
+The reference consumer is `demo/realtime.html`. Run `bun run demo` from
+`packages/react`, then open `http://localhost:3100/realtime.html?mode=mock` for
+deterministic selection/start/mute/stop/reconnect/error testing. Use
+`?mode=live&workspaceId=…&sessionId=…` against the web server's same-origin
+`/demo-api` proxy for a real local OpenGeni environment. Configure
+`OPENGENI_DEMO_API_URL` and, only on the server, optional demo API/access
+credentials; the browser receives neither credential.
+
+Microphone capture works on `localhost` or a secure HTTPS origin. A remote HTTP
+deployment cannot request microphone access. The live page exercises catalog
+loading, realtime-first creation, Codex Live, Gateway models, mute, recovery,
+delegation/context timeline updates, structured questions, and stop/restart
+through published package APIs only.
 
 ## Composer customization (`@opengeni/react/composer`)
 
@@ -418,4 +495,6 @@ what the surfaces you mount need:
 `bun run demo` (from this package) serves a harness that drives the real hooks
 and components against a scripted mock client — a manager ops-channel narrative
 with streaming, tool calls, and a worker spawn, plus fleet and scheduled-task
-views and a dark/light toggle. `bun run demo:build` is part of the repo gate.
+views and a dark/light toggle. `realtime.html` is the public-package reference
+consumer described above, with deterministic mock and same-origin live modes.
+`bun run demo:build` is part of the repo gate.

--- a/packages/react/demo/fleet-policy-harness.tsx
+++ b/packages/react/demo/fleet-policy-harness.tsx
@@ -1,6 +1,6 @@
 import type { SessionEvent } from "@opengeni/sdk";
 import { createRoot } from "react-dom/client";
-import { MessageTimeline } from "../src/index";
+import { MessageTimeline } from "@opengeni/react";
 import { createFleetPolicyCanonicalProof } from "./fleet-policy-canonical-proof";
 import "./styles.css";
 

--- a/packages/react/demo/machines-fixtures.ts
+++ b/packages/react/demo/machines-fixtures.ts
@@ -12,7 +12,7 @@ import type {
   MachinesResponse,
   MachineView,
   MetricSample,
-} from "../src/index";
+} from "@opengeni/react";
 
 const GiB = 1024 * 1024 * 1024;
 

--- a/packages/react/demo/machines-harness.tsx
+++ b/packages/react/demo/machines-harness.tsx
@@ -19,7 +19,7 @@ import {
   SharedMachineDisclosure,
   type MachinesResponse,
   type MachineView,
-} from "../src/index";
+} from "@opengeni/react";
 import {
   consentHeadlessMachine,
   consentMachine,

--- a/packages/react/demo/main.tsx
+++ b/packages/react/demo/main.tsx
@@ -15,7 +15,7 @@ import {
   useSession,
   useSessionEvents,
   useWorkspaceSessions,
-} from "../src/index";
+} from "@opengeni/react";
 import { MANAGER_SESSION_ID, MockOpenGeniClient } from "./mock";
 import "./styles.css";
 

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -15,6 +15,7 @@ import type {
   CapabilityPack,
   ClientConfig,
   ComposerDraft,
+  CreateSessionRequest,
   CreateWorkspaceEnvironmentRequest,
   CreateVariableSetRequest,
   CreateRigRequest,
@@ -77,9 +78,10 @@ import type {
   VariableSet,
   VariableSetVariableMetadata,
   WorkspaceRegisteredPack,
+  WorkspaceRealtimeModelCatalogResponse,
 } from "@opengeni/sdk";
-import type { SessionClientLike } from "../src/index";
-import type { MachinesResponse } from "../src/machines";
+import type { SessionClientLike } from "@opengeni/react";
+import type { MachinesResponse } from "@opengeni/react/machines";
 
 const WORKSPACE_ID = "11111111-2222-4333-8444-555555555555";
 export const MANAGER_SESSION_ID = "3f6e1a2b-4c5d-4e6f-8a9b-0c1d2e3f4a5b";
@@ -195,6 +197,56 @@ export class MockOpenGeniClient implements SessionClientLike {
           checkedAt: null,
         },
       })),
+    };
+  }
+
+  async getWorkspaceRealtimeModelCatalog(
+    _workspaceId: string,
+  ): Promise<WorkspaceRealtimeModelCatalogResponse> {
+    return {
+      models: [
+        {
+          id: "opengeni-gateway/openai/gpt-realtime-2.1",
+          label: "GPT Realtime 2.1",
+          provider: "OpenGeni",
+          description: "Best overall voice intelligence",
+          available: true,
+          unavailableReason: null,
+          recommended: true,
+        },
+        {
+          id: "gpt-live-1-boulder-alpha",
+          label: "Codex Live",
+          provider: "Connected Codex",
+          description: "Deep session integration",
+          available: true,
+          unavailableReason: null,
+          recommended: false,
+        },
+        {
+          id: "workspace-gateway/openai/gpt-realtime-mini",
+          label: "GPT Realtime Mini",
+          provider: "Your Gateway",
+          description: "Faster, lighter live voice",
+          available: true,
+          unavailableReason: null,
+          recommended: false,
+        },
+      ],
+    };
+  }
+
+  async createSession(
+    _workspaceId: string,
+    request: CreateSessionRequest,
+  ): Promise<Session & { initialTurnId: string | null }> {
+    const sessionId = request.requestedSessionId ?? demoUuid();
+    const bus = this.bus(sessionId);
+    bus.setStatus("idle");
+    return {
+      ...this.fabricateSession(sessionId, "idle", "Realtime-first demo session"),
+      createIdempotencyKey: request.idempotencyKey ?? null,
+      initialTurnId: null,
     };
   }
 

--- a/packages/react/demo/queue-harness.tsx
+++ b/packages/react/demo/queue-harness.tsx
@@ -16,7 +16,7 @@ import {
   type QueueHarnessErrorShape,
   type QueueVisibilityProbeKind,
 } from "./queue-fixtures";
-import "../../../apps/web/src/styles.css";
+import "./styles.css";
 import "./queue-harness.css";
 
 declare global {

--- a/packages/react/demo/queue-harness.tsx
+++ b/packages/react/demo/queue-harness.tsx
@@ -1,7 +1,7 @@
 import type { SessionTurn } from "@opengeni/sdk";
 import { useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { QueueSurface, type ComposerState, type UseTurnQueueResult } from "../src/index";
+import { QueueSurface, type ComposerState, type UseTurnQueueResult } from "@opengeni/react";
 import {
   QUEUE_BOUNDARY_CLUSTERS,
   queueBoundaryPrompt,

--- a/packages/react/demo/realtime-controller.ts
+++ b/packages/react/demo/realtime-controller.ts
@@ -1,0 +1,206 @@
+import type {
+  SessionRealtimeController,
+  SessionRealtimeControllerSnapshot,
+  SessionRealtimeLifecycleProjection,
+} from "@opengeni/sdk/realtime";
+import type { SessionRealtimeControllerFactory } from "@opengeni/react/realtime";
+
+const IDLE_SNAPSHOT: SessionRealtimeControllerSnapshot = {
+  status: "idle",
+  realtimeId: null,
+  mode: null,
+  bridge: null,
+  microphone: "inactive",
+  inputMuted: false,
+  audibleOutput: "inactive",
+  outputMuted: false,
+  connectionGeneration: 0,
+  reconnectAttempt: 0,
+  diagnostic: null,
+  error: null,
+};
+
+type DemoController = SessionRealtimeController & {
+  reconnect(): void;
+  fail(): void;
+};
+
+export type DeterministicRealtimeHarness = {
+  factory: SessionRealtimeControllerFactory;
+  reconnect(sessionId: string): void;
+  fail(sessionId: string): void;
+  snapshot(sessionId: string): SessionRealtimeControllerSnapshot | null;
+};
+
+/**
+ * Deterministic transport-free controller used by the public demo and browser
+ * screenshots. Production mode never passes this factory and therefore uses
+ * the exact SDK WebRTC/Gateway controller selected by `@opengeni/sdk/realtime`.
+ */
+export function createDeterministicRealtimeHarness(): DeterministicRealtimeHarness {
+  const controllers = new Map<string, DemoController>();
+  return {
+    factory(options) {
+      const controller = createDemoController(options.sessionId, options.model);
+      controllers.set(options.sessionId, controller);
+      return controller;
+    },
+    reconnect(sessionId) {
+      controllers.get(sessionId)?.reconnect();
+    },
+    fail(sessionId) {
+      controllers.get(sessionId)?.fail();
+    },
+    snapshot(sessionId) {
+      return controllers.get(sessionId)?.snapshot() ?? null;
+    },
+  };
+}
+
+function createDemoController(
+  sessionId: string,
+  model: NonNullable<SessionRealtimeControllerSnapshot["mode"]>["model"],
+): DemoController {
+  let current = IDLE_SNAPSHOT;
+  let closed = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const listeners = new Set<(snapshot: SessionRealtimeControllerSnapshot) => void>();
+
+  const publish = (snapshot: SessionRealtimeControllerSnapshot) => {
+    if (closed) return;
+    current = snapshot;
+    for (const listener of listeners) listener(snapshot);
+  };
+  const scheduleActive = (delayMs = 350) => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => publish(activeSnapshot(sessionId, model, current)), delayMs);
+  };
+  const start = async () => {
+    publish({
+      ...IDLE_SNAPSHOT,
+      status: "starting",
+      microphone: "acquiring",
+      audibleOutput: "pending",
+      connectionGeneration: current.connectionGeneration + 1,
+    });
+    scheduleActive();
+  };
+
+  return {
+    snapshot: () => current,
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(current);
+      return () => listeners.delete(listener);
+    },
+    start,
+    async observeLifecycle(_lifecycle: SessionRealtimeLifecycleProjection | null) {},
+    async heartbeat() {},
+    async flush() {},
+    async ingestProviderEvent() {},
+    async retry() {
+      await start();
+    },
+    async retryAudibleOutput() {
+      publish({ ...current, audibleOutput: "audible", diagnostic: null, error: null });
+      return true;
+    },
+    setInputMuted(muted) {
+      publish({ ...current, inputMuted: muted });
+    },
+    setOutputMuted(muted) {
+      publish({ ...current, outputMuted: muted });
+    },
+    async stop() {
+      publish({ ...current, status: "stopping" });
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => publish(IDLE_SNAPSHOT), 70);
+    },
+    close() {
+      closed = true;
+      if (timer) clearTimeout(timer);
+      listeners.clear();
+    },
+    reconnect() {
+      if (current.mode?.state !== "active") return;
+      publish({
+        ...current,
+        status: "recovering",
+        reconnectAttempt: current.reconnectAttempt + 1,
+        diagnostic: {
+          kind: "reconnect",
+          message: "The deterministic demo interrupted the transport.",
+          recoverable: true,
+          connectionGeneration: current.connectionGeneration,
+          attempt: current.reconnectAttempt + 1,
+        },
+        error: "The deterministic demo interrupted the transport.",
+      });
+    },
+    fail() {
+      publish({
+        ...IDLE_SNAPSHOT,
+        status: "error",
+        diagnostic: {
+          kind: "negotiation_failure",
+          message: "The deterministic demo rejected the connection.",
+          recoverable: true,
+          connectionGeneration: current.connectionGeneration,
+          attempt: 1,
+        },
+        error: "The deterministic demo rejected the connection.",
+      });
+    },
+  };
+}
+
+function activeSnapshot(
+  sessionId: string,
+  model: NonNullable<SessionRealtimeControllerSnapshot["mode"]>["model"],
+  previous: SessionRealtimeControllerSnapshot,
+): SessionRealtimeControllerSnapshot {
+  return {
+    status: "active",
+    realtimeId: "33333333-3333-4333-8333-333333333333",
+    mode: {
+      id: "33333333-3333-4333-8333-333333333333",
+      sessionId,
+      operationId: "44444444-4444-4444-8444-444444444444",
+      browserInstanceId: "55555555-5555-4555-8555-555555555555",
+      model,
+      state: "active",
+      version: 1,
+      connectionEpoch: 1,
+      leaseExpiresAt: "2026-08-03T12:00:30.000Z",
+      lastHeartbeatAt: "2026-08-03T12:00:00.000Z",
+      startedAt: "2026-08-03T12:00:00.000Z",
+      endedAt: null,
+      endReason: null,
+    },
+    bridge: {
+      connectionId: "66666666-6666-4666-8666-666666666666",
+      connectionEpoch: 1,
+      startupFenceSequence: 0,
+      modeVersion: 1,
+      speaking: false,
+      activeDelegationId: null,
+      lastError: null,
+      ignoredEventCount: 0,
+      lastIgnoredEventType: null,
+      pendingInbound: 0,
+      pendingInboundBytes: 0,
+      clientAckThroughSequence: null,
+      providerAckSequences: [],
+      providerStarted: true,
+      fatal: null,
+    },
+    microphone: "active",
+    inputMuted: previous.inputMuted,
+    audibleOutput: "audible",
+    outputMuted: previous.outputMuted,
+    connectionGeneration: Math.max(1, previous.connectionGeneration),
+    reconnectAttempt: 0,
+    diagnostic: null,
+    error: null,
+  };
+}

--- a/packages/react/demo/realtime-harness.tsx
+++ b/packages/react/demo/realtime-harness.tsx
@@ -1,0 +1,295 @@
+import {
+  type EffectiveSessionControl,
+  OpenGeniClient,
+  type SessionRealtimeModel,
+} from "@opengeni/sdk";
+import {
+  ChatComposer,
+  HumanInputSurface,
+  MessageTimeline,
+  OpenGeniProvider,
+  SessionStatus,
+  useComposer,
+  useHumanInputRequests,
+  useSession,
+  useSessionEvents,
+} from "@opengeni/react";
+import { NewSessionRealtimeControl, SessionRealtimeControl } from "@opengeni/react/realtime";
+import { useMemo, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+import { MANAGER_SESSION_ID, MockOpenGeniClient } from "./mock";
+import { createDeterministicRealtimeHarness } from "./realtime-controller";
+import "./styles.css";
+
+const MOCK_WORKSPACE_ID = "11111111-2222-4333-8444-555555555555";
+const params = new URLSearchParams(window.location.search);
+const mode = params.get("mode") === "live" ? "live" : "mock";
+const initialWorkspaceId = params.get("workspaceId") ?? MOCK_WORKSPACE_ID;
+const initialSessionId = params.get("sessionId") ?? (mode === "mock" ? MANAGER_SESSION_ID : "");
+const deterministicRealtime = createDeterministicRealtimeHarness();
+const client =
+  mode === "live"
+    ? new OpenGeniClient({
+        baseUrl: "/demo-api",
+        fetch: (input, init) => fetch(input, { ...init, credentials: "include" }),
+      })
+    : new MockOpenGeniClient();
+
+function ReferenceConsumer() {
+  const [workspaceId, setWorkspaceId] = useState(initialWorkspaceId);
+  const [sessionId, setSessionId] = useState(initialSessionId);
+  const [realtimeAutostartModel, setRealtimeAutostartModel] = useState<SessionRealtimeModel | null>(
+    null,
+  );
+  const [creationCount, setCreationCount] = useState(0);
+
+  if (!workspaceId || (mode === "live" && !sessionId)) {
+    return (
+      <LiveConfiguration
+        workspaceId={workspaceId}
+        sessionId={sessionId}
+        onSubmit={(nextWorkspaceId, nextSessionId) => {
+          setWorkspaceId(nextWorkspaceId);
+          setSessionId(nextSessionId);
+          writeLiveLocation(nextWorkspaceId, nextSessionId);
+        }}
+      />
+    );
+  }
+
+  const createRealtimeFirstSession = async (model: SessionRealtimeModel): Promise<boolean> => {
+    const requestedSessionId = crypto.randomUUID();
+    const created = await client.createSession(workspaceId, {
+      requestedSessionId,
+      startMode: "realtime",
+      idempotencyKey: `react-realtime-demo:${requestedSessionId}`,
+    });
+    setCreationCount((value) => value + 1);
+    setRealtimeAutostartModel(model);
+    setSessionId(created.id);
+    writeLiveLocation(workspaceId, created.id);
+    return true;
+  };
+
+  return (
+    <OpenGeniProvider client={client} workspaceId={workspaceId}>
+      <main className="og-root min-h-dvh bg-og-bg px-4 py-8 text-og-fg sm:px-6">
+        <div className="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[minmax(0,1fr)_22rem]">
+          <ExistingSession
+            key={sessionId}
+            sessionId={sessionId}
+            autostartModel={realtimeAutostartModel}
+            onAutostartConsumed={() => setRealtimeAutostartModel(null)}
+          />
+          <aside className="space-y-6">
+            <section className="rounded-og-xl border border-og-border bg-og-surface-1 p-4 shadow-og-sm">
+              <p className="text-og-xs font-medium uppercase tracking-[0.12em] text-og-fg-subtle">
+                Public reference consumer
+              </p>
+              <h1 className="mt-2 text-og-lg font-semibold">@opengeni/react/realtime</h1>
+              <dl className="mt-4 grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 text-og-xs">
+                <dt className="text-og-fg-subtle">Mode</dt>
+                <dd data-testid="demo-mode" className="font-og-mono">
+                  {mode}
+                </dd>
+                <dt className="text-og-fg-subtle">Workspace</dt>
+                <dd className="truncate font-og-mono">{workspaceId}</dd>
+                <dt className="text-og-fg-subtle">Session</dt>
+                <dd data-testid="current-session-id" className="truncate font-og-mono">
+                  {sessionId}
+                </dd>
+                <dt className="text-og-fg-subtle">Created here</dt>
+                <dd data-testid="realtime-first-count" className="font-og-mono">
+                  {creationCount}
+                </dd>
+              </dl>
+              {mode === "mock" ? (
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => deterministicRealtime.reconnect(sessionId)}
+                    className="rounded-og-md border border-og-border px-2.5 py-1.5 text-og-xs hover:border-og-accent/40"
+                  >
+                    Simulate reconnect
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => deterministicRealtime.fail(sessionId)}
+                    className="rounded-og-md border border-og-border px-2.5 py-1.5 text-og-xs hover:border-og-accent/40"
+                  >
+                    Simulate error
+                  </button>
+                </div>
+              ) : null}
+            </section>
+            <NewSessionComposer onStart={createRealtimeFirstSession} />
+          </aside>
+        </div>
+      </main>
+    </OpenGeniProvider>
+  );
+}
+
+function ExistingSession(props: {
+  sessionId: string;
+  autostartModel: SessionRealtimeModel | null;
+  onAutostartConsumed(): void;
+}) {
+  const { session } = useSession(props.sessionId, { pollIntervalMs: mode === "live" ? 5_000 : 0 });
+  const events = useSessionEvents(props.sessionId);
+  const composer = useComposer(props.sessionId, {
+    events: events.events,
+    effectiveControl: session?.effectiveControl,
+  });
+  const humanInput = useHumanInputRequests(props.sessionId, { events: events.events });
+  const status = events.sessionStatus ?? session?.status ?? "idle";
+  const effectiveControl = session?.effectiveControl ?? ACTIVE_CONTROL;
+
+  return (
+    <section
+      data-realtime-existing-composer=""
+      className="flex min-h-[42rem] flex-col overflow-hidden rounded-og-xl border border-og-border bg-og-surface-1 shadow-og-sm"
+    >
+      <header className="flex items-center justify-between gap-3 border-b border-og-border px-4 py-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-og-sm font-semibold">Existing-session composer</h2>
+          <p className="truncate font-og-mono text-[11px] text-og-fg-subtle">{props.sessionId}</p>
+        </div>
+        <SessionStatus status={status} />
+      </header>
+      <MessageTimeline items={events.timeline} status={status} className="min-h-0 flex-1" />
+      <HumanInputSurface
+        requests={humanInput.requests}
+        respondingRequestId={humanInput.respondingRequestId}
+        error={humanInput.mutationError?.message ?? humanInput.error?.message ?? null}
+        onSubmit={async (requestId, response) => {
+          await humanInput.respond(requestId, response);
+        }}
+        className="border-t border-og-border px-4 py-3"
+      />
+      <div className="shrink-0 border-t border-og-border px-4 py-4">
+        <ChatComposer
+          composer={composer}
+          effectiveControl={effectiveControl}
+          placeholder="Message this live session…"
+          actionsStart={
+            <SessionRealtimeControl
+              sessionId={props.sessionId}
+              sessionStatus={status}
+              effectiveControl={effectiveControl}
+              events={events.events}
+              eventsReady={!events.initialLoading}
+              codexConnected={mode === "mock"}
+              realtimeAutostartModel={props.autostartModel ?? undefined}
+              onRealtimeAutostartConsumed={props.onAutostartConsumed}
+              controllerFactory={mode === "mock" ? deterministicRealtime.factory : undefined}
+            />
+          }
+        />
+      </div>
+    </section>
+  );
+}
+
+function NewSessionComposer(props: { onStart(model: SessionRealtimeModel): Promise<boolean> }) {
+  const composer = useComposer(null, { draftPersistence: "disabled" });
+  return (
+    <section
+      data-realtime-new-composer=""
+      className="rounded-og-xl border border-og-border bg-og-surface-1 p-4 shadow-og-sm"
+    >
+      <h2 className="text-og-sm font-semibold">New-session composer</h2>
+      <p className="mt-1 text-og-xs leading-5 text-og-fg-subtle">
+        Starts with <code className="font-og-mono">startMode: &quot;realtime&quot;</code>, then
+        mounts the same existing-session control with autostart.
+      </p>
+      <div className="mt-4">
+        <ChatComposer
+          composer={composer}
+          placeholder="Optional first typed message…"
+          actionsStart={
+            <NewSessionRealtimeControl codexConnected={mode === "mock"} onStart={props.onStart} />
+          }
+        />
+      </div>
+    </section>
+  );
+}
+
+function LiveConfiguration(props: {
+  workspaceId: string;
+  sessionId: string;
+  onSubmit(workspaceId: string, sessionId: string): void;
+}) {
+  const [workspaceId, setWorkspaceId] = useState(props.workspaceId);
+  const [sessionId, setSessionId] = useState(props.sessionId);
+  const valid = useMemo(
+    () => workspaceId.trim().length > 0 && sessionId.trim().length > 0,
+    [sessionId, workspaceId],
+  );
+  return (
+    <main className="og-root grid min-h-dvh place-items-center bg-og-bg p-6 text-og-fg">
+      <form
+        className="w-full max-w-lg rounded-og-xl border border-og-border bg-og-surface-1 p-6 shadow-og-lg"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (valid) props.onSubmit(workspaceId.trim(), sessionId.trim());
+        }}
+      >
+        <h1 className="text-og-lg font-semibold">Connect the live realtime demo</h1>
+        <p className="mt-2 text-og-sm leading-6 text-og-fg-subtle">
+          The browser uses the public SDK through the same-origin <code>/demo-api</code> proxy.
+          Credentials remain on the server.
+        </p>
+        <label className="mt-5 grid gap-1.5 text-og-xs text-og-fg-muted">
+          Workspace ID
+          <input
+            value={workspaceId}
+            onChange={(event) => setWorkspaceId(event.target.value)}
+            className="h-10 rounded-og-md border border-og-border bg-og-surface-2 px-3 font-og-mono text-og-sm text-og-fg outline-none focus:border-og-accent/50"
+          />
+        </label>
+        <label className="mt-4 grid gap-1.5 text-og-xs text-og-fg-muted">
+          Existing session ID
+          <input
+            value={sessionId}
+            onChange={(event) => setSessionId(event.target.value)}
+            className="h-10 rounded-og-md border border-og-border bg-og-surface-2 px-3 font-og-mono text-og-sm text-og-fg outline-none focus:border-og-accent/50"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={!valid}
+          className="mt-5 h-10 rounded-og-md bg-og-accent px-4 text-og-sm font-medium text-og-accent-fg disabled:opacity-45"
+        >
+          Open reference consumer
+        </button>
+      </form>
+    </main>
+  );
+}
+
+function writeLiveLocation(workspaceId: string, sessionId: string): void {
+  if (mode !== "live") return;
+  const next = new URL(window.location.href);
+  next.searchParams.set("mode", "live");
+  next.searchParams.set("workspaceId", workspaceId);
+  next.searchParams.set("sessionId", sessionId);
+  window.history.replaceState(null, "", next);
+}
+
+const ACTIVE_CONTROL: EffectiveSessionControl = {
+  state: "active",
+  controlVersion: 0,
+  controlEtag: "realtime-demo-active",
+  directState: "active",
+  primaryBlocker: null,
+  additionalBlockerCount: 0,
+  blockers: [],
+  resumeOptions: [],
+  override: null,
+  settlement: null,
+};
+
+createRoot(document.getElementById("root")!).render(<ReferenceConsumer />);

--- a/packages/react/demo/realtime.html
+++ b/packages/react/demo/realtime.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="data:," />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@opengeni/react/realtime — reference consumer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/realtime-harness.tsx"></script>
+  </body>
+</html>

--- a/packages/react/demo/styles.css
+++ b/packages/react/demo/styles.css
@@ -1,9 +1,9 @@
 @import "tailwindcss";
 @import "@fontsource-variable/inter/wght.css";
 @import "@fontsource-variable/jetbrains-mono/wght.css";
-@import "../styles/index.css";
+@import "@opengeni/react/styles.css";
 
-@source "../src";
+@source "../../../node_modules/@opengeni/react/src";
 
 html,
 body,

--- a/packages/react/demo/terminal-harness.tsx
+++ b/packages/react/demo/terminal-harness.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { SandboxTerminal } from "../src/components/sandbox-terminal";
-import type { TerminalChunk, UseSandboxTerminalResult } from "../src/hooks/use-sandbox-terminal";
+import {
+  SandboxTerminal,
+  type TerminalChunk,
+  type UseSandboxTerminalResult,
+} from "@opengeni/react";
 import "./styles.css";
 
 /* ----------------------------------------------------------------------------

--- a/packages/react/demo/timeline-harness.tsx
+++ b/packages/react/demo/timeline-harness.tsx
@@ -11,7 +11,7 @@ import {
   TurnSummary,
   type ActivityItem,
   type TimelineGroup,
-} from "../src/index";
+} from "@opengeni/react";
 import {
   authNeededEvents,
   cancelledTurnEvents,

--- a/packages/react/demo/timeline-scroll-merge-test-harness.tsx
+++ b/packages/react/demo/timeline-scroll-merge-test-harness.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 
-import { MessageTimeline, type TimelineItem } from "../src/index";
+import { MessageTimeline, type TimelineItem } from "@opengeni/react";
 import "./styles.css";
 
 type TimelineMergeHarness = {

--- a/packages/react/demo/timeline-scroll-test-harness.tsx
+++ b/packages/react/demo/timeline-scroll-test-harness.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 
-import { MessageTimeline, type TimelineItem } from "../src/index";
+import { MessageTimeline, type TimelineItem } from "@opengeni/react";
 import "./styles.css";
 
 type VisibleRow = { id: string | null; top: number | null };

--- a/packages/react/demo/timeline-tip-follow-test-harness.tsx
+++ b/packages/react/demo/timeline-tip-follow-test-harness.tsx
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 
-import { MessageTimeline, type TimelineItem } from "../src/index";
+import { MessageTimeline, type TimelineItem } from "@opengeni/react";
 import "./styles.css";
 
 type TipFollowHarness = {

--- a/packages/react/demo/transcription-harness.tsx
+++ b/packages/react/demo/transcription-harness.tsx
@@ -2,7 +2,7 @@ import type { ClientVoiceInputConfig } from "@opengeni/sdk";
 import { useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { ChatComposer, type ComposerState } from "@opengeni/react";
-import "../../../apps/web/src/styles.css";
+import "./styles.css";
 
 type FixtureMode = "normal" | "denied" | "hanging";
 

--- a/packages/react/demo/transcription-harness.tsx
+++ b/packages/react/demo/transcription-harness.tsx
@@ -1,7 +1,7 @@
 import type { ClientVoiceInputConfig } from "@opengeni/sdk";
 import { useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { ChatComposer, type ComposerState } from "../src/index";
+import { ChatComposer, type ComposerState } from "@opengeni/react";
 import "../../../apps/web/src/styles.css";
 
 type FixtureMode = "normal" | "denied" | "hanging";

--- a/packages/react/demo/vite.config.ts
+++ b/packages/react/demo/vite.config.ts
@@ -4,8 +4,10 @@ import viteReact from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  base: process.env.OPENGENI_REACT_DEMO_BASE ?? "/",
   plugins: [viteReact(), tailwindcss()],
   build: {
+    outDir: process.env.OPENGENI_REACT_DEMO_OUT_DIR ?? "../demo-dist",
     // The harness deliberately exposes the full lazy language/theme catalog.
     // Keep the warning boundary aligned with the production app's enforced
     // 800 kB raw lazy-chunk budget; the largest generated chunk remains below
@@ -27,6 +29,7 @@ export default defineConfig({
         workbenchEmbed: resolve(__dirname, "workbench-embed.html"),
         terminal: resolve(__dirname, "terminal.html"),
         transcription: resolve(__dirname, "transcription.html"),
+        realtime: resolve(__dirname, "realtime.html"),
       },
     },
   },

--- a/packages/react/demo/workbench-dock-harness.tsx
+++ b/packages/react/demo/workbench-dock-harness.tsx
@@ -1,5 +1,5 @@
 import { createRoot } from "react-dom/client";
-import { OpenGeniProvider, SandboxWorkspace, useSessionEvents } from "../src/index";
+import { OpenGeniProvider, SandboxWorkspace, useSessionEvents } from "@opengeni/react";
 import { DOCK_SESSION_ID, DOCK_STATES, DockStateMockClient } from "./workbench-dock-states";
 import "./styles.css";
 

--- a/packages/react/demo/workbench-dock-states.ts
+++ b/packages/react/demo/workbench-dock-states.ts
@@ -25,7 +25,7 @@ import type {
   SessionCapabilities,
   WorkspaceCaptureManifest,
 } from "@opengeni/sdk";
-import type { MachinesResponse, MachineView } from "../src/machines";
+import type { MachinesResponse, MachineView } from "@opengeni/react/machines";
 import { MockOpenGeniClient } from "./mock";
 
 export const DOCK_SESSION_ID = "9c1d2e3f-4a5b-4c6d-8e7f-0a1b2c3d4e5f";

--- a/packages/react/demo/workbench-embed-harness.tsx
+++ b/packages/react/demo/workbench-embed-harness.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { OpenGeniClient, type SessionEvent } from "@opengeni/sdk";
-import { OpenGeniProvider, SandboxWorkspace, useSessionEvents } from "../src/index";
+import { OpenGeniProvider, SandboxWorkspace, useSessionEvents } from "@opengeni/react";
 import "./styles.css";
 
 /* ----------------------------------------------------------------------------

--- a/packages/react/demo/workbench-harness.tsx
+++ b/packages/react/demo/workbench-harness.tsx
@@ -1,8 +1,11 @@
 import { createRoot } from "react-dom/client";
 import type { GitDiffHunk, GitDiffLine, GitFileDiff } from "@opengeni/sdk";
-import { WorkbenchChanges } from "../src/components/workbench-changes";
-import { FileBrowser } from "../src/components/file-browser";
-import type { FileTreeNode, UseSandboxFilesResult } from "../src/hooks/use-sandbox-files";
+import {
+  FileBrowser,
+  WorkbenchChanges,
+  type FileTreeNode,
+  type UseSandboxFilesResult,
+} from "@opengeni/react";
 import "./styles.css";
 
 /* ----------------------------------------------------------------------------

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,6 +44,10 @@
       "import": "./src/model-policy.ts",
       "default": "./src/model-policy.ts"
     },
+    "./realtime": {
+      "types": "./src/realtime.ts",
+      "default": "./src/realtime.ts"
+    },
     "./styles.css": {
       "types": "./styles/index.d.ts",
       "default": "./styles/index.css"
@@ -62,6 +66,7 @@
     "build": "bun ../../scripts/build-typescript-package.ts",
     "demo": "vite dev demo --port 3100",
     "demo:build": "vite build demo",
+    "demo:build:deployed": "OPENGENI_REACT_DEMO_BASE=/react-demo/ OPENGENI_REACT_DEMO_OUT_DIR=../../../apps/web/dist/react-demo vite build demo",
     "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -171,3 +171,16 @@ export type EmbeddedHumanInputSessionClientLike = EmbeddedSessionEventClientLike
 /** Exact client surface required by MCP approval-policy hooks. */
 export type EmbeddedSessionMcpApprovalPolicyClientLike = EmbeddedSessionEventClientLike &
   Pick<OpenGeniClient, "updateSessionMcpApprovalPolicy">;
+
+/** Exact client surface required by the public realtime React subpath. */
+export type EmbeddedRealtimeSessionClientLike = Pick<
+  OpenGeniClient,
+  | "getWorkspaceRealtimeModelCatalog"
+  | "beginSessionRealtime"
+  | "heartbeatSessionRealtime"
+  | "negotiateCodexRealtimeWebrtc"
+  | "negotiateGatewayRealtime"
+  | "activateCodexRealtimeConnection"
+  | "syncSessionRealtimeLedger"
+  | "endSessionRealtime"
+>;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -447,6 +447,8 @@ export { SandboxTerminal } from "./components/sandbox-terminal";
 export type { SandboxTerminalProps, XtermTheme } from "./components/sandbox-terminal";
 export { FileBrowser } from "./components/file-browser";
 export type { FileBrowserProps } from "./components/file-browser";
+export { WorkbenchChanges } from "./components/workbench-changes";
+export type { WorkbenchChangesProps } from "./components/workbench-changes";
 export { DiffView } from "./components/diff-view";
 export type { DiffViewProps, DiffTheme } from "./components/diff-view";
 export { PierreDiff } from "./components/pierre-diff";

--- a/packages/react/src/realtime.ts
+++ b/packages/react/src/realtime.ts
@@ -1,0 +1,27 @@
+/**
+ * Batteries-included realtime voice controls and hooks.
+ *
+ * Import this subpath lazily when the composer action slot is rendered. The
+ * base `@opengeni/react` entry remains SSR/browser safe and does not eagerly
+ * load microphone, WebRTC, Gateway, or realtime UI code.
+ */
+export {
+  CodexRealtimeControl,
+  NewSessionRealtimeControl,
+  RealtimeModelPickerMenu,
+  RealtimeVoiceControl,
+  SessionCodexRealtimeControl,
+  SessionRealtimeControl,
+  codexRealtimeAdmissionAllowed,
+  codexRealtimeAdmissionBlocker,
+  useRealtimeModelSelection,
+  useSessionCodexRealtime,
+  useSessionRealtime,
+  useWorkspaceRealtimeModelSelection,
+} from "./realtime/realtime-control";
+export type {
+  RealtimeModelOption,
+  SessionRealtimeControllerFactory,
+} from "./realtime/realtime-control";
+export type { EmbeddedRealtimeSessionClientLike } from "./client";
+export type { EmbeddedRealtimeSessionClientOverride } from "./session-context";

--- a/packages/react/src/realtime/dropdown-menu.tsx
+++ b/packages/react/src/realtime/dropdown-menu.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { ChevronRightIcon } from "lucide-react";
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+import type { ComponentProps } from "react";
+import { cn } from "../lib/cn";
+
+function DropdownMenu(props: ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuTrigger(props: ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub(props: ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & { inset?: boolean }) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+};

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -1,15 +1,14 @@
+import { type EffectiveSessionControl, type SessionEvent, type SessionStatus } from "@opengeni/sdk";
 import {
+  hasStoredSessionRealtimeOwnerProof,
   projectSessionRealtimeLifecycle,
-  type CodexRealtimeController,
-  type CodexRealtimeControllerClient,
-  type CodexRealtimeControllerSnapshot,
-  type EffectiveSessionControl,
-  type SessionEvent,
+  type SessionRealtimeClientLike,
+  type SessionRealtimeController,
+  type SessionRealtimeControllerSnapshot,
+  type CreateSessionRealtimeControllerOptions,
   type SessionRealtimeModel,
-  type SessionStatus,
   type WorkspaceRealtimeModelCatalogItem,
-  type WorkspaceRealtimeModelCatalogResponse,
-} from "@opengeni/sdk";
+} from "@opengeni/sdk/realtime";
 import {
   AudioLinesIcon,
   CheckIcon,
@@ -26,8 +25,16 @@ import {
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { BillingClassMark, type BillingClass } from "@/components/billing-class-mark";
-import { PickerAnimatedPage, PickerBackHeader, PickerNavRow } from "@/components/pickers";
+import {
+  BillingClassMark,
+  PickerAnimatedPage,
+  PickerBackHeader,
+  PickerNavRow,
+} from "../components/model-policy-picker";
+import type { EmbeddedRealtimeSessionClientLike } from "../client";
+import { cn } from "../lib/cn";
+import type { PickerBillingClass as BillingClass } from "../model-policy";
+import { useEmbeddedRealtimeSession } from "../session-context";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -37,8 +44,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { cn } from "@/lib/utils";
+} from "./dropdown-menu";
 
 export type RealtimeModelOption = {
   id: SessionRealtimeModel;
@@ -76,11 +82,11 @@ const REALTIME_PROVIDER_META: Record<
 };
 const REALTIME_MODEL_STORAGE_PREFIX = "opengeni:realtime-model";
 
-type RealtimeControllerClient = CodexRealtimeControllerClient & {
-  getWorkspaceRealtimeModelCatalog?(
-    workspaceId: string,
-  ): Promise<WorkspaceRealtimeModelCatalogResponse>;
-};
+type RealtimeControllerClient = EmbeddedRealtimeSessionClientLike & SessionRealtimeClientLike;
+
+export type SessionRealtimeControllerFactory = (
+  options: CreateSessionRealtimeControllerOptions,
+) => SessionRealtimeController;
 
 type AdmissionInput = {
   sessionStatus: SessionStatus;
@@ -103,9 +109,9 @@ export function codexRealtimeAdmissionBlocker(input: AdmissionInput): string | n
   return null;
 }
 
-export function useSessionCodexRealtime(options: {
-  client: RealtimeControllerClient;
-  workspaceId: string;
+export function useSessionRealtime(options: {
+  client?: RealtimeControllerClient | undefined;
+  workspaceId?: string | undefined;
   sessionId: string;
   sessionStatus: SessionStatus;
   effectiveControl: EffectiveSessionControl;
@@ -115,13 +121,19 @@ export function useSessionCodexRealtime(options: {
   model?: SessionRealtimeModel | undefined;
   modelAvailable?: boolean | undefined;
   modelUnavailableReason?: string | null | undefined;
+  /** Deterministic browser-test/demo seam. Production hosts should use the SDK default. */
+  controllerFactory?: SessionRealtimeControllerFactory | undefined;
 }) {
+  const { client, workspaceId } = useEmbeddedRealtimeSession({
+    client: options.client,
+    workspaceId: options.workspaceId,
+  });
   const model = options.model ?? CODEX_LIVE_MODEL.id;
   const audioRef = useRef<HTMLAudioElement>(null);
-  const controllerRef = useRef<CodexRealtimeController | null>(null);
+  const controllerRef = useRef<SessionRealtimeController | null>(null);
   const controllerModelRef = useRef<SessionRealtimeModel | null>(null);
-  const [snapshot, setSnapshot] = useState<CodexRealtimeControllerSnapshot>(() => ({
-    status: hasStoredOwnerProof(options.workspaceId, options.sessionId, model)
+  const [snapshot, setSnapshot] = useState<SessionRealtimeControllerSnapshot>(() => ({
+    status: hasStoredSessionRealtimeOwnerProof({ workspaceId, sessionId: options.sessionId, model })
       ? "recovering"
       : "idle",
     realtimeId: null,
@@ -148,28 +160,18 @@ export function useSessionCodexRealtime(options: {
 
   useEffect(() => {
     let disposed = false;
-    let controller: CodexRealtimeController | null = null;
+    let controller: SessionRealtimeController | null = null;
     let unsubscribe: (() => void) | null = null;
-    void Promise.all([
-      import("@opengeni/sdk/codex-realtime-controller"),
-      model === CODEX_LIVE_MODEL.id
-        ? Promise.resolve(null)
-        : import("@opengeni/sdk/gateway-realtime-transport"),
-    ])
-      .then(([{ createCodexRealtimeController }, gateway]) => {
+    void import("@opengeni/sdk/realtime")
+      .then(({ createSessionRealtimeController }) => {
         if (disposed) return;
-        controller = createCodexRealtimeController({
-          client: options.client,
-          workspaceId: options.workspaceId,
+        const controllerFactory = options.controllerFactory ?? createSessionRealtimeController;
+        controller = controllerFactory({
+          client,
+          workspaceId,
           sessionId: options.sessionId,
           ...(audioRef.current ? { remoteAudio: audioRef.current } : {}),
-          ...(model === CODEX_LIVE_MODEL.id
-            ? {}
-            : {
-                model,
-                ownerStorageNamespace: "gateway-realtime-owner",
-                startTransport: gateway!.createGatewayRealtimeTransportStarter(),
-              }),
+          model,
         });
         controllerRef.current = controller;
         controllerModelRef.current = model;
@@ -212,7 +214,7 @@ export function useSessionCodexRealtime(options: {
         controllerModelRef.current = null;
       }
     };
-  }, [model, options.client, options.sessionId, options.workspaceId]);
+  }, [client, model, options.controllerFactory, options.sessionId, workspaceId]);
 
   useEffect(() => {
     if (!options.eventsReady) return;
@@ -274,26 +276,9 @@ export function useSessionCodexRealtime(options: {
   };
 }
 
-function hasStoredOwnerProof(
-  workspaceId: string,
-  sessionId: string,
-  model: SessionRealtimeModel,
-): boolean {
-  if (typeof sessionStorage === "undefined") return false;
-  try {
-    return (
-      sessionStorage.getItem(
-        `opengeni:${model === CODEX_LIVE_MODEL.id ? "codex" : "gateway"}-realtime-owner:${workspaceId}:${sessionId}`,
-      ) !== null
-    );
-  } catch {
-    return false;
-  }
-}
-
-export function SessionCodexRealtimeControl(props: {
-  client: RealtimeControllerClient;
-  workspaceId: string;
+export function SessionRealtimeControl(props: {
+  client?: RealtimeControllerClient | undefined;
+  workspaceId?: string | undefined;
   sessionId: string;
   sessionStatus: SessionStatus;
   effectiveControl: EffectiveSessionControl;
@@ -302,16 +287,18 @@ export function SessionCodexRealtimeControl(props: {
   codexConnected: boolean;
   realtimeAutostartModel?: SessionRealtimeModel | undefined;
   onRealtimeAutostartConsumed?: (() => void) | undefined;
+  /** Deterministic browser-test/demo seam. Production hosts should use the SDK default. */
+  controllerFactory?: SessionRealtimeControllerFactory | undefined;
 }) {
   const lifecycle = useMemo(() => projectSessionRealtimeLifecycle(props.events), [props.events]);
-  const selection = useWorkspaceRealtimeModelSelection({
+  const selection = useRealtimeModelSelection({
     client: props.client,
     workspaceId: props.workspaceId,
     codexConnected: props.codexConnected,
     activeModel: lifecycle?.state === "active" ? lifecycle.model : null,
   });
   const selectedModel = selection.selectedModel;
-  const realtime = useSessionCodexRealtime({
+  const realtime = useSessionRealtime({
     ...props,
     model: selectedModel.id,
     modelAvailable: selectedModel.available,
@@ -356,7 +343,7 @@ export function SessionCodexRealtimeControl(props: {
   ]);
 
   return (
-    <CodexRealtimeControl
+    <RealtimeVoiceControl
       snapshot={realtime.snapshot}
       canStart={realtime.canStart}
       admissionBlocker={realtime.admissionBlocker}
@@ -376,12 +363,16 @@ export function SessionCodexRealtimeControl(props: {
   );
 }
 
-export function useWorkspaceRealtimeModelSelection(options: {
-  client: RealtimeControllerClient;
-  workspaceId: string;
+export function useRealtimeModelSelection(options: {
+  client?: RealtimeControllerClient | undefined;
+  workspaceId?: string | undefined;
   codexConnected: boolean;
   activeModel?: SessionRealtimeModel | null | undefined;
 }) {
+  const { client, workspaceId } = useEmbeddedRealtimeSession({
+    client: options.client,
+    workspaceId: options.workspaceId,
+  });
   const activeModel = options.activeModel;
   const [catalog, setCatalog] = useState<RealtimeModelOption[]>(() => [
     {
@@ -391,15 +382,15 @@ export function useWorkspaceRealtimeModelSelection(options: {
     },
   ]);
   const [selectedModelId, setSelectedModelId] = useState<SessionRealtimeModel>(
-    () => readRealtimeModelPreference(options.workspaceId) ?? CODEX_LIVE_MODEL.id,
+    () => readRealtimeModelPreference(workspaceId) ?? CODEX_LIVE_MODEL.id,
   );
 
   useEffect(() => {
     let disposed = false;
-    const load = options.client.getWorkspaceRealtimeModelCatalog;
+    const load = client.getWorkspaceRealtimeModelCatalog;
     if (!load) return;
     void load
-      .call(options.client, options.workspaceId)
+      .call(client, workspaceId)
       .then((response) => {
         if (disposed) return;
         const models = response.models.map(toRealtimeModelOption);
@@ -413,7 +404,7 @@ export function useWorkspaceRealtimeModelSelection(options: {
     return () => {
       disposed = true;
     };
-  }, [options.client, options.workspaceId]);
+  }, [client, workspaceId]);
 
   useEffect(() => {
     if (activeModel) setSelectedModelId(activeModel);
@@ -431,15 +422,15 @@ export function useWorkspaceRealtimeModelSelection(options: {
       const model = catalog.find((candidate) => candidate.id === value);
       if (!model || !model.available || activeModel) return;
       setSelectedModelId(model.id);
-      writeRealtimeModelPreference(options.workspaceId, model.id);
+      writeRealtimeModelPreference(workspaceId, model.id);
     },
-    [activeModel, catalog, options.workspaceId],
+    [activeModel, catalog, workspaceId],
   );
 
   return { models: catalog, selectedModel, selectModel };
 }
 
-const IDLE_REALTIME_SNAPSHOT: CodexRealtimeControllerSnapshot = {
+const IDLE_REALTIME_SNAPSHOT: SessionRealtimeControllerSnapshot = {
   status: "idle",
   realtimeId: null,
   mode: null,
@@ -455,14 +446,14 @@ const IDLE_REALTIME_SNAPSHOT: CodexRealtimeControllerSnapshot = {
 };
 
 export function NewSessionRealtimeControl(props: {
-  client: RealtimeControllerClient;
-  workspaceId: string;
+  client?: RealtimeControllerClient | undefined;
+  workspaceId?: string | undefined;
   codexConnected: boolean;
   disabled?: boolean | undefined;
   disabledReason?: string | null | undefined;
   onStart: (model: SessionRealtimeModel) => Promise<boolean>;
 }) {
-  const selection = useWorkspaceRealtimeModelSelection({
+  const selection = useRealtimeModelSelection({
     client: props.client,
     workspaceId: props.workspaceId,
     codexConnected: props.codexConnected,
@@ -470,7 +461,7 @@ export function NewSessionRealtimeControl(props: {
   const audioRef = useRef<HTMLAudioElement>(null);
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const snapshot = useMemo<CodexRealtimeControllerSnapshot>(
+  const snapshot = useMemo<SessionRealtimeControllerSnapshot>(
     () =>
       starting
         ? { ...IDLE_REALTIME_SNAPSHOT, status: "starting" }
@@ -497,7 +488,7 @@ export function NewSessionRealtimeControl(props: {
   }, [canStart, onStart, selectedModelId]);
 
   return (
-    <CodexRealtimeControl
+    <RealtimeVoiceControl
       snapshot={snapshot}
       canStart={canStart}
       admissionBlocker={selection.selectedModel.unavailableReason ?? props.disabledReason ?? null}
@@ -519,8 +510,8 @@ export function NewSessionRealtimeControl(props: {
   );
 }
 
-export function CodexRealtimeControl(props: {
-  snapshot: CodexRealtimeControllerSnapshot;
+export function RealtimeVoiceControl(props: {
+  snapshot: SessionRealtimeControllerSnapshot;
   canStart: boolean;
   admissionBlocker?: string | null | undefined;
   modelAvailable: boolean;
@@ -605,7 +596,7 @@ export function CodexRealtimeControl(props: {
             data-testid="realtime-mute-controls"
             initial={reduceMotion ? false : { opacity: 0, width: 0, marginRight: 0 }}
             animate={{ opacity: 1, width: "auto", marginRight: 4 }}
-            exit={reduceMotion ? undefined : { opacity: 0, width: 0, marginRight: 0 }}
+            {...(reduceMotion ? {} : { exit: { opacity: 0, width: 0, marginRight: 0 } })}
             transition={{ duration: reduceMotion ? 0 : 0.18, ease: [0.2, 0.8, 0.2, 1] }}
             className="inline-flex shrink-0 items-center gap-0.5 overflow-hidden"
           >
@@ -632,7 +623,7 @@ export function CodexRealtimeControl(props: {
         aria-pressed={modeOwned}
         title={mainLabel}
         disabled={mainDisabled}
-        whileTap={reduceMotion ? undefined : { scale: 0.92 }}
+        {...(reduceMotion ? {} : { whileTap: { scale: 0.92 } })}
         transition={{ type: "spring", stiffness: 520, damping: 30 }}
         onClick={() => void runMainAction().catch(() => undefined)}
         className={cn(
@@ -781,7 +772,7 @@ function RealtimeMuteButton(props: {
       aria-label={label}
       aria-pressed={props.muted}
       title={label}
-      whileTap={props.reduceMotion ? undefined : { scale: 0.92 }}
+      {...(props.reduceMotion ? {} : { whileTap: { scale: 0.92 } })}
       onClick={props.onToggle}
       className={cn(
         "inline-flex size-8 shrink-0 items-center justify-center rounded-og-md border outline-none",
@@ -875,7 +866,7 @@ export function RealtimeModelPickerMenu(props: {
   );
 }
 
-function RealtimeDiagnosticsMenu({ snapshot }: { snapshot: CodexRealtimeControllerSnapshot }) {
+function RealtimeDiagnosticsMenu({ snapshot }: { snapshot: SessionRealtimeControllerSnapshot }) {
   const bridge = snapshot.bridge;
   const rows = [
     ["controller", snapshot.status],
@@ -937,7 +928,7 @@ type RealtimeVisualPhase =
   | "stopping";
 
 function statusContent(
-  snapshot: CodexRealtimeControllerSnapshot,
+  snapshot: SessionRealtimeControllerSnapshot,
   modelAvailable: boolean,
   canStart: boolean,
   admissionBlocker: string | null,
@@ -1176,3 +1167,12 @@ function isRealtimeModel(value: string | null): value is SessionRealtimeModel {
     value === "workspace-gateway/xai/grok-voice-think-fast-2.0"
   );
 }
+
+/** @deprecated Use the provider-neutral realtime names. */
+export const useSessionCodexRealtime = useSessionRealtime;
+/** @deprecated Use the provider-neutral realtime names. */
+export const useWorkspaceRealtimeModelSelection = useRealtimeModelSelection;
+/** @deprecated Use the provider-neutral realtime names. */
+export const SessionCodexRealtimeControl = SessionRealtimeControl;
+/** @deprecated Use the provider-neutral realtime names. */
+export const CodexRealtimeControl = RealtimeVoiceControl;

--- a/packages/react/src/session-context.ts
+++ b/packages/react/src/session-context.ts
@@ -4,6 +4,7 @@ import type {
   EmbeddedFileAttachmentClientLike,
   EmbeddedGoalClientLike,
   EmbeddedHumanInputSessionClientLike,
+  EmbeddedRealtimeSessionClientLike,
   EmbeddedSessionClientLike,
   EmbeddedSessionLineageClientLike,
   EmbeddedSessionMcpApprovalPolicyClientLike,
@@ -52,6 +53,11 @@ export type EmbeddedSessionMcpApprovalPolicyClientOverride = {
 
 export type EmbeddedSessionReadClientOverride = {
   client?: EmbeddedSessionReadClientLike | undefined;
+  workspaceId?: string | undefined;
+};
+
+export type EmbeddedRealtimeSessionClientOverride = {
+  client?: EmbeddedRealtimeSessionClientLike | undefined;
   workspaceId?: string | undefined;
 };
 
@@ -238,6 +244,16 @@ export function useEmbeddedSessionMcpApprovalPolicy(
     eventClientMethods(override, ["getSession", "updateSessionMcpApprovalPolicy"]),
     "useSessionMcpApprovalPolicy",
   );
+}
+
+/** Resolve the exact browser/API surface required by `@opengeni/react/realtime`. */
+export function useEmbeddedRealtimeSession(
+  override: EmbeddedRealtimeSessionClientOverride = {},
+): EmbeddedClientContextValue<EmbeddedRealtimeSessionClientLike> {
+  // Preserve the existing lazy capability behavior: proxy/test clients may
+  // implement only the methods reached by their selected model and lifecycle.
+  // The exported structural type remains the complete embedding contract.
+  return useEmbeddedClientRefinement(override, [], "realtime hooks");
 }
 
 /**

--- a/packages/react/styles/index.css
+++ b/packages/react/styles/index.css
@@ -19,6 +19,11 @@
 @theme inline {
   --font-og-sans: var(--og-font-sans);
   --font-og-mono: var(--og-font-mono);
+  /* Compatibility aliases still used by published components and the exact
+     dropdown primitives shared with the web app. Keep the public stylesheet
+     self-contained instead of requiring consumers to copy the app theme. */
+  --font-sans: var(--og-font-sans);
+  --font-mono: var(--og-font-mono);
 
   /* Type ramp — a real 4-step scale (no half-pixel hand-tuning). Every
      timeline string maps to one of these via `text-og-{xs,sm,base,md}`;
@@ -31,6 +36,8 @@
   --text-og-base--line-height: 1.55;
   --text-og-md: 15px;
   --text-og-md--line-height: 1.6;
+  --text-2xs: 0.6875rem;
+  --text-2xs--line-height: 1rem;
 
   --color-og-bg: var(--og-color-bg);
   --color-og-surface-1: var(--og-color-surface-1);
@@ -56,11 +63,64 @@
   --color-og-status-cancelled: var(--og-color-status-cancelled);
   --color-og-danger: var(--og-color-danger);
 
+  --color-bg: var(--og-color-bg);
+  --color-surface: var(--og-color-surface-1);
+  --color-surface-2: var(--og-color-surface-2);
+  --color-surface-3: var(--og-color-surface-3);
+  --color-border: var(--og-color-border);
+  --color-border-strong: var(--og-color-border-strong);
+  --color-fg: var(--og-color-fg);
+  --color-fg-muted: var(--og-color-fg-muted);
+  --color-fg-subtle: var(--og-color-fg-subtle);
+  --color-brand: var(--og-color-accent);
+  --color-brand-strong: var(--og-color-accent-deep);
+  --color-brand-fg: var(--og-color-accent-fg);
+  --color-status-queued: var(--og-color-status-queued);
+  --color-status-running: var(--og-color-status-running);
+  --color-status-idle: var(--og-color-status-idle);
+  --color-status-waiting: var(--og-color-status-waiting);
+  --color-status-success: var(--og-color-status-idle);
+  --color-status-failed: var(--og-color-status-failed);
+  --color-status-cancelled: var(--og-color-status-cancelled);
+  --color-danger: var(--og-color-danger);
+
+  --color-background: var(--color-bg);
+  --color-foreground: var(--color-fg);
+  --color-card: var(--color-surface);
+  --color-card-foreground: var(--color-fg);
+  --color-popover: var(--color-surface-3);
+  --color-popover-foreground: var(--color-fg);
+  --color-primary: var(--color-brand-strong);
+  --color-primary-foreground: var(--color-brand-fg);
+  --color-secondary: var(--color-surface-2);
+  --color-secondary-foreground: var(--color-fg);
+  --color-muted: var(--color-surface-2);
+  --color-muted-foreground: var(--color-fg-muted);
+  --color-accent: var(--color-surface-2);
+  --color-accent-foreground: var(--color-fg);
+  --color-destructive: var(--og-color-danger);
+  --color-destructive-filled: color-mix(in oklch, var(--og-color-danger) 70%, black);
+  --color-destructive-foreground: var(--og-color-accent-fg);
+  --color-input: var(--color-surface-2);
+  --color-ring: var(--color-brand);
+  --color-sidebar: var(--color-surface);
+  --color-sidebar-foreground: var(--color-fg);
+  --color-sidebar-primary: var(--color-brand-strong);
+  --color-sidebar-primary-foreground: var(--color-brand-fg);
+  --color-sidebar-accent: var(--color-surface-2);
+  --color-sidebar-accent-foreground: var(--color-fg);
+  --color-sidebar-border: var(--color-border);
+  --color-sidebar-ring: var(--color-brand);
+
   --radius-og-xs: var(--og-radius-xs);
   --radius-og-sm: var(--og-radius-sm);
   --radius-og-md: var(--og-radius-md);
   --radius-og-lg: var(--og-radius-lg);
   --radius-og-xl: var(--og-radius-xl);
+  --radius-sm: var(--og-radius-sm);
+  --radius-md: var(--og-radius-md);
+  --radius-lg: var(--og-radius-lg);
+  --radius-xl: var(--og-radius-xl);
 
   --shadow-og-sm: var(--og-shadow-sm);
   --shadow-og-md: var(--og-shadow-md);

--- a/packages/react/test/realtime-control.test.tsx
+++ b/packages/react/test/realtime-control.test.tsx
@@ -2,20 +2,16 @@ import { afterAll, afterEach, beforeEach, describe, expect, spyOn, test } from "
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act, createRef, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import type {
-  CodexRealtimeControllerSnapshot,
-  EffectiveSessionControl,
-  OpenGeniClient,
-  SessionEvent,
-} from "@opengeni/sdk";
+import type { EffectiveSessionControl, OpenGeniClient, SessionEvent } from "@opengeni/sdk";
+import type { SessionRealtimeControllerSnapshot } from "@opengeni/sdk/realtime";
 
 import {
-  CodexRealtimeControl,
+  RealtimeVoiceControl,
   RealtimeModelPickerMenu,
   codexRealtimeAdmissionAllowed,
   type RealtimeModelOption,
-  useSessionCodexRealtime,
-} from "./codex-realtime-control";
+  useSessionRealtime,
+} from "../src/realtime/realtime-control";
 
 GlobalRegistrator.register({ url: "https://app.example.test" });
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -25,7 +21,7 @@ afterAll(() => {
   GlobalRegistrator.unregister();
 });
 
-const idle: CodexRealtimeControllerSnapshot = {
+const idle: SessionRealtimeControllerSnapshot = {
   status: "idle",
   realtimeId: null,
   mode: null,
@@ -40,7 +36,7 @@ const idle: CodexRealtimeControllerSnapshot = {
   error: null,
 };
 
-const activeMode: NonNullable<CodexRealtimeControllerSnapshot["mode"]> = {
+const activeMode: NonNullable<SessionRealtimeControllerSnapshot["mode"]> = {
   id: "33333333-3333-4333-8333-333333333333",
   sessionId: "22222222-2222-4222-8222-222222222222",
   operationId: "44444444-4444-4444-8444-444444444444",
@@ -142,7 +138,7 @@ describe("ordinary session Codex realtime control", () => {
     const events = [started];
 
     function Harness() {
-      const realtime = useSessionCodexRealtime({
+      const realtime = useSessionRealtime({
         client,
         workspaceId: started.workspaceId,
         sessionId: started.sessionId,
@@ -179,7 +175,7 @@ describe("ordinary session Codex realtime control", () => {
     const calls: string[] = [];
     await act(async () => {
       root.render(
-        <CodexRealtimeControl
+        <RealtimeVoiceControl
           snapshot={idle}
           canStart={true}
           modelAvailable={true}
@@ -221,7 +217,7 @@ describe("ordinary session Codex realtime control", () => {
 
     await act(async () => {
       root.render(
-        <CodexRealtimeControl
+        <RealtimeVoiceControl
           snapshot={{
             ...idle,
             status: "active",
@@ -347,7 +343,7 @@ describe("ordinary session Codex realtime control", () => {
   test("configures the voice model picker below the new-session composer", async () => {
     await act(async () => {
       root.render(
-        <CodexRealtimeControl
+        <RealtimeVoiceControl
           snapshot={idle}
           canStart={true}
           modelAvailable={true}
@@ -372,7 +368,7 @@ describe("ordinary session Codex realtime control", () => {
     const calls: string[] = [];
     await act(async () => {
       root.render(
-        <CodexRealtimeControl
+        <RealtimeVoiceControl
           snapshot={{
             ...idle,
             status: "active",
@@ -425,7 +421,7 @@ describe("ordinary session Codex realtime control", () => {
   test("keeps an unavailable provider quiet and explains why start is disabled", async () => {
     await act(async () => {
       root.render(
-        <CodexRealtimeControl
+        <RealtimeVoiceControl
           snapshot={idle}
           canStart={false}
           admissionBlocker="Connect Codex to use this voice model."

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     "src/session-ui.ts",
     "src/machines.ts",
     "src/model-policy.ts",
+    "src/realtime.ts",
   ],
   format: ["esm"],
   target: "es2022",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -37,6 +37,56 @@ for await (const event of client.streamEvents(workspaceId, session.id)) {
 }
 ```
 
+## Realtime browser controller (`@opengeni/sdk/realtime`)
+
+The public realtime subpath owns the provider-neutral browser controller and
+the existing Codex Live, WebRTC/V3, and AI Gateway transports. It selects the
+transport from the catalog model without changing the backend API, durable
+ledger, delegation, context, or recovery semantics:
+
+```ts
+import { OpenGeniClient } from "@opengeni/sdk";
+import type { SessionRealtimeClientLike } from "@opengeni/sdk/realtime";
+
+const client = new OpenGeniClient({ baseUrl: "/opengeni-api" });
+const realtimeClient: SessionRealtimeClientLike = client;
+const catalog = await realtimeClient.getWorkspaceRealtimeModelCatalog(workspaceId);
+const model = catalog.models.find((candidate) => candidate.available)?.id;
+if (!model) throw new Error("No realtime model is available");
+
+// Lazy import keeps the base SDK entry safe for server and non-realtime hosts.
+const { createSessionRealtimeController } = await import("@opengeni/sdk/realtime");
+const controller = createSessionRealtimeController({
+  client: realtimeClient,
+  workspaceId,
+  sessionId,
+  model,
+  remoteAudio,
+});
+
+const unsubscribe = controller.subscribe((snapshot) => {
+  console.log(snapshot.status, snapshot.microphone, snapshot.diagnostic);
+});
+await controller.start();
+
+// Later:
+await controller.stop();
+unsubscribe();
+controller.close();
+```
+
+`SessionRealtimeClientLike` is the exact proxy-friendly backend surface:
+catalog, begin, Codex/Gateway negotiation, activation, heartbeat, ledger sync,
+and end. Existing `OpenGeniClient` methods remain the implementation. Current
+Codex-named controller and transport exports remain available as compatibility
+aliases, but new integrations should use the provider-neutral names.
+
+Do not put API credentials in browser bundles. Browser hosts should either use
+the deployment's normal browser authentication or expose these same methods
+through a tenant-scoped, same-origin proxy. The SDK does not move persistence,
+prompt construction, context processing, delegation, or provider credentials
+out of `apps/api`, `apps/worker`, or `packages/db`.
+
 ## Workspace artifacts
 
 Workspace artifacts are generic, immutable HTML publications. The SDK does not

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -26,6 +26,10 @@
       "types": "./src/core.ts",
       "default": "./src/core.ts"
     },
+    "./realtime": {
+      "types": "./src/realtime.ts",
+      "default": "./src/realtime.ts"
+    },
     "./codex-realtime-controller": {
       "types": "./src/codex-realtime-controller.ts",
       "default": "./src/codex-realtime-controller.ts"

--- a/packages/sdk/src/codex-realtime-controller.ts
+++ b/packages/sdk/src/codex-realtime-controller.ts
@@ -162,9 +162,9 @@ export function sessionRealtimeOwnerStorageKey(
 }
 
 /**
- * Truthfully project whether this browser has resumable owner proof before the
- * lazily loaded controller is constructed. Invalid or cross-session records are
- * removed by the same parser used by controller recovery.
+ * Preserve the existing pre-controller owner-presence projection used by the
+ * lazy React control. The controller remains the sole authority that validates
+ * or removes malformed records once it is constructed.
  */
 export function hasStoredSessionRealtimeOwnerProof(input: {
   workspaceId: string;
@@ -173,13 +173,16 @@ export function hasStoredSessionRealtimeOwnerProof(input: {
   storage?: CodexRealtimeOwnerStorage | undefined;
 }): boolean {
   const storage = input.storage ?? defaultStorage();
-  return (
-    readOwnerRecord(
-      storage,
-      sessionRealtimeOwnerStorageKey(input.workspaceId, input.sessionId, input.model),
-      input,
-    ) !== null
-  );
+  if (!storage) return false;
+  try {
+    return (
+      storage.getItem(
+        sessionRealtimeOwnerStorageKey(input.workspaceId, input.sessionId, input.model),
+      ) !== null
+    );
+  } catch {
+    return false;
+  }
 }
 
 export type CreateCodexRealtimeControllerOptions = {

--- a/packages/sdk/src/codex-realtime-controller.ts
+++ b/packages/sdk/src/codex-realtime-controller.ts
@@ -147,6 +147,41 @@ export type CodexRealtimeControllerClient = {
 
 export type CodexRealtimeOwnerStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
+/** Canonical browser-owner storage namespace for a public realtime model. */
+export function sessionRealtimeOwnerStorageNamespace(model: SessionRealtimeModel): string {
+  return model === "gpt-live-1-boulder-alpha" ? "codex-realtime-owner" : "gateway-realtime-owner";
+}
+
+/** Canonical browser-owner storage key shared by the SDK controller and React facade. */
+export function sessionRealtimeOwnerStorageKey(
+  workspaceId: string,
+  sessionId: string,
+  model: SessionRealtimeModel,
+): string {
+  return ownerStorageKey(workspaceId, sessionId, sessionRealtimeOwnerStorageNamespace(model));
+}
+
+/**
+ * Truthfully project whether this browser has resumable owner proof before the
+ * lazily loaded controller is constructed. Invalid or cross-session records are
+ * removed by the same parser used by controller recovery.
+ */
+export function hasStoredSessionRealtimeOwnerProof(input: {
+  workspaceId: string;
+  sessionId: string;
+  model: SessionRealtimeModel;
+  storage?: CodexRealtimeOwnerStorage | undefined;
+}): boolean {
+  const storage = input.storage ?? defaultStorage();
+  return (
+    readOwnerRecord(
+      storage,
+      sessionRealtimeOwnerStorageKey(input.workspaceId, input.sessionId, input.model),
+      input,
+    ) !== null
+  );
+}
+
 export type CreateCodexRealtimeControllerOptions = {
   client: CodexRealtimeControllerClient;
   workspaceId: string;

--- a/packages/sdk/src/realtime.ts
+++ b/packages/sdk/src/realtime.ts
@@ -1,0 +1,172 @@
+/**
+ * Public, provider-neutral realtime browser SDK.
+ *
+ * Import this subpath lazily in browser applications. The base `@opengeni/sdk`
+ * entry remains free of eager realtime transport initialization.
+ */
+import {
+  createCodexRealtimeController,
+  hasStoredSessionRealtimeOwnerProof,
+  sessionRealtimeOwnerStorageKey,
+  sessionRealtimeOwnerStorageNamespace,
+  type CodexRealtimeController,
+  type CodexRealtimeControllerClient,
+  type CodexRealtimeControllerSnapshot,
+  type CodexRealtimeControllerStatus,
+  type CodexRealtimeDiagnostic,
+  type CodexRealtimeDiagnosticKind,
+  type CodexRealtimeMicrophoneState,
+  type CodexRealtimeOwnerStorage,
+  type CreateCodexRealtimeControllerOptions,
+  type RealtimeControllerTransportStarter,
+} from "./codex-realtime-controller";
+import { createGatewayRealtimeTransportStarter } from "./gateway-realtime-transport";
+import type { SessionRealtimeModel, WorkspaceRealtimeModelCatalogResponse } from "./types";
+
+/** Exact backend-facing methods required by the batteries-included realtime SDK. */
+export type SessionRealtimeClientLike = CodexRealtimeControllerClient & {
+  getWorkspaceRealtimeModelCatalog(
+    workspaceId: string,
+  ): Promise<WorkspaceRealtimeModelCatalogResponse>;
+};
+
+export type SessionRealtimeTransportKind = "codex" | "gateway";
+
+/** Provider-neutral names for the existing, battle-tested controller projection. */
+export type SessionRealtimeController = CodexRealtimeController;
+export type SessionRealtimeControllerSnapshot = CodexRealtimeControllerSnapshot;
+export type SessionRealtimeControllerStatus = CodexRealtimeControllerStatus;
+export type SessionRealtimeDiagnostic = CodexRealtimeDiagnostic;
+export type SessionRealtimeDiagnosticKind = CodexRealtimeDiagnosticKind;
+export type SessionRealtimeMicrophoneState = CodexRealtimeMicrophoneState;
+export type SessionRealtimeOwnerStorage = CodexRealtimeOwnerStorage;
+
+export type CreateSessionRealtimeControllerOptions = Omit<
+  CreateCodexRealtimeControllerOptions,
+  "client" | "model" | "ownerStorageNamespace" | "startTransport"
+> & {
+  client: CodexRealtimeControllerClient;
+  model: SessionRealtimeModel;
+};
+
+/** Select the existing transport without exposing provider mechanics to hosts. */
+export function sessionRealtimeTransportKind(
+  model: SessionRealtimeModel,
+): SessionRealtimeTransportKind {
+  return model === "gpt-live-1-boulder-alpha" ? "codex" : "gateway";
+}
+
+/**
+ * Compose the exact current controller with its existing Codex Live or AI
+ * Gateway transport. Wire, ledger, delegation, recovery, and lifecycle
+ * semantics remain owned by the existing implementations below this facade.
+ */
+export function createSessionRealtimeController(
+  options: CreateSessionRealtimeControllerOptions,
+): SessionRealtimeController {
+  const transport = sessionRealtimeTransportKind(options.model);
+  return createCodexRealtimeController({
+    ...options,
+    ownerStorageNamespace: sessionRealtimeOwnerStorageNamespace(options.model),
+    ...(transport === "gateway" ? { startTransport: createGatewayRealtimeTransportStarter() } : {}),
+  });
+}
+
+export {
+  createCodexRealtimeController,
+  createGatewayRealtimeTransportStarter,
+  hasStoredSessionRealtimeOwnerProof,
+  sessionRealtimeOwnerStorageKey,
+  sessionRealtimeOwnerStorageNamespace,
+};
+export type {
+  CodexRealtimeController,
+  CodexRealtimeControllerClient,
+  CodexRealtimeControllerSnapshot,
+  CodexRealtimeControllerStatus,
+  CodexRealtimeDiagnostic,
+  CodexRealtimeDiagnosticKind,
+  CodexRealtimeMicrophoneState,
+  CodexRealtimeOwnerStorage,
+  CreateCodexRealtimeControllerOptions,
+  RealtimeControllerTransportStarter,
+};
+
+export {
+  CODEX_REALTIME_NEGOTIATION_TIMEOUT_MS,
+  projectSessionRealtimeLifecycle,
+} from "./codex-realtime-controller";
+export type { SessionRealtimeLifecycleProjection } from "./codex-realtime-lifecycle";
+
+export {
+  CodexRealtimeMicrophoneError,
+  acquireCodexRealtimeMicrophone,
+  codexRealtimeMicrophoneHealthy,
+  startCodexRealtimeWebrtc,
+} from "./codex-realtime";
+export type {
+  AcquireCodexRealtimeMicrophoneOptions,
+  CodexRealtimeAudibleOutputState,
+  CodexRealtimeConnectionHealth,
+  CodexRealtimeMicrophoneErrorCode,
+  CodexRealtimeNegotiator,
+  CodexRealtimeWebrtcSession,
+  StartCodexRealtimeWebrtcOptions,
+} from "./codex-realtime";
+
+export {
+  CODEX_REALTIME_CONTEXT_APPEND_MAX_BYTES,
+  CODEX_REALTIME_V3_MAX_EVENT_BYTES,
+  CODEX_REALTIME_V3_MAX_IDENTIFIER_BYTES,
+  CODEX_REALTIME_V3_MAX_TEXT_BYTES,
+  CODEX_REALTIME_V3_PENDING_MAX_BYTES,
+  CODEX_REALTIME_V3_PENDING_MAX_ENTRIES,
+  CODEX_REALTIME_V3_SYNC_MAX_ENTRIES,
+  contextAppendChunks,
+  createCodexRealtimeV3Bridge,
+  encodeCodexRealtimeV3DelegationContextAppend,
+  encodeCodexRealtimeV3SessionContextAppend,
+  parseCodexRealtimeV3Event,
+} from "./codex-realtime-v3";
+export type {
+  CodexRealtimeV3Bridge,
+  CodexRealtimeV3BridgeFatal,
+  CodexRealtimeV3BridgeOptions,
+  CodexRealtimeV3BridgeSnapshot,
+  CodexRealtimeV3ContextAppendChannel,
+  CodexRealtimeV3DelegationContextAppend,
+  CodexRealtimeV3Event,
+  CodexRealtimeV3ParseFailure,
+  CodexRealtimeV3ParseResult,
+  CodexRealtimeV3SessionContextAppend,
+} from "./codex-realtime-v3";
+
+export {
+  CODEX_REALTIME_INITIAL_ITEMS_MAX_COUNT,
+  CODEX_REALTIME_INITIAL_ITEMS_MAX_TOKENS,
+} from "./codex-realtime-v3-wire";
+export type { CodexRealtimeInitialItem } from "./codex-realtime-v3-wire";
+
+export type {
+  ActivateCodexRealtimeConnectionRequest,
+  BeginSessionRealtimeRequest,
+  CodexRealtimeVoice,
+  CodexRealtimeWebrtcRequest,
+  CodexRealtimeWebrtcResponse,
+  CodexRealtimeWebrtcVersion,
+  EndSessionRealtimeRequest,
+  GatewayRealtimeConnectRequest,
+  GatewayRealtimeConnectResponse,
+  GatewayRealtimeInitialItem,
+  RenewSessionRealtimeRequest,
+  SessionRealtimeEndReason,
+  SessionRealtimeLedgerEntry,
+  SessionRealtimeMode,
+  SessionRealtimeModel,
+  SessionRealtimeMutationResponse,
+  SessionRealtimeState,
+  SyncSessionRealtimeLedgerRequest,
+  SyncSessionRealtimeLedgerResponse,
+  WorkspaceRealtimeModelCatalogItem,
+  WorkspaceRealtimeModelCatalogResponse,
+} from "./types";

--- a/packages/sdk/test/realtime-public.test.ts
+++ b/packages/sdk/test/realtime-public.test.ts
@@ -43,7 +43,7 @@ describe("@opengeni/sdk/realtime", () => {
     }
   });
 
-  test("projects canonical owner proof through the provider-neutral facade", () => {
+  test("preserves pre-controller owner presence while controller startup validates proof", () => {
     const storage = storageFixture();
     const model = "workspace-gateway/openai/gpt-realtime-mini" as const;
     const key = sessionRealtimeOwnerStorageKey(WORKSPACE_ID, SESSION_ID, model);
@@ -81,6 +81,46 @@ describe("@opengeni/sdk/realtime", () => {
     });
     expect(controller.snapshot().status).toBe("recovering");
     controller.close();
+
+    storage.setItem(key, "not-json");
+    expect(
+      hasStoredSessionRealtimeOwnerProof({
+        workspaceId: WORKSPACE_ID,
+        sessionId: SESSION_ID,
+        model,
+        storage,
+      }),
+    ).toBe(true);
+
+    const invalidController = createSessionRealtimeController({
+      client: {} as SessionRealtimeClientLike,
+      workspaceId: WORKSPACE_ID,
+      sessionId: SESSION_ID,
+      model,
+      storage,
+      setInterval: () => 0,
+      clearInterval: () => undefined,
+      setTimeout: () => 0,
+      clearTimeout: () => undefined,
+    });
+    expect(invalidController.snapshot().status).toBe("idle");
+    expect(storage.getItem(key)).toBeNull();
+    invalidController.close();
+
+    expect(
+      hasStoredSessionRealtimeOwnerProof({
+        workspaceId: WORKSPACE_ID,
+        sessionId: SESSION_ID,
+        model,
+        storage: {
+          getItem: () => {
+            throw new Error("storage unavailable");
+          },
+          setItem: () => undefined,
+          removeItem: () => undefined,
+        },
+      }),
+    ).toBe(false);
   });
 
   test("keeps the complete proxy-client contract structural and backend-facing", () => {

--- a/packages/sdk/test/realtime-public.test.ts
+++ b/packages/sdk/test/realtime-public.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createSessionRealtimeController,
+  hasStoredSessionRealtimeOwnerProof,
+  sessionRealtimeOwnerStorageKey,
+  sessionRealtimeOwnerStorageNamespace,
+  sessionRealtimeTransportKind,
+  type SessionRealtimeClientLike,
+  type SessionRealtimeModel,
+} from "../src/realtime";
+
+const WORKSPACE_ID = "11111111-1111-4111-8111-111111111111";
+const SESSION_ID = "22222222-2222-4222-8222-222222222222";
+
+const MODELS: readonly SessionRealtimeModel[] = [
+  "gpt-live-1-boulder-alpha",
+  "opengeni-gateway/openai/gpt-realtime-2.1",
+  "opengeni-gateway/openai/gpt-realtime-mini",
+  "opengeni-gateway/xai/grok-voice-think-fast-2.0",
+  "workspace-gateway/openai/gpt-realtime-2.1",
+  "workspace-gateway/openai/gpt-realtime-mini",
+  "workspace-gateway/xai/grok-voice-think-fast-2.0",
+];
+
+function storageFixture() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+  };
+}
+
+describe("@opengeni/sdk/realtime", () => {
+  test("selects the exact existing Codex Live or Gateway transport for every public model", () => {
+    for (const model of MODELS) {
+      const expected = model === "gpt-live-1-boulder-alpha" ? "codex" : "gateway";
+      expect(sessionRealtimeTransportKind(model)).toBe(expected);
+      expect(sessionRealtimeOwnerStorageNamespace(model)).toBe(`${expected}-realtime-owner`);
+      expect(sessionRealtimeOwnerStorageKey(WORKSPACE_ID, SESSION_ID, model)).toBe(
+        `opengeni:${expected}-realtime-owner:${WORKSPACE_ID}:${SESSION_ID}`,
+      );
+    }
+  });
+
+  test("projects canonical owner proof through the provider-neutral facade", () => {
+    const storage = storageFixture();
+    const model = "workspace-gateway/openai/gpt-realtime-mini" as const;
+    const key = sessionRealtimeOwnerStorageKey(WORKSPACE_ID, SESSION_ID, model);
+    storage.setItem(
+      key,
+      JSON.stringify({
+        version: 1,
+        workspaceId: WORKSPACE_ID,
+        sessionId: SESSION_ID,
+        operationId: "33333333-3333-4333-8333-333333333333",
+        browserInstanceId: "44444444-4444-4444-8444-444444444444",
+        ownerKey: "opengeni-realtime-owner:55555555-5555-4555-8555-555555555555",
+      }),
+    );
+
+    expect(
+      hasStoredSessionRealtimeOwnerProof({
+        workspaceId: WORKSPACE_ID,
+        sessionId: SESSION_ID,
+        model,
+        storage,
+      }),
+    ).toBe(true);
+
+    const controller = createSessionRealtimeController({
+      client: {} as SessionRealtimeClientLike,
+      workspaceId: WORKSPACE_ID,
+      sessionId: SESSION_ID,
+      model,
+      storage,
+      setInterval: () => 0,
+      clearInterval: () => undefined,
+      setTimeout: () => 0,
+      clearTimeout: () => undefined,
+    });
+    expect(controller.snapshot().status).toBe("recovering");
+    controller.close();
+  });
+
+  test("keeps the complete proxy-client contract structural and backend-facing", () => {
+    const client = {
+      getWorkspaceRealtimeModelCatalog: async () => ({ models: [] }),
+      beginSessionRealtime: async () => ({}) as never,
+      heartbeatSessionRealtime: async () => ({}) as never,
+      negotiateCodexRealtimeWebrtc: async () => ({}) as never,
+      negotiateGatewayRealtime: async () => ({}) as never,
+      activateCodexRealtimeConnection: async () => ({}) as never,
+      syncSessionRealtimeLedger: async () => ({ accepted: [], outbound: [] }),
+      endSessionRealtime: async () => ({}) as never,
+    } satisfies SessionRealtimeClientLike;
+
+    expect(Object.keys(client).sort()).toEqual(
+      [
+        "activateCodexRealtimeConnection",
+        "beginSessionRealtime",
+        "endSessionRealtime",
+        "getWorkspaceRealtimeModelCatalog",
+        "heartbeatSessionRealtime",
+        "negotiateCodexRealtimeWebrtc",
+        "negotiateGatewayRealtime",
+        "syncSessionRealtimeLedger",
+      ].sort(),
+    );
+  });
+});

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   entry: [
     "src/index.ts",
     "src/core.ts",
+    "src/realtime.ts",
     "src/codex-realtime-controller.ts",
     "src/gateway-realtime-transport.ts",
   ],

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -9,6 +9,7 @@ const testFiles =
         "./test/e2e/knowledge-surfaces.browser.e2e.ts",
         "./test/e2e/codex-overview.e2e.ts",
         "./test/e2e/queue-surface.browser.e2e.ts",
+        "./test/e2e/realtime-demo.browser.e2e.ts",
         "./test/e2e/session-header.browser.e2e.ts",
         "./test/e2e/session-pins.browser.e2e.ts",
         "./test/e2e/timeline-scroll.browser.e2e.ts",

--- a/scripts/test-publish-consumer.ts
+++ b/scripts/test-publish-consumer.ts
@@ -9,7 +9,9 @@
  * from the frozen Bun lock), typechecks with stable TypeScript 7, builds the root and session
  * subpaths through Vite, verifies the packed runtime skill-library subpath, and
  * server-renders populated embedded host surfaces without a DOM. A second
- * consumer installs only the session subpath's required peers.
+ * consumer installs only the session subpath's required peers. A third imports
+ * only the public SDK/React realtime subpaths, renders both batteries-included
+ * composer controls without a provider, and bundles them as an external host.
  */
 import { cp, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -153,11 +155,13 @@ try {
   const tarballRoot = join(tempRoot, "tarballs");
   const consumerRoot = join(tempRoot, "consumer");
   const minimalSessionRoot = join(tempRoot, "minimal-session-consumer");
+  const minimalRealtimeRoot = join(tempRoot, "minimal-realtime-consumer");
   await Promise.all([
     mkdir(stagingRoot, { recursive: true }),
     mkdir(tarballRoot, { recursive: true }),
     mkdir(consumerRoot, { recursive: true }),
     mkdir(minimalSessionRoot, { recursive: true }),
+    mkdir(minimalRealtimeRoot, { recursive: true }),
   ]);
 
   const versions = await workspaceVersions();
@@ -456,6 +460,125 @@ try {
     ),
   ]);
 
+  const minimalRealtimeManifest = {
+    name: "opengeni-minimal-realtime-proof",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    scripts: {
+      typecheck: "tsc -p tsconfig.json --noEmit",
+      build: "vite build --logLevel warn",
+      ssr: "bun realtime.tsx",
+    },
+    dependencies: {
+      "@opengeni/react": `file:${react.tarball}`,
+      "@opengeni/sdk": sdkFile,
+      react: reactSource.peerDependencies?.react,
+      "react-dom": reactSource.peerDependencies?.["react-dom"],
+    },
+    devDependencies: {
+      "@types/node": "^24.10.1",
+      "@types/react": reactSource.devDependencies?.["@types/react"],
+      "@types/react-dom": reactSource.devDependencies?.["@types/react-dom"],
+      typescript: rootManifest.devDependencies?.typescript,
+      vite: reactSource.devDependencies?.vite,
+    },
+    overrides: {
+      "@opengeni/sdk": sdkFile,
+    },
+  };
+  await Promise.all([
+    writeFile(
+      join(minimalRealtimeRoot, "package.json"),
+      `${JSON.stringify(minimalRealtimeManifest, null, 2)}\n`,
+    ),
+    writeFile(
+      join(minimalRealtimeRoot, "tsconfig.json"),
+      `${JSON.stringify(
+        {
+          compilerOptions: {
+            strict: true,
+            target: "ESNext",
+            lib: ["ESNext", "DOM", "DOM.Iterable"],
+            module: "ESNext",
+            moduleResolution: "Bundler",
+            jsx: "react-jsx",
+            skipLibCheck: false,
+            noEmit: true,
+            types: ["node"],
+          },
+          include: ["realtime.tsx", "vite.config.ts"],
+        },
+        null,
+        2,
+      )}\n`,
+    ),
+    writeFile(
+      join(minimalRealtimeRoot, "vite.config.ts"),
+      'import { defineConfig } from "vite";\nexport default defineConfig({ build: { emptyOutDir: true, lib: { entry: "realtime.tsx", formats: ["es"], fileName: "realtime" }, rollupOptions: { external: ["react", "react/jsx-runtime", "react-dom/server"] } } });\n',
+    ),
+    writeFile(
+      join(minimalRealtimeRoot, "realtime.tsx"),
+      [
+        'import { createSessionRealtimeController, sessionRealtimeTransportKind, type SessionRealtimeClientLike } from "@opengeni/sdk/realtime";',
+        'import { NewSessionRealtimeControl, SessionRealtimeControl, type EmbeddedRealtimeSessionClientLike } from "@opengeni/react/realtime";',
+        'import { renderToStaticMarkup } from "react-dom/server";',
+        "",
+        'const unsupported = async (..._input: unknown[]): Promise<never> => { throw new Error("not called during SSR proof"); };',
+        "const proxyClient = {",
+        "  getWorkspaceRealtimeModelCatalog: unsupported,",
+        "  beginSessionRealtime: unsupported,",
+        "  heartbeatSessionRealtime: unsupported,",
+        "  negotiateCodexRealtimeWebrtc: unsupported,",
+        "  negotiateGatewayRealtime: unsupported,",
+        "  activateCodexRealtimeConnection: unsupported,",
+        "  syncSessionRealtimeLedger: unsupported,",
+        "  endSessionRealtime: unsupported,",
+        "} satisfies EmbeddedRealtimeSessionClientLike & SessionRealtimeClientLike;",
+        "const effectiveControl = {",
+        '  state: "active" as const,',
+        "  controlVersion: 0,",
+        '  controlEtag: "active-0",',
+        '  directState: "active" as const,',
+        "  primaryBlocker: null,",
+        "  additionalBlockerCount: 0,",
+        "  blockers: [],",
+        "  resumeOptions: [],",
+        "  override: null,",
+        "  settlement: null,",
+        "};",
+        "",
+        'if (sessionRealtimeTransportKind("gpt-live-1-boulder-alpha") !== "codex") throw new Error("Codex transport selection drifted");',
+        'if (sessionRealtimeTransportKind("opengeni-gateway/openai/gpt-realtime-2.1") !== "gateway") throw new Error("Gateway transport selection drifted");',
+        "void createSessionRealtimeController;",
+        "const markup = renderToStaticMarkup(",
+        "  <>",
+        "    <SessionRealtimeControl",
+        "      client={proxyClient}",
+        '      workspaceId="workspace-proof"',
+        '      sessionId="session-proof"',
+        '      sessionStatus="idle"',
+        "      effectiveControl={effectiveControl}",
+        "      events={[]}",
+        "      eventsReady={false}",
+        "      codexConnected={true}",
+        "    />",
+        "    <NewSessionRealtimeControl",
+        "      client={proxyClient}",
+        '      workspaceId="workspace-proof"',
+        "      codexConnected={true}",
+        "      onStart={async () => true}",
+        "    />",
+        "  </>,",
+        ");",
+        'if ((markup.match(/aria-label="Start voice with Codex Live"/g) ?? []).length !== 2) throw new Error("SSR output lost public realtime composer controls");',
+        'if (!markup.includes("Choose voice model and options")) throw new Error("SSR output lost realtime model picker ARIA copy");',
+        "console.log(`REALTIME_SUBPATH_SSR_OK bytes=${new TextEncoder().encode(markup).byteLength}`);",
+        "",
+      ].join("\n"),
+    ),
+  ]);
+
   process.stdout.write("[publish-consumer] installing release-shaped tarballs\n");
   await run(["bun", "install"], consumerRoot);
   await rm(join(consumerRoot, "node_modules"), { recursive: true, force: true });
@@ -472,6 +595,13 @@ try {
   await run(["bun", "install", "--frozen-lockfile"], minimalSessionRoot);
   await run(["bun", "run", "typecheck"], minimalSessionRoot);
   await run(["bun", "run", "build"], minimalSessionRoot);
+  process.stdout.write("[publish-consumer] installing minimal realtime-only consumer\n");
+  await run(["bun", "install"], minimalRealtimeRoot);
+  await rm(join(minimalRealtimeRoot, "node_modules"), { recursive: true, force: true });
+  await run(["bun", "install", "--frozen-lockfile"], minimalRealtimeRoot);
+  await run(["bun", "run", "typecheck"], minimalRealtimeRoot);
+  await run(["bun", "run", "build"], minimalRealtimeRoot);
+  await run(["bun", "run", "ssr"], minimalRealtimeRoot);
 
   const sessionBundle = await readFile(
     join(consumerRoot, "session-dist", "session-consumer.js"),
@@ -502,7 +632,7 @@ try {
 
   passed = true;
   process.stdout.write(
-    `[publish-consumer] PASS ${sdk.manifest.name}@${sdk.manifest.version} + ${react.manifest.name}@${react.manifest.version} + ${runtime.manifest.name}@${runtime.manifest.version}; strict types, session-only bundle, browser CSS, SSR, and packed skill-library imports are clean.\n`,
+    `[publish-consumer] PASS ${sdk.manifest.name}@${sdk.manifest.version} + ${react.manifest.name}@${react.manifest.version} + ${runtime.manifest.name}@${runtime.manifest.version}; strict types, session-only and realtime-only bundles, browser CSS, SSR, and packed skill-library imports are clean.\n`,
   );
 } finally {
   if (passed && !keepArtifacts) {

--- a/test/e2e/realtime-demo.browser.e2e.ts
+++ b/test/e2e/realtime-demo.browser.e2e.ts
@@ -1,0 +1,283 @@
+import AxeBuilder from "@axe-core/playwright";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { chromium, type Browser, type Locator, type Page } from "playwright";
+import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+
+const repoRoot = new URL("../..", import.meta.url).pathname;
+const evidenceDirectory =
+  process.env.OPENGENI_REALTIME_DEMO_EVIDENCE_DIR ?? "/tmp/opengeni-realtime-demo-evidence";
+
+describe("public realtime React demo browser acceptance", () => {
+  let browser: Browser;
+  let demo: StartedProcess;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    await mkdir(evidenceDirectory, { recursive: true });
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    const configuredChromium = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+    const sandboxChromium = "/usr/local/bin/chromium";
+    const executablePath =
+      configuredChromium ?? (existsSync(sandboxChromium) ? sandboxChromium : undefined);
+    browser = await chromium.launch(executablePath ? { executablePath } : undefined);
+    demo = await startProcess(
+      [
+        "bun",
+        "run",
+        "vite",
+        "dev",
+        "demo",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(port),
+        "--strictPort",
+        "--force",
+      ],
+      {
+        cwd: `${repoRoot}/packages/react`,
+        ready: async () =>
+          (
+            await fetch(`${baseUrl}/realtime.html?mode=mock`, {
+              signal: AbortSignal.timeout(2_000),
+            }).catch(() => null)
+          )?.ok === true,
+        timeoutMs: 45_000,
+      },
+    );
+  }, 60_000);
+
+  afterAll(async () => {
+    await Promise.allSettled([demo?.stop(), browser?.close()]);
+  }, 30_000);
+
+  test("selection, start, mute, diagnostics, reconnect, stop, error, and realtime-first creation preserve the public contract", async () => {
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 1000 },
+      reducedMotion: "reduce",
+    });
+    const page = await context.newPage();
+    const failures = observePageFailures(page);
+    await page.goto(`${baseUrl}/realtime.html?mode=mock`, { waitUntil: "networkidle" });
+
+    const existing = page.locator("[data-realtime-existing-composer]");
+    const next = page.locator("[data-realtime-new-composer]");
+    const primary = existing.getByTestId("realtime-primary-action");
+    await expectLabel(primary, "Start voice with Codex Live");
+    expect(
+      await existing.locator('[aria-label="Realtime voice"]').getAttribute("data-picker-side"),
+    ).toBe("top");
+    expect(
+      await next.locator('[aria-label="Realtime voice"]').getAttribute("data-picker-side"),
+    ).toBe("bottom");
+    await capture(page, "01-idle-desktop.png");
+
+    await openPicker(existing);
+    await page.getByTestId("model-picker-back").click();
+    await page.getByTestId("realtime-model-provider-opengeni_credits").click();
+    await page
+      .getByTestId("realtime-model-choice-opengeni-gateway/openai/gpt-realtime-2.1")
+      .waitFor();
+    await capture(page, "02-picker-desktop-menu-up.png");
+    await page
+      .getByTestId("realtime-model-choice-opengeni-gateway/openai/gpt-realtime-2.1")
+      .click();
+    await expectLabel(primary, "Start voice with GPT Realtime 2.1");
+
+    await primary.click();
+    await expectPhase(primary, "connecting");
+    await capture(page, "03-starting-desktop.png");
+    await expectLabel(primary, "End voice conversation");
+    await expectPhase(primary, "listening");
+    expect(await existing.getByTestId("realtime-mute-controls").count()).toBe(1);
+    await capture(page, "04-active-desktop.png");
+
+    const microphone = existing.getByRole("button", { name: "Mute microphone" });
+    const output = existing.getByRole("button", { name: "Mute voice audio" });
+    await microphone.click();
+    await output.click();
+    expect(
+      await existing
+        .getByRole("button", { name: "Unmute microphone" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      await existing
+        .getByRole("button", { name: "Unmute voice audio" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    await capture(page, "05-muted-desktop.png");
+
+    await openPicker(existing);
+    const diagnostics = page.getByText("Realtime diagnostics", { exact: true });
+    await diagnostics.hover();
+    await page.getByText("controller", { exact: true }).last().waitFor();
+    expect(await page.getByText("active", { exact: true }).last().count()).toBe(1);
+    await capture(page, "06-diagnostics-desktop.png");
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+
+    await page.getByRole("button", { name: "Simulate reconnect" }).click();
+    await expectLabel(primary, "Retry voice connection");
+    await expectPhase(primary, "reconnecting");
+    await capture(page, "07-reconnecting-desktop.png");
+    await primary.click();
+    await expectLabel(primary, "End voice conversation");
+
+    await primary.click();
+    await expectPhase(primary, "stopping");
+    await expectLabel(primary, "Start voice with GPT Realtime 2.1");
+    await page.getByRole("button", { name: "Simulate error" }).click();
+    await expectPhase(primary, "error");
+    expect(await existing.getByRole("alert").textContent()).toContain(
+      "The deterministic demo rejected the connection.",
+    );
+    await capture(page, "08-error-desktop.png");
+
+    await openPicker(next);
+    await page.getByTestId("model-picker-back").click();
+    await page.getByTestId("realtime-model-provider-byok").click();
+    await page
+      .getByTestId("realtime-model-choice-workspace-gateway/openai/gpt-realtime-mini")
+      .click();
+    await next.getByRole("button", { name: "Start voice with GPT Realtime Mini" }).click();
+    await page.getByTestId("realtime-first-count").filter({ hasText: "1" }).waitFor();
+    const createdSessionId = await page.getByTestId("current-session-id").textContent();
+    expect(createdSessionId).not.toBeNull();
+    expect(createdSessionId).not.toBe("3f6e1a2b-4c5d-4e6f-8a9b-0c1d2e3f4a5b");
+    await expectLabel(
+      page.locator("[data-realtime-existing-composer]").getByTestId("realtime-primary-action"),
+      "End voice conversation",
+    );
+    await capture(page, "09-realtime-first-created-desktop.png");
+
+    const contract = await page.evaluate(() =>
+      Array.from(document.querySelectorAll<HTMLElement>('[aria-label="Realtime voice"]')).map(
+        (region) => ({
+          pickerSide: region.dataset.pickerSide,
+          primaryLabel:
+            region
+              .querySelector<HTMLElement>('[data-testid="realtime-primary-action"]')
+              ?.getAttribute("aria-label") ?? null,
+          primaryPhase:
+            region.querySelector<HTMLElement>('[data-testid="realtime-primary-action"]')?.dataset
+              .phase ?? null,
+          primaryClass:
+            region.querySelector<HTMLElement>('[data-testid="realtime-primary-action"]')
+              ?.className ?? null,
+          optionsLabel:
+            region
+              .querySelector<HTMLElement>('button[aria-label="Choose voice model and options"]')
+              ?.getAttribute("aria-label") ?? null,
+          liveText: region.querySelector<HTMLElement>('[role="status"]')?.textContent ?? null,
+        }),
+      ),
+    );
+    await writeFile(
+      `${evidenceDirectory}/dom-copy-aria-class-contract.json`,
+      `${JSON.stringify(contract, null, 2)}\n`,
+    );
+    expect(contract).toHaveLength(2);
+    expect(contract[0]?.pickerSide).toBe("top");
+    expect(contract[1]?.pickerSide).toBe("bottom");
+    expect(contract.every((entry) => entry.optionsLabel === "Choose voice model and options")).toBe(
+      true,
+    );
+    expect(contract.every((entry) => entry.primaryClass?.includes("rounded-l-og-md"))).toBe(true);
+    expect(failures).toEqual([]);
+    await context.close();
+  }, 90_000);
+
+  test("mobile keeps both composer controls bounded and preserves menu-up/menu-down placement", async () => {
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      hasTouch: true,
+      isMobile: true,
+      reducedMotion: "reduce",
+    });
+    const page = await context.newPage();
+    const failures = observePageFailures(page);
+    await page.goto(`${baseUrl}/realtime.html?mode=mock`, { waitUntil: "networkidle" });
+    const existing = page.locator("[data-realtime-existing-composer]");
+    const next = page.locator("[data-realtime-new-composer]");
+    const audit = await page.evaluate(() => ({
+      overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      regions: document.querySelectorAll('[aria-label="Realtime voice"]').length,
+      minimumPrimarySize: Math.min(
+        ...Array.from(
+          document.querySelectorAll<HTMLElement>('[data-testid="realtime-primary-action"]'),
+          (element) =>
+            Math.min(element.getBoundingClientRect().width, element.getBoundingClientRect().height),
+        ),
+      ),
+    }));
+    expect(audit.overflow).toBeLessThanOrEqual(1);
+    expect(audit.regions).toBe(2);
+    expect(audit.minimumPrimarySize).toBeGreaterThanOrEqual(44);
+
+    await openPicker(existing);
+    await capture(page, "10-picker-mobile-menu-up.png");
+    await page.keyboard.press("Escape");
+    await openPicker(next);
+    await capture(page, "11-picker-mobile-menu-down.png");
+    await page.keyboard.press("Escape");
+    const axe = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
+      .analyze();
+    expect(axe.violations).toEqual([]);
+    expect(failures).toEqual([]);
+    await context.close();
+  }, 60_000);
+});
+
+async function openPicker(surface: Locator): Promise<void> {
+  await surface.getByRole("button", { name: "Choose voice model and options" }).click();
+  await surface.page().getByTestId("realtime-model-picker-menu").waitFor();
+}
+
+async function expectLabel(button: Locator, label: string): Promise<void> {
+  await button.waitFor();
+  await button
+    .page()
+    .waitForFunction(
+      ({ expected, testId }) =>
+        document.querySelector(`[data-testid="${testId}"]`)?.getAttribute("aria-label") ===
+        expected,
+      { expected: label, testId: "realtime-primary-action" },
+    );
+  expect(await button.getAttribute("aria-label")).toBe(label);
+}
+
+async function expectPhase(button: Locator, phase: string): Promise<void> {
+  await button
+    .page()
+    .waitForFunction(
+      ({ expected, testId }) =>
+        document.querySelector(`[data-testid="${testId}"]`)?.getAttribute("data-phase") ===
+        expected,
+      { expected: phase, testId: "realtime-primary-action" },
+    );
+  expect(await button.getAttribute("data-phase")).toBe(phase);
+}
+
+async function capture(page: Page, name: string): Promise<void> {
+  await page.evaluate(() => document.fonts.ready);
+  await page.screenshot({
+    path: `${evidenceDirectory}/${name}`,
+    fullPage: true,
+    animations: "disabled",
+  });
+}
+
+function observePageFailures(page: Page): string[] {
+  const failures: string[] = [];
+  page.on("pageerror", (error) => failures.push(`pageerror:${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") failures.push(`console:${message.text()}`);
+  });
+  page.on("requestfailed", (request) => failures.push(`request:${request.url()}`));
+  return failures;
+}

--- a/test/realtime-public-ownership.test.ts
+++ b/test/realtime-public-ownership.test.ts
@@ -4,6 +4,7 @@ import { extname, join, relative } from "node:path";
 
 const repositoryRoot = join(import.meta.dir, "..");
 const webSourceRoot = join(repositoryRoot, "apps/web/src");
+const reactDemoRoot = join(repositoryRoot, "packages/react/demo");
 
 async function sourceFiles(directory: string): Promise<string[]> {
   const entries = await readdir(directory, { withFileTypes: true });
@@ -60,5 +61,21 @@ describe("public realtime ownership", () => {
     );
     expect(sessionRoute).toContain('import("@opengeni/react/realtime")');
     expect(newSessionRoute).toContain('from "@opengeni/react/realtime"');
+  });
+
+  test("keeps the public React demo on published package imports", async () => {
+    const violations: string[] = [];
+    for (const file of await sourceFiles(reactDemoRoot)) {
+      const source = await readFile(file, "utf8");
+      const path = relative(repositoryRoot, file);
+      for (const [label, pattern] of [
+        ["private package source import", /(?:from\s+|import\s*)["'][^"']*\.\.\/src(?:\/|["'])/],
+        ["web application import", /(?:from\s+|import\s*)["'][^"']*apps\/web(?:\/|["'])/],
+      ] as const) {
+        if (pattern.test(source)) violations.push(`${path}: ${label}`);
+      }
+    }
+
+    expect(violations).toEqual([]);
   });
 });

--- a/test/realtime-public-ownership.test.ts
+++ b/test/realtime-public-ownership.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { readdir, readFile } from "node:fs/promises";
+import { extname, join, relative } from "node:path";
+
+const repositoryRoot = join(import.meta.dir, "..");
+const webSourceRoot = join(repositoryRoot, "apps/web/src");
+
+async function sourceFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) return await sourceFiles(path);
+      return [".ts", ".tsx"].includes(extname(entry.name)) ? [path] : [];
+    }),
+  );
+  return nested.flat();
+}
+
+describe("public realtime ownership", () => {
+  test("keeps realtime UI and controller orchestration out of apps/web", async () => {
+    const violations: string[] = [];
+    for (const file of await sourceFiles(webSourceRoot)) {
+      const source = await readFile(file, "utf8");
+      const path = relative(repositoryRoot, file);
+      for (const [label, pattern] of [
+        [
+          "app-owned realtime control",
+          /(?:function|const)\s+(?:RealtimeVoiceControl|SessionRealtimeControl|NewSessionRealtimeControl|RealtimeModelPickerMenu)\b/,
+        ],
+        [
+          "app-owned realtime hook",
+          /(?:function|const)\s+(?:useSessionRealtime|useRealtimeModelSelection)\b/,
+        ],
+        [
+          "direct realtime controller import",
+          /@opengeni\/sdk\/(?:realtime|codex-realtime-controller|gateway-realtime-transport)/,
+        ],
+        [
+          "direct realtime controller construction",
+          /create(?:Codex|Session)RealtimeController\s*\(/,
+        ],
+        [
+          "app-owned realtime transport selection",
+          /(?:gateway|codex)-realtime-owner|createGatewayRealtimeTransportStarter/,
+        ],
+      ] as const) {
+        if (pattern.test(source)) violations.push(`${path}: ${label}`);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test("dogfoods the public React realtime subpath in both composer routes", async () => {
+    const sessionRoute = await readFile(join(webSourceRoot, "routes/session.tsx"), "utf8");
+    const newSessionRoute = await readFile(
+      join(webSourceRoot, "routes/sessions-index.tsx"),
+      "utf8",
+    );
+    expect(sessionRoute).toContain('import("@opengeni/react/realtime")');
+    expect(newSessionRoute).toContain('from "@opengeni/react/realtime"');
+  });
+});


### PR DESCRIPTION
## Summary

- publish the existing provider-neutral realtime controller and transport selection through `@opengeni/sdk/realtime`, with narrow proxy-compatible client contracts and Codex compatibility aliases
- move the exact current realtime composer controls into `@opengeni/react/realtime`, including existing-session and realtime-first new-session wrappers, model selection, diagnostics, mute/reconnect behavior, and explicit provider/client overrides
- make `apps/web` consume only the public React subpath and add a static ownership guard preventing UI/controller logic from returning to the app
- turn the React demo into the public reference consumer with deterministic mock coverage and a same-origin live proxy whose credentials remain server-side; ship it at `/react-demo/realtime.html`
- wire the demo proxy through the production web server and Helm chart without moving or changing API, DB, prompt, context, delegation, ledger, or provider behavior
- add public-subpath package-consumer/SSR coverage, browser parity evidence, transport-selection tests, deployment tests, docs, and linked minor changesets for `@opengeni/sdk` and `@opengeni/react`

## Testing

- [x] `bun run typecheck` — all 23 projects
- [x] `bun run format:check` — all 1,412 files
- [x] `bun run lint` — 0 warnings/errors across 1,349 files
- [x] focused realtime/controller/ownership/server tests — 17/17 after rebase
- [x] SDK realtime and unchanged transport suites — 48/48
- [x] React/web realtime parity suites — 14/14
- [x] deployment suites — 35/35
- [x] realtime demo browser acceptance — 2/2 tests, 32 assertions, 11 parity screenshots, DOM/copy/ARIA/class contract, no page/console/request/Axe failures
- [x] SDK and React package builds
- [x] clean-room publish consumer using only `@opengeni/sdk/realtime` and `@opengeni/react/realtime`, including browser bundle and SSR render
- [x] production web build and bundle budgets
- [x] Helm lint/render
- [x] Checkov rendered-chart delta — 0 new failures (`base_failed=59`, `current_failed=59`)
- [x] docs reference, public repository hygiene, diff, and Changesets status guards
- [ ] GitHub CI unit shards and full acceptance matrix (pending on this PR)
- [ ] live Codex Live and Gateway canaries (post-merge release/deployment gate)

## Notes

- Realtime DOM, copy, ARIA, classes, styling, animations, prompts, lifecycle projection, recovery, wire protocol, ledger, delegation, and provider semantics are intentionally unchanged.
- Base `@opengeni/sdk` / `@opengeni/react` imports remain browser/SSR-safe; realtime is exposed through independently loadable subpaths and remains lazy in `apps/web`.
- The local sandbox intermittently terminates long monolithic processes with provider `SIGHUP`; the repository's official CI shards are the authoritative full-unit gate. All focused, package, browser, deployment, build, lint, format, type, and consumer checks listed above completed successfully.
