### PR TITLE
chore(release): bump product version to 0.22.73

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.72
-appVersion: "0.22.72"
+version: 0.22.73
+appVersion: "0.22.73"


### PR DESCRIPTION
## Summary
- bump Helm chart and app version to 0.22.73
- issue a fresh release identity after the 0.22.72 main test failure was repaired

## Verification
- exact two-line version-only diff
- previous repair merge passed the full monolithic main CI suite (run 30957812632)