### PR TITLE
fix(react): preserve dirty editor snapshots

### DIFF
--- a/.changeset/quiet-editors-guard.md
+++ b/.changeset/quiet-editors-guard.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Preserve dirty code-editor buffers and their guarded-save baseline across live same-file refreshes.

--- a/packages/react/src/components/code-editor.tsx
+++ b/packages/react/src/components/code-editor.tsx
@@ -392,7 +392,9 @@ export function CodeEditor({
               {saveError.message}
             </span>
           )}
-          {!saveError && savedTick && <span className="text-og-xs text-og-status-idle">Saved</span>}
+          {!saveError && savedTick && !dirty && (
+            <span className="text-og-xs text-og-status-idle">Saved</span>
+          )}
           {readOnly ? (
             <span className="text-og-xs uppercase tracking-wide text-og-fg-subtle">Read-only</span>
           ) : !saveConflict ? (

--- a/packages/react/src/components/code-editor.tsx
+++ b/packages/react/src/components/code-editor.tsx
@@ -95,8 +95,13 @@ export type CodeEditorProps = {
   path: string;
   /** The decoded text contents to seed the editor with. */
   initialContents: string;
-  /** Persist the current buffer. Resolves when the write lands; rejects to surface an error. */
-  onSave: (contents: string) => Promise<unknown>;
+  /**
+   * Persist the current buffer against the exact contents it was edited from.
+   * The second argument is the immutable compare-and-swap baseline; hosts must
+   * not replace it with a newer remote snapshot or concurrent writes can be
+   * silently overwritten.
+   */
+  onSave: (contents: string, expectedContents: string) => Promise<unknown>;
   /** Explicitly overwrite after a visible expected-content conflict. */
   onOverwrite?: ((contents: string) => Promise<unknown>) | undefined;
   /** Re-read the selected file after a visible save conflict. */
@@ -114,6 +119,41 @@ export type CodeEditorProps = {
   fallback?: ReactNode | undefined;
   className?: string | undefined;
 };
+
+export type EditorBufferState = {
+  path: string;
+  value: string;
+  baseline: string;
+};
+
+/**
+ * Reconcile a remote file snapshot without destroying unsaved local work.
+ *
+ * A different path is a new document and always resets. For the same path, a
+ * clean editor follows the remote snapshot while a dirty editor retains both
+ * its local value and the original CAS baseline. The eventual save will then
+ * either succeed against that baseline or surface a typed conflict.
+ */
+export function reconcileEditorBuffer(
+  current: EditorBufferState,
+  incoming: { path: string; contents: string },
+): EditorBufferState {
+  if (current.path === incoming.path && current.value !== current.baseline) {
+    return current;
+  }
+  if (
+    current.path === incoming.path &&
+    current.value === incoming.contents &&
+    current.baseline === incoming.contents
+  ) {
+    return current;
+  }
+  return {
+    path: incoming.path,
+    value: incoming.contents,
+    baseline: incoming.contents,
+  };
+}
 
 /**
  * The EDITABLE single-file pane: CodeMirror 6 with a per-language grammar chosen
@@ -143,42 +183,45 @@ export function CodeEditor({
   const [failed, setFailed] = useState(false);
   const [bundle, setBundle] = useState<EditorBundle | null>(null);
 
-  // The live buffer + the baseline it's compared against for dirtiness. The
-  // baseline resets whenever a *new* file is loaded (path/initialContents change)
-  // or after a successful save.
-  const [value, setValue] = useState(initialContents);
-  const [baseline, setBaseline] = useState(initialContents);
+  // The live buffer and its compare-and-swap baseline are one state value so a
+  // remote refresh cannot update one without the other.
+  const [buffer, setBuffer] = useState<EditorBufferState>(() => ({
+    path,
+    value: initialContents,
+    baseline: initialContents,
+  }));
+  const { value, baseline } = buffer;
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<Error | null>(null);
   const [savedTick, setSavedTick] = useState(false);
+  const saveInFlightRef = useRef(false);
 
   const dirty = value !== baseline;
   const saveConflict =
     saveError !== null && (saveError as Error & { code?: unknown }).code === "file_write_conflict";
 
-  // Reload the buffer when the file identity changes. Guard on initialContents
-  // too so an external refresh of the SAME path (e.g. fs.changed re-read) reseeds
-  // a clean buffer — but only when the user hasn't got unsaved edits in flight.
-  // Fire the wake-on-edit intent at most once per opened file — reset on re-seed.
+  // Follow path changes and clean same-file refreshes. Dirty same-file buffers
+  // intentionally ignore remote snapshots: the original baseline must survive
+  // until guarded save, explicit reload, or navigation.
   const editIntentFiredRef = useRef(false);
-  const lastSeed = useRef<{ path: string; contents: string }>({ path, contents: initialContents });
   useEffect(() => {
-    const seedChanged =
-      lastSeed.current.path !== path || lastSeed.current.contents !== initialContents;
-    if (!seedChanged) return;
-    lastSeed.current = { path, contents: initialContents };
+    setBuffer((current) => reconcileEditorBuffer(current, { path, contents: initialContents }));
+  }, [path, initialContents]);
+
+  // A new document is a new edit-intent/error lifecycle. The normal
+  // SandboxFiles host also keys the component by path; this keeps standalone
+  // consumers correct without relying on that implementation detail.
+  useEffect(() => {
     editIntentFiredRef.current = false;
-    setValue(initialContents);
-    setBaseline(initialContents);
     setSaveError(null);
     setSavedTick(false);
-  }, [path, initialContents]);
+  }, [path]);
 
   // Record a buffer change: the FIRST divergence from the baseline is the edit
   // intent that warms the box (idempotent — latched per opened file).
   const noteEdit = useCallback(
     (next: string) => {
-      setValue(next);
+      setBuffer((current) => ({ ...current, value: next }));
       setSavedTick(false);
       if (!editIntentFiredRef.current && next !== baseline) {
         editIntentFiredRef.current = true;
@@ -246,40 +289,46 @@ export function CodeEditor({
   const saveRef = useRef<() => void>(() => {});
 
   const save = useCallback(async () => {
-    if (readOnly) return;
+    if (readOnly || saveInFlightRef.current) return;
     // Snapshot the buffer at call time so an in-flight edit can't race the write.
     const snapshot = value;
     if (snapshot === baseline) return; // nothing to persist
+    saveInFlightRef.current = true;
     setSaving(true);
     setSaveError(null);
     setSavedTick(false);
     try {
-      await onSave(snapshot);
-      setBaseline(snapshot);
-      lastSeed.current = { path, contents: snapshot };
+      await onSave(snapshot, baseline);
+      setBuffer((current) =>
+        current.path === path ? { ...current, baseline: snapshot } : current,
+      );
       setSavedTick(true);
     } catch (cause) {
       setSaveError(cause instanceof Error ? cause : new Error(String(cause)));
     } finally {
+      saveInFlightRef.current = false;
       setSaving(false);
     }
   }, [readOnly, value, baseline, onSave, path]);
 
   const overwrite = useCallback(async () => {
-    if (readOnly || !onOverwrite) return;
+    if (readOnly || !onOverwrite || saveInFlightRef.current) return;
     const snapshot = value;
     if (snapshot === baseline) return;
+    saveInFlightRef.current = true;
     setSaving(true);
     setSaveError(null);
     setSavedTick(false);
     try {
       await onOverwrite(snapshot);
-      setBaseline(snapshot);
-      lastSeed.current = { path, contents: snapshot };
+      setBuffer((current) =>
+        current.path === path ? { ...current, baseline: snapshot } : current,
+      );
       setSavedTick(true);
     } catch (cause) {
       setSaveError(cause instanceof Error ? cause : new Error(String(cause)));
     } finally {
+      saveInFlightRef.current = false;
       setSaving(false);
     }
   }, [readOnly, onOverwrite, value, baseline, path]);
@@ -306,10 +355,19 @@ export function CodeEditor({
 
   const Editor = bundle?.Editor;
 
+  const reload = useCallback(() => {
+    setBuffer({ path, value: initialContents, baseline: initialContents });
+    editIntentFiredRef.current = false;
+    setSaveError(null);
+    setSavedTick(false);
+    onReload?.();
+  }, [initialContents, onReload, path]);
+
   return (
     <div
       className={cn("flex h-full min-h-0 flex-col", className)}
       data-opengeni-code-editor
+      data-opengeni-editor-dirty={dirty ? "true" : "false"}
       style={editorVars}
     >
       {/* Save bar: dirty indicator + status + the explicit Save button. */}
@@ -375,8 +433,7 @@ export function CodeEditor({
               <button
                 type="button"
                 onClick={() => {
-                  setSaveError(null);
-                  onReload();
+                  reload();
                 }}
                 className="min-h-8 rounded-og-sm border border-og-border bg-og-surface-1 px-2 text-og-xs font-medium text-og-fg hover:bg-og-surface-2 pointer-coarse:min-h-11"
               >

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -319,8 +319,8 @@ export function SandboxFiles({
                   path={viewPath}
                   initialContents={fileView.content}
                   themeType={resolvedTheme}
-                  onSave={(contents) =>
-                    files.writeFile(viewPath, contents, { expectedContent: fileView.content! })
+                  onSave={(contents, expectedContents) =>
+                    files.writeFile(viewPath, contents, { expectedContent: expectedContents })
                   }
                   onOverwrite={(contents) => files.writeFile(viewPath, contents, { force: true })}
                   onReload={() => setViewReloadRevision((revision) => revision + 1)}

--- a/packages/react/test/code-editor-buffer.test.ts
+++ b/packages/react/test/code-editor-buffer.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { reconcileEditorBuffer, type EditorBufferState } from "../src/components/code-editor";
+
+describe("CodeEditor buffer ownership", () => {
+  const clean = (contents = "base\n"): EditorBufferState => ({
+    path: "api/base.txt",
+    value: contents,
+    baseline: contents,
+  });
+
+  test("adopts a same-file remote refresh while clean", () => {
+    expect(
+      reconcileEditorBuffer(clean(), {
+        path: "api/base.txt",
+        contents: "remote\n",
+      }),
+    ).toEqual(clean("remote\n"));
+  });
+
+  test("retains a dirty buffer and its original CAS baseline across remote refreshes", () => {
+    const dirty: EditorBufferState = {
+      path: "api/base.txt",
+      value: "base\nlocal\n",
+      baseline: "base\n",
+    };
+    const reconciled = reconcileEditorBuffer(dirty, {
+      path: "api/base.txt",
+      contents: "remote\n",
+    });
+
+    expect(reconciled).toBe(dirty);
+    expect(reconciled.value).toBe("base\nlocal\n");
+    expect(reconciled.baseline).toBe("base\n");
+  });
+
+  test("switching files resets even a dirty buffer", () => {
+    expect(
+      reconcileEditorBuffer(
+        {
+          path: "api/base.txt",
+          value: "base\nlocal\n",
+          baseline: "base\n",
+        },
+        { path: "api/server.ts", contents: "export {};\n" },
+      ),
+    ).toEqual({
+      path: "api/server.ts",
+      value: "export {};\n",
+      baseline: "export {};\n",
+    });
+  });
+
+  test("returns the existing state when the clean snapshot is unchanged", () => {
+    const state = clean();
+    expect(reconcileEditorBuffer(state, { path: "api/base.txt", contents: "base\n" })).toBe(state);
+  });
+});

--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -17,7 +17,6 @@ import {
   captureApiRegionalProbeEnvironment,
   controlCancellationDurationMs,
   fixturePrompt,
-  isDormantSandboxLiveness,
   isExpectedBrowserCancellation,
   maskKnownPublicEvidenceValues,
   openWorkspaceIfCollapsed,
@@ -27,8 +26,10 @@ import {
   runCaptureApiRegionalProbe,
   selectTreeFile,
   validateCaptureApiRegionalProbeResult,
+  waitForCold,
   waitForSandboxLiveness,
   waitForSandboxFileViewerText,
+  waitForWarm,
   type CaptureApiRegionalProbeRequest,
 } from "./workbench-live-acceptance";
 
@@ -747,11 +748,46 @@ describe("workbench live acceptance preflight", () => {
     expect(signals).toHaveLength(2);
   });
 
-  test("accepts holderless draining as dormant without admitting a warm sandbox", () => {
-    expect(isDormantSandboxLiveness("cold")).toBe(true);
-    expect(isDormantSandboxLiveness("draining")).toBe(true);
-    expect(isDormantSandboxLiveness("warming")).toBe(false);
-    expect(isDormantSandboxLiveness("warm")).toBe(false);
+  test("does not call a draining lease cold before teardown completes", async () => {
+    let calls = 0;
+    const client = {
+      async getStreamCapabilities() {
+        calls += 1;
+        return { liveness: calls === 1 ? "draining" : "cold" } as never;
+      },
+    };
+
+    await waitForCold(
+      client,
+      "10000000-0000-4000-8000-000000000001",
+      "20000000-0000-4000-8000-000000000002",
+      1_000,
+      0,
+      50,
+    );
+
+    expect(calls).toBe(2);
+  });
+
+  test("does not call a draining lease warm before deliberate wake completes", async () => {
+    let calls = 0;
+    const client = {
+      async getStreamCapabilities() {
+        calls += 1;
+        return { liveness: calls === 1 ? "draining" : "warm" } as never;
+      },
+    };
+
+    await waitForWarm(
+      client,
+      "10000000-0000-4000-8000-000000000001",
+      "20000000-0000-4000-8000-000000000002",
+      1_000,
+      0,
+      50,
+    );
+
+    expect(calls).toBe(2);
   });
 
   test("requires interactive scopes only from the dedicated canary principal", () => {

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -1139,15 +1139,20 @@ async function runLiveWorkspaceFlow(input: {
       "Reads and mutations through file and parent-directory symlink escapes returned HTTP 400 and left every outside target byte-for-byte unchanged.",
     );
 
-    await page.getByRole("button", { name: "Edit", exact: true }).click();
-    const editor = page.locator("[data-opengeni-code-editor]");
+    await fileViewer.getByRole("button", { name: "Edit", exact: true }).click();
+    const editor = fileViewer.locator("[data-opengeni-code-editor]");
     await editor.waitFor({ timeout: 30_000 });
     const editable = editor.locator(".cm-content");
     await editable.waitFor({ timeout: 30_000 });
     await editable.click();
-    await page.keyboard.press("Control+End");
-    await page.keyboard.type(`\nui edit ${marker}`);
-    await editor.getByRole("button", { name: "Save", exact: true }).click();
+    await editable.press("Control+End");
+    await editable.press("Enter");
+    await editable.pressSequentially(`ui edit ${marker}`);
+    await fileViewer
+      .locator('[data-opengeni-code-editor][data-opengeni-editor-dirty="true"]')
+      .waitFor({ state: "visible", timeout: 20_000 });
+    const saveButton = editor.getByRole("button", { name: "Save", exact: true });
+    await saveButton.click();
     await editor.getByText("Saved", { exact: true }).waitFor({ timeout: 20_000 });
     const saved = await client.fsRead(workspaceId, sessionId, { path: "api/base.txt" });
     if (!saved.content.includes(`ui edit ${marker}`)) {
@@ -1161,9 +1166,13 @@ async function runLiveWorkspaceFlow(input: {
       overwrite: true,
     });
     await editable.click();
-    await page.keyboard.press("Control+End");
-    await page.keyboard.type("\nlocal conflict candidate");
-    await editor.getByRole("button", { name: "Save", exact: true }).click();
+    await editable.press("Control+End");
+    await editable.press("Enter");
+    await editable.pressSequentially("local conflict candidate");
+    await fileViewer
+      .locator('[data-opengeni-code-editor][data-opengeni-editor-dirty="true"]')
+      .waitFor({ state: "visible", timeout: 20_000 });
+    await saveButton.click();
     await editor
       .getByText("File changed on machine.", { exact: true })
       .waitFor({ timeout: 20_000 });

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -390,7 +390,7 @@ async function main(): Promise<void> {
   pass(
     checks,
     "functional.real-cold-lease",
-    "The real Modal lease reached a dormant cold/draining state before UI review.",
+    "The real Modal lease completed teardown and reached cold before UI review.",
   );
 
   const captureApiRegionProbe = await runCaptureApiRegionalProbe(
@@ -488,13 +488,13 @@ async function main(): Promise<void> {
     }
 
     const afterPassiveBrowser = await cookieClient.getStreamCapabilities(workspaceId, session.id);
-    if (!isDormantSandboxLiveness(afterPassiveBrowser.liveness)) {
+    if (afterPassiveBrowser.liveness !== "cold") {
       throw new Error("passive browser acceptance unexpectedly warmed the sandbox");
     }
     pass(
       checks,
       "functional.capture-cold-zero-channel-a",
-      "Fresh desktop/mobile browsers rendered capture-backed Changes and Files with zero Channel-A requests and left the lease dormant.",
+      "Fresh desktop/mobile browsers rendered capture-backed Changes and Files with zero Channel-A requests and left the lease cold.",
     );
 
     const liveFlow = await runLiveWorkspaceFlow({
@@ -1017,38 +1017,41 @@ export async function waitForSandboxLiveness(
   );
 }
 
-export function isDormantSandboxLiveness(liveness: string): boolean {
-  return liveness === "cold" || liveness === "draining";
-}
-
-async function waitForCold(
-  client: OpenGeniClient,
+export async function waitForCold(
+  client: Pick<OpenGeniClient, "getStreamCapabilities">,
   workspaceId: string,
   sessionId: string,
   timeoutMs: number,
+  pollIntervalMs = 2_000,
+  requestTimeoutMs = 10_000,
 ): Promise<void> {
   await waitForSandboxLiveness(
     client,
     workspaceId,
     sessionId,
-    new Set(["cold", "draining"]),
+    new Set(["cold"]),
     timeoutMs,
+    pollIntervalMs,
+    requestTimeoutMs,
   );
 }
 
-async function waitForWarm(
-  client: OpenGeniClient,
+export async function waitForWarm(
+  client: Pick<OpenGeniClient, "getStreamCapabilities">,
   workspaceId: string,
   sessionId: string,
   timeoutMs = 90_000,
+  pollIntervalMs = 1_000,
+  requestTimeoutMs = 10_000,
 ): Promise<void> {
   await waitForSandboxLiveness(
     client,
     workspaceId,
     sessionId,
-    new Set(["warm", "draining"]),
+    new Set(["warm"]),
     timeoutMs,
-    1_000,
+    pollIntervalMs,
+    requestTimeoutMs,
   );
 }
 


### PR DESCRIPTION
## Cause
A same-file live refresh could replace both an unsaved editor buffer and its guarded-write baseline. That erased dirty state, disabled Save, and could weaken conflict detection. The live release check also admitted a transitional draining lease as both cold and warm.

## Fix
- keep path, buffer, and compare-and-swap baseline as one owned editor snapshot
- retain dirty same-file state across remote refreshes
- pass the original baseline through the sandbox guarded write
- prevent overlapping save and overwrite operations
- report Saved only when no later edit remains dirty
- require exact cold and warm lifecycle endpoints in live acceptance
- target the exact file viewer and wait for observable dirty state before Save

## Validation
- full suite: 6,777 pass, 29 skip, 0 fail
- targeted editor and acceptance tests: 31 pass, 0 fail
- typecheck: all 23 projects clean
- lint and formatting: clean