### PR TITLE
chore(release): bump product version to 0.22.96

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ci-impact-plan
+          path: ${{ runner.temp }}/ci-impact-plan
 
       - name: Validate changeset release plan
         shell: bash
@@ -329,7 +330,8 @@ jobs:
           --name typecheck
           --output ci-profile/typecheck.json
           --timeout-seconds 600
-          -- bun scripts/ci/run-typecheck-plan.ts --plan impact-plan.json
+          -- bun scripts/ci/run-typecheck-plan.ts
+          --plan ${{ runner.temp }}/ci-impact-plan/impact-plan.json
 
       - name: Run exactly the explained source guards
         run: >-
@@ -338,7 +340,7 @@ jobs:
           --output ci-profile/guards.json
           --timeout-seconds 900
           -- bun scripts/ci/run-guards-plan.ts
-          --plan impact-plan.json
+          --plan ${{ runner.temp }}/ci-impact-plan/impact-plan.json
           --exclude publish-closure
 
       - name: Impact, resource, and profiling contracts

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.95
-appVersion: "0.22.95"
+version: 0.22.96
+appVersion: "0.22.96"

--- a/scripts/ci/impact.test.ts
+++ b/scripts/ci/impact.test.ts
@@ -321,6 +321,14 @@ describe("workflow fail-closed contracts", () => {
     expect(ci).toContain("bun scripts/ci/impact.ts --full --output impact-plan.json");
     expect(ci).not.toContain("jq . impact-plan.json");
     expect(ci).toContain("changedCount:(.changedFiles|length)");
+
+    const sourceContracts = ci.slice(
+      ci.indexOf("  source-contracts:"),
+      ci.indexOf("  unit-shards:"),
+    );
+    expect(sourceContracts).toContain("path: ${{ runner.temp }}/ci-impact-plan");
+    expect(sourceContracts).toContain("--plan ${{ runner.temp }}/ci-impact-plan/impact-plan.json");
+    expect(sourceContracts).not.toContain("--plan impact-plan.json");
   });
 
   test("CI retains exact aggregate names and every current release/image lane", () => {


### PR DESCRIPTION
Bump the canonical Helm chart and application product identity together for the verified 0.22.96 release train.\n\nValidation: release-version and chart-packaging contract tests.