### PR TITLE
fix(sandbox): recover rotated Modal read transports

### DIFF
--- a/.changeset/refresh-stale-channel-a-handles.md
+++ b/.changeset/refresh-stale-channel-a-handles.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/worker-bundle": patch
+"@opengeni/observability": patch
+"@opengeni/runtime": patch
+---
+
+Isolate read handles from process-capable handles, replace Modal's transport in place when its command-router URL rotates, rebuild the exact lease-fenced handle once for side-effect-free reads after a typed provider outage, and correlate handle recovery safely across API and reaper logs.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -946,6 +946,23 @@ const routeLabelPatterns: Array<{ pattern: RegExp; label: string }> = [
     label: "/v1/workspaces/:workspaceId/inference-control",
   },
   {
+    pattern:
+      /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/fs\/(list|list-batch|read|write|delete|move|mkdir)$/,
+    label: "/v1/workspaces/:workspaceId/sessions/:id/fs/:operation",
+  },
+  {
+    pattern: /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/git\/(status|diff|read-batch|log|show)$/,
+    label: "/v1/workspaces/:workspaceId/sessions/:id/git/:operation",
+  },
+  {
+    pattern: /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/terminal\/(exec|pty)$/,
+    label: "/v1/workspaces/:workspaceId/sessions/:id/terminal/:operation",
+  },
+  {
+    pattern: /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/terminal\/pty\/(write|resize|close)$/,
+    label: "/v1/workspaces/:workspaceId/sessions/:id/terminal/pty/:action",
+  },
+  {
     pattern: /^\/v1\/workspaces\/[^/]+\/sessions\/[^/]+\/events\/stream$/,
     label: "/v1/workspaces/:workspaceId/sessions/:id/events/stream",
   },

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -43,7 +43,11 @@ import {
   type LeaseSnapshot,
 } from "@opengeni/db";
 import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
