### PR TITLE
chore(release): relax workbench latency budgets

### DIFF
--- a/docs/workbench-acceptance.md
+++ b/docs/workbench-acceptance.md
@@ -244,8 +244,8 @@ with a warm cache. Reports include p50, p75, p95, p99, and worst observation.
 
 | Metric | Release budget |
 | --- | --- |
-| Capture API response | p95 ≤ 200 ms when served from the deployment region |
-| Capture-backed usable workbench | cold-cache p95 ≤ 5 s from full navigation on the production network path |
+| Capture API response | p95 ≤ 400 ms when served from the deployment region |
+| Capture-backed usable workbench | cold-cache p95 ≤ 10 s from full navigation on the production network path |
 | Warm-cache session switch | p95 ≤ 250 ms, with zero stale frames |
 | Immediate interaction feedback | p95 ≤ 100 ms |
 | Editor typing latency | p95 ≤ 50 ms per input event |
@@ -258,7 +258,7 @@ with a warm cache. Reports include p50, p75, p95, p99, and worst observation.
 | Direct session asset graph | ≤ 1,900 KiB raw and ≤ 540 KiB gzip before optional editor/diff/terminal chunks |
 | Lazy JavaScript chunk | ≤ 800 KiB raw and ≤ 240 KiB gzip |
 | CSS asset | ≤ 30 KiB gzip |
-| Steer/Pause physical cancellation | worst ≤ 2,000 ms from committed control to replacement `turn.started` (Steer) or physically stopped activity (Pause), with zero zombie output |
+| Steer/Pause physical cancellation | worst ≤ 4,000 ms from committed control to replacement `turn.started` (Steer) or physically stopped activity (Pause), with zero zombie output |
 
 Measure representative high-, mid-, and low-end desktop hardware plus current
 iOS and Android devices. Include a 4× CPU slowdown and constrained-network run.

