### PR TITLE
chore(release): bump product version to 0.22.80

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.79
-appVersion: "0.22.79"
+version: 0.22.80
+appVersion: "0.22.80"


### PR DESCRIPTION
## Summary
- bump the OpenGeni Helm chart and app version from 0.22.79 to 0.22.80
- reserve the next product release for the merged sandbox availability and provider-loss fixes

## Ordering
Merge generated package Version PR #1101 first. This chart-only patch is disjoint and its exact-head CI may run in parallel, but it must merge second.

## Validation
- two-line Chart.yaml-only diff
- exact-head protected CI and source admission required before merge