### PR TITLE
fix(agent): rotate split NATS generations

### DIFF
--- a/agent/crates/opengeni-agent/src/engine.rs
+++ b/agent/crates/opengeni-agent/src/engine.rs
@@ -39,7 +39,7 @@ use opengeni_agent_engine::registry::{
 use opengeni_agent_engine::retention::RetentionConfig;
 use opengeni_agent_engine::{Frame, HostCapacity, OpId};
 use opengeni_agent_platform::ContainedExec;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, Notify};
 use tracing::{info, warn};
 
 use crate::job::{run_job, JobCommand, JobConfig, JobEnd, JobExit, JobHooks, JobParams};
@@ -714,7 +714,7 @@ impl Engine {
 
     /// Detaches only jobs owned by one deployment/workspace link. Other links
     /// continue streaming uninterrupted when this transport reconnects.
-    pub fn detach_scope(&self, scope: &str) {
+    pub async fn detach_scope(&self, scope: &str) {
         let prefix = format!("{scope}:");
         let routes: Vec<mpsc::Sender<JobCommand>> = self
             .routes
@@ -724,8 +724,27 @@ impl Engine {
             .filter(|(op_id, _)| op_id.as_str().starts_with(&prefix))
             .map(|(_, sender)| sender.clone())
             .collect();
+        let mut completions = Vec::with_capacity(routes.len());
         for sender in routes {
-            let _ = sender.try_send(JobCommand::Detach);
+            let completed = Arc::new(Notify::new());
+            if sender
+                .send(JobCommand::Detach {
+                    completed: Some(completed.clone()),
+                })
+                .await
+                .is_ok()
+            {
+                completions.push((sender, completed));
+            }
+        }
+        // FIFO mailbox ordering makes each receipt a hard generation fence:
+        // every earlier Ack/Attach has been handled and Detach has disabled
+        // emission before a successor bulk lane may become visible.
+        for (sender, completed) in completions {
+            tokio::select! {
+                () = completed.notified() => {}
+                () = sender.closed() => {}
+            }
         }
     }
 
@@ -916,6 +935,166 @@ mod tests {
         let second = scoped_op_id("deployment-b", "call:0");
         assert_ne!(first, second);
         assert_eq!(first.as_str(), "deployment-a:call:0");
+    }
+
+    #[tokio::test]
+    async fn detach_scope_waits_through_a_full_mailbox_for_the_pump_receipt() {
+        let (engine, _dir) = test_engine(AdmissionConfig::default());
+        let op = scoped_op_id("deployment-a", "slow-pump");
+        let (sender, mut receiver) = mpsc::channel(1);
+        engine
+            .routes
+            .lock()
+            .expect("routes lock")
+            .insert(op, sender.clone());
+
+        // Fill the mailbox so detach_scope must wait for pump capacity before
+        // it can even enqueue the generation fence.
+        sender
+            .send(JobCommand::Ack {
+                generation: 1,
+                acked_seq: 0,
+                credit_bytes: 0,
+                final_ack: false,
+            })
+            .await
+            .expect("prefill mailbox");
+
+        let detach = {
+            let engine = engine.clone();
+            tokio::spawn(async move { engine.detach_scope("deployment-a").await })
+        };
+        tokio::task::yield_now().await;
+        assert!(
+            !detach.is_finished(),
+            "a full pump mailbox must hold the generation fence"
+        );
+
+        assert!(matches!(
+            receiver.recv().await,
+            Some(JobCommand::Ack { .. })
+        ));
+        let completed = match receiver.recv().await {
+            Some(JobCommand::Detach {
+                completed: Some(completed),
+            }) => completed,
+            other => panic!("expected receipt-bearing detach, got {other:?}"),
+        };
+        tokio::task::yield_now().await;
+        assert!(
+            !detach.is_finished(),
+            "enqueue alone is not proof that the pump applied detach"
+        );
+
+        completed.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(1), detach)
+            .await
+            .expect("detach scope completes after the pump receipt")
+            .expect("detach task did not panic");
+    }
+
+    #[tokio::test]
+    async fn detach_scope_accepts_route_closure_as_terminal_proof() {
+        let (engine, _dir) = test_engine(AdmissionConfig::default());
+        let op = scoped_op_id("deployment-a", "dead-pump");
+        let (sender, receiver) = mpsc::channel(1);
+        engine
+            .routes
+            .lock()
+            .expect("routes lock")
+            .insert(op, sender);
+        drop(receiver);
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            engine.detach_scope("deployment-a"),
+        )
+        .await
+        .expect("a dead pump cannot strand generation teardown");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn detached_active_job_cannot_emit_into_a_successor_lane_before_reattach() {
+        let (engine, _dir) = test_engine(AdmissionConfig::default());
+        let op = scoped_op_id("deployment-a", "streaming-op");
+        let ticket = engine
+            .admit(&op, JobClass::Heavy, "o")
+            .await
+            .expect("admit");
+
+        // Mirrors the supervisor's shared bulk-lane cell: each emission reads
+        // whichever generation sender is currently installed.
+        let lane: Arc<RwLock<Option<mpsc::UnboundedSender<Frame>>>> = Arc::new(RwLock::new(None));
+        let (first_tx, mut first_rx) = mpsc::unbounded_channel();
+        *lane.write().expect("lane lock") = Some(first_tx);
+        let emit_lane = lane.clone();
+        let outcome = engine.start_job(
+            &op,
+            ticket,
+            Vec::new(),
+            None,
+            false,
+            || {
+                Ok::<_, std::io::Error>(sh(
+                    "i=0; while [ $i -lt 200 ]; do printf '%08d' $i; i=$((i+1)); sleep 0.005; done",
+                ))
+            },
+            move |frame| {
+                if let Some(sender) = emit_lane.read().expect("lane lock").as_ref() {
+                    let _ = sender.send(frame);
+                }
+            },
+            |_| Vec::new(),
+            |_, _| {},
+        );
+        let StartOutcome::Started(started) = outcome else {
+            panic!("fresh op must start");
+        };
+        started
+            .mailbox
+            .send(JobCommand::Attach {
+                generation: 1,
+                from_seq: 0,
+                window_bytes: 1 << 20,
+            })
+            .await
+            .expect("initial attach");
+        let first = tokio::time::timeout(std::time::Duration::from_secs(2), first_rx.recv())
+            .await
+            .expect("first generation emits in time")
+            .expect("first lane remains open");
+
+        engine.detach_scope("deployment-a").await;
+        let (successor_tx, mut successor_rx) = mpsc::unbounded_channel();
+        *lane.write().expect("lane lock") = Some(successor_tx);
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), successor_rx.recv(),)
+                .await
+                .is_err(),
+            "a detached old pump must not emit through the successor lane"
+        );
+
+        started
+            .mailbox
+            .send(JobCommand::Attach {
+                generation: 2,
+                from_seq: first.seq,
+                window_bytes: 1 << 20,
+            })
+            .await
+            .expect("successor attach");
+        let replayed = tokio::time::timeout(std::time::Duration::from_secs(2), successor_rx.recv())
+            .await
+            .expect("reattached generation emits in time")
+            .expect("successor lane remains open");
+        assert!(
+            replayed.seq > first.seq,
+            "successor resumes strictly after the acknowledged floor"
+        );
+
+        engine.cancel(&op);
     }
 
     #[tokio::test]
