### PR TITLE
Add a bounded, lazy-loaded agent topology view

### DIFF
--- a/.changeset/bright-agents-branch.md
+++ b/.changeset/bright-agents-branch.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/api-router": minor
+"@opengeni/contracts": minor
+"@opengeni/db": minor
+"@opengeni/sdk": minor
+---
+
+Add a compact, cursor-paginated agent-topology read surface with root, direct-child, and search filters for lazy hierarchy browsers.

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -60,6 +60,7 @@ import {
   type SandboxBackend,
   type LineageNode,
   type Session,
+  type AgentTopologyPageResponse,
   type ErrorCode,
   type SessionAuthorizationOperation,
   type SessionQueueSnapshot,
@@ -88,6 +89,8 @@ import {
   listSessionEventPage,
   listSessionHumanInputRequests,
   listSessionIdsInGroup,
+  listSessionDiscoverySummaries,
+  listSessionDiscoveryAncestorPaths,
   listSessionsForSubject,
   getLatestStartedSessionTurn,
   listSessionTurns,
@@ -133,6 +136,8 @@ import {
   type SandboxPtyProcessIdentity,
   type SandboxRetainedProcess,
   type Database,
+  type SessionDiscoveryCursor,
+  type SessionDiscoveryAncestor,
 } from "@opengeni/db";
 import {
   appendAndPublishEvents,
@@ -554,6 +559,83 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     // than a /sessions/page path is deliberate: an older API safely ignores it
     // and returns its historical array instead of treating "page" as a UUID.
     return c.json([...page.pinned, ...page.sessions].map(decorate));
+  });
+
+  app.get("/v1/workspaces/:workspaceId/agent-topology", async (c) => {
+    const workspaceId = c.req.param("workspaceId");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "sessions:read");
+    let authorizationScope;
+    try {
+      authorizationScope = await requireSessionAuthorizationListScope(deps, grant, "http");
+    } catch (error) {
+      throw sessionAuthorizationHttpError(error);
+    }
+    const query = agentTopologyQuery(c.req.query());
+    const page = await listSessionDiscoverySummaries(db, workspaceId, {
+      limit: query.limit,
+      orderBy: "updatedAt",
+      subjectId: grant.subjectId,
+      ...(query.cursor ? { cursor: query.cursor } : {}),
+      ...(query.search ? { search: query.search } : { parentSessionId: query.parentSessionId }),
+      ...(authorizationScope ? { authorizationScope } : {}),
+    });
+    const ancestorPaths = query.search
+      ? await listSessionDiscoveryAncestorPaths(
+          db,
+          workspaceId,
+          page.sessions.map((session) => session.id),
+          authorizationScope ?? undefined,
+        )
+      : new Map<string, SessionDiscoveryAncestor[]>();
+    const sessions: AgentTopologyPageResponse["sessions"] = page.sessions.map((session) => {
+      const blocker = session.effectiveControl.primaryBlocker;
+      return {
+        id: session.id,
+        title: session.title,
+        titleTruncated:
+          session.titleOriginalChars !== null &&
+          session.titleOriginalChars > Array.from(session.title ?? "").length,
+        parentSessionId: session.parentSessionId,
+        rootSessionId: session.rootSessionId,
+        nestedAgentDepth: session.nestedAgentDepth,
+        ancestorPath: (ancestorPaths.get(session.id) ?? []).map((ancestor) => ({
+          id: ancestor.id,
+          title: ancestor.title,
+          titleTruncated:
+            ancestor.titleOriginalChars !== null &&
+            ancestor.titleOriginalChars > Array.from(ancestor.title ?? "").length,
+        })),
+        status: session.status,
+        pause: {
+          state: session.effectiveControl.state,
+          additionalBlockerCount: session.effectiveControl.additionalBlockerCount,
+          source: blocker
+            ? {
+                kind: blocker.kind,
+                ...(blocker.sessionId ? { sessionId: blocker.sessionId } : {}),
+                displayName: blocker.displayName,
+                displayNameTruncated:
+                  blocker.displayNameOriginalChars > Array.from(blocker.displayName).length,
+              }
+            : null,
+        },
+        children: session.treeStats,
+        createdAt: session.createdAt,
+        updatedAt: session.updatedAt,
+      };
+    });
+    return c.json({
+      sessions,
+      total: page.total,
+      hasMore: page.hasMore,
+      nextCursor: page.nextCursor
+        ? encodeAgentTopologyCursor({
+            cursor: page.nextCursor,
+            parentSessionId: query.parentSessionId,
+            search: query.search ?? null,
+          })
+        : null,
+    } satisfies AgentTopologyPageResponse);
   });
 
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId", async (c) => {
@@ -3297,6 +3379,99 @@ function sessionListQuery(
     cursor,
     search: search || undefined,
     pinsOnly,
+  };
+}
+
+export type AgentTopologyCursorEnvelope = {
+  cursor: SessionDiscoveryCursor;
+  parentSessionId: string | null;
+  search: string | null;
+};
+
+export function encodeAgentTopologyCursor(value: AgentTopologyCursorEnvelope): string {
+  return Buffer.from(JSON.stringify({ v: 1, ...value }), "utf8").toString("base64url");
+}
+
+function decodeAgentTopologyCursor(value: string): AgentTopologyCursorEnvelope {
+  if (value.length > 2_048) {
+    throw new HTTPException(400, { message: "agent topology cursor is invalid" });
+  }
+  try {
+    const parsed = z
+      .object({
+        v: z.literal(1),
+        parentSessionId: z.string().uuid().nullable(),
+        search: z.string().max(200).nullable(),
+        cursor: z.object({
+          orderBy: z.enum(["createdAt", "updatedAt"]),
+          sortRevision: z.string().max(64),
+          sortAt: z.string().max(64),
+          id: z.string().uuid(),
+          snapshotAt: z.string().max(64),
+          snapshotRevision: z.string().max(64),
+          updatedAfter: z.string().max(64).nullable(),
+        }),
+      })
+      .parse(JSON.parse(Buffer.from(value, "base64url").toString("utf8")));
+    if (
+      parsed.cursor.orderBy !== "updatedAt" ||
+      parsed.cursor.updatedAfter !== null ||
+      !/^(?:0|[1-9]\d*)$/.test(parsed.cursor.sortRevision) ||
+      !/^(?:0|[1-9]\d*)$/.test(parsed.cursor.snapshotRevision) ||
+      BigInt(parsed.cursor.sortRevision) > 9_223_372_036_854_775_807n ||
+      BigInt(parsed.cursor.snapshotRevision) > 9_223_372_036_854_775_807n ||
+      Number.isNaN(Date.parse(parsed.cursor.sortAt)) ||
+      Number.isNaN(Date.parse(parsed.cursor.snapshotAt))
+    ) {
+      throw new Error("invalid topology cursor fields");
+    }
+    return parsed;
+  } catch {
+    throw new HTTPException(400, { message: "agent topology cursor is invalid" });
+  }
+}
+
+export function agentTopologyQuery(query: Record<string, string>): {
+  limit: number;
+  parentSessionId: string | null;
+  search: string | undefined;
+  cursor: SessionDiscoveryCursor | undefined;
+} {
+  const rawLimit = query.limit;
+  const limit = rawLimit === undefined ? 25 : Number(rawLimit);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+    throw new HTTPException(400, { message: "limit must be an integer between 1 and 100" });
+  }
+  const rawParent = query.parentSessionId;
+  if (
+    rawParent !== undefined &&
+    rawParent !== "null" &&
+    !z.string().uuid().safeParse(rawParent).success
+  ) {
+    throw new HTTPException(400, {
+      message: 'parentSessionId must be a session id or the literal "null"',
+    });
+  }
+  const parentSessionId = rawParent === undefined || rawParent === "null" ? null : rawParent;
+  const search = query.search?.trim();
+  if (search && search.length > 200) {
+    throw new HTTPException(400, { message: "search must be at most 200 characters" });
+  }
+  if (search && rawParent !== undefined) {
+    throw new HTTPException(400, { message: "search cannot be combined with parentSessionId" });
+  }
+  const envelope = query.cursor ? decodeAgentTopologyCursor(query.cursor) : undefined;
+  if (
+    envelope &&
+    (envelope.parentSessionId !== parentSessionId || envelope.search !== (search || null))
+  ) {
+    throw new HTTPException(400, { message: "agent topology cursor does not match its filters" });
+  }
+  return {
+    limit,
+    parentSessionId,
+    search: search || undefined,
+    cursor: envelope?.cursor,
   };
 }
 

