### PR TITLE
chore: bump chart to 0.22.56

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.55
-appVersion: "0.22.55"
+version: 0.22.56
+appVersion: "0.22.56"


### PR DESCRIPTION
Bumps the Helm chart and application release version to 0.22.56 so the current source can be published as a new immutable release.

Validation:
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `helm lint deploy/helm/opengeni`
- `git diff --check`