### PR TITLE
fix(config): enable Codex tool search by default

### DIFF
--- a/.changeset/quiet-tools-default.md
+++ b/.changeset/quiet-tools-default.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/config": patch
+---
+
+Enable progressive Codex MCP tool disclosure by default while retaining an explicit operator opt-out.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -415,9 +415,11 @@ const SettingsSchema = z.object({
   // flag non-mandatory selected MCP tools `defer_loading:true` (dropping their
   // schemas from model context) and add one client-executed tool_search tool
   // that BM25-discloses bounded matches. The mandatory OpenGeni tools stay
-  // eager. Default OFF — a codex turn is byte-for-byte unchanged until enabled.
+  // eager. Default ON so selected connector catalogues do not consume every
+  // Codex turn's context. Operators may explicitly disable it for emergency
+  // compatibility diagnosis.
   // OPENGENI_CODEX_TOOL_SEARCH_ENABLED
-  codexToolSearchEnabled: EnvBoolean.default(false),
+  codexToolSearchEnabled: EnvBoolean.default(true),
   // credential allocator atomic, workspace-local credential allocation. Default OFF is a
   // deliberate rolling-deploy fence: migrate + roll every worker first, then
   // enable. Turning it off restores the legacy sticky selector without a schema

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -98,6 +98,16 @@ describe("browser analytics configuration", () => {
   });
 });
 
+describe("Codex progressive tool disclosure", () => {
+  test("is enabled by default and supports an explicit emergency opt-out", () => {
+    expect(withEnv({}, () => getSettings()).codexToolSearchEnabled).toBe(true);
+    expect(
+      withEnv({ OPENGENI_CODEX_TOOL_SEARCH_ENABLED: "false" }, () => getSettings())
+        .codexToolSearchEnabled,
+    ).toBe(false);
+  });
+});
+
 describe("Google Drive integration settings", () => {
   test("loads the split localhost browser and API origins", () => {
     const settings = withEnv(


### PR DESCRIPTION
## Summary
- default progressive Codex MCP tool disclosure to enabled
- retain an explicit  emergency opt-out
- lock the contract with a configuration test and changeset

## Verification
- bun test v1.3.13 (bf2e2cec) (92 passed)
