### PR TITLE
fix(react): isolate embedded UI density

### DIFF
--- a/.changeset/clean-embedded-density.md
+++ b/.changeset/clean-embedded-density.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Add render-compatible runtime typography and model-picker density tokens, a compact embedded preset, host-reset-safe component typography, and token propagation for portalled model and realtime menus.

--- a/docs/embedding-workbench.md
+++ b/docs/embedding-workbench.md
@@ -162,7 +162,16 @@ whole workbench. The high-value tokens:
 | `--og-color-status-running` / `--og-color-status-idle` / `--og-color-danger` | the machine chip dot, diff add/remove, and error text. |
 | `--og-color-diff-add-bg` / `--og-color-diff-del-bg` | the Changes diff add/remove backgrounds. |
 | `--og-font-sans` / `--og-font-mono` | UI vs. code/terminal typography. |
+| `--og-font-size-xs` … `--og-font-size-md` | the compact SDK text ramp. Matching `--og-line-height-*` tokens control rhythm. |
+| `--og-font-size-control` / `--og-font-size-menu` | compact chrome vs. dropdown/menu labels. |
+| `--og-font-size-composer` / `--og-font-size-composer-wide` | composer text on narrow and wide viewports. |
+| `--og-model-picker-*` | picker trigger height, menu width/padding, row padding, and effort-row height. |
 | `--og-radius-sm` … `--og-radius-xl` | corner rounding across the dock. |
 
 Light mode is a first-class opt-in: set `data-og-theme="light"` on any ancestor.
-Dark is the default.
+Dark is the default. Set `data-og-density="compact"` (or
+`class="og-density-compact"`) on an SDK ancestor for the supported embedded
+sidebar preset. The defaults stay render-compatible with the web app's
+current type sizes and control geometry. Portalled SDK surfaces copy all
+effective `--og-*` values from their trigger, so locally scoped theme and
+density overrides remain intact outside the ancestor DOM subtree.

--- a/examples/northstar-support/README.md
+++ b/examples/northstar-support/README.md
@@ -22,6 +22,10 @@ integration as a clear before/after:
 8. The session composer also includes the provider-neutral realtime voice control
    from `@opengeni/react/realtime`; this workspace exposes Codex Live as the
    available voice model.
+9. The panel uses the SDK's `data-og-density="compact"` preset. Typography,
+   composer sizing, picker geometry, and the portalled picker/voice menus all
+   come from public `--og-*` tokens; the demo only supplies Northstar colors and
+   product-specific layout.
 
 The demo deliberately exposes four tools over the selected ticket: `get_ticket`,
 `get_customer`, `update_ticket`, and `add_internal_note`. Mutations are

--- a/examples/northstar-support/src/main.tsx
+++ b/examples/northstar-support/src/main.tsx
@@ -54,6 +54,7 @@ function NorthstarApp() {
             : "northstar grid h-dvh min-w-[980px] grid-cols-[320px_minmax(0,1fr)] overflow-hidden bg-[#f7f7f5] transition-[grid-template-columns] duration-300 ease-out"
         }
         data-agent-enabled={agentEnabled}
+        data-og-density="compact"
         data-og-theme="light"
       >
         <SupportInbox

--- a/examples/northstar-support/src/styles.css
+++ b/examples/northstar-support/src/styles.css
@@ -72,11 +72,6 @@ body {
   gap: 14px;
 }
 
