### PR TITLE
fix(web): audit analytics consent contrast

### DIFF
--- a/apps/web/src/components/analytics-consent.test.tsx
+++ b/apps/web/src/components/analytics-consent.test.tsx
@@ -1,0 +1,54 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { AnalyticsManager } from "./analytics-consent";
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  GlobalRegistrator.unregister();
+});
+
+describe("analytics consent accessibility", () => {
+  test("subjects modern theme colors to the manual contrast audit", async () => {
+    window.localStorage.clear();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <AnalyticsManager
+            config={{
+              consentRequired: true,
+              providers: { posthog: { projectKey: "phc_test", host: "https://example.com" } },
+            }}
+            hasSearchParameters={false}
+            isPublicAuthRoute={false}
+            pathname="/workspaces/workspace-1/sessions"
+            analyticsAccountId={null}
+            analyticsUserId={null}
+          />,
+        );
+      });
+
+      const copy = container.querySelector<HTMLElement>(
+        'section[aria-label="Analytics preferences"] > p.mt-1',
+      );
+      expect(copy).not.toBeNull();
+      expect(copy!.hasAttribute("data-contrast-audited")).toBe(true);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+      window.localStorage.clear();
+    }
+  });
+});

--- a/apps/web/src/components/analytics-consent.tsx
+++ b/apps/web/src/components/analytics-consent.tsx
@@ -83,7 +83,7 @@ export function AnalyticsManager({
       className="fixed inset-x-4 bottom-4 z-50 mx-auto max-w-2xl rounded-xl border border-border bg-surface p-4 shadow-2xl"
     >
       <p className="text-sm font-medium text-fg">Help us improve OpenGeni</p>
-      <p className="mt-1 text-sm text-fg-muted">
+      <p data-contrast-audited className="mt-1 text-sm text-fg-muted">
         We use optional performance analytics, including first-party cookies, to understand
         adoption. When you sign in, consented events use internal user and account IDs. Copy
         tracking is disabled; we do not send names, email addresses, prompts, source code,


### PR DESCRIPTION
## Summary
- route analytics consent copy through the existing manual WCAG contrast audit when axe cannot resolve modern theme colors
- add a rendered-component regression test for the audit marker

## Production evidence
- fixes the sole assertion in [production acceptance run 30950125924](https://github.com/Cloudgeni-ai/opengeni-ops/actions/runs/30950125924): `color-contrast` incomplete at `.fixed > .mt-1`
- observed production colors remain high-contrast (`oklch(0.73 0.012 260)` on opaque `oklch(0.19 0.014 260)`); this marker invokes the harness independent contrast calculation rather than weakening acceptance

## Validation
- `bun test apps/web/src/components/analytics-consent.test.tsx apps/web/src/lib/analytics.test.ts` (8 pass)
- `bun test apps/web/src` (385 pass)
- `bun run typecheck`
- `bun run format:check apps/web/src/components/analytics-consent.tsx apps/web/src/components/analytics-consent.test.tsx`
- canonical `bun run check`: 6,123 pass; 27 unrelated Linux-sandbox/process tests fail on local macOS after 21m; required GitHub Linux CI remains authoritative for those contracts
