### PR TITLE
chore(release): bump product version to 0.23.1

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.0
-appVersion: "0.23.0"
+version: 0.23.1
+appVersion: "0.23.1"


### PR DESCRIPTION
Advances the canonical Helm chart and application product identity together for the verified 0.23.1 release train. Both version and appVersion remain identical.

Validation:
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml` → `0.23.1`
- release-version, image-workflow, and Helm-upgrade contract tests: 22 pass
- full format, lint, public-hygiene, and diff guards pass