### PR TITLE
fix(ui): preserve full mobile touch targets

### DIFF
--- a/.changeset/mobile-touch-targets.md
+++ b/.changeset/mobile-touch-targets.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/react": patch
+---
+
+Keep compact desktop controls while giving mobile model, voice, navigation,
+composer, and session controls full-size touch targets.

--- a/apps/web/src/components/analytics-consent.tsx
+++ b/apps/web/src/components/analytics-consent.tsx
@@ -11,7 +11,7 @@ import {
 import type { ClientConfig } from "@/types";
 
 const BUTTON_CLASS =
-  "inline-flex h-9 cursor-pointer items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
+  "inline-flex h-11 cursor-pointer items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
 
 export function AnalyticsManager({
   config,

--- a/apps/web/src/components/composer-mobile-plus.tsx
+++ b/apps/web/src/components/composer-mobile-plus.tsx
@@ -95,7 +95,7 @@ export function ComposerMobilePlus(props: {
           size="icon-xs"
           disabled={props.disabled}
           aria-label="More composer actions"
-          className="size-8 shrink-0 rounded-full border border-border text-fg-muted hover:text-fg sm:hidden pointer-coarse:size-9"
+          className="size-11 shrink-0 rounded-full border border-border text-fg-muted hover:text-fg sm:hidden"
         >
           <PlusIcon className="size-4" />
         </Button>

--- a/apps/web/src/components/rail/rail-shell.tsx
+++ b/apps/web/src/components/rail/rail-shell.tsx
@@ -403,7 +403,7 @@ function CanvasTopStrip({ hamburgerRef }: { hamburgerRef: RefObject<HTMLButtonEl
         context.setInspectorOpen(false);
         rail.setDrawerOpen(true);
       }}
-      className="pointer-coarse:size-11"
+      className="size-11"
     >
       <MenuIcon className="size-4" />
     </Button>

--- a/apps/web/src/components/session/subagents.tsx
+++ b/apps/web/src/components/session/subagents.tsx
@@ -126,7 +126,7 @@ function SubagentRow({
       {/* The container owns the hover wash + focus ring so the WHOLE row lights
           as one target; the Link inside covers dot→title→hint (the nav hit
           area), the chevron toggles without navigating. */}
-      <div className="group/row flex h-7 items-center gap-1.5 rounded-md pr-1.5 transition-colors hover:bg-surface-2 has-[a:focus-visible]:bg-surface-2">
+      <div className="group/row flex h-7 items-center gap-1.5 rounded-md pr-1.5 transition-colors hover:bg-surface-2 has-[a:focus-visible]:bg-surface-2 max-sm:h-11">
         {/* Lead cluster: expand chevron + child-count. Omitted entirely for
             flat fleets so the chrome agents panel stays dense. */}
         {showLead ? (
@@ -137,7 +137,7 @@ function SubagentRow({
                   type="button"
                   aria-label={open ? "Collapse" : "Expand"}
                   onClick={() => setOpen((prev) => !prev)}
-                  className="inline-flex size-4 shrink-0 items-center justify-center rounded text-fg-subtle/50 outline-none transition-colors hover:text-fg group-hover/row:text-fg-subtle focus-visible:text-fg"
+                  className="inline-flex size-4 shrink-0 items-center justify-center rounded text-fg-subtle/50 outline-none transition-colors hover:text-fg group-hover/row:text-fg-subtle focus-visible:text-fg max-sm:size-11"
                 >
                   <ChevronRightIcon
                     className={cn("size-3 transition-transform", open && "rotate-90")}
@@ -155,7 +155,7 @@ function SubagentRow({
           params={{ workspaceId, sessionId: node.session.id }}
           onClick={() => onNavigate?.()}
           title={title}
-          className="flex min-w-0 flex-1 items-center gap-2 text-xs text-fg-muted outline-none group-hover/row:text-fg"
+          className="flex h-full min-w-0 flex-1 items-center gap-2 text-xs text-fg-muted outline-none group-hover/row:text-fg"
         >
           <StatusDot tone={tone} pulse={live} className="size-1.5 shrink-0" />
           <span className="min-w-0 flex-1 truncate">{title}</span>
@@ -313,7 +313,7 @@ function BreadcrumbLink({
       params={{ workspaceId, sessionId: session.id }}
       title={label}
       dir="auto"
-      className="max-w-40 truncate outline-none transition-colors hover:text-fg focus-visible:text-fg"
+      className="inline-flex max-w-40 items-center truncate outline-none transition-colors hover:text-fg focus-visible:text-fg max-sm:min-h-11"
     >
       {label}
     </Link>

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -504,7 +504,7 @@ function SessionDock(props: {
           size="icon-sm"
           aria-label="Open navigation"
           onClick={props.onOpenNavigation}
-          className="pointer-coarse:size-10"
+          className="size-11"
         >
           <MenuIcon className="size-4" />
         </Button>

--- a/packages/react/src/components/model-policy-picker.tsx
+++ b/packages/react/src/components/model-policy-picker.tsx
@@ -573,7 +573,7 @@ export function ModelPolicyPicker(props: ModelPolicyPickerProps) {
           disabled={props.disabled}
           aria-label={messages.label}
           className={cn(
-            "og-root inline-flex h-[var(--og-model-picker-trigger-height)] min-w-0 max-w-64 items-center gap-1 rounded-full border border-transparent px-2.5 text-og-control text-og-fg-muted outline-none transition-colors hover:border-og-border hover:bg-og-surface-2 hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/40 disabled:cursor-not-allowed disabled:opacity-50 max-sm:h-[var(--og-model-picker-trigger-height-mobile)] max-sm:max-w-[7.5rem] max-sm:px-2",
+            "og-root inline-flex h-[var(--og-model-picker-trigger-height)] min-w-0 max-w-64 items-center gap-1 rounded-full border border-transparent px-2.5 text-og-control text-og-fg-muted outline-none transition-colors hover:border-og-border hover:bg-og-surface-2 hover:text-og-fg focus-visible:ring-2 focus-visible:ring-og-accent/40 disabled:cursor-not-allowed disabled:opacity-50 max-sm:h-11 max-sm:max-w-[7.5rem] max-sm:px-2",
             props.className,
           )}
         >

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -746,11 +746,11 @@ export function RealtimeVoiceControl(props: {
                 title={`Voice model: ${selectedModel.label}`}
                 disabled={props.selectionDisabled}
                 className={cn(
-                  // ≥24px wide so WCAG 2.2 target-size passes when the chevron is shown.
-                  "inline-flex h-8 w-6 items-center justify-center rounded-r-og-md outline-none",
+                  // Keep the split trigger compact on desktop while preserving a
+                  // full 44px mobile target independent of pointer-media support.
+                  "inline-flex h-11 w-11 items-center justify-center rounded-r-og-md outline-none sm:h-8 sm:w-6",
                   "transition-[background-color,border-color,color] duration-200 ease-og-out",
                   "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-og-accent/45",
-                  "pointer-coarse:h-11 pointer-coarse:w-7",
                   desktopOnlyModelMenu && "hidden sm:inline-flex",
                   voiceChevronTone(status.phase),
                 )}

--- a/packages/react/test/realtime-control.test.tsx
+++ b/packages/react/test/realtime-control.test.tsx
@@ -215,8 +215,9 @@ describe("ordinary session Codex realtime control", () => {
       'button[aria-label="Choose voice model and options"]',
     );
     expect(voiceOptions).not.toBeNull();
-    // Public default: chevron available at every breakpoint (≥24px wide).
-    expect(voiceOptions?.classList.contains("w-6")).toBe(true);
+    // Public default: 44px mobile target, compact 24px desktop split trigger.
+    expect(voiceOptions?.classList.contains("w-11")).toBe(true);
+    expect(voiceOptions?.classList.contains("sm:w-6")).toBe(true);
     expect(voiceOptions?.classList.contains("hidden")).toBe(false);
     expect(voiceOptions?.classList.contains("inline-flex")).toBe(true);
     expect(container.textContent).not.toContain("Realtime diagnostics");


### PR DESCRIPTION
## Summary

- keep compact desktop controls while giving mobile model, voice, composer, navigation, consent, and session controls full 44px targets
- make responsive sizing independent of pointer-media detection
- publish the React surface change as a patch

## Validation

- focused React and web tests: 16 passed
- full TypeScript graph: passed
- lint: passed
- formatting: passed
- public hygiene and package/web/example builds: passed
- complete local check reached one environment-only failure: macOS BSD tar does not support the release test's GNU-only `--sort=name` option; Linux CI owns that gate
