### PR TITLE
fix(runtime): honor Connected Machine shell selection

### DIFF
--- a/.changeset/calm-shells-obey.md
+++ b/.changeset/calm-shells-obey.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Honor explicit shell and login selections when commands run on Connected Machines instead of substituting the machine service's ambient default shell.

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -154,6 +154,11 @@ Exec requests carry a finite agent-side process deadline inside a slightly
 larger request/reply deadline. If that deadline or the connection generation
 ends, the agent cancels the accepted operation and terminates its POSIX process
 group or Windows Job Object, including ordinary descendants spawned by a shell.
+The session shell capability also preserves an explicit `exec_command.shell`
+selection: OpenGeni sends that shell as direct argv, with the requested login or
+non-login semantics, instead of silently substituting the machine service's
+ambient default shell. Calls that omit `shell` intentionally retain the
+machine-owned `$SHELL`/`ComSpec` default.
 On Unix a private unreaped group anchor fences the PGID until cleanup has been
 issued, so cancellation cannot signal a recycled group and the requested command
 cannot exit and leave invisible same-group work behind.

--- a/packages/runtime/src/sandbox/selfhosted/session.ts
+++ b/packages/runtime/src/sandbox/selfhosted/session.ts
@@ -115,6 +115,43 @@ function toMachinePath(p: string | undefined, workingDir: string): string {
   return base ? `${base}/${p}` : p;
 }
 
+/**
+ * Builds the exact argv for an explicitly selected shell.
+ *
+ * The self-hosted wire already supports direct argv (`ExecRequest.shell=false`),
+ * which is the compatibility-safe way to honor the SDK shell tool's `shell` and
+ * `login` arguments: every enrolled agent version understands this shape. Sending
+ * `{ command: [cmd], shell: true }` instead delegates shell selection to the
+ * machine's ambient `$SHELL`/`ComSpec` and silently discards the caller's choice.
+ *
+ * `login` maps to profile/login semantics where the shell family exposes them.
+ * Windows `cmd.exe` has no login-shell mode. PowerShell profile loading is the
+ * closest equivalent, so non-login calls use `-NoProfile` while login calls do
+ * not. Other shells use the common POSIX `-l -c` / `-c` contract.
+ */
+function explicitShellArgv(shell: string, command: string, login: boolean): string[] {
+  const leaf = shell.replaceAll("\\", "/").split("/").at(-1)?.toLowerCase() ?? "";
+  if (leaf === "cmd" || leaf === "cmd.exe") {
+    return [shell, "/D", "/S", "/C", command];
+  }
+  if (
+    leaf === "powershell" ||
+    leaf === "powershell.exe" ||
+    leaf === "pwsh" ||
+    leaf === "pwsh.exe"
+  ) {
+    return [
+      shell,
+      "-NoLogo",
+      ...(!login ? ["-NoProfile"] : []),
+      "-NonInteractive",
+      "-Command",
+      command,
+    ];
+  }
+  return [shell, ...(login ? ["-l"] : []), "-c", command];
+}
+
 // ── The agent-turn provided-session contract (@openai/agents-core) ──────────
 // When the routing proxy resolves a selfhosted ACTIVE backend, the @openai/agents
 // agent loop binds its filesystem/shell/skills capabilities to THIS session and
