### PR TITLE
fix(release): measure capture latency regionally

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.55
-appVersion: "0.22.55"
+version: 0.22.56
+appVersion: "0.22.56"

--- a/docs/workbench-acceptance.md
+++ b/docs/workbench-acceptance.md
@@ -73,6 +73,20 @@ Evidence MUST NOT contain raw credentials, cookies, signed object URLs,
 kubeconfigs, customer data, conversation content outside the deterministic
 fixture, or unredacted provider responses.
 
+The capture API latency row is measured by a protected operator probe running
+in the deployment's exact cloud region rather than by the generic GitHub-hosted
+browser runner. The live harness sends the dedicated canary cookie to that
+operator only over child-process stdin. The operator creates an ephemeral,
+token-free Kubernetes Job from the exact digest-pinned API image, performs the
+100 sequential HTTPS reads through the public ingress, and deletes the Job and
+its temporary Secret. The sanitized result must bind the environment, source
+SHA, acceptance run, region, API image, workspace, session, capture revision,
+turn, decoded byte count, gzip encoding, and exact sample count before the
+public harness will calculate the p95. Browser navigation, interaction,
+accessibility, and screenshots remain on the ordinary release runner and the
+production network path. A runner in an unspecified geography is not valid
+evidence for the deployment-region capture API budget.
+
 The manually dispatched release-candidate workflow derives the complete package
 plan from the exact checkout and npm registry state (which is empty for an
 application-only release), takes the product release version from the

