### PR TITLE
Explain missing social OAuth apps

### DIFF
--- a/.changeset/calm-social-errors.md
+++ b/.changeset/calm-social-errors.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Return actionable operator configuration guidance when social OAuth credentials are missing.

--- a/apps/api/src/integrations/social-oauth.ts
+++ b/apps/api/src/integrations/social-oauth.ts
@@ -22,6 +22,7 @@ import { OAUTH_MAX_RESPONSE_BYTES, pinnedFetch, readResponseJsonBounded } from "
 import { Buffer } from "node:buffer";
 import { createHash, randomBytes } from "node:crypto";
 import { HTTPException } from "hono/http-exception";
+import { ApiHttpError } from "../http/api-error";
 import {
   integrationBaseUrl,
   oauthStateTtlMs,
@@ -154,8 +155,12 @@ export function socialOAuthClientFor(
 ): { clientId: string; clientSecret?: string | undefined } {
   const configured = parseSocialOauthClientsJson(settings.socialOauthClientsJson)[provider];
   if (!configured) {
-    throw new HTTPException(503, {
-      message: `social provider ${provider} requires an operator OAuth app in OPENGENI_SOCIAL_OAUTH_CLIENTS_JSON`,
+    const providerLabel = provider === "x" ? "X" : "Reddit";
+    throw new ApiHttpError(503, {
+      code: "upstream_unavailable",
+      message: `${providerLabel} connection is not configured. An operator must add ${providerLabel} OAuth credentials to OPENGENI_SOCIAL_OAUTH_CLIENTS_JSON.`,
+      retryable: false,
+      details: { oauthReason: "operator_oauth_app_missing", provider },
     });
   }
   return configured;

--- a/apps/api/test/social-oauth.test.ts
+++ b/apps/api/test/social-oauth.test.ts
@@ -5,6 +5,7 @@ import type { Database } from "@opengeni/db";
 import { readSignedState } from "@opengeni/github";
 import { testSettings } from "@opengeni/testing";
 import { HTTPException } from "hono/http-exception";
+import { ApiHttpError } from "../src/http/api-error";
 import {
   parseSocialCredentialBundle,
   SocialTokenRequestError,
@@ -93,14 +94,21 @@ describe("startSocialOAuth", () => {
     );
   });
 
-  test("unconfigured provider fails with 503, not a broken redirect", async () => {
+  test("unconfigured provider returns actionable operator configuration details", async () => {
     const settings = settingsWithClients({ x: { clientId: "x-client" } });
-    await expect(
-      startSocialOAuth(
-        { db: noDb, settings },
-        { ...startContext, payload: { provider: "reddit" } },
-      ),
-    ).rejects.toThrow(HTTPException);
+    const error = await startSocialOAuth(
+      { db: noDb, settings },
+      { ...startContext, payload: { provider: "reddit" } },
+    ).catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(ApiHttpError);
+    expect(error).toMatchObject({
+      status: 503,
+      code: "upstream_unavailable",
+      retryable: false,
+      message:
+        "Reddit connection is not configured. An operator must add Reddit OAuth credentials to OPENGENI_SOCIAL_OAUTH_CLIENTS_JSON.",
+      details: { oauthReason: "operator_oauth_app_missing", provider: "reddit" },
+    });
   });
 
   test("absolute returnPath is rejected", async () => {


### PR DESCRIPTION
## Summary
- return a safe structured error when X or Reddit OAuth operator credentials are absent
- mark the configuration failure non-retryable instead of telling users to retry
- include bounded provider and reason details for UI and diagnostics

## Verification
- focused social OAuth tests: 13 passed
- API typecheck passed
- targeted lint passed with zero warnings
- repository formatter check passed