### PR TITLE
revert: regenerate canonical release receipt

### DIFF
--- a/.changeset/quiet-ravens-stop.md
+++ b/.changeset/quiet-ravens-stop.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/runtime": patch
+"@opengeni/react": patch
+---
+
+Cancel Modal commands that stall before provider yield without bypassing physical quiescence, and show the truthful stopping state while replacement work waits.

--- a/apps/api/CHANGELOG.md
+++ b/apps/api/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @opengeni/api-router
 
-## 0.23.4
-
-### Patch Changes
-
-- Updated dependencies [b7315b8]
-  - @opengeni/runtime@0.18.27
-  - @opengeni/core@0.21.13
-
 ## 0.23.3
 
 ### Patch Changes

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/api-router",
-  "version": "0.23.4",
+  "version": "0.23.3",
   "description": "OpenGeni HTTP surface: the Hono adapter/router (createApp), routes, MCP HTTP transport, and HTTP access adapters over @opengeni/core. An engine-distribution surface — its runtime closure includes engine-internal packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/apps/worker/CHANGELOG.md
+++ b/apps/worker/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @opengeni/worker-bundle
 
-## 0.16.32
-
-### Patch Changes
-
-- Updated dependencies [b7315b8]
-  - @opengeni/runtime@0.18.27
-  - @opengeni/core@0.21.13
-
 ## 0.16.31
 
 ### Patch Changes

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/worker-bundle",
-  "version": "0.16.32",
+  "version": "0.16.31",
   "description": "OpenGeni worker entry and reusable embedded lifecycle, shipped with a release-coherent pre-bundled Temporal workflow artifact.",
   "license": "Apache-2.0",
   "repository": {

--- a/examples/northstar-support/CHANGELOG.md
+++ b/examples/northstar-support/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @opengeni/example-northstar-support
 
-## 0.0.85
-
-### Patch Changes
-
-- Updated dependencies [b7315b8]
-  - @opengeni/react@0.48.2
-
 ## 0.0.84
 
 ### Patch Changes

--- a/examples/northstar-support/package.json
+++ b/examples/northstar-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/example-northstar-support",
-  "version": "0.0.85",
+  "version": "0.0.84",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @opengeni/core
 
-## 0.21.13
-
-### Patch Changes
-
-- Updated dependencies [b7315b8]
-  - @opengeni/runtime@0.18.27
-
 ## 0.21.12
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/core",
-  "version": "0.21.13",
+  "version": "0.21.12",
   "description": "OpenGeni framework-agnostic core: the domain, access, and billing layers (neutral access, off-HTTP V2 surface). Behavior-preserving extraction from apps/api — keeps Hono's HTTPException for error throwing (typed-errors cleanup deferred).",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @opengeni/react
 
-## 0.48.2
-
-### Patch Changes
-
-- b7315b8: Cancel Modal commands that stall before provider yield without bypassing physical quiescence, and show the truthful stopping state while replacement work waits.
-
 ## 0.48.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/react",
-  "version": "0.48.2",
+  "version": "0.48.1",
   "description": "React hooks and styled components for OpenGeni: live session streaming, chat composer, message timeline, session status, and fleet views — token-themed (CSS variables), dark-first, built on Tailwind v4 + Radix + Motion.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @opengeni/runtime
 
-## 0.18.27
-
-### Patch Changes
-
-- b7315b8: Cancel Modal commands that stall before provider yield without bypassing physical quiescence, and show the truthful stopping state while replacement work waits.
-
 ## 0.18.26
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/runtime",
-  "version": "0.18.27",
+  "version": "0.18.26",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Mechanical recovery: restore the already-reviewed #1178 changeset so Changesets can regenerate the identical version tree with a canonical pre-merge release receipt. Current branch tree exactly equals previously green main b7315b812388fd7ce8f115d48dc1b0ab17ae20f6. No application-code delta.