### PR TITLE
fix(agent): account only actual spool bytes

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1599,7 +1599,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opengeni-agent"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-macos-ffi"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "block2",
  "dispatch2",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-platform"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-trait",
  "command-group",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-proto"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "prost",
  "prost-build",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-stream"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-update"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "blake3",
  "hex",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-relay"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-trait",
  "axum",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 # we lean on clippy::pedantic at the workspace level and silence only the few
 # lints that fight generated code or add no value here.
 [workspace.package]
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"

--- a/agent/crates/opengeni-agent-engine/src/retention.rs
+++ b/agent/crates/opengeni-agent-engine/src/retention.rs
@@ -18,14 +18,16 @@
 //! payoff). Spool segments are dropped whole once fully acked.
 //!
 //! Nothing here reads clocks or spawns tasks; disk I/O is plain `std::fs`
-//! against a caller-provided directory (the integration layer owns placement
-//! and the global spool budget: it reserves an op's quota before constructing
-//! the log — see PROTOCOL.md ruling M2 "global byte budget").
+//! against a caller-provided directory. The shared [`GlobalSpoolBudget`] is
+//! charged only when bytes actually spill to disk, never from a command's
+//! theoretical maximum (PROTOCOL.md ruling M2 "global byte budget").
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use crate::{Channel, Frame, FrameBody};
 
@@ -77,6 +79,23 @@ pub enum RetentionError {
         /// The configured per-op spool quota.
         spool_max_bytes: u64,
     },
+    /// The machine-wide actual-byte spool budget cannot hold this write.
+    /// Starting an op never causes this: it is returned only at the write
+    /// that would exceed the shared disk safety budget.
+    #[error(
+        "global spool budget exhausted: requested {requested_bytes} bytes with {used_bytes} of \
+         {spool_budget_bytes} already used"
+    )]
+    GlobalSpoolExhausted {
+        /// This op's projected retained record-cost bytes.
+        retained_bytes: u64,
+        /// Additional physical encoded bytes this write needs.
+        requested_bytes: u64,
+        /// Actual encoded bytes held by all spooled ops.
+        used_bytes: u64,
+        /// The current machine-wide spool safety budget.
+        spool_budget_bytes: u64,
+    },
     /// A spool read/write failed (including ENOSPC). Terminal and typed
     /// (invariant #1: a spool I/O error is never a silently dropped frame).
     #[error("spool i/o failure during {during}: {source}")]
@@ -118,6 +137,105 @@ fn record_cost(body: &FrameBody) -> u64 {
         .saturating_add(RECORD_OVERHEAD_BYTES)
 }
 
