### PR TITLE
chore(release): bump product version to 0.22.88

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.87
-appVersion: "0.22.87"
+version: 0.22.88
+appVersion: "0.22.88"


### PR DESCRIPTION
## Release intent

Release the crash-safe sandbox drain lifecycle merged in #1198 as product version 0.22.88.

## Exact admission

- Reviewed base: `143bebeb1452cec4c10886ec69ccf7d2b535fa9b`
- Candidate head: `5391fe939b17198a5aea78718e8d6fc615894165`
- Diff: only `deploy/helm/opengeni/Chart.yaml`, with chart and app version `0.22.87` → `0.22.88`

## Validation

- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml` → `0.22.88`
- release version/candidate/BOM tests: 13 pass, 0 fail
- `bun x changeset status --since origin/main`: no packages to bump
- `git diff --check origin/main...HEAD`: clean