### PR TITLE
perf(ci): cache workload image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,7 +820,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-api:dogfood-sha-{0}', github.sha) || 'opengeni-api:ci' }}
           cache-from: type=gha,scope=opengeni-ci-api
-          cache-to: type=gha,mode=min,scope=opengeni-ci-api,ignore-error=true
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=min,scope=opengeni-ci-api,ignore-error=true' || '' }}
           build-args: |
             OPENGENI_SERVER_VERSION=sha-${{ github.sha }}
 
@@ -835,7 +835,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-worker:dogfood-sha-{0}', github.sha) || 'opengeni-worker:ci' }}
           cache-from: type=gha,scope=opengeni-ci-worker
-          cache-to: type=gha,mode=min,scope=opengeni-ci-worker,ignore-error=true
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=min,scope=opengeni-ci-worker,ignore-error=true' || '' }}
           build-args: |
             OPENGENI_SERVER_VERSION=sha-${{ github.sha }}
 
@@ -850,7 +850,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-web:dogfood-sha-{0}', github.sha) || 'opengeni-web:ci' }}
           cache-from: type=gha,scope=opengeni-ci-web
-          cache-to: type=gha,mode=min,scope=opengeni-ci-web,ignore-error=true
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=min,scope=opengeni-ci-web,ignore-error=true' || '' }}
           build-args: |
             OPENGENI_SERVER_VERSION=sha-${{ github.sha }}
             OPENGENI_DEPLOYMENT_REVISION=${{ github.sha }}
@@ -895,7 +895,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-relay:dogfood-sha-{0}', github.sha) || 'opengeni-relay:ci' }}
           cache-from: type=gha,scope=opengeni-ci-relay
-          cache-to: type=gha,mode=min,scope=opengeni-ci-relay,ignore-error=true
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=min,scope=opengeni-ci-relay,ignore-error=true' || '' }}
   sandbox-image:
     name: Build headless sandbox workload image
     needs: automation-admission
@@ -935,7 +935,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-sandbox:dogfood-sha-{0}', github.sha) || 'opengeni-sandbox:ci' }}
           cache-from: type=gha,scope=opengeni-ci-sandbox
-          cache-to: type=gha,mode=min,scope=opengeni-ci-sandbox,ignore-error=true
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=min,scope=opengeni-ci-sandbox,ignore-error=true' || '' }}
 
   images:
     name: Workload image builds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,6 +819,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-api:dogfood-sha-{0}', github.sha) || 'opengeni-api:ci' }}
+          cache-from: type=gha,scope=opengeni-ci-api
+          cache-to: type=gha,mode=min,scope=opengeni-ci-api,ignore-error=true
           build-args: |
             OPENGENI_SERVER_VERSION=sha-${{ github.sha }}
 
@@ -832,6 +834,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-worker:dogfood-sha-{0}', github.sha) || 'opengeni-worker:ci' }}
+          cache-from: type=gha,scope=opengeni-ci-worker
+          cache-to: type=gha,mode=min,scope=opengeni-ci-worker,ignore-error=true
           build-args: |
             OPENGENI_SERVER_VERSION=sha-${{ github.sha }}
 
@@ -845,6 +849,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-web:dogfood-sha-{0}', github.sha) || 'opengeni-web:ci' }}
+          cache-from: type=gha,scope=opengeni-ci-web
+          cache-to: type=gha,mode=min,scope=opengeni-ci-web,ignore-error=true
           build-args: |
             OPENGENI_SERVER_VERSION=sha-${{ github.sha }}
             OPENGENI_DEPLOYMENT_REVISION=${{ github.sha }}
@@ -888,6 +894,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-relay:dogfood-sha-{0}', github.sha) || 'opengeni-relay:ci' }}
+          cache-from: type=gha,scope=opengeni-ci-relay
+          cache-to: type=gha,mode=min,scope=opengeni-ci-relay,ignore-error=true
   sandbox-image:
     name: Build headless sandbox workload image
     needs: automation-admission
@@ -926,6 +934,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ github.event_name == 'push' && format('ghcr.io/cloudgeni-ai/opengeni-sandbox:dogfood-sha-{0}', github.sha) || 'opengeni-sandbox:ci' }}
+          cache-from: type=gha,scope=opengeni-ci-sandbox
+          cache-to: type=gha,mode=min,scope=opengeni-ci-sandbox,ignore-error=true
 
   images:
     name: Workload image builds

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -581,7 +581,7 @@ ${parser}`,
 
     const imageSteps = ["service-images", "relay-image", "sandbox-image"].flatMap((jobName) =>
       parsed.jobs[jobName]!.steps.filter(
-        (step): step is { name: string; uses: string } =>
+        (step): step is { name: string; uses: string; with: Record<string, string> } =>
           typeof step === "object" &&
           step !== null &&
           "uses" in step &&
@@ -589,35 +589,60 @@ ${parser}`,
       ).map((step) => ({
         jobName,
         name: step.name,
+        step,
         fingerprint: createHash("sha256").update(JSON.stringify(step)).digest("hex"),
       })),
     );