@@ -589,11 +626,15 @@ export class SelfhostedSession {
     // wire carried timeoutMs=0 (unbounded) while the caller stopped waiting after
     // ~30s, leaving accepted work invisible and able to starve control liveness.
     const executionTimeoutMs = this.effectiveExecDeadlineMs;
+    const requestedShell = args.shell?.trim();
     const execReq: ExecRequest = {
-      // The agent does NOT shell-interpret unless `shell` — Channel-A passes a
-      // single shell command string, so run it through the platform shell.
-      command: [args.cmd],
-      shell: true,
+      // An explicit shell is encoded as direct argv so every agent version honors
+      // it. With no explicit shell, preserve the existing machine-owned default
+      // shell behavior byte-for-byte.
+      command: requestedShell
+        ? explicitShellArgv(requestedShell, args.cmd, args.login === true)
+        : [args.cmd],
+      shell: !requestedShell,
       // Rewrite a virtual-root cwd ("/workspace[/…]") onto the machine's frame —
       // an absolute "/workspace" would ENOENT on a real machine (see
       // SELFHOSTED_VIRTUAL_ROOT). Empty → the session workingDir (itself "" by
@@ -734,8 +775,8 @@ export class SelfhostedSession {
    *  after a newline when there is partial output (a timed-out result is already not
    *  cleanly parseable — silence is worse than an explanatory suffix). The structured
    *  `exec()` result is left untouched for the Channel-A parsers. */
-  async execCommand(args: { cmd: string; workdir?: string; runAs?: string }): Promise<string> {
-    const result = await this.exec({ cmd: args.cmd, workdir: args.workdir, runAs: args.runAs });
+  async execCommand(args: SelfhostedExecArgs): Promise<string> {
+    const result = await this.exec(args);
     if (result.timedOut) {
       const hint = execDeadlineHint(Math.round(this.effectiveExecDeadlineMs / 1000));
       return result.output ? `${result.output}\n${hint}` : hint;

--- a/packages/runtime/test/selfhosted-session.test.ts
+++ b/packages/runtime/test/selfhosted-session.test.ts
@@ -81,6 +81,69 @@ describe("SelfhostedSession — structural surface over a ControlRpc (mock)", ()
     expect(seen[0]?.timeoutMs).toBe(17_000);
   });
 
+  test("exec preserves the ambient machine shell only when no shell is requested", async () => {
+    const mock = new MockAgentResponder();
+    await sessionWith(mock).exec({ cmd: "printf ambient" });
+
+    const op = mock.requests[0]?.req.op;
+    if (op?.$case !== "exec") throw new Error("expected exec request");
+    expect(op.exec.command).toEqual(["printf ambient"]);
+    expect(op.exec.shell).toBe(true);
+  });
+
+  test("exec honors explicit POSIX shell and login choices through direct argv", async () => {
+    const mock = new MockAgentResponder();
+    const session = sessionWith(mock);
+
+    await session.exec({ cmd: "printf non-login", shell: "/bin/bash", login: false });
+    await session.execCommand({ cmd: "printf login", shell: "/bin/zsh", login: true });
+
+    const first = mock.requests[0]?.req.op;
+    const second = mock.requests[1]?.req.op;
+    if (first?.$case !== "exec" || second?.$case !== "exec") {
+      throw new Error("expected exec requests");
+    }
+    expect(first.exec).toMatchObject({
+      command: ["/bin/bash", "-c", "printf non-login"],
+      shell: false,
+    });
+    expect(second.exec).toMatchObject({
+      command: ["/bin/zsh", "-l", "-c", "printf login"],
+      shell: false,
+    });
+  });
+
+  test("exec maps explicit Windows shell families without POSIX flags", async () => {
+    const mock = new MockAgentResponder();
+    const session = sessionWith(mock);
+
+    await session.exec({ cmd: "echo cmd", shell: String.raw`C:\Windows\System32\cmd.exe` });
+    await session.exec({ cmd: "Write-Output profile", shell: "pwsh.exe", login: true });
+    await session.exec({ cmd: "Write-Output clean", shell: "powershell.exe", login: false });
+
+    const requests = mock.requests.map((request) => request.req.op);
+    if (requests.some((op) => op?.$case !== "exec")) throw new Error("expected exec requests");
+    expect(requests[0]?.exec).toMatchObject({
+      command: [String.raw`C:\Windows\System32\cmd.exe`, "/D", "/S", "/C", "echo cmd"],
+      shell: false,
+    });
+    expect(requests[1]?.exec).toMatchObject({
+      command: ["pwsh.exe", "-NoLogo", "-NonInteractive", "-Command", "Write-Output profile"],
+      shell: false,
+    });
+    expect(requests[2]?.exec).toMatchObject({
+      command: [
+        "powershell.exe",
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "Write-Output clean",
+      ],
+      shell: false,
+    });
+  });
+
   test("exec surfaces $HOSTNAME from the machine", async () => {
     const mock = new MockAgentResponder({ hostname: "the-vm" });
     const res = await sessionWith(mock).exec({ cmd: "echo $HOSTNAME" });


### PR DESCRIPTION
## Summary

- preserve explicit `exec_command` shell and login choices on Connected Machines
- encode selected shells as direct argv so mixed-version runners cannot substitute the machine service's ambient default shell
- retain the existing machine-owned `$SHELL` / `ComSpec` behavior when no shell is selected
- document the contract and add Linux/macOS-style, `cmd.exe`, and PowerShell wire regressions

## Problem

Connected Machine command execution accepted `shell` and `login` arguments but discarded them before constructing the agent request. Commands therefore always ran through the machine service's ambient default shell. Shell-specific syntax and variables could change meaning; for example, a Bash-oriented `path=...` assignment is special in zsh and can unexpectedly replace `PATH`.

## Validation

- complete `packages/runtime/test` suite
- monorepo typecheck: 23 projects clean
- `@opengeni/runtime` build
- full `oxlint --deny-warnings`
- full `oxfmt --check`
- docs reference guard
- public repository hygiene guard
- Rust direct-argv execution regression
