### PR TITLE
perf: enforce bounded observability memory

### DIFF
--- a/deploy/observability/Chart.yaml
+++ b/deploy/observability/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opengeni-observability
 description: Optional self-hosted Prometheus and Grafana stack for OpenGeni.
 type: application
-version: 0.1.3
+version: 0.1.4
 dependencies:
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts

--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -39,6 +39,13 @@ compact self-hosted cluster:
 | Alertmanager | 2 GiB | 120 hours |
 | Grafana | 2 GiB | persistent database and plugins |
 
+The compact profile filters metrics at ingestion, retaining every signal used
+by the pinned Kubernetes mixin and OpenGeni dashboards/rules while excluding
+unused modern Go runtime fanout and redundant zero-valued pod reasons. Validate
+the live target mix with `bun run bench:observability-series -- --prometheus-url
+<url> --check`; the guard requires at least a 4x instantaneous series reduction
+and treats TSDB head series as diagnostic because they include stale data.
+
 `values.production.example.yaml` raises Prometheus to 50 GiB/15 days, Grafana
 to 5 GiB, Alertmanager to 5 GiB, and requires an existing
 `opengeni-grafana-admin` Secret. It is a capacity and credential example, not a

--- a/deploy/observability/values.yaml
+++ b/deploy/observability/values.yaml
@@ -35,7 +35,7 @@ kube-prometheus-stack:
       metricRelabelings:
         - action: keep
           sourceLabels: [__name__]
-          regex: '^(?:go_.*|process_.*|prometheus_operator_(?:list_operations_(?:failed_)?total|managed_resources|node_address_lookup_errors_total|ready|reconcile_(?:errors|operations)_total|status_update_(?:errors|operations)_total|syncs|watch_operations_(?:failed_)?total))$'
+          regex: '^(?:go_(?:gc_duration_seconds(?:_count|_sum)?|goroutines|info|memstats_.*|threads)|process_.*|prometheus_operator_(?:list_operations_(?:failed_)?total|managed_resources|node_address_lookup_errors_total|ready|reconcile_(?:errors|operations)_total|status_update_(?:errors|operations)_total|syncs|watch_operations_(?:failed_)?total))$'
     resources:
       requests:
         cpu: 50m
@@ -48,14 +48,16 @@ kube-prometheus-stack:
     serviceMonitor:
       # Preserve the Kubernetes-mixin API availability, latency, certificate,
       # client, process, and workqueue signals while rejecting unrelated
-      # high-cardinality API-server internals before they enter the TSDB.
+      # high-cardinality API-server internals before they enter the TSDB. The
+      # retained SLI buckets are 0.1s plus the mixin's exact 1s/5s/30s SLO
+      # boundaries and +Inf; count/sum remain available.
       metricRelabelings:
         - action: drop
           sourceLabels: [__name__, le]
-          regex: '(etcd_request|apiserver_request_slo|apiserver_request_sli|apiserver_request)_duration_seconds_bucket;(0\.15|0\.2|0\.3|0\.35|0\.4|0\.45|0\.6|0\.7|0\.8|0\.9|1\.25|1\.5|1\.75|2|3|3\.5|4|4\.5|6|7|8|9|15|20|40|45|50)(\.0)?'
+          regex: '(etcd_request|apiserver_request_slo|apiserver_request_sli|apiserver_request)_duration_seconds_bucket;(0\.05|0\.15|0\.2|0\.3|0\.35|0\.4|0\.45|0\.6|0\.7|0\.8|0\.9|1\.25|1\.5|1\.75|2|3|3\.5|4|4\.5|6|7|8|9|10|15|20|40|45|50|60)(\.0)?'
         - action: keep
           sourceLabels: [__name__]