--- a/scripts/verify-workbench-acceptance-bundle.test.ts
+++ b/scripts/verify-workbench-acceptance-bundle.test.ts
@@ -293,17 +293,24 @@ describe("workbench acceptance bundle", () => {
     const capture = slow.results.find(
       (item) => item.requirementId === "performance.capture-api-response",
     )!;
-    capture.measurement!.p95 = 201;
-    expect(() => validate(slow)).toThrow("exceeds 200 ms");
+    capture.measurement!.p95 = 401;
+    expect(() => validate(slow)).toThrow("exceeds 400 ms");
 
     const slowWorkbench = validBundle();
     const workbench = slowWorkbench.results.find(
       (item) => item.requirementId === "performance.capture-usable-workbench",
     )!;
-    workbench.measurement!.p95 = 5_001;
-    workbench.measurement!.p99 = 5_001;
-    workbench.measurement!.worst = 5_001;
-    expect(() => validate(slowWorkbench)).toThrow("exceeds 5000 ms");
+    workbench.measurement!.p95 = 10_001;
+    workbench.measurement!.p99 = 10_001;
+    workbench.measurement!.worst = 10_001;
+    expect(() => validate(slowWorkbench)).toThrow("exceeds 10000 ms");
+
+    const slowCancellation = validBundle();
+    const cancellation = slowCancellation.results.find(
+      (item) => item.requirementId === "performance.control-cancellation",
+    )!;
+    cancellation.measurement!.worst = 4_001;
+    expect(() => validate(slowCancellation)).toThrow("exceeds 4000 ms");
 
     const secret = validBundle() as any;
     secret.cookie = "session=not-allowed";

--- a/scripts/workbench-acceptance-contract.ts
+++ b/scripts/workbench-acceptance-contract.ts
@@ -53,19 +53,19 @@ export const NUMERIC_PERFORMANCE_BUDGETS: Readonly<Record<string, NumericBudget>
   "performance.capture-api-response": {
     statistic: "p95",
     direction: "maximum",
-    limit: 200,
+    limit: 400,
     unit: "ms",
   },
   "performance.capture-usable-workbench": {
     statistic: "p95",
     direction: "maximum",
-    limit: 5_000,
+    limit: 10_000,
     unit: "ms",
   },
   "performance.control-cancellation": {
     statistic: "worst",
     direction: "maximum",
-    limit: 2_000,
+    limit: 4_000,
     unit: "ms",
   },
 };

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -49,6 +49,10 @@ const CAPTURE_USABLE_WORKBENCH_P95_MS = maximumMillisecondBudget(
   "performance.capture-usable-workbench",
   "p95",
 );
+const CONTROL_CANCELLATION_WORST_MS = maximumMillisecondBudget(
+  "performance.control-cancellation",
+  "worst",
+);
 const shaPattern = /^[0-9a-f]{40}$/;
 const runIdPattern = /^[a-z0-9][a-z0-9-]{2,63}$/;
 
@@ -1286,7 +1290,7 @@ async function runLiveWorkspaceFlow(input: {
     pass(
       checks,
       "performance.control-cancellation",
-      `Steer/Pause physical cancellation worst=${round(controlSummary.worst)}ms, p95=${round(controlSummary.p95)}ms across ${controlSummary.sampleCount} controls (hard budget 2000ms).`,
+      `Steer/Pause physical cancellation worst=${round(controlSummary.worst)}ms, p95=${round(controlSummary.p95)}ms across ${controlSummary.sampleCount} controls (hard budget ${CONTROL_CANCELLATION_WORST_MS}ms).`,
     );
 
     assertNoProblems(problems, false);
@@ -1429,16 +1433,18 @@ async function proveLiveSteerCancellation(input: {
     workspaceId,
     sessionId,
     ready.sequence,
-    2_000,
+    CONTROL_CANCELLATION_WORST_MS,
     (event) => event.type === "turn.started" && event.turnId === replacementTurnId,
-    "replacement turn start inside the 2s physical-cancellation budget",
+    "replacement turn start inside the physical-cancellation budget",
   );
   const controlCancellationMs = controlCancellationDurationMs(
     committedAt,
     Date.parse(replacementStarted.occurredAt),
   );
-  if (controlCancellationMs > 2_000) {
-    throw new Error(`Steer replacement took ${controlCancellationMs}ms; budget is 2000ms`);
+  if (controlCancellationMs > CONTROL_CANCELLATION_WORST_MS) {
+    throw new Error(
+      `Steer replacement took ${controlCancellationMs}ms; budget is ${CONTROL_CANCELLATION_WORST_MS}ms`,
+    );
   }
   const renderedStoppingState = await stoppingVisible;
   if (controlCancellationMs > 100 && !renderedStoppingState) {
@@ -1620,7 +1626,7 @@ async function proveLivePauseCancellation(input: {
     workspaceId,
     sessionId,
     ready.sequence,
-    2_000,
+    CONTROL_CANCELLATION_WORST_MS,
     (event) =>
       event.type === "session.control.paused" &&
       isRecord(event.payload) &&
@@ -1632,7 +1638,7 @@ async function proveLivePauseCancellation(input: {
     workspaceId,
     sessionId,
     pauseRequested.sequence,
-    2_000,
+    CONTROL_CANCELLATION_WORST_MS,
     (event) =>
       event.type === "session.queue.changed" &&
       event.turnId === predecessorTurnId &&
@@ -1644,9 +1650,9 @@ async function proveLivePauseCancellation(input: {
     committedAt,
     Date.parse(quiesced.occurredAt),
   );
-  if (controlCancellationMs > 2_000) {
+  if (controlCancellationMs > CONTROL_CANCELLATION_WORST_MS) {
     throw new Error(
-      `Pause physical cancellation took ${controlCancellationMs}ms; budget is 2000ms`,
+      `Pause physical cancellation took ${controlCancellationMs}ms; budget is ${CONTROL_CANCELLATION_WORST_MS}ms`,
     );
   }
   const renderedStoppingState = await stoppingState;


### PR DESCRIPTION
## Summary
- double every numeric latency ceiling in the canonical per-candidate workbench acceptance contract
- make live control-cancellation probes consume the shared contract instead of hard-coded values
- update release documentation and boundary tests

## Validation
- `bun test --timeout 30000 scripts/verify-workbench-acceptance-bundle.test.ts scripts/workbench-live-acceptance.test.ts`
- `bun run typecheck`
- targeted Oxlint and Oxfmt

Functional, security, evidence, sample-count, and zero-zombie requirements are unchanged.