### PR TITLE
feat(web): select document upload authority

### DIFF
--- a/apps/web/src/routes/documents.test.tsx
+++ b/apps/web/src/routes/documents.test.tsx
@@ -1,9 +1,9 @@
-import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 
-import type { DocumentBase } from "@/types";
+import type { DocumentAuthorityKind, DocumentBase, IndexedDocument } from "@/types";
 
 const defaultBase: DocumentBase = {
   id: "11111111-1111-4111-8111-111111111111",
@@ -21,11 +21,65 @@ const customBase: DocumentBase = {
   createdAt: "2026-08-02T12:01:00.000Z",
   updatedAt: "2026-08-02T12:01:00.000Z",
 };
+
+function indexedDocument(authorityKind: DocumentAuthorityKind): IndexedDocument {
+  return {
+    id: "33333333-3333-4333-8333-333333333333",
+    workspaceId: "workspace-a",
+    baseId: defaultBase.id,
+    fileId: "44444444-4444-4444-8444-444444444444",
+    status: "ready",
+    title: "Uploaded document",
+    parser: "text",
+    chunkCount: 1,
+    error: null,
+    sourceKind: "manual_upload",
+    sourceUri: null,
+    sourceExternalId: null,
+    sourceTitle: null,
+    sourceAuthor: null,
+    sourceCreatedAt: null,
+    sourceUpdatedAt: null,
+    sourceVersion: null,
+    aclTags: [],
+    authorityKind,
+    authorityWorkspaceId: authorityKind === "organization" ? null : "workspace-a",
+    authoritySubjectId: authorityKind === "personal" ? "subject-a" : null,
+    visibility: authorityKind === "personal" ? "private" : "workspace",
+    createdBy: "subject-a",
+    agentAccess: true,
+    summary: null,
+    topics: [],
+    curationStatus: "none",
+    curation: null,
+    createdAt: "2026-08-04T01:00:00.000Z",
+    updatedAt: "2026-08-04T01:00:00.000Z",
+  };
+}
+
+const listDocumentBases = mock(async () => [customBase, defaultBase]);
 const listDocuments = mock(async (_workspaceId: string, _baseId: string) => []);
+const uploadFile = mock(async (_workspaceId: string, _request: unknown) => ({
+  id: "44444444-4444-4444-8444-444444444444",
+}));
+const addDocument = mock(
+  async (
+    _workspaceId: string,
+    _baseId: string,
+    request: { authorityKind?: DocumentAuthorityKind },
+  ) => indexedDocument(request.authorityKind ?? "workspace"),
+);
+const createKnowledgeDrop = mock(
+  async (_workspaceId: string, request: { authorityKind?: DocumentAuthorityKind }) =>
+    indexedDocument(request.authorityKind ?? "workspace"),
+);
 const context = {
   client: {
-    listDocumentBases: mock(async () => [customBase, defaultBase]),
+    listDocumentBases,
     listDocuments,
+    uploadFile,
+    addDocument,
+    createKnowledgeDrop,
   },
   clientConfig: { fileUploads: { enabled: true, maxSizeBytes: 10_000_000 } },
 };
@@ -34,7 +88,13 @@ mock.module("@/context", () => ({
   useAppContext: () => context,
 }));
 
-const { DocumentsRoute, resolveDocumentCollectionSelection } = await import("./documents");
+const {
+  DEFAULT_DOCUMENT_AUTHORITY_KIND,
+  DOCUMENT_AUTHORITY_OPTIONS,
+  DocumentsRoute,
+  documentAuthorityLabel,
+  resolveDocumentCollectionSelection,
+} = await import("./documents");
 
 beforeAll(() => {
   GlobalRegistrator.register();
@@ -48,7 +108,65 @@ afterAll(() => {
   GlobalRegistrator.unregister();
 });
 
+beforeEach(() => {
+  listDocumentBases.mockClear();
+  listDocuments.mockClear();
+  uploadFile.mockClear();
+  addDocument.mockClear();
+  createKnowledgeDrop.mockClear();
+});
+
+async function settleRoute(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function setControlledTextarea(textarea: HTMLTextAreaElement, value: string): void {
+  Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")!.set!.call(
+    textarea,
+    value,
+  );
+  const reactPropsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"));
+  expect(reactPropsKey).toBeDefined();
+  const onChange = (
+    textarea as unknown as Record<
+      string,
+      { onChange?: (event: { target: HTMLTextAreaElement }) => void }
+    >
+  )[reactPropsKey!]!.onChange;
+  expect(typeof onChange).toBe("function");
+  onChange!({ target: textarea });
+}
+
+function fireFileDrop(target: HTMLElement, files: File[]): void {
+  const fileList = {
+    ...files,
+    length: files.length,
+    item: (index: number) => files[index] ?? null,
+    [Symbol.iterator]: () => files[Symbol.iterator](),
+  } as unknown as FileList;
+  const event = new DragEvent("drop", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", {
+    configurable: true,
+    value: { files: fileList } as DataTransfer,
+  });
+  target.dispatchEvent(event);
+}
+
 describe("Documents Default collection UX", () => {
+  test("uses the fixed authority labels, mappings, and workspace-safe default", () => {
+    expect(DOCUMENT_AUTHORITY_OPTIONS).toEqual([
+      { value: "organization", label: "Company" },
+      { value: "workspace", label: "Current workspace" },
+      { value: "personal", label: "Only me" },
+    ]);
+    expect(DEFAULT_DOCUMENT_AUTHORITY_KIND).toBe("workspace");
+    expect(documentAuthorityLabel("organization")).toBe("Company");
+    expect(documentAuthorityLabel("workspace")).toBe("Current workspace");
+    expect(documentAuthorityLabel("personal")).toBe("Only me");
+  });
+
   test("keeps valid choices and recovers missing choices to Default", () => {
     expect(resolveDocumentCollectionSelection(customBase.id, [customBase, defaultBase])).toBe(
       customBase.id,
@@ -71,9 +189,7 @@ describe("Documents Default collection UX", () => {
         root.render(<DocumentsRoute workspaceId="workspace-a" />);
         await Promise.resolve();
       });
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await settleRoute();
 
       expect(listDocuments).toHaveBeenCalledWith("workspace-a", defaultBase.id);
       expect(container.textContent).toContain("Upload immediately for agent search");
@@ -85,6 +201,106 @@ describe("Documents Default collection UX", () => {
       );
       expect(upload).not.toBeUndefined();
       expect(upload?.disabled).toBe(false);
+      const authoritySelects = [
+        container.querySelector<HTMLSelectElement>('[aria-label="Drop authority"]'),
+        container.querySelector<HTMLSelectElement>('[aria-label="Upload authority"]'),
+      ];
+      for (const select of authoritySelects) {
+        expect(select?.value).toBe("workspace");
+        expect([...select!.options].map((option) => [option.value, option.textContent])).toEqual([
+          ["organization", "Company"],
+          ["workspace", "Current workspace"],
+          ["personal", "Only me"],
+        ]);
+      }
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("propagates the selected authority through uploads and text/file drops", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(<DocumentsRoute workspaceId="workspace-a" />);
+        await Promise.resolve();
+      });
+      await settleRoute();
+
+      const uploadAuthority = container.querySelector<HTMLSelectElement>(
+        '[aria-label="Upload authority"]',
+      )!;
+      await act(async () => {
+        uploadAuthority.value = "organization";
+        uploadAuthority.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+
+      const ordinaryUpload = container.querySelector<HTMLInputElement>(
+        '[aria-label="Upload documents to selected collection"]',
+      )!;
+      const upload = new File(["company"], "company.txt", { type: "text/plain" });
+      Object.defineProperty(ordinaryUpload, "files", { configurable: true, value: [upload] });
+      await act(async () => {
+        ordinaryUpload.dispatchEvent(new Event("change", { bubbles: true }));
+        await Promise.resolve();
+      });
+      await settleRoute();
+
+      expect(addDocument).toHaveBeenCalledWith(
+        "workspace-a",
+        defaultBase.id,
+        expect.objectContaining({
+          fileId: "44444444-4444-4444-8444-444444444444",
+          authorityKind: "organization",
+        }),
+      );
+
+      const dropAuthority = container.querySelector<HTMLSelectElement>(
+        '[aria-label="Drop authority"]',
+      )!;
+      const dropText = container.querySelector<HTMLTextAreaElement>(
+        '[aria-label="Knowledge drop text"]',
+      )!;
+      await act(async () => {
+        dropAuthority.value = "personal";
+        dropAuthority.dispatchEvent(new Event("change", { bubbles: true }));
+        setControlledTextarea(dropText, "Personal note");
+      });
+      const dropButton = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+        (button) => button.textContent?.trim() === "Drop",
+      )!;
+      await act(async () => {
+        dropButton.click();
+        await Promise.resolve();
+      });
+      await settleRoute();
+
+      expect(createKnowledgeDrop).toHaveBeenCalledWith(
+        "workspace-a",
+        expect.objectContaining({ text: "Personal note", authorityKind: "personal" }),
+      );
+
+      const droppedFile = new File(["personal file"], "personal.txt", { type: "text/plain" });
+      await act(async () => {
+        fireFileDrop(
+          container.querySelector<HTMLElement>('[aria-label="Knowledge drop zone"]')!,
+          [droppedFile],
+        );
+        await Promise.resolve();
+      });
+      await settleRoute();
+
+      expect(createKnowledgeDrop.mock.calls).toContainEqual([
+        "workspace-a",
+        expect.objectContaining({
+          fileId: "44444444-4444-4444-8444-444444444444",
+          authorityKind: "personal",
+        }),
+      ]);
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/routes/documents.test.tsx
+++ b/apps/web/src/routes/documents.test.tsx
@@ -286,10 +286,9 @@ describe("Documents Default collection UX", () => {
 
       const droppedFile = new File(["personal file"], "personal.txt", { type: "text/plain" });
       await act(async () => {
-        fireFileDrop(
-          container.querySelector<HTMLElement>('[aria-label="Knowledge drop zone"]')!,
-          [droppedFile],
-        );
+        fireFileDrop(container.querySelector<HTMLElement>('[aria-label="Knowledge drop zone"]')!, [
+          droppedFile,
+        ]);
         await Promise.resolve();
       });
       await settleRoute();

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -28,10 +28,10 @@ import { useAppContext } from "@/context";
 import { listViewState } from "@/lib/load-state";
 import { cn } from "@/lib/utils";
 import type {
+  DocumentAuthorityKind,
   DocumentBase,
   DocumentSearchMode,
   DocumentSearchResult,
-  DocumentVisibility,
   IndexedDocument,
   KnowledgeSourceKind,
 } from "@/types";
@@ -46,6 +46,21 @@ const sourceKindOptions: KnowledgeSourceKind[] = [
   "web",
   "other",
 ];
+
+export const DEFAULT_DOCUMENT_AUTHORITY_KIND: DocumentAuthorityKind = "workspace";
+
+export const DOCUMENT_AUTHORITY_OPTIONS = [
+  { value: "organization", label: "Company" },
+  { value: "workspace", label: "Current workspace" },
+  { value: "personal", label: "Only me" },
+] as const satisfies ReadonlyArray<{
+  value: DocumentAuthorityKind;
+  label: string;
+}>;
+
+export function documentAuthorityLabel(kind: DocumentAuthorityKind): string {
+  return DOCUMENT_AUTHORITY_OPTIONS.find((option) => option.value === kind)?.label ?? kind;
+}
 
 export function isDefaultDocumentCollection(base: Pick<DocumentBase, "name">): boolean {
   return base.name.trim().toLowerCase() === "default";
@@ -83,10 +98,14 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
   const [uploadSourceTitle, setUploadSourceTitle] = useState("");
   const [uploadSourceAuthor, setUploadSourceAuthor] = useState("");
   const [uploadAclTags, setUploadAclTags] = useState("");
-  const [uploadVisibility, setUploadVisibility] = useState<DocumentVisibility>("workspace");
+  const [uploadAuthorityKind, setUploadAuthorityKind] = useState<DocumentAuthorityKind>(
+    DEFAULT_DOCUMENT_AUTHORITY_KIND,
+  );
   const [uploadAgentAccess, setUploadAgentAccess] = useState(true);
   const [dropText, setDropText] = useState("");
-  const [dropVisibility, setDropVisibility] = useState<DocumentVisibility>("workspace");
+  const [dropAuthorityKind, setDropAuthorityKind] = useState<DocumentAuthorityKind>(
+    DEFAULT_DOCUMENT_AUTHORITY_KIND,
+  );
   const [dropAgentAccess, setDropAgentAccess] = useState(true);
   const [dropping, setDropping] = useState(false);
   const [creatingBase, setCreatingBase] = useState(false);
@@ -220,7 +239,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
         const indexed = await client.addDocument(workspaceId, selectedBaseId, {
           fileId: asset.id,
           sourceKind: uploadSourceKind,
-          visibility: uploadVisibility,
+          authorityKind: uploadAuthorityKind,
           agentAccess: uploadAgentAccess,
           ...(uploadSourceUri.trim() ? { sourceUri: uploadSourceUri.trim() } : {}),
           ...(uploadSourceTitle.trim() ? { sourceTitle: uploadSourceTitle.trim() } : {}),
@@ -260,7 +279,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
     try {
       const document = await client.createKnowledgeDrop(workspaceId, {
         text,
-        visibility: dropVisibility,
+        authorityKind: dropAuthorityKind,
         agentAccess: dropAgentAccess,
       });
       setDropText("");
@@ -290,7 +309,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
         });
         last = await client.createKnowledgeDrop(workspaceId, {
           fileId: asset.id,
-          visibility: dropVisibility,
+          authorityKind: dropAuthorityKind,
           agentAccess: dropAgentAccess,
         });
       }
@@ -450,6 +469,8 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
         />
 
         <div
+          role="region"
+          aria-label="Knowledge drop zone"
           className="mt-5 rounded-lg border border-dashed border-border bg-surface/25 p-3"
           onDragOver={(event) => event.preventDefault()}
           onDrop={(event) => {
@@ -466,6 +487,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
           </div>
           <div className="mt-2 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
             <textarea
+              aria-label="Knowledge drop text"
               value={dropText}
               onChange={(event) => setDropText(event.target.value)}
               placeholder="Paste notes, a transcript, an email — or drag files here."
@@ -474,16 +496,24 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
               className="min-h-16 w-full resize-y rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2.5 py-2 text-xs leading-5 text-[color:var(--color-fg)]"
             />
             <div className="flex flex-col gap-2">
-              <select
-                value={dropVisibility}
-                onChange={(event) => setDropVisibility(event.target.value as DocumentVisibility)}
-                disabled={dropping}
-                aria-label="Who can see this document"
-                className="h-8 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-xs text-[color:var(--color-fg)]"
-              >
-                <option value="workspace">Everyone in workspace</option>
-                <option value="private">Private — creator subject only</option>
-              </select>
+              <label className="grid gap-1 text-2xs font-medium text-fg-subtle">
+                Authority
+                <select
+                  value={dropAuthorityKind}
+                  onChange={(event) =>
+                    setDropAuthorityKind(event.target.value as DocumentAuthorityKind)
+                  }
+                  disabled={dropping}
+                  aria-label="Drop authority"
+                  className="h-8 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-xs font-normal text-[color:var(--color-fg)]"
+                >
+                  {DOCUMENT_AUTHORITY_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
               <label className="flex items-center gap-2 text-xs text-fg-muted">
                 <input
                   type="checkbox"
@@ -498,6 +528,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                   ref={dropFileInputRef}
                   type="file"
                   multiple
+                  aria-label="Add files as a knowledge drop"
                   className="hidden"
                   onChange={(event) => void handleDropFiles(event.target.files)}
                 />
@@ -613,6 +644,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                       ref={fileInputRef}
                       type="file"
                       multiple
+                      aria-label="Upload documents to selected collection"
                       className="hidden"
                       onChange={(event) => void handleFiles(event.target.files)}
                     />
@@ -699,16 +731,20 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                       placeholder="team, confidential"
                     />
                   </FormField>
-                  <FormField label="Visibility">
+                  <FormField label="Authority">
                     <Select
-                      value={uploadVisibility}
+                      aria-label="Upload authority"
+                      value={uploadAuthorityKind}
                       onChange={(event) =>
-                        setUploadVisibility(event.target.value as DocumentVisibility)
+                        setUploadAuthorityKind(event.target.value as DocumentAuthorityKind)
                       }
                       className="h-8 text-xs pointer-coarse:min-h-10"
                     >
-                      <option value="workspace">Everyone in workspace</option>
-                      <option value="private">Private — creator subject only</option>
+                      {DOCUMENT_AUTHORITY_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
                     </Select>
                   </FormField>
                   <FormField label="Agent access">
@@ -806,12 +842,12 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                           <div className="mt-1 flex flex-wrap gap-1 text-[11px] text-[color:var(--color-fg-subtle)]">
                             <span>{formatToken(document.sourceKind)}</span>
                             {document.sourceTitle ? <span>· {document.sourceTitle}</span> : null}
-                            {document.visibility === "private" ? (
-                              <span className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1">
+                            <span className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1">
+                              {document.authorityKind === "personal" ? (
                                 <LockIcon className="size-3" />
-                                creator subject only
-                              </span>
-                            ) : null}
+                              ) : null}
+                              Authority: {documentAuthorityLabel(document.authorityKind)}
+                            </span>
                             <span className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1">
                               {document.agentAccess === false ? (
                                 <BotOffIcon className="size-3" />

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -31,6 +31,7 @@ export type {
   OAuthStartResponse,
   CreateWorkspaceRequest,
   Document as IndexedDocument,
+  DocumentAuthorityKind,
   DocumentBase,
   DocumentCurationStatus,
   DocumentSearchMode,


### PR DESCRIPTION
KNOWLEDGE_DOCUMENT_UPLOAD_AUTHORITY_SOURCE_READY_V3

## Immutable source
- Base: `d46922247e7d8e734d3a628ba03de58ec6ab3b7f`
- Head: `ef2168f9c1c99ac066a97dd72da38f1b82314d82`
- Tree: `a2478c10439d5e9ccd8861ca73e5b282ffa91386`
- Files: exactly the complete immutable candidate file set represented by the base/head/tree above; no files outside that focused Documents upload-authority UI slice.

## Behavior
- **Company** maps to `organization` authority.
- **Current workspace** maps to `workspace` authority.
- **Only me** maps to `personal` authority.
- `workspace` is the default selection.
- The selected authority propagates through upload, text-drop, and file-drop ingestion paths.

## Validation
- Checkpoint decoded SHA-256: `c08563e6d25809daf1c5082a41a28804ece227255c033e95eafb3d13a11c2e79`
- Checkpoint base64 SHA-256: `827cd5bc7dd19a022ac6e27cb79e561192cbfecfe20d4921b600751e837d485a`
- `git diff --check`: PASS
- Runtime checks were unavailable; CI is authoritative.

## Scope boundaries
- No migration or legacy-document reclassification.
- Connector configuration and OPE-128 work are excluded.
