### PR TITLE
fix(mcp): bound scheduled-task receipt projections

### DIFF
--- a/.changeset/tidy-mcp-receipts.md
+++ b/.changeset/tidy-mcp-receipts.md
@@ -1,0 +1,11 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/contracts": patch
+"@opengeni/core": patch
+"@opengeni/db": patch
+"@opengeni/react": patch
+---
+
+Replace first-party MCP mutation entity echoes with strict, versioned compact
+receipts; add bounded scheduled-task list/detail projections and preserve worker
+session references across receipt and legacy timeline results.

--- a/apps/api/src/mcp/documents.ts
+++ b/apps/api/src/mcp/documents.ts
@@ -9,6 +9,7 @@ import {
 import { createKnowledgeMemory, listKnowledgeMemories, type Database } from "@opengeni/db";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
+import { mcpMutationReceipt } from "./receipts";
 
 const SearchInputSchema = {
   query: z.string().min(1),
@@ -192,31 +193,47 @@ export function buildDocumentsMcpServer(
         metadata: z.record(z.string(), z.unknown()).optional(),
       },
     },
-    async ({ text, kind, scope, sourceRefs, confidence, metadata }) => ({
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(
-            await createKnowledgeMemory(db, {
-              accountId,
-              workspaceId,
-              status: "proposed",
-              kind: kind ?? "semantic",
-              scope: scope ?? "workspace",
-              text,
-              sourceRefs:
-                sourceRefs?.map((sourceRef) => ({
-                  ...sourceRef,
-                  metadata: sourceRef.metadata ?? {},
-                })) ?? [],
-              confidence: confidence ?? 0.5,
-              metadata: metadata ?? {},
-              createdBySessionId: options.createdBySessionId,
-            }),
-          ),
-        },
-      ],
-    }),
+    async ({ text, kind, scope, sourceRefs, confidence, metadata }) => {
+      const memory = await createKnowledgeMemory(db, {
+        accountId,
+        workspaceId,
+        status: "proposed",
+        kind: kind ?? "semantic",
+        scope: scope ?? "workspace",
+        text,
+        sourceRefs:
+          sourceRefs?.map((sourceRef) => ({
+            ...sourceRef,
+            metadata: sourceRef.metadata ?? {},
+          })) ?? [],
+        confidence: confidence ?? 0.5,
+        metadata: metadata ?? {},
+        createdBySessionId: options.createdBySessionId,
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              mcpMutationReceipt({
+                operation: "memory_propose",
+                committed: true,
+                outcome: "created",
+                changed: true,
+                resource: {
+                  type: "knowledge_memory",
+                  id: memory.id,
+                  state: memory.status,
+                },
+                timestamp: memory.updatedAt,
+                idempotency: { status: "not_supported" },
+                nextAction: { tool: "memory_search", arguments: {} },
+              }),
+            ),
+          },
+        ],
+      };
+    },
   );
 
   return server;

--- a/apps/api/src/mcp/receipts.ts
+++ b/apps/api/src/mcp/receipts.ts
@@ -33,6 +33,9 @@ export type SessionCreateReceiptResult = {
     status: string;
     sandboxGroupId: string;
     parentSessionId: string | null;
+    rootSessionId: string;
+    nestedAgentDepth: number;
+    effectiveMaxNestedAgentDepth: number;
   };
   outcome: "created" | "repaired" | "replayed";
   changed: boolean;
@@ -80,6 +83,10 @@ export function sessionCreateMutationReceipt(
       parentSessionId: result.session.parentSessionId,
       sessionCreateOutcome: result.outcome,
     },
+    id: result.session.id,
+    rootSessionId: result.session.rootSessionId,
+    nestedAgentDepth: result.session.nestedAgentDepth,
+    effectiveMaxNestedAgentDepth: result.session.effectiveMaxNestedAgentDepth,
     nextAction: {
       tool: "session_get",
       arguments: { sessionId: result.session.id },

--- a/apps/api/src/mcp/receipts.ts
+++ b/apps/api/src/mcp/receipts.ts
@@ -25,3 +25,64 @@ export function mcpMutationReceipt(input: McpMutationReceiptInput): McpMutationR
     warnings: input.warnings ?? [],
   });
 }
+
+export type SessionCreateReceiptResult = {
+  session: {
+    id: string;
+    queueVersion: number;
+    status: string;
+    sandboxGroupId: string;
+    parentSessionId: string | null;
+  };
+  outcome: "created" | "repaired" | "replayed";
+  changed: boolean;
+  usageRecording: "recorded" | "failed";
+};
+
+/** Project committed session-create truth without copying request fields. */
+export function sessionCreateMutationReceipt(
+  result: SessionCreateReceiptResult,
+  idempotencyKeyRequested: boolean,
+): McpMutationReceiptType {
+  const usageRecordingFailed = result.usageRecording === "failed";
+  const retryable = usageRecordingFailed && idempotencyKeyRequested;
+  return mcpMutationReceipt({
+    operation: "session_create",
+    committed: true,
+    outcome: usageRecordingFailed ? "partial_failure" : result.outcome,
+    changed: result.changed,
+    resource: {
+      type: "session",
+      id: result.session.id,
+      version: result.session.queueVersion,
+      state: result.session.status,
+    },
+    idempotency: {
+      status:
+        result.outcome === "replayed"
+          ? "replayed"
+          : idempotencyKeyRequested
+            ? "applied"
+            : "not_requested",
+    },
+    ...(usageRecordingFailed
+      ? {
+          partialFailure: { stage: "usage_recording", retryable },
+          warnings: [
+            retryable
+              ? "The session committed, but usage recording failed. Retry only with the same idempotency key."
+              : "The session committed, but usage recording failed. Do not retry this keyless request; inspect the returned session.",
+          ],
+        }
+      : {}),
+    facts: {
+      sandboxGroupId: result.session.sandboxGroupId,
+      parentSessionId: result.session.parentSessionId,
+      sessionCreateOutcome: result.outcome,
+    },
+    nextAction: {
+      tool: "session_get",
+      arguments: { sessionId: result.session.id },
+    },
+  });
+}

--- a/apps/api/src/mcp/receipts.ts
+++ b/apps/api/src/mcp/receipts.ts
@@ -1,0 +1,27 @@
+import {
+  MCP_MUTATION_RECEIPT_VERSION,
+  McpMutationReceipt,
+  type McpMutationReceiptType,
+} from "@opengeni/contracts";
+
+export type McpMutationReceiptInput = Omit<
+  McpMutationReceiptType,
+  "receiptVersion" | "timestamp" | "warnings"
+> & {
+  timestamp?: string;
+  warnings?: string[];
+};
+
+/**
+ * Build and validate a compact first-party MCP mutation receipt at the API
+ * boundary. Contract parsing is intentional: it prevents a handler from
+ * accidentally adding an unbounded entity or a copy of request fields.
+ */
+export function mcpMutationReceipt(input: McpMutationReceiptInput): McpMutationReceiptType {
+  return McpMutationReceipt.parse({
+    receiptVersion: MCP_MUTATION_RECEIPT_VERSION,
+    ...input,
+    timestamp: input.timestamp ?? new Date().toISOString(),
+    warnings: input.warnings ?? [],
+  });
+}

--- a/apps/api/src/mcp/scheduled-task-view.ts
+++ b/apps/api/src/mcp/scheduled-task-view.ts
@@ -1,0 +1,258 @@
+import type { ResourceRef, ScheduledTask, ToolRef } from "@opengeni/contracts";
+
+export const SCHEDULED_TASK_MCP_MAX_BYTES = 64 * 1024;
+export const SCHEDULED_TASK_NAME_MAX_BYTES = 512;
+export const SCHEDULED_TASK_PROMPT_MAX_BYTES = 8 * 1024;
+const SCHEDULED_TASK_GOAL_FIELD_MAX_BYTES = 2 * 1024;
+const SCHEDULED_TASK_IDENTITY_PREVIEW_LIMIT = 20;
+
+type Utf8Projection = {
+  value: string;
+  originalBytes: number;
+  deliveredBytes: number;
+  truncated: boolean;
+};
+
+function utf8Prefix(value: string, maxBytes: number): string {
+  let index = 0;
+  let bytes = 0;
+  while (index < value.length) {
+    const codePoint = value.codePointAt(index)!;
+    const character = String.fromCodePoint(codePoint);
+    const characterBytes = Buffer.byteLength(character, "utf8");
+    if (bytes + characterBytes > maxBytes) break;
+    bytes += characterBytes;
+    index += character.length;
+  }
+  return value.slice(0, index);
+}
+
+export function projectScheduledTaskUtf8(value: string, maxBytes: number): Utf8Projection {
+  const originalBytes = Buffer.byteLength(value, "utf8");
+  if (originalBytes <= maxBytes) {
+    return { value, originalBytes, deliveredBytes: originalBytes, truncated: false };
+  }
+  let marker = "";
+  let prefix = "";
+  let omittedBytes = originalBytes;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    marker = `…[${omittedBytes} UTF-8 bytes omitted]`;
+    prefix = utf8Prefix(value, Math.max(0, maxBytes - Buffer.byteLength(marker, "utf8")));
+    const nextOmitted = originalBytes - Buffer.byteLength(prefix, "utf8");
+    if (nextOmitted === omittedBytes) break;
+    omittedBytes = nextOmitted;
+  }
+  const projected = `${prefix}${marker}`;
+  return {
+    value: projected,
+    originalBytes,
+    deliveredBytes: Buffer.byteLength(projected, "utf8"),
+    truncated: true,
+  };
+}
+
+function jsonBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+function mcpJsonBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value, null, 2), "utf8");
+}
+
+function resourceIdentity(resource: ResourceRef): Record<string, unknown> {
+  if (resource.kind === "repository") {
+    return {
+      kind: resource.kind,
+      uri: projectScheduledTaskUtf8(resource.uri, 512).value,
+      ...(resource.ref ? { ref: projectScheduledTaskUtf8(resource.ref, 256).value } : {}),
+    };
+  }
+  return { kind: resource.kind, fileId: resource.fileId };
+}
+
+function toolIdentity(tool: ToolRef): Record<string, unknown> {
+  return {
+    kind: tool.kind,
+    id: projectScheduledTaskUtf8(tool.id, 256).value,
+    ...(tool.optional !== undefined ? { optional: tool.optional } : {}),
+  };
+}
+
+export function scheduledTaskMcpSummary(task: ScheduledTask) {
+  const name = projectScheduledTaskUtf8(task.name, SCHEDULED_TASK_NAME_MAX_BYTES);
+  return {
+    id: task.id,
+    name: name.value,
+    status: task.status,
+    schedule: task.schedule,
+    runMode: task.runMode,
+    overlapPolicy: task.overlapPolicy,
+    reusableSessionId: task.reusableSessionId,
+    variableSetId: task.variableSetId,
+    rigId: task.rigId,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+    configuration: {
+      model: task.agentConfig.model ?? null,
+      reasoningEffort: task.agentConfig.reasoningEffort ?? null,
+      sandboxBackend: task.agentConfig.sandboxBackend ?? null,
+      hasGoal: task.agentConfig.goal !== undefined,
+      promptBytes: Buffer.byteLength(task.agentConfig.prompt, "utf8"),
+      resourceCount: task.agentConfig.resources.length,
+      toolCount: task.agentConfig.tools.length,
+      metadataKeyCount: Object.keys(task.agentConfig.metadata).length,
+      taskMetadataKeyCount: Object.keys(task.metadata).length,
+    },
+    projection: {
+      name: {
+        originalBytes: name.originalBytes,
+        deliveredBytes: name.deliveredBytes,
+        truncated: name.truncated,
+      },
+    },
+  };
+}
+
+export function boundScheduledTaskDetailMcp(task: ScheduledTask) {
+  const prompt = projectScheduledTaskUtf8(task.agentConfig.prompt, SCHEDULED_TASK_PROMPT_MAX_BYTES);
+  const goalText = task.agentConfig.goal
+    ? projectScheduledTaskUtf8(task.agentConfig.goal.text, SCHEDULED_TASK_GOAL_FIELD_MAX_BYTES)
+    : null;
+  const goalCriteria = task.agentConfig.goal?.successCriteria
+    ? projectScheduledTaskUtf8(
+        task.agentConfig.goal.successCriteria,
+        SCHEDULED_TASK_GOAL_FIELD_MAX_BYTES,
+      )
+    : null;
+  const resources = task.agentConfig.resources
+    .slice(0, SCHEDULED_TASK_IDENTITY_PREVIEW_LIMIT)
+    .map(resourceIdentity);
+  const tools = task.agentConfig.tools
+    .slice(0, SCHEDULED_TASK_IDENTITY_PREVIEW_LIMIT)
+    .map(toolIdentity);
+  const metadataKeys = Object.keys(task.agentConfig.metadata)
+    .sort()
+    .slice(0, SCHEDULED_TASK_IDENTITY_PREVIEW_LIMIT)
+    .map((key) => projectScheduledTaskUtf8(key, 256).value);
+  const taskMetadataKeys = Object.keys(task.metadata)
+    .sort()
+    .slice(0, SCHEDULED_TASK_IDENTITY_PREVIEW_LIMIT)
+    .map((key) => projectScheduledTaskUtf8(key, 256).value);
+
+  const result = {
+    ...scheduledTaskMcpSummary(task),
+    entity: {
+      agentConfig: {
+        prompt: prompt.value,
+        resources,
+        tools,
+        metadataKeys,
+        model: task.agentConfig.model ?? null,
+        reasoningEffort: task.agentConfig.reasoningEffort ?? null,
+        sandboxBackend: task.agentConfig.sandboxBackend ?? null,
+        goal: goalText
+          ? {
+              text: goalText.value,
+              successCriteria: goalCriteria?.value ?? null,
+              maxAutoContinuations: task.agentConfig.goal?.maxAutoContinuations ?? null,
+            }
+          : null,
+      },
+      taskMetadataKeys,
+    },
+    detailProjection: {
+      bounded: true,
+      fullEntityAvailableViaRest: true,
+      prompt: {
+        originalBytes: prompt.originalBytes,
+        deliveredBytes: prompt.deliveredBytes,
+        truncated: prompt.truncated,
+      },
+      goalText: goalText
+        ? {
+            originalBytes: goalText.originalBytes,
+            deliveredBytes: goalText.deliveredBytes,
+            truncated: goalText.truncated,
+          }
+        : null,
+      goalSuccessCriteria: goalCriteria
+        ? {
+            originalBytes: goalCriteria.originalBytes,
+            deliveredBytes: goalCriteria.deliveredBytes,
+            truncated: goalCriteria.truncated,
+          }
+        : null,
+      resources: {
+        originalCount: task.agentConfig.resources.length,
+        deliveredCount: resources.length,
+        originalBytes: jsonBytes(task.agentConfig.resources),
+      },
+      tools: {
+        originalCount: task.agentConfig.tools.length,
+        deliveredCount: tools.length,
+        originalBytes: jsonBytes(task.agentConfig.tools),
+      },
+      metadata: {
+        originalKeyCount: Object.keys(task.agentConfig.metadata).length,
+        deliveredKeyCount: metadataKeys.length,
+        originalBytes: jsonBytes(task.agentConfig.metadata),
+        valuesIncluded: false,
+      },
+      taskMetadata: {
+        originalKeyCount: Object.keys(task.metadata).length,
+        deliveredKeyCount: taskMetadataKeys.length,
+        originalBytes: jsonBytes(task.metadata),
+        valuesIncluded: false,
+      },
+    },
+  };
+  if (mcpJsonBytes(result) > SCHEDULED_TASK_MCP_MAX_BYTES) {
+    throw new RangeError(
+      `Scheduled-task detail projection exceeds ${SCHEDULED_TASK_MCP_MAX_BYTES} bytes`,
+    );
+  }
+  return result;
+}
+
+export function boundScheduledTaskMcpPage(input: {
+  tasks: ScheduledTask[];
+  limit: number;
+  offset: number;
+  sourceHasMore: boolean;
+}) {
+  let summaries = input.tasks.map(scheduledTaskMcpSummary);
+  let modelRowsDropped = false;
+  const build = () => ({
+    tasks: summaries,
+    page: {
+      limit: input.limit,
+      offset: input.offset,
+      hasMore: input.sourceHasMore || modelRowsDropped,
+      nextOffset: input.sourceHasMore || modelRowsDropped ? input.offset + summaries.length : null,
+    },
+    projection: {
+      bounded: true,
+      rowsDroppedForBytes: modelRowsDropped,
+      bytes: 0,
+      maxBytes: SCHEDULED_TASK_MCP_MAX_BYTES,
+    },
+  });
+  let page = build();
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    page.projection.bytes = mcpJsonBytes(page);
+  }
+  while (page.projection.bytes > SCHEDULED_TASK_MCP_MAX_BYTES && summaries.length > 0) {
+    summaries = summaries.slice(0, -1);
+    modelRowsDropped = true;
+    page = build();
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      page.projection.bytes = mcpJsonBytes(page);
+    }
+  }
+  if (page.projection.bytes > SCHEDULED_TASK_MCP_MAX_BYTES) {
+    throw new RangeError(
+      `Scheduled-task list metadata exceeds ${SCHEDULED_TASK_MCP_MAX_BYTES} bytes`,
+    );
+  }
+  return page;
+}

--- a/apps/api/src/mcp/scheduled-task-view.ts
+++ b/apps/api/src/mcp/scheduled-task-view.ts
@@ -1,9 +1,17 @@
-import type { ResourceRef, ScheduledTask, ToolRef } from "@opengeni/contracts";
+import type {
+  ResourceRef,
+  ScheduledTask,
+  ScheduledTaskScheduleSpec,
+  ToolRef,
+} from "@opengeni/contracts";
 
 export const SCHEDULED_TASK_MCP_MAX_BYTES = 64 * 1024;
 export const SCHEDULED_TASK_NAME_MAX_BYTES = 512;
 export const SCHEDULED_TASK_PROMPT_MAX_BYTES = 8 * 1024;
+export const SCHEDULED_TASK_SCHEDULE_FIELD_MAX_BYTES = 256;
 const SCHEDULED_TASK_GOAL_FIELD_MAX_BYTES = 2 * 1024;