-import { sandboxOperationMetricObserver, type Observability } from "@opengeni/observability";
+import {
+  sandboxLeaseTelemetryKey,
+  sandboxOperationMetricObserver,
+  type Observability,
+} from "@opengeni/observability";
 import { HTTPException } from "hono/http-exception";
 
 import {
@@ -110,13 +114,30 @@ export type ChannelAHandle = {
  * expire opportunistically; eviction only drops local references and never
  * terminates the lease-owned sandbox.
  */
-const CHANNEL_A_HANDLE_CACHE_TTL_MS = 300_000;
+// Read/viewer handles and process-capable handles deliberately have separate
+// caches. The pinned Modal patch rotates a handle's command-router transport in
+// place, while a typed read failure below still gets one fresh-handle fallback.
+// Periodically rebuilding a healthy hot read handle would add multi-second
+// stalls, so both caches keep the pre-existing five-minute IDLE lifetime.
+//
+// Modal and Unix/Docker SDK sessions retain yielded exec/PTY process objects in
+// a process-local map; rebuilding the wrapper cannot reconstruct those objects
+// from the numeric provider session id. Reads therefore never enter or evict
+// the process cache merely to refresh their own transport.
+const CHANNEL_A_READ_HANDLE_CACHE_IDLE_TTL_MS = 5 * 60_000;
+const CHANNEL_A_PROCESS_HANDLE_CACHE_IDLE_TTL_MS = 5 * 60_000;
 const CHANNEL_A_HANDLE_CACHE_MAX_ENTRIES = 64;
-type CachedEstablishedHandle = {
+type CachedReadHandle = {
   promise: Promise<EstablishedSandboxSession>;
-  lastUsedAt: number;
+  lastUsedAtMonotonicMs: number;
 };
-const establishedHandleCache = new Map<string, CachedEstablishedHandle>();
+type CachedProcessHandle = {
+  promise: Promise<EstablishedSandboxSession>;
+  lastUsedAtMonotonicMs: number;
+};
+export type EstablishedHandleCacheKind = "read" | "process" | "none";
+const establishedReadHandleCache = new Map<string, CachedReadHandle>();
+const establishedProcessHandleCache = new Map<string, CachedProcessHandle>();
 
 function establishedHandleCacheKey(
   workspaceId: string,
@@ -126,42 +147,98 @@ function establishedHandleCacheKey(
   return [workspaceId, sessionId, lease.leaseEpoch, lease.instanceId ?? ""].join("\u0000");
 }
 
-function pruneEstablishedHandleCache(now: number): void {
-  for (const [key, entry] of establishedHandleCache) {
-    if (now - entry.lastUsedAt > CHANNEL_A_HANDLE_CACHE_TTL_MS) {
-      establishedHandleCache.delete(key);
+export function isChannelAHandleCacheEntryFresh(
+  lastUsedAtMonotonicMs: number,
+  nowMonotonicMs: number,
+  idleTtlMs = CHANNEL_A_READ_HANDLE_CACHE_IDLE_TTL_MS,
+): boolean {
+  return nowMonotonicMs - lastUsedAtMonotonicMs < idleTtlMs;
+}
+
+export function isChannelAProcessHandleCacheEntryFresh(
+  lastUsedAtMonotonicMs: number,
+  nowMonotonicMs: number,
+  idleTtlMs = CHANNEL_A_PROCESS_HANDLE_CACHE_IDLE_TTL_MS,
+): boolean {
+  return nowMonotonicMs - lastUsedAtMonotonicMs < idleTtlMs;
+}
+
+function pruneEstablishedReadHandleCache(nowMonotonicMs: number): void {
+  for (const [key, entry] of establishedReadHandleCache) {
+    if (!isChannelAHandleCacheEntryFresh(entry.lastUsedAtMonotonicMs, nowMonotonicMs)) {
+      establishedReadHandleCache.delete(key);
     }
-  }
-  while (establishedHandleCache.size >= CHANNEL_A_HANDLE_CACHE_MAX_ENTRIES) {
-    const oldestKey = establishedHandleCache.keys().next().value as string | undefined;
-    if (oldestKey === undefined) break;
-    establishedHandleCache.delete(oldestKey);
   }
 }
 
-async function establishCachedHandle(
+function pruneEstablishedProcessHandleCache(nowMonotonicMs: number): void {
+  for (const [key, entry] of establishedProcessHandleCache) {
+    if (!isChannelAProcessHandleCacheEntryFresh(entry.lastUsedAtMonotonicMs, nowMonotonicMs)) {
+      establishedProcessHandleCache.delete(key);
+    }
+  }
+}
+
+function enforceEstablishedHandleCacheSize<T>(cache: Map<string, T>): void {
+  while (cache.size > CHANNEL_A_HANDLE_CACHE_MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value as string | undefined;
+    if (oldestKey === undefined) break;
+    cache.delete(oldestKey);
+  }
+}
+
+async function establishCachedReadHandle(
   key: string,
   establish: () => Promise<EstablishedSandboxSession>,
 ): Promise<EstablishedSandboxSession> {
-  const now = Date.now();
-  pruneEstablishedHandleCache(now);
-  const cached = establishedHandleCache.get(key);
+  const now = performance.now();
+  pruneEstablishedReadHandleCache(now);
+  const cached = establishedReadHandleCache.get(key);
   if (cached) {
-    cached.lastUsedAt = now;
+    cached.lastUsedAtMonotonicMs = now;
     // Refresh insertion order so the bounded map evicts the least-recently used
     // exact lease identity first.
-    establishedHandleCache.delete(key);
-    establishedHandleCache.set(key, cached);
+    establishedReadHandleCache.delete(key);
+    establishedReadHandleCache.set(key, cached);
     return await cached.promise;
   }
 
   const promise = establish();
-  const entry: CachedEstablishedHandle = { promise, lastUsedAt: now };
-  establishedHandleCache.set(key, entry);
+  const entry: CachedReadHandle = { promise, lastUsedAtMonotonicMs: now };
+  establishedReadHandleCache.set(key, entry);
+  enforceEstablishedHandleCacheSize(establishedReadHandleCache);
   try {
     return await promise;
   } catch (error) {
-    if (establishedHandleCache.get(key) === entry) establishedHandleCache.delete(key);
+    if (establishedReadHandleCache.get(key) === entry) establishedReadHandleCache.delete(key);
+    throw error;
+  }
+}
+
+async function establishCachedProcessHandle(
+  key: string,
+  establish: () => Promise<EstablishedSandboxSession>,
+): Promise<EstablishedSandboxSession> {
+  const now = performance.now();
+  pruneEstablishedProcessHandleCache(now);
+  const cached = establishedProcessHandleCache.get(key);
+  if (cached) {
+    cached.lastUsedAtMonotonicMs = now;
+    establishedProcessHandleCache.delete(key);
+    establishedProcessHandleCache.set(key, cached);
+    return await cached.promise;
+  }
+
+  const promise = establish();
+  const entry: CachedProcessHandle = { promise, lastUsedAtMonotonicMs: now };
+  establishedProcessHandleCache.set(key, entry);
+  enforceEstablishedHandleCacheSize(establishedProcessHandleCache);
+  try {
+    return await promise;
+  } catch (error) {
+    if (establishedProcessHandleCache.get(key) === entry) {
+      establishedProcessHandleCache.delete(key);
+    }
     throw error;
   }
 }
@@ -175,7 +252,19 @@ export async function establishCachedChannelAHandle(
   lease: LeaseSnapshot,
   establish: () => Promise<EstablishedSandboxSession>,
 ): Promise<EstablishedSandboxSession> {
-  return await establishCachedHandle(
+  return await establishCachedReadHandle(
+    establishedHandleCacheKey(workspaceId, sessionId, lease),
+    establish,
+  );
+}
+
+async function establishCachedChannelAProcessHandle(
+  workspaceId: string,
+  sessionId: string,
+  lease: LeaseSnapshot,
+  establish: () => Promise<EstablishedSandboxSession>,
+): Promise<EstablishedSandboxSession> {
+  return await establishCachedProcessHandle(
     establishedHandleCacheKey(workspaceId, sessionId, lease),
     establish,
   );
@@ -220,12 +309,63 @@ export async function runConcurrentChannelAReads<T>(
   return values;
 }
 
-function rememberEstablishedHandle(key: string, established: EstablishedSandboxSession): void {
-  pruneEstablishedHandleCache(Date.now());
-  establishedHandleCache.set(key, {
+/** Retry a side-effect-free Channel-A read once, but only after the caller has
+ * discarded and freshly re-established its provider handle. Provider commands
+ * are not replayed for validation/conflict/unknown errors, and mutation routes
+ * never call this helper. */
+export async function runChannelAReadWithFreshHandleRetry<T>(
+  run: () => Promise<T>,
+  refreshHandle: () => Promise<void>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (!(error instanceof ChannelAUnavailableError)) throw error;
+    await refreshHandle();
+    return await run();
+  }
+}
+
+export function shouldEvictChannelAHandleAfterError(
+  error: unknown,
+  cacheKind: EstablishedHandleCacheKind,
+): boolean {
+  return error instanceof ChannelAUnavailableError && cacheKind === "read";
+}
+
+function evictEstablishedHandle(key: string, cacheKind: EstablishedHandleCacheKind): void {
+  if (cacheKind === "read") establishedReadHandleCache.delete(key);
+  if (cacheKind === "process") establishedProcessHandleCache.delete(key);
+}
+
+function evictAllEstablishedHandles(key: string): void {
+  establishedReadHandleCache.delete(key);
+  establishedProcessHandleCache.delete(key);
+}
+
+function rememberEstablishedHandle(
+  key: string,
+  established: EstablishedSandboxSession,
+  cacheKind: Exclude<EstablishedHandleCacheKind, "none">,
+): void {
+  const now = performance.now();
+  if (cacheKind === "read") {
+    pruneEstablishedReadHandleCache(now);
+    establishedReadHandleCache.delete(key);
+    establishedReadHandleCache.set(key, {
+      promise: Promise.resolve(established),
+      lastUsedAtMonotonicMs: now,
+    });
+    enforceEstablishedHandleCacheSize(establishedReadHandleCache);
+    return;
+  }
+  pruneEstablishedProcessHandleCache(now);
+  establishedProcessHandleCache.delete(key);
+  establishedProcessHandleCache.set(key, {
     promise: Promise.resolve(established),
-    lastUsedAt: Date.now(),
+    lastUsedAtMonotonicMs: now,
   });
+  enforceEstablishedHandleCacheSize(establishedProcessHandleCache);
 }
 
 /**
@@ -247,7 +387,9 @@ export async function withChannelA<T>(
 
 /** Read-only API-direct seam. Separate requests for the same exact live Modal
  * instance are serialized across API replicas; each request's batched reads
- * remain concurrent behind that one distributed boundary. */
+ * remain concurrent behind that one distributed boundary. A typed temporary
+ * provider-channel failure gets one retry only after rebuilding the exact
+ * lease-fenced handle. */
 export async function withChannelARead<T>(
   services: ChannelAServices,
   ctx: ChannelAContext,
@@ -457,6 +599,56 @@ async function withChannelAOperation<T>(
   let established: EstablishedSandboxSession | undefined;
   let leaseSnapshot: LeaseSnapshot = acquired.lease;
   let establishedCacheKey: string | null = null;
+  let establishedCacheKind: EstablishedHandleCacheKind = "none";
+  const requestedCacheKind: Exclude<EstablishedHandleCacheKind, "none"> = readOnly
+    ? "read"
+    : "process";
+
+  const establishAttachedLiveHandle = async (
+    live: LeaseSnapshot,
+    cacheKind: EstablishedHandleCacheKind,
+  ): Promise<{ established: EstablishedSandboxSession; cacheKey: string }> => {
+    const cacheKey = establishedHandleCacheKey(workspaceId, session.id, live);
+    const establish = () =>
+      establishSandboxSessionFromEnvelope(settings, live.resumeState, {
+        sessionId: session.id,
+        recovery: "resume-only",
+        backendOverride: session.sandboxBackend,
+        environment,
+      });
+    try {
+      const attached =
+        cacheKind === "read"
+          ? await establishCachedChannelAHandle(workspaceId, session.id, live, establish)
+          : cacheKind === "process"
+            ? await establishCachedChannelAProcessHandle(workspaceId, session.id, live, establish)
+            : await establish();
+      return { established: attached, cacheKey };
+    } catch (error) {
+      if (!isProviderSandboxNotFoundError(session.sandboxBackend, error)) throw error;
+      // The exact provider instance is definitively gone, so neither a read nor
+      // a process wrapper for that lease identity may survive locally.
+      evictAllEstablishedHandles(cacheKey);
+      const marked = await markWarmLeaseInstanceLost(db, {
+        accountId,
+        workspaceId,
+        sandboxGroupId,
+        expectedEpoch: live.leaseEpoch,
+        expectedInstanceId: live.instanceId!,
+      });
+      if (marked.status === "marked") {
+        await appendAndPublishEvents(db, bus, workspaceId, session.id, [
+          {
+            type: "sandbox.box.lost",
+            payload: { sandboxId: live.instanceId },
+          },
+        ]);
+      }
+      throw new HTTPException(409, {
+        message: `sandbox instance was lost; retry to restore it`,
+      });
+    }
+  };
 
   try {
     const envelope = await getSandboxSessionEnvelope(db, workspaceId, session.id);
@@ -490,7 +682,8 @@ async function withChannelAOperation<T>(
         established = result.established;
         leaseSnapshot = result.lease;
         establishedCacheKey = establishedHandleCacheKey(workspaceId, session.id, leaseSnapshot);
-        rememberEstablishedHandle(establishedCacheKey, established);
+        establishedCacheKind = requestedCacheKind;
+        rememberEstablishedHandle(establishedCacheKey, established, establishedCacheKind);
       } catch (error) {
         throw new HTTPException(409, {
           message: `sandbox not available (${error instanceof Error ? error.message : "spawn failed"})`,
@@ -511,82 +704,129 @@ async function withChannelAOperation<T>(
         });
       }
       leaseSnapshot = live;
-      establishedCacheKey = establishedHandleCacheKey(workspaceId, session.id, live);
-      try {
-        established = await establishCachedChannelAHandle(workspaceId, session.id, live, () =>
-          establishSandboxSessionFromEnvelope(settings, live.resumeState, {
-            sessionId: session.id,
-            recovery: "resume-only",
-            backendOverride: session.sandboxBackend,
-            environment,
-          }),
-        );
-      } catch (error) {
-        if (!isProviderSandboxNotFoundError(session.sandboxBackend, error)) {
-          throw error;
-        }
-        establishedHandleCache.delete(establishedCacheKey);
-        const marked = await markWarmLeaseInstanceLost(db, {
-          accountId,
-          workspaceId,
-          sandboxGroupId,
-          expectedEpoch: live.leaseEpoch,
-          expectedInstanceId: live.instanceId,
-        });
-        if (marked.status === "marked") {
-          await appendAndPublishEvents(db, bus, workspaceId, session.id, [
-            {
-              type: "sandbox.box.lost",
-              payload: { sandboxId: live.instanceId },
-            },
-          ]);
-        }
-        throw new HTTPException(409, {
-          message: `sandbox instance was lost; retry to restore it`,
-        });
-      }
+      const attached = await establishAttachedLiveHandle(live, requestedCacheKind);
+      established = attached.established;
+      establishedCacheKey = attached.cacheKey;
+      establishedCacheKind = requestedCacheKind;
     }
 
-    // Route every call through the same proxy, even when hot-swap is disabled:
-    // routing may be dormant, but its direct mutation admission is mandatory for
-    // every persistable provider write.
-    const routed = wrapChannelABoxWithRouting(
-      {
-        db,
-        settings,
-        bus,
-        ...(onSandboxOperation ? { onSandboxOperation } : {}),
-        ...(ctx.waitSignal ? { waitSignal: ctx.waitSignal } : {}),
-      },
-      {
-        accountId,
-        workspaceId,
-        sessionId: session.id,
-        homeLease: {
-          sandboxGroupId,
-          leaseEpoch: leaseSnapshot.leaseEpoch,
-          instanceId: leaseSnapshot.instanceId!,
-          backend: session.sandboxBackend,
-        },
-        directRequest: { requestId, holderId },
-      },
-      established,
-    );
-    const run = async () => await runEstablished(routed, leaseSnapshot);
-    return readOnly && session.sandboxBackend === "modal"
-      ? await withSandboxProviderReadLock(
+    const runProviderOperation = async (): Promise<T> => {
+      // Route every call through the same proxy, even when hot-swap is disabled:
+      // routing may be dormant, but its direct mutation admission is mandatory for
+      // every persistable provider write.
+      const routed = wrapChannelABoxWithRouting(
+        {
           db,
-          {
-            workspaceId,
+          settings,
+          bus,
+          ...(onSandboxOperation ? { onSandboxOperation } : {}),
+          ...(ctx.waitSignal ? { waitSignal: ctx.waitSignal } : {}),
+        },
+        {
+          accountId,
+          workspaceId,
+          sessionId: session.id,
+          homeLease: {
             sandboxGroupId,
             leaseEpoch: leaseSnapshot.leaseEpoch,
             instanceId: leaseSnapshot.instanceId!,
+            backend: session.sandboxBackend,
           },
-          ctx.waitSignal,
-          run,
-        )
-      : await run();
+          directRequest: { requestId, holderId },
+        },
+        established!,
+      );
+      const run = async () => await runEstablished(routed, leaseSnapshot);
+      return readOnly && session.sandboxBackend === "modal"
+        ? await withSandboxProviderReadLock(
+            db,
+            {
+              workspaceId,
+              sandboxGroupId,
+              leaseEpoch: leaseSnapshot.leaseEpoch,
+              instanceId: leaseSnapshot.instanceId!,
+            },
+            ctx.waitSignal,
+            run,
+          )
+        : await run();
+    };
+
+    // A failed attempt leaves the advisory-lock transaction before refresh;
+    // the retry acquires a new transaction/lock against the same fenced lease.
+    return readOnly
+      ? await runChannelAReadWithFreshHandleRetry(runProviderOperation, async () => {
+          const refreshStartedAt = performance.now();
+          const observeRefresh = (outcome: "ok" | "failed"): void => {
+            if (!services.observability) return;
+            const attributes = {
+              sandboxLeaseKey: sandboxLeaseTelemetryKey(workspaceId, sandboxGroupId),
+              backend: session.sandboxBackend,
+              reason: "provider_handle_unavailable",
+              outcome,
+              durationMs: Math.max(0, Math.round(performance.now() - refreshStartedAt)),
+            };
+            try {
+              services.observability.incrementCounter({
+                name: "opengeni_channel_a_handle_refresh_total",
+                help: "Channel-A provider handles rebuilt after a typed temporary-unavailable read.",
+                labels: { backend: session.sandboxBackend, outcome },
+              });
+            } catch {
+              // Metrics can never alter lease or provider authority.
+            }
+            try {
+              if (outcome === "ok") {
+                services.observability.info(
+                  "Channel-A provider handle refresh completed",
+                  attributes,
+                );
+              } else {
+                services.observability.warn("Channel-A provider handle refresh failed", attributes);
+              }
+            } catch {
+              // Logs can never alter lease or provider authority.
+            }
+          };
+          try {
+            if (establishedCacheKey) {
+              evictEstablishedHandle(establishedCacheKey, establishedCacheKind);
+            }
+            await dropEstablishedHandle(established);
+            // This request still owns its direct holder, so the exact live identity
+            // should be stable. Revalidate it before rebuilding the provider handle.
+            const live = await readLease(db, workspaceId, sandboxGroupId);
+            if (
+              !live ||
+              live.liveness !== "warm" ||
+              live.leaseEpoch !== leaseSnapshot.leaseEpoch ||
+              live.instanceId !== leaseSnapshot.instanceId
+            ) {
+              throw new HTTPException(409, {
+                message: `sandbox lease changed while refreshing its provider handle; retry`,
+              });
+            }
+            const refreshed = await establishAttachedLiveHandle(live, "none");
+            established = refreshed.established;
+            establishedCacheKey = refreshed.cacheKey;
+            establishedCacheKind = "read";
+            leaseSnapshot = live;
+            rememberEstablishedHandle(refreshed.cacheKey, refreshed.established, "read");
+            observeRefresh("ok");
+          } catch (error) {
+            observeRefresh("failed");
+            throw error;
+          }
+        })
+      : await runProviderOperation();
   } catch (error) {
+    // A read wrapper carries no yielded process state and is safe to discard.
+    // A mutation/terminal wrapper may own the SDK's only local process object;
+    // retain it after an ambiguous transport failure so a later control call
+    // can use the in-place provider transport recovery without losing the PTY.
+    if (establishedCacheKey && shouldEvictChannelAHandleAfterError(error, establishedCacheKind)) {
+      evictEstablishedHandle(establishedCacheKey, establishedCacheKind);
+    }
     throw mapChannelAError(error);
   } finally {
     await release();

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -451,6 +451,18 @@ describe("API helpers", () => {
     expect(routeLabel(`/v1/workspaces/${workspace}/sessions/session-1/control`)).toBe(
       "/v1/workspaces/:workspaceId/sessions/:id/:controlAction",
     );
+    expect(routeLabel(`/v1/workspaces/${workspace}/sessions/session-1/git/read-batch`)).toBe(
+      "/v1/workspaces/:workspaceId/sessions/:id/git/:operation",
+    );
+    expect(routeLabel(`/v1/workspaces/${workspace}/sessions/session-1/fs/read`)).toBe(
+      "/v1/workspaces/:workspaceId/sessions/:id/fs/:operation",
+    );
+    expect(routeLabel(`/v1/workspaces/${workspace}/sessions/session-1/terminal/exec`)).toBe(
+      "/v1/workspaces/:workspaceId/sessions/:id/terminal/:operation",
+    );
+    expect(routeLabel(`/v1/workspaces/${workspace}/sessions/session-1/terminal/pty/resize`)).toBe(
+      "/v1/workspaces/:workspaceId/sessions/:id/terminal/pty/:action",
+    );
     expect(routeLabel(`/v1/workspaces/${workspace}/control-events/stream`)).toBe(
       "/v1/workspaces/:workspaceId/control-events/stream",
     );

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -4,7 +4,14 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { HTTPException } from "hono/http-exception";
 import { ChannelAUnavailableError, ChannelAValidationError } from "@opengeni/runtime/sandbox";
-import { mapChannelAError, runConcurrentChannelAReads } from "../src/sandbox/channel-a";
+import {
+  isChannelAHandleCacheEntryFresh,
+  isChannelAProcessHandleCacheEntryFresh,
+  mapChannelAError,
+  runChannelAReadWithFreshHandleRetry,
+  runConcurrentChannelAReads,
+  shouldEvictChannelAHandleAfterError,
+} from "../src/sandbox/channel-a";
 
 // P4.4 route-discipline guards for all Channel-A structured-service routes (a
 // complement to the real-box runtime test + the docker e2e). The invariants the
@@ -23,26 +30,59 @@ const here = dirname(fileURLToPath(import.meta.url));
 const sessionsRoute = readFileSync(resolve(here, "..", "src", "routes", "sessions.ts"), "utf8");
 const channelASeam = readFileSync(resolve(here, "..", "src", "sandbox", "channel-a.ts"), "utf8");
 
-type RouteSpec = { path: string; permission: "files:read" | "files:write" | "terminal:attach" };
+type RouteSpec = {
+  path: string;
+  permission: "files:read" | "files:write" | "terminal:attach";
+};
 const CHANNEL_A_ROUTES: RouteSpec[] = [
-  { path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/list", permission: "files:read" },
+  {
+    path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/list",
+    permission: "files:read",
+  },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/list-batch",
     permission: "files:read",
   },
-  { path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/read", permission: "files:read" },
-  { path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/write", permission: "files:write" },
-  { path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/delete", permission: "files:write" },
-  { path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/move", permission: "files:write" },
-  { path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/mkdir", permission: "files:write" },
-  { path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/status", permission: "files:read" },
-  { path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/diff", permission: "files:read" },
+  {
+    path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/read",
+    permission: "files:read",
+  },
+  {
+    path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/write",
+    permission: "files:write",
+  },
+  {
+    path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/delete",
+    permission: "files:write",
+  },
+  {
+    path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/move",
+    permission: "files:write",
+  },
+  {
+    path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/mkdir",
+    permission: "files:write",
+  },
+  {
+    path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/status",
+    permission: "files:read",
+  },
+  {
+    path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/diff",
+    permission: "files:read",
+  },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/read-batch",
     permission: "files:read",
   },
-  { path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/log", permission: "files:read" },
-  { path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/show", permission: "files:read" },
+  {
+    path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/log",
+    permission: "files:read",
+  },
+  {
+    path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/show",
+    permission: "files:read",
+  },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/terminal/exec",
     permission: "terminal:attach",
@@ -199,7 +239,7 @@ describe("P4.4 Channel-A route discipline", () => {
     }
   });
 
-  test("every provider-backed point read uses the cross-replica read seam", () => {
+  test("every side-effect-free point read uses the coordinated recovery seam", () => {
     for (const route of [
       "fs/list",
       "fs/list-batch",
@@ -227,6 +267,76 @@ describe("P4.4 Channel-A route discipline", () => {
       expect(body).toContain("withChannelA(");
       expect(body).not.toContain("withChannelARead(");
     }
+  });
+
+  test("read and process wrappers are isolated and idle-bounded", () => {
+    const lastUsedAt = 1_000;
+    expect(isChannelAHandleCacheEntryFresh(lastUsedAt, lastUsedAt + 299_999)).toBe(true);
+    expect(isChannelAHandleCacheEntryFresh(lastUsedAt, lastUsedAt + 300_000)).toBe(false);
+    expect(isChannelAProcessHandleCacheEntryFresh(lastUsedAt, lastUsedAt + 299_999)).toBe(true);
+    expect(isChannelAProcessHandleCacheEntryFresh(lastUsedAt, lastUsedAt + 300_000)).toBe(false);
+    expect(channelASeam).toContain("establishedReadHandleCache");
+    expect(channelASeam).toContain("establishedProcessHandleCache");
+    expect(channelASeam).toContain("lastUsedAtMonotonicMs");
+  });
+
+  test("side-effect-free reads rebuild before one typed unavailable retry", async () => {
+    const order: string[] = [];
+    let calls = 0;
+    const value = await runChannelAReadWithFreshHandleRetry(
+      async () => {
+        calls += 1;
+        order.push(`run:${calls}`);
+        if (calls === 1) throw new ChannelAUnavailableError("stale provider channel");
+        return "fresh";
+      },
+      async () => {
+        order.push("refresh");
+      },
+    );
+    expect(value).toBe("fresh");
+    expect(order).toEqual(["run:1", "refresh", "run:2"]);
+  });
+
+  test("fresh-handle recovery neither retries twice nor replays non-transient errors", async () => {
+    let unavailableCalls = 0;
+    await expect(
+      runChannelAReadWithFreshHandleRetry(
+        async () => {
+          unavailableCalls += 1;
+          throw new ChannelAUnavailableError("provider still unavailable");
+        },
+        async () => undefined,
+      ),
+    ).rejects.toBeInstanceOf(ChannelAUnavailableError);
+    expect(unavailableCalls).toBe(2);
+
+    let validationCalls = 0;
+    let refreshCalls = 0;
+    const validation = new ChannelAValidationError("bad path");
+    await expect(
+      runChannelAReadWithFreshHandleRetry(
+        async () => {
+          validationCalls += 1;
+          throw validation;
+        },
+        async () => {
+          refreshCalls += 1;
+        },
+      ),
+    ).rejects.toBe(validation);
+    expect(validationCalls).toBe(1);
+    expect(refreshCalls).toBe(0);
+  });
+
+  test("transport failures evict disposable reads but preserve process-capable wrappers", () => {
+    const unavailable = new ChannelAUnavailableError("provider transport unavailable");
+    expect(shouldEvictChannelAHandleAfterError(unavailable, "read")).toBe(true);
+    expect(shouldEvictChannelAHandleAfterError(unavailable, "process")).toBe(false);
+    expect(shouldEvictChannelAHandleAfterError(unavailable, "none")).toBe(false);
+    expect(
+      shouldEvictChannelAHandleAfterError(new ChannelAValidationError("bad path"), "read"),
+    ).toBe(false);
   });
 
   test("near-identical non-transient reads are never retried", async () => {

--- a/apps/worker/src/activities/sandbox-lease.ts
+++ b/apps/worker/src/activities/sandbox-lease.ts
@@ -62,6 +62,7 @@ import {
   type LeaseSnapshot,
 } from "@opengeni/db";
 import { sandboxWarmRateMicrosPerSecond } from "@opengeni/config";
+import { sandboxLeaseTelemetryKey } from "@opengeni/observability";
 import {
   // Normal drain teardown builds the client and resumes the envelope directly:
   // a live box gets its /workspace persisted before termination, while a gone
@@ -127,6 +128,8 @@ import {
   recordTurnsQueuedGauge,
 } from "../observability-metrics";
 import { providerIdentityFromResumeState } from "../sandbox-routing";
+
+export { sandboxLeaseTelemetryKey } from "@opengeni/observability";
 
 export type ReapSandboxLeasesResult = {
   /** Stale viewer holders + warming-death rows the sweep touched is folded into
@@ -395,22 +398,6 @@ export function sandboxDrainCaptureId(operationId: string, attempt: number): str
   bytes[8] = (bytes[8]! & 0x3f) | 0x80;
   const hex = bytes.toString("hex");
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
-}
-
-/**
- * Stable, non-reversible correlation key for one logical sandbox lease. Public
- * telemetry intentionally drops workspace/group identifiers; this key lets an
- * operator correlate repeated reaper attempts without publishing either UUID.
- * The domain separator makes the digest unusable as a generic identifier hash.
- */
-export function sandboxLeaseTelemetryKey(workspaceId: string, sandboxGroupId: string): string {
-  return `slk_${createHash("sha256")
-    .update("opengeni:sandbox-lease-telemetry:v1\0")
-    .update(workspaceId)
-    .update("\0")
-    .update(sandboxGroupId)
-    .digest("hex")
-    .slice(0, 32)}`;
 }
 
 function sandboxDrainActivityAttempt(): number {

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { collectDefaultMetrics, Counter, Gauge, Histogram, Registry } from "prom-client";
 import { SandboxBackend } from "@opengeni/contracts";
 
@@ -27,6 +28,23 @@ export type Span = {
 };
 
 export type MetricLabels = Record<string, AttributeValue>;
+
+/**
+ * Stable, non-reversible correlation key for one logical sandbox lease. Public
+ * telemetry intentionally drops workspace/group identifiers; this key lets an
+ * operator correlate API, worker, and reaper failures without publishing
+ * either UUID. The domain separator prevents reuse as a generic identifier
+ * digest.
+ */
+export function sandboxLeaseTelemetryKey(workspaceId: string, sandboxGroupId: string): string {
+  return `slk_${createHash("sha256")
+    .update("opengeni:sandbox-lease-telemetry:v1\0")
+    .update(workspaceId)
+    .update("\0")
+    .update(sandboxGroupId)
+    .digest("hex")
+    .slice(0, 32)}`;
+}
 
 /**
  * Stable selectors shared by OpenGeni's runtime metrics and optional

--- a/packages/runtime/test/modal-snapshot-retention.test.ts
+++ b/packages/runtime/test/modal-snapshot-retention.test.ts
@@ -98,6 +98,24 @@ describe("OpenGeni Modal 0.9 snapshot policy", () => {
     expect(callerOwnedSnapshotIds).toHaveLength(2);
   });
 
+  test("the pinned Modal patch replaces a rotated command-router transport in place", async () => {
+    // ContainerProcess and Agents' active-process table retain this client
+    // object. Replacing only the outer Sandbox wrapper would strand yielded
+    // exec/PTY processes, so the patch must swap this object's channel + stub.
+    const source = await readFile(fileURLToPath(import.meta.resolve("modal")), "utf8");
+    expect(source).toContain("createTransport(routerUrl)");
+    expect(source).toContain("const attemptedJwt = this.jwt;");
+    expect(source).toContain("if (this.jwt !== failedJwt)");
+    expect(source).toContain(
+      "const replacement = routerChanged ? this.createTransport(resp.url) : null;",
+    );
+    expect(source).toContain("this.channel = replacement.channel;");
+    expect(source).toContain("this.stub = replacement.stub;");
+    expect(source).toContain("previousChannel?.close();");
+    expect(source).toContain("Task router URL changed during session; transport replaced");
+    expect(source).not.toContain('this.logger.warn("Task router URL changed during session");');
+  });
+
   test("the runtime resolves the exact supported Modal SDK", () => {
     const modal = new ModalClient({
       tokenId: "test-token-id",

--- a/patches/modal@0.9.0.patch
+++ b/patches/modal@0.9.0.patch
@@ -1,8 +1,193 @@
 diff --git a/dist/index.cjs b/dist/index.cjs
-index e1794ee4e42d61ebb0c35654318fe5c84a946b04..7698cc32f0ce496e2c724832f30f11b3ce21b749 100644
+index e1794ee4e42d61ebb0c35654318fe5c84a946b04..decf3777c34f4e76a58e5d0f0273529c2b9419c1 100644
 --- a/dist/index.cjs
 +++ b/dist/index.cjs
-@@ -64658,7 +64658,7 @@ var Sandbox2 = class _Sandbox {
+@@ -61900,6 +61900,7 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+   jwtExp;
+   jwtRefreshLock = Promise.resolve();
+   logger;
++  profile;
+   closed = false;
+   static async tryInit(serverClient, taskId, sandboxId, isV2, logger2, profile) {
+     let resp;
+@@ -61928,9 +61929,41 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+       "url",
+       resp.url
+     );
+-    const url = new URL(resp.url);
++    const client = new _TaskCommandRouterClientImpl(
++      serverClient,
++      taskId,
++      sandboxId,
++      isV2,
++      resp.url,
++      resp.jwt,
++      logger2,
++      profile
++    );
++    logger2.debug(
++      "Successfully initialized command router client",
++      "task_id",
++      taskId
++    );
++    return client;
++  }
++  constructor(serverClient, taskId, sandboxId, isV2, serverUrl, jwt, logger2, profile) {
++    this.serverClient = serverClient;
++    this.taskId = taskId;
++    this.sandboxId = sandboxId;
++    this.isV2 = isV2;
++    this.serverUrl = serverUrl;
++    this.jwt = jwt;
++    this.jwtExp = parseJwtExpiration(jwt, logger2);
++    this.logger = logger2;
++    this.profile = profile;
++    const transport = this.createTransport(serverUrl);
++    this.channel = transport.channel;
++    this.stub = transport.stub;
++  }
++  createTransport(routerUrl) {
++    const url = new URL(routerUrl);
+     if (url.protocol !== "https:") {
+-      throw new Error(`Task router URL must be https, got: ${resp.url}`);
++      throw new Error(`Task router URL must be https, got: ${routerUrl}`);
+     }
+     const host = url.hostname;
+     const port = url.port ? parseInt(url.port) : 443;
+@@ -61944,8 +61977,8 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+       "grpc.keepalive_permit_without_calls": 1
+     };
+     let channel;
+-    if (isLocalhost(profile)) {
+-      logger2.warn(
++    if (isLocalhost(this.profile)) {
++      this.logger.warn(
+         "Using insecure TLS (skip certificate verification) for task command router"
+       );
+       channel = (0, import_nice_grpc11.createChannel)(
+@@ -61960,40 +61993,16 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+         channelConfig
+       );
+     }
+-    const client = new _TaskCommandRouterClientImpl(
+-      serverClient,
+-      taskId,
+-      sandboxId,
+-      isV2,
+-      resp.url,
+-      resp.jwt,
+-      channel,
+-      logger2
+-    );
+-    logger2.debug(
+-      "Successfully initialized command router client",
+-      "task_id",
+-      taskId
+-    );
+-    return client;
+-  }
+-  constructor(serverClient, taskId, sandboxId, isV2, serverUrl, jwt, channel, logger2) {
+-    this.serverClient = serverClient;
+-    this.taskId = taskId;
+-    this.sandboxId = sandboxId;
+-    this.isV2 = isV2;
+-    this.serverUrl = serverUrl;
+-    this.jwt = jwt;
+-    this.jwtExp = parseJwtExpiration(jwt, logger2);
+-    this.logger = logger2;
+-    this.channel = channel;
+     const self = this;
+     const factory = (0, import_nice_grpc11.createClientFactory)().use(timeoutMiddleware).use(async function* authMiddleware(call, options) {
+       options.metadata ??= new import_nice_grpc11.Metadata();
+       options.metadata.set("authorization", `Bearer ${self.jwt}`);
+       return yield* call.next(call.request, options);
+     });
+-    this.stub = factory.create(TaskCommandRouterDefinition, channel);
++    return {
++      channel,
++      stub: factory.create(TaskCommandRouterDefinition, channel)
++    };
+   }
+   close() {
+     if (this.closed) {
+@@ -62229,15 +62238,15 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+       throw err;
+     }
+   }
+-  async refreshJwt() {
++  async refreshJwt(failedJwt) {
+     let error;
+     this.jwtRefreshLock = this.jwtRefreshLock.then(async () => {
+       if (this.closed) {
+         return;
+       }
+-      if (this.jwtExp !== null && this.jwtExp - Date.now() / 1e3 > 30) {
++      if (this.jwt !== failedJwt) {
+         this.logger.debug(
+-          "Skipping JWT refresh because expiration is far enough in the future",
++          "Skipping JWT refresh because another request already refreshed it",
+           "task_id",
+           this.taskId
+         );
+@@ -62250,11 +62259,24 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+           this.sandboxId,
+           this.isV2
+         );
+-        if (resp.url !== this.serverUrl) {
+-          this.logger.warn("Task router URL changed during session");
++        if (this.closed) {
++          return;
+         }
++        const routerChanged = resp.url !== this.serverUrl;
++        const replacement = routerChanged ? this.createTransport(resp.url) : null;
++        const previousChannel = routerChanged ? this.channel : null;
+         this.jwt = resp.jwt;
+         this.jwtExp = parseJwtExpiration(resp.jwt, this.logger);
++        if (replacement) {
++          this.serverUrl = resp.url;
++          this.channel = replacement.channel;
++          this.stub = replacement.stub;
++          try {
++            previousChannel?.close();
++          } catch {
++          }
++          this.logger.warn("Task router URL changed during session; transport replaced");
++        }
+       } catch (err) {
+         error = err;
+       }
+@@ -62265,11 +62287,12 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+     }
+   }
+   async callWithAuthRetry(func) {
++    const attemptedJwt = this.jwt;
+     try {
+       return await func();
+     } catch (err) {
+       if (err instanceof import_nice_grpc11.ClientError && err.code === import_nice_grpc11.Status.UNAUTHENTICATED) {
+-        await this.refreshJwt();
++        await this.refreshJwt(attemptedJwt);
+         return await func();
+       }
+       throw err;
+@@ -62291,6 +62314,7 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+     while (true) {
+       try {
+         const timeoutMs = deadline !== null ? Math.max(0, deadline - Date.now()) : void 0;
++        const attemptedJwt = this.jwt;
+         const request = TaskExecStdioReadRequest.create({
+           taskId,
+           execId,
+@@ -62312,7 +62336,7 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+           return;
+         } catch (err) {
+           if (err instanceof import_nice_grpc11.ClientError && err.code === import_nice_grpc11.Status.UNAUTHENTICATED && !didAuthRetry) {
+-            await this.refreshJwt();
++            await this.refreshJwt(attemptedJwt);
+             didAuthRetry = true;
+             continue;
+           }
+@@ -64658,7 +64682,7 @@ var Sandbox2 = class _Sandbox {
      const [taskId, commandRouterClient] = await this.#getCommandRouter();
      const request = TaskSnapshotFilesystemRequest.create({
        taskId,
@@ -11,7 +196,7 @@ index e1794ee4e42d61ebb0c35654318fe5c84a946b04..7698cc32f0ce496e2c724832f30f11b3
        ttlSeconds: wireTtlSeconds
      });
      const response = await commandRouterClient.snapshotFilesystem(request, {
-@@ -64778,7 +64778,7 @@ var Sandbox2 = class _Sandbox {
+@@ -64778,7 +64802,7 @@ var Sandbox2 = class _Sandbox {
      const request = buildTaskSnapshotDirectoryRequestProto(
        taskId,
        path2,
@@ -81,10 +266,195 @@ index 9b2f092b923c931edd32b39aeb7af55ec1c9ec1b..4ad4fd812241dd29387fe29a35e898d4
       * Overall budget for the snapshot call, in milliseconds. Defaults to
       * 55000. If it elapses before a snapshot completes, the call is cancelled
 diff --git a/dist/index.js b/dist/index.js
-index 83068162e5c4b650f1046bcaf3ba8b4f9f73b7b9..4b499115699f18d62db53fefa168f32b17e14440 100644
+index 83068162e5c4b650f1046bcaf3ba8b4f9f73b7b9..21f6b419054b56b9f64ade77f779828b1c83832a 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -64586,7 +64586,7 @@ var Sandbox2 = class _Sandbox {
+@@ -61828,6 +61828,7 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+   jwtExp;
+   jwtRefreshLock = Promise.resolve();
+   logger;
++  profile;
+   closed = false;
+   static async tryInit(serverClient, taskId, sandboxId, isV2, logger2, profile) {
+     let resp;
+@@ -61856,9 +61857,41 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+       "url",
+       resp.url
+     );
+-    const url = new URL(resp.url);
++    const client = new _TaskCommandRouterClientImpl(
++      serverClient,
++      taskId,
++      sandboxId,
++      isV2,
++      resp.url,
++      resp.jwt,
++      logger2,
++      profile
++    );
++    logger2.debug(
++      "Successfully initialized command router client",
++      "task_id",
++      taskId
++    );
++    return client;
++  }
++  constructor(serverClient, taskId, sandboxId, isV2, serverUrl, jwt, logger2, profile) {
++    this.serverClient = serverClient;
++    this.taskId = taskId;
++    this.sandboxId = sandboxId;
++    this.isV2 = isV2;
++    this.serverUrl = serverUrl;
++    this.jwt = jwt;
++    this.jwtExp = parseJwtExpiration(jwt, logger2);
++    this.logger = logger2;
++    this.profile = profile;
++    const transport = this.createTransport(serverUrl);
++    this.channel = transport.channel;
++    this.stub = transport.stub;
++  }
++  createTransport(routerUrl) {
++    const url = new URL(routerUrl);
+     if (url.protocol !== "https:") {
+-      throw new Error(`Task router URL must be https, got: ${resp.url}`);
++      throw new Error(`Task router URL must be https, got: ${routerUrl}`);
+     }
+     const host = url.hostname;
+     const port = url.port ? parseInt(url.port) : 443;
+@@ -61872,8 +61905,8 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+       "grpc.keepalive_permit_without_calls": 1
+     };
+     let channel;
+-    if (isLocalhost(profile)) {
+-      logger2.warn(
++    if (isLocalhost(this.profile)) {
++      this.logger.warn(
+         "Using insecure TLS (skip certificate verification) for task command router"
+       );
+       channel = createChannel2(
+@@ -61888,40 +61921,16 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+         channelConfig
+       );
+     }
+-    const client = new _TaskCommandRouterClientImpl(
+-      serverClient,
+-      taskId,
+-      sandboxId,
+-      isV2,
+-      resp.url,
+-      resp.jwt,
+-      channel,
+-      logger2
+-    );
+-    logger2.debug(
+-      "Successfully initialized command router client",
+-      "task_id",
+-      taskId
+-    );
+-    return client;
+-  }
+-  constructor(serverClient, taskId, sandboxId, isV2, serverUrl, jwt, channel, logger2) {
+-    this.serverClient = serverClient;
+-    this.taskId = taskId;
+-    this.sandboxId = sandboxId;
+-    this.isV2 = isV2;
+-    this.serverUrl = serverUrl;
+-    this.jwt = jwt;
+-    this.jwtExp = parseJwtExpiration(jwt, logger2);
+-    this.logger = logger2;
+-    this.channel = channel;
+     const self = this;
+     const factory = createClientFactory2().use(timeoutMiddleware).use(async function* authMiddleware(call, options) {
+       options.metadata ??= new Metadata2();
+       options.metadata.set("authorization", `Bearer ${self.jwt}`);
+       return yield* call.next(call.request, options);
+     });
+-    this.stub = factory.create(TaskCommandRouterDefinition, channel);
++    return {
++      channel,
++      stub: factory.create(TaskCommandRouterDefinition, channel)
++    };
+   }
+   close() {
+     if (this.closed) {
+@@ -62157,15 +62166,15 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+       throw err;
+     }
+   }
+-  async refreshJwt() {
++  async refreshJwt(failedJwt) {
+     let error;
+     this.jwtRefreshLock = this.jwtRefreshLock.then(async () => {
+       if (this.closed) {
+         return;
+       }
+-      if (this.jwtExp !== null && this.jwtExp - Date.now() / 1e3 > 30) {
++      if (this.jwt !== failedJwt) {
+         this.logger.debug(
+-          "Skipping JWT refresh because expiration is far enough in the future",
++          "Skipping JWT refresh because another request already refreshed it",
+           "task_id",
+           this.taskId
+         );
+@@ -62178,11 +62187,24 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+           this.sandboxId,
+           this.isV2
+         );
+-        if (resp.url !== this.serverUrl) {
+-          this.logger.warn("Task router URL changed during session");
++        if (this.closed) {
++          return;
+         }
++        const routerChanged = resp.url !== this.serverUrl;
++        const replacement = routerChanged ? this.createTransport(resp.url) : null;
++        const previousChannel = routerChanged ? this.channel : null;
+         this.jwt = resp.jwt;
+         this.jwtExp = parseJwtExpiration(resp.jwt, this.logger);
++        if (replacement) {
++          this.serverUrl = resp.url;
++          this.channel = replacement.channel;
++          this.stub = replacement.stub;
++          try {
++            previousChannel?.close();
++          } catch {
++          }
++          this.logger.warn("Task router URL changed during session; transport replaced");
++        }
+       } catch (err) {
+         error = err;
+       }
+@@ -62193,11 +62215,12 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+     }
+   }
+   async callWithAuthRetry(func) {
++    const attemptedJwt = this.jwt;
+     try {
+       return await func();
+     } catch (err) {
+       if (err instanceof ClientError10 && err.code === Status10.UNAUTHENTICATED) {
+-        await this.refreshJwt();
++        await this.refreshJwt(attemptedJwt);
+         return await func();
+       }
+       throw err;
+@@ -62219,6 +62242,7 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+     while (true) {
+       try {
+         const timeoutMs = deadline !== null ? Math.max(0, deadline - Date.now()) : void 0;
++        const attemptedJwt = this.jwt;
+         const request = TaskExecStdioReadRequest.create({
+           taskId,
+           execId,
+@@ -62240,7 +62264,7 @@ var TaskCommandRouterClientImpl = class _TaskCommandRouterClientImpl {
+           return;
+         } catch (err) {
+           if (err instanceof ClientError10 && err.code === Status10.UNAUTHENTICATED && !didAuthRetry) {
+-            await this.refreshJwt();
++            await this.refreshJwt(attemptedJwt);
+             didAuthRetry = true;
+             continue;
+           }
+@@ -64586,7 +64610,7 @@ var Sandbox2 = class _Sandbox {
      const [taskId, commandRouterClient] = await this.#getCommandRouter();
      const request = TaskSnapshotFilesystemRequest.create({
        taskId,
@@ -93,7 +463,7 @@ index 83068162e5c4b650f1046bcaf3ba8b4f9f73b7b9..4b499115699f18d62db53fefa168f32b
        ttlSeconds: wireTtlSeconds
      });
      const response = await commandRouterClient.snapshotFilesystem(request, {
-@@ -64706,7 +64706,7 @@ var Sandbox2 = class _Sandbox {
+@@ -64706,7 +64730,7 @@ var Sandbox2 = class _Sandbox {
      const request = buildTaskSnapshotDirectoryRequestProto(
        taskId,
        path2,


### PR DESCRIPTION
Fixes the production Channel-A failure exposed by the 0.22.89 live acceptance.

- rotates Modal command-router channel and stub in place when the refreshed access URL changes, preserving yielded process objects
- isolates read/viewer wrappers from process-capable terminal wrappers
- refreshes and retries side-effect-free reads exactly once after a typed unavailable result; mutations are never replayed
- composes with the cross-replica Modal read lock from #1207 and reacquires it for the retry
- adds bounded low-cardinality recovery telemetry and concrete Channel-A route labels
- keeps Linux/Docker process-wrapper semantics unchanged

Validation: full unit suite; full typecheck; lint; format; focused API, DB advisory-lock, Modal patch, runtime, worker, and observability tests.