### PR TITLE
fix(api): recover transient concurrent sandbox reads

### DIFF
--- a/.changeset/retry-concurrent-channel-a-reads.md
+++ b/.changeset/retry-concurrent-channel-a-reads.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Wait for concurrent structured sandbox reads to settle and retry only typed transient failures once.

--- a/.changeset/retry-concurrent-channel-a-reads.md
+++ b/.changeset/retry-concurrent-channel-a-reads.md
@@ -1,5 +1,6 @@
 ---
 "@opengeni/api-router": patch
+"@opengeni/runtime": patch
 ---
 
 Wait for concurrent structured sandbox reads to settle and retry only typed transient failures once.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -2639,10 +2639,8 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     const ctx = await channelAPreamble(c, "files:read");
     const req = await parseChannelABody(c, FsListBatchRequest);
     const out = await withChannelA(channelAServices, ctx, async ({ service }) => ({
-      results: await Promise.all(
-        req.requests.map((request) =>
-          Promise.resolve().then(async () => await service.fsList(request)),
-        ),
+      results: await runConcurrentChannelAReads(
+        req.requests.map((request) => async () => await service.fsList(request)),
       ),
     }));
     return c.json(out);

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -143,7 +143,12 @@ import {
   GatewayRealtimeBrokerError,
 } from "../gateway-realtime";
 import { z, ZodError } from "zod";
-import { withChannelA, type ChannelAContext, type ChannelAHandle } from "../sandbox/channel-a";
+import {
+  runConcurrentChannelAReads,
+  withChannelA,
+  type ChannelAContext,
+  type ChannelAHandle,
+} from "../sandbox/channel-a";
 import { negotiateCapabilities } from "@opengeni/runtime/sandbox";
 import type { Context, Hono, MiddlewareHandler } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -2696,20 +2701,51 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/git/read-batch", async (c) => {
     const ctx = await channelAPreamble(c, "files:read");
     const req = await parseChannelABody(c, GitReadBatchRequest);
-    const out = await withChannelA(channelAServices, ctx, async ({ service }) => ({
-      results: await Promise.all(
-        req.requests.map(async (request) => {
+    const out = await withChannelA(channelAServices, ctx, async ({ service }) => {
+      type StatusResult = Awaited<ReturnType<typeof service.gitStatus>>;
+      type DiffResult = Awaited<ReturnType<typeof service.gitDiff>>;
+      type ReadResult =
+        | { requestIndex: number; kind: "status"; value: StatusResult }
+        | { requestIndex: number; kind: "diff"; value: DiffResult };
+      const operations: Array<() => Promise<ReadResult>> = [];
+      req.requests.forEach((request, requestIndex) => {
+        operations.push(async () => ({
+          requestIndex,
+          kind: "status" as const,
+          value: await service.gitStatus(request.status),
+        }));
+        if (request.diff) {
           const diffRequest = request.diff;
-          const [status, diff] = await Promise.all([
-            Promise.resolve().then(async () => await service.gitStatus(request.status)),
-            diffRequest
-              ? Promise.resolve().then(async () => await service.gitDiff(diffRequest))
-              : Promise.resolve(undefined),
-          ]);
+          operations.push(async () => ({
+            requestIndex,
+            kind: "diff" as const,
+            value: await service.gitDiff(diffRequest),
+          }));
+        }
+      });
+
+      const reads = await runConcurrentChannelAReads(operations);
+      const statuses = new Map<number, StatusResult>();
+      const diffs = new Map<number, DiffResult>();
+      for (const read of reads) {
+        if (read.kind === "status") statuses.set(read.requestIndex, read.value);
+        else diffs.set(read.requestIndex, read.value);
+      }
+
+      return {
+        results: req.requests.map((request, requestIndex) => {
+          const status = statuses.get(requestIndex);
+          if (!status) {
+            throw new Error(`Workspace Git batch omitted status result ${requestIndex}.`);
+          }
+          const diff = request.diff ? diffs.get(requestIndex) : undefined;
+          if (request.diff && !diff) {
+            throw new Error(`Workspace Git batch omitted diff result ${requestIndex}.`);
+          }
           return { status, ...(diff ? { diff } : {}) };
         }),
-      ),
-    }));
+      };
+    });
     return c.json(out);
   });
 

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -179,6 +179,45 @@ export async function establishCachedChannelAHandle(
   );
 }
 
