### PR TITLE
feat: make Connected Machine setup additive

### DIFF
--- a/.changeset/wise-machines-connect.md
+++ b/.changeset/wise-machines-connect.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/core": patch
+"@opengeni/react": patch
+"@opengeni/config": patch
+---
+
+Let one Connected Machine agent retain and serve independent connections to multiple OpenGeni workspaces and deployments, with additive connection UX and connection-scoped runtime isolation.

--- a/.env.example
+++ b/.env.example
@@ -89,7 +89,7 @@ OPENGENI_USAGE_LIMITS_MODE=none
 # Public agent archive and explicit stable-channel promotion pointer. The stable
 # version must already exist as an `agent-v<version>` release.
 # OPENGENI_AGENT_RELEASES_BASE_URL=https://github.com/Cloudgeni-ai/opengeni/releases
-# OPENGENI_AGENT_STABLE_VERSION=0.1.9
+# OPENGENI_AGENT_STABLE_VERSION=0.1.10
 # OPENGENI_DELEGATION_SECRET=replace-with-long-random-token-signing-secret
 # OPENGENI_STATIC_ENTITLEMENTS_JSON='{"feature_key":true}'
 # OPENGENI_STATIC_USAGE_LIMITS_JSON='{"maxWorkspacesPerAccount":1,"maxMonthlyAgentRunsPerWorkspace":100}'

--- a/README.md
+++ b/README.md
@@ -275,11 +275,11 @@ tfvars in private operator-controlled storage outside the repository.
 
 Sessions are durable. Reloading the browser or opening the session URL later replays event history from Postgres and reconnects to live events.
 
-### Enrolling a Connected Machine
+### Connecting a Machine
 