--- a/apps/api/test/agent-topology-query.test.ts
+++ b/apps/api/test/agent-topology-query.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { agentTopologyQuery, encodeAgentTopologyCursor } from "../src/routes/sessions";
+
+const PARENT_ID = "00000000-0000-4000-8000-000000000001";
+const CURSOR = {
+  orderBy: "updatedAt" as const,
+  sortRevision: "12",
+  sortAt: "2026-08-10T10:00:00.123456Z",
+  id: "00000000-0000-4000-8000-000000000002",
+  snapshotAt: "2026-08-10T10:00:01.123456Z",
+  snapshotRevision: "20",
+  updatedAfter: null,
+};
+
+describe("agent topology query", () => {
+  test("defaults to a bounded root page", () => {
+    expect(agentTopologyQuery({})).toEqual({
+      limit: 25,
+      parentSessionId: null,
+      search: undefined,
+      cursor: undefined,
+    });
+  });
+
+  test("round-trips a cursor only with its original branch filters", () => {
+    const cursor = encodeAgentTopologyCursor({
+      cursor: CURSOR,
+      parentSessionId: PARENT_ID,
+      search: null,
+    });
+    expect(agentTopologyQuery({ parentSessionId: PARENT_ID, cursor })).toMatchObject({
+      parentSessionId: PARENT_ID,
+      cursor: CURSOR,
+    });
+    expect(() => agentTopologyQuery({ parentSessionId: "null", cursor })).toThrow(
+      "cursor does not match",
+    );
+  });
+
+  test("rejects invalid limits, parents, searches, and cursors", () => {
+    expect(() => agentTopologyQuery({ limit: "101" })).toThrow("between 1 and 100");
+    expect(() => agentTopologyQuery({ parentSessionId: "not-a-uuid" })).toThrow("parentSessionId");
+    expect(() => agentTopologyQuery({ search: "x".repeat(201) })).toThrow("at most 200");
+    expect(() => agentTopologyQuery({ search: "rollout", parentSessionId: "null" })).toThrow(
+      "cannot be combined",
+    );
+    expect(() => agentTopologyQuery({ cursor: "not-a-cursor" })).toThrow("cursor is invalid");
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@
 //   /workspaces/:id/agent                    → sessions redirect (legacy URL)
 //   /workspaces/:id/sessions                 → sessions index + create
 //   /workspaces/:id/sessions/:sessionId      → session view (queue/goal rail)
+//   /workspaces/:id/agents                   → workspace agent topology
 //   /sessions/:sessionId                     → authorized compatibility redirect
 //   /workspaces/:id/variable-sets            → variable sets + variables
 //   /workspaces/:id/rigs                     → rigs list + create
@@ -21,6 +22,7 @@
 //   /billing?checkout=success|cancelled      → Stripe return → default organization
 //   /device?user_code=…                      → self-hosted enrollment approve page
 //   /dev/composer-chrome                     → DEV-only SessionChrome harness (mocked)
+//   /dev/agent-topology                      → DEV-only agent tree preview (mocked)
 import {
   Navigate,
   RouterProvider,
@@ -39,6 +41,11 @@ export { workspaceAgentPath, workspaceSessionPath, workspaceSessionsPath } from 
 const LazyCapabilitiesRoute = lazyRouteComponent(
   () => import("@/routes/capabilities"),
   "CapabilitiesRoute",
+);
+const LazyAgentsRoute = lazyRouteComponent(() => import("@/routes/agents"), "AgentsRoute");
+const LazyAgentTopologyPreviewRoute = lazyRouteComponent(
+  () => import("@/routes/agents"),
+  "AgentTopologyPreviewRoute",
 );
 const LazyDeviceRoute = lazyRouteComponent(() => import("@/routes/device"), "DeviceRoute");
 const LazyDocumentsRoute = lazyRouteComponent(() => import("@/routes/documents"), "DocumentsRoute");
@@ -151,6 +158,11 @@ const composerChromeGalleryRoute = createRoute({
   path: "dev/composer-chrome",
   component: ComposerChromeGallery,
 });
+const agentTopologyPreviewRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "dev/agent-topology",
+  component: AgentTopologyPreview,
+});
 const workspaceRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "workspaces/$workspaceId",
@@ -180,6 +192,11 @@ const workspaceSessionRoute = createRoute({
   validateSearch: (search: Record<string, unknown>): ComposerLaunchSearch =>
     parseComposerLaunchSearch(search),
   component: SessionView,
+});
+const workspaceAgentsRoute = createRoute({
+  getParentRoute: () => workspaceRoute,
+  path: "agents",
+  component: Agents,
 });
 const workspaceVariableSetsRoute = createRoute({
   getParentRoute: () => workspaceRoute,
@@ -312,12 +329,13 @@ const routeTree = rootRoute.addChildren([
   billingReturnRoute,
   deviceRoute,
   resetPasswordRoute,
-  ...(import.meta.env.DEV ? [composerChromeGalleryRoute] : []),
+  ...(import.meta.env.DEV ? [composerChromeGalleryRoute, agentTopologyPreviewRoute] : []),
   workspaceRoute.addChildren([
     workspaceIndexRoute,
     workspaceAgentRoute,
     workspaceSessionsRoute,
     workspaceSessionRoute,
+    workspaceAgentsRoute,
     workspaceVariableSetsRoute,
     workspaceEnvironmentsRoute,
     workspaceRigsRoute,
@@ -394,6 +412,11 @@ function SessionView() {
       realtimeAutostartModel={launch.realtime}
     />
   );
+}
+
+function Agents() {
+  const { workspaceId } = workspaceAgentsRoute.useParams();
+  return <LazyAgentsRoute workspaceId={workspaceId} />;
 }
 
 function SessionDeepLink() {
@@ -535,6 +558,10 @@ function ResetPassword() {
 
 function ComposerChromeGallery() {
   return <LazyComposerChromeGalleryRoute />;
+}
+
+function AgentTopologyPreview() {
+  return <LazyAgentTopologyPreviewRoute />;
 }
 
 function BillingReturnRoute() {

--- a/apps/web/src/components/rail/workspace-nav-data.ts
+++ b/apps/web/src/components/rail/workspace-nav-data.ts
@@ -2,6 +2,7 @@
 // `workspace-config-link.tsx`.
 
 export type WorkspaceConfigTarget =
+  | "/workspaces/$workspaceId/agents"
   | "/workspaces/$workspaceId/insights"
   | "/workspaces/$workspaceId/variable-sets"
   | "/workspaces/$workspaceId/rigs"
@@ -47,6 +48,12 @@ export const WORKSPACE_CONFIG_GROUPS: WorkspaceConfigGroup[] = [
     id: "overview",
     label: "Overview",
     items: [
+      {
+        to: "/workspaces/$workspaceId/agents",
+        icon: "map",
+        label: "Agents",
+        description: "Live agent trees and spawned work",
+      },
       {
         to: "/workspaces/$workspaceId/insights",
         icon: "gauge",

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -365,9 +365,11 @@ export function RootRouteComponent() {
     select: (state) => Object.keys(state.location.search).length > 0,
   });
   // Public surfaces render ahead of auth/config gates. `/reset-password` is
-  // always public; the SessionChrome DEV harness is public and needs no session.
-  const isPublicAuthRoute =
-    pathname === "/reset-password" || (import.meta.env.DEV && pathname === "/dev/composer-chrome");
+  // always public; DEV visual harnesses are public and need no session.
+  const isPublicDevHarness =
+    import.meta.env.DEV &&
+    (pathname === "/dev/composer-chrome" || pathname === "/dev/agent-topology");
+  const isPublicAuthRoute = pathname === "/reset-password" || isPublicDevHarness;
   // The @opengeni/sdk client behind every console API call and hook. Auth
   // headers are read per request; a new identity per key version makes the
   // hooks re-fetch and the event streams reconnect with the new credentials.
@@ -388,6 +390,7 @@ export function RootRouteComponent() {
   }, []);
 
   useEffect(() => {
+    if (isPublicDevHarness) return;
     let cancelled = false;
     void fetchClientConfig()
       .then((config) => {
@@ -415,7 +418,7 @@ export function RootRouteComponent() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [isPublicDevHarness]);
 
   useEffect(() => {
     if (!clientConfig) {

--- a/apps/web/src/lib/agent-topology.test.ts
+++ b/apps/web/src/lib/agent-topology.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentTopologySession } from "@opengeni/sdk";
+
+import {
+  AGENT_DIAGRAM_NODE_HEIGHT,
+  AGENT_DIAGRAM_NODE_WIDTH,
+  buildAgentTopology,
+  filterAgentTopology,
+  layoutAgentTopologyDiagram,
+  limitAgentTopology,
+  summarizeAgentTopology,
+} from "./agent-topology";
+
+function session(
+  id: string,
+  options: Partial<Pick<AgentTopologySession, "parentSessionId" | "status" | "title">> = {},
+): AgentTopologySession {
+  return {
+    id,
+    parentSessionId: options.parentSessionId ?? null,
+    status: options.status ?? "idle",
+    title: options.title ?? id,
+    titleTruncated: false,
+    rootSessionId: options.parentSessionId ? "root" : id,
+    nestedAgentDepth: options.parentSessionId ? 1 : 0,
+    ancestorPath: [],
+    updatedAt: "2026-08-10T10:00:00.000Z",
+    createdAt: "2026-08-10T10:00:00.000Z",
+    pause: { state: "active", additionalBlockerCount: 0, source: null },
+    children: {
+      directChildren: 0,
+      totalDescendants: 0,
+      runningDescendants: 0,
+      queuedDescendants: 0,
+      attentionDescendants: 0,
+      pausedDescendants: 0,
+      failedDescendants: 0,
+      truncated: false,
+    },
+  };
+}
+
+describe("agent topology", () => {
+  test("builds spawned sessions beneath their durable parent", () => {
+    const root = session("root", { status: "running" });
+    const child = session("child", { parentSessionId: "root" });
+    const grandchild = session("grandchild", { parentSessionId: "child" });
+    const forest = buildAgentTopology([grandchild, root, child]);
+    expect(forest.map((node) => node.session.id)).toEqual(["root"]);
+    expect(forest[0]?.children[0]?.session.id).toBe("child");
+    expect(forest[0]?.children[0]?.children[0]?.session.id).toBe("grandchild");
+  });
+
+  test("keeps orphaned and cyclic history visible without recursive nodes", () => {
+    const orphan = session("orphan", { parentSessionId: "missing" });
+    const a = session("a", { parentSessionId: "b" });
+    const b = session("b", { parentSessionId: "a" });
+    const forest = buildAgentTopology([orphan, a, b]);
+    expect(new Set(forest.map((node) => node.session.id))).toEqual(new Set(["orphan", "a", "b"]));
+    expect(forest.every((node) => node.detached && node.children.length === 0)).toBe(true);
+  });
+
+  test("active filtering retains the ancestor path", () => {
+    const root = session("root");
+    const child = session("child", { parentSessionId: "root", status: "running" });
+    const filtered = filterAgentTopology(buildAgentTopology([root, child]), "active", "");
+    expect(filtered[0]?.session.id).toBe("root");
+    expect(filtered[0]?.children[0]?.session.id).toBe("child");
+  });
+
+  test("keeps an unloaded branch when server aggregates contain a matching descendant", () => {
+    const root = session("root");
+    root.children.runningDescendants = 1;
+    root.children.totalDescendants = 1;
+    const filtered = filterAgentTopology(buildAgentTopology([root]), "active", "");
+    expect(filtered.map((node) => node.session.id)).toEqual(["root"]);
+  });
+
+  test("summarizes paused work separately from active statuses", () => {
+    const running = session("running", { status: "running" });
+    const queued = session("queued", { status: "queued" });
+    const paused = {
+      ...session("paused", { status: "running" }),
+      pause: { state: "paused", additionalBlockerCount: 0, source: null },
+    } as AgentTopologySession;
+    expect(summarizeAgentTopology([running, queued, paused])).toMatchObject({
+      total: 3,
+      active: 2,
+      running: 1,
+      queued: 1,
+      paused: 1,
+    });
+  });
+
+  test("lays out a top-down diagram and removes collapsed descendants", () => {
+    const root = session("root", { status: "running" });
+    const childA = session("child-a", { parentSessionId: "root" });
+    const childB = session("child-b", { parentSessionId: "root" });
+    const grandchild = session("grandchild", { parentSessionId: "child-a" });
+    const forest = buildAgentTopology([root, childA, childB, grandchild]);
+
+    const expanded = layoutAgentTopologyDiagram(forest, new Set());
+    const rootPosition = expanded.nodes.find((item) => item.node.session.id === "root");
+    const childPosition = expanded.nodes.find((item) => item.node.session.id === "child-a");
+    expect(expanded.nodes).toHaveLength(4);
+    expect(rootPosition?.x).toBeGreaterThanOrEqual(0);
+    expect(childPosition?.y).toBeGreaterThan(rootPosition?.y ?? 0);
+    expect(expanded.width).toBeGreaterThan(AGENT_DIAGRAM_NODE_WIDTH * 2);
+    expect(expanded.height).toBeGreaterThan(AGENT_DIAGRAM_NODE_HEIGHT * 2);
+
+    const collapsed = layoutAgentTopologyDiagram(forest, new Set(["root"]));
+    expect(collapsed.nodes.map((item) => item.node.session.id)).toEqual(["root"]);
+  });
+
+  test("bounds wide and deep trees without losing omitted counts", () => {
+    const root = session("root");
+    const children = Array.from({ length: 20 }, (_, index) =>
+      session(`child-${index}`, { parentSessionId: "root" }),
+    );
+    const deep = session("deep", { parentSessionId: "child-0" });
+    const deeper = session("deeper", { parentSessionId: "deep" });
+    const forest = buildAgentTopology([root, ...children, deep, deeper]);
+
+    const limited = limitAgentTopology(forest, {
+      maxDepth: 1,
+      maxChildren: 5,
+      maxNodes: 200,
+    });
+    expect(limited.visibleCount).toBe(6);
+    expect(limited.hiddenCount).toBe(17);
+    expect(limited.hiddenByParent.get("root")).toBe(15);
+    expect(limited.hiddenByParent.get("child-0")).toBe(2);
+
+    const globallyLimited = limitAgentTopology(forest, {
+      maxDepth: null,
+      maxChildren: null,
+      maxNodes: 4,
+    });
+    expect(globallyLimited.visibleCount).toBe(4);
+    expect(globallyLimited.hiddenCount).toBe(19);
+  });
+
+  test("places the highest-priority child near the center of a wide diagram", () => {
+    const root = session("root");
+    const children = Array.from({ length: 5 }, (_, index) =>
+      session(`child-${index}`, {
+        parentSessionId: "root",
+        status: index === 0 ? "running" : "idle",
+      }),
+    );
+    const layout = layoutAgentTopologyDiagram(buildAgentTopology([root, ...children]), new Set());
+    const rootPosition = layout.nodes.find((item) => item.node.session.id === "root")!;
+    const priorityPosition = layout.nodes.find((item) => item.node.session.id === "child-0")!;
+    expect(priorityPosition.x).toBe(rootPosition.x);
+  });
+});

--- a/apps/web/src/lib/agent-topology.ts
+++ b/apps/web/src/lib/agent-topology.ts
@@ -1,0 +1,335 @@
+import type { AgentTopologySession } from "@opengeni/sdk";
+
+export type AgentTopologyFilter = "all" | "active" | "attention" | "paused" | "failed";
+
+export type AgentTopologyNode = {
+  session: AgentTopologySession;
+  children: AgentTopologyNode[];
+  detached: boolean;
+  cycle: boolean;
+};
+
+export type AgentTopologySummary = {
+  total: number;
+  active: number;
+  running: number;
+  queued: number;
+  attention: number;
+  paused: number;
+  failed: number;
+};
+
+export type AgentTopologyDiagramNode = {
+  node: AgentTopologyNode;
+  parentId: string | null;
+  depth: number;
+  x: number;
+  y: number;
+};
+
+export type AgentTopologyDiagramLayout = {
+  nodes: AgentTopologyDiagramNode[];
+  width: number;
+  height: number;
+};
+
+export type AgentTopologyLimits = {
+  maxDepth: number | null;
+  maxChildren: number | null;
+  maxNodes: number;
+};
+
+export type LimitedAgentTopology = {
+  roots: AgentTopologyNode[];
+  visibleCount: number;
+  hiddenCount: number;
+  hiddenByParent: ReadonlyMap<string, number>;
+};
+
+export const AGENT_DIAGRAM_NODE_WIDTH = 224;
+export const AGENT_DIAGRAM_NODE_HEIGHT = 96;
+const AGENT_DIAGRAM_COLUMN_GAP = 48;
+const AGENT_DIAGRAM_ROW_GAP = 64;
+const AGENT_DIAGRAM_PADDING = 24;
+
+export function isPausedAgent(session: AgentTopologySession): boolean {
+  return session.pause.state === "paused";
+}
+
+export function isActiveAgent(session: AgentTopologySession): boolean {
+  return (
+    !isPausedAgent(session) &&
+    (session.status === "running" ||
+      session.status === "queued" ||
+      session.status === "requires_action")
+  );
+}
+
+export function summarizeAgentTopology(sessions: AgentTopologySession[]): AgentTopologySummary {
+  const summary: AgentTopologySummary = {
+    total: sessions.length,
+    active: 0,
+    running: 0,
+    queued: 0,
+    attention: 0,
+    paused: 0,
+    failed: 0,
+  };
+  for (const session of sessions) {
+    if (isPausedAgent(session)) {
+      summary.paused += 1;
+      continue;
+    }
+    if (isActiveAgent(session)) summary.active += 1;
+    if (session.status === "running") summary.running += 1;
+    if (session.status === "queued") summary.queued += 1;
+    if (session.status === "requires_action") summary.attention += 1;
+    if (session.status === "failed") summary.failed += 1;
+  }
+  return summary;
+}
+
+function compareAgentSessions(left: AgentTopologySession, right: AgentTopologySession): number {
+  const activeDelta = Number(isActiveAgent(right)) - Number(isActiveAgent(left));
+  if (activeDelta !== 0) return activeDelta;
+  const attentionDelta =
+    Number(right.status === "requires_action") - Number(left.status === "requires_action");
+  if (attentionDelta !== 0) return attentionDelta;
+  const updatedDelta = Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+  return updatedDelta || left.id.localeCompare(right.id);
+}
+
+/** Build a cycle-safe forest from server-authored session parent identities. */
+export function buildAgentTopology(sessions: AgentTopologySession[]): AgentTopologyNode[] {
+  const unique = new Map(sessions.map((session) => [session.id, session]));
+  const nodes = new Map<string, AgentTopologyNode>();
+  for (const session of unique.values()) {
+    nodes.set(session.id, { session, children: [], detached: false, cycle: false });
+  }
+
+  const roots: AgentTopologyNode[] = [];
+  for (const node of nodes.values()) {
+    const parentId = node.session.parentSessionId;
+    if (!parentId) {
+      roots.push(node);
+      continue;
+    }
+    const parent = nodes.get(parentId);
+    if (!parent) {
+      node.detached = true;
+      roots.push(node);
+      continue;
+    }
+
+    // Following parent pointers before linking makes a malformed historical
+    // cycle visible as detached roots instead of recursing forever in the UI.
+    const seen = new Set<string>([node.session.id]);
+    let cursor: AgentTopologySession | undefined = parent.session;
+    let cycle = false;
+    while (cursor) {
+      if (seen.has(cursor.id)) {
+        cycle = true;
+        break;
+      }
+      seen.add(cursor.id);
+      cursor = cursor.parentSessionId ? unique.get(cursor.parentSessionId) : undefined;
+    }
+    if (cycle) {
+      node.detached = true;
+      node.cycle = true;
+      roots.push(node);
+      continue;
+    }
+    parent.children.push(node);
+  }
+
+  const sortTree = (node: AgentTopologyNode): void => {
+    node.children.sort((a, b) => compareAgentSessions(a.session, b.session));
+    node.children.forEach(sortTree);
+  };
+  roots.sort((a, b) => compareAgentSessions(a.session, b.session));
+  roots.forEach(sortTree);
+  return roots;
+}
+
+export function agentMatchesFilter(
+  session: AgentTopologySession,
+  filter: AgentTopologyFilter,
+): boolean {
+  if (filter === "all") return true;
+  if (filter === "active") {
+    return (
+      isActiveAgent(session) ||
+      session.children.runningDescendants +
+        session.children.queuedDescendants +
+        session.children.attentionDescendants >
+        0
+    );
+  }
+  if (filter === "attention") {
+    return (
+      (!isPausedAgent(session) && session.status === "requires_action") ||
+      session.children.attentionDescendants > 0
+    );
+  }
+  if (filter === "paused") {
+    return isPausedAgent(session) || session.children.pausedDescendants > 0;
+  }
+  return (
+    (!isPausedAgent(session) && session.status === "failed") ||
+    session.children.failedDescendants > 0
+  );
+}
+
+/** Keep ancestors of matching nodes so filtered results retain their branch context. */
+export function filterAgentTopology(
+  roots: AgentTopologyNode[],
+  filter: AgentTopologyFilter,
+  query: string,
+): AgentTopologyNode[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const visit = (node: AgentTopologyNode): AgentTopologyNode | null => {
+    const children = node.children
+      .map(visit)
+      .filter((child): child is AgentTopologyNode => !!child);
+    const title = node.session.title?.trim() || "Untitled agent";
+    const matchesQuery =
+      normalizedQuery.length === 0 ||
+      title.toLocaleLowerCase().includes(normalizedQuery) ||
+      node.session.id.toLocaleLowerCase().includes(normalizedQuery);
+    const matches = agentMatchesFilter(node.session, filter) && matchesQuery;
+    return matches || children.length > 0 ? { ...node, children } : null;
+  };
+  return roots.map(visit).filter((node): node is AgentTopologyNode => !!node);
+}
+
+export function countTopologyDescendants(node: AgentTopologyNode): number {
+  return node.children.reduce((count, child) => count + 1 + countTopologyDescendants(child), 0);
+}
+
+/** Bound rendering cost while retaining exact omitted-descendant counts. */
+export function limitAgentTopology(
+  roots: AgentTopologyNode[],
+  limits: AgentTopologyLimits,
+): LimitedAgentTopology {
+  const totalCount = roots.reduce((count, root) => count + 1 + countTopologyDescendants(root), 0);
+  const hiddenByParent = new Map<string, number>();
+  let remaining = Math.max(1, limits.maxNodes);
+  let visibleCount = 0;
+
+  const subtreeSize = (node: AgentTopologyNode): number => 1 + countTopologyDescendants(node);
+  const visit = (node: AgentTopologyNode, depth: number): AgentTopologyNode | null => {
+    if (remaining <= 0) return null;
+    remaining -= 1;
+    visibleCount += 1;
+    if (limits.maxDepth !== null && depth >= limits.maxDepth) {
+      const hidden = countTopologyDescendants(node);
+      if (hidden > 0) hiddenByParent.set(node.session.id, hidden);
+      return { ...node, children: [] };
+    }
+
+    const allowedChildren =
+      limits.maxChildren === null ? node.children : node.children.slice(0, limits.maxChildren);
+    let hidden = node.children
+      .slice(allowedChildren.length)
+      .reduce((count, child) => count + subtreeSize(child), 0);
+    const children: AgentTopologyNode[] = [];
+    for (const child of allowedChildren) {
+      const visibleChild = visit(child, depth + 1);
+      if (visibleChild) children.push(visibleChild);
+      else hidden += subtreeSize(child);
+    }
+    if (hidden > 0) hiddenByParent.set(node.session.id, hidden);
+    return { ...node, children };
+  };
+
+  const limitedRoots: AgentTopologyNode[] = [];
+  for (const root of roots) {
+    const visibleRoot = visit(root, 0);
+    if (visibleRoot) limitedRoots.push(visibleRoot);
+  }
+  return {
+    roots: limitedRoots,
+    visibleCount,
+    hiddenCount: totalCount - visibleCount,
+    hiddenByParent,
+  };
+}
+
+/** Position a visible forest as a compact top-down decision tree. */
+export function layoutAgentTopologyDiagram(
+  roots: AgentTopologyNode[],
+  collapsed: ReadonlySet<string>,
+): AgentTopologyDiagramLayout {
+  const centerPriority = (children: AgentTopologyNode[]): AgentTopologyNode[] => {
+    if (children.length < 3) return children;
+    const slots = new Array<AgentTopologyNode>(children.length);
+    const center = Math.floor((children.length - 1) / 2);
+    slots[center] = children[0]!;
+    let left = center - 1;
+    let right = center + 1;
+    let placeRight = children.length % 2 === 0;
+    for (const child of children.slice(1)) {
+      if ((placeRight && right < slots.length) || left < 0) slots[right++] = child;
+      else slots[left--] = child;
+      placeRight = !placeRight;
+    }
+    return slots;
+  };
+  const units = new Map<string, number>();
+  const measure = (node: AgentTopologyNode): number => {
+    const visibleChildren = collapsed.has(node.session.id) ? [] : node.children;
+    const width = Math.max(
+      1,
+      visibleChildren.reduce((sum, child) => sum + measure(child), 0),
+    );
+    units.set(node.session.id, width);
+    return width;
+  };
+  roots.forEach(measure);
+
+  const pitch = AGENT_DIAGRAM_NODE_WIDTH + AGENT_DIAGRAM_COLUMN_GAP;
+  const nodes: AgentTopologyDiagramNode[] = [];
+  let maxDepth = 0;
+  const place = (
+    node: AgentTopologyNode,
+    parentId: string | null,
+    offsetUnits: number,
+    depth: number,
+  ): void => {
+    const widthUnits = units.get(node.session.id) ?? 1;
+    maxDepth = Math.max(maxDepth, depth);
+    nodes.push({
+      node,
+      parentId,
+      depth,
+      x:
+        AGENT_DIAGRAM_PADDING +
+        (offsetUnits + widthUnits / 2) * pitch -
+        AGENT_DIAGRAM_NODE_WIDTH / 2,
+      y: AGENT_DIAGRAM_PADDING + depth * (AGENT_DIAGRAM_NODE_HEIGHT + AGENT_DIAGRAM_ROW_GAP),
+    });
+    if (collapsed.has(node.session.id)) return;
+    let childOffset = offsetUnits;
+    for (const child of centerPriority(node.children)) {
+      place(child, node.session.id, childOffset, depth + 1);
+      childOffset += units.get(child.session.id) ?? 1;
+    }
+  };
+
+  let rootOffset = 0;
+  for (const root of roots) {
+    place(root, null, rootOffset, 0);
+    rootOffset += units.get(root.session.id) ?? 1;
+  }
+  const totalUnits = Math.max(1, rootOffset);
+  return {
+    nodes,
+    width: Math.ceil(AGENT_DIAGRAM_PADDING * 2 + totalUnits * pitch),
+    height: Math.ceil(
+      AGENT_DIAGRAM_PADDING * 2 +
+        (maxDepth + 1) * AGENT_DIAGRAM_NODE_HEIGHT +
+        maxDepth * AGENT_DIAGRAM_ROW_GAP,
+    ),
+  };
+}

--- a/apps/web/src/routes/agents.tsx
+++ b/apps/web/src/routes/agents.tsx
@@ -1,0 +1,1190 @@
+import { Link } from "@tanstack/react-router";
+import {
+  ActivityIcon,
+  BotIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  CircleAlertIcon,
+  Clock3Icon,
+  GitForkIcon,
+  ListTreeIcon,
+  NetworkIcon,
+  PauseIcon,
+  RefreshCwIcon,
+  SearchIcon,
+  WorkflowIcon,
+  XCircleIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+
+import { PageHeader } from "@/components/common";
+import { Button } from "@/components/ui/button";
+import { ContentPage, ContentSurface } from "@/components/ui/content-layout";
+import { EmptyState } from "@/components/common";
+import { Input } from "@/components/ui/input";
+import { StatusDot, type StatusTone } from "@/components/ui/status-dot";
+import { useAppContext } from "@/context";
+import {
+  AGENT_DIAGRAM_NODE_HEIGHT,
+  AGENT_DIAGRAM_NODE_WIDTH,
+  buildAgentTopology,
+  countTopologyDescendants,
+  filterAgentTopology,
+  isActiveAgent,
+  isPausedAgent,
+  layoutAgentTopologyDiagram,
+  limitAgentTopology,
+  summarizeAgentTopology,
+  type AgentTopologyFilter,
+  type AgentTopologyNode,
+} from "@/lib/agent-topology";
+import { relativeTimeLabel } from "@/lib/sessions-group";
+import { cn } from "@/lib/utils";
+import type { AgentTopologySession } from "@opengeni/sdk";
+
+const ROOT_PAGE_LIMIT = 25;
+const MAX_LOADED_AGENTS = 200;
+const MAX_RENDERED_AGENTS = 200;
+
+type AgentTopologyView = "outline" | "diagram";
+
+type AgentTopologyData = {
+  sessions: AgentTopologySession[];
+  loading: boolean;
+  refreshing: boolean;
+  total: number;
+  hasMore: boolean;
+  nextCursor: string | null;
+  error: Error | null;
+};
+
+type AgentTopologyBranchPage = {
+  loading: boolean;
+  total: number;
+  hasMore: boolean;
+  nextCursor: string | null;
+  error: Error | null;
+};
+
+const EMPTY_DATA: AgentTopologyData = {
+  sessions: [],
+  loading: true,
+  refreshing: false,
+  total: 0,
+  hasMore: false,
+  nextCursor: null,
+  error: null,
+};
+
+export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
+  const context = useAppContext();
+  const requestSequence = useRef(0);
+  const [data, setData] = useState<AgentTopologyData>(EMPTY_DATA);
+  const [branchPages, setBranchPages] = useState<ReadonlyMap<string, AgentTopologyBranchPage>>(
+    () => new Map(),
+  );
+  const [filter, setFilter] = useState<AgentTopologyFilter>("active");
+  const [query, setQuery] = useState("");
+  const [view, setView] = useState<AgentTopologyView>("outline");
+  const [maxDepth, setMaxDepth] = useState<number | null>(3);
+  const [maxChildren, setMaxChildren] = useState<number | null>(5);
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
+
+  const refresh = useCallback(
+    async (cursor?: string) => {
+      const request = ++requestSequence.current;
+      setData((current) => ({
+        ...current,
+        loading: !cursor && current.sessions.length === 0,
+        refreshing: !cursor && current.sessions.length > 0,
+        error: null,
+      }));
+      try {
+        const search = query.trim();
+        const page = await context.client.listAgentTopology(workspaceId, {
+          limit: ROOT_PAGE_LIMIT,
+          ...(cursor ? { cursor } : {}),
+          ...(search ? { search } : { parentSessionId: null }),
+        });
+        if (request !== requestSequence.current) return;
+        setData((current) => {
+          const sessions = new Map<string, AgentTopologySession>();
+          if (cursor) {
+            for (const session of current.sessions) sessions.set(session.id, session);
+          } else if (!search) {
+            for (const session of current.sessions) {
+              if (session.parentSessionId !== null) sessions.set(session.id, session);
+            }
+          }
+          for (const session of page.sessions) {
+            if (sessions.size >= MAX_LOADED_AGENTS && !sessions.has(session.id)) break;
+            sessions.set(session.id, session);
+          }
+          return {
+            sessions: [...sessions.values()],
+            loading: false,
+            refreshing: false,
+            total: page.total,
+            hasMore: page.hasMore,
+            nextCursor: page.nextCursor,
+            error: null,
+          };
+        });
+        if (search) {
+          setExpanded(new Set());
+          setBranchPages(new Map());
+        }
+      } catch (error) {
+        if (request !== requestSequence.current) return;
+        setData((current) => ({
+          ...current,
+          loading: false,
+          refreshing: false,
+          error: error instanceof Error ? error : new Error(String(error)),
+        }));
+      }
+    },
+    [context.client, query, workspaceId],
+  );
+
+  useEffect(() => {
+    setData(EMPTY_DATA);
+    setExpanded(new Set());
+    setBranchPages(new Map());
+    const start = window.setTimeout(() => void refresh(), query.trim() ? 250 : 0);
+    const interval = query.trim() ? undefined : window.setInterval(() => void refresh(), 15_000);
+    return () => {
+      requestSequence.current += 1;
+      window.clearTimeout(start);
+      if (interval !== undefined) window.clearInterval(interval);
+    };
+  }, [query, refresh]);
+
+  const loadChildren = useCallback(
+    async (parentSessionId: string, cursor?: string) => {
+      const remaining = MAX_LOADED_AGENTS - data.sessions.length;
+      if (remaining <= 0) return;
+      setBranchPages((current) =>
+        new Map(current).set(parentSessionId, {
+          ...(current.get(parentSessionId) ?? {
+            total: 0,
+            hasMore: false,
+            nextCursor: null,
+            error: null,
+          }),
+          loading: true,
+          error: null,
+        }),
+      );
+      try {
+        const page = await context.client.listAgentTopology(workspaceId, {
+          parentSessionId,
+          limit: Math.min(remaining, maxChildren ?? 25),
+          ...(cursor ? { cursor } : {}),
+        });
+        setData((current) => {
+          const sessions = new Map(current.sessions.map((session) => [session.id, session]));
+          for (const session of page.sessions) {
+            if (sessions.size >= MAX_LOADED_AGENTS && !sessions.has(session.id)) break;
+            sessions.set(session.id, session);
+          }
+          return { ...current, sessions: [...sessions.values()] };
+        });
+        setBranchPages((current) =>
+          new Map(current).set(parentSessionId, {
+            loading: false,
+            total: page.total,
+            hasMore: page.hasMore,
+            nextCursor: page.nextCursor,
+            error: null,
+          }),
+        );
+      } catch (error) {
+        setBranchPages((current) =>
+          new Map(current).set(parentSessionId, {
+            ...(current.get(parentSessionId) ?? {
+              total: 0,
+              hasMore: false,
+              nextCursor: null,
+            }),
+            loading: false,
+            error: error instanceof Error ? error : new Error(String(error)),
+          }),
+        );
+      }
+    },
+    [context.client, data.sessions.length, maxChildren, workspaceId],
+  );
+
+  const forest = useMemo(() => buildAgentTopology(data.sessions), [data.sessions]);
+  const filteredForest = useMemo(() => filterAgentTopology(forest, filter, ""), [filter, forest]);
+  const limitedTopology = useMemo(
+    () =>
+      limitAgentTopology(filteredForest, {
+        maxDepth,
+        maxChildren,
+        maxNodes: MAX_RENDERED_AGENTS,
+      }),
+    [filteredForest, maxChildren, maxDepth],
+  );
+  const visibleForest = limitedTopology.roots;
+  const summary = useMemo(() => summarizeAgentTopology(data.sessions), [data.sessions]);
+  const collapsed = useMemo(
+    () =>
+      new Set(
+        data.sessions
+          .filter((session) => session.children.directChildren > 0 && !expanded.has(session.id))
+          .map((session) => session.id),
+      ),
+    [data.sessions, expanded],
+  );
+  const toggleCollapsed = (sessionId: string) => {
+    const willExpand = !expanded.has(sessionId);
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(sessionId)) next.delete(sessionId);
+      else next.add(sessionId);
+      return next;
+    });
+    if (willExpand && !branchPages.has(sessionId)) void loadChildren(sessionId);
+  };
+
+  return (
+    <ContentPage width="wide" className="gap-5" data-agent-topology>
+      <PageHeader
+        icon={<NetworkIcon className="size-4" />}
+        title="Agents"
+        description="Every visible agent workstream, connected to the agents it spawned. Open a node to inspect its session, goal, turns, and output."
+        actions={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void refresh()}
+            disabled={data.loading || data.refreshing}
+          >
+            <RefreshCwIcon className={cn("size-3.5", data.refreshing && "animate-spin")} />
+            Refresh
+          </Button>
+        }
+      />
+
+      <section
+        aria-label="Loaded agent status summary"
+        className="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-4"
+      >
+        <TopologyMetric label="Active" value={summary.active} icon={ActivityIcon} tone="running" />
+        <TopologyMetric label="Running" value={summary.running} icon={BotIcon} tone="running" />
+        <TopologyMetric label="Queued" value={summary.queued} icon={Clock3Icon} tone="queued" />
+        <TopologyMetric
+          label="Needs you"
+          value={summary.attention}
+          icon={CircleAlertIcon}
+          tone="waiting"
+        />
+        <TopologyMetric label="Paused" value={summary.paused} icon={PauseIcon} tone="idle" />
+        <TopologyMetric label="Failed" value={summary.failed} icon={XCircleIcon} tone="failed" />
+      </section>
+
+      <ContentSurface className="flex min-h-0 flex-1 flex-col gap-4" style={{ padding: 0 }}>
+        <div className="flex min-w-0 flex-col gap-3 border-b border-border px-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-4">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <AgentViewToggle value={view} onChange={setView} />
+            <TopologyLimitControls
+              maxDepth={maxDepth}
+              maxChildren={maxChildren}
+              onMaxDepthChange={setMaxDepth}
+              onMaxChildrenChange={setMaxChildren}
+            />
+            <div
+              className="flex min-w-0 flex-wrap items-center gap-1"
+              role="group"
+              aria-label="Filter agents"
+            >
+              {(
+                [
+                  ["active", "Active"],
+                  ["all", "All"],
+                  ["attention", "Needs you"],
+                  ["paused", "Paused"],
+                  ["failed", "Failed"],
+                ] as const
+              ).map(([value, label]) => (
+                <button
+                  key={value}
+                  type="button"
+                  aria-pressed={filter === value}
+                  onClick={() => setFilter(value)}
+                  className={cn(
+                    "h-7 rounded-md px-2.5 text-xs font-medium transition-colors",
+                    filter === value
+                      ? "bg-fg text-bg"
+                      : "text-fg-muted hover:bg-surface-2 hover:text-fg",
+                  )}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <label className="relative w-full min-w-0 max-w-56">
+            <span className="sr-only">Search agents</span>
+            <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-fg-subtle" />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search agents"
+              className="h-8 pl-8 text-xs"
+            />
+          </label>
+        </div>
+
+        <div className="flex items-center justify-between gap-3 px-3 text-xs text-fg-subtle sm:px-4">
+          <span>
+            Showing {limitedTopology.visibleCount.toLocaleString()} loaded agents
+            {limitedTopology.hiddenCount > 0
+              ? ` · ${limitedTopology.hiddenCount.toLocaleString()} summarized`
+              : ""}
+            {data.total > 0
+              ? ` · ${data.total.toLocaleString()} ${query.trim() ? "matches" : "roots"}`
+              : ""}
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="size-1.5 rounded-full bg-status-running" />
+            Updates every 15 seconds
+          </span>
+        </div>
+
+        {data.hasMore || data.sessions.length >= MAX_LOADED_AGENTS ? (
+          <div className="mx-3 rounded-md border border-status-waiting/30 bg-status-waiting/10 px-3 py-2 text-xs text-status-waiting">
+            The browser keeps at most {MAX_LOADED_AGENTS} agents in memory. Expand only the branches
+            you need; omitted descendant counts remain server-authored
+            {data.hasMore ? ", and more roots are available" : ""}.
+          </div>
+        ) : null}
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-4 sm:px-4">
+          {data.loading ? (
+            <AgentTreeSkeleton />
+          ) : data.error && data.sessions.length === 0 ? (
+            <EmptyState>
+              <div className="flex items-center justify-between gap-3">
+                <span>Couldn&apos;t load the agent topology: {data.error.message}</span>
+                <Button variant="outline" size="sm" onClick={() => void refresh()}>
+                  Retry
+                </Button>
+              </div>
+            </EmptyState>
+          ) : visibleForest.length === 0 ? (
+            <EmptyState>
+              {data.sessions.length === 0
+                ? "No agents have been started in this workspace yet."
+                : "No agents match this view."}
+            </EmptyState>
+          ) : view === "outline" ? (
+            <div role="tree" aria-label="Agent spawn topology" className="space-y-3">
+              {visibleForest.map((node) => (
+                <AgentBranch
+                  key={node.session.id}
+                  node={node}
+                  workspaceId={workspaceId}
+                  depth={0}
+                  collapsed={collapsed}
+                  onToggle={toggleCollapsed}
+                  hiddenByParent={limitedTopology.hiddenByParent}
+                  branchPages={branchPages}
+                  onLoadMore={(parentSessionId, cursor) =>
+                    void loadChildren(parentSessionId, cursor)
+                  }
+                />
+              ))}
+              {data.nextCursor && data.sessions.length < MAX_LOADED_AGENTS ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void refresh(data.nextCursor ?? undefined)}
+                  disabled={data.loading || data.refreshing}
+                >
+                  Load more {query.trim() ? "matches" : "root agents"}
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            <AgentDiagram
+              roots={visibleForest}
+              workspaceId={workspaceId}
+              collapsed={collapsed}
+              onToggle={toggleCollapsed}
+              hiddenByParent={limitedTopology.hiddenByParent}
+            />
+          )}
+        </div>
+      </ContentSurface>
+    </ContentPage>
+  );
+}
+
+function AgentViewToggle({
+  value,
+  onChange,
+}: {
+  value: AgentTopologyView;
+  onChange: (view: AgentTopologyView) => void;
+}) {
+  return (
+    <div
+      className="inline-flex h-8 items-center rounded-md border border-border bg-surface-2/60 p-0.5"
+      role="group"
+      aria-label="Agent topology layout"
+    >
+      {(
+        [
+          ["outline", "Outline", ListTreeIcon],
+          ["diagram", "Tree", WorkflowIcon],
+        ] as const
+      ).map(([view, label, Icon]) => (
+        <button
+          key={view}
+          type="button"
+          aria-pressed={value === view}
+          onClick={() => onChange(view)}
+          className={cn(
+            "inline-flex h-6 items-center gap-1.5 rounded px-2 text-2xs font-medium transition-colors",
+            value === view ? "bg-surface text-fg shadow-sm" : "text-fg-subtle hover:text-fg-muted",
+          )}
+        >
+          <Icon className="size-3" />
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function TopologyLimitControls({
+  maxDepth,
+  maxChildren,
+  onMaxDepthChange,
+  onMaxChildrenChange,
+}: {
+  maxDepth: number | null;
+  maxChildren: number | null;
+  onMaxDepthChange: (value: number | null) => void;
+  onMaxChildrenChange: (value: number | null) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1.5" aria-label="Topology display limits">
+      <label>
+        <span className="sr-only">Maximum nested depth</span>
+        <select
+          value={maxDepth ?? "all"}
+          onChange={(event) =>
+            onMaxDepthChange(event.target.value === "all" ? null : Number(event.target.value))
+          }
+          className="h-8 rounded-md border border-border bg-surface/50 px-2 text-xs text-fg outline-none focus-visible:border-brand/50"
+        >
+          <option value="2">Depth 2</option>
+          <option value="3">Depth 3</option>
+          <option value="5">Depth 5</option>
+          <option value="all">Any depth</option>
+        </select>
+      </label>
+      <label>
+        <span className="sr-only">Maximum children per agent</span>
+        <select
+          value={maxChildren ?? "all"}
+          onChange={(event) =>
+            onMaxChildrenChange(event.target.value === "all" ? null : Number(event.target.value))
+          }
+          className="h-8 rounded-md border border-border bg-surface/50 px-2 text-xs text-fg outline-none focus-visible:border-brand/50"
+        >
+          <option value="5">5 per agent</option>
+          <option value="10">10 per agent</option>
+          <option value="25">25 per agent</option>
+          <option value="all">All children</option>
+        </select>
+      </label>
+    </div>
+  );
+}
+
+function AgentDiagram({
+  roots,
+  workspaceId,
+  collapsed,
+  onToggle,
+  hiddenByParent,
+}: {
+  roots: AgentTopologyNode[];
+  workspaceId: string;
+  collapsed: ReadonlySet<string>;
+  onToggle: (sessionId: string) => void;
+  hiddenByParent: ReadonlyMap<string, number>;
+}) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const layout = useMemo(() => layoutAgentTopologyDiagram(roots, collapsed), [collapsed, roots]);
+  const positions = useMemo(
+    () => new Map(layout.nodes.map((item) => [item.node.session.id, item])),
+    [layout.nodes],
+  );
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    const preferredRoot =
+      layout.nodes.find((item) => item.parentId === null && isActiveAgent(item.node.session)) ??
+      layout.nodes.find((item) => item.parentId === null);
+    if (!container || !preferredRoot) return;
+    const revealPreferredRoot = () => {
+      const center = preferredRoot.x + AGENT_DIAGRAM_NODE_WIDTH / 2;
+      container.scrollLeft =
+        center <= container.clientWidth ? 0 : Math.max(0, center - container.clientWidth / 2);
+      container.scrollTop = 0;
+    };
+    revealPreferredRoot();
+    const observer = new ResizeObserver(revealPreferredRoot);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [layout]);
+
+  return (
+    <div
+      ref={scrollContainerRef}
+      className="overflow-auto rounded-lg border border-border bg-bg/35"
+    >
+      <div
+        role="tree"
+        aria-label="Agent decision tree"
+        className="relative"
+        style={{ width: layout.width, height: layout.height, minWidth: "100%" }}
+      >
+        <svg
+          className="pointer-events-none absolute inset-0 size-full text-border"
+          width={layout.width}
+          height={layout.height}
+          aria-hidden
+        >
+          {layout.nodes.map((item) => {
+            if (!item.parentId) return null;
+            const parent = positions.get(item.parentId);
+            if (!parent) return null;
+            const fromX = parent.x + AGENT_DIAGRAM_NODE_WIDTH / 2;
+            const fromY = parent.y + AGENT_DIAGRAM_NODE_HEIGHT;
+            const toX = item.x + AGENT_DIAGRAM_NODE_WIDTH / 2;
+            const toY = item.y;
+            const middleY = fromY + (toY - fromY) / 2;
+            return (
+              <path
+                key={`${item.parentId}:${item.node.session.id}`}
+                d={`M ${fromX} ${fromY} V ${middleY} H ${toX} V ${toY}`}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
+            );
+          })}
+        </svg>
+
+        {layout.nodes.map(({ node, depth, x, y }) => {
+          const status = agentStatus(node.session);
+          const title = node.session.title?.trim() || "Untitled agent";
+          const hasChildren = node.session.children.directChildren > 0 || node.children.length > 0;
+          const isCollapsed = collapsed.has(node.session.id);
+          const hiddenCount = Math.max(
+            hiddenByParent.get(node.session.id) ?? 0,
+            node.session.children.totalDescendants - countTopologyDescendants(node),
+          );
+          return (
+            <div
+              key={node.session.id}
+              role="treeitem"
+              aria-level={depth + 1}
+              aria-expanded={hasChildren ? !isCollapsed : undefined}
+              className={cn(
+                "absolute rounded-lg border bg-surface shadow-sm transition-colors hover:border-border-strong",
+                status.tone === "waiting" && "border-status-waiting/40",
+                status.tone === "failed" && "border-status-failed/40",
+                status.tone === "running" && "border-status-running/40",
+              )}
+              style={{
+                left: x,
+                top: y,
+                width: AGENT_DIAGRAM_NODE_WIDTH,
+                height: AGENT_DIAGRAM_NODE_HEIGHT,
+              }}
+            >
+              <Link
+                to="/workspaces/$workspaceId/sessions/$sessionId"
+                params={{ workspaceId, sessionId: node.session.id }}
+                className="flex size-full flex-col rounded-lg px-3 py-2.5 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <div className="flex min-w-0 items-center gap-2 pr-8">
+                  <StatusDot tone={status.tone} pulse={status.pulse} className="size-2 shrink-0" />
+                  <span className={cn("text-2xs font-medium", status.textClass)}>
+                    {status.label}
+                  </span>
+                  {node.detached ? (
+                    <span className="truncate text-2xs text-status-waiting">Detached</span>
+                  ) : null}
+                </div>
+                <div className="mt-1 line-clamp-2 min-w-0 text-xs font-medium leading-4 text-fg">
+                  {title}
+                </div>
+                <div className="mt-auto flex items-center justify-between gap-2 text-2xs text-fg-subtle">
+                  <span className="truncate">Depth {node.session.nestedAgentDepth}</span>
+                  <span className="shrink-0">
+                    {hiddenCount > 0
+                      ? `+${hiddenCount.toLocaleString()} hidden`
+                      : node.children.length > 0
+                        ? `${node.children.length} direct`
+                        : "Leaf"}
+                  </span>
+                </div>
+              </Link>
+              {hasChildren ? (
+                <button
+                  type="button"
+                  aria-label={isCollapsed ? `Expand ${title}` : `Collapse ${title}`}
+                  onClick={() => onToggle(node.session.id)}
+                  className="absolute right-2 top-2 grid size-6 place-items-center rounded text-fg-subtle hover:bg-surface-2 hover:text-fg"
+                >
+                  {isCollapsed ? (
+                    <ChevronRightIcon className="size-3.5" />
+                  ) : (
+                    <ChevronDownIcon className="size-3.5" />
+                  )}
+                </button>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function TopologyMetric({
+  label,
+  value,
+  icon: Icon,
+  tone,
+}: {
+  label: string;
+  value: number;
+  icon: typeof ActivityIcon;
+  tone: StatusTone;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-3 rounded-lg border border-border bg-surface/45 px-3 py-3">
+      <span className="grid size-8 shrink-0 place-items-center rounded-md bg-surface-2 text-fg-muted">
+        <Icon className="size-4" />
+      </span>
+      <div className="min-w-0">
+        <div className="text-lg font-semibold tabular-nums text-fg">{value.toLocaleString()}</div>
+        <div className="flex items-center gap-1.5 truncate text-2xs text-fg-subtle">
+          <StatusDot tone={tone} className="size-1.5" />
+          {label}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AgentBranch({
+  node,
+  workspaceId,
+  depth,
+  collapsed,
+  onToggle,
+  hiddenByParent,
+  branchPages,
+  onLoadMore,
+}: {
+  node: AgentTopologyNode;
+  workspaceId: string;
+  depth: number;
+  collapsed: ReadonlySet<string>;
+  onToggle: (sessionId: string) => void;
+  hiddenByParent: ReadonlyMap<string, number>;
+  branchPages: ReadonlyMap<string, AgentTopologyBranchPage>;
+  onLoadMore: (parentSessionId: string, cursor: string) => void;
+}) {
+  const hasChildren = node.session.children.directChildren > 0 || node.children.length > 0;
+  const isCollapsed = collapsed.has(node.session.id);
+  const descendants = countTopologyDescendants(node);
+  const hiddenCount = Math.max(
+    hiddenByParent.get(node.session.id) ?? 0,
+    node.session.children.totalDescendants - descendants,
+  );
+  const branchPage = branchPages.get(node.session.id);
+  const status = agentStatus(node.session);
+  const title = node.session.title?.trim() || "Untitled agent";
+  return (
+    <div
+      role="treeitem"
+      aria-level={depth + 1}
+      aria-expanded={hasChildren ? !isCollapsed : undefined}
+    >
+      <div className="group/node relative flex min-w-0 items-stretch">
+        {depth > 0 ? (
+          <span
+            className="absolute top-1/2 h-px bg-border"
+            style={{ left: -12, width: 12 }}
+            aria-hidden
+          />
+        ) : null}
+        <div
+          className={cn(
+            "flex min-w-0 flex-1 items-center gap-2 rounded-lg border bg-surface px-2.5 py-2 shadow-sm transition-colors",
+            "hover:border-border-strong hover:bg-surface-2/40",
+            status.tone === "waiting" && "border-status-waiting/40",
+            status.tone === "failed" && "border-status-failed/40",
+            status.tone === "running" && "border-status-running/40",
+          )}
+        >
+          {hasChildren ? (
+            <button
+              type="button"
+              aria-label={isCollapsed ? `Expand ${title}` : `Collapse ${title}`}
+              onClick={() => onToggle(node.session.id)}
+              className="grid size-6 shrink-0 place-items-center rounded text-fg-subtle hover:bg-surface-2 hover:text-fg"
+            >
+              {isCollapsed ? (
+                <ChevronRightIcon className="size-3.5" />
+              ) : (
+                <ChevronDownIcon className="size-3.5" />
+              )}
+            </button>
+          ) : (
+            <span className="grid size-6 shrink-0 place-items-center opacity-50" aria-hidden>
+              <span className="size-1.5 rounded-full bg-fg-subtle" />
+            </span>
+          )}
+
+          <StatusDot tone={status.tone} pulse={status.pulse} className="size-2 shrink-0" />
+          <Link
+            to="/workspaces/$workspaceId/sessions/$sessionId"
+            params={{ workspaceId, sessionId: node.session.id }}
+            className="min-w-0 flex-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+              <span className="min-w-0 truncate text-sm font-medium text-fg">{title}</span>
+              <span className={cn("shrink-0 text-2xs font-medium", status.textClass)}>
+                {status.label}
+              </span>
+              {node.detached ? (
+                <span className="shrink-0 rounded bg-status-waiting/10 px-1.5 py-0.5 text-2xs text-status-waiting">
+                  {node.cycle
+                    ? "Invalid lineage"
+                    : node.session.ancestorPath.length > 0
+                      ? "Search result"
+                      : "Parent unavailable"}
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-fg-subtle">
+              <span>Depth {node.session.nestedAgentDepth}</span>
+              <span>{relativeTimeLabel(node.session.updatedAt)}</span>
+            </div>
+            {node.session.ancestorPath.length > 0 ? (
+              <div className="mt-1 truncate text-2xs text-fg-subtle">
+                {node.session.ancestorPath
+                  .map((ancestor) => ancestor.title?.trim() || "Untitled agent")
+                  .join(" › ")}
+              </div>
+            ) : null}
+          </Link>
+
+          <div className="hidden shrink-0 items-center gap-2 sm:flex">
+            {descendants > 0 ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-surface-2 px-2 py-1 text-2xs text-fg-muted">
+                <GitForkIcon className="size-3" />
+                {descendants} spawned
+              </span>
+            ) : null}
+            {hiddenCount > 0 ? (
+              <span className="rounded-full bg-surface-2 px-2 py-1 text-2xs text-fg-muted">
+                +{hiddenCount.toLocaleString()} hidden
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {hasChildren && !isCollapsed ? (
+        <div role="group" className="relative ml-6 space-y-2 border-l border-border pl-4 pt-2">
+          {node.children.map((child) => (
+            <AgentBranch
+              key={child.session.id}
+              node={child}
+              workspaceId={workspaceId}
+              depth={depth + 1}
+              collapsed={collapsed}
+              onToggle={onToggle}
+              hiddenByParent={hiddenByParent}
+              branchPages={branchPages}
+              onLoadMore={onLoadMore}
+            />
+          ))}
+          {branchPage?.loading ? (
+            <div className="px-2 py-1 text-xs text-fg-subtle">Loading children…</div>
+          ) : branchPage?.error ? (
+            <button
+              type="button"
+              className="px-2 py-1 text-left text-xs text-status-failed hover:underline"
+              onClick={() => onLoadMore(node.session.id, branchPage.nextCursor ?? "")}
+            >
+              Couldn&apos;t load this branch. Retry
+            </button>
+          ) : branchPage?.nextCursor ? (
+            <button
+              type="button"
+              className="px-2 py-1 text-left text-xs text-fg-muted hover:text-fg hover:underline"
+              onClick={() => onLoadMore(node.session.id, branchPage.nextCursor!)}
+            >
+              Load more children
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function agentStatus(session: AgentTopologySession): {
+  label: string;
+  tone: StatusTone;
+  pulse: boolean;
+  textClass: string;
+} {
+  if (isPausedAgent(session)) {
+    const source = session.pause.source;
+    const label =
+      source?.kind === "workspace"
+        ? "Paused by workspace"
+        : source?.sessionId === session.id
+          ? "Paused here"
+          : "Paused by ancestor";
+    return { label, tone: "idle", pulse: false, textClass: "text-fg-subtle" };
+  }
+  if (session.status === "running") {
+    return { label: "Running", tone: "running", pulse: true, textClass: "text-status-running" };
+  }
+  if (session.status === "queued") {
+    return { label: "Queued", tone: "queued", pulse: false, textClass: "text-status-queued" };
+  }
+  if (session.status === "requires_action") {
+    return { label: "Needs you", tone: "waiting", pulse: false, textClass: "text-status-waiting" };
+  }
+  if (session.status === "failed") {
+    return { label: "Failed", tone: "failed", pulse: false, textClass: "text-status-failed" };
+  }
+  if (session.status === "cancelled") {
+    return { label: "Cancelled", tone: "cancelled", pulse: false, textClass: "text-fg-subtle" };
+  }
+  return {
+    label: isActiveAgent(session) ? "Active" : "Idle",
+    tone: "idle",
+    pulse: false,
+    textClass: "text-fg-subtle",
+  };
+}
+
+function AgentTreeSkeleton() {
+  return (
+    <div className="space-y-3" aria-label="Loading agent topology">
+      {["w-full", "w-2/3", "w-3/4"].map((width, index) => (
+        <div
+          key={width}
+          className={cn("h-16 animate-pulse rounded-lg bg-surface-2", width, index > 0 && "ml-6")}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Public development-only visual harness for reviewing the topology without a live stack. */
+export function AgentTopologyPreviewRoute() {
+  const sessions = useMemo(() => previewSessions(), []);
+  const fullForest = useMemo(() => buildAgentTopology(sessions), [sessions]);
+  const summary = useMemo(() => summarizeAgentTopology(sessions), [sessions]);
+  const [view, setView] = useState<AgentTopologyView>("diagram");
+  const [maxDepth, setMaxDepth] = useState<number | null>(3);
+  const [maxChildren, setMaxChildren] = useState<number | null>(5);
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(() => new Set());
+  const limitedTopology = useMemo(
+    () =>
+      limitAgentTopology(fullForest, {
+        maxDepth,
+        maxChildren,
+        maxNodes: MAX_RENDERED_AGENTS,
+      }),
+    [fullForest, maxChildren, maxDepth],
+  );
+  const forest = limitedTopology.roots;
+  const toggleCollapsed = (sessionId: string) => {
+    setCollapsed((current) => {
+      const next = new Set(current);
+      if (next.has(sessionId)) next.delete(sessionId);
+      else next.add(sessionId);
+      return next;
+    });
+  };
+  return (
+    <div className="flex min-h-dvh bg-bg text-fg">
+      <ContentPage width="wide" className="gap-5">
+        <PageHeader
+          icon={<NetworkIcon className="size-4" />}
+          title="Agents"
+          description="Every visible agent workstream, connected to the agents it spawned. This static development preview uses the same tree renderer as the workspace page."
+        />
+        <section
+          aria-label="Agent status summary"
+          className="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-4"
+        >
+          <TopologyMetric
+            label="Active"
+            value={summary.active}
+            icon={ActivityIcon}
+            tone="running"
+          />
+          <TopologyMetric label="Running" value={summary.running} icon={BotIcon} tone="running" />
+          <TopologyMetric label="Queued" value={summary.queued} icon={Clock3Icon} tone="queued" />
+          <TopologyMetric
+            label="Needs you"
+            value={summary.attention}
+            icon={CircleAlertIcon}
+            tone="waiting"
+          />
+          <TopologyMetric label="Paused" value={summary.paused} icon={PauseIcon} tone="idle" />
+          <TopologyMetric label="Failed" value={summary.failed} icon={XCircleIcon} tone="failed" />
+        </section>
+        <ContentSurface className="flex min-h-0 flex-1 flex-col gap-4" style={{ padding: 0 }}>
+          <div className="flex flex-col gap-1 border-b border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-sm font-semibold text-fg">Agent topology</h2>
+              <p className="mt-0.5 text-xs text-fg-muted">
+                Root agents sit at the top. Connector lines preserve every spawned branch.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-xs text-fg-subtle">
+                {limitedTopology.visibleCount.toLocaleString()} shown ·{" "}
+                {limitedTopology.hiddenCount.toLocaleString()} summarized
+              </span>
+              <AgentViewToggle value={view} onChange={setView} />
+              <TopologyLimitControls
+                maxDepth={maxDepth}
+                maxChildren={maxChildren}
+                onMaxDepthChange={setMaxDepth}
+                onMaxChildrenChange={setMaxChildren}
+              />
+            </div>
+          </div>
+          {view === "outline" ? (
+            <div role="tree" aria-label="Agent spawn topology" className="space-y-3 px-4 pb-4">
+              {forest.map((node) => (
+                <AgentBranch
+                  key={node.session.id}
+                  node={node}
+                  workspaceId="00000000-0000-4000-8000-000000000001"
+                  depth={0}
+                  collapsed={collapsed}
+                  onToggle={toggleCollapsed}
+                  hiddenByParent={limitedTopology.hiddenByParent}
+                  branchPages={new Map()}
+                  onLoadMore={() => {}}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="px-4 pb-4">
+              <AgentDiagram
+                roots={forest}
+                workspaceId="00000000-0000-4000-8000-000000000001"
+                collapsed={collapsed}
+                onToggle={toggleCollapsed}
+                hiddenByParent={limitedTopology.hiddenByParent}
+              />
+            </div>
+          )}
+        </ContentSurface>
+      </ContentPage>
+    </div>
+  );
+}
+
+function previewSessions(): AgentTopologySession[] {
+  const now = Date.now();
+  const ids = {
+    infrastructure: "00000000-0000-4000-8000-000000000101",
+    terraform: "00000000-0000-4000-8000-000000000102",
+    security: "00000000-0000-4000-8000-000000000103",
+    compliance: "00000000-0000-4000-8000-000000000104",
+    product: "00000000-0000-4000-8000-000000000105",
+    research: "00000000-0000-4000-8000-000000000106",
+    release: "00000000-0000-4000-8000-000000000107",
+    launchPlan: "00000000-0000-4000-8000-000000000108",
+    launchResearch: "00000000-0000-4000-8000-000000000109",
+    launchCopy: "00000000-0000-4000-8000-000000000110",
+    launchLegal: "00000000-0000-4000-8000-000000000111",
+    launchLocales: "00000000-0000-4000-8000-000000000112",
+  } as const;
+  const make = (input: {
+    id: string;
+    parentSessionId?: string;
+    title: string;
+    status: AgentTopologySession["status"];
+    depth: number;
+    minutesAgo: number;
+    model?: string;
+    sandboxBackend?: string;
+    paused?: boolean;
+    activeTurn?: boolean;
+  }): AgentTopologySession => ({
+    id: input.id,
+    parentSessionId: input.parentSessionId ?? null,
+    title: input.title,
+    titleTruncated: false,
+    status: input.status,
+    rootSessionId: input.parentSessionId ?? input.id,
+    nestedAgentDepth: input.depth,
+    ancestorPath: [],
+    pause: {
+      state: input.paused ? "paused" : "active",
+      additionalBlockerCount: 0,
+      source: input.paused
+        ? {
+            kind: "session",
+            sessionId: input.id,
+            displayName: input.title,
+            displayNameTruncated: false,
+          }
+        : null,
+    },
+    children: {
+      directChildren: 0,
+      totalDescendants: 0,
+      runningDescendants: 0,
+      queuedDescendants: 0,
+      attentionDescendants: 0,
+      pausedDescendants: 0,
+      failedDescendants: 0,
+      truncated: false,
+    },
+    createdAt: new Date(now - input.minutesAgo * 60_000).toISOString(),
+    updatedAt: new Date(now - input.minutesAgo * 60_000).toISOString(),
+  });
+
+  const overflowAgents = Array.from({ length: 1_000 }, (_, index) =>
+    make({
+      id: `00000000-0000-4000-8000-${String(index + 1_000).padStart(12, "0")}`,
+      parentSessionId: ids.infrastructure,
+      title: `Parallel rollout check ${String(index + 1).padStart(4, "0")}`,
+      status: "idle",
+      depth: 1,
+      minutesAgo: 40 + index,
+    }),
+  );
+
+  return [
+    make({
+      id: ids.infrastructure,
+      title: "Ship the production infrastructure rollout",
+      status: "running",
+      depth: 0,
+      minutesAgo: 0,
+      activeTurn: true,
+    }),
+    make({
+      id: ids.terraform,
+      parentSessionId: ids.infrastructure,
+      title: "Apply the Terraform changes",
+      status: "running",
+      depth: 1,
+      minutesAgo: 1,
+      activeTurn: true,
+    }),
+    make({
+      id: ids.security,
+      parentSessionId: ids.infrastructure,
+      title: "Review network and identity boundaries",
+      status: "requires_action",
+      depth: 1,
+      minutesAgo: 4,
+    }),
+    make({
+      id: ids.compliance,
+      parentSessionId: ids.security,
+      title: "Check policy evidence for the release",
+      status: "queued",
+      depth: 2,
+      minutesAgo: 6,
+    }),
+    make({
+      id: ids.product,
+      title: "Prepare the customer launch brief",
+      status: "idle",
+      depth: 0,
+      minutesAgo: 18,
+      model: "gpt-5.3-codex",
+    }),
+    make({
+      id: ids.research,
+      parentSessionId: ids.product,
+      title: "Collect customer proof points",
+      status: "running",
+      depth: 1,
+      minutesAgo: 24,
+      paused: true,
+      sandboxBackend: "selfhosted",
+    }),
+    make({
+      id: ids.release,
+      parentSessionId: ids.product,
+      title: "Verify release screenshots",
+      status: "failed",
+      depth: 1,
+      minutesAgo: 31,
+      model: "gpt-5.3-codex",
+    }),
+    make({
+      id: ids.launchPlan,
+      parentSessionId: ids.product,
+      title: "Plan the launch narrative",
+      status: "idle",
+      depth: 1,
+      minutesAgo: 32,
+    }),
+    make({
+      id: ids.launchResearch,
+      parentSessionId: ids.launchPlan,
+      title: "Research audience segments",
+      status: "idle",
+      depth: 2,
+      minutesAgo: 33,
+    }),
+    make({
+      id: ids.launchCopy,
+      parentSessionId: ids.launchResearch,
+      title: "Draft segment-specific copy",
+      status: "idle",
+      depth: 3,
+      minutesAgo: 34,
+    }),
+    make({
+      id: ids.launchLegal,
+      parentSessionId: ids.launchCopy,
+      title: "Review regional claims",
+      status: "idle",
+      depth: 4,
+      minutesAgo: 35,
+    }),
+    make({
+      id: ids.launchLocales,
+      parentSessionId: ids.launchLegal,
+      title: "Prepare localized variants",
+      status: "idle",
+      depth: 5,
+      minutesAgo: 36,
+    }),
+    ...overflowAgents,
+  ];
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7177,6 +7177,57 @@ export const SessionListResponse = z.object({
 });
 export type SessionListResponse = z.infer<typeof SessionListResponse>;
 
+/** Compact, bounded session projection for workspace agent-topology browsers. */
+export const AgentTopologySession = z.object({
+  id: z.string().uuid(),
+  title: z.string().nullable(),
+  titleTruncated: z.boolean(),
+  parentSessionId: z.string().uuid().nullable(),
+  rootSessionId: z.string().uuid(),
+  nestedAgentDepth: NestedAgentDepthValue,
+  ancestorPath: z.array(
+    z.object({
+      id: z.string().uuid(),
+      title: z.string().nullable(),
+      titleTruncated: z.boolean(),
+    }),
+  ),
+  status: SessionStatus,
+  pause: z.object({
+    state: z.enum(["active", "paused"]),
+    additionalBlockerCount: z.number().int().nonnegative(),
+    source: z
+      .object({
+        kind: z.enum(["session", "workspace"]),
+        sessionId: z.string().uuid().optional(),
+        displayName: z.string(),
+        displayNameTruncated: z.boolean(),
+      })
+      .nullable(),
+  }),
+  children: z.object({
+    directChildren: z.number().int().nonnegative(),
+    totalDescendants: z.number().int().nonnegative(),
+    runningDescendants: z.number().int().nonnegative(),
+    queuedDescendants: z.number().int().nonnegative(),
+    attentionDescendants: z.number().int().nonnegative(),
+    pausedDescendants: z.number().int().nonnegative(),
+    failedDescendants: z.number().int().nonnegative(),
+    truncated: z.boolean(),
+  }),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type AgentTopologySession = z.infer<typeof AgentTopologySession>;
+
+export const AgentTopologyPageResponse = z.object({
+  sessions: z.array(AgentTopologySession),
+  total: z.number().int().nonnegative(),
+  hasMore: z.boolean(),
+  nextCursor: z.string().nullable(),
+});
+export type AgentTopologyPageResponse = z.infer<typeof AgentTopologyPageResponse>;
+
 // Recursive: the TS type is declared first so the schema annotation can carry
 // the FULL recursive shape (a shallow annotation loses type information for
 // contracts consumers after one level of nesting).

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21415,6 +21415,8 @@ export type SessionDiscoverySummary = {
   title: string | null;
   titleOriginalChars: number | null;
   parentSessionId: string | null;
+  rootSessionId: string;
+  nestedAgentDepth: number;
   status: SessionStatus;
   effectiveControl: SessionDiscoveryControl;
   goal: {
@@ -21517,6 +21519,9 @@ export async function listSessionDiscoverySummaries(
     includeLastMessage?: boolean;
     orderBy?: SessionDiscoveryOrderBy;
     updatedAfter?: string;
+    parentSessionId?: string | null;
+    search?: string;
+    subjectId?: string;
     authorizationScope?: SessionAuthorizationListScope;
   },
 ): Promise<{
@@ -21614,8 +21619,35 @@ export async function listSessionDiscoverySummaries(
           )
       : undefined;
     const snapshotFilters: SQL[] = [eq(schema.sessions.workspaceId, workspaceId)];
+    if (options.subjectId) {
+      snapshotFilters.push(sql`not exists (
+        select 1
+        from ${schema.slackInteractions} private_slack_interaction
+        where private_slack_interaction.workspace_id = ${schema.sessions.workspaceId}
+          and private_slack_interaction.session_reservation_id = ${schema.sessions.rootSessionId}
+          and private_slack_interaction.visibility = 'private'
+          and private_slack_interaction.owning_subject_id <> ${options.subjectId}
+      )`);
+    }
     if (options.authorizationScope) {
       snapshotFilters.push(sessionAuthorizationScopeFilter(options.authorizationScope));
+    }
+    if (Object.prototype.hasOwnProperty.call(options, "parentSessionId")) {
+      snapshotFilters.push(
+        options.parentSessionId === null
+          ? isNull(schema.sessions.parentSessionId)
+          : eq(schema.sessions.parentSessionId, options.parentSessionId!),
+      );
+    }
+    const search = options.search?.trim();
+    if (search) {
+      const pattern = `%${search
+        .replaceAll("\\", "\\\\")
+        .replaceAll("%", "\\%")
+        .replaceAll("_", "\\_")}%`;
+      snapshotFilters.push(
+        or(ilike(schema.sessions.title, pattern), ilike(schema.sessions.initialMessage, pattern))!,
+      );
     }
     snapshotFilters.push(
       orderBy === "updatedAt"
@@ -21635,6 +21667,8 @@ export async function listSessionDiscoverySummaries(
         >`left(${schema.sessions.title}, ${SESSION_DISCOVERY_CONTROL_TITLE_MAX_CHARS})`,
         titleOriginalChars: sql<number | null>`char_length(${schema.sessions.title})::integer`,
         parentSessionId: schema.sessions.parentSessionId,
+        rootSessionId: schema.sessions.rootSessionId,
+        nestedAgentDepth: schema.sessions.nestedAgentDepth,
         status: schema.sessions.status,
         createdAt: schema.sessions.createdAt,
         updatedAt: schema.sessions.updatedAt,
@@ -21762,6 +21796,8 @@ export async function listSessionDiscoverySummaries(
         title: row.title,
         titleOriginalChars: row.titleOriginalChars === null ? null : Number(row.titleOriginalChars),
         parentSessionId: relatedAccess === "root" ? row.parentSessionId : null,
+        rootSessionId: relatedAccess === "root" ? row.rootSessionId : row.id,
+        nestedAgentDepth: row.nestedAgentDepth,
         status: row.status as SessionStatus,
         effectiveControl: projectSessionDiscoveryControlForRelatedAccess(
           control,
@@ -21817,6 +21853,108 @@ export async function listSessionDiscoverySummaries(
       updatedThrough: orderBy === "updatedAt" ? snapshotRevision : null,
       updatedAfter,
     };
+  });
+}
+
+export type SessionDiscoveryAncestor = {
+  id: string;
+  title: string | null;
+  titleOriginalChars: number | null;
+};
+
+/**
+ * Return bounded root-to-parent paths for a bounded discovery result page.
+ * Authorization is re-applied to every ancestor so exact-session grants never
+ * acquire parent metadata merely by searching for their target.
+ */
+export async function listSessionDiscoveryAncestorPaths(
+  db: Database,
+  workspaceId: string,
+  sessionIds: string[],
+  authorizationScope?: SessionAuthorizationListScope,
+): Promise<Map<string, SessionDiscoveryAncestor[]>> {
+  const targetIds = [...new Set(sessionIds)].slice(0, 100);
+  if (targetIds.length === 0) return new Map();
+  return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
+    const rows = await rawRows<{
+      targetId: string;
+      id: string;
+      title: string | null;
+      titleOriginalChars: number | string | null;
+      depth: number | string;
+      cycle: boolean;
+    }>(
+      scopedDb,
+      sql`
+      with recursive lineage as (
+        select
+          target.id as target_id,
+          target.id,
+          target.parent_session_id,
+          target.title,
+          0::integer as depth,
+          array[target.id]::uuid[] as path,
+          false as cycle
+        from ${schema.sessions} target
+        where target.workspace_id = ${workspaceId}
+          and ${inArray(sql`target.id`, targetIds)}
+
+        union all
+
+        select
+          child.target_id,
+          parent.id,
+          parent.parent_session_id,
+          parent.title,
+          child.depth + 1,
+          child.path || parent.id,
+          parent.id = any(child.path)
+        from lineage child
+        join ${schema.sessions} parent
+          on parent.workspace_id = ${workspaceId}
+         and parent.id = child.parent_session_id
+        where not child.cycle
+          and child.depth < 64
+      )
+      select
+        target_id as "targetId",
+        id,
+        left(title, ${SESSION_DISCOVERY_CONTROL_TITLE_MAX_CHARS}) as title,
+        char_length(title)::integer as "titleOriginalChars",
+        depth,
+        cycle
+      from lineage
+      where depth > 0
+      order by target_id, depth desc
+    `,
+    );
+    const candidateIds = [...new Set(rows.filter((row) => !row.cycle).map((row) => row.id))];
+    let allowed = new Set(candidateIds);
+    if (authorizationScope && authorizationScope.kind !== "all" && candidateIds.length > 0) {
+      const allowedRows = await scopedDb
+        .select({ id: schema.sessions.id })
+        .from(schema.sessions)
+        .where(
+          and(
+            eq(schema.sessions.workspaceId, workspaceId),
+            inArray(schema.sessions.id, candidateIds),
+            sessionAuthorizationScopeFilter(authorizationScope),
+          ),
+        );
+      allowed = new Set(allowedRows.map((row) => row.id));
+    }
+    const result = new Map<string, SessionDiscoveryAncestor[]>();
+    for (const row of rows) {
+      if (row.cycle || !allowed.has(row.id)) continue;
+      const path = result.get(row.targetId) ?? [];
+      path.push({
+        id: row.id,
+        title: row.title,
+        titleOriginalChars: row.titleOriginalChars === null ? null : Number(row.titleOriginalChars),
+      });
+      result.set(row.targetId, path);
+    }
+    return result;
   });
 }
 

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -43,6 +43,7 @@ import {
   listOutstandingSessionSystemUpdates,
   listSessionEvents,
   listSessionDiscoverySummaries,
+  listSessionDiscoveryAncestorPaths,
   listSessionSystemUpdatesForTurn,
   listUsageEvents,
   listWorkspaceControlEvents,
@@ -732,6 +733,46 @@ describe("clean session control plane", () => {
     expect(new Set([...pageOne.sessions, ...pageTwo.sessions].map((entry) => entry.id))).toEqual(
       new Set([first.id, second.id, third.id]),
     );
+
+    const roots = await listSessionDiscoverySummaries(client.db, grant.workspaceId!, {
+      limit: 10,
+      parentSessionId: null,
+      subjectId: grant.subjectId,
+    });
+    expect(roots.total).toBe(2);
+    expect(new Set(roots.sessions.map((entry) => entry.id))).toEqual(
+      new Set([first.id, second.id]),
+    );
+
+    const children = await listSessionDiscoverySummaries(client.db, grant.workspaceId!, {
+      limit: 10,
+      parentSessionId: second.id,
+      subjectId: grant.subjectId,
+    });
+    expect(children.total).toBe(1);
+    expect(children.sessions[0]).toMatchObject({
+      id: third.id,
+      parentSessionId: second.id,
+    });
+
+    const search = await listSessionDiscoverySummaries(client.db, grant.workspaceId!, {
+      limit: 10,
+      search: "third",
+      subjectId: grant.subjectId,
+    });
+    expect(search.total).toBe(1);
+    expect(search.sessions[0]?.id).toBe(third.id);
+    const paths = await listSessionDiscoveryAncestorPaths(client.db, grant.workspaceId!, [
+      third.id,
+    ]);
+    expect(paths.get(third.id)?.map((entry) => entry.id)).toEqual([second.id]);
+    const exactOnlyPaths = await listSessionDiscoveryAncestorPaths(
+      client.db,
+      grant.workspaceId!,
+      [third.id],
+      { kind: "scoped", rootSessionIds: [], sessionIds: [third.id] },
+    );
+    expect(exactOnlyPaths.get(third.id)).toBeUndefined();
   });
 
   test("session discovery preserves exact keysets and hands concurrent changes to the next scan", async () => {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -460,6 +460,12 @@ the enrollment methods (`mintEnrollToken`, `lookupDeviceEnrollment`,
 `approveDeviceEnrollment`, `denyDeviceEnrollment`) are covered in the
 [Connected Machines guide](../../docs/connected-machines.md).
 
+For large agent hierarchies, use `listAgentTopology` instead of collecting full
+session pages. It returns compact root, direct-child, or server-side search
+pages with opaque cursors and server-authored descendant counts. Load a child
+page only when its parent is expanded; `children.truncated` makes a lower-bound
+aggregate explicit.
+
 ## Full API coverage
 
 Every public endpoint group has typed methods:
@@ -467,7 +473,7 @@ Every public endpoint group has typed methods:
 | Group | Methods |
 | --- | --- |
 | Access + workspaces | `getAccessContext`, `listWorkspaces`, `createWorkspace`, `getWorkspace`, `updateWorkspace` |
-| Sessions + events | `createSession`, `listSessions`, `getSession`, `updateSession`, `listEvents`, `sendEvent`, `sendMessage`, `steerMessage`, `pauseSession`, `resumeSession`, `cancelSession`, `sendApprovalDecision`, `streamEvents`, `openEventStream` |
+| Sessions + events | `createSession`, `listSessions`, `listSessionPage`, `listAgentTopology`, `getSession`, `getSessionLineage`, `updateSession`, `listEvents`, `sendEvent`, `sendMessage`, `steerMessage`, `pauseSession`, `resumeSession`, `cancelSession`, `sendApprovalDecision`, `streamEvents`, `openEventStream` |
 | Machines (bring-your-own-compute) | `listMachines`, `machineMetricsSeries`, `swapActiveSandbox`, `mintEnrollToken`, `lookupDeviceEnrollment`, `approveDeviceEnrollment`, `denyDeviceEnrollment` |
 | Turn queue | `getQueue`, `moveQueueItem`, `editQueueItem`, `steerQueueItem`, `deleteQueueItem` |
 | Goal | `getGoal`, `updateGoal`, `pauseGoal`, `resumeGoal` |

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -124,6 +124,7 @@ import type {
   ScheduledTaskRun,
   Session,
   SessionListResponse,
+  AgentTopologyPageResponse,
   UpdateSessionPinRequest,
   SessionEvent,
   SessionEventCompactResult,
@@ -788,6 +789,32 @@ export class OpenGeniClient {
       return { pinned: [], sessions: response, nextCursor: null };
     }
     return response;
+  }
+
+  /** Compact, bounded workspace agent hierarchy page. */
+  async listAgentTopology(
+    workspaceId: string,
+    options: {
+      limit?: number;
+      parentSessionId?: string | null;
+      cursor?: string;
+      search?: string;
+    } = {},
+  ): Promise<AgentTopologyPageResponse> {
+    const search = options.search?.trim();
+    return await this.requestJson<AgentTopologyPageResponse>(
+      "GET",
+      `/v1/workspaces/${workspaceId}/agent-topology`,
+      undefined,
+      {
+        ...(options.limit !== undefined ? { limit: String(options.limit) } : {}),
+        ...(options.parentSessionId === undefined
+          ? {}
+          : { parentSessionId: options.parentSessionId ?? "null" }),
+        ...(options.cursor ? { cursor: options.cursor } : {}),
+        ...(search ? { search } : {}),
+      },
+    );
   }
 
   /** Set this authenticated member's personal workspace pin for a session. */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -533,6 +533,8 @@ export type {
   ScheduledTaskTriggerType,
   Session,
   SessionCapabilities,
+  AgentTopologyPageResponse,
+  AgentTopologySession,
   SessionListResponse,
   SessionLineageResponse,
   SessionEffectiveToolPolicy,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -967,6 +967,47 @@ export type SessionListResponse = {
   nextCursor: string | null;
 };
 
+/** Compact, bounded session projection for workspace agent-topology browsers. */
+export type AgentTopologySession = {
+  id: string;
+  title: string | null;
+  titleTruncated: boolean;
+  parentSessionId: string | null;
+  rootSessionId: string;
+  nestedAgentDepth: number;
+  ancestorPath: Array<{ id: string; title: string | null; titleTruncated: boolean }>;
+  status: SessionStatus;
+  pause: {
+    state: "active" | "paused";
+    additionalBlockerCount: number;
+    source: {
+      kind: "session" | "workspace";
+      sessionId?: string | undefined;
+      displayName: string;
+      displayNameTruncated: boolean;
+    } | null;
+  };
+  children: {
+    directChildren: number;
+    totalDescendants: number;
+    runningDescendants: number;
+    queuedDescendants: number;
+    attentionDescendants: number;
+    pausedDescendants: number;
+    failedDescendants: number;
+    truncated: boolean;
+  };
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AgentTopologyPageResponse = {
+  sessions: AgentTopologySession[];
+  total: number;
+  hasMore: boolean;
+  nextCursor: string | null;
+};
+
 export type UpdateSessionPinRequest = {
   pinned: boolean;
   expectedVersion?: number;

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -1027,6 +1027,24 @@ describe("OpenGeniClient", () => {
     );
   });
 
+  test("lists compact topology roots, children, and searches through the dedicated endpoint", async () => {
+    const { client, requests } = makeClient(() =>
+      jsonResponse({ sessions: [], total: 0, hasMore: false, nextCursor: null }),
+    );
+    await client.listAgentTopology(WORKSPACE_ID, { limit: 25, parentSessionId: null });
+    await client.listAgentTopology(WORKSPACE_ID, {
+      limit: 10,
+      parentSessionId: SESSION_ID,
+      cursor: "opaque",
+    });
+    await client.listAgentTopology(WORKSPACE_ID, { search: "  rollout  " });
+    expect(requests.map((request) => request.url)).toEqual([
+      `https://api.example.test/v1/workspaces/${WORKSPACE_ID}/agent-topology?limit=25&parentSessionId=null`,
+      `https://api.example.test/v1/workspaces/${WORKSPACE_ID}/agent-topology?limit=10&parentSessionId=${SESSION_ID}&cursor=opaque`,
+      `https://api.example.test/v1/workspaces/${WORKSPACE_ID}/agent-topology?search=rollout`,
+    ]);
+  });
+
   test("listSessionPage falls back to an older server's array endpoint", async () => {
     const legacy = [
       { id: SESSION_ID, workspaceId: WORKSPACE_ID },

--- a/packages/sdk/test/contract-parity.test.ts
+++ b/packages/sdk/test/contract-parity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   AcknowledgeStreamRequest as ContractAcknowledgeStreamRequest,
+  AgentTopologyPageResponse as ContractAgentTopologyPageResponse,
   ActivateCodexRealtimeConnectionRequest as ContractActivateCodexRealtimeConnectionRequest,
   AcknowledgeStreamResponse as ContractAcknowledgeStreamResponse,
   AddWorkspaceMemberRequest as ContractAddWorkspaceMemberRequest,
@@ -90,6 +91,7 @@ import {
 } from "../src/types";
 import type {
   AcknowledgeStreamRequest,
+  AgentTopologyPageResponse,
   ActivateCodexRealtimeConnectionRequest,
   AcknowledgeStreamResponse,
   AddWorkspaceMemberRequest,
@@ -280,6 +282,9 @@ describe("SDK / contracts parity", () => {
   test("contract-parsed payloads are assignable to SDK types (compile-time)", () => {
     // Server -> client shapes: anything the contracts produce, the SDK accepts.
     const acceptSession = (value: z.infer<typeof ContractSessionSchema>): Session => value;
+    const acceptAgentTopologyPage = (
+      value: z.infer<typeof ContractAgentTopologyPageResponse>,
+    ): AgentTopologyPageResponse => value;
     const acceptCreateResponse = (
       value: z.infer<typeof ContractCreateSessionResponse>,
     ): CreateSessionResponse => value;
@@ -326,6 +331,7 @@ describe("SDK / contracts parity", () => {
     };
     const checks = [
       acceptSession,
+      acceptAgentTopologyPage,
       acceptCreateResponse,
       acceptEvent,
       acceptHumanInputRequest,


### PR DESCRIPTION
## Summary

- add a workspace Agents route with outline and decision-tree views; every node opens its canonical session
- add an authorization-scoped compact topology API and SDK method for cursor-paginated roots, direct children, and server-side search with bounded ancestor context
- lazy-load expanded branches and cap root pages, API pages, browser memory, rendered nodes, visible depth, and visible children so 1,000+ agent trees remain usable
- preserve truthful server descendant aggregates and distinguish local, ancestor, and workspace pause provenance

Linear: [OPE-189](https://linear.app/cloudgeni/issue/OPE-189/add-a-bounded-lazy-loaded-agent-topology-view)

## Verification

- `bun test apps/api/test/agent-topology-query.test.ts apps/web/src/lib/agent-topology.test.ts packages/sdk/test/contract-parity.test.ts packages/sdk/test/client.test.ts`
- `bun test packages/db/test/session-control-plane.test.ts --test-name-pattern "session discovery is compact-by-query"`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run check:docs-refs`
- `bun run build` in `apps/web` including bundle budgets
- browser acceptance at `/dev/agent-topology`: tree/outline toggle, depth and child limits, 1,000-child summarization, exact session navigation, and accessibility/console checks