### PR TITLE
Fix realtime voice control semantics

### DIFF
--- a/.changeset/calm-voices-group.md
+++ b/.changeset/calm-voices-group.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Give the realtime voice controls an accessible named group role.

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -629,6 +629,7 @@ export function RealtimeVoiceControl(props: {
 
   return (
     <div
+      role="group"
       aria-label="Realtime voice"
       data-picker-side={props.menuSide ?? "top"}
       className="inline-flex shrink-0 items-center"

--- a/packages/react/test/realtime-control.test.tsx
+++ b/packages/react/test/realtime-control.test.tsx
@@ -201,7 +201,7 @@ describe("ordinary session Codex realtime control", () => {
         />,
       );
     });
-    const region = container.querySelector('[aria-label="Realtime voice"]');
+    const region = container.querySelector('[role="group"][aria-label="Realtime voice"]');
     const start = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Start voice with Codex Live"]',
     );
@@ -446,7 +446,9 @@ describe("ordinary session Codex realtime control", () => {
     });
 
     expect(
-      container.querySelector('[aria-label="Realtime voice"]')?.getAttribute("data-picker-side"),
+      container
+        .querySelector('[role="group"][aria-label="Realtime voice"]')
+        ?.getAttribute("data-picker-side"),
     ).toBe("bottom");
   });
 


### PR DESCRIPTION
## Summary
- give the labelled realtime voice control container an explicit group role
- keep the existing compact control behavior and model picker unchanged
- cover the semantic selector in the realtime control tests

## Verification
- `bun test packages/react/test/realtime-control.test.tsx`
- `bun run --cwd packages/react typecheck`
- `bun run lint`
- focused formatting check