### PR TITLE
perf(ci): shorten sandbox toolchain builds

### DIFF
--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -1,3 +1,12 @@
+FROM python:3.12-slim AS checkov-runtime
+
+ARG CHECKOV_VERSION=3.2.526
+
+RUN set -eux; \
+    python -m venv /opt/checkov; \
+    /opt/checkov/bin/pip install --no-cache-dir "checkov==${CHECKOV_VERSION}"; \
+    /opt/checkov/bin/checkov --version
+
 FROM node:22.22.0-bookworm-slim AS node-runtime
 
 FROM oven/bun:1.3.14 AS artifact-runtime-builder
@@ -55,7 +64,6 @@ RUN set -eux; \
 FROM python:3.12-slim
 
 ARG TERRAFORM_VERSION=1.13.3
-ARG CHECKOV_VERSION=3.2.526
 ARG TTYD_VERSION=1.7.7
 ARG TARGETARCH
 
@@ -96,21 +104,6 @@ RUN set -eux; \
 COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
 RUN test "$(node --version)" = "v22.22.0"
 
-# Exact native document/spreadsheet/presentation runtime. The builder turns the
-# release-matrix input into a self-contained Node facade, vendors only its
-# target-native renderer closure, pins every byte in installation.json, and
-# runs real DOCX/XLSX/PPTX plus PNG/WebP smoke probes before this copy.
-COPY --from=artifact-runtime-builder /opt/opengeni/artifact-runtime /opt/opengeni/artifact-runtime
-RUN set -eux; \
-    if [ -f /opt/opengeni/artifact-runtime/installation.json ]; then \
-      ln -s /opt/opengeni/artifact-runtime/opengeni-artifact-runtime.mjs /usr/local/bin/opengeni-artifact-runtime; \
-      OPENGENI_ARTIFACT_RUNTIME_MANIFEST=/opt/opengeni/artifact-runtime/installation.json \
-        OPENGENI_ARTIFACT_TOOL_ENTRY=/opt/opengeni/artifact-runtime/skill-facade-entry.mjs \
-        opengeni-artifact-runtime doctor --json; \
-    else \
-      test -f /opt/opengeni/artifact-runtime/.unavailable; \
-    fi
-
 RUN set -eux; \
     arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
     case "${arch}" in amd64) terraform_arch="amd64" ;; arm64|aarch64) terraform_arch="arm64" ;; *) echo "unsupported architecture=${arch}" >&2; exit 1 ;; esac; \
@@ -118,10 +111,6 @@ RUN set -eux; \
     unzip /tmp/terraform.zip -d /usr/local/bin; \
     rm /tmp/terraform.zip; \
     terraform version
-
-RUN set -eux; \
-    pip install --no-cache-dir "checkov==${CHECKOV_VERSION}"; \
-    checkov --version
 
 RUN set -eux; \
     curl -fsSL https://aka.ms/InstallAzureCLIDeb | bash; \
@@ -156,6 +145,30 @@ RUN set -eux; \
     curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.${tarch}" -o /usr/local/bin/ttyd; \
     chmod 0755 /usr/local/bin/ttyd; \
     ttyd --version
+
+# Checkov's large target-native Python closure is independent of the serial
+# final-image toolchain. Build it in parallel, then retain the existing final
+# executable path and version probe on the identical Python base image.
+COPY --from=checkov-runtime /opt/checkov /opt/checkov
+RUN set -eux; \
+    ln -s /opt/checkov/bin/checkov /usr/local/bin/checkov; \
+    checkov --version
+
+# Exact native document/spreadsheet/presentation runtime. Keep this exact-source
+# copy after the source-invariant toolchain so remote BuildKit caches can reuse
+# Terraform, Checkov, Azure CLI, GitHub CLI, and ttyd across source revisions.
+# The builder still pins every byte and runs real DOCX/XLSX/PPTX plus PNG/WebP
+# smoke probes before this copy, and the final image still doctors that runtime.
+COPY --from=artifact-runtime-builder /opt/opengeni/artifact-runtime /opt/opengeni/artifact-runtime
+RUN set -eux; \
+    if [ -f /opt/opengeni/artifact-runtime/installation.json ]; then \
+      ln -s /opt/opengeni/artifact-runtime/opengeni-artifact-runtime.mjs /usr/local/bin/opengeni-artifact-runtime; \
+      OPENGENI_ARTIFACT_RUNTIME_MANIFEST=/opt/opengeni/artifact-runtime/installation.json \
+        OPENGENI_ARTIFACT_TOOL_ENTRY=/opt/opengeni/artifact-runtime/skill-facade-entry.mjs \
+        opengeni-artifact-runtime doctor --json; \
+    else \
+      test -f /opt/opengeni/artifact-runtime/.unavailable; \
+    fi
 
 ENV HOME=/workspace
 ENV OPENGENI_TERMINAL_STREAM_PORT=7681

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -16,6 +16,60 @@ async function action(name: string): Promise<string> {
   return readFile(resolve(root, ".github/actions", name, "action.yml"), "utf8");
 }
 
