### PR TITLE
fix(test): follow current secret contracts

### DIFF
--- a/apps/api/test/social-oauth.test.ts
+++ b/apps/api/test/social-oauth.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { randomBytes } from "node:crypto";
-import type { Settings } from "@opengeni/config";
-import type { Database } from "@opengeni/db";
+import { environmentsEncryptionKeyBytes, type Settings } from "@opengeni/config";
+import { decryptVariableSetValue, type Database } from "@opengeni/db";
 import { readSignedState } from "@opengeni/github";
 import { testSettings } from "@opengeni/testing";
 import { HTTPException } from "hono/http-exception";
@@ -84,7 +84,11 @@ describe("startSocialOAuth", () => {
     expect(payload.returnPath).toBe("/social?tab=x");
     expect(typeof payload.nonce).toBe("string");
     // The PKCE verifier must never travel in cleartext state.
-    expect(String(payload.encryptedPkceVerifier)).toStartWith("v1:");
+    const key = environmentsEncryptionKeyBytes(settings);
+    expect(key).not.toBeNull();
+    expect(decryptVariableSetValue(key!, String(payload.encryptedPkceVerifier))).toMatch(
+      /^[A-Za-z0-9_-]{43,128}$/,
+    );
   });
 
   test("caller-provided scopes replace defaults", async () => {

--- a/packages/db/test/migration-0172-retire-model-visible-github-token.test.ts
+++ b/packages/db/test/migration-0172-retire-model-visible-github-token.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { FIRST_PARTY_MCP_TOOL_NAMES } from "@opengeni/contracts";
 import { acquireBlankTestDatabase, type BlankTestDatabase } from "@opengeni/testing";
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -77,9 +76,16 @@ describe("retire model-visible GitHub token migration", () => {
           and table_name = 'sessions'
           and column_name = 'first_party_mcp_tools'`;
       expect(column?.column_default).not.toContain("github_token");
-      for (const tool of FIRST_PARTY_MCP_TOOL_NAMES) {
-        expect(column?.column_default).toContain(tool);
-      }
+      const migrationSql = await readFile(join(migrationsDir, migration), "utf8");
+      const defaultLiteral = migrationSql.match(/SET DEFAULT '(\[[\s\S]*?\])'::jsonb;/)?.[1];
+      expect(defaultLiteral).toBeDefined();
+      const [defaulted] = await admin<Array<{ tools: string[] }>>`
+        insert into sessions (id)
+        values (${crypto.randomUUID()})
+        returning first_party_mcp_tools as tools`;
+      expect(defaulted?.tools).toEqual(JSON.parse(defaultLiteral!));
+      expect(defaulted?.tools).toContain("session_get");
+      expect(defaulted?.tools).not.toContain("github_token");
 
       let staleWriterError: unknown;
       try {


### PR DESCRIPTION
## Summary

- validate social OAuth PKCE state by decrypting through the supported variable-set crypto contract instead of pinning `v1`
- validate migration 0172's applied default against its immutable SQL literal instead of the evolving first-party tool registry
- keep both fixes test-only and future-compatible

## Verification

- `bun test apps/api/test/social-oauth.test.ts packages/db/test/migration-0172-retire-model-visible-github-token.test.ts` — 15 pass
- `bun run typecheck`
- `bun run lint`
- `bun run check:public-repo-hygiene`

Linear: OPE-174
