### PR TITLE
feat(react): collapse long sent user messages

### DIFF
--- a/.changeset/calm-user-messages-fold.md
+++ b/.changeset/calm-user-messages-fold.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": minor
+---
+
+Add a lossless `UserMessageBody` disclosure for very tall sent messages, including per-message expansion memory and timeline-owned scroll anchoring.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,9 @@ jobs:
         id: queue_surface_browser
         run: bun scripts/run-browser-e2e.ts ./test/e2e/queue-surface.browser.e2e.ts
 
+      - name: Long user-message disclosure browser acceptance
+        run: bun scripts/run-browser-e2e.ts ./test/e2e/user-message-disclosure.browser.e2e.ts
+
       - name: Public realtime SDK demo browser acceptance
         env:
           OPENGENI_REALTIME_DEMO_EVIDENCE_DIR: /tmp/opengeni-realtime-demo-evidence

--- a/apps/web/src/components/session/banners.tsx
+++ b/apps/web/src/components/session/banners.tsx
@@ -9,7 +9,11 @@ import {
   AudioLinesIcon,
   TerminalIcon,
 } from "lucide-react";
-import { useLightboxOptional, type UserMessageItem } from "@opengeni/react";
+import {
+  UserMessageBody as CollapsibleUserMessageBody,
+  useLightboxOptional,
+  type UserMessageItem,
+} from "@opengeni/react";
 import { Link } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -298,7 +302,9 @@ export function UserMessageBody({
         </div>
       ) : null}
 
