### PR TITLE
chore(release): bump product version to 0.22.66

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.65
-appVersion: "0.22.65"
+version: 0.22.66
+appVersion: "0.22.66"


### PR DESCRIPTION
## Summary
- advance the immutable product/chart version to `0.22.66`
- keep chart and application version aligned

## Verification
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `bun test scripts/release-version.test.ts scripts/release-image-workflow-contract.test.ts`
- `git diff --check`