### PR TITLE
docs: correct evidence-bound release flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Release and publishing guidance starts here; executable truth lives in [`package
 Two publish-coherence rules learned the hard way (all versions are 0.x):
 
 - **A minor bump of a package must cascade to its dependents.** Published manifests carry caret ranges (`^0.3.0`), and under 0.x caret semantics a minor bump (0.3.0 → 0.4.0) leaves every dependent's range. Add a patch changeset covering the dependent closure in the same release, or external consumers nest a stale copy of the bumped package.
-- **Publish-mode Release runs only on a Version-Packages-PR merge commit.** Any other push to `main` produces a version-mode run that just refreshes the Version PR. To ship a publish, merge the Version PR deliberately and watch that specific run.
+- **Merging a Version PR only creates versioned source; it does not publish.** Obtain the required native pre-merge review (including a human approval for a bot-authored Version PR), merge deliberately, then run the evidence-bound candidate, acceptance, and release workflows for that exact retained source.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

- clarify that merging the generated Version PR only creates versioned source
- document the native pre-merge review requirement
- point contributors at the evidence-bound candidate, acceptance, and release sequence

## Validation

- `bun run check:docs-refs`
- `git diff --check`

This is generic public release documentation only.