### PR TITLE
fix: project cancellation receipts before queue refresh

### DIFF
--- a/.changeset/clear-cancellation-receipts.md
+++ b/.changeset/clear-cancellation-receipts.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/core": patch
+"@opengeni/react": patch
+"@opengeni/sdk": patch
+---
+
+Project physical cancellation immediately from atomic Steer and Pause receipts, then reconcile it against durable queue truth.

--- a/apps/api/test/session-human-input-routes.test.ts
+++ b/apps/api/test/session-human-input-routes.test.ts
@@ -258,21 +258,25 @@ describe("structured human-input HTTP surface (real PostgreSQL)", () => {
       },
     });
 
+    const steerClientEventId = crypto.randomUUID();
+    const steerBody = {
+      text: "",
+      clientEventId: steerClientEventId,
+      annotations: [{ ...annotation, id: crypto.randomUUID() }],
+    };
     const steerResponse = await app.request(
       `http://x/v1/workspaces/${grant.workspaceId}/sessions/${session.id}/steer`,
       {
         method: "POST",
         headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-        body: JSON.stringify({
-          text: "",
-          clientEventId: crypto.randomUUID(),
-          annotations: [{ ...annotation, id: crypto.randomUUID() }],
-        }),
+        body: JSON.stringify(steerBody),
       },
     );
     expect(steerResponse.status).toBe(202);
