### PR TITLE
fix: include API contract header on managed mutations

### DIFF
--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -3,6 +3,7 @@ import {
   authHeadersForAccessKey,
   configureClientAuth,
   createOpenGeniClient,
+  redeemCodexResetCredit,
   resolveApiBaseUrl,
   sendVerificationEmail,
   setStoredAccessKey,
@@ -111,6 +112,45 @@ describe("web API auth helpers", () => {
     expect(request!.init?.method).toBe("POST");
     expect(request!.init?.credentials).toBe("include");
     expect(JSON.parse(String(request!.init?.body))).toEqual({ email: "user@example.com" });
+  });
+
+  test("sends the API contract header on managed-session mutations", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ input: Parameters<typeof fetch>[0]; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      requests.push({ input, init });
+      return Response.json({
+        status: "completed",
+        attemptId: "attempt-id",
+        outcome: "reset",
+        overview: null,
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      await expect(
+        redeemCodexResetCredit("workspace-id", "account-id", {
+          attemptId: "attempt-id",
+          creditId: "credit-id",
+          confirmationToken: "confirmation-token",
+          confirmation: "REDEEM_USAGE_LIMIT_RESET",
+        }),
+      ).resolves.toMatchObject({ status: "completed", outcome: "reset" });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const request = requests[0];
+    expect(request).toBeDefined();
+    expect(String(request!.input)).toBe(
+      "/v1/workspaces/workspace-id/codex/accounts/account-id/reset-credits/redeem",
+    );
+    expect(request!.init?.credentials).toBe("include");
+    expect(new Headers(request!.init?.headers).get("x-opengeni-api-contract")).toBe(
+      "2026-07-workspace-artifacts-v1",
+    );
+    expect(new Headers(request!.init?.headers).get("authorization")).toBeNull();
+    expect(new Headers(request!.init?.headers).get("x-opengeni-access-key")).toBeNull();
   });
 });
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -237,10 +237,18 @@ async function managedBrowserMutation<T>(path: string, body: unknown): Promise<T
   const response = await fetch(`${apiBaseUrl}${path}`, {
     method: "POST",
     credentials: "include",
-    headers: { "content-type": "application/json" },
+    // Managed-session mutations intentionally authenticate only with the
+    // Better Auth cookie. The contract header is protocol negotiation, not an
+    // access-key/bearer credential, and is required by the API before routing
+    // protected state changes.
+    headers: {
+      "content-type": "application/json",
+      [OPENGENI_API_CONTRACT_HEADER]: OPENGENI_API_CONTRACT_REVISION,
+    },
     body: JSON.stringify(body),
   });
   if (!response.ok) {
+    handleApiContractResponse(response);
     throw new ApiError(response.status, await response.text());
   }
   return (await response.json()) as T;


### PR DESCRIPTION
## Summary
- include the API contract header on managed-session state mutations
- preserve cookie-only authentication for managed sessions
- add regression coverage for redemption requests

## Verification
- bun test apps/web/src/api.test.ts
- bun run --cwd apps/web typecheck