### PR TITLE
chore: release 0.22.83

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.82
-appVersion: "0.22.82"
+version: 0.22.83
+appVersion: "0.22.83"


### PR DESCRIPTION
## Summary

- bump the Helm chart and application version from 0.22.82 to 0.22.83
- release the merged pending-tool protocol JSON normalization fix (#1139), together with the already-versioned current-main changes
- retain the ordinary rolling deployment path; this release adds no migration or deployment topology change

## Validation

- exact parent: `6c53a7841d4199e2c0582b2a7c4d106781665ea9`
- exact head: `23b81c4415b2a951620399e9e71c2bfafa39f3c8`
- diff contains only `deploy/helm/opengeni/Chart.yaml`
- `git diff --check`
- `helm lint deploy/helm/opengeni`
- no pending Changesets remain after Version PR #1141

The release will use immutable candidate digests and the serialized rolling production controller.
