### PR TITLE
fix(auth): preserve managed session renewal cookies

### DIFF
--- a/.changeset/fresh-cookies-renew.md
+++ b/.changeset/fresh-cookies-renew.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/core": patch
+---
+
+Preserve sliding managed-session renewal cookies on protected API responses so active browser sessions do not expire at their original sign-in boundary.

--- a/apps/api/src/auth/managed-auth.ts
+++ b/apps/api/src/auth/managed-auth.ts
@@ -151,22 +151,6 @@ export function createManagedAuth(settings: Settings, db: Database): ManagedAuth
   }) as ManagedAuth;
 }
 
-export async function managedSessionAccessContext(
-  auth: ManagedAuth,
-  db: Database,
-  headers: Headers,
-) {
-  const session = await auth.api.getSession({ headers });
-  if (!session?.user) {
-    return null;
-  }
-  return await ensureManagedAccessForUser(db, {
-    userId: session.user.id,
-    email: session.user.email,
-    name: session.user.name,
-  });
-}
-
 function betterAuthBaseUrl(settings: Settings) {
   const allowedHosts = splitCsv(settings.betterAuthAllowedHosts);
   if (allowedHosts.length === 0) {

--- a/apps/api/src/routes/codex.ts
+++ b/apps/api/src/routes/codex.ts
@@ -150,7 +150,12 @@ export function codexModelsForPicker(liveSlugs: readonly string[]): Array<{
   }));
 }
 import { createSignedState, readSignedState } from "@opengeni/github";
