### PR TITLE
fix(slack): decouple hosted OAuth from request signing

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4474,11 +4474,6 @@ function validateSettings(settings: Settings): void {
     );
   }
   if (settings.slackClientId) {
-    if (!settings.slackSigningSecret) {
-      throw new Error(
-        "OPENGENI_SLACK_SIGNING_SECRET is required when the OpenGeni Slack app is configured",
-      );
-    }
     if (!settings.publicBaseUrl) {
       throw new Error(
         "OPENGENI_PUBLIC_BASE_URL is required when the OpenGeni Slack app is configured",

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -167,10 +167,11 @@ describe("OpenGeni Slack interaction settings", () => {
     OPENGENI_SLACK_CLIENT_SECRET: "slack-client-secret",
   };
 
-  test("requires the request signing secret whenever the Slack app is configured", () => {
-    expect(() => withEnv(slackEnv, () => getSettings())).toThrow(
-      "OPENGENI_SLACK_SIGNING_SECRET is required when the OpenGeni Slack app is configured",
-    );
+  test("allows hosted Slack OAuth without enabling signed Slack interactions", () => {
+    const settings = withEnv(slackEnv, () => getSettings());
+    expect(settings.slackClientId).toBe("slack-client-id");
+    expect(settings.slackClientSecret).toBe("slack-client-secret");
+    expect(settings.slackSigningSecret).toBeUndefined();
   });
 
   test("loads the signing secret without projecting it into any public contract", () => {


### PR DESCRIPTION
## Summary
- allow hosted Slack OAuth client credentials without also requiring a Slack request-signing secret
- keep signed Slack interactions opt-in through `OPENGENI_SLACK_SIGNING_SECRET`
- cover the OAuth-only configuration in the config suite

## Verification
- `bun test packages/config/test/config.test.ts` (95 passed)
- `bun run typecheck`
- `bun run lint`
- full `bun test`: 6921 passed, 29 skipped; one unrelated Docker Postgres fixture failed to start on fixed port 61444 and reproduced in isolation (`packages/db/test/codex-credentials.test.ts`)