### PR TITLE
chore: reissue version release evidence

### DIFF
--- a/.changeset/calm-session-chrome-tokens.md
+++ b/.changeset/calm-session-chrome-tokens.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Keep derived design tokens available through both the compiled stylesheet and the Tailwind source bridge while sharing compact public fallbacks, so SessionChrome retains its complete default presentation without duplicating color formulas in application bundles.

--- a/.changeset/clean-sandbox-manifest-state.md
+++ b/.changeset/clean-sandbox-manifest-state.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Persist sandbox session state without the redundant hydrated provider manifest when the canonical serialized manifest is already present, so durable turn reconciliation remains JSON-safe.

--- a/.changeset/strong-machines-wait.md
+++ b/.changeset/strong-machines-wait.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/config": patch
+"@opengeni/runtime": patch
+"@opengeni/core": patch
+"@opengeni/api-router": patch
+"@opengeni/worker-bundle": patch
+---
+
+Make Connected Machine command duration unbounded by default over replayable op-stream execution, preserve explicit positive deadlines for constrained deployments, wire and finalize streaming across direct and swapped machine routes, remove the generated service's aggregate memory throttle while retaining accounting and OOM isolation, and bound transient reordering memory by bytes without limiting command resources or output.

--- a/.changeset/wise-machines-connect.md
+++ b/.changeset/wise-machines-connect.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/core": patch
+"@opengeni/react": patch
+"@opengeni/config": patch
+---
+
+Let one Connected Machine agent retain and serve independent connections to multiple OpenGeni workspaces and deployments, with additive connection UX and connection-scoped runtime isolation.

--- a/apps/api/CHANGELOG.md
+++ b/apps/api/CHANGELOG.md
@@ -1,22 +1,5 @@
 # @opengeni/api-router
 
-## 0.22.9
-
-### Patch Changes
-
-- b43432e: Make Connected Machine command duration unbounded by default over replayable op-stream execution, preserve explicit positive deadlines for constrained deployments, wire and finalize streaming across direct and swapped machine routes, remove the generated service's aggregate memory throttle while retaining accounting and OOM isolation, and bound transient reordering memory by bytes without limiting command resources or output.
-- Updated dependencies [57ea10e]
-- Updated dependencies [b43432e]
-- Updated dependencies [f92e953]
-  - @opengeni/runtime@0.18.23
-  - @opengeni/config@0.11.6
-  - @opengeni/core@0.21.9
-  - @opengeni/db@0.28.8
-  - @opengeni/documents@0.5.17
-  - @opengeni/github@0.4.37
-  - @opengeni/storage@0.2.74
-  - @opengeni/events@0.3.87
-
 ## 0.22.8
 
 ### Patch Changes

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/api-router",
-  "version": "0.22.9",
+  "version": "0.22.8",
   "description": "OpenGeni HTTP surface: the Hono adapter/router (createApp), routes, MCP HTTP transport, and HTTP access adapters over @opengeni/core. An engine-distribution surface — its runtime closure includes engine-internal packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/apps/worker/CHANGELOG.md
+++ b/apps/worker/CHANGELOG.md
@@ -1,22 +1,5 @@
 # @opengeni/worker-bundle
 
