### PR TITLE
test(web): isolate analytics consent accessibility state

### DIFF
--- a/apps/web/src/components/analytics-consent.test.tsx
+++ b/apps/web/src/components/analytics-consent.test.tsx
@@ -3,6 +3,8 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 
+import { openAnalyticsPreferences } from "@/lib/analytics-consent";
+
 import { AnalyticsManager } from "./analytics-consent";
 
 beforeAll(() => {
@@ -19,6 +21,7 @@ afterAll(() => {
 describe("analytics consent accessibility", () => {
   test("subjects modern theme colors to the manual contrast audit", async () => {
     window.localStorage.clear();
+    window.localStorage.setItem("opengeni.analyticsConsent", "denied");
     const container = document.createElement("div");
     document.body.append(container);
     const root = createRoot(container);
@@ -39,6 +42,7 @@ describe("analytics consent accessibility", () => {
           />,
         );
       });
+      await act(async () => openAnalyticsPreferences());
 
       const copy = container.querySelector<HTMLElement>(
         'section[aria-label="Analytics preferences"] > p.mt-1',


### PR DESCRIPTION
## Summary
- make the analytics consent accessibility test independent of consent state left by earlier files
- seed denied consent only in the test window storage, open preferences through the public event, and clean storage afterward

## Evidence
- fixes the sole failure in [protected main CI 30955908823](https://github.com/Cloudgeni-ai/opengeni/actions/runs/30955908823)
- `bun test apps/web/src/components/analytics-consent.test.tsx apps/web/src/lib/analytics.test.ts` (8 pass)
- `bun run format:check apps/web/src/components/analytics-consent.test.tsx`
- `bun run typecheck`
