### PR TITLE
Fix ambiguous Modal process promotion finalization

### DIFF
--- a/.changeset/drain-ambiguous-sandbox-processes.md
+++ b/.changeset/drain-ambiguous-sandbox-processes.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/db": patch
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Retry transient retained-process promotion transactions and hand ambiguous yielded processes to exact-route turn finalization so they cannot strand sandbox leases.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -30125,9 +30125,14 @@ export async function retainWorkspaceMutationProcess(
           routeTargetId: input.owner.routeTargetId,
           routeEpoch: input.owner.routeEpoch,
         };
-  const result = await withRlsContext(
+  const result = await retryRlsPersistence(
     db,
     { accountId: input.accountId, workspaceId: input.workspaceId },
+    {
+      stage: "sandbox_retained_process_promotion",
+      maxAttempts: 5,
+      correlationId: input.processId,
+    },
     async (scopedDb) =>
       await scopedDb.transaction(async (txRaw) => {
         const tx = txRaw as unknown as Database;

--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -1045,7 +1045,16 @@ export class RoutingSandboxSession implements RoutableBackendSession {
             retainedRecord
               ? `Mutating sandbox operation "${op}" yielded provider session ${retainedRecord.process.providerSessionId} but lost durable process promotion; exact-backend tracking remains and the operation was not replayed`
               : `Mutating sandbox operation "${op}" returned from the provider but lost its durable route settlement; its outcome is unknown and it was not replayed`,
-            { cause: error },
+            {
+              cause: error,
+              // Promotion is not yet durable, so the rejected provider output
+              // must not reach the caller. The locator is nevertheless bound
+              // to this proxy's exact backend and pending parent promotion.
+              // Hand it to turn finalization so process-control can retry that
+              // same promotion and drain the already-running process without
+              // replaying the workspace mutation.
+              ...(retainedRecord ? { retainedProcess: retainedRecord.process } : {}),
+            },
           );
         }
       }

--- a/packages/runtime/src/sandbox/turn-tool-cancellation.ts
+++ b/packages/runtime/src/sandbox/turn-tool-cancellation.ts
@@ -640,6 +640,36 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
           correlationId,
           async () => await invokeExecNative(commandInput),
         );
+      } catch (error) {
+        const retainedProcess =
+          !useRemoteOpCancellation && error instanceof RoutingMutationOutcomeUnknownError
+            ? error.retainedProcess
+            : null;
+        const processSession =
+          retainedProcess === null
+            ? null
+            : retainedProcessSession(session, retainedProcess.providerSessionId);
+        if (retainedProcess && processSession) {
+          // The lifecycle/Channel-A entry point must preserve the same exact
+          // process handoff as the model-tool entry point below. A routing
+          // session can reject the provider output while its parent promotion
+          // is still pending; cancellation retries that promotion on the
+          // already-bound backend before draining the physical process.
+          this.shellSessions.set(retainedProcess.providerSessionId, {
+            sessionId: retainedProcess.providerSessionId,
+            markerPath,
+            token: markerPath.slice(markerPath.lastIndexOf("/") + 1),
+            interactive,
+            runContext: lifecycleRunContext,
+            execInvoke: invokeExec,
+            writeInvoke: invokeWrite,
+            processSession,
+            identity: null,
+            identityValidated: false,
+            cancellation: null,
+          });
+        }
+        throw error;
       } finally {
         remoteExec?.settle();
       }
