### PR TITLE
Fix Connected Machine cgroup descendant placement race

### DIFF
--- a/agent/crates/opengeni-agent-platform/src/cgroup.rs
+++ b/agent/crates/opengeni-agent-platform/src/cgroup.rs
@@ -21,10 +21,13 @@
 //!    `<service>/cgroup.subtree_control`. Per-op cgroups are then
 //!    `<service>/op-<n>` siblings of `supervisor`, each with its own memory
 //!    accounting.
-//! 2. **Per-exec placement** ([`OpCgroups::place_op`]). After a child is spawned,
-//!    its PID and the #344 process-group anchor's PID are written into a fresh
-//!    `op-<n>` leaf (optionally capped by [`OpCgroupConfig`]). A memory blow-up in
-//!    that leaf is contained to the leaf; the supervisor in its own leaf survives.
+//! 2. **Per-exec placement** ([`OpCgroups::place_stopped_group`]). After a child is
+//!    spawned, the caller stops its process group, then every current group member
+//!    plus the #344 process-group anchor is written into a fresh `op-<n>` leaf
+//!    (optionally capped by [`OpCgroupConfig`]) before the group resumes. Stopping
+//!    closes the fork-before-placement race: ordinary descendants cannot remain
+//!    billed to the supervisor leaf. A memory blow-up in the op leaf is contained
+//!    to that leaf; the supervisor in its own leaf survives.
 //! 3. **Teardown** ([`OpCgroupHandle`]). The op leaf is `rmdir`'d after the op's
 //!    process tree is reaped, tolerating a transient `EBUSY` with a bounded retry.
 //!
@@ -128,6 +131,55 @@ pub struct OpCgroups {
 }
 
 impl OpCgroups {
+    /// Expands a stopped exec process group to every member still inherited in the
+    /// supervisor leaf, then places that complete set in one op cgroup.
+    ///
+    /// The caller MUST stop `pgid` before calling and resume it afterwards. While
+    /// stopped, no ordinary descendant can fork between enumeration and placement.
+    /// `direct_pids` (the command + anchor) remain the fallback if the supervisor
+    /// membership read is unavailable; placement is deliberately best-effort.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn place_stopped_group(
+        &self,
+        pgid: i32,
+        direct_pids: &[u32],
+    ) -> Option<OpCgroupHandle> {
+        let mut pids = direct_pids.to_vec();
+        let supervisor_procs = self.service_dir.join(SUPERVISOR_LEAF).join("cgroup.procs");
+
+        match std::fs::read_to_string(&supervisor_procs) {
+            Ok(contents) => {
+                for raw in contents.split_whitespace() {
+                    let Ok(pid) = raw.parse::<u32>() else {
+                        continue;
+                    };
+                    let Ok(raw_pid) = i32::try_from(pid) else {
+                        continue;
+                    };
+                    if nix::unistd::getpgid(Some(nix::unistd::Pid::from_raw(raw_pid)))
+                        .is_ok_and(|member_pgid| member_pgid.as_raw() == pgid)
+                    {
+                        pids.push(pid);
+                    }
+                }
+            }
+            Err(error) => self.note_fallback(format_args!(
+                "cannot enumerate stopped process group {pgid} from {}: {error}",
+                supervisor_procs.display()
+            )),
+        }
+
+        pids.sort_unstable();
+        pids.dedup();
+        // A descendant may have forked before the direct child received its
+        // oom_score_adj bias. Re-stamp every stopped member; future descendants
+        // inherit from these corrected parents after the group resumes.
+        for pid in &pids {
+            raise_exec_oom_score_adj(*pid);
+        }
+        self.place_op(&pids)
+    }
+
     /// Places one exec's processes into a fresh `op-<n>` memory leaf and returns a
     /// teardown handle. `pids` is the requested child plus the #344 group anchor —
     /// both are moved so the whole op shares one memory fate.

--- a/agent/crates/opengeni-agent-platform/src/cgroup.rs
+++ b/agent/crates/opengeni-agent-platform/src/cgroup.rs
@@ -21,13 +21,14 @@
 //!    `<service>/cgroup.subtree_control`. Per-op cgroups are then
 //!    `<service>/op-<n>` siblings of `supervisor`, each with its own memory
 //!    accounting.
