### PR TITLE
perf(runtime): bundle artifact sidecars

### DIFF
--- a/docker/opengeni.Dockerfile
+++ b/docker/opengeni.Dockerfile
@@ -127,8 +127,9 @@ FROM base AS artifact-outbox-dispatcher
 ENV OPENGENI_ARTIFACT_OUTBOX_ENABLED=true \
   OPENGENI_ARTIFACT_OUTBOX_DATABASE_ROLE=opengeni_artifact_outbox_dispatcher \
   OPENGENI_ARTIFACT_OUTBOX_HTTP_PORT=9466
+RUN bun scripts/build-runtime-processes.ts artifact-outbox
 EXPOSE 9466
-CMD ["bun", "run", "--cwd", "apps/worker", "start:artifact-outbox"]
+CMD ["bun", "apps/worker/dist/process/artifact-outbox/artifact-outbox-entry.js"]
 
 # Dedicated artifact materializer image. It inherits the same exact runtime
 # authority as API and never compiles, downloads, or substitutes kernel bytes.
@@ -153,8 +154,9 @@ ENV OPENGENI_ARTIFACT_MATERIALIZER_ENABLED=true \
   OPENGENI_ARTIFACT_MATERIALIZER_HTTP_PORT=9465
 # Build-time load verifies the complete manifest/file chain and native ABI.
 RUN /opt/opengeni/bin/opengeni-artifact-materializer --opengeni-materializer-identity-v1
+RUN bun scripts/build-runtime-processes.ts artifact-materializer
 EXPOSE 9465
-CMD ["bun", "run", "--cwd", "apps/worker", "start:artifact-materializer"]
+CMD ["bun", "apps/worker/dist/process/artifact-materializer/artifact-materializer-entry.js"]
 
 FROM base AS web-build
 ARG OPENGENI_DEPLOYMENT_REVISION=dev

--- a/scripts/bench-process-memory.ts
+++ b/scripts/bench-process-memory.ts
@@ -40,6 +40,32 @@ const profiles: Array<{ profile: string; path: string; role?: Role; smol?: boole
     role: "turn",
     smol: true,
   },
