### PR TITLE
fix(release): retain reviewed heads across moving main

### DIFF
--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -840,12 +840,19 @@ export async function recoverReleaseHeadEvidence(options = {}) {
       "release-head pull-request timeline",
     ),
   ]);
-  invariant(
-    source.treeSha === head.treeSha,
-    "release-head merged source tree differs from the reviewed head",
-  );
   assertProviderMergeEvent(timeline, context.sourceSha, pullIdentity);
-  const mergeMethod = await classifyMergeOutcome(api, source, pullIdentity);
+  // A provider squash can be based on a newer, disjoint main commit than the
+  // PR's event base. In that case the merged source tree correctly contains
+  // both the reviewed head delta and the intervening main delta, so whole-tree
+  // equality is not a valid retention precondition. The provider-owned merged
+  // PR identity and timeline event above bind the exact base, head, merge SHA,
+  // actor, and timestamp; historical source admission below independently
+  // proves the reviewed base→head file manifest. The ordinary release verifier
+  // remains responsible for proving the final source composition.
+  const mergeMethod =
+    source.treeSha === head.treeSha
+      ? await classifyMergeOutcome(api, source, pullIdentity)
+      : "provider-verified-moving-main";
   await assertSourceAncestorOfCurrentMain(api, context.sourceSha, context.sha);
   const historicalAdmission = await verifyHistoricalSourceAdmission({
     number: context.prNumber,

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -1390,6 +1390,46 @@ describe("release head retention recovery", () => {
     ).toBe(false);
   });
 
+  test("retains the reviewed head when the provider squashes it after disjoint main movement", async () => {
+    const fixture = recoverySealFixture({
+      sourceTreeSha: "9".repeat(40),
+      releaseHeadRef: null,
+      release: null,
+    });
+
+    const result = await recoverReleaseHeadEvidence({
+      env: recoverySealEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+      now: () => new Date("2026-07-27T09:30:00Z"),
+    });
+
+    expect(result).toMatchObject({
+      baseSha,
+      headSha,
+      sourceSha: mergeSha,
+      mergeMethod: "provider-verified-moving-main",
+      releaseHead: {
+        ref: `refs/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${headSha}`,
+        sha: headSha,
+      },
+    });
+    expect(
+      fixture.requests.filter(
+        (request) => request.method === "POST" && request.path.endsWith("/git/refs"),
+      ),
+    ).toHaveLength(1);
+    expect(
+      fixture.checks.find(
+        (check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.releaseHeadRetention,
+      ),
+    ).toMatchObject({
+      head_sha: headSha,
+      status: "completed",
+      conclusion: "success",
+    });
+  });
+
   test("rejects a conflicting retention check for an exact retained pair before mutation", async () => {
     const fixture = recoverySealFixture();
     const options = {


### PR DESCRIPTION
Fix the exact post-merge release-head recovery failure exposed by the 0.22.80 train.

- accept provider-owned merged PR/timeline identity when the final source tree also contains disjoint main movement
- retain historical base→head source admission as the reviewed patch proof
- keep final source composition verification in the ordinary release verifier
- add a clean-absent immutable retention regression

Local validation: 66/66 focused release-automation tests, oxlint deny-warnings, oxfmt check, and diff hygiene.