### PR TITLE
fix(api): recover prolonged Modal read rollover

### DIFF
--- a/.changeset/retry-modal-read-rollover.md
+++ b/.changeset/retry-modal-read-rollover.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Retry a side-effect-free Modal Channel-A read through one additional fresh handle when the provider route remains temporarily unavailable after the first successful handle rebuild.

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -309,20 +309,29 @@ export async function runConcurrentChannelAReads<T>(
   return values;
 }
 
-/** Retry a side-effect-free Channel-A read once, but only after the caller has
- * discarded and freshly re-established its provider handle. Provider commands
- * are not replayed for validation/conflict/unknown errors, and mutation routes
- * never call this helper. */
+/** Retry a side-effect-free Channel-A read at most twice, but only after the
+ * caller has discarded and freshly re-established its provider handle.
+ *
+ * Modal's command-router rollover can outlive the first replacement handle: a
+ * request may rebuild successfully, then receive one more typed unavailable
+ * result while the provider finishes the route transition. A second fresh
+ * handle is therefore allowed for reads only. Provider commands are never
+ * replayed for validation/conflict/unknown errors, and mutation routes never
+ * call this helper. */
 export async function runChannelAReadWithFreshHandleRetry<T>(
   run: () => Promise<T>,
   refreshHandle: () => Promise<void>,
 ): Promise<T> {
-  try {
-    return await run();
-  } catch (error) {
-    if (!(error instanceof ChannelAUnavailableError)) throw error;
-    await refreshHandle();
-    return await run();
+  const maxFreshHandleRetries = 2;
+  for (let retry = 0; ; retry += 1) {
+    try {
+      return await run();
+    } catch (error) {
+      if (!(error instanceof ChannelAUnavailableError) || retry >= maxFreshHandleRetries) {
+        throw error;
+      }
+      await refreshHandle();
+    }
   }
 }
 

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -3,7 +3,11 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { HTTPException } from "hono/http-exception";
-import { ChannelAUnavailableError, ChannelAValidationError } from "@opengeni/runtime/sandbox";
+import {
+  ChannelAConflictError,
+  ChannelAUnavailableError,
+  ChannelAValidationError,
+} from "@opengeni/runtime/sandbox";
 import {
   isChannelAHandleCacheEntryFresh,
   isChannelAProcessHandleCacheEntryFresh,
@@ -280,14 +284,14 @@ describe("P4.4 Channel-A route discipline", () => {
     expect(channelASeam).toContain("lastUsedAtMonotonicMs");
   });
 
-  test("side-effect-free reads rebuild before one typed unavailable retry", async () => {
+  test("side-effect-free reads rebuild across a second rollover unavailable result", async () => {
     const order: string[] = [];
     let calls = 0;
     const value = await runChannelAReadWithFreshHandleRetry(
       async () => {
         calls += 1;
         order.push(`run:${calls}`);
-        if (calls === 1) throw new ChannelAUnavailableError("stale provider channel");
+        if (calls <= 2) throw new ChannelAUnavailableError("provider rollover still settling");
         return "fresh";
       },
       async () => {
@@ -295,10 +299,10 @@ describe("P4.4 Channel-A route discipline", () => {
       },
     );
     expect(value).toBe("fresh");
-    expect(order).toEqual(["run:1", "refresh", "run:2"]);
+    expect(order).toEqual(["run:1", "refresh", "run:2", "refresh", "run:3"]);
   });
 
-  test("fresh-handle recovery neither retries twice nor replays non-transient errors", async () => {
+  test("fresh-handle recovery is bounded and never replays non-transient errors", async () => {
     let unavailableCalls = 0;
     await expect(
       runChannelAReadWithFreshHandleRetry(
@@ -309,7 +313,7 @@ describe("P4.4 Channel-A route discipline", () => {
         async () => undefined,
       ),
     ).rejects.toBeInstanceOf(ChannelAUnavailableError);
-    expect(unavailableCalls).toBe(2);
+    expect(unavailableCalls).toBe(3);
 
     let validationCalls = 0;
     let refreshCalls = 0;
@@ -327,6 +331,26 @@ describe("P4.4 Channel-A route discipline", () => {
     ).rejects.toBe(validation);
     expect(validationCalls).toBe(1);
     expect(refreshCalls).toBe(0);
+
+    let mixedCalls = 0;
+    let mixedRefreshes = 0;
+    const conflict = new ChannelAConflictError("lease changed");
+    await expect(
+      runChannelAReadWithFreshHandleRetry(
+        async () => {
+          mixedCalls += 1;
+          if (mixedCalls === 1) {
+            throw new ChannelAUnavailableError("provider rollover started");
+          }
+          throw conflict;
+        },
+        async () => {
+          mixedRefreshes += 1;
+        },
+      ),
+    ).rejects.toBe(conflict);
+    expect(mixedCalls).toBe(2);
+    expect(mixedRefreshes).toBe(1);
   });
 
   test("transport failures evict disposable reads but preserve process-capable wrappers", () => {


### PR DESCRIPTION
## Summary

- allow one additional freshly re-established handle for side-effect-free Channel-A reads when Modal remains typed-unavailable after the first successful handle refresh
- keep mutation routes unchanged and stop immediately on validation, conflict, not-found, and unknown failures
- add positive proof for two rollover failures followed by recovery and a near-identical planted negative for a conflict after the first transient failure

## Live defect receipt

OpenGeni production acceptance run `31275726664` for source `fa715bbcbbc550e149889821adbd92182fbbe32a` failed after the intentional 302-second command-router expiry window. API logs at `2026-08-08T20:08:33.735Z` show the first fresh-handle rebuild completed successfully in 481 ms; the same Git read request then returned HTTP 503 at `2026-08-08T20:08:37.194Z`. The existing single fresh-handle attempt was therefore insufficient.

Failed ledger `Cloudgeni-ai/opengeni-ops#398` remains sealed and unchanged.

## Verification

- `bun test apps/api/test/channel-a-routes.test.ts packages/runtime/test/modal-snapshot-retention.test.ts` — 50 passed, 0 failed
- `bun run typecheck` — all 23 projects clean
- `bun run format:check` — pass
- `bun run lint` — 0 warnings, 0 errors
- `git diff --check` — pass

## No-Claim

No-Claim: local tests prove only the bounded read-only retry contract and its non-transient negative. They do not claim live Modal acceptance; that requires a new canonical candidate, production acceptance, and a new soak ledger after merge.
