### PR TITLE
fix: mint live plane credentials just in time

### DIFF
--- a/.changeset/calm-terminals-connect.md
+++ b/.changeset/calm-terminals-connect.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/contracts": patch
+"@opengeni/react": patch
+"@opengeni/runtime": patch
+"@opengeni/sdk": patch
+---
+
+Separate credential-free capability discovery from exact, permission-checked live-plane grants; mint terminal credentials just in time, preserve first input across connection setup, and bound pre-open terminal memory.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -55,6 +55,8 @@ import {
   ViewerHeartbeatRequest,
   WORKSPACE_CONTROL_ACTOR_MAX_BYTES,
   workspaceControlUtf8Bytes,
+  type AccessGrant,
+  type AttachViewerResponse,
   type SandboxBackend,
   type LineageNode,
   type Session,
@@ -156,6 +158,7 @@ import type { Context, Hono, MiddlewareHandler } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import {
+  hasPermission,
   requireAccessGrant,
   requirePermission,
   requireSessionAuthorization,
@@ -212,6 +215,19 @@ import {
 } from "./workspace-capture";
 
 type SessionRouteDeps = ApiRouteDeps & Pick<ViewerServices, "establishSandboxSession">;
+
+const VIEWER_LIFECYCLE_PERMISSIONS = ["stream:view", "terminal:attach", "files:write"] as const;
+
+function requireViewerLifecyclePermission(grant: AccessGrant): void {
+  if (
+    VIEWER_LIFECYCLE_PERMISSIONS.some((permission) => hasPermission(grant.permissions, permission))
+  ) {
+    return;
+  }
+  throw new HTTPException(403, {
+    message: `missing permission: ${VIEWER_LIFECYCLE_PERMISSIONS.join(" or ")}`,
+  });
+}
 
 export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   const { settings, db, bus, workflowClient, objectStorage } = deps;
@@ -2064,8 +2080,8 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   // GET .../stream-capabilities — the capability-negotiation read. Returns the
   // SessionCapabilities doc (descriptor + lease liveness/epoch + os + the
   // shared-exposure disclosure + the calling principal's acknowledgment state),
-  // API-direct. The desktop URL/token stay null until P4 mints them (gated by
-  // liveness=cold until a box is warm); the read is non-mutating.
+  // API-direct. It is a pure descriptor read: every URL/token stays null until an
+  // exact, permission-checked POST /viewers grant mints it just in time.
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/stream-capabilities", async (c) => {
     const workspaceId = c.req.param("workspaceId");
     const grant = await requireAccessGrant(c, deps, workspaceId, "sessions:read");
@@ -2082,12 +2098,9 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     const { shared, sharedSessionIds } = await resolveSharedExposure(workspaceId, session);
     const visibleSharedSessionIds = relatedSessionAccessFor(c) === "root" ? sharedSessionIds : [];
     // Per-principal acknowledgment: A acknowledging does not consent for B. The
-    // un-redacted desktop stream ALWAYS requires the un-redacted ack; a shared box
-    // ADDITIONALLY requires the shared-exposure ack. Both must match the POST
-    // /viewers gate EXACTLY — otherwise a principal who recorded shared consent
-    // WITHOUT un-redacted consent could be handed a live VNC URL + scoped token
-    // from this read path while being correctly 409'd on attach (a consent-gate
-    // bypass of the un-redacted pixel plane).
+    // Surface consent state so the UI can decide whether an explicit desktop
+    // grant may be requested. This descriptor read never mints a credential; the
+    // POST /viewers grant below re-checks both consent bits and stream:view.
     const ack = await getStreamAcknowledgment(db, {
       workspaceId,
       sandboxGroupId: session.sandboxGroupId,
@@ -2097,61 +2110,10 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       ? ack.acknowledgedUnredacted && (!shared || ack.acknowledgedShared)
       : false;
 
-    // P4.2 — the pixel DATA PLANE, served API-direct. When the backend is
-    // desktop-capable AND sandboxDesktopEnabled AND the (shared, if shared)
-    // acknowledgment is present AND the box is WARM, mint the REAL DesktopStream
-    // cell IN-PROCESS: resume the box by id, ensureDisplayStack (idempotent),
-    // exposeStreamPort (resolve the 6080 tunnel + mint the scoped token), record
-    // data_plane_url under the epoch fence, and emit stream.url.rotated to other
-    // viewers on a box rollover. The handshake never SPINS UP a cold box (that is
-    // the viewer-attach path) — a cold lease stays lease_cold. A degraded mint
-    // (no secret / display-stack or tunnel failure) returns null → transport:null.
-    let desktopStream: DesktopStreamMint | null = null;
-    const desktopUnlocked =
-      settings.sandboxDesktopEnabled &&
-      !streamTokenDegraded(settings) &&
-      acknowledged &&
-      (session.activeSandboxId != null || lease?.liveness === "warm");
-    if (desktopUnlocked) {
-      desktopStream = await mintDesktopStream(
-        { db, settings, bus },
-        {
-          accountId: grant.accountId,
-          workspaceId,
-          session,
-          // The handshake's token is scoped to the calling principal (it is a read,
-          // not a viewer-holder acquire); the per-holder token is re-minted on
-          // POST /viewers. A previousEpoch != current would have rotated already
-          // via the warming-commit; the read does not itself drive rotation.
-          viewerId: grant.subjectId,
-          ...(lease ? { lease } : {}),
-        },
-      );
-    }
-
-    // P5.t — the REAL PTY terminal cell, served API-DIRECT. Independent of the
-    // desktop: it gates ONLY on sandboxTerminalEnabled + a real-PTY backend + a
-    // WARM box (NO un-redacted ack — the terminal cell has no acknowledgment
-    // gate). A degraded mint (terminal off / no secret / ttyd or tunnel failure)
-    // returns null → the Terminal cell falls back to the sse-events firehose.
-    let terminalStream: TerminalStreamMint | null = null;
-    const terminalUnlocked =
-      settings.sandboxTerminalEnabled &&
-      !streamTokenDegraded(settings) &&
-      (session.activeSandboxId != null || lease?.liveness === "warm");
-    if (terminalUnlocked) {
-      terminalStream = await mintTerminalStream(
-        { db, settings, bus },
-        {
-          accountId: grant.accountId,
-          workspaceId,
-          session,
-          viewerId: grant.subjectId,
-          ...(lease ? { lease } : {}),
-        },
-      );
-    }
-
+    // This GET is deliberately descriptor-only: no provider resume, display/ttyd
+    // startup, port exposure, or short-lived bearer mint. Besides enforcing least
+    // privilege, that keeps the 120-second stream credentials from aging before a
+    // user opens their surface. POST /viewers is the sole credential grant.
     const capabilities = negotiateCapabilities({
       sessionId,
       backend: session.sandboxBackend as SandboxBackend,
@@ -2178,31 +2140,9 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       desktopAcknowledged: acknowledged,
       shared,
       sharedSessionIds: visibleSharedSessionIds,
-      // The minted live address (null when not unlocked/degraded). The resolver
-      // only folds it in when the desktop gates pass + the ack is present.
-      ...(desktopStream
-        ? {
-            desktopStream: {
-              url: desktopStream.url,
-              token: desktopStream.token,
-              expiresAt: desktopStream.expiresAt,
-              resolution: desktopStream.resolution,
-            },
-          }
-        : {}),
-      // P5.t — the terminal policy toggle + the minted pty-ws address. The
-      // resolver advertises sse-events (firehose) on a cold/disabled terminal and
-      // folds the live pty-ws url/token in only when the gates passed + minted.
+      // Plane policy only. Live addresses are intentionally absent on a
+      // descriptor read and arrive from an authorized viewer grant.
       terminalEnabled: settings.sandboxTerminalEnabled,
-      ...(terminalStream
-        ? {
-            terminalStream: {
-              url: terminalStream.url,
-              token: terminalStream.token,
-              expiresAt: terminalStream.expiresAt,
-            },
-          }
-        : {}),
     });
 
     const repositoryRoots = [
@@ -2320,20 +2260,29 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
         message: "invalid viewer attach request",
       });
     }
-    // Consent gate (P3.2 / addendum E.1): ONLY the un-redacted DESKTOP pixel plane
-    // requires the calling principal's acknowledgment (recorded per group+subject;
-    // a shared box additionally needs the shared-exposure consent). A TERMINAL-ONLY
-    // warm attach (`desktop:false`, the default) carries NO consent gate — a shell
-    // is interactive by nature and the gate is the scoped tunnel URL + stream token
-    // — so it warms the box and mints the pty-ws terminal cell without a 409. Gating
-    // the terminal attach behind the desktop ack (the bug this fixes) dead-ended the
-    // interactive terminal: the box never warmed → the Terminal cell stayed on the
-    // read-only sse-events firehose forever ("read only"), and with the desktop tier
-    // off by default there was no consent flow to ever clear the gate.
+    // Resolve exact requested planes before authorization. Empty and
+    // `desktop:false` v1 bodies remain terminal-only during rolling upgrades;
+    // either new plane flag selects exact semantics. This closes desktop→terminal
+    // privilege bleed and lets file edits avoid unrelated terminal bearers.
     const wantDesktop = parsed.data.desktop ?? false;
-    requirePermission(grant, wantDesktop ? "stream:view" : "terminal:attach");
-    const { shared } = await resolveSharedExposure(workspaceId, session);
+    const wantFiles = parsed.data.files ?? false;
+    const hasExactPlaneSet = parsed.data.terminal !== undefined || parsed.data.files !== undefined;
+    // v1 clients sent only `desktop:false` for both terminal and file warming;
+    // retain its terminal-only grant during rolling upgrades. Presence of either
+    // v2 flag switches to exact-plane semantics.
+    const wantTerminal = parsed.data.terminal ?? (!hasExactPlaneSet && !wantDesktop);
+    if (!wantDesktop && !wantTerminal && !wantFiles) {
+      throw new HTTPException(400, { message: "viewer attach requires a live plane" });
+    }
+    if (wantDesktop) requirePermission(grant, "stream:view");
+    if (wantTerminal) requirePermission(grant, "terminal:attach");
+    if (wantFiles) requirePermission(grant, "files:write");
+
+    // Consent gate (P3.2 / addendum E.1): only the explicitly requested,
+    // un-redacted desktop plane needs acknowledgment. Terminal and files retain
+    // their independent permission boundaries.
     if (wantDesktop) {
+      const { shared } = await resolveSharedExposure(workspaceId, session);
       const ack = await getStreamAcknowledgment(db, {
         workspaceId,
         sandboxGroupId: session.sandboxGroupId,
@@ -2376,7 +2325,8 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
         dataPlaneUrl: null,
       };
       if (
-        (settings.sandboxDesktopEnabled || settings.sandboxTerminalEnabled) &&
+        ((wantDesktop && settings.sandboxDesktopEnabled) ||
+          (wantTerminal && settings.sandboxTerminalEnabled)) &&
         !streamTokenDegraded(settings)
       ) {
         if (wantDesktop && settings.sandboxDesktopEnabled) {
@@ -2388,7 +2338,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
             // No Modal lease for selfhosted-active; the mint routes to the relay.
           });
         }
-        if (settings.sandboxTerminalEnabled) {
+        if (wantTerminal && settings.sandboxTerminalEnabled) {
           terminal = await mintTerminalStream(viewerServices, {
             accountId: grant.accountId,
             workspaceId,
@@ -2415,7 +2365,8 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       // box is warm here (attachViewer spun it up or attached), so the handshake's
       // never-spin-up rule does not apply.
       if (
-        (settings.sandboxDesktopEnabled || settings.sandboxTerminalEnabled) &&
+        ((wantDesktop && settings.sandboxDesktopEnabled) ||
+          (wantTerminal && settings.sandboxTerminalEnabled)) &&
         !streamTokenDegraded(settings)
       ) {
         const lease = await readGroupLease(
@@ -2423,9 +2374,8 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
           { workspaceId, sandboxGroupId: session.sandboxGroupId },
         );
         if (lease) {
-          // The pixel cell is minted only when the caller asked for the desktop plane
-          // (and consented above). A terminal-only attach skips it — the box is warm,
-          // the terminal mint below still runs.
+          // Mint only explicitly authorized plane credentials. The shared holder
+          // supplies liveness; it is not itself authority for another plane.
           if (wantDesktop && settings.sandboxDesktopEnabled) {
             stream = await mintDesktopStream(viewerServices, {
               accountId: grant.accountId,
@@ -2435,10 +2385,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
               lease,
             });
           }
-          // P5.t — the same warm-box viewer attach also mints the REAL PTY terminal
-          // address (independent of the desktop toggle). A degraded mint leaves the
-          // terminal fields null → the client falls back to the sse-events firehose.
-          if (settings.sandboxTerminalEnabled) {
+          if (wantTerminal && settings.sandboxTerminalEnabled) {
             terminal = await mintTerminalStream(viewerServices, {
               accountId: grant.accountId,
               workspaceId,
@@ -2450,42 +2397,42 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
         }
       }
     }
-    return c.json(
-      {
-        ...result,
-        dataPlaneUrl: stream?.url ?? result.dataPlaneUrl,
-        streamToken: stream?.token ?? null,
-        streamExpiresAt: stream?.expiresAt ?? null,
-        resolution: stream?.resolution ?? null,
-        // Transport MUST match where the pixels were minted: a selfhosted-active box
-        // serves the RELAY framebuffer (relay-frames/frames), a Modal box serves noVNC
-        // (vnc-ws/novnc). Hardcoding vnc-ws here handed a machine's relay URL to the
-        // noVNC renderer (and vice-versa on the swap-away case) → "closed before it
-        // opened". Key off the SAME selfhostedActive the mint routed on.
-        transport: stream
-          ? selfhostedActive
-            ? ("relay-frames" as const)
-            : ("vnc-ws" as const)
-          : null,
-        client: stream ? (selfhostedActive ? ("frames" as const) : ("novnc" as const)) : null,
-        // The REAL PTY terminal address (pty-ws), null when degraded.
-        terminalUrl: terminal?.url ?? null,
-        terminalToken: terminal?.token ?? null,
-        terminalExpiresAt: terminal?.expiresAt ?? null,
-        terminalTransport: terminal ? ("pty-ws" as const) : null,
-      },
-      201,
-    );
+    const response = {
+      ...result,
+      dataPlaneUrl: stream?.url ?? null,
+      streamToken: stream?.token ?? null,
+      streamExpiresAt: stream?.expiresAt ?? null,
+      resolution: stream?.resolution ?? null,
+      // Transport MUST match where the pixels were minted: a selfhosted-active box
+      // serves the RELAY framebuffer (relay-frames/frames), a Modal box serves noVNC
+      // (vnc-ws/novnc). Hardcoding vnc-ws here handed a machine's relay URL to the
+      // noVNC renderer (and vice-versa on the swap-away case) → "closed before it
+      // opened". Key off the SAME selfhostedActive the mint routed on.
+      transport: stream
+        ? selfhostedActive
+          ? ("relay-frames" as const)
+          : ("vnc-ws" as const)
+        : null,
+      client: stream ? (selfhostedActive ? ("frames" as const) : ("novnc" as const)) : null,
+      // The REAL PTY terminal address (pty-ws), null when degraded.
+      terminalUrl: terminal?.url ?? null,
+      terminalToken: terminal?.token ?? null,
+      terminalExpiresAt: terminal?.expiresAt ?? null,
+      terminalTransport: terminal ? ("pty-ws" as const) : null,
+    } satisfies AttachViewerResponse;
+    return c.json(response, 201);
   });
 
   // POST .../viewers/:viewerId/heartbeat — refresh the holder TTL (epoch-fenced).
-  // A holder can represent the terminal-only plane, so lifecycle control uses
-  // terminal:attach. Desktop callers continue to pass via workspace:admin.
+  // A holder may belong to any exact live plane. Lifecycle control accepts any
+  // permission that could have minted it; the unguessable holder id and workspace
+  // grant remain the ownership boundary.
   app.post(
     "/v1/workspaces/:workspaceId/sessions/:sessionId/viewers/:viewerId/heartbeat",
     async (c) => {
       const workspaceId = c.req.param("workspaceId");
-      const grant = await requireAccessGrant(c, deps, workspaceId, "terminal:attach");
+      const grant = await requireAccessGrant(c, deps, workspaceId);
+      requireViewerLifecyclePermission(grant);
       assertOwnershipEnabled();
       const sessionId = c.req.param("sessionId");
       const session = await getSession(db, workspaceId, sessionId);
@@ -2515,7 +2462,8 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   // DELETE .../viewers/:viewerId — release the holder (idempotent).
   app.delete("/v1/workspaces/:workspaceId/sessions/:sessionId/viewers/:viewerId", async (c) => {
     const workspaceId = c.req.param("workspaceId");
-    const grant = await requireAccessGrant(c, deps, workspaceId, "terminal:attach");
+    const grant = await requireAccessGrant(c, deps, workspaceId);
+    requireViewerLifecyclePermission(grant);
     assertOwnershipEnabled();
     const sessionId = c.req.param("sessionId");
     const session = await getSession(db, workspaceId, sessionId);

--- a/apps/api/test/sandbox-consent-gate.test.ts
+++ b/apps/api/test/sandbox-consent-gate.test.ts
@@ -378,6 +378,12 @@ describe("P3.2 consent gate — un-redacted acknowledgment (solo box)", () => {
     ).json();
     expect(capsX.DesktopStream.acknowledged).toBe(true);
     expect(capsY.DesktopStream.acknowledged).toBe(false);
+    // Negotiation is descriptor-only even for a warm, acknowledged box. A
+    // sessions:read principal never receives a short-lived stream bearer.
+    expect(capsX.DesktopStream.url).toBeNull();
+    expect(capsX.DesktopStream.token).toBeNull();
+    expect(capsX.Terminal.url).toBeNull();
+    expect(capsX.Terminal.token).toBeNull();
     // Solo box: not shared, no sibling ids disclosed.
     expect(capsX.DesktopStream.shared).toBe(false);
     expect(capsX.DesktopStream.sharedSessionIds).toEqual([]);
@@ -652,6 +658,67 @@ describe("P3.2 viewer revocation (OD-6 v1) — holder-drop drains iff last holde
 });
 
 describe("P3.2 route auth (stream:view / stream:acknowledge)", () => {
+  test("an exact files holder requires files:write and mints no unrelated plane", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, sessionId } = await soloSession();
+    const terminalOnly = await bearer({
+      accountId,
+      workspaceId,
+      subjectId: "terminal-only",
+      permissions: ["terminal:attach"],
+    });
+    const denied = await app.request(url(workspaceId, sessionId, "/viewers"), {
+      method: "POST",
+      headers: { authorization: terminalOnly, "content-type": "application/json" },
+      body: JSON.stringify({ desktop: false, terminal: false, files: true }),
+    });
+    expect(denied.status).toBe(403);
+
+    const fileWriter = await bearer({
+      accountId,
+      workspaceId,
+      subjectId: "file-writer",
+      permissions: ["files:write"],
+    });
+    const allowed = await app.request(url(workspaceId, sessionId, "/viewers"), {
+      method: "POST",
+      headers: { authorization: fileWriter, "content-type": "application/json" },
+      body: JSON.stringify({ desktop: false, terminal: false, files: true }),
+    });
+    expect(allowed.status).toBe(201);
+    const holder = await allowed.json();
+    expect(holder).toMatchObject({
+      dataPlaneUrl: null,
+      streamToken: null,
+      terminalUrl: null,
+      terminalToken: null,
+      terminalExpiresAt: null,
+      terminalTransport: null,
+    });
+    const heartbeat = await app.request(
+      url(workspaceId, sessionId, `/viewers/${holder.viewerId}/heartbeat`),
+      {
+        method: "POST",
+        headers: { authorization: fileWriter, "content-type": "application/json" },
+        body: JSON.stringify({ leaseEpoch: holder.leaseEpoch }),
+      },
+    );
+    expect(heartbeat.status).toBe(200);
+    const detached = await app.request(url(workspaceId, sessionId, `/viewers/${holder.viewerId}`), {
+      method: "DELETE",
+      headers: { authorization: fileWriter },
+    });
+    expect(detached.status).toBe(204);
+
+    // Rolling compatibility: v1 sent only desktop:false for terminal intent.
+    const legacy = await app.request(url(workspaceId, sessionId, "/viewers"), {
+      method: "POST",
+      headers: { authorization: terminalOnly, "content-type": "application/json" },
+      body: JSON.stringify({ desktop: false }),
+    });
+    expect(legacy.status).toBe(201);
+  }, 60_000);
+
   test("the viewer-attach (desktop-stream) path requires stream:view — sessions:read alone is 403", async () => {
     if (!available) return;
     const { accountId, workspaceId, sessionId } = await soloSession();

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9657,7 +9657,7 @@ export type SessionCapabilities = z.infer<typeof SessionCapabilities>;
 // consent gate, `terminal` carries terminal:attach, and `files` carries
 // files:write. For compatibility, an entirely omitted plane set retains the old
 // terminal-only meaning; new clients always send all three flags explicitly.
-export const AttachViewerRequest = z.object({
+export const AttachViewerRequest = /* @__PURE__ */ z.object({
   viewerId: z.string().uuid().optional(),
   desktop: z.boolean().optional(),
   terminal: z.boolean().optional(),
@@ -9665,7 +9665,7 @@ export const AttachViewerRequest = z.object({
 });
 export type AttachViewerRequest = z.infer<typeof AttachViewerRequest>;
 
-export const ViewerHolder = z.object({
+export const ViewerHolder = /* @__PURE__ */ z.object({
   viewerId: z.string().uuid(),
   sandboxGroupId: z.string().uuid(),
   liveness: z.enum(["cold", "warming", "warm", "draining"]),
@@ -9683,7 +9683,7 @@ export type ViewerHolder = z.infer<typeof ViewerHolder>;
 
 /** Exact POST /viewers response. Keep the credential cells in the contracts
  * package so API and zero-runtime SDK mirrors cannot silently drift. */
-export const AttachViewerResponse = ViewerHolder.extend({
+export const AttachViewerResponse = /* @__PURE__ */ ViewerHolder.extend({
   streamToken: z.string().nullable(),
   streamExpiresAt: z.string().nullable(),
   resolution: z.tuple([z.number().int().positive(), z.number().int().positive()]).nullable(),
@@ -9705,7 +9705,7 @@ export type AttachViewerResponse = z.infer<typeof AttachViewerResponse>;
 // session): the un-redacted desktop path returns 409 shared_acknowledgment_required
 // until a shared box is acknowledged WITH the shared-exposure consent. For a
 // solo box `acknowledgeShared` is irrelevant (the un-redacted ack alone gates).
-export const AcknowledgeStreamRequest = z.object({
+export const AcknowledgeStreamRequest = /* @__PURE__ */ z.object({
   // The principal accepts that the desktop pixel plane is un-redacted (can show
   // cloud creds the agent cat's into a terminal). Always true to record consent;
   // present for self-documentation + a future explicit withdraw.
@@ -9716,7 +9716,7 @@ export const AcknowledgeStreamRequest = z.object({
 });
 export type AcknowledgeStreamRequest = z.infer<typeof AcknowledgeStreamRequest>;
 
-export const AcknowledgeStreamResponse = z.object({
+export const AcknowledgeStreamResponse = /* @__PURE__ */ z.object({
   acknowledged: z.boolean(),
   acknowledgedShared: z.boolean(),
 });
@@ -9724,12 +9724,12 @@ export type AcknowledgeStreamResponse = z.infer<typeof AcknowledgeStreamResponse
 
 // POST .../viewers/:viewerId/heartbeat — refresh the holder TTL. Epoch-fenced:
 // a stale-epoch beat (a box re-established under a newer epoch) is rejected.
-export const ViewerHeartbeatRequest = z.object({
+export const ViewerHeartbeatRequest = /* @__PURE__ */ z.object({
   leaseEpoch: z.number().int().nonnegative(),
 });
 export type ViewerHeartbeatRequest = z.infer<typeof ViewerHeartbeatRequest>;
 
-export const ViewerHeartbeatResponse = z.object({
+export const ViewerHeartbeatResponse = /* @__PURE__ */ z.object({
   // false ⇒ the holder was reaped or the epoch is stale; the client re-attaches.
   alive: z.boolean(),
 });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9651,15 +9651,17 @@ export type SessionCapabilities = z.infer<typeof SessionCapabilities>;
 // POST .../viewers — acquire a viewer holder. An omitted viewerId mints a fresh
 // one (returned in the response, to carry through heartbeats + detach).
 //
-// `desktop` declares intent to attach the UN-REDACTED pixel plane (noVNC). ONLY
-// that plane carries the consent gate (the un-redacted/shared acknowledgment). A
-// terminal-only warm attach (`desktop:false`, the default) needs NO consent — a
-// shell is interactive by nature and the gate is the scoped tunnel URL + stream
-// token — so it warms the box and mints the pty-ws terminal cell WITHOUT a 409.
-// Omitted defaults to `false` so a terminal-only client never trips the gate.
+// Each optional plane flag declares exactly which live capability is being
+// acquired. The holder itself is shared liveness; credentials are minted only
+// for explicitly requested planes. `desktop` alone carries the un-redacted pixel
+// consent gate, `terminal` carries terminal:attach, and `files` carries
+// files:write. For compatibility, an entirely omitted plane set retains the old
+// terminal-only meaning; new clients always send all three flags explicitly.
 export const AttachViewerRequest = z.object({
   viewerId: z.string().uuid().optional(),
   desktop: z.boolean().optional(),
+  terminal: z.boolean().optional(),
+  files: z.boolean().optional(),
 });
 export type AttachViewerRequest = z.infer<typeof AttachViewerRequest>;
 
@@ -9678,6 +9680,21 @@ export const ViewerHolder = z.object({
   dataPlaneUrl: z.string().nullable(),
 });
 export type ViewerHolder = z.infer<typeof ViewerHolder>;
+
+/** Exact POST /viewers response. Keep the credential cells in the contracts
+ * package so API and zero-runtime SDK mirrors cannot silently drift. */
+export const AttachViewerResponse = ViewerHolder.extend({
+  streamToken: z.string().nullable(),
+  streamExpiresAt: z.string().nullable(),
+  resolution: z.tuple([z.number().int().positive(), z.number().int().positive()]).nullable(),
+  transport: z.enum(["vnc-ws", "relay-frames"]).nullable(),
+  client: z.enum(["novnc", "frames"]).nullable(),
+  terminalUrl: z.string().nullable(),
+  terminalToken: z.string().nullable(),
+  terminalExpiresAt: z.string().nullable(),
+  terminalTransport: z.literal("pty-ws").nullable(),
+});
+export type AttachViewerResponse = z.infer<typeof AttachViewerResponse>;
 
 // POST .../stream-capabilities/acknowledge — record the calling principal's
 // acknowledgment of the un-redacted pixel plane. Reuses the acknowledgment

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -1282,6 +1282,7 @@ export class MockOpenGeniClient implements SessionClientLike {
         shell: "/bin/bash",
         url: null,
         token: null,
+        expiresAt: null,
         reason: null,
       },
       Git: { available: true, repos: ["."], reason: null },
@@ -1328,6 +1329,7 @@ export class MockOpenGeniClient implements SessionClientLike {
       client: null,
       terminalUrl: null,
       terminalToken: null,
+      terminalExpiresAt: null,
       terminalTransport: null,
     };
   }

--- a/packages/react/demo/workbench-dock-states.ts
+++ b/packages/react/demo/workbench-dock-states.ts
@@ -335,6 +335,7 @@ function caps(
       shell: "/bin/bash",
       url: null,
       token: null,
+      expiresAt: null,
       reason: null,
     },
     Git: { available: true, repos: ["."], reason: null },
@@ -369,6 +370,7 @@ function capsCold(overrides: Partial<SessionCapabilities> = {}): SessionCapabili
       shell: "/bin/bash",
       url: null,
       token: null,
+      expiresAt: null,
       reason: "lease_cold",
     },
     DesktopStream: {
@@ -593,6 +595,7 @@ export const DOCK_STATES: Record<string, DockState> = {
         shell: "/bin/bash",
         url: null,
         token: null,
+        expiresAt: null,
         reason: "agent_offline",
       },
       DesktopStream: {
@@ -725,6 +728,7 @@ export const DOCK_STATES: Record<string, DockState> = {
         shell: "/bin/bash",
         url: null,
         token: null,
+        expiresAt: null,
         reason: "disabled_by_policy",
       },
       DesktopStream: {

--- a/packages/react/src/components/sandbox-terminal.tsx
+++ b/packages/react/src/components/sandbox-terminal.tsx
@@ -1,18 +1,11 @@
 import type { TerminalCapability } from "@opengeni/sdk";
-import {
-  type FocusEvent as ReactFocusEvent,
-  type MouseEvent as ReactMouseEvent,
-  type PointerEvent as ReactPointerEvent,
-  type ReactNode,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { cn } from "../lib/cn";
 import { type TerminalStreamStatus, useTerminalStream } from "../hooks/use-terminal-stream";
 import type { UseSandboxTerminalResult } from "../hooks/use-sandbox-terminal";
 import { resolveTerminalFont, xtermThemeFromTokens } from "../lib/xterm-theme";
 import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
+import { terminalCanAcquirePty } from "../lib/terminal-capability";
 import { attachRenderer, type RendererLoaders, type RendererTier } from "../lib/xterm-renderer";
 
 /**
@@ -157,42 +150,6 @@ export function subscribeTerminalInput(
   return term.onData(sink);
 }
 
-export function terminalInputEngagementAllowed(input: {
-  acceptsInput: boolean;
-  readOnly: boolean;
-  ptyCapable: boolean;
-  ptyWs: boolean;
-  hasWrite: boolean;
-}): boolean {
-  const expectsInteractiveInput =
-    !input.readOnly && (input.ptyCapable || input.ptyWs || input.hasWrite);
-  return input.acceptsInput || !expectsInteractiveInput;
-}
-
-type TerminalEngagementEvent = {
-  preventDefault: () => void;
-  stopPropagation: () => void;
-  target?: unknown;
-};
-
-/**
- * A pre-connect click still warms the terminal, but must not reach xterm and
- * focus its hidden textarea. Otherwise the user's first keystrokes are accepted
- * visually and then silently dropped while the PTY socket is still connecting.
- */
-export function guardTerminalEngagement(
-  event: TerminalEngagementEvent,
-  inputAllowed: boolean,
-  blurTarget = false,
-): boolean {
-  if (inputAllowed) return false;
-  event.preventDefault();
-  event.stopPropagation();
-  const target = event.target as { blur?: unknown } | null | undefined;
-  if (blurTarget && typeof target?.blur === "function") target.blur();
-  return true;
-}
-
 /** Clear the transient wake line and put the first live prompt at cell 1,1.
  * `Terminal.clear()` removes scrollback but deliberately preserves the cursor,
  * which lets the first PTY frame append to the old wake message. */
@@ -280,53 +237,52 @@ export function SandboxTerminal({
   const [activated, setActivated] = useState(false);
 
   // ── Interactive transport switch ─────────────────────────────────────────────
-  const ptyWs = terminalCapability?.transport === "pty-ws" && Boolean(terminalCapability?.url);
-  // Output frames buffer here until xterm has mounted; the write effect drains it.
-  const ptyOutputQueueRef = useRef<string[]>([]);
+  const ptyDescriptor = terminalCapability?.transport === "pty-ws";
+  const ptyAttachable = terminalCanAcquirePty(terminalCapability);
   const {
     status: ptyStatus,
     write: ptyWrite,
     resize: resizePty,
     connected: ptyConnected,
   } = useTerminalStream({
-    capability: ptyWs
-      ? {
-          transport: terminalCapability!.transport,
-          url: terminalCapability!.url,
-          token: terminalCapability!.token,
-        }
-      : null,
+    // Connect only after xterm exists. This makes the renderer the sole output
+    // owner from the first websocket frame and removes an otherwise unbounded
+    // pre-mount output queue during large command bursts.
+    capability:
+      ptyAttachable && ready
+        ? {
+            transport: "pty-ws",
+            url: ptyDescriptor ? terminalCapability!.url : null,
+            token: ptyDescriptor ? terminalCapability!.token : null,
+            expiresAt: ptyDescriptor ? terminalCapability!.expiresAt : null,
+          }
+        : null,
     onOutput: (data) => {
-      const term = termRef.current;
-      if (term) term.write(data);
-      else ptyOutputQueueRef.current.push(data);
+      termRef.current?.write(data);
     },
   });
 
-  // PTY mode = a live ttyd socket drives the screen. Firehose mode = the
-  // read-only projection (or the legacy HTTP-write fallback).
-  const ptyMode = ptyWs && ptyStatus !== "closed";
-  const interactive = !readOnly && (ptyMode ? ptyConnected : result.write !== null);
-  const acceptsInput = interactive && inputReady;
-  const inputPending = interactive && !inputReady;
-  const inputEngagementAllowed = terminalInputEngagementAllowed({
-    acceptsInput,
-    readOnly: Boolean(readOnly),
-    ptyCapable: terminalCapability?.ptyCapable === true,
-    ptyWs,
-    hasWrite: result.write !== null,
-  });
-  const terminalModeLabel = acceptsInput
-    ? null
-    : readOnly
-      ? "read-only"
-      : inputPending
-        ? "connecting"
-        : ptyMode && ptyStatus === "connecting"
-          ? "connecting"
-          : ptyMode && ptyStatus === "error"
-            ? "connection error"
-            : "output only";
+  // A pty-ws capability exclusively owns the screen even while connecting or
+  // after a visible connection failure; never silently switch one terminal UI
+  // between two PTYs. Input is enabled during the handshake because the stream
+  // hook buffers it strictly and flushes only after ttyd auth succeeds.
+  const ptyMode = ptyDescriptor;
+  // Keep xterm stdin live for an attachable descriptor even before its URL has
+  // arrived. Focus/click triggers the grant; any immediately following input is
+  // bounded in the stream hook instead of disappearing in that HTTP interval.
+  const ptyCapturesInput = ptyAttachable && ptyStatus !== "error";
+  const interactive = !readOnly && (ptyAttachable ? ptyCapturesInput : result.write !== null);
+  // Public "interactive" means the mounted input subscription can reach a live
+  // PTY now. Before that point xterm still captures into the bounded queue, but
+  // acceptance and embedders see an explicit connecting state.
+  const acceptsInput = inputReady && (!ptyAttachable || ptyConnected);
+  const inputPending = inputReady && ptyAttachable && !ptyConnected && activated;
+  let terminalModeLabel: string | null;
+  if (readOnly) terminalModeLabel = "read-only";
+  else if (!ptyAttachable) terminalModeLabel = acceptsInput ? null : "output only";
+  else if (ptyStatus === "error") terminalModeLabel = "connection error";
+  else if (acceptsInput) terminalModeLabel = null;
+  else terminalModeLabel = activated ? "connecting" : "connect on input";
 
   // Boot-in-terminal: after the user engages a not-yet-warm box, show styled
   // status lines INSIDE xterm instead of an overlay — but only when there is no
@@ -350,20 +306,6 @@ export function SandboxTerminal({
   function handleActivate() {
     if (!activated) setActivated(true);
     onActivate?.();
-  }
-
-  function handlePointerDownCapture(event: ReactPointerEvent<HTMLDivElement>) {
-    handleActivate();
-    guardTerminalEngagement(event, inputEngagementAllowed);
-  }
-
-  function handleMouseDownCapture(event: ReactMouseEvent<HTMLDivElement>) {
-    guardTerminalEngagement(event, inputEngagementAllowed);
-  }
-
-  function handleFocusCapture(event: ReactFocusEvent<HTMLDivElement>) {
-    handleActivate();
-    guardTerminalEngagement(event, inputEngagementAllowed, true);
   }
 
   // Mount xterm once (client-only). Never re-mounts on interactive/theme flips —
@@ -477,10 +419,6 @@ export function SandboxTerminal({
       requestAnimationFrame(() => {
         if (disposed) return;
         settle();
-        if (ptyOutputQueueRef.current.length > 0) {
-          for (const data of ptyOutputQueueRef.current) term.write(data);
-          ptyOutputQueueRef.current = [];
-        }
         el.setAttribute("data-og-term-ready", "true");
         if (typeof globalThis.__OG_TERMINAL_DEBUG__ === "function") {
           globalThis.__OG_TERMINAL_DEBUG__({
@@ -579,11 +517,15 @@ export function SandboxTerminal({
       setInputReady(false);
       return;
     }
-    const sink = ptyMode ? ptyWrite : result.write;
+    const sink = ptyAttachable ? ptyWrite : result.write;
+    if (!sink) {
+      setInputReady(false);
+      return;
+    }
     const sub = subscribeTerminalInput(term, sink, true);
     setInputReady(sub !== null);
     return () => sub?.dispose();
-  }, [ready, interactive, ptyMode, ptyWrite, result.write]);
+  }, [ready, interactive, ptyAttachable, ptyWrite, result.write]);
 
   // In PTY mode, tell ttyd the window size on the xterm resize event.
   useEffect(() => {
@@ -659,9 +601,8 @@ export function SandboxTerminal({
           12px inset + `--og-color-bg` ground match the dock surface. */}
       <div
         className="relative min-h-0 flex-1 bg-og-bg p-3"
-        onPointerDownCapture={handlePointerDownCapture}
-        onMouseDownCapture={handleMouseDownCapture}
-        onFocusCapture={handleFocusCapture}
+        onPointerDownCapture={handleActivate}
+        onFocusCapture={handleActivate}
       >
         {!ready && (placeholder ?? <TerminalPlaceholder />)}
         {/* Kept `visibility:hidden` until the first successful fit so the first
@@ -674,6 +615,7 @@ export function SandboxTerminal({
           data-opengeni-terminal-ready={ready ? "true" : "false"}
           data-opengeni-terminal-interactive={surfaceState === "interactive" ? "true" : "false"}
           data-opengeni-terminal-state={surfaceState}
+          data-opengeni-terminal-status={ptyAttachable ? ptyStatus : "firehose"}
         />
       </div>
     </div>

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -345,12 +345,15 @@ export function useSandboxWorkspaceTabs(
   const filesEditable = fileSystemOn && !fsReadOnly && sandboxAcceptsLiveIo(liveness);
   const gitOn = capabilities?.Git.available ?? false;
   const terminalOn = terminalEnabled && (capabilities?.Terminal.transport ?? null) !== null;
-  // The REAL interactive terminal is the ttyd pty-ws stream. When it's live the
-  // legacy HTTP PTY must NOT run; `useSandboxTerminal` opens its HTTP PTY only as
-  // the firehose-mode fallback (a backend without ttyd).
-  const ptyWsLive =
-    capabilities?.Terminal.transport === "pty-ws" && Boolean(capabilities?.Terminal.url);
-  const ptyCapable = (capabilities?.Terminal.ptyCapable ?? false) && !ptyWsLive;
+  // A descriptor-only pty-ws cell intentionally has no short-lived URL until
+  // terminal intent acquires one. Do not mistake that grant boundary for a
+  // legacy HTTP PTY and eagerly open a second terminal. The fallback exists only
+  // for a genuinely firehose-transport backend with no typed degradation.
+  const ptyCapable =
+    warmTerminal &&
+    (capabilities?.Terminal.ptyCapable ?? false) &&
+    capabilities?.Terminal.transport === "sse-events" &&
+    capabilities?.Terminal.reason === null;
   const terminal = useSandboxTerminal(sessionId, {
     events: terminalEnabled ? events : [],
     interactive: terminalEnabled && ptyCapable,
@@ -715,6 +718,7 @@ export function useSandboxWorkspaceTabs(
         content: (
           <div className="h-full bg-og-bg p-1">
             <SandboxTerminal
+              key={sessionId}
               result={terminal}
               terminalCapability={capabilities?.Terminal ?? null}
               onActivate={() => requestWarmIntent("warmTerminal")}

--- a/packages/react/src/hooks/use-session-capabilities.ts
+++ b/packages/react/src/hooks/use-session-capabilities.ts
@@ -357,7 +357,7 @@ export function useSessionCapabilities(
               // a successful holder that waits forever. Release it and surface
               // a retryable error instead of retaining stale credentials.
               await client.detachViewer(workspaceId, sessionId, holder.viewerId).catch(() => {});
-              throw new Error("requested live plane grant was unavailable");
+              throw new Error("live plane unavailable");
             }
             localViewerId = holder.viewerId;
             viewerIdRef.current = holder.viewerId;

--- a/packages/react/src/hooks/use-session-capabilities.ts
+++ b/packages/react/src/hooks/use-session-capabilities.ts
@@ -8,6 +8,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useOpenGeni, type ClientOverride } from "../provider";
 import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
+import { terminalCanAcquirePty } from "../lib/terminal-capability";
 import { usePageLiveActivity } from "./internal";
 
 // "on-demand" is the boxless-benign resting state: the lease is not currently
@@ -115,24 +116,10 @@ function desktopAttachable(cell: SessionCapabilities["DesktopStream"]): boolean 
 
 /**
  * Whether warming the box for the interactive terminal (pty-ws) is worth it.
- * The Terminal cell is ALWAYS feasible when the backend advertises a transport at
- * all (`sse-events` on a cold box, `pty-ws` once warm) — only a genuinely
- * terminal-less backend reports transport:null with a hard reason. The attach is
- * what flips `sse-events` → `pty-ws` by warming the box and minting the ttyd
- * tunnel URL, so we attach whenever the terminal is not hard-unavailable.
+ * A real-PTY descriptor is attachable when already routed as `pty-ws`, or while
+ * transiently cold. A firehose-only backend and policy/OS/backend degradation
+ * cannot become interactive, so attaching there would only waste a holder.
  */
-function terminalAttachable(cell: SessionCapabilities["Terminal"]): boolean {
-  if (cell.transport === null) {
-    // No terminal at all unless the only blocker is a transient cold state.
-    return (
-      cell.reason === "lease_cold" || cell.reason === "not_provisioned" || cell.reason === null
-    );
-  }
-  // Already pty-ws (warm) is fine to (re)attach; sse-events is the cold state the
-  // attach upgrades. Either way it's attachable.
-  return true;
-}
-
 /** Read `stream.url.rotated` payloads off the live event log, newest last. */
 function rotationsFrom(events: SessionEvent[]): StreamUrlRotatedPayload[] {
   const out: StreamUrlRotatedPayload[] = [];
@@ -210,8 +197,15 @@ export function useSessionCapabilities(
     if (!lifecycleEnabled || !sessionId) {
       setState("idle");
       setCapabilities(null);
+      viewerIdRef.current = null;
+      setViewerId(null);
       return;
     }
+    // The preceding effect cleanup released any old holder before this fresh
+    // lifecycle starts. Never project that stale id while re-negotiating or if
+    // the replacement grant degrades.
+    viewerIdRef.current = null;
+    setViewerId(null);
     let cancelled = false;
     let pollTimer: ReturnType<typeof setTimeout> | null = null;
     let heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
@@ -324,7 +318,7 @@ export function useSessionCapabilities(
         // already live OR cold-but-feasible — and let POST /viewers warm the box and
         // mint the URLs. Only a genuinely-unsupported reason suppresses the attach.
         const wantDesktopAttach = attachDesktop && desktopAttachable(caps.DesktopStream);
-        const wantTerminalAttach = attachTerminal && terminalAttachable(caps.Terminal);
+        const wantTerminalAttach = attachTerminal && terminalCanAcquirePty(caps.Terminal);
         // The Files attach warms the box for a file WRITE (wake-on-edit intent). It
         // folds no live URL (files are stateless HTTP) — the attach is purely a
         // liveness refcount. Unlike the previous "keep the box warm while the Files
@@ -342,6 +336,8 @@ export function useSessionCapabilities(
             // pty-ws terminal cell WITHOUT tripping the desktop consent 409.
             const holder = await client.attachViewer(workspaceId, sessionId, {
               desktop: wantDesktopAttach,
+              terminal: wantTerminalAttach,
+              files: wantFilesAttach,
             });
             if (cancelled) {
               // The attach crossed an identity/unmount boundary after the server
@@ -350,6 +346,18 @@ export function useSessionCapabilities(
               // reaper runs. Release that exact old-session holder immediately.
               void client.detachViewer(workspaceId, sessionId, holder.viewerId).catch(() => {});
               return;
+            }
+            if (
+              (wantDesktopAttach &&
+                (!holder.dataPlaneUrl || !holder.transport || !holder.client)) ||
+              (wantTerminalAttach && (!holder.terminalUrl || !holder.terminalTransport))
+            ) {
+              // Nullable plane cells are valid graceful-degradation values at
+              // the raw API boundary, but an explicit UI grant must not become
+              // a successful holder that waits forever. Release it and surface
+              // a retryable error instead of retaining stale credentials.
+              await client.detachViewer(workspaceId, sessionId, holder.viewerId).catch(() => {});
+              throw new Error("requested live plane grant was unavailable");
             }
             localViewerId = holder.viewerId;
             viewerIdRef.current = holder.viewerId;
@@ -370,24 +378,24 @@ export function useSessionCapabilities(
                           ...prev.DesktopStream,
                           transport: holder.transport ?? prev.DesktopStream.transport,
                           client: holder.client ?? prev.DesktopStream.client,
-                          url: holder.dataPlaneUrl ?? prev.DesktopStream.url,
-                          token: holder.streamToken ?? prev.DesktopStream.token,
-                          expiresAt: holder.streamExpiresAt ?? prev.DesktopStream.expiresAt,
+                          url: holder.dataPlaneUrl,
+                          token: holder.streamToken,
+                          expiresAt: holder.streamExpiresAt,
                           resolution: holder.resolution ?? prev.DesktopStream.resolution,
                         }
                       : prev.DesktopStream,
-                    Terminal:
-                      holder.terminalUrl && holder.terminalTransport
-                        ? {
-                            ...prev.Terminal,
-                            transport: holder.terminalTransport,
-                            url: holder.terminalUrl,
-                            token: holder.terminalToken ?? prev.Terminal.token,
-                            // A live pty-ws means the box is pty-capable for real.
-                            ptyCapable: true,
-                            reason: null,
-                          }
-                        : prev.Terminal,
+                    Terminal: wantTerminalAttach
+                      ? {
+                          ...prev.Terminal,
+                          transport: holder.terminalTransport ?? prev.Terminal.transport,
+                          url: holder.terminalUrl,
+                          token: holder.terminalToken,
+                          expiresAt: holder.terminalExpiresAt,
+                          // A live pty-ws means the box is pty-capable for real.
+                          ptyCapable: holder.terminalTransport ? true : prev.Terminal.ptyCapable,
+                          reason: holder.terminalTransport ? null : prev.Terminal.reason,
+                        }
+                      : prev.Terminal,
                   }
                 : prev,
             );
@@ -411,6 +419,8 @@ export function useSessionCapabilities(
                 setState("error");
                 setError(cause);
                 return;
+              } else {
+                throw cause;
               }
               // 409/429 are recoverable: structured surfaces still negotiated;
               // keep going to set ready/cold below.

--- a/packages/react/src/hooks/use-terminal-stream.ts
+++ b/packages/react/src/hooks/use-terminal-stream.ts
@@ -74,6 +74,14 @@ function decodeFrame(data: string | ArrayBuffer): { command: string; payload: st
   return { command, payload };
 }
 
+function closeSocket(socket: WebSocket | null): void {
+  try {
+    socket?.close();
+  } catch {
+    // Already closed or rejected by the host WebSocket implementation.
+  }
+}
+
 /**
  * Drive a ttyd PTY-over-websocket connection from a `pty-ws` Terminal capability,
  * symmetric with `use-desktop-stream` (the noVNC-over-tunnel hook). The scoped
@@ -180,11 +188,7 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
       } catch {
         socketFailedRef.current = true;
         setStatus("error");
-        try {
-          socket.close();
-        } catch {
-          // already closed
-        }
+        closeSocket(socket);
         return;
       }
       setStatus("open");
@@ -227,11 +231,7 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
       socket.onmessage = null;
       socket.onerror = null;
       socket.onclose = null;
-      try {
-        socket.close();
-      } catch {
-        // ignore teardown errors
-      }
+      closeSocket(socket);
     };
     // A url/token change (rotation) re-runs this effect → close old, open new.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -246,11 +246,7 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
         } catch {
           socketFailedRef.current = true;
           setStatus("error");
-          try {
-            ws.close();
-          } catch {
-            // already closed
-          }
+          closeSocket(ws);
         }
       } else if (transport === "pty-ws" && !socketFailedRef.current) {
         const nextSize = pendingInputRef.current.length + data.length;
@@ -258,13 +254,7 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
           pendingInputRef.current = "";
           socketFailedRef.current = true;
           setStatus("error");
-          if (ws) {
-            try {
-              ws.close();
-            } catch {
-              // already closed
-            }
-          }
+          closeSocket(ws);
           return;
         }
         pendingInputRef.current += data;
@@ -289,13 +279,7 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
       socketFailedRef.current = false;
       socketAuthenticatedRef.current = false;
       setStatus("closed");
-      if (ws) {
-        try {
-          ws.close();
-        } catch {
-          // ignore
-        }
-      }
+      closeSocket(ws);
     };
     return { connected: status === "open", status, write, resize, disconnect };
   }, [status, transport]);

--- a/packages/react/src/hooks/use-terminal-stream.ts
+++ b/packages/react/src/hooks/use-terminal-stream.ts
@@ -17,7 +17,7 @@ export type UseTerminalStreamOptions = {
    *  The stream connects ONLY when `transport === "pty-ws"` and `url` is set; on a
    *  cold box (`transport === "sse-events"` / no url) it stays idle and the caller
    *  falls back to the Channel-A read-only firehose. */
-  capability: Pick<TerminalCapability, "transport" | "url" | "token"> | null;
+  capability: Pick<TerminalCapability, "transport" | "url" | "token" | "expiresAt"> | null;
   /** Called for each OUTPUT payload from ttyd (write verbatim into xterm). */
   onOutput?: ((data: string) => void) | undefined;
   /** Called when ttyd sends a SET_WINDOW_TITLE frame. */
@@ -31,13 +31,35 @@ export type UseTerminalStreamResult = {
   /** True once the ttyd socket is open (and the auth frame has been sent). */
   connected: boolean;
   status: TerminalStreamStatus;
-  /** Pipe a keystroke/paste to the PTY stdin. No-op until the socket is open. */
+  /** Pipe a keystroke/paste to PTY stdin. Input during CONNECTING is bounded and
+   *  replayed only after ttyd authentication succeeds. */
   write: (data: string) => void;
   /** Tell ttyd the PTY window changed size (on xterm fit/resize). */
   resize: (cols: number, rows: number) => void;
   /** Tear the socket down (the effect also tears down on unmount / url change). */
   disconnect: () => void;
 };
+
+// Keystrokes entered during the websocket handshake are held until ttyd has
+// accepted its auth/resize frames. Bound the queue by UTF-16 code units (a hard
+// <=128 KiB string payload in current JS engines) so a paste cannot turn a slow
+// handshake into unbounded renderer memory. Overflow rejects the whole pending
+// input rather than ever executing a truncated shell command.
+export const MAX_PENDING_TERMINAL_INPUT_CODE_UNITS = 64 * 1024;
+const TERMINAL_CONNECT_EXPIRY_SKEW_MS = 5_000;
+
+/** A bearer must remain valid long enough to finish a new websocket handshake.
+ * Existing open sockets are unaffected: this is evaluated only when the
+ * credential identity changes and the connection effect attempts a new socket. */
+export function terminalStreamCredentialUsable(
+  capability: Pick<TerminalCapability, "transport" | "url" | "expiresAt"> | null | undefined,
+  nowMs = Date.now(),
+): boolean {
+  if (capability?.transport !== "pty-ws" || !capability.url) return false;
+  if (!capability.expiresAt) return true;
+  const expiresAt = Date.parse(capability.expiresAt);
+  return Number.isFinite(expiresAt) && expiresAt > nowMs + TERMINAL_CONNECT_EXPIRY_SKEW_MS;
+}
 
 /** Decode an inbound ttyd frame's payload (everything after the 1-char command).
  *  ttyd may send either a text frame (string) or a binary frame (ArrayBuffer);
@@ -73,6 +95,9 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
   const { capability, onOutput, onTitle, initialCols, initialRows } = options;
   const [status, setStatus] = useState<TerminalStreamStatus>("closed");
   const wsRef = useRef<WebSocket | null>(null);
+  const pendingInputRef = useRef("");
+  const socketFailedRef = useRef(false);
+  const socketAuthenticatedRef = useRef(false);
   // Latest size, so a resize() before the socket opens is replayed on open, and a
   // reconnect seeds the right geometry.
   const sizeRef = useRef<{ cols: number; rows: number }>({
@@ -89,12 +114,35 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
   const transport = capability?.transport ?? null;
   const url = capability?.url ?? null;
   const token = capability?.token ?? null;
+  const expiresAt = capability?.expiresAt ?? null;
 
   useEffect(() => {
     // SSR / no WebSocket / not a live pty-ws cell: stay closed; the caller falls
     // back to the Channel-A read-only firehose.
     if (typeof window === "undefined" || typeof WebSocket === "undefined") return;
-    if (transport !== "pty-ws" || !url) {
+    if (transport !== "pty-ws") {
+      // A transport downgrade is a real semantic boundary. Do not replay input
+      // captured for a PTY if this surface later changes back from firehose mode.
+      pendingInputRef.current = "";
+      socketAuthenticatedRef.current = false;
+      setStatus("closed");
+      return;
+    }
+    // A changed/cleared credential is a new connection attempt boundary. It may
+    // receive input while its exact grant is pending even if the prior socket
+    // failed; the unchanged failed identity remains fenced because this effect
+    // does not re-run for a status-only render.
+    socketFailedRef.current = false;
+    socketAuthenticatedRef.current = false;
+    if (!url) {
+      // Exact grants arrive asynchronously. Preserve the bounded first input
+      // while the descriptor remains pty-ws, but never open without a credential.
+      setStatus("closed");
+      return;
+    }
+    if (!terminalStreamCredentialUsable({ transport, url, expiresAt })) {
+      // A descriptor from an older rolling server may still carry a bearer that
+      // aged out before this surface mounted. Wait for the exact fresh grant.
       setStatus("closed");
       return;
     }
@@ -107,6 +155,7 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
       // it. The scoped token is already in the tunnel `url`.
       socket = new WebSocket(terminalSocketUrl({ url }), TTYD_SUBPROTOCOL);
     } catch {
+      socketFailedRef.current = true;
       setStatus("error");
       return;
     }
@@ -121,8 +170,22 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
       try {
         socket.send(ttydAuthFrame({ columns: sizeRef.current.cols, rows: sizeRef.current.rows }));
         socket.send(ttydResizeFrame(sizeRef.current.cols, sizeRef.current.rows));
+        if (pendingInputRef.current.length > 0) {
+          // One websocket frame makes the pre-open queue all-or-nothing from this
+          // client's perspective; never execute a prefix of a buffered command.
+          socket.send(ttydInputFrame(pendingInputRef.current));
+          pendingInputRef.current = "";
+        }
+        socketAuthenticatedRef.current = true;
       } catch {
-        // a closed socket between open and send — onclose handles state.
+        socketFailedRef.current = true;
+        setStatus("error");
+        try {
+          socket.close();
+        } catch {
+          // already closed
+        }
+        return;
       }
       setStatus("open");
     };
@@ -144,15 +207,21 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
     };
 
     socket.onerror = () => {
-      if (!disposed) setStatus("error");
+      if (!disposed) {
+        socketFailedRef.current = true;
+        setStatus("error");
+      }
     };
     socket.onclose = () => {
-      if (!disposed) setStatus("closed");
+      if (wsRef.current === socket) wsRef.current = null;
+      socketAuthenticatedRef.current = false;
+      if (!disposed) setStatus(socketFailedRef.current ? "error" : "closed");
     };
 
     return () => {
       disposed = true;
       wsRef.current = null;
+      socketAuthenticatedRef.current = false;
       // Drop handlers so an in-flight close/error doesn't mutate state post-unmount.
       socket.onopen = null;
       socket.onmessage = null;
@@ -166,24 +235,46 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
     };
     // A url/token change (rotation) re-runs this effect → close old, open new.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [transport, url, token]);
+  }, [transport, url, token, expiresAt]);
 
   return useMemo<UseTerminalStreamResult>(() => {
     const write = (data: string) => {
       const ws = wsRef.current;
-      if (ws && ws.readyState === WebSocket.OPEN) {
+      if (ws && ws.readyState === WebSocket.OPEN && socketAuthenticatedRef.current) {
         try {
           ws.send(ttydInputFrame(data));
         } catch {
-          // socket raced closed — the reconnect effect will re-establish.
+          socketFailedRef.current = true;
+          setStatus("error");
+          try {
+            ws.close();
+          } catch {
+            // already closed
+          }
         }
+      } else if (transport === "pty-ws" && !socketFailedRef.current) {
+        const nextSize = pendingInputRef.current.length + data.length;
+        if (nextSize > MAX_PENDING_TERMINAL_INPUT_CODE_UNITS) {
+          pendingInputRef.current = "";
+          socketFailedRef.current = true;
+          setStatus("error");
+          if (ws) {
+            try {
+              ws.close();
+            } catch {
+              // already closed
+            }
+          }
+          return;
+        }
+        pendingInputRef.current += data;
       }
     };
     const resize = (cols: number, rows: number) => {
       if (cols <= 0 || rows <= 0) return;
       sizeRef.current = { cols, rows };
       const ws = wsRef.current;
-      if (ws && ws.readyState === WebSocket.OPEN) {
+      if (ws && ws.readyState === WebSocket.OPEN && socketAuthenticatedRef.current) {
         try {
           ws.send(ttydResizeFrame(cols, rows));
         } catch {
@@ -194,6 +285,10 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
     const disconnect = () => {
       const ws = wsRef.current;
       wsRef.current = null;
+      pendingInputRef.current = "";
+      socketFailedRef.current = false;
+      socketAuthenticatedRef.current = false;
+      setStatus("closed");
       if (ws) {
         try {
           ws.close();
@@ -203,5 +298,5 @@ export function useTerminalStream(options: UseTerminalStreamOptions): UseTermina
       }
     };
     return { connected: status === "open", status, write, resize, disconnect };
-  }, [status]);
+  }, [status, transport]);
 }

--- a/packages/react/src/lib/terminal-capability.ts
+++ b/packages/react/src/lib/terminal-capability.ts
@@ -1,0 +1,10 @@
+import type { TerminalCapability } from "@opengeni/sdk";
+
+/** Whether an explicit viewer grant can upgrade this cell to a real PTY.
+ * Keep acquisition feasibility separate from the current transport: a cold
+ * real-PTY backend reports sse-events until the just-in-time grant warms it. */
+export function terminalCanAcquirePty(cell: TerminalCapability | null | undefined): boolean {
+  if (!cell?.ptyCapable) return false;
+  if (cell.transport === "pty-ws") return true;
+  return cell.reason === "lease_cold" || cell.reason === "not_provisioned";
+}

--- a/packages/react/test/sandbox-fixtures.ts
+++ b/packages/react/test/sandbox-fixtures.ts
@@ -34,6 +34,7 @@ export function fakeCapabilities(
       shell: "/bin/bash",
       url: null,
       token: null,
+      expiresAt: null,
       reason: null,
     },
     Git: { available: true, repos: ["."], reason: null },
@@ -88,6 +89,15 @@ export function fakeColdCapabilities(): SessionCapabilities {
   return fakeCapabilities({
     liveness: "cold",
     leaseEpoch: 0,
+    Terminal: {
+      transport: "sse-events",
+      ptyCapable: true,
+      shell: "/bin/bash",
+      url: null,
+      token: null,
+      expiresAt: null,
+      reason: "lease_cold",
+    },
     DesktopStream: {
       transport: null,
       client: null,
@@ -126,6 +136,7 @@ export function fakeAttachResponse(
     client: "novnc",
     terminalUrl: null,
     terminalToken: null,
+    terminalExpiresAt: null,
     terminalTransport: null,
     ...overrides,
   };

--- a/packages/react/test/sandbox-hooks.test.tsx
+++ b/packages/react/test/sandbox-hooks.test.tsx
@@ -4,7 +4,7 @@
    terminal/files/git hooks project Channel-A data; stream.url.rotated folds in.
    -------------------------------------------------------------------------- */
 import { describe, expect, test } from "bun:test";
-import { OpenGeniApiError, type SessionEvent } from "@opengeni/sdk";
+import { OpenGeniApiError, type AttachViewerRequest, type SessionEvent } from "@opengeni/sdk";
 import { actRun, registerDom, renderHook, flush } from "./render-hook";
 import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
 import {
@@ -283,6 +283,25 @@ describe("useSessionCapabilities", () => {
     await hook.unmount();
   });
 
+  test("attachTerminal on a firehose-only backend never acquires a holder", async () => {
+    let attachCalls = 0;
+    const client = fakeClient({
+      getStreamCapabilities: async () => fakeHeadlessCapabilities(),
+      attachViewer: async () => {
+        attachCalls += 1;
+        return fakeAttachResponse();
+      },
+    });
+    const hook = await renderHook(
+      () => useSessionCapabilities(SESSION_ID, { ...ctx, client, attachTerminal: true }),
+      undefined,
+    );
+    await flush();
+    expect(attachCalls).toBe(0);
+    expect(hook.result.current.state).toBe("ready");
+    await hook.unmount();
+  });
+
   test.each(["cold", "draining"] as const)(
     "attachFiles explicitly reacquires a %s box for wake-on-edit",
     async (liveness) => {
@@ -290,14 +309,18 @@ describe("useSessionCapabilities", () => {
       // across teardown. Passive review stays capture-backed; this explicit path
       // asks the server to cold-create or safely re-arm before returning warm.
       let attachCalls = 0;
-      let attachOpts: { desktop?: boolean } | null = null;
+      const attachRequests: AttachViewerRequest[] = [];
       const client = fakeClient({
         getStreamCapabilities: async () =>
           liveness === "cold" ? fakeColdCapabilities() : fakeCapabilities({ liveness: "draining" }),
-        attachViewer: async (_w: string, _s: string, opts: { desktop?: boolean }) => {
+        attachViewer: async (_w: string, _s: string, opts: AttachViewerRequest) => {
           attachCalls += 1;
-          attachOpts = opts;
-          return fakeAttachResponse();
+          attachRequests.push(opts);
+          return fakeAttachResponse({
+            terminalUrl: "https://terminal.example/should-not-fold",
+            terminalToken: "unrequested",
+            terminalTransport: "pty-ws",
+          });
         },
         heartbeatViewer: async () => ({ alive: true }),
         detachViewer: async () => {},
@@ -308,13 +331,78 @@ describe("useSessionCapabilities", () => {
       );
       await flush();
       expect(attachCalls).toBe(1);
-      expect(attachOpts).not.toBeNull();
-      expect((attachOpts as unknown as { desktop?: boolean }).desktop).toBe(false);
+      expect(attachRequests[0]).toEqual({ desktop: false, terminal: false, files: true });
+      expect(hook.result.current.capabilities?.Terminal.url).toBeNull();
       // A holder was minted → the box is live, not resting on the benign on-demand state.
       expect(hook.result.current.state).toBe("ready");
       await hook.unmount();
     },
   );
+
+  test("terminal intent requests and folds only a fresh terminal grant", async () => {
+    const attachRequests: AttachViewerRequest[] = [];
+    const client = fakeClient({
+      getStreamCapabilities: async () => fakeColdCapabilities(),
+      attachViewer: async (_w, _s, opts = {}) => {
+        attachRequests.push(opts);
+        return fakeAttachResponse({
+          dataPlaneUrl: null,
+          streamToken: null,
+          streamExpiresAt: null,
+          transport: null,
+          client: null,
+          terminalUrl: "https://terminal.example/fresh",
+          terminalToken: "fresh-terminal-token",
+          terminalExpiresAt: "2026-08-09T12:02:00.000Z",
+          terminalTransport: "pty-ws",
+        });
+      },
+      heartbeatViewer: async () => ({ alive: true }),
+      detachViewer: async () => {},
+    });
+    const hook = await renderHook(
+      () => useSessionCapabilities(SESSION_ID, { ...ctx, client, attachTerminal: true }),
+      undefined,
+    );
+    await flush();
+
+    expect(attachRequests[0]).toEqual({ desktop: false, terminal: true, files: false });
+    expect(hook.result.current.capabilities?.Terminal).toMatchObject({
+      transport: "pty-ws",
+      url: "https://terminal.example/fresh",
+      token: "fresh-terminal-token",
+      expiresAt: "2026-08-09T12:02:00.000Z",
+    });
+    expect(hook.result.current.capabilities?.DesktopStream.url).toBeNull();
+    await hook.unmount();
+  });
+
+  test("an explicit terminal grant that degrades releases its holder and surfaces an error", async () => {
+    const detached: string[] = [];
+    const client = fakeClient({
+      getStreamCapabilities: async () => fakeColdCapabilities(),
+      attachViewer: async () =>
+        fakeAttachResponse({
+          terminalUrl: null,
+          terminalToken: null,
+          terminalExpiresAt: null,
+          terminalTransport: null,
+        }),
+      detachViewer: async (_workspaceId, _sessionId, viewerId) => {
+        detached.push(viewerId);
+      },
+    });
+    const hook = await renderHook(
+      () => useSessionCapabilities(SESSION_ID, { ...ctx, client, attachTerminal: true }),
+      undefined,
+    );
+    await flush();
+
+    expect(hook.result.current.state).toBe("error");
+    expect(hook.result.current.error?.message).toContain("grant was unavailable");
+    expect(detached).toEqual([fakeAttachResponse().viewerId]);
+    await hook.unmount();
+  });
 
   test("no attach intent: a cold session NEVER calls attachViewer — browsing is free (Refinement 1)", async () => {
     // With no desktop/terminal/edit intent, a cold lease must warm nothing: reviewing

--- a/packages/react/test/sandbox-hooks.test.tsx
+++ b/packages/react/test/sandbox-hooks.test.tsx
@@ -399,7 +399,7 @@ describe("useSessionCapabilities", () => {
     await flush();
 
     expect(hook.result.current.state).toBe("error");
-    expect(hook.result.current.error?.message).toContain("grant was unavailable");
+    expect(hook.result.current.error?.message).toBe("live plane unavailable");
     expect(detached).toEqual([fakeAttachResponse().viewerId]);
     await hook.unmount();
   });

--- a/packages/react/test/sandbox-terminal.test.ts
+++ b/packages/react/test/sandbox-terminal.test.ts
@@ -20,12 +20,12 @@ import {
 } from "../src/lib/xterm-theme";
 import {
   clearTerminalBootStatus,
-  guardTerminalEngagement,
   subscribeTerminalInput,
-  terminalInputEngagementAllowed,
   terminalSurfaceState,
   type XtermTheme,
 } from "../src/components/sandbox-terminal";
+import { terminalStreamCredentialUsable } from "../src/hooks/use-terminal-stream";
+import { terminalCanAcquirePty } from "../src/lib/terminal-capability";
 
 const tick = () => new Promise<void>((r) => setTimeout(r, 0));
 
@@ -118,25 +118,7 @@ describe("terminal semantic readiness", () => {
     ).toBe("interactive");
   });
 
-  test("pre-connect engagement does not focus, advertise, or send input", () => {
-    const calls: string[] = [];
-    let emit: ((data: string) => void) | undefined;
-    const term = {
-      onData(callback: (data: string) => void) {
-        emit = callback;
-        calls.push("subscribed");
-        return { dispose: () => calls.push("disposed") };
-      },
-    };
-    const sent: string[] = [];
-    const subscription = subscribeTerminalInput(term, (data) => sent.push(data), false);
-    const event = {
-      preventDefault: () => calls.push("prevented"),
-      stopPropagation: () => calls.push("stopped"),
-      target: { blur: () => calls.push("blurred") },
-    };
-
-    expect(subscription).toBeNull();
+  test("reports queued pre-connect input as connecting, not live", () => {
     expect(
       terminalSurfaceState({
         ready: true,
@@ -146,87 +128,56 @@ describe("terminal semantic readiness", () => {
         booting: false,
       }),
     ).toBe("connecting");
-    expect(guardTerminalEngagement(event, false, true)).toBe(true);
-    emit?.("lost input");
-    expect(sent).toEqual([]);
-    expect(calls).toEqual(["prevented", "stopped", "blurred"]);
   });
 
-  test("post-connect engagement stays focusable and typed bytes reach the PTY sink", () => {
-    const calls: string[] = [];
+  test("subscribes xterm before the live PTY opens so first input reaches the bounded sink", () => {
     let emit: ((data: string) => void) | undefined;
     const term = {
       onData(callback: (data: string) => void) {
         emit = callback;
-        calls.push("subscribed");
-        return { dispose: () => calls.push("disposed") };
+        return { dispose() {} };
       },
     };
-    const sent: string[] = [];
-    const subscription = subscribeTerminalInput(term, (data) => sent.push(data), true);
-    const event = {
-      preventDefault: () => calls.push("prevented"),
-      stopPropagation: () => calls.push("stopped"),
-      target: { blur: () => calls.push("blurred") },
-    };
-
+    const captured: string[] = [];
+    const subscription = subscribeTerminalInput(term, (data) => captured.push(data), true);
+    emit?.("first command\r");
     expect(subscription).not.toBeNull();
-    expect(
-      terminalSurfaceState({
-        ready: true,
-        acceptsInput: subscription !== null,
-        inputPending: false,
-        ptyStatus: "open",
-        booting: false,
-      }),
-    ).toBe("interactive");
-    expect(guardTerminalEngagement(event, true, true)).toBe(false);
-    emit?.("printf 'ready'\r");
-    expect(sent).toEqual(["printf 'ready'\r"]);
-    expect(calls).toEqual(["subscribed"]);
-    subscription?.dispose();
-    expect(calls).toEqual(["subscribed", "disposed"]);
+    expect(captured).toEqual(["first command\r"]);
   });
+});
 
-  test("permanent output-only capability still activates without blocking selection", () => {
-    const calls: string[] = [];
-    const event = {
-      preventDefault: () => calls.push("prevented"),
-      stopPropagation: () => calls.push("stopped"),
-      target: { blur: () => calls.push("blurred") },
-    };
-    calls.push("activated");
-    const inputAllowed = terminalInputEngagementAllowed({
-      acceptsInput: false,
-      readOnly: false,
-      ptyCapable: false,
-      ptyWs: false,
-      hasWrite: false,
-    });
+test("terminal websocket handshakes reject stale grants but retain unexpiring URLs", () => {
+  const now = Date.parse("2026-08-09T12:00:00.000Z");
+  const capability = {
+    transport: "pty-ws" as const,
+    ptyCapable: true,
+    shell: "/bin/bash",
+    url: "https://terminal.example/pty",
+    token: "scoped",
+    expiresAt: "2026-08-09T12:00:04.000Z",
+    reason: null,
+  };
+  expect(terminalStreamCredentialUsable(capability, now)).toBe(false);
+  expect(
+    terminalStreamCredentialUsable({ ...capability, expiresAt: "2026-08-09T12:00:06.000Z" }, now),
+  ).toBe(true);
+  expect(terminalStreamCredentialUsable({ ...capability, expiresAt: null }, now)).toBe(true);
+});
 
-    expect(guardTerminalEngagement(event, inputAllowed, true)).toBe(false);
-    expect(calls).toEqual(["activated"]);
-  });
-
-  test("cold PTY-capable engagement activates warm-up but blocks pre-connect focus", () => {
-    const calls: string[] = [];
-    const event = {
-      preventDefault: () => calls.push("prevented"),
-      stopPropagation: () => calls.push("stopped"),
-      target: { blur: () => calls.push("blurred") },
-    };
-    calls.push("activated");
-    const inputAllowed = terminalInputEngagementAllowed({
-      acceptsInput: false,
-      readOnly: false,
-      ptyCapable: true,
-      ptyWs: false,
-      hasWrite: false,
-    });
-
-    expect(guardTerminalEngagement(event, inputAllowed, true)).toBe(true);
-    expect(calls).toEqual(["activated", "prevented", "stopped", "blurred"]);
-  });
+test("only a real PTY or transiently cold real-PTY cell can request a grant", () => {
+  const base = {
+    transport: "sse-events" as const,
+    ptyCapable: true,
+    shell: "/bin/bash",
+    url: null,
+    token: null,
+    expiresAt: null,
+    reason: "lease_cold" as const,
+  };
+  expect(terminalCanAcquirePty(base)).toBe(true);
+  expect(terminalCanAcquirePty({ ...base, reason: "not_provisioned" })).toBe(true);
+  expect(terminalCanAcquirePty({ ...base, reason: "disabled_by_policy" })).toBe(false);
+  expect(terminalCanAcquirePty({ ...base, ptyCapable: false, reason: null })).toBe(false);
 });
 
 // ── E1: renderer fallback ladder ─────────────────────────────────────────────

--- a/packages/react/test/terminal-stream.test.tsx
+++ b/packages/react/test/terminal-stream.test.tsx
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { actRun, flush, registerDom, renderHook } from "./render-hook";
+import {
+  MAX_PENDING_TERMINAL_INPUT_CODE_UNITS,
+  useTerminalStream,
+} from "../src/hooks/use-terminal-stream";
+
+registerDom();
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  binaryType = "blob";
+  readonly sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string | ArrayBuffer }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(
+    readonly url: string,
+    readonly protocols?: string | string[],
+  ) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    if (this.readyState !== FakeWebSocket.OPEN) throw new Error("socket is not open");
+    this.sent.push(data);
+  }
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+const originalWebSocket = globalThis.WebSocket;
+const capability = (url: string | null) => ({
+  transport: "pty-ws" as const,
+  url,
+  token: "scoped",
+  expiresAt: null,
+});
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+  globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+  globalThis.WebSocket = originalWebSocket;
+});
+
+describe("useTerminalStream connection boundary", () => {
+  test("buffers pre-open input and flushes it only after ttyd auth and resize", async () => {
+    const hook = await renderHook(
+      () => useTerminalStream({ capability: capability("https://terminal.example/one") }),
+      undefined,
+    );
+    await flush();
+    const socket = FakeWebSocket.instances[0]!;
+    expect(hook.result.current.status).toBe("connecting");
+
+    await actRun(() => {
+      hook.result.current.write("printf '");
+      hook.result.current.write("ready\\n'");
+    });
+    expect(socket.sent).toEqual([]);
+
+    await actRun(() => socket.open());
+    await flush();
+    expect(hook.result.current.status).toBe("open");
+    expect(socket.sent).toHaveLength(3);
+    expect(socket.sent[0]).toContain("AuthToken");
+    expect(socket.sent[1]?.startsWith("1")).toBe(true);
+    expect(socket.sent[2]).toBe("0printf 'ready\\n'");
+    await hook.unmount();
+  });
+
+  test("does not treat websocket OPEN as ttyd-authenticated", async () => {
+    const hook = await renderHook(
+      () => useTerminalStream({ capability: capability("https://terminal.example/auth-race") }),
+      undefined,
+    );
+    await flush();
+    const socket = FakeWebSocket.instances[0]!;
+    socket.readyState = FakeWebSocket.OPEN;
+    await actRun(() => hook.result.current.write("queued-before-auth\n"));
+    expect(socket.sent).toEqual([]);
+
+    await actRun(() => socket.onopen?.());
+    await flush();
+    expect(socket.sent[0]).toContain("AuthToken");
+    expect(socket.sent[1]?.startsWith("1")).toBe(true);
+    expect(socket.sent[2]).toBe("0queued-before-auth\n");
+    await hook.unmount();
+  });
+
+  test("preserves first input while an exact terminal grant is still being minted", async () => {
+    const initial: { url: string | null } = { url: null };
+    const hook = await renderHook(
+      (props: { url: string | null }) => useTerminalStream({ capability: capability(props.url) }),
+      initial,
+    );
+    await flush();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    await actRun(() => hook.result.current.write("echo preserved\\n"));
+
+    await hook.rerender({ url: "https://terminal.example/fresh" });
+    await flush();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    const fresh = FakeWebSocket.instances[0]!;
+    await actRun(() => fresh.open());
+    await flush();
+    expect(fresh.sent.at(-1)).toBe("0echo preserved\\n");
+    await hook.unmount();
+  });
+
+  test("rejects a stale rolling credential and replays input only to its fresh replacement", async () => {
+    type Props = { url: string; expiresAt: string };
+    const hook = await renderHook(
+      (props: Props) =>
+        useTerminalStream({ capability: { ...capability(props.url), expiresAt: props.expiresAt } }),
+      { url: "https://terminal.example/stale", expiresAt: "2000-01-01T00:00:00.000Z" },
+    );
+    await flush();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    await actRun(() => hook.result.current.write("fresh-only\n"));
+
+    await hook.rerender({
+      url: "https://terminal.example/fresh-after-stale",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+    });
+    await flush();
+    const fresh = FakeWebSocket.instances[0]!;
+    await actRun(() => fresh.open());
+    await flush();
+    expect(fresh.sent.at(-1)).toBe("0fresh-only\n");
+    await hook.unmount();
+  });
+
+  test("preserves input across a clean socket close and credential rotation", async () => {
+    const hook = await renderHook(
+      (props: { url: string }) => useTerminalStream({ capability: capability(props.url) }),
+      { url: "https://terminal.example/old" },
+    );
+    await flush();
+    const old = FakeWebSocket.instances[0]!;
+    await actRun(() => old.open());
+    await actRun(() => old.close());
+    await flush();
+    await actRun(() => hook.result.current.write("echo after-rotation\n"));
+
+    await hook.rerender({ url: "https://terminal.example/new" });
+    await flush();
+    const fresh = FakeWebSocket.instances[1]!;
+    await actRun(() => fresh.open());
+    await flush();
+    expect(fresh.sent.at(-1)).toBe("0echo after-rotation\n");
+    await hook.unmount();
+  });
+
+  test("drops queued PTY input across a transport downgrade", async () => {
+    type Props = { transport: "pty-ws" | "sse-events"; url: string | null };
+    const initial: Props = { transport: "pty-ws", url: null };
+    const hook = await renderHook(
+      (props: Props) =>
+        useTerminalStream({
+          capability: {
+            transport: props.transport,
+            url: props.url,
+            token: null,
+            expiresAt: null,
+          },
+        }),
+      initial,
+    );
+    await flush();
+    await actRun(() => hook.result.current.write("must-not-replay\n"));
+    await hook.rerender({ transport: "sse-events", url: null });
+    await flush();
+    await hook.rerender({ transport: "pty-ws", url: "https://terminal.example/reacquired" });
+    await flush();
+    const socket = FakeWebSocket.instances[0]!;
+    await actRun(() => socket.open());
+    await flush();
+    expect(socket.sent).toHaveLength(2);
+    await hook.unmount();
+  });
+
+  test("fails the connection without sending a truncated command on queue overflow", async () => {
+    const hook = await renderHook(
+      () => useTerminalStream({ capability: capability("https://terminal.example/overflow") }),
+      undefined,
+    );
+    await flush();
+    const socket = FakeWebSocket.instances[0]!;
+
+    await actRun(() =>
+      hook.result.current.write("x".repeat(MAX_PENDING_TERMINAL_INPUT_CODE_UNITS + 1)),
+    );
+    await flush();
+    expect(hook.result.current.status).toBe("error");
+    expect(socket.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(socket.sent).toEqual([]);
+    await hook.unmount();
+  });
+});

--- a/packages/runtime/src/sandbox/select.ts
+++ b/packages/runtime/src/sandbox/select.ts
@@ -70,9 +70,9 @@ export interface NegotiationContext {
   sharedSessionIds?: string[];
   /**
    * The minted pixel-plane endpoint (P4.2): the direct-to-provider WS URL + the
-   * scoped stream token + its expiry + the framebuffer geometry. Threaded by the
-   * API-direct handshake AFTER it has resumed the box, ensured the display stack,
-   * and resolved the provider tunnel. When ABSENT (the negotiation-only read, a
+   * scoped stream token + its expiry + the framebuffer geometry. Threaded only by
+   * the explicit viewer grant AFTER it has resumed the box, ensured the display
+   * stack, and resolved the provider tunnel. When ABSENT (the descriptor read, a
    * cold lease, or a degraded desktop) the DesktopStream cell reports url/token/
    * expiresAt as null — the capability is advertised, the live address is not yet
    * minted (the caller POSTs to /viewers to mint it). Presence does NOT override
@@ -93,7 +93,7 @@ export interface NegotiationContext {
   /**
    * The minted terminal-plane endpoint (P5.t): the direct-to-provider ttyd
    * PTY-over-websocket URL + the scoped stream token + its expiry. Threaded by the
-   * API-direct handshake AFTER it has resumed the box, ensured the terminal
+   * explicit viewer grant AFTER it has resumed the box, ensured the terminal
    * server, and resolved the provider tunnel (mintTerminalStream) — SYMMETRIC with
    * `desktopStream`. When ABSENT (the negotiation-only read, a cold lease, or a
    * degraded terminal) the Terminal cell reports url/token/expiresAt as null and
@@ -261,7 +261,7 @@ export function negotiateCapabilities(ctx: NegotiationContext): SessionCapabilit
     const ptyCapable = cap.pty;
     let transport: "pty-ws" | "sse-events" = ptyCapable ? "pty-ws" : "sse-events";
     let reason: CapabilityUnavailableReason | null = null;
-    if (ptyCapable && ctx.terminalEnabled === false) {
+    if (ptyCapable && (ctx.terminalEnabled === false || ctx.streamTokenSecretAvailable === false)) {
       transport = "sse-events";
       reason = "disabled_by_policy";
     } else if (ptyCapable && ctx.liveness !== "warm" && !ctx.terminalStream) {

--- a/packages/runtime/test/sandbox-provider-registry.test.ts
+++ b/packages/runtime/test/sandbox-provider-registry.test.ts
@@ -531,6 +531,23 @@ describe("negotiateCapabilities — coherent doc, degrades as a value", () => {
     expect(caps.Terminal.url).toBeNull();
   });
 
+  test("missing stream-token authority disables every credentialed live plane", () => {
+    const caps = negotiateCapabilities({
+      ...base,
+      backend: "modal",
+      liveness: "warm",
+      streamTokenSecretAvailable: false,
+    });
+    expect(caps.DesktopStream.transport).toBeNull();
+    expect(caps.DesktopStream.reason).toBe("disabled_by_policy");
+    expect(caps.DesktopStream.url).toBeNull();
+    expect(caps.DesktopStream.token).toBeNull();
+    expect(caps.Terminal.transport).toBe("sse-events");
+    expect(caps.Terminal.reason).toBe("disabled_by_policy");
+    expect(caps.Terminal.url).toBeNull();
+    expect(caps.Terminal.token).toBeNull();
+  });
+
   // The ack gate is NOT weakened by honouring a cold-but-minted desktop: a minted
   // url with NO acknowledgment is still withheld (the un-redacted-pixel consent
   // gate). The cell stays available (liveness honoured) but the live url is dropped.

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2093,13 +2093,11 @@ export class OpenGeniClient {
   }
 
   /** Attach a viewer holder (refcounted liveness — keeps the box warm while
-   *  watched/used), spinning the box up in-process when cold, and mint the scoped
-   *  direct-to-provider URLs for the requested plane(s). `request.desktop:true`
-   *  opts into the un-redacted pixel plane and mints the noVNC URL — that plane
-   *  alone throws `OpenGeniApiError(409)` when the un-redacted/shared
-   *  acknowledgment is missing (the consent gate). A terminal-only attach
-   *  (`desktop` omitted/false) warms the box + mints the pty-ws terminal cell with
-   *  NO consent gate. An omitted `viewerId` mints a fresh one. */
+   *  watched/used), spinning the box up in-process when cold. Exact plane flags
+   *  mint only the requested short-lived credentials and enforce that plane's
+   *  permission. `desktop:true` alone carries the un-redacted/shared consent
+   *  gate. An entirely omitted plane set retains the legacy terminal-only
+   *  meaning; current clients should send all three flags. */
   async attachViewer(
     workspaceId: string,
     sessionId: string,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -287,6 +287,7 @@ export type SessionCapabilities = {
     shell: string;
     url: string | null;
     token: string | null;
+    expiresAt: string | null;
     reason: CapabilityUnavailableReason | null;
   };
   Git: {
@@ -374,12 +375,14 @@ export type StreamRevokedPayload = {
 
 // Mirror of `@opengeni/contracts` AttachViewerRequest. Omitting `viewerId` mints
 // a fresh holder id (returned on the response, carried through heartbeat/detach).
-// `desktop:true` opts into the un-redacted pixel plane (the consent-gated noVNC
-// stream); a terminal/files-only warm attach omits it (defaults false) so it
-// warms the box + mints the pty-ws terminal cell WITHOUT tripping the consent 409.
+// Plane flags are exact: credentials are minted only for the requested live
+// surfaces and each surface enforces its own permission. An omitted plane set is
+// retained as the legacy terminal-only request; current clients send all flags.
 export type AttachViewerRequest = {
   viewerId?: string | undefined;
   desktop?: boolean | undefined;
+  terminal?: boolean | undefined;
+  files?: boolean | undefined;
 };
 
 // Mirror of `@opengeni/contracts` ViewerHolder + the P4.2 desktop-stream fields
@@ -402,8 +405,8 @@ export type AttachViewerResponse = ViewerHolder & {
   streamToken: string | null;
   streamExpiresAt: string | null;
   resolution: [number, number] | null;
-  transport: "vnc-ws" | null;
-  client: "novnc" | null;
+  transport: "vnc-ws" | "relay-frames" | null;
+  client: "novnc" | "frames" | null;
   // The scoped ttyd PTY-over-websocket address minted for THIS holder — the REAL
   // interactive terminal, symmetric with the desktop pixel plane (same Modal
   // tunnel, same scoped stream token). Populated on a warm box; null when the
@@ -412,6 +415,7 @@ export type AttachViewerResponse = ViewerHolder & {
   // `terminalTransport` is "pty-ws" iff a live `terminalUrl` was minted.
   terminalUrl: string | null;
   terminalToken: string | null;
+  terminalExpiresAt: string | null;
   terminalTransport: "pty-ws" | null;
 };
 

--- a/packages/sdk/test/contract-parity.test.ts
+++ b/packages/sdk/test/contract-parity.test.ts
@@ -5,6 +5,7 @@ import {
   AcknowledgeStreamResponse as ContractAcknowledgeStreamResponse,
   AddWorkspaceMemberRequest as ContractAddWorkspaceMemberRequest,
   AttachViewerRequest as ContractAttachViewerRequest,
+  AttachViewerResponse as ContractAttachViewerResponse,
   BeginSessionRealtimeRequest as ContractBeginSessionRealtimeRequest,
   CAPABILITY_DESCRIPTORS,
   ClientConfig as ContractClientConfig,
@@ -93,6 +94,7 @@ import type {
   AcknowledgeStreamResponse,
   AddWorkspaceMemberRequest,
   AttachViewerRequest,
+  AttachViewerResponse,
   BeginSessionRealtimeRequest,
   CreateKnowledgeMemoryRequest,
   FirstPartyMcpToolName,
@@ -770,6 +772,12 @@ describe("SDK / contracts parity", () => {
       v: z.infer<typeof ContractWorkspaceModelCatalogResponse>,
     ): WorkspaceModelCatalogResponse => v;
     const acceptViewerHolder = (v: z.infer<typeof ContractViewerHolder>): ViewerHolder => v;
+    const acceptAttachResponse = (
+      v: z.infer<typeof ContractAttachViewerResponse>,
+    ): AttachViewerResponse => v;
+    const acceptContractAttachResponse = (
+      v: AttachViewerResponse,
+    ): z.infer<typeof ContractAttachViewerResponse> => v;
     const acceptHeartbeatResponse = (
       v: z.infer<typeof ContractViewerHeartbeatResponse>,
     ): ViewerHeartbeatResponse => v;
@@ -788,6 +796,8 @@ describe("SDK / contracts parity", () => {
       acceptClientConfig,
       acceptWorkspaceModelCatalog,
       acceptViewerHolder,
+      acceptAttachResponse,
+      acceptContractAttachResponse,
       acceptHeartbeatResponse,
       acceptAckResponse,
       acceptRotated,
@@ -798,6 +808,9 @@ describe("SDK / contracts parity", () => {
     // Client -> server: SDK-sent request bodies parse under the contracts schema.
     const attach: AttachViewerRequest = {
       viewerId: "33333333-3333-4333-8333-333333333333",
+      desktop: false,
+      terminal: false,
+      files: true,
     };
     const ack: AcknowledgeStreamRequest = {
       acknowledgeUnredacted: true,

--- a/scripts/ci/profile-command.ts
+++ b/scripts/ci/profile-command.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { constants } from "node:os";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -132,6 +132,22 @@ export function parseGnuTime(output: string): GnuTimeMetrics {
   };
 }
 
+function resolveGnuTime(): string | null {
+  // `/usr/bin/time` is BSD time on macOS and rejects GNU-only `-v -o --` with
+  // exit 1. Probe the binary rather than treating path existence as a wire
+  // contract; Homebrew exposes GNU time as `gtime`.
+  for (const candidate of ["/usr/bin/time", "gtime"]) {
+    const probe = spawnSync(candidate, ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (probe.status === 0 && /gnu time/i.test(`${probe.stdout ?? ""}\n${probe.stderr ?? ""}`)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const separator = args.indexOf("--");
@@ -170,8 +186,9 @@ async function main(): Promise<void> {
   let peakMemoryBytes = before.memoryBytes;
   const startedAt = new Date();
   const started = performance.now();
-  const wrapped = existsSync("/usr/bin/time")
-    ? ["/usr/bin/time", "-v", "-o", temporaryTimePath, "--", ...command]
+  const gnuTimeExecutable = resolveGnuTime();
+  const wrapped = gnuTimeExecutable
+    ? [gnuTimeExecutable, "-v", "-o", temporaryTimePath, "--", ...command]
     : command;
   const useProcessGroup = process.platform !== "win32";
   const child = spawn(wrapped[0] as string, wrapped.slice(1), {

--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -132,7 +132,11 @@ describe("workbench live acceptance preflight", () => {
       ["page.locator", "[data-opengeni-terminal]"],
       ["terminal.waitFor", { state: "visible", timeout: 90_000 }],
       ["terminal.click"],
-      ["page.locator", '[data-opengeni-terminal][data-opengeni-terminal-interactive="true"]'],
+      [
+        "page.locator",
+        '[data-opengeni-terminal][data-opengeni-terminal-status="open"]' +
+          '[data-opengeni-terminal-interactive="true"]',
+      ],
       ["interactive.waitFor", { state: "visible", timeout: 90_000 }],
       ["interactive.locator", ".xterm-helper-textarea"],
       ["input.waitFor", { state: "attached", timeout: 90_000 }],

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -47,7 +47,8 @@ const FILE_TREE_MAX_DIAGNOSTIC_ROWS = 8;
 const FILE_TREE_DIAGNOSTIC_FIELD_LENGTH = 80;
 const TERMINAL_SELECTOR = "[data-opengeni-terminal]";
 const INTERACTIVE_TERMINAL_SELECTOR =
-  '[data-opengeni-terminal][data-opengeni-terminal-interactive="true"]';
+  '[data-opengeni-terminal][data-opengeni-terminal-status="open"]' +
+  '[data-opengeni-terminal-interactive="true"]';
 const CAPTURE_API_P95_MS = maximumMillisecondBudget("performance.capture-api-response", "p95");
 const CAPTURE_USABLE_WORKBENCH_P95_MS = maximumMillisecondBudget(
   "performance.capture-usable-workbench",


### PR DESCRIPTION
## Summary
- make capability discovery credential-free and side-effect-free
- grant desktop, terminal, and files independently with exact permissions and response-contract parity
- preserve bounded first terminal input through grant and websocket authentication without pre-mount output buffering
- make live acceptance wait for a truly open PTY and keep command profiling portable across GNU/BSD time

## Verification
- full Bun suite: pass
- typecheck, lint, format, and public-hygiene gates: pass
- focused API, React, runtime, SDK, profiling, and live-acceptance tests: pass