-          regex: '^(?:aggregator_unavailable_apiservice(?:_total)?|apiserver_client_certificate_expiration_seconds_(?:bucket|count|sum)|apiserver_request_sli_duration_seconds_(?:bucket|count|sum)|apiserver_request_terminations_total|apiserver_request_total|go_.*|kubernetes_build_info|process_.*|rest_client_request_duration_seconds_(?:bucket|count|sum)|rest_client_requests_total|workqueue_(?:adds_total|depth|queue_duration_seconds_(?:bucket|count|sum)))$'
+          regex: '^(?:aggregator_unavailable_apiservice(?:_total)?|apiserver_client_certificate_expiration_seconds_(?:bucket|count|sum)|apiserver_request_sli_duration_seconds_(?:bucket|count|sum)|apiserver_request_terminations_total|apiserver_request_total|go_(?:gc_duration_seconds(?:_count|_sum)?|goroutines|info|memstats_.*|threads)|kubernetes_build_info|process_.*|rest_client_request_duration_seconds_(?:bucket|count|sum)|rest_client_requests_total|workqueue_(?:adds_total|depth|queue_duration_seconds_(?:bucket|count|sum)))$'
 
   kubelet:
     serviceMonitor:
@@ -79,14 +81,14 @@ kube-prometheus-stack:
           regex: '(csi_operations|storage_operation_duration)_seconds_bucket;(0.25|2.5|15|25|120|600)(\.0)?'
         - action: keep
           sourceLabels: [__name__]
-          regex: '^(?:apiserver_client_certificate_expiration_seconds_(?:bucket|count|sum)|go_.*|kubelet_(?:certificate_manager_.*|cgroup_manager_duration_seconds_(?:bucket|count|sum)|evictions|node_config_error|node_name|pleg_relist_.*|pod_start_duration_seconds_(?:bucket|count|sum)|pod_worker_duration_seconds_(?:bucket|count|sum)|running_containers|running_pods|runtime_operations_.*|server_expiration_renew_errors|volume_stats_.*)|kubernetes_build_info|process_.*|rest_client_request_duration_seconds_(?:bucket|count|sum)|rest_client_requests_total|storage_operation_(?:duration_seconds_(?:bucket|count|sum)|errors_total)|volume_manager_total_volumes|workqueue_(?:adds_total|depth|queue_duration_seconds_(?:bucket|count|sum)))$'
+          regex: '^(?:apiserver_client_certificate_expiration_seconds_(?:bucket|count|sum)|go_(?:gc_duration_seconds(?:_count|_sum)?|goroutines|info|memstats_.*|threads)|kubelet_(?:certificate_manager_.*|cgroup_manager_duration_seconds_(?:bucket|count|sum)|evictions|node_config_error|node_name|pleg_relist_.*|pod_start_duration_seconds_(?:bucket|count|sum)|pod_worker_duration_seconds_(?:bucket|count|sum)|running_containers|running_pods|runtime_operations_.*|server_expiration_renew_errors|volume_stats_.*)|kubernetes_build_info|process_.*|rest_client_request_duration_seconds_(?:bucket|count|sum)|rest_client_requests_total|storage_operation_(?:duration_seconds_(?:bucket|count|sum)|errors_total)|volume_manager_total_volumes|workqueue_(?:adds_total|depth|queue_duration_seconds_(?:bucket|count|sum)))$'
 
   prometheus:
     serviceMonitor:
       metricRelabelings:
         - action: keep
           sourceLabels: [__name__]
