### PR TITLE
fix(release): preserve valid retention duplicates

### DIFF
--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -871,6 +871,7 @@ export async function recoverReleaseHeadEvidence(options = {}) {
     JSON.stringify(preMutationEvidence) === JSON.stringify(initialEvidence),
     "release head evidence moved before recovery mutation",
   );
+  let existingRetention;
   if (initialEvidence === null) {
     invariant(
       preMutationChecks.every(
@@ -883,7 +884,7 @@ export async function recoverReleaseHeadEvidence(options = {}) {
       ...context,
       releaseHeadRelease: initialEvidence.releaseHeadRelease,
     };
-    await findCheckRun(
+    existingRetention = await findCheckRun(
       api,
       retentionContext,
       checkIdentity("release-head-retention", retentionContext),
@@ -931,19 +932,21 @@ export async function recoverReleaseHeadEvidence(options = {}) {
     context.headSha,
     sourceAdmissionIdentity.externalId,
   );
-  await upsertCheckRun(
-    api,
-    checkContext,
-    "release-head-retention",
-    {
-      status: "in_progress",
-      title: "Recovering immutable release-head retention evidence",
-      summary:
-        `Recovering the provider check for retained head ${context.headSha} ` +
-        `from merged source ${context.sourceSha}.`,
-    },
-    now,
-  );
+  if (!existingRetention) {
+    await upsertCheckRun(
+      api,
+      checkContext,
+      "release-head-retention",
+      {
+        status: "in_progress",
+        title: "Recovering immutable release-head retention evidence",
+        summary:
+          `Recovering the provider check for retained head ${context.headSha} ` +
+          `from merged source ${context.sourceSha}.`,
+      },
+      now,
+    );
+  }
 
   const [terminalMain, terminalPull, terminalEvidence] = await Promise.all([
     api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
@@ -960,21 +963,23 @@ export async function recoverReleaseHeadEvidence(options = {}) {
     JSON.stringify(terminalEvidence.releaseHeadRelease) === JSON.stringify(releaseHeadRelease),
     "release head immutable release moved during recovery",
   );
-  await upsertCheckRun(
-    api,
-    checkContext,
-    "release-head-retention",
-    {
-      status: "completed",
-      conclusion: "success",
-      title: "Release head retention evidence recovered",
-      summary:
-        `PR #${context.prNumber} exact head ${context.headSha} remains retained at ` +
-        `${releaseHead.ref} by immutable prerelease ${releaseHeadRelease.id}; ` +
-        `the accepted merge source is ${context.sourceSha}.`,
-    },
-    now,
-  );
+  if (!existingRetention) {
+    await upsertCheckRun(
+      api,
+      checkContext,
+      "release-head-retention",
+      {
+        status: "completed",
+        conclusion: "success",
+        title: "Release head retention evidence recovered",
+        summary:
+          `PR #${context.prNumber} exact head ${context.headSha} remains retained at ` +
+          `${releaseHead.ref} by immutable prerelease ${releaseHeadRelease.id}; ` +
+          `the accepted merge source is ${context.sourceSha}.`,
+      },
+      now,
+    );
+  }
   logger.log(
     `Recovered release-head retention check for ${context.headSha} ` +
       `from merged source ${context.sourceSha}.`,
@@ -1187,8 +1192,19 @@ async function findCheckRun(api, context, identity) {
     if (response.check_runs.length < recordsPerPage) break;
     invariant(page < maximumPages, "check-run listing exceeded its page limit");
   }
-  invariant(canonicalMatches.length <= 1, "multiple check runs share the idempotency marker");
-  if (canonicalMatches.length === 1) return canonicalMatches[0];
+  if (canonicalMatches.length > 1) {
+    const suiteIds = new Set(canonicalMatches.map((check) => check?.check_suite?.id));
+    invariant(
+      identity.exclusive &&
+        suiteIds.size === 1 &&
+        Number.isSafeInteger(canonicalMatches[0]?.check_suite?.id) &&
+        canonicalMatches.every(
+          (check) => check?.status === "completed" && check?.conclusion === "success",
+        ),
+      "multiple check runs share the idempotency marker",
+    );
+  }
+  if (canonicalMatches.length >= 1) return canonicalMatches[0];
   return migrationMatches.length === 1 ? migrationMatches[0] : undefined;
 }
 

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -1415,6 +1415,42 @@ describe("release head retention recovery", () => {
     expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
   });
 
+  test("accepts successful exact retention projections from one check suite", async () => {
+    const fixture = recoverySealFixture();
+    const options = {
+      env: recoverySealEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+      now: () => new Date("2026-07-27T09:30:00Z"),
+    };
+    await recoverReleaseHeadEvidence(options);
+    const retentionCheck = fixture.checks.find(
+      (check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention,
+    );
+    expect(retentionCheck).toBeDefined();
+    Object.assign(retentionCheck!, { check_suite: { id: 123 } });
+    fixture.checks.push({
+      ...retentionCheck,
+      id: Number(retentionCheck?.id) + 1,
+      check_suite: { id: 123 },
+    });
+    fixture.requests.length = 0;
+
+    await expect(recoverReleaseHeadEvidence(options)).resolves.toBeDefined();
+    expect(
+      fixture.checks.filter(
+        (check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention,
+      ),
+    ).toHaveLength(2);
+    expect(
+      fixture.requests.filter(
+        (request) =>
+          request.method === "PATCH" &&
+          request.body?.name === RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention,
+      ),
+    ).toHaveLength(0);
+  });
+
   test("rejects duplicate exact retention checks for an exact retained pair before mutation", async () => {
     const fixture = recoverySealFixture();
     const options = {


### PR DESCRIPTION
## Summary
- accept exact successful retention projections only when they share one provider check suite
- reuse already-valid retention evidence during historical source-admission recovery
- retain fail-closed behavior for cross-suite, failed, incomplete, or conflicting duplicates

## Verification
- `bun test scripts/check-release-pr-automation.test.ts` (65 tests)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`