### PR TITLE
chore(agent): promote stable agent to 0.1.9

### DIFF
--- a/.changeset/calm-machines-move.md
+++ b/.changeset/calm-machines-move.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/config": patch
+---
+
+Promote the default stable Connected Machine agent release to 0.1.9.

--- a/.env.example
+++ b/.env.example
@@ -89,7 +89,7 @@ OPENGENI_USAGE_LIMITS_MODE=none
 # Public agent archive and explicit stable-channel promotion pointer. The stable
 # version must already exist as an `agent-v<version>` release.
 # OPENGENI_AGENT_RELEASES_BASE_URL=https://github.com/Cloudgeni-ai/opengeni/releases
-# OPENGENI_AGENT_STABLE_VERSION=0.1.8
+# OPENGENI_AGENT_STABLE_VERSION=0.1.9
 # OPENGENI_DELEGATION_SECRET=replace-with-long-random-token-signing-secret
 # OPENGENI_STATIC_ENTITLEMENTS_JSON='{"feature_key":true}'
 # OPENGENI_STATIC_USAGE_LIMITS_JSON='{"maxWorkspacesPerAccount":1,"maxMonthlyAgentRunsPerWorkspace":100}'

--- a/apps/api/test/install.test.ts
+++ b/apps/api/test/install.test.ts
@@ -105,7 +105,7 @@ describe("get.<domain> install routes", () => {
     );
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(
-      "https://github.com/Cloudgeni-ai/opengeni/releases/download/agent-v0.1.8/opengeni-agent-universal-apple-darwin",
+      "https://github.com/Cloudgeni-ai/opengeni/releases/download/agent-v0.1.9/opengeni-agent-universal-apple-darwin",
     );
   });
 
@@ -213,7 +213,7 @@ describe("get.<domain> install routes — baked binary serving", () => {
     );
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toContain(
-      "/releases/download/agent-v0.1.8/opengeni-agent-universal-apple-darwin",
+      "/releases/download/agent-v0.1.9/opengeni-agent-universal-apple-darwin",
     );
   });
 });

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1237,7 +1237,7 @@ for other OS/arch assets and the self-update channel. Route these paths (and an
 optional `get.<domain>` host) to the `api` service in the ingress.
 
 `/agent/latest/<asset>` is a compatibility route backed by the immutable
-versioned release selected by `OPENGENI_AGENT_STABLE_VERSION` (default `0.1.8`).
+versioned release selected by `OPENGENI_AGENT_STABLE_VERSION` (default `0.1.9`).
 `OPENGENI_AGENT_RELEASES_BASE_URL` selects the archive origin. Promote or roll
 back the stable channel by changing the configured version only after the
 corresponding `agent-v<version>` release and its signed assets exist; never move

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -249,7 +249,7 @@ const SettingsSchema = z.object({
   agentStableVersion: z
     .string()
     .regex(/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u)
-    .default("0.1.8"),
+    .default("0.1.9"),
   productAccessMode: ProductAccessMode.default("local"),
   billingMode: BillingMode.default("disabled"),
   entitlementsMode: EntitlementsMode.default("none"),

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -171,7 +171,7 @@ describe("Docker workspace materialization", () => {
 
 describe("agent stable release selection", () => {
   test("uses an exact stable version and supports an explicit operator promotion", () => {
-    expect(withEnv({}, () => getSettings()).agentStableVersion).toBe("0.1.8");
+    expect(withEnv({}, () => getSettings()).agentStableVersion).toBe("0.1.9");
     expect(
       withEnv({ OPENGENI_AGENT_STABLE_VERSION: "1.4.2" }, () => getSettings()).agentStableVersion,
     ).toBe("1.4.2");

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -42,7 +42,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     authAllowMetrics: false,
     publicBaseUrl: "http://127.0.0.1:3000",
     agentReleasesBaseUrl: "https://github.com/Cloudgeni-ai/opengeni/releases",
-    agentStableVersion: "0.1.8",
+    agentStableVersion: "0.1.9",
     productAccessMode: "local",
     billingMode: "disabled",
     entitlementsMode: "none",


### PR DESCRIPTION
Promote the default Connected Machine stable channel to the immutable, signed `agent-v0.1.9` release.

The release was built successfully across Linux, macOS, and Windows. The published Linux assets, `SHA256SUMS`, and their minisign signatures were independently verified; the matching AArch64 binary reports `opengeni-agent 0.1.9`.

This updates the config default, example environment, deployment documentation, test settings, and install-route expectations.

Validation:
- `bun test packages/config/test/config.test.ts apps/api/test/install.test.ts`
- `bunx tsc -p packages/config/tsconfig.json --noEmit`
- `bunx changeset status`
- `git diff --check`