-.northstar-agent-copy {
-  font-size: 13px;
-  line-height: 1.6;
-}
-
 .northstar-agent-copy p,
 .northstar-agent-copy li {
   line-height: 1.6;

--- a/examples/northstar-support/src/support-agent-panel.tsx
+++ b/examples/northstar-support/src/support-agent-panel.tsx
@@ -475,10 +475,7 @@ function NorthstarComposer({
           <Composer.PausedState />
           <Composer.RestoredResources />
           <Composer.Attachments />
-          <Composer.Input
-            placeholder="Ask OpenGeni…"
-            className="min-h-[42px] px-3.5 pb-1 pt-2.5 !text-[13px] !leading-5"
-          />
+          <Composer.Input placeholder="Ask OpenGeni…" className="min-h-[42px] px-3.5 pb-1 pt-2.5" />
           {controller.confirmState ? (
             <Composer.Confirmation />
           ) : (

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -66,6 +66,48 @@ entry CSS:
 Consuming only the tokens without Tailwind? Import
 `@opengeni/react/tokens.css` and use the `--og-*` variables directly.)
 
+### Product-compatible theming and density
+
+The default typography and control geometry are the same values used by
+`apps/web`. Put theme overrides on one ancestor; SDK popovers and dropdowns
+copy the effective `--og-*` values from their trigger across the portal
+boundary, so a menu mounted under `<body>` still matches the embedded panel.
+SDK type utilities are also scoped against ordinary host resets such as
+`.app button { font: inherit }`; customize their public tokens instead of
+adding selector-specific overrides.
+
+For a narrow product sidebar, opt into the supported compact preset:
+
+```tsx
+<aside data-og-theme="light" data-og-density="compact">
+  <MessageTimeline {...timelineProps} />
+  <ChatComposer {...composerProps} />
+</aside>
+```
+
+The preset is only a starting point. Override individual runtime tokens on the
+same ancestor without rebuilding Tailwind:
+
+```css
+.my-agent {
+  --og-font-sans: "Inter Variable", ui-sans-serif, system-ui, sans-serif;
+  --og-font-size-menu: 12px;
+  --og-line-height-menu: 18px;
+  --og-font-size-composer-wide: 13px;
+  --og-line-height-composer-wide: 20px;
+  --og-model-picker-menu-width: 15rem;
+  --og-color-accent: oklch(0.58 0.19 288);
+}
+```
+
+The type ramp is `--og-font-size-{xs,sm,base,md}` with matching
+`--og-line-height-*` tokens. Interactive chrome uses the semantic `control`,
+`menu`, `composer`, and `composer-wide` pairs. Model picker height, width,
+padding, and row-density tokens are grouped under `--og-model-picker-*` in
+`styles/tokens.css`. `ModelPolicyPicker` also exposes `contentClassName` and
+`contentStyle` for exceptional surface-level customization; tokens are the
+recommended path.
+
 ## Quick start
 
 ```tsx

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -837,7 +837,7 @@ export const Surface = forwardRef<HTMLDivElement, ComposerSurfaceProps>(function
           aria-hidden
           className={cn(
             "pointer-events-none absolute inset-0 z-10 flex items-center justify-center",
-            "rounded-og-lg bg-og-surface-1/85 text-sm font-medium text-og-accent backdrop-blur-[1px]",
+            "rounded-og-lg bg-og-surface-1/85 text-og-menu font-medium text-og-accent backdrop-blur-[1px]",
           )}
         >
           <span className="inline-flex items-center gap-2">
@@ -957,7 +957,7 @@ export const Input = forwardRef<HTMLTextAreaElement, ComposerInputProps>(functio
         paletteOpen ? `${controller.listboxId}-option-${controller.palette.highlight}` : undefined
       }
       className={cn(
-        "block w-full resize-none bg-transparent px-3.5 pt-3 pb-1 text-base leading-6 md:px-4 md:text-og-md",
+        "block w-full resize-none bg-transparent px-3.5 pt-3 pb-1 text-og-composer md:px-4 md:text-og-composer-wide",
         "text-og-fg placeholder:text-og-fg-subtle focus:outline-none focus-visible:outline-none",
         "disabled:cursor-not-allowed disabled:opacity-60",
         className,
@@ -1262,7 +1262,7 @@ export function Status() {
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}
             className={cn(
-              "overflow-hidden px-1 pt-1.5 text-xs",
+              "overflow-hidden px-1 pt-1.5 text-og-control",
               controller.activeNotice.tone === "ok" ? "text-og-fg-muted" : "text-og-status-failed",
             )}
           >

--- a/packages/react/src/components/enrollment-device-flow.tsx
+++ b/packages/react/src/components/enrollment-device-flow.tsx
@@ -82,7 +82,7 @@ export function EnrollmentDeviceFlow({
           <span className="flex size-7 items-center justify-center rounded-full bg-og-surface-2 text-og-fg-muted">
             <LaptopIcon className="size-4" aria-hidden />
           </span>
-          <h2 className="text-sm font-semibold text-og-fg">Connect a machine</h2>
+          <h2 className="text-og-menu font-semibold text-og-fg">Connect a machine</h2>
         </div>
         <ConnectionStatusPill
           status={
@@ -156,7 +156,7 @@ export function EnrollmentDeviceFlow({
         target="_blank"
         rel="noreferrer"
         onClick={onOpenVerification}
-        className="inline-flex items-center justify-center gap-1.5 rounded-og-sm bg-og-accent px-3 py-2 text-sm font-medium text-og-accent-fg transition-colors hover:bg-og-accent-strong"
+        className="inline-flex items-center justify-center gap-1.5 rounded-og-sm bg-og-accent px-3 py-2 text-og-menu font-medium text-og-accent-fg transition-colors hover:bg-og-accent-strong"
       >
         Open approval page
         <ExternalLinkIcon className="size-3.5" aria-hidden />

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -1183,7 +1183,7 @@ export function MessageTimeline({
                     <div className="relative mx-auto flex w-full max-w-3xl flex-col gap-5">
                       {groups.length === 0
                         ? (emptyState ?? (
-                            <p className="py-10 text-center text-sm text-og-fg-subtle">
+                            <p className="py-10 text-center text-og-menu text-og-fg-subtle">
                               No activity yet.
                             </p>
                           ))
@@ -1270,7 +1270,7 @@ export function MessageTimeline({
                         className="absolute inset-x-0 top-3 z-10 flex justify-center gap-2"
                       >
                         {loadingOlder || loadingOldest ? (
-                          <span className="pointer-events-none inline-flex items-center rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1 text-xs font-medium shadow-og-md backdrop-blur">
+                          <span className="pointer-events-none inline-flex items-center rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1 text-og-control font-medium shadow-og-md backdrop-blur">
                             <span className="og-shimmer-text">
                               {loadingOldest ? "Jumping to start…" : "Loading earlier activity…"}
                             </span>
@@ -1317,7 +1317,7 @@ export function MessageTimeline({
                             }}
                             className={cn(
                               "inline-flex items-center gap-1.5 rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1.5",
-                              "text-xs font-medium text-og-fg shadow-og-md backdrop-blur",
+                              "text-og-control font-medium text-og-fg shadow-og-md backdrop-blur",
                               "hover:border-og-border-strong disabled:opacity-60",
                             )}
                           >
@@ -1339,7 +1339,7 @@ export function MessageTimeline({
                         aria-live="polite"
                         className="pointer-events-none absolute inset-x-0 bottom-14 z-10 flex justify-center"
                       >
-                        <span className="inline-flex items-center rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1 text-xs font-medium shadow-og-md backdrop-blur">
+                        <span className="inline-flex items-center rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1 text-og-control font-medium shadow-og-md backdrop-blur">
                           <span className="og-shimmer-text">Loading later activity…</span>
                         </span>
                       </motion.div>
@@ -1397,7 +1397,7 @@ export function MessageTimeline({
                         className={cn(
                           "absolute bottom-4 left-1/2 -translate-x-1/2",
                           "inline-flex items-center gap-1.5 rounded-full border border-og-border bg-og-surface-3/90 px-3 py-1.5",
-                          "text-xs font-medium text-og-fg shadow-og-md backdrop-blur",
+                          "text-og-control font-medium text-og-fg shadow-og-md backdrop-blur",
                           "hover:border-og-border-strong",
                         )}
                       >
@@ -1541,7 +1541,7 @@ class TimelineGroupRenderBoundary extends Component<
         <div
           data-testid="timeline-group-render-error"
           role="status"
-          className="flex items-start gap-2 rounded-lg border border-og-border bg-og-surface-muted px-3 py-2 text-sm text-og-fg-muted"
+          className="flex items-start gap-2 rounded-lg border border-og-border bg-og-surface-muted px-3 py-2 text-og-menu text-og-fg-muted"
         >
           <TriangleAlertIcon aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
           <div>
@@ -2505,12 +2505,12 @@ function MachineInputRow({ member }: { member: MachineInputBatchItem["members"][
     <div className="flex min-w-0 items-start gap-2.5">
       <span className="mt-2 size-1.5 shrink-0 rounded-full bg-og-fg-subtle" aria-hidden />
       <div className="min-w-0 flex-1">
-        <span className="text-xs font-medium text-og-fg-muted">
+        <span className="text-og-control font-medium text-og-fg-muted">
           {MACHINE_INPUT_META[member.kind]}
         </span>
-        {source && <span className="ml-1.5 text-xs text-og-fg-subtle">from {source}</span>}
+        {source && <span className="ml-1.5 text-og-control text-og-fg-subtle">from {source}</span>}
         {summary ? (
-          <p className="mt-0.5 whitespace-pre-wrap break-words text-sm leading-5 text-og-fg">
+          <p className="mt-0.5 whitespace-pre-wrap break-words text-og-menu leading-5 text-og-fg">
             {truncate(summary, 320)}
           </p>
         ) : null}
@@ -2531,7 +2531,7 @@ function NoticeRow({ item }: { item: NoticeItem }) {
     <div
       className={cn(
         enter && "animate-og-enter",
-        "flex items-start gap-2.5 rounded-og-md border px-3.5 py-2.5 text-sm",
+        "flex items-start gap-2.5 rounded-og-md border px-3.5 py-2.5 text-og-menu",
         tone,
       )}
       role="status"
@@ -2542,7 +2542,7 @@ function NoticeRow({ item }: { item: NoticeItem }) {
       <div className="min-w-0 flex-1">
         <span className="whitespace-pre-wrap break-words">{item.text}</span>
         {item.details ? (
-          <details className="mt-2 text-xs">
+          <details className="mt-2 text-og-control">
             <summary className="cursor-pointer font-medium">{item.details.label}</summary>
             <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-all rounded-og-sm bg-black/5 p-2 font-mono dark:bg-white/5">
               {JSON.stringify(item.details.value, null, 2)}
@@ -2552,7 +2552,7 @@ function NoticeRow({ item }: { item: NoticeItem }) {
       </div>
       {item.action ? (
         <a
-          className="shrink-0 rounded-og-sm border border-current/25 px-2 py-1 text-xs font-medium hover:bg-current/10"
+          className="shrink-0 rounded-og-sm border border-current/25 px-2 py-1 text-og-control font-medium hover:bg-current/10"
           href={item.action.url}
           rel="noreferrer"
           target="_blank"
@@ -2631,7 +2631,7 @@ function AuthNeededRow({
             onClick={() => void start()}
             disabled={busy}
             className={cn(
-              "inline-flex w-full shrink-0 items-center justify-center gap-1.5 rounded-og-md bg-og-accent px-3 py-1.5 text-sm font-medium text-og-accent-fg sm:w-auto",
+              "inline-flex w-full shrink-0 items-center justify-center gap-1.5 rounded-og-md bg-og-accent px-3 py-1.5 text-og-menu font-medium text-og-accent-fg sm:w-auto",
               "transition-colors hover:bg-og-accent-strong disabled:opacity-70 pointer-coarse:min-h-9",
             )}
           >
@@ -2644,7 +2644,7 @@ function AuthNeededRow({
             rel="noreferrer"
             target="_blank"
             className={cn(
-              "inline-flex w-full shrink-0 items-center justify-center gap-1.5 rounded-og-md bg-og-accent px-3 py-1.5 text-sm font-medium text-og-accent-fg sm:w-auto",
+              "inline-flex w-full shrink-0 items-center justify-center gap-1.5 rounded-og-md bg-og-accent px-3 py-1.5 text-og-menu font-medium text-og-accent-fg sm:w-auto",
               "transition-colors hover:bg-og-accent-strong pointer-coarse:min-h-9",
             )}
           >
@@ -2683,7 +2683,7 @@ function AuthProviderLogo({ src, label }: { src: string | null; label: string })
   const showImage = src && !failed;
   return (
     <span
-      className="relative flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-og-md border border-og-border bg-og-surface-2 text-sm font-semibold text-og-fg-muted"
+      className="relative flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-og-md border border-og-border bg-og-surface-2 text-og-menu font-semibold text-og-fg-muted"
       aria-hidden
     >
       {showImage ? (

--- a/packages/react/src/components/model-policy-picker.tsx
+++ b/packages/react/src/components/model-policy-picker.tsx
@@ -9,8 +9,17 @@ import {
 } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import { DropdownMenu } from "radix-ui";
-import { useEffect, useMemo, useState, type ReactNode, type SVGProps } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  type SVGProps,
+} from "react";
 import { cn } from "../lib/cn";
+import { usePortalTokenStyle } from "../lib/use-portal-token-style";
 import {
   coerceReasoningEffortForModel,
   effortOptionsForModel,
@@ -72,12 +81,21 @@ export type ModelPolicyPickerProps = {
   disabled?: boolean | undefined;
   loading?: boolean | undefined;
   error?: string | null | undefined;
+  /** Controlled menu state. Omit for the built-in uncontrolled behavior. */
+  open?: boolean | undefined;
+  /** Initial menu state when `open` is uncontrolled. */
+  defaultOpen?: boolean | undefined;
+  onOpenChange?: ((open: boolean) => void) | undefined;
   /** Non-Codex models stay visible but cannot be selected. */
   codexOnly?: boolean | undefined;
   /** Resets drill-down navigation when the session scope changes. */
   sessionKey?: string | undefined;
   /** Prefer bottom on new-chat surfaces and top for bottom-docked composers. */
   menuSide?: "top" | "bottom" | undefined;
+  /** Classes for the portalled menu surface. Prefer --og-* tokens for theming. */
+  contentClassName?: string | undefined;
+  /** Inline styles for the portalled menu, applied after inherited --og-* tokens. */
+  contentStyle?: CSSProperties | undefined;
   className?: string | undefined;
   messages?: Partial<ModelPolicyPickerMessages> | undefined;
   onModelChange: (modelId: string) => void;
@@ -225,17 +243,19 @@ export function PickerNavRow(props: {
       onClick={props.onClick}
       data-testid={props.testId}
       className={cn(
-        "flex w-full cursor-pointer items-center gap-2 rounded-og-sm px-2.5 py-2 text-left text-og-fg outline-none transition-colors hover:bg-og-surface-2 focus-visible:ring-2 focus-visible:ring-og-accent/40",
+        "flex w-full cursor-pointer items-center gap-2 rounded-og-sm px-[var(--og-model-picker-row-padding-x)] py-[var(--og-model-picker-row-padding-y)] text-left text-og-fg outline-none transition-colors hover:bg-og-surface-2 focus-visible:ring-2 focus-visible:ring-og-accent/40",
         props.disabled && "cursor-not-allowed opacity-50",
       )}
     >
       {props.icon}
       <span className="min-w-0 flex-1">
-        <span className={cn("block truncate text-sm", props.active && "font-medium")}>
+        <span className={cn("block truncate text-og-menu", props.active && "font-medium")}>
           {props.label}
         </span>
         {props.hint ? (
-          <span className="mt-0.5 block truncate text-xs text-og-fg-subtle">{props.hint}</span>
+          <span className="mt-0.5 block truncate text-og-control text-og-fg-subtle">
+            {props.hint}
+          </span>
         ) : null}
       </span>
       {props.trailing ? <span className="ml-auto shrink-0">{props.trailing}</span> : null}
@@ -262,7 +282,7 @@ export function PickerBackHeader(props: {
       >
         <ChevronLeftIcon className="size-3.5 shrink-0 text-og-fg-subtle" />
         {props.icon}
-        <span className="min-w-0 flex-1 truncate text-sm font-medium">{props.label}</span>
+        <span className="min-w-0 flex-1 truncate text-og-menu font-medium">{props.label}</span>
       </button>
       {props.trailing ? <div className="relative z-10 shrink-0">{props.trailing}</div> : null}
     </div>
@@ -352,9 +372,9 @@ export function ModelPolicyPickerMenu(
 
   let body: ReactNode;
   if (props.loading) {
-    body = <p className="px-2 py-3 text-xs text-og-fg-subtle">{messages.loading}</p>;
+    body = <p className="px-2 py-3 text-og-control text-og-fg-subtle">{messages.loading}</p>;
   } else if (groups.length === 0) {
-    body = <p className="px-2 py-3 text-xs text-og-fg-subtle">{messages.noModels}</p>;
+    body = <p className="px-2 py-3 text-og-control text-og-fg-subtle">{messages.noModels}</p>;
   } else if (effectiveNav.level === "providers") {
     body = (
       <div className="flex flex-col gap-0.5" data-testid="model-picker-providers">
@@ -449,11 +469,11 @@ export function ModelPolicyPickerMenu(
             ) : null
           }
         />
-        <p className="px-2.5 pt-1 pb-1 text-xs font-medium tracking-wide text-og-fg-subtle uppercase">
+        <p className="px-2.5 pt-1 pb-1 text-og-control font-medium tracking-wide text-og-fg-subtle uppercase">
           {messages.thinking}
         </p>
         {focusModel.catalog.capabilities?.inputModalities.includes("image") === false ? (
-          <p className="px-2.5 pb-1.5 text-xs leading-relaxed text-og-fg-subtle">
+          <p className="px-2.5 pb-1.5 text-og-control leading-relaxed text-og-fg-subtle">
             Unsupported attachments stay in the session but are hidden from this model.
           </p>
         ) : null}
@@ -467,7 +487,7 @@ export function ModelPolicyPickerMenu(
                 disabled={!focusModel.selectable}
                 onClick={() => selectEffort(focusModel, effort)}
                 className={cn(
-                  "flex h-8 w-full cursor-pointer items-center rounded-og-sm px-2.5 text-left text-sm text-og-fg outline-none transition-colors hover:bg-og-surface-2 focus-visible:ring-2 focus-visible:ring-og-accent/40 disabled:cursor-not-allowed disabled:opacity-50",
+                  "flex h-[var(--og-model-picker-effort-height)] w-full cursor-pointer items-center rounded-og-sm px-[var(--og-model-picker-row-padding-x)] text-left text-og-menu text-og-fg outline-none transition-colors hover:bg-og-surface-2 focus-visible:ring-2 focus-visible:ring-og-accent/40 disabled:cursor-not-allowed disabled:opacity-50",
                   selected && "bg-og-surface-2",
                 )}
               >
@@ -504,7 +524,7 @@ export function ModelPolicyPickerMenu(
   return (
     <div data-testid="model-picker-menu" className="relative overflow-hidden">
       {props.error ? (
-        <p className="px-2 py-1 text-xs text-og-status-failed" role="alert">
+        <p className="px-2 py-1 text-og-control text-og-status-failed" role="alert">
           {props.error}
         </p>
       ) : null}
@@ -516,7 +536,14 @@ export function ModelPolicyPickerMenu(
 }
 
 export function ModelPolicyPicker(props: ModelPolicyPickerProps) {
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(props.defaultOpen ?? false);
+  const open = props.open ?? uncontrolledOpen;
+  const setOpen = (next: boolean) => {
+    if (props.open === undefined) setUncontrolledOpen(next);
+    props.onOpenChange?.(next);
+  };
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const portalStyle = usePortalTokenStyle(triggerRef);
   const messages = useMemo(
     () => ({ ...defaultModelPolicyPickerMessages, ...props.messages }),
     [props.messages],
@@ -541,11 +568,12 @@ export function ModelPolicyPicker(props: ModelPolicyPickerProps) {
     <DropdownMenu.Root open={open} onOpenChange={setOpen}>
       <DropdownMenu.Trigger asChild>
         <button
+          ref={triggerRef}
           type="button"
           disabled={props.disabled}
           aria-label={messages.label}
           className={cn(
-            "inline-flex h-8 min-w-0 max-w-64 items-center gap-1 rounded-full border border-transparent px-2.5 text-xs text-og-fg-muted outline-none transition-colors hover:border-og-border hover:bg-og-surface-2 hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/40 disabled:cursor-not-allowed disabled:opacity-50 max-sm:h-7 max-sm:max-w-[7.5rem] max-sm:px-2",
+            "og-root inline-flex h-[var(--og-model-picker-trigger-height)] min-w-0 max-w-64 items-center gap-1 rounded-full border border-transparent px-2.5 text-og-control text-og-fg-muted outline-none transition-colors hover:border-og-border hover:bg-og-surface-2 hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/40 disabled:cursor-not-allowed disabled:opacity-50 max-sm:h-[var(--og-model-picker-trigger-height-mobile)] max-sm:max-w-[7.5rem] max-sm:px-2",
             props.className,
           )}
         >
@@ -580,7 +608,12 @@ export function ModelPolicyPicker(props: ModelPolicyPickerProps) {
           sideOffset={8}
           collisionPadding={12}
           onCloseAutoFocus={(event) => event.preventDefault()}
-          className="z-50 flex max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))] w-72 max-w-[calc(100vw-16px)] flex-col overflow-hidden rounded-og-lg border border-og-border bg-og-surface-1 p-1.5 text-og-fg shadow-og-lg"
+          className={cn(
+            "og-root z-50 flex max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))] w-[var(--og-model-picker-menu-width)] max-w-[calc(100vw-16px)] flex-col overflow-hidden rounded-og-lg border border-og-border bg-og-surface-1 p-[var(--og-model-picker-menu-padding)] text-og-fg shadow-og-lg",
+            props.contentClassName,
+          )}
+          style={{ ...portalStyle, ...props.contentStyle }}
+          data-testid="model-picker-content"
         >
           <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
             <ModelPolicyPickerMenu {...props} nav={nav} onNavChange={setNav} />

--- a/packages/react/src/components/queue-surface-implementation.tsx
+++ b/packages/react/src/components/queue-surface-implementation.tsx
@@ -40,6 +40,7 @@ import {
 import { DropdownMenu } from "radix-ui";
 import type { ComposerState } from "../hooks/use-composer";
 import type { QueueMutationKind, UseTurnQueueResult } from "../hooks/use-turn-queue";
+import { type PortalTokenStyle, usePortalTokenStyle } from "../lib/use-portal-token-style";
 import { requestQueueDraftEdit } from "./queue-draft-policy";
 import { QueueErrorAlert, QueueStoppingStatus } from "./queue-surface-state";
 
@@ -80,6 +81,7 @@ export function QueueSurface({
   const [announcement, setAnnouncement] = useState("");
   const [draggedTurnId, setDraggedTurnId] = useState<string | null>(null);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
+  const portalTokenStyle = usePortalTokenStyle(surfaceRef);
   const [keyboardDrag, setKeyboardDrag] = useState<{
     turnId: string;
     projectedIndex: number;
@@ -244,7 +246,7 @@ export function QueueSurface({
   return (
     <div
       ref={surfaceRef}
-      className="mx-auto mb-2 w-full max-w-3xl shrink-0 px-4 sm:px-6"
+      className="og-root mx-auto mb-2 w-full max-w-3xl shrink-0 px-4 sm:px-6"
       data-testid="queue-surface"
     >
       <div className="overflow-hidden rounded-lg border border-border bg-surface/80 shadow-sm">
@@ -265,7 +267,7 @@ export function QueueSurface({
             aria-hidden="true"
             className={`size-3.5 shrink-0 text-fg-subtle transition-transform ${open ? "rotate-180" : ""}`}
           />
-          <span className="text-xs font-medium text-fg">
+          <span className="text-og-control font-medium text-fg">
             {count > 0 ? `${count} queued prompt${count === 1 ? "" : "s"}` : null}
             {count > 0 && pendingInputCount > 0 ? " · " : null}
             {pendingInputCount > 0
@@ -273,7 +275,7 @@ export function QueueSurface({
               : null}
           </span>
           {readOnly ? (
-            <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-2xs text-fg-subtle">
+            <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-og-xs text-fg-subtle">
               Read-only
             </span>
           ) : null}
@@ -282,7 +284,7 @@ export function QueueSurface({
               aria-hidden="true"
               className={`max-w-full truncate text-fg-muted ${
                 collapsedPreview.collapsedVisual === collapsedPreview.summary
-                  ? "min-w-0 flex-1 text-xs"
+                  ? "min-w-0 flex-1 text-og-control"
                   : "shrink-0 text-[10px]"
               }`}
               data-testid="queue-collapsed-preview"
@@ -352,6 +354,7 @@ export function QueueSurface({
                     pending={queue.mutationFor(turn.id)}
                     confirmingReplace={replaceDraftFor === turn.id}
                     keyboardDragging={keyboardDrag?.turnId === turn.id}
+                    portalTokenStyle={portalTokenStyle}
                     onHandleKeyDown={(event) => onHandleKeyDown(event, turn.id)}
                     onMove={(nextIndex) => void moveToIndex(turn.id, nextIndex)}
                     onEdit={canEditInComposer ? () => requestEdit(turn) : undefined}
@@ -393,7 +396,7 @@ export function QueueSurface({
             <DragOverlay modifiers={[verticalOnly]}>
               {draggedTurnId ? (
                 <div
-                  className="max-h-20 w-[min(36rem,calc(100vw-2rem))] max-w-[calc(100vw-2rem)] overflow-hidden rounded-md border border-brand/40 bg-surface px-3 py-2 text-xs text-fg shadow-lg"
+                  className="max-h-20 w-[min(36rem,calc(100vw-2rem))] max-w-[calc(100vw-2rem)] overflow-hidden rounded-md border border-brand/40 bg-surface px-3 py-2 text-og-control text-fg shadow-lg"
                   data-testid="queue-drag-overlay"
                 >
                   <p
@@ -434,14 +437,18 @@ function PendingMachineInputs({
 }) {
   return (
     <section className="border-t border-border px-3 py-2">
-      <p className="text-2xs font-medium text-fg-subtle">
+      <p className="text-og-xs font-medium text-fg-subtle">
         {attached
           ? `${inputs.length} update${inputs.length === 1 ? "" : "s"} will join this prompt`
           : "Incoming updates waiting to run"}
       </p>
       <ol className="mt-1 space-y-1">
         {inputs.map((input) => (
-          <li key={input.id} className="line-clamp-3 break-words text-xs text-fg" dir="auto">
+          <li
+            key={input.id}
+            className="line-clamp-3 break-words text-og-control text-fg"
+            dir="auto"
+          >
             <strong className="capitalize text-fg-muted">
               {input.kind.replace("_terminal", "").replaceAll("_", " ")}
             </strong>{" "}
@@ -756,7 +763,7 @@ function QueuePrompt({
     <div className="w-full min-w-0 max-w-full">
       <div
         aria-label={`Queued prompt ${index + 1} summary: ${preview.summary}`}
-        className="max-w-full overflow-hidden text-xs leading-5 text-fg"
+        className="max-w-full overflow-hidden text-og-control leading-5 text-fg"
         data-testid={`queue-prompt-preview-${index + 1}`}
         dir="auto"
         role="note"
@@ -771,7 +778,7 @@ function QueuePrompt({
           </span>
           {preview.visibleIdentity && preview.visibleIdentityLabel ? (
             <span
-              className="flex min-w-0 max-w-[70%] shrink-0 items-center gap-1 text-2xs leading-4 text-fg-muted sm:mt-0.5 sm:max-w-full"
+              className="flex min-w-0 max-w-[70%] shrink-0 items-center gap-1 text-og-xs leading-4 text-fg-muted sm:mt-0.5 sm:max-w-full"
               data-testid={`queue-prompt-identity-row-${index + 1}`}
             >
               <span className="shrink-0 font-medium text-fg-subtle">
@@ -793,7 +800,7 @@ function QueuePrompt({
         aria-controls={fullContentId}
         aria-expanded={expanded}
         aria-label={`${expanded ? "Hide" : "Show"} full content for queued prompt ${index + 1}`}
-        className="mt-1 inline-flex min-h-7 min-w-0 max-w-full items-center gap-1 whitespace-normal rounded-md text-left text-2xs font-medium text-fg outline-none focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:min-h-[44px]"
+        className="mt-1 inline-flex min-h-7 min-w-0 max-w-full items-center gap-1 whitespace-normal rounded-md text-left text-og-xs font-medium text-fg outline-none focus-visible:ring-2 focus-visible:ring-ring/40 pointer-coarse:min-h-[44px]"
         data-testid={`queue-prompt-disclosure-${index + 1}`}
         onClick={() => {
           const next = !expanded;
@@ -812,7 +819,7 @@ function QueuePrompt({
           id={fullContentId}
           role="region"
           aria-label={`Full content for queued prompt ${index + 1}`}
-          className="mt-1.5 max-h-64 w-full min-w-0 max-w-full overflow-auto overscroll-contain rounded-md border border-border bg-surface-2/60 p-2 whitespace-pre-wrap break-all font-mono text-xs leading-5 text-fg [unicode-bidi:plaintext]"
+          className="mt-1.5 max-h-64 w-full min-w-0 max-w-full overflow-auto overscroll-contain rounded-md border border-border bg-surface-2/60 p-2 whitespace-pre-wrap break-all font-mono text-og-control leading-5 text-fg [unicode-bidi:plaintext]"
           data-testid={`queue-prompt-full-${index + 1}`}
           dir="auto"
           tabIndex={0}
@@ -837,13 +844,13 @@ function ReadOnlyQueueRow({
 }) {
   return (
     <li className="flex min-w-0 items-start gap-2 bg-surface px-3 py-2">
-      <span className="mt-1 shrink-0 font-mono text-2xs text-fg-subtle">{index + 1}</span>
+      <span className="mt-1 shrink-0 font-mono text-og-xs text-fg-subtle">{index + 1}</span>
       <div className="min-w-0 flex-1">
         <QueuePrompt prompt={turn.prompt} index={index} onDisclosureChange={onDisclosureChange} />
         {attachedInputs.length > 0 ? (
           <PendingMachineInputs inputs={attachedInputs} attached />
         ) : null}
-        <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap text-2xs text-fg-subtle">
+        <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap text-og-xs text-fg-subtle">
           {turn.resources.length > 0 ? (
             <span className="shrink-0">
               {turn.resources.length} resource{turn.resources.length === 1 ? "" : "s"}
@@ -870,6 +877,7 @@ function SortableQueueRow({
   pending,
   confirmingReplace,
   keyboardDragging,
+  portalTokenStyle,
   onHandleKeyDown,
   onMove,
   onEdit,
@@ -886,6 +894,7 @@ function SortableQueueRow({
   pending: QueueMutationKind | null;
   confirmingReplace: boolean;
   keyboardDragging: boolean;
+  portalTokenStyle: PortalTokenStyle;
   onHandleKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>) => void;
   onMove: (index: number) => void;
   onEdit?: (() => void) | undefined;
@@ -924,7 +933,7 @@ function SortableQueueRow({
         >
           <GripVerticalIcon className="size-3.5" />
         </button>
-        <span className="col-start-2 row-start-1 mt-1 shrink-0 font-mono text-2xs text-fg-subtle">
+        <span className="col-start-2 row-start-1 mt-1 shrink-0 font-mono text-og-xs text-fg-subtle">
           {index + 1}
         </span>
         <div className="col-span-full row-start-2 min-w-0 sm:col-span-1 sm:col-start-3 sm:row-start-1">
@@ -932,7 +941,7 @@ function SortableQueueRow({
           {attachedInputs.length > 0 ? (
             <PendingMachineInputs inputs={attachedInputs} attached />
           ) : null}
-          <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap text-2xs text-fg-subtle">
+          <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap text-og-xs text-fg-subtle">
             {turn.resources.length > 0 ? (
               <span className="shrink-0">
                 {turn.resources.length} resource{turn.resources.length === 1 ? "" : "s"}
@@ -954,7 +963,7 @@ function SortableQueueRow({
             onClick={onSteer}
             aria-label={`Steer queued prompt ${index + 1}`}
             title="Steer — interrupt the current turn and send this message now"
-            className="inline-flex h-7 shrink-0 items-center justify-center gap-1 rounded-md px-2 text-xs font-medium text-fg outline-none transition-[background-color] hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:min-h-[44px] pointer-coarse:min-w-[44px]"
+            className="inline-flex h-7 shrink-0 items-center justify-center gap-1 rounded-md px-2 text-og-control font-medium text-fg outline-none transition-[background-color] hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 pointer-coarse:min-h-[44px] pointer-coarse:min-w-[44px]"
           >
             {pending === "steer" ? (
               <Loader2Icon className="size-3.5 animate-spin" />
@@ -996,7 +1005,8 @@ function SortableQueueRow({
               <DropdownMenu.Content
                 align="end"
                 sideOffset={4}
-                className="z-50 w-48 max-w-[calc(100vw-16px)] rounded-md border border-border bg-surface p-1 text-xs text-fg shadow-lg"
+                className="og-root z-50 w-48 max-w-[calc(100vw-16px)] rounded-md border border-border bg-surface p-1 text-og-control text-fg shadow-lg"
+                style={portalTokenStyle}
                 data-testid={`queue-actions-menu-${index + 1}`}
               >
                 {onEdit ? (
@@ -1044,7 +1054,7 @@ function SortableQueueRow({
         </div>
       </div>
       {confirmingReplace ? (
-        <div className="mx-3 mb-2 rounded-md border border-status-waiting/30 bg-status-waiting/10 p-2 text-xs text-fg">
+        <div className="mx-3 mb-2 rounded-md border border-status-waiting/30 bg-status-waiting/10 p-2 text-og-control text-fg">
           <p>Your composer already has a draft. Replace it with this queued prompt?</p>
           <p className="mt-0.5 text-fg-muted">
             The current draft will be permanently discarded; this queued prompt is preserved until

--- a/packages/react/src/components/queue-surface-state.tsx
+++ b/packages/react/src/components/queue-surface-state.tsx
@@ -10,7 +10,7 @@ export function EmptyQueueStateSurface({ queue }: QueueStateProps) {
   const hasError = Boolean(queue.error || queue.mutationError);
   return (
     <div
-      className="mx-auto mb-2 w-full max-w-3xl shrink-0 px-4 sm:px-6"
+      className="og-root mx-auto mb-2 w-full max-w-3xl shrink-0 px-4 sm:px-6"
       data-testid="queue-surface"
     >
       <div className="overflow-hidden rounded-lg border border-border bg-surface/80 shadow-sm">
@@ -31,7 +31,7 @@ export function QueueStoppingStatus({
     <div
       role="status"
       aria-live="polite"
-      className={`flex min-h-11 items-center gap-2.5 bg-status-waiting/[0.07] px-3 py-2 text-xs text-fg ${
+      className={`flex min-h-11 items-center gap-2.5 bg-status-waiting/[0.07] px-3 py-2 text-og-control text-fg ${
         dividerAfter ? "border-b border-status-waiting/20" : ""
       }`}
       data-testid="stopping-previous-attempt"
@@ -64,7 +64,7 @@ export function QueueErrorAlert({
     <div className={`${dividerBefore ? "border-t border-border" : ""} p-2`}>
       <div
         role="alert"
-        className="flex min-w-0 max-w-full flex-wrap items-start gap-2 rounded-md bg-status-failed/10 px-2 py-1.5 text-xs text-status-failed"
+        className="flex min-w-0 max-w-full flex-wrap items-start gap-2 rounded-md bg-status-failed/10 px-2 py-1.5 text-og-control text-status-failed"
       >
         <span
           role="region"

--- a/packages/react/src/components/queue-surface.tsx
+++ b/packages/react/src/components/queue-surface.tsx
@@ -43,12 +43,12 @@ function QueueSurfaceFallback() {
   return (
     <div
       aria-live="polite"
-      className="mx-auto mb-2 w-full max-w-3xl shrink-0 px-4 sm:px-6"
+      className="og-root mx-auto mb-2 w-full max-w-3xl shrink-0 px-4 sm:px-6"
       data-testid="queue-surface-loading"
       role="status"
     >
       <div className="overflow-hidden rounded-lg border border-border bg-surface/80 shadow-sm">
-        <div className="flex items-center gap-2 px-3 py-2 text-xs text-fg-muted pointer-coarse:min-h-[44px]">
+        <div className="flex items-center gap-2 px-3 py-2 text-og-control text-fg-muted pointer-coarse:min-h-[44px]">
           <Loader2Icon
             aria-hidden="true"
             className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none"

--- a/packages/react/src/components/session-status.tsx
+++ b/packages/react/src/components/session-status.tsx
@@ -77,7 +77,7 @@ export function SessionStatus({ status, label, size = "md", className }: Session
       data-status={status}
       className={cn(
         "og-root inline-flex shrink-0 items-center rounded-full border font-medium",
-        size === "sm" ? "gap-1 px-1.5 py-px text-og-xs" : "gap-1.5 px-2 py-0.5 text-xs",
+        size === "sm" ? "gap-1 px-1.5 py-px text-og-xs" : "gap-1.5 px-2 py-0.5 text-og-control",
         meta.badgeClassName,
         className,
       )}

--- a/packages/react/src/lib/cn.ts
+++ b/packages/react/src/lib/cn.ts
@@ -15,7 +15,20 @@ import { extendTailwindMerge } from "tailwind-merge";
 const twMerge = extendTailwindMerge({
   extend: {
     classGroups: {
-      "font-size": [{ text: ["og-xs", "og-sm", "og-base", "og-md"] }],
+      "font-size": [
+        {
+          text: [
+            "og-xs",
+            "og-sm",
+            "og-base",
+            "og-md",
+            "og-control",
+            "og-menu",
+            "og-composer",
+            "og-composer-wide",
+          ],
+        },
+      ],
     },
   },
 });

--- a/packages/react/src/lib/use-portal-token-style.ts
+++ b/packages/react/src/lib/use-portal-token-style.ts
@@ -34,7 +34,7 @@ export function usePortalTokenStyle(sourceRef: RefObject<HTMLElement | null>): P
       const observer = new MutationObserver(sync);
       observer.observe(ancestor, {
         attributes: true,
-        attributeFilter: ["class", "data-og-theme", "style"],
+        attributeFilter: ["class", "data-og-density", "data-og-theme", "style"],
       });
       observers.push(observer);
       ancestor = ancestor.parentElement;

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -152,17 +152,17 @@ function ApiContractMismatchScreen({ mismatch }: { mismatch: OpenGeniApiContract
       data-opengeni-api-contract-mismatch
     >
       <div className="w-full max-w-md rounded-xl border border-og-border bg-og-surface p-6 shadow-2xl">
-        <p className="text-sm font-semibold text-og-fg">OpenGeni updated</p>
-        <p className="mt-2 text-sm leading-6 text-og-muted">
+        <p className="text-og-menu font-semibold text-og-fg">OpenGeni updated</p>
+        <p className="mt-2 text-og-menu leading-6 text-og-muted">
           This tab cannot safely continue with the new server version. Reload it before sending or
           controlling work.
         </p>
-        <p className="mt-3 font-mono text-xs text-og-subtle">
+        <p className="mt-3 font-mono text-og-control text-og-subtle">
           Client {mismatch.expected} · API {mismatch.actual}
         </p>
         <button
           type="button"
-          className="mt-5 inline-flex h-9 items-center rounded-md bg-og-fg px-3 text-sm font-medium text-og-bg"
+          className="mt-5 inline-flex h-9 items-center rounded-md bg-og-fg px-3 text-og-menu font-medium text-og-bg"
           onClick={() => window.location.reload()}
         >
           Reload now

--- a/packages/react/src/realtime/dropdown-menu.tsx
+++ b/packages/react/src/realtime/dropdown-menu.tsx
@@ -2,31 +2,69 @@
 
 import { ChevronRightIcon } from "lucide-react";
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
-import type { ComponentProps } from "react";
+import {
+  createContext,
+  useContext,
+  useRef,
+  type ComponentProps,
+  type Ref,
+  type RefObject,
+} from "react";
 import { cn } from "../lib/cn";
+import { usePortalTokenStyle } from "../lib/use-portal-token-style";
 
-function DropdownMenu(props: ComponentProps<typeof DropdownMenuPrimitive.Root>) {
-  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+const DropdownMenuSourceContext = createContext<RefObject<HTMLElement | null> | null>(null);
+
+function assignRef<T>(ref: Ref<T> | undefined, value: T | null) {
+  if (typeof ref === "function") ref(value);
+  else if (ref) ref.current = value;
 }
 
-function DropdownMenuTrigger(props: ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
-  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+function DropdownMenu(props: ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  const sourceRef = useRef<HTMLElement | null>(null);
+  return (
+    <DropdownMenuSourceContext.Provider value={sourceRef}>
+      <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+    </DropdownMenuSourceContext.Provider>
+  );
+}
+
+function DropdownMenuTrigger({
+  ref,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  const sourceRef = useContext(DropdownMenuSourceContext);
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      ref={(node) => {
+        if (sourceRef) sourceRef.current = node;
+        assignRef(ref, node);
+      }}
+      {...props}
+    />
+  );
 }
 
 function DropdownMenuContent({
   className,
   sideOffset = 4,
+  style,
   ...props
 }: ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  const sourceRef = useContext(DropdownMenuSourceContext);
+  const fallbackRef = useRef<HTMLElement | null>(null);
+  const portalStyle = usePortalTokenStyle(sourceRef ?? fallbackRef);
   return (
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "og-root z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className,
         )}
+        style={{ ...portalStyle, ...style }}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
@@ -48,7 +86,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-og-menu outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
         className,
       )}
       {...props}
@@ -84,7 +122,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-og-menu outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className,
       )}
       {...props}
@@ -97,15 +135,20 @@ function DropdownMenuSubTrigger({
 
 function DropdownMenuSubContent({
   className,
+  style,
   ...props
 }: ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  const sourceRef = useContext(DropdownMenuSourceContext);
+  const fallbackRef = useRef<HTMLElement | null>(null);
+  const portalStyle = usePortalTokenStyle(sourceRef ?? fallbackRef);
   return (
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        "og-root z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         className,
       )}
+      style={{ ...portalStyle, ...style }}
       {...props}
     />
   );

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -866,8 +866,8 @@ export function RealtimeVoiceModelPanel(props: {
       <div className="flex shrink-0 items-start gap-1 px-2 pt-1 pb-1.5">
         {props.leading}
         <div className="min-w-0">
-          <div className="text-sm font-medium text-og-fg">Voice model</div>
-          <p className="mt-0.5 text-xs text-og-fg-subtle">
+          <div className="text-og-menu font-medium text-og-fg">Voice model</div>
+          <p className="mt-0.5 text-og-control text-og-fg-subtle">
             Used when you start a voice conversation.
           </p>
         </div>

--- a/packages/react/styles/index.css
+++ b/packages/react/styles/index.css
@@ -25,17 +25,26 @@
   --font-sans: var(--og-font-sans);
   --font-mono: var(--og-font-mono);
 
-  /* Type ramp — a real 4-step scale (no half-pixel hand-tuning). Every
-     timeline string maps to one of these via `text-og-{xs,sm,base,md}`;
-     mono reuses the same steps. */
-  --text-og-xs: 11px;
-  --text-og-xs--line-height: 1.45;
-  --text-og-sm: 12px;
-  --text-og-sm--line-height: 1.5;
-  --text-og-base: 13px;
-  --text-og-base--line-height: 1.55;
-  --text-og-md: 15px;
-  --text-og-md--line-height: 1.6;
+  /* Type ramp. Runtime values live in tokens.css so an embedder can tune the
+     complete SDK subtree without rebuilding Tailwind. The control/menu tokens
+     preserve Tailwind's historic xs/sm metrics without leaking through or
+     mutating the host application's own `text-xs` / `text-sm` utilities. */
+  --text-og-xs: var(--og-font-size-xs);
+  --text-og-xs--line-height: var(--og-line-height-xs);
+  --text-og-sm: var(--og-font-size-sm);
+  --text-og-sm--line-height: var(--og-line-height-sm);
+  --text-og-base: var(--og-font-size-base);
+  --text-og-base--line-height: var(--og-line-height-base);
+  --text-og-md: var(--og-font-size-md);
+  --text-og-md--line-height: var(--og-line-height-md);
+  --text-og-control: var(--og-font-size-control);
+  --text-og-control--line-height: var(--og-line-height-control);
+  --text-og-menu: var(--og-font-size-menu);
+  --text-og-menu--line-height: var(--og-line-height-menu);
+  --text-og-composer: var(--og-font-size-composer);
+  --text-og-composer--line-height: var(--og-line-height-composer);
+  --text-og-composer-wide: var(--og-font-size-composer-wide);
+  --text-og-composer-wide--line-height: var(--og-line-height-composer-wide);
   --text-2xs: 0.6875rem;
   --text-2xs--line-height: 1rem;
 
@@ -149,6 +158,52 @@
   /* Stream end fallback breath when View Transitions are unavailable. */
   --animate-og-markdown-settle: og-markdown-settle var(--og-duration-markdown-crystallize)
     var(--og-ease-stream) both;
+}
+
+/* Typography utilities also publish their effective metrics as private
+   component variables. A host reset such as `.app button { font: inherit }`
+   otherwise beats a one-class Tailwind utility on specificity and silently
+   inflates embedded controls. The scoped guard below reads these variables at
+   higher specificity, while responsive variants can still replace them and
+   public --og-* tokens remain the only customization surface. */
+@utility text-og-xs {
+  --og-component-font-size: var(--og-font-size-xs);
+  --og-component-line-height: var(--og-line-height-xs);
+}
+
+@utility text-og-sm {
+  --og-component-font-size: var(--og-font-size-sm);
+  --og-component-line-height: var(--og-line-height-sm);
+}
+
+@utility text-og-base {
+  --og-component-font-size: var(--og-font-size-base);
+  --og-component-line-height: var(--og-line-height-base);
+}
+
+@utility text-og-md {
+  --og-component-font-size: var(--og-font-size-md);
+  --og-component-line-height: var(--og-line-height-md);
+}
+
+@utility text-og-control {
+  --og-component-font-size: var(--og-font-size-control);
+  --og-component-line-height: var(--og-line-height-control);
+}
+
+@utility text-og-menu {
+  --og-component-font-size: var(--og-font-size-menu);
+  --og-component-line-height: var(--og-line-height-menu);
+}
+
+@utility text-og-composer {
+  --og-component-font-size: var(--og-font-size-composer);
+  --og-component-line-height: var(--og-line-height-composer);
+}
+
+@utility text-og-composer-wide {
+  --og-component-font-size: var(--og-font-size-composer-wide);
+  --og-component-line-height: var(--og-line-height-composer-wide);
 }
 
 /* Radix Collapsible disclosure: height auto-animates via the content var. Used
@@ -358,6 +413,31 @@
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   color: var(--og-color-fg);
+}
+
+:is(.og-root.og-root, .og-root .og-root)
+  :where(
+    .text-og-xs,
+    .text-og-sm,
+    .text-og-base,
+    .text-og-md,
+    .text-og-control,
+    .text-og-menu,
+    .text-og-composer,
+    .text-og-composer-wide
+  ),
+:is(
+  .og-root.text-og-xs,
+  .og-root.text-og-sm,
+  .og-root.text-og-base,
+  .og-root.text-og-md,
+  .og-root.text-og-control,
+  .og-root.text-og-menu,
+  .og-root.text-og-composer,
+  .og-root.text-og-composer-wide
+) {
+  font-size: var(--og-component-font-size);
+  line-height: var(--tw-leading, var(--og-component-line-height));
 }
 
 .og-root :where(*) {

--- a/packages/react/styles/tokens.css
+++ b/packages/react/styles/tokens.css
@@ -17,8 +17,39 @@
   --og-font-sans: "Inter Variable", "Inter", "Noto Sans JP Variable", "Noto Sans Arabic Variable", ui-sans-serif, system-ui, sans-serif;
   --og-font-mono: "JetBrains Mono Variable", "JetBrains Mono", "Noto Sans JP Variable", "Noto Sans Arabic Variable", ui-monospace, SFMono-Regular, Menlo, monospace;
   --og-font-features: "cv11", "ss01", "ss03";
+  /* Runtime type tokens. Defaults are the exact values used by apps/web, so
+     adopting the public token surface is render-compatible with the product.
+     Hosts can override these on any SDK ancestor; portalled surfaces copy the
+     effective --og-* values from their trigger. */
+  --og-font-size-xs: 11px;
+  --og-line-height-xs: 1.45;
+  --og-font-size-sm: 12px;
+  --og-line-height-sm: 1.5;
+  --og-font-size-base: 13px;
+  --og-line-height-base: 1.55;
+  --og-font-size-md: 15px;
+  --og-line-height-md: 1.6;
+  --og-font-size-control: 12px;
+  --og-line-height-control: 16px;
+  --og-font-size-menu: 14px;
+  --og-line-height-menu: 20px;
+  --og-font-size-composer: 16px;
+  --og-line-height-composer: 24px;
+  --og-font-size-composer-wide: 15px;
+  --og-line-height-composer-wide: 24px;
   --og-code-font-size: 12px;
   --og-code-line-height: 18px;
+
+  /* Model-policy picker density. These defaults preserve today's apps/web
+     geometry. They are tokens (rather than host-only class overrides) so an
+     embedded composer and its portalled menu can be tuned as one surface. */
+  --og-model-picker-trigger-height: 2rem;
+  --og-model-picker-trigger-height-mobile: 1.75rem;
+  --og-model-picker-menu-width: 18rem;
+  --og-model-picker-menu-padding: 0.375rem;
+  --og-model-picker-row-padding-x: 0.625rem;
+  --og-model-picker-row-padding-y: 0.5rem;
+  --og-model-picker-effort-height: 2rem;
 
   /* Radius ----------------------------------------------------------------- */
   --og-radius-xs: 4px;
@@ -117,6 +148,36 @@
   --og-session-chrome-row-hover: color-mix(in oklch, var(--og-color-surface-3) 55%, transparent);
 
   color-scheme: dark;
+}
+
+/* One supported dense preset for embedded product panels. It changes only
+   typography and model-picker density; colors, radii, and brand tokens remain
+   independently customizable. Apply either form to an SDK ancestor. */
+[data-og-density="compact"],
+.og-density-compact {
+  --og-font-size-xs: 10px;
+  --og-line-height-xs: 1.5;
+  --og-font-size-sm: 11px;
+  --og-line-height-sm: 1.5;
+  --og-font-size-base: 12px;
+  --og-line-height-base: 1.55;
+  --og-font-size-md: 13px;
+  --og-line-height-md: 1.6;
+  --og-font-size-control: 11px;
+  --og-line-height-control: 16px;
+  --og-font-size-menu: 12px;
+  --og-line-height-menu: 18px;
+  --og-font-size-composer: 13px;
+  --og-line-height-composer: 20px;
+  --og-font-size-composer-wide: 13px;
+  --og-line-height-composer-wide: 20px;
+  --og-model-picker-trigger-height: 1.75rem;
+  --og-model-picker-trigger-height-mobile: 1.75rem;
+  --og-model-picker-menu-width: 15rem;
+  --og-model-picker-menu-padding: 0.25rem;
+  --og-model-picker-row-padding-x: 0.5rem;
+  --og-model-picker-row-padding-y: 0.375rem;
+  --og-model-picker-effort-height: 1.75rem;
 }
 
 /* Light theme — explicit opt-in, themable per subtree ----------------------- */

--- a/packages/react/test/typography-tokens.test.ts
+++ b/packages/react/test/typography-tokens.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import { cn } from "../src/lib/cn";
+
+const tokens = await Bun.file(`${import.meta.dir}/../styles/tokens.css`).text();
+const styles = await Bun.file(`${import.meta.dir}/../styles/index.css`).text();
+
+describe("public typography token contract", () => {
+  test("keeps apps/web's current default metrics", () => {
+    for (const declaration of [
+      "--og-font-size-xs: 11px",
+      "--og-line-height-xs: 1.45",
+      "--og-font-size-sm: 12px",
+      "--og-line-height-sm: 1.5",
+      "--og-font-size-base: 13px",
+      "--og-line-height-base: 1.55",
+      "--og-font-size-md: 15px",
+      "--og-line-height-md: 1.6",
+      "--og-font-size-control: 12px",
+      "--og-line-height-control: 16px",
+      "--og-font-size-menu: 14px",
+      "--og-line-height-menu: 20px",
+      "--og-font-size-composer: 16px",
+      "--og-line-height-composer: 24px",
+      "--og-font-size-composer-wide: 15px",
+      "--og-line-height-composer-wide: 24px",
+      "--og-model-picker-trigger-height: 2rem",
+      "--og-model-picker-menu-width: 18rem",
+      "--og-model-picker-row-padding-x: 0.625rem",
+      "--og-model-picker-row-padding-y: 0.5rem",
+    ]) {
+      expect(tokens).toContain(declaration);
+    }
+  });
+
+  test("maps every SDK typography utility to runtime variables", () => {
+    for (const name of ["xs", "sm", "base", "md", "control", "menu", "composer", "composer-wide"]) {
+      expect(styles).toContain(`--text-og-${name}: var(--og-font-size-${name})`);
+      expect(styles).toContain(`--text-og-${name}--line-height: var(--og-line-height-${name})`);
+      expect(styles).toContain(`@utility text-og-${name}`);
+      expect(styles).toContain(`--og-component-font-size: var(--og-font-size-${name})`);
+      expect(styles).toContain(`--og-component-line-height: var(--og-line-height-${name})`);
+    }
+  });
+
+  test("shields SDK typography from higher-specificity host font resets", () => {
+    expect(styles).toContain(":is(.og-root.og-root, .og-root .og-root)");
+    expect(styles).toContain("font-size: var(--og-component-font-size)");
+    expect(styles).toContain("line-height: var(--tw-leading, var(--og-component-line-height))");
+    expect(styles).not.toContain("font-size: var(--og-component-font-size) !important");
+  });
+
+  test("keeps font-size and color utilities together after class merging", () => {
+    expect(cn("text-og-menu", "text-og-fg-muted")).toBe("text-og-menu text-og-fg-muted");
+    expect(cn("text-og-composer-wide", "text-og-fg")).toBe("text-og-composer-wide text-og-fg");
+  });
+
+  test("ships a compact preset without changing brand tokens", () => {
+    const compact = tokens.slice(
+      tokens.indexOf('[data-og-density="compact"]'),
+      tokens.indexOf("/* Light theme"),
+    );
+    expect(compact).toContain("--og-font-size-menu: 12px");
+    expect(compact).toContain("--og-font-size-composer-wide: 13px");
+    expect(compact).toContain("--og-model-picker-menu-width: 15rem");
+    expect(compact).not.toContain("--og-color-accent:");
+  });
+});


### PR DESCRIPTION
## Summary
- move SDK typography and model-picker density to runtime `--og-*` tokens while preserving `apps/web` defaults
- protect component type metrics from host font resets and propagate scoped tokens across model/realtime/queue portals
- opt Northstar into the supported compact preset and remove demo-only font hacks

## Verification
- 44 focused React tests + package typecheck
- full monorepo typecheck
- package/app/demo production builds
- publish closure guard + packed external-consumer test
- local browser: composer 13/20, trigger 11/16, menu 12/18, portal theme/density preserved

Local aggregate hygiene sees only pre-existing untracked `tmp/`; CI checkout is unaffected. The macOS unit aggregate also hits the known GNU `tar --sort=name` platform test; all change-focused tests and Linux CI own the authoritative run.