### PR TITLE
test(secrets): satisfy public repository hygiene

### DIFF
--- a/packages/db/test/migration-0178-permissioned-secret-reads.test.ts
+++ b/packages/db/test/migration-0178-permissioned-secret-reads.test.ts
@@ -63,7 +63,7 @@ describe("0178 permissioned secret reads migration", () => {
       accountId: grant.accountId,
       workspaceId: grant.workspaceId,
       name: "Legacy wildcard API key",
-      prefix: `ope97_${suffix.slice(0, 8)}`,
+      prefix: `legacy_${suffix.slice(0, 8)}`,
       keyHash: `migration-0178-${suffix}`,
       permissions: [...legacyPermissions],
     });


### PR DESCRIPTION
## Summary
- replace an internal-ticket-shaped synthetic API-key prefix with a neutral migration fixture prefix

## Evidence
- `bun run check:public-hygiene`
- `bun test --timeout 30000 packages/db/test/migration-0178-permissioned-secret-reads.test.ts` — 1 pass, 0 fail against real Postgres
- `bun run lint`
- `bun run format:check`

Follow-up to #1118 after the protected Version PR public-repository hygiene guard correctly rejected the internal issue-shaped fixture string.