### PR TITLE
fix(release): satisfy contrast audit lint

### DIFF
--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -2423,9 +2423,9 @@ async function markIncompleteContrastTargetsForManualAudit(
     const selector = axeManualContrastSelector(target);
     return selector ? [{ selector, serializedTarget: JSON.stringify(target) }] : [];
   });
-  return page.evaluate((candidates) => {
+  return page.evaluate((browserCandidates) => {
     const audited: string[] = [];
-    for (const { selector, serializedTarget } of candidates) {
+    for (const { selector, serializedTarget } of browserCandidates) {
       try {
         const visibleMatches = Array.from(document.querySelectorAll<HTMLElement>(selector)).filter(
           (element) => {


### PR DESCRIPTION
## Summary
- remove the acceptance helper parameter-shadowing warning
- preserve the exact manual contrast audit behavior merged in #1075

## Verification
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun test scripts/workbench-live-acceptance.test.ts`