### PR TITLE
perf(ci): preserve service image layer reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1067,8 +1067,8 @@ jobs:
           build-args: |
             OPENGENI_SERVER_VERSION=sha-${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.event.pull_request.head.sha || github.sha }}
 
-  worker-image:
-    name: Build worker workload image
+  worker-web-images:
+    name: Build worker and web workload images
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
@@ -1077,6 +1077,7 @@ jobs:
       packages: write # push the immutable exact-main-SHA dogfood image; PR and automation runs remain build-only
     outputs:
       worker_digest: ${{ steps.worker_image.outputs.digest }}
+      web_digest: ${{ steps.web_image.outputs.digest }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -1111,36 +1112,6 @@ jobs:
           cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=min,scope=opengeni-ci-worker,ignore-error=true' || '' }}
           build-args: |
             OPENGENI_SERVER_VERSION=sha-${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.event.pull_request.head.sha || github.sha }}
-
-  web-image:
-    name: Build web workload image
-    needs: [automation-admission, plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write # push the immutable exact-main-SHA dogfood image; PR and automation runs remain build-only
-    outputs:
-      web_digest: ${{ steps.web_image.outputs.digest }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.automation_head_sha || github.event.pull_request.head.sha || github.sha }}
-          persist-credentials: false
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build web image
         id: web_image
@@ -1242,7 +1213,7 @@ jobs:
 
   images:
     name: Workload image builds
-    needs: [automation-admission, plan, api-image, worker-image, web-image, relay-image, sandbox-image]
+    needs: [automation-admission, plan, api-image, worker-web-images, relay-image, sandbox-image]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
     permissions:
@@ -1251,15 +1222,13 @@ jobs:
       - name: Require every workload image build
         env:
           API_IMAGE_RESULT: ${{ needs.api-image.result }}
-          WORKER_IMAGE_RESULT: ${{ needs.worker-image.result }}
-          WEB_IMAGE_RESULT: ${{ needs.web-image.result }}
+          WORKER_WEB_IMAGES_RESULT: ${{ needs.worker-web-images.result }}
           RELAY_IMAGE_RESULT: ${{ needs.relay-image.result }}
           SANDBOX_IMAGE_RESULT: ${{ needs.sandbox-image.result }}
         run: |
           set -euo pipefail
           test "$API_IMAGE_RESULT" = "success"
-          test "$WORKER_IMAGE_RESULT" = "success"
-          test "$WEB_IMAGE_RESULT" = "success"
+          test "$WORKER_WEB_IMAGES_RESULT" = "success"
           test "$RELAY_IMAGE_RESULT" = "success"
           test "$SANDBOX_IMAGE_RESULT" = "success"
 
@@ -1272,8 +1241,8 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         env:
           API_DIGEST: ${{ needs.api-image.outputs.api_digest }}
