### PR TITLE
fix(worker): retain image outputs before SDK history

### DIFF
--- a/.changeset/early-images-settle.md
+++ b/.changeset/early-images-settle.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Retain explicit image-tool outputs before they enter live agent history, preventing inline image bytes from reaching durable session history during SDK event/state ordering skew.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -139,6 +139,7 @@ import {
   type SandboxFileDownloadFailure,
   type OpenGeniRuntime,
   type ComputerToolMode,
+  type RetainableSessionImageOutputHook,
   type ModelResponseUsage,
   type ModelCallUsageInput,
   type ModelCallUsageNormalization,
@@ -352,7 +353,9 @@ import {
   materializeRetainedScreenshotRunState,
   sdkEventContainsInlineImage,
   retainComputerScreenshot,
+  toolOutputContainsInlineImage,
   typedScreenshotFromSdkEvent,
+  typedScreenshotFromToolOutput,
   unavailableRetainedSessionImage,
 } from "./retained-screenshots";
 import {
@@ -3638,6 +3641,57 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // intentional computer_screenshot or view_image result must never be lost
     // when the event/history sanitizer removes its inline bytes.
     const retainedSessionImageCallIds = new Set<string>();
+    const retainSessionImageAtToolBoundary: RetainableSessionImageOutputHook = async ({
+      toolCallId,
+      output,
+    }) => {
+      const activeTurnId = turnId;
+      if (!activeTurnId) {
+        throw new Error("Session image tool completed before turn initialization");
+      }
+      const typedScreenshot = typedScreenshotFromToolOutput({ callId: toolCallId, output });
+      retainedSessionImageCallIds.add(toolCallId);
+      if (!typedScreenshot) {
+        if (toolOutputContainsInlineImage(output)) {
+          retainedScreenshotReceiptsByCallId.set(
+            toolCallId,
+            unavailableRetainedSessionImage({
+              sessionId: input.sessionId,
+              turnId: activeTurnId,
+              attemptId: input.attemptId,
+              toolCallId,
+              toolOutputId: toolCallId,
+              reason: "unsupported",
+            }),
+          );
+        }
+        return;
+      }
+      retainedScreenshotReceiptsByCallId.set(
+        toolCallId,
+        unavailableRetainedSessionImage({
+          sessionId: input.sessionId,
+          turnId: activeTurnId,
+          attemptId: input.attemptId,
+          toolCallId,
+          toolOutputId: toolCallId,
+          reason: "pending",
+        }),
+      );
+      retainedScreenshotReceiptsByCallId.set(
+        toolCallId,
+        await retainComputerScreenshot({
+          db,
+          objectStorage,
+          accountId: input.accountId,
+          workspaceId: input.workspaceId,
+          sessionId: input.sessionId,
+          turnId: activeTurnId,
+          attemptId: input.attemptId,
+          output: typedScreenshot,
+        }),
+      );
+    };
     const materializeScreenshotHistory = async (history: Array<Record<string, unknown>>) => {
       collectRetainedScreenshotReceipts(history, retainedScreenshotReceiptsByCallId);
       if (!modelCanReceiveRetainedSessionImages) return history;
@@ -6550,6 +6604,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           didComputerUse = true;
           await maybeStartOnTurnRecording(resolvedSandbox, activeSandboxBackend);
         },
+        onRetainableSessionImageOutput: retainSessionImageAtToolBoundary,
         ...(packRuntime.skills.length > 0 ? { packSkills: packRuntime.skills } : {}),
         ...(session.skills.length > 0 ? { sessionSkills: session.skills } : {}),
         ...(skillLibraryRuntime.skillLibrarySkills.length > 0
@@ -7555,8 +7610,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             }
             const completedToolCall = completedToolCallFromSdkEvent(durableSdkEvent);
             if (completedToolCall) {
-              const typedScreenshot = typedScreenshotFromSdkEvent(durableSdkEvent);
+              retainedScreenshotMetadata =
+                retainedScreenshotReceiptsByCallId.get(completedToolCall.callId) ?? null;
+              const typedScreenshot = retainedScreenshotMetadata
+                ? null
+                : typedScreenshotFromSdkEvent(durableSdkEvent);
               if (
+                !retainedScreenshotMetadata &&
                 retainedSessionImageCallIds.has(completedToolCall.callId) &&
                 sdkEventContainsInlineImage(durableSdkEvent) &&
                 !typedScreenshot
@@ -7575,6 +7635,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 );
               }
               if (
+                !retainedScreenshotMetadata &&
                 typedScreenshot &&
                 typedScreenshot.callId === completedToolCall.callId &&
                 retainedSessionImageCallIds.has(completedToolCall.callId)

--- a/apps/worker/src/activities/retained-screenshots.ts
+++ b/apps/worker/src/activities/retained-screenshots.ts
@@ -75,6 +75,21 @@ export class RetainedScreenshotUnavailableError extends Error {
   }
 }
 
+/** Read an intentional image directly at the tool execution boundary. */
+export function typedScreenshotFromToolOutput(input: {
+  callId: string;
+  output: unknown;
+}): TypedScreenshotToolOutput | null {
+  const image = imageBytesFromSdkToolOutput(input.output);
+  if (!image) return null;
+  return {
+    callId: input.callId,
+    toolOutputId: input.callId,
+    bytes: image.bytes,
+    mediaType: image.mediaType,
+  };
+}
+
 /** Read the SDK's trusted typed image before event/history serialization. */
 export function typedScreenshotFromSdkEvent(event: unknown): TypedScreenshotToolOutput | null {
   if (!event || typeof event !== "object") return null;
@@ -178,7 +193,7 @@ function sdkImageSourceContainsInlineImage(source: unknown): boolean {
   );
 }
 
-function toolOutputContainsInlineImage(output: unknown): boolean {
+export function toolOutputContainsInlineImage(output: unknown): boolean {
   if (typeof output === "string") return output.startsWith("data:image/");
   if (Array.isArray(output)) {
     return output.some((entry) => {

--- a/apps/worker/test/retained-screenshots.test.ts
+++ b/apps/worker/test/retained-screenshots.test.ts
@@ -7,6 +7,7 @@ import {
   sdkEventContainsInlineImage,
   ScreenshotValidationError,
   typedScreenshotFromSdkEvent,
+  typedScreenshotFromToolOutput,
   unavailableRetainedSessionImage,
   validateComputerScreenshot,
   validateRetainableSessionImage,
@@ -30,6 +31,23 @@ const WEBP = Uint8Array.from([
 ]);
 
 describe("retained computer screenshots", () => {
+  test("extracts an image before it enters SDK event history", () => {
+    expect(
+      typedScreenshotFromToolOutput({
+        callId: "call-boundary",
+        output: {
+          type: "image",
+          image: { url: `data:image/png;base64,${Buffer.from(PNG).toString("base64")}` },
+        },
+      }),
+    ).toEqual({
+      callId: "call-boundary",
+      toolOutputId: "call-boundary",
+      bytes: PNG,
+      mediaType: "image/png",
+    });
+  });
+
   test("extracts the SDK typed image and validates exact PNG facts", () => {
     const output = typedScreenshotFromSdkEvent({
       type: "run_item_stream_event",

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -903,9 +903,12 @@ wrong one is the classic mistake.
    graph fail closed with the exact offending path. Historical inline image and
    screenshot items remain backward-compatible model history. New
    `computer_screenshot` and `view_image` typed PNG/JPEG/WebP bytes are validated
-   and retained before persistence; every new history copy receives the
-   deterministic bounded artifact receipt (or an explicit unavailable fact),
-   never the provider object key or re-encoded base64 source.
+   and retained inside the tool invocation, before its result can enter live SDK
+   history. The later SDK event only projects the established receipt, so
+   event/state ordering cannot expose inline bytes to reconciliation. Every new
+   history copy receives the deterministic bounded artifact receipt (or an
+   explicit unavailable fact), never the provider object key or re-encoded
+   base64 source.
    New generated images follow the same no-inline-byte rule but are permanent
    workspace files: native hosted base64 is retained before serialization and
    adapter tools return the same compact `generated_image` receipt. A later

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -216,7 +216,12 @@ import {
   type TurnSandboxCommandSession,
   type TurnToolCancellationFence,
 } from "./sandbox/turn-tool-cancellation";
-import { computerUse, type ComputerToolMode } from "./sandbox-computer";
+import {
+  computerUse,
+  withRetainableSessionImageOutputHook,
+  type ComputerToolMode,
+  type RetainableSessionImageOutputHook,
+} from "./sandbox-computer";
 import type { RuntimeMetricsHooks } from "./metrics";
 import { workspaceSkills, type WorkspaceSkillSearchPath } from "./workspace-skills";
 import { appendWorkspaceGovernance } from "./workspace-governance";
@@ -298,6 +303,8 @@ export {
   type SandboxComputerOptions,
   type ComputerUseArgs,
   type ComputerToolMode,
+  type RetainableSessionImageOutputHook,
+  type RetainableSessionImageToolName,
   type ScreenshotReadErrorCode,
 } from "./sandbox-computer";
 
@@ -2018,6 +2025,8 @@ export type BuildAgentOptions = {
    * shell/filesystem turns never pay that cost.
    */
   onComputerUseReady?: (session: SandboxSessionLike) => Promise<void>;
+  /** Persist intentional image outputs before the SDK can add them to history. */
+  onRetainableSessionImageOutput?: RetainableSessionImageOutputHook;
   // The LIVE, by-reference connector-namespace Set from prepareAgentTools
   // (codexConnectorNamespaces): fills during each turn's codex_apps tools/list,
   // read per model call by the codex tool_search description so the model sees
@@ -2748,6 +2757,9 @@ export function buildOpenGeniAgent(
         ? { computerToolMode: options.computerToolMode }
         : {}),
       ...(options.onComputerUseReady ? { onComputerUseReady: options.onComputerUseReady } : {}),
+      ...(options.onRetainableSessionImageOutput
+        ? { onRetainableSessionImageOutput: options.onRetainableSessionImageOutput }
+        : {}),
       ...(options.turnCancellationSignal
         ? { turnCancellationSignal: options.turnCancellationSignal }
         : {}),
@@ -3254,6 +3266,7 @@ export function buildAgentCapabilities(
     // Omitted/unproven transport fails closed with no computer tools.
     computerToolMode?: ComputerToolMode;
     onComputerUseReady?: (session: SandboxSessionLike) => Promise<void>;
+    onRetainableSessionImageOutput?: RetainableSessionImageOutputHook;
     turnCancellationSignal?: AbortSignal;
     onToolCancellationFence?: (fence: TurnToolCancellationFence) => void;
   } = {},
@@ -3275,12 +3288,19 @@ export function buildAgentCapabilities(
       options.structuredToolTransport === false
         ? withStructuredViewImageFunctionResults(tools)
         : tools;
-    return options.supportsImageInput === false
-      ? withoutImageInputTools(transportTools)
-      : transportTools;
+    const imageCapableTools =
+      options.supportsImageInput === false
+        ? withoutImageInputTools(transportTools)
+        : transportTools;
+    return withRetainableSessionImageOutputHook(
+      imageCapableTools,
+      options.onRetainableSessionImageOutput,
+    );
   };
   const filesystemCapability = filesystem({
-    ...(options.structuredToolTransport === false || options.supportsImageInput === false
+    ...(options.structuredToolTransport === false ||
+    options.supportsImageInput === false ||
+    options.onRetainableSessionImageOutput
       ? { configureTools: configureFilesystemTools }
       : {}),
   });
@@ -3347,6 +3367,9 @@ export function buildAgentCapabilities(
       readOnly: settings.computerUseReadOnly,
       ...(options.turnCancellationSignal ? { abortSignal: options.turnCancellationSignal } : {}),
       ...(options.onComputerUseReady ? { onReady: options.onComputerUseReady } : {}),
+      ...(options.onRetainableSessionImageOutput
+        ? { onRetainableSessionImageOutput: options.onRetainableSessionImageOutput }
+        : {}),
       toolMode: options.computerToolMode ?? "disabled",
     });
     caps.push(computerCapability as unknown as ReturnType<typeof Capabilities.default>[number]);

--- a/packages/runtime/src/sandbox-computer.ts
+++ b/packages/runtime/src/sandbox-computer.ts
@@ -1777,6 +1777,48 @@ export function computerFunctionTools(
  */
 export type ComputerToolMode = "hosted" | "function-image" | "disabled" | "function-text";
 
+export type RetainableSessionImageToolName = "view_image" | "computer_screenshot";
+
+export type RetainableSessionImageOutputHook = (input: {
+  toolName: RetainableSessionImageToolName;
+  toolCallId: string;
+  output: unknown;
+}) => Promise<void>;
+
+/**
+ * Retain an intentional image result before the Agents SDK can add it to live
+ * history. The original result is returned unchanged so the current model call
+ * still receives the exact SDK-native image representation.
+ */
+export function withRetainableSessionImageOutputHook(
+  tools: Tool<unknown>[],
+  hook?: RetainableSessionImageOutputHook,
+): Tool<unknown>[] {
+  if (!hook) return tools;
+  return tools.map((capabilityTool) => {
+    if (
+      capabilityTool.type !== "function" ||
+      (capabilityTool.name !== "view_image" && capabilityTool.name !== "computer_screenshot")
+    ) {
+      return capabilityTool;
+    }
+    const invoke = capabilityTool.invoke;
+    const toolName = capabilityTool.name;
+    return {
+      ...capabilityTool,
+      invoke: async (runContext, input, details) => {
+        const output = await invoke(runContext, input, details);
+        const toolCallId = details?.toolCall?.callId;
+        if (!toolCallId) {
+          throw new Error(`${toolName} completed without a tool-call identity`);
+        }
+        await hook({ toolName, toolCallId, output });
+        return output;
+      },
+    };
+  });
+}
+
 export type ComputerUseArgs = {
   dimensions?: [number, number];
   readOnly?: boolean;
@@ -1791,6 +1833,8 @@ export type ComputerUseArgs = {
   toolMode?: ComputerToolMode;
   /** Called after the display is ready on the first actual computer action. */
   onReady?: (session: SandboxSessionLike) => Promise<void>;
+  /** Persist intentional image results before they enter SDK history. */
+  onRetainableSessionImageOutput?: RetainableSessionImageOutputHook;
 };
 
 export function computerUse(args: ComputerUseArgs = {}): ComputerUseCapability {
@@ -1850,11 +1894,14 @@ export class ComputerUseCapability extends Capability {
       case "hosted":
         return [this.hostedComputerTool(computer)];
       case "function-image":
-        return computerFunctionTools(
-          computer,
-          this.args.readOnly ?? false,
-          this.args.needsApproval,
-          true,
+        return withRetainableSessionImageOutputHook(
+          computerFunctionTools(
+            computer,
+            this.args.readOnly ?? false,
+            this.args.needsApproval,
+            true,
+          ),
+          this.args.onRetainableSessionImageOutput,
         );
       case "disabled":
       case "function-text":

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1325,6 +1325,39 @@ describe("runtime event normalization", () => {
     );
   });
 
+  test("view_image crosses the retention hook before returning to SDK history", async () => {
+    const observed: unknown[] = [];
+    const [filesystemCapability] = buildAgentCapabilities(testSettings(), [], {
+      structuredToolTransport: false,
+      supportsImageInput: true,
+      onRetainableSessionImageOutput: async (input) => {
+        observed.push(input);
+      },
+    });
+    const bound = (filesystemCapability as any).bind({
+      createEditor: () => ({}),
+      viewImage: async () => ({
+        type: "image",
+        image: { data: Uint8Array.from([1, 2, 3]), mediaType: "image/png" },
+      }),
+    });
+    const viewImage = bound.tools().find((tool: { name?: string }) => tool.name === "view_image");
+    const output = await viewImage.invoke(undefined, '{"path":"/tmp/image.png"}', {
+      toolCall: { callId: "call-view" },
+    });
+    expect(observed).toEqual([
+      {
+        toolName: "view_image",
+        toolCallId: "call-view",
+        output,
+      },
+    ]);
+    expect(output).toEqual({
+      type: "image",
+      image: { url: "data:image/png;base64,AQID" },
+    });
+  });
+
   test("text-only models do not receive the filesystem view_image tool", () => {
     const toolNames = (supportsImageInput: boolean) => {
       const [filesystemCapability] = buildAgentCapabilities(testSettings(), [], {

--- a/packages/runtime/test/sandbox-computer.test.ts
+++ b/packages/runtime/test/sandbox-computer.test.ts
@@ -10,6 +10,7 @@ import {
   ComputerUseCapability,
   computerUse,
   computerFunctionTools,
+  withRetainableSessionImageOutputHook,
   ComputerReadOnlyError,
   ComputerUnavailableError,
   ComputerActionError,
@@ -1379,6 +1380,35 @@ describe("computerFunctionTools image delivery on the codex backend", () => {
   const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
   const PNG_B64 = Buffer.from(PNG).toString("base64");
   const PNG_DATA_URL = `data:image/png;base64,${PNG_B64}`;
+
+  test("retains a screenshot before returning its unchanged result to the SDK", async () => {
+    const { computer } = makeFakeComputer({ screenshotB64: PNG_B64 });
+    const calls: unknown[] = [];
+    const wrapped = withRetainableSessionImageOutputHook(
+      computerFunctionTools(computer as never, false, undefined, true),
+      async (input) => {
+        calls.push(input);
+      },
+    );
+    const screenshot = toolsByName(wrapped).computer_screenshot as {
+      invoke: (context: never, input: string, details: unknown) => Promise<unknown>;
+    };
+    const output = await screenshot.invoke({} as never, "{}", {
+      toolCall: { callId: "call_image" },
+    });
+    expect(calls).toEqual([
+      {
+        toolName: "computer_screenshot",
+        toolCallId: "call_image",
+        output,
+      },
+    ]);
+    expect((output as { type: string }).type).toBe("image");
+
+    await expect(invokeTool(screenshot, {})).rejects.toThrow(
+      "computer_screenshot completed without a tool-call identity",
+    );
+  });
 
   test("imageFunctionResults=false (default): computer_screenshot returns the text data-URL string", async () => {
     const { computer } = makeFakeComputer({ screenshotB64: PNG_B64 });


### PR DESCRIPTION
## Summary
- retain explicit `view_image` and `computer_screenshot` outputs at the tool boundary, before Agents SDK history can observe inline bytes
- reuse the established artifact receipt when the later SDK completion event arrives
- preserve the original image output for the current model call without adding history sweeps or changing the active-history size guard

## Verification
- `bun test packages/runtime/test/runtime.test.ts packages/runtime/test/sandbox-computer.test.ts apps/worker/test/retained-screenshots.test.ts apps/worker/test/agent-turn.test.ts apps/worker/test/retained-screenshot-lifecycle.test.ts` (493 pass)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:public-hygiene`
- `bun run check:docs-refs`