### PR TITLE
fix(runtime): persist sandbox manifests losslessly

### DIFF
--- a/.changeset/clean-sandbox-envelope-manifests.md
+++ b/.changeset/clean-sandbox-envelope-manifests.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Serialize SDK sandbox manifests once at the canonical lease-envelope field and normalize cross-realm provider JSON before persistence.

--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
     },
     "apps/api": {
       "name": "@opengeni/api-router",
-      "version": "0.22.5",
+      "version": "0.23.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",
@@ -130,7 +130,7 @@
     },
     "apps/worker": {
       "name": "@opengeni/worker-bundle",
-      "version": "0.16.24",
+      "version": "0.16.29",
       "dependencies": {
         "@opengeni/agent-proto": "workspace:*",
         "@opengeni/codex": "workspace:*",
@@ -159,7 +159,7 @@
     },
     "examples/northstar-support": {
       "name": "@opengeni/example-northstar-support",
-      "version": "0.0.78",
+      "version": "0.0.83",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opengeni/react": "workspace:*",
@@ -194,7 +194,7 @@
     },
     "packages/codex": {
       "name": "@opengeni/codex",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "zod": "^4.2.1",
       },
@@ -205,7 +205,7 @@
     },
     "packages/config": {
       "name": "@opengeni/config",
-      "version": "0.11.3",
+      "version": "0.12.1",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -218,7 +218,7 @@
     },
     "packages/contracts": {
       "name": "@opengeni/contracts",
-      "version": "0.39.3",
+      "version": "0.40.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
         "zod": "^4.2.1",
@@ -230,7 +230,7 @@
     },
     "packages/core": {
       "name": "@opengeni/core",
-      "version": "0.21.5",
+      "version": "0.21.10",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opengeni/codex": "workspace:*",
@@ -252,7 +252,7 @@
     },
     "packages/db": {
       "name": "@opengeni/db",
-      "version": "0.28.4",
+      "version": "0.28.9",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/config": "workspace:*",
@@ -281,7 +281,7 @@
     },
     "packages/documents": {
       "name": "@opengeni/documents",
-      "version": "0.5.13",
+      "version": "0.5.18",
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.3",
         "@opengeni/config": "workspace:*",
@@ -299,7 +299,7 @@
     },
     "packages/events": {
       "name": "@opengeni/events",
-      "version": "0.3.83",
+      "version": "0.3.88",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "@opengeni/db": "workspace:*",
@@ -312,7 +312,7 @@
     },
     "packages/github": {
       "name": "@opengeni/github",
-      "version": "0.4.34",
+      "version": "0.4.38",
       "dependencies": {
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -336,7 +336,7 @@
     },
     "packages/observability": {
       "name": "@opengeni/observability",
-      "version": "0.5.3",
+      "version": "0.5.6",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "prom-client": "^15.1.3",
@@ -359,7 +359,7 @@
     },
     "packages/react": {
       "name": "@opengeni/react",
-      "version": "0.46.4",
+      "version": "0.48.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
         "@dnd-kit/core": "6.3.1",
@@ -446,11 +446,12 @@
     },
     "packages/runtime": {
       "name": "@opengeni/runtime",
-      "version": "0.18.20",
+      "version": "0.18.24",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@noble/hashes": "^1.8.0",
         "@openai/agents": "0.13.3",
+        "@openai/agents-core": "0.13.3",
         "@openai/agents-extensions": "0.13.3",
         "@opengeni/agent-proto": "workspace:*",
         "@opengeni/codex": "workspace:*",
@@ -463,7 +464,6 @@
         "ws": "8.21.1",
       },
       "devDependencies": {
-        "@openai/agents-core": "0.13.3",
         "tsup": "^8.5.0",
         "typescript": "7.0.2",
         "zod": "4.4.3",
@@ -471,7 +471,7 @@
     },
     "packages/sdk": {
       "name": "@opengeni/sdk",
-      "version": "0.46.4",
+      "version": "0.48.0",
       "devDependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -483,7 +483,7 @@
     },
     "packages/storage": {
       "name": "@opengeni/storage",
-      "version": "0.2.71",
+      "version": "0.2.75",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -47,6 +47,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@noble/hashes": "^1.8.0",
     "@openai/agents": "0.13.3",
+    "@openai/agents-core": "0.13.3",
     "@openai/agents-extensions": "0.13.3",
     "@opengeni/agent-proto": "workspace:*",
     "@opengeni/codex": "workspace:*",
@@ -59,7 +60,6 @@
     "ws": "8.21.1"
   },
   "devDependencies": {
-    "@openai/agents-core": "0.13.3",
     "tsup": "^8.5.0",
     "typescript": "7.0.2",
     "zod": "4.4.3"

--- a/packages/runtime/src/protocol-json.ts
+++ b/packages/runtime/src/protocol-json.ts
@@ -132,8 +132,13 @@ function normalizeObject(
   path: string,
 ): NormalizeResult {
   const descriptors = Object.getOwnPropertyDescriptors(value);
-  const output = Object.create(Object.getPrototypeOf(value)) as Record<string, unknown>;
-  let changed = false;
+  const prototype = Object.getPrototypeOf(value);
+  const hasForeignObjectPrototype = prototype !== Object.prototype && prototype !== null;
+  const output = Object.create(prototype === null ? null : Object.prototype) as Record<
+    string,
+    unknown
+  >;
+  let changed = hasForeignObjectPrototype;
 
   for (const [key, descriptor] of Object.entries(descriptors)) {
     const propertyPath = `${path}[${JSON.stringify(key)}]`;
@@ -162,5 +167,17 @@ function normalizeObject(
 
 function isPlainObject(value: object): value is Record<string, unknown> {
   const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
+  if (prototype === Object.prototype || prototype === null) return true;
+
+  // SDKs can return otherwise-plain JSON objects created in another JavaScript
+  // realm (for example a VM-backed sandbox provider). Their Object.prototype
+  // is not reference-equal to this realm's Object.prototype. Accept only the
+  // foreign realm's native Object prototype; class instances still fail.
+  if (Object.getPrototypeOf(prototype) !== null) return false;
+  const constructor = Object.getOwnPropertyDescriptor(prototype, "constructor")?.value;
+  return (
+    typeof constructor === "function" &&
+    constructor.name === "Object" &&
+    Function.prototype.toString.call(constructor).includes("[native code]")
+  );
 }

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -26,10 +26,12 @@ import {
   type SandboxBackend,
 } from "@opengeni/contracts";
 import type {
+  Manifest,
   SandboxClient,
   SandboxSessionLike,
   SandboxSessionState,
 } from "@openai/agents/sandbox";
+import { serializeManifestRecord } from "@openai/agents-core/sandbox/internal";
 import { PROVIDER_REGISTRY } from "./providers";
 import { SandboxConfigError, SandboxResumeStateUnavailableError } from "./errors";
 import { isProviderSandboxNotFoundError } from "./provider-errors";
@@ -42,6 +44,7 @@ import {
   type WorkspaceArchiveDescriptor,
 } from "./workspace-archive";
 import type { RuntimeMetricsHooks } from "../metrics";
+import { normalizeProtocolJsonValue } from "../protocol-json";
 import { runStateCompatibilityProvider, runStateExposedPortsRecord } from "./run-state-compat";
 
 // Re-export the config-owned environment/port helpers from the leaf so the
@@ -604,7 +607,10 @@ export function sandboxStateEntryFromRunState(state: unknown): Record<string, un
   if (!entry || !entry.sessionState) {
     return null;
   }
-  return sandboxEntryForPersistence(entry as Record<string, unknown>);
+  return normalizeProtocolJsonValue(
+    sandboxEntryForPersistence(entry as Record<string, unknown>),
+    '$["sandboxSessionEnvelope"]',
+  ) as Record<string, unknown>;
 }
 
 /**
@@ -636,6 +642,18 @@ function sandboxEntryForPersistence(entry: Record<string, unknown>): Record<stri
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function providerStateWithoutDuplicateManifest(value: object): Record<string, unknown> {
+  const { manifest: _manifest, ...providerState } = value as Record<string, unknown>;
+  return providerState;
+}
+
+function serializeSdkManifestForEnvelope(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype === Object.prototype || prototype === null) return value;
+  return serializeManifestRecord(value as Manifest);
 }
 
 /**
@@ -1332,16 +1350,17 @@ export async function serializeEstablishedSandboxEnvelope(
     // rehydrates `{ ...providerState, manifest, snapshot?, exposedPorts?,
     // workspaceReady }`. So the FLAT serialized state must be nested under
     // `providerState` (and manifest/ports lifted), or sandboxId is dropped on the
-    // round-trip and resume() throws "requires a persisted sandboxId". We pull
-    // manifest/native endpoint records up but leave them in providerState too
-    // (harmless; the deserialize spreads providerState first, then overlays
-    // manifest/ports). configuredExposedPorts is provider configuration/state,
-    // not the SDK's port-keyed endpoint record, so it must never be lifted.
+    // round-trip and resume() throws "requires a persisted sandboxId". SDK-owned
+    // envelope fields are removed from providerState after lifting; providers can
+    // return live Manifest instances there, and deserialization overlays the
+    // authoritative manifest anyway. configuredExposedPorts is provider
+    // configuration/state, not the SDK's port-keyed endpoint record, so it must
+    // never be lifted.
     const flat = serialized as Record<string, unknown>;
-    const manifest = flat.manifest;
+    const manifest = serializeSdkManifestForEnvelope(flat.manifest);
     const exposedPorts = runStateExposedPortsRecord(flat.exposedPorts);
     const sessionState: Record<string, unknown> = {
-      providerState: flat,
+      providerState: providerStateWithoutDuplicateManifest(flat),
       ...(manifest !== undefined ? { manifest } : {}),
       ...(exposedPorts !== undefined ? { exposedPorts } : {}),
       workspaceReady: true,

--- a/packages/runtime/test/protocol-json.test.ts
+++ b/packages/runtime/test/protocol-json.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { runInNewContext } from "node:vm";
 import {
   normalizeProtocolJsonValue,
   UnsupportedProtocolJsonValueError,
@@ -32,6 +33,20 @@ describe("normalizeProtocolJsonValue", () => {
   test("retains references for already-valid protocol JSON", () => {
     const input = { type: "message", content: [{ type: "output_text", text: "done" }] };
     expect(normalizeProtocolJsonValue(input)).toBe(input);
+  });
+
+  test("normalizes plain JSON objects received from another JavaScript realm", () => {
+    const input = runInNewContext('({ providerState: { manifest: { image: "node:22" } } })');
+
+    const normalized = normalizeProtocolJsonValue(input);
+
+    expect(normalized).toEqual({
+      providerState: { manifest: { image: "node:22" } },
+    });
+    expect(normalized).not.toBe(input);
+    expect(Object.getPrototypeOf(normalized)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(normalized.providerState)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(normalized.providerState.manifest)).toBe(Object.prototype);
   });
 
   test("rejects undefined array elements with their exact path", () => {

--- a/packages/runtime/test/runstate-exposed-ports-compat.test.ts
+++ b/packages/runtime/test/runstate-exposed-ports-compat.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { RunContext, RunState } from "@openai/agents-core";
+import { Manifest } from "@openai/agents-core/sandbox";
 import { testSettings } from "@opengeni/testing";
 import {
   buildOpenGeniAgent,
@@ -134,6 +135,39 @@ describe("RunState exposedPorts compatibility", () => {
       configuredExposedPorts: [3000],
       exposedPorts,
     });
+  });
+
+  test("serializes a live SDK Manifest once at the envelope boundary", async () => {
+    const manifest = new Manifest({
+      root: "/workspace",
+      entries: {},
+      environment: { TEST_VALUE: "manifest-ok" },
+    });
+    const envelope = await serializeEstablishedSandboxEnvelope({
+      client: {
+        backendId: "docker",
+        async serializeSessionState() {
+          return {
+            containerId: "container-manifest",
+            manifest,
+          };
+        },
+      },
+      session: {},
+      sessionState: { containerId: "container-manifest" },
+      instanceId: "container-manifest",
+      backendId: "docker",
+    } as never);
+
+    const sessionState = envelope?.sessionState as Record<string, unknown>;
+    expect(sessionState.manifest).toMatchObject({
+      version: 1,
+      root: "/workspace",
+      entries: {},
+      environment: { TEST_VALUE: { value: "manifest-ok" } },
+    });
+    expect(sessionState.manifest).not.toBe(manifest);
+    expect(sessionState.providerState).toEqual({ containerId: "container-manifest" });
   });
 
   test("historical lease-envelope arrays are not rehydrated as SDK exposedPorts", async () => {

--- a/packages/runtime/test/sandbox-leaf-no-agent-loop.test.ts
+++ b/packages/runtime/test/sandbox-leaf-no-agent-loop.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { runInNewContext } from "node:vm";
 
 // P0.2 guard: @opengeni/runtime/sandbox is the agent-loop-free leaf. The API
 // imports resume-by-id + file/exec/port helpers from it WITHOUT pulling in the
@@ -213,6 +214,40 @@ describe("@opengeni/runtime/sandbox — agent-loop-free leaf (P0.2 guard)", () =
       },
     });
     expect(sourceEntry.sessionState.providerState.manifest).toBe(providerManifest);
+
+    const foreignRealmEntry = sandboxStateEntryFromRunState(
+      runInNewContext(`({
+        _sandbox: {
+          currentAgentKey: "root",
+          sessionsByAgent: {
+            root: {
+              backendId: "docker",
+              sessionState: {
+                version: 1,
+                backendId: "docker",
+                manifest: { root: "/workspace" },
+                workspaceReady: true,
+                providerState: {
+                  manifest: { redundant: true },
+                  containerId: "container-1"
+                }
+              }
+            }
+          }
+        }
+      })`),
+    );
+    expect(foreignRealmEntry).toEqual({
+      backendId: "docker",
+      sessionState: {
+        version: 1,
+        backendId: "docker",
+        manifest: { root: "/workspace" },
+        workspaceReady: true,
+        providerState: { containerId: "container-1" },
+      },
+    });
+    expect(Object.getPrototypeOf(foreignRealmEntry)).toBe(Object.prototype);
   });
 
   test("sandboxStateEntryFromRunState preserves provider manifest without an outer replacement", async () => {


### PR DESCRIPTION
## Summary
- serialize live SDK manifests once at the canonical lease-envelope field
- remove the redundant provider-state manifest before persistence
- normalize cross-realm plain provider JSON while still rejecting class instances

## Verification
- 20 focused runtime tests pass
- @opengeni/runtime typecheck passes
- @opengeni/runtime build passes
- format and diff checks pass