### PR TITLE
chore(release): bump product version to 0.22.68

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.67
-appVersion: "0.22.67"
+version: 0.22.68
+appVersion: "0.22.68"


### PR DESCRIPTION
## Summary
- bump the OpenGeni product/Helm release version to 0.22.68
- provide a fresh governed release head on current main

## Verification
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `bun test scripts/release-version.test.ts scripts/check-release-pr-automation.test.ts`
- `git diff --check`