### PR TITLE
chore(release): bump product version to 0.22.90

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.89
-appVersion: "0.22.89"
+version: 0.22.90
+appVersion: "0.22.90"


### PR DESCRIPTION
Bumps the Helm chart and app version together to the next unoccupied product release identity. 0.22.89 is already bound to the superseded immutable candidate; this source must use 0.22.90.

Validated locally: release-version contract, release workflow contract (15/15), Helm lint, lint, format, and diff checks.