+const sandboxArtifactRuntimeCopy =
+  "COPY --from=artifact-runtime-builder /opt/opengeni/artifact-runtime /opt/opengeni/artifact-runtime";
+const sandboxCheckovCopy = "COPY --from=checkov-runtime /opt/checkov /opt/checkov";
+
+function keepsStableSandboxToolchainBeforeArtifactRuntime(dockerfile: string): boolean {
+  const runtimeCopy = dockerfile.indexOf(sandboxArtifactRuntimeCopy);
+  const runtimeDoctor = dockerfile.indexOf("opengeni-artifact-runtime doctor --json");
+  const stableToolchain = [
+    "releases.hashicorp.com/terraform/${TERRAFORM_VERSION}",
+    'pip install --no-cache-dir "checkov==${CHECKOV_VERSION}"',
+    "https://aka.ms/InstallAzureCLIDeb",
+    "https://cli.github.com/packages/githubcli-archive-keyring.gpg",
+    "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}",
+  ];
+
+  return (
+    runtimeCopy >= 0 &&
+    runtimeDoctor > runtimeCopy &&
+    stableToolchain.every((marker) => {
+      const tool = dockerfile.indexOf(marker);
+      return tool >= 0 && tool < runtimeCopy;
+    })
+  );
+}
+
+function buildsSandboxCheckovOffTheSerialToolchain(dockerfile: string): boolean {
+  const checkovStage = dockerfile.indexOf("FROM python:3.12-slim AS checkov-runtime");
+  const finalStage = dockerfile.indexOf("\nFROM python:3.12-slim\n", checkovStage + 1);
+  const checkovInstall = dockerfile.indexOf(
+    'pip install --no-cache-dir "checkov==${CHECKOV_VERSION}"',
+    checkovStage,
+  );
+  const ttydInstall = dockerfile.indexOf(
+    "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}",
+    finalStage,
+  );
+  const checkovCopy = dockerfile.indexOf(sandboxCheckovCopy, finalStage);
+  const checkovVerification = dockerfile.indexOf(
+    "ln -s /opt/checkov/bin/checkov /usr/local/bin/checkov",
+    checkovCopy,
+  );
+  const runtimeCopy = dockerfile.indexOf(sandboxArtifactRuntimeCopy, finalStage);
+
+  return (
+    checkovStage >= 0 &&
+    checkovInstall > checkovStage &&
+    finalStage > checkovInstall &&
+    ttydInstall > finalStage &&
+    checkovCopy > ttydInstall &&
+    checkovVerification > checkovCopy &&
+    runtimeCopy > checkovVerification
+  );
+}
+
 function ghApiCommands(source: string): string[] {
   const commands: string[] = [];
   let command = "";
@@ -43,6 +97,55 @@ describe("release image workflow contract", () => {
 
     expect(patchCopy).toBeGreaterThan(-1);
     expect(frozenInstall).toBeGreaterThan(patchCopy);
+  });
+
+  test("keeps stable sandbox tools cacheable across exact runtime revisions", async () => {
+    const dockerfile = await readFile(resolve(root, "docker/sandbox.Dockerfile"), "utf8");
+
+    expect(keepsStableSandboxToolchainBeforeArtifactRuntime(dockerfile)).toBe(true);
+
+    const runtimeBlockStart = dockerfile.indexOf("# Exact native document");
+    const runtimeBlockEnd = dockerfile.indexOf("ENV HOME=/workspace", runtimeBlockStart);
+    const runtimeBlock = dockerfile.slice(runtimeBlockStart, runtimeBlockEnd);
+    const withoutRuntimeBlock =
+      dockerfile.slice(0, runtimeBlockStart) + dockerfile.slice(runtimeBlockEnd);
+    const terraformLayer = withoutRuntimeBlock.indexOf(
+      'RUN set -eux; \\\n    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \\\n    case "${arch}" in amd64) terraform_arch=',
+    );
+    const previousOrdering =
+      withoutRuntimeBlock.slice(0, terraformLayer) +
+      runtimeBlock +
+      withoutRuntimeBlock.slice(terraformLayer);
+
+    expect(runtimeBlockStart).toBeGreaterThan(-1);
+    expect(runtimeBlockEnd).toBeGreaterThan(runtimeBlockStart);
+    expect(terraformLayer).toBeGreaterThan(-1);
+    expect(keepsStableSandboxToolchainBeforeArtifactRuntime(previousOrdering)).toBe(false);
+  });
+
+  test("builds Checkov outside the serial sandbox toolchain", async () => {
+    const dockerfile = await readFile(resolve(root, "docker/sandbox.Dockerfile"), "utf8");
+
+    expect(buildsSandboxCheckovOffTheSerialToolchain(dockerfile)).toBe(true);
+
+    const checkovFinalizationStart = dockerfile.indexOf(sandboxCheckovCopy);
+    const checkovFinalizationEnd = dockerfile.indexOf(
+      "# Exact native document",
+      checkovFinalizationStart,
+    );
+    const serialCheckov = dockerfile
+      .replace(
+        "FROM python:3.12-slim AS checkov-runtime",
+        "FROM python:3.12-slim AS unused-checkov",
+      )
+      .replace(
+        dockerfile.slice(checkovFinalizationStart, checkovFinalizationEnd),
+        'RUN set -eux; \\\n    pip install --no-cache-dir "checkov==${CHECKOV_VERSION}"; \\\n    checkov --version\n\n',
+      );
+
+    expect(checkovFinalizationStart).toBeGreaterThan(-1);
+    expect(checkovFinalizationEnd).toBeGreaterThan(checkovFinalizationStart);
+    expect(buildsSandboxCheckovOffTheSerialToolchain(serialCheckov)).toBe(false);
   });
 
   test("dedicated artifact sidecars run self-contained production bundles", async () => {


### PR DESCRIPTION
## Summary

- build pinned Checkov in an independent multi-architecture virtual-environment stage so its dominant arm64 install overlaps the final-image toolchain
- copy and verify that environment on the identical `python:3.12-slim` final base, preserving `/usr/local/bin/checkov`
- keep the source-varying exact artifact-runtime copy/doctor after all stable tool layers so subsequent main-cache generations can reuse the stable closure
- enforce both properties with order-sensitive contracts and planted serial/cache-barrier negatives

## Measured result

Original exact-head sandbox baselines:

- run `31341489793`: `621s`
- run `31342344845`: `627s`

The cache-order-only first head of this PR ran in `592s`; its stable layers were unprimed, so that result was explicitly rejected as insufficient.

The amended implementation was measured on exact run `31344739912` at tested head `4c10560ad2a684edf36344614fd8ff40c1832eee`:

- all checks green
- headless sandbox: **465s**
- **127s / 21.5% faster** than the prior PR head
- **156–162s / 25–26% faster** than the original baselines
- workflow: `1114s` versus about `1150s` on the prior head

The job log proves actual branch overlap rather than a cache-only variance. Arm64 Checkov ran for `371.1s` while the final arm64 branch completed base packages (`154.0s`), Terraform (`4.6s`), Azure CLI (`96.9s`), GitHub CLI (`43.8s`), and ttyd (`1.1s`). The joined final image then passed `checkov --version` and exact artifact-runtime `doctor --json`.

The PR was subsequently rebased without conflict onto current main `670dc6fae8d0a8d2bf34e1dd3b53eca4daa10932`; fresh exact-head CI is required before merge.

## Safety

- Checkov remains pinned to `3.2.526`
- builder and final stages use the identical Python base reference in one build graph
- final image retains `/usr/local/bin/checkov` and verifies the executable/version
- exact artifact-runtime source/byte verification, final copy, executable symlink, and doctor gate are unchanged and mandatory
- regression contracts reject both the prior source-varying cache barrier and a near-identical serial Checkov install

## Validation

Fresh rebased head:

- focused artifact/image contracts: `27 pass`, `0 fail`
- `bun run typecheck`: all 25 projects clean
- focused lint and format checks: clean
- `git diff --check`: clean
- exact multi-architecture CI pending on the fresh current-base head

Refs OPE-27.
