### PR TITLE
fix(analytics): disable PostHog GeoIP enrichment

### DIFF
--- a/apps/web/src/lib/analytics.test.ts
+++ b/apps/web/src/lib/analytics.test.ts
@@ -237,6 +237,34 @@ describe("analytics providers", () => {
       captureAnalyticsEvent("workspace_created", { workspace_id: "workspace-1" });
       await new Promise((resolve) => setTimeout(resolve, 0));
 
+      const initCall = calls.find(([method]) => method === "init");
+      const beforeSend = (
+        initCall?.[2] as {
+          before_send?: (
+            event: {
+              uuid: string;
+              event: string;
+              properties: Record<string, unknown>;
+            } | null,
+          ) => {
+            uuid: string;
+            event: string;
+            properties: Record<string, unknown>;
+          } | null;
+        }
+      )?.before_send;
+      expect(
+        beforeSend?.({
+          uuid: "event-1",
+          event: "session_started",
+          properties: { session_id: "session-1" },
+        }),
+      ).toEqual({
+        uuid: "event-1",
+        event: "session_started",
+        properties: { session_id: "session-1", $geoip_disable: true },
+      });
+      expect(beforeSend?.(null)).toBeNull();
       expect(calls).toContainEqual(["identify", "user-1"]);
       expect(calls).toContainEqual(["group", "account", "account-1"]);
       expect(calls).toContainEqual([

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -185,6 +185,15 @@ async function initializePostHog(projectKey: string, host: string): Promise<void
   posthog.init(projectKey, {
     api_host: host,
     autocapture: false,
+    // PostHog can derive GeoIP properties before its project-level IP discard runs.
+    // Disable that enrichment at the event boundary as well.
+    before_send: (event) =>
+      event
+        ? {
+            ...event,
+            properties: { ...event.properties, $geoip_disable: true },
+          }
+        : null,
     capture_pageview: false,
     capture_pageleave: false,
     disable_session_recording: true,


### PR DESCRIPTION
## What
- stamp `$geoip_disable: true` onto every PostHog event in the centralized `before_send` hook
- verify transformed events and null passthrough

PostHog's project-level IP discard prevents IP storage but can still enrich events before discard. This disables enrichment at capture time too.

## Verification
- `bun test apps/web/src/lib/analytics.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run --cwd apps/web build`

Full local suite: relevant tests pass; one unrelated existing macOS portability failure in `scripts/package-release-chart.test.ts` because BSD tar lacks `--sort=name`. Protected Linux CI remains authoritative.