### PR TITLE
perf(ci): install only headless Chromium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install pinned Playwright Chromium runtime
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install --with-deps --only-shell chromium
 
       - name: Codex quota Codex quota and entitlement browser acceptance
         env:

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2818,6 +2818,23 @@ describe("workflow contracts", () => {
     expect(safetyStep.run).toBe("bun run test:unit");
 
     const browser = ci.jobs["browser-acceptance"];
+    const browserInstall = browser.steps.find(
+      (step: any) => step.name === "Install pinned Playwright Chromium runtime",
+    );
+    expect(browserInstall).toEqual({
+      name: "Install pinned Playwright Chromium runtime",
+      run: "bunx playwright install --with-deps --only-shell chromium",
+    });
+    expect(
+      browser.steps.filter((step: any) => String(step.run ?? "").includes("playwright install")),
+    ).toEqual([browserInstall]);
+    expect(
+      browser.steps.some(
+        (step: any) =>
+          String(step.uses ?? "").startsWith("actions/cache@") &&
+          JSON.stringify(step.with ?? {}).includes("ms-playwright"),
+      ),
+    ).toBe(false);
     expect(
       browser.steps.find(
         (step: any) => step.name === "Codex quota Codex quota and entitlement browser acceptance",


### PR DESCRIPTION
## Summary

- install only Playwright's pinned Chromium headless shell in the browser acceptance lane
- retain Playwright's exact `--with-deps` OS dependency installation and Chromium revision
- preserve every browser, visual, accessibility, mobile, PostgreSQL/RLS, and artifact gate unchanged
- add a workflow contract that pins the exact install command and prevents an implicit Playwright cache path

## Diagnosis and measured effect

Thirty recent successful natural runs showed Playwright installation at 23.5s median and 31s p95, with one 619s outlier. The outlier was an Ubuntu font-package mirror transfer (21.1 MiB in 9m56s), not a browser download, so a large browser cache would not repair it and would have restore cost near the normal download time.

An isolated Playwright 1.61.1 / Chromium revision 1228 comparison measured:

- full Chromium install: 11.62s, 674,463,925 installed bytes, 281,719,279 gzip-comparable bytes
- headless shell: 5.98s, 278,121,757 installed bytes, 110,878,291 gzip-comparable bytes
- reduction: 5.64s (48.5%), 396,342,168 installed bytes (58.8%), and 170,840,988 compressed bytes (60.6%)

The exact new `--with-deps --only-shell chromium` path completed in 17.07s including OS dependencies, and a real Chromium launch/mobile-page smoke completed in 0.74s.

## Validation

- workflow and release-image contracts: 75 tests, 738 assertions
- realtime, queue, and workbench browser suites with only the headless shell: 23 tests, 6,903 assertions
- TS7 typecheck: 23 projects
- lint and format
- generated-font, workspace/billing, docs-reference, public-hygiene, and release-schema guards
- package build, publish closure, clean packed consumer, runtime embedding consumer, and ogtool package proofs
- `git diff --check`

The remaining exact CI run is authoritative for the real PostgreSQL-backed Codex quota, session-pin, and knowledge-surface gates. This change does not alter their commands, dependencies, or artifact requirements.