-          WORKER_DIGEST: ${{ needs.worker-image.outputs.worker_digest }}
-          WEB_DIGEST: ${{ needs.web-image.outputs.web_digest }}
+          WORKER_DIGEST: ${{ needs.worker-web-images.outputs.worker_digest }}
+          WEB_DIGEST: ${{ needs.worker-web-images.outputs.web_digest }}
           SANDBOX_DIGEST: ${{ needs.sandbox-image.outputs.sandbox_digest }}
           RELAY_DIGEST: ${{ needs.relay-image.outputs.relay_digest }}
         run: |

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2826,7 +2826,7 @@ describe("workflow contracts", () => {
       "${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}",
     );
     expect(ci.jobs.images.if).toBe(ci.jobs.deployment.if);
-    const imageLeaves = ["api-image", "worker-image", "web-image", "relay-image", "sandbox-image"];
+    const imageLeaves = ["api-image", "worker-web-images", "relay-image", "sandbox-image"];
     for (const jobName of imageLeaves) expect(ci.jobs[jobName].if).toBe(ci.jobs.deployment.if);
     const imageSteps = imageLeaves.flatMap((jobName) =>
       ci.jobs[jobName].steps.filter((candidate: any) => candidate.with?.push),
@@ -2860,8 +2860,7 @@ describe("workflow contracts", () => {
       "test",
       "deployment",
       "api-image",
-      "worker-image",
-      "web-image",
+      "worker-web-images",
       "relay-image",
       "sandbox-image",
       "images",

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -156,7 +156,7 @@ describe("release image workflow contract", () => {
       >;
     };
 
-    const leafNames = ["api-image", "worker-image", "web-image", "relay-image", "sandbox-image"];
+    const leafNames = ["api-image", "worker-web-images", "relay-image", "sandbox-image"];
     for (const jobName of leafNames) {
       expect(parsed.jobs[jobName]?.needs).toEqual(["automation-admission", "plan"]);
     }
@@ -165,8 +165,7 @@ describe("release image workflow contract", () => {
       "automation-admission",
       "plan",
       "api-image",
-      "worker-image",
-      "web-image",
+      "worker-web-images",
       "relay-image",
       "sandbox-image",
     ]);
@@ -174,7 +173,7 @@ describe("release image workflow contract", () => {
       expect(parsed.jobs[jobName]?.if).toBe(parsed.jobs["api-image"]?.if);
     }
     expect(parsed.jobs.images?.if).toBe(parsed.jobs["api-image"]?.if);
-    expect(images.match(/packages: write/g)).toHaveLength(5);
+    expect(images.match(/packages: write/g)).toHaveLength(4);
     for (const jobName of leafNames) {
       const login = parsed.jobs[jobName]?.steps?.find((step) => step.name === "Log in to GHCR");
       expect(login?.with).toEqual({
@@ -185,8 +184,7 @@ describe("release image workflow contract", () => {
     }
     expect(images).toContain("Require every workload image build");
     expect(images).toContain("API_IMAGE_RESULT: ${{ needs.api-image.result }}");
-    expect(images).toContain("WORKER_IMAGE_RESULT: ${{ needs.worker-image.result }}");
-    expect(images).toContain("WEB_IMAGE_RESULT: ${{ needs.web-image.result }}");
+    expect(images).toContain("WORKER_WEB_IMAGES_RESULT: ${{ needs.worker-web-images.result }}");
     expect(images).toContain("RELAY_IMAGE_RESULT: ${{ needs.relay-image.result }}");
     expect(images).toContain("SANDBOX_IMAGE_RESULT: ${{ needs.sandbox-image.result }}");
     const aggregate = parsed.jobs.images?.steps?.find(
@@ -194,8 +192,7 @@ describe("release image workflow contract", () => {
     );
     expect(aggregate?.env).toEqual({
       API_IMAGE_RESULT: "${{ needs.api-image.result }}",
-      WORKER_IMAGE_RESULT: "${{ needs.worker-image.result }}",
-      WEB_IMAGE_RESULT: "${{ needs.web-image.result }}",
+      WORKER_WEB_IMAGES_RESULT: "${{ needs.worker-web-images.result }}",
       RELAY_IMAGE_RESULT: "${{ needs.relay-image.result }}",
       SANDBOX_IMAGE_RESULT: "${{ needs.sandbox-image.result }}",
     });
@@ -204,16 +201,15 @@ describe("release image workflow contract", () => {
         env: {
           ...process.env,
           API_IMAGE_RESULT: results[0],
-          WORKER_IMAGE_RESULT: results[1],
-          WEB_IMAGE_RESULT: results[2],
-          RELAY_IMAGE_RESULT: results[3],
-          SANDBOX_IMAGE_RESULT: results[4],
+          WORKER_WEB_IMAGES_RESULT: results[1],
+          RELAY_IMAGE_RESULT: results[2],
+          SANDBOX_IMAGE_RESULT: results[3],
         },
       }).exitCode;
-    expect(aggregateResult("success", "success", "success", "success", "success")).toBe(0);
+    expect(aggregateResult("success", "success", "success", "success")).toBe(0);
     for (const result of ["failure", "skipped", "cancelled", ""]) {
-      for (let index = 0; index < 5; index += 1) {
-        const results = Array(5).fill("success") as string[];
+      for (let index = 0; index < 4; index += 1) {
+        const results = Array(4).fill("success") as string[];
         results[index] = result;
         expect(aggregateResult(...results)).not.toBe(0);
       }
@@ -226,8 +222,8 @@ describe("release image workflow contract", () => {
     expect(images).toContain("Write exact-main-SHA dogfood receipt");
     expect(images).toContain("Upload exact-main-SHA dogfood receipt");
     expect(images).toContain("API_DIGEST: ${{ needs.api-image.outputs.api_digest }}");
-    expect(images).toContain("WORKER_DIGEST: ${{ needs.worker-image.outputs.worker_digest }}");
-    expect(images).toContain("WEB_DIGEST: ${{ needs.web-image.outputs.web_digest }}");
+    expect(images).toContain("WORKER_DIGEST: ${{ needs.worker-web-images.outputs.worker_digest }}");
+    expect(images).toContain("WEB_DIGEST: ${{ needs.worker-web-images.outputs.web_digest }}");
     expect(images).toContain("RELAY_DIGEST: ${{ needs.relay-image.outputs.relay_digest }}");
     expect(images).toContain("SANDBOX_DIGEST: ${{ needs.sandbox-image.outputs.sandbox_digest }}");
     expect(images).toContain('--arg tag "dogfood-sha-${GITHUB_SHA}"');
@@ -574,25 +570,20 @@ ${parser}`,
     expect(imagesJob).toContain("docker/setup-qemu-action@");
     expect(imagesJob.match(/platforms: linux\/amd64,linux\/arm64/g)).toHaveLength(5);
 
-    const imageSteps = [
-      "api-image",
-      "worker-image",
-      "web-image",
-      "relay-image",
-      "sandbox-image",
-    ].flatMap((jobName) =>
-      parsed.jobs[jobName]!.steps.filter(
-        (step): step is { name: string; uses: string; with: Record<string, string> } =>
-          typeof step === "object" &&
-          step !== null &&
-          "uses" in step &&
-          step.uses === "docker/build-push-action@v7.3.0",
-      ).map((step) => ({
-        jobName,
-        name: step.name,
-        step,
-        fingerprint: createHash("sha256").update(JSON.stringify(step)).digest("hex"),
-      })),
+    const imageSteps = ["api-image", "worker-web-images", "relay-image", "sandbox-image"].flatMap(
+      (jobName) =>
+        parsed.jobs[jobName]!.steps.filter(
+          (step): step is { name: string; uses: string; with: Record<string, string> } =>
+            typeof step === "object" &&
+            step !== null &&
+            "uses" in step &&
+            step.uses === "docker/build-push-action@v7.3.0",
+        ).map((step) => ({
+          jobName,
+          name: step.name,
+          step,
+          fingerprint: createHash("sha256").update(JSON.stringify(step)).digest("hex"),
+        })),
     );
     expect(imageSteps.map(({ step: _step, ...identity }) => identity)).toEqual([
       {
@@ -601,12 +592,12 @@ ${parser}`,
         fingerprint: "92035198e8acb29ffa33ae46602f0f4cbe3332e18257cb3bd8582538db3e16dd",
       },
       {
-        jobName: "worker-image",
+        jobName: "worker-web-images",
         name: "Build worker image",
         fingerprint: "8562ea25e72c99df48b2f2150cf9bcbb5a13b39633a5cb4e2648521e24840f67",
       },
       {
-        jobName: "web-image",
+        jobName: "worker-web-images",
         name: "Build web image",
         fingerprint: "641ae5f4c76a62fe3d3f2e42cea03cd5514d6db906be3d824f9e602b0955cc9f",
       },


### PR DESCRIPTION
## OPE-27: preserve worker→web layer reuse on the parallel image path

### Scope

Base `c3cfd8680492fd2a8538d3971f188c0feb252a9a` already ran API, worker, web, relay, and sandbox image work as separate plan-gated jobs. This PR made one narrow correction:

- keep API, relay, and sandbox in their independent jobs
- combine the unchanged worker and web build steps in `worker-web-images`
- retain the existing `plan`/impact conditions, automation admission, exact-head checkout, multi-architecture coverage, cache scopes, tags, digests, and direct fail-closed outer aggregate

There is no intermediate service aggregate and no change to the resource-bounded delivery planner.

### Why worker and web share one builder

Baseline run `31303010122` completed in 476s / 2,975 runner-seconds. Its serial API/worker/web lane was 465s, with worker at 108s and web at 61s.

A rejected three-isolated-builder experiment at head `8abcbc44f41051c5e61276b0f8482f6d7915fba5` completed green in run `31303934510` at 408s / 3,379 runner-seconds, but lost cross-target BuildKit reuse:

- worker: 222s
- web: 225s
- service builders plus aggregate: 859 runner-seconds

The corrected API + worker/web topology at older-base head `a5103983c7d6855b6f92588d2cfa9858aa921c5c` completed green in run `31304629136` at 391s / 3,194 runner-seconds:

- API builder: 331s
- worker+web builder: 301s
- worker build: 211s
- web build: 60s
- service-builder runner use: 636s

That correction restored worker→web local layer reuse and removed 223 service runner-seconds from the rejected topology.

### Final exact-base evidence

Run `31308706571` completed green at exact head `e027095c2ab50076044234140611bcf112bf5498` against current base `c3cfd8680492fd2a8538d3971f188c0feb252a9a`:

- required CI wall clock: 553s
- total CI runner use: 4,696 runner-seconds
- API builder: 349s
- worker+web builder: 382s
- worker build step: 278s
- web build step: 79s
- image aggregate: 5s, completed 132s before the run
- critical lanes: unit shard 1 at 511s and real-service shard 4 at 509s

The topology-specific signal is consistent across both corrected runs: web retained local reuse at 79s, versus 225s when worker and web used isolated BuildKit daemons. Images are no longer the critical lane.

The overall 553-second run remains above the repository-wide five-minute target. This PR closes the image-topology slice only; it does not claim the broader CI objective is complete.

### Detection preserved

The workflow contracts prove:

- exactly five physical multi-architecture image build steps remain
- exact build-step fingerprints, targets, tags, cache scopes, and push conditions remain unchanged
- all image jobs retain current plan/impact and automation-admission conditions
- worker and web share one checkout, QEMU setup, Buildx daemon, and GHCR login
- the direct outer aggregate fails closed unless API, worker+web, relay, and sandbox jobs all succeed
- worker and web digests still feed the exact-main-SHA dogfood receipt

The planted-negative aggregate matrix rejects `failure`, `skipped`, `cancelled`, and missing results for every required image job.

### Validation and merge

- exact-head CI: green (`31308706571`)
- affected workflow and impact contracts: 110 pass, 0 fail, 873 assertions
- full TypeScript graph: 24/24 projects clean
- full lint: 1,540 files, 0 warnings/errors
- touched formatting and `git diff --check`: clean
- squash merge: `2c6af5252ad412b9f5ede75291d78b99ca602522`

No changeset. No deployment.
