### PR TITLE
fix(agent): promote 0.1.12 as stable

### DIFF
--- a/.changeset/promote-agent-0-1-12.md
+++ b/.changeset/promote-agent-0-1-12.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/config": patch
+---
+
+Promote the immutable OpenGeni connected-machine agent 0.1.12 release through the default stable install and update channel.

--- a/apps/api/test/install.test.ts
+++ b/apps/api/test/install.test.ts
@@ -109,7 +109,7 @@ describe("get.<domain> install routes", () => {
     );
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(
-      "https://github.com/Cloudgeni-ai/opengeni/releases/download/agent-v0.1.11/opengeni-agent-universal-apple-darwin",
+      "https://github.com/Cloudgeni-ai/opengeni/releases/download/agent-v0.1.12/opengeni-agent-universal-apple-darwin",
     );
   });
 
@@ -247,7 +247,7 @@ describe("get.<domain> install routes — baked binary serving", () => {
     );
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toContain(
-      "/releases/download/agent-v0.1.11/opengeni-agent-universal-apple-darwin",
+      "/releases/download/agent-v0.1.12/opengeni-agent-universal-apple-darwin",
     );
   });
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -249,7 +249,7 @@ const SettingsSchema = z.object({
   agentStableVersion: z
     .string()
     .regex(/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u)
-    .default("0.1.11"),
+    .default("0.1.12"),
   // Optional independent beta-channel pointer. When unset, the beta update
   // manifest route is unavailable rather than silently serving stable.
   agentBetaVersion: z

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -181,7 +181,7 @@ describe("Docker workspace materialization", () => {
 
 describe("agent stable release selection", () => {
   test("uses an exact stable version and supports an explicit operator promotion", () => {
-    expect(withEnv({}, () => getSettings()).agentStableVersion).toBe("0.1.11");
+    expect(withEnv({}, () => getSettings()).agentStableVersion).toBe("0.1.12");
     expect(
       withEnv({ OPENGENI_AGENT_STABLE_VERSION: "1.4.2" }, () => getSettings()).agentStableVersion,
     ).toBe("1.4.2");

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -42,7 +42,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     authAllowMetrics: false,
     publicBaseUrl: "http://127.0.0.1:3000",
     agentReleasesBaseUrl: "https://github.com/Cloudgeni-ai/opengeni/releases",
-    agentStableVersion: "0.1.11",
+    agentStableVersion: "0.1.12",
     agentBetaVersion: undefined,
     productAccessMode: "local",
     billingMode: "disabled",


### PR DESCRIPTION
## Summary

Promote the immutable `agent-v0.1.12` release through the control plane’s stable install/update channel. This keeps `/agent/latest/*`, the stable manifest, API settings, and test fixtures aligned with the agent version that contains the multi-deployment, service-lifecycle, unbounded-exec, and release hardening work.

## Verification

- `bun test packages/config/test/config.test.ts apps/api/test/install.test.ts`
- `bunx oxfmt --check packages/config/src/index.ts packages/testing/src/settings.ts packages/config/test/config.test.ts apps/api/test/install.test.ts`
- `git diff --check`

## Release safety

The versioned release remains immutable. This only advances the operator-controlled stable pointer from `0.1.11` to `0.1.12`; explicit environment overrides still take precedence.