### PR TITLE
docs: clarify customer integration paths

### DIFF
--- a/.agents/skills/opengeni-client/SKILL.md
+++ b/.agents/skills/opengeni-client/SKILL.md
@@ -1,52 +1,120 @@
 ---
 name: opengeni-client
 audience: integration-agent
-description: Use when integrating a customer product, coding agent, generic automation agent, CLI, SDK, or backend service with the OpenGeni API. Covers managed API-key auth, configured/self-host bearer auth, workspace discovery, workspace-scoped sessions, choosing a session's compute target (a managed sandbox or an enrolled Connected Machine), machine enrollment (device-flow consent + headless enroll tokens), SSE/event replay, files, documents/search, schedules, GitHub repository resources, billing/limits handling, safe retries, and keeping client guidance aligned with the live OpenGeni service rather than stale docs.
+description: >-
+  Use when an external product, coding agent, CLI, backend, or automation uses a
+  standalone OpenGeni deployment through @opengeni/sdk or @opengeni/react.
+  Covers choosing between a stock-UI handoff, a headless product integration,
+  embedded React session surfaces, or the optional workbench; tenant-safe proxy
+  boundaries; workspace/session/turn instructions; events, uploads, tools,
+  realtime, compute targets, and schedules. Not for editing OpenGeni internals
+  or mounting the OpenGeni runtime in the customer's process.
 ---
 
 # OpenGeni Client
 
-This skill is for integration agents building customer products, CLIs, SDK wrappers, or automations against an OpenGeni API service.
+Use this skill when a customer's product and OpenGeni remain separate systems.
+That is the normal integration shape: the product owns its users and business
+UI, while a standalone OpenGeni deployment owns agent sessions and execution.
 
-Use this skill to help a customer-side agent or product consume OpenGeni as an API service. It is for client integration, not for editing OpenGeni internals.
+Do not interpret "embed" as "move OpenGeni into the product process." Advanced
+in-process router/core embedding is a separate infrastructure choice. Route that
+work to the repo-maintainer `opengeni` skill and `docs/embedding.md`.
 
-Code and live service behavior are the source of truth. Prefer `/v1/config/client`, `/v1/access/me`, contracts/OpenAPI when available, and live HTTP probes over memorized route lists. If the OpenGeni repo is available and exactness matters, inspect `packages/contracts/src/index.ts`, `apps/api/src/routes/`, and `apps/web/src/api.ts`.
+Do not confuse two meanings of "skill": this file teaches a customer's coding
+agent how to integrate OpenGeni; session `skills` are runtime capabilities or
+instructions attached to an OpenGeni agent. The former designs the integration.
+The latter is product data sent through the installed SDK contract.
 
-## Core Model
+Code and the live service are authoritative. Prefer `/v1/config/client`,
+`/v1/access/me`, the installed package types, and live probes over memorized
+route, model, tool, or backend lists. When source is available, verify exact
+behavior in `packages/sdk`, `packages/react`, contracts, and API routes.
 