-      <MarkdownText text={item.text} compact />
+      <CollapsibleUserMessageBody messageId={item.id} text={item.text}>
+        <MarkdownText text={item.text} compact />
+      </CollapsibleUserMessageBody>
 
       {item.presentation ? (
         <details className="group mt-2 border-t border-border/60 pt-1.5 text-xs text-fg-muted">

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -412,6 +412,9 @@ intentional changes should regenerate those snapshots and review the diff.
   "jump to latest" affordance, streaming caret, collapsible activity clusters,
   and worker cards (wire `onOpenSession` to drill into a worker). Pass
   `renderMessageText` to plug a markdown renderer.
+- `UserMessageBody` — the shared lossless rendered-height disclosure for
+  already-sent user text. Use it inside a custom `renderMessageText` user branch
+  so attachments and voice identity remain outside the clipped Markdown region.
 - `SessionStatus` / `StatusDot` — status badges; live states breathe.
 - `FleetTile` — one session in a fleet grid: title, status, model, recency.
 - `ModelPicker` — a compact model dropdown for a composer slot, grouping the

--- a/packages/react/demo/user-message-test-harness.tsx
+++ b/packages/react/demo/user-message-test-harness.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+
+import {
+  Markdown,
+  MessageTimeline,
+  UserMessageBody,
+  type TimelineItem,
+  type UserMessageItem,
+} from "@opengeni/react";
+import "./styles.css";
+
+type UserMessageHarness = {
+  prepend: () => void;
+  stream: () => void;
+  scroller: () => HTMLElement;
+};
+
+declare global {
+  interface Window {
+    userMessageHarness?: UserMessageHarness;
+  }
+}
+
+const LONG_MESSAGE = [
+  "# Launch review notes",
+  "",
+  "This already-sent prompt is intentionally long and must remain completely available. ".repeat(
+    10,
+  ),
+  "",
+  "## Acceptance list",
+  "",
+  "- Preserve every Markdown paragraph and embedded newline.",
+  "- Keep attachments and voice identity outside the collapsed text region.",
+  "- Keep expansion stable while unrelated assistant output streams.",
+  "",
+  "> The reader's viewport—not a raw character count—owns presentation.",
+  "",
+  "```ts",
+  "const multilingual = 'こんにちは · مرحبا · 👩🏽‍💻 · café';",
+  "const lossless = true;",
+  "```",
+  "",
+  `https://example.test/${"very-long-unbroken-url-segment-".repeat(28)}`,
+  "",
+  "Final paragraph after the URL so visual clipping cannot masquerade as data truncation.",
+].join("\n");
+
+function ordinaryUser(sequence: number): TimelineItem {
+  return {
+    kind: "user-message",
+    id: `ordinary-${sequence}`,
+    text: `Ordinary timeline message ${sequence}`,
+    resources: [],
+    tools: [],
+    occurredAt: new Date(1_775_000_000_000 + sequence).toISOString(),
+  };
+}
+
+function longUser(): UserMessageItem {
+  return {
+    kind: "user-message",
+    id: "long-user-message",
+    text: LONG_MESSAGE,
+    resources: [
+      { kind: "repository", uri: "https://github.com/example/long-message-demo.git", ref: "main" },
+    ],
+    tools: [],
+    presentation: {
+      kind: "realtime_voice_handoff",
+      context: "Voice handoff context remains available outside the collapsed Markdown body.",
+    },
+    occurredAt: "2026-08-04T20:00:00.000Z",
+  };
+}
+
+function assistant(text: string): TimelineItem {
+  return {
+    kind: "agent-message",
+    id: "assistant-stream",
+    turnId: "turn-long-message",
+    text,
+    streaming: true,
+    occurredAt: "2026-08-04T20:00:01.000Z",
+  };
+}
+
+function Harness() {
+  const [streamed, setStreamed] = useState(false);
+  const [prepended, setPrepended] = useState(false);
+  const items = useMemo(
+    () => [
+      ...(prepended ? Array.from({ length: 8 }, (_, index) => ordinaryUser(index - 8)) : []),
+      ...Array.from({ length: 14 }, (_, index) => ordinaryUser(index)),
+      longUser(),
+      assistant(
+        streamed
+          ? "Assistant output streamed after the user expanded the durable prompt. ".repeat(10)
+          : "Assistant response is streaming.",
+      ),
+    ],
+    [prepended, streamed],
+  );
+
+  const scroller = useCallback(() => {
+    const node = document.querySelector<HTMLElement>("[data-og-timeline-scroller]");
+    if (!node) {
+      throw new Error("timeline scroller unavailable");
+    }
+    return node;
+  }, []);
+
+  useEffect(() => {
+    window.userMessageHarness = {
+      prepend: () => flushSync(() => setPrepended(true)),
+      stream: () => flushSync(() => setStreamed(true)),
+      scroller,
+    };
+    return () => {
+      delete window.userMessageHarness;
+    };
+  }, [scroller]);
+
+  const renderMessageText = useCallback((text: string, item: TimelineItem) => {
+    if (item.kind !== "user-message") {
+      return (
+        <Markdown streaming={item.kind === "agent-message" && item.streaming}>{text}</Markdown>
+      );
+    }
+    return (
+      <div data-user-message-shell={item.id}>
+        {item.presentation ? (
+          <div data-voice-identity="" className="mb-2 text-og-sm font-medium text-og-fg-muted">
+            Voice handoff
+          </div>
+        ) : null}
+        {item.resources.length > 0 ? (
+          <div
+            data-message-attachments=""
+            className="mb-2 rounded-og-md border border-og-border bg-og-surface-1 px-2 py-1 text-og-sm text-og-fg-muted"
+          >
+            Repository · long-message-demo · main
+          </div>
+        ) : null}
+        <UserMessageBody messageId={item.id} text={text}>
+          <Markdown>{text}</Markdown>
+        </UserMessageBody>
+        {item.presentation ? (
+          <details data-voice-context="" className="mt-2 border-t border-og-border pt-2 text-og-sm">
+            <summary>Context sent to agent</summary>
+            <p>{item.presentation.context}</p>
+          </details>
+        ) : null}
+      </div>
+    );
+  }, []);
+
+  return (
+    <main className="h-full bg-og-bg p-3 text-og-fg sm:p-8" data-og-theme="light">
+      <section className="mx-auto flex h-full max-w-5xl flex-col">
+        <header className="mb-3 shrink-0">
+          <h1 className="text-xl font-semibold">Long sent user-message acceptance</h1>
+          <p className="text-og-sm text-og-fg-muted">
+            Lossless Markdown disclosure with fixed attachment and voice identity.
+          </p>
+        </header>
+        <MessageTimeline
+          className="min-h-0 flex-1 overflow-hidden rounded-og-lg border border-og-border bg-og-surface-1"
+          items={items}
+          hasOlder
+          renderMessageText={renderMessageText}
+        />
+      </section>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<Harness />);

--- a/packages/react/demo/user-message-test-harness.tsx
+++ b/packages/react/demo/user-message-test-harness.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 
@@ -91,6 +91,32 @@ function assistant(text: string): TimelineItem {
   };
 }
 
+function HiddenShadowActionFixture() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const host = document.createElement("og-hidden-shadow-control");
+    host.setAttribute("data-hidden-shadow-control", "");
+    host.style.display = "block";
+    host.style.marginTop = "8px";
+    const shadowRoot = host.attachShadow({ mode: "open", delegatesFocus: true });
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = "Shadow hidden action";
+    button.style.font = "inherit";
+    button.style.padding = "4px 8px";
+    shadowRoot.append(button);
+    container.replaceChildren(host);
+    return () => container.replaceChildren();
+  }, []);
+
+  return <div ref={containerRef} data-hidden-shadow-fixture="" />;
+}
+
 function Harness() {
   const [streamed, setStreamed] = useState(false);
   const [prepended, setPrepended] = useState(false);
@@ -152,13 +178,31 @@ function Harness() {
           <div>
             <Markdown>{text}</Markdown>
             {item.id === "long-user-message" ? (
-              <button
-                type="button"
-                data-hidden-message-action=""
-                className="mt-2 rounded-og-sm border border-og-border px-2 py-1 text-og-sm"
-              >
-                Hidden message action
-              </button>
+              <>
+                <HiddenShadowActionFixture />
+                <button
+                  type="button"
+                  data-zero-size-message-action=""
+                  className="block h-0 w-0 overflow-hidden border-0 p-0"
+                >
+                  Zero-size hidden action
+                </button>
+                <button
+                  type="button"
+                  data-hidden-message-action=""
+                  className="mt-2 rounded-og-sm border border-og-border px-2 py-1 text-og-sm"
+                >
+                  Hidden message action
+                </button>
+                <button
+                  inert
+                  type="button"
+                  data-preexisting-inert-message-action=""
+                  className="mt-2 rounded-og-sm border border-og-border px-2 py-1 text-og-sm"
+                >
+                  Pre-existing inert action
+                </button>
+              </>
             ) : null}
           </div>
         </UserMessageBody>

--- a/packages/react/demo/user-message-test-harness.tsx
+++ b/packages/react/demo/user-message-test-harness.tsx
@@ -26,6 +26,8 @@ declare global {
 const LONG_MESSAGE = [
   "# Launch review notes",
   "",
+  "[Visible preview link](https://example.test/visible-preview)",
+  "",
   "This already-sent prompt is intentionally long and must remain completely available. ".repeat(
     10,
   ),
@@ -42,6 +44,8 @@ const LONG_MESSAGE = [
   "const multilingual = 'こんにちは · مرحبا · 👩🏽‍💻 · café';",
   "const lossless = true;",
   "```",
+  "",
+  "[Hidden review link](https://example.test/hidden-review)",
   "",
   `https://example.test/${"very-long-unbroken-url-segment-".repeat(28)}`,
   "",
@@ -145,7 +149,18 @@ function Harness() {
           </div>
         ) : null}
         <UserMessageBody messageId={item.id} text={text}>
-          <Markdown>{text}</Markdown>
+          <div>
+            <Markdown>{text}</Markdown>
+            {item.id === "long-user-message" ? (
+              <button
+                type="button"
+                data-hidden-message-action=""
+                className="mt-2 rounded-og-sm border border-og-border px-2 py-1 text-og-sm"
+              >
+                Hidden message action
+              </button>
+            ) : null}
+          </div>
         </UserMessageBody>
         {item.presentation ? (
           <details data-voice-context="" className="mt-2 border-t border-og-border pt-2 text-og-sm">

--- a/packages/react/demo/user-message-test.html
+++ b/packages/react/demo/user-message-test.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Long user-message disclosure acceptance</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body,
+      #root {
+        height: 100%;
+        margin: 0;
+      }
+      button,
+      summary {
+        font: inherit;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/user-message-test-harness.tsx"></script>
+  </body>
+</html>

--- a/packages/react/src/components/markdown.tsx
+++ b/packages/react/src/components/markdown.tsx
@@ -97,7 +97,7 @@ const components: Components = {
   ),
   a: ({ children, ...props }) => (
     <a
-      className="break-words font-medium text-og-accent underline-offset-2 hover:underline"
+      className="break-words font-medium text-og-accent-strong underline-offset-2 hover:underline"
       target="_blank"
       rel="noreferrer noopener"
       {...props}

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -37,6 +37,11 @@ import { formatClockTime, formatRelativeTime, truncate } from "../lib/format";
 import { prefersReducedMotion } from "../lib/motion";
 import { Markdown } from "./markdown";
 import {
+  UserMessageBody,
+  UserMessageDisclosureProvider,
+  type UserMessageDisclosureContextValue,
+} from "./user-message-body";
+import {
   createTipFollowState,
   readerScrollUpPx,
   tipFollowCancel,
@@ -359,6 +364,13 @@ export function MessageTimeline({
    */
   const programmaticScrollRef = useRef(0);
   /**
+   * Disclosure height changes are not reader navigation. While an unpinned
+   * Show more/less state is active, its clamp/native-anchor scroll echoes must
+   * never geometrically re-enable bottom-follow. A later real reader navigation
+   * or explicit Jump to latest releases this fence.
+   */
+  const disclosureKeepsUnpinnedRef = useRef(false);
+  /**
    * Unarmed scroll-away observed; waiting for scrollend (or rAF fallback).
    * Blocks layout tip-follow so a stream token cannot yank before leave settles.
    */
@@ -369,6 +381,7 @@ export function MessageTimeline({
   // deliberate chip remounts (activity→turn wrap, nested key flips) so a fold
   // that already settled closed — or that the reader closed — never reopens.
   const foldMemoryRef = useRef<Map<string, FoldRestingState>>(new Map());
+  const userMessageDisclosureMemoryRef = useRef<Map<string, boolean>>(new Map());
   const seenActivityIdsRef = useRef<Set<string>>(new Set());
   const groupKeyByItemIdRef = useRef<Map<string, string>>(new Map());
   const groupOffsetByKeyRef = useRef<Map<string, number>>(new Map());
@@ -513,14 +526,18 @@ export function MessageTimeline({
     target: EventTarget | null;
     currentTarget: EventTarget | null;
   }) => {
-    // Nested overflow (code / notice pre) or mostly-horizontal pan: not tip leave.
-    if (event.deltaY >= 0) {
-      return;
-    }
+    // Nested overflow (code / notice pre) or mostly-horizontal pan: not
+    // timeline reader intent. A real timeline wheel in either direction
+    // releases the disclosure fence; downward movement may then re-pin
+    // naturally when it reaches the bottom.
     if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) {
       return;
     }
     if (wheelConsumedByNestedScrollable(event)) {
+      return;
+    }
+    disclosureKeepsUnpinnedRef.current = false;
+    if (event.deltaY >= 0) {
       return;
     }
     const node =
@@ -546,10 +563,21 @@ export function MessageTimeline({
     ) {
       return;
     }
+    disclosureKeepsUnpinnedRef.current = false;
     readerIntentArmRef.current = true;
   };
 
   const onKeyDown = (event: { key: string; currentTarget: EventTarget | null }) => {
+    if (
+      event.key === "ArrowUp" ||
+      event.key === "ArrowDown" ||
+      event.key === "PageUp" ||
+      event.key === "PageDown" ||
+      event.key === "Home" ||
+      event.key === "End"
+    ) {
+      disclosureKeepsUnpinnedRef.current = false;
+    }
     if (event.key !== "ArrowUp" && event.key !== "PageUp" && event.key !== "Home") {
       return;
     }
@@ -572,6 +600,65 @@ export function MessageTimeline({
       };
     },
     [cancelLeaveFallback, stopFollow, syncScrollBaseline, writeScrollTop],
+  );
+
+  const beginUserMessageDisclosureChange = useCallback(
+    (messageBody: HTMLElement, disclosureControl: HTMLElement) => {
+      const node = scrollRef.current;
+      if (!node || !node.contains(messageBody)) {
+        return null;
+      }
+      const keepBottom = autoFollow && pinnedRef.current && !hasNewerRef.current;
+      if (keepBottom) {
+        return () => {
+          const current = scrollRef.current;
+          if (current) {
+            snapToBottom(current);
+          }
+        };
+      }
+
+      disclosureKeepsUnpinnedRef.current = true;
+
+      const scrollerRect = node.getBoundingClientRect();
+      const group = messageBody.closest<HTMLElement>("[data-og-timeline-group-anchor]");
+      const groupRect = group?.getBoundingClientRect();
+      // Expanding from a visible message top keeps the beginning in place.
+      // Collapsing after reading deep in the message keeps the disclosure
+      // control in place because the message top is already above the viewport.
+      const anchor =
+        group &&
+        groupRect &&
+        groupRect.top >= scrollerRect.top - 1 &&
+        groupRect.top < scrollerRect.bottom
+          ? group
+          : disclosureControl;
+      const beforeTop = anchor.getBoundingClientRect().top - scrollerRect.top;
+
+      return () => {
+        const current = scrollRef.current;
+        if (!current || !current.contains(anchor)) {
+          return;
+        }
+        const currentScrollerTop = current.getBoundingClientRect().top;
+        const afterTop = anchor.getBoundingClientRect().top - currentScrollerTop;
+        const delta = afterTop - beforeTop;
+        if (Math.abs(delta) > 0.5) {
+          writeScrollTop(current, current.scrollTop + delta);
+        }
+        applyPinned(false);
+        syncScrollBaseline(current);
+      };
+    },
+    [applyPinned, autoFollow, snapToBottom, syncScrollBaseline, writeScrollTop],
+  );
+
+  const userMessageDisclosureContext = useMemo<UserMessageDisclosureContextValue>(
+    () => ({
+      expandedByMessageId: userMessageDisclosureMemoryRef.current,
+      beginChange: beginUserMessageDisclosureChange,
+    }),
+    [beginUserMessageDisclosureChange],
   );
 
   const driveFollowRef = useRef<(node: HTMLElement, now?: number) => void>(() => undefined);
@@ -868,6 +955,8 @@ export function MessageTimeline({
     groupKeyByItemIdRef.current = new Map();
     groupOffsetByKeyRef.current = new Map();
     foldMemoryRef.current.clear();
+    userMessageDisclosureMemoryRef.current.clear();
+    disclosureKeepsUnpinnedRef.current = false;
     seenActivityIdsRef.current.clear();
     applyPinned(true);
   }, [allGroups.length, revealed, applyPinned]);
@@ -1045,6 +1134,12 @@ export function MessageTimeline({
     if (programmatic) {
       programmaticScrollRef.current = 0;
     }
+    if (disclosureKeepsUnpinnedRef.current) {
+      stopFollow();
+      applyPinned(false);
+      syncScrollBaseline(node);
+      return;
+    }
 
     if (autoFollow && pinnedRef.current && !hasNewer) {
       // Fold / composer / SessionChrome: viewport shrink raises maxScroll without
@@ -1144,6 +1239,13 @@ export function MessageTimeline({
       return;
     }
     cancelLeaveFallback();
+    if (disclosureKeepsUnpinnedRef.current) {
+      programmaticScrollRef.current = 0;
+      stopFollow();
+      applyPinned(false);
+      syncScrollBaseline(node);
+      return;
+    }
     if (programmaticScrollRef.current > 0) {
       programmaticScrollRef.current = 0;
       syncScrollBaseline(node);
@@ -1164,6 +1266,8 @@ export function MessageTimeline({
           Unpinned: native scroll anchoring holds the reader's place. */}
                   <div
                     ref={scrollRef}
+                    data-og-timeline-scroller=""
+                    data-og-bottom-follow={autoFollow && pinned && !hasNewer ? "true" : "false"}
                     tabIndex={-1}
                     onScroll={onScroll}
                     onScrollEnd={onScrollEnd}
@@ -1224,21 +1328,23 @@ export function MessageTimeline({
                                 turnSummary,
                               ]}
                             >
-                              <TimelineGroupView
-                                group={group}
-                                renderMessageText={renderMessageText}
-                                onOpenSession={onOpenSession}
-                                onMemoryClick={onMemoryClick}
-                                onReconnect={onReconnect}
-                                resolveProviderLogo={resolveProviderLogo}
-                                toolRegistry={toolRegistry}
-                                turnSummary={turnSummary}
-                                foldLiveCluster={isAgentProgress(next)}
-                                trailingAgentText={trailingAgentTextAfterTurn(group, next)}
-                                contextCompactionCount={
-                                  contextCompactionCount > 0 ? contextCompactionCount : undefined
-                                }
-                              />
+                              <UserMessageDisclosureProvider value={userMessageDisclosureContext}>
+                                <TimelineGroupView
+                                  group={group}
+                                  renderMessageText={renderMessageText}
+                                  onOpenSession={onOpenSession}
+                                  onMemoryClick={onMemoryClick}
+                                  onReconnect={onReconnect}
+                                  resolveProviderLogo={resolveProviderLogo}
+                                  toolRegistry={toolRegistry}
+                                  turnSummary={turnSummary}
+                                  foldLiveCluster={isAgentProgress(next)}
+                                  trailingAgentText={trailingAgentTextAfterTurn(group, next)}
+                                  contextCompactionCount={
+                                    contextCompactionCount > 0 ? contextCompactionCount : undefined
+                                  }
+                                />
+                              </UserMessageDisclosureProvider>
                             </TimelineGroupRenderBoundary>
                           </div>
                         );
@@ -1354,6 +1460,7 @@ export function MessageTimeline({
                         exit={{ opacity: 0, y: 8 }}
                         transition={{ duration: 0.15, ease: "easeOut" }}
                         onClick={() => {
+                          disclosureKeepsUnpinnedRef.current = false;
                           if (hasNewer) {
                             // Do not pin against the current history page — its bottom
                             // is not the tip. The pin + snap run when the tip window
@@ -2171,7 +2278,9 @@ function UserMessageRow({
             {renderMessageText ? (
               renderMessageText(item.text, item)
             ) : (
-              <Markdown>{item.text}</Markdown>
+              <UserMessageBody messageId={item.id} text={item.text}>
+                <Markdown>{item.text}</Markdown>
+              </UserMessageBody>
             )}
           </div>
         </CopyHoverFrame>

--- a/packages/react/src/components/user-message-body.tsx
+++ b/packages/react/src/components/user-message-body.tsx
@@ -13,6 +13,36 @@ import { cn } from "../lib/cn";
 const FALLBACK_LINE_THRESHOLD = 12;
 const FALLBACK_TEXT_THRESHOLD = 900;
 const FALLBACK_UNBROKEN_THRESHOLD = 260;
+const INTERACTIVE_DESCENDANT_SELECTOR = [
+  "a[href]",
+  "area[href]",
+  "button",
+  "input:not([type='hidden'])",
+  "select",
+  "textarea",
+  "iframe",
+  "object",
+  "embed",
+  "audio[controls]",
+  "video[controls]",
+  "summary",
+  "[contenteditable]:not([contenteditable='false'])",
+  "[tabindex]",
+  "[role='button']",
+  "[role='link']",
+  "[role='checkbox']",
+  "[role='radio']",
+  "[role='switch']",
+  "[role='slider']",
+  "[role='spinbutton']",
+  "[role='textbox']",
+  "[role='combobox']",
+  "[role='listbox']",
+  "[role='menuitem']",
+  "[role='option']",
+  "[role='tab']",
+  "[role='treeitem']",
+].join(",");
 
 type RestoreDisclosureAnchor = (() => void) | null;
 
@@ -80,10 +110,60 @@ export function UserMessageBody({ messageId, text, children, className }: UserMe
   );
   const [collapsible, setCollapsible] = useState(() => userMessageLikelyNeedsDisclosure(text));
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const clipRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const thresholdRef = useRef<HTMLSpanElement | null>(null);
   const pendingRestoreRef = useRef<RestoreDisclosureAnchor>(null);
+  const managedInertDescendantsRef = useRef(new Set<HTMLElement>());
   const contentId = `og-user-message-${useId().replace(/:/g, "")}`;
+  const collapsed = collapsible && !expanded;
+
+  const restoreManagedInertDescendants = useCallback(() => {
+    for (const descendant of managedInertDescendantsRef.current) {
+      if (descendant.hasAttribute("data-og-user-message-managed-inert")) {
+        descendant.removeAttribute("inert");
+        descendant.removeAttribute("data-og-user-message-managed-inert");
+      }
+    }
+    managedInertDescendantsRef.current.clear();
+  }, []);
+
+  const syncCollapsedInteractivity = useCallback(() => {
+    restoreManagedInertDescendants();
+    if (!collapsed) {
+      return;
+    }
+
+    const clip = clipRef.current;
+    const content = contentRef.current;
+    if (!clip || !content) {
+      return;
+    }
+
+    const clipRect = clip.getBoundingClientRect();
+    if (clipRect.height <= 0) {
+      return;
+    }
+
+    for (const descendant of content.querySelectorAll<HTMLElement>(
+      INTERACTIVE_DESCENDANT_SELECTOR,
+    )) {
+      if (descendant.closest("[inert]")) {
+        continue;
+      }
+      const rect = descendant.getBoundingClientRect();
+      if (rect.width <= 0 && rect.height <= 0) {
+        continue;
+      }
+      const fullyInsidePreview = rect.top >= clipRect.top - 1 && rect.bottom <= clipRect.bottom + 1;
+      if (fullyInsidePreview) {
+        continue;
+      }
+      descendant.setAttribute("inert", "");
+      descendant.setAttribute("data-og-user-message-managed-inert", "");
+      managedInertDescendantsRef.current.add(descendant);
+    }
+  }, [collapsed, restoreManagedInertDescendants]);
 
   const measure = useCallback(() => {
     const content = contentRef.current;
@@ -108,19 +188,33 @@ export function UserMessageBody({ messageId, text, children, className }: UserMe
     const content = contentRef.current;
     const threshold = thresholdRef.current;
     const observer =
-      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => measure());
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => {
+            measure();
+            syncCollapsedInteractivity();
+          });
     if (content) {
       observer?.observe(content);
     }
     if (threshold) {
       observer?.observe(threshold);
     }
-    window.addEventListener("resize", measure);
+    const handleResize = () => {
+      measure();
+      syncCollapsedInteractivity();
+    };
+    window.addEventListener("resize", handleResize);
     return () => {
       observer?.disconnect();
-      window.removeEventListener("resize", measure);
+      window.removeEventListener("resize", handleResize);
     };
-  }, [measure]);
+  }, [measure, syncCollapsedInteractivity]);
+
+  useLayoutEffect(() => {
+    syncCollapsedInteractivity();
+    return restoreManagedInertDescendants;
+  }, [restoreManagedInertDescendants, syncCollapsedInteractivity]);
 
   useLayoutEffect(() => {
     const restore = pendingRestoreRef.current;
@@ -132,11 +226,12 @@ export function UserMessageBody({ messageId, text, children, className }: UserMe
     const root = rootRef.current;
     pendingRestoreRef.current = root && disclosure ? disclosure.beginChange(root, control) : null;
     const next = !expanded;
+    if (!next && contentRef.current?.contains(document.activeElement)) {
+      control.focus({ preventScroll: true });
+    }
     disclosure?.expandedByMessageId.set(messageId, next);
     setExpanded(next);
   };
-
-  const collapsed = collapsible && !expanded;
 
   return (
     <div
@@ -152,6 +247,7 @@ export function UserMessageBody({ messageId, text, children, className }: UserMe
         className="pointer-events-none absolute h-56 w-0 invisible sm:h-72"
       />
       <div
+        ref={clipRef}
         id={contentId}
         data-og-user-message-clip=""
         className={cn("relative min-w-0", collapsed && "max-h-56 overflow-hidden sm:max-h-72")}

--- a/packages/react/src/components/user-message-body.tsx
+++ b/packages/react/src/components/user-message-body.tsx
@@ -44,6 +44,69 @@ const INTERACTIVE_DESCENDANT_SELECTOR = [
   "[role='treeitem']",
 ].join(",");
 
+function composedParentElement(element: Element): Element | null {
+  if (element.assignedSlot) {
+    return element.assignedSlot;
+  }
+  if (element.parentElement) {
+    return element.parentElement;
+  }
+  const root = element.getRootNode();
+  return typeof ShadowRoot !== "undefined" && root instanceof ShadowRoot ? root.host : null;
+}
+
+function hasComposedInertAncestor(element: Element, boundary: Element): boolean {
+  let current: Element | null = element;
+  while (current) {
+    if (current.hasAttribute("inert")) {
+      return true;
+    }
+    if (current === boundary) {
+      return false;
+    }
+    current = composedParentElement(current);
+  }
+  return false;
+}
+
+/**
+ * Native inert crosses shadow boundaries, but ordinary selectors do not.
+ * Recursively inspect open roots control-by-control so visible shadow content
+ * stays interactive. An opaque custom-element host is the conservative focus
+ * boundary for a closed root that cannot be inspected.
+ */
+function collectInteractionBoundaries(root: ParentNode): HTMLElement[] {
+  const boundaries: HTMLElement[] = [];
+  const scopes: ParentNode[] = [root];
+  for (let scopeIndex = 0; scopeIndex < scopes.length; scopeIndex += 1) {
+    for (const element of scopes[scopeIndex]!.querySelectorAll("*")) {
+      if (!(element instanceof HTMLElement)) {
+        continue;
+      }
+      const shadowRoot = element.shadowRoot;
+      const opaqueCustomElement = element.localName.includes("-") && !shadowRoot;
+      if (element.matches(INTERACTIVE_DESCENDANT_SELECTOR) || opaqueCustomElement) {
+        boundaries.push(element);
+      }
+      if (shadowRoot) {
+        scopes.push(shadowRoot);
+      }
+    }
+  }
+  return boundaries;
+}
+
+function isFullyInsideVisiblePreview(rect: DOMRect, clipRect: DOMRect): boolean {
+  return (
+    rect.width > 0 &&
+    rect.height > 0 &&
+    rect.top >= clipRect.top - 1 &&
+    rect.bottom <= clipRect.bottom + 1 &&
+    rect.left >= clipRect.left - 1 &&
+    rect.right <= clipRect.right + 1
+  );
+}
+
 type RestoreDisclosureAnchor = (() => void) | null;
 
 export type UserMessageDisclosureContextValue = {
@@ -145,18 +208,12 @@ export function UserMessageBody({ messageId, text, children, className }: UserMe
       return;
     }
 
-    for (const descendant of content.querySelectorAll<HTMLElement>(
-      INTERACTIVE_DESCENDANT_SELECTOR,
-    )) {
-      if (descendant.closest("[inert]")) {
+    for (const descendant of collectInteractionBoundaries(content)) {
+      if (hasComposedInertAncestor(descendant, content)) {
         continue;
       }
       const rect = descendant.getBoundingClientRect();
-      if (rect.width <= 0 && rect.height <= 0) {
-        continue;
-      }
-      const fullyInsidePreview = rect.top >= clipRect.top - 1 && rect.bottom <= clipRect.bottom + 1;
-      if (fullyInsidePreview) {
+      if (isFullyInsideVisiblePreview(rect, clipRect)) {
         continue;
       }
       descendant.setAttribute("inert", "");
@@ -214,7 +271,7 @@ export function UserMessageBody({ messageId, text, children, className }: UserMe
   useLayoutEffect(() => {
     syncCollapsedInteractivity();
     return restoreManagedInertDescendants;
-  }, [restoreManagedInertDescendants, syncCollapsedInteractivity]);
+  });
 
   useLayoutEffect(() => {
     const restore = pendingRestoreRef.current;

--- a/packages/react/src/components/user-message-body.tsx
+++ b/packages/react/src/components/user-message-body.tsx
@@ -1,0 +1,188 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { cn } from "../lib/cn";
+
+const FALLBACK_LINE_THRESHOLD = 12;
+const FALLBACK_TEXT_THRESHOLD = 900;
+const FALLBACK_UNBROKEN_THRESHOLD = 260;
+
+type RestoreDisclosureAnchor = (() => void) | null;
+
+export type UserMessageDisclosureContextValue = {
+  expandedByMessageId: Map<string, boolean>;
+  beginChange: (
+    messageBody: HTMLElement,
+    disclosureControl: HTMLElement,
+  ) => RestoreDisclosureAnchor;
+};
+
+const UserMessageDisclosureContext = createContext<UserMessageDisclosureContextValue | null>(null);
+
+export function UserMessageDisclosureProvider({
+  value,
+  children,
+}: {
+  value: UserMessageDisclosureContextValue;
+  children: ReactNode;
+}) {
+  return (
+    <UserMessageDisclosureContext.Provider value={value}>
+      {children}
+    </UserMessageDisclosureContext.Provider>
+  );
+}
+
+/**
+ * Deterministic first-paint fallback for runtimes without layout measurement.
+ * Real browsers replace this estimate with the rendered-height decision in the
+ * first layout effect. The complete text always remains mounted either way.
+ */
+export function userMessageLikelyNeedsDisclosure(text: string): boolean {
+  const lines = text.split(/\r?\n/);
+  return (
+    lines.length > FALLBACK_LINE_THRESHOLD ||
+    text.length > FALLBACK_TEXT_THRESHOLD ||
+    lines.some((line) => line.length > FALLBACK_UNBROKEN_THRESHOLD)
+  );
+}
+
+export type UserMessageBodyProps = {
+  /** Durable timeline item id. Expansion memory is keyed by this value. */
+  messageId: string;
+  /** Complete source text. Used only for the deterministic measurement fallback. */
+  text: string;
+  children: ReactNode;
+  className?: string | undefined;
+};
+
+/**
+ * Lossless disclosure boundary for already-sent user-message text.
+ *
+ * The full rendered subtree always remains in the DOM. A real browser decides
+ * whether disclosure is needed from rendered height (including Markdown
+ * structure and wrapping); the source-text heuristic is only a deterministic
+ * fallback for SSR/test environments without layout. Timeline-owned context
+ * remembers expansion per durable message id and preserves the reader's scroll
+ * anchor when height changes.
+ */
+export function UserMessageBody({ messageId, text, children, className }: UserMessageBodyProps) {
+  const disclosure = useContext(UserMessageDisclosureContext);
+  const [expanded, setExpanded] = useState(
+    () => disclosure?.expandedByMessageId.get(messageId) ?? false,
+  );
+  const [collapsible, setCollapsible] = useState(() => userMessageLikelyNeedsDisclosure(text));
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const thresholdRef = useRef<HTMLSpanElement | null>(null);
+  const pendingRestoreRef = useRef<RestoreDisclosureAnchor>(null);
+  const contentId = `og-user-message-${useId().replace(/:/g, "")}`;
+
+  const measure = useCallback(() => {
+    const content = contentRef.current;
+    const threshold = thresholdRef.current;
+    if (!content || !threshold) {
+      return;
+    }
+    const renderedHeight = Math.max(content.scrollHeight, content.getBoundingClientRect().height);
+    const collapseHeight = Math.max(
+      threshold.offsetHeight,
+      threshold.getBoundingClientRect().height,
+    );
+    setCollapsible(
+      renderedHeight > 0 && collapseHeight > 0
+        ? renderedHeight > collapseHeight + 1
+        : userMessageLikelyNeedsDisclosure(text),
+    );
+  }, [text]);
+
+  useLayoutEffect(() => {
+    measure();
+    const content = contentRef.current;
+    const threshold = thresholdRef.current;
+    const observer =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => measure());
+    if (content) {
+      observer?.observe(content);
+    }
+    if (threshold) {
+      observer?.observe(threshold);
+    }
+    window.addEventListener("resize", measure);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [measure]);
+
+  useLayoutEffect(() => {
+    const restore = pendingRestoreRef.current;
+    pendingRestoreRef.current = null;
+    restore?.();
+  }, [expanded]);
+
+  const toggle = (control: HTMLButtonElement) => {
+    const root = rootRef.current;
+    pendingRestoreRef.current = root && disclosure ? disclosure.beginChange(root, control) : null;
+    const next = !expanded;
+    disclosure?.expandedByMessageId.set(messageId, next);
+    setExpanded(next);
+  };
+
+  const collapsed = collapsible && !expanded;
+
+  return (
+    <div
+      ref={rootRef}
+      data-og-user-message-body=""
+      data-og-message-id={messageId}
+      data-og-expanded={expanded ? "true" : "false"}
+      className={cn("relative min-w-0", className)}
+    >
+      <span
+        ref={thresholdRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute h-56 w-0 invisible sm:h-72"
+      />
+      <div
+        id={contentId}
+        data-og-user-message-clip=""
+        className={cn("relative min-w-0", collapsed && "max-h-56 overflow-hidden sm:max-h-72")}
+      >
+        <div
+          ref={contentRef}
+          data-og-user-message-content=""
+          className="min-w-0 [overflow-wrap:anywhere]"
+        >
+          {children}
+        </div>
+        {collapsed ? (
+          <span
+            aria-hidden="true"
+            data-og-user-message-fade=""
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-og-surface-2 via-og-surface-2/90 to-transparent"
+          />
+        ) : null}
+      </div>
+      {collapsible ? (
+        <button
+          type="button"
+          aria-controls={contentId}
+          aria-expanded={expanded}
+          data-og-user-message-disclosure=""
+          className="mt-1.5 inline-flex min-h-7 items-center rounded-og-sm px-1.5 text-og-xs font-medium text-og-fg-muted outline-none transition-colors hover:bg-og-surface-3/60 hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/45 pointer-coarse:min-h-11"
+          onClick={(event) => toggle(event.currentTarget)}
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -460,6 +460,8 @@ export {
 export type { LatencyModeId, PickerBillingClass, PickerModelRow } from "./model-policy";
 export { MessageTimeline, TimelineRow } from "./components/message-timeline";
 export type { MessageTimelineProps } from "./components/message-timeline";
+export { UserMessageBody, userMessageLikelyNeedsDisclosure } from "./components/user-message-body";
+export type { UserMessageBodyProps } from "./components/user-message-body";
 export { Markdown } from "./components/markdown";
 export { CopyButton, CopyHoverFrame } from "./components/copy-button";
 export { copyTextToClipboard, tableElementToTsv } from "./lib/clipboard";

--- a/packages/react/src/session-ui.ts
+++ b/packages/react/src/session-ui.ts
@@ -11,6 +11,8 @@ export { HumanInputSurface } from "./components/human-input-surface";
 export type { HumanInputSurfaceProps } from "./components/human-input-surface";
 export { MessageTimeline, TimelineRow } from "./components/message-timeline";
 export type { MessageTimelineProps } from "./components/message-timeline";
+export { UserMessageBody, userMessageLikelyNeedsDisclosure } from "./components/user-message-body";
+export type { UserMessageBodyProps } from "./components/user-message-body";
 export { BUILT_IN_TURN_SUMMARY_FACET_IDS } from "./timeline/turn-summary";
 export type {
   BuiltInTurnSummaryFacetId,

--- a/packages/react/test/user-message-body.test.tsx
+++ b/packages/react/test/user-message-body.test.tsx
@@ -138,7 +138,7 @@ describe("UserMessageBody", () => {
     await r.unmount();
   });
 
-  test("makes only clipped interactive descendants inert and restores focusability on expand", async () => {
+  test("covers composed and zero-size focus boundaries while preserving visible and preexisting state", async () => {
     const callbacks: ResizeObserverCallback[] = [];
     globalThis.ResizeObserver = class {
       constructor(callback: ResizeObserverCallback) {
@@ -160,6 +160,10 @@ describe("UserMessageBody", () => {
         <button data-testid="hidden-button" type="button">
           Hidden action
         </button>
+        <div data-testid="shadow-slot" />
+        <button data-testid="zero-size-button" type="button">
+          Zero-size action
+        </button>
         <button data-testid="preexisting-inert" type="button">
           Already inert
         </button>
@@ -176,17 +180,45 @@ describe("UserMessageBody", () => {
     const hiddenButton = r.container.querySelector<HTMLButtonElement>(
       "[data-testid='hidden-button']",
     )!;
+    const zeroSizeButton = r.container.querySelector<HTMLButtonElement>(
+      "[data-testid='zero-size-button']",
+    )!;
     const preexistingInert = r.container.querySelector<HTMLElement>(
       "[data-testid='preexisting-inert']",
     )!;
+    const shadowSlot = r.container.querySelector<HTMLElement>("[data-testid='shadow-slot']")!;
+    const clippedShadowHost = document.createElement("og-clipped-shadow-control");
+    const clippedShadowRoot = clippedShadowHost.attachShadow({
+      mode: "open",
+      delegatesFocus: true,
+    });
+    const clippedShadowButton = document.createElement("button");
+    clippedShadowButton.textContent = "Clipped shadow action";
+    clippedShadowRoot.append(clippedShadowButton);
+    const opaqueShadowHost = document.createElement("og-opaque-shadow-control");
+    opaqueShadowHost
+      .attachShadow({ mode: "closed", delegatesFocus: true })
+      .append(document.createElement("button"));
+    const visibleShadowHost = document.createElement("og-visible-shadow-control");
+    const visibleShadowRoot = visibleShadowHost.attachShadow({ mode: "open" });
+    const escapedShadowButton = document.createElement("button");
+    escapedShadowButton.textContent = "Escaped shadow action";
+    visibleShadowRoot.append(escapedShadowButton);
+    shadowSlot.append(clippedShadowHost, opaqueShadowHost, visibleShadowHost);
 
-    Object.defineProperty(content, "scrollHeight", { configurable: true, value: 520 });
+    Object.defineProperty(content, "scrollHeight", { configurable: true, value: 620 });
     Object.defineProperty(threshold, "offsetHeight", { configurable: true, value: 224 });
     clip.getBoundingClientRect = () => elementRect(0, 224);
     visibleLink.getBoundingClientRect = () => elementRect(24, 48);
     hiddenLink.getBoundingClientRect = () => elementRect(260, 284);
     hiddenButton.getBoundingClientRect = () => elementRect(300, 332);
-    preexistingInert.getBoundingClientRect = () => elementRect(348, 380);
+    clippedShadowHost.getBoundingClientRect = () => elementRect(348, 380);
+    clippedShadowButton.getBoundingClientRect = () => elementRect(352, 376);
+    opaqueShadowHost.getBoundingClientRect = () => elementRect(388, 420);
+    visibleShadowHost.getBoundingClientRect = () => elementRect(64, 88);
+    escapedShadowButton.getBoundingClientRect = () => elementRect(432, 460);
+    zeroSizeButton.getBoundingClientRect = () => elementRect(476, 476, 0, 0);
+    preexistingInert.getBoundingClientRect = () => elementRect(492, 524);
     preexistingInert.setAttribute("inert", "");
 
     await actRun(() => callbacks.forEach((callback) => callback([], {} as ResizeObserver)));
@@ -194,6 +226,12 @@ describe("UserMessageBody", () => {
     expect(hiddenLink.hasAttribute("inert")).toBe(true);
     expect(hiddenButton.hasAttribute("inert")).toBe(true);
     expect(hiddenLink.hasAttribute("data-og-user-message-managed-inert")).toBe(true);
+    expect(clippedShadowHost.hasAttribute("inert")).toBe(false);
+    expect(clippedShadowButton.hasAttribute("inert")).toBe(true);
+    expect(opaqueShadowHost.hasAttribute("inert")).toBe(true);
+    expect(visibleShadowHost.hasAttribute("inert")).toBe(false);
+    expect(escapedShadowButton.hasAttribute("inert")).toBe(true);
+    expect(zeroSizeButton.hasAttribute("inert")).toBe(true);
     expect(preexistingInert.hasAttribute("inert")).toBe(true);
     expect(preexistingInert.hasAttribute("data-og-user-message-managed-inert")).toBe(false);
 
@@ -201,6 +239,11 @@ describe("UserMessageBody", () => {
     expect(disclosure.getAttribute("aria-expanded")).toBe("true");
     expect(hiddenLink.hasAttribute("inert")).toBe(false);
     expect(hiddenButton.hasAttribute("inert")).toBe(false);
+    expect(clippedShadowHost.hasAttribute("inert")).toBe(false);
+    expect(clippedShadowButton.hasAttribute("inert")).toBe(false);
+    expect(opaqueShadowHost.hasAttribute("inert")).toBe(false);
+    expect(escapedShadowButton.hasAttribute("inert")).toBe(false);
+    expect(zeroSizeButton.hasAttribute("inert")).toBe(false);
     expect(preexistingInert.hasAttribute("inert")).toBe(true);
 
     hiddenButton.focus();
@@ -210,6 +253,22 @@ describe("UserMessageBody", () => {
     expect(document.activeElement).toBe(disclosure);
     expect(hiddenLink.hasAttribute("inert")).toBe(true);
     expect(hiddenButton.hasAttribute("inert")).toBe(true);
+    expect(clippedShadowHost.hasAttribute("inert")).toBe(false);
+    expect(clippedShadowButton.hasAttribute("inert")).toBe(true);
+    expect(opaqueShadowHost.hasAttribute("inert")).toBe(true);
+    expect(escapedShadowButton.hasAttribute("inert")).toBe(true);
+    expect(zeroSizeButton.hasAttribute("inert")).toBe(true);
+
+    clippedShadowButton.removeAttribute("inert");
+    opaqueShadowHost.removeAttribute("inert");
+    escapedShadowButton.removeAttribute("inert");
+    zeroSizeButton.removeAttribute("inert");
+    await actRun(() => callbacks.forEach((callback) => callback([], {} as ResizeObserver)));
+    expect(clippedShadowButton.hasAttribute("inert")).toBe(true);
+    expect(opaqueShadowHost.hasAttribute("inert")).toBe(true);
+    expect(escapedShadowButton.hasAttribute("inert")).toBe(true);
+    expect(zeroSizeButton.hasAttribute("inert")).toBe(true);
+    expect(preexistingInert.hasAttribute("inert")).toBe(true);
     await r.unmount();
   });
 

--- a/packages/react/test/user-message-body.test.tsx
+++ b/packages/react/test/user-message-body.test.tsx
@@ -1,0 +1,222 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  Markdown,
+  MessageTimeline,
+  UserMessageBody,
+  type TimelineItem,
+  type UserMessageItem,
+} from "../src";
+import { actRun, flush, registerDom, renderComponent } from "./render-hook";
+
+registerDom();
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+afterEach(() => {
+  globalThis.ResizeObserver = originalResizeObserver;
+});
+
+function longMarkdown(): string {
+  const unbroken = `https://example.test/${"continuously-wrapped-segment-".repeat(24)}`;
+  return [
+    "# A complete long prompt",
+    "",
+    "This paragraph stays lossless even while the rendered presentation is collapsed. ".repeat(8),
+    "",
+    "- First list item",
+    "- Second list item with **bold** and _emphasis_",
+    "- Third list item",
+    "",
+    "> A block quote whose complete source remains mounted.",
+    "",
+    "```ts",
+    "const unicode = 'こんにちは · مرحبا · 👩🏽‍💻';",
+    "console.log(unicode);",
+    "```",
+    "",
+    unbroken,
+    "",
+    "Final paragraph after the long URL.",
+  ].join("\n");
+}
+
+function user(id: string, text: string): UserMessageItem {
+  return {
+    kind: "user-message",
+    id,
+    text,
+    resources: [],
+    tools: [],
+    occurredAt: "2026-08-04T20:00:00.000Z",
+  };
+}
+
+function agent(text: string): TimelineItem {
+  return {
+    kind: "agent-message",
+    id: "assistant-stream",
+    turnId: "turn-1",
+    text,
+    streaming: true,
+    occurredAt: "2026-08-04T20:00:01.000Z",
+  };
+}
+
+describe("UserMessageBody", () => {
+  test("keeps the complete Markdown subtree mounted behind an accessible disclosure", async () => {
+    const text = longMarkdown();
+    const r = await renderComponent(
+      <UserMessageBody messageId="message-long" text={text}>
+        <Markdown>{text}</Markdown>
+      </UserMessageBody>,
+    );
+
+    const button = r.container.querySelector<HTMLButtonElement>(
+      "[data-og-user-message-disclosure]",
+    );
+    const clip = r.container.querySelector<HTMLElement>("[data-og-user-message-clip]");
+    expect(button?.textContent).toBe("Show more");
+    expect(button?.getAttribute("aria-expanded")).toBe("false");
+    expect(button?.getAttribute("aria-controls")).toBe(clip?.id);
+    expect(r.container.querySelector("[data-og-user-message-fade]")).not.toBeNull();
+    expect(r.container.textContent).toContain("こんにちは · مرحبا · 👩🏽‍💻");
+    expect(r.container.textContent).toContain("Final paragraph after the long URL.");
+    expect(r.container.querySelector("pre code")?.textContent).toContain("console.log(unicode)");
+
+    await actRun(() => button?.click());
+    expect(button?.textContent).toBe("Show less");
+    expect(button?.getAttribute("aria-expanded")).toBe("true");
+    expect(r.container.querySelector("[data-og-user-message-fade]")).toBeNull();
+    expect(r.container.textContent).toContain("Final paragraph after the long URL.");
+
+    await actRun(() => button?.click());
+    expect(button?.getAttribute("aria-expanded")).toBe("false");
+    await r.unmount();
+  });
+
+  test("uses rendered height when layout measurement is available", async () => {
+    const callbacks: ResizeObserverCallback[] = [];
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        callbacks.push(callback);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    const r = await renderComponent(
+      <UserMessageBody messageId="measured" text="Short source with tall rendered children">
+        <div>Measured content</div>
+      </UserMessageBody>,
+    );
+    const content = r.container.querySelector<HTMLElement>("[data-og-user-message-content]")!;
+    const threshold = r.container.querySelector<HTMLElement>("[aria-hidden='true']")!;
+    Object.defineProperty(content, "scrollHeight", { configurable: true, value: 480 });
+    Object.defineProperty(threshold, "offsetHeight", { configurable: true, value: 224 });
+
+    await actRun(() => callbacks.forEach((callback) => callback([], {} as ResizeObserver)));
+    expect(r.container.querySelector("[data-og-user-message-disclosure]")).not.toBeNull();
+
+    Object.defineProperty(content, "scrollHeight", { configurable: true, value: 180 });
+    await actRun(() => callbacks.forEach((callback) => callback([], {} as ResizeObserver)));
+    expect(r.container.querySelector("[data-og-user-message-disclosure]")).toBeNull();
+    await r.unmount();
+  });
+
+  test("leaves ordinary messages unchanged", async () => {
+    const r = await renderComponent(
+      <UserMessageBody messageId="short" text="Ordinary prompt">
+        <p>Ordinary prompt</p>
+      </UserMessageBody>,
+    );
+    expect(r.container.querySelector("[data-og-user-message-disclosure]")).toBeNull();
+    expect(r.container.textContent).toBe("Ordinary prompt");
+    await r.unmount();
+  });
+});
+
+describe("MessageTimeline user-message disclosure", () => {
+  test("retains per-message expansion through assistant streaming and history prepend", async () => {
+    const text = longMarkdown();
+    const initial = [user("long-user", text), agent("Streaming response")];
+    const r = await renderComponent(<MessageTimeline items={initial} />);
+    await flush();
+    const button = r.container.querySelector<HTMLButtonElement>(
+      "[data-og-user-message-disclosure]",
+    )!;
+    await actRun(() => button.click());
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+
+    await r.rerender(
+      <MessageTimeline
+        items={[
+          user("older", "Earlier message"),
+          user("long-user", text),
+          agent("Streaming response grew without changing the user message"),
+        ]}
+      />,
+    );
+    await flush();
+    expect(
+      r.container
+        .querySelector("[data-og-message-id='long-user'] [data-og-user-message-disclosure]")
+        ?.getAttribute("aria-expanded"),
+    ).toBe("true");
+    expect(r.container.textContent).toContain("Earlier message");
+    expect(r.container.textContent).toContain("Streaming response grew");
+    await r.unmount();
+  });
+
+  test("keeps voice identity and attachments outside the collapsed text region", async () => {
+    const text = longMarkdown();
+    const voiceItem: TimelineItem = {
+      ...user("voice-user", text),
+      resources: [
+        { kind: "repository", uri: "https://github.com/example/repository.git", ref: "main" },
+      ],
+      presentation: {
+        kind: "realtime_voice_handoff",
+        context: "Complete voice execution context",
+      },
+    };
+    const r = await renderComponent(
+      <MessageTimeline
+        items={[voiceItem]}
+        renderMessageText={(messageText, item) =>
+          item.kind === "user-message" ? (
+            <div data-testid="custom-user-message">
+              <div data-testid="voice-identity">Voice handoff</div>
+              <div data-testid="attachments">
+                {item.resources.map((resource) =>
+                  resource.kind === "repository" ? resource.uri : resource.fileId,
+                )}
+              </div>
+              <UserMessageBody messageId={item.id} text={messageText}>
+                <Markdown>{messageText}</Markdown>
+              </UserMessageBody>
+              <div data-testid="voice-context">{item.presentation?.context}</div>
+            </div>
+          ) : (
+            messageText
+          )
+        }
+      />,
+    );
+    await flush();
+    const clip = r.container.querySelector("[data-og-user-message-clip]")!;
+    const voice = r.container.querySelector("[data-testid='voice-identity']")!;
+    const attachments = r.container.querySelector("[data-testid='attachments']")!;
+    const context = r.container.querySelector("[data-testid='voice-context']")!;
+    expect(clip.contains(voice)).toBe(false);
+    expect(clip.contains(attachments)).toBe(false);
+    expect(clip.contains(context)).toBe(false);
+    expect(voice.textContent).toBe("Voice handoff");
+    expect(attachments.textContent).toContain("repository.git");
+    expect(context.textContent).toBe("Complete voice execution context");
+    expect(
+      r.container.querySelector("[data-og-user-message-disclosure]")?.getAttribute("aria-expanded"),
+    ).toBe("false");
+    await r.unmount();
+  });
+});

--- a/packages/react/test/user-message-body.test.tsx
+++ b/packages/react/test/user-message-body.test.tsx
@@ -62,6 +62,20 @@ function agent(text: string): TimelineItem {
   };
 }
 
+function elementRect(top: number, bottom: number, left = 0, right = 240): DOMRect {
+  return {
+    x: left,
+    y: top,
+    top,
+    bottom,
+    left,
+    right,
+    width: right - left,
+    height: bottom - top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
 describe("UserMessageBody", () => {
   test("keeps the complete Markdown subtree mounted behind an accessible disclosure", async () => {
     const text = longMarkdown();
@@ -121,6 +135,81 @@ describe("UserMessageBody", () => {
     Object.defineProperty(content, "scrollHeight", { configurable: true, value: 180 });
     await actRun(() => callbacks.forEach((callback) => callback([], {} as ResizeObserver)));
     expect(r.container.querySelector("[data-og-user-message-disclosure]")).toBeNull();
+    await r.unmount();
+  });
+
+  test("makes only clipped interactive descendants inert and restores focusability on expand", async () => {
+    const callbacks: ResizeObserverCallback[] = [];
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        callbacks.push(callback);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    const r = await renderComponent(
+      <UserMessageBody messageId="interactive" text={longMarkdown()}>
+        <a data-testid="visible-link" href="https://example.test/visible">
+          Visible link
+        </a>
+        <a data-testid="hidden-link" href="https://example.test/hidden">
+          Hidden link
+        </a>
+        <button data-testid="hidden-button" type="button">
+          Hidden action
+        </button>
+        <button data-testid="preexisting-inert" type="button">
+          Already inert
+        </button>
+      </UserMessageBody>,
+    );
+    const clip = r.container.querySelector<HTMLElement>("[data-og-user-message-clip]")!;
+    const content = r.container.querySelector<HTMLElement>("[data-og-user-message-content]")!;
+    const threshold = r.container.querySelector<HTMLElement>("[aria-hidden='true']")!;
+    const disclosure = r.container.querySelector<HTMLButtonElement>(
+      "[data-og-user-message-disclosure]",
+    )!;
+    const visibleLink = r.container.querySelector<HTMLElement>("[data-testid='visible-link']")!;
+    const hiddenLink = r.container.querySelector<HTMLElement>("[data-testid='hidden-link']")!;
+    const hiddenButton = r.container.querySelector<HTMLButtonElement>(
+      "[data-testid='hidden-button']",
+    )!;
+    const preexistingInert = r.container.querySelector<HTMLElement>(
+      "[data-testid='preexisting-inert']",
+    )!;
+
+    Object.defineProperty(content, "scrollHeight", { configurable: true, value: 520 });
+    Object.defineProperty(threshold, "offsetHeight", { configurable: true, value: 224 });
+    clip.getBoundingClientRect = () => elementRect(0, 224);
+    visibleLink.getBoundingClientRect = () => elementRect(24, 48);
+    hiddenLink.getBoundingClientRect = () => elementRect(260, 284);
+    hiddenButton.getBoundingClientRect = () => elementRect(300, 332);
+    preexistingInert.getBoundingClientRect = () => elementRect(348, 380);
+    preexistingInert.setAttribute("inert", "");
+
+    await actRun(() => callbacks.forEach((callback) => callback([], {} as ResizeObserver)));
+    expect(visibleLink.hasAttribute("inert")).toBe(false);
+    expect(hiddenLink.hasAttribute("inert")).toBe(true);
+    expect(hiddenButton.hasAttribute("inert")).toBe(true);
+    expect(hiddenLink.hasAttribute("data-og-user-message-managed-inert")).toBe(true);
+    expect(preexistingInert.hasAttribute("inert")).toBe(true);
+    expect(preexistingInert.hasAttribute("data-og-user-message-managed-inert")).toBe(false);
+
+    await actRun(() => disclosure.click());
+    expect(disclosure.getAttribute("aria-expanded")).toBe("true");
+    expect(hiddenLink.hasAttribute("inert")).toBe(false);
+    expect(hiddenButton.hasAttribute("inert")).toBe(false);
+    expect(preexistingInert.hasAttribute("inert")).toBe(true);
+
+    hiddenButton.focus();
+    expect(document.activeElement).toBe(hiddenButton);
+    await actRun(() => disclosure.click());
+    expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(disclosure);
+    expect(hiddenLink.hasAttribute("inert")).toBe(true);
+    expect(hiddenButton.hasAttribute("inert")).toBe(true);
     await r.unmount();
   });
 

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -13,6 +13,7 @@ const testFiles =
         "./test/e2e/session-header.browser.e2e.ts",
         "./test/e2e/session-pins.browser.e2e.ts",
         "./test/e2e/timeline-scroll.browser.e2e.ts",
+        "./test/e2e/user-message-disclosure.browser.e2e.ts",
         "./test/e2e/workbench.browser.e2e.ts",
       ];
 

--- a/test/e2e/user-message-disclosure.browser.e2e.ts
+++ b/test/e2e/user-message-disclosure.browser.e2e.ts
@@ -55,6 +55,9 @@ describe("long sent user-message browser acceptance", () => {
         const body = page.locator('[data-og-message-id="long-user-message"]');
         const clip = body.locator("[data-og-user-message-clip]");
         const disclosure = body.getByRole("button", { name: "Show more" });
+        const visibleLink = body.getByRole("link", { name: "Visible preview link" });
+        const hiddenLink = body.locator('a[href="https://example.test/hidden-review"]');
+        const hiddenAction = body.locator("[data-hidden-message-action]");
         await disclosure.scrollIntoViewIfNeeded();
         const collapsed = await body.evaluate((node) => {
           const clipNode = node.querySelector<HTMLElement>("[data-og-user-message-clip]")!;
@@ -86,6 +89,52 @@ describe("long sent user-message browser acceptance", () => {
         expect(collapsed.voiceOutsideClip).toBe(true);
         expect(collapsed.contextOutsideClip).toBe(true);
         expect(collapsed.pageOverflow).toBeLessThanOrEqual(1);
+        expect(
+          await body.evaluate((node) => {
+            const paragraph = [...node.querySelectorAll("p")].find((candidate) =>
+              candidate.textContent?.includes("This already-sent prompt"),
+            );
+            const selection = window.getSelection();
+            if (!paragraph || !selection) {
+              return "";
+            }
+            const range = document.createRange();
+            range.selectNodeContents(paragraph);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            const selected = selection.toString();
+            selection.removeAllRanges();
+            return selected;
+          }),
+        ).toContain("This already-sent prompt");
+        expect(await visibleLink.evaluate((node) => node.hasAttribute("inert"))).toBe(false);
+        expect(await hiddenLink.evaluate((node) => node.hasAttribute("inert"))).toBe(true);
+        expect(await hiddenAction.evaluate((node) => node.hasAttribute("inert"))).toBe(true);
+
+        const collapsedAccessibility = await new AxeBuilder({ page })
+          .include('[data-og-message-id="long-user-message"]')
+          .analyze();
+        expect(collapsedAccessibility.violations).toEqual([]);
+
+        await visibleLink.focus();
+        await page.keyboard.press("Tab");
+        expect(
+          await page.evaluate(() =>
+            document.activeElement?.hasAttribute("data-og-user-message-disclosure"),
+          ),
+        ).toBe(true);
+        await hiddenLink.evaluate((node: HTMLElement) => node.focus());
+        expect(
+          await page.evaluate(() =>
+            document.activeElement?.hasAttribute("data-og-user-message-disclosure"),
+          ),
+        ).toBe(true);
+        await hiddenAction.evaluate((node: HTMLElement) => node.focus());
+        expect(
+          await page.evaluate(() =>
+            document.activeElement?.hasAttribute("data-og-user-message-disclosure"),
+          ),
+        ).toBe(true);
 
         if (evidenceDir) {
           await page.screenshot({
@@ -96,12 +145,47 @@ describe("long sent user-message browser acceptance", () => {
 
         await disclosure.focus();
         await page.keyboard.press("Enter");
-        const showLess = body.getByRole("button", { name: "Show less" });
+        let showLess = body.getByRole("button", { name: "Show less" });
         await showLess.waitFor();
         expect(await showLess.getAttribute("aria-expanded")).toBe("true");
         const expandedHeight = await clip.evaluate((node) => node.getBoundingClientRect().height);
         expect(expandedHeight).toBeGreaterThan(collapsed.clipHeight + 100);
         expect(await body.locator("[data-og-user-message-fade]").count()).toBe(0);
+        expect(await hiddenLink.evaluate((node) => node.hasAttribute("inert"))).toBe(false);
+        expect(await hiddenAction.evaluate((node) => node.hasAttribute("inert"))).toBe(false);
+
+        await visibleLink.focus();
+        await page.keyboard.press("Tab");
+        expect(
+          await body.evaluate((node) => {
+            const content = node.querySelector("[data-og-user-message-content]");
+            const active = document.activeElement;
+            return {
+              insideContent: Boolean(content && active && content.contains(active)),
+              insideInertSubtree: Boolean(active?.closest("[inert]")),
+            };
+          }),
+        ).toEqual({ insideContent: true, insideInertSubtree: false });
+
+        await hiddenLink.focus();
+        expect(await page.evaluate(() => document.activeElement?.getAttribute("href"))).toBe(
+          "https://example.test/hidden-review",
+        );
+
+        await hiddenAction.focus();
+        await showLess.evaluate((node: HTMLButtonElement) => node.click());
+        const showMoreAgain = body.getByRole("button", { name: "Show more" });
+        await showMoreAgain.waitFor();
+        expect(
+          await page.evaluate(() =>
+            document.activeElement?.hasAttribute("data-og-user-message-disclosure"),
+          ),
+        ).toBe(true);
+        expect(await hiddenLink.evaluate((node) => node.hasAttribute("inert"))).toBe(true);
+        expect(await hiddenAction.evaluate((node) => node.hasAttribute("inert"))).toBe(true);
+        await page.keyboard.press("Enter");
+        showLess = body.getByRole("button", { name: "Show less" });
+        await showLess.waitFor();
 
         const accessibility = await new AxeBuilder({ page })
           .include('[data-og-message-id="long-user-message"]')
@@ -122,6 +206,7 @@ describe("long sent user-message browser acceptance", () => {
                 expandedHeight,
                 ariaExpanded: await showLess.getAttribute("aria-expanded"),
                 focusedLabel: await page.evaluate(() => document.activeElement?.textContent),
+                collapsedAxeViolations: collapsedAccessibility.violations.length,
                 axeViolations: accessibility.violations.length,
               },
               null,

--- a/test/e2e/user-message-disclosure.browser.e2e.ts
+++ b/test/e2e/user-message-disclosure.browser.e2e.ts
@@ -58,10 +58,19 @@ describe("long sent user-message browser acceptance", () => {
         const visibleLink = body.getByRole("link", { name: "Visible preview link" });
         const hiddenLink = body.locator('a[href="https://example.test/hidden-review"]');
         const hiddenAction = body.locator("[data-hidden-message-action]");
+        const shadowHost = body.locator("[data-hidden-shadow-control]");
+        const zeroSizeAction = body.locator("[data-zero-size-message-action]");
+        const preexistingInertAction = body.locator("[data-preexisting-inert-message-action]");
         await disclosure.scrollIntoViewIfNeeded();
+        await forceResizeResync(page);
         const collapsed = await body.evaluate((node) => {
           const clipNode = node.querySelector<HTMLElement>("[data-og-user-message-clip]")!;
+          const shadowNode = node.querySelector<HTMLElement>("[data-hidden-shadow-control]")!;
+          const zeroSizeNode = node.querySelector<HTMLElement>("[data-zero-size-message-action]")!;
           const root = document.documentElement;
+          const clipRect = clipNode.getBoundingClientRect();
+          const shadowRect = shadowNode.getBoundingClientRect();
+          const zeroSizeRect = zeroSizeNode.getBoundingClientRect();
           return {
             ariaExpanded: node
               .querySelector("[data-og-user-message-disclosure]")
@@ -77,6 +86,11 @@ describe("long sent user-message browser acceptance", () => {
             voiceOutsideClip: !clipNode.contains(node.querySelector("[data-voice-identity]")),
             contextOutsideClip: !clipNode.contains(node.querySelector("[data-voice-context]")),
             pageOverflow: root.scrollWidth - window.innerWidth,
+            shadowTop: shadowRect.top,
+            zeroSizeTop: zeroSizeRect.top,
+            zeroSizeWidth: zeroSizeRect.width,
+            zeroSizeHeight: zeroSizeRect.height,
+            clipBottom: clipRect.bottom,
           };
         });
         expect(collapsed.ariaExpanded).toBe("false");
@@ -89,6 +103,10 @@ describe("long sent user-message browser acceptance", () => {
         expect(collapsed.voiceOutsideClip).toBe(true);
         expect(collapsed.contextOutsideClip).toBe(true);
         expect(collapsed.pageOverflow).toBeLessThanOrEqual(1);
+        expect(collapsed.shadowTop).toBeGreaterThan(collapsed.clipBottom);
+        expect(collapsed.zeroSizeTop).toBeGreaterThan(collapsed.clipBottom);
+        expect(collapsed.zeroSizeWidth).toBeLessThanOrEqual(0.5);
+        expect(collapsed.zeroSizeHeight).toBeLessThanOrEqual(0.5);
         expect(
           await body.evaluate((node) => {
             const paragraph = [...node.querySelectorAll("p")].find((candidate) =>
@@ -110,6 +128,21 @@ describe("long sent user-message browser acceptance", () => {
         expect(await visibleLink.evaluate((node) => node.hasAttribute("inert"))).toBe(false);
         expect(await hiddenLink.evaluate((node) => node.hasAttribute("inert"))).toBe(true);
         expect(await hiddenAction.evaluate((node) => node.hasAttribute("inert"))).toBe(true);
+        expect(await shadowHost.evaluate((node) => node.hasAttribute("inert"))).toBe(false);
+        expect(
+          await shadowHost.evaluate((node) =>
+            node.shadowRoot?.querySelector("button")?.hasAttribute("inert"),
+          ),
+        ).toBe(true);
+        expect(await zeroSizeAction.evaluate((node) => node.hasAttribute("inert"))).toBe(true);
+        expect(await preexistingInertAction.evaluate((node) => node.hasAttribute("inert"))).toBe(
+          true,
+        );
+        expect(
+          await preexistingInertAction.evaluate((node) =>
+            node.hasAttribute("data-og-user-message-managed-inert"),
+          ),
+        ).toBe(false);
 
         const collapsedAccessibility = await new AxeBuilder({ page })
           .include('[data-og-message-id="long-user-message"]')
@@ -123,12 +156,39 @@ describe("long sent user-message browser acceptance", () => {
             document.activeElement?.hasAttribute("data-og-user-message-disclosure"),
           ),
         ).toBe(true);
+        await page.keyboard.press("Shift+Tab");
+        expect(await page.evaluate(() => document.activeElement?.getAttribute("href"))).toBe(
+          "https://example.test/visible-preview",
+        );
+        await disclosure.focus();
         await hiddenLink.evaluate((node: HTMLElement) => node.focus());
         expect(
           await page.evaluate(() =>
             document.activeElement?.hasAttribute("data-og-user-message-disclosure"),
           ),
         ).toBe(true);
+        await shadowHost.evaluate((node) => {
+          (node.shadowRoot?.querySelector("button") as HTMLElement | null)?.focus();
+        });
+        expect(
+          await page.evaluate(() =>
+            document.activeElement?.hasAttribute("data-og-user-message-disclosure"),
+          ),
+        ).toBe(true);
+        await zeroSizeAction.evaluate((node: HTMLElement) => node.focus());
+        expect(
+          await page.evaluate(() =>
+            document.activeElement?.hasAttribute("data-og-user-message-disclosure"),
+          ),
+        ).toBe(true);
+        await preexistingInertAction.evaluate((node: HTMLElement) => node.focus());
+        expect(
+          await page.evaluate(() =>
+            document.activeElement?.hasAttribute("data-og-user-message-disclosure"),
+          ),
+        ).toBe(true);
+        const collapsedAxTree = await chromeAccessibilityTree(page);
+        expect(exposedSpecialControlNames(collapsedAxTree)).toEqual([]);
         await hiddenAction.evaluate((node: HTMLElement) => node.focus());
         expect(
           await page.evaluate(() =>
@@ -153,6 +213,16 @@ describe("long sent user-message browser acceptance", () => {
         expect(await body.locator("[data-og-user-message-fade]").count()).toBe(0);
         expect(await hiddenLink.evaluate((node) => node.hasAttribute("inert"))).toBe(false);
         expect(await hiddenAction.evaluate((node) => node.hasAttribute("inert"))).toBe(false);
+        expect(await shadowHost.evaluate((node) => node.hasAttribute("inert"))).toBe(false);
+        expect(
+          await shadowHost.evaluate((node) =>
+            node.shadowRoot?.querySelector("button")?.hasAttribute("inert"),
+          ),
+        ).toBe(false);
+        expect(await zeroSizeAction.evaluate((node) => node.hasAttribute("inert"))).toBe(false);
+        expect(await preexistingInertAction.evaluate((node) => node.hasAttribute("inert"))).toBe(
+          true,
+        );
 
         await visibleLink.focus();
         await page.keyboard.press("Tab");
@@ -172,7 +242,34 @@ describe("long sent user-message browser acceptance", () => {
           "https://example.test/hidden-review",
         );
 
-        await hiddenAction.focus();
+        expect(
+          await shadowHost.evaluate((node) => {
+            const button = node.shadowRoot?.querySelector("button") as HTMLElement | null;
+            button?.focus();
+            return {
+              documentFocusOnHost: document.activeElement === node,
+              shadowFocusLabel: node.shadowRoot?.activeElement?.textContent,
+            };
+          }),
+        ).toEqual({ documentFocusOnHost: true, shadowFocusLabel: "Shadow hidden action" });
+        await zeroSizeAction.focus();
+        expect(
+          await page.evaluate(() =>
+            document.activeElement?.hasAttribute("data-zero-size-message-action"),
+          ),
+        ).toBe(true);
+        await preexistingInertAction.evaluate((node: HTMLElement) => node.focus());
+        expect(
+          await page.evaluate(() =>
+            document.activeElement?.hasAttribute("data-zero-size-message-action"),
+          ),
+        ).toBe(true);
+        const expandedAxTree = await chromeAccessibilityTree(page);
+        expect(exposedSpecialControlNames(expandedAxTree)).toEqual([
+          "Shadow hidden action",
+          "Zero-size hidden action",
+        ]);
+
         await showLess.evaluate((node: HTMLButtonElement) => node.click());
         const showMoreAgain = body.getByRole("button", { name: "Show more" });
         await showMoreAgain.waitFor();
@@ -183,6 +280,36 @@ describe("long sent user-message browser acceptance", () => {
         ).toBe(true);
         expect(await hiddenLink.evaluate((node) => node.hasAttribute("inert"))).toBe(true);
         expect(await hiddenAction.evaluate((node) => node.hasAttribute("inert"))).toBe(true);
+        expect(await shadowHost.evaluate((node) => node.hasAttribute("inert"))).toBe(false);
+        expect(
+          await shadowHost.evaluate((node) =>
+            node.shadowRoot?.querySelector("button")?.hasAttribute("inert"),
+          ),
+        ).toBe(true);
+        expect(await zeroSizeAction.evaluate((node) => node.hasAttribute("inert"))).toBe(true);
+        expect(await preexistingInertAction.evaluate((node) => node.hasAttribute("inert"))).toBe(
+          true,
+        );
+
+        await shadowHost.evaluate((node) =>
+          node.shadowRoot?.querySelector("button")?.removeAttribute("inert"),
+        );
+        await zeroSizeAction.evaluate((node) => node.removeAttribute("inert"));
+        await forceResizeResync(page);
+        expect(
+          await shadowHost.evaluate((node) =>
+            node.shadowRoot?.querySelector("button")?.hasAttribute("inert"),
+          ),
+        ).toBe(true);
+        expect(await zeroSizeAction.evaluate((node) => node.hasAttribute("inert"))).toBe(true);
+        await shadowHost.evaluate((node) => {
+          (node.shadowRoot?.querySelector("button") as HTMLElement | null)?.focus();
+        });
+        expect(
+          await page.evaluate(() =>
+            document.activeElement?.hasAttribute("data-og-user-message-disclosure"),
+          ),
+        ).toBe(true);
         await page.keyboard.press("Enter");
         showLess = body.getByRole("button", { name: "Show less" });
         await showLess.waitFor();
@@ -208,6 +335,8 @@ describe("long sent user-message browser acceptance", () => {
                 focusedLabel: await page.evaluate(() => document.activeElement?.textContent),
                 collapsedAxeViolations: collapsedAccessibility.violations.length,
                 axeViolations: accessibility.violations.length,
+                collapsedSpecialAxControls: exposedSpecialControlNames(collapsedAxTree),
+                expandedSpecialAxControls: exposedSpecialControlNames(expandedAxTree),
               },
               null,
               2,
@@ -318,4 +447,46 @@ async function relativeTop(target: Locator, scroller: Locator) {
     throw new Error("expected visible target and timeline scroller");
   }
   return targetBox.y - scrollerBox.y;
+}
+
+type AccessibleTreeNode = {
+  ignored: boolean;
+  role: string;
+  name: string;
+};
+
+async function chromeAccessibilityTree(page: Page): Promise<AccessibleTreeNode[]> {
+  const session = await page.context().newCDPSession(page);
+  try {
+    const { nodes } = await session.send("Accessibility.getFullAXTree");
+    return nodes.map((node) => ({
+      ignored: node.ignored,
+      role: accessibilityValue(node.role),
+      name: accessibilityValue(node.name),
+    }));
+  } finally {
+    await session.detach();
+  }
+}
+
+function accessibilityValue(value: { value?: unknown } | undefined): string {
+  return typeof value?.value === "string" ? value.value : "";
+}
+
+function exposedSpecialControlNames(nodes: AccessibleTreeNode[]): string[] {
+  const names = new Set(["Shadow hidden action", "Zero-size hidden action"]);
+  return nodes
+    .filter((node) => !node.ignored && node.role === "button" && names.has(node.name))
+    .map((node) => node.name)
+    .sort();
+}
+
+async function forceResizeResync(page: Page) {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        window.dispatchEvent(new Event("resize"));
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
 }

--- a/test/e2e/user-message-disclosure.browser.e2e.ts
+++ b/test/e2e/user-message-disclosure.browser.e2e.ts
@@ -1,0 +1,236 @@
+import AxeBuilder from "@axe-core/playwright";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+import { chromium, type Browser, type Locator, type Page } from "playwright";
+
+const repoRoot = new URL("../..", import.meta.url).pathname;
+const demoRoot = `${repoRoot}/packages/react/demo`;
+const evidenceDir = process.env.USER_MESSAGE_ARTIFACT_DIR;
+
+describe("long sent user-message browser acceptance", () => {
+  let web: StartedProcess;
+  let browser: Browser;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    web = await startProcess(
+      ["bun", "run", "vite", ".", "--port", String(port), "--strictPort", "--host", "127.0.0.1"],
+      {
+        cwd: demoRoot,
+        ready: async () =>
+          (await fetch(baseUrl, { signal: AbortSignal.timeout(2_000) }).catch(() => null))?.ok ===
+          true,
+        timeoutMs: 45_000,
+      },
+    );
+    const executablePath = [
+      process.env.CHROMIUM_EXECUTABLE_PATH,
+      "/opt/google/chrome/chrome",
+      "/usr/local/bin/chromium",
+    ].find((candidate): candidate is string => Boolean(candidate && existsSync(candidate)));
+    browser = await chromium.launch({
+      ...(executablePath ? { executablePath } : {}),
+      args: ["--no-sandbox", "--disable-dev-shm-usage"],
+    });
+    if (evidenceDir) {
+      await mkdir(evidenceDir, { recursive: true });
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    await Promise.allSettled([browser?.close(), web?.stop()]);
+  });
+
+  for (const viewport of [
+    { name: "mobile", width: 390, height: 844 },
+    { name: "desktop", width: 1440, height: 960 },
+  ] as const) {
+    test(`is lossless, bounded, keyboard accessible, and viewport-safe on ${viewport.name}`, async () => {
+      const page = await openHarness(browser, baseUrl, viewport);
+      try {
+        const body = page.locator('[data-og-message-id="long-user-message"]');
+        const clip = body.locator("[data-og-user-message-clip]");
+        const disclosure = body.getByRole("button", { name: "Show more" });
+        await disclosure.scrollIntoViewIfNeeded();
+        const collapsed = await body.evaluate((node) => {
+          const clipNode = node.querySelector<HTMLElement>("[data-og-user-message-clip]")!;
+          const root = document.documentElement;
+          return {
+            ariaExpanded: node
+              .querySelector("[data-og-user-message-disclosure]")
+              ?.getAttribute("aria-expanded"),
+            clipHeight: clipNode.getBoundingClientRect().height,
+            clipScrollHeight: clipNode.scrollHeight,
+            hasFade: Boolean(node.querySelector("[data-og-user-message-fade]")),
+            hasFinalParagraph: (node.textContent ?? "").includes("Final paragraph after the URL"),
+            hasUnicode: (node.textContent ?? "").includes("こんにちは · مرحبا · 👩🏽‍💻"),
+            attachmentOutsideClip: !clipNode.contains(
+              node.querySelector("[data-message-attachments]"),
+            ),
+            voiceOutsideClip: !clipNode.contains(node.querySelector("[data-voice-identity]")),
+            contextOutsideClip: !clipNode.contains(node.querySelector("[data-voice-context]")),
+            pageOverflow: root.scrollWidth - window.innerWidth,
+          };
+        });
+        expect(collapsed.ariaExpanded).toBe("false");
+        expect(collapsed.clipHeight).toBeLessThanOrEqual(viewport.width < 640 ? 225 : 289);
+        expect(collapsed.clipScrollHeight).toBeGreaterThan(collapsed.clipHeight + 100);
+        expect(collapsed.hasFade).toBe(true);
+        expect(collapsed.hasFinalParagraph).toBe(true);
+        expect(collapsed.hasUnicode).toBe(true);
+        expect(collapsed.attachmentOutsideClip).toBe(true);
+        expect(collapsed.voiceOutsideClip).toBe(true);
+        expect(collapsed.contextOutsideClip).toBe(true);
+        expect(collapsed.pageOverflow).toBeLessThanOrEqual(1);
+
+        if (evidenceDir) {
+          await page.screenshot({
+            path: `${evidenceDir}/user-message-${viewport.name}-collapsed.png`,
+            fullPage: true,
+          });
+        }
+
+        await disclosure.focus();
+        await page.keyboard.press("Enter");
+        const showLess = body.getByRole("button", { name: "Show less" });
+        await showLess.waitFor();
+        expect(await showLess.getAttribute("aria-expanded")).toBe("true");
+        const expandedHeight = await clip.evaluate((node) => node.getBoundingClientRect().height);
+        expect(expandedHeight).toBeGreaterThan(collapsed.clipHeight + 100);
+        expect(await body.locator("[data-og-user-message-fade]").count()).toBe(0);
+
+        const accessibility = await new AxeBuilder({ page })
+          .include('[data-og-message-id="long-user-message"]')
+          .analyze();
+        expect(accessibility.violations).toEqual([]);
+
+        if (evidenceDir) {
+          await page.screenshot({
+            path: `${evidenceDir}/user-message-${viewport.name}-expanded.png`,
+            fullPage: true,
+          });
+          await writeFile(
+            `${evidenceDir}/user-message-${viewport.name}-accessibility.json`,
+            `${JSON.stringify(
+              {
+                viewport,
+                collapsed,
+                expandedHeight,
+                ariaExpanded: await showLess.getAttribute("aria-expanded"),
+                focusedLabel: await page.evaluate(() => document.activeElement?.textContent),
+                axeViolations: accessibility.violations.length,
+              },
+              null,
+              2,
+            )}\n`,
+          );
+        }
+      } finally {
+        await page.context().close();
+      }
+    }, 30_000);
+  }
+
+  test("preserves scrolled-back anchors, expansion state, streaming, and prepend", async () => {
+    const page = await openHarness(browser, baseUrl, { width: 1280, height: 900 });
+    try {
+      const body = page.locator('[data-og-message-id="long-user-message"]');
+      const group = body.locator("xpath=ancestor::*[@data-og-timeline-group-anchor]");
+      const scroller = page.locator("[data-og-timeline-scroller]");
+      await scroller.evaluate((node) => {
+        node.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }));
+      });
+      await group.evaluate((node) => node.scrollIntoView({ block: "start" }));
+      await page.waitForTimeout(100);
+      expect(await scroller.getAttribute("data-og-bottom-follow")).toBe("false");
+      const beforeExpand = await relativeTop(group, scroller);
+      await body
+        .getByRole("button", { name: "Show more" })
+        .evaluate((node: HTMLButtonElement) => node.click());
+      const afterExpand = await relativeTop(group, scroller);
+      expect(afterExpand).toBeCloseTo(beforeExpand, 0);
+
+      await page.evaluate(() => window.userMessageHarness!.stream());
+      await page.evaluate(() => window.userMessageHarness!.prepend());
+      expect(
+        await body.locator("[data-og-user-message-disclosure]").getAttribute("aria-expanded"),
+      ).toBe("true");
+      const afterUpdates = await relativeTop(group, scroller);
+      expect(afterUpdates).toBeCloseTo(afterExpand, 0);
+
+      const showLess = body.getByRole("button", { name: "Show less" });
+      await showLess.evaluate((node) => node.scrollIntoView({ block: "center" }));
+      await page.waitForTimeout(50);
+      const beforeCollapse = await relativeTop(showLess, scroller);
+      await showLess.evaluate((node: HTMLButtonElement) => node.click());
+      const afterCollapse = await relativeTop(
+        body.getByRole("button", { name: "Show more" }),
+        scroller,
+      );
+      expect(afterCollapse).toBeCloseTo(beforeCollapse, 0);
+      expect(await scroller.getAttribute("data-og-bottom-follow")).toBe("false");
+    } finally {
+      await page.context().close();
+    }
+  }, 30_000);
+
+  test("keeps bottom-follow pinned when a near-tip message expands", async () => {
+    const page = await openHarness(browser, baseUrl, { width: 1280, height: 900 });
+    try {
+      const scroller = page.locator("[data-og-timeline-scroller]");
+      await scroller.evaluate((node) => {
+        node.scrollTop = node.scrollHeight;
+      });
+      await page.waitForTimeout(100);
+      expect(await scroller.getAttribute("data-og-bottom-follow")).toBe("true");
+      const disclosure = page
+        .locator('[data-og-message-id="long-user-message"]')
+        .getByRole("button", { name: "Show more" });
+      await disclosure.evaluate((node: HTMLButtonElement) => node.click());
+      await page.waitForFunction(() => {
+        const node = document.querySelector<HTMLElement>("[data-og-timeline-scroller]");
+        return Boolean(node && node.scrollHeight - node.scrollTop - node.clientHeight < 2);
+      });
+      const result = await scroller.evaluate((node) => ({
+        gap: node.scrollHeight - node.scrollTop - node.clientHeight,
+        bottomFollow: node.getAttribute("data-og-bottom-follow"),
+      }));
+      expect(result.gap).toBeLessThan(2);
+      expect(result.bottomFollow).toBe("true");
+    } finally {
+      await page.context().close();
+    }
+  }, 30_000);
+});
+
+async function openHarness(
+  browser: Browser,
+  baseUrl: string,
+  viewport: { width: number; height: number },
+): Promise<Page> {
+  const context = await browser.newContext({
+    viewport,
+    hasTouch: viewport.width <= 768,
+    isMobile: viewport.width <= 390,
+  });
+  const page = await context.newPage();
+  await page.goto(`${baseUrl}/user-message-test.html`);
+  await page.waitForFunction(() => window.userMessageHarness !== undefined);
+  await page.locator('[data-og-message-id="long-user-message"]').waitFor({ timeout: 15_000 });
+  return page;
+}
+
+async function relativeTop(target: Locator, scroller: Locator) {
+  const [targetBox, scrollerBox] = await Promise.all([
+    target.boundingBox(),
+    scroller.boundingBox(),
+  ]);
+  if (!targetBox || !scrollerBox) {
+    throw new Error("expected visible target and timeline scroller");
+  }
+  return targetBox.y - scrollerBox.y;
+}


### PR DESCRIPTION
## Summary

- add a shared, lossless `UserMessageBody` disclosure for very tall already-sent user messages, using real rendered height with deterministic non-layout fallback
- retain per-message expansion through rerenders, assistant streaming, and history prepend while preserving scrolled-back anchors and bottom-follow behavior
- keep voice identity, repositories/files, and voice context outside the clipped Markdown region; add accessible Show more/Show less controls and safe wrapping/contrast for long links
- add unit coverage plus a real Chromium mobile/desktop acceptance harness for losslessness, unbroken URLs, Unicode, keyboard/ARIA/Axe, pagination, streaming, and scroll anchoring

## Testing

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck` (23/23 projects)
- [x] `bun run --cwd packages/react build`
- [x] `bun run --cwd packages/react demo:build`
- [x] `bun run --cwd apps/web build` (bundle budgets pass)
- [x] focused React/timeline suites: 107 pass, 0 fail
- [x] dedicated Chromium suite: 4 tests, 37 assertions, 0 Axe violations on 390x844 and 1440x960
- [ ] `bun run test:unit` — 5,826 pass / 6 skip / 52 environment-dependent failures because this rigless sandbox has no PostgreSQL test database and cannot satisfy local provider/lifecycle fixtures; no focused or affected-surface failures

## Notes

- OPE-167
- OPE-9 queue/draft ownership is unchanged.
- OPE-99 timeline pagination ownership is unchanged; this PR only adds disclosure-specific anchor preservation at the existing timeline scroll owner.
- OPE-167 should remain In Progress after merge until production deployment/live verification.
