### PR TITLE
chore: release 0.22.82

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.81
-appVersion: "0.22.81"
+version: 0.22.82
+appVersion: "0.22.82"


### PR DESCRIPTION
## Summary

- bump the Helm chart and application version from 0.22.81 to 0.22.82
- release the merged canonical-JSON history fix (#1131) and ambiguous Modal retained-process finalization fix (#1133)
- retain the ordinary rolling deployment path; migrations introduced since 0.22.81 are classified rolling

## Validation

- exact parent: `6335b9962524d835ee707aed956567b37c237141`
- exact head: `c6a1f3f7bdbbd800e9090e031e8d0846d8737d26`
- diff contains only `deploy/helm/opengeni/Chart.yaml`
- `git diff --check HEAD^`
- `helm lint deploy/helm/opengeni`
- no pending Changesets remain after Version PR #1127

The release will use immutable candidate digests and the ordinary serialized production controller.