-- Managed SaaS browser users sign up with email/password, then create OpenGeni product API keys.
-- Product API keys and configured/delegated tokens use `Authorization: Bearer <token>`.
-- The optional deployment shared key uses `x-opengeni-access-key` and is only an operator/edge boundary.
-- Workspace-scoped routes are canonical: `/v1/workspaces/:workspaceId/...`.
-- Old unscoped operational routes are intentionally removed, not soft-deprecated.
-- Resource ids never authorize by themselves; use the URL workspace plus credential grant.
-- Sessions and scheduled tasks are the current run primitives. Do not assume a first-class agent-definition API exists until the live service exposes one.
-- Every session picks a compute target at creation. Two co-equal kinds: a **Managed Sandbox** (a platform-owned ephemeral box, selected via the `sandboxBackend` enum and the `sandbox` placement union) or a **Connected Machine** (a user-owned machine enrolled into the workspace, addressed by `targetSandboxId` plus an optional per-session `workingDir`).
-- A Connected Machine is first-class *primary* compute, not a backend overlay: there is no phantom cloud box behind it, no OpenGeni credential is distributed to it (it uses its own git auth), repos are not cloned onto it, and the session runs directly under the chosen `workingDir` on the machine. `selfhosted` is the internal `sandboxBackend` enum value for such a machine — prefer the product term "Connected Machine" in client-facing copy.
-- Enrolling a machine is a client capability: an interactive device flow with a loud whole-machine consent step, or a headless enroll token for fleet/non-interactive enrollment. Gated by `enrollments:read` (list a workspace's machines) and `enrollments:manage` (approve/mint/revoke); `workspace:admin` is the super-wildcard over both.
+## Choose The Integration Shape First
 
-## Integration Workflow
+Pick the smallest surface that satisfies the product:
 
-1. Determine the API base URL and credential type.
-2. Fetch `/v1/config/client` to learn auth mode, model options, MCP providers, and upload capability.
-3. Call `/v1/access/me`; use `defaultWorkspaceId` or list/create workspaces if permissions allow.
-4. Create sessions under `/v1/workspaces/:workspaceId/sessions`, choosing the compute target: omit the sandbox fields for a managed sandbox (optionally pin `sandboxBackend` or the `sandbox` placement union), or set `targetSandboxId` (plus an optional `workingDir`) to run the session on an enrolled Connected Machine.
-5. Stream events from `/v1/workspaces/:workspaceId/sessions/:sessionId/events/stream` and replay from the event list after reconnects.
-6. Upload files through the workspace file upload flow before attaching file resources.
-7. Select MCP tools by configured id, such as OpenGeni, Files, or Document Search.
-8. Use workspace GitHub repository listings before attaching private GitHub App repositories.
-9. For Connected Machines: list a workspace's machines (and their metrics) before targeting one, swap a session's active machine after create when needed, and enroll new machines through the device-flow (with consent) or a headless enroll token.
-10. For recurring work, create scheduled tasks under the workspace and inspect run history.
-11. Treat 401/403/404/402/429 as product signals: re-authenticate, switch workspace, stop on missing permissions, top up credits, or back off.
+1. **Stock OpenGeni handoff** — link or deep-link into the OpenGeni web app.
+   The product keeps no agent UI.
+2. **Headless product integration (default)** — the product backend uses
+   `@opengeni/sdk`; the product renders its own UI and exposes tenant-scoped,
+   same-origin routes to its browser or mobile client.
+3. **React session integration** — compose `@opengeni/react/session` hooks and
+   pure projections into the product's UI. Add styled subpaths only for the
+   surfaces the product wants.
+4. **OpenGeni-rendered React experience** — mount the packaged composer,
+   timeline, realtime, or session chrome and import
+   `@opengeni/react/compiled.css` once. No Tailwind setup or source scan is
+   required. Override `--og-*` tokens only when branding is wanted.
+5. **Workbench integration** — mount the optional Changes/Files/Terminal/Desktop
+   workspace when the product genuinely exposes agent compute. It has optional
+   heavy peers and is not required for ordinary chat/session integration.
 
-If you build a React client with `@opengeni/react`, the root entrypoint is the clean sandbox-only default. The Connected-Machine UI — the machines dashboard, the enrollment device-flow/consent screens, and the machine status pills — lives under the `@opengeni/react/machines` subpath (the root still re-exports it for back-compat, deprecated per #144). Separately, the root-exported sandbox-surfacing components (`WorkspaceDock`, `SandboxTerminal`, `FileBrowser`, `DiffView`, `DesktopViewer`) pull heavy client deps (`@xterm/*`, `@novnc/novnc`, `@pierre/diffs`, `@uiw/react-codemirror`, `@codemirror/lang-*`) as optional peer dependencies you install only for the surfaces you mount.
+Read `references/product-integration-shapes.md` before designing the boundary.
+Read `references/api-workflows.md` for session, upload, retry, repository,
+machine, and schedule patterns.
 
-Read `references/api-workflows.md` for request shapes, retry guidance, and common client patterns.
+## Default Trust Boundary
+
+- Keep OpenGeni API keys and operator credentials on the product server.
+- Authenticate the product's user first, resolve their allowed OpenGeni
+  workspace/session server-side, and expose only the routes that product needs.
+- Use `@opengeni/sdk` instead of reconstructing event streaming, upload signing,
+  retries, or wire types by hand.
+- Use `proxySessionEventStream` for a same-origin browser SSE route. Structural
+  React client types let a host implement only the methods its mounted hooks use.
+- Direct browser access is valid only when the deployment's normal browser auth
+  or an explicitly accepted bearer/CORS design makes it safe. Never ship a
+  privileged shared API key in a browser bundle.
+
+The product owns external identity, tenant-to-workspace mapping, business
+entities, navigation, presentation, and product-specific admission. OpenGeni
+owns sessions, turns, durable event history, approvals, agent execution,
+selected tools/resources, files, realtime session state, and compute lifecycle.
+Link records by opaque IDs; do not copy one system's whole data model into the
+other.
+
+## Prompt And Context Contract
+
+Keep visible user text separate from system-level agent context:
+
+- Workspace `agentInstructions`: stable workspace-wide persona and behavior.
+- Session `instructions`: durable agent-type refinement for one session.
+- Turn `turnInstructions`: one exact submit-time context snapshot, such as the
+  current product route, selected entity, or viewport state.
+- `initialMessage` and later message text: user-visible timeline content.
+
+Do not hide business facts in a prompt when the agent should inspect them with
+an authorized product MCP tool. Prefer concise turn context plus canonical tool
+access. Never put secrets in any instruction scope.
+
+## Client Workflow
+
+1. Resolve API base URL, credential mode, and product user-to-workspace mapping.
+2. Read client config and access context.
+3. Create a session with a stable idempotency key; optionally preallocate its ID
+   when the product must persist a link before the first turn can run.
+4. Attach only canonical resources, skills, and tool selections the user may use.
+5. Stream/replay session events through the SDK; tolerate unknown additive event
+   types.
+6. Send visible text separately from `turnInstructions`.
+7. Use the SDK upload helper; it owns begin, signed storage PUT, and completion.
+8. Surface approvals, human-input requests, queue state, errors, credit limits,
+   and reconnect state as product state rather than generic chat text.
+9. Add realtime, Connected Machines, schedules, or the workbench only when the
+   product use case needs them.
 
 ## Guardrails
 
-- Never put raw OpenGeni API keys, deployment shared keys, Stripe secrets, GitHub App secrets, cookies, or customer data into generated skills, docs, examples, or logs.
-- Keep client examples generic and parameterized: `OPENGENI_API_BASE_URL`, `OPENGENI_API_KEY`, and `OPENGENI_WORKSPACE_ID`.
-- Do not tell customer agents to call Temporal, NATS, Postgres, the worker, or the sandbox directly.
-- Do not claim RLS, billing, GitHub, model, or sandbox behavior unless the deployed service or current source proves it.
-- When behavior is ambiguous, write a small HTTP probe or inspect live responses instead of guessing.
+- Workspace-scoped routes are canonical; resource IDs never authorize by
+  themselves.
+- Do not call Temporal, NATS, Postgres, workers, sandbox providers, object
+  storage APIs, or MCP transports as substitutes for the public SDK/API.
+- Do not claim auth, model, tool, billing, CORS, storage, or compute behavior
+  until the live deployment or current source proves it.
+- Keep examples generic and parameterized. Skills may name non-secret origins
+  and conventions, but credentials come from a secret manager or environment.
+- Generate a customer-specific skill only for stable facts their coding agents
+  repeatedly need. Keep it beside their integration code, point it at the SDK,
+  include a config/access smoke probe, and never paste secrets into it.

--- a/.agents/skills/opengeni-client/references/api-workflows.md
+++ b/.agents/skills/opengeni-client/references/api-workflows.md
@@ -12,37 +12,36 @@ Use one of these product credentials:
 
 Only add `x-opengeni-access-key` when the operator says the deployment shared-key boundary is enabled. It is not a replacement for product API keys in managed SaaS.
 
-## Minimal Session Client
+## Minimal Server-Side Session Client
 
 ```ts
-const baseUrl = process.env.OPENGENI_API_BASE_URL!;
-const apiKey = process.env.OPENGENI_API_KEY!;
+import { OpenGeniClient } from "@opengeni/sdk";
 
-const headers = {
-  authorization: `Bearer ${apiKey}`,
-  "content-type": "application/json",
-};
-
-const access = await fetch(`${baseUrl}/v1/access/me`, { headers }).then((r) => r.json());
-const workspaceId = process.env.OPENGENI_WORKSPACE_ID ?? access.defaultWorkspaceId;
-
-const created = await fetch(`${baseUrl}/v1/workspaces/${workspaceId}/sessions`, {
-  method: "POST",
-  headers,
-  body: JSON.stringify({
-    initialMessage: "Inspect the uploaded logs and summarize the failing deploy step.",
-    tools: [{ kind: "mcp", id: "opengeni" }],
-  }),
-}).then((r) => r.json());
-
-const events = new EventSource(`${baseUrl}/v1/workspaces/${workspaceId}/sessions/${created.id}/events/stream`);
-events.addEventListener("agent.message.delta", (event) => {
-  const payload = JSON.parse(event.data);
-  process.stdout.write(payload.text ?? "");
+const client = new OpenGeniClient({
+  baseUrl: process.env.OPENGENI_API_BASE_URL!,
+  apiKey: process.env.OPENGENI_API_KEY!,
 });
+
+const access = await client.getAccessContext();
+const workspaceId = process.env.OPENGENI_WORKSPACE_ID ?? access.defaultWorkspaceId;
+if (!workspaceId) throw new Error("No OpenGeni workspace is available");
+
+const created = await client.createSession(workspaceId, {
+  initialMessage: "Inspect the uploaded logs and summarize the failing deploy step.",
+  idempotencyKey: crypto.randomUUID(),
+});
+
+for await (const event of client.streamEvents(workspaceId, created.id)) {
+  if (event.type === "agent.message.delta") {
+    process.stdout.write((event.payload as { text?: string }).text ?? "");
+  }
+}
 ```
 
-If the runtime cannot attach `Authorization` headers to `EventSource`, use `fetch` streaming or a server-side proxy that injects the credential.
+This code belongs on the product server, not in a browser bundle. For a browser
+timeline, expose a tenant-scoped same-origin route and use the SDK's
+`proxySessionEventStream` helper. Authenticate the product user and resolve the
+allowed workspace/session before opening the upstream stream.
 
 ## Session Creation Options
 
@@ -120,4 +119,7 @@ When generating a customer-specific agent skill that teaches their coding agents
 - Include only their non-secret base URL, workspace naming convention, and safe API examples.
 - Tell the agent to read API keys from the customer's secret manager or environment, never from the skill.
 - Keep the skill versioned with their integration code and add a quick smoke command that calls `/v1/config/client` and `/v1/access/me`.
-- Note that session/schedule APIs exist today; first-class agent-definition APIs are roadmap until the live service exposes them.
+- State which integration shape the product chose and where its tenant-safe
+  proxy/client lives; do not teach every possible shape in every customer skill.
+- Describe only primitives proven by the installed SDK and live deployment; do
+  not turn roadmap assumptions into customer instructions.

--- a/.agents/skills/opengeni-client/references/product-integration-shapes.md
+++ b/.agents/skills/opengeni-client/references/product-integration-shapes.md
@@ -1,0 +1,175 @@
+# Product Integration Shapes
+
+This reference helps a customer-side agent decide how a product should use a
+standalone OpenGeni deployment. It is intentionally architecture-level. Verify
+exact methods and props against the installed `@opengeni/sdk` and
+`@opengeni/react` versions.
+
+## The Common Architecture
+
+```text
+customer browser / mobile app
+            |
+            | customer session, same-origin product API
+            v
+customer backend / tenant boundary
+            |
+            | @opengeni/sdk, server-held OpenGeni credential
+            v
+standalone OpenGeni API -> sessions, workers, tools, storage, compute
+```
+
+The customer does not need to embed OpenGeni's database, workers, router, event
+bus, or sandbox runtime. "Embedded agent" usually means the product presents an
+OpenGeni-backed agent in its own experience while OpenGeni remains a service.
+
+This integration skill belongs to the customer's development agent. Runtime
+skills selected in `CreateSessionRequest.skills` belong to the OpenGeni session
+it creates. Keep those layers separate: integration knowledge should not be
+copied into every runtime agent prompt, and runtime skills should not redefine
+the product's trust boundary.
+
+## Decision Matrix
+
+| Need | Recommended surface | Product renders | OpenGeni package |
+| --- | --- | --- | --- |
+| Send users to the complete stock experience | Link/deep-link | Product entry point only | None |
+| Custom UI in any framework, mobile, CLI, or automation | Headless SDK | Everything user-facing | `@opengeni/sdk` |
+| Custom React UI using canonical session behavior | Headless React session hooks | Product timeline/composer/layout | `@opengeni/react/session` |
+| Packaged OpenGeni chat/session controls | Styled React surfaces | Product shell and domain UI | `@opengeni/react/session-ui`, `/composer`, `/realtime` |
+| Agent workspace with files, changes, terminal, or desktop | Workbench | Product shell plus chosen tabs | `@opengeni/react` |
+| OpenGeni runtime inside the host process | Advanced in-process embedding | Host owns infrastructure seams | Repo-level packages; see `docs/embedding.md` |
+
+Start with the headless SDK. Add React surfaces rather than designing a larger
+boundary up front. The packages are composable; using one hook does not require
+mounting the stock OpenGeni application.
+
+## Server And Browser Responsibilities
+
+### Product server
+
+- Authenticates its own user and enforces its own tenant/business permissions.
+- Maps that principal to one allowed OpenGeni workspace and allowed sessions.
+- Holds OpenGeni API keys or delegated credentials.
+- Calls `OpenGeniClient` and returns product-shaped responses.
+- Re-streams session SSE with `proxySessionEventStream` when the browser needs a
+  live timeline.
+- Rejects caller-supplied workspace/session IDs that are not already authorized
+  by the product relationship.
+
+### Product browser
+
+- Talks to the product's same-origin routes or the deployment's normal browser
+  auth boundary.
+- May use the SDK with a custom `fetch`/same-origin base URL.
+- May mount React hooks/components against a structural proxy client.
+- Never receives a privileged OpenGeni API key just because it renders an agent.
+
+The browser may PUT file bytes directly to a short-lived signed object-storage
+URL returned by the SDK flow. That URL is scoped upload authority, not the
+OpenGeni API credential. The SDK omits ambient cookies and auth on the storage
+request. The deployment must configure storage CORS for intended browser
+origins when browser uploads are enabled.
+
+## UI Composition
+
+### Headless session semantics
+
+Use `@opengeni/react/session` when the product owns every visual decision but
+wants canonical event, queue, composer, goal, approval, human-input, and timeline
+behavior. The exported client contracts are structural and intentionally
+narrow. Implement the exact client refinement required by each mounted hook;
+do not stub billing, workspace administration, machines, or workbench methods.
+
+### Packaged visuals
+
+Use the styled subpaths for only the features the product wants:
+
+- `@opengeni/react/session-ui` for timeline/session chrome surfaces.
+- `@opengeni/react/composer` for the standard composer or its controller and
+  compound primitives.
+- `@opengeni/react/realtime` for realtime session controls.
+- `@opengeni/react/machines` for Connected Machine management.
+- the root package for the optional workspace/workbench graph.
+
+Import `@opengeni/react/compiled.css` once for the default styled experience.
+It is package-compiled, scoped under `.og-root`, and does not require the host to
+run Tailwind or scan package source. Theme and density are `--og-*` runtime
+tokens. Tailwind v4 hosts may deliberately compile the additive `styles.css`
+source bridge instead, but must use one styling path, not both.
+
+Responsive behavior should be container-based inside sidebars, drawers, and
+split panes. Prefer package density/responsive props over host CSS selectors
+that reach into SDK internals.
+
+## Context And Instructions
+
+The product should send four different kinds of information through their
+matching contracts:
+
+| Information | Contract | Lifetime | Visible in timeline |
+| --- | --- | --- | --- |
+| Stable workspace persona | workspace `agentInstructions` | every session in workspace | No |
+| Agent role/persona refinement | session `instructions` | one session | No, but session metadata is org-visible |
+| Current route/selection/viewport snapshot | `turnInstructions` | one accepted turn | No |
+| What the user said | message text / `initialMessage` | durable conversation | Yes |
+
+Use `requestedSessionId` plus a stable `idempotencyKey` when the product must
+persist its own link before the first OpenGeni turn can run. The ID is
+correlation, not authorization.
+
+Turn context is a snapshot, not a substitute for tools. If the agent needs
+current product state or must mutate product data, expose a tenant-scoped MCP
+server. Keep tool outputs machine-useful; the product may render a separate,
+more concise user-facing projection.
+
+## Ownership Of Product Data
+
+Keep customer domain records in the customer product. Give the agent authorized
+MCP tools to read or change them. Store only OpenGeni-native facts in OpenGeni:
+sessions, events, selected resources/tools/skills, files used by sessions,
+approvals, goals, schedules, and execution state.
+
+Do not duplicate the customer's project/contact/document model into OpenGeni
+only to make it available to the agent. Conversely, do not treat OpenGeni's
+event stream as the customer's domain audit log. Each system remains canonical
+for the state it owns.
+
+## Files And Artifacts
+
+- One-off user attachments use `OpenGeniClient.uploadFile`, then a file resource
+  on session create or message send.
+- Indexed reusable knowledge uses the document/knowledge APIs when enabled.
+- Product-domain documents may stay in the product and be exposed through the
+  product's MCP server when OpenGeni should not own a second copy.
+- Agent-produced durable product records should be written through product MCP
+  tools. Do not infer a generic write-back/artifact path that the live service
+  does not expose.
+
+## Realtime And Compute
+
+Realtime is an optional session transport, not a second agent. Use the public
+SDK/React realtime subpaths so negotiation, lifecycle, recovery, and durable
+session context stay server-owned.
+
+Managed Sandboxes and Connected Machines are compute choices for a session.
+They do not change the product integration boundary. A customer product should
+only expose machine selection/enrollment when its users need to run on their own
+computers; ordinary embedded agents should use the deployment default.
+
+## Delivery Checklist
+
+Before calling an integration complete, verify:
+
+1. Credentials never reach browser bundles, logs, prompts, or generated skills.
+2. Product authorization is checked before every workspace/session proxy call.
+3. Session creation retries reuse one idempotency key.
+4. SSE reconnect resumes by sequence and does not duplicate timeline effects.
+5. Unknown additive event types do not crash the client.
+6. File upload works from every intended browser origin, including signed PUT
+   CORS and completion.
+7. Prompt scopes are used correctly; visible text is not carrying hidden policy.
+8. MCP tools enforce the same tenant/user boundary as the product API.
+9. Narrow and wide layouts work without host CSS reaching into SDK internals.
+10. The integration pins compatible SDK/server major versions and checks the
+    live client config rather than hard-coding volatile catalogs.

--- a/.agents/skills/opengeni/SKILL.md
+++ b/.agents/skills/opengeni/SKILL.md
@@ -2,7 +2,12 @@
 name: opengeni
 audience: repo-maintainer-agent
 description: >-
-  Use when working in, operating, extending, integrating, documenting, or debugging OpenGeni: the session-based agent service with an API, durable event log, Temporal worker, sandboxed OpenAI Agents SDK runtime, file/object storage, MCP tools, scheduled tasks, and self-hosted local stack. Trigger this skill for questions about OpenGeni architecture, client-side API integration, sessions/events, worker orchestration, sandbox backends, file uploads, tools/MCP, scheduling, storage, GitHub integration, configuration, deployment, or how to keep agents using OpenGeni correctly as the repo evolves.
+  Use when editing, operating, extending, documenting, or debugging the OpenGeni
+  source repository or deployment: architecture, sessions/events, worker
+  orchestration, sandbox backends, files/storage, tools/MCP, scheduling,
+  configuration, and deployment. For a customer product that consumes a
+  standalone OpenGeni deployment through the SDK or React packages, use the
+  separate opengeni-client skill instead.
 ---
 
 # OpenGeni

--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ Pair this README with the [CloudGeni Infrastructure Agents Guide](https://github
 
 The capability catalog lets operators see and enable packs, MCP tools, APIs, skills, and plugins for the same runtime. See [docs/capabilities.md](docs/capabilities.md) for the unified catalog and [docs/packs.md](docs/packs.md) for the marketing social daily analysis pack.
 
+For product integration, keep OpenGeni as a standalone service by default. Start
+with the [TypeScript SDK](packages/sdk/README.md), add the
+[React surfaces](packages/react/README.md) the product needs, and use the
+[workbench guide](docs/embedding-workbench.md) only when exposing agent compute.
+The [`opengeni-client` skill](.agents/skills/opengeni-client/SKILL.md) gives
+customer-side coding agents the same decision path. The
+[in-process embedding guide](docs/embedding.md) is for advanced hosts that
+intentionally bind OpenGeni runtime infrastructure into their own process.
+
 ## Quick Start
 
 Prerequisites:

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,10 @@ This map defines who each doc tier serves and where volatile facts belong.
 
 | Audience | Reads | Notes |
 | --- | --- | --- |
-| Integrator | `README.md`, `docs/embedding.md`, `packages/sdk/README.md` | OSS self-hosters and embedding hosts building against OpenGeni. |
+| Integrator | `README.md`, `packages/sdk/README.md`, `packages/react/README.md`, `docs/embedding-workbench.md` | Products consuming a standalone OpenGeni deployment; `docs/embedding.md` is only for advanced in-process hosts. |
 | Maintainer | `CONTRIBUTING.md`, `docs/architecture.md`, topic docs | Contributors changing code, packages, workflows, or release mechanics. |
 | Repo agent | `AGENTS.md`, `.agents/skills/opengeni/SKILL.md`, this map | Coding agents working in this repository. |
+| Integration agent | `.agents/skills/opengeni-client/SKILL.md` and its references | Customer-side coding agents choosing and implementing a product integration shape. |
 | Product agent | Bundled skills in `packages/runtime/src/bundled_hashicorp_terraform_skills` and curated entries in `packages/runtime/src/bundled_skill_library` | Versioned product content; not covered by this freshness system. |
 | Operator | `docs/deployment.md`, deployment contracts and chart docs | People deploying and operating OpenGeni. |
 | Record | `docs/design/**` | Public-safe point-in-time architecture and product-design records; never raw operator evidence. |
@@ -18,14 +19,15 @@ This map defines who each doc tier serves and where volatile facts belong.
 | Topic | Current canonical home | Known restatement locations |
 | --- | --- | --- |
 | Architecture & package layout | `docs/architecture.md` | `README.md`, `AGENTS.md`, package READMEs should link or summarize lightly. |
-| Embedding & ports | `docs/embedding.md` | `README.md`, `CONTRIBUTING.md`, SDK/client examples should link. |
+| Standalone product integration | `packages/sdk/README.md`, `packages/react/README.md` | `docs/embedding-workbench.md` owns the optional workbench; `.agents/skills/opengeni-client/` owns agent guidance. |
+| Advanced in-process embedding & ports | `docs/embedding.md` | `README.md` and `CONTRIBUTING.md` should not present it as the default customer path. |
 | Run lifecycle | `docs/run-lifecycle.md` | `AGENTS.md`, `.agents/skills/opengeni/SKILL.md`, architecture summaries should link. |
 | Codex subscription rotation | `docs/codex-subscription-rotation.md` | `docs/run-lifecycle.md`, `docs/architecture.md`, and operator notes should link instead of restating allocator/failure semantics. |
 | Per-session MCP servers | `docs/session-mcp-servers.md` | `docs/architecture.md`, SDK/client examples should link instead of restating credential semantics. |
 | Connected machines | `docs/connected-machines.md` | `README.md`, `AGENTS.md`, client docs and skills should link. |
 | Deployment | `docs/deployment.md` | `README.md`, `AGENTS.md`, Helm/Terraform notes should link. |
 | Release/publishing | `CONTRIBUTING.md` § Release / Publishing, plus workflow files as executable truth | `README.md`, package READMEs, architecture release notes should link. |
-| Client/SDK integration | `packages/sdk/README.md` | `README.md`, `docs/embedding.md`, `@opengeni/react` docs should link. |
+| Client/SDK integration | `packages/sdk/README.md` | `README.md`, `packages/react/README.md`, and customer integration skills should link. |
 | Composer voice input | `docs/transcription.md` | Architecture, SDK/React docs, and host-app guides should link instead of restating provider selection or microphone lifecycle rules. |
 | Workbench embedding & production acceptance | `docs/embedding-workbench.md`, `docs/workbench-acceptance.md` | Host-app guides should link instead of weakening or restating the live evidence contract. |
 | Credential taxonomy | `docs/credentials.md` | `docs/embedding.md`, `docs/capabilities.md`, route comments should link instead of re-listing token types. |

--- a/docs/embedding-workbench.md
+++ b/docs/embedding-workbench.md
@@ -1,11 +1,12 @@
-# Embedding the OpenGeni workbench (frontend)
+# Embedding the OpenGeni Workbench
 
 This guide is for a host app that wants to drop the OpenGeni **session workspace**
 — the Changes / Files / Terminal / Desktop dock, with instant cold paint and the
 machine-state chip — into its own UI. It is the frontend companion to the
-backend embedding guide in `docs/embedding.md`, and it is the exact surface
-`apps/web` itself consumes (see `apps/web/src/components/session/sandbox-workspace.tsx`),
-so an external embedder and the first-party app run the same code path.
+standalone SDK/proxy integration as well as the advanced in-process path in
+`docs/embedding.md`. It is the exact surface `apps/web` itself consumes (see
+`apps/web/src/components/session/sandbox-workspace.tsx`), so an external
+embedder and the first-party app run the same code path.
 
 Shipping that code path is not acceptance by itself. The required live,
 performance, accessibility, identity-race, browser/device, and visual evidence
@@ -42,17 +43,22 @@ surface to a notice; it never crashes the dock.
 The authoritative list is the `peerDependencies` block of the package manifest
 (`packages/react/package.json`).
 
-## 2. Provider
+## 2. Provider And Trust Boundary
 
 Wrap the tree once in `OpenGeniProvider`, giving it an OpenGeni client and the
 workspace id. Every hook and component below reads the client from here (there is
 no app-context coupling — that is what makes the workbench embeddable).
 
+Keep privileged OpenGeni credentials on the host server. The browser client
+below points at a tenant-scoped, same-origin host proxy that preserves the
+OpenGeni route contract. A host may instead pass any structural client matching
+the methods used by the mounted surfaces.
+
 ```tsx
 import { OpenGeniProvider } from "@opengeni/react";
 import { OpenGeniClient } from "@opengeni/sdk";
 
-const client = new OpenGeniClient({ baseUrl: "https://api.your-host.example", apiKey });
+const client = new OpenGeniClient({ baseUrl: "/api/opengeni" });
 
 export function Root({ children }: { children: React.ReactNode }) {
   return (

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,4 +1,11 @@
-# Embedding OpenGeni
+# Advanced In-Process Embedding
+
+> Most customer products do **not** need this integration shape. When OpenGeni
+> remains a standalone service and the product presents an OpenGeni-backed agent
+> in its own UI, use `@opengeni/sdk` through a tenant-scoped server proxy and add
+> only the `@opengeni/react` surfaces the product wants. See the package READMEs
+> and the `opengeni-client` skill. This guide is for the rarer case where the
+> host mounts OpenGeni's router or calls its core domain packages in-process.
 
 This guide is for a host application that embeds OpenGeni instead of running it only as the stock API + worker service. Embedding means binding host-owned concerns (identity, tenancy, billing admission, credentials, persistence, worker process, and event bus) into the same OpenGeni domain/runtime code the standalone stack uses.
 


### PR DESCRIPTION
## Summary
- make standalone OpenGeni plus a customer-owned product boundary the default integration model
- give customer coding agents a decision path across stock UI, headless SDK, React session surfaces, styled UI, and the optional workbench
- document the server-side credential/proxy boundary, instruction scopes, file ownership, MCP tools, realtime, and compute choices
- distinguish customer integration work from advanced in-process runtime embedding and repo-maintainer work
- update the workbench example so privileged credentials stay off the browser

## Validation
- Docs reference freshness guard passed.
- 
- verified named SDK methods, React subpath exports, session skill fields, and instruction fields against current source

This change contains only generic public OpenGeni guidance.