### PR TITLE
fix(sandbox): fence teardown workspace reads

### DIFF
--- a/.changeset/calm-workspaces-rest.md
+++ b/.changeset/calm-workspaces-rest.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/react": patch
+"@opengeni/runtime": patch
+---
+
+Keep teardown-owned workspaces capture-backed until explicit reacquisition reaches warm, and prevent historical events or capability reads from issuing provider I/O during teardown.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -2108,9 +2108,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       settings.sandboxDesktopEnabled &&
       !streamTokenDegraded(settings) &&
       acknowledged &&
-      (session.activeSandboxId != null ||
-        lease?.liveness === "warm" ||
-        lease?.liveness === "draining");
+      (session.activeSandboxId != null || lease?.liveness === "warm");
     if (desktopUnlocked) {
       desktopStream = await mintDesktopStream(
         { db, settings, bus },
@@ -2137,9 +2135,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     const terminalUnlocked =
       settings.sandboxTerminalEnabled &&
       !streamTokenDegraded(settings) &&
-      (session.activeSandboxId != null ||
-        lease?.liveness === "warm" ||
-        lease?.liveness === "draining");
+      (session.activeSandboxId != null || lease?.liveness === "warm");
     if (terminalUnlocked) {
       terminalStream = await mintTerminalStream(
         { db, settings, bus },

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -645,7 +645,7 @@ export type MintDesktopStreamInput = {
   session: Session;
   /** The viewer holder id the scoped token is minted for. */
   viewerId: string;
-  /** The live lease (must be warm/draining — the box is up). A selfhosted-active
+  /** The live lease (must be holder-confirmed warm). A selfhosted-active
    *  session may have no Modal group lease; omit and the selfhosted branch handles it. */
   lease?: LeaseSnapshot;
   /** The epoch the CALLER last observed the URL minted under. When the live
@@ -737,7 +737,7 @@ export async function mintDesktopStream(
 
   // GATE 2: the box must be live (the handshake never spins one up — a cold box
   // returns lease_cold; the viewer-attach path warms it first, then mints).
-  if (!lease || (lease.liveness !== "warm" && lease.liveness !== "draining")) {
+  if (!lease || lease.liveness !== "warm") {
     return null;
   }
 
@@ -899,7 +899,7 @@ export type MintTerminalStreamInput = {
   session: Session;
   /** The viewer holder / principal id the scoped token is minted for. */
   viewerId: string;
-  /** The live lease (must be warm/draining — the box is up). A selfhosted-active
+  /** The live lease (must be holder-confirmed warm). A selfhosted-active
    *  session may have no Modal group lease; omit and the selfhosted branch handles it. */
   lease?: LeaseSnapshot;
   /** Test seam: override how the box is re-established by id (see
@@ -967,7 +967,7 @@ export async function mintTerminalStream(
   }
 
   // GATE 2: the box must be live (the handshake never spins one up).
-  if (!lease || (lease.liveness !== "warm" && lease.liveness !== "draining")) {
+  if (!lease || lease.liveness !== "warm") {
     return null;
   }
 

--- a/apps/api/test/sandbox-desktop-stream.test.ts
+++ b/apps/api/test/sandbox-desktop-stream.test.ts
@@ -281,6 +281,47 @@ describe("P4.2 desktop pixel data plane (real lease + RLS + fence)", () => {
     expect(mint).toBeNull();
   }, 60_000);
 
+  test("GATE — a DRAINING lease never performs observer provider I/O", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const { session, lease } = await seedWarmModalBox(accountId, workspaceId);
+    let establishCalls = 0;
+    const establish = async () => {
+      establishCalls += 1;
+      return await fakeEstablish(lease.leaseEpoch)();
+    };
+    const drainingLease: LeaseSnapshot = { ...lease, liveness: "draining" };
+
+    const [desktop, terminal] = await Promise.all([
+      mintDesktopStream(
+        { db, settings },
+        {
+          accountId,
+          workspaceId,
+          session: session!,
+          viewerId: crypto.randomUUID(),
+          lease: drainingLease,
+          establish,
+        },
+      ),
+      mintTerminalStream(
+        { db, settings },
+        {
+          accountId,
+          workspaceId,
+          session: session!,
+          viewerId: crypto.randomUUID(),
+          lease: drainingLease,
+          establish,
+        },
+      ),
+    ]);
+
+    expect(desktop).toBeNull();
+    expect(terminal).toBeNull();
+    expect(establishCalls).toBe(0);
+  }, 60_000);
+
   test("GATE — desktop DISABLED ⇒ no mint (degradation is a value)", async () => {
     if (!available) return;
     const { accountId, workspaceId } = await freshWorkspace();

--- a/packages/react/src/components/sandbox-terminal.tsx
+++ b/packages/react/src/components/sandbox-terminal.tsx
@@ -4,6 +4,7 @@ import { cn } from "../lib/cn";
 import { useTerminalStream } from "../hooks/use-terminal-stream";
 import type { UseSandboxTerminalResult } from "../hooks/use-sandbox-terminal";
 import { resolveTerminalFont, xtermThemeFromTokens } from "../lib/xterm-theme";
+import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
 import { attachRenderer, type RendererLoaders, type RendererTier } from "../lib/xterm-renderer";
 
 /**
@@ -236,7 +237,7 @@ export function SandboxTerminal({
   // Boot-in-terminal: after the user focuses a not-yet-warm box, show styled
   // status lines INSIDE xterm instead of an overlay — but only when there is no
   // firehose transcript to show yet (otherwise the projected output is shown).
-  const warm = liveness === "warm" || liveness === "draining";
+  const warm = sandboxAcceptsLiveIo(liveness);
   const booting =
     activated &&
     !ptyMode &&

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -30,6 +30,7 @@ import {
 import { type ClientOverride, useOpenGeni } from "../provider";
 import { cn } from "../lib/cn";
 import { xtermThemeFromTokens } from "../lib/xterm-theme";
+import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
 import { useSessionCapabilities } from "../hooks/use-session-capabilities";
 import { useSandboxFiles } from "../hooks/use-sandbox-files";
 import {
@@ -336,8 +337,7 @@ export function useSandboxWorkspaceTabs(
   // Mutations are live-only. A capture is a review artifact, never a writable
   // surrogate for a sleeping machine; the user must deliberately open the live
   // workspace before create/rename/delete/edit controls appear.
-  const filesEditable =
-    fileSystemOn && !fsReadOnly && (liveness === "warm" || liveness === "draining");
+  const filesEditable = fileSystemOn && !fsReadOnly && sandboxAcceptsLiveIo(liveness);
   const gitOn = capabilities?.Git.available ?? false;
   const terminalOn = terminalEnabled && (capabilities?.Terminal.transport ?? null) !== null;
   // The REAL interactive terminal is the ttyd pty-ws stream. When it's live the
@@ -382,7 +382,7 @@ export function useSandboxWorkspaceTabs(
     enabled: workspaceDataEnabled,
   });
   const captureAvailable = captureState.available;
-  const liveWorkspaceExpected = liveness === "warm" || liveness === "draining";
+  const liveWorkspaceExpected = sandboxAcceptsLiveIo(liveness);
   // Capability negotiation and capture resolution are independent requests. A
   // cold capability document can win that race by a few milliseconds; enabling
   // the leaf hooks in that window would make them interpret `capture: null` as a
@@ -691,7 +691,7 @@ export function useSandboxWorkspaceTabs(
                   ...(requestedFileRequestId !== null && requestedFileRequestId !== undefined
                     ? { requestedPathRequestId: requestedFileRequestId }
                     : {}),
-                  requestedPathReady: liveness === "warm" || liveness === "draining",
+                  requestedPathReady: sandboxAcceptsLiveIo(liveness),
                 }
               : {})}
             // Ordinary capture browsing does not warm a box. The first edit — or an

--- a/packages/react/src/hooks/use-machine-chip.ts
+++ b/packages/react/src/hooks/use-machine-chip.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import type { MachineState } from "@opengeni/sdk";
 import type { SessionCapabilitiesState } from "./use-session-capabilities";
+import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
 
 /** The one truthful machine indicator. Honest staleness beats
  *  fake liveness: a cold/asleep box reads "offline — as of <time>", never "live". */
@@ -53,7 +54,7 @@ export function formatAsOf(capturedAt: string, now: number): string {
  * it; the whole point is a deterministic, testable projection).
  *
  * Precedence:
- *   1. warm/draining lease → **live** (a warm box always wins).
+ *   1. warm lease → **live** (a holder-confirmed box always wins).
  *   2. actively warming (negotiating, wake-on-edit, or a reconnecting/enrolling
  *      machine) → **waking**.
  *   3. everything else (a cold/asleep box, a self-hosted machine that's offline,
@@ -64,8 +65,9 @@ export function deriveMachineChip(input: DeriveMachineChipInput): MachineChip {
   const asOf = input.capturedAt ?? null;
   const offlineLabel = asOf ? `Offline — as of ${formatAsOf(asOf, now)}` : "Offline";
 
-  // 1. A warm (or draining) lease is live regardless of anything else.
-  if (input.liveness === "warm" || input.liveness === "draining") {
+  // 1. Only holder-confirmed warm is live. Draining is teardown-owned and may
+  // already have lost its provider instance, so it uses the capture-backed label.
+  if (sandboxAcceptsLiveIo(input.liveness)) {
     return { state: "live", label: "Live", asOf: null };
   }
 

--- a/packages/react/src/hooks/use-sandbox-files.ts
+++ b/packages/react/src/hooks/use-sandbox-files.ts
@@ -12,6 +12,7 @@ import type {
 } from "@opengeni/sdk";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type ClientOverride, useOpenGeni } from "../provider";
+import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
 
 /** The git-status overlay a file row may carry (tints modified files in the tree). */
 export type FileTreeStatus = "added" | "modified" | "deleted" | "renamed" | "untracked";
@@ -487,7 +488,10 @@ export function useSandboxFiles(
   ].join("\u0000");
   const repoPaths = useMemo(() => repoPathsKey.split("\u0000"), [repoPathsKey]);
   const capture = options.capture ?? null;
-  const isLive = options.liveness === "warm" || options.liveness === "draining";
+  const isLive = sandboxAcceptsLiveIo(options.liveness);
+  // `liveness` predates this hook option. Preserve legacy embedders that omit it;
+  // an explicit lifecycle value, however, must pass the warm-only provider fence.
+  const acceptsEventReads = options.liveness === undefined || isLive;
   const identityKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${rootPath}\u0000${repoPathsKey}`;
 
   const [tree, setTree] = useState<FileTreeNode[]>([]);
@@ -1075,7 +1079,7 @@ export function useSandboxFiles(
 
   // Initial paint + reset on identity change. Source selection:
   //   • any box WITH a capture → paint instantly from the durable capture index;
-  //     a warm/draining box then reconciles live in place.
+  //     a holder-confirmed warm box then reconciles live in place.
   //   • if that live reconciliation fails, keep the capture visible and read-only.
   //   • cold box with NO capture → best-effort live list (status quo — never worse).
   // Key the seed on the capture's REVISION (a primitive), not the manifest object
@@ -1197,13 +1201,20 @@ export function useSandboxFiles(
 
   useEffect(() => {
     if (!enabled || !events) return;
-    // An inactive tab must not replay the entire historical event log when it is
-    // opened. Keep its cursor current without performing any reconciliation;
-    // only events that arrive while Files is visible should trigger live reads.
-    if (!active) {
+    // An inactive tab or holderless draining/cold lease must not replay the
+    // historical log into live provider reads. The capture already includes
+    // those events; a later warm transition performs one authoritative refresh.
+    if (!active || !acceptsEventReads) {
       for (const event of events) {
         if (event.sequence > lastSeqRef.current) lastSeqRef.current = event.sequence;
       }
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      pendingParentsRef.current = new Set();
+      pendingGitRef.current = false;
+      pendingAgentToolRef.current = false;
       return;
     }
     let sawNew = false;
@@ -1297,10 +1308,10 @@ export function useSandboxFiles(
         ]);
       })();
     }, delay);
-  }, [enabled, active, events, reconcilePath, refreshGitOverlay]);
+  }, [enabled, active, acceptsEventReads, events, reconcilePath, refreshGitOverlay]);
 
   useEffect(() => {
-    if (active) return;
+    if (active && acceptsEventReads) return;
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
@@ -1308,7 +1319,7 @@ export function useSandboxFiles(
     pendingParentsRef.current = new Set();
     pendingGitRef.current = false;
     pendingAgentToolRef.current = false;
-  }, [active]);
+  }, [active, acceptsEventReads]);
 
   useEffect(
     () => () => {

--- a/packages/react/src/hooks/use-sandbox-git.ts
+++ b/packages/react/src/hooks/use-sandbox-git.ts
@@ -6,6 +6,7 @@ import type {
 } from "@opengeni/sdk";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type ClientOverride, useOpenGeni } from "../provider";
+import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
 
 export type UseSandboxGitOptions = ClientOverride & {
   /** Live event log (usually `useSessionEvents().events`) — drives auto-refresh
@@ -206,7 +207,10 @@ export function useSandboxGit(
   // remains live-only; legacy captures simply lack branchDiff and fall back via
   // the workspace controller without inventing an empty branch comparison.
   const capture = comparison === "staged" ? null : (options.capture ?? null);
-  const isLive = options.liveness === "warm" || options.liveness === "draining";
+  const isLive = sandboxAcceptsLiveIo(options.liveness);
+  // `liveness` is optional for compatibility with direct hook consumers. Only
+  // an explicit lifecycle value is subject to the warm-only provider fence.
+  const acceptsEventReads = options.liveness === undefined || isLive;
   const identityKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${repoPathsKey}\u0000${workspaceWide}\u0000${comparison}`;
 
   const [diff, setDiff] = useState<SandboxGitFileDiff[]>([]);
@@ -466,7 +470,20 @@ export function useSandboxGit(
   // therefore emit no git.changed event. This is event-driven, never polling.
   const events = options.events;
   useEffect(() => {
-    if (!enabled || !active || !events) {
+    if (!enabled || !events) {
+      if (commandRefreshTimerRef.current) {
+        clearTimeout(commandRefreshTimerRef.current);
+        commandRefreshTimerRef.current = null;
+      }
+      return;
+    }
+    // Historical events describe the capture we already loaded. Inactive tabs
+    // and holderless draining/cold leases advance the cursor without issuing
+    // provider I/O; becoming warm performs one authoritative reconcile above.
+    if (!active || !acceptsEventReads) {
+      for (const event of events) {
+        if (event.sequence > lastChangeRef.current) lastChangeRef.current = event.sequence;
+      }
       if (commandRefreshTimerRef.current) {
         clearTimeout(commandRefreshTimerRef.current);
         commandRefreshTimerRef.current = null;
@@ -499,7 +516,7 @@ export function useSandboxGit(
         }, 1_000);
       }
     }
-  }, [enabled, active, events, refresh]);
+  }, [enabled, active, acceptsEventReads, events, refresh]);
 
   useEffect(
     () => () => {

--- a/packages/react/src/hooks/use-sandbox-terminal.ts
+++ b/packages/react/src/hooks/use-sandbox-terminal.ts
@@ -7,6 +7,7 @@ import type {
 import { OpenGeniApiError } from "@opengeni/sdk";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useOpenGeni, type ClientOverride } from "../provider";
+import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
 
 export type TerminalChunk = {
   /** Stable key (the source event id) so the xterm writer tracks a written-cursor. */
@@ -107,9 +108,9 @@ export function useSandboxTerminal(
   // projection is the single source of truth for what's written). The open is
   // gated on a WARM box: opening on a cold/warming lease races the box (the PTY
   // exec-session is created on a box that the next op may not resume), which is
-  // exactly the "session not found" terminal failure; we wait for warm/draining.
+  // exactly the "session not found" terminal failure; we wait for warm.
   const openInFlight = useRef(false);
-  const boxWarm = liveness === undefined || liveness === "warm" || liveness === "draining";
+  const boxWarm = liveness === undefined || sandboxAcceptsLiveIo(liveness);
   useEffect(() => {
     if (!interactive || !sessionId || ptyFilter || !boxWarm) {
       setOpenError(null);

--- a/packages/react/src/hooks/use-session-capabilities.ts
+++ b/packages/react/src/hooks/use-session-capabilities.ts
@@ -7,10 +7,12 @@ import {
 } from "@opengeni/sdk";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useOpenGeni, type ClientOverride } from "../provider";
+import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
 import { usePageLiveActivity } from "./internal";
 
-// "on-demand" is the boxless-benign resting state: the lease is cold and NOTHING
-// asked to warm a box (no viewer/consent action, no files-tab warm). Under lazy
+// "on-demand" is the boxless-benign resting state: the lease is not currently
+// holder-backed and NOTHING asked to warm a box (no viewer/consent action, no
+// files-tab warm). Under lazy
 // provisioning a chat-only turn never creates a box, so this is the correct calm
 // terminal state — NOT an error. It is distinct from "cold", which now means "a
 // warm-up is genuinely in flight" (a viewer attach was requested) and therefore
@@ -274,7 +276,7 @@ export function useSessionCapabilities(
           .then((caps) => {
             if (cancelled) return;
             settle(caps);
-            if (caps.liveness === "warm" || caps.liveness === "draining") {
+            if (sandboxAcceptsLiveIo(caps.liveness)) {
               setState("ready");
               return;
             }
@@ -419,16 +421,16 @@ export function useSessionCapabilities(
         }
 
         // Whether ANYTHING asked to warm a box this negotiation. Only then is a
-        // cold lease "warming in flight" — worth polling, and worth surfacing a
+        // non-warm lease "warming in flight" — worth polling, and worth surfacing a
         // stall as an error. With no warm-up requested a cold lease is the benign
         // boxless resting state (below), never an error.
         const warmUpRequested = wantDesktopAttach || wantTerminalAttach || wantFilesAttach;
-        if (caps.liveness === "warm" || caps.liveness === "draining" || localViewerId) {
+        if (sandboxAcceptsLiveIo(caps.liveness) || localViewerId) {
           setState("ready");
           startHeartbeat(caps);
         } else if (warmUpRequested) {
           // A warm-up is genuinely in flight (a viewer attach was requested) but the
-          // box isn't warm yet — poll until it warms, with the patience deadline so a
+          // box isn't holder-confirmed warm yet — poll until it is, with the deadline so a
           // real stall surfaces as an error.
           setState("cold");
           pollUntilWarm();

--- a/packages/react/src/hooks/use-workspace-edit.ts
+++ b/packages/react/src/hooks/use-workspace-edit.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useOpenGeni, type ClientOverride } from "../provider";
+import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
 
 /**
  * The wake-on-edit state machine. This hook owns the logic and the UI renders
@@ -73,7 +74,7 @@ export type UseWorkspaceEditResult = {
 };
 
 function isLive(liveness: string | undefined): boolean {
-  return liveness === "warm" || liveness === "draining";
+  return sandboxAcceptsLiveIo(liveness);
 }
 
 /**

--- a/packages/react/src/lib/sandbox-liveness.ts
+++ b/packages/react/src/lib/sandbox-liveness.ts
@@ -1,0 +1,11 @@
+/**
+ * A sandbox is available for new I/O only after a holder has observed `warm`.
+ *
+ * `draining` means the holder count is zero and teardown owns the provider
+ * instance. The provider may disappear before the durable lease reaches `cold`,
+ * so treating `draining` as live races capture/termination. Explicit user intent
+ * reacquires a holder; only its subsequent `warm` state re-enables live I/O.
+ */
+export function sandboxAcceptsLiveIo(liveness: string | null | undefined): boolean {
+  return liveness === "warm";
+}

--- a/packages/react/test/sandbox-hooks.test.tsx
+++ b/packages/react/test/sandbox-hooks.test.tsx
@@ -81,6 +81,32 @@ describe("useSessionCapabilities", () => {
     await hook.unmount();
   });
 
+  test("a draining lease without intent stays on-demand and never polls or attaches", async () => {
+    let capabilityCalls = 0;
+    let attachCalls = 0;
+    const client = fakeClient({
+      getStreamCapabilities: async () => {
+        capabilityCalls += 1;
+        return fakeCapabilities({ liveness: "draining" });
+      },
+      attachViewer: async () => {
+        attachCalls += 1;
+        return fakeAttachResponse();
+      },
+    });
+    const hook = await renderHook(
+      () => useSessionCapabilities(SESSION_ID, { ...ctx, client, warmingPollMs: 20 }),
+      undefined,
+    );
+    await flush(120);
+
+    expect(hook.result.current.state).toBe("on-demand");
+    expect(hook.result.current.capabilities?.liveness).toBe("draining");
+    expect(capabilityCalls).toBe(1);
+    expect(attachCalls).toBe(0);
+    await hook.unmount();
+  });
+
   test("a cold lease WITH a warm-up in flight polls toward warm (then ready)", async () => {
     let calls = 0;
     const client = fakeClient({
@@ -257,34 +283,38 @@ describe("useSessionCapabilities", () => {
     await hook.unmount();
   });
 
-  test("attachFiles warms even a COLD box — wake-on-edit cold-creates (Refinement 1)", async () => {
-    // Edit intent legitimately spins a cold box up (that IS the wake). The old
-    // "keep-warm-only-if-already-warm" guard is gone: attachFiles now attaches on a
-    // cold lease, minting a holder with desktop:false (no un-redacted consent gate).
-    let attachCalls = 0;
-    let attachOpts: { desktop?: boolean } | null = null;
-    const client = fakeClient({
-      getStreamCapabilities: async () => fakeColdCapabilities(),
-      attachViewer: async (_w: string, _s: string, opts: { desktop?: boolean }) => {
-        attachCalls += 1;
-        attachOpts = opts;
-        return fakeAttachResponse();
-      },
-      heartbeatViewer: async () => ({ alive: true }),
-      detachViewer: async () => {},
-    });
-    const hook = await renderHook(
-      () => useSessionCapabilities(SESSION_ID, { ...ctx, client, attachFiles: true }),
-      undefined,
-    );
-    await flush();
-    expect(attachCalls).toBe(1);
-    expect(attachOpts).not.toBeNull();
-    expect((attachOpts as unknown as { desktop?: boolean }).desktop).toBe(false);
-    // A holder was minted → the box is live, not resting on the benign on-demand state.
-    expect(hook.result.current.state).toBe("ready");
-    await hook.unmount();
-  });
+  test.each(["cold", "draining"] as const)(
+    "attachFiles explicitly reacquires a %s box for wake-on-edit",
+    async (liveness) => {
+      // Edit intent legitimately acquires a holder (that IS the wake), including
+      // across teardown. Passive review stays capture-backed; this explicit path
+      // asks the server to cold-create or safely re-arm before returning warm.
+      let attachCalls = 0;
+      let attachOpts: { desktop?: boolean } | null = null;
+      const client = fakeClient({
+        getStreamCapabilities: async () =>
+          liveness === "cold" ? fakeColdCapabilities() : fakeCapabilities({ liveness: "draining" }),
+        attachViewer: async (_w: string, _s: string, opts: { desktop?: boolean }) => {
+          attachCalls += 1;
+          attachOpts = opts;
+          return fakeAttachResponse();
+        },
+        heartbeatViewer: async () => ({ alive: true }),
+        detachViewer: async () => {},
+      });
+      const hook = await renderHook(
+        () => useSessionCapabilities(SESSION_ID, { ...ctx, client, attachFiles: true }),
+        undefined,
+      );
+      await flush();
+      expect(attachCalls).toBe(1);
+      expect(attachOpts).not.toBeNull();
+      expect((attachOpts as unknown as { desktop?: boolean }).desktop).toBe(false);
+      // A holder was minted → the box is live, not resting on the benign on-demand state.
+      expect(hook.result.current.state).toBe("ready");
+      await hook.unmount();
+    },
+  );
 
   test("no attach intent: a cold session NEVER calls attachViewer — browsing is free (Refinement 1)", async () => {
     // With no desktop/terminal/edit intent, a cold lease must warm nothing: reviewing
@@ -518,6 +548,36 @@ describe("useSandboxTerminal", () => {
     await flush();
     expect(opened).toBe(false);
     expect(hook.result.current.write).toBeNull();
+    await hook.unmount();
+  });
+
+  test("interactive mode does not open a PTY until a draining lease becomes warm", async () => {
+    let opens = 0;
+    const client = fakeClient({
+      terminalPtyOpen: async () => {
+        opens += 1;
+        return { ptyId: "opened-1", streamVia: "sse-events" as const, supportsInput: true };
+      },
+      terminalPtyClose: async () => {},
+    });
+    const hook = await renderHook(
+      (props: { liveness: string }) =>
+        useSandboxTerminal(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          events: [],
+          interactive: true,
+          liveness: props.liveness,
+        }),
+      { liveness: "draining" },
+    );
+    await flush();
+    expect(opens).toBe(0);
+
+    await hook.rerender({ liveness: "warm" });
+    await flush();
+    expect(opens).toBe(1);
+    expect(hook.result.current.activePtyId).toBe("opened-1");
     await hook.unmount();
   });
 

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -372,6 +372,79 @@ describe("workbench prewarm gating (Refinement 1)", () => {
     await hook.unmount();
   });
 
+  test("a draining capture replays historical events with zero live Files or Git reads", async () => {
+    const historicalEvents = [
+      fakeEvent(1, "git.changed", { revision: 3 }),
+      fakeEvent(2, "fs.changed", {
+        changes: [{ path: "app.py", kind: "modified", isDir: false, sizeBytes: 10 }],
+        source: "agent",
+        revision: 3,
+        leaseEpoch: 1,
+      }),
+      fakeEvent(3, "agent.toolCall.output", {}),
+      fakeEvent(4, "sandbox.command.output.delta", { stream: "stdout", chunk: "done\n" }),
+    ];
+
+    for (const initialTab of [WORKBENCH_TAB_CHANGES, WORKBENCH_TAB_FILES]) {
+      const reads = {
+        fsList: 0,
+        fsListBatch: 0,
+        gitStatus: 0,
+        gitDiff: 0,
+        gitReadBatch: 0,
+      };
+      const { client, spy } = coldClient({
+        getStreamCapabilities: async () => fakeCapabilities({ liveness: "draining" }),
+        fsList: async () => {
+          reads.fsList += 1;
+          throw new Error("draining review must not list the provider filesystem");
+        },
+        fsListBatch: async () => {
+          reads.fsListBatch += 1;
+          throw new Error("draining review must not batch-list the provider filesystem");
+        },
+        gitStatus: async () => {
+          reads.gitStatus += 1;
+          throw new Error("draining review must not query provider Git status");
+        },
+        gitDiff: async () => {
+          reads.gitDiff += 1;
+          throw new Error("draining review must not query a provider Git diff");
+        },
+        gitReadBatch: async () => {
+          reads.gitReadBatch += 1;
+          throw new Error("draining review must not batch-read provider Git");
+        },
+      });
+      const hook = await renderTabsHook(client, {
+        sessionId: SESSION_ID,
+        events: historicalEvents,
+        initialTab,
+      });
+
+      // Cross the command-delta debounce window too: neither immediate nor
+      // delayed historical invalidation may escape the capture boundary.
+      await flush(1_150);
+      expect(reads).toEqual({
+        fsList: 0,
+        fsListBatch: 0,
+        gitStatus: 0,
+        gitDiff: 0,
+        gitReadBatch: 0,
+      });
+      expect(spy.attachCalls).toBe(0);
+      const changes = hook.result.current.tabs.find((tab) => tab.id === WORKBENCH_TAB_CHANGES);
+      const files = hook.result.current.tabs.find((tab) => tab.id === WORKBENCH_TAB_FILES);
+      expect(
+        (changes!.content as ReactElement<{ git: { source: string | null } }>).props.git.source,
+      ).toBe("capture");
+      expect(
+        (files!.content as ReactElement<{ files: { source: string | null } }>).props.files.source,
+      ).toBe("capture");
+      await hook.unmount();
+    }
+  });
+
   test("a cold dock mount browsing capture-served surfaces warms NO box", async () => {
     const { client, spy } = coldClient();
     const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });

--- a/packages/react/test/workspace-capture-hooks.test.tsx
+++ b/packages/react/test/workspace-capture-hooks.test.tsx
@@ -1929,6 +1929,56 @@ describe("useWorkspaceEdit", () => {
     await hook.unmount();
   });
 
+  test("a buffered edit never flushes while teardown owns a draining lease", async () => {
+    const reads: string[] = [];
+    const writes: string[] = [];
+    const client = fakeClient({
+      fsRead: async (_workspaceId, _sessionId, request) => {
+        reads.push(request.path);
+        return {
+          path: request.path,
+          encoding: "utf8" as const,
+          content: "base\n",
+          sizeBytes: 5,
+          truncated: false,
+          isBinary: false,
+          revision: 0,
+        };
+      },
+      fsWrite: async (_workspaceId, _sessionId, request) => {
+        writes.push(request.path);
+        return { path: request.path, sizeBytes: request.content.length, revision: 1 };
+      },
+    });
+    const hook = await renderHook(
+      (props: { liveness: string }) =>
+        useWorkspaceEdit(SESSION_ID, {
+          ...ctx,
+          client,
+          path: "a.txt",
+          baseContent: "base\n",
+          liveness: props.liveness,
+        }),
+      { liveness: "cold" },
+    );
+    await flush();
+    await actRun(() => hook.result.current.edit("edited\n"));
+    await hook.rerender({ liveness: "draining" });
+    await flush();
+
+    expect(hook.result.current.state).toBe("buffering");
+    expect(hook.result.current.buffer).toBe("edited\n");
+    expect(reads).toEqual([]);
+    expect(writes).toEqual([]);
+
+    await hook.rerender({ liveness: "warm" });
+    await flush();
+    expect(hook.result.current.state).toBe("flushed");
+    expect(reads).toEqual(["a.txt"]);
+    expect(writes).toEqual(["a.txt"]);
+    await hook.unmount();
+  });
+
   test("conflict path: live diverged from base → conflict, NO write (C2)", async () => {
     const writes: unknown[] = [];
     const client = fakeClient({
@@ -2163,13 +2213,23 @@ describe("useWorkspaceEdit", () => {
 describe("deriveMachineChip", () => {
   const NOW = Date.parse("2026-07-08T12:05:00.000Z");
 
-  test("warm lease → live", () => {
+  test("only a holder-confirmed warm lease is live", () => {
     expect(deriveMachineChip({ liveness: "warm" })).toEqual({
       state: "live",
       label: "Live",
       asOf: null,
     });
-    expect(deriveMachineChip({ liveness: "draining" }).state).toBe("live");
+    expect(
+      deriveMachineChip({
+        liveness: "draining",
+        capturedAt: "2026-07-08T12:00:00.000Z",
+        now: NOW,
+      }),
+    ).toEqual({
+      state: "offline",
+      label: "Offline — as of 5m ago",
+      asOf: "2026-07-08T12:00:00.000Z",
+    });
   });
 
   test("negotiating or wanting-warm → waking", () => {

--- a/packages/runtime/src/sandbox/select.ts
+++ b/packages/runtime/src/sandbox/select.ts
@@ -20,7 +20,7 @@ export interface NegotiationContext {
   sessionId: string;
   backend: SandboxBackend;
   os: SandboxOs;
-  /** Current lease liveness; cold means nothing is provisioned yet. */
+  /** Current lease liveness; only warm proves a holder-backed live provider. */
   liveness: "cold" | "warming" | "warm" | "draining";
   /** The lease epoch echoed on viewer heartbeats (the split-brain fence). */
   leaseEpoch: number;
@@ -264,7 +264,7 @@ export function negotiateCapabilities(ctx: NegotiationContext): SessionCapabilit
     if (ptyCapable && ctx.terminalEnabled === false) {
       transport = "sse-events";
       reason = "disabled_by_policy";
-    } else if (ptyCapable && ctx.liveness === "cold" && !ctx.terminalStream) {
+    } else if (ptyCapable && ctx.liveness !== "warm" && !ctx.terminalStream) {
       transport = "sse-events";
       reason = "lease_cold";
     }
@@ -319,7 +319,7 @@ export function negotiateCapabilities(ctx: NegotiationContext): SessionCapabilit
       // reason rather than crashing the API.
       available = false;
       reason = "disabled_by_policy";
-    } else if (ctx.liveness === "cold" && !ctx.desktopStream) {
+    } else if (ctx.liveness !== "warm" && !ctx.desktopStream) {
       // A PRESENT minted pixel url (ctx.desktopStream) is ITSELF proof of liveness:
       // the box (Modal-warm OR selfhosted-online) actually served the noVNC port,
       // so a cold MODAL-GROUP lease liveness must NOT degrade it. lease_cold only

--- a/packages/runtime/test/sandbox-provider-registry.test.ts
+++ b/packages/runtime/test/sandbox-provider-registry.test.ts
@@ -460,6 +460,18 @@ describe("negotiateCapabilities — coherent doc, degrades as a value", () => {
     expect(caps.DesktopStream.reason).toBe("lease_cold");
   });
 
+  test.each(["warming", "draining"] as const)(
+    "%s lease without a minted stream remains non-live",
+    (liveness) => {
+      const caps = negotiateCapabilities({ ...base, backend: "modal", liveness });
+      expect(caps.DesktopStream.transport).toBeNull();
+      expect(caps.DesktopStream.reason).toBe("lease_cold");
+      expect(caps.Terminal.transport).toBe("sse-events");
+      expect(caps.Terminal.reason).toBe("lease_cold");
+      expect(caps.Terminal.url).toBeNull();
+    },
+  );
+
   // ── A successfully-minted relay/Modal stream url is ITSELF proof of liveness ──
   // A selfhosted-active session has NO warm Modal GROUP lease, so ctx.liveness is
   // "cold" — but the stream cells are minted against the selfhosted RELAY (the box


### PR DESCRIPTION
## Summary

- treat holderless teardown leases as non-live until explicit reacquisition reaches warm
- keep Files and Changes capture-backed while teardown owns the provider
- block stream minting, historical-event refreshes, PTY opens, and writes during teardown
- preserve explicit desktop, terminal, and edit wake-up paths

## Verification

- `bun run check`
- `bun run lint`
- `bun run format --check`
- `git diff --check`
- public repository hygiene guard