### PR TITLE
chore(release): bump product version to 0.22.74

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.73
-appVersion: "0.22.73"
+version: 0.22.74
+appVersion: "0.22.74"


### PR DESCRIPTION
Bumps the Helm chart and application version for the next immutable release candidate from current main.

Validation:
- helm lint deploy/helm/opengeni
- git diff --check