### PR TITLE
OPE-169: reconcile quiescence while paused

### DIFF
--- a/.changeset/tidy-paused-quiescence.md
+++ b/.changeset/tidy-paused-quiescence.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Reconcile settled attempt quiescence while session control remains paused so ancestor sessions do not stay stuck in a stopping transition.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -39494,8 +39494,10 @@ export async function peekSessionWork(
         attemptId: interruption.attemptId,
       };
     }
-    if (effectiveControl.state !== "active") return { kind: "idle" };
-
+    // Physical quiescence finishes an already-accepted interruption; it is not
+    // new session work. Reconcile the missing receipt even while control stays
+    // paused, otherwise the pause itself can strand this session and every
+    // ancestor behind a permanent `settlement: stopping` projection.
     const awaitingQuiescence = await nextSessionAttemptAwaitingQuiescence(
       scopedDb,
       workspaceId,
@@ -39507,6 +39509,8 @@ export async function peekSessionWork(
         attemptId: awaitingQuiescence.attemptId,
       };
     }
+
+    if (effectiveControl.state !== "active") return { kind: "idle" };
 
     const [capacityWait] = await scopedDb
       .select()

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -3773,6 +3773,69 @@ describe("clean session control plane", () => {
     ).toEqual({ action: "quiesced", events: [] });
   });
 
+  test("a paused session still reconciles its settled attempt quiescence", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "run until paused");
+    const attemptId = crypto.randomUUID();
+    const workflowId = `session-${session.id}`;
+    const workflowRunId = crypto.randomUUID();
+    const dispatchId = `dispatch-${crypto.randomUUID()}`;
+    const predecessor = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      workflowId,
+      { attemptId, workflowRunId, dispatchId },
+    );
+    expect(predecessor).not.toBeNull();
+
+    await controlSession(grant, session.id, "pause");
+    expect(
+      await settleSessionAttemptInterruptions(client.db, grant.workspaceId!, session.id, attemptId),
+    ).toMatchObject({ action: "paused", attemptId });
+    expect(
+      await withWorkspaceRls(client.db, grant.workspaceId!, (db) =>
+        evaluateSessionControl(db, grant.workspaceId!, session.id),
+      ),
+    ).toMatchObject({
+      state: "paused",
+      settlement: {
+        state: "stopping",
+        attemptCount: 1,
+        interruptionPendingCount: 0,
+        quiescencePendingCount: 1,
+      },
+    });
+
+    expect(await peekSessionWork(client.db, grant.workspaceId!, session.id)).toEqual({
+      kind: "cancellation-wait",
+      attemptId,
+    });
+    expect(
+      await reconcileSessionAttemptQuiescence(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        attemptId,
+        temporalWorkflowId: workflowId,
+        temporalWorkflowRunId: workflowRunId,
+        temporalActivityId: dispatchId,
+        activitySettled: true,
+      }),
+    ).toMatchObject({ action: "quiesced" });
+    expect(
+      await withWorkspaceRls(client.db, grant.workspaceId!, (db) =>
+        evaluateSessionControl(db, grant.workspaceId!, session.id),
+      ),
+    ).toMatchObject({
+      state: "paused",
+      settlement: null,
+    });
+    expect(await peekSessionWork(client.db, grant.workspaceId!, session.id)).toEqual({
+      kind: "idle",
+    });
+  });
+
   test("quiescence reconciliation finds an older rejected-stale predecessor", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "run the predecessor");


### PR DESCRIPTION
## Summary

- reconcile a settled interrupted attempt before treating paused session control as idle
- allow physical-quiescence recovery to finish without resuming or admitting new session work
- add real-PostgreSQL regression coverage for the paused-session deadlock

## Why

A vanished activity can leave a logically settled interruption without its durable `quiesced_at` receipt. `peekSessionWork` previously returned `idle` for paused control before checking that receipt, so reconciliation never ran and ancestor sessions remained in `settlement: stopping` indefinitely.

## Verification

- `bunx oxfmt --check packages/db/src/index.ts packages/db/test/session-control-plane.test.ts .changeset/tidy-paused-quiescence.md`
- `bun run typecheck` in `packages/db`
- `OPENGENI_REQUIRE_REAL_DB=1 bun test packages/db/test/session-control-plane.test.ts --test-name-pattern 'a paused session still reconciles its settled attempt quiescence'`
- `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/session-control-plane.test.ts` — 75 passed

Linear: OPE-169
