### PR TITLE
fix(react): expose terminal input readiness

### DIFF
--- a/.changeset/terminal-interactive-readiness.md
+++ b/.changeset/terminal-interactive-readiness.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Expose semantic terminal readiness, prevent pre-connect focus from silently dropping keystrokes, and let browser automation wait for live PTY input.

--- a/packages/react/src/components/sandbox-terminal.tsx
+++ b/packages/react/src/components/sandbox-terminal.tsx
@@ -1,7 +1,15 @@
 import type { TerminalCapability } from "@opengeni/sdk";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import {
+  type FocusEvent as ReactFocusEvent,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { cn } from "../lib/cn";
-import { useTerminalStream } from "../hooks/use-terminal-stream";
+import { type TerminalStreamStatus, useTerminalStream } from "../hooks/use-terminal-stream";
 import type { UseSandboxTerminalResult } from "../hooks/use-sandbox-terminal";
 import { resolveTerminalFont, xtermThemeFromTokens } from "../lib/xterm-theme";
 import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
@@ -61,7 +69,7 @@ export type SandboxTerminalProps = {
   fontSize?: number | undefined;
   /**
    * Lease liveness (`cold` | `warming` | `warm` | `draining`). Drives the
-   * boot-in-terminal status lines: once the user has focused the terminal and
+   * boot-in-terminal status lines: once the user has engaged the terminal and
    * the box is not yet warm, a styled "● waking machine — Ns…" line is rendered
    * INSIDE xterm (no overlay/spinner) until the live PTY connects.
    */
@@ -110,6 +118,80 @@ type XtermLike = {
   };
 };
 type FitAddonLike = { fit: () => void };
+
+export type TerminalSurfaceState =
+  | "loading"
+  | "connecting"
+  | "error"
+  | "waking"
+  | "output-only"
+  | "interactive";
+
+/**
+ * Stable semantic state for hosts and browser acceptance. The xterm helper
+ * textarea exists before the live PTY socket is ready, so its presence alone
+ * must never be treated as proof that keystrokes can reach the sandbox.
+ */
+export function terminalSurfaceState(input: {
+  ready: boolean;
+  acceptsInput: boolean;
+  inputPending: boolean;
+  ptyStatus: TerminalStreamStatus;
+  booting: boolean;
+}): TerminalSurfaceState {
+  if (!input.ready) return "loading";
+  if (input.acceptsInput) return "interactive";
+  if (input.inputPending) return "connecting";
+  if (input.ptyStatus === "connecting") return "connecting";
+  if (input.ptyStatus === "error") return "error";
+  if (input.booting) return "waking";
+  return "output-only";
+}
+
+export function subscribeTerminalInput(
+  term: Pick<XtermLike, "onData"> | null,
+  sink: ((data: string) => void) | null,
+  enabled: boolean,
+): { dispose: () => void } | null {
+  if (!enabled || !term || !sink) return null;
+  return term.onData(sink);
+}
+
+export function terminalInputEngagementAllowed(input: {
+  acceptsInput: boolean;
+  readOnly: boolean;
+  ptyCapable: boolean;
+  ptyWs: boolean;
+  hasWrite: boolean;
+}): boolean {
+  const expectsInteractiveInput =
+    !input.readOnly && (input.ptyCapable || input.ptyWs || input.hasWrite);
+  return input.acceptsInput || !expectsInteractiveInput;
+}
+
+type TerminalEngagementEvent = {
+  preventDefault: () => void;
+  stopPropagation: () => void;
+  target?: unknown;
+};
+
+/**
+ * A pre-connect click still warms the terminal, but must not reach xterm and
+ * focus its hidden textarea. Otherwise the user's first keystrokes are accepted
+ * visually and then silently dropped while the PTY socket is still connecting.
+ */
+export function guardTerminalEngagement(
+  event: TerminalEngagementEvent,
+  inputAllowed: boolean,
+  blurTarget = false,
+): boolean {
+  if (inputAllowed) return false;
+  event.preventDefault();
+  event.stopPropagation();
+  const target = event.target as { blur?: unknown } | null | undefined;
+  if (blurTarget && typeof target?.blur === "function") target.blur();
+  return true;
+}
 
 /** Clear the transient wake line and put the first live prompt at cell 1,1.
  * `Terminal.clear()` removes scrollback but deliberately preserves the cursor,
@@ -194,6 +276,7 @@ export function SandboxTerminal({
   const wroteFirehoseRef = useRef(false);
   const bootActiveRef = useRef(false);
   const [ready, setReady] = useState(false);
+  const [inputReady, setInputReady] = useState(false);
   const [activated, setActivated] = useState(false);
 
   // ── Interactive transport switch ─────────────────────────────────────────────
@@ -224,17 +307,28 @@ export function SandboxTerminal({
   // read-only projection (or the legacy HTTP-write fallback).
   const ptyMode = ptyWs && ptyStatus !== "closed";
   const interactive = !readOnly && (ptyMode ? ptyConnected : result.write !== null);
-  const terminalModeLabel = interactive
+  const acceptsInput = interactive && inputReady;
+  const inputPending = interactive && !inputReady;
+  const inputEngagementAllowed = terminalInputEngagementAllowed({
+    acceptsInput,
+    readOnly: Boolean(readOnly),
+    ptyCapable: terminalCapability?.ptyCapable === true,
+    ptyWs,
+    hasWrite: result.write !== null,
+  });
+  const terminalModeLabel = acceptsInput
     ? null
     : readOnly
       ? "read-only"
-      : ptyMode && ptyStatus === "connecting"
+      : inputPending
         ? "connecting"
-        : ptyMode && ptyStatus === "error"
-          ? "connection error"
-          : "output only";
+        : ptyMode && ptyStatus === "connecting"
+          ? "connecting"
+          : ptyMode && ptyStatus === "error"
+            ? "connection error"
+            : "output only";
 
-  // Boot-in-terminal: after the user focuses a not-yet-warm box, show styled
+  // Boot-in-terminal: after the user engages a not-yet-warm box, show styled
   // status lines INSIDE xterm instead of an overlay — but only when there is no
   // firehose transcript to show yet (otherwise the projected output is shown).
   const warm = sandboxAcceptsLiveIo(liveness);
@@ -245,10 +339,31 @@ export function SandboxTerminal({
     liveness !== null &&
     liveness !== undefined &&
     result.chunks.length === 0;
+  const surfaceState = terminalSurfaceState({
+    ready,
+    acceptsInput,
+    inputPending,
+    ptyStatus,
+    booting,
+  });
 
   function handleActivate() {
     if (!activated) setActivated(true);
     onActivate?.();
+  }
+
+  function handlePointerDownCapture(event: ReactPointerEvent<HTMLDivElement>) {
+    handleActivate();
+    guardTerminalEngagement(event, inputEngagementAllowed);
+  }
+
+  function handleMouseDownCapture(event: ReactMouseEvent<HTMLDivElement>) {
+    guardTerminalEngagement(event, inputEngagementAllowed);
+  }
+
+  function handleFocusCapture(event: ReactFocusEvent<HTMLDivElement>) {
+    handleActivate();
+    guardTerminalEngagement(event, inputEngagementAllowed, true);
   }
 
   // Mount xterm once (client-only). Never re-mounts on interactive/theme flips —
@@ -460,11 +575,14 @@ export function SandboxTerminal({
   // socket; firehose mode uses the legacy ptyWrite-over-HTTP fn.
   useEffect(() => {
     const term = termRef.current;
-    if (!ready || !term || !interactive) return;
+    if (!ready || !term || !interactive) {
+      setInputReady(false);
+      return;
+    }
     const sink = ptyMode ? ptyWrite : result.write;
-    if (!sink) return;
-    const sub = term.onData((data) => sink(data));
-    return () => sub.dispose();
+    const sub = subscribeTerminalInput(term, sink, true);
+    setInputReady(sub !== null);
+    return () => sub?.dispose();
   }, [ready, interactive, ptyMode, ptyWrite, result.write]);
 
   // In PTY mode, tell ttyd the window size on the xterm resize event.
@@ -541,8 +659,9 @@ export function SandboxTerminal({
           12px inset + `--og-color-bg` ground match the dock surface. */}
       <div
         className="relative min-h-0 flex-1 bg-og-bg p-3"
-        onPointerDownCapture={handleActivate}
-        onFocusCapture={handleActivate}
+        onPointerDownCapture={handlePointerDownCapture}
+        onMouseDownCapture={handleMouseDownCapture}
+        onFocusCapture={handleFocusCapture}
       >
         {!ready && (placeholder ?? <TerminalPlaceholder />)}
         {/* Kept `visibility:hidden` until the first successful fit so the first
@@ -552,6 +671,9 @@ export function SandboxTerminal({
           className="h-full w-full"
           style={{ visibility: ready ? "visible" : "hidden" }}
           data-opengeni-terminal
+          data-opengeni-terminal-ready={ready ? "true" : "false"}
+          data-opengeni-terminal-interactive={surfaceState === "interactive" ? "true" : "false"}
+          data-opengeni-terminal-state={surfaceState}
         />
       </div>
     </div>

--- a/packages/react/test/sandbox-terminal.test.ts
+++ b/packages/react/test/sandbox-terminal.test.ts
@@ -18,7 +18,14 @@ import {
   resolveTerminalFontFromReader,
   type TokenReader,
 } from "../src/lib/xterm-theme";
-import { clearTerminalBootStatus, type XtermTheme } from "../src/components/sandbox-terminal";
+import {
+  clearTerminalBootStatus,
+  guardTerminalEngagement,
+  subscribeTerminalInput,
+  terminalInputEngagementAllowed,
+  terminalSurfaceState,
+  type XtermTheme,
+} from "../src/components/sandbox-terminal";
 
 const tick = () => new Promise<void>((r) => setTimeout(r, 0));
 
@@ -45,6 +52,181 @@ test("wake cleanup erases the transient line and homes the live prompt", () => {
   const writes: string[] = [];
   clearTerminalBootStatus({ write: (data) => writes.push(data) });
   expect(writes).toEqual(["\r\x1b[2K\x1b[2J\x1b[H"]);
+});
+
+describe("terminal semantic readiness", () => {
+  test("does not advertise interactivity before xterm is ready", () => {
+    expect(
+      terminalSurfaceState({
+        ready: false,
+        acceptsInput: true,
+        inputPending: false,
+        ptyStatus: "open",
+        booting: false,
+      }),
+    ).toBe("loading");
+  });
+
+  test("distinguishes transport and output-only states", () => {
+    expect(
+      terminalSurfaceState({
+        ready: true,
+        acceptsInput: false,
+        inputPending: false,
+        ptyStatus: "connecting",
+        booting: false,
+      }),
+    ).toBe("connecting");
+    expect(
+      terminalSurfaceState({
+        ready: true,
+        acceptsInput: false,
+        inputPending: false,
+        ptyStatus: "error",
+        booting: false,
+      }),
+    ).toBe("error");
+    expect(
+      terminalSurfaceState({
+        ready: true,
+        acceptsInput: false,
+        inputPending: false,
+        ptyStatus: "closed",
+        booting: true,
+      }),
+    ).toBe("waking");
+    expect(
+      terminalSurfaceState({
+        ready: true,
+        acceptsInput: false,
+        inputPending: false,
+        ptyStatus: "closed",
+        booting: false,
+      }),
+    ).toBe("output-only");
+  });
+
+  test("advertises interactivity only when the mounted terminal accepts stdin", () => {
+    expect(
+      terminalSurfaceState({
+        ready: true,
+        acceptsInput: true,
+        inputPending: false,
+        ptyStatus: "open",
+        booting: false,
+      }),
+    ).toBe("interactive");
+  });
+
+  test("pre-connect engagement does not focus, advertise, or send input", () => {
+    const calls: string[] = [];
+    let emit: ((data: string) => void) | undefined;
+    const term = {
+      onData(callback: (data: string) => void) {
+        emit = callback;
+        calls.push("subscribed");
+        return { dispose: () => calls.push("disposed") };
+      },
+    };
+    const sent: string[] = [];
+    const subscription = subscribeTerminalInput(term, (data) => sent.push(data), false);
+    const event = {
+      preventDefault: () => calls.push("prevented"),
+      stopPropagation: () => calls.push("stopped"),
+      target: { blur: () => calls.push("blurred") },
+    };
+
+    expect(subscription).toBeNull();
+    expect(
+      terminalSurfaceState({
+        ready: true,
+        acceptsInput: false,
+        inputPending: true,
+        ptyStatus: "open",
+        booting: false,
+      }),
+    ).toBe("connecting");
+    expect(guardTerminalEngagement(event, false, true)).toBe(true);
+    emit?.("lost input");
+    expect(sent).toEqual([]);
+    expect(calls).toEqual(["prevented", "stopped", "blurred"]);
+  });
+
+  test("post-connect engagement stays focusable and typed bytes reach the PTY sink", () => {
+    const calls: string[] = [];
+    let emit: ((data: string) => void) | undefined;
+    const term = {
+      onData(callback: (data: string) => void) {
+        emit = callback;
+        calls.push("subscribed");
+        return { dispose: () => calls.push("disposed") };
+      },
+    };
+    const sent: string[] = [];
+    const subscription = subscribeTerminalInput(term, (data) => sent.push(data), true);
+    const event = {
+      preventDefault: () => calls.push("prevented"),
+      stopPropagation: () => calls.push("stopped"),
+      target: { blur: () => calls.push("blurred") },
+    };
+
+    expect(subscription).not.toBeNull();
+    expect(
+      terminalSurfaceState({
+        ready: true,
+        acceptsInput: subscription !== null,
+        inputPending: false,
+        ptyStatus: "open",
+        booting: false,
+      }),
+    ).toBe("interactive");
+    expect(guardTerminalEngagement(event, true, true)).toBe(false);
+    emit?.("printf 'ready'\r");
+    expect(sent).toEqual(["printf 'ready'\r"]);
+    expect(calls).toEqual(["subscribed"]);
+    subscription?.dispose();
+    expect(calls).toEqual(["subscribed", "disposed"]);
+  });
+
+  test("permanent output-only capability still activates without blocking selection", () => {
+    const calls: string[] = [];
+    const event = {
+      preventDefault: () => calls.push("prevented"),
+      stopPropagation: () => calls.push("stopped"),
+      target: { blur: () => calls.push("blurred") },
+    };
+    calls.push("activated");
+    const inputAllowed = terminalInputEngagementAllowed({
+      acceptsInput: false,
+      readOnly: false,
+      ptyCapable: false,
+      ptyWs: false,
+      hasWrite: false,
+    });
+
+    expect(guardTerminalEngagement(event, inputAllowed, true)).toBe(false);
+    expect(calls).toEqual(["activated"]);
+  });
+
+  test("cold PTY-capable engagement activates warm-up but blocks pre-connect focus", () => {
+    const calls: string[] = [];
+    const event = {
+      preventDefault: () => calls.push("prevented"),
+      stopPropagation: () => calls.push("stopped"),
+      target: { blur: () => calls.push("blurred") },
+    };
+    calls.push("activated");
+    const inputAllowed = terminalInputEngagementAllowed({
+      acceptsInput: false,
+      readOnly: false,
+      ptyCapable: true,
+      ptyWs: false,
+      hasWrite: false,
+    });
+
+    expect(guardTerminalEngagement(event, inputAllowed, true)).toBe(true);
+    expect(calls).toEqual(["activated", "prevented", "stopped", "blurred"]);
+  });
 });
 
 // ── E1: renderer fallback ladder ─────────────────────────────────────────────

--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -27,6 +27,7 @@ import {
   selectTreeFile,
   validateCaptureApiRegionalProbeResult,
   waitForCold,
+  waitForInteractiveTerminal,
   waitForSandboxLiveness,
   waitForSandboxFileViewerText,
   waitForWarm,
@@ -34,6 +35,51 @@ import {
 } from "./workbench-live-acceptance";
 
 describe("workbench live acceptance preflight", () => {
+  test("waits for terminal interactivity before resolving the xterm input", async () => {
+    const calls: unknown[] = [];
+    const input = {
+      waitFor: async (options: { state: string; timeout: number }) => {
+        calls.push(["input.waitFor", options]);
+      },
+    };
+    const interactiveTerminal = {
+      waitFor: async (options: { state: string; timeout: number }) => {
+        calls.push(["interactive.waitFor", options]);
+      },
+      locator: (selector: string) => {
+        calls.push(["interactive.locator", selector]);
+        return input;
+      },
+    };
+    const terminal = {
+      waitFor: async (options: { state: string; timeout: number }) => {
+        calls.push(["terminal.waitFor", options]);
+      },
+      click: async () => {
+        calls.push(["terminal.click"]);
+      },
+    };
+    const page = {
+      locator: (selector: string) => {
+        calls.push(["page.locator", selector]);
+        return selector === "[data-opengeni-terminal]" ? terminal : interactiveTerminal;
+      },
+    } as never;
+
+    const resolved = await waitForInteractiveTerminal(page, 90_000);
+
+    expect(resolved).toBe(input as never);
+    expect(calls).toEqual([
+      ["page.locator", "[data-opengeni-terminal]"],
+      ["terminal.waitFor", { state: "visible", timeout: 90_000 }],
+      ["terminal.click"],
+      ["page.locator", '[data-opengeni-terminal][data-opengeni-terminal-interactive="true"]'],
+      ["interactive.waitFor", { state: "visible", timeout: 90_000 }],
+      ["interactive.locator", ".xterm-helper-textarea"],
+      ["input.waitFor", { state: "attached", timeout: 90_000 }],
+    ]);
+  });
+
   test("admits only concrete single-selector Axe targets to the manual contrast audit", () => {
     expect(axeManualContrastSelector(['button[class="bg-primary"]'])).toBe(
       'button[class="bg-primary"]',

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -45,6 +45,9 @@ const FILE_TREE_READY_SELECTOR =
 const FILE_TREE_MAX_NAVIGATION_STEPS = 4_096;
 const FILE_TREE_MAX_DIAGNOSTIC_ROWS = 8;
 const FILE_TREE_DIAGNOSTIC_FIELD_LENGTH = 80;
+const TERMINAL_SELECTOR = "[data-opengeni-terminal]";
+const INTERACTIVE_TERMINAL_SELECTOR =
+  '[data-opengeni-terminal][data-opengeni-terminal-interactive="true"]';
 const CAPTURE_API_P95_MS = maximumMillisecondBudget("performance.capture-api-response", "p95");
 const CAPTURE_USABLE_WORKBENCH_P95_MS = maximumMillisecondBudget(
   "performance.capture-usable-workbench",
@@ -1055,6 +1058,20 @@ export async function waitForWarm(
   );
 }
 
+export async function waitForInteractiveTerminal(
+  page: Pick<Page, "locator">,
+  timeoutMs = 90_000,
+): Promise<Locator> {
+  const terminal = page.locator(TERMINAL_SELECTOR);
+  await terminal.waitFor({ state: "visible", timeout: timeoutMs });
+  await terminal.click();
+  const interactiveTerminal = page.locator(INTERACTIVE_TERMINAL_SELECTOR);
+  await interactiveTerminal.waitFor({ state: "visible", timeout: timeoutMs });
+  const input = interactiveTerminal.locator(".xterm-helper-textarea");
+  await input.waitFor({ state: "attached", timeout: timeoutMs });
+  return input;
+}
+
 async function runLiveWorkspaceFlow(input: {
   browser: Browser;
   cookieHeader: string;
@@ -1196,8 +1213,7 @@ async function runLiveWorkspaceFlow(input: {
     );
 
     await page.getByRole("tab", { name: "Terminal", exact: true }).click();
-    const terminalInput = page.locator(".xterm-helper-textarea");
-    await terminalInput.waitFor({ timeout: 30_000 });
+    const terminalInput = await waitForInteractiveTerminal(page);
     await terminalInput.click();
     const terminalMarker = `TERMINAL_${marker}`;
     await page.keyboard.type(`printf '${terminalMarker}\\n'`);


### PR DESCRIPTION
## Summary

- expose stable terminal `loading`, `connecting`, `error`, `waking`, `output-only`, and `interactive` DOM states
- publish `interactive` only after xterm is mounted and its stdin sink is subscribed
- keep pre-connect engagement as a warm-up intent, but prevent it from focusing xterm or silently dropping a user's first keystrokes; permanent read-only/output-only terminals retain normal interaction via the explicit `ptyCapable` contract
- make live workbench acceptance activate a cold terminal, wait for semantic input readiness, then send and verify the deterministic terminal marker
- add paired pre-connect/post-connect input regressions and a patch Changeset for `@opengeni/react`

## Testing

- [x] `bun run typecheck`
- [x] `bun test packages/react/test/sandbox-terminal.test.ts scripts/workbench-live-acceptance.test.ts` (50 passed)
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run check:public-hygiene`
- [ ] `bun test` (earlier sandbox attempt: 6,601 passed, 7 skipped, 45 environment failures because Docker/PostgreSQL and `lsof` are unavailable; no terminal-readiness test failed)

## Notes

- This preserves interact-to-warm without input buffering: the first pre-connect engagement is consumed as activation, the visible state remains waking/connecting, and normal focus/input begins only after the live sink subscription exists.
- The prior `.xterm-helper-textarea` presence check was insufficient because xterm creates that element before the PTY websocket can accept input.
