### PR TITLE
chore(agent): bump agent workspace version to 0.1.9

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1599,7 +1599,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opengeni-agent"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-macos-ffi"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "block2",
  "dispatch2",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-platform"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "command-group",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-proto"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "prost",
  "prost-build",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-stream"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-update"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "blake3",
  "hex",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-relay"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "axum",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 # we lean on clippy::pedantic at the workspace level and silence only the few
 # lints that fight generated code or add no value here.
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"


### PR DESCRIPTION
Release v0.1.9 of the independently versioned OpenGeni Connected Machine agent.

This release makes the already-merged service-environment repair available as a signed agent binary: service definitions preserve the installer command PATH, so non-login commands can resolve the machine’s normal tools instead of inheriting a minimal service-manager PATH. It also includes the other agent changes merged since v0.1.8.

Validation:
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --release --workspace`

After merge, an immutable `agent-v0.1.9` tag will trigger the signed cross-platform Agent Release workflow. Stable-channel defaults will be promoted only after those assets exist.