### PR TITLE
fix(react): retain SessionChrome token defaults

### DIFF
--- a/.changeset/calm-session-chrome-tokens.md
+++ b/.changeset/calm-session-chrome-tokens.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Keep derived design tokens available through both the compiled stylesheet and the Tailwind source bridge so SessionChrome retains its complete default presentation in every supported integration path.

--- a/packages/react/scripts/build-compiled-css.ts
+++ b/packages/react/scripts/build-compiled-css.ts
@@ -16,7 +16,6 @@ const checkOnly = process.argv.includes("--check");
 const input = `@import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities) source(none);
 @import "./index.css";
-@import "./effective-tokens.css";
 @import "./responsive.css";
 @source "../src";
 `;

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -4609,6 +4609,55 @@
   color-scheme: light;
   --_og-color-scheme: light;
 }
+:where(.og-root),:where( [data-og-density="compact"]):where(.og-root),:where( [data-og-density="compact"]):has(:where(.og-root)),:where(.og-root) :where( [data-og-density="compact"]),:where( .og-density-compact):where(.og-root),:where( .og-density-compact):has(:where(.og-root)),:where(.og-root) :where( .og-density-compact),:where( [data-og-theme="light"]):where(.og-root),:where( [data-og-theme="light"]):has(:where(.og-root)),:where(.og-root) :where( [data-og-theme="light"]),:where( .og-light):where(.og-root),:where( .og-light):has(:where(.og-root)),:where(.og-root) :where( .og-light) {
+  --_og-duration-fast: var(--og-duration-fast, calc(120ms * var(--og-motion-inspect-scale)));
+  --_og-duration-base: var(--og-duration-base, calc(180ms * var(--og-motion-inspect-scale)));
+  --_og-duration-slow: var(--og-duration-slow, calc(320ms * var(--og-motion-inspect-scale)));
+  --_og-duration-disclose: var(--og-duration-disclose, calc(120ms * var(--og-motion-inspect-scale)));
+  --_og-duration-disclose-settle: var(--og-duration-disclose-settle, calc(820ms * var(--og-motion-inspect-scale)));
+  --_og-duration-stream: var(--og-duration-stream, calc(420ms * var(--og-motion-inspect-scale)));
+  --_og-duration-markdown-crystallize: var(--og-duration-markdown-crystallize, calc(480ms * var(--og-motion-inspect-scale)));
+  --_og-color-accent-soft: var(--og-color-accent-soft, var(--og-color-accent));
+  @supports (color: color-mix(in lab, red, red)) {
+    --_og-color-accent-soft: var(--og-color-accent-soft, color-mix(in oklch, var(--og-color-accent) 16%, transparent));
+  }
+  --_og-color-diff-add-bg: var(--og-color-diff-add-bg, var(--og-color-status-idle));
+  @supports (color: color-mix(in lab, red, red)) {
+    --_og-color-diff-add-bg: var(--og-color-diff-add-bg, color-mix(in oklch, var(--og-color-status-idle) 14%, transparent));
+  }
+  --_og-color-diff-del-bg: var(--og-color-diff-del-bg, var(--og-color-status-failed));
+  @supports (color: color-mix(in lab, red, red)) {
+    --_og-color-diff-del-bg: var(--og-color-diff-del-bg, color-mix(in oklch, var(--og-color-status-failed) 14%, transparent));
+  }
+  --_og-shadow-glow: var(--og-shadow-glow, 0 0 24px var(--og-color-accent));
+  @supports (color: color-mix(in lab, red, red)) {
+    --_og-shadow-glow: var(--og-shadow-glow, 0 0 24px color-mix(in oklch, var(--og-color-accent) 18%, transparent));
+  }
+  --_og-session-chrome-surface: var(--og-session-chrome-surface, var(--og-color-surface-2));
+  @supports (color: color-mix(in lab, red, red)) {
+    --_og-session-chrome-surface: var(--og-session-chrome-surface, color-mix(in oklch, var(--og-color-surface-2) 82%, transparent));
+  }
+  --_og-session-chrome-surface-open: var(--og-session-chrome-surface-open, var(--og-color-surface-2));
+  @supports (color: color-mix(in lab, red, red)) {
+    --_og-session-chrome-surface-open: var(--og-session-chrome-surface-open, color-mix(in oklch, var(--og-color-surface-2) 92%, transparent));
+  }
+  --_og-session-chrome-border: var(--og-session-chrome-border, var(--og-color-border));
+  @supports (color: color-mix(in lab, red, red)) {
+    --_og-session-chrome-border: var(--og-session-chrome-border, color-mix(in oklch, var(--og-color-border) 85%, transparent));
+  }
+  --_og-session-chrome-border-open: var(--og-session-chrome-border-open, var(--og-color-border));
+  --_og-session-chrome-highlight: var(--og-session-chrome-highlight, var(--og-color-surface-3));
+  --_og-session-chrome-highlight-ring: var(--og-session-chrome-highlight-ring, var(--og-color-fg));
+  @supports (color: color-mix(in lab, red, red)) {
+    --_og-session-chrome-highlight-ring: var(--og-session-chrome-highlight-ring, color-mix(in oklch, var(--og-color-fg) 16%, transparent));
+  }
+  --_og-session-chrome-radius: var(--og-session-chrome-radius, var(--og-radius-lg));
+  --_og-session-chrome-ease: var(--og-session-chrome-ease, var(--og-ease-out));
+  --_og-session-chrome-row-hover: var(--og-session-chrome-row-hover, var(--og-color-surface-3));
+  @supports (color: color-mix(in lab, red, red)) {
+    --_og-session-chrome-row-hover: var(--og-session-chrome-row-hover, color-mix(in oklch, var(--og-color-surface-3) 55%, transparent));
+  }
+}
 @keyframes og-expand {
   from {
     height: 0;
@@ -4828,55 +4877,6 @@
   visibility: hidden !important;
   pointer-events: none !important;
   z-index: -1 !important;
-}
-:where(.og-root),:where( [data-og-density="compact"]):where(.og-root),:where( [data-og-density="compact"]):has(:where(.og-root)),:where(.og-root) :where( [data-og-density="compact"]),:where( .og-density-compact):where(.og-root),:where( .og-density-compact):has(:where(.og-root)),:where(.og-root) :where( .og-density-compact),:where( [data-og-theme="light"]):where(.og-root),:where( [data-og-theme="light"]):has(:where(.og-root)),:where(.og-root) :where( [data-og-theme="light"]),:where( .og-light):where(.og-root),:where( .og-light):has(:where(.og-root)),:where(.og-root) :where( .og-light) {
-  --_og-duration-fast: var(--og-duration-fast, calc(120ms * var(--og-motion-inspect-scale)));
-  --_og-duration-base: var(--og-duration-base, calc(180ms * var(--og-motion-inspect-scale)));
-  --_og-duration-slow: var(--og-duration-slow, calc(320ms * var(--og-motion-inspect-scale)));
-  --_og-duration-disclose: var(--og-duration-disclose, calc(120ms * var(--og-motion-inspect-scale)));
-  --_og-duration-disclose-settle: var(--og-duration-disclose-settle, calc(820ms * var(--og-motion-inspect-scale)));
-  --_og-duration-stream: var(--og-duration-stream, calc(420ms * var(--og-motion-inspect-scale)));
-  --_og-duration-markdown-crystallize: var(--og-duration-markdown-crystallize, calc(480ms * var(--og-motion-inspect-scale)));
-  --_og-color-accent-soft: var(--og-color-accent-soft, var(--og-color-accent));
-  @supports (color: color-mix(in lab, red, red)) {
-    --_og-color-accent-soft: var(--og-color-accent-soft, color-mix(in oklch, var(--og-color-accent) 16%, transparent));
-  }
-  --_og-color-diff-add-bg: var(--og-color-diff-add-bg, var(--og-color-status-idle));
-  @supports (color: color-mix(in lab, red, red)) {
-    --_og-color-diff-add-bg: var(--og-color-diff-add-bg, color-mix(in oklch, var(--og-color-status-idle) 14%, transparent));
-  }
-  --_og-color-diff-del-bg: var(--og-color-diff-del-bg, var(--og-color-status-failed));
-  @supports (color: color-mix(in lab, red, red)) {
-    --_og-color-diff-del-bg: var(--og-color-diff-del-bg, color-mix(in oklch, var(--og-color-status-failed) 14%, transparent));
-  }
-  --_og-shadow-glow: var(--og-shadow-glow, 0 0 24px var(--og-color-accent));
-  @supports (color: color-mix(in lab, red, red)) {
-    --_og-shadow-glow: var(--og-shadow-glow, 0 0 24px color-mix(in oklch, var(--og-color-accent) 18%, transparent));
-  }
-  --_og-session-chrome-surface: var(--og-session-chrome-surface, var(--og-color-surface-2));
-  @supports (color: color-mix(in lab, red, red)) {
-    --_og-session-chrome-surface: var(--og-session-chrome-surface, color-mix(in oklch, var(--og-color-surface-2) 82%, transparent));
-  }
-  --_og-session-chrome-surface-open: var(--og-session-chrome-surface-open, var(--og-color-surface-2));
-  @supports (color: color-mix(in lab, red, red)) {
-    --_og-session-chrome-surface-open: var(--og-session-chrome-surface-open, color-mix(in oklch, var(--og-color-surface-2) 92%, transparent));
-  }
-  --_og-session-chrome-border: var(--og-session-chrome-border, var(--og-color-border));
-  @supports (color: color-mix(in lab, red, red)) {
-    --_og-session-chrome-border: var(--og-session-chrome-border, color-mix(in oklch, var(--og-color-border) 85%, transparent));
-  }
-  --_og-session-chrome-border-open: var(--og-session-chrome-border-open, var(--og-color-border));
-  --_og-session-chrome-highlight: var(--og-session-chrome-highlight, var(--og-color-surface-3));
-  --_og-session-chrome-highlight-ring: var(--og-session-chrome-highlight-ring, var(--og-color-fg));
-  @supports (color: color-mix(in lab, red, red)) {
-    --_og-session-chrome-highlight-ring: var(--og-session-chrome-highlight-ring, color-mix(in oklch, var(--og-color-fg) 16%, transparent));
-  }
-  --_og-session-chrome-radius: var(--og-session-chrome-radius, var(--og-radius-lg));
-  --_og-session-chrome-ease: var(--og-session-chrome-ease, var(--og-ease-out));
-  --_og-session-chrome-row-hover: var(--og-session-chrome-row-hover, var(--og-color-surface-3));
-  @supports (color: color-mix(in lab, red, red)) {
-    --_og-session-chrome-row-hover: var(--og-session-chrome-row-hover, color-mix(in oklch, var(--og-color-surface-3) 55%, transparent));
-  }
 }
 :where(.og-root).og-composer[data-og-responsive-basis="container"],:where(.og-root) .og-composer[data-og-responsive-basis="container"] {
   container: og-composer / inline-size;

--- a/packages/react/styles/index.css
+++ b/packages/react/styles/index.css
@@ -15,6 +15,7 @@
    -------------------------------------------------------------------------- */
 
 @import "./tokens.css";
+@import "./effective-tokens.css";
 
 @theme inline {
   --font-og-sans: var(--og-font-sans);

--- a/packages/react/test/compiled-css.test.ts
+++ b/packages/react/test/compiled-css.test.ts
@@ -14,6 +14,7 @@ const packageRoot = join(import.meta.dir, "..");
 const compiledPath = join(packageRoot, "styles/compiled.css");
 const compiled = await readFile(compiledPath, "utf8");
 const effectiveTokens = await readFile(join(packageRoot, "styles/effective-tokens.css"), "utf8");
+const sourceBridge = await readFile(join(packageRoot, "styles/index.css"), "utf8");
 const parsed = parse(compiled);
 
 function classesIn(node: { walkClasses(callback: (className: { value: string }) => void): void }) {
@@ -118,6 +119,10 @@ function tokenRegistration(property: string) {
 }
 
 describe("compiled CSS contract", () => {
+  test("ships effective derived tokens through the Tailwind source bridge", () => {
+    expect(sourceBridge).toContain('@import "./tokens.css";\n@import "./effective-tokens.css";');
+  });
+
   test("is deterministic, directive-free, scoped, and bounded", async () => {
     expect(await buildCompiledCss()).toBe(compiled);
     expect(await buildEffectiveTokensCss()).toBe(effectiveTokens);

--- a/scripts/test-publish-consumer.ts
+++ b/scripts/test-publish-consumer.ts
@@ -302,7 +302,7 @@ try {
     writeFile(
       join(consumerRoot, "presentation.tsx"),
       [
-        'import { ApprovalSurface, HumanInputForm, MessageTimeline, QueueSurface, createDefaultToolRegistry, type QueueSurfaceProps, type ToolRendererProps, type UseTurnQueueResult } from "@opengeni/react";',
+        'import { ApprovalSurface, HumanInputForm, MessageTimeline, QueueSurface, SessionChrome, createDefaultToolRegistry, type QueueSurfaceProps, type ToolRendererProps, type UseTurnQueueResult } from "@opengeni/react";',
         'import * as Composer from "@opengeni/react/composer";',
         'import { useMemo, useRef, useState } from "react";',
         "",
@@ -363,6 +363,7 @@ try {
         "",
         "  return (",
         "    <section>",
+        '      <SessionChrome queue={queueState} agentsSignal={{ count: 2, detail: "1 running" }} readOnly />',
         '      <MessageTimeline items={[{ kind: "tool-call", id: "tool-proof", turnId: "turn-proof", callId: "call-proof", name: "host.entity", arguments: { entityId: "entity-proof" }, output: { updated: true }, raw: null, status: "complete", occurredAt: "2026-07-23T00:00:00.000Z" }]} toolRegistry={toolRegistry} />',
         "      <QueueSurface queue={queueState} readOnly onRequestComposerFocus={requestComposerFocus} />",
         "      <ApprovalSurface",
@@ -398,7 +399,7 @@ try {
     ),
     writeFile(
       join(consumerRoot, "ssr.tsx"),
-      'import { renderToStaticMarkup } from "react-dom/server";\nimport { HostEmbeddedSurfaces } from "./presentation";\nconst markup = renderToStaticMarkup(<HostEmbeddedSurfaces />);\nfor (const expected of ["Open host entity", "Loading inputs…", "entity-proof", "What should change?", "Host model"]) { if (!markup.includes(expected)) throw new Error(`SSR output lost populated host surface: ${expected}`); }\nconsole.log(`SSR_OK bytes=${new TextEncoder().encode(markup).byteLength}`);\n',
+      'import { renderToStaticMarkup } from "react-dom/server";\nimport { HostEmbeddedSurfaces } from "./presentation";\nconst markup = renderToStaticMarkup(<HostEmbeddedSurfaces />);\nfor (const expected of ["2 agents", "1 running", "Open host entity", "Loading inputs…", "entity-proof", "What should change?", "Host model"]) { if (!markup.includes(expected)) throw new Error(`SSR output lost populated host surface: ${expected}`); }\nconsole.log(`SSR_OK bytes=${new TextEncoder().encode(markup).byteLength}`);\n',
     ),
     writeFile(
       join(consumerRoot, "runtime-proof.ts"),


### PR DESCRIPTION
## Summary
- make the Tailwind source bridge import the same derived fallback-token layer used by compiled CSS
- compile from that canonical bridge instead of maintaining a second token import path
- cover SessionChrome in the release-shaped external-consumer proof

## Why
SessionChrome consumes derived fallback tokens. The compiled stylesheet included those tokens, while the Tailwind source bridge did not, so source-integrated consumers could lose the component defaults even though the compiled path remained correct.

## Validation
- React typecheck
- focused compiled-CSS and SessionChrome tests
- generated CSS freshness check
- repository formatting check
- release-shaped packed-consumer proof, including strict types, SSR, session-only and realtime-only bundles, compiler-free scoped CSS, and packed artifacts
- visual verification at narrow and wide widths for both source-bridge and compiled-CSS paths

The web production bundle remains at the exact current-main size and hits the existing bundle-budget baseline failure; this patch does not change JavaScript output or weaken that gate.