### PR TITLE
chore(release): bump product version to 0.22.64

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.63
-appVersion: "0.22.63"
+version: 0.22.64
+appVersion: "0.22.64"


### PR DESCRIPTION
## Summary

- bump the OpenGeni Helm chart and application version from `0.22.63` to `0.22.64`
- bind the release train to exact package-bearing main source `a532e2ba55d1e3e92fed936ad6eb72e33205ce46`

## Validation

- `helm lint deploy/helm/opengeni`
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml` → `0.22.64`
- `git diff --check`