### PR TITLE
perf(ci): avoid duplicate Checkov startup

### DIFF
--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -4,8 +4,7 @@ ARG CHECKOV_VERSION=3.2.526
 
 RUN set -eux; \
     python -m venv /opt/checkov; \
-    /opt/checkov/bin/pip install --no-cache-dir "checkov==${CHECKOV_VERSION}"; \
-    /opt/checkov/bin/checkov --version
+    /opt/checkov/bin/pip install --no-cache-dir "checkov==${CHECKOV_VERSION}"
 
 FROM node:22.22.0-bookworm-slim AS node-runtime
 

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -58,6 +58,7 @@ function buildsSandboxCheckovOffTheSerialToolchain(dockerfile: string): boolean 
     checkovCopy,
   );
   const runtimeCopy = dockerfile.indexOf(sandboxArtifactRuntimeCopy, finalStage);
+  const versionProbes = dockerfile.match(/checkov --version/g)?.length ?? 0;
 
   return (
     checkovStage >= 0 &&
@@ -66,7 +67,8 @@ function buildsSandboxCheckovOffTheSerialToolchain(dockerfile: string): boolean 
     ttydInstall > finalStage &&
     checkovCopy > ttydInstall &&
     checkovVerification > checkovCopy &&
-    runtimeCopy > checkovVerification
+    runtimeCopy > checkovVerification &&
+    versionProbes === 1
   );
 }
 
@@ -146,6 +148,12 @@ describe("release image workflow contract", () => {
     expect(checkovFinalizationStart).toBeGreaterThan(-1);
     expect(checkovFinalizationEnd).toBeGreaterThan(checkovFinalizationStart);
     expect(buildsSandboxCheckovOffTheSerialToolchain(serialCheckov)).toBe(false);
+
+    const duplicateBuilderProbe = dockerfile.replace(
+      '/opt/checkov/bin/pip install --no-cache-dir "checkov==${CHECKOV_VERSION}"',
+      '/opt/checkov/bin/pip install --no-cache-dir "checkov==${CHECKOV_VERSION}"; \\\n+    /opt/checkov/bin/checkov --version',
+    );
+    expect(buildsSandboxCheckovOffTheSerialToolchain(duplicateBuilderProbe)).toBe(false);
   });
 
   test("dedicated artifact sidecars run self-contained production bundles", async () => {


### PR DESCRIPTION
## Summary
- remove the duplicate Checkov CLI startup from the independent builder stage
- retain the final sandbox-image `checkov --version` verification after the venv is copied and linked
- extend the workflow contract test to reject multiple Checkov version probes

## Measurement
- current `main` natural CI run `31347039929`: sandbox image job `93331721797` completed in 645s
- its cold arm64 builder-stage Checkov probe took about 45.2s (`399.9s` to `445.1s`)
- the final-image arm64 Checkov probe still took about 53s and remains the authoritative runtime gate
- expected cold-path benefit: eliminate the redundant builder startup from the sandbox critical path
- warm behavior is separate: no material gain is expected when that builder stage is already cached

The unrelated workbench browser acceptance failure in main run `31347039929` was an isolated 30s live-replica timeout; this change does not alter that test or its tolerance.

## Verification
- `git diff --check`
- `bun test scripts/release-image-workflow-contract.test.ts scripts/dev-stack-artifact-runtime.test.ts scripts/artifact-runtime-workflow-contract.test.ts` (27 pass)
- `bunx oxfmt --check scripts/release-image-workflow-contract.test.ts`
- `bunx oxlint --deny-warnings scripts/release-image-workflow-contract.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`

Refs OPE-27.
