### PR TITLE
chore(release): advance product version to 0.22.58

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.57
-appVersion: "0.22.57"
+version: 0.22.58
+appVersion: "0.22.58"


### PR DESCRIPTION
Advances the Helm chart and application version together to a fresh immutable product release version.

Validation:
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `helm lint deploy/helm/opengeni`
- `git diff --check`