### PR TITLE
Add URL composer launch and fix composer autosize flicker

### DIFF
--- a/.changeset/calm-composer-launch.md
+++ b/.changeset/calm-composer-launch.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Measure composer textarea height off-DOM so multi-line typing no longer collapses the live box and yanks tip-follow.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,11 +29,12 @@ import {
   createRouter,
   lazyRouteComponent,
 } from "@tanstack/react-router";
-import { SessionRealtimeModel as SessionRealtimeModelSchema } from "@opengeni/contracts";
-import type { SessionRealtimeModel } from "@opengeni/sdk";
-
 import { ProblemPanel } from "@/components/common";
 import { RootRouteComponent, useAppContext } from "@/context";
+import {
+  parseComposerLaunchSearch,
+  type ComposerLaunchSearch,
+} from "@/lib/composer-launch";
 import { parseCheckoutOutcome, type CheckoutOutcome } from "@/lib/routes";
 
 export { workspaceAgentPath, workspaceSessionPath, workspaceSessionsPath } from "@/lib/routes";
@@ -168,15 +169,15 @@ const workspaceAgentRoute = createRoute({
 const workspaceSessionsRoute = createRoute({
   getParentRoute: () => workspaceRoute,
   path: "sessions",
+  validateSearch: (search: Record<string, unknown>): ComposerLaunchSearch =>
+    parseComposerLaunchSearch(search),
   component: SessionsIndex,
 });
 const workspaceSessionRoute = createRoute({
   getParentRoute: () => workspaceRoute,
   path: "sessions/$sessionId",
-  validateSearch: (search: Record<string, unknown>): { realtime?: SessionRealtimeModel } => {
-    const realtime = SessionRealtimeModelSchema.safeParse(search.realtime);
-    return realtime.success ? { realtime: realtime.data } : {};
-  },
+  validateSearch: (search: Record<string, unknown>): ComposerLaunchSearch =>
+    parseComposerLaunchSearch(search),
   component: SessionView,
 });
 const workspaceVariableSetsRoute = createRoute({
@@ -371,17 +372,19 @@ function WorkspaceShell() {
 
 function SessionsIndex() {
   const { workspaceId } = workspaceSessionsRoute.useParams();
-  return <LazySessionsIndexRoute workspaceId={workspaceId} />;
+  const launch = workspaceSessionsRoute.useSearch();
+  return <LazySessionsIndexRoute workspaceId={workspaceId} launch={launch} />;
 }
 
 function SessionView() {
   const { workspaceId, sessionId } = workspaceSessionRoute.useParams();
-  const { realtime } = workspaceSessionRoute.useSearch();
+  const launch = workspaceSessionRoute.useSearch();
   return (
     <LazySessionRoute
       workspaceId={workspaceId}
       sessionId={sessionId}
-      realtimeAutostartModel={realtime}
+      launch={launch}
+      realtimeAutostartModel={launch.realtime}
     />
   );
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -31,10 +31,7 @@ import {
 } from "@tanstack/react-router";
 import { ProblemPanel } from "@/components/common";
 import { RootRouteComponent, useAppContext } from "@/context";
-import {
-  parseComposerLaunchSearch,
-  type ComposerLaunchSearch,
-} from "@/lib/composer-launch";
+import { parseComposerLaunchSearch, type ComposerLaunchSearch } from "@/lib/composer-launch";
 import { parseCheckoutOutcome, type CheckoutOutcome } from "@/lib/routes";
 
 export { workspaceAgentPath, workspaceSessionPath, workspaceSessionsPath } from "@/lib/routes";

--- a/apps/web/src/lib/composer-launch.test.ts
+++ b/apps/web/src/lib/composer-launch.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  composerLaunchSearchAfterPolicyApply,
+  composerLaunchSearchKey,
+  parseComposerLaunchSearch,
+} from "./composer-launch";
+
+describe("parseComposerLaunchSearch", () => {
+  test("accepts model, effort, latency, and realtime", () => {
+    expect(
+      parseComposerLaunchSearch({
+        model: " codex/gpt-5.6-sol ",
+        effort: "xhigh",
+        latency: "fast",
+        realtime: "opengeni-gateway/openai/gpt-realtime-2.1",
+      }),
+    ).toEqual({
+      model: "codex/gpt-5.6-sol",
+      effort: "xhigh",
+      latency: "fast",
+      realtime: "opengeni-gateway/openai/gpt-realtime-2.1",
+    });
+  });
+
+  test("drops unknown or empty values", () => {
+    expect(
+      parseComposerLaunchSearch({
+        model: "   ",
+        effort: "ludicrous",
+        latency: "turbo",
+        realtime: "not-a-realtime-model",
+        other: "x",
+      }),
+    ).toEqual({});
+  });
+
+  test("key and leftover search helpers", () => {
+    const full = parseComposerLaunchSearch({
+      model: "gpt-5.6-sol",
+      effort: "low",
+      latency: "standard",
+      realtime: "gpt-live-1-boulder-alpha",
+    });
+    expect(composerLaunchSearchKey(full)).toContain("gpt-5.6-sol");
+    expect(composerLaunchSearchAfterPolicyApply(full)).toEqual({
+      realtime: "gpt-live-1-boulder-alpha",
+    });
+    expect(composerLaunchSearchAfterPolicyApply({ model: "gpt-5.6-sol" })).toEqual({});
+    expect(composerLaunchSearchKey({})).toBeNull();
+  });
+});

--- a/apps/web/src/lib/composer-launch.ts
+++ b/apps/web/src/lib/composer-launch.ts
@@ -14,9 +14,10 @@ export type ComposerLaunchSearch = {
   realtime?: SessionRealtimeModel;
 };
 
-export function parseComposerLaunchSearch(
-  search: Record<string, unknown>,
-): ComposerLaunchSearch {
+/** Stable empty search — safe default prop (no per-render object literal). */
+export const EMPTY_COMPOSER_LAUNCH: ComposerLaunchSearch = {};
+
+export function parseComposerLaunchSearch(search: Record<string, unknown>): ComposerLaunchSearch {
   const out: ComposerLaunchSearch = {};
   if (typeof search.model === "string") {
     const model = search.model.trim();

--- a/apps/web/src/lib/composer-launch.ts
+++ b/apps/web/src/lib/composer-launch.ts
@@ -1,0 +1,49 @@
+import {
+  LatencyMode,
+  ReasoningEffort,
+  SessionRealtimeModel as SessionRealtimeModelSchema,
+  type SessionRealtimeModel,
+} from "@opengeni/contracts";
+import type { LatencyMode as LatencyModeT, ReasoningEffort as ReasoningEffortT } from "@/types";
+
+/** Query-string composer / voice launch intent (session + sessions-index). */
+export type ComposerLaunchSearch = {
+  model?: string;
+  effort?: ReasoningEffortT;
+  latency?: LatencyModeT;
+  realtime?: SessionRealtimeModel;
+};
+
+export function parseComposerLaunchSearch(
+  search: Record<string, unknown>,
+): ComposerLaunchSearch {
+  const out: ComposerLaunchSearch = {};
+  if (typeof search.model === "string") {
+    const model = search.model.trim();
+    if (model.length > 0) out.model = model;
+  }
+  const effort = ReasoningEffort.safeParse(search.effort);
+  if (effort.success) out.effort = effort.data;
+  const latency = LatencyMode.safeParse(search.latency);
+  if (latency.success) out.latency = latency.data;
+  const realtime = SessionRealtimeModelSchema.safeParse(search.realtime);
+  if (realtime.success) out.realtime = realtime.data;
+  return out;
+}
+
+export function composerLaunchSearchKey(launch: ComposerLaunchSearch): string | null {
+  if (!launch.model && !launch.effort && !launch.latency && !launch.realtime) return null;
+  return JSON.stringify({
+    model: launch.model ?? null,
+    effort: launch.effort ?? null,
+    latency: launch.latency ?? null,
+    realtime: launch.realtime ?? null,
+  });
+}
+
+/** Keep only realtime after model/effort/latency have been applied locally. */
+export function composerLaunchSearchAfterPolicyApply(
+  launch: ComposerLaunchSearch,
+): ComposerLaunchSearch {
+  return launch.realtime ? { realtime: launch.realtime } : {};
+}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -52,6 +52,11 @@ import {
   projectSessionTimeline,
   summarizeSessionFailure,
 } from "@/lib/events";
+import {
+  composerLaunchSearchAfterPolicyApply,
+  composerLaunchSearchKey,
+  type ComposerLaunchSearch,
+} from "@/lib/composer-launch";
 import { coerceReasoningEffortForModel, findPickerRow } from "@/lib/model-policy";
 import { resolveSessionComposerModel } from "@/lib/session-model";
 import { mergeSessionContextProjection } from "@/lib/session-pins";
@@ -80,10 +85,12 @@ const LazyCodexRealtimeControl = lazy(() =>
 export function SessionRoute({
   workspaceId,
   sessionId,
+  launch = {},
   realtimeAutostartModel,
 }: {
   workspaceId: string;
   sessionId: string;
+  launch?: ComposerLaunchSearch;
   realtimeAutostartModel?: SessionRealtimeModel | undefined;
 }) {
   const context = useAppContext();
@@ -363,6 +370,7 @@ export function SessionRoute({
       events={events}
       timeline={timeline}
       initialLoading={initialLoading}
+      launch={launch}
       realtimeAutostartModel={realtimeAutostartModel}
       onRealtimeAutostartConsumed={consumeRealtimeAutostart}
       approvals={approvals}
@@ -509,6 +517,7 @@ function SessionChatPane(props: {
   events: SessionEvent[];
   timeline: TimelineItem[];
   initialLoading: boolean;
+  launch?: ComposerLaunchSearch;
   realtimeAutostartModel?: SessionRealtimeModel | undefined;
   onRealtimeAutostartConsumed: () => void;
   approvals: PendingApproval[];
@@ -666,9 +675,45 @@ function SessionChatPane(props: {
   useEffect(() => {
     pickerTouchedRef.current = false;
   }, [props.session.id]);
+  const navigate = useNavigate();
+  const launch = props.launch ?? {};
+  const launchKey = composerLaunchSearchKey(launch);
+  const appliedLaunchKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!launchKey || appliedLaunchKeyRef.current === launchKey) return;
+    const hasPolicy = Boolean(launch.model || launch.effort || launch.latency);
+    if (!hasPolicy) {
+      appliedLaunchKeyRef.current = launchKey;
+      return;
+    }
+    appliedLaunchKeyRef.current = launchKey;
+    pickerTouchedRef.current = true;
+    if (launch.model) setModelForSession(props.session.id, launch.model);
+    if (launch.effort) setEffortForSession(props.session.id, launch.effort);
+    if (launch.latency) setLatencyMode(launch.latency);
+    void navigate({
+      to: "/workspaces/$workspaceId/sessions/$sessionId",
+      params: { workspaceId: props.session.workspaceId, sessionId: props.session.id },
+      search: composerLaunchSearchAfterPolicyApply(launch),
+      replace: true,
+    });
+  }, [
+    launch,
+    launch.effort,
+    launch.latency,
+    launch.model,
+    launchKey,
+    navigate,
+    props.session.id,
+    props.session.workspaceId,
+    setEffortForSession,
+    setLatencyMode,
+    setModelForSession,
+  ]);
   // Seed once from durable session facts so open sessions never inherit the
   // mutable new-session composer picks. Draft apply / picker writes still win.
   useEffect(() => {
+    if (pickerTouchedRef.current) return;
     ensureModelForSession(props.session.id, props.session.model);
     const metaEffort = props.session.metadata.reasoningEffort;
     if (isIntelligenceEffort(metaEffort)) {
@@ -676,11 +721,9 @@ function SessionChatPane(props: {
     }
     // Seed latency from durable session metadata until the composer draft
     // applies (draft wins). Avoids flashing the global leftover/standard mode.
-    if (!pickerTouchedRef.current) {
-      const metaLatency = props.session.metadata.latencyMode;
-      if (metaLatency === "fast" || metaLatency === "priority" || metaLatency === "standard") {
-        setLatencyMode(metaLatency);
-      }
+    const metaLatency = props.session.metadata.latencyMode;
+    if (metaLatency === "fast" || metaLatency === "priority" || metaLatency === "standard") {
+      setLatencyMode(metaLatency);
     }
   }, [
     setLatencyMode,

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -53,6 +53,7 @@ import {
   summarizeSessionFailure,
 } from "@/lib/events";
 import {
+  EMPTY_COMPOSER_LAUNCH,
   composerLaunchSearchAfterPolicyApply,
   composerLaunchSearchKey,
   type ComposerLaunchSearch,
@@ -85,7 +86,7 @@ const LazyCodexRealtimeControl = lazy(() =>
 export function SessionRoute({
   workspaceId,
   sessionId,
-  launch = {},
+  launch = EMPTY_COMPOSER_LAUNCH,
   realtimeAutostartModel,
 }: {
   workspaceId: string;
@@ -676,32 +677,41 @@ function SessionChatPane(props: {
     pickerTouchedRef.current = false;
   }, [props.session.id]);
   const navigate = useNavigate();
-  const launch = props.launch ?? {};
+  const launch = props.launch ?? EMPTY_COMPOSER_LAUNCH;
+  const launchModel = launch.model;
+  const launchEffort = launch.effort;
+  const launchLatency = launch.latency;
+  const launchRealtime = launch.realtime;
   const launchKey = composerLaunchSearchKey(launch);
   const appliedLaunchKeyRef = useRef<string | null>(null);
   useEffect(() => {
     if (!launchKey || appliedLaunchKeyRef.current === launchKey) return;
-    const hasPolicy = Boolean(launch.model || launch.effort || launch.latency);
+    const hasPolicy = Boolean(launchModel || launchEffort || launchLatency);
     if (!hasPolicy) {
       appliedLaunchKeyRef.current = launchKey;
       return;
     }
     appliedLaunchKeyRef.current = launchKey;
     pickerTouchedRef.current = true;
-    if (launch.model) setModelForSession(props.session.id, launch.model);
-    if (launch.effort) setEffortForSession(props.session.id, launch.effort);
-    if (launch.latency) setLatencyMode(launch.latency);
+    if (launchModel) setModelForSession(props.session.id, launchModel);
+    if (launchEffort) setEffortForSession(props.session.id, launchEffort);
+    if (launchLatency) setLatencyMode(launchLatency);
     void navigate({
       to: "/workspaces/$workspaceId/sessions/$sessionId",
       params: { workspaceId: props.session.workspaceId, sessionId: props.session.id },
-      search: composerLaunchSearchAfterPolicyApply(launch),
+      search: composerLaunchSearchAfterPolicyApply({
+        model: launchModel,
+        effort: launchEffort,
+        latency: launchLatency,
+        realtime: launchRealtime,
+      }),
       replace: true,
     });
   }, [
-    launch,
-    launch.effort,
-    launch.latency,
-    launch.model,
+    launchEffort,
+    launchLatency,
+    launchModel,
+    launchRealtime,
     launchKey,
     navigate,
     props.session.id,

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -51,6 +51,10 @@ import { Notice } from "@/components/ui/notice";
 import { Select } from "@/components/ui/select";
 import { StatusDot, type StatusTone } from "@/components/ui/status-dot";
 import { useAppContext, useLatestCallback } from "@/context";
+import {
+  composerLaunchSearchKey,
+  type ComposerLaunchSearch,
+} from "@/lib/composer-launch";
 import { FOCUS_CREATE_COMPOSER_EVENT } from "@/lib/create-composer-focus";
 import type { RepoDraft } from "@/lib/session-tools";
 import { displayModel } from "@/lib/format";
@@ -91,17 +95,30 @@ import {
 } from "@/routes/sessions-index-submission";
 import type { Session } from "@/types";
 
-export function SessionsIndexRoute({ workspaceId }: { workspaceId: string }) {
+export function SessionsIndexRoute({
+  workspaceId,
+  launch = {},
+}: {
+  workspaceId: string;
+  launch?: ComposerLaunchSearch;
+}) {
   const { accessKeyVersion } = useAppContext();
   return (
     <SessionsIndexRouteContent
       key={`${workspaceId}:${accessKeyVersion}`}
       workspaceId={workspaceId}
+      launch={launch}
     />
   );
 }
 
-function SessionsIndexRouteContent({ workspaceId }: { workspaceId: string }) {
+function SessionsIndexRouteContent({
+  workspaceId,
+  launch,
+}: {
+  workspaceId: string;
+  launch: ComposerLaunchSearch;
+}) {
   const context = useAppContext();
   const navigate = useNavigate();
   const modelCatalog = useWorkspaceModelCatalog(workspaceId);
@@ -238,86 +255,190 @@ function SessionsIndexRouteContent({ workspaceId }: { workspaceId: string }) {
     textarea.focus();
   }, [createComposerFocusGen, newSessionDraft.loading]);
 
-  const submitNewSession = async (realtimeModel: SessionRealtimeModel | null): Promise<boolean> => {
-    const typedText = message.trim();
-    const text = typedText || (attachments.readyResources.length > 0 ? FILE_ONLY_MESSAGE_TEXT : "");
-    if (busy || newSessionDraft.loading || newSessionDraft.conflict) return false;
-    if (
-      createdSessionAuthority === null &&
-      ((!text && !realtimeModel) || attachments.hasUnresolved || !computeReady)
-    ) {
-      return false;
-    }
-    setSubmitting(true);
-    try {
-      return await runNewSessionRouteSubmission({
-        authority: createdSessionAuthority,
-        onAuthorityChange: setCreatedSessionAuthority,
-        create: async () => {
-          const submittedResources =
-            draft.compute.kind === "machine"
-              ? attachments.readyResources
-              : persistedValue.resources;
-          const flushed = await newSessionDraft.flush();
-          if (!flushed) return null;
-          const submission = submissionFromSessionDraft(draft);
-          const created = await context.startSession(
-            workspaceId,
-            {
-              text,
-              resources: submittedResources,
-              tools: persistedValue.tools,
-              model: persistedValue.model,
-              reasoningEffort: persistedValue.reasoningEffort,
-              latencyMode: persistedValue.latencyMode,
-              ...submission.extras,
-            },
-            {
-              targetSandboxId: submission.options.targetSandboxId,
-              workingDir: submission.options.workingDir,
-              omitWorkspaceResources: submission.omitWorkspaceResources,
-              expectedNewSessionDraftRevision: flushed.revision,
-              ...(realtimeModel && !typedText ? { startMode: "realtime" as const } : {}),
-            },
-          );
-          if (!created) return null;
-          return {
-            sessionId: created.id,
-            settleDraft: async () => {
-              const acknowledged = await newSessionDraft.acknowledgeConsumed(flushed);
-              if (acknowledged?.kind === "consumed") {
-                setMessage("");
-                setDraft(emptySessionDraft());
-                attachments.removeReadyFiles(
-                  submittedResources.flatMap((resource) =>
-                    resource.kind === "file" ? [resource.fileId] : [],
-                  ),
-                );
-              } else if (
-                !acknowledged ||
-                !newSessionDraft.isCurrentSignature(acknowledged.flushed.signature)
-              ) {
-                const preserved = await newSessionDraft.flush();
-                if (!preserved || !newSessionDraft.isCurrentSignature(preserved.signature)) {
-                  return false;
+  const submitNewSession = useLatestCallback(
+    async (
+      realtimeModel: SessionRealtimeModel | null,
+      policy?: Pick<ComposerLaunchSearch, "model" | "effort" | "latency">,
+    ): Promise<boolean> => {
+      const typedText = message.trim();
+      const text = typedText || (attachments.readyResources.length > 0 ? FILE_ONLY_MESSAGE_TEXT : "");
+      if (busy || newSessionDraft.loading || newSessionDraft.conflict) return false;
+      if (
+        createdSessionAuthority === null &&
+        ((!text && !realtimeModel) || attachments.hasUnresolved || !computeReady)
+      ) {
+        return false;
+      }
+      const model = policy?.model ?? persistedValue.model;
+      const reasoningEffort = policy?.effort ?? persistedValue.reasoningEffort;
+      const latencyMode = policy?.latency ?? persistedValue.latencyMode;
+      setSubmitting(true);
+      try {
+        return await runNewSessionRouteSubmission({
+          authority: createdSessionAuthority,
+          onAuthorityChange: setCreatedSessionAuthority,
+          create: async () => {
+            // Voice launch is realtime-only: never turn composer text/files into
+            // an initial message. Persist the draft so a pending autosave is not
+            // lost on navigate, but do not consume it — text stays for later.
+            if (realtimeModel) {
+              const flushed = await newSessionDraft.flush();
+              if (!flushed) return null;
+              const submission = submissionFromSessionDraft(draft);
+              const created = await context.startSession(
+                workspaceId,
+                {
+                  text: "",
+                  resources: [],
+                  tools: persistedValue.tools,
+                  model,
+                  reasoningEffort,
+                  latencyMode,
+                  ...submission.extras,
+                },
+                {
+                  targetSandboxId: submission.options.targetSandboxId,
+                  workingDir: submission.options.workingDir,
+                  omitWorkspaceResources: submission.omitWorkspaceResources,
+                  startMode: "realtime",
+                },
+              );
+              if (!created) return null;
+              return {
+                sessionId: created.id,
+                settleDraft: async () => true,
+              };
+            }
+
+            const submittedResources =
+              draft.compute.kind === "machine"
+                ? attachments.readyResources
+                : persistedValue.resources;
+            const flushed = await newSessionDraft.flush();
+            if (!flushed) return null;
+            const submission = submissionFromSessionDraft(draft);
+            const created = await context.startSession(
+              workspaceId,
+              {
+                text,
+                resources: submittedResources,
+                tools: persistedValue.tools,
+                model,
+                reasoningEffort,
+                latencyMode,
+                ...submission.extras,
+              },
+              {
+                targetSandboxId: submission.options.targetSandboxId,
+                workingDir: submission.options.workingDir,
+                omitWorkspaceResources: submission.omitWorkspaceResources,
+                expectedNewSessionDraftRevision: flushed.revision,
+              },
+            );
+            if (!created) return null;
+            return {
+              sessionId: created.id,
+              settleDraft: async () => {
+                const acknowledged = await newSessionDraft.acknowledgeConsumed(flushed);
+                if (acknowledged?.kind === "consumed") {
+                  setMessage("");
+                  setDraft(emptySessionDraft());
+                  attachments.removeReadyFiles(
+                    submittedResources.flatMap((resource) =>
+                      resource.kind === "file" ? [resource.fileId] : [],
+                    ),
+                  );
+                } else if (
+                  !acknowledged ||
+                  !newSessionDraft.isCurrentSignature(acknowledged.flushed.signature)
+                ) {
+                  const preserved = await newSessionDraft.flush();
+                  if (!preserved || !newSessionDraft.isCurrentSignature(preserved.signature)) {
+                    return false;
+                  }
                 }
-              }
-              return true;
-            },
-          };
-        },
-        navigate: async (sessionId) => {
-          await navigate({
-            to: "/workspaces/$workspaceId/sessions/$sessionId",
-            params: { workspaceId, sessionId },
-            search: realtimeModel ? { realtime: realtimeModel } : {},
-          });
-        },
+                return true;
+              },
+            };
+          },
+          navigate: async (sessionId) => {
+            const search: ComposerLaunchSearch = {
+              ...(model ? { model } : {}),
+              ...(reasoningEffort ? { effort: reasoningEffort } : {}),
+              ...(latencyMode ? { latency: latencyMode } : {}),
+              ...(realtimeModel ? { realtime: realtimeModel } : {}),
+            };
+            await navigate({
+              to: "/workspaces/$workspaceId/sessions/$sessionId",
+              params: { workspaceId, sessionId },
+              search,
+            });
+          },
+        });
+      } finally {
+        setSubmitting(false);
+      }
+    },
+  );
+
+  // URL launch: ?model=&effort=&latency= prefill the composer; +?realtime= also
+  // creates a realtime-first session and autostarts voice on the session page.
+  // Wait for the durable new-session draft so remote hydrate cannot stomp the
+  // URL policy after we apply it.
+  const launchKey = composerLaunchSearchKey(launch);
+  const handledLaunchKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!launchKey || handledLaunchKeyRef.current === launchKey) return;
+    if (newSessionDraft.loading || newSessionDraft.conflict !== null) return;
+    if (launch.model) setModel(launch.model);
+    if (launch.effort) setReasoningEffort(launch.effort);
+    if (launch.latency) setLatencyMode(launch.latency);
+    if (!launch.realtime) {
+      handledLaunchKeyRef.current = launchKey;
+      void navigate({
+        to: "/workspaces/$workspaceId/sessions",
+        params: { workspaceId },
+        search: {},
+        replace: true,
       });
-    } finally {
-      setSubmitting(false);
+      return;
     }
-  };
+    if (
+      busy ||
+      !computeReady ||
+      !context.workspaceMcpCatalogReady ||
+      attachments.hasUnresolved
+    ) {
+      return;
+    }
+    handledLaunchKeyRef.current = launchKey;
+    void submitNewSession(launch.realtime, {
+      model: launch.model,
+      effort: launch.effort,
+      latency: launch.latency,
+    }).then((ok) => {
+      if (!ok) handledLaunchKeyRef.current = null;
+    });
+  }, [
+    attachments.hasUnresolved,
+    busy,
+    computeReady,
+    context.workspaceMcpCatalogReady,
+    launch,
+    launch.effort,
+    launch.latency,
+    launch.model,
+    launch.realtime,
+    launchKey,
+    navigate,
+    newSessionDraft.conflict,
+    newSessionDraft.loading,
+    setLatencyMode,
+    setModel,
+    setReasoningEffort,
+    submitNewSession,
+    workspaceId,
+  ]);
 
   // The session does not exist yet, so this surface cannot use `useComposer`
   // (that hook sends to a session). It still renders the package ChatComposer

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -52,6 +52,7 @@ import { Select } from "@/components/ui/select";
 import { StatusDot, type StatusTone } from "@/components/ui/status-dot";
 import { useAppContext, useLatestCallback } from "@/context";
 import {
+  EMPTY_COMPOSER_LAUNCH,
   composerLaunchSearchKey,
   type ComposerLaunchSearch,
 } from "@/lib/composer-launch";
@@ -97,7 +98,7 @@ import type { Session } from "@/types";
 
 export function SessionsIndexRoute({
   workspaceId,
-  launch = {},
+  launch = EMPTY_COMPOSER_LAUNCH,
 }: {
   workspaceId: string;
   launch?: ComposerLaunchSearch;
@@ -261,7 +262,8 @@ function SessionsIndexRouteContent({
       policy?: Pick<ComposerLaunchSearch, "model" | "effort" | "latency">,
     ): Promise<boolean> => {
       const typedText = message.trim();
-      const text = typedText || (attachments.readyResources.length > 0 ? FILE_ONLY_MESSAGE_TEXT : "");
+      const text =
+        typedText || (attachments.readyResources.length > 0 ? FILE_ONLY_MESSAGE_TEXT : "");
       if (busy || newSessionDraft.loading || newSessionDraft.conflict) return false;
       if (
         createdSessionAuthority === null &&
@@ -385,15 +387,19 @@ function SessionsIndexRouteContent({
   // creates a realtime-first session and autostarts voice on the session page.
   // Wait for the durable new-session draft so remote hydrate cannot stomp the
   // URL policy after we apply it.
+  const launchModel = launch.model;
+  const launchEffort = launch.effort;
+  const launchLatency = launch.latency;
+  const launchRealtime = launch.realtime;
   const launchKey = composerLaunchSearchKey(launch);
   const handledLaunchKeyRef = useRef<string | null>(null);
   useEffect(() => {
     if (!launchKey || handledLaunchKeyRef.current === launchKey) return;
     if (newSessionDraft.loading || newSessionDraft.conflict !== null) return;
-    if (launch.model) setModel(launch.model);
-    if (launch.effort) setReasoningEffort(launch.effort);
-    if (launch.latency) setLatencyMode(launch.latency);
-    if (!launch.realtime) {
+    if (launchModel) setModel(launchModel);
+    if (launchEffort) setReasoningEffort(launchEffort);
+    if (launchLatency) setLatencyMode(launchLatency);
+    if (!launchRealtime) {
       handledLaunchKeyRef.current = launchKey;
       void navigate({
         to: "/workspaces/$workspaceId/sessions",
@@ -403,19 +409,14 @@ function SessionsIndexRouteContent({
       });
       return;
     }
-    if (
-      busy ||
-      !computeReady ||
-      !context.workspaceMcpCatalogReady ||
-      attachments.hasUnresolved
-    ) {
+    if (busy || !computeReady || !context.workspaceMcpCatalogReady || attachments.hasUnresolved) {
       return;
     }
     handledLaunchKeyRef.current = launchKey;
-    void submitNewSession(launch.realtime, {
-      model: launch.model,
-      effort: launch.effort,
-      latency: launch.latency,
+    void submitNewSession(launchRealtime, {
+      model: launchModel,
+      effort: launchEffort,
+      latency: launchLatency,
     }).then((ok) => {
       if (!ok) handledLaunchKeyRef.current = null;
     });
@@ -424,11 +425,10 @@ function SessionsIndexRouteContent({
     busy,
     computeReady,
     context.workspaceMcpCatalogReady,
-    launch,
-    launch.effort,
-    launch.latency,
-    launch.model,
-    launch.realtime,
+    launchEffort,
+    launchLatency,
+    launchModel,
+    launchRealtime,
     launchKey,
     navigate,
     newSessionDraft.conflict,

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -241,25 +241,86 @@ export type UseChatComposerControllerOptions = {
 };
 
 /**
- * Autosize a composer textarea up to `maxPx` without the classic height→0
- * measure collapse (that flash expands the timeline flex sibling and yanks
- * tip-follow while a stream is pinned).
+ * Off-document mirror for shrink/steady measure. Measuring with
+ * `height: auto` on the live `rows={1}` textarea collapses it for a layout
+ * frame, expands the flex timeline sibling, and yanks tip-follow — the
+ * multi-line typing flicker that stops only once the box is capped.
+ */
+let composerHeightMirror: HTMLTextAreaElement | null = null;
+
+function measureComposerContentHeight(textarea: HTMLTextAreaElement): number {
+  if (typeof document === "undefined") {
+    return textarea.scrollHeight;
+  }
+  const width = textarea.clientWidth;
+  if (width <= 0) {
+    return textarea.offsetHeight;
+  }
+
+  let mirror = composerHeightMirror;
+  if (!mirror) {
+    mirror = document.createElement("textarea");
+    mirror.setAttribute("aria-hidden", "true");
+    mirror.tabIndex = -1;
+    mirror.rows = 1;
+    mirror.style.cssText =
+      "position:absolute;top:0;left:0;visibility:hidden;pointer-events:none;height:auto;min-height:0;max-height:none;overflow:hidden;z-index:-1;";
+    composerHeightMirror = mirror;
+  }
+
+  const style = getComputedStyle(textarea);
+  mirror.style.width = `${width}px`;
+  mirror.style.boxSizing = style.boxSizing;
+  mirror.style.font = style.font;
+  mirror.style.fontSize = style.fontSize;
+  mirror.style.fontFamily = style.fontFamily;
+  mirror.style.fontWeight = style.fontWeight;
+  mirror.style.fontStyle = style.fontStyle;
+  mirror.style.letterSpacing = style.letterSpacing;
+  mirror.style.lineHeight = style.lineHeight;
+  mirror.style.textTransform = style.textTransform;
+  mirror.style.paddingTop = style.paddingTop;
+  mirror.style.paddingRight = style.paddingRight;
+  mirror.style.paddingBottom = style.paddingBottom;
+  mirror.style.paddingLeft = style.paddingLeft;
+  mirror.style.borderTopWidth = style.borderTopWidth;
+  mirror.style.borderRightWidth = style.borderRightWidth;
+  mirror.style.borderBottomWidth = style.borderBottomWidth;
+  mirror.style.borderLeftWidth = style.borderLeftWidth;
+  mirror.style.borderStyle = style.borderStyle;
+  mirror.style.whiteSpace = style.whiteSpace;
+  mirror.style.wordBreak = style.wordBreak;
+  mirror.style.overflowWrap = style.overflowWrap;
+  mirror.value = textarea.value;
+
+  if (!mirror.isConnected) {
+    document.documentElement.appendChild(mirror);
+  }
+  return mirror.scrollHeight;
+}
+
+/**
+ * Autosize a composer textarea up to `maxPx`. Never writes intermediate
+ * `height: auto` / `0` on the live element — only the final pixel height.
+ *
+ * `measure` is injectable for unit tests; production always uses the off-DOM
+ * mirror so shrink/steady never collapses the laid-out box.
  */
 export function applyComposerTextareaHeight(
   textarea: HTMLTextAreaElement,
   maxPx: number = 220,
+  measure: (el: HTMLTextAreaElement) => number = measureComposerContentHeight,
 ): void {
-  // Grow path: content already overflows — raise height, no measure collapse.
-  if (textarea.scrollHeight > textarea.clientHeight + 1) {
-    textarea.style.height = `${Math.min(textarea.scrollHeight, maxPx)}px`;
-    return;
-  }
-  // Shrink / steady: `auto` measures natural height without flashing empty.
   const before = textarea.offsetHeight;
-  textarea.style.height = "auto";
-  const nextPx = Math.min(textarea.scrollHeight, maxPx);
+  // Overflow: content taller than the box — scrollHeight is the needed size.
+  // Fit/shrink: content fits (or box is oversized) — measure off-DOM.
+  const nextPx = Math.min(
+    textarea.scrollHeight > textarea.clientHeight + 1
+      ? textarea.scrollHeight
+      : measure(textarea),
+    maxPx,
+  );
   if (Math.abs(nextPx - before) < 1) {
-    textarea.style.height = `${before}px`;
     return;
   }
   textarea.style.height = `${nextPx}px`;

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -315,9 +315,7 @@ export function applyComposerTextareaHeight(
   // Overflow: content taller than the box — scrollHeight is the needed size.
   // Fit/shrink: content fits (or box is oversized) — measure off-DOM.
   const nextPx = Math.min(
-    textarea.scrollHeight > textarea.clientHeight + 1
-      ? textarea.scrollHeight
-      : measure(textarea),
+    textarea.scrollHeight > textarea.clientHeight + 1 ? textarea.scrollHeight : measure(textarea),
     maxPx,
   );
   if (Math.abs(nextPx - before) < 1) {

--- a/packages/react/test/composer-autosize.test.ts
+++ b/packages/react/test/composer-autosize.test.ts
@@ -4,40 +4,47 @@ import { registerDom } from "./render-hook";
 
 registerDom();
 
+function trackHeightWrites(el: HTMLTextAreaElement): string[] {
+  const writes: string[] = [];
+  const desc = Object.getOwnPropertyDescriptor(CSSStyleDeclaration.prototype, "height");
+  Object.defineProperty(el.style, "height", {
+    configurable: true,
+    get() {
+      return desc?.get?.call(this) ?? "";
+    },
+    set(value: string) {
+      writes.push(value);
+      desc?.set?.call(this, value);
+    },
+  });
+  return writes;
+}
+
 describe("applyComposerTextareaHeight", () => {
-  test("grows from overflow without writing height 0", () => {
+  test("grows from overflow without writing height auto or 0", () => {
     const el = document.createElement("textarea");
     Object.defineProperty(el, "clientHeight", { configurable: true, get: () => 40 });
     Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => 96 });
     Object.defineProperty(el, "offsetHeight", { configurable: true, get: () => 40 });
     el.style.height = "40px";
-
-    const writes: string[] = [];
-    const desc = Object.getOwnPropertyDescriptor(CSSStyleDeclaration.prototype, "height");
-    Object.defineProperty(el.style, "height", {
-      configurable: true,
-      get() {
-        return desc?.get?.call(this) ?? "";
-      },
-      set(value: string) {
-        writes.push(value);
-        desc?.set?.call(this, value);
-      },
-    });
+    const writes = trackHeightWrites(el);
 
     applyComposerTextareaHeight(el, 220);
+    expect(writes).not.toContain("auto");
     expect(writes).not.toContain("0px");
-    expect(writes.at(-1)).toBe("96px");
+    expect(writes).toEqual(["96px"]);
   });
 
-  test("restores prior height when auto measure matches", () => {
+  test("steady fit does not rewrite height", () => {
     const el = document.createElement("textarea");
     Object.defineProperty(el, "clientHeight", { configurable: true, get: () => 40 });
     Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => 40 });
     Object.defineProperty(el, "offsetHeight", { configurable: true, get: () => 40 });
     el.style.height = "40px";
+    const writes = trackHeightWrites(el);
 
-    applyComposerTextareaHeight(el, 220);
+    applyComposerTextareaHeight(el, 220, () => 40);
+    expect(writes).toEqual([]);
     expect(el.style.height).toBe("40px");
   });
 
@@ -49,5 +56,19 @@ describe("applyComposerTextareaHeight", () => {
 
     applyComposerTextareaHeight(el, 220);
     expect(el.style.height).toBe("220px");
+  });
+
+  test("shrink writes only the final height — never auto or 0", () => {
+    const el = document.createElement("textarea");
+    Object.defineProperty(el, "clientHeight", { configurable: true, get: () => 200 });
+    Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => 200 });
+    Object.defineProperty(el, "offsetHeight", { configurable: true, get: () => 200 });
+    el.style.height = "200px";
+    const writes = trackHeightWrites(el);
+
+    applyComposerTextareaHeight(el, 220, () => 48);
+    expect(writes).toEqual(["48px"]);
+    expect(writes).not.toContain("auto");
+    expect(writes).not.toContain("0px");
   });
 });


### PR DESCRIPTION
## Summary
- Add Shortcuts-friendly query launch (`?model=&effort=&latency=&realtime=`) on sessions index and session routes: prefill policy, realtime-first create without sending draft text, autostart voice, then clear consumed search params.
- Keep voice creates realtime-only (flush draft without consuming it; no initial message / composer files).
- Fix multi-line composer height flicker by measuring off-DOM so the live textarea never collapses via `height: auto` and yanks tip-follow.

## Test plan
- [ ] Open `/workspaces/:ws/sessions?model=<id>&effort=high&latency=fast` — composer prefills, URL clears, draft hydrate does not stomp
- [ ] Open same URL with `&realtime=<SessionRealtimeModel>` — creates realtime-first session and autostarts voice; composer text is not sent
- [ ] Existing session `/sessions/:id?model=...&realtime=...` — applies policy, strips to realtime, autostarts, clears search after start
- [ ] Type multi-line text under composer max height — timeline should not flicker; at max height still stable
- [ ] `bun test apps/web/src/lib/composer-launch.test.ts packages/react/test/composer-autosize.test.ts`


Made with [Cursor](https://cursor.com)