### PR TITLE
chore(release): bump product version to 0.22.89

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.88
-appVersion: "0.22.88"
+version: 0.22.89
+appVersion: "0.22.89"


### PR DESCRIPTION
## Summary

- bump the source-controlled Helm chart and app version from 0.22.88 to 0.22.89
- prepare the immutable production candidate containing the sandbox lifecycle/reaper fix and generated package versions

## Validation

- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `bun test --timeout 30000 scripts/release-version.test.ts scripts/release-image-workflow-contract.test.ts scripts/package-release-chart.test.ts`
- `bun run format:check`
- `helm lint deploy/helm/opengeni`
- `git diff --check`