### PR TITLE
fix(runtime): parse routed screenshot stdout once

### DIFF
--- a/.changeset/routed-screenshot-stdout.md
+++ b/.changeset/routed-screenshot-stdout.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Read routed sandbox command stdout exactly once so Modal screenshot size and chunk output remain machine-parseable.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8647,6 +8647,22 @@ export function sandboxCommandOutput(result: unknown): string {
     .join("\n");
 }
 
+/**
+ * Return the command's stdout body exactly once. `sandboxCommandOutput()` is a
+ * human-readable aggregate and deliberately joins output/stderr/stdout; it is
+ * unsafe for machine-parsed output because a provider adapter may preserve the
+ * same body in both `output` and `stdout`.
+ */
+export function sandboxCommandStdout(result: unknown): string {
+  if (typeof result === "string") return sandboxCommandOutput(result);
+  if (!result || typeof result !== "object") return "";
+  const candidate = result as { output?: unknown; stdout?: unknown };
+  if (typeof candidate.stdout === "string" && candidate.stdout.length > 0) {
+    return candidate.stdout;
+  }
+  return typeof candidate.output === "string" ? candidate.output : "";
+}
+
 function assertSandboxCommandSucceeded(result: unknown, operation: string): void {
   const output = sandboxCommandOutput(result);
   if (sandboxCommandStillRunning(result)) {

--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -41,12 +41,13 @@ import {
 } from "@opengeni/agent-proto";
 import { redactSensitiveText } from "@opengeni/contracts";
 
-import { sandboxCommandExitCode, sandboxCommandOutput, sandboxCommandStillRunning } from "./index";
-// `stripExecBanner` is the SAME pure helper recording.ts uses to recover the raw
-// command body from Modal's execCommand banner ("…Output:\n<body>"). Imported from
-// the agent-loop-free leaf (importing a pure parser FROM the leaf is allowed — the
-// leaf boundary only forbids the leaf importing the agent loop, not the reverse).
-import { ensureDisplayStack, stripExecBanner } from "./sandbox";
+import {
+  sandboxCommandExitCode,
+  sandboxCommandOutput,
+  sandboxCommandStillRunning,
+  sandboxCommandStdout,
+} from "./index";
+import { ensureDisplayStack } from "./sandbox";
 
 // `requireBoundSession` lives in @openai/agents-core/sandbox/capabilities/base
 // but is NOT re-exported from the public @openai/agents/sandbox barrel, so we
@@ -737,7 +738,7 @@ export class SandboxComputer implements Computer {
     // A routing proxy fronting a Modal box can return the execCommand banner STRING;
     // a native structured exec returns an object. Handle both so neither silently
     // yields an empty body.
-    return typeof result === "string" ? stripExecBanner(result) : sandboxCommandOutput(result);
+    return sandboxCommandStdout(result);
   }
 
   private parseScreenshotByteSize(raw: string): number {

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -19,6 +19,7 @@ import {
   SCREENSHOT_READ_CHUNK_BYTES,
   type NativeDesktopSession,
 } from "../src/sandbox-computer";
+import { RoutingSandboxSession } from "../src/sandbox";
 import {
   KeyAction,
   PointerAction,
@@ -299,6 +300,34 @@ describe("SandboxComputer (P4.3 computer-use)", () => {
           cmd.includes("dd if=") && cmd.includes("/tmp/og-shot-") && cmd.includes("| base64"),
       ).length,
     ).toBeGreaterThanOrEqual(3);
+  });
+
+  test("ROUTING-PROXY-FIX: an execCommand-only backend does not duplicate machine-parsed stdout", async () => {
+    const png = new Uint8Array(250_000);
+    for (let i = 0; i < png.length; i++) png[i] = (i * 31 + 7) & 0xff;
+    const { session, execCalls } = makeMockSession({ pngBytes: png });
+    const proxy = new RoutingSandboxSession({
+      readPointer: async () => ({ activeSandboxId: null, activeEpoch: 0 }),
+      resolveActiveBackend: async () => ({
+        session: session as never,
+        sandboxId: null,
+        kind: "modal",
+      }),
+    });
+
+    // RoutingSandboxSession.exec() preserves the Modal banner body in both
+    // `output` and `stdout`. Screenshot parsing must select stdout once rather
+    // than feed the display-oriented aggregate into the strict integer parser.
+    const c = new SandboxComputer(proxy as never);
+    const shot = await c.screenshot();
+
+    expect(shot).toBe(Buffer.from(png).toString("base64"));
+    expect(
+      execCalls.filter(
+        (cmd) =>
+          cmd.includes("dd if=") && cmd.includes("/tmp/og-shot-") && cmd.includes("| base64"),
+      ).length,
+    ).toBe(3);
   });
 
   // ── The exec-output-cap fix: a fully-painted 1280x800 desktop PNG (~222 KB) base64s


### PR DESCRIPTION
## Root cause

RoutingSandboxSession preserves an execCommand body in both output and stdout. The screenshot reader fed sandboxCommandOutput into machine parsing; that display-oriented aggregate concatenates both fields, turning a real size such as 220123 into 220123 followed by 220123. Before #1100 this admitted millions of chunk reads. After #1100 it fails safely as invalid_size_output, but routed screenshots still do not work.

## Fix

- add a raw stdout selector that consumes the command body exactly once
- use it for screenshot size and chunk reads
- add an end-to-end regression through the real RoutingSandboxSession over an execCommand-only Modal-shaped backend
- prove a 250 KB screenshot is reconstructed byte-for-byte in three reads

## Verification

- bun test packages/runtime/test/sandbox-computer.test.ts packages/runtime/test/routing-proxy.test.ts (125 pass)
- bun run lint
- bun run typecheck
- bun run format:check
- git diff --check

The monorepo-wide bun test runner was attempted but hung in an unrelated process-lifecycle fixture with Atomics.wait children; isolated CI owns the full matrix.