### PR TITLE
fix(agent): prevent cross-deployment installer downgrades

### DIFF
--- a/agent/install/install.ps1
+++ b/agent/install/install.ps1
@@ -23,6 +23,8 @@
   OPENGENI_INSTALL_BASE_URL  Release asset base URL (default https://get.opengeni.ai).
                              Point at a local mock (http://localhost/...) to test offline.
   OPENGENI_AGENT_VERSION     Pin a version (default "latest").
+  OPENGENI_ALLOW_DOWNGRADE   "1" explicitly allows an older verified agent to
+                             replace a newer installed one. Default: preserve newer.
   OPENGENI_INSTALL_DIR       Install dir (default %LOCALAPPDATA%\OpenGeni\bin).
   OPENGENI_ENROLL_TOKEN      Non-interactive connection token (CI/automation);
                              adds or refreshes only its deployment/workspace.
@@ -60,6 +62,31 @@ $Version = Get-EnvOr 'OPENGENI_AGENT_VERSION' 'latest'
 
 function Log($msg)  { Write-Host "opengeni-install: $msg" }
 function Fail($code, $msg) { Write-Host "opengeni-install: ERROR: $msg" -ForegroundColor Red; exit $code }
+
+function Get-AgentReleaseVersion($path) {
+  if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { return $null }
+  try {
+    $line = @(& $path --version 2>$null)[0]
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($line)) { return $null }
+    $match = [regex]::Match([string]$line, '^opengeni-agent ([0-9]+\.[0-9]+\.[0-9]+)$')
+    if (-not $match.Success) { return $null }
+    return [version]$match.Groups[1].Value
+  } catch {
+    return $null
+  }
+}
+
+function Test-KeepNewerAgent($installed, $candidate) {
+  if ((Get-EnvOr 'OPENGENI_ALLOW_DOWNGRADE' '0') -eq '1') { return $false }
+  $installedVersion = Get-AgentReleaseVersion $installed
+  $candidateVersion = Get-AgentReleaseVersion $candidate
+  if ($null -eq $installedVersion -or $null -eq $candidateVersion) { return $false }
+  if ($installedVersion -gt $candidateVersion) {
+    Log "keeping installed opengeni-agent $installedVersion; verified candidate $candidateVersion is older (set OPENGENI_ALLOW_DOWNGRADE=1 to override)"
+    return $true
+  }
+  return $false
+}
 
 function Get-Asset {
   # ARM64 vs x64. PROCESSOR_ARCHITECTURE is the running process arch; on WoW64 the
@@ -200,13 +227,17 @@ function Main {
     $installDir = Get-InstallDir
     New-Item -ItemType Directory -Path $installDir -Force | Out-Null
     $dest = Join-Path $installDir 'opengeni-agent.exe'
-    if (Test-Path $dest) {
-      $aside = "$dest.old"
-      Remove-Item -Force $aside -ErrorAction SilentlyContinue
-      try { Move-Item -Force $dest $aside } catch { } # locked-running: rename aside
+    if (Test-KeepNewerAgent $dest $binTmp) {
+      Remove-Item -Force $binTmp -ErrorAction SilentlyContinue
+    } else {
+      if (Test-Path $dest) {
+        $aside = "$dest.old"
+        Remove-Item -Force $aside -ErrorAction SilentlyContinue
+        try { Move-Item -Force $dest $aside } catch { } # locked-running: rename aside
+      }
+      Move-Item -Force $binTmp $dest
+      Log "installed verified binary to $dest"
     }
-    Move-Item -Force $binTmp $dest
-    Log "installed verified binary to $dest"
     Add-UserPath $installDir
 
     Complete-Install $dest

--- a/agent/install/install.sh
+++ b/agent/install/install.sh
@@ -28,6 +28,9 @@
 #                              which resolves the immutable per-version path the
 #                              edge advertises. The direct GitHub-Releases asset
 #                              URL is the documented fallback (see below).
+#   OPENGENI_ALLOW_DOWNGRADE=1 Explicitly allow an older verified agent to replace
+#                              a newer installed one. By default, installers from
+#                              lagging deployments cannot downgrade a shared agent.
 #   OPENGENI_INSTALL_DIR       Install dir. Default: ~/.local/bin (no sudo).
 #   OPENGENI_SYSTEM=1          Install to /usr/local/bin (needs sudo/root).
 #   OPENGENI_ENROLL_TOKEN      Non-interactive connection token (CI/automation/fleet):
@@ -125,6 +128,52 @@ OPENGENI_APP_BUNDLE_ASSET="OpenGeni-Agent.app.zip"
 log()  { printf '%s\n' "opengeni-install: $*" >&2; }
 err()  { printf '%s\n' "opengeni-install: ERROR: $*" >&2; }
 die()  { err "$2"; exit "$1"; }
+
+# Read the strict release version reported by one agent binary. Unknown/custom
+# binaries are deliberately not ordered: the installer preserves its historical
+# replace behavior when either side does not report `opengeni-agent X.Y.Z`.
+agent_release_version() {
+  _policy_bin="$1"
+  [ -x "$_policy_bin" ] || return 1
+  "$_policy_bin" --version 2>/dev/null | awk '
+    NR == 1 && $1 == "opengeni-agent" && $2 ~ /^[0-9]+\.[0-9]+\.[0-9]+$/ {
+      print $2
+      found = 1
+    }
+    END { if (!found) exit 1 }
+  '
+}
+
+# Success means $1 is a strictly newer X.Y.Z than $2.
+release_version_gt() {
+  awk -v installed="$1" -v candidate="$2" 'BEGIN {
+    if (installed !~ /^[0-9]+\.[0-9]+\.[0-9]+$/ || candidate !~ /^[0-9]+\.[0-9]+\.[0-9]+$/) exit 2
+    split(installed, a, ".")
+    split(candidate, b, ".")
+    for (i = 1; i <= 3; i++) {
+      if ((a[i] + 0) > (b[i] + 0)) exit 0
+      if ((a[i] + 0) < (b[i] + 0)) exit 1
+    }
+    exit 1
+  }'
+}
+
+# Protect the single shared install path when a user connects through a deployment
+# that has not promoted as far as another deployment on the same machine. The
+# verified candidate is still used when it is equal/newer, when ordering is
+# unknown, or when the operator explicitly opts into a downgrade.
+should_keep_newer_agent() {
+  _policy_installed="$1"
+  _policy_candidate="$2"
+  [ "${OPENGENI_ALLOW_DOWNGRADE:-0}" != "1" ] || return 1
+  _policy_installed_version="$(agent_release_version "$_policy_installed")" || return 1
+  _policy_candidate_version="$(agent_release_version "$_policy_candidate")" || return 1
+  if release_version_gt "$_policy_installed_version" "$_policy_candidate_version"; then
+    log "keeping installed opengeni-agent $_policy_installed_version; verified candidate $_policy_candidate_version is older (set OPENGENI_ALLOW_DOWNGRADE=1 to override)"
+    return 0
+  fi
+  return 1
+}
 
 # A temp dir we always clean up, so a failed/partial download never lingers.
 TMPDIR_OG=""
@@ -484,6 +533,12 @@ macos_swap_bundle_into_place() {
 install_macos_local_bundle() {
   _bin="$1"; _install_dir="$2"
   _app="$HOME/Applications/$OPENGENI_APP_NAME.app"
+  _existing_bin="$_app/Contents/MacOS/opengeni-agent"
+
+  if should_keep_newer_agent "$_existing_bin" "$_bin"; then
+    link_macos_cli "$_app" "$_install_dir"
+    return 0
+  fi
 
   # Preserve a real-Apple-signed bundle unless explicitly told to replace it.
   if macos_bundle_is_signed_nonadhoc "$_app"; then
@@ -582,9 +637,13 @@ install_macos_prebuilt_bundle() {
       codesign --verify --strict "$_staged_app" >/dev/null 2>&1 \
         || die 2 "codesign --verify --strict FAILED for the prebuilt bundle; not installing"
     fi
-    mkdir -p "$_apps" || die 2 "cannot create $_apps"
-    macos_swap_bundle_into_place "$_staged_app" "$_app"
-    log "installed notarized app bundle at $_app"
+    if should_keep_newer_agent "$_app/Contents/MacOS/opengeni-agent" "$_staged_app/Contents/MacOS/opengeni-agent"; then
+      log "kept the newer installed notarized app bundle"
+    else
+      mkdir -p "$_apps" || die 2 "cannot create $_apps"
+      macos_swap_bundle_into_place "$_staged_app" "$_app"
+      log "installed notarized app bundle at $_app"
+    fi
   fi
   link_macos_cli "$_app" "$_install_dir"
 }
@@ -632,6 +691,7 @@ main() {
 
   # GATE 2: minisign signature against the pinned key (fail-closed, no skip).
   verify_signature "$bin_tmp" "$sig_tmp"
+  chmod 0755 "$bin_tmp"
 
   install_dir="$(resolve_install_dir)"
   if [ "$os" = "Darwin" ]; then
@@ -644,9 +704,12 @@ main() {
     # leaves a half-written binary on PATH.
     mkdir -p "$install_dir" 2>/dev/null || die 2 "cannot create install dir $install_dir"
     dest="$install_dir/opengeni-agent"
-    chmod 0755 "$bin_tmp"
-    mv -f "$bin_tmp" "$dest" || die 2 "cannot install to $dest (try OPENGENI_SYSTEM=1 with sudo, or set OPENGENI_INSTALL_DIR)"
-    log "installed verified binary to $dest"
+    if should_keep_newer_agent "$dest" "$bin_tmp"; then
+      rm -f "$bin_tmp"
+    else
+      mv -f "$bin_tmp" "$dest" || die 2 "cannot install to $dest (try OPENGENI_SYSTEM=1 with sudo, or set OPENGENI_INSTALL_DIR)"
+      log "installed verified binary to $dest"
+    fi
   fi
 
   path_hint "$install_dir"

--- a/agent/install/test/ci-install-smoke.ps1
+++ b/agent/install/test/ci-install-smoke.ps1
@@ -37,6 +37,33 @@ try {
   }
   Write-Host "install-smoke OK: verified + installed $asset"
 
+  # Compile a tiny executable that reports a future version, place it at the
+  # shared install path, and prove a lagging deployment cannot replace it unless
+  # the operator explicitly opts into a downgrade.
+  $newerDir = Join-Path $work 'newer-bin'
+  New-Item -ItemType Directory -Path $newerDir -Force | Out-Null
+  $newerSource = Join-Path $work 'newer-agent.rs'
+  'fn main() { println!("opengeni-agent 9.9.9"); }' | Set-Content $newerSource
+  $newerExe = Join-Path $newerDir 'opengeni-agent.exe'
+  & rustc $newerSource -o $newerExe
+  if ($LASTEXITCODE -ne 0) { throw "could not compile newer-agent fixture" }
+
+  $env:OPENGENI_INSTALL_DIR = $newerDir
+  Remove-Item Env:OPENGENI_ALLOW_DOWNGRADE -ErrorAction SilentlyContinue
+  & pwsh -File $script
+  if ((& $newerExe --version) -ne 'opengeni-agent 9.9.9') {
+    throw "lagging installer replaced a newer installed agent"
+  }
+  Write-Host "install-smoke OK: newer installed agent preserved"
+
+  $env:OPENGENI_ALLOW_DOWNGRADE = '1'
+  & pwsh -File $script
+  if ((& $newerExe --version) -ne (& $built --version)) {
+    throw "explicit downgrade override did not install the verified candidate"
+  }
+  Remove-Item Env:OPENGENI_ALLOW_DOWNGRADE -ErrorAction SilentlyContinue
+  Write-Host "install-smoke OK: explicit downgrade override honored"
+
   # A tampered artifact MUST be rejected (exit 5).
   Add-Content (Join-Path $mock $asset) 'TAMPER'
   $hash2 = (Get-FileHash -Algorithm SHA256 (Join-Path $mock $asset)).Hash.ToLowerInvariant()

--- a/agent/install/test/ci-install-smoke.sh
+++ b/agent/install/test/ci-install-smoke.sh
@@ -75,6 +75,39 @@ else
 fi
 echo "install-smoke OK: verified + installed $asset"
 
+# A deployment lagging behind the machine's installed agent must not downgrade
+# the one shared binary. Use a tiny executable reporting 9.9.9 as the installed
+# agent, then prove the real verified candidate is skipped unless explicitly
+# authorized. On macOS, exercise the actual app-bundle path under an isolated HOME.
+newer_home="$work/newer-home"
+newer_install_dir="$work/newer-bin"
+if [ "$os" = "Darwin" ]; then
+  newer_installed="$newer_home/Applications/OpenGeni Agent.app/Contents/MacOS/opengeni-agent"
+else
+  newer_installed="$newer_install_dir/opengeni-agent"
+fi
+mkdir -p "$(dirname "$newer_installed")"
+printf '%s\n' '#!/bin/sh' "printf '%s\\n' 'opengeni-agent 9.9.9'" > "$newer_installed"
+chmod 0755 "$newer_installed"
+
+HOME="$newer_home" OPENGENI_INSTALL_BASE_URL="file://$work/mock" \
+OPENGENI_INSTALL_DIR="$newer_install_dir" OPENGENI_NO_RUN=1 \
+  sh "$work/install.sh" </dev/null
+[ "$("$newer_install_dir/opengeni-agent" --version)" = "opengeni-agent 9.9.9" ] || {
+  echo "lagging installer replaced a newer installed agent" >&2
+  exit 1
+}
+echo "install-smoke OK: newer installed agent preserved"
+
+HOME="$newer_home" OPENGENI_INSTALL_BASE_URL="file://$work/mock" \
+OPENGENI_INSTALL_DIR="$newer_install_dir" OPENGENI_NO_RUN=1 OPENGENI_ALLOW_DOWNGRADE=1 \
+  sh "$work/install.sh" </dev/null
+[ "$("$newer_install_dir/opengeni-agent" --version)" = "$("$built" --version)" ] || {
+  echo "explicit downgrade override did not install the verified candidate" >&2
+  exit 1
+}
+echo "install-smoke OK: explicit downgrade override honored"
+
 # A tampered artifact MUST be rejected (exit 5).
 echo TAMPER >> "$mock/$asset"
 ( cd "$mock" && sha256_line "$asset" > "$asset.sha256" )

--- a/agent/install/test/macos-bundle-sim.sh
+++ b/agent/install/test/macos-bundle-sim.sh
@@ -18,6 +18,8 @@
 #      (deterministic) and logged;
 #   4. an atomic-swap FAILURE                         -> the previous bundle is
 #      restored from its .bak and the installer dies loudly (rc 2).
+#   5. a newer installed agent                        -> an older deployment's
+#      candidate is preserved unless downgrade is explicitly authorized.
 #
 # Usage:  sh agent/install/test/macos-bundle-sim.sh
 set -eu
@@ -167,6 +169,43 @@ if ls "$WORK/apps"/.*.bak.* >/dev/null 2>&1; then
 else
   ok "no .bak backup left behind"
 fi
+
+echo "SIM 5: a lagging deployment cannot downgrade the shared agent binary"
+make_version_agent() {
+  _version_path="$1"; _version_value="$2"
+  printf '%s\n' '#!/bin/sh' "printf '%s\\n' 'opengeni-agent $_version_value'" > "$_version_path"
+  chmod 0755 "$_version_path"
+}
+NEWER_AGENT="$WORK/newer-agent"
+OLDER_AGENT="$WORK/older-agent"
+UNKNOWN_AGENT="$WORK/unknown-agent"
+make_version_agent "$NEWER_AGENT" "10.0.0"
+make_version_agent "$OLDER_AGENT" "9.99.99"
+printf '%s\n' '#!/bin/sh' "printf '%s\\n' 'custom build'" > "$UNKNOWN_AGENT"
+chmod 0755 "$UNKNOWN_AGENT"
+
+if should_keep_newer_agent "$NEWER_AGENT" "$OLDER_AGENT"; then
+  ok "strict numeric semver preserves the newer installed agent"
+else
+  bad "newer installed agent was not protected"
+fi
+if should_keep_newer_agent "$OLDER_AGENT" "$NEWER_AGENT"; then
+  bad "older installed agent incorrectly blocked an upgrade"
+else
+  ok "a newer candidate remains installable"
+fi
+if should_keep_newer_agent "$UNKNOWN_AGENT" "$OLDER_AGENT"; then
+  bad "an unknown custom build was ordered as a release"
+else
+  ok "unknown/custom versions retain the historical replace behavior"
+fi
+OPENGENI_ALLOW_DOWNGRADE=1; export OPENGENI_ALLOW_DOWNGRADE
+if should_keep_newer_agent "$NEWER_AGENT" "$OLDER_AGENT"; then
+  bad "the explicit downgrade override was ignored"
+else
+  ok "OPENGENI_ALLOW_DOWNGRADE=1 permits the deliberate downgrade"
+fi
+unset OPENGENI_ALLOW_DOWNGRADE
 
 echo ""
 echo "SIM RESULT: $PASS passed, $FAIL failed"

--- a/apps/api/test/install.test.ts
+++ b/apps/api/test/install.test.ts
@@ -41,6 +41,8 @@ describe("get.<domain> install routes", () => {
     expect(body).toContain("OPENGENI_INSTALL_BASE_URL");
     expect(body).toContain("opengeni-agent");
     expect(body).toContain('connect --token "$OPENGENI_ENROLL_TOKEN" --non-interactive');
+    expect(body).toContain("OPENGENI_ALLOW_DOWNGRADE");
+    expect(body).toContain("should_keep_newer_agent");
   });
 
   // "The agent ships inside the control-plane": a DEPLOYED control plane self-serves
@@ -79,6 +81,8 @@ describe("get.<domain> install routes", () => {
     const body = await res.text();
     expect(body.length).toBeGreaterThan(0);
     expect(body).toContain("connect --token $enrollToken --non-interactive");
+    expect(body).toContain("OPENGENI_ALLOW_DOWNGRADE");
+    expect(body).toContain("Test-KeepNewerAgent");
   });
 
   test("GET /uninstall.sh serves the uninstall script", async () => {

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -263,6 +263,10 @@ The universal Machines-page one-liner installs or updates the binary and runs
 service agent detects the new owner-only connection file automatically. When the
 command upgrades an older running process, restart that process once; subsequent
 connections load live.
+
+Because the binary is shared, the current installer refuses to replace a newer
+installed agent with an older verified release from a lagging deployment. Set
+`OPENGENI_ALLOW_DOWNGRADE=1` only for an intentional rollback.
 Operators can inspect or remove local links with:
 
 ```sh


### PR DESCRIPTION
## Outcome
A machine can safely use one shared OpenGeni agent across deployments that promote releases at different times. The current POSIX and Windows installers compare the verified candidate with the installed agent and refuse a strict semantic-version downgrade by default.

- equal/newer candidates install normally
- unknown/custom version output retains the existing replacement behavior
- an intentional rollback remains possible with `OPENGENI_ALLOW_DOWNGRADE=1`
- the selected newer binary still handles the new workspace connection

## Verification
- installer version-policy simulation: 14/14
- 40 focused install/deployment/React tests
- shell syntax and diff hygiene
- lint, formatting, all 23 TypeScript projects
- docs-reference and public-hygiene guards
- expanded Linux/macOS and Windows CI install smokes cover preserve + explicit override

This is a narrow mixed-deployment hardening follow-up to #1153 and #1154. #1143 remains untouched.