### PR TITLE
fix(sandbox): settle direct admissions on release

### DIFF
--- a/.changeset/settle-direct-sandbox-admissions.md
+++ b/.changeset/settle-direct-sandbox-admissions.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Settle abandoned null-outcome direct sandbox mutation admissions when their physically completed request holder is released, preventing a failed settlement callback from blocking workspace checkpoint capture indefinitely.

--- a/.changeset/settle-direct-sandbox-admissions.md
+++ b/.changeset/settle-direct-sandbox-admissions.md
@@ -2,4 +2,4 @@
 "@opengeni/db": patch
 ---
 
-Settle abandoned null-outcome direct sandbox mutation admissions when their physically completed request holder is released, preventing a failed settlement callback from blocking workspace checkpoint capture indefinitely.
+Settle abandoned null-outcome direct sandbox mutation admissions when their physically completed request holder is released, preventing a failed settlement callback from blocking workspace checkpoint capture indefinitely. Require an exact physical-quiescence receipt before re-admitting a turn after graceful worker or provider recovery, and reconcile pre-fix attempts from their durable recovery event plus Temporal activity proof.

--- a/apps/web/src/components/rail/session-header.test.tsx
+++ b/apps/web/src/components/rail/session-header.test.tsx
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { Session } from "@/types";
+
+import { SessionHeader } from "./session-header";
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  GlobalRegistrator.unregister();
+});
+
+const session = {
+  id: "session-1",
+  workspaceId: "workspace-1",
+  initialMessage: "Run this exact bash script once in the workspace root.",
+  title: null,
+  titleSource: null,
+  parentSessionId: null,
+  model: "codex/gpt-5.6-sol",
+  metadata: {},
+  status: "idle",
+  pinned: false,
+  effectiveControl: {
+    state: "active",
+    directState: "active",
+    primaryBlocker: null,
+    additionalBlockerCount: 0,
+  },
+} as Session;
+
+describe("SessionHeader mobile touch targets", () => {
+  test("keeps the editable session title at least 44px high on coarse pointers", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <SessionHeader
+            session={session}
+            ancestors={[]}
+            connectionState="live"
+            status="idle"
+            keyAuthRequired={false}
+            onForgetAccessKey={() => undefined}
+            inspectorOpen={false}
+            onToggleInspector={() => undefined}
+            onRename={async () => null}
+            onPin={async () => null}
+          />,
+        );
+      });
+
+      const title = container.querySelector<HTMLButtonElement>(
+        'button[title$="· click to rename"]',
+      );
+      expect(title).not.toBeNull();
+      expect(title!.className).toContain("pointer-coarse:min-h-11");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+});

--- a/apps/web/src/components/rail/session-header.tsx
+++ b/apps/web/src/components/rail/session-header.tsx
@@ -357,7 +357,7 @@ function SessionTitleEditor(props: {
         onClick={rename.startEditing}
         title={`${display} · click to rename`}
         dir="auto"
-        className="min-w-0 shrink truncate rounded-sm text-left text-[15px] font-semibold leading-6 tracking-[-0.01em] text-fg hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/40"
+        className="min-w-0 shrink truncate rounded-sm text-left text-[15px] font-semibold leading-6 tracking-[-0.01em] text-fg hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/40 pointer-coarse:min-h-11 pointer-coarse:px-2"
       >
         {display}
       </button>

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -2378,6 +2378,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       acknowledgeQuiescence = true;
       noteCancellationRequested();
     };
+    const acknowledgeRecoveryQuiescence = (): void => {
+      // requestSessionTurnRecovery closed this exact attempt and durably
+      // recorded the replacement cause. The activity still owns the physical
+      // tool/credential boundary until finally drains it and publishes the
+      // exact quiescence receipt; a workflow result alone is never that proof.
+      acknowledgeQuiescence = true;
+      noteCancellationRequested();
+    };
     let turnId: string | undefined;
     let triggerEventId: string | undefined;
     const claimedResult = (
@@ -7142,6 +7150,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             turnMetricOutcome = "cancelled";
             return claimedResult({ status: "cancelled" });
           }
+          acknowledgeRecoveryQuiescence();
           await publishDurableSessionEvents(
             bus,
             input.workspaceId,
@@ -7193,6 +7202,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             turnMetricOutcome = "cancelled";
             return claimedResult({ status: "cancelled" });
           }
+          acknowledgeRecoveryQuiescence();
           await publishDurableSessionEvents(
             bus,
             input.workspaceId,
@@ -7242,6 +7252,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             turnMetricOutcome = "cancelled";
             return claimedResult({ status: "cancelled" });
           }
+          acknowledgeRecoveryQuiescence();
           await publishDurableSessionEvents(
             bus,
             input.workspaceId,
@@ -8029,6 +8040,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           return claimedResult({ status: "cancelled" });
         }
         if (recovery.action === "recovering") {
+          acknowledgeRecoveryQuiescence();
           await publishDurableSessionEvents(
             bus,
             input.workspaceId,
@@ -8105,6 +8117,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             turnMetricOutcome = "cancelled";
             return claimedResult({ status: "cancelled" });
           }
+          acknowledgeRecoveryQuiescence();
           await publishDurableSessionEvents(
             bus,
             input.workspaceId,

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.80
-appVersion: "0.22.80"
+version: 0.22.81
+appVersion: "0.22.81"

--- a/deploy/observability/Chart.yaml
+++ b/deploy/observability/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opengeni-observability
 description: Optional self-hosted Prometheus and Grafana stack for OpenGeni.
 type: application
-version: 0.1.1
+version: 0.1.2
 dependencies:
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -27714,6 +27714,46 @@ export async function releaseLeaseHolder(
     async (scopedDb) =>
       await scopedDb.transaction(async (txRaw) => {
         const tx = txRaw as unknown as Database;
+        // A direct request reaches this release seam only after its provider
+        // operation has resolved, rejected, or been physically quiesced by the
+        // Channel-A cancellation fence. If the ordinary settlement callback
+        // failed after that physical boundary (for example, its worker was
+        // interrupted during a rollout), leaving a null-outcome admission here
+        // would block archive capture forever after the request holder leaves.
+        //
+        // Lock admission -> lease, the same suffix used by mutation settlement
+        // and retained-process promotion. Taking the lease first recreates the
+        // admission/lease deadlock this fallback exists to recover. A promoted
+        // process has provider_outcome='retained' and is deliberately untouched;
+        // its non-TTL process holder remains the only settlement authority.
+        if (input.kind === "direct") {
+          await tx.execute(sql`
+            select id
+            from sandbox_workspace_mutation_admissions
+            where account_id = ${input.accountId}
+              and workspace_id = ${input.workspaceId}
+              and sandbox_group_id = ${input.sandboxGroupId}
+              and actor_kind = 'direct'
+              and holder_kind = 'direct'
+              and holder_id = ${input.holderId}
+              and provider_outcome is null
+              and settled_at is null
+            order by id
+            for update
+          `);
+          await tx.execute(sql`
+            update sandbox_workspace_mutation_admissions
+            set provider_outcome = 'rejected', settled_at = now()
+            where account_id = ${input.accountId}
+              and workspace_id = ${input.workspaceId}
+              and sandbox_group_id = ${input.sandboxGroupId}
+              and actor_kind = 'direct'
+              and holder_kind = 'direct'
+              and holder_id = ${input.holderId}
+              and provider_outcome is null
+              and settled_at is null
+          `);
+        }
         const rows = await tx.execute<LeaseRow>(sql`
         select * from sandbox_leases
         where workspace_id = ${input.workspaceId} and sandbox_group_id = ${input.sandboxGroupId}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -40323,11 +40323,15 @@ export type SessionWorkPeek =
   | { kind: "idle" };
 
 /**
- * Return the oldest exact attempt whose logical interruption or same-turn
- * recovery request settled but whose physical quiescence receipt is still
- * missing. This deliberately searches all attempts: a provider-recovery race
- * can create a newer generation before the predecessor receipt is reconciled,
- * and looking only at the newest attempt would strand the replacement forever.
+ * Return an exact attempt whose logical interruption or same-turn recovery
+ * request settled but whose physical quiescence receipt is still missing.
+ * Durable Pause/Steer interruptions deliberately search all predecessors: a
+ * recovery race can create a newer generation before their receipt arrives.
+ * A recovery-only row blocks admission only while it is the session's newest
+ * attempt. A later admitted attempt is durable proof that pre-fix code already
+ * crossed that recovery boundary; replaying every historical recovery receipt
+ * on the user's next prompt would add unbounded critical-path work. Historical
+ * rows remain available for the bounded operator cleanup.
  */
 async function nextSessionAttemptAwaitingQuiescence(
   db: Database,
@@ -40358,6 +40362,20 @@ async function nextSessionAttemptAwaitingQuiescence(
           )
           or (
             ${schema.sessionTurnAttempts.outcome} = 'interrupted_recoverable'
+            and not exists (
+              select 1
+              from session_turn_attempts successor
+              where successor.account_id = ${schema.sessionTurnAttempts.accountId}
+                and successor.workspace_id = ${schema.sessionTurnAttempts.workspaceId}
+                and successor.session_id = ${schema.sessionTurnAttempts.sessionId}
+                and (
+                  successor.started_at > ${schema.sessionTurnAttempts.startedAt}
+                  or (
+                    successor.started_at = ${schema.sessionTurnAttempts.startedAt}
+                    and successor.id > ${schema.sessionTurnAttempts.id}
+                  )
+                )
+            )
             and exists (
               select 1
               from session_events event

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -39828,6 +39828,7 @@ export async function reconcileSessionAttemptQuiescence(
       const rows = await scopedDb.execute<{
         account_id: string;
         state: string;
+        outcome: string | null;
         quiesced_at: Date | string | null;
         temporal_workflow_id: string;
         temporal_workflow_run_id: string;
@@ -39840,6 +39841,7 @@ export async function reconcileSessionAttemptQuiescence(
         select
           attempt.account_id,
           attempt.state,
+          attempt.outcome,
           attempt.quiesced_at,
           attempt.temporal_workflow_id,
           attempt.temporal_workflow_run_id,
@@ -39921,7 +39923,8 @@ export async function reconcileSessionAttemptQuiescence(
     eligibility.temporal_workflow_run_id !== input.temporalWorkflowRunId ||
     eligibility.temporal_activity_id !== input.temporalActivityId ||
     eligibility.state !== "closed" ||
-    (!eligibility.interruption_settled && !eligibility.recovery_requested) ||
+    (!eligibility.interruption_settled &&
+      (!eligibility.recovery_requested || eligibility.outcome !== "interrupted_recoverable")) ||
     eligibility.interruption_pending
   ) {
     return { action: "stale", events: [] };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -39397,7 +39397,10 @@ export type SessionAttemptInterruptionSettlement = {
  * exact turn -> exact attempt lock order and require the durable interruption.
  * Temporal activity cancellation/terminalization is transport state only. The
  * workflow admits a replacement from this durable receipt, never from the
- * activity promise.
+ * activity promise. The same boundary also applies when the activity itself
+ * durably requested same-turn recovery (for example during a worker rollout):
+ * that recovery event is the logical settlement cause in place of a
+ * Pause/Steer interruption row.
  */
 export async function markSessionAttemptQuiesced(
   db: Database,
@@ -39493,23 +39496,48 @@ export async function markSessionAttemptQuiesced(
           .orderBy(asc(schema.sessionAttemptInterruptions.requestedAt))
           .limit(1)
       : [];
-    if (!interruption) {
+    const [recoveryRequest] =
+      attempt && !interruption
+        ? await scopedDb
+            .select({ id: schema.sessionEvents.id })
+            .from(schema.sessionEvents)
+            .where(
+              and(
+                eq(schema.sessionEvents.accountId, attempt.accountId),
+                eq(schema.sessionEvents.workspaceId, input.workspaceId),
+                eq(schema.sessionEvents.sessionId, input.sessionId),
+                eq(schema.sessionEvents.turnId, attempt.turnId),
+                eq(schema.sessionEvents.turnAttemptId, input.attemptId),
+                eq(schema.sessionEvents.type, "turn.recovery.requested"),
+              ),
+            )
+            .limit(1)
+        : [];
+    const recoveryQuiescence =
+      !interruption &&
+      recoveryRequest !== undefined &&
+      attempt.state === "closed" &&
+      attempt.outcome === "interrupted_recoverable";
+    if (!interruption && !recoveryQuiescence) {
       if (input.allowUninterrupted) return [];
       throw new SessionControlInvariantError(
-        `Attempt ${input.attemptId} cannot acknowledge quiescence without its interruption`,
+        `Attempt ${input.attemptId} cannot acknowledge quiescence without its interruption or recovery request`,
       );
     }
     const liveQuiescence =
+      interruption !== undefined &&
       (attempt.state === "claimed" || attempt.state === "running") &&
       (interruption.state === "pending" ||
         interruption.state === "delivered" ||
         interruption.state === "acknowledged");
     const settledQuiescence =
-      attempt.state === "closed" &&
-      (interruption.state === "settled" || interruption.state === "rejected_stale");
+      recoveryQuiescence ||
+      (interruption !== undefined &&
+        attempt.state === "closed" &&
+        (interruption.state === "settled" || interruption.state === "rejected_stale"));
     if (!liveQuiescence && !settledQuiescence) {
       throw new SessionControlInvariantError(
-        `Attempt ${input.attemptId} cannot acknowledge quiescence from ${attempt.state}/${interruption.state}`,
+        `Attempt ${input.attemptId} cannot acknowledge quiescence from ${attempt.state}/${interruption?.state ?? "recovery"}`,
       );
     }
 
@@ -39806,6 +39834,7 @@ export async function reconcileSessionAttemptQuiescence(
         temporal_activity_id: string;
         interruption_settled: boolean;
         interruption_pending: boolean;
+        recovery_requested: boolean;
         writer_pending: boolean;
       }>(sql`
         select
@@ -39831,6 +39860,16 @@ export async function reconcileSessionAttemptQuiescence(
               and interruption.attempt_id = attempt.id
               and interruption.state in ('pending', 'delivered', 'acknowledged')
           ) as interruption_pending,
+          exists (
+            select 1
+            from session_events event
+            where event.account_id = attempt.account_id
+              and event.workspace_id = attempt.workspace_id
+              and event.session_id = attempt.session_id
+              and event.turn_id = attempt.turn_id
+              and event.turn_attempt_id = attempt.id
+              and event.type = 'turn.recovery.requested'
+          ) as recovery_requested,
           (
             exists (
               select 1
@@ -39882,7 +39921,7 @@ export async function reconcileSessionAttemptQuiescence(
     eligibility.temporal_workflow_run_id !== input.temporalWorkflowRunId ||
     eligibility.temporal_activity_id !== input.temporalActivityId ||
     eligibility.state !== "closed" ||
-    !eligibility.interruption_settled ||
+    (!eligibility.interruption_settled && !eligibility.recovery_requested) ||
     eligibility.interruption_pending
   ) {
     return { action: "stale", events: [] };
@@ -40281,11 +40320,11 @@ export type SessionWorkPeek =
   | { kind: "idle" };
 
 /**
- * Return the oldest exact attempt whose logical interruption settled but whose
- * physical quiescence receipt is still missing. This deliberately searches all
- * attempts: a provider-recovery race can create a newer generation before the
- * predecessor receipt is reconciled, and looking only at the newest attempt
- * would strand the replacement forever.
+ * Return the oldest exact attempt whose logical interruption or same-turn
+ * recovery request settled but whose physical quiescence receipt is still
+ * missing. This deliberately searches all attempts: a provider-recovery race
+ * can create a newer generation before the predecessor receipt is reconciled,
+ * and looking only at the newest attempt would strand the replacement forever.
  */
 async function nextSessionAttemptAwaitingQuiescence(
   db: Database,
@@ -40299,27 +40338,38 @@ async function nextSessionAttemptAwaitingQuiescence(
       attemptId: schema.sessionTurnAttempts.id,
     })
     .from(schema.sessionTurnAttempts)
-    .innerJoin(
-      schema.sessionAttemptInterruptions,
-      and(
-        eq(schema.sessionAttemptInterruptions.workspaceId, schema.sessionTurnAttempts.workspaceId),
-        eq(schema.sessionAttemptInterruptions.sessionId, schema.sessionTurnAttempts.sessionId),
-        eq(schema.sessionAttemptInterruptions.attemptId, schema.sessionTurnAttempts.id),
-      ),
-    )
     .where(
       and(
         eq(schema.sessionTurnAttempts.workspaceId, workspaceId),
         eq(schema.sessionTurnAttempts.sessionId, sessionId),
         eq(schema.sessionTurnAttempts.state, "closed"),
         isNull(schema.sessionTurnAttempts.quiescedAt),
-        inArray(schema.sessionAttemptInterruptions.state, ["settled", "rejected_stale"]),
+        sql`(
+          exists (
+            select 1
+            from session_attempt_interruptions interruption
+            where interruption.workspace_id = ${schema.sessionTurnAttempts.workspaceId}
+              and interruption.session_id = ${schema.sessionTurnAttempts.sessionId}
+              and interruption.attempt_id = ${schema.sessionTurnAttempts.id}
+              and interruption.state in ('settled', 'rejected_stale')
+          )
+          or (
+            ${schema.sessionTurnAttempts.outcome} = 'interrupted_recoverable'
+            and exists (
+              select 1
+              from session_events event
+              where event.account_id = ${schema.sessionTurnAttempts.accountId}
+                and event.workspace_id = ${schema.sessionTurnAttempts.workspaceId}
+                and event.session_id = ${schema.sessionTurnAttempts.sessionId}
+                and event.turn_id = ${schema.sessionTurnAttempts.turnId}
+                and event.turn_attempt_id = ${schema.sessionTurnAttempts.id}
+                and event.type = 'turn.recovery.requested'
+            )
+          )
+        )`,
       ),
     )
-    .orderBy(
-      asc(schema.sessionAttemptInterruptions.requestedAt),
-      asc(schema.sessionAttemptInterruptions.id),
-    )
+    .orderBy(asc(schema.sessionTurnAttempts.closedAt), asc(schema.sessionTurnAttempts.id))
     .limit(1);
   return row ?? null;
 }

--- a/packages/db/test/migration-0172-retire-model-visible-github-token.test.ts
+++ b/packages/db/test/migration-0172-retire-model-visible-github-token.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { FIRST_PARTY_MCP_TOOL_NAMES } from "@opengeni/contracts";
 import { acquireBlankTestDatabase, type BlankTestDatabase } from "@opengeni/testing";
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -77,12 +76,12 @@ describe("retire model-visible GitHub token migration", () => {
           and table_name = 'sessions'
           and column_name = 'first_party_mcp_tools'`;
       expect(column?.column_default).not.toContain("github_token");
-      const toolsIntroducedAfterMigration = new Set(["variable_set_get_variable"]);
-      for (const tool of FIRST_PARTY_MCP_TOOL_NAMES.filter(
-        (name) => !toolsIntroducedAfterMigration.has(name),
-      )) {
-        expect(column?.column_default).toContain(tool);
-      }
+      // This assertion is intentionally bound to the historical 0172 default.
+      // Later migrations may add first-party tools; replaying 0172 in isolation
+      // must not be reinterpreted through today's expanded tool registry.
+      expect(column?.column_default).toContain("session_get");
+      expect(column?.column_default).toContain("github_connect_link");
+      expect(column?.column_default).toContain("artifacts_rollback");
 
       let staleWriterError: unknown;
       try {

--- a/packages/db/test/sandbox-leases.test.ts
+++ b/packages/db/test/sandbox-leases.test.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import postgres from "postgres";
 import {
   acquireLease,
+  advanceWorkspaceGenerationForDirectRequest,
   adoptLegacyModalCheckpointArtifact,
   beginSandboxRematerialization,
   claimWorkspaceArchiveCapture,
@@ -20,6 +21,7 @@ import {
   claimSandboxCheckpointArtifactsForGc,
   persistDrainSnapshot as persistDrainSnapshotRaw,
   readLease,
+  readWorkspaceArchiveCapturePreflight,
   recordWarmingSandboxCreated,
   registerSandboxCheckpointArtifact,
   reapStaleLeaseHolders,
@@ -1474,6 +1476,95 @@ describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
     });
     expect(reap.drained.map((d) => d.sandboxGroupId)).toContain(groupId);
     expect(reap.drained.find((d) => d.sandboxGroupId === groupId)?.instanceId).toBe("box");
+  }, 60_000);
+
+  test("(3a) releasing a completed direct request settles its abandoned null-outcome admission", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    const sessionId = crypto.randomUUID();
+    const requestId = crypto.randomUUID();
+    const holderId = `direct:${requestId}`;
+    await admin`
+      insert into sessions (
+        id, account_id, workspace_id, status, initial_message, model,
+        sandbox_backend, sandbox_group_id, temporal_workflow_id, tool_policy
+      ) values (
+        ${sessionId}, ${accountId}, ${workspaceId}, 'idle',
+        'direct release fixture', 'test-model', 'modal', ${groupId},
+        ${`session-${sessionId}`},
+        jsonb_build_object('mode', 'explicit', 'inheritedFromSessionId', null)
+      )`;
+    const acquired = await acquireLease(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "direct",
+      holderId,
+      subjectId: sessionId,
+      backend: "modal",
+      leaseTtlMs: 45_000,
+    });
+    expect(acquired.role).toBe("spawner");
+    const committed = await commitWarmingToWarm(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      expectedEpoch: acquired.lease.leaseEpoch,
+      instanceId: "box-direct-release",
+      leaseTtlMs: 45_000,
+    });
+    const epoch = committed.lease!.leaseEpoch;
+    const admission = await advanceWorkspaceGenerationForDirectRequest(db, {
+      accountId,
+      workspaceId,
+      sessionId,
+      requestId,
+      holderId,
+      sandboxGroupId: groupId,
+      expectedEpoch: epoch,
+      expectedInstanceId: "box-direct-release",
+      routeTargetId: null,
+      routeEpoch: 0,
+      operation: "exec",
+    });
+
+    expect(
+      await readWorkspaceArchiveCapturePreflight(db, {
+        accountId,
+        workspaceId,
+        sandboxGroupId: groupId,
+        expectedEpoch: epoch,
+        expectedInstanceId: "box-direct-release",
+        liveness: "warm",
+      }),
+    ).toBeNull();
+    expect(
+      await releaseLeaseHolder(db, {
+        accountId,
+        workspaceId,
+        sandboxGroupId: groupId,
+        kind: "direct",
+        holderId,
+        idleGraceMs: 45_000,
+      }),
+    ).toEqual({ liveness: "draining", refcount: 0 });
+
+    const [settled] = await admin<{ providerOutcome: string | null; settledAt: Date | null }[]>`
+      select provider_outcome as "providerOutcome", settled_at as "settledAt"
+      from sandbox_workspace_mutation_admissions
+      where id = ${admission.id}`;
+    expect(settled).toMatchObject({ providerOutcome: "rejected" });
+    expect(settled?.settledAt).toBeInstanceOf(Date);
+    expect(
+      await readWorkspaceArchiveCapturePreflight(db, {
+        accountId,
+        workspaceId,
+        sandboxGroupId: groupId,
+        expectedEpoch: epoch,
+        expectedInstanceId: "box-direct-release",
+        liveness: "draining",
+      }),
+    ).toMatchObject({ workspaceGeneration: admission.workspaceGeneration });
   }, 60_000);
 
   test("(4) a stale VIEWER holder is TTL-reaped while a same-age TURN holder survives; lease stays warm", async () => {

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -4032,16 +4032,19 @@ describe("clean session control plane", () => {
     ).toMatchObject({ action: "quiesced" });
   });
 
-  test("worker death recovers the same compaction execution without entering the queue", async () => {
+  test("graceful worker shutdown waits for quiescence before recovering the same compaction", async () => {
     const { grant, session } = await fixture();
     await requestSessionCompaction(client.db, grant.workspaceId!, session.id);
     const attemptId = crypto.randomUUID();
+    const workflowId = `session-${session.id}`;
+    const workflowRunId = crypto.randomUUID();
+    const dispatchId = `dispatch-${crypto.randomUUID()}`;
     const first = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
-      `session-${session.id}`,
-      { attemptId },
+      workflowId,
+      { attemptId, workflowRunId, dispatchId },
     );
     expect(
       await requestSessionTurnRecovery(client.db, grant.workspaceId!, {
@@ -4053,11 +4056,36 @@ describe("clean session control plane", () => {
       }),
     ).toMatchObject({ action: "recovering" });
 
+    expect(await peekSessionWork(client.db, grant.workspaceId!, session.id)).toEqual({
+      kind: "cancellation-wait",
+      attemptId,
+    });
+    const quiescence = await reconcileSessionAttemptQuiescence(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      attemptId,
+      temporalWorkflowId: workflowId,
+      temporalWorkflowRunId: workflowRunId,
+      temporalActivityId: dispatchId,
+      activitySettled: true,
+    });
+    expect(quiescence).toMatchObject({
+      action: "quiesced",
+      events: [
+        expect.objectContaining({
+          type: "session.queue.changed",
+          turnAttemptId: attemptId,
+          payload: expect.objectContaining({ operation: "attempt_quiesced", attemptId }),
+        }),
+      ],
+    });
+
     const recovered = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
-      `session-${session.id}`,
+      workflowId,
     );
     expect(recovered).toMatchObject({
       id: first!.id,

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -4119,6 +4119,71 @@ describe("clean session control plane", () => {
     );
   });
 
+  test("a superseded historical recovery receipt stays off the next prompt's critical path", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "run the recoverable turn");
+    const workflowId = `session-${session.id}`;
+    const predecessorAttemptId = crypto.randomUUID();
+    const predecessorRunId = crypto.randomUUID();
+    const predecessorActivityId = `dispatch-${crypto.randomUUID()}`;
+    const turn = await claimTestSessionWork(client.db, grant.workspaceId!, session.id, workflowId, {
+      attemptId: predecessorAttemptId,
+      workflowRunId: predecessorRunId,
+      dispatchId: predecessorActivityId,
+    });
+    expect(turn).not.toBeNull();
+    await requestSessionTurnRecovery(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: turn!.id,
+      triggerEventId: turn!.triggerEventId,
+      attemptId: predecessorAttemptId,
+      reason: "worker_shutdown",
+    });
+    await reconcileSessionAttemptQuiescence(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      attemptId: predecessorAttemptId,
+      temporalWorkflowId: workflowId,
+      temporalWorkflowRunId: predecessorRunId,
+      temporalActivityId: predecessorActivityId,
+      activitySettled: true,
+    });
+
+    const successorAttemptId = crypto.randomUUID();
+    const successor = await claimTestSessionWork(
+      client.db,
+      grant.workspaceId!,
+      session.id,
+      workflowId,
+      { attemptId: successorAttemptId },
+    );
+    await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: successor!.id,
+      triggerEventId: successor!.triggerEventId,
+      attemptId: successorAttemptId,
+      turnStatus: "completed",
+      sessionStatus: "idle",
+      activeTurnId: null,
+      events: [],
+    });
+
+    // Recreate one of the 1,662 pre-fix historical rows found in production.
+    // The later admitted attempt proves this row is historical, not the current
+    // replacement boundary. Operator cleanup may still attach the old receipt,
+    // but an unrelated user prompt must not replay an unbounded backlog first.
+    await withWorkspaceRls(client.db, grant.workspaceId!, async (db) => {
+      await db
+        .update(schema.sessionTurnAttempts)
+        .set({ quiescedAt: null })
+        .where(eq(schema.sessionTurnAttempts.id, predecessorAttemptId));
+    });
+    expect(await peekSessionWork(client.db, grant.workspaceId!, session.id)).toEqual({
+      kind: "idle",
+    });
+  });
+
   test("a prompt queued during compaction makes settlement publish queued, not idle", async () => {
     const { grant, session } = await fixture();
     await requestSessionCompaction(client.db, grant.workspaceId!, session.id);

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -571,17 +571,19 @@ describe("clean session control plane", () => {
     expect(claimed?.id).toBe(replacement.turn.id);
   });
 
-  test("Steer immediately supersedes an ownerless turn during its recovery wait", async () => {
+  test("Steer supersedes an ownerless recovery turn but waits for its physical receipt", async () => {
     const { grant, session } = await fixture();
     await send(grant, session.id, "run the predecessor");
     const attemptId = crypto.randomUUID();
     const workflowId = `session-${session.id}`;
+    const workflowRunId = crypto.randomUUID();
+    const dispatchId = `dispatch-${crypto.randomUUID()}`;
     const predecessor = await claimTestSessionWork(
       client.db,
       grant.workspaceId!,
       session.id,
       workflowId,
-      { attemptId },
+      { attemptId, workflowRunId, dispatchId },
     );
     expect(predecessor).not.toBeNull();
     expect(
@@ -600,6 +602,22 @@ describe("clean session control plane", () => {
     expect((await getSessionTurn(client.db, grant.workspaceId!, predecessor!.id))?.status).toBe(
       "superseded",
     );
+    expect(await peekSessionWork(client.db, grant.workspaceId!, session.id)).toEqual({
+      kind: "cancellation-wait",
+      attemptId,
+    });
+    expect(
+      await reconcileSessionAttemptQuiescence(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        attemptId,
+        temporalWorkflowId: workflowId,
+        temporalWorkflowRunId: workflowRunId,
+        temporalActivityId: dispatchId,
+        activitySettled: true,
+      }),
+    ).toMatchObject({ action: "quiesced" });
     expect(await peekSessionWork(client.db, grant.workspaceId!, session.id)).toEqual({
       kind: "runnable",
     });


### PR DESCRIPTION
## Summary

- settle unresolved direct-operation admissions when their exact holder releases, preserving admission→lease lock order
- leave retained-process admissions untouched for ordinary reconciliation
- add a real PostgreSQL/RLS lifecycle regression proving checkpoint capture unblocks
- restore the required 44px coarse-pointer session-title touch target so production sandbox acceptance can complete
- reserve app 0.22.81 and observability chart 0.1.2

## Validation

- direct-admission PostgreSQL regression: pass
- retained-process reconciliation: 16/16 pass
- session-header render regression: pass
- full 23-project typecheck: pass
- oxlint/oxfmt/diff hygiene: pass

## Production evidence

The one genuine stranded production lease was provider-inspected fail-closed, its three exact abandoned admissions were settled as rejected/outcome-unknown, and the ordinary reaper captured and terminated the box. Current fleet audit: zero expired draining leases over five minutes and zero retained processes with terminal owners.