+/**
+ * Run independent, side-effect-free Channel-A reads concurrently without
+ * releasing the direct-request holder while sibling provider commands are
+ * still settling. A typed temporary-unavailable failure is retried exactly
+ * once after every first attempt has settled; validation, conflict, not-found,
+ * and unknown failures are never replayed.
+ */
+export async function runConcurrentChannelAReads<T>(
+  operations: readonly (() => Promise<T>)[],
+): Promise<T[]> {
+  const values = new Array<T>(operations.length);
+  const first = await Promise.allSettled(
+    operations.map((operation) => Promise.resolve().then(operation)),
+  );
+  const retryIndexes: number[] = [];
+
+  for (const [index, result] of first.entries()) {
+    if (result.status === "fulfilled") {
+      values[index] = result.value;
+      continue;
+    }
+    if (!(result.reason instanceof ChannelAUnavailableError)) {
+      throw result.reason;
+    }
+    retryIndexes.push(index);
+  }
+
+  if (retryIndexes.length === 0) return values;
+
+  const retried = await Promise.allSettled(
+    retryIndexes.map((index) => Promise.resolve().then(operations[index]!)),
+  );
+  for (const [retryIndex, result] of retried.entries()) {
+    if (result.status === "rejected") throw result.reason;
+    values[retryIndexes[retryIndex]!] = result.value;
+  }
+  return values;
+}
+
 function rememberEstablishedHandle(key: string, established: EstablishedSandboxSession): void {
   pruneEstablishedHandleCache(Date.now());
   establishedHandleCache.set(key, {

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -187,6 +187,18 @@ describe("P4.4 Channel-A route discipline", () => {
     expect(transientCalls).toBe(2);
   });
 
+  test("both concurrent batch routes use the settled read helper", () => {
+    for (const route of ["fs/list-batch", "git/read-batch"]) {
+      const body = handlerBody(
+        sessionsRoute,
+        "post",
+        `/v1/workspaces/:workspaceId/sessions/:sessionId/${route}`,
+      );
+      expect(body).toContain("runConcurrentChannelAReads(");
+      expect(body).not.toContain("Promise.all(");
+    }
+  });
+
   test("near-identical non-transient reads are never retried", async () => {
     let calls = 0;
     const failure = new ChannelAValidationError("bad path");

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -3,8 +3,8 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { HTTPException } from "hono/http-exception";
-import { ChannelAUnavailableError } from "@opengeni/runtime/sandbox";
-import { mapChannelAError } from "../src/sandbox/channel-a";
+import { ChannelAUnavailableError, ChannelAValidationError } from "@opengeni/runtime/sandbox";
+import { mapChannelAError, runConcurrentChannelAReads } from "../src/sandbox/channel-a";
 
 // P4.4 route-discipline guards for all Channel-A structured-service routes (a
 // complement to the real-box runtime test + the docker e2e). The invariants the
@@ -162,6 +162,44 @@ describe("P4.4 Channel-A route discipline", () => {
     expect((mapped as HTTPException).message).toBe(
       "Workspace files are temporarily unavailable. Retry.",
     );
+  });
+
+  test("concurrent reads settle before one bounded transient retry", async () => {
+    let transientCalls = 0;
+    let siblingSettled = false;
+    const values = await runConcurrentChannelAReads([
+      async () => {
+        transientCalls += 1;
+        if (transientCalls === 1) {
+          throw new ChannelAUnavailableError("temporary provider wake race");
+        }
+        expect(siblingSettled).toBe(true);
+        return "recovered";
+      },
+      async () => {
+        await Bun.sleep(5);
+        siblingSettled = true;
+        return "sibling";
+      },
+    ]);
+
+    expect(values).toEqual(["recovered", "sibling"]);
+    expect(transientCalls).toBe(2);
+  });
+
+  test("near-identical non-transient reads are never retried", async () => {
+    let calls = 0;
+    const failure = new ChannelAValidationError("bad path");
+    await expect(
+      runConcurrentChannelAReads([
+        async () => {
+          calls += 1;
+          throw failure;
+        },
+        async () => "sibling",
+      ]),
+    ).rejects.toBe(failure);
+    expect(calls).toBe(1);
   });
 
   test("the seam never signals Temporal / routes through a worker (API-direct only)", () => {

--- a/packages/runtime/src/sandbox/channel-a.ts
+++ b/packages/runtime/src/sandbox/channel-a.ts
@@ -287,6 +287,23 @@ const US = String.fromCharCode(0x1f); // \x1f unit sep — git-log field separat
 const RS = String.fromCharCode(0x1e); // \x1e record sep — git-log record separator
 const SELFHOSTED_VIRTUAL_ROOT = "/workspace";
 
+/**
+ * Preserve Promise.all's ordered values and failure propagation without
+ * allowing one rejected provider read to return while already-started siblings
+ * are still running. A caller may release sandbox ownership as soon as its
+ * method settles, so every concurrent read layer must join all of its children.
+ */
+async function settleConcurrentReads<const T extends readonly unknown[]>(reads: {
+  readonly [K in keyof T]: Promise<T[K]>;
+}): Promise<T> {
+  const settled = await Promise.allSettled(reads);
+  const rejected = settled.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (rejected) throw rejected.reason;
+  return settled.map((result) => (result as PromiseFulfilledResult<unknown>).value) as unknown as T;
+}
+
 export class SandboxChannelAService {
   private readonly session: ChannelASession;
   private readonly workspaceRoot: string;
@@ -1274,7 +1291,7 @@ export class SandboxChannelAService {
     // Capture tracked metadata, the complete ordinary patch, and all untracked
     // after-images concurrently. A normal review now completes in one provider
     // round; oversized captures retain the exact per-file fallback below.
-    const [numstat, combinedPatch, combinedUntracked] = await Promise.all([
+    const [numstat, combinedPatch, combinedUntracked] = await settleConcurrentReads([
       this.readConfinedCommandBytes(
         repo,
         gitCommand(
@@ -1381,7 +1398,7 @@ export class SandboxChannelAService {
               };
             }),
           )
-        : Promise.all(stats.map(readTrackedFile));
+        : settleConcurrentReads(stats.map(readTrackedFile));
 
     const shapeUntrackedSnapshot = (snapshot: CombinedUntrackedSnapshot): GitFileDiff => {
       let { sampled, sizeBytes, lineCount } = snapshot;
@@ -1513,14 +1530,17 @@ export class SandboxChannelAService {
               "Workspace Git metadata exceeded the safe capture limit. Retry with a narrower path.",
             );
           }
-          return Promise.all(
+          return settleConcurrentReads(
             decodeGitMetadataUtf8(listing.bytes).split(NUL).filter(Boolean).map(readUntrackedFile),
           );
         })();
       }
     }
 
-    const [files, untrackedFiles] = await Promise.all([trackedFilesPromise, untrackedFilesPromise]);
+    const [files, untrackedFiles] = await settleConcurrentReads([
+      trackedFilesPromise,
+      untrackedFilesPromise,
+    ]);
     files.push(...untrackedFiles);
     return { files, revision: this.revision };
   }

--- a/packages/runtime/test/channel-a.test.ts
+++ b/packages/runtime/test/channel-a.test.ts
@@ -1180,6 +1180,54 @@ describe("P4.4 SandboxChannelAService — Git (real local box)", () => {
     expect(hunk.lines.some((l) => l.type === "context")).toBe(true);
   });
 
+  test("git diff joins every nested provider read before surfacing a failure", async () => {
+    const root = mkdtempSync(join(tmpdir(), "opengeni-channel-a-settle-"));
+    temporaryRoots.push(root);
+    runFixtureCommand(
+      root,
+      [
+        "git init -q",
+        "git config user.email t@t.io",
+        "git config user.name t",
+        "git config commit.gpgsign false",
+        "printf 'base\\n' > file.txt",
+        "git add file.txt",
+        "git commit -q -m base",
+        "printf 'changed\\n' > file.txt",
+      ].join(" && "),
+    );
+
+    const modalLike = makeModalLikeExecOnlySession(root);
+    const execCommand = modalLike.session.execCommand!;
+    let siblingSettled = false;
+    modalLike.session.execCommand = async (args) => {
+      const running = execCommand(args);
+      if (args.cmd.includes("diff --no-color -U3")) {
+        await Bun.sleep(25);
+        const output = await running;
+        siblingSettled = true;
+        return output;
+      }
+      const output = await running;
+      return args.cmd.includes("diff --no-color -z --numstat")
+        ? output.replace("__OPENGENI_GIT_CHUNK_V1__", "__OPENGENI_GIT_CHUNK_INVALID__")
+        : output;
+    };
+
+    const svc = new SandboxChannelAService({ session: modalLike.session, workspaceRoot: root });
+    await expect(
+      svc.gitDiff({
+        path: "",
+        staged: false,
+        includeUntracked: false,
+        pathspec: [],
+        contextLines: 3,
+        maxBytesPerFile: 512 * 1024,
+      }),
+    ).rejects.toBeInstanceOf(ChannelAUnavailableError);
+    expect(siblingSettled).toBe(true);
+  });
+
   test("workspace-review diff includes bounded text, binary, and oversized untracked files", async () => {
     const { svc } = await makeRepoWithStagedChange();
     await svc.fsWrite({

--- a/test/e2e/channel-a.e2e.ts
+++ b/test/e2e/channel-a.e2e.ts
@@ -91,7 +91,7 @@ describe("Channel-A structured services e2e (real Docker box, API-direct)", () =
   }, 60_000);
 
   test("fs.write then fs.read round-trips text API-direct", async () => {
-    const write = await channelA("/fs/write", {
+    const write = await channelAOk("/fs/write", {
       path: "channel-a.txt",
       content: "hello from channel-a\n",
     });
@@ -100,7 +100,7 @@ describe("Channel-A structured services e2e (real Docker box, API-direct)", () =
     expect(wb.path).toBe("channel-a.txt");
     expect(wb.revision).toBeGreaterThanOrEqual(1);
 
-    const read = await channelA("/fs/read", { path: "channel-a.txt" });
+    const read = await channelAOk("/fs/read", { path: "channel-a.txt" });
     expect(read.status).toBe(200);
     const rb = (await read.json()) as { content: string; encoding: string; isBinary: boolean };
     expect(rb.content).toBe("hello from channel-a\n");
@@ -110,22 +110,22 @@ describe("Channel-A structured services e2e (real Docker box, API-direct)", () =
 
   test("fs.write then fs.read round-trips a binary file (base64)", async () => {
     const bytes = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe]);
-    const write = await channelA("/fs/write", {
+    const write = await channelAOk("/fs/write", {
       path: "blob.bin",
       encoding: "base64",
       content: bytes.toString("base64"),
     });
     expect(write.status).toBe(200);
-    const read = await channelA("/fs/read", { path: "blob.bin", encoding: "base64" });
+    const read = await channelAOk("/fs/read", { path: "blob.bin", encoding: "base64" });
     const rb = (await read.json()) as { content: string; isBinary: boolean };
     expect(rb.isBinary).toBe(true);
     expect(Buffer.from(rb.content, "base64").equals(bytes)).toBe(true);
   }, 60_000);
 
   test("fs.list returns a coherent tree of a known directory", async () => {
-    await channelA("/fs/write", { path: "tree/a.txt", content: "a" });
-    await channelA("/fs/write", { path: "tree/sub/b.txt", content: "b" });
-    const list = await channelA("/fs/list", { path: "tree", depth: 3 });
+    await channelAOk("/fs/write", { path: "tree/a.txt", content: "a" });
+    await channelAOk("/fs/write", { path: "tree/sub/b.txt", content: "b" });
+    const list = await channelAOk("/fs/list", { path: "tree", depth: 3 });
     expect(list.status).toBe(200);
     const body = (await list.json()) as {
       root: { path: string; children?: { path: string; type: string; children?: unknown[] }[] };
@@ -142,27 +142,37 @@ describe("Channel-A structured services e2e (real Docker box, API-direct)", () =
     expect(paths).toContain("tree/a.txt");
     expect(paths).toContain("tree/sub");
     expect(paths).toContain("tree/sub/b.txt");
+
+    const batch = await channelAOk("/fs/list-batch", {
+      requests: [
+        { path: "tree", depth: 1 },
+        { path: "tree/sub", depth: 1 },
+      ],
+    });
+    expect(batch.status).toBe(200);
+    const batched = (await batch.json()) as { results: { root: { path: string } }[] };
+    expect(batched.results.map((result) => result.root.path)).toEqual(["tree", "tree/sub"]);
   }, 60_000);
 
   test("git status + diff on a staged change parse into structured hunks", async () => {
     // Build a repo with a staged modification via terminal exec + fs.write.
-    await channelA("/terminal/exec", {
+    await channelAOk("/terminal/exec", {
       command:
-        "git init -q && git config user.email t@t.io && git config user.name t && git config commit.gpgsign false",
-      cwd: "repo",
+        "mkdir -p repo && git -C repo init -q && git -C repo config user.email t@t.io && git -C repo config user.name t && git -C repo config commit.gpgsign false",
+      cwd: "",
     });
-    await channelA("/fs/write", { path: "repo/code.txt", content: "alpha\nbeta\ngamma\n" });
-    await channelA("/terminal/exec", {
+    await channelAOk("/fs/write", { path: "repo/code.txt", content: "alpha\nbeta\ngamma\n" });
+    await channelAOk("/terminal/exec", {
       command: "git add code.txt && git commit -q -m base",
       cwd: "repo",
     });
-    await channelA("/fs/write", {
+    await channelAOk("/fs/write", {
       path: "repo/code.txt",
       content: "alpha\nbeta CHANGED\ngamma\ndelta\n",
     });
-    await channelA("/terminal/exec", { command: "git add code.txt", cwd: "repo" });
+    await channelAOk("/terminal/exec", { command: "git add code.txt", cwd: "repo" });
 
-    const status = await channelA("/git/status", { path: "repo" });
+    const status = await channelAOk("/git/status", { path: "repo" });
     expect(status.status).toBe(200);
     const sb = (await status.json()) as {
       isRepo: boolean;
@@ -171,7 +181,7 @@ describe("Channel-A structured services e2e (real Docker box, API-direct)", () =
     expect(sb.isRepo).toBe(true);
     expect(sb.files.some((f) => f.path === "code.txt" && f.index === "modified")).toBe(true);
 
-    const diff = await channelA("/git/diff", { path: "repo", staged: true });
+    const diff = await channelAOk("/git/diff", { path: "repo", staged: true });
     expect(diff.status).toBe(200);
     const db = (await diff.json()) as {
       files: {
@@ -187,10 +197,26 @@ describe("Channel-A structured services e2e (real Docker box, API-direct)", () =
     const lines = file!.hunks.flatMap((h) => h.lines);
     expect(lines.some((l) => l.type === "add" && l.newNo !== null && l.oldNo === null)).toBe(true);
     expect(lines.some((l) => l.type === "del")).toBe(true);
+
+    const batch = await channelAOk("/git/read-batch", {
+      requests: [
+        { status: { path: "repo" }, diff: { path: "repo", staged: true } },
+        { status: { path: "" } },
+      ],
+    });
+    expect(batch.status).toBe(200);
+    const batched = (await batch.json()) as {
+      results: { status: { isRepo: boolean }; diff?: { files: { path: string }[] } }[];
+    };
+    expect(batched.results).toHaveLength(2);
+    expect(batched.results[0]?.status.isRepo).toBe(true);
+    expect(batched.results[0]?.diff?.files.some((entry) => entry.path === "code.txt")).toBe(true);
+    expect(batched.results[1]?.status.isRepo).toBe(false);
+    expect(batched.results[1]?.diff).toBeUndefined();
   }, 120_000);
 
   test("terminal exec 'echo $DISPLAY' streams output + a sandbox.command.output.delta", async () => {
-    const res = await channelA("/terminal/exec", {
+    const res = await channelAOk("/terminal/exec", {
       command: "echo display=$DISPLAY; echo channel_a_terminal_marker",
       cwd: "",
     });
@@ -236,10 +262,22 @@ describe("Channel-A structured services e2e (real Docker box, API-direct)", () =
       body: JSON.stringify(body),
     });
   }
+
+  async function channelAOk(suffix: string, body: unknown): Promise<Response> {
+    const response = await channelA(suffix, body);
+    if (!response.ok) {
+      throw new Error(
+        `Channel-A ${suffix} failed with HTTP ${response.status}: ${await response.text()}`,
+      );
+    }
+    return response;
+  }
 });
 
 async function sessionEvents(sessionId: string): Promise<{ type: string; payload: unknown }[]> {
-  const response = await fetch(apiPath(`/sessions/${sessionId}/events?limit=400`));
+  const response = await fetch(
+    apiPath(`/sessions/${sessionId}/events?mode=forensic&payloadMode=full&limit=400`),
+  );
   expect(response.ok).toBe(true);
   return (await response.json()) as { type: string; payload: unknown }[];
 }


### PR DESCRIPTION
## User-visible defect
Authenticated production workbench acceptance for candidate `2fa4510694cf8a93b41834140bbd8fba1e5bcf28` observed the first `git/read-batch` return HTTP 503 while an identical retry succeeded seconds later. `Promise.all` rejected before sibling read commands settled, allowing direct-request authority to release while provider reads were still in flight.

## Fix
- settle every independent read before leaving the request;
- retry only typed `ChannelAUnavailableError` reads exactly once;
- preserve concurrent/batched status and diff reads;
- never retry validation, conflict, not-found, or unknown failures.

## Proof
- `bun test apps/api/test/channel-a-routes.test.ts` — 27 passed, 0 failed;
- positive: transient read retries only after its sibling settled;
- planted negative: near-identical `ChannelAValidationError` executes once and is propagated;
- `bun run --cwd apps/api typecheck` — pass;
- repository `oxfmt --check` on all touched files — pass;
- `git diff --check` — pass.

No-Claim: this local proof does not claim live provider acceptance. Canonical acceptance must run after merge through the ordinary release chain.