-          regex: '^(?:go_.*|process_.*|reloader_last_reload_successful|prometheus_(?:build_info|config_last_reload_successful|engine_queries|engine_queries_concurrent_max|engine_query_duration_seconds(?:_count|_sum)?|notifications_.*|remote_storage_.*|rule_evaluation_failures_total|rule_group_(?:iterations_missed_total|rules)|sd_(?:discovered_targets|kubernetes_failures_total|refresh_failures_total)|target_(?:interval_length_seconds_(?:count|sum)|metadata_cache_entries|scrape_pool_.*|scrapes_.*|sync_failed_total|sync_length_seconds_(?:count|sum))|tsdb_(?:compactions_failed_total|head_chunks|head_samples_appended_total|head_series|reloads_failures_total)))$'
+          regex: '^(?:go_(?:gc_duration_seconds(?:_count|_sum)?|goroutines|info|memstats_.*|threads)|process_.*|reloader_last_reload_successful|prometheus_(?:build_info|config_last_reload_successful|engine_queries|engine_queries_concurrent_max|engine_query_duration_seconds(?:_count|_sum)?|notifications_.*|remote_storage_.*|rule_evaluation_failures_total|rule_group_(?:iterations_missed_total|rules)|sd_(?:discovered_targets|kubernetes_failures_total|refresh_failures_total)|target_(?:interval_length_seconds_(?:count|sum)|metadata_cache_entries|scrape_pool_.*|scrapes_.*|sync_failed_total|sync_length_seconds_(?:count|sum))|tsdb_(?:compactions_failed_total|head_chunks|head_samples_appended_total|head_series|reloads_failures_total)))$'
     prometheusSpec:
       externalLabels:
         environment: self-hosted
@@ -127,7 +129,7 @@ kube-prometheus-stack:
       metricRelabelings:
         - action: keep
           sourceLabels: [__name__]
-          regex: '^(?:alertmanager_(?:alerts|alerts_invalid_total|alerts_received_total|cluster_(?:failed_peers|members)|config_(?:hash|last_reload_successful)|notification_latency_seconds_(?:bucket|count|sum)|notifications_(?:failed_)?total)|go_.*|process_.*|reloader_last_reload_successful)$'
+          regex: '^(?:alertmanager_(?:alerts|alerts_invalid_total|alerts_received_total|cluster_(?:failed_peers|members)|config_(?:hash|last_reload_successful)|notification_latency_seconds_(?:bucket|count|sum)|notifications_(?:failed_)?total)|go_(?:gc_duration_seconds(?:_count|_sum)?|goroutines|info|memstats_.*|threads)|process_.*|reloader_last_reload_successful)$'
     alertmanagerSpec:
       retention: 120h
       resources:
@@ -155,7 +157,7 @@ kube-prometheus-stack:
       metricRelabelings:
         - action: keep
           sourceLabels: [__name__]
-          regex: '^(?:grafana_(?:alerting_result_total|build_info|http_request_duration_seconds_(?:bucket|count|sum)|stat_totals_dashboard)|go_.*|process_.*)$'
+          regex: '^(?:grafana_(?:alerting_result_total|build_info|http_request_duration_seconds_(?:bucket|count|sum)|stat_totals_dashboard)|go_(?:gc_duration_seconds(?:_count|_sum)?|goroutines|info|memstats_.*|threads)|process_.*)$'
     resources:
       requests:
         cpu: 100m
@@ -267,6 +269,13 @@ kube-prometheus-stack:
       monitor:
         additionalLabels:
           opengeni.ai/monitoring: enabled
+        # kube_pod_status_reason exports one zero-valued series per known reason
+        # for every pod. The pinned mixin consumes only SchedulingGated; retain
+        # that exact exception and allow future reasons through for review.
+        metricRelabelings:
+          - action: drop
+            sourceLabels: [__name__, reason]
+            regex: 'kube_pod_status_reason;(?:Evicted|NodeAffinity|NodeLost|PreemptionByScheduler|Shutdown|TerminationByKubelet|UnexpectedAdmissionError)'
     resources:
       requests:
         cpu: 50m
@@ -283,7 +292,7 @@ kube-prometheus-stack:
         metricRelabelings:
           - action: keep
             sourceLabels: [__name__]
