### PR TITLE
chore(release): bump product version to 0.22.91

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.90
-appVersion: "0.22.90"
+version: 0.22.91
+appVersion: "0.22.91"


### PR DESCRIPTION
Bumps the Helm chart and app version together to the next unoccupied product release identity. 0.22.90 is bound to a superseded immutable candidate and must not be reused.\n\nValidated: release-version contract, release workflow contract (15/15), Helm lint, lint, format, and diff checks.