### PR TITLE
fix(documents): preserve LiteParse native runtime

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -41,6 +41,7 @@
     "@aws-sdk/client-s3": "^3.1044.0",
     "@aws-sdk/s3-request-presigner": "^3.1044.0",
     "@hono/zod-validator": "^0.7.6",
+    "@llamaindex/liteparse": "^1.5.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opengeni/agent-proto": "workspace:*",
     "@opengeni/artifact-tool": "workspace:*",
@@ -61,6 +62,7 @@
     "hono": "^4.12.18",
     "pg": "^8.21.0",
     "resend": "^6.12.4",
+    "sharp": "^0.34.5",
     "stripe": "^22.2.0",
     "zod": "^4.2.1"
   },

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -53,6 +53,7 @@
     "prepublishOnly": "bash ../../scripts/prepublish-guard"
   },
   "dependencies": {
+    "@llamaindex/liteparse": "^1.5.3",
     "@opengeni/agent-proto": "workspace:*",
     "@opengeni/codex": "workspace:*",
     "@opengeni/config": "workspace:*",
@@ -69,7 +70,8 @@
     "@temporalio/activity": "^1.17.0",
     "@temporalio/client": "^1.17.0",
     "@temporalio/worker": "^1.17.0",
-    "@temporalio/workflow": "^1.17.0"
+    "@temporalio/workflow": "^1.17.0",
+    "sharp": "^0.34.5"
   },
   "devDependencies": {
     "@openai/agents-core": "0.14.3",

--- a/scripts/build-runtime-processes.ts
+++ b/scripts/build-runtime-processes.ts
@@ -46,6 +46,12 @@ const sharedBuild = {
   sourcemap: "none" as const,
 };
 
+// LiteParse and its native Sharp dependency must resolve from the workload
+// package's node_modules at runtime. Bundling either package detaches Sharp's
+// dynamic @img/* binding lookups and LiteParse's packaged PDF.js assets from
+// their installed dependency graph.
+const nativeRuntimeExternals = ["@llamaindex/liteparse", "sharp"];
+
 async function buildApi(): Promise<void> {
   const outdir = join(repositoryRoot, "apps/api/dist/process");
   await rm(outdir, { recursive: true, force: true });
@@ -53,7 +59,7 @@ async function buildApi(): Promise<void> {
     ...sharedBuild,
     entrypoints: [join(repositoryRoot, "apps/api/src/index.ts")],
     outdir,
-    external: ["better-auth", "better-auth/*", "@better-auth/*"],
+    external: [...nativeRuntimeExternals, "better-auth", "better-auth/*", "@better-auth/*"],
   });
   await copyDirectory(join(repositoryRoot, "agent/install"), join(outdir, "assets/agent-install"));
   await copyDirectory(
@@ -69,7 +75,7 @@ async function buildWorker(): Promise<void> {
     ...sharedBuild,
     entrypoints: [join(repositoryRoot, "apps/worker/src/index.ts")],
     outdir,
-    external: ["@temporalio/*"],
+    external: [...nativeRuntimeExternals, "@temporalio/*"],
   });
 
   // Generate with the worker package's own Temporal dependency, then colocate

--- a/scripts/runtime-process-native-closure.test.ts
+++ b/scripts/runtime-process-native-closure.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const root = resolve(import.meta.dir, "..");
+
+test("bundled document parsing retains the Linux sharp native closure", async () => {
+  const temporaryRoot = await mkdtemp(join(root, "apps/worker/.native-closure-"));
+  const entrypoint = join(temporaryRoot, "entry.ts");
+  const outdir = join(temporaryRoot, "dist");
+
+  try {
+    await mkdir(outdir, { recursive: true });
+    await writeFile(
+      entrypoint,
+      `import { LiteParse } from "@llamaindex/liteparse";
+
+new LiteParse({ ocrEnabled: true, numWorkers: 1 });
+process.stdout.write("sharp-native-runtime-ready");
+`,
+    );
+
+    const result = await Bun.build({
+      entrypoints: [entrypoint],
+      outdir,
+      target: "bun",
+      format: "esm",
+      splitting: true,
+      minify: { syntax: true, whitespace: true, identifiers: false },
+      external: ["@llamaindex/liteparse", "sharp"],
+    });
+    expect(result.success, result.logs.map(String).join("\n")).toBe(true);
+
+    const process = Bun.spawn({
+      cmd: ["bun", join(outdir, "entry.js")],
+      cwd: root,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stdout).text(),
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("sharp-native-runtime-ready");
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- preserve `@llamaindex/liteparse` and `sharp` as runtime dependencies of both API and worker workloads
- externalize LiteParse and Sharp from Bun process bundles so Sharp can resolve its Linux `@img/*` native closure and LiteParse can resolve packaged PDF.js assets
- add a regression test that executes the externalized native runtime closure

## Root cause
The deployed Documents parser bundle inlined LiteParse/Sharp JavaScript while leaving Sharp's platform-specific native package outside the generated bundle. Importing the generated production worker chunk reproduced:

`Could not load the "sharp" module using the linux-x64 runtime`

Externalizing Sharp alone exposed the same packaging class for LiteParse's packaged PDF.js assets, so both packages must remain installed workload dependencies and runtime externals.

## Validation
- `bun install --frozen-lockfile`
- targeted native-closure, release-image, and Documents tests: 36 passed
- `bun run typecheck`: all 25 projects clean
- lint and formatting checks passed
- exact API and worker process bundles built successfully; generated Documents code retains `import("@llamaindex/liteparse")` and contains no inlined Sharp native-loader error

## Scope
This restores the current Documents/LiteParse runtime packaging under OPE-19. It does not claim the broader durable image extraction/OCR contract in OPE-187, and it does not claim deployment or live PNG acceptance.
