### PR TITLE
perf(ci): parallelize relay image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -750,7 +750,7 @@ jobs:
           terraform -chdir=deploy/terraform/gcp validate
 
   service-images:
-    name: Build service workload images
+    name: Build API, worker, and web workload images
     needs: automation-admission
     if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
@@ -761,7 +761,6 @@ jobs:
       api_digest: ${{ steps.api_image.outputs.digest }}
       worker_digest: ${{ steps.worker_image.outputs.digest }}
       web_digest: ${{ steps.web_image.outputs.digest }}
-      relay_digest: ${{ steps.relay_image.outputs.digest }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -822,6 +821,36 @@ jobs:
             OPENGENI_SERVER_VERSION=sha-${{ github.sha }}
             OPENGENI_DEPLOYMENT_REVISION=${{ github.sha }}
 
+  relay-image:
+    name: Build relay workload image
+    needs: automation-admission
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push the immutable exact-main-SHA dogfood image; PR and automation runs remain build-only
+    outputs:
+      relay_digest: ${{ steps.relay_image.outputs.digest }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.sha }}
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build relay image
         id: relay_image
         uses: docker/build-push-action@v7.3.0
@@ -831,7 +860,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-relay:dogfood-sha-{0}', github.sha) || 'opengeni-relay:ci' }}
-
   sandbox-image:
     name: Build headless sandbox workload image
     needs: automation-admission
@@ -873,7 +901,7 @@ jobs:
 
   images:
     name: Workload image builds
