### PR TITLE
perf(terraform): safely enable bounded AKS autoscaling

### DIFF
--- a/deploy/terraform/azure/README.md
+++ b/deploy/terraform/azure/README.md
@@ -73,6 +73,46 @@ aks = {
 }
 ```
 
+An already-existing fixed pool must not jump directly to an unbounded or
+rotation-sensitive configuration. Use the `bounds` phase, explicitly attest
+that the refreshed pool is still fixed, preserve every rotation-sensitive
+field, and bind `node_count` to the exact live count. The live count must fit
+inside the requested bounds, so enabling autoscaling cannot immediately create
+nodes beyond the reviewed maximum. Terraform then omits `node_count` from the
+desired autoscaled resource and lets Azure own the converging live count.
+
+```hcl
+aks_existing_pool = true
+
+aks = {
+  node_count           = 6
+  vm_size              = "Standard_D4ds_v4"
+  auto_scaling_enabled = true
+  min_count            = 3
+  max_count            = 6
+  max_pods             = 30
+  os_disk_size_gb      = 128
+  os_disk_type         = "Managed"
+  temporary_name_for_rotation = null
+}
+
+aks_rollout = {
+  phase = "bounds"
+  expected_existing = {
+    auto_scaling_enabled        = false
+    vm_size                     = "Standard_D4ds_v4"
+    max_pods                    = 30
+    os_disk_size_gb             = 128
+    os_disk_type                = "Managed"
+    temporary_name_for_rotation = null
+  }
+}
+```
+
+Review the saved plan and require an in-place update limited to autoscaling and
+its bounds. After apply, refresh provider state and verify the live count is
+inside the bounds before any later bounds or rotation change.
+
 For the observed staging pool, phase 1 must change only autoscaling bounds. The
 SKU, pod density, managed-disk type, and rotation name below are the existing
 live settings and are repeated to make accidental rotation visible in the
@@ -99,6 +139,7 @@ aks = {
 aks_rollout = {
   phase = "bounds"
   expected_existing = {
+    auto_scaling_enabled = true
     vm_size      = "Standard_D4ds_v4"
     max_pods     = 30
     os_disk_size_gb = 128

--- a/deploy/terraform/azure/main.tf
+++ b/deploy/terraform/azure/main.tf
@@ -41,6 +41,7 @@ locals {
   aks_vm_size                           = var.aks.vm_size
   aks_rotation_preflight                = try(var.aks_rollout.rotation_preflight, null)
   aks_existing_node_pool                = try(data.azurerm_kubernetes_cluster_node_pool.existing[0], null)
+  aks_existing_auto_scaling_enabled     = coalesce(try(local.aks_existing_node_pool.auto_scaling_enabled, null), false)
   aks_existing_node_count               = try(local.aks_existing_node_pool.node_count, null)
   aks_rotation_count_matches_live = try(
     local.aks_rotation_preflight.observed_node_count == local.aks_existing_node_count,
@@ -192,7 +193,7 @@ resource "azurerm_kubernetes_cluster" "this" {
     precondition {
       condition = var.aks_rollout.phase != "bounds" || (
         var.aks_rollout.expected_existing != null &&
-        try(local.aks_existing_node_pool.auto_scaling_enabled, false) &&
+        try(var.aks_rollout.expected_existing.auto_scaling_enabled, true) == local.aks_existing_auto_scaling_enabled &&
         try(var.aks_rollout.expected_existing.vm_size, null) == local.aks_existing_node_pool.vm_size &&
         try(var.aks_rollout.expected_existing.max_pods, null) == local.aks_existing_node_pool.max_pods &&
         try(var.aks_rollout.expected_existing.os_disk_size_gb, null) == local.aks_existing_node_pool.os_disk_size_gb &&
@@ -202,9 +203,17 @@ resource "azurerm_kubernetes_cluster" "this" {
         var.aks.os_disk_size_gb == local.aks_existing_node_pool.os_disk_size_gb &&
         var.aks.os_disk_type == local.aks_existing_node_pool.os_disk_type &&
         try(var.aks_rollout.expected_existing.temporary_name_for_rotation, null) == null &&
-        var.aks.temporary_name_for_rotation == null
+        var.aks.temporary_name_for_rotation == null &&
+        (
+          try(var.aks_rollout.expected_existing.auto_scaling_enabled, true) ||
+          (
+            var.aks.node_count == local.aks_existing_node_count &&
+            local.aks_existing_node_count >= local.aks_min_count &&
+            local.aks_existing_node_count <= local.aks_max_count
+          )
+        )
       )
-      error_message = "AKS bounds rollout must match the refreshed live system pool for SKU, pod density, disk, and autoscaling; rotation settings must remain null."
+      error_message = "AKS bounds rollout must match the refreshed live system pool for SKU, pod density, disk, and autoscaling; a fixed-to-autoscaled transition must also bind the exact live count inside the requested bounds; rotation settings must remain null."
     }
 
     precondition {

--- a/deploy/terraform/azure/tests/aks_capacity_unit_test.tftest.hcl
+++ b/deploy/terraform/azure/tests/aks_capacity_unit_test.tftest.hcl
@@ -77,6 +77,35 @@ mock_provider "azurerm" {
   }
 }
 
+# Model the pre-transition state of an imported fixed system pool. Bounds
+# admission must prove this provider state exactly before enabling autoscaling.
+mock_provider "azurerm" {
+  alias = "fixed"
+
+  mock_data "azurerm_client_config" {
+    defaults = {
+      client_id       = "00000000-0000-0000-0000-000000000001"
+      object_id       = "00000000-0000-0000-0000-000000000002"
+      subscription_id = "00000000-0000-0000-0000-000000000003"
+      tenant_id       = "00000000-0000-0000-0000-000000000004"
+    }
+  }
+
+  mock_data "azurerm_kubernetes_cluster_node_pool" {
+    defaults = {
+      auto_scaling_enabled = false
+      max_count            = null
+      max_pods             = 30
+      min_count            = null
+      name                 = "system"
+      node_count           = 6
+      os_disk_size_gb      = 128
+      os_disk_type         = "Managed"
+      vm_size              = "Standard_D4ds_v4"
+    }
+  }
+}
+
 # Model the authoritative post-convergence refresh separately from the
 # imported count-four provider state above. The real operator refresh supplies
 # this state after phase 1; the alias keeps that transition deterministic in
@@ -213,6 +242,124 @@ run "direct_autoscaling_omits_node_count" {
     )
     error_message = "Autoscaled pools must omit node_count so provider state owns the live count."
   }
+}
+
+run "fixed_pool_can_enable_bounded_autoscaling_in_place" {
+  command = plan
+  providers = {
+    azurerm = azurerm.fixed
+  }
+
+  variables {
+    aks_existing_pool = true
+    aks = {
+      node_count                  = 6
+      vm_size                     = "Standard_D4ds_v4"
+      auto_scaling_enabled        = true
+      min_count                   = 3
+      max_count                   = 6
+      max_pods                    = 30
+      os_disk_size_gb             = 128
+      os_disk_type                = "Managed"
+      temporary_name_for_rotation = null
+    }
+
+    aks_rollout = {
+      phase = "bounds"
+      expected_existing = {
+        auto_scaling_enabled        = false
+        vm_size                     = "Standard_D4ds_v4"
+        max_pods                    = 30
+        os_disk_size_gb             = 128
+        os_disk_type                = "Managed"
+        temporary_name_for_rotation = null
+      }
+    }
+  }
+
+  assert {
+    condition = (
+      local.aks_existing_node_count == 6 &&
+      azurerm_kubernetes_cluster.this.default_node_pool[0].auto_scaling_enabled == true &&
+      azurerm_kubernetes_cluster.this.default_node_pool[0].min_count == 3 &&
+      azurerm_kubernetes_cluster.this.default_node_pool[0].max_count == 6 &&
+      local.aks_node_count_for_pool == null
+    )
+    error_message = "A fixed pool transition must bind live count six and configure only bounded autoscaling while omitting desired node_count."
+  }
+}
+
+run "fixed_pool_transition_rejects_a_false_live_count" {
+  command = plan
+  providers = {
+    azurerm = azurerm.fixed
+  }
+
+  variables {
+    aks_existing_pool = true
+    aks = {
+      node_count                  = 5
+      vm_size                     = "Standard_D4ds_v4"
+      auto_scaling_enabled        = true
+      min_count                   = 3
+      max_count                   = 6
+      max_pods                    = 30
+      os_disk_size_gb             = 128
+      os_disk_type                = "Managed"
+      temporary_name_for_rotation = null
+    }
+
+    aks_rollout = {
+      phase = "bounds"
+      expected_existing = {
+        auto_scaling_enabled        = false
+        vm_size                     = "Standard_D4ds_v4"
+        max_pods                    = 30
+        os_disk_size_gb             = 128
+        os_disk_type                = "Managed"
+        temporary_name_for_rotation = null
+      }
+    }
+  }
+
+  expect_failures = [
+    azurerm_kubernetes_cluster.this,
+  ]
+}
+
+run "fixed_pool_transition_rejects_stale_autoscaling_state" {
+  command = plan
+
+  variables {
+    aks_existing_pool = true
+    aks = {
+      node_count                  = 4
+      vm_size                     = "Standard_D4ds_v4"
+      auto_scaling_enabled        = true
+      min_count                   = 3
+      max_count                   = 4
+      max_pods                    = 30
+      os_disk_size_gb             = 128
+      os_disk_type                = "Managed"
+      temporary_name_for_rotation = null
+    }
+
+    aks_rollout = {
+      phase = "bounds"
+      expected_existing = {
+        auto_scaling_enabled        = false
+        vm_size                     = "Standard_D4ds_v4"
+        max_pods                    = 30
+        os_disk_size_gb             = 128
+        os_disk_type                = "Managed"
+        temporary_name_for_rotation = null
+      }
+    }
+  }
+
+  expect_failures = [
+    azurerm_kubernetes_cluster.this,
+  ]
 }
 
 run "bounds_rollout_preserves_existing_rotation_fields" {

--- a/deploy/terraform/azure/variables.tf
+++ b/deploy/terraform/azure/variables.tf
@@ -129,10 +129,11 @@ variable "aks" {
 }
 
 variable "aks_rollout" {
-  description = "Optional explicit guardrails for staged AKS changes. Existing-pool bounds compare expected_existing and desired rotation-sensitive settings with a refreshed live system-pool data source, then rotation compares observed count and quota evidence with that same live count."
+  description = "Optional explicit guardrails for staged AKS changes. Existing-pool bounds compare expected_existing and desired rotation-sensitive settings with a refreshed live system-pool data source, including an explicit fixed-to-autoscaled transition, then rotation compares observed count and quota evidence with that same live count."
   type = object({
     phase = optional(string, "direct")
     expected_existing = optional(object({
+      auto_scaling_enabled        = optional(bool, true)
       vm_size                     = optional(string)
       max_pods                    = optional(number)
       os_disk_size_gb             = optional(number)


### PR DESCRIPTION
## Summary

- let an imported fixed AKS system pool enter bounded autoscaling through the existing staged bounds phase
- bind the transition to refreshed provider state, exact live node count, and unchanged rotation-sensitive fields
- keep autoscaled node count provider-owned and reject stale or self-attested state

## Validation

- Terraform validation succeeds
- AKS capacity suite: 20 pass, 0 fail
- repository typecheck, format, and public-hygiene guards pass