### PR TITLE
chore(release): bump product version to 0.22.78

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.77
-appVersion: "0.22.77"
+version: 0.22.78
+appVersion: "0.22.78"


### PR DESCRIPTION
## Summary
- advance the OpenGeni product/chart identity to `0.22.78`
- keep chart `version` and `appVersion` aligned
- package the Modal snapshot-timeout propagation and legacy durable-backend recovery fixes from exact current main

## Verification
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `bun test scripts/release-version.test.ts scripts/release-candidate.test.ts`
- `bun run release:schema-contract`
- `bun run deployment:profiles`
- `bun run lint`
- `bun run format:check`
- `git diff --check`