### PR TITLE
chore(release): bump product version to 0.22.65

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.64
-appVersion: "0.22.64"
+version: 0.22.65
+appVersion: "0.22.65"


### PR DESCRIPTION
Bumps the immutable product release version after the previous candidate reserved 0.22.64.\n\nValidation:\n- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`\n- `bun test scripts/release-version.test.ts scripts/release-image-workflow-contract.test.ts`\n- `git diff --check`