### PR TITLE
fix(sandbox): resolve lazy cancellation transport

### DIFF
--- a/.changeset/lazy-sandboxes-cancel.md
+++ b/.changeset/lazy-sandboxes-cancel.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Resolve lazy sandbox command cancellation against the physical backend before execution.

--- a/apps/worker/src/sandbox-routing.ts
+++ b/apps/worker/src/sandbox-routing.ts
@@ -47,6 +47,7 @@ import {
   resolveModalCheckpointProviderBindingForSession,
   sandboxProviderInstanceIdFromEnvelope,
   sandboxBackendForSdkBackendId,
+  selectBackend,
   verifySandboxExecReadiness,
   type ControlRpc,
   type EstablishedSandboxSession,
@@ -869,8 +870,17 @@ export function wrapLazyTurnBoxWithRouting(
   const beforeProcessMutation = beforeRetainedProcessMutation(services, ids);
   const afterProcessMutation = afterRetainedProcessMutation(services, ids);
   const settleProcess = settleRetainedProcessForTurn(services, ids);
+  const defaultBackend = sandboxBackendForSdkBackendId(args.backendId);
+  const defaultSupportsPty = defaultBackend
+    ? selectBackend(defaultBackend).capabilities.Terminal.pty
+    : false;
   const syntheticSession: RoutableBackendSession = {
     state: { manifest: args.agentDefaultManifest },
+    // The SDK binds shell tools synchronously before lazy provisioning. Preserve
+    // the authoritative descriptor's PTY shape so a Modal home exposes
+    // write_stdin on its first turn operation; the async cancellation transport
+    // below still resolves the exact live route before executing a command.
+    supportsPty: () => defaultSupportsPty,
   };
   const routedResolver = makeActiveBackendResolver({
     workspaceId: ids.workspaceId,

--- a/apps/worker/test/sandbox-routing.test.ts
+++ b/apps/worker/test/sandbox-routing.test.ts
@@ -686,10 +686,16 @@ describe("M7 worker routing — wrapTurnBoxWithRouting + a real DB pointer + set
     );
     const proxy = lazy.session as {
       state: { manifest: unknown };
+      supportsPty: () => boolean;
+      commandCancellationTransport: () => Promise<"remote_operation" | "shell_session">;
       exec: (a: unknown) => Promise<{ stdout: string }>;
     };
 
     expect(proxy.state.manifest).toBe(manifest);
+    expect(proxy.supportsPty()).toBe(true);
+    expect(provisions).toBe(0);
+    expect(await proxy.commandCancellationTransport()).toBe("shell_session");
+    expect(provisions).toBe(1);
     expect((await proxy.exec({ cmd: "echo hi" })).stdout).toBe("lazy-real");
     expect(provisions).toBe(1);
     expect((await proxy.exec({ cmd: "echo again" })).stdout).toBe("lazy-real");

--- a/packages/runtime/src/sandbox/routing/routing-session.ts
+++ b/packages/runtime/src/sandbox/routing/routing-session.ts
@@ -63,6 +63,7 @@ export interface ActivePointer {
  */
 export interface RoutableBackendSession {
   state?: unknown;
+  commandCancellationTransport?(): Promise<"remote_operation" | "shell_session">;
   exec?(args: unknown): Promise<unknown>;
   execCommand?(args: unknown): Promise<string>;
   writeStdin?(args: unknown): Promise<string>;
@@ -1426,6 +1427,22 @@ export class RoutingSandboxSession implements RoutableBackendSession {
   supportsPty(): boolean {
     const s = (this.lastResolved ?? this.deps.defaultResolved)?.session;
     return Boolean(s?.supportsPty?.());
+  }
+
+  /** Resolve cancellation from the physical backend, not this proxy's
+   * unconditional forwarding methods. Before a lazy first operation the proxy
+   * exposes cancelExecCommand structurally and its synchronous PTY probe may be
+   * only a binding-time hint; combining those two facts would misclassify Modal
+   * as a connected-machine op stream and leave its process uncancellable. */
+  async commandCancellationTransport(): Promise<"remote_operation" | "shell_session"> {
+    const backend = await this.resolve();
+    if (backend.session.commandCancellationTransport) {
+      return await backend.session.commandCancellationTransport();
+    }
+    return typeof backend.session.cancelExecCommand === "function" &&
+      backend.session.supportsPty?.() === false
+      ? "remote_operation"
+      : "shell_session";
   }
 
   /** createEditor is a synchronous factory in the SDK surface. The SDK's filesystem

--- a/packages/runtime/src/sandbox/turn-tool-cancellation.ts
+++ b/packages/runtime/src/sandbox/turn-tool-cancellation.ts
@@ -70,6 +70,10 @@ type ActiveShellSession = {
 };
 
 type CommandCancellationSession = {
+  /** Resolve the physical cancellation primitive for the current route. A
+   * routing proxy must answer from its resolved backend, not from the proxy's
+   * always-present method surface or a pre-resolution PTY default. */
+  commandCancellationTransport?(): Promise<"remote_operation" | "shell_session">;
   cancelExecCommand?(opId: string): Promise<boolean>;
   /** Abort a provider exec-start transport before it returns a session id. */
   cancelPendingExecCommand?(): Promise<void>;
@@ -92,6 +96,19 @@ type CommandCancellationSession = {
     args: TurnSandboxCommandArgs,
   ): Promise<string>;
 };
+
+async function usesRemoteOperationCancellation(
+  session: CommandCancellationSession | undefined,
+): Promise<boolean> {
+  const resolved = await session?.commandCancellationTransport?.();
+  if (resolved !== undefined) {
+    if (resolved !== "remote_operation" && resolved !== "shell_session") {
+      throw new Error(`Unsupported sandbox command cancellation transport: ${String(resolved)}`);
+    }
+    return resolved === "remote_operation";
+  }
+  return Boolean(session?.cancelExecCommand) && session?.supportsPty?.() === false;
+}
 
 export type TurnSandboxCommandArgs = {
   cmd: string;
@@ -674,8 +691,8 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
             }
           : null;
       const correlationId = `turn_lifecycle_${crypto.randomUUID()}`;
-      const useRemoteOpCancellation =
-        Boolean(session.cancelExecCommand) && session.supportsPty?.() === false;
+      const useRemoteOpCancellation = await usesRemoteOperationCancellation(session);
+      if (this.cancelled) throw cancellationError(this.reason);
       const interactive = args.tty ?? true;
       const remoteExec =
         session.cancelExecCommand && useRemoteOpCancellation
@@ -888,7 +905,8 @@ class TurnToolCancellationControllerImpl implements TurnToolCancellationControll
             // wrapper and preserves the user's command byte-for-byte. PTY-backed
             // cloud/local sessions use the portable SDK session + POSIX marker.
             const useRemoteOpCancellation =
-              Boolean(cancelExecCommand) && cancellationSession?.supportsPty?.() === false;
+              await usesRemoteOperationCancellation(cancellationSession);
+            if (this.cancelled) throw cancellationError(this.reason);
             const interactive = parsed.tty !== false;
             const remoteExec =
               cancelExecCommand && useRemoteOpCancellation

--- a/packages/runtime/test/turn-tool-cancellation.test.ts
+++ b/packages/runtime/test/turn-tool-cancellation.test.ts
@@ -512,6 +512,89 @@ describe("turn sandbox-tool physical cancellation fence", () => {
     expect(session.hasRetainedProcess(34)).toBe(false);
   });
 
+  test("resolves a lazy routing backend before choosing its cancellation transport", async () => {
+    const controller = createTurnToolCancellationController();
+    let resolves = 0;
+    let wrappedInput: Record<string, unknown> | null = null;
+    const backend = {
+      supportsPty: () => true,
+      execCommand: async () => running(41, "started"),
+      writeStdin: async () => "write_stdin failed: session not found: 41",
+    };
+    const session = new RoutingSandboxSession({
+      defaultResolved: {
+        session: { state: { manifest: {} }, supportsPty: () => false },
+        sandboxId: null,
+        kind: "unprovisioned",
+      },
+      readPointer: async () => ({ activeSandboxId: null, activeEpoch: 0 }),
+      resolveActiveBackend: async () => {
+        resolves += 1;
+        return { session: backend, sandboxId: null, kind: "modal" };
+      },
+    });
+    const exec = functionTool("exec_command", async (_runContext, input) => {
+      wrappedInput = JSON.parse(input) as Record<string, unknown>;
+      return await session.execCommand({
+        cmd: wrappedInput.cmd,
+        tty: wrappedInput.tty,
+        yieldTimeMs: wrappedInput.yield_time_ms,
+      });
+    });
+    const write = functionTool("write_stdin", async (_runContext, input) => {
+      const parsed = JSON.parse(input) as { session_id: number };
+      return await session.writeStdin({ sessionId: parsed.session_id });
+    });
+    const [wrappedExec, wrappedWrite] = controller.wrapTools([exec, write], session) as Array<
+      Extract<Tool<unknown>, { type: "function" }>
+    >;
+
+    expect(
+      await wrappedExec!.invoke(
+        runContext,
+        JSON.stringify({ cmd: "sleep 60", tty: false, yield_time_ms: 10_000 }),
+      ),
+    ).toContain("Process running with session ID 41");
+    expect(resolves).toBe(1);
+    expect(wrappedInput?.yield_time_ms).toBe(250);
+    expect(String(wrappedInput?.cmd)).toContain("/tmp/opengeni-turn-shell/");
+
+    await wrappedWrite!.invoke(runContext, JSON.stringify({ session_id: 41, chars: "" }));
+    controller.cancel(new Error("turn finalized"));
+    await controller.waitForQuiescence();
+  });
+
+  test("does not start a command after cancellation wins transport resolution", async () => {
+    const abort = new AbortController();
+    const controller = createTurnToolCancellationController(abort.signal);
+    let releaseTransport!: () => void;
+    const transport = new Promise<void>((resolve) => {
+      releaseTransport = resolve;
+    });
+    let execCalls = 0;
+    const exec = functionTool("exec_command", async () => {
+      execCalls += 1;
+      return exited(0);
+    });
+    const [wrappedExec] = controller.wrapTools([exec], {
+      commandCancellationTransport: async () => {
+        await transport;
+        return "shell_session";
+      },
+    }) as Array<Extract<Tool<unknown>, { type: "function" }>>;
+
+    const invocation = wrappedExec!
+      .invoke(runContext, JSON.stringify({ cmd: "printf late" }))
+      .catch((error) => error);
+    await Promise.resolve();
+    abort.abort(new Error("steered while resolving"));
+    releaseTransport();
+    await controller.waitForQuiescence();
+
+    expect(await invocation).toBeInstanceOf(Error);
+    expect(execCalls).toBe(0);
+  });
+
   test("lifecycle command finalization drains an exact process whose promotion was ambiguous", async () => {
     const controller = createTurnToolCancellationController();
     let providerMutationCalls = 0;

--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -16,6 +16,7 @@ import {
   assertChangesDefaultVisible,
   assertRepositoryChangesVisible,
   captureApiRegionalProbeEnvironment,
+  classifyControlCommandMarkerEvent,
   controlCancellationDurationMs,
   fixturePrompt,
   isExpectedBrowserCancellation,
@@ -37,6 +38,38 @@ import {
 } from "./workbench-live-acceptance";
 
 describe("workbench live acceptance preflight", () => {
+  test("accepts only a marker from a still-running agent command", () => {
+    const marker = "CONTROL_READY_EXACT";
+    const event = (output: string, type = "agent.toolCall.output") =>
+      ({ type, payload: { output } }) as never;
+
+    expect(
+      classifyControlCommandMarkerEvent(
+        event(`Chunk ID: abc\nProcess running with session ID 7\nOutput:\n${marker}`),
+        marker,
+      ),
+    ).toBe("running");
+    expect(
+      classifyControlCommandMarkerEvent(
+        event(`Chunk ID: abc\nProcess exited with code 0\nOutput:\n${marker}`),
+        marker,
+      ),
+    ).toBe("completed");
+    expect(
+      classifyControlCommandMarkerEvent(
+        event(
+          `Chunk ID: abc\nProcess exited with code 0\nOutput:\nProcess running with session ID 7\n${marker}`,
+        ),
+        marker,
+      ),
+    ).toBe("malformed");
+    expect(classifyControlCommandMarkerEvent(event(marker), marker)).toBe("malformed");
+    expect(
+      classifyControlCommandMarkerEvent(event(marker, "sandbox.command.output.delta"), marker),
+    ).toBeNull();
+    expect(classifyControlCommandMarkerEvent(event("different"), marker)).toBeNull();
+  });
+
   test("observes split binary terminal output without depending on xterm DOM rows", async () => {
     let onSocket: ((socket: unknown) => void) | undefined;
     let onFrame: ((frame: { payload: string | Buffer }) => void) | undefined;

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -1450,6 +1450,31 @@ type ControlCancellationAudit = {
   >;
 };
 
+export function classifyControlCommandMarkerEvent(
+  event: Pick<SessionEvent, "type" | "payload">,
+  marker: string,
+): "running" | "completed" | "malformed" | null {
+  if (event.type !== "agent.toolCall.output" || !isRecord(event.payload)) return null;
+  const output = event.payload.output;
+  if (typeof output !== "string" || !output.includes(marker)) return null;
+  const running = /^Process running with session ID [1-9][0-9]*$/mu.test(output);
+  const completed = /^Process exited with code -?[0-9]+$/mu.test(output);
+  if (running && !completed) return "running";
+  if (completed && !running) return "completed";
+  return "malformed";
+}
+
+function isRunningControlCommandMarkerEvent(event: SessionEvent, marker: string): boolean {
+  const state = classifyControlCommandMarkerEvent(event, marker);
+  if (state === "completed") {
+    throw new Error("the cancellation fixture command completed before control was requested");
+  }
+  if (state === "malformed") {
+    throw new Error("the cancellation fixture command marker had no running-process receipt");
+  }
+  return state === "running";
+}
+
 async function proveLiveSteerCancellation(input: {
   client: OpenGeniClient;
   page: Page;
@@ -1477,8 +1502,8 @@ async function proveLiveSteerCancellation(input: {
   const zombiePath = `steer-stress/zombie-${iteration}.txt`;
   const terminalCommand =
     iteration === 0
-      ? `rm -rf steer-stress; mkdir -p steer-stress; for d in $(seq 1 150); do mkdir -p "steer-stress/d$d"; for f in $(seq 1 29); do : > "steer-stress/d$d/f$f.ts"; done; done; printf '${controlMarker}\\n'; trap '' INT TERM; sleep 5; printf zombie > '${zombiePath}'`
-      : `rm -f '${zombiePath}'; test "$(find steer-stress -type f | wc -l)" -ge 4350; printf '${controlMarker}\\n'; trap '' INT TERM; sleep 5; printf zombie > '${zombiePath}'`;
+      ? `rm -rf steer-stress; mkdir -p steer-stress; for d in $(seq 1 150); do mkdir -p "steer-stress/d$d"; for f in $(seq 1 29); do : > "steer-stress/d$d/f$f.ts"; done; done; printf '${controlMarker}\\n'; trap '' INT TERM; sleep 30; printf zombie > '${zombiePath}'`
+      : `rm -f '${zombiePath}'; test "$(find steer-stress -type f | wc -l)" -ge 4350; printf '${controlMarker}\\n'; trap '' INT TERM; sleep 30; printf zombie > '${zombiePath}'`;
   const queue = await client.getQueue(workspaceId, sessionId);
   const initialAccepted = await client.sendMessage(workspaceId, sessionId, {
     text: [
@@ -1497,10 +1522,8 @@ async function proveLiveSteerCancellation(input: {
     sessionId,
     afterSequence,
     sessionTimeoutMs,
-    (event) =>
-      event.type === "sandbox.command.output.delta" &&
-      JSON.stringify(event.payload).includes(controlMarker),
-    "the live cancellation fixture command marker",
+    (event) => isRunningControlCommandMarkerEvent(event, controlMarker),
+    "the running live cancellation fixture command marker",
   );
   if (!ready.turnId || !ready.turnAttemptId) {
     throw new Error("control fixture output was not bound to its owning turn attempt");
@@ -1686,7 +1709,7 @@ async function proveLivePauseCancellation(input: {
   // safe branch and cannot manufacture a false zombie after Resume.
   const terminalCommand =
     `if mkdir pause-stress/claimed 2>/dev/null; then printf '${controlMarker}\\n'; ` +
-    `trap '' INT TERM; sleep 5; printf zombie > '${zombiePath}'; ` +
+    `trap '' INT TERM; sleep 30; printf zombie > '${zombiePath}'; ` +
     `else printf 'PAUSE_RESUMED_SAFE_${marker}\\n'; fi`;
   await client.sendMessage(workspaceId, sessionId, {
     text: [
@@ -1705,10 +1728,8 @@ async function proveLivePauseCancellation(input: {
     sessionId,
     afterSequence,
     sessionTimeoutMs,
-    (event) =>
-      event.type === "sandbox.command.output.delta" &&
-      JSON.stringify(event.payload).includes(controlMarker),
-    "the live Pause fixture command marker",
+    (event) => isRunningControlCommandMarkerEvent(event, controlMarker),
+    "the running live Pause fixture command marker",
   );
   if (!ready.turnId || !ready.turnAttemptId) {
     throw new Error("Pause fixture output was not bound to its owning turn attempt");


### PR DESCRIPTION
## Summary

- resolve cancellation transport from the actual lazy routing backend before each sandbox command
- preserve the Modal PTY capability during first-turn lazy tool binding so `write_stdin` is available
- stop commands from starting when Steer/Pause wins the lazy-resolution race
- make live acceptance require a still-running tool receipt, reject completed/malformed marker output, and keep the fixture alive long enough to exercise cancellation
- publish the runtime correction through the normal patch release train

## Production evidence

Production acceptance run 31324720848 timed out waiting for a marker event even though the command completed after 6.592 seconds. The persisted event was an `agent.toolCall.output`, not `sandbox.command.output.delta`. More importantly, the first lazy Modal route was misclassified as connected-machine cancellation because the stable routing proxy always exposes `cancelExecCommand` while its synthetic pre-provisioning session reported no PTY. That bypassed the POSIX process fence, short provider yield, and retained-session cancellation path.

## Validation

- root typecheck: 24/24 projects
- full unit suite: 6,948 passed, 29 provider/platform skips, 0 failed
- targeted routing/cancellation/acceptance suite: 174 passed, 3 platform skips, 0 failed
- changeset release plan: `@opengeni/runtime` patch plus dependents
- changed-file oxlint, oxfmt, and `git diff --check`: passed

Exact head: `876c8af292f3553cf04259bd46daf648ef863b6e`