### PR TITLE
fix(api): recover prolonged Modal read rollover

### DIFF
--- a/.changeset/retry-modal-read-rollover.md
+++ b/.changeset/retry-modal-read-rollover.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/api-router": patch
+---
+
+Recover side-effect-free Modal Channel-A reads through one additional cancel-aware fresh-handle rebuild when a provider command-router rollover outlives the first replacement handle.

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -349,20 +349,39 @@ export async function runConcurrentChannelAReads<T>(
   return values;
 }
 
-/** Retry a side-effect-free Channel-A read once, but only after the caller has
- * discarded and freshly re-established its provider handle. Provider commands
- * are not replayed for validation/conflict/unknown errors, and mutation routes
- * never call this helper. */
+type ChannelAReadRecoveryOptions = {
+  /** Modal may expose one more stale command-router route after the first
+   * successful handle rebuild. Keep this closed and statically bounded. */
+  maxFreshHandleRetries?: 1 | 2;
+  /** Never start another provider attempt after the originating request ends. */
+  waitSignal?: AbortSignal | undefined;
+};
+
+/** Retry a side-effect-free Channel-A read only after the caller has discarded
+ * and freshly re-established its provider handle. The ordinary provider-neutral
+ * contract allows one retry; Modal opts into one additional rebuild because a
+ * command-router rollover can outlive the first replacement handle. Provider
+ * commands are never replayed for validation/conflict/unknown errors, mutation
+ * routes never call this helper, and request cancellation stops recovery before
+ * another provider command begins. */
 export async function runChannelAReadWithFreshHandleRetry<T>(
   run: () => Promise<T>,
-  refreshHandle: () => Promise<void>,
+  refreshHandle: (attempt: 1 | 2) => Promise<void>,
+  options: ChannelAReadRecoveryOptions = {},
 ): Promise<T> {
-  try {
-    return await run();
-  } catch (error) {
-    if (!(error instanceof ChannelAUnavailableError)) throw error;
-    await refreshHandle();
-    return await run();
+  const maxFreshHandleRetries = options.maxFreshHandleRetries ?? 1;
+  for (let retries = 0; ; retries += 1) {
+    options.waitSignal?.throwIfAborted();
+    try {
+      return await run();
+    } catch (error) {
+      if (!(error instanceof ChannelAUnavailableError) || retries >= maxFreshHandleRetries) {
+        throw error;
+      }
+      options.waitSignal?.throwIfAborted();
+      const attempt = retries === 0 ? 1 : 2;
+      await refreshHandle(attempt);
+    }
   }
 }
 
@@ -832,69 +851,80 @@ async function withChannelAOperation<T>(
     // A failed attempt leaves the advisory-lock transaction before refresh;
     // the retry acquires a new transaction/lock against the same fenced lease.
     return readOnly
-      ? await runChannelAReadWithFreshHandleRetry(runProviderOperation, async () => {
-          const refreshStartedAt = performance.now();
-          const observeRefresh = (outcome: "ok" | "failed"): void => {
-            if (!services.observability) return;
-            const attributes = {
-              sandboxLeaseKey: sandboxLeaseTelemetryKey(workspaceId, sandboxGroupId),
-              backend: session.sandboxBackend,
-              reason: "provider_handle_unavailable",
-              outcome,
-              durationMs: Math.max(0, Math.round(performance.now() - refreshStartedAt)),
+      ? await runChannelAReadWithFreshHandleRetry(
+          runProviderOperation,
+          async (attempt) => {
+            const refreshStartedAt = performance.now();
+            const observeRefresh = (outcome: "ok" | "failed"): void => {
+              if (!services.observability) return;
+              const attributes = {
+                sandboxLeaseKey: sandboxLeaseTelemetryKey(workspaceId, sandboxGroupId),
+                backend: session.sandboxBackend,
+                reason: "provider_handle_unavailable",
+                outcome,
+                attempt,
+                durationMs: Math.max(0, Math.round(performance.now() - refreshStartedAt)),
+              };
+              try {
+                services.observability.incrementCounter({
+                  name: "opengeni_channel_a_handle_refresh_total",
+                  help: "Channel-A provider handles rebuilt after a typed temporary-unavailable read.",
+                  labels: { backend: session.sandboxBackend, outcome },
+                });
+              } catch {
+                // Metrics can never alter lease or provider authority.
+              }
+              try {
+                if (outcome === "ok") {
+                  services.observability.info(
+                    "Channel-A provider handle refresh completed",
+                    attributes,
+                  );
+                } else {
+                  services.observability.warn(
+                    "Channel-A provider handle refresh failed",
+                    attributes,
+                  );
+                }
+              } catch {
+                // Logs can never alter lease or provider authority.
+              }
             };
             try {
-              services.observability.incrementCounter({
-                name: "opengeni_channel_a_handle_refresh_total",
-                help: "Channel-A provider handles rebuilt after a typed temporary-unavailable read.",
-                labels: { backend: session.sandboxBackend, outcome },
-              });
-            } catch {
-              // Metrics can never alter lease or provider authority.
-            }
-            try {
-              if (outcome === "ok") {
-                services.observability.info(
-                  "Channel-A provider handle refresh completed",
-                  attributes,
-                );
-              } else {
-                services.observability.warn("Channel-A provider handle refresh failed", attributes);
+              if (establishedCacheKey) {
+                evictEstablishedHandle(establishedCacheKey, establishedCacheKind);
               }
-            } catch {
-              // Logs can never alter lease or provider authority.
+              await dropEstablishedHandle(established);
+              // This request still owns its direct holder, so the exact live identity
+              // should be stable. Revalidate it before rebuilding the provider handle.
+              const live = await readLease(db, workspaceId, sandboxGroupId);
+              if (
+                !live ||
+                live.liveness !== "warm" ||
+                live.leaseEpoch !== leaseSnapshot.leaseEpoch ||
+                live.instanceId !== leaseSnapshot.instanceId
+              ) {
+                throw new HTTPException(409, {
+                  message: `sandbox lease changed while refreshing its provider handle; retry`,
+                });
+              }
+              const refreshed = await establishAttachedLiveHandle(live, "none");
+              established = refreshed.established;
+              establishedCacheKey = refreshed.cacheKey;
+              establishedCacheKind = "read";
+              leaseSnapshot = live;
+              rememberEstablishedHandle(refreshed.cacheKey, refreshed.established, "read");
+              observeRefresh("ok");
+            } catch (error) {
+              observeRefresh("failed");
+              throw error;
             }
-          };
-          try {
-            if (establishedCacheKey) {
-              evictEstablishedHandle(establishedCacheKey, establishedCacheKind);
-            }
-            await dropEstablishedHandle(established);
-            // This request still owns its direct holder, so the exact live identity
-            // should be stable. Revalidate it before rebuilding the provider handle.
-            const live = await readLease(db, workspaceId, sandboxGroupId);
-            if (
-              !live ||
-              live.liveness !== "warm" ||
-              live.leaseEpoch !== leaseSnapshot.leaseEpoch ||
-              live.instanceId !== leaseSnapshot.instanceId
-            ) {
-              throw new HTTPException(409, {
-                message: `sandbox lease changed while refreshing its provider handle; retry`,
-              });
-            }
-            const refreshed = await establishAttachedLiveHandle(live, "none");
-            established = refreshed.established;
-            establishedCacheKey = refreshed.cacheKey;
-            establishedCacheKind = "read";
-            leaseSnapshot = live;
-            rememberEstablishedHandle(refreshed.cacheKey, refreshed.established, "read");
-            observeRefresh("ok");
-          } catch (error) {
-            observeRefresh("failed");
-            throw error;
-          }
-        })
+          },
+          {
+            maxFreshHandleRetries: session.sandboxBackend === "modal" ? 2 : 1,
+            ...(ctx.waitSignal ? { waitSignal: ctx.waitSignal } : {}),
+          },
+        )
       : await runProviderOperation();
   } catch (error) {
     // A read wrapper carries no yielded process state and is safe to discard.

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -4,7 +4,11 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { HTTPException } from "hono/http-exception";
 import { SandboxProviderReadLockUnavailableError } from "@opengeni/db";
-import { ChannelAUnavailableError, ChannelAValidationError } from "@opengeni/runtime/sandbox";
+import {
+  ChannelAConflictError,
+  ChannelAUnavailableError,
+  ChannelAValidationError,
+} from "@opengeni/runtime/sandbox";
 import {
   channelAOperationFailureDiagnostic,
   isChannelAHandleCacheEntryFresh,
@@ -345,25 +349,26 @@ describe("P4.4 Channel-A route discipline", () => {
     expect(channelASeam).toContain("lastUsedAtMonotonicMs");
   });
 
-  test("side-effect-free reads rebuild before one typed unavailable retry", async () => {
+  test("Modal reads rebuild across a second rollover unavailable result", async () => {
     const order: string[] = [];
     let calls = 0;
     const value = await runChannelAReadWithFreshHandleRetry(
       async () => {
         calls += 1;
         order.push(`run:${calls}`);
-        if (calls === 1) throw new ChannelAUnavailableError("stale provider channel");
+        if (calls <= 2) throw new ChannelAUnavailableError("provider rollover still settling");
         return "fresh";
       },
-      async () => {
-        order.push("refresh");
+      async (attempt) => {
+        order.push(`refresh:${attempt}`);
       },
+      { maxFreshHandleRetries: 2 },
     );
     expect(value).toBe("fresh");
-    expect(order).toEqual(["run:1", "refresh", "run:2"]);
+    expect(order).toEqual(["run:1", "refresh:1", "run:2", "refresh:2", "run:3"]);
   });
 
-  test("fresh-handle recovery neither retries twice nor replays non-transient errors", async () => {
+  test("provider-neutral recovery defaults to one retry and never replays non-transient errors", async () => {
     let unavailableCalls = 0;
     await expect(
       runChannelAReadWithFreshHandleRetry(
@@ -392,6 +397,88 @@ describe("P4.4 Channel-A route discipline", () => {
     ).rejects.toBe(validation);
     expect(validationCalls).toBe(1);
     expect(refreshCalls).toBe(0);
+
+    let mixedCalls = 0;
+    let mixedRefreshes = 0;
+    const conflict = new ChannelAConflictError("lease changed");
+    await expect(
+      runChannelAReadWithFreshHandleRetry(
+        async () => {
+          mixedCalls += 1;
+          if (mixedCalls === 1) {
+            throw new ChannelAUnavailableError("provider rollover started");
+          }
+          throw conflict;
+        },
+        async () => {
+          mixedRefreshes += 1;
+        },
+        { maxFreshHandleRetries: 2 },
+      ),
+    ).rejects.toBe(conflict);
+    expect(mixedCalls).toBe(2);
+    expect(mixedRefreshes).toBe(1);
+  });
+
+  test("Modal recovery stops after exactly two fresh handles", async () => {
+    const refreshAttempts: number[] = [];
+    let calls = 0;
+    await expect(
+      runChannelAReadWithFreshHandleRetry(
+        async () => {
+          calls += 1;
+          throw new ChannelAUnavailableError("provider remains unavailable");
+        },
+        async (attempt) => {
+          refreshAttempts.push(attempt);
+        },
+        { maxFreshHandleRetries: 2 },
+      ),
+    ).rejects.toBeInstanceOf(ChannelAUnavailableError);
+    expect(calls).toBe(3);
+    expect(refreshAttempts).toEqual([1, 2]);
+  });
+
+  test("request cancellation prevents another handle refresh or provider command", async () => {
+    const controller = new AbortController();
+    const cancelled = new DOMException("request ended", "AbortError");
+    let runs = 0;
+    let refreshes = 0;
+    await expect(
+      runChannelAReadWithFreshHandleRetry(
+        async () => {
+          runs += 1;
+          controller.abort(cancelled);
+          throw new ChannelAUnavailableError("provider unavailable during disconnect");
+        },
+        async () => {
+          refreshes += 1;
+        },
+        { maxFreshHandleRetries: 2, waitSignal: controller.signal },
+      ),
+    ).rejects.toBe(cancelled);
+    expect(runs).toBe(1);
+    expect(refreshes).toBe(0);
+
+    const duringRefresh = new AbortController();
+    const cancelledDuringRefresh = new DOMException("request ended during refresh", "AbortError");
+    runs = 0;
+    refreshes = 0;
+    await expect(
+      runChannelAReadWithFreshHandleRetry(
+        async () => {
+          runs += 1;
+          throw new ChannelAUnavailableError("provider unavailable");
+        },
+        async () => {
+          refreshes += 1;
+          duringRefresh.abort(cancelledDuringRefresh);
+        },
+        { maxFreshHandleRetries: 2, waitSignal: duringRefresh.signal },
+      ),
+    ).rejects.toBe(cancelledDuringRefresh);
+    expect(runs).toBe(1);
+    expect(refreshes).toBe(1);
   });
 
   test("transport failures evict disposable reads but preserve process-capable wrappers", () => {


### PR DESCRIPTION
Summary:
- allow one additional freshly re-established handle only for side-effect-free Modal Channel-A reads after a typed provider-unavailable result
- retain the one-retry provider-neutral behavior for Linux/Docker and leave all mutation/PTY paths unchanged
- stop before any further refresh or provider call once the originating HTTP request is cancelled
- revalidate exact warm lease epoch and instance before every refresh; record a bounded refresh attempt diagnostic

Live defect receipt:
Production acceptance for source fa715bbcbbc550e149889821adbd92182fbbe32a showed a successful first handle rebuild at 2026-08-08T20:08:33.735Z, followed by HTTP 503 for that Git read at 2026-08-08T20:08:37.194Z. The first replacement handle was therefore insufficient through the Modal router rollover.

Verification:
- full suite: 6770 passed, 29 gated skips, 0 failed; 6799 tests across 640 files
- full production build: pass
- typecheck: all 23 projects clean
- lint: zero warnings/errors
- full format check and git diff check: pass

Supersedes #1217, which was based before the cancellation/diagnostic changes in #1219.

No-Claim: deterministic tests prove bounded read-only recovery and cancellation. Live Modal acceptance remains required from the exact merged candidate before release completion.