-    needs: [automation-admission, service-images, sandbox-image]
+    needs: [automation-admission, service-images, relay-image, sandbox-image]
     if: ${{ always() && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     permissions:
@@ -882,10 +910,12 @@ jobs:
       - name: Require every workload image build
         env:
           SERVICE_IMAGES_RESULT: ${{ needs.service-images.result }}
+          RELAY_IMAGE_RESULT: ${{ needs.relay-image.result }}
           SANDBOX_IMAGE_RESULT: ${{ needs.sandbox-image.result }}
         run: |
           set -euo pipefail
           test "$SERVICE_IMAGES_RESULT" = "success"
+          test "$RELAY_IMAGE_RESULT" = "success"
           test "$SANDBOX_IMAGE_RESULT" = "success"
 
       - name: Check out exact aggregate source
@@ -900,7 +930,7 @@ jobs:
           WORKER_DIGEST: ${{ needs.service-images.outputs.worker_digest }}
           WEB_DIGEST: ${{ needs.service-images.outputs.web_digest }}
           SANDBOX_DIGEST: ${{ needs.sandbox-image.outputs.sandbox_digest }}
-          RELAY_DIGEST: ${{ needs.service-images.outputs.relay_digest }}
+          RELAY_DIGEST: ${{ needs.relay-image.outputs.relay_digest }}
         run: |
           set -euo pipefail
           for digest in \

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2627,8 +2627,9 @@ describe("workflow contracts", () => {
     );
     expect(ci.jobs.images.if).toBe(ci.jobs.deployment.if);
     expect(ci.jobs["service-images"].if).toBe(ci.jobs.deployment.if);
+    expect(ci.jobs["relay-image"].if).toBe(ci.jobs.deployment.if);
     expect(ci.jobs["sandbox-image"].if).toBe(ci.jobs.deployment.if);
-    const imageSteps = ["service-images", "sandbox-image"].flatMap((jobName) =>
+    const imageSteps = ["service-images", "relay-image", "sandbox-image"].flatMap((jobName) =>
       ci.jobs[jobName].steps.filter((candidate: any) => candidate.with?.push),
     );
     expect(imageSteps).toHaveLength(5);
@@ -2657,6 +2658,7 @@ describe("workflow contracts", () => {
       "package-contracts",
       "deployment",
       "service-images",
+      "relay-image",
       "sandbox-image",
       "images",
     ])

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
@@ -150,17 +151,21 @@ describe("release image workflow contract", () => {
     };
 
     expect(parsed.jobs["service-images"]?.needs).toBe("automation-admission");
+    expect(parsed.jobs["relay-image"]?.needs).toBe("automation-admission");
     expect(parsed.jobs["sandbox-image"]?.needs).toBe("automation-admission");
     expect(parsed.jobs.images?.name).toBe("Workload image builds");
     expect(parsed.jobs.images?.needs).toEqual([
       "automation-admission",
       "service-images",
+      "relay-image",
       "sandbox-image",
     ]);
+    expect(parsed.jobs["service-images"]?.if).toBe(parsed.jobs["relay-image"]?.if);
+    expect(parsed.jobs["relay-image"]?.if).toBe(parsed.jobs["sandbox-image"]?.if);
     expect(parsed.jobs["service-images"]?.if).toBe(parsed.jobs["sandbox-image"]?.if);
     expect(parsed.jobs.images?.if).toBe(parsed.jobs["service-images"]?.if);
-    expect(images.match(/packages: write/g)).toHaveLength(2);
-    for (const jobName of ["service-images", "sandbox-image"]) {
+    expect(images.match(/packages: write/g)).toHaveLength(3);
+    for (const jobName of ["service-images", "relay-image", "sandbox-image"]) {
       const login = parsed.jobs[jobName]?.steps?.find((step) => step.name === "Log in to GHCR");
       expect(login?.with).toEqual({
         registry: "ghcr.io",
@@ -170,26 +175,30 @@ describe("release image workflow contract", () => {
     }
     expect(images).toContain("Require every workload image build");
     expect(images).toContain("SERVICE_IMAGES_RESULT: ${{ needs.service-images.result }}");
+    expect(images).toContain("RELAY_IMAGE_RESULT: ${{ needs.relay-image.result }}");
     expect(images).toContain("SANDBOX_IMAGE_RESULT: ${{ needs.sandbox-image.result }}");
     const aggregate = parsed.jobs.images?.steps?.find(
       (step) => step.name === "Require every workload image build",
     );
     expect(aggregate?.env).toEqual({
       SERVICE_IMAGES_RESULT: "${{ needs.service-images.result }}",
+      RELAY_IMAGE_RESULT: "${{ needs.relay-image.result }}",
       SANDBOX_IMAGE_RESULT: "${{ needs.sandbox-image.result }}",
     });
-    const aggregateResult = (serviceResult: string, sandboxResult: string) =>
+    const aggregateResult = (serviceResult: string, relayResult: string, sandboxResult: string) =>
       Bun.spawnSync(["bash", "-c", aggregate?.run ?? "exit 1"], {
         env: {
           ...process.env,
           SERVICE_IMAGES_RESULT: serviceResult,
+          RELAY_IMAGE_RESULT: relayResult,
           SANDBOX_IMAGE_RESULT: sandboxResult,
         },
       }).exitCode;
-    expect(aggregateResult("success", "success")).toBe(0);
+    expect(aggregateResult("success", "success", "success")).toBe(0);
     for (const result of ["failure", "skipped", "cancelled", ""]) {
-      expect(aggregateResult(result, "success")).not.toBe(0);
-      expect(aggregateResult("success", result)).not.toBe(0);
+      expect(aggregateResult(result, "success", "success")).not.toBe(0);
+      expect(aggregateResult("success", result, "success")).not.toBe(0);
+      expect(aggregateResult("success", "success", result)).not.toBe(0);
     }
     expect(images.match(/push: \$\{\{ github\.event_name == 'push' \}\}/g)).toHaveLength(5);
     expect(images.match(/:dogfood-sha-\{0\}', github\.sha\)/g)).toHaveLength(5);
@@ -199,6 +208,7 @@ describe("release image workflow contract", () => {
     expect(images).toContain("Write exact-main-SHA dogfood receipt");
     expect(images).toContain("Upload exact-main-SHA dogfood receipt");
     expect(images).toContain("API_DIGEST: ${{ needs.service-images.outputs.api_digest }}");
+    expect(images).toContain("RELAY_DIGEST: ${{ needs.relay-image.outputs.relay_digest }}");
     expect(images).toContain("SANDBOX_DIGEST: ${{ needs.sandbox-image.outputs.sandbox_digest }}");
     expect(images).toContain('--arg tag "dogfood-sha-${GITHUB_SHA}"');
     expect(images).not.toContain('--arg tag "sha-${GITHUB_SHA}"');
@@ -493,9 +503,14 @@ ${parser}`,
 
   test("ordinary CI builds the same five physical image roles", async () => {
     const ci = await workflow("ci.yml");
+    const parsed = Bun.YAML.parse(ci) as { jobs: Record<string, { steps: Array<unknown> }> };
     const imagesJob = ci.slice(ci.indexOf("\n  service-images:\n"));
     const serviceImages = ci.slice(
       ci.indexOf("\n  service-images:\n"),
+      ci.indexOf("\n  relay-image:\n"),
+    );
+    const relayImage = ci.slice(
+      ci.indexOf("\n  relay-image:\n"),
       ci.indexOf("\n  sandbox-image:\n"),
     );
     const sandboxImage = ci.slice(ci.indexOf("\n  sandbox-image:\n"), ci.indexOf("\n  images:\n"));
@@ -512,7 +527,52 @@ ${parser}`,
     expect(imagesJob).toContain("docker/setup-qemu-action@");
     expect(imagesJob.match(/platforms: linux\/amd64,linux\/arm64/g)).toHaveLength(5);
     expect(serviceImages).not.toContain("docker/sandbox.Dockerfile");
+    expect(serviceImages).not.toContain("agent/crates/opengeni-relay/Dockerfile");
+    expect(relayImage).toContain("agent/crates/opengeni-relay/Dockerfile");
+    expect(relayImage).not.toMatch(/target: (?:api|worker|web)/);
+    expect(relayImage).not.toContain("docker/sandbox.Dockerfile");
     expect(sandboxImage).toContain("docker/sandbox.Dockerfile");
     expect(sandboxImage).not.toMatch(/target: (?:api|worker|web)/);
+
+    const imageSteps = ["service-images", "relay-image", "sandbox-image"].flatMap((jobName) =>
+      parsed.jobs[jobName]!.steps.filter(
+        (step): step is { name: string; uses: string } =>
+          typeof step === "object" &&
+          step !== null &&
+          "uses" in step &&
+          step.uses === "docker/build-push-action@v7.3.0",
+      ).map((step) => ({
+        jobName,
+        name: step.name,
+        fingerprint: createHash("sha256").update(JSON.stringify(step)).digest("hex"),
+      })),
+    );
+    expect(imageSteps).toEqual([
+      {
+        jobName: "service-images",
+        name: "Build API image",
+        fingerprint: "4f1bf9e5979e86bc78b8813e4c2ed834bd9e24781d8906a493be33d235113231",
+      },
+      {
+        jobName: "service-images",
+        name: "Build worker image",
+        fingerprint: "df6c0eea3a346c6ad9f71bb5545044a062179ffd9447553a1e21f467d85c65f4",
+      },
+      {
+        jobName: "service-images",
+        name: "Build web image",
+        fingerprint: "a535f3fae1f58cdd9d47273d2340c26d4e3c143c4e69c59f2de984fcfec37714",
+      },
+      {
+        jobName: "relay-image",
+        name: "Build relay image",
+        fingerprint: "1e26cd74190f9b806413e6943324c20a9da0e8f84dd42406555fca5b5c11c4f9",
+      },
+      {
+        jobName: "sandbox-image",
+        name: "Build headless sandbox image",
+        fingerprint: "6d1ce559070b6825ff5684da724e4c69baad72f6346ab3db04acb46f3cdccbff",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- keep API, worker, and web image builds on one Buildx builder so their shared `docker/opengeni.Dockerfile` layers can still be reused
- move the independent relay context/Dockerfile to one parallel image lane
- preserve the required `Workload image builds` aggregate, all five exact Buildx definitions, exact-source checkout, push/load behavior, image outputs, and exact-main-SHA dogfood receipt

This does not change cancellation, cache, release, deployment, or publication semantics. It adds one bounded GitHub-hosted runner plus duplicated checkout/QEMU/Buildx/login setup.

## Natural-run diagnosis

A post-#958 August 3–4 sample showed:

- service-image job median/p95: 727.0/868.4s
- headless-image job median/p95: 625.0/678.2s
- relay build step median/p95: 353.0/407.4s
- API + worker + web build-step sum: 332.0s median; 428.1s from the per-step p95s

Using the observed service-job setup overhead, the bounded relay split projects the image critical path at 625.0s median and 678.2s p95: reductions of 102.0s (14.0%) and 190.2s (21.9%) from the current service-image lane. This is a projection from natural-run distributions; candidate CI remains authoritative.

The retained natural image logs each contain 108 BuildKit `CACHED` markers, supporting the decision to keep the three shared-Dockerfile targets together. No cache export or cache-byte measurement is available, and this change does not add or modify cache configuration.

## Validation

- parsed workflow identity audit: all five `docker/build-push-action@v7.3.0` step objects and all checkout/QEMU/Buildx/login definitions unchanged from the exact base
- 93 workflow, source-admission, and release-image contract tests; 810 expectations
- fail-closed aggregate adversarial coverage for failure, skipped, cancelled, and empty results in every image lane
- TS7 typecheck: 23 projects, 9.44s elapsed, 1,732,700 KiB peak RSS
- lint: 0 warnings/errors, 1.84s elapsed, 722,984 KiB peak RSS
- format check
- generated-font, workspace/billing static, docs-reference, public-hygiene, and release-schema guards
- `git diff HEAD^ --check`

Per-command elapsed/user/system CPU, peak RSS, block I/O, and context-switch measurements were captured privately. Block I/O was zero for the validation commands; network bytes were not exposed. Buildx 0.30.1 is installed locally, but the Docker daemon/socket is unavailable, so no local multi-platform image build is claimed.