### PR TITLE
fix(test): restore main CI after secret reads

### DIFF
--- a/packages/db/test/variable-set-secret-read.test.ts
+++ b/packages/db/test/variable-set-secret-read.test.ts
@@ -61,7 +61,7 @@ describe("permissioned variable-set plaintext reads", () => {
     const { grant, subjectId } = await fixture("roundtrip");
     const exact =
       `ordinary source: const tokenized = "ghp_not_a_credential";\n` +
-      `shell: printf '%s\\n' \"$VALUE\"\n` +
+      `shell: printf '%s\\n' "$VALUE"\n` +
       `unicode:${String.fromCharCode(0)}:${String.fromCharCode(0xd800)}:${String.fromCharCode(0xdc00)}`;
     const variableSet = await createVariableSet(client.db, {
       accountId: grant.accountId,

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -3446,8 +3446,11 @@ describe("useEnvironments", () => {
     expect(hook.result.current.environments.map((environment) => environment.name)).toEqual([
       "staging",
     ]);
-    const secret = await hook.result.current.readVariable("env-1", "EXAMPLE_TOKEN");
-    expect(secret?.value).toBe(`const fake = "ghp_not_a_credential";\nprintf '%s\\n' "$VALUE"`);
+    let readValue = "";
+    await flushing(async () => {
+      readValue = (await hook.result.current.readVariable("env-1", "EXAMPLE_TOKEN"))?.value ?? "";
+    });
+    expect(readValue).toBe(`const fake = "ghp_not_a_credential";\nprintf '%s\\n' "$VALUE"`);
     // Plaintext is returned directly to the caller and never triggers a
     // metadata-cache refresh that could retain it.
     expect(log.at(-1)).toBe("read:env-1:EXAMPLE_TOKEN");


### PR DESCRIPTION
## Summary

- remove the unnecessary quote escape that breaks the lint gate
- wrap the new variable-value hook read in the existing `flushing`/`act` helper
- keep plaintext in a test-local return value rather than hook state

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run test:react:clean` — 1,074 pass, zero warnings
- `bun test packages/react/test/hooks.test.tsx` — 82 pass, zero warnings
- `bun test packages/db/test/variable-set-secret-read.test.ts` — 4 pass
- `bun run check:public-repo-hygiene`

Linear: OPE-173
