### PR TITLE
chore(release): bump product version to 0.22.71

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.70
-appVersion: "0.22.70"
+version: 0.22.71
+appVersion: "0.22.71"


### PR DESCRIPTION
Advance the immutable product release identity for the current protected main snapshot.