### PR TITLE
chore(release): bump product version to 0.22.76

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.75
-appVersion: "0.22.75"
+version: 0.22.76
+appVersion: "0.22.76"


### PR DESCRIPTION
## Summary
- advance the OpenGeni product/chart identity to `0.22.76`
- keep chart `version` and `appVersion` aligned
- include the doubled canonical release-gating latency budgets already merged on `main`

## Verification
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `bun test scripts/release-version.test.ts scripts/release-candidate.test.ts`
- `bun run release:schema-contract`
- `bun run deployment:profiles`
- `bun run lint`
- `bun run format:check`