--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
 import type { AccessContext, WorkspaceCaptureManifest } from "@opengeni/sdk";
 
 import {
@@ -10,6 +13,7 @@ import {
   assertChangedFileLabelsContainRepositoryRoots,
   assertChangesDefaultVisible,
   assertRepositoryChangesVisible,
+  captureApiRegionalProbeEnvironment,
   controlCancellationDurationMs,
   fixturePrompt,
   isExpectedBrowserCancellation,
@@ -17,9 +21,12 @@ import {
   parseCookieHeader,
   parseLiveAcceptanceArgs,
   parseProtectedEmails,
+  runCaptureApiRegionalProbe,
   sanitizeDiagnostic,
   selectTreeFile,
+  validateCaptureApiRegionalProbeResult,
   waitForSandboxLiveness,
+  type CaptureApiRegionalProbeRequest,
 } from "./workbench-live-acceptance";
 
 describe("workbench live acceptance preflight", () => {
@@ -205,10 +212,89 @@ describe("workbench live acceptance preflight", () => {
       "acceptance-001",
       "--model",
       "codex/model",
+      "--capture-api-region-probe-command",
+      "/tmp/capture-api-regional-probe.ts",
+      "--capture-api-region",
+      "northeurope",
+      "--capture-api-image",
+      `registry.example.com/opengeni-api:candidate-${"a".repeat(40)}@sha256:${"b".repeat(64)}`,
     ];
     expect(parseLiveAcceptanceArgs(base).repetitions).toBe(100);
     expect(() => parseLiveAcceptanceArgs([...base, "--repetitions", "99"])).toThrow(">= 100");
     expect(() => parseLiveAcceptanceArgs(base.with(1, "http://api.example.com"))).toThrow("HTTPS");
+  });
+
+  test("binds capture API samples to the exact regional deployment identity", () => {
+    const request = captureApiRegionalProbeRequest();
+    const result = captureApiRegionalProbeResult(request);
+    expect(validateCaptureApiRegionalProbeResult(result, request)).toEqual(result);
+    expect(result.captureTurnId).toBe(request.captureTurnId);
+    expect(() =>
+      validateCaptureApiRegionalProbeResult({ ...result, region: "westus" }, request),
+    ).toThrow("region mismatch");
+    expect(() =>
+      validateCaptureApiRegionalProbeResult(
+        { ...result, samplesMs: result.samplesMs.slice(1) },
+        request,
+      ),
+    ).toThrow("sample count mismatch");
+    expect(() =>
+      validateCaptureApiRegionalProbeResult({ ...result, extra: true }, request),
+    ).toThrow("fields are invalid");
+  });
+
+  test("passes the managed cookie only over probe stdin and redacts child failures", async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), "opengeni-regional-probe-"));
+    const success = resolve(directory, "success.ts");
+    const failure = resolve(directory, "failure.ts");
+    const request = captureApiRegionalProbeRequest();
+    try {
+      await writeFile(
+        success,
+        `const request = JSON.parse(await Bun.stdin.text());\n` +
+          `if (process.env.OPENGENI_ACCEPTANCE_SESSION_COOKIE) throw new Error("cookie leaked through environment");\n` +
+          `process.stdout.write(JSON.stringify({\n` +
+          `  schemaVersion: "opengeni/workbench-capture-api-regional-probe/v1",\n` +
+          `  apiOrigin: new URL(request.apiUrl).origin, environment: request.environment,\n` +
+          `  sourceSha: request.sourceSha, runId: request.runId, workspaceId: request.workspaceId,\n` +
+          `  sessionId: request.sessionId, captureRevision: request.captureRevision,\n` +
+          `  captureTurnId: request.captureTurnId, sampleCount: request.repetitions,\n` +
+          `  region: request.region, apiImage: request.apiImage, decodedBytes: 4096,\n` +
+          `  contentEncoding: "gzip", samplesMs: Array(request.repetitions).fill(12.5)\n` +
+          `}));\n`,
+      );
+      await writeFile(
+        failure,
+        `const request = JSON.parse(await Bun.stdin.text());\n` +
+          `console.error(request.cookieHeader);\nprocess.exit(7);\n`,
+      );
+
+      const result = await runCaptureApiRegionalProbe(success, request);
+      expect(result.sampleCount).toBe(request.repetitions);
+      expect(JSON.stringify(result)).not.toContain(request.cookieHeader);
+      await expect(runCaptureApiRegionalProbe(failure, request)).rejects.toThrow(
+        "exit code 7: [redacted]",
+      );
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("strips every acceptance secret from the regional probe environment", () => {
+    expect(
+      captureApiRegionalProbeEnvironment({
+        PATH: "/usr/bin",
+        KUBECONFIG: "/tmp/kubeconfig",
+        OPENGENI_CAPTURE_API_PROBE_NAMESPACE: "opengeni",
+        OPENGENI_ACCEPTANCE_SESSION_COOKIE: "secret-cookie",
+        OPENGENI_ACCEPTANCE_PRODUCT_TOKEN: "secret-token",
+        UNDEFINED_VALUE: undefined,
+      }),
+    ).toEqual({
+      PATH: "/usr/bin",
+      KUBECONFIG: "/tmp/kubeconfig",
+      OPENGENI_CAPTURE_API_PROBE_NAMESPACE: "opengeni",
+    });
   });
 
   test("cookie parser preserves signed values and diagnostics strip URL credentials", () => {
@@ -550,4 +636,42 @@ function fixtureManifest(marker: string): WorkspaceCaptureManifest {
 
 function hash(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+function captureApiRegionalProbeRequest(): CaptureApiRegionalProbeRequest {
+  return {
+    schemaVersion: "opengeni/workbench-capture-api-regional-probe-request/v1",
+    apiUrl: "https://app.example.com",
+    environment: "production",
+    sourceSha: "a".repeat(40),
+    runId: "production-12345-1",
+    workspaceId: "11111111-1111-4111-8111-111111111111",
+    sessionId: "22222222-2222-4222-8222-222222222222",
+    captureRevision: 7,
+    captureTurnId: "33333333-3333-4333-8333-333333333333",
+    repetitions: 100,
+    region: "northeurope",
+    apiImage: `registry.example.com/opengeni-api:candidate-${"a".repeat(40)}@sha256:${"b".repeat(64)}`,
+    cookieHeader: "better-auth.session_token=secret-cookie",
+  };
+}
+
+function captureApiRegionalProbeResult(request: CaptureApiRegionalProbeRequest) {
+  return {
+    schemaVersion: "opengeni/workbench-capture-api-regional-probe/v1" as const,
+    apiOrigin: new URL(request.apiUrl).origin,
+    environment: request.environment,
+    sourceSha: request.sourceSha,
+    runId: request.runId,
+    workspaceId: request.workspaceId,
+    sessionId: request.sessionId,
+    captureRevision: request.captureRevision,
+    captureTurnId: request.captureTurnId,
+    sampleCount: request.repetitions,
+    region: request.region,
+    apiImage: request.apiImage,
+    decodedBytes: 4096,
+    contentEncoding: "gzip" as const,
+    samplesMs: Array(request.repetitions).fill(12.5),
+  };
 }

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -60,6 +60,43 @@ export type LiveAcceptanceArgs = {
   repetitions: number;
   sessionTimeoutMs: number;
   coldTimeoutMs: number;
+  captureApiRegionProbeCommand: string;
+  captureApiRegion: string;
+  captureApiImage: string;
+};
+
+export type CaptureApiRegionalProbeRequest = {
+  schemaVersion: "opengeni/workbench-capture-api-regional-probe-request/v1";
+  apiUrl: string;
+  environment: "staging" | "production";
+  sourceSha: string;
+  runId: string;
+  workspaceId: string;
+  sessionId: string;
+  captureRevision: number;
+  captureTurnId: string;
+  repetitions: number;
+  region: string;
+  apiImage: string;
+  cookieHeader: string;
+};
+
+export type CaptureApiRegionalProbeResult = {
+  schemaVersion: "opengeni/workbench-capture-api-regional-probe/v1";
+  apiOrigin: string;
+  environment: "staging" | "production";
+  sourceSha: string;
+  runId: string;
+  workspaceId: string;
+  sessionId: string;
+  captureRevision: number;
+  captureTurnId: string;
+  sampleCount: number;
+  region: string;
+  apiImage: string;
+  decodedBytes: number;
+  contentEncoding: "gzip";
+  samplesMs: number[];
 };
 
 type Check = {
@@ -100,6 +137,10 @@ type LiveReceipt = {
   sessionId: string;
   captureRevision: number;
   captureStats: WorkspaceCaptureManifest["stats"];
+  captureApiRegionProbe: Omit<
+    CaptureApiRegionalProbeResult,
+    "workspaceId" | "sessionId" | "captureRevision" | "samplesMs"
+  >;
   checks: Check[];
   measurements: {
     captureApiResponse: Measurement;
@@ -137,6 +178,9 @@ export function parseLiveAcceptanceArgs(argv: string[]): LiveAcceptanceArgs {
     "--repetitions",
     "--session-timeout-ms",
     "--cold-timeout-ms",
+    "--capture-api-region-probe-command",
+    "--capture-api-region",
+    "--capture-api-image",
   ]);
   for (const flag of values.keys()) if (!allowed.has(flag)) throw new Error(`unknown flag ${flag}`);
 
@@ -155,6 +199,18 @@ export function parseLiveAcceptanceArgs(argv: string[]): LiveAcceptanceArgs {
   const backend = values.get("--backend") ?? "modal";
   if (backend !== "modal") throw new Error("live workbench acceptance requires --backend modal");
   const repetitions = integer(values.get("--repetitions") ?? "100", "--repetitions", 100);
+  const captureApiRegionProbeCommand = required(values, "--capture-api-region-probe-command");
+  if (/\0|[\r\n]/.test(captureApiRegionProbeCommand)) {
+    throw new Error("--capture-api-region-probe-command is invalid");
+  }
+  const captureApiRegion = required(values, "--capture-api-region");
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(captureApiRegion)) {
+    throw new Error("--capture-api-region must be a lowercase deployment region");
+  }
+  const captureApiImage = required(values, "--capture-api-image");
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:/-]*@sha256:[0-9a-f]{64}$/.test(captureApiImage)) {
+    throw new Error("--capture-api-image must be a digest-pinned image reference");
+  }
   return {
     apiUrl,
     webUrl,
@@ -176,6 +232,9 @@ export function parseLiveAcceptanceArgs(argv: string[]): LiveAcceptanceArgs {
       "--cold-timeout-ms",
       60_000,
     ),
+    captureApiRegionProbeCommand: resolve(captureApiRegionProbeCommand),
+    captureApiRegion,
+    captureApiImage,
   };
 }
 
@@ -335,12 +394,25 @@ async function main(): Promise<void> {
   await waitForCold(cookieClient, workspaceId, session.id, args.coldTimeoutMs);
   pass(checks, "functional.real-cold-lease", "The real Modal lease reached cold before UI review.");
 
-  const captureApiSamples = await measureCaptureApi(
-    cookieClient,
-    workspaceId,
-    session.id,
-    args.repetitions,
+  const captureApiRegionProbe = await runCaptureApiRegionalProbe(
+    args.captureApiRegionProbeCommand,
+    {
+      schemaVersion: "opengeni/workbench-capture-api-regional-probe-request/v1",
+      apiUrl: args.apiUrl,
+      environment: args.environment,
+      sourceSha: args.sourceSha,
+      runId: args.runId,
+      workspaceId,
+      sessionId: session.id,
+      captureRevision: manifest.revision,
+      captureTurnId: manifest.turnId,
+      repetitions: args.repetitions,
+      region: args.captureApiRegion,
+      apiImage: args.captureApiImage,
+      cookieHeader,
+    },
   );
+  const captureApiSamples = captureApiRegionProbe.samplesMs;
   const captureApiResponse = measurement(captureApiSamples);
   if (captureApiResponse.p95 > CAPTURE_API_P95_MS) {
     throw new Error(`capture API p95 ${captureApiResponse.p95}ms exceeds ${CAPTURE_API_P95_MS}ms`);
@@ -459,6 +531,19 @@ async function main(): Promise<void> {
     sessionId: session.id,
     captureRevision: manifest.revision,
     captureStats: manifest.stats,
+    captureApiRegionProbe: {
+      schemaVersion: captureApiRegionProbe.schemaVersion,
+      apiOrigin: captureApiRegionProbe.apiOrigin,
+      environment: captureApiRegionProbe.environment,
+      sourceSha: captureApiRegionProbe.sourceSha,
+      runId: captureApiRegionProbe.runId,
+      captureTurnId: captureApiRegionProbe.captureTurnId,
+      sampleCount: captureApiRegionProbe.sampleCount,
+      region: captureApiRegionProbe.region,
+      apiImage: captureApiRegionProbe.apiImage,
+      decodedBytes: captureApiRegionProbe.decodedBytes,
+      contentEncoding: captureApiRegionProbe.contentEncoding,
+    },
     checks,
     measurements: { captureApiResponse, captureUsableWorkbench, controlCancellation },
     artifacts,
@@ -1738,20 +1823,149 @@ async function waitForCaptureTurn(
   throw new Error("replacement turn capture did not become authoritative before timeout");
 }
 
-async function measureCaptureApi(
-  client: OpenGeniClient,
-  workspaceId: string,
-  sessionId: string,
-  repetitions: number,
-): Promise<number[]> {
-  const samples: number[] = [];
-  for (let index = 0; index < repetitions; index += 1) {
-    const started = performance.now();
-    const response = await client.getWorkspaceCapture(workspaceId, sessionId);
-    samples.push(performance.now() - started);
-    if (!response.available) throw new Error(`capture disappeared during repetition ${index}`);
+export async function runCaptureApiRegionalProbe(
+  command: string,
+  request: CaptureApiRegionalProbeRequest,
+): Promise<CaptureApiRegionalProbeResult> {
+  const child = Bun.spawn([process.execPath, command], {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: captureApiRegionalProbeEnvironment(process.env),
+  });
+  const timeout = setTimeout(() => child.kill(), 300_000);
+  timeout.unref();
+  child.stdin.write(JSON.stringify(request));
+  child.stdin.end();
+  let stdout: string;
+  let stderr: string;
+  let exitCode: number;
+  try {
+    [stdout, stderr, exitCode] = await Promise.all([
+      readBoundedText(child.stdout, 256 * 1024, "capture API regional probe output"),
+      readBoundedText(child.stderr, 256 * 1024, "capture API regional probe diagnostics"),
+      child.exited,
+    ]);
+  } catch (error) {
+    child.kill();
+    await child.exited.catch(() => undefined);
+    throw error;
+  } finally {
+    clearTimeout(timeout);
   }
-  return samples;
+  if (exitCode !== 0) {
+    const safe = sanitizeDiagnostic(stderr.replaceAll(request.cookieHeader, "[redacted]")).slice(
+      0,
+      512,
+    );
+    throw new Error(
+      `capture API regional probe failed with exit code ${exitCode}${safe ? `: ${safe}` : ""}`,
+    );
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(stdout);
+  } catch {
+    throw new Error("capture API regional probe did not return one JSON object");
+  }
+  return validateCaptureApiRegionalProbeResult(value, request);
+}
+
+export function captureApiRegionalProbeEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(environment).filter(
+      (entry): entry is [string, string] =>
+        entry[1] !== undefined && !entry[0].startsWith("OPENGENI_ACCEPTANCE_"),
+    ),
+  );
+}
+
+async function readBoundedText(
+  stream: ReadableStream<Uint8Array>,
+  maximumBytes: number,
+  label: string,
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      bytes += next.value.byteLength;
+      if (bytes > maximumBytes) throw new Error(`${label} exceeded 256 KiB`);
+      text += decoder.decode(next.value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export function validateCaptureApiRegionalProbeResult(
+  value: unknown,
+  request: CaptureApiRegionalProbeRequest,
+): CaptureApiRegionalProbeResult {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("capture API regional probe result is not an object");
+  }
+  const result = value as Record<string, unknown>;
+  const expectedKeys = [
+    "apiImage",
+    "apiOrigin",
+    "captureRevision",
+    "captureTurnId",
+    "contentEncoding",
+    "decodedBytes",
+    "environment",
+    "region",
+    "runId",
+    "sampleCount",
+    "samplesMs",
+    "schemaVersion",
+    "sessionId",
+    "sourceSha",
+    "workspaceId",
+  ];
+  if (JSON.stringify(Object.keys(result).sort()) !== JSON.stringify(expectedKeys)) {
+    throw new Error("capture API regional probe result fields are invalid");
+  }
+  const exact: Array<[keyof CaptureApiRegionalProbeResult, unknown]> = [
+    ["schemaVersion", "opengeni/workbench-capture-api-regional-probe/v1"],
+    ["apiOrigin", new URL(request.apiUrl).origin],
+    ["environment", request.environment],
+    ["sourceSha", request.sourceSha],
+    ["runId", request.runId],
+    ["workspaceId", request.workspaceId],
+    ["sessionId", request.sessionId],
+    ["captureRevision", request.captureRevision],
+    ["captureTurnId", request.captureTurnId],
+    ["sampleCount", request.repetitions],
+    ["region", request.region],
+    ["apiImage", request.apiImage],
+    ["contentEncoding", "gzip"],
+  ];
+  for (const [key, expected] of exact) {
+    if (result[key] !== expected) throw new Error(`capture API regional probe ${key} mismatch`);
+  }
+  if (!Number.isSafeInteger(result.decodedBytes) || Number(result.decodedBytes) < 1) {
+    throw new Error("capture API regional probe decoded byte count is invalid");
+  }
+  if (!Array.isArray(result.samplesMs) || result.samplesMs.length !== request.repetitions) {
+    throw new Error("capture API regional probe sample count mismatch");
+  }
+  if (
+    result.samplesMs.some(
+      (sample) =>
+        typeof sample !== "number" || !Number.isFinite(sample) || sample <= 0 || sample > 60_000,
+    )
+  ) {
+    throw new Error("capture API regional probe samples are invalid");
+  }
+  return result as CaptureApiRegionalProbeResult;
 }
 
 async function expectApiRejection(


### PR DESCRIPTION
## Summary
- delegate the capture API performance row to a protected operator probe in the deployment region
- bind the sanitized result to the exact source, run, workspace/session/capture identity, region, and digest-pinned API image
- keep the 200 ms p95 contract unchanged while preventing canary credentials from entering the child environment
- bump the application chart to 0.22.56

## Why
The generic GitHub-hosted runner is not region-bound and produced false release failures even though the same public-ingress endpoint measured well below budget from North Europe, where the deployment runs. This makes the existing contract measure the documented deployment-region path without changing runtime behavior or thresholds.

## Verification
- `bun test scripts/workbench-live-acceptance.test.ts` (18 pass)
- `bun run typecheck` (23 projects clean)
- `bun scripts/check-public-repo-hygiene.ts`
- `bunx oxfmt --check scripts/workbench-live-acceptance.ts scripts/workbench-live-acceptance.test.ts docs/workbench-acceptance.md deploy/helm/opengeni/Chart.yaml`
- package, SDK, React, demo, web, and Northstar builds passed before the final no-behavior hardening edit; exact-head CI is required before merge
