### PR TITLE
chore(release): bump product version to 0.23.0

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.22.99
-appVersion: "0.22.99"
+version: 0.23.0
+appVersion: "0.23.0"


### PR DESCRIPTION
## Summary
- advance the coordinated product release identity to 0.23.0
- keep Helm chart and application versions identical

## Validation
- release version and image-workflow contracts
- Helm lint