-            regex: '^(?:go_.*|node_(?:bonding_(?:active|slaves)|cpu_seconds_total|disk_(?:io_time_seconds_total|io_time_weighted_seconds_total|read_bytes_total|written_bytes_total)|exporter_build_info|filefd_(?:allocated|maximum)|filesystem_(?:avail_bytes|files|files_free|readonly|size_bytes)|load(?:1|5|15)|md_disks(?:_required)?|memory_(?:Buffers_bytes|Cached_bytes|MemAvailable_bytes|MemFree_bytes|MemTotal_bytes|Slab_bytes|available_bytes|compressed_bytes|internal_bytes|purgeable_bytes|total_bytes|wired_bytes)|netstat_(?:TcpExt_TCPSynRetrans|Tcp_OutSegs|Tcp_RetransSegs)|network_(?:receive|transmit)_(?:bytes_total|drop_total|errs_total|packets_total)|network_up|nf_conntrack_entries(?:_limit)?|pressure_(?:io|memory)_stalled_seconds_total|systemd_(?:service_restart_total|unit_state)|textfile_scrape_error|time_seconds|timex_(?:maxerror_seconds|offset_seconds|sync_status)|uname_info|vmstat_(?:pgmajfault|pswpout))|process_.*)$'
+            regex: '^(?:go_(?:gc_duration_seconds(?:_count|_sum)?|goroutines|info|memstats_.*|threads)|node_(?:bonding_(?:active|slaves)|cpu_seconds_total|disk_(?:io_time_seconds_total|io_time_weighted_seconds_total|read_bytes_total|written_bytes_total)|exporter_build_info|filefd_(?:allocated|maximum)|filesystem_(?:avail_bytes|files|files_free|readonly|size_bytes)|load(?:1|5|15)|md_disks(?:_required)?|memory_(?:Buffers_bytes|Cached_bytes|MemAvailable_bytes|MemFree_bytes|MemTotal_bytes|Slab_bytes|available_bytes|compressed_bytes|internal_bytes|purgeable_bytes|total_bytes|wired_bytes)|netstat_(?:TcpExt_TCPSynRetrans|Tcp_OutSegs|Tcp_RetransSegs)|network_(?:receive|transmit)_(?:bytes_total|drop_total|errs_total|packets_total)|network_up|nf_conntrack_entries(?:_limit)?|pressure_(?:io|memory)_stalled_seconds_total|systemd_(?:service_restart_total|unit_state)|textfile_scrape_error|time_seconds|timex_(?:maxerror_seconds|offset_seconds|sync_status)|uname_info|vmstat_(?:pgmajfault|pswpout))|process_.*)$'
     resources:
       requests:
         cpu: 25m

