### PR TITLE
chore(release): bump product version to 0.22.63

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.62
-appVersion: "0.22.62"
+version: 0.22.63
+appVersion: "0.22.63"


### PR DESCRIPTION
## Summary

- bump the OpenGeni product/chart version from `0.22.62` to `0.22.63`
- reserve a unique immutable release identity for the current package-version main
- no runtime, package, migration, or workflow behavior changes

## Validation

- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `helm lint deploy/helm/opengeni`
- `git diff --check`
- exact one-file diff from main `2a5e47016b5ed86b91798f68c4497c71b69364c1`