### PR TITLE
Polish session chrome, apply_patch UI, and realtime voice handoff

### DIFF
--- a/.changeset/session-chrome-apply-patch-realtime.md
+++ b/.changeset/session-chrome-apply-patch-realtime.md
@@ -1,0 +1,11 @@
+---
+"@opengeni/react": patch
+"@opengeni/sdk": patch
+"@opengeni/db": patch
+"@opengeni/config": patch
+"@opengeni/contracts": patch
+---
+
+Polish session chrome and apply_patch rendering; clarify realtime voice-end handoff.
+
+SessionChrome gets denser selected-chip UX and Codex function-tool apply_patch shapes render in the specialized diff UI. Solo goal_continuation machine-input rows are suppressed in favor of the GoalRow landmark. The realtime transcript-tail instruction now keeps in-flight work going after voice ends.

--- a/apps/api/src/model-catalog.ts
+++ b/apps/api/src/model-catalog.ts
@@ -50,6 +50,7 @@ export function projectClientModel(model: ConfiguredModel): ClientModel {
   return ClientModel.parse({
     id: model.id,
     label: model.label,
+    ...(model.shortLabel ? { shortLabel: model.shortLabel } : {}),
     ...publicProvider,
     source,
     api: model.api,

--- a/apps/web/src/components/Composer.tsx
+++ b/apps/web/src/components/Composer.tsx
@@ -37,6 +37,8 @@ export function ConsoleComposer(props: {
   actions?: ReactNode;
   commandContext?: SlashCommandContext;
   onClearView?: () => void;
+  /** Soft-hide dictate while realtime voice is active. */
+  transcriptionSuppressed?: boolean;
 }) {
   const context = useAppContext();
   const workspace = context.workspaces.find((candidate) => candidate.id === props.workspaceId);
@@ -59,6 +61,7 @@ export function ConsoleComposer(props: {
       attachButtonClassName="max-sm:hidden"
       controlsStart={props.controls}
       actionsStart={props.actions}
+      transcriptionSuppressed={props.transcriptionSuppressed === true}
       {...(context.clientConfig.voiceInput?.available
         ? {
             transcription: {

--- a/apps/web/src/components/composer-mobile-plus.tsx
+++ b/apps/web/src/components/composer-mobile-plus.tsx
@@ -7,7 +7,7 @@ import {
   PlugIcon,
   PlusIcon,
 } from "lucide-react";
-import { useState, type ReactNode } from "react";
+import { cloneElement, isValidElement, useState, type ReactElement, type ReactNode } from "react";
 
 import {
   SessionToolsMenuBody,
@@ -42,13 +42,15 @@ export function ComposerMobilePlus(props: {
   repositories?: {
     selectedCount: number;
     disabled?: boolean;
-    renderBody: (leading: ReactNode) => ReactNode;
+    /** Panel element; receives `leading` (back control) via clone. */
+    panel: ReactElement<{ leading?: ReactNode }>;
   };
   /** When set, Voice model appears under + (bar keeps a start-only control). */
   voiceModel?: {
     selectedLabel: string;
     disabled?: boolean;
-    renderBody: (leading: ReactNode) => ReactNode;
+    /** Panel element; receives `leading` (back control) via clone. */
+    panel: ReactElement<{ leading?: ReactNode }>;
   };
 }) {
   const [open, setOpen] = useState(false);
@@ -188,11 +190,21 @@ export function ComposerMobilePlus(props: {
             leading={backButton}
           />
         ) : panel === "repos" && repositories ? (
-          repositories.renderBody(backButton)
+          withLeading(repositories.panel, backButton)
         ) : panel === "voice" && voiceModel ? (
-          voiceModel.renderBody(backButton)
+          withLeading(voiceModel.panel, backButton)
         ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );
+}
+
+function withLeading(
+  panel: ReactElement<{ leading?: ReactNode }>,
+  leading: ReactNode,
+): ReactElement {
+  if (!isValidElement(panel)) {
+    throw new Error("ComposerMobilePlus panel must be a valid React element");
+  }
+  return cloneElement(panel, { leading });
 }

--- a/apps/web/src/components/composer-mobile-plus.tsx
+++ b/apps/web/src/components/composer-mobile-plus.tsx
@@ -1,6 +1,13 @@
 import type { FirstPartyMcpToolName } from "@opengeni/contracts";
-import { ChevronLeftIcon, PaperclipIcon, PlugIcon, PlusIcon } from "lucide-react";
-import { useState } from "react";
+import {
+  AudioLinesIcon,
+  ChevronLeftIcon,
+  GitBranchIcon,
+  PaperclipIcon,
+  PlugIcon,
+  PlusIcon,
+} from "lucide-react";
+import { useState, type ReactNode } from "react";
 
 import {
   SessionToolsMenuBody,
@@ -14,14 +21,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { repoCountLabel } from "@/lib/format";
 import type { McpServerOption } from "@/lib/session-tools";
 
-type Panel = "root" | "tools";
+type Panel = "root" | "tools" | "repos" | "voice";
 
 /**
- * Mobile-only “+” overflow. Attach + tools live here so the bar stays one row.
- * Tools drill in inside this same menu (anchored to +) — never a second floating
- * menu tied to a hidden desktop trigger.
+ * Mobile-only “+” overflow. Attach, tools, repositories, and voice model live
+ * here so the bar stays one compact row.
  */
 export function ComposerMobilePlus(props: {
   disabled?: boolean;
@@ -31,6 +38,18 @@ export function ComposerMobilePlus(props: {
   selection: SessionToolSelection;
   toolsDisabled?: boolean;
   onToolSelectionChange: (selection: SessionToolSelection) => void;
+  /** When set, Repositories appears under + and opens a drill-in panel. */
+  repositories?: {
+    selectedCount: number;
+    disabled?: boolean;
+    renderBody: (leading: ReactNode) => ReactNode;
+  };
+  /** When set, Voice model appears under + (bar keeps a start-only control). */
+  voiceModel?: {
+    selectedLabel: string;
+    disabled?: boolean;
+    renderBody: (leading: ReactNode) => ReactNode;
+  };
 }) {
   const [open, setOpen] = useState(false);
   const [panel, setPanel] = useState<Panel>("root");
@@ -42,6 +61,22 @@ export function ComposerMobilePlus(props: {
   );
   const toolsSelected = visible.mcpServerIds.size + visible.firstPartyToolIds.size;
   const toolsAvailable = toolsTotal > 0;
+  const repositories = props.repositories;
+  const voiceModel = props.voiceModel;
+
+  const backButton = (
+    <button
+      type="button"
+      aria-label="Back"
+      className="mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-md text-fg-muted hover:bg-surface-2 hover:text-fg"
+      onClick={(event) => {
+        event.preventDefault();
+        setPanel("root");
+      }}
+    >
+      <ChevronLeftIcon className="size-4" />
+    </button>
+  );
 
   return (
     <DropdownMenu
@@ -69,9 +104,11 @@ export function ComposerMobilePlus(props: {
         sideOffset={8}
         collisionPadding={12}
         className={
-          panel === "tools"
+          panel === "tools" || panel === "voice"
             ? "flex w-[min(20rem,calc(100vw-1.5rem))] max-h-[min(24rem,var(--radix-dropdown-menu-content-available-height))] flex-col overflow-hidden rounded-xl p-2"
-            : "min-w-52 rounded-xl"
+            : panel === "repos"
+              ? "flex w-[min(28rem,calc(100vw-1.5rem))] max-h-[min(32rem,var(--radix-dropdown-menu-content-available-height))] flex-col overflow-hidden rounded-xl p-0"
+              : "min-w-52 rounded-xl"
         }
       >
         {panel === "root" ? (
@@ -107,28 +144,54 @@ export function ComposerMobilePlus(props: {
                 </span>
               </DropdownMenuItem>
             ) : null}
+            {repositories ? (
+              <DropdownMenuItem
+                className="pointer-coarse:min-h-11"
+                disabled={props.disabled || repositories.disabled}
+                onSelect={(event) => {
+                  event.preventDefault();
+                  setPanel("repos");
+                }}
+              >
+                <GitBranchIcon className="size-4" />
+                Repositories
+                <span className="ml-auto text-2xs text-fg-subtle">
+                  {repositories.selectedCount > 0
+                    ? repoCountLabel(repositories.selectedCount)
+                    : "Optional"}
+                </span>
+              </DropdownMenuItem>
+            ) : null}
+            {voiceModel ? (
+              <DropdownMenuItem
+                className="pointer-coarse:min-h-11"
+                disabled={props.disabled || voiceModel.disabled}
+                onSelect={(event) => {
+                  event.preventDefault();
+                  setPanel("voice");
+                }}
+              >
+                <AudioLinesIcon className="size-4" />
+                Voice model
+                <span className="ml-auto max-w-[7rem] truncate text-2xs text-fg-subtle">
+                  {voiceModel.selectedLabel}
+                </span>
+              </DropdownMenuItem>
+            ) : null}
           </>
-        ) : (
+        ) : panel === "tools" ? (
           <SessionToolsMenuBody
             servers={props.servers}
             firstPartyTools={props.firstPartyTools}
             selection={props.selection}
             onChange={props.onToolSelectionChange}
-            leading={
-              <button
-                type="button"
-                aria-label="Back"
-                className="mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-md text-fg-muted hover:bg-surface-2 hover:text-fg"
-                onClick={(event) => {
-                  event.preventDefault();
-                  setPanel("root");
-                }}
-              >
-                <ChevronLeftIcon className="size-4" />
-              </button>
-            }
+            leading={backButton}
           />
-        )}
+        ) : panel === "repos" && repositories ? (
+          repositories.renderBody(backButton)
+        ) : panel === "voice" && voiceModel ? (
+          voiceModel.renderBody(backButton)
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/src/components/repository-picker.tsx
+++ b/apps/web/src/components/repository-picker.tsx
@@ -11,7 +11,7 @@ import {
   Trash2Icon,
   XIcon,
 } from "lucide-react";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -103,7 +103,7 @@ export function repositoryBindingPresentation(
   };
 }
 
-export function RepositoryContextPicker(props: {
+export type RepositoryContextPickerProps = {
   setupMode: GitHubAppSetupMode;
   configured: boolean;
   status: GitHubBindingStatus;
@@ -133,7 +133,14 @@ export function RepositoryContextPicker(props: {
   onOrgChange: (value: string) => void;
   onStartGitHubApp: () => void;
   onDisconnectInstallation: (installationId: number) => Promise<void>;
-}) {
+  /** Optional back control when embedded in the mobile “+” drill-in. */
+  leading?: ReactNode;
+  /** Extra classes on the bar trigger (e.g. `max-sm:hidden` when opened from +). */
+  triggerClassName?: string;
+};
+
+/** Shared picker body — desktop dropdown and mobile “+” drill-in. */
+export function RepositoryContextMenuBody(props: RepositoryContextPickerProps) {
   const selectedInstalledCount = props.selectedRepoIds.size;
   const manualCount = props.manualRepos.filter((repo) => repo.url.trim().length > 0).length;
   const selectedCount = selectedInstalledCount + manualCount;
@@ -302,6 +309,313 @@ export function RepositoryContextPicker(props: {
   );
 
   return (
+    <div onKeyDown={(event) => event.stopPropagation()} className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-3 py-2.5">
+        <div className="flex min-w-0 items-start gap-1">
+          {props.leading}
+          <div className="min-w-0">
+            <div className="truncate text-sm font-medium text-fg">Repository context</div>
+            <div className="mt-0.5 truncate text-2xs text-fg-subtle">
+              {selectedCount > 0
+                ? `${repoCountLabel(selectedCount)} selected for this session`
+                : "Optional repositories for the sandbox"}
+            </div>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          onClick={() => void props.onRefresh()}
+          disabled={!bindingPresentation.canRefresh || props.repoBusy}
+          aria-label="Refresh repositories"
+          className="size-7"
+        >
+          <RefreshCwIcon className={cn("size-3.5", props.repoBusy && "animate-spin")} />
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain max-h-[min(calc(var(--radix-dropdown-menu-content-available-height,70vh)-3.5rem),620px)]">
+        <div className="space-y-2.5 p-2.5">
+          {props.status === "disabled" ? (
+            <div className="space-y-3">
+              <EmptyState
+                icon={<GitBranchIcon className="size-5" />}
+                title="No repositories connected"
+                description={bindingPresentation.emptyDescription}
+              />
+              <div className="px-1 pt-1">{setupForm}</div>
+            </div>
+          ) : props.repoBusy ? (
+            <div className="flex items-center gap-2 rounded-lg border border-border bg-bg/25 p-3 text-xs text-fg-muted">
+              <Loader2Icon className="size-3.5 animate-spin" />
+              Loading repositories…
+            </div>
+          ) : !hasRepos ? (
+            <div className="space-y-3">
+              <EmptyState
+                icon={<GitBranchIcon className="size-5" />}
+                title="No repositories connected"
+                description={bindingPresentation.emptyDescription}
+              />
+              {props.setupMode === "platform" ? (
+                <div className="px-1 pt-1">{setupForm}</div>
+              ) : (
+                settingsDisclosure
+              )}
+            </div>
+          ) : (
+            <>
+              <div className="flex items-center justify-between gap-2 px-1 py-0.5">
+                <div className="flex min-w-0 items-center gap-2">
+                  <MetaChip dot="idle" rounded="full">
+                    GitHub app
+                  </MetaChip>
+                  {props.org ? (
+                    <span className="min-w-0 truncate text-2xs text-fg-subtle" title={props.org}>
+                      {props.org}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+
+              <section className="overflow-hidden rounded-lg border border-border bg-bg/25">
+                <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2">
+                  <div className="min-w-0 truncate text-xs font-medium text-fg">Repositories</div>
+                  <div className="shrink-0 text-2xs text-fg-subtle">
+                    {props.repositories.length} available
+                  </div>
+                </div>
+                <div>
+                  {props.groups.map((group) => (
+                    <div
+                      key={group.installationId}
+                      className="border-b border-border last:border-b-0"
+                    >
+                      <div className="flex items-center justify-between gap-3 bg-surface/45 px-3 py-1.5">
+                        <div className="min-w-0 truncate text-2xs font-medium text-fg-muted">
+                          {group.label}
+                        </div>
+                        <div className="shrink-0 text-2xs uppercase tracking-wide text-fg-subtle">
+                          {group.repositories.length} repos
+                        </div>
+                      </div>
+                      <div className="divide-y divide-border/70">
+                        {group.repositories.map((repo) => {
+                          const checked = props.selectedRepoIds.has(repo.id);
+                          const blocked =
+                            props.selectedInstallationId !== null &&
+                            props.selectedInstallationId !== repo.installationId &&
+                            !checked;
+                          return (
+                            <div
+                              key={`${repo.installationId}:${repo.id}`}
+                              className={cn(
+                                "px-2 py-2 transition-colors hover:bg-surface-2/45",
+                                blocked && "opacity-55",
+                              )}
+                            >
+                              <button
+                                type="button"
+                                onClick={() => props.onToggleRepo(repo)}
+                                disabled={props.pending}
+                                aria-pressed={checked}
+                                aria-label={`Select ${repo.fullName}`}
+                                className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md text-left outline-none"
+                              >
+                                <span
+                                  className={cn(
+                                    "flex size-4 items-center justify-center rounded border",
+                                    checked
+                                      ? "border-brand bg-brand-strong text-brand-fg"
+                                      : "border-border-strong bg-surface",
+                                  )}
+                                >
+                                  {checked ? <CheckIcon className="size-3" /> : null}
+                                </span>
+                                <span className="min-w-0">
+                                  <span className="flex min-w-0 items-center gap-1.5">
+                                    <span className="truncate text-xs font-medium text-fg">
+                                      {repo.fullName}
+                                    </span>
+                                    {repo.private ? (
+                                      <LockIcon className="size-3 shrink-0 text-fg-subtle" />
+                                    ) : null}
+                                  </span>
+                                  <span className="mt-0.5 block truncate text-2xs text-fg-subtle">
+                                    default {repo.defaultBranch}
+                                  </span>
+                                </span>
+                                {blocked ? (
+                                  <MetaChip dot="waiting" rounded="full">
+                                    Other app
+                                  </MetaChip>
+                                ) : checked ? (
+                                  <MetaChip dot="idle" rounded="full">
+                                    Selected
+                                  </MetaChip>
+                                ) : null}
+                              </button>
+                              {checked ? (
+                                <div className="mt-2 flex items-center gap-2 pl-6">
+                                  <GitBranchIcon className="size-3.5 shrink-0 text-fg-subtle" />
+                                  <Input
+                                    value={props.selectedRepoRefs[repo.id] ?? repo.defaultBranch}
+                                    onChange={(event) =>
+                                      props.onRefChange(repo.id, event.target.value)
+                                    }
+                                    onClick={(event) => event.stopPropagation()}
+                                    disabled={props.pending}
+                                    placeholder={repo.defaultBranch}
+                                    aria-label={`${repo.fullName} ref`}
+                                    className="h-7 text-xs"
+                                  />
+                                </div>
+                              ) : null}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+
+              {settingsDisclosure}
+            </>
+          )}
+
+          <Collapsible open={props.manualOpen} onOpenChange={props.onManualOpenChange}>
+            <div className="border-t border-border/60 pt-1">
+              <div className="flex items-center justify-between gap-2 px-3 py-2">
+                <CollapsibleTrigger asChild>
+                  <button
+                    type="button"
+                    className="flex min-w-0 flex-1 items-center gap-2 rounded-md text-left text-xs font-medium text-fg"
+                  >
+                    <ChevronDownIcon
+                      className={cn(
+                        "size-3.5 shrink-0 text-fg-subtle transition-transform",
+                        props.manualOpen && "rotate-180",
+                      )}
+                    />
+                    <span className="truncate">Add by URL</span>
+                    {manualCount > 0 ? <MetaChip rounded="full">{manualCount}</MetaChip> : null}
+                  </button>
+                </CollapsibleTrigger>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  onClick={props.onManualAdd}
+                  disabled={props.pending}
+                  className="h-7 text-xs"
+                >
+                  <PlusIcon className="size-3" />
+                  Add
+                </Button>
+              </div>
+
+              <CollapsibleContent>
+                <div className="space-y-2 border-t border-border p-3">
+                  {props.manualRepos.length === 0 ? (
+                    <p className="text-xs leading-5 text-fg-muted">
+                      Add HTTPS Git repositories that don't use the GitHub app token.
+                    </p>
+                  ) : (
+                    props.manualRepos.map((repo) => (
+                      <div
+                        key={repo.id}
+                        className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_7rem_auto]"
+                      >
+                        <Input
+                          value={repo.url}
+                          onChange={(event) =>
+                            props.onManualUpdate(repo.id, { url: event.target.value })
+                          }
+                          disabled={props.pending}
+                          placeholder="https://github.com/org/repo"
+                          className="h-8 text-xs"
+                        />
+                        <div className="relative">
+                          <GitBranchIcon className="pointer-events-none absolute left-2.5 top-2 size-3.5 text-fg-subtle" />
+                          <Input
+                            value={repo.ref}
+                            onChange={(event) =>
+                              props.onManualUpdate(repo.id, { ref: event.target.value })
+                            }
+                            disabled={props.pending}
+                            placeholder="main"
+                            className="h-8 pl-7 text-xs"
+                          />
+                        </div>
+                        {confirmRemoveId === repo.id ? (
+                          <div className="flex items-center gap-1">
+                            <Button
+                              type="button"
+                              variant="destructive"
+                              size="icon-sm"
+                              onClick={() => {
+                                props.onManualRemove(repo.id);
+                                setConfirmRemoveId(null);
+                              }}
+                              disabled={props.pending}
+                              aria-label="Confirm remove repository"
+                              title="Remove"
+                              className="size-8"
+                            >
+                              <CheckIcon className="size-3.5" />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() => setConfirmRemoveId(null)}
+                              aria-label="Keep repository"
+                              title="Cancel"
+                              className="size-8"
+                            >
+                              <XIcon className="size-3.5" />
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={() => setConfirmRemoveId(repo.id)}
+                            disabled={props.pending}
+                            aria-label="Remove repository"
+                            title="Remove"
+                            className="size-8"
+                          >
+                            <Trash2Icon className="size-3.5" />
+                          </Button>
+                        )}
+                      </div>
+                    ))
+                  )}
+                </div>
+              </CollapsibleContent>
+            </div>
+          </Collapsible>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function RepositoryContextPicker(props: RepositoryContextPickerProps) {
+  const selectedInstalledCount = props.selectedRepoIds.size;
+  const manualCount = props.manualRepos.filter((repo) => repo.url.trim().length > 0).length;
+  const selectedCount = selectedInstalledCount + manualCount;
+  const bindingPresentation = repositoryBindingPresentation(
+    props.status,
+    props.installUrl,
+    props.setupMode,
+  );
+
+  return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
@@ -314,6 +628,7 @@ export function RepositoryContextPicker(props: {
             "h-8 max-w-[13rem] gap-1.5 rounded-full border border-transparent px-2.5 text-xs",
             "text-fg-muted hover:border-border hover:bg-surface-2 hover:text-fg",
             selectedCount > 0 && "border-brand/35 bg-brand/10 text-fg",
+            props.triggerClassName,
           )}
         >
           <GitBranchIcon className="size-3.5" />
@@ -335,305 +650,9 @@ export function RepositoryContextPicker(props: {
         align="start"
         side="top"
         sideOffset={8}
-        className="w-[min(560px,calc(100vw-2rem))] overflow-hidden rounded-xl border-border bg-surface p-0 shadow-2xl"
+        className="flex w-[min(560px,calc(100vw-2rem))] max-h-[min(70vh,var(--radix-dropdown-menu-content-available-height))] flex-col overflow-hidden rounded-xl border-border bg-surface p-0 shadow-2xl"
       >
-        <div onKeyDown={(event) => event.stopPropagation()}>
-          <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2.5">
-            <div className="min-w-0">
-              <div className="truncate text-sm font-medium text-fg">Repository context</div>
-              <div className="mt-0.5 truncate text-2xs text-fg-subtle">
-                {selectedCount > 0
-                  ? `${repoCountLabel(selectedCount)} selected for this session`
-                  : "Optional repositories for the sandbox"}
-              </div>
-            </div>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              onClick={() => void props.onRefresh()}
-              disabled={!bindingPresentation.canRefresh || props.repoBusy}
-              aria-label="Refresh repositories"
-              className="size-7"
-            >
-              <RefreshCwIcon className={cn("size-3.5", props.repoBusy && "animate-spin")} />
-            </Button>
-          </div>
-
-          <div className="max-h-[min(calc(var(--radix-dropdown-menu-content-available-height,70vh)-3.5rem),620px)] overflow-y-auto overscroll-contain">
-            <div className="space-y-2.5 p-2.5">
-              {props.status === "disabled" ? (
-                <div className="space-y-3">
-                  <EmptyState
-                    icon={<GitBranchIcon className="size-5" />}
-                    title="No repositories connected"
-                    description={bindingPresentation.emptyDescription}
-                  />
-                  <div className="px-1 pt-1">{setupForm}</div>
-                </div>
-              ) : props.repoBusy ? (
-                <div className="flex items-center gap-2 rounded-lg border border-border bg-bg/25 p-3 text-xs text-fg-muted">
-                  <Loader2Icon className="size-3.5 animate-spin" />
-                  Loading repositories…
-                </div>
-              ) : !hasRepos ? (
-                <div className="space-y-3">
-                  <EmptyState
-                    icon={<GitBranchIcon className="size-5" />}
-                    title="No repositories connected"
-                    description={bindingPresentation.emptyDescription}
-                  />
-                  {props.setupMode === "platform" ? (
-                    <div className="px-1 pt-1">{setupForm}</div>
-                  ) : (
-                    settingsDisclosure
-                  )}
-                </div>
-              ) : (
-                <>
-                  <div className="flex items-center justify-between gap-2 px-1 py-0.5">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <MetaChip dot="idle" rounded="full">
-                        GitHub app
-                      </MetaChip>
-                      {props.org ? (
-                        <span
-                          className="min-w-0 truncate text-2xs text-fg-subtle"
-                          title={props.org}
-                        >
-                          {props.org}
-                        </span>
-                      ) : null}
-                    </div>
-                  </div>
-
-                  <section className="overflow-hidden rounded-lg border border-border bg-bg/25">
-                    <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2">
-                      <div className="min-w-0 truncate text-xs font-medium text-fg">
-                        Repositories
-                      </div>
-                      <div className="shrink-0 text-2xs text-fg-subtle">
-                        {props.repositories.length} available
-                      </div>
-                    </div>
-                    <div>
-                      {props.groups.map((group) => (
-                        <div
-                          key={group.installationId}
-                          className="border-b border-border last:border-b-0"
-                        >
-                          <div className="flex items-center justify-between gap-3 bg-surface/45 px-3 py-1.5">
-                            <div className="min-w-0 truncate text-2xs font-medium text-fg-muted">
-                              {group.label}
-                            </div>
-                            <div className="shrink-0 text-2xs uppercase tracking-wide text-fg-subtle">
-                              {group.repositories.length} repos
-                            </div>
-                          </div>
-                          <div className="divide-y divide-border/70">
-                            {group.repositories.map((repo) => {
-                              const checked = props.selectedRepoIds.has(repo.id);
-                              const blocked =
-                                props.selectedInstallationId !== null &&
-                                props.selectedInstallationId !== repo.installationId &&
-                                !checked;
-                              return (
-                                <div
-                                  key={`${repo.installationId}:${repo.id}`}
-                                  className={cn(
-                                    "px-2 py-2 transition-colors hover:bg-surface-2/45",
-                                    blocked && "opacity-55",
-                                  )}
-                                >
-                                  <button
-                                    type="button"
-                                    onClick={() => props.onToggleRepo(repo)}
-                                    disabled={props.pending}
-                                    aria-pressed={checked}
-                                    aria-label={`Select ${repo.fullName}`}
-                                    className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md text-left outline-none"
-                                  >
-                                    <span
-                                      className={cn(
-                                        "flex size-4 items-center justify-center rounded border",
-                                        checked
-                                          ? "border-brand bg-brand-strong text-brand-fg"
-                                          : "border-border-strong bg-surface",
-                                      )}
-                                    >
-                                      {checked ? <CheckIcon className="size-3" /> : null}
-                                    </span>
-                                    <span className="min-w-0">
-                                      <span className="flex min-w-0 items-center gap-1.5">
-                                        <span className="truncate text-xs font-medium text-fg">
-                                          {repo.fullName}
-                                        </span>
-                                        {repo.private ? (
-                                          <LockIcon className="size-3 shrink-0 text-fg-subtle" />
-                                        ) : null}
-                                      </span>
-                                      <span className="mt-0.5 block truncate text-2xs text-fg-subtle">
-                                        default {repo.defaultBranch}
-                                      </span>
-                                    </span>
-                                    {blocked ? (
-                                      <MetaChip dot="waiting" rounded="full">
-                                        Other app
-                                      </MetaChip>
-                                    ) : checked ? (
-                                      <MetaChip dot="idle" rounded="full">
-                                        Selected
-                                      </MetaChip>
-                                    ) : null}
-                                  </button>
-                                  {checked ? (
-                                    <div className="mt-2 flex items-center gap-2 pl-6">
-                                      <GitBranchIcon className="size-3.5 shrink-0 text-fg-subtle" />
-                                      <Input
-                                        value={
-                                          props.selectedRepoRefs[repo.id] ?? repo.defaultBranch
-                                        }
-                                        onChange={(event) =>
-                                          props.onRefChange(repo.id, event.target.value)
-                                        }
-                                        onClick={(event) => event.stopPropagation()}
-                                        disabled={props.pending}
-                                        placeholder={repo.defaultBranch}
-                                        aria-label={`${repo.fullName} ref`}
-                                        className="h-7 text-xs"
-                                      />
-                                    </div>
-                                  ) : null}
-                                </div>
-                              );
-                            })}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </section>
-
-                  {settingsDisclosure}
-                </>
-              )}
-
-              <Collapsible open={props.manualOpen} onOpenChange={props.onManualOpenChange}>
-                <div className="border-t border-border/60 pt-1">
-                  <div className="flex items-center justify-between gap-2 px-3 py-2">
-                    <CollapsibleTrigger asChild>
-                      <button
-                        type="button"
-                        className="flex min-w-0 flex-1 items-center gap-2 rounded-md text-left text-xs font-medium text-fg"
-                      >
-                        <ChevronDownIcon
-                          className={cn(
-                            "size-3.5 shrink-0 text-fg-subtle transition-transform",
-                            props.manualOpen && "rotate-180",
-                          )}
-                        />
-                        <span className="truncate">Add by URL</span>
-                        {manualCount > 0 ? <MetaChip rounded="full">{manualCount}</MetaChip> : null}
-                      </button>
-                    </CollapsibleTrigger>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="xs"
-                      onClick={props.onManualAdd}
-                      disabled={props.pending}
-                      className="h-7 text-xs"
-                    >
-                      <PlusIcon className="size-3" />
-                      Add
-                    </Button>
-                  </div>
-
-                  <CollapsibleContent>
-                    <div className="space-y-2 border-t border-border p-3">
-                      {props.manualRepos.length === 0 ? (
-                        <p className="text-xs leading-5 text-fg-muted">
-                          Add HTTPS Git repositories that don't use the GitHub app token.
-                        </p>
-                      ) : (
-                        props.manualRepos.map((repo) => (
-                          <div
-                            key={repo.id}
-                            className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_7rem_auto]"
-                          >
-                            <Input
-                              value={repo.url}
-                              onChange={(event) =>
-                                props.onManualUpdate(repo.id, { url: event.target.value })
-                              }
-                              disabled={props.pending}
-                              placeholder="https://github.com/org/repo"
-                              className="h-8 text-xs"
-                            />
-                            <div className="relative">
-                              <GitBranchIcon className="pointer-events-none absolute left-2.5 top-2 size-3.5 text-fg-subtle" />
-                              <Input
-                                value={repo.ref}
-                                onChange={(event) =>
-                                  props.onManualUpdate(repo.id, { ref: event.target.value })
-                                }
-                                disabled={props.pending}
-                                placeholder="main"
-                                className="h-8 pl-7 text-xs"
-                              />
-                            </div>
-                            {confirmRemoveId === repo.id ? (
-                              <div className="flex items-center gap-1">
-                                <Button
-                                  type="button"
-                                  variant="destructive"
-                                  size="icon-sm"
-                                  onClick={() => {
-                                    props.onManualRemove(repo.id);
-                                    setConfirmRemoveId(null);
-                                  }}
-                                  disabled={props.pending}
-                                  aria-label="Confirm remove repository"
-                                  title="Remove"
-                                  className="size-8"
-                                >
-                                  <CheckIcon className="size-3.5" />
-                                </Button>
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="icon-sm"
-                                  onClick={() => setConfirmRemoveId(null)}
-                                  aria-label="Keep repository"
-                                  title="Cancel"
-                                  className="size-8"
-                                >
-                                  <XIcon className="size-3.5" />
-                                </Button>
-                              </div>
-                            ) : (
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon-sm"
-                                onClick={() => setConfirmRemoveId(repo.id)}
-                                disabled={props.pending}
-                                aria-label="Remove repository"
-                                title="Remove"
-                                className="size-8"
-                              >
-                                <Trash2Icon className="size-3.5" />
-                              </Button>
-                            )}
-                          </div>
-                        ))
-                      )}
-                    </div>
-                  </CollapsibleContent>
-                </div>
-              </Collapsible>
-            </div>
-          </div>
-        </div>
+        <RepositoryContextMenuBody {...props} />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/src/components/session/subagents.tsx
+++ b/apps/web/src/components/session/subagents.tsx
@@ -67,6 +67,8 @@ export function SubagentTree({
   nodes: LineageNode[];
   onNavigate?: (() => void) | undefined;
 }) {
+  // Flat fleets (no grandchildren) skip the expander gutter so chrome stays dense.
+  const showLead = nodes.some((node) => node.children.length > 0);
   return (
     <ul className="flex flex-col gap-px">
       {nodes.map((node) => (
@@ -75,6 +77,7 @@ export function SubagentTree({
           node={node}
           workspaceId={workspaceId}
           depth={0}
+          showLead={showLead}
           onNavigate={onNavigate}
         />
       ))}
@@ -86,11 +89,13 @@ function SubagentRow({
   node,
   workspaceId,
   depth,
+  showLead,
   onNavigate,
 }: {
   node: LineageNode;
   workspaceId: string;
   depth: number;
+  showLead: boolean;
   onNavigate?: (() => void) | undefined;
 }) {
   const [open, setOpen] = useState(false);
@@ -122,28 +127,29 @@ function SubagentRow({
           as one target; the Link inside covers dot→title→hint (the nav hit
           area), the chevron toggles without navigating. */}
       <div className="group/row flex h-7 items-center gap-1.5 rounded-md pr-1.5 transition-colors hover:bg-surface-2 has-[a:focus-visible]:bg-surface-2">
-        {/* Lead cluster: the expand chevron + child-count grouped as the "has N
-            children" affordance, at a fixed width so every dot column lines up
-            whether or not a row has children. */}
-        <span className="flex w-7 shrink-0 items-center gap-0.5">
-          {canExpand ? (
-            <>
-              <button
-                type="button"
-                aria-label={open ? "Collapse" : "Expand"}
-                onClick={() => setOpen((prev) => !prev)}
-                className="inline-flex size-4 shrink-0 items-center justify-center rounded text-fg-subtle/50 outline-none transition-colors hover:text-fg group-hover/row:text-fg-subtle focus-visible:text-fg"
-              >
-                <ChevronRightIcon
-                  className={cn("size-3 transition-transform", open && "rotate-90")}
-                />
-              </button>
-              <span className="text-2xs leading-none tabular-nums text-fg-subtle/60">
-                {node.children.length}
-              </span>
-            </>
-          ) : null}
-        </span>
+        {/* Lead cluster: expand chevron + child-count. Omitted entirely for
+            flat fleets so the chrome agents panel stays dense. */}
+        {showLead ? (
+          <span className="flex w-7 shrink-0 items-center gap-0.5">
+            {canExpand ? (
+              <>
+                <button
+                  type="button"
+                  aria-label={open ? "Collapse" : "Expand"}
+                  onClick={() => setOpen((prev) => !prev)}
+                  className="inline-flex size-4 shrink-0 items-center justify-center rounded text-fg-subtle/50 outline-none transition-colors hover:text-fg group-hover/row:text-fg-subtle focus-visible:text-fg"
+                >
+                  <ChevronRightIcon
+                    className={cn("size-3 transition-transform", open && "rotate-90")}
+                  />
+                </button>
+                <span className="text-2xs leading-none tabular-nums text-fg-subtle/60">
+                  {node.children.length}
+                </span>
+              </>
+            ) : null}
+          </span>
+        ) : null}
         <Link
           to="/workspaces/$workspaceId/sessions/$sessionId"
           params={{ workspaceId, sessionId: node.session.id }}
@@ -168,6 +174,7 @@ function SubagentRow({
               node={child}
               workspaceId={workspaceId}
               depth={depth + 1}
+              showLead={showLead}
               onNavigate={onNavigate}
             />
           ))}

--- a/apps/web/src/dev/composer-chrome-fixtures.ts
+++ b/apps/web/src/dev/composer-chrome-fixtures.ts
@@ -352,8 +352,8 @@ function catalogModel(
 }
 
 export const galleryModelRows: PickerModelRow[] = projectPickerRows([
-  catalogModel({ id: "gpt-5.6-sol", label: "gpt-5.6-sol" }),
-  catalogModel({ id: "gpt-5.4", label: "gpt-5.4" }),
+  catalogModel({ id: "gpt-5.6-sol", label: "GPT-5.6 Sol", shortLabel: "5.6 Sol" }),
+  catalogModel({ id: "gpt-5.6-luna", label: "GPT-5.6 Luna", shortLabel: "5.6 Luna" }),
 ]);
 
 /** 52 first-party + 1 MCP = 53; leave two off → Tools · 51/53. */
@@ -392,13 +392,17 @@ export const screenshotIncomingInputs: SessionPendingInputPreview[] = [
 ];
 
 export type ChromeScenarioId =
+  | "crowded-mobile"
   | "screenshot"
   | "queued-only"
   | "incoming-and-queued"
+  | "steering"
+  | "voice-queued"
   | "goal-running"
   | "goal-paused"
   | "goal-blocked"
   | "goal-held"
+  | "goal-completed"
   | "agents-many"
   | "agents-none"
   | "composer-only";
@@ -411,6 +415,8 @@ export type ChromeScenario = {
   queue: UseTurnQueueResult;
   goal: UseGoalResult;
   agentNodes: LineageNode[];
+  /** Open this segment when the phone mounts (matches production uncontrolled default). */
+  defaultActive?: "incoming" | "steering" | "queue" | "goal" | "agents" | null;
 };
 
 export function chromeScenarios(): ChromeScenario[] {
@@ -444,15 +450,54 @@ export function chromeScenarios(): ChromeScenario[] {
     }),
   ];
 
+  const fifteenIdleAgents = Array.from({ length: 15 }, (_, index) =>
+    galleryAgentNode(index, {
+      title: index === 0 ? "Primary worker" : `Worker ${index + 1}`,
+      metadata: { title: index === 0 ? "Primary worker" : `Worker ${index + 1}` },
+      status: "idle",
+    }),
+  );
+
   return [
     {
+      id: "crowded-mobile",
+      title: "Crowded mobile (reference)",
+      description:
+        "Queue open + blocked goal (~3d 16h) + 15 idle agents — the dense stack from the phone screenshot.",
+      session,
+      queue: galleryQueue({
+        queue: [
+          galleryTurn(
+            0,
+            "Wtf are you talking about? The x mcp credential readiness flow still needs the five secrets in SOPS before enable.",
+          ),
+        ],
+      }),
+      goal: galleryGoal({
+        text: "Implement and harden the X XMCP credential readiness path end-to-end on jorgebot",
+        createdAt: isoMinutesAgo(3 * 24 * 60 + 16 * 60),
+        updatedAt: new Date(FIXED_NOW).toISOString(),
+        continuation: {
+          state: "blocked",
+          reason: "human_work_pending",
+          wakeRevision: 8,
+          observedRevision: 7,
+          nextAttemptAt: null,
+          lastError: "Waiting for a human follow-up before the next goal turn.",
+        },
+      }),
+      agentNodes: fifteenIdleAgents,
+      defaultActive: "queue",
+    },
+    {
       id: "screenshot",
-      title: "Screenshot stack",
-      description: "Incoming updates + continuation blocked + 2 agents — closest to the reference.",
+      title: "Incoming + blocked + agents",
+      description: "Incoming updates + continuation blocked + 2 agents.",
       session,
       queue: galleryQueue({ pendingInputs: screenshotIncomingInputs }),
       goal: galleryGoal({}),
       agentNodes: twoAgents,
+      defaultActive: "incoming",
     },
     {
       id: "queued-only",
@@ -463,15 +508,20 @@ export function chromeScenarios(): ChromeScenario[] {
         queue: [
           galleryTurn(0, "Please retry the Linear webhook after the deploy finishes."),
           galleryTurn(1, "Then paste the activation evidence into the runbook."),
+          galleryTurn(
+            2,
+            "Finally verify the production callback URL still matches the workspace setting.",
+          ),
         ],
       }),
       goal: galleryGoal(null),
       agentNodes: [],
+      defaultActive: "queue",
     },
     {
       id: "incoming-and-queued",
       title: "Incoming + queued",
-      description: "Collapsed queue shows both counts and a preview.",
+      description: "Collapsed chips show both counts; open either segment.",
       session,
       queue: galleryQueue({
         queue: [galleryTurn(0, "Follow up once the child session is inspected.")],
@@ -479,6 +529,56 @@ export function chromeScenarios(): ChromeScenario[] {
       }),
       goal: galleryGoal(null),
       agentNodes: [galleryAgentNode(0)],
+    },
+    {
+      id: "steering",
+      title: "Steering in flight",
+      description: "Steer delivery chip while a direction is accepted at the queue head.",
+      session: gallerySession({ status: "running" }),
+      queue: galleryQueue({
+        queue: [
+          galleryTurn(0, "Keep Linear project keys aligned with production and continue."),
+        ].map((turn) => ({
+          ...turn,
+          metadata: { ...turn.metadata, delivery: "steer" },
+        })),
+      }),
+      goal: galleryGoal({
+        continuation: {
+          state: "running",
+          reason: "goal_turn_running",
+          wakeRevision: 3,
+          observedRevision: 3,
+          nextAttemptAt: null,
+          lastError: null,
+        },
+        updatedAt: new Date(FIXED_NOW).toISOString(),
+      }),
+      agentNodes: twoAgents,
+      defaultActive: "steering",
+    },
+    {
+      id: "voice-queued",
+      title: "Voice request queued",
+      description: "Realtime voice transcript waiting as a queued turn.",
+      session,
+      queue: galleryQueue({
+        queue: [
+          {
+            ...galleryTurn(0, ""),
+            prompt: "",
+            metadata: {
+              realtimeDelegation: {
+                inputTranscript:
+                  "Hey — when you wake up, finish the credential readiness checklist and ping me.",
+              },
+            },
+          },
+        ],
+      }),
+      goal: galleryGoal(null),
+      agentNodes: [],
+      defaultActive: "queue",
     },
     {
       id: "goal-running",
@@ -498,6 +598,7 @@ export function chromeScenarios(): ChromeScenario[] {
         updatedAt: new Date(FIXED_NOW).toISOString(),
       }),
       agentNodes: twoAgents,
+      defaultActive: "goal",
     },
     {
       id: "goal-paused",
@@ -518,6 +619,7 @@ export function chromeScenarios(): ChromeScenario[] {
         },
       }),
       agentNodes: [],
+      defaultActive: "goal",
     },
     {
       id: "goal-blocked",
@@ -544,6 +646,7 @@ export function chromeScenarios(): ChromeScenario[] {
         },
       }),
       agentNodes: twoAgents,
+      defaultActive: "goal",
     },
     {
       id: "goal-held",
@@ -562,6 +665,27 @@ export function chromeScenarios(): ChromeScenario[] {
         },
       }),
       agentNodes: [],
+      defaultActive: "goal",
+    },
+    {
+      id: "goal-completed",
+      title: "Goal completed",
+      description: "Done pill — chrome still visible until cleared.",
+      session,
+      queue: galleryQueue(),
+      goal: galleryGoal({
+        status: "completed",
+        continuation: {
+          state: "inactive",
+          reason: "goal_inactive",
+          wakeRevision: 9,
+          observedRevision: 9,
+          nextAttemptAt: null,
+          lastError: null,
+        },
+      }),
+      agentNodes: [],
+      defaultActive: "goal",
     },
     {
       id: "agents-many",
@@ -580,6 +704,7 @@ export function chromeScenarios(): ChromeScenario[] {
         },
       }),
       agentNodes: manyAgents,
+      defaultActive: "agents",
     },
     {
       id: "agents-none",
@@ -600,6 +725,7 @@ export function chromeScenarios(): ChromeScenario[] {
         updatedAt: new Date(FIXED_NOW).toISOString(),
       }),
       agentNodes: [],
+      defaultActive: "goal",
     },
     {
       id: "composer-only",
@@ -609,6 +735,7 @@ export function chromeScenarios(): ChromeScenario[] {
       queue: galleryQueue(),
       goal: galleryGoal(null),
       agentNodes: [],
+      defaultActive: null,
     },
   ];
 }

--- a/apps/web/src/dev/composer-chrome-fixtures.ts
+++ b/apps/web/src/dev/composer-chrome-fixtures.ts
@@ -404,6 +404,7 @@ export type ChromeScenarioId =
   | "goal-held"
   | "goal-completed"
   | "agents-many"
+  | "agents-only"
   | "agents-none"
   | "composer-only";
 
@@ -704,6 +705,17 @@ export function chromeScenarios(): ChromeScenario[] {
         },
       }),
       agentNodes: manyAgents,
+      defaultActive: "agents",
+    },
+    {
+      id: "agents-only",
+      title: "Agents only",
+      description:
+        "Just the agents chip — no queue, incoming, or goal. Open by default to check close-on-chip + highlight.",
+      session,
+      queue: galleryQueue(),
+      goal: galleryGoal(null),
+      agentNodes: fifteenIdleAgents,
       defaultActive: "agents",
     },
     {

--- a/apps/web/src/routes/composer-chrome/index.tsx
+++ b/apps/web/src/routes/composer-chrome/index.tsx
@@ -1,66 +1,166 @@
 // DEV-only session chrome harness for the production SessionChrome dock.
 // Open: http://127.0.0.1:3000/dev/composer-chrome
+// Mobile phone stage is the default — tweak SessionChrome and refresh this page.
 import { useMemo, useState } from "react";
 
 import { idleComposer, type ChromeScenarioId } from "@/dev/composer-chrome-fixtures";
 
+import { PhoneFrame } from "./phone-frame";
 import { ScenarioFilter, useGalleryScenarios } from "./scenario-matrix";
 import { ScenarioStack } from "./scenario-stack";
+
+type ViewMode = "phone" | "gallery";
 
 export function ComposerChromeGalleryRoute() {
   const composer = useMemo(() => idleComposer(), []);
   const scenarios = useGalleryScenarios();
-  const [filter, setFilter] = useState<"all" | ChromeScenarioId>("all");
-  const visible = filter === "all" ? scenarios : scenarios.filter((row) => row.id === filter);
+  const [mode, setMode] = useState<ViewMode>("phone");
+  const [phoneScenarioId, setPhoneScenarioId] = useState<ChromeScenarioId>("crowded-mobile");
+  const [galleryFilter, setGalleryFilter] = useState<"all" | ChromeScenarioId>("all");
+
+  const phoneScenario = scenarios.find((row) => row.id === phoneScenarioId) ?? scenarios[0] ?? null;
+  const galleryVisible =
+    galleryFilter === "all" ? scenarios : scenarios.filter((row) => row.id === galleryFilter);
 
   return (
     <main className="min-h-dvh overflow-y-auto bg-bg text-fg">
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-8 sm:px-6">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-6 sm:px-6">
         <header className="space-y-3">
           <p className="text-2xs font-medium uppercase tracking-[0.12em] text-fg-subtle">
             Dev harness · session chrome
           </p>
           <h1 className="text-xl font-semibold tracking-tight">Session chrome</h1>
-          <p className="text-sm leading-relaxed text-fg-muted">
-            Scenario matrix for the production{" "}
-            <code className="font-mono text-xs text-fg">SessionChrome</code> dock (incoming, queue,
-            goal, agents) above the stock ChatComposer.
+          <p className="max-w-2xl text-sm leading-relaxed text-fg-muted">
+            Interactive gallery of the production{" "}
+            <code className="font-mono text-xs text-fg">SessionChrome</code> dock (the bar above the
+            composer). Edits to that component show up here immediately — same code as the live
+            session route.
           </p>
           <code className="block rounded-lg border border-border bg-surface-2/60 px-3 py-2 font-mono text-xs text-fg-muted">
             http://127.0.0.1:3000/dev/composer-chrome
           </code>
-          <ScenarioFilter scenarios={scenarios} filter={filter} onChange={setFilter} />
+
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="inline-flex rounded-lg border border-border bg-surface p-0.5">
+              <button
+                type="button"
+                className={
+                  mode === "phone"
+                    ? "rounded-md bg-fg px-3 py-1.5 text-xs font-medium text-bg"
+                    : "rounded-md px-3 py-1.5 text-xs font-medium text-fg-muted hover:text-fg"
+                }
+                onClick={() => setMode("phone")}
+              >
+                iPhone 12 Pro
+              </button>
+              <button
+                type="button"
+                className={
+                  mode === "gallery"
+                    ? "rounded-md bg-fg px-3 py-1.5 text-xs font-medium text-bg"
+                    : "rounded-md px-3 py-1.5 text-xs font-medium text-fg-muted hover:text-fg"
+                }
+                onClick={() => setMode("gallery")}
+              >
+                All scenarios
+              </button>
+            </div>
+            {mode === "gallery" ? (
+              <ScenarioFilter
+                scenarios={scenarios}
+                filter={galleryFilter}
+                onChange={setGalleryFilter}
+              />
+            ) : null}
+          </div>
         </header>
 
-        <div className="flex flex-col gap-10" data-session-chrome-harness="">
-          {visible.map((scenario, index) => (
-            <section
-              key={scenario.id}
-              aria-labelledby={`session-chrome-scenario-${scenario.id}`}
-              className="overflow-hidden rounded-xl border border-border bg-surface/30"
-            >
-              <header className="space-y-1 border-b border-border bg-surface-2/50 px-4 py-3 sm:px-5">
-                <p className="text-2xs font-medium uppercase tracking-[0.14em] text-fg-subtle">
-                  Scenario {index + 1}
-                  <span className="mx-1.5 text-border">·</span>
-                  <span className="font-mono normal-case tracking-normal text-fg-muted">
-                    {scenario.id}
-                  </span>
+        {mode === "phone" && phoneScenario ? (
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:gap-8">
+            <aside className="w-full shrink-0 space-y-2 lg:w-64">
+              <p className="text-2xs font-medium uppercase tracking-[0.12em] text-fg-subtle">
+                States
+              </p>
+              <ul className="flex max-h-[min(70dvh,40rem)] flex-col gap-1 overflow-y-auto overscroll-contain rounded-xl border border-border bg-surface/40 p-1.5">
+                {scenarios.map((scenario) => {
+                  const selected = scenario.id === phoneScenario.id;
+                  return (
+                    <li key={scenario.id}>
+                      <button
+                        type="button"
+                        aria-pressed={selected}
+                        className={
+                          selected
+                            ? "w-full rounded-lg bg-fg px-3 py-2 text-left text-xs font-medium text-bg"
+                            : "w-full rounded-lg px-3 py-2 text-left text-xs text-fg-muted hover:bg-surface-2 hover:text-fg"
+                        }
+                        onClick={() => setPhoneScenarioId(scenario.id)}
+                      >
+                        <span className="block">{scenario.title}</span>
+                        <span
+                          className={
+                            selected
+                              ? "mt-0.5 block text-2xs font-normal text-bg/70"
+                              : "mt-0.5 block text-2xs text-fg-subtle"
+                          }
+                        >
+                          {scenario.id}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div className="rounded-lg border border-border bg-surface-2/40 px-3 py-2 text-xs text-fg-muted">
+                <p className="font-medium text-fg">{phoneScenario.title}</p>
+                <p className="mt-1 leading-relaxed">{phoneScenario.description}</p>
+                <p className="mt-2 text-2xs text-fg-subtle">
+                  Tap chips to expand. Queue edit/steer/delete and goal pause/resume/clear are live
+                  in the mock.
                 </p>
-                <h2
-                  id={`session-chrome-scenario-${scenario.id}`}
-                  className="text-sm font-semibold text-fg"
-                >
-                  {scenario.title}
-                </h2>
-                <p className="text-xs text-fg-muted">{scenario.description}</p>
-              </header>
-              <div className="p-3 sm:p-4">
-                <ScenarioStack scenario={scenario} composer={composer} />
               </div>
-            </section>
-          ))}
-        </div>
+            </aside>
+
+            <PhoneFrame>
+              <ScenarioStack
+                key={phoneScenario.id}
+                scenario={phoneScenario}
+                composer={composer}
+                variant="phone"
+              />
+            </PhoneFrame>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-10" data-session-chrome-harness="">
+            {galleryVisible.map((scenario, index) => (
+              <section
+                key={scenario.id}
+                aria-labelledby={`session-chrome-scenario-${scenario.id}`}
+                className="overflow-hidden rounded-xl border border-border bg-surface/30"
+              >
+                <header className="space-y-1 border-b border-border bg-surface-2/50 px-4 py-3 sm:px-5">
+                  <p className="text-2xs font-medium uppercase tracking-[0.14em] text-fg-subtle">
+                    Scenario {index + 1}
+                    <span className="mx-1.5 text-border">·</span>
+                    <span className="font-mono normal-case tracking-normal text-fg-muted">
+                      {scenario.id}
+                    </span>
+                  </p>
+                  <h2
+                    id={`session-chrome-scenario-${scenario.id}`}
+                    className="text-sm font-semibold text-fg"
+                  >
+                    {scenario.title}
+                  </h2>
+                  <p className="text-xs text-fg-muted">{scenario.description}</p>
+                </header>
+                <div className="p-3 sm:p-4">
+                  <ScenarioStack scenario={scenario} composer={composer} />
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
       </div>
     </main>
   );

--- a/apps/web/src/routes/composer-chrome/index.tsx
+++ b/apps/web/src/routes/composer-chrome/index.tsx
@@ -15,7 +15,7 @@ export function ComposerChromeGalleryRoute() {
   const composer = useMemo(() => idleComposer(), []);
   const scenarios = useGalleryScenarios();
   const [mode, setMode] = useState<ViewMode>("phone");
-  const [phoneScenarioId, setPhoneScenarioId] = useState<ChromeScenarioId>("crowded-mobile");
+  const [phoneScenarioId, setPhoneScenarioId] = useState<ChromeScenarioId>("agents-only");
   const [galleryFilter, setGalleryFilter] = useState<"all" | ChromeScenarioId>("all");
 
   const phoneScenario = scenarios.find((row) => row.id === phoneScenarioId) ?? scenarios[0] ?? null;

--- a/apps/web/src/routes/composer-chrome/phone-frame.tsx
+++ b/apps/web/src/routes/composer-chrome/phone-frame.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react";
+
+/** CSS logical size for iPhone 12/13/14 Pro (used across e2e as 390×844). */
+export const IPHONE_12_PRO = { width: 390, height: 844 } as const;
+
+/**
+ * Device chrome for the SessionChrome mobile harness. The inner stage is a
+ * fixed 390×844 viewport so chrome + composer density matches a real phone.
+ */
+export function PhoneFrame({
+  children,
+  label = "iPhone 12 Pro · 390×844",
+}: {
+  children: ReactNode;
+  label?: string;
+}) {
+  return (
+    <div className="mx-auto flex w-full max-w-[26rem] flex-col items-center gap-3">
+      <p className="text-2xs font-medium uppercase tracking-[0.14em] text-fg-subtle">{label}</p>
+      <div
+        className="relative shrink-0 overflow-hidden rounded-[2.4rem] border-[3px] border-fg/20 bg-fg/90 p-[10px] shadow-[0_24px_80px_-32px_rgba(0,0,0,0.65)]"
+        style={{ width: IPHONE_12_PRO.width + 26, height: IPHONE_12_PRO.height + 26 }}
+      >
+        <div
+          className="relative flex h-full w-full flex-col overflow-hidden rounded-[2rem] bg-bg text-fg"
+          style={{ width: IPHONE_12_PRO.width, height: IPHONE_12_PRO.height }}
+          data-og-phone-stage=""
+        >
+          {/* Status bar */}
+          <div className="flex h-11 shrink-0 items-end justify-between px-6 pb-1.5 text-[12px] font-semibold tabular-nums text-fg">
+            <span>9:41</span>
+            <span
+              aria-hidden
+              className="absolute left-1/2 top-2 h-[28px] w-[110px] -translate-x-1/2 rounded-full bg-fg/90"
+            />
+            <span className="flex items-center gap-1.5 text-[11px] font-medium">
+              <span aria-hidden>●●●</span>
+              <span aria-hidden>▮</span>
+            </span>
+          </div>
+
+          {/* App chrome stub — matches session header density without routing */}
+          <div className="flex h-11 shrink-0 items-center gap-2 border-b border-border/70 px-3">
+            <span className="inline-flex size-8 items-center justify-center rounded-md text-fg-muted">
+              ☰
+            </span>
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">MCP O…</span>
+            <span className="shrink-0 rounded-full border border-border px-2 py-0.5 text-2xs text-fg-muted">
+              on jorgebot
+            </span>
+          </div>
+
+          {/* Scrollable faux timeline so chrome sits above a real composer dock */}
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-3">
+            <div className="space-y-3 opacity-55">
+              <p className="text-2xs font-medium uppercase tracking-[0.12em] text-fg-subtle">
+                waiting on you · 7h
+              </p>
+              <div className="rounded-xl border border-border bg-surface/60 p-3">
+                <p className="text-sm font-medium text-fg">X XMCP credential readiness</p>
+                <p className="mt-1 text-xs leading-relaxed text-fg-muted">
+                  Faux timeline card — not interactive. Focus the chrome + composer below.
+                </p>
+              </div>
+              <div className="h-24 rounded-xl border border-dashed border-border/80 bg-surface-2/30" />
+              <div className="h-16 rounded-xl border border-dashed border-border/80 bg-surface-2/30" />
+            </div>
+          </div>
+
+          {children}
+
+          {/* Home indicator */}
+          <div className="flex h-5 shrink-0 items-start justify-center pt-1">
+            <span className="h-1 w-28 rounded-full bg-fg/35" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/composer-chrome/scenario-stack.tsx
+++ b/apps/web/src/routes/composer-chrome/scenario-stack.tsx
@@ -3,15 +3,18 @@ import {
   ChatComposer,
   SessionChrome,
   type ComposerState,
+  type UseGoalResult,
   type UseTurnQueueResult,
 } from "@opengeni/react";
 import type {
   ClientVoiceInputConfig,
+  SessionGoal,
   SessionPendingInputPreview,
   SessionTurn,
 } from "@opengeni/sdk";
 import { useMemo, useState } from "react";
 
+import { ComposerMobilePlus } from "@/components/composer-mobile-plus";
 import { ModelPicker, SessionToolPicker } from "@/components/pickers";
 import { SubagentTree } from "@/components/session/subagents";
 import {
@@ -101,18 +104,78 @@ function useHarnessLiveQueue(seed: UseTurnQueueResult): {
   };
 }
 
+function useHarnessLiveGoal(seed: UseGoalResult): UseGoalResult {
+  const [goal, setGoal] = useState<SessionGoal | null>(seed.goal);
+  return useMemo(
+    () => ({
+      ...seed,
+      goal,
+      isActive: goal?.status === "active",
+      isPaused: goal?.status === "paused",
+      isCompleted: goal?.status === "completed",
+      pause: async () => {
+        if (!goal || goal.status !== "active") return goal;
+        const next: SessionGoal = {
+          ...goal,
+          status: "paused",
+          pausedReason: "Paused from the gallery",
+          continuation: {
+            state: "inactive",
+            reason: "goal_inactive",
+            wakeRevision: goal.continuation?.wakeRevision ?? 0,
+            observedRevision: goal.continuation?.observedRevision ?? 0,
+            nextAttemptAt: null,
+            lastError: null,
+          },
+        };
+        setGoal(next);
+        return next;
+      },
+      resume: async () => {
+        if (!goal || goal.status !== "paused") return goal;
+        const next: SessionGoal = {
+          ...goal,
+          status: "active",
+          pausedReason: null,
+          continuation: {
+            state: "scheduled",
+            reason: "wake_pending",
+            wakeRevision: (goal.continuation?.wakeRevision ?? 0) + 1,
+            observedRevision: goal.continuation?.observedRevision ?? 0,
+            nextAttemptAt: new Date().toISOString(),
+            lastError: null,
+          },
+        };
+        setGoal(next);
+        return next;
+      },
+      clearGoal: async () => {
+        setGoal(null);
+      },
+      deleteGoal: async () => {
+        setGoal(null);
+      },
+    }),
+    [goal, seed],
+  );
+}
+
 export function ScenarioStack({
   scenario,
   composer,
+  /** Phone stage uses tighter padding to match the session dock. */
+  variant = "gallery",
 }: {
   scenario: ChromeScenario;
   composer: ComposerState;
+  variant?: "gallery" | "phone";
 }) {
   const [model, setModel] = useState("gpt-5.6-sol");
   const [effort, setEffort] = useState<IntelligenceEffort>("medium");
   const [toolSelection, setToolSelection] = useState(galleryToolSelection);
   const attachments = useMemo(() => emptyAttachments(), []);
   const { queue, dismissIncoming } = useHarnessLiveQueue(scenario.queue);
+  const goal = useHarnessLiveGoal(scenario.goal);
   const agents = scenario.agentNodes;
 
   const runningAgents = agents.filter(
@@ -122,76 +185,102 @@ export function ScenarioStack({
     (node) => node.session.effectiveControl.state === "paused",
   ).length;
 
+  const chrome = (
+    <SessionChrome
+      key={`${scenario.id}-${scenario.defaultActive ?? "none"}`}
+      queue={queue}
+      composer={composer}
+      goal={goal}
+      onDismissIncoming={dismissIncoming}
+      defaultActive={scenario.defaultActive}
+      agentsSignal={
+        agents.length > 0
+          ? {
+              count: agents.length,
+              detail:
+                runningAgents > 0
+                  ? `${runningAgents} running`
+                  : pausedAgents > 0
+                    ? `${pausedAgents} paused`
+                    : "Idle",
+              tone: runningAgents > 0 ? "running" : pausedAgents > 0 ? "waiting" : "neutral",
+            }
+          : undefined
+      }
+      agentsPanel={
+        agents.length > 0 ? (
+          <SubagentTree workspaceId={GALLERY_WORKSPACE_ID} nodes={agents} />
+        ) : null
+      }
+    />
+  );
+
+  const composerBlock = (
+    <ChatComposer
+      composer={composer}
+      effectiveControl={scenario.session.effectiveControl}
+      queuedAheadCount={queue.queue.length}
+      placeholder="Send a follow-up…"
+      attachments={attachments}
+      attachButtonClassName="max-sm:hidden"
+      transcription={{
+        client: fixtureClient as never,
+        workspaceId: GALLERY_WORKSPACE_ID,
+        capability: VOICE_CAPABILITY,
+        workspaceEnabled: true,
+      }}
+      controlsLeading={
+        <ComposerMobilePlus
+          fileUploadsEnabled
+          servers={galleryToolServers}
+          firstPartyTools={galleryFirstPartyTools}
+          selection={toolSelection}
+          onToolSelectionChange={setToolSelection}
+        />
+      }
+      controlsStart={
+        <div className="flex min-w-0 items-center gap-1.5 max-sm:min-w-0 max-sm:flex-nowrap">
+          <ModelPicker
+            rows={galleryModelRows}
+            model={model}
+            effort={effort}
+            latencyMode="standard"
+            menuSide="top"
+            onModelChange={setModel}
+            onEffortChange={setEffort}
+            onLatencyModeChange={() => {}}
+          />
+          <SessionToolPicker
+            servers={galleryToolServers}
+            firstPartyTools={galleryFirstPartyTools}
+            selection={toolSelection}
+            menuSide="top"
+            triggerClassName="max-sm:hidden"
+            onChange={setToolSelection}
+          />
+        </div>
+      }
+    />
+  );
+
+  if (variant === "phone") {
+    return (
+      <div className="shrink-0 border-t border-border/80 bg-bg" data-scenario={scenario.id}>
+        <div className="px-3 pt-2">{chrome}</div>
+        <div className="px-3 pb-2 pt-1">{composerBlock}</div>
+      </div>
+    );
+  }
+
   return (
     <div
       className="flex flex-col justify-end rounded-xl border border-border bg-bg/40 pt-8"
       data-scenario={scenario.id}
       data-session-chrome-stack=""
     >
-      <div className="mx-auto mb-2 w-full max-w-3xl shrink-0 px-4 sm:px-6">
-        <SessionChrome
-          queue={queue}
-          composer={composer}
-          goal={scenario.goal}
-          onDismissIncoming={dismissIncoming}
-          agentsSignal={
-            agents.length > 0
-              ? {
-                  count: agents.length,
-                  detail:
-                    runningAgents > 0
-                      ? `${runningAgents} running`
-                      : pausedAgents > 0
-                        ? `${pausedAgents} paused`
-                        : "Idle",
-                  tone: runningAgents > 0 ? "running" : pausedAgents > 0 ? "waiting" : "neutral",
-                }
-              : undefined
-          }
-          agentsPanel={
-            agents.length > 0 ? (
-              <SubagentTree workspaceId={GALLERY_WORKSPACE_ID} nodes={agents} />
-            ) : null
-          }
-        />
-      </div>
+      <div className="mx-auto mb-2 w-full max-w-3xl shrink-0 px-4 sm:px-6">{chrome}</div>
       <div className="shrink-0 px-4 pb-4 pt-1 sm:px-6">
-        <div className="mx-auto w-full max-w-3xl">
-          <ChatComposer
-            composer={composer}
-            effectiveControl={scenario.session.effectiveControl}
-            queuedAheadCount={queue.queue.length}
-            placeholder="Send a follow-up…"
-            attachments={attachments}
-            transcription={{
-              client: fixtureClient as never,
-              workspaceId: GALLERY_WORKSPACE_ID,
-              capability: VOICE_CAPABILITY,
-              workspaceEnabled: true,
-            }}
-            controlsStart={
-              <div className="flex min-w-0 items-center gap-1.5">
-                <ModelPicker
-                  rows={galleryModelRows}
-                  model={model}
-                  effort={effort}
-                  latencyMode="standard"
-                  menuSide="top"
-                  onModelChange={setModel}
-                  onEffortChange={setEffort}
-                  onLatencyModeChange={() => {}}
-                />
-                <SessionToolPicker
-                  servers={galleryToolServers}
-                  firstPartyTools={galleryFirstPartyTools}
-                  selection={toolSelection}
-                  menuSide="top"
-                  onChange={setToolSelection}
-                />
-              </div>
-            }
-          />
-        </div>
+        <div className="mx-auto w-full max-w-3xl">{composerBlock}</div>
       </div>
     </div>
   );

--- a/apps/web/src/routes/composer-chrome/scenario-stack.tsx
+++ b/apps/web/src/routes/composer-chrome/scenario-stack.tsx
@@ -263,11 +263,34 @@ export function ScenarioStack({
     />
   );
 
+  // Match `session.tsx`: SessionChrome card, then composer — same spacing in phone + gallery.
+  const stack = (
+    <>
+      <div
+        className={
+          variant === "phone"
+            ? "mb-2 w-full shrink-0 px-3"
+            : "mx-auto mb-2 w-full max-w-3xl shrink-0 px-4 sm:px-6"
+        }
+      >
+        {chrome}
+      </div>
+      <div
+        className={
+          variant === "phone" ? "shrink-0 px-3 pb-3 pt-1" : "shrink-0 px-4 pb-4 pt-1 sm:px-6"
+        }
+      >
+        <div className={variant === "phone" ? "w-full" : "mx-auto w-full max-w-3xl"}>
+          {composerBlock}
+        </div>
+      </div>
+    </>
+  );
+
   if (variant === "phone") {
     return (
-      <div className="shrink-0 border-t border-border/80 bg-bg" data-scenario={scenario.id}>
-        <div className="px-3 pt-2">{chrome}</div>
-        <div className="px-3 pb-2 pt-1">{composerBlock}</div>
+      <div className="shrink-0 bg-bg" data-scenario={scenario.id} data-session-chrome-stack="phone">
+        {stack}
       </div>
     );
   }
@@ -278,10 +301,7 @@ export function ScenarioStack({
       data-scenario={scenario.id}
       data-session-chrome-stack=""
     >
-      <div className="mx-auto mb-2 w-full max-w-3xl shrink-0 px-4 sm:px-6">{chrome}</div>
-      <div className="shrink-0 px-4 pb-4 pt-1 sm:px-6">
-        <div className="mx-auto w-full max-w-3xl">{composerBlock}</div>
-      </div>
+      {stack}
     </div>
   );
 }

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -575,6 +575,11 @@ function SessionChatPane(props: {
       candidate.provider === "codex-subscription" &&
       candidate.credentialReadiness.status === "ready",
   );
+  // Soft-hide dictate while realtime voice owns the mic (model + mutes stay on the bar).
+  const [voiceActive, setVoiceActive] = useState(false);
+  const onVoiceActiveChange = useCallback((active: boolean) => {
+    setVoiceActive(active);
+  }, []);
   // Per-approval decision state: an in-flight decision disables both buttons for
   // that approval and shows progress; a settled one can never double-submit even
   // if the strip lingers for a beat before the status flips.
@@ -1046,6 +1051,7 @@ function SessionChatPane(props: {
             commandContext={commandContext}
             onClearView={props.onClearView}
             fileUploadsEnabled={context.clientConfig.fileUploads.enabled === true}
+            transcriptionSuppressed={voiceActive}
             controlsLeading={
               <ComposerMobilePlus
                 disabled={terminal || composer.sending}
@@ -1075,6 +1081,7 @@ function SessionChatPane(props: {
                     codexConnected={codexConnected}
                     realtimeAutostartModel={props.realtimeAutostartModel}
                     onRealtimeAutostartConsumed={props.onRealtimeAutostartConsumed}
+                    onVoiceActiveChange={onVoiceActiveChange}
                   />
                 </Suspense>
               ) : null

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -441,6 +441,7 @@ function SessionsIndexRouteContent({ workspaceId }: { workspaceId: string }) {
                 models={voiceSelection.models}
                 selectedModel={voiceSelection.selectedModel}
                 onSelectModel={voiceSelection.selectModel}
+                modelMenu="split-desktop"
                 disabled={
                   busy ||
                   newSessionDraft.loading ||

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -410,11 +410,10 @@ function SessionsIndexRouteContent({ workspaceId }: { workspaceId: string }) {
                           context.selectedRepoIds.size +
                           context.manualRepos.filter((repo) => repo.url.trim().length > 0).length,
                         disabled: busy || newSessionDraft.loading,
-                        renderBody: (leading) => (
+                        panel: (
                           <WorkspaceRepositoryMenuBody
                             workspaceId={workspaceId}
                             disabled={busy || newSessionDraft.loading}
-                            leading={leading}
                           />
                         ),
                       },
@@ -423,12 +422,11 @@ function SessionsIndexRouteContent({ workspaceId }: { workspaceId: string }) {
                 voiceModel={{
                   selectedLabel: voiceSelection.selectedModel.label,
                   disabled: busy || newSessionDraft.loading,
-                  renderBody: (leading) => (
+                  panel: (
                     <RealtimeVoiceModelPanel
                       models={voiceSelection.models}
                       selectedModel={voiceSelection.selectedModel}
                       disabled={busy || newSessionDraft.loading}
-                      leading={leading}
                       onSelect={voiceSelection.selectModel}
                     />
                   ),

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -23,7 +23,11 @@ import {
   type ComposerState,
 } from "@opengeni/react";
 import { useMachines, type MachineView } from "@opengeni/react/machines";
-import { NewSessionRealtimeControl } from "@opengeni/react/realtime";
+import {
+  NewSessionRealtimeControl,
+  RealtimeVoiceModelPanel,
+  useRealtimeModelSelection,
+} from "@opengeni/react/realtime";
 import { OpenGeniApiError, type SessionRealtimeModel } from "@opengeni/sdk";
 import { Link, useNavigate } from "@tanstack/react-router";
 import {
@@ -40,7 +44,7 @@ import { BillingClassMark } from "@/components/billing-class-mark";
 import { ConsoleComposer, useDraftAttachments } from "@/components/Composer";
 import { ComposerMobilePlus } from "@/components/composer-mobile-plus";
 import { ModelPicker, SessionToolPicker, type SessionToolSelection } from "@/components/pickers";
-import { RepositoryContextPicker } from "@/components/repository-picker";
+import { RepositoryContextMenuBody, RepositoryContextPicker } from "@/components/repository-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Notice } from "@/components/ui/notice";
@@ -48,6 +52,7 @@ import { Select } from "@/components/ui/select";
 import { StatusDot, type StatusTone } from "@/components/ui/status-dot";
 import { useAppContext, useLatestCallback } from "@/context";
 import { FOCUS_CREATE_COMPOSER_EVENT } from "@/lib/create-composer-focus";
+import type { RepoDraft } from "@/lib/session-tools";
 import { displayModel } from "@/lib/format";
 import { isMachineComputeSelectable } from "@/lib/machine-selectability";
 import {
@@ -219,6 +224,12 @@ function SessionsIndexRouteContent({ workspaceId }: { workspaceId: string }) {
       candidate.provider === "codex-subscription" &&
       candidate.credentialReadiness.status === "ready",
   );
+  // Shared with the bar start control and the mobile “+ → Voice model” panel.
+  const voiceSelection = useRealtimeModelSelection({
+    client: context.client,
+    workspaceId,
+    codexConnected,
+  });
 
   useEffect(() => {
     if (createComposerFocusGen === 0 || newSessionDraft.loading) return;
@@ -392,6 +403,36 @@ function SessionsIndexRouteContent({ workspaceId }: { workspaceId: string }) {
                     firstPartyMcpTools: selection.firstPartyToolIds,
                   }));
                 }}
+                {...(draft.compute.kind === "sandbox"
+                  ? {
+                      repositories: {
+                        selectedCount:
+                          context.selectedRepoIds.size +
+                          context.manualRepos.filter((repo) => repo.url.trim().length > 0).length,
+                        disabled: busy || newSessionDraft.loading,
+                        renderBody: (leading) => (
+                          <WorkspaceRepositoryMenuBody
+                            workspaceId={workspaceId}
+                            disabled={busy || newSessionDraft.loading}
+                            leading={leading}
+                          />
+                        ),
+                      },
+                    }
+                  : {})}
+                voiceModel={{
+                  selectedLabel: voiceSelection.selectedModel.label,
+                  disabled: busy || newSessionDraft.loading,
+                  renderBody: (leading) => (
+                    <RealtimeVoiceModelPanel
+                      models={voiceSelection.models}
+                      selectedModel={voiceSelection.selectedModel}
+                      disabled={busy || newSessionDraft.loading}
+                      leading={leading}
+                      onSelect={voiceSelection.selectModel}
+                    />
+                  ),
+                }}
               />
             }
             actions={
@@ -399,6 +440,9 @@ function SessionsIndexRouteContent({ workspaceId }: { workspaceId: string }) {
                 client={context.client}
                 workspaceId={workspaceId}
                 codexConnected={codexConnected}
+                models={voiceSelection.models}
+                selectedModel={voiceSelection.selectedModel}
+                onSelectModel={voiceSelection.selectModel}
                 disabled={
                   busy ||
                   newSessionDraft.loading ||
@@ -639,67 +683,98 @@ function SessionControlStrip({
         onChange={onToolSelectionChange}
       />
       {showRepos ? (
-        <WorkspaceRepositoryPicker workspaceId={workspaceId} disabled={disabled} />
+        <WorkspaceRepositoryPicker
+          workspaceId={workspaceId}
+          disabled={disabled}
+          triggerClassName="max-sm:hidden"
+        />
       ) : null}
     </div>
   );
 }
 
+function workspaceRepositoryPickerProps(
+  context: ReturnType<typeof useAppContext>,
+  workspaceId: string,
+  disabled: boolean,
+) {
+  return {
+    setupMode:
+      context.githubStatus?.setupMode ??
+      (context.clientConfig.productAccessMode === "managed" ? "platform" : "operator"),
+    configured: context.githubStatus?.configured === true,
+    status: context.githubStatus?.status ?? ("disabled" as const),
+    installUrl: context.githubStatus?.installUrl ?? null,
+    linkUrl: context.githubStatus?.linkUrl ?? null,
+    installations: context.githubStatus?.installations ?? [],
+    repositories: context.githubRepos,
+    groups: context.repositoryGroups,
+    selectedRepoIds: context.selectedRepoIds,
+    selectedRepoRefs: context.selectedRepoRefs,
+    selectedInstallationId: context.selectedInstallationId,
+    manualRepos: context.manualRepos,
+    manualOpen: context.manualReposOpen,
+    githubAppOpen: context.githubAppOpen,
+    org: context.githubOrg,
+    pending: context.busy || disabled,
+    repoBusy: context.repoBusy,
+    githubAppBusy: context.githubAppBusy,
+    onRefresh: () => context.refreshGitHub(workspaceId, undefined, { sync: true }),
+    onToggleRepo: context.toggleGitHubRepository,
+    onRefChange: (repoId: number, ref: string) =>
+      context.setSelectedRepoRefs((current) => ({ ...current, [repoId]: ref })),
+    onManualOpenChange: context.setManualReposOpen,
+    onManualAdd: context.addManualRepository,
+    onManualUpdate: (id: number, patch: Partial<RepoDraft>) =>
+      context.setManualRepos((current) =>
+        current.map((repo) => (repo.id === id ? { ...repo, ...patch } : repo)),
+      ),
+    onManualRemove: (id: number) =>
+      context.setManualRepos((current) => current.filter((repo) => repo.id !== id)),
+    onGitHubAppOpenChange: context.setGithubAppOpen,
+    onOrgChange: context.setGithubOrg,
+    onStartGitHubApp: () => void context.startGitHubAppManifestFlow(workspaceId),
+    onDisconnectInstallation: (installationId: number) =>
+      context.disconnectGitHubInstallation(workspaceId, installationId),
+  };
+}
+
 // The workspace repository picker, wired to the cross-route selection in context.
 // Reused in both compute kinds: the primary clone source on a managed sandbox,
 // and grayed/disabled on a connected machine (which uses its own checkout).
+// Mobile opens the same body from ComposerMobilePlus — hide the bar pill there.
 function WorkspaceRepositoryPicker({
   workspaceId,
   disabled,
+  triggerClassName,
 }: {
   workspaceId: string;
   disabled: boolean;
+  triggerClassName?: string;
 }) {
   const context = useAppContext();
   return (
     <RepositoryContextPicker
-      setupMode={
-        context.githubStatus?.setupMode ??
-        (context.clientConfig.productAccessMode === "managed" ? "platform" : "operator")
-      }
-      configured={context.githubStatus?.configured === true}
-      status={context.githubStatus?.status ?? "disabled"}
-      installUrl={context.githubStatus?.installUrl ?? null}
-      linkUrl={context.githubStatus?.linkUrl ?? null}
-      installations={context.githubStatus?.installations ?? []}
-      repositories={context.githubRepos}
-      groups={context.repositoryGroups}
-      selectedRepoIds={context.selectedRepoIds}
-      selectedRepoRefs={context.selectedRepoRefs}
-      selectedInstallationId={context.selectedInstallationId}
-      manualRepos={context.manualRepos}
-      manualOpen={context.manualReposOpen}
-      githubAppOpen={context.githubAppOpen}
-      org={context.githubOrg}
-      pending={context.busy || disabled}
-      repoBusy={context.repoBusy}
-      githubAppBusy={context.githubAppBusy}
-      onRefresh={() => context.refreshGitHub(workspaceId, undefined, { sync: true })}
-      onToggleRepo={context.toggleGitHubRepository}
-      onRefChange={(repoId, ref) =>
-        context.setSelectedRepoRefs((current) => ({ ...current, [repoId]: ref }))
-      }
-      onManualOpenChange={context.setManualReposOpen}
-      onManualAdd={context.addManualRepository}
-      onManualUpdate={(id, patch) =>
-        context.setManualRepos((current) =>
-          current.map((repo) => (repo.id === id ? { ...repo, ...patch } : repo)),
-        )
-      }
-      onManualRemove={(id) =>
-        context.setManualRepos((current) => current.filter((repo) => repo.id !== id))
-      }
-      onGitHubAppOpenChange={context.setGithubAppOpen}
-      onOrgChange={context.setGithubOrg}
-      onStartGitHubApp={() => void context.startGitHubAppManifestFlow(workspaceId)}
-      onDisconnectInstallation={(installationId) =>
-        context.disconnectGitHubInstallation(workspaceId, installationId)
-      }
+      {...workspaceRepositoryPickerProps(context, workspaceId, disabled)}
+      {...(triggerClassName ? { triggerClassName } : {})}
+    />
+  );
+}
+
+function WorkspaceRepositoryMenuBody({
+  workspaceId,
+  disabled,
+  leading,
+}: {
+  workspaceId: string;
+  disabled: boolean;
+  leading?: ReactNode;
+}) {
+  const context = useAppContext();
+  return (
+    <RepositoryContextMenuBody
+      {...workspaceRepositoryPickerProps(context, workspaceId, disabled)}
+      {...(leading ? { leading } : {})}
     />
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
     },
     "apps/api": {
       "name": "@opengeni/api-router",
-      "version": "0.15.5",
+      "version": "0.21.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",
@@ -130,7 +130,7 @@
     },
     "apps/worker": {
       "name": "@opengeni/worker-bundle",
-      "version": "0.13.10",
+      "version": "0.16.4",
       "dependencies": {
         "@opengeni/agent-proto": "workspace:*",
         "@opengeni/codex": "workspace:*",
@@ -159,7 +159,7 @@
     },
     "examples/northstar-support": {
       "name": "@opengeni/example-northstar-support",
-      "version": "0.0.44",
+      "version": "0.0.59",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opengeni/react": "workspace:*",
@@ -194,7 +194,7 @@
     },
     "packages/codex": {
       "name": "@opengeni/codex",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "zod": "^4.2.1",
       },
@@ -205,7 +205,7 @@
     },
     "packages/config": {
       "name": "@opengeni/config",
-      "version": "0.9.1",
+      "version": "0.10.7",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -218,7 +218,7 @@
     },
     "packages/contracts": {
       "name": "@opengeni/contracts",
-      "version": "0.28.1",
+      "version": "0.36.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
         "zod": "^4.2.1",
@@ -230,7 +230,7 @@
     },
     "packages/core": {
       "name": "@opengeni/core",
-      "version": "0.16.2",
+      "version": "0.20.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opengeni/codex": "workspace:*",
@@ -252,7 +252,7 @@
     },
     "packages/db": {
       "name": "@opengeni/db",
-      "version": "0.19.0",
+      "version": "0.27.0",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/config": "workspace:*",
@@ -281,7 +281,7 @@
     },
     "packages/documents": {
       "name": "@opengeni/documents",
-      "version": "0.2.64",
+      "version": "0.3.3",
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.3",
         "@opengeni/config": "workspace:*",
@@ -292,13 +292,14 @@
         "openai": "6.36.0",
       },
       "devDependencies": {
+        "@opengeni/testing": "workspace:*",
         "tsup": "^8.5.0",
         "typescript": "7.0.2",
       },
     },
     "packages/events": {
       "name": "@opengeni/events",
-      "version": "0.3.55",
+      "version": "0.3.66",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "@opengeni/db": "workspace:*",
@@ -311,7 +312,7 @@
     },
     "packages/github": {
       "name": "@opengeni/github",
-      "version": "0.4.13",
+      "version": "0.4.23",
       "dependencies": {
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -335,7 +336,7 @@
     },
     "packages/observability": {
       "name": "@opengeni/observability",
-      "version": "0.3.0",
+      "version": "0.4.10",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "prom-client": "^15.1.3",
@@ -358,7 +359,7 @@
     },
     "packages/react": {
       "name": "@opengeni/react",
-      "version": "0.34.1",
+      "version": "0.41.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
         "@dnd-kit/core": "6.3.1",
@@ -442,7 +443,7 @@
     },
     "packages/runtime": {
       "name": "@opengeni/runtime",
-      "version": "0.15.3",
+      "version": "0.18.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@noble/hashes": "^1.8.0",
@@ -467,7 +468,7 @@
     },
     "packages/sdk": {
       "name": "@opengeni/sdk",
-      "version": "0.34.1",
+      "version": "0.41.0",
       "devDependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -479,7 +480,7 @@
     },
     "packages/storage": {
       "name": "@opengeni/storage",
-      "version": "0.2.50",
+      "version": "0.2.60",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1306,6 +1306,7 @@ const RegistryModelSchema = z
     upstreamModelId: z.string().min(1).optional(), // exact provider slug; defaults to id
     aliases: z.array(z.string().min(1)).optional(), // accepted input only; never sent upstream
     label: z.string().min(1).optional(), // display name; defaults to id
+    shortLabel: z.string().min(1).max(64).optional(), // compact UI label; optional
     contextWindowTokens: z.number().int().positive().optional(),
     effectiveContextWindowTokens: z.number().int().positive().optional(),
     autoCompactTokenLimit: z.number().int().positive().optional(),
@@ -1406,6 +1407,8 @@ export interface ConfiguredModel {
   id: string;
   aliases: string[];
   label: string;
+  /** Optional curated compact label for dense UI (e.g. mobile composer). */
+  shortLabel?: string | undefined;
   providerId: string;
   providerLabel: string;
   api: ModelProviderApi;
@@ -1491,6 +1494,7 @@ export const OPENGENI_GATEWAY_MODELS = {
     workspaceProductId: `${WORKSPACE_GATEWAY_MODEL_ID_PREFIX}deepseek-v4-flash-0731`,
     upstreamModelId: "deepseek/deepseek-v4-flash-0731",
     label: "DeepSeek V4 Flash 0731",
+    shortLabel: "V4 Flash",
     providers: ["baseten", "novita", "deepinfra"],
     implicitCaching: true,
   },
@@ -1499,6 +1503,7 @@ export const OPENGENI_GATEWAY_MODELS = {
     workspaceProductId: `${WORKSPACE_GATEWAY_MODEL_ID_PREFIX}kimi-k3`,
     upstreamModelId: "moonshotai/kimi-k3",
     label: "Kimi K3",
+    shortLabel: "Kimi K3",
     providers: ["baseten", "fireworks"],
     implicitCaching: true,
   },
@@ -2381,6 +2386,7 @@ function gatewayRegistryProvider(
       id: workspace ? model.workspaceProductId : model.productId,
       upstreamModelId: model.upstreamModelId,
       label: model.label,
+      shortLabel: model.shortLabel,
       capabilities: gatewayModelCapabilities(settings, {
         implicitCaching: model.implicitCaching,
         vision: kimi,
@@ -2479,6 +2485,26 @@ export function productLabelForModelId(modelId: string): string {
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
     .join(" ");
   return suffix.length > 0 ? `${family} ${suffix}` : family;
+}
+
+/**
+ * Curated compact product labels for dense UI. Only known GPT family slugs;
+ * everything else returns null so callers fall back to the full `label`.
+ */
+export function productShortLabelForModelId(modelId: string): string | null {
+  const slug = modelId.startsWith(CODEX_MODEL_ID_PREFIX)
+    ? modelId.slice(CODEX_MODEL_ID_PREFIX.length)
+    : modelId;
+  switch (slug) {
+    case "gpt-5.6-sol":
+      return "5.6 Sol";
+    case "gpt-5.6-terra":
+      return "5.6 Terra";
+    case "gpt-5.6-luna":
+      return "5.6 Luna";
+    default:
+      return null;
+  }
 }
 
 function builtinLatencyModesForModel(modelId: string): Array<{
@@ -2780,6 +2806,9 @@ export function withCodexCatalogProvider(settings: Settings): Settings {
         id: `${CODEX_MODEL_ID_PREFIX}${slug}`,
         upstreamModelId: slug,
         label: productLabelForModelId(slug),
+        ...(productShortLabelForModelId(slug)
+          ? { shortLabel: productShortLabelForModelId(slug)! }
+          : {}),
         reasoningEffort: true,
         // The ChatGPT/Codex Responses backend accepts the native web_search
         // hosted tool (unlike hosted apply_patch/computer transports). Declaring
@@ -2965,6 +2994,9 @@ export function configuredModels(settings: Settings): ConfiguredModel[] {
         id,
         aliases: [],
         label: productLabelForModelId(id),
+        ...(productShortLabelForModelId(id)
+          ? { shortLabel: productShortLabelForModelId(id)! }
+          : {}),
         providerId: builtinId,
         providerLabel: builtinLabel,
         api: "responses" as const,
@@ -2999,6 +3031,11 @@ export function configuredModels(settings: Settings): ConfiguredModel[] {
           id: model.id,
           aliases: [...(model.aliases ?? [])],
           label: model.label ?? productLabelForModelId(model.id),
+          ...(model.shortLabel
+            ? { shortLabel: model.shortLabel }
+            : productShortLabelForModelId(model.id)
+              ? { shortLabel: productShortLabelForModelId(model.id)! }
+              : {}),
           providerId: provider.id,
           providerLabel,
           api: provider.api,

--- a/packages/config/test/model-providers.test.ts
+++ b/packages/config/test/model-providers.test.ts
@@ -14,6 +14,7 @@ import {
   parseModelProvidersJson,
   policyProviderIdForModel,
   productLabelForModelId,
+  productShortLabelForModelId,
   resolveModelProvider,
   resolveProviderApiKey,
   resolveTurnExecutionPolicyV1,
@@ -82,6 +83,9 @@ describe("curated AI Gateway catalogue", () => {
     )!;
     const kimi = models.find((model) => model.id === OPENGENI_GATEWAY_MODELS.kimi.productId)!;
     expect(deepseek.upstreamModelId).toBe(OPENGENI_GATEWAY_MODELS.deepseek.upstreamModelId);
+    expect(deepseek.label).toBe("DeepSeek V4 Flash 0731");
+    expect(deepseek.shortLabel).toBe("V4 Flash");
+    expect(kimi.shortLabel).toBe("Kimi K3");
     expect(deepseek.requestPolicy).toEqual({
       gateway: { only: ["baseten", "novita", "deepinfra"], caching: "auto" },
     });
@@ -613,6 +617,16 @@ describe("productLabelForModelId", () => {
   });
 });
 
+describe("productShortLabelForModelId", () => {
+  test("curates compact GPT-5.6 product labels and leaves others unset", () => {
+    expect(productShortLabelForModelId("gpt-5.6-sol")).toBe("5.6 Sol");
+    expect(productShortLabelForModelId("codex/gpt-5.6-sol")).toBe("5.6 Sol");
+    expect(productShortLabelForModelId("gpt-5.6-luna")).toBe("5.6 Luna");
+    expect(productShortLabelForModelId("gpt-5.6-terra")).toBe("5.6 Terra");
+    expect(productShortLabelForModelId("gpt-5.4-mini")).toBeNull();
+  });
+});
+
 describe("configuredModels", () => {
   test("Codex catalog overlay uses the same product labels as OpenAI", () => {
     const settings = withEnv(
@@ -627,6 +641,10 @@ describe("configuredModels", () => {
     const models = configuredModels(settings);
     expect(models.find((model) => model.id === "gpt-5.6-luna")?.label).toBe("GPT-5.6 Luna");
     expect(models.find((model) => model.id === "codex/gpt-5.6-luna")?.label).toBe("GPT-5.6 Luna");
+    expect(models.find((model) => model.id === "gpt-5.6-sol")?.shortLabel).toBe("5.6 Sol");
+    expect(models.find((model) => model.id === "codex/gpt-5.6-sol")?.shortLabel).toBe("5.6 Sol");
+    expect(models.find((model) => model.id === "gpt-5.6-luna")?.shortLabel).toBe("5.6 Luna");
+    expect(models.find((model) => model.id === "gpt-5.6-terra")?.shortLabel).toBe("5.6 Terra");
     expect(
       models.find((model) => model.id === "gpt-5.6-luna")?.capabilities.inputModalities,
     ).toEqual(["text", "image"]);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9772,6 +9772,8 @@ export const ClientModel = /* @__PURE__ */ defineModelContractSchema(() =>
   z.object({
     id: z.string(),
     label: z.string(),
+    /** Optional curated compact label for dense UI (e.g. mobile composer). */
+    shortLabel: z.string().min(1).max(64).optional(),
     provider: z.string(), // provider id
     providerLabel: z.string(),
     api: z.enum(["responses", "chat"]),

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -1079,6 +1079,26 @@ describe("contracts", () => {
     ).toThrow();
   });
 
+  test("accepts an optional curated shortLabel on ClientModel", () => {
+    const withShort = ClientModel.parse({
+      id: "deepseek-v4-flash-0731",
+      label: "DeepSeek V4 Flash 0731",
+      shortLabel: "V4 Flash",
+      provider: "opengeni-gateway",
+      providerLabel: "OpenGeni Gateway",
+      api: "responses",
+    });
+    expect(withShort.shortLabel).toBe("V4 Flash");
+    const without = ClientModel.parse({
+      id: "gpt-5.6-sol",
+      label: "GPT-5.6 Sol",
+      provider: "openai",
+      providerLabel: "OpenAI",
+      api: "responses",
+    });
+    expect(without.shortLabel).toBeUndefined();
+  });
+
   test("accepts additive normalized model definitions and authenticated availability", () => {
     const normalized = ClientModel.parse({
       id: "xai/grok-4.5",

--- a/packages/db/src/session-realtime-context.ts
+++ b/packages/db/src/session-realtime-context.ts
@@ -10,7 +10,7 @@ import { submitHumanPromptInTransaction } from "./session-queue-commands";
 export const SESSION_REALTIME_CONTEXT_MAX_BYTES = 65_536;
 export const SESSION_REALTIME_TAIL_SOURCE = "transcript_tail_flush";
 export const SESSION_REALTIME_TAIL_INSTRUCTION =
-  "The user just ended their realtime session. Here is the remaining handoff/transcript tail. You probably do not have to do anything; acknowledge the handoff unless the transcript itself asks for something.";
+  "The user just ended the realtime voice session but remains reachable by text. Ending voice changes only the communication mode; it does not stop, pause, or complete existing work. Treat the remaining transcript tail as additional context. If work was already underway, continue it from the current state. Change or stop that work only if the user explicitly requested it. If nothing was underway and the transcript contains no unhandled request, acknowledge briefly; otherwise handle any unhandled request.";
 
 export type SessionRealtimeContextProjection = {
   id: string;

--- a/packages/db/test/session-realtime-context.test.ts
+++ b/packages/db/test/session-realtime-context.test.ts
@@ -14,6 +14,7 @@ import {
   getSessionRealtimeContinuityEntries,
   renderSessionRealtimeTail,
   SESSION_REALTIME_CONTEXT_MAX_BYTES,
+  SESSION_REALTIME_TAIL_INSTRUCTION,
   SESSION_REALTIME_TAIL_SOURCE,
   syncSessionRealtimeLedgerInTransaction,
   withWorkspaceRls,
@@ -215,6 +216,9 @@ describe("session realtime transcript tail and continuity", () => {
       sourceEntry("user", "x".repeat(SESSION_REALTIME_CONTEXT_MAX_BYTES * 2)),
     ]);
     expect(rendered.context).toContain(`<source>${SESSION_REALTIME_TAIL_SOURCE}</source>`);
+    expect(rendered.context).toContain(SESSION_REALTIME_TAIL_INSTRUCTION);
+    expect(rendered.context).toContain("continue it from the current state");
+    expect(rendered.context).not.toContain("You probably do not have to do anything");
     expect(rendered.context).toContain("[2 older transcript turns omitted]");
     expect(Buffer.byteLength(rendered.context!, "utf8")).toBeLessThanOrEqual(
       SESSION_REALTIME_CONTEXT_MAX_BYTES,

--- a/packages/react/demo/timeline-fixtures.ts
+++ b/packages/react/demo/timeline-fixtures.ts
@@ -335,6 +335,33 @@ export function tourEvents(): SessionEvent[] {
     },
     turn,
   );
+  // apply_patch — Codex function-tool freeform `{ patch }` (not hosted apply_patch_call)
+  {
+    const freeformPatch = [
+      "*** Begin Patch",
+      "*** Update File: src/realtime/controller.ts",
+      "@@",
+      "-export const legacy = true;",
+      "+export const legacy = false;",
+      "*** Add File: src/realtime/public.ts",
+      "+export { RealtimeController } from './controller';",
+      "*** End Patch",
+    ].join("\n");
+    log.tool(
+      {
+        name: "apply_patch",
+        id: "call-ap-codex-0",
+        raw: {
+          type: "function_call",
+          name: "apply_patch",
+          arguments: JSON.stringify({ patch: freeformPatch }),
+        },
+        arguments: JSON.stringify({ patch: freeformPatch }),
+        output: "Patch applied.",
+      },
+      turn,
+    );
+  }
 
   // computer_call — screenshot with image
   log.tool(

--- a/packages/react/src/components/chat-composer.tsx
+++ b/packages/react/src/components/chat-composer.tsx
@@ -1,4 +1,5 @@
 import type { ClientModel, EffectiveSessionControl } from "@opengeni/sdk";
+import { LayoutGroup, motion } from "motion/react";
 import type { ClipboardEvent, ReactNode } from "react";
 import type { SlashCommand } from "../commands/types";
 import type { ComposerState } from "../hooks/use-composer";
@@ -61,6 +62,10 @@ export type ChatComposerProps = {
   attachButtonClassName?: string | undefined;
   /** Provider-neutral speech capability. Provider configuration stays in workspace settings. */
   transcription?: ComposerTranscriptionControlProps | undefined;
+  /** Extra classes on the transcription control. */
+  transcriptionClassName?: string | undefined;
+  /** Soft-hide dictate while realtime voice is active (animated collapse). */
+  transcriptionSuppressed?: boolean | undefined;
   /** Content rendered above the textarea, inside the field chrome. */
   header?: ReactNode | undefined;
   /** Paste hook composed with the attachment paste path. */
@@ -99,6 +104,8 @@ export function ChatComposer({
   actionsStart,
   attachButtonClassName,
   transcription,
+  transcriptionClassName,
+  transcriptionSuppressed = false,
   header,
   onPaste,
   attachments,
@@ -145,25 +152,57 @@ export function ChatComposer({
           {controller.confirmState ? (
             <Confirmation />
           ) : (
-            <Footer className={stackActions ? "flex-wrap" : undefined}>
-              {hasControls ? (
-                <Controls className={stackActions ? "w-full sm:w-auto" : undefined}>
-                  {controlsLeading}
-                  <AttachButton className={attachButtonClassName} />
-                  {transcription ? <ComposerTranscriptionControl {...transcription} /> : null}
-                  {models ? (
-                    <ModelPicker models={models} value={selectedModel} onChange={onSelectModel} />
-                  ) : null}
-                  {controlsStart}
-                </Controls>
-              ) : (
-                <Hint>{hint}</Hint>
-              )}
-              <Actions className={stackActions ? "w-full justify-end sm:w-auto" : undefined}>
-                {actionsStart}
-                <PauseButton />
-                <SendButton />
-              </Actions>
+            <Footer className={stackActions ? "max-sm:flex-nowrap sm:flex-wrap" : undefined}>
+              <LayoutGroup id="og-composer-footer">
+                {hasControls ? (
+                  <Controls
+                    className={stackActions ? "min-w-0 max-sm:flex-1 sm:w-auto" : undefined}
+                  >
+                    {controlsLeading}
+                    <AttachButton className={attachButtonClassName} />
+                    {transcription ? (
+                      <ComposerTranscriptionControl
+                        {...transcription}
+                        suppressed={transcriptionSuppressed}
+                        className={[transcription.className, transcriptionClassName]
+                          .filter(Boolean)
+                          .join(" ")}
+                      />
+                    ) : null}
+                    {models ? (
+                      <motion.span
+                        layout
+                        transition={{ duration: 0.36, ease: [0.22, 1, 0.36, 1] }}
+                        className="inline-flex min-w-0"
+                      >
+                        <ModelPicker
+                          models={models}
+                          value={selectedModel}
+                          onChange={onSelectModel}
+                        />
+                      </motion.span>
+                    ) : null}
+                    {controlsStart ? (
+                      <motion.span
+                        layout
+                        transition={{ duration: 0.36, ease: [0.22, 1, 0.36, 1] }}
+                        className="inline-flex min-w-0 items-center gap-1.5"
+                      >
+                        {controlsStart}
+                      </motion.span>
+                    ) : null}
+                  </Controls>
+                ) : (
+                  <Hint>{hint}</Hint>
+                )}
+                <Actions
+                  className={stackActions ? "max-sm:shrink-0 sm:w-auto sm:justify-end" : undefined}
+                >
+                  {actionsStart}
+                  <PauseButton />
+                  <SendButton />
+                </Actions>
+              </LayoutGroup>
             </Footer>
           )}
         </Surface>

--- a/packages/react/src/components/composer-transcription-control.tsx
+++ b/packages/react/src/components/composer-transcription-control.tsx
@@ -101,6 +101,8 @@ export type ComposerTranscriptionControlProps = {
   createRecordingStore?: (() => VoiceRecordingStore) | undefined;
   /** Test/embed seam. Production acquires a coordinated browser-document owner lease. */
   createOwnerId?: (() => string) | undefined;
+  /** Hide while realtime voice owns the mic — collapses with a layout-friendly exit. */
+  suppressed?: boolean | undefined;
 };
 
 const WAVEFORM_BARS = 18;
@@ -119,6 +121,7 @@ export function ComposerTranscriptionControl({
   className,
   createRecordingStore,
   createOwnerId,
+  suppressed = false,
 }: ComposerTranscriptionControlProps) {
   const composer = useChatComposer();
   const messages = { ...defaultMessages, ...overrides };
@@ -126,7 +129,7 @@ export function ComposerTranscriptionControl({
     client,
     workspaceId,
     capability,
-    enabled: workspaceEnabled,
+    enabled: workspaceEnabled && !suppressed,
     value: composer.value,
     setValue: composer.setValue,
     focusInput: composer.focusInput,
@@ -135,6 +138,14 @@ export function ComposerTranscriptionControl({
     createOwnerId,
   });
   const { status } = transcription;
+
+  const cancelTranscription = transcription.cancel;
+  useEffect(() => {
+    if (!suppressed) return;
+    if (status === "recording" || status === "requesting-permission") {
+      cancelTranscription();
+    }
+  }, [cancelTranscription, status, suppressed]);
   const active =
     status === "requesting-permission" ||
     status === "recording" ||
@@ -181,179 +192,197 @@ export function ComposerTranscriptionControl({
   }
 
   return (
-    <span
-      className={cn("inline-flex min-w-0 items-center gap-1.5", className)}
-      data-transcription-status={status}
-    >
-      <AnimatePresence mode="popLayout" initial={false}>
-        {recoverable ? (
-          <motion.span
-            key="recovered"
-            initial={{ opacity: 0, scale: 0.96 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.96 }}
-            transition={{ duration: 0.16, ease: [0.22, 1, 0.36, 1] }}
-            className={cn(
-              "inline-flex h-8 min-w-0 items-center gap-1 rounded-og-md border border-og-border/80",
-              "bg-og-surface-2/70 pl-2 pr-1 pointer-coarse:h-11",
-            )}
-          >
-            <span className="max-w-44 truncate text-og-xs text-og-fg-muted max-sm:max-w-28">
-              {savedTranscript
-                ? (errorMessage ?? messages.recoveredTranscript)
-                : status === "error"
-                  ? (errorMessage ?? messages.errorRetryable)
-                  : messages.recovered}
-            </span>
-            <Tip tip={savedTranscript ? messages.insertRecoveredTranscript : messages.retry}>
-              <button
-                type="button"
-                onClick={() =>
-                  savedTranscript
-                    ? void transcription.insertSavedTranscript()
-                    : transcription.retry()
-                }
-                aria-label={savedTranscript ? messages.insertRecoveredTranscript : messages.retry}
-                className={cn(
-                  "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
-                  "bg-og-fg text-og-bg transition-colors duration-150 motion-reduce:transition-none",
-                  "hover:bg-og-fg-muted pointer-coarse:size-11",
-                )}
-              >
-                {savedTranscript ? (
-                  <ClipboardPasteIcon className="size-3.5" />
-                ) : (
-                  <RefreshCwIcon className="size-3.5" />
-                )}
-              </button>
-            </Tip>
-            <Tip tip={messages.discardRecovered}>
-              <button
-                type="button"
-                onClick={() => void transcription.discard()}
-                aria-label={messages.discardRecovered}
-                className={cn(
-                  "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
-                  "text-og-fg-muted transition-colors duration-150 motion-reduce:transition-none",
-                  "hover:bg-og-surface-3 hover:text-og-status-failed pointer-coarse:size-11",
-                )}
-              >
-                <Trash2Icon className="size-3.5" />
-              </button>
-            </Tip>
-          </motion.span>
-        ) : active ? (
-          <motion.span
-            key={status === "transcribing" || status === "saving" ? "processing" : "capture"}
-            initial={{ opacity: 0, scale: 0.96 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.96 }}
-            transition={{ duration: 0.16, ease: [0.22, 1, 0.36, 1] }}
-            className={cn(
-              "inline-flex h-8 items-center gap-1 rounded-og-md border border-og-border/80",
-              "bg-og-surface-2/70 pl-2 pr-1 pointer-coarse:h-11",
-            )}
-          >
-            {status === "requesting-permission" ? (
-              <LoaderCircleIcon
-                className="size-3.5 shrink-0 text-og-fg-muted animate-og-spin motion-reduce:animate-none"
-                aria-hidden
-              />
-            ) : (
-              <span className="flex items-center gap-1.5">
-                {status === "recording" ? (
-                  <span
-                    aria-hidden
-                    className="size-1.5 shrink-0 rounded-full bg-og-status-failed animate-og-pulse motion-reduce:animate-none"
-                  />
-                ) : null}
-                <VoiceWaveform
-                  stream={status === "recording" ? transcription.stream : null}
-                  mode={status === "recording" ? "recording" : "transcribing"}
-                />
-              </span>
-            )}
-            {status === "recording" ? (
-              <>
-                <Tip tip={messages.cancel}>
-                  <button
+    <AnimatePresence initial={false}>
+      {suppressed ? null : (
+        <motion.span
+          key="composer-dictate"
+          initial={{ opacity: 0, width: 0 }}
+          animate={{ opacity: 1, width: "auto" }}
+          exit={{ opacity: 0, width: 0 }}
+          transition={{ duration: 0.36, ease: [0.22, 1, 0.36, 1] }}
+          className={cn("inline-flex min-w-0 overflow-hidden", className)}
+          data-transcription-status={status}
+        >
+          <span className="inline-flex min-w-0 items-center gap-1.5">
+            <AnimatePresence mode="popLayout" initial={false}>
+              {recoverable ? (
+                <motion.span
+                  key="recovered"
+                  initial={{ opacity: 0, scale: 0.96 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.96 }}
+                  transition={{ duration: 0.16, ease: [0.22, 1, 0.36, 1] }}
+                  className={cn(
+                    "inline-flex h-8 min-w-0 items-center gap-1 rounded-og-md border border-og-border/80",
+                    "bg-og-surface-2/70 pl-2 pr-1 pointer-coarse:h-11",
+                  )}
+                >
+                  <span className="max-w-44 truncate text-og-xs text-og-fg-muted max-sm:max-w-28">
+                    {savedTranscript
+                      ? (errorMessage ?? messages.recoveredTranscript)
+                      : status === "error"
+                        ? (errorMessage ?? messages.errorRetryable)
+                        : messages.recovered}
+                  </span>
+                  <Tip tip={savedTranscript ? messages.insertRecoveredTranscript : messages.retry}>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        savedTranscript
+                          ? void transcription.insertSavedTranscript()
+                          : transcription.retry()
+                      }
+                      aria-label={
+                        savedTranscript ? messages.insertRecoveredTranscript : messages.retry
+                      }
+                      className={cn(
+                        "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
+                        "bg-og-fg text-og-bg transition-colors duration-150 motion-reduce:transition-none",
+                        "hover:bg-og-fg-muted pointer-coarse:size-11",
+                      )}
+                    >
+                      {savedTranscript ? (
+                        <ClipboardPasteIcon className="size-3.5" />
+                      ) : (
+                        <RefreshCwIcon className="size-3.5" />
+                      )}
+                    </button>
+                  </Tip>
+                  <Tip tip={messages.discardRecovered}>
+                    <button
+                      type="button"
+                      onClick={() => void transcription.discard()}
+                      aria-label={messages.discardRecovered}
+                      className={cn(
+                        "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
+                        "text-og-fg-muted transition-colors duration-150 motion-reduce:transition-none",
+                        "hover:bg-og-surface-3 hover:text-og-status-failed pointer-coarse:size-11",
+                      )}
+                    >
+                      <Trash2Icon className="size-3.5" />
+                    </button>
+                  </Tip>
+                </motion.span>
+              ) : active ? (
+                <motion.span
+                  key={status === "transcribing" || status === "saving" ? "processing" : "capture"}
+                  initial={{ opacity: 0, scale: 0.96 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.96 }}
+                  transition={{ duration: 0.16, ease: [0.22, 1, 0.36, 1] }}
+                  className={cn(
+                    "inline-flex h-8 items-center gap-1 rounded-og-md border border-og-border/80",
+                    "bg-og-surface-2/70 pl-2 pr-1 pointer-coarse:h-11",
+                  )}
+                >
+                  {status === "requesting-permission" ? (
+                    <LoaderCircleIcon
+                      className="size-3.5 shrink-0 text-og-fg-muted animate-og-spin motion-reduce:animate-none"
+                      aria-hidden
+                    />
+                  ) : (
+                    <span className="flex items-center gap-1.5">
+                      {status === "recording" ? (
+                        <span
+                          aria-hidden
+                          className="size-1.5 shrink-0 rounded-full bg-og-status-failed animate-og-pulse motion-reduce:animate-none"
+                        />
+                      ) : null}
+                      <VoiceWaveform
+                        stream={status === "recording" ? transcription.stream : null}
+                        mode={status === "recording" ? "recording" : "transcribing"}
+                      />
+                    </span>
+                  )}
+                  {status === "recording" ? (
+                    <>
+                      <Tip tip={messages.cancel}>
+                        <button
+                          type="button"
+                          onClick={() => transcription.cancel()}
+                          aria-label={messages.cancel}
+                          aria-keyshortcuts="Escape"
+                          className={cn(
+                            "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
+                            "text-og-fg-muted transition-colors duration-150 motion-reduce:transition-none",
+                            "hover:bg-og-surface-3 hover:text-og-fg pointer-coarse:size-11",
+                          )}
+                        >
+                          <XIcon className="size-3.5" />
+                        </button>
+                      </Tip>
+                      <Tip tip={messages.stop}>
+                        <button
+                          type="button"
+                          onClick={() => transcription.stop()}
+                          aria-label={messages.stop}
+                          className={cn(
+                            "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
+                            "bg-og-fg text-og-bg transition-colors duration-150 motion-reduce:transition-none",
+                            "hover:bg-og-fg-muted pointer-coarse:size-11",
+                          )}
+                        >
+                          <SquareIcon className="size-2.5 fill-current" />
+                        </button>
+                      </Tip>
+                    </>
+                  ) : status === "transcribing" || status === "saving" ? (
+                    <span className="og-shimmer-text px-1.5 text-og-xs font-medium whitespace-nowrap">
+                      {status === "saving" ? messages.saving : messages.transcribing}
+                    </span>
+                  ) : (
+                    <span className="px-1.5 text-og-xs text-og-fg-muted whitespace-nowrap">
+                      {messages.requestingPermission}
+                    </span>
+                  )}
+                </motion.span>
+              ) : (
+                <Tip key="idle" tip={idleLabel}>
+                  <motion.button
                     type="button"
-                    onClick={() => transcription.cancel()}
-                    aria-label={messages.cancel}
-                    aria-keyshortcuts="Escape"
+                    data-og-composer-dictate
+                    initial={{ opacity: 0, scale: 0.96 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{ opacity: 0, scale: 0.96 }}
+                    transition={{ duration: 0.14, ease: [0.22, 1, 0.36, 1] }}
+                    onClick={start}
+                    aria-label={idleLabel}
+                    aria-pressed={false}
+                    aria-disabled={unavailableMessage !== null}
                     className={cn(
-                      "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
+                      "inline-flex size-8 shrink-0 items-center justify-center rounded-og-md pointer-coarse:size-11",
                       "text-og-fg-muted transition-colors duration-150 motion-reduce:transition-none",
-                      "hover:bg-og-surface-3 hover:text-og-fg pointer-coarse:size-11",
+                      unavailableMessage
+                        ? "cursor-not-allowed opacity-45"
+                        : "hover:bg-og-surface-2 hover:text-og-fg",
                     )}
                   >
-                    <XIcon className="size-3.5" />
-                  </button>
+                    <MicIcon className="size-4" />
+                  </motion.button>
                 </Tip>
-                <Tip tip={messages.stop}>
-                  <button
-                    type="button"
-                    onClick={() => transcription.stop()}
-                    aria-label={messages.stop}
-                    className={cn(
-                      "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
-                      "bg-og-fg text-og-bg transition-colors duration-150 motion-reduce:transition-none",
-                      "hover:bg-og-fg-muted pointer-coarse:size-11",
-                    )}
-                  >
-                    <SquareIcon className="size-2.5 fill-current" />
-                  </button>
-                </Tip>
-              </>
-            ) : status === "transcribing" || status === "saving" ? (
-              <span className="og-shimmer-text px-1.5 text-og-xs font-medium whitespace-nowrap">
-                {status === "saving" ? messages.saving : messages.transcribing}
-              </span>
-            ) : (
-              <span className="px-1.5 text-og-xs text-og-fg-muted whitespace-nowrap">
-                {messages.requestingPermission}
-              </span>
-            )}
-          </motion.span>
-        ) : (
-          <Tip key="idle" tip={idleLabel}>
-            <motion.button
-              type="button"
-              initial={{ opacity: 0, scale: 0.96 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.96 }}
-              transition={{ duration: 0.14, ease: [0.22, 1, 0.36, 1] }}
-              onClick={start}
-              aria-label={idleLabel}
-              aria-pressed={false}
-              aria-disabled={unavailableMessage !== null}
-              className={cn(
-                "inline-flex size-8 shrink-0 items-center justify-center rounded-og-md pointer-coarse:size-11",
-                "text-og-fg-muted transition-colors duration-150 motion-reduce:transition-none",
-                unavailableMessage
-                  ? "cursor-not-allowed opacity-45"
-                  : "hover:bg-og-surface-2 hover:text-og-fg",
               )}
+            </AnimatePresence>
+            {status === "error" && errorMessage && !recoverable ? (
+              <Tip tip={errorMessage}>
+                <span
+                  aria-hidden="true"
+                  className="max-w-40 truncate text-og-xs text-og-status-failed max-sm:max-w-24"
+                >
+                  {errorMessage}
+                </span>
+              </Tip>
+            ) : null}
+            <span
+              className="sr-only"
+              role={status === "error" ? "alert" : "status"}
+              aria-live="polite"
             >
-              <MicIcon className="size-4" />
-            </motion.button>
-          </Tip>
-        )}
-      </AnimatePresence>
-      {status === "error" && errorMessage && !recoverable ? (
-        <Tip tip={errorMessage}>
-          <span
-            aria-hidden="true"
-            className="max-w-40 truncate text-og-xs text-og-status-failed max-sm:max-w-24"
-          >
-            {errorMessage}
+              {announcement}
+            </span>
           </span>
-        </Tip>
-      ) : null}
-      <span className="sr-only" role={status === "error" ? "alert" : "status"} aria-live="polite">
-        {announcement}
-      </span>
-    </span>
+        </motion.span>
+      )}
+    </AnimatePresence>
   );
 }
 

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -934,7 +934,8 @@ export const Footer = forwardRef<HTMLDivElement, ComposerFooterProps>(function C
       ref={ref}
       className={cn(
         "flex items-end gap-1.5 px-2 pb-2 pt-0.5 sm:px-2.5 sm:pb-2.5",
-        "max-sm:items-center max-sm:gap-1",
+        // Mobile: one control row — never wrap into a second toolbar line.
+        "max-sm:flex-nowrap max-sm:items-center max-sm:gap-1",
         className,
       )}
     />
@@ -987,7 +988,11 @@ export const Actions = forwardRef<HTMLSpanElement, ComposerActionsProps>(functio
     <span
       {...props}
       ref={ref}
-      className={cn("ml-auto flex shrink-0 items-center gap-1.5", className)}
+      className={cn(
+        "ml-auto flex shrink-0 items-center gap-1.5",
+        "max-sm:flex-nowrap max-sm:gap-1",
+        className,
+      )}
     />
   );
 });

--- a/packages/react/src/components/model-policy-picker.tsx
+++ b/packages/react/src/components/model-policy-picker.tsx
@@ -545,7 +545,7 @@ export function ModelPolicyPicker(props: ModelPolicyPickerProps) {
           disabled={props.disabled}
           aria-label={messages.label}
           className={cn(
-            "inline-flex h-8 max-w-64 items-center gap-1 rounded-full border border-transparent px-2.5 text-xs text-og-fg-muted outline-none transition-colors hover:border-og-border hover:bg-og-surface-2 hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/40 disabled:cursor-not-allowed disabled:opacity-50 max-sm:h-7 max-sm:max-w-[9rem] max-sm:px-2",
+            "inline-flex h-8 min-w-0 max-w-64 items-center gap-1 rounded-full border border-transparent px-2.5 text-xs text-og-fg-muted outline-none transition-colors hover:border-og-border hover:bg-og-surface-2 hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/40 disabled:cursor-not-allowed disabled:opacity-50 max-sm:h-7 max-sm:max-w-[7.5rem] max-sm:px-2",
             props.className,
           )}
         >
@@ -556,7 +556,12 @@ export function ModelPolicyPicker(props: ModelPolicyPickerProps) {
             }
             className="text-og-fg"
           />
-          <span className="truncate font-medium text-og-fg">{selected?.label ?? props.model}</span>
+          <span className="min-w-0 truncate font-medium text-og-fg max-sm:hidden">
+            {selected?.label ?? props.model}
+          </span>
+          <span className="min-w-0 truncate font-medium text-og-fg sm:hidden">
+            {selected?.shortLabel ?? selected?.label ?? props.model}
+          </span>
           <span className="max-sm:hidden">{labelReasoningEffort(props.effort)}</span>
           {props.latencyMode === "fast" ? (
             <ZapIcon

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -394,7 +394,7 @@ export function SessionChrome({
   const chipRefs = useRef<Partial<Record<SessionChromeSignalId, HTMLButtonElement | null>>>({});
   const railRef = useRef<HTMLDivElement | null>(null);
   const panelBodyRef = useRef<HTMLDivElement | null>(null);
-  const [pill, setPill] = useState({ left: 0, width: 0, opacity: 0 });
+  const [pill, setPill] = useState({ left: 0, top: 0, width: 0, height: 0, opacity: 0 });
   const [panelHeight, setPanelHeight] = useState(0);
 
   const signalIds = signals.map((signal) => signal.id).join(",");
@@ -421,11 +421,15 @@ export function SessionChrome({
       }
       const chip = chipRefs.current[active];
       if (!chip) return;
+      // Measure against the chip's own box so a wrapped multi-row rail never
+      // stretches the highlight into a tall stripe across every signal.
       const railBox = rail.getBoundingClientRect();
       const chipBox = chip.getBoundingClientRect();
       setPill({
         left: chipBox.left - railBox.left,
+        top: chipBox.top - railBox.top,
         width: chipBox.width,
+        height: chipBox.height,
         opacity: 1,
       });
     };
@@ -433,6 +437,9 @@ export function SessionChrome({
     if (!rail) return;
     const observer = new ResizeObserver(measure);
     observer.observe(rail);
+    for (const chip of Object.values(chipRefs.current)) {
+      if (chip) observer.observe(chip);
+    }
     window.addEventListener("resize", measure);
     return () => {
       observer.disconnect();
@@ -568,88 +575,91 @@ export function SessionChrome({
           }}
         >
           <div
-            ref={railRef}
-            className="relative flex flex-wrap items-stretch"
+            className="relative"
             style={{
-              gap: "var(--og-session-chrome-chip-gap)",
-              padding: "var(--og-session-chrome-rail-pad)",
+              paddingTop: "var(--og-session-chrome-rail-pad)",
+              paddingBottom: "var(--og-session-chrome-rail-pad)",
+              paddingLeft: "var(--og-session-chrome-rail-pad)",
+              paddingRight: "var(--og-session-chrome-rail-pad)",
             }}
           >
-            <motion.div
-              aria-hidden
-              className="pointer-events-none absolute rounded-og-md ring-1 ring-og-border/50"
+            <div
+              ref={railRef}
+              className="relative flex flex-wrap items-center"
               style={{
-                top: "var(--og-session-chrome-rail-pad)",
-                bottom: "var(--og-session-chrome-rail-pad)",
-                background: "var(--og-session-chrome-highlight)",
+                gap: "var(--og-session-chrome-chip-gap)",
               }}
-              initial={false}
-              animate={{
-                x: pill.left,
-                width: pill.width,
-                opacity: pill.opacity,
-              }}
-              transition={{ duration: shellDuration, ease }}
-            />
-            {signals.map((signal) => {
-              const selected = active === signal.id;
-              return (
-                <button
-                  key={signal.id}
-                  type="button"
-                  ref={(node) => {
-                    chipRefs.current[signal.id] = node;
-                  }}
-                  aria-expanded={selected}
-                  aria-controls={panelId}
-                  data-testid={`session-chrome-${signal.id}`}
-                  data-og-session-chrome-signal={signal.id}
-                  onClick={() => setActive(selected ? null : signal.id)}
-                  className={cn(
-                    "group relative z-[1] inline-flex min-h-[var(--og-session-chrome-chip-min-height)] max-w-full items-center gap-1 rounded-og-md text-left text-og-xs outline-none",
-                    "transition-colors duration-150 motion-reduce:transition-none",
-                    "hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/40",
-                    "pointer-coarse:min-h-11",
-                    selected ? "text-og-fg" : "text-og-fg-muted",
-                  )}
-                  style={{
-                    paddingInline: "var(--og-session-chrome-chip-pad-x)",
-                  }}
-                >
-                  <span className={cn("shrink-0", toneClass(signal.tone, selected))}>
-                    {signal.icon}
-                  </span>
-                  <span className="shrink-0 font-medium text-og-fg">{signal.label}</span>
-                  {signal.detail ? (
-                    <>
-                      <span aria-hidden className="shrink-0 text-og-fg-subtle/60">
-                        ·
+            >
+              <motion.div
+                aria-hidden
+                className="pointer-events-none absolute left-0 top-0 rounded-og-md"
+                style={{
+                  background: "var(--og-session-chrome-highlight)",
+                }}
+                initial={false}
+                animate={{
+                  x: pill.left,
+                  y: pill.top,
+                  width: pill.width,
+                  height: pill.height,
+                  opacity: pill.opacity,
+                }}
+                transition={{ duration: shellDuration, ease }}
+              />
+              {signals.map((signal) => {
+                const selected = active === signal.id;
+                return (
+                  <button
+                    key={signal.id}
+                    type="button"
+                    ref={(node) => {
+                      chipRefs.current[signal.id] = node;
+                    }}
+                    aria-expanded={selected}
+                    aria-controls={panelId}
+                    aria-label={selected ? `Close ${signal.label}` : undefined}
+                    data-testid={`session-chrome-${signal.id}`}
+                    data-og-session-chrome-signal={signal.id}
+                    onClick={() => setActive(selected ? null : signal.id)}
+                    className={cn(
+                      "group relative z-[1] inline-flex min-h-[var(--og-session-chrome-chip-min-height)] max-w-full items-center gap-1 rounded-og-md text-left text-og-xs outline-none",
+                      "transition-colors duration-150 motion-reduce:transition-none",
+                      // Quiet focus — no accent ring (it fought the soft selection wash).
+                      "hover:text-og-fg focus-visible:bg-og-surface-3/50",
+                      "pointer-coarse:min-h-11",
+                      selected ? "text-og-fg" : "text-og-fg-muted",
+                    )}
+                    style={{
+                      paddingInline: "var(--og-session-chrome-chip-pad-x)",
+                    }}
+                  >
+                    <span className={cn("shrink-0", toneClass(signal.tone, selected))}>
+                      {signal.icon}
+                    </span>
+                    <span className="shrink-0 font-medium text-og-fg">{signal.label}</span>
+                    {signal.detail ? (
+                      <>
+                        <span aria-hidden className="shrink-0 text-og-fg-subtle/60">
+                          ·
+                        </span>
+                        <span className="min-w-0 max-w-[8.5rem] truncate text-og-fg sm:max-w-[12rem]">
+                          {signal.detail}
+                        </span>
+                      </>
+                    ) : null}
+                    {selected ? (
+                      <span
+                        data-testid="session-chrome-close"
+                        className="ml-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-og-sm text-og-fg-subtle transition-colors group-hover:text-og-fg pointer-coarse:size-5"
+                        aria-hidden
+                      >
+                        <XIcon className="size-3" />
                       </span>
-                      <span className="min-w-0 max-w-[8.5rem] truncate text-og-fg sm:max-w-[12rem]">
-                        {signal.detail}
-                      </span>
-                    </>
-                  ) : null}
-                </button>
-              );
-            })}
-            <AnimatePresence initial={false}>
-              {open ? (
-                <motion.button
-                  key="close"
-                  type="button"
-                  aria-label="Close session chrome panel"
-                  onClick={() => setActive(null)}
-                  initial={reduceMotion ? false : { opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={reduceMotion ? { opacity: 1 } : { opacity: 0 }}
-                  transition={{ duration: crossfadeDuration, ease }}
-                  className="relative z-[1] ml-auto inline-flex size-7 shrink-0 items-center justify-center rounded-og-md text-og-fg-subtle outline-none transition-colors hover:bg-og-surface-3/60 hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/40 pointer-coarse:size-11"
-                >
-                  <XIcon className="size-3" />
-                </motion.button>
-              ) : null}
-            </AnimatePresence>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
           </div>
 
           <motion.div

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -623,9 +623,9 @@ export function SessionChrome({
                     data-og-session-chrome-signal={signal.id}
                     onClick={() => setActive(selected ? null : signal.id)}
                     className={cn(
-                      // Keep chrome chips compact — do not inflate to 44px touch targets
-                      // (that made the open dock look oddly tall vs the composer).
                       "group relative z-[1] inline-flex min-h-[var(--og-session-chrome-chip-min-height)] max-w-full items-center gap-1 rounded-og-md py-1 text-left text-og-xs outline-none",
+                      // Coarse pointers keep a 44px target (session-pins acceptance).
+                      "pointer-coarse:min-h-11",
                       "transition-colors duration-150 motion-reduce:transition-none",
                       "hover:text-og-fg focus-visible:bg-og-surface-3/50",
                       selected ? "text-og-fg" : "text-og-fg-muted",

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -11,7 +11,7 @@
  * | --- | --- |
  * | `--og-session-chrome-surface` / `-open` | Dock fill (collapsed / expanded) |
  * | `--og-session-chrome-border` / `-open` | Dock edge |
- * | `--og-session-chrome-highlight` | Sliding chip selection pill |
+ * | `--og-session-chrome-highlight` / `-ring` | Sliding chip selection fill + edge |
  * | `--og-session-chrome-shadow` / `-open` | Elevation |
  * | `--og-session-chrome-radius` | Dock corner radius |
  * | `--og-session-chrome-chip-min-height` | Signal chip height |
@@ -595,6 +595,7 @@ export function SessionChrome({
                 className="pointer-events-none absolute left-0 top-0 rounded-og-md"
                 style={{
                   background: "var(--og-session-chrome-highlight)",
+                  boxShadow: "inset 0 0 0 1px var(--og-session-chrome-highlight-ring)",
                 }}
                 initial={false}
                 animate={{
@@ -622,11 +623,11 @@ export function SessionChrome({
                     data-og-session-chrome-signal={signal.id}
                     onClick={() => setActive(selected ? null : signal.id)}
                     className={cn(
-                      "group relative z-[1] inline-flex min-h-[var(--og-session-chrome-chip-min-height)] max-w-full items-center gap-1 rounded-og-md text-left text-og-xs outline-none",
+                      // Keep chrome chips compact — do not inflate to 44px touch targets
+                      // (that made the open dock look oddly tall vs the composer).
+                      "group relative z-[1] inline-flex min-h-[var(--og-session-chrome-chip-min-height)] max-w-full items-center gap-1 rounded-og-md py-1 text-left text-og-xs outline-none",
                       "transition-colors duration-150 motion-reduce:transition-none",
-                      // Quiet focus — no accent ring (it fought the soft selection wash).
                       "hover:text-og-fg focus-visible:bg-og-surface-3/50",
-                      "pointer-coarse:min-h-11",
                       selected ? "text-og-fg" : "text-og-fg-muted",
                     )}
                     style={{

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -367,12 +367,14 @@ export type {
 // Pure provider-shape parsers (exec banner, V4A diff, secret redaction, …)
 export {
   applyPatchOps,
+  applyPatchOpsFromToolItem,
   controlCaret,
   execTruncated,
   isApplyPatch,
   isExecSessionLostBanner,
   looksBinary,
   parseExecBannerSessionId,
+  parseFreeformApplyPatch,
   parseToolArgs,
   redactSecrets,
   sandboxCommandExitCode,

--- a/packages/react/src/model-policy.ts
+++ b/packages/react/src/model-policy.ts
@@ -5,6 +5,8 @@ export type PickerBillingClass = "opengeni_credits" | "codex_subscription" | "by
 export type PickerModelRow<TCatalog extends ClientModel = WorkspaceModelCatalogModel> = {
   id: string;
   label: string;
+  /** Catalog-curated compact label for dense UI; fall back to `label` when absent. */
+  shortLabel?: string | undefined;
   billingClass: PickerBillingClass;
   billingClassLabel: string;
   selectable: boolean;
@@ -171,6 +173,7 @@ export function projectPickerRows(models: WorkspaceModelCatalogModel[]): PickerM
       return {
         id: catalog.id,
         label: catalog.label,
+        ...(catalog.shortLabel ? { shortLabel: catalog.shortLabel } : {}),
         billingClass,
         billingClassLabel: billingClassLabel(billingClass),
         selectable: catalog.availability.selectable,
@@ -191,6 +194,7 @@ export function projectClientModelRows(models: ClientModel[]): PickerModelRow<Cl
     return {
       id: catalog.id,
       label: catalog.label,
+      ...(catalog.shortLabel ? { shortLabel: catalog.shortLabel } : {}),
       billingClass,
       billingClassLabel: billingClassLabel(billingClass),
       selectable: true,

--- a/packages/react/src/realtime.ts
+++ b/packages/react/src/realtime.ts
@@ -10,6 +10,7 @@ export {
   NewSessionRealtimeControl,
   RealtimeModelPickerMenu,
   RealtimeVoiceControl,
+  RealtimeVoiceModelPanel,
   SessionCodexRealtimeControl,
   SessionRealtimeControl,
   codexRealtimeAdmissionAllowed,

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -23,7 +23,15 @@ import {
   VolumeXIcon,
 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import {
   BillingClassMark,
@@ -287,6 +295,8 @@ export function SessionRealtimeControl(props: {
   codexConnected: boolean;
   realtimeAutostartModel?: SessionRealtimeModel | undefined;
   onRealtimeAutostartConsumed?: (() => void) | undefined;
+  /** Host hides dictate (and can choreograph layout) while realtime voice is live. */
+  onVoiceActiveChange?: ((active: boolean) => void) | undefined;
   /** Deterministic browser-test/demo seam. Production hosts should use the SDK default. */
   controllerFactory?: SessionRealtimeControllerFactory | undefined;
 }) {
@@ -310,6 +320,12 @@ export function SessionRealtimeControl(props: {
   const { models, selectedModel: selectedRealtimeModel, selectModel } = selection;
   const { canStart, start } = realtime;
   const onRealtimeAutostartConsumed = props.onRealtimeAutostartConsumed;
+  const onVoiceActiveChange = props.onVoiceActiveChange;
+  const voiceActive = realtime.snapshot.mode?.state === "active";
+
+  useEffect(() => {
+    onVoiceActiveChange?.(voiceActive);
+  }, [onVoiceActiveChange, voiceActive]);
 
   useEffect(() => {
     const pending = autostartModelRef.current;
@@ -452,12 +468,29 @@ export function NewSessionRealtimeControl(props: {
   disabled?: boolean | undefined;
   disabledReason?: string | null | undefined;
   onStart: (model: SessionRealtimeModel) => Promise<boolean>;
+  /** Parent-owned selection (e.g. shared with the mobile “+” voice-model panel). */
+  models?: readonly RealtimeModelOption[] | undefined;
+  selectedModel?: RealtimeModelOption | undefined;
+  onSelectModel?: ((modelId: string) => void) | undefined;
+  /**
+   * `split` keeps a desktop chevron menu (hidden below `sm` — use “+” there).
+   * `none` never attaches a model menu to the bar button.
+   */
+  modelMenu?: "split" | "none" | undefined;
 }) {
-  const selection = useRealtimeModelSelection({
+  const internalSelection = useRealtimeModelSelection({
     client: props.client,
     workspaceId: props.workspaceId,
     codexConnected: props.codexConnected,
   });
+  const selection =
+    props.models && props.selectedModel && props.onSelectModel
+      ? {
+          models: props.models,
+          selectedModel: props.selectedModel,
+          selectModel: props.onSelectModel,
+        }
+      : internalSelection;
   const audioRef = useRef<HTMLAudioElement>(null);
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -495,6 +528,7 @@ export function NewSessionRealtimeControl(props: {
       modelAvailable={selection.selectedModel.available}
       selectionDisabled={starting}
       menuSide="bottom"
+      modelMenu={props.modelMenu ?? "split"}
       showDiagnostics={false}
       audioRef={audioRef}
       selectedModel={selection.selectedModel}
@@ -518,7 +552,14 @@ export function RealtimeVoiceControl(props: {
   selectionDisabled?: boolean | undefined;
   /** Prefer `bottom` on home/new-session; `top` for the docked session composer. */
   menuSide?: "top" | "bottom" | undefined;
+  /**
+   * `split` = start + desktop-only model chevron (mobile uses the composer “+”).
+   * `none` = start button only.
+   */
+  modelMenu?: "split" | "none" | undefined;
   showDiagnostics?: boolean;
+  /** Extra classes on the in-bar mute cluster (e.g. `max-sm:hidden` when mutes live in “+”). */
+  muteControlsClassName?: string | undefined;
   audioRef: RefObject<HTMLAudioElement | null>;
   selectedModel?: RealtimeModelOption | undefined;
   models?: readonly RealtimeModelOption[] | undefined;
@@ -571,6 +612,8 @@ export function RealtimeVoiceControl(props: {
         ? props.onStop
         : props.onStart;
   const diagnosticsVisible = props.showDiagnostics ?? import.meta.env.DEV;
+  const modelMenu = props.modelMenu ?? "split";
+  const showAttachedModelMenu = modelMenu === "split";
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerProvider, setPickerProvider] = useState<RealtimeModelProvider | null>(
     selectedModel.provider,
@@ -594,143 +637,196 @@ export function RealtimeVoiceControl(props: {
           <motion.div
             key="realtime-mute-controls"
             data-testid="realtime-mute-controls"
-            initial={reduceMotion ? false : { opacity: 0, width: 0, marginRight: 0 }}
-            animate={{ opacity: 1, width: "auto", marginRight: 4 }}
-            {...(reduceMotion ? {} : { exit: { opacity: 0, width: 0, marginRight: 0 } })}
-            transition={{ duration: reduceMotion ? 0 : 0.18, ease: [0.2, 0.8, 0.2, 1] }}
-            className="inline-flex shrink-0 items-center gap-0.5 overflow-hidden"
+            // After dictate collapses and the model slides left, bloom mutes
+            // out from the primary voice control. Exit is immediate (no delay).
+            initial={reduceMotion ? false : { opacity: 0, width: 0 }}
+            animate={{
+              opacity: 1,
+              width: "auto",
+              transition: reduceMotion
+                ? { duration: 0 }
+                : { delay: 0.3, duration: 0.48, ease: [0.22, 1, 0.36, 1] },
+            }}
+            {...(reduceMotion
+              ? {}
+              : {
+                  exit: {
+                    opacity: 0,
+                    width: 0,
+                    transition: { duration: 0.28, ease: [0.4, 0, 1, 1] },
+                  },
+                })}
+            className={cn(
+              "inline-flex shrink-0 items-center overflow-hidden",
+              props.muteControlsClassName,
+            )}
           >
-            <RealtimeMuteButton
-              muted={props.snapshot.inputMuted}
-              kind="microphone"
-              reduceMotion={reduceMotion === true}
-              onToggle={() => props.onSetInputMuted(!props.snapshot.inputMuted)}
-            />
-            <RealtimeMuteButton
-              muted={props.snapshot.outputMuted}
-              kind="output"
-              reduceMotion={reduceMotion === true}
-              onToggle={() => props.onSetOutputMuted(!props.snapshot.outputMuted)}
-            />
+            <motion.div
+              className="inline-flex items-center gap-0.5 pr-1"
+              initial={reduceMotion ? false : { x: 18, opacity: 0 }}
+              animate={{
+                x: 0,
+                opacity: 1,
+                transition: reduceMotion
+                  ? { duration: 0 }
+                  : { delay: 0.32, type: "spring", stiffness: 320, damping: 30, mass: 0.8 },
+              }}
+              {...(reduceMotion
+                ? {}
+                : {
+                    exit: {
+                      x: 14,
+                      opacity: 0,
+                      transition: { duration: 0.22, ease: [0.4, 0, 1, 1] },
+                    },
+                  })}
+            >
+              <RealtimeMuteButton
+                muted={props.snapshot.inputMuted}
+                kind="microphone"
+                reduceMotion={reduceMotion === true}
+                enterDelay={reduceMotion ? 0 : 0.34}
+                onToggle={() => props.onSetInputMuted(!props.snapshot.inputMuted)}
+              />
+              <RealtimeMuteButton
+                muted={props.snapshot.outputMuted}
+                kind="output"
+                reduceMotion={reduceMotion === true}
+                enterDelay={reduceMotion ? 0 : 0.4}
+                onToggle={() => props.onSetOutputMuted(!props.snapshot.outputMuted)}
+              />
+            </motion.div>
           </motion.div>
         ) : null}
       </AnimatePresence>
-      <motion.button
-        type="button"
-        data-testid="realtime-primary-action"
-        data-phase={status.phase}
-        aria-label={mainLabel}
-        aria-pressed={modeOwned}
-        title={mainLabel}
-        disabled={mainDisabled}
-        {...(reduceMotion ? {} : { whileTap: { scale: 0.92 } })}
-        transition={{ type: "spring", stiffness: 520, damping: 30 }}
-        onClick={() => void runMainAction().catch(() => undefined)}
-        className={cn(
-          "relative inline-flex size-8 items-center justify-center rounded-l-og-md border outline-none",
-          "transition-[background-color,border-color,color,box-shadow] duration-200 ease-og-out",
-          "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-og-accent/45",
-          "disabled:cursor-not-allowed disabled:opacity-45 pointer-coarse:size-11",
-          voiceButtonTone(status.phase),
-        )}
-      >
-        <RealtimeActionGlyph
-          phase={status.phase}
-          audioBlocked={audioBlocked}
-          reduceMotion={reduceMotion === true}
-        />
-      </motion.button>
-
-      <DropdownMenu open={pickerOpen} onOpenChange={setPickerOpen}>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-label="Choose voice model and options"
-            title={`Voice model: ${selectedModel.label}`}
-            disabled={props.selectionDisabled}
-            className={cn(
-              "inline-flex h-8 w-6 items-center justify-center rounded-r-og-md border border-l-0 outline-none",
-              "transition-[background-color,border-color,color] duration-200 ease-og-out",
-              "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-og-accent/45",
-              "pointer-coarse:h-11 pointer-coarse:w-7",
-              voiceButtonTone(status.phase),
-            )}
-          >
-            <ChevronDownIcon className="size-3" aria-hidden />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          side={props.menuSide ?? "top"}
-          align="end"
-          sideOffset={8}
-          collisionPadding={12}
-          className="flex w-72 max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))] flex-col overflow-hidden rounded-xl border-border bg-surface p-1.5 shadow-xl"
-          onCloseAutoFocus={(event) => event.preventDefault()}
+      <div className="inline-flex shrink-0 items-center">
+        <motion.button
+          type="button"
+          data-testid="realtime-primary-action"
+          data-phase={status.phase}
+          aria-label={mainLabel}
+          aria-pressed={modeOwned}
+          title={mainLabel}
+          disabled={mainDisabled}
+          {...(reduceMotion ? {} : { whileTap: { scale: 0.92 } })}
+          transition={{ type: "spring", stiffness: 520, damping: 30 }}
+          onClick={() => void runMainAction().catch(() => undefined)}
+          className={cn(
+            // Match transcription mic: ghost icon when idle; filled only when live.
+            "relative inline-flex size-8 items-center justify-center outline-none",
+            "rounded-og-md transition-[background-color,border-color,color,box-shadow] duration-200 ease-og-out",
+            "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-og-accent/45",
+            "disabled:cursor-not-allowed disabled:opacity-45 pointer-coarse:size-9",
+            showAttachedModelMenu && "sm:rounded-r-none",
+            voiceButtonTone(status.phase),
+          )}
         >
-          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
-            <RealtimeModelPickerMenu
-              models={models}
-              selectedModel={selectedModel}
-              provider={pickerProvider}
-              direction={pickerDirection}
-              disabled={props.selectionDisabled === true || props.snapshot.mode?.state === "active"}
-              onProviderChange={(provider, direction) => {
-                setPickerDirection(direction);
-                setPickerProvider(provider);
-              }}
-              onSelect={(modelId) => {
-                props.onSelectModel?.(modelId);
-                setPickerOpen(false);
-              }}
-            />
-          </div>
+          <RealtimeActionGlyph
+            phase={status.phase}
+            audioBlocked={audioBlocked}
+            reduceMotion={reduceMotion === true}
+          />
+        </motion.button>
 
-          {status.phase !== "idle" ? (
-            <>
-              <DropdownMenuSeparator className="mx-1 bg-og-border" />
-              <div className="px-2.5 py-2" role="status" aria-live="polite">
-                <div className="flex items-center gap-2 text-og-sm font-medium text-og-fg">
-                  <RealtimeStatusDot phase={status.phase} reduceMotion={reduceMotion === true} />
-                  {status.label}
-                </div>
-                <p className="mt-1 text-og-xs leading-5 text-og-fg-subtle">{status.detail}</p>
+        {showAttachedModelMenu ? (
+          <DropdownMenu open={pickerOpen} onOpenChange={setPickerOpen}>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="Choose voice model and options"
+                title={`Voice model: ${selectedModel.label}`}
+                disabled={props.selectionDisabled}
+                className={cn(
+                  // Desktop-only: mobile picks the model from composer “+”.
+                  "hidden sm:inline-flex h-8 w-5 items-center justify-center rounded-r-og-md outline-none",
+                  "transition-[background-color,border-color,color] duration-200 ease-og-out",
+                  "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-og-accent/45",
+                  "pointer-coarse:h-9 pointer-coarse:w-6",
+                  voiceChevronTone(status.phase),
+                )}
+              >
+                <ChevronDownIcon className="size-3" aria-hidden />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              side={props.menuSide ?? "top"}
+              align="end"
+              sideOffset={8}
+              collisionPadding={12}
+              className="flex w-72 max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))] flex-col overflow-hidden rounded-xl border-border bg-surface p-1.5 shadow-xl"
+              onCloseAutoFocus={(event) => event.preventDefault()}
+            >
+              <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+                <RealtimeModelPickerMenu
+                  models={models}
+                  selectedModel={selectedModel}
+                  provider={pickerProvider}
+                  direction={pickerDirection}
+                  disabled={
+                    props.selectionDisabled === true || props.snapshot.mode?.state === "active"
+                  }
+                  onProviderChange={(provider, direction) => {
+                    setPickerDirection(direction);
+                    setPickerProvider(provider);
+                  }}
+                  onSelect={(modelId) => {
+                    props.onSelectModel?.(modelId);
+                    setPickerOpen(false);
+                  }}
+                />
               </div>
-            </>
-          ) : null}
 
-          {audioBlocked ? (
-            <DropdownMenuItem
-              className="rounded-og-md"
-              onSelect={() => void props.onRetryAudibleOutput().catch(() => undefined)}
-            >
-              <Volume2Icon />
-              Resume audio
-            </DropdownMenuItem>
-          ) : null}
-          {retryConnection ? (
-            <DropdownMenuItem
-              className="rounded-og-md"
-              onSelect={() => void props.onRetry().catch(() => undefined)}
-            >
-              <RotateCcwIcon />
-              Retry connection
-            </DropdownMenuItem>
-          ) : null}
-          {modeOwned && props.snapshot.status !== "lost_owner" ? (
-            <DropdownMenuItem
-              variant="destructive"
-              className="rounded-og-md"
-              disabled={props.snapshot.status === "stopping"}
-              onSelect={() => void props.onStop().catch(() => undefined)}
-            >
-              <SquareIcon />
-              End voice conversation
-            </DropdownMenuItem>
-          ) : null}
+              {status.phase !== "idle" ? (
+                <>
+                  <DropdownMenuSeparator className="mx-1 bg-og-border" />
+                  <div className="px-2.5 py-2" role="status" aria-live="polite">
+                    <div className="flex items-center gap-2 text-og-sm font-medium text-og-fg">
+                      <RealtimeStatusDot
+                        phase={status.phase}
+                        reduceMotion={reduceMotion === true}
+                      />
+                      {status.label}
+                    </div>
+                    <p className="mt-1 text-og-xs leading-5 text-og-fg-subtle">{status.detail}</p>
+                  </div>
+                </>
+              ) : null}
 
-          {diagnosticsVisible ? <RealtimeDiagnosticsMenu snapshot={props.snapshot} /> : null}
-        </DropdownMenuContent>
-      </DropdownMenu>
+              {audioBlocked ? (
+                <DropdownMenuItem
+                  className="rounded-og-md"
+                  onSelect={() => void props.onRetryAudibleOutput().catch(() => undefined)}
+                >
+                  <Volume2Icon />
+                  Resume audio
+                </DropdownMenuItem>
+              ) : null}
+              {retryConnection ? (
+                <DropdownMenuItem
+                  className="rounded-og-md"
+                  onSelect={() => void props.onRetry().catch(() => undefined)}
+                >
+                  <RotateCcwIcon />
+                  Retry connection
+                </DropdownMenuItem>
+              ) : null}
+              {modeOwned && props.snapshot.status !== "lost_owner" ? (
+                <DropdownMenuItem
+                  variant="destructive"
+                  className="rounded-og-md"
+                  disabled={props.snapshot.status === "stopping"}
+                  onSelect={() => void props.onStop().catch(() => undefined)}
+                >
+                  <SquareIcon />
+                  End voice conversation
+                </DropdownMenuItem>
+              ) : null}
+
+              {diagnosticsVisible ? <RealtimeDiagnosticsMenu snapshot={props.snapshot} /> : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
+      </div>
 
       <span className="sr-only" role="status" aria-live="polite">
         {status.label}. {status.detail}
@@ -744,10 +840,51 @@ export function RealtimeVoiceControl(props: {
   );
 }
 
+/** Drill-in body for the mobile composer “+” menu — same catalog as the desktop chevron. */
+export function RealtimeVoiceModelPanel(props: {
+  models: readonly RealtimeModelOption[];
+  selectedModel: RealtimeModelOption;
+  disabled?: boolean | undefined;
+  leading?: ReactNode | undefined;
+  onSelect: (modelId: SessionRealtimeModel) => void;
+}) {
+  const [provider, setProvider] = useState<RealtimeModelProvider | null>(null);
+  const [direction, setDirection] = useState<1 | -1>(1);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col" data-testid="realtime-voice-model-panel">
+      <div className="flex shrink-0 items-start gap-1 px-2 pt-1 pb-1.5">
+        {props.leading}
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-og-fg">Voice model</div>
+          <p className="mt-0.5 text-xs text-og-fg-subtle">
+            Used when you start a voice conversation.
+          </p>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-1.5 pb-1.5">
+        <RealtimeModelPickerMenu
+          models={props.models}
+          selectedModel={props.selectedModel}
+          provider={provider}
+          direction={direction}
+          disabled={props.disabled === true}
+          onProviderChange={(next, nextDirection) => {
+            setDirection(nextDirection);
+            setProvider(next);
+          }}
+          onSelect={props.onSelect}
+        />
+      </div>
+    </div>
+  );
+}
+
 function RealtimeMuteButton(props: {
   muted: boolean;
   kind: "microphone" | "output";
   reduceMotion: boolean;
+  enterDelay?: number | undefined;
   onToggle(): void;
 }) {
   const microphone = props.kind === "microphone";
@@ -772,15 +909,24 @@ function RealtimeMuteButton(props: {
       aria-label={label}
       aria-pressed={props.muted}
       title={label}
+      initial={props.reduceMotion ? false : { scale: 0.72, opacity: 0 }}
+      animate={{ scale: 1, opacity: 1 }}
+      transition={{
+        delay: props.enterDelay ?? 0,
+        type: "spring",
+        stiffness: 420,
+        damping: 26,
+        mass: 0.7,
+      }}
       {...(props.reduceMotion ? {} : { whileTap: { scale: 0.92 } })}
       onClick={props.onToggle}
       className={cn(
-        "inline-flex size-8 shrink-0 items-center justify-center rounded-og-md border outline-none",
+        "inline-flex size-8 shrink-0 items-center justify-center rounded-og-md outline-none",
         "transition-[background-color,border-color,color] duration-150 ease-og-out",
-        "focus-visible:ring-2 focus-visible:ring-og-accent/45 pointer-coarse:size-11",
+        "focus-visible:ring-2 focus-visible:ring-og-accent/45 pointer-coarse:size-9",
         props.muted
-          ? "border-og-accent/35 bg-og-accent-soft text-og-accent"
-          : "border-og-border bg-og-surface-2 text-og-fg-muted hover:border-og-accent/35 hover:text-og-fg",
+          ? "border border-og-accent/35 bg-og-accent-soft text-og-accent"
+          : "text-og-fg-muted hover:bg-og-surface-2 hover:text-og-fg",
       )}
     >
       <Icon className="size-3.5" aria-hidden />
@@ -1122,15 +1268,29 @@ function RealtimeStatusDot(props: { phase: RealtimeVisualPhase; reduceMotion: bo
 
 function voiceButtonTone(phase: RealtimeVisualPhase): string {
   if (phase === "listening" || phase === "speaking") {
-    return "border-og-accent/45 bg-og-accent text-og-accent-fg shadow-og-sm hover:bg-og-accent-strong";
+    return "border border-og-accent/45 bg-og-accent text-og-accent-fg shadow-og-sm hover:bg-og-accent-strong";
   }
   if (phase === "blocked" || phase === "error") {
-    return "border-og-status-waiting/35 bg-og-status-waiting/10 text-og-status-waiting hover:bg-og-status-waiting/15";
+    return "border border-og-status-waiting/35 bg-og-status-waiting/10 text-og-status-waiting hover:bg-og-status-waiting/15";
   }
   if (phase === "connecting" || phase === "reconnecting" || phase === "stopping") {
-    return "border-og-accent/35 bg-og-accent-soft text-og-accent";
+    return "border border-og-accent/35 bg-og-accent-soft text-og-accent";
   }
-  return "border-og-border bg-og-surface-2 text-og-fg-muted hover:border-og-accent/35 hover:bg-og-accent-soft hover:text-og-accent";
+  // Idle: same ghost treatment as the composer transcription mic — no box.
+  return "text-og-fg-muted hover:bg-og-surface-2 hover:text-og-fg";
+}
+
+function voiceChevronTone(phase: RealtimeVisualPhase): string {
+  if (phase === "listening" || phase === "speaking") {
+    return "border border-l-0 border-og-accent/45 bg-og-accent text-og-accent-fg hover:bg-og-accent-strong";
+  }
+  if (phase === "blocked" || phase === "error") {
+    return "border border-l-0 border-og-status-waiting/35 bg-og-status-waiting/10 text-og-status-waiting hover:bg-og-status-waiting/15";
+  }
+  if (phase === "connecting" || phase === "reconnecting" || phase === "stopping") {
+    return "border border-l-0 border-og-accent/35 bg-og-accent-soft text-og-accent";
+  }
+  return "text-og-fg-muted hover:bg-og-surface-2 hover:text-og-fg";
 }
 
 function toRealtimeModelOption(model: WorkspaceRealtimeModelCatalogItem): RealtimeModelOption {

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -713,11 +713,13 @@ export function RealtimeVoiceControl(props: {
           onClick={() => void runMainAction().catch(() => undefined)}
           className={cn(
             // Match transcription mic: ghost icon when idle; filled only when live.
+            // Public contract: coarse pointers keep a 44px target; split menu uses
+            // left-only rounding at `sm+` where the chevron attaches.
             "relative inline-flex size-8 items-center justify-center outline-none",
             "rounded-og-md transition-[background-color,border-color,color,box-shadow] duration-200 ease-og-out",
             "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-og-accent/45",
-            "disabled:cursor-not-allowed disabled:opacity-45 pointer-coarse:size-9",
-            showAttachedModelMenu && "sm:rounded-r-none",
+            "disabled:cursor-not-allowed disabled:opacity-45 pointer-coarse:size-11",
+            showAttachedModelMenu && "sm:rounded-l-og-md sm:rounded-r-none",
             voiceButtonTone(status.phase),
           )}
         >
@@ -741,7 +743,7 @@ export function RealtimeVoiceControl(props: {
                   "hidden sm:inline-flex h-8 w-5 items-center justify-center rounded-r-og-md outline-none",
                   "transition-[background-color,border-color,color] duration-200 ease-og-out",
                   "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-og-accent/45",
-                  "pointer-coarse:h-9 pointer-coarse:w-6",
+                  "pointer-coarse:h-11 pointer-coarse:w-7",
                   voiceChevronTone(status.phase),
                 )}
               >
@@ -923,7 +925,7 @@ function RealtimeMuteButton(props: {
       className={cn(
         "inline-flex size-8 shrink-0 items-center justify-center rounded-og-md outline-none",
         "transition-[background-color,border-color,color] duration-150 ease-og-out",
-        "focus-visible:ring-2 focus-visible:ring-og-accent/45 pointer-coarse:size-9",
+        "focus-visible:ring-2 focus-visible:ring-og-accent/45 pointer-coarse:size-11",
         props.muted
           ? "border border-og-accent/35 bg-og-accent-soft text-og-accent"
           : "text-og-fg-muted hover:bg-og-surface-2 hover:text-og-fg",

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -745,7 +745,8 @@ export function RealtimeVoiceControl(props: {
                 title={`Voice model: ${selectedModel.label}`}
                 disabled={props.selectionDisabled}
                 className={cn(
-                  "inline-flex h-8 w-5 items-center justify-center rounded-r-og-md outline-none",
+                  // ≥24px wide so WCAG 2.2 target-size passes when the chevron is shown.
+                  "inline-flex h-8 w-6 items-center justify-center rounded-r-og-md outline-none",
                   "transition-[background-color,border-color,color] duration-200 ease-og-out",
                   "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-og-accent/45",
                   "pointer-coarse:h-11 pointer-coarse:w-7",

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -473,10 +473,11 @@ export function NewSessionRealtimeControl(props: {
   selectedModel?: RealtimeModelOption | undefined;
   onSelectModel?: ((modelId: string) => void) | undefined;
   /**
-   * `split` keeps a desktop chevron menu (hidden below `sm` — use “+” there).
+   * `split` attaches the model chevron at every breakpoint (public default).
+   * `split-desktop` hides it below `sm` when the host owns mobile selection (e.g. “+”).
    * `none` never attaches a model menu to the bar button.
    */
-  modelMenu?: "split" | "none" | undefined;
+  modelMenu?: "split" | "split-desktop" | "none" | undefined;
 }) {
   const internalSelection = useRealtimeModelSelection({
     client: props.client,
@@ -553,10 +554,11 @@ export function RealtimeVoiceControl(props: {
   /** Prefer `bottom` on home/new-session; `top` for the docked session composer. */
   menuSide?: "top" | "bottom" | undefined;
   /**
-   * `split` = start + desktop-only model chevron (mobile uses the composer “+”).
+   * `split` = start + model chevron at every breakpoint (public SDK default).
+   * `split-desktop` = chevron from `sm` up; below that the host owns selection.
    * `none` = start button only.
    */
-  modelMenu?: "split" | "none" | undefined;
+  modelMenu?: "split" | "split-desktop" | "none" | undefined;
   showDiagnostics?: boolean;
   /** Extra classes on the in-bar mute cluster (e.g. `max-sm:hidden` when mutes live in “+”). */
   muteControlsClassName?: string | undefined;
@@ -613,7 +615,8 @@ export function RealtimeVoiceControl(props: {
         : props.onStart;
   const diagnosticsVisible = props.showDiagnostics ?? import.meta.env.DEV;
   const modelMenu = props.modelMenu ?? "split";
-  const showAttachedModelMenu = modelMenu === "split";
+  const showAttachedModelMenu = modelMenu === "split" || modelMenu === "split-desktop";
+  const desktopOnlyModelMenu = modelMenu === "split-desktop";
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerProvider, setPickerProvider] = useState<RealtimeModelProvider | null>(
     selectedModel.provider,
@@ -719,7 +722,10 @@ export function RealtimeVoiceControl(props: {
             "rounded-og-md transition-[background-color,border-color,color,box-shadow] duration-200 ease-og-out",
             "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-og-accent/45",
             "disabled:cursor-not-allowed disabled:opacity-45 pointer-coarse:size-11",
-            showAttachedModelMenu && "sm:rounded-l-og-md sm:rounded-r-none",
+            showAttachedModelMenu &&
+              (desktopOnlyModelMenu
+                ? "sm:rounded-l-og-md sm:rounded-r-none"
+                : "rounded-l-og-md rounded-r-none"),
             voiceButtonTone(status.phase),
           )}
         >
@@ -739,11 +745,11 @@ export function RealtimeVoiceControl(props: {
                 title={`Voice model: ${selectedModel.label}`}
                 disabled={props.selectionDisabled}
                 className={cn(
-                  // Desktop-only: mobile picks the model from composer “+”.
-                  "hidden sm:inline-flex h-8 w-5 items-center justify-center rounded-r-og-md outline-none",
+                  "inline-flex h-8 w-5 items-center justify-center rounded-r-og-md outline-none",
                   "transition-[background-color,border-color,color] duration-200 ease-og-out",
                   "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-og-accent/45",
                   "pointer-coarse:h-11 pointer-coarse:w-7",
+                  desktopOnlyModelMenu && "hidden sm:inline-flex",
                   voiceChevronTone(status.phase),
                 )}
               >

--- a/packages/react/src/timeline/index.ts
+++ b/packages/react/src/timeline/index.ts
@@ -114,6 +114,8 @@ export type {
 // parsers (pure, reusable by custom renderers)
 export {
   applyPatchOps,
+  applyPatchOpsFromToolItem,
+  parseFreeformApplyPatch,
   controlCaret,
   execTruncated,
   isApplyPatch,

--- a/packages/react/src/timeline/parsers.ts
+++ b/packages/react/src/timeline/parsers.ts
@@ -210,40 +210,222 @@ export function v4aToGitFileDiff(op: ApplyPatchOperation): GitFileDiff {
   };
 }
 
-/**
- * Extract the `apply_patch` operations from a provider-native tool item's `raw`
- * payload, normalizing the two wire shapes (`raw.operations[]` for a multi-file
- * patch, `raw.operation` for a single op). The single owner of this shape so the
- * renderer and the turn-summary facet counter never drift.
- */
-export function applyPatchOps(raw: unknown): ApplyPatchOperation[] {
-  const r = (raw ?? {}) as {
-    operation?: ApplyPatchOperation;
-    operations?: ApplyPatchOperation[];
-  };
-  if (Array.isArray(r.operations)) {
-    return r.operations;
-  }
-  return r.operation ? [r.operation] : [];
+const BEGIN_PATCH = "*** Begin Patch";
+const END_PATCH = "*** End Patch";
+const ADD_FILE = "*** Add File: ";
+const DELETE_FILE = "*** Delete File: ";
+const UPDATE_FILE = "*** Update File: ";
+const MOVE_TO = "*** Move to: ";
+
+const APPLY_PATCH_OP_TYPES = new Set(["create_file", "update_file", "delete_file"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-/** Ops from provider `raw`, or from function-tool arguments when raw is empty. */
+/** Freeform / `{ patch }` / command payloads — tolerate leading whitespace. */
+function freeformApplyPatchOps(rawPatch: string): ApplyPatchOperation[] {
+  return parseFreeformApplyPatch(rawPatch.trimStart());
+}
+
+function asApplyPatchOperation(value: unknown): ApplyPatchOperation | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.type !== "string" || !APPLY_PATCH_OP_TYPES.has(value.type)) {
+    return null;
+  }
+  if (typeof value.path !== "string" || !value.path) {
+    return null;
+  }
+  const op: ApplyPatchOperation = {
+    type: value.type as ApplyPatchOperation["type"],
+    path: value.path,
+  };
+  if (typeof value.diff === "string") op.diff = value.diff;
+  if (typeof value.moveTo === "string" && value.moveTo.length > 0) op.moveTo = value.moveTo;
+  return op;
+}
+
+function parseStructuredOperations(payloads: unknown[]): ApplyPatchOperation[] {
+  if (payloads.length === 0) return [];
+  const operations: ApplyPatchOperation[] = [];
+  for (const payload of payloads) {
+    const op = asApplyPatchOperation(payload);
+    if (!op) return [];
+    operations.push(op);
+  }
+  return operations;
+}
+
+/**
+ * Mirror of `@openai/agents-core` freeform `*** Begin Patch` → ops. Kept here so
+ * the timeline can render Codex function-tool apply_patch without importing the
+ * server SDK package.
+ */
+export function parseFreeformApplyPatch(rawPatch: string): ApplyPatchOperation[] {
+  const lines = rawPatch.split(/\r?\n/);
+  if (lines.at(-1) === "") lines.pop();
+  if (lines[0] !== BEGIN_PATCH) return [];
+  if (lines.length < 2 || lines.at(-1) !== END_PATCH) return [];
+
+  const operations: ApplyPatchOperation[] = [];
+  let index = 1;
+  while (index < lines.length - 1) {
+    const line = lines[index]!;
+    let parsed: { operation: ApplyPatchOperation; nextIndex: number } | { error: true } | null =
+      null;
+    if (line.startsWith(ADD_FILE)) parsed = parseAddFilePatch(lines, index);
+    else if (line.startsWith(DELETE_FILE)) parsed = parseDeleteFilePatch(lines, index);
+    else if (line.startsWith(UPDATE_FILE)) parsed = parseUpdateFilePatch(lines, index);
+    else return [];
+    if (!parsed || "error" in parsed) return [];
+    operations.push(parsed.operation);
+    index = parsed.nextIndex;
+  }
+  // Match the SDK: Begin/End with no file ops is not a valid patch.
+  return operations.length > 0 ? operations : [];
+}
+
+function parsePatchHeader(line: string, prefix: string): string | null {
+  const path = line.slice(prefix.length).trim();
+  return path || null;
+}
+
+function isFileOperationHeader(line: string): boolean {
+  return line.startsWith(ADD_FILE) || line.startsWith(DELETE_FILE) || line.startsWith(UPDATE_FILE);
+}
+
+function joinDiff(lines: string[]): string {
+  return `${lines.join("\n")}\n`;
+}
+
+function parseAddFilePatch(
+  lines: string[],
+  index: number,
+): { operation: ApplyPatchOperation; nextIndex: number } | { error: true } {
+  const path = parsePatchHeader(lines[index]!, ADD_FILE);
+  if (!path) return { error: true };
+  index += 1;
+  const diffLines: string[] = [];
+  while (index < lines.length - 1 && !isFileOperationHeader(lines[index]!)) {
+    const line = lines[index]!;
+    if (!line.startsWith("+")) return { error: true };
+    diffLines.push(line);
+    index += 1;
+  }
+  if (diffLines.length === 0) return { error: true };
+  return {
+    operation: { type: "create_file", path, diff: joinDiff(diffLines) },
+    nextIndex: index,
+  };
+}
+
+function parseDeleteFilePatch(
+  lines: string[],
+  index: number,
+): { operation: ApplyPatchOperation; nextIndex: number } | { error: true } {
+  const path = parsePatchHeader(lines[index]!, DELETE_FILE);
+  if (!path) return { error: true };
+  index += 1;
+  if (index < lines.length - 1 && !isFileOperationHeader(lines[index]!)) {
+    return { error: true };
+  }
+  return { operation: { type: "delete_file", path }, nextIndex: index };
+}
+
+function parseUpdateFilePatch(
+  lines: string[],
+  index: number,
+): { operation: ApplyPatchOperation; nextIndex: number } | { error: true } {
+  const path = parsePatchHeader(lines[index]!, UPDATE_FILE);
+  if (!path) return { error: true };
+  index += 1;
+  let moveTo: string | undefined;
+  if (index < lines.length - 1 && lines[index]!.startsWith(MOVE_TO)) {
+    const parsedMoveTo = parsePatchHeader(lines[index]!, MOVE_TO);
+    if (!parsedMoveTo) return { error: true };
+    moveTo = parsedMoveTo;
+    index += 1;
+  }
+  const diffLines: string[] = [];
+  while (index < lines.length - 1 && !isFileOperationHeader(lines[index]!)) {
+    diffLines.push(lines[index]!);
+    index += 1;
+  }
+  if (diffLines.length === 0 && !moveTo) return { error: true };
+  return {
+    operation: {
+      type: "update_file",
+      path,
+      diff: diffLines.length > 0 ? joinDiff(diffLines) : "",
+      ...(moveTo ? { moveTo } : {}),
+    },
+    nextIndex: index,
+  };
+}
+
+/**
+ * Normalize every apply_patch payload the Agents SDK accepts into structured
+ * ops — hosted `{ operation }` / `{ operations }`, function-tool `{ patch }`,
+ * `command` tuple, flat op, freeform string, or op array.
+ */
+export function applyPatchOps(raw: unknown): ApplyPatchOperation[] {
+  if (raw == null) return [];
+  if (typeof raw === "string") {
+    const trimmed = raw.trimStart();
+    if (trimmed.startsWith(BEGIN_PATCH)) return freeformApplyPatchOps(trimmed);
+    const parsed = tryParseJson(trimmed);
+    return parsed === undefined ? [] : applyPatchOps(parsed);
+  }
+  if (Array.isArray(raw)) return parseStructuredOperations(raw);
+  if (!isRecord(raw)) return [];
+
+  if (typeof raw.patch === "string") return freeformApplyPatchOps(raw.patch);
+  if (Array.isArray(raw.command)) {
+    const [commandName, patch] = raw.command;
+    if (commandName === "apply_patch" && typeof patch === "string") {
+      return freeformApplyPatchOps(patch);
+    }
+  }
+  // Empty `operations: []` is not authoritative — fall through to operation/flat.
+  if (Array.isArray(raw.operations) && raw.operations.length > 0) {
+    return parseStructuredOperations(raw.operations);
+  }
+  if (raw.operation !== undefined) {
+    const op = asApplyPatchOperation(raw.operation);
+    return op ? [op] : [];
+  }
+  // Flat single op: `{ type, path, diff?, moveTo? }`.
+  const flat = asApplyPatchOperation(raw);
+  return flat ? [flat] : [];
+}
+
+/** Ops from provider `raw` and/or function-tool arguments (Codex path). */
 export function applyPatchOpsFromToolItem(item: {
   raw: unknown;
   arguments: unknown;
 }): ApplyPatchOperation[] {
   const fromRaw = applyPatchOps(item.raw);
-  if (fromRaw.length > 0) {
-    return fromRaw;
+  if (fromRaw.length > 0) return fromRaw;
+
+  // function_call envelopes sometimes keep the payload only under raw.arguments.
+  if (isRecord(item.raw)) {
+    const nested = item.raw.arguments ?? item.raw.input;
+    if (nested !== undefined && nested !== item.arguments) {
+      const fromNested = applyPatchOps(nested);
+      if (fromNested.length > 0) return fromNested;
+    }
   }
-  const args = parseToolArgs(item.arguments);
-  return applyPatchOps(args);
+
+  if (item.arguments !== undefined && item.arguments !== null) {
+    return applyPatchOps(item.arguments);
+  }
+  return [];
 }
 
 /**
- * True when a tool item is an `apply_patch_call` — by its provider-native
- * `raw.type` (the live-wire source of truth) or by tool `name` (first-party
- * replays that omit `raw`). Centralizes the rawType-or-name check.
+ * True when a tool item is apply_patch — hosted `raw.type === "apply_patch_call"`,
+ * function-tool `name` `apply_patch` / `apply_patch_call`, or an MCP-prefixed
+ * `…__apply_patch` leaf. Centralizes the rawType-or-name check.
  */
 export function isApplyPatch(item: { name: string; raw: unknown }): boolean {
   const type =

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -54,6 +54,11 @@ const WORKER_MESSAGE_TOOL = "session_send_message";
  * `"agent"`. That keeps mid-turn goal tools from splitting the step rail with
  * a breakaway GoalRow pill. Non-agent goal events (API, create-session,
  * system auto-pause, continuations) still render as landmarks.
+ *
+ * Solo `goal_continuation` machine-input batches are also suppressed: the
+ * paired `goal.continuation` GoalRow already marks the tick; rendering both
+ * restates the goal text. Mixed batches (continuation + other kinds) still
+ * render as machine-input rows.
  */
 const LANDMARK_ONLY_TOOL_LEAVES = new Set(["memory_save", "memory_correct"]);
 
@@ -140,6 +145,12 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
       case "system.update.delivered": {
         const inputs = machineInputMembers(payload.members);
         if (inputs.length === 0) break;
+        // Goal continuations already land as `goal.continuation` GoalRows.
+        // A solo continuation batch would duplicate that landmark + dump the
+        // model-facing prompt — skip chrome for that case only.
+        if (inputs.every((member) => member.kind === "goal_continuation")) {
+          break;
+        }
         closeStreamingTail();
         items.push({
           kind: "machine-input-batch",

--- a/packages/react/src/timeline/tool-renderers.tsx
+++ b/packages/react/src/timeline/tool-renderers.tsx
@@ -364,12 +364,13 @@ function ApplyPatchRenderer({ item }: ToolRendererProps) {
           </RunningPreview>
         }
       >
-        {ops.map((op) => {
+        {ops.map((op, index) => {
           const file = safeParseOp(op);
+          const key = `${op.type}:${op.path}:${index}`;
           return file ? (
-            <ToolDiff key={op.path} files={[file]} />
+            <ToolDiff key={key} files={[file]} />
           ) : (
-            <div key={op.path}>
+            <div key={key}>
               <p className="mb-1 font-og-mono text-og-xs text-og-fg-muted">{op.path}</p>
               <RawPatch diff={op.diff ?? ""} />
             </div>
@@ -421,10 +422,11 @@ function ApplyPatchRenderer({ item }: ToolRendererProps) {
       >
         {ops.map((op, index) => {
           const file = parsed[index];
+          const key = `${op.type}:${op.path}:${index}`;
           return file ? (
-            <ToolDiff key={op.path} files={[file]} />
+            <ToolDiff key={key} files={[file]} />
           ) : (
-            <div key={op.path}>
+            <div key={key}>
               <p className="mb-1 font-og-mono text-og-xs text-og-fg-muted">{op.path}</p>
               <RawPatch diff={op.diff ?? ""} />
             </div>

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -16,7 +16,12 @@ import { MOTION_INSPECT_SCALE } from "../lib/motion-inspect";
 import { useForcedDefaultOpen } from "./disclosure-context";
 import { useEntranceAnimation } from "./entrance";
 import { useFoldMemory, type FoldRestingState } from "./fold-memory";
-import { applyPatchOps, isApplyPatch, mediaPreviewFact, screenshotDataUrl } from "./parsers";
+import {
+  applyPatchOpsFromToolItem,
+  isApplyPatch,
+  mediaPreviewFact,
+  screenshotDataUrl,
+} from "./parsers";
 import { rawTypeOf } from "./registry";
 import type { ActivityItem, ToolCallItem, TurnOutcome } from "./types";
 export type { TurnOutcome } from "./types";
@@ -571,7 +576,7 @@ const BUILT_IN_TURN_SUMMARY_FACETS: readonly TurnSummaryFacet[] = Object.freeze(
       let files = 0;
       for (const item of toolCalls) {
         if (isApplyPatch(item)) {
-          files += applyPatchOps(item.raw).length;
+          files += applyPatchOpsFromToolItem(item).length;
         }
       }
       return files ? { content: `${files} ${files === 1 ? "file" : "files"} edited` } : null;

--- a/packages/react/styles/tokens.css
+++ b/packages/react/styles/tokens.css
@@ -97,7 +97,8 @@
   --og-session-chrome-surface-open: color-mix(in oklch, var(--og-color-surface-2) 92%, transparent);
   --og-session-chrome-border: color-mix(in oklch, var(--og-color-border) 85%, transparent);
   --og-session-chrome-border-open: var(--og-color-border);
-  --og-session-chrome-highlight: color-mix(in oklch, var(--og-color-bg) 72%, transparent);
+  /* Soft wash only — no ring/border; the active chip carries the X. */
+  --og-session-chrome-highlight: color-mix(in oklch, var(--og-color-surface-3) 55%, transparent);
   --og-session-chrome-shadow: 0 6px 22px -14px oklch(0 0 0 / 0.42);
   --og-session-chrome-shadow-open: 0 10px 28px -16px oklch(0 0 0 / 0.5);
   --og-session-chrome-radius: var(--og-radius-lg);
@@ -158,7 +159,7 @@
   --og-session-chrome-surface-open: var(--og-color-surface-2);
   --og-session-chrome-border: color-mix(in oklch, var(--og-color-border) 90%, transparent);
   --og-session-chrome-border-open: var(--og-color-border);
-  --og-session-chrome-highlight: color-mix(in oklch, var(--og-color-surface-1) 88%, transparent);
+  --og-session-chrome-highlight: color-mix(in oklch, var(--og-color-surface-3) 70%, transparent);
   --og-session-chrome-shadow: 0 4px 16px -10px oklch(0.2 0.02 260 / 0.14);
   --og-session-chrome-shadow-open: 0 8px 22px -12px oklch(0.2 0.02 260 / 0.18);
   --og-session-chrome-row-hover: color-mix(in oklch, var(--og-color-surface-3) 70%, transparent);

--- a/packages/react/styles/tokens.css
+++ b/packages/react/styles/tokens.css
@@ -97,17 +97,18 @@
   --og-session-chrome-surface-open: color-mix(in oklch, var(--og-color-surface-2) 92%, transparent);
   --og-session-chrome-border: color-mix(in oklch, var(--og-color-border) 85%, transparent);
   --og-session-chrome-border-open: var(--og-color-border);
-  /* Soft wash only — no ring/border; the active chip carries the X. */
-  --og-session-chrome-highlight: color-mix(in oklch, var(--og-color-surface-3) 55%, transparent);
+  /* Selected chip: solid lift vs open dock surface (not a faint wash). */
+  --og-session-chrome-highlight: var(--og-color-surface-3);
+  --og-session-chrome-highlight-ring: color-mix(in oklch, var(--og-color-fg) 16%, transparent);
   --og-session-chrome-shadow: 0 6px 22px -14px oklch(0 0 0 / 0.42);
   --og-session-chrome-shadow-open: 0 10px 28px -16px oklch(0 0 0 / 0.5);
   --og-session-chrome-radius: var(--og-radius-lg);
   --og-session-chrome-chip-min-height: 1.75rem;
   --og-session-chrome-chip-pad-x: 0.5rem;
   --og-session-chrome-chip-gap: 0.125rem;
-  --og-session-chrome-rail-pad: 0.2rem;
-  --og-session-chrome-panel-pad-x: 0.5rem;
-  --og-session-chrome-panel-pad-y: 0.4rem;
+  --og-session-chrome-rail-pad: 0.15rem;
+  --og-session-chrome-panel-pad-x: 0.45rem;
+  --og-session-chrome-panel-pad-y: 0.3rem;
   /* Expanded agents/queue/inbox/goal body — scroll inside, never grow unbound. */
   --og-session-chrome-panel-max-height: min(18rem, 40dvh);
   --og-session-chrome-duration: 220ms;
@@ -159,7 +160,8 @@
   --og-session-chrome-surface-open: var(--og-color-surface-2);
   --og-session-chrome-border: color-mix(in oklch, var(--og-color-border) 90%, transparent);
   --og-session-chrome-border-open: var(--og-color-border);
-  --og-session-chrome-highlight: color-mix(in oklch, var(--og-color-surface-3) 70%, transparent);
+  --og-session-chrome-highlight: var(--og-color-surface-3);
+  --og-session-chrome-highlight-ring: color-mix(in oklch, var(--og-color-fg) 12%, transparent);
   --og-session-chrome-shadow: 0 4px 16px -10px oklch(0.2 0.02 260 / 0.14);
   --og-session-chrome-shadow-open: 0 8px 22px -12px oklch(0.2 0.02 260 / 0.18);
   --og-session-chrome-row-hover: color-mix(in oklch, var(--og-color-surface-3) 70%, transparent);

--- a/packages/react/test/chat-composer-controls.test.tsx
+++ b/packages/react/test/chat-composer-controls.test.tsx
@@ -73,6 +73,28 @@ async function press(textarea: HTMLTextAreaElement, init: KeyboardEventInit): Pr
 }
 
 describe("ChatComposer delivery and lifecycle controls", () => {
+  test("keeps the mobile footer on one nowrap row when controls and actions share the bar", async () => {
+    const spy = { sends: [] as string[], pauses: 0, resumes: 0 };
+    mounted = await renderComponent(
+      <ChatComposer
+        composer={composer(spy)}
+        controlsStart={<span data-testid="chat-model">model</span>}
+        actionsStart={<span data-testid="voice">voice</span>}
+        transcriptionSuppressed
+      />,
+    );
+    const footer = [...mounted.container.querySelectorAll("div")].find((node) =>
+      node.className.includes("max-sm:flex-nowrap"),
+    );
+    expect(footer).toBeTruthy();
+    expect(footer?.className).toContain("sm:flex-wrap");
+    const actions = [...mounted.container.querySelectorAll("span")].find((node) =>
+      node.className.includes("max-sm:shrink-0"),
+    );
+    expect(actions).toBeTruthy();
+    expect(actions?.className).toContain("max-sm:flex-nowrap");
+  });
+
   test("Enter queues while Cmd/Ctrl+Enter steers", async () => {
     const spy = { sends: [] as string[], pauses: 0, resumes: 0 };
     mounted = await renderComponent(<ChatComposer composer={composer(spy)} />);

--- a/packages/react/test/model-policy-picker.test.tsx
+++ b/packages/react/test/model-policy-picker.test.tsx
@@ -35,6 +35,7 @@ const MODELS: ClientModel[] = [
   {
     id: "codex/gpt-5.6-sol",
     label: "GPT-5.6 Sol",
+    shortLabel: "5.6 Sol",
     provider: "codex",
     providerLabel: "Codex",
     source: "codex",
@@ -131,6 +132,15 @@ describe("ModelPolicyPicker", () => {
     expect(trigger?.textContent).toContain("Medium");
     expect(container.querySelector('[data-testid="model-picker-fast-icon"]')).toBeTruthy();
     expect(container.querySelector("select")).toBeNull();
+    // Mobile span prefers curated shortLabel; desktop keeps the full label.
+    const labelSpans = [...(trigger?.querySelectorAll("span.truncate") ?? [])];
+    const mobileLabel = labelSpans.find((span) => /(?:^|\s)sm:hidden(?:\s|$)/.test(span.className));
+    const desktopLabel = labelSpans.find((span) =>
+      /(?:^|\s)max-sm:hidden(?:\s|$)/.test(span.className),
+    );
+    expect(mobileLabel?.textContent).toBe("5.6 Sol");
+    expect(desktopLabel?.textContent).toBe("GPT-5.6 Sol");
+    expect(trigger?.className).toContain("max-sm:max-w-[7.5rem]");
   });
 
   test("changes model policy only when an effort is chosen", async () => {

--- a/packages/react/test/model-policy.test.ts
+++ b/packages/react/test/model-policy.test.ts
@@ -73,6 +73,23 @@ describe("model-policy", () => {
     expect(rows[0]).toMatchObject({ billingClass: "byok", billingClassLabel: "Your Gateway" });
   });
 
+  test("projects curated shortLabel into picker rows", () => {
+    const rows = projectPickerRows([
+      catalogModel({
+        id: "gpt-5.6-sol",
+        label: "GPT-5.6 Sol",
+        shortLabel: "5.6 Sol",
+      }),
+      catalogModel({
+        id: "deepseek-v4-flash-0731",
+        label: "DeepSeek V4 Flash 0731",
+        shortLabel: "V4 Flash",
+      }),
+    ]);
+    expect(rows.find((row) => row.id === "gpt-5.6-sol")?.shortLabel).toBe("5.6 Sol");
+    expect(rows.find((row) => row.id === "deepseek-v4-flash-0731")?.shortLabel).toBe("V4 Flash");
+  });
+
   test("groups catalog rows by billing class", () => {
     const rows = projectPickerRows([
       catalogModel({

--- a/packages/react/test/realtime-control.test.tsx
+++ b/packages/react/test/realtime-control.test.tsx
@@ -8,10 +8,13 @@ import type { SessionRealtimeControllerSnapshot } from "@opengeni/sdk/realtime";
 import {
   RealtimeVoiceControl,
   RealtimeModelPickerMenu,
+  SessionRealtimeControl,
   codexRealtimeAdmissionAllowed,
   type RealtimeModelOption,
+  type SessionRealtimeControllerFactory,
   useSessionRealtime,
 } from "../src/realtime/realtime-control";
+import type { SessionRealtimeController } from "@opengeni/sdk/realtime";
 
 GlobalRegistrator.register({ url: "https://app.example.test" });
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -204,11 +207,18 @@ describe("ordinary session Codex realtime control", () => {
     );
     expect(region).not.toBeNull();
     expect(container.querySelector('[role="status"]')?.textContent).toContain("Start voice");
+    // Idle primary control is a ghost icon (no border/surface box).
+    expect(start?.className).not.toMatch(/(?:^|\s)border(?:\s|$)/);
+    expect(start?.className).not.toContain("bg-og-accent");
+    expect(start?.className).toContain("text-og-fg-muted");
     const voiceOptions = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Choose voice model and options"]',
     );
     expect(voiceOptions).not.toBeNull();
-    expect(voiceOptions?.classList.contains("w-6")).toBe(true);
+    // Desktop-only chevron (hidden below sm); still present for wider viewports.
+    expect(voiceOptions?.classList.contains("w-5")).toBe(true);
+    expect(voiceOptions?.classList.contains("hidden")).toBe(true);
+    expect(voiceOptions?.classList.contains("sm:inline-flex")).toBe(true);
     expect(container.textContent).not.toContain("Realtime diagnostics");
     expect(start?.disabled).toBe(false);
     await act(async () => start?.click());
@@ -249,13 +259,16 @@ describe("ordinary session Codex realtime control", () => {
       'button[aria-label="End voice conversation"]',
     );
     expect(container.querySelector('[role="status"]')?.textContent).toContain("Listening");
+    expect(stop?.className).toContain("bg-og-accent");
+    const muteCluster = container.querySelector('[data-testid="realtime-mute-controls"]');
+    expect(muteCluster).not.toBeNull();
+    expect(muteCluster?.className).not.toContain("max-sm:hidden");
     const muteMicrophone = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Mute microphone"]',
     );
     const muteAudio = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Mute voice audio"]',
     );
-    expect(container.querySelector('[data-testid="realtime-mute-controls"]')).not.toBeNull();
     expect(muteMicrophone?.getAttribute("aria-pressed")).toBe("false");
     expect(muteAudio?.getAttribute("aria-pressed")).toBe("false");
     await act(async () => {
@@ -265,6 +278,79 @@ describe("ordinary session Codex realtime control", () => {
     expect(stop?.disabled).toBe(false);
     await act(async () => stop?.click());
     expect(calls).toEqual(["start", "input:true", "output:true", "stop"]);
+  });
+
+  test("notifies the host when voice becomes active so dictate can soft-hide", async () => {
+    const activeUpdates: boolean[] = [];
+    let current = {
+      ...idle,
+      status: "active" as const,
+      realtimeId: activeMode.id,
+      mode: activeMode,
+    };
+    const listeners = new Set<(snapshot: typeof current) => void>();
+    const factory: SessionRealtimeControllerFactory = () => {
+      const controller: SessionRealtimeController = {
+        snapshot: () => current,
+        subscribe(listener) {
+          listeners.add(listener);
+          listener(current);
+          return () => listeners.delete(listener);
+        },
+        start: async () => undefined,
+        observeLifecycle: async () => undefined,
+        heartbeat: async () => undefined,
+        flush: async () => undefined,
+        ingestProviderEvent: async () => undefined,
+        retry: async () => undefined,
+        retryAudibleOutput: async () => true,
+        setInputMuted(muted) {
+          current = { ...current, inputMuted: muted };
+          for (const listener of listeners) listener(current);
+        },
+        setOutputMuted(muted) {
+          current = { ...current, outputMuted: muted };
+          for (const listener of listeners) listener(current);
+        },
+        stop: async () => undefined,
+        close() {
+          listeners.clear();
+        },
+      };
+      return controller;
+    };
+
+    await act(async () => {
+      root.render(
+        <SessionRealtimeControl
+          client={
+            {
+              getWorkspaceRealtimeModelCatalog: undefined,
+            } as unknown as OpenGeniClient
+          }
+          workspaceId="11111111-1111-4111-8111-111111111111"
+          sessionId="22222222-2222-4222-8222-222222222222"
+          sessionStatus="idle"
+          effectiveControl={effectiveControl}
+          events={[]}
+          eventsReady={true}
+          codexConnected={true}
+          controllerFactory={factory}
+          onVoiceActiveChange={(active) => {
+            activeUpdates.push(active);
+          }}
+        />,
+      );
+    });
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await act(async () => await new Promise((resolve) => setTimeout(resolve, 0)));
+      if (activeUpdates.includes(true)) break;
+    }
+    expect(activeUpdates.includes(true)).toBe(true);
+    expect(container.querySelector('[data-testid="realtime-mute-controls"]')).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="realtime-mute-controls"]')?.className,
+    ).not.toContain("max-sm:hidden");
   });
 
   test("uses the shared provider-to-model drill-down with recognizable provider marks", async () => {

--- a/packages/react/test/realtime-control.test.tsx
+++ b/packages/react/test/realtime-control.test.tsx
@@ -215,10 +215,10 @@ describe("ordinary session Codex realtime control", () => {
       'button[aria-label="Choose voice model and options"]',
     );
     expect(voiceOptions).not.toBeNull();
-    // Desktop-only chevron (hidden below sm); still present for wider viewports.
+    // Public default: chevron available at every breakpoint.
     expect(voiceOptions?.classList.contains("w-5")).toBe(true);
-    expect(voiceOptions?.classList.contains("hidden")).toBe(true);
-    expect(voiceOptions?.classList.contains("sm:inline-flex")).toBe(true);
+    expect(voiceOptions?.classList.contains("hidden")).toBe(false);
+    expect(voiceOptions?.classList.contains("inline-flex")).toBe(true);
     expect(container.textContent).not.toContain("Realtime diagnostics");
     expect(start?.disabled).toBe(false);
     await act(async () => start?.click());

--- a/packages/react/test/realtime-control.test.tsx
+++ b/packages/react/test/realtime-control.test.tsx
@@ -215,8 +215,8 @@ describe("ordinary session Codex realtime control", () => {
       'button[aria-label="Choose voice model and options"]',
     );
     expect(voiceOptions).not.toBeNull();
-    // Public default: chevron available at every breakpoint.
-    expect(voiceOptions?.classList.contains("w-5")).toBe(true);
+    // Public default: chevron available at every breakpoint (≥24px wide).
+    expect(voiceOptions?.classList.contains("w-6")).toBe(true);
     expect(voiceOptions?.classList.contains("hidden")).toBe(false);
     expect(voiceOptions?.classList.contains("inline-flex")).toBe(true);
     expect(container.textContent).not.toContain("Realtime diagnostics");

--- a/packages/react/test/session-chrome.test.tsx
+++ b/packages/react/test/session-chrome.test.tsx
@@ -450,6 +450,29 @@ describe("SessionChrome", () => {
     expect(queueChip?.getAttribute("data-slot")).not.toBe("tooltip-trigger");
   });
 
+  test("puts the close affordance on the expanded chip", async () => {
+    mounted = await renderComponent(
+      <SessionChrome
+        queue={queue({
+          queue: [fakeTurn({ prompt: "Queued prompt that should wrap on a narrow rail" })],
+        })}
+        composer={composer()}
+        goal={goal()}
+        agentsSignal={{ count: 15, detail: "Idle" }}
+        defaultActive="agents"
+      />,
+    );
+    const agentsChip = mounted.container.querySelector<HTMLButtonElement>(
+      '[data-og-session-chrome-signal="agents"]',
+    );
+    const close = agentsChip?.querySelector('[data-testid="session-chrome-close"]');
+    expect(close).not.toBeNull();
+    expect(agentsChip?.getAttribute("aria-label")).toBe("Close 15 agents");
+    // Other chips stay free of a close glyph.
+    const queueChip = mounted.container.querySelector('[data-og-session-chrome-signal="queue"]');
+    expect(queueChip?.querySelector('[data-testid="session-chrome-close"]')).toBeNull();
+  });
+
   test("caps expanded panel height so long agents/queue lists scroll inside", async () => {
     mounted = await renderComponent(
       <SessionChrome

--- a/packages/react/test/timeline-parsers.test.ts
+++ b/packages/react/test/timeline-parsers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   applyPatchOps,
+  applyPatchOpsFromToolItem,
+  parseFreeformApplyPatch,
   controlCaret,
   execTruncated,
   isApplyPatch,
@@ -246,9 +248,109 @@ describe("V4A apply_patch parsing", () => {
     expect(applyPatchOps(null)).toHaveLength(0);
   });
 
+  test("applyPatchOps accepts every Agents SDK function-tool shape", () => {
+    const freeform = [
+      "*** Begin Patch",
+      "*** Add File: src/hello.ts",
+      "+export const hello = 1;",
+      "*** Update File: src/bye.ts",
+      "@@",
+      "-old",
+      "+new",
+      "*** Delete File: src/gone.ts",
+      "*** End Patch",
+    ].join("\n");
+
+    expect(parseFreeformApplyPatch(freeform)).toEqual([
+      { type: "create_file", path: "src/hello.ts", diff: "+export const hello = 1;\n" },
+      { type: "update_file", path: "src/bye.ts", diff: "@@\n-old\n+new\n" },
+      { type: "delete_file", path: "src/gone.ts" },
+    ]);
+
+    expect(applyPatchOps({ patch: freeform })).toHaveLength(3);
+    expect(applyPatchOps({ command: ["apply_patch", freeform] })).toHaveLength(3);
+    expect(applyPatchOps(freeform)).toHaveLength(3);
+    expect(
+      applyPatchOps({
+        type: "update_file",
+        path: "flat.ts",
+        diff: "@@\n-a\n+b\n",
+      }),
+    ).toEqual([{ type: "update_file", path: "flat.ts", diff: "@@\n-a\n+b\n" }]);
+    expect(
+      applyPatchOps([
+        { type: "create_file", path: "a.ts", diff: "+a\n" },
+        { type: "delete_file", path: "b.ts" },
+      ]),
+    ).toHaveLength(2);
+
+    // Codex function_call: args on the tool item, not hosted operation.
+    expect(
+      applyPatchOpsFromToolItem({
+        raw: {
+          type: "function_call",
+          name: "apply_patch",
+          arguments: JSON.stringify({ patch: freeform }),
+        },
+        arguments: JSON.stringify({ patch: freeform }),
+      }),
+    ).toHaveLength(3);
+    expect(
+      applyPatchOpsFromToolItem({
+        raw: { type: "function_call", name: "apply_patch", arguments: freeform },
+        arguments: freeform,
+      }),
+    ).toHaveLength(3);
+    expect(
+      applyPatchOpsFromToolItem({
+        raw: {
+          type: "apply_patch_call",
+          operation: { type: "create_file", path: "hosted.ts", diff: "+x\n" },
+        },
+        arguments: undefined,
+      }),
+    ).toEqual([{ type: "create_file", path: "hosted.ts", diff: "+x\n" }]);
+  });
+
+  test("applyPatchOps tolerates leading whitespace and rejects unknown op types", () => {
+    const freeform = [
+      "*** Begin Patch",
+      "*** Update File: spaced.ts",
+      "@@",
+      "-a",
+      "+b",
+      "*** End Patch",
+    ].join("\n");
+
+    expect(applyPatchOps({ patch: `\n  ${freeform}` })).toEqual([
+      { type: "update_file", path: "spaced.ts", diff: "@@\n-a\n+b\n" },
+    ]);
+    expect(applyPatchOps({ command: ["apply_patch", `\n${freeform}`] })).toHaveLength(1);
+    expect(applyPatchOps(`  ${JSON.stringify({ patch: freeform })}`)).toHaveLength(1);
+    expect(applyPatchOps(`\n${freeform}`)).toHaveLength(1);
+
+    // Envelope-like type+path must not become a fake op.
+    expect(applyPatchOps({ type: "function_call", path: "nope.ts", arguments: "{}" })).toHaveLength(
+      0,
+    );
+    expect(applyPatchOps({ type: "rename_file", path: "a.ts" })).toHaveLength(0);
+
+    // Empty operations[] falls through to singular operation.
+    expect(
+      applyPatchOps({
+        operations: [],
+        operation: { type: "delete_file", path: "gone.ts" },
+      }),
+    ).toEqual([{ type: "delete_file", path: "gone.ts" }]);
+
+    expect(parseFreeformApplyPatch("*** Begin Patch\n*** End Patch")).toHaveLength(0);
+  });
+
   test("isApplyPatch matches by raw.type and by name", () => {
     expect(isApplyPatch({ name: "anything", raw: { type: "apply_patch_call" } })).toBe(true);
     expect(isApplyPatch({ name: "apply_patch_call", raw: undefined })).toBe(true);
+    expect(isApplyPatch({ name: "apply_patch", raw: { type: "function_call" } })).toBe(true);
+    expect(isApplyPatch({ name: "opengeni__apply_patch", raw: null })).toBe(true);
     expect(isApplyPatch({ name: "exec_command", raw: { type: "function_call" } })).toBe(false);
     expect(isApplyPatch({ name: "exec_command", raw: null })).toBe(false);
   });

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -1394,6 +1394,40 @@ describe("ApplyPatchRenderer — running state (in-flight affordance)", () => {
 
     await r.unmount();
   });
+
+  test("Codex function-tool { patch } shape uses the specialized renderer", async () => {
+    const freeform = [
+      "*** Begin Patch",
+      "*** Update File: src/hello.ts",
+      "@@",
+      "-old",
+      "+new",
+      "*** End Patch",
+    ].join("\n");
+    const item = toolItem({
+      name: "apply_patch",
+      raw: {
+        type: "function_call",
+        name: "apply_patch",
+        arguments: JSON.stringify({ patch: freeform }),
+      },
+      arguments: JSON.stringify({ patch: freeform }),
+      status: "complete",
+      output: "Patch applied.",
+    });
+    const Renderer = defaultToolRegistry.resolve(item);
+    const r = await renderComponent(<Renderer item={item} />);
+    await flush();
+
+    const text = r.container.textContent ?? "";
+    expect(text).toContain("Edited");
+    expect(text).toContain("hello.ts");
+    // Must not fall through to GenericRenderer chrome.
+    expect(text).not.toMatch(/Apply patch/i);
+    expect(r.container.textContent).not.toContain("Arguments");
+
+    await r.unmount();
+  });
 });
 
 /* ---- Running-state: write_stdin ------------------------------------------- */

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -1602,6 +1602,71 @@ describe("buildTimeline", () => {
     });
   });
 
+  test("solo goal_continuation machine-input batches are suppressed (GoalRow owns the tick)", () => {
+    reset();
+    const items = buildTimeline([
+      event("goal.continuation", { text: "Extract the realtime controller" }),
+      event("system.update.delivered", {
+        historyItemId: "history-1",
+        count: 1,
+        members: [
+          {
+            id: "update-1",
+            kind: "goal_continuation",
+            classification: "info",
+            sourceId: "goal-1",
+            summary: "The session goal is not done. Goal: Extract the realtime controller",
+          },
+        ],
+      }),
+    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: "goal",
+      action: "continuation",
+      text: "Extract the realtime controller",
+    });
+  });
+
+  test("mixed batches that include goal_continuation still render as machine-input", () => {
+    reset();
+    const items = buildTimeline([
+      event("goal.continuation", { text: "keep going" }),
+      event("system.update.delivered", {
+        historyItemId: "history-2",
+        count: 2,
+        members: [
+          {
+            id: "update-1",
+            kind: "goal_continuation",
+            classification: "info",
+            sourceId: "goal-1",
+            summary: "The session goal is not done.",
+          },
+          {
+            id: "update-2",
+            kind: "child_terminal_result",
+            classification: "success",
+            sourceId: "child-1",
+            summary: "Child finished.",
+          },
+        ],
+      }),
+    ]);
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "goal", action: "continuation" }),
+        expect.objectContaining({
+          kind: "machine-input-batch",
+          members: expect.arrayContaining([
+            expect.objectContaining({ kind: "goal_continuation" }),
+            expect.objectContaining({ kind: "child_terminal_result" }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
   test("goal.cleared is tolerated as a goal landmark", () => {
     reset();
     const items = buildTimeline([event("goal.cleared", { goalId: "goal-1" })]);

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -2188,6 +2188,8 @@ export type ModelPricingScheduleV1 = {
 export type ClientModel = {
   id: string;
   label: string;
+  /** Optional curated compact label for dense UI (e.g. mobile composer). */
+  shortLabel?: string | undefined;
   /** Provider id (e.g. `openai`, `azure`, or a registry provider id). */
   provider: string;
   providerLabel: string;


### PR DESCRIPTION
## Summary
- Harden SessionChrome for mobile: close-on-chip, stronger selected state, denser agents panel, and a `/dev/composer-chrome` agents-only harness that mirrors the live session dock.
- Render Codex function-tool `apply_patch` shapes with the specialized diff UI (not GenericRenderer), and suppress solo `goal_continuation` machine-input rows so only the GoalRow landmark shows.
- Clarify the realtime voice-end transcript-tail instruction so agents continue in-flight work instead of treating hangup as “do nothing.”

## Test plan
- [ ] `/dev/composer-chrome` → **Agents only**: chip opens with × on the chip, clear selection highlight, compact height; close collapses.
- [ ] Live session with agents: same SessionChrome behavior as harness.
- [ ] Codex turn that calls function `apply_patch` with `{ patch }`: shows Edited/Created/Deleted UI, not raw Arguments.
- [ ] Goal continuation: only “Continuing toward the goal…” landmark; no duplicate “Goal continued” machine-input row.
- [ ] End a realtime voice session mid-task: agent continues work rather than only acknowledging handoff.
- [ ] `bun test packages/react/test/session-chrome.test.tsx packages/react/test/timeline-parsers.test.ts packages/react/test/timeline.test.ts packages/db/test/session-realtime-context.test.ts`


Made with [Cursor](https://cursor.com)