-    expect(imageSteps).toEqual([
+    expect(imageSteps.map(({ step: _step, ...identity }) => identity)).toEqual([
       {
         jobName: "service-images",
         name: "Build API image",
-        fingerprint: "4f1bf9e5979e86bc78b8813e4c2ed834bd9e24781d8906a493be33d235113231",
+        fingerprint: "05ac3061343c2e148b0d18d8a1288c38dbf165354d16cc1d1542c99303f8d37c",
       },
       {
         jobName: "service-images",
         name: "Build worker image",
-        fingerprint: "df6c0eea3a346c6ad9f71bb5545044a062179ffd9447553a1e21f467d85c65f4",
+        fingerprint: "79436eb9c77b0a919099815ce1a9cbbbf480e538f72cb204d276dc3adf877749",
       },
       {
         jobName: "service-images",
         name: "Build web image",
-        fingerprint: "a535f3fae1f58cdd9d47273d2340c26d4e3c143c4e69c59f2de984fcfec37714",
+        fingerprint: "6fc459016eb3fa26809d7861c74281aac840a72d4da3af7b6678999a083c97c7",
       },
       {
         jobName: "relay-image",
         name: "Build relay image",
-        fingerprint: "1e26cd74190f9b806413e6943324c20a9da0e8f84dd42406555fca5b5c11c4f9",
+        fingerprint: "7a94a29a7561d8edfa3c9871d27f8ea312799079ad0857635eed6c67a2f25af7",
       },
       {
         jobName: "sandbox-image",
         name: "Build headless sandbox image",
-        fingerprint: "6d1ce559070b6825ff5684da724e4c69baad72f6346ab3db04acb46f3cdccbff",
+        fingerprint: "60cecf54236dc84c7752ba02b8c48e67e7dd614f0083b35673d4a4ebd426cff3",
       },
     ]);
+
+    const expectedCacheScopes = new Map([
+      ["Build API image", "opengeni-ci-api"],
+      ["Build worker image", "opengeni-ci-worker"],
+      ["Build web image", "opengeni-ci-web"],
+      ["Build relay image", "opengeni-ci-relay"],
+      ["Build headless sandbox image", "opengeni-ci-sandbox"],
+    ]);
+    const hasCompleteCacheContract = (
+      steps: Array<{ name: string; step: { with: Record<string, string> } }>,
+    ) =>
+      steps.every(({ name, step }) => {
+        const scope = expectedCacheScopes.get(name);
+        return (
+          scope !== undefined &&
+          step.with["cache-from"] === `type=gha,scope=${scope}` &&
+          step.with["cache-to"] === `type=gha,mode=min,scope=${scope},ignore-error=true`
+        );
+      });
+
+    expect(hasCompleteCacheContract(imageSteps)).toBe(true);
+    const missingExporter = structuredClone(imageSteps);
+    delete missingExporter[0]!.step.with["cache-to"];
+    expect(hasCompleteCacheContract(missingExporter)).toBe(false);
   });
 });

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -597,27 +597,27 @@ ${parser}`,
       {
         jobName: "service-images",
         name: "Build API image",
-        fingerprint: "05ac3061343c2e148b0d18d8a1288c38dbf165354d16cc1d1542c99303f8d37c",
+        fingerprint: "200e6507d925ce5608edcefa9a4f51af2a25af4f116a9dc71ac3f583031b4e71",
       },
       {
         jobName: "service-images",
         name: "Build worker image",
-        fingerprint: "79436eb9c77b0a919099815ce1a9cbbbf480e538f72cb204d276dc3adf877749",
+        fingerprint: "1f0f09b8087ce5131969fb3fa104c477d60ce41213c4dfb9ea960a40f00a787d",
       },
       {
         jobName: "service-images",
         name: "Build web image",
-        fingerprint: "6fc459016eb3fa26809d7861c74281aac840a72d4da3af7b6678999a083c97c7",
+        fingerprint: "64b1fb64bbcacd194132e5f4d91f6e09b85044b4cc01b577230272910ab5c66b",
       },
       {
         jobName: "relay-image",
         name: "Build relay image",
-        fingerprint: "7a94a29a7561d8edfa3c9871d27f8ea312799079ad0857635eed6c67a2f25af7",
+        fingerprint: "1464aec087ebbbd792371ceb86f67c41ecd75ba500b824a784ed94affb8e6a9f",
       },
       {
         jobName: "sandbox-image",
         name: "Build headless sandbox image",
-        fingerprint: "60cecf54236dc84c7752ba02b8c48e67e7dd614f0083b35673d4a4ebd426cff3",
+        fingerprint: "0985451362b8a06fe51d1a56186445a7311c916f3908e56c48c9fd4d9a1ec46f",
       },
     ]);
 
@@ -636,7 +636,8 @@ ${parser}`,
         return (
           scope !== undefined &&
           step.with["cache-from"] === `type=gha,scope=${scope}` &&
-          step.with["cache-to"] === `type=gha,mode=min,scope=${scope},ignore-error=true`
+          step.with["cache-to"] ===
+            `\${{ github.event_name == 'push' && 'type=gha,mode=min,scope=${scope},ignore-error=true' || '' }}`
         );
       });
 