+const SCHEDULED_TASK_MODEL_MAX_BYTES = 512;
+const SCHEDULED_TASK_TIMESTAMP_MAX_BYTES = 128;
 const SCHEDULED_TASK_IDENTITY_PREVIEW_LIMIT = 20;
 
 type Utf8Projection = {
@@ -12,6 +20,100 @@ type Utf8Projection = {
   deliveredBytes: number;
   truncated: boolean;
 };
+
+export type ScheduledTaskUtf8ProjectionFact = Omit<Utf8Projection, "value">;
+
+type ScheduledTaskScheduleProjection =
+  | {
+      schedule: Extract<ScheduledTaskScheduleSpec, { type: "once" }>;
+      projection: {
+        type: "once";
+        truncated: boolean;
+        fields: {
+          runAt: ScheduledTaskUtf8ProjectionFact;
+          timeZone: ScheduledTaskUtf8ProjectionFact;
+        };
+      };
+    }
+  | {
+      schedule: Extract<ScheduledTaskScheduleSpec, { type: "interval" }>;
+      projection: {
+        type: "interval";
+        truncated: boolean;
+        fields: {
+          startAt: ScheduledTaskUtf8ProjectionFact | null;
+          endAt: ScheduledTaskUtf8ProjectionFact | null;
+        };
+      };
+    }
+  | {
+      schedule: Extract<ScheduledTaskScheduleSpec, { type: "calendar" }>;
+      projection: {
+        type: "calendar";
+        truncated: boolean;
+        fields: {
+          timeZone: ScheduledTaskUtf8ProjectionFact;
+        };
+      };
+    };
+
+type DetailBudget = {
+  promptBytes: number;
+  goalFieldBytes: number;
+  identityPreviewLimit: number;
+  resourceUriBytes: number;
+  resourceRefBytes: number;
+  toolIdBytes: number;
+  metadataKeyBytes: number;
+};
+
+const DETAIL_BUDGETS: readonly DetailBudget[] = [
+  {
+    promptBytes: SCHEDULED_TASK_PROMPT_MAX_BYTES,
+    goalFieldBytes: SCHEDULED_TASK_GOAL_FIELD_MAX_BYTES,
+    identityPreviewLimit: SCHEDULED_TASK_IDENTITY_PREVIEW_LIMIT,
+    resourceUriBytes: 512,
+    resourceRefBytes: 256,
+    toolIdBytes: 256,
+    metadataKeyBytes: 256,
+  },
+  {
+    promptBytes: 4 * 1024,
+    goalFieldBytes: 1024,
+    identityPreviewLimit: 10,
+    resourceUriBytes: 256,
+    resourceRefBytes: 128,
+    toolIdBytes: 128,
+    metadataKeyBytes: 128,
+  },
+  {
+    promptBytes: 2 * 1024,
+    goalFieldBytes: 512,
+    identityPreviewLimit: 5,
+    resourceUriBytes: 128,
+    resourceRefBytes: 96,
+    toolIdBytes: 96,
+    metadataKeyBytes: 96,
+  },
+  {
+    promptBytes: 1024,
+    goalFieldBytes: 256,
+    identityPreviewLimit: 2,
+    resourceUriBytes: 96,
+    resourceRefBytes: 64,
+    toolIdBytes: 64,
+    metadataKeyBytes: 64,
+  },
+  {
+    promptBytes: 512,
+    goalFieldBytes: 128,
+    identityPreviewLimit: 0,
+    resourceUriBytes: 64,
+    resourceRefBytes: 64,
+    toolIdBytes: 64,
+    metadataKeyBytes: 64,
+  },
+];
 
 function utf8Prefix(value: string, maxBytes: number): string {
   let index = 0;
@@ -28,8 +130,9 @@ function utf8Prefix(value: string, maxBytes: number): string {
 }
 
 export function projectScheduledTaskUtf8(value: string, maxBytes: number): Utf8Projection {
+  const byteLimit = Math.max(0, Math.floor(maxBytes));
   const originalBytes = Buffer.byteLength(value, "utf8");
-  if (originalBytes <= maxBytes) {
+  if (originalBytes <= byteLimit) {
     return { value, originalBytes, deliveredBytes: originalBytes, truncated: false };
   }
   let marker = "";
@@ -37,7 +140,12 @@ export function projectScheduledTaskUtf8(value: string, maxBytes: number): Utf8P
   let omittedBytes = originalBytes;
   for (let attempt = 0; attempt < 4; attempt += 1) {
     marker = `…[${omittedBytes} UTF-8 bytes omitted]`;
-    prefix = utf8Prefix(value, Math.max(0, maxBytes - Buffer.byteLength(marker, "utf8")));
+    if (Buffer.byteLength(marker, "utf8") > byteLimit) {
+      marker = utf8Prefix(marker, byteLimit);
+      prefix = "";
+      break;
+    }
+    prefix = utf8Prefix(value, byteLimit - Buffer.byteLength(marker, "utf8"));
     const nextOmitted = originalBytes - Buffer.byteLength(prefix, "utf8");
     if (nextOmitted === omittedBytes) break;
     omittedBytes = nextOmitted;
@@ -51,6 +159,83 @@ export function projectScheduledTaskUtf8(value: string, maxBytes: number): Utf8P
   };
 }
 
+function projectionFact(projection: Utf8Projection): ScheduledTaskUtf8ProjectionFact {
+  return {
+    originalBytes: projection.originalBytes,
+    deliveredBytes: projection.deliveredBytes,
+    truncated: projection.truncated,
+  };
+}
+
+export function projectScheduledTaskSchedule(
+  schedule: ScheduledTaskScheduleSpec,
+): ScheduledTaskScheduleProjection {
+  switch (schedule.type) {
+    case "once": {
+      const runAt = projectScheduledTaskUtf8(
+        schedule.runAt,
+        SCHEDULED_TASK_SCHEDULE_FIELD_MAX_BYTES,
+      );
+      const timeZone = projectScheduledTaskUtf8(
+        schedule.timeZone,
+        SCHEDULED_TASK_SCHEDULE_FIELD_MAX_BYTES,
+      );
+      return {
+        schedule: { type: "once", runAt: runAt.value, timeZone: timeZone.value },
+        projection: {
+          type: "once",
+          truncated: runAt.truncated || timeZone.truncated,
+          fields: { runAt: projectionFact(runAt), timeZone: projectionFact(timeZone) },
+        },
+      };
+    }
+    case "interval": {
+      const startAt = schedule.startAt
+        ? projectScheduledTaskUtf8(schedule.startAt, SCHEDULED_TASK_SCHEDULE_FIELD_MAX_BYTES)
+        : null;
+      const endAt = schedule.endAt
+        ? projectScheduledTaskUtf8(schedule.endAt, SCHEDULED_TASK_SCHEDULE_FIELD_MAX_BYTES)
+        : null;
+      return {
+        schedule: {
+          type: "interval",
+          everySeconds: schedule.everySeconds,
+          ...(startAt ? { startAt: startAt.value } : {}),
+          ...(endAt ? { endAt: endAt.value } : {}),
+        },
+        projection: {
+          type: "interval",
+          truncated: Boolean(startAt?.truncated || endAt?.truncated),
+          fields: {
+            startAt: startAt ? projectionFact(startAt) : null,
+            endAt: endAt ? projectionFact(endAt) : null,
+          },
+        },
+      };
+    }
+    case "calendar": {
+      const timeZone = projectScheduledTaskUtf8(
+        schedule.timeZone,
+        SCHEDULED_TASK_SCHEDULE_FIELD_MAX_BYTES,
+      );
+      return {
+        schedule: {
+          type: "calendar",
+          timeZone: timeZone.value,
+          hour: schedule.hour,
+          minute: schedule.minute,
+          ...(schedule.daysOfWeek ? { daysOfWeek: schedule.daysOfWeek } : {}),
+        },
+        projection: {
+          type: "calendar",
+          truncated: timeZone.truncated,
+          fields: { timeZone: projectionFact(timeZone) },
+        },
+      };
+    }
+  }
+}
+
 function jsonBytes(value: unknown): number {
   return Buffer.byteLength(JSON.stringify(value), "utf8");
 }
@@ -59,41 +244,77 @@ function mcpJsonBytes(value: unknown): number {
   return Buffer.byteLength(JSON.stringify(value, null, 2), "utf8");
 }
 
-function resourceIdentity(resource: ResourceRef): Record<string, unknown> {
-  if (resource.kind === "repository") {
-    return {
-      kind: resource.kind,
-      uri: projectScheduledTaskUtf8(resource.uri, 512).value,
-      ...(resource.ref ? { ref: projectScheduledTaskUtf8(resource.ref, 256).value } : {}),
-    };
+function settleMeasuredBytes(
+  value: unknown,
+  read: () => number,
+  write: (bytes: number) => void,
+): number {
+  for (let attempt = 0; attempt < 16; attempt += 1) {
+    const bytes = mcpJsonBytes(value);
+    if (bytes === read()) return bytes;
+    write(bytes);
   }
-  return { kind: resource.kind, fileId: resource.fileId };
+  return mcpJsonBytes(value);
 }
 
-function toolIdentity(tool: ToolRef): Record<string, unknown> {
+function resourceIdentity(
+  resource: ResourceRef,
+  budget: DetailBudget,
+): { value: Record<string, unknown>; truncatedFieldCount: number } {
+  if (resource.kind === "repository") {
+    const uri = projectScheduledTaskUtf8(resource.uri, budget.resourceUriBytes);
+    const ref = resource.ref
+      ? projectScheduledTaskUtf8(resource.ref, budget.resourceRefBytes)
+      : null;
+    return {
+      value: {
+        kind: resource.kind,
+        uri: uri.value,
+        ...(ref ? { ref: ref.value } : {}),
+      },
+      truncatedFieldCount: Number(uri.truncated) + Number(ref?.truncated ?? false),
+    };
+  }
+  return { value: { kind: resource.kind, fileId: resource.fileId }, truncatedFieldCount: 0 };
+}
+
+function toolIdentity(
+  tool: ToolRef,
+  budget: DetailBudget,
+): { value: Record<string, unknown>; truncatedFieldCount: number } {
+  const id = projectScheduledTaskUtf8(tool.id, budget.toolIdBytes);
   return {
-    kind: tool.kind,
-    id: projectScheduledTaskUtf8(tool.id, 256).value,
-    ...(tool.optional !== undefined ? { optional: tool.optional } : {}),
+    value: {
+      kind: tool.kind,
+      id: id.value,
+      ...(tool.optional !== undefined ? { optional: tool.optional } : {}),
+    },
+    truncatedFieldCount: Number(id.truncated),
   };
 }
 
 export function scheduledTaskMcpSummary(task: ScheduledTask) {
   const name = projectScheduledTaskUtf8(task.name, SCHEDULED_TASK_NAME_MAX_BYTES);
-  return {
+  const schedule = projectScheduledTaskSchedule(task.schedule);
+  const model = task.agentConfig.model
+    ? projectScheduledTaskUtf8(task.agentConfig.model, SCHEDULED_TASK_MODEL_MAX_BYTES)
+    : null;
+  const createdAt = projectScheduledTaskUtf8(task.createdAt, SCHEDULED_TASK_TIMESTAMP_MAX_BYTES);
+  const updatedAt = projectScheduledTaskUtf8(task.updatedAt, SCHEDULED_TASK_TIMESTAMP_MAX_BYTES);
+  const result = {
     id: task.id,
     name: name.value,
     status: task.status,
-    schedule: task.schedule,
+    schedule: schedule.schedule,
     runMode: task.runMode,
     overlapPolicy: task.overlapPolicy,
     reusableSessionId: task.reusableSessionId,
     variableSetId: task.variableSetId,
     rigId: task.rigId,
-    createdAt: task.createdAt,
-    updatedAt: task.updatedAt,
+    createdAt: createdAt.value,
+    updatedAt: updatedAt.value,
     configuration: {
-      model: task.agentConfig.model ?? null,
+      model: model?.value ?? null,
       reasoningEffort: task.agentConfig.reasoningEffort ?? null,
       sandboxBackend: task.agentConfig.sandboxBackend ?? null,
       hasGoal: task.agentConfig.goal !== undefined,
@@ -104,40 +325,56 @@ export function scheduledTaskMcpSummary(task: ScheduledTask) {
       taskMetadataKeyCount: Object.keys(task.metadata).length,
     },
     projection: {
-      name: {
-        originalBytes: name.originalBytes,
-        deliveredBytes: name.deliveredBytes,
-        truncated: name.truncated,
-      },
+      bounded: true,
+      name: projectionFact(name),
+      schedule: schedule.projection,
+      model: model ? projectionFact(model) : null,
+      createdAt: projectionFact(createdAt),
+      updatedAt: projectionFact(updatedAt),
+      bytes: 0,
+      maxBytes: SCHEDULED_TASK_MCP_MAX_BYTES,
     },
   };
+  settleMeasuredBytes(
+    result,
+    () => result.projection.bytes,
+    (bytes) => {
+      result.projection.bytes = bytes;
+    },
+  );
+  return result;
 }
 
-export function boundScheduledTaskDetailMcp(task: ScheduledTask) {
-  const prompt = projectScheduledTaskUtf8(task.agentConfig.prompt, SCHEDULED_TASK_PROMPT_MAX_BYTES);
+function buildScheduledTaskDetailMcp(
+  task: ScheduledTask,
+  budget: DetailBudget,
+  reducedForBytes: boolean,
+) {
+  const prompt = projectScheduledTaskUtf8(task.agentConfig.prompt, budget.promptBytes);
   const goalText = task.agentConfig.goal
-    ? projectScheduledTaskUtf8(task.agentConfig.goal.text, SCHEDULED_TASK_GOAL_FIELD_MAX_BYTES)
+    ? projectScheduledTaskUtf8(task.agentConfig.goal.text, budget.goalFieldBytes)
     : null;
   const goalCriteria = task.agentConfig.goal?.successCriteria
-    ? projectScheduledTaskUtf8(
-        task.agentConfig.goal.successCriteria,
-        SCHEDULED_TASK_GOAL_FIELD_MAX_BYTES,
-      )
+    ? projectScheduledTaskUtf8(task.agentConfig.goal.successCriteria, budget.goalFieldBytes)
     : null;
-  const resources = task.agentConfig.resources
-    .slice(0, SCHEDULED_TASK_IDENTITY_PREVIEW_LIMIT)
-    .map(resourceIdentity);
-  const tools = task.agentConfig.tools
-    .slice(0, SCHEDULED_TASK_IDENTITY_PREVIEW_LIMIT)
-    .map(toolIdentity);
-  const metadataKeys = Object.keys(task.agentConfig.metadata)
+  const resourceProjections = task.agentConfig.resources
+    .slice(0, budget.identityPreviewLimit)
+    .map((resource) => resourceIdentity(resource, budget));
+  const toolProjections = task.agentConfig.tools
+    .slice(0, budget.identityPreviewLimit)
+    .map((tool) => toolIdentity(tool, budget));
+  const resources = resourceProjections.map((projection) => projection.value);
+  const tools = toolProjections.map((projection) => projection.value);
+  const metadataKeyProjections = Object.keys(task.agentConfig.metadata)
     .sort()
-    .slice(0, SCHEDULED_TASK_IDENTITY_PREVIEW_LIMIT)
-    .map((key) => projectScheduledTaskUtf8(key, 256).value);
-  const taskMetadataKeys = Object.keys(task.metadata)
+    .slice(0, budget.identityPreviewLimit)
+    .map((key) => projectScheduledTaskUtf8(key, budget.metadataKeyBytes));
+  const taskMetadataKeyProjections = Object.keys(task.metadata)
     .sort()
-    .slice(0, SCHEDULED_TASK_IDENTITY_PREVIEW_LIMIT)
-    .map((key) => projectScheduledTaskUtf8(key, 256).value);
+    .slice(0, budget.identityPreviewLimit)
+    .map((key) => projectScheduledTaskUtf8(key, budget.metadataKeyBytes));
+  const metadataKeys = metadataKeyProjections.map((projection) => projection.value);
+  const taskMetadataKeys = taskMetadataKeyProjections.map((projection) => projection.value);
 
   const result = {
     ...scheduledTaskMcpSummary(task),
@@ -147,7 +384,9 @@ export function boundScheduledTaskDetailMcp(task: ScheduledTask) {
         resources,
         tools,
         metadataKeys,
-        model: task.agentConfig.model ?? null,
+        model: task.agentConfig.model
+          ? projectScheduledTaskUtf8(task.agentConfig.model, SCHEDULED_TASK_MODEL_MAX_BYTES).value
+          : null,
         reasoningEffort: task.agentConfig.reasoningEffort ?? null,
         sandboxBackend: task.agentConfig.sandboxBackend ?? null,
         goal: goalText
@@ -163,55 +402,146 @@ export function boundScheduledTaskDetailMcp(task: ScheduledTask) {
     detailProjection: {
       bounded: true,
       fullEntityAvailableViaRest: true,
-      prompt: {
-        originalBytes: prompt.originalBytes,
-        deliveredBytes: prompt.deliveredBytes,
-        truncated: prompt.truncated,
-      },
-      goalText: goalText
-        ? {
-            originalBytes: goalText.originalBytes,
-            deliveredBytes: goalText.deliveredBytes,
-            truncated: goalText.truncated,
-          }
-        : null,
-      goalSuccessCriteria: goalCriteria
-        ? {
-            originalBytes: goalCriteria.originalBytes,
-            deliveredBytes: goalCriteria.deliveredBytes,
-            truncated: goalCriteria.truncated,
-          }
-        : null,
+      reducedForBytes,
+      terminal: false,
+      prompt: projectionFact(prompt),
+      goalText: goalText ? projectionFact(goalText) : null,
+      goalSuccessCriteria: goalCriteria ? projectionFact(goalCriteria) : null,
       resources: {
         originalCount: task.agentConfig.resources.length,
         deliveredCount: resources.length,
         originalBytes: jsonBytes(task.agentConfig.resources),
+        truncatedIdentityFieldCount: resourceProjections.reduce(
+          (count, projection) => count + projection.truncatedFieldCount,
+          0,
+        ),
       },
       tools: {
         originalCount: task.agentConfig.tools.length,
         deliveredCount: tools.length,
         originalBytes: jsonBytes(task.agentConfig.tools),
+        truncatedIdentityFieldCount: toolProjections.reduce(
+          (count, projection) => count + projection.truncatedFieldCount,
+          0,
+        ),
       },
       metadata: {
         originalKeyCount: Object.keys(task.agentConfig.metadata).length,
         deliveredKeyCount: metadataKeys.length,
         originalBytes: jsonBytes(task.agentConfig.metadata),
+        truncatedKeyCount: metadataKeyProjections.filter((projection) => projection.truncated)
+          .length,
         valuesIncluded: false,
       },
       taskMetadata: {
         originalKeyCount: Object.keys(task.metadata).length,
         deliveredKeyCount: taskMetadataKeys.length,
         originalBytes: jsonBytes(task.metadata),
+        truncatedKeyCount: taskMetadataKeyProjections.filter((projection) => projection.truncated)
+          .length,
         valuesIncluded: false,
       },
+      bytes: 0,
+      maxBytes: SCHEDULED_TASK_MCP_MAX_BYTES,
     },
   };
-  if (mcpJsonBytes(result) > SCHEDULED_TASK_MCP_MAX_BYTES) {
-    throw new RangeError(
-      `Scheduled-task detail projection exceeds ${SCHEDULED_TASK_MCP_MAX_BYTES} bytes`,
-    );
-  }
+  settleMeasuredBytes(
+    result,
+    () => result.detailProjection.bytes,
+    (bytes) => {
+      result.detailProjection.bytes = bytes;
+    },
+  );
   return result;
+}
+
+export function boundScheduledTaskDetailMcp(task: ScheduledTask) {
+  for (const [index, budget] of DETAIL_BUDGETS.entries()) {
+    const result = buildScheduledTaskDetailMcp(task, budget, index > 0);
+    if (result.detailProjection.bytes <= SCHEDULED_TASK_MCP_MAX_BYTES) return result;
+  }
+
+  const summary = scheduledTaskMcpSummary(task);
+  const prompt = projectScheduledTaskUtf8(task.agentConfig.prompt, 128);
+  const goalText = task.agentConfig.goal
+    ? projectScheduledTaskUtf8(task.agentConfig.goal.text, 64)
+    : null;
+  const goalCriteria = task.agentConfig.goal?.successCriteria
+    ? projectScheduledTaskUtf8(task.agentConfig.goal.successCriteria, 64)
+    : null;
+  const terminal = {
+    ...summary,
+    entity: {
+      agentConfig: {
+        prompt: prompt.value,
+        resources: [],
+        tools: [],
+        metadataKeys: [],
+        model: null,
+        reasoningEffort: task.agentConfig.reasoningEffort ?? null,
+        sandboxBackend: task.agentConfig.sandboxBackend ?? null,
+        goal: goalText
+          ? {
+              text: goalText.value,
+              successCriteria: goalCriteria?.value ?? null,
+              maxAutoContinuations: task.agentConfig.goal?.maxAutoContinuations ?? null,
+            }
+          : null,
+      },
+      taskMetadataKeys: [],
+    },
+    detailProjection: {
+      bounded: true,
+      fullEntityAvailableViaRest: true,
+      reducedForBytes: true,
+      terminal: true,
+      reason: "detail_projection_exceeded_model_envelope",
+      nextAction: {
+        surface: "REST",
+        resourceType: "scheduled_task",
+        resourceId: task.id,
+      },
+      prompt: projectionFact(prompt),
+      goalText: goalText ? projectionFact(goalText) : null,
+      goalSuccessCriteria: goalCriteria ? projectionFact(goalCriteria) : null,
+      resources: {
+        originalCount: task.agentConfig.resources.length,
+        deliveredCount: 0,
+        originalBytes: jsonBytes(task.agentConfig.resources),
+        truncatedIdentityFieldCount: 0,
+      },
+      tools: {
+        originalCount: task.agentConfig.tools.length,
+        deliveredCount: 0,
+        originalBytes: jsonBytes(task.agentConfig.tools),
+        truncatedIdentityFieldCount: 0,
+      },
+      metadata: {
+        originalKeyCount: Object.keys(task.agentConfig.metadata).length,
+        deliveredKeyCount: 0,
+        originalBytes: jsonBytes(task.agentConfig.metadata),
+        truncatedKeyCount: 0,
+        valuesIncluded: false,
+      },
+      taskMetadata: {
+        originalKeyCount: Object.keys(task.metadata).length,
+        deliveredKeyCount: 0,
+        originalBytes: jsonBytes(task.metadata),
+        truncatedKeyCount: 0,
+        valuesIncluded: false,
+      },
+      bytes: 0,
+      maxBytes: SCHEDULED_TASK_MCP_MAX_BYTES,
+    },
+  };
+  settleMeasuredBytes(
+    terminal,
+    () => terminal.detailProjection.bytes,
+    (bytes) => {
+      terminal.detailProjection.bytes = bytes;
+    },
+  );
+  return terminal;
 }
 
 export function boundScheduledTaskMcpPage(input: {
@@ -219,40 +549,59 @@ export function boundScheduledTaskMcpPage(input: {
   limit: number;
   offset: number;
   sourceHasMore: boolean;
+  maxBytes?: number;
 }) {
+  const maxBytes = Math.max(8 * 1024, input.maxBytes ?? SCHEDULED_TASK_MCP_MAX_BYTES);
   let summaries = input.tasks.map(scheduledTaskMcpSummary);
-  let modelRowsDropped = false;
-  const build = () => ({
-    tasks: summaries,
-    page: {
-      limit: input.limit,
-      offset: input.offset,
-      hasMore: input.sourceHasMore || modelRowsDropped,
-      nextOffset: input.sourceHasMore || modelRowsDropped ? input.offset + summaries.length : null,
-    },
-    projection: {
-      bounded: true,
-      rowsDroppedForBytes: modelRowsDropped,
-      bytes: 0,
-      maxBytes: SCHEDULED_TASK_MCP_MAX_BYTES,
-    },
-  });
-  let page = build();
-  for (let attempt = 0; attempt < 8; attempt += 1) {
-    page.projection.bytes = mcpJsonBytes(page);
-  }
-  while (page.projection.bytes > SCHEDULED_TASK_MCP_MAX_BYTES && summaries.length > 0) {
-    summaries = summaries.slice(0, -1);
-    modelRowsDropped = true;
-    page = build();
-    for (let attempt = 0; attempt < 8; attempt += 1) {
-      page.projection.bytes = mcpJsonBytes(page);
-    }
-  }
-  if (page.projection.bytes > SCHEDULED_TASK_MCP_MAX_BYTES) {
-    throw new RangeError(
-      `Scheduled-task list metadata exceeds ${SCHEDULED_TASK_MCP_MAX_BYTES} bytes`,
+
+  const build = () => {
+    const droppedTasks = input.tasks.slice(summaries.length);
+    const rowsDroppedForBytes = droppedTasks.length > 0;
+    const hasMore = input.sourceHasMore || rowsDroppedForBytes;
+    const nextOffset = hasMore && input.tasks.length > 0 ? input.offset + input.tasks.length : null;
+    const page = {
+      tasks: summaries,
+      page: {
+        limit: input.limit,
+        offset: input.offset,
+        hasMore,
+        nextOffset,
+      },
+      projection: {
+        bounded: true,
+        rowsDroppedForBytes,
+        droppedRowCount: droppedTasks.length,
+        droppedRows: droppedTasks.map((task) => ({
+          id: task.id,
+          nextAction: {
+            tool: "scheduled_tasks_get",
+            arguments: { id: task.id, includeEntity: false },
+          },
+        })),
+        sourceRowsConsumed: input.tasks.length,
+        rowsReturned: summaries.length,
+        terminal: hasMore && nextOffset === null,
+        ...(hasMore && nextOffset === null
+          ? { reason: "source_reported_more_rows_without_a_consumed_row" }
+          : {}),
+        bytes: 0,
+        maxBytes,
+      },
+    };
+    settleMeasuredBytes(
+      page,
+      () => page.projection.bytes,
+      (bytes) => {
+        page.projection.bytes = bytes;
+      },
     );
+    return page;
+  };
+
+  let page = build();
+  while (page.projection.bytes > maxBytes && summaries.length > 0) {
+    summaries = summaries.slice(0, -1);
+    page = build();
   }
   return page;
 }

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -1874,28 +1874,6 @@ function registerPreferenceRegistryTools(
 
 const MemoryKindSchema = z4.enum(["preference", "semantic", "procedural", "decision", "episodic"]);
 
-function scheduledTaskMutableState(task: ScheduledTask): Record<string, unknown> {
-  return {
-    name: task.name,
-    status: task.status,
-    schedule: task.schedule,
-    runMode: task.runMode,
-    overlapPolicy: task.overlapPolicy,
-    agentConfig: task.agentConfig,
-    reusableSessionId: task.reusableSessionId,
-    variableSetId: task.variableSetId,
-    rigId: task.rigId,
-    metadata: task.metadata,
-  };
-}
-
-function scheduledTaskStateChanged(before: ScheduledTask, after: ScheduledTask): boolean {
-  return (
-    JSON.stringify(scheduledTaskMutableState(before)) !==
-    JSON.stringify(scheduledTaskMutableState(after))
-  );
-}
-
 function scheduledTaskReceipt(
   operation: string,
   task: ScheduledTask,

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -134,12 +134,13 @@ import {
   manualScheduledTaskTriggerWorkflowId,
   scheduledTaskToolsProvided,
   scheduledTaskTriggerToken,
+  ScheduledTaskSyncError,
   syncCreatedScheduledTask,
   syncUpdatedScheduledTask,
   validatedScheduledTaskUpdate,
 } from "@opengeni/core";
 import {
-  acceptSessionUserMessage,
+  acceptSessionUserMessageWithOutcome,
   controlAgentSessionWorkstream,
   controlHumanSessionWorkstream,
   createSessionForRequest,
@@ -170,6 +171,12 @@ import {
   boundRigDetailMcp,
   SESSION_EVENT_MCP_MAX_BYTES,
 } from "./session-view";
+import { mcpMutationReceipt } from "./receipts";
+import {
+  boundScheduledTaskDetailMcp,
+  boundScheduledTaskMcpPage,
+  scheduledTaskMcpSummary,
+} from "./scheduled-task-view";
 import type { ToolspaceMcpSurface } from "./toolspace";
 import { ensureSessionGroupReady as ensureViewerSessionGroupReady } from "../sandbox/viewer";
 import {
@@ -769,22 +776,41 @@ export function buildOpenGeniMcpServer(
     server.registerTool(
       "scheduled_tasks_list",
       {
-        description: "List scheduled tasks.",
-        inputSchema: { limit: z4.number().int().positive().optional() },
+        description:
+          "List compact scheduled-task summaries. Prompts, goal text, resource/tool bodies, and metadata values are represented by byte/count facts; page with offset and use scheduled_tasks_get for a bounded explicit detail projection.",
+        inputSchema: {
+          limit: z4.number().int().positive().max(50).optional(),
+          offset: z4.number().int().nonnegative().max(10_000).optional(),
+        },
       },
-      async ({ limit }) =>
-        json({
-          tasks: await listScheduledTasks(deps.db, grant.workspaceId, limit ?? 100),
-        }),
+      async ({ limit: requestedLimit, offset: requestedOffset }) => {
+        const limit = requestedLimit ?? 25;
+        const offset = requestedOffset ?? 0;
+        const rows = await listScheduledTasks(deps.db, grant.workspaceId, limit + 1, offset);
+        return json(
+          boundScheduledTaskMcpPage({
+            tasks: rows.slice(0, limit),
+            limit,
+            offset,
+            sourceHasMore: rows.length > limit,
+          }),
+        );
+      },
     );
 
     server.registerTool(
       "scheduled_tasks_get",
       {
-        description: "Get one scheduled task.",
-        inputSchema: { id: z4.string().uuid() },
+        description:
+          "Get one scheduled task. The default is the same compact summary used by scheduled_tasks_list; pass includeEntity=true for a bounded projection with an 8 KiB prompt preview, bounded goal fields, resource/tool identity previews, and metadata keys without values.",
+        inputSchema: { id: z4.string().uuid(), includeEntity: z4.boolean().optional() },
       },
-      async ({ id }) => json(await requireScheduledTask(deps.db, grant.workspaceId, id)),
+      async ({ id, includeEntity }) => {
+        const task = await requireScheduledTask(deps.db, grant.workspaceId, id);
+        return json(
+          includeEntity ? boundScheduledTaskDetailMcp(task) : scheduledTaskMcpSummary(task),
+        );
+      },
     );
 
     server.registerTool(
@@ -824,12 +850,26 @@ export function buildOpenGeniMcpServer(
           payload,
           toolsProvided: scheduledTaskToolsProvided(args),
         });
-        await syncCreatedScheduledTask({
-          db: deps.db,
-          workflowClient: deps.workflowClient,
-          task,
-        });
-        return json(task);
+        try {
+          await syncCreatedScheduledTask({
+            db: deps.db,
+            workflowClient: deps.workflowClient,
+            task,
+          });
+        } catch (error) {
+          if (!(error instanceof ScheduledTaskSyncError) || error.persistenceRestored) {
+            throw error;
+          }
+          return json(
+            scheduledTaskReceipt("scheduled_tasks_create", task, "partial_failure", true, {
+              partialFailure: { stage: "schedule_sync", retryable: true },
+              warnings: [
+                "The task database record committed, but Temporal schedule synchronization failed.",
+              ],
+            }),
+          );
+        }
+        return json(scheduledTaskReceipt("scheduled_tasks_create", task, "created", true));
       },
     );
 
@@ -955,18 +995,36 @@ export function buildOpenGeniMcpServer(
           triggerWorkflowId,
           initiator: { kind: "subject", subjectId: grant.subjectId },
         });
-        await recordWorkspaceUsage(deps, {
-          accountId: grant.accountId,
-          workspaceId: grant.workspaceId,
-          subjectId: grant.subjectId,
-          eventType: "agent_run.created",
-          quantity: 1,
-          unit: "run",
-          sourceResourceType: "scheduled_task",
-          sourceResourceId: task.id,
-          idempotencyKey: agentRunUsageIdempotencyKey,
-        });
-        return json(task);
+        try {
+          await recordWorkspaceUsage(deps, {
+            accountId: grant.accountId,
+            workspaceId: grant.workspaceId,
+            subjectId: grant.subjectId,
+            eventType: "agent_run.created",
+            quantity: 1,
+            unit: "run",
+            sourceResourceType: "scheduled_task",
+            sourceResourceId: task.id,
+            idempotencyKey: agentRunUsageIdempotencyKey,
+          });
+        } catch {
+          return json(
+            scheduledTaskReceipt("scheduled_tasks_trigger", task, "partial_failure", true, {
+              partialFailure: { stage: "usage_recording", retryable: true },
+              warnings: [
+                "The Temporal run trigger completed, but usage recording failed; retry with the same triggerId.",
+              ],
+              idempotencyStatus: triggerId ? "unknown" : "not_requested",
+              facts: { triggerWorkflowId },
+            }),
+          );
+        }
+        return json(
+          scheduledTaskReceipt("scheduled_tasks_trigger", task, "triggered", true, {
+            idempotencyStatus: triggerId ? "unknown" : "not_requested",
+            facts: { triggerWorkflowId },
+          }),
+        );
       },
     );
 
@@ -981,8 +1039,28 @@ export function buildOpenGeniMcpServer(
         await deps.workflowClient.deleteScheduledTaskSchedule({
           temporalScheduleId: task.temporalScheduleId,
         });
-        await deleteScheduledTask(deps.db, grant.workspaceId, id);
-        return json({ ok: true });
+        try {
+          await deleteScheduledTask(deps.db, grant.workspaceId, id);
+        } catch {
+          return json(
+            scheduledTaskReceipt("scheduled_tasks_delete", task, "partial_failure", true, {
+              partialFailure: { stage: "database_delete", retryable: true },
+              warnings: [
+                "The Temporal schedule was deleted, but the task database record remains.",
+              ],
+            }),
+          );
+        }
+        return json(
+          mcpMutationReceipt({
+            operation: "scheduled_tasks_delete",
+            committed: true,
+            outcome: "deleted",
+            changed: true,
+            resource: { type: "scheduled_task", id: task.id, state: "deleted" },
+            idempotency: { status: "not_supported" },
+          }),
+        );
       },
     );
 
@@ -1444,7 +1522,23 @@ function registerGoalTools(
       if (events.length > 0) {
         await deps.bus.publish(grant.workspaceId, sessionId, events);
       }
-      return json(goal);
+      return json(
+        mcpMutationReceipt({
+          operation: "goal_complete",
+          committed: true,
+          outcome: changed ? "updated" : "unchanged",
+          changed,
+          resource: {
+            type: "session_goal",
+            id: goal.id,
+            version: goal.version,
+            state: goal.status,
+          },
+          timestamp: goal.updatedAt,
+          idempotency: { status: "not_supported" },
+          nextAction: { tool: "session_get", arguments: { sessionId } },
+        }),
+      );
     },
   );
 
@@ -1481,7 +1575,23 @@ function registerGoalTools(
       if (events.length > 0) {
         await deps.bus.publish(grant.workspaceId, sessionId, events);
       }
-      return json(goal);
+      return json(
+        mcpMutationReceipt({
+          operation: "goal_pause",
+          committed: true,
+          outcome: changed ? "updated" : "unchanged",
+          changed,
+          resource: {
+            type: "session_goal",
+            id: goal.id,
+            version: goal.version,
+            state: goal.status,
+          },
+          timestamp: goal.updatedAt,
+          idempotency: { status: "not_supported" },
+          nextAction: { tool: "session_get", arguments: { sessionId } },
+        }),
+      );
     },
   );
 }
@@ -1761,6 +1871,60 @@ function registerPreferenceRegistryTools(
 
 const MemoryKindSchema = z4.enum(["preference", "semantic", "procedural", "decision", "episodic"]);
 
+function scheduledTaskMutableState(task: ScheduledTask): Record<string, unknown> {
+  return {
+    name: task.name,
+    status: task.status,
+    schedule: task.schedule,
+    runMode: task.runMode,
+    overlapPolicy: task.overlapPolicy,
+    agentConfig: task.agentConfig,
+    reusableSessionId: task.reusableSessionId,
+    variableSetId: task.variableSetId,
+    rigId: task.rigId,
+    metadata: task.metadata,
+  };
+}
+
+function scheduledTaskStateChanged(before: ScheduledTask, after: ScheduledTask): boolean {
+  return (
+    JSON.stringify(scheduledTaskMutableState(before)) !==
+    JSON.stringify(scheduledTaskMutableState(after))
+  );
+}
+
+function scheduledTaskReceipt(
+  operation: string,
+  task: ScheduledTask,
+  outcome: "created" | "updated" | "unchanged" | "triggered" | "partial_failure",
+  changed: boolean,
+  options: {
+    partialFailure?: { stage: string; retryable: boolean };
+    warnings?: string[];
+    idempotencyStatus?: "not_supported" | "not_requested" | "applied" | "replayed" | "unknown";
+    facts?: Record<string, string | number | boolean | null>;
+  } = {},
+) {
+  return mcpMutationReceipt({
+    operation,
+    committed: true,
+    outcome,
+    changed,
+    resource: {
+      type: "scheduled_task",
+      id: task.id,
+      version: task.updatedAt,
+      state: task.status,
+    },
+    timestamp: task.updatedAt,
+    idempotency: { status: options.idempotencyStatus ?? "not_supported" },
+    ...(options.partialFailure ? { partialFailure: options.partialFailure } : {}),
+    ...(options.warnings ? { warnings: options.warnings } : {}),
+    ...(options.facts ? { facts: options.facts } : {}),
+    nextAction: { tool: "scheduled_tasks_get", arguments: { id: task.id } },
+  });
+}
+
 function memoryPreview(text: string): string {
   const normalized = text.replace(/\s+/g, " ").trim();
   return normalized.length <= 120 ? normalized : `${normalized.slice(0, 119)}…`;
@@ -1836,7 +2000,52 @@ function registerMemoryTools(
           },
         },
       ]);
-      return json(result);
+      const changed = !result.deduped || result.updated || result.superseded !== null;
+      const outcome =
+        result.updated || result.superseded !== null
+          ? "updated"
+          : result.deduped
+            ? "unchanged"
+            : "created";
+      return json(
+        mcpMutationReceipt({
+          operation: "memory_save",
+          committed: true,
+          outcome,
+          changed,
+          resource: {
+            type: "knowledge_memory",
+            id: result.memory.id,
+            state: result.memory.status,
+          },
+          relatedResources: result.superseded
+            ? [
+                {
+                  type: "knowledge_memory",
+                  id: result.superseded.id,
+                  state: result.superseded.status,
+                },
+              ]
+            : undefined,
+          timestamp: result.memory.updatedAt,
+          idempotency: { status: "not_supported" },
+          warnings: [
+            ...(result.redactionCount > 0
+              ? [`Redacted ${result.redactionCount} sensitive value(s) before committing memory.`]
+              : []),
+            ...(!result.embedded
+              ? ["Memory committed without a vector embedding; keyword search remains available."]
+              : []),
+          ],
+          facts: {
+            deduped: result.deduped,
+            dedupeReason: result.dedupeReason,
+            updatedInPlace: result.updated,
+            redactionCount: result.redactionCount,
+            embedded: result.embedded,
+          },
+        }),
+      );
     },
   );
 
@@ -1881,7 +2090,31 @@ function registerMemoryTools(
           },
         },
       ]);
-      return json(result);
+      return json(
+        mcpMutationReceipt({
+          operation: "memory_correct",
+          committed: true,
+          outcome: "updated",
+          changed: true,
+          resource: {
+            type: "knowledge_memory",
+            id: result.memory.id,
+            state: result.memory.status,
+          },
+          relatedResources: result.replacement
+            ? [
+                {
+                  type: "knowledge_memory",
+                  id: result.replacement.id,
+                  state: result.replacement.status,
+                },
+              ]
+            : undefined,
+          timestamp: (result.replacement ?? result.memory).updatedAt,
+          idempotency: { status: "not_supported" },
+          facts: { correctionAction: result.action },
+        }),
+      );
     },
   );
 }
@@ -2101,12 +2334,57 @@ function registerRigTools(
           sessionId ? { proposedBy: `session:${sessionId}` } : {},
         );
         const verifying = await beginMcpRigVerificationAttempt(deps, grant.workspaceId, change.id);
-        await deps.workflowClient.startRigVerification({
-          workspaceId: grant.workspaceId,
-          changeId: change.id,
-          workflowId: `rig-verification-change-${change.id}-attempt-${verificationAttempt(verifying)}`,
-        });
-        return json({ change: verifying, verificationStarted: true });
+        const attempt = verificationAttempt(verifying);
+        try {
+          await deps.workflowClient.startRigVerification({
+            workspaceId: grant.workspaceId,
+            changeId: change.id,
+            workflowId: `rig-verification-change-${change.id}-attempt-${attempt}`,
+          });
+        } catch {
+          return json(
+            mcpMutationReceipt({
+              operation: "rig_propose_change",
+              committed: true,
+              outcome: "partial_failure",
+              changed: true,
+              resource: {
+                type: "rig_change",
+                id: verifying.id,
+                version: verifying.updatedAt,
+                state: verifying.status,
+              },
+              relatedResources: [{ type: "rig", id: rig.id }],
+              timestamp: verifying.updatedAt,
+              idempotency: { status: "not_supported" },
+              partialFailure: { stage: "verification_workflow_start", retryable: true },
+              warnings: [
+                "The rig change and verifying transition committed, but verification workflow start failed.",
+              ],
+              facts: { verificationAttempt: attempt },
+              nextAction: { tool: "rig_get", arguments: { rigId: rig.id } },
+            }),
+          );
+        }
+        return json(
+          mcpMutationReceipt({
+            operation: "rig_propose_change",
+            committed: true,
+            outcome: "created",
+            changed: true,
+            resource: {
+              type: "rig_change",
+              id: verifying.id,
+              version: verifying.updatedAt,
+              state: verifying.status,
+            },
+            relatedResources: [{ type: "rig", id: rig.id }],
+            timestamp: verifying.updatedAt,
+            idempotency: { status: "not_supported" },
+            facts: { verificationStarted: true, verificationAttempt: attempt },
+            nextAction: { tool: "rig_get", arguments: { rigId: rig.id } },
+          }),
+        );
       },
     );
 
@@ -2129,12 +2407,57 @@ function registerRigTools(
             grant.workspaceId,
             change.id,
           );
-          await deps.workflowClient.startRigVerification({
-            workspaceId: grant.workspaceId,
-            changeId: change.id,
-            workflowId: `rig-verification-change-${change.id}-attempt-${verificationAttempt(verifying)}`,
-          });
-          return json({ ok: true, changeId: change.id });
+          const attempt = verificationAttempt(verifying);
+          try {
+            await deps.workflowClient.startRigVerification({
+              workspaceId: grant.workspaceId,
+              changeId: change.id,
+              workflowId: `rig-verification-change-${change.id}-attempt-${attempt}`,
+            });
+          } catch {
+            return json(
+              mcpMutationReceipt({
+                operation: "rig_verify",
+                committed: true,
+                outcome: "partial_failure",
+                changed: true,
+                resource: {
+                  type: "rig_change",
+                  id: verifying.id,
+                  version: verifying.updatedAt,
+                  state: verifying.status,
+                },
+                relatedResources: [{ type: "rig", id: rig.id }],
+                timestamp: verifying.updatedAt,
+                idempotency: { status: "not_supported" },
+                partialFailure: { stage: "verification_workflow_start", retryable: true },
+                warnings: [
+                  "The verifying transition committed, but verification workflow start failed.",
+                ],
+                facts: { verificationAttempt: attempt },
+                nextAction: { tool: "rig_get", arguments: { rigId: rig.id } },
+              }),
+            );
+          }
+          return json(
+            mcpMutationReceipt({
+              operation: "rig_verify",
+              committed: true,
+              outcome: "accepted",
+              changed: true,
+              resource: {
+                type: "rig_change",
+                id: verifying.id,
+                version: verifying.updatedAt,
+                state: verifying.status,
+              },
+              relatedResources: [{ type: "rig", id: rig.id }],
+              timestamp: verifying.updatedAt,
+              idempotency: { status: "not_supported" },
+              facts: { verificationStarted: true, verificationAttempt: attempt },
+              nextAction: { tool: "rig_get", arguments: { rigId: rig.id } },
+            }),
+          );
         }
         if (!rig.activeVersion) {
           throw new Error("rig has no active version");
@@ -2144,7 +2467,23 @@ function registerRigTools(
           versionId: rig.activeVersion.id,
           workflowId: `rig-verification-version-${rig.activeVersion.id}-${crypto.randomUUID()}`,
         });
