### PR TITLE
fix(release): select the latest protected check run

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -73,9 +73,11 @@ jobs:
             jq -e \
               --arg name "$name" \
               '[.check_runs[]
-                | select(.name == $name and .app.slug == "github-actions"
-                    and .status == "completed" and .conclusion == "success")]
-                | length == 1' \
+                | select(.name == $name and .app.slug == "github-actions")]
+                | if length == 0 then false
+                  else max_by(.id)
+                    | .status == "completed" and .conclusion == "success"
+                  end' \
               <<<"$checks" >/dev/null || {
                 echo "required exact-source check is not successful: $name" >&2
                 exit 1

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -393,6 +393,9 @@ describe("release image workflow contract", () => {
     expect(publish).toContain('test "$GITHUB_REF" = "refs/heads/main"');
     expect(publish).toContain('git merge-base --is-ancestor "$SOURCE_SHA" origin/main');
     expect(publish).not.toContain('test "$(git rev-parse origin/main)" = "$SOURCE_SHA"');
+    expect(publish).toContain("else max_by(.id)");
+    expect(publish).toContain('.status == "completed" and .conclusion == "success"');
+    expect(publish).not.toContain("| length == 1");
     for (const required of [
       "Typecheck and unit tests",
       "Deployment artifacts",


### PR DESCRIPTION
## Summary
- select the newest GitHub Actions check run for each protected source check
- permit legitimate duplicate check names while remaining fail-closed on missing, pending, or failed latest runs
- cover the workflow contract

## Verification
- bun test scripts/release-image-workflow-contract.test.ts
- synthetic jq cases for duplicate-success, latest-failure, and missing-check inputs
- git diff --check