### PR TITLE
feat(web): add privacy-safe product analytics

### DIFF
--- a/apps/web/src/components/analytics-consent.tsx
+++ b/apps/web/src/components/analytics-consent.tsx
@@ -18,11 +18,15 @@ export function AnalyticsManager({
   hasSearchParameters,
   isPublicAuthRoute,
   pathname,
+  analyticsAccountId,
+  analyticsUserId,
 }: {
   config: ClientConfig["analytics"];
   hasSearchParameters: boolean;
   isPublicAuthRoute: boolean;
   pathname: string;
+  analyticsAccountId: string | null;
+  analyticsUserId: string | null;
 }) {
   const [choice, setChoice] = useState<AnalyticsConsent | null>(() => storedAnalyticsConsent());
   const [editing, setEditing] = useState(choice === null);
@@ -41,6 +45,14 @@ export function AnalyticsManager({
       cancelled = true;
     };
   }, [config, hasSearchParameters, isPublicAuthRoute, pathname]);
+
+  useEffect(() => {
+    void import("@/lib/analytics").then(({ syncAnalyticsIdentity }) => {
+      syncAnalyticsIdentity(
+        analyticsUserId ? { userId: analyticsUserId, accountId: analyticsAccountId } : null,
+      );
+    });
+  }, [analyticsAccountId, analyticsUserId]);
 
   useEffect(() => {
     const open = () => {
@@ -73,8 +85,9 @@ export function AnalyticsManager({
       <p className="text-sm font-medium text-fg">Help us improve OpenGeni</p>
       <p className="mt-1 text-sm text-fg-muted">
         We use optional performance analytics, including first-party cookies, to understand
-        adoption. Copy tracking is disabled; we do not send prompts, source code, repository
-        content, tool arguments, or secrets.
+        adoption. When you sign in, consented events use internal user and account IDs. Copy
+        tracking is disabled; we do not send names, email addresses, prompts, source code,
+        repository content, tool arguments, or secrets.
       </p>
       <div className="mt-3 flex justify-end gap-2">
         {choice !== null ? (

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -39,6 +39,7 @@ import { LoadingPanel, ProblemPanel } from "@/components/common";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import type { AnalyticsEventName, AnalyticsProperties } from "@/lib/analytics";
 import { sameSessionForContext } from "@/lib/session-context";
 import { runSingleFlight } from "@/lib/single-flight";
 import {
@@ -90,6 +91,15 @@ const AnalyticsManager = lazy(() =>
     default: module.AnalyticsManager,
   })),
 );
+
+function captureProductAnalyticsEvent(
+  name: AnalyticsEventName,
+  properties: AnalyticsProperties = {},
+): void {
+  void import("@/lib/analytics").then(({ captureAnalyticsEvent }) => {
+    captureAnalyticsEvent(name, properties);
+  });
+}
 
 export type AppContextValue = {
   client: OpenGeniCoreClient;
@@ -480,6 +490,11 @@ export function RootRouteComponent() {
       return null;
     }
     setWorkspaces((current) => upsertWorkspace(current, created));
+    captureProductAnalyticsEvent("workspace_created", {
+      $insert_id: `workspace_created:${created.id}`,
+      account_id: created.accountId,
+      workspace_id: created.id,
+    });
     // Refresh grants so the new workspace's owner permissions apply at once;
     // the workspace itself is already usable if this refresh fails — surface a
     // soft warning so a stale permission set doesn't fail silently.
@@ -835,6 +850,14 @@ export function RootRouteComponent() {
       }
       setSession(created);
       setConnectionState("idle");
+      captureProductAnalyticsEvent("session_started", {
+        $insert_id: `session_started:${created.id}`,
+        account_id: created.accountId,
+        workspace_id: created.workspaceId,
+        session_id: created.id,
+        ...(attempt.request.model ? { model: attempt.request.model } : {}),
+        start_mode: options?.startMode ?? "standard",
+      });
       return created;
     } catch (error) {
       // Keep the attempt on failure. An exact retry dedups against a create that
@@ -957,6 +980,10 @@ export function RootRouteComponent() {
   ) {
     if (mode === "signup") {
       await signUpEmail(input);
+      captureProductAnalyticsEvent("signup_submitted", {
+        method: "email",
+        verification_required: true,
+      });
     } else {
       await signInEmail({
         email: input.email,
@@ -1206,6 +1233,8 @@ export function RootRouteComponent() {
       {clientConfig ? (
         <Suspense fallback={null}>
           <AnalyticsManager
+            analyticsAccountId={accessContext?.defaultAccountId ?? null}
+            analyticsUserId={authSession?.user.id ?? null}
             config={clientConfig.analytics}
             hasSearchParameters={hasSearchParameters}
             isPublicAuthRoute={isPublicAuthRoute}

--- a/apps/web/src/lib/analytics.test.ts
+++ b/apps/web/src/lib/analytics.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
-import { applyAnalyticsConsent, syncAnalytics } from "./analytics";
+import {
+  applyAnalyticsConsent,
+  captureAnalyticsEvent,
+  syncAnalytics,
+  syncAnalyticsIdentity,
+} from "./analytics";
 import {
   analyticsHasProviders,
   analyticsPreferencesAvailable,
@@ -180,6 +185,74 @@ describe("analytics providers", () => {
       persistAnalyticsConsent("denied", fakeWindow.localStorage);
       applyAnalyticsConsent("denied");
       expect(unloadCalls).toBe(1);
+    } finally {
+      restoreGlobal("window", originalWindow);
+      restoreGlobal("document", originalDocument);
+    }
+  });
+
+  test("identifies only by internal IDs and delivers lifecycle events after PostHog loads", async () => {
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+    const calls: Array<[string, ...unknown[]]> = [];
+    const posthog = {
+      capture: (...args: unknown[]) => calls.push(["capture", ...args]),
+      group: (...args: unknown[]) => calls.push(["group", ...args]),
+      identify: (...args: unknown[]) => calls.push(["identify", ...args]),
+      init: (...args: unknown[]) => calls.push(["init", ...args]),
+      opt_in_capturing: () => calls.push(["opt_in_capturing"]),
+      opt_out_capturing: () => calls.push(["opt_out_capturing"]),
+      reset: () => calls.push(["reset"]),
+    };
+    mock.module("posthog-js", () => ({ default: posthog }));
+    const fakeWindow = {
+      localStorage: {
+        getItem: () => "granted",
+        setItem: () => undefined,
+      },
+      location: { origin: "https://app.opengeni.ai" },
+    };
+
+    Object.defineProperty(globalThis, "window", { configurable: true, value: fakeWindow });
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: {
+        getElementById: () => null,
+        createElement: () => ({ id: "", async: false, src: "" }),
+        head: { append: () => undefined },
+      },
+    });
+
+    try {
+      syncAnalytics(
+        {
+          consentRequired: true,
+          providers: {
+            posthog: { projectKey: "phc_test", host: "https://eu.i.posthog.com" },
+          },
+        },
+        "/workspaces",
+      );
+      syncAnalyticsIdentity({ userId: "user-1", accountId: "account-1" });
+      captureAnalyticsEvent("workspace_created", { workspace_id: "workspace-1" });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(calls).toContainEqual(["identify", "user-1"]);
+      expect(calls).toContainEqual(["group", "account", "account-1"]);
+      expect(calls).toContainEqual([
+        "capture",
+        "$pageview",
+        { $current_url: "https://app.opengeni.ai/workspaces" },
+      ]);
+      expect(calls).toContainEqual([
+        "capture",
+        "workspace_created",
+        { workspace_id: "workspace-1" },
+      ]);
+
+      syncAnalyticsIdentity(null);
+      expect(calls).toContainEqual(["reset"]);
+      applyAnalyticsConsent("denied");
     } finally {
       restoreGlobal("window", originalWindow);
       restoreGlobal("document", originalDocument);

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -2,17 +2,15 @@ import { analyticsHasProviders, storedAnalyticsConsent } from "@/lib/analytics-c
 import type { AnalyticsConsent } from "@/lib/analytics-consent";
 import type { ClientConfig } from "@/types";
 
-export type AnalyticsEventName =
-  | "signed_up"
-  | "workspace_created"
-  | "integration_connected"
-  | "session_started"
-  | "session_completed"
-  | "subscription_started";
+export type AnalyticsEventName = "signup_submitted" | "workspace_created" | "session_started";
 
 type AnalyticsConfig = ClientConfig["analytics"];
-type AnalyticsProperty = boolean | number | string;
-type AnalyticsProperties = Record<string, AnalyticsProperty>;
+export type AnalyticsProperty = boolean | number | string;
+export type AnalyticsProperties = Record<string, AnalyticsProperty>;
+export type AnalyticsIdentity = Readonly<{
+  userId: string;
+  accountId: string | null;
+}>;
 type PostHogClient = typeof import("posthog-js").default;
 type ReoClient = {
   init: (config: { clientID: string; dnt: string[] }) => void;
@@ -30,6 +28,9 @@ let providersReady = false;
 let posthogClient: PostHogClient | null = null;
 let ga4MeasurementId: string | null = null;
 let latestPathname: string | null = null;
+let activeIdentity: AnalyticsIdentity | null = null;
+let identifiedUserId: string | null = null;
+let identifiedAccountId: string | null = null;
 let suspended = false;
 
 declare global {
@@ -49,6 +50,7 @@ export function syncAnalytics(config: AnalyticsConfig, pathname: string): void {
   }
   if (initialization) {
     if (providersReady) {
+      applyActiveIdentity();
       dispatchPageView(pathname);
     }
     return;
@@ -67,19 +69,33 @@ export function applyAnalyticsConsent(consent: AnalyticsConsent): void {
     return;
   }
   if (consent === "denied") {
+    resetProviderIdentity(true);
     stopProviders();
   }
+}
+
+/**
+ * Associates consented analytics with stable internal IDs only. Names, email
+ * addresses, prompts, repository content, and other customer data stay out of
+ * the analytics boundary. Calling this is harmless when analytics is disabled.
+ */
+export function syncAnalyticsIdentity(identity: AnalyticsIdentity | null): void {
+  activeIdentity = identity;
+  if (!identity) {
+    resetProviderIdentity();
+    return;
+  }
+  runWhenProvidersReady(applyActiveIdentity);
 }
 
 export function captureAnalyticsEvent(
   name: AnalyticsEventName,
   properties: AnalyticsProperties = {},
 ): void {
-  if (!analyticsCollectionAllowed()) {
-    return;
-  }
-  posthogClient?.capture(name, properties);
-  window.gtag?.("event", name, properties);
+  runWhenProvidersReady(() => {
+    posthogClient?.capture(name, properties);
+    window.gtag?.("event", name, properties);
+  });
 }
 
 async function initializeProviders(config: AnalyticsConfig): Promise<void> {
@@ -96,10 +112,22 @@ async function initializeProviders(config: AnalyticsConfig): Promise<void> {
   ]).then(() => {
     if (generation === initializationGeneration && latestPathname && analyticsCollectionAllowed()) {
       providersReady = true;
+      applyActiveIdentity();
       dispatchPageView(latestPathname);
     }
   });
   await initialization;
+}
+
+function runWhenProvidersReady(callback: () => void): void {
+  if (!analyticsCollectionAllowed() || !activeConfig) {
+    return;
+  }
+  void initializeProviders(activeConfig).then(() => {
+    if (analyticsCollectionAllowed()) {
+      callback();
+    }
+  });
 }
 
 function analyticsCollectionAllowed(): boolean {
@@ -111,7 +139,9 @@ function analyticsCollectionAllowed(): boolean {
 }
 
 function dispatchPageView(pathname: string): void {
-  posthogClient?.capture("$pageview", { $current_url: pathname });
+  posthogClient?.capture("$pageview", {
+    $current_url: `${window.location.origin}${pathname}`,
+  });
   if (ga4MeasurementId) {
     window.gtag?.("event", "page_view", {
       page_location: `${window.location.origin}${pathname}`,
@@ -161,6 +191,32 @@ async function initializePostHog(projectKey: string, host: string): Promise<void
     person_profiles: "identified_only",
   });
   posthogClient = posthog;
+}
+
+function applyActiveIdentity(): void {
+  if (!activeIdentity || !posthogClient || !analyticsCollectionAllowed()) {
+    return;
+  }
+  if (identifiedUserId !== activeIdentity.userId) {
+    if (identifiedUserId) {
+      posthogClient.reset();
+    }
+    posthogClient.identify(activeIdentity.userId);
+    identifiedUserId = activeIdentity.userId;
+    identifiedAccountId = null;
+  }
+  if (activeIdentity.accountId && identifiedAccountId !== activeIdentity.accountId) {
+    posthogClient.group("account", activeIdentity.accountId);
+    identifiedAccountId = activeIdentity.accountId;
+  }
+}
+
+function resetProviderIdentity(force = false): void {
+  if (force || identifiedUserId) {
+    posthogClient?.reset();
+  }
+  identifiedUserId = null;
+  identifiedAccountId = null;
 }
 
 async function initializeGa4(measurementId: string): Promise<void> {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -621,14 +621,16 @@ Self-hosted deployments therefore emit no analytics unless their operator
 explicitly enables and configures it. OpenGeni's explicit route tracking sends
 pathnames only and suspends providers on public-auth or query-bearing routes.
 The Reo adapter initializes with clipboard/code-copy and supported AI-widget
-capture disabled. It does not send authenticated identity: adding an identify
-call requires a separate privacy review and explicit consent copy. First visit
-shows a consent sheet; after that, visitors reopen preferences from the Account
-menu (no persistent floating chrome) and can withdraw consent. Provider cleanup
-must run without breaking the console even when browser storage or a third-party
-script fails. The event surface must never carry prompts, source code, repository
-content, tool arguments, logs, secrets, or document contents. Provider selection
-belongs to validated runtime configuration, never arbitrary script injection.
+capture disabled. The PostHog adapter may identify a consenting, authenticated
+visitor by stable internal user ID and group them by stable internal account ID;
+it never sends names or email addresses. First visit shows a consent sheet;
+after that, visitors reopen preferences from the Account menu (no persistent
+floating chrome) and can withdraw consent. Provider cleanup must run without
+breaking the console even when browser storage or a third-party script fails.
+The event surface must never carry names, email addresses, prompts, source code,
+repository content, tool arguments, logs, secrets, or document contents.
+Provider selection belongs to validated runtime configuration, never arbitrary
+script injection.
 
 Watch-outs: `/clear-view` is local/this-device-only; stale-bundle auto-reload on revision mismatch; the stock repository picker is GitHub-oriented even though session resources and credential bindings support multiple providers and accounts.
 


### PR DESCRIPTION
## Summary

- identify consenting managed users with internal user and account IDs only
- capture signup submission, workspace creation, and session start lifecycle events
- preserve optional/default-off self-hosted analytics and lazy provider loading
- document and test the no-PII/no-content boundary

## Testing

- [x] bun test apps/web/src/lib/analytics.test.ts
- [x] bun run --cwd apps/web typecheck
- [x] bun run lint
- [x] bun run --cwd apps/web build

## Notes

- PostHog autocapture and session replay remain disabled.
- Events are queued while the consented provider loads.