### PR TITLE
fix(workbench): preserve committed and multi-repo changes

### DIFF
--- a/.changeset/honest-workbench-changes.md
+++ b/.changeset/honest-workbench-changes.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/react": patch
+"@opengeni/worker-bundle": patch
+---
+
+Preserve committed-only workspace captures and load multi-repository Git changes in bounded batches.

--- a/apps/worker/src/activities/workspace-capture.ts
+++ b/apps/worker/src/activities/workspace-capture.ts
@@ -1036,24 +1036,49 @@ function statusCodeOf(f: GitFileStatus): GitFileStatusCode {
 
 /**
  * sha256 over the CHANGE SURFACE only — per-file (path, status, hash, deleted,
- * tooLarge) and per-repo diff summary (path, status, additions, deletions).
+ * tooLarge), the working diff summary, and exact committed branch changes.
  * Deliberately excludes the tree index and file mtimes (which drift without a
  * real change) so two turns that leave the workspace in the same state produce
  * the same fingerprint (the empty-turn gate). Order-independent (sorted).
  */
-function changeFingerprint(repos: WorkspaceCaptureRepo[], files: WorkspaceCaptureFile[]): string {
+export function changeFingerprint(
+  repos: WorkspaceCaptureRepo[],
+  files: WorkspaceCaptureFile[],
+): string {
   const fileParts = files
     .map((f) => `${f.path}|${f.status}|${f.hash ?? ""}|${f.deleted ? 1 : 0}|${f.tooLarge ? 1 : 0}`)
     .sort();
+  const branchDiffPart = (diff: WorkspaceCaptureRepo["diff"][number]): string =>
+    JSON.stringify([
+      diff.path,
+      diff.oldPath,
+      diff.status,
+      diff.isBinary,
+      diff.isImage,
+      diff.additions,
+      diff.deletions,
+      diff.truncated,
+      diff.hunks.map((hunk) => [
+        hunk.oldStart,
+        hunk.oldLines,
+        hunk.newStart,
+        hunk.newLines,
+        hunk.header,
+        hunk.lines.map((line) => [line.type, line.oldNo, line.newNo, line.text]),
+      ]),
+    ]);
   const repoParts = repos
-    .map(
-      (r) =>
-        `${r.root}#${r.head ?? ""}#` +
-        r.diff
-          .map((d) => `${d.path}:${d.status}:${d.additions}:${d.deletions}:${d.truncated ? 1 : 0}`)
-          .sort()
-          .join(","),
-    )
+    .map((repo) => {
+      const workingDiff = repo.diff
+        .map(
+          (diff) =>
+            `${diff.path}:${diff.status}:${diff.additions}:${diff.deletions}:${diff.truncated ? 1 : 0}`,
+        )
+        .sort();
+      const branchDiff =
+        repo.branchDiff === undefined ? null : repo.branchDiff.map(branchDiffPart).sort();
+      return JSON.stringify([repo.root, repo.head, repo.ahead, workingDiff, branchDiff]);
+    })
     .sort();
   return sha256(utf8(JSON.stringify({ files: fileParts, repos: repoParts })));
 }

--- a/apps/worker/test/workspace-capture.test.ts
+++ b/apps/worker/test/workspace-capture.test.ts
@@ -16,6 +16,8 @@ import {
   WorkspaceCaptureManifest,
   WorkspaceRevisionCapturedPayload,
   WorkspaceRevisionDegradedPayload,
+  type WorkspaceCaptureFile,
+  type WorkspaceCaptureRepo,
 } from "@opengeni/contracts";
 import type { ObjectStorage } from "@opengeni/storage";
 import { ChannelAUnavailableError, type ChannelASession } from "@opengeni/runtime/sandbox";
@@ -23,6 +25,7 @@ import {
   blobKey,
   BoxExitingError,
   captureWorkspaceRevision,
+  changeFingerprint,
   isBoxExitingError,
   isUnderResidueDir,
   joinRepoPath,
@@ -68,6 +71,49 @@ const forbiddenDb = new Proxy(
   },
 ) as unknown as Database;
 const dummySession = {} as ChannelASession;
+
+function captureRepo(overrides: Partial<WorkspaceCaptureRepo> = {}): WorkspaceCaptureRepo {
+  return {
+    root: "",
+    head: "feature",
+    detached: false,
+    upstream: "origin/feature",
+    ahead: 0,
+    behind: 0,
+    status: [],
+    diff: [],
+    branchDiff: [],
+    ...overrides,
+  };
+}
+
+function committedBranchDiff(
+  text = "new",
+): NonNullable<WorkspaceCaptureRepo["branchDiff"]>[number] {
+  return {
+    path: "src/app.ts",
+    oldPath: null,
+    status: "modified",
+    isBinary: false,
+    isImage: false,
+    additions: 1,
+    deletions: 1,
+    hunks: [
+      {
+        oldStart: 1,
+        oldLines: 1,
+        newStart: 1,
+        newLines: 1,
+        header: "@@ -1 +1 @@",
+        lines: [
+          { type: "del", oldNo: 1, newNo: null, text: "old" },
+          { type: "add", oldNo: null, newNo: 1, text },
+        ],
+      },
+    ],
+    truncated: false,
+  };
+}
 
 function baseInput() {
   return {
@@ -278,6 +324,46 @@ describe("workspace-capture — path & key helpers", () => {
   });
   test("blobKey is content-addressed under the session prefix", () => {
     expect(blobKey("ws", "sess", "abc123")).toBe("workspace-captures/ws/sess/blobs/abc123");
+  });
+});
+
+describe("workspace-capture — durable change fingerprint", () => {
+  const noFiles: WorkspaceCaptureFile[] = [];
+
+  test("a committed-only branch diff cannot deduplicate against the prior clean revision", () => {
+    const cleanFingerprint = changeFingerprint([captureRepo()], noFiles);
+    const committedFingerprint = changeFingerprint(
+      [captureRepo({ ahead: 1, branchDiff: [committedBranchDiff()] })],
+      noFiles,
+    );
+
+    expect(committedFingerprint).not.toBe(cleanFingerprint);
+    expect(
+      changeFingerprint(
+        [captureRepo({ ahead: 1, branchDiff: [committedBranchDiff("newer")] })],
+        noFiles,
+      ),
+    ).not.toBe(committedFingerprint);
+    expect(
+      changeFingerprint([captureRepo({ ahead: 2, branchDiff: [committedBranchDiff()] })], noFiles),
+    ).not.toBe(committedFingerprint);
+  });
+
+  test("identical clean and committed states remain order-independent and empty-turn stable", () => {
+    expect(changeFingerprint([captureRepo()], noFiles)).toBe(
+      changeFingerprint([captureRepo()], noFiles),
+    );
+
+    const first = captureRepo({ ahead: 1, branchDiff: [committedBranchDiff()] });
+    const second = captureRepo({
+      root: "packages/web",
+      ahead: 1,
+      branchDiff: [{ ...committedBranchDiff(), path: "src/web.ts" }],
+    });
+
+    expect(changeFingerprint([first, second], noFiles)).toBe(
+      changeFingerprint([second, first], noFiles),
+    );
   });
 });
 

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -134,7 +134,19 @@ export function initialWorkspaceTab(
     bestSeq = event.sequence;
     bestFileCount = typeof stats?.fileCount === "number" ? stats.fileCount : 0;
   }
-  return bestFileCount > 0 ? WORKBENCH_TAB_CHANGES : WORKBENCH_TAB_FILES;
+  if (bestFileCount > 0) return WORKBENCH_TAB_CHANGES;
+
+  let latestGitSeq = -1;
+  let committedOnly = false;
+  for (const event of events ?? []) {
+    if (event.type !== "git.changed" || event.sequence > bestSeq) continue;
+    if (event.sequence <= latestGitSeq) continue;
+    const payload = event.payload as { ahead?: number; reason?: string } | null;
+    latestGitSeq = event.sequence;
+    committedOnly =
+      (typeof payload?.ahead === "number" && payload.ahead > 0) || payload?.reason === "commit";
+  }
+  return committedOnly ? WORKBENCH_TAB_CHANGES : WORKBENCH_TAB_FILES;
 }
 
 /**
@@ -543,7 +555,11 @@ export function useSandboxWorkspaceTabs(
   }
   const captureIsAuthoritative =
     !liveWorkspaceExpected && (liveness !== undefined || caps.error !== null);
-  const captureUnavailable = captureState.fileCount === 0 || captureState.error !== null;
+  const captureHasChanges =
+    (captureState.fileCount ?? 0) > 0 ||
+    (captureState.capture?.repos.some((repo) => (repo.branchDiff?.length ?? 0) > 0) ?? false);
+  const captureUnavailable =
+    (captureState.fileCount === 0 && !captureHasChanges) || captureState.error !== null;
   const implicitBranchFallbackPending =
     changesComparison === "branch" &&
     git.error !== null &&
@@ -563,7 +579,7 @@ export function useSandboxWorkspaceTabs(
       captureState.available
     ) {
       defaultTabRef.current.value = sourceDrivenDefaultTab(
-        captureState.fileCount > 0,
+        captureHasChanges,
         changesEnabled,
         filesEnabled,
       );
@@ -586,7 +602,7 @@ export function useSandboxWorkspaceTabs(
       // A warm live read failed but the durable capture is intact: retain an
       // immediate, deterministic review surface instead of hanging unresolved.
       defaultTabRef.current.value = sourceDrivenDefaultTab(
-        captureState.fileCount > 0,
+        captureHasChanges,
         changesEnabled,
         filesEnabled,
       );

--- a/packages/react/src/hooks/use-sandbox-git.ts
+++ b/packages/react/src/hooks/use-sandbox-git.ts
@@ -93,6 +93,11 @@ function uniqueRoots(roots: readonly string[]): string[] {
   return [...new Set(roots.map(normalizeRoot))].sort((a, b) => a.localeCompare(b));
 }
 
+// GitReadBatchRequest is contract-bounded to 32 items. Keep workspace-wide
+// reads bounded without changing the wire limit; sequential chunks preserve
+// deterministic root/result mapping and cap Channel-A lease concurrency at one.
+const GIT_READ_BATCH_REQUEST_LIMIT = 32;
+
 /** Find the capture repo matching `repoPath` (default workspace root). */
 function repoForPath(
   manifest: WorkspaceCaptureManifest,
@@ -251,35 +256,54 @@ export function useSandboxGit(
       // take several seconds on a remote sandbox. The legacy root probe remains
       // serial so a non-repository workspace never receives a failing git diff.
       const prefetched = hasAdvertisedRepoPaths
-        ? await client
-            .gitReadBatch(
-              workspaceId,
-              sessionId,
-              {
-                requests: repoPaths.map((root) => ({
-                  status: { path: root },
-                  diff: {
-                    path: root,
-                    ...(comparison === "branch"
-                      ? { fromRef: "origin/HEAD", includeUntracked: true }
-                      : comparison === "working"
-                        ? { fromRef: "HEAD", includeUntracked: true }
-                        : { staged: true, includeUntracked: false }),
-                  },
-                })),
-              },
-              { signal: refreshAbort.signal },
-            )
-            .then((batch) =>
-              batch.results.map((item, index) => ({
-                root: repoPaths[index] ?? "",
-                status: item.status,
-                result: item.diff ?? {
-                  files: [],
-                  revision: item.status.revision,
+        ? await (async () => {
+            const prefetchedRepos: Array<{
+              root: string;
+              status: Awaited<ReturnType<typeof client.gitStatus>>;
+              result: Awaited<ReturnType<typeof client.gitDiff>>;
+            }> = [];
+            for (
+              let offset = 0;
+              offset < repoPaths.length;
+              offset += GIT_READ_BATCH_REQUEST_LIMIT
+            ) {
+              const roots = repoPaths.slice(offset, offset + GIT_READ_BATCH_REQUEST_LIMIT);
+              const batch = await client.gitReadBatch(
+                workspaceId,
+                sessionId,
+                {
+                  requests: roots.map((root) => ({
+                    status: { path: root },
+                    diff: {
+                      path: root,
+                      ...(comparison === "branch"
+                        ? { fromRef: "origin/HEAD", includeUntracked: true }
+                        : comparison === "working"
+                          ? { fromRef: "HEAD", includeUntracked: true }
+                          : { staged: true, includeUntracked: false }),
+                    },
+                  })),
                 },
-              })),
-            )
+                { signal: refreshAbort.signal },
+              );
+              if (batch.results.length !== roots.length) {
+                throw new Error(
+                  `Workspace Git batch returned ${batch.results.length} results for ${roots.length} repositories.`,
+                );
+              }
+              batch.results.forEach((item, index) => {
+                prefetchedRepos.push({
+                  root: roots[index]!,
+                  status: item.status,
+                  result: item.diff ?? {
+                    files: [],
+                    revision: item.status.revision,
+                  },
+                });
+              });
+            }
+            return prefetchedRepos;
+          })()
         : null;
       const statuses =
         prefetched ??

--- a/packages/react/test/sandbox-hooks.test.tsx
+++ b/packages/react/test/sandbox-hooks.test.tsx
@@ -1352,6 +1352,149 @@ describe("useSandboxGit", () => {
     await hook.unmount();
   });
 
+  test("warm multi-repo mode chunks 33 and 65 roots at the 32-request protocol boundary", async () => {
+    for (const [rootCount, expectedBatchSizes] of [
+      [33, [32, 1]],
+      [65, [32, 32, 1]],
+    ] as const) {
+      const roots = Array.from(
+        { length: rootCount },
+        (_, index) => `repo-${String(index).padStart(2, "0")}`,
+      );
+      const batches: string[][] = [];
+      const client = fakeClient({
+        gitReadBatch: async (_workspaceId, _sessionId, request) => {
+          const batchRoots = request.requests.map((item) => item.status.path ?? "");
+          batches.push(batchRoots);
+          if (request.requests.length > 32) {
+            throw new Error("GitReadBatchRequest exceeded 32 requests");
+          }
+          return {
+            results: batchRoots.map((root) => ({
+              status: {
+                isRepo: true,
+                head: `${root}-main`,
+                detached: false,
+                upstream: null,
+                ahead: 0,
+                behind: 0,
+                files: [],
+                revision: 1,
+              },
+              diff: { files: [fakeFileDiff({ path: "src/index.ts" })], revision: 1 },
+            })),
+          };
+        },
+      });
+      const hook = await renderHook(
+        () =>
+          useSandboxGit(SESSION_ID, {
+            client,
+            workspaceId: WORKSPACE_ID,
+            liveness: "warm",
+            repoPaths: roots,
+          }),
+        undefined,
+      );
+      await flush();
+
+      expect(batches.map((batch) => batch.length)).toEqual([...expectedBatchSizes]);
+      expect(batches.flat()).toEqual(roots);
+      expect(hook.result.current.error).toBeNull();
+      expect(hook.result.current.repoCount).toBe(rootCount);
+      expect(hook.result.current.repoRoots).toEqual(roots);
+      expect(hook.result.current.diff.map((file) => file.path)).toEqual(
+        roots.map((root) => `${root}/src/index.ts`),
+      );
+      await hook.unmount();
+    }
+  });
+
+  test("warm multi-repo mode keeps an exact 32-root request in one batch", async () => {
+    const roots = Array.from(
+      { length: 32 },
+      (_, index) => `repo-${String(index).padStart(2, "0")}`,
+    );
+    const batchSizes: number[] = [];
+    const client = fakeClient({
+      gitReadBatch: async (_workspaceId, _sessionId, request) => {
+        batchSizes.push(request.requests.length);
+        return {
+          results: request.requests.map((item) => ({
+            status: {
+              isRepo: true,
+              head: `${item.status.path ?? ""}-main`,
+              detached: false,
+              upstream: null,
+              ahead: 0,
+              behind: 0,
+              files: [],
+              revision: 1,
+            },
+            diff: { files: [], revision: 1 },
+          })),
+        };
+      },
+    });
+    const hook = await renderHook(
+      () =>
+        useSandboxGit(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          liveness: "warm",
+          repoPaths: roots,
+        }),
+      undefined,
+    );
+    await flush();
+
+    expect(batchSizes).toEqual([32]);
+    expect(hook.result.current.error).toBeNull();
+    expect(hook.result.current.repoRoots).toEqual(roots);
+    await hook.unmount();
+  });
+
+  test("warm multi-repo mode fails closed when a batch result count cannot map to its roots", async () => {
+    const roots = ["api", "web"];
+    const client = fakeClient({
+      gitReadBatch: async () => ({
+        results: [
+          {
+            status: {
+              isRepo: true,
+              head: "api-main",
+              detached: false,
+              upstream: null,
+              ahead: 0,
+              behind: 0,
+              files: [],
+              revision: 1,
+            },
+            diff: { files: [], revision: 1 },
+          },
+        ],
+      }),
+    });
+    const hook = await renderHook(
+      () =>
+        useSandboxGit(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          liveness: "warm",
+          repoPaths: roots,
+        }),
+      undefined,
+    );
+    await flush();
+
+    expect(hook.result.current.error?.message).toBe(
+      "Workspace Git batch returned 1 results for 2 repositories.",
+    );
+    expect(hook.result.current.repoRoots).toEqual([]);
+    expect(hook.result.current.diff).toEqual([]);
+    await hook.unmount();
+  });
+
   test("a non-repo box reports isRepo false with an empty diff (not an error)", async () => {
     const client = fakeClient({
       gitStatus: async () => ({

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -21,12 +21,14 @@ import {
   fakeAttachResponse,
   fakeCapabilities,
   fakeColdCapabilities,
+  fakeEvent,
   fakeFileDiff,
 } from "./sandbox-fixtures";
 import { OpenGeniProvider } from "../src/provider";
 import type { MachinesResponse } from "../src/types/machines";
 import {
   useSandboxWorkspaceTabs,
+  initialWorkspaceTab,
   type UseSandboxWorkspaceTabsOptions,
   type UseSandboxWorkspaceTabsResult,
   SandboxWorkspace,
@@ -622,6 +624,52 @@ describe("workbench prewarm gating (Refinement 1)", () => {
 // ── Refinement 2: capture-driven default tab ─────────────────────────────────
 
 describe("capture-driven default tab (Refinement 2)", () => {
+  test("committed-only capture signals default Changes while a truly empty capture defaults Files", async () => {
+    expect(
+      initialWorkspaceTab([
+        fakeEvent(1, "git.changed", {
+          head: "feature",
+          dirty: false,
+          ahead: 1,
+          behind: 0,
+          changedFileCount: 0,
+          reason: "commit",
+        }),
+        fakeEvent(2, "workspace.revision.captured", { stats: { fileCount: 0 } }),
+      ]),
+    ).toBe(WORKBENCH_TAB_CHANGES);
+    expect(
+      initialWorkspaceTab([
+        fakeEvent(1, "git.changed", {
+          head: "feature",
+          dirty: false,
+          ahead: 0,
+          behind: 0,
+          changedFileCount: 0,
+          reason: "worktree",
+        }),
+        fakeEvent(2, "workspace.revision.captured", { stats: { fileCount: 0 } }),
+      ]),
+    ).toBe(WORKBENCH_TAB_FILES);
+
+    const committedOnly = fakeManifest(0);
+    committedOnly.repos[0] = {
+      ...committedOnly.repos[0]!,
+      ahead: 1,
+      branchDiff: [fakeFileDiff({ path: "src/committed.ts" })],
+    };
+    const committedClient = coldClient({
+      getWorkspaceCapture: async () => captureAvailable(committedOnly),
+    });
+    const committedHook = await renderTabsHook(committedClient.client, {
+      sessionId: SESSION_ID,
+      events: [],
+    });
+    await flush();
+    expect(committedHook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
+    await committedHook.unmount();
+  });
+
   test("changes present → default Changes; empty → default Files", async () => {
     const withChanges = coldClient({
       getWorkspaceCapture: async () => captureAvailable(fakeManifest(2)),


### PR DESCRIPTION
## Summary
- make workspace-capture deduplication include existing committed-only `ahead` and exact `branchDiff` content, so a clean working tree after a commit cannot collapse into the prior clean revision
- default a cold captured workspace to Changes when existing capture/event evidence shows committed-only changes, without adding manifest or wire fields
- split multi-repository Git reads into deterministic sequential batches of at most 32, preserving root/diff ordering and failing closed on cardinality mismatch

## Validation
- 150 focused worker/React tests, including committed-only positive + clean planted negative and exact 32/33/65-root batching
- 98 source-admission/release/workflow contract tests
- TypeScript 7: all 23 projects clean
- oxlint: 0 warnings/errors; oxfmt: 1,513 files clean
- generated fonts, workspace/billing static, docs refs, public hygiene, and `git diff --check`
- publishable package closure, publish consumer, runtime embedding consumer, portable ogtool, React demo, web production build, and bundle budgets
- full local unit attempt: 6,141 passed, 6 skipped, 44 service-bound failures because this sandbox has no Docker daemon/PostgreSQL; no mocks substituted

**No-Claim:** This PR does not broaden the public 32-request protocol limit, add manifest/wire fields, alter release/workload contracts, or claim review, merge, release, deployment, or unavailable real-service validation.
