### PR TITLE
fix(agent): make direct release fallback installable

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -209,7 +209,13 @@ jobs:
           rcodesign sign --for-notarization --p12-file /tmp/cert.p12 --p12-password "$APPLE_CERT_PASSWORD" \
             --code-signature-flags runtime "${{ matrix.asset }}"
           echo "$APPLE_ASC_KEY" > /tmp/asc.json
-          rcodesign notary-submit --api-key-path /tmp/asc.json --wait "${{ matrix.asset }}"
+          # Apple's notary service accepts distribution containers, not a raw
+          # Mach-O. Submit a temporary ZIP containing the exact signed binary;
+          # the published binary remains byte-for-byte the notarized payload.
+          NOTARY_ARCHIVE="${{ matrix.asset }}.notary.zip"
+          trap 'rm -f /tmp/cert.p12 /tmp/asc.json "$NOTARY_ARCHIVE"' EXIT
+          ditto -c -k --keepParent "${{ matrix.asset }}" "$NOTARY_ARCHIVE"
+          rcodesign notary-submit --api-key-path /tmp/asc.json --wait "$NOTARY_ARCHIVE"
 
       - name: macOS unsigned note (no creds)
         if: matrix.kind == 'macos' && steps.creds.outputs.has_macos != 'true'

--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1599,7 +1599,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opengeni-agent"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-macos-ffi"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "block2",
  "dispatch2",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-platform"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "command-group",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-proto"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "prost",
  "prost-build",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-stream"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-update"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "blake3",
  "hex",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-relay"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "axum",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 # we lean on clippy::pedantic at the workspace level and silence only the few
 # lints that fight generated code or add no value here.
 [workspace.package]
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"

--- a/agent/README.md
+++ b/agent/README.md
@@ -98,9 +98,12 @@ An installation upgraded from the old single-connection file keeps that link
 online immediately. Because the old file did not record its deployment URL,
 `connections` labels the migrated origin unverified; running the exact
 deployment's connect command once confirms the origin and replaces only that
-legacy record. Self-update is binary-wide: matching per-connection channels are
-used automatically, while mixed `stable`/`beta` links require an explicit
-`opengeni-agent update --channel …` choice instead of silently picking one.
+legacy record. An unverified URL hint is never used as an update source; the
+signed public channel (or an explicit `update --base-url …`) remains the safe
+fallback until reconnect confirms it. Self-update is binary-wide: matching
+per-connection channels are used automatically, while mixed `stable`/`beta`
+links require an explicit `opengeni-agent update --channel …` choice instead of
+silently picking one.
 
 ## Wire protocol — single source of truth
 

--- a/agent/crates/opengeni-agent/src/update.rs
+++ b/agent/crates/opengeni-agent/src/update.rs
@@ -168,6 +168,14 @@ fn resolve_update_bases(explicit: Option<&str>, connections: &[StoredConnection]
     }
     let bases: BTreeSet<_> = connections
         .iter()
+        // A pre-multi-connection credentials file did not persist its control-
+        // plane origin. `load_connections` keeps the caller/default URL only as
+        // a visibly unverified hint so the runtime transport remains usable.
+        // Never turn that hint into update authority: on a private deployment it
+        // is commonly the public default and would query the wrong server. The
+        // public signed channel remains the safe fallback until one explicit
+        // reconnect confirms the deployment origin.
+        .filter(|connection| !connection.legacy_origin)
         .map(|connection| connection.api_url.trim_end_matches('/').to_string())
         .collect();
     if bases.is_empty() {
@@ -267,6 +275,22 @@ mod tests {
         assert_eq!(
             resolve_update_bases(None, &[]),
             vec![DEFAULT_BASE_URL.to_string()]
+        );
+    }
+
+    #[test]
+    fn unverified_legacy_origin_is_never_an_update_source() {
+        let mut legacy = connection("stable");
+        legacy.api_url = "https://possibly-wrong.example".to_string();
+        legacy.legacy_origin = true;
+
+        assert_eq!(
+            resolve_update_bases(None, &[legacy.clone()]),
+            vec![DEFAULT_BASE_URL.to_string()]
+        );
+        assert_eq!(
+            resolve_update_bases(Some("https://operator.example/"), &[legacy]),
+            vec!["https://operator.example".to_string()]
         );
     }
 }

