### PR TITLE
fix(runtime): fence legacy MCP approval replay

### DIFF
--- a/.changeset/safe-mcp-replays.md
+++ b/.changeset/safe-mcp-replays.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/runtime": patch
+"@opengeni/db": patch
+---
+
+Fence approved session MCP tool execution against worker-shutdown replay.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -8056,8 +8056,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           // the frozen RunState blob (the only representation of a turn
           // paused mid-flight), so swapping the trigger for a resume notice
           // could drop the user's decision. Re-applying an already-consumed
-          // approval re-executes at most the single approved step — the same
-          // bound every recovery already accepts.
+          // approval re-enters at most the single approved step. Every
+          // approval-gated MCP action crosses the durable execution admission
+          // fence before its provider invocation, so a consumed step resumes
+          // as already-executed or outcome-unknown rather than calling MCP again.
           const recovery = await requestSessionTurnRecovery(db, input.workspaceId, {
             sessionId: input.sessionId,
             turnId: recoveryTurnId,

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -745,6 +745,14 @@ explicit checkpoint/resume, not an automatic Temporal retry. A newer control
 revision, terminal state, or successor attempt wins instead of being
 overwritten.
 
+Approval-gated MCP execution has an additional provider-side-effect fence.
+Connection-backed actions and legacy per-session MCP servers configured with
+`requireApproval` both create a durable action request keyed by the logical turn
+and approval id before invocation. The approved transition admits the provider
+once; a replay after execution started is recorded as outcome-unknown, and a
+replay after completion is rejected as already executed. Recovery may therefore
+re-enter the SDK approval step without issuing the MCP request again.
+
 Resource-based turn workers use that exact graceful path only as emergency
 memory protection. Temporal's cgroup-aware slot tuner closes new admission at
 `OPENGENI_TURN_WORKER_TARGET_MEMORY_USAGE`; reaching that target is ordinary

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17836,6 +17836,8 @@ export type ConnectorActionInvocation = {
   serverId: string;
   toolName: string;
   arguments: unknown;
+  /** Explicit per-session MCP approval, rather than a connector-policy decision. */
+  approvalMode?: "session_mcp";
 };
 
 export type PrepareConnectorActionApprovalResult =
@@ -17895,7 +17897,14 @@ function connectorActionPolicySelector(toolName: string, args: unknown): string 
 function connectorActionEvidenceName(
   resolved: Exclude<ResolvedConnectorActionPolicy, { managed: false }>,
 ): string {
-  return resolved.entry?.actionName ?? "*";
+  return resolved.entry?.actionName ?? ("actionName" in resolved ? resolved.actionName : "*");
+}
+
+function connectorActionPolicyDecision(
+  resolved: Exclude<ResolvedConnectorActionPolicy, { managed: false }>,
+): ConnectorActionPolicyDecision {
+  if (resolved.entry) return resolved.entry.policy;
+  return resolved.decision;
 }
 
 function connectorActionFingerprint(input: {
@@ -17927,6 +17936,13 @@ type ResolvedConnectorActionPolicy =
       managed: true;
       source: "explicit";
       entry: ConnectorActionPolicySnapshotEntry;
+    }
+  | {
+      managed: true;
+      source: "explicit";
+      entry: null;
+      decision: "ask";
+      actionName: string;
     }
   | {
       managed: true;
@@ -18042,6 +18058,7 @@ function normalizedConnectorActionInvocation(
   toolName: string;
   policyActionSelector: string;
   arguments: unknown;
+  approvalMode: "connector" | "session_mcp";
 } {
   const approvalId = boundedConnectorActionText(
     invocation.approvalId,
@@ -18066,6 +18083,13 @@ function normalizedConnectorActionInvocation(
         CONNECTOR_ACTION_CONNECTION_ID_MAX,
       )
     : null;
+  const approvalMode = invocation.approvalMode ?? "connector";
+  if (approvalMode !== "connector" && approvalMode !== "session_mcp") {
+    throw new Error("connector approval mode is unsupported");
+  }
+  if (approvalMode === "session_mcp" && !connectionId?.startsWith("session-mcp:")) {
+    throw new Error("session MCP approval is missing its synthetic connection identity");
+  }
   return {
     approvalId,
     connectionId,
@@ -18073,6 +18097,19 @@ function normalizedConnectorActionInvocation(
     toolName,
     policyActionSelector,
     arguments: invocation.arguments,
+    approvalMode,
+  };
+}
+
+function resolvedSessionMcpApproval(
+  actionName: string,
+): Exclude<ResolvedConnectorActionPolicy, { managed: false }> {
+  return {
+    managed: true,
+    source: "explicit",
+    entry: null,
+    decision: "ask",
+    actionName,
   };
 }
 
@@ -18171,7 +18208,7 @@ function connectorActionRequestMatches(
     row.policyId === (entry?.id ?? null) &&
     row.policyVersion === (entry?.version ?? null) &&
     row.policySource === input.resolved.source &&
-    row.policyDecision === (entry?.policy ?? "block") &&
+    row.policyDecision === connectorActionPolicyDecision(input.resolved) &&
     row.actionFingerprint === input.invocation.actionFingerprint
   );
 }
@@ -18237,7 +18274,7 @@ async function insertConnectorActionRequest(
       policyId: entry?.id ?? null,
       policyVersion: entry?.version ?? null,
       policySource: input.resolved.source,
-      policyDecision: entry?.policy ?? "block",
+      policyDecision: connectorActionPolicyDecision(input.resolved),
       actionFingerprint: input.invocation.actionFingerprint!,
       status: input.status,
       ...(input.status === "executing"
@@ -18405,19 +18442,22 @@ export async function prepareConnectorActionApproval(
     async (scopedDb) =>
       await scopedDb.transaction(async (tx) => {
         const snapshot = await connectorActionAttemptSnapshot(tx as unknown as Database, identity);
-        const resolved = resolveConnectorActionPolicy(snapshot, {
-          connectionId: normalized.connectionId!,
-          serverId: normalized.serverId,
-          toolName: normalized.toolName,
-          actionName: normalized.policyActionSelector,
-        });
+        const resolved =
+          normalized.approvalMode === "session_mcp"
+            ? resolvedSessionMcpApproval(normalized.policyActionSelector)
+            : resolveConnectorActionPolicy(snapshot, {
+                connectionId: normalized.connectionId!,
+                serverId: normalized.serverId,
+                toolName: normalized.toolName,
+                actionName: normalized.policyActionSelector,
+              });
         if (!resolved.managed) return { managed: false, decision: "unmanaged" } as const;
         const durable = durableConnectorActionInvocation(
           identity,
           { ...normalized, connectionId: normalized.connectionId! },
           resolved,
         );
-        const decision = resolved.entry?.policy ?? "block";
+        const decision = connectorActionPolicyDecision(resolved);
         if (decision === "allow") {
           return {
             managed: true,
@@ -18486,19 +18526,22 @@ export async function beginConnectorActionExecution(
         let row = existing;
         let inserted = false;
         if (!row) {
-          const resolved = resolveConnectorActionPolicy(snapshot, {
-            connectionId: normalized.connectionId!,
-            serverId: normalized.serverId,
-            toolName: normalized.toolName,
-            actionName: normalized.policyActionSelector,
-          });
+          const resolved =
+            normalized.approvalMode === "session_mcp"
+              ? resolvedSessionMcpApproval(normalized.policyActionSelector)
+              : resolveConnectorActionPolicy(snapshot, {
+                  connectionId: normalized.connectionId!,
+                  serverId: normalized.serverId,
+                  toolName: normalized.toolName,
+                  actionName: normalized.policyActionSelector,
+                });
           if (!resolved.managed) return { allowed: true, managed: false } as const;
           const durable = durableConnectorActionInvocation(
             identity,
             { ...normalized, connectionId: normalized.connectionId! },
             resolved,
           );
-          const decision = resolved.entry?.policy ?? "block";
+          const decision = connectorActionPolicyDecision(resolved);
           const created = await insertConnectorActionRequest(tx as unknown as Database, {
             identity,
             invocation: durable,

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -5654,6 +5654,122 @@ describe("clean session control plane", () => {
     }
   });
 
+  test("legacy session MCP approval admits one execution and denies an ambiguous replay", async () => {
+    const { grant, session } = await fixture();
+    await send(grant, session.id, "run one approved legacy MCP action");
+
+    const firstAttemptId = crypto.randomUUID();
+    const firstClaim = await claimSessionWorkForAttempt(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+      workflowRunId: crypto.randomUUID(),
+      dispatchId: crypto.randomUUID(),
+      attemptId: firstAttemptId,
+      trigger: { kind: "next" },
+    });
+    if (firstClaim.action !== "claimed") throw new Error(`claim failed: ${firstClaim.reason}`);
+    const firstIdentity = {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      turnId: firstClaim.turn.id,
+      attemptId: firstAttemptId,
+      executionGeneration: firstClaim.turn.executionGeneration,
+      initiator: firstClaim.turn.initiator,
+    };
+    const call = {
+      approvalId: "legacy-mcp-approved-call",
+      connectionId: `session-mcp:legacy:${"a".repeat(64)}`,
+      serverId: "legacy",
+      toolName: "perform_action",
+      arguments: { action: "create_issue", title: "exactly once" },
+      approvalMode: "session_mcp" as const,
+    };
+
+    expect(await prepareConnectorActionApproval(client.db, firstIdentity, call)).toMatchObject({
+      managed: true,
+      decision: "ask",
+    });
+    expect(
+      await saveRunState(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: firstClaim.turn.id,
+        expectedExecutionGeneration: firstClaim.turn.executionGeneration,
+        expectedAttemptId: firstAttemptId,
+        serializedRunState: "legacy-mcp-approval-state",
+        pendingApprovals: [{ id: call.approvalId }],
+      }),
+    ).toBe(true);
+    await applySessionTurnSettlement(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      turnId: firstClaim.turn.id,
+      triggerEventId: firstClaim.turn.triggerEventId,
+      attemptId: firstAttemptId,
+      turnStatus: "requires_action",
+      sessionStatus: "requires_action",
+      activeTurnId: firstClaim.turn.id,
+      events: [{ type: "session.requiresAction", payload: { approvalId: call.approvalId } }],
+    });
+    const accepted = await acceptSessionApprovalDecision(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      subjectId: grant.subjectId,
+      payload: { approvalId: call.approvalId, decision: "approve" },
+      clientEventId: crypto.randomUUID(),
+    });
+    if (accepted.action !== "accepted") throw new Error("legacy MCP approval was not accepted");
+
+    const resumedAttemptId = crypto.randomUUID();
+    const resumedClaim = await claimSessionWorkForAttempt(client.db, grant.workspaceId!, {
+      sessionId: session.id,
+      workflowId: `session-${session.id}`,
+      workflowRunId: crypto.randomUUID(),
+      dispatchId: crypto.randomUUID(),
+      attemptId: resumedAttemptId,
+      trigger: { kind: "approval", triggerEventId: accepted.event.id },
+    });
+    if (resumedClaim.action !== "claimed") {
+      throw new Error(`approval resume failed: ${resumedClaim.reason}`);
+    }
+    const resumedIdentity = {
+      ...firstIdentity,
+      attemptId: resumedAttemptId,
+      executionGeneration: resumedClaim.turn.executionGeneration,
+      initiator: resumedClaim.turn.initiator,
+    };
+    expect(await beginConnectorActionExecution(client.db, resumedIdentity, call)).toMatchObject({
+      allowed: true,
+      managed: true,
+    });
+
+    // Planted near-identical negative: a retry at the exact provider-started
+    // boundary must become outcome-unknown and never receive execution admission.
+    expect(await beginConnectorActionExecution(client.db, resumedIdentity, call)).toMatchObject({
+      allowed: false,
+      managed: true,
+      reason: "uncertain_retry",
+    });
+
+    const [request] = await withWorkspaceRls(client.db, grant.workspaceId!, (db) =>
+      db
+        .select()
+        .from(schema.connectorActionRequests)
+        .where(eq(schema.connectorActionRequests.approvalId, call.approvalId)),
+    );
+    expect(request).toMatchObject({
+      status: "uncertain",
+      policySource: "explicit",
+      policyDecision: "ask",
+      policyId: null,
+      actionName: "create_issue",
+      executionAttemptId: resumedAttemptId,
+      outcome: "retry_after_execution_started",
+    });
+  });
+
   test("a committed session control command replays before its stale control fence is checked", async () => {
     const { grant, session } = await fixture();
     const before = await withWorkspaceRls(client.db, grant.workspaceId!, (db) =>

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1911,6 +1911,7 @@ export type ConnectorActionToolCall = {
   serverId: string;
   toolName: string;
   arguments: unknown;
+  approvalMode?: "session_mcp";
 };
 
 export type ConnectorActionPolicyPreparation =
@@ -2833,6 +2834,12 @@ function mcpToolRequiresApproval(
   return policy === true || (policy !== false && policy.has(unprefixedName));
 }
 
+/** Stable, secret-free execution identity for an MCP server without a connection row. */
+function sessionMcpApprovalConnectionId(serverId: string, url: string): string {
+  const targetHash = createHash("sha256").update(url, "utf8").digest("hex");
+  return `session-mcp:${serverId}:${targetHash}`;
+}
+
 /** A per-server approval policy keyed by the server's `<id>__` tool prefix. */
 type McpApprovalPolicy = {
   prefix: string;
@@ -2884,8 +2891,12 @@ function installMcpApprovalPolicy(
       const unprefixed = tool.name.slice(policy.prefix.length);
       const originalNeedsApproval = tool.needsApproval.bind(tool);
       const originalInvoke = tool.invoke.bind(tool);
-      const connectorManaged = Boolean(connectorActionPolicy && policy.connectorBacked);
-      if (!connectorManaged && !mcpToolRequiresApproval(policy.requireApproval, unprefixed)) {
+      const legacyApproval =
+        !policy.connectorBacked && mcpToolRequiresApproval(policy.requireApproval, unprefixed);
+      const durableManaged = Boolean(
+        connectorActionPolicy && (policy.connectorBacked || legacyApproval),
+      );
+      if (!durableManaged && !legacyApproval) {
         return tool;
       }
       const connectorCall = (approvalId: string, args: unknown): ConnectorActionToolCall => {
@@ -2898,6 +2909,7 @@ function installMcpApprovalPolicy(
           serverId: policy.serverId,
           toolName: unprefixed,
           arguments: args,
+          ...(legacyApproval ? { approvalMode: "session_mcp" as const } : {}),
         };
       };
       return {
@@ -2907,22 +2919,27 @@ function installMcpApprovalPolicy(
           parsedInput: Parameters<typeof originalNeedsApproval>[1],
           callId: Parameters<typeof originalNeedsApproval>[2],
         ) => {
-          if (connectorManaged && !callId) {
+          if (durableManaged && !callId) {
             throw new Error("Connector action is missing its durable approval identity");
           }
-          const preparation = connectorManaged
+          const preparation = durableManaged
             ? await connectorActionPolicy!.prepare(connectorCall(callId!, parsedInput))
             : ({ managed: false, decision: "unmanaged" } as const);
           if (preparation.managed && preparation.decision === "block") {
             return false;
           }
-          const legacyApproval =
+          const approvalRequired =
             mcpToolRequiresApproval(policy.requireApproval, unprefixed) ||
             (await originalNeedsApproval(runContext, parsedInput, callId));
-          return (preparation.managed && preparation.decision === "ask") || legacyApproval;
+          return (preparation.managed && preparation.decision === "ask") || approvalRequired;
         },
         invoke: async (runContext, input, details) => {
-          if (!connectorManaged) {
+          if (legacyApproval && !connectorActionPolicy) {
+            throw new Error(
+              "Approval-gated MCP action was not executed: durable execution policy is unavailable",
+            );
+          }
+          if (!durableManaged) {
             return await originalInvoke(runContext, input, details);
           }
           const callId = details?.toolCall?.callId;
@@ -3024,7 +3041,10 @@ function applyMcpApprovalPolicy(
         requireApproval:
           server.requireApproval === true ? true : new Set(server.requireApproval as string[]),
         connectorBacked: Boolean(server.connectionRef),
-        connectionId: resolvedConnectionId ?? staticConnectionId,
+        connectionId:
+          resolvedConnectionId ??
+          staticConnectionId ??
+          (server.connectionRef ? null : sessionMcpApprovalConnectionId(server.id, server.url)),
       };
     })
     .sort((a, b) => b.prefix.length - a.prefix.length);

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1751,6 +1751,125 @@ describe("runtime event normalization", () => {
       }
     });
 
+    test("legacy approved MCP execution is durably admitted once and replay is denied", async () => {
+      const mcp = startTestMcpServer();
+      const serverConfig = {
+        id: "docs",
+        name: "Document Search",
+        url: mcp.url,
+        cacheToolsList: false,
+        requireApproval: true as const,
+      };
+      const settings = testSettings({ sandboxBackend: "none", mcpServers: [serverConfig] });
+      const prepared = await prepareAgentTools(settings, [{ kind: "mcp", id: "docs" }]);
+      const policyCalls: Array<{ phase: string; call: Record<string, unknown> }> = [];
+      let begins = 0;
+      const hooks: ConnectorActionPolicyHooks = {
+        prepare: async (call) => {
+          policyCalls.push({ phase: "prepare", call });
+          return { managed: true, decision: "ask" };
+        },
+        begin: async (call) => {
+          policyCalls.push({ phase: "begin", call });
+          begins += 1;
+          return begins === 1
+            ? { allowed: true, managed: true, requestId: "legacy-request" }
+            : {
+                allowed: false,
+                managed: true,
+                requestId: "legacy-request",
+                reason: "already_executed",
+              };
+        },
+        complete: async ({ requestId, outcome }) => {
+          policyCalls.push({ phase: `complete:${requestId}:${outcome}`, call: {} });
+        },
+      };
+      const agent = buildOpenGeniAgent(settings, [], {
+        mcpServers: prepared.mcpServers,
+        connectorActionPolicy: hooks,
+      });
+
+      try {
+        const [tool] = (await agent.getMcpTools(new RunContext())).filter(
+          (candidate) =>
+            candidate.type === "function" && candidate.name === "docs__search_documents",
+        );
+        if (!tool || tool.type !== "function") throw new Error("legacy MCP tool missing");
+        const input = { query: "create-once" };
+        const callId = "legacy-approved-call";
+        expect(await tool.needsApproval(new RunContext(), input, callId)).toBe(true);
+        const details = { toolCall: { callId } } as any;
+
+        await expect(
+          tool.invoke(new RunContext(), JSON.stringify(input), details),
+        ).resolves.toBeDefined();
+        await expect(tool.invoke(new RunContext(), JSON.stringify(input), details)).rejects.toThrow(
+          "already_executed",
+        );
+
+        expect(mcp.calls).toEqual([{ tool: "search_documents", args: input }]);
+        expect(policyCalls.map(({ phase }) => phase)).toEqual([
+          "prepare",
+          "begin",
+          "complete:legacy-request:completed",
+          "begin",
+        ]);
+        for (const { call } of policyCalls.filter(({ phase }) => !phase.startsWith("complete:"))) {
+          expect(call).toMatchObject({
+            approvalId: callId,
+            approvalMode: "session_mcp",
+            serverId: "docs",
+            toolName: "search_documents",
+            arguments: input,
+          });
+          expect(call.connectionId).toMatch(/^session-mcp:docs:[0-9a-f]{64}$/);
+        }
+      } finally {
+        await prepared.close();
+        mcp.close();
+      }
+    });
+
+    test("legacy approved MCP execution fails closed without durable admission hooks", async () => {
+      const mcp = startTestMcpServer();
+      const settings = testSettings({
+        sandboxBackend: "none",
+        mcpServers: [
+          {
+            id: "docs",
+            name: "Document Search",
+            url: mcp.url,
+            cacheToolsList: false,
+            requireApproval: true,
+          },
+        ],
+      });
+      const prepared = await prepareAgentTools(settings, [{ kind: "mcp", id: "docs" }]);
+      const agent = buildOpenGeniAgent(settings, [], { mcpServers: prepared.mcpServers });
+
+      try {
+        const [tool] = (await agent.getMcpTools(new RunContext())).filter(
+          (candidate) =>
+            candidate.type === "function" && candidate.name === "docs__search_documents",
+        );
+        if (!tool || tool.type !== "function") throw new Error("legacy MCP tool missing");
+        const input = { query: "must-not-run" };
+        expect(await tool.needsApproval(new RunContext(), input, "legacy-unfenced-call")).toBe(
+          true,
+        );
+        await expect(
+          tool.invoke(new RunContext(), JSON.stringify(input), {
+            toolCall: { callId: "legacy-unfenced-call" },
+          } as any),
+        ).rejects.toThrow("durable execution policy is unavailable");
+        expect(mcp.calls).toEqual([]);
+      } finally {
+        await prepared.close();
+        mcp.close();
+      }
+    });
+
     test("subject-scoped generic refs enforce Allow/Ask/Block with the broker-frozen connection", async () => {
       const connectionId = "11111111-1111-4111-8111-111111111111";
       const initiatingSubjectId = "user:immutable-initiator";


### PR DESCRIPTION
## Summary

- route legacy/non-connector MCP tools configured with `requireApproval` through the existing durable action-request admission fence
- reject replay after provider execution starts or completes, and fail closed if legacy approval lacks durable hooks
- preserve connector-backed behavior, document recovery semantics, and add a patch changeset

## Validation

- `bun test packages/runtime/test/runtime.test.ts` — 232 pass
- focused replay/connector tests — 4 pass
- `bun test packages/db/test/connector-action-policy.test.ts` — 3 pass
- `bun run typecheck` — all 23 projects clean
- `bun run lint` — clean
- formatting, diff check, and changeset release plan — clean

## Integration limitation

`bun test packages/db/test/session-control-plane.test.ts --test-name-pattern 'legacy session MCP approval admits one execution'` could not start because the sandbox has no PostgreSQL harness and Docker is unavailable. CI must provide the real-Postgres proof.

## Follow-up

- Linear OPE-179 records separate low-priority duplicate tool-call-ID defensive hardening. No supported production duplicate-ID producer is currently known.

**No-claim:** this PR has no local real-Postgres pass; it does have runtime provider-call proof plus the planted DB replay negative committed for CI.