### PR TITLE
chore(release): bump product version to 0.22.96

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules/
 .turbo/
 .vite/
 coverage/
+/impact-plan.json
+/ci-profile/
 tmp/
 *.tsbuildinfo
 bun.lockb

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.95
-appVersion: "0.22.95"
+version: 0.22.96
+appVersion: "0.22.96"

--- a/scripts/ci/impact.test.ts
+++ b/scripts/ci/impact.test.ts
@@ -323,6 +323,12 @@ describe("workflow fail-closed contracts", () => {
     expect(ci).toContain("changedCount:(.changedFiles|length)");
   });
 
+  test("CI-generated planning and profiling files stay outside source formatting", () => {
+    const ignorePatterns = readFileSync(".gitignore", "utf8").split("\n");
+    expect(ignorePatterns).toContain("/impact-plan.json");
+    expect(ignorePatterns).toContain("/ci-profile/");
+  });
+
   test("CI retains exact aggregate names and every current release/image lane", () => {
     const ci = readFileSync(".github/workflows/ci.yml", "utf8");
     expect(ci).toContain("name: Typecheck and unit tests");


### PR DESCRIPTION
Advances the canonical Helm product identity for the next immutable candidate. Both `version` and `appVersion` remain identical.

Also keeps generated CI impact/profile artifacts outside the source-format boundary. A one-file plan previously made the format guard inspect downloaded runtime evidence; the ignore contract and regression test now make that boundary explicit.

Validation:
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `oxfmt --check`
- `bun test scripts/ci/impact.test.ts scripts/release-version.test.ts scripts/release-image-workflow-contract.test.ts scripts/helm-upgrade-contract.test.ts` (50 pass)