### PR TITLE
chore(release): bump product version to 0.22.87

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.86
-appVersion: "0.22.86"
+version: 0.22.87
+appVersion: "0.22.87"


### PR DESCRIPTION
## Base

Exact base: `a0215c3bab339a66d5ade24c9a15532f09b5ef06`.

## Validation

- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml` returned exactly `0.22.87`.
- `bun test scripts/release-version.test.ts scripts/release-candidate.test.ts scripts/release-bom.test.ts` passed: 13 tests, 0 failures.
- `git diff --check` passed.
- Diff against the exact base is limited to `deploy/helm/opengeni/Chart.yaml`, changing only `version` and `appVersion` to `0.22.87`.

## Release intent

This is a fresh ordinary release source for the truthful browser-truncation disclosure fix merged through #1193 and package-version PR #1194.

This PR has explicitly no retry linkage to failed immutable ledger #381; the corrected source and candidate will create a new ledger.