### PR TITLE
chore(agent): promote 0.1.14 stable

### DIFF
--- a/.changeset/promote-agent-0-1-14.md
+++ b/.changeset/promote-agent-0-1-14.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/config": patch
+---
+
+Promote the immutable OpenGeni connected-machine agent 0.1.14 release through the default stable install and update channel.

--- a/.env.example
+++ b/.env.example
@@ -93,7 +93,7 @@ OPENGENI_USAGE_LIMITS_MODE=none
 # Public agent archive and explicit stable-channel promotion pointer. The stable
 # version must already exist as an `agent-v<version>` release.
 # OPENGENI_AGENT_RELEASES_BASE_URL=https://github.com/Cloudgeni-ai/opengeni/releases
-# OPENGENI_AGENT_STABLE_VERSION=0.1.11
+# OPENGENI_AGENT_STABLE_VERSION=0.1.14
 # OPENGENI_AGENT_BETA_VERSION=
 # OPENGENI_DELEGATION_SECRET=replace-with-long-random-token-signing-secret
 # OPENGENI_STATIC_ENTITLEMENTS_JSON='{"feature_key":true}'

--- a/apps/api/test/install.test.ts
+++ b/apps/api/test/install.test.ts
@@ -109,7 +109,7 @@ describe("get.<domain> install routes", () => {
     );
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(
-      "https://github.com/Cloudgeni-ai/opengeni/releases/download/agent-v0.1.13/opengeni-agent-universal-apple-darwin",
+      "https://github.com/Cloudgeni-ai/opengeni/releases/download/agent-v0.1.14/opengeni-agent-universal-apple-darwin",
     );
   });
 
@@ -247,7 +247,7 @@ describe("get.<domain> install routes — baked binary serving", () => {
     );
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toContain(
-      "/releases/download/agent-v0.1.13/opengeni-agent-universal-apple-darwin",
+      "/releases/download/agent-v0.1.14/opengeni-agent-universal-apple-darwin",
     );
   });
 });

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1322,7 +1322,7 @@ for other OS/arch assets and the self-update channel. Route these paths (and an
 optional `get.<domain>` host) to the `api` service in the ingress.
 
 `/agent/latest/<asset>` is a compatibility route backed by the immutable
-versioned release selected by `OPENGENI_AGENT_STABLE_VERSION` (default `0.1.11`).
+versioned release selected by `OPENGENI_AGENT_STABLE_VERSION` (default `0.1.14`).
 `OPENGENI_AGENT_RELEASES_BASE_URL` selects the archive origin. Promote or roll
 back the stable channel by changing the configured version only after the
 corresponding `agent-v<version>` release and its signed assets exist; never move

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -251,7 +251,7 @@ const SettingsSchema = z.object({
   agentStableVersion: z
     .string()
     .regex(/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u)
-    .default("0.1.13"),
+    .default("0.1.14"),
   // Optional independent beta-channel pointer. When unset, the beta update
   // manifest route is unavailable rather than silently serving stable.
   agentBetaVersion: z

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -181,7 +181,7 @@ describe("Docker workspace materialization", () => {
 
 describe("agent stable release selection", () => {
   test("uses an exact stable version and supports an explicit operator promotion", () => {
-    expect(withEnv({}, () => getSettings()).agentStableVersion).toBe("0.1.13");
+    expect(withEnv({}, () => getSettings()).agentStableVersion).toBe("0.1.14");
     expect(
       withEnv({ OPENGENI_AGENT_STABLE_VERSION: "1.4.2" }, () => getSettings()).agentStableVersion,
     ).toBe("1.4.2");

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -44,7 +44,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     authAllowMetrics: false,
     publicBaseUrl: "http://127.0.0.1:3000",
     agentReleasesBaseUrl: "https://github.com/Cloudgeni-ai/opengeni/releases",
-    agentStableVersion: "0.1.13",
+    agentStableVersion: "0.1.14",
     agentBetaVersion: undefined,
     productAccessMode: "local",
     billingMode: "disabled",


### PR DESCRIPTION
Promotes the immutable, signed agent-v0.1.14 release as the default stable Connected Machine agent.

Changes:
- set the runtime and test defaults to 0.1.14
- update immutable install-route expectations
- update the operator environment example and deployment guide
- add the changeset for the API/config packages

Release acceptance:
- tag resolves exactly to 00a17ba51742e83b724deef69b32e205ba6d86dd
- five native binaries and the notarized macOS app bundle downloaded from the published release
- all SHA-256 and minisign signatures verified against the pinned public key
- signed stable manifest verified at 100 percent rollout
- macOS Developer ID, notarization, stapling, bundle identity, architectures, and reported version verified

Local verification:
- 110 focused tests passed
- formatting and diff checks passed
- independent autoreview passed after correcting stale operator docs