-import { hasPermission, requireAccessGrant, type ApiRouteDeps } from "@opengeni/core";
+import {
+  getManagedSession,
+  hasPermission,
+  requireAccessGrant,
+  type ApiRouteDeps,
+} from "@opengeni/core";
 import type { Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import * as z from "zod/v4";
@@ -190,9 +195,7 @@ async function managedCookieHuman(
   ) {
     return null;
   }
-  const session = await deps.managedAuth.api.getSession({
-    headers: c.req.raw.headers,
-  });
+  const session = await getManagedSession(c, deps.managedAuth);
   if (!session?.user?.id || !session.session?.id) return null;
   return {
     subjectId: `user:${session.user.id}`,

--- a/apps/api/test/codex-redemption-routes.test.ts
+++ b/apps/api/test/codex-redemption-routes.test.ts
@@ -196,7 +196,10 @@ function app(
     managedAuth: {
       handler: async () => new Response("not used", { status: 404 }),
       api: {
-        getSession: async ({ headers }: { headers: Headers }) => cookieSession(headers),
+        getSession: async ({ headers }: { headers: Headers }) => ({
+          headers: new Headers(),
+          response: cookieSession(headers),
+        }),
       },
     } as any,
     codexFetch: options.codexFetch ?? (provider.fetch.bind(provider) as typeof fetch),
@@ -287,10 +290,31 @@ describe("Codex quota managed-cookie-only reset redemption API", () => {
     expect(signin.status).toBeLessThan(300);
     const cookie = signin.headers.get("set-cookie");
     expect(cookie).toBeTruthy();
+
+    const [agedSession] = await admin`
+      update auth_sessions
+      set expires_at = now() + interval '5 days',
+          updated_at = now() - interval '2 days'
+      where user_id = (select id from auth_users where email = ${email})
+      returning expires_at`;
+    expect(agedSession).toBeTruthy();
+
     const access = await actual.request("/v1/access/me", {
       headers: { cookie: cookie! },
     });
     expect(access.status).toBe(200);
+    const renewedCookie = access.headers
+      .getSetCookie()
+      .find((value) => value.includes("session_token="));
+    expect(renewedCookie).toBeTruthy();
+    const [refreshedSession] = await admin`
+      select expires_at
+      from auth_sessions
+      where user_id = (select id from auth_users where email = ${email})`;
+    expect(refreshedSession!.expires_at.getTime()).toBeGreaterThan(
+      agedSession!.expires_at.getTime(),
+    );
+
     const context = (await access.json()) as AccessContext;
     const ownerSubject = context.workspaceGrants[0]!.subjectId;
     expect(ownerSubject).toStartWith("user:");
@@ -321,7 +345,7 @@ describe("Codex quota managed-cookie-only reset redemption API", () => {
       connected.id,
       "credit-reset",
       crypto.randomUUID(),
-      browserHeaders(cookie!),
+      browserHeaders(renewedCookie!),
     );
     expect(prepared.response.status).toBe(200);
     expect(prepared.body.confirmationToken).toBeString();

--- a/apps/api/test/preference-registry.test.ts
+++ b/apps/api/test/preference-registry.test.ts
@@ -394,7 +394,10 @@ describe("structured preference registry API and PostgreSQL authority", () => {
       db: client.db,
       managedAuth: {
         api: {
-          getSession: async () => ({ user }),
+          getSession: async () => ({
+            headers: new Headers(),
+            response: { user },
+          }),
         },
       },
     } as unknown as ApiRouteDeps);

--- a/packages/core/src/access/index.ts
+++ b/packages/core/src/access/index.ts
@@ -17,6 +17,7 @@ import {
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { ManagedAuth } from "../managed-auth-type";
+import { getManagedSession } from "../managed-session";
 
 const bearerPrefix = "Bearer ";
 
@@ -210,9 +211,7 @@ async function resolveAccessContext(c: Context, deps: AccessDeps): Promise<Acces
   }
 
   if (deps.managedAuth) {
-    const session = await deps.managedAuth.api.getSession({
-      headers: c.req.raw.headers,
-    });
+    const session = await getManagedSession(c, deps.managedAuth);
     if (session?.user) {
       return await ensureManagedAccessForUser(deps.db, {
         userId: session.user.id,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export * from "./workflow-wake-contract";
 // structural TYPES live here.
 export * from "./sandbox-types";
 export * from "./managed-auth-type";
+export * from "./managed-session";
 export * from "./transcription";
 
 // Sandbox fleet/routing service — the closure of `domain/sessions.ts`

--- a/packages/core/src/managed-auth-type.ts
+++ b/packages/core/src/managed-auth-type.ts
@@ -1,9 +1,10 @@
 // @opengeni/core ManagedAuth TYPE alias.
 //
 // WHY THIS MODULE LIVES IN CORE: `dependencies.ts` carries a `managedAuth?:
-// ManagedAuth | null` passthrough slot and the access layer calls
-// `managedAuth.api.getSession({ headers })`. Both are framework-agnostic, so
-// they belong in @opengeni/core. The CONSTRUCTION of a real Better Auth
+// ManagedAuth | null` passthrough slot and the access layer resolves managed
+// sessions through the cookie-renewing bridge in `managed-session.ts`. The
+// auth type is framework-agnostic, so it belongs in @opengeni/core. The
+// CONSTRUCTION of a real Better Auth
 // instance — `createManagedAuth`, which opens its own `pg.Pool` and wires
 // Resend — stays in `apps/api/src/auth/managed-auth.ts` (it pulls the `pg`
 // driver, which must NEVER enter @opengeni/core).

--- a/packages/core/src/managed-session.ts
+++ b/packages/core/src/managed-session.ts
@@ -1,0 +1,36 @@
+import type { Context } from "hono";
+import type { ManagedAuth } from "./managed-auth-type";
+
+/**
+ * Read a Better Auth session without bypassing its sliding-cookie renewal.
+ *
+ * Better Auth can refresh the durable session while resolving `getSession`.
+ * Programmatic callers must explicitly request and forward the returned cookie
+ * headers; the HTTP handler does this automatically, but direct API calls do not.
+ */
+export async function getManagedSession(c: Context, auth: ManagedAuth) {
+  const result = await auth.api.getSession({
+    headers: c.req.raw.headers,
+    returnHeaders: true,
+  });
+
+  for (const cookie of setCookieHeaders(result.headers)) {
+    c.header("set-cookie", cookie, { append: true });
+  }
+
+  return result.response;
+}
+
+function setCookieHeaders(headers: Headers): string[] {
+  const getSetCookie = (
+    headers as Headers & {
+      getSetCookie?: () => string[];
+    }
+  ).getSetCookie;
+  if (getSetCookie) {
+    return getSetCookie.call(headers);
+  }
+
+  const cookie = headers.get("set-cookie");
+  return cookie ? [cookie] : [];
+}

--- a/packages/core/test/managed-session.test.ts
+++ b/packages/core/test/managed-session.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { getManagedSession } from "../src/managed-session";
+
+describe("getManagedSession", () => {
+  test("requests and forwards every Better Auth session renewal cookie", async () => {
+    const renewedSession = "better-auth.session_token=renewed; Path=/; HttpOnly";
+    const refreshedCache =
+      "better-auth.session_data=refreshed; Expires=Wed, 12 Aug 2026 12:00:00 GMT; Path=/; HttpOnly";
+    let receivedHeaders: Headers | undefined;
+    let returnHeaders: boolean | undefined;
+    const auth = {
+      api: {
+        getSession: async (input: { headers: Headers; returnHeaders?: boolean }) => {
+          receivedHeaders = input.headers;
+          returnHeaders = input.returnHeaders;
+          const headers = new Headers();
+          headers.append("set-cookie", renewedSession);
+          headers.append("set-cookie", refreshedCache);
+          return {
+            headers,
+            response: {
+              session: { id: "session-1" },
+              user: { id: "user-1" },
+            },
+          };
+        },
+      },
+    };
+    const app = new Hono().get("/", async (c) => {
+      const session = await getManagedSession(c, auth as never);
+      return c.json({ userId: session?.user.id });
+    });
+
+    const response = await app.request("/", {
+      headers: { cookie: "better-auth.session_token=original" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(returnHeaders).toBe(true);
+    expect(receivedHeaders?.get("cookie")).toBe("better-auth.session_token=original");
+    expect(response.headers.getSetCookie()).toEqual([renewedSession, refreshedCache]);
+    expect(await response.json()).toEqual({ userId: "user-1" });
+  });
+
+  test("does not invent a cookie when Better Auth does not refresh the session", async () => {
+    const auth = {
+      api: {
+        getSession: async () => ({
+          headers: new Headers(),
+          response: null,
+        }),
+      },
+    };
+    const app = new Hono().get("/", async (c) => {
+      const session = await getManagedSession(c, auth as never);
+      return c.json({ authenticated: session !== null });
+    });
+
+    const response = await app.request("/");
+
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(await response.json()).toEqual({ authenticated: false });
+  });
+});

--- a/test/e2e/codex-overview.e2e.ts
+++ b/test/e2e/codex-overview.e2e.ts
@@ -285,7 +285,10 @@ beforeAll(async () => {
           ? json(sessionForHeaders(request.headers))
           : new Response("not found", { status: 404 }),
       api: {
-        getSession: async ({ headers }: { headers: Headers }) => sessionForHeaders(headers),
+        getSession: async ({ headers }: { headers: Headers }) => ({
+          headers: new Headers(),
+          response: sessionForHeaders(headers),
+        }),
       },
     } as any,
     codexFetch: provider.fetch.bind(provider) as typeof fetch,

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1195,7 +1195,10 @@ describe("API component integration", () => {
       managedAuth: {
         api: {
           getSession: async () => ({
-            user: { id: userId, email, name: "Managed Cookie User" },
+            headers: new Headers(),
+            response: {
+              user: { id: userId, email, name: "Managed Cookie User" },
+            },
           }),
         },
       } as any,


### PR DESCRIPTION
## Summary

- centralize programmatic Better Auth session reads behind a cookie-renewing bridge
- forward every returned `Set-Cookie` header on ordinary protected API responses
- remove the obsolete direct-session helper and route the browser-only Codex check through the same boundary
- cover multiple cookies and a real aged Better Auth/Postgres session refresh

## Verification

- `bun run lint`
- `bun run typecheck`
- changed-path unit/API tests (16 passing)
- `bun run --cwd packages/core build`
- `bun run --cwd apps/api build`
- `bun run check:public-hygiene`
- changeset status validation

The full local unit command was also exercised; unrelated macOS/BSD-only fixture assumptions fail outside the changed auth surface (GNU `tar --sort` and local sandbox filesystem fixtures).