### PR TITLE
fix(release): navigate virtualized tree roots

### DIFF
--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -98,6 +98,7 @@ describe("workbench live acceptance preflight", () => {
     const directoryButton = { click: async () => clicks.push("directory") };
     const fileButton = { click: async () => clicks.push("file") };
     const directoryItem = {
+      isVisible: async () => true,
       getAttribute: async (name: string) => {
         expect(name).toBe("aria-expanded");
         return "true";
@@ -129,6 +130,7 @@ describe("workbench live acceptance preflight", () => {
     let active = 0;
     const rows = ["api", "base.txt", "notes.txt", "server.ts"];
     const directoryItem = {
+      isVisible: async () => true,
       getAttribute: async () => "true",
       getByRole: () => ({ first: () => ({ click: async () => {} }) }),
     };
@@ -161,6 +163,11 @@ describe("workbench live acceptance preflight", () => {
         const index = Number(selector.match(/tree-item-(\d+)/)?.[1]);
         return {
           waitFor: async () => {},
+          getAttribute: async (name: string) => {
+            if (name === "aria-level") return rows[index] === "api" ? "1" : "2";
+            if (name === "aria-expanded") return rows[index] === "api" ? "true" : null;
+            throw new Error(`unexpected attribute ${name}`);
+          },
           getByText(text: string, options: { exact: boolean }) {
             expect(options).toEqual({ exact: true });
             return { count: async () => (rows[index] === text ? 1 : 0) };
@@ -172,6 +179,60 @@ describe("workbench live acceptance preflight", () => {
     await selectTreeFile(page, "api", "server.ts");
 
     expect(presses).toEqual(["Home", "ArrowDown", "ArrowDown", "ArrowDown", "Enter"]);
+  });
+
+  test("selects a file when its virtualized root directory is initially off-screen", async () => {
+    const presses: string[] = [];
+    let active = 0;
+    let expanded = false;
+    const rows = ["README.md", "api", "base.txt"];
+    const tree = {
+      focus: async () => {},
+      press: async (key: string) => {
+        presses.push(key);
+        if (key === "Home") active = 0;
+        if (key === "ArrowRight" && rows[active] === "api") expanded = true;
+        if (key === "ArrowDown") active = Math.min(active + 1, rows.length - 1);
+      },
+      getAttribute: async (name: string) => {
+        expect(name).toBe("aria-activedescendant");
+        return `tree-item-${active}`;
+      },
+    };
+    const page = {
+      getByRole(role: string) {
+        if (role === "tree") return { first: () => tree };
+        expect(role).toBe("treeitem");
+        return {
+          filter: () => ({
+            first: () => ({
+              isVisible: async () => false,
+            }),
+          }),
+        };
+      },
+      locator(selector: string) {
+        const index = Number(selector.match(/tree-item-(\d+)/)?.[1]);
+        return {
+          waitFor: async () => {},
+          getAttribute: async (name: string) => {
+            if (name === "aria-level") return rows[index] === "base.txt" ? "2" : "1";
+            if (name === "aria-expanded") {
+              return rows[index] === "api" && expanded ? "true" : "false";
+            }
+            throw new Error(`unexpected attribute ${name}`);
+          },
+          getByText(text: string, options: { exact: boolean }) {
+            expect(options).toEqual({ exact: true });
+            return { count: async () => (rows[index] === text ? 1 : 0) };
+          },
+        };
+      },
+    } as never;
+
+    await selectTreeFile(page, "api", "base.txt");
+
+    expect(presses).toEqual(["Home", "ArrowDown", "ArrowRight", "ArrowDown", "Enter"]);
   });
 
   test("accepts repository evidence from the compact changed-file picker", async () => {

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -2096,9 +2096,9 @@ async function selectChangesTab(page: Page): Promise<void> {
 
 export async function selectTreeFile(page: Page, directory: string, file: string): Promise<void> {
   const directoryItem = page.getByRole("treeitem").filter({ hasText: directory }).first();
-  const directoryButton = directoryItem.getByRole("button").first();
-  if ((await directoryItem.getAttribute("aria-expanded")) !== "true") {
-    await directoryButton.click();
+  const directoryVisible = await directoryItem.isVisible();
+  if (directoryVisible && (await directoryItem.getAttribute("aria-expanded")) !== "true") {
+    await directoryItem.getByRole("button").first().click();
   }
 
   // The Files tree is virtualized: an expanded directory can truthfully contain
@@ -2107,7 +2107,7 @@ export async function selectTreeFile(page: Page, directory: string, file: string
   // the tree's public composite-keyboard contract instead of assuming every
   // logical row permanently exists in the DOM.
   const fileItem = page.getByRole("treeitem").filter({ hasText: file }).first();
-  if (await fileItem.isVisible()) {
+  if (directoryVisible && (await fileItem.isVisible())) {
     await fileItem.getByRole("button").click();
     return;
   }
@@ -2115,11 +2115,43 @@ export async function selectTreeFile(page: Page, directory: string, file: string
   const tree = page.getByRole("tree").first();
   await tree.focus();
   await tree.press("Home");
+
+  let directoryLevel: number | undefined;
   for (let index = 0; index < 4_096; index += 1) {
     const activeId = await tree.getAttribute("aria-activedescendant");
     if (!activeId) throw new Error("file tree has no active descendant");
     const activeItem = page.locator(`[id=${JSON.stringify(activeId)}]`);
     await activeItem.waitFor({ state: "visible", timeout: 2_000 });
+    if ((await activeItem.getByText(directory, { exact: true }).count()) > 0) {
+      const rawLevel = await activeItem.getAttribute("aria-level");
+      directoryLevel = Number(rawLevel);
+      if (!Number.isInteger(directoryLevel) || directoryLevel < 1) {
+        throw new Error(`file tree directory ${directory} has no valid aria-level`);
+      }
+      if ((await activeItem.getAttribute("aria-expanded")) !== "true") {
+        await tree.press("ArrowRight");
+      }
+      await tree.press("ArrowDown");
+      break;
+    }
+    await tree.press("ArrowDown");
+  }
+
+  if (directoryLevel === undefined) {
+    throw new Error(`file tree did not expose directory ${directory}`);
+  }
+
+  for (let index = 0; index < 4_096; index += 1) {
+    const activeId = await tree.getAttribute("aria-activedescendant");
+    if (!activeId) throw new Error("file tree has no active descendant");
+    const activeItem = page.locator(`[id=${JSON.stringify(activeId)}]`);
+    await activeItem.waitFor({ state: "visible", timeout: 2_000 });
+    const rawLevel = await activeItem.getAttribute("aria-level");
+    const activeLevel = Number(rawLevel);
+    if (!Number.isInteger(activeLevel) || activeLevel < 1) {
+      throw new Error("file tree item has no valid aria-level");
+    }
+    if (activeLevel <= directoryLevel) break;
     if ((await activeItem.getByText(file, { exact: true }).count()) > 0) {
       await tree.press("Enter");
       return;


### PR DESCRIPTION
## Summary
- navigate virtualized root directories through the file tree composite keyboard contract
- constrain file lookup to the selected directory subtree
- cover an initially off-screen root directory with a regression test

## Verification
- `bun test scripts/workbench-live-acceptance.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx oxfmt --check scripts/workbench-live-acceptance.ts scripts/workbench-live-acceptance.test.ts`
- `git diff --check`