### PR TITLE
chore(release): bump product version to 0.22.94

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.93
-appVersion: "0.22.93"
+version: 0.22.94
+appVersion: "0.22.94"


### PR DESCRIPTION
## Summary
- bump the OpenGeni Helm chart and application version to 0.22.94

## Verification
- `helm lint deploy/helm/opengeni`
- `bun test scripts/release-candidate.test.ts scripts/release-image-workflow-contract.test.ts`