### PR TITLE
chore(release): bump product version to 0.23.1

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.0
-appVersion: "0.23.0"
+version: 0.23.1
+appVersion: "0.23.1"


### PR DESCRIPTION
## Summary

- advance the coordinated product release identity to `0.23.1` for the corrective production train
- keep Helm chart `version` and `appVersion` identical
- preserve the already-merged 500ms cancellation-heartbeat correction and unchanged 4,000ms acceptance gate

## Validation

- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml` → `0.23.1`
- release-version, image-workflow, and Helm-upgrade contract tests: 22 passed
- Helm 3.18.6 lint: 1 chart linted, 0 failed
- format check, public-repository hygiene, and `git diff --check`: passed