-        return json({ ok: true, versionId: rig.activeVersion.id });
+        return json(
+          mcpMutationReceipt({
+            operation: "rig_verify",
+            committed: true,
+            outcome: "accepted",
+            changed: true,
+            resource: {
+              type: "rig_version",
+              id: rig.activeVersion.id,
+              version: rig.activeVersion.version,
+              state: "verification_started",
+            },
+            relatedResources: [{ type: "rig", id: rig.id }],
+            idempotency: { status: "not_supported" },
+            nextAction: { tool: "rig_get", arguments: { rigId: rig.id } },
+          }),
+        );
       },
     );
   }
@@ -2163,8 +2502,32 @@ function registerRigTools(
       async ({ rigId, changeId }) => {
         const rig = await requireRigForApi(deps.db, grant.workspaceId, rigId);
         const change = await requireRigChangeForApi(deps.db, grant.workspaceId, rig.id, changeId);
+        const promoted = await promoteVerifiedDefinitionEditChangeForApi(
+          { db: deps.db },
+          grant,
+          rig,
+          change,
+        );
         return json(
-          await promoteVerifiedDefinitionEditChangeForApi({ db: deps.db }, grant, rig, change),
+          mcpMutationReceipt({
+            operation: "rig_promote",
+            committed: true,
+            outcome: "updated",
+            changed: true,
+            resource: {
+              type: "rig_version",
+              id: promoted.version.id,
+              version: promoted.version.version,
+              state: "active",
+            },
+            relatedResources: [
+              { type: "rig_change", id: promoted.change.id, state: promoted.change.status },
+              { type: "rig", id: rig.id },
+            ],
+            timestamp: promoted.version.createdAt,
+            idempotency: { status: "not_supported" },
+            nextAction: { tool: "rig_get", arguments: { rigId: rig.id } },
+          }),
         );
       },
     );
@@ -2549,17 +2912,30 @@ function registerWorkspaceOrchestrationTools(
             exactAgentCommandContext(grant, callerSessionId),
             { targetSessionId, text, idempotencyKey },
           );
-          return json({
-            delivered: true,
-            updateId: result.updateId,
-            delivery: "coalesced_internal_update",
-            effectiveState: result.effectiveState,
-            wakeRequested: result.wakeRevision !== null,
-            resumeRequired: result.effectiveState === "paused",
-            replay: result.replay,
-          });
+          return json(
+            mcpMutationReceipt({
+              operation: "session_send_message",
+              committed: true,
+              outcome: result.replay ? "replayed" : "accepted",
+              changed: !result.replay,
+              resource: {
+                type: "session_system_update",
+                id: result.updateId,
+                state: result.effectiveState,
+              },
+              relatedResources: [{ type: "session", id: targetSessionId }],
+              timestamp: result.receipt.createdAt.toISOString(),
+              idempotency: { status: result.replay ? "replayed" : "applied" },
+              facts: {
+                delivery: "coalesced_internal_update",
+                wakeRequested: result.wakeRevision !== null,
+                resumeRequired: result.effectiveState === "paused",
+              },
+              nextAction: { tool: "session_get", arguments: { sessionId: targetSessionId } },
+            }),
+          );
         }
-        const { accepted, turn } = await acceptSessionUserMessage(
+        const { accepted, turn, replay } = await acceptSessionUserMessageWithOutcome(
           deps,
           grant,
           grant.workspaceId,
@@ -2574,7 +2950,27 @@ function registerWorkspaceOrchestrationTools(
             ),
           },
         );
-        return json({ event: accepted, turnId: turn.id });
+        return json(
+          mcpMutationReceipt({
+            operation: "session_send_message",
+            committed: true,
+            outcome: replay ? "replayed" : "accepted",
+            changed: !replay,
+            resource: {
+              type: "session_turn",
+              id: turn.id,
+              version: turn.version,
+              state: turn.status,
+            },
+            relatedResources: [
+              { type: "session", id: targetSessionId },
+              { type: "session_event", id: accepted.id, state: accepted.type },
+            ],
+            timestamp: accepted.occurredAt,
+            idempotency: { status: replay ? "replayed" : "applied" },
+            nextAction: { tool: "session_get", arguments: { sessionId: targetSessionId } },
+          }),
+        );
       },
     );
 
@@ -2701,13 +3097,27 @@ function registerWorkspaceOrchestrationTools(
             exactAgentCommandContext(grant, callerSessionId, "first_party_mcp"),
             { targetSessionId: sessionId, instruction, idempotencyKey },
           );
-          return json({
-            updateId: result.updateId,
-            interruptionCount: result.interruptionCount,
-            stoppingPreviousAttempt: result.interruptionCount > 0,
-            effectiveState: result.effectiveState,
-            replay: result.replay,
-          });
+          return json(
+            mcpMutationReceipt({
+              operation: "session_steer",
+              committed: true,
+              outcome: result.replay ? "replayed" : "updated",
+              changed: !result.replay,
+              resource: {
+                type: "session_system_update",
+                id: result.updateId,
+                state: result.effectiveState,
+              },
+              relatedResources: [{ type: "session", id: sessionId }],
+              timestamp: result.receipt.createdAt.toISOString(),
+              idempotency: { status: result.replay ? "replayed" : "applied" },
+              facts: {
+                interruptionCount: result.interruptionCount,
+                stoppingPreviousAttempt: result.interruptionCount > 0,
+              },
+              nextAction: { tool: "session_get", arguments: { sessionId } },
+            }),
+          );
         },
       );
     }
@@ -2760,93 +3170,114 @@ function registerVariableSetTools(
       },
     );
   };
-  const setVariableHandler = async ({
-    variableSetId,
-    variableSetName,
-    environmentId,
-    environmentName,
-    name,
-    value,
-  }: {
-    variableSetId?: string | undefined;
-    variableSetName?: string | undefined;
-    environmentId?: string | undefined;
-    environmentName?: string | undefined;
-    name: string;
-    value: string;
-  }) => {
-    const key = requireVariableSetEncryption(deps.settings);
-    const parsedName = VariableSetVariableName.safeParse(name);
-    if (!parsedName.success) {
-      throw new Error("variable set/environment variable names must match ^[A-Z][A-Z0-9_]*$");
-    }
-    assertAllowedVariableSetVariableName(parsedName.data);
-    const targetId = variableSetId ?? environmentId;
-    const targetName = variableSetName ?? environmentName;
-    if ((targetId === undefined) === (targetName === undefined)) {
-      throw new Error(
-        "provide exactly one of variableSetId or variableSetName; deprecated aliases must provide exactly one of environmentId or environmentName",
-      );
-    }
-    const trimmedVariableSetName = targetName?.trim();
-    if (targetName !== undefined && !trimmedVariableSetName) {
-      throw new Error("variable set name is required");
-    }
-    let created = false;
-    let variableSet =
-      targetId !== undefined
-        ? await getVariableSet(deps.db, grant.workspaceId, targetId)
-        : await getVariableSetByName(deps.db, grant.workspaceId, trimmedVariableSetName!);
-    if (!variableSet && targetId !== undefined) {
-      throw new Error("variable set/environment not found");
-    }
-    if (!variableSet) {
-      if ((await countVariableSets(deps.db, grant.workspaceId)) >= MAX_ENVIRONMENTS_PER_WORKSPACE) {
+  const setVariableHandler =
+    (operation: "variable_set_set_variable" | "environment_set_variable") =>
+    async ({
+      variableSetId,
+      variableSetName,
+      environmentId,
+      environmentName,
+      name,
+      value,
+    }: {
+      variableSetId?: string | undefined;
+      variableSetName?: string | undefined;
+      environmentId?: string | undefined;
+      environmentName?: string | undefined;
+      name: string;
+      value: string;
+    }) => {
+      const key = requireVariableSetEncryption(deps.settings);
+      const parsedName = VariableSetVariableName.safeParse(name);
+      if (!parsedName.success) {
+        throw new Error("variable set/environment variable names must match ^[A-Z][A-Z0-9_]*$");
+      }
+      assertAllowedVariableSetVariableName(parsedName.data);
+      const targetId = variableSetId ?? environmentId;
+      const targetName = variableSetName ?? environmentName;
+      if ((targetId === undefined) === (targetName === undefined)) {
         throw new Error(
-          `a workspace supports at most ${MAX_ENVIRONMENTS_PER_WORKSPACE} variable sets`,
+          "provide exactly one of variableSetId or variableSetName; deprecated aliases must provide exactly one of environmentId or environmentName",
         );
       }
-      variableSet = await createVariableSet(deps.db, {
+      const trimmedVariableSetName = targetName?.trim();
+      if (targetName !== undefined && !trimmedVariableSetName) {
+        throw new Error("variable set name is required");
+      }
+      let created = false;
+      let variableSet =
+        targetId !== undefined
+          ? await getVariableSet(deps.db, grant.workspaceId, targetId)
+          : await getVariableSetByName(deps.db, grant.workspaceId, trimmedVariableSetName!);
+      if (!variableSet && targetId !== undefined) {
+        throw new Error("variable set/environment not found");
+      }
+      if (!variableSet) {
+        if (
+          (await countVariableSets(deps.db, grant.workspaceId)) >= MAX_ENVIRONMENTS_PER_WORKSPACE
+        ) {
+          throw new Error(
+            `a workspace supports at most ${MAX_ENVIRONMENTS_PER_WORKSPACE} variable sets`,
+          );
+        }
+        variableSet = await createVariableSet(deps.db, {
+          accountId: grant.accountId,
+          workspaceId: grant.workspaceId,
+          name: trimmedVariableSetName!,
+        });
+        created = true;
+        await recordVariableSetAuditEvent(deps.db, {
+          grant,
+          action: "variable_set.created",
+          variableSetId: variableSet.id,
+        });
+      }
+      const exists = variableSet.variables.some((variable) => variable.name === parsedName.data);
+      if (!exists && variableSet.variables.length >= MAX_VARIABLES_PER_ENVIRONMENT) {
+        throw new Error(
+          `a variable set supports at most ${MAX_VARIABLES_PER_ENVIRONMENT} variables`,
+        );
+      }
+      const metadata = await setVariableSetVariable(deps.db, {
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
-        name: trimmedVariableSetName!,
+        variableSetId: variableSet.id,
+        name: parsedName.data,
+        valueEncrypted: encryptVariableSetValue(key, value),
       });
-      created = true;
       await recordVariableSetAuditEvent(deps.db, {
         grant,
-        action: "variable_set.created",
+        action: "variable_set.variable.set",
         variableSetId: variableSet.id,
+        variableName: parsedName.data,
       });
-    }
-    const exists = variableSet.variables.some((variable) => variable.name === parsedName.data);
-    if (!exists && variableSet.variables.length >= MAX_VARIABLES_PER_ENVIRONMENT) {
-      throw new Error(`a variable set supports at most ${MAX_VARIABLES_PER_ENVIRONMENT} variables`);
-    }
-    const metadata = await setVariableSetVariable(deps.db, {
-      accountId: grant.accountId,
-      workspaceId: grant.workspaceId,
-      variableSetId: variableSet.id,
-      name: parsedName.data,
-      valueEncrypted: encryptVariableSetValue(key, value),
-    });
-    await recordVariableSetAuditEvent(deps.db, {
-      grant,
-      action: "variable_set.variable.set",
-      variableSetId: variableSet.id,
-      variableName: parsedName.data,
-    });
-    const responseVariableSet = {
-      id: variableSet.id,
-      name: variableSet.name,
-      created,
+      return json(
+        mcpMutationReceipt({
+          operation,
+          committed: true,
+          outcome: exists ? "updated" : "created",
+          changed: true,
+          resource: {
+            type: "variable_set",
+            id: variableSet.id,
+            version: metadata.version,
+            state: "variable_written",
+          },
+          timestamp: metadata.updatedAt,
+          idempotency: { status: "not_supported" },
+          facts: {
+            variableCreated: !exists,
+            variableSetCreated: created,
+            deprecatedAlias: operation === "environment_set_variable",
+          },
+          nextAction: { tool: "variable_set_list", arguments: {} },
+        }),
+      );
     };
-    return json({
-      variableSet: responseVariableSet,
-      environment: responseVariableSet,
-      variable: metadata,
-    });
-  };
-  const registerSetTool = (name: string, description: string): void => {
+  const registerSetTool = (
+    name: "variable_set_set_variable" | "environment_set_variable",
+    description: string,
+  ): void => {
     server.registerTool(
       name,
       {
@@ -2860,7 +3291,7 @@ function registerVariableSetTools(
           value: z4.string().min(1).max(32768),
         },
       },
-      setVariableHandler,
+      setVariableHandler(name),
     );
   };
   if (can("variable-sets:use")) {

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -24,6 +24,7 @@ import {
   type SessionAuthorizationOperation,
   type SessionAuthorizationSurface,
   type Session,
+  type ScheduledTask,
   UpdateScheduledTaskRequest,
   normalizeWorkspaceArtifactSlug,
   WORKSPACE_ARTIFACT_HTML_MAX_UTF8_BYTES,
@@ -143,7 +144,7 @@ import {
   acceptSessionUserMessageWithOutcome,
   controlAgentSessionWorkstream,
   controlHumanSessionWorkstream,
-  createSessionForRequest,
+  createSessionForRequestWithOutcome,
   SessionSpawnDeniedError,
   sessionSpawnDenialEnvelope,
   sendAgentSessionMessage,
@@ -171,7 +172,7 @@ import {
   boundRigDetailMcp,
   SESSION_EVENT_MCP_MAX_BYTES,
 } from "./session-view";
-import { mcpMutationReceipt } from "./receipts";
+import { mcpMutationReceipt, sessionCreateMutationReceipt } from "./receipts";
 import {
   boundScheduledTaskDetailMcp,
   boundScheduledTaskMcpPage,
@@ -1519,6 +1520,7 @@ function registerGoalTools(
           event: { type: "goal.completed", evidence },
         },
       );
+      const changed = events.length > 0;
       if (events.length > 0) {
         await deps.bus.publish(grant.workspaceId, sessionId, events);
       }
@@ -1572,6 +1574,7 @@ function registerGoalTools(
           },
         },
       );
+      const changed = events.length > 0;
       if (events.length > 0) {
         await deps.bus.publish(grant.workspaceId, sessionId, events);
       }
@@ -2871,8 +2874,13 @@ function registerWorkspaceOrchestrationTools(
           if (callerSessionId !== null) {
             await authorizeFirstPartySession(deps, grant, callerSessionId, "session.child.create");
           }
-          const created = await createSessionForRequest(deps, grant, grant.workspaceId, args);
-          return json(await withMcpEffectivePolicy(deps, grant.workspaceId, created));
+          const result = await createSessionForRequestWithOutcome(
+            deps,
+            grant,
+            grant.workspaceId,
+            args,
+          );
+          return json(sessionCreateMutationReceipt(result, Boolean(args.idempotencyKey)));
         } catch (error) {
           if (error instanceof SessionSpawnDeniedError) {
             return {

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -3101,6 +3101,7 @@ function registerWorkspaceOrchestrationTools(
                 interruptionCount: result.interruptionCount,
                 stoppingPreviousAttempt: result.interruptionCount > 0,
               },
+              updateId: result.updateId,
               nextAction: { tool: "session_get", arguments: { sessionId } },
             }),
           );

--- a/apps/api/test/mcp-receipt-size.test.ts
+++ b/apps/api/test/mcp-receipt-size.test.ts
@@ -59,6 +59,10 @@ function sizeCases(): SizeCase[] {
     timestamp: TIMESTAMP,
     idempotency: { status: "not_requested" },
     facts: { sandboxGroupId: ID, parentSessionId: null },
+    id: ID,
+    rootSessionId: ID,
+    nestedAgentDepth: 0,
+    effectiveMaxNestedAgentDepth: 3,
     nextAction: { tool: "session_get", arguments: { sessionId: ID } },
   });
 
@@ -335,6 +339,10 @@ describe("MCP receipt response size", () => {
         resource: { type: "session", id: ID },
         timestamp: TIMESTAMP,
         idempotency: { status: "not_requested" },
+        id: ID,
+        rootSessionId: ID,
+        nestedAgentDepth: 0,
+        effectiveMaxNestedAgentDepth: 3,
         warnings: ["界".repeat(512)],
       }),
     ).toThrow();
@@ -350,6 +358,10 @@ describe("MCP receipt response size", () => {
       timestamp: TIMESTAMP,
       idempotency: { status: "applied" },
       facts: { sessionCreateOutcome: "repaired" },
+      id: ID,
+      rootSessionId: ID,
+      nestedAgentDepth: 0,
+      effectiveMaxNestedAgentDepth: 3,
       nextAction: { tool: "session_get", arguments: { sessionId: ID } },
     });
     const partialFailure = mcpMutationReceipt({
@@ -365,6 +377,10 @@ describe("MCP receipt response size", () => {
         "The session committed, but usage recording failed. Do not retry this keyless request; inspect the returned session.",
       ],
       facts: { sessionCreateOutcome: "created" },
+      id: ID,
+      rootSessionId: ID,
+      nestedAgentDepth: 0,
+      effectiveMaxNestedAgentDepth: 3,
       nextAction: { tool: "session_get", arguments: { sessionId: ID } },
     });
     expect(utf8Bytes(repaired)).toBeLessThanOrEqual(MCP_MUTATION_RECEIPT_MAX_BYTES);

--- a/apps/api/test/mcp-receipt-size.test.ts
+++ b/apps/api/test/mcp-receipt-size.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { MCP_MUTATION_RECEIPT_MAX_BYTES } from "@opengeni/contracts";
 import { mcpMutationReceipt } from "../src/mcp/receipts";
 
 const ID = "11111111-1111-4111-8111-111111111111";
@@ -250,7 +251,7 @@ describe("MCP receipt response size", () => {
     }
   });
 
-  test("the maximum contract-shaped receipt remains below the canonical 64 KiB envelope", () => {
+  test("the maximum ASCII contract-shaped receipt remains below the canonical envelope", () => {
     const maximum = mcpMutationReceipt({
       operation: "x".repeat(128),
       committed: true,
@@ -284,7 +285,90 @@ describe("MCP receipt response size", () => {
         ),
       },
     });
-    expect(utf8Bytes(maximum)).toBeLessThanOrEqual(64 * 1024);
+    expect(utf8Bytes(maximum)).toBeLessThanOrEqual(MCP_MUTATION_RECEIPT_MAX_BYTES);
+  });
+
+  test("a valid multibyte maximum is bounded by UTF-8 bytes", () => {
+    const maximum = mcpMutationReceipt({
+      operation: exactUtf8String(128),
+      committed: true,
+      outcome: "partial_failure",
+      changed: true,
+      resource: {
+        type: exactUtf8String(128),
+        id: exactUtf8String(256),
+        version: exactUtf8String(128),
+        etag: exactUtf8String(512),
+        state: exactUtf8String(128),
+      },
+      relatedResources: Array.from({ length: 8 }, (_, index) => ({
+        type: exactUtf8String(128),
+        id: `${index}${exactUtf8String(255)}`,
+        version: exactUtf8String(128),
+        etag: exactUtf8String(512),
+        state: exactUtf8String(128),
+      })),
+      timestamp: TIMESTAMP,
+      idempotency: { status: "not_supported" },
+      partialFailure: { stage: exactUtf8String(128), retryable: true },
+      warnings: Array.from({ length: 20 }, () => exactUtf8String(512)),
+      facts: Object.fromEntries(
+        Array.from({ length: 16 }, (_, index) => [`fact${index}`, exactUtf8String(512)]),
+      ),
+      nextAction: {
+        tool: exactUtf8String(128),
+        arguments: Object.fromEntries(
+          Array.from({ length: 8 }, (_, index) => [`arg${index}`, exactUtf8String(512)]),
+        ),
+      },
+    });
+    expect(utf8Bytes(maximum)).toBeLessThanOrEqual(MCP_MUTATION_RECEIPT_MAX_BYTES);
+  });
+
+  test("rejects a code-unit maximum that exceeds its UTF-8 byte limit", () => {
+    expect(() =>
+      mcpMutationReceipt({
+        operation: "session_create",
+        committed: true,
+        outcome: "created",
+        changed: true,
+        resource: { type: "session", id: ID },
+        timestamp: TIMESTAMP,
+        idempotency: { status: "not_requested" },
+        warnings: ["界".repeat(512)],
+      }),
+    ).toThrow();
+  });
+
+  test("keeps repaired and committed partial-failure session receipts compact", () => {
+    const repaired = mcpMutationReceipt({
+      operation: "session_create",
+      committed: true,
+      outcome: "repaired",
+      changed: true,
+      resource: { type: "session", id: ID, version: 1, state: "queued" },
+      timestamp: TIMESTAMP,
+      idempotency: { status: "applied" },
+      facts: { sessionCreateOutcome: "repaired" },
+      nextAction: { tool: "session_get", arguments: { sessionId: ID } },
+    });
+    const partialFailure = mcpMutationReceipt({
+      operation: "session_create",
+      committed: true,
+      outcome: "partial_failure",
+      changed: true,
+      resource: { type: "session", id: ID, version: 1, state: "queued" },
+      timestamp: TIMESTAMP,
+      idempotency: { status: "not_requested" },
+      partialFailure: { stage: "usage_recording", retryable: false },
+      warnings: [
+        "The session committed, but usage recording failed. Do not retry this keyless request; inspect the returned session.",
+      ],
+      facts: { sessionCreateOutcome: "created" },
+      nextAction: { tool: "session_get", arguments: { sessionId: ID } },
+    });
+    expect(utf8Bytes(repaired)).toBeLessThanOrEqual(MCP_MUTATION_RECEIPT_MAX_BYTES);
+    expect(utf8Bytes(partialFailure)).toBeLessThanOrEqual(MCP_MUTATION_RECEIPT_MAX_BYTES);
   });
 });
 

--- a/apps/api/test/mcp-receipt-size.test.ts
+++ b/apps/api/test/mcp-receipt-size.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, test } from "bun:test";
+import { mcpMutationReceipt } from "../src/mcp/receipts";
+
+const ID = "11111111-1111-4111-8111-111111111111";
+const RELATED_ID = "22222222-2222-4222-8222-222222222222";
+const TIMESTAMP = "2026-07-20T00:00:00.000Z";
+
+const utf8Bytes = (value: unknown): number =>
+  Buffer.byteLength(JSON.stringify(value, null, 2), "utf8");
+
+const exactUtf8String = (bytes: number): string => {
+  const glyph = "界";
+  const glyphBytes = Buffer.byteLength(glyph, "utf8");
+  const glyphCount = Math.floor(bytes / glyphBytes);
+  return `${glyph.repeat(glyphCount)}${"x".repeat(bytes - glyphCount * glyphBytes)}`;
+};
+
+type SizeCase = {
+  name: string;
+  request: unknown;
+  legacyResponse: unknown;
+  receipt: unknown;
+  duplicatedInputBytes: number;
+};
+
+function sizeCases(): SizeCase[] {
+  const large32KiB = exactUtf8String(32 * 1024);
+  const memoryText = exactUtf8String(4_000);
+  const rigCommand = exactUtf8String(8_192);
+  const rigNote = exactUtf8String(2_000);
+
+  const sessionRequest = {
+    initialMessage: large32KiB,
+    instructions: large32KiB,
+    model: "gpt-5-codex",
+  };
+  const sessionLegacy = {
+    id: ID,
+    workspaceId: RELATED_ID,
+    initialMessage: sessionRequest.initialMessage,
+    instructions: sessionRequest.instructions,
+    resources: [],
+    tools: [],
+    metadata: { model: sessionRequest.model },
+    model: sessionRequest.model,
+    status: "queued",
+    queueVersion: 1,
+    temporalWorkflowId: `session-${ID}`,
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  };
+  const sessionReceipt = mcpMutationReceipt({
+    operation: "session_create",
+    committed: true,
+    outcome: "created",
+    changed: true,
+    resource: { type: "session", id: ID, version: 1, state: "queued" },
+    timestamp: TIMESTAMP,
+    idempotency: { status: "not_requested" },
+    facts: { sandboxGroupId: ID, parentSessionId: null },
+    nextAction: { tool: "session_get", arguments: { sessionId: ID } },
+  });
+
+  const scheduledRequest = {
+    name: "pathological scheduled task",
+    schedule: { type: "interval", everySeconds: 3600 },
+    agentConfig: {
+      prompt: large32KiB,
+      resources: Array.from({ length: 100 }, (_, index) => ({
+        kind: "repository",
+        id: `${ID}:${index}`,
+        name: exactUtf8String(200),
+      })),
+      tools: Array.from({ length: 100 }, (_, index) => ({
+        kind: "mcp",
+        name: `tool-${index}-${exactUtf8String(200)}`,
+      })),
+    },
+    metadata: Object.fromEntries(
+      Array.from({ length: 100 }, (_, index) => [`key-${index}`, exactUtf8String(200)]),
+    ),
+  };
+  const scheduledLegacy = {
+    id: ID,
+    workspaceId: RELATED_ID,
+    ...scheduledRequest,
+    status: "active",
+    runMode: "fresh_session",
+    overlapPolicy: "skip",
+    temporalScheduleId: `scheduled-task-${ID}`,
+    version: 1,
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  };
+  const scheduledReceipt = mcpMutationReceipt({
+    operation: "scheduled_tasks_create",
+    committed: true,
+    outcome: "created",
+    changed: true,
+    resource: { type: "scheduled_task", id: ID, version: 1, state: "active" },
+    timestamp: TIMESTAMP,
+    idempotency: { status: "not_supported" },
+    nextAction: { tool: "scheduled_tasks_get", arguments: { id: ID } },
+  });
+
+  const goalRequest = { text: large32KiB, evidence: large32KiB, rationale: large32KiB };
+  const goalLegacy = {
+    id: ID,
+    sessionId: RELATED_ID,
+    status: "completed",
+    ...goalRequest,
+    successCriteria: large32KiB,
+    version: 4,
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  };
+  const goalReceipt = mcpMutationReceipt({
+    operation: "goal_complete",
+    committed: true,
+    outcome: "updated",
+    changed: true,
+    resource: { type: "session_goal", id: ID, version: 4, state: "completed" },
+    timestamp: TIMESTAMP,
+    idempotency: { status: "not_supported" },
+    nextAction: { tool: "session_get", arguments: { sessionId: RELATED_ID } },
+  });
+
+  const memoryRequest = { text: memoryText, kind: "semantic", confidence: 0.9 };
+  const memoryLegacy = {
+    memory: {
+      id: ID,
+      workspaceId: RELATED_ID,
+      status: "active",
+      ...memoryRequest,
+      scope: "workspace",
+      sourceRefs: [],
+      metadata: { origin: "agent" },
+      createdAt: TIMESTAMP,
+      updatedAt: TIMESTAMP,
+    },
+    deduped: false,
+  };
+  const memoryReceipt = mcpMutationReceipt({
+    operation: "memory_save",
+    committed: true,
+    outcome: "created",
+    changed: true,
+    resource: { type: "knowledge_memory", id: ID, state: "active" },
+    timestamp: TIMESTAMP,
+    idempotency: { status: "not_supported" },
+    facts: { deduped: false },
+    nextAction: { tool: "memory_search", arguments: { query: ID } },
+  });
+
+  const rigRequest = { rigId: RELATED_ID, command: rigCommand, note: rigNote };
+  const rigLegacy = {
+    change: {
+      id: ID,
+      rigId: RELATED_ID,
+      kind: "setup_append",
+      payload: { command: rigCommand, note: rigNote },
+      status: "verifying",
+      proposedBy: "session:test",
+      createdAt: TIMESTAMP,
+      updatedAt: TIMESTAMP,
+    },
+    verificationStarted: true,
+  };
+  const rigReceipt = mcpMutationReceipt({
+    operation: "rig_propose_change",
+    committed: true,
+    outcome: "created",
+    changed: true,
+    resource: { type: "rig_change", id: ID, version: TIMESTAMP, state: "verifying" },
+    relatedResources: [{ type: "rig", id: RELATED_ID }],
+    timestamp: TIMESTAMP,
+    idempotency: { status: "not_supported" },
+    facts: { verificationStarted: true, verificationAttempt: 1 },
+    nextAction: { tool: "rig_get", arguments: { rigId: RELATED_ID } },
+  });
+
+  return [
+    {
+      name: "session_create",
+      request: sessionRequest,
+      legacyResponse: sessionLegacy,
+      receipt: sessionReceipt,
+      duplicatedInputBytes:
+        Buffer.byteLength(sessionRequest.initialMessage, "utf8") +
+        Buffer.byteLength(sessionRequest.instructions, "utf8"),
+    },
+    {
+      name: "scheduled_tasks_create",
+      request: scheduledRequest,
+      legacyResponse: scheduledLegacy,
+      receipt: scheduledReceipt,
+      duplicatedInputBytes:
+        utf8Bytes(scheduledRequest.agentConfig) + utf8Bytes(scheduledRequest.metadata),
+    },
+    {
+      name: "goal_complete",
+      request: goalRequest,
+      legacyResponse: goalLegacy,
+      receipt: goalReceipt,
+      duplicatedInputBytes:
+        Buffer.byteLength(goalRequest.text, "utf8") +
+        Buffer.byteLength(goalRequest.evidence, "utf8") +
+        Buffer.byteLength(goalRequest.rationale, "utf8"),
+    },
+    {
+      name: "memory_save",
+      request: memoryRequest,
+      legacyResponse: memoryLegacy,
+      receipt: memoryReceipt,
+      duplicatedInputBytes: Buffer.byteLength(memoryRequest.text, "utf8"),
+    },
+    {
+      name: "rig_propose_change",
+      request: rigRequest,
+      legacyResponse: rigLegacy,
+      receipt: rigReceipt,
+      duplicatedInputBytes:
+        Buffer.byteLength(rigRequest.command, "utf8") + Buffer.byteLength(rigRequest.note, "utf8"),
+    },
+  ];
+}
+
+describe("MCP receipt response size", () => {
+  test("removes pathological request echoes from mutation results", () => {
+    for (const fixture of sizeCases()) {
+      const legacyBytes = utf8Bytes(fixture.legacyResponse);
+      const receiptBytes = utf8Bytes(fixture.receipt);
+      expect(receiptBytes).toBeLessThan(legacyBytes * 0.15);
+      expect(JSON.stringify(fixture.receipt)).not.toContain(exactUtf8String(256));
+      expect(fixture.duplicatedInputBytes).toBeGreaterThan(receiptBytes);
+    }
+  });
+
+  test("shrinks the same session result in model history, events, and realtime transport", () => {
+    const session = sizeCases()[0]!;
+    const projections = (result: unknown) => ({
+      modelHistory: { role: "tool", content: JSON.stringify(result) },
+      event: { type: "agent.toolCall.output", payload: { output: result } },
+      realtime: `event: session.event\ndata: ${JSON.stringify({ output: result })}\n\n`,
+    });
+    const legacy = projections(session.legacyResponse);
+    const receipt = projections(session.receipt);
+    for (const surface of ["modelHistory", "event", "realtime"] as const) {
+      expect(utf8Bytes(receipt[surface])).toBeLessThan(utf8Bytes(legacy[surface]) * 0.02);
+    }
+  });
+
+  test("the maximum contract-shaped receipt remains below the canonical 64 KiB envelope", () => {
+    const maximum = mcpMutationReceipt({
+      operation: "x".repeat(128),
+      committed: true,
+      outcome: "partial_failure",
+      changed: true,
+      resource: {
+        type: "x".repeat(128),
+        id: "x".repeat(256),
+        version: "x".repeat(128),
+        etag: "x".repeat(512),
+        state: "x".repeat(128),
+      },
+      relatedResources: Array.from({ length: 8 }, (_, index) => ({
+        type: "x".repeat(128),
+        id: `${index}${"x".repeat(255)}`,
+        version: "x".repeat(128),
+        etag: "x".repeat(512),
+        state: "x".repeat(128),
+      })),
+      timestamp: TIMESTAMP,
+      idempotency: { status: "not_supported" },
+      partialFailure: { stage: "x".repeat(128), retryable: true },
+      warnings: Array.from({ length: 20 }, () => "x".repeat(512)),
+      facts: Object.fromEntries(
+        Array.from({ length: 16 }, (_, index) => [`fact${index}`, "x".repeat(512)]),
+      ),
+      nextAction: {
+        tool: "x".repeat(128),
+        arguments: Object.fromEntries(
+          Array.from({ length: 8 }, (_, index) => [`arg${index}`, "x".repeat(512)]),
+        ),
+      },
+    });
+    expect(utf8Bytes(maximum)).toBeLessThanOrEqual(64 * 1024);
+  });
+});
+
+export function measuredReceiptSizes(): Array<{
+  name: string;
+  requestBytes: number;
+  duplicatedInputBytes: number;
+  legacyBytes: number;
+  receiptBytes: number;
+  approximateLegacyTokens: number;
+  approximateReceiptTokens: number;
+  reductionPercent: number;
+}> {
+  return sizeCases().map((fixture) => {
+    const legacyBytes = utf8Bytes(fixture.legacyResponse);
+    const receiptBytes = utf8Bytes(fixture.receipt);
+    return {
+      name: fixture.name,
+      requestBytes: utf8Bytes(fixture.request),
+      duplicatedInputBytes: fixture.duplicatedInputBytes,
+      legacyBytes,
+      receiptBytes,
+      approximateLegacyTokens: Math.ceil(legacyBytes / 4),
+      approximateReceiptTokens: Math.ceil(receiptBytes / 4),
+      reductionPercent: Number((((legacyBytes - receiptBytes) / legacyBytes) * 100).toFixed(2)),
+    };
+  });
+}
+
+export function measuredProjectionSizes(): Array<{
+  surface: "modelHistory" | "event" | "realtime";
+  legacyBytes: number;
+  receiptBytes: number;
+  reductionPercent: number;
+}> {
+  const session = sizeCases()[0]!;
+  const projections = (result: unknown) => ({
+    modelHistory: { role: "tool", content: JSON.stringify(result) },
+    event: { type: "agent.toolCall.output", payload: { output: result } },
+    realtime: `event: session.event\ndata: ${JSON.stringify({ output: result })}\n\n`,
+  });
+  const legacy = projections(session.legacyResponse);
+  const receipt = projections(session.receipt);
+  return (["modelHistory", "event", "realtime"] as const).map((surface) => {
+    const legacyBytes = utf8Bytes(legacy[surface]);
+    const receiptBytes = utf8Bytes(receipt[surface]);
+    return {
+      surface,
+      legacyBytes,
+      receiptBytes,
+      reductionPercent: Number((((legacyBytes - receiptBytes) / legacyBytes) * 100).toFixed(2)),
+    };
+  });
+}
+
+if (process.env.OPENGENI_PRINT_MCP_RECEIPT_SIZES === "1") {
+  console.table(measuredReceiptSizes());
+  console.table(measuredProjectionSizes());
+}

--- a/apps/api/test/mcp-receipts.test.ts
+++ b/apps/api/test/mcp-receipts.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { mcpMutationReceipt } from "../src/mcp/receipts";
+
+describe("first-party MCP receipt builder", () => {
+  test("defaults version, timestamp, and warnings without echoing mutation input", () => {
+    const receipt = mcpMutationReceipt({
+      operation: "goal_set",
+      committed: true,
+      outcome: "created",
+      changed: true,
+      resource: {
+        type: "session_goal",
+        id: "00000000-0000-4000-8000-000000000001",
+        version: 1,
+        state: "active",
+      },
+      idempotency: { status: "not_supported" },
+      nextAction: {
+        tool: "session_get",
+        arguments: { sessionId: "00000000-0000-4000-8000-000000000002" },
+      },
+    });
+
+    expect(receipt).toMatchObject({
+      receiptVersion: "mcp-mutation-receipt.v1",
+      operation: "goal_set",
+      warnings: [],
+    });
+    expect(new Date(receipt.timestamp).toISOString()).toBe(receipt.timestamp);
+    expect(JSON.stringify(receipt)).not.toContain("successCriteria");
+  });
+
+  test("fails closed when a handler attempts to add a full entity", () => {
+    expect(() =>
+      mcpMutationReceipt({
+        operation: "memory_save",
+        committed: true,
+        outcome: "created",
+        changed: true,
+        resource: { type: "memory", id: "00000000-0000-4000-8000-000000000003" },
+        idempotency: { status: "not_supported" },
+        // The cast models an accidental handler extension across a dynamic seam.
+        entity: { text: "must not enter the receipt" },
+      } as Parameters<typeof mcpMutationReceipt>[0]),
+    ).toThrow();
+  });
+});

--- a/apps/api/test/mcp-receipts.test.ts
+++ b/apps/api/test/mcp-receipts.test.ts
@@ -12,6 +12,9 @@ const sessionCreateResult = {
     status: "queued",
     sandboxGroupId: "00000000-0000-4000-8000-000000000004",
     parentSessionId: null,
+    rootSessionId: "00000000-0000-4000-8000-000000000004",
+    nestedAgentDepth: 0,
+    effectiveMaxNestedAgentDepth: 3,
   },
   outcome: "created",
   changed: true,
@@ -73,6 +76,10 @@ describe("first-party MCP receipt builder", () => {
       changed: true,
       idempotency: { status: "applied" },
       facts: { sessionCreateOutcome: "repaired" },
+      id: sessionCreateResult.session.id,
+      rootSessionId: sessionCreateResult.session.rootSessionId,
+      nestedAgentDepth: 0,
+      effectiveMaxNestedAgentDepth: 3,
     });
   });
 

--- a/apps/api/test/mcp-receipts.test.ts
+++ b/apps/api/test/mcp-receipts.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, test } from "bun:test";
-import { mcpMutationReceipt } from "../src/mcp/receipts";
+import {
+  mcpMutationReceipt,
+  sessionCreateMutationReceipt,
+  type SessionCreateReceiptResult,
+} from "../src/mcp/receipts";
+
+const sessionCreateResult = {
+  session: {
+    id: "00000000-0000-4000-8000-000000000004",
+    queueVersion: 1,
+    status: "queued",
+    sandboxGroupId: "00000000-0000-4000-8000-000000000004",
+    parentSessionId: null,
+  },
+  outcome: "created",
+  changed: true,
+  usageRecording: "recorded",
+} satisfies SessionCreateReceiptResult;
 
 describe("first-party MCP receipt builder", () => {
   test("defaults version, timestamp, and warnings without echoing mutation input", () => {
@@ -43,5 +60,85 @@ describe("first-party MCP receipt builder", () => {
         entity: { text: "must not enter the receipt" },
       } as Parameters<typeof mcpMutationReceipt>[0]),
     ).toThrow();
+  });
+
+  test("maps an applied session repair separately from a replay", () => {
+    expect(
+      sessionCreateMutationReceipt(
+        { ...sessionCreateResult, outcome: "repaired", changed: true },
+        true,
+      ),
+    ).toMatchObject({
+      outcome: "repaired",
+      changed: true,
+      idempotency: { status: "applied" },
+      facts: { sessionCreateOutcome: "repaired" },
+    });
+  });
+
+  test("makes a committed keyless usage failure explicitly non-retryable", () => {
+    expect(
+      sessionCreateMutationReceipt({ ...sessionCreateResult, usageRecording: "failed" }, false),
+    ).toMatchObject({
+      committed: true,
+      outcome: "partial_failure",
+      changed: true,
+      idempotency: { status: "not_requested" },
+      partialFailure: { stage: "usage_recording", retryable: false },
+      warnings: [expect.stringContaining("Do not retry this keyless request")],
+    });
+  });
+
+  test("preserves pure replay truth when keyed usage recording also fails", () => {
+    expect(
+      sessionCreateMutationReceipt({ ...sessionCreateResult, usageRecording: "failed" }, true),
+    ).toMatchObject({
+      committed: true,
+      outcome: "partial_failure",
+      changed: true,
+      idempotency: { status: "applied" },
+      partialFailure: { stage: "usage_recording", retryable: true },
+      warnings: [expect.stringContaining("same idempotency key")],
+      facts: { sessionCreateOutcome: "created" },
+    });
+
+    expect(
+      sessionCreateMutationReceipt(
+        {
+          ...sessionCreateResult,
+          outcome: "repaired",
+          changed: true,
+          usageRecording: "failed",
+        },
+        true,
+      ),
+    ).toMatchObject({
+      committed: true,
+      outcome: "partial_failure",
+      changed: true,
+      idempotency: { status: "applied" },
+      partialFailure: { stage: "usage_recording", retryable: true },
+      facts: { sessionCreateOutcome: "repaired" },
+    });
+
+    expect(
+      sessionCreateMutationReceipt(
+        {
+          ...sessionCreateResult,
+          outcome: "replayed",
+          changed: false,
+          usageRecording: "failed",
+        },
+        true,
+      ),
+    ).toMatchObject({
+      committed: true,
+      outcome: "partial_failure",
+      changed: false,
+      idempotency: { status: "replayed" },
+      partialFailure: { stage: "usage_recording", retryable: true },
+      warnings: [expect.stringContaining("same idempotency key")],
+      facts: { sessionCreateOutcome: "replayed" },
+    });
   });
 });

