### PR TITLE
chore: release 0.22.84 with immutable migration repair

### DIFF
--- a/.changeset/bright-composers-measure.md
+++ b/.changeset/bright-composers-measure.md
@@ -1,5 +1,0 @@
----
-"@opengeni/react": minor
----
-
-Add opt-in container-responsive `ChatComposer` and `Composer.Root` layout, including source-container-aware portalled model and realtime menus while preserving viewport defaults.

--- a/.changeset/calm-scoped-styles.md
+++ b/.changeset/calm-scoped-styles.md
@@ -1,5 +1,0 @@
----
-"@opengeni/react": minor
----
-
-Ship a ready-to-use, Preflight-free compiled CSS entry scoped to OpenGeni React roots, while retaining the Tailwind v4 bridge and CSS-free session surface.

--- a/.changeset/immutable-machine-removal-default.md
+++ b/.changeset/immutable-machine-removal-default.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Preserve the deployed migration 0172 bytes and move the connected-machine session default into a forward rolling migration.

--- a/.changeset/immutable-machine-removal-default.md
+++ b/.changeset/immutable-machine-removal-default.md
@@ -1,5 +1,0 @@
----
-"@opengeni/db": patch
----
-
-Preserve the deployed migration 0172 bytes and move the connected-machine session default into a forward rolling migration.

--- a/apps/api/CHANGELOG.md
+++ b/apps/api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @opengeni/api-router
 
+## 0.22.8
+
+### Patch Changes
+
+- Updated dependencies [377180c]
+  - @opengeni/db@0.28.7
+  - @opengeni/core@0.21.8
+  - @opengeni/documents@0.5.16
+  - @opengeni/events@0.3.86
+
 ## 0.22.7
 
 ### Patch Changes

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/api-router",
-  "version": "0.22.7",
+  "version": "0.22.8",
   "description": "OpenGeni HTTP surface: the Hono adapter/router (createApp), routes, MCP HTTP transport, and HTTP access adapters over @opengeni/core. An engine-distribution surface — its runtime closure includes engine-internal packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/apps/api/test/connections-routes.test.ts