@@ -644,5 +645,9 @@ ${parser}`,
     const missingExporter = structuredClone(imageSteps);
     delete missingExporter[0]!.step.with["cache-to"];
     expect(hasCompleteCacheContract(missingExporter)).toBe(false);
+    const unconditionalPullRequestExporter = structuredClone(imageSteps);
+    unconditionalPullRequestExporter[0]!.step.with["cache-to"] =
+      "type=gha,mode=min,scope=opengeni-ci-api,ignore-error=true";
+    expect(hasCompleteCacheContract(unconditionalPullRequestExporter)).toBe(false);
   });
 });


### PR DESCRIPTION
## OPE-27: reuse trusted workload-image caches

### Measured problem

Representative successful PR CI run `31298684324` had a 627-second wall clock and 3,839 runner-seconds. Its critical lanes were:

- headless sandbox image: 616s (593s build step)
- API/worker/web images: 569s (306s + 143s + 84s, serial)
- browser acceptance: 562s
- slowest unit shard: 375s

The nine dependency-install steps totaled only 23s, so install deduplication is not the first bottleneck. Runner logs report the actual GitHub-hosted class as 4 CPUs / 15.61 GiB RAM; existing logs do not expose per-job CPU/RAM peaks.

### Change

Every existing multi-architecture workload image build imports a content-addressed GitHub Actions BuildKit cache under a distinct stable scope:

- API
- worker
- web
- relay
- headless sandbox

Only trusted `push` runs on `main` export/update those caches. Pull requests consume an available default-branch cache but do not pay cache-upload latency or create per-PR cache churn. `mode=min` limits exported cache volume to final-image-reachable layers; export is best-effort, while the actual image build remains mandatory.

### Measured correction and exact-head result

The initial exact-head population run `31300194368` was green but took 732s / 4,091 runner-seconds. Exporting on the PR increased API image time to 472s and sandbox image time to 663s while successfully creating all five cache indexes under `refs/pull/1237/merge`. That evidence changed the implementation: the final head imports caches on PRs but exports only on trusted `main` pushes.

Final exact-head run `31300855192` at `ace2d7551378325e9efbce86fda0324424cb224a` completed green in 612s / 3,036 runner-seconds:

- relay image job: 21s vs 309s baseline; build step 2s vs 279s
- sandbox image job: 26s vs 616s baseline; build step 2s vs 593s
- overall runner use: 803s lower (20.9%)
- overall wall clock: 15s lower (2.4%) because browser acceptance (562s) and the serial service-image lane (602s) remained critical

The logs show real GHA cache-manifest imports and cached layers. They contain zero cache-export operations on the PR. The moving-main rebase invalidated enough API inputs that API still rebuilt in 325s (306s baseline); worker/web remained 145s/84s. This result is preserved rather than rerun or overstated.

The warm evidence uses indexes populated by the rejected first head under this PR's merge ref. After merge, the first trusted `main` push will populate the default-branch scopes; subsequent PR measurements will establish the durable cross-PR effect.

### Detection preserved

This does **not** skip, narrow, mock, or replace an image build. It preserves:

- all five physical image roles
- `linux/amd64,linux/arm64` coverage
- exact-SHA build arguments and immutable main dogfood tags
- required API/worker/web/relay/sandbox success aggregation
- exact digest validation and dogfood receipt publication

The workflow contract continues fingerprinting every complete build step. It additionally proves the exact importer, trusted-main-only exporter, and unique scope for every image. Near-identical planted negatives delete one exporter and make a PR exporter unconditional; both are rejected.

### Validation

Final rebased head:

- exact-head CI: green (`31300855192`)
- release/workflow contracts: 79 pass, 781 assertions
- full TypeScript graph: 23/23 projects clean
- full lint: 1,518 files, 0 warnings/errors
- touched format: clean
- `git diff --check`: clean

GitHub cache eviction/quota can reduce hits, but cannot bypass or falsify the required image builds.