+/// Physical encoded bytes appended to the disk spool for one frame.
+fn disk_record_cost(body: &FrameBody) -> u64 {
+    u64::try_from(body.payload_len())
+        .unwrap_or(u64::MAX)
+        .saturating_add(RECORD_HEADER_LEN as u64)
+}
+
+/// Machine-wide spool accounting shared by every retention log.
+///
+/// The ledger tracks actual encoded bytes currently held by disk-backed
+/// logs. Merely starting a command costs nothing, so many quiet or normally
+/// acknowledged commands do not crowd one another out. Reservation is atomic:
+/// concurrent spills cannot oversubscribe the configured disk safety budget.
+#[derive(Debug)]
+pub struct GlobalSpoolBudget {
+    max_bytes: AtomicU64,
+    used_bytes: AtomicU64,
+}
+
+impl GlobalSpoolBudget {
+    /// Creates a shared ledger with the given maximum actual spool usage.
+    #[must_use]
+    pub fn new(max_bytes: u64) -> Self {
+        Self {
+            max_bytes: AtomicU64::new(max_bytes),
+            used_bytes: AtomicU64::new(0),
+        }
+    }
+
+    /// A ledger suitable for isolated unit tests and direct library callers.
+    #[must_use]
+    pub fn unlimited() -> Self {
+        Self::new(u64::MAX)
+    }
+
+    /// Updates the ceiling for future writes. Existing retained bytes remain
+    /// valid when a fresh capacity sample lowers the ceiling.
+    pub fn set_max_bytes(&self, max_bytes: u64) {
+        self.max_bytes.store(max_bytes, Ordering::Release);
+    }
+
+    /// Current ceiling in physical encoded bytes.
+    #[must_use]
+    pub fn max_bytes(&self) -> u64 {
+        self.max_bytes.load(Ordering::Acquire)
+    }
+
+    /// Actual encoded bytes currently charged by disk-backed logs.
+    #[must_use]
+    pub fn used_bytes(&self) -> u64 {
+        self.used_bytes.load(Ordering::Acquire)
+    }
+
+    fn try_reserve(&self, bytes: u64) -> Result<(), SpoolBudgetExhausted> {
+        if bytes == 0 {
+            return Ok(());
+        }
+        let mut used = self.used_bytes.load(Ordering::Acquire);
+        loop {
+            let max = self.max_bytes.load(Ordering::Acquire);
+            if bytes > max.saturating_sub(used) {
+                return Err(SpoolBudgetExhausted {
+                    requested: bytes,
+                    used,
+                    max,
+                });
+            }
+            match self.used_bytes.compare_exchange_weak(
+                used,
+                used + bytes,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Ok(()),
+                Err(actual) => used = actual,
+            }
+        }
+    }
+
+    fn release(&self, bytes: u64) {
+        if bytes == 0 {
+            return;
+        }
+        let result = self
+            .used_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |used| {
+                used.checked_sub(bytes)
+            });
+        debug_assert!(result.is_ok(), "spool ledger release exceeds usage");
+    }
+}
+
+#[derive(Debug)]
+struct SpoolBudgetExhausted {
+    requested: u64,
+    used: u64,
+    max: u64,
+}
+
 /// Where the retained frames physically live.
 enum Mode {
     /// All retained frames are in memory, oldest-first.
@@ -142,6 +260,13 @@ pub struct RetentionLog {
     /// The op-private spool directory, held until the (at most one) spill;
     /// `None` once spooled.
     spool_dir_pending: Option<PathBuf>,
+    /// Shared actual-byte ledger and this log's currently charged physical
+    /// encoded bytes.
+    spool_budget: Arc<GlobalSpoolBudget>,
+    spool_charged_bytes: u64,
+    /// A spool create/write failure may leave a partial trailing record. Keep
+    /// successful earlier frames replayable, but never append behind it.
+    spool_failed: bool,
 }
 
 impl std::fmt::Debug for RetentionLog {
@@ -167,6 +292,16 @@ impl RetentionLog {
     /// lazily on first spill.
     #[must_use]
     pub fn new(config: RetentionConfig, spool_dir: PathBuf) -> Self {
+        Self::with_spool_budget(config, spool_dir, Arc::new(GlobalSpoolBudget::unlimited()))
+    }
+
+    /// Creates an empty log backed by a machine-wide actual-byte spool ledger.
+    #[must_use]
+    pub fn with_spool_budget(
+        config: RetentionConfig,
+        spool_dir: PathBuf,
+        spool_budget: Arc<GlobalSpoolBudget>,
+    ) -> Self {
         Self {
             config,
             mode: Mode::Memory(VecDeque::new()),
@@ -174,6 +309,9 @@ impl RetentionLog {
             floor: 0,
             retained_bytes: 0,
             spool_dir_pending: Some(spool_dir),
+            spool_budget,
+            spool_charged_bytes: 0,
+            spool_failed: false,
         }
     }
 
@@ -185,6 +323,12 @@ impl RetentionLog {
     /// frame; [`RetentionError::SpoolIo`] on any disk failure. Both are
     /// terminal for the op.
     pub fn append(&mut self, body: FrameBody) -> Result<u64, RetentionError> {
+        if self.spool_failed {
+            return Err(RetentionError::SpoolIo {
+                during: "append after prior spool failure",
+                source: std::io::Error::other("retention spool is unavailable"),
+            });
+        }
         let seq = self.next_seq;
         let len = record_cost(&body);
 
@@ -206,20 +350,33 @@ impl RetentionLog {
             }
         }
 
-        match &mut self.mode {
+        if matches!(self.mode, Mode::Spooled(_)) {
+            if self.retained_bytes + len > self.config.spool_max_bytes {
+                return Err(RetentionError::Overflow {
+                    retained_bytes: self.retained_bytes + len,
+                    memory_max_bytes: self.config.memory_max_bytes,
+                    spool_max_bytes: self.config.spool_max_bytes,
+                });
+            }
+            self.charge_spool(disk_record_cost(&body), self.retained_bytes + len)?;
+        }
+
+        let append_failure = match &mut self.mode {
             Mode::Memory(frames) => {
                 frames.push_back(Frame { seq, body });
+                None
             }
-            Mode::Spooled(spool) => {
-                if self.retained_bytes + len > self.config.spool_max_bytes {
-                    return Err(RetentionError::Overflow {
-                        retained_bytes: self.retained_bytes + len,
-                        memory_max_bytes: self.config.memory_max_bytes,
-                        spool_max_bytes: self.config.spool_max_bytes,
-                    });
-                }
-                spool.append(&Frame { seq, body }, self.config.spool_segment_bytes)?;
+            Mode::Spooled(spool) => spool
+                .append(&Frame { seq, body }, self.config.spool_segment_bytes)
+                .err()
+                .map(|error| (error, spool.charged_bytes_after_failure())),
+        };
+        if let Some((error, actual_bytes)) = append_failure {
+            self.spool_failed = true;
+            if let Some(actual_bytes) = actual_bytes {
+                self.reconcile_spool_charge(actual_bytes);
             }
+            return Err(error);
         }
 
         self.next_seq += 1;
@@ -237,7 +394,7 @@ impl RetentionLog {
         }
         // Never ack past what exists; clamp to the highest assigned seq.
         let acked_seq = acked_seq.min(self.next_seq.saturating_sub(1));
-        match &mut self.mode {
+        let spool_freed = match &mut self.mode {
             Mode::Memory(frames) => {
                 while let Some(front) = frames.front() {
                     if front.seq > acked_seq {
@@ -246,11 +403,16 @@ impl RetentionLog {
                     self.retained_bytes -= record_cost(&front.body);
                     frames.pop_front();
                 }
+                SpoolFreed::default()
             }
             Mode::Spooled(spool) => {
                 let freed = spool.free_through(acked_seq);
-                self.retained_bytes -= freed;
+                self.retained_bytes -= freed.retention_bytes;
+                freed
             }
+        };
+        if spool_freed.disk_bytes > 0 {
+            self.release_spool(spool_freed.disk_bytes);
         }
         self.floor = acked_seq;
     }
@@ -355,18 +517,92 @@ impl RetentionLog {
     /// Migrates all retained memory frames into a fresh spool. Called exactly
     /// once, on the first append that exceeds the memory caps.
     fn spill_to_spool(&mut self) -> Result<(), RetentionError> {
+        if self.retained_bytes > self.config.spool_max_bytes {
+            return Err(RetentionError::Overflow {
+                retained_bytes: self.retained_bytes,
+                memory_max_bytes: self.config.memory_max_bytes,
+                spool_max_bytes: self.config.spool_max_bytes,
+            });
+        }
+        let disk_bytes = match &self.mode {
+            Mode::Memory(frames) => frames
+                .iter()
+                .map(|frame| disk_record_cost(&frame.body))
+                .sum(),
+            Mode::Spooled(_) => 0,
+        };
+        self.charge_spool(disk_bytes, self.retained_bytes)?;
         let dir = self
             .spool_dir_pending
             .take()
             .expect("spill only happens once, dir must still be pending");
-        let mut spool = Spool::create(dir)?;
-        if let Mode::Memory(frames) = &mut self.mode {
-            for frame in frames.drain(..) {
-                spool.append(&frame, self.config.spool_segment_bytes)?;
+        let mut spool = match Spool::create(dir) {
+            Ok(spool) => spool,
+            Err(error) => {
+                self.spool_failed = true;
+                self.release_spool(disk_bytes);
+                return Err(error);
             }
+        };
+        let copy_failure = if let Mode::Memory(frames) = &self.mode {
+            let mut failure = None;
+            for frame in frames {
+                if let Err(error) = spool.append(frame, self.config.spool_segment_bytes) {
+                    failure = Some(error);
+                    break;
+                }
+            }
+            failure
+        } else {
+            None
+        };
+        if let Some(error) = copy_failure {
+            self.spool_failed = true;
+            if let Some(actual_bytes) = spool.charged_bytes_after_failure() {
+                self.reconcile_spool_charge(actual_bytes);
+            }
+            return Err(error);
         }
         self.mode = Mode::Spooled(spool);
         Ok(())
+    }
+
+    fn charge_spool(
+        &mut self,
+        bytes: u64,
+        projected_retained_bytes: u64,
+    ) -> Result<(), RetentionError> {
+        self.spool_budget.try_reserve(bytes).map_err(|exhausted| {
+            RetentionError::GlobalSpoolExhausted {
+                retained_bytes: projected_retained_bytes,
+                requested_bytes: exhausted.requested,
+                used_bytes: exhausted.used,
+                spool_budget_bytes: exhausted.max,
+            }
+        })?;
+        self.spool_charged_bytes = self.spool_charged_bytes.saturating_add(bytes);
+        Ok(())
+    }
+
+    fn release_spool(&mut self, bytes: u64) {
+        let released = bytes.min(self.spool_charged_bytes);
+        self.spool_charged_bytes -= released;
+        self.spool_budget.release(released);
+    }
+
+    fn reconcile_spool_charge(&mut self, actual_bytes: u64) {
+        debug_assert!(
+            actual_bytes <= self.spool_charged_bytes,
+            "spool wrote more physical bytes than it reserved"
+        );
+        self.release_spool(self.spool_charged_bytes.saturating_sub(actual_bytes));
+    }
+}
+
+impl Drop for RetentionLog {
+    fn drop(&mut self) {
+        self.spool_budget.release(self.spool_charged_bytes);
+        self.spool_charged_bytes = 0;
     }
 }
 
@@ -445,6 +681,15 @@ struct Spool {
     /// Open handle for the segment currently being appended.
     active: Option<(u64, fs::File, u64 /* bytes written */)>,
     index: VecDeque<FrameLoc>,
+    /// Physical bytes present per segment, including records whose logical
+    /// frames were acknowledged before the whole segment became deletable.
+    segment_sizes: HashMap<u64, u64>,
+}
+
+#[derive(Debug, Default)]
+struct SpoolFreed {
+    retention_bytes: u64,
+    disk_bytes: u64,
 }
 
 /// Record header: [seq: u64 LE][kind: u8][payload_len: u32 LE].
@@ -460,11 +705,28 @@ impl Spool {
             dir,
             active: None,
             index: VecDeque::new(),
+            segment_sizes: HashMap::new(),
         })
     }
 
     fn segment_path(&self, segment: u64) -> PathBuf {
         self.dir.join(format!("seg-{segment:08}.spool"))
+    }
+
+    /// Physical bytes this spool successfully committed plus any partial
+    /// trailing write in the active segment. Used only to reconcile a
+    /// reservation after I/O failure; stale pre-existing files are excluded.
+    fn charged_bytes_after_failure(&self) -> Option<u64> {
+        let committed = self.segment_sizes.values().copied().sum::<u64>();
+        let partial = if let Some((segment, _, written)) = &self.active {
+            fs::metadata(self.segment_path(*segment))
+                .ok()?
+                .len()
+                .saturating_sub(*written)
+        } else {
+            0
+        };
+        Some(committed.saturating_add(partial))
     }
 
     fn append(&mut self, frame: &Frame, segment_bytes: u64) -> Result<(), RetentionError> {
@@ -521,20 +783,21 @@ impl Spool {
             kind: RecordKind::of(&frame.body),
         });
         *written += record_len;
+        *self.segment_sizes.entry(*segment).or_default() += record_len;
         Ok(())
     }
 
     /// Frees every indexed frame with `seq <= acked_seq`; deletes segment
-    /// files whose every record is freed. Returns freed RECORD-cost bytes
-    /// (payload + [`RECORD_OVERHEAD_BYTES`] per frame) — the same denomination
-    /// `append` charged, so the ledger balances.
-    fn free_through(&mut self, acked_seq: u64) -> u64 {
-        let mut freed = 0u64;
+    /// files whose every record is freed. Returns logical retention bytes and
+    /// physical disk bytes actually removed; the shared disk ledger releases
+    /// only the latter.
+    fn free_through(&mut self, acked_seq: u64) -> SpoolFreed {
+        let mut freed = SpoolFreed::default();
         while let Some(front) = self.index.front() {
             if front.seq > acked_seq {
                 break;
             }
-            freed += front.payload_len + RECORD_OVERHEAD_BYTES;
+            freed.retention_bytes += front.payload_len + RECORD_OVERHEAD_BYTES;
             let seg = front.segment;
             self.index.pop_front();
             let segment_still_referenced =
@@ -547,7 +810,26 @@ impl Spool {
                 // Best-effort delete: a failed unlink only leaks disk, never
                 // correctness; the next free attempt will not retry (the index
                 // entries are gone) but op teardown removes the whole dir.
-                let _ = fs::remove_file(self.segment_path(seg));
+                if fs::remove_file(self.segment_path(seg)).is_ok() {
+                    freed.disk_bytes += self.segment_sizes.remove(&seg).unwrap_or(0);
+                }
+            }
+        }
+        // If every record in the active segment was acknowledged, close and
+        // remove it immediately. Otherwise an attached high-volume command
+        // could keep gigabytes of already-acked disk charged until teardown.
+        if self.index.is_empty() {
+            if let Some((active_segment, file, written)) = self.active.take() {
+                drop(file);
+                let path = self.segment_path(active_segment);
+                if fs::remove_file(&path).is_ok() {
+                    freed.disk_bytes += self.segment_sizes.remove(&active_segment).unwrap_or(0);
+                } else if let Ok(file) = fs::OpenOptions::new().append(true).open(path) {
+                    // Windows requires closing before unlink. If deletion
+                    // still fails, restore the append handle and retain the
+                    // disk charge rather than corrupting or undercounting it.
+                    self.active = Some((active_segment, file, written));
+                }
             }
         }
         freed
@@ -817,6 +1099,136 @@ mod tests {
         assert!(matches!(err, RetentionError::Overflow { .. }));
         // Nothing was silently dropped: the first frame is still replayable.
         assert_eq!(log.replay(0).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn shared_budget_charges_actual_spills_not_theoretical_quotas() {
+        let disk_record_bytes = 40 + RECORD_HEADER_LEN as u64;
+        let budget = Arc::new(GlobalSpoolBudget::new(2 * disk_record_bytes));
+        let dirs = (0..100)
+            .map(|_| tempfile::tempdir().unwrap())
+            .collect::<Vec<_>>();
+        let mut logs = dirs
+            .iter()
+            .map(|dir| {
+                RetentionLog::with_spool_budget(
+                    small_config(),
+                    dir.path().join("spool"),
+                    budget.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(budget.used_bytes(), 0, "100 idle logs reserve nothing");
+
+        let payload = [1u8; 40];
+        logs[0].append(data(&payload)).unwrap();
+        logs[1].append(data(&payload)).unwrap();
+        assert_eq!(budget.used_bytes(), 2 * disk_record_bytes);
+
+        let error = logs[2].append(data(&payload)).unwrap_err();
+        assert!(matches!(error, RetentionError::GlobalSpoolExhausted { .. }));
+
+        logs[0].ack(1);
+        assert_eq!(budget.used_bytes(), disk_record_bytes);
+        logs[2].append(data(&payload)).unwrap();
+        assert_eq!(budget.used_bytes(), 2 * disk_record_bytes);
+
+        drop(logs);
+        assert_eq!(
+            budget.used_bytes(),
+            0,
+            "log teardown releases its exact share"
+        );
+    }
+
+    #[test]
+    fn shared_budget_is_atomic_under_concurrent_writers() {
+        let budget = Arc::new(GlobalSpoolBudget::new(1_000));
+        let barrier = Arc::new(std::sync::Barrier::new(100));
+        let writers = (0..100)
+            .map(|_| {
+                let budget = budget.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    budget.try_reserve(100).is_ok()
+                })
+            })
+            .collect::<Vec<_>>();
+        let admitted = writers
+            .into_iter()
+            .map(|writer| writer.join().unwrap())
+            .filter(|admitted| *admitted)
+            .count();
+        assert_eq!(admitted, 10);
+        assert_eq!(budget.used_bytes(), 1_000);
+        budget.release(1_000);
+        assert_eq!(budget.used_bytes(), 0);
+    }
+
+    #[test]
+    fn shared_budget_releases_only_when_physical_segment_is_deleted() {
+        let budget = Arc::new(GlobalSpoolBudget::new(4096));
+        let dir = tempfile::tempdir().unwrap();
+        let mut log = RetentionLog::with_spool_budget(
+            RetentionConfig {
+                spool_segment_bytes: 4096,
+                ..small_config()
+            },
+            dir.path().join("spool"),
+            budget.clone(),
+        );
+        let payload = [1u8; 40];
+        log.append(data(&payload)).unwrap();
+        log.append(data(&payload)).unwrap();
+        let two_records = 2 * (40 + RECORD_HEADER_LEN as u64);
+        assert_eq!(budget.used_bytes(), two_records);
+
+        log.ack(1);
+        assert_eq!(
+            budget.used_bytes(),
+            two_records,
+            "a partially live segment still occupies all of its disk bytes"
+        );
+        log.ack(2);
+        assert_eq!(budget.used_bytes(), 0);
+    }
+
+    #[test]
+    fn spool_create_failure_is_sticky_without_losing_memory_replay() {
+        let budget = Arc::new(GlobalSpoolBudget::new(4096));
+        let dir = tempfile::tempdir().unwrap();
+        let spool_path = dir.path().join("spool");
+        let one_record = usize::try_from(40 + RECORD_OVERHEAD_BYTES).unwrap();
+        let mut log = RetentionLog::with_spool_budget(
+            RetentionConfig {
+                memory_max_bytes: one_record,
+                ..small_config()
+            },
+            spool_path.clone(),
+            budget.clone(),
+        );
+        let payload = [1u8; 40];
+        log.append(data(&payload)).unwrap();
+        fs::write(&spool_path, b"blocks directory creation").unwrap();
+
+        assert!(matches!(
+            log.append(data(&payload)).unwrap_err(),
+            RetentionError::SpoolIo { .. }
+        ));
+        assert!(matches!(
+            log.append(FrameBody::Progress).unwrap_err(),
+            RetentionError::SpoolIo { .. }
+        ));
+        assert_eq!(log.replay(0).unwrap().len(), 1);
+        assert_eq!(
+            budget.used_bytes(),
+            0,
+            "a create failure writes no bytes and releases the reservation immediately"
+        );
+        drop(log);
+        assert_eq!(budget.used_bytes(), 0);
     }
 
     #[test]

--- a/agent/crates/opengeni-agent-macos-ffi/src/ffi.rs
+++ b/agent/crates/opengeni-agent-macos-ffi/src/ffi.rs
@@ -46,8 +46,7 @@ use block2::RcBlock;
 use objc2::AnyThread;
 use objc2_core_foundation::CGPoint;
 use objc2_core_graphics::{
-    CGDataProvider, CGDisplayCopyDisplayMode, CGDisplayModeGetHeight, CGDisplayModeGetPixelHeight,
-    CGDisplayModeGetPixelWidth, CGDisplayModeGetWidth, CGEvent, CGEventSource,
+    CGDataProvider, CGDisplayCopyDisplayMode, CGDisplayMode, CGEvent, CGEventSource,
     CGEventSourceStateID, CGEventTapLocation, CGEventType, CGImage, CGMainDisplayID, CGMouseButton,
     CGPreflightScreenCaptureAccess, CGRequestScreenCaptureAccess, CGScrollEventUnit,
 };
@@ -116,8 +115,8 @@ pub(super) fn probe_display() -> Option<DisplayInfo> {
 /// The main display's backing pixel dimensions from its current `CGDisplayMode`.
 fn display_pixel_dims(did: u32) -> Option<(u32, u32)> {
     let mode = CGDisplayCopyDisplayMode(did)?;
-    let w = CGDisplayModeGetPixelWidth(Some(&mode));
-    let h = CGDisplayModeGetPixelHeight(Some(&mode));
+    let w = CGDisplayMode::pixel_width(Some(&mode));
+    let h = CGDisplayMode::pixel_height(Some(&mode));
     if w == 0 || h == 0 {
         None
     } else {
@@ -128,10 +127,10 @@ fn display_pixel_dims(did: u32) -> Option<(u32, u32)> {
 /// Per-axis pixel/point scale (backing scale factor) for pixel→point conversion.
 fn display_scale(did: u32) -> (f64, f64) {
     if let Some(mode) = CGDisplayCopyDisplayMode(did) {
-        let pw = CGDisplayModeGetPixelWidth(Some(&mode));
-        let ph = CGDisplayModeGetPixelHeight(Some(&mode));
-        let ptw = CGDisplayModeGetWidth(Some(&mode));
-        let pth = CGDisplayModeGetHeight(Some(&mode));
+        let pw = CGDisplayMode::pixel_width(Some(&mode));
+        let ph = CGDisplayMode::pixel_height(Some(&mode));
+        let ptw = CGDisplayMode::width(Some(&mode));
+        let pth = CGDisplayMode::height(Some(&mode));
         let sx = if ptw > 0 { pw as f64 / ptw as f64 } else { 1.0 };
         let sy = if pth > 0 { ph as f64 / pth as f64 } else { 1.0 };
         (sx, sy)
@@ -168,9 +167,7 @@ pub(super) fn capture_rgba() -> Result<RgbaFrame, MacFfiError> {
     );
 
     unsafe {
-        // `&*outer` derefs the RcBlock to `&Block` (= `&DynBlock`) explicitly, so
-        // the call never leans on deref-coercion at the argument site.
-        SCShareableContent::getShareableContentWithCompletionHandler(&*outer);
+        SCShareableContent::getShareableContentWithCompletionHandler(&outer);
     }
 
     match rx.recv_timeout(Duration::from_secs(15)) {
@@ -192,18 +189,15 @@ fn capture_from_content(
     let displays = unsafe { content.displays() };
 
     let mut chosen = None;
-    for display in displays.iter() {
+    for display in &displays {
         if unsafe { display.displayID() } == main_id {
             chosen = Some(display);
             break;
         }
     }
-    let display = match chosen.or_else(|| displays.firstObject()) {
-        Some(d) => d,
-        None => {
-            let _ = tx.send(Err("no capturable display found".to_string()));
-            return;
-        }
+    let Some(display) = chosen.or_else(|| displays.firstObject()) else {
+        let _ = tx.send(Err("no capturable display found".to_string()));
+        return;
     };
 
     let windows = NSArray::<SCWindow>::new();

--- a/agent/crates/opengeni-agent/src/engine.rs
+++ b/agent/crates/opengeni-agent/src/engine.rs
@@ -15,10 +15,10 @@
 //!   [`HostCapacity`] as a fraction with the old absolute defaults as FLOORS
 //!   (rule R), and the per-frame wire size is T-derived from the negotiated
 //!   NATS `max_payload` (the smallest active link value wins).
-//! * **Spool ledger** — the global disk budget (PROTOCOL.md ruling M2): each
-//!   job reserves its per-op spool quota against the shared budget at start
-//!   and releases it at teardown; when the budget is short the op's quota is
-//!   clamped (loudly) rather than the op refused.
+//! * **Spool ledger** — the global disk budget (PROTOCOL.md ruling M2) is
+//!   shared by every job and charged only for bytes actually spooled. Starting
+//!   many commands consumes no disk budget; concurrent writes cannot
+//!   oversubscribe it.
 //! * **Routing** — connection-scoped `op_id → mailbox` for wire-command
 //!   delivery. A lost link detaches only the jobs it owns.
 //!
@@ -36,7 +36,7 @@ use opengeni_agent_engine::admission::{
 use opengeni_agent_engine::registry::{
     BeginOutcome, CancelOutcome, OpRegistry, QueryAnswer, RegistryConfig, RegistryCounters,
 };
-use opengeni_agent_engine::retention::RetentionConfig;
+use opengeni_agent_engine::retention::{GlobalSpoolBudget, RetentionConfig};
 use opengeni_agent_engine::{Frame, HostCapacity, OpId};
 use opengeni_agent_platform::ContainedExec;
 use tokio::sync::{mpsc, oneshot, Notify};
@@ -81,7 +81,7 @@ const FALLBACK_FRAME_BYTES: usize = 128 * 1024;
 pub struct EngineBudgets {
     /// Per-op retention template (memory ring + spool quota + segment size).
     pub retention_per_op: RetentionConfig,
-    /// The global spool budget every per-op quota is reserved against (M2).
+    /// The global budget for actual retained spool bytes (M2).
     pub spool_budget_bytes: u64,
     /// Circuit breaker on a legacy adapter's assembled reply buffer: far above
     /// any publishable reply (the transport caps those at `max_payload`), it
@@ -193,32 +193,12 @@ impl Drop for AdmissionTicket {
     }
 }
 
-/// A job's share of the global spool ledger (M2). Idempotent release: the
-/// legacy adapter returns it early at the terminal record (no consumer is
-/// ever coming for a legacy op's spool frames), the task-end guard returns
-/// whatever remains, and a double release is a no-op.
-struct SpoolReservation {
-    engine: Arc<Engine>,
-    granted: AtomicU64,
-}
-
-impl SpoolReservation {
-    fn release(&self) {
-        let granted = self.granted.swap(0, Ordering::AcqRel);
-        if granted > 0 {
-            self.engine.release_spool(granted);
-        }
-    }
-}
-
-/// Owned by the pump task: route removal + spool release run on Drop, so a
-/// PANICKING pump still cleans up (design-review fold-in — previously the
-/// cleanup ran after `run_job().await` and a panic leaked the route and the
-/// reservation until restart).
+/// Owned by the pump task: route removal runs on Drop, so a PANICKING pump
+/// still cleans up. The retention log independently owns and releases its
+/// actual spool-byte charge.
 struct JobCleanup {
     engine: Arc<Engine>,
     op_id: OpId,
-    reservation: Arc<SpoolReservation>,
 }
 
 impl Drop for JobCleanup {
@@ -228,7 +208,6 @@ impl Drop for JobCleanup {
             .lock()
             .expect("routes lock")
             .remove(&self.op_id);
-        self.reservation.release();
     }
 }
 
@@ -245,7 +224,7 @@ pub struct Engine {
     budgets: RwLock<EngineBudgets>,
     capacity: RwLock<HostCapacity>,
     spool_root: PathBuf,
-    spool_reserved: Mutex<u64>,
+    spool_budget: Arc<GlobalSpoolBudget>,
     /// T-derived per-frame data size (from the negotiated max_payload).
     max_frame_bytes: AtomicUsize,
     /// Negotiated payload per active deployment link. The shared engine uses the
@@ -310,6 +289,7 @@ impl Engine {
         if let Some(v) = overrides.registry_tombstone_ttl_ms {
             registry.tombstone_ttl_ms = v;
         }
+        let spool_budget = Arc::new(GlobalSpoolBudget::new(budgets.spool_budget_bytes));
         Arc::new(Self {
             registry: Mutex::new(OpRegistry::new(registry)),
             admission: Mutex::new(AdmissionState::new(admission)),
@@ -318,7 +298,7 @@ impl Engine {
             budgets: RwLock::new(budgets),
             capacity: RwLock::new(capacity),
             spool_root,
-            spool_reserved: Mutex::new(0),
+            spool_budget,
             max_frame_bytes: AtomicUsize::new(FALLBACK_FRAME_BYTES),
             transport_payloads: Mutex::new(HashMap::new()),
             frames_dropped: AtomicU64::new(0),
@@ -346,6 +326,7 @@ impl Engine {
         if let Some(v) = overrides.retention_spool_max_bytes {
             budgets.retention_per_op.spool_max_bytes = v;
         }
+        self.spool_budget.set_max_bytes(budgets.spool_budget_bytes);
         *self.budgets.write().expect("budgets lock") = budgets;
         *self.capacity.write().expect("capacity lock") = capacity;
     }
@@ -519,43 +500,12 @@ impl Engine {
 
     /// Idempotently starts a job (ruling B1: a known id NEVER re-runs — the
     /// registry is consulted BEFORE `spawn` so a duplicate has no side
-    /// effects). On the fresh path: reserves spool against the global budget,
-    /// spawns the child via `spawn`, wires the pump hooks (engine lifecycle
-    /// bookkeeping composed in front of the caller's `on_exit`), and launches
-    /// the pump task. The admission ticket rides inside `on_exit`, releasing
-    /// at completion (linger is not running work). Route removal + spool
-    /// release live in a task-owned Drop guard, so even a panicking pump
-    /// cleans up.
-    ///
-    /// Reserves the op's spool quota against the global ledger (M2); a short
-    /// budget clamps the quota (loudly) rather than refusing the op.
-    fn reserve_op_spool(
-        self: &Arc<Self>,
-        op_id: &OpId,
-        retention: &mut RetentionConfig,
-    ) -> Arc<SpoolReservation> {
-        let granted = self.reserve_spool(retention.spool_max_bytes);
-        if granted < retention.spool_max_bytes {
-            warn!(
-                op = %op_id,
-                wanted = retention.spool_max_bytes,
-                granted,
-                "global spool budget short; op spool quota clamped"
-            );
-        }
-        retention.spool_max_bytes = granted;
-        Arc::new(SpoolReservation {
-            engine: self.clone(),
-            granted: AtomicU64::new(granted),
-        })
-    }
-
-    /// `release_spool_at_exit`: LEGACY ops set this — their spool ledger
-    /// share returns at the terminal record instead of task end, because no
-    /// consumer ever collects a legacy op's spool frames post-exit (duplicate
-    /// replies serve the stashed ENCODED reply); the lingering pump's spool
-    /// residue is already ack-trimmed to ~nothing. Op-stream ops keep their
-    /// reservation through the linger — post-exit replay is their whole point.
+    /// effects). On the fresh path: spawns the child via `spawn`, wires the
+    /// pump hooks (engine lifecycle bookkeeping composed in front of the
+    /// caller's `on_exit`), and launches the pump task. The admission ticket
+    /// rides inside `on_exit`, releasing at completion (linger is not running
+    /// work). Route removal lives in a task-owned Drop guard; the retention
+    /// log owns exact shared-spool charging and release.
     #[allow(clippy::too_many_arguments)] // the job seams are irreducible; a builder would just rename them
     pub fn start_job<E>(
         self: &Arc<Self>,
@@ -563,7 +513,6 @@ impl Engine {
         ticket: AdmissionTicket,
         stdin: Vec<u8>,
         deadline: Option<tokio::time::Instant>,
-        release_spool_at_exit: bool,
         spawn: impl FnOnce() -> Result<ContainedExec, E>,
         emit: impl Fn(Frame) + Send + 'static,
         encode_exit: impl Fn(&JobExit) -> Vec<u8> + Send + 'static,
@@ -601,14 +550,14 @@ impl Engine {
             }
         };
 
-        let mut retention = self.budgets().retention_per_op;
-        let reservation = self.reserve_op_spool(op_id, &mut retention);
+        let retention = self.budgets().retention_per_op;
 
         let (mailbox_tx, mailbox_rx) = mpsc::channel(JOB_MAILBOX_DEPTH);
         let params = JobParams {
             child,
             stdin,
             retention,
+            spool_budget: self.spool_budget.clone(),
             spool_dir: self.spool_root.join(op_dir_name(op_id)),
             deadline,
             config: JobConfig {
@@ -627,7 +576,6 @@ impl Engine {
             let id = op_id.clone();
             let exit_stash = handles.exit.clone();
             let watermark = handles.watermark.clone();
-            let exit_reservation = release_spool_at_exit.then(|| reservation.clone());
             JobHooks::new(emit, encode_exit, move |exit_seq, exit: &JobExit| {
                 let _ = exit_stash.set(exit.clone());
                 engine.registry.lock().expect("registry lock").complete(
@@ -635,9 +583,6 @@ impl Engine {
                     exit_seq.unwrap_or_else(|| watermark.load(Ordering::Relaxed)),
                     engine.now_ms(),
                 );
-                if let Some(reservation) = exit_reservation {
-                    reservation.release();
-                }
                 drop(ticket);
                 on_exit(exit_seq, exit);
             })
@@ -651,11 +596,10 @@ impl Engine {
         let cleanup = JobCleanup {
             engine: self.clone(),
             op_id: op_id.clone(),
-            reservation,
         };
         tokio::spawn(async move {
-            // Owned here so a PANIC in the pump still removes the route and
-            // returns the spool reservation on unwind (Drop guard).
+            // Owned here so a PANIC in the pump still removes the route. The
+            // RetentionLog drop separately releases actual spool bytes.
             let cleanup = cleanup;
             let end = run_job(params, mailbox_rx, hooks).await;
             if end == JobEnd::FinalAcked {
@@ -812,26 +756,6 @@ impl Engine {
                 "engine gc pass"
             );
         }
-    }
-
-    /// Reserves up to `want` spool bytes against the global budget, returning
-    /// the granted amount.
-    fn reserve_spool(&self, want: u64) -> u64 {
-        let budget = self
-            .budgets
-            .read()
-            .expect("budgets lock")
-            .spool_budget_bytes;
-        let mut reserved = self.spool_reserved.lock().expect("spool ledger lock");
-        let granted = want.min(budget.saturating_sub(*reserved));
-        *reserved += granted;
-        granted
-    }
-
-    /// Returns a job's spool reservation to the global budget.
-    fn release_spool(&self, granted: u64) {
-        let mut reserved = self.spool_reserved.lock().expect("spool ledger lock");
-        *reserved = reserved.saturating_sub(granted);
     }
 }
 
@@ -1034,7 +958,6 @@ mod tests {
             ticket,
             Vec::new(),
             None,
-            false,
             || {
                 Ok::<_, std::io::Error>(sh(
                     "i=0; while [ $i -lt 200 ]; do printf '%08d' $i; i=$((i+1)); sleep 0.005; done",
@@ -1209,7 +1132,6 @@ mod tests {
             ticket,
             Vec::new(),
             None,
-            false,
             || Ok::<_, std::io::Error>(sh("printf out; exit 4")),
             |_frame| {},
             |exit| format!("{exit:?}").into_bytes(),
@@ -1251,7 +1173,6 @@ mod tests {
             ticket2,
             Vec::new(),
             None,
-            false,
             || -> Result<ContainedExec, std::io::Error> { panic!("a known op id must not spawn") },
             |_| {},
             |_| Vec::new(),
@@ -1318,7 +1239,6 @@ mod tests {
             ticket,
             Vec::new(),
             None,
-            false,
             || Err(std::io::Error::other("no such program")),
             |_| {},
             |_| Vec::new(),
@@ -1334,8 +1254,7 @@ mod tests {
                 ..
             }
         ));
-        // Nothing reserved: the ledger only moves for launched jobs.
-        assert_eq!(*engine.spool_reserved.lock().expect("ledger"), 0);
+        assert_eq!(engine.spool_budget.used_bytes(), 0);
     }
 
     #[tokio::test]
@@ -1357,7 +1276,6 @@ mod tests {
             ticket,
             Vec::new(),
             None,
-            false,
             || -> Result<ContainedExec, std::io::Error> {
                 panic!("a tombstoned op must not spawn")
             },
@@ -1371,10 +1289,8 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn panicking_pump_still_cleans_up_route_and_ledger() {
-        // The emit hook panics on the first frame: the pump task unwinds and
-        // the task-owned Drop guard must still remove the route and return
-        // the spool reservation (design-review fold-in — previously the
-        // cleanup ran only on the normal path).
+        // The emit hook panics on the first frame: task and retention-log Drop
+        // guards must still remove the route and release actual spool bytes.
         let (engine, _dir) = test_engine(AdmissionConfig::default());
         let op = OpId::from("panicky");
         let ticket = engine
@@ -1386,7 +1302,6 @@ mod tests {
             ticket,
             Vec::new(),
             None,
-            false,
             || Ok::<_, std::io::Error>(sh("printf boom")),
             |_frame| panic!("emit hook panic (deliberate)"),
             |_| Vec::new(),
@@ -1409,26 +1324,18 @@ mod tests {
         let route_alive =
             |engine: &Arc<Engine>| engine.routes.lock().expect("routes lock").contains_key(&op);
         for _ in 0..500 {
-            if !route_alive(&engine) && *engine.spool_reserved.lock().expect("ledger") == 0 {
+            if !route_alive(&engine) && engine.spool_budget.used_bytes() == 0 {
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
         assert!(!route_alive(&engine), "route removed on the panic path");
-        assert_eq!(
-            *engine.spool_reserved.lock().expect("ledger"),
-            0,
-            "spool reservation returned on the panic path"
-        );
+        assert_eq!(engine.spool_budget.used_bytes(), 0);
     }
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn legacy_jobs_release_their_ledger_share_at_exit() {
-        // release_spool_at_exit: the ledger share returns at the terminal
-        // record while the pump still lingers (route alive) — legacy ops
-        // never serve post-exit spool replay, so holding the share through
-        // the linger only starves new ops under connection churn.
+    async fn starting_a_job_does_not_reserve_its_theoretical_spool_quota() {
         let (engine, _dir) = test_engine(AdmissionConfig::default());
         let op = OpId::from("legacy-early-release");
         let ticket = engine
@@ -1441,7 +1348,6 @@ mod tests {
             ticket,
             Vec::new(),
             None,
-            true,
             || Ok::<_, std::io::Error>(sh("printf done")),
             |_frame| {},
             |_| Vec::new(),
@@ -1456,14 +1362,10 @@ mod tests {
             .await
             .expect("exit in time")
             .expect("exit delivered");
-        assert_eq!(
-            *engine.spool_reserved.lock().expect("ledger"),
-            0,
-            "ledger share returned at the terminal record"
-        );
+        assert_eq!(engine.spool_budget.used_bytes(), 0);
         assert!(
             engine.route_command(&op, JobCommand::Detach { completed: None }),
-            "the pump still lingers (route alive) after the early release"
+            "the pump still lingers (route alive) after exit"
         );
         // Normal teardown still works.
         let _ = started
@@ -1483,19 +1385,6 @@ mod tests {
                 final_ack: true,
             })
             .await;
-    }
-
-    #[test]
-    fn spool_reservation_clamps_to_the_global_budget() {
-        let (engine, _dir) = test_engine(AdmissionConfig::default());
-        let budget = engine.budgets().spool_budget_bytes;
-        let first = engine.reserve_spool(budget - 100);
-        assert_eq!(first, budget - 100);
-        let second = engine.reserve_spool(1000);
-        assert_eq!(second, 100, "clamped to the remaining budget");
-        engine.release_spool(first);
-        engine.release_spool(second);
-        assert_eq!(*engine.spool_reserved.lock().expect("ledger"), 0);
     }
 
     #[test]

--- a/agent/crates/opengeni-agent/src/job.rs
+++ b/agent/crates/opengeni-agent/src/job.rs
@@ -57,7 +57,9 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use opengeni_agent_engine::flow::{AckOutcome, AttachOutcome, CreditFlow};
-use opengeni_agent_engine::retention::{RetentionConfig, RetentionError, RetentionLog};
+use opengeni_agent_engine::retention::{
+    GlobalSpoolBudget, RetentionConfig, RetentionError, RetentionLog,
+};
 use opengeni_agent_engine::{Channel, Frame, FrameBody};
 use opengeni_agent_platform::ContainedExec;
 use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWriteExt as _};
@@ -139,9 +141,10 @@ pub struct JobParams {
     /// Bytes to feed the child's stdin; the handle is closed after writing
     /// (empty ⇒ closed immediately so a stdin-reading child never hangs).
     pub stdin: Vec<u8>,
-    /// Retention bounds for this op (the supervisor already reserved the op's
-    /// share of the global spool budget — ruling M2).
+    /// Retention bounds for this op.
     pub retention: RetentionConfig,
+    /// Machine-wide actual-byte disk-spool ledger (ruling M2).
+    pub spool_budget: Arc<GlobalSpoolBudget>,
     /// The op-private spool directory (created lazily on first spill; removed
     /// when the job task ends).
     pub spool_dir: PathBuf,
@@ -206,7 +209,8 @@ impl JobFailure {
     /// Maps a typed retention failure onto the job-failure form.
     fn from_retention(error: &RetentionError) -> Self {
         match error {
-            RetentionError::Overflow { retained_bytes, .. } => JobFailure::Overflow {
+            RetentionError::Overflow { retained_bytes, .. }
+            | RetentionError::GlobalSpoolExhausted { retained_bytes, .. } => JobFailure::Overflow {
                 retained_bytes: *retained_bytes,
             },
             // SpoolIo — and ReplayBelowFloor, which cannot come out of an
@@ -309,6 +313,7 @@ pub async fn run_job(
         mut child,
         stdin,
         retention,
+        spool_budget,
         spool_dir,
         deadline,
         config,
@@ -321,7 +326,11 @@ pub async fn run_job(
     spawn_stdin_writer(child.stdin.take(), stdin);
 
     let pump = Pump {
-        retention: RetentionLog::new(retention.clone(), spool_dir.clone()),
+        retention: RetentionLog::with_spool_budget(
+            retention.clone(),
+            spool_dir.clone(),
+            spool_budget,
+        ),
         retention_config: retention,
         flow: CreditFlow::new(),
         hooks,
@@ -984,6 +993,7 @@ mod tests {
                 child,
                 stdin: self.stdin,
                 retention: self.retention,
+                spool_budget: Arc::new(GlobalSpoolBudget::unlimited()),
                 spool_dir: dir.path().join("spool"),
                 deadline: self.deadline_after.map(|after| Instant::now() + after),
                 config: self.config,

--- a/agent/crates/opengeni-agent/src/legacy.rs
+++ b/agent/crates/opengeni-agent/src/legacy.rs
@@ -123,8 +123,6 @@ pub async fn serve_exec_scoped<P: Platform>(
         ticket,
         stdin,
         deadline,
-        // Legacy: the spool ledger share returns at the terminal record.
-        true,
         || platform.spawn_exec(&req),
         emit,
         // The legacy consumer never replays the Exit frame; its record flows
@@ -245,8 +243,6 @@ pub async fn serve_git_scoped<P: Platform>(
         Vec::new(),
         // Rule C: git carries no caller deadline field; none is imposed.
         None,
-        // Legacy: the spool ledger share returns at the terminal record.
-        true,
         || platform.spawn_git(&req),
         emit,
         |_exit| Vec::new(),

--- a/agent/crates/opengeni-agent/src/ops.rs
+++ b/agent/crates/opengeni-agent/src/ops.rs
@@ -110,9 +110,6 @@ pub async fn serve_op_start_scoped<P: Platform>(
         ticket,
         stdin,
         deadline,
-        // Op-stream: retention (and its ledger share) survives to the final
-        // ack — post-exit replay is the point.
-        false,
         || platform.spawn_exec(&exec),
         frame_publisher(publish, request_id.clone()),
         |exit| wire_exit(exit).encode_to_vec(),


### PR DESCRIPTION
## Summary

- charge the shared Connected Machine spool budget only for encoded bytes physically written, instead of reserving every command’s theoretical maximum at startup
- release disk charges only after physical segment deletion; reconcile exact filesystem bytes on I/O failure and preserve typed replay/failure behavior
- prove 100 idle operations reserve nothing and 100 concurrent writers cannot oversubscribe the shared budget
- update the macOS desktop bridge to the current CoreGraphics API and bump the agent workspace to 0.1.13

## Why

The 0.1.12 runner still let a handful of commands reserve the entire global spool allowance without writing output. Later commands received a zero-byte spool quota and failed, which reproduced the VM2 session failures.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- independent `autoreview --mode local`: clean after fixing its one accepted I/O-failure reconciliation finding

## Release

Agent version 0.1.13. Tag and release only after exact-head hosted CI is green.