### PR TITLE
fix(deploy): keep platform monitors discoverable

### DIFF
--- a/deploy/observability/Chart.yaml
+++ b/deploy/observability/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opengeni-observability
 description: Optional self-hosted Prometheus and Grafana stack for OpenGeni.
 type: application
-version: 0.1.0
+version: 0.1.1
 dependencies:
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts

--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -111,6 +111,8 @@ It verifies:
 - the source-revision annotations match the source checkout;
 - OpenGeni `ServiceMonitor` and `PrometheusRule` resources exist with the shared
   discovery label;
+- the bundled Grafana, kube-state-metrics, and node-exporter ServiceMonitors
+  carry the same discovery label and have healthy live targets;
 - required rules are declared and loaded by the live Prometheus API;
 - Grafana is healthy and its dashboard provisioner has received the exact files.
 

--- a/deploy/observability/values.yaml
+++ b/deploy/observability/values.yaml
@@ -97,6 +97,9 @@ kube-prometheus-stack:
   grafana:
     rbac:
       namespaced: true
+    serviceMonitor:
+      labels:
+        opengeni.ai/monitoring: enabled
     resources:
       requests:
         cpu: 100m
@@ -131,6 +134,10 @@ kube-prometheus-stack:
         resource: configmap
 
   kube-state-metrics:
+    prometheus:
+      monitor:
+        additionalLabels:
+          opengeni.ai/monitoring: enabled
     resources:
       requests:
         cpu: 50m
@@ -140,6 +147,10 @@ kube-prometheus-stack:
         memory: 256Mi
 
   prometheus-node-exporter:
+    prometheus:
+      monitor:
+        additionalLabels:
+          opengeni.ai/monitoring: enabled
     resources:
       requests:
         cpu: 50m

--- a/scripts/check-observability-render.ts
+++ b/scripts/check-observability-render.ts
@@ -74,6 +74,21 @@ for (const selectorName of ["serviceMonitorNamespaceSelector", "ruleNamespaceSel
   );
 }
 
+for (const applicationName of ["grafana", "kube-state-metrics", "prometheus-node-exporter"]) {
+  const serviceMonitor = exactlyOne(
+    resources.filter(
+      (resource) =>
+        resource.kind === "ServiceMonitor" &&
+        resource.metadata?.labels?.["app.kubernetes.io/name"] === applicationName,
+    ),
+    `${applicationName} ServiceMonitor`,
+  );
+  assert(
+    serviceMonitor.metadata?.labels?.["opengeni.ai/monitoring"] === "enabled",
+    `${applicationName} ServiceMonitor must carry opengeni.ai/monitoring=enabled`,
+  );
+}
+
 const dashboardsDirectory = "deploy/observability/dashboards";
 const dashboardFiles = readdirSync(dashboardsDirectory)
   .filter((name) => name.endsWith(".json"))

