### PR TITLE
fix(api): accept native resumable upload bodies

### DIFF
--- a/.changeset/repair-native-voice-upload.md
+++ b/.changeset/repair-native-voice-upload.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Accept resumable voice chunks through Bun's native HTTP body reader without assuming the reader exposes an optional stream-lock release method.

--- a/apps/api/src/routes/transcription-recordings.ts
+++ b/apps/api/src/routes/transcription-recordings.ts
@@ -724,22 +724,18 @@ async function readBoundedBody(request: Request, maxBytes: number): Promise<Uint
   const reader = request.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
-  try {
-    for (;;) {
-      if (request.signal.aborted) {
-        throw new RecordingProcessingError("Chunk upload was cancelled", "cancelled", true);
-      }
-      const next = await reader.read();
-      if (next.done) break;
-      total += next.value.byteLength;
-      if (total > maxBytes) {
-        await reader.cancel();
-        throw new RecordingProcessingError("Chunk is too large", "too_large", false);
-      }
-      chunks.push(next.value);
+  for (;;) {
+    if (request.signal.aborted) {
+      throw new RecordingProcessingError("Chunk upload was cancelled", "cancelled", true);
     }
-  } finally {
-    reader.releaseLock();
+    const next = await reader.read();
+    if (next.done) break;
+    total += next.value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new RecordingProcessingError("Chunk is too large", "too_large", false);
+    }
+    chunks.push(next.value);
   }
   if (total === 0) {
     throw new RecordingProcessingError("Chunk is required", "invalid_audio", false);

--- a/apps/api/test/transcription-recording-routes.test.ts
+++ b/apps/api/test/transcription-recording-routes.test.ts
@@ -119,6 +119,98 @@ afterEach(() => {
 });
 
 describe("resumable transcription recording routes", () => {
+  test("accepts a chunk through Bun's native HTTP request body reader", async () => {
+    const chunkBytes = new Uint8Array([1, 2, 3]);
+    const chunkSha256 = createHash("sha256").update(chunkBytes).digest("hex");
+    const transcription: TranscriptionService = {
+      limits: () => ({
+        maxDurationSeconds: 50,
+        maxSizeBytes: 25 * 1024 * 1024,
+        acceptedMimeTypes: ["audio/webm"],
+      }),
+      available: () => true,
+      selectProvider: () => "openai",
+      transcribe: async () => {
+        throw new Error("not used");
+      },
+    };
+    const segmenter: TranscriptionSegmenter = {
+      available: () => true,
+      async *segment() {
+        yield* [];
+      },
+    };
+    const recording = response("uploading", {
+      nextChunkNumber: 0,
+      chunkCount: 0,
+      totalBytes: 0,
+      totalDurationMilliseconds: 0,
+    });
+    const chunk = {
+      accountId: ACCOUNT_ID,
+      workspaceId: WORKSPACE_ID,
+      subjectId: SUBJECT_ID,
+      recordingId: RECORDING_ID,
+      chunkNumber: 0,
+      byteLength: chunkBytes.byteLength,
+      sha256: chunkSha256,
+      startMilliseconds: 0,
+      durationMilliseconds: 1_000,
+      objectKey: "transcription-recordings/test/chunk-0.bin",
+      state: "complete" as const,
+      createdAt: new Date("2026-08-04T07:00:00.000Z"),
+      completedAt: new Date("2026-08-04T07:00:01.000Z"),
+    };
+    spyOn(dbModule, "getWorkspace").mockResolvedValue({ settings: {} } as never);
+    spyOn(dbModule, "getTranscriptionRecording").mockResolvedValue(recording);
+    spyOn(dbModule, "reserveTranscriptionRecordingChunk").mockResolvedValue({
+      recording,
+      chunk,
+      deduplicated: false,
+    });
+    spyOn(dbModule, "completeTranscriptionRecordingChunk").mockResolvedValue({
+      recording: response("uploading", {
+        nextChunkNumber: 1,
+        chunkCount: 1,
+        totalBytes: chunkBytes.byteLength,
+        totalDurationMilliseconds: 1_000,
+      }),
+      chunk,
+      deduplicated: false,
+    });
+
+    const api = app({ transcription, segmenter, objectStorage: storage() });
+    const server = Bun.serve({ port: 0, fetch: api.fetch });
+    try {
+      const result = await fetch(
+        new URL(
+          `/v1/workspaces/${WORKSPACE_ID}/transcription-recordings/${RECORDING_ID}/chunks/0`,
+          server.url,
+        ),
+        {
+          method: "PUT",
+          headers: {
+            authorization: await bearer(),
+            "content-type": "audio/webm",
+            "x-opengeni-chunk-sha256": chunkSha256,
+            "x-opengeni-chunk-start-milliseconds": "0",
+            "x-opengeni-chunk-duration-milliseconds": "1000",
+          },
+          body: chunkBytes,
+        },
+      );
+
+      expect(result.status).toBe(200);
+      expect((await result.json()) as { chunk: { sha256: string } }).toEqual(
+        expect.objectContaining({
+          chunk: expect.objectContaining({ sha256: chunkSha256 }),
+        }),
+      );
+    } finally {
+      server.stop(true);
+    }
+  });
+
   test("retries an idempotent chunk reservation and exposes an observable retryable failure", async () => {
     const chunkBytes = new Uint8Array([1, 2, 3]);
     const chunkSha256 = createHash("sha256").update(chunkBytes).digest("hex");

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -224,6 +224,9 @@ available independently when a provider is ready.
    retryable storage failures cross the ordinary typed API error envelope with a
    correlation id; unexpected failures propagate to HTTP failure observability
    rather than being converted into anonymous successful-route 500 responses.
+10. Prove chunk ingestion through the real Bun HTTP listener, not only Hono's
+    in-memory `app.request()` path. The bounded reader owns one complete read and
+    must not assume the runtime exposes an optional stream-lock release method.
 
 ## Canonical implementation
 


### PR DESCRIPTION
## Summary
- remove the unsupported stream-reader lock release that crashes Bun native HTTP uploads after reading the complete voice chunk
- cover the production boundary through a real Bun listener, rather than only Hono's in-memory request path
- document the native-listener verification invariant

## Root cause
Bun's native incoming request body reader does not expose `releaseLock()`. The resumable transcription route successfully read and hashed the entire recording chunk, then threw `TypeError: undefined is not a function` in its cleanup path, returning 500 before reservation.

## Verification
- regression test failed with HTTP 500 before the fix and passes after it
- `bun test apps/api/test/transcription-recording-routes.test.ts` (10 pass)
- `bun run --cwd apps/api typecheck`
- root typecheck, docs refs, public hygiene, lint/format, and diff checks passed during the fix
- exact saved jorgebot recording reproduced the production 500 before the fix; it will be replayed after deployment