--- a/scripts/bench-observability-series.test.ts
+++ b/scripts/bench-observability-series.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MIN_INSTANT_SERIES_REDUCTION,
+  reductionRatio,
+  retainedByProfile,
+  TEMPORAL_MATCHING_METRICS,
+} from "./bench-observability-series";
+
+const values = Bun.YAML.parse(await Bun.file("deploy/observability/values.yaml").text())[
+  "kube-prometheus-stack"
+] as Record<string, any>;
+
+describe("observability series projection", () => {
+  test("retains Prometheus-generated scrape health outside metric relabeling", () => {
+    expect(retainedByProfile("grafana", { __name__: "up" }, values)).toBe(true);
+    expect(
+      retainedByProfile(
+        "prometheus-operator",
+        { __name__: "scrape_samples_post_metric_relabeling" },
+        values,
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps only the logical Temporal backlog needed by the OpenGeni queue alert", () => {
+    expect(TEMPORAL_MATCHING_METRICS).toEqual(
+      new Set(["approximate_backlog_age_seconds", "approximate_backlog_count"]),
+    );
+    expect(
+      retainedByProfile("temporal", { __name__: "approximate_backlog_age_seconds" }, values),
+    ).toBe(true);
+    expect(retainedByProfile("temporal", { __name__: "poll_latency_bucket" }, values)).toBe(false);
+  });
+
+  test("retains only the pod-reason exception consumed by the pinned mixin", () => {
+    expect(
+      retainedByProfile(
+        "kube-state-metrics",
+        { __name__: "kube_pod_status_reason", reason: "SchedulingGated" },
+        values,
+      ),
+    ).toBe(true);
+    expect(
+      retainedByProfile(
+        "kube-state-metrics",
+        { __name__: "kube_pod_status_reason", reason: "Evicted" },
+        values,
+      ),
+    ).toBe(false);
+  });
+
+  test("compares like-for-like instantaneous series instead of stale head state", () => {
+    expect(MIN_INSTANT_SERIES_REDUCTION).toBe(4);
+    expect(reductionRatio(80_000, 20_000)).toBe(4);
+    expect(reductionRatio(80_000, 0)).toBe(0);
+  });
+
+  test("applies secondary-label bucket and interface drops", () => {
+    expect(
+      retainedByProfile(
+        "kubernetes-api",
+        { __name__: "apiserver_request_sli_duration_seconds_bucket", le: "1.0" },
+        values,
+      ),
+    ).toBe(true);
+    expect(
+      retainedByProfile(
+        "kubernetes-api",
+        { __name__: "apiserver_request_sli_duration_seconds_bucket", le: "10.0" },
+        values,
+      ),
+    ).toBe(false);
+    expect(
+      retainedByProfile(
+        "kubelet",
+        {
+          __name__: "container_network_receive_bytes_total",
+          metrics_path: "/metrics/cadvisor",
+          interface: "cni0",
+        },
+        values,
+      ),
+    ).toBe(false);
+  });
+});

--- a/scripts/bench-observability-series.ts
+++ b/scripts/bench-observability-series.ts
@@ -15,60 +15,90 @@ interface RelabelRule {
   sourceLabels?: string[];
 }
 
-const args = parseArgs(process.argv.slice(2));
-const stackValues = Bun.YAML.parse(await Bun.file("deploy/observability/values.yaml").text())[
-  "kube-prometheus-stack"
-] as Record<string, any>;
-const rows = await prometheusQuery(
-  args.prometheusUrl,
-  'count by (job, metrics_path, __name__) ({__name__!=""})',
-);
-const headRows = await prometheusQuery(args.prometheusUrl, "prometheus_tsdb_head_series");
-const headSeries = sumRows(headRows);
+// Prometheus adds these after scraping. Metric relabeling cannot remove them,
+// so a projection that runs relabel rules against them understates the retained
+// series count. Keep this list aligned with Prometheus' automatic scrape-series
+// contract rather than exporter implementations.
+export const AUTOMATIC_SCRAPE_METRICS = new Set([
+  "up",
+  "scrape_duration_seconds",
+  "scrape_samples_post_metric_relabeling",
+  "scrape_samples_scraped",
+  "scrape_series_added",
+]);
 
-const categoryTotals = new Map<string, { current: number; projected: number }>();
-for (const row of rows) {
-  const labels = row.metric;
-  const name = labels.__name__ ?? "";
-  const count = Number(row.value[1]);
-  const category = categoryFor(labels.job ?? "", name);
-  const retained = retainedByProfile(category, labels, stackValues);
-  const totals = categoryTotals.get(category) ?? { current: 0, projected: 0 };
-  totals.current += count;
-  if (retained) totals.projected += count;
-  categoryTotals.set(category, totals);
-}
+// The matching target exists for one OpenGeni alert: logical turn-queue age.
+// Count is retained alongside age for diagnosis; the generic Temporal server
+// telemetry is intentionally outside this narrowly owned ServiceMonitor.
+export const TEMPORAL_MATCHING_METRICS = new Set([
+  "approximate_backlog_age_seconds",
+  "approximate_backlog_count",
+]);
+export const MIN_INSTANT_SERIES_REDUCTION = 4;
 
-const currentSamples = [...categoryTotals.values()].reduce((sum, row) => sum + row.current, 0);
-const projectedSamples = [...categoryTotals.values()].reduce((sum, row) => sum + row.projected, 0);
-const headReduction = projectedSamples > 0 ? headSeries / projectedSamples : 0;
-const currentReduction = projectedSamples > 0 ? currentSamples / projectedSamples : 0;
-const result = {
-  measurement: "instant-vector upper bound; secondary label drops can reduce it further",
-  headSeries,
-  currentSamples,
-  projectedSamples,
-  headReduction: Number(headReduction.toFixed(2)),
-  currentReduction: Number(currentReduction.toFixed(2)),
-  categories: Object.fromEntries(
-    [...categoryTotals]
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([name, totals]) => [name, totals]),
-  ),
-};
-console.log(JSON.stringify(result, null, 2));
-
-if (args.check && headReduction < 3.5) {
-  throw new Error(
-    `projected head-series reduction ${headReduction.toFixed(2)}x is below the 3.5x safety floor`,
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const stackValues = Bun.YAML.parse(await Bun.file("deploy/observability/values.yaml").text())[
+    "kube-prometheus-stack"
+  ] as Record<string, any>;
+  const rows = await prometheusQuery(
+    args.prometheusUrl,
+    'count by (job, metrics_path, __name__, le, interface, id, pod, reason) ({__name__!=""})',
   );
+  const headRows = await prometheusQuery(args.prometheusUrl, "prometheus_tsdb_head_series");
+  const headSeries = sumRows(headRows);
+
+  const categoryTotals = new Map<string, { current: number; projected: number }>();
+  for (const row of rows) {
+    const labels = row.metric;
+    const name = labels.__name__ ?? "";
+    const count = Number(row.value[1]);
+    const category = categoryFor(labels.job ?? "", name);
+    const retained = retainedByProfile(category, labels, stackValues);
+    const totals = categoryTotals.get(category) ?? { current: 0, projected: 0 };
+    totals.current += count;
+    if (retained) totals.projected += count;
+    categoryTotals.set(category, totals);
+  }
+
+  const currentSamples = [...categoryTotals.values()].reduce((sum, row) => sum + row.current, 0);
+  const projectedSamples = [...categoryTotals.values()].reduce(
+    (sum, row) => sum + row.projected,
+    0,
+  );
+  const instantReduction = reductionRatio(currentSamples, projectedSamples);
+  const headToProjectedRatio = reductionRatio(headSeries, projectedSamples);
+  const result = {
+    measurement:
+      "instant-vector projection; head-to-projected ratio is diagnostic because head includes stale series",
+    headSeries,
+    currentSamples,
+    projectedSamples,
+    instantReduction: Number(instantReduction.toFixed(2)),
+    headToProjectedRatio: Number(headToProjectedRatio.toFixed(2)),
+    categories: Object.fromEntries(
+      [...categoryTotals]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([name, totals]) => [name, totals]),
+    ),
+  };
+  console.log(JSON.stringify(result, null, 2));
+
+  if (args.check && instantReduction < MIN_INSTANT_SERIES_REDUCTION) {
+    throw new Error(
+      `projected instantaneous series reduction ${instantReduction.toFixed(2)}x is below the ${MIN_INSTANT_SERIES_REDUCTION.toFixed(1)}x safety floor`,
+    );
+  }
 }
 
-function retainedByProfile(
+if (import.meta.main) await main();
+
+export function retainedByProfile(
   category: string,
   labels: Record<string, string>,
   values: Record<string, any>,
 ): boolean {
+  if (AUTOMATIC_SCRAPE_METRICS.has(labels.__name__ ?? "")) return true;
   switch (category) {
     case "kubernetes-api":
       return applyRelabelRules(labels, values.kubeApiServer.serviceMonitor.metricRelabelings);
@@ -83,14 +113,17 @@ function retainedByProfile(
       return applyRelabelRules(labels, rules);
     }
     case "kube-state-metrics":
-      return new Set(values["kube-state-metrics"].metricAllowlist).has(labels.__name__);
+      return (
+        new Set(values["kube-state-metrics"].metricAllowlist).has(labels.__name__) &&
+        applyRelabelRules(labels, values["kube-state-metrics"].prometheus.monitor.metricRelabelings)
+      );
     case "node-exporter":
       return applyRelabelRules(
         labels,
         values["prometheus-node-exporter"].prometheus.monitor.metricRelabelings,
       );
     case "temporal":
-      return !/.*latency.*_bucket/.test(labels.__name__ ?? "");
+      return TEMPORAL_MATCHING_METRICS.has(labels.__name__ ?? "");
     case "grafana":
       return applyRelabelRules(labels, values.grafana.serviceMonitor.metricRelabelings);
     case "alertmanager":
@@ -102,6 +135,10 @@ function retainedByProfile(
     default:
       return true;
   }
+}
+
+export function reductionRatio(current: number, projected: number): number {
+  return projected > 0 ? current / projected : 0;
 }
 
 function applyRelabelRules(labels: Record<string, string>, rules: RelabelRule[]): boolean {

--- a/scripts/check-observability-render.ts
+++ b/scripts/check-observability-render.ts
@@ -89,6 +89,24 @@ const serviceMonitors = resources.filter(
 ) as Resource[];
 const apiServerMonitor = serviceMonitorEndingIn(serviceMonitors, "-apiserver");
 assertMetricRetention(apiServerMonitor, "/metrics", "apiserver_request_total", true);
+for (const le of ["0.1", "1", "5", "30", "+Inf"]) {
+  assertMetricRetention(
+    apiServerMonitor,
+    "/metrics",
+    "apiserver_request_sli_duration_seconds_bucket",
+    true,
+    { le },
+  );
+}
+for (const le of ["0.05", "10", "60"]) {
+  assertMetricRetention(
+    apiServerMonitor,
+    "/metrics",
+    "apiserver_request_sli_duration_seconds_bucket",
+    false,
+    { le },
+  );
+}
 assertMetricRetention(
   apiServerMonitor,
   "/metrics",
@@ -160,6 +178,18 @@ assert(allowlistArgument, "kube-state-metrics must render an explicit metric all
 const kubeStateAllowlist = new Set(
   allowlistArgument.slice("--metric-allowlist=".length).split(","),
 );
+const kubeStateMonitor = exactlyOne(
+  serviceMonitors.filter(
+    (resource) => resource.metadata?.labels?.["app.kubernetes.io/name"] === "kube-state-metrics",
+  ),
+  "kube-state-metrics ServiceMonitor",
+);
+assertMetricRetention(kubeStateMonitor, "/metrics", "kube_pod_status_reason", true, {
+  reason: "SchedulingGated",
+});
+assertMetricRetention(kubeStateMonitor, "/metrics", "kube_pod_status_reason", false, {
+  reason: "Evicted",
+});
 for (const metric of referencedMetrics) {
   if (metric.startsWith("kube_") && !metric.includes(":")) {
     assert(
@@ -220,6 +250,9 @@ for (const monitor of [
   operatorMonitor,
 ]) {
   assertMetricRetention(monitor, "/metrics", "go_memstats_heap_alloc_bytes", true);
+  assertMetricRetention(monitor, "/metrics", "go_gc_heap_allocs_by_size_bytes_bucket", false, {
+    le: "1024",
+  });
   assertMetricRetention(monitor, "/metrics", "process_open_fds", true);
 }
 for (const metric of referencedMetrics) {

--- a/scripts/deployment-observability.test.ts
+++ b/scripts/deployment-observability.test.ts
@@ -28,7 +28,7 @@ describe("observability deployment plan", () => {
     });
 
     expect(plan.chartPath).toBe("deploy/observability");
-    expect(plan.chartVersion).toBe("0.1.3");
+    expect(plan.chartVersion).toBe("0.1.4");
     expect(plan.kubePrometheusStackVersion).toBe("87.16.1");
     expect(plan.valuesFiles).toEqual(["deploy/observability/values.production.example.yaml"]);
     expect(plan.installCommands.slice(0, 2)).toEqual([

--- a/scripts/deployment-observability.ts
+++ b/scripts/deployment-observability.ts
@@ -17,7 +17,7 @@ export interface ObservabilityStackPlan {
   appReleaseName: string;
   environment: string;
   chartPath: "deploy/observability";
-  chartVersion: "0.1.3";
+  chartVersion: "0.1.4";
   kubePrometheusStackVersion: "87.16.1";
   valuesFiles: string[];
   applicationValuesFile: "deploy/observability/opengeni.values.example.yaml";
@@ -103,7 +103,7 @@ export function observabilityStackPlanFor(
     appReleaseName,
     environment,
     chartPath: "deploy/observability",
-    chartVersion: "0.1.3",
+    chartVersion: "0.1.4",
     kubePrometheusStackVersion: "87.16.1",
     valuesFiles,
     applicationValuesFile: "deploy/observability/opengeni.values.example.yaml",

--- a/scripts/resolve-optional-oci-manifest.test.ts
+++ b/scripts/resolve-optional-oci-manifest.test.ts
@@ -5,6 +5,17 @@ import { resolveOptionalOciManifest } from "./resolve-optional-oci-manifest";
 const digest = `sha256:${"a".repeat(64)}`;
 
 describe("optional OCI manifest resolution", () => {
+  test("fails closed when the registry lookup times out", async () => {
+    await expect(
+      resolveOptionalOciManifest("registry.example/image:1.0.0", async () => ({
+        exitCode: 143,
+        stdout: "",
+        stderr: "",
+        timedOut: true,
+      })),
+    ).rejects.toThrow("OCI manifest lookup timed out");
+  });
+
   test("returns only an exact immutable digest", async () => {
     await expect(
       resolveOptionalOciManifest("registry.example/image:1.0.0", async () => ({

--- a/scripts/resolve-optional-oci-manifest.ts
+++ b/scripts/resolve-optional-oci-manifest.ts
@@ -2,6 +2,7 @@ type CommandResult = {
   exitCode: number;
   stdout: string;
   stderr: string;
+  timedOut?: boolean;
 };
 
 type Run = (argv: string[]) => Promise<CommandResult>;
@@ -25,6 +26,9 @@ export async function resolveOptionalOciManifest(
     "--format",
     "{{json .Manifest}}",
   ]);
+  if (result.timedOut) {
+    throw new Error(`OCI manifest lookup timed out for ${reference}`);
+  }
   if (result.exitCode === 0) {
     let digest: unknown;
     try {
@@ -50,17 +54,40 @@ export async function resolveOptionalOciManifest(
 }
 
 async function runCommand(argv: string[]): Promise<CommandResult> {
+  const useProcessGroup = process.platform !== "win32";
   const child = Bun.spawn(argv, {
+    detached: useProcessGroup,
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [exitCode, stdout, stderr] = await Promise.all([
-    child.exited,
-    new Response(child.stdout).text(),
-    new Response(child.stderr).text(),
-  ]);
-  return { exitCode, stdout, stderr };
+  let timedOut = false;
+  const terminate = (signal: NodeJS.Signals): void => {
+    try {
+      if (useProcessGroup) process.kill(-child.pid, signal);
+      else child.kill(signal);
+    } catch {
+      // A concurrent normal exit wins the race with timeout cleanup.
+    }
+  };
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    terminate("SIGTERM");
+  }, 30_000);
+  const force = setTimeout(() => {
+    if (timedOut) terminate("SIGKILL");
+  }, 32_000);
+  try {
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    return { exitCode, stdout, stderr, timedOut };
+  } finally {
+    clearTimeout(timeout);
+    clearTimeout(force);
+  }
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
Narrows self-hosted metric ingestion to the signals consumed by pinned rules and dashboards, adds render/conformance checks plus a live fourfold-series guard, and makes optional OCI manifest discovery fail closed with bounded process-tree cleanup. Validation: focused tests, full lint/typecheck/build, public-hygiene check, default/production Helm render checks, and a 4.18x live instantaneous-series projection.