### PR TITLE
chore(release): bump product version to 0.22.65

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.64
-appVersion: "0.22.64"
+version: 0.22.65
+appVersion: "0.22.65"


### PR DESCRIPTION
## Summary

- bump the OpenGeni Helm chart and application version from `0.22.64` to `0.22.65`
- bind the release train to exact package-bearing main source `ece8a39c64f0a86200315dacc0948350a70ebe72`
- include latest non-package main source `392029b22322a953a1448d66030eb2aec92ff659`

## Validation

- `helm lint deploy/helm/opengeni`
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml` → `0.22.65`
- `git diff --check`