+++ b/apps/api/test/connections-routes.test.ts
@@ -924,7 +924,11 @@ describe("connections routes", () => {
       const startedAt = performance.now();
       const response = await appWithDeps(
         { environment: "test" },
-        { oauthStartDeadlineMs: 25 },
+        // The deadline covers the real PostgreSQL connection lookup as well as
+        // network discovery. Leave enough room for that prerequisite under a
+        // loaded suite so this test deterministically reaches the stalled
+        // protected-resource response it is intended to classify.
+        { oauthStartDeadlineMs: 3_000 },
       ).request(`/v1/workspaces/${workspace.workspaceId}/connections/oauth/start`, {
         method: "POST",
         headers: {
@@ -945,7 +949,7 @@ describe("connections routes", () => {
         };
       };
       expect(response.status).toBe(408);
-      expect(performance.now() - startedAt).toBeLessThan(1_000);
+      expect(performance.now() - startedAt).toBeLessThan(6_000);
       expect(body.error).toMatchObject({
         code: "upstream_unavailable",
         retryable: true,

--- a/apps/worker/CHANGELOG.md
+++ b/apps/worker/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @opengeni/worker-bundle
 
+## 0.16.27
+
+### Patch Changes
+
+- Updated dependencies [377180c]
+  - @opengeni/db@0.28.7
+  - @opengeni/core@0.21.8
+  - @opengeni/documents@0.5.16
+  - @opengeni/events@0.3.86
+
 ## 0.16.26
 
 ### Patch Changes

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/worker-bundle",
-  "version": "0.16.26",
+  "version": "0.16.27",
   "description": "OpenGeni worker entry and reusable embedded lifecycle, shipped with a release-coherent pre-bundled Temporal workflow artifact.",
   "license": "Apache-2.0",
   "repository": {

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.83
-appVersion: "0.22.83"
+version: 0.22.84
+appVersion: "0.22.84"

--- a/examples/northstar-support/CHANGELOG.md
+++ b/examples/northstar-support/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @opengeni/example-northstar-support
 
+## 0.0.81
+
+### Patch Changes
+
+- Updated dependencies [d8b9b71]
+- Updated dependencies [d8b9b71]
+  - @opengeni/react@0.47.0
+
 ## 0.0.80
 
 ### Patch Changes

--- a/examples/northstar-support/package.json
+++ b/examples/northstar-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/example-northstar-support",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @opengeni/core
 
+## 0.21.8
+
+### Patch Changes
+
+- Updated dependencies [377180c]
+  - @opengeni/db@0.28.7
+  - @opengeni/documents@0.5.16
+  - @opengeni/events@0.3.86
+
 ## 0.21.7
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/core",
-  "version": "0.21.7",
+  "version": "0.21.8",
   "description": "OpenGeni framework-agnostic core: the domain, access, and billing layers (neutral access, off-HTTP V2 surface). Behavior-preserving extraction from apps/api — keeps Hono's HTTPException for error throwing (typed-errors cleanup deferred).",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opengeni/db
 
+## 0.28.7
+
+### Patch Changes
+
+- 377180c: Preserve the deployed migration 0172 bytes and move the connected-machine session default into a forward rolling migration.
+
 ## 0.28.6
 
 ### Patch Changes

--- a/packages/db/drizzle/0182_connected_machine_remove_session_default.sql
+++ b/packages/db/drizzle/0182_connected_machine_remove_session_default.sql
@@ -1,11 +1,8 @@
--- deployment-mode: maintenance
--- GitHub App installation credentials are host-owned run material. Retire the
--- model-visible github_token MCP tool from every durable session selection and
--- prevent an old writer from reintroducing it after the coordinated cutover.
-
-UPDATE "sessions"
-SET "first_party_mcp_tools" = "first_party_mcp_tools" - 'github_token'
-WHERE "first_party_mcp_tools" ? 'github_token';
+-- deployment-mode: rolling
+-- Migration 0172 is already deployed and immutable. Keep its database-owned
+-- fallback default aligned with the connected-machine removal tool through a
+-- forward migration; application session creation still writes its exact
+-- frozen tool selection explicitly.
 
 ALTER TABLE "sessions"
   ALTER COLUMN "first_party_mcp_tools"
@@ -25,6 +22,7 @@ ALTER TABLE "sessions"
     "sandbox_swap",
     "run_on",
     "sandbox_provision",
+    "connected_machine_remove",
     "rig_list",
     "rig_get",
     "rig_propose_change",
@@ -77,10 +75,3 @@ ALTER TABLE "sessions"
     "artifacts_publish",
     "artifacts_rollback"
   ]'::jsonb;
-
-ALTER TABLE "sessions"
-  DROP CONSTRAINT IF EXISTS "sessions_first_party_mcp_tools_no_model_credentials_chk";
-
-ALTER TABLE "sessions"
-  ADD CONSTRAINT "sessions_first_party_mcp_tools_no_model_credentials_chk"
-  CHECK (NOT ("first_party_mcp_tools" @> '["github_token"]'::jsonb));

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/db",
-  "version": "0.28.6",
+  "version": "0.28.7",
   "description": "OpenGeni persistence: Drizzle schema, RLS-scoped query layer, the SQL migration runner, and role provisioning.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/db/test/connected-machine-removal.test.ts
+++ b/packages/db/test/connected-machine-removal.test.ts
@@ -73,6 +73,18 @@ afterAll(async () => {
 }, 180_000);
 
 describe("connected machine removal lifecycle", () => {
+  test("forward migration exposes the tool through the database fallback default", async () => {
+    if (!available) return;
+    const [column] = await admin<{ column_default: string | null }[]>`
+      select column_default
+      from information_schema.columns
+      where table_schema = current_schema()
+        and table_name = 'sessions'
+        and column_name = 'first_party_mcp_tools'`;
+
+    expect(column?.column_default).toContain('"connected_machine_remove"');
+  });
+
   test("removes an offline enrollment without deleting history, rejects stale heartbeat, and replays idempotently", async () => {
     if (!available) return;
     const { accountId, workspaceId } = await freshWorkspace();

--- a/packages/documents/CHANGELOG.md
+++ b/packages/documents/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @opengeni/documents
 
+## 0.5.16
+
+### Patch Changes
+
+- Updated dependencies [377180c]
+  - @opengeni/db@0.28.7
+
 ## 0.5.15
 
 ### Patch Changes

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/documents",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @opengeni/events
 
+## 0.3.86
+
+### Patch Changes
+
+- Updated dependencies [377180c]
+  - @opengeni/db@0.28.7
+
 ## 0.3.85
 
 ### Patch Changes

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/events",
-  "version": "0.3.85",
+  "version": "0.3.86",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @opengeni/react
 
+## 0.47.0
+
+### Minor Changes
+
+- d8b9b71: Add opt-in container-responsive `ChatComposer` and `Composer.Root` layout, including source-container-aware portalled model and realtime menus while preserving viewport defaults.
+- d8b9b71: Ship a ready-to-use, Preflight-free compiled CSS entry scoped to OpenGeni React roots, while retaining the Tailwind v4 bridge and CSS-free session surface.
+
 ## 0.46.6
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/react",
-  "version": "0.46.6",
+  "version": "0.47.0",
   "description": "React hooks and styled components for OpenGeni: live session streaming, chat composer, message timeline, session status, and fleet views — token-themed (CSS variables), dark-first, built on Tailwind v4 + Radix + Motion.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/react/test/composer-responsive.test.tsx
+++ b/packages/react/test/composer-responsive.test.tsx
@@ -156,8 +156,10 @@ describe("container-responsive composer", () => {
     const root = mounted.container.querySelector<HTMLElement>(".og-composer");
     const trigger = mounted.container.querySelector<HTMLButtonElement>("[data-portal-source]");
     expect(root?.dataset.ogResponsiveBasis).toBe("container");
-    const [observer] = observersFor(root!);
-    expect(observersFor(root!)).toHaveLength(1);
+    const observed = observersFor(root!);
+    expect(observed).toHaveLength(1);
+    const observer = observed[0];
+    if (!observer) throw new Error("expected the composer resize observer to be registered");
 
     let inlineSize = 320;
     Object.defineProperty(root, "clientWidth", {

--- a/packages/runtime/test/turn-tool-cancellation.test.ts
+++ b/packages/runtime/test/turn-tool-cancellation.test.ts
@@ -9,6 +9,7 @@ import {
   cancellableShellCommand,
   createTurnToolCancellationController,
 } from "../src/sandbox/turn-tool-cancellation";
+import { parseExecResponseBanner } from "../src/sandbox/exec-banner";
 import {
   RoutingMutationOutcomeUnknownError,
   RoutingSandboxSession,
@@ -1019,9 +1020,14 @@ describe("turn sandbox-tool cancellation against a real local process", () => {
         (tool): tool is Extract<Tool<unknown>, { type: "function" }> =>
           tool.type === "function" && tool.name === "exec_command",
       );
+      const write = tools.find(
+        (tool): tool is Extract<Tool<unknown>, { type: "function" }> =>
+          tool.type === "function" && tool.name === "write_stdin",
+      );
       expect(exec).toBeDefined();
+      expect(write).toBeDefined();
 
-      const output = await exec!.invoke(
+      let current = await exec!.invoke(
         runContext,
         JSON.stringify({
           tty: false,
@@ -1042,7 +1048,23 @@ describe("turn sandbox-tool cancellation against a real local process", () => {
           ].join("\n"),
         }),
       );
+      let output = current;
+      for (let attempt = 0; attempt < 120; attempt += 1) {
+        const banner = parseExecResponseBanner(current);
+        if (banner.kind !== "running") break;
+        current = await write!.invoke(
+          runContext,
+          JSON.stringify({
+            session_id: banner.sessionId,
+            chars: "",
+            yield_time_ms: 250,
+            max_output_tokens: 4_096,
+          }),
+        );
+        output += `\n${current}`;
+      }
 
+      expect(parseExecResponseBanner(current)).toEqual({ kind: "exited", exitCode: 0 });
       expect(output).toContain("stdin=pipe stdout=pipe stderr=pipe");
       expect(output).toContain("pager=not-invoked");
       expect(existsSync(pagerMarker)).toBe(false);

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -198,18 +198,23 @@ describe("release schema contract", () => {
         (migrations.has("0178_permissioned_secret_reads.sql") ? 1 : 0) +
         (migrations.has("0179_slack_private_shortcut_delivery_gate.sql") ? 1 : 0) +
         (migrations.has("0180_retained_screenshot_lifecycle_fences.sql") ? 1 : 0) +
-        (migrations.has("0181_connected_machine_removal.sql") ? 1 : 0),
+        (migrations.has("0181_connected_machine_removal.sql") ? 1 : 0) +
+        (migrations.has("0182_connected_machine_remove_session_default.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(
-      "bef9b8266df4412e4a35df16521b66285faecfc0451b6898c52d1d4471ce76f9",
+      "7102df9f5f2da4825c2d2dd1a2e165afd8df256bc14465c904fcc89f06eeee83",
     );
-    expect(contract.latestMigration).toBe("0181_connected_machine_removal.sql");
+    expect(contract.latestMigration).toBe("0182_connected_machine_remove_session_default.sql");
     expect(migrations.get("0065_enrollment_credential_generation.sql")).toMatchObject({
       sha256: "2e25fa2dfb8a95a7a9ba1ef5aa9bd219755af998b3317bcdf4d7acc4f67264fe",
       deploymentMode: "rolling",
     });
     expect(migrations.get("0181_connected_machine_removal.sql")).toMatchObject({
       sha256: "c933a0781ac3c78272c5049637e3718299382e93272ea04095077f8ce7148f0a",
+      deploymentMode: "rolling",
+    });
+    expect(migrations.get("0182_connected_machine_remove_session_default.sql")).toMatchObject({
+      sha256: "c15bd3b6d71f15be9e163481c3cb698d8f46620d655a72a5e56d193bc16310cd",
       deploymentMode: "rolling",
     });
     expect(migrations.get("0180_retained_screenshot_lifecycle_fences.sql")).toMatchObject({
@@ -263,7 +268,7 @@ describe("release schema contract", () => {
       deploymentMode: "rolling",
     });
     expect(migrations.get("0172_retire_model_visible_github_token.sql")).toMatchObject({
-      sha256: "e16ecce0d4e067168590cd54086c85b2bb0d6e0f244976aa4190b942e5f76356",
+      sha256: "6e2123085f5574a046eaea7db7b5168540625d554771ee9e5639787bbde4c713",
       deploymentMode: "maintenance",
     });
     expect(


### PR DESCRIPTION
## Summary

- restore deployed migration `0172` byte-for-byte to its immutable production hash
- add rolling forward migration `0182` for the `connected_machine_remove` session default
- update the governed schema contract and cover the real PostgreSQL default
- harden three current-main tests exposed by a loaded repository-wide run: guard a registered React observer, follow a legitimate yielded local shell process to completion, and give the real-DB prerequisite enough budget before classifying a deliberately stalled OAuth metadata stream
- deterministically consume all pending Changesets and advance chart/app to the next unused release, `0.22.84`

## Root cause

The 0.22.83 source modified migration `0172` after that migration was already applied in production. The release schema gate correctly rejects that candidate even though the runtime tool selection is otherwise explicit. This patch preserves deployed history and expresses the intended default change only through a new forward migration.

## Validation

- `OPENGENI_REQUIRE_REAL_TEST_SERVICES=1 bun test packages/db/test/connected-machine-removal.test.ts scripts/release-schema-contract.test.ts` — 10/10
- `bun run typecheck` — 23/23 projects
- `bun run lint`
- `bun run format:check`
- focused React, local-process, and stalled-OAuth regressions pass
- the first loaded monolithic run completed 6,421/6,423 before exposing the two timing assumptions now hardened
- exact bounded repository gate (`check:public-hygiene`, 23-project typecheck, full tests at `--max-concurrency=4`, SDK/React/demo/web/Northstar builds) — terminal exit 0
- exact release head after deterministic versioning: public hygiene, 23-project typecheck, lint, format, and mandatory real-PostgreSQL migration suite — 10/10 tests, 125 assertions
- repaired contract verified against the live production migration contract; only rolling additions 0065, 0181, and 0182 remain
- restored `0172` SHA-256: `6e2123085f5574a046eaea7db7b5168540625d554771ee9e5639787bbde4c713`

The existing 0.22.83 candidate is quarantined and must not be deployed. GitHub Actions is in a provider-declared critical outage, so the exact `0.22.84` release head is using the previously authorized, evidence-preserving break-glass path: no check is fabricated, all new images are built from this head, and production mutation remains fenced until schema/image/rolling-deployment verification.