-## 0.16.28
-
-### Patch Changes
-
-- b43432e: Make Connected Machine command duration unbounded by default over replayable op-stream execution, preserve explicit positive deadlines for constrained deployments, wire and finalize streaming across direct and swapped machine routes, remove the generated service's aggregate memory throttle while retaining accounting and OOM isolation, and bound transient reordering memory by bytes without limiting command resources or output.
-- Updated dependencies [57ea10e]
-- Updated dependencies [b43432e]
-- Updated dependencies [f92e953]
-  - @opengeni/runtime@0.18.23
-  - @opengeni/config@0.11.6
-  - @opengeni/core@0.21.9
-  - @opengeni/db@0.28.8
-  - @opengeni/documents@0.5.17
-  - @opengeni/github@0.4.37
-  - @opengeni/storage@0.2.74
-  - @opengeni/events@0.3.87
-
 ## 0.16.27
 
 ### Patch Changes

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/worker-bundle",
-  "version": "0.16.28",
+  "version": "0.16.27",
   "description": "OpenGeni worker entry and reusable embedded lifecycle, shipped with a release-coherent pre-bundled Temporal workflow artifact.",
   "license": "Apache-2.0",
   "repository": {

--- a/examples/northstar-support/CHANGELOG.md
+++ b/examples/northstar-support/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @opengeni/example-northstar-support
 
-## 0.0.82
-
-### Patch Changes
-
-- Updated dependencies [bf68b01]
-- Updated dependencies [f92e953]
-  - @opengeni/react@0.47.1
-
 ## 0.0.81
 
 ### Patch Changes

--- a/examples/northstar-support/package.json
+++ b/examples/northstar-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/example-northstar-support",
-  "version": "0.0.82",
+  "version": "0.0.81",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @opengeni/config
 
-## 0.11.6
-
-### Patch Changes
-
-- b43432e: Make Connected Machine command duration unbounded by default over replayable op-stream execution, preserve explicit positive deadlines for constrained deployments, wire and finalize streaming across direct and swapped machine routes, remove the generated service's aggregate memory throttle while retaining accounting and OOM isolation, and bound transient reordering memory by bytes without limiting command resources or output.
-- f92e953: Let one Connected Machine agent retain and serve independent connections to multiple OpenGeni workspaces and deployments, with additive connection UX and connection-scoped runtime isolation.
-
 ## 0.11.5
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/config",
-  "version": "0.11.6",
+  "version": "0.11.5",
   "description": "OpenGeni runtime configuration: settings resolution, deployment knobs, and config validation shared across the server packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,21 +1,5 @@
 # @opengeni/core
 
-## 0.21.9
-
-### Patch Changes
-
-- b43432e: Make Connected Machine command duration unbounded by default over replayable op-stream execution, preserve explicit positive deadlines for constrained deployments, wire and finalize streaming across direct and swapped machine routes, remove the generated service's aggregate memory throttle while retaining accounting and OOM isolation, and bound transient reordering memory by bytes without limiting command resources or output.
-- f92e953: Let one Connected Machine agent retain and serve independent connections to multiple OpenGeni workspaces and deployments, with additive connection UX and connection-scoped runtime isolation.
-- Updated dependencies [57ea10e]
-- Updated dependencies [b43432e]
-- Updated dependencies [f92e953]
-  - @opengeni/runtime@0.18.23
-  - @opengeni/config@0.11.6
-  - @opengeni/db@0.28.8
-  - @opengeni/documents@0.5.17
-  - @opengeni/storage@0.2.74
-  - @opengeni/events@0.3.87
-
 ## 0.21.8
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/core",
-  "version": "0.21.9",
+  "version": "0.21.8",
   "description": "OpenGeni framework-agnostic core: the domain, access, and billing layers (neutral access, off-HTTP V2 surface). Behavior-preserving extraction from apps/api — keeps Hono's HTTPException for error throwing (typed-errors cleanup deferred).",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @opengeni/db
 
-## 0.28.8
-
-### Patch Changes
-
-- Updated dependencies [b43432e]
-- Updated dependencies [f92e953]
-  - @opengeni/config@0.11.6
-
 ## 0.28.7
 
 ### Patch Changes

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/db",
-  "version": "0.28.8",
+  "version": "0.28.7",
   "description": "OpenGeni persistence: Drizzle schema, RLS-scoped query layer, the SQL migration runner, and role provisioning.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/documents/CHANGELOG.md
+++ b/packages/documents/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @opengeni/documents
 
-## 0.5.17
-
-### Patch Changes
-
-- Updated dependencies [b43432e]
-- Updated dependencies [f92e953]
-  - @opengeni/config@0.11.6
-  - @opengeni/db@0.28.8
-  - @opengeni/storage@0.2.74
-
 ## 0.5.16
 
 ### Patch Changes

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/documents",
-  "version": "0.5.17",
+  "version": "0.5.16",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @opengeni/events
 
-## 0.3.87
-
-### Patch Changes
-
-- @opengeni/db@0.28.8
-
 ## 0.3.86
 
 ### Patch Changes

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/events",
-  "version": "0.3.87",
+  "version": "0.3.86",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/github/CHANGELOG.md
+++ b/packages/github/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @opengeni/github
 
-## 0.4.37
-
-### Patch Changes
-
-- Updated dependencies [b43432e]
-- Updated dependencies [f92e953]
-  - @opengeni/config@0.11.6
-
 ## 0.4.36
 
 ### Patch Changes

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/github",
-  "version": "0.4.37",
+  "version": "0.4.36",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @opengeni/react
 
-## 0.47.1
-
-### Patch Changes
-
-- bf68b01: Keep derived design tokens available through both the compiled stylesheet and the Tailwind source bridge while sharing compact public fallbacks, so SessionChrome retains its complete default presentation without duplicating color formulas in application bundles.
-- f92e953: Let one Connected Machine agent retain and serve independent connections to multiple OpenGeni workspaces and deployments, with additive connection UX and connection-scoped runtime isolation.
-
 ## 0.47.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/react",
-  "version": "0.47.1",
+  "version": "0.47.0",
   "description": "React hooks and styled components for OpenGeni: live session streaming, chat composer, message timeline, session status, and fleet views — token-themed (CSS variables), dark-first, built on Tailwind v4 + Radix + Motion.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @opengeni/runtime
 
-## 0.18.23
-
-### Patch Changes
-
-- 57ea10e: Persist sandbox session state without the redundant hydrated provider manifest when the canonical serialized manifest is already present, so durable turn reconciliation remains JSON-safe.
-- b43432e: Make Connected Machine command duration unbounded by default over replayable op-stream execution, preserve explicit positive deadlines for constrained deployments, wire and finalize streaming across direct and swapped machine routes, remove the generated service's aggregate memory throttle while retaining accounting and OOM isolation, and bound transient reordering memory by bytes without limiting command resources or output.
-- Updated dependencies [b43432e]
-- Updated dependencies [f92e953]
-  - @opengeni/config@0.11.6
-
 ## 0.18.22
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/runtime",
-  "version": "0.18.23",
+  "version": "0.18.22",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/storage/CHANGELOG.md
+++ b/packages/storage/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @opengeni/storage
 
-## 0.2.74
-
-### Patch Changes
-
-- Updated dependencies [b43432e]
-- Updated dependencies [f92e953]
-  - @opengeni/config@0.11.6
-
 ## 0.2.73
 
 ### Patch Changes

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/storage",
-  "version": "0.2.74",
+  "version": "0.2.73",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Restore the pending changesets and pre-version package state byte-for-byte so the automated Version PR can be regenerated with its required exact-head release-review receipt recorded before merge.

This is a release-provenance repair only: the resulting tree exactly matches `57ea10eadbaea86a34434f07644f397b59be8328`; no runtime source or package content changes.