### PR TITLE
feat(react-demo): make the public demo mobile-first

### DIFF
--- a/.changeset/calm-demos-touch.md
+++ b/.changeset/calm-demos-touch.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Improve mobile touch targets and responsive session interactions across the React surfaces.

--- a/packages/react/demo/index.html
+++ b/packages/react/demo/index.html
@@ -2,11 +2,59 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@opengeni/react — component harness</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%230d1016'/%3E%3Cpath d='M9 10h14v4H13v8H9z' fill='%2375a7ff'/%3E%3Cpath d='M15 16h8v6h-4v-2h-4z' fill='%23e9eef8'/%3E%3C/svg%3E"
+    />
+    <title>OpenGeni React demo — durable agent sessions</title>
+    <style>
+      html,
+      body,
+      #root {
+        margin: 0;
+        min-height: 100%;
+        background: #0d1016;
+        color: #e9eef8;
+      }
+
+      .demo-boot {
+        box-sizing: border-box;
+        display: grid;
+        min-height: 100dvh;
+        place-items: center;
+        padding: max(1.5rem, env(safe-area-inset-top)) 1.5rem
+          max(1.5rem, env(safe-area-inset-bottom));
+        font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+      }
+
+      .demo-boot__copy {
+        max-width: 22rem;
+        text-align: center;
+      }
+
+      .demo-boot__title {
+        margin: 0;
+        font-size: 0.875rem;
+        font-weight: 600;
+      }
+
+      .demo-boot__status {
+        margin: 0.375rem 0 0;
+        color: #969ca8;
+        font-size: 0.75rem;
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <main class="demo-boot" aria-busy="true" aria-label="Loading OpenGeni React demo">
+        <div class="demo-boot__copy">
+          <p class="demo-boot__title">OpenGeni React demo</p>
+          <p class="demo-boot__status">Loading the scripted manager session…</p>
+        </div>
+      </main>
+    </div>
     <script type="module" src="/main.tsx"></script>
   </body>
 </html>

--- a/packages/react/demo/main.tsx
+++ b/packages/react/demo/main.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { createRoot } from "react-dom/client";
 import { CalendarClockIcon, MessagesSquareIcon, NetworkIcon, PanelRightIcon } from "lucide-react";
 import {
@@ -94,6 +94,8 @@ function Harness() {
   });
   const [view, setView] = useState<DemoView>(initialRoute.view);
   const [workspaceOpen, setWorkspaceOpen] = useState(initialRoute.workspaceOpen);
+  const workspaceTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const previousWorkspaceOpenRef = useRef(workspaceOpen);
   // Mount the whole workbench through its public `<SandboxWorkspace>` surface —
   // the exact integration an external embedder uses. The deterministic client
   // supplies realistic data without pretending this public demo is a customer workspace.
@@ -150,6 +152,25 @@ function Harness() {
     [closeWorkspace, compact, openWorkspace],
   );
 
+  // A controlled Workspace can mount already open after reload, so the shared
+  // dock has no live opener element to remember. Restore focus to this host's
+  // stable trigger after any compact close; a second frame runs after the
+  // dock's own modal cleanup without competing with its normal opener path.
+  useEffect(() => {
+    const wasOpen = previousWorkspaceOpenRef.current;
+    previousWorkspaceOpenRef.current = workspaceOpen;
+    if (!compact || !wasOpen || workspaceOpen) return;
+
+    let focusFrame = 0;
+    const settleFrame = requestAnimationFrame(() => {
+      focusFrame = requestAnimationFrame(() => workspaceTriggerRef.current?.focus());
+    });
+    return () => {
+      cancelAnimationFrame(settleFrame);
+      if (focusFrame) cancelAnimationFrame(focusFrame);
+    };
+  }, [compact, workspaceOpen]);
+
   return (
     <div
       className="og-root box-border h-dvh overflow-hidden bg-og-bg pt-[env(safe-area-inset-top)]"
@@ -180,6 +201,7 @@ function Harness() {
               onSelectView={selectView}
               onOpenWorkspace={openWorkspace}
               workspaceOpen={workspaceOpen}
+              workspaceTriggerRef={workspaceTriggerRef}
             />
           ) : null}
           <div className="min-h-0 flex-1">
@@ -207,11 +229,13 @@ function DemoNavigation({
   onSelectView,
   onOpenWorkspace,
   workspaceOpen,
+  workspaceTriggerRef,
 }: {
   activeView: DemoView;
   onSelectView: (view: DemoView) => void;
   onOpenWorkspace: () => void;
   workspaceOpen: boolean;
+  workspaceTriggerRef: RefObject<HTMLButtonElement | null>;
 }) {
   const itemClass =
     "flex min-h-11 min-w-0 flex-col items-center justify-center gap-0.5 rounded-og-sm px-1 text-[11px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent";
@@ -251,6 +275,7 @@ function DemoNavigation({
         <span className="truncate">Schedules</span>
       </button>
       <button
+        ref={workspaceTriggerRef}
         type="button"
         onClick={onOpenWorkspace}
         aria-haspopup="dialog"

--- a/packages/react/demo/main.tsx
+++ b/packages/react/demo/main.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
-import type { SessionStatus as SessionStatusValue } from "@opengeni/sdk";
+import { CalendarClockIcon, MessagesSquareIcon, NetworkIcon, PanelRightIcon } from "lucide-react";
 import {
   ChatComposer,
   FleetTile,
@@ -19,70 +19,288 @@ import {
 import { MANAGER_SESSION_ID, MockOpenGeniClient } from "./mock";
 import "./styles.css";
 
-const ALL_STATUSES: SessionStatusValue[] = [
-  "queued",
-  "running",
-  "idle",
-  "requires_action",
-  "failed",
-  "cancelled",
-];
+type DemoView = "session" | "fleet" | "schedules";
+
+type DemoHistoryState = {
+  view: DemoView;
+  workspaceOpen: boolean;
+};
+
+const DEMO_HISTORY_KEY = "ogReactDemo";
+const COMPACT_BREAKPOINT = 1024;
+
+function isDemoView(value: string): value is DemoView {
+  return value === "session" || value === "fleet" || value === "schedules";
+}
+
+function viewFromLocation(): DemoView {
+  const candidate = window.location.hash.replace(/^#/, "");
+  return isDemoView(candidate) ? candidate : "session";
+}
+
+function demoHistoryState(): DemoHistoryState | null {
+  const state = window.history.state;
+  if (!state || typeof state !== "object") return null;
+  const candidate = (state as Record<string, unknown>)[DEMO_HISTORY_KEY];
+  if (!candidate || typeof candidate !== "object") return null;
+  const view = (candidate as Record<string, unknown>).view;
+  const workspaceOpen = (candidate as Record<string, unknown>).workspaceOpen;
+  if (typeof view !== "string" || !isDemoView(view) || typeof workspaceOpen !== "boolean") {
+    return null;
+  }
+  return { view, workspaceOpen };
+}
+
+function nextHistoryState(view: DemoView, workspaceOpen: boolean): Record<string, unknown> {
+  const current = window.history.state;
+  const state = current && typeof current === "object" ? { ...current } : {};
+  return {
+    ...state,
+    [DEMO_HISTORY_KEY]: { view, workspaceOpen } satisfies DemoHistoryState,
+  };
+}
+
+function urlForView(view: DemoView): string {
+  const url = new URL(window.location.href);
+  url.hash = view === "session" ? "" : view;
+  return url.toString();
+}
+
+function useCompactViewport(): boolean {
+  const [compact, setCompact] = useState(
+    () => window.matchMedia(`(max-width: ${COMPACT_BREAKPOINT - 1}px)`).matches,
+  );
+
+  useEffect(() => {
+    const query = window.matchMedia(`(max-width: ${COMPACT_BREAKPOINT - 1}px)`);
+    const update = () => setCompact(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  return compact;
+}
 
 function Harness() {
   const [theme, setTheme] = useState<"dark" | "light">("dark");
+  const compact = useCompactViewport();
+  const [initialRoute] = useState(() => {
+    const history = demoHistoryState();
+    return {
+      view: history?.view ?? viewFromLocation(),
+      workspaceOpen: history?.workspaceOpen ?? false,
+    };
+  });
+  const [view, setView] = useState<DemoView>(initialRoute.view);
+  const [workspaceOpen, setWorkspaceOpen] = useState(initialRoute.workspaceOpen);
   // Mount the whole workbench through its public `<SandboxWorkspace>` surface —
-  // the exact integration an external embedder uses. This is
-  // the F2 embedder proof: provider + styles + mock client, no app plumbing.
+  // the exact integration an external embedder uses. The deterministic client
+  // supplies realistic data without pretending this public demo is a customer workspace.
   const { events } = useSessionEvents(MANAGER_SESSION_ID);
+
+  useEffect(() => {
+    const syncFromHistory = () => {
+      const state = demoHistoryState();
+      setView(state?.view ?? viewFromLocation());
+      setWorkspaceOpen(state?.workspaceOpen ?? false);
+    };
+
+    window.history.replaceState(
+      nextHistoryState(initialRoute.view, initialRoute.workspaceOpen),
+      "",
+      urlForView(initialRoute.view),
+    );
+    window.addEventListener("popstate", syncFromHistory);
+    window.addEventListener("hashchange", syncFromHistory);
+    return () => {
+      window.removeEventListener("popstate", syncFromHistory);
+      window.removeEventListener("hashchange", syncFromHistory);
+    };
+  }, [initialRoute]);
+
+  const selectView = useCallback((next: DemoView) => {
+    const current = demoHistoryState();
+    if (current?.view === next && !current.workspaceOpen) return;
+    window.history.pushState(nextHistoryState(next, false), "", urlForView(next));
+    setView(next);
+    setWorkspaceOpen(false);
+  }, []);
+
+  const openWorkspace = useCallback(() => {
+    if (workspaceOpen) return;
+    window.history.pushState(nextHistoryState(view, true), "", window.location.href);
+    setWorkspaceOpen(true);
+  }, [view, workspaceOpen]);
+
+  const closeWorkspace = useCallback(() => {
+    if (demoHistoryState()?.workspaceOpen) {
+      window.history.back();
+      return;
+    }
+    setWorkspaceOpen(false);
+  }, []);
+
+  const onWorkspaceCollapsedChange = useCallback(
+    (collapsed: boolean) => {
+      if (!compact) return;
+      if (collapsed) closeWorkspace();
+      else openWorkspace();
+    },
+    [closeWorkspace, compact, openWorkspace],
+  );
+
   return (
     <div
-      className="og-root min-h-full bg-og-bg"
+      className="og-root box-border h-dvh overflow-hidden bg-og-bg pt-[env(safe-area-inset-top)]"
       data-og-theme={theme === "light" ? "light" : undefined}
     >
-      <div className="mx-auto flex h-dvh max-w-7xl flex-col px-4 sm:px-6">
-        <header className="flex shrink-0 items-center justify-between gap-4 border-b border-og-border py-4">
-          <div>
-            <h1 className="text-sm font-semibold text-og-fg">@opengeni/react</h1>
-            <p className="text-xs text-og-fg-subtle">
-              Component harness — real hooks against a scripted client
+      <div className="mx-auto flex h-full max-w-7xl flex-col pl-[max(0.75rem,env(safe-area-inset-left))] pr-[max(0.75rem,env(safe-area-inset-right))] sm:pl-[max(1.25rem,env(safe-area-inset-left))] sm:pr-[max(1.25rem,env(safe-area-inset-right))] lg:pl-[max(1.5rem,env(safe-area-inset-left))] lg:pr-[max(1.5rem,env(safe-area-inset-right))]">
+        <header className="flex shrink-0 items-center justify-between gap-3 border-b border-og-border py-2.5 sm:py-3.5">
+          <div className="min-w-0">
+            <h1 className="truncate text-sm font-semibold text-og-fg">OpenGeni React demo</h1>
+            <p className="truncate text-[11px] text-og-fg-subtle sm:text-xs">
+              Public React UI · scripted data
             </p>
           </div>
-          <div className="flex items-center gap-2">
-            {ALL_STATUSES.map((status) => (
-              <SessionStatus key={status} status={status} size="sm" className="max-md:hidden" />
-            ))}
-            <button
-              type="button"
-              onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-              className="rounded-og-sm border border-og-border px-2.5 py-1 text-xs font-medium text-og-fg-muted transition-colors hover:border-og-border-strong hover:text-og-fg"
-            >
-              {theme === "dark" ? "Light" : "Dark"}
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+            className="inline-flex min-h-11 shrink-0 items-center justify-center rounded-og-md border border-og-border px-3 text-xs font-medium text-og-fg-muted transition-colors hover:border-og-border-strong hover:bg-og-surface-1 hover:text-og-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent"
+            aria-label={`Use ${theme === "dark" ? "light" : "dark"} theme`}
+          >
+            {theme === "dark" ? "Light" : "Dark"}
+          </button>
         </header>
-        <main className="min-h-0 flex-1 py-5">
-          <SandboxWorkspace
-            sessionId={MANAGER_SESSION_ID}
-            events={events}
-            autoSaveId="og.demo.dock"
-            primary={
-              <div className="grid h-full min-h-0 gap-6 overflow-hidden lg:grid-cols-[minmax(0,1fr)_minmax(0,300px)]">
-                <OpsChannel />
-                <aside className="flex min-h-0 flex-col gap-6 overflow-y-auto pb-4 max-lg:hidden">
-                  <Fleet />
-                  <Schedules />
-                </aside>
-              </div>
-            }
-          />
+
+        <main className="flex min-h-0 flex-1 flex-col pt-2.5 pb-[max(0.625rem,env(safe-area-inset-bottom))] sm:py-4 lg:py-5">
+          {compact ? (
+            <DemoNavigation
+              activeView={view}
+              onSelectView={selectView}
+              onOpenWorkspace={openWorkspace}
+              workspaceOpen={workspaceOpen}
+            />
+          ) : null}
+          <div className="min-h-0 flex-1">
+            <SandboxWorkspace
+              sessionId={MANAGER_SESSION_ID}
+              events={events}
+              autoSaveId="og.demo.dock"
+              {...(compact
+                ? {
+                    collapsed: !workspaceOpen,
+                    onCollapsedChange: onWorkspaceCollapsedChange,
+                  }
+                : {})}
+              primary={<DemoPrimary compact={compact} view={view} />}
+            />
+          </div>
         </main>
       </div>
     </div>
   );
 }
 
+function DemoNavigation({
+  activeView,
+  onSelectView,
+  onOpenWorkspace,
+  workspaceOpen,
+}: {
+  activeView: DemoView;
+  onSelectView: (view: DemoView) => void;
+  onOpenWorkspace: () => void;
+  workspaceOpen: boolean;
+}) {
+  const itemClass =
+    "flex min-h-11 min-w-0 flex-col items-center justify-center gap-0.5 rounded-og-sm px-1 text-[11px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent";
+  const selectedClass = "bg-og-surface-3 text-og-fg";
+  const idleClass = "text-og-fg-subtle hover:bg-og-surface-2 hover:text-og-fg";
+
+  return (
+    <nav
+      aria-label="Demo views"
+      className="mb-2 grid shrink-0 grid-cols-4 gap-1 rounded-og-md border border-og-border bg-og-surface-1 p-1"
+    >
+      <button
+        type="button"
+        onClick={() => onSelectView("session")}
+        aria-current={activeView === "session" && !workspaceOpen ? "page" : undefined}
+        className={`${itemClass} ${activeView === "session" && !workspaceOpen ? selectedClass : idleClass}`}
+      >
+        <MessagesSquareIcon className="size-4" aria-hidden />
+        <span className="truncate">Session</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => onSelectView("fleet")}
+        aria-current={activeView === "fleet" && !workspaceOpen ? "page" : undefined}
+        className={`${itemClass} ${activeView === "fleet" && !workspaceOpen ? selectedClass : idleClass}`}
+      >
+        <NetworkIcon className="size-4" aria-hidden />
+        <span className="truncate">Fleet</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => onSelectView("schedules")}
+        aria-current={activeView === "schedules" && !workspaceOpen ? "page" : undefined}
+        className={`${itemClass} ${activeView === "schedules" && !workspaceOpen ? selectedClass : idleClass}`}
+      >
+        <CalendarClockIcon className="size-4" aria-hidden />
+        <span className="truncate">Schedules</span>
+      </button>
+      <button
+        type="button"
+        onClick={onOpenWorkspace}
+        aria-haspopup="dialog"
+        aria-expanded={workspaceOpen}
+        className={`${itemClass} ${workspaceOpen ? selectedClass : idleClass}`}
+      >
+        <PanelRightIcon className="size-4" aria-hidden />
+        <span className="truncate">Workspace</span>
+      </button>
+    </nav>
+  );
+}
+
+function DemoPrimary({ compact, view }: { compact: boolean; view: DemoView }) {
+  return (
+    <div
+      className={
+        compact
+          ? "h-full min-h-0"
+          : "grid h-full min-h-0 gap-6 overflow-hidden lg:grid-cols-[minmax(0,1fr)_minmax(0,300px)]"
+      }
+    >
+      <div className={compact && view !== "session" ? "hidden" : "h-full min-h-0"}>
+        <OpsChannel autoFocus={!compact} />
+      </div>
+      <div
+        role={!compact ? "complementary" : undefined}
+        aria-label={!compact ? "Fleet and scheduled tasks" : undefined}
+        tabIndex={!compact ? 0 : undefined}
+        className={
+          compact
+            ? view === "session"
+              ? "hidden"
+              : "h-full min-h-0"
+            : "flex min-h-0 flex-col gap-6 overflow-y-auto pb-4"
+        }
+      >
+        <div className={compact && view !== "fleet" ? "hidden" : compact ? "h-full" : ""}>
+          <Fleet standalone={compact} />
+        </div>
+        <div className={compact && view !== "schedules" ? "hidden" : compact ? "h-full" : ""}>
+          <Schedules standalone={compact} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /** The hero surface: manager session timeline + composer. */
-function OpsChannel() {
+function OpsChannel({ autoFocus }: { autoFocus: boolean }) {
   const { client, workspaceId } = useOpenGeni();
   const { session } = useSession(MANAGER_SESSION_ID, { pollIntervalMs: 5000 });
   const { timeline, sessionStatus, connectionState } = useSessionEvents(MANAGER_SESSION_ID);
@@ -109,31 +327,28 @@ function OpsChannel() {
   };
 
   return (
-    <section className="flex min-h-0 flex-col overflow-hidden rounded-og-xl border border-og-border bg-og-surface-1/50">
-      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-og-border px-4 py-3">
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-og-xl border border-og-border bg-og-surface-1/50">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-og-border px-3.5 py-3 sm:px-4">
         <div className="min-w-0">
-          <h2 className="truncate text-sm font-medium text-og-fg">Ops channel</h2>
-          <p className="truncate font-og-mono text-[11px] text-og-fg-subtle">
-            {MANAGER_SESSION_ID}
+          <h2 className="truncate text-sm font-medium text-og-fg">Staging operations</h2>
+          <p className="truncate text-[11px] text-og-fg-subtle">
+            Manager · API staging + production drift
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <span className="text-[11px] text-og-fg-subtle">{connectionState}</span>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="hidden text-[11px] capitalize text-og-fg-subtle min-[360px]:inline">
+            {connectionState === "live" ? "stream live" : connectionState}
+          </span>
           {status ? <SessionStatus status={status} /> : null}
         </div>
       </div>
-      <MessageTimeline
-        items={timeline}
-        status={status}
-        className="min-h-0 flex-1"
-        onOpenSession={(sessionId) => window.alert(`Open worker session ${sessionId}`)}
-      />
-      <div className="shrink-0 px-4 pb-4 pt-1">
+      <MessageTimeline items={timeline} status={status} className="min-h-0 flex-1" />
+      <div className="shrink-0 px-3.5 pb-3 pt-1 sm:px-4 sm:pb-4">
         <ChatComposer
           composer={composer}
           effectiveControl={session?.effectiveControl}
-          placeholder="Message your infrastructure…"
-          autoFocus
+          placeholder="Ask the manager to adjust the plan…"
+          autoFocus={autoFocus}
           commandContext={commandContext}
           models={models}
           selectedModel={model}
@@ -144,30 +359,55 @@ function OpsChannel() {
   );
 }
 
-function Fleet() {
+function Fleet({ standalone }: { standalone: boolean }) {
   const { sessions, loading } = useWorkspaceSessions({ pollIntervalMs: 10000 });
   return (
-    <section>
-      <h2 className="mb-3 text-xs font-medium uppercase tracking-[0.08em] text-og-fg-subtle">
-        Fleet
-      </h2>
-      <div className="grid grid-cols-1 gap-3">
+    <section
+      className={
+        standalone
+          ? "flex h-full min-h-0 flex-col overflow-hidden rounded-og-xl border border-og-border bg-og-surface-1/50"
+          : ""
+      }
+    >
+      <div className={standalone ? "shrink-0 border-b border-og-border px-4 py-3" : ""}>
+        <h2
+          className={
+            standalone
+              ? "text-sm font-medium text-og-fg"
+              : "mb-3 text-xs font-medium uppercase tracking-[0.08em] text-og-fg-subtle"
+          }
+        >
+          Fleet
+        </h2>
+        {standalone ? (
+          <p className="mt-0.5 text-[11px] text-og-fg-subtle">
+            Durable manager and worker sessions in this scripted workspace
+          </p>
+        ) : null}
+      </div>
+      <div
+        aria-label={standalone ? "Fleet sessions" : undefined}
+        tabIndex={standalone ? 0 : undefined}
+        className={
+          standalone
+            ? "min-h-0 flex-1 overflow-y-auto overscroll-contain p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]"
+            : "grid grid-cols-1 gap-3"
+        }
+      >
         {loading && sessions.length === 0 ? (
           <p className="text-xs text-og-fg-subtle">Loading sessions…</p>
         ) : null}
-        {sessions.map((session) => (
-          <FleetTile
-            key={session.id}
-            session={session}
-            onOpen={(s) => window.alert(`Open session ${s.id}`)}
-          />
-        ))}
+        <div className={standalone ? "grid grid-cols-1 gap-3 sm:grid-cols-2" : "contents"}>
+          {sessions.map((session) => (
+            <FleetTile key={session.id} session={session} />
+          ))}
+        </div>
       </div>
     </section>
   );
 }
 
-function Schedules() {
+function Schedules({ standalone }: { standalone: boolean }) {
   const { tasks } = useScheduledTasks();
   const labels = useMemo(
     () =>
@@ -185,17 +425,44 @@ function Schedules() {
     [tasks],
   );
   return (
-    <section>
-      <h2 className="mb-3 text-xs font-medium uppercase tracking-[0.08em] text-og-fg-subtle">
-        Scheduled tasks
-      </h2>
-      <ul className="flex flex-col gap-2">
+    <section
+      className={
+        standalone
+          ? "flex h-full min-h-0 flex-col overflow-hidden rounded-og-xl border border-og-border bg-og-surface-1/50"
+          : ""
+      }
+    >
+      <div className={standalone ? "shrink-0 border-b border-og-border px-4 py-3" : ""}>
+        <h2
+          className={
+            standalone
+              ? "text-sm font-medium text-og-fg"
+              : "mb-3 text-xs font-medium uppercase tracking-[0.08em] text-og-fg-subtle"
+          }
+        >
+          Scheduled tasks
+        </h2>
+        {standalone ? (
+          <p className="mt-0.5 text-[11px] text-og-fg-subtle">
+            Recurring autonomous work configured for this workspace
+          </p>
+        ) : null}
+      </div>
+      <ul
+        aria-label={standalone ? "Scheduled tasks" : undefined}
+        tabIndex={standalone ? 0 : undefined}
+        className={
+          standalone
+            ? "flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]"
+            : "flex flex-col gap-2"
+        }
+      >
         {labels.map((task) => (
           <li
             key={task.id}
-            className="flex items-center justify-between gap-3 rounded-og-md border border-og-border bg-og-surface-1 px-3.5 py-2.5"
+            className="flex flex-col items-start gap-1.5 rounded-og-md border border-og-border bg-og-surface-1 px-3.5 py-3 min-[390px]:flex-row min-[390px]:items-center min-[390px]:justify-between min-[390px]:gap-3"
           >
-            <span className="min-w-0 truncate text-[13px] text-og-fg">{task.name}</span>
+            <span className="min-w-0 break-words text-[13px] text-og-fg">{task.name}</span>
             <span className="flex shrink-0 items-center gap-2 text-[11px] text-og-fg-subtle">
               <span className="font-og-mono">{task.cadence}</span>
               <span className={task.status === "active" ? "text-og-status-idle" : ""}>

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -166,6 +166,8 @@ export class MockOpenGeniClient implements SessionClientLike {
   private pausedSessions = new Set<string>();
   private drafts = new Map<string, ComposerDraft>();
   private scripted = false;
+  private managerScript: Promise<void> | null = null;
+  private responseQueues = new Map<string, Promise<void>>();
 
   bus(sessionId: string): SessionBus {
     let bus = this.buses.get(sessionId);
@@ -370,7 +372,7 @@ export class MockOpenGeniClient implements SessionClientLike {
     const bus = this.bus(sessionId);
     const text = typeof message === "string" ? message : message.text;
     const event = bus.append("user.message", { text });
-    void this.respond(bus, text);
+    this.queueResponse(bus, text);
     return event;
   }
 
@@ -398,7 +400,16 @@ export class MockOpenGeniClient implements SessionClientLike {
     const bus = this.bus(sessionId);
     if (sessionId === MANAGER_SESSION_ID && !this.scripted) {
       this.scripted = true;
-      void runOpsChannelScript(bus);
+      const script = runOpsChannelScript(bus);
+      this.managerScript = script;
+      void script.then(
+        () => {
+          if (this.managerScript === script) this.managerScript = null;
+        },
+        () => {
+          if (this.managerScript === script) this.managerScript = null;
+        },
+      );
     }
     options.onStateChange?.("live");
     return bus.stream(options.after ?? 0, options.signal);
@@ -1621,6 +1632,31 @@ export class MockOpenGeniClient implements SessionClientLike {
       updatedAt: now,
       ...overrides,
     };
+  }
+
+  /** Keep the scripted narrative and interactive turns ordered per session. */
+  private queueResponse(bus: SessionBus, text: string): void {
+    const previous = this.responseQueues.get(bus.sessionId) ?? Promise.resolve();
+    const script = bus.sessionId === MANAGER_SESSION_ID ? this.managerScript : null;
+    const queued = previous
+      .catch(() => undefined)
+      .then(async () => {
+        await script?.catch(() => undefined);
+        await this.respond(bus, text);
+      });
+    this.responseQueues.set(bus.sessionId, queued);
+    void queued.then(
+      () => {
+        if (this.responseQueues.get(bus.sessionId) === queued) {
+          this.responseQueues.delete(bus.sessionId);
+        }
+      },
+      () => {
+        if (this.responseQueues.get(bus.sessionId) === queued) {
+          this.responseQueues.delete(bus.sessionId);
+        }
+      },
+    );
   }
 
   /** Canned manager acknowledgment for anything typed into the composer. */

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -371,6 +371,20 @@ export class MockOpenGeniClient implements SessionClientLike {
   ): Promise<SessionEvent> {
     const bus = this.bus(sessionId);
     const text = typeof message === "string" ? message : message.text;
+    // The managed API accepts the message and clears the matching durable
+    // composer draft atomically. Mirror that ordering before publishing the
+    // user.message invalidation so a reconciliation read cannot resurrect the
+    // just-submitted text and leave the Send action enabled.
+    const currentDraft = await this.getComposerDraft(_workspaceId, sessionId);
+    this.drafts.set(sessionId, {
+      ...currentDraft,
+      revision: currentDraft.revision + 1,
+      text: "",
+      resources: [],
+      sourceTurnId: null,
+      sourceTurnVersion: null,
+      updatedAt: new Date().toISOString(),
+    });
     const event = bus.append("user.message", { text });
     this.queueResponse(bus, text);
     return event;

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -957,7 +957,7 @@ export const Input = forwardRef<HTMLTextAreaElement, ComposerInputProps>(functio
         paletteOpen ? `${controller.listboxId}-option-${controller.palette.highlight}` : undefined
       }
       className={cn(
-        "block w-full resize-none bg-transparent px-3.5 pt-3 pb-1 text-og-composer md:px-4 md:text-og-composer-wide",
+        "block w-full resize-none bg-transparent px-3.5 pt-3 pb-1 text-og-composer md:px-4 md:text-og-composer-wide pointer-coarse:min-h-11",
         "text-og-fg placeholder:text-og-fg-subtle focus:outline-none focus-visible:outline-none",
         "disabled:cursor-not-allowed disabled:opacity-60",
         className,
@@ -1095,7 +1095,7 @@ export const AttachButton = forwardRef<HTMLButtonElement, ComposerAttachButtonPr
             className={cn(
               "inline-flex size-8 items-center justify-center rounded-og-md",
               "text-og-fg-muted transition-colors duration-150 hover:bg-og-surface-2 hover:text-og-fg",
-              "disabled:cursor-not-allowed disabled:opacity-50 pointer-coarse:size-9",
+              "disabled:cursor-not-allowed disabled:opacity-50 pointer-coarse:size-11",
               className,
             )}
           >
@@ -1167,7 +1167,7 @@ export const PauseButton = forwardRef<HTMLButtonElement, ComposerPauseButtonProp
           disabled={busy}
           aria-label={ariaLabel ?? controller.messages.pauseAriaLabel}
           className={cn(
-            "inline-flex size-8 items-center justify-center rounded-og-md border border-og-border pointer-coarse:size-9",
+            "inline-flex size-8 items-center justify-center rounded-og-md border border-og-border pointer-coarse:size-11",
             "bg-og-surface-2 text-og-fg-muted transition-colors duration-150",
             "hover:border-og-status-waiting/50 hover:text-og-status-waiting",
             "disabled:opacity-50",
@@ -1216,7 +1216,7 @@ export const SendButton = forwardRef<HTMLButtonElement, ComposerSendButtonProps>
               : controller.messages.sendMessageAriaLabel)
           }
           className={cn(
-            "inline-flex size-8 items-center justify-center rounded-og-md pointer-coarse:size-9",
+            "inline-flex size-8 items-center justify-center rounded-og-md pointer-coarse:size-11",
             "bg-og-accent text-og-accent-fg shadow-og-sm",
             "transition-[background-color,transform,opacity] duration-150 ease-og-spring",
             "hover:bg-og-accent-strong active:scale-95",

--- a/packages/react/src/components/copy-button.tsx
+++ b/packages/react/src/components/copy-button.tsx
@@ -93,7 +93,7 @@ export function CopyButton({
           aria-label={tip}
           onClick={onClick}
           className={cn(
-            "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm",
+            "inline-flex size-7 shrink-0 items-center justify-center rounded-og-sm pointer-coarse:size-11",
             "text-og-fg-subtle transition-[opacity,color,background-color] duration-150",
             "hover:bg-og-surface-2/80 hover:text-og-fg",
             "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-og-accent/40",

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -2247,7 +2247,7 @@ function MessageFooterTime({ occurredAt }: { occurredAt: string }) {
       className={cn(
         "shrink-0 tabular-nums text-og-xs text-og-fg-subtle",
         "opacity-0 transition-opacity duration-150",
-        "group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 pointer-coarse:opacity-70",
+        "group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 pointer-coarse:opacity-100",
       )}
     >
       {formatClockTime(occurredAt)}

--- a/packages/react/src/components/model-picker.tsx
+++ b/packages/react/src/components/model-picker.tsx
@@ -100,7 +100,7 @@ export function ModelPicker({
         disabled={disabled === true}
         aria-label={label}
         className={cn(
-          "h-8 max-w-[180px] cursor-pointer appearance-none truncate rounded-og-md bg-transparent",
+          "h-8 max-w-[180px] cursor-pointer appearance-none truncate rounded-og-md bg-transparent pointer-coarse:h-11",
           "py-0 pl-2 pr-6 text-[13px] text-og-fg-muted",
           "transition-colors duration-150 hover:bg-og-surface-2 hover:text-og-fg",
           "focus:outline-none focus-visible:outline-none",

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -419,7 +419,7 @@ function WorkerRow({
         className={cn(
           "group/worker -mx-1.5 flex w-full items-start gap-2 rounded-og-sm px-1.5 py-1.5 text-left",
           "outline-none transition-colors duration-150 hover:bg-og-surface-1 focus-visible:ring-2 focus-visible:ring-og-accent",
-          "pointer-coarse:py-2.5",
+          "pointer-coarse:min-h-11 pointer-coarse:py-2.5",
         )}
       >
         {inner}

--- a/packages/react/src/timeline/shared.tsx
+++ b/packages/react/src/timeline/shared.tsx
@@ -154,9 +154,9 @@ export function ActivityDisclosure({
   const rowClass = cn(
     "group/disclosure flex w-full min-w-0 items-center gap-2 rounded-og-sm px-1.5 py-1.5 text-left text-og-base",
     "text-og-fg-muted transition-colors duration-150",
-    // A tool row is a touch target on coarse pointers: grow its padding so the
-    // hit area clears the 40px minimum without loosening the dense desktop rail.
-    "pointer-coarse:py-2.5",
+    // A tool row is a touch target on coarse pointers: grow its hit area to the
+    // 44px mobile minimum without loosening the dense desktop rail.
+    "pointer-coarse:min-h-11 pointer-coarse:py-2.5",
   );
   // The chevron rotates to point down when open; it tracks `data-state` on this
   // same row (the Trigger), so the affordance never freezes.

--- a/packages/react/src/timeline/turn-summary.tsx
+++ b/packages/react/src/timeline/turn-summary.tsx
@@ -416,8 +416,8 @@ export function TurnSummary({
               // as a turn landmark above any nested cluster rows it groups.
               "group flex w-full items-center rounded-og-sm text-left transition-colors",
               // A folded turn is a touch target on coarse pointers: grow the row so it
-              // clears the 40px minimum without disturbing the calm desktop rhythm.
-              "pointer-coarse:py-2.5",
+              // clears the 44px minimum without disturbing the calm desktop rhythm.
+              "pointer-coarse:min-h-11 pointer-coarse:py-2.5",
               bare
                 ? "gap-2 px-1.5 py-1.5 text-og-sm text-og-fg-muted"
                 : "-mx-2 gap-2.5 px-2 py-1.5 text-og-base text-og-fg-muted",

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -9,6 +9,7 @@ const testFiles =
         "./test/e2e/knowledge-surfaces.browser.e2e.ts",
         "./test/e2e/codex-overview.e2e.ts",
         "./test/e2e/queue-surface.browser.e2e.ts",
+        "./test/e2e/react-demo-mobile.browser.e2e.ts",
         "./test/e2e/realtime-demo.browser.e2e.ts",
         "./test/e2e/session-header.browser.e2e.ts",
         "./test/e2e/session-pins.browser.e2e.ts",

--- a/test/e2e/react-demo-mobile.browser.e2e.ts
+++ b/test/e2e/react-demo-mobile.browser.e2e.ts
@@ -152,7 +152,19 @@ describe("public React demo mobile product acceptance", () => {
       .getByText(submittedPrompt, { exact: true })
       .waitFor({ timeout: 15_000 });
     await waitForBodyText(page, 'Got it — "Summarize the rollout risk', 15_000);
+    expect(await textbox.inputValue()).toBe("");
+    expect(await page.getByRole("button", { name: "Send message" }).isDisabled()).toBe(true);
     await capture(page, "390-after-send.png");
+
+    const keyboardPrompt = "Confirm the keyboard send clears this draft.";
+    await textbox.fill(keyboardPrompt);
+    await textbox.press("Enter");
+    await page
+      .locator('[id^="og-user-message-"]')
+      .getByText(keyboardPrompt, { exact: true })
+      .waitFor({ timeout: 15_000 });
+    expect(await textbox.inputValue()).toBe("");
+    expect(await page.getByRole("button", { name: "Send message" }).isDisabled()).toBe(true);
 
     await openClearConfirmation(page, textbox);
     await page.getByRole("button", { name: "Cancel" }).click();
@@ -182,6 +194,15 @@ describe("public React demo mobile product acceptance", () => {
     await workspace.waitFor();
     await page.goBack();
     await workspace.waitFor({ state: "hidden" });
+
+    await workspaceButton.click();
+    await workspace.waitFor();
+    await page.reload({ waitUntil: "networkidle" });
+    await workspace.waitFor();
+    await page.keyboard.press("Escape");
+    await workspace.waitFor({ state: "hidden" });
+    await page.waitForFunction(() => document.activeElement?.textContent?.trim() === "Workspace");
+    expect(await workspaceButton.getAttribute("aria-expanded")).toBe("false");
 
     await navigation.getByRole("button", { name: "Fleet", exact: true }).click();
     await page.reload({ waitUntil: "networkidle" });

--- a/test/e2e/react-demo-mobile.browser.e2e.ts
+++ b/test/e2e/react-demo-mobile.browser.e2e.ts
@@ -1,0 +1,323 @@
+import AxeBuilder from "@axe-core/playwright";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { chromium, type Browser, type Locator, type Page } from "playwright";
+import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+
+const repoRoot = new URL("../..", import.meta.url).pathname;
+const evidenceDirectory =
+  process.env.OPENGENI_REACT_DEMO_MOBILE_EVIDENCE_DIR ?? "/tmp/opengeni-react-demo-mobile-evidence";
+
+const VIEWPORTS = [
+  { name: "320", width: 320, height: 700, compact: true },
+  { name: "360", width: 360, height: 800, compact: true },
+  { name: "375", width: 375, height: 812, compact: true },
+  { name: "390", width: 390, height: 844, compact: true },
+  { name: "430", width: 430, height: 932, compact: true },
+  { name: "768", width: 768, height: 1024, compact: true },
+  { name: "1024", width: 1024, height: 768, compact: false },
+  { name: "1440", width: 1440, height: 1000, compact: false },
+] as const;
+
+describe("public React demo mobile product acceptance", () => {
+  let browser: Browser;
+  let demo: StartedProcess;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    await mkdir(evidenceDirectory, { recursive: true });
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    const configuredChromium = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+    const sandboxChromium = "/usr/local/bin/chromium";
+    const executablePath =
+      configuredChromium ?? (existsSync(sandboxChromium) ? sandboxChromium : undefined);
+    browser = await chromium.launch(executablePath ? { executablePath } : undefined);
+    demo = await startProcess(
+      [
+        "bun",
+        "run",
+        "vite",
+        "dev",
+        "demo",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(port),
+        "--strictPort",
+        "--force",
+      ],
+      {
+        cwd: `${repoRoot}/packages/react`,
+        ready: async () =>
+          (
+            await fetch(baseUrl, {
+              signal: AbortSignal.timeout(2_000),
+            }).catch(() => null)
+          )?.ok === true,
+        timeoutMs: 45_000,
+      },
+    );
+  }, 60_000);
+
+  afterAll(async () => {
+    await Promise.allSettled([demo?.stop(), browser?.close()]);
+  }, 30_000);
+
+  test("session-first information architecture stays bounded and accessible at every supported width", async () => {
+    for (const viewport of VIEWPORTS) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+        hasTouch: viewport.compact,
+        isMobile: viewport.width <= 430,
+        reducedMotion: "reduce",
+      });
+      const page = await context.newPage();
+      const failures = observePageFailures(page);
+      await page.goto(baseUrl, { waitUntil: "networkidle" });
+      await page.getByRole("heading", { name: "OpenGeni React demo" }).waitFor();
+      await page.getByRole("heading", { name: "Staging operations" }).waitFor();
+
+      expect(await page.title()).toBe("OpenGeni React demo — durable agent sessions");
+      expect(await page.locator('meta[name="viewport"]').getAttribute("content")).toContain(
+        "viewport-fit=cover",
+      );
+      await expectNoHorizontalOverflow(page);
+      expect(
+        await page.evaluate(() => matchMedia("(prefers-reduced-motion: reduce)").matches),
+      ).toBe(true);
+
+      if (viewport.compact) {
+        const navigation = page.getByRole("navigation", { name: "Demo views" });
+        expect(await navigation.getByRole("button").count()).toBe(4);
+        expect(await visibleWorkspaceDialog(page).count()).toBe(0);
+        await expectCriticalTouchTargets(page);
+
+        await navigation.getByRole("button", { name: "Fleet", exact: true }).click();
+        await page.getByRole("heading", { name: "Fleet", exact: true }).waitFor();
+        expect(new URL(page.url()).hash).toBe("#fleet");
+
+        await navigation.getByRole("button", { name: "Schedules", exact: true }).click();
+        await page.getByRole("heading", { name: "Scheduled tasks" }).waitFor();
+        expect(new URL(page.url()).hash).toBe("#schedules");
+
+        await navigation.getByRole("button", { name: "Workspace", exact: true }).click();
+        await visibleWorkspaceDialog(page).waitFor();
+        expect(
+          await page.getByRole("tab", { name: /^Changes/ }).getAttribute("aria-selected"),
+        ).toBe("true");
+        await page.getByRole("button", { name: "Close workspace" }).click();
+        await visibleWorkspaceDialog(page).waitFor({ state: "hidden" });
+      } else {
+        expect(await page.getByRole("navigation", { name: "Demo views" }).count()).toBe(0);
+        expect(await page.getByRole("heading", { name: "Fleet", exact: true }).count()).toBe(1);
+        expect(await page.getByRole("heading", { name: "Scheduled tasks" }).count()).toBe(1);
+        expect(await page.locator("[data-workspace-surface]").count()).toBeGreaterThan(0);
+      }
+
+      await expectAxeClean(page);
+      await capture(page, `${viewport.name}-responsive.png`);
+      expect(failures).toEqual([]);
+      await context.close();
+    }
+  }, 150_000);
+
+  test("phone interaction preserves session state, confirmations, focus, browser history, orientation, and offline-after-load use", async () => {
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      hasTouch: true,
+      isMobile: true,
+      reducedMotion: "reduce",
+    });
+    const page = await context.newPage();
+    const failures = observePageFailures(page);
+    await page.goto(baseUrl, { waitUntil: "networkidle" });
+    await page.getByRole("heading", { name: "Staging operations" }).waitFor();
+
+    const root = page.locator(".og-root").first();
+    await page.getByRole("button", { name: "Use light theme" }).click();
+    expect(await root.getAttribute("data-og-theme")).toBe("light");
+
+    const model = page.getByRole("combobox", { name: "Model" });
+    await model.selectOption("accounts/fireworks/models/glm-5p2");
+    expect(await model.inputValue()).toBe("accounts/fireworks/models/glm-5p2");
+
+    const textbox = page.getByRole("textbox", { name: "Message the agent" });
+    const submittedPrompt = "Summarize the rollout risk in one sentence.";
+    await textbox.fill(submittedPrompt);
+    await page.getByRole("button", { name: "Send message" }).click();
+    await page
+      .locator('[id^="og-user-message-"]')
+      .getByText(submittedPrompt, { exact: true })
+      .waitFor({ timeout: 15_000 });
+    await waitForBodyText(page, 'Got it — "Summarize the rollout risk', 15_000);
+    await capture(page, "390-after-send.png");
+
+    await openClearConfirmation(page, textbox);
+    await page.getByRole("button", { name: "Cancel" }).click();
+    expect(await page.getByRole("button", { name: "Run /clear" }).count()).toBe(0);
+    await openClearConfirmation(page, textbox);
+    await page.getByRole("button", { name: "Run /clear" }).click();
+    await page.getByRole("status").filter({ hasText: "Context cleared." }).waitFor();
+
+    const navigation = page.getByRole("navigation", { name: "Demo views" });
+    const workspaceButton = navigation.getByRole("button", { name: "Workspace", exact: true });
+    await workspaceButton.click();
+    const workspace = visibleWorkspaceDialog(page);
+    await workspace.waitFor();
+    expect(await page.evaluate(() => document.activeElement?.getAttribute("role"))).toBe("tab");
+    await page.keyboard.press("ArrowRight");
+    expect(
+      await page.getByRole("tab", { name: "Files", exact: true }).getAttribute("aria-selected"),
+    ).toBe("true");
+    await expectAxeClean(page);
+    await capture(page, "390-workspace-files.png");
+
+    await page.keyboard.press("Escape");
+    await workspace.waitFor({ state: "hidden" });
+    await page.waitForFunction(() => document.activeElement?.textContent?.trim() === "Workspace");
+    expect(await workspaceButton.getAttribute("aria-expanded")).toBe("false");
+    await page.goForward();
+    await workspace.waitFor();
+    await page.goBack();
+    await workspace.waitFor({ state: "hidden" });
+
+    await navigation.getByRole("button", { name: "Fleet", exact: true }).click();
+    await page.reload({ waitUntil: "networkidle" });
+    await page.getByRole("heading", { name: "Fleet", exact: true }).waitFor();
+    expect(new URL(page.url()).hash).toBe("#fleet");
+    await page.goBack();
+    await page.getByRole("heading", { name: "Staging operations" }).waitFor();
+
+    await page.setViewportSize({ width: 844, height: 390 });
+    await expectNoHorizontalOverflow(page);
+    expect(await page.getByRole("navigation", { name: "Demo views" }).count()).toBe(1);
+    expect(
+      await root.evaluate((element) => Math.round(element.getBoundingClientRect().height)),
+    ).toBe(390);
+    await capture(page, "390-landscape.png");
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    await context.setOffline(true);
+    expect(await page.evaluate(() => navigator.onLine)).toBe(false);
+    await navigation.getByRole("button", { name: "Fleet", exact: true }).click();
+    await page.getByRole("heading", { name: "Fleet", exact: true }).waitFor();
+    await navigation.getByRole("button", { name: "Schedules", exact: true }).click();
+    await page.getByRole("heading", { name: "Scheduled tasks" }).waitFor();
+    await navigation.getByRole("button", { name: "Session", exact: true }).click();
+    await page.getByRole("heading", { name: "Staging operations" }).waitFor();
+    await textbox.fill("Keep the loaded scripted demo usable offline.");
+    expect(await textbox.inputValue()).toBe("Keep the loaded scripted demo usable offline.");
+    await expectNoHorizontalOverflow(page);
+    await context.setOffline(false);
+
+    await expectAxeClean(page);
+    expect(failures).toEqual([]);
+    await context.close();
+  }, 90_000);
+
+  test("withheld script delivery shows a stable, accessible boot state before hydration", async () => {
+    const context = await browser.newContext({
+      viewport: { width: 360, height: 800 },
+      hasTouch: true,
+      isMobile: true,
+      reducedMotion: "reduce",
+    });
+    const page = await context.newPage();
+    const html = await (await fetch(baseUrl)).text();
+    const bootOnlyHtml = html.replace('<script type="module" src="/main.tsx"></script>', "");
+    expect(bootOnlyHtml).not.toBe(html);
+    await page.setContent(bootOnlyHtml, { waitUntil: "domcontentloaded" });
+    await page.getByRole("main", { name: "Loading OpenGeni React demo" }).waitFor();
+    expect(await page.getByText("Loading the scripted manager session…").count()).toBe(1);
+    expect(
+      await page
+        .getByRole("main", { name: "Loading OpenGeni React demo" })
+        .getAttribute("aria-busy"),
+    ).toBe("true");
+    await expectNoHorizontalOverflow(page);
+    await expectAxeClean(page);
+    await capture(page, "360-slow-boot.png");
+
+    await page.goto(baseUrl, { waitUntil: "networkidle" });
+    await page.getByRole("heading", { name: "Staging operations" }).waitFor();
+    expect(await page.getByRole("main", { name: "Loading OpenGeni React demo" }).count()).toBe(0);
+    await expectNoHorizontalOverflow(page);
+    await context.close();
+  }, 45_000);
+});
+
+async function openClearConfirmation(page: Page, textbox: Locator): Promise<void> {
+  await textbox.fill("/");
+  const listbox = page.getByRole("listbox", { name: "Slash commands" });
+  await listbox.waitFor();
+  await listbox.getByRole("option").filter({ hasText: "/clear" }).last().click();
+  await page.getByRole("button", { name: "Run /clear" }).waitFor();
+}
+
+function visibleWorkspaceDialog(page: Page): Locator {
+  return page.locator('[role="dialog"][aria-label="Workspace"]:not([hidden])');
+}
+
+async function expectCriticalTouchTargets(page: Page): Promise<void> {
+  const navigation = page.getByRole("navigation", { name: "Demo views" });
+  const targets: Locator[] = [
+    page.getByRole("button", { name: /Use (light|dark) theme/ }),
+    ...Array.from({ length: 4 }, (_, index) => navigation.getByRole("button").nth(index)),
+    page.getByRole("button", { name: "Copy message" }).first(),
+    page.getByRole("button", { name: /^(Thinking|Thought)/ }).first(),
+    page.getByRole("textbox", { name: "Message the agent" }),
+    page.getByRole("combobox", { name: "Model" }),
+    page.getByRole("button", { name: "Pause this workstream" }),
+    page.getByRole("button", { name: "Send message" }),
+  ];
+
+  for (const target of targets) {
+    await target.waitFor();
+    const box = await target.boundingBox();
+    expect(box).not.toBeNull();
+    expect(Math.min(box!.width, box!.height)).toBeGreaterThanOrEqual(43.5);
+  }
+}
+
+async function expectNoHorizontalOverflow(page: Page): Promise<void> {
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(1);
+}
+
+async function waitForBodyText(page: Page, expected: string, timeout = 8_000): Promise<void> {
+  await page.waitForFunction((text) => document.body.innerText.includes(text), expected, {
+    timeout,
+  });
+}
+
+async function expectAxeClean(page: Page): Promise<void> {
+  const axe = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
+    .analyze();
+  expect(axe.violations).toEqual([]);
+}
+
+async function capture(page: Page, name: string): Promise<void> {
+  await page.evaluate(() => document.fonts.ready);
+  await page.screenshot({
+    path: `${evidenceDirectory}/${name}`,
+    fullPage: true,
+    animations: "disabled",
+  });
+}
+
+function observePageFailures(page: Page): string[] {
+  const failures: string[] = [];
+  page.on("pageerror", (error) => failures.push(`pageerror:${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") failures.push(`console:${message.text()}`);
+  });
+  page.on("requestfailed", (request) => {
+    if (!request.url().startsWith("ws:")) failures.push(`request:${request.url()}`);
+  });
+  return failures;
+}


### PR DESCRIPTION
## Summary

- replace the public React component harness framing with a session-first mobile product experience while preserving the desktop three-pane demo
- add complete phone/tablet navigation for Session, Fleet, Schedules, and the controlled Workspace overlay, including browser history, focus restoration, safe-area handling, and stable scroll ownership
- raise shared coarse-pointer controls and timeline disclosures to 44px targets, fix touch timestamp contrast, and serialize mock manager replies so interactive turns cannot interleave with the initial narrative
- add deterministic responsive browser acceptance across 320, 360, 375, 390, 430, 768, 1024, and 1440 widths, including axe, reduced motion, overflow, send/clear, workspace keyboard/focus, reload/history, orientation, offline-after-load, and slow-module boot coverage

Linear: OPE-168

## Product diagnosis

The deployed `/react-demo/` opened into an uncontrolled full-screen Workspace on compact screens, hid Fleet and Schedules below the desktop breakpoint, overflowed at 768px, exposed technical harness/UUID framing, used undersized touch targets, and allowed scripted and interactive mock turns to interleave. The new direction treats the evaluator's manager session as the primary job, progressively discloses secondary operational views, and keeps the public demo truthful about scripted data.

Before/after screenshots and the compact design diagnosis are attached to OPE-168.

## Testing

- [x] `bun run typecheck` (all 23 projects)
- [x] `bun run --cwd packages/react typecheck`
- [x] `bun test --max-concurrency=8 --timeout=30000 packages/react/test` — 1,057 pass, 0 fail
- [x] `bun scripts/run-browser-e2e.ts ./test/e2e/react-demo-mobile.browser.e2e.ts` — 3 pass, 241 assertions, zero axe violations/browser errors
- [x] same browser suite plus React typecheck after a clean no-commit synthetic merge with current `main` `c0361ef8b9badf675486e4a5a9fbddbf265fb9e2`
- [x] `bun run --cwd packages/react build`
- [x] `bun run --cwd apps/web build` — deployed demo build, precompression, and bundle budgets pass
- [x] targeted `oxfmt --check`, `oxlint --deny-warnings`, and `git diff --check`

## Notes

- Exact reviewed candidate head: `a9a9ceab3847825041d6e21d64e4c8cb06dde920`
- No API or public React prop contract changes.
- Release and production verification remain coordinated under OPE-168; the issue stays In Progress until the deployed `/react-demo/` is verified.
