### PR TITLE
fix(sandbox): settle draining workspace reads

### DIFF
--- a/.changeset/quiet-sandboxes-settle.md
+++ b/.changeset/quiet-sandboxes-settle.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/observability": patch
+"@opengeni/react": patch
+---
+
+Keep known-cold sandbox views passive, fence delayed live-read invalidations across draining transitions, and expose bounded structural Channel-A failure diagnostics without leaking provider details.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -149,6 +149,7 @@ import {
   withChannelARead,
   type ChannelAContext,
   type ChannelAHandle,
+  type ChannelAOperation,
 } from "../sandbox/channel-a";
 import { negotiateCapabilities } from "@opengeni/runtime/sandbox";
 import type { Context, Hono, MiddlewareHandler } from "hono";
@@ -2579,12 +2580,9 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   // FS uses files:read for reads, files:write for mutations; Git is read-only
   // (rides files:read); Terminal exec + PTY ride terminal:attach.
 
-  type ChannelARouteCtx = {
-    accountId: string;
-    workspaceId: string;
-    session: Session;
-    subjectId: string;
+  type ChannelARouteCtx = ChannelAContext & {
     waitSignal: AbortSignal;
+    operation: ChannelAOperation;
   };
 
   // Shared preamble: grant BEFORE parse, ownership gate, session lookup. Returns
@@ -2592,6 +2590,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   async function channelAPreamble(
     c: Context,
     permission: "files:read" | "files:write" | "terminal:attach",
+    operation: ChannelAOperation,
   ): Promise<ChannelARouteCtx> {
     const workspaceId = c.req.param("workspaceId") ?? "";
     const grant = await requireAccessGrant(c, deps, workspaceId, permission);
@@ -2607,6 +2606,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       session,
       subjectId: grant.subjectId,
       waitSignal: c.req.raw.signal,
+      operation,
     };
   }
 
