### PR TITLE
chore(release): bump product version to 0.22.72

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.71
-appVersion: "0.22.71"
+version: 0.22.72
+appVersion: "0.22.72"


### PR DESCRIPTION
Advance the immutable product release identity for the current protected main snapshot containing the analytics consent accessibility fix.