### PR TITLE
fix(sandbox): allow Modal readiness tail

### DIFF
--- a/.changeset/modal-exec-readiness-tail.md
+++ b/.changeset/modal-exec-readiness-tail.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Allow Modal cold filesystem-snapshot restores up to 60 seconds to become command-ready before failing lease warm-up.

--- a/apps/worker/src/sandbox-resume.ts
+++ b/apps/worker/src/sandbox-resume.ts
@@ -55,6 +55,7 @@ import {
 import {
   captureVerifiedWorkspaceArchive,
   describeLegacyNativeSnapshotArchive,
+  MODAL_EXEC_READINESS_TIMEOUT_MS,
   WorkspaceArchiveIntegrityError,
   establishSandboxSessionFromEnvelope,
   isProviderSandboxNotFoundError,
@@ -218,7 +219,6 @@ export class SandboxLeaseInstanceLostError extends SandboxLeaseSupersededError {
 // Bounded poll while a sibling spawner is mid cold-restore. The wait budget is
 // user-facing and separate from the lease TTL heartbeat/reaper horizon.
 const WARMING_POLL_INTERVAL_MS = 250;
-const MODAL_EXEC_READINESS_TIMEOUT_MS = 15_000;
 
 async function sleep(ms: number): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, ms));

--- a/apps/worker/test/sandbox-resume-readiness.test.ts
+++ b/apps/worker/test/sandbox-resume-readiness.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { type EstablishedSandboxSession, SandboxExecReadinessError } from "@opengeni/runtime";
+import {
+  type EstablishedSandboxSession,
+  MODAL_EXEC_READINESS_TIMEOUT_MS,
+  SandboxExecReadinessError,
+} from "@opengeni/runtime";
 import {
   SandboxWarmingTimeoutError,
   isRetryableDegradedRestore,
@@ -22,6 +26,10 @@ function established(
 }
 
 describe("sandbox exec readiness", () => {
+  test("allows Modal cold restores up to the shared 60 second readiness budget", () => {
+    expect(MODAL_EXEC_READINESS_TIMEOUT_MS).toBe(60_000);
+  });
+
   test("probes Modal before the lease is published warm", async () => {
     const commands: string[] = [];
     await waitForSandboxExecReadiness(

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -1045,6 +1045,11 @@ export class SandboxExecReadinessError extends Error {
   }
 }
 
+/** Modal may return a sandbox handle before its command router accepts exec.
+ * Allow cold filesystem-snapshot restores to absorb provider tail latency
+ * without publishing the lease warm before command execution is possible. */
+export const MODAL_EXEC_READINESS_TIMEOUT_MS = 60_000;
+
 function sandboxExecProbeExitCode(result: unknown): number | null {
   if (typeof result === "string") {
     const match = result.match(/Process exited with code (-?\d+)/);
@@ -1075,7 +1080,7 @@ function sandboxExecProbeStillRunning(result: unknown): boolean {
  * bounded probe before atomically publishing the lease warm/ready. */
 export async function verifySandboxExecReadiness(
   established: EstablishedSandboxSession,
-  timeoutMs = 15_000,
+  timeoutMs = MODAL_EXEC_READINESS_TIMEOUT_MS,
 ): Promise<void> {
   if (established.backendId !== "modal") return;
   const session = established.session as {


### PR DESCRIPTION
## Summary
- raise Modal command-readiness deadline from 15s to 60s
- centralize the deadline in runtime so every restore/attach path agrees
- keep readiness probing before publishing a lease warm

## Evidence
- exact production snapshot: create RPC 794ms; first exec accepted 16.275s later
- focused tests: 23 passed
- runtime and worker typechecks passed
- focused formatting and lint passed

The API package typecheck remains blocked by pre-existing missing generated artifact-tool runtime modules in this local checkout.