### PR TITLE
fix(demo): preserve Northstar control typography

### DIFF
--- a/.changeset/northstar-reset-scope.md
+++ b/.changeset/northstar-reset-scope.md
@@ -1,4 +1,5 @@
 ---
+"@opengeni/react": patch
 ---
 
 Keep the Northstar demo's host font reset contained to embedded OpenGeni surfaces.

--- a/.changeset/northstar-reset-scope.md
+++ b/.changeset/northstar-reset-scope.md
@@ -1,0 +1,4 @@
+---
+---
+
+Keep the Northstar demo's host font reset contained to embedded OpenGeni surfaces.

--- a/examples/northstar-support/src/styles.css
+++ b/examples/northstar-support/src/styles.css
@@ -42,10 +42,13 @@ body {
   scrollbar-color: rgba(45, 48, 60, 0.15) transparent;
 }
 
-.northstar button,
-.northstar select,
-.northstar input,
-.northstar textarea {
+/* Keep a deliberately hostile host reset around the embedded SDK so this demo
+   exercises its isolation contract without flattening Northstar's own control
+   typography. SDK consumers customize these metrics through public --og-* tokens. */
+.northstar .og-root button,
+.northstar .og-root select,
+.northstar .og-root input,
+.northstar .og-root textarea {
   font: inherit;
 }
 

--- a/examples/northstar-support/src/styles.test.ts
+++ b/examples/northstar-support/src/styles.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+
+const styles = await Bun.file(`${import.meta.dir}/styles.css`).text();
+
+describe("Northstar host typography", () => {
+  test("limits the hostile font reset to embedded OpenGeni surfaces", () => {
+    const resetSelectors = styles.match(/([^{}]+)\{\s*font:\s*inherit;\s*\}/)?.[1];
+    expect(resetSelectors).toBeDefined();
+
+    for (const control of ["button", "select", "input", "textarea"]) {
+      expect(resetSelectors).toContain(`.northstar .og-root ${control}`);
+      expect(resetSelectors).not.toMatch(new RegExp(`\\.northstar ${control}(?:,|$)`));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- scope the demo host font reset to embedded OpenGeni surfaces
- preserve Northstar product controls’ intended Tailwind typography
- add a regression test for reset containment

## Verification
- `bun test examples/northstar-support/src/styles.test.ts packages/react/test/typography-tokens.test.ts`
- `bun run typecheck` in `examples/northstar-support`
- `bun run build` in `examples/northstar-support`
- `git diff --check`