-    expect(await steerResponse.json()).toMatchObject({
+    const steerResult = await steerResponse.json();
+    expect(steerResult).toMatchObject({
       interruptionCount: 0,
+      replay: false,
       accepted: {
         payload: {
           text: "",
@@ -283,6 +287,22 @@ describe("structured human-input HTTP surface (real PostgreSQL)", () => {
         prompt: "",
         annotations: [{ ordinal: 1, quote: "beta", source: { eventId: source!.id } }],
       },
+    });
+
+    const replayResponse = await app.request(
+      `http://x/v1/workspaces/${grant.workspaceId}/sessions/${session.id}/steer`,
+      {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        body: JSON.stringify(steerBody),
+      },
+    );
+    expect(replayResponse.status).toBe(202);
+    expect(await replayResponse.json()).toMatchObject({
+      interruptionCount: 0,
+      replay: true,
+      accepted: { id: steerResult.accepted.id },
+      turn: { id: steerResult.turn.id },
     });
   });
 

--- a/apps/api/test/session-human-input-routes.test.ts
+++ b/apps/api/test/session-human-input-routes.test.ts
@@ -272,6 +272,7 @@ describe("structured human-input HTTP surface (real PostgreSQL)", () => {
     );
     expect(steerResponse.status).toBe(202);
     expect(await steerResponse.json()).toMatchObject({
+      interruptionCount: 0,
       accepted: {
         payload: {
           text: "",

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.1
-appVersion: "0.23.1"
+version: 0.23.2
+appVersion: "0.23.2"

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1988,15 +1988,20 @@ export async function acceptSessionUserMessage(
   workspaceId: Parameters<typeof acceptSessionUserMessageWithOutcome>[2],
   sessionId: Parameters<typeof acceptSessionUserMessageWithOutcome>[3],
   input: Parameters<typeof acceptSessionUserMessageWithOutcome>[4],
-): Promise<{ accepted: SessionEvent; turn: SessionTurn; interruptionCount: number }> {
-  const { accepted, turn, interruptionCount } = await acceptSessionUserMessageWithOutcome(
+): Promise<{
+  accepted: SessionEvent;
+  turn: SessionTurn;
+  interruptionCount: number;
+  replay: boolean;
+}> {
+  const { accepted, turn, interruptionCount, replay } = await acceptSessionUserMessageWithOutcome(
     deps,
     grant,
     workspaceId,
     sessionId,
     input,
   );
-  return { accepted, turn, interruptionCount };
+  return { accepted, turn, interruptionCount, replay };
 }
 
 /**

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1044,7 +1044,12 @@ export async function postUserMessageTurn(input: {
   expectedDraftRevision?: number | null;
   reasoningEffortFallback?: Settings["openaiReasoningEffort"];
   turnExecutionPolicy: TurnExecutionPolicyV1;
-}): Promise<{ accepted: SessionEvent; turn: SessionTurn; replay: boolean }> {
+}): Promise<{
+  accepted: SessionEvent;
+  turn: SessionTurn;
+  interruptionCount: number;
+  replay: boolean;
+}> {
   const { db, bus, workflowClient, settings, accountId, workspaceId, sessionId } = input;
   const requestedModel = canonicalConfiguredModel(settings, input.model ?? null) ?? null;
   const requestedReasoningEffort = input.reasoningEffort ?? null;
@@ -1158,7 +1163,12 @@ export async function postUserMessageTurn(input: {
       origin: "core",
     });
   }
-  return { accepted, turn, replay: result.replay };
+  return {
+    accepted,
+    turn,
+    interruptionCount: result.interruptionCount,
+    replay: result.replay,
+  };
 }
 
 /**
@@ -1828,7 +1838,12 @@ export async function acceptSessionUserMessageWithOutcome(
     controlEtag?: string | null;
     expectedDraftRevision?: number | null;
   },
-): Promise<{ accepted: SessionEvent; turn: SessionTurn; replay: boolean }> {
+): Promise<{
+  accepted: SessionEvent;
+  turn: SessionTurn;
+  interruptionCount: number;
+  replay: boolean;
+}> {
   const { settings, db, bus, workflowClient, objectStorage } = deps;
   await requireSessionAuthorization(deps, grant, {
     sessionId,
@@ -1906,7 +1921,7 @@ export async function acceptSessionUserMessageWithOutcome(
     source: personalConnectionDelegationSourceForGrant(grant),
   });
   const delegatedServiceInitiator = serviceInitiatorForGrant(grant);
-  const { accepted, turn, replay } = await postUserMessageTurn({
+  const { accepted, turn, interruptionCount, replay } = await postUserMessageTurn({
     db,
     bus,
     workflowClient,
@@ -1963,7 +1978,7 @@ export async function acceptSessionUserMessageWithOutcome(
     origin: turn.source,
     idempotencyKey: `agent_run.created:${workspaceId}:${turn.id}`,
   });
-  return { accepted, turn, replay };
+  return { accepted, turn, interruptionCount, replay };
 }
 
 /** Backward-compatible entity-returning path used by existing REST callers. */
@@ -1973,15 +1988,15 @@ export async function acceptSessionUserMessage(
   workspaceId: Parameters<typeof acceptSessionUserMessageWithOutcome>[2],
   sessionId: Parameters<typeof acceptSessionUserMessageWithOutcome>[3],
   input: Parameters<typeof acceptSessionUserMessageWithOutcome>[4],
-): Promise<{ accepted: SessionEvent; turn: SessionTurn }> {
-  const { accepted, turn } = await acceptSessionUserMessageWithOutcome(
+): Promise<{ accepted: SessionEvent; turn: SessionTurn; interruptionCount: number }> {
+  const { accepted, turn, interruptionCount } = await acceptSessionUserMessageWithOutcome(
     deps,
     grant,
     workspaceId,
     sessionId,
     input,
   );
-  return { accepted, turn };
+  return { accepted, turn, interruptionCount };
 }
 
 /**

--- a/packages/react/src/components/session-chrome.tsx
+++ b/packages/react/src/components/session-chrome.tsx
@@ -272,7 +272,14 @@ export function SessionChrome({
       queuedTurns: currentTurnId ? turns.filter((turn) => turn.id !== currentTurnId) : turns,
     };
   }, [composerSteering, queue.pendingByTurn, turns]);
-  const stopping = queue.stoppingPreviousAttempt;
+  const stoppingKind =
+    composer?.stoppingAttempt ??
+    (queue.stoppingPreviousAttempt
+      ? queue.effectiveControl?.state === "paused"
+        ? "current"
+        : "previous"
+      : null);
+  const stopping = stoppingKind !== null;
   const canMutateQueue = !readOnly && composer !== undefined;
 
   const liveGoal =
@@ -312,7 +319,7 @@ export function SessionChrome({
       rows.push({
         id: "steering",
         label: stopping
-          ? queue.effectiveControl?.state === "paused"
+          ? stoppingKind === "current"
             ? "Stopping current work…"
             : "Stopping previous work…"
           : "Changing direction…",
@@ -389,11 +396,11 @@ export function SessionChrome({
     elapsed,
     goalState,
     incoming,
-    queue.effectiveControl,
     queuedTurns,
     record,
     steering,
     stopping,
+    stoppingKind,
   ]);
 
   const [activeUncontrolled, setActiveUncontrolled] = useState<SessionChromeSignalId | null>(
@@ -497,6 +504,7 @@ export function SessionChrome({
     ) : active === "steering" && (steering || stopping) ? (
       <SteeringPanel
         phase={stopping ? "stopping" : (steering?.phase ?? "accepted")}
+        stoppingKind={stoppingKind}
         text={steering?.text}
       />
     ) : active === "queue" ? (
@@ -782,9 +790,11 @@ function IncomingPanel({
 
 function SteeringPanel({
   phase,
+  stoppingKind,
   text,
 }: {
   phase: "submitting" | "accepted" | "stopping";
+  stoppingKind?: "current" | "previous" | null | undefined;
   text?: string | undefined;
 }) {
   return (
@@ -809,7 +819,7 @@ function SteeringPanel({
           {phase === "submitting"
             ? "Sending your latest direction…"
             : phase === "stopping"
-              ? text
+              ? stoppingKind === "previous"
                 ? "Direction saved. Waiting for the previous command to stop safely."
                 : "Waiting for the current command to stop safely."
               : "Direction accepted. The agent will continue from it."}

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -298,6 +298,8 @@ export type ComposerState = {
   steer: (text?: string) => Promise<boolean>;
   /** Optimistic-to-durable projection for a Steer that has not started yet. */
   steering?: ComposerSteeringState | null | undefined;
+  /** Immediate mutation-receipt projection while physical cancellation settles. */
+  stoppingAttempt?: "current" | "previous" | null | undefined;
   sending: boolean;
   canSend: boolean;
   /** Pause the session without deleting its prompt queue. */
@@ -329,6 +331,13 @@ export type ComposerSteeringState = {
   clientEventId: string | null;
   triggerEventId: string | null;
   turnId: string | null;
+  /** True only when the accepted Steer durably interrupted a live attempt. */
+  stoppingPreviousAttempt?: boolean | undefined;
+};
+
+type ComposerControlStoppingState = {
+  controlVersion: number;
+  controlEtag: string;
 };
 
 const STEERING_SETTLEMENT_EVENT_TYPES = new Set([
@@ -413,6 +422,7 @@ export function useComposer(
       : null,
   );
   const [pausing, setPausing] = useState(false);
+  const [controlStopping, setControlStopping] = useState<ComposerControlStoppingState | null>(null);
   const [resuming, setResuming] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [draft, setDraft] = useState<ComposerDraft | null>(null);
@@ -496,6 +506,7 @@ export function useComposer(
         : null,
     );
     setPausing(false);
+    setControlStopping(null);
     setResuming(false);
     setError(null);
     setDraft(null);
@@ -763,6 +774,22 @@ export function useComposer(
     steeringSettlementEventsRef.current = [];
     setSteering(null);
   }, [options.events, steering]);
+
+  useEffect(() => {
+    if (!controlStopping) return;
+    const effectiveControl = options.effectiveControl;
+    if (!effectiveControl || effectiveControl.controlVersion < controlStopping.controlVersion) {
+      return;
+    }
+    if (
+      effectiveControl.controlVersion === controlStopping.controlVersion &&
+      effectiveControl.controlEtag !== controlStopping.controlEtag
+    ) {
+      return;
+    }
+    if (effectiveControl.settlement !== null) return;
+    setControlStopping((current) => (current === controlStopping ? null : current));
+  }, [controlStopping, options.effectiveControl]);
 
   const currentDraftPayload = useCallback((): SaveComposerDraftRequest | null => {
     if (!durableDrafts || targetKeyRef.current !== targetKey) return null;
@@ -1059,6 +1086,7 @@ export function useComposer(
                 clientEventId: pending.input.clientEventId ?? null,
                 triggerEventId: result.accepted.id,
                 turnId: result.turn.id,
+                stoppingPreviousAttempt: (result.interruptionCount ?? 0) > 0,
               });
             }
           } catch (cause) {
@@ -1144,6 +1172,7 @@ export function useComposer(
               clientEventId: input.clientEventId ?? null,
               triggerEventId: result.accepted.id,
               turnId: result.turn.id,
+              stoppingPreviousAttempt: (result.interruptionCount ?? 0) > 0,
             });
           }
         } catch (cause) {
@@ -1219,12 +1248,25 @@ export function useComposer(
       setPausing(true);
       setError(null);
       try {
-        await client.pauseSession(workspaceId, sessionId, {
+        const result = await client.pauseSession(workspaceId, sessionId, {
           ...(reason !== undefined ? { reason } : {}),
           ...(options.effectiveControl?.controlEtag
             ? { expectedControlEtag: options.effectiveControl.controlEtag }
             : {}),
         });
+        if (
+          targetKeyRef.current === ownedTargetKey &&
+          targetGeneration.current === ownedGeneration
+        ) {
+          setControlStopping(
+            result.interruptionCount > 0 && result.effectiveControl.settlement !== null
+              ? {
+                  controlVersion: result.effectiveControl.controlVersion,
+                  controlEtag: result.effectiveControl.controlEtag,
+                }
+              : null,
+          );
+        }
       } catch (cause) {
         if (
           targetKeyRef.current === ownedTargetKey &&
@@ -1481,6 +1523,7 @@ export function useComposer(
   );
 
   const identityMatches = stateTargetKey === targetKey;
+  const visibleSteering = identityMatches ? steering : null;
   const reloadDraft = useCallback(async () => await loadDraft(true), [loadDraft]);
   const clearError = useCallback(() => {
     if (targetKeyRef.current !== targetKey) return;
@@ -1500,7 +1543,14 @@ export function useComposer(
     hasDraftContent,
     send,
     steer,
-    steering: identityMatches ? steering : null,
+    steering: visibleSteering,
+    stoppingAttempt: identityMatches
+      ? controlStopping
+        ? "current"
+        : visibleSteering?.phase === "accepted" && visibleSteering.stoppingPreviousAttempt === true
+          ? "previous"
+          : null
+      : null,
     sending: identityMatches ? sending : false,
     canSend:
       identityMatches &&

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -783,11 +783,14 @@ export function useComposer(
     }
     if (
       effectiveControl.controlVersion === controlStopping.controlVersion &&
-      effectiveControl.controlEtag !== controlStopping.controlEtag
+      effectiveControl.controlEtag === controlStopping.controlEtag &&
+      effectiveControl.settlement !== null
     ) {
       return;
     }
-    if (effectiveControl.settlement !== null) return;
+    // A newer control revision, an impossible same-version/different-etag
+    // projection, or quiescence at this exact revision supersedes the local
+    // mutation receipt. SessionChrome then falls back to durable queue truth.
     setControlStopping((current) => (current === controlStopping ? null : current));
   }, [controlStopping, options.effectiveControl]);
 
@@ -1086,7 +1089,8 @@ export function useComposer(
                 clientEventId: pending.input.clientEventId ?? null,
                 triggerEventId: result.accepted.id,
                 turnId: result.turn.id,
-                stoppingPreviousAttempt: (result.interruptionCount ?? 0) > 0,
+                stoppingPreviousAttempt:
+                  result.replay !== true && (result.interruptionCount ?? 0) > 0,
               });
             }
           } catch (cause) {
@@ -1172,7 +1176,8 @@ export function useComposer(
               clientEventId: input.clientEventId ?? null,
               triggerEventId: result.accepted.id,
               turnId: result.turn.id,
-              stoppingPreviousAttempt: (result.interruptionCount ?? 0) > 0,
+              stoppingPreviousAttempt:
+                result.replay !== true && (result.interruptionCount ?? 0) > 0,
             });
           }
         } catch (cause) {
@@ -1259,7 +1264,9 @@ export function useComposer(
           targetGeneration.current === ownedGeneration
         ) {
           setControlStopping(
-            result.interruptionCount > 0 && result.effectiveControl.settlement !== null
+            result.interruptionCount > 0 &&
+              result.effectiveControl.state === "paused" &&
+              result.effectiveControl.settlement !== null
               ? {
                   controlVersion: result.effectiveControl.controlVersion,
                   controlEtag: result.effectiveControl.controlEtag,

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1700,8 +1700,16 @@ describe("useComposer queue-vs-steer", () => {
   });
 
   test("projects Steer immediately, keeps it accepted, then settles when execution starts", async () => {
-    let resolveSteer!: (value: { accepted: SessionEvent; turn: SessionTurn }) => void;
-    const pendingSteer = new Promise<{ accepted: SessionEvent; turn: SessionTurn }>((resolve) => {
+    let resolveSteer!: (value: {
+      accepted: SessionEvent;
+      turn: SessionTurn;
+      interruptionCount: number;
+    }) => void;
+    const pendingSteer = new Promise<{
+      accepted: SessionEvent;
+      turn: SessionTurn;
+      interruptionCount: number;
+    }>((resolve) => {
       resolveSteer = resolve;
     });
     const turn = fakeTurn({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" });
@@ -1729,14 +1737,16 @@ describe("useComposer queue-vs-steer", () => {
     });
 
     await reactAct(async () => {
-      resolveSteer({ accepted, turn });
+      resolveSteer({ accepted, turn, interruptionCount: 1 });
       expect(await result).toBe(true);
     });
     expect(hook.result.current.steering).toMatchObject({
       phase: "accepted",
       triggerEventId: accepted.id,
       turnId: turn.id,
+      stoppingPreviousAttempt: true,
     });
+    expect(hook.result.current.stoppingAttempt).toBe("previous");
 
     await hook.rerender({
       events: [
@@ -1748,6 +1758,61 @@ describe("useComposer queue-vs-steer", () => {
       ],
     });
     expect(hook.result.current.steering).toBeNull();
+    expect(hook.result.current.stoppingAttempt).toBeNull();
+    await hook.unmount();
+  });
+
+  test("projects a Pause receipt until the authoritative quiescence snapshot arrives", async () => {
+    const pendingControl = {
+      ...queueSnapshot([]).effectiveControl,
+      state: "paused" as const,
+      directState: "paused" as const,
+      controlVersion: 4,
+      controlEtag: "control-4",
+      settlement: {
+        state: "stopping" as const,
+        attemptCount: 1,
+        interruptionPendingCount: 0,
+        quiescencePendingCount: 1,
+      },
+    };
+    const client = fakeClient({
+      pauseSession: async () => ({
+        receipt: {
+          id: crypto.randomUUID(),
+          action: "session.paused",
+          operationKey: crypto.randomUUID(),
+          targetSessionId: SESSION_ID,
+          targetTurnId: null,
+          appliedControlRevision: 4,
+          appliedQueueVersion: null,
+          appliedTurnVersion: null,
+          appliedDraftRevision: null,
+          createdAt: new Date().toISOString(),
+        },
+        effectiveControl: pendingControl,
+        interruptionCount: 1,
+        wakeCount: 0,
+        cancelledSessionCount: 0,
+        cancelledTurnCount: 0,
+      }),
+    });
+    const hook = await renderHook(
+      (effectiveControl: SessionQueueSnapshot["effectiveControl"]) =>
+        useComposer(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          effectiveControl,
+        }),
+      queueSnapshot([]).effectiveControl,
+    );
+    await flush();
+
+    await flushing(async () => await hook.result.current.pause());
+    expect(hook.result.current.stoppingAttempt).toBe("current");
+
+    await hook.rerender({ ...pendingControl, settlement: null });
+    expect(hook.result.current.stoppingAttempt).toBeNull();
     await hook.unmount();
   });
 

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -1762,6 +1762,29 @@ describe("useComposer queue-vs-steer", () => {
     await hook.unmount();
   });
 
+  test("does not resurrect physical stopping from an idempotent Steer replay", async () => {
+    const client = fakeClient({
+      steerMessage: async () => ({
+        accepted: makeEvent(10, "user.message", { delivery: "steer" }),
+        turn: fakeTurn({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
+        interruptionCount: 1,
+        replay: true,
+      }),
+    });
+    const hook = await renderHook(
+      () => useComposer(SESSION_ID, { client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+    await flush();
+
+    await flushing(async () => {
+      expect(await hook.result.current.steer("Retry the accepted direction")).toBe(true);
+    });
+    expect(hook.result.current.steering?.phase).toBe("accepted");
+    expect(hook.result.current.stoppingAttempt).toBeNull();
+    await hook.unmount();
+  });
+
   test("projects a Pause receipt until the authoritative quiescence snapshot arrives", async () => {
     const pendingControl = {
       ...queueSnapshot([]).effectiveControl,
@@ -1812,6 +1835,66 @@ describe("useComposer queue-vs-steer", () => {
     expect(hook.result.current.stoppingAttempt).toBe("current");
 
     await hook.rerender({ ...pendingControl, settlement: null });
+    expect(hook.result.current.stoppingAttempt).toBeNull();
+    await hook.unmount();
+  });
+
+  test("retires a Pause receipt when a newer control revision supersedes it", async () => {
+    const pendingControl = {
+      ...queueSnapshot([]).effectiveControl,
+      state: "paused" as const,
+      directState: "paused" as const,
+      controlVersion: 4,
+      controlEtag: "control-4",
+      settlement: {
+        state: "stopping" as const,
+        attemptCount: 1,
+        interruptionPendingCount: 0,
+        quiescencePendingCount: 1,
+      },
+    };
+    const client = fakeClient({
+      pauseSession: async () => ({
+        receipt: {
+          id: crypto.randomUUID(),
+          action: "session.paused",
+          operationKey: crypto.randomUUID(),
+          targetSessionId: SESSION_ID,
+          targetTurnId: null,
+          appliedControlRevision: 4,
+          appliedQueueVersion: null,
+          appliedTurnVersion: null,
+          appliedDraftRevision: null,
+          createdAt: new Date().toISOString(),
+        },
+        effectiveControl: pendingControl,
+        interruptionCount: 1,
+        wakeCount: 0,
+        cancelledSessionCount: 0,
+        cancelledTurnCount: 0,
+      }),
+    });
+    const hook = await renderHook(
+      (effectiveControl: SessionQueueSnapshot["effectiveControl"]) =>
+        useComposer(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          effectiveControl,
+        }),
+      queueSnapshot([]).effectiveControl,
+    );
+    await flush();
+
+    await flushing(async () => await hook.result.current.pause());
+    expect(hook.result.current.stoppingAttempt).toBe("current");
+
+    await hook.rerender({
+      ...pendingControl,
+      state: "active",
+      directState: "active",
+      controlVersion: 5,
+      controlEtag: "control-5",
+    });
     expect(hook.result.current.stoppingAttempt).toBeNull();
     await hook.unmount();
   });

--- a/packages/react/test/session-chrome.test.tsx
+++ b/packages/react/test/session-chrome.test.tsx
@@ -79,6 +79,26 @@ function queue(overrides: Partial<UseTurnQueueResult> = {}): UseTurnQueueResult 
   };
 }
 
+function pausedEffectiveControl(): NonNullable<UseTurnQueueResult["effectiveControl"]> {
+  return {
+    state: "paused",
+    controlVersion: 4,
+    controlEtag: "control-4",
+    directState: "paused",
+    primaryBlocker: null,
+    additionalBlockerCount: 0,
+    blockers: [],
+    resumeOptions: [],
+    override: null,
+    settlement: {
+      state: "stopping",
+      attemptCount: 1,
+      interruptionPendingCount: 0,
+      quiescencePendingCount: 1,
+    },
+  };
+}
+
 function pendingInput(): UseTurnQueueResult["pendingInputs"][number] {
   return {
     id: "33333333-3333-4333-8333-333333333333",
@@ -330,15 +350,64 @@ describe("SessionChrome", () => {
     expect(steeringPanel?.textContent).not.toContain("agent will continue");
   });
 
-  test("shows stopping even when no Steer is queued", async () => {
+  test("shows an accepted composer Steer receipt before the queue refresh arrives", async () => {
     mounted = await renderComponent(
-      <SessionChrome queue={queue({ queue: [], stoppingPreviousAttempt: true })} />,
+      <SessionChrome
+        queue={queue({ queue: [], stoppingPreviousAttempt: false })}
+        composer={composer({
+          stoppingAttempt: "previous",
+          steering: {
+            phase: "accepted",
+            text: "Use the corrected digest",
+            clientEventId: "client-steer-2",
+            triggerEventId: "event-steer-2",
+            turnId: "11111111-1111-4111-8111-111111111111",
+            stoppingPreviousAttempt: true,
+          },
+        })}
+      />,
+    );
+
+    const steeringChip = mounted.container.querySelector<HTMLButtonElement>(
+      '[data-og-session-chrome-signal="steering"]',
+    );
+    expect(steeringChip?.textContent).toContain("Stopping previous work");
+    expect(steeringChip?.textContent).not.toContain("Changing direction");
+  });
+
+  test("shows a Pause receipt as stopping current work before the queue refresh arrives", async () => {
+    mounted = await renderComponent(
+      <SessionChrome
+        queue={queue({ queue: [], stoppingPreviousAttempt: false })}
+        composer={composer({ stoppingAttempt: "current" })}
+      />,
     );
 
     const stoppingChip = mounted.container.querySelector<HTMLButtonElement>(
       '[data-og-session-chrome-signal="steering"]',
     );
-    expect(stoppingChip?.textContent).toContain("Stopping previous work");
+    expect(stoppingChip?.textContent).toContain("Stopping current work");
+    await act(async () => stoppingChip?.click());
+    expect(
+      mounted.container.querySelector('[data-og-session-chrome-panel="steering"]')?.textContent,
+    ).toContain("current command to stop safely");
+  });
+
+  test("shows stopping even when no Steer is queued", async () => {
+    mounted = await renderComponent(
+      <SessionChrome
+        queue={queue({
+          queue: [],
+          stoppingPreviousAttempt: true,
+          effectiveControl: pausedEffectiveControl(),
+        })}
+      />,
+    );
+
+    const stoppingChip = mounted.container.querySelector<HTMLButtonElement>(
+      '[data-og-session-chrome-signal="steering"]',
+    );
+    expect(stoppingChip?.textContent).toContain("Stopping current work");
     await act(async () => stoppingChip?.click());
     expect(
       mounted.container.querySelector('[data-og-session-chrome-panel="steering"]')?.textContent,

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -341,6 +341,8 @@ export type SteerMessageResult = {
   turn: SessionTurn;
   /** Number of live attempts durably asked to stop by this atomic Steer. */
   interruptionCount?: number;
+  /** True when this response came from the command's immutable idempotency receipt. */
+  replay?: boolean;
 };
 
 export type TranscribeAudioInput = {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -339,6 +339,8 @@ export type SteerMessageResult = {
   accepted: SessionEvent;
   /** The exact turn created for this message in the same server transaction. */
   turn: SessionTurn;
+  /** Number of live attempts durably asked to stop by this atomic Steer. */
+  interruptionCount?: number;
 };
 
 export type TranscribeAudioInput = {

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -198,12 +198,13 @@ describe("OpenGeniClient turn queue", () => {
       triggerEventId: accepted.id,
     });
     const { client, requests } = makeClient(() =>
-      jsonResponse({ accepted, turn: steerTurn, interruptionCount: 1 }, 202),
+      jsonResponse({ accepted, turn: steerTurn, interruptionCount: 1, replay: false }, 202),
     );
     const result = await client.steerMessage(WORKSPACE_ID, SESSION_ID, "do this now");
     expect(result.accepted.id).toBe(accepted.id);
     expect(result.turn.id).toBe(TURN_B);
     expect(result.interruptionCount).toBe(1);
+    expect(result.replay).toBe(false);
     expect(requests).toHaveLength(1);
     expect(requests[0]!.method).toBe("POST");
     expect(requests[0]!.url).toBe(

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -197,10 +197,13 @@ describe("OpenGeniClient turn queue", () => {
       position: 1,
       triggerEventId: accepted.id,
     });
-    const { client, requests } = makeClient(() => jsonResponse({ accepted, turn: steerTurn }, 202));
+    const { client, requests } = makeClient(() =>
+      jsonResponse({ accepted, turn: steerTurn, interruptionCount: 1 }, 202),
+    );
     const result = await client.steerMessage(WORKSPACE_ID, SESSION_ID, "do this now");
     expect(result.accepted.id).toBe(accepted.id);
     expect(result.turn.id).toBe(TURN_B);
+    expect(result.interruptionCount).toBe(1);
     expect(requests).toHaveLength(1);
     expect(requests[0]!.method).toBe("POST");
     expect(requests[0]!.url).toBe(

--- a/scripts/workbench-live-acceptance.test.ts
+++ b/scripts/workbench-live-acceptance.test.ts
@@ -21,6 +21,7 @@ import {
   controlCancellationTimelineMs,
   fixturePrompt,
   isExpectedBrowserCancellation,
+  liveStoppingStateLocator,
   maskKnownPublicEvidenceValues,
   openWorkspaceIfCollapsed,
   parseCookieHeader,
@@ -69,6 +70,31 @@ describe("workbench live acceptance preflight", () => {
       classifyControlCommandMarkerEvent(event(marker, "sandbox.command.output.delta"), marker),
     ).toBeNull();
     expect(classifyControlCommandMarkerEvent(event("different"), marker)).toBeNull();
+  });
+
+  test("matches authoritative SessionChrome stopping copy, not optimistic Steer copy", () => {
+    const filters: unknown[] = [];
+    const steering = {
+      filter: (options: unknown) => {
+        filters.push(options);
+        return steering;
+      },
+    };
+    const testIds: string[] = [];
+    const page = {
+      getByTestId: (testId: string) => {
+        testIds.push(testId);
+        return steering;
+      },
+    } as never;
+
+    expect(liveStoppingStateLocator(page, "steer")).toBe(steering as never);
+    expect(liveStoppingStateLocator(page, "pause")).toBe(steering as never);
+    expect(testIds).toEqual(["session-chrome-steering", "session-chrome-steering"]);
+    expect(filters).toEqual([
+      { hasText: "Stopping previous work" },
+      { hasText: "Stopping current work" },
+    ]);
   });
 
   test("observes split binary terminal output without depending on xterm DOM rows", async () => {

--- a/scripts/workbench-live-acceptance.ts
+++ b/scripts/workbench-live-acceptance.ts
@@ -49,6 +49,7 @@ const TERMINAL_SELECTOR = "[data-opengeni-terminal]";
 const INTERACTIVE_TERMINAL_SELECTOR =
   '[data-opengeni-terminal][data-opengeni-terminal-status="open"]' +
   '[data-opengeni-terminal-interactive="true"]';
+const SESSION_CHROME_STEERING_TEST_ID = "session-chrome-steering";
 const CAPTURE_API_P95_MS = maximumMillisecondBudget("performance.capture-api-response", "p95");
 const CAPTURE_USABLE_WORKBENCH_P95_MS = maximumMillisecondBudget(
   "performance.capture-usable-workbench",
@@ -1475,6 +1476,20 @@ function isRunningControlCommandMarkerEvent(event: SessionEvent, marker: string)
   return state === "running";
 }
 
+/**
+ * The production session route renders control state in SessionChrome. Match
+ * both its stable test id and the exact authoritative stopping projection so
+ * the optimistic "Changing direction" state cannot satisfy this proof.
+ */
+export function liveStoppingStateLocator(
+  page: Pick<Page, "getByTestId">,
+  control: "steer" | "pause",
+): Locator {
+  return page.getByTestId(SESSION_CHROME_STEERING_TEST_ID).filter({
+    hasText: control === "steer" ? "Stopping previous work" : "Stopping current work",
+  });
+}
+
 async function proveLiveSteerCancellation(input: {
   client: OpenGeniClient;
   page: Page;
@@ -1555,8 +1570,8 @@ async function proveLiveSteerCancellation(input: {
   const composer = page.getByLabel("Message the agent");
   await composer.waitFor({ timeout: 20_000 });
   await composer.fill(`Reply exactly REPLACED_${marker}. Do not run a tool.`);
-  const stoppingVisible = page
-    .getByTestId("stopping-previous-attempt")
+  const stoppingState = liveStoppingStateLocator(page, "steer");
+  const stoppingVisible = stoppingState
     .waitFor({ state: "visible", timeout: 1_000 })
     .then(() => true)
     .catch(() => false);
@@ -1640,7 +1655,7 @@ async function proveLiveSteerCancellation(input: {
       `Steer spent ${cancellationTimeline.physicalQuiescenceMs}ms behind the physical fence without rendering its stopping state`,
     );
   }
-  await page.getByTestId("stopping-previous-attempt").waitFor({ state: "hidden", timeout: 5_000 });
+  await stoppingState.waitFor({ state: "hidden", timeout: 5_000 });
 
   const settled = await waitForSettled(client, workspaceId, sessionId, sessionTimeoutMs);
   if (settled.status !== "idle") {
@@ -1758,12 +1773,12 @@ async function proveLivePauseCancellation(input: {
   const predecessorTurnId = ready.turnId;
   const predecessorAttemptId = ready.turnAttemptId;
 
-  const stoppingState = page
-    .getByTestId("stopping-previous-attempt")
+  const stoppingState = liveStoppingStateLocator(page, "pause");
+  const stoppingObservation = stoppingState
     .waitFor({ state: "visible", timeout: 1_000 })
     .then(async () => ({
       visible: true,
-      text: (await page.getByTestId("stopping-previous-attempt").textContent()) ?? "",
+      text: (await stoppingState.textContent()) ?? "",
     }))
     .catch(() => ({ visible: false, text: "" }));
   const pauseResponsePromise = page.waitForResponse(
@@ -1831,22 +1846,19 @@ async function proveLivePauseCancellation(input: {
       `Pause physical cancellation took ${controlCancellationMs}ms; budget is ${CONTROL_CANCELLATION_WORST_MS}ms`,
     );
   }
-  const renderedStoppingState = await stoppingState;
-  if (controlCancellationMs > 100 && !renderedStoppingState.visible) {
+  const observedStoppingState = await stoppingObservation;
+  if (controlCancellationMs > 100 && !observedStoppingState.visible) {
     throw new Error(
       `Pause spent ${controlCancellationMs}ms behind the physical fence without rendering its stopping state`,
     );
   }
   if (
-    renderedStoppingState.visible &&
-    (!renderedStoppingState.text.includes("Stopping current attempt") ||
-      !renderedStoppingState.text.includes("until you resume"))
+    observedStoppingState.visible &&
+    !observedStoppingState.text.includes("Stopping current work")
   ) {
-    throw new Error(
-      "Pause rendered misleading Steer queue copy while physical cancellation settled",
-    );
+    throw new Error("Pause rendered misleading control-state copy while cancellation settled");
   }
-  await page.getByTestId("stopping-previous-attempt").waitFor({ state: "hidden", timeout: 5_000 });
+  await stoppingState.waitFor({ state: "hidden", timeout: 5_000 });
   await page.getByText("Paused here", { exact: true }).waitFor({ timeout: 5_000 });
 
   audit.fences.set(predecessorAttemptId, {


### PR DESCRIPTION
## What\n- surface physical cancellation immediately from atomic Steer and Pause receipts, then reconcile against durable queue/control truth\n- preserve replay safety so old idempotency receipts cannot resurrect a completed stopping state\n- distinguish current-work Pause from previous-work Steer in SessionChrome\n- make live acceptance observe the production SessionChrome signal instead of a retired queue selector\n- advance the coordinated product train to 0.23.2\n\n## Correctness\n- the database transaction remains the sole authority for whether a live attempt was interrupted\n- rolling clients tolerate older API responses; no cancellation state is guessed before acceptance\n- target switches, event settlement, quiescence, newer control revisions, and idempotent replay all retire local receipt state\n- durable queue truth remains the fallback and reconciliation authority\n\n## Verification\n- 7,785 pass, 50 skip, 0 fail across the full 772-file unit suite\n- 176 focused API/core/SDK/React/acceptance tests pass\n- 25 release-version, image-workflow, and Helm-upgrade contract tests pass\n- typecheck, lint, format, public-hygiene, and diff guards pass\n- runtime RSS benchmark reconfirmed normal bundled mode is preferable to Bun smol for API and workers