### PR TITLE
feat(artifacts): add session dock and durable discovery

### DIFF
--- a/apps/api/src/routes/editable-artifacts.ts
+++ b/apps/api/src/routes/editable-artifacts.ts
@@ -26,7 +26,7 @@ import {
   type EditableArtifactModality,
   type ImportEditableArtifactApplicationInput,
 } from "@opengeni/core";
-import { getFile } from "@opengeni/db";
+import { getFile, listEditableArtifactIdsCreatedBySubject } from "@opengeni/db";
 import type { Context, Hono } from "hono";
 import { z } from "zod";
 
@@ -68,7 +68,14 @@ const VersionName = z
       isWellFormedPersistedText(value),
   );
 const AttemptId = z.string().uuid();
+const SessionId = z.string().uuid();
 const AttemptGeneration = z.number().int().positive().max(2_147_483_647);
+const ListEditableArtifactsQuery = z
+  .object({
+    sourceSessionId: SessionId,
+    replicaId: ReplicaId,
+  })
+  .strict();
 
 const MintEditableArtifactLiveTicketRequest = z
   .object({
@@ -216,6 +223,10 @@ const EditableArtifactResult = z
   })
   .strict();
 
+const EditableArtifactListResult = z
+  .object({ artifacts: z.array(EditableArtifactResult).max(64) })
+  .strict();
+
 const PinnedVersionResult = z
   .object({
     id: ArtifactId,
@@ -340,6 +351,12 @@ export type EditableArtifactRouteDependencies = AccessDeps &
       workspaceId: string,
       fileId: string,
     ) => Promise<FileAsset | null>;
+    /** Test/embedding seam; returned ids are still authorized one by one. */
+    editableArtifactSessionArtifactIds?: (
+      scope: EditableArtifactRouteScope,
+      sourceSessionId: string,
+      limit: number,
+    ) => Promise<readonly string[]>;
   }>;
 
 export type EditableArtifactApplicationErrorCode =
@@ -364,6 +381,50 @@ export function registerEditableArtifactRoutes(
 ): void {
   const collection = "/v1/workspaces/:workspaceId/editable-artifacts";
   const item = `${collection}/:artifactId`;
+
+  app.get(collection, async (context) => {
+    const workspaceId = context.req.param("workspaceId");
+    const grant = await requireAccessGrant(context, deps, workspaceId, "artifacts:read");
+    const query = ListEditableArtifactsQuery.safeParse({
+      sourceSessionId: context.req.query("sourceSessionId"),
+      replicaId: context.req.query("replicaId"),
+    });
+    if (!query.success) {
+      throw new ApiHttpError(422, {
+        code: "validation_failed",
+        message: "Invalid editable artifact list query.",
+      });
+    }
+    const scope = editableArtifactScope({ accountId: grant.accountId, workspaceId });
+    const actor = editableArtifactActorForGrant(grant, query.data.replicaId);
+    const candidateIds = await (deps.editableArtifactSessionArtifactIds
+      ? deps.editableArtifactSessionArtifactIds(scope, query.data.sourceSessionId, 64)
+      : listEditableArtifactIdsCreatedBySubject(
+          deps.db,
+          scope,
+          `agent:${query.data.sourceSessionId}`,
+          64,
+        ));
+    const artifactIds = normalizeArtifactIdList(candidateIds);
+    const application = requireEditableArtifactApplication(deps);
+    const artifacts: z.infer<typeof EditableArtifactResult>[] = [];
+    for (const artifactId of artifactIds) {
+      try {
+        const artifact = await application.readArtifact({
+          scope,
+          actor,
+          artifactId: editableArtifactId(artifactId),
+        });
+        artifacts.push(projectArtifact(artifact, scope));
+      } catch (error) {
+        if (isInvisibleListCandidate(error)) continue;
+        throw editableArtifactHttpError(error);
+      }
+    }
+    const result = EditableArtifactListResult.parse({ artifacts });
+    context.header("cache-control", "private, no-store");
+    return context.json(result, 200);
+  });
 
   app.post(collection, async (context) => {
     const workspaceId = context.req.param("workspaceId");
@@ -857,6 +918,32 @@ function parseArtifactId(value: string): string {
     });
   }
   return parsed.data;
+}
+
+function normalizeArtifactIdList(value: readonly string[]): readonly string[] {
+  if (!Array.isArray(value) || value.length > 64) {
+    throw new Error("Editable artifact list adapter returned too many candidates");
+  }
+  const ids = value.map((candidate) => {
+    const parsed = ArtifactId.safeParse(candidate);
+    if (!parsed.success) {
+      throw new Error("Editable artifact list adapter returned an invalid candidate");
+    }
+    return parsed.data;
+  });
+  if (new Set(ids).size !== ids.length) {
+    throw new Error("Editable artifact list adapter returned duplicate candidates");
+  }
+  return ids;
+}
+
+function isInvisibleListCandidate(error: unknown): boolean {
+  return (
+    (error instanceof EditableArtifactDomainError &&
+      (error.code === "forbidden" || error.code === "not_found")) ||
+    (error instanceof EditableArtifactApplicationError &&
+      (error.code === "forbidden" || error.code === "not_found"))
+  );
 }
 
 function parseReplicaId(value: string): string {

--- a/apps/api/test/editable-artifacts-routes.test.ts
+++ b/apps/api/test/editable-artifacts-routes.test.ts
@@ -35,6 +35,7 @@ type RecordedApplication = {
   createCalls: Array<Parameters<EditableArtifactApplicationPort["createArtifact"]>[0]>;
   importCalls: Array<Parameters<EditableArtifactApplicationPort["importArtifact"]>[0]>;
   readCalls: Array<Parameters<EditableArtifactApplicationPort["readArtifact"]>[0]>;
+  listCalls: Array<readonly [{ accountId: string; workspaceId: string }, string, number]>;
   sourceCalls: Array<readonly [string, string]>;
   sourceValue: { value: FileAsset | null };
   sourceError: { value: Error | null };
@@ -53,6 +54,7 @@ function routeFixture(
   const createCalls: RecordedApplication["createCalls"] = [];
   const importCalls: RecordedApplication["importCalls"] = [];
   const readCalls: RecordedApplication["readCalls"] = [];
+  const listCalls: RecordedApplication["listCalls"] = [];
   const sourceCalls: RecordedApplication["sourceCalls"] = [];
   const sourceValue = { value: readyOfficeFile() as FileAsset | null };
   const sourceError = { value: null as Error | null };
@@ -102,6 +104,10 @@ function routeFixture(
       if (sourceError.value) throw sourceError.value;
       return sourceValue.value;
     },
+    editableArtifactSessionArtifactIds: async (scope, sourceSessionId, limit) => {
+      listCalls.push([scope, sourceSessionId, limit]);
+      return [ARTIFACT_ID];
+    },
     ...(options.uncomposed ? {} : { editableArtifacts: application }),
   });
   return {
@@ -110,6 +116,7 @@ function routeFixture(
     createCalls,
     importCalls,
     readCalls,
+    listCalls,
     sourceCalls,
     sourceValue,
     sourceError,
@@ -338,6 +345,63 @@ describe("editable artifact create/open routes", () => {
       actor: { kind: "human", replicaId: REPLICA_ID },
     });
   });
+
+  test("discovers session artifacts then authorizes each exact resource", async () => {
+    const fixture = routeFixture();
+    const response = await fixture.app.request(
+      `http://api.test/v1/workspaces/${WORKSPACE_ID}/editable-artifacts?sourceSessionId=${SESSION_ID}&replicaId=${REPLICA_ID}`,
+      { headers: { authorization: await bearer() } },
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(await response.json()).toEqual({
+      artifacts: [
+        {
+          id: ARTIFACT_ID,
+          modality: "spreadsheet",
+          title: "Forecast",
+          lifecycle: "active",
+          headSequence: 0,
+          stateHash: `sha256:${"0".repeat(64)}`,
+          createdAt: "2026-08-08T12:00:00.000Z",
+          updatedAt: "2026-08-08T12:00:00.000Z",
+        },
+      ],
+    });
+    expect(fixture.listCalls).toEqual([
+      [{ accountId: ACCOUNT_ID, workspaceId: WORKSPACE_ID }, SESSION_ID, 64],
+    ]);
+    expect(fixture.readCalls[0]).toMatchObject({
+      artifactId: ARTIFACT_ID,
+      actor: { kind: "human", replicaId: REPLICA_ID },
+    });
+  });
+
+  test("rejects incomplete session discovery queries before touching storage", async () => {
+    const fixture = routeFixture();
+    const response = await fixture.app.request(
+      `http://api.test/v1/workspaces/${WORKSPACE_ID}/editable-artifacts?sourceSessionId=${SESSION_ID}`,
+      { headers: { authorization: await bearer() } },
+    );
+    expect(response.status).toBe(422);
+    expect(fixture.listCalls).toEqual([]);
+    expect(fixture.readCalls).toEqual([]);
+  });
+
+  test.each(["forbidden", "not_found"] as const)(
+    "does not expose %s discovery candidates",
+    async (code) => {
+      const fixture = routeFixture();
+      fixture.failWith.value = new EditableArtifactApplicationError(code);
+      const response = await fixture.app.request(
+        `http://api.test/v1/workspaces/${WORKSPACE_ID}/editable-artifacts?sourceSessionId=${SESSION_ID}&replicaId=${REPLICA_ID}`,
+        { headers: { authorization: await bearer() } },
+      );
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ artifacts: [] });
+      expect(fixture.readCalls).toHaveLength(1);
+    },
+  );
 
   test.each([
     [" padded", 422],

--- a/apps/web/src/components/session/editable-artifacts-workspace.tsx
+++ b/apps/web/src/components/session/editable-artifacts-workspace.tsx
@@ -1,0 +1,98 @@
+import { Link } from "@tanstack/react-router";
+import {
+  ExternalLinkIcon,
+  FilePenLineIcon,
+  GalleryHorizontalEndIcon,
+  Table2Icon,
+} from "lucide-react";
+import { useEffect, useState, type ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+import { EditableArtifactRoute } from "@/routes/editable-artifact";
+
+export type SessionEditableArtifactSummary = Readonly<{
+  id: string;
+  modality: "document" | "spreadsheet" | "presentation";
+  title: string;
+}>;
+
+export function SessionEditableArtifactsWorkspace({
+  workspaceId,
+  artifacts,
+}: Readonly<{
+  workspaceId: string;
+  artifacts: readonly SessionEditableArtifactSummary[];
+}>) {
+  const [selectedArtifactId, setSelectedArtifactId] = useState(() => artifacts.at(-1)?.id ?? null);
+
+  useEffect(() => {
+    setSelectedArtifactId((current) => {
+      if (current && artifacts.some((artifact) => artifact.id === current)) {
+        return current;
+      }
+      return artifacts.at(-1)?.id ?? null;
+    });
+  }, [artifacts]);
+
+  const artifact =
+    artifacts.find((candidate) => candidate.id === selectedArtifactId) ?? artifacts.at(-1);
+  if (!artifact) return null;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-bg text-fg">
+      <div className="flex min-h-11 shrink-0 items-center gap-2 border-b border-border px-2">
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-accent text-accent-foreground">
+          {artifactIcon(artifact.modality)}
+        </span>
+        {artifacts.length > 1 ? (
+          <div className="min-w-0 flex-1 [&>span]:block [&>span]:w-full">
+            <Select
+              aria-label="Choose editable artifact"
+              className="h-8 min-w-0 border-0 bg-transparent pl-1 font-medium shadow-none"
+              value={artifact.id}
+              onChange={(event) => setSelectedArtifactId(event.target.value)}
+            >
+              {artifacts.map((candidate) => (
+                <option key={candidate.id} value={candidate.id}>
+                  {candidate.title}
+                </option>
+              ))}
+            </Select>
+          </div>
+        ) : (
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{artifact.title}</p>
+            <p className="truncate text-xs capitalize text-fg-subtle">
+              {artifact.modality} · shared editor
+            </p>
+          </div>
+        )}
+        <Button
+          asChild
+          variant="ghost"
+          size="icon-sm"
+          className="ml-auto shrink-0"
+          title="Open full-page editor"
+        >
+          <Link
+            to="/workspaces/$workspaceId/artifacts/editable/$artifactId"
+            params={{ workspaceId, artifactId: artifact.id }}
+            aria-label={`Open ${artifact.title} in the full-page editor`}
+          >
+            <ExternalLinkIcon className="size-4" />
+          </Link>
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1">
+        <EditableArtifactRoute workspaceId={workspaceId} artifactId={artifact.id} />
+      </div>
+    </div>
+  );
+}
+
+function artifactIcon(modality: "document" | "spreadsheet" | "presentation"): ReactNode {
+  if (modality === "document") return <FilePenLineIcon className="size-4" />;
+  if (modality === "spreadsheet") return <Table2Icon className="size-4" />;
+  return <GalleryHorizontalEndIcon className="size-4" />;
+}

--- a/apps/web/src/lib/editable-artifact-client.ts
+++ b/apps/web/src/lib/editable-artifact-client.ts
@@ -1,0 +1,10 @@
+import { OpenGeniClient } from "@opengeni/sdk/artifacts";
+
+import { apiBaseUrl, authHeadersForAccessKey, getStoredAccessKey } from "@/api";
+
+/** One authenticated, artifact-only SDK client shared by route and session dock. */
+export const editableArtifactClient = new OpenGeniClient({
+  baseUrl: apiBaseUrl,
+  headers: () => authHeadersForAccessKey(getStoredAccessKey()),
+  fetch: (input, init) => fetch(input, { ...init, credentials: init?.credentials ?? "include" }),
+});

--- a/apps/web/src/routes/editable-artifact.tsx
+++ b/apps/web/src/routes/editable-artifact.tsx
@@ -3,7 +3,7 @@ import { editableArtifactKernelRuntime as presentationRuntime } from "@opengeni/
 import { editableArtifactKernelRuntime as spreadsheetRuntime } from "@opengeni/artifact-kernel-wasm-spreadsheet";
 import { BrowserEditableArtifactWorkbench } from "@opengeni/react/artifacts";
 import type { AccessContext, Workspace } from "@opengeni/sdk";
-import { OpenGeniClient, type EditableArtifactResource } from "@opengeni/sdk/artifacts";
+import type { EditableArtifactResource } from "@opengeni/sdk/artifacts";
 import {
   type EditableArtifactBrowserRuntime,
   type EditableArtifactCacheAuthority,
@@ -23,6 +23,7 @@ import {
   createConsoleEditableArtifactAuthority,
   resolveConsoleEditableArtifactWorkerUrl,
 } from "@/lib/editable-artifact-browser";
+import { editableArtifactClient } from "@/lib/editable-artifact-client";
 
 type OpenArtifact = Readonly<{
   artifact: EditableArtifactResource;
@@ -36,11 +37,6 @@ type LoadState =
   | Readonly<{ kind: "error"; error: Error }>;
 
 const absoluteApiBaseUrl = new URL(apiBaseUrl || "/", window.location.origin);
-const artifactClient = new OpenGeniClient({
-  baseUrl: apiBaseUrl,
-  headers: () => authHeadersForAccessKey(getStoredAccessKey()),
-  fetch: (input, init) => fetch(input, { ...init, credentials: init?.credentials ?? "include" }),
-});
 
 /** First-party consumer of the exact public SDK/React editable-artifact API. */
 export function EditableArtifactRoute({
@@ -153,9 +149,11 @@ async function loadArtifact(
     accessKeyVersion: input.accessKeyVersion,
   });
   const replicaId = createConsoleEditableArtifactReplicaId();
-  const artifact = await artifactClient.getEditableArtifact(input.workspaceId, input.artifactId, {
-    replicaId,
-  });
+  const artifact = await editableArtifactClient.getEditableArtifact(
+    input.workspaceId,
+    input.artifactId,
+    { replicaId },
+  );
   return Object.freeze({ artifact, authority, replicaId });
 }
 

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -21,7 +21,14 @@ import {
   type UserMessageItem,
 } from "@opengeni/react/session";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { CheckIcon, Loader2Icon, MenuIcon, MessagesSquareIcon, XIcon } from "lucide-react";
+import {
+  CheckIcon,
+  Loader2Icon,
+  MenuIcon,
+  MessagesSquareIcon,
+  PanelsTopLeftIcon,
+  XIcon,
+} from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -45,7 +52,10 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Notice } from "@/components/ui/notice";
 import type { WorkspaceTab } from "@opengeni/react";
+import { projectEditableArtifactPublications } from "@opengeni/sdk/editable-artifact-publication";
+import type { EditableArtifactResource } from "@opengeni/sdk/artifacts";
 import { useAppContext } from "@/context";
+import type { SessionEditableArtifactSummary } from "@/components/session/editable-artifacts-workspace";
 import {
   normalizeProviderDomain,
   oauthConnectionOwnership,
@@ -83,6 +93,14 @@ const LazySessionInspector = lazy(() =>
   import("@/components/session/inspector").then(({ SessionInspector }) => ({
     default: SessionInspector,
   })),
+);
+
+const LazySessionEditableArtifactsWorkspace = lazy(() =>
+  import("@/components/session/editable-artifacts-workspace").then(
+    ({ SessionEditableArtifactsWorkspace }) => ({
+      default: SessionEditableArtifactsWorkspace,
+    }),
+  ),
 );
 
 const LazyCodexRealtimeControl = lazy(() =>
@@ -592,25 +610,57 @@ function SessionDock(props: {
   onOpenNavigation: () => void;
 }) {
   // The workbench (Changes | Files | Terminal | Desktop + machine chip) lives in
-  // the package now; the app injects Debug around it. Agents remain in the one
-  // compact composer-adjacent surface.
-  const trailingTabs: WorkspaceTab[] = props.session
-    ? [
-        {
-          id: "debug",
-          label: "Debug",
-          content: (
-            <Suspense fallback={<LoadingPanel label="Opening debug inspector" />}>
-              <LazySessionInspector
-                session={props.session}
-                events={props.events}
-                connectionState={props.connectionState}
-              />
-            </Suspense>
-          ),
-        },
-      ]
-    : [];
+  // the package now; the app injects durable artifacts and Debug around it.
+  // Heavy editor/runtime code stays lazy until the user opens the tab.
+  const editableArtifacts = useMemo(
+    () => projectEditableArtifactPublications(props.events, props.workspaceId, props.sessionId),
+    [props.events, props.sessionId, props.workspaceId],
+  );
+  const artifactSummaries = useSessionEditableArtifactSummaries({
+    workspaceId: props.workspaceId,
+    sessionId: props.sessionId,
+    eventPublications: editableArtifacts,
+  });
+  const trailingTabs: WorkspaceTab[] = [];
+  if (artifactSummaries.length > 0) {
+    trailingTabs.push({
+      id: "artifacts",
+      label: (
+        <span className="inline-flex items-center gap-1.5">
+          <PanelsTopLeftIcon className="size-3.5" aria-hidden />
+          <span>Artifacts</span>
+        </span>
+      ),
+      badge: (
+        <span className="rounded-og-xs bg-og-accent-soft px-1 text-og-xs text-og-fg-muted">
+          {artifactSummaries.length}
+        </span>
+      ),
+      content: (
+        <Suspense fallback={<LoadingPanel label="Opening artifact" />}>
+          <LazySessionEditableArtifactsWorkspace
+            workspaceId={props.workspaceId}
+            artifacts={artifactSummaries}
+          />
+        </Suspense>
+      ),
+    });
+  }
+  if (props.session) {
+    trailingTabs.push({
+      id: "debug",
+      label: "Debug",
+      content: (
+        <Suspense fallback={<LoadingPanel label="Opening debug inspector" />}>
+          <LazySessionInspector
+            session={props.session}
+            events={props.events}
+            connectionState={props.connectionState}
+          />
+        </Suspense>
+      ),
+    });
+  }
 
   return (
     <SessionWorkspace
@@ -635,6 +685,73 @@ function SessionDock(props: {
       }
     />
   );
+}
+
+function useSessionEditableArtifactSummaries(input: {
+  workspaceId: string;
+  sessionId: string;
+  eventPublications: ReturnType<typeof projectEditableArtifactPublications>;
+}): readonly SessionEditableArtifactSummary[] {
+  const context = useAppContext();
+  const fallback = useMemo<readonly SessionEditableArtifactSummary[]>(
+    () =>
+      input.eventPublications.map(({ receipt }) => ({
+        id: receipt.artifact.id,
+        modality: receipt.artifact.modality,
+        title: receipt.artifact.title,
+      })),
+    [input.eventPublications],
+  );
+  const publicationSequence = input.eventPublications.at(-1)?.sequence ?? 0;
+  const authorityKey = `${input.workspaceId}:${input.sessionId}:${context.accessKeyVersion}`;
+  const refreshKey = `${authorityKey}:${publicationSequence}`;
+  const [loaded, setLoaded] = useState<{
+    key: string;
+    artifacts: readonly EditableArtifactResource[];
+  } | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let current = true;
+    void Promise.all([
+      import("@/lib/editable-artifact-client"),
+      import("@/lib/editable-artifact-browser"),
+    ])
+      .then(async ([{ editableArtifactClient }, { createConsoleEditableArtifactReplicaId }]) => {
+        const result = await editableArtifactClient.listSessionEditableArtifacts(
+          input.workspaceId,
+          input.sessionId,
+          {
+            replicaId: createConsoleEditableArtifactReplicaId(),
+            signal: controller.signal,
+          },
+        );
+        if (current) setLoaded({ key: authorityKey, artifacts: result.artifacts });
+      })
+      .catch(() => {
+        // A validated publication receipt remains a useful degraded fallback.
+        // Discovery will retry after auth changes or the next publication.
+      });
+    return () => {
+      current = false;
+      controller.abort();
+    };
+  }, [authorityKey, input.sessionId, input.workspaceId, refreshKey]);
+
+  const durable = loaded?.key === authorityKey ? loaded.artifacts : [];
+  return mergeArtifactSummaries(durable, fallback);
+}
+
+function mergeArtifactSummaries(
+  durable: readonly SessionEditableArtifactSummary[],
+  fallback: readonly SessionEditableArtifactSummary[],
+): readonly SessionEditableArtifactSummary[] {
+  const merged = new Map<string, SessionEditableArtifactSummary>();
+  for (const artifact of durable) merged.set(artifact.id, artifact);
+  for (const artifact of fallback) {
+    if (!merged.has(artifact.id)) merged.set(artifact.id, artifact);
+  }
+  return [...merged.values()];
 }
 
 function SessionChatPane(props: {

--- a/docs/artifact-engine.md
+++ b/docs/artifact-engine.md
@@ -322,11 +322,33 @@ advisory-lock winner becomes durable and retries return that winner.
    called once after final export, re-import, and visual verification; its
    closed receipt opens the durable collaborative editor in the stock timeline.
 
+### Current product bridge
+
+- `publish_editable_artifact` turns one verified Office output into a durable
+  editable artifact and returns a closed receipt. The session dock discovers
+  all active artifacts created by that exact session through an authorized
+  server query; recent receipt events are only a degraded fallback.
+- The dock and full-page route open the same public SDK/React editor. Browser
+  edits commit to the canonical artifact head and are visible to every other
+  browser replica. The imported Office file remains immutable source evidence,
+  not a second mutable authority.
+- The agent bridge is currently one-way: an agent can author and publish an
+  artifact, but a later agent turn has no bound tool for opening, inspecting,
+  or editing the artifact's current durable head. Re-reading the sandbox Office
+  file therefore does **not** reveal later browser edits. Completing the product
+  contract requires an agent-facing artifact session/tool that reads the exact
+  current head and submits normal canonical transactions; it must not restore
+  the Office file as mutable truth.
+
+Until that final bridge exists, supported collaboration is browser-to-browser
+and agent-publish-to-browser, not browser-edit-to-agent.
+
 ### Edit
 
-1. Browser/agent validates commands locally and submits a stable replica id,
+1. An SDK client validates commands locally and submits a stable replica id,
    transaction id, request hash, causal base, and typed commands—not trusted
-   canonical operation bytes.
+   canonical operation bytes. The browser client is implemented; the bound
+   agent client described above remains required.
 2. Server derives principal or exact live session/turn/attempt/generation
    authority and reads a consistent detached basis: head sequence, causal
    frontier, state hash, snapshot/tail references, and authorization revision.

--- a/packages/db/src/editable-artifacts.ts
+++ b/packages/db/src/editable-artifacts.ts
@@ -585,6 +585,41 @@ export class EditableArtifactPersistenceError extends Error {
   }
 }
 
+/**
+ * Discover durable artifacts created by one exact principal. This is only a
+ * tenant-scoped candidate query: callers must still authorize every returned
+ * artifact through the application boundary before exposing metadata.
+ */
+export async function listEditableArtifactIdsCreatedBySubject(
+  db: Database,
+  scopeInput: PersistedEditableArtifactScope,
+  subjectIdInput: string,
+  limitInput = 64,
+): Promise<readonly string[]> {
+  const scope = validateScope(scopeInput);
+  const subjectId = validateIdentity(subjectIdInput, "creator subject id");
+  const limit = validateInteger(limitInput, "editable artifact list limit", 1, 64);
+  return await withRlsContext(
+    db,
+    scope,
+    async (tx) => {
+      const rows = await rawRows<{ id: string }>(
+        tx,
+        sql`select id
+          from editable_artifacts
+          where account_id = ${scope.accountId}::uuid
+            and workspace_id = ${scope.workspaceId}::uuid
+            and created_by_subject_id = ${subjectId}
+            and lifecycle_state = 'active'
+          order by created_at asc, id asc
+          limit ${limit}`,
+      );
+      return Object.freeze(rows.map((row) => validateStableId(row.id, "artifact id")));
+    },
+    { isolationLevel: "repeatable read", accessMode: "read only" },
+  );
+}
+
 export const EDITABLE_ARTIFACT_INTENT_MAX_BYTES = 5 * 1024 * 1024;
 export const EDITABLE_ARTIFACT_KERNEL_TAIL_MAX_TRANSACTIONS = 100_000;
 export const EDITABLE_ARTIFACT_KERNEL_TAIL_MAX_BYTES = 64 * 1024 * 1024;

--- a/packages/db/test/editable-artifacts-postgres.test.ts
+++ b/packages/db/test/editable-artifacts-postgres.test.ts
@@ -23,6 +23,7 @@ import {
   PostgresEditableArtifactLiveReadStore,
   PostgresEditableArtifactLiveTicketStore,
   PostgresEditableArtifactStore,
+  listEditableArtifactIdsCreatedBySubject,
   type PersistedEditableArtifact,
   type PersistedEditableArtifactCausalFrontier,
   type PersistedEditableArtifactKernelState,
@@ -103,6 +104,47 @@ afterAll(async () => {
 }, 180_000);
 
 describe("Postgres editable artifact authority", () => {
+  test("discovers active artifacts by exact creator without crossing tenant scope", async () => {
+    if (!available || !client || !shared) return;
+    const scope = { accountId, workspaceId };
+    const sourceSessionId = crypto.randomUUID();
+    const matchingId = nextId();
+    const otherId = nextId();
+    for (const [artifactId, marker, createdBySubjectId] of [
+      [matchingId, "1", `agent:${sourceSessionId}`],
+      [otherId, "2", `agent:${crypto.randomUUID()}`],
+    ] as const) {
+      const created = await store.createArtifact({
+        ...creationFixture({
+          scope,
+          artifactId,
+          receiptId: nextId(),
+          authorityKey: JSON.stringify(["human", "user:alice"]),
+          idempotencyKey: `creator-list:${artifactId}`,
+          requestHash: hash(marker),
+          modality: "spreadsheet",
+          title: `Creator list ${marker}`,
+          stateHash: hash(marker === "1" ? "3" : "4"),
+          authorizationRevision: 1,
+          createdBySubjectId,
+        }),
+        authorizationActor: humanAuthorizationActor("user:alice"),
+      });
+      expect(created.kind).toBe("result");
+    }
+
+    expect(
+      await listEditableArtifactIdsCreatedBySubject(client.db, scope, `agent:${sourceSessionId}`),
+    ).toEqual([matchingId]);
+    expect(
+      await listEditableArtifactIdsCreatedBySubject(
+        client.db,
+        { accountId: otherAccountId, workspaceId: otherWorkspaceId },
+        `agent:${sourceSessionId}`,
+      ),
+    ).toEqual([]);
+  });
+
   test("prepares one exact replay-safe Office source upload", async () => {
     if (!available || !client) return;
     const fileId = crypto.randomUUID();

--- a/packages/sdk/src/artifact-client.ts
+++ b/packages/sdk/src/artifact-client.ts
@@ -2,10 +2,12 @@ import { OpenGeniClient as OpenGeniCoreClient } from "./client";
 import type {
   CreateEditableArtifactMaterializationRequest,
   CreateEditableArtifactResourceRequest,
+  EditableArtifactListResource,
   EditableArtifactMaterializationJobResource,
   EditableArtifactPinnedVersionResource,
   EditableArtifactResource,
   ImportEditableArtifactResourceRequest,
+  ListSessionEditableArtifactResourcesOptions,
   PinEditableArtifactVersionRequest,
   ReadEditableArtifactMaterializationOptions,
   ReadEditableArtifactResourceOptions,
@@ -61,6 +63,20 @@ export class OpenGeniClient extends OpenGeniCoreClient {
       `/v1/workspaces/${encodeURIComponent(workspaceId)}/editable-artifacts/${encodeURIComponent(artifactId)}`,
       undefined,
       { replicaId: options.replicaId },
+      options,
+    );
+  }
+
+  async listSessionEditableArtifacts(
+    workspaceId: string,
+    sourceSessionId: string,
+    options: ListSessionEditableArtifactResourcesOptions,
+  ): Promise<EditableArtifactListResource> {
+    return await this.requestJson<EditableArtifactListResource>(
+      "GET",
+      `/v1/workspaces/${encodeURIComponent(workspaceId)}/editable-artifacts`,
+      undefined,
+      { sourceSessionId, replicaId: options.replicaId },
       options,
     );
   }

--- a/packages/sdk/src/artifacts.ts
+++ b/packages/sdk/src/artifacts.ts
@@ -3,11 +3,13 @@ export { OpenGeniClient } from "./artifact-client";
 export type {
   CreateEditableArtifactMaterializationRequest,
   CreateEditableArtifactResourceRequest,
+  EditableArtifactListResource,
   EditableArtifactMaterializationFormat,
   EditableArtifactMaterializationJobResource,
   EditableArtifactMaterializationResultResource,
   EditableArtifactPinnedVersionResource,
   EditableArtifactResource,
+  ListSessionEditableArtifactResourcesOptions,
   PinEditableArtifactVersionRequest,
   ReadEditableArtifactMaterializationOptions,
   ReadEditableArtifactResourceOptions,

--- a/packages/sdk/src/editable-artifact-publication.ts
+++ b/packages/sdk/src/editable-artifact-publication.ts
@@ -3,7 +3,16 @@ import {
   type PublishEditableArtifactReceipt,
 } from "@opengeni/contracts/editable-artifact-publication-receipt";
 
+import type { SessionEvent } from "./types";
+
 export type { PublishEditableArtifactReceipt };
+
+export type EditableArtifactPublication = Readonly<{
+  receipt: PublishEditableArtifactReceipt;
+  eventId: string;
+  sequence: number;
+  occurredAt: string;
+}>;
 
 /** Parse the closed durable receipt emitted by `publish_editable_artifact`. */
 export function parseEditableArtifactPublicationReceipt(
@@ -19,4 +28,53 @@ export function parseEditableArtifactPublicationReceipt(
   }
   const parsed = PublishEditableArtifactReceiptSchema.safeParse(candidate);
   return parsed.success ? parsed.data : null;
+}
+
+/**
+ * Project the durable editable artifacts published in a session event window.
+ *
+ * The receipt is a closed, self-identifying contract, so its output can be
+ * projected without retaining the corresponding tool-call input. Duplicate or
+ * replayed outputs collapse by artifact id while the newest sequence wins.
+ */
+export function projectEditableArtifactPublications(
+  events: readonly SessionEvent[],
+  workspaceId?: string,
+  sessionId?: string,
+): EditableArtifactPublication[] {
+  const publications = new Map<string, EditableArtifactPublication>();
+  for (const event of events) {
+    if (event.type !== "agent.toolCall.output") continue;
+    if (workspaceId !== undefined && event.workspaceId !== workspaceId) continue;
+    if (sessionId !== undefined && event.sessionId !== sessionId) continue;
+
+    const payload = record(event.payload);
+    if (!payload || payload.error === true || payload.isError === true) continue;
+    const receipt =
+      parseEditableArtifactPublicationReceipt(payload.output) ??
+      parseEditableArtifactPublicationReceipt(payload.preview);
+    if (!receipt) continue;
+
+    const expectedEditorPath = `/workspaces/${event.workspaceId}/artifacts/editable/${receipt.artifact.id}`;
+    if (receipt.editorPath !== expectedEditorPath) continue;
+
+    const current = publications.get(receipt.artifact.id);
+    if (current && current.sequence > event.sequence) continue;
+    publications.set(
+      receipt.artifact.id,
+      Object.freeze({
+        receipt,
+        eventId: event.id,
+        sequence: event.sequence,
+        occurredAt: event.occurredAt,
+      }),
+    );
+  }
+  return [...publications.values()].sort((left, right) => left.sequence - right.sequence);
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }

--- a/packages/sdk/src/editable-artifact-resources.ts
+++ b/packages/sdk/src/editable-artifact-resources.ts
@@ -13,6 +13,10 @@ export type EditableArtifactResource = Readonly<{
   updatedAt: string;
 }>;
 
+export type EditableArtifactListResource = Readonly<{
+  artifacts: readonly EditableArtifactResource[];
+}>;
+
 export type CreateEditableArtifactResourceRequest = Readonly<{
   /** Stable across transport retries; conflicting reuse is rejected. */
   idempotencyKey: string;
@@ -59,6 +63,11 @@ export type ImportEditableArtifactResourceRequest = Readonly<{
 export type ReadEditableArtifactResourceOptions = OpenGeniRequestOptions &
   Readonly<{
     /** Writer/read replica used to mint artifact-scoped authority. */
+    replicaId: string;
+  }>;
+
+export type ListSessionEditableArtifactResourcesOptions = OpenGeniRequestOptions &
+  Readonly<{
     replicaId: string;
   }>;
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,11 +11,13 @@ export type {
 export type {
   CreateEditableArtifactMaterializationRequest,
   CreateEditableArtifactResourceRequest,
+  EditableArtifactListResource,
   EditableArtifactMaterializationFormat,
   EditableArtifactMaterializationJobResource,
   EditableArtifactMaterializationResultResource,
   EditableArtifactPinnedVersionResource,
   EditableArtifactResource,
+  ListSessionEditableArtifactResourcesOptions,
   PinEditableArtifactVersionRequest,
   ReadEditableArtifactMaterializationOptions,
   ReadEditableArtifactResourceOptions,

--- a/packages/sdk/test/editable-artifact-publication.test.ts
+++ b/packages/sdk/test/editable-artifact-publication.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { parseEditableArtifactPublicationReceipt } from "../src/editable-artifact-publication";
+import {
+  parseEditableArtifactPublicationReceipt,
+  projectEditableArtifactPublications,
+} from "../src/editable-artifact-publication";
+import type { SessionEvent } from "../src/types";
 
 const artifactId = "a".repeat(32);
 const receipt = {
@@ -31,4 +35,49 @@ describe("parseEditableArtifactPublicationReceipt", () => {
       }),
     ).toBeNull();
   });
+
+  test("projects closed receipts without requiring the tool-call input", () => {
+    const workspaceId = "22222222-2222-4222-8222-222222222222";
+    const first = event(8, workspaceId, { output: receipt });
+    const replay = event(12, workspaceId, { output: JSON.stringify(receipt) });
+    const unrelated = event(10, workspaceId, { output: "done" });
+
+    expect(projectEditableArtifactPublications([replay, unrelated, first], workspaceId)).toEqual([
+      {
+        receipt,
+        eventId: replay.id,
+        sequence: 12,
+        occurredAt: replay.occurredAt,
+      },
+    ]);
+  });
+
+  test("rejects errors and receipts routed to another workspace or session", () => {
+    const workspaceId = "22222222-2222-4222-8222-222222222222";
+    const otherWorkspaceId = "33333333-3333-4333-8333-333333333333";
+    const sessionId = "44444444-4444-4444-8444-444444444444";
+    expect(
+      projectEditableArtifactPublications(
+        [
+          event(1, workspaceId, { output: receipt, error: true }),
+          event(2, otherWorkspaceId, { output: receipt }),
+          { ...event(3, workspaceId, { output: receipt }), sessionId: crypto.randomUUID() },
+        ],
+        workspaceId,
+        sessionId,
+      ),
+    ).toEqual([]);
+  });
 });
+
+function event(sequence: number, workspaceId: string, payload: unknown): SessionEvent {
+  return {
+    id: `event-${sequence}`,
+    workspaceId,
+    sessionId: "44444444-4444-4444-8444-444444444444",
+    sequence,
+    type: "agent.toolCall.output",
+    payload,
+    occurredAt: `2026-08-10T10:00:${String(sequence).padStart(2, "0")}.000Z`,
+  };
+}

--- a/packages/sdk/test/editable-artifact-resources.test.ts
+++ b/packages/sdk/test/editable-artifact-resources.test.ts
@@ -70,6 +70,28 @@ describe("editable artifact public SDK", () => {
     expect(signals).toEqual([abort.signal, abort.signal]);
   });
 
+  test("lists exact session artifacts through the public client", async () => {
+    const sourceSessionId = "33333333-3333-4333-8333-333333333333";
+    let request: Request | null = null;
+    const client = new OpenGeniClient({
+      baseUrl: "https://api.example.test",
+      fetch: (async (input, init) => {
+        request = new Request(input, init);
+        return Response.json({ artifacts: [artifact] });
+      }) as typeof fetch,
+    });
+
+    await expect(
+      client.listSessionEditableArtifacts(WORKSPACE_ID, sourceSessionId, {
+        replicaId: REPLICA_ID,
+      }),
+    ).resolves.toEqual({ artifacts: [artifact] });
+    expect(request!.method).toBe("GET");
+    expect(request!.url).toBe(
+      `https://api.example.test/v1/workspaces/${WORKSPACE_ID}/editable-artifacts?sourceSessionId=${sourceSessionId}&replicaId=${REPLICA_ID}`,
+    );
+  });
+
   test("generates canonical nonzero replica identities", () => {
     const values = new Set(Array.from({ length: 64 }, () => createEditableArtifactReplicaId()));
     expect(values.size).toBe(64);


### PR DESCRIPTION
## Summary
- discover active editable artifacts created by an exact session through an authorized API/SDK boundary
- add a lazy Artifacts tab to the session dock using the existing shared editors
- document the current one-way agent bridge without changing artifact authority

## Verification
- 25-project typecheck
- 41 focused API/SDK tests
- real Postgres tenant-scoped discovery test
- production web build and bundle budgets
- exact local browser acceptance with an existing two-sheet workbook
- lint, formatting, docs references, and diff checks