-//! 2. **Per-exec placement** ([`OpCgroups::place_stopped_group`]). After a child is
-//!    spawned, the caller stops its process group, then every current group member
-//!    plus the #344 process-group anchor is written into a fresh `op-<n>` leaf
-//!    (optionally capped by [`OpCgroupConfig`]) before the group resumes. Stopping
-//!    closes the fork-before-placement race: ordinary descendants cannot remain
-//!    billed to the supervisor leaf. A memory blow-up in the op leaf is contained
-//!    to that leaf; the supervisor in its own leaf survives.
+//! 2. **Per-exec placement** ([`OpCgroups::place_process_group`]). After a child is
+//!    spawned, the caller stops its process group, places the direct child + #344
+//!    process-group anchor, then drains every same-group process still inherited in
+//!    `supervisor` into the same fresh `op-<n>` leaf before resuming the group. The
+//!    drain does not assume that `killpg(SIGSTOP)` is synchronous: once a parent is
+//!    moved, every later child inherits the op leaf, and the scan continues until no
+//!    ordinary descendant remains in `supervisor`. A memory blow-up in the op leaf
+//!    is contained to that leaf; the supervisor in its own leaf survives.
 //! 3. **Teardown** ([`OpCgroupHandle`]). The op leaf is `rmdir`'d after the op's
 //!    process tree is reaped, tolerating a transient `EBUSY` with a bounded retry.
 //!
