### PR TITLE
fix(web): settle session focus before paint

### DIFF
--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -903,7 +903,9 @@ export function SessionList() {
 
   // Consume an explicit reveal/focus intent once. Data churn can rerun this
   // effect, but with no intent it owns neither DOM focus nor rail scroll.
-  useEffect(() => {
+  // Layout timing makes real DOM focus part of the discrete keyboard commit;
+  // a passive effect can leave Home/End visibly on the prior row for a frame.
+  useLayoutEffect(() => {
     const root = listRef.current;
     if (focusIndex < 0 || !root) {
       return;


### PR DESCRIPTION
## Summary
- settle explicit session-rail keyboard focus in the layout phase
- prevent `Home`/`End` from visibly remaining on the prior row for a frame on slow runners

## Failure bound
- exact Version PR CI run 31044574035 failed the real session-pin browser gate at `ArrowDown → Home`: DOM focus still named “Open Newer unrelated activity” instead of the pinned first row

## Evidence
- `bun test apps/web/src/lib/session-focus.test.ts` — 8 pass
- fresh-process real PostgreSQL/browser test for pin reconciliation and roving focus — 1 pass, 30 assertions
- full 23-project typecheck
- lint, format, and diff checks
- UBS changed-file scan has an identical 48/0/287 baseline on untouched `main`; all nonzero hits are pre-existing ID/cursor false positives and none touches this hunk