### PR TITLE
Stop false Codex capacity resumes

### DIFF
--- a/.changeset/quiet-capacity-waits.md
+++ b/.changeset/quiet-capacity-waits.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": patch
+"@opengeni/worker-bundle": patch
+---
+
+Keep capped rotation-off Codex sessions in one durable capacity wait and suppress wakes for identical usage snapshots.

--- a/apps/worker/src/activities/codex-capacity.ts
+++ b/apps/worker/src/activities/codex-capacity.ts
@@ -12,6 +12,7 @@ import {
   CODEX_USAGE_EXHAUSTED_PCT,
   authoritativeCodexCapacityResetAt,
   isCodexCredentialEligible,
+  isCodexCredentialHealthy,
   selectCodexCredentialLeaseForTurn,
 } from "./codex-rotation";
 import type {
@@ -96,7 +97,15 @@ export function codexCapacityDecision(
     sessionLastCredentialId: context.sessionLastCredentialId,
     now,
   });
-  if (selected.credentialId) {
+  const selectedAccount = selected.credentialId
+    ? context.accounts.find((account) => account.id === selected.credentialId)
+    : undefined;
+  const selectedIsAvailable =
+    selectedAccount !== undefined &&
+    (selectedAccount.id === context.existingCredentialId
+      ? isCodexCredentialHealthy(selectedAccount, now)
+      : isCodexCredentialEligible(selectedAccount, now));
+  if (selected.credentialId && selectedIsAvailable) {
     return {
       kind: "available",
       credentialId: selected.credentialId,

--- a/apps/worker/src/activities/codex-rotation.ts
+++ b/apps/worker/src/activities/codex-rotation.ts
@@ -694,13 +694,27 @@ export function selectCodexCredentialLeaseForTurn(args: {
 
   // A stale policy pin is intentionally ignored here and cleared by the caller
   // after the atomic selection. Rotation-off/unpinned behavior otherwise keeps
-  // the pre-lease pin > active-pointer contract.
+  // the pre-lease pin > active-pointer contract. The pointer is preference, not
+  // proof of capacity: rotation-off must wait on a capped pointer rather than
+  // falsely admitting it or silently failing over to another subscription.
   if (!rotationEnabled) {
-    const credentialId =
-      activeCredentialId && connectedIds.has(activeCredentialId) ? activeCredentialId : null;
+    const active = activeCredentialId
+      ? accounts.find((account) => account.id === activeCredentialId)
+      : undefined;
+    if (!active?.allocatorEnabled) {
+      return { credentialId: null, decision: { kind: "none" }, advanceActivePointer: false };
+    }
+    if (!isCodexCredentialHealthy(active, args.now)) {
+      return {
+        credentialId: null,
+        decision: { kind: "allCapped", earliestResetAt: availableAt(active, args.now) },
+        advanceActivePointer: false,
+      };
+    }
     return {
-      credentialId,
-      decision: credentialId ? { kind: "active", credentialId, moved: false } : { kind: "none" },
+      credentialId: active.id,
+      decision: { kind: "active", credentialId: active.id, moved: false },
+      advanceActivePointer: false,
     };
   }
 

--- a/apps/worker/test/codex-capacity.test.ts
+++ b/apps/worker/test/codex-capacity.test.ts
@@ -73,6 +73,42 @@ describe("Codex capacity availability diagnostics", () => {
     });
   });
 
+  test("rotation-off capped active account stays unavailable despite a healthy alternate", () => {
+    const resetAt = new Date("2100-01-01T00:00:00.000Z");
+    const context: CodexCapacitySelectionContext = {
+      accounts: [
+        account("active-capped", { primaryUsedPercent: 100, primaryResetAt: resetAt }),
+        account("healthy-alternate"),
+      ],
+      activeCredentialId: "active-capped",
+      rotationEnabled: false,
+      leaseRotationEnabled: false,
+      rotationStrategy: "sharded",
+      existingCredentialId: null,
+      policyScope: null,
+      unavailableDiagnostics: [],
+      sessionId: "session-rotation-off",
+      sessionPinnedCredentialId: null,
+      sessionPinSource: null,
+      sessionLastCredentialId: null,
+      policyHash: null,
+    };
+
+    expect(
+      codexCapacityDecision(
+        context,
+        testSettings({
+          codexCredentialLeasingEnabled: true,
+        }),
+      ),
+    ).toMatchObject({
+      kind: "unavailable",
+      earliestResetAt: resetAt,
+      resetKind: "authoritative",
+      diagnostic: { connectedCount: 2, allocatorEnabledCount: 2 },
+    });
+  });
+
   test("committed capacity targets prefer typed signals and retain generic outbox delivery", async () => {
     const target = {
       accountId: "account",

--- a/apps/worker/test/codex-rotation.test.ts
+++ b/apps/worker/test/codex-rotation.test.ts
@@ -1183,6 +1183,31 @@ describe("credential allocator pin and rollout policy", () => {
     expect(selected.credentialId).toBe("a");
   });
 
+  test("rotation false waits on a capped active pointer without failing over", () => {
+    const resetAt = new Date(NOW.getTime() + HOUR);
+    const selected = selectCodexCredentialLeaseForTurn({
+      context: {
+        ...context([
+          leasedAcct("a", { primaryUsedPercent: 100, primaryResetAt: resetAt }),
+          leasedAcct("b"),
+        ]),
+        rotationEnabled: false,
+        leaseRotationEnabled: false,
+      },
+      leasingEnabled: true,
+      sessionId: "session-test",
+      sessionPinSource: null,
+      sessionPinnedCredentialId: null,
+      sessionLastCredentialId: "b",
+      now: NOW,
+    });
+    expect(selected).toEqual({
+      credentialId: null,
+      decision: { kind: "allCapped", earliestResetAt: resetAt },
+      advanceActivePointer: false,
+    });
+  });
+
   test("sharded-rotation policy: stored round_robin behaves EXACTLY as sharded in the lease selector (sticky, never advancing)", () => {
     const args = (rotationStrategy: string) => ({
       context: {

--- a/docs/codex-subscription-rotation.md
+++ b/docs/codex-subscription-rotation.md
@@ -229,6 +229,12 @@ waiter as resumed/stale and performs no work.
 eligibility or future pool membership/default write: it locks the workspace
 rotation row first, applies the mutation, increments matching waiter wake
 revisions only when truth changed, and returns secret-safe signal targets.
+Refreshing only `usage_checked_at` or reset-credit display metadata is not a
+capacity-truth change; an identical quota snapshot must not advance waiter or
+workflow wake revisions. With rotation disabled, an unpinned turn considers only
+the workspace active pointer: a capped pointer enters the same durable wait and
+never becomes “available” merely because it remains connected, while healthy
+alternate subscriptions remain unused until rotation is explicitly enabled.
 `listPendingCodexCapacityWakeTargets` repairs commit→signal loss. The session
 workflow's `codexCapacityChanged` signal is only a nudge; the Postgres revision
 is authoritative. The workflow snapshots its wake counters before dispatching a

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -15113,6 +15113,24 @@ export async function recordCodexAccountUsageWithWakeTargets(
     db,
     { workspaceId, reason: "codex_usage_refreshed" },
     async (tx) => {
+      const [previous] = await tx
+        .select({
+          primaryUsedPercent: schema.codexSubscriptionCredentials.primaryUsedPercent,
+          primaryResetAt: schema.codexSubscriptionCredentials.primaryResetAt,
+          secondaryUsedPercent: schema.codexSubscriptionCredentials.secondaryUsedPercent,
+          secondaryResetAt: schema.codexSubscriptionCredentials.secondaryResetAt,
+        })
+        .from(schema.codexSubscriptionCredentials)
+        .where(
+          and(
+            eq(schema.codexSubscriptionCredentials.id, credentialId),
+            eq(schema.codexSubscriptionCredentials.workspaceId, workspaceId),
+          ),
+        )
+        .for("update");
+      if (!previous) {
+        return { result: false, changed: false };
+      }
       const updated = await tx
         .update(schema.codexSubscriptionCredentials)
         .set({
@@ -15142,8 +15160,17 @@ export async function recordCodexAccountUsageWithWakeTargets(
           ),
         )
         .returning({ id: schema.codexSubscriptionCredentials.id });
-      const changed = updated.length > 0;
-      return { result: changed, changed };
+      const rowUpdated = updated.length > 0;
+      const timestampChanged = (before: Date | null, after: Date | null): boolean =>
+        before?.getTime() !== after?.getTime();
+      const capacityChanged =
+        rowUpdated &&
+        snapshot.checkedAt !== undefined &&
+        (previous.primaryUsedPercent !== (snapshot.primaryUsedPercent ?? null) ||
+          timestampChanged(previous.primaryResetAt, snapshot.primaryResetAt ?? null) ||
+          previous.secondaryUsedPercent !== (snapshot.secondaryUsedPercent ?? null) ||
+          timestampChanged(previous.secondaryResetAt, snapshot.secondaryResetAt ?? null));
+      return { result: rowUpdated, changed: capacityChanged };
     },
   );
 }

--- a/packages/db/test/codex-capacity-waiters.test.ts
+++ b/packages/db/test/codex-capacity-waiters.test.ts
@@ -19,6 +19,7 @@ import {
   listPendingCodexCapacityWakeTargets,
   mutateSessionControlInTransaction,
   reconcileCodexCapacityWait,
+  recordCodexAccountUsageWithWakeTargets,
   registerPendingSessionToolCall,
   setSessionCodexPin,
   submitHumanPromptInTransaction,
@@ -724,6 +725,48 @@ describe("durable Codex capacity waits", () => {
       executionGeneration: 2,
     });
     expect(claimed[0]?.activeAttemptId).not.toBe(scenario.attemptId);
+  });
+
+  test("an identical usage refresh updates freshness without advancing waiter revisions", async () => {
+    if (!available) return;
+    const ws = await freshWorkspace();
+    const credentialId = await connectCredential(ws, false);
+    const scenario = await seedScenario(ws);
+    const armed = await arm(scenario);
+    if (armed.action !== "waiting") throw new Error("expected waiter");
+    const resetAt = new Date(Date.now() + 5 * 60 * 60_000);
+    const first = await recordCodexAccountUsageWithWakeTargets(dbA, ws.workspaceId, credentialId, {
+      primaryUsedPercent: 100,
+      primaryResetAt: resetAt,
+      secondaryUsedPercent: 25,
+      secondaryResetAt: null,
+      checkedAt: new Date(),
+    });
+    expect(first.result).toBe(true);
+    expect(first.wakeTargets).toEqual([
+      expect.objectContaining({
+        waiterId: armed.waiter.id,
+        wakeRevision: armed.waiter.wakeRevision + 1,
+      }),
+    ]);
+
+    const repeated = await recordCodexAccountUsageWithWakeTargets(
+      dbA,
+      ws.workspaceId,
+      credentialId,
+      {
+        primaryUsedPercent: 100,
+        primaryResetAt: resetAt,
+        secondaryUsedPercent: 25,
+        secondaryResetAt: null,
+        checkedAt: new Date(Date.now() + 1_000),
+      },
+    );
+    expect(repeated.result).toBe(true);
+    expect(repeated.wakeTargets).toEqual([]);
+    expect(
+      (await getCodexCapacityWaitForSession(dbA, ws.workspaceId, scenario.sessionId))?.wakeRevision,
+    ).toBe(first.wakeTargets[0]!.wakeRevision);
   });
 
   test("a policy-pin CAS advances the waiter outbox in the same allocator transaction", async () => {


### PR DESCRIPTION
## Summary
- fail closed when a rotation-disabled workspace's active Codex credential is capped instead of treating connection membership as available capacity
- preserve explicit rotation-off semantics: wait on the active pointer without silently using a healthy alternate
- defensively revalidate the selected credential against the allocator's full health predicate before resuming a durable waiter
- update quota freshness without advancing waiter/workflow wake revisions for an identical usage snapshot
- document the rotation-off and capacity-truth wake invariants and publish patch changesets

## Incident fixed
A capped active credential in a rotation-disabled workspace was selected as available on every capacity re-evaluation. Repeated usage refreshes then advanced wake revisions even when only `usage_checked_at` changed. Together these resumed the same blocked turn hundreds of times, reprovisioning and reattaching its sandbox before the provider returned the same quota error.

## Safety
- no automatic failover is introduced while rotation is off
- manual pins and existing healthy same-turn leases retain their current behavior
- quota/reset field changes still wake durable waiters; timestamp-only and reset-credit display refreshes do not
- no session, turn, queue, or sandbox lifecycle path is added

## Verification
- `bun run typecheck` — all 23 projects clean
- `bun run lint`
- `bun run format:check`
- `bun run check:docs-refs`
- `bun test --timeout 120000 apps/worker/test/codex-rotation.test.ts apps/worker/test/codex-capacity.test.ts packages/db/test/codex-capacity-waiters.test.ts` — 89 passed, including real PostgreSQL waiter/outbox coverage
- `bunx changeset status` — valid release plan
