### PR TITLE
fix(release): survive exact-head merge completion race

### DIFF
--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -336,6 +336,38 @@ function assertVersionPull(pull, expected) {
   return headSha;
 }
 
+function assertMergedVersionPull(pull, expected) {
+  const expectedNumber = expected.prNumber ?? expected.number;
+  invariant(pull?.number === expectedNumber, "merged Version PR number changed");
+  invariant(pull?.state === "closed" && pull?.merged === true, "Version PR is not merged");
+  invariant(pull?.draft === false, "merged Version PR is a draft");
+  assertIdentity(pull?.user, RELEASE_AUTOMATION_CONTRACT.versionAuthor, "merged Version PR author");
+  invariant(
+    pull?.base?.ref === RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+    "merged Version PR base branch changed",
+  );
+  invariant(
+    pull?.base?.repo?.full_name === RELEASE_AUTOMATION_CONTRACT.repository,
+    "merged Version PR base repository changed",
+  );
+  invariant(pull?.base?.sha === expected.baseSha, "merged Version PR base SHA changed");
+  invariant(
+    pull?.head?.ref === RELEASE_AUTOMATION_CONTRACT.versionBranch,
+    "merged Version PR head branch changed",
+  );
+  invariant(
+    pull?.head?.repo?.full_name === RELEASE_AUTOMATION_CONTRACT.repository,
+    "merged Version PR is not from the base repository",
+  );
+  invariant(pull?.head?.sha === expected.headSha, "merged Version PR head SHA changed");
+  invariant(pull?.commits === 1, "merged Version PR is not one commit");
+  invariant(
+    Number.isSafeInteger(pull?.changed_files) && pull.changed_files > 0,
+    "merged Version PR changed-file count is invalid",
+  );
+  return assertSha(pull?.merge_commit_sha, "merged Version PR commit SHA");
+}
+
 function versionBranchProjection(value) {
   invariant(
     value?.ref === `refs/heads/${RELEASE_AUTOMATION_CONTRACT.versionBranch}`,
@@ -470,6 +502,48 @@ async function terminalVersionIdentity(api, context) {
     "terminal Version head parent changed",
   );
   return pull;
+}
+
+async function terminalMergedVersionIdentity(api, context, pull) {
+  const mergeSha = assertMergedVersionPull(pull, context);
+  const [headCommit, mergeCommit] = await Promise.all([
+    api.get(repositoryPath(`/git/commits/${context.headSha}`)),
+    api.get(repositoryPath(`/git/commits/${mergeSha}`)),
+  ]);
+  invariant(
+    versionHeadParent(headCommit, context.headSha) === context.baseSha,
+    "merged Version head parent changed",
+  );
+  invariant(
+    assertSha(headCommit?.tree?.sha, "merged Version head tree SHA") ===
+      assertSha(mergeCommit?.tree?.sha, "merged Version commit tree SHA"),
+    "merged Version commit tree differs from its exact head",
+  );
+  invariant(
+    assertSha(mergeCommit?.sha, "merged Version commit SHA") === mergeSha,
+    "merged Version commit changed",
+  );
+  invariant(
+    Array.isArray(mergeCommit?.parents) &&
+      ((mergeCommit.parents.length === 1 && mergeCommit.parents[0]?.sha === context.baseSha) ||
+        (mergeCommit.parents.length === 2 &&
+          mergeCommit.parents[0]?.sha === context.baseSha &&
+          mergeCommit.parents[1]?.sha === context.headSha)),
+    "merged Version commit topology changed",
+  );
+  return pull;
+}
+
+async function terminalCompletableVersionIdentity(api, context) {
+  try {
+    return await terminalVersionIdentity(api, context);
+  } catch (openError) {
+    // Completion can race the approved merge and automatic deletion/reuse of
+    // changeset-release/main. Accept only provider-proved exact-tree landing.
+    const pull = await api.get(repositoryPath(`/pulls/${context.prNumber}`));
+    if (pull?.state !== "closed" || pull?.merged !== true) throw openError;
+    return terminalMergedVersionIdentity(api, context, pull);
+  }
 }
 
 async function convergedVersionHeadSha(api, context, options = {}) {
@@ -1309,7 +1383,7 @@ export async function completeVersionPrChecks(options = {}) {
   let terminalError;
   if (conclusion === "success") {
     try {
-      await terminalVersionIdentity(api, context);
+      await terminalCompletableVersionIdentity(api, context);
     } catch (error) {
       conclusion = "failure";
       terminalError = error;

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import {
   RELEASE_AUTOMATION_CONTRACT,
   beginVersionPrChecks,
+  completeVersionPrChecks,
   recoverReleaseHeadEvidence,
   sealReleaseHeadEvidence,
   validateVersionPrCiAdmission,
@@ -115,6 +116,16 @@ function versionPull(
     },
     commits: 1,
     changed_files: 1,
+  };
+}
+
+function mergedVersionPull(overrides: { merge?: string } = {}) {
+  return {
+    ...versionPull(),
+    state: "closed",
+    merged: true,
+    merge_commit_sha: overrides.merge ?? mergeSha,
+    merged_at: "2026-08-09T06:08:35Z",
   };
 }
 
@@ -1673,6 +1684,9 @@ describe("release head retention recovery", () => {
 
 function checksFixture(
   options: {
+    merged?: boolean;
+    mergedTreeSha?: string;
+    missingVersionBranch?: boolean;
     releaseHeadSha?: string;
     release?: Record<string, unknown> | null;
   } = {},
@@ -1702,14 +1716,26 @@ function checksFixture(
     if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/main`)
       return response(mainRef());
     if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}`)
-      return response(versionPull());
+      return response(options.merged ? mergedVersionPull() : versionPull());
     if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/changeset-release/main`)
-      return response({
-        ref: "refs/heads/changeset-release/main",
-        object: { type: "commit", sha: headSha },
-      });
+      return options.missingVersionBranch
+        ? response({ message: "missing version branch" }, 404)
+        : response({
+            ref: "refs/heads/changeset-release/main",
+            object: { type: "commit", sha: headSha },
+          });
     if (method === "GET" && url.pathname === `${prefix}/git/commits/${headSha}`)
-      return response({ sha: headSha, parents: [{ sha: baseSha }] });
+      return response({
+        sha: headSha,
+        tree: { sha: headTreeSha },
+        parents: [{ sha: baseSha }],
+      });
+    if (method === "GET" && url.pathname === `${prefix}/git/commits/${mergeSha}`)
+      return response({
+        sha: mergeSha,
+        tree: { sha: options.mergedTreeSha ?? headTreeSha },
+        parents: [{ sha: baseSha }],
+      });
     if (method === "GET" && url.pathname === `${prefix}/git/ref/tags/${releaseHeadTag}`)
       return releaseHeadRef === null
         ? response({ message: "missing release head ref" }, 404)
@@ -1794,6 +1820,75 @@ test("exact-head check markers update idempotently instead of duplicating", asyn
     ),
   ).toHaveLength(3);
   expect(fixture.requests.filter((request) => request.method === "PATCH")).toHaveLength(3);
+});
+
+test("exact-head check completion succeeds while the Version PR remains unchanged", async () => {
+  const fixture = checksFixture();
+  const options = {
+    env: automationCiEnv(),
+    fetchImpl: fixture.fetchImpl,
+    now: () => new Date("2026-08-09T06:00:00Z"),
+  };
+  await beginVersionPrChecks(options);
+  await completeVersionPrChecks({
+    ...options,
+    kind: "automation-ci",
+    conclusion: "success",
+  });
+  expect(
+    fixture.checks.find((check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.automationCi),
+  ).toMatchObject({ status: "completed", conclusion: "success" });
+});
+
+test("exact-head check completion accepts an exact-tree merge after branch deletion", async () => {
+  const fixtureOptions = { merged: false, missingVersionBranch: false };
+  const fixture = checksFixture(fixtureOptions);
+  const options = {
+    env: automationCiEnv(),
+    fetchImpl: fixture.fetchImpl,
+    now: () => new Date("2026-08-09T06:11:17Z"),
+  };
+  await beginVersionPrChecks(options);
+  fixtureOptions.merged = true;
+  fixtureOptions.missingVersionBranch = true;
+
+  await completeVersionPrChecks({
+    ...options,
+    kind: "automation-ci",
+    conclusion: "success",
+  });
+
+  expect(
+    fixture.checks.find((check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.automationCi),
+  ).toMatchObject({ status: "completed", conclusion: "success" });
+});
+
+test("exact-head check completion rejects a merged tree that differs from the admitted head", async () => {
+  const fixtureOptions = {
+    merged: false,
+    mergedTreeSha: "1".repeat(40),
+    missingVersionBranch: false,
+  };
+  const fixture = checksFixture(fixtureOptions);
+  const options = {
+    env: automationCiEnv(),
+    fetchImpl: fixture.fetchImpl,
+    now: () => new Date("2026-08-09T06:11:17Z"),
+  };
+  await beginVersionPrChecks(options);
+  fixtureOptions.merged = true;
+  fixtureOptions.missingVersionBranch = true;
+
+  await expect(
+    completeVersionPrChecks({
+      ...options,
+      kind: "automation-ci",
+      conclusion: "success",
+    }),
+  ).rejects.toThrow("merged Version commit tree differs from its exact head");
+  expect(
+    fixture.checks.find((check) => check.name === RELEASE_AUTOMATION_CONTRACT.checks.automationCi),
+  ).toMatchObject({ status: "completed", conclusion: "failure" });
 });
 
 test("exact-head check creation rejects a conflicting retained release head", async () => {


### PR DESCRIPTION
## Summary

- fix the exact-head automation reporter race observed on Version PR #1232: every substantive CI job passed, but the final reporter ran after merge/branch deletion and failed on `GET .../git/ref/heads/changeset-release/main` with HTTP 404
- preserve the existing open-PR terminal identity check
- when completion races a merge, accept success only after proving the same bot-authored PR/base/head, one-commit candidate, identical landed tree, and valid squash/rebase or merge parent topology

## Proof

- positive: unchanged open Version PR completion succeeds
- positive: exact-tree merged Version PR completion succeeds after branch deletion
- planted negative: a merged commit whose tree differs from the admitted head marks the check failed and throws

## Validation

- `bun test scripts/check-release-pr-automation.test.ts` (69 pass, 0 fail)
- `bun run typecheck` (23 projects clean)
- `bun run lint` (0 warnings/errors)
- `bun run format:check`
- `git diff --check`

## No-Claim

This does not relax pre-merge admission, accept a missing branch by itself, accept an unmerged/foreign/moved PR, or claim broader release behavior beyond exact-head check completion.
