### PR TITLE
chore(release): bump product version to 0.22.85

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.84
-appVersion: "0.22.84"
+version: 0.22.85
+appVersion: "0.22.85"


### PR DESCRIPTION
Bumps the immutable OpenGeni product release identity after the runtime/React package release. The previous 0.22.84 OCI tags are already occupied, so the corrected candidate must publish as 0.22.85.\n\nVerified:\n- `bun test scripts/release-version.test.ts scripts/release-image-workflow-contract.test.ts`\n- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`\n- `git diff --check`