### PR TITLE
fix(demo): preserve embedded SDK typography

### DIFF
--- a/examples/northstar-support/src/styles.css
+++ b/examples/northstar-support/src/styles.css
@@ -44,11 +44,12 @@ body {
 
 /* Keep a deliberately hostile host reset around the embedded SDK so this demo
    exercises its isolation contract without flattening Northstar's own control
-   typography. SDK consumers customize these metrics through public --og-* tokens. */
-.northstar .og-root button,
-.northstar .og-root select,
-.northstar .og-root input,
-.northstar .og-root textarea {
+   typography. :where() scopes the reset without making it stronger than the
+   SDK's semantic typography guard. Consumers customize metrics via --og-* tokens. */
+.northstar :where(.og-root) button,
+.northstar :where(.og-root) select,
+.northstar :where(.og-root) input,
+.northstar :where(.og-root) textarea {
   font: inherit;
 }
 

--- a/examples/northstar-support/src/styles.test.ts
+++ b/examples/northstar-support/src/styles.test.ts
@@ -8,8 +8,12 @@ describe("Northstar host typography", () => {
     expect(resetSelectors).toBeDefined();
 
     for (const control of ["button", "select", "input", "textarea"]) {
-      expect(resetSelectors).toContain(`.northstar .og-root ${control}`);
+      expect(resetSelectors).toContain(`.northstar :where(.og-root) ${control}`);
       expect(resetSelectors).not.toMatch(new RegExp(`\\.northstar ${control}(?:,|$)`));
     }
+  });
+
+  test("keeps the host reset below the SDK typography guard's specificity", () => {
+    expect(styles).not.toMatch(/\.northstar \.og-root (?:button|select|input|textarea)/);
   });
 });


### PR DESCRIPTION
## Summary
- keep the Northstar reset scoped to embedded OpenGeni controls
- lower only the scoping selector specificity with `:where()` so the SDK semantic typography guard wins
- retain the host-reset regression and assert it cannot drift back to a stronger selector

## Verification
- `bun test ./examples/northstar-support/src/styles.test.ts`
- `bun test ./packages/react/test/typography-tokens.test.ts`
- Northstar `bun run typecheck`
- Northstar `bun run build`
- formatting and `git diff --check`

This does not change SDK tokens or apps/web defaults; it corrects the demo host reset that was overriding the already-released compact SDK metrics.