--- a/apps/api/test/rigs-mcp.test.ts
+++ b/apps/api/test/rigs-mcp.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import type { AccessGrant, McpMutationReceiptType, Permission } from "@opengeni/contracts";
+import type { AccessGrant, Permission } from "@opengeni/contracts";
 import {
   bootstrapWorkspace,
   createDb,

--- a/apps/api/test/rigs-mcp.test.ts
+++ b/apps/api/test/rigs-mcp.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import type { AccessGrant, Permission } from "@opengeni/contracts";
+import type { AccessGrant, McpMutationReceiptType, Permission } from "@opengeni/contracts";
 import {
   bootstrapWorkspace,
   createDb,
@@ -110,16 +110,22 @@ describe("rig MCP tools", () => {
       command: "touch /opt/mcp/tool",
       note: "mcp proposal",
     });
-    expect(proposed.change.status).toBe("verifying");
-    expect(proposed.verificationStarted).toBe(true);
+    expect(proposed).toMatchObject({
+      operation: "rig_propose_change",
+      outcome: "created",
+      resource: { type: "rig_change", state: "verifying" },
+      facts: { verificationStarted: true, verificationAttempt: 1 },
+    });
+    expect(JSON.stringify(proposed)).not.toContain("touch /opt/mcp/tool");
+    expect(JSON.stringify(proposed)).not.toContain("mcp proposal");
     expect(workflow.rigVerifications).toEqual([
       {
         workspaceId,
-        changeId: proposed.change.id,
-        workflowId: `rig-verification-change-${proposed.change.id}-attempt-1`,
+        changeId: proposed.resource.id,
+        workflowId: `rig-verification-change-${proposed.resource.id}-attempt-1`,
       },
     ]);
-    const stored = await getRigChange(client.db, workspaceId, proposed.change.id);
+    const stored = await getRigChange(client.db, workspaceId, proposed.resource.id);
     expect(stored?.kind).toBe("setup_append");
     expect(stored?.proposedBy).toBe(`session:${sessionId}`);
   });

--- a/apps/api/test/scheduled-task-view.test.ts
+++ b/apps/api/test/scheduled-task-view.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import type { ScheduledTask } from "@opengeni/contracts";
+import type { ScheduledTask, ScheduledTaskScheduleSpec } from "@opengeni/contracts";
 import {
   boundScheduledTaskDetailMcp,
   boundScheduledTaskMcpPage,
+  projectScheduledTaskSchedule,
   SCHEDULED_TASK_MCP_MAX_BYTES,
+  SCHEDULED_TASK_SCHEDULE_FIELD_MAX_BYTES,
   scheduledTaskMcpSummary,
 } from "../src/mcp/scheduled-task-view";
 
@@ -35,6 +37,14 @@ function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
   };
 }
 
