### PR TITLE
fix(runtime): keep provider context usage synchronized

### DIFF
--- a/.changeset/clean-provider-usage-state.md
+++ b/.changeset/clean-provider-usage-state.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/db": patch
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Use one terminal-response ordinal for provider context binding, and clear the
+durable input-token signal when the latest provider response supplies no usable
+usage instead of retaining an older response's count.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -89,7 +89,7 @@ import {
   sandboxStateEntryFromRunState,
   maxTurnsExceededRunState,
   modelResponseServiceTierFromSdkEvent,
-  modelResponseUsageFromSdkEvent,
+  modelTerminalResponseFromSdkEvent,
   normalizeModelCallUsage,
   normalizeSdkEvent,
   projectHistoryForProvider,
@@ -1123,10 +1123,9 @@ type TurnEventPublisher = (
   immediate?: boolean,
 ) => Promise<{ events: SessionEvent[]; accepted: boolean }>;
 
-export type ModelResponseUsageEventState = {
-  responseUsageCount: number;
-  providerContextRevision: number;
-  lastProviderContextTokensObserved: number | null;
+export type ModelResponseEventState = {
+  responseCount: number;
+  contextSignal: { revision: number; totalTokens: number } | null;
   claimedSourceKeys: Set<string>;
 };
 
@@ -1135,13 +1134,12 @@ export type CompactionModelUsageEventState = {
   claimedSourceKeys: Set<string>;
 };
 
-export function createModelResponseUsageEventState(
+export function createModelResponseEventState(
   claimedSourceKeys: Set<string> = new Set<string>(),
-): ModelResponseUsageEventState {
+): ModelResponseEventState {
   return {
-    responseUsageCount: 0,
-    providerContextRevision: 0,
-    lastProviderContextTokensObserved: null,
+    responseCount: 0,
+    contextSignal: null,
     claimedSourceKeys,
   };
 }
@@ -1152,15 +1150,10 @@ export function createCompactionModelUsageEventState(
   return { usageCount: 0, claimedSourceKeys };
 }
 
-export function modelResponseUsageContextSignal(
-  state: ModelResponseUsageEventState,
+export function modelResponseContextSignal(
+  state: ModelResponseEventState,
 ): { revision: number; totalTokens: number } | null {
-  return state.lastProviderContextTokensObserved === null
-    ? null
-    : {
-        revision: state.providerContextRevision,
-        totalTokens: state.lastProviderContextTokensObserved,
-      };
+  return state.contextSignal;
 }
 
 export function assertModelResponseLatencyMode(input: {
@@ -1195,19 +1188,20 @@ export function assertModelResponseLatencyMode(input: {
 }
 
 /**
- * Process one SDK stream event through the exact production usage path.
+ * Process one SDK terminal-response event through the production authority path.
  *
  * The pinned Responses SDK mirrors one provider terminal response as both a
  * normalized `response_done` and a raw `model/response.completed` event. Claim
- * the stable response/source key before lease renewal or any usage side effect,
- * and advance the positional ordinal only for a newly claimed response. The
- * durable `agent.model.usage` source-key fence remains the cross-restart
- * authority: a replay may retry the idempotent billing write, but it cannot
- * advance process-local metrics, provider context, or attempt-owned signals.
+ * the stable response/source key before lease renewal or any side effect, and
+ * use that one positional ordinal for both response identity and same-run
+ * context binding. A response without usage still clears attempt-owned token
+ * state. When usage exists, the durable `agent.model.usage` source-key fence
+ * remains the cross-restart authority: a replay may retry the idempotent billing
+ * write, but it cannot advance metrics, context, or attempt-owned signals.
  */
-export async function processModelResponseUsageEvent(input: {
-  event: Parameters<typeof modelResponseUsageFromSdkEvent>[0];
-  state: ModelResponseUsageEventState;
+export async function processModelResponseTerminalEvent(input: {
+  event: Parameters<typeof modelTerminalResponseFromSdkEvent>[0];
+  state: ModelResponseEventState;
   dispatchId: string | null;
   settings: Settings;
   db: ActivityServices["db"];
@@ -1230,20 +1224,25 @@ export async function processModelResponseUsageEvent(input: {
   renewLease: () => Promise<void>;
   leaseLost: () => boolean;
   leaseLostMessage: string;
-  setLastInputTokens: (tokens: number) => Promise<void>;
+  setLastInputTokens: (tokens: number | null) => Promise<void>;
 }): Promise<
-  | { status: "not_usage" }
+  | { status: "not_response" }
   | { status: "duplicate"; sourceKey: string }
-  | { status: "processed"; sourceKey: string; authoritative: boolean }
+  | {
+      status: "processed";
+      sourceKey: string;
+      authoritative: boolean;
+      usageReported: boolean;
+    }
 > {
-  const responseUsage = modelResponseUsageFromSdkEvent(input.event);
-  if (!responseUsage) {
-    return { status: "not_usage" };
+  const terminal = modelTerminalResponseFromSdkEvent(input.event);
+  if (!terminal) {
+    return { status: "not_response" };
   }
 
-  const responseOrdinal = input.state.responseUsageCount + 1;
+  const responseOrdinal = input.state.responseCount + 1;
   const sourceKey = modelUsageSourceKey({
-    responseId: responseUsage.responseId,
+    responseId: terminal.responseId,
     dispatchId: input.dispatchId,
     positionalKey: `response-${responseOrdinal}`,
   });
@@ -1251,20 +1250,25 @@ export async function processModelResponseUsageEvent(input: {
     return { status: "duplicate", sourceKey };
   }
   input.state.claimedSourceKeys.add(sourceKey);
-  input.state.responseUsageCount = responseOrdinal;
+  input.state.responseCount = responseOrdinal;
 
-  const normalizedUsage = normalizeModelCallUsage(responseUsage.usage);
+  const responseUsage = terminal.usage;
+
+  const normalizedUsage = normalizeModelCallUsage(responseUsage?.usage);
   const accountContext = modelCallAccountContext({
     servingCredentialId: input.servingCredentialId,
     priorSessionCredentialId: input.priorSessionCredentialId,
     isFirstCallOfTurn: responseOrdinal === 1,
   });
-  let authoritative = false;
+  // A terminal response without usage still authoritatively replaces the
+  // attempt-owned context signal. There is simply no billing event to claim.
+  let authoritative = responseUsage === null;
   await recordCompletedModelCallBeforeOwnershipFences({
     renewLease: input.renewLease,
     leaseLost: input.leaseLost,
     leaseLostMessage: input.leaseLostMessage,
     recordUsage: async () => {
+      if (!responseUsage) return;
       const billing = await recordModelUsageAndDebitCredits(input.settings, input.db, {
         accountId: input.accountId,
         workspaceId: input.workspaceId,
@@ -1322,17 +1326,22 @@ export async function processModelResponseUsageEvent(input: {
     recordAttemptSignals: async () => {
       if (!authoritative) return;
       const observedTotal = normalizedUsage.totalTokens;
-      if (observedTotal !== null) {
-        input.state.lastProviderContextTokensObserved = observedTotal;
-        input.state.providerContextRevision += 1;
-      }
+      input.state.contextSignal =
+        observedTotal !== null && observedTotal > 0
+          ? { revision: responseOrdinal, totalTokens: observedTotal }
+          : null;
       const observedInput = normalizedUsage.telemetry.inputTokens;
-      if (observedInput !== null && observedInput > 0) {
-        await input.setLastInputTokens(observedInput);
-      }
+      await input.setLastInputTokens(
+        observedInput !== null && observedInput > 0 ? observedInput : null,
+      );
     },
   });
-  return { status: "processed", sourceKey, authoritative };
+  return {
+    status: "processed",
+    sourceKey,
+    authoritative,
+    usageReported: responseUsage !== null,
+  };
 }
 
 /**
@@ -2454,7 +2463,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // Still required by credential-loss/capacity settlements, whose own
     // recovery transactions fence against worker-death redispatches.
     let redispatchesAtDispatch = 0;
-    const setLastInputTokensFenced = async (lastInputTokens: number): Promise<void> => {
+    const setLastInputTokensFenced = async (lastInputTokens: number | null): Promise<void> => {
       if (!turnId || executionGeneration <= 0) {
         throw new Error("Turn attempt was not initialized before token accounting");
       }
@@ -6535,13 +6544,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         return outcome;
       };
 
-      // Keep response usage identity across every stream attempt in this
+      // Keep response identity across every stream attempt in this
       // activity. Context compaction retries the same logical dispatch by
       // calling runStreamAttempt again; resetting this state there would reuse
       // the first no-response-ID fallback key and suppress a real model call.
-      const modelResponseUsageState = createModelResponseUsageEventState(
-        claimedModelUsageSourceKeys,
-      );
+      const modelResponseState = createModelResponseEventState(claimedModelUsageSourceKeys);
       const runStreamAttempt = async (): Promise<RunAgentTurnResult> => {
         if (!runInput) {
           throw new Error("Run input was not prepared");
@@ -6555,6 +6562,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // schema or compatibility state.
         let currentToolBatchCallIds = new Set<string>();
         let currentToolBatchCompletedCallIds = new Set<string>();
+        let streamSawPerResponseUsage = false;
         // Actual input tokens of the most recent model response this turn; the
         // pre-read trigger for the NEXT turn. Persisted at every turn-end path.
         throwIfWorkerShuttingDown();
@@ -6671,7 +6679,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                     : {}),
                 }
               : {}),
-            contextCompactionSignal: () => modelResponseUsageContextSignal(modelResponseUsageState),
+            contextCompactionSignal: () => modelResponseContextSignal(modelResponseState),
             contextCompactionRequested: () =>
               isSessionCompactionRequested(db, input.workspaceId, input.sessionId),
             callModelInputFilter: secretRedactionModelInputFilter((value) => redact(value)),
@@ -6712,9 +6720,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             }
             let stableToolCallIdsToClear: string[] | null = null;
             let completedCurrentToolBatch = false;
-            const responseUsageResult = await processModelResponseUsageEvent({
+            const responseResult = await processModelResponseTerminalEvent({
               event: next.value,
-              state: modelResponseUsageState,
+              state: modelResponseState,
               dispatchId: modelUsageDispatchId,
               settings,
               db,
@@ -6745,7 +6753,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               model: turn.model,
               ...(resolvedModel?.provider.id ? { providerId: resolvedModel.provider.id } : {}),
             });
-            if (responseUsageResult.status === "processed") {
+            if (responseResult.status === "processed") {
+              streamSawPerResponseUsage ||= responseResult.usageReported;
               currentToolBatchCallIds = new Set<string>();
               currentToolBatchCompletedCallIds = new Set<string>();
               await reconcileConversationTruth();
@@ -6884,7 +6893,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           stream.completed.catch(() => undefined),
           cancellationSignal,
         );
-        if (modelResponseUsageState.responseUsageCount === 0) {
+        if (!streamSawPerResponseUsage) {
           const aggregateUsage = stream.state.usage;
           const normalizedAggregateUsage = normalizeModelCallUsage(aggregateUsage);
           const aggregateInput = normalizedAggregateUsage.telemetry.inputTokens;
@@ -6895,8 +6904,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           });
           if (!claimedModelUsageSourceKeys.has(aggregateSourceKey)) {
             claimedModelUsageSourceKeys.add(aggregateSourceKey);
-            // The single aggregate frame is this turn's only model-usage record, so
-            // it is the first (account-switch surfaces here just like a first response).
+            // The aggregate frame is only a billing fallback when no terminal
+            // response exposed usage. It is not final-request context authority.
             const aggregateAccountCtx = modelCallAccountContext({
               servingCredentialId: effectiveCodexCredentialId,
               priorSessionCredentialId: priorSessionCodexCredentialId,
@@ -6963,14 +6972,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               },
               recordAttemptSignals: async () => {
                 if (!aggregateAuthoritative) return;
-                if (normalizedAggregateUsage.totalTokens !== null) {
-                  modelResponseUsageState.lastProviderContextTokensObserved =
-                    normalizedAggregateUsage.totalTokens;
-                  modelResponseUsageState.providerContextRevision += 1;
-                }
-                if (aggregateInput !== null && aggregateInput > 0) {
-                  await setLastInputTokensFenced(aggregateInput);
-                }
+                // Stream aggregates can cover multiple requests and therefore
+                // cannot identify the final request that compaction must bind.
+                // They remain billing/telemetry fallback data only.
+                modelResponseState.contextSignal = null;
+                await setLastInputTokensFenced(null);
               },
             });
           }

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -20,6 +20,7 @@ import {
   SessionEventPersistenceError,
 } from "@opengeni/db";
 import {
+  CompactionNeededError,
   CompactionProviderResponseError,
   EmptyCompactionSummaryError,
   WorkspaceArchiveIntegrityError,
@@ -41,7 +42,7 @@ import {
   codexCredentialLeaseDeadlineExpired,
   computerToolModeForTurn,
   createCompactionModelUsageEventState,
-  createModelResponseUsageEventState,
+  createModelResponseEventState,
   createTurnSandboxProvisioner,
   drainAttemptOwnedSandboxWriters,
   emitModelCallUsage,
@@ -59,11 +60,11 @@ import {
   modelSupportsImageInputForTurn,
   recordCompletedModelCallBeforeOwnershipFences,
   modelUsageSourceKey,
-  modelResponseUsageContextSignal,
+  modelResponseContextSignal,
   managedSandboxOwnershipForTurn,
   pointerReconcileReason,
   processCompactionModelUsageEvent,
-  processModelResponseUsageEvent,
+  processModelResponseTerminalEvent,
   persistOrSignalSessionAttemptQuiescence,
   PROVIDER_BACKPRESSURE_DELAY_MS,
   providerRecoveryCountFromMetadata,
@@ -1161,11 +1162,11 @@ describe("production model-response usage callback authority", () => {
           };
         }),
       });
-      const fencedInputs: number[] = [];
-      const state = createModelResponseUsageEventState();
+      const fencedInputs: Array<number | null> = [];
+      const state = createModelResponseEventState();
       const emittedSourceKeys = new Set<string>();
       const process = (event: any, targetState = state, dispatchId = "activity-A") =>
-        processModelResponseUsageEvent({
+        processModelResponseTerminalEvent({
           event,
           state: targetState,
           dispatchId,
@@ -1201,7 +1202,7 @@ describe("production model-response usage callback authority", () => {
         }),
         {
           throwOnCompactionNeeded: true,
-          contextCompactionSignal: () => modelResponseUsageContextSignal(state),
+          contextCompactionSignal: () => modelResponseContextSignal(state),
         },
       );
       const first = [{ type: "message", role: "user", content: "start" }] as any;
@@ -1215,9 +1216,8 @@ describe("production model-response usage callback authority", () => {
 
       expect((await process(normalizedTerminal)).status).toBe("processed");
       expect((await process(rawTerminal)).status).toBe("duplicate");
-      expect(state.responseUsageCount).toBe(1);
-      expect(state.providerContextRevision).toBe(1);
-      expect(state.lastProviderContextTokensObserved).toBe(120);
+      expect(state.responseCount).toBe(1);
+      expect(state.contextSignal).toEqual({ revision: 1, totalTokens: 120 });
       expect(fencedInputs).toEqual([100]);
       expect(durableUsageSourceKeys).toEqual(new Set([response.id]));
       expect([...billingRows.values()]).toEqual([
@@ -1259,10 +1259,10 @@ describe("production model-response usage callback authority", () => {
       // response id reaches the durable fences again, but duplicate authority
       // prevents every local metric/context/fenced-input effect and the DB-level
       // idempotency key keeps one billing row.
-      const restartedState = createModelResponseUsageEventState();
+      const restartedState = createModelResponseEventState();
       const restartedInputsBefore = fencedInputs.length;
       const restartedEmittedSourceKeys = new Set<string>();
-      const restarted = await processModelResponseUsageEvent({
+      const restarted = await processModelResponseTerminalEvent({
         event: normalizedTerminal as any,
         state: restartedState,
         dispatchId: "activity-B",
@@ -1295,15 +1295,124 @@ describe("production model-response usage callback authority", () => {
         authoritative: false,
         sourceKey: response.id,
       });
-      expect(restartedState.responseUsageCount).toBe(1);
-      expect(restartedState.providerContextRevision).toBe(0);
-      expect(restartedState.lastProviderContextTokensObserved).toBeNull();
+      expect(restartedState.responseCount).toBe(1);
+      expect(restartedState.contextSignal).toBeNull();
       expect(fencedInputs).toHaveLength(restartedInputsBefore);
       expect(billingRows).toHaveLength(1);
       const metricsAfterRestart = await observability.prometheusMetrics();
       expect(metricsAfterRestart).toMatch(
         /opengeni_model_input_tokens_count\{[^}]*provider="codex-subscription"[^}]*\} 1\b/,
       );
+    } finally {
+      recordUsageSpy.mockRestore();
+    }
+  });
+
+  test("clears missing usage and uses the same response ordinal when usage resumes", async () => {
+    const observability = createObservability(testSettings(), { component: "worker" });
+    const recordUsageSpy = spyOn(opengeniDb, "recordUsageEvent").mockImplementation(
+      async () => undefined,
+    );
+    try {
+      const state = createModelResponseEventState();
+      const fencedInputs: Array<number | null> = [];
+      const emittedSourceKeys = new Set<string>();
+      const publish = async (batch: any[]) => ({
+        accepted: true,
+        events: batch.map((event) => ({
+          ...event,
+          id: crypto.randomUUID(),
+          turnAssociation: "current" as const,
+        })),
+      });
+      const process = (event: RunRawModelStreamEvent) =>
+        processModelResponseTerminalEvent({
+          event,
+          state,
+          dispatchId: "activity-missing-usage",
+          settings: testSettings(),
+          db: {} as any,
+          observability,
+          publish: publish as any,
+          accountId: "acct-1",
+          workspaceId: "ws-1",
+          sessionId: "sess-1",
+          turnId: "turn-1",
+          turnAttemptId: "attempt-1",
+          provider: "codex-subscription",
+          providerApi: "responses",
+          model: "codex/gpt-5.6-sol",
+          metricProvider: "codex-subscription",
+          externallyBilled: true,
+          servingCredentialId: "credential-1",
+          priorSessionCredentialId: "credential-1",
+          emittedSourceKeys,
+          renewLease: async () => undefined,
+          leaseLost: () => false,
+          leaseLostMessage: "lease lost",
+          setLastInputTokens: async (tokens) => {
+            fencedInputs.push(tokens);
+          },
+        });
+      const filter = contextRobustnessFilterForSettings(
+        testSettings({
+          contextWindowTokens: 20_000,
+          contextAutoCompactThresholdTokens: 10_000,
+        }),
+        {
+          throwOnCompactionNeeded: true,
+          contextCompactionSignal: () => modelResponseContextSignal(state),
+        },
+      );
+
+      const first = [{ type: "message", role: "user", content: "start" }] as any;
+      await filter({ modelData: { input: first, instructions: "system" }, agent: {} as any });
+      const missingUsage = new RunRawModelStreamEvent({
+        type: "response_done",
+        response: { id: "resp-1", output: [] },
+      } as any);
+      expect(await process(missingUsage)).toMatchObject({
+        status: "processed",
+        authoritative: true,
+      });
+      expect(state).toMatchObject({
+        responseCount: 1,
+        contextSignal: null,
+      });
+      expect(fencedInputs).toEqual([null]);
+
+      const second = [
+        ...first,
+        { type: "message", role: "assistant", content: "first response" },
+        { type: "message", role: "user", content: "continue" },
+      ] as any;
+      await filter({ modelData: { input: second, instructions: "system" }, agent: {} as any });
+      const validUsage = new RunRawModelStreamEvent({
+        type: "response_done",
+        response: {
+          id: "resp-2",
+          output: [],
+          usage: { inputTokens: 11_000, outputTokens: 1_000, totalTokens: 12_000 },
+        },
+      } as any);
+      expect(await process(validUsage)).toMatchObject({
+        status: "processed",
+        authoritative: true,
+      });
+      expect(state).toMatchObject({
+        responseCount: 2,
+        contextSignal: { revision: 2, totalTokens: 12_000 },
+      });
+      expect(fencedInputs).toEqual([null, 11_000]);
+
+      const third = [
+        ...second,
+        { type: "message", role: "assistant", content: "second response" },
+        { type: "message", role: "user", content: "continue again" },
+      ] as any;
+      await expect(
+        filter({ modelData: { input: third, instructions: "system" }, agent: {} as any }),
+      ).rejects.toBeInstanceOf(CompactionNeededError);
     } finally {
       recordUsageSpy.mockRestore();
     }
@@ -1346,10 +1455,10 @@ describe("production model-response usage callback authority", () => {
             },
           },
         } as any);
-      const state = createModelResponseUsageEventState();
+      const state = createModelResponseEventState();
       const emittedSourceKeys = new Set<string>();
       const process = (event: RunRawModelStreamEvent) =>
-        processModelResponseUsageEvent({
+        processModelResponseTerminalEvent({
           event,
           state,
           dispatchId: "activity-A",
@@ -1378,7 +1487,7 @@ describe("production model-response usage callback authority", () => {
 
       const beforeCompaction = await process(terminal(100, 20));
       // The compaction retry re-enters the stream callback with this same
-      // activity-wide state rather than resetting responseUsageCount.
+      // activity-wide state rather than resetting responseCount.
       const afterCompaction = await process(terminal(200, 30));
 
       expect(beforeCompaction).toMatchObject({
@@ -1391,7 +1500,7 @@ describe("production model-response usage callback authority", () => {
         sourceKey: "activity-A:response-2",
         authoritative: true,
       });
-      expect(state.responseUsageCount).toBe(2);
+      expect(state.responseCount).toBe(2);
       expect(durableUsageSourceKeys).toEqual(
         new Set(["activity-A:response-1", "activity-A:response-2"]),
       );

--- a/docs/command-palette.md
+++ b/docs/command-palette.md
@@ -178,7 +178,7 @@ wait for settlement before retrying.
    transcript survives as an audit trail (same pattern as compaction).
 2. Inserts **one neutral boundary marker** (`[context cleared]`, a sanitizer-
    clean user message) at `max(position)+1`.
-3. Resets `last_input_tokens` to 0 so the next turn's compaction trigger starts
+3. Resets `last_input_tokens` to null so the next turn's compaction trigger starts
    fresh.
 
 It is idempotent, and the API emits a `session.context.cleared` event carrying

--- a/docs/context-compaction.md
+++ b/docs/context-compaction.md
@@ -65,8 +65,10 @@ instruction or tool-schema growth. That anchor is accepted only when the usage
 revision belongs to the immediately preceding model request; a delayed signal
 is ignored rather than attached to newer input. At a later turn boundary, the
 attempt-fenced provider-reported `last_input_tokens` is the only durable
-automatic signal. Compaction or context clearing sets it to null until the
-first successful ordinary model response reports the new context. Local
+automatic signal. Every newer authoritative terminal response replaces it with
+that response's usable input count or null when the provider supplied none;
+compaction and context clearing also set it to null. A missing or invalid count
+never carries an older response's value forward. Local
 estimates remain limited to shaping a compaction request and describing the
 history-only before/after replacement; they never enter `last_input_tokens`.
 

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -350,6 +350,8 @@ prior-call input count at a turn boundary, or the immediately preceding
 same-activity provider total plus bounded newly appended input. With no bound
 provider count, OpenGeni sends the request and recovers from a genuine provider
 context overflow instead of compacting from a whole-request approximation.
+Each authoritative terminal response replaces the durable count with its usable
+input count or null; an omitted count never leaves an older response active.
 Local media-aware estimates remain confined to compaction-request fitting and
 history-only replacement reporting. See
 [`context-compaction.md`](context-compaction.md).

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -6257,9 +6257,9 @@ export const Session = z.object({
   createIdempotencyKey: z.string().nullable(),
   temporalWorkflowId: z.string().nullable(),
   activeTurnId: z.string().uuid().nullable(),
-  // Actual input tokens of the last model call of the most recent turn; the
-  // pre-turn portable context-compaction trigger reads it as its budget
-  // signal. Null until a turn with usage has completed.
+  // Provider-reported input tokens of the latest authoritative terminal
+  // response. Null after a context transition or whenever that latest response
+  // supplied no usable count, so an older response can never drive compaction.
   lastInputTokens: z.number().int().nonnegative().nullable(),
   queueVersion: z.number().int().nonnegative(),
   queueHeadPosition: z.number().int(),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -22281,8 +22281,9 @@ export async function nextSessionHistoryPosition(
 }
 
 /**
- * Record the actual input-token count of the most recent turn's final model
- * call, for the next turn's pre-read compaction trigger.
+ * Replace the input-token count for the most recent authoritative terminal
+ * response. Null means that response supplied no usable final-call count, so
+ * the next turn must not reuse an older response's value for compaction.
  */
 export async function setSessionLastInputTokensForTurnAttempt(
   db: Database,
@@ -22292,7 +22293,7 @@ export async function setSessionLastInputTokensForTurnAttempt(
     turnId: string;
     expectedExecutionGeneration: number;
     expectedAttemptId: string;
-    lastInputTokens: number;
+    lastInputTokens: number | null;
   },
 ): Promise<boolean> {
   return await withWorkspaceRls(db, input.workspaceId, async (scopedDb) => {

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -4582,6 +4582,19 @@ describe("clean session control plane", () => {
         lastInputTokens: 999,
       }),
     ).toBe(true);
+    expect(
+      await setSessionLastInputTokensForTurnAttempt(client.db, {
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: second!.id,
+        expectedExecutionGeneration: second!.executionGeneration,
+        expectedAttemptId: secondAttemptId,
+        lastInputTokens: null,
+      }),
+    ).toBe(true);
+    expect(
+      (await getSession(client.db, grant.workspaceId!, session.id))?.lastInputTokens,
+    ).toBeNull();
     const currentCompaction = await applyContextCompaction(client.db, {
       accountId: grant.accountId,
       workspaceId: grant.workspaceId!,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -402,6 +402,11 @@ export type ModelResponseUsage = {
   };
 };
 
+export type ModelTerminalResponse = {
+  responseId?: string;
+  usage: ModelResponseUsage | null;
+};
+
 type RuntimeMcpTool = Awaited<ReturnType<MCPServer["listTools"]>>[number];
 
 type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
@@ -6297,8 +6302,22 @@ export function normalizeSdkEvent(event: RunStreamEvent): NormalizedRuntimeEvent
 }
 
 export function modelResponseUsageFromSdkEvent(event: RunStreamEvent): ModelResponseUsage | null {
+  return modelTerminalResponseFromSdkEvent(event)?.usage ?? null;
+}
+
+/** Recognize a terminal response even when the provider omitted usage. */
+export function modelTerminalResponseFromSdkEvent(
+  event: RunStreamEvent,
+): ModelTerminalResponse | null {
   const response = modelResponseFromSdkEvent(event);
-  return modelResponseUsageFromResponse(response);
+  if (!response) {
+    return null;
+  }
+  const responseId = modelResponseIdFromResponse(response);
+  return {
+    ...(responseId ? { responseId } : {}),
+    usage: modelResponseUsageFromResponse(response),
+  };
 }
 
 /** Normalize usage from either a Responses or Chat Completions result. */
@@ -6307,12 +6326,7 @@ export function modelResponseUsageFromResponse(response: unknown): ModelResponse
   if (!usage) {
     return null;
   }
-  const responseId =
-    typeof (response as { id?: unknown } | null)?.id === "string"
-      ? (response as { id: string }).id
-      : typeof (response as { responseId?: unknown } | null)?.responseId === "string"
-        ? (response as { responseId: string }).responseId
-        : undefined;
+  const responseId = modelResponseIdFromResponse(response);
   const serviceTier = modelResponseServiceTierFromResponse(response);
   const gatewayBilling = gatewayBillingFromResponse(response);
   return {
@@ -6321,6 +6335,14 @@ export function modelResponseUsageFromResponse(response: unknown): ModelResponse
     ...(gatewayBilling ? { gatewayBilling } : {}),
     usage,
   };
+}
+
+function modelResponseIdFromResponse(response: unknown): string | undefined {
+  return typeof (response as { id?: unknown } | null)?.id === "string"
+    ? (response as { id: string }).id
+    : typeof (response as { responseId?: unknown } | null)?.responseId === "string"
+      ? (response as { responseId: string }).responseId
+      : undefined;
 }
 
 /** Extract only the bounded, non-secret Gateway billing facts we consume. */

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -70,6 +70,7 @@ import {
   modelCallUsageTelemetry,
   normalizeModelCallUsage,
   modelResponseServiceTierFromSdkEvent,
+  modelTerminalResponseFromSdkEvent,
   modelResponseUsageFromSdkEvent,
   modelResponseUsageFromResponse,
   normalizeSdkEvent,
@@ -415,6 +416,22 @@ describe("runtime event normalization", () => {
       },
     });
     expect(normalizeSdkEvent(event)).toEqual([]);
+  });
+
+  test("recognizes a terminal response when the provider omitted usage", () => {
+    const event = {
+      type: "raw_model_stream_event",
+      data: {
+        type: "response_done",
+        response: { id: "resp-without-usage" },
+      },
+    } as any;
+
+    expect(modelTerminalResponseFromSdkEvent(event)).toEqual({
+      responseId: "resp-without-usage",
+      usage: null,
+    });
+    expect(modelResponseUsageFromSdkEvent(event)).toBeNull();
   });
 
   test("extracts raw Responses usage without manufacturing a durable event", () => {


### PR DESCRIPTION
## What changed
- use one terminal-response ordinal for both response identity and same-run provider context binding
- recognize terminal responses even when provider usage is absent
- replace `last_input_tokens` with the latest usable provider count or `null`; never retain an older response count
- keep stream aggregate usage as billing/telemetry fallback only
- correct lifecycle and command-palette documentation

## Regression coverage
- missing-usage terminal clears the attempt-owned token signal
- the following valid response uses ordinal 2 and binds to request 2
- duplicate mirrored terminal events and worker restart authority remain fenced
- nullable writes remain protected by the real-Postgres turn-attempt fence

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:docs-refs`
- `bun test --timeout 30000 packages/runtime/test/runtime.test.ts apps/worker/test/agent-turn.test.ts` (350 passed)
- `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 120000 packages/db/test/session-control-plane.test.ts -t "a replaced attempt cannot compact history or overwrite its token signal"`
- full `bun run test`: relevant suites passed; one existing macOS-only failure because BSD tar does not support the release-chart test's GNU `--sort=name` option