### PR TITLE
fix(react): enforce CodeMirror runtime singleton

### DIFF
--- a/.changeset/fix-codemirror-singletons.md
+++ b/.changeset/fix-codemirror-singletons.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Keep CodeMirror state and view on one compatible runtime instance so real editor input remains tracked and saveable.

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/lang-python": "^6.2.1",
+        "@codemirror/state": "^6.7.1",
         "@codemirror/view": "^6.43.6",
         "@pierre/trees": "1.0.0-beta.4",
         "@uiw/react-codemirror": "^4.25.11",
@@ -388,6 +389,8 @@
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/lang-python": "^6.2.1",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.6",
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@happy-dom/global-registrator": "^20.10.2",
@@ -421,6 +424,8 @@
         "@codemirror/lang-json": "^6.0.0",
         "@codemirror/lang-markdown": "^6.0.0",
         "@codemirror/lang-python": "^6.0.0",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.6",
         "@novnc/novnc": "^1.7.0",
         "@pierre/diffs": "^1.2.11",
         "@uiw/react-codemirror": "^4.23.0",
@@ -438,6 +443,8 @@
         "@codemirror/lang-json",
         "@codemirror/lang-markdown",
         "@codemirror/lang-python",
+        "@codemirror/state",
+        "@codemirror/view",
         "@novnc/novnc",
         "@pierre/diffs",
         "@uiw/react-codemirror",
@@ -530,6 +537,8 @@
     "@openai/agents-core@0.14.3": "patches/@openai%2Fagents-core@0.14.3.patch",
   },
   "overrides": {
+    "@codemirror/state": "6.7.1",
+    "@codemirror/view": "6.43.6",
     "@grpc/grpc-js": "1.14.4",
     "dompurify": "3.4.12",
     "esbuild": "0.25.0",
@@ -790,7 +799,7 @@
 
     "@codemirror/search": ["@codemirror/search@6.7.1", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA=="],
 
-    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
+    "@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
 
     "@codemirror/theme-one-dark": ["@codemirror/theme-one-dark@6.1.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/highlight": "^1.0.0" } }, "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA=="],
 
@@ -3166,26 +3175,6 @@
 
     "@better-auth/utils/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
-    "@codemirror/autocomplete/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/commands/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/lang-html/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/lang-javascript/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/lang-markdown/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/language/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/lint/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/search/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/theme-one-dark/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
-
-    "@codemirror/view/@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
-
     "@google-cloud/storage/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -3234,11 +3223,7 @@
 
     "@typespec/ts-http-runtime/http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
-    "@uiw/codemirror-extensions-basic-setup/@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
-
     "better-auth/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
-
-    "codemirror/@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.6",
     "@pierre/trees": "1.0.0-beta.4",
     "@uiw/react-codemirror": "^4.25.11"
@@ -144,6 +145,8 @@
     "typescript": "7.0.2"
   },
   "overrides": {
+    "@codemirror/state": "6.7.1",
+    "@codemirror/view": "6.43.6",
     "@grpc/grpc-js": "1.14.4",
     "dompurify": "3.4.12",
     "esbuild": "0.25.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -110,6 +110,8 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.6",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@happy-dom/global-registrator": "^20.10.2",
@@ -143,6 +145,8 @@
     "@codemirror/lang-json": "^6.0.0",
     "@codemirror/lang-markdown": "^6.0.0",
     "@codemirror/lang-python": "^6.0.0",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.6",
     "@novnc/novnc": "^1.7.0",
     "@pierre/diffs": "^1.2.11",
     "@uiw/react-codemirror": "^4.23.0",
@@ -170,6 +174,12 @@
       "optional": true
     },
     "@codemirror/lang-python": {
+      "optional": true
+    },
+    "@codemirror/state": {
+      "optional": true
+    },
+    "@codemirror/view": {
       "optional": true
     },
     "@novnc/novnc": {

--- a/test/e2e/workbench.browser.e2e.ts
+++ b/test/e2e/workbench.browser.e2e.ts
@@ -828,6 +828,44 @@ describe("workbench browser acceptance", () => {
     await context.close();
   });
 
+  test("real CodeMirror input marks the file editor dirty", async () => {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 960 } });
+    try {
+      const page = await context.newPage();
+      const pageErrors: string[] = [];
+      page.on("pageerror", (error) => pageErrors.push(error.stack ?? error.message));
+      await page.goto(dockUrl(baseUrl, "warm-live", "dark", "files"), {
+        waitUntil: "networkidle",
+      });
+      const file = page.getByRole("treeitem").filter({ hasText: "README.md" }).first();
+      await file.getByRole("button").click();
+      const fileViewer = page.locator("#sandbox-files-viewer");
+      await fileViewer.getByRole("button", { name: "Edit", exact: true }).click();
+      const editor = fileViewer.locator("[data-opengeni-code-editor]");
+      await editor.waitFor();
+      const editable = editor.locator(".cm-content");
+      await editable.waitFor();
+      expect(await editable.getAttribute("contenteditable")).toBe("true");
+
+      await editable.click();
+      await editable.press("Control+End");
+      await editable.press("Enter");
+      await editable.pressSequentially("ui edit marker");
+      await fileViewer
+        .locator('[data-opengeni-code-editor][data-opengeni-editor-dirty="true"]')
+        .waitFor({ timeout: 10_000 });
+      expect(await editable.textContent()).toContain("ui edit marker");
+      const save = editor.getByRole("button", { name: "Save", exact: true });
+      expect(await save.isEnabled()).toBe(true);
+      await save.click();
+      await editor.getByText("Saved", { exact: true }).waitFor({ timeout: 10_000 });
+      expect(await editor.getAttribute("data-opengeni-editor-dirty")).toBe("false");
+      expect(pageErrors).toEqual([]);
+    } finally {
+      await context.close().catch(() => undefined);
+    }
+  }, 30_000);
+
   test("file deletion uses an accessible non-blocking dialog on mobile", async () => {
     const context = await browser.newContext({
       viewport: { width: 320, height: 720 },


### PR DESCRIPTION
## Summary

- keep `@codemirror/state` and `@codemirror/view` on one compatible runtime instance
- declare both optional React package peers so consumers preserve the same graph
- exercise real CodeMirror typing, dirty state, and save behavior in browser acceptance

The split runtime graph allowed a CodeMirror state field to throw during document updates before the controlled `onChange` callback ran. The editor DOM changed, but the application buffer stayed clean and could not be saved.

## Verification

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:public-hygiene`
- `bun scripts/publish-closure-guard.ts`
- `bun run build:packages`
- `bun run test:unit` (6,858 pass, 29 skip, 0 fail)
- `bun test --max-concurrency=1 --timeout 180000 ./test/e2e/workbench.browser.e2e.ts` (13 pass)