+function prettyBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value, null, 2), "utf8");
+}
+
+function expectNoInvalidUtf8(value: unknown): void {
+  expect(JSON.stringify(value)).not.toContain("�");
+}
+
 describe("scheduled-task MCP views", () => {
   test("summaries replace prompts and metadata values with exact byte/count facts", () => {
     const secretMarker = `must-not-echo-${crypto.randomUUID()}`;
@@ -56,6 +66,90 @@ describe("scheduled-task MCP views", () => {
     expect(serialized).not.toContain(secretMarker);
     expect(summary.configuration.metadataKeyCount).toBe(1);
     expect(summary.configuration.taskMetadataKeyCount).toBe(1);
+    expect(summary.projection.bytes).toBe(prettyBytes(summary));
+    expect(summary.projection.bytes).toBeLessThanOrEqual(SCHEDULED_TASK_MCP_MAX_BYTES);
+  });
+
+  test("every request-controlled schedule string has a typed exact UTF-8 projection", () => {
+    const huge = "界".repeat(100_000);
+    const schedules: ScheduledTaskScheduleSpec[] = [
+      { type: "once", runAt: huge, timeZone: huge },
+      { type: "interval", everySeconds: 60, startAt: huge, endAt: huge },
+      { type: "calendar", timeZone: huge, hour: 1, minute: 2, daysOfWeek: ["MONDAY"] },
+    ];
+
+    for (const schedule of schedules) {
+      const projected = projectScheduledTaskSchedule(schedule);
+      expect(projected.projection.type).toBe(schedule.type);
+      expect(projected.projection.truncated).toBeTrue();
+      for (const fact of Object.values(projected.projection.fields)) {
+        if (!fact) continue;
+        expect(fact.originalBytes).toBe(Buffer.byteLength(huge, "utf8"));
+        expect(fact.deliveredBytes).toBeLessThanOrEqual(SCHEDULED_TASK_SCHEDULE_FIELD_MAX_BYTES);
+        expect(fact.truncated).toBeTrue();
+      }
+      expectNoInvalidUtf8(projected);
+    }
+  });
+
+  test("default summary, list, and explicit detail stay deterministic under pathological schedule strings", () => {
+    const fixtures = [
+      { label: "100k ASCII", value: "x".repeat(100_000) },
+      { label: "100k multibyte", value: "界".repeat(100_000) },
+      { label: "JSON escape expansion", value: '"\\\u0000\n\t'.repeat(20_000) },
+    ];
+
+    for (const fixture of fixtures) {
+      const source = task({
+        schedule: {
+          type: "once",
+          runAt: "2026-08-06T00:00:00.000Z",
+          timeZone: fixture.value,
+        },
+      });
+
+      const summary = scheduledTaskMcpSummary(source);
+      const repeatedSummary = scheduledTaskMcpSummary(source);
+      expect(summary, fixture.label).toEqual(repeatedSummary);
+      expect(summary.projection.bytes, fixture.label).toBe(prettyBytes(summary));
+      expect(summary.projection.bytes, fixture.label).toBeLessThanOrEqual(
+        SCHEDULED_TASK_MCP_MAX_BYTES,
+      );
+      expect(summary.schedule.type).toBe("once");
+      if (summary.schedule.type !== "once" || summary.projection.schedule.type !== "once") {
+        throw new Error(`unexpected projected schedule for ${fixture.label}`);
+      }
+      expect(summary.schedule.timeZone, fixture.label).not.toBe(fixture.value);
+      expect(summary.projection.schedule.fields.timeZone, fixture.label).toMatchObject({
+        originalBytes: Buffer.byteLength(fixture.value, "utf8"),
+        deliveredBytes: Buffer.byteLength(summary.schedule.timeZone, "utf8"),
+        truncated: true,
+      });
+
+      const page = boundScheduledTaskMcpPage({
+        tasks: [source],
+        limit: 25,
+        offset: 0,
+        sourceHasMore: false,
+      });
+      expect(page.tasks, fixture.label).toHaveLength(1);
+      expect(page.projection.bytes, fixture.label).toBe(prettyBytes(page));
+      expect(page.projection.bytes, fixture.label).toBeLessThanOrEqual(
+        SCHEDULED_TASK_MCP_MAX_BYTES,
+      );
+
+      const detail = boundScheduledTaskDetailMcp(source);
+      const repeatedDetail = boundScheduledTaskDetailMcp(source);
+      expect(detail, fixture.label).toEqual(repeatedDetail);
+      expect(detail.detailProjection.terminal, fixture.label).toBeFalse();
+      expect(detail.detailProjection.bytes, fixture.label).toBe(prettyBytes(detail));
+      expect(detail.detailProjection.bytes, fixture.label).toBeLessThanOrEqual(
+        SCHEDULED_TASK_MCP_MAX_BYTES,
+      );
+      expectNoInvalidUtf8(summary);
+      expectNoInvalidUtf8(page);
+      expectNoInvalidUtf8(detail);
+    }
   });
 
   test("explicit detail is deterministic and bounded for pathological multibyte input", () => {
@@ -90,7 +184,8 @@ describe("scheduled-task MCP views", () => {
     const second = boundScheduledTaskDetailMcp(source);
     const serialized = JSON.stringify(first, null, 2);
     expect(first).toEqual(second);
-    expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(SCHEDULED_TASK_MCP_MAX_BYTES);
+    expect(first.detailProjection.bytes).toBe(Buffer.byteLength(serialized, "utf8"));
+    expect(first.detailProjection.bytes).toBeLessThanOrEqual(SCHEDULED_TASK_MCP_MAX_BYTES);
     expect(first.detailProjection.prompt.truncated).toBeTrue();
     expect(first.detailProjection.prompt.originalBytes).toBe(
       Buffer.byteLength(source.agentConfig.prompt, "utf8"),
@@ -102,7 +197,7 @@ describe("scheduled-task MCP views", () => {
     expect(first.detailProjection.metadata.valuesIncluded).toBeFalse();
     expect(serialized).not.toContain("PROMPT-TAIL");
     expect(serialized).not.toContain(huge);
-    expect(serialized).not.toContain("�");
+    expectNoInvalidUtf8(first);
   });
 
   test("list pages expose continuation without returning an over-limit row", () => {
@@ -118,7 +213,73 @@ describe("scheduled-task MCP views", () => {
 
     expect(page.tasks).toHaveLength(2);
     expect(page.page).toEqual({ limit: 2, offset: 10, hasMore: true, nextOffset: 12 });
-    expect(page.projection.bytes).toBe(Buffer.byteLength(JSON.stringify(page, null, 2), "utf8"));
+    expect(page.projection).toMatchObject({
+      rowsDroppedForBytes: false,
+      droppedRowCount: 0,
+      sourceRowsConsumed: 2,
+      rowsReturned: 2,
+    });
+    expect(page.projection.bytes).toBe(prettyBytes(page));
     expect(page.projection.bytes).toBeLessThanOrEqual(SCHEDULED_TASK_MCP_MAX_BYTES);
+  });
+
+  test("a sole byte-dropped row advances past the consumed source row", () => {
+    const escaped = "\u0000".repeat(100_000);
+    const source = task({
+      name: escaped,
+      schedule: {
+        type: "calendar",
+        timeZone: escaped,
+        hour: 0,
+        minute: 0,
+      },
+      agentConfig: {
+        prompt: "inspect",
+        resources: [],
+        tools: [],
+        metadata: {},
+        model: escaped,
+      },
+      createdAt: escaped,
+      updatedAt: escaped,
+    });
+    const page = boundScheduledTaskMcpPage({
+      tasks: [source],
+      limit: 1,
+      offset: 41,
+      sourceHasMore: false,
+      maxBytes: 8 * 1024,
+    });
+
+    expect(page.tasks).toHaveLength(0);
+    expect(page.page).toEqual({ limit: 1, offset: 41, hasMore: true, nextOffset: 42 });
+    expect(page.projection).toMatchObject({
+      rowsDroppedForBytes: true,
+      droppedRowCount: 1,
+      sourceRowsConsumed: 1,
+      rowsReturned: 0,
+      terminal: false,
+      droppedRows: [
+        {
+          id: source.id,
+          nextAction: {
+            tool: "scheduled_tasks_get",
+            arguments: { id: source.id, includeEntity: false },
+          },
+        },
+      ],
+    });
+    expect(page.projection.bytes).toBe(prettyBytes(page));
+    expect(page.projection.bytes).toBeLessThanOrEqual(8 * 1024);
+    expectNoInvalidUtf8(page);
+
+    const next = boundScheduledTaskMcpPage({
+      tasks: [],
+      limit: 1,
+      offset: page.page.nextOffset!,
+      sourceHasMore: false,
+      maxBytes: 8 * 1024,
+    });
+    expect(next.page).toEqual({ limit: 1, offset: 42, hasMore: false, nextOffset: null });
   });
 });

--- a/apps/api/test/scheduled-task-view.test.ts
+++ b/apps/api/test/scheduled-task-view.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import type { ScheduledTask } from "@opengeni/contracts";
+import {
+  boundScheduledTaskDetailMcp,
+  boundScheduledTaskMcpPage,
+  SCHEDULED_TASK_MCP_MAX_BYTES,
+  scheduledTaskMcpSummary,
+} from "../src/mcp/scheduled-task-view";
+
+function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: crypto.randomUUID(),
+    accountId: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    name: "Daily analysis",
+    status: "active",
+    schedule: { type: "interval", everySeconds: 3600 },
+    temporalScheduleId: `schedule-${crypto.randomUUID()}`,
+    runMode: "new_session_per_run",
+    overlapPolicy: "allow_concurrent",
+    agentConfig: {
+      prompt: "Inspect activity",
+      resources: [],
+      tools: [],
+      metadata: {},
+    },
+    reusableSessionId: null,
+    variableSetId: null,
+    environmentId: null,
+    rigId: null,
+    metadata: {},
+    createdAt: "2026-07-20T00:00:00.000Z",
+    updatedAt: "2026-07-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("scheduled-task MCP views", () => {
+  test("summaries replace prompts and metadata values with exact byte/count facts", () => {
+    const secretMarker = `must-not-echo-${crypto.randomUUID()}`;
+    const source = task({
+      agentConfig: {
+        prompt: `界🙂${secretMarker}`,
+        resources: [],
+        tools: [],
+        metadata: { privateValue: secretMarker },
+      },
+      metadata: { otherPrivateValue: secretMarker },
+    });
+    const summary = scheduledTaskMcpSummary(source);
+    const serialized = JSON.stringify(summary);
+
+    expect(summary.configuration.promptBytes).toBe(
+      Buffer.byteLength(source.agentConfig.prompt, "utf8"),
+    );
+    expect(serialized).not.toContain(secretMarker);
+    expect(summary.configuration.metadataKeyCount).toBe(1);
+    expect(summary.configuration.taskMetadataKeyCount).toBe(1);
+  });
+
+  test("explicit detail is deterministic and bounded for pathological multibyte input", () => {
+    const huge = "界🙂".repeat(20_000);
+    const source = task({
+      name: huge,
+      agentConfig: {
+        prompt: `PROMPT-HEAD-${huge}-PROMPT-TAIL`,
+        resources: Array.from({ length: 100 }, () => ({
+          kind: "repository" as const,
+          uri: `https://example.test/${huge}`,
+          ref: huge,
+        })),
+        tools: Array.from({ length: 100 }, (_, index) => ({
+          kind: "mcp" as const,
+          id: `tool-${index}-${huge}`,
+        })),
+        metadata: Object.fromEntries(
+          Array.from({ length: 100 }, (_, index) => [`key-${index}-${huge}`, huge]),
+        ),
+        goal: {
+          text: `GOAL-HEAD-${huge}`,
+          successCriteria: `CRITERIA-HEAD-${huge}`,
+        },
+      },
+      metadata: Object.fromEntries(
+        Array.from({ length: 100 }, (_, index) => [`task-key-${index}-${huge}`, huge]),
+      ),
+    });
+
+    const first = boundScheduledTaskDetailMcp(source);
+    const second = boundScheduledTaskDetailMcp(source);
+    const serialized = JSON.stringify(first, null, 2);
+    expect(first).toEqual(second);
+    expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(SCHEDULED_TASK_MCP_MAX_BYTES);
+    expect(first.detailProjection.prompt.truncated).toBeTrue();
+    expect(first.detailProjection.prompt.originalBytes).toBe(
+      Buffer.byteLength(source.agentConfig.prompt, "utf8"),
+    );
+    expect(first.detailProjection.resources).toMatchObject({
+      originalCount: 100,
+      deliveredCount: 20,
+    });
+    expect(first.detailProjection.metadata.valuesIncluded).toBeFalse();
+    expect(serialized).not.toContain("PROMPT-TAIL");
+    expect(serialized).not.toContain(huge);
+    expect(serialized).not.toContain("�");
+  });
+
+  test("list pages expose continuation without returning an over-limit row", () => {
+    const source = Array.from({ length: 3 }, (_, index) =>
+      task({ name: `task-${index}`, createdAt: `2026-07-20T00:00:0${index}.000Z` }),
+    );
+    const page = boundScheduledTaskMcpPage({
+      tasks: source.slice(0, 2),
+      limit: 2,
+      offset: 10,
+      sourceHasMore: true,
+    });
+
+    expect(page.tasks).toHaveLength(2);
+    expect(page.page).toEqual({ limit: 2, offset: 10, hasMore: true, nextOffset: 12 });
+    expect(page.projection.bytes).toBe(Buffer.byteLength(JSON.stringify(page, null, 2), "utf8"));
+    expect(page.projection.bytes).toBeLessThanOrEqual(SCHEDULED_TASK_MCP_MAX_BYTES);
+  });
+});

--- a/apps/api/test/session-create-receipts.test.ts
+++ b/apps/api/test/session-create-receipts.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import type { AccessGrant, McpMutationReceiptType } from "@opengeni/contracts";
-import { bootstrapWorkspace, createDb, createSession, type DbClient } from "@opengeni/db";
+import {
+  bootstrapWorkspace,
+  claimSessionWorkForAttempt,
+  createDb,
+  createSession,
+  type DbClient,
+} from "@opengeni/db";
 import type { ApiRouteDeps, SessionWorkflowClient } from "@opengeni/core";
 import {
   acquireSharedTestDatabase,
@@ -116,12 +122,19 @@ async function withUsageInsertRevoked<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-async function markInitialTurnRunning(workspaceId: string, sessionId: string): Promise<void> {
-  await shared!.admin`
-    update session_turns
-    set status = 'running'
-    where workspace_id = ${workspaceId} and session_id = ${sessionId}
-  `;
+async function claimInitialTurnRunning(workspaceId: string, sessionId: string): Promise<void> {
+  const claim = await claimSessionWorkForAttempt(client.db, workspaceId, {
+    sessionId,
+    workflowId: `session-${sessionId}`,
+    workflowRunId: crypto.randomUUID(),
+    attemptId: crypto.randomUUID(),
+    dispatchId: crypto.randomUUID(),
+    trigger: { kind: "next" },
+  });
+  expect(claim).toMatchObject({ action: "claimed" });
+  if (claim.action !== "claimed") {
+    throw new Error(`initial turn was not legally claimed: ${claim.reason}`);
+  }
 }
 
 beforeAll(async () => {
@@ -227,7 +240,16 @@ describe("session_create receipts under FORCE RLS (real PostgreSQL)", () => {
 
     // Once the initial queued turn has advanced, the same key neither repairs
     // start state nor issues another wake and is therefore a true replay.
-    await markInitialTurnRunning(grant.workspaceId, seeded.id);
+    await claimInitialTurnRunning(grant.workspaceId, seeded.id);
+    const afterClaim = await durableCounts(grant.workspaceId, seeded.id);
+    expect(afterClaim).toMatchObject({
+      workspaceSessions: 1,
+      events: 4,
+      turns: 1,
+      wakeRows: 1,
+      wakeRevision: 2,
+      usageEvents: 1,
+    });
     const replayed = await callMcpTool<McpMutationReceiptType>(server, "session_create", args);
     expect(replayed).toMatchObject({
       outcome: "replayed",
@@ -245,7 +267,7 @@ describe("session_create receipts under FORCE RLS (real PostgreSQL)", () => {
       wakeRevision: 2,
       usageEvents: 1,
     });
-    expect(afterReplay.updatedAt.getTime()).toBe(afterRepair.updatedAt.getTime());
+    expect(afterReplay.updatedAt.getTime()).toBe(afterClaim.updatedAt.getTime());
     expect(workflow.wakeups).toHaveLength(2);
   });
 
@@ -321,7 +343,16 @@ describe("session_create receipts under FORCE RLS (real PostgreSQL)", () => {
         partialFailure: { stage: "usage_recording", retryable: true },
         facts: { sessionCreateOutcome: "repaired" },
       });
-      await markInitialTurnRunning(grant.workspaceId, first.resource.id);
+      await claimInitialTurnRunning(grant.workspaceId, first.resource.id);
+      const afterClaim = await durableCounts(grant.workspaceId, first.resource.id);
+      expect(afterClaim).toMatchObject({
+        workspaceSessions: 1,
+        events: 4,
+        turns: 1,
+        wakeRows: 1,
+        wakeRevision: 2,
+        usageEvents: 0,
+      });
       const replay = await callMcpTool<McpMutationReceiptType>(server, "session_create", args);
       expect(replay).toMatchObject({
         committed: true,
@@ -338,7 +369,8 @@ describe("session_create receipts under FORCE RLS (real PostgreSQL)", () => {
       expect(wakeRepair.warnings).toEqual(first.warnings);
       expect(replay.warnings).toEqual(first.warnings);
       expect(workflow.wakeups).toHaveLength(2);
-      expect(await durableCounts(grant.workspaceId, first.resource.id)).toMatchObject({
+      const afterReplay = await durableCounts(grant.workspaceId, first.resource.id);
+      expect(afterReplay).toMatchObject({
         workspaceSessions: 1,
         events: 4,
         turns: 1,
@@ -346,6 +378,7 @@ describe("session_create receipts under FORCE RLS (real PostgreSQL)", () => {
         wakeRevision: 2,
         usageEvents: 0,
       });
+      expect(afterReplay.updatedAt.getTime()).toBe(afterClaim.updatedAt.getTime());
     });
   });
 });

--- a/apps/api/test/session-create-receipts.test.ts
+++ b/apps/api/test/session-create-receipts.test.ts
@@ -1,0 +1,351 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { AccessGrant, McpMutationReceiptType } from "@opengeni/contracts";
+import { bootstrapWorkspace, createDb, createSession, type DbClient } from "@opengeni/db";
+import type { ApiRouteDeps, SessionWorkflowClient } from "@opengeni/core";
+import {
+  acquireSharedTestDatabase,
+  MemoryEventBus,
+  testSettings,
+  type SharedTestDatabase,
+} from "@opengeni/testing";
+import { buildOpenGeniMcpServer } from "../src/mcp/server";
+
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let client: DbClient;
+
+class FakeWorkflowClient {
+  wakeups: unknown[] = [];
+
+  async wakeSessionWorkflow(input: unknown): Promise<void> {
+    this.wakeups.push(input);
+  }
+}
+
+async function freshGrant(): Promise<AccessGrant> {
+  const suffix = crypto.randomUUID();
+  const access = await bootstrapWorkspace(client.db, {
+    accountExternalSource: "session-create-receipts",
+    accountExternalId: `account-${suffix}`,
+    accountName: "Session create receipt account",
+    workspaceExternalSource: "session-create-receipts",
+    workspaceExternalId: `workspace-${suffix}`,
+    workspaceName: "Session create receipt workspace",
+    subjectId: `subject-${suffix}`,
+  });
+  return access.workspaceGrants[0]!;
+}
+
+function buildServer(grant: AccessGrant, workflow: FakeWorkflowClient): unknown {
+  const noop = async () => undefined;
+  return buildOpenGeniMcpServer(
+    {
+      settings: testSettings({ databaseUrl: shared!.appUrl, sandboxBackend: "none" }),
+      db: client.db,
+      bus: new MemoryEventBus(),
+      workflowClient: {
+        signalUserMessage: noop,
+        wakeSessionWorkflow: workflow.wakeSessionWorkflow.bind(workflow),
+        requestSessionWorkflowWakeDispatch: noop,
+        signalApprovalDecision: noop,
+        signalSessionControl: noop,
+        syncScheduledTask: noop,
+        deleteScheduledTaskSchedule: noop,
+        triggerScheduledTask: noop,
+      } as unknown as SessionWorkflowClient,
+      objectStorage: null,
+      githubStateSecret: "test",
+      documentIndexer: { indexDocument: noop },
+      getDocumentServices: () => ({}) as never,
+    } as unknown as ApiRouteDeps,
+    grant,
+  );
+}
+
+async function callMcpTool<T>(
+  server: unknown,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const tool = (
+    server as {
+      _registeredTools?: Record<
+        string,
+        { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+      >;
+    }
+  )._registeredTools?.[name];
+  if (!tool) throw new Error(`MCP tool not registered: ${name}`);
+  const result = await tool.handler(args, {});
+  const text = (result as { content?: Array<{ text?: string }> }).content?.[0]?.text;
+  if (!text) throw new Error(`MCP tool returned no text: ${name}`);
+  return JSON.parse(text) as T;
+}
+
+async function durableCounts(workspaceId: string, sessionId: string) {
+  const [row] = await shared!.admin<
+    Array<{
+      workspaceSessions: number;
+      events: number;
+      turns: number;
+      wakeRows: number;
+      wakeRevision: number;
+      usageEvents: number;
+      updatedAt: Date;
+    }>
+  >`
+    select
+      (select count(*)::int from sessions where workspace_id = ${workspaceId}) as "workspaceSessions",
+      (select count(*)::int from session_events where workspace_id = ${workspaceId} and session_id = ${sessionId}) as events,
+      (select count(*)::int from session_turns where workspace_id = ${workspaceId} and session_id = ${sessionId}) as turns,
+      (select count(*)::int from session_workflow_wake_outbox where workspace_id = ${workspaceId} and session_id = ${sessionId}) as "wakeRows",
+      coalesce((select wake_revision::int from session_workflow_wake_outbox where workspace_id = ${workspaceId} and session_id = ${sessionId}), 0) as "wakeRevision",
+      (select count(*)::int from usage_events where workspace_id = ${workspaceId} and source_resource_id = ${sessionId}) as "usageEvents",
+      (select updated_at from sessions where workspace_id = ${workspaceId} and id = ${sessionId}) as "updatedAt"
+  `;
+  if (!row) throw new Error("durable count query returned no row");
+  return row;
+}
+
+async function withUsageInsertRevoked<T>(fn: () => Promise<T>): Promise<T> {
+  await shared!.admin`revoke insert on table usage_events from opengeni_app`;
+  try {
+    return await fn();
+  } finally {
+    await shared!.admin`grant insert on table usage_events to opengeni_app`;
+  }
+}
+
+async function markInitialTurnRunning(workspaceId: string, sessionId: string): Promise<void> {
+  await shared!.admin`
+    update session_turns
+    set status = 'running'
+    where workspace_id = ${workspaceId} and session_id = ${sessionId}
+  `;
+}
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("session-create-receipts");
+  if (!shared) {
+    if (process.env.OPENGENI_REQUIRE_REAL_DB === "1") {
+      throw new Error("PostgreSQL test database unavailable");
+    }
+    available = false;
+    // eslint-disable-next-line no-console
+    console.warn("[session-create-receipts] docker unavailable, skipping");
+    return;
+  }
+  client = createDb(shared.appUrl, { max: 2 });
+}, 180_000);
+
+afterAll(async () => {
+  await client?.close();
+  await shared?.release();
+}, 60_000);
+
+describe("session_create receipts under FORCE RLS (real PostgreSQL)", () => {
+  test("runs through a non-superuser, non-BYPASSRLS app role on forced tables", async () => {
+    if (!available) return;
+    const [role] = await shared!.admin<Array<{ superuser: boolean; bypassRls: boolean }>>`
+      select rolsuper as superuser, rolbypassrls as "bypassRls"
+      from pg_roles
+      where rolname = 'opengeni_app'
+    `;
+    const forced = await shared!.admin<Array<{ relname: string; forced: boolean }>>`
+      select relname, relforcerowsecurity as forced
+      from pg_class
+      where relname in ('sessions', 'session_events', 'session_turns', 'usage_events')
+      order by relname
+    `;
+    expect(role).toEqual({ superuser: false, bypassRls: false });
+    expect(forced).toHaveLength(4);
+    expect(forced.every((table) => table.forced)).toBeTrue();
+  });
+
+  test("reports keyed state and wake repairs before a pure replay", async () => {
+    if (!available) return;
+    const grant = await freshGrant();
+    const idempotencyKey = `repair-${crypto.randomUUID()}`;
+    const initialMessage = `repair fixture ${crypto.randomUUID()}`;
+    const seeded = await createSession(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage,
+      resources: [],
+      tools: [],
+      metadata: { model: "scripted-model", reasoningEffort: "high" },
+      model: "scripted-model",
+      sandboxBackend: "none",
+      createIdempotencyKey: idempotencyKey,
+    });
+    expect(await durableCounts(grant.workspaceId, seeded.id)).toMatchObject({
+      workspaceSessions: 1,
+      events: 0,
+      turns: 0,
+      wakeRows: 0,
+      wakeRevision: 0,
+    });
+
+    const workflow = new FakeWorkflowClient();
+    const server = buildServer(grant, workflow);
+    const args = {
+      initialMessage,
+      model: "scripted-model",
+      sandboxBackend: "none",
+      idempotencyKey,
+    };
+    const repaired = await callMcpTool<McpMutationReceiptType>(server, "session_create", args);
+    expect(repaired).toMatchObject({
+      operation: "session_create",
+      outcome: "repaired",
+      changed: true,
+      resource: { type: "session", id: seeded.id, state: "queued" },
+      idempotency: { status: "applied" },
+      facts: { sessionCreateOutcome: "repaired" },
+    });
+    const afterRepair = await durableCounts(grant.workspaceId, seeded.id);
+    expect(afterRepair).toMatchObject({
+      workspaceSessions: 1,
+      events: 4,
+      turns: 1,
+      wakeRows: 1,
+      wakeRevision: 1,
+      usageEvents: 1,
+    });
+    expect(workflow.wakeups).toHaveLength(1);
+
+    const wakeRepair = await callMcpTool<McpMutationReceiptType>(server, "session_create", args);
+    expect(wakeRepair).toMatchObject({
+      outcome: "repaired",
+      changed: true,
+      resource: { id: seeded.id },
+      idempotency: { status: "applied" },
+      facts: { sessionCreateOutcome: "repaired" },
+    });
+    expect(workflow.wakeups).toHaveLength(2);
+    expect(await durableCounts(grant.workspaceId, seeded.id)).toMatchObject({ wakeRevision: 2 });
+
+    // Once the initial queued turn has advanced, the same key neither repairs
+    // start state nor issues another wake and is therefore a true replay.
+    await markInitialTurnRunning(grant.workspaceId, seeded.id);
+    const replayed = await callMcpTool<McpMutationReceiptType>(server, "session_create", args);
+    expect(replayed).toMatchObject({
+      outcome: "replayed",
+      changed: false,
+      resource: { id: seeded.id },
+      idempotency: { status: "replayed" },
+      facts: { sessionCreateOutcome: "replayed" },
+    });
+    const afterReplay = await durableCounts(grant.workspaceId, seeded.id);
+    expect(afterReplay).toMatchObject({
+      workspaceSessions: 1,
+      events: 4,
+      turns: 1,
+      wakeRows: 1,
+      wakeRevision: 2,
+      usageEvents: 1,
+    });
+    expect(afterReplay.updatedAt.getTime()).toBe(afterRepair.updatedAt.getTime());
+    expect(workflow.wakeups).toHaveLength(2);
+  });
+
+  test("returns a committed non-retryable receipt when keyless usage recording fails", async () => {
+    if (!available) return;
+    const grant = await freshGrant();
+    const workflow = new FakeWorkflowClient();
+    const server = buildServer(grant, workflow);
+
+    await withUsageInsertRevoked(async () => {
+      const receipt = await callMcpTool<McpMutationReceiptType>(server, "session_create", {
+        initialMessage: `keyless usage failure ${crypto.randomUUID()}`,
+        model: "scripted-model",
+        sandboxBackend: "none",
+      });
+      expect(receipt).toMatchObject({
+        operation: "session_create",
+        committed: true,
+        outcome: "partial_failure",
+        changed: true,
+        resource: { type: "session", state: "queued" },
+        idempotency: { status: "not_requested" },
+        partialFailure: { stage: "usage_recording", retryable: false },
+        facts: { sessionCreateOutcome: "created" },
+        nextAction: { tool: "session_get", arguments: { sessionId: receipt.resource.id } },
+      });
+      expect(receipt.warnings).toEqual([
+        "The session committed, but usage recording failed. Do not retry this keyless request; inspect the returned session.",
+      ]);
+      expect(await durableCounts(grant.workspaceId, receipt.resource.id)).toMatchObject({
+        workspaceSessions: 1,
+        events: 4,
+        turns: 1,
+        wakeRows: 1,
+        wakeRevision: 1,
+        usageEvents: 0,
+      });
+      expect(workflow.wakeups).toHaveLength(1);
+      // Deliberately no keyless retry: the returned receipt says it would be unsafe.
+    });
+  });
+
+  test("keeps a failed keyed usage retry safe and truthful", async () => {
+    if (!available) return;
+    const grant = await freshGrant();
+    const workflow = new FakeWorkflowClient();
+    const server = buildServer(grant, workflow);
+    const idempotencyKey = `usage-failure-${crypto.randomUUID()}`;
+    const args = {
+      initialMessage: `keyed usage failure ${crypto.randomUUID()}`,
+      model: "scripted-model",
+      sandboxBackend: "none",
+      idempotencyKey,
+    };
+
+    await withUsageInsertRevoked(async () => {
+      const first = await callMcpTool<McpMutationReceiptType>(server, "session_create", args);
+      const wakeRepair = await callMcpTool<McpMutationReceiptType>(server, "session_create", args);
+      expect(first).toMatchObject({
+        committed: true,
+        outcome: "partial_failure",
+        changed: true,
+        idempotency: { status: "applied" },
+        partialFailure: { stage: "usage_recording", retryable: true },
+        facts: { sessionCreateOutcome: "created" },
+      });
+      expect(wakeRepair).toMatchObject({
+        committed: true,
+        outcome: "partial_failure",
+        changed: true,
+        resource: { id: first.resource.id },
+        idempotency: { status: "applied" },
+        partialFailure: { stage: "usage_recording", retryable: true },
+        facts: { sessionCreateOutcome: "repaired" },
+      });
+      await markInitialTurnRunning(grant.workspaceId, first.resource.id);
+      const replay = await callMcpTool<McpMutationReceiptType>(server, "session_create", args);
+      expect(replay).toMatchObject({
+        committed: true,
+        outcome: "partial_failure",
+        changed: false,
+        resource: { id: first.resource.id },
+        idempotency: { status: "replayed" },
+        partialFailure: { stage: "usage_recording", retryable: true },
+        facts: { sessionCreateOutcome: "replayed" },
+      });
+      expect(first.warnings).toEqual([
+        "The session committed, but usage recording failed. Retry only with the same idempotency key.",
+      ]);
+      expect(wakeRepair.warnings).toEqual(first.warnings);
+      expect(replay.warnings).toEqual(first.warnings);
+      expect(workflow.wakeups).toHaveLength(2);
+      expect(await durableCounts(grant.workspaceId, first.resource.id)).toMatchObject({
+        workspaceSessions: 1,
+        events: 4,
+        turns: 1,
+        wakeRows: 1,
+        wakeRevision: 2,
+        usageEvents: 0,
+      });
+    });
+  });
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ This map defines who each doc tier serves and where volatile facts belong.
 | Hierarchical workspace memory foundation | `docs/hierarchical-memory.md` | `docs/architecture.md`, DB/domain comments, and future API/runtime/UI slices should link instead of weakening typed-scope RLS, immutable actor evidence, or maintenance-cutover semantics. |
 | Scoped knowledge provenance | `docs/scoped-knowledge.md` | Source/document bridges, future connectors, claim retrieval, and policy/preference materialization should link here instead of weakening fixed authority, ACL intersection, tombstone, legacy non-widening, or proposal-only invariants. |
 | MCP surface selection | `docs/mcp-surfaces.md` | `docs/architecture.md`, `docs/capabilities.md`, `docs/session-mcp-servers.md` should link. |
+| First-party MCP response contracts | `docs/mcp-response-contracts.md` | Mutation handlers, consumer migration notes, and release notes should link instead of restating the receipt schema and tool classification. |
 | Toolspace programmatic tool access | `docs/mcp-surfaces.md`, `docs/architecture.md`; record design in `docs/design/toolspace.md` | Runtime/API/worker comments should link instead of restating security invariants. |
 | Client/server compatibility policy | `docs/architecture.md` §3.10 | `packages/sdk/README.md` links; release notes should link. |
 | Typecheck/lint/format toolchain | `docs/toolchain.md` | `CONTRIBUTING.md` links; other docs should not restate tool choice or version. |

--- a/docs/mcp-response-contracts.md
+++ b/docs/mcp-response-contracts.md
@@ -38,6 +38,10 @@ unbounded.
   "timestamp": "2026-07-20T00:00:00.000Z",
   "idempotency": { "status": "applied" },
   "warnings": [],
+  "id": "11111111-1111-4111-8111-111111111111",
+  "rootSessionId": "11111111-1111-4111-8111-111111111111",
+  "nestedAgentDepth": 0,
+  "effectiveMaxNestedAgentDepth": 3,
   "nextAction": {
     "tool": "session_get",
     "arguments": {
@@ -63,6 +67,8 @@ unbounded.
 | `partialFailure` | Present only for `partial_failure`; names the failed stage and whether retry is safe. |
 | `warnings` | Bounded operational warnings, never request or entity bodies. |
 | `facts` | At most 16 bounded scalar operation facts. Nested entities and arbitrary JSON are forbidden. |
+| `id`, `rootSessionId`, `nestedAgentDepth`, `effectiveMaxNestedAgentDepth` | Required only for `session_create`. These bounded top-level compatibility aliases preserve the generated session identity and immutable descendant-policy lineage without returning the full session. `id` is validated to equal `resource.id`. |
+| `updateId` | Required only for `session_steer`; a bounded compatibility alias validated to equal `resource.id`. |
 | `nextAction` | A safe explicit read/follow-up tool plus at most eight bounded scalar arguments. |
 
 The schema is intentionally strict and intrinsically bounded: resource strings,
@@ -171,11 +177,19 @@ non-model clients and is unchanged.
 ## Compatibility and migration
 
 This is an intentional breaking change for MCP consumers that assumed a
-mutation returned a full entity. The versioned compatibility path is:
+mutation returned a full entity. Small server-authored facts used by existing
+session orchestration remain available as bounded compatibility aliases:
+
+- `session_create` preserves `id`, `rootSessionId`, `nestedAgentDepth`, and
+  `effectiveMaxNestedAgentDepth` at the top level;
+- `session_steer` preserves top-level `updateId`.
+
+The versioned compatibility path is:
 
 1. Detect `receiptVersion === "mcp-mutation-receipt.v1"`.
-2. Read the primary generated identity from `receipt.resource.id`, not a legacy
-   top-level `id`.
+2. Prefer the primary generated identity at `receipt.resource.id`. For
+   `session_create`, the bounded top-level `id` alias remains equal to it for
+   existing orchestration consumers.
 3. Inspect `committed`, `outcome`, `changed`, and `idempotency.status` instead of
    inferring success or replay from an entity body.
 4. When entity details are actually needed, call `receipt.nextAction.tool` or
@@ -197,9 +211,10 @@ instructions into a full session:
 }
 ```
 
-The new result is the receipt shown at the top of this page. Call
-`session_get({sessionId: receipt.resource.id})` when a current session projection
-is needed.
+The new result is the receipt shown at the top of this page. The bounded
+top-level lineage aliases are sufficient to spawn descendants under the same
+depth policy. Call `session_get({sessionId: receipt.resource.id})` when any other
+current session projection is needed.
 
 The REST API is unchanged. The React timeline's worker-reference projection is
 a tolerant reader: it recognizes v1 `resource.type:"session"` receipts and the

--- a/docs/mcp-response-contracts.md
+++ b/docs/mcp-response-contracts.md
@@ -54,8 +54,8 @@ unbounded.
 | `receiptVersion` | Literal `mcp-mutation-receipt.v1`; use this discriminator before reading the rest of the shape. |
 | `operation` | The exact MCP mutation tool that produced the receipt. |
 | `committed` | Whether the mutation truth described by the receipt committed. A returned `partial_failure` is necessarily committed; validation, authorization, conflict, and fully compensated failures are MCP errors instead of `committed:false` receipts. |
-| `outcome` | One of `created`, `updated`, `deleted`, `unchanged`, `accepted`, `triggered`, `replayed`, or `partial_failure`. |
-| `changed` | Whether this invocation applied a new authoritative change. `unchanged` and `replayed` always carry `false`. |
+| `outcome` | One of `created`, `updated`, `deleted`, `unchanged`, `accepted`, `triggered`, `repaired`, `replayed`, or `partial_failure`. |
+| `changed` | Whether this invocation applied a new authoritative change. `repaired` always carries `true`; `unchanged` and `replayed` always carry `false`. |
 | `resource` | Primary server-generated identity: `type`, `id`, and, when authoritative for that resource, `version`, `etag`, and current `state`. |
 | `relatedResources` | At most eight additional generated resource identities needed to interpret the mutation. |
 | `timestamp` | Authoritative resource/update time when available, otherwise receipt creation time. It is an offset-aware ISO-8601 timestamp. |
@@ -67,8 +67,9 @@ unbounded.
 
 The schema is intentionally strict and intrinsically bounded: resource strings,
 warnings, scalar facts, related resources, and next-action arguments all have
-individual size/count limits. The adversarial contract-shaped maximum is tested
-against the 64 KiB model-facing envelope.
+individual UTF-8 byte/count limits. The complete pretty-printed JSON receipt is
+also validated against the canonical 64 KiB model-facing envelope, including
+JSON escape expansion.
 
 ### Replay, no-op, and partial-failure truth
 
@@ -76,6 +77,11 @@ against the 64 KiB model-facing envelope.
   `changed:false`, and `idempotency.status:"replayed"` only when the underlying
   idempotency store reports a replay. In particular, `session_create`, Send, and
   session control do not infer replay merely from a repeated-looking request.
+- **Repair is a change.** A keyed `session_create` that finds a session row but
+  installs missing initial events, turn, or runnable state, or commits a new
+  workflow-wake revision for queued work, is
+  `outcome:"repaired"`, `changed:true`, and `idempotency.status:"applied"`.
+  Only a fully initialized retry that issues no new wake is a pure replay.
 - **No-op is not replay.** An already-paused task, a deduplicated memory write,
   or another mutation that commits no new state can return `unchanged` with the
   applicable non-replay idempotency status.
@@ -85,6 +91,12 @@ against the 64 KiB model-facing envelope.
   a partial failure only when compensation failed and the database mutation
   remains committed. If compensation restores the prior persistence state, the
   operation throws an MCP error instead.
+- **Session usage-recording failure is returned, not thrown.** Session creation
+  and workflow wake have already committed at that point. A keyless receipt is
+  `partialFailure.retryable:false` and says not to retry; a keyed receipt is
+  retryable only with the same idempotency key. A failed usage-recording attempt
+  on a pure keyed retry retains `idempotency.status:"replayed"` and
+  `changed:false` while reporting `outcome:"partial_failure"`.
 - **Noncommit failures remain errors.** Authorization, input validation,
   missing resources, conflicts, and failures before commit preserve their
   existing MCP error behavior. They do not return a success-shaped receipt.

--- a/docs/mcp-response-contracts.md
+++ b/docs/mcp-response-contracts.md
@@ -1,0 +1,237 @@
+# First-party MCP response contracts
+
+Audience: integrators and maintainers of the built-in OpenGeni MCP servers.
+
+OpenGeni's first-party MCP mutation tools return a compact, versioned receipt
+instead of returning the full entity they just created or changed. The caller
+already has the mutation arguments in its tool-call history; returning prompts,
+instructions, commands, evidence, secret values, or other request fields again
+wastes model context and duplicates sensitive data across storage and transport
+surfaces.
+
+This contract applies to the built-in OpenGeni MCP and docs MCP. It does not
+change REST response bodies. Toolspace-proxied tools retain the result contract
+of their selected first-party, capability, or per-session provider.
+
+## Mutation receipt v1
+
+The public schema is `McpMutationReceipt` in
+`packages/contracts/src/mcp-receipts.ts`. API handlers construct receipts through
+`mcpMutationReceipt` in `apps/api/src/mcp/receipts.ts`, which parses the strict
+schema before serializing the result. An accidental full-entity or request-field
+addition therefore fails closed rather than silently making the result
+unbounded.
+
+```json
+{
+  "receiptVersion": "mcp-mutation-receipt.v1",
+  "operation": "session_create",
+  "committed": true,
+  "outcome": "created",
+  "changed": true,
+  "resource": {
+    "type": "session",
+    "id": "11111111-1111-4111-8111-111111111111",
+    "version": 1,
+    "state": "queued"
+  },
+  "timestamp": "2026-07-20T00:00:00.000Z",
+  "idempotency": { "status": "applied" },
+  "warnings": [],
+  "nextAction": {
+    "tool": "session_get",
+    "arguments": {
+      "sessionId": "11111111-1111-4111-8111-111111111111"
+    }
+  }
+}
+```
+
+### Fields and semantics
+
+| Field | Meaning |
+| --- | --- |
+| `receiptVersion` | Literal `mcp-mutation-receipt.v1`; use this discriminator before reading the rest of the shape. |
+| `operation` | The exact MCP mutation tool that produced the receipt. |
+| `committed` | Whether the mutation truth described by the receipt committed. A returned `partial_failure` is necessarily committed; validation, authorization, conflict, and fully compensated failures are MCP errors instead of `committed:false` receipts. |
+| `outcome` | One of `created`, `updated`, `deleted`, `unchanged`, `accepted`, `triggered`, `replayed`, or `partial_failure`. |
+| `changed` | Whether this invocation applied a new authoritative change. `unchanged` and `replayed` always carry `false`. |
+| `resource` | Primary server-generated identity: `type`, `id`, and, when authoritative for that resource, `version`, `etag`, and current `state`. |
+| `relatedResources` | At most eight additional generated resource identities needed to interpret the mutation. |
+| `timestamp` | Authoritative resource/update time when available, otherwise receipt creation time. It is an offset-aware ISO-8601 timestamp. |
+| `idempotency.status` | `not_supported`, `not_requested`, `applied`, `replayed`, or `unknown`. `replayed` is emitted only when the authoritative persistence path says the existing operation was replayed. |
+| `partialFailure` | Present only for `partial_failure`; names the failed stage and whether retry is safe. |
+| `warnings` | Bounded operational warnings, never request or entity bodies. |
+| `facts` | At most 16 bounded scalar operation facts. Nested entities and arbitrary JSON are forbidden. |
+| `nextAction` | A safe explicit read/follow-up tool plus at most eight bounded scalar arguments. |
+
+The schema is intentionally strict and intrinsically bounded: resource strings,
+warnings, scalar facts, related resources, and next-action arguments all have
+individual size/count limits. The adversarial contract-shaped maximum is tested
+against the 64 KiB model-facing envelope.
+
+### Replay, no-op, and partial-failure truth
+
+- **Replay is authoritative.** A retry is `outcome:"replayed"`,
+  `changed:false`, and `idempotency.status:"replayed"` only when the underlying
+  idempotency store reports a replay. In particular, `session_create`, Send, and
+  session control do not infer replay merely from a repeated-looking request.
+- **No-op is not replay.** An already-paused task, a deduplicated memory write,
+  or another mutation that commits no new state can return `unchanged` with the
+  applicable non-replay idempotency status.
+- **Partial failure means partial commit.** The receipt says which stage failed,
+  whether a retry is safe, and what resource identity remains authoritative. A
+  scheduled-task database change followed by failed schedule synchronization is
+  a partial failure only when compensation failed and the database mutation
+  remains committed. If compensation restores the prior persistence state, the
+  operation throws an MCP error instead.
+- **Noncommit failures remain errors.** Authorization, input validation,
+  missing resources, conflicts, and failures before commit preserve their
+  existing MCP error behavior. They do not return a success-shaped receipt.
+
+## Response classification and complete tool matrix
+
+The following is the complete built-in registration inventory. Availability is
+still permission-, deployment-, session-, and Toolspace-mode-dependent.
+
+| Server / tools | Class | Response contract |
+| --- | --- | --- |
+| First-party: `set_session_title` | Mutation | v1 receipt |
+| First-party: `scheduled_tasks_create`, `scheduled_tasks_update`, `scheduled_tasks_pause`, `scheduled_tasks_resume`, `scheduled_tasks_trigger`, `scheduled_tasks_delete` | Mutation | v1 receipt |
+| First-party: `goal_set`, `goal_update`, `goal_complete`, `goal_pause` | Mutation | v1 receipt |
+| First-party: `memory_save`, `memory_correct` | Mutation | v1 receipt |
+| First-party: `rig_propose_change`, `rig_verify`, `rig_promote` | Mutation | v1 receipt |
+| First-party: `session_create`, `session_send_message`, `session_pause`, `session_resume`, `session_steer`, `set_other_session_title` | Mutation | v1 receipt |
+| First-party: `variable_set_set_variable`, deprecated `environment_set_variable` | Mutation | v1 receipt; secret values are never returned |
+| Docs: `memory_propose` | Mutation | v1 receipt |
+| First-party: `files_get_download_url` | Read | Bounded access URL/result required to perform the read; not a redundant entity echo |
+| First-party: `github_repositories_list` | List | Existing bounded list/read result |
+| First-party: `social_connections_list`, `social_posts_recent` | List | Existing bounded list result |
+| First-party: `social_daily_analysis_context` | Read | Existing bounded analysis input projection |
+| First-party: `scheduled_tasks_list` | List | Compact, offset-paginated list result; scheduled-task entity bodies are not returned |
+| First-party: `scheduled_task_runs_list` | List | Existing caller-limited run list; not a redundant mutation echo |
+| First-party: `scheduled_tasks_get` | Read | Compact summary by default; optional explicitly bounded entity projection |
+| First-party: `memory_search` | List/read | Existing bounded search result |
+| First-party: `sandboxes_list` | List | Existing fleet projection |
+| First-party: `rig_list`, `sessions_list`, `variable_set_list`, deprecated `environment_list` | List | Existing compact list projections; variable values are never returned |
+| First-party: `rig_get`, `session_get` | Read | Existing exact-ID, bounded detail projections |
+| First-party: `session_events` | List/read | Existing paginated and byte-bounded monitoring result |
+| Docs: `list_document_bases` | List | Existing document-base list result |
+| Docs: `search_documents`, `knowledge_search`, `memory_search` | List/read | Existing bounded retrieval result |
+| Docs: `fetch_document_chunk`, `knowledge_fetch` | Read | Explicit chunk read result |
+| First-party: `sandbox_attach`, `sandbox_swap` | Action output | The returned routing target and epoch are the essential result of the action, not an echo of the request |
+| First-party: `run_on` | Action output | Essential remote stdout/read/write result |
+| First-party: `sandbox_provision` | Action output | Essential provisioning or human enrollment result |
+| First-party: `github_connect_link` | Action output | Essential short-lived browser/configuration result |
+| First-party: `github_token` | Action output | Essential short-lived credential result; callers must handle it as a secret |
+| Toolspace-proxied tools (dynamic selected tool names) | Provider/selected-tool output | Preserve the selected first-party or upstream provider result; proxy/raw-transfer adaptation is outside this receipt contract |
+
+Reads, lists, and action outputs are not converted into receipts: their result
+contains information the caller did not already provide. This work removes
+redundant mutation echo; it is not a blanket instruction to replace useful tool
+output with acknowledgements.
+
+## Scheduled-task reads
+
+`scheduled_tasks_list` defaults to 25 rows and accepts `limit` up to 50 plus a
+numeric `offset` up to 10,000. It fetches only the requested page plus one row
+for `hasMore`, and returns compact summaries. Prompts, goal text, resources,
+tools, and metadata values are represented by byte/count facts rather than
+serialized in every list row. The complete pretty-printed model result has an
+exact 64 KiB cap; when byte pressure drops rows from the pagination edge,
+`projection.rowsDroppedForBytes`, `page.hasMore`, and `page.nextOffset` preserve
+truthful forward progress.
+
+`scheduled_tasks_get` returns the same summary by default. Passing
+`includeEntity:true` explicitly requests a bounded detail projection:
+
+- prompt preview: at most 8 KiB UTF-8;
+- goal text and success criteria: at most 2 KiB UTF-8 each;
+- resource identities, tool identities, agent metadata keys, and task metadata
+  keys: at most 20 each;
+- metadata values: never included;
+- exact original/delivered byte or count facts and truncation flags; and
+- a complete pretty-printed response no larger than 64 KiB.
+
+The full scheduled-task REST detail contract remains available to authorized
+non-model clients and is unchanged.
+
+## Compatibility and migration
+
+This is an intentional breaking change for MCP consumers that assumed a
+mutation returned a full entity. The versioned compatibility path is:
+
+1. Detect `receiptVersion === "mcp-mutation-receipt.v1"`.
+2. Read the primary generated identity from `receipt.resource.id`, not a legacy
+   top-level `id`.
+3. Inspect `committed`, `outcome`, `changed`, and `idempotency.status` instead of
+   inferring success or replay from an entity body.
+4. When entity details are actually needed, call `receipt.nextAction.tool` or
+   the corresponding explicit bounded get/read tool.
+5. Do not expect request fields to be copied into the result; retain them from
+   the original tool call if the client needs them.
+
+For example, a legacy `session_create` result copied the caller's message and
+instructions into a full session:
+
+```json
+{
+  "id": "11111111-1111-4111-8111-111111111111",
+  "initialMessage": "<32 KiB already present in the tool call>",
+  "instructions": "<32 KiB already present in the tool call>",
+  "status": "queued",
+  "queueVersion": 1,
+  "createdAt": "2026-07-20T00:00:00.000Z"
+}
+```
+
+The new result is the receipt shown at the top of this page. Call
+`session_get({sessionId: receipt.resource.id})` when a current session projection
+is needed.
+
+The REST API is unchanged. The React timeline's worker-reference projection is
+a tolerant reader: it recognizes v1 `resource.type:"session"` receipts and the
+legacy full-session top-level `id` during migration.
+
+## Measured byte and context reduction
+
+The deterministic regression fixture uses production-style pretty-printed JSON
+and UTF-8 byte measurement. Approximate tokens are `ceil(bytes / 4)`; they are a
+coarse comparison, not provider billing truth. Pathological inputs cover two
+32 KiB multibyte session fields, large scheduled prompt/resources/tools/metadata,
+large goal fields, the maximum accepted 4,000-byte memory text, and the maximum
+8,192-byte rig command plus 2,000-byte note.
+
+| Mutation | Request bytes | Duplicated input bytes | Legacy response bytes | Receipt bytes | Approx. legacy tokens | Approx. receipt tokens | Reduction |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `session_create` | 65,610 | 65,536 | 65,998 | 636 | 16,500 | 159 | 99.04% |
+| `scheduled_tasks_create` | 113,758 | 111,596 | 114,123 | 544 | 28,531 | 136 | 99.52% |
+| `goal_complete` | 98,357 | 98,304 | 131,380 | 535 | 32,845 | 134 | 99.59% |
+| `memory_save` | 4,059 | 4,000 | 4,423 | 553 | 1,106 | 139 | 87.50% |
+| `rig_propose_change` | 10,276 | 10,192 | 10,587 | 748 | 2,647 | 187 | 92.93% |
+
+The same smaller serialized mutation result is reused by more than the immediate
+MCP response. It reduces subsequent model tool history, the persisted
+tool-result/event representation, and NATS/SSE/realtime projections:
+
+| Surface | Legacy bytes | Receipt bytes | Reduction |
+| --- | ---: | ---: | ---: |
+| Model history | 66,021 | 613 | 99.07% |
+| Event | 66,134 | 816 | 98.77% |
+| Realtime | 66,031 | 623 | 99.06% |
+
+Canonical measurement: `apps/api/test/mcp-receipt-size.test.ts`.
+
+## Boundaries and residual compatibility risk
+
+- **Universal output-safety boundary:** receipts are intrinsically bounded and the maximum
+  contract-shaped receipt is tested below 64 KiB. Universal output
+  normalization/truncation across arbitrary provider and tool output remains
+  a separate safety layer; compact receipts do not replace it.
+- **Connector/raw-transfer boundary:** this contract does not change
+  `apps/api/src/mcp/toolspace.ts`, runtime connector proxy adaptation,
+  worker/storage attachment transfer, provider wrappers, or raw-byte paths.
+  Those selected/upstream results remain provider-owned.
+- **Compatibility risk:** public MCP behavior is intentionally breaking for
+  third-party clients that parse full mutation entities. Consumers must migrate
+  to `receipt.resource.id` plus explicit reads. REST behavior is unchanged.

--- a/docs/mcp-surfaces.md
+++ b/docs/mcp-surfaces.md
@@ -121,6 +121,8 @@ Rules of thumb:
   as a second GitHub/GitLab/Azure identity.
 
 Details: first-party tools and grants in [architecture.md](architecture.md),
+first-party mutation receipts and read/action response classes in
+[mcp-response-contracts.md](mcp-response-contracts.md),
 per-session servers in [session-mcp-servers.md](session-mcp-servers.md),
 workspace capabilities in [capabilities.md](capabilities.md), credential
 handling in [credentials.md](credentials.md), and the full Toolspace design in

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -37,6 +37,7 @@ export {
 } from "./artifacts";
 
 export {
+  MCP_MUTATION_RECEIPT_MAX_BYTES,
   MCP_MUTATION_RECEIPT_VERSION,
   McpMutationReceipt,
   McpMutationReceiptIdempotencyStatus,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -37,6 +37,18 @@ export {
 } from "./artifacts";
 
 export {
+  MCP_MUTATION_RECEIPT_VERSION,
+  McpMutationReceipt,
+  McpMutationReceiptIdempotencyStatus,
+  McpMutationReceiptOutcome,
+  McpMutationResource,
+  type McpMutationReceipt as McpMutationReceiptType,
+  type McpMutationReceiptIdempotencyStatus as McpMutationReceiptIdempotencyStatusType,
+  type McpMutationReceiptOutcome as McpMutationReceiptOutcomeType,
+  type McpMutationResource as McpMutationResourceType,
+} from "./mcp-receipts";
+
+export {
   SESSION_EVENT_PAYLOAD_MAX_BYTES,
   approximateSessionEventTokens,
   boundSessionEventPayload,

--- a/packages/contracts/src/mcp-receipts.ts
+++ b/packages/contracts/src/mcp-receipts.ts
@@ -127,9 +127,77 @@ export const McpMutationReceipt = z
       .optional(),
     /** Operation-specific outcome facts. Values are deliberately bounded scalars. */
     facts: McpMutationReceiptFacts.optional(),
+    /**
+     * Bounded session_create compatibility aliases. Existing orchestration
+     * consumers use these server-authored lineage facts to spawn descendants
+     * without fetching the full session entity.
+     */
+    id: boundedUtf8String(256, 1).optional(),
+    rootSessionId: boundedUtf8String(256, 1).optional(),
+    nestedAgentDepth: z.number().int().nonnegative().optional(),
+    effectiveMaxNestedAgentDepth: z.number().int().nonnegative().optional(),
+    /** Bounded session_steer compatibility alias for resource.id. */
+    updateId: boundedUtf8String(256, 1).optional(),
   })
   .strict()
   .superRefine((receipt, context) => {
+    const sessionCreateCompatibility = [
+      ["id", receipt.id],
+      ["rootSessionId", receipt.rootSessionId],
+      ["nestedAgentDepth", receipt.nestedAgentDepth],
+      ["effectiveMaxNestedAgentDepth", receipt.effectiveMaxNestedAgentDepth],
+    ] as const;
+    if (receipt.operation === "session_create") {
+      for (const [field, value] of sessionCreateCompatibility) {
+        if (value === undefined) {
+          context.addIssue({
+            code: "custom",
+            path: [field],
+            message: `session_create receipts require ${field}`,
+          });
+        }
+      }
+      if (receipt.id !== undefined && receipt.id !== receipt.resource.id) {
+        context.addIssue({
+          code: "custom",
+          path: ["id"],
+          message: "session_create id must equal resource.id",
+        });
+      }
+    } else {
+      for (const [field, value] of sessionCreateCompatibility) {
+        if (value !== undefined) {
+          context.addIssue({
+            code: "custom",
+            path: [field],
+            message: `${field} is only valid for session_create receipts`,
+          });
+        }
+      }
+    }
+
+    if (receipt.operation === "session_steer") {
+      if (receipt.updateId === undefined) {
+        context.addIssue({
+          code: "custom",
+          path: ["updateId"],
+          message: "session_steer receipts require updateId",
+        });
+      } else if (receipt.updateId !== receipt.resource.id) {
+        context.addIssue({
+          code: "custom",
+          path: ["updateId"],
+          message: "session_steer updateId must equal resource.id",
+        });
+      }
+    } else if (receipt.updateId !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["updateId"],
+        message: "updateId is only valid for session_steer receipts",
+      });
+    }
+
     if (receipt.outcome === "partial_failure") {
       if (!receipt.committed) {
         context.addIssue({

--- a/packages/contracts/src/mcp-receipts.ts
+++ b/packages/contracts/src/mcp-receipts.ts
@@ -1,0 +1,167 @@
+import { z } from "zod";
+
+/**
+ * Versioned, provider-neutral receipt returned by first-party MCP mutation tools.
+ *
+ * A receipt intentionally contains only server-generated identity and outcome
+ * facts. Callers already have mutation inputs in their tool-call history, so
+ * copying names, prompts, instructions, commands, evidence, or other request
+ * fields into the result wastes context and can expose data twice.
+ */
+export const MCP_MUTATION_RECEIPT_VERSION = "mcp-mutation-receipt.v1" as const;
+
+export const McpMutationReceiptOutcome = z.enum([
+  "created",
+  "updated",
+  "deleted",
+  "unchanged",
+  "accepted",
+  "triggered",
+  "replayed",
+  "partial_failure",
+]);
+export type McpMutationReceiptOutcome = z.infer<typeof McpMutationReceiptOutcome>;
+
+export const McpMutationReceiptIdempotencyStatus = z.enum([
+  "not_supported",
+  "not_requested",
+  "applied",
+  "replayed",
+  "unknown",
+]);
+export type McpMutationReceiptIdempotencyStatus = z.infer<
+  typeof McpMutationReceiptIdempotencyStatus
+>;
+
+export const McpMutationResource = z
+  .object({
+    type: z.string().min(1).max(128),
+    id: z.string().min(1).max(256),
+    version: z.union([z.number().int().nonnegative(), z.string().min(1).max(128)]).optional(),
+    etag: z.string().min(1).max(512).optional(),
+    state: z.string().min(1).max(128).optional(),
+  })
+  .strict();
+export type McpMutationResource = z.infer<typeof McpMutationResource>;
+
+const McpMutationReceiptFact = z.union([
+  z.string().max(512),
+  z.number().finite(),
+  z.boolean(),
+  z.null(),
+]);
+
+const McpMutationReceiptFacts = z
+  .record(z.string().min(1).max(64), McpMutationReceiptFact)
+  .superRefine((value, context) => {
+    if (Object.keys(value).length > 16) {
+      context.addIssue({
+        code: "custom",
+        message: "receipt facts may contain at most 16 scalar entries",
+      });
+    }
+  });
+
+const McpMutationReceiptNextActionArguments = z
+  .record(z.string().min(1).max(64), McpMutationReceiptFact)
+  .superRefine((value, context) => {
+    if (Object.keys(value).length > 8) {
+      context.addIssue({
+        code: "custom",
+        message: "receipt nextAction arguments may contain at most 8 scalar entries",
+      });
+    }
+  });
+
+export const McpMutationReceipt = z
+  .object({
+    receiptVersion: z.literal(MCP_MUTATION_RECEIPT_VERSION),
+    operation: z.string().min(1).max(128),
+    // v1 receipts describe committed truth only. Validation/auth/conflict and
+    // fully compensated failures remain MCP errors rather than success-shaped
+    // committed=false results.
+    committed: z.literal(true),
+    outcome: McpMutationReceiptOutcome,
+    changed: z.boolean(),
+    resource: McpMutationResource,
+    relatedResources: z.array(McpMutationResource).max(8).optional(),
+    timestamp: z.string().datetime({ offset: true }),
+    idempotency: z
+      .object({
+        status: McpMutationReceiptIdempotencyStatus,
+      })
+      .strict(),
+    partialFailure: z
+      .object({
+        stage: z.string().min(1).max(128),
+        retryable: z.boolean(),
+      })
+      .strict()
+      .optional(),
+    warnings: z.array(z.string().min(1).max(512)).max(20),
+    nextAction: z
+      .object({
+        tool: z.string().min(1).max(128),
+        arguments: McpMutationReceiptNextActionArguments,
+      })
+      .strict()
+      .optional(),
+    /** Operation-specific outcome facts. Values are deliberately bounded scalars. */
+    facts: McpMutationReceiptFacts.optional(),
+  })
+  .strict()
+  .superRefine((receipt, context) => {
+    if (receipt.outcome === "partial_failure") {
+      if (!receipt.committed) {
+        context.addIssue({
+          code: "custom",
+          path: ["committed"],
+          message: "partial-failure receipts describe a committed mutation",
+        });
+      }
+      if (!receipt.partialFailure) {
+        context.addIssue({
+          code: "custom",
+          path: ["partialFailure"],
+          message: "partial-failure receipts require stage and retryability",
+        });
+      }
+    } else if (receipt.partialFailure) {
+      context.addIssue({
+        code: "custom",
+        path: ["partialFailure"],
+        message: "partialFailure is only valid for a partial_failure outcome",
+      });
+    }
+
+    if (receipt.outcome === "unchanged" && receipt.changed) {
+      context.addIssue({
+        code: "custom",
+        path: ["changed"],
+        message: "unchanged receipts cannot report changed=true",
+      });
+    }
+    if (receipt.outcome === "replayed") {
+      if (receipt.changed) {
+        context.addIssue({
+          code: "custom",
+          path: ["changed"],
+          message: "a replay does not apply a new mutation",
+        });
+      }
+      if (receipt.idempotency.status !== "replayed") {
+        context.addIssue({
+          code: "custom",
+          path: ["idempotency", "status"],
+          message: "replayed outcomes require idempotency.status=replayed",
+        });
+      }
+    } else if (receipt.idempotency.status === "replayed") {
+      context.addIssue({
+        code: "custom",
+        path: ["outcome"],
+        message: "idempotency.status=replayed requires outcome=replayed",
+      });
+    }
+  });
+export type McpMutationReceipt = z.infer<typeof McpMutationReceipt>;

--- a/packages/contracts/src/mcp-receipts.ts
+++ b/packages/contracts/src/mcp-receipts.ts
@@ -9,6 +9,24 @@ import { z } from "zod";
  * fields into the result wastes context and can expose data twice.
  */
 export const MCP_MUTATION_RECEIPT_VERSION = "mcp-mutation-receipt.v1" as const;
+export const MCP_MUTATION_RECEIPT_MAX_BYTES = 64 * 1024;
+
+const utf8ByteLength = (value: string): number => new TextEncoder().encode(value).byteLength;
+
+function boundedUtf8String(maxBytes: number, minLength = 0) {
+  return z
+    .string()
+    .min(minLength)
+    .max(maxBytes)
+    .superRefine((value, context) => {
+      if (utf8ByteLength(value) > maxBytes) {
+        context.addIssue({
+          code: "custom",
+          message: `string must contain at most ${maxBytes} UTF-8 bytes`,
+        });
+      }
+    });
+}
 
 export const McpMutationReceiptOutcome = z.enum([
   "created",
@@ -17,6 +35,7 @@ export const McpMutationReceiptOutcome = z.enum([
   "unchanged",
   "accepted",
   "triggered",
+  "repaired",
   "replayed",
   "partial_failure",
 ]);
@@ -35,24 +54,24 @@ export type McpMutationReceiptIdempotencyStatus = z.infer<
 
 export const McpMutationResource = z
   .object({
-    type: z.string().min(1).max(128),
-    id: z.string().min(1).max(256),
-    version: z.union([z.number().int().nonnegative(), z.string().min(1).max(128)]).optional(),
-    etag: z.string().min(1).max(512).optional(),
-    state: z.string().min(1).max(128).optional(),
+    type: boundedUtf8String(128, 1),
+    id: boundedUtf8String(256, 1),
+    version: z.union([z.number().int().nonnegative(), boundedUtf8String(128, 1)]).optional(),
+    etag: boundedUtf8String(512, 1).optional(),
+    state: boundedUtf8String(128, 1).optional(),
   })
   .strict();
 export type McpMutationResource = z.infer<typeof McpMutationResource>;
 
 const McpMutationReceiptFact = z.union([
-  z.string().max(512),
+  boundedUtf8String(512),
   z.number().finite(),
   z.boolean(),
   z.null(),
 ]);
 
 const McpMutationReceiptFacts = z
-  .record(z.string().min(1).max(64), McpMutationReceiptFact)
+  .record(boundedUtf8String(64, 1), McpMutationReceiptFact)
   .superRefine((value, context) => {
     if (Object.keys(value).length > 16) {
       context.addIssue({
@@ -63,7 +82,7 @@ const McpMutationReceiptFacts = z
   });
 
 const McpMutationReceiptNextActionArguments = z
-  .record(z.string().min(1).max(64), McpMutationReceiptFact)
+  .record(boundedUtf8String(64, 1), McpMutationReceiptFact)
   .superRefine((value, context) => {
     if (Object.keys(value).length > 8) {
       context.addIssue({
@@ -76,7 +95,7 @@ const McpMutationReceiptNextActionArguments = z
 export const McpMutationReceipt = z
   .object({
     receiptVersion: z.literal(MCP_MUTATION_RECEIPT_VERSION),
-    operation: z.string().min(1).max(128),
+    operation: boundedUtf8String(128, 1),
     // v1 receipts describe committed truth only. Validation/auth/conflict and
     // fully compensated failures remain MCP errors rather than success-shaped
     // committed=false results.
@@ -93,15 +112,15 @@ export const McpMutationReceipt = z
       .strict(),
     partialFailure: z
       .object({
-        stage: z.string().min(1).max(128),
+        stage: boundedUtf8String(128, 1),
         retryable: z.boolean(),
       })
       .strict()
       .optional(),
-    warnings: z.array(z.string().min(1).max(512)).max(20),
+    warnings: z.array(boundedUtf8String(512, 1)).max(20),
     nextAction: z
       .object({
-        tool: z.string().min(1).max(128),
+        tool: boundedUtf8String(128, 1),
         arguments: McpMutationReceiptNextActionArguments,
       })
       .strict()
@@ -141,6 +160,22 @@ export const McpMutationReceipt = z
         message: "unchanged receipts cannot report changed=true",
       });
     }
+    if (receipt.outcome === "repaired") {
+      if (!receipt.changed) {
+        context.addIssue({
+          code: "custom",
+          path: ["changed"],
+          message: "a repair must report changed=true",
+        });
+      }
+      if (receipt.idempotency.status !== "applied") {
+        context.addIssue({
+          code: "custom",
+          path: ["idempotency", "status"],
+          message: "repaired outcomes require idempotency.status=applied",
+        });
+      }
+    }
     if (receipt.outcome === "replayed") {
       if (receipt.changed) {
         context.addIssue({
@@ -156,11 +191,22 @@ export const McpMutationReceipt = z
           message: "replayed outcomes require idempotency.status=replayed",
         });
       }
-    } else if (receipt.idempotency.status === "replayed") {
+    } else if (
+      receipt.idempotency.status === "replayed" &&
+      !(receipt.outcome === "partial_failure" && !receipt.changed)
+    ) {
       context.addIssue({
         code: "custom",
         path: ["outcome"],
-        message: "idempotency.status=replayed requires outcome=replayed",
+        message:
+          "idempotency.status=replayed requires a replayed outcome or unchanged partial failure",
+      });
+    }
+
+    if (utf8ByteLength(JSON.stringify(receipt, null, 2)) > MCP_MUTATION_RECEIPT_MAX_BYTES) {
+      context.addIssue({
+        code: "custom",
+        message: `receipt must contain at most ${MCP_MUTATION_RECEIPT_MAX_BYTES} UTF-8 bytes when serialized as pretty JSON`,
       });
     }
   });

--- a/packages/contracts/test/mcp-receipts.test.ts
+++ b/packages/contracts/test/mcp-receipts.test.ts
@@ -27,6 +27,13 @@ const baseReceipt = {
   },
 } satisfies McpMutationReceiptType;
 
+const sessionCreateCompatibility = {
+  id: "00000000-0000-4000-8000-000000000002",
+  rootSessionId: "00000000-0000-4000-8000-000000000002",
+  nestedAgentDepth: 0,
+  effectiveMaxNestedAgentDepth: 3,
+} as const;
+
 describe("MCP mutation receipt contract", () => {
   test("accepts a compact versioned mutation receipt", () => {
     expect(McpMutationReceipt.parse(baseReceipt)).toEqual(baseReceipt);
@@ -40,6 +47,7 @@ describe("MCP mutation receipt contract", () => {
       changed: false,
       resource: { type: "session", id: "00000000-0000-4000-8000-000000000002" },
       idempotency: { status: "replayed" },
+      ...sessionCreateCompatibility,
       nextAction: {
         tool: "session_get",
         arguments: { sessionId: "00000000-0000-4000-8000-000000000002" },
@@ -57,6 +65,7 @@ describe("MCP mutation receipt contract", () => {
         changed: true,
         resource: { type: "session", id: "00000000-0000-4000-8000-000000000002" },
         idempotency: { status: "applied" },
+        ...sessionCreateCompatibility,
       }),
     ).toMatchObject({ outcome: "repaired", changed: true });
 
@@ -98,7 +107,9 @@ describe("MCP mutation receipt contract", () => {
         operation: "session_create",
         outcome: "partial_failure",
         changed: false,
+        resource: { type: "session", id: sessionCreateCompatibility.id },
         idempotency: { status: "replayed" },
+        ...sessionCreateCompatibility,
         partialFailure: { stage: "usage_recording", retryable: true },
         warnings: ["Retry only with the same idempotency key."],
       }),
@@ -107,6 +118,43 @@ describe("MCP mutation receipt contract", () => {
       changed: false,
       idempotency: { status: "replayed" },
     });
+  });
+
+  test("requires exact bounded session compatibility aliases", () => {
+    expect(() =>
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        operation: "session_create",
+        resource: { type: "session", id: sessionCreateCompatibility.id },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        operation: "session_create",
+        resource: { type: "session", id: sessionCreateCompatibility.id },
+        ...sessionCreateCompatibility,
+        id: "00000000-0000-4000-8000-000000000099",
+      }),
+    ).toThrow();
+
+    expect(
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        operation: "session_steer",
+        resource: { type: "session_system_update", id: sessionCreateCompatibility.id },
+        updateId: sessionCreateCompatibility.id,
+      }),
+    ).toMatchObject({ updateId: sessionCreateCompatibility.id });
+
+    expect(() =>
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        operation: "session_steer",
+        resource: { type: "session_system_update", id: sessionCreateCompatibility.id },
+      }),
+    ).toThrow();
   });
 
   test("rejects success-shaped receipts for noncommitted operations", () => {

--- a/packages/contracts/test/mcp-receipts.test.ts
+++ b/packages/contracts/test/mcp-receipts.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MCP_MUTATION_RECEIPT_VERSION,
+  McpMutationReceipt,
+  type McpMutationReceiptType,
+} from "../src";
+
+const baseReceipt = {
+  receiptVersion: MCP_MUTATION_RECEIPT_VERSION,
+  operation: "scheduled_tasks_update",
+  committed: true,
+  outcome: "updated",
+  changed: true,
+  resource: {
+    type: "scheduled_task",
+    id: "00000000-0000-4000-8000-000000000001",
+    version: 4,
+    state: "active",
+  },
+  timestamp: "2026-07-20T00:00:00.000Z",
+  idempotency: { status: "not_supported" },
+  warnings: [],
+  nextAction: {
+    tool: "scheduled_tasks_get",
+    arguments: { id: "00000000-0000-4000-8000-000000000001" },
+  },
+} satisfies McpMutationReceiptType;
+
+describe("MCP mutation receipt contract", () => {
+  test("accepts a compact versioned mutation receipt", () => {
+    expect(McpMutationReceipt.parse(baseReceipt)).toEqual(baseReceipt);
+  });
+
+  test("represents idempotent replay without claiming a new change", () => {
+    const replay = McpMutationReceipt.parse({
+      ...baseReceipt,
+      operation: "session_create",
+      outcome: "replayed",
+      changed: false,
+      resource: { type: "session", id: "00000000-0000-4000-8000-000000000002" },
+      idempotency: { status: "replayed" },
+      nextAction: {
+        tool: "session_get",
+        arguments: { sessionId: "00000000-0000-4000-8000-000000000002" },
+      },
+    });
+    expect(replay.outcome).toBe("replayed");
+  });
+
+  test("requires truthful partial-commit failure facts", () => {
+    expect(
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        outcome: "partial_failure",
+        partialFailure: { stage: "schedule_sync", retryable: true },
+        warnings: ["The database mutation committed; schedule synchronization failed."],
+      }),
+    ).toMatchObject({ committed: true, outcome: "partial_failure" });
+
+    expect(() =>
+      McpMutationReceipt.parse({ ...baseReceipt, outcome: "partial_failure" }),
+    ).toThrow();
+    expect(() =>
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        committed: false,
+        outcome: "partial_failure",
+        partialFailure: { stage: "schedule_sync", retryable: true },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects success-shaped receipts for noncommitted operations", () => {
+    expect(() =>
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        committed: false,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects request-shaped or unbounded fields", () => {
+    expect(() =>
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        prompt: "already known request text",
+      }),
+    ).toThrow();
+    expect(() =>
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        nextAction: {
+          tool: "scheduled_tasks_get",
+          arguments: { agentConfig: { prompt: "nested request echo" } },
+        },
+      }),
+    ).toThrow();
+    expect(() =>
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        warnings: ["x".repeat(513)],
+      }),
+    ).toThrow();
+  });
+
+  test("rejects contradictory unchanged and replay outcomes", () => {
+    expect(() =>
+      McpMutationReceipt.parse({ ...baseReceipt, outcome: "unchanged", changed: true }),
+    ).toThrow();
+    expect(() =>
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        outcome: "replayed",
+        changed: false,
+        idempotency: { status: "applied" },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/contracts/test/mcp-receipts.test.ts
+++ b/packages/contracts/test/mcp-receipts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  MCP_MUTATION_RECEIPT_MAX_BYTES,
   MCP_MUTATION_RECEIPT_VERSION,
   McpMutationReceipt,
   type McpMutationReceiptType,
@@ -47,6 +48,28 @@ describe("MCP mutation receipt contract", () => {
     expect(replay.outcome).toBe("replayed");
   });
 
+  test("distinguishes an applied repair from a pure replay", () => {
+    expect(
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        operation: "session_create",
+        outcome: "repaired",
+        changed: true,
+        resource: { type: "session", id: "00000000-0000-4000-8000-000000000002" },
+        idempotency: { status: "applied" },
+      }),
+    ).toMatchObject({ outcome: "repaired", changed: true });
+
+    expect(() =>
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        outcome: "repaired",
+        changed: false,
+        idempotency: { status: "applied" },
+      }),
+    ).toThrow();
+  });
+
   test("requires truthful partial-commit failure facts", () => {
     expect(
       McpMutationReceipt.parse({
@@ -68,6 +91,22 @@ describe("MCP mutation receipt contract", () => {
         partialFailure: { stage: "schedule_sync", retryable: true },
       }),
     ).toThrow();
+
+    expect(
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        operation: "session_create",
+        outcome: "partial_failure",
+        changed: false,
+        idempotency: { status: "replayed" },
+        partialFailure: { stage: "usage_recording", retryable: true },
+        warnings: ["Retry only with the same idempotency key."],
+      }),
+    ).toMatchObject({
+      outcome: "partial_failure",
+      changed: false,
+      idempotency: { status: "replayed" },
+    });
   });
 
   test("rejects success-shaped receipts for noncommitted operations", () => {
@@ -101,6 +140,50 @@ describe("MCP mutation receipt contract", () => {
         warnings: ["x".repeat(513)],
       }),
     ).toThrow();
+  });
+
+  test("bounds strings and the full envelope by serialized UTF-8 bytes", () => {
+    expect(() =>
+      McpMutationReceipt.parse({
+        ...baseReceipt,
+        warnings: ["界".repeat(512)],
+      }),
+    ).toThrow();
+
+    const escapedMaximum = {
+      ...baseReceipt,
+      operation: "\0".repeat(128),
+      outcome: "partial_failure",
+      resource: {
+        type: "\0".repeat(128),
+        id: "\0".repeat(256),
+        version: "\0".repeat(128),
+        etag: "\0".repeat(512),
+        state: "\0".repeat(128),
+      },
+      relatedResources: Array.from({ length: 8 }, () => ({
+        type: "\0".repeat(128),
+        id: "\0".repeat(256),
+        version: "\0".repeat(128),
+        etag: "\0".repeat(512),
+        state: "\0".repeat(128),
+      })),
+      partialFailure: { stage: "\0".repeat(128), retryable: false },
+      warnings: Array.from({ length: 20 }, () => "\0".repeat(512)),
+      facts: Object.fromEntries(
+        Array.from({ length: 16 }, (_, index) => [`fact${index}`, "\0".repeat(512)]),
+      ),
+      nextAction: {
+        tool: "\0".repeat(128),
+        arguments: Object.fromEntries(
+          Array.from({ length: 8 }, (_, index) => [`arg${index}`, "\0".repeat(512)]),
+        ),
+      },
+    };
+    expect(Buffer.byteLength(JSON.stringify(escapedMaximum, null, 2), "utf8")).toBeGreaterThan(
+      MCP_MUTATION_RECEIPT_MAX_BYTES,
+    );
+    expect(() => McpMutationReceipt.parse(escapedMaximum)).toThrow();
   });
 
   test("rejects contradictory unchanged and replay outcomes", () => {

--- a/packages/core/src/application/session-commands.ts
+++ b/packages/core/src/application/session-commands.ts
@@ -574,7 +574,7 @@ export async function controlHumanSessionWorkstreamWithOutcome(
   },
   context: HumanSessionCommandContext,
   input: SessionControlRequest,
-): Promise<SessionControlResponse> {
+): Promise<{ response: SessionControlResponse; replay: boolean }> {
   const authorization = await authorizeHumanSessionCommand(deps, context, "session.control");
   const result = await withWorkspaceRls(deps.db, context.workspaceId, (scoped) =>
     scoped.transaction((tx) =>

--- a/packages/core/src/application/session-commands.ts
+++ b/packages/core/src/application/session-commands.ts
@@ -565,7 +565,7 @@ export async function steerHumanQueuePrompt(
   return response;
 }
 
-export async function controlHumanSessionWorkstream(
+export async function controlHumanSessionWorkstreamWithOutcome(
   deps: {
     db: Database;
     bus: EventBus;
@@ -607,7 +607,16 @@ export async function controlHumanSessionWorkstream(
   }
   await publishWorkspaceControlEvent(deps, context.workspaceId, result.workspaceControlEventId);
   await requestControlWakeDispatch(deps, result.wakeCount);
-  return response;
+  return { response, replay: result.replay };
+}
+
+/** Backward-compatible response path used by the REST control route. */
+export async function controlHumanSessionWorkstream(
+  deps: Parameters<typeof controlHumanSessionWorkstreamWithOutcome>[0],
+  context: Parameters<typeof controlHumanSessionWorkstreamWithOutcome>[1],
+  input: Parameters<typeof controlHumanSessionWorkstreamWithOutcome>[2],
+): Promise<SessionControlResponse> {
+  return (await controlHumanSessionWorkstreamWithOutcome(deps, context, input)).response;
 }
 
 export async function controlHumanWorkspace(

--- a/packages/core/src/domain/scheduled-tasks.ts
+++ b/packages/core/src/domain/scheduled-tasks.ts
@@ -332,6 +332,16 @@ export async function restoreScheduledTask(
   });
 }
 
+export class ScheduledTaskSyncError extends Error {
+  readonly persistenceRestored: boolean;
+
+  constructor(cause: unknown, persistenceRestored: boolean) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = "ScheduledTaskSyncError";
+    this.persistenceRestored = persistenceRestored;
+  }
+}
+
 export async function syncCreatedScheduledTask(input: {
   db: Database;
   workflowClient: SessionWorkflowClient;
@@ -340,10 +350,13 @@ export async function syncCreatedScheduledTask(input: {
   try {
     await input.workflowClient.syncScheduledTask({ task: input.task });
   } catch (error) {
-    await deleteScheduledTask(input.db, input.task.workspaceId, input.task.id).catch(
-      () => undefined,
-    );
-    throw error;
+    let persistenceRestored = true;
+    try {
+      await deleteScheduledTask(input.db, input.task.workspaceId, input.task.id);
+    } catch {
+      persistenceRestored = false;
+    }
+    throw new ScheduledTaskSyncError(error, persistenceRestored);
   }
 }
 
@@ -356,8 +369,13 @@ export async function syncUpdatedScheduledTask(input: {
   try {
     await input.workflowClient.syncScheduledTask({ task: input.task });
   } catch (error) {
-    await restoreScheduledTask(input.db, input.previous).catch(() => undefined);
-    throw error;
+    let persistenceRestored = true;
+    try {
+      await restoreScheduledTask(input.db, input.previous);
+    } catch {
+      persistenceRestored = false;
+    }
+    throw new ScheduledTaskSyncError(error, persistenceRestored);
   }
 }
 

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -506,7 +506,22 @@ function validateSessionMcpCredentialUpdates(input: {
   return encryptedUpdates;
 }
 
-export async function createAndStartSession(input: {
+export type CreateSessionOutcome = {
+  session: CreateSessionResponse;
+  /** The committed create/start effect represented by this request. */
+  outcome: "created" | "repaired" | "replayed";
+  /** Backward-compatible replay flag for existing entity-oriented callers. */
+  replay: boolean;
+  /** True when the request created/repaired start state or committed a new wake revision. */
+  changed: boolean;
+};
+
+export type CreateSessionRequestOutcome = CreateSessionOutcome & {
+  /** Billing telemetry is recorded after the committed session start. */
+  usageRecording: "recorded" | "failed";
+};
+
+export async function createAndStartSessionWithOutcome(input: {
   requestedSessionId?: string;
   db: Database;
   bus: EventBus;
@@ -597,7 +612,7 @@ export async function createAndStartSession(input: {
   maxNestedAgentDepthOverride?: number | null;
   allowNestedAgentDepthIncrease?: boolean;
   subjectId?: string | null;
-}): Promise<CreateSessionResponse> {
+}): Promise<CreateSessionOutcome> {
   const sessionMetadata = {
     ...input.metadata,
     model: input.model,
@@ -647,15 +662,24 @@ export async function createAndStartSession(input: {
     }
     const { session: keyed, created } = keyedResult;
     if (!created) {
+      const finished = await finishStartSession(
+        keyed.temporalWorkflowId ? { ...input, seedTargetSandbox: null } : input,
+        keyed,
+      );
       return {
-        session: await finishStartSession(
-          keyed.temporalWorkflowId ? { ...input, seedTargetSandbox: null } : input,
-          keyed,
-        ),
-        replay: true,
+        session: finished.session,
+        outcome: finished.changed ? "repaired" : "replayed",
+        replay: !finished.changed,
+        changed: finished.changed,
       };
     }
-    return { session: await finishStartSession(input, keyed), replay: false };
+    const finished = await finishStartSession(input, keyed);
+    return {
+      session: finished.session,
+      outcome: "created",
+      replay: false,
+      changed: true,
+    };
   }
   let session: Session;
   try {
@@ -697,7 +721,20 @@ export async function createAndStartSession(input: {
     }
     throw error;
   }
-  return await finishStartSession(input, session);
+  const finished = await finishStartSession(input, session);
+  return {
+    session: finished.session,
+    outcome: "created",
+    replay: false,
+    changed: true,
+  };
+}
+
+/** Backward-compatible entity-returning create path used by existing callers. */
+export async function createAndStartSession(
+  input: Parameters<typeof createAndStartSessionWithOutcome>[0],
+): Promise<CreateSessionResponse> {
+  return (await createAndStartSessionWithOutcome(input)).session;
 }
 
 /**
@@ -733,7 +770,7 @@ async function finishStartSession(
     consumeNewSessionDraft?: { subjectId: string; expectedRevision: number } | null;
   },
   session: Session,
-): Promise<CreateSessionResponse> {
+): Promise<{ session: CreateSessionResponse; changed: boolean }> {
   // Create-time machine targeting (A-2a): seed the active-sandbox pointer BEFORE
   // the atomic initial turn transaction, so the FIRST turn routes to the chosen
   // machine. swapActiveSandbox does
@@ -809,7 +846,10 @@ async function finishStartSession(
     started.turn?.id ??
     (await listSessionTurns(input.db, session.workspaceId, session.id, 1))[0]?.id ??
     null;
-  return { ...persisted, initialTurnId };
+  return {
+    session: { ...persisted, initialTurnId },
+    changed: started.changed,
+  };
 }
 
 export function workflowIdForSession(sessionId: string): string {
@@ -1000,7 +1040,7 @@ export async function postUserMessageTurn(input: {
   expectedDraftRevision?: number | null;
   reasoningEffortFallback?: Settings["openaiReasoningEffort"];
   turnExecutionPolicy: TurnExecutionPolicyV1;
-}): Promise<{ accepted: SessionEvent; turn: SessionTurn }> {
+}): Promise<{ accepted: SessionEvent; turn: SessionTurn; replay: boolean }> {
   const { db, bus, workflowClient, settings, accountId, workspaceId, sessionId } = input;
   const requestedModel = canonicalConfiguredModel(settings, input.model ?? null) ?? null;
   const requestedReasoningEffort = input.reasoningEffort ?? null;
@@ -1129,7 +1169,7 @@ export async function createSessionForRequestWithOutcome(
   grant: AccessGrant,
   workspaceId: string,
   rawPayload: unknown,
-): Promise<CreateSessionOutcome> {
+): Promise<CreateSessionRequestOutcome> {
   const { settings, db, bus, workflowClient, objectStorage } = deps;
   const payload = CreateSessionRequest.parse(rawPayload);
   if (hasReservedOpenGeniSlackBotSessionMetadata(payload.metadata)) {
@@ -1624,9 +1664,9 @@ export async function createSessionForRequestWithOutcome(
     });
   }
   const creationInitiator = creationInitiatorForGrant(grant);
-  let session: CreateSessionResponse;
+  let createOutcome: CreateSessionOutcome;
   try {
-    session = await createAndStartSession({
+    createOutcome = await createAndStartSessionWithOutcome({
       ...(payload.requestedSessionId ? { requestedSessionId: payload.requestedSessionId } : {}),
       db,
       bus,
@@ -1707,24 +1747,42 @@ export async function createSessionForRequestWithOutcome(
     }
     throw error;
   }
+  let usageRecording: CreateSessionRequestOutcome["usageRecording"] = "recorded";
   if (payload.startMode !== "realtime") {
-    await recordWorkspaceUsage(deps, {
-      accountId: grant.accountId,
-      workspaceId,
-      subjectId: grant.subjectId,
-      eventType: "agent_run.created",
-      quantity: 1,
-      unit: "run",
-      sourceResourceType: "session",
-      sourceResourceId: session.id,
-      sessionId: session.id,
-      initiator: session.createdBy,
-      initiatorContext: session.createdByContext,
-      origin: creationInitiator.actor ? "system" : "user",
-      idempotencyKey: `agent_run.created:${workspaceId}:${session.id}`,
-    });
+    try {
+      await recordWorkspaceUsage(deps, {
+        accountId: grant.accountId,
+        workspaceId,
+        subjectId: grant.subjectId,
+        eventType: "agent_run.created",
+        quantity: 1,
+        unit: "run",
+        sourceResourceType: "session",
+        sourceResourceId: createOutcome.session.id,
+        sessionId: createOutcome.session.id,
+        initiator: createOutcome.session.createdBy,
+        initiatorContext: createOutcome.session.createdByContext,
+        origin: creationInitiator.actor ? "system" : "user",
+        idempotencyKey: `agent_run.created:${workspaceId}:${createOutcome.session.id}`,
+      });
+    } catch {
+      usageRecording = "failed";
+      console.warn(
+        `[sessions] usage recording failed after committed session create ${workspaceId}/${createOutcome.session.id}; returning committed outcome`,
+      );
+    }
   }
-  return session;
+  return { ...createOutcome, usageRecording };
+}
+
+/** Backward-compatible entity-returning request path for REST and core callers. */
+export async function createSessionForRequest(
+  deps: ApiRouteDeps,
+  grant: AccessGrant,
+  workspaceId: string,
+  rawPayload: unknown,
+): Promise<CreateSessionResponse> {
+  return (await createSessionForRequestWithOutcome(deps, grant, workspaceId, rawPayload)).session;
 }
 
 /**
@@ -1825,7 +1883,7 @@ export async function acceptSessionUserMessageWithOutcome(
     source: personalConnectionDelegationSourceForGrant(grant),
   });
   const delegatedServiceInitiator = serviceInitiatorForGrant(grant);
-  const { accepted, turn } = await postUserMessageTurn({
+  const { accepted, turn, replay } = await postUserMessageTurn({
     db,
     bus,
     workflowClient,

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -647,12 +647,15 @@ export async function createAndStartSession(input: {
     }
     const { session: keyed, created } = keyedResult;
     if (!created) {
-      return await finishStartSession(
-        keyed.temporalWorkflowId ? { ...input, seedTargetSandbox: null } : input,
-        keyed,
-      );
+      return {
+        session: await finishStartSession(
+          keyed.temporalWorkflowId ? { ...input, seedTargetSandbox: null } : input,
+          keyed,
+        ),
+        replay: true,
+      };
     }
-    return await finishStartSession(input, keyed);
+    return { session: await finishStartSession(input, keyed), replay: false };
   }
   let session: Session;
   try {
@@ -1109,7 +1112,7 @@ export async function postUserMessageTurn(input: {
       error,
     );
   }
-  return { accepted, turn };
+  return { accepted, turn, replay: result.replay };
 }
 
 /**
@@ -1121,12 +1124,12 @@ export async function postUserMessageTurn(input: {
  * trusted immediate parent, while explicit arrays (including []) win. A
  * top-level create with omitted tools applies workspace-default capability MCPs.
  */
-export async function createSessionForRequest(
+export async function createSessionForRequestWithOutcome(
   deps: ApiRouteDeps,
   grant: AccessGrant,
   workspaceId: string,
   rawPayload: unknown,
-): Promise<Session> {
+): Promise<CreateSessionOutcome> {
   const { settings, db, bus, workflowClient, objectStorage } = deps;
   const payload = CreateSessionRequest.parse(rawPayload);
   if (hasReservedOpenGeniSlackBotSessionMetadata(payload.metadata)) {
@@ -1731,7 +1734,7 @@ export async function createSessionForRequest(
  * enqueue, and usage recording. `toolsProvided: false` durably preserves an
  * Tool selection is durable session state and never rides a follow-up prompt.
  */
-export async function acceptSessionUserMessage(
+export async function acceptSessionUserMessageWithOutcome(
   deps: AcceptSessionUserMessageDependencies,
   grant: AccessGrant,
   workspaceId: string,
@@ -1750,7 +1753,7 @@ export async function acceptSessionUserMessage(
     controlEtag?: string | null;
     expectedDraftRevision?: number | null;
   },
-): Promise<{ accepted: SessionEvent; turn: SessionTurn }> {
+): Promise<{ accepted: SessionEvent; turn: SessionTurn; replay: boolean }> {
   const { settings, db, bus, workflowClient, objectStorage } = deps;
   await requireSessionAuthorization(deps, grant, {
     sessionId,
@@ -1878,6 +1881,24 @@ export async function acceptSessionUserMessage(
     origin: turn.source,
     idempotencyKey: `agent_run.created:${workspaceId}:${turn.id}`,
   });
+  return { accepted, turn, replay };
+}
+
+/** Backward-compatible entity-returning path used by existing REST callers. */
+export async function acceptSessionUserMessage(
+  deps: Parameters<typeof acceptSessionUserMessageWithOutcome>[0],
+  grant: Parameters<typeof acceptSessionUserMessageWithOutcome>[1],
+  workspaceId: Parameters<typeof acceptSessionUserMessageWithOutcome>[2],
+  sessionId: Parameters<typeof acceptSessionUserMessageWithOutcome>[3],
+  input: Parameters<typeof acceptSessionUserMessageWithOutcome>[4],
+): Promise<{ accepted: SessionEvent; turn: SessionTurn }> {
+  const { accepted, turn } = await acceptSessionUserMessageWithOutcome(
+    deps,
+    grant,
+    workspaceId,
+    sessionId,
+    input,
+  );
   return { accepted, turn };
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9419,6 +9419,7 @@ export async function listScheduledTasks(
   db: Database,
   workspaceId: string,
   limit = 100,
+  offset = 0,
 ): Promise<ScheduledTask[]> {
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     const rows = await scopedDb
@@ -9426,7 +9427,8 @@ export async function listScheduledTasks(
       .from(schema.scheduledTasks)
       .where(eq(schema.scheduledTasks.workspaceId, workspaceId))
       .orderBy(desc(schema.scheduledTasks.createdAt))
-      .limit(limit);
+      .limit(limit)
+      .offset(offset);
     return rows.map(mapScheduledTask);
   });
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -36617,6 +36617,8 @@ export type InitializeSessionStartResult = {
   turn: SessionTurn | null;
   temporalWorkflowId: string;
   workflowWakeRevision: number | null;
+  /** True when this call installed/repaired start state or committed a new wake revision. */
+  changed: boolean;
 };
 
 /**
@@ -36665,9 +36667,11 @@ export async function initializeSessionStartAtomically(
             turn: null,
             temporalWorkflowId,
             workflowWakeRevision: null,
+            changed: false,
           };
         }
 
+        let insertedGoal = false;
         let [goal] = await tx
           .select()
           .from(schema.sessionGoals)
@@ -36693,6 +36697,7 @@ export async function initializeSessionStartAtomically(
             })
             .returning();
           if (!goal) throw new Error("Failed to create initial session goal");
+          insertedGoal = true;
         }
 
         if (input.deferInitialTurn) {
@@ -36751,20 +36756,26 @@ export async function initializeSessionStartAtomically(
               .returning();
             initializedNow = true;
           }
-          await tx
-            .update(schema.sessions)
-            .set({
-              temporalWorkflowId,
-              lastSequence: sequence,
-              ...(initializedNow && session.status === "queued" ? { status: "idle" } : {}),
-              updatedAt: new Date(),
-            })
-            .where(
-              and(
-                eq(schema.sessions.workspaceId, input.workspaceId),
-                eq(schema.sessions.id, session.id),
-              ),
-            );
+          const sessionNeedsRepair =
+            session.temporalWorkflowId !== temporalWorkflowId ||
+            session.lastSequence !== sequence ||
+            (initializedNow && session.status === "queued");
+          if (sessionNeedsRepair) {
+            await tx
+              .update(schema.sessions)
+              .set({
+                temporalWorkflowId,
+                lastSequence: sequence,
+                ...(initializedNow && session.status === "queued" ? { status: "idle" } : {}),
+                updatedAt: new Date(),
+              })
+              .where(
+                and(
+                  eq(schema.sessions.workspaceId, input.workspaceId),
+                  eq(schema.sessions.id, session.id),
+                ),
+              );
+          }
           if (initializedNow && input.consumeNewSessionDraft) {
             await setSubjectRlsContext(
               tx as unknown as Database,
@@ -36781,6 +36792,7 @@ export async function initializeSessionStartAtomically(
             turn: null,
             temporalWorkflowId,
             workflowWakeRevision: null,
+            changed: insertedGoal || insertedEvents.length > 0 || sessionNeedsRepair,
           };
         }
 
@@ -36974,26 +36986,33 @@ export async function initializeSessionStartAtomically(
         }
 
         const turnNeedsWake = turn.status === "queued" && runnable;
-        await tx
-          .update(schema.sessions)
-          .set({
-            temporalWorkflowId,
-            lastSequence: sequence,
-            ...(insertedTurn
-              ? {
-                  queueVersion: session.queueVersion + 1,
-                  queueTailPosition,
-                }
-              : {}),
-            ...(turn.status === "queued" ? { status: publicQueuedStatus } : {}),
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(schema.sessions.workspaceId, input.workspaceId),
-              eq(schema.sessions.id, session.id),
-            ),
-          );
+        const sessionNeedsRepair =
+          session.temporalWorkflowId !== temporalWorkflowId ||
+          session.lastSequence !== sequence ||
+          insertedTurn ||
+          (turn.status === "queued" && session.status !== publicQueuedStatus);
+        if (sessionNeedsRepair) {
+          await tx
+            .update(schema.sessions)
+            .set({
+              temporalWorkflowId,
+              lastSequence: sequence,
+              ...(insertedTurn
+                ? {
+                    queueVersion: session.queueVersion + 1,
+                    queueTailPosition,
+                  }
+                : {}),
+              ...(turn.status === "queued" ? { status: publicQueuedStatus } : {}),
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(schema.sessions.workspaceId, input.workspaceId),
+                eq(schema.sessions.id, session.id),
+              ),
+            );
+        }
         const workflowWakeRevision = turnNeedsWake
           ? await enqueueSessionWorkflowWakeInTransaction(tx as unknown as Database, {
               accountId: session.accountId,
@@ -37014,11 +37033,18 @@ export async function initializeSessionStartAtomically(
             expectedRevision: input.consumeNewSessionDraft.expectedRevision,
           });
         }
+        const changed =
+          insertedGoal ||
+          insertedEvents.length > 0 ||
+          insertedTurn ||
+          sessionNeedsRepair ||
+          workflowWakeRevision !== null;
         return {
           events: insertedEvents.map(mapEvent),
           turn: mapSessionTurn(turn),
           temporalWorkflowId,
           workflowWakeRevision,
+          changed,
         };
       }),
   );

--- a/packages/db/test/session-workflow-wake-outbox.test.ts
+++ b/packages/db/test/session-workflow-wake-outbox.test.ts
@@ -163,6 +163,9 @@ describe("transactional session workflow wake outbox", () => {
     ]);
     expect(results.flatMap((result) => result.events)).toHaveLength(5);
     expect(results.map((result) => result.workflowWakeRevision).sort()).toEqual([1, 2]);
+    // Both concurrent callers own a committed wake revision, so neither may
+    // describe itself as a mutation-free replay.
+    expect(results.map((result) => result.changed).sort()).toEqual([true, true]);
 
     const events = await listSessionEvents(
       client.db,

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -1609,6 +1609,15 @@ export function extractSessionRef(value: unknown, depth = 0): string | null {
     return null;
   }
   const record = value as Record<string, unknown>;
+  const receiptResource = asRecord(record.resource);
+  if (
+    record.receiptVersion === "mcp-mutation-receipt.v1" &&
+    receiptResource.type === "session" &&
+    typeof receiptResource.id === "string" &&
+    looksLikeId(receiptResource.id)
+  ) {
+    return receiptResource.id;
+  }
   if (typeof record.sessionId === "string" && looksLikeId(record.sessionId)) {
     return record.sessionId;
   }

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -907,10 +907,11 @@ describe("buildTimeline", () => {
 
   test("session_create becomes a worker item with prompt and spawned session id from MCP output", () => {
     reset();
-    const worker = {
-      id: "0b3ba745-1111-4222-8333-9c76ad9e0000",
-      workspaceId: "ws-1",
-      status: "queued",
+    const workerId = "0b3ba745-1111-4222-8333-9c76ad9e0000";
+    const receipt = {
+      receiptVersion: "mcp-mutation-receipt.v1",
+      operation: "session_create",
+      resource: { type: "session", id: workerId, state: "queued" },
     };
     const items = buildTimeline([
       event("agent.toolCall.created", {
@@ -920,7 +921,7 @@ describe("buildTimeline", () => {
       }),
       event("agent.toolCall.output", {
         id: "call-1",
-        output: { content: [{ type: "text", text: JSON.stringify(worker) }] },
+        output: { content: [{ type: "text", text: JSON.stringify(receipt) }] },
       }),
     ]);
     expect(items).toHaveLength(1);
@@ -929,7 +930,7 @@ describe("buildTimeline", () => {
     expect(item.action).toBe("spawn");
     expect(item.prompt).toBe("Run the drift check on prod");
     expect(item.status).toBe("complete");
-    expect(item.workerSessionId).toBe(worker.id);
+    expect(item.workerSessionId).toBe(workerId);
   });
 
   test("a worker spawn whose output carries an error flag settles to failed, not complete", () => {
@@ -2161,6 +2162,12 @@ describe("extractSessionRef", () => {
       }),
     ).toBe(id);
     expect(extractSessionRef({ structuredContent: { sessionId: id } })).toBe(id);
+    expect(
+      extractSessionRef({
+        receiptVersion: "mcp-mutation-receipt.v1",
+        resource: { type: "session", id, state: "queued" },
+      }),
+    ).toBe(id);
   });
 
   test("rejects non-uuid ids and unrelated payloads", () => {

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -59,6 +59,7 @@ import { appendAndPublishEvents } from "@opengeni/events";
 import {
   signDelegatedAccessToken,
   type AccessContext,
+  type McpMutationReceiptType,
   type Permission,
   type SessionEvent,
   type SessionStatus,
@@ -901,16 +902,17 @@ describe("API component integration", () => {
     };
     const mcp = buildOpenGeniMcpServer(mcpDeps, grant);
 
-    const setGoal = await callMcpTool<{
-      id: string;
-      status: string;
-      version: number;
-    }>(mcp, "goal_set", {
+    const setGoal = await callMcpTool<McpMutationReceiptType>(mcp, "goal_set", {
       text: "keep CI green",
       successCriteria: "main pipeline passes",
     });
-    expect(setGoal.status).toBe("active");
-    expect(setGoal.version).toBe(1);
+    expect(setGoal).toMatchObject({
+      receiptVersion: "mcp-mutation-receipt.v1",
+      outcome: "created",
+      changed: true,
+      resource: { state: "active", version: 1 },
+    });
+    expect(JSON.stringify(setGoal)).not.toContain("main pipeline passes");
 
     const updated = await callMcpTool<{
       version: number;
@@ -926,24 +928,26 @@ describe("API component integration", () => {
     expect(updated.operationId).toBeTruthy();
     expect(updated.replay).toBe(false);
 
-    const pausedGoal = await callMcpTool<{
-      status: string;
-      pausedReason: string;
-    }>(mcp, "goal_pause", { rationale: "waiting on upstream fix" });
-    expect(pausedGoal.status).toBe("paused");
-    expect(pausedGoal.pausedReason).toBe("agent");
+    const pausedGoal = await callMcpTool<McpMutationReceiptType>(mcp, "goal_pause", {
+      rationale: "waiting on upstream fix",
+    });
+    expect(pausedGoal.resource.state).toBe("paused");
+    expect(JSON.stringify(pausedGoal)).not.toContain("waiting on upstream fix");
 
-    const replacedGoal = await callMcpTool<{ status: string }>(mcp, "goal_set", {
+    const replacedGoal = await callMcpTool<McpMutationReceiptType>(mcp, "goal_set", {
       text: "upstream fixed; finish the job",
     });
-    expect(replacedGoal.status).toBe("active");
+    expect(replacedGoal).toMatchObject({
+      outcome: "updated",
+      resource: { state: "active" },
+      facts: { replaced: true },
+    });
 
-    const completedGoal = await callMcpTool<{
-      status: string;
-      evidence: string;
-    }>(mcp, "goal_complete", { evidence: "CI green for 3 consecutive runs" });
-    expect(completedGoal.status).toBe("completed");
-    expect(completedGoal.evidence).toBe("CI green for 3 consecutive runs");
+    const completedGoal = await callMcpTool<McpMutationReceiptType>(mcp, "goal_complete", {
+      evidence: "CI green for 3 consecutive runs",
+    });
+    expect(completedGoal.resource.state).toBe("completed");
+    expect(JSON.stringify(completedGoal)).not.toContain("CI green for 3 consecutive runs");
     await expect(callMcpTool(mcp, "goal_pause", { rationale: "too late" })).rejects.toThrow(
       "completed",
     );
@@ -3735,22 +3739,128 @@ describe("API component integration", () => {
     ).toBe(false);
 
     workflow.syncError = null;
-    const task = await callMcpTool<{ id: string }>(mcp, "scheduled_tasks_create", {
+    const taskReceipt = await callMcpTool<McpMutationReceiptType>(mcp, "scheduled_tasks_create", {
       name: `mcp-rollback-${crypto.randomUUID()}`,
       schedule: { type: "interval", everySeconds: 3600 },
       agentConfig: { prompt: "inspect" },
     });
+    const taskId = taskReceipt.resource.id;
+    expect(taskReceipt).toMatchObject({
+      operation: "scheduled_tasks_create",
+      outcome: "created",
+      changed: true,
+      resource: { type: "scheduled_task", id: taskId, state: "active" },
+    });
 
     workflow.syncError = new Error("temporal unavailable");
-    await expect(callMcpTool(mcp, "scheduled_tasks_pause", { id: task.id })).rejects.toThrow(
+    await expect(callMcpTool(mcp, "scheduled_tasks_pause", { id: taskId })).rejects.toThrow(
       "temporal unavailable",
     );
-    expect((await getScheduledTask(dbClient.db, grant.workspaceId, task.id))?.status).toBe(
-      "active",
-    );
+    expect((await getScheduledTask(dbClient.db, grant.workspaceId, taskId))?.status).toBe("active");
     await expect(
       callMcpTool(mcp, "scheduled_tasks_resume", { id: crypto.randomUUID() }),
     ).rejects.toThrow("Scheduled task not found");
+  });
+
+  test("returns compact receipts across the MCP scheduled task lifecycle", async () => {
+    const workflowClient = new FakeWorkflowClient();
+    const grant = await bootstrapMcpGrant(dbClient.db);
+    const mcp = buildOpenGeniMcpServer(
+      {
+        settings: testSettings({ databaseUrl: services.databaseUrl }),
+        db: dbClient.db,
+        bus: new MemoryEventBus(),
+        workflowClient,
+        objectStorage: null,
+        githubStateSecret: "test-state-secret",
+        documentIndexer: { indexDocument: async () => undefined },
+        getDocumentServices: () => {
+          throw new Error("document services are not used by scheduled task lifecycle tests");
+        },
+        resumeBoxById: fakeResumeBoxById,
+      },
+      grant,
+    );
+    const prompt = `scheduled receipt prompt ${crypto.randomUUID()}`;
+    const originalName = `scheduled-receipt-${crypto.randomUUID()}`;
+    const created = await callMcpTool<McpMutationReceiptType>(mcp, "scheduled_tasks_create", {
+      name: originalName,
+      schedule: { type: "interval", everySeconds: 3600 },
+      agentConfig: { prompt },
+    });
+    expect(created).toMatchObject({
+      outcome: "created",
+      changed: true,
+      resource: { type: "scheduled_task", state: "active" },
+    });
+    expect(JSON.stringify(created)).not.toContain(prompt);
+    expect(JSON.stringify(created)).not.toContain(originalName);
+
+    const summary = await callMcpTool<{
+      id: string;
+      configuration: { promptBytes: number };
+    }>(mcp, "scheduled_tasks_get", { id: created.resource.id });
+    expect(summary).toMatchObject({
+      id: created.resource.id,
+      configuration: { promptBytes: Buffer.byteLength(prompt, "utf8") },
+    });
+    expect(JSON.stringify(summary)).not.toContain(prompt);
+
+    const detail = await callMcpTool<{
+      entity: { agentConfig: { prompt: string } };
+      detailProjection: { bounded: boolean };
+    }>(mcp, "scheduled_tasks_get", { id: created.resource.id, includeEntity: true });
+    expect(detail.entity.agentConfig.prompt).toBe(prompt);
+    expect(detail.detailProjection.bounded).toBe(true);
+
+    const updatedName = `scheduled-updated-${crypto.randomUUID()}`;
+    const updated = await callMcpTool<McpMutationReceiptType>(mcp, "scheduled_tasks_update", {
+      id: created.resource.id,
+      name: updatedName,
+    });
+    expect(updated).toMatchObject({ outcome: "updated", changed: true });
+    expect(JSON.stringify(updated)).not.toContain(updatedName);
+    const unchanged = await callMcpTool<McpMutationReceiptType>(mcp, "scheduled_tasks_update", {
+      id: created.resource.id,
+      name: updatedName,
+    });
+    expect(unchanged).toMatchObject({ outcome: "unchanged", changed: false });
+
+    const paused = await callMcpTool<McpMutationReceiptType>(mcp, "scheduled_tasks_pause", {
+      id: created.resource.id,
+    });
+    expect(paused).toMatchObject({ outcome: "updated", resource: { state: "paused" } });
+    const alreadyPaused = await callMcpTool<McpMutationReceiptType>(mcp, "scheduled_tasks_pause", {
+      id: created.resource.id,
+    });
+    expect(alreadyPaused).toMatchObject({ outcome: "unchanged", changed: false });
+
+    const resumed = await callMcpTool<McpMutationReceiptType>(mcp, "scheduled_tasks_resume", {
+      id: created.resource.id,
+    });
+    expect(resumed).toMatchObject({ outcome: "updated", resource: { state: "active" } });
+
+    const triggerId = `scheduled-receipt-trigger-${crypto.randomUUID()}`;
+    const triggered = await callMcpTool<McpMutationReceiptType>(mcp, "scheduled_tasks_trigger", {
+      id: created.resource.id,
+      triggerId,
+    });
+    expect(triggered).toMatchObject({
+      outcome: "triggered",
+      changed: true,
+      idempotency: { status: "unknown" },
+    });
+    expect(workflowClient.triggers).toHaveLength(1);
+
+    const deleted = await callMcpTool<McpMutationReceiptType>(mcp, "scheduled_tasks_delete", {
+      id: created.resource.id,
+    });
+    expect(deleted).toMatchObject({
+      outcome: "deleted",
+      changed: true,
+      resource: { id: created.resource.id, state: "deleted" },
+    });
+    expect(await getScheduledTask(dbClient.db, grant.workspaceId, created.resource.id)).toBeNull();
   });
 
   test("MCP scheduled task tools enforce the same billing limits as REST routes", async () => {
@@ -3772,7 +3882,7 @@ describe("API component integration", () => {
       },
       grant,
     );
-    const task = await callMcpTool<{ id: string }>(allowedMcp, "scheduled_tasks_create", {
+    const task = await callMcpTool<McpMutationReceiptType>(allowedMcp, "scheduled_tasks_create", {
       name: `mcp-limit-trigger-${crypto.randomUUID()}`,
       schedule: { type: "interval", everySeconds: 3600 },
       agentConfig: { prompt: "inspect" },
@@ -3818,8 +3928,8 @@ describe("API component integration", () => {
       quantity: 1,
       unit: "run",
       sourceResourceType: "test",
-      sourceResourceId: task.id,
-      idempotencyKey: `test:mcp-agent-run-cap:${task.id}`,
+      sourceResourceId: task.resource.id,
+      idempotencyKey: `test:mcp-agent-run-cap:${task.resource.id}`,
     });
 
     const blockedTriggerMcp = buildOpenGeniMcpServer(
@@ -3846,7 +3956,7 @@ describe("API component integration", () => {
     );
     await expect(
       callMcpTool(blockedTriggerMcp, "scheduled_tasks_trigger", {
-        id: task.id,
+        id: task.resource.id,
       }),
     ).rejects.toThrow("monthly agent run limit reached");
     expect(workflow.triggers).toHaveLength(0);
@@ -6552,10 +6662,26 @@ describe("API component integration", () => {
             createdBySessionId: forgedSession.id,
           }),
         ),
-      ) as { text: string; createdBySessionId: string | null };
-      expect(proposedMemory.text).toBe("Private endpoint MCP memory should be reviewed.");
-      expect(proposedMemory.createdBySessionId).toBe(serverSession.id);
-      expect(proposedMemory.createdBySessionId).not.toBe(forgedSession.id);
+      ) as McpMutationReceiptType;
+      expect(proposedMemory).toMatchObject({
+        operation: "memory_propose",
+        outcome: "created",
+        changed: true,
+        resource: { type: "knowledge_memory", state: "proposed" },
+      });
+      expect(JSON.stringify(proposedMemory)).not.toContain(
+        "Private endpoint MCP memory should be reviewed.",
+      );
+      expect(
+        await getKnowledgeMemory(dbClient.db, workspaceId, proposedMemory.resource.id),
+      ).toMatchObject({
+        text: "Private endpoint MCP memory should be reviewed.",
+        createdBySessionId: serverSession.id,
+      });
+      expect(
+        (await getKnowledgeMemory(dbClient.db, workspaceId, proposedMemory.resource.id))
+          ?.createdBySessionId,
+      ).not.toBe(forgedSession.id);
 
       const downloadResult = await filesServer.callTool("files__files_get_download_url", {
         fileId: upload.fileId,
@@ -6704,26 +6830,20 @@ describe("API component integration", () => {
             confidence: 0.91,
           }),
         ),
-      ) as {
-        memory: {
-          id: string;
-          status: string;
-          kind: string;
-          createdBySessionId: string | null;
-          metadata: Record<string, unknown>;
-        };
-        deduped: boolean;
-      };
-      expect(saved.deduped).toBe(false);
-      expect(saved.memory).toMatchObject({
+      ) as McpMutationReceiptType;
+      expect(saved).toMatchObject({
+        outcome: "created",
+        changed: true,
+        resource: { type: "knowledge_memory", state: "active" },
+        facts: { deduped: false },
+      });
+      expect(JSON.stringify(saved)).not.toContain(
+        "Staging deploys from main only, via opengeni-ops.",
+      );
+      expect(await getKnowledgeMemory(dbClient.db, workspaceId, saved.resource.id)).toMatchObject({
+        id: saved.resource.id,
         status: "active",
         kind: "procedural",
-        createdBySessionId: session.id,
-        metadata: { origin: "agent" },
-      });
-      expect(await getKnowledgeMemory(dbClient.db, workspaceId, saved.memory.id)).toMatchObject({
-        id: saved.memory.id,
-        status: "active",
         createdBySessionId: session.id,
         metadata: { origin: "agent" },
       });
@@ -6733,7 +6853,7 @@ describe("API component integration", () => {
       );
       expect(saveEvents).toHaveLength(1);
       expect(saveEvents[0]?.payload).toMatchObject({
-        memoryId: saved.memory.id,
+        memoryId: saved.resource.id,
         kind: "procedural",
         preview: "Staging deploys from main only, via opengeni-ops.",
       });
@@ -6755,61 +6875,63 @@ describe("API component integration", () => {
           matchType: string;
         }>;
       };
-      expect(search.results[0]?.memory.id).toBe(saved.memory.id);
+      expect(search.results[0]?.memory.id).toBe(saved.resource.id);
       expect(search.results[0]!.score).toBeGreaterThan(0);
       expect(search.results[0]!.memory.usageCount).toBe(1);
 
       const superseded = JSON.parse(
         mcpText(
           await prepared.mcpServers[0]!.callTool("opengeni__memory_correct", {
-            id: saved.memory.id.slice(0, 8),
+            id: saved.resource.id.slice(0, 8),
             reason: "Deployment branch changed",
             replacement_text: "Staging deploys from release only, via opengeni-ops.",
           }),
         ),
-      ) as {
-        action: string;
-        memory: { id: string; status: string };
-        replacement: { id: string; status: string } | null;
-      };
-      expect(superseded.action).toBe("superseded");
-      expect(superseded.memory.id).toBe(saved.memory.id);
-      expect(superseded.replacement?.status).toBe("active");
-      expect(await getKnowledgeMemory(dbClient.db, workspaceId, saved.memory.id)).toMatchObject({
+      ) as McpMutationReceiptType;
+      expect(superseded).toMatchObject({
+        outcome: "updated",
+        resource: { id: saved.resource.id, state: "superseded" },
+        facts: { correctionAction: "superseded" },
+      });
+      const replacementId = superseded.relatedResources?.[0]?.id;
+      expect(typeof replacementId).toBe("string");
+      expect(superseded.relatedResources?.[0]?.state).toBe("active");
+      expect(JSON.stringify(superseded)).not.toContain(
+        "Staging deploys from release only, via opengeni-ops.",
+      );
+      expect(await getKnowledgeMemory(dbClient.db, workspaceId, saved.resource.id)).toMatchObject({
         status: "superseded",
-        supersededById: superseded.replacement!.id,
+        supersededById: replacementId,
       });
 
       const archived = JSON.parse(
         mcpText(
           await prepared.mcpServers[0]!.callTool("opengeni__memory_correct", {
-            id: superseded.replacement!.id,
+            id: replacementId!,
             reason: "Staging deploy process moved into a runbook.",
           }),
         ),
-      ) as {
-        action: string;
-        memory: { id: string; status: string };
-        replacement: null;
-      };
-      expect(archived.action).toBe("archived");
-      expect(archived.memory.status).toBe("archived");
-      expect(
-        await getKnowledgeMemory(dbClient.db, workspaceId, superseded.replacement!.id),
-      ).toMatchObject({ status: "archived" });
+      ) as McpMutationReceiptType;
+      expect(archived).toMatchObject({
+        resource: { id: replacementId, state: "archived" },
+        facts: { correctionAction: "archived" },
+      });
+      expect(await getKnowledgeMemory(dbClient.db, workspaceId, replacementId!)).toMatchObject({
+        status: "archived",
+      });
 
       const correctionEvents = (
         await listSessionEvents(dbClient.db, workspaceId, session.id)
       ).filter((event) => event.type === "memory.corrected");
       expect(correctionEvents).toHaveLength(2);
       expect(correctionEvents[0]?.payload).toMatchObject({
-        memoryId: saved.memory.id,
+        memoryId: saved.resource.id,
         action: "superseded",
         reason: "Deployment branch changed",
-        replacementMemoryId: superseded.replacement!.id,
+        replacementMemoryId: replacementId,
       });
       expect(correctionEvents[1]?.payload).toMatchObject({
-        memoryId: superseded.replacement!.id,
+        memoryId: replacementId,
         action: "archived",
         reason: "Staging deploy process moved into a runbook.",
       });
@@ -7329,32 +7451,38 @@ describe("API component integration", () => {
       }),
     ).rejects.toThrow("missing permission: variable-sets:use");
 
-    const created = await callMcpTool<{
-      id: string;
-      environmentId: string | null;
-    }>(adminMcp, "scheduled_tasks_create", {
-      name: `mcp-attach-${crypto.randomUUID()}`,
-      schedule: { type: "interval", everySeconds: 3600 },
-      agentConfig: { prompt: "inspect" },
-      environmentId: environment.id,
-    });
-    expect(created.environmentId).toBe(environment.id);
+    const createdReceipt = await callMcpTool<McpMutationReceiptType>(
+      adminMcp,
+      "scheduled_tasks_create",
+      {
+        name: `mcp-attach-${crypto.randomUUID()}`,
+        schedule: { type: "interval", everySeconds: 3600 },
+        agentConfig: { prompt: "inspect" },
+        environmentId: environment.id,
+      },
+    );
+    const created = await getScheduledTask(
+      dbClient.db,
+      grant.workspaceId,
+      createdReceipt.resource.id,
+    );
+    expect(created?.variableSetId).toBe(environment.id);
 
     await expect(
       callMcpTool(sandboxMcp, "scheduled_tasks_update", {
-        id: created.id,
+        id: createdReceipt.resource.id,
         environmentId: environment.id,
       }),
     ).rejects.toThrow("missing permission: variable-sets:use");
     await expect(
       callMcpTool(sandboxMcp, "scheduled_tasks_update", {
-        id: created.id,
+        id: createdReceipt.resource.id,
         environmentId: null,
       }),
     ).rejects.toThrow("missing permission: variable-sets:use");
     await expect(
       callMcpTool(sandboxMcp, "scheduled_tasks_update", {
-        id: created.id,
+        id: createdReceipt.resource.id,
         agentConfig: { prompt: "exfiltrate the injected secrets" },
       }),
     ).rejects.toThrow("missing permission: variable-sets:use");
@@ -7378,16 +7506,26 @@ describe("API component integration", () => {
     };
     const mcp = buildOpenGeniMcpServer(mcpDeps, grant);
 
+    const createdReceipt = await callMcpTool<McpMutationReceiptType>(mcp, "session_create", {
+      initialMessage: "take the staging deploy zero-to-one",
+      model: "scripted-model",
+      goal: { text: "staging deployed", successCriteria: "healthz green" },
+    });
+    expect(createdReceipt).toMatchObject({
+      operation: "session_create",
+      outcome: "created",
+      changed: true,
+      resource: { type: "session", state: "queued" },
+      idempotency: { status: "not_requested" },
+    });
+    expect(JSON.stringify(createdReceipt)).not.toContain("take the staging deploy zero-to-one");
     const created = await callMcpTool<{
       id: string;
       status: string;
       model: string;
       temporalWorkflowId: string;
-    }>(mcp, "session_create", {
-      initialMessage: "take the staging deploy zero-to-one",
-      model: "scripted-model",
-      goal: { text: "staging deployed", successCriteria: "healthz green" },
-    });
+      environmentId: string | null;
+    }>(mcp, "session_get", { sessionId: createdReceipt.resource.id });
     expect(created.status).toBe("queued");
     expect(created.model).toBe("scripted-model");
     expect(created.temporalWorkflowId).toBe(`session-${created.id}`);
@@ -7505,19 +7643,23 @@ describe("API component integration", () => {
       boundedForensic.events.every((event) => event.id !== "00000000-0000-0000-0000-000000000000"),
     ).toBeTrue();
 
-    const sent = await callMcpTool<{
-      event: { type: string; payload: { text: string } };
-      turnId: string;
-    }>(mcp, "session_send_message", {
+    const sent = await callMcpTool<McpMutationReceiptType>(mcp, "session_send_message", {
       sessionId: created.id,
       text: "also enable the health alerts",
       idempotencyKey: crypto.randomUUID(),
     });
-    expect(sent.event.type).toBe("user.message");
-    expect(sent.event.payload.text).toBe("also enable the health alerts");
+    expect(sent).toMatchObject({
+      operation: "session_send_message",
+      outcome: "accepted",
+      resource: { type: "session_turn", state: "queued" },
+      idempotency: { status: "applied" },
+    });
+    expect(JSON.stringify(sent)).not.toContain("also enable the health alerts");
     expect(wf.wakeups).toHaveLength(2);
     const turns = await listSessionTurns(dbClient.db, grant.workspaceId, created.id);
-    expect(turns.some((turn) => turn.id === sent.turnId && turn.status === "queued")).toBe(true);
+    expect(turns.some((turn) => turn.id === sent.resource.id && turn.status === "queued")).toBe(
+      true,
+    );
 
     const callerAttemptId = crypto.randomUUID();
     const callerClaim = await claimSessionWorkForAttempt(dbClient.db, grant.workspaceId, {
@@ -7547,19 +7689,21 @@ describe("API component integration", () => {
     )
       .map((turn) => turn.id)
       .sort();
-    const internal = await callMcpTool<{
-      delivered: boolean;
-      updateId: string;
-      delivery: string;
-    }>(workerMcpWithIdentity, "session_send_message", {
-      sessionId: created.id,
-      text: "child result one of several",
-      idempotencyKey: crypto.randomUUID(),
-    });
+    const internal = await callMcpTool<McpMutationReceiptType>(
+      workerMcpWithIdentity,
+      "session_send_message",
+      {
+        sessionId: created.id,
+        text: "child result one of several",
+        idempotencyKey: crypto.randomUUID(),
+      },
+    );
     expect(internal).toMatchObject({
-      delivered: true,
-      delivery: "coalesced_internal_update",
+      outcome: "accepted",
+      resource: { type: "session_system_update", state: "active" },
+      facts: { delivery: "coalesced_internal_update" },
     });
+    expect(JSON.stringify(internal)).not.toContain("child result one of several");
     expect(
       (await listSessionTurns(dbClient.db, grant.workspaceId, created.id))
         .map((turn) => turn.id)
@@ -7569,7 +7713,7 @@ describe("API component integration", () => {
       await listOutstandingSessionSystemUpdates(dbClient.db, grant.workspaceId, created.id),
     ).toEqual([
       expect.objectContaining({
-        id: internal.updateId,
+        id: internal.resource.id,
         kind: "agent_message",
         sourceId: created.id,
         summary: "child result one of several",
@@ -7580,7 +7724,7 @@ describe("API component integration", () => {
     // descendant attempt receives an immediate revisioned control wake; Resume
     // creates no human prompt, and Agent Steer is one typed internal update
     // rather than a fake prompt-queue row.
-    const controlledChild = await callMcpTool<{ id: string }>(
+    const controlledChild = await callMcpTool<McpMutationReceiptType>(
       workerMcpWithIdentity,
       "session_create",
       {
@@ -7590,8 +7734,8 @@ describe("API component integration", () => {
     );
     const childAttemptId = crypto.randomUUID();
     const childClaim = await claimSessionWorkForAttempt(dbClient.db, grant.workspaceId, {
-      sessionId: controlledChild.id,
-      workflowId: `session-${controlledChild.id}`,
+      sessionId: controlledChild.resource.id,
+      workflowId: `session-${controlledChild.resource.id}`,
       workflowRunId: crypto.randomUUID(),
       attemptId: childAttemptId,
       dispatchId: `dispatch-${crypto.randomUUID()}`,
@@ -7601,53 +7745,67 @@ describe("API component integration", () => {
       throw new Error(`controlled child was not claimed: ${childClaim.reason}`);
     }
     const dispatchCountBeforeAgentPause = wf.wakeDispatches;
-    const agentPause = await callMcpTool<{
-      effectiveControl: { state: string };
-      interruptionCount: number;
-    }>(workerMcpWithIdentity, "session_pause", {
-      sessionId: controlledChild.id,
-      idempotencyKey: crypto.randomUUID(),
-      reason: "manager inspection",
-    });
+    const agentPause = await callMcpTool<McpMutationReceiptType>(
+      workerMcpWithIdentity,
+      "session_pause",
+      {
+        sessionId: controlledChild.resource.id,
+        idempotencyKey: crypto.randomUUID(),
+        reason: "manager inspection",
+      },
+    );
     expect(agentPause).toMatchObject({
-      effectiveControl: { state: "paused" },
-      interruptionCount: 1,
+      outcome: "updated",
+      resource: { type: "session", state: "paused" },
+      facts: { interruptionCount: 1 },
     });
+    expect(JSON.stringify(agentPause)).not.toContain("manager inspection");
     expect(wf.wakeDispatches).toBe(dispatchCountBeforeAgentPause + 1);
     const turnsBeforeAgentResume = await listSessionTurns(
       dbClient.db,
       grant.workspaceId,
-      controlledChild.id,
+      controlledChild.resource.id,
     );
-    const agentResume = await callMcpTool<{
-      effectiveControl: { state: string };
-    }>(workerMcpWithIdentity, "session_resume", {
-      sessionId: controlledChild.id,
-      idempotencyKey: crypto.randomUUID(),
-    });
-    expect(agentResume.effectiveControl.state).toBe("active");
+    const agentResume = await callMcpTool<McpMutationReceiptType>(
+      workerMcpWithIdentity,
+      "session_resume",
+      {
+        sessionId: controlledChild.resource.id,
+        idempotencyKey: crypto.randomUUID(),
+      },
+    );
+    expect(agentResume.resource.state).toBe("active");
     expect(
-      (await listSessionTurns(dbClient.db, grant.workspaceId, controlledChild.id)).map(
+      (await listSessionTurns(dbClient.db, grant.workspaceId, controlledChild.resource.id)).map(
         (turn) => turn.id,
       ),
     ).toEqual(turnsBeforeAgentResume.map((turn) => turn.id));
-    const agentSteer = await callMcpTool<{
-      updateId: string;
-      interruptionCount: number;
-    }>(workerMcpWithIdentity, "session_steer", {
-      sessionId: controlledChild.id,
-      instruction: "Inspect the new control-plane evidence first",
-      idempotencyKey: crypto.randomUUID(),
-    });
+    const agentSteer = await callMcpTool<McpMutationReceiptType>(
+      workerMcpWithIdentity,
+      "session_steer",
+      {
+        sessionId: controlledChild.resource.id,
+        instruction: "Inspect the new control-plane evidence first",
+        idempotencyKey: crypto.randomUUID(),
+      },
+    );
     expect(agentSteer).toMatchObject({
-      updateId: expect.any(String),
-      interruptionCount: 1,
+      outcome: "updated",
+      resource: { type: "session_system_update" },
+      facts: { interruptionCount: 1, stoppingPreviousAttempt: true },
     });
+    expect(JSON.stringify(agentSteer)).not.toContain(
+      "Inspect the new control-plane evidence first",
+    );
     expect(
-      await listOutstandingSessionSystemUpdates(dbClient.db, grant.workspaceId, controlledChild.id),
+      await listOutstandingSessionSystemUpdates(
+        dbClient.db,
+        grant.workspaceId,
+        controlledChild.resource.id,
+      ),
     ).toContainEqual(
       expect.objectContaining({
-        id: agentSteer.updateId,
+        id: agentSteer.resource.id,
         kind: "agent_steer_instruction",
         summary: "Inspect the new control-plane evidence first",
       }),
@@ -7682,6 +7840,61 @@ describe("API component integration", () => {
     ]) {
       await expect(callMcpTool(workerMcp, tool, {})).rejects.toThrow("MCP tool not registered");
     }
+  });
+
+  test("MCP session_create returns a compact, truthful idempotent replay receipt", async () => {
+    const workflowClient = new FakeWorkflowClient();
+    const grant = await bootstrapMcpGrant(dbClient.db);
+    const mcp = buildOpenGeniMcpServer(
+      {
+        settings: testSettings({ databaseUrl: services.databaseUrl }),
+        db: dbClient.db,
+        bus: new MemoryEventBus(),
+        workflowClient,
+        objectStorage: null,
+        githubStateSecret: "test-state-secret",
+        documentIndexer: { indexDocument: async () => undefined },
+        getDocumentServices: () => {
+          throw new Error("document services are not used by session replay tests");
+        },
+        resumeBoxById: fakeResumeBoxById,
+      },
+      grant,
+    );
+    const initialMessage = `idempotent secret ${crypto.randomUUID()}`;
+    const idempotencyKey = `compact-receipt-session-create-${crypto.randomUUID()}`;
+    const args = {
+      initialMessage,
+      model: "scripted-model",
+      sandboxBackend: "none",
+      idempotencyKey,
+    };
+
+    const first = await callMcpTool<McpMutationReceiptType>(mcp, "session_create", args);
+    const replay = await callMcpTool<McpMutationReceiptType>(mcp, "session_create", args);
+
+    expect(first).toMatchObject({
+      operation: "session_create",
+      outcome: "created",
+      changed: true,
+      idempotency: { status: "applied" },
+      resource: { type: "session", state: "queued" },
+    });
+    expect(replay).toMatchObject({
+      operation: "session_create",
+      outcome: "replayed",
+      changed: false,
+      idempotency: { status: "replayed" },
+      resource: { type: "session", id: first.resource.id, state: "queued" },
+    });
+    expect(JSON.stringify(first)).not.toContain(initialMessage);
+    expect(JSON.stringify(replay)).not.toContain(initialMessage);
+    expect(await withWorkspaceCount(dbClient.db, grant.workspaceId, idempotencyKey)).toBe(1);
+    expect(await requireSession(dbClient.db, grant.workspaceId, first.resource.id)).toMatchObject({
+      id: first.resource.id,
+      initialMessage,
+      createIdempotencyKey: idempotencyKey,
+    });
   });
 
   test("per-session first-party MCP permissions are capped by the creator and gate the manager tools", async () => {
@@ -7821,16 +8034,17 @@ describe("API component integration", () => {
         firstPartyMcpPermissions: ["environments:manage"],
       }),
     ).rejects.toThrow("cannot grant first-party MCP permission beyond the creating grant");
-    const spawned = await callMcpTool<{
-      id: string;
-      firstPartyMcpPermissions: string[] | null;
-      sandboxBackend: string;
-    }>(managerMcp, "session_create", {
+    const spawnedReceipt = await callMcpTool<McpMutationReceiptType>(managerMcp, "session_create", {
       initialMessage: "spawn a delegated worker",
       model: "scripted-model",
       sandboxBackend: "none",
       firstPartyMcpPermissions: ["sessions:read"],
     });
+    const spawned = await requireSession(
+      dbClient.db,
+      grant.workspaceId,
+      spawnedReceipt.resource.id,
+    );
     expect(spawned.firstPartyMcpPermissions).toEqual(["sessions:read"]);
     expect(spawned.sandboxBackend).toBe("none");
 
@@ -8887,15 +9101,17 @@ describe("API component integration", () => {
     ).rejects.toThrow("missing permission: variable-sets:use (deprecated alias: environments:use)");
 
     const mcp = buildOpenGeniMcpServer(mcpDeps, grant);
-    const attached = await callMcpTool<{
-      id: string;
-      environmentId: string | null;
-    }>(mcp, "session_create", {
+    const attachedReceipt = await callMcpTool<McpMutationReceiptType>(mcp, "session_create", {
       initialMessage: "deploy with cloud credentials",
       model: "scripted-model",
       environmentId: environment.id,
     });
-    expect(attached.environmentId).toBe(environment.id);
+    const attached = await requireSession(
+      dbClient.db,
+      grant.workspaceId,
+      attachedReceipt.resource.id,
+    );
+    expect(attached.variableSetId).toBe(environment.id);
     await expect(
       callMcpTool(mcp, "session_create", {
         initialMessage: "unknown environment",
@@ -8956,11 +9172,12 @@ describe("API component integration", () => {
 
     // Control: a backend:"none" create WITHOUT a target succeeds — no machine
     // is pinned, so nothing exercises the create-time targeting path.
-    const plain = await callMcpTool<{ id: string; sandboxBackend: string }>(mcp, "session_create", {
+    const plainReceipt = await callMcpTool<McpMutationReceiptType>(mcp, "session_create", {
       initialMessage: "no target",
       model: "scripted-model",
       sandboxBackend: "none",
     });
+    const plain = await requireSession(dbClient.db, grant.workspaceId, plainReceipt.resource.id);
     expect(plain.sandboxBackend).toBe("none");
 
     // The fix: targetSandboxId is now declared on the session_create inputSchema,
@@ -9002,39 +9219,43 @@ describe("API component integration", () => {
     const environmentName = `geni-cloud-${crypto.randomUUID()}`;
     const secretValue = `super-secret-${crypto.randomUUID()}`;
 
-    const first = await callMcpTool<{
-      environment: { id: string; name: string; created: boolean };
-      variable: { name: string; version: number };
-    }>(mcp, "environment_set_variable", {
+    const first = await callMcpTool<McpMutationReceiptType>(mcp, "environment_set_variable", {
       environmentName,
       name: "AZURE_CLIENT_SECRET",
       value: secretValue,
     });
-    expect(first.environment.created).toBe(true);
-    expect(first.environment.name).toBe(environmentName);
-    expect(first.variable).toMatchObject({
-      name: "AZURE_CLIENT_SECRET",
-      version: 1,
+    expect(first).toMatchObject({
+      operation: "environment_set_variable",
+      outcome: "created",
+      resource: { type: "variable_set", version: 1, state: "variable_written" },
+      facts: {
+        variableCreated: true,
+        variableSetCreated: true,
+        deprecatedAlias: true,
+      },
     });
+    expect(JSON.stringify(first)).not.toContain(secretValue);
+    expect(JSON.stringify(first)).not.toContain("AZURE_CLIENT_SECRET");
+    expect(JSON.stringify(first)).not.toContain(environmentName);
 
     const rotatedValue = `rotated-${crypto.randomUUID()}`;
-    const rotated = await callMcpTool<{
-      environment: { id: string; created: boolean };
-      variable: { version: number };
-    }>(mcp, "environment_set_variable", {
-      environmentId: first.environment.id,
+    const rotated = await callMcpTool<McpMutationReceiptType>(mcp, "environment_set_variable", {
+      environmentId: first.resource.id,
       name: "AZURE_CLIENT_SECRET",
       value: rotatedValue,
     });
-    expect(rotated.environment.created).toBe(false);
-    expect(rotated.variable.version).toBe(2);
+    expect(rotated).toMatchObject({
+      outcome: "updated",
+      resource: { id: first.resource.id, version: 2 },
+      facts: { variableCreated: false, variableSetCreated: false, deprecatedAlias: true },
+    });
 
     // The stored value round-trips through the operator key, proving the MCP
     // write path encrypts exactly like the REST route.
     const stored = await getWorkspaceEnvironmentValuesForRun(
       dbClient.db,
       grant.workspaceId,
-      first.environment.id,
+      first.resource.id,
     );
     const key = new Uint8Array(Buffer.from(environmentsTestKey, "base64"));
     expect(decryptEnvironmentValue(key, stored!.values["AZURE_CLIENT_SECRET"]!)).toBe(rotatedValue);
@@ -9047,7 +9268,7 @@ describe("API component integration", () => {
       }>;
     }>(mcp, "environment_list", {});
     const listedEnvironment = listedEnvironments.environments.find(
-      (candidate) => candidate.id === first.environment.id,
+      (candidate) => candidate.id === first.resource.id,
     );
     expect(listedEnvironment?.variables).toEqual([
       expect.objectContaining({ name: "AZURE_CLIENT_SECRET", version: 2 }),
@@ -9072,7 +9293,7 @@ describe("API component integration", () => {
     ).rejects.toThrow("environment variable names must match");
     await expect(
       callMcpTool(mcp, "environment_set_variable", {
-        environmentId: first.environment.id,
+        environmentId: first.resource.id,
         environmentName,
         name: "AMBIGUOUS",
         value: "nope",
@@ -9096,9 +9317,9 @@ describe("API component integration", () => {
     const useOnlyList = await callMcpTool<{
       environments: Array<{ id: string }>;
     }>(useOnlyMcp, "environment_list", {});
-    expect(
-      useOnlyList.environments.some((candidate) => candidate.id === first.environment.id),
-    ).toBe(true);
+    expect(useOnlyList.environments.some((candidate) => candidate.id === first.resource.id)).toBe(
+      true,
+    );
     await expect(
       callMcpTool(useOnlyMcp, "environment_set_variable", {
         environmentName,


### PR DESCRIPTION
## Summary

- bound scheduled-task schedule projections with typed UTF-8/envelope facts
- degrade oversized detail deterministically instead of throwing `RangeError`
- keep pagination advancing when rows are omitted, with dropped IDs and retrieval guidance
- use the supported receipt transition in replay/settlement tests

## Validation

- adversarial scheduled-task tests: 6/6
- focused receipt tests: 25/25
- real PostgreSQL/FORCE-RLS receipt tests: 4/4
- affected MCP/rig tests: 9/9
- TypeScript typecheck: 23 projects
- lint, format, docs references, public hygiene, production build and bundle budgets: passed
- OPE-85 shared contracts compatibility: 76/76; synthetic combined tree `5e9c57cc9f062dca462cc2d1447bc2cc6caedf5b`

Linear: OPE-83. Keep the issue open until identical production deployment and live verification.