@@ -2626,14 +2626,14 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
 
   // ── FileSystem ──────────────────────────────────────────────────────────
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/fs/list", async (c) => {
-    const ctx = await channelAPreamble(c, "files:read");
+    const ctx = await channelAPreamble(c, "files:read", "fs.list");
     const req = await parseChannelABody(c, FsListRequest);
     const out = await withChannelARead(channelAServices, ctx, ({ service }) => service.fsList(req));
     return c.json(out);
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/fs/list-batch", async (c) => {
-    const ctx = await channelAPreamble(c, "files:read");
+    const ctx = await channelAPreamble(c, "files:read", "fs.list-batch");
     const req = await parseChannelABody(c, FsListBatchRequest);
     const out = await withChannelARead(channelAServices, ctx, async ({ service }) => ({
       results: await runConcurrentChannelAReads(
@@ -2644,35 +2644,35 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/fs/read", async (c) => {
-    const ctx = await channelAPreamble(c, "files:read");
+    const ctx = await channelAPreamble(c, "files:read", "fs.read");
     const req = await parseChannelABody(c, FsReadRequest);
     const out = await withChannelARead(channelAServices, ctx, ({ service }) => service.fsRead(req));
     return c.json(out);
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/fs/write", async (c) => {
-    const ctx = await channelAPreamble(c, "files:write");
+    const ctx = await channelAPreamble(c, "files:write", "fs.write");
     const req = await parseChannelABody(c, FsWriteRequest);
     const out = await withChannelA(channelAServices, ctx, ({ service }) => service.fsWrite(req));
     return c.json(out);
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/fs/delete", async (c) => {
-    const ctx = await channelAPreamble(c, "files:write");
+    const ctx = await channelAPreamble(c, "files:write", "fs.delete");
     const req = await parseChannelABody(c, FsDeleteRequest);
     const out = await withChannelA(channelAServices, ctx, ({ service }) => service.fsDelete(req));
     return c.json(out);
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/fs/move", async (c) => {
-    const ctx = await channelAPreamble(c, "files:write");
+    const ctx = await channelAPreamble(c, "files:write", "fs.move");
     const req = await parseChannelABody(c, FsMoveRequest);
     const out = await withChannelA(channelAServices, ctx, ({ service }) => service.fsMove(req));
     return c.json(out);
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/fs/mkdir", async (c) => {
-    const ctx = await channelAPreamble(c, "files:write");
+    const ctx = await channelAPreamble(c, "files:write", "fs.mkdir");
     const req = await parseChannelABody(c, FsMkdirRequest);
     const out = await withChannelA(channelAServices, ctx, ({ service }) => service.fsMkdir(req));
     return c.json(out);
@@ -2680,7 +2680,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
 
   // ── Git (read-only) ─────────────────────────────────────────────────────
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/git/status", async (c) => {
-    const ctx = await channelAPreamble(c, "files:read");
+    const ctx = await channelAPreamble(c, "files:read", "git.status");
     const req = await parseChannelABody(c, GitStatusRequest);
     const out = await withChannelARead(channelAServices, ctx, ({ service }) =>
       service.gitStatus(req),
@@ -2689,7 +2689,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/git/diff", async (c) => {
-    const ctx = await channelAPreamble(c, "files:read");
+    const ctx = await channelAPreamble(c, "files:read", "git.diff");
     const req = await parseChannelABody(c, GitDiffRequest);
     const out = await withChannelARead(channelAServices, ctx, ({ service }) =>
       service.gitDiff(req),
@@ -2698,7 +2698,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/git/read-batch", async (c) => {
-    const ctx = await channelAPreamble(c, "files:read");
+    const ctx = await channelAPreamble(c, "files:read", "git.read-batch");
     const req = await parseChannelABody(c, GitReadBatchRequest);
     const out = await withChannelARead(channelAServices, ctx, async ({ service }) => {
       type StatusResult = Awaited<ReturnType<typeof service.gitStatus>>;
@@ -2749,14 +2749,14 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/git/log", async (c) => {
-    const ctx = await channelAPreamble(c, "files:read");
+    const ctx = await channelAPreamble(c, "files:read", "git.log");
     const req = await parseChannelABody(c, GitLogRequest);
     const out = await withChannelARead(channelAServices, ctx, ({ service }) => service.gitLog(req));
     return c.json(out);
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/git/show", async (c) => {
-    const ctx = await channelAPreamble(c, "files:read");
+    const ctx = await channelAPreamble(c, "files:read", "git.show");
     const req = await parseChannelABody(c, GitShowRequest);
     const out = await withChannelARead(channelAServices, ctx, ({ service }) =>
       service.gitShow(req),
@@ -2823,7 +2823,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
 
   // ── Terminal: synchronous exec ────────────────────────────────────────────
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/terminal/exec", async (c) => {
-    const ctx = await channelAPreamble(c, "terminal:attach");
+    const ctx = await channelAPreamble(c, "terminal:attach", "terminal.exec");
     const req = await parseChannelABody(c, TerminalExecRequest);
     const out = await withChannelA(channelAServices, ctx, ({ service }) =>
       service.terminalExec(req),
@@ -2833,7 +2833,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
 
   // ── Terminal: interactive PTY control (output rides A1) ───────────────────
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/terminal/pty", async (c) => {
-    const ctx = await channelAPreamble(c, "terminal:attach");
+    const ctx = await channelAPreamble(c, "terminal:attach", "terminal.pty.open");
     const req = await parseChannelABody(c, PtyOpenRequest);
     if (ctx.session.sandboxBackend === "selfhosted" || ctx.session.activeSandboxId !== null) {
       throw new HTTPException(409, {
@@ -2942,7 +2942,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/terminal/pty/write", async (c) => {
-    const ctx = await channelAPreamble(c, "terminal:attach");
+    const ctx = await channelAPreamble(c, "terminal:attach", "terminal.pty.write");
     const req = await parseChannelABody(c, PtyWriteRequest);
     const pty = await getOpenPtySession(db, {
       workspaceId: ctx.workspaceId,
@@ -3006,7 +3006,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/terminal/pty/resize", async (c) => {
-    const ctx = await channelAPreamble(c, "terminal:attach");
+    const ctx = await channelAPreamble(c, "terminal:attach", "terminal.pty.resize");
     const req = await parseChannelABody(c, PtyResizeRequest);
     const pty = await getOpenPtySession(db, {
       workspaceId: ctx.workspaceId,
@@ -3038,7 +3038,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   });
 
   app.post("/v1/workspaces/:workspaceId/sessions/:sessionId/terminal/pty/close", async (c) => {
-    const ctx = await channelAPreamble(c, "terminal:attach");
+    const ctx = await channelAPreamble(c, "terminal:attach", "terminal.pty.close");
     const req = await parseChannelABody(c, PtyCloseRequest);
     const pty = await getOpenPtySession(db, {
       workspaceId: ctx.workspaceId,

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -81,6 +81,25 @@ export type ChannelAServices = {
   observability?: Observability | undefined;
 };
 
+export type ChannelAOperation =
+  | "fs.list"
+  | "fs.list-batch"
+  | "fs.read"
+  | "fs.write"
+  | "fs.delete"
+  | "fs.move"
+  | "fs.mkdir"
+  | "git.status"
+  | "git.diff"
+  | "git.read-batch"
+  | "git.log"
+  | "git.show"
+  | "terminal.exec"
+  | "terminal.pty.open"
+  | "terminal.pty.write"
+  | "terminal.pty.resize"
+  | "terminal.pty.close";
+
 export type ChannelAContext = {
   accountId: string;
   workspaceId: string;
@@ -89,6 +108,27 @@ export type ChannelAContext = {
   subjectId: string;
   /** Cancel lifecycle waiting when the originating HTTP request disconnects. */
   waitSignal?: AbortSignal | undefined;
+  /** Bounded route identity for metrics and safe operator diagnostics. */
+  operation?: ChannelAOperation | undefined;
+};
+
+export type ChannelAOperationFailureReason =
+  | "request_cancelled"
+  | "provider_read_busy"
+  | "provider_unavailable"
+  | "lifecycle_conflict"
+  | "request_rejected"
+  | "unexpected";
+
+export type ChannelAOperationFailureDiagnostic = {
+  reason: ChannelAOperationFailureReason;
+  status: number;
+  errorCode:
+    | "sandbox_channel_a_cancelled"
+    | "sandbox_channel_a_provider_busy"
+    | "sandbox_channel_a_provider_unavailable"
+    | "sandbox_channel_a_lifecycle_conflict"
+    | "sandbox_channel_a_operation_failed";
 };
 
 // The live op surface handed to a route's callback: the service + the live lease
@@ -417,6 +457,8 @@ async function withChannelAOperation<T>(
   const sandboxGroupId = session.sandboxGroupId;
   const requestId = crypto.randomUUID();
   const holderId = `direct:${requestId}`;
+  const operationStartedAt = performance.now();
+  const operation = ctx.operation ?? (readOnly ? "read" : "mutation");
   const leaseTtlMs = settings.sandboxLeaseTtlMs;
 
   // The STABLE run-environment used by both a cloud home and a machine home.
@@ -483,6 +525,7 @@ async function withChannelAOperation<T>(
   if (session.sandboxBackend === "selfhosted") {
     let established: EstablishedSandboxSession | undefined;
     try {
+      ctx.waitSignal?.throwIfAborted();
       const pointer = await readActiveSandbox(db, workspaceId, session.id);
       if (!pointer?.activeSandboxId) {
         throw new HTTPException(409, {
@@ -547,7 +590,16 @@ async function withChannelAOperation<T>(
       );
       return await runEstablished(routed, null);
     } catch (error) {
-      throw mapChannelAError(error);
+      observeChannelAOperationFailure(services, {
+        workspaceId,
+        sandboxGroupId,
+        backend: session.sandboxBackend,
+        operation,
+        durationMs: performance.now() - operationStartedAt,
+        error,
+        waitSignal: ctx.waitSignal,
+      });
+      throw mapChannelAError(error, ctx.waitSignal);
     } finally {
       await dropEstablishedHandle(established);
     }
@@ -564,36 +616,61 @@ async function withChannelAOperation<T>(
     });
   };
 
-  // Acquire exact request authority; the cold->warming CAS spawns the box when cold.
-  const acquired = await acquireLease(db, {
-    accountId,
-    workspaceId,
-    sandboxGroupId,
-    kind: "direct",
-    holderId,
-    subjectId: session.id,
-    backend: session.sandboxBackend,
-    os: session.sandboxOs,
-    leaseTtlMs,
-    warmingLeaseTtlMs: settings.sandboxWarmingTimeoutMs,
-    captureWaitMs: sandboxLifecycleTransitionWaitMs(settings),
-    ...(ctx.waitSignal ? { waitSignal: ctx.waitSignal } : {}),
-  });
+  // Acquire exact request authority; the cold->warming CAS spawns the box when
+  // cold. This wait is request-abort aware and must pass through the same typed
+  // cancellation/diagnostic seam as provider execution below.
+  let acquired: Awaited<ReturnType<typeof acquireLease>>;
+  let acquisitionMayHaveCommitted = false;
+  try {
+    ctx.waitSignal?.throwIfAborted();
+    acquisitionMayHaveCommitted = true;
+    acquired = await acquireLease(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId,
+      kind: "direct",
+      holderId,
+      subjectId: session.id,
+      backend: session.sandboxBackend,
+      os: session.sandboxOs,
+      leaseTtlMs,
+      warmingLeaseTtlMs: settings.sandboxWarmingTimeoutMs,
+      captureWaitMs: sandboxLifecycleTransitionWaitMs(settings),
+      ...(ctx.waitSignal ? { waitSignal: ctx.waitSignal } : {}),
+    });
+    // Close the commit/abort race before any provider handle is established.
+    // The catch below drops an exact holder committed just before disconnect.
+    ctx.waitSignal?.throwIfAborted();
 
-  if (acquired.role === "blocked") {
-    await release();
-    throw new HTTPException(409, {
-      message: `sandbox recovery ${acquired.lease.recovery.restore.status} at epoch ${acquired.lease.leaseEpoch}`,
+    if (acquired.role === "blocked") {
+      throw new HTTPException(409, {
+        message: `sandbox recovery ${acquired.lease.recovery.restore.status} at epoch ${acquired.lease.leaseEpoch}`,
+      });
+    }
+    if (acquired.role === "fenced") {
+      throw new HTTPException(409, {
+        message:
+          acquired.reason === "superseded"
+            ? `sandbox lease superseded (epoch ${acquired.lease.leaseEpoch}); retry`
+            : `sandbox lifecycle transition in progress (${acquired.reason}, epoch ${acquired.lease.leaseEpoch}, backend ${acquired.lease.backend}, instance ${acquired.lease.instanceId ?? "none"}); retry`,
+      });
+    }
+  } catch (error) {
+    // Release is idempotent. If acquisition committed before the request was
+    // cancelled, this removes that exact direct holder; a transient DB failure
+    // must not overwrite the original structural error (holder TTL is the final
+    // cleanup fence).
+    if (acquisitionMayHaveCommitted) await release().catch(() => undefined);
+    observeChannelAOperationFailure(services, {
+      workspaceId,
+      sandboxGroupId,
+      backend: session.sandboxBackend,
+      operation,
+      durationMs: performance.now() - operationStartedAt,
+      error,
+      waitSignal: ctx.waitSignal,
     });
-  }
-  if (acquired.role === "fenced") {
-    await release();
-    throw new HTTPException(409, {
-      message:
-        acquired.reason === "superseded"
-          ? `sandbox lease superseded (epoch ${acquired.lease.leaseEpoch}); retry`
-          : `sandbox lifecycle transition in progress (${acquired.reason}, epoch ${acquired.lease.leaseEpoch}, backend ${acquired.lease.backend}, instance ${acquired.lease.instanceId ?? "none"}); retry`,
-    });
+    throw mapChannelAError(error, ctx.waitSignal);
   }
 
   let established: EstablishedSandboxSession | undefined;
@@ -827,7 +904,16 @@ async function withChannelAOperation<T>(
     if (establishedCacheKey && shouldEvictChannelAHandleAfterError(error, establishedCacheKind)) {
       evictEstablishedHandle(establishedCacheKey, establishedCacheKind);
     }
-    throw mapChannelAError(error);
+    observeChannelAOperationFailure(services, {
+      workspaceId,
+      sandboxGroupId,
+      backend: session.sandboxBackend,
+      operation,
+      durationMs: performance.now() - operationStartedAt,
+      error,
+      waitSignal: ctx.waitSignal,
+    });
+    throw mapChannelAError(error, ctx.waitSignal);
   } finally {
     await release();
     await dropEstablishedHandle(established);
@@ -836,8 +922,13 @@ async function withChannelAOperation<T>(
 
 /** Map the service's typed errors to HTTP status (the §5.3 matrix). Re-throws an
  *  already-HTTPException unchanged. */
-export function mapChannelAError(error: unknown): unknown {
+export function mapChannelAError(error: unknown, waitSignal?: AbortSignal): unknown {
   if (error instanceof HTTPException) return error;
+  if (isChannelARequestCancellation(error, waitSignal))
+    return new HTTPException(499 as never, {
+      message: "request cancelled",
+      cause: error,
+    });
   if (
     error instanceof SandboxResumeIdentityMismatchError ||
     error instanceof SandboxResumeIdentityUnavailableError
@@ -856,6 +947,133 @@ export function mapChannelAError(error: unknown): unknown {
   if (error instanceof ChannelAUnsupportedError)
     return new HTTPException(409, { message: error.message });
   return error;
+}
+
+export function isChannelARequestCancellation(error: unknown, waitSignal?: AbortSignal): boolean {
+  if (waitSignal?.aborted !== true) return false;
+  const isSignalReason = waitSignal.reason !== undefined && error === waitSignal.reason;
+  const isAbortError =
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError");
+  return isSignalReason || isAbortError;
+}
+
+/** Structural classification only: exact provider exception text, codes, URLs,
+ * and identifiers never cross the telemetry boundary. */
+export function channelAOperationFailureDiagnostic(
+  error: unknown,
+  waitSignal?: AbortSignal,
+): ChannelAOperationFailureDiagnostic {
+  if (isChannelARequestCancellation(error, waitSignal)) {
+    return {
+      reason: "request_cancelled",
+      status: 499,
+      errorCode: "sandbox_channel_a_cancelled",
+    };
+  }
+  if (error instanceof SandboxProviderReadLockUnavailableError) {
+    return {
+      reason: "provider_read_busy",
+      status: 503,
+      errorCode: "sandbox_channel_a_provider_busy",
+    };
+  }
+  if (error instanceof ChannelAUnavailableError) {
+    return {
+      reason: "provider_unavailable",
+      status: 503,
+      errorCode: "sandbox_channel_a_provider_unavailable",
+    };
+  }
+  if (
+    error instanceof SandboxResumeIdentityMismatchError ||
+    error instanceof SandboxResumeIdentityUnavailableError ||
+    (error instanceof HTTPException && error.status === 409)
+  ) {
+    return {
+      reason: "lifecycle_conflict",
+      status: 409,
+      errorCode: "sandbox_channel_a_lifecycle_conflict",
+    };
+  }
+  if (
+    error instanceof ChannelAValidationError ||
+    error instanceof ChannelANotFoundError ||
+    error instanceof ChannelAConflictError ||
+    error instanceof ChannelAUnsupportedError
+  ) {
+    const mapped = mapChannelAError(error, waitSignal);
+    return {
+      reason: "request_rejected",
+      status: mapped instanceof HTTPException ? mapped.status : 500,
+      errorCode: "sandbox_channel_a_operation_failed",
+    };
+  }
+  if (error instanceof HTTPException) {
+    return {
+      reason: error.status >= 500 ? "unexpected" : "request_rejected",
+      status: error.status,
+      errorCode: "sandbox_channel_a_operation_failed",
+    };
+  }
+  return {
+    reason: "unexpected",
+    status: 500,
+    errorCode: "sandbox_channel_a_operation_failed",
+  };
+}
+
+function observeChannelAOperationFailure(
+  services: ChannelAServices,
+  input: {
+    workspaceId: string;
+    sandboxGroupId: string;
+    backend: string;
+    operation: string;
+    durationMs: number;
+    error: unknown;
+    waitSignal?: AbortSignal | undefined;
+  },
+): void {
+  if (!services.observability) return;
+  const diagnostic = channelAOperationFailureDiagnostic(input.error, input.waitSignal);
+  const attributes = {
+    sandboxLeaseKey: sandboxLeaseTelemetryKey(input.workspaceId, input.sandboxGroupId),
+    backend: input.backend,
+    op: input.operation,
+    outcome: "failed",
+    reason: diagnostic.reason,
+    status: diagnostic.status,
+    durationMs: Math.max(0, Math.round(input.durationMs)),
+    errorClass: "SandboxChannelAOperationError",
+    errorCode: diagnostic.errorCode,
+    origin: "api",
+  } as const;
+  try {
+    services.observability.incrementCounter({
+      name: "opengeni_channel_a_operation_failures_total",
+      help: "Channel-A failures by bounded operation and structural reason.",
+      labels: {
+        backend: input.backend,
+        op: input.operation,
+        reason: diagnostic.reason,
+        status: String(diagnostic.status),
+      },
+    });
+  } catch {
+    // Metrics can never alter request or lease settlement.
+  }
+  try {
+    if (diagnostic.reason === "request_cancelled") {
+      services.observability.info("Channel-A request cancelled", attributes);
+    } else if (diagnostic.reason === "request_rejected") {
+      services.observability.debug("Channel-A request rejected", attributes);
+    } else {
+      services.observability.warn("Channel-A operation failed", attributes);
+    }
+  } catch {
+    // Logs can never alter request or lease settlement.
+  }
 }
 
 // Drop a transiently-established, NON-OWNED handle WITHOUT terminating the box.

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -3,10 +3,13 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { HTTPException } from "hono/http-exception";
+import { SandboxProviderReadLockUnavailableError } from "@opengeni/db";
 import { ChannelAUnavailableError, ChannelAValidationError } from "@opengeni/runtime/sandbox";
 import {
+  channelAOperationFailureDiagnostic,
   isChannelAHandleCacheEntryFresh,
   isChannelAProcessHandleCacheEntryFresh,
+  isChannelARequestCancellation,
   mapChannelAError,
   runChannelAReadWithFreshHandleRetry,
   runConcurrentChannelAReads,
@@ -33,75 +36,93 @@ const channelASeam = readFileSync(resolve(here, "..", "src", "sandbox", "channel
 type RouteSpec = {
   path: string;
   permission: "files:read" | "files:write" | "terminal:attach";
+  operation: string;
 };
 const CHANNEL_A_ROUTES: RouteSpec[] = [
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/list",
     permission: "files:read",
+    operation: "fs.list",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/list-batch",
     permission: "files:read",
+    operation: "fs.list-batch",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/read",
     permission: "files:read",
+    operation: "fs.read",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/write",
     permission: "files:write",
+    operation: "fs.write",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/delete",
     permission: "files:write",
+    operation: "fs.delete",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/move",
     permission: "files:write",
+    operation: "fs.move",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/fs/mkdir",
     permission: "files:write",
+    operation: "fs.mkdir",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/status",
     permission: "files:read",
+    operation: "git.status",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/diff",
     permission: "files:read",
+    operation: "git.diff",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/read-batch",
     permission: "files:read",
+    operation: "git.read-batch",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/log",
     permission: "files:read",
+    operation: "git.log",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/git/show",
     permission: "files:read",
+    operation: "git.show",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/terminal/exec",
     permission: "terminal:attach",
+    operation: "terminal.exec",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/terminal/pty",
     permission: "terminal:attach",
+    operation: "terminal.pty.open",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/terminal/pty/write",
     permission: "terminal:attach",
+    operation: "terminal.pty.write",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/terminal/pty/resize",
     permission: "terminal:attach",
+    operation: "terminal.pty.resize",
   },
   {
     path: "/v1/workspaces/:workspaceId/sessions/:sessionId/terminal/pty/close",
     permission: "terminal:attach",
+    operation: "terminal.pty.close",
   },
 ];
 
@@ -129,7 +150,7 @@ function handlerBody(source: string, method: string, path: string): string {
 }
 
 describe("P4.4 Channel-A route discipline", () => {
-  test("all 13 routes are registered", () => {
+  test("all 17 routes are registered", () => {
     for (const route of CHANNEL_A_ROUTES) {
       expect(
         routeRegex("post", route.path).test(sessionsRoute),
@@ -153,6 +174,7 @@ describe("P4.4 Channel-A route discipline", () => {
       }
       // the correct permission is passed to the preamble.
       expect(body).toContain(`"${route.permission}"`);
+      expect(body).toContain(`"${route.operation}"`);
     });
   }
 
@@ -202,6 +224,49 @@ describe("P4.4 Channel-A route discipline", () => {
     expect((mapped as HTTPException).message).toBe(
       "Workspace files are temporarily unavailable. Retry.",
     );
+  });
+
+  test("request aborts map to a distinct 499 cancellation diagnostic", () => {
+    const controller = new AbortController();
+    const abort = new DOMException("client disconnected", "AbortError");
+    controller.abort(abort);
+    expect(isChannelARequestCancellation(abort, controller.signal)).toBe(true);
+    expect(channelAOperationFailureDiagnostic(abort, controller.signal)).toEqual({
+      reason: "request_cancelled",
+      status: 499,
+      errorCode: "sandbox_channel_a_cancelled",
+    });
+    const mapped = mapChannelAError(abort, controller.signal);
+    expect(mapped).toBeInstanceOf(HTTPException);
+    expect((mapped as HTTPException).status).toBe(499);
+    expect((mapped as HTTPException).message).toBe("request cancelled");
+  });
+
+  test("an unrelated provider AbortError is not misreported as a client cancellation", () => {
+    const abort = new DOMException("provider aborted", "AbortError");
+    const liveRequest = new AbortController();
+    expect(isChannelARequestCancellation(abort, liveRequest.signal)).toBe(false);
+    expect(channelAOperationFailureDiagnostic(abort, liveRequest.signal)).toEqual({
+      reason: "unexpected",
+      status: 500,
+      errorCode: "sandbox_channel_a_operation_failed",
+    });
+    expect(mapChannelAError(abort, liveRequest.signal)).toBe(abort);
+  });
+
+  test("provider contention and provider unavailability remain distinguishable", () => {
+    expect(
+      channelAOperationFailureDiagnostic(new SandboxProviderReadLockUnavailableError()),
+    ).toEqual({
+      reason: "provider_read_busy",
+      status: 503,
+      errorCode: "sandbox_channel_a_provider_busy",
+    });
+    expect(channelAOperationFailureDiagnostic(new ChannelAUnavailableError("temporary"))).toEqual({
+      reason: "provider_unavailable",
+      status: 503,
+      errorCode: "sandbox_channel_a_provider_unavailable",
+    });
   });
 
   test("concurrent reads settle before one bounded transient retry", async () => {

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -143,6 +143,37 @@ const PUBLIC_TELEMETRY_OPAQUE_ATTRIBUTE_PATTERNS = new Map<string, RegExp>([
   ["sandboxLeaseKey", /^slk_[0-9a-f]{32}$/],
 ]);
 
+const PUBLIC_CHANNEL_A_OPERATIONS = new Set([
+  "fs.list",
+  "fs.list-batch",
+  "fs.read",
+  "fs.write",
+  "fs.delete",
+  "fs.move",
+  "fs.mkdir",
+  "git.status",
+  "git.diff",
+  "git.read-batch",
+  "git.log",
+  "git.show",
+  "terminal.exec",
+  "terminal.pty.open",
+  "terminal.pty.write",
+  "terminal.pty.resize",
+  "terminal.pty.close",
+  "read",
+  "mutation",
+]);
+
+const PUBLIC_CHANNEL_A_FAILURE_REASONS = new Set([
+  "request_cancelled",
+  "provider_read_busy",
+  "provider_unavailable",
+  "lifecycle_conflict",
+  "request_rejected",
+  "unexpected",
+]);
+
 /**
  * Public diagnostic values are protocol constants, never values inferred from
  * an exception's name, constructor, code, message, or enumerable properties.
@@ -169,6 +200,7 @@ const PUBLIC_TELEMETRY_ERROR_CLASSES = new Set([
   "OAuthOperationError",
   "RunCredentialRenewalOperationError",
   "RunStateCompatibilityError",
+  "SandboxChannelAOperationError",
   "SnapshotOperationError",
   "StartupDependencyError",
   "TelemetryExportError",
@@ -216,6 +248,11 @@ const PUBLIC_TELEMETRY_ERROR_CODES = new Set([
   "otlp_export_failed",
   "payment_required",
   "provider_verification_failed",
+  "sandbox_channel_a_cancelled",
+  "sandbox_channel_a_lifecycle_conflict",
+  "sandbox_channel_a_operation_failed",
+  "sandbox_channel_a_provider_busy",
+  "sandbox_channel_a_provider_unavailable",
   "screenshot_capture_failed",
   "session_event_live_publish_failed",
   "session_workflow_wake_failed",
@@ -729,7 +766,10 @@ function cleanAttributes(attributes: Attributes): Record<string, string | number
 
 function projectPublicTelemetryAttributes(attributes: Attributes): Attributes {
   if ("errorClass" in attributes || "errorCode" in attributes) {
-    return projectPublicDiagnosticAttributes(attributes);
+    return {
+      ...projectPublicChannelADiagnosticAttributes(attributes),
+      ...projectPublicDiagnosticAttributes(attributes),
+    };
   }
   return Object.fromEntries(
     Object.entries(attributes).filter(([key, value]) => {
@@ -739,6 +779,31 @@ function projectPublicTelemetryAttributes(attributes: Attributes): Attributes {
       return typeof value === "string" && pattern?.test(value) === true;
     }),
   );
+}
+
+function projectPublicChannelADiagnosticAttributes(attributes: Attributes): Attributes {
+  if (attributes.errorClass !== "SandboxChannelAOperationError") return {};
+  const backend = attributes.backend;
+  const op = attributes.op;
+  const outcome = attributes.outcome;
+  const reason = attributes.reason;
+  const durationMs = attributes.durationMs;
+  const sandboxLeaseKey = attributes.sandboxLeaseKey;
+  return {
+    ...(typeof backend === "string" && SANDBOX_OPERATION_BACKENDS.has(backend) ? { backend } : {}),
+    ...(typeof op === "string" && PUBLIC_CHANNEL_A_OPERATIONS.has(op) ? { op } : {}),
+    ...(outcome === "failed" ? { outcome } : {}),
+    ...(typeof reason === "string" && PUBLIC_CHANNEL_A_FAILURE_REASONS.has(reason)
+      ? { reason }
+      : {}),
+    ...(typeof durationMs === "number" && Number.isFinite(durationMs) && durationMs >= 0
+      ? { durationMs }
+      : {}),
+    ...(typeof sandboxLeaseKey === "string" &&
+    PUBLIC_TELEMETRY_OPAQUE_ATTRIBUTE_PATTERNS.get("sandboxLeaseKey")?.test(sandboxLeaseKey)
+      ? { sandboxLeaseKey }
+      : {}),
+  };
 }
 
 function projectPublicDiagnosticAttributes(attributes: Attributes): Attributes {

--- a/packages/observability/test/observability.test.ts
+++ b/packages/observability/test/observability.test.ts
@@ -363,6 +363,81 @@ describe("observability", () => {
     expect(JSON.parse(observed[1]!)).not.toHaveProperty("sandboxLeaseKey");
   });
 
+  test("public diagnostics retain safe operation fields and validated lease correlation", () => {
+    const sentinel = "DIAGNOSTIC_PRIVATE_SENTINEL_6a44f8";
+    const observed: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => observed.push(String(message));
+    try {
+      const obs = createObservability(settings, { component: "api", now: () => 1 });
+      obs.warn("Channel-A operation failed", {
+        errorClass: "SandboxChannelAOperationError",
+        errorCode: "sandbox_channel_a_provider_unavailable",
+        origin: "api",
+        status: 503,
+        backend: "modal",
+        op: "git.read-batch",
+        reason: "provider_unavailable",
+        outcome: "failed",
+        durationMs: 812,
+        sandboxLeaseKey: "slk_0123456789abcdef0123456789abcdef",
+        workspaceId: sentinel,
+        error: sentinel,
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]).not.toContain(sentinel);
+    expect(JSON.parse(observed[0]!)).toMatchObject({
+      message: "Channel-A operation failed",
+      errorClass: "SandboxChannelAOperationError",
+      errorCode: "sandbox_channel_a_provider_unavailable",
+      origin: "api",
+      status: 503,
+      backend: "modal",
+      op: "git.read-batch",
+      reason: "provider_unavailable",
+      outcome: "failed",
+      durationMs: 812,
+      sandboxLeaseKey: "slk_0123456789abcdef0123456789abcdef",
+    });
+    expect(JSON.parse(observed[0]!)).not.toHaveProperty("workspaceId");
+    expect(JSON.parse(observed[0]!)).not.toHaveProperty("error");
+  });
+
+  test("Channel-A diagnostics reject unreviewed operational values", () => {
+    const sentinel = "DIAGNOSTIC_VALUE_SENTINEL_58c2";
+    const observed: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => observed.push(String(message));
+    try {
+      const obs = createObservability(settings, { component: "api", now: () => 1 });
+      obs.warn("Channel-A operation failed", {
+        errorClass: "SandboxChannelAOperationError",
+        errorCode: "sandbox_channel_a_operation_failed",
+        backend: sentinel,
+        op: sentinel,
+        outcome: sentinel,
+        reason: sentinel,
+        durationMs: -1,
+        sandboxLeaseKey: `slk_${sentinel}`,
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const parsed = JSON.parse(observed[0]!);
+    expect(observed[0]).not.toContain(sentinel);
+    expect(parsed).not.toHaveProperty("backend");
+    expect(parsed).not.toHaveProperty("op");
+    expect(parsed).not.toHaveProperty("outcome");
+    expect(parsed).not.toHaveProperty("reason");
+    expect(parsed).not.toHaveProperty("durationMs");
+    expect(parsed).not.toHaveProperty("sandboxLeaseKey");
+  });
+
   test("public diagnostics reject syntactically valid secret-shaped classes and codes", () => {
     const sentinel = "SECRET_SENTINEL_123";
     const SecretSentinelError = class SECRET_SENTINEL_123 extends Error {};

--- a/packages/react/src/hooks/use-sandbox-files.ts
+++ b/packages/react/src/hooks/use-sandbox-files.ts
@@ -7,6 +7,7 @@ import type {
   GitFileStatusCode,
   GitStatusResponse,
   OpenGeniRequestOptions,
+  SessionCapabilities,
   SessionEvent,
   WorkspaceCaptureManifest,
 } from "@opengeni/sdk";
@@ -88,12 +89,12 @@ export type UseSandboxFilesOptions = ClientOverride & {
   active?: boolean | undefined;
   /** Repository roots advertised by capabilities, relative to the workspace. */
   repoPaths?: readonly string[] | undefined;
-  /** The lease liveness ("cold" | "warm" | "draining"). The structured FileSystem
+  /** The lease liveness. The structured FileSystem
    *  capability is advertised even on a COLD box, so the mount-time list can race
    *  the box: it lists before the box is warm, gets an empty/errored result, and
    *  (with no `fs.changed` event) never re-lists. Passing liveness re-lists when
    *  the box first becomes warm, so the tree populates as soon as the box is up. */
-  liveness?: string | undefined;
+  liveness?: SessionCapabilities["liveness"] | undefined;
   /** The latest turn-end workspace capture (from `useWorkspaceCapture`). The tree
    *  paints immediately from this durable index, then a warm box reconciles live
    *  in place. If that live read fails, the capture remains a truthful read-only
@@ -492,6 +493,9 @@ export function useSandboxFiles(
   // `liveness` predates this hook option. Preserve legacy embedders that omit it;
   // an explicit lifecycle value, however, must pass the warm-only provider fence.
   const acceptsEventReads = options.liveness === undefined || isLive;
+  const acceptsEventReadsRef = useRef(acceptsEventReads);
+  acceptsEventReadsRef.current = acceptsEventReads;
+  const livenessKnown = options.liveness !== undefined;
   const identityKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${rootPath}\u0000${repoPathsKey}`;
 
   const [tree, setTree] = useState<FileTreeNode[]>([]);
@@ -516,6 +520,7 @@ export function useSandboxFiles(
   const refreshGenerationRef = useRef(0);
   const refreshAbortRef = useRef<AbortController | null>(null);
   const identityAbortRef = useRef(new AbortController());
+  const eventReadAbortRef = useRef(new AbortController());
   const identityGenerationRef = useRef(0);
   const lastSeqRef = useRef(0);
   const pendingParentsRef = useRef<Set<string>>(new Set());
@@ -850,20 +855,18 @@ export function useSandboxFiles(
   // of a parent that isn't loaded (collapsed/unmounted) is a no-op — there's
   // nothing visible to update, and it re-lists fresh when the user expands it.
   const reconcilePath = useCallback(
-    async (path: string) => {
+    async (path: string, requestSignal?: AbortSignal) => {
       if (!sessionId) return;
       const identityGeneration = identityGenerationRef.current;
       const identitySignal = identityAbortRef.current.signal;
+      const signal = requestSignal
+        ? AbortSignal.any([identitySignal, requestSignal])
+        : identitySignal;
       // Skip parents that aren't currently loaded/expanded in the tree (nothing
       // visible to update; they re-list fresh on the next expand).
       if (!parentIsLoaded(treeRef.current, path)) return;
       try {
-        const listed = await client.fsList(
-          workspaceId,
-          sessionId,
-          { path, depth: 1 },
-          { signal: identitySignal },
-        );
+        const listed = await client.fsList(workspaceId, sessionId, { path, depth: 1 }, { signal });
         if (identityGenerationRef.current !== identityGeneration) return;
         const children = (listed.root.children ?? []).map((node) => fsNodeToTree(node));
         if (path === "") setTree((prev) => applyStatus(mergeRootChildren(prev, children)));
@@ -1081,7 +1084,8 @@ export function useSandboxFiles(
   //   • any box WITH a capture → paint instantly from the durable capture index;
   //     a holder-confirmed warm box then reconciles live in place.
   //   • if that live reconciliation fails, keep the capture visible and read-only.
-  //   • cold box with NO capture → best-effort live list (status quo — never worse).
+  //   • legacy callers that omit liveness and have no capture retain their live
+  //     fallback; an explicitly cold/draining lease never wakes from a passive mount.
   // Key the seed on the capture's REVISION (a primitive), not the manifest object
   // — a consumer passing a fresh object each render (or a new revision) must not
   // spin the effect. The latest manifest is read from a ref at run time.
@@ -1096,6 +1100,8 @@ export function useSandboxFiles(
     refreshAbortRef.current?.abort();
     refreshAbortRef.current = null;
     refreshGenerationRef.current += 1;
+    eventReadAbortRef.current.abort();
+    eventReadAbortRef.current = new AbortController();
     const identityChanged = previousIdentityRef.current !== identityKey;
     previousIdentityRef.current = identityKey;
     if (identityChanged || !enabled) {
@@ -1139,53 +1145,69 @@ export function useSandboxFiles(
       }
       return;
     }
-    if (isLive || !currentCapture) {
+    if (isLive || (!livenessKnown && !currentCapture)) {
       void refresh();
     }
     return () => {
       refreshAbortRef.current?.abort();
       refreshAbortRef.current = null;
       refreshGenerationRef.current += 1;
+      eventReadAbortRef.current.abort();
     };
-  }, [enabled, active, isLive, captureRevision, identityKey, refresh, seedFromCapture]);
+  }, [
+    enabled,
+    active,
+    isLive,
+    livenessKnown,
+    captureRevision,
+    identityKey,
+    refresh,
+    seedFromCapture,
+  ]);
 
   // Re-pull JUST the git-status overlay and re-tint the existing tree in place —
   // no fs re-list, no collapse. This is all a `git.changed` (commit/stage/checkout)
   // needs: the tree SHAPE is unchanged, only the tints move.
-  const refreshGitOverlay = useCallback(async () => {
-    if (!sessionId) return;
-    const identityGeneration = identityGenerationRef.current;
-    const identitySignal = identityAbortRef.current.signal;
-    setGitLoading(true);
-    try {
-      const batch = await client.gitReadBatch(
-        workspaceId,
-        sessionId,
-        { requests: repoPaths.map((root) => ({ status: { path: root } })) },
-        { signal: identitySignal },
-      );
-      const statuses = batch.results.map((result, index) => ({
-        root: repoPaths[index] ?? "",
-        status: result.status,
-      }));
-      if (identityGenerationRef.current !== identityGeneration) return;
-      const overlay = new Map<string, FileTreeStatus>();
-      for (const { root, status } of statuses) {
-        for (const file of status.files) {
-          const code = file.worktree ?? file.index;
-          const mapped = code ? GIT_STATUS_TO_TREE[code] : undefined;
-          if (mapped) overlay.set(qualifyStatusPath(root, file.path), mapped);
+  const refreshGitOverlay = useCallback(
+    async (requestSignal?: AbortSignal) => {
+      if (!sessionId) return;
+      const identityGeneration = identityGenerationRef.current;
+      const identitySignal = identityAbortRef.current.signal;
+      const signal = requestSignal
+        ? AbortSignal.any([identitySignal, requestSignal])
+        : identitySignal;
+      setGitLoading(true);
+      try {
+        const batch = await client.gitReadBatch(
+          workspaceId,
+          sessionId,
+          { requests: repoPaths.map((root) => ({ status: { path: root } })) },
+          { signal },
+        );
+        const statuses = batch.results.map((result, index) => ({
+          root: repoPaths[index] ?? "",
+          status: result.status,
+        }));
+        if (identityGenerationRef.current !== identityGeneration) return;
+        const overlay = new Map<string, FileTreeStatus>();
+        for (const { root, status } of statuses) {
+          for (const file of status.files) {
+            const code = file.worktree ?? file.index;
+            const mapped = code ? GIT_STATUS_TO_TREE[code] : undefined;
+            if (mapped) overlay.set(qualifyStatusPath(root, file.path), mapped);
+          }
         }
+        statusRef.current = overlay;
+        setGitSummary(summarizeStatuses(statuses));
+        setTree((prev) => applyStatus(prev));
+      } catch {
+        /* a non-repo box has no overlay — leave the tree untinted */
+      } finally {
+        if (identityGenerationRef.current === identityGeneration) setGitLoading(false);
       }
-      statusRef.current = overlay;
-      setGitSummary(summarizeStatuses(statuses));
-      setTree((prev) => applyStatus(prev));
-    } catch {
-      /* a non-repo box has no overlay — leave the tree untinted */
-    } finally {
-      if (identityGenerationRef.current === identityGeneration) setGitLoading(false);
-    }
-  }, [client, workspaceId, sessionId, repoPaths, applyStatus]);
+    },
+    [client, workspaceId, sessionId, repoPaths, applyStatus],
+  );
 
   // Auto-reconcile on fs/git change notifications — TARGETED, never a root
   // collapse-reload, and de-duped against our OWN mutations.
@@ -1288,6 +1310,12 @@ export function useSandboxFiles(
     debounceRef.current = setTimeout(() => {
       debounceRef.current = null;
       if (identityGenerationRef.current !== identityGeneration) return;
+      if (!acceptsEventReadsRef.current) {
+        pendingParentsRef.current = new Set();
+        pendingGitRef.current = false;
+        pendingAgentToolRef.current = false;
+        return;
+      }
       if (sawCommandDelta) {
         lastCommandRefreshAtRef.current = Date.now();
         setContentRevision((revision) => revision + 1);
@@ -1300,11 +1328,12 @@ export function useSandboxFiles(
       pendingAgentToolRef.current = false;
       // Reconcile the changed directories and Git overlay concurrently. Both are
       // independent remote reads; applyStatus makes their completion order safe.
+      const eventReadSignal = eventReadAbortRef.current.signal;
       void (async () => {
         const paths = wantAgentTool ? loadedDirectoryPaths(treeRef.current) : [...parents];
         await Promise.all([
-          wantGit ? refreshGitOverlay() : Promise.resolve(),
-          Promise.all(paths.map((path) => reconcilePath(path))),
+          wantGit ? refreshGitOverlay(eventReadSignal) : Promise.resolve(),
+          Promise.all(paths.map((path) => reconcilePath(path, eventReadSignal))),
         ]);
       })();
     }, delay);
@@ -1325,6 +1354,7 @@ export function useSandboxFiles(
     () => () => {
       refreshAbortRef.current?.abort();
       identityAbortRef.current.abort();
+      eventReadAbortRef.current.abort();
       identityGenerationRef.current += 1;
       if (debounceRef.current) clearTimeout(debounceRef.current);
     },

--- a/packages/react/src/hooks/use-sandbox-git.ts
+++ b/packages/react/src/hooks/use-sandbox-git.ts
@@ -1,5 +1,6 @@
 import type {
   GitFileDiff,
+  SessionCapabilities,
   SessionEvent,
   WorkspaceCaptureManifest,
   WorkspaceCaptureRepo,
@@ -29,7 +30,7 @@ export type UseSandboxGitOptions = ClientOverride & {
   active?: boolean | undefined;
   /** Lease liveness ("warm" | "draining" | "cold"). When NOT warm, the diff is
    *  served from the capture (cold/offline) instead of a live `gitDiff` RPC. */
-  liveness?: string | undefined;
+  liveness?: SessionCapabilities["liveness"] | undefined;
   /** The latest turn-end capture (from `useWorkspaceCapture`). Seeds the diff
    *  immediately; a warm box reconciles live and leaves this durable review
    *  surface in place if the live request is temporarily unavailable. */
@@ -211,6 +212,9 @@ export function useSandboxGit(
   // `liveness` is optional for compatibility with direct hook consumers. Only
   // an explicit lifecycle value is subject to the warm-only provider fence.
   const acceptsEventReads = options.liveness === undefined || isLive;
+  const acceptsEventReadsRef = useRef(acceptsEventReads);
+  acceptsEventReadsRef.current = acceptsEventReads;
+  const livenessKnown = options.liveness !== undefined;
   const identityKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${repoPathsKey}\u0000${workspaceWide}\u0000${comparison}`;
 
   const [diff, setDiff] = useState<SandboxGitFileDiff[]>([]);
@@ -455,7 +459,7 @@ export function useSandboxGit(
       if (!active) setLoading(false);
       return;
     }
-    if (isLive || !currentCapture) {
+    if (isLive || (!livenessKnown && !currentCapture)) {
       void refresh();
     }
     return () => {
@@ -463,7 +467,16 @@ export function useSandboxGit(
       refreshAbortRef.current = null;
       refreshGenerationRef.current += 1;
     };
-  }, [enabled, active, isLive, captureRevision, identityKey, refresh, seedFromCapture]);
+  }, [
+    enabled,
+    active,
+    isLive,
+    livenessKnown,
+    captureRevision,
+    identityKey,
+    refresh,
+    seedFromCapture,
+  ]);
 
   // git.changed → re-fetch the LIVE diff. Agent tool completion is also an
   // invalidation point because shell/apply-patch writes can bypass Channel-A and
@@ -508,11 +521,11 @@ export function useSandboxGit(
       if (immediate) {
         if (commandRefreshTimerRef.current) clearTimeout(commandRefreshTimerRef.current);
         commandRefreshTimerRef.current = null;
-        void refresh();
+        if (acceptsEventReadsRef.current) void refresh();
       } else if (commandDelta && !commandRefreshTimerRef.current) {
         commandRefreshTimerRef.current = setTimeout(() => {
           commandRefreshTimerRef.current = null;
-          void refresh();
+          if (acceptsEventReadsRef.current) void refresh();
         }, 1_000);
       }
     }

--- a/packages/react/test/workspace-capture-hooks.test.tsx
+++ b/packages/react/test/workspace-capture-hooks.test.tsx
@@ -13,6 +13,7 @@ import type {
   FsTreeNode,
   GetWorkspaceCaptureResponse,
   GitFileDiff,
+  SessionCapabilities,
   SessionEvent,
   WorkspaceCaptureManifest,
   WorkspaceCaptureRepo,
@@ -1073,7 +1074,7 @@ describe("useSandboxFiles — capture source", () => {
       },
     });
     const hook = await renderHook(
-      (props: { liveness: string }) =>
+      (props: { liveness: SessionCapabilities["liveness"] }) =>
         useSandboxFiles(SESSION_ID, {
           ...ctx,
           client,
@@ -1114,7 +1115,7 @@ describe("useSandboxFiles — capture source", () => {
     await hook.unmount();
   });
 
-  test("no capture + cold falls back to the live list (status quo, never worse)", async () => {
+  test("known-cold + no capture never issues a passive live list", async () => {
     let fsListCalls = 0;
     const client = fakeClient({
       gitStatus: async () => ({
@@ -1141,8 +1142,56 @@ describe("useSandboxFiles — capture source", () => {
       undefined,
     );
     await flush();
-    expect(fsListCalls).toBeGreaterThan(0);
-    expect(hook.result.current.source).toBe("live");
+    expect(fsListCalls).toBe(0);
+    expect(hook.result.current.source).toBeNull();
+    await hook.unmount();
+  });
+
+  test("warm event reconciliation is cancelled before a draining transition can rearm", async () => {
+    let fsListCalls = 0;
+    let gitBatchCalls = 0;
+    const client = fakeClient({
+      fsList: async () => {
+        fsListCalls += 1;
+        return {
+          root: treeDir("", "", [treeFile("app.py", "app.py", 1)]),
+          revision: 1,
+          truncated: false,
+        };
+      },
+      gitReadBatch: async () => {
+        gitBatchCalls += 1;
+        return { results: [] };
+      },
+    });
+    const hook = await renderHook(
+      (props: { liveness: SessionCapabilities["liveness"]; events: SessionEvent[] }) =>
+        useSandboxFiles(SESSION_ID, {
+          ...ctx,
+          client,
+          capture: fakeManifest(),
+          liveness: props.liveness,
+          events: props.events,
+        }),
+      { liveness: "warm", events: [] },
+    );
+    await flush();
+    fsListCalls = 0;
+    gitBatchCalls = 0;
+
+    await hook.rerender({
+      liveness: "warm",
+      events: [fakeEvent(1, "agent.toolCall.output")],
+    });
+    await hook.rerender({
+      liveness: "draining",
+      events: [fakeEvent(1, "agent.toolCall.output")],
+    });
+    await flush(250);
+
+    expect(fsListCalls).toBe(0);
+    expect(gitBatchCalls).toBe(0);
+    expect(hook.result.current.source).toBe("capture");
     await hook.unmount();
   });
 
@@ -1436,6 +1485,84 @@ describe("useSandboxGit — capture source", () => {
     await hook.unmount();
   });
 
+  test("known-cold + no capture never issues passive Git reads", async () => {
+    let gitStatusCalls = 0;
+    let gitDiffCalls = 0;
+    const client = fakeClient({
+      gitStatus: async () => {
+        gitStatusCalls += 1;
+        throw new Error("known-cold Git must remain passive");
+      },
+      gitDiff: async () => {
+        gitDiffCalls += 1;
+        throw new Error("known-cold Git must remain passive");
+      },
+    });
+    const hook = await renderHook(
+      () => useSandboxGit(SESSION_ID, { ...ctx, client, liveness: "cold" }),
+      undefined,
+    );
+    await flush();
+
+    expect(gitStatusCalls).toBe(0);
+    expect(gitDiffCalls).toBe(0);
+    expect(hook.result.current.source).toBeNull();
+    await hook.unmount();
+  });
+
+  test("a queued warm command refresh cannot run after the lease starts draining", async () => {
+    let gitStatusCalls = 0;
+    let gitDiffCalls = 0;
+    const client = fakeClient({
+      gitStatus: async () => {
+        gitStatusCalls += 1;
+        return {
+          isRepo: true,
+          head: "main",
+          detached: false,
+          upstream: null,
+          ahead: 0,
+          behind: 0,
+          files: [],
+          revision: 1,
+        };
+      },
+      gitDiff: async () => {
+        gitDiffCalls += 1;
+        return { files: [], revision: 1 };
+      },
+    });
+    const hook = await renderHook(
+      (props: { liveness: SessionCapabilities["liveness"]; events: SessionEvent[] }) =>
+        useSandboxGit(SESSION_ID, {
+          ...ctx,
+          client,
+          capture: fakeManifest(),
+          liveness: props.liveness,
+          events: props.events,
+        }),
+      { liveness: "warm", events: [] },
+    );
+    await flush();
+    gitStatusCalls = 0;
+    gitDiffCalls = 0;
+
+    await hook.rerender({
+      liveness: "warm",
+      events: [fakeEvent(1, "sandbox.command.output.delta")],
+    });
+    await hook.rerender({
+      liveness: "draining",
+      events: [fakeEvent(1, "sandbox.command.output.delta")],
+    });
+    await flush(1_100);
+
+    expect(gitStatusCalls).toBe(0);
+    expect(gitDiffCalls).toBe(0);
+    expect(hook.result.current.source).toBe("capture");
+    await hook.unmount();
+  });
+
   test("cold Branch view uses the captured base-branch diff without waking the sandbox", async () => {
     let gitStatusCalls = 0;
     let gitDiffCalls = 0;
@@ -1561,7 +1688,7 @@ describe("useSandboxGit — capture source", () => {
       }),
     });
     const hook = await renderHook(
-      (props: { liveness: string }) =>
+      (props: { liveness: SessionCapabilities["liveness"] }) =>
         useSandboxGit(SESSION_ID, {
           ...ctx,
           client,
@@ -1615,7 +1742,7 @@ describe("useSandboxGit — capture source", () => {
       }),
     });
     const hook = await renderHook(
-      (props: { liveness: string }) =>
+      (props: { liveness: SessionCapabilities["liveness"] }) =>
         useSandboxGit(SESSION_ID, {
           ...ctx,
           client,


### PR DESCRIPTION
## Summary
- keep explicit cold/draining workbench views capture-backed and prevent passive provider reacquisition
- cancel queued/in-flight event reads across lifecycle transitions
- make Channel-A lifecycle waits request-abort-aware with safe bounded diagnostics

## Validation
- bun run test:unit: 6768 pass, 29 skip, 0 fail
- bun run format:check
- bun run lint
- bun run typecheck
- bun run build
- git diff --check