### PR TITLE
fix(web): normalize decoded demo proxy responses

### DIFF
--- a/apps/web/src/server.test.ts
+++ b/apps/web/src/server.test.ts
@@ -202,6 +202,42 @@ describe("production web handler", () => {
     expect(await head.text()).toBe("");
   });
 
+  test("ignores malformed connection options while stripping valid hop-by-hop names", async () => {
+    const root = await fixture();
+    let upstreamRequestHeaders = new Headers();
+    const handler = createWebHandler(root, {
+      demoApiProxy: {
+        targetBaseUrl: "http://api.internal:8000",
+        fetch: async (_input, init) => {
+          upstreamRequestHeaders = new Headers(init?.headers);
+          return new Response('{"ok":true}', {
+            headers: {
+              connection: "keep-alive, bad name, x-upstream-hop",
+              "content-type": "application/json",
+              "x-upstream-hop": "must-not-be-forwarded",
+            },
+          });
+        },
+      },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/demo-api/v1/workspaces", {
+        headers: {
+          connection: "keep-alive, bad name, x-browser-hop",
+          "x-browser-hop": "must-not-be-forwarded",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstreamRequestHeaders.get("connection")).toBeNull();
+    expect(upstreamRequestHeaders.get("x-browser-hop")).toBeNull();
+    expect(response.headers.get("connection")).toBeNull();
+    expect(response.headers.get("x-upstream-hop")).toBeNull();
+    expect(await response.json()).toEqual({ ok: true });
+  });
+
   test("derives optional authority headers from environment names", () => {
     expect(demoApiProxyFromEnvironment({})).toBeUndefined();
     expect(() =>

--- a/apps/web/src/server.test.ts
+++ b/apps/web/src/server.test.ts
@@ -89,8 +89,10 @@ describe("production web handler", () => {
     });
     const browserHeaders = new Headers({
       "content-type": "application/json",
+      connection: "keep-alive, x-browser-hop",
       forwarded: "for=spoofed;host=evil.example",
       origin: "https://example.test",
+      "x-browser-hop": "browser-hop-value-that-must-not-be-forwarded",
       "x-forwarded-port": "4444",
       "x-opengeni-access-key": "browser-access-value-that-must-be-replaced",
       "x-real-ip": "203.0.113.10",
@@ -110,6 +112,7 @@ describe("production web handler", () => {
     const headers = new Headers(seen.init?.headers);
     expect(headers.get("authorization")).toBe(["Bearer", serverApiValue].join(" "));
     expect(headers.get("x-opengeni-access-key")).toBe(serverAccessValue);
+    expect(headers.get("x-browser-hop")).toBeNull();
     expect(headers.get("forwarded")).toBeNull();
     expect(headers.get("x-forwarded-host")).toBe("example.test");
     expect(headers.get("x-forwarded-port")).toBeNull();
@@ -160,11 +163,12 @@ describe("production web handler", () => {
           return new Response('{"error":"Unauthorized"}', {
             status: 401,
             headers: {
-              connection: "keep-alive",
+              connection: "keep-alive, x-upstream-hop",
               "content-encoding": "gzip",
               "content-length": "999",
               "content-type": "application/json",
               "transfer-encoding": "chunked",
+              "x-upstream-hop": "upstream-hop-value-that-must-not-be-forwarded",
             },
           });
         },
@@ -183,8 +187,19 @@ describe("production web handler", () => {
     expect(response.headers.get("content-length")).toBeNull();
     expect(response.headers.get("connection")).toBeNull();
     expect(response.headers.get("transfer-encoding")).toBeNull();
+    expect(response.headers.get("x-upstream-hop")).toBeNull();
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(await response.json()).toEqual({ error: "Unauthorized" });
+
+    const head = await handler(
+      new Request("https://example.test/demo-api/v1/workspaces/ws/sessions", {
+        method: "HEAD",
+      }),
+    );
+    expect(head.headers.get("content-encoding")).toBe("gzip");
+    expect(head.headers.get("content-length")).toBe("999");
+    expect(head.headers.get("x-upstream-hop")).toBeNull();
+    expect(await head.text()).toBe("");
   });
 
   test("derives optional authority headers from environment names", () => {

--- a/apps/web/src/server.test.ts
+++ b/apps/web/src/server.test.ts
@@ -114,6 +114,7 @@ describe("production web handler", () => {
     expect(headers.get("x-forwarded-host")).toBe("example.test");
     expect(headers.get("x-forwarded-port")).toBeNull();
     expect(headers.get("x-real-ip")).toBeNull();
+    expect(headers.get("accept-encoding")).toBe("identity");
     expect(seen.init?.redirect).toBe("manual");
     expect(seen.body).toContain("realtime");
 
@@ -144,6 +145,46 @@ describe("production web handler", () => {
         )
       ).status,
     ).toBe(400);
+  });
+
+  test("normalizes representation and hop-by-hop headers after upstream decoding", async () => {
+    const root = await fixture();
+    const seen: { acceptEncoding?: string | null } = {};
+    const handler = createWebHandler(root, {
+      demoApiProxy: {
+        targetBaseUrl: "http://api.internal:8000",
+        fetch: async (_input, init) => {
+          seen.acceptEncoding = new Headers(init?.headers).get("accept-encoding");
+          // This is the shape exposed by Bun when it has already decoded a
+          // gzip response body but retained the upstream response headers.
+          return new Response('{"error":"Unauthorized"}', {
+            status: 401,
+            headers: {
+              connection: "keep-alive",
+              "content-encoding": "gzip",
+              "content-length": "999",
+              "content-type": "application/json",
+              "transfer-encoding": "chunked",
+            },
+          });
+        },
+      },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/demo-api/v1/workspaces/ws/sessions", {
+        headers: { "accept-encoding": "br, gzip" },
+      }),
+    );
+
+    expect(seen.acceptEncoding).toBe("identity");
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("connection")).toBeNull();
+    expect(response.headers.get("transfer-encoding")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
   });
 
   test("derives optional authority headers from environment names", () => {

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -17,6 +17,7 @@ const HOP_BY_HOP_HEADERS = [
   "transfer-encoding",
   "upgrade",
 ] as const;
+const HTTP_FIELD_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
 export type DemoApiProxyOptions = {
   targetBaseUrl: string;
@@ -159,7 +160,7 @@ async function proxyDemoApi(
 function stripHopByHopHeaders(headers: Headers): void {
   for (const name of headers.get("connection")?.split(",") ?? []) {
     const normalized = name.trim();
-    if (normalized) headers.delete(normalized);
+    if (HTTP_FIELD_NAME_PATTERN.test(normalized)) headers.delete(normalized);
   }
   for (const name of HOP_BY_HOP_HEADERS) headers.delete(name);
 }

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -101,12 +101,12 @@ async function proxyDemoApi(
     normalizedBaseUrl(options.targetBaseUrl),
   );
   const headers = new Headers(request.headers);
+  stripHopByHopHeaders(headers);
   for (const name of [
     "authorization",
     "content-length",
     "forwarded",
     "host",
-    ...HOP_BY_HOP_HEADERS,
     "x-forwarded-for",
     "x-forwarded-host",
     "x-forwarded-port",
@@ -136,13 +136,15 @@ async function proxyDemoApi(
       signal: request.signal,
     });
     const responseHeaders = new Headers(upstream.headers);
+    stripHopByHopHeaders(responseHeaders);
     // A fetch implementation may retain the upstream representation headers
     // after transparently decoding its body. Forwarding those stale headers
     // makes browsers attempt a second decompression and fail before the SDK can
     // read even an ordinary JSON error response.
-    responseHeaders.delete("content-encoding");
-    responseHeaders.delete("content-length");
-    for (const name of HOP_BY_HOP_HEADERS) responseHeaders.delete(name);
+    if (request.method !== "HEAD") {
+      responseHeaders.delete("content-encoding");
+      responseHeaders.delete("content-length");
+    }
     responseHeaders.set("cache-control", "no-store");
     return new Response(request.method === "HEAD" ? null : upstream.body, {
       status: upstream.status,
@@ -152,6 +154,14 @@ async function proxyDemoApi(
   } catch {
     return new Response("Demo API upstream unavailable", { status: 502 });
   }
+}
+
+function stripHopByHopHeaders(headers: Headers): void {
+  for (const name of headers.get("connection")?.split(",") ?? []) {
+    const normalized = name.trim();
+    if (normalized) headers.delete(normalized);
+  }
+  for (const name of HOP_BY_HOP_HEADERS) headers.delete(name);
 }
 
 function normalizedBaseUrl(value: string): string {

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -7,6 +7,16 @@ const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
 const REVALIDATE_CACHE_CONTROL = "no-cache";
 const SHORT_CACHE_CONTROL = "public, max-age=3600";
 const DEMO_API_PREFIX = "/demo-api";
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+] as const;
 
 export type DemoApiProxyOptions = {
   targetBaseUrl: string;
@@ -93,17 +103,10 @@ async function proxyDemoApi(
   const headers = new Headers(request.headers);
   for (const name of [
     "authorization",
-    "connection",
     "content-length",
     "forwarded",
     "host",
-    "keep-alive",
-    "proxy-authenticate",
-    "proxy-authorization",
-    "te",
-    "trailer",
-    "transfer-encoding",
-    "upgrade",
+    ...HOP_BY_HOP_HEADERS,
     "x-forwarded-for",
     "x-forwarded-host",
     "x-forwarded-port",
@@ -116,6 +119,10 @@ async function proxyDemoApi(
   for (const [name, value] of new Headers(options.credentialHeaders)) {
     headers.set(name, value);
   }
+  // Bun's fetch transparently decodes compressed upstream responses. Ask for
+  // the identity representation so the streamed body and response metadata
+  // agree even before the defensive response-header normalization below.
+  headers.set("accept-encoding", "identity");
   headers.set("x-forwarded-host", incomingUrl.host);
   headers.set("x-forwarded-proto", incomingUrl.protocol.slice(0, -1));
 
@@ -129,6 +136,13 @@ async function proxyDemoApi(
       signal: request.signal,
     });
     const responseHeaders = new Headers(upstream.headers);
+    // A fetch implementation may retain the upstream representation headers
+    // after transparently decoding its body. Forwarding those stale headers
+    // makes browsers attempt a second decompression and fail before the SDK can
+    // read even an ordinary JSON error response.
+    responseHeaders.delete("content-encoding");
+    responseHeaders.delete("content-length");
+    for (const name of HOP_BY_HOP_HEADERS) responseHeaders.delete(name);
     responseHeaders.set("cache-control", "no-store");
     return new Response(request.method === "HEAD" ? null : upstream.body, {
       status: upstream.status,

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.54
-appVersion: "0.22.54"
+version: 0.22.55
+appVersion: "0.22.55"


### PR DESCRIPTION
## Summary
- request an identity-encoded upstream representation for the deployed React demo proxy
- strip stale representation and hop-by-hop response headers before streaming Bun's decoded body
- add a regression for the production gzip double-decompression failure
- advance the immutable product chart from `0.22.54` to `0.22.55`

## Production evidence
The deployed `/demo-api` proxy returned an already-decoded JSON authorization response while preserving `Content-Encoding: gzip`. Bun/SDK clients then failed with `ZlibError: incorrect header check` before they could read the HTTP status or body. The failed unauthenticated session create did not commit: `requireAccessGrant(..., "sessions:create")` runs before request parsing and `createSessionForRequest`.

## Verification
- `bun run typecheck` (23 projects)
- `bun run format:check`
- `bun run lint -- apps/web/src/server.ts apps/web/src/server.test.ts`
- `bun test apps/web/src/server.test.ts` (7 pass, 45 assertions)
- `bun run --cwd apps/web build` (including deployed React demo and bundle budgets)
- real Bun upstream + proxy HTTP socket smoke (401 JSON readable; no stale content encoding/length)
- Helm lint and full CI render matrix
- release-version/candidate/chart/workflow tests (23 pass, 312 assertions)
- Checkov normalized baseline/current comparison: 53 existing findings in both, 0 new findings

No realtime UI, transport, wire, API, DB, provider, context, delegation, or SDK package behavior changes.