@@ -1111,13 +1290,13 @@ mod tests {
             })
             .await;
         for _ in 0..200 {
-            if !engine.route_command(&op, JobCommand::Detach) {
+            if !engine.route_command(&op, JobCommand::Detach { completed: None }) {
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
         assert!(
-            !engine.route_command(&op, JobCommand::Detach),
+            !engine.route_command(&op, JobCommand::Detach { completed: None }),
             "route removed once the pump task ends"
         );
     }
@@ -1279,7 +1458,7 @@ mod tests {
             "ledger share returned at the terminal record"
         );
         assert!(
-            engine.route_command(&op, JobCommand::Detach),
+            engine.route_command(&op, JobCommand::Detach { completed: None }),
             "the pump still lingers (route alive) after the early release"
         );
         // Normal teardown still works.

--- a/agent/crates/opengeni-agent/src/job.rs
+++ b/agent/crates/opengeni-agent/src/job.rs
@@ -61,14 +61,14 @@ use opengeni_agent_engine::retention::{RetentionConfig, RetentionError, Retentio
 use opengeni_agent_engine::{Channel, Frame, FrameBody};
 use opengeni_agent_platform::ContainedExec;
 use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWriteExt as _};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Notify};
 use tokio::time::{Instant, MissedTickBehavior};
 use tracing::{debug, warn};
 
 /// A command delivered to a running (or lingering completed) job through its
 /// mailbox. The supervisor translates wire messages (`OpAck`/`OpAttach`/…)
 /// into these; the pump never sees the transport.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum JobCommand {
     /// A cumulative ack + absolute credit grant from the consumer
     /// (wire: `OpAck`).
@@ -96,7 +96,12 @@ pub enum JobCommand {
     },
     /// The transport is gone (connection loss). Sending stops; the op keeps
     /// running and retention keeps accumulating (op ⊥ connection).
-    Detach,
+    Detach {
+        /// Optional teardown barrier. The pump signals this only after the
+        /// detach has been applied, allowing a transport generation to prove
+        /// every prior sink is quiescent before exposing its successor lane.
+        completed: Option<Arc<Notify>>,
+    },
     /// Kill the job (wire: `OpCancel`). Terminates the process group and
     /// produces `Exit{cancelled}`. Idempotent; a no-op once terminal.
     Cancel,
@@ -593,7 +598,15 @@ impl Pump {
                 from_seq,
                 window_bytes,
             } => self.apply_attach(generation, from_seq, window_bytes),
-            JobCommand::Detach => self.flow.detach(),
+            JobCommand::Detach { completed } => {
+                self.flow.detach();
+                if let Some(completed) = completed {
+                    // `notify_one` stores a permit when the supervisor has not
+                    // registered its waiter yet, so the completion receipt
+                    // cannot be lost in the send→wait handoff.
+                    completed.notify_one();
+                }
+            }
             JobCommand::Cancel => {
                 // Idempotent; once the child is done the natural result stands
                 // (the registry answers a late OpCancel with AlreadyComplete).
@@ -1221,7 +1234,7 @@ mod tests {
             job.ack(1, acked, 16 * 1024).await;
             frames.push(frame);
         }
-        job.send(JobCommand::Detach).await;
+        job.send(JobCommand::Detach { completed: None }).await;
 
         // Reconnect as the next consumer generation from the ack floor; the
         // window between our last ack and the detach replays (dedup-checked).

--- a/agent/crates/opengeni-agent/src/ops.rs
+++ b/agent/crates/opengeni-agent/src/ops.rs
@@ -963,13 +963,17 @@ mod tests {
         );
         let op = scoped_op_id("default", "op-replay");
         for _ in 0..500 {
-            if !rig.engine.route_command(&op, JobCommand::Detach) {
+            if !rig
+                .engine
+                .route_command(&op, JobCommand::Detach { completed: None })
+            {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         assert!(
-            !rig.engine.route_command(&op, JobCommand::Detach),
+            !rig.engine
+                .route_command(&op, JobCommand::Detach { completed: None }),
             "pump ended after the final ack"
         );
         assert!(matches!(

--- a/agent/crates/opengeni-agent/src/supervisor.rs
+++ b/agent/crates/opengeni-agent/src/supervisor.rs
@@ -162,6 +162,40 @@ impl ShutdownSignal {
     }
 }
 
+/// A level-triggered signal that one NATS client in the current connection
+/// generation lost its transport.
+///
+/// async-nats may reconnect a client internally before a subscription or publish
+/// call surfaces the loss. That is not sufficient for this supervisor: control
+/// and bulk are a single logical generation, so either lane disconnecting must
+/// tear down both lanes and let the outer loop establish a fresh pair. The
+/// latched flag closes the same missed-wakeup race as [`ShutdownSignal`].
+#[derive(Clone, Default)]
+struct TransportLossSignal {
+    lost: Arc<AtomicBool>,
+    notify: Arc<Notify>,
+}
+
+impl TransportLossSignal {
+    fn request(&self) {
+        self.lost.store(true, Ordering::Release);
+        self.notify.notify_waiters();
+    }
+
+    fn is_requested(&self) -> bool {
+        self.lost.load(Ordering::Acquire)
+    }
+
+    async fn notified(&self) {
+        self.notify.notified().await;
+    }
+}
+
+struct ConnectedNats {
+    client: async_nats::Client,
+    transport_lost: TransportLossSignal,
+}
+
 /// Public, immutable definition of one independently authenticated connection.
 /// The platform carries that connection's relay registrar while host-operation
 /// containment is shared underneath (for `NativePlatform`, the cgroup manager is
@@ -502,8 +536,11 @@ impl<P: Platform + 'static> Supervisor<P> {
             () = self.link_stop_notified(link) => return ConnectionOutcome::CleanShutdown,
             result = self.connect(link) => result,
         };
-        let client = match connect {
-            Ok(client) => client,
+        let ConnectedNats {
+            client,
+            transport_lost: control_transport_lost,
+        } = match connect {
+            Ok(connection) => connection,
             Err(e @ SupervisorError::Authentication(_)) => {
                 // A CLEAR auth denial (not a panic): log it loudly so the operator
                 // knows a re-enroll may be needed, then treat it as a (slow) retry —
@@ -547,13 +584,17 @@ impl<P: Platform + 'static> Supervisor<P> {
         // The BULK connection: op frames publish here so a saturated stream
         // can never head-of-line-block control liveness (invariant #4). Its
         // loss is a generation loss (conservative: detach + reconnect).
-        let bulk_client = match self.connect(link).await {
-            Ok(client) => client,
+        let ConnectedNats {
+            client: bulk_client,
+            transport_lost: bulk_transport_lost,
+        } = match self.connect(link).await {
+            Ok(connection) => connection,
             Err(e) => return ConnectionOutcome::Disconnected(format!("bulk dial failed: {e}")),
         };
         let (bulk_tx, mut bulk_rx) =
             tokio::sync::mpsc::channel::<(String, Vec<u8>)>(BULK_CHANNEL_DEPTH);
         let publisher_engine = self.engine.clone();
+        let publisher_transport_lost = bulk_transport_lost.clone();
         let publisher = tokio::spawn(async move {
             while let Some((subject, bytes)) = bulk_rx.recv().await {
                 if let Err(error) = bulk_client.publish(subject, bytes.into()).await {
@@ -562,6 +603,8 @@ impl<P: Platform + 'static> Supervisor<P> {
                     // drop is RECORDED (FAILURE-VISIBILITY healed-fault rule).
                     publisher_engine.note_frame_dropped();
                     warn!(%error, "op frame publish failed (replay heals)");
+                    publisher_transport_lost.request();
+                    break;
                 }
             }
         });
@@ -574,13 +617,25 @@ impl<P: Platform + 'static> Supervisor<P> {
             .set_link_max_payload(&link.connection_id, client.server_info().max_payload);
 
         let outcome = self
-            .serve_connection_generation(link, &client, subscription, ack_subscription)
+            .serve_connection_generation(
+                link,
+                &client,
+                subscription,
+                ack_subscription,
+                control_transport_lost,
+                bulk_transport_lost,
+            )
             .await;
 
         // Tear the bulk lane down with the generation: hooks see None and
         // drop frames until the next generation re-attaches consumers.
         *link.bulk_tx.write().expect("bulk lock") = None;
         publisher.abort();
+        if let Err(error) = publisher.await {
+            if !error.is_cancelled() {
+                warn!(%error, "bulk publisher task failed during generation teardown");
+            }
+        }
         outcome
     }
 
@@ -593,6 +648,8 @@ impl<P: Platform + 'static> Supervisor<P> {
         client: &async_nats::Client,
         mut subscription: async_nats::Subscriber,
         mut ack_subscription: async_nats::Subscriber,
+        control_transport_lost: TransportLossSignal,
+        bulk_transport_lost: TransportLossSignal,
     ) -> ConnectionOutcome {
         let mut heartbeat = tokio::time::interval(DEFAULT_HEARTBEAT);
         heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -608,12 +665,30 @@ impl<P: Platform + 'static> Supervisor<P> {
             if self.link_stop_requested(link) {
                 break ConnectionOutcome::CleanShutdown;
             }
+            if control_transport_lost.is_requested() {
+                break ConnectionOutcome::Disconnected(
+                    "control transport disconnected".to_string(),
+                );
+            }
+            if bulk_transport_lost.is_requested() {
+                break ConnectionOutcome::Disconnected("bulk transport disconnected".to_string());
+            }
             tokio::select! {
                 biased;
                 // Stop accepting work immediately. Accepted work is cancelled below
                 // before we announce going-offline and return.
                 () = self.link_stop_notified(link) => {
                     break ConnectionOutcome::CleanShutdown;
+                }
+                () = control_transport_lost.notified() => {
+                    break ConnectionOutcome::Disconnected(
+                        "control transport disconnected".to_string(),
+                    );
+                }
+                () = bulk_transport_lost.notified() => {
+                    break ConnectionOutcome::Disconnected(
+                        "bulk transport disconnected".to_string(),
+                    );
                 }
                 // Heartbeat is deliberately ahead of inbound work in this biased
                 // select. A ready subscription can never starve the liveness tick.
@@ -686,7 +761,10 @@ impl<P: Platform + 'static> Supervisor<P> {
 
         // The transport is gone: every live op detaches and keeps running
         // (op ⊥ connection — the server re-attaches per op after reconnect).
-        self.engine.detach_scope(&link.connection_id);
+        // Await every pump's FIFO completion receipt before returning this
+        // generation: a successor bulk lane must not become visible while an
+        // old pump can still emit through the shared sender cell.
+        self.engine.detach_scope(&link.connection_id).await;
         self.engine.clear_link_max_payload(&link.connection_id);
 
         if matches!(&outcome, ConnectionOutcome::CleanShutdown) {
@@ -909,10 +987,7 @@ impl<P: Platform + 'static> Supervisor<P> {
     /// as a connect error → [`SupervisorError::Connect`], which the supervise loop
     /// treats as a transient disconnect and backs off + retries with the SAME
     /// (possibly rotated, on re-enroll) bearer — never a panic.
-    async fn connect(
-        &self,
-        link: &WorkspaceLink<P>,
-    ) -> Result<async_nats::Client, SupervisorError> {
+    async fn connect(&self, link: &WorkspaceLink<P>) -> Result<ConnectedNats, SupervisorError> {
         if link.creds.nats_bearer.is_empty() {
             // No bearer means the control plane never minted one (an enrollment from
             // before the credential plane was configured). Surface a clear, typed
@@ -922,6 +997,8 @@ impl<P: Platform + 'static> Supervisor<P> {
             ));
         }
         let connection_id = link.connection_id.clone();
+        let transport_lost = TransportLossSignal::default();
+        let event_transport_lost = transport_lost.clone();
         let opts = async_nats::ConnectOptions::new()
             .token(link.creds.nats_bearer.clone())
             .name(format!("opengeni-agent/{}", link.creds.agent_id))
@@ -929,10 +1006,12 @@ impl<P: Platform + 'static> Supervisor<P> {
             .max_reconnects(Some(1))
             .event_callback(move |event| {
                 let connection_id = connection_id.clone();
+                let transport_lost = event_transport_lost.clone();
                 async move {
                     match event {
                         async_nats::Event::Disconnected => {
                             warn!(%connection_id, "nats event: disconnected");
+                            transport_lost.request();
                         }
                         async_nats::Event::Connected => {
                             info!(%connection_id, "nats event: connected");
@@ -948,7 +1027,7 @@ impl<P: Platform + 'static> Supervisor<P> {
                 }
             });
 
-        async_nats::connect_with_options(link.creds.nats_urls.clone(), opts)
+        let client = async_nats::connect_with_options(link.creds.nats_urls.clone(), opts)
             .await
             .map_err(|e| {
                 if is_authentication_error(&e) {
@@ -956,7 +1035,11 @@ impl<P: Platform + 'static> Supervisor<P> {
                 } else {
                     SupervisorError::Connect(e.to_string())
                 }
-            })
+            })?;
+        Ok(ConnectedNats {
+            client,
+            transport_lost,
+        })
     }
 
     /// Publishes the connect [`Hello`] on the events subject and folds the
@@ -1466,6 +1549,202 @@ mod tests {
         assert!(signal.is_requested(), "request latches permanently");
     }
 
+    #[tokio::test]
+    async fn transport_loss_signal_latches_and_wakes_registered_waiters() {
+        let signal = TransportLossSignal::default();
+        assert!(!signal.is_requested(), "transport starts healthy");
+
+        let waiter = {
+            let signal = signal.clone();
+            tokio::spawn(async move { signal.notified().await })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        signal.request();
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("a registered transport waiter wakes")
+            .expect("waiter task did not panic");
+
+        assert!(
+            signal.is_requested(),
+            "transport loss remains visible to later loop-top checks"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn connected_nats_latches_transport_loss_after_server_exit() {
+        use opengeni_agent_platform::NativePlatform;
+
+        let Some(nats_bin) = it::find_nats_server() else {
+            eprintln!(
+                "SKIP connected_nats_latches_transport_loss_after_server_exit: no nats-server"
+            );
+            return;
+        };
+        let port = it::free_local_port();
+        let mut server = it::NatsServerGuard::spawn(&nats_bin, port);
+        let url = format!("nats://127.0.0.1:{port}");
+        let credentials = it::test_credentials(&url);
+        let platform = Arc::new(NativePlatform::new());
+        let link = WorkspaceLink::from_definition(SupervisorLink::new(
+            "transport-loss-test",
+            platform.clone(),
+            credentials.clone(),
+        ));
+        let supervisor = Supervisor::new(platform, credentials, "test-0.0.0");
+        let ConnectedNats {
+            client: _client,
+            transport_lost,
+        } = supervisor
+            .connect(&link)
+            .await
+            .expect("connect to local NATS");
+
+        server.stop();
+        if !transport_lost.is_requested() {
+            tokio::time::timeout(Duration::from_secs(5), transport_lost.notified())
+                .await
+                .expect("disconnect event should signal generation loss");
+        }
+        assert!(
+            transport_lost.is_requested(),
+            "a real NATS disconnect must remain latched"
+        );
+    }
+
+    /// A dead bulk lane must end the whole logical connection generation even
+    /// while control subscriptions and heartbeats remain healthy. This is the
+    /// split-generation regression: without the explicit signal branch the
+    /// generation stayed online indefinitely and every op-frame publish failed on
+    /// a closed channel.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bulk_transport_loss_ends_the_connection_generation() {
+        use opengeni_agent_platform::NativePlatform;
+
+        let Some(nats_bin) = it::find_nats_server() else {
+            eprintln!("SKIP bulk_transport_loss_ends_the_connection_generation: no nats-server");
+            return;
+        };
+        let port = it::free_local_port();
+        let _server = it::NatsServerGuard::spawn(&nats_bin, port);
+        let url = format!("nats://127.0.0.1:{port}");
+        let credentials = it::test_credentials(&url);
+        let platform = Arc::new(NativePlatform::new());
+        let link = WorkspaceLink::from_definition(SupervisorLink::new(
+            "bulk-loss-test",
+            platform.clone(),
+            credentials.clone(),
+        ));
+        let supervisor = Supervisor::new(platform, credentials, "test-0.0.0");
+        let ConnectedNats {
+            client: control_client,
+            transport_lost: control_transport_lost,
+        } = supervisor
+            .connect(&link)
+            .await
+            .expect("connect control lane");
+        let ConnectedNats {
+            client: bulk_client,
+            transport_lost: bulk_transport_lost,
+        } = supervisor.connect(&link).await.expect("connect bulk lane");
+        let subscription = control_client
+            .subscribe("agent.hx-test-ws.hx-test-agent.rpc".to_string())
+            .await
+            .expect("subscribe rpc");
+        let ack_subscription = control_client
+            .subscribe("agent.hx-test-ws.hx-test-agent.ack".to_string())
+            .await
+            .expect("subscribe ack");
+
+        let generation = supervisor.serve_connection_generation(
+            &link,
+            &control_client,
+            subscription,
+            ack_subscription,
+            control_transport_lost,
+            bulk_transport_lost,
+        );
+        let sever_bulk = async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            bulk_client
+                .force_reconnect()
+                .await
+                .expect("force only the bulk client to disconnect");
+        };
+        let (outcome, ()) = tokio::join!(generation, sever_bulk);
+
+        assert!(matches!(
+            outcome,
+            ConnectionOutcome::Disconnected(reason) if reason == "bulk transport disconnected"
+        ));
+    }
+
+    /// The symmetric half of the generation fence: a control-only disconnect
+    /// also ends the pair while the independently connected bulk client stays
+    /// alive.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn control_transport_loss_ends_the_connection_generation() {
+        use opengeni_agent_platform::NativePlatform;
+
+        let Some(nats_bin) = it::find_nats_server() else {
+            eprintln!("SKIP control_transport_loss_ends_the_connection_generation: no nats-server");
+            return;
+        };
+        let port = it::free_local_port();
+        let _server = it::NatsServerGuard::spawn(&nats_bin, port);
+        let url = format!("nats://127.0.0.1:{port}");
+        let credentials = it::test_credentials(&url);
+        let platform = Arc::new(NativePlatform::new());
+        let link = WorkspaceLink::from_definition(SupervisorLink::new(
+            "control-loss-test",
+            platform.clone(),
+            credentials.clone(),
+        ));
+        let supervisor = Supervisor::new(platform, credentials, "test-0.0.0");
+        let ConnectedNats {
+            client: control_client,
+            transport_lost: control_transport_lost,
+        } = supervisor
+            .connect(&link)
+            .await
+            .expect("connect control lane");
+        let ConnectedNats {
+            client: _bulk_client,
+            transport_lost: bulk_transport_lost,
+        } = supervisor.connect(&link).await.expect("connect bulk lane");
+        let subscription = control_client
+            .subscribe("agent.hx-test-ws.hx-test-agent.rpc".to_string())
+            .await
+            .expect("subscribe rpc");
+        let ack_subscription = control_client
+            .subscribe("agent.hx-test-ws.hx-test-agent.ack".to_string())
+            .await
+            .expect("subscribe ack");
+
+        let control_to_sever = control_client.clone();
+        let generation = supervisor.serve_connection_generation(
+            &link,
+            &control_client,
+            subscription,
+            ack_subscription,
+            control_transport_lost,
+            bulk_transport_lost,
+        );
+        let sever_control = async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            control_to_sever
+                .force_reconnect()
+                .await
+                .expect("force only the control client to disconnect");
+        };
+        let (outcome, ()) = tokio::join!(generation, sever_control);
+
+        assert!(matches!(
+            outcome,
+            ConnectionOutcome::Disconnected(reason) if reason == "control transport disconnected"
+        ));
+    }
+
     /// End-to-end regression test for the going-offline-on-clean-shutdown bug: a
     /// real supervisor over a real local nats-server must publish a `GoingOffline`
     /// event when a clean shutdown is requested DURING an active connection.
@@ -1846,12 +2125,16 @@ mod tests {
                     .expect("spawn nats-server");
                 Self(child)
             }
+
+            pub fn stop(&mut self) {
+                let _ = self.0.kill();
+                let _ = self.0.wait();
+            }
         }
 
         impl Drop for NatsServerGuard {
             fn drop(&mut self) {
-                let _ = self.0.kill();
-                let _ = self.0.wait();
+                self.stop();
             }
         }
 


### PR DESCRIPTION
## Summary

- Treat either control or bulk NATS transport loss as loss of the entire Connected Machine connection generation.
- Latch async-nats disconnect events so an internal reconnect cannot leave one lane stale while the other continues serving heartbeats.
- Escalate the first bulk publish failure into the same generation-rotation path instead of repeatedly publishing into a closed channel.
- Preserve the existing op-stream contract: streamed host work detaches and re-attaches across the reconnect rather than being replayed or killed.

## Problem

The control and bulk clients form one logical generation, but only control subscription/heartbeat failure previously ended that generation. If the bulk client became unusable while the control client internally reconnected, the machine could continue reporting healthy liveness while op-frame publication failed indefinitely. That also produced a closed-channel warning storm and prevented retained output from healing through a fresh attachment.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p opengeni-agent` (165 passed)
- `cargo test --workspace --all-features`
- `cargo build --release --workspace`

Regression coverage includes a real local NATS server exit, level-triggered disconnect signaling, and bulk-lane loss ending an otherwise healthy control generation.
