### PR TITLE
fix(runtime): bound MCP transport error inspection

### DIFF
--- a/.changeset/bound-mcp-error-inspection.md
+++ b/.changeset/bound-mcp-error-inspection.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Bound nested MCP transport error inspection and fail closed on pathological wrappers.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3736,11 +3736,18 @@ function safeMcpErrorFields(error: unknown): {
   errorClass: string;
   status?: number;
 } {
-  const errorClass = error instanceof Error ? error.constructor.name : typeof error;
-  const raw = (error as { code?: unknown; status?: unknown } | null)?.code;
+  let errorClass: string;
+  let raw: unknown;
+  let altRaw: unknown;
+  try {
+    errorClass = error instanceof Error ? error.constructor.name : typeof error;
+    raw = (error as { code?: unknown; status?: unknown } | null)?.code;
+    altRaw = (error as { status?: unknown } | null)?.status;
+  } catch {
+    return { errorClass: "unknown" };
+  }
   const status = typeof raw === "number" ? raw : undefined;
   if (status === undefined) {
-    const altRaw = (error as { status?: unknown } | null)?.status;
     return typeof altRaw === "number" ? { errorClass, status: altRaw } : { errorClass };
   }
   return { errorClass, status };
@@ -3759,40 +3766,106 @@ const MCP_CONNECTIVITY_ERROR_CODES = new Set([
   "ECONNREFUSED",
   "EPIPE",
 ]);
+const MCP_REQUEST_TIMEOUT_MESSAGES = new Set([
+  "Request timed out",
+  "MCP error -32001: Request timed out",
+  "Maximum total timeout exceeded",
+  "MCP error -32001: Maximum total timeout exceeded",
+]);
 
-function mcpTransportHttpStatuses(error: unknown, seen = new WeakSet<object>()): number[] {
-  if (!error || typeof error !== "object" || seen.has(error)) {
-    return [];
-  }
-  seen.add(error);
-  const record = error as Record<string, unknown>;
+const MCP_TRANSPORT_ERROR_MAX_DEPTH = 8;
+const MCP_TRANSPORT_ERROR_MAX_NODES = 32;
+const MCP_TRANSPORT_ERROR_NESTED_KEYS = ["error", "cause", "response", "data"] as const;
+
+function inspectMcpTransportError(
+  error: unknown,
+  seen = new WeakSet<object>(),
+): {
+  complete: boolean;
+  hasConnectivityCode: boolean;
+  hasConnectivityMarker: boolean;
+  hasRequestTimeout: boolean;
+  statuses: number[];
+} {
+  const pending: Array<{ depth: number; value: unknown }> = [{ depth: 0, value: error }];
   const statuses: number[] = [];
-  for (const value of [record.status, record.statusCode, record.code]) {
-    if (typeof value === "number" && Number.isFinite(value) && value >= 100 && value <= 599) {
-      statuses.push(value);
+  let hasConnectivityCode = false;
+  let hasConnectivityMarker = false;
+  let hasRequestTimeout = false;
+  let inspectedNodes = 0;
+  let complete = true;
+
+  while (pending.length > 0 && inspectedNodes < MCP_TRANSPORT_ERROR_MAX_NODES) {
+    const current = pending.shift()!;
+    if (!current.value || typeof current.value !== "object" || seen.has(current.value)) {
+      continue;
+    }
+    seen.add(current.value);
+    inspectedNodes += 1;
+    const record = current.value as Record<string, unknown>;
+    let statusValues: unknown[];
+    let code: unknown;
+    let failureKind: unknown;
+    let message: unknown;
+    try {
+      statusValues = [record.status, record.statusCode, record.code];
+      code = record.code;
+      failureKind = record.mcpTransportFailureKind;
+      message = record.message;
+    } catch {
+      complete = false;
+      continue;
+    }
+    for (const value of statusValues) {
+      if (typeof value === "number" && Number.isFinite(value) && value >= 100 && value <= 599) {
+        statuses.push(value);
+      }
+    }
+    if (typeof code === "string" && MCP_CONNECTIVITY_ERROR_CODES.has(code.toUpperCase())) {
+      hasConnectivityCode = true;
+    }
+    if (failureKind === "connectivity_unavailable") {
+      hasConnectivityMarker = true;
+    }
+    const timeoutCode = typeof code === "number" ? code : statusValues[0];
+    if (
+      failureKind === "request_timeout" ||
+      (timeoutCode === -32_001 &&
+        typeof message === "string" &&
+        MCP_REQUEST_TIMEOUT_MESSAGES.has(message))
+    ) {
+      hasRequestTimeout = true;
+    }
+
+    for (const key of MCP_TRANSPORT_ERROR_NESTED_KEYS) {
+      let nested: unknown;
+      try {
+        nested = record[key];
+      } catch {
+        complete = false;
+        continue;
+      }
+      if (!nested || typeof nested !== "object" || seen.has(nested)) {
+        continue;
+      }
+      if (current.depth >= MCP_TRANSPORT_ERROR_MAX_DEPTH) {
+        complete = false;
+        continue;
+      }
+      pending.push({ depth: current.depth + 1, value: nested });
     }
   }
-  for (const key of ["error", "cause", "response", "data"]) {
-    statuses.push(...mcpTransportHttpStatuses(record[key], seen));
-  }
-  return statuses;
-}
 
-function hasMcpConnectivityErrorCode(error: unknown, seen = new WeakSet<object>()): boolean {
-  if (!error || typeof error !== "object" || seen.has(error)) {
-    return false;
+  if (pending.length > 0) {
+    complete = false;
   }
-  seen.add(error);
-  const record = error as Record<string, unknown>;
-  if (
-    typeof record.code === "string" &&
-    MCP_CONNECTIVITY_ERROR_CODES.has(record.code.toUpperCase())
-  ) {
-    return true;
-  }
-  return ["error", "cause", "response", "data"].some((key) =>
-    hasMcpConnectivityErrorCode(record[key], seen),
-  );
+  return {
+    complete,
+    hasConnectivityCode,
+    hasConnectivityMarker,
+    hasRequestTimeout,
+    statuses,
+  };
 }
 
 /**
@@ -3805,17 +3878,20 @@ function isRawMcpTransportConnectivityError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
   }
-  if ((error as Record<string, unknown>).mcpTransportFailureKind === "connectivity_unavailable") {
+  const inspection = inspectMcpTransportError(error);
+  if (inspection.hasConnectivityMarker) {
     return true;
   }
-  const statuses = mcpTransportHttpStatuses(error);
-  if (statuses.some((status) => status >= 400 && status < 500)) {
+  if (!inspection.complete) {
     return false;
   }
-  if (statuses.some((status) => status >= 500 && status < 600)) {
+  if (inspection.statuses.some((status) => status >= 400 && status < 500)) {
+    return false;
+  }
+  if (inspection.statuses.some((status) => status >= 500 && status < 600)) {
     return true;
   }
-  return hasMcpConnectivityErrorCode(error);
+  return inspection.hasConnectivityCode;
 }
 
 /**
@@ -3838,31 +3914,7 @@ export function isMcpTransportConnectivityError(error: unknown): boolean {
  * AbortSignal reasons, so only the SDK's two owned timeout messages qualify.
  */
 export function isMcpRequestTimeoutError(error: unknown, seen = new WeakSet<object>()): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-  if (seen.has(error)) {
-    return false;
-  }
-  seen.add(error);
-  const record = error as Record<string, unknown>;
-  if (record.mcpTransportFailureKind === "request_timeout") {
-    return true;
-  }
-  const code = typeof record.code === "number" ? record.code : record.status;
-  const message = typeof record.message === "string" ? record.message : "";
-  const sdkTimeoutMessages = new Set([
-    "Request timed out",
-    "MCP error -32001: Request timed out",
-    "Maximum total timeout exceeded",
-    "MCP error -32001: Maximum total timeout exceeded",
-  ]);
-  if (code === -32_001 && sdkTimeoutMessages.has(message)) {
-    return true;
-  }
-  return ["error", "cause", "response", "data"].some((key) =>
-    isMcpRequestTimeoutError(record[key], seen),
-  );
+  return inspectMcpTransportError(error, seen).hasRequestTimeout;
 }
 
 export function safeMcpTransportError(error: unknown): SafeMcpTransportError {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -211,6 +211,28 @@ test("does not turn MCP client failures or arbitrary codes into connectivity rec
   expect(safeMcpTransportError(arbitrary)).not.toHaveProperty("mcpTransportFailureKind");
 });
 
+test("fails closed on pathological MCP transport error wrappers", () => {
+  let deeplyWrapped: Record<string, unknown> = { code: "ECONNREFUSED" };
+  for (let depth = 0; depth < 10; depth += 1) {
+    deeplyWrapped = { cause: deeplyWrapped };
+  }
+  const throwingWrapper = {
+    code: "ECONNRESET",
+    get cause(): unknown {
+      throw new Error("unsafe transport getter");
+    },
+  };
+  const throwingFields = {
+    get code(): unknown {
+      throw new Error("unsafe code getter");
+    },
+  };
+
+  expect(isMcpTransportConnectivityError(safeMcpTransportError(deeplyWrapped))).toBe(false);
+  expect(isMcpTransportConnectivityError(safeMcpTransportError(throwingWrapper))).toBe(false);
+  expect(isMcpTransportConnectivityError(safeMcpTransportError(throwingFields))).toBe(false);
+});
+
 describe("structured human-input runtime boundary", () => {
   const interruption = {
     name: HUMAN_INPUT_TOOL_NAME,


### PR DESCRIPTION
## Summary

- bound nested MCP transport error inspection by depth and node count
- fail closed when wrapped provider errors expose throwing fields or exceed the inspection budget
- preserve the existing secret-safe timeout and connectivity markers
- cover deeply nested and throwing wrapper regressions

## Why

The required-MCP recovery path merged in #1051 classified nested transport errors recursively. A pathological SDK/provider wrapper could make the error handler recurse excessively or throw from a property getter while handling an outage. This keeps recovery classification bounded and terminal-by-default when the wrapper cannot be inspected safely.

## Validation

- `bun test packages/runtime/test/runtime.test.ts` — 213 pass
- `bun run typecheck` — all 23 projects clean
- `bun run lint`
- `bun run format:check`
- `bun run check:docs-refs`
- `bun run check:public-hygiene`
- `git diff --check`

No deployment or publication was run.