### PR TITLE
chore(release): bump product version to 0.22.93

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.92
-appVersion: "0.22.92"
+version: 0.22.93
+appVersion: "0.22.93"


### PR DESCRIPTION
Bumps the Helm chart and app version together to the next unoccupied product release identity. All five workload image tags and the chart tag for 0.22.93 are currently absent from the public registry.

Validated: release-version and release workflow contracts (15/15), Helm lint, lint, format, diff checks, and bounded direct OCI occupancy checks.