@@ -815,9 +845,11 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
                   ? null
                   : retainedProcessSession(cancellationSession, retainedProcess.providerSessionId);
               if (retainedProcess && processSession) {
-                // The provider output remains rejected, but DB promotion is
-                // already durable. Preserve only the safe process locator and
-                // exact routing session so turn finalization can drain it; never
+                // The provider output remains rejected. DB promotion may be
+                // durable already or pending after an ambiguous persistence
+                // failure; the exact routing session owns that distinction and
+                // retries promotion before any process control. Preserve only
+                // its safe locator so turn finalization can drain it, and never
                 // invoke a helper through the mutable current route.
                 this.shellSessions.set(retainedProcess.providerSessionId, {
                   sessionId: retainedProcess.providerSessionId,

--- a/packages/runtime/test/routing-proxy.test.ts
+++ b/packages/runtime/test/routing-proxy.test.ts
@@ -679,9 +679,12 @@ describe("RoutingSandboxSession — per-call re-read + per-epoch dispatch", () =
       },
     });
 
-    await expect(proxy.execCommand({ cmd: "start" })).rejects.toBeInstanceOf(
-      RoutingMutationOutcomeUnknownError,
-    );
+    const error = await proxy.execCommand({ cmd: "start" }).catch((caught) => caught);
+    expect(error).toBeInstanceOf(RoutingMutationOutcomeUnknownError);
+    expect((error as RoutingMutationOutcomeUnknownError).retainedProcess).toEqual({
+      id: expect.any(String),
+      providerSessionId: 76,
+    });
     expect(proxy.hasRetainedProcess(76)).toBe(true);
     ptr.swap("sbx-new");
 

--- a/packages/runtime/test/turn-tool-cancellation.test.ts
+++ b/packages/runtime/test/turn-tool-cancellation.test.ts
@@ -9,7 +9,10 @@ import {
   cancellableShellCommand,
   createTurnToolCancellationController,
 } from "../src/sandbox/turn-tool-cancellation";
-import { RoutingMutationOutcomeUnknownError } from "../src/sandbox/routing/routing-session";
+import {
+  RoutingMutationOutcomeUnknownError,
+  RoutingSandboxSession,
+} from "../src/sandbox/routing/routing-session";
 import { createSandboxClientForBackend } from "../src/index";
 import { testSettings } from "@opengeni/testing";
 
@@ -427,6 +430,147 @@ describe("turn sandbox-tool physical cancellation fence", () => {
     expect(providerCalls).toBe(1);
     expect(controlPolls).toBe(1);
     expect(retained).toBe(false);
+  });
+
+  test("retries ambiguous process promotion on the exact route before finalization drains it", async () => {
+    const controller = createTurnToolCancellationController();
+    let providerCalls = 0;
+    let promotions = 0;
+    let controlPolls = 0;
+    let processAlive = true;
+    const retainedIds: string[] = [];
+    const backend = {
+      supportsPty: () => true,
+      execCommand: async (args: unknown) => {
+        const cmd =
+          args && typeof args === "object" && typeof (args as { cmd?: unknown }).cmd === "string"
+            ? ((args as { cmd: string }).cmd ?? "")
+            : "";
+        if (cmd.includes("command cat '/tmp/opengeni-turn-shell/")) {
+          return exited(0, "6200 6200\n");
+        }
+        if (cmd.includes("command kill -TERM")) {
+          processAlive = false;
+          return exited(0);
+        }
+        if (cmd.includes("command kill -0")) {
+          return exited(processAlive ? 75 : 0);
+        }
+        providerCalls += 1;
+        return running(34, "started");
+      },
+      writeStdin: async () => {
+        controlPolls += 1;
+        processAlive = false;
+        return exited(143);
+      },
+    };
+    const session = new RoutingSandboxSession({
+      defaultResolved: {
+        session: backend,
+        sandboxId: null,
+        kind: "modal",
+        activeEpoch: 0,
+      },
+      readPointer: async () => ({ activeSandboxId: null, activeEpoch: 0 }),
+      resolveActiveBackend: async () => ({
+        session: backend,
+        sandboxId: null,
+        kind: "modal",
+      }),
+      beforeMutation: async () => "parent",
+      afterMutation: async ({ retainedProcess }) => {
+        promotions += 1;
+        retainedIds.push(retainedProcess!.id);
+        if (promotions === 1) throw new Error("promotion transaction lost");
+      },
+    });
+    const exec = functionTool("exec_command", async (_runContext, input) => {
+      return await session.execCommand(JSON.parse(input) as Record<string, unknown>);
+    });
+    const [wrappedExec] = controller.wrapTools([exec], session) as Array<
+      Extract<Tool<unknown>, { type: "function" }>
+    >;
+
+    const error = await wrappedExec!
+      .invoke(runContext, JSON.stringify({ cmd: "sleep 60" }))
+      .catch((caught) => caught);
+    expect(error).toBeInstanceOf(RoutingMutationOutcomeUnknownError);
+    expect((error as RoutingMutationOutcomeUnknownError).retainedProcess).toEqual({
+      id: expect.any(String),
+      providerSessionId: 34,
+    });
+
+    controller.cancel(new Error("turn finalized"));
+    await controller.waitForQuiescence();
+
+    expect(providerCalls).toBe(1);
+    expect(promotions).toBe(2);
+    expect(new Set(retainedIds).size).toBe(1);
+    expect(controlPolls).toBe(1);
+    expect(session.hasRetainedProcess(34)).toBe(false);
+  });
+
+  test("lifecycle command finalization drains an exact process whose promotion was ambiguous", async () => {
+    const controller = createTurnToolCancellationController();
+    let providerMutationCalls = 0;
+    let promotions = 0;
+    let controlPolls = 0;
+    const retainedIds: string[] = [];
+    const backend = {
+      supportsPty: () => true,
+      execCommand: async (args: unknown) => {
+        const cmd =
+          args && typeof args === "object" && typeof (args as { cmd?: unknown }).cmd === "string"
+            ? ((args as { cmd: string }).cmd ?? "")
+            : "";
+        if (!cmd.includes("sleep 60")) return exited(0, "6200 6200\n");
+        providerMutationCalls += 1;
+        return running(35, "started");
+      },
+      writeStdin: async () => {
+        controlPolls += 1;
+        return exited(143);
+      },
+    };
+    const session = new RoutingSandboxSession({
+      defaultResolved: {
+        session: backend,
+        sandboxId: null,
+        kind: "modal",
+        activeEpoch: 0,
+      },
+      readPointer: async () => ({ activeSandboxId: null, activeEpoch: 0 }),
+      resolveActiveBackend: async () => ({
+        session: backend,
+        sandboxId: null,
+        kind: "modal",
+      }),
+      beforeMutation: async () => "parent",
+      afterMutation: async ({ retainedProcess }) => {
+        promotions += 1;
+        retainedIds.push(retainedProcess!.id);
+        if (promotions === 1) throw new Error("promotion transaction lost");
+      },
+    });
+
+    const error = await controller
+      .runSandboxCommandStructured(session, { cmd: "sleep 60", yieldTimeMs: 100 })
+      .catch((caught) => caught);
+    expect(error).toBeInstanceOf(RoutingMutationOutcomeUnknownError);
+    expect((error as RoutingMutationOutcomeUnknownError).retainedProcess).toEqual({
+      id: expect.any(String),
+      providerSessionId: 35,
+    });
+
+    controller.cancel(new Error("lifecycle request finalized"));
+    await controller.waitForQuiescence();
+
+    expect(providerMutationCalls).toBe(1);
+    expect(promotions).toBe(2);
+    expect(new Set(retainedIds).size).toBe(1);
+    expect(controlPolls).toBe(1);
+    expect(session.hasRetainedProcess(35)).toBe(false);
   });
 
   test("retained-process terminal settlement failure keeps the cancellation fence closed", async () => {


### PR DESCRIPTION
## Summary

- retry only the idempotent retained-process database promotion transaction on PostgreSQL deadlock/serialization failures
- expose a yielded process's safe exact-route locator even when its durable promotion is still pending
- let the turn finalizer retry that exact promotion, terminate/drain the physical provider process, and settle its admission without replaying the workspace mutation
- apply the same exact-process handoff to API-direct/lifecycle terminal commands so both command entry points share the invariant
- add integrated regressions proving one provider mutation, one retained UUID, same-route promotion retry, and complete finalizer cleanup

## Production incident

Session `aed24825-71d0-465e-8f9b-37f4d51b8eac` yielded Modal process session `4`, then lost durable retained-process promotion. The proxy retained the exact backend in memory but the thrown `RoutingMutationOutcomeUnknownError` omitted the retained locator, so turn finalization could not recover it and its workspace-mutation admission stranded the lease. The one-time repair positively proved provider session `4` missing, rejected the exact admission without replay, and reaped the exact box into a verified native checkpoint at aligned workspace/archive generation `9866`.

## Verification

- 223 focused runtime/worker/database tests pass
- model-tool and API-direct/lifecycle finalizer regressions pass
- real PostgreSQL retained-process/lock-order suite passes with `OPENGENI_REQUIRE_REAL_DB=1`
- all 23 TypeScript projects pass
- root lint and formatting checks pass
- `git diff --check` passes

The SDK history `undefined` failure observed immediately afterward is separate and is already fixed on this branch's base by merged PR #1131.