@@ -131,53 +132,91 @@ pub struct OpCgroups {
 }
 
 impl OpCgroups {
-    /// Expands a stopped exec process group to every member still inherited in the
-    /// supervisor leaf, then places that complete set in one op cgroup.
+    /// Stops an exec process group, places its direct members, then drains every
+    /// same-group process still inherited in the supervisor leaf into the same op
+    /// cgroup before resuming it.
     ///
-    /// The caller MUST stop `pgid` before calling and resume it afterwards. While
-    /// stopped, no ordinary descendant can fork between enumeration and placement.
-    /// `direct_pids` (the command + anchor) remain the fallback if the supervisor
-    /// membership read is unavailable; placement is deliberately best-effort.
+    /// A `killpg(SIGSTOP)` return is not itself a barrier: delivery may still be
+    /// pending on another CPU. Correctness therefore comes from cgroup inheritance,
+    /// not signal timing. Direct roots move first; every later fork inherits their
+    /// op leaf. Any child forked before its parent moved remains visible in the
+    /// supervisor leaf and is moved by a later drain pass. The loop ends only when
+    /// no live ordinary member remains there. A repeated identical set means the
+    /// kernel refused every move, so isolation degrades loudly instead of spinning.
     #[cfg(target_os = "linux")]
-    pub(crate) fn place_stopped_group(
+    pub(crate) fn place_process_group(
         &self,
         pgid: i32,
         direct_pids: &[u32],
-    ) -> Option<OpCgroupHandle> {
-        let mut pids = direct_pids.to_vec();
-        let supervisor_procs = self.service_dir.join(SUPERVISOR_LEAF).join("cgroup.procs");
+    ) -> std::io::Result<Option<OpCgroupHandle>> {
+        signal_process_group(pgid, nix::sys::signal::Signal::SIGSTOP)?;
 
-        match std::fs::read_to_string(&supervisor_procs) {
-            Ok(contents) => {
-                for raw in contents.split_whitespace() {
-                    let Ok(member_pid) = raw.parse::<u32>() else {
-                        continue;
-                    };
-                    let Ok(member_raw_pid) = i32::try_from(member_pid) else {
-                        continue;
-                    };
-                    if nix::unistd::getpgid(Some(nix::unistd::Pid::from_raw(member_raw_pid)))
-                        .is_ok_and(|member_pgid| member_pgid.as_raw() == pgid)
-                    {
-                        pids.push(member_pid);
-                    }
+        let Some(handle) = self.place_op(direct_pids) else {
+            signal_process_group(pgid, nix::sys::signal::Signal::SIGCONT)?;
+            return Ok(None);
+        };
+
+        let mut prior_members: Option<Vec<u32>> = None;
+        loop {
+            let members = match self.supervisor_process_group_members(pgid) {
+                Ok(members) => members,
+                Err(error) => {
+                    self.note_fallback(format_args!(
+                        "cannot drain process-group {pgid} from the supervisor cgroup: {error}"
+                    ));
+                    break;
                 }
+            };
+            if members.is_empty() {
+                break;
             }
-            Err(error) => self.note_fallback(format_args!(
-                "cannot enumerate stopped process group {pgid} from {}: {error}",
-                supervisor_procs.display()
-            )),
+            if prior_members.as_ref() == Some(&members) {
+                self.note_fallback(format_args!(
+                    "process-group {pgid} cgroup drain made no progress for pids {members:?}"
+                ));
+                break;
+            }
+            prior_members = Some(members.clone());
+
+            // A descendant may have forked before the direct child received its
+            // OOM bias. Re-stamp every discovered member; later descendants inherit
+            // from their corrected parent after it moves into the op leaf.
+            for pid in &members {
+                raise_exec_oom_score_adj(*pid);
+            }
+            self.place_pids_in(&handle.dir, &members);
         }
 
-        pids.sort_unstable();
-        pids.dedup();
-        // A descendant may have forked before the direct child received its
-        // oom_score_adj bias. Re-stamp every stopped member; future descendants
-        // inherit from these corrected parents after the group resumes.
-        for pid in &pids {
-            raise_exec_oom_score_adj(*pid);
+        if let Err(error) = signal_process_group(pgid, nix::sys::signal::Signal::SIGCONT) {
+            let _ = signal_process_group(pgid, nix::sys::signal::Signal::SIGKILL);
+            handle.teardown_best_effort();
+            return Err(error);
         }
-        self.place_op(&pids)
+        Ok(Some(handle))
+    }
+
+    /// Enumerates live members of `pgid` that still inherit the supervisor leaf.
+    #[cfg(target_os = "linux")]
+    fn supervisor_process_group_members(&self, pgid: i32) -> std::io::Result<Vec<u32>> {
+        let supervisor_procs = self.service_dir.join(SUPERVISOR_LEAF).join("cgroup.procs");
+        let contents = std::fs::read_to_string(supervisor_procs)?;
+        let mut members = Vec::new();
+        for raw in contents.split_whitespace() {
+            let Ok(member_pid) = raw.parse::<u32>() else {
+                continue;
+            };
+            let Ok(member_raw_pid) = i32::try_from(member_pid) else {
+                continue;
+            };
+            if nix::unistd::getpgid(Some(nix::unistd::Pid::from_raw(member_raw_pid)))
+                .is_ok_and(|member_pgid| member_pgid.as_raw() == pgid)
+            {
+                members.push(member_pid);
+            }
+        }
+        members.sort_unstable();
+        members.dedup();
+        Ok(members)
     }
 
     /// Places one exec's processes into a fresh `op-<n>` memory leaf and returns a
@@ -220,9 +259,15 @@ impl OpCgroups {
             }
         }
 
-        // Move the exec's processes into the leaf. cgroup.procs takes one PID per
-        // write; the tiny window between spawn and this move is the accepted
-        // post-spawn billing window (no async-signal-unsafe pre_exec tricks).
+        self.place_pids_in(&dir, pids);
+
+        Some(OpCgroupHandle { dir })
+    }
+
+    /// Moves each live PID into an existing operation leaf. `cgroup.procs` moves
+    /// the entire thread group and returns only after the migration is visible.
+    #[cfg(target_os = "linux")]
+    fn place_pids_in(&self, dir: &Path, pids: &[u32]) {
         let procs = dir.join("cgroup.procs");
         for pid in pids {
             if let Err(error) = std::fs::write(&procs, pid.to_string()) {
@@ -232,8 +277,6 @@ impl OpCgroups {
                 ));
             }
         }
-
-        Some(OpCgroupHandle { dir })
     }
 
     /// Non-Linux no-op: no manager is ever constructed off Linux, so this is never
@@ -421,6 +464,20 @@ pub fn establish_oom_isolation(config: OpCgroupConfig) -> Option<Arc<OpCgroups>>
 pub fn establish_oom_isolation(_config: OpCgroupConfig) -> Option<Arc<OpCgroups>> {
     tracing::debug!("per-op OOM cgroup isolation is Linux-only; running without it on this OS");
     None
+}
+
+/// Signals an owned process group. ESRCH is success: the group completed before
+/// the placement barrier and has nothing left to isolate or resume.
+#[cfg(target_os = "linux")]
+fn signal_process_group(pgid: i32, signal: nix::sys::signal::Signal) -> std::io::Result<()> {
+    use nix::errno::Errno;
+    use nix::sys::signal::killpg;
+    use nix::unistd::Pid;
+
+    match killpg(Pid::from_raw(pgid), signal) {
+        Ok(()) | Err(Errno::ESRCH) => Ok(()),
+        Err(error) => Err(std::io::Error::from(error)),
+    }
 }
 
 /// Creates `dir`, treating an already-existing directory as success (a leaked leaf

--- a/agent/crates/opengeni-agent-platform/src/cgroup.rs
+++ b/agent/crates/opengeni-agent-platform/src/cgroup.rs
@@ -71,6 +71,13 @@ const TEARDOWN_ATTEMPTS: u32 = 5;
 #[cfg(target_os = "linux")]
 const TEARDOWN_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(20);
 
+/// Honest fallback when Linux exposes neither the delegated cgroup PID ceiling,
+/// `RLIMIT_NPROC`, nor the kernel PID namespace ceiling. Production normally
+/// derives the breaker from the first available host limit; this fallback is far
+/// above an ordinary spawn race (one shell + a few immediate children).
+#[cfg(target_os = "linux")]
+const PLACEMENT_PID_BREAKER_FALLBACK: usize = 256;
+
 /// Environment variable naming an optional per-op `memory.max` hard cap, in bytes.
 const OP_MEMORY_MAX_ENV: &str = "OPENGENI_AGENT_OP_MEMORY_MAX";
 
@@ -124,6 +131,9 @@ pub struct OpCgroups {
     service_dir: PathBuf,
     /// The per-op memory limits to stamp on each leaf.
     config: OpCgroupConfig,
+    /// Host-derived ceiling on cumulative supervisor-leaf PIDs drained during one
+    /// spawn. Crossing it means an active fork pathology, not normal concurrency.
+    placement_pid_breaker: usize,
     /// The next op-id; each `place_op` allocates a unique `op-<n>` sibling.
     next_op: AtomicU64,
     /// Guards the "log once" of the per-op placement fallback so a persistent
@@ -157,6 +167,7 @@ impl OpCgroups {
         };
 
         let mut prior_members: Option<Vec<u32>> = None;
+        let mut drained_pids = 0usize;
         loop {
             let members = match self.supervisor_process_group_members(pgid) {
                 Ok(members) => members,
@@ -178,6 +189,25 @@ impl OpCgroups {
             }
             prior_members = Some(members.clone());
 
+            let next_drained = drained_pids.saturating_add(members.len());
+            if next_drained > self.placement_pid_breaker {
+                let error = std::io::Error::other(format!(
+                    "process-group {pgid} cgroup drain exceeded the host-derived PID breaker of {} while containing an active fork storm",
+                    self.placement_pid_breaker
+                ));
+                tracing::warn!(
+                    group_id = pgid,
+                    drained_pids,
+                    pending_pids = members.len(),
+                    breaker = self.placement_pid_breaker,
+                    "terminating exec whose pre-containment fork storm tripped the cgroup placement breaker"
+                );
+                let _ = signal_process_group(pgid, nix::sys::signal::Signal::SIGKILL);
+                handle.teardown_best_effort();
+                return Err(error);
+            }
+            drained_pids = next_drained;
+
             // A descendant may have forked before the direct child received its
             // OOM bias. Re-stamp every discovered member; later descendants inherit
             // from their corrected parent after it moves into the op leaf.
@@ -185,6 +215,11 @@ impl OpCgroups {
                 raise_exec_oom_score_adj(*pid);
             }
             self.place_pids_in(&handle.dir, &members);
+            if let Err(error) = signal_process_group(pgid, nix::sys::signal::Signal::SIGSTOP) {
+                let _ = signal_process_group(pgid, nix::sys::signal::Signal::SIGKILL);
+                handle.teardown_best_effort();
+                return Err(error);
+            }
         }
 
         if let Err(error) = signal_process_group(pgid, nix::sys::signal::Signal::SIGCONT) {
@@ -443,15 +478,18 @@ pub fn establish_oom_isolation(config: OpCgroupConfig) -> Option<Arc<OpCgroups>>
         return None;
     }
 
+    let placement_pid_breaker = placement_pid_breaker(&service_dir);
     tracing::info!(
         service_cgroup = %service_dir.display(),
         memory_max = ?config.memory_max,
         memory_high = ?config.memory_high,
+        placement_pid_breaker,
         "established per-op OOM cgroup isolation: host execs run in memory sub-cgroups; the control supervisor is fate-isolated in its own leaf"
     );
     Some(Arc::new(OpCgroups {
         service_dir,
         config,
+        placement_pid_breaker,
         next_op: AtomicU64::new(0),
         fallback_logged: AtomicBool::new(false),
     }))
@@ -478,6 +516,46 @@ fn signal_process_group(pgid: i32, signal: nix::sys::signal::Signal) -> std::io:
         Ok(()) | Err(Errno::ESRCH) => Ok(()),
         Err(error) => Err(std::io::Error::from(error)),
     }
+}
+
+/// Derives a one-spawn fork-pathology breaker from the delegated service's PID
+/// ceiling, then the user's process rlimit, then the PID namespace ceiling. Half
+/// the available ceiling leaves the supervisor and unrelated work headroom. This
+/// breaker limits only the synchronous pre-containment drain; it does not limit a
+/// successfully-contained command's lifetime or eventual process count.
+#[cfg(target_os = "linux")]
+fn placement_pid_breaker(service_dir: &Path) -> usize {
+    let cgroup_ceiling = std::fs::read_to_string(service_dir.join("pids.max"))
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok());
+    let rlimit_ceiling = std::fs::read_to_string("/proc/self/limits")
+        .ok()
+        .and_then(|limits| parse_soft_process_limit(&limits));
+    let namespace_ceiling = std::fs::read_to_string("/proc/sys/kernel/pid_max")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok());
+    derive_placement_pid_breaker(cgroup_ceiling.or(rlimit_ceiling).or(namespace_ceiling))
+}
+
+/// Half a known host PID ceiling (at least one), or a generous fallback when the
+/// Linux host exposes no ceiling at all.
+#[cfg(target_os = "linux")]
+fn derive_placement_pid_breaker(pid_ceiling: Option<u64>) -> usize {
+    pid_ceiling.map_or(PLACEMENT_PID_BREAKER_FALLBACK, |ceiling| {
+        usize::try_from((ceiling / 2).max(1)).unwrap_or(usize::MAX)
+    })
+}
+
+/// Parses the soft `RLIMIT_NPROC` value from `/proc/self/limits`; `unlimited`
+/// deliberately falls through to the kernel PID namespace ceiling.
+#[cfg(target_os = "linux")]
+fn parse_soft_process_limit(limits: &str) -> Option<u64> {
+    let value = limits
+        .lines()
+        .find_map(|line| line.strip_prefix("Max processes"))?
+        .split_whitespace()
+        .next()?;
+    (value != "unlimited").then(|| value.parse().ok()).flatten()
 }
 
 /// Creates `dir`, treating an already-existing directory as success (a leaked leaf
@@ -621,6 +699,29 @@ mod tests {
         assert_eq!(op_cgroup_name(0), "op-0");
         assert_eq!(op_cgroup_name(42), "op-42");
         assert_ne!(op_cgroup_name(1), op_cgroup_name(2));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn placement_pid_breaker_scales_from_the_host_ceiling() {
+        assert_eq!(derive_placement_pid_breaker(Some(28_708)), 14_354);
+        assert_eq!(derive_placement_pid_breaker(Some(1)), 1);
+        assert_eq!(
+            derive_placement_pid_breaker(None),
+            PLACEMENT_PID_BREAKER_FALLBACK
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parses_finite_process_rlimit_and_skips_unlimited() {
+        let finite = "Limit                     Soft Limit           Hard Limit           Units\n\
+                      Max processes             95695                95695                processes\n";
+        assert_eq!(parse_soft_process_limit(finite), Some(95_695));
+
+        let unlimited = "Limit                     Soft Limit           Hard Limit           Units\n\
+                         Max processes             unlimited            unlimited            processes\n";
+        assert_eq!(parse_soft_process_limit(unlimited), None);
     }
 
     #[test]

--- a/agent/crates/opengeni-agent-platform/src/cgroup.rs
+++ b/agent/crates/opengeni-agent-platform/src/cgroup.rs
@@ -150,16 +150,16 @@ impl OpCgroups {
         match std::fs::read_to_string(&supervisor_procs) {
             Ok(contents) => {
                 for raw in contents.split_whitespace() {
-                    let Ok(pid) = raw.parse::<u32>() else {
+                    let Ok(member_pid) = raw.parse::<u32>() else {
                         continue;
                     };
-                    let Ok(raw_pid) = i32::try_from(pid) else {
+                    let Ok(member_raw_pid) = i32::try_from(member_pid) else {
                         continue;
                     };
-                    if nix::unistd::getpgid(Some(nix::unistd::Pid::from_raw(raw_pid)))
+                    if nix::unistd::getpgid(Some(nix::unistd::Pid::from_raw(member_raw_pid)))
                         .is_ok_and(|member_pgid| member_pgid.as_raw() == pgid)
                     {
-                        pids.push(pid);
+                        pids.push(member_pid);
                     }
                 }
             }

--- a/agent/crates/opengeni-agent-platform/src/native.rs
+++ b/agent/crates/opengeni-agent-platform/src/native.rs
@@ -265,20 +265,21 @@ impl ExecProcessGroup {
         // Place the COMPLETE ordinary process group in one per-op memory leaf. A
         // shell can fork between Command::spawn returning and post-spawn placement;
         // moving only the direct child would leave that fast descendant billed to
-        // the supervisor. Stop the group first, enumerate + move every member, then
-        // resume it. A stopped member cannot extend the fork race while placement
-        // runs. This is a no-op when isolation is unavailable / off Linux.
+        // the supervisor. The cgroup manager stops the group, moves its direct
+        // roots, then drains same-group descendants from the supervisor leaf before
+        // resuming. Correctness does not depend on synchronous SIGSTOP delivery.
+        // This is a no-op when isolation is unavailable / off Linux.
         #[cfg(target_os = "linux")]
         let op_cgroup = if let Some(cg) = cgroups {
-            stop_unix_process_group(pgid)?;
             let pids: Vec<u32> = [anchor.id(), child.id()].into_iter().flatten().collect();
-            let handle = cg.place_stopped_group(pgid, &pids);
-            if let Err(error) = continue_unix_process_group(pgid) {
-                let _ = terminate_unix_process_group(pgid);
-                let _ = anchor.start_kill();
-                return Err(error);
+            match cg.place_process_group(pgid, &pids) {
+                Ok(handle) => handle,
+                Err(error) => {
+                    let _ = terminate_unix_process_group(pgid);
+                    let _ = anchor.start_kill();
+                    return Err(error);
+                }
             }
-            handle
         } else {
             None
         };
@@ -390,28 +391,6 @@ fn terminate_unix_process_group(pgid: i32) -> std::io::Result<()> {
             );
             Ok(())
         }
-        Err(error) => Err(std::io::Error::from(error)),
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn stop_unix_process_group(pgid: i32) -> std::io::Result<()> {
-    signal_unix_process_group(pgid, nix::sys::signal::Signal::SIGSTOP)
-}
-
-#[cfg(target_os = "linux")]
-fn continue_unix_process_group(pgid: i32) -> std::io::Result<()> {
-    signal_unix_process_group(pgid, nix::sys::signal::Signal::SIGCONT)
-}
-
-#[cfg(target_os = "linux")]
-fn signal_unix_process_group(pgid: i32, signal: nix::sys::signal::Signal) -> std::io::Result<()> {
-    use nix::errno::Errno;
-    use nix::sys::signal::killpg;
-    use nix::unistd::Pid;
-
-    match killpg(Pid::from_raw(pgid), signal) {
-        Ok(()) | Err(Errno::ESRCH) => Ok(()),
         Err(error) => Err(std::io::Error::from(error)),
     }
 }

--- a/agent/crates/opengeni-agent-platform/src/native.rs
+++ b/agent/crates/opengeni-agent-platform/src/native.rs
@@ -262,11 +262,27 @@ impl ExecProcessGroup {
             crate::cgroup::raise_exec_oom_score_adj(child_pid);
         }
 
-        // Place the requested child AND the group anchor into a per-op memory leaf
-        // so they share one OOM fate, isolated from the control supervisor. The tiny
-        // window between spawn and this move is the accepted post-spawn billing
-        // window — pre_exec placement is async-signal-unsafe and deliberately not
-        // used. A no-op when `cgroups` is `None` (isolation unavailable / off Linux).
+        // Place the COMPLETE ordinary process group in one per-op memory leaf. A
+        // shell can fork between Command::spawn returning and post-spawn placement;
+        // moving only the direct child would leave that fast descendant billed to
+        // the supervisor. Stop the group first, enumerate + move every member, then
+        // resume it. A stopped member cannot extend the fork race while placement
+        // runs. This is a no-op when isolation is unavailable / off Linux.
+        #[cfg(target_os = "linux")]
+        let op_cgroup = if let Some(cg) = cgroups {
+            stop_unix_process_group(pgid)?;
+            let pids: Vec<u32> = [anchor.id(), child.id()].into_iter().flatten().collect();
+            let handle = cg.place_stopped_group(pgid, &pids);
+            if let Err(error) = continue_unix_process_group(pgid) {
+                let _ = terminate_unix_process_group(pgid);
+                let _ = anchor.start_kill();
+                return Err(error);
+            }
+            handle
+        } else {
+            None
+        };
+        #[cfg(not(target_os = "linux"))]
         let op_cgroup = cgroups.and_then(|cg| {
             let pids: Vec<u32> = [anchor.id(), child.id()].into_iter().flatten().collect();
             cg.place_op(&pids)
@@ -374,6 +390,28 @@ fn terminate_unix_process_group(pgid: i32) -> std::io::Result<()> {
             );
             Ok(())
         }
+        Err(error) => Err(std::io::Error::from(error)),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn stop_unix_process_group(pgid: i32) -> std::io::Result<()> {
+    signal_unix_process_group(pgid, nix::sys::signal::Signal::SIGSTOP)
+}
+
+#[cfg(target_os = "linux")]
+fn continue_unix_process_group(pgid: i32) -> std::io::Result<()> {
+    signal_unix_process_group(pgid, nix::sys::signal::Signal::SIGCONT)
+}
+
+#[cfg(target_os = "linux")]
+fn signal_unix_process_group(pgid: i32, signal: nix::sys::signal::Signal) -> std::io::Result<()> {
+    use nix::errno::Errno;
+    use nix::sys::signal::killpg;
+    use nix::unistd::Pid;
+
+    match killpg(Pid::from_raw(pgid), signal) {
+        Ok(()) | Err(Errno::ESRCH) => Ok(()),
         Err(error) => Err(std::io::Error::from(error)),
     }
 }

--- a/agent/crates/opengeni-agent-platform/tests/cgroup_placement.rs
+++ b/agent/crates/opengeni-agent-platform/tests/cgroup_placement.rs
@@ -1,9 +1,11 @@
 //! Live cgroup-placement integration test for OOM fate isolation (issue #345).
 //!
 //! Exercises the REAL path — [`establish_oom_isolation`] runs the startup dance
-//! and a real `exec` places its child into an `op-<n>` memory leaf — then asserts
-//! the child lands in that leaf with `oom_score_adj=500` while the supervisor (this
-//! process) stays in the `supervisor` leaf.
+//! and a real shell `exec` immediately forks a child — then asserts BOTH the shell
+//! and the fast descendant land in one `op-<n>` memory leaf with
+//! `oom_score_adj=500` while the supervisor (this process) stays in the
+//! `supervisor` leaf. This is the live regression proof for the post-spawn fork
+//! race observed on jorgebot.
 //!
 //! # Why it is environment-gated
 //!
@@ -106,13 +108,14 @@ mod linux {
             "supervisor must be fate-isolated in its own leaf, got {self_unified}"
         );
 
-        // Run a real exec whose direct child reports its PID and stays alive (a pure
-        // shell busy-loop — no coreutil dependency) so we can inspect it live.
+        // Run a real shell exec that IMMEDIATELY forks a descendant. Both publish
+        // their PIDs and stay alive so the test catches a child that escaped into
+        // the supervisor leaf before post-spawn placement.
         let pid_file = std::env::temp_dir().join(format!("oom-itest-{}.pid", std::process::id()));
         let _ = std::fs::remove_file(&pid_file);
         let req = ExecRequest {
             command: vec![format!(
-                "echo $$ > {}; while :; do :; done",
+                "while :; do :; done & echo $$ $! > {}; wait",
                 pid_file.display()
             )],
             shell: true,
@@ -121,13 +124,17 @@ mod linux {
         let task_platform = platform.clone();
         let exec_task = tokio::spawn(async move { task_platform.exec(&req).await });
 
-        let child_pid = read_child_pid(&pid_file).await;
+        let (shell_pid, descendant_pid) = read_fixture_pids(&pid_file).await;
 
-        // Placement is post-spawn, so poll the child's cgroup + score for the target.
-        let child_unified = poll_child_cgroup(child_pid).await;
-        let score = std::fs::read_to_string(format!("/proc/{child_pid}/oom_score_adj"))
+        let shell_unified = poll_child_cgroup(shell_pid).await;
+        let descendant_unified = poll_child_cgroup(descendant_pid).await;
+        let score = std::fs::read_to_string(format!("/proc/{shell_pid}/oom_score_adj"))
             .map(|s| s.trim().to_string())
             .unwrap_or_default();
+        let descendant_score =
+            std::fs::read_to_string(format!("/proc/{descendant_pid}/oom_score_adj"))
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default();
 
         exec_task.abort();
         let _ = exec_task.await;
@@ -135,45 +142,62 @@ mod linux {
 
         eprintln!("LIVE EVIDENCE (issue #345 OOM fate isolation):");
         eprintln!("  supervisor (this process) cgroup: {self_unified}");
-        eprintln!("  exec child {child_pid} cgroup:      {child_unified}");
-        eprintln!("  exec child {child_pid} oom_score_adj: {score}");
+        eprintln!("  exec shell {shell_pid} cgroup:      {shell_unified}");
+        eprintln!("  descendant {descendant_pid} cgroup: {descendant_unified}");
+        eprintln!("  exec shell {shell_pid} oom_score_adj: {score}");
+        eprintln!("  descendant {descendant_pid} oom_score_adj: {descendant_score}");
 
         assert!(
-            child_unified.contains("/op-"),
-            "exec child {child_pid} must run in an op-<n> leaf, got {child_unified}"
+            shell_unified.contains("/op-"),
+            "exec shell {shell_pid} must run in an op-<n> leaf, got {shell_unified}"
+        );
+        assert_eq!(
+            descendant_unified, shell_unified,
+            "fast descendant {descendant_pid} must share the shell's op leaf"
         );
         assert!(
-            child_unified.starts_with(&self_unified[..self_unified.len() - "/supervisor".len()]),
+            shell_unified.starts_with(&self_unified[..self_unified.len() - "/supervisor".len()]),
             "the op leaf must be a sibling of the supervisor leaf under the service cgroup \
-             ({child_unified} vs {self_unified})"
+             ({shell_unified} vs {self_unified})"
         );
         assert_eq!(
             score, "500",
-            "exec child {child_pid} must carry oom_score_adj=500"
+            "exec shell {shell_pid} must carry oom_score_adj=500"
+        );
+        assert_eq!(
+            descendant_score, "500",
+            "fast descendant {descendant_pid} must carry oom_score_adj=500"
         );
 
         // The op leaf is a real child of the resolved service cgroup.
         assert!(
             service_dir
-                .join(child_unified.rsplit('/').next().expect("op leaf name"))
+                .join(shell_unified.rsplit('/').next().expect("op leaf name"))
                 .exists(),
-            "the op leaf {child_unified} should exist under {}",
+            "the op leaf {shell_unified} should exist under {}",
             service_dir.display()
         );
     }
 
-    /// Waits for the child fixture to publish its PID (bounded), then parses it.
-    async fn read_child_pid(pid_file: &Path) -> u32 {
+    /// Waits for the shell fixture to publish both PIDs (bounded), then parses them.
+    async fn read_fixture_pids(pid_file: &Path) -> (u32, u32) {
         for _ in 0..200 {
             if let Ok(raw) = tokio::fs::read_to_string(pid_file).await {
-                if let Ok(pid) = raw.trim().parse::<u32>() {
-                    return pid;
+                let mut parts = raw.split_whitespace();
+                if let (Some(shell), Some(descendant), None) =
+                    (parts.next(), parts.next(), parts.next())
+                {
+                    if let (Ok(shell), Ok(descendant)) =
+                        (shell.parse::<u32>(), descendant.parse::<u32>())
+                    {
+                        return (shell, descendant);
+                    }
                 }
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         panic!(
-            "child fixture never published its PID to {}",
+            "child fixture never published both PIDs to {}",
             pid_file.display()
         );
     }

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -152,9 +152,11 @@ sit above normal workloads (including 100 concurrent command requests). Linux
 puts the supervisor and each operation in separate cgroup-v2 leaves for fate
 isolation and accounting. The generated systemd unit enables accounting without
 a parent `MemoryHigh`, and the default operation leaf has no memory maximum or
-throttle. At spawn, the agent briefly stops the command's process group, moves
-the command, its already-forked ordinary descendants, and the group anchor into
-one operation leaf, then resumes it. This closes the post-spawn fork race.
+throttle. At spawn, the agent stops the command's process group, moves its direct
+roots, then repeatedly drains any same-group descendants still inherited in the
+supervisor leaf into the same operation leaf before resuming it. Correctness does
+not depend on synchronous stop-signal delivery: after a parent moves, future
+children inherit its operation leaf. This closes the post-spawn fork race.
 Commands therefore have the same machine resources and authority as commands
 launched by an unrestricted local agent; the OS scheduler owns contention,
 while a pathological breaker trip is loud and typed.

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -156,7 +156,10 @@ throttle. At spawn, the agent stops the command's process group, moves its direc
 roots, then repeatedly drains any same-group descendants still inherited in the
 supervisor leaf into the same operation leaf before resuming it. Correctness does
 not depend on synchronous stop-signal delivery: after a parent moves, future
-children inherit its operation leaf. This closes the post-spawn fork race.
+children inherit its operation leaf. This closes the post-spawn fork race. A
+same-group fork storm that keeps creating escaped descendants during this tiny
+pre-containment window is terminated only after crossing a PID breaker derived
+from that machine's process ceiling; it cannot wedge command admission forever.
 Commands therefore have the same machine resources and authority as commands
 launched by an unrestricted local agent; the OS scheduler owns contention,
 while a pathological breaker trip is loud and typed.

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -152,9 +152,12 @@ sit above normal workloads (including 100 concurrent command requests). Linux
 puts the supervisor and each operation in separate cgroup-v2 leaves for fate
 isolation and accounting. The generated systemd unit enables accounting without
 a parent `MemoryHigh`, and the default operation leaf has no memory maximum or
-throttle. Commands therefore have the same machine resources and authority as
-commands launched by an unrestricted local agent; the OS scheduler owns
-contention, while a pathological breaker trip is loud and typed.
+throttle. At spawn, the agent briefly stops the command's process group, moves
+the command, its already-forked ordinary descendants, and the group anchor into
+one operation leaf, then resumes it. This closes the post-spawn fork race.
+Commands therefore have the same machine resources and authority as commands
+launched by an unrestricted local agent; the OS scheduler owns contention,
+while a pathological breaker trip is loud and typed.
 
 Operators can opt into local per-operation limits with
 `OPENGENI_AGENT_OP_MEMORY_MAX` and `OPENGENI_AGENT_OP_MEMORY_HIGH`; unset is the


### PR DESCRIPTION
## What changed

- stop each newly spawned Unix exec process group before cgroup placement
- move the direct command and PGID anchor first, then drain same-group descendants still inherited in the supervisor leaf
- make correctness independent of asynchronous `SIGSTOP` delivery through cgroup inheritance
- terminate only a pre-containment fork storm that crosses a host-PID-derived pathology breaker
- keep normal commands unlimited in duration and memory by default

## Why

Live inspection on jorgebot showed a fast shell descendant could fork before post-spawn placement and remain billed to the agent supervisor cgroup. That defeated the intended OOM fate isolation.

## Verification

- macOS default-feature strict clippy + platform tests: 55 passed, 3 ignored; integration Linux-only skip passed
- jorgebot Linux strict clippy + platform tests: 67 passed, 3 ignored; integration test passed
- explicit delegated cgroup-v2 scope on jorgebot: supervisor in `supervisor`; shell and immediate descendant both in `op-0`; both `oom_score_adj=500`
- structured autoreview against `origin/main`: clean, patch correct

No control-plane image, schema, timeout default, service-wide memory limit, or Codex Apps/Linear authority changes.