### PR TITLE
OPE-156: choose document upload authority

### DIFF
--- a/apps/web/src/routes/documents.test.tsx
+++ b/apps/web/src/routes/documents.test.tsx
@@ -1,9 +1,9 @@
-import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 
-import type { DocumentBase } from "@/types";
+import type { DocumentAuthorityKind, DocumentBase } from "@/types";
 
 const defaultBase: DocumentBase = {
   id: "11111111-1111-4111-8111-111111111111",
@@ -22,10 +22,23 @@ const customBase: DocumentBase = {
   updatedAt: "2026-08-02T12:01:00.000Z",
 };
 const listDocuments = mock(async (_workspaceId: string, _baseId: string) => []);
+const uploadFile = mock(async () => ({ id: "33333333-3333-4333-8333-333333333333" }));
+const addDocument = mock(async () => ({
+  id: "44444444-4444-4444-8444-444444444444",
+  baseId: defaultBase.id,
+}));
+const createKnowledgeDrop = mock(async () => ({
+  id: "55555555-5555-4555-8555-555555555555",
+  baseId: defaultBase.id,
+  curationStatus: "none" as const,
+}));
 const context = {
   client: {
     listDocumentBases: mock(async () => [customBase, defaultBase]),
     listDocuments,
+    uploadFile,
+    addDocument,
+    createKnowledgeDrop,
   },
   clientConfig: { fileUploads: { enabled: true, maxSizeBytes: 10_000_000 } },
 };
@@ -34,7 +47,12 @@ mock.module("@/context", () => ({
   useAppContext: () => context,
 }));
 
-const { DocumentsRoute, resolveDocumentCollectionSelection } = await import("./documents");
+const {
+  DocumentsRoute,
+  documentAuthorityOptions,
+  documentAuthorityRequest,
+  resolveDocumentCollectionSelection,
+} = await import("./documents");
 
 beforeAll(() => {
   GlobalRegistrator.register();
@@ -48,7 +66,29 @@ afterAll(() => {
   GlobalRegistrator.unregister();
 });
 
+beforeEach(() => {
+  listDocuments.mockClear();
+  uploadFile.mockClear();
+  addDocument.mockClear();
+  createKnowledgeDrop.mockClear();
+});
+
 describe("Documents Default collection UX", () => {
+  test("maps Company, Current workspace, and Only me to fixed authority kinds", () => {
+    expect(documentAuthorityOptions).toEqual([
+      { value: "organization", label: "Company" },
+      { value: "workspace", label: "Current workspace" },
+      { value: "personal", label: "Only me" },
+    ]);
+    for (const authorityKind of [
+      "organization",
+      "workspace",
+      "personal",
+    ] satisfies DocumentAuthorityKind[]) {
+      expect(documentAuthorityRequest(authorityKind)).toEqual({ authorityKind });
+    }
+  });
+
   test("keeps valid choices and recovers missing choices to Default", () => {
     expect(resolveDocumentCollectionSelection(customBase.id, [customBase, defaultBase])).toBe(
       customBase.id,
@@ -79,12 +119,64 @@ describe("Documents Default collection UX", () => {
       expect(container.textContent).toContain("Upload immediately for agent search");
       expect(container.textContent).toContain("Collections (optional)");
       expect(container.textContent).toContain("New collectionoptional");
+      expect(container.textContent).toContain("Company");
+      expect(container.textContent).toContain("Current workspace");
+      expect(container.textContent).toContain("Only me");
       expect(container.textContent).not.toContain("Create your first base");
       const upload = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
         (button) => button.textContent?.trim() === "Upload files",
       );
       expect(upload).not.toBeUndefined();
       expect(upload?.disabled).toBe(false);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("sends the selected authority for direct knowledge drops", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(<DocumentsRoute workspaceId="workspace-a" />);
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      const authority = container.querySelector<HTMLSelectElement>(
+        'select[aria-label="Drop document authority"]',
+      );
+      const text = container.querySelector<HTMLTextAreaElement>("textarea");
+      const drop = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+        (button) => button.textContent?.trim() === "Drop",
+      );
+      expect(authority).not.toBeNull();
+      expect(text).not.toBeNull();
+      expect(drop).not.toBeUndefined();
+
+      await act(async () => {
+        if (!authority || !text || !drop) return;
+        authority.value = "organization";
+        authority.dispatchEvent(new Event("change", { bubbles: true }));
+        text.value = "Company handbook";
+        text.dispatchEvent(new Event("input", { bubbles: true }));
+        drop.click();
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(createKnowledgeDrop).toHaveBeenCalledWith("workspace-a", {
+        text: "Company handbook",
+        authorityKind: "organization",
+        agentAccess: true,
+      });
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -28,10 +28,10 @@ import { useAppContext } from "@/context";
 import { listViewState } from "@/lib/load-state";
 import { cn } from "@/lib/utils";
 import type {
+  DocumentAuthorityKind,
   DocumentBase,
   DocumentSearchMode,
   DocumentSearchResult,
-  DocumentVisibility,
   IndexedDocument,
   KnowledgeSourceKind,
 } from "@/types";
@@ -46,6 +46,25 @@ const sourceKindOptions: KnowledgeSourceKind[] = [
   "web",
   "other",
 ];
+
+export const documentAuthorityOptions = [
+  { value: "organization", label: "Company" },
+  { value: "workspace", label: "Current workspace" },
+  { value: "personal", label: "Only me" },
+] as const satisfies ReadonlyArray<{ value: DocumentAuthorityKind; label: string }>;
+
+export function documentAuthorityRequest(authorityKind: DocumentAuthorityKind): {
+  authorityKind: DocumentAuthorityKind;
+} {
+  return { authorityKind };
+}
+
+export function documentAuthorityLabel(authorityKind: DocumentAuthorityKind): string {
+  return (
+    documentAuthorityOptions.find((option) => option.value === authorityKind)?.label ??
+    "Current workspace"
+  );
+}
 
 export function isDefaultDocumentCollection(base: Pick<DocumentBase, "name">): boolean {
   return base.name.trim().toLowerCase() === "default";
@@ -83,10 +102,10 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
   const [uploadSourceTitle, setUploadSourceTitle] = useState("");
   const [uploadSourceAuthor, setUploadSourceAuthor] = useState("");
   const [uploadAclTags, setUploadAclTags] = useState("");
-  const [uploadVisibility, setUploadVisibility] = useState<DocumentVisibility>("workspace");
+  const [uploadAuthority, setUploadAuthority] = useState<DocumentAuthorityKind>("workspace");
   const [uploadAgentAccess, setUploadAgentAccess] = useState(true);
   const [dropText, setDropText] = useState("");
-  const [dropVisibility, setDropVisibility] = useState<DocumentVisibility>("workspace");
+  const [dropAuthority, setDropAuthority] = useState<DocumentAuthorityKind>("workspace");
   const [dropAgentAccess, setDropAgentAccess] = useState(true);
   const [dropping, setDropping] = useState(false);
   const [creatingBase, setCreatingBase] = useState(false);
@@ -220,7 +239,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
         const indexed = await client.addDocument(workspaceId, selectedBaseId, {
           fileId: asset.id,
           sourceKind: uploadSourceKind,
-          visibility: uploadVisibility,
+          ...documentAuthorityRequest(uploadAuthority),
           agentAccess: uploadAgentAccess,
           ...(uploadSourceUri.trim() ? { sourceUri: uploadSourceUri.trim() } : {}),
           ...(uploadSourceTitle.trim() ? { sourceTitle: uploadSourceTitle.trim() } : {}),
@@ -260,7 +279,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
     try {
       const document = await client.createKnowledgeDrop(workspaceId, {
         text,
-        visibility: dropVisibility,
+        ...documentAuthorityRequest(dropAuthority),
         agentAccess: dropAgentAccess,
       });
       setDropText("");
@@ -290,7 +309,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
         });
         last = await client.createKnowledgeDrop(workspaceId, {
           fileId: asset.id,
-          visibility: dropVisibility,
+          ...documentAuthorityRequest(dropAuthority),
           agentAccess: dropAgentAccess,
         });
       }
@@ -475,14 +494,19 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
             />
             <div className="flex flex-col gap-2">
               <select
-                value={dropVisibility}
-                onChange={(event) => setDropVisibility(event.target.value as DocumentVisibility)}
+                value={dropAuthority}
+                onChange={(event) =>
+                  setDropAuthority(event.target.value as DocumentAuthorityKind)
+                }
                 disabled={dropping}
-                aria-label="Who can see this document"
+                aria-label="Drop document authority"
                 className="h-8 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-xs text-[color:var(--color-fg)]"
               >
-                <option value="workspace">Everyone in workspace</option>
-                <option value="private">Private — creator subject only</option>
+                {documentAuthorityOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
               </select>
               <label className="flex items-center gap-2 text-xs text-fg-muted">
                 <input
@@ -699,16 +723,20 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                       placeholder="team, confidential"
                     />
                   </FormField>
-                  <FormField label="Visibility">
+                  <FormField label="Authority">
                     <Select
-                      value={uploadVisibility}
+                      value={uploadAuthority}
                       onChange={(event) =>
-                        setUploadVisibility(event.target.value as DocumentVisibility)
+                        setUploadAuthority(event.target.value as DocumentAuthorityKind)
                       }
+                      aria-label="Upload document authority"
                       className="h-8 text-xs pointer-coarse:min-h-10"
                     >
-                      <option value="workspace">Everyone in workspace</option>
-                      <option value="private">Private — creator subject only</option>
+                      {documentAuthorityOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
                     </Select>
                   </FormField>
                   <FormField label="Agent access">
@@ -806,19 +834,19 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                           <div className="mt-1 flex flex-wrap gap-1 text-[11px] text-[color:var(--color-fg-subtle)]">
                             <span>{formatToken(document.sourceKind)}</span>
                             {document.sourceTitle ? <span>· {document.sourceTitle}</span> : null}
-                            {document.visibility === "private" ? (
-                              <span className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1">
+                            <span className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1">
+                              {document.authorityKind === "personal" ? (
                                 <LockIcon className="size-3" />
-                                creator subject only
-                              </span>
-                            ) : null}
+                              ) : null}
+                              {documentAuthorityLabel(document.authorityKind)}
+                            </span>
                             <span className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1">
                               {document.agentAccess === false ? (
                                 <BotOffIcon className="size-3" />
                               ) : null}
                               {document.agentAccess
-                                ? document.visibility === "private"
-                                  ? "creator's subject-aware agent can read"
+                                ? document.authorityKind === "personal"
+                                  ? "only my subject-aware agents can read"
                                   : "subject-aware agents can read"
                                 : "agents blocked"}
                             </span>

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -31,6 +31,7 @@ export type {
   OAuthStartResponse,
   CreateWorkspaceRequest,
   Document as IndexedDocument,
+  DocumentAuthorityKind,
   DocumentBase,
   DocumentCurationStatus,
   DocumentSearchMode,


### PR DESCRIPTION
KNOWLEDGE_DOCUMENT_UPLOAD_AUTHORITY_SOURCE_READY_V1

## Ownership
- Owning issue: OPE-156
- Governing fixed-authority contract: OPE-152
- Umbrella: OPE-105
- Dependent follow-on retained in OPE-128
- Sole source lane starting from live \[redacted]

## Exact provenance
- Base/main: \[redacted]
- Head: \[redacted]
- Head tree: \[redacted]
- Branch: \[redacted]

## Focused behavior
- Replaces legacy Documents upload/drop visibility wording with explicit **Company**, **Current workspace**, and **Only me** authority choices.
- Serializes those choices through the existing SDK/API \[redacted] contract as \[redacted], \[redacted], and \[redacted].
- Defaults visibly and behaviorally to \[redacted] for backward compatibility.
- Keeps workspace identity and immutable initiating-user personal subject binding server-owned.
- Relies on existing server-side exact \[redacted] denial for Company publication.
- Preserves automatic Default collection creation/selection and optional organization collections; collections remain metadata, not authority checks.

## Files changed
- \[redacted]
- \[redacted]
- \[redacted]

## Validation
- PASS: \[redacted]
- Added focused coverage for the three label-to-authority mappings, selected authority on direct knowledge drops, and the no-mandatory-collection regression.
- Existing backend coverage retains organization-authority denial and immutable personal subject binding.
- Local Bun/Node/TypeScript/formatter tests were not run because this restricted standalone workspace has no pre-existing runtime and package installation is prohibited. Exact-head GitHub CI is requested to execute repository validation.

## Migration and data safety
- No database migration or schema change.
- No data rewrite, visibility migration, connector sync, release, deployment, package publication, or cloud mutation.
- Existing legacy documents and authority tuples are unchanged; omitted authority continues to resolve deterministically to current workspace server-side.
- Documents remain RAG evidence and are not promoted into prompts or a parallel memory system.

## Remaining product slices
- Google/connector ingestion and synchronization remain outside this PR.
- Broad MCP retrieval composition, migration operations, and connector configuration remain outside this PR.
- OPE-128 retains its dependency on this direct Documents UI cutover.

Please perform an independent review at the exact head \[redacted] and verify the current-main synthetic integration before merge.
