### PR TITLE
chore(release): advance product version to 0.22.57

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.56
-appVersion: "0.22.56"
+version: 0.22.57
+appVersion: "0.22.57"


### PR DESCRIPTION
## Summary
- advance the Helm product version from 0.22.56 to 0.22.57
- reserve a fresh immutable release identity for the merged regional capture acceptance fix
- keep runtime, API, SDK, React, demo, transport, provider, prompt, context, UI, copy, animation, and styling behavior unchanged

The prior 0.22.56 train was checksummed-blocked before staging deployment after being superseded by source `12fc0c6679ddcbfb2762927242f23eda507b8e3f`.

## Verification
- `git diff --check`
- `helm lint deploy/helm/opengeni`
- `helm package deploy/helm/opengeni` (produced `opengeni-0.22.57.tgz`)
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml` → `0.22.57`