--- a/agent/install/install.ps1
+++ b/agent/install/install.ps1
@@ -101,8 +101,15 @@ function Get-Asset {
 }
 
 function Get-AssetUrl($name) {
-  if ($Version -eq 'latest') { return "$BaseUrl/agent/latest/$name" }
-  return "$BaseUrl/agent/v$Version/$name"
+  $base = $BaseUrl.TrimEnd('/')
+  # A pinned GitHub Release URL is already the asset directory. Keep the normal
+  # edge layout everywhere else without duplicating it on the documented
+  # direct-release fallback.
+  if ($Version -ne 'latest' -and $base.EndsWith("/releases/download/agent-v$Version")) {
+    return "$base/$name"
+  }
+  if ($Version -eq 'latest') { return "$base/agent/latest/$name" }
+  return "$base/agent/v$Version/$name"
 }
 
 function Invoke-Download($url, $out) {

--- a/agent/install/install.sh
+++ b/agent/install/install.sh
@@ -349,10 +349,22 @@ b64decode() {
 # edge's latest-pointer.
 asset_url() {
   _name="$1"
+  _base="${BASE_URL%/}"
+  # A pinned GitHub Release URL is already the asset directory. Keep the normal
+  # edge layout for every other base URL, but do not append it a second time to
+  # the documented direct-release fallback.
+  if [ "$VERSION" != "latest" ]; then
+    case "$_base" in
+      */releases/download/agent-v"$VERSION")
+        echo "$_base/$_name"
+        return
+        ;;
+    esac
+  fi
   if [ "$VERSION" = "latest" ]; then
-    echo "$BASE_URL/agent/latest/$_name"
+    echo "$_base/agent/latest/$_name"
   else
-    echo "$BASE_URL/agent/v$VERSION/$_name"
+    echo "$_base/agent/v$VERSION/$_name"
   fi
 }
 

--- a/agent/install/test/ci-install-smoke.ps1
+++ b/agent/install/test/ci-install-smoke.ps1
@@ -37,6 +37,27 @@ try {
   }
   Write-Host "install-smoke OK: verified + installed $asset"
 
+  # A pinned GitHub Release URL is already the asset directory. Exercise the
+  # documented fallback shape so the installer cannot silently append the edge
+  # /agent/v<version> path a second time.
+  $releaseVersion = (& $built --version).Split()[-1]
+  $direct = Join-Path $work "github\releases\download\agent-v$releaseVersion"
+  New-Item -ItemType Directory -Path $direct -Force | Out-Null
+  Copy-Item (Join-Path $mock $asset) $direct
+  Copy-Item (Join-Path $mock "$asset.sha256") $direct
+  Copy-Item (Join-Path $mock "$asset.minisig") $direct
+  $env:OPENGENI_INSTALL_BASE_URL = "file://$($direct -replace '\\','/')"
+  $env:OPENGENI_AGENT_VERSION = $releaseVersion
+  $env:OPENGENI_INSTALL_DIR = Join-Path $work 'direct-bin'
+  & pwsh -File $script
+  $directAgent = Join-Path $env:OPENGENI_INSTALL_DIR 'opengeni-agent.exe'
+  if (-not (Test-Path $directAgent) -or (& $directAgent --version) -ne (& $built --version)) {
+    throw "direct GitHub Release fallback installed the wrong agent"
+  }
+  Remove-Item Env:OPENGENI_AGENT_VERSION -ErrorAction SilentlyContinue
+  $env:OPENGENI_INSTALL_BASE_URL = "file://$($work -replace '\\','/')/mock"
+  Write-Host "install-smoke OK: direct GitHub Release fallback verified + installed"
+
   # Compile a tiny executable that reports a future version, place it at the
   # shared install path, and prove a lagging deployment cannot replace it unless
   # the operator explicitly opts into a downgrade.

--- a/agent/install/test/ci-install-smoke.sh
+++ b/agent/install/test/ci-install-smoke.sh
@@ -75,6 +75,25 @@ else
 fi
 echo "install-smoke OK: verified + installed $asset"
 
+# The documented direct GitHub Release fallback is already an asset directory,
+# not an edge origin. Prove its pinned-version URL shape downloads the same
+# verified artifact without appending /agent/v<version> a second time.
+release_version="$("$built" --version | awk 'NR == 1 { print $NF }')"
+direct="$work/github/releases/download/agent-v$release_version"
+mkdir -p "$direct"
+cp "$mock/$asset" "$mock/$asset.sha256" "$mock/$asset.minisig" "$direct/"
+OPENGENI_INSTALL_BASE_URL="file://$direct" \
+OPENGENI_AGENT_VERSION="$release_version" \
+OPENGENI_INSTALL_DIR="$work/direct-bin" \
+OPENGENI_NO_SERVICE=1 \
+  sh "$work/install.sh" </dev/null
+test -x "$work/direct-bin/opengeni-agent"
+[ "$("$work/direct-bin/opengeni-agent" --version)" = "$("$built" --version)" ] || {
+  echo "direct GitHub Release fallback installed the wrong agent" >&2
+  exit 1
+}
+echo "install-smoke OK: direct GitHub Release fallback verified + installed"
+
 # A deployment lagging behind the machine's installed agent must not downgrade
 # the one shared binary. Use a tiny executable reporting 9.9.9 as the installed
 # agent, then prove the real verified candidate is skipped unless explicitly

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -479,6 +479,16 @@ describe("release image workflow contract", () => {
     expect(agentRelease).toContain("dist/manifest.json.minisig");
     expect(agentRelease).toContain("rollout_percent 100");
     expect(agentRelease).toContain("Require the release signing key");
+    expect(agentRelease).toContain('NOTARY_ARCHIVE="${{ matrix.asset }}.notary.zip"');
+    expect(agentRelease).toContain(
+      'ditto -c -k --keepParent "${{ matrix.asset }}" "$NOTARY_ARCHIVE"',
+    );
+    expect(agentRelease).toContain(
+      'rcodesign notary-submit --api-key-path /tmp/asc.json --wait "$NOTARY_ARCHIVE"',
+    );
+    expect(agentRelease).not.toContain(
+      'rcodesign notary-submit --api-key-path /tmp/asc.json --wait "${{ matrix.asset }}"',
+    );
     expect(agentRelease).not.toContain("manifest publish is wired via");
     expect(agentRelease).not.toContain("gh release delete");
     expect(agentRelease).not.toContain("gh release create agent-latest");


### PR DESCRIPTION
## Outcome

Makes the documented direct GitHub Release installer fallback work on Unix and Windows, and publishes the correction as immutable agent version `0.1.12`.

## Problem

When a deployment edge or `get.opengeni.ai` was unavailable, users were told to point `OPENGENI_INSTALL_BASE_URL` at the pinned GitHub Release asset directory. Both installers then appended the edge-only `/agent/v<version>/` path again, producing a nonexistent URL.

## Change

- recognize the exact pinned GitHub Release asset-directory shape in both installers;
- retain the existing private-edge and `latest` URL layouts everywhere else;
- add end-to-end signed install-smoke coverage for the direct fallback on Unix and Windows;
- bump the agent workspace to `0.1.12` so the already-immutable `0.1.11` tag is never moved.

## Verification

- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo test --workspace` (all green; platform totals unchanged)
- shell syntax and direct/edge/latest URL assertions
- focused API install and release-workflow contract tests (30 passed)
- full typecheck, lint, formatting, and diff checks