--- a/scripts/deployment-observability.test.ts
+++ b/scripts/deployment-observability.test.ts
@@ -1,8 +1,26 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 
 import { observabilityStackPlanFor } from "./deployment-observability";
 
 describe("observability deployment plan", () => {
+  test("keeps every bundled platform ServiceMonitor inside canonical discovery", () => {
+    const values = Bun.YAML.parse(readFileSync("deploy/observability/values.yaml", "utf8"));
+
+    expect(
+      values["kube-prometheus-stack"].grafana.serviceMonitor.labels["opengeni.ai/monitoring"],
+    ).toBe("enabled");
+    expect(
+      values["kube-prometheus-stack"]["kube-state-metrics"].prometheus.monitor.additionalLabels[
+        "opengeni.ai/monitoring"
+      ],
+    ).toBe("enabled");
+    expect(
+      values["kube-prometheus-stack"]["prometheus-node-exporter"].prometheus.monitor
+        .additionalLabels["opengeni.ai/monitoring"],
+    ).toBe("enabled");
+  });
+
   test("renders a pinned, ordered production plan", () => {
     const plan = observabilityStackPlanFor({
       profile: "production",
@@ -10,7 +28,7 @@ describe("observability deployment plan", () => {
     });
 
     expect(plan.chartPath).toBe("deploy/observability");
-    expect(plan.chartVersion).toBe("0.1.0");
+    expect(plan.chartVersion).toBe("0.1.1");
     expect(plan.kubePrometheusStackVersion).toBe("87.16.1");
     expect(plan.valuesFiles).toEqual(["deploy/observability/values.production.example.yaml"]);
     expect(plan.installCommands.slice(0, 2)).toEqual([

--- a/scripts/deployment-observability.ts
+++ b/scripts/deployment-observability.ts
@@ -17,7 +17,7 @@ export interface ObservabilityStackPlan {
   appReleaseName: string;
   environment: string;
   chartPath: "deploy/observability";
-  chartVersion: "0.1.0";
+  chartVersion: "0.1.1";
   kubePrometheusStackVersion: "87.16.1";
   valuesFiles: string[];
   applicationValuesFile: "deploy/observability/opengeni.values.example.yaml";
@@ -102,7 +102,7 @@ export function observabilityStackPlanFor(
     appReleaseName,
     environment,
     chartPath: "deploy/observability",
-    chartVersion: "0.1.0",
+    chartVersion: "0.1.1",
     kubePrometheusStackVersion: "87.16.1",
     valuesFiles,
     applicationValuesFile: "deploy/observability/opengeni.values.example.yaml",

--- a/scripts/verify-observability-stack.ts
+++ b/scripts/verify-observability-stack.ts
@@ -47,11 +47,16 @@ const requiredRules = [
 
 const args = parseArgs(process.argv.slice(2));
 const sourceRevision = args.sourceRevision ?? process.env.OPENGENI_SOURCE_REVISION ?? gitHead();
+const chartDefinition = Bun.YAML.parse(
+  await Bun.file("deploy/observability/Chart.yaml").text(),
+) as { name?: string; version?: string };
+assert(chartDefinition.name, "observability Chart.yaml has no name");
+assert(chartDefinition.version, "observability Chart.yaml has no version");
 
 const release = helmRelease(args.namespace, args.releaseName);
 assert(release.status === "deployed", `Helm release is ${release.status}, not deployed`);
 assert(
-  release.chart === "opengeni-observability-0.1.0",
+  release.chart === `${chartDefinition.name}-${chartDefinition.version}`,
   `unexpected observability chart: ${release.chart}`,
 );
 assertMonitoringNamespace(args.namespace);
@@ -107,7 +112,7 @@ for (const configMap of configMaps) {
   );
 }
 
-const serviceMonitors = kubectlJson<KubernetesList<{ metadata: KubernetesMetadata }>>([
+const applicationServiceMonitors = kubectlJson<KubernetesList<{ metadata: KubernetesMetadata }>>([
   "-n",
   args.appNamespace,
   "get",
@@ -117,7 +122,34 @@ const serviceMonitors = kubectlJson<KubernetesList<{ metadata: KubernetesMetadat
   "-o",
   "json",
 ]).items;
-assert(serviceMonitors.length > 0, "no OpenGeni ServiceMonitor resources were found");
+assert(applicationServiceMonitors.length > 0, "no OpenGeni ServiceMonitor resources were found");
+
+const platformServiceMonitors = kubectlJson<KubernetesList<{ metadata: KubernetesMetadata }>>([
+  "-n",
+  args.namespace,
+  "get",
+  "servicemonitors.monitoring.coreos.com",
+  "-l",
+  monitoringSelector,
+  "-o",
+  "json",
+]).items;
+const requiredPlatformApplicationNames = [
+  "grafana",
+  "kube-state-metrics",
+  "prometheus-node-exporter",
+] as const;
+const requiredPlatformServiceMonitors = requiredPlatformApplicationNames.map((applicationName) => {
+  const matches = platformServiceMonitors.filter(
+    (serviceMonitor) =>
+      serviceMonitor.metadata.labels?.["app.kubernetes.io/name"] === applicationName,
+  );
+  assert(
+    matches.length === 1,
+    `expected one selected ${applicationName} ServiceMonitor, found ${matches.length}`,
+  );
+  return matches[0] as { metadata: KubernetesMetadata };
+});
 
 const prometheusRules = kubectlJson<
   KubernetesList<{
@@ -184,8 +216,11 @@ if (!args.skipLiveApis) {
       };
     }>(`${baseUrl}/api/v1/targets?state=active`);
     assert(targets.status === "success", "Prometheus targets API did not return success");
-    for (const serviceMonitor of serviceMonitors) {
-      const poolPrefix = `serviceMonitor/${args.appNamespace}/${serviceMonitor.metadata.name}/`;
+    for (const [namespace, serviceMonitor] of [
+      ...applicationServiceMonitors.map((item) => [args.appNamespace, item] as const),
+      ...requiredPlatformServiceMonitors.map((item) => [args.namespace, item] as const),
+    ]) {
+      const poolPrefix = `serviceMonitor/${namespace}/${serviceMonitor.metadata.name}/`;
       const matches = (targets.data?.activeTargets ?? []).filter((target) =>
         target.scrapePool?.startsWith(poolPrefix),
       );
@@ -231,7 +266,10 @@ console.log(
       release: `${args.namespace}/${args.releaseName}`,
       sourceRevision,
       dashboards: [...expectedDashboards.keys()].sort(),
-      serviceMonitors: serviceMonitors.map((item) => item.metadata.name).sort(),
+      serviceMonitors: applicationServiceMonitors.map((item) => item.metadata.name).sort(),
+      platformServiceMonitors: requiredPlatformServiceMonitors
+        .map((item) => item.metadata.name)
+        .sort(),
       prometheusRules: prometheusRules.map((item) => item.metadata.name).sort(),
       liveApisVerified: !args.skipLiveApis,
     },


### PR DESCRIPTION
## Summary
- label the Grafana, kube-state-metrics, and node-exporter ServiceMonitors with the canonical OpenGeni monitoring selector
- extend render and deployment tests so nested chart monitor labels cannot silently regress
- make the live verifier discover and require the selected platform monitors and targets
- bump the observability wrapper chart to 0.1.1

## Validation
- `helm lint deploy/observability`
- single-replica and production-shaped `helm template` output passed `scripts/check-observability-render.ts`
- `bun test scripts/deployment-observability.test.ts`
- `bun run typecheck` (23 projects clean)
- `bun run check:docs-refs`
- full repository suite before the unrelated release/main rebase: 6,214 passed, 6 skipped, 0 failed (33,987 assertions across 576 files)
