### PR TITLE
fix(db): serialize concurrent agent session creation

### DIFF
--- a/.changeset/serialize-agent-session-creation.md
+++ b/.changeset/serialize-agent-session-creation.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Prevent parallel child-session creation from the same agent attempt from deadlocking on the parent session row.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17432,6 +17432,18 @@ async function lockSessionCreateIdempotencyKey(
   );
 }
 
+async function lockAgentSessionCreate(tx: Database, input: SessionCreateInput): Promise<void> {
+  const actorSessionId = input.createdByActor?.sessionId;
+  if (!actorSessionId) return;
+  // Agent-originated child creation first reads the parent under FOR SHARE,
+  // then verifies the live attempt under FOR UPDATE. Serialize creates from
+  // the same parent session so concurrent tool calls cannot deadlock while
+  // upgrading that row lock. Unrelated sessions retain full concurrency.
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${`agent-session-create:${input.workspaceId}:${actorSessionId}`}, 0))`,
+  );
+}
+
 async function existingSpawnDenialForKey(
   tx: Database,
   workspaceId: string,
@@ -17536,6 +17548,8 @@ async function createSessionInTransaction(
       };
     }
   }
+
+  await lockAgentSessionCreate(tx, input);
 
   const decision = await resolveSessionDepthDecision(tx, input, id, workspace, deploymentPolicy);
   if (decision.denied) {

--- a/packages/db/test/session-depth-policy.test.ts
+++ b/packages/db/test/session-depth-policy.test.ts
@@ -2,10 +2,12 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import postgres from "postgres";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
 import {
+  claimSessionWorkForAttempt,
   createDb,
   createSession,
   createSessionWithIdempotencyKeyResult,
   getSessionSpawnDenialByIdempotencyKey,
+  initializeSessionStartAtomically,
   type DbClient,
   type Database,
   type SessionCreateResult,
@@ -107,6 +109,53 @@ describe("nested-agent depth database admission", () => {
       nestedAgentDepthPolicySource: "default",
       nestedAgentDepthPolicySessionId: null,
     });
+  }, 60_000);
+
+  test("serializes parallel agent child creation without a parent lock upgrade deadlock", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace("db parallel agent child creation");
+    const parent = await createSession(db, sessionInput(workspace, "parent"));
+    const started = await initializeSessionStartAtomically(db, {
+      accountId: workspace.accountId,
+      workspaceId: workspace.workspaceId,
+      sessionId: parent.id,
+      reasoningEffortFallback: "low",
+      createdEventPayload: {},
+    });
+    if (!started.turn) throw new Error("missing parent turn");
+    const attemptId = crypto.randomUUID();
+    const claimed = await claimSessionWorkForAttempt(db, workspace.workspaceId, {
+      sessionId: parent.id,
+      workflowId: `session-${parent.id}`,
+      workflowRunId: crypto.randomUUID(),
+      attemptId,
+      dispatchId: crypto.randomUUID(),
+      trigger: { kind: "next" },
+    });
+    if (claimed.action !== "claimed") throw new Error("parent turn was not claimed");
+    const createdByActor = {
+      type: "agent_attempt" as const,
+      sessionId: parent.id,
+      turnId: claimed.turn.id,
+      attemptId,
+      executionGeneration: claimed.turn.executionGeneration,
+    };
+
+    const children = await Promise.all(
+      Array.from({ length: 12 }, (_, index) =>
+        createSession(
+          db,
+          sessionInput(workspace, `child ${index}`, {
+            parentSessionId: parent.id,
+            createdByActor,
+          }),
+        ),
+      ),
+    );
+
+    expect(new Set(children.map((child) => child.id)).size).toBe(12);
+    expect(children.every((child) => child.parentSessionId === parent.id)).toBe(true);
+    expect(children.every((child) => child.nestedAgentDepth === 1)).toBe(true);
   }, 60_000);
 
   test("records one keyed denial without creating a session or child artifacts", async () => {


### PR DESCRIPTION
## Summary
- serialize agent-originated child-session creation per parent session inside the database transaction
- prevent concurrent `session_create` calls from deadlocking during the parent row lock upgrade
- add a 12-way concurrency regression test

## Validation
- `bun test packages/db/test/session-depth-policy.test.ts`
- `bun run typecheck` (`packages/db`)
- `bun run lint -- packages/db/src/index.ts packages/db/test/session-depth-policy.test.ts`
- `bun run format:check`