### PR TITLE
fix(release): wait for live file tree readiness

### DIFF
--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -138,6 +138,7 @@ describe("workbench live acceptance preflight", () => {
       isVisible: async () => false,
     };
     const tree = {
+      waitFor: async () => {},
       focus: async () => {},
       press: async (key: string) => {
         presses.push(key);
@@ -163,6 +164,7 @@ describe("workbench live acceptance preflight", () => {
         const index = Number(selector.match(/tree-item-(\d+)/)?.[1]);
         return {
           waitFor: async () => {},
+          textContent: async () => rows[index] ?? null,
           getAttribute: async (name: string) => {
             if (name === "aria-level") return rows[index] === "api" ? "1" : "2";
             if (name === "aria-expanded") return rows[index] === "api" ? "true" : null;
@@ -187,6 +189,7 @@ describe("workbench live acceptance preflight", () => {
     let expanded = false;
     const rows = ["README.md", "api", "base.txt"];
     const tree = {
+      waitFor: async () => {},
       focus: async () => {},
       press: async (key: string) => {
         presses.push(key);
@@ -215,6 +218,7 @@ describe("workbench live acceptance preflight", () => {
         const index = Number(selector.match(/tree-item-(\d+)/)?.[1]);
         return {
           waitFor: async () => {},
+          textContent: async () => rows[index] ?? null,
           getAttribute: async (name: string) => {
             if (name === "aria-level") return rows[index] === "base.txt" ? "2" : "1";
             if (name === "aria-expanded") {
@@ -233,6 +237,218 @@ describe("workbench live acceptance preflight", () => {
     await selectTreeFile(page, "api", "base.txt");
 
     expect(presses).toEqual(["Home", "ArrowDown", "ArrowRight", "ArrowDown", "Enter"]);
+  });
+
+  test("waits for a cold virtualized tree to expose an active descendant", async () => {
+    const presses: string[] = [];
+    let active = 0;
+    let hydrated = false;
+    let readinessWaits = 0;
+    const rows = ["api", "server.ts"];
+    const tree = {
+      waitFor: async (options: { state?: string; timeout?: number }) => {
+        expect(options).toEqual({ state: "visible", timeout: 20_000 });
+      },
+      focus: async () => {},
+      press: async (key: string) => {
+        presses.push(key);
+        if (key === "Home" && hydrated) active = 0;
+        if (key === "ArrowDown") active = Math.min(active + 1, rows.length - 1);
+      },
+      getAttribute: async (name: string) => {
+        expect(name).toBe("aria-activedescendant");
+        return hydrated ? `tree-item-${active}` : null;
+      },
+    };
+    const page = {
+      getByRole(role: string) {
+        if (role === "tree") return { first: () => tree };
+        expect(role).toBe("treeitem");
+        return {
+          filter: () => ({
+            first: () => ({
+              isVisible: async () => false,
+            }),
+          }),
+        };
+      },
+      locator(selector: string) {
+        if (selector === '[role="tree"][aria-activedescendant]:not([aria-activedescendant=""])') {
+          return {
+            first: () => ({
+              waitFor: async (options: { state?: string; timeout?: number }) => {
+                expect(options).toEqual({ state: "visible", timeout: 20_000 });
+                readinessWaits += 1;
+                hydrated = true;
+              },
+            }),
+          };
+        }
+        const index = Number(selector.match(/tree-item-(\d+)/)?.[1]);
+        return {
+          waitFor: async () => {},
+          textContent: async () => rows[index] ?? null,
+          getAttribute: async (name: string) => {
+            if (name === "aria-level") return rows[index] === "api" ? "1" : "2";
+            if (name === "aria-expanded") return rows[index] === "api" ? "true" : null;
+            throw new Error(`unexpected attribute ${name}`);
+          },
+          getByText(text: string, options: { exact: boolean }) {
+            expect(options).toEqual({ exact: true });
+            return { count: async () => (rows[index] === text ? 1 : 0) };
+          },
+        };
+      },
+    } as never;
+
+    await selectTreeFile(page, "api", "server.ts");
+
+    expect(readinessWaits).toBe(1);
+    expect(presses).toEqual(["Home", "Home", "ArrowDown", "Enter"]);
+  });
+
+  test("waits for an expanded lazy directory to finish hydrating its children", async () => {
+    const presses: string[] = [];
+    let active = 0;
+    let expanded = false;
+    let busy = false;
+    let loaded = false;
+    let hydrationWaits = 0;
+    const rows = () => (loaded ? ["api", "server.ts"] : ["api"]);
+    const tree = {
+      waitFor: async () => {},
+      focus: async () => {},
+      press: async (key: string) => {
+        presses.push(key);
+        if (key === "Home") active = 0;
+        if (key === "ArrowRight") {
+          expanded = true;
+          busy = true;
+        }
+        if (key === "ArrowDown") active = Math.min(active + 1, rows().length - 1);
+      },
+      getAttribute: async (name: string) => {
+        expect(name).toBe("aria-activedescendant");
+        return `tree-item-${active}`;
+      },
+    };
+    const page = {
+      getByRole(role: string) {
+        if (role === "tree") return { first: () => tree };
+        expect(role).toBe("treeitem");
+        return {
+          filter: () => ({
+            first: () => ({
+              isVisible: async () => false,
+            }),
+          }),
+        };
+      },
+      locator(selector: string) {
+        if (selector === '[id="tree-item-0"][aria-expanded="true"]:not([aria-busy="true"])') {
+          return {
+            waitFor: async (options: { state?: string; timeout?: number }) => {
+              expect(options).toEqual({ state: "visible", timeout: 20_000 });
+              expect(expanded).toBe(true);
+              expect(busy).toBe(true);
+              hydrationWaits += 1;
+              busy = false;
+              loaded = true;
+            },
+          };
+        }
+        const index = Number(selector.match(/tree-item-(\d+)/)?.[1]);
+        return {
+          waitFor: async () => {},
+          textContent: async () => rows()[index] ?? null,
+          getAttribute: async (name: string) => {
+            if (name === "aria-level") return rows()[index] === "api" ? "1" : "2";
+            if (name === "aria-expanded") return rows()[index] === "api" ? String(expanded) : null;
+            if (name === "aria-busy") return rows()[index] === "api" ? String(busy) : null;
+            throw new Error(`unexpected attribute ${name}`);
+          },
+          getByText(text: string, options: { exact: boolean }) {
+            expect(options).toEqual({ exact: true });
+            return { count: async () => (rows()[index] === text ? 1 : 0) };
+          },
+        };
+      },
+    } as never;
+
+    await selectTreeFile(page, "api", "server.ts");
+
+    expect(hydrationWaits).toBe(1);
+    expect(presses).toEqual(["Home", "ArrowRight", "ArrowDown", "Enter"]);
+  });
+
+  test("reports bounded tree observations when a target directory is absent", async () => {
+    const presses: string[] = [];
+    let active = 0;
+    const rows = Array.from(
+      { length: 10 },
+      (_, index) => `root-${String(index).padStart(2, "0")}-${"x".repeat(120)}`,
+    );
+    const tree = {
+      waitFor: async () => {},
+      focus: async () => {},
+      press: async (key: string) => {
+        presses.push(key);
+        if (key === "Home") active = 0;
+        if (key === "ArrowDown") active = Math.min(active + 1, rows.length - 1);
+      },
+      getAttribute: async (name: string) => {
+        expect(name).toBe("aria-activedescendant");
+        return `tree-item-${active}`;
+      },
+    };
+    const page = {
+      getByRole(role: string) {
+        if (role === "tree") return { first: () => tree };
+        expect(role).toBe("treeitem");
+        return {
+          filter: () => ({
+            first: () => ({
+              isVisible: async () => false,
+            }),
+          }),
+        };
+      },
+      locator(selector: string) {
+        const index = Number(selector.match(/tree-item-(\d+)/)?.[1]);
+        return {
+          waitFor: async () => {},
+          textContent: async () => rows[index] ?? null,
+          getAttribute: async (name: string) => {
+            if (name === "aria-level") return "1";
+            if (name === "aria-expanded") return "false";
+            throw new Error(`unexpected attribute ${name}`);
+          },
+          getByText(text: string, options: { exact: boolean }) {
+            expect(options).toEqual({ exact: true });
+            return { count: async () => (rows[index] === text ? 1 : 0) };
+          },
+        };
+      },
+    } as never;
+
+    let failure: unknown;
+    try {
+      await selectTreeFile(page, "api", "server.ts");
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain(
+      "file tree could not select api/server.ts: navigation stalled at the tree boundary",
+    );
+    expect((failure as Error).message).not.toContain("root-00");
+    expect((failure as Error).message).not.toContain("root-01");
+    expect((failure as Error).message).toContain('"label":"root-02-');
+    expect((failure as Error).message).toContain('"label":"root-09-');
+    expect((failure as Error).message).toContain('"level":1');
+    expect(presses).toEqual(["Home", ...Array.from({ length: 10 }, () => "ArrowDown")]);
+    expect((failure as Error).message.length).toBeLessThan(2_000);
   });
 
   test("accepts repository evidence from the compact changed-file picker", async () => {

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -12,7 +12,7 @@ import {
   type WorkspaceCaptureManifest,
 } from "@opengeni/sdk";
 import { assertScreenshotPainted } from "@opengeni/testing";
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
 
 import { NUMERIC_PERFORMANCE_BUDGETS } from "./workbench-acceptance-contract";
 
@@ -39,6 +39,11 @@ const OPTIONAL_ANALYTICS_CHUNK_PATH = /^\/assets\/analytics-consent-[A-Za-z0-9_-
 const MANAGED_SESSION_PATH = /^\/v1\/auth\/get-session$/;
 const WORKSPACE_SURFACE_SELECTOR = "[data-workspace-surface]";
 const CHANGES_LAYOUT_SELECTOR = "[data-workbench-changes-layout]";
+const FILE_TREE_READY_SELECTOR =
+  '[role="tree"][aria-activedescendant]:not([aria-activedescendant=""])';
+const FILE_TREE_MAX_NAVIGATION_STEPS = 4_096;
+const FILE_TREE_MAX_DIAGNOSTIC_ROWS = 8;
+const FILE_TREE_DIAGNOSTIC_FIELD_LENGTH = 80;
 const CAPTURE_API_P95_MS = maximumMillisecondBudget("performance.capture-api-response", "p95");
 const CAPTURE_USABLE_WORKBENCH_P95_MS = maximumMillisecondBudget(
   "performance.capture-usable-workbench",
@@ -2094,6 +2099,69 @@ async function selectChangesTab(page: Page): Promise<void> {
   });
 }
 
+type FileTreeObservation = {
+  id: string;
+  label: string;
+  level: number | null;
+  expanded: boolean | null;
+};
+
+function normalizeFileTreeLabel(value: string | null): string {
+  return (value ?? "").replace(/\s+/g, " ").trim().slice(0, FILE_TREE_DIAGNOSTIC_FIELD_LENGTH);
+}
+
+async function readActiveFileTreeItem(
+  page: Page,
+  tree: Locator,
+): Promise<{ activeId: string; item: Locator; observation: FileTreeObservation } | undefined> {
+  const activeId = await tree.getAttribute("aria-activedescendant");
+  if (!activeId) return undefined;
+
+  const item = page.locator(`[id=${JSON.stringify(activeId)}]`);
+  await item.waitFor({ state: "visible", timeout: 2_000 });
+  const rawLevel = await item.getAttribute("aria-level");
+  const level = Number(rawLevel);
+  const rawExpanded = await item.getAttribute("aria-expanded");
+  return {
+    activeId,
+    item,
+    observation: {
+      id: activeId.slice(0, FILE_TREE_DIAGNOSTIC_FIELD_LENGTH),
+      label: normalizeFileTreeLabel(await item.textContent()),
+      level: Number.isInteger(level) && level >= 1 ? level : null,
+      expanded: rawExpanded === null ? null : rawExpanded === "true",
+    },
+  };
+}
+
+function rememberFileTreeObservation(
+  observations: FileTreeObservation[],
+  observation: FileTreeObservation,
+): void {
+  const previous = observations[observations.length - 1];
+  if (
+    previous?.id === observation.id &&
+    previous.label === observation.label &&
+    previous.level === observation.level &&
+    previous.expanded === observation.expanded
+  ) {
+    return;
+  }
+  observations.push(observation);
+  if (observations.length > FILE_TREE_MAX_DIAGNOSTIC_ROWS) observations.shift();
+}
+
+function fileTreeSelectionError(
+  directory: string,
+  file: string,
+  reason: string,
+  observations: readonly FileTreeObservation[],
+): Error {
+  return new Error(
+    `file tree could not select ${directory}/${file}: ${reason}; observations=${JSON.stringify(observations)}`,
+  );
+}
+
 export async function selectTreeFile(page: Page, directory: string, file: string): Promise<void> {
   const directoryItem = page.getByRole("treeitem").filter({ hasText: directory }).first();
   const directoryVisible = await directoryItem.isVisible();
@@ -2113,52 +2181,124 @@ export async function selectTreeFile(page: Page, directory: string, file: string
   }
 
   const tree = page.getByRole("tree").first();
+  await tree.waitFor({ state: "visible", timeout: 20_000 });
   await tree.focus();
   await tree.press("Home");
 
+  if (!(await tree.getAttribute("aria-activedescendant"))) {
+    // A cold Files tab can mount the composite before its async capture rows
+    // hydrate. Wait on the ARIA readiness contract rather than sleeping or
+    // assuming the first virtual row already exists.
+    await page.locator(FILE_TREE_READY_SELECTOR).first().waitFor({
+      state: "visible",
+      timeout: 20_000,
+    });
+    await tree.focus();
+    await tree.press("Home");
+  }
+
+  const observations: FileTreeObservation[] = [];
   let directoryLevel: number | undefined;
-  for (let index = 0; index < 4_096; index += 1) {
-    const activeId = await tree.getAttribute("aria-activedescendant");
-    if (!activeId) throw new Error("file tree has no active descendant");
-    const activeItem = page.locator(`[id=${JSON.stringify(activeId)}]`);
-    await activeItem.waitFor({ state: "visible", timeout: 2_000 });
-    if ((await activeItem.getByText(directory, { exact: true }).count()) > 0) {
-      const rawLevel = await activeItem.getAttribute("aria-level");
-      directoryLevel = Number(rawLevel);
-      if (!Number.isInteger(directoryLevel) || directoryLevel < 1) {
-        throw new Error(`file tree directory ${directory} has no valid aria-level`);
-      }
-      if ((await activeItem.getAttribute("aria-expanded")) !== "true") {
-        await tree.press("ArrowRight");
-      }
-      await tree.press("ArrowDown");
+  let directoryFailureReason = `directory traversal exceeded ${FILE_TREE_MAX_NAVIGATION_STEPS} steps`;
+  for (let index = 0; index < FILE_TREE_MAX_NAVIGATION_STEPS; index += 1) {
+    const active = await readActiveFileTreeItem(page, tree);
+    if (!active) {
+      directoryFailureReason = "the tree lost its active descendant during directory traversal";
       break;
     }
+    rememberFileTreeObservation(observations, active.observation);
+    if ((await active.item.getByText(directory, { exact: true }).count()) > 0) {
+      if (active.observation.level === null) {
+        throw fileTreeSelectionError(
+          directory,
+          file,
+          `directory ${directory} has no valid aria-level`,
+          observations,
+        );
+      }
+      directoryLevel = active.observation.level;
+      if (active.observation.expanded !== true) {
+        await tree.press("ArrowRight");
+      }
+      await page
+        .locator(
+          `[id=${JSON.stringify(active.activeId)}][aria-expanded="true"]:not([aria-busy="true"])`,
+        )
+        .waitFor({ state: "visible", timeout: 20_000 });
+      await tree.press("ArrowDown");
+      const childId = await tree.getAttribute("aria-activedescendant");
+      if (!childId) {
+        throw fileTreeSelectionError(
+          directory,
+          file,
+          `directory ${directory} lost the active descendant after expansion`,
+          observations,
+        );
+      }
+      if (childId === active.activeId) {
+        throw fileTreeSelectionError(
+          directory,
+          file,
+          `directory ${directory} exposed no navigable child after expansion`,
+          observations,
+        );
+      }
+      break;
+    }
+
     await tree.press("ArrowDown");
+    const nextActiveId = await tree.getAttribute("aria-activedescendant");
+    if (!nextActiveId) {
+      directoryFailureReason = "the tree lost its active descendant during directory traversal";
+      break;
+    }
+    if (nextActiveId === active.activeId) {
+      directoryFailureReason = "navigation stalled at the tree boundary";
+      break;
+    }
   }
 
   if (directoryLevel === undefined) {
-    throw new Error(`file tree did not expose directory ${directory}`);
+    throw fileTreeSelectionError(directory, file, directoryFailureReason, observations);
   }
 
-  for (let index = 0; index < 4_096; index += 1) {
-    const activeId = await tree.getAttribute("aria-activedescendant");
-    if (!activeId) throw new Error("file tree has no active descendant");
-    const activeItem = page.locator(`[id=${JSON.stringify(activeId)}]`);
-    await activeItem.waitFor({ state: "visible", timeout: 2_000 });
-    const rawLevel = await activeItem.getAttribute("aria-level");
-    const activeLevel = Number(rawLevel);
-    if (!Number.isInteger(activeLevel) || activeLevel < 1) {
-      throw new Error("file tree item has no valid aria-level");
+  let fileFailureReason = `file traversal exceeded ${FILE_TREE_MAX_NAVIGATION_STEPS} steps`;
+  for (let index = 0; index < FILE_TREE_MAX_NAVIGATION_STEPS; index += 1) {
+    const active = await readActiveFileTreeItem(page, tree);
+    if (!active) {
+      fileFailureReason = "the tree lost its active descendant during file traversal";
+      break;
     }
-    if (activeLevel <= directoryLevel) break;
-    if ((await activeItem.getByText(file, { exact: true }).count()) > 0) {
+    rememberFileTreeObservation(observations, active.observation);
+    if (active.observation.level === null) {
+      throw fileTreeSelectionError(
+        directory,
+        file,
+        `tree item ${active.observation.id} has no valid aria-level`,
+        observations,
+      );
+    }
+    if (active.observation.level <= directoryLevel) {
+      fileFailureReason = `navigation left the ${directory} subtree`;
+      break;
+    }
+    if ((await active.item.getByText(file, { exact: true }).count()) > 0) {
       await tree.press("Enter");
       return;
     }
+
     await tree.press("ArrowDown");
+    const nextActiveId = await tree.getAttribute("aria-activedescendant");
+    if (!nextActiveId) {
+      fileFailureReason = "the tree lost its active descendant during file traversal";
+      break;
+    }
+    if (nextActiveId === active.activeId) {
+      fileFailureReason = `navigation stalled inside the ${directory} subtree`;
+      break;
+    }
   }
-  throw new Error(`file tree did not expose ${directory}/${file}`);
+  throw fileTreeSelectionError(directory, file, fileFailureReason, observations);
 }
 
 async function assertColdReview(page: Page, marker: string): Promise<void> {


### PR DESCRIPTION
## Summary
- wait for the cold virtualized Files tree to expose its semantic `aria-activedescendant` readiness contract before keyboard traversal
- stop traversal deterministically at composite keyboard boundaries instead of spinning through all 4,096 steps
- attach capped row id/label/level/expanded observations to genuine missing-target failures

## Root cause and scope
Release 0.22.65 source `7761ef809098cc9c63a760b4c4095c49e0fc3fc8` reached production, but official acceptance run `30923569078` failed during cold review before selecting `api/server.ts`. The earlier virtualized-root correction in #1035 removed the mounted-row assumption; this follow-up covers the remaining cold hydration window and makes real absence failures actionable.

This PR is harness-only. It does **not** rerun release 0.22.65, redispatch its candidate, or mutate sealed ops ledger `Cloudgeni-ai/opengeni-ops#329`. OPE-25 remains In Progress until a later release passes production/live acceptance.

## Verification
- `bun test scripts/workbench-live-acceptance.test.ts --timeout=30000` (23 pass)
- `bun test packages/react/test/file-browser-virtualization.test.tsx --timeout=30000` (5 pass)
- `bun run typecheck` (23 projects clean)
- `bun x oxlint --deny-warnings scripts/workbench-live-acceptance.ts scripts/workbench-live-acceptance.test.ts`
- `bun x oxfmt --check scripts/workbench-live-acceptance.ts scripts/workbench-live-acceptance.test.ts`
- real Playwright Chromium smoke: delayed root hydration + busy lazy-child hydration + one mounted virtual row selected `api/server.ts`

Linear: OPE-25