-When Connected Machines are enabled, enroll one from the workspace **Machines** dashboard (or from the composer's machine picker):
+When Connected Machines are enabled, connect one from the workspace **Machines** dashboard (or from the composer's machine picker):
 
-1. Click **Enroll a machine** and run the printed install one-liner on the computer you want to connect. It pulls the OpenGeni agent binary from the control plane and starts it.
+1. Click **Connect a machine** and run the printed one-liner on the computer you want to connect. The same command installs or updates the agent and adds this workspace without replacing any existing OpenGeni connections on that computer.
 2. Approve the machine. Two paths exist:
    - **Device flow (consent):** the agent prints a short code and a verification link; you open it and click **Grant** in the workspace to approve that specific machine. Approval is the loud, explicit consent step, and it records who approved.
    - **Zero-click enroll token:** mint a short-lived enroll token in the workspace ahead of time; the agent redeems it headlessly (the token is the grant, no per-machine click) — the path for scripted or fleet enrollment.

--- a/agent/install/install.ps1
+++ b/agent/install/install.ps1
@@ -9,7 +9,7 @@
   for your arch, VERIFIES it two independent ways (a minisign signature against a
   public key PINNED in this script's body, AND a sha256 checksum), installs it to
   a per-user path, adds that path to your user PATH, and then PRINTS the exact
-  command to enroll + run it. It installs NO Windows Service by default and
+  command to connect + run it. It installs NO Windows Service by default and
   contains NO secrets. The pinned public key travels WITH this audited script, so
   a compromised CDN cannot serve a binary that verifies.
 
@@ -24,10 +24,10 @@
                              Point at a local mock (http://localhost/...) to test offline.
   OPENGENI_AGENT_VERSION     Pin a version (default "latest").
   OPENGENI_INSTALL_DIR       Install dir (default %LOCALAPPDATA%\OpenGeni\bin).
-  OPENGENI_ENROLL_TOKEN      Non-interactive fresh-enrollment token
-                             (CI/automation); replaces an existing enrollment.
+  OPENGENI_ENROLL_TOKEN      Non-interactive connection token (CI/automation);
+                             adds or refreshes only its deployment/workspace.
   OPENGENI_NO_RUN            "1" => do not start a foreground run; just print the command.
-  OPENGENI_API_URL           Control-plane API base URL for enrollment.
+  OPENGENI_API_URL           Control-plane API base URL for the connection.
 
   Immutable-per-version + GitHub-Releases fallback: assets resolve to
   $BASE/agent/v<ver>/<asset>. If the edge is down, the same assets are mirrored at
@@ -219,18 +219,24 @@ function Complete-Install($bin) {
   Write-Host ""
   $enrollToken = [Environment]::GetEnvironmentVariable('OPENGENI_ENROLL_TOKEN')
   if (-not [string]::IsNullOrEmpty($enrollToken)) {
-    Log "non-interactive enroll (OPENGENI_ENROLL_TOKEN set)"
-    # Supplying a token explicitly requests this enrollment. Never silently
-    # retain credentials for a previous control plane.
-    & $bin enroll --token $enrollToken --non-interactive --force
-    Log "enrolled. Start the agent (foreground) with:  $bin run"
+    Log "non-interactive connection (OPENGENI_ENROLL_TOKEN set)"
+    # This upserts only the token's deployment/workspace connection; unrelated
+    # OpenGeni connections remain configured and online.
+    $apiUrl = [Environment]::GetEnvironmentVariable('OPENGENI_API_URL')
+    if ([string]::IsNullOrEmpty($apiUrl)) {
+      & $bin connect --token $enrollToken --non-interactive
+    } else {
+      & $bin --api-url $apiUrl connect --token $enrollToken --non-interactive
+    }
+    Log "connected. Agents v0.1.10+ pick up future connections automatically. If this upgraded an older running agent, restart that process once."
+    Log "Otherwise start the agent (foreground) with:  $bin run"
     return
   }
 
   Write-Host "opengeni-agent installed at: $bin"
   Write-Host ""
   Write-Host "Next steps (the agent runs in the FOREGROUND — it does NOT install a service):"
-  Write-Host "  1. Enroll this machine:   $bin enroll"
+  Write-Host "  1. Connect this machine:  $bin connect"
   Write-Host "  2. Run it (online while this runs, offline when you stop it):"
   Write-Host "       $bin run"
   Write-Host ""

--- a/agent/install/install.sh
+++ b/agent/install/install.sh
@@ -10,7 +10,7 @@
 # `opengeni-agent` binary for your OS/arch, VERIFIES it two independent ways
 # (a minisign signature against a public key PINNED in this script's body, AND
 # a sha256 checksum), installs it to a per-user path, and then PRINTS the exact
-# command to enroll + run it. It installs NO background service by default and
+# command to connect + run it. It installs NO background service by default and
 # contains NO secrets. The pinned public key travels WITH this audited script,
 # so a compromised CDN or mirror cannot serve a binary that verifies.
 #
@@ -30,26 +30,26 @@
 #                              URL is the documented fallback (see below).
 #   OPENGENI_INSTALL_DIR       Install dir. Default: ~/.local/bin (no sudo).
 #   OPENGENI_SYSTEM=1          Install to /usr/local/bin (needs sudo/root).
-#   OPENGENI_ENROLL_TOKEN      Non-interactive enroll token (CI/automation/fleet):
-#                              the script runs `enroll --token <tok>
-#                              --non-interactive --force` itself — the token IS
-#                              the requested fresh grant, so it replaces any
-#                              enrollment already present on the machine and
-#                              needs NO device-approve step. The workspace is
+#   OPENGENI_ENROLL_TOKEN      Non-interactive connection token (CI/automation/fleet):
+#                              the script runs `connect --token <tok>
+#                              --non-interactive` itself — the token IS the
+#                              requested grant. It adds or refreshes only that
+#                              deployment/workspace connection and needs NO
+#                              device-approve step. The workspace is
 #                              encoded in the token; OPENGENI_WORKSPACE_ID is not
 #                              needed on this path.
 #   OPENGENI_NO_RUN=1          Do not start a foreground run; just print the
-#                              enroll+run command (the default when stdin is not
+#                              connect+run command (the default when stdin is not
 #                              a TTY, e.g. piped from curl).
-#   OPENGENI_API_URL           Control-plane API base URL for enrollment. Carried
-#                              into BOTH the non-interactive enroll (forwarded as
-#                              --api-url below) and the interactive `enroll`/`run`
+#   OPENGENI_API_URL           Control-plane API base URL for connection. Carried
+#                              into BOTH the non-interactive connect (forwarded as
+#                              --api-url below) and the interactive `connect`/`run`
 #                              (the agent reads $OPENGENI_API_URL via clap). Set it
 #                              to target a specific deployment instead of the
 #                              api.opengeni.ai default.
 #   OPENGENI_WORKSPACE_ID      The workspace (UUID) an INTERACTIVE device-flow
-#                              enroll binds to (the user who approves must hold a
-#                              grant in it). Honored by the agent's `enroll`/`run`
+#                              connection binds to (the approver must hold a grant
+#                              in it). Honored by the agent's `connect`/`run`
 #                              via clap ($OPENGENI_WORKSPACE_ID); the one-liner
 #                              from the Machines page sets it so no UUID is typed.
 #                              Not used on the OPENGENI_ENROLL_TOKEN path.
@@ -70,7 +70,7 @@
 # — one code-signing identity for both the CLI and the background app. macOS TCC
 # (Screen Recording / Accessibility) grants attach to that identity + bundle id, so
 # the agent's screen/computer-use features work from either entry point. The two
-# system permission prompts fire at `opengeni-agent enroll`, not on first use.
+# system permission prompts fire at `opengeni-agent connect`, not on first use.
 #
 # Immutable-per-version + GH-Releases fallback. The edge serves the latest
 # release at $BASE/install.sh and immutable copies at $BASE/v/<ver>/install.sh.
@@ -662,40 +662,41 @@ path_hint() {
   esac
 }
 
-# Print the enroll+run instructions, or — in CI mode — enroll non-interactively.
+# Print the connect+run instructions, or connect non-interactively.
 # Per §23.0 the installer NEVER installs a service and only starts a foreground
 # run when explicitly asked on an interactive TTY.
 finish() {
   _bin="$1"
   echo ""
   if [ -n "${OPENGENI_ENROLL_TOKEN:-}" ]; then
-    log "non-interactive enroll (OPENGENI_ENROLL_TOKEN set)"
+    log "non-interactive connection (OPENGENI_ENROLL_TOKEN set)"
     # Forward OPENGENI_API_URL explicitly so the exchange targets THIS deployment
     # (not the api.opengeni.ai default) even when the agent's env-inherit path is
     # ever bypassed. The agent also reads $OPENGENI_API_URL via clap, so the env
     # alone would suffice — this is belt-and-suspenders. The workspace is encoded
     # in the token, so no --workspace-id is needed on this path. A supplied token
-    # is an explicit request for this enrollment; --force prevents a previous
-    # control-plane credential from being silently reused.
+    # is an explicit request for this connection. The multi-connection store
+    # upserts only this deployment/workspace and preserves every other link.
     if [ -n "${OPENGENI_API_URL:-}" ]; then
-      "$_bin" --api-url "$OPENGENI_API_URL" enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive --force
+      "$_bin" --api-url "$OPENGENI_API_URL" connect --token "$OPENGENI_ENROLL_TOKEN" --non-interactive
     else
-      "$_bin" enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive --force
+      "$_bin" connect --token "$OPENGENI_ENROLL_TOKEN" --non-interactive
     fi
-    log "enrolled. Start the agent (foreground) with:  $_bin run"
+    log "connected. Agents v0.1.10+ pick up future connections automatically. If this upgraded an older running agent, restart that process once."
+    log "Otherwise start the agent (foreground) with:  $_bin run"
     return 0
   fi
 
   # Concise post-install: at most 3 short lines, one clear next command. The
   # always-on service + uninstall hints fold into a single `--help` pointer.
   #
-  # The interactive device-flow enroll needs the workspace id (and, for a
+  # The interactive device-flow connection needs the workspace id (and, for a
   # non-default deployment, the api url). When this ran as `curl | sh`, those env
   # vars existed ONLY for this piped process — they do NOT survive into the user's
-  # shell, and the pipe has no TTY so we cannot enroll here. So a bare `enroll`
-  # they paste later would fail with "enrollment requires a workspace id". When we
+  # shell, and the pipe has no TTY so we cannot connect here. So a bare `connect`
+  # they paste later would fail with "connection requires a workspace id". When we
   # know them, bake them into the printed command so the copy-paste is correct;
-  # otherwise the single next step is exactly `opengeni-agent enroll`.
+  # otherwise the single next step is exactly `opengeni-agent connect`.
   _enroll_env=""
   if [ -n "${OPENGENI_WORKSPACE_ID:-}" ]; then
     _enroll_env="OPENGENI_WORKSPACE_ID=$OPENGENI_WORKSPACE_ID"
@@ -709,9 +710,9 @@ finish() {
   fi
   printf '%s\n' "opengeni-agent installed."
   if [ -n "$_enroll_env" ]; then
-    printf '%s\n' "Next: $_enroll_env $_bin enroll   (then: $_bin run)"
+    printf '%s\n' "Next: $_enroll_env $_bin connect   (then: $_bin run)"
   else
-    printf '%s\n' "Next: $_bin enroll   (then: $_bin run)"
+    printf '%s\n' "Next: $_bin connect   (then: $_bin run)"
   fi
   printf '%s\n' "Always-on service, uninstall, and more: $_bin --help"
 

--- a/apps/api/test/install.test.ts
+++ b/apps/api/test/install.test.ts
@@ -40,7 +40,7 @@ describe("get.<domain> install routes", () => {
     // The real committed install.sh body (no secrets; curl|sh entrypoint).
     expect(body).toContain("OPENGENI_INSTALL_BASE_URL");
     expect(body).toContain("opengeni-agent");
-    expect(body).toContain('enroll --token "$OPENGENI_ENROLL_TOKEN" --non-interactive --force');
+    expect(body).toContain('connect --token "$OPENGENI_ENROLL_TOKEN" --non-interactive');
   });
 
   // "The agent ships inside the control-plane": a DEPLOYED control plane self-serves
@@ -78,7 +78,7 @@ describe("get.<domain> install routes", () => {
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body.length).toBeGreaterThan(0);
-    expect(body).toContain("enroll --token $enrollToken --non-interactive --force");
+    expect(body).toContain("connect --token $enrollToken --non-interactive");
   });
 
   test("GET /uninstall.sh serves the uninstall script", async () => {
@@ -105,7 +105,7 @@ describe("get.<domain> install routes", () => {
     );
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(
-      "https://github.com/Cloudgeni-ai/opengeni/releases/download/agent-v0.1.9/opengeni-agent-universal-apple-darwin",
+      "https://github.com/Cloudgeni-ai/opengeni/releases/download/agent-v0.1.10/opengeni-agent-universal-apple-darwin",
     );
   });
 
@@ -213,7 +213,7 @@ describe("get.<domain> install routes — baked binary serving", () => {
     );
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toContain(
-      "/releases/download/agent-v0.1.9/opengeni-agent-universal-apple-darwin",
+      "/releases/download/agent-v0.1.10/opengeni-agent-universal-apple-darwin",
     );
   });
 });

--- a/apps/web/src/lib/deployment.test.ts
+++ b/apps/web/src/lib/deployment.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { deviceVerificationUri, installOneLiner } from "./deployment";
+
+describe("Connected Machine deployment URLs", () => {
+  test("builds an additive token connect command pinned to this deployment", () => {
+    const command = installOneLiner("https://one.opengeni.example/", {
+      enrollToken: "oget_example",
+    });
+
+    expect(command).toBe(
+      "curl -fsSL https://one.opengeni.example/install.sh | " +
+        "OPENGENI_API_URL=https://one.opengeni.example " +
+        "OPENGENI_ENROLL_TOKEN=oget_example sh",
+    );
+    expect(command).not.toContain("--force");
+  });
+
+  test("pins interactive setup and approval to the selected deployment", () => {
+    expect(
+      installOneLiner("https://two.opengeni.example///", { workspaceId: "workspace-2" }),
+    ).toContain(
+      "OPENGENI_API_URL=https://two.opengeni.example OPENGENI_WORKSPACE_ID=workspace-2 sh",
+    );
+    expect(deviceVerificationUri("https://two.opengeni.example/")).toBe(
+      "https://two.opengeni.example/device",
+    );
+  });
+});

--- a/apps/web/src/lib/deployment.ts
+++ b/apps/web/src/lib/deployment.ts
@@ -10,7 +10,9 @@ function originOf(baseUrl: string): string {
 }
 
 /**
- * The install one-liner the user runs on the machine they want to enroll.
+ * The universal install-or-connect one-liner. The installer is idempotent and
+ * `connect` adds only this deployment/workspace, so it is safe on a machine
+ * already serving other OpenGeni instances.
  *
  * It ALWAYS bakes `OPENGENI_API_URL=${origin}` so the agent targets *this*
  * deployment rather than the hardcoded `api.opengeni.ai` default. Pass:

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -201,7 +201,7 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
       <PageHeader
         icon={<LaptopIcon className="size-4" />}
         title="Machines"
-        description="Your own computers, enrolled as agent sandboxes. Run the install one-liner on a machine and it appears here — usable from any session alongside the managed sandbox."
+        description="Your own computers, connected as agent sandboxes. One agent can serve this workspace alongside any other OpenGeni workspaces or deployments already connected to the machine."
       />
 
       <div className="mt-5">
@@ -247,9 +247,10 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
       <Dialog open={enrollOpen} onOpenChange={setEnrollOpen}>
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>Enroll a machine</DialogTitle>
+            <DialogTitle>Connect a machine</DialogTitle>
             <DialogDescription>
-              Run a one-liner on the machine you want to share as an agent sandbox.
+              Run one command to install or update the agent and add this workspace. Existing
+              OpenGeni connections stay intact.
             </DialogDescription>
           </DialogHeader>
           {/* Gated on `enrollOpen` so the body mounts (and mints a fresh token)
@@ -358,7 +359,7 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
         const message = err instanceof Error ? err.message : String(err);
         setError(message);
         setToken(null);
-        toast.error("Could not create an enroll token", { description: message });
+        toast.error("Could not create a connect command", { description: message });
       } finally {
         if (seq === mintSeq.current) {
           setMinting(false);
@@ -380,7 +381,7 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
     if (!command) {
       return;
     }
-    void copyToClipboard(command, "Install command copied").then((ok) => {
+    void copyToClipboard(command, "Connect command copied").then((ok) => {
       if (ok) {
         setCopied(true);
       }
@@ -400,7 +401,7 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
           onClick={() => setMode("token")}
         >
           <ArrowLeftIcon className="size-4" />
-          Back to one-click enroll
+          Back to one-command setup
         </Button>
         <EnrollmentDeviceFlow
           // The agent mints the real code via the device-flow start; until the
@@ -410,7 +411,7 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
           verificationUri={verificationUri}
           installCommand={installCommand}
           phase={"pending" satisfies DeviceFlowPhase}
-          onCopyInstall={() => void copyToClipboard(installCommand, "Install command copied")}
+          onCopyInstall={() => void copyToClipboard(installCommand, "Connect command copied")}
           className="border-0 shadow-none"
         />
         <p className="text-center text-2xs text-fg-muted">
@@ -423,8 +424,9 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
   return (
     <div className="flex flex-col gap-3">
       <p className="text-xs leading-4 text-fg-muted">
-        Run this on the machine you want to share. It enrolls instantly as an agent sandbox — no
-        approval step.
+        Run this on the machine you want to share. Agents v0.1.10+ add the workspace live within a
+        few seconds; if the command upgrades an older running agent, restart that agent once. Other
+        workspaces stay configured.
       </p>
 
       <label className="flex items-start gap-2 rounded-md border border-border bg-bg/40 px-2.5 py-2 text-xs leading-4 text-fg">
@@ -448,18 +450,18 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
       </label>
 
       <Notice tone="waiting" title="Secret — copy it now">
-        This command embeds a one-time enroll token that grants enrollment into this workspace until
-        it expires. Anyone who has it can enroll a machine here.
+        This command embeds a one-time token that can connect a machine to this workspace until it
+        expires. Anyone who has it can connect a machine here.
       </Notice>
 
       {minting ? (
         <Notice tone="muted" icon={<Loader2Icon className="size-4 animate-spin" />}>
-          Minting enroll token…
+          Preparing secure connect command…
         </Notice>
       ) : error ? (
         <Notice
           tone="failed"
-          title="Could not create an enroll token"
+          title="Could not create a connect command"
           action={
             <Button
               type="button"
@@ -501,7 +503,7 @@ function EnrollDialogBody({ workspaceId, origin }: { workspaceId: string; origin
             onClick={copyCommand}
           >
             {copied ? <CheckIcon className="size-4" /> : <CopyIcon className="size-4" />}
-            {copied ? "Copied" : "Copy install command"}
+            {copied ? "Copied" : "Copy connect command"}
           </Button>
         </>
       ) : null}

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -1,14 +1,14 @@
 # Connected Machines (bring-your-own-compute)
 
 A **Connected Machine** is one of a session's compute targets — your own
-computer (a laptop, a workstation, a CI box, even a macOS machine) enrolled into
+computer (a laptop, a workstation, a CI box, even a macOS machine) connected to
 a workspace and driven by the agent directly. It is a **first-class, co-equal
 primary compute target**, not a backend variant layered on top of a managed
 box.
 
 This guide is embedder-facing: it shows how to create a session on a machine,
 discover the enrolled machines and their metrics, swap a session's active
-sandbox, enroll a machine (zero-click token or the interactive device flow), and
+sandbox, connect a machine (zero-click token or the interactive device flow), and
 revoke/detach — all through the typed [`@opengeni/sdk`](../packages/sdk/README.md)
 client. The matching UI ships in
 [`@opengeni/react/machines`](../packages/react/README.md).
@@ -250,10 +250,30 @@ Validation (ownership, liveness, epoch fence) is server-side; a rejected target
 comes back as `swapped: false` with a `reason` rather than throwing. The next
 turn runs on whatever the pointer resolves to.
 
-## Enroll a machine
+## Connect a machine
 
 Enrollment turns a user's machine into a `selfhosted` sandbox in the workspace.
-There are two paths. Both require the caller to hold `enrollments:manage`.
+The machine agent is multi-connection: installing it once and connecting another
+workspace—even on a different OpenGeni deployment—adds an independent link and
+preserves all existing links. There are two enrollment paths. Both require the
+caller to hold `enrollments:manage`.
+
+The universal Machines-page one-liner installs or updates the binary and runs
+`opengeni-agent connect` for that deployment. A running v0.1.10+ foreground or
+service agent detects the new owner-only connection file automatically. When the
+command upgrades an older running process, restart that process once; subsequent
+connections load live.
+Operators can inspect or remove local links with:
+
+```sh
+opengeni-agent connections
+opengeni-agent disconnect <connection-id-or-prefix>
+```
+
+`disconnect` stops only the local link. The enrollment remains visible offline
+in that workspace until a workspace administrator removes/revokes it. This is
+intentional: possessing the machine credential does not grant workspace-admin
+authority.
 
 ### Zero-click token (fleet / headless)
 
@@ -268,7 +288,8 @@ const { token, expiresAt, expiresInSeconds } =
 // Run on the machine (the installer dials OpenGeni and exchanges the token for
 // its own long-lived agent credentials — the token exchange happens on the
 // machine, not through this client):
-//   curl -fsSL https://…/install.sh | sh -s -- --token <token>
+//   OPENGENI_API_URL=https://… OPENGENI_ENROLL_TOKEN=<token> \
+//     sh -c 'curl -fsSL "$OPENGENI_API_URL/install.sh" | sh'
 ```
 
 `allowScreenControl` bakes the (optional) screen-control consent into the token;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1313,7 +1313,7 @@ for other OS/arch assets and the self-update channel. Route these paths (and an
 optional `get.<domain>` host) to the `api` service in the ingress.
 
 `/agent/latest/<asset>` is a compatibility route backed by the immutable
-versioned release selected by `OPENGENI_AGENT_STABLE_VERSION` (default `0.1.9`).
+versioned release selected by `OPENGENI_AGENT_STABLE_VERSION` (default `0.1.10`).
 `OPENGENI_AGENT_RELEASES_BASE_URL` selects the archive origin. Promote or roll
 back the stable channel by changing the configured version only after the
 corresponding `agent-v<version>` release and its signed assets exist; never move

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -249,7 +249,7 @@ const SettingsSchema = z.object({
   agentStableVersion: z
     .string()
     .regex(/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u)
-    .default("0.1.9"),
+    .default("0.1.10"),
   productAccessMode: ProductAccessMode.default("local"),
   billingMode: BillingMode.default("disabled"),
   entitlementsMode: EntitlementsMode.default("none"),

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -181,7 +181,7 @@ describe("Docker workspace materialization", () => {
 
 describe("agent stable release selection", () => {
   test("uses an exact stable version and supports an explicit operator promotion", () => {
-    expect(withEnv({}, () => getSettings()).agentStableVersion).toBe("0.1.9");
+    expect(withEnv({}, () => getSettings()).agentStableVersion).toBe("0.1.10");
     expect(
       withEnv({ OPENGENI_AGENT_STABLE_VERSION: "1.4.2" }, () => getSettings()).agentStableVersion,
     ).toBe("1.4.2");

--- a/packages/core/src/sandbox/fleet.ts
+++ b/packages/core/src/sandbox/fleet.ts
@@ -747,7 +747,7 @@ export async function provisionSandbox(
     return {
       kind: "selfhosted",
       instructions:
-        "Share these instructions with a human operator. They install the OpenGeni agent on the machine, run `opengeni-agent enroll`, complete the device-flow at the verification URL (the loud whole-machine + screen-control consent), and the machine then appears here as an attachable selfhosted sandbox.",
+        "Share these instructions with a human operator. They install the OpenGeni agent on the machine, run `opengeni-agent connect`, complete the device-flow at the verification URL (the loud whole-machine + screen-control consent), and the machine then appears here as an attachable selfhosted sandbox. Existing connections to other OpenGeni workspaces or deployments are preserved.",
       // Install from THIS control plane's origin (not a hardcoded public CDN): the
       // served install script is rewritten to pull the per-SHA agent baked into
       // this exact deployment (see apps/api/src/routes/install.ts), so a deployed

--- a/packages/react/src/components/machines-dashboard.tsx
+++ b/packages/react/src/components/machines-dashboard.tsx
@@ -20,7 +20,7 @@ export type MachinesDashboardProps = {
   onOpenDetail?: ((machine: MachineView) => void) | undefined;
   /** Shared clock so freshness/relative times render consistently across cards. */
   now?: number | undefined;
-  /** Open the enrollment flow (the "Enroll a machine" CTA). */
+  /** Open the connection flow (the "Connect a machine" CTA). */
   onEnroll?: (() => void) | undefined;
   onRefresh?: (() => void) | undefined;
   className?: string | undefined;
@@ -38,7 +38,8 @@ function EmptyState({ onEnroll }: { onEnroll?: (() => void) | undefined }) {
       <div className="space-y-1">
         <p className="text-og-base font-medium text-og-fg">No machines yet</p>
         <p className="max-w-xs text-og-sm text-og-fg-muted">
-          Enroll your own computer to run the agent on it — your files, your terminal, your desktop.
+          Connect your own computer to run the agent on it — your files, your terminal, your
+          desktop.
         </p>
       </div>
       {onEnroll ? (
@@ -49,7 +50,7 @@ function EmptyState({ onEnroll }: { onEnroll?: (() => void) | undefined }) {
           className="inline-flex items-center gap-1.5 rounded-og-sm bg-og-accent px-3 py-1.5 text-og-sm font-medium text-og-accent-fg transition-colors hover:bg-og-accent-strong pointer-coarse:min-h-11"
         >
           <PlusIcon className="size-3.5" aria-hidden />
-          Enroll a machine
+          Connect a machine
         </button>
       ) : null}
     </div>
@@ -93,7 +94,7 @@ function Header({
             className="inline-flex items-center gap-1.5 rounded-og-sm border border-og-border px-2.5 py-1 text-og-sm font-medium text-og-fg-muted transition-colors hover:border-og-border-strong hover:text-og-fg pointer-coarse:min-h-11"
           >
             <PlusIcon className="size-3.5" aria-hidden />
-            Enroll machine
+            Connect a machine
           </button>
         ) : null}
       </div>
@@ -102,10 +103,10 @@ function Header({
 }
 
 /**
- * The workspace Machines dashboard: the fleet of selfhosted enrollments + the
+ * The workspace Machines dashboard: the fleet of Connected Machines + the
  * session's managed sandbox, each with its connection-status pill, state badges,
  * latest metrics, and an attach/swap affordance. Renders the empty state (no
- * machines → enroll CTA), a load error, and the populated grid. The component
+ * machines → connect CTA), a load error, and the populated grid. The component
  * is purely presentational — feed it `MachinesResponse` data via `useMachines`.
  */
 export function MachinesDashboard({

--- a/packages/react/test/machines-components.test.tsx
+++ b/packages/react/test/machines-components.test.tsx
@@ -216,7 +216,7 @@ describe("MachineCard — attach/swap affordance", () => {
 });
 
 describe("MachinesDashboard", () => {
-  test("empty state renders the enroll CTA", async () => {
+  test("empty state renders the connect CTA", async () => {
     let enrolled = false;
     const r = await renderComponent(
       <MachinesDashboard machines={[]} onEnroll={() => (enrolled = true)} />,
@@ -225,6 +225,7 @@ describe("MachinesDashboard", () => {
     expect(r.container.querySelector("[data-machines-empty]")).not.toBeNull();
     const cta = r.container.querySelector("[data-enroll-cta]") as HTMLButtonElement | null;
     expect(cta).not.toBeNull();
+    expect(cta?.textContent).toContain("Connect a machine");
     cta!.click();
     await flush();
     expect(enrolled).toBe(true);

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -42,7 +42,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     authAllowMetrics: false,
     publicBaseUrl: "http://127.0.0.1:3000",
     agentReleasesBaseUrl: "https://github.com/Cloudgeni-ai/opengeni/releases",
-    agentStableVersion: "0.1.9",
+    agentStableVersion: "0.1.10",
     productAccessMode: "local",
     billingMode: "disabled",
     entitlementsMode: "none",


### PR DESCRIPTION
## Outcome
- turns the Machines flow into one additive install-or-connect command
- preserves every existing OpenGeni workspace/deployment connection on the machine
- promotes the now-published signed agent release 0.1.10 as the stable default
- adds clear local connection listing/disconnect guidance and a truthful one-time restart note for upgrades from pre-0.1.10

## Rollout safety
- agent capability merged first in #1153
- immutable release: https://github.com/Cloudgeni-ai/opengeni/releases/tag/agent-v0.1.10
- all five platform binaries, SHA-256 files, and minisign signatures verified present before opening this PR

## Verification
- 40 focused API/React/deployment tests
- all 23 TypeScript projects
- lint and formatting
- docs-reference and public-hygiene guards
- POSIX installer syntax and diff hygiene

#1143 is intentionally untouched.