### PR TITLE
Harden MCP OAuth setup deadlines

### DIFF
--- a/.changeset/bright-otters-timeout.md
+++ b/.changeset/bright-otters-timeout.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/network": minor
+"@opengeni/sdk": minor
+"@opengeni/core": patch
+---
+
+Bound MCP OAuth setup with an absolute server deadline, abort stalled response streams, and preserve safe stage-specific API error details in SDK clients.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -31,6 +31,7 @@ import { bodyLimit } from "hono/body-limit";
 import { compress } from "hono/compress";
 import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
+import { ApiHttpError } from "./http/api-error";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { ApiRouteDeps, AppDependencies } from "@opengeni/core";
 import {
@@ -239,7 +240,11 @@ export function createAppComposition(deps: AppDependencies): {
     ],
     exposeHeaders: ["X-OpenGeni-Api-Contract", "X-OpenGeni-Correlation-Id"],
   };
-  const publicApiCors = cors({ ...corsHeaders, credentials: false, origin: "*" });
+  const publicApiCors = cors({
+    ...corsHeaders,
+    credentials: false,
+    origin: "*",
+  });
   const credentialedCors = cors({
     ...corsHeaders,
     credentials: true,
@@ -565,8 +570,11 @@ export function createAppComposition(deps: AppDependencies): {
 
   app.onError((error, c) => {
     const compactionLock = codexCompactionV2ProviderLockedError(error);
+    const apiError = error instanceof ApiHttpError ? error : null;
     const status = compactionLock ? 422 : httpStatusForError(error);
-    const code: ErrorCode = compactionLock ? compactionLock.code : errorCodeForStatus(status);
+    const code: ErrorCode = compactionLock
+      ? compactionLock.code
+      : (apiError?.code ?? errorCodeForStatus(status));
     const requestId = correlationIds.get(c.req.raw) ?? crypto.randomUUID();
     c.header(OPENGENI_CORRELATION_HEADER, requestId);
     if (new URL(c.req.url).pathname.startsWith("/v1/")) {
@@ -578,9 +586,12 @@ export function createAppComposition(deps: AppDependencies): {
         code,
         message: compactionLock
           ? (boundedPublicMessage(compactionLock.message) ?? "Request failed.")
-          : publicErrorMessage(error, status),
-        retryable: retryableHttpStatus(status),
+          : apiError
+            ? (boundedPublicMessage(apiError.message) ?? "Request failed.")
+            : publicErrorMessage(error, status),
+        retryable: apiError?.retryable ?? retryableHttpStatus(status),
         requestId,
+        ...(apiError?.details ? { details: apiError.details } : {}),
       },
     });
     return c.json(envelope, status as ContentfulStatusCode);

--- a/apps/api/src/http/api-error.ts
+++ b/apps/api/src/http/api-error.ts
@@ -1,0 +1,25 @@
+import type { ErrorCode } from "@opengeni/contracts";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { HTTPException } from "hono/http-exception";
+
+type ApiHttpErrorOptions = {
+  code: ErrorCode;
+  message: string;
+  retryable?: boolean;
+  details?: Record<string, unknown>;
+};
+
+/** A public, structured API failure whose message and details are safe for clients. */
+export class ApiHttpError extends HTTPException {
+  readonly code: ErrorCode;
+  readonly retryable: boolean | undefined;
+  readonly details: Record<string, unknown> | undefined;
+
+  constructor(status: number, options: ApiHttpErrorOptions) {
+    super(status as ContentfulStatusCode, { message: options.message });
+    this.name = "ApiHttpError";
+    this.code = options.code;
+    this.retryable = options.retryable;
+    this.details = options.details;
+  }
+}

--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -29,6 +29,7 @@ import { createSignedState, readSignedState } from "@opengeni/github";
 import {
   DestinationPolicyError,
   OAUTH_MAX_RESPONSE_BYTES,
+  RequestDeadlineError,
   isLocalTestEnvironment,
   pinnedFetch,
   readResponseJsonBounded,
@@ -37,6 +38,7 @@ import {
 import { Buffer } from "node:buffer";
 import { createHash, randomBytes } from "node:crypto";
 import { HTTPException } from "hono/http-exception";
+import { ApiHttpError } from "../http/api-error";
 import { canonicalProviderDomain } from "./provider-domain";
 
 export const oauthStateTtlMs = 10 * 60 * 1000;
@@ -49,6 +51,7 @@ type OAuthClientDeps = {
   db: Database;
   settings: Settings;
   observability?: Observability | undefined;
+  oauthStartDeadlineMs?: number | undefined;
 };
 
 export type OAuthStartContext = {
@@ -133,6 +136,66 @@ type TokenResponse = {
 
 type OAuthCallbackStage = "state_verify" | "token_exchange" | "tools_list" | "persist";
 
+export const OAUTH_START_DEADLINE_MS = 15_000;
+
+export type OAuthStartStage =
+  | "connection_lookup"
+  | "mcp_challenge"
+  | "protected_resource_metadata"
+  | "authorization_server_metadata"
+  | "client_registration";
+
+class OAuthStartStageError extends Error {
+  constructor(
+    readonly stage: OAuthStartStage,
+    readonly reason: string,
+    readonly cause: unknown,
+  ) {
+    super(errorMessage(cause));
+    this.name = "OAuthStartStageError";
+  }
+}
+
+class OAuthStartDeadline {
+  readonly signal: AbortSignal;
+  private readonly controller = new AbortController();
+  private readonly timer: ReturnType<typeof setTimeout>;
+
+  constructor(timeoutMs: number) {
+    this.signal = this.controller.signal;
+    this.timer = setTimeout(() => this.controller.abort(), timeoutMs);
+    this.timer.unref?.();
+  }
+
+  async run<T>(stage: OAuthStartStage, operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
+    if (this.signal.aborted) {
+      throw new OAuthStartStageError(stage, "timeout", new RequestDeadlineError(stage));
+    }
+    let removeAbortListener = () => {};
+    const aborted = new Promise<never>((_resolve, reject) => {
+      const onAbort = () =>
+        reject(new OAuthStartStageError(stage, "timeout", new RequestDeadlineError(stage)));
+      this.signal.addEventListener("abort", onAbort, { once: true });
+      removeAbortListener = () => this.signal.removeEventListener("abort", onAbort);
+    });
+    try {
+      return await Promise.race([operation(this.signal), aborted]);
+    } catch (error) {
+      if (error instanceof OAuthStartStageError) throw error;
+      if (this.signal.aborted || error instanceof RequestDeadlineError) {
+        throw new OAuthStartStageError(stage, "timeout", error);
+      }
+      throw new OAuthStartStageError(stage, oauthStartFailureReason(error), error);
+    } finally {
+      removeAbortListener();
+    }
+  }
+
+  dispose(): void {
+    clearTimeout(this.timer);
+  }
+}
+
 class OAuthCallbackStageError extends Error {
   constructor(
     readonly stage: OAuthCallbackStage,
@@ -147,6 +210,27 @@ class OAuthCallbackStageError extends Error {
 export async function startMcpOAuth(
   deps: OAuthClientDeps,
   context: OAuthStartContext,
+): Promise<OAuthStartResponse> {
+  const deadline = new OAuthStartDeadline(deps.oauthStartDeadlineMs ?? OAUTH_START_DEADLINE_MS);
+  try {
+    return await startMcpOAuthWithinDeadline(deps, context, deadline);
+  } catch (error) {
+    const staged =
+      error instanceof OAuthStartStageError
+        ? error
+        : new OAuthStartStageError("connection_lookup", oauthStartFailureReason(error), error);
+    const providerDomain = safeRequestedProviderDomain(context.payload);
+    logOAuthStartFailure(deps.observability, staged, providerDomain);
+    throw oauthStartApiError(staged);
+  } finally {
+    deadline.dispose();
+  }
+}
+
+async function startMcpOAuthWithinDeadline(
+  deps: OAuthClientDeps,
+  context: OAuthStartContext,
+  deadline: OAuthStartDeadline,
 ): Promise<OAuthStartResponse> {
   const { db, settings } = deps;
   const mcpUrl = canonicalMcpResource(context.payload.mcpUrl ?? context.payload.resource);
@@ -169,16 +253,18 @@ export async function startMcpOAuth(
   const baseUrl = integrationBaseUrl(settings.publicBaseUrl, context.requestUrl);
   const redirectUri = `${baseUrl}/v1/integrations/oauth/callback`;
   const metadataUrl = `${baseUrl}/v1/integrations/oauth/client-metadata.json`;
-  const existing = await existingOAuthConnectionForStart(db, {
-    workspaceId: context.workspaceId,
-    subjectId: context.subjectId,
-    providerDomain,
-    mcpUrl,
-    personalSlack,
-    connectionId: context.payload.connectionId,
-    requestedOwnership: context.payload.ownership,
-    newConnectionOwnership: requestedOwnership,
-  });
+  const existing = await deadline.run("connection_lookup", async () =>
+    existingOAuthConnectionForStart(db, {
+      workspaceId: context.workspaceId,
+      subjectId: context.subjectId,
+      providerDomain,
+      mcpUrl,
+      personalSlack,
+      connectionId: context.payload.connectionId,
+      requestedOwnership: context.payload.ownership,
+      newConnectionOwnership: requestedOwnership,
+    }),
+  );
   if (context.payload.connectionId && !existing) {
     throw new HTTPException(404, { message: "connection not found" });
   }
@@ -186,7 +272,7 @@ export async function startMcpOAuth(
     ? ownershipForConnection(existing.subjectId, context.subjectId)
     : requestedOwnership;
 
-  const discovery = await discoverMcpOAuth(mcpUrl, settings);
+  const discovery = await discoverMcpOAuth(mcpUrl, settings, deadline);
   if (personalSlack && !isLocalTestEnvironment(settings.environment)) {
     assertSlackAuthorizationServer(discovery.as);
   }
@@ -197,14 +283,17 @@ export async function startMcpOAuth(
     discovery.challenge.scope,
     discovery.prm.scopesSupported,
   );
-  const client = await registerOAuthClient(
-    db,
-    settings,
-    discovery.as,
-    metadataUrl,
-    redirectUri,
-    authorizeScopes,
-    context.payload.oauthClient,
+  const client = await deadline.run("client_registration", (signal) =>
+    registerOAuthClient(
+      db,
+      settings,
+      discovery.as,
+      metadataUrl,
+      redirectUri,
+      authorizeScopes,
+      context.payload.oauthClient,
+      signal,
+    ),
   );
   const key = requireEnvironmentEncryption(settings);
   const state = createSignedState(requireIntegrationsStateSecret(settings), {
@@ -225,7 +314,9 @@ export async function startMcpOAuth(
     clientRegistrationMethod: client.method,
     tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
     ...(client.method === "manual" && client.clientSecret
-      ? { encryptedClientSecret: encryptEnvironmentValue(key, client.clientSecret) }
+      ? {
+          encryptedClientSecret: encryptEnvironmentValue(key, client.clientSecret),
+        }
       : {}),
     returnPath,
     ...(existing ? { connectionId: existing.id, connectionVersion: existing.version } : {}),
@@ -249,7 +340,11 @@ export async function startMcpOAuth(
 
 export async function completeMcpOAuthCallback(
   deps: OAuthClientDeps,
-  input: { code?: string | undefined; state?: string | undefined; requestUrl: string },
+  input: {
+    code?: string | undefined;
+    state?: string | undefined;
+    requestUrl: string;
+  },
 ): Promise<OAuthCallbackResult> {
   const { db, settings, observability } = deps;
   let state: OAuthStatePayload | null = null;
@@ -260,14 +355,20 @@ export async function completeMcpOAuthCallback(
       new Error("missing OAuth state"),
     );
     logOAuthCallbackFailure(observability, error, state);
-    return { redirectTo: callbackReturnPath("/integrations", "error", { reason: error.reason }) };
+    return {
+      redirectTo: callbackReturnPath("/integrations", "error", {
+        reason: error.reason,
+      }),
+    };
   }
   try {
     state = readOAuthState(input.state, settings);
     await requireOAuthCallbackGrant(db, state);
     if (!input.code) {
       return {
-        redirectTo: callbackReturnPath(state.returnPath, "error", { reason: "missing_code" }),
+        redirectTo: callbackReturnPath(state.returnPath, "error", {
+          reason: "missing_code",
+        }),
       };
     }
     const consumed = await consumeIntegrationOAuthStateNonce(db, {
@@ -279,7 +380,9 @@ export async function completeMcpOAuthCallback(
       now: new Date(),
     });
     if (!consumed) {
-      throw new HTTPException(400, { message: "OAuth state has already been used" });
+      throw new HTTPException(400, {
+        message: "OAuth state has already been used",
+      });
     }
   } catch (error) {
     const staged = new OAuthCallbackStageError("state_verify", "state_invalid", error);
@@ -377,7 +480,11 @@ export async function completeMcpOAuthCallback(
         ? error
         : new OAuthCallbackStageError("persist", "persist_failed", error);
     logOAuthCallbackFailure(observability, staged, state);
-    return { redirectTo: callbackReturnPath(state.returnPath, "error", { reason: staged.reason }) };
+    return {
+      redirectTo: callbackReturnPath(state.returnPath, "error", {
+        reason: staged.reason,
+      }),
+    };
   }
 }
 
@@ -421,7 +528,9 @@ function assertPersonalSlackOAuthStart(
     });
   }
   if (payload.providerDomain && canonicalProviderDomain(payload.providerDomain) !== "slack.com") {
-    throw new HTTPException(422, { message: "Slack provider identity does not match slack.com" });
+    throw new HTTPException(422, {
+      message: "Slack provider identity does not match slack.com",
+    });
   }
   if (!isLocalTestEnvironment(settings.environment) && mcpUrl !== OFFICIAL_SLACK_MCP_URL) {
     throw new HTTPException(422, {
@@ -454,16 +563,17 @@ export function assertSlackAuthorizationServer(as: AuthorizationServerMetadata):
 async function discoverMcpOAuth(
   resource: string,
   settings: Settings,
+  deadline: OAuthStartDeadline,
 ): Promise<{
   challenge: WwwAuthenticateChallenge;
   prm: ProtectedResourceMetadata;
   as: AuthorizationServerMetadata;
 }> {
-  const challenge = await probeMcpChallenge(resource, settings);
-  const prm = await discoverProtectedResourceMetadata(
-    resource,
-    settings,
-    challenge.resourceMetadata,
+  const challenge = await deadline.run("mcp_challenge", (signal) =>
+    probeMcpChallenge(resource, settings, signal),
+  );
+  const prm = await deadline.run("protected_resource_metadata", (signal) =>
+    discoverProtectedResourceMetadata(resource, settings, challenge.resourceMetadata, signal),
   );
   const authorizationServer = prm.authorizationServers[0];
   if (!authorizationServer) {
@@ -471,7 +581,9 @@ async function discoverMcpOAuth(
       message: "MCP protected resource metadata did not advertise an authorization server",
     });
   }
-  const as = await discoverAuthorizationServerMetadata(authorizationServer, settings);
+  const as = await deadline.run("authorization_server_metadata", (signal) =>
+    discoverAuthorizationServerMetadata(authorizationServer, settings, signal),
+  );
   if (!as.codeChallengeMethodsSupported.includes("S256")) {
     throw new HTTPException(422, {
       message: "authorization server does not support required PKCE S256",
@@ -483,10 +595,12 @@ async function discoverMcpOAuth(
 async function probeMcpChallenge(
   resource: string,
   settings: Settings,
+  signal: AbortSignal,
 ): Promise<WwwAuthenticateChallenge> {
   const response = await fetchOAuth(resource, settings, {
     method: "GET",
     headers: { accept: "application/json" },
+    signal,
   });
   try {
     if (response.status !== 401) {
@@ -502,13 +616,14 @@ async function discoverProtectedResourceMetadata(
   resource: string,
   settings: Settings,
   advertisedUrl?: string,
+  signal?: AbortSignal,
 ): Promise<ProtectedResourceMetadata> {
   const candidates = uniqueStrings([
     ...(advertisedUrl ? [advertisedUrl] : []),
     ...wellKnownCandidates(resource, "oauth-protected-resource"),
   ]);
   for (const candidate of candidates) {
-    const payload = await fetchJsonObject(candidate, settings).catch((error) => {
+    const payload = await fetchJsonObject(candidate, settings, signal).catch((error) => {
       if (error instanceof HTTPException) {
         throw error;
       }
@@ -528,12 +643,15 @@ async function discoverProtectedResourceMetadata(
       ...(stringValue(payload.resource) ? { resource: stringValue(payload.resource)! } : {}),
     };
   }
-  throw new HTTPException(422, { message: "could not discover MCP protected resource metadata" });
+  throw new HTTPException(422, {
+    message: "could not discover MCP protected resource metadata",
+  });
 }
 
 async function discoverAuthorizationServerMetadata(
   authorizationServer: string,
   settings: Settings,
+  signal: AbortSignal,
 ): Promise<AuthorizationServerMetadata> {
   const safeAuthorizationServer = oauthEndpointUrl(
     authorizationServer,
@@ -551,7 +669,7 @@ async function discoverAuthorizationServerMetadata(
     safeAuthorizationServer,
   ]);
   for (const candidate of candidates) {
-    const payload = await fetchJsonObject(candidate, settings).catch((error) => {
+    const payload = await fetchJsonObject(candidate, settings, signal).catch((error) => {
       if (error instanceof HTTPException) {
         throw error;
       }
@@ -605,6 +723,7 @@ async function registerOAuthClient(
   redirectUri: string,
   scopes: string[],
   manual: OAuthStartRequest["oauthClient"],
+  signal: AbortSignal,
 ): Promise<OAuthClientRegistration> {
   const operator = operatorClientForAs(settings, as);
   if (operator) {
@@ -614,7 +733,14 @@ async function registerOAuthClient(
   // the authorization endpoint. Its documented interactive setup uses DCR,
   // so prefer the simultaneously advertised registration endpoint.
   if (prefersDynamicClientRegistration(as)) {
-    return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri, scopes);
+    return await getOrCreateDynamicClientRegistration(
+      db,
+      settings,
+      as,
+      redirectUri,
+      scopes,
+      signal,
+    );
   }
   if (as.clientIdMetadataDocumentSupported) {
     return {
@@ -638,7 +764,7 @@ async function registerOAuthClient(
       ),
     };
   }
-  return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri, scopes);
+  return await getOrCreateDynamicClientRegistration(db, settings, as, redirectUri, scopes, signal);
 }
 
 function prefersDynamicClientRegistration(as: AuthorizationServerMetadata): boolean {
@@ -653,6 +779,7 @@ async function getOrCreateDynamicClientRegistration(
   as: AuthorizationServerMetadata,
   redirectUri: string,
   scopes: string[],
+  signal: AbortSignal,
 ): Promise<OAuthClientRegistration> {
   const storedClient = await loadIntegrationOAuthClient(db, settings, as.issuer);
   if (storedClient && storedDcrClientSatisfiesPolicy(storedClient, scopes)) {
@@ -673,7 +800,7 @@ async function getOrCreateDynamicClientRegistration(
       message: "manual OAuth client credentials are required for this authorization server",
     });
   }
-  const dcr = await dynamicClientRegistration(settings, as, redirectUri, scopes);
+  const dcr = await dynamicClientRegistration(settings, as, redirectUri, scopes, signal);
   const key = dcr.clientSecret ? requireEnvironmentEncryption(settings) : null;
   const storeInput = {
     issuer: as.issuer,
@@ -814,6 +941,7 @@ async function dynamicClientRegistration(
   as: AuthorizationServerMetadata,
   redirectUri: string,
   scopes: string[],
+  signal: AbortSignal,
 ): Promise<OAuthClientRegistration> {
   if (!as.registrationEndpoint) {
     throw new HTTPException(422, {
@@ -831,6 +959,7 @@ async function dynamicClientRegistration(
       response_types: ["code"],
       ...(scopes.length ? { scope: scopes.join(" ") } : {}),
     }),
+    signal,
   });
   if (!response.ok) {
     await cancelResponseBody(response);
@@ -842,6 +971,7 @@ async function dynamicClientRegistration(
     response,
     OAUTH_MAX_RESPONSE_BYTES,
     "OAuth dynamic registration response",
+    { signal },
   );
   const clientId = stringValue(payload.client_id);
   if (!clientId) {
@@ -1039,7 +1169,9 @@ async function clientForState(
       authorizationServer: state.authorizationServer,
       clientId: state.clientId,
       ...(state.encryptedClientSecret
-        ? { clientSecret: decryptEnvironmentValue(key, state.encryptedClientSecret) }
+        ? {
+            clientSecret: decryptEnvironmentValue(key, state.encryptedClientSecret),
+          }
         : {}),
       tokenEndpointAuthMethod: state.tokenEndpointAuthMethod,
     };
@@ -1052,7 +1184,9 @@ async function clientForState(
       stored.issuer !== state.issuer ||
       stored.authorizationServer !== state.authorizationServer
     ) {
-      throw new HTTPException(400, { message: "OAuth client registration is no longer available" });
+      throw new HTTPException(400, {
+        message: "OAuth client registration is no longer available",
+      });
     }
     return {
       method: "dcr",
@@ -1183,6 +1317,64 @@ function logOAuthCallbackFailure(
   });
 }
 
+function logOAuthStartFailure(
+  observability: Observability | undefined,
+  error: OAuthStartStageError,
+  providerDomain: string | undefined,
+): void {
+  observability?.warn("MCP OAuth setup failed", {
+    "opengeni.oauth.stage": error.stage,
+    "opengeni.oauth.reason": error.reason,
+    "opengeni.oauth.provider_domain": providerDomain,
+    error: sanitizedError(error.cause),
+  });
+}
+
+function oauthStartFailureReason(error: unknown): string {
+  if (error instanceof RequestDeadlineError) return "timeout";
+  if (error instanceof DestinationPolicyError) return error.reason;
+  if (error instanceof HTTPException) return `http_${error.status}`;
+  if (error instanceof SyntaxError) return "invalid_response";
+  return "request_failed";
+}
+
+function oauthStartApiError(error: OAuthStartStageError): ApiHttpError {
+  const timeout = error.reason === "timeout";
+  const status = timeout ? 408 : error.cause instanceof HTTPException ? error.cause.status : 422;
+  return new ApiHttpError(status, {
+    code: timeout || status >= 500 ? "upstream_unavailable" : "validation_failed",
+    retryable: timeout || status === 429 || status >= 500,
+    message: timeout
+      ? oauthStartTimeoutMessage(error.stage)
+      : error.cause instanceof HTTPException
+        ? error.cause.message
+        : `Connection setup failed during ${oauthStartStageLabel(error.stage)}.`,
+    details: {
+      oauthStage: error.stage,
+      oauthReason: error.reason,
+    },
+  });
+}
+
+function oauthStartTimeoutMessage(stage: OAuthStartStage): string {
+  return `Connection setup timed out during ${oauthStartStageLabel(stage)}. Try again.`;
+}
+
+function oauthStartStageLabel(stage: OAuthStartStage): string {
+  switch (stage) {
+    case "connection_lookup":
+      return "connection lookup";
+    case "mcp_challenge":
+      return "MCP authorization discovery";
+    case "protected_resource_metadata":
+      return "protected-resource discovery";
+    case "authorization_server_metadata":
+      return "authorization-server discovery";
+    case "client_registration":
+      return "OAuth client registration";
+  }
+}
+
 function logOAuthVerificationWarning(
   observability: Observability | undefined,
   error: OAuthCallbackStageError,
@@ -1218,6 +1410,16 @@ function errorMessage(error: unknown): string {
 function safeHost(rawUrl: string): string | undefined {
   try {
     return new URL(rawUrl).host;
+  } catch {
+    return undefined;
+  }
+}
+
+function safeRequestedProviderDomain(payload: OAuthStartRequest): string | undefined {
+  try {
+    const resource = payload.mcpUrl ?? payload.resource;
+    if (!resource) return undefined;
+    return canonicalProviderDomain(payload.providerDomain ?? new URL(resource).hostname);
   } catch {
     return undefined;
   }
@@ -1266,7 +1468,10 @@ async function verifyMcpToolsList(
       timeout: 10_000,
       maxTotalTimeout: 10_000,
     });
-    const listed = await client.listTools(undefined, { timeout: 10_000, maxTotalTimeout: 10_000 });
+    const listed = await client.listTools(undefined, {
+      timeout: 10_000,
+      maxTotalTimeout: 10_000,
+    });
     return listed.tools.map((tool) => ({
       name: tool.name,
       ...(tool.description ? { description: tool.description } : {}),
@@ -1414,19 +1619,30 @@ function oauthEndpointUrl(rawUrl: string, settings: Settings, label: string): st
 
 function safeReturnPath(value: string): string {
   if (!value.startsWith("/") || value.startsWith("//")) {
-    throw new HTTPException(400, { message: "OAuth returnPath must be a relative path" });
+    throw new HTTPException(400, {
+      message: "OAuth returnPath must be a relative path",
+    });
   }
   const parsed = new URL(value, "https://opengeni.local");
   // `..` segments can normalize back into a `//host` prefix, which browsers
   // resolve as a protocol-relative absolute URL. Reject the NORMALIZED path.
   if (parsed.origin !== "https://opengeni.local" || parsed.pathname.startsWith("//")) {
-    throw new HTTPException(400, { message: "OAuth returnPath must be a relative path" });
+    throw new HTTPException(400, {
+      message: "OAuth returnPath must be a relative path",
+    });
   }
   return `${parsed.pathname}${parsed.search}${parsed.hash}`;
 }
 
-async function fetchJsonObject(url: string, settings: Settings): Promise<Record<string, unknown>> {
-  const response = await fetchOAuth(url, settings, { headers: { accept: "application/json" } });
+async function fetchJsonObject(
+  url: string,
+  settings: Settings,
+  signal?: AbortSignal,
+): Promise<Record<string, unknown>> {
+  const response = await fetchOAuth(url, settings, {
+    headers: { accept: "application/json" },
+    ...(signal ? { signal } : {}),
+  });
   if (!response.ok) {
     await cancelResponseBody(response);
     throw new Error(`HTTP ${response.status}`);
@@ -1435,6 +1651,7 @@ async function fetchJsonObject(url: string, settings: Settings): Promise<Record<
     response,
     OAUTH_MAX_RESPONSE_BYTES,
     "OAuth metadata response",
+    { ...(signal ? { signal } : {}) },
   );
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     throw new Error("metadata response was not a JSON object");
@@ -1477,19 +1694,25 @@ async function fetchOAuth(
   }
   if (hop >= 3) {
     await cancelResponseBody(response);
-    throw new HTTPException(422, { message: "OAuth fetch exceeded maximum redirect hops" });
+    throw new HTTPException(422, {
+      message: "OAuth fetch exceeded maximum redirect hops",
+    });
   }
   const location = response.headers.get("location");
   if (!location) {
     await cancelResponseBody(response);
-    throw new HTTPException(422, { message: "OAuth fetch redirect was missing Location" });
+    throw new HTTPException(422, {
+      message: "OAuth fetch redirect was missing Location",
+    });
   }
   let nextUrl: string;
   try {
     nextUrl = new URL(location, rawUrl).toString();
   } catch {
     await cancelResponseBody(response);
-    throw new HTTPException(422, { message: "OAuth fetch redirect Location was invalid" });
+    throw new HTTPException(422, {
+      message: "OAuth fetch redirect Location was invalid",
+    });
   }
   await cancelResponseBody(response);
   return await fetchOAuth(nextUrl, settings, init, hop + 1);
@@ -1624,7 +1847,9 @@ function numberValue(value: unknown): number | undefined {
 function requiredString(value: unknown, field: string): string {
   const result = stringValue(value);
   if (!result) {
-    throw new HTTPException(400, { message: `invalid OAuth state: missing ${field}` });
+    throw new HTTPException(400, {
+      message: `invalid OAuth state: missing ${field}`,
+    });
   }
   return result;
 }

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -517,7 +517,7 @@ export function registerConnectionRoutes(app: Hono, deps: ApiRouteDeps): void {
     }
     const payload = parsed.data;
     const result = await startMcpOAuth(
-      { db, settings, observability },
+      { db, settings, observability, oauthStartDeadlineMs: deps.oauthStartDeadlineMs },
       {
         accountId: grant.accountId,
         workspaceId,

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -75,6 +75,17 @@ function app(overrides: Partial<Settings> = {}) {
   } as never);
 }
 
+function appWithDeps(overrides: Partial<Settings>, extraDeps: Record<string, unknown>) {
+  return createApp({
+    settings: { ...settings, ...overrides },
+    db: client.db,
+    bus: {} as never,
+    workflowClient: {} as never,
+    managedAuth: null,
+    ...extraDeps,
+  } as never);
+}
+
 function publicApp(dbOverride: unknown = client?.db ?? {}, overrides: Partial<Settings> = {}) {
   const publicSettings = testSettings({
     authRequired: true,
@@ -865,6 +876,78 @@ describe("connections routes", () => {
     }
   });
 
+  test("oauth start fails promptly with a structured stage when metadata streaming stalls", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    let origin = "";
+    const source = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const path = new URL(request.url).pathname;
+        if (path === "/mcp") {
+          return new Response(null, {
+            status: 401,
+            headers: {
+              "www-authenticate": `Bearer resource_metadata="${origin}/prm"`,
+            },
+          });
+        }
+        if (path === "/prm") {
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(
+                  new TextEncoder().encode('{"authorization_servers":["https://issuer.test"]'),
+                );
+              },
+            }),
+            { headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    origin = `http://127.0.0.1:${source.port}`;
+    try {
+      const startedAt = performance.now();
+      const response = await appWithDeps(
+        { environment: "test" },
+        { oauthStartDeadlineMs: 25 },
+      ).request(`/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`, {
+        method: "POST",
+        headers: {
+          authorization: await bearer(workspace, "subject-a", ["connections:write"]),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          providerDomain: "stalled.example.test",
+          mcpUrl: `${origin}/mcp`,
+        }),
+      });
+      const body = (await response.json()) as {
+        error: {
+          code: string;
+          message: string;
+          retryable: boolean;
+          details?: Record<string, string>;
+        };
+      };
+      expect(response.status).toBe(408);
+      expect(performance.now() - startedAt).toBeLessThan(1_000);
+      expect(body.error).toMatchObject({
+        code: "upstream_unavailable",
+        retryable: true,
+        details: {
+          oauthStage: "protected_resource_metadata",
+          oauthReason: "timeout",
+        },
+      });
+      expect(body.error.message).toContain("protected-resource discovery");
+    } finally {
+      source.stop(true);
+    }
+  });
+
   test("oauth uses protected-resource metadata resource as token audience while connecting to the MCP endpoint", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
@@ -1469,7 +1552,9 @@ describe("connections routes", () => {
 
     const missingDeploymentClient = await request({}, "https://mcp.slack.com/mcp");
     expect(missingDeploymentClient.status).toBe(503);
-    expect(await missingDeploymentClient.text()).toContain("temporarily unavailable");
+    expect(await missingDeploymentClient.text()).toContain(
+      "personal Slack OAuth requires OPENGENI_SLACK_CLIENT_ID and OPENGENI_SLACK_CLIENT_SECRET",
+    );
 
     const nonOfficialResource = await request(
       {

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -117,6 +117,8 @@ export type AppDependencies = {
   slackFetch?: typeof fetch;
   /** Injectable Google OAuth/Drive transport for deterministic connector tests. */
   googleDriveFetch?: typeof fetch;
+  /** Injectable MCP OAuth setup deadline for deterministic stalled-provider tests. */
+  oauthStartDeadlineMs?: number;
   /** Optional host-owned voice-input transcription service. */
   transcription?: TranscriptionService | null;
   // The API process's OWN agent-loop-free sandbox client (constructed from

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -95,6 +95,18 @@ export class ResponseBodyLimitError extends Error {
   }
 }
 
+/** Raised when a caller-supplied absolute request deadline expires. */
+export class RequestDeadlineError extends Error {
+  constructor(readonly label: string) {
+    super(`${label} timed out`);
+    this.name = "RequestDeadlineError";
+  }
+}
+
+export type BoundedResponseReadOptions = {
+  signal?: AbortSignal;
+};
+
 /**
  * Read a response through its stream with a hard byte ceiling.
  *
@@ -107,6 +119,7 @@ export async function readResponseBodyBounded(
   response: Response,
   maxBytes: number,
   label: string,
+  options: BoundedResponseReadOptions = {},
 ): Promise<Uint8Array> {
   if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
     throw new RangeError("response body limit must be a non-negative safe integer");
@@ -133,7 +146,7 @@ export async function readResponseBodyBounded(
   let receivedBytes = 0;
   try {
     for (;;) {
-      const result = await reader.read();
+      const result = await readStreamChunk(reader, options.signal, label);
       if (result.done) {
         break;
       }
@@ -145,10 +158,15 @@ export async function readResponseBodyBounded(
       chunks.push(result.value);
     }
   } catch (error) {
-    await reader.cancel().catch(() => undefined);
+    void reader.cancel(error).catch(() => undefined);
     throw error;
   } finally {
-    reader.releaseLock();
+    try {
+      reader.releaseLock();
+    } catch {
+      // An aborted read may still own the lock until the underlying transport
+      // observes cancellation. The response is already being cancelled above.
+    }
   }
 
   const body = new Uint8Array(receivedBytes);
@@ -164,16 +182,52 @@ export async function readResponseTextBounded(
   response: Response,
   maxBytes: number,
   label: string,
+  options: BoundedResponseReadOptions = {},
 ): Promise<string> {
-  return new TextDecoder().decode(await readResponseBodyBounded(response, maxBytes, label));
+  return new TextDecoder().decode(
+    await readResponseBodyBounded(response, maxBytes, label, options),
+  );
 }
 
 export async function readResponseJsonBounded<T = unknown>(
   response: Response,
   maxBytes: number,
   label: string,
+  options: BoundedResponseReadOptions = {},
 ): Promise<T> {
-  return JSON.parse(await readResponseTextBounded(response, maxBytes, label)) as T;
+  return JSON.parse(await readResponseTextBounded(response, maxBytes, label, options)) as T;
+}
+
+type ResponseStreamReadResult = Awaited<
+  ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]>
+>;
+
+async function readStreamChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal: AbortSignal | undefined,
+  label: string,
+): Promise<ResponseStreamReadResult> {
+  if (!signal) return await reader.read();
+  if (signal.aborted) throw new RequestDeadlineError(label);
+  return await new Promise<ResponseStreamReadResult>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      callback();
+    };
+    const onAbort = () => {
+      const error = new RequestDeadlineError(label);
+      void reader.cancel(error).catch(() => undefined);
+      finish(() => reject(error));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void reader.read().then(
+      (result) => finish(() => resolve(result)),
+      (error) => finish(() => reject(error)),
+    );
+  });
 }
 
 export type ResolvePinnedDestinationOptions = {
@@ -477,7 +531,10 @@ function createPinnedAgent(addresses: readonly DnsAddress[]): DispatcherLifecycl
         if (options.all) {
           callback(
             null,
-            candidates.map((entry) => ({ address: entry.address, family: entry.family })),
+            candidates.map((entry) => ({
+              address: entry.address,
+              family: entry.family,
+            })),
           );
           return;
         }

--- a/packages/network/test/index.test.ts
+++ b/packages/network/test/index.test.ts
@@ -5,6 +5,7 @@ import {
   pinnedFetch,
   readResponseBodyBounded,
   readResponseJsonBounded,
+  RequestDeadlineError,
   resolvePinnedDestination,
   ResponseBodyLimitError,
   validateHttpUrl,
@@ -503,6 +504,30 @@ describe("bounded response readers", () => {
     await expect(readResponseBodyBounded(response, 32, "OAuth response")).rejects.toMatchObject<
       Partial<ResponseBodyLimitError>
     >({ reason: "invalid_content_length" });
+  });
+
+  test("aborts a chunked body that stays below the byte limit but never completes", async () => {
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+    );
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 5);
+
+    await expect(
+      readResponseBodyBounded(response, 32, "OAuth response", {
+        signal: controller.signal,
+      }),
+    ).rejects.toBeInstanceOf(RequestDeadlineError);
+    await Bun.sleep(0);
+    expect(cancelled).toBe(true);
   });
 });
 

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -7,6 +7,7 @@ export class OpenGeniApiError extends Error {
   /** True only when an uncontrolled transport failed after a mutation may have been accepted. */
   readonly outcomeUnknown: boolean;
   readonly body: string;
+  readonly details: Record<string, unknown> | undefined;
 
   constructor(
     status: number,
@@ -42,6 +43,7 @@ export class OpenGeniApiError extends Error {
     this.outcomeUnknown =
       options.outcomeUnknown ?? (gatewayFailure && !!options.mutation && !decoded);
     this.body = !fromResponse || decoded ? body : "";
+    this.details = decoded?.details;
   }
 }
 
@@ -50,6 +52,7 @@ function decodeApiErrorBody(body: string): {
   message: string | undefined;
   requestId: string | undefined;
   retryable: boolean | undefined;
+  details: Record<string, unknown> | undefined;
 } | null {
   if (!body) return null;
   try {
@@ -64,16 +67,34 @@ function decodeApiErrorBody(body: string): {
     const message = boundedApiField(nested.message);
     const requestId = boundedCorrelationId(nested.requestId);
     const retryable = typeof nested.retryable === "boolean" ? nested.retryable : undefined;
-    if (!code && !message && !requestId && retryable === undefined) return null;
+    const details = boundedApiDetails(nested.details);
+    if (!code && !message && !requestId && retryable === undefined && !details) return null;
     return {
       code,
       message,
       requestId,
       retryable,
+      details,
     };
   } catch {
     return null;
   }
+}
+
+function boundedApiDetails(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return;
+  const entries = Object.entries(value as Record<string, unknown>).slice(0, 16);
+  const details: Record<string, unknown> = {};
+  for (const [key, entry] of entries) {
+    if (!/^[a-zA-Z][\w.-]{0,63}$/.test(key)) continue;
+    if (typeof entry === "string") {
+      const bounded = boundedApiField(entry);
+      if (bounded !== undefined) details[key] = bounded;
+    } else if (typeof entry === "number" || typeof entry === "boolean" || entry === null) {
+      details[key] = entry;
+    }
+  }
+  return Object.keys(details).length > 0 ? details : undefined;
 }
 
 function boundedApiField(value: unknown): string | undefined {

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -1097,6 +1097,32 @@ describe("OpenGeniClient connections", () => {
 });
 
 describe("OpenGeniClient error handling for new endpoints", () => {
+  test("preserves safe structured OAuth failure details", () => {
+    const error = new OpenGeniApiError(
+      408,
+      JSON.stringify({
+        error: {
+          status: 408,
+          code: "upstream_unavailable",
+          message: "Connection setup timed out during authorization-server discovery. Try again.",
+          retryable: true,
+          requestId: "oauth-timeout-test",
+          details: {
+            oauthStage: "authorization_server_metadata",
+            oauthReason: "timeout",
+            ignoredNestedValue: { secret: "not projected" },
+          },
+        },
+      }),
+      { mutation: true },
+    );
+
+    expect(error.details).toEqual({
+      oauthStage: "authorization_server_metadata",
+      oauthReason: "timeout",
+    });
+  });
+
   test("non-2xx responses raise OpenGeniApiError with status and body", async () => {
     const { client } = makeClient(() => new Response("goal not found", { status: 404 }));
     const error = await client.getGoal(WORKSPACE_ID, SESSION_ID).then(


### PR DESCRIPTION
## Summary

- enforce one absolute server-side deadline across MCP OAuth connection lookup, challenge discovery, metadata candidates and redirects, bounded response streaming, and dynamic client registration
- return safe structured OAuth stage/reason details so clients can distinguish provider stalls from generic network failures
- preserve bounded structured API error details in the SDK and add deterministic stalled-stream/provider regressions

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test packages/network/test/index.test.ts apps/web/src/lib/mcp-oauth.test.ts packages/sdk/test/client-coverage.test.ts apps/api/test/app.test.ts apps/api/test/connections-routes.test.ts`