### PR TITLE
fix: navigate virtualized workbench files in acceptance

### DIFF
--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -105,6 +105,7 @@ describe("workbench live acceptance preflight", () => {
       getByRole: () => ({ first: () => directoryButton }),
     };
     const fileItem = {
+      isVisible: async () => true,
       getByRole: () => fileButton,
     };
     const page = {
@@ -121,6 +122,56 @@ describe("workbench live acceptance preflight", () => {
     await selectTreeFile(page, "api", "base.txt");
 
     expect(clicks).toEqual(["file"]);
+  });
+
+  test("selects an off-screen virtualized file through the tree keyboard contract", async () => {
+    const presses: string[] = [];
+    let active = 0;
+    const rows = ["api", "base.txt", "notes.txt", "server.ts"];
+    const directoryItem = {
+      getAttribute: async () => "true",
+      getByRole: () => ({ first: () => ({ click: async () => {} }) }),
+    };
+    const fileItem = {
+      isVisible: async () => false,
+    };
+    const tree = {
+      focus: async () => {},
+      press: async (key: string) => {
+        presses.push(key);
+        if (key === "Home") active = 0;
+        if (key === "ArrowDown") active = Math.min(active + 1, rows.length - 1);
+      },
+      getAttribute: async (name: string) => {
+        expect(name).toBe("aria-activedescendant");
+        return `tree-item-${active}`;
+      },
+    };
+    const page = {
+      getByRole(role: string) {
+        if (role === "tree") return { first: () => tree };
+        expect(role).toBe("treeitem");
+        return {
+          filter({ hasText }: { hasText: string }) {
+            return { first: () => (hasText === "api" ? directoryItem : fileItem) };
+          },
+        };
+      },
+      locator(selector: string) {
+        const index = Number(selector.match(/tree-item-(\d+)/)?.[1]);
+        return {
+          waitFor: async () => {},
+          getByText(text: string, options: { exact: boolean }) {
+            expect(options).toEqual({ exact: true });
+            return { count: async () => (rows[index] === text ? 1 : 0) };
+          },
+        };
+      },
+    } as never;
+
+    await selectTreeFile(page, "api", "server.ts");
+
+    expect(presses).toEqual(["Home", "ArrowDown", "ArrowDown", "ArrowDown", "Enter"]);
   });
 
   test("accepts repository evidence from the compact changed-file picker", async () => {

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -2100,7 +2100,33 @@ export async function selectTreeFile(page: Page, directory: string, file: string
   if ((await directoryItem.getAttribute("aria-expanded")) !== "true") {
     await directoryButton.click();
   }
-  await page.getByRole("treeitem").filter({ hasText: file }).first().getByRole("button").click();
+
+  // The Files tree is virtualized: an expanded directory can truthfully contain
+  // a file whose row is not mounted until keyboard navigation scrolls it into
+  // view. Prefer the direct click when the row is already visible, then exercise
+  // the tree's public composite-keyboard contract instead of assuming every
+  // logical row permanently exists in the DOM.
+  const fileItem = page.getByRole("treeitem").filter({ hasText: file }).first();
+  if (await fileItem.isVisible()) {
+    await fileItem.getByRole("button").click();
+    return;
+  }
+
+  const tree = page.getByRole("tree").first();
+  await tree.focus();
+  await tree.press("Home");
+  for (let index = 0; index < 4_096; index += 1) {
+    const activeId = await tree.getAttribute("aria-activedescendant");
+    if (!activeId) throw new Error("file tree has no active descendant");
+    const activeItem = page.locator(`[id=${JSON.stringify(activeId)}]`);
+    await activeItem.waitFor({ state: "visible", timeout: 2_000 });
+    if ((await activeItem.getByText(file, { exact: true }).count()) > 0) {
+      await tree.press("Enter");
+      return;
+    }
+    await tree.press("ArrowDown");
+  }
+  throw new Error(`file tree did not expose ${directory}/${file}`);
 }
 
 async function assertColdReview(page: Page, marker: string): Promise<void> {


### PR DESCRIPTION
## Summary
- select already-mounted Files rows directly
- fall back to the public composite-tree keyboard contract for virtualized off-screen rows
- cover the off-screen selection path with a focused regression test

## Verification
- `bun test scripts/workbench-live-acceptance.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`

This is a generic OpenGeni acceptance fix and contains no deployment- or integration-specific information.