+  {
+    profile: "artifact-materializer-source",
+    path: "apps/worker/src/artifact-materializer-entry.ts",
+  },
+  {
+    profile: "artifact-materializer-bundle",
+    path: "apps/worker/dist/process/artifact-materializer/artifact-materializer-entry.js",
+  },
+  {
+    profile: "artifact-materializer-bundle-smol",
+    path: "apps/worker/dist/process/artifact-materializer/artifact-materializer-entry.js",
+    smol: true,
+  },
+  {
+    profile: "artifact-outbox-source",
+    path: "apps/worker/src/artifact-outbox-entry.ts",
+  },
+  {
+    profile: "artifact-outbox-bundle",
+    path: "apps/worker/dist/process/artifact-outbox/artifact-outbox-entry.js",
+  },
+  {
+    profile: "artifact-outbox-bundle-smol",
+    path: "apps/worker/dist/process/artifact-outbox/artifact-outbox-entry.js",
+    smol: true,
+  },
 ];
 
 function median(values: number[]): number {
@@ -83,7 +109,13 @@ for (const profile of profiles) {
 const medians = Object.fromEntries(
   [...samples.entries()].map(([profile, values]) => [profile, median(values)]),
 ) as Record<string, number>;
-const comparisons = ["api", "worker-control", "worker-turn"].map((profile) => {
+const comparisons = [
+  "api",
+  "worker-control",
+  "worker-turn",
+  "artifact-materializer",
+  "artifact-outbox",
+].map((profile) => {
   const sourceMiB = medians[`${profile}-source`]!;
   const bundleMiB = medians[`${profile}-bundle`]!;
   const smolBundleMiB = medians[`${profile}-bundle-smol`]!;

--- a/scripts/build-runtime-processes.ts
+++ b/scripts/build-runtime-processes.ts
@@ -4,15 +4,20 @@ import { cp, mkdir, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-type ProcessTarget = "api" | "worker";
+type ProcessTarget = "api" | "worker" | "artifact-materializer" | "artifact-outbox";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const requested = process.argv.slice(2);
 const targets: ProcessTarget[] =
   requested.length === 0
-    ? ["api", "worker"]
+    ? ["api", "worker", "artifact-materializer", "artifact-outbox"]
     : requested.map((target) => {
-        if (target !== "api" && target !== "worker") {
+        if (
+          target !== "api" &&
+          target !== "worker" &&
+          target !== "artifact-materializer" &&
+          target !== "artifact-outbox"
+        ) {
           throw new Error(`Unknown runtime process target: ${target}`);
         }
         return target;
@@ -93,8 +98,29 @@ async function buildWorker(): Promise<void> {
   );
 }
 
+async function buildArtifactSidecar(
+  target: "artifact-materializer" | "artifact-outbox",
+): Promise<void> {
+  const entrypoint =
+    target === "artifact-materializer"
+      ? "artifact-materializer-entry.ts"
+      : "artifact-outbox-entry.ts";
+  const outdir = join(repositoryRoot, `apps/worker/dist/process/${target}`);
+  await rm(outdir, { recursive: true, force: true });
+  await checkedBuild({
+    ...sharedBuild,
+    // Each sidecar is shipped in a different image. Keep its dependency graph
+    // self-contained so it never loads source maps, TypeScript, Temporal, or a
+    // shared worker chunk at runtime.
+    splitting: false,
+    entrypoints: [join(repositoryRoot, `apps/worker/src/${entrypoint}`)],
+    outdir,
+  });
+}
+
 for (const target of targets) {
   if (target === "api") await buildApi();
-  else await buildWorker();
+  else if (target === "worker") await buildWorker();
+  else await buildArtifactSidecar(target);
   process.stdout.write(`[runtime-process] built ${target}\n`);
 }

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -45,6 +45,27 @@ describe("release image workflow contract", () => {
     expect(frozenInstall).toBeGreaterThan(patchCopy);
   });
 
+  test("dedicated artifact sidecars run self-contained production bundles", async () => {
+    const [dockerfile, builder] = await Promise.all([
+      readFile(resolve(root, "docker/opengeni.Dockerfile"), "utf8"),
+      readFile(resolve(root, "scripts/build-runtime-processes.ts"), "utf8"),
+    ]);
+
+    for (const target of ["artifact-materializer", "artifact-outbox"]) {
+      expect(builder).toContain(`"${target}"`);
+      expect(dockerfile).toContain(`RUN bun scripts/build-runtime-processes.ts ${target}`);
+    }
+    expect(builder).toContain("splitting: false");
+    expect(dockerfile).toContain(
+      'CMD ["bun", "apps/worker/dist/process/artifact-materializer/artifact-materializer-entry.js"]',
+    );
+    expect(dockerfile).toContain(
+      'CMD ["bun", "apps/worker/dist/process/artifact-outbox/artifact-outbox-entry.js"]',
+    );
+    expect(dockerfile).not.toContain('"start:artifact-materializer"');
+    expect(dockerfile).not.toContain('"start:artifact-outbox"');
+  });
+
   test("coalesces mutable Version-PR work without cancelling immutable publication", async () => {
     const [release, ci] = await Promise.all([workflow("release.yml"), workflow("ci.yml")]);
     const versionProjection = release.slice(


### PR DESCRIPTION
## Summary
- build the materializer and outbox dispatcher as isolated production process bundles
- run those bundles directly in their dedicated images instead of loading TypeScript source graphs
- extend the RSS benchmark and release-image contract to cover both sidecars

## Measured idle RSS (median of three)
- artifact materializer: 217.6 MiB to 138.5 MiB (-36.4%)
- artifact outbox dispatcher: 254.1 MiB to 123.1 MiB (-51.6%)
- combined saving: 210.1 MiB per replica pair

## Validation
- process RSS benchmark with reduction floors
- full typecheck
- full production build
- release image/version contracts
- public repository hygiene