### PR TITLE
chore(release): bump chart to 0.22.69

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.68
-appVersion: "0.22.68"
+version: 0.22.69
+appVersion: "0.22.69"


### PR DESCRIPTION
## Summary
- reserve immutable product release 0.22.69 for the React 0.44.5 distribution
- keep chart version and appVersion aligned

## Verification
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `helm lint deploy/helm/opengeni`
- confirmed API and chart 0.22.69 aliases are unoccupied
- `git diff --check`