### PR TITLE
fix(react): restore code editor dirty tracking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -530,6 +530,8 @@
     "@openai/agents-core@0.14.3": "patches/@openai%2Fagents-core@0.14.3.patch",
   },
   "overrides": {
+    "@codemirror/state": "6.7.1",
+    "@codemirror/view": "6.43.6",
     "@grpc/grpc-js": "1.14.4",
     "dompurify": "3.4.12",
     "esbuild": "0.25.0",
@@ -790,7 +792,7 @@
 
     "@codemirror/search": ["@codemirror/search@6.7.1", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA=="],
 
-    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
+    "@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
 
     "@codemirror/theme-one-dark": ["@codemirror/theme-one-dark@6.1.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/highlight": "^1.0.0" } }, "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA=="],
 
@@ -3166,26 +3168,6 @@
 
     "@better-auth/utils/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
-    "@codemirror/autocomplete/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/commands/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/lang-html/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/lang-javascript/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/lang-markdown/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/language/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/lint/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/search/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/theme-one-dark/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/view/@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
-
     "@google-cloud/storage/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -3234,11 +3216,7 @@
 
     "@typespec/ts-http-runtime/http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
-    "@uiw/codemirror-extensions-basic-setup/@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
-
     "better-auth/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
-
-    "codemirror/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 

--- a/package.json
+++ b/package.json
@@ -144,6 +144,8 @@
     "typescript": "7.0.2"
   },
   "overrides": {
+    "@codemirror/state": "6.7.1",
+    "@codemirror/view": "6.43.6",
     "@grpc/grpc-js": "1.14.4",
     "dompurify": "3.4.12",
     "esbuild": "0.25.0",

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -9,6 +9,7 @@ const testFiles =
         "./test/e2e/connected-machine-removal.browser.e2e.ts",
         "./test/e2e/knowledge-surfaces.browser.e2e.ts",
         "./test/e2e/codex-overview.e2e.ts",
+        "./test/e2e/code-editor.browser.e2e.ts",
         "./test/e2e/queue-surface.browser.e2e.ts",
         "./test/e2e/react-compiled-css.browser.e2e.ts",
         "./test/e2e/react-demo-mobile.browser.e2e.ts",

--- a/test/e2e/code-editor.browser.e2e.ts
+++ b/test/e2e/code-editor.browser.e2e.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { chromium, type Browser, type Page } from "playwright";
+import { freePort, runCommand, startProcess, type StartedProcess } from "@opengeni/testing";
+
+const repoRoot = new URL("../..", import.meta.url).pathname;
+
+describe("sandbox code editor browser acceptance", () => {
+  let browser: Browser;
+  let demo: StartedProcess;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    const build = await runCommand(["bun", "run", "vite", "build", "demo"], {
+      cwd: `${repoRoot}/packages/react`,
+      timeoutMs: 45_000,
+    });
+    if (build.exitCode !== 0) {
+      throw new Error(`Workbench demo build failed:\n${build.stdout}\n${build.stderr}`);
+    }
+    const executablePath = existsSync("/usr/local/bin/chromium")
+      ? "/usr/local/bin/chromium"
+      : undefined;
+    browser = await chromium.launch(executablePath ? { executablePath } : undefined);
+    demo = await startProcess(
+      [
+        "bun",
+        "run",
+        "vite",
+        "preview",
+        "demo",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(port),
+        "--strictPort",
+      ],
+      {
+        cwd: `${repoRoot}/packages/react`,
+        ready: async () =>
+          (
+            await fetch(`${baseUrl}/workbench-dock.html`, {
+              signal: AbortSignal.timeout(2_000),
+            }).catch(() => null)
+          )?.ok === true,
+        timeoutMs: 45_000,
+      },
+    );
+  }, 60_000);
+
+  afterAll(async () => {
+    await Promise.allSettled([demo?.stop(), browser?.close()]);
+  }, 60_000);
+
+  test("real keyboard input marks the buffer dirty and save re-baselines it", async () => {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.stack ?? String(error)));
+    try {
+      const { editor, editable, save } = await openEditor(page, baseUrl);
+      expect(await editor.getAttribute("data-opengeni-editor-dirty")).toBe("false");
+      expect(await save.isDisabled()).toBe(true);
+
+      await editable.click();
+      await editable.press("Control+End");
+      await editable.press("Enter");
+      await editable.pressSequentially("ui edit persisted");
+
+      await waitForDirty(page, true);
+      expect(await editable.textContent()).toContain("ui edit persisted");
+      expect(await save.isDisabled()).toBe(false);
+
+      await save.click();
+      await waitForDirty(page, false);
+      await page.getByText("Saved", { exact: true }).waitFor();
+      expect(await save.isDisabled()).toBe(true);
+      expect(pageErrors).toEqual([]);
+    } finally {
+      await page.close();
+    }
+  });
+
+  test("undoing the same keyboard edit returns to the clean baseline", async () => {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.stack ?? String(error)));
+    try {
+      const { editable, save } = await openEditor(page, baseUrl);
+      await editable.click();
+      await editable.press("Control+End");
+      await editable.pressSequentially("x");
+      await waitForDirty(page, true);
+
+      await editable.press("Control+Z");
+      await waitForDirty(page, false);
+      expect(await save.isDisabled()).toBe(true);
+      expect(pageErrors).toEqual([]);
+    } finally {
+      await page.close();
+    }
+  });
+});
+
+async function openEditor(page: Page, baseUrl: string) {
+  await page.goto(`${baseUrl}/workbench-dock.html?state=warm-live&theme=dark&tab=files`, {
+    waitUntil: "networkidle",
+  });
+  const file = page.getByRole("treeitem").filter({ hasText: "README.md" }).first();
+  await file.getByRole("button").click();
+  const viewer = page.locator("#sandbox-files-viewer");
+  await viewer.getByRole("button", { name: "Edit", exact: true }).click();
+  const editor = viewer.locator("[data-opengeni-code-editor]");
+  const editable = editor.locator(".cm-content");
+  await editable.waitFor();
+  return {
+    editor,
+    editable,
+    save: editor.getByRole("button", { name: "Save", exact: true }),
+  };
+}
+
+async function waitForDirty(page: Page, dirty: boolean): Promise<void> {
+  await page.waitForFunction(
+    ({ selector, expected }) =>
+      document.querySelector(selector)?.getAttribute("data-opengeni-editor-dirty") === expected,
+    {
+      selector: "#sandbox-files-viewer [data-opengeni-code-editor]",
+      expected: dirty ? "true" : "false",
+    },
+    { timeout: 5_000 },
+  );
+}


### PR DESCRIPTION
## Summary

- force one compatible CodeMirror core graph (`@codemirror/state` 6.7.1 and `@codemirror/view` 6.43.6) across Bun's transitive resolution
- remove the package-local `state@6.6.0` / `view@6.43.6` split that made CodeMirror mutate the contenteditable DOM and then throw before UIW's `onChange`
- add focused production-bundle browser acceptance for real keyboard dirty tracking, Save re-baselining, and an undo-to-clean planted negative
- register the focused test in the standard browser acceptance runner

## Production evidence

- production version: `0.22.95`
- source: `80a6d5e85608d05fb0124a4c62bd0094685a270b`
- workflow run: `31301732552`
- artifact: `9035016105`
- artifact SHA-256: `0720eee3a8a0fb756a61888bf62fcf54183319bfbcb3bee3d55093a113d0f081`
- observed failure: step 28 timed out waiting for `data-opengeni-editor-dirty="true"` after `pressSequentially`
- local reproduction on current main: `.cm-content` visibly changed while CodeMirror threw `TypeError: Cannot read properties of undefined (reading 'length')`; dirty stayed false because the transaction never reached `onChange`

## Validation

Exact head `fff9ab4d1a43354049547e9e88c16b173e204035`:

- `bun install --frozen-lockfile`
- `bun test --timeout 30000 packages/react/test/code-editor-buffer.test.ts`
- `bun test --timeout 30000 packages/react/test/workspace-capture-hooks.test.tsx -t 'editor save detects live divergence and requires an explicit overwrite'`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check origin/main..HEAD`
- `bun scripts/run-browser-e2e.ts ./test/e2e/code-editor.browser.e2e.ts`

## No-Claim

This proves the production-built local workbench now receives real CodeMirror transactions, marks the exact edited buffer dirty, saves/re-baselines it, and returns clean on undo without browser exceptions. It does **not** claim production is deployed or verified; deployment remains with the production release train. It also does not change guarded-write semantics—the existing compare-and-swap conflict/explicit-overwrite tests remain the authority for that behavior.

Linear: OPE-180
