### PR TITLE
chore(release): prepare 0.22.74 maintenance cutover

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.73
-appVersion: "0.22.73"
+version: 0.22.74
+appVersion: "0.22.74"

--- a/docs/maintenance-migrations/0172-retire-model-visible-github-token.md
+++ b/docs/maintenance-migrations/0172-retire-model-visible-github-token.md
@@ -1,0 +1,11 @@
+# Maintenance release: migration 0172
+
+OpenGeni 0.22.74 applies the immutable
+`0172_retire_model_visible_github_token.sql` migration under the production
+maintenance gate. The migration removes the model-visible `github_token` tool
+from durable session selections and prevents older writers from restoring it.
+
+The release must use the maintenance deployment path so serving workloads are
+drained before the one-way migration and only the new runtime starts afterward.
+The candidate schema contract, production backup gate, rollout health checks,
+and live acceptance remain mandatory.


### PR DESCRIPTION
## Summary
- bump product and chart version to 0.22.74
- explicitly classify the release for the separately reviewed migration 0172 maintenance cutover
- preserve all backup, schema-contract, drain, rollout-health, and live-acceptance gates

## Reason
Production correctly rejected 0.22.73 before rollout because migration 0172 requires maintenance mode. This release binds that incompatible migration operation to a reviewed source change instead of weakening the schema gate.