### PR TITLE
fix(release): accept draining sandbox as dormant

### DIFF
--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -17,6 +17,7 @@ import {
   captureApiRegionalProbeEnvironment,
   controlCancellationDurationMs,
   fixturePrompt,
+  isDormantSandboxLiveness,
   isExpectedBrowserCancellation,
   maskKnownPublicEvidenceValues,
   openWorkspaceIfCollapsed,
@@ -686,6 +687,13 @@ describe("workbench live acceptance preflight", () => {
 
     expect(calls).toBe(2);
     expect(signals).toHaveLength(2);
+  });
+
+  test("accepts holderless draining as dormant without admitting a warm sandbox", () => {
+    expect(isDormantSandboxLiveness("cold")).toBe(true);
+    expect(isDormantSandboxLiveness("draining")).toBe(true);
+    expect(isDormantSandboxLiveness("warming")).toBe(false);
+    expect(isDormantSandboxLiveness("warm")).toBe(false);
   });
 
   test("requires interactive scopes only from the dedicated canary principal", () => {

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -386,7 +386,11 @@ async function main(): Promise<void> {
   );
 
   await waitForCold(cookieClient, workspaceId, session.id, args.coldTimeoutMs);
-  pass(checks, "functional.real-cold-lease", "The real Modal lease reached cold before UI review.");
+  pass(
+    checks,
+    "functional.real-cold-lease",
+    "The real Modal lease reached a dormant cold/draining state before UI review.",
+  );
 
   const captureApiRegionProbe = await runCaptureApiRegionalProbe(
     args.captureApiRegionProbeCommand,
@@ -483,13 +487,13 @@ async function main(): Promise<void> {
     }
 
     const afterPassiveBrowser = await cookieClient.getStreamCapabilities(workspaceId, session.id);
-    if (afterPassiveBrowser.liveness !== "cold") {
+    if (!isDormantSandboxLiveness(afterPassiveBrowser.liveness)) {
       throw new Error("passive browser acceptance unexpectedly warmed the sandbox");
     }
     pass(
       checks,
       "functional.capture-cold-zero-channel-a",
-      "Fresh desktop/mobile browsers rendered capture-backed Changes and Files with zero Channel-A requests and left the lease cold.",
+      "Fresh desktop/mobile browsers rendered capture-backed Changes and Files with zero Channel-A requests and left the lease dormant.",
     );
 
     const liveFlow = await runLiveWorkspaceFlow({
@@ -1012,13 +1016,23 @@ export async function waitForSandboxLiveness(
   );
 }
 
+export function isDormantSandboxLiveness(liveness: string): boolean {
+  return liveness === "cold" || liveness === "draining";
+}
+
 async function waitForCold(
   client: OpenGeniClient,
   workspaceId: string,
   sessionId: string,
   timeoutMs: number,
 ): Promise<void> {
-  await waitForSandboxLiveness(client, workspaceId, sessionId, new Set(["cold"]), timeoutMs);
+  await waitForSandboxLiveness(
+    client,
+    workspaceId,
+    sessionId,
+    new Set(["cold", "draining"]),
+    timeoutMs,
+  );
 }
 
 async function waitForWarm(


### PR DESCRIPTION
## What
- treat holderless `draining` as a valid dormant state in live workbench acceptance
- keep `warming` and `warm` rejected
- update evidence language from literal cold to dormant cold/draining

## Proof
- `bun test scripts/workbench-live-acceptance.test.ts` — 25 pass, 0 fail
- `bun x oxfmt --check scripts/workbench-live-acceptance.ts scripts/workbench-live-acceptance.test.ts`
- `bun x oxlint scripts/workbench-live-acceptance.ts scripts/workbench-live-acceptance.test.ts` — 0 warnings/errors
- `bun run typecheck` — all 23 projects clean
- `git diff --check`

Positive observable: `cold` and holderless `draining` are accepted as dormant.
Planted near-identical negatives: `warming` and `warm` remain rejected.

No-Claim: this changes only the release acceptance verifier; it does not claim or alter sandbox runtime lifecycle behavior.