### PR TITLE
chore: bump Helm chart for realtime release

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.53
-appVersion: "0.22.53"
+version: 0.22.54
+appVersion: "0.22.54"


### PR DESCRIPTION
Bump the application chart version for the release that adds the public realtime SDK surface.