### PR TITLE
fix(release): recover duplicate legacy checks

### DIFF
--- a/.changeset/quiet-release-recovery.md
+++ b/.changeset/quiet-release-recovery.md
@@ -1,0 +1,4 @@
+---
+---
+
+Repair release-head recovery when GitHub emits duplicate legacy check projections.

--- a/.changeset/quiet-release-recovery.md
+++ b/.changeset/quiet-release-recovery.md
@@ -1,4 +1,5 @@
 ---
+"@opengeni/core": patch
 ---
 
 Repair release-head recovery when GitHub emits duplicate legacy check projections.

--- a/examples/northstar-support/src/server.ts
+++ b/examples/northstar-support/src/server.ts
@@ -448,10 +448,9 @@ async function createAgentSession(request: Request): Promise<Response> {
     return json({ error: `Ticket ${ticketId || "unknown"} not found.` }, 404);
   }
   const { ticket, customer } = supportCase;
-  const initialMessage =
-    requestedMessage
-      ? requestedMessage
-      : `Investigate ${ticket.id}. Use the available support tools, explain the evidence, and take the appropriate actions.`;
+  const initialMessage = requestedMessage
+    ? requestedMessage
+    : `Investigate ${ticket.id}. Use the available support tools, explain the evidence, and take the appropriate actions.`;
 
   const mcpServer = {
     id: MCP_SERVER_ID,

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -1187,10 +1187,7 @@ async function findCheckRun(api, context, identity) {
     if (response.check_runs.length < recordsPerPage) break;
     invariant(page < maximumPages, "check-run listing exceeded its page limit");
   }
-  invariant(
-    canonicalMatches.length <= 1,
-    "multiple check runs share the idempotency marker",
-  );
+  invariant(canonicalMatches.length <= 1, "multiple check runs share the idempotency marker");
   if (canonicalMatches.length === 1) return canonicalMatches[0];
   return migrationMatches.length === 1 ? migrationMatches[0] : undefined;
 }

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -1146,11 +1146,9 @@ function checkIdentity(kind, context) {
 }
 
 async function findCheckRun(api, context, identity) {
-  const matches = [];
-  const acceptedExternalIds = new Set([
-    identity.externalId,
-    ...(identity.migrationExternalIds ?? []),
-  ]);
+  const canonicalMatches = [];
+  const migrationMatches = [];
+  const migrationExternalIds = new Set(identity.migrationExternalIds ?? []);
   const acceptedExternalIdPatterns = identity.migrationExternalIdPatterns ?? [];
   for (let page = 1; page <= maximumPages; page += 1) {
     const response = record(
@@ -1165,10 +1163,11 @@ async function findCheckRun(api, context, identity) {
     invariant(Array.isArray(response.check_runs), "check-run records are missing");
     for (const check of response.check_runs) {
       const externalId = check?.external_id;
-      if (
-        !acceptedExternalIds.has(externalId) &&
-        !acceptedExternalIdPatterns.some((pattern) => pattern.test(externalId ?? ""))
-      ) {
+      const canonical =
+        externalId === identity.externalId ||
+        acceptedExternalIdPatterns.some((pattern) => pattern.test(externalId ?? ""));
+      const migration = migrationExternalIds.has(externalId);
+      if (!canonical && !migration) {
         if (!identity.exclusive) continue;
         invariant(
           check?.head_sha === context.headSha,
@@ -1183,13 +1182,17 @@ async function findCheckRun(api, context, identity) {
         Number.isSafeInteger(check?.id) && check.id > 0,
         "existing check-run ID is invalid",
       );
-      matches.push(check);
+      (canonical ? canonicalMatches : migrationMatches).push(check);
     }
     if (response.check_runs.length < recordsPerPage) break;
     invariant(page < maximumPages, "check-run listing exceeded its page limit");
   }
-  invariant(matches.length <= 1, "multiple check runs share the idempotency marker");
-  return matches[0];
+  invariant(
+    canonicalMatches.length <= 1,
+    "multiple check runs share the idempotency marker",
+  );
+  if (canonicalMatches.length === 1) return canonicalMatches[0];
+  return migrationMatches.length === 1 ? migrationMatches[0] : undefined;
 }
 
 async function upsertCheckRun(api, context, kind, state, now) {

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -1180,13 +1180,11 @@ describe("release head retention recovery", () => {
     });
 
     expect(
-      fixture.checks.filter(
-        (check) => check.external_id === recoveredSourceAdmissionExternalId(),
-      ),
+      fixture.checks.filter((check) => check.external_id === recoveredSourceAdmissionExternalId()),
     ).toHaveLength(1);
-    expect(
-      fixture.checks.filter((check) => check.external_id === legacyExternalId),
-    ).toHaveLength(2);
+    expect(fixture.checks.filter((check) => check.external_id === legacyExternalId)).toHaveLength(
+      2,
+    );
   });
 
   test("moves one prior v2 recovery check to the current seal run without duplicating it", async () => {

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -1157,6 +1157,38 @@ describe("release head retention recovery", () => {
     ).toHaveLength(0);
   });
 
+  test("creates one recovery receipt when duplicate legacy idempotency markers exist", async () => {
+    const legacyExternalId = String.raw`opengeni:release-automation:source-admission:v1:pr:${pullNumber}:head:${headSha}`;
+    const legacy = (id: number) => ({
+      id,
+      name: RELEASE_AUTOMATION_CONTRACT.checks.sourceAdmission,
+      head_sha: headSha,
+      status: "completed",
+      conclusion: "success",
+      external_id: legacyExternalId,
+      app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+    });
+    const fixture = recoverySealFixture({
+      existingRecoveryChecks: [legacy(777), legacy(778)],
+    });
+
+    await recoverReleaseHeadEvidence({
+      env: recoverySealEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+      now: () => new Date("2026-07-27T09:30:00Z"),
+    });
+
+    expect(
+      fixture.checks.filter(
+        (check) => check.external_id === recoveredSourceAdmissionExternalId(),
+      ),
+    ).toHaveLength(1);
+    expect(
+      fixture.checks.filter((check) => check.external_id === legacyExternalId),
+    ).toHaveLength(2);
+  });
+
   test("moves one prior v2 recovery check to the current seal run without duplicating it", async () => {
     const fixture = recoverySealFixture();
     const options = {


### PR DESCRIPTION
## Summary
- prefer one canonical source-admission recovery receipt over legacy migration markers
- create the canonical recovery receipt when GitHub projected the same legacy marker more than once
- keep duplicate canonical recoveries and exclusive retention duplicates fail-closed

## Verification
- `bun test scripts/check-release-pr-automation.test.ts` (64 tests)
- `bun run typecheck`
- `bun run lint`