### PR TITLE
fix(react): prevent Changes rail crash after live refresh

### DIFF
--- a/.changeset/calm-rails-reset.md
+++ b/.changeset/calm-rails-reset.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Preserve Changes rail focus and scroll while safely resetting virtualization after diff shrinks.

--- a/packages/react/src/components/workbench-changes.tsx
+++ b/packages/react/src/components/workbench-changes.tsx
@@ -345,7 +345,11 @@ export function WorkbenchChanges({
         <div className="flex min-h-0 flex-1">
           {/* File rail — virtualized (virtua): a dense change set is fine. */}
           <div className="w-[clamp(12rem,28%,15rem)] shrink-0 border-r border-og-border bg-og-surface-1/35">
+            {/* A capture-to-live refresh can shrink the rail before Virtua has
+                reconciled its cached visible range. Remount on count changes so
+                it never asks React for a now-out-of-range child. */}
             <VList
+              key={rows.length}
               className="h-full"
               itemSize={coarsePointer ? 44 : 28}
               ssrCount={Math.min(30, rows.length)}

--- a/packages/react/src/components/workbench-changes.tsx
+++ b/packages/react/src/components/workbench-changes.tsx
@@ -101,6 +101,7 @@ type ChangesRailVListProps = {
   children: ReactNode;
   className: string;
   coarsePointer: boolean;
+  files: readonly SandboxGitFileDiff[];
   rowCount: number;
 };
 
@@ -128,6 +129,7 @@ class ChangesRailVList extends Component<
 
   private host: HTMLDivElement | null = null;
   private listHandle: VListHandle | null = null;
+  private pendingFocusedPath: string | null = null;
   private restoreFrame: number | null = null;
 
   static getDerivedStateFromProps(
@@ -155,7 +157,7 @@ class ChangesRailVList extends Component<
         ? active.closest<HTMLElement>("[data-rail-file-path]")
         : null;
     return {
-      focusedPath: focusedRow?.dataset.railFilePath ?? null,
+      focusedPath: focusedRow?.dataset.railFilePath ?? this.pendingFocusedPath,
       scrollOffset: scroller.scrollTop,
     };
   }
@@ -170,24 +172,36 @@ class ChangesRailVList extends Component<
     const maxOffset = Math.max(0, this.listHandle.scrollSize - this.listHandle.viewportSize);
     this.listHandle.scrollTo(Math.min(Math.max(snapshot.scrollOffset, 0), maxOffset));
     const focusedPath = snapshot.focusedPath;
-    if (!focusedPath || this.restoreFocusedPath(focusedPath)) return;
-    if (typeof requestAnimationFrame === "function") {
-      this.restoreFrame = requestAnimationFrame(() => {
-        this.restoreFrame = null;
-        this.restoreFocusedPath(focusedPath);
-      });
-    }
+    if (!focusedPath) return;
+    this.pendingFocusedPath = focusedPath;
+    this.continueFocusRestore();
   }
 
   componentWillUnmount(): void {
     this.cancelRestoreFrame();
+    this.pendingFocusedPath = null;
   }
 
   private cancelRestoreFrame(): void {
-    if (this.restoreFrame === null || typeof cancelAnimationFrame !== "function") return;
-    cancelAnimationFrame(this.restoreFrame);
+    if (this.restoreFrame === null) return;
+    if (typeof cancelAnimationFrame === "function") cancelAnimationFrame(this.restoreFrame);
     this.restoreFrame = null;
   }
+
+  private continueFocusRestore = (): void => {
+    const path = this.pendingFocusedPath;
+    if (!path) return;
+    if (this.restoreFocusedPath(path)) {
+      this.pendingFocusedPath = null;
+      return;
+    }
+    if (this.restoreFrame === null && typeof requestAnimationFrame === "function") {
+      this.restoreFrame = requestAnimationFrame(() => {
+        this.restoreFrame = null;
+        this.continueFocusRestore();
+      });
+    }
+  };
 
   private restoreFocusedPath(path: string): boolean {
     const host = this.host;
@@ -196,6 +210,7 @@ class ChangesRailVList extends Component<
     if (active instanceof HTMLElement && active.isConnected && active !== document.body) {
       return true;
     }
+    if (!this.props.files.some((file) => file.path === path)) return true;
     const row = Array.from(host.querySelectorAll<HTMLButtonElement>("[data-rail-file-path]")).find(
       (candidate) => candidate.dataset.railFilePath === path,
     );
@@ -480,6 +495,7 @@ export function WorkbenchChanges({
           <ChangesRailVList
             rowCount={rows.length}
             coarsePointer={coarsePointer}
+            files={orderedFiles}
             className="w-[clamp(12rem,28%,15rem)] shrink-0 border-r border-og-border bg-og-surface-1/35"
           >
             {rows.map((row) =>

--- a/packages/react/src/components/workbench-changes.tsx
+++ b/packages/react/src/components/workbench-changes.tsx
@@ -1,6 +1,7 @@
 import type { GitFileDiff } from "@opengeni/sdk";
 import { ArrowUpRightIcon, FileWarningIcon, HistoryIcon } from "lucide-react";
 import {
+  Component,
   type ReactNode,
   useCallback,
   useEffect,
@@ -10,7 +11,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { VList } from "virtua";
+import { VList, type VListHandle } from "virtua";
 import { cn } from "../lib/cn";
 import { useUnicodeFallbackFonts } from "../lib/use-unicode-fonts";
 import { useThemeType } from "../lib/use-theme-type";
@@ -95,6 +96,138 @@ export type WorkbenchChangesProps = {
 type RailRow =
   | { kind: "group"; label: string; count: number }
   | { kind: "file"; file: SandboxGitFileDiff; index: number };
+
+type ChangesRailVListProps = {
+  children: ReactNode;
+  className: string;
+  coarsePointer: boolean;
+  rowCount: number;
+};
+
+type ChangesRailVListState = {
+  renderedRowCount: number;
+  resetVersion: number;
+};
+
+type ChangesRailSnapshot = {
+  focusedPath: string | null;
+  scrollOffset: number;
+};
+
+/** Virtua must reset its cached range when the rail shrinks. Keep that remount
+ * scoped to shrink transitions and preserve the reader's focus/scroll context. */
+class ChangesRailVList extends Component<
+  ChangesRailVListProps,
+  ChangesRailVListState,
+  ChangesRailSnapshot | null
+> {
+  state: ChangesRailVListState = {
+    renderedRowCount: this.props.rowCount,
+    resetVersion: 0,
+  };
+
+  private host: HTMLDivElement | null = null;
+  private listHandle: VListHandle | null = null;
+  private restoreFrame: number | null = null;
+
+  static getDerivedStateFromProps(
+    props: ChangesRailVListProps,
+    state: ChangesRailVListState,
+  ): ChangesRailVListState | null {
+    if (props.rowCount === state.renderedRowCount) return null;
+    return {
+      renderedRowCount: props.rowCount,
+      resetVersion:
+        props.rowCount < state.renderedRowCount ? state.resetVersion + 1 : state.resetVersion,
+    };
+  }
+
+  getSnapshotBeforeUpdate(
+    _previousProps: ChangesRailVListProps,
+    previousState: ChangesRailVListState,
+  ): ChangesRailSnapshot | null {
+    if (previousState.resetVersion === this.state.resetVersion) return null;
+    const scroller = this.host?.firstElementChild;
+    if (!(scroller instanceof HTMLElement)) return null;
+    const active = document.activeElement;
+    const focusedRow =
+      active instanceof HTMLElement && scroller.contains(active)
+        ? active.closest<HTMLElement>("[data-rail-file-path]")
+        : null;
+    return {
+      focusedPath: focusedRow?.dataset.railFilePath ?? null,
+      scrollOffset: scroller.scrollTop,
+    };
+  }
+
+  componentDidUpdate(
+    _previousProps: ChangesRailVListProps,
+    _previousState: ChangesRailVListState,
+    snapshot: ChangesRailSnapshot | null,
+  ): void {
+    if (!snapshot || !this.listHandle) return;
+    this.cancelRestoreFrame();
+    const maxOffset = Math.max(0, this.listHandle.scrollSize - this.listHandle.viewportSize);
+    this.listHandle.scrollTo(Math.min(Math.max(snapshot.scrollOffset, 0), maxOffset));
+    const focusedPath = snapshot.focusedPath;
+    if (!focusedPath || this.restoreFocusedPath(focusedPath)) return;
+    if (typeof requestAnimationFrame === "function") {
+      this.restoreFrame = requestAnimationFrame(() => {
+        this.restoreFrame = null;
+        this.restoreFocusedPath(focusedPath);
+      });
+    }
+  }
+
+  componentWillUnmount(): void {
+    this.cancelRestoreFrame();
+  }
+
+  private cancelRestoreFrame(): void {
+    if (this.restoreFrame === null || typeof cancelAnimationFrame !== "function") return;
+    cancelAnimationFrame(this.restoreFrame);
+    this.restoreFrame = null;
+  }
+
+  private restoreFocusedPath(path: string): boolean {
+    const host = this.host;
+    if (!host) return true;
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && active.isConnected && active !== document.body) {
+      return true;
+    }
+    const row = Array.from(host.querySelectorAll<HTMLButtonElement>("[data-rail-file-path]")).find(
+      (candidate) => candidate.dataset.railFilePath === path,
+    );
+    if (!row) return false;
+    row.focus({ preventScroll: true });
+    return true;
+  }
+
+  private setHost = (host: HTMLDivElement | null): void => {
+    this.host = host;
+  };
+
+  private setListHandle = (handle: VListHandle | null): void => {
+    this.listHandle = handle;
+  };
+
+  render() {
+    return (
+      <div ref={this.setHost} data-opengeni-changes-rail className={this.props.className}>
+        <VList
+          key={this.state.resetVersion}
+          ref={this.setListHandle}
+          className="h-full"
+          itemSize={this.props.coarsePointer ? 44 : 28}
+          ssrCount={Math.min(30, this.props.rowCount)}
+        >
+          {this.props.children}
+        </VList>
+      </div>
+    );
+  }
+}
 
 /** Order the files and build the rail rows (grouped past the threshold). The
  *  returned `orderedFiles` drives BOTH the rail and the diff pane so a rail row's
@@ -344,38 +477,32 @@ export function WorkbenchChanges({
       ) : (
         <div className="flex min-h-0 flex-1">
           {/* File rail — virtualized (virtua): a dense change set is fine. */}
-          <div className="w-[clamp(12rem,28%,15rem)] shrink-0 border-r border-og-border bg-og-surface-1/35">
-            {/* A capture-to-live refresh can shrink the rail before Virtua has
-                reconciled its cached visible range. Remount on count changes so
-                it never asks React for a now-out-of-range child. */}
-            <VList
-              key={rows.length}
-              className="h-full"
-              itemSize={coarsePointer ? 44 : 28}
-              ssrCount={Math.min(30, rows.length)}
-            >
-              {rows.map((row) =>
-                row.kind === "group" ? (
-                  <div
-                    key={`g:${row.label}`}
-                    data-rail-group
-                    className="flex items-center gap-1.5 px-2 pb-0.5 pt-2 text-og-xs font-medium uppercase tracking-wide text-og-fg-subtle"
-                  >
-                    <span className="min-w-0 truncate">{row.label}</span>
-                    <span className="shrink-0">{row.count}</span>
-                  </div>
-                ) : (
-                  <RailFileRow
-                    key={row.file.path}
-                    file={row.file}
-                    grouped={grouped}
-                    active={row.index === activeIndex}
-                    onClick={() => jumpTo(row.index)}
-                  />
-                ),
-              )}
-            </VList>
-          </div>
+          <ChangesRailVList
+            rowCount={rows.length}
+            coarsePointer={coarsePointer}
+            className="w-[clamp(12rem,28%,15rem)] shrink-0 border-r border-og-border bg-og-surface-1/35"
+          >
+            {rows.map((row) =>
+              row.kind === "group" ? (
+                <div
+                  key={`g:${row.label}`}
+                  data-rail-group
+                  className="flex items-center gap-1.5 px-2 pb-0.5 pt-2 text-og-xs font-medium uppercase tracking-wide text-og-fg-subtle"
+                >
+                  <span className="min-w-0 truncate">{row.label}</span>
+                  <span className="shrink-0">{row.count}</span>
+                </div>
+              ) : (
+                <RailFileRow
+                  key={row.file.path}
+                  file={row.file}
+                  grouped={grouped}
+                  active={row.index === activeIndex}
+                  onClick={() => jumpTo(row.index)}
+                />
+              ),
+            )}
+          </ChangesRailVList>
 
           {/* Diff pane — windowed file sections. Only the sections inside the
             visible window ± overscan are in the DOM; the container reserves the
@@ -483,6 +610,7 @@ function RailFileRow({
       onClick={onClick}
       title={file.path}
       data-rail-file
+      data-rail-file-path={file.path}
       className={cn(
         "relative flex min-h-7 w-full items-center gap-1.5 truncate px-2 py-0.5 text-left text-og-sm transition-colors hover:bg-og-surface-2 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-og-accent pointer-coarse:min-h-11",
         grouped && "pl-3",

--- a/packages/react/test/file-browser-virtualization.test.tsx
+++ b/packages/react/test/file-browser-virtualization.test.tsx
@@ -43,6 +43,28 @@ function filesResult(
 }
 
 describe("FileBrowser virtualization", () => {
+  test("a large tree can shrink below the virtualization threshold", async () => {
+    const largeTree: FileTreeNode[] = Array.from({ length: 600 }, (_, index) => ({
+      path: `file-${index}.ts`,
+      name: `file-${index}.ts`,
+      kind: "file" as const,
+    }));
+    const smallTree: FileTreeNode[] = [
+      { path: "README.md", name: "README.md", kind: "file" as const },
+    ];
+    const r = await renderComponent(
+      <FileBrowser result={filesResult(largeTree)} editable={false} />,
+    );
+    await flush();
+
+    await r.rerender(<FileBrowser result={filesResult(smallTree)} editable={false} />);
+    await flush();
+
+    expect(r.container.textContent).toContain("README.md");
+    expect(r.container.querySelectorAll('[role="treeitem"]')).toHaveLength(1);
+    await r.unmount();
+  });
+
   test("the composite tree exposes its active descendant and complete boundary navigation", async () => {
     const tree: FileTreeNode[] = Array.from({ length: 20 }, (_, index) => ({
       path: `file-${String(index).padStart(2, "0")}.ts`,

--- a/packages/react/test/workbench-changes.test.tsx
+++ b/packages/react/test/workbench-changes.test.tsx
@@ -79,6 +79,20 @@ describe("WorkbenchChanges — windowing (D2)", () => {
 });
 
 describe("WorkbenchChanges — rail, badge, guard", () => {
+  test("the virtual rail survives a captured-to-live list shrink", async () => {
+    const r = await renderComponent(
+      <WorkbenchChanges diff={manyFiles(40)} source="capture" capturedAt="2026-08-09T12:00:00Z" />,
+    );
+    await flush();
+
+    await r.rerender(<WorkbenchChanges diff={manyFiles(1)} source="live" capturedAt={null} />);
+    await flush();
+
+    expect(container(r).textContent).toContain("file-000.ts");
+    expect(container(r).querySelectorAll("[data-rail-file]")).toHaveLength(1);
+    await r.unmount();
+  });
+
   test("a compact surface replaces the cramped rail with a full-width file picker", async () => {
     const original = globalThis.ResizeObserver;
     class CompactResizeObserver {

--- a/packages/react/test/workbench-changes.test.tsx
+++ b/packages/react/test/workbench-changes.test.tsx
@@ -49,6 +49,54 @@ function changesRailScroller(root: HTMLElement): HTMLElement {
   return scroller;
 }
 
+function controlAnimationFrames() {
+  const originalRequest = globalThis.requestAnimationFrame;
+  const originalCancel = globalThis.cancelAnimationFrame;
+  const frames = new Map<number, FrameRequestCallback>();
+  let nextFrame = 1;
+  globalThis.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+    const frame = nextFrame++;
+    frames.set(frame, callback);
+    return frame;
+  };
+  globalThis.cancelAnimationFrame = (frame: number): void => {
+    frames.delete(frame);
+  };
+  return {
+    async runNextBatch() {
+      const callbacks = [...frames.values()];
+      frames.clear();
+      await act(async () => {
+        for (const callback of callbacks) callback(performance.now());
+      });
+    },
+    restore() {
+      globalThis.requestAnimationFrame = originalRequest;
+      globalThis.cancelAnimationFrame = originalCancel;
+    },
+  };
+}
+
+/** Make the same surviving path look temporarily unmounted to the focus
+ * restorer, as it is while Virtua catches up to a restored scroll offset. */
+function hideRailPathQueries(host: HTMLElement, count: number): () => void {
+  const querySelectorAll = host.querySelectorAll.bind(host);
+  let remaining = count;
+  Object.defineProperty(host, "querySelectorAll", {
+    configurable: true,
+    value: ((selectors: string) => {
+      if (selectors === "[data-rail-file-path]" && remaining > 0) {
+        remaining -= 1;
+        return document.createElement("div").querySelectorAll(selectors);
+      }
+      return querySelectorAll(selectors);
+    }) as typeof host.querySelectorAll,
+  });
+  return () => {
+    Reflect.deleteProperty(host, "querySelectorAll");
+  };
+}
+
 describe("WorkbenchChanges — windowing (D2)", () => {
   test("a 40-file change set mounts a BOUNDED window, not all 40 sections", async () => {
     const r = await renderComponent(
@@ -137,6 +185,71 @@ describe("WorkbenchChanges — rail, badge, guard", () => {
     expect(changesRailScroller(container(r))).toBe(afterScroller);
     expect(document.activeElement).toBe(afterFocused);
     await r.unmount();
+  });
+
+  test("consecutive shrink resets carry a pending same-row focus restore", async () => {
+    const r = await renderComponent(
+      <WorkbenchChanges diff={manyFiles(80)} source="live" capturedAt={null} />,
+    );
+    await flush();
+    const host = container(r).querySelector<HTMLElement>("[data-opengeni-changes-rail]");
+    const focused = container(r).querySelector<HTMLButtonElement>(
+      '[data-rail-file-path="src/file-000.ts"]',
+    );
+    expect(host).not.toBeNull();
+    focused?.focus();
+
+    const frames = controlAnimationFrames();
+    const restoreQueries = hideRailPathQueries(host!, 2);
+    try {
+      await r.rerender(<WorkbenchChanges diff={manyFiles(79)} source="live" capturedAt={null} />);
+      await r.rerender(<WorkbenchChanges diff={manyFiles(78)} source="live" capturedAt={null} />);
+      restoreQueries();
+      await frames.runNextBatch();
+
+      expect(document.activeElement?.getAttribute("data-rail-file-path")).toBe("src/file-000.ts");
+    } finally {
+      restoreQueries();
+      await r.unmount();
+      frames.restore();
+    }
+  });
+
+  test("deferred rail focus restoration yields permanently to external focus", async () => {
+    const r = await renderComponent(
+      <WorkbenchChanges diff={manyFiles(80)} source="live" capturedAt={null} />,
+    );
+    await flush();
+    const host = container(r).querySelector<HTMLElement>("[data-opengeni-changes-rail]");
+    const focused = container(r).querySelector<HTMLButtonElement>(
+      '[data-rail-file-path="src/file-000.ts"]',
+    );
+    expect(host).not.toBeNull();
+    focused?.focus();
+
+    const external = document.createElement("button");
+    document.body.appendChild(external);
+    const frames = controlAnimationFrames();
+    const restoreQueries = hideRailPathQueries(host!, 1);
+    try {
+      await r.rerender(<WorkbenchChanges diff={manyFiles(79)} source="live" capturedAt={null} />);
+      restoreQueries();
+      external.focus();
+      await frames.runNextBatch();
+      expect(document.activeElement).toBe(external);
+
+      external.blur();
+      await r.rerender(<WorkbenchChanges diff={manyFiles(78)} source="live" capturedAt={null} />);
+      await frames.runNextBatch();
+      expect(document.activeElement?.getAttribute("data-rail-file-path")).not.toBe(
+        "src/file-000.ts",
+      );
+    } finally {
+      restoreQueries();
+      external.remove();
+      await r.unmount();
+      frames.restore();
+    }
   });
 
   test("a shrink reset does not focus a different row when the focused file disappears", async () => {

--- a/packages/react/test/workbench-changes.test.tsx
+++ b/packages/react/test/workbench-changes.test.tsx
@@ -43,6 +43,12 @@ function mountedIndices(root: HTMLElement): number[] {
     .sort((a, b) => a - b);
 }
 
+function changesRailScroller(root: HTMLElement): HTMLElement {
+  const scroller = root.querySelector("[data-opengeni-changes-rail]")?.firstElementChild;
+  if (!(scroller instanceof HTMLElement)) throw new Error("Changes rail scroller was not mounted");
+  return scroller;
+}
+
 describe("WorkbenchChanges — windowing (D2)", () => {
   test("a 40-file change set mounts a BOUNDED window, not all 40 sections", async () => {
     const r = await renderComponent(
@@ -85,11 +91,68 @@ describe("WorkbenchChanges — rail, badge, guard", () => {
     );
     await flush();
 
+    const beforeScroller = changesRailScroller(container(r));
+    const beforeFocused = container(r).querySelector<HTMLButtonElement>("[data-rail-file]");
+    beforeScroller.scrollTop = 196;
+    beforeFocused?.focus();
+
     await r.rerender(<WorkbenchChanges diff={manyFiles(1)} source="live" capturedAt={null} />);
     await flush();
 
+    const afterScroller = changesRailScroller(container(r));
+    const afterFocused = container(r).querySelector<HTMLButtonElement>("[data-rail-file]");
+    expect(afterScroller).not.toBe(beforeScroller);
+    expect(afterScroller.scrollTop).toBeLessThanOrEqual(28);
+    expect(document.activeElement).toBe(afterFocused);
     expect(container(r).textContent).toContain("file-000.ts");
     expect(container(r).querySelectorAll("[data-rail-file]")).toHaveLength(1);
+    await r.unmount();
+  });
+
+  test("a shrink reset preserves a surviving focused row and rail scroll", async () => {
+    const r = await renderComponent(
+      <WorkbenchChanges diff={manyFiles(80)} source="live" capturedAt={null} />,
+    );
+    await flush();
+
+    const beforeScroller = changesRailScroller(container(r));
+    const beforeFocused = container(r).querySelector<HTMLButtonElement>("[data-rail-file]");
+    expect(beforeFocused?.dataset.railFilePath).toBe("src/file-000.ts");
+    beforeFocused?.focus();
+    beforeScroller.scrollTop = 196;
+
+    await r.rerender(<WorkbenchChanges diff={manyFiles(79)} source="live" capturedAt={null} />);
+    await flush();
+
+    const afterScroller = changesRailScroller(container(r));
+    const afterFocused = container(r).querySelector<HTMLButtonElement>(
+      '[data-rail-file-path="src/file-000.ts"]',
+    );
+    expect(afterScroller).not.toBe(beforeScroller);
+    expect(afterScroller.scrollTop).toBe(196);
+    expect(document.activeElement).toBe(afterFocused);
+
+    await r.rerender(<WorkbenchChanges diff={manyFiles(80)} source="live" capturedAt={null} />);
+    await flush();
+    expect(changesRailScroller(container(r))).toBe(afterScroller);
+    expect(document.activeElement).toBe(afterFocused);
+    await r.unmount();
+  });
+
+  test("a shrink reset does not focus a different row when the focused file disappears", async () => {
+    const r = await renderComponent(
+      <WorkbenchChanges diff={manyFiles(2)} source="live" capturedAt={null} />,
+    );
+    await flush();
+    const rows = container(r).querySelectorAll<HTMLButtonElement>("[data-rail-file]");
+    rows.item(1).focus();
+
+    await r.rerender(<WorkbenchChanges diff={manyFiles(1)} source="live" capturedAt={null} />);
+    await flush();
+
+    const survivingRow = container(r).querySelector<HTMLButtonElement>("[data-rail-file]");
+    expect(survivingRow?.dataset.railFilePath).toBe("src/file-000.ts");
+    expect(document.activeElement).not.toBe(survivingRow);
     await r.unmount();
   });
 


### PR DESCRIPTION
## Summary

- fix OPE-182 by remounting the Changes virtual rail when its child count changes
- prevent virtua from addressing a stale captured-diff index after the live diff shrinks
- add the exact captured-to-live regression and verify the separate Files virtualizer threshold transition

## Production evidence

The Knowledge Product Completion session consistently crashed with `Cannot read properties of undefined (reading 'key')`. Production and the pre-fix local regression both resolve to virtua's key helper after a 40-row captured Changes rail shrinks to a 1-row live rail.

## Validation

- `bun test packages/react/test/file-browser-virtualization.test.tsx packages/react/test/workbench-changes.test.tsx` — 17 passed
- `@opengeni/react` typecheck — passed
- changed-file oxlint — passed
- changed-file oxfmt check — passed
- production web build, demo build, precompression, and bundle budgets — passed before current-main rebase; the affected React source/tests were conflict-free
- `git diff --check origin/main...HEAD` — passed

Linear: OPE-182

Exact head: `b0bd153b0a5d61e8639bb0ed10992864761d645c`