### PR TITLE
fix(worker): settle abandoned turn admissions

### DIFF
--- a/.changeset/settle-turn-admissions.md
+++ b/.changeset/settle-turn-admissions.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/worker-bundle": patch
+"@opengeni/db": patch
+---
+
+Settle abandoned turn workspace admissions only after the exact attempt's physical writers drain, while preserving eager cancellation holder release and late sandbox provisioning safety.

--- a/.changeset/settle-turn-admissions.md
+++ b/.changeset/settle-turn-admissions.md
@@ -1,6 +1,7 @@
 ---
 "@opengeni/worker-bundle": patch
 "@opengeni/db": patch
+"@opengeni/observability": patch
 ---
 
-Settle abandoned turn workspace admissions only after the exact attempt's physical writers drain, while preserving eager cancellation holder release and late sandbox provisioning safety.
+Settle abandoned turn workspace admissions only after the exact attempt's physical writers drain, while preserving eager cancellation holder release and late sandbox provisioning safety. Add privacy-preserving sandbox lease correlation keys to rendered lifecycle logs.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -809,6 +809,37 @@ export async function drainAttemptOwnedSandboxWriters(input: {
   await input.runCredentialRenewal?.stop();
 }
 
+/** Persist the exact turn's second-stage release only after the caller has
+ * crossed the physical writer boundary. This wait is intentionally independent
+ * of Temporal cancellation: it is a short idempotent DB transaction that closes
+ * the durable archive-capture fence. Bounded retries cover a rollout connection
+ * reset without turning ordinary finalizer housekeeping into lifecycle state. */
+export async function releaseTurnSandboxAfterWriterDrain(
+  sandbox: Pick<ResumedTurnSandbox, "release">,
+  options: {
+    maxAttempts?: number;
+    retryDelayMs?: number;
+    wait?: (delayMs: number) => Promise<void>;
+  } = {},
+): Promise<void> {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 3);
+  const retryDelayMs = Math.max(0, options.retryDelayMs ?? 50);
+  const wait = options.wait ?? sleep;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      await sandbox.release({ workspaceWritersQuiesced: true });
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxAttempts) {
+        await wait(retryDelayMs * attempt);
+      }
+    }
+  }
+  throw lastError;
+}
+
 /**
  * Await a finalizer operation only while this Temporal activity still owns its
  * execution window. Once Pause/Steer cancellation arrives, the operation keeps
@@ -2707,6 +2738,25 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // run. null when the flag is off (byte-for-byte the legacy build-and-discard
     // path) OR when the backend is "none". Released + dropped in `finally`.
     let resolvedSandbox: ResumedTurnSandbox | null = null;
+    let attemptWritersDrained = false;
+    const lateSandboxesAwaitingWriterDrain = new Set<ResumedTurnSandbox>();
+    const releaseLateSandbox = async (sandbox: ResumedTurnSandbox): Promise<void> => {
+      lateSandboxesAwaitingWriterDrain.add(sandbox);
+      // Drop the holder/timer immediately, but keep its null-outcome admissions
+      // fenced until the shared attempt writer drain completes. The staged
+      // release serializes a later proof-bearing call behind this one.
+      await sandbox.release().catch(() => undefined);
+      if (!attemptWritersDrained) return;
+      try {
+        await releaseTurnSandboxAfterWriterDrain(sandbox);
+        lateSandboxesAwaitingWriterDrain.delete(sandbox);
+      } catch (error) {
+        console.error(
+          "late sandbox quiesced release failed (turn outcome unaffected)",
+          safeErrorDiagnostic(error),
+        );
+      }
+    };
     const requireResolvedSandboxForMutation = (message: string): ResumedTurnSandbox => {
       if (!resolvedSandbox) throw new Error(message);
       return resolvedSandbox;
@@ -5594,7 +5644,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               managedOwnership!.holderId,
             ),
             sandboxResumeSignal,
-            async (lateSandbox) => await lateSandbox.release(),
+            releaseLateSandbox,
           );
           setupBoxSession = resolvedSandbox.established.session;
           // Durable box-lifecycle events (sandbox-file-persistence observability):
@@ -6167,7 +6217,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               );
             },
             disposeResult: async (provisioned) => {
-              await provisioned.release().catch(() => undefined);
+              await releaseLateSandbox(provisioned);
             },
           },
         );
@@ -8565,6 +8615,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           toolspaceTokenRenewal: toolspaceRenewalToStop,
           runCredentialRenewal: runRenewalToStop,
         });
+        attemptWritersDrained = true;
         if (acknowledgeQuiescence) {
           // A cancellation before sandbox-backed capabilities exist still has
           // no tool controller to drain. Sandbox agent construction fails closed
@@ -8873,17 +8924,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             // while the box is still solidly alive, instead of racing the turn-end
             // teardown that was killing 100% of captures on real Modal desktop boxes.
           }
-          const sandboxToRelease = resolvedSandbox;
-          resolvedSandbox = null; // drop ownership now; the exact-holder release may finish later
-          await waitForTurnFinalizerStep(
-            sandboxToRelease.release().catch((releaseError) => {
-              console.error(
-                "sandbox lease release failed (turn outcome unaffected)",
-                safeErrorDiagnostic(releaseError),
-              );
-            }),
-            finalizerSignal,
-          );
         }
       } catch (error) {
         finalizationError ??= error;
@@ -8892,9 +8932,42 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           safeErrorDiagnostic(error),
         );
       } finally {
-        // If fallible finalization exited before the ordinary exact-holder
-        // release, the resume signal is the unconditional last line of defense.
-        // Normal finalization already removed its listener in release().
+        // The writer drain is the only authority that licenses settling an
+        // abandoned turn admission. Keep this second-stage release outside all
+        // later housekeeping so an event/cache/capture/recording failure cannot
+        // strand a null-outcome admission forever. Do not race it against
+        // Temporal cancellation: the eager listener may already have dropped
+        // the holder, and this idempotent proof-bearing pass still must run.
+        stopLeaseHeartbeat();
+        const sandboxReleaseTargets = new Set(lateSandboxesAwaitingWriterDrain);
+        lateSandboxesAwaitingWriterDrain.clear();
+        if (resolvedSandbox) {
+          sandboxReleaseTargets.add(resolvedSandbox);
+          resolvedSandbox = null;
+        }
+        if (attemptWritersDrained) {
+          for (const sandboxToRelease of sandboxReleaseTargets) {
+            try {
+              await releaseTurnSandboxAfterWriterDrain(sandboxToRelease);
+            } catch (releaseError) {
+              finalizationError ??= releaseError;
+              console.error(
+                "sandbox lease quiesced release failed (turn outcome unaffected)",
+                safeErrorDiagnostic(releaseError),
+              );
+            }
+          }
+        } else {
+          // No proof exists. Ensure every late result still receives the eager
+          // leak-prevention release while preserving its admissions as a
+          // fail-closed archive-capture fence.
+          for (const sandboxToRelease of sandboxReleaseTargets) {
+            await sandboxToRelease.release().catch(() => undefined);
+          }
+        }
+        // Close provisioning after consuming the currently known targets. A
+        // provider result that races in later is routed through releaseLateSandbox;
+        // targets already released above synchronously removed their listener.
         if (!sandboxResumeController.signal.aborted) {
           sandboxResumeController.abort(
             cancellationSignal?.reason ?? new Error("TURN_ATTEMPT_FINALIZED"),

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -397,6 +397,22 @@ export function sandboxDrainCaptureId(operationId: string, attempt: number): str
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
+/**
+ * Stable, non-reversible correlation key for one logical sandbox lease. Public
+ * telemetry intentionally drops workspace/group identifiers; this key lets an
+ * operator correlate repeated reaper attempts without publishing either UUID.
+ * The domain separator makes the digest unusable as a generic identifier hash.
+ */
+export function sandboxLeaseTelemetryKey(workspaceId: string, sandboxGroupId: string): string {
+  return `slk_${createHash("sha256")
+    .update("opengeni:sandbox-lease-telemetry:v1\0")
+    .update(workspaceId)
+    .update("\0")
+    .update(sandboxGroupId)
+    .digest("hex")
+    .slice(0, 32)}`;
+}
+
 function sandboxDrainActivityAttempt(): number {
   try {
     const attempt = Context.current().info.attempt;
@@ -543,6 +559,7 @@ export function createSandboxLeaseActivities(
       } catch (error) {
         const lease = await readLease(db, row.workspaceId, row.sandboxGroupId).catch(() => null);
         const details = {
+          sandboxLeaseKey: sandboxLeaseTelemetryKey(row.workspaceId, row.sandboxGroupId),
           workspaceId: row.workspaceId,
           sandboxGroupId: row.sandboxGroupId,
           leaseEpoch: row.leaseEpoch,

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -176,9 +176,11 @@ export type ResumedTurnSandbox = {
   established: EstablishedSandboxSession;
   /** The lease_epoch this turn holds; the heartbeat/fence token. */
   leaseEpoch: number;
-  /** Idempotent release: deletes this holder row and (if refcount hits 0 with no
-   *  turn holders) CASes warm->draining. NEVER stops the box. Safe to call once. */
-  release: () => Promise<void>;
+  /** Staged idempotent release. The ordinary form immediately prevents a
+   * holder/timer leak. The quiesced form may be called later—even after the
+   * ordinary form—to repair null-outcome admissions only after every exact
+   * attempt-owned workspace writer has physically drained. NEVER stops the box. */
+  release: (options?: { workspaceWritersQuiesced?: boolean }) => Promise<void>;
 };
 
 export class SandboxWarmingTimeoutError extends Error {
@@ -715,37 +717,74 @@ export async function resumeBoxForTurn(
   // It is also bound directly to the logical attempt signal: an uninterruptible
   // provider promise must never keep its private warmup timer and holder alive
   // after Temporal has abandoned the activity.
-  let released = false;
+  let releaseStarted = false;
+  let holderRelease: Promise<void> | null = null;
+  let quiescedRelease: Promise<void> | null = null;
   let holderLivenessTimer: ReturnType<typeof setInterval> | undefined;
   let cancellationListener: (() => void) | undefined;
-  const release = async (): Promise<void> => {
-    if (released) {
-      return;
+  const release = (options?: { workspaceWritersQuiesced?: boolean }): Promise<void> => {
+    const writersQuiesced = options?.workspaceWritersQuiesced === true;
+    // First invocation synchronously closes every in-memory liveness source.
+    // A later quiesced invocation is still allowed to enter the DB: cancellation
+    // commonly wins this race and drops the holder before the physical writer
+    // drain can prove that abandoned turn admissions are safe to settle.
+    if (!releaseStarted) {
+      releaseStarted = true;
+      if (cancellationListener) {
+        cancellationSignal?.removeEventListener("abort", cancellationListener);
+        cancellationListener = undefined;
+      }
+      if (holderLivenessTimer) {
+        clearInterval(holderLivenessTimer);
+        holderLivenessTimer = undefined;
+      }
     }
-    released = true;
-    if (cancellationListener) {
-      cancellationSignal?.removeEventListener("abort", cancellationListener);
-      cancellationListener = undefined;
+    const persistRelease = async (workspaceWritersQuiesced: boolean): Promise<void> => {
+      await releaseLeaseHolder(db, {
+        accountId: ids.accountId,
+        workspaceId: ids.workspaceId,
+        sandboxGroupId: ids.sandboxGroupId,
+        kind,
+        holderId,
+        idleGraceMs: settings.sandboxIdleGraceMs,
+        ...(workspaceWritersQuiesced ? { workspaceWritersQuiesced: true } : {}),
+      });
+    };
+    if (writersQuiesced) {
+      if (!quiescedRelease) {
+        // Serialize behind an eager cancellation release when one exists. Its
+        // failure is intentionally swallowed only as a predecessor: this exact
+        // idempotent proof-bearing call retries both holder deletion and
+        // admission settlement in one transaction.
+        const predecessor = holderRelease;
+        const attempt = (predecessor ? predecessor.catch(() => undefined) : Promise.resolve()).then(
+          async () => await persistRelease(true),
+        );
+        const tracked = attempt.catch((error) => {
+          if (quiescedRelease === tracked) quiescedRelease = null;
+          throw error;
+        });
+        quiescedRelease = tracked;
+        holderRelease = tracked;
+      }
+      return quiescedRelease;
     }
-    if (holderLivenessTimer) {
-      clearInterval(holderLivenessTimer);
-      holderLivenessTimer = undefined;
+    if (!holderRelease) {
+      const attempt = persistRelease(false);
+      const tracked = attempt.catch((error) => {
+        if (holderRelease === tracked) holderRelease = null;
+        throw error;
+      });
+      holderRelease = tracked;
     }
-    await releaseLeaseHolder(db, {
-      accountId: ids.accountId,
-      workspaceId: ids.workspaceId,
-      sandboxGroupId: ids.sandboxGroupId,
-      kind,
-      holderId,
-      idleGraceMs: settings.sandboxIdleGraceMs,
-    });
+    return holderRelease;
   };
   const cancellationError = (): Error =>
     cancellationSignal?.reason instanceof Error
       ? cancellationSignal.reason
       : new Error("Sandbox resume was cancelled with its owning turn attempt");
   const throwIfReleasedOrCancelled = (): void => {
-    if (released || cancellationSignal?.aborted) {
+    if (releaseStarted || cancellationSignal?.aborted) {
       throw cancellationError();
     }
   };
@@ -778,9 +817,11 @@ export async function resumeBoxForTurn(
 
   if (cancellationSignal) {
     cancellationListener = () => {
-      // release() flips `released` and clears the timer synchronously before its
-      // first await. The detached rejection handler is intentional: the outer
-      // turn owns diagnostics, while this listener owns leak prevention.
+      // release() flips `releaseStarted` and clears the timer synchronously
+      // before its first await. This eager form deliberately carries no writer-
+      // quiescence proof; the outer turn supplies that second stage after its
+      // physical drain. The detached rejection handler is intentional: the
+      // outer turn owns diagnostics, while this listener owns leak prevention.
       void release().catch(() => undefined);
     };
     cancellationSignal.addEventListener("abort", cancellationListener, { once: true });

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -50,6 +50,7 @@ import {
   createModelResponseEventState,
   createTurnSandboxProvisioner,
   drainAttemptOwnedSandboxWriters,
+  releaseTurnSandboxAfterWriterDrain,
   emitModelCallUsage,
   ensureTurnModalRegistryImage,
   escapedMcpTimeoutRecoveryFailure,
@@ -2791,6 +2792,28 @@ describe("worker shutdown preemption", () => {
     await Promise.all([boundary, gitRefresh]);
     expect(steps.at(-1)).toBe("receipt");
     expect(receipts).toBe(1);
+  });
+
+  test("retries the proof-bearing turn release outside Temporal cancellation", async () => {
+    const proofFlags: boolean[] = [];
+    const delays: number[] = [];
+    await releaseTurnSandboxAfterWriterDrain(
+      {
+        release: async (options) => {
+          proofFlags.push(options?.workspaceWritersQuiesced === true);
+          if (proofFlags.length < 3) throw new Error("rollout connection reset");
+        },
+      },
+      {
+        maxAttempts: 3,
+        retryDelayMs: 25,
+        wait: async (delayMs) => {
+          delays.push(delayMs);
+        },
+      },
+    );
+    expect(proofFlags).toEqual([true, true, true]);
+    expect(delays).toEqual([25, 50]);
   });
 
   test("retries one immutable quiescence proof after receipt exhaustion", async () => {

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -2202,6 +2202,100 @@ describe("P1.3 reapSandboxLeases — the one global reaper (real lease + RLS, sp
     ).toMatchObject({ workspaceGeneration: 2 });
   }, 60_000);
 
+  test("(1b-release-settlement) eager turn release stays fenced until the exact writer-drained release", async () => {
+    if (!available) return;
+    const ids = await freshWorkspace();
+    const attempt = await freshWarmSnapshotAttempt(ids);
+    ids.groupId = attempt.sandboxGroupId;
+    const leaseId = await insertLease(ids, {
+      liveness: "warm",
+      refcount: 1,
+      turnHolders: 1,
+      leaseEpoch: 11,
+      expiresInMs: 600_000,
+      instanceId: "box-staged-release",
+      backend: "modal",
+      resumeBackendId: "modal",
+      resumeState: {
+        backendId: "modal",
+        sessionState: { providerState: { sandboxId: "box-staged-release" } },
+      },
+    });
+    await insertHolder(ids, leaseId, "turn", attempt.holderId, 0, attempt.sessionId);
+    const admission = await advanceWorkspaceGeneration(db, {
+      accountId: ids.accountId,
+      workspaceId: ids.workspaceId,
+      ...attempt,
+      sandboxGroupId: ids.groupId,
+      expectedEpoch: 11,
+      expectedInstanceId: "box-staged-release",
+      operation: "providerPromiseLostSettlement",
+    });
+
+    // Temporal cancellation eagerly drops the holder to prevent a liveness
+    // leak. It has not proven provider writer quiescence, so the admission must
+    // remain the archive-capture fence.
+    expect(
+      await releaseLeaseHolder(db, {
+        accountId: ids.accountId,
+        workspaceId: ids.workspaceId,
+        sandboxGroupId: ids.groupId,
+        kind: "turn",
+        holderId: attempt.holderId,
+        idleGraceMs: 45_000,
+      }),
+    ).toEqual({ liveness: "draining", refcount: 0 });
+    const [stillFenced] = await admin<
+      { provider_outcome: string | null; settled_at: Date | null }[]
+    >`
+      select provider_outcome, settled_at
+      from sandbox_workspace_mutation_admissions
+      where id = ${admission.id}`;
+    expect(stillFenced).toEqual({ provider_outcome: null, settled_at: null });
+    expect(
+      await readWorkspaceArchiveCapturePreflight(db, {
+        accountId: ids.accountId,
+        workspaceId: ids.workspaceId,
+        sandboxGroupId: ids.groupId,
+        expectedEpoch: 11,
+        expectedInstanceId: "box-staged-release",
+        liveness: "draining",
+      }),
+    ).toBeNull();
+
+    // The activity's non-detachable writer drain is stronger authority. Its
+    // second idempotent release must work even though the holder is already
+    // gone, close only this exact turn's null-outcome admissions, and unblock
+    // generation-complete capture.
+    expect(
+      await releaseLeaseHolder(db, {
+        accountId: ids.accountId,
+        workspaceId: ids.workspaceId,
+        sandboxGroupId: ids.groupId,
+        kind: "turn",
+        holderId: attempt.holderId,
+        idleGraceMs: 45_000,
+        workspaceWritersQuiesced: true,
+      }),
+    ).toEqual({ liveness: "draining", refcount: 0 });
+    const [settled] = await admin<{ provider_outcome: string | null; settled_at: Date | null }[]>`
+      select provider_outcome, settled_at
+      from sandbox_workspace_mutation_admissions
+      where id = ${admission.id}`;
+    expect(settled?.provider_outcome).toBe("rejected");
+    expect(settled?.settled_at).not.toBeNull();
+    expect(
+      await readWorkspaceArchiveCapturePreflight(db, {
+        accountId: ids.accountId,
+        workspaceId: ids.workspaceId,
+        sandboxGroupId: ids.groupId,
+        expectedEpoch: 11,
+        expectedInstanceId: "box-staged-release",
+        liveness: "draining",
+      }),
+    ).toMatchObject({ workspaceGeneration: admission.workspaceGeneration });
+  }, 60_000);
+
   test("(1b-settlement-race) provider success settles once before a stale-route rejection", async () => {
     if (!available) return;
     const ids = await freshWorkspace();

--- a/apps/worker/test/sandbox-lease.test.ts
+++ b/apps/worker/test/sandbox-lease.test.ts
@@ -77,6 +77,7 @@ import {
 } from "@opengeni/testing";
 import {
   createSandboxLeaseActivities,
+  sandboxLeaseTelemetryKey,
   type SweepModalOrphansFn,
   type TerminateBoxFn,
 } from "../src/activities/sandbox-lease";
@@ -95,6 +96,18 @@ const MODAL_PROVIDER_BINDING = {
     environment: "test",
   },
 };
+
+test("sandbox lease telemetry keys are stable, scoped, and contain no raw identifiers", () => {
+  const workspaceId = "c77bf2b8-3d09-4963-a40d-30588f5139f7";
+  const groupId = "9725b1c3-0d87-44a8-aa63-f6cbee2a1bc9";
+  const key = sandboxLeaseTelemetryKey(workspaceId, groupId);
+
+  expect(key).toMatch(/^slk_[0-9a-f]{32}$/);
+  expect(key).toBe(sandboxLeaseTelemetryKey(workspaceId, groupId));
+  expect(key).not.toContain(workspaceId);
+  expect(key).not.toContain(groupId);
+  expect(key).not.toBe(sandboxLeaseTelemetryKey(workspaceId, crypto.randomUUID()));
+});
 
 // Swap process.env for the duration of a getSettings() parse (mirrors the
 // @opengeni/config test harness; getSettings reads process.env, not an arg).

--- a/apps/worker/test/sandbox-resume.test.ts
+++ b/apps/worker/test/sandbox-resume.test.ts
@@ -24,11 +24,14 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import postgres from "postgres";
 import {
   acquireLease,
+  advanceWorkspaceGeneration,
   beginSandboxRematerialization,
+  claimSessionWorkForAttempt,
   commitWarmingToWarm,
   createSession,
   createDb,
   heartbeatLeaseHolder,
+  initializeSessionStartAtomically,
   markSandboxRestoreVerifying,
   markWarmLeaseInstanceLost,
   readLease,
@@ -230,6 +233,90 @@ describe("P1.2 resumeBoxForTurn — stateless resume-by-id (local backend, real 
     const drained = await readRow(workspaceId, groupId);
     expect(drained?.liveness).toBe("draining");
     expect(drained?.refcount).toBe(0);
+  }, 60_000);
+
+  test("(1a) an eager cancellation release can be followed by the exact writer-drained settlement", async () => {
+    if (!available) return;
+    const settings = settingsFor(true);
+    const { accountId, workspaceId } = await freshWorkspace();
+    const session = await createSession(db, {
+      accountId,
+      workspaceId,
+      initialMessage: "exercise staged turn release",
+      resources: [],
+      metadata: {},
+      model: "scripted-model",
+      sandboxBackend: "none",
+    });
+    await initializeSessionStartAtomically(db, {
+      accountId,
+      workspaceId,
+      sessionId: session.id,
+      reasoningEffortFallback: "low",
+      createdEventPayload: {},
+    });
+    const attemptId = crypto.randomUUID();
+    const claim = await claimSessionWorkForAttempt(db, workspaceId, {
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+      workflowRunId: crypto.randomUUID(),
+      attemptId,
+      dispatchId: `staged-release-${crypto.randomUUID()}`,
+      trigger: { kind: "next" },
+    });
+    if (claim.action !== "claimed") {
+      throw new Error(`Staged release fixture did not claim its turn: ${claim.reason}`);
+    }
+    const holderId = sandboxLeaseHolderIdForAttempt(attemptId);
+    const resumed = await resumeBoxForTurn(
+      { db, settings },
+      {
+        accountId,
+        workspaceId,
+        sandboxGroupId: session.sandboxGroupId,
+        sessionId: session.id,
+        backend: "local",
+        os: "linux",
+      },
+      "turn",
+      holderId,
+    );
+    try {
+      const admission = await advanceWorkspaceGeneration(db, {
+        accountId,
+        workspaceId,
+        sessionId: session.id,
+        turnId: claim.turn.id,
+        executionGeneration: claim.turn.executionGeneration,
+        attemptId,
+        holderId,
+        sandboxGroupId: session.sandboxGroupId,
+        expectedEpoch: resumed.leaseEpoch,
+        expectedInstanceId: resumed.established.instanceId,
+        operation: "stagedReleaseFixture",
+      });
+
+      await resumed.release();
+      const [fenced] = await admin<{ provider_outcome: string | null; settled_at: Date | null }[]>`
+        select provider_outcome, settled_at
+        from sandbox_workspace_mutation_admissions
+        where id = ${admission.id}`;
+      expect(fenced).toEqual({ provider_outcome: null, settled_at: null });
+
+      // The same release closure must not treat the eager call as terminal. Its
+      // proof-bearing stage retries the idempotent holder release and settles
+      // the exact admission after physical writer quiescence.
+      await resumed.release({ workspaceWritersQuiesced: true });
+      const [settled] = await admin<{ provider_outcome: string | null; settled_at: Date | null }[]>`
+        select provider_outcome, settled_at
+        from sandbox_workspace_mutation_admissions
+        where id = ${admission.id}`;
+      expect(settled?.provider_outcome).toBe("rejected");
+      expect(settled?.settled_at).not.toBeNull();
+    } finally {
+      await resumed.release({ workspaceWritersQuiesced: true }).catch(() => undefined);
+      await dropSession(resumed.established);
+    }
   }, 60_000);
 
   test("(2) a second turn ATTACHES to the same warm box (refcount fans in, ONE box)", async () => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -29312,6 +29312,11 @@ export async function releaseLeaseHolder(
     kind: LeaseHolderKind;
     holderId: string;
     idleGraceMs: number;
+    /** The caller has crossed the non-detachable physical boundary for this
+     * exact turn holder: every admitted attempt-owned workspace writer has
+     * resolved, rejected, or been physically quiesced. A cancellation listener
+     * that merely prevents a holder leak must leave this false. */
+    workspaceWritersQuiesced?: boolean;
   },
 ): Promise<{ liveness: SandboxLeaseLiveness; refcount: number } | null> {
   if (input.kind === "process") {
@@ -29325,25 +29330,33 @@ export async function releaseLeaseHolder(
         const tx = txRaw as unknown as Database;
         // A direct request reaches this release seam only after its provider
         // operation has resolved, rejected, or been physically quiesced by the
-        // Channel-A cancellation fence. If the ordinary settlement callback
-        // failed after that physical boundary (for example, its worker was
-        // interrupted during a rollout), leaving a null-outcome admission here
-        // would block archive capture forever after the request holder leaves.
+        // Channel-A cancellation fence. A turn may use the same repair only
+        // after its caller explicitly proves the stronger attempt-writer drain;
+        // the eager cancellation listener drops the holder before that boundary
+        // and therefore must not settle an admission.
+        //
+        // If the ordinary settlement callback failed after the physical
+        // boundary (for example, later finalizer housekeeping threw), leaving a
+        // null-outcome admission here would block archive capture forever after
+        // the request holder leaves.
         //
         // Lock admission -> lease, the same suffix used by mutation settlement
         // and retained-process promotion. Taking the lease first recreates the
         // admission/lease deadlock this fallback exists to recover. A promoted
         // process has provider_outcome='retained' and is deliberately untouched;
         // its non-TTL process holder remains the only settlement authority.
-        if (input.kind === "direct") {
+        const settleAbandonedAdmissions =
+          input.kind === "direct" ||
+          (input.kind === "turn" && input.workspaceWritersQuiesced === true);
+        if (settleAbandonedAdmissions) {
           await tx.execute(sql`
             select id
             from sandbox_workspace_mutation_admissions
             where account_id = ${input.accountId}
               and workspace_id = ${input.workspaceId}
               and sandbox_group_id = ${input.sandboxGroupId}
-              and actor_kind = 'direct'
-              and holder_kind = 'direct'
+              and actor_kind = ${input.kind}
+              and holder_kind = ${input.kind}
               and holder_id = ${input.holderId}
               and provider_outcome is null
               and settled_at is null
@@ -29356,8 +29369,8 @@ export async function releaseLeaseHolder(
             where account_id = ${input.accountId}
               and workspace_id = ${input.workspaceId}
               and sandbox_group_id = ${input.sandboxGroupId}
-              and actor_kind = 'direct'
-              and holder_kind = 'direct'
+              and actor_kind = ${input.kind}
+              and holder_kind = ${input.kind}
               and holder_id = ${input.holderId}
               and provider_outcome is null
               and settled_at is null

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -118,6 +118,13 @@ const PUBLIC_TELEMETRY_ATTRIBUTE_KEYS = new Set([
   "retainedOutputKind",
 ]);
 
+/** Opaque correlation fields require both a reviewed name and a closed value
+ * grammar. Merely adding one to the ordinary allow-list would let an unrelated
+ * caller accidentally publish a raw identifier under that name. */
+const PUBLIC_TELEMETRY_OPAQUE_ATTRIBUTE_PATTERNS = new Map<string, RegExp>([
+  ["sandboxLeaseKey", /^slk_[0-9a-f]{32}$/],
+]);
+
 /**
  * Public diagnostic values are protocol constants, never values inferred from
  * an exception's name, constructor, code, message, or enumerable properties.
@@ -707,9 +714,12 @@ function projectPublicTelemetryAttributes(attributes: Attributes): Attributes {
     return projectPublicDiagnosticAttributes(attributes);
   }
   return Object.fromEntries(
-    Object.entries(attributes).filter(
-      ([key, value]) => value !== undefined && PUBLIC_TELEMETRY_ATTRIBUTE_KEYS.has(key),
-    ),
+    Object.entries(attributes).filter(([key, value]) => {
+      if (value === undefined) return false;
+      if (PUBLIC_TELEMETRY_ATTRIBUTE_KEYS.has(key)) return true;
+      const pattern = PUBLIC_TELEMETRY_OPAQUE_ATTRIBUTE_PATTERNS.get(key);
+      return typeof value === "string" && pattern?.test(value) === true;
+    }),
   );
 }
 

--- a/packages/observability/test/observability.test.ts
+++ b/packages/observability/test/observability.test.ts
@@ -340,6 +340,29 @@ describe("observability", () => {
     expect(JSON.parse(observed[0]!)).not.toHaveProperty("arbitraryDiagnostic");
   });
 
+  test("public structured logs admit only validated opaque sandbox correlation keys", () => {
+    const observed: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => observed.push(String(message));
+    try {
+      const obs = createObservability(settings, { component: "worker", now: () => 1 });
+      obs.info("valid", {
+        sandboxLeaseKey: "slk_0123456789abcdef0123456789abcdef",
+        workspaceId: "workspace-must-not-leak",
+      });
+      obs.info("invalid", { sandboxLeaseKey: "raw-workspace-or-group-id" });
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(JSON.parse(observed[0]!)).toMatchObject({
+      message: "valid",
+      sandboxLeaseKey: "slk_0123456789abcdef0123456789abcdef",
+    });
+    expect(JSON.parse(observed[0]!)).not.toHaveProperty("workspaceId");
+    expect(JSON.parse(observed[1]!)).not.toHaveProperty("sandboxLeaseKey");
+  });
+
   test("public diagnostics reject syntactically valid secret-shaped classes and codes", () => {
     const sentinel = "SECRET_SENTINEL_123";
     const SecretSentinelError = class SECRET_SENTINEL_123 extends Error {};


### PR DESCRIPTION
## Summary

- split turn sandbox release into immediate liveness release and proof-bearing admission settlement
- settle only the exact turn holder after all attempt-owned workspace writers physically drain
- make cancellation, late provisioning, retry, and failed-drain paths idempotent and fail-closed

## Validation

- `bun test apps/worker/test/agent-turn.test.ts`
- real PostgreSQL sandbox lease/resume tests, including Local/Linux staged release
- Docker lifecycle roundtrip and gated live Docker restore
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- full suite running before merge

Modal production acceptance will run through the immutable ordinary release train after merge.