### PR TITLE
fix(runtime): fence stalled cleanup exec cancellation

### DIFF
--- a/.changeset/calm-lamps-fence.md
+++ b/.changeset/calm-lamps-fence.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Keep a stalled Modal cleanup-proof start and its provider cancellation inside the physical-quiescence fence until both settle.

--- a/packages/runtime/src/sandbox/turn-tool-cancellation.ts
+++ b/packages/runtime/src/sandbox/turn-tool-cancellation.ts
@@ -1224,11 +1224,7 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
     // every other result retries and keeps quiescence closed.
     while (true) {
       try {
-        const output = await state.execInvoke(
-          state.runContext,
-          shellHelperInput(pendingShellCancellationCommand(state)),
-          undefined,
-        );
+        const output = await this.invokePendingShellCancellationCommand(state);
         if (typeof output === "string" && parseExecBannerExitCode(output) === 0) break;
       } catch {
         // A replacement command-router connection can itself fail transiently.
@@ -1239,6 +1235,44 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
     // Transport settlement is still mandatory. Process-group absence does not
     // turn a pending provider promise into completion.
     await state.settledPromise;
+  }
+
+  private async invokePendingShellCancellationCommand(state: PendingShellStart): Promise<unknown> {
+    const observation = state
+      .execInvoke(
+        state.runContext,
+        shellHelperInput(pendingShellCancellationCommand(state)),
+        undefined,
+      )
+      .then(
+        (output) => ({ kind: "fulfilled" as const, output }),
+        (error: unknown) => ({ kind: "rejected" as const, error }),
+      );
+
+    let providerCancellation: Promise<void> | null = null;
+    let outcome = await Promise.race([observation, delay(SHELL_HELPER_YIELD_MS).then(() => null)]);
+    while (outcome === null && state.cancelProviderStart) {
+      // The proof helper uses the same Modal TaskExecStart transport as the
+      // command being cancelled. Rotate that isolated start too when it fails
+      // to return within its requested helper yield; otherwise the cleanup
+      // command can recreate the original pre-yield deadlock. The provider
+      // request is rejection-contained, while both it and `observation` remain
+      // inside the authoritative settlement fence.
+      if (!providerCancellation) {
+        const cancellation = state.cancelProviderStart().catch(() => undefined);
+        providerCancellation = cancellation;
+        void cancellation.then(() => {
+          if (providerCancellation === cancellation) providerCancellation = null;
+        });
+      }
+      await Promise.race([observation, providerCancellation, delay(SHELL_POLL_MS)]);
+      outcome = await Promise.race([observation, delay(SHELL_POLL_MS).then(() => null)]);
+    }
+
+    outcome ??= await observation;
+    if (providerCancellation) await providerCancellation;
+    if (outcome.kind === "rejected") throw outcome.error;
+    return outcome.output;
   }
 
   private registerRemoteExec(

--- a/packages/runtime/test/turn-tool-cancellation.test.ts
+++ b/packages/runtime/test/turn-tool-cancellation.test.ts
@@ -657,6 +657,76 @@ describe("turn sandbox-tool physical cancellation fence", () => {
     expect(cancellationCommands[0]).toContain("command kill -KILL");
   });
 
+  test("abort also cancels a cleanup exec that stalls before provider yield", async () => {
+    const abort = new AbortController();
+    const controller = createTurnToolCancellationController(abort.signal);
+    let rejectOriginal!: (error: Error) => void;
+    let rejectCleanup!: (error: Error) => void;
+    let execStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      execStarted = resolve;
+    });
+    const original = new Promise<string>((_resolve, reject) => {
+      rejectOriginal = reject;
+    });
+    const cleanup = new Promise<string>((_resolve, reject) => {
+      rejectCleanup = reject;
+    });
+    let releaseCleanupCancellation!: () => void;
+    const cleanupCancellation = new Promise<void>((resolve) => {
+      releaseCleanupCancellation = resolve;
+    });
+    let markCleanupCancellationStarted!: () => void;
+    const cleanupCancellationStarted = new Promise<void>((resolve) => {
+      markCleanupCancellationStarted = resolve;
+    });
+    const cancellationCommands: string[] = [];
+    let execCalls = 0;
+    const exec = functionTool("exec_command", async (_context, rawInput) => {
+      execCalls += 1;
+      const cmd = String((JSON.parse(rawInput) as { cmd?: unknown }).cmd);
+      if (execCalls === 1) {
+        execStarted();
+        return await original;
+      }
+      cancellationCommands.push(cmd);
+      if (execCalls === 2) return await cleanup;
+      return exited(0);
+    });
+    const write = functionTool("write_stdin", async () => exited(130));
+    let providerCancellations = 0;
+    const wrapped = controller.wrapTools([exec, write], {
+      supportsPty: () => true,
+      cancelPendingExecCommand: async () => {
+        providerCancellations += 1;
+        if (providerCancellations === 1) {
+          rejectOriginal(new Error("original Modal command-router transport closed"));
+        } else if (providerCancellations === 2) {
+          rejectCleanup(new Error("cleanup Modal command-router transport closed"));
+          markCleanupCancellationStarted();
+          await cleanupCancellation;
+        }
+      },
+    }) as Array<Extract<Tool<unknown>, { type: "function" }>>;
+
+    const invocation = wrapped[0]!
+      .invoke(runContext, JSON.stringify({ cmd: "sleep 60" }))
+      .catch((error) => error);
+    await started;
+    abort.abort(new Error("steered"));
+    const quiescence = controller.waitForQuiescence();
+    await cleanupCancellationStarted;
+    expect(await pendingAfterMicrotasks(quiescence)).toBe(true);
+    releaseCleanupCancellation();
+    await quiescence;
+
+    expect(await invocation).toBeInstanceOf(Error);
+    expect(providerCancellations).toBe(2);
+    expect(cancellationCommands).toHaveLength(2);
+    expect(cancellationCommands[0]).toContain(".cancelled");
+    expect(cancellationCommands[1]).toContain(".cancelled");
+  });
+
   test("matching lost-session banners unregister ordinary and cancellation-finalizer PTYs", async () => {
     const ordinaryController = createTurnToolCancellationController();
     let ordinaryWrites = 0;


### PR DESCRIPTION
## What

- make the token-scoped cleanup proof cancel its own Modal exec start when that start stalls before provider yield
- keep every started provider cancellation inside the physical-quiescence fence until it settles
- add the required focused runtime patch changeset so the corrected bytes receive their own immutable package version

## Why

The #1178 fix cancelled a stalled user command start, then issued the tombstone/process-group proof through the same exec-start transport. If that proof start stalled in the same way, quiescence could still hang. A first follow-up attempt also exposed a late-cancellation race; this final implementation awaits that cancellation before opening the fence.

## Verification

- `bun test packages/runtime/test/turn-tool-cancellation.test.ts packages/runtime/test/modal-snapshot-retention.test.ts` — 33 pass, 3 environment-dependent skips, 0 fail
- `bun run --cwd packages/runtime typecheck`
- `bunx oxfmt --check ...`
- `bunx oxlint --deny-warnings ...`
- `bunx changeset status` — runtime 0.18.28 plus exact dependent closure
- `git diff --check`
- structured Codex autoreview: two P1 findings accepted and fixed; final rerun clean with no actionable findings
