### PR TITLE
fix(release): allow application-only embedded candidates

### DIFF
--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -152,10 +152,14 @@ jobs:
             --slurpfile producer evidence/candidate-provenance.json \
             '.sourceSha == $sourceSha and .sourceTreeSha == $sourceTreeSha and .producer == $producer[0].producer' \
             evidence/release-candidate.json >/dev/null
-          bun scripts/release-candidate.ts \
-            --verify evidence/release-candidate.json \
-            --source-sha "$SOURCE_SHA" \
-            --expected-packages "$EXPECTED_PACKAGES"
+          candidate_verify_args=(
+            --verify evidence/release-candidate.json
+            --source-sha "$SOURCE_SHA"
+          )
+          if [ -n "$EXPECTED_PACKAGES" ]; then
+            candidate_verify_args+=(--expected-packages "$EXPECTED_PACKAGES")
+          fi
+          bun scripts/release-candidate.ts "${candidate_verify_args[@]}"
           release_version="$(jq -er '.releaseVersion' evidence/release-candidate.json)"
           [ "$release_version" = "$(bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml)" ] || {
             echo "candidate release version differs from the source-controlled chart version" >&2

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -326,6 +326,9 @@ describe("release image workflow contract", () => {
     expect(release).toContain("CANDIDATE_ARTIFACT_DIGEST:");
     expect(release).toContain("CANDIDATE_SOURCE_TREE_SHA:");
     expect(release).toContain("bun scripts/release-candidate.ts");
+    expect(release).toContain('if [ -n "$EXPECTED_PACKAGES" ]; then');
+    expect(release).toContain('candidate_verify_args+=(--expected-packages "$EXPECTED_PACKAGES")');
+    expect(release).toContain('bun scripts/release-candidate.ts "${candidate_verify_args[@]}"');
     expect(release).toContain("bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml");
     expect(release).not.toContain('map(select(.name == "@opengeni/sdk"))');
     expect(release).toContain("bun run test:runtime-embedding-consumer");


### PR DESCRIPTION
## Summary

- allow `release-embedded.yml` to verify application-only release candidates without asserting an empty candidate package plan
- retain exact package-plan verification whenever `expected_packages` is non-empty
- add a workflow contract assertion for the conditional candidate-verification arguments

## Why

Embedded distribution run `31086059170` for approved OpenGeni `0.22.78` source `ca8ad18b0bee17a82ca3a13210da51262d56e0bf` failed before publication in **Plan exact package publication**. The workflow passed `--expected-packages ""` to candidate verification, which incorrectly required the accepted application-only candidate to contain zero package entries even though package reconciliation already preserves the registry identity, integrity, and original `gitHead` for every unchanged package in the release BOM.

The failed run published no packages, chart, image aliases, release BOM, or immutable release receipt. It must remain preserved as failed evidence and must not be rerun.

## Safety properties retained

- exact candidate source SHA, source tree, and trusted producer provenance remain required
- exact chart and image candidate bytes remain required
- non-empty declared package plans must still match exactly
- empty `expected_packages` means application-only release, not automatic package derivation
- unchanged package identities remain reconciled into the complete release BOM
- no rebuild occurs after candidate acceptance

## Validation

- `git diff --check`
- `bun x oxfmt --check scripts/release-image-workflow-contract.test.ts`
- `bun x oxlint --deny-warnings scripts/release-image-workflow-contract.test.ts`
- YAML parse of `.github/workflows/release-embedded.yml`
- `bash -n` on the extracted **Plan exact package publication** shell step
- `bun test scripts/release-image-workflow-contract.test.ts scripts/release-candidate.test.ts scripts/verify-release-packages.test.ts` — 32 pass, 0 fail, 355 assertions
