### PR TITLE
chore(release): advance product version to 0.22.62

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.61
-appVersion: "0.22.61"
+version: 0.22.62
+appVersion: "0.22.62"


### PR DESCRIPTION
Advance the immutable OpenGeni product release version for the latest exact package-version snapshot.

Validation:
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `helm lint deploy/helm/opengeni`
- `git diff --check`