### PR TITLE
test(secrets): satisfy exact-head release gates

### DIFF
--- a/packages/db/test/variable-set-secret-read.test.ts
+++ b/packages/db/test/variable-set-secret-read.test.ts
@@ -61,7 +61,7 @@ describe("permissioned variable-set plaintext reads", () => {
     const { grant, subjectId } = await fixture("roundtrip");
     const exact =
       `ordinary source: const tokenized = "ghp_not_a_credential";\n` +
-      `shell: printf '%s\\n' \"$VALUE\"\n` +
+      `shell: printf '%s\\n' "$VALUE"\n` +
       `unicode:${String.fromCharCode(0)}:${String.fromCharCode(0xd800)}:${String.fromCharCode(0xdc00)}`;
     const variableSet = await createVariableSet(client.db, {
       accountId: grant.accountId,

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -3446,8 +3446,10 @@ describe("useEnvironments", () => {
     expect(hook.result.current.environments.map((environment) => environment.name)).toEqual([
       "staging",
     ]);
-    const secret = await hook.result.current.readVariable("env-1", "EXAMPLE_TOKEN");
-    expect(secret?.value).toBe(`const fake = "ghp_not_a_credential";\nprintf '%s\\n' "$VALUE"`);
+    await flushing(async () => {
+      const secret = await hook.result.current.readVariable("env-1", "EXAMPLE_TOKEN");
+      expect(secret?.value).toBe(`const fake = "ghp_not_a_credential";\nprintf '%s\\n' "$VALUE"`);
+    });
     // Plaintext is returned directly to the caller and never triggers a
     // metadata-cache refresh that could retain it.
     expect(log.at(-1)).toBe("read:env-1:EXAMPLE_TOKEN");


### PR DESCRIPTION
## Summary
- remove unnecessary quote escapes from the exact round-trip database fixture
- keep the permissioned read hook mutation inside React `act` so the warning-free gate observes all state transitions

## Evidence
- `bun run test:react:clean` — 1,074 pass, 0 fail, no runtime warnings
- `bun test --timeout 30000 packages/db/test/variable-set-secret-read.test.ts` — 4 pass, 0 fail against real Postgres
- `bun run lint`
- `bun run format:check`

Follow-up to #1118 after the protected Version PR exact-head gate correctly caught these two test hygiene failures.