### PR TITLE
Harden MCP OAuth callback completion

### DIFF
--- a/.changeset/calm-foxes-finish.md
+++ b/.changeset/calm-foxes-finish.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/core": patch
+"@opengeni/db": patch
+---
+
+Bound MCP OAuth callbacks through token exchange and persistence, return safe stage-specific failures to the capabilities UI, and replace incompatible dynamic client registrations with a compare-and-swap update.

--- a/apps/api/src/integrations/oauth-client.ts
+++ b/apps/api/src/integrations/oauth-client.ts
@@ -21,8 +21,10 @@ import {
   listConnectionsMetadata,
   loadIntegrationOAuthClient,
   normalizeBearerScheme,
+  replaceIntegrationOAuthClientIfCurrent,
   storeIntegrationOAuthClient,
   updateConnection,
+  withDatabaseStatementTimeout,
   type Database,
 } from "@opengeni/db";
 import { createSignedState, readSignedState } from "@opengeni/github";
@@ -52,6 +54,7 @@ type OAuthClientDeps = {
   settings: Settings;
   observability?: Observability | undefined;
   oauthStartDeadlineMs?: number | undefined;
+  oauthCallbackDeadlineMs?: number | undefined;
 };
 
 export type OAuthStartContext = {
@@ -134,9 +137,16 @@ type TokenResponse = {
   raw: Record<string, unknown>;
 };
 
-type OAuthCallbackStage = "state_verify" | "token_exchange" | "tools_list" | "persist";
+type OAuthCallbackStage =
+  | "state_verify"
+  | "client_lookup"
+  | "token_exchange"
+  | "tools_list"
+  | "persist";
 
 export const OAUTH_START_DEADLINE_MS = 15_000;
+export const OAUTH_CALLBACK_DEADLINE_MS = 30_000;
+const OAUTH_CALLBACK_DB_STATEMENT_TIMEOUT_MS = 5_000;
 
 export type OAuthStartStage =
   | "connection_lookup"
@@ -204,6 +214,59 @@ class OAuthCallbackStageError extends Error {
   ) {
     super(errorMessage(cause));
     this.name = "OAuthCallbackStageError";
+  }
+}
+
+class OAuthCallbackDeadline {
+  readonly signal: AbortSignal;
+  private readonly controller = new AbortController();
+  private readonly timer: ReturnType<typeof setTimeout>;
+  private readonly expiresAt: number;
+
+  constructor(timeoutMs: number) {
+    this.signal = this.controller.signal;
+    this.expiresAt = Date.now() + timeoutMs;
+    this.timer = setTimeout(() => this.controller.abort(), timeoutMs);
+    this.timer.unref?.();
+  }
+
+  remainingMs(): number {
+    return Math.max(1, this.expiresAt - Date.now());
+  }
+
+  async run<T>(
+    stage: OAuthCallbackStage,
+    operation: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T> {
+    if (this.signal.aborted) {
+      throw new OAuthCallbackStageError(stage, "timeout", new RequestDeadlineError(stage));
+    }
+    let removeAbortListener = () => {};
+    const aborted = new Promise<never>((_resolve, reject) => {
+      const onAbort = () =>
+        reject(new OAuthCallbackStageError(stage, "timeout", new RequestDeadlineError(stage)));
+      this.signal.addEventListener("abort", onAbort, { once: true });
+      removeAbortListener = () => this.signal.removeEventListener("abort", onAbort);
+    });
+    try {
+      return await Promise.race([operation(this.signal), aborted]);
+    } catch (error) {
+      if (error instanceof OAuthCallbackStageError) throw error;
+      if (
+        this.signal.aborted ||
+        error instanceof RequestDeadlineError ||
+        isDatabaseStatementTimeout(error)
+      ) {
+        throw new OAuthCallbackStageError(stage, "timeout", error);
+      }
+      throw new OAuthCallbackStageError(stage, oauthCallbackFailureReason(stage, error), error);
+    } finally {
+      removeAbortListener();
+    }
+  }
+
+  dispose(): void {
+    clearTimeout(this.timer);
   }
 }
 
@@ -346,6 +409,25 @@ export async function completeMcpOAuthCallback(
     requestUrl: string;
   },
 ): Promise<OAuthCallbackResult> {
+  const deadline = new OAuthCallbackDeadline(
+    deps.oauthCallbackDeadlineMs ?? OAUTH_CALLBACK_DEADLINE_MS,
+  );
+  try {
+    return await completeMcpOAuthCallbackWithinDeadline(deps, input, deadline);
+  } finally {
+    deadline.dispose();
+  }
+}
+
+async function completeMcpOAuthCallbackWithinDeadline(
+  deps: OAuthClientDeps,
+  input: {
+    code?: string | undefined;
+    state?: string | undefined;
+    requestUrl: string;
+  },
+  deadline: OAuthCallbackDeadline,
+): Promise<OAuthCallbackResult> {
   const { db, settings, observability } = deps;
   let state: OAuthStatePayload | null = null;
   if (!input.state) {
@@ -357,38 +439,51 @@ export async function completeMcpOAuthCallback(
     logOAuthCallbackFailure(observability, error, state);
     return {
       redirectTo: callbackReturnPath("/integrations", "error", {
+        stage: error.stage,
         reason: error.reason,
       }),
     };
   }
   try {
     state = readOAuthState(input.state, settings);
-    await requireOAuthCallbackGrant(db, state);
     if (!input.code) {
       return {
         redirectTo: callbackReturnPath(state.returnPath, "error", {
+          stage: "state_verify",
           reason: "missing_code",
         }),
       };
     }
-    const consumed = await consumeIntegrationOAuthStateNonce(db, {
-      accountId: state.accountId,
-      workspaceId: state.workspaceId,
-      subjectId: state.subjectId,
-      nonce: state.nonce,
-      expiresAt: new Date(state.iat * 1000 + oauthStateTtlMs),
-      now: new Date(),
-    });
+    const consumed = await runCallbackDatabaseStage(
+      deadline,
+      "state_verify",
+      db,
+      async (scopedDb) => {
+        await requireOAuthCallbackGrant(scopedDb, state!);
+        return await consumeIntegrationOAuthStateNonce(scopedDb, {
+          accountId: state!.accountId,
+          workspaceId: state!.workspaceId,
+          subjectId: state!.subjectId,
+          nonce: state!.nonce,
+          expiresAt: new Date(state!.iat * 1000 + oauthStateTtlMs),
+          now: new Date(),
+        });
+      },
+    );
     if (!consumed) {
       throw new HTTPException(400, {
         message: "OAuth state has already been used",
       });
     }
   } catch (error) {
-    const staged = new OAuthCallbackStageError("state_verify", "state_invalid", error);
+    const staged =
+      error instanceof OAuthCallbackStageError
+        ? error
+        : new OAuthCallbackStageError("state_verify", "state_invalid", error);
     logOAuthCallbackFailure(observability, staged, state);
     return {
       redirectTo: callbackReturnPath(state?.returnPath ?? "/integrations", "error", {
+        stage: staged.stage,
         reason: staged.reason,
       }),
     };
@@ -400,8 +495,10 @@ export async function completeMcpOAuthCallback(
     const redirectUri = `${baseUrl}/v1/integrations/oauth/callback`;
     const key = requireEnvironmentEncryption(settings);
     const verifier = decryptEnvironmentValue(key, state.encryptedPkceVerifier);
-    const client = await clientForState(db, settings, state);
-    const token = await runCallbackStage("token_exchange", "token_exchange_failed", () =>
+    const client = await runCallbackDatabaseStage(deadline, "client_lookup", db, (scopedDb) =>
+      clientForState(scopedDb, settings, state),
+    );
+    const token = await deadline.run("token_exchange", (signal) =>
       exchangeAuthorizationCode(settings, {
         code: input.code!,
         verifier,
@@ -409,9 +506,16 @@ export async function completeMcpOAuthCallback(
         resource: state.resource,
         tokenEndpoint: state.tokenEndpoint,
         client,
+        signal,
       }),
     );
-    const verification = await verifyMcpToolsListNonFatal(observability, settings, state, token);
+    const verification = await verifyMcpToolsListNonFatal(
+      observability,
+      settings,
+      state,
+      token,
+      deadline,
+    );
     const scopes = grantedScopes(token.scopeText, state.authorizeScopes);
     const credential = credentialBundle(token, state, client);
     const metadata = {
@@ -426,10 +530,10 @@ export async function completeMcpOAuthCallback(
       ...(verification.tools ? { mcpTools: verification.tools } : {}),
     };
     const credentialEncrypted = encryptEnvironmentValue(key, JSON.stringify(credential));
-    await requireOAuthCallbackGrant(db, state);
-    const connection = await runCallbackStage("persist", "persist_failed", () =>
-      state.connectionId
-        ? updateConnection(db, {
+    const connection = await runCallbackDatabaseStage(deadline, "persist", db, async (scopedDb) => {
+      await requireOAuthCallbackGrant(scopedDb, state!);
+      return state!.connectionId
+        ? await updateConnection(scopedDb, {
             workspaceId: state.workspaceId,
             connectionId: state.connectionId,
             visibleToSubjectId: state.subjectId,
@@ -444,7 +548,7 @@ export async function completeMcpOAuthCallback(
             metadata,
             updatedBySubjectId: state.subjectId,
           })
-        : createConnection(db, {
+        : await createConnection(scopedDb, {
             accountId: state.accountId,
             workspaceId: state.workspaceId,
             subjectId: ownerSubjectId,
@@ -455,8 +559,8 @@ export async function completeMcpOAuthCallback(
             expiresAt: token.expiresAt,
             metadata,
             createdBySubjectId: state.subjectId,
-          }),
-    );
+          });
+    });
     if (!connection) {
       throw new HTTPException(409, {
         message: "connection changed during OAuth reconnect; start again",
@@ -482,6 +586,7 @@ export async function completeMcpOAuthCallback(
     logOAuthCallbackFailure(observability, staged, state);
     return {
       redirectTo: callbackReturnPath(state.returnPath, "error", {
+        stage: staged.stage,
         reason: staged.reason,
       }),
     };
@@ -782,7 +887,7 @@ async function getOrCreateDynamicClientRegistration(
   signal: AbortSignal,
 ): Promise<OAuthClientRegistration> {
   const storedClient = await loadIntegrationOAuthClient(db, settings, as.issuer);
-  if (storedClient && storedDcrClientSatisfiesPolicy(storedClient, scopes)) {
+  if (storedClient && storedDcrClientSatisfiesPolicy(storedClient, as, redirectUri, scopes)) {
     return {
       method: "dcr",
       issuer: storedClient.issuer,
@@ -809,26 +914,55 @@ async function getOrCreateDynamicClientRegistration(
     clientSecretEncrypted:
       dcr.clientSecret && key ? encryptEnvironmentValue(key, dcr.clientSecret) : null,
     tokenEndpointAuthMethod: dcr.tokenEndpointAuthMethod,
-    metadata: registrationMetadata(as, scopes),
+    metadata: registrationMetadata(as, redirectUri, scopes),
   };
-  const storedWinner = await storeIntegrationOAuthClient(db, storeInput);
-  if (storedWinner.clientId !== dcr.clientId) {
-    const winner = await loadIntegrationOAuthClient(db, settings, as.issuer);
-    if (!winner) {
-      throw new HTTPException(422, {
-        message: "OAuth client registration could not be loaded after a registration race",
-      });
+  if (storedClient) {
+    const replaced = await replaceIntegrationOAuthClientIfCurrent(db, {
+      ...storeInput,
+      expectedClientId: storedClient.clientId,
+    });
+    if (replaced?.clientId === dcr.clientId) {
+      return dcr;
     }
+    return await loadCompatibleDcrWinner(db, settings, as, redirectUri, scopes);
+  }
+  const storedWinner = await storeIntegrationOAuthClient(db, storeInput);
+  if (storedWinner.clientId === dcr.clientId) {
+    return dcr;
+  }
+  const winner = await loadIntegrationOAuthClient(db, settings, as.issuer);
+  if (winner && storedDcrClientSatisfiesPolicy(winner, as, redirectUri, scopes)) {
     return dcrRegistrationFromStored(winner);
   }
-  return dcr;
+  if (winner) {
+    const replaced = await replaceIntegrationOAuthClientIfCurrent(db, {
+      ...storeInput,
+      expectedClientId: winner.clientId,
+    });
+    if (replaced?.clientId === dcr.clientId) {
+      return dcr;
+    }
+  }
+  return await loadCompatibleDcrWinner(db, settings, as, redirectUri, scopes);
 }
 
 function storedDcrClientSatisfiesPolicy(
-  stored: { metadata: Record<string, unknown> },
+  stored: {
+    authorizationServer: string;
+    metadata: Record<string, unknown>;
+  },
+  as: AuthorizationServerMetadata,
+  redirectUri: string,
   scopes: string[],
 ): boolean {
-  return registeredScopesMatch(stored.metadata, scopes);
+  return (
+    stored.authorizationServer === as.authorizationServer &&
+    stringValue(stored.metadata.registrationEndpoint) === as.registrationEndpoint &&
+    stringValue(stored.metadata.authorizationEndpoint) === as.authorizationEndpoint &&
+    stringValue(stored.metadata.tokenEndpoint) === as.tokenEndpoint &&
+    stringValue(stored.metadata.redirectUri) === redirectUri &&
+    registeredScopesMatch(stored.metadata, scopes)
+  );
 }
 
 function registeredScopesMatch(metadata: Record<string, unknown>, scopes: string[]): boolean {
@@ -841,13 +975,33 @@ function stableScopeKey(scopes: string[]): string {
 
 function registrationMetadata(
   as: AuthorizationServerMetadata,
+  redirectUri: string,
   scopes: string[],
 ): Record<string, unknown> {
   return {
     registrationEndpoint: as.registrationEndpoint,
+    authorizationEndpoint: as.authorizationEndpoint,
+    tokenEndpoint: as.tokenEndpoint,
+    redirectUri,
     registeredAt: new Date().toISOString(),
     registeredScopes: uniqueStrings(scopes),
   };
+}
+
+async function loadCompatibleDcrWinner(
+  db: Database,
+  settings: Settings,
+  as: AuthorizationServerMetadata,
+  redirectUri: string,
+  scopes: string[],
+): Promise<OAuthClientRegistration> {
+  const winner = await loadIntegrationOAuthClient(db, settings, as.issuer);
+  if (!winner || !storedDcrClientSatisfiesPolicy(winner, as, redirectUri, scopes)) {
+    throw new HTTPException(409, {
+      message: "OAuth client registration changed concurrently; start again",
+    });
+  }
+  return dcrRegistrationFromStored(winner);
 }
 
 function dcrRegistrationFromStored(stored: {
@@ -1228,6 +1382,7 @@ async function exchangeAuthorizationCode(
     resource: string;
     tokenEndpoint: string;
     client: OAuthClientRegistration;
+    signal: AbortSignal;
   },
 ): Promise<TokenResponse> {
   const body = new URLSearchParams();
@@ -1255,9 +1410,10 @@ async function exchangeAuthorizationCode(
     method: "POST",
     headers,
     body,
+    signal: input.signal,
   });
   if (!response.ok) {
-    const oauthError = await oauthErrorFromResponse(response);
+    const oauthError = await oauthErrorFromResponse(response, input.signal);
     throw new OAuthCallbackStageError(
       "token_exchange",
       oauthError ?? "token_exchange_failed",
@@ -1268,6 +1424,7 @@ async function exchangeAuthorizationCode(
     response,
     OAUTH_MAX_RESPONSE_BYTES,
     "OAuth token response",
+    { signal: input.signal },
   );
   const accessToken = stringValue(payload.access_token);
   if (!accessToken) {
@@ -1285,18 +1442,32 @@ async function exchangeAuthorizationCode(
   };
 }
 
-async function runCallbackStage<T>(
-  callbackStage: OAuthCallbackStage,
-  fallbackReason: string,
-  fn: () => Promise<T>,
+async function runCallbackDatabaseStage<T>(
+  deadline: OAuthCallbackDeadline,
+  stage: "state_verify" | "client_lookup" | "persist",
+  db: Database,
+  fn: (db: Database) => Promise<T>,
 ): Promise<T> {
-  try {
-    return await fn();
-  } catch (error) {
-    if (error instanceof OAuthCallbackStageError) {
-      throw error;
-    }
-    throw new OAuthCallbackStageError(callbackStage, fallbackReason, error);
+  return await deadline.run(stage, async (signal) => {
+    const statementTimeoutMs = Math.min(
+      OAUTH_CALLBACK_DB_STATEMENT_TIMEOUT_MS,
+      deadline.remainingMs(),
+    );
+    return await withDatabaseStatementTimeout(db, statementTimeoutMs, async (scopedDb) => {
+      throwIfCallbackAborted(signal, stage);
+      const result = await fn(scopedDb);
+      // If the application deadline won the race while Postgres was finishing,
+      // throw inside this outer transaction so the write is rolled back rather
+      // than committing after the browser has received a timeout redirect.
+      throwIfCallbackAborted(signal, stage);
+      return result;
+    });
+  });
+}
+
+function throwIfCallbackAborted(signal: AbortSignal, stage: OAuthCallbackStage): void {
+  if (signal.aborted) {
+    throw new RequestDeadlineError(stage);
   }
 }
 
@@ -1336,6 +1507,38 @@ function oauthStartFailureReason(error: unknown): string {
   if (error instanceof HTTPException) return `http_${error.status}`;
   if (error instanceof SyntaxError) return "invalid_response";
   return "request_failed";
+}
+
+function oauthCallbackFailureReason(stage: OAuthCallbackStage, error: unknown): string {
+  if (error instanceof RequestDeadlineError || isDatabaseStatementTimeout(error)) return "timeout";
+  switch (stage) {
+    case "state_verify":
+      return "state_invalid";
+    case "client_lookup":
+      return "client_lookup_failed";
+    case "token_exchange":
+      return "token_exchange_failed";
+    case "tools_list":
+      return "tools_list_failed";
+    case "persist":
+      return "persist_failed";
+  }
+}
+
+function isDatabaseStatementTimeout(error: unknown): boolean {
+  let current = error;
+  for (let depth = 0; depth < 4 && current && typeof current === "object"; depth += 1) {
+    const candidate = current as { code?: unknown; message?: unknown; cause?: unknown };
+    if (
+      candidate.code === "57014" ||
+      (typeof candidate.message === "string" &&
+        candidate.message.toLowerCase().includes("statement timeout"))
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
 }
 
 function oauthStartApiError(error: OAuthStartStageError): ApiHttpError {
@@ -1425,7 +1628,10 @@ function safeRequestedProviderDomain(payload: OAuthStartRequest): string | undef
   }
 }
 
-async function oauthErrorFromResponse(response: Response): Promise<string | null> {
+async function oauthErrorFromResponse(
+  response: Response,
+  signal?: AbortSignal,
+): Promise<string | null> {
   const contentType = response.headers.get("content-type") ?? "";
   if (!contentType.toLowerCase().includes("application/json")) {
     await cancelResponseBody(response);
@@ -1438,6 +1644,7 @@ async function oauthErrorFromResponse(response: Response): Promise<string | null
     response,
     OAUTH_MAX_RESPONSE_BYTES,
     "OAuth token error response",
+    { ...(signal ? { signal } : {}) },
   ).catch(() => null);
   const error = stringValue(payload?.error);
   if (!error || !/^[a-zA-Z0-9_.-]{1,80}$/.test(error)) {
@@ -1450,6 +1657,7 @@ async function verifyMcpToolsList(
   settings: Settings,
   resource: string,
   token: TokenResponse,
+  signal: AbortSignal,
 ): Promise<Array<{ name: string; description?: string }>> {
   const client = new Client(
     { name: "opengeni-integration-verify", version: "0.1.0" },
@@ -1462,7 +1670,11 @@ async function verifyMcpToolsList(
           authorization: `${normalizeBearerScheme(token.tokenType)} ${token.accessToken}`,
         },
       },
-      fetch: (url, init) => fetchOAuth(url.toString(), settings, init),
+      fetch: (url, init) =>
+        fetchOAuth(url.toString(), settings, {
+          ...init,
+          signal: init?.signal ? AbortSignal.any([signal, init.signal]) : signal,
+        }),
     });
     await client.connect(transport as unknown as Transport, {
       timeout: 10_000,
@@ -1486,6 +1698,7 @@ async function verifyMcpToolsListNonFatal(
   settings: Settings,
   state: OAuthStatePayload,
   token: TokenResponse,
+  deadline: OAuthCallbackDeadline,
 ): Promise<{
   metadata:
     | { status: "ok"; checkedAt: string; toolCount: number }
@@ -1493,8 +1706,8 @@ async function verifyMcpToolsListNonFatal(
   tools?: Array<{ name: string; description?: string }>;
 }> {
   try {
-    const tools = await runCallbackStage("tools_list", "tools_list_failed", () =>
-      verifyMcpToolsList(settings, state.mcpUrl, token),
+    const tools = await deadline.run("tools_list", (signal) =>
+      verifyMcpToolsList(settings, state.mcpUrl, token, signal),
     );
     return {
       metadata: {
@@ -1509,6 +1722,9 @@ async function verifyMcpToolsListNonFatal(
       error instanceof OAuthCallbackStageError
         ? error
         : new OAuthCallbackStageError("tools_list", "tools_list_failed", error);
+    if (staged.reason === "timeout" && deadline.signal.aborted) {
+      throw staged;
+    }
     logOAuthVerificationWarning(observability, staged, state);
     return {
       metadata: {

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -532,7 +532,7 @@ export function registerConnectionRoutes(app: Hono, deps: ApiRouteDeps): void {
   app.get("/v1/integrations/oauth/callback", async (c) => {
     assertIntegrationsEnabled();
     const result = await completeMcpOAuthCallback(
-      { db, settings, observability },
+      { db, settings, observability, oauthCallbackDeadlineMs: deps.oauthCallbackDeadlineMs },
       {
         code: c.req.query("code"),
         state: c.req.query("state"),

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -13,6 +13,7 @@ import {
   decryptEnvironmentValue,
   encryptEnvironmentValue,
   getConnectionMetadata,
+  loadIntegrationOAuthClient,
   loadConnectionCredentialForBroker,
   type DbClient,
 } from "@opengeni/db";
@@ -188,6 +189,7 @@ function startFakeAuthorizationServer(
     tokenAccessToken?: string | ((body: URLSearchParams) => string);
     tokenStatus?: number;
     tokenError?: string;
+    tokenResponseStalls?: boolean;
     onTokenRequest?: (body: URLSearchParams) => void | Promise<void>;
   } = {},
 ): FakeAuthorizationServer {
@@ -258,6 +260,16 @@ function startFakeAuthorizationServer(
               error_description: "fake token failure",
             },
             { status: options.tokenStatus },
+          );
+        }
+        if (options.tokenResponseStalls) {
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode('{"access_token":"partial'));
+              },
+            }),
+            { headers: { "content-type": "application/json" } },
           );
         }
         return Response.json({
@@ -1063,6 +1075,7 @@ describe("connections routes", () => {
       expect(callback.status).toBe(302);
       const location = callback.headers.get("location")!;
       expect(location).toContain("integration_oauth=error");
+      expect(location).toContain("stage=token_exchange");
       expect(location).toContain("reason=invalid_client");
       expect(location).toContain("connect_item=linear");
 
@@ -1076,6 +1089,60 @@ describe("connections routes", () => {
       });
       expect(JSON.stringify(errors)).not.toContain(verifier);
       expect(JSON.stringify(errors)).not.toContain("abc");
+    } finally {
+      mcp.close();
+      as.close();
+    }
+  });
+
+  test("oauth callback aborts a stalled token response and redirects with its exact stage", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const as = startFakeAuthorizationServer({
+      clientIdMetadataDocumentSupported: true,
+      tokenResponseStalls: true,
+    });
+    const mcp = startTestMcpServer({
+      requiredAuthorization: "Bearer mcp-access-token",
+      unauthorizedAuthenticateHeader: `Bearer resource_metadata="${as.url}/.well-known/oauth-protected-resource"`,
+    });
+    try {
+      const started = await app().request(
+        `/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`,
+        {
+          method: "POST",
+          headers: {
+            authorization: await bearer(workspace, "subject-a", ["connections:write"]),
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            providerDomain: "stalled-token.example.com",
+            mcpUrl: mcp.url,
+            returnPath: "/integrations?connect_item=stalled-token",
+          }),
+        },
+      );
+      const state = ((await started.json()) as { state: string }).state;
+      const startedAt = performance.now();
+      const callback = await publicAppWithDeps(
+        client.db,
+        {},
+        { oauthCallbackDeadlineMs: 500 },
+      ).request(`/v1/integrations/oauth/callback?code=abc&state=${encodeURIComponent(state)}`);
+      expect(callback.status).toBe(302);
+      expect(performance.now() - startedAt).toBeLessThan(2_000);
+      const location = callback.headers.get("location")!;
+      expect(location).toContain("integration_oauth=error");
+      expect(location).toContain("stage=token_exchange");
+      expect(location).toContain("reason=timeout");
+      expect(
+        await loadConnectionCredentialForBroker(client.db, settings, {
+          workspaceId: workspace.workspaceId,
+          providerDomain: "stalled-token.example.com",
+          kind: "oauth2",
+          allowSubjectOwned: false,
+        }),
+      ).toBeNull();
     } finally {
       mcp.close();
       as.close();
@@ -1624,6 +1691,81 @@ describe("connections routes", () => {
     } finally {
       mcp.close();
       as.close();
+    }
+  });
+
+  test("oauth start replaces a stale DCR client when provider endpoints change", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const issuer = "https://stable-issuer.example.test";
+    const firstAs = startFakeAuthorizationServer({
+      issuer,
+      clientIdMetadataDocumentSupported: false,
+      dcr: true,
+      scopesSupported: ["read"],
+    });
+    const firstMcp = startTestMcpServer({
+      requiredAuthorization: "Bearer mcp-access-token",
+      unauthorizedAuthenticateHeader: `Bearer resource_metadata="${firstAs.url}/.well-known/oauth-protected-resource", scope="read"`,
+    });
+    const secondAs = startFakeAuthorizationServer({
+      issuer,
+      clientIdMetadataDocumentSupported: false,
+      dcr: true,
+      scopesSupported: ["read"],
+    });
+    const secondMcp = startTestMcpServer({
+      requiredAuthorization: "Bearer mcp-access-token",
+      unauthorizedAuthenticateHeader: `Bearer resource_metadata="${secondAs.url}/.well-known/oauth-protected-resource", scope="read"`,
+    });
+    const start = async (mcpUrl: string) =>
+      await app().request(`/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`, {
+        method: "POST",
+        headers: {
+          authorization: await bearer(workspace, "subject-a", ["connections:write"]),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          providerDomain: "moving-provider.example.com",
+          mcpUrl,
+          returnPath: "/integrations?connect_item=moving-provider",
+        }),
+      });
+    try {
+      const first = await start(firstMcp.url);
+      expect(first.status).toBe(200);
+      expect(firstAs.registrations).toHaveLength(1);
+
+      const second = await start(secondMcp.url);
+      const secondText = await second.clone().text();
+      expect(second.status, secondText).toBe(200);
+      const secondBody = (await second.json()) as { state: string; authorizationUrl: string };
+      expect(secondAs.registrations).toHaveLength(1);
+      expect(new URL(secondBody.authorizationUrl).searchParams.get("client_id")).toBe(
+        `${secondAs.url}/registered-client/1`,
+      );
+
+      const stored = await loadIntegrationOAuthClient(
+        client.db,
+        settings,
+        new URL(issuer).toString(),
+      );
+      expect(stored).toMatchObject({
+        authorizationServer: secondAs.url,
+        clientId: `${secondAs.url}/registered-client/1`,
+        metadata: {
+          registrationEndpoint: `${secondAs.url}/register`,
+          authorizationEndpoint: `${secondAs.url}/authorize`,
+          tokenEndpoint: `${secondAs.url}/token`,
+          redirectUri: "https://api.opengeni.test/v1/integrations/oauth/callback",
+          registeredScopes: ["read"],
+        },
+      });
+    } finally {
+      firstMcp.close();
+      firstAs.close();
+      secondMcp.close();
+      secondAs.close();
     }
   });
 

--- a/apps/web/src/lib/mcp-oauth.test.ts
+++ b/apps/web/src/lib/mcp-oauth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { startMcpOAuthWithTimeout } from "./mcp-oauth";
+import { mcpOAuthCallbackFailureMessage, startMcpOAuthWithTimeout } from "./mcp-oauth";
 
 const request = {
   mcpUrl: "https://mcp.linear.app/mcp",
@@ -70,5 +70,23 @@ describe("startMcpOAuthWithTimeout", () => {
         50,
       ),
     ).rejects.toBe(failure);
+  });
+});
+
+describe("mcpOAuthCallbackFailureMessage", () => {
+  test("explains the exact timed-out stage without exposing raw provider text", () => {
+    expect(mcpOAuthCallbackFailureMessage("token_exchange", "timeout")).toBe(
+      "Connection timed out while finishing provider authorization. Try again.",
+    );
+  });
+
+  test("makes rollback-safe persistence failures explicit", () => {
+    expect(mcpOAuthCallbackFailureMessage("persist", "timeout")).toContain("Nothing was committed");
+  });
+
+  test("turns an invalid client response into administrator-actionable guidance", () => {
+    const message = mcpOAuthCallbackFailureMessage("token_exchange", "invalid_client");
+    expect(message).toContain("provider rejected the OAuth client registration");
+    expect(message).toContain("provider configuration needs attention");
   });
 });

--- a/apps/web/src/lib/mcp-oauth.ts
+++ b/apps/web/src/lib/mcp-oauth.ts
@@ -2,6 +2,14 @@ import type { OAuthStartRequest, OAuthStartResponse } from "@/types";
 
 export const MCP_OAUTH_START_TIMEOUT_MS = 20_000;
 
+const CALLBACK_STAGE_LABELS: Record<string, string> = {
+  state_verify: "validating the connection attempt",
+  client_lookup: "loading the OAuth client",
+  token_exchange: "finishing provider authorization",
+  tools_list: "verifying the MCP server",
+  persist: "saving the connection",
+};
+
 type OAuthStartClient = {
   startConnectionOAuth: (
     workspaceId: string,
@@ -37,4 +45,34 @@ export async function startMcpOAuthWithTimeout(
   } finally {
     clearTimeout(timeout);
   }
+}
+
+export function mcpOAuthCallbackFailureMessage(
+  stage: string | null,
+  reason: string | null,
+): string {
+  if (stage === "state_verify") {
+    return "This connection attempt expired or was already used. Try connecting again.";
+  }
+  if (stage === "client_lookup") {
+    return "The OAuth client registration changed while connecting. Try again.";
+  }
+  if (stage === "token_exchange" && reason === "invalid_client") {
+    return "The provider rejected the OAuth client registration. Try again; if it continues, the provider configuration needs attention.";
+  }
+  if (stage === "persist") {
+    return reason === "timeout"
+      ? "Authorization succeeded, but saving the connection timed out. Nothing was committed; try again."
+      : "Authorization succeeded, but OpenGeni couldn't save the connection. Try again.";
+  }
+  if (reason === "timeout") {
+    const label = stage ? CALLBACK_STAGE_LABELS[stage] : null;
+    return label
+      ? `Connection timed out while ${label}. Try again.`
+      : "Connection timed out. Try again.";
+  }
+  const label = stage ? CALLBACK_STAGE_LABELS[stage] : null;
+  return label
+    ? `Connection failed while ${label}. Try again.`
+    : "Couldn't connect. Please try again.";
 }

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -67,7 +67,7 @@ import {
   type SheetSelection,
 } from "@/lib/capabilities";
 import { listViewState } from "@/lib/load-state";
-import { startMcpOAuthWithTimeout } from "@/lib/mcp-oauth";
+import { mcpOAuthCallbackFailureMessage, startMcpOAuthWithTimeout } from "@/lib/mcp-oauth";
 import {
   personalSlackAccountState,
   personalSlackCapability,
@@ -753,14 +753,13 @@ export function CapabilitiesRoute({
       );
     } else {
       const reason = params.get("reason");
+      const message = mcpOAuthCallbackFailureMessage(params.get("stage"), reason);
       const item = itemId ? (items.find((candidate) => candidate.id === itemId) ?? null) : null;
       if (item) {
-        setSheetError(
-          reason ? `Couldn't connect: ${reason}.` : "Couldn't connect. Please try again.",
-        );
+        setSheetError(message);
         setSelected({ id: item.id, registry: false, snapshotFallback: false, snapshot: item });
       } else {
-        toast.error("Connection failed", { description: reason ?? undefined });
+        toast.error("Connection failed", { description: message });
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -119,6 +119,8 @@ export type AppDependencies = {
   googleDriveFetch?: typeof fetch;
   /** Injectable MCP OAuth setup deadline for deterministic stalled-provider tests. */
   oauthStartDeadlineMs?: number;
+  /** Injectable MCP OAuth callback deadline for deterministic stalled-provider tests. */
+  oauthCallbackDeadlineMs?: number;
   /** Optional host-owned voice-input transcription service. */
   transcription?: TranscriptionService | null;
   // The API process's OWN agent-loop-free sandbox client (constructed from

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1106,6 +1106,31 @@ export async function withRlsContext<T>(
   }, transactionConfig);
 }
 
+/**
+ * Run one bounded database operation on a transaction-pinned backend.
+ *
+ * Callers that also have an application deadline should check their abort
+ * signal before returning from `fn`; throwing there rolls the transaction back
+ * even when the application deadline won a surrounding Promise race.
+ */
+export async function withDatabaseStatementTimeout<T>(
+  db: Database,
+  timeoutMs: number,
+  fn: (db: Database) => Promise<T>,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error("withDatabaseStatementTimeout requires a positive timeout");
+  }
+  const boundedTimeoutMs = Math.max(1, Math.floor(timeoutMs));
+  return await db.transaction(async (tx) => {
+    const scoped = tx as unknown as Database;
+    await scoped.execute(
+      sql`select set_config('statement_timeout', ${`${boundedTimeoutMs}ms`}, true)`,
+    );
+    return await fn(scoped);
+  });
+}
+
 export async function rlsContextForWorkspace(
   db: Database,
   workspaceId: string,
@@ -3697,6 +3722,10 @@ export type StoreIntegrationOAuthClientInput = {
 };
 
 export type ReplaceIntegrationOAuthClientInput = StoreIntegrationOAuthClientInput;
+
+export type ReplaceIntegrationOAuthClientIfCurrentInput = ReplaceIntegrationOAuthClientInput & {
+  expectedClientId: string;
+};
 
 export type ConsumeOAuthStateNonceInput = {
   accountId: string;
@@ -7928,6 +7957,30 @@ export async function replaceIntegrationOAuthClient(
     throw new Error(`OAuth client registration replacement failed for issuer ${input.issuer}`);
   }
   return mapStoredIntegrationOAuthClient(row);
+}
+
+export async function replaceIntegrationOAuthClientIfCurrent(
+  db: Database,
+  input: ReplaceIntegrationOAuthClientIfCurrentInput,
+): Promise<StoredIntegrationOAuthClient | null> {
+  const [row] = await db
+    .update(schema.integrationOauthClients)
+    .set({
+      authorizationServer: input.authorizationServer,
+      clientId: input.clientId,
+      clientSecretEncrypted: input.clientSecretEncrypted ?? null,
+      tokenEndpointAuthMethod: input.tokenEndpointAuthMethod ?? "none",
+      metadata: input.metadata ?? {},
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(schema.integrationOauthClients.issuer, input.issuer),
+        eq(schema.integrationOauthClients.clientId, input.expectedClientId),
+      ),
+    )
+    .returning();
+  return row ? mapStoredIntegrationOAuthClient(row) : null;
 }
 
 function mapStoredIntegrationOAuthClient(

--- a/packages/db/test/connections.test.ts
+++ b/packages/db/test/connections.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { randomBytes } from "node:crypto";
 import { environmentsEncryptionKeyBytes, type Settings } from "@opengeni/config";
+import { sql } from "drizzle-orm";
 import {
   acquireSharedTestDatabase,
   testSettings,
@@ -29,10 +30,12 @@ import {
   recordConnectionTokenRefresh,
   recordConnectionUsed,
   refreshOAuthConnectionCredential,
+  replaceIntegrationOAuthClientIfCurrent,
   revokeConnection,
   setConnectionStatus,
   storeIntegrationOAuthClient,
   transitionConnectionState,
+  withDatabaseStatementTimeout,
   type ConnectionBrokerDeps,
   type ConnectionCredentialForBroker,
   type Database,
@@ -710,6 +713,53 @@ describe("connections table and helpers", () => {
       tokenEndpointAuthMethod: "client_secret_post",
       metadata: { registrationEndpoint: "https://as.example.com/register-1" },
     });
+  });
+
+  test("DCR OAuth client replacement is compare-and-swap on the current client", async () => {
+    if (!available) return;
+    const issuer = `https://issuer-${randomBytes(8).toString("hex")}.example.com`;
+    await storeIntegrationOAuthClient(db, {
+      issuer,
+      authorizationServer: issuer,
+      clientId: "client-1",
+      metadata: { registrationEndpoint: `${issuer}/register-1` },
+    });
+    expect(
+      await replaceIntegrationOAuthClientIfCurrent(db, {
+        issuer,
+        authorizationServer: issuer,
+        expectedClientId: "already-replaced",
+        clientId: "client-2",
+        metadata: { registrationEndpoint: `${issuer}/register-2` },
+      }),
+    ).toBeNull();
+    expect(
+      await replaceIntegrationOAuthClientIfCurrent(db, {
+        issuer,
+        authorizationServer: issuer,
+        expectedClientId: "client-1",
+        clientId: "client-2",
+        metadata: { registrationEndpoint: `${issuer}/register-2` },
+      }),
+    ).toMatchObject({
+      clientId: "client-2",
+      metadata: { registrationEndpoint: `${issuer}/register-2` },
+    });
+  });
+
+  test("database statement timeout cancels a stalled operation natively", async () => {
+    if (!available) return;
+    const startedAt = performance.now();
+    let caught: unknown;
+    try {
+      await withDatabaseStatementTimeout(db, 25, async (scopedDb) => {
+        await scopedDb.execute(sql`select pg_sleep(1)`);
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+    expect(caught).toMatchObject({ cause: { code: "57014" } });
   });
 
   test("OAuth state nonce consumption is single-use and TTL-cleaned per workspace", async () => {


### PR DESCRIPTION
## Summary

- bound MCP OAuth callback work across state validation, client lookup, token exchange, tool verification, and persistence
- use native PostgreSQL statement timeouts and rollback if the application deadline wins
- return safe callback stage/reason parameters and show concise actionable guidance in the capabilities UI
- replace incompatible dynamic client registrations with a compare-and-swap update keyed to the current client

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck` (23 projects)
- `bun test apps/web/src/lib/mcp-oauth.test.ts apps/api/test/connections-routes.test.ts packages/db/test/connections.test.ts` (73 passing locally; database-backed cases run in CI)

The change is provider-neutral and does not include deployment-specific configuration.