### PR TITLE
fix(react): stale draft OCC recovery + tool_search timeline card

### DIFF
--- a/.changeset/soft-draft-wake.md
+++ b/.changeset/soft-draft-wake.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Recover stale composer-draft OCC after tab sleep by recognizing DRAFT_CHANGED, soft-reloading on wake, and retrying autosave with the server revision while keeping local text.

--- a/.changeset/tool-search-renderer.md
+++ b/.changeset/tool-search-renderer.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Give progressive `tool_search` its own timeline card: capability query, disclosed tool leaves with source prefixes, and quiet no-match / failure states instead of the generic Done dump.

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -585,6 +585,22 @@ export function useComposer(
     }
     void loadDraft(false);
   }, [durableDrafts, loadDraft, sessionId]);
+  // After long background / sleep the in-memory revision is often stale while
+  // a prior autosave already advanced the server. Soft-reload on wake so the
+  // next keystroke does not OCC against a dead revision.
+  useEffect(() => {
+    if (!sessionId || !durableDrafts) return;
+    const onWake = () => {
+      if (typeof document !== "undefined" && document.visibilityState === "hidden") return;
+      void loadDraft(false);
+    };
+    document.addEventListener("visibilitychange", onWake);
+    window.addEventListener("pageshow", onWake);
+    return () => {
+      document.removeEventListener("visibilitychange", onWake);
+      window.removeEventListener("pageshow", onWake);
+    };
+  }, [durableDrafts, loadDraft, sessionId]);
   useEffect(() => {
     if (!sessionId || !durableDrafts) return;
     return registerSessionReconciler(sessionId, "composer", async () => await loadDraft(false));
@@ -692,7 +708,16 @@ export function useComposer(
         }
         setDraftSaving(true);
         try {
-          const saved = await client.saveComposerDraft(workspaceId, sessionId, request);
+          const saved = await saveComposerDraftWithStaleRetry({
+            client,
+            workspaceId,
+            sessionId,
+            request,
+            onAdoptRemote: (remote) => {
+              draftRef.current = remote;
+              setDraft(remote);
+            },
+          });
           if (
             targetKeyRef.current !== ownedTargetKey ||
             targetGeneration.current !== ownedGeneration
@@ -701,8 +726,12 @@ export function useComposer(
           }
           draftRef.current = saved;
           setDraft(saved);
-          lastSavedSignature.current = signature;
+          lastSavedSignature.current = draftSignature({
+            ...request,
+            expectedRevision: saved.revision,
+          });
           setDraftConflict(null);
+          setError(null);
           success = true;
         } catch (cause) {
           if (
@@ -1260,11 +1289,13 @@ export function useComposer(
       }
       if (choice === "use_remote") {
         applyDraft(remote);
+        setError(null);
         return;
       }
       draftRef.current = remote;
       setDraft(remote);
       setDraftConflict(null);
+      setError(null);
       const payload = currentDraftPayload();
       if (payload) await persistPayload({ ...payload, expectedRevision: remote.revision });
     },
@@ -1393,13 +1424,52 @@ function asError(cause: unknown): Error {
 
 function isDraftConflictError(error: Error): boolean {
   const apiError = error as Partial<OpenGeniApiError>;
-  return (
-    apiError.status === 409 &&
-    apiError.outcomeUnknown === false &&
-    (apiError.code === undefined ||
-      apiError.code === "conflict" ||
-      apiError.code === "idempotency_conflict")
-  );
+  if (apiError.status !== 409 || apiError.outcomeUnknown === true) return false;
+  // Production queue OCC returns `DRAFT_CHANGED`. Older/SDK-shaped 409s may
+  // omit code or use the generic conflict labels — all are recoverable OCC.
+  const code = apiError.code;
+  if (
+    code === undefined ||
+    code === "DRAFT_CHANGED" ||
+    code === "conflict" ||
+    code === "idempotency_conflict"
+  ) {
+    return true;
+  }
+  return /draft changed/i.test(error.message);
+}
+
+/**
+ * One OCC retry: adopt the server revision and rewrite the same local content.
+ * Covers the common "tab slept through a successful autosave" case without
+ * stranding the operator on a raw 409 toast.
+ */
+async function saveComposerDraftWithStaleRetry(input: {
+  client: {
+    getComposerDraft: (workspaceId: string, sessionId: string) => Promise<ComposerDraft>;
+    saveComposerDraft: (
+      workspaceId: string,
+      sessionId: string,
+      request: SaveComposerDraftRequest,
+    ) => Promise<ComposerDraft>;
+  };
+  workspaceId: string;
+  sessionId: string;
+  request: SaveComposerDraftRequest;
+  onAdoptRemote: (remote: ComposerDraft) => void;
+}): Promise<ComposerDraft> {
+  try {
+    return await input.client.saveComposerDraft(input.workspaceId, input.sessionId, input.request);
+  } catch (cause) {
+    const problem = asError(cause);
+    if (!isDraftConflictError(problem)) throw problem;
+    const remote = await input.client.getComposerDraft(input.workspaceId, input.sessionId);
+    input.onAdoptRemote(remote);
+    return await input.client.saveComposerDraft(input.workspaceId, input.sessionId, {
+      ...input.request,
+      expectedRevision: remote.revision,
+    });
+  }
 }
 
 function draftPayload(draft: ComposerDraft): SaveComposerDraftRequest {

--- a/packages/react/src/timeline/tool-renderers.tsx
+++ b/packages/react/src/timeline/tool-renderers.tsx
@@ -1099,7 +1099,11 @@ function parseDisclosedTools(output: unknown): DisclosedTool[] | null {
           if (typeof tool === "string" && tool.trim()) {
             return splitToolWireName(tool.trim());
           }
-          if (tool && typeof tool === "object" && typeof (tool as { name?: unknown }).name === "string") {
+          if (
+            tool &&
+            typeof tool === "object" &&
+            typeof (tool as { name?: unknown }).name === "string"
+          ) {
             const name = (tool as { name: string }).name.trim();
             return name ? splitToolWireName(name) : null;
           }

--- a/packages/react/src/timeline/tool-renderers.tsx
+++ b/packages/react/src/timeline/tool-renderers.tsx
@@ -17,6 +17,7 @@ import {
   MessagesSquareIcon,
   MessageSquareIcon,
   MousePointer2Icon,
+  PackageSearchIcon,
   PanelsTopLeftIcon,
   PlugIcon,
   SearchIcon,
@@ -1033,6 +1034,200 @@ function SecretSetRenderer({ item }: ToolRendererProps) {
   );
 }
 
+/* ---- tool_search (progressive MCP disclosure) ------------------------------ */
+
+type DisclosedTool = {
+  /** Full wire name (`server__leaf` or bare). */
+  name: string;
+  /** Server / namespace prefix before `__`, when present. */
+  source: string | null;
+  /** Leaf tool name after `__`. */
+  leaf: string;
+};
+
+function splitToolWireName(name: string): DisclosedTool {
+  const boundary = name.indexOf("__");
+  if (boundary <= 0) {
+    return { name, source: null, leaf: name };
+  }
+  return {
+    name,
+    source: name.slice(0, boundary),
+    leaf: name.slice(boundary + 2),
+  };
+}
+
+/** Capability query from live tool_search args (object or JSON string). */
+function toolSearchQuery(item: ToolRendererProps["item"]): string {
+  const fromArgs = parseToolArgs(item.arguments);
+  if (typeof fromArgs.query === "string" && fromArgs.query.trim()) {
+    return fromArgs.query.trim();
+  }
+  const raw = item.raw;
+  if (raw && typeof raw === "object") {
+    const rawArgs = (raw as { arguments?: unknown }).arguments;
+    if (typeof rawArgs === "string" && rawArgs.trim()) {
+      const parsed = tryParseJson(rawArgs);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const query = (parsed as { query?: unknown }).query;
+        if (typeof query === "string" && query.trim()) {
+          return query.trim();
+        }
+      }
+    } else if (rawArgs && typeof rawArgs === "object" && !Array.isArray(rawArgs)) {
+      const query = (rawArgs as { query?: unknown }).query;
+      if (typeof query === "string" && query.trim()) {
+        return query.trim();
+      }
+    }
+  }
+  return "";
+}
+
+/**
+ * Parse disclosed tools from the runtime event shape.
+ * `normalizeSdkEvent` collapses `tool_search_output.tools[]` into text:
+ *   "Disclosed tools: a, b" | "No matching tools found."
+ * Also accept a structured `tools` array when a host/enricher preserves it.
+ */
+function parseDisclosedTools(output: unknown): DisclosedTool[] | null {
+  if (output && typeof output === "object" && !Array.isArray(output)) {
+    const tools = (output as { tools?: unknown }).tools;
+    if (Array.isArray(tools)) {
+      return tools
+        .map((tool) => {
+          if (typeof tool === "string" && tool.trim()) {
+            return splitToolWireName(tool.trim());
+          }
+          if (tool && typeof tool === "object" && typeof (tool as { name?: unknown }).name === "string") {
+            const name = (tool as { name: string }).name.trim();
+            return name ? splitToolWireName(name) : null;
+          }
+          return null;
+        })
+        .filter((tool): tool is DisclosedTool => tool != null);
+    }
+  }
+
+  const { text } = unwrapMcpOutput(output);
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^no matching tools found\.?$/i.test(trimmed)) {
+    return [];
+  }
+  const disclosed = trimmed.match(/^disclosed tools:\s*(.+)$/i);
+  if (disclosed?.[1]) {
+    return disclosed[1]
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map(splitToolWireName);
+  }
+  const parsed = tryParseJson(trimmed);
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return parseDisclosedTools(parsed);
+  }
+  return null;
+}
+
+function toolSearchPreview(tools: DisclosedTool[] | null, cancelled: boolean): string | undefined {
+  if (cancelled) {
+    return undefined;
+  }
+  if (!tools) {
+    return "Done";
+  }
+  if (tools.length === 0) {
+    return "No matches";
+  }
+  if (tools.length === 1) {
+    return tools[0]!.leaf;
+  }
+  const head = tools[0]!.leaf;
+  return `${tools.length} tools · ${truncatePreview(head, 28)}`;
+}
+
+function ToolSearchRenderer({ item }: ToolRendererProps) {
+  const query = toolSearchQuery(item);
+  const icon = <PackageSearchIcon className={ICON_SIZE} />;
+  const running = item.status === "running";
+  const queryPreview = query ? truncatePreview(query, 64) : "";
+
+  if (running) {
+    return (
+      <ActivityDisclosure
+        icon={icon}
+        iconTone="running"
+        title="Looking up tools"
+        running
+        preview={
+          queryPreview ? (
+            <RunningPreview>{queryPreview}</RunningPreview>
+          ) : (
+            <RunningPreview>Matching capabilities…</RunningPreview>
+          )
+        }
+      >
+        {query ? <BodyNote>capability query: {query}</BodyNote> : null}
+        <PayloadBlock label="Arguments" value={redactSecrets(parseToolArgs(item.arguments))} />
+      </ActivityDisclosure>
+    );
+  }
+
+  const { text: outText, isError } = unwrapMcpOutput(item.output);
+  if ((isError || item.status === "failed") && item.status !== "cancelled") {
+    return (
+      <ActivityDisclosure
+        icon={icon}
+        iconTone="failed"
+        title="Tool lookup failed"
+        failed
+        preview={truncatePreview(outText, 80) || queryPreview || "Lookup failed"}
+      >
+        {query ? <BodyNote>capability query: {query}</BodyNote> : null}
+        <PayloadBlock label="Arguments" value={redactSecrets(parseToolArgs(item.arguments))} />
+        <PayloadBlock label="Error" value={outText} failed />
+      </ActivityDisclosure>
+    );
+  }
+
+  const tools = parseDisclosedTools(item.output);
+  const preview = toolSearchPreview(tools, item.status === "cancelled");
+
+  return (
+    <ActivityDisclosure
+      icon={icon}
+      iconTone="muted"
+      title="Looked up tools"
+      cancelled={item.status === "cancelled"}
+      preview={preview}
+    >
+      {query ? <BodyNote>capability query: {query}</BodyNote> : null}
+      {tools && tools.length > 0 ? (
+        <ul className="grid gap-1.5">
+          {tools.slice(0, 12).map((tool) => (
+            <li key={tool.name} className="flex min-w-0 items-baseline gap-2">
+              {tool.source ? (
+                <span className="shrink-0 text-og-xs text-og-fg-subtle">{tool.source}</span>
+              ) : null}
+              <span className="truncate font-mono text-og-sm text-og-fg">{tool.leaf}</span>
+            </li>
+          ))}
+          {tools.length > 12 ? (
+            <li className="text-og-xs text-og-fg-muted">+{tools.length - 12} more</li>
+          ) : null}
+        </ul>
+      ) : tools && tools.length === 0 ? (
+        <BodyNote>no deferred tools matched this capability query.</BodyNote>
+      ) : null}
+      <PayloadBlock label="Arguments" value={redactSecrets(parseToolArgs(item.arguments))} />
+      {tools == null && outText ? <PayloadBlock label="Result" value={outText} /> : null}
+    </ActivityDisclosure>
+  );
+}
+
 /* ---- docs / knowledge search ----------------------------------------------- */
 
 function DocsSearchRenderer({ item }: ToolRendererProps) {
@@ -1577,9 +1772,11 @@ function GenericToolIcon({ name }: { name: string }) {
                                   leaf.includes("knowledge") ||
                                   leaf === "list_document_bases"
                                 ? FileSearchIcon
-                                : leaf === "tool_search" || leaf === "load_skill"
-                                  ? PlugIcon
-                                  : WrenchIcon;
+                                : leaf === "tool_search"
+                                  ? PackageSearchIcon
+                                  : leaf === "load_skill"
+                                    ? PlugIcon
+                                    : WrenchIcon;
   return <Icon className={ICON_SIZE} />;
 }
 
@@ -1591,6 +1788,7 @@ const BASE_ENTRIES: ToolRegistryEntry[] = [
   { match: "rawType", type: "apply_patch_call", render: ApplyPatchRenderer },
   { match: "rawType", type: "computer_call", render: ComputerCallRenderer },
   { match: "rawType", type: "hosted_tool_call", render: WebSearchRenderer },
+  { match: "rawType", type: "tool_search_call", render: ToolSearchRenderer },
   // First-party sandbox + MCP tools resolve by name (exact or MCP leaf).
   { match: "name", name: "exec_command", render: ExecRenderer },
   { match: "name", name: "request_human_input", render: AskRenderer },
@@ -1609,6 +1807,7 @@ const BASE_ENTRIES: ToolRegistryEntry[] = [
   { match: "name", name: "computer_keypress", render: ComputerCallRenderer },
   { match: "name", name: "computer_drag", render: ComputerCallRenderer },
   { match: "name", name: "web_search_call", render: WebSearchRenderer },
+  { match: "name", name: "tool_search", render: ToolSearchRenderer },
   { match: "name", name: "view_image", render: ViewImageRenderer },
   { match: "name", name: "environment_set_variable", render: SecretSetRenderer },
   { match: "name", name: "variable_set_set_variable", render: SecretSetRenderer },

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -2779,7 +2779,12 @@ describe("useComposer durable draft and control binding", () => {
     const client = fakeClient({
       getComposerDraft: async () => initial,
       saveComposerDraft: async () => {
-        throw new OpenGeniApiError(409, "draft changed");
+        // Persistently conflict even after the stale-revision retry adopts
+        // the server revision — surfaces the keep_mine / use_remote banner.
+        throw new OpenGeniApiError(
+          409,
+          JSON.stringify({ code: "DRAFT_CHANGED", message: "Composer draft changed" }),
+        );
       },
     });
     const hook = await renderHook(
@@ -2790,7 +2795,57 @@ describe("useComposer durable draft and control binding", () => {
     await flushing(async () => hook.result.current.setValue("mine remains"));
     await flush(600);
     expect(hook.result.current.value).toBe("mine remains");
-    expect(hook.result.current.draftConflict?.message).toContain("409");
+    expect(hook.result.current.draftConflict?.message).toContain("Composer draft changed");
+    await hook.unmount();
+  });
+
+  test("autosave recovers a stale revision after tab-sleep OCC without surfacing a conflict", async () => {
+    const initial = {
+      revision: 1,
+      text: "remote one",
+      resources: [],
+      model: "model-x",
+      reasoningEffort: "medium" as const,
+      sourceTurnId: null,
+      sourceTurnVersion: null,
+      updatedAt: new Date().toISOString(),
+    };
+    let saves = 0;
+    const client = fakeClient({
+      getComposerDraft: async () =>
+        saves === 0
+          ? initial
+          : {
+              ...initial,
+              revision: 2,
+              text: "remote one",
+            },
+      saveComposerDraft: async (_workspaceId, _sessionId, request) => {
+        saves += 1;
+        if (request.expectedRevision === 1) {
+          throw new OpenGeniApiError(
+            409,
+            JSON.stringify({ code: "DRAFT_CHANGED", message: "Composer draft changed" }),
+          );
+        }
+        return {
+          ...initial,
+          revision: request.expectedRevision + 1,
+          text: request.text,
+        };
+      },
+    });
+    const hook = await renderHook(
+      () => useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+    await flush();
+    await flushing(async () => hook.result.current.setValue("mine remains"));
+    await flush(600);
+    expect(hook.result.current.value).toBe("mine remains");
+    expect(hook.result.current.draftConflict).toBeNull();
+    expect(hook.result.current.draft?.revision).toBe(3);
+    expect(saves).toBe(2);
     await hook.unmount();
   });
 

--- a/packages/react/test/timeline-failed-status.test.tsx
+++ b/packages/react/test/timeline-failed-status.test.tsx
@@ -215,6 +215,16 @@ const CASES: Case[] = [
     }),
   },
   {
+    label: "ToolSearchRenderer — failed",
+    kind: "tool",
+    item: toolItem({
+      name: "tool_search",
+      arguments: { query: "send email" },
+      raw: { type: "tool_search_call", call_id: "ts-fail" },
+      output: { type: "text", text: "search executor crashed" },
+    }),
+  },
+  {
     label: "GenericRenderer (fallback) — failed",
     kind: "tool",
     item: toolItem({
@@ -662,6 +672,16 @@ const CANCELLED_CASES: CancelledCase[] = [
     item: cancelledToolItem({
       name: "environment_set_variable",
       arguments: JSON.stringify({ name: "MY_VAR", value: "secret" }),
+      output: undefined,
+    }),
+  },
+  {
+    label: "ToolSearchRenderer — cancelled",
+    kind: "tool",
+    item: cancelledToolItem({
+      name: "tool_search",
+      arguments: { query: "send email" },
+      raw: { type: "tool_search_call", call_id: "ts-cancel" },
       output: undefined,
     }),
   },

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -1264,6 +1264,122 @@ describe("WebSearchRenderer — null/undefined entries in results array", () => 
   });
 });
 
+describe("ToolSearchRenderer", () => {
+  test("running shows capability query without flashing Done", async () => {
+    const item = toolItem({
+      name: "tool_search",
+      arguments: { query: "send an email to someone", limit: 8 },
+      raw: {
+        type: "tool_search_call",
+        call_id: "ts1",
+        execution: "client",
+        arguments: { query: "send an email to someone", limit: 8 },
+      },
+      status: "running",
+    });
+    const Renderer = defaultToolRegistry.resolve(item);
+    expect(Renderer.name).toBe("ToolSearchRenderer");
+    const r = await renderComponent(<Renderer item={item} />);
+    await flush();
+
+    const text = r.container.textContent ?? "";
+    expect(text).toContain("Looking up tools");
+    expect(text).toContain("send an email to someone");
+    expect(text).not.toContain("Done");
+
+    await r.unmount();
+  });
+
+  test("settled disclosed-tools text lists leaves with source prefix", async () => {
+    const item = toolItem({
+      name: "tool_search",
+      arguments: { query: "email" },
+      raw: { type: "tool_search_call", call_id: "ts2", execution: "client" },
+      output: {
+        type: "text",
+        text: "Disclosed tools: codex_apps__gmail_send_email, slack__post_message",
+      },
+      status: "complete",
+    });
+    const Renderer = defaultToolRegistry.resolve(item);
+    const r = await renderComponent(<Renderer item={item} />);
+    await flush();
+
+    expect(r.container.textContent).toContain("Looked up tools");
+    expect(r.container.textContent).toContain("2 tools");
+
+    const trigger = r.container.querySelector('[role="button"]') as HTMLElement | null;
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    const text = r.container.textContent ?? "";
+    expect(text).toContain("gmail_send_email");
+    expect(text).toContain("post_message");
+    expect(text).toContain("codex_apps");
+    expect(text).toContain("slack");
+    expect(text).toContain("capability query: email");
+    // Parsed list owns the face — no raw "Disclosed tools:" dump.
+    expect(text).not.toContain("Disclosed tools:");
+
+    await r.unmount();
+  });
+
+  test("no matches settles quietly", async () => {
+    const item = toolItem({
+      name: "tool_search",
+      arguments: JSON.stringify({ query: "teleport to mars" }),
+      output: { type: "text", text: "No matching tools found." },
+      status: "complete",
+    });
+    const Renderer = defaultToolRegistry.resolve(item);
+    const r = await renderComponent(<Renderer item={item} />);
+    await flush();
+
+    expect(r.container.textContent).toContain("No matches");
+
+    const trigger = r.container.querySelector('[role="button"]') as HTMLElement | null;
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    expect((r.container.textContent ?? "").toLowerCase()).toContain("no deferred tools matched");
+
+    await r.unmount();
+  });
+
+  test("structured tools array on output is accepted", async () => {
+    const item = toolItem({
+      name: "tool_search",
+      arguments: { query: "calendar" },
+      output: {
+        tools: [
+          { type: "function", name: "codex_apps__google_calendar_create_event" },
+          null,
+          { type: "function", name: "codex_apps__google_calendar_list_events" },
+        ],
+      },
+      status: "complete",
+    });
+    const Renderer = defaultToolRegistry.resolve(item);
+    const r = await renderComponent(<Renderer item={item} />);
+    await flush();
+
+    expect(r.container.textContent).toContain("2 tools");
+
+    const trigger = r.container.querySelector('[role="button"]') as HTMLElement | null;
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    expect(r.container.textContent).toContain("google_calendar_create_event");
+    expect(r.container.textContent).toContain("google_calendar_list_events");
+
+    await r.unmount();
+  });
+});
+
 /* ---- Finding B: failed tool WITH non-empty output shows failure affordance */
 
 describe("ExecRenderer — failed status with non-empty output", () => {

--- a/packages/react/test/tool-registry.test.ts
+++ b/packages/react/test/tool-registry.test.ts
@@ -52,4 +52,16 @@ describe("defaultToolRegistry leaf resolution", () => {
     const renderer = registry.resolve(tool({ name: "docs__knowledge_search" }));
     expect(renderer.name).toBe("DocsSearchRenderer");
   });
+
+  test("resolves ToolSearch by name and tool_search_call raw type", () => {
+    const byName = registry.resolve(tool({ name: "tool_search" }));
+    const byRaw = registry.resolve(
+      tool({
+        name: "tool",
+        raw: { type: "tool_search_call", call_id: "c1", arguments: { query: "email" } },
+      }),
+    );
+    expect(byName.name).toBe("ToolSearchRenderer");
+    expect(byRaw.name).toBe("ToolSearchRenderer");
+  });
 });


### PR DESCRIPTION
## Summary
- Recover composer draft after tab sleep: recognize production `DRAFT_CHANGED` 409s, soft-reload revision on wake, and retry autosave once with the server revision while keeping local text (no raw toast / stuck OCC).
- Add a dedicated `ToolSearchRenderer` for progressive MCP `tool_search` / `tool_search_call`: capability query, disclosed tool leaves with source prefixes, quiet no-match and failure states instead of generic “Done”.

## Test plan
- [ ] Leave a session tab sleeping long enough for a draft save to land server-side; wake and type — no `Composer draft changed` toast; text keeps local edits
- [ ] Two-browser race on the same draft: silent recovery or conflict banner only if retry also fails
- [ ] Timeline: running `tool_search` shows “Looking up tools” + query
- [ ] Settled disclosure lists `source` + leaf names from `Disclosed tools: …` text; empty search shows “No matches”
- [ ] Failed / cancelled `tool_search` rows show the same affordances as other search cards


Made with [Cursor](https://cursor.com)