### PR TITLE
fix(web): restore workspace route scrolling

### DIFF
--- a/apps/web/src/components/ui/content-layout.test.tsx
+++ b/apps/web/src/components/ui/content-layout.test.tsx
@@ -37,6 +37,7 @@ describe("ContentPage scroll contract", () => {
       const inner = container.querySelector<HTMLElement>('[data-slot="content-page-inner"]');
       expect(page).not.toBeNull();
       expect(inner).not.toBeNull();
+      expect(page!.dataset.workspaceScrollOwner).toBe("page");
 
       // Scrollport is the full-width shell child — not the centered column.
       expect(page!.className).toContain("min-h-0");

--- a/apps/web/src/components/ui/content-layout.tsx
+++ b/apps/web/src/components/ui/content-layout.tsx
@@ -26,6 +26,7 @@ export function ContentPage({
   return (
     <div
       data-slot="content-page"
+      data-workspace-scroll-owner="page"
       className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto overscroll-y-contain"
       {...props}
     >

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -1133,6 +1133,7 @@ export function CapabilitiesRoute({
       role="region"
       aria-label="Capabilities"
       tabIndex={-1}
+      data-workspace-scroll-owner="self-managed"
       className="min-h-0 flex-1 overflow-y-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-inset"
     >
       <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">

--- a/apps/web/src/routes/editable-artifact.tsx
+++ b/apps/web/src/routes/editable-artifact.tsx
@@ -106,7 +106,7 @@ export function EditableArtifactRoute({
     absoluteApiBaseUrl.protocol === "http:" && isLoopbackHost(absoluteApiBaseUrl.hostname);
   const headers = authHeadersForAccessKey(getStoredAccessKey());
   return (
-    <div className="h-full min-h-0 bg-og-bg text-og-fg">
+    <div data-workspace-scroll-owner="self-managed" className="h-full min-h-0 bg-og-bg text-og-fg">
       <BrowserEditableArtifactWorkbench
         options={{
           baseUrl: absoluteApiBaseUrl,

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -34,6 +34,7 @@ import { apiBaseUrl } from "@/api";
 import { PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { ContentPage } from "@/components/ui/content-layout";
 import { Notice } from "@/components/ui/notice";
 import { deviceVerificationUri, installOneLiner } from "@/lib/deployment";
 import {
@@ -197,7 +198,7 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
     machines.error instanceof OpenGeniApiError && machines.error.status === 404;
 
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
+    <ContentPage width="standard">
       <PageHeader
         icon={<LaptopIcon className="size-4" />}
         title="Machines"
@@ -307,7 +308,7 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
           </div>
         ) : null}
       </ConfirmDialog>
-    </div>
+    </ContentPage>
   );
 }
 

--- a/apps/web/src/routes/rig-detail.tsx
+++ b/apps/web/src/routes/rig-detail.tsx
@@ -26,6 +26,7 @@ import { RigVersionsTimeline } from "@/components/rigs/rig-versions-timeline";
 import { LoadErrorState } from "@/components/common";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { ContentPage } from "@/components/ui/content-layout";
 import { Input } from "@/components/ui/input";
 import { MetaChip } from "@/components/ui/meta-chip";
 import { Notice } from "@/components/ui/notice";
@@ -348,7 +349,7 @@ export function RigDetailRoute({ workspaceId, rigId }: { workspaceId: string; ri
 
 function Shell({ workspaceId, children }: { workspaceId: string; children: React.ReactNode }) {
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
+    <ContentPage width="standard">
       <Link
         to="/workspaces/$workspaceId/rigs"
         params={{ workspaceId }}
@@ -358,7 +359,7 @@ function Shell({ workspaceId, children }: { workspaceId: string; children: React
         Rigs
       </Link>
       {children}
-    </div>
+    </ContentPage>
   );
 }
 

--- a/apps/web/src/routes/rigs.tsx
+++ b/apps/web/src/routes/rigs.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/rigs/rig-definition-fields";
 import { RigStatusChip } from "@/components/rigs/rig-status-chip";
 import { Button } from "@/components/ui/button";
+import { ContentPage } from "@/components/ui/content-layout";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -182,11 +183,7 @@ export function RigsRoute({ workspaceId }: { workspaceId: string }) {
 }
 
 function PageShell({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
-      {children}
-    </div>
-  );
+  return <ContentPage width="standard">{children}</ContentPage>;
 }
 
 export function PermissionDenied() {

--- a/apps/web/src/routes/schedules.tsx
+++ b/apps/web/src/routes/schedules.tsx
@@ -23,6 +23,7 @@ import { SchedulePersonalConnectionDisclosure } from "@/components/capabilities/
 import { ScheduledTaskRepositoryPicker } from "@/components/repository-picker";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { ContentPage } from "@/components/ui/content-layout";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -277,7 +278,7 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8">
+    <ContentPage width="standard">
       <PageHeader
         icon={<CalendarClockIcon className="size-4" />}
         title="Schedules"
@@ -363,7 +364,11 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
             const lastRun = summarizeLastRun(taskRuns);
             const state = scheduledTaskStateLabel(task);
             return (
-              <div key={task.id} className="rounded-lg border border-border bg-surface p-3">
+              <div
+                key={task.id}
+                data-scheduled-task-id={task.id}
+                className="rounded-lg border border-border bg-surface p-3"
+              >
                 <div className="flex min-w-0 items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex min-w-0 items-center gap-2">
@@ -604,7 +609,7 @@ export function SchedulesRoute({ workspaceId }: { workspaceId: string }) {
         confirmLabel="Delete task"
         onConfirm={() => (confirmDelete ? taskAction(confirmDelete, "delete") : false)}
       />
-    </div>
+    </ContentPage>
   );
 }
 

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1076,7 +1076,10 @@ function SessionChatPane(props: {
   );
 
   return (
-    <section className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+    <section
+      data-workspace-scroll-owner="self-managed"
+      className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden"
+    >
       {terminal ? (
         <div className="mx-auto w-full max-w-3xl px-4 pt-6 sm:px-6">
           <TerminalSessionBanner session={props.session} onNewSession={props.onNewSession} />

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -488,7 +488,7 @@ function SessionsIndexRouteContent({
   return (
     // The canvas parent is overflow-hidden, so this route owns its scrolling —
     // without it the page clips (recent sessions were unreachable below the fold).
-    <div className="min-h-0 flex-1 overflow-y-auto">
+    <div data-workspace-scroll-owner="self-managed" className="min-h-0 flex-1 overflow-y-auto">
       <div className="mx-auto flex w-full max-w-3xl flex-col px-4 pt-10 pb-16 sm:px-6 sm:pt-16">
         <section className="flex flex-col items-center gap-2 text-center">
           <h1 className="text-balance text-2xl font-semibold tracking-tight sm:text-3xl">

--- a/apps/web/src/workspace-route-scroll-contract.test.ts
+++ b/apps/web/src/workspace-route-scroll-contract.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+
+type ScrollContract =
+  | { kind: "page"; source: string }
+  | { kind: "self-managed"; source: string }
+  | { kind: "redirect" };
+
+const workspaceRouteContracts = {
+  workspaceIndexRoute: { kind: "redirect" },
+  workspaceAgentRoute: { kind: "redirect" },
+  workspaceSessionsRoute: { kind: "self-managed", source: "routes/sessions-index.tsx" },
+  workspaceSessionRoute: { kind: "self-managed", source: "routes/session.tsx" },
+  workspaceVariableSetsRoute: { kind: "page", source: "routes/variable-sets.tsx" },
+  workspaceEnvironmentsRoute: { kind: "redirect" },
+  workspaceRigsRoute: { kind: "page", source: "routes/rigs.tsx" },
+  workspaceRigDetailRoute: { kind: "page", source: "routes/rig-detail.tsx" },
+  workspaceMachinesRoute: { kind: "page", source: "routes/machines.tsx" },
+  workspaceInsightsRoute: { kind: "page", source: "routes/insights.tsx" },
+  workspacePacksRoute: { kind: "redirect" },
+  workspaceCapabilitiesRoute: { kind: "self-managed", source: "routes/capabilities.tsx" },
+  workspaceSchedulesRoute: { kind: "page", source: "routes/schedules.tsx" },
+  workspaceDocumentsRoute: { kind: "page", source: "routes/documents.tsx" },
+  workspaceMemoryRoute: { kind: "page", source: "routes/memory.tsx" },
+  workspaceStateRoute: { kind: "page", source: "routes/workspace-state.tsx" },
+  workspaceArtifactsRoute: { kind: "page", source: "routes/artifacts.tsx" },
+  workspaceArtifactDetailRoute: { kind: "page", source: "routes/artifacts.tsx" },
+  workspaceEditableArtifactRoute: {
+    kind: "self-managed",
+    source: "routes/editable-artifact.tsx",
+  },
+  workspaceSettingsRoute: { kind: "page", source: "routes/workspace-settings.tsx" },
+  workspaceOrganizationRoute: { kind: "page", source: "routes/org-settings.tsx" },
+  workspaceAccountRoute: { kind: "redirect" },
+} satisfies Record<string, ScrollContract>;
+
+async function source(path: string): Promise<string> {
+  return Bun.file(`${import.meta.dir}/${path}`).text();
+}
+
+describe("workspace route scroll ownership", () => {
+  test("classifies every route mounted inside the fixed app canvas", async () => {
+    const app = await source("App.tsx");
+    const workspaceChildren = app.match(/workspaceRoute\.addChildren\(\[([\s\S]*?)\n  \]\),/);
+    const workspaceChildrenSource = workspaceChildren?.[1];
+    expect(workspaceChildrenSource).toBeDefined();
+    if (!workspaceChildrenSource) throw new Error("Workspace route children were not found");
+
+    const registeredRoutes = Array.from(
+      workspaceChildrenSource.matchAll(/^\s+(workspace[A-Z]\w+Route),$/gm),
+      (match) => match[1],
+    ).sort();
+
+    expect(registeredRoutes).toEqual(Object.keys(workspaceRouteContracts).sort());
+  });
+
+  test("ordinary pages use ContentPage and workbenches declare self-managed overflow", async () => {
+    const sources = new Map<string, string>();
+    for (const contract of Object.values(workspaceRouteContracts)) {
+      if (contract.kind === "redirect" || sources.has(contract.source)) continue;
+      sources.set(contract.source, await source(contract.source));
+    }
+
+    for (const [route, contract] of Object.entries(workspaceRouteContracts)) {
+      if (contract.kind === "redirect") continue;
+      const routeSource = sources.get(contract.source)!;
+      if (contract.kind === "page") {
+        expect(routeSource, `${route} must render the canonical ContentPage scrollport`).toContain(
+          "<ContentPage",
+        );
+      } else {
+        expect(
+          routeSource,
+          `${route} must declare its intentional internal scroll model`,
+        ).toContain('data-workspace-scroll-owner="self-managed"');
+      }
+    }
+  });
+
+  test("legacy max-width wrappers cannot return as route scroll owners", async () => {
+    const legacyWrapper =
+      'className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-5 sm:px-6 lg:px-8"';
+    for (const path of [
+      "routes/schedules.tsx",
+      "routes/rigs.tsx",
+      "routes/rig-detail.tsx",
+      "routes/machines.tsx",
+    ]) {
+      expect(await source(path), path).not.toContain(legacyWrapper);
+    }
+  });
+});

--- a/test/e2e/knowledge-surfaces.browser.e2e.ts
+++ b/test/e2e/knowledge-surfaces.browser.e2e.ts
@@ -296,6 +296,45 @@ describe("responsive knowledge surfaces (real API + PostgreSQL)", () => {
     }
   }, 240_000);
 
+  test("keeps a long schedules list inside the workspace scroll owner", async () => {
+    const desktop = await configuredContext(
+      browser,
+      {
+        viewport: { width: 1280, height: 900 },
+        extraHTTPHeaders: ownerHeaders,
+      },
+      browserTestSettings.sandboxSelfhostedEnabled,
+    );
+    let workspaceId: string;
+    let tailTask: SeededScheduledTask;
+    try {
+      const page = await desktop.newPage();
+      await page.goto(webBaseUrl);
+      workspaceId = await workspaceFromPage(page);
+      tailTask = await seedScheduledTasks(page, apiBaseUrl, workspaceId);
+      await expectSchedulesScroll(page, webBaseUrl, workspaceId, tailTask);
+      expect(unexpectedDiagnostics(desktop)).toEqual([]);
+    } finally {
+      await desktop.close();
+    }
+
+    const constrained = await configuredContext(
+      browser,
+      {
+        viewport: { width: 375, height: 720 },
+        extraHTTPHeaders: ownerHeaders,
+      },
+      browserTestSettings.sandboxSelfhostedEnabled,
+    );
+    try {
+      const page = await constrained.newPage();
+      await expectSchedulesScroll(page, webBaseUrl, workspaceId, tailTask);
+      expect(unexpectedDiagnostics(constrained)).toEqual([]);
+    } finally {
+      await constrained.close();
+    }
+  }, 120_000);
+
   async function exerciseTruthfulStates(
     page: Page,
     workspaceId: string,
@@ -452,6 +491,11 @@ describe("responsive knowledge surfaces (real API + PostgreSQL)", () => {
 type SeededFixtures = {
   proposedMemoryId: string;
   tailMemoryId: string;
+};
+
+type SeededScheduledTask = {
+  id: string;
+  name: string;
 };
 
 type Surface = "variable-sets" | "documents" | "memory";
@@ -641,6 +685,71 @@ async function seedKnowledgeSurfaces(
       },
     },
   );
+}
+
+async function seedScheduledTasks(
+  page: Page,
+  apiBaseUrl: string,
+  workspaceId: string,
+): Promise<SeededScheduledTask> {
+  return await page.evaluate(
+    async ({ apiBaseUrl: targetApiBaseUrl, workspaceId: targetWorkspaceId }) => {
+      let tailTask: SeededScheduledTask | null = null;
+      for (let index = 0; index < 16; index += 1) {
+        const name =
+          index === 0
+            ? `Tail schedule ${"reachable-without-document-scroll-".repeat(3)}`
+            : `Responsive schedule ${String(index + 1).padStart(2, "0")}`;
+        const response = await fetch(
+          `${targetApiBaseUrl}/v1/workspaces/${targetWorkspaceId}/scheduled-tasks`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              name,
+              schedule: { type: "interval", everySeconds: 3600 + index },
+              agentConfig: { prompt: `Run responsive schedule fixture ${index + 1}` },
+            }),
+          },
+        );
+        if (!response.ok) {
+          throw new Error(
+            `POST scheduled task failed: ${response.status} ${await response.text()}`,
+          );
+        }
+        const created = (await response.json()) as SeededScheduledTask;
+        tailTask ??= { id: created.id, name: created.name };
+      }
+      if (!tailTask) throw new Error("Scheduled task fixture was not created");
+      return tailTask;
+    },
+    { apiBaseUrl, workspaceId },
+  );
+}
+
+async function expectSchedulesScroll(
+  page: Page,
+  baseUrl: string,
+  workspaceId: string,
+  tailTask: SeededScheduledTask,
+): Promise<void> {
+  await page.goto(`${baseUrl}/workspaces/${workspaceId}/schedules`);
+  await page.getByRole("heading", { level: 1, name: "Schedules", exact: true }).waitFor();
+  const tailCard = page.locator(`[data-scheduled-task-id="${tailTask.id}"]`);
+  await tailCard.getByText(tailTask.name, { exact: true }).waitFor();
+  const scrollOwner = page.locator('[data-workspace-scroll-owner="page"]');
+  expect(await scrollOwner.count()).toBe(1);
+  await expectContentPageScrollAndFocus(
+    page,
+    tailCard.getByRole("button", { name: "Edit", exact: true }),
+  );
+  await expectNoPageOverflow(page);
+  const documentScroll = await page.evaluate(() => ({
+    scrollX: window.scrollX,
+    scrollY: window.scrollY,
+  }));
+  expect(documentScroll.scrollX).toBe(0);
+  expect(documentScroll.scrollY).toBe(0);
 }
 
 function surfaceUrl(


### PR DESCRIPTION
## Summary
- move Schedules, Rigs, Rig detail, and Machines onto the canonical full-width `ContentPage` scroll owner
- mark canonical and intentional self-managed route scroll surfaces explicitly
- add a route-tree contract test so every authenticated route must be classified and legacy non-scrolling wrappers cannot return
- extend the curated real-API/PostgreSQL browser acceptance with an overflowing Schedules list at desktop and 375px widths, including wheel and focus reachability plus zero document/horizontal scroll
- reconcile and preserve the knowledge-source schedule functionality merged in #1263

## Validation
- `bun run format:check -- <changed files>`
- `bun run lint -- <changed files>` (repository-wide oxlint: 0 warnings/errors)
- `bun run typecheck` (25 projects clean)
- `bun test --timeout 30000 apps/web/src/App.test.ts apps/web/src/lib/scheduled-tasks.test.ts apps/web/src/components/ui/content-layout.test.tsx apps/web/src/workspace-route-scroll-contract.test.ts` (112 pass)
- `bun run --cwd apps/web build` (pass, bundle budgets pass)
- curated browser acceptance runs in CI with real PostgreSQL; the local rig has no Docker/PostgreSQL test database

## Current-main reconciliation
- exact head: `b775dd6b346c29be8267051aa43408e46591347d`
- exact parent/current main at rebase: `bd5514e1d2a4c2ae28b9e83ddedbc13d77d94c5d`
- exact-head review marker: `OPE191_PR1295_EXACT_HEAD_REVIEW_V3`

Linear: OPE-191