### PR TITLE
fix(react): disclose bounded tool output truthfully

### DIFF
--- a/.changeset/truthful-browser-truncation.md
+++ b/.changeset/truthful-browser-truncation.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Render bounded tool-output previews with explicit delivery and full-evidence truncation facts.

--- a/packages/react/src/timeline/activity-rail.tsx
+++ b/packages/react/src/timeline/activity-rail.tsx
@@ -14,7 +14,7 @@ import { defaultToolRegistry } from "./tool-renderers";
 import { useEntranceAnimation, useEntranceAnimationLive } from "./entrance";
 import type { RetainedScreenshotLoader, ToolRegistry } from "./registry";
 import { useSeenActivityIds } from "./seen-activity-ids";
-import { BodyNote, PayloadBlock, ActivityDisclosure } from "./shared";
+import { BodyNote, PayloadBlock, ActivityDisclosure, ToolCallTruncationProvider } from "./shared";
 import { toolDisplayName } from "./tool-display-name";
 import type { ActivityItem, MemoryItem, ReasoningItem, SandboxItem, WorkerItem } from "./types";
 
@@ -152,7 +152,11 @@ function renderActivity(
       return <ReasoningRow item={item} />;
     case "tool-call": {
       const Renderer = toolRegistry.resolve(item);
-      return <Renderer item={item} loadRetainedScreenshot={loadRetainedScreenshot} />;
+      return (
+        <ToolCallTruncationProvider value={item.truncation ?? null}>
+          <Renderer item={item} loadRetainedScreenshot={loadRetainedScreenshot} />
+        </ToolCallTruncationProvider>
+      );
     }
     case "worker":
       return <WorkerRow item={item} onOpenSession={onOpenSession} />;

--- a/packages/react/src/timeline/projection.ts
+++ b/packages/react/src/timeline/projection.ts
@@ -21,6 +21,7 @@ import type {
   TimelineItem,
   TurnEndItem,
   ToolCallItem,
+  ToolCallTruncation,
   WorkerItem,
 } from "./types";
 
@@ -312,6 +313,7 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
           name,
           arguments: args,
           output: undefined,
+          truncation: null,
           // The provider-native item drives the per-tool renderers (apply_patch
           // operation, computer_call action, web_search providerData, …).
           raw: payload.raw,
@@ -336,8 +338,14 @@ export function buildTimeline(events: SessionEvent[]): TimelineItem[] {
         }
         // An output carrying an explicit error flag (or an MCP isError result)
         // settles the tool to "failed" so the renderer can surface it loudly.
+        const truncation = toolCallTruncation(payload);
         target.status = isErrorOutput(payload) ? "failed" : "complete";
-        target.output = payload.output;
+        target.output = Object.prototype.hasOwnProperty.call(payload, "output")
+          ? payload.output
+          : truncation && typeof payload.preview === "string"
+            ? payload.preview
+            : payload.output;
+        target.truncation = truncation;
         break;
       }
 
@@ -1438,6 +1446,31 @@ function isErrorOutput(payload: Record<string, unknown>): boolean {
   return (
     !!output && typeof output === "object" && (output as { isError?: unknown }).isError === true
   );
+}
+
+function toolCallTruncation(payload: Record<string, unknown>): ToolCallTruncation | null {
+  const truncation = asRecord(payload.truncation);
+  const fullEvidence = asRecord(truncation.fullEvidence);
+  const surface = stringValue(truncation.surface);
+  const reason = stringValue(truncation.reason);
+  if (
+    truncation.truncated !== true ||
+    !surface ||
+    !reason ||
+    typeof fullEvidence.available !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    truncated: true,
+    surface,
+    reason,
+    omittedBytes: numberOrNull(truncation.omittedBytes),
+    fullEvidence: {
+      available: fullEvidence.available,
+      reason: stringValue(fullEvidence.reason) || null,
+    },
+  };
 }
 
 function findOpenCall(

--- a/packages/react/src/timeline/shared.tsx
+++ b/packages/react/src/timeline/shared.tsx
@@ -1,9 +1,10 @@
 import { CameraIcon, CameraOffIcon, ChevronRightIcon } from "lucide-react";
-import { useState, type ReactNode } from "react";
+import { createContext, useContext, useState, type ReactNode } from "react";
 import { cn } from "../lib/cn";
 import { stringifyPayload } from "../lib/format";
 import { useForcedDefaultOpen } from "./disclosure-context";
 import { useLightboxOptional } from "./screenshot-lightbox";
+import type { ToolCallTruncation } from "./types";
 
 /* ----------------------------------------------------------------------------
    Shared timeline primitives
@@ -36,6 +37,22 @@ export type DisclosureChip = {
   tone: "ok" | "bad" | "muted" | "interrupted";
   text: string;
 };
+
+const ToolCallTruncationContext = createContext<ToolCallTruncation | null>(null);
+
+export function ToolCallTruncationProvider({
+  value,
+  children,
+}: {
+  value: ToolCallTruncation | null;
+  children: ReactNode;
+}) {
+  return (
+    <ToolCallTruncationContext.Provider value={value}>
+      {children}
+    </ToolCallTruncationContext.Provider>
+  );
+}
 
 export type ActivityDisclosureProps = {
   icon: ReactNode;
@@ -129,7 +146,8 @@ export function ActivityDisclosure({
   // absent in normal app usage, where the row starts collapsed.
   const forcedDefaultOpen = useForcedDefaultOpen();
   const [open, setOpen] = useState(forcedDefaultOpen ?? false);
-  const hasBody = expandable && children != null;
+  const truncation = useContext(ToolCallTruncationContext);
+  const hasBody = expandable && (children != null || truncation != null);
 
   // The preview is detail-on-demand: it is suppressed once the row is open so a
   // path/stat shown in the body never also sits in the collapsed row.
@@ -235,8 +253,27 @@ export function ActivityDisclosure({
       {open ? (
         <div className="mb-2 ml-7 mt-1.5 flex flex-col gap-2 overflow-hidden animate-og-expand">
           {children}
+          {truncation ? <ToolCallTruncationNotice truncation={truncation} /> : null}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function ToolCallTruncationNotice({ truncation }: { truncation: ToolCallTruncation }) {
+  const fullEvidence = truncation.fullEvidence.available
+    ? "retained"
+    : (truncation.fullEvidence.reason ?? "unavailable");
+  return (
+    <div data-og-tool-output-truncation="" className="text-og-sm leading-5 text-og-fg-subtle">
+      Output bounded at <code className="font-og-mono">{truncation.surface}</code>
+      {truncation.omittedBytes != null && truncation.omittedBytes > 0
+        ? ` · ${truncation.omittedBytes.toLocaleString()} bytes omitted`
+        : null}
+      {" · reason "}
+      <code className="font-og-mono">{truncation.reason}</code>
+      {" · full evidence "}
+      <code className="font-og-mono">{fullEvidence}</code>
     </div>
   );
 }

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -44,6 +44,23 @@ export type ReasoningItem = {
   occurredAt: string;
 };
 
+/**
+ * Bounded delivery metadata carried by a projected tool-output event. The
+ * canonical event remains unchanged; this fact only explains what the current
+ * timeline surface could render and whether separately retained full evidence
+ * exists.
+ */
+export type ToolCallTruncation = {
+  truncated: true;
+  surface: string;
+  reason: string;
+  omittedBytes: number | null;
+  fullEvidence: {
+    available: boolean;
+    reason: string | null;
+  };
+};
+
 export type ToolCallItem = {
   kind: "tool-call";
   id: string;
@@ -52,6 +69,7 @@ export type ToolCallItem = {
   name: string;
   arguments: unknown;
   output: unknown;
+  truncation?: ToolCallTruncation | null;
   /**
    * The provider-native tool item (`agent.toolCall.created.payload.raw`). Carries
    * `type` (e.g. `apply_patch_call`, `computer_call`, `hosted_tool_call`) and the

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -239,12 +239,70 @@ function toolItem(overrides: Partial<ToolCallItem>): ToolCallItem {
     name: "exec_command",
     arguments: {},
     output: undefined,
+    truncation: null,
     raw: undefined,
     status: "complete",
     occurredAt: new Date(0).toISOString(),
     ...overrides,
   };
 }
+
+describe("tool-output truncation disclosure", () => {
+  test("shows bounded delivery and non-retention facts only after expansion", async () => {
+    const item = toolItem({
+      arguments: { cmd: "incident-canary-telemetry" },
+      output: "bounded preview",
+      truncation: {
+        truncated: true,
+        surface: "browser_legacy_guard",
+        reason: "event_envelope_bytes_exceeded",
+        omittedBytes: 83_000,
+        fullEvidence: { available: false, reason: "not_retained" },
+      },
+    });
+    const r = await renderComponent(<ActivityRail items={[item]} bare />);
+    await flush();
+
+    expect(r.container.textContent).not.toContain("not_retained");
+    const disclosure = r.container.querySelector('[role="button"]');
+    expect(disclosure).not.toBeNull();
+    await act(async () => {
+      disclosure?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    expect(r.container.textContent).toContain("bounded preview");
+    expect(r.container.textContent).toContain("browser_legacy_guard");
+    expect(r.container.textContent).toContain("event_envelope_bytes_exceeded");
+    expect(r.container.textContent).toContain("not_retained");
+    expect(r.container.querySelector("[data-og-tool-output-truncation]")).not.toBeNull();
+
+    await r.unmount();
+  });
+
+  test("keeps the near-identical ordinary output free of truncation claims", async () => {
+    const item = toolItem({
+      arguments: { cmd: "incident-canary-telemetry" },
+      output: "bounded preview",
+    });
+    const r = await renderComponent(<ActivityRail items={[item]} bare />);
+    await flush();
+
+    const disclosure = r.container.querySelector('[role="button"]');
+    expect(disclosure).not.toBeNull();
+    await act(async () => {
+      disclosure?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    expect(r.container.textContent).toContain("bounded preview");
+    expect(r.container.textContent).not.toContain("browser_legacy_guard");
+    expect(r.container.textContent).not.toContain("not_retained");
+    expect(r.container.querySelector("[data-og-tool-output-truncation]")).toBeNull();
+
+    await r.unmount();
+  });
+});
 
 function fleetDecisionEventPayload(): Record<string, unknown> {
   return {

--- a/packages/react/test/timeline.test.ts
+++ b/packages/react/test/timeline.test.ts
@@ -805,6 +805,62 @@ describe("buildTimeline", () => {
     expect(second.output).toBe("resource {}");
   });
 
+  test("projects a bounded tool-output preview with truthful truncation metadata", () => {
+    reset();
+    const preview = '{"id":"call-1","output":"bounded preview"}';
+    const items = buildTimeline([
+      event("agent.toolCall.created", {
+        id: "call-1",
+        name: "exec_command",
+        arguments: { cmd: "incident-canary-telemetry" },
+      }),
+      event("agent.toolCall.output", {
+        id: "call-1",
+        preview,
+        truncation: {
+          truncated: true,
+          surface: "browser_legacy_guard",
+          reason: "event_envelope_bytes_exceeded",
+          omittedBytes: 83_000,
+          fullEvidence: { available: false, reason: "not_retained" },
+        },
+      }),
+    ]);
+
+    expect(items[0]).toMatchObject({
+      kind: "tool-call",
+      output: preview,
+      truncation: {
+        truncated: true,
+        surface: "browser_legacy_guard",
+        reason: "event_envelope_bytes_exceeded",
+        omittedBytes: 83_000,
+        fullEvidence: { available: false, reason: "not_retained" },
+      },
+    });
+  });
+
+  test("does not synthesize truncation metadata for an ordinary tool output", () => {
+    reset();
+    const items = buildTimeline([
+      event("agent.toolCall.created", {
+        id: "call-1",
+        name: "exec_command",
+        arguments: { cmd: "incident-canary-telemetry" },
+      }),
+      event("agent.toolCall.output", {
+        id: "call-1",
+        output: '{"id":"call-1","output":"bounded preview"}',
+      }),
+    ]);
+
+    expect(items[0]).toMatchObject({
+      kind: "tool-call",
+      output: '{"id":"call-1","output":"bounded preview"}',
+      truncation: null,
+    });
+  });
+
   test("a completed hosted web-search item settles without a separate output event", () => {
     reset();
     const items = buildTimeline([


### PR DESCRIPTION
## Why

OpenGeni `0.22.86` production acceptance run `31226139009` expanded the exact synthetic tool-output row but the browser timeline discarded the bounded `preview` and did not disclose `fullEvidence.reason=not_retained`. The canonical event remained lossless; the rendered projection was not truthful about its browser boundary.

## Change

- preserve a bounded tool-output `preview` when the projected event omits `output`;
- carry additive, optional truncation metadata on `ToolCallItem`;
- render the delivery surface, omission count, projection reason, and full-evidence state inside the standard expanded activity disclosure;
- keep ordinary, unbounded tool outputs unchanged.

## Verification

- `bun test packages/react/test` — 1,110 pass
- `bun run --cwd packages/react typecheck`
- `bun run --cwd packages/react build`
- `bun run lint`
- `bun run typecheck` — all 23 projects clean
- `bun run format:check`
- `git diff --check`

Positive DOM proof exercises `browser_legacy_guard` + `not_retained`; a near-identical ordinary-output negative proves no truncation claim is synthesized.

**No-Claim:** this PR does not alter canonical event storage, model context, release images already deployed, or the acceptance workflow. The live production acceptance gate must be rerun only after this source is released and deployed through the canonical chain.
