### PR TITLE
fix(events): preserve exact forensic payloads

### DIFF
--- a/.changeset/quiet-mice-replay.md
+++ b/.changeset/quiet-mice-replay.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/events": patch
+---
+
+Preserve exact retained session-event payloads for explicit forensic full replay while keeping ordinary HTTP event reads byte-bounded through the existing projection.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -1563,6 +1563,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     const projected = compact ? coalesceSessionEventDeltas(events) : events;
     const page = boundSessionEventHttpPage(projected, {
       direction,
+      eventProjection: mode === "forensic" && payloadMode === "full" ? "exact" : "bounded",
     });
     const hasMore = dbPage.hasMore || page.truncated;
     c.header("X-OpenGeni-Page-Bytes", String(page.bytes));

--- a/apps/api/test/session-events-page.test.ts
+++ b/apps/api/test/session-events-page.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { signDelegatedAccessToken } from "@opengeni/contracts";
+import { sessionEventPayloadTruncation, signDelegatedAccessToken } from "@opengeni/contracts";
 import { bootstrapWorkspace, createDb, createSession, type DbClient } from "@opengeni/db";
 import type { ApiRouteDeps, SessionWorkflowClient } from "@opengeni/core";
 import {
@@ -258,6 +258,56 @@ describe("session event byte-bounded HTTP pages", () => {
       { headers: { authorization } },
     );
     expect(invalidResultMode.status).toBe(400);
+  });
+
+  test("returns exact oversized forensic payloads without widening ordinary full reads", async () => {
+    if (!available) return;
+    const { workspaceId, sessionId, authorization } = await fixture();
+    const [session] = await admin<Array<{ accountId: string }>>`
+      select account_id as "accountId" from sessions where id = ${sessionId}`;
+    const callId = `forensic-${crypto.randomUUID()}`;
+    const oversizedOutput = "界".repeat(Math.ceil((128 * 1024) / 3));
+    const outputPayload = {
+      id: callId,
+      output: { id: `${callId}-oversized`, output: oversizedOutput },
+    };
+    await admin`
+      insert into session_events (
+        account_id, workspace_id, session_id, sequence, type, payload
+      ) values
+        (${session!.accountId}, ${workspaceId}, ${sessionId}, 1, 'agent.toolCall.created',
+          ${admin.json({ id: callId, name: "exec_command", arguments: { cmd: "forensic-proof" } })}),
+        (${session!.accountId}, ${workspaceId}, ${sessionId}, 2, 'agent.toolCall.output',
+          ${admin.json(outputPayload)})`;
+
+    const forensic = await app.request(
+      `http://x/v1/workspaces/${workspaceId}/sessions/${sessionId}/events?mode=forensic&payloadMode=full&after=0&limit=2`,
+      { headers: { authorization } },
+    );
+    expect(forensic.status).toBe(200);
+    const forensicBody = (await forensic.json()) as Array<{ type: string; payload: unknown }>;
+    expect(forensicBody).toHaveLength(2);
+    expect(forensicBody[1]).toEqual(
+      expect.objectContaining({
+        type: "agent.toolCall.output",
+        payload: outputPayload,
+      }),
+    );
+    expect(sessionEventPayloadTruncation(forensicBody[1]?.payload)).toBeNull();
+    expect(forensic.headers.get("X-OpenGeni-Forensic-Exact")).toBe("true");
+
+    const ordinaryFull = await app.request(
+      `http://x/v1/workspaces/${workspaceId}/sessions/${sessionId}/events?mode=monitoring&payloadMode=full&after=0&limit=2`,
+      { headers: { authorization } },
+    );
+    expect(ordinaryFull.status).toBe(200);
+    const ordinaryBody = (await ordinaryFull.json()) as Array<{ type: string; payload: unknown }>;
+    expect(ordinaryBody).toHaveLength(2);
+    expect(ordinaryBody[1]?.payload).not.toEqual(outputPayload);
+    expect(sessionEventPayloadTruncation(ordinaryBody[1]?.payload)?.surface).toBe(
+      "http_projection",
+    );
+    expect(ordinaryFull.headers.get("X-OpenGeni-Forensic-Exact")).toBe("false");
   });
 
   test("compact pages expose exact bytes and advance through coalescedUntil", async () => {

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -865,7 +865,12 @@ export function sessionEventBatchesByBytes(
 /** Return one count+byte-bounded HTTP page and truthful continuation facts. */
 export function boundSessionEventHttpPage(
   events: readonly SessionEvent[],
-  options: { direction: "after" | "before"; maxBytes?: number },
+  options: {
+    direction: "after" | "before";
+    maxBytes?: number;
+    /** Exact mode is restricted to already-canonical forensic REST rows. */
+    eventProjection?: "bounded" | "exact";
+  },
 ): {
   events: SessionEvent[];
   truncated: boolean;
@@ -875,7 +880,10 @@ export function boundSessionEventHttpPage(
   const maxBytes = options.maxBytes ?? SESSION_EVENT_HTTP_PAGE_MAX_BYTES;
   const selected: SessionEvent[] = [];
   let bytes = 2; // []
-  const projected = events.map((event) => boundSessionEventForSurface(event, "http_projection"));
+  const projected =
+    options.eventProjection === "exact"
+      ? [...events]
+      : events.map((event) => boundSessionEventForSurface(event, "http_projection"));
   const candidates = options.direction === "after" ? projected : [...projected].reverse();
   for (const event of candidates) {
     const eventBytes = sessionEventJsonBytes(event);

--- a/packages/events/test/events.test.ts
+++ b/packages/events/test/events.test.ts
@@ -540,6 +540,31 @@ describe("session event transport envelopes", () => {
       "http_projection",
     );
   });
+
+  test("preserves canonical oversized payloads only for explicit exact HTTP pages", () => {
+    const payload = {
+      id: "forensic-call",
+      output: {
+        id: "forensic-call-oversized",
+        output: "界".repeat(Math.ceil((128 * 1024) / 3)),
+      },
+    };
+    const retained = event(90, payload);
+
+    const exact = boundSessionEventHttpPage([retained], {
+      direction: "after",
+      eventProjection: "exact",
+    });
+    expect(exact.events).toEqual([retained]);
+    expect(exact.events[0]?.payload).toEqual(payload);
+    expect(sessionEventPayloadTruncation(exact.events[0]?.payload)).toBeNull();
+
+    const bounded = boundSessionEventHttpPage([retained], { direction: "after" });
+    expect(bounded.events[0]?.payload).not.toEqual(payload);
+    expect(sessionEventPayloadTruncation(bounded.events[0]?.payload)?.surface).toBe(
+      "http_projection",
+    );
+  });
 });
 
 describe("workspace-control transport envelopes", () => {


### PR DESCRIPTION
## Problem

Ordinary release ledger `Cloudgeni-ai/opengeni-ops#380` deployed source `2b4a721d71324a32a2215202b657ea396cf30bc6` successfully, but authenticated acceptance run `31203473267` failed at `checks/release-incident-canary.ts:747` with `incident telemetry full payload semantics mismatch`.

The route advertises `X-OpenGeni-Forensic-Exact: true` for `mode=forensic&payloadMode=full`, but then unconditionally applies the legacy `http_projection`, truncating the retained 128 KiB UTF-8 tool output.

## Fix

- Keep the current bounded HTTP projection as the default.
- Permit an explicit exact pager mode only for already-canonical rows.
- Select exact mode only for `mode=forensic&payloadMode=full`.
- Add a 128 KiB UTF-8 positive round-trip and a near-identical monitoring/full planted negative that must remain projected.
- Add patch changesets for `@opengeni/events` and `@opengeni/api-router`.

## Local verification

- `bun run format:check` — pass
- `bun run lint` — pass
- `bun run typecheck` — 23/23 projects pass
- `bun test packages/events/test/events.test.ts` — 17/17 pass
- `OPENGENI_REQUIRE_REAL_DB=1 bun test --timeout 180000 apps/api/test/session-events-page.test.ts` — blocked before tests because this Modal sandbox has neither Docker daemon nor PostgreSQL; exact error preserved: `PostgreSQL test database unavailable while OPENGENI_REQUIRE_REAL_DB=1`

**No-Claim:** the subsequent local API test file run used its documented no-PostgreSQL skip path. This PR is not merge-ready until protected CI runs the new API test against real PostgreSQL and passes.

## Release impact

Ledger #380 is closed failed. Do not publish its pending npm BOM. After this fix is reviewed and merged, create a new canonical candidate/release train and restart from staging; never rerun the failed child.