### PR TITLE
chore(release): advance product version to 0.22.59

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.58
-appVersion: "0.22.58"
+version: 0.22.59
+appVersion: "0.22.59"


### PR DESCRIPTION
Advance the immutable OpenGeni product release version after the latest admitted source and package-version update.