### PR TITLE
chore(release): bump product version to 0.22.70

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.69
-appVersion: "0.22.69"
+version: 0.22.70
+appVersion: "0.22.70"


### PR DESCRIPTION
## Summary
- reserve immutable product release 0.22.70 for the current versioned source
- keep chart version and appVersion aligned

## Verification
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `helm lint deploy/helm/opengeni`
- `git diff --check`