### PR TITLE
Simplify Agent Brain, Documents, and connector UX

### DIFF
--- a/.changeset/fixed-genie-shortcut.md
+++ b/.changeset/fixed-genie-shortcut.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/sdk": patch
+---
+
+Pin the Slack reaction shortcut to the OpenGeni genie emoji across contracts and SDK types.

--- a/apps/api/test/slack-bot.test.ts
+++ b/apps/api/test/slack-bot.test.ts
@@ -3257,8 +3257,8 @@ describe("OpenGeni Slack bot connection", () => {
       new URL("../../web/src/routes/capabilities.tsx", import.meta.url),
     ).text();
     expect(capabilitiesSource).toContain("Slack knowledge destination");
-    expect(capabilitiesSource).toContain("slackBotDestinationLabel");
+    expect(capabilitiesSource).toContain("slackDestinationAuthority");
     expect(capabilitiesSource).toContain("collectionId: null");
-    expect(capabilitiesSource).toMatch(/No\s+user-created collection is required/);
+    expect(capabilitiesSource).toContain("Save imported Slack messages");
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -262,8 +262,10 @@ const workspaceDocumentsRoute = createRoute({
   // Memory used to live inside Documents, so existing timeline links and
   // bookmarks can still carry `?memory=<id>`. Preserve that public URL as a
   // compatibility redirect to the first-class Memory surface.
-  validateSearch: (search: Record<string, unknown>): { memory?: string } =>
-    typeof search.memory === "string" ? { memory: search.memory } : {},
+  validateSearch: (search: Record<string, unknown>): { memory?: string; from?: "brain" } => ({
+    ...(typeof search.memory === "string" ? { memory: search.memory } : {}),
+    ...(search.from === "brain" ? { from: "brain" as const } : {}),
+  }),
   component: Documents,
 });
 const workspaceMemoryRoute = createRoute({
@@ -272,8 +274,10 @@ const workspaceMemoryRoute = createRoute({
   // `?memory=<id>` deep-links a memory record (from a timeline memory step): the
   // Memory page reveals + highlights that record even when the filters would
   // otherwise hide it. Unknown values are ignored.
-  validateSearch: (search: Record<string, unknown>): { memory?: string } =>
-    typeof search.memory === "string" ? { memory: search.memory } : {},
+  validateSearch: (search: Record<string, unknown>): { memory?: string; from?: "brain" } => ({
+    ...(typeof search.memory === "string" ? { memory: search.memory } : {}),
+    ...(search.from === "brain" ? { from: "brain" as const } : {}),
+  }),
   component: Memory,
 });
 const workspaceSettingsRoute = createRoute({
@@ -284,6 +288,12 @@ const workspaceSettingsRoute = createRoute({
 const workspaceStateRoute = createRoute({
   getParentRoute: () => workspaceRoute,
   path: "state",
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { view?: "company" | "instructions" | "preferences" } =>
+    search.view === "company" || search.view === "instructions" || search.view === "preferences"
+      ? { view: search.view }
+      : {},
   component: WorkspaceState,
 });
 const workspaceArtifactsRoute = createRoute({
@@ -485,24 +495,30 @@ function Schedules() {
 
 function Documents() {
   const { workspaceId } = workspaceDocumentsRoute.useParams();
-  const { memory } = workspaceDocumentsRoute.useSearch();
+  const { memory, from } = workspaceDocumentsRoute.useSearch();
   if (memory) {
     return (
       <Navigate
         to="/workspaces/$workspaceId/memory"
         params={{ workspaceId }}
-        search={{ memory }}
+        search={{ memory, ...(from ? { from } : {}) }}
         replace
       />
     );
   }
-  return <LazyDocumentsRoute workspaceId={workspaceId} />;
+  return <LazyDocumentsRoute workspaceId={workspaceId} returnToBrain={from === "brain"} />;
 }
 
 function Memory() {
   const { workspaceId } = workspaceMemoryRoute.useParams();
-  const { memory } = workspaceMemoryRoute.useSearch();
-  return <LazyMemoryRoute workspaceId={workspaceId} focusMemoryId={memory} />;
+  const { memory, from } = workspaceMemoryRoute.useSearch();
+  return (
+    <LazyMemoryRoute
+      workspaceId={workspaceId}
+      focusMemoryId={memory}
+      returnToBrain={from === "brain"}
+    />
+  );
 }
 
 function WorkspaceSettings() {
@@ -512,7 +528,8 @@ function WorkspaceSettings() {
 
 function WorkspaceState() {
   const { workspaceId } = workspaceStateRoute.useParams();
-  return <LazyWorkspaceStateRoute workspaceId={workspaceId} />;
+  const { view } = workspaceStateRoute.useSearch();
+  return <LazyWorkspaceStateRoute workspaceId={workspaceId} view={view} />;
 }
 
 function Artifacts() {

--- a/apps/web/src/components/capabilities/capability-tile.tsx
+++ b/apps/web/src/components/capabilities/capability-tile.tsx
@@ -5,10 +5,7 @@ import { capabilityAuthHint, capabilityKindLabel } from "@/lib/capabilities";
 import { cn } from "@/lib/utils";
 import type { CapabilityCatalogItem } from "@/types";
 
-/**
- * One catalog tile in the Browse grid. The whole tile is the click target
- * (opens the detail sheet) — no per-tile enable button crowding the grid.
- */
+/** One compact catalog row. The whole row opens the same detail/settings sheet. */
 export const CapabilityTile = memo(function CapabilityTile({
   item,
   logoSrc,
@@ -24,31 +21,27 @@ export const CapabilityTile = memo(function CapabilityTile({
       type="button"
       onClick={onOpen}
       className={cn(
-        "group flex h-full flex-col gap-3 rounded-xl border border-border bg-surface/50 p-4 text-left",
-        "transition-all hover:-translate-y-px hover:border-border-strong hover:bg-surface hover:shadow-md",
+        "group flex min-w-0 items-center gap-3 rounded-xl border border-border bg-surface/50 p-3 text-left",
+        "transition-colors hover:border-border-strong hover:bg-surface",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
       )}
     >
-      <div className="flex items-start justify-between gap-2">
-        <CapabilityLogo src={logoSrc} name={item.name} />
-        <div className="flex items-center gap-1.5">
+      <CapabilityLogo src={logoSrc} name={item.name} size="sm" />
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <h3 className="truncate text-sm font-medium text-fg">{item.name}</h3>
           {item.enabled ? (
-            <span className="inline-flex items-center gap-1 text-2xs font-medium text-status-idle">
+            <span className="inline-flex shrink-0 items-center gap-1 text-2xs font-medium text-status-idle">
               <span className="size-1.5 rounded-full bg-status-idle" />
               Enabled
             </span>
           ) : null}
         </div>
-      </div>
-
-      <div className="min-w-0 flex-1">
-        <h3 className="truncate text-sm font-medium text-fg">{item.name}</h3>
-        <p className="mt-1 line-clamp-2 text-xs leading-5 text-fg-muted">
+        <p className="mt-0.5 truncate text-xs text-fg-muted">
           {item.description ?? "No description provided."}
         </p>
       </div>
-
-      <div className="flex items-center gap-2 text-2xs text-fg-subtle">
+      <div className="hidden shrink-0 items-center gap-2 text-2xs text-fg-subtle sm:flex">
         <span className="truncate">{capabilityKindLabel(item.kind)}</span>
         {authHint ? (
           <>

--- a/apps/web/src/components/capabilities/google-drive-connector-card.tsx
+++ b/apps/web/src/components/capabilities/google-drive-connector-card.tsx
@@ -1,4 +1,4 @@
-import { FolderOpenIcon, HardDriveIcon, Loader2Icon } from "lucide-react";
+import { FolderOpenIcon, Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -375,7 +375,7 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
   return (
     <>
       <section className="mt-5 rounded-lg border border-border bg-surface/35 p-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 gap-3">
             <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border bg-bg">
               <img
@@ -402,26 +402,15 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
             ) : connection && accountState.state !== "disconnected" ? (
               <>
                 {accountState.state === "connected" ? (
-                  <>
-                    <Button
-                      type="button"
-                      size="sm"
-                      disabled={busy || !canWrite}
-                      onClick={openBrowser}
-                    >
-                      <FolderOpenIcon className="size-3.5" />
-                      {savedSources.length > 0 ? "Manage folders" : "Connect folders"}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="sm"
-                      disabled={busy || !canWrite}
-                      onClick={() => void transitionLifecycle("pause")}
-                    >
-                      Pause
-                    </Button>
-                  </>
+                  <Button
+                    type="button"
+                    size="sm"
+                    disabled={busy || !canWrite}
+                    onClick={openBrowser}
+                  >
+                    <FolderOpenIcon className="size-3.5" />
+                    {savedSources.length > 0 ? "Manage folders" : "Connect folders"}
+                  </Button>
                 ) : null}
                 {accountState.state === "paused" ? (
                   <Button
@@ -433,19 +422,20 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
                     Resume
                   </Button>
                 ) : null}
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  disabled={busy || !canWrite}
-                  onClick={() => void connect(true)}
-                >
-                  {accountState.state === "reconsent_required"
-                    ? "Re-consent"
-                    : accountState.state === "app_removed"
-                      ? "Retry reconnect"
-                      : "Reconnect"}
-                </Button>
+                {accountState.state !== "connected" && accountState.state !== "paused" ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    disabled={busy || !canWrite}
+                    onClick={() => void connect(true)}
+                  >
+                    {accountState.state === "reconsent_required"
+                      ? "Re-consent"
+                      : accountState.state === "app_removed"
+                        ? "Retry"
+                        : "Reconnect"}
+                  </Button>
+                ) : null}
                 <Button
                   type="button"
                   variant="ghost"
@@ -463,12 +453,8 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
                 disabled={busy || !canWrite}
                 onClick={() => void connect()}
               >
-                {busy ? (
-                  <Loader2Icon className="size-3.5 animate-spin" />
-                ) : (
-                  <HardDriveIcon className="size-3.5" />
-                )}
-                Connect Google Drive
+                {busy ? <Loader2Icon className="size-3.5 animate-spin" /> : null}
+                Connect
               </Button>
             )}
           </div>
@@ -505,9 +491,11 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
           </div>
         ) : null}
 
-        <Notice tone={stateNotice.tone} title={stateNotice.title} className="mt-3">
-          {stateNotice.description}
-        </Notice>
+        {stateNotice ? (
+          <Notice tone={stateNotice.tone} title={stateNotice.title} className="mt-3">
+            {stateNotice.description}
+          </Notice>
+        ) : null}
       </section>
 
       <ConfirmDialog
@@ -882,7 +870,7 @@ function googleDriveStateNotice(state: GoogleDriveAccountState["state"]): {
   tone: NoticeTone;
   title: string;
   description: string;
-} {
+} | null {
   if (state === "paused") {
     return {
       tone: "waiting",
@@ -921,24 +909,5 @@ function googleDriveStateNotice(state: GoogleDriveAccountState["state"]): {
         "Reconnect with the same Google account and approve the requested read access for configured locations.",
     };
   }
-  if (state === "disconnected") {
-    return {
-      tone: "muted",
-      title: "Google Drive is disconnected",
-      description:
-        "OpenGeni will not use this local connection. You can connect a different Google account; Google may still list the prior project-wide OAuth grant.",
-    };
-  }
-  if (state === "connected") {
-    return {
-      tone: "info",
-      title: "Google Drive is connected",
-      description: "Folder setup works locally; document import is not built yet.",
-    };
-  }
-  return {
-    tone: "waiting",
-    title: "Google Drive is not connected",
-    description: "Connect an account to select folders and Shared Drives.",
-  };
+  return null;
 }

--- a/apps/web/src/components/capabilities/google-drive-connector-card.tsx
+++ b/apps/web/src/components/capabilities/google-drive-connector-card.tsx
@@ -384,7 +384,7 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
 
   return (
     <>
-      <section className="mt-5 rounded-lg border border-border bg-surface/35 p-4">
+      <section className="mt-12 rounded-lg border border-border bg-surface/35 p-4">
         <div className="flex items-center gap-3">
           <div className="flex min-w-0 flex-1 gap-3">
             <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border bg-bg">

--- a/apps/web/src/components/capabilities/google-drive-connector-card.tsx
+++ b/apps/web/src/components/capabilities/google-drive-connector-card.tsx
@@ -377,8 +377,14 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
       <section className="mt-5 rounded-lg border border-border bg-surface/35 p-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex min-w-0 gap-3">
-            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-brand/10 text-brand">
-              <HardDriveIcon className="size-4" />
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border bg-bg">
+              <img
+                src="https://www.gstatic.com/images/branding/productlogos/drive_2026/v2/web-64dp/logo_drive_2026_color_2x_web_64dp.png"
+                alt=""
+                aria-hidden="true"
+                draggable={false}
+                className="size-5 object-contain"
+              />
             </div>
             <div className="min-w-0">
               <div className="text-sm font-medium">Google Drive</div>

--- a/apps/web/src/components/capabilities/google-drive-connector-card.tsx
+++ b/apps/web/src/components/capabilities/google-drive-connector-card.tsx
@@ -21,6 +21,7 @@ import {
   googleDriveAccountState,
   googleDriveConnectionMetadata,
   googleDriveDisconnectAttempt,
+  localConnectedGoogleDrivePreview,
   preferredGoogleDriveConnection,
   type GoogleDriveAccountState,
   type GoogleDriveDisconnectAttempt,
@@ -84,8 +85,17 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
   const [syncEnabled, setSyncEnabled] = useState(false);
   const [readPolicy, setReadPolicy] = useState<GoogleDriveReadPolicy>("allow");
 
-  const connection = useMemo(() => preferredGoogleDriveConnection(connections), [connections]);
-  const accountState = googleDriveAccountState(connection, !loading);
+  const previewConnection = useMemo(
+    () => localConnectedGoogleDrivePreview(window.location.search, workspaceId),
+    [workspaceId],
+  );
+  const connection = useMemo(
+    () => previewConnection ?? preferredGoogleDriveConnection(connections),
+    [connections, previewConnection],
+  );
+  const readOnly = previewConnection !== null;
+  const visibleLoading = loading && !readOnly;
+  const accountState = googleDriveAccountState(connection, readOnly || !loading);
   const metadata = connection
     ? (googleDriveConnectionMetadata(connection.metadata) ?? undefined)
     : undefined;
@@ -375,8 +385,8 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
   return (
     <>
       <section className="mt-5 rounded-lg border border-border bg-surface/35 p-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex min-w-0 gap-3">
+        <div className="flex items-center gap-3">
+          <div className="flex min-w-0 flex-1 gap-3">
             <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border bg-bg">
               <img
                 src="https://www.gstatic.com/images/branding/productlogos/drive_2026/v2/web-64dp/logo_drive_2026_color_2x_web_64dp.png"
@@ -394,7 +404,7 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
             </div>
           </div>
           <div className="flex shrink-0 flex-wrap gap-2">
-            {loading ? (
+            {visibleLoading ? (
               <Button type="button" variant="secondary" size="sm" disabled>
                 <Loader2Icon className="size-3.5 animate-spin" />
                 Loading
@@ -405,7 +415,7 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
                   <Button
                     type="button"
                     size="sm"
-                    disabled={busy || !canWrite}
+                    disabled={busy || !canWrite || readOnly}
                     onClick={openBrowser}
                   >
                     <FolderOpenIcon className="size-3.5" />
@@ -416,7 +426,7 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
                   <Button
                     type="button"
                     size="sm"
-                    disabled={busy || !canWrite}
+                    disabled={busy || !canWrite || readOnly}
                     onClick={() => void transitionLifecycle("resume")}
                   >
                     Resume
@@ -426,7 +436,7 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
                   <Button
                     type="button"
                     size="sm"
-                    disabled={busy || !canWrite}
+                    disabled={busy || !canWrite || readOnly}
                     onClick={() => void connect(true)}
                   >
                     {accountState.state === "reconsent_required"
@@ -440,7 +450,7 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
                   type="button"
                   variant="ghost"
                   size="sm"
-                  disabled={busy || !canWrite}
+                  disabled={busy || !canWrite || readOnly}
                   onClick={() => setDisconnectOpen(true)}
                 >
                   Disconnect
@@ -450,7 +460,7 @@ export function GoogleDriveConnectorCard({ workspaceId }: { workspaceId: string 
               <Button
                 type="button"
                 size="sm"
-                disabled={busy || !canWrite}
+                disabled={busy || !canWrite || readOnly}
                 onClick={() => void connect()}
               >
                 {busy ? <Loader2Icon className="size-3.5 animate-spin" /> : null}

--- a/apps/web/src/components/capabilities/personal-slack-account-card.test.tsx
+++ b/apps/web/src/components/capabilities/personal-slack-account-card.test.tsx
@@ -6,7 +6,10 @@ import { createRoot } from "react-dom/client";
 
 import type { PersonalSlackAccountState } from "@/lib/personal-slack";
 import type { ConnectionMetadata } from "@/types";
-import { PersonalSlackAccountCard } from "./personal-slack-account-card";
+import {
+  PersonalSlackAccountCard,
+  personalSlackAccountStatusLabel,
+} from "./personal-slack-account-card";
 
 beforeAll(() => {
   GlobalRegistrator.register();
@@ -79,6 +82,37 @@ async function renderCard(accountState: PersonalSlackAccountState) {
 }
 
 describe("PersonalSlackAccountCard", () => {
+  test("keeps the embedded control free of repeated status and explanation copy", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    try {
+      const state: PersonalSlackAccountState = { state: "not_connected" };
+      await act(async () => {
+        root.render(
+          <PersonalSlackAccountCard
+            available
+            canManage
+            busy={false}
+            accountState={state}
+            embedded
+            onConnect={() => {}}
+            onReconnect={() => {}}
+            onDisconnect={() => {}}
+          />,
+        );
+      });
+
+      expect(personalSlackAccountStatusLabel(state, true)).toBe("Not connected");
+      expect(container.textContent).toContain("Connect my Slack account");
+      expect(container.textContent).not.toContain("Not connected");
+      expect(container.textContent).not.toContain("Connect only when");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
   test("renders a subject-owned status without exposing its private row id", async () => {
     const rendered = await renderCard({
       state: "connected",
@@ -96,13 +130,11 @@ describe("PersonalSlackAccountCard", () => {
       expect(rendered.container.textContent).not.toContain("Required bot scopes");
 
       const buttons = [...rendered.container.querySelectorAll<HTMLButtonElement>("button")];
-      await act(async () =>
-        buttons.find((button) => button.textContent?.includes("Reconnect"))!.click(),
-      );
+      expect(buttons.some((button) => button.textContent?.includes("Reconnect"))).toBe(false);
       await act(async () =>
         buttons.find((button) => button.textContent?.includes("Disconnect"))!.click(),
       );
-      expect(rendered.onReconnect).toHaveBeenCalledTimes(1);
+      expect(rendered.onReconnect).not.toHaveBeenCalled();
       expect(rendered.onDisconnect).toHaveBeenCalledTimes(1);
       expect(rendered.onConnect).not.toHaveBeenCalled();
     } finally {

--- a/apps/web/src/components/capabilities/personal-slack-account-card.test.tsx
+++ b/apps/web/src/components/capabilities/personal-slack-account-card.test.tsx
@@ -113,6 +113,40 @@ describe("PersonalSlackAccountCard", () => {
     }
   });
 
+  test("keeps a connected embedded control to the single disconnect action", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(
+          <PersonalSlackAccountCard
+            available
+            canManage
+            busy={false}
+            accountState={{
+              state: "connected",
+              connection: connection(),
+              accessTokenRefreshDue: false,
+            }}
+            embedded
+            onConnect={() => {}}
+            onReconnect={() => {}}
+            onDisconnect={() => {}}
+          />,
+        );
+      });
+
+      const buttons = [...container.querySelectorAll<HTMLButtonElement>("button")];
+      expect(buttons.map((button) => button.textContent?.trim())).toEqual(["Disconnect"]);
+      expect(container.querySelector("details")).toBeNull();
+      expect(container.textContent).not.toContain("Connection details");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
   test("renders a subject-owned status without exposing its private row id", async () => {
     const rendered = await renderCard({
       state: "connected",

--- a/apps/web/src/components/capabilities/personal-slack-account-card.test.tsx
+++ b/apps/web/src/components/capabilities/personal-slack-account-card.test.tsx
@@ -86,7 +86,10 @@ describe("PersonalSlackAccountCard", () => {
       accessTokenRefreshDue: false,
     });
     try {
-      expect(rendered.container.textContent).toContain("Personal · only you");
+      expect(rendered.container.textContent).toContain("Personal Slack access");
+      expect(rendered.container.textContent).toContain(
+        "This connection belongs only to your account",
+      );
       expect(rendered.container.textContent).toContain("Connected");
       expect(rendered.container.textContent).toContain("search:read.public, chat:write");
       expect(rendered.container.textContent).not.toContain("11111111-1111-4111-8111-111111111111");
@@ -115,7 +118,9 @@ describe("PersonalSlackAccountCard", () => {
     });
     try {
       expect(refreshPending.container.textContent).toContain("Connected · refresh pending");
-      expect(refreshPending.container.textContent).toContain("refresh it automatically on use");
+      expect(refreshPending.container.textContent).toContain(
+        "refresh this connection automatically",
+      );
     } finally {
       await refreshPending.unmount();
     }
@@ -127,7 +132,7 @@ describe("PersonalSlackAccountCard", () => {
     });
     try {
       expect(reconnect.container.textContent).toContain("Reconnect required");
-      expect(reconnect.container.textContent).toContain("expired and could not be refreshed");
+      expect(reconnect.container.textContent).toContain("connection expired");
     } finally {
       await reconnect.unmount();
     }

--- a/apps/web/src/components/capabilities/personal-slack-account-card.test.tsx
+++ b/apps/web/src/components/capabilities/personal-slack-account-card.test.tsx
@@ -6,10 +6,7 @@ import { createRoot } from "react-dom/client";
 
 import type { PersonalSlackAccountState } from "@/lib/personal-slack";
 import type { ConnectionMetadata } from "@/types";
-import {
-  PersonalSlackAccountCard,
-  personalSlackAccountStatusLabel,
-} from "./personal-slack-account-card";
+import { PersonalSlackAccountCard } from "./personal-slack-account-card";
 
 beforeAll(() => {
   GlobalRegistrator.register();
@@ -103,8 +100,7 @@ describe("PersonalSlackAccountCard", () => {
         );
       });
 
-      expect(personalSlackAccountStatusLabel(state, true)).toBe("Not connected");
-      expect(container.textContent).toContain("Connect my Slack account");
+      expect(container.textContent).toContain("Connect");
       expect(container.textContent).not.toContain("Not connected");
       expect(container.textContent).not.toContain("Connect only when");
     } finally {
@@ -209,7 +205,7 @@ describe("PersonalSlackAccountCard", () => {
     });
     try {
       expect(disconnected.container.textContent).toContain("Disconnected");
-      expect(disconnected.container.textContent).toContain("Reconnect my Slack account");
+      expect(disconnected.container.textContent).toContain("Reconnect");
       expect(disconnected.container.textContent).not.toContain("DisconnectDisconnect");
     } finally {
       await disconnected.unmount();

--- a/apps/web/src/components/capabilities/personal-slack-account-card.tsx
+++ b/apps/web/src/components/capabilities/personal-slack-account-card.tsx
@@ -18,6 +18,7 @@ export function PersonalSlackAccountCard({
   canManage,
   busy,
   accountState,
+  embedded = false,
   onConnect,
   onReconnect,
   onDisconnect,
@@ -26,6 +27,7 @@ export function PersonalSlackAccountCard({
   canManage: boolean;
   busy: boolean;
   accountState: PersonalSlackAccountState;
+  embedded?: boolean;
   onConnect: () => void;
   onReconnect: () => void;
   onDisconnect: () => void;
@@ -40,77 +42,45 @@ export function PersonalSlackAccountCard({
 
   return (
     <section
-      className="rounded-xl border border-brand/25 bg-brand/[0.035] p-4"
-      aria-labelledby="personal-slack-heading"
+      className={cn(!embedded && "rounded-lg border border-border bg-bg/40 p-3")}
+      aria-label={embedded ? "Personal Slack access" : undefined}
+      aria-labelledby={embedded ? undefined : "personal-slack-heading"}
     >
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex min-w-0 items-start gap-3">
-          <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-brand/10 text-brand">
-            <UserRoundIcon className="size-4" />
-          </span>
+      {embedded ? (
+        <div
+          className={cn(
+            "flex items-center gap-1.5 text-xs font-medium",
+            view.attention ? "text-status-waiting" : "text-fg-muted",
+          )}
+        >
+          <view.Icon className={cn("size-4 shrink-0", !view.attention && "text-brand")} />
+          {view.label}
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <h3 id="personal-slack-heading" className="text-sm font-semibold text-fg">
-                Your Slack account
-              </h3>
-              <span className="rounded-full border border-brand/20 bg-brand/10 px-2 py-0.5 text-2xs font-medium text-brand">
-                Personal · only you
-              </span>
-            </div>
+            <h3 id="personal-slack-heading" className="text-sm font-semibold text-fg">
+              Personal Slack access
+            </h3>
             <p className="mt-1 max-w-xl text-xs leading-5 text-fg-muted">
-              Authorize your own Slack identity for interactive tools. Messages act as you using
-              @OpenGeni; workspace bot installations and scheduled tasks never borrow this grant.
+              Let agents use Slack as you. This connection belongs only to your account.
             </p>
           </div>
-        </div>
-      </div>
-
-      <div
-        className={cn(
-          "mt-4 rounded-lg border p-3",
-          view.attention
-            ? "border-status-waiting/30 bg-status-waiting/5"
-            : "border-border bg-bg/55",
-        )}
-      >
-        <div className="flex items-start gap-3">
-          <view.Icon
+          <div
             className={cn(
-              "mt-0.5 size-5 shrink-0",
-              view.attention ? "text-status-waiting" : "text-brand",
+              "flex shrink-0 items-center gap-1.5 text-xs font-medium",
+              view.attention ? "text-status-waiting" : "text-fg-muted",
             )}
-          />
-          <div className="min-w-0">
-            <p className="text-sm font-semibold text-fg">{view.label}</p>
-            <p className="mt-0.5 text-xs leading-5 text-fg-muted">{view.description}</p>
+          >
+            <view.Icon className={cn("size-4 shrink-0", !view.attention && "text-brand")} />
+            {view.label}
           </div>
         </div>
-      </div>
+      )}
 
-      {connection ? (
-        <details className="group mt-3 border-t border-border/70 pt-3">
-          <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
-            <ShieldCheckIcon className="size-3" />
-            <span>Personal authorization details</span>
-          </summary>
-          <dl className="mt-3 grid gap-2 rounded-md bg-bg/50 p-3 text-2xs">
-            <ConnectionFact label="Ownership">Only your signed-in OpenGeni identity</ConnectionFact>
-            <ConnectionFact label="Granted scopes">
-              {connection.grantedScopes.length > 0
-                ? connection.grantedScopes.join(", ")
-                : "Provider-managed; none reported"}
-            </ConnectionFact>
-            <ConnectionFact label="Last used">
-              {formatConnectionDate(connection.lastUsedAt)}
-            </ConnectionFact>
-            <ConnectionFact label="Access expiry">
-              {formatConnectionDate(connection.expiresAt)}
-            </ConnectionFact>
-          </dl>
-        </details>
-      ) : null}
+      <p className="mt-2 text-xs leading-5 text-fg-muted">{view.description}</p>
 
-      <div className="mt-4 flex flex-wrap items-center gap-2">
+      <div className="mt-3 flex flex-wrap items-center gap-2">
         {accountState.state === "not_connected" ? (
           <Button type="button" disabled={!canManage || !canStartOAuth || busy} onClick={onConnect}>
             {busy ? <Loader2Icon className="animate-spin" /> : <UserRoundIcon />}
@@ -148,6 +118,29 @@ export function PersonalSlackAccountCard({
           Connection management permission is required to change this personal link.
         </p>
       ) : null}
+
+      {connection ? (
+        <details className="group mt-3 border-t border-border/70 pt-3">
+          <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
+            <ShieldCheckIcon className="size-3" />
+            <span>Connection details</span>
+          </summary>
+          <dl className="mt-3 grid gap-2 rounded-md bg-bg/50 p-3 text-2xs">
+            <ConnectionFact label="Owner">Your account only</ConnectionFact>
+            <ConnectionFact label="Permissions">
+              {connection.grantedScopes.length > 0
+                ? connection.grantedScopes.join(", ")
+                : "Managed by Slack"}
+            </ConnectionFact>
+            <ConnectionFact label="Last used">
+              {formatConnectionDate(connection.lastUsedAt)}
+            </ConnectionFact>
+            <ConnectionFact label="Expires">
+              {formatConnectionDate(connection.expiresAt)}
+            </ConnectionFact>
+          </dl>
+        </details>
+      ) : null}
     </section>
   );
 }
@@ -182,7 +175,7 @@ function personalSlackStateView(
     case "not_connected":
       return {
         label: "Not connected",
-        description: "Connect intentionally when you want agents to use your own Slack identity.",
+        description: "Connect only when an agent needs to work through your Slack account.",
         attention: false,
         Icon: UserRoundIcon,
       };
@@ -191,13 +184,13 @@ function personalSlackStateView(
         ? {
             label: "Connected · refresh pending",
             description:
-              "The access token reached its expiry time. OpenGeni will refresh it automatically on use; reconnect only if Slack rejects that refresh.",
+              "OpenGeni will refresh this connection automatically when it is next used.",
             attention: false,
             Icon: Clock3Icon,
           }
         : {
             label: "Connected",
-            description: "Your subject-owned Slack authorization is ready for interactive use.",
+            description: "Agents can use your Slack identity when a task needs it.",
             attention: false,
             Icon: CheckCircle2Icon,
           };
@@ -206,18 +199,17 @@ function personalSlackStateView(
         label: "Reconnect required",
         description:
           state.reason === "expired"
-            ? "The authorization expired and could not be refreshed. Reconnect your Slack account to restore access."
+            ? "The connection expired. Reconnect it to restore access."
             : state.reason === "provider_rejected"
-              ? "Slack no longer accepts this authorization. Reconnect your account to restore access."
-              : "OpenGeni could not use this authorization. Reconnect rather than reusing stale credentials.",
+              ? "Slack no longer accepts this connection. Reconnect it to restore access."
+              : "OpenGeni could not use this connection. Reconnect it to restore access.",
         attention: true,
         Icon: AlertTriangleIcon,
       };
     case "disconnected":
       return {
         label: "Disconnected",
-        description:
-          "OpenGeni no longer uses this personal grant. Reconnect to use your Slack identity again.",
+        description: "Reconnect when you want agents to use your Slack identity again.",
         attention: false,
         Icon: UnplugIcon,
       };

--- a/apps/web/src/components/capabilities/personal-slack-account-card.tsx
+++ b/apps/web/src/components/capabilities/personal-slack-account-card.tsx
@@ -82,7 +82,7 @@ export function PersonalSlackAccountCard({
             onClick={onConnect}
           >
             {busy ? <Loader2Icon className="animate-spin" /> : <UserRoundIcon />}
-            Connect my Slack account
+            Connect
           </Button>
         ) : accountState.state === "reconnect_required" || accountState.state === "disconnected" ? (
           <Button
@@ -92,7 +92,7 @@ export function PersonalSlackAccountCard({
             onClick={onReconnect}
           >
             {busy ? <Loader2Icon className="animate-spin" /> : <RefreshCwIcon />}
-            Reconnect my Slack account
+            Reconnect
           </Button>
         ) : null}
         {canDisconnect ? (
@@ -139,13 +139,6 @@ export function PersonalSlackAccountCard({
       ) : null}
     </section>
   );
-}
-
-export function personalSlackAccountStatusLabel(
-  state: PersonalSlackAccountState,
-  available: boolean,
-): string {
-  return personalSlackStateView(state, available).label;
 }
 
 function personalSlackStateView(

--- a/apps/web/src/components/capabilities/personal-slack-account-card.tsx
+++ b/apps/web/src/components/capabilities/personal-slack-account-card.tsx
@@ -115,7 +115,7 @@ export function PersonalSlackAccountCard({
         </p>
       ) : null}
 
-      {connection ? (
+      {connection && !embedded ? (
         <details className="group mt-3 border-t border-border/70 pt-3">
           <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
             <ShieldCheckIcon className="size-3" />

--- a/apps/web/src/components/capabilities/personal-slack-account-card.tsx
+++ b/apps/web/src/components/capabilities/personal-slack-account-card.tsx
@@ -19,6 +19,7 @@ export function PersonalSlackAccountCard({
   busy,
   accountState,
   embedded = false,
+  readOnly = false,
   onConnect,
   onReconnect,
   onDisconnect,
@@ -28,6 +29,7 @@ export function PersonalSlackAccountCard({
   busy: boolean;
   accountState: PersonalSlackAccountState;
   embedded?: boolean;
+  readOnly?: boolean;
   onConnect: () => void;
   onReconnect: () => void;
   onDisconnect: () => void;
@@ -46,17 +48,7 @@ export function PersonalSlackAccountCard({
       aria-label={embedded ? "Personal Slack access" : undefined}
       aria-labelledby={embedded ? undefined : "personal-slack-heading"}
     >
-      {embedded ? (
-        <div
-          className={cn(
-            "flex items-center gap-1.5 text-xs font-medium",
-            view.attention ? "text-status-waiting" : "text-fg-muted",
-          )}
-        >
-          <view.Icon className={cn("size-4 shrink-0", !view.attention && "text-brand")} />
-          {view.label}
-        </div>
-      ) : (
+      {!embedded ? (
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
             <h3 id="personal-slack-heading" className="text-sm font-semibold text-fg">
@@ -76,23 +68,27 @@ export function PersonalSlackAccountCard({
             {view.label}
           </div>
         </div>
-      )}
+      ) : null}
 
-      <p className="mt-2 text-xs leading-5 text-fg-muted">{view.description}</p>
+      {!embedded ? (
+        <p className="mt-2 text-xs leading-5 text-fg-muted">{view.description}</p>
+      ) : null}
 
-      <div className="mt-3 flex flex-wrap items-center gap-2">
+      <div className={cn("flex flex-wrap items-center gap-2", !embedded && "mt-3")}>
         {accountState.state === "not_connected" ? (
-          <Button type="button" disabled={!canManage || !canStartOAuth || busy} onClick={onConnect}>
+          <Button
+            type="button"
+            disabled={readOnly || !canManage || !canStartOAuth || busy}
+            onClick={onConnect}
+          >
             {busy ? <Loader2Icon className="animate-spin" /> : <UserRoundIcon />}
             Connect my Slack account
           </Button>
-        ) : accountState.state === "connected" ||
-          accountState.state === "reconnect_required" ||
-          accountState.state === "disconnected" ? (
+        ) : accountState.state === "reconnect_required" || accountState.state === "disconnected" ? (
           <Button
             type="button"
             variant={accountState.state === "reconnect_required" ? "default" : "outline"}
-            disabled={!canManage || !canStartOAuth || busy}
+            disabled={readOnly || !canManage || !canStartOAuth || busy}
             onClick={onReconnect}
           >
             {busy ? <Loader2Icon className="animate-spin" /> : <RefreshCwIcon />}
@@ -104,7 +100,7 @@ export function PersonalSlackAccountCard({
             type="button"
             variant="ghost"
             className="text-status-failed hover:bg-status-failed/10 hover:text-status-failed"
-            disabled={!canManage || busy}
+            disabled={readOnly || !canManage || busy}
             onClick={onDisconnect}
           >
             <UnplugIcon />
@@ -113,7 +109,7 @@ export function PersonalSlackAccountCard({
         ) : null}
       </div>
 
-      {!canManage ? (
+      {!canManage && !readOnly ? (
         <p className="mt-3 text-2xs text-fg-subtle">
           Connection management permission is required to change this personal link.
         </p>
@@ -143,6 +139,13 @@ export function PersonalSlackAccountCard({
       ) : null}
     </section>
   );
+}
+
+export function personalSlackAccountStatusLabel(
+  state: PersonalSlackAccountState,
+  available: boolean,
+): string {
+  return personalSlackStateView(state, available).label;
 }
 
 function personalSlackStateView(

--- a/apps/web/src/components/capabilities/slack-reaction-summon-card.tsx
+++ b/apps/web/src/components/capabilities/slack-reaction-summon-card.tsx
@@ -120,20 +120,20 @@ export function SlackReactionSummonCard({
     else selected.delete(channelId);
     setDraft({
       ...draft,
-      channelPolicy: { mode: "allowlist", channelIds: [...selected].slice(0, 100) },
+      channelPolicy: {
+        mode: "allowlist",
+        channelIds: [...selected].slice(0, 100),
+      },
     });
   }
 
   return (
-    <div className="mt-4 rounded-lg border border-border bg-bg/40 p-3">
+    <div className="rounded-lg border border-border bg-bg/40 p-3">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <p className="text-xs font-semibold text-fg">Summon OpenGeni with an emoji</p>
+          <p className="text-xs font-semibold text-fg">Emoji shortcut</p>
           <p className="mt-1 max-w-2xl text-2xs leading-5 text-fg-muted">
-            Disabled by default. A linked, authorized user can react to one message; OpenGeni reads
-            only that message and bounded containing-thread context, then replies in the same
-            thread. This does not authorize channel ingestion or automatic Knowledge, Memory,
-            preference, or policy writes.
+            React with an emoji to ask OpenGeni about a message.
           </p>
         </div>
         <label className="flex items-center gap-2 text-xs font-medium text-fg">
@@ -152,9 +152,8 @@ export function SlackReactionSummonCard({
           <div className="flex items-start gap-2">
             <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-warning" />
             <p className="text-2xs leading-5 text-fg-muted">
-              <strong className="text-fg">Reinstall required.</strong> This installation is missing
-              the least-privilege <code>reactions:read</code> scope. Existing Slack tools remain
-              available, but reaction summon stays disabled until an admin reinstalls the bot.
+              <strong className="text-fg">Reinstall required.</strong> Slack has not granted access
+              to emoji reactions yet.
             </p>
           </div>
           {canManage ? (
@@ -168,7 +167,7 @@ export function SlackReactionSummonCard({
 
       <div className="mt-3 grid gap-3 sm:grid-cols-2">
         <label className="text-2xs font-medium text-fg-muted">
-          Emoji name
+          Emoji
           <Input
             className="mt-1"
             value={draft.emoji}
@@ -177,13 +176,10 @@ export function SlackReactionSummonCard({
             placeholder="genie"
             onChange={(event) => setDraft({ ...draft, emoji: event.target.value.trim() })}
           />
-          <span className="mt-1 block font-normal text-fg-subtle">
-            Exact Slack emoji name without surrounding colons, for example <code>genie</code>.
-          </span>
         </label>
 
         <label className="text-2xs font-medium text-fg-muted">
-          Conversation policy
+          Where it works
           <select
             className="mt-1 h-9 w-full rounded-md border border-border bg-bg px-3 text-xs text-fg"
             value={draft.channelPolicy.mode}
@@ -198,12 +194,9 @@ export function SlackReactionSummonCard({
               })
             }
           >
-            <option value="bot_member">Every conversation where the bot is already a member</option>
-            <option value="allowlist">Only selected conversations</option>
+            <option value="bot_member">Anywhere OpenGeni is a member</option>
+            <option value="allowlist">Selected conversations</option>
           </select>
-          <span className="mt-1 block font-normal text-fg-subtle">
-            OpenGeni never auto-joins a channel and shared Slack Connect conversations fail closed.
-          </span>
         </label>
       </div>
 
@@ -241,6 +234,10 @@ export function SlackReactionSummonCard({
           )}
         </div>
       ) : null}
+
+      <p className="mt-3 text-2xs leading-5 text-fg-subtle">
+        This reads the selected message and its thread. It does not sync the channel.
+      </p>
 
       {canManage ? (
         <div className="mt-3 flex justify-end">

--- a/apps/web/src/components/capabilities/slack-reaction-summon-card.tsx
+++ b/apps/web/src/components/capabilities/slack-reaction-summon-card.tsx
@@ -9,22 +9,23 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useAppContext } from "@/context";
 import type { ConnectionMetadata } from "@/types";
+
+const OPENGENI_REACTION_EMOJI = "genie" as const;
 
 export function SlackReactionSummonCard({
   workspaceId,
   connection,
   canManage,
   installBusy,
-  onReinstall,
+  onUpdatePermissions,
 }: {
   workspaceId: string;
   connection: ConnectionMetadata;
   canManage: boolean;
   installBusy: boolean;
-  onReinstall: () => void;
+  onUpdatePermissions: () => void;
 }) {
   const context = useAppContext();
   const workspace = context.workspaces.find((candidate) => candidate.id === workspaceId);
@@ -91,7 +92,7 @@ export function SlackReactionSummonCard({
 
   async function save() {
     if (draft.enabled && !installReady) {
-      toast.error("Reinstall the Slack bot before enabling reaction summon");
+      toast.error("Update Slack permissions before enabling the emoji shortcut");
       return;
     }
     if (
@@ -104,10 +105,14 @@ export function SlackReactionSummonCard({
     }
     setSaving(true);
     try {
+      const next = { ...draft, emoji: OPENGENI_REACTION_EMOJI };
       const updated = await context.updateWorkspaceSettings(workspaceId, {
-        slackReactionSummon: draft,
+        slackReactionSummon: next,
       });
-      if (updated) toast.success("Slack reaction summon settings saved");
+      if (updated) {
+        setDraft(next);
+        toast.success("Slack emoji shortcut saved");
+      }
     } finally {
       setSaving(false);
     }
@@ -133,7 +138,7 @@ export function SlackReactionSummonCard({
         <div>
           <p className="text-xs font-semibold text-fg">Emoji shortcut</p>
           <p className="mt-1 max-w-2xl text-2xs leading-5 text-fg-muted">
-            React with an emoji to ask OpenGeni about a message.
+            React with 🧞 to ask OpenGeni about a message.
           </p>
         </div>
         <label className="flex items-center gap-2 text-xs font-medium text-fg">
@@ -152,32 +157,19 @@ export function SlackReactionSummonCard({
           <div className="flex items-start gap-2">
             <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-warning" />
             <p className="text-2xs leading-5 text-fg-muted">
-              <strong className="text-fg">Reinstall required.</strong> Slack has not granted access
-              to emoji reactions yet.
+              Slack needs permission to read the 🧞 reaction before this shortcut can be enabled.
             </p>
           </div>
           {canManage ? (
-            <Button type="button" size="sm" disabled={installBusy} onClick={onReinstall}>
+            <Button type="button" size="sm" disabled={installBusy} onClick={onUpdatePermissions}>
               {installBusy ? <Loader2Icon className="animate-spin" /> : null}
-              Reinstall Slack bot
+              Update Slack permissions
             </Button>
           ) : null}
         </div>
       ) : null}
 
-      <div className="mt-3 grid gap-3 sm:grid-cols-2">
-        <label className="text-2xs font-medium text-fg-muted">
-          Emoji
-          <Input
-            className="mt-1"
-            value={draft.emoji}
-            disabled={!canManage || saving}
-            maxLength={64}
-            placeholder="genie"
-            onChange={(event) => setDraft({ ...draft, emoji: event.target.value.trim() })}
-          />
-        </label>
-
+      <div className="mt-3">
         <label className="text-2xs font-medium text-fg-muted">
           Where it works
           <select
@@ -243,7 +235,7 @@ export function SlackReactionSummonCard({
         <div className="mt-3 flex justify-end">
           <Button type="button" size="sm" disabled={saving} onClick={() => void save()}>
             {saving ? <Loader2Icon className="animate-spin" /> : null}
-            Save reaction settings
+            Save
           </Button>
         </div>
       ) : (

--- a/apps/web/src/lib/google-drive-connection.test.ts
+++ b/apps/web/src/lib/google-drive-connection.test.ts
@@ -5,6 +5,7 @@ import {
   googleDriveAccountState,
   googleDriveConnections,
   googleDriveDisconnectAttempt,
+  localConnectedGoogleDrivePreview,
   preferredGoogleDriveConnection,
 } from "./google-drive-connection";
 
@@ -59,6 +60,24 @@ function lifecycle(
 }
 
 describe("Google Drive connection lifecycle projection", () => {
+  test("offers a local-only connected preview with realistic folder configuration", () => {
+    expect(
+      localConnectedGoogleDrivePreview(
+        "?previewGoogleDrive=connected",
+        "33333333-3333-4333-8333-333333333333",
+        false,
+      ),
+    ).toBeNull();
+
+    const preview = localConnectedGoogleDrivePreview(
+      "?previewGoogleDrive=connected",
+      "33333333-3333-4333-8333-333333333333",
+      true,
+    );
+    expect(googleDriveAccountState(preview, true).state).toBe("connected");
+    expect((preview?.metadata as GoogleDriveConnectionMetadata).selectedSources).toHaveLength(2);
+  });
+
   test("reuses a disconnect operation key only for the same connection generation", () => {
     const first = googleDriveDisconnectAttempt(connection(), null, () => "disconnect-1");
     expect(first).toEqual({

--- a/apps/web/src/lib/google-drive-connection.test.ts
+++ b/apps/web/src/lib/google-drive-connection.test.ts
@@ -75,7 +75,7 @@ describe("Google Drive connection lifecycle projection", () => {
       true,
     );
     expect(googleDriveAccountState(preview, true).state).toBe("connected");
-    expect((preview?.metadata as GoogleDriveConnectionMetadata).selectedSources).toHaveLength(2);
+    expect((preview!.metadata as GoogleDriveConnectionMetadata).selectedSources).toHaveLength(2);
   });
 
   test("reuses a disconnect operation key only for the same connection generation", () => {

--- a/apps/web/src/lib/google-drive-connection.ts
+++ b/apps/web/src/lib/google-drive-connection.ts
@@ -6,6 +6,71 @@ import type {
 
 const GOOGLE_DRIVE_PROVIDER_DOMAIN = "googleapis.com";
 
+export function localConnectedGoogleDrivePreview(
+  search: string,
+  workspaceId: string,
+  enabled = import.meta.env.DEV,
+): ConnectionMetadata | null {
+  if (!enabled || new URLSearchParams(search).get("previewGoogleDrive") !== "connected") {
+    return null;
+  }
+
+  const now = new Date().toISOString();
+  return {
+    id: "00000000-0000-4000-8000-000000000011",
+    accountId: "00000000-0000-4000-8000-000000000001",
+    workspaceId,
+    subjectId: "preview-user",
+    providerDomain: GOOGLE_DRIVE_PROVIDER_DOMAIN,
+    kind: "oauth2",
+    status: "active",
+    grantedScopes: ["https://www.googleapis.com/auth/drive.readonly"],
+    expiresAt: null,
+    lastRefreshAt: now,
+    lastUsedAt: now,
+    lastError: null,
+    version: 1,
+    metadata: {
+      credentialRole: "google_drive_metadata",
+      credentialLabel: "Google Drive metadata browser",
+      googlePermissionId: "preview-permission",
+      googleEmail: "bendik@cloudgeni.ai",
+      googleDisplayName: "Bendik Nyheim",
+      verifiedAt: now,
+      accessMode: "readonly",
+      lifecycle: { state: "active", recoverable: true, observedAt: now },
+      selectedSources: [
+        {
+          id: "preview-cloudgeni-drive",
+          name: "CloudGeni",
+          mimeType: "application/vnd.google-apps.folder",
+          driveId: "preview-cloudgeni-drive",
+          syncCadence: "hourly",
+          syncEnabled: true,
+          configGeneration: 1,
+          readPolicy: "allow",
+          selectedAt: now,
+        },
+        {
+          id: "preview-research-folder",
+          name: "Research",
+          mimeType: "application/vnd.google-apps.folder",
+          driveId: "preview-cloudgeni-drive",
+          syncCadence: "hourly",
+          syncEnabled: true,
+          configGeneration: 1,
+          readPolicy: "allow",
+          selectedAt: now,
+        },
+      ],
+    },
+    createdBySubjectId: "preview-user",
+    updatedBySubjectId: "preview-user",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
 export type GoogleDriveAccountState =
   | { state: "unverified" }
   | { state: "not_connected" }

--- a/apps/web/src/routes/agent-brain-overview.tsx
+++ b/apps/web/src/routes/agent-brain-overview.tsx
@@ -4,481 +4,230 @@ import {
   ArrowRightIcon,
   BookOpenIcon,
   BrainCircuitIcon,
+  Building2Icon,
   FileSearchIcon,
-  HistoryIcon,
-  NetworkIcon,
-  ShieldCheckIcon,
+  SlidersHorizontalIcon,
 } from "lucide-react";
 import type { ReactNode } from "react";
 
-function formatDate(value: string | null): string {
-  if (!value) return "No activity";
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? "Unknown" : date.toLocaleString();
-}
-
-function humanize(value: string): string {
-  return value.replaceAll("_", " ").replace(/^./u, (character) => character.toUpperCase());
-}
-
-function OverviewPanel(props: { title: string; description?: string; children: ReactNode }) {
+function SummaryGroup(props: { title: string; children: ReactNode }) {
   return (
-    <section className="rounded-lg border border-border bg-surface p-4">
-      <h2 className="text-sm font-semibold text-fg">{props.title}</h2>
-      {props.description ? (
-        <p className="mt-1 text-xs leading-5 text-fg-muted">{props.description}</p>
-      ) : null}
-      <div className="mt-4">{props.children}</div>
+    <section aria-labelledby={`${props.title.toLowerCase().replaceAll(" ", "-")}-heading`}>
+      <div className="mb-4 px-0.5">
+        <h2
+          id={`${props.title.toLowerCase().replaceAll(" ", "-")}-heading`}
+          className="text-xs font-semibold uppercase tracking-wider text-fg-subtle"
+        >
+          {props.title}
+        </h2>
+      </div>
+      <div className="divide-y divide-border overflow-hidden rounded-lg border border-border bg-surface">
+        {props.children}
+      </div>
     </section>
   );
 }
 
-function AuthorityStatus(props: { children: ReactNode; tone?: "default" | "good" | "warning" }) {
-  const tone = props.tone ?? "default";
-  return (
-    <span
-      className={
-        tone === "good"
-          ? "rounded-full border border-status-success/30 bg-status-success/10 px-2 py-1 text-2xs font-medium text-status-success"
-          : tone === "warning"
-            ? "rounded-full border border-status-waiting/40 bg-status-waiting/10 px-2 py-1 text-2xs font-medium text-status-waiting"
-            : "rounded-full border border-border bg-surface-2/50 px-2 py-1 text-2xs font-medium text-fg-muted"
-      }
-    >
-      {props.children}
-    </span>
-  );
-}
-
-function AuthorityCard(props: {
+function SummaryRow(props: {
   icon: ReactNode;
-  eyebrow: string;
   title: string;
   description: string;
-  status: ReactNode;
-  statusTone?: "default" | "good" | "warning";
-  facts: Array<{ label: string; value: ReactNode }>;
-  children?: ReactNode;
+  status: string;
+  tone?: "default" | "warning";
   action?: ReactNode;
 }) {
   return (
-    <article className="flex min-h-full flex-col rounded-lg border border-border bg-surface p-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex min-w-0 items-start gap-3">
-          <span className="mt-0.5 rounded-md border border-brand/20 bg-brand/10 p-2 text-brand">
-            {props.icon}
+    <article className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center">
+      <span className="self-start rounded-md bg-brand/10 p-2 text-brand">{props.icon}</span>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <h3 className="text-sm font-medium text-fg">{props.title}</h3>
+          <span
+            className={
+              props.tone === "warning"
+                ? "text-xs font-medium text-status-waiting"
+                : "text-xs text-fg-muted"
+            }
+          >
+            {props.status}
           </span>
-          <div className="min-w-0">
-            <div className="text-2xs font-medium uppercase tracking-wider text-fg-subtle">
-              {props.eyebrow}
-            </div>
-            <h3 className="mt-1 text-sm font-semibold text-fg">{props.title}</h3>
-          </div>
         </div>
-        <AuthorityStatus tone={props.statusTone}>{props.status}</AuthorityStatus>
+        <p className="mt-1 text-xs leading-5 text-fg-muted">{props.description}</p>
       </div>
-      <p className="mt-3 text-xs leading-5 text-fg-muted">{props.description}</p>
-      <dl className="mt-4 grid gap-2 rounded-md border border-border/70 bg-surface-2/30 p-3 text-xs">
-        {props.facts.map((fact) => (
-          <div key={fact.label} className="grid gap-1 sm:grid-cols-[7rem_minmax(0,1fr)]">
-            <dt className="font-medium text-fg-subtle">{fact.label}</dt>
-            <dd className="min-w-0 text-fg-muted">{fact.value}</dd>
-          </div>
-        ))}
-      </dl>
-      {props.children ? <div className="mt-3">{props.children}</div> : null}
-      {props.action ? <div className="mt-auto pt-4">{props.action}</div> : null}
+      {props.action ? <div className="shrink-0 sm:ml-3">{props.action}</div> : null}
     </article>
   );
 }
 
-function DiagnosticsLink({ children, onOpen }: { children: ReactNode; onOpen: () => void }) {
+function FocusAction({
+  children,
+  view,
+  workspaceId,
+}: {
+  children: ReactNode;
+  view: "company" | "instructions" | "preferences";
+  workspaceId: string;
+}) {
   return (
-    <a
-      href="#brain-diagnostics"
+    <Link
+      to="/workspaces/$workspaceId/state"
+      params={{ workspaceId }}
+      search={{ view }}
       className="inline-flex items-center gap-1 text-xs font-medium text-brand hover:underline"
-      onClick={onOpen}
     >
       {children}
       <ArrowRightIcon className="size-3" />
-    </a>
+    </Link>
   );
 }
 
-function policyProjectedStatus(state: WorkspaceStateResponse): string {
-  const count = state.policy.activeHeads.length;
-  if (count === 0) return "No structured active heads";
-  return state.policy.activeHeadsTruncated ? `${count}+ active heads · partial` : `${count} active`;
+function RouteAction({
+  children,
+  to,
+  workspaceId,
+}: {
+  children: ReactNode;
+  to: "/workspaces/$workspaceId/documents" | "/workspaces/$workspaceId/memory";
+  workspaceId: string;
+}) {
+  return (
+    <Link
+      to={to}
+      params={{ workspaceId }}
+      search={{ from: "brain" }}
+      className="inline-flex items-center gap-1 text-xs font-medium text-brand hover:underline"
+    >
+      {children}
+      <ArrowRightIcon className="size-3" />
+    </Link>
+  );
 }
 
-function policyScopeSummary(state: WorkspaceStateResponse): string {
-  const globalCount = state.policy.activeHeads.filter((head) => head.scope === "global").length;
-  const roleCount = state.policy.activeHeads.filter((head) => head.scope === "role").length;
-  if (globalCount + roleCount === 0) return "No active structured targets";
-  const suffix = state.policy.activeHeadsTruncated ? " · shown subset" : "";
-  return `${globalCount} global · ${roleCount} role${suffix}`;
+function workspaceInstructionStatus(state: WorkspaceStateResponse): string {
+  if (state.policy.activeHeads.length > 0) {
+    const suffix = state.policy.activeHeadsTruncated ? "+" : "";
+    return `${state.policy.activeHeads.length}${suffix} active`;
+  }
+  if (state.policy.legacyRuntime.workspaceOverrideConfigured) {
+    return "Custom instructions configured";
+  }
+  return "Not set";
 }
 
-function sourceKindCount(state: WorkspaceStateResponse): number {
-  if (state.knowledge.availability === "unavailable") return 0;
-  return Object.values(state.knowledge.sourceKindCounts).filter((count) => count > 0).length;
+function documentStatus(state: WorkspaceStateResponse): {
+  status: string;
+  tone: "default" | "warning";
+} {
+  if (state.knowledge.availability === "unavailable") {
+    return { status: "Permission required", tone: "warning" };
+  }
+
+  const counts = state.knowledge.documentStatusCounts;
+  const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
+  const needsAttention = counts.failed + counts.queued + counts.indexing;
+  const parts = [`${total} document${total === 1 ? "" : "s"}`, `${counts.ready} ready`];
+  if (needsAttention > 0) parts.push(`${needsAttention} need attention`);
+  if (state.knowledge.coverage === "partial") parts.push("partial view");
+  return {
+    status: parts.join(" · "),
+    tone: needsAttention > 0 || state.knowledge.coverage === "partial" ? "warning" : "default",
+  };
+}
+
+function memoryStatus(state: WorkspaceStateResponse): {
+  status: string;
+  tone: "default" | "warning";
+} {
+  if (state.knowledge.availability === "unavailable") {
+    return { status: "Permission required", tone: "warning" };
+  }
+  const sample = state.knowledge.memorySample;
+  return {
+    status: sample.limitReached
+      ? `${sample.recordCount}+ recent records`
+      : `${sample.recordCount} recent record${sample.recordCount === 1 ? "" : "s"}`,
+    tone: sample.limitReached ? "warning" : "default",
+  };
 }
 
 export function BrainOverview({
   state,
   workspaceId,
-  onOpenDiagnostics,
+  companyProfileStatus,
 }: {
   state: WorkspaceStateResponse;
   workspaceId: string;
-  onOpenDiagnostics: () => void;
+  companyProfileStatus: { label: string; tone?: "default" | "warning" };
 }) {
-  const knowledge = state.knowledge;
-  const latestPolicyRevision = state.policy.latestRevision;
-  const processingDocumentCount =
-    knowledge.availability === "available"
-      ? knowledge.documentStatusCounts.queued + knowledge.documentStatusCounts.indexing
-      : 0;
-  const visibleDocumentCount =
-    knowledge.availability === "available"
-      ? Object.values(knowledge.documentStatusCounts).reduce((total, count) => total + count, 0)
-      : 0;
-  const agentVisibleMemoryCount =
-    knowledge.availability === "available"
-      ? knowledge.memorySample.statusCounts.active + knowledge.memorySample.statusCounts.approved
-      : 0;
+  const documents = documentStatus(state);
+  const memory = memoryStatus(state);
 
   return (
-    <div className="grid gap-5">
-      <section
-        aria-labelledby="agent-brain-model"
-        className="rounded-lg border border-brand/20 bg-brand/5 p-4"
-      >
-        <div className="flex items-start gap-3">
-          <span className="rounded-md bg-brand/10 p-2 text-brand">
-            <NetworkIcon className="size-4" />
-          </span>
-          <div>
-            <h2 id="agent-brain-model" className="text-sm font-semibold text-fg">
-              Four authorities, two ways agents use them
-            </h2>
-            <p className="mt-1 max-w-3xl text-xs leading-5 text-fg-muted">
-              Charter/policy and bounded preference descriptors are always-known governance.
-              Documents and Memory stay separate and are retrieved only when relevant. This page
-              projects those authorities; it is not another knowledge store and never merges or
-              rewrites their content.
-            </p>
-          </div>
-        </div>
-      </section>
+    <div className="grid gap-6">
+      <SummaryGroup title="Included automatically">
+        <SummaryRow
+          icon={<Building2Icon className="size-4" />}
+          title="Company profile & goals"
+          status={companyProfileStatus.label}
+          tone={companyProfileStatus.tone}
+          description="The essential company context every agent should know."
+          action={
+            <FocusAction view="company" workspaceId={workspaceId}>
+              Manage
+            </FocusAction>
+          }
+        />
+        <SummaryRow
+          icon={<BookOpenIcon className="size-4" />}
+          title="Workspace instructions"
+          status={workspaceInstructionStatus(state)}
+          description="How agents should work in this workspace."
+          action={
+            <FocusAction view="instructions" workspaceId={workspaceId}>
+              Review
+            </FocusAction>
+          }
+        />
+        <SummaryRow
+          icon={<SlidersHorizontalIcon className="size-4" />}
+          title="Preferences"
+          status={`${state.preferences.activeDescriptorCount} active`}
+          description="Short summaries are always known; full instructions are fetched when needed."
+          tone={state.preferences.truncated ? "warning" : "default"}
+          action={
+            <FocusAction view="preferences" workspaceId={workspaceId}>
+              Manage
+            </FocusAction>
+          }
+        />
+      </SummaryGroup>
 
-      <section aria-labelledby="always-known-heading">
-        <div className="mb-3 flex flex-wrap items-end justify-between gap-2">
-          <div>
-            <h2 id="always-known-heading" className="text-sm font-semibold text-fg">
-              Always known
-            </h2>
-            <p className="mt-1 text-xs text-fg-muted">
-              Bounded mandatory context resolved at an accepted turn boundary.
-            </p>
-          </div>
-          <ShieldCheckIcon className="size-4 text-brand" aria-hidden="true" />
-        </div>
-        <div className="grid gap-4 lg:grid-cols-2">
-          <AuthorityCard
-            icon={<BookOpenIcon className="size-4" />}
-            eyebrow="Mandatory context"
-            title="Charter & policy"
-            description="Workspace charter and policy context belongs to the versioned instruction-policy authority. This projection shows bounded active-head and revision metadata, but it cannot infer the composed runtime source or expose hidden prompt bodies."
-            status={policyProjectedStatus(state)}
-            statusTone={
-              state.policy.activeHeadsTruncated
-                ? "warning"
-                : state.policy.activeHeads.length > 0
-                  ? "good"
-                  : "default"
-            }
-            facts={[
-              { label: "Authority", value: "workspace_instruction_policy_heads" },
-              { label: "Active scope", value: policyScopeSummary(state) },
-              {
-                label: "Latest revision",
-                value: latestPolicyRevision
-                  ? `r${latestPolicyRevision.revision} · ${humanize(latestPolicyRevision.state)}`
-                  : "No revisions returned",
-              },
-              {
-                label: "Latest provenance",
-                value: latestPolicyRevision
-                  ? `${humanize(latestPolicyRevision.provenanceSource)} · revision metadata only`
-                  : "Unavailable",
-              },
-              {
-                label: "Legacy configuration",
-                value: state.policy.legacyRuntime.workspaceOverrideConfigured
-                  ? "Workspace override configured"
-                  : "Deployment default configured",
-              },
-              {
-                label: "Runtime composition",
-                value: "Not projected; no combined effective source is inferred",
-              },
-              {
-                label: "Coverage",
-                value: "Workspace charter/policy; organization profile is not projected here",
-              },
-            ]}
-            action={
-              <DiagnosticsLink onOpen={onOpenDiagnostics}>
-                Inspect policy status and audit metadata
-              </DiagnosticsLink>
-            }
-          >
-            {state.policy.activeHeadsTruncated ? (
-              <p className="text-xs leading-5 text-status-waiting">
-                The active-head list reached its safety bound. Counts and scopes are a partial view.
-              </p>
-            ) : null}
-          </AuthorityCard>
-          <AuthorityCard
-            icon={<BrainCircuitIcon className="size-4" />}
-            eyebrow="Bounded descriptors"
-            title="Preference Registry"
-            description="Preferences, procedures, and working methods live in the structured registry. Agents receive bounded descriptors by default and retrieve the full body only when needed under accepted-turn authority."
-            status={
-              state.preferences.truncated
-                ? `Partial · ${state.preferences.activeDescriptorCount} shown`
-                : state.preferences.activeDescriptorCount > 0
-                  ? `${state.preferences.activeDescriptorCount} active`
-                  : "No active descriptors"
-            }
-            statusTone={
-              state.preferences.truncated
-                ? "warning"
-                : state.preferences.activeDescriptorCount > 0
-                  ? "good"
-                  : "default"
-            }
-            facts={[
-              { label: "Authority", value: "Structured preference registry" },
-              {
-                label: "Scope",
-                value: `${state.preferences.scopeCounts.organization} organization · ${state.preferences.scopeCounts.workspace} workspace · ${state.preferences.scopeCounts.user} personal`,
-              },
-              {
-                label: "Default context",
-                value: "Bounded descriptor metadata plus exact retrieval handle",
-              },
-              { label: "Full content", value: "On demand; never loaded by this overview" },
-            ]}
-            action={
-              <DiagnosticsLink onOpen={onOpenDiagnostics}>
-                Inspect bounded registry metadata
-              </DiagnosticsLink>
-            }
-          >
-            {state.preferences.truncated ? (
-              <p className="text-xs leading-5 text-status-waiting">
-                The descriptor projection reached its safety bound, so this is a partial view.
-              </p>
-            ) : null}
-          </AuthorityCard>
-        </div>
-      </section>
-
-      <section aria-labelledby="retrieved-knowledge-heading">
-        <div className="mb-3">
-          <h2 id="retrieved-knowledge-heading" className="text-sm font-semibold text-fg">
-            Retrieved when relevant
-          </h2>
-          <p className="mt-1 text-xs text-fg-muted">
-            Evidence and learned records remain searchable authorities, not mandatory prompt
-            content.
-          </p>
-        </div>
-        <div className="grid gap-4 lg:grid-cols-2">
-          <AuthorityCard
-            icon={<FileSearchIcon className="size-4" />}
-            eyebrow="Searchable evidence"
-            title="Documents / RAG"
-            description="Uploaded and connected content stays in Documents. Search results carry their immutable organization, workspace, or initiating-user authority and source provenance."
-            status={
-              knowledge.availability === "unavailable"
-                ? "Unavailable · permission"
-                : knowledge.coverage === "partial"
-                  ? `Partial · ${knowledge.documentStatusCounts.ready} ready`
-                  : visibleDocumentCount === 0
-                    ? "Empty"
-                    : processingDocumentCount > 0
-                      ? `${knowledge.documentStatusCounts.ready} ready · ${processingDocumentCount} processing`
-                      : knowledge.documentStatusCounts.failed > 0
-                        ? `${knowledge.documentStatusCounts.ready} ready · ${knowledge.documentStatusCounts.failed} failed`
-                        : `${knowledge.documentStatusCounts.ready} ready`
-            }
-            statusTone={
-              knowledge.availability === "available" &&
-              (knowledge.coverage === "partial" ||
-                processingDocumentCount > 0 ||
-                knowledge.documentStatusCounts.failed > 0)
-                ? "warning"
-                : knowledge.availability === "available" && visibleDocumentCount > 0
-                  ? "good"
-                  : "default"
-            }
-            facts={
-              knowledge.availability === "available"
-                ? [
-                    {
-                      label: "Scope",
-                      value: `${knowledge.authorityKindCounts.organization} organization · ${knowledge.authorityKindCounts.workspace} workspace · ${knowledge.authorityKindCounts.personal} personal`,
-                    },
-                    {
-                      label: "Indexing",
-                      value: `${knowledge.documentStatusCounts.queued + knowledge.documentStatusCounts.indexing} processing · ${knowledge.documentStatusCounts.failed} failed`,
-                    },
-                    {
-                      label: "Provenance",
-                      value: `${sourceKindCount(state)} visible source types`,
-                    },
-                    {
-                      label: "Freshness",
-                      value: formatDate(knowledge.latestDocumentUpdatedAt),
-                    },
-                  ]
-                : [
-                    { label: "Scope", value: "Not disclosed without documents:search" },
-                    { label: "Status", value: "No document or source counts were returned" },
-                  ]
-            }
-            action={
-              <Link
-                to="/workspaces/$workspaceId/documents"
-                params={{ workspaceId }}
-                className="inline-flex items-center gap-1 text-xs font-medium text-brand hover:underline"
-              >
-                Open Documents
-                <ArrowRightIcon className="size-3" />
-              </Link>
-            }
-          >
-            {knowledge.availability === "available" && knowledge.coverage === "partial" ? (
-              <p className="text-xs leading-5 text-status-waiting">
-                The document inventory reached a safety bound. Counts, source types, and freshness
-                are partial.
-              </p>
-            ) : null}
-          </AuthorityCard>
-          <AuthorityCard
-            icon={<HistoryIcon className="size-4" />}
-            eyebrow="Learned facts and decisions"
-            title="Memory"
-            description="Facts, decisions, observations, and history stay in Memory. The Brain shows only a bounded structural sample; record text, provenance, and correction chains remain on the Memory surface."
-            status={
-              knowledge.availability === "unavailable"
-                ? "Unavailable · permission"
-                : knowledge.memorySample.limitReached
-                  ? `Partial sample · ${knowledge.memorySample.recordCount} shown`
-                  : knowledge.memorySample.recordCount === 0
-                    ? "Empty sample"
-                    : `${agentVisibleMemoryCount} agent-visible in sample`
-            }
-            statusTone={
-              knowledge.availability === "available" && knowledge.memorySample.limitReached
-                ? "warning"
-                : knowledge.availability === "available" && knowledge.memorySample.recordCount > 0
-                  ? "good"
-                  : "default"
-            }
-            facts={
-              knowledge.availability === "available"
-                ? [
-                    {
-                      label: "Sample",
-                      value: `${knowledge.memorySample.recordCount} newest authorized records`,
-                    },
-                    {
-                      label: "Kinds",
-                      value: `${knowledge.memorySample.kindCounts.semantic} facts · ${knowledge.memorySample.kindCounts.decision} decisions · ${knowledge.memorySample.kindCounts.episodic} history`,
-                    },
-                    {
-                      label: "Lifecycle",
-                      value: `${knowledge.memorySample.statusCounts.proposed} proposed · ${knowledge.memorySample.statusCounts.superseded + knowledge.memorySample.statusCounts.archived} retired`,
-                    },
-                    {
-                      label: "Freshness",
-                      value: formatDate(knowledge.memorySample.latestUpdatedAt),
-                    },
-                  ]
-                : [
-                    { label: "Scope", value: "Authorized Memory metadata was not disclosed" },
-                    { label: "Status", value: "Open Memory for your permitted records" },
-                  ]
-            }
-            action={
-              <Link
-                to="/workspaces/$workspaceId/memory"
-                params={{ workspaceId }}
-                className="inline-flex items-center gap-1 text-xs font-medium text-brand hover:underline"
-              >
-                Open Memory history
-                <ArrowRightIcon className="size-3" />
-              </Link>
-            }
-          >
-            {knowledge.availability === "available" && knowledge.memorySample.limitReached ? (
-              <p className="text-xs leading-5 text-status-waiting">
-                The Memory sample reached {knowledge.memorySample.sampleLimit} records. Lifecycle,
-                kind, and freshness values describe only this partial sample.
-              </p>
-            ) : null}
-            {knowledge.availability === "available" &&
-            knowledge.memorySample.kindCounts.preference > 0 ? (
-              <p className="text-xs leading-5 text-status-waiting">
-                {knowledge.memorySample.kindCounts.preference} legacy preference-like Memory
-                record(s) are observations only. The Preference Registry remains authoritative.
-              </p>
-            ) : null}
-          </AuthorityCard>
-        </div>
-      </section>
-
-      <section className="grid gap-4 lg:grid-cols-2" aria-label="Brain change controls">
-        <OverviewPanel
-          title="Pending changes"
-          description="Suggestions must remain inactive until an authorized authority-specific lifecycle accepts them."
-        >
-          <div className="rounded-md border border-border/70 bg-surface-2/30 p-3 text-xs leading-5 text-fg-muted">
-            This projection does not yet expose a unified governed-learning suggestion queue.
-            Existing instruction-policy onboarding drafts remain separate evidence under Advanced &
-            diagnostics and must not be mistaken for active policy or automatic learning.
-          </div>
-          <div className="mt-3">
-            <DiagnosticsLink onOpen={onOpenDiagnostics}>
-              Review inactive policy draft evidence
-            </DiagnosticsLink>
-          </div>
-        </OverviewPanel>
-        <OverviewPanel
-          title="History & rollback"
-          description="Audit and rollback remain owned by each authority; the Brain never performs a cross-authority rollback."
-        >
-          <ul className="grid gap-2 text-xs text-fg-muted">
-            <li className="rounded-md border border-border/70 bg-surface-2/30 p-3">
-              <span className="font-medium text-fg">Charter & policy:</span> revision, activation,
-              provenance, and accepted-attempt drift metadata are available in diagnostics.
-            </li>
-            <li className="rounded-md border border-border/70 bg-surface-2/30 p-3">
-              <span className="font-medium text-fg">Preferences:</span> immutable registry lifecycle
-              stays canonical, but this base projection exposes only bounded identities; no full
-              body or rollback control is loaded here.
-            </li>
-            <li className="rounded-md border border-border/70 bg-surface-2/30 p-3">
-              <span className="font-medium text-fg">Documents and Memory:</span> use their source
-              surfaces for indexing evidence, corrections, supersession, and record-level history.
-            </li>
-          </ul>
-        </OverviewPanel>
-      </section>
+      <SummaryGroup title="Available when needed">
+        <SummaryRow
+          icon={<FileSearchIcon className="size-4" />}
+          title="Documents"
+          status={documents.status}
+          tone={documents.tone}
+          description="Uploaded files and connected sources, kept within their selected scope."
+          action={
+            <RouteAction to="/workspaces/$workspaceId/documents" workspaceId={workspaceId}>
+              Open
+            </RouteAction>
+          }
+        />
+        <SummaryRow
+          icon={<BrainCircuitIcon className="size-4" />}
+          title="Memory"
+          status={memory.status}
+          tone={memory.tone}
+          description="Facts, decisions and observations learned across agent work."
+          action={
+            <RouteAction to="/workspaces/$workspaceId/memory" workspaceId={workspaceId}>
+              Open
+            </RouteAction>
+          }
+        />
+      </SummaryGroup>
     </div>
   );
 }

--- a/apps/web/src/routes/agent-brain-prompt.tsx
+++ b/apps/web/src/routes/agent-brain-prompt.tsx
@@ -1,0 +1,118 @@
+import { useNavigate } from "@tanstack/react-router";
+import { SparklesIcon } from "lucide-react";
+import { type FormEvent, useState } from "react";
+
+import { useAppContext } from "@/context";
+
+type AgentBrainPromptKind = "company_profile" | "preference" | "workspace_instructions";
+
+function promptCopy(kind: AgentBrainPromptKind): {
+  label: string;
+  placeholder: string;
+  button: string;
+  openingMessage: (request: string) => string;
+  instructions: string;
+} {
+  if (kind === "company_profile") {
+    return {
+      label: "Tell OpenGeni about your company and goals",
+      placeholder:
+        "For example: We build OpenGeni for teams that want dependable autonomous agents. Our current goal is to make the agent brain simple and useful.",
+      button: "Create with OpenGeni",
+      openingMessage: (request) =>
+        `Help me create or update our organization-wide company profile and goals.\n\nWhat I want agents to know:\n${request}`,
+      instructions:
+        "Help the user create concise organization-wide company context covering only useful identity, mission, products, customers, goals, and critical constraints. Ask only essential follow-up questions. Show the proposed profile before applying it. After explicit confirmation, use the canonical durable-learning company-profile authority tool if available. Do not save this as ordinary Memory, Documents, workspace policy, or a preference. If the write tool is unavailable, say so briefly and leave the final proposal ready for the manual editor.",
+    };
+  }
+  if (kind === "workspace_instructions") {
+    return {
+      label: "Tell OpenGeni how agents should work",
+      placeholder:
+        "For example: Keep updates concise, explain important decisions, and surface blockers early.",
+      button: "Create with OpenGeni",
+      openingMessage: (request) =>
+        `Help me create or update the instructions for agents working in this workspace.\n\nWhat I want:\n${request}`,
+      instructions:
+        "Help the user turn a natural-language request into concise global workspace instructions. Ask only essential follow-up questions. Show the proposed instructions before applying them. After explicit confirmation, use the canonical durable-learning or workspace instruction-policy tool if one is available. Never use ordinary Memory as a substitute. If the write tool is unavailable, say so briefly and leave the final proposed text ready for the manual editor.",
+    };
+  }
+  return {
+    label: "Tell OpenGeni what you want it to remember",
+    placeholder:
+      "For example: When giving me progress updates, lead with the outcome and keep the explanation short.",
+    button: "Create with OpenGeni",
+    openingMessage: (request) =>
+      `Help me turn this into a reusable preference for OpenGeni agents.\n\nWhat I want:\n${request}`,
+    instructions:
+      "Help the user create one reusable preference. Determine whether it should be personal, workspace-wide, or organization-wide; ask only when scope is genuinely ambiguous. Propose a clear name, a short always-visible summary, and focused full instructions. Show the proposal before applying it. After explicit confirmation, use the canonical durable-learning preference tool if one is available. Never save the preference as ordinary Memory. If the write tool is unavailable, say so briefly and leave the structured proposal ready for the manual editor.",
+  };
+}
+
+export function AgentBrainPrompt({
+  kind,
+  workspaceId,
+}: {
+  kind: AgentBrainPromptKind;
+  workspaceId: string;
+}) {
+  const context = useAppContext();
+  const navigate = useNavigate();
+  const copy = promptCopy(kind);
+  const [request, setRequest] = useState("");
+  const [starting, setStarting] = useState(false);
+
+  const start = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+    const trimmed = request.trim();
+    if (!trimmed || starting || context.busy) return;
+    setStarting(true);
+    try {
+      const created = await context.startSession(
+        workspaceId,
+        { text: copy.openingMessage(trimmed) },
+        { instructions: copy.instructions },
+      );
+      if (created) {
+        await navigate({
+          to: "/workspaces/$workspaceId/sessions/$sessionId",
+          params: { workspaceId, sessionId: created.id },
+        });
+      }
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <form
+      className="grid gap-3 rounded-lg border border-border bg-surface p-4"
+      onSubmit={(event) => void start(event)}
+    >
+      <label className="grid gap-2 text-sm font-medium text-fg">
+        <span className="flex items-center gap-2">
+          <SparklesIcon className="size-4 text-brand" />
+          {copy.label}
+        </span>
+        <textarea
+          className="min-h-28 rounded-md border border-border bg-surface px-3 py-2 text-sm leading-6 text-fg outline-none focus:border-brand"
+          value={request}
+          placeholder={copy.placeholder}
+          onChange={(event) => setRequest(event.target.value)}
+        />
+      </label>
+      <p className="text-xs leading-5 text-fg-subtle">
+        OpenGeni will ask questions if needed and show you the result before saving it.
+      </p>
+      <div>
+        <button
+          type="submit"
+          className="rounded-md bg-brand px-3 py-2 text-sm font-medium text-white hover:bg-brand/90 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={!request.trim() || starting || context.busy}
+        >
+          {starting ? "Starting…" : copy.button}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/routes/capabilities.test.tsx
+++ b/apps/web/src/routes/capabilities.test.tsx
@@ -13,7 +13,6 @@ import {
   localConnectedSlackPreview,
   slackBotDocumentDestinationAuthority,
   SlackBotInstallControls,
-  WorkspaceSlackBotRequestedScopes,
 } from "./capabilities";
 
 beforeAll(() => {
@@ -106,21 +105,6 @@ describe("OpenGeni Slack bot install controls", () => {
         documentDestination: { authorityKind: "organization" },
       }),
     ).toBe("organization");
-  });
-
-  test("renders every requested workspace-bot scope including read-only reactions", async () => {
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-    const root = createRoot(container);
-    try {
-      await act(async () => root.render(<WorkspaceSlackBotRequestedScopes />));
-      expect(container.textContent).toBe(OPENGENI_SLACK_BOT_REQUESTED_SCOPES.join(", "));
-      expect(container.textContent).toContain("reactions:read");
-      expect(container.textContent).not.toContain("reactions:write");
-    } finally {
-      await act(async () => root.unmount());
-      container.remove();
-    }
   });
 
   test("uses the authoritative workspace permission grant", () => {

--- a/apps/web/src/routes/capabilities.test.tsx
+++ b/apps/web/src/routes/capabilities.test.tsx
@@ -11,6 +11,7 @@ import {
   canWriteWorkspaceConnections,
   googleDriveStatusLabel,
   localConnectedSlackPreview,
+  slackBotDocumentDestinationAuthority,
   SlackBotInstallControls,
   WorkspaceSlackBotRequestedScopes,
 } from "./capabilities";
@@ -90,7 +91,21 @@ describe("OpenGeni Slack bot install controls", () => {
     const preview = localConnectedSlackPreview("?previewSlack=connected", "workspace-a", true);
     expect(preview?.bot.workspaceId).toBe("workspace-a");
     expect(preview?.bot.status).toBe("active");
+    expect(preview?.bot.grantedScopes).toEqual([...OPENGENI_SLACK_BOT_REQUESTED_SCOPES]);
     expect(preview?.personal.state).toBe("connected");
+  });
+
+  test("keeps workspace-bot knowledge out of personal scope", () => {
+    expect(
+      slackBotDocumentDestinationAuthority({
+        documentDestination: { authorityKind: "personal" },
+      }),
+    ).toBe("workspace");
+    expect(
+      slackBotDocumentDestinationAuthority({
+        documentDestination: { authorityKind: "organization" },
+      }),
+    ).toBe("organization");
   });
 
   test("renders every requested workspace-bot scope including read-only reactions", async () => {
@@ -147,13 +162,13 @@ describe("OpenGeni Slack bot install controls", () => {
     }
   });
 
-  test("renders a disabled reinstall control without offering another installation", async () => {
+  test("renders a disabled reconnect control without offering another installation", async () => {
     const rendered = await renderControls({ canInstall: false, hasConnection: true });
 
     try {
       const buttons = [...rendered.container.querySelectorAll<HTMLButtonElement>("button")];
       expect(buttons).toHaveLength(1);
-      expect(buttons[0]?.textContent?.trim()).toBe("Reinstall");
+      expect(buttons[0]?.textContent?.trim()).toBe("Reconnect");
       expect(buttons[0]?.disabled).toBe(true);
       expect(rendered.container.textContent).not.toContain("Install in another workspace");
       expect(rendered.container.textContent).toContain(
@@ -182,15 +197,15 @@ describe("OpenGeni Slack bot install controls", () => {
 
     try {
       const buttons = [...connected.container.querySelectorAll<HTMLButtonElement>("button")];
-      const reinstall = buttons.find((button) => button.textContent?.trim() === "Reinstall");
+      const reconnect = buttons.find((button) => button.textContent?.trim() === "Reconnect");
       const installAnother = [
         ...connected.container.querySelectorAll<HTMLButtonElement>("button"),
       ].find((button) => button.textContent?.trim() === "Install in another workspace");
       expect(connected.container.querySelector("[data-opengeni-slack-install]")).toBeNull();
-      expect(reinstall).not.toBeUndefined();
+      expect(reconnect).not.toBeUndefined();
       expect(installAnother).not.toBeUndefined();
 
-      await act(async () => reinstall!.click());
+      await act(async () => reconnect!.click());
       await act(async () => installAnother!.click());
       expect(connected.onInstall).toHaveBeenNthCalledWith(1, false);
       expect(connected.onInstall).toHaveBeenNthCalledWith(2, true);

--- a/apps/web/src/routes/capabilities.test.tsx
+++ b/apps/web/src/routes/capabilities.test.tsx
@@ -9,6 +9,7 @@ import {
   canInstallOpenGeniSlackBot,
   canManageSlackReactionSummon,
   canWriteWorkspaceConnections,
+  googleDriveStatusLabel,
   localConnectedSlackPreview,
   SlackBotInstallControls,
   WorkspaceSlackBotRequestedScopes,
@@ -74,6 +75,15 @@ function accessContext(
 }
 
 describe("OpenGeni Slack bot install controls", () => {
+  test("summarizes Google Drive state for the compact app catalog", () => {
+    expect(googleDriveStatusLabel("connected")).toBe("Connected");
+    expect(googleDriveStatusLabel("paused")).toBe("Paused");
+    expect(googleDriveStatusLabel("not_connected")).toBe("Not connected");
+    expect(googleDriveStatusLabel("disconnected")).toBe("Not connected");
+    expect(googleDriveStatusLabel("reconsent_required")).toBe("Needs attention");
+    expect(googleDriveStatusLabel("unverified")).toBe("Loading");
+  });
+
   test("offers a local-only connected Slack preview without changing persisted connections", () => {
     expect(localConnectedSlackPreview("?previewSlack=connected", "workspace-a", false)).toBeNull();
 

--- a/apps/web/src/routes/capabilities.test.tsx
+++ b/apps/web/src/routes/capabilities.test.tsx
@@ -9,6 +9,7 @@ import {
   canInstallOpenGeniSlackBot,
   canManageSlackReactionSummon,
   canWriteWorkspaceConnections,
+  localConnectedSlackPreview,
   SlackBotInstallControls,
   WorkspaceSlackBotRequestedScopes,
 } from "./capabilities";
@@ -73,6 +74,15 @@ function accessContext(
 }
 
 describe("OpenGeni Slack bot install controls", () => {
+  test("offers a local-only connected Slack preview without changing persisted connections", () => {
+    expect(localConnectedSlackPreview("?previewSlack=connected", "workspace-a", false)).toBeNull();
+
+    const preview = localConnectedSlackPreview("?previewSlack=connected", "workspace-a", true);
+    expect(preview?.bot.workspaceId).toBe("workspace-a");
+    expect(preview?.bot.status).toBe("active");
+    expect(preview?.personal.state).toBe("connected");
+  });
+
   test("renders every requested workspace-bot scope including read-only reactions", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -15,13 +15,24 @@ import {
   CheckCircle2Icon,
   ChevronDownIcon,
   GlobeIcon,
+  HardDriveIcon,
   Loader2Icon,
+  MessagesSquareIcon,
   PlugIcon,
   PlusIcon,
   RefreshCwIcon,
   SearchIcon,
 } from "lucide-react";
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { toast } from "sonner";
 
 import { AddCustomDialog } from "@/components/capabilities/add-custom-dialog";
@@ -43,6 +54,13 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAppContext } from "@/context";
 import {
@@ -70,6 +88,10 @@ import {
   type SheetSelection,
 } from "@/lib/capabilities";
 import { listViewState } from "@/lib/load-state";
+import {
+  googleDriveAccountState,
+  preferredGoogleDriveConnection,
+} from "@/lib/google-drive-connection";
 import { mcpOAuthCallbackFailureMessage, startMcpOAuthWithTimeout } from "@/lib/mcp-oauth";
 import { hasAccountPermission, hasWorkspacePermission } from "@/lib/permissions";
 import {
@@ -327,6 +349,7 @@ export function CapabilitiesRoute({
   const capabilityFocusFallbackRef = useRef<HTMLDivElement | null>(null);
   const [sheetError, setSheetError] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
+  const [managedApp, setManagedApp] = useState<"google-drive" | "slack" | null>(null);
 
   // Public MCP registry search (only offered when the catalog has no matches).
   const [registryBusy, setRegistryBusy] = useState(false);
@@ -378,12 +401,23 @@ export function CapabilitiesRoute({
     [client],
   );
   const connectionsLoaded = connections !== null;
+  const googleDriveConnection = preferredGoogleDriveConnection(connections ?? []);
+  const googleDriveState = googleDriveAccountState(googleDriveConnection, connectionsLoaded);
   const personalSlackItem = personalSlackCapability(items);
   const personalSlackConnection = preferredPersonalSlackConnection(connections ?? []);
   const personalSlackStatus = personalSlackAccountState(personalSlackConnection, connectionsLoaded);
   const visiblePersonalSlackStatus = slackPreview?.personal ?? personalSlackStatus;
   const personalSlackAvailable = personalSlackItem !== null || slackPreview !== null;
   const canManagePersonalSlack = canWriteWorkspaceConnections(context.accessContext, workspaceId);
+  const slackAppStatus = visibleSlackBotConnection
+    ? visibleSlackBotConnection.status === "active"
+      ? "Connected"
+      : "Needs attention"
+    : visiblePersonalSlackStatus.state === "connected"
+      ? "Connected"
+      : connectionsLoaded
+        ? "Not connected"
+        : "Loading";
 
   useEffect(() => {
     const authority = slackBotDocumentDestinationAuthority(slackBotConnection?.metadata);
@@ -1228,236 +1262,276 @@ export function CapabilitiesRoute({
           }
         />
 
-        <Suspense fallback={<Skeleton className="mt-6 h-40 w-full rounded-xl" />}>
-          <GoogleDriveConnectorCard workspaceId={workspaceId} />
-        </Suspense>
-
-        <section className="mt-6" aria-labelledby="slack-connections-heading">
+        <section className="mt-6 space-y-3" aria-labelledby="apps-heading">
           <div>
-            <h2 id="slack-connections-heading" className="text-sm font-semibold text-fg">
-              Slack
+            <h2 id="apps-heading" className="text-sm font-semibold text-fg">
+              Apps
             </h2>
-            <p className="mt-1 text-xs text-fg-muted">
-              Ask OpenGeni questions and start work without leaving Slack.
-            </p>
+            <p className="mt-1 text-xs text-fg-muted">Connect services your agents can use.</p>
           </div>
+          <div className="grid gap-2 sm:grid-cols-2">
+            <ManagedAppTile
+              icon={<HardDriveIcon className="size-5" />}
+              name="Google Drive"
+              description="Search, sync, and create files in Drive."
+              status={googleDriveStatusLabel(googleDriveState.state)}
+              onOpen={() => setManagedApp("google-drive")}
+            />
+            <ManagedAppTile
+              icon={<MessagesSquareIcon className="size-5" />}
+              name="Slack"
+              description="Chat with OpenGeni and start work from Slack."
+              status={slackAppStatus}
+              onOpen={() => setManagedApp("slack")}
+            />
+          </div>
+        </section>
 
-          <section
-            className="mt-3 rounded-xl border border-border bg-surface p-4"
-            aria-labelledby="workspace-slack-bot-heading"
-          >
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div className="flex min-w-0 items-start gap-3">
-                <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-brand/10 text-brand">
-                  <Building2Icon className="size-4" />
-                </span>
-                <div className="min-w-0">
-                  <h3 id="workspace-slack-bot-heading" className="text-sm font-semibold text-fg">
-                    OpenGeni in Slack
-                  </h3>
-                  <p className="mt-1 max-w-xl text-xs leading-5 text-fg-muted">
-                    Use mentions, /opengeni, DMs and message shortcuts.
-                  </p>
-                </div>
-              </div>
-            </div>
+        <Sheet
+          open={managedApp === "google-drive"}
+          onOpenChange={(open) => !open && setManagedApp(null)}
+        >
+          <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
+            <SheetHeader className="sr-only">
+              <SheetTitle>Google Drive</SheetTitle>
+              <SheetDescription>Google Drive connection settings.</SheetDescription>
+            </SheetHeader>
+            <Suspense fallback={<Skeleton className="m-5 h-40 rounded-xl" />}>
+              <GoogleDriveConnectorCard workspaceId={workspaceId} />
+            </Suspense>
+          </SheetContent>
+        </Sheet>
 
-            {visibleSlackBotConnection && visibleSlackBotMetadata ? (
-              <>
-                <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-brand/20 bg-brand/5 p-3">
-                  <div className="flex items-center gap-2">
-                    <CheckCircle2Icon className="size-4 shrink-0 text-brand" />
-                    <p className="text-sm font-medium text-fg">
-                      {visibleSlackBotConnection.status === "active"
-                        ? `Connected to ${visibleSlackBotMetadata.slackTeamName}`
-                        : `${visibleSlackBotMetadata.slackTeamName} needs to be reconnected`}
-                    </p>
+        <Sheet open={managedApp === "slack"} onOpenChange={(open) => !open && setManagedApp(null)}>
+          <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
+            <SheetHeader className="border-b border-border px-5 py-4 pr-12">
+              <SheetTitle>Slack</SheetTitle>
+              <SheetDescription>Chat with OpenGeni and start work from Slack.</SheetDescription>
+            </SheetHeader>
+            <section className="space-y-3 px-5 pb-6" aria-label="Slack settings">
+              <section
+                className="mt-3 rounded-xl border border-border bg-surface p-4"
+                aria-labelledby="workspace-slack-bot-heading"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="flex min-w-0 items-start gap-3">
+                    <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-brand/10 text-brand">
+                      <Building2Icon className="size-4" />
+                    </span>
+                    <div className="min-w-0">
+                      <h3
+                        id="workspace-slack-bot-heading"
+                        className="text-sm font-semibold text-fg"
+                      >
+                        OpenGeni in Slack
+                      </h3>
+                      <p className="mt-1 max-w-xl text-xs leading-5 text-fg-muted">
+                        Use mentions, /opengeni, DMs and message shortcuts.
+                      </p>
+                    </div>
                   </div>
-                  {visibleSlackBotConnection.status !== "active" ? (
+                </div>
+
+                {visibleSlackBotConnection && visibleSlackBotMetadata ? (
+                  <>
+                    <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-brand/20 bg-brand/5 p-3">
+                      <div className="flex items-center gap-2">
+                        <CheckCircle2Icon className="size-4 shrink-0 text-brand" />
+                        <p className="text-sm font-medium text-fg">
+                          {visibleSlackBotConnection.status === "active"
+                            ? `Connected to ${visibleSlackBotMetadata.slackTeamName}`
+                            : `${visibleSlackBotMetadata.slackTeamName} needs to be reconnected`}
+                        </p>
+                      </div>
+                      {visibleSlackBotConnection.status !== "active" ? (
+                        <SlackBotInstallControls
+                          canInstall={canInstallSlackBot}
+                          hasConnection
+                          busy={slackBotBusy}
+                          onInstall={(createNewConnection) =>
+                            void installSlackBot(createNewConnection)
+                          }
+                        />
+                      ) : null}
+                    </div>
+
+                    <details className="group mt-3 rounded-lg border border-border bg-bg/30 p-3">
+                      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-xs font-medium text-fg">
+                        <span>Settings</span>
+                        <ChevronDownIcon className="size-3.5 text-fg-subtle transition-transform group-open:rotate-180" />
+                      </summary>
+                      <div className="mt-3 border-t border-border/70 pt-3">
+                        <div className="flex flex-wrap items-end justify-between gap-3">
+                          <div>
+                            <p className="text-xs font-semibold text-fg">Knowledge from Slack</p>
+                            <p className="mt-1 text-2xs leading-4 text-fg-muted">
+                              Save imported Slack content to{" "}
+                              {slackBotDestinationLabel(savedSlackDestinationAuthority)}.
+                            </p>
+                          </div>
+                          <div className="flex flex-wrap items-end gap-2">
+                            <label className="grid gap-1 text-2xs font-medium text-fg-muted">
+                              Destination
+                              <Select
+                                aria-label="Slack knowledge destination"
+                                value={slackDestinationAuthority}
+                                disabled={!canInstallSlackBot || slackDestinationBusy}
+                                onChange={(event) =>
+                                  setSlackDestinationAuthority(
+                                    event.target.value as ConnectorDocumentDestinationAuthority,
+                                  )
+                                }
+                              >
+                                <option value="personal">My knowledge</option>
+                                <option
+                                  value="workspace"
+                                  disabled={!canManageSlackWorkspaceDestination}
+                                >
+                                  Workspace knowledge
+                                </option>
+                                <option
+                                  value="organization"
+                                  disabled={!canManageSlackOrganizationDestination}
+                                >
+                                  Organization knowledge
+                                </option>
+                              </Select>
+                            </label>
+                            <Button
+                              type="button"
+                              size="sm"
+                              disabled={
+                                !canInstallSlackBot ||
+                                slackDestinationBusy ||
+                                (slackDestinationAuthority === "workspace" &&
+                                  !canManageSlackWorkspaceDestination) ||
+                                (slackDestinationAuthority === "organization" &&
+                                  !canManageSlackOrganizationDestination)
+                              }
+                              onClick={() => void saveSlackBotDestination()}
+                            >
+                              {slackDestinationBusy ? (
+                                <Loader2Icon className="size-3.5 animate-spin" />
+                              ) : null}
+                              Save
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="mt-3">
+                        <SlackReactionSummonCard
+                          workspaceId={workspaceId}
+                          connection={visibleSlackBotConnection}
+                          canManage={canManageSlackReaction}
+                          installBusy={slackBotBusy}
+                          onReinstall={() => void installSlackBot(false)}
+                        />
+                      </div>
+
+                      <details className="group mt-3 border-t border-border/70 pt-3">
+                        <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
+                          <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
+                          <span>Connection details</span>
+                        </summary>
+                        <div className="mt-3 rounded-md bg-bg/50 p-3">
+                          <p className="text-2xs font-medium text-fg-muted">Slack permissions</p>
+                          <p className="mt-1 break-words font-mono text-2xs leading-relaxed text-fg-subtle">
+                            {OPENGENI_SLACK_BOT_REQUIRED_SCOPES.join(", ")}
+                          </p>
+                          <p className="mt-2 text-2xs text-fg-subtle">
+                            Bot connection ID:{" "}
+                            <span className="font-mono">{visibleSlackBotConnection.id}</span>
+                            {(slackPreview ? 1 : slackBotConnections.length) > 1
+                              ? ` · ${slackBotConnections.length} Slack installations`
+                              : ""}
+                          </p>
+                          <SlackBotInstallControls
+                            canInstall={canInstallSlackBot}
+                            hasConnection
+                            busy={slackBotBusy}
+                            onInstall={(createNewConnection) =>
+                              void installSlackBot(createNewConnection)
+                            }
+                          />
+                          {visibleSlackBotConnection.status === "active" ? (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="mt-1"
+                              disabled={slackBotBusy}
+                              onClick={() => void disconnectSlackBot()}
+                            >
+                              Disconnect workspace bot
+                            </Button>
+                          ) : null}
+                        </div>
+                      </details>
+                    </details>
+                  </>
+                ) : (
+                  <>
                     <SlackBotInstallControls
                       canInstall={canInstallSlackBot}
-                      hasConnection
+                      hasConnection={false}
                       busy={slackBotBusy}
                       onInstall={(createNewConnection) => void installSlackBot(createNewConnection)}
                     />
-                  ) : null}
-                </div>
+                    <details className="group mt-3">
+                      <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
+                        <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
+                        <span>Permissions</span>
+                      </summary>
+                      <p className="mt-2 text-2xs leading-5 text-fg-muted">
+                        Slack shows these permissions before you approve the installation.
+                      </p>
+                      <WorkspaceSlackBotRequestedScopes />
+                    </details>
+                  </>
+                )}
+              </section>
 
-                <details className="group mt-3 rounded-lg border border-border bg-bg/30 p-3">
-                  <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-xs font-medium text-fg">
-                    <span>Settings</span>
-                    <ChevronDownIcon className="size-3.5 text-fg-subtle transition-transform group-open:rotate-180" />
-                  </summary>
-                  <div className="mt-3 border-t border-border/70 pt-3">
-                    <div className="flex flex-wrap items-end justify-between gap-3">
-                      <div>
-                        <p className="text-xs font-semibold text-fg">Knowledge from Slack</p>
-                        <p className="mt-1 text-2xs leading-4 text-fg-muted">
-                          Save imported Slack content to{" "}
-                          {slackBotDestinationLabel(savedSlackDestinationAuthority)}.
-                        </p>
-                      </div>
-                      <div className="flex flex-wrap items-end gap-2">
-                        <label className="grid gap-1 text-2xs font-medium text-fg-muted">
-                          Destination
-                          <Select
-                            aria-label="Slack knowledge destination"
-                            value={slackDestinationAuthority}
-                            disabled={!canInstallSlackBot || slackDestinationBusy}
-                            onChange={(event) =>
-                              setSlackDestinationAuthority(
-                                event.target.value as ConnectorDocumentDestinationAuthority,
-                              )
-                            }
-                          >
-                            <option value="personal">My knowledge</option>
-                            <option
-                              value="workspace"
-                              disabled={!canManageSlackWorkspaceDestination}
-                            >
-                              Workspace knowledge
-                            </option>
-                            <option
-                              value="organization"
-                              disabled={!canManageSlackOrganizationDestination}
-                            >
-                              Organization knowledge
-                            </option>
-                          </Select>
-                        </label>
-                        <Button
-                          type="button"
-                          size="sm"
-                          disabled={
-                            !canInstallSlackBot ||
-                            slackDestinationBusy ||
-                            (slackDestinationAuthority === "workspace" &&
-                              !canManageSlackWorkspaceDestination) ||
-                            (slackDestinationAuthority === "organization" &&
-                              !canManageSlackOrganizationDestination)
-                          }
-                          onClick={() => void saveSlackBotDestination()}
-                        >
-                          {slackDestinationBusy ? (
-                            <Loader2Icon className="size-3.5 animate-spin" />
-                          ) : null}
-                          Save
-                        </Button>
-                      </div>
+              <details className="group mt-3 rounded-xl border border-border bg-surface px-4 py-3">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
+                  <div className="flex min-w-0 items-start gap-3">
+                    <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-fg-muted/10 text-fg-muted">
+                      <PlugIcon className="size-4" />
+                    </span>
+                    <div>
+                      <p className="text-sm font-medium text-fg">Personal Slack</p>
+                      <p className="mt-0.5 text-xs text-fg-muted">
+                        Let agents act through your Slack account.
+                      </p>
                     </div>
                   </div>
-
-                  <div className="mt-3">
-                    <SlackReactionSummonCard
-                      workspaceId={workspaceId}
-                      connection={visibleSlackBotConnection}
-                      canManage={canManageSlackReaction}
-                      installBusy={slackBotBusy}
-                      onReinstall={() => void installSlackBot(false)}
-                    />
+                  <div className="flex shrink-0 items-center gap-2 text-xs text-fg-muted">
+                    <span>
+                      {personalSlackAccountStatusLabel(
+                        visiblePersonalSlackStatus,
+                        personalSlackAvailable,
+                      )}
+                    </span>
+                    <ChevronDownIcon className="size-4 text-fg-subtle transition-transform group-open:rotate-180" />
                   </div>
-
-                  <details className="group mt-3 border-t border-border/70 pt-3">
-                    <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
-                      <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
-                      <span>Connection details</span>
-                    </summary>
-                    <div className="mt-3 rounded-md bg-bg/50 p-3">
-                      <p className="text-2xs font-medium text-fg-muted">Slack permissions</p>
-                      <p className="mt-1 break-words font-mono text-2xs leading-relaxed text-fg-subtle">
-                        {OPENGENI_SLACK_BOT_REQUIRED_SCOPES.join(", ")}
-                      </p>
-                      <p className="mt-2 text-2xs text-fg-subtle">
-                        Bot connection ID:{" "}
-                        <span className="font-mono">{visibleSlackBotConnection.id}</span>
-                        {(slackPreview ? 1 : slackBotConnections.length) > 1
-                          ? ` · ${slackBotConnections.length} Slack installations`
-                          : ""}
-                      </p>
-                      <SlackBotInstallControls
-                        canInstall={canInstallSlackBot}
-                        hasConnection
-                        busy={slackBotBusy}
-                        onInstall={(createNewConnection) =>
-                          void installSlackBot(createNewConnection)
-                        }
-                      />
-                      {visibleSlackBotConnection.status === "active" ? (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="mt-1"
-                          disabled={slackBotBusy}
-                          onClick={() => void disconnectSlackBot()}
-                        >
-                          Disconnect workspace bot
-                        </Button>
-                      ) : null}
-                    </div>
-                  </details>
-                </details>
-              </>
-            ) : (
-              <>
-                <SlackBotInstallControls
-                  canInstall={canInstallSlackBot}
-                  hasConnection={false}
-                  busy={slackBotBusy}
-                  onInstall={(createNewConnection) => void installSlackBot(createNewConnection)}
-                />
-                <details className="group mt-3">
-                  <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
-                    <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
-                    <span>Permissions</span>
-                  </summary>
-                  <p className="mt-2 text-2xs leading-5 text-fg-muted">
-                    Slack shows these permissions before you approve the installation.
-                  </p>
-                  <WorkspaceSlackBotRequestedScopes />
-                </details>
-              </>
-            )}
-          </section>
-
-          <details className="group mt-3 rounded-xl border border-border bg-surface px-4 py-3">
-            <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
-              <div className="flex min-w-0 items-start gap-3">
-                <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-fg-muted/10 text-fg-muted">
-                  <PlugIcon className="size-4" />
-                </span>
-                <div>
-                  <p className="text-sm font-medium text-fg">Personal Slack</p>
-                  <p className="mt-0.5 text-xs text-fg-muted">
-                    Let agents act through your Slack account.
-                  </p>
+                </summary>
+                <div className="mt-3 border-t border-border/70 pt-3">
+                  <PersonalSlackAccountCard
+                    available={personalSlackAvailable}
+                    canManage={canManagePersonalSlack}
+                    busy={personalSlackBusy}
+                    accountState={visiblePersonalSlackStatus}
+                    embedded
+                    readOnly={slackPreview !== null}
+                    onConnect={() => void startPersonalSlackOAuth()}
+                    onReconnect={() => void startPersonalSlackOAuth()}
+                    onDisconnect={() => setPersonalSlackDisconnectOpen(true)}
+                  />
                 </div>
-              </div>
-              <div className="flex shrink-0 items-center gap-2 text-xs text-fg-muted">
-                <span>
-                  {personalSlackAccountStatusLabel(
-                    visiblePersonalSlackStatus,
-                    personalSlackAvailable,
-                  )}
-                </span>
-                <ChevronDownIcon className="size-4 text-fg-subtle transition-transform group-open:rotate-180" />
-              </div>
-            </summary>
-            <div className="mt-3 border-t border-border/70 pt-3">
-              <PersonalSlackAccountCard
-                available={personalSlackAvailable}
-                canManage={canManagePersonalSlack}
-                busy={personalSlackBusy}
-                accountState={visiblePersonalSlackStatus}
-                embedded
-                readOnly={slackPreview !== null}
-                onConnect={() => void startPersonalSlackOAuth()}
-                onReconnect={() => void startPersonalSlackOAuth()}
-                onDisconnect={() => setPersonalSlackDisconnectOpen(true)}
-              />
-            </div>
-          </details>
-        </section>
+              </details>
+            </section>
+          </SheetContent>
+        </Sheet>
 
         <ConfirmDialog
           open={personalSlackDisconnectOpen}
@@ -1550,7 +1624,7 @@ export function CapabilitiesRoute({
               ) : null}
 
               {catalogView === "loading" ? (
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                   {[
                     "catalog-skeleton-1",
                     "catalog-skeleton-2",
@@ -1561,11 +1635,15 @@ export function CapabilitiesRoute({
                     "catalog-skeleton-7",
                     "catalog-skeleton-8",
                   ].map((rowKey) => (
-                    <div key={rowKey} className="rounded-xl border border-border bg-surface/50 p-4">
-                      <Skeleton className="size-10 rounded-lg" />
-                      <Skeleton className="mt-3 h-4 w-24" />
-                      <Skeleton className="mt-2 h-3 w-full" />
-                      <Skeleton className="mt-1.5 h-3 w-2/3" />
+                    <div
+                      key={rowKey}
+                      className="flex items-center gap-3 rounded-xl border border-border bg-surface/50 p-3"
+                    >
+                      <Skeleton className="size-8 shrink-0 rounded-lg" />
+                      <div className="min-w-0 flex-1">
+                        <Skeleton className="h-4 w-24" />
+                        <Skeleton className="mt-2 h-3 w-2/3" />
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -1588,7 +1666,7 @@ export function CapabilitiesRoute({
                 />
               ) : (
                 <>
-                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                     {visibleBrowse.map((item) => (
                       <CapabilityTile
                         key={item.id}
@@ -1639,6 +1717,63 @@ export function CapabilitiesRoute({
         onSubmit={submitAddCustom}
       />
     </div>
+  );
+}
+
+export function googleDriveStatusLabel(
+  state: ReturnType<typeof googleDriveAccountState>["state"],
+): string {
+  if (state === "connected") return "Connected";
+  if (state === "paused") return "Paused";
+  if (state === "not_connected" || state === "disconnected") return "Not connected";
+  if (state === "unverified") return "Loading";
+  return "Needs attention";
+}
+
+function ManagedAppTile({
+  icon,
+  name,
+  description,
+  status,
+  onOpen,
+}: {
+  icon: ReactNode;
+  name: string;
+  description: string;
+  status: string;
+  onOpen: () => void;
+}) {
+  const connected = status === "Connected";
+  const attention = status === "Needs attention";
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="group flex min-w-0 items-center gap-3 rounded-xl border border-border bg-surface/50 p-3 text-left transition-colors hover:border-border-strong hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+    >
+      <span className="grid size-10 shrink-0 place-items-center rounded-lg border border-border bg-bg text-fg-muted">
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-fg">{name}</span>
+        <span className="mt-0.5 block truncate text-xs text-fg-muted">{description}</span>
+      </span>
+      <span
+        className={cn(
+          "flex shrink-0 items-center gap-1.5 text-2xs",
+          attention ? "text-status-waiting" : "text-fg-subtle",
+        )}
+      >
+        <span
+          className={cn(
+            "size-1.5 rounded-full",
+            connected ? "bg-status-idle" : attention ? "bg-status-waiting" : "bg-fg-subtle/50",
+          )}
+        />
+        {status}
+      </span>
+    </button>
   );
 }
 
@@ -1743,7 +1878,7 @@ function RegistryFallback({
     return (
       <div className="space-y-3">
         <p className="text-xs text-fg-subtle">From the public MCP registry</p>
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           {results.map((item) => (
             <CapabilityTile
               key={item.id}

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -1168,83 +1168,66 @@ export function CapabilitiesRoute({
         <section className="mt-6" aria-labelledby="slack-connections-heading">
           <div>
             <h2 id="slack-connections-heading" className="text-sm font-semibold text-fg">
-              Slack connections
+              Slack
             </h2>
-            <p className="mt-1 max-w-3xl text-xs leading-5 text-fg-muted">
-              Personal account linking and workspace bot installation are separate principals.
-              Connecting one never exposes, replaces, or reuses the other's credentials.
+            <p className="mt-1 text-xs text-fg-muted">
+              Ask OpenGeni questions and start work without leaving Slack.
             </p>
           </div>
 
-          <div className="mt-3 grid gap-4 xl:grid-cols-2">
-            <PersonalSlackAccountCard
-              available={personalSlackItem !== null}
-              canManage={canManagePersonalSlack}
-              busy={personalSlackBusy}
-              accountState={personalSlackStatus}
-              onConnect={() => void startPersonalSlackOAuth()}
-              onReconnect={() => void startPersonalSlackOAuth()}
-              onDisconnect={() => setPersonalSlackDisconnectOpen(true)}
-            />
-
-            <section
-              className="rounded-xl border border-border bg-surface p-4"
-              aria-labelledby="workspace-slack-bot-heading"
-            >
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div className="flex min-w-0 items-start gap-3">
-                  <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-fg-muted/10 text-fg-muted">
-                    <Building2Icon className="size-4" />
-                  </span>
-                  <div className="min-w-0">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <h3
-                        id="workspace-slack-bot-heading"
-                        className="text-sm font-semibold text-fg"
-                      >
-                        OpenGeni workspace bot
-                      </h3>
-                      <span className="rounded-full border border-border bg-bg px-2 py-0.5 text-2xs font-medium text-fg-muted">
-                        Workspace shared · bot identity
-                      </span>
-                    </div>
-                    <p className="mt-1 max-w-xl text-xs leading-5 text-fg-muted">
-                      Install a separate bot principal for first-party Slack tools and explicitly
-                      bound scheduled tasks. Linked users can mention @OpenGeni in a member channel,
-                      run /opengeni, DM the bot, or use the Open in OpenGeni message shortcut. A
-                      shortcut from a human DM creates a private task and continues in the invoking
-                      user's bot DM; it never joins or exposes workspace output in the source DM. It
-                      never uses a person's Slack OAuth grant.
-                    </p>
-                  </div>
+          <section
+            className="mt-3 rounded-xl border border-border bg-surface p-4"
+            aria-labelledby="workspace-slack-bot-heading"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="flex min-w-0 items-start gap-3">
+                <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-brand/10 text-brand">
+                  <Building2Icon className="size-4" />
+                </span>
+                <div className="min-w-0">
+                  <h3 id="workspace-slack-bot-heading" className="text-sm font-semibold text-fg">
+                    OpenGeni in Slack
+                  </h3>
+                  <p className="mt-1 max-w-xl text-xs leading-5 text-fg-muted">
+                    Use mentions, /opengeni, DMs and message shortcuts.
+                  </p>
                 </div>
               </div>
+            </div>
 
-              {slackBotConnection && slackBotMetadata ? (
-                <>
-                  <div className="mt-4 flex items-start gap-3 rounded-lg border border-brand/20 bg-brand/5 p-3">
-                    <CheckCircle2Icon className="mt-0.5 size-5 shrink-0 text-brand" />
-                    <div>
-                      <p className="text-sm font-semibold text-fg">
-                        {slackBotConnection.status === "active"
-                          ? `Installed in ${slackBotMetadata.slackTeamName}`
-                          : `Reinstall needed for ${slackBotMetadata.slackTeamName}`}
-                      </p>
-                      <p className="mt-0.5 text-xs text-fg-muted">
-                        {slackBotConnection.status === "active"
-                          ? "The workspace bot is ready to use in this Slack workspace."
-                          : "Reinstall the workspace bot to restore its Slack access."}
-                      </p>
-                    </div>
+            {slackBotConnection && slackBotMetadata ? (
+              <>
+                <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-brand/20 bg-brand/5 p-3">
+                  <div className="flex items-center gap-2">
+                    <CheckCircle2Icon className="size-4 shrink-0 text-brand" />
+                    <p className="text-sm font-medium text-fg">
+                      {slackBotConnection.status === "active"
+                        ? `Connected to ${slackBotMetadata.slackTeamName}`
+                        : `${slackBotMetadata.slackTeamName} needs to be reconnected`}
+                    </p>
                   </div>
+                  {slackBotConnection.status !== "active" ? (
+                    <SlackBotInstallControls
+                      canInstall={canInstallSlackBot}
+                      hasConnection
+                      busy={slackBotBusy}
+                      onInstall={(createNewConnection) => void installSlackBot(createNewConnection)}
+                    />
+                  ) : null}
+                </div>
 
-                  <div className="mt-3 rounded-lg border border-border bg-bg/40 p-3">
+                <details className="group mt-3 rounded-lg border border-border bg-bg/30 p-3">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-xs font-medium text-fg">
+                    <span>Settings</span>
+                    <ChevronDownIcon className="size-3.5 text-fg-subtle transition-transform group-open:rotate-180" />
+                  </summary>
+                  <div className="mt-3 border-t border-border/70 pt-3">
                     <div className="flex flex-wrap items-end justify-between gap-3">
                       <div>
-                        <p className="text-xs font-semibold text-fg">Slack knowledge destination</p>
+                        <p className="text-xs font-semibold text-fg">Knowledge from Slack</p>
                         <p className="mt-1 text-2xs leading-4 text-fg-muted">
-                          Saved as {slackBotDestinationLabel(savedSlackDestinationAuthority)}. No
-                          user-created collection is required.
+                          Save imported Slack content to{" "}
+                          {slackBotDestinationLabel(savedSlackDestinationAuthority)}.
                         </p>
                       </div>
                       <div className="flex flex-wrap items-end gap-2">
@@ -1291,27 +1274,29 @@ export function CapabilitiesRoute({
                           {slackDestinationBusy ? (
                             <Loader2Icon className="size-3.5 animate-spin" />
                           ) : null}
-                          Save destination
+                          Save
                         </Button>
                       </div>
                     </div>
                   </div>
 
-                  <SlackReactionSummonCard
-                    workspaceId={workspaceId}
-                    connection={slackBotConnection}
-                    canManage={canManageSlackReaction}
-                    installBusy={slackBotBusy}
-                    onReinstall={() => void installSlackBot(false)}
-                  />
+                  <div className="mt-3">
+                    <SlackReactionSummonCard
+                      workspaceId={workspaceId}
+                      connection={slackBotConnection}
+                      canManage={canManageSlackReaction}
+                      installBusy={slackBotBusy}
+                      onReinstall={() => void installSlackBot(false)}
+                    />
+                  </div>
 
                   <details className="group mt-3 border-t border-border/70 pt-3">
                     <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
                       <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
-                      <span>Workspace bot permissions and installation details</span>
+                      <span>Connection details</span>
                     </summary>
                     <div className="mt-3 rounded-md bg-bg/50 p-3">
-                      <p className="text-2xs font-medium text-fg-muted">Required bot scopes</p>
+                      <p className="text-2xs font-medium text-fg-muted">Slack permissions</p>
                       <p className="mt-1 break-words font-mono text-2xs leading-relaxed text-fg-subtle">
                         {OPENGENI_SLACK_BOT_REQUIRED_SCOPES.join(", ")}
                       </p>
@@ -1344,29 +1329,58 @@ export function CapabilitiesRoute({
                       ) : null}
                     </div>
                   </details>
-                </>
-              ) : (
-                <>
-                  <p className="mt-4 max-w-2xl text-xs text-fg-muted">
-                    Install the OpenGeni bot in a Slack workspace to get started.
+                </details>
+              </>
+            ) : (
+              <>
+                <SlackBotInstallControls
+                  canInstall={canInstallSlackBot}
+                  hasConnection={false}
+                  busy={slackBotBusy}
+                  onInstall={(createNewConnection) => void installSlackBot(createNewConnection)}
+                />
+                <details className="group mt-3">
+                  <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
+                    <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
+                    <span>Permissions</span>
+                  </summary>
+                  <p className="mt-2 text-2xs leading-5 text-fg-muted">
+                    Slack shows these permissions before you approve the installation.
                   </p>
-                  <SlackBotInstallControls
-                    canInstall={canInstallSlackBot}
-                    hasConnection={false}
-                    busy={slackBotBusy}
-                    onInstall={(createNewConnection) => void installSlackBot(createNewConnection)}
-                  />
-                  <details className="group mt-3">
-                    <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
-                      <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
-                      <span>Workspace bot permissions requested</span>
-                    </summary>
-                    <WorkspaceSlackBotRequestedScopes />
-                  </details>
-                </>
-              )}
-            </section>
-          </div>
+                  <WorkspaceSlackBotRequestedScopes />
+                </details>
+              </>
+            )}
+          </section>
+
+          <details className="group mt-3 rounded-xl border border-border bg-surface px-4 py-3">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
+              <div className="flex min-w-0 items-start gap-3">
+                <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-fg-muted/10 text-fg-muted">
+                  <PlugIcon className="size-4" />
+                </span>
+                <div>
+                  <p className="text-sm font-medium text-fg">Use Slack as me</p>
+                  <p className="mt-0.5 text-xs text-fg-muted">
+                    Optional. Only needed when an agent should act through your account.
+                  </p>
+                </div>
+              </div>
+              <ChevronDownIcon className="size-4 shrink-0 text-fg-subtle transition-transform group-open:rotate-180" />
+            </summary>
+            <div className="mt-3 border-t border-border/70 pt-3">
+              <PersonalSlackAccountCard
+                available={personalSlackItem !== null}
+                canManage={canManagePersonalSlack}
+                busy={personalSlackBusy}
+                accountState={personalSlackStatus}
+                embedded
+                onConnect={() => void startPersonalSlackOAuth()}
+                onReconnect={() => void startPersonalSlackOAuth()}
+                onDisconnect={() => setPersonalSlackDisconnectOpen(true)}
+              />
+            </div>
+          </details>
         </section>
 
         <ConfirmDialog

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -86,6 +86,7 @@ import {
 import { listViewState } from "@/lib/load-state";
 import {
   googleDriveAccountState,
+  localConnectedGoogleDrivePreview,
   preferredGoogleDriveConnection,
 } from "@/lib/google-drive-connection";
 import { mcpOAuthCallbackFailureMessage, startMcpOAuthWithTimeout } from "@/lib/mcp-oauth";
@@ -387,8 +388,16 @@ export function CapabilitiesRoute({
     [client],
   );
   const connectionsLoaded = connections !== null;
-  const googleDriveConnection = preferredGoogleDriveConnection(connections ?? []);
-  const googleDriveState = googleDriveAccountState(googleDriveConnection, connectionsLoaded);
+  const googleDrivePreviewConnection = localConnectedGoogleDrivePreview(
+    window.location.search,
+    workspaceId,
+  );
+  const googleDriveConnection =
+    googleDrivePreviewConnection ?? preferredGoogleDriveConnection(connections ?? []);
+  const googleDriveState = googleDriveAccountState(
+    googleDriveConnection,
+    googleDrivePreviewConnection !== null || connectionsLoaded,
+  );
   const personalSlackItem = personalSlackCapability(items);
   const personalSlackConnection = preferredPersonalSlackConnection(connections ?? []);
   const personalSlackStatus = personalSlackAccountState(personalSlackConnection, connectionsLoaded);

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -1480,8 +1480,8 @@ export function CapabilitiesRoute({
                 )}
               </section>
 
-              <details className="group mt-3 rounded-xl border border-border bg-surface px-4 py-3">
-                <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
+              <section className="mt-3 rounded-xl border border-border bg-surface px-4 py-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
                   <div className="flex min-w-0 items-start gap-3">
                     <span className="grid size-8 shrink-0 place-items-center rounded-lg border border-border bg-bg">
                       <AppLogo app="slack" className="size-4" />
@@ -1493,30 +1493,27 @@ export function CapabilitiesRoute({
                       </p>
                     </div>
                   </div>
-                  <div className="flex shrink-0 items-center gap-2 text-xs text-fg-muted">
-                    <span>
+                  <div className="flex shrink-0 flex-wrap items-center justify-end gap-3">
+                    <span className="text-xs text-fg-muted">
                       {personalSlackAccountStatusLabel(
                         visiblePersonalSlackStatus,
                         personalSlackAvailable,
                       )}
                     </span>
-                    <ChevronDownIcon className="size-4 text-fg-subtle transition-transform group-open:rotate-180" />
+                    <PersonalSlackAccountCard
+                      available={personalSlackAvailable}
+                      canManage={canManagePersonalSlack}
+                      busy={personalSlackBusy}
+                      accountState={visiblePersonalSlackStatus}
+                      embedded
+                      readOnly={slackPreview !== null}
+                      onConnect={() => void startPersonalSlackOAuth()}
+                      onReconnect={() => void startPersonalSlackOAuth()}
+                      onDisconnect={() => setPersonalSlackDisconnectOpen(true)}
+                    />
                   </div>
-                </summary>
-                <div className="mt-3 border-t border-border/70 pt-3">
-                  <PersonalSlackAccountCard
-                    available={personalSlackAvailable}
-                    canManage={canManagePersonalSlack}
-                    busy={personalSlackBusy}
-                    accountState={visiblePersonalSlackStatus}
-                    embedded
-                    readOnly={slackPreview !== null}
-                    onConnect={() => void startPersonalSlackOAuth()}
-                    onReconnect={() => void startPersonalSlackOAuth()}
-                    onDisconnect={() => setPersonalSlackDisconnectOpen(true)}
-                  />
                 </div>
-              </details>
+              </section>
             </section>
           </SheetContent>
         </Sheet>

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -216,14 +216,6 @@ export function canManageSlackReactionSummon(
   return grant?.permissions.includes("workspace:admin") === true;
 }
 
-export function WorkspaceSlackBotRequestedScopes() {
-  return (
-    <p className="mt-2 max-w-3xl break-words font-mono text-2xs leading-relaxed text-fg-subtle">
-      {OPENGENI_SLACK_BOT_REQUESTED_SCOPES.join(", ")}
-    </p>
-  );
-}
-
 export function SlackBotInstallControls({
   canInstall,
   hasConnection,
@@ -1459,24 +1451,12 @@ export function CapabilitiesRoute({
                     </details>
                   </>
                 ) : (
-                  <>
-                    <SlackBotInstallControls
-                      canInstall={canInstallSlackBot}
-                      hasConnection={false}
-                      busy={slackBotBusy}
-                      onInstall={(createNewConnection) => void installSlackBot(createNewConnection)}
-                    />
-                    <details className="group mt-3">
-                      <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-2xs text-fg-subtle transition-colors hover:text-fg-muted">
-                        <ChevronDownIcon className="size-3 shrink-0 transition-transform group-open:rotate-180" />
-                        <span>Permissions</span>
-                      </summary>
-                      <p className="mt-2 text-2xs leading-5 text-fg-muted">
-                        Slack shows these permissions before you approve the installation.
-                      </p>
-                      <WorkspaceSlackBotRequestedScopes />
-                    </details>
-                  </>
+                  <SlackBotInstallControls
+                    canInstall={canInstallSlackBot}
+                    hasConnection={false}
+                    busy={slackBotBusy}
+                    onInstall={(createNewConnection) => void installSlackBot(createNewConnection)}
+                  />
                 )}
               </section>
 

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -249,7 +249,7 @@ export function SlackBotInstallControls({
   }
 
   return (
-    <div className="mt-4">
+    <div className="shrink-0">
       <button
         type="button"
         aria-busy={busy}
@@ -1297,8 +1297,8 @@ export function CapabilitiesRoute({
                 className="mt-3 rounded-xl border border-border bg-surface p-4"
                 aria-labelledby="workspace-slack-bot-heading"
               >
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="flex min-w-0 items-start gap-3">
+                <div className="flex items-center gap-3">
+                  <div className="flex min-w-0 flex-1 items-start gap-3">
                     <span className="grid size-9 shrink-0 place-items-center rounded-lg border border-border bg-bg">
                       <AppLogo app="slack" className="size-5" />
                     </span>
@@ -1314,6 +1314,14 @@ export function CapabilitiesRoute({
                       </p>
                     </div>
                   </div>
+                  {!visibleSlackBotConnection || !visibleSlackBotMetadata ? (
+                    <SlackBotInstallControls
+                      canInstall={canInstallSlackBot}
+                      hasConnection={false}
+                      busy={slackBotBusy}
+                      onInstall={(createNewConnection) => void installSlackBot(createNewConnection)}
+                    />
+                  ) : null}
                 </div>
 
                 {visibleSlackBotConnection && visibleSlackBotMetadata ? (
@@ -1447,14 +1455,7 @@ export function CapabilitiesRoute({
                       </details>
                     </details>
                   </>
-                ) : (
-                  <SlackBotInstallControls
-                    canInstall={canInstallSlackBot}
-                    hasConnection={false}
-                    busy={slackBotBusy}
-                    onInstall={(createNewConnection) => void installSlackBot(createNewConnection)}
-                  />
-                )}
+                ) : null}
               </section>
 
               <section className="mt-3 rounded-xl border border-border bg-surface px-4 py-3">

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -11,7 +11,6 @@ import {
 } from "@opengeni/contracts/slack-bot-scopes";
 import { usePacks, useVariableSets } from "@opengeni/react";
 import {
-  Building2Icon,
   CheckCircle2Icon,
   ChevronDownIcon,
   GlobeIcon,
@@ -1271,14 +1270,14 @@ export function CapabilitiesRoute({
           </div>
           <div className="grid gap-2 sm:grid-cols-2">
             <ManagedAppTile
-              icon={<HardDriveIcon className="size-5" />}
+              icon={<AppLogo app="googleDrive" />}
               name="Google Drive"
               description="Search, sync, and create files in Drive."
               status={googleDriveStatusLabel(googleDriveState.state)}
               onOpen={() => setManagedApp("google-drive")}
             />
             <ManagedAppTile
-              icon={<MessagesSquareIcon className="size-5" />}
+              icon={<AppLogo app="slack" />}
               name="Slack"
               description="Chat with OpenGeni and start work from Slack."
               status={slackAppStatus}
@@ -1315,8 +1314,8 @@ export function CapabilitiesRoute({
               >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="flex min-w-0 items-start gap-3">
-                    <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-brand/10 text-brand">
-                      <Building2Icon className="size-4" />
+                    <span className="grid size-9 shrink-0 place-items-center rounded-lg border border-border bg-bg">
+                      <AppLogo app="slack" className="size-5" />
                     </span>
                     <div className="min-w-0">
                       <h3
@@ -1495,8 +1494,8 @@ export function CapabilitiesRoute({
               <details className="group mt-3 rounded-xl border border-border bg-surface px-4 py-3">
                 <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
                   <div className="flex min-w-0 items-start gap-3">
-                    <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-fg-muted/10 text-fg-muted">
-                      <PlugIcon className="size-4" />
+                    <span className="grid size-8 shrink-0 place-items-center rounded-lg border border-border bg-bg">
+                      <AppLogo app="slack" className="size-4" />
                     </span>
                     <div>
                       <p className="text-sm font-medium text-fg">Personal Slack</p>
@@ -1728,6 +1727,30 @@ export function googleDriveStatusLabel(
   if (state === "not_connected" || state === "disconnected") return "Not connected";
   if (state === "unverified") return "Loading";
   return "Needs attention";
+}
+
+const APP_LOGO_URLS = {
+  googleDrive:
+    "https://www.gstatic.com/images/branding/productlogos/drive_2026/v2/web-64dp/logo_drive_2026_color_2x_web_64dp.png",
+  slack: "https://a.slack-edge.com/80588/marketing/img/meta/slack_hash_256.png",
+} as const;
+
+function AppLogo({ app, className }: { app: keyof typeof APP_LOGO_URLS; className?: string }) {
+  const [failed, setFailed] = useState(false);
+  if (failed) {
+    const FallbackIcon = app === "googleDrive" ? HardDriveIcon : MessagesSquareIcon;
+    return <FallbackIcon className={cn("size-5 text-fg-muted", className)} aria-hidden="true" />;
+  }
+  return (
+    <img
+      src={APP_LOGO_URLS[app]}
+      alt=""
+      aria-hidden="true"
+      draggable={false}
+      onError={() => setFailed(true)}
+      className={cn("size-6 object-contain", className)}
+    />
+  );
 }
 
 function ManagedAppTile({

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -166,7 +166,7 @@ export function localConnectedSlackPreview(
       id: "00000000-0000-4000-8000-000000000003",
       subjectId: null,
       kind: "app_install",
-      grantedScopes: [...OPENGENI_SLACK_BOT_REQUIRED_SCOPES],
+      grantedScopes: [...OPENGENI_SLACK_BOT_REQUESTED_SCOPES],
       verifiedInstallAt: now,
       verifiedInstallVersion: 1,
       metadata: {
@@ -246,7 +246,7 @@ export function SlackBotInstallControls({
             onClick={() => onInstall(false)}
           >
             {busy ? <Loader2Icon className="animate-spin" /> : null}
-            Reinstall
+            Reconnect
           </Button>
           {canInstall ? (
             <Button type="button" variant="ghost" disabled={busy} onClick={() => onInstall(true)}>
@@ -328,8 +328,6 @@ export function CapabilitiesRoute({
   const [slackBotBusy, setSlackBotBusy] = useState(false);
   const [slackDestinationBusy, setSlackDestinationBusy] = useState(false);
   const [slackDestinationAuthority, setSlackDestinationAuthority] =
-    useState<ConnectorDocumentDestinationAuthority>("workspace");
-  const [savedSlackDestinationAuthority, setSavedSlackDestinationAuthority] =
     useState<ConnectorDocumentDestinationAuthority>("workspace");
 
   const [filter, setFilter] = useState<CapabilityFilter>(
@@ -421,7 +419,6 @@ export function CapabilitiesRoute({
   useEffect(() => {
     const authority = slackBotDocumentDestinationAuthority(slackBotConnection?.metadata);
     setSlackDestinationAuthority(authority);
-    setSavedSlackDestinationAuthority(authority);
   }, [slackBotConnection?.id, slackBotConnection?.metadata]);
   // The item the sheet renders, always from the live catalog. Registry items
   // aren't in `items` until persisted, so they fall back to their snapshot; a
@@ -640,7 +637,6 @@ export function CapabilitiesRoute({
           },
         },
       });
-      setSavedSlackDestinationAuthority(slackDestinationAuthority);
       toast.success("Slack knowledge destination saved");
     } catch (error) {
       toast.error("Couldn't save the Slack knowledge destination", {
@@ -1362,10 +1358,12 @@ export function CapabilitiesRoute({
                       <div className="mt-3 border-t border-border/70 pt-3">
                         <div className="flex flex-wrap items-end justify-between gap-3">
                           <div>
-                            <p className="text-xs font-semibold text-fg">Knowledge from Slack</p>
+                            <p className="text-xs font-semibold text-fg">
+                              Save imported Slack messages
+                            </p>
                             <p className="mt-1 text-2xs leading-4 text-fg-muted">
-                              Save imported Slack content to{" "}
-                              {slackBotDestinationLabel(savedSlackDestinationAuthority)}.
+                              Messages are saved only when explicitly imported. Slack is not synced
+                              automatically.
                             </p>
                           </div>
                           <div className="flex flex-wrap items-end gap-2">
@@ -1381,7 +1379,6 @@ export function CapabilitiesRoute({
                                   )
                                 }
                               >
-                                <option value="personal">My knowledge</option>
                                 <option
                                   value="workspace"
                                   disabled={!canManageSlackWorkspaceDestination}
@@ -1424,7 +1421,7 @@ export function CapabilitiesRoute({
                           connection={visibleSlackBotConnection}
                           canManage={canManageSlackReaction}
                           installBusy={slackBotBusy}
-                          onReinstall={() => void installSlackBot(false)}
+                          onUpdatePermissions={() => void installSlackBot(false)}
                         />
                       </div>
 
@@ -1445,14 +1442,6 @@ export function CapabilitiesRoute({
                               ? ` · ${slackBotConnections.length} Slack installations`
                               : ""}
                           </p>
-                          <SlackBotInstallControls
-                            canInstall={canInstallSlackBot}
-                            hasConnection
-                            busy={slackBotBusy}
-                            onInstall={(createNewConnection) =>
-                              void installSlackBot(createNewConnection)
-                            }
-                          />
                           {visibleSlackBotConnection.status === "active" ? (
                             <Button
                               type="button"
@@ -1982,17 +1971,7 @@ export function slackBotDocumentDestinationAuthority(
     return "workspace";
   }
   const authorityKind = (destination as Record<string, unknown>).authorityKind;
-  return authorityKind === "organization" ||
-    authorityKind === "workspace" ||
-    authorityKind === "personal"
+  return authorityKind === "organization" || authorityKind === "workspace"
     ? authorityKind
     : "workspace";
-}
-
-export function slackBotDestinationLabel(
-  authorityKind: ConnectorDocumentDestinationAuthority,
-): string {
-  if (authorityKind === "organization") return "organization knowledge";
-  if (authorityKind === "personal") return "your personal knowledge";
-  return "workspace knowledge";
 }

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -32,7 +32,10 @@ import {
 import { CapabilityLogo } from "@/components/capabilities/capability-logo";
 import { CapabilityTile } from "@/components/capabilities/capability-tile";
 import { PacksSection } from "@/components/capabilities/packs-section";
-import { PersonalSlackAccountCard } from "@/components/capabilities/personal-slack-account-card";
+import {
+  PersonalSlackAccountCard,
+  personalSlackAccountStatusLabel,
+} from "@/components/capabilities/personal-slack-account-card";
 import { SlackReactionSummonCard } from "@/components/capabilities/slack-reaction-summon-card";
 import { LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
@@ -74,6 +77,7 @@ import {
   personalSlackCapability,
   personalSlackOAuthTarget,
   preferredPersonalSlackConnection,
+  type PersonalSlackAccountState,
 } from "@/lib/personal-slack";
 import {
   openGeniSlackBotConnections,
@@ -100,6 +104,65 @@ import type {
 
 const PAGE_SIZE = 48;
 const FILTERS: CapabilityFilter[] = ["all", "pack", "mcp", "api", "skill", "plugin"];
+
+export function localConnectedSlackPreview(
+  search: string,
+  workspaceId: string,
+  enabled = import.meta.env.DEV,
+): { bot: ConnectionMetadata; personal: PersonalSlackAccountState } | null {
+  if (!enabled || new URLSearchParams(search).get("previewSlack") !== "connected") {
+    return null;
+  }
+
+  const now = new Date().toISOString();
+  const shared = {
+    accountId: "00000000-0000-4000-8000-000000000001",
+    workspaceId,
+    providerDomain: "slack.com",
+    status: "active" as const,
+    expiresAt: null,
+    lastRefreshAt: now,
+    lastUsedAt: now,
+    lastError: null,
+    version: 1,
+    createdBySubjectId: "preview-user",
+    updatedBySubjectId: "preview-user",
+    createdAt: now,
+    updatedAt: now,
+  };
+  const personalConnection: ConnectionMetadata = {
+    ...shared,
+    id: "00000000-0000-4000-8000-000000000002",
+    subjectId: "preview-user",
+    kind: "oauth2",
+    grantedScopes: ["search:read.public", "channels:history", "chat:write"],
+    metadata: {},
+  };
+
+  return {
+    bot: {
+      ...shared,
+      id: "00000000-0000-4000-8000-000000000003",
+      subjectId: null,
+      kind: "app_install",
+      grantedScopes: [...OPENGENI_SLACK_BOT_REQUIRED_SCOPES],
+      verifiedInstallAt: now,
+      verifiedInstallVersion: 1,
+      metadata: {
+        credentialRole: "opengeni_slack_bot",
+        credentialLabel: "OpenGeni Slack bot",
+        slackTeamId: "T_CLOUDGENI_PREVIEW",
+        slackTeamName: "CloudGeni",
+        botDisplayName: "OpenGeni",
+      },
+    },
+    personal: {
+      state: "connected",
+      connection: personalConnection,
+      accessTokenRefreshDue: false,
+    },
+  };
+}
 
 export function canWriteWorkspaceConnections(
   accessContext: AccessContext | null,
@@ -285,10 +348,12 @@ export function CapabilitiesRoute({
   const enabledItems = useMemo(() => filtered.filter((item) => item.enabled), [filtered]);
   const browseItems = useMemo(() => filtered.filter((item) => !item.enabled), [filtered]);
   const visibleBrowse = browseItems.slice(0, visibleCount);
+  const slackPreview = localConnectedSlackPreview(window.location.search, workspaceId);
   const slackBotConnections = openGeniSlackBotConnections(connections ?? []);
   const slackBotConnection = preferredOpenGeniSlackBotConnection(slackBotConnections);
-  const slackBotMetadata = slackBotConnection
-    ? openGeniSlackBotUiMetadata(slackBotConnection)
+  const visibleSlackBotConnection = slackPreview?.bot ?? slackBotConnection;
+  const visibleSlackBotMetadata = visibleSlackBotConnection
+    ? openGeniSlackBotUiMetadata(visibleSlackBotConnection)
     : null;
   const slackWorkspaceGrant = context.accessContext?.workspaceGrants.find(
     (grant) => grant.workspaceId === workspaceId,
@@ -316,6 +381,8 @@ export function CapabilitiesRoute({
   const personalSlackItem = personalSlackCapability(items);
   const personalSlackConnection = preferredPersonalSlackConnection(connections ?? []);
   const personalSlackStatus = personalSlackAccountState(personalSlackConnection, connectionsLoaded);
+  const visiblePersonalSlackStatus = slackPreview?.personal ?? personalSlackStatus;
+  const personalSlackAvailable = personalSlackItem !== null || slackPreview !== null;
   const canManagePersonalSlack = canWriteWorkspaceConnections(context.accessContext, workspaceId);
 
   useEffect(() => {
@@ -1195,18 +1262,18 @@ export function CapabilitiesRoute({
               </div>
             </div>
 
-            {slackBotConnection && slackBotMetadata ? (
+            {visibleSlackBotConnection && visibleSlackBotMetadata ? (
               <>
                 <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-brand/20 bg-brand/5 p-3">
                   <div className="flex items-center gap-2">
                     <CheckCircle2Icon className="size-4 shrink-0 text-brand" />
                     <p className="text-sm font-medium text-fg">
-                      {slackBotConnection.status === "active"
-                        ? `Connected to ${slackBotMetadata.slackTeamName}`
-                        : `${slackBotMetadata.slackTeamName} needs to be reconnected`}
+                      {visibleSlackBotConnection.status === "active"
+                        ? `Connected to ${visibleSlackBotMetadata.slackTeamName}`
+                        : `${visibleSlackBotMetadata.slackTeamName} needs to be reconnected`}
                     </p>
                   </div>
-                  {slackBotConnection.status !== "active" ? (
+                  {visibleSlackBotConnection.status !== "active" ? (
                     <SlackBotInstallControls
                       canInstall={canInstallSlackBot}
                       hasConnection
@@ -1283,7 +1350,7 @@ export function CapabilitiesRoute({
                   <div className="mt-3">
                     <SlackReactionSummonCard
                       workspaceId={workspaceId}
-                      connection={slackBotConnection}
+                      connection={visibleSlackBotConnection}
                       canManage={canManageSlackReaction}
                       installBusy={slackBotBusy}
                       onReinstall={() => void installSlackBot(false)}
@@ -1302,8 +1369,8 @@ export function CapabilitiesRoute({
                       </p>
                       <p className="mt-2 text-2xs text-fg-subtle">
                         Bot connection ID:{" "}
-                        <span className="font-mono">{slackBotConnection.id}</span>
-                        {slackBotConnections.length > 1
+                        <span className="font-mono">{visibleSlackBotConnection.id}</span>
+                        {(slackPreview ? 1 : slackBotConnections.length) > 1
                           ? ` · ${slackBotConnections.length} Slack installations`
                           : ""}
                       </p>
@@ -1315,7 +1382,7 @@ export function CapabilitiesRoute({
                           void installSlackBot(createNewConnection)
                         }
                       />
-                      {slackBotConnection.status === "active" ? (
+                      {visibleSlackBotConnection.status === "active" ? (
                         <Button
                           type="button"
                           variant="ghost"
@@ -1360,21 +1427,30 @@ export function CapabilitiesRoute({
                   <PlugIcon className="size-4" />
                 </span>
                 <div>
-                  <p className="text-sm font-medium text-fg">Use Slack as me</p>
+                  <p className="text-sm font-medium text-fg">Personal Slack</p>
                   <p className="mt-0.5 text-xs text-fg-muted">
-                    Optional. Only needed when an agent should act through your account.
+                    Let agents act through your Slack account.
                   </p>
                 </div>
               </div>
-              <ChevronDownIcon className="size-4 shrink-0 text-fg-subtle transition-transform group-open:rotate-180" />
+              <div className="flex shrink-0 items-center gap-2 text-xs text-fg-muted">
+                <span>
+                  {personalSlackAccountStatusLabel(
+                    visiblePersonalSlackStatus,
+                    personalSlackAvailable,
+                  )}
+                </span>
+                <ChevronDownIcon className="size-4 text-fg-subtle transition-transform group-open:rotate-180" />
+              </div>
             </summary>
             <div className="mt-3 border-t border-border/70 pt-3">
               <PersonalSlackAccountCard
-                available={personalSlackItem !== null}
+                available={personalSlackAvailable}
                 canManage={canManagePersonalSlack}
                 busy={personalSlackBusy}
-                accountState={personalSlackStatus}
+                accountState={visiblePersonalSlackStatus}
                 embedded
+                readOnly={slackPreview !== null}
                 onConnect={() => void startPersonalSlackOAuth()}
                 onReconnect={() => void startPersonalSlackOAuth()}
                 onDisconnect={() => setPersonalSlackDisconnectOpen(true)}

--- a/apps/web/src/routes/capabilities.tsx
+++ b/apps/web/src/routes/capabilities.tsx
@@ -42,10 +42,7 @@ import {
 import { CapabilityLogo } from "@/components/capabilities/capability-logo";
 import { CapabilityTile } from "@/components/capabilities/capability-tile";
 import { PacksSection } from "@/components/capabilities/packs-section";
-import {
-  PersonalSlackAccountCard,
-  personalSlackAccountStatusLabel,
-} from "@/components/capabilities/personal-slack-account-card";
+import { PersonalSlackAccountCard } from "@/components/capabilities/personal-slack-account-card";
 import { SlackReactionSummonCard } from "@/components/capabilities/slack-reaction-summon-card";
 import { LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
@@ -1474,12 +1471,6 @@ export function CapabilitiesRoute({
                     </div>
                   </div>
                   <div className="flex shrink-0 flex-wrap items-center justify-end gap-3">
-                    <span className="text-xs text-fg-muted">
-                      {personalSlackAccountStatusLabel(
-                        visiblePersonalSlackStatus,
-                        personalSlackAvailable,
-                      )}
-                    </span>
                     <PersonalSlackAccountCard
                       available={personalSlackAvailable}
                       canManage={canManagePersonalSlack}

--- a/apps/web/src/routes/documents.test.tsx
+++ b/apps/web/src/routes/documents.test.tsx
@@ -192,27 +192,31 @@ describe("Documents Default collection UX", () => {
       await settleRoute();
 
       expect(listDocuments).toHaveBeenCalledWith("workspace-a", defaultBase.id);
-      expect(container.textContent).toContain("Upload immediately for agent search");
+      expect(container.textContent).toContain(
+        "Add information agents can find when it is relevant",
+      );
+      expect(container.textContent).toContain("Add knowledge");
       expect(container.textContent).toContain("Collections (optional)");
-      expect(container.textContent).toContain("New collectionoptional");
+      expect(container.textContent).not.toContain("Advanced access");
+      expect(container.textContent).not.toContain("ACL tags");
+      expect(container.textContent).not.toContain("Search filters");
       expect(container.textContent).not.toContain("Create your first base");
       const upload = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
-        (button) => button.textContent?.trim() === "Upload files",
+        (button) => button.textContent?.trim() === "Choose files",
       );
       expect(upload).not.toBeUndefined();
       expect(upload?.disabled).toBe(false);
-      const authoritySelects = [
-        container.querySelector<HTMLSelectElement>('[aria-label="Drop authority"]'),
-        container.querySelector<HTMLSelectElement>('[aria-label="Upload authority"]'),
-      ];
-      for (const select of authoritySelects) {
-        expect(select?.value).toBe("workspace");
-        expect([...select!.options].map((option) => [option.value, option.textContent])).toEqual([
-          ["organization", "Company"],
-          ["workspace", "Current workspace"],
-          ["personal", "Only me"],
-        ]);
-      }
+      const authoritySelect = container.querySelector<HTMLSelectElement>(
+        '[aria-label="Drop authority"]',
+      );
+      expect(authoritySelect?.value).toBe("workspace");
+      expect(
+        [...authoritySelect!.options].map((option) => [option.value, option.textContent]),
+      ).toEqual([
+        ["organization", "Company"],
+        ["workspace", "Current workspace"],
+        ["personal", "Only me"],
+      ]);
     } finally {
       await act(async () => root.unmount());
       container.remove();
@@ -231,12 +235,12 @@ describe("Documents Default collection UX", () => {
       });
       await settleRoute();
 
-      const uploadAuthority = container.querySelector<HTMLSelectElement>(
-        '[aria-label="Upload authority"]',
+      const dropAuthority = container.querySelector<HTMLSelectElement>(
+        '[aria-label="Drop authority"]',
       )!;
       await act(async () => {
-        uploadAuthority.value = "organization";
-        uploadAuthority.dispatchEvent(new Event("change", { bubbles: true }));
+        dropAuthority.value = "organization";
+        dropAuthority.dispatchEvent(new Event("change", { bubbles: true }));
       });
 
       const ordinaryUpload = container.querySelector<HTMLInputElement>(
@@ -256,12 +260,10 @@ describe("Documents Default collection UX", () => {
         expect.objectContaining({
           fileId: "44444444-4444-4444-8444-444444444444",
           authorityKind: "organization",
+          agentAccess: true,
         }),
       );
 
-      const dropAuthority = container.querySelector<HTMLSelectElement>(
-        '[aria-label="Drop authority"]',
-      )!;
       const dropText = container.querySelector<HTMLTextAreaElement>(
         '[aria-label="Knowledge drop text"]',
       )!;
@@ -271,7 +273,7 @@ describe("Documents Default collection UX", () => {
         setControlledTextarea(dropText, "Personal note");
       });
       const dropButton = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
-        (button) => button.textContent?.trim() === "Drop",
+        (button) => button.textContent?.trim() === "Add",
       )!;
       await act(async () => {
         dropButton.click();
@@ -281,7 +283,11 @@ describe("Documents Default collection UX", () => {
 
       expect(createKnowledgeDrop).toHaveBeenCalledWith(
         "workspace-a",
-        expect.objectContaining({ text: "Personal note", authorityKind: "personal" }),
+        expect.objectContaining({
+          text: "Personal note",
+          authorityKind: "personal",
+          agentAccess: true,
+        }),
       );
 
       const droppedFile = new File(["personal file"], "personal.txt", { type: "text/plain" });
@@ -298,6 +304,7 @@ describe("Documents Default collection UX", () => {
         expect.objectContaining({
           fileId: "44444444-4444-4444-8444-444444444444",
           authorityKind: "personal",
+          agentAccess: true,
         }),
       ]);
     } finally {

--- a/apps/web/src/routes/documents.test.tsx
+++ b/apps/web/src/routes/documents.test.tsx
@@ -62,24 +62,18 @@ const listDocuments = mock(async (_workspaceId: string, _baseId: string) => []);
 const uploadFile = mock(async (_workspaceId: string, _request: unknown) => ({
   id: "44444444-4444-4444-8444-444444444444",
 }));
-const addDocument = mock(
-  async (
-    _workspaceId: string,
-    _baseId: string,
-    request: { authorityKind?: DocumentAuthorityKind },
-  ) => indexedDocument(request.authorityKind ?? "workspace"),
-);
 const createKnowledgeDrop = mock(
   async (_workspaceId: string, request: { authorityKind?: DocumentAuthorityKind }) =>
     indexedDocument(request.authorityKind ?? "workspace"),
 );
+const searchKnowledge = mock(async () => ({ results: [] }));
 const context = {
   client: {
     listDocumentBases,
     listDocuments,
     uploadFile,
-    addDocument,
     createKnowledgeDrop,
+    searchKnowledge,
   },
   clientConfig: { fileUploads: { enabled: true, maxSizeBytes: 10_000_000 } },
 };
@@ -93,7 +87,6 @@ const {
   DOCUMENT_AUTHORITY_OPTIONS,
   DocumentsRoute,
   documentAuthorityLabel,
-  resolveDocumentCollectionSelection,
 } = await import("./documents");
 
 beforeAll(() => {
@@ -112,8 +105,8 @@ beforeEach(() => {
   listDocumentBases.mockClear();
   listDocuments.mockClear();
   uploadFile.mockClear();
-  addDocument.mockClear();
   createKnowledgeDrop.mockClear();
+  searchKnowledge.mockClear();
 });
 
 async function settleRoute(): Promise<void> {
@@ -139,6 +132,17 @@ function setControlledTextarea(textarea: HTMLTextAreaElement, value: string): vo
   onChange!({ target: textarea });
 }
 
+function setControlledInput(input: HTMLInputElement, value: string): void {
+  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, value);
+  const reactPropsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
+  expect(reactPropsKey).toBeDefined();
+  const onChange = (
+    input as unknown as Record<string, { onChange?: (event: { target: HTMLInputElement }) => void }>
+  )[reactPropsKey!]!.onChange;
+  expect(typeof onChange).toBe("function");
+  onChange!({ target: input });
+}
+
 function fireFileDrop(target: HTMLElement, files: File[]): void {
   const fileList = {
     ...files,
@@ -154,7 +158,7 @@ function fireFileDrop(target: HTMLElement, files: File[]): void {
   target.dispatchEvent(event);
 }
 
-describe("Documents Default collection UX", () => {
+describe("Documents scope-first UX", () => {
   test("uses the fixed authority labels, mappings, and workspace-safe default", () => {
     expect(DOCUMENT_AUTHORITY_OPTIONS).toEqual([
       { value: "organization", label: "Company" },
@@ -167,19 +171,7 @@ describe("Documents Default collection UX", () => {
     expect(documentAuthorityLabel("personal")).toBe("Only me");
   });
 
-  test("keeps valid choices and recovers missing choices to Default", () => {
-    expect(resolveDocumentCollectionSelection(customBase.id, [customBase, defaultBase])).toBe(
-      customBase.id,
-    );
-    expect(resolveDocumentCollectionSelection(null, [customBase, defaultBase])).toBe(
-      defaultBase.id,
-    );
-    expect(
-      resolveDocumentCollectionSelection("deleted-collection", [customBase, defaultBase]),
-    ).toBe(defaultBase.id);
-  });
-
-  test("renders upload as the primary empty-state action without a create-base gate", async () => {
+  test("shows one upload surface and keeps internal collections out of the UI", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -192,11 +184,14 @@ describe("Documents Default collection UX", () => {
       await settleRoute();
 
       expect(listDocuments).toHaveBeenCalledWith("workspace-a", defaultBase.id);
+      expect(listDocuments).toHaveBeenCalledWith("workspace-a", customBase.id);
       expect(container.textContent).toContain(
         "Add information agents can find when it is relevant",
       );
       expect(container.textContent).toContain("Add knowledge");
-      expect(container.textContent).toContain("Collections (optional)");
+      expect(container.textContent).not.toContain("Collections");
+      expect(container.textContent).not.toContain("Create collection");
+      expect(container.textContent).not.toContain("Add files to collection");
       expect(container.textContent).not.toContain("Advanced access");
       expect(container.textContent).not.toContain("ACL tags");
       expect(container.textContent).not.toContain("Search filters");
@@ -223,7 +218,7 @@ describe("Documents Default collection UX", () => {
     }
   });
 
-  test("propagates the selected authority through uploads and text/file drops", async () => {
+  test("propagates the selected authority through text and file ingestion", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -243,20 +238,19 @@ describe("Documents Default collection UX", () => {
         dropAuthority.dispatchEvent(new Event("change", { bubbles: true }));
       });
 
-      const ordinaryUpload = container.querySelector<HTMLInputElement>(
-        '[aria-label="Upload documents to selected collection"]',
+      const fileUpload = container.querySelector<HTMLInputElement>(
+        '[aria-label="Add files as a knowledge drop"]',
       )!;
       const upload = new File(["company"], "company.txt", { type: "text/plain" });
-      Object.defineProperty(ordinaryUpload, "files", { configurable: true, value: [upload] });
+      Object.defineProperty(fileUpload, "files", { configurable: true, value: [upload] });
       await act(async () => {
-        ordinaryUpload.dispatchEvent(new Event("change", { bubbles: true }));
+        fileUpload.dispatchEvent(new Event("change", { bubbles: true }));
         await Promise.resolve();
       });
       await settleRoute();
 
-      expect(addDocument).toHaveBeenCalledWith(
+      expect(createKnowledgeDrop).toHaveBeenCalledWith(
         "workspace-a",
-        defaultBase.id,
         expect.objectContaining({
           fileId: "44444444-4444-4444-8444-444444444444",
           authorityKind: "organization",
@@ -307,6 +301,42 @@ describe("Documents Default collection UX", () => {
           agentAccess: true,
         }),
       ]);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("searches all effective knowledge without a collection filter", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(<DocumentsRoute workspaceId="workspace-a" />);
+        await Promise.resolve();
+      });
+      await settleRoute();
+
+      const query = container.querySelector<HTMLInputElement>(
+        '[aria-label="Search indexed documents"]',
+      )!;
+      await act(async () => setControlledInput(query, "company policy"));
+      const search = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+        (button) => button.textContent?.trim() === "Search",
+      )!;
+      await act(async () => {
+        search.click();
+        await Promise.resolve();
+      });
+      await settleRoute();
+
+      expect(searchKnowledge).toHaveBeenCalledWith("workspace-a", {
+        query: "company policy",
+        limit: 8,
+        mode: "hybrid",
+      });
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/routes/documents.test.tsx
+++ b/apps/web/src/routes/documents.test.tsx
@@ -87,6 +87,8 @@ const {
   DOCUMENT_AUTHORITY_OPTIONS,
   DocumentsRoute,
   documentAuthorityLabel,
+  documentTypeLabel,
+  localPopulatedDocumentsPreview,
 } = await import("./documents");
 
 beforeAll(() => {
@@ -159,6 +161,31 @@ function fireFileDrop(target: HTMLElement, files: File[]): void {
 }
 
 describe("Documents scope-first UX", () => {
+  test("provides a development-only populated preview across file types and scopes", () => {
+    expect(
+      localPopulatedDocumentsPreview("?previewDocuments=populated", "workspace-a", false),
+    ).toBeNull();
+    const preview = localPopulatedDocumentsPreview(
+      "?previewDocuments=populated",
+      "workspace-a",
+      true,
+    );
+    expect(preview?.documents.map((document) => document.authorityKind)).toEqual([
+      "organization",
+      "workspace",
+      "organization",
+      "workspace",
+      "personal",
+    ]);
+    expect(preview?.documents.map(documentTypeLabel)).toEqual([
+      "PDF",
+      "Word document",
+      "Image",
+      "Spreadsheet",
+      "Text",
+    ]);
+  });
+
   test("uses the fixed authority labels, mappings, and workspace-safe default", () => {
     expect(DOCUMENT_AUTHORITY_OPTIONS).toEqual([
       { value: "organization", label: "Company" },

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -3,7 +3,11 @@
 // it belongs to, and search everything they are authorized to access.
 import {
   ArrowLeftIcon,
+  FileIcon,
+  FileImageIcon,
   FileSearchIcon,
+  FileSpreadsheetIcon,
+  FileTextIcon,
   FilesIcon,
   Loader2Icon,
   PlusIcon,
@@ -47,6 +51,99 @@ export function documentAuthorityLabel(kind: DocumentAuthorityKind): string {
   return DOCUMENT_AUTHORITY_OPTIONS.find((option) => option.value === kind)?.label ?? kind;
 }
 
+export function localPopulatedDocumentsPreview(
+  search: string,
+  workspaceId: string,
+  enabled = import.meta.env.DEV,
+): { base: DocumentBase; documents: IndexedDocument[] } | null {
+  if (!enabled || new URLSearchParams(search).get("previewDocuments") !== "populated") {
+    return null;
+  }
+
+  const timestamp = "2026-08-10T10:00:00.000Z";
+  const base: DocumentBase = {
+    id: "preview-documents",
+    workspaceId,
+    name: "Documents",
+    description: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  const examples = [
+    {
+      title: "Company strategy 2026.pdf",
+      parser: "pdf",
+      summary: "Company direction, annual priorities, and the goals every agent should understand.",
+      authorityKind: "organization" as const,
+      topics: ["strategy", "company goals"],
+    },
+    {
+      title: "Product launch plan.docx",
+      parser: "docx",
+      summary: "Launch milestones, owners, messaging, and the rollout plan for the next release.",
+      authorityKind: "workspace" as const,
+      topics: ["product", "launch"],
+    },
+    {
+      title: "Brand guidelines.png",
+      parser: "image",
+      summary: "Visual reference covering the approved logo, colors, typography, and spacing.",
+      authorityKind: "organization" as const,
+      topics: ["brand", "design"],
+    },
+    {
+      title: "Lead pipeline.xlsx",
+      parser: "xlsx",
+      summary: "Current sales prospects, stages, owners, and expected contract values.",
+      authorityKind: "workspace" as const,
+      topics: ["sales", "pipeline"],
+    },
+    {
+      title: "Research notes.txt",
+      parser: "text",
+      summary: "Private notes and early observations for an upcoming market analysis.",
+      authorityKind: "personal" as const,
+      topics: ["research"],
+    },
+  ];
+
+  return {
+    base,
+    documents: examples.map((example, index) => ({
+      id: `preview-document-${index + 1}`,
+      workspaceId,
+      baseId: base.id,
+      fileId: `preview-file-${index + 1}`,
+      status: "ready",
+      title: example.title,
+      parser: example.parser,
+      chunkCount: index === 2 ? 1 : 6 - index,
+      error: null,
+      sourceKind: "manual_upload",
+      sourceUri: null,
+      sourceExternalId: null,
+      sourceTitle: null,
+      sourceAuthor: "Preview user",
+      sourceCreatedAt: timestamp,
+      sourceUpdatedAt: timestamp,
+      sourceVersion: "1",
+      aclTags: [],
+      authorityKind: example.authorityKind,
+      authorityWorkspaceId: example.authorityKind === "workspace" ? workspaceId : null,
+      authoritySubjectId: example.authorityKind === "personal" ? "preview-user" : null,
+      visibility: example.authorityKind === "personal" ? "private" : "workspace",
+      createdBy: "preview-user",
+      agentAccess: true,
+      summary: example.summary,
+      topics: example.topics,
+      curationStatus: "auto_filed",
+      curation: null,
+      createdAt: timestamp,
+      updatedAt: new Date(Date.parse(timestamp) - index * 60_000).toISOString(),
+    })),
+  };
+}
+
 export function DocumentsRoute({
   workspaceId,
   returnToBrain = false,
@@ -82,6 +179,8 @@ export function DocumentsRoute({
   // rows carry a visible notice instead of silently freezing.
   const [pollFailed, setPollFailed] = useState(false);
   const failedDocuments = documents.filter((document) => document.status === "failed");
+  const populatedPreview = localPopulatedDocumentsPreview(window.location.search, workspaceId);
+  const visibleDocuments = populatedPreview?.documents ?? documents;
   // Honest list states: an initial fetch renders as loading and a failed load
   // as an error with retry instead of exposing the internal storage model.
   const basesView = listViewState({
@@ -94,6 +193,8 @@ export function DocumentsRoute({
     error: documentsError,
     count: documents.length,
   });
+  const visibleBasesView = populatedPreview ? "ready" : basesView;
+  const visibleDocumentsView = populatedPreview ? "ready" : documentsView;
 
   const refreshBases = useCallback(async () => {
     setBasesLoading(true);
@@ -427,7 +528,7 @@ export function DocumentsRoute({
 
         <div className="mt-5 grid min-h-0 min-w-0 flex-1 gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]">
           <div className="min-w-0">
-            {basesView === "ready" ? (
+            {visibleBasesView === "ready" ? (
               <>
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div className="min-w-0">
@@ -474,18 +575,18 @@ export function DocumentsRoute({
                       Couldn't reach the server to refresh indexing progress. It will keep retrying.
                     </Notice>
                   ) : null}
-                  {documentsView === "loading" ? (
+                  {visibleDocumentsView === "loading" ? (
                     <div className="flex items-center justify-center gap-2 rounded-lg border border-border p-6 text-xs text-fg-muted">
                       <Loader2Icon className="size-3.5 animate-spin" />
                       Loading documents
                     </div>
-                  ) : documentsView === "error" ? (
+                  ) : visibleDocumentsView === "error" ? (
                     <LoadErrorState
                       title="Couldn't load documents"
                       error={documentsError}
                       onRetry={() => void refreshDocuments(bases)}
                     />
-                  ) : documentsView === "empty" ? (
+                  ) : visibleDocumentsView === "empty" ? (
                     <EmptyState
                       icon={<FilesIcon className="size-4" />}
                       title="No documents yet"
@@ -496,44 +597,47 @@ export function DocumentsRoute({
                       }
                     />
                   ) : (
-                    documents.map((document) => (
+                    visibleDocuments.map((document) => (
                       <div
                         key={document.id}
                         className="flex items-start justify-between gap-3 rounded-lg border border-border bg-surface/35 px-3 py-2.5"
                       >
-                        <div className="min-w-0">
-                          <div className="break-words text-sm font-medium" title={document.title}>
-                            {document.title}
-                          </div>
-                          {document.summary ? (
-                            <p className="mt-1 line-clamp-2 max-w-3xl text-xs leading-5 text-fg-muted">
-                              {document.summary}
-                            </p>
-                          ) : null}
-                          <div className="mt-1 flex flex-wrap gap-1 text-[11px] text-[color:var(--color-fg-subtle)]">
-                            <span>{formatToken(document.sourceKind)}</span>
-                            {document.sourceTitle ? <span>· {document.sourceTitle}</span> : null}
-                            <span className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1">
-                              {documentAuthorityLabel(document.authorityKind)}
-                            </span>
-                            {document.status !== "ready" ? <span>{document.status}</span> : null}
-                            {document.agentAccess === false ? (
-                              <span className="text-danger">Agents cannot access this</span>
-                            ) : null}
-                            {document.topics.slice(0, 2).map((topic) => (
-                              <span
-                                key={topic}
-                                className="rounded border border-[color:var(--color-border)] px-1"
-                              >
-                                {topic}
-                              </span>
-                            ))}
-                          </div>
-                          {document.status === "failed" && document.error ? (
-                            <div className="mt-2 line-clamp-2 max-w-3xl text-xs leading-5 text-danger">
-                              {document.error}
+                        <div className="flex min-w-0 gap-3">
+                          <DocumentTypeIcon document={document} />
+                          <div className="min-w-0">
+                            <div className="break-words text-sm font-medium" title={document.title}>
+                              {document.title}
                             </div>
-                          ) : null}
+                            {document.summary ? (
+                              <p className="mt-1 line-clamp-2 max-w-3xl text-xs leading-5 text-fg-muted">
+                                {document.summary}
+                              </p>
+                            ) : null}
+                            <div className="mt-1 flex flex-wrap gap-1 text-[11px] text-[color:var(--color-fg-subtle)]">
+                              <span>{documentTypeLabel(document)}</span>
+                              {document.sourceTitle ? <span>· {document.sourceTitle}</span> : null}
+                              <span className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1">
+                                {documentAuthorityLabel(document.authorityKind)}
+                              </span>
+                              {document.status !== "ready" ? <span>{document.status}</span> : null}
+                              {document.agentAccess === false ? (
+                                <span className="text-danger">Agents cannot access this</span>
+                              ) : null}
+                              {document.topics.slice(0, 2).map((topic) => (
+                                <span
+                                  key={topic}
+                                  className="rounded border border-[color:var(--color-border)] px-1"
+                                >
+                                  {topic}
+                                </span>
+                              ))}
+                            </div>
+                            {document.status === "failed" && document.error ? (
+                              <div className="mt-2 line-clamp-2 max-w-3xl text-xs leading-5 text-danger">
+                                {document.error}
+                              </div>
+                            ) : null}
+                          </div>
                         </div>
                         <div className="flex shrink-0 items-center gap-2 pt-0.5">
                           <StatusDot
@@ -564,7 +668,7 @@ export function DocumentsRoute({
                   )}
                 </div>
               </>
-            ) : basesView === "empty" ? (
+            ) : visibleBasesView === "empty" ? (
               <EmptyState
                 icon={<FileSearchIcon className="size-4" />}
                 title="Preparing document storage"
@@ -661,6 +765,49 @@ export function DocumentsRoute({
         </div>
       </section>
     </ContentPage>
+  );
+}
+
+type DocumentType = "pdf" | "word" | "image" | "spreadsheet" | "text" | "file";
+
+export function documentType(document: Pick<IndexedDocument, "parser" | "title">): DocumentType {
+  const value = `${document.parser} ${document.title}`.toLowerCase();
+  if (/\.(png|jpe?g|gif|webp|svg|heic|tiff?)\b/.test(value) || value.includes("image")) {
+    return "image";
+  }
+  if (/\.(xlsx?|csv|tsv)\b/.test(value) || /spreadsheet|excel/.test(value)) {
+    return "spreadsheet";
+  }
+  if (/\.(docx?|odt|rtf)\b/.test(value) || /word|docx/.test(value)) return "word";
+  if (/\.pdf\b/.test(value) || value.includes("pdf")) return "pdf";
+  if (/\.(txt|md|markdown)\b/.test(value) || /plain.?text|markdown/.test(value)) return "text";
+  return "file";
+}
+
+export function documentTypeLabel(document: Pick<IndexedDocument, "parser" | "title">): string {
+  const kind = documentType(document);
+  if (kind === "pdf") return "PDF";
+  if (kind === "word") return "Word document";
+  if (kind === "image") return "Image";
+  if (kind === "spreadsheet") return "Spreadsheet";
+  if (kind === "text") return "Text";
+  return formatToken(document.parser || "file");
+}
+
+function DocumentTypeIcon({ document }: { document: IndexedDocument }) {
+  const kind = documentType(document);
+  const Icon =
+    kind === "image"
+      ? FileImageIcon
+      : kind === "spreadsheet"
+        ? FileSpreadsheetIcon
+        : kind === "pdf" || kind === "word" || kind === "text"
+          ? FileTextIcon
+          : FileIcon;
+  return (
+    <span className="grid size-9 shrink-0 place-items-center rounded-lg border border-border bg-bg text-fg-muted">
+      <Icon className="size-4" aria-hidden="true" />
+    </span>
   );
 }
 

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -2,8 +2,8 @@
 // optional collections for organization, reindex, and semantic search — all
 // through the SDK client.
 import {
+  ArrowLeftIcon,
   BotOffIcon,
-  CheckIcon,
   FileSearchIcon,
   FilesIcon,
   FolderInputIcon,
@@ -13,12 +13,13 @@ import {
   RefreshCwIcon,
   SparklesIcon,
 } from "lucide-react";
+import { Link } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
-import { ContentPage, FormField, FormGrid } from "@/components/ui/content-layout";
+import { ContentPage, FormField } from "@/components/ui/content-layout";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Notice } from "@/components/ui/notice";
@@ -27,26 +28,12 @@ import { StatusDot, type StatusTone } from "@/components/ui/status-dot";
 import { useAppContext } from "@/context";
 import { usePageLiveActivity } from "@opengeni/react";
 import { listViewState } from "@/lib/load-state";
-import { cn } from "@/lib/utils";
 import type {
   DocumentAuthorityKind,
   DocumentBase,
-  DocumentSearchMode,
   DocumentSearchResult,
   IndexedDocument,
-  KnowledgeSourceKind,
 } from "@/types";
-
-const sourceKindOptions: KnowledgeSourceKind[] = [
-  "manual_upload",
-  "meeting_transcript",
-  "repository",
-  "email",
-  "chat",
-  "document",
-  "web",
-  "other",
-];
 
 export const DEFAULT_DOCUMENT_AUTHORITY_KIND: DocumentAuthorityKind = "workspace";
 
@@ -77,7 +64,13 @@ export function resolveDocumentCollectionSelection(
   return bases.find(isDefaultDocumentCollection)?.id ?? bases[0]?.id ?? null;
 }
 
-export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
+export function DocumentsRoute({
+  workspaceId,
+  returnToBrain = false,
+}: {
+  workspaceId: string;
+  returnToBrain?: boolean;
+}) {
   const context = useAppContext();
   const client = context.client;
   const pageLive = usePageLiveActivity();
@@ -92,23 +85,10 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
   const [results, setResults] = useState<DocumentSearchResult[]>([]);
   const [name, setName] = useState("");
   const [query, setQuery] = useState("");
-  const [searchMode, setSearchMode] = useState<DocumentSearchMode>("hybrid");
-  const [searchSourceKind, setSearchSourceKind] = useState<KnowledgeSourceKind | "">("");
-  const [searchAclTags, setSearchAclTags] = useState("");
-  const [uploadSourceKind, setUploadSourceKind] = useState<KnowledgeSourceKind>("manual_upload");
-  const [uploadSourceUri, setUploadSourceUri] = useState("");
-  const [uploadSourceTitle, setUploadSourceTitle] = useState("");
-  const [uploadSourceAuthor, setUploadSourceAuthor] = useState("");
-  const [uploadAclTags, setUploadAclTags] = useState("");
-  const [uploadAuthorityKind, setUploadAuthorityKind] = useState<DocumentAuthorityKind>(
-    DEFAULT_DOCUMENT_AUTHORITY_KIND,
-  );
-  const [uploadAgentAccess, setUploadAgentAccess] = useState(true);
   const [dropText, setDropText] = useState("");
   const [dropAuthorityKind, setDropAuthorityKind] = useState<DocumentAuthorityKind>(
     DEFAULT_DOCUMENT_AUTHORITY_KIND,
   );
-  const [dropAgentAccess, setDropAgentAccess] = useState(true);
   const [dropping, setDropping] = useState(false);
   const [creatingBase, setCreatingBase] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -243,7 +223,6 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
     if (!selectedBaseId || !files || files.length === 0) return;
     setUploading(true);
     try {
-      const aclTags = splitTags(uploadAclTags);
       for (const file of Array.from(files)) {
         const asset = await client.uploadFile(workspaceId, {
           filename: file.name || "file",
@@ -252,13 +231,8 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
         });
         const indexed = await client.addDocument(workspaceId, selectedBaseId, {
           fileId: asset.id,
-          sourceKind: uploadSourceKind,
-          authorityKind: uploadAuthorityKind,
-          agentAccess: uploadAgentAccess,
-          ...(uploadSourceUri.trim() ? { sourceUri: uploadSourceUri.trim() } : {}),
-          ...(uploadSourceTitle.trim() ? { sourceTitle: uploadSourceTitle.trim() } : {}),
-          ...(uploadSourceAuthor.trim() ? { sourceAuthor: uploadSourceAuthor.trim() } : {}),
-          ...(aclTags.length > 0 ? { aclTags } : {}),
+          authorityKind: dropAuthorityKind,
+          agentAccess: true,
         });
         setDocuments((current) => [indexed, ...current.filter((item) => item.id !== indexed.id)]);
       }
@@ -294,7 +268,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
       const document = await client.createKnowledgeDrop(workspaceId, {
         text,
         authorityKind: dropAuthorityKind,
-        agentAccess: dropAgentAccess,
+        agentAccess: true,
       });
       setDropText("");
       toast.success("Dropped into knowledge", {
@@ -324,7 +298,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
         last = await client.createKnowledgeDrop(workspaceId, {
           fileId: asset.id,
           authorityKind: dropAuthorityKind,
-          agentAccess: dropAgentAccess,
+          agentAccess: true,
         });
       }
       toast.success(
@@ -373,9 +347,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
       const response = await client.searchDocuments(workspaceId, selectedBaseId, {
         query: query.trim(),
         limit: 8,
-        mode: searchMode,
-        ...(searchSourceKind ? { sourceKinds: [searchSourceKind] } : {}),
-        ...(splitTags(searchAclTags).length > 0 ? { aclTags: splitTags(searchAclTags) } : {}),
+        mode: "hybrid",
       });
       setResults(response.results);
       setSearched(query.trim());
@@ -443,44 +415,19 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
         <PageHeader
           icon={<FileSearchIcon className="size-4" />}
           title="Documents"
-          description="Upload immediately for agent search. Collections are optional organization."
-          actions={
-            <details className="w-full min-w-0 lg:w-auto">
-              <summary className="flex h-8 cursor-pointer list-none items-center justify-center gap-1.5 rounded-md border border-border bg-surface px-3 text-xs font-medium text-fg-muted hover:bg-surface-2 pointer-coarse:min-h-10">
-                <PlusIcon className="size-3.5" />
-                New collection
-                <span className="font-normal text-fg-subtle">optional</span>
-              </summary>
-              <div className="mt-2 grid min-w-0 gap-2 rounded-lg border border-border bg-surface p-2 sm:min-w-80 sm:grid-cols-[minmax(10rem,1fr)_auto]">
-                <Input
-                  ref={nameInputRef}
-                  aria-label="New document collection name"
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  placeholder="Collection name"
-                  className="h-8 min-w-0 text-xs pointer-coarse:min-h-10"
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") void handleCreateBase();
-                  }}
-                />
-                <Button
-                  type="button"
-                  size="sm"
-                  onClick={() => void handleCreateBase()}
-                  disabled={creatingBase || !name.trim()}
-                  className="h-8 shrink-0 pointer-coarse:min-h-10"
-                >
-                  {creatingBase ? (
-                    <Loader2Icon className="size-3.5 animate-spin" />
-                  ) : (
-                    <PlusIcon className="size-3.5" />
-                  )}
-                  Create
-                </Button>
-              </div>
-            </details>
-          }
+          description="Add information agents can find when it is relevant."
         />
+        {returnToBrain ? (
+          <Link
+            to="/workspaces/$workspaceId/state"
+            params={{ workspaceId }}
+            search={{}}
+            className="mt-6 inline-flex items-center gap-1 text-xs font-medium text-brand hover:underline"
+          >
+            <ArrowLeftIcon className="size-3" />
+            Back to Agent Brain
+          </Link>
+        ) : null}
 
         <div
           role="region"
@@ -494,24 +441,21 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
         >
           <div className="flex items-center gap-2 text-sm font-medium">
             <SparklesIcon className="size-4 text-brand" />
-            Drop anything
-            <span className="text-2xs font-normal text-fg-subtle">
-              Drops start in Default; enabled curation may name, summarize, and organize them.
-            </span>
+            Add knowledge
           </div>
           <div className="mt-2 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
             <textarea
               aria-label="Knowledge drop text"
               value={dropText}
               onChange={(event) => setDropText(event.target.value)}
-              placeholder="Paste notes, a transcript, an email — or drag files here."
+              placeholder="Paste text here, drag in files, or choose files below."
               rows={2}
               disabled={!fileUploadsEnabled || dropping}
               className="min-h-16 w-full resize-y rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2.5 py-2 text-xs leading-5 text-[color:var(--color-fg)]"
             />
             <div className="flex flex-col gap-2">
               <label className="grid gap-1 text-2xs font-medium text-fg-subtle">
-                Authority
+                Save for
                 <select
                   value={dropAuthorityKind}
                   onChange={(event) =>
@@ -527,15 +471,6 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                     </option>
                   ))}
                 </select>
-              </label>
-              <label className="flex items-center gap-2 text-xs text-fg-muted">
-                <input
-                  type="checkbox"
-                  checked={dropAgentAccess}
-                  onChange={(event) => setDropAgentAccess(event.target.checked)}
-                  disabled={dropping}
-                />
-                Subject-aware agents can read it
               </label>
               <div className="flex gap-2">
                 <input
@@ -555,7 +490,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                   className="h-8"
                 >
                   <FilesIcon className="size-3.5" />
-                  Files
+                  Choose files
                 </Button>
                 <Button
                   type="button"
@@ -569,7 +504,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                   ) : (
                     <SparklesIcon className="size-3.5" />
                   )}
-                  Drop
+                  Add
                 </Button>
               </div>
             </div>
@@ -581,197 +516,110 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
           ) : null}
         </div>
 
-        <div className="mt-5 grid min-h-0 min-w-0 flex-1 gap-4 lg:grid-cols-[15rem_minmax(0,1fr)] xl:grid-cols-[15rem_minmax(0,1fr)_20rem]">
-          <aside
-            aria-labelledby="document-bases-heading"
-            className="min-w-0 border-b border-border pb-4 lg:border-b-0 lg:border-r lg:pr-4"
-          >
-            <div className="mb-2 flex items-center justify-between gap-2">
-              <h2
-                id="document-bases-heading"
-                className="text-xs font-medium uppercase text-fg-subtle"
-              >
-                Collections <span className="normal-case font-normal">(optional)</span>
-              </h2>
-              <div className="text-2xs text-fg-subtle">{bases.length}</div>
-            </div>
-            <div className="grid auto-cols-[minmax(10rem,80%)] grid-flow-col gap-1 overflow-x-auto overscroll-x-contain pb-1 lg:block lg:space-y-1 lg:overflow-visible lg:pb-0">
-              {basesView === "loading" ? (
-                <div className="flex items-center gap-2 rounded-lg border border-border p-3 text-xs text-fg-muted">
-                  <Loader2Icon className="size-3.5 animate-spin" />
-                  Loading collections
-                </div>
-              ) : basesView === "error" ? (
-                <LoadErrorState
-                  title="Couldn't load document collections"
-                  error={basesError}
-                  onRetry={() => void refreshBases()}
-                />
-              ) : basesView === "empty" ? (
-                <div className="rounded-lg border border-dashed border-border p-3 text-xs leading-5 text-fg-muted">
-                  Default is being prepared. Refresh if this message persists.
-                </div>
-              ) : (
-                bases.map((base) => (
-                  <button
-                    key={base.id}
+        <details className="mt-4 rounded-lg border border-border bg-surface">
+          <summary className="cursor-pointer list-none px-4 py-3 text-sm font-medium text-fg [&::-webkit-details-marker]:hidden">
+            Collections (optional)
+          </summary>
+          <div className="grid gap-4 border-t border-border p-4">
+            <p className="text-xs text-fg-muted">
+              Add directly to a collection when you do not want OpenGeni to organize it
+              automatically.
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <FormField label="Collection">
+                <Select
+                  value={selectedBaseId ?? ""}
+                  onChange={(event) => setSelectedBaseId(event.target.value || null)}
+                  disabled={basesView !== "ready"}
+                >
+                  {bases.map((base) => (
+                    <option key={base.id} value={base.id}>
+                      {base.name}
+                    </option>
+                  ))}
+                </Select>
+              </FormField>
+              <FormField label="Create collection">
+                <div className="flex gap-2">
+                  <Input
+                    ref={nameInputRef}
+                    aria-label="New document collection name"
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                    placeholder="Collection name"
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") void handleCreateBase();
+                    }}
+                  />
+                  <Button
                     type="button"
-                    onClick={() => setSelectedBaseId(base.id)}
-                    className={cn(
-                      "flex w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 text-left text-xs pointer-coarse:min-h-10",
-                      selectedBaseId === base.id
-                        ? "border-brand/40 bg-brand/10 text-fg"
-                        : "border-border bg-bg/25 text-fg-muted hover:bg-surface-2",
-                    )}
+                    variant="secondary"
+                    onClick={() => void handleCreateBase()}
+                    disabled={creatingBase || !name.trim()}
                   >
-                    <span className="flex min-w-0 items-center gap-1.5">
-                      <span className="min-w-0 break-words" title={base.name}>
-                        {base.name}
-                      </span>
-                      {isDefaultDocumentCollection(base) ? (
-                        <span className="shrink-0 rounded border border-border px-1 text-[10px] font-normal text-fg-subtle">
-                          automatic
-                        </span>
-                      ) : null}
-                    </span>
-                    {selectedBaseId === base.id ? (
-                      <CheckIcon className="size-3.5 shrink-0" />
-                    ) : null}
-                  </button>
-                ))
-              )}
+                    {creatingBase ? (
+                      <Loader2Icon className="size-3.5 animate-spin" />
+                    ) : (
+                      <PlusIcon className="size-3.5" />
+                    )}
+                    Create
+                  </Button>
+                </div>
+              </FormField>
             </div>
-          </aside>
+            <div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                aria-label="Upload documents to selected collection"
+                className="hidden"
+                onChange={(event) => void handleFiles(event.target.files)}
+              />
+              <Button
+                type="button"
+                disabled={uploading || !fileUploadsEnabled || !selectedBaseId}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {uploading ? (
+                  <Loader2Icon className="size-3.5 animate-spin" />
+                ) : (
+                  <FilesIcon className="size-3.5" />
+                )}
+                Add files to collection
+              </Button>
+            </div>
+          </div>
+        </details>
 
+        <div className="mt-5 grid min-h-0 min-w-0 flex-1 gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]">
           <div className="min-w-0">
             {selectedBase ? (
               <>
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div className="min-w-0">
-                    <div className="truncate text-base font-medium">{selectedBase.name}</div>
-                    <div className="text-xs text-fg-subtle">
-                      {documents.length} files · {failedDocuments.length} failed
+                    <div className="truncate text-base font-medium">Your documents</div>
+                  </div>
+                  {failedDocuments.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        disabled={retryingAll}
+                        onClick={() => void handleRetryFailedDocuments()}
+                        className="h-8 pointer-coarse:min-h-10"
+                      >
+                        {retryingAll ? (
+                          <Loader2Icon className="size-3.5 animate-spin" />
+                        ) : (
+                          <RefreshCwIcon className="size-3.5" />
+                        )}
+                        Retry failed
+                      </Button>
                     </div>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      multiple
-                      aria-label="Upload documents to selected collection"
-                      className="hidden"
-                      onChange={(event) => void handleFiles(event.target.files)}
-                    />
-                    <Button
-                      type="button"
-                      size="sm"
-                      disabled={uploading || !fileUploadsEnabled}
-                      onClick={() => fileInputRef.current?.click()}
-                      className="h-8 pointer-coarse:min-h-10"
-                    >
-                      {uploading ? (
-                        <Loader2Icon className="size-3.5 animate-spin" />
-                      ) : (
-                        <FilesIcon className="size-3.5" />
-                      )}
-                      Upload
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="sm"
-                      disabled={retryingAll || failedDocuments.length === 0}
-                      onClick={() => void handleRetryFailedDocuments()}
-                      className="h-8 pointer-coarse:min-h-10"
-                    >
-                      {retryingAll ? (
-                        <Loader2Icon className="size-3.5 animate-spin" />
-                      ) : (
-                        <RefreshCwIcon className="size-3.5" />
-                      )}
-                      Retry failed
-                    </Button>
-                  </div>
+                  ) : null}
                 </div>
-
-                <FormGrid
-                  columns="three"
-                  className="mt-4 rounded-lg border border-border bg-surface/25 p-3 xl:grid-cols-5"
-                >
-                  <FormField label="Source">
-                    <Select
-                      value={uploadSourceKind}
-                      onChange={(event) =>
-                        setUploadSourceKind(event.target.value as KnowledgeSourceKind)
-                      }
-                      className="h-8 text-xs pointer-coarse:min-h-10"
-                    >
-                      {sourceKindOptions.map((kind) => (
-                        <option key={kind} value={kind}>
-                          {formatToken(kind)}
-                        </option>
-                      ))}
-                    </Select>
-                  </FormField>
-                  <FormField label="URI">
-                    <Input
-                      value={uploadSourceUri}
-                      onChange={(event) => setUploadSourceUri(event.target.value)}
-                      className="h-8 text-xs pointer-coarse:min-h-10"
-                      placeholder="https://..."
-                    />
-                  </FormField>
-                  <FormField label="Title">
-                    <Input
-                      value={uploadSourceTitle}
-                      onChange={(event) => setUploadSourceTitle(event.target.value)}
-                      className="h-8 text-xs pointer-coarse:min-h-10"
-                      placeholder="Source title"
-                    />
-                  </FormField>
-                  <FormField label="Author">
-                    <Input
-                      value={uploadSourceAuthor}
-                      onChange={(event) => setUploadSourceAuthor(event.target.value)}
-                      className="h-8 text-xs pointer-coarse:min-h-10"
-                      placeholder="Owner"
-                    />
-                  </FormField>
-                  <FormField label="ACL tags">
-                    <Input
-                      value={uploadAclTags}
-                      onChange={(event) => setUploadAclTags(event.target.value)}
-                      className="h-8 text-xs pointer-coarse:min-h-10"
-                      placeholder="team, confidential"
-                    />
-                  </FormField>
-                  <FormField label="Authority">
-                    <Select
-                      aria-label="Upload authority"
-                      value={uploadAuthorityKind}
-                      onChange={(event) =>
-                        setUploadAuthorityKind(event.target.value as DocumentAuthorityKind)
-                      }
-                      className="h-8 text-xs pointer-coarse:min-h-10"
-                    >
-                      {DOCUMENT_AUTHORITY_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </Select>
-                  </FormField>
-                  <FormField label="Agent access">
-                    <Select
-                      value={uploadAgentAccess ? "on" : "off"}
-                      onChange={(event) => setUploadAgentAccess(event.target.value === "on")}
-                      className="h-8 text-xs pointer-coarse:min-h-10"
-                    >
-                      <option value="on">Subject-aware agents can read</option>
-                      <option value="off">Agents blocked</option>
-                    </Select>
-                  </FormField>
-                </FormGrid>
 
                 <div className="mt-4 space-y-2">
                   {pollFailed ? (
@@ -814,25 +662,8 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                       title="No documents yet"
                       description={
                         fileUploadsEnabled
-                          ? "Upload files to index them for agent search."
+                          ? "Add files or text above to make them available to agents."
                           : "File uploads are turned off for this deployment."
-                      }
-                      action={
-                        fileUploadsEnabled ? (
-                          <Button
-                            type="button"
-                            size="sm"
-                            disabled={uploading}
-                            onClick={() => fileInputRef.current?.click()}
-                          >
-                            {uploading ? (
-                              <Loader2Icon className="size-3.5 animate-spin" />
-                            ) : (
-                              <FilesIcon className="size-3.5" />
-                            )}
-                            Upload files
-                          </Button>
-                        ) : undefined
                       }
                     />
                   ) : (
@@ -884,14 +715,6 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                                 className="rounded border border-[color:var(--color-border)] px-1"
                               >
                                 {topic}
-                              </span>
-                            ))}
-                            {document.aclTags.slice(0, 3).map((tag) => (
-                              <span
-                                key={tag}
-                                className="rounded border border-[color:var(--color-border)] px-1"
-                              >
-                                {tag}
                               </span>
                             ))}
                           </div>
@@ -978,7 +801,7 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
 
           <aside
             aria-labelledby="document-search-heading"
-            className="min-w-0 border-t border-border pt-4 lg:col-span-2 xl:col-span-1 xl:border-l xl:border-t-0 xl:pl-4 xl:pt-0"
+            className="min-w-0 border-t border-border pt-4 xl:border-l xl:border-t-0 xl:pl-5 xl:pt-0"
           >
             <h2
               id="document-search-heading"
@@ -999,44 +822,6 @@ export function DocumentsRoute({ workspaceId }: { workspaceId: string }) {
                   if (event.key === "Enter") void handleSearch();
                 }}
               />
-              <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-2">
-                <Select
-                  aria-label="Search mode"
-                  value={searchMode}
-                  onChange={(event) => setSearchMode(event.target.value as DocumentSearchMode)}
-                  className="h-8 text-xs pointer-coarse:min-h-10"
-                  disabled={!selectedBaseId}
-                >
-                  <option value="hybrid">Hybrid</option>
-                  <option value="vector">Vector</option>
-                  <option value="keyword">Keyword</option>
-                </Select>
-                <Select
-                  aria-label="Source kind"
-                  value={searchSourceKind}
-                  onChange={(event) =>
-                    setSearchSourceKind(event.target.value as KnowledgeSourceKind | "")
-                  }
-                  className="h-8 text-xs pointer-coarse:min-h-10"
-                  disabled={!selectedBaseId}
-                >
-                  <option value="">All sources</option>
-                  {sourceKindOptions.map((kind) => (
-                    <option key={kind} value={kind}>
-                      {formatToken(kind)}
-                    </option>
-                  ))}
-                </Select>
-              </div>
-              <FormField label="ACL tags">
-                <Input
-                  value={searchAclTags}
-                  onChange={(event) => setSearchAclTags(event.target.value)}
-                  placeholder="team, confidential"
-                  className="h-8 text-xs pointer-coarse:min-h-10"
-                  disabled={!selectedBaseId}
-                />
-              </FormField>
               <Button
                 type="button"
                 size="sm"
@@ -1114,17 +899,6 @@ function documentStatusTone(status: IndexedDocument["status"]): StatusTone {
   if (status === "failed") return "failed";
   if (status === "indexing") return "running";
   return "waiting";
-}
-
-function splitTags(value: string): string[] {
-  return [
-    ...new Set(
-      value
-        .split(",")
-        .map((tag) => tag.trim())
-        .filter(Boolean),
-    ),
-  ];
 }
 
 function formatToken(value: string): string {

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -1,14 +1,11 @@
-// Documents: immediate upload into an internal Default collection, with
-// optional collections for organization, reindex, and semantic search — all
-// through the SDK client.
+// Documents: one scope-first surface over the internal document store. Storage
+// collections remain an implementation detail; users add knowledge, choose who
+// it belongs to, and search everything they are authorized to access.
 import {
   ArrowLeftIcon,
-  BotOffIcon,
   FileSearchIcon,
   FilesIcon,
-  FolderInputIcon,
   Loader2Icon,
-  LockIcon,
   PlusIcon,
   RefreshCwIcon,
   SparklesIcon,
@@ -19,7 +16,7 @@ import { toast } from "sonner";
 
 import { LoadErrorState, PageHeader } from "@/components/common";
 import { Button } from "@/components/ui/button";
-import { ContentPage, FormField } from "@/components/ui/content-layout";
+import { ContentPage } from "@/components/ui/content-layout";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Notice } from "@/components/ui/notice";
@@ -50,20 +47,6 @@ export function documentAuthorityLabel(kind: DocumentAuthorityKind): string {
   return DOCUMENT_AUTHORITY_OPTIONS.find((option) => option.value === kind)?.label ?? kind;
 }
 
-export function isDefaultDocumentCollection(base: Pick<DocumentBase, "name">): boolean {
-  return base.name.trim().toLowerCase() === "default";
-}
-
-export function resolveDocumentCollectionSelection(
-  currentId: string | null,
-  bases: DocumentBase[],
-): string | null {
-  if (currentId && bases.some((base) => base.id === currentId)) {
-    return currentId;
-  }
-  return bases.find(isDefaultDocumentCollection)?.id ?? bases[0]?.id ?? null;
-}
-
 export function DocumentsRoute({
   workspaceId,
   returnToBrain = false,
@@ -78,21 +61,16 @@ export function DocumentsRoute({
   const [bases, setBases] = useState<DocumentBase[]>([]);
   const [basesLoading, setBasesLoading] = useState(true);
   const [basesError, setBasesError] = useState<Error | null>(null);
-  const [selectedBaseId, setSelectedBaseId] = useState<string | null>(null);
   const [documents, setDocuments] = useState<IndexedDocument[]>([]);
   const [documentsLoading, setDocumentsLoading] = useState(false);
   const [documentsError, setDocumentsError] = useState<Error | null>(null);
   const [results, setResults] = useState<DocumentSearchResult[]>([]);
-  const [name, setName] = useState("");
   const [query, setQuery] = useState("");
   const [dropText, setDropText] = useState("");
   const [dropAuthorityKind, setDropAuthorityKind] = useState<DocumentAuthorityKind>(
     DEFAULT_DOCUMENT_AUTHORITY_KIND,
   );
   const [dropping, setDropping] = useState(false);
-  const [creatingBase, setCreatingBase] = useState(false);
-  const [uploading, setUploading] = useState(false);
-  const [movingIds, setMovingIds] = useState<Set<string>>(() => new Set());
   const dropFileInputRef = useRef<HTMLInputElement | null>(null);
   const [searching, setSearching] = useState(false);
   // The query behind the results on screen, so a completed search that found
@@ -103,12 +81,9 @@ export function DocumentsRoute({
   // Set when background indexing-status polling fails, so stale "indexing…"
   // rows carry a visible notice instead of silently freezing.
   const [pollFailed, setPollFailed] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const nameInputRef = useRef<HTMLInputElement | null>(null);
-  const selectedBase = bases.find((base) => base.id === selectedBaseId) ?? null;
   const failedDocuments = documents.filter((document) => document.status === "failed");
   // Honest list states: an initial fetch renders as loading and a failed load
-  // as an error with retry — never as a mandatory collection-creation gate.
+  // as an error with retry instead of exposing the internal storage model.
   const basesView = listViewState({
     loading: basesLoading,
     error: basesError,
@@ -126,20 +101,24 @@ export function DocumentsRoute({
       const next = await client.listDocumentBases(workspaceId);
       setBases(next);
       setBasesError(null);
-      setSelectedBaseId((current) => resolveDocumentCollectionSelection(current, next));
     } catch (error) {
       setBasesError(error instanceof Error ? error : new Error(String(error)));
-      toast.error("Failed to load document collections", { description: String(error) });
+      toast.error("Failed to load documents", { description: String(error) });
     } finally {
       setBasesLoading(false);
     }
   }, [client, workspaceId]);
 
   const refreshDocuments = useCallback(
-    async (baseId: string) => {
+    async (availableBases: DocumentBase[]) => {
       setDocumentsLoading(true);
       try {
-        setDocuments(await client.listDocuments(workspaceId, baseId));
+        const grouped = await Promise.all(
+          availableBases.map((base) => client.listDocuments(workspaceId, base.id)),
+        );
+        setDocuments(
+          grouped.flat().sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)),
+        );
         setDocumentsError(null);
       } catch (error) {
         setDocumentsError(error instanceof Error ? error : new Error(String(error)));
@@ -159,18 +138,18 @@ export function DocumentsRoute({
     setResults([]);
     setSearched(null);
     setPollFailed(false);
-    if (!selectedBaseId) {
+    if (basesLoading || basesError) {
       setDocuments([]);
       setDocumentsError(null);
       return;
     }
-    void refreshDocuments(selectedBaseId);
-  }, [selectedBaseId, refreshDocuments]);
+    void refreshDocuments(bases);
+  }, [bases, basesError, basesLoading, refreshDocuments]);
 
   useEffect(() => {
     if (
       !pageLive ||
-      !selectedBaseId ||
+      bases.length === 0 ||
       !documents.some((document) => document.status === "queued" || document.status === "indexing")
     ) {
       return;
@@ -178,11 +157,12 @@ export function DocumentsRoute({
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
     const load = async () => {
-      await client
-        .listDocuments(workspaceId, selectedBaseId)
+      await Promise.all(bases.map((base) => client.listDocuments(workspaceId, base.id)))
         .then((next) => {
           if (!cancelled) {
-            setDocuments(next);
+            setDocuments(
+              next.flat().sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)),
+            );
             setPollFailed(false);
           }
         })
@@ -196,68 +176,19 @@ export function DocumentsRoute({
       cancelled = true;
       if (timer !== null) clearTimeout(timer);
     };
-  }, [client, workspaceId, selectedBaseId, documents, pageLive]);
+  }, [client, workspaceId, bases, documents, pageLive]);
 
-  async function handleCreateBase() {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    setCreatingBase(true);
+  // Refresh every internal storage bucket after a drop. Collections stay
+  // invisible, including when legacy curation rules move a document.
+  async function finishDrop() {
+    let nextBases = bases;
     try {
-      const base = await client.createDocumentBase(workspaceId, { name: trimmed });
-      setBases((current) => [...current, base]);
-      setSelectedBaseId(base.id);
-      setName("");
-      toast.success("Collection created", {
-        description: `“${base.name}” is ready for uploads.`,
-      });
-    } catch (error) {
-      toast.error("Failed to create collection", {
-        description: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      setCreatingBase(false);
-    }
-  }
-
-  async function handleFiles(files: FileList | null) {
-    if (!selectedBaseId || !files || files.length === 0) return;
-    setUploading(true);
-    try {
-      for (const file of Array.from(files)) {
-        const asset = await client.uploadFile(workspaceId, {
-          filename: file.name || "file",
-          contentType: file.type || "application/octet-stream",
-          data: file,
-        });
-        const indexed = await client.addDocument(workspaceId, selectedBaseId, {
-          fileId: asset.id,
-          authorityKind: dropAuthorityKind,
-          agentAccess: true,
-        });
-        setDocuments((current) => [indexed, ...current.filter((item) => item.id !== indexed.id)]);
-      }
-      toast.success("Document indexed");
-    } catch (error) {
-      toast.error("Failed to index document", {
-        description: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      setUploading(false);
-      if (fileInputRef.current) fileInputRef.current.value = "";
-    }
-  }
-
-  // A drop can create Default or auto-file into any collection — re-pull the
-  // collection list and land the user where the document actually went.
-  async function finishDrop(document: IndexedDocument) {
-    try {
-      const nextBases = await client.listDocumentBases(workspaceId);
+      nextBases = await client.listDocumentBases(workspaceId);
       setBases(nextBases);
     } catch {
-      // Base list refresh is cosmetic here; the document view below still lands.
+      // The existing inventory can still be refreshed if the base-list request fails.
     }
-    setSelectedBaseId(document.baseId);
-    await refreshDocuments(document.baseId);
+    await refreshDocuments(nextBases);
   }
 
   async function handleDropText() {
@@ -274,7 +205,7 @@ export function DocumentsRoute({
       toast.success("Dropped into knowledge", {
         description: dropResultDescription(document),
       });
-      await finishDrop(document);
+      await finishDrop();
     } catch (error) {
       toast.error("Drop failed", {
         description: error instanceof Error ? error.message : String(error),
@@ -304,10 +235,10 @@ export function DocumentsRoute({
       toast.success(
         files.length === 1 ? "Dropped into knowledge" : `${files.length} files dropped`,
         {
-          description: last ? dropResultDescription(last) : "The files were added to Default.",
+          description: last ? dropResultDescription(last) : "The files were added to knowledge.",
         },
       );
-      if (last) await finishDrop(last);
+      if (last) await finishDrop();
     } catch (error) {
       toast.error("Drop failed", {
         description: error instanceof Error ? error.message : String(error),
@@ -318,33 +249,11 @@ export function DocumentsRoute({
     }
   }
 
-  async function handleApplySuggestion(document: IndexedDocument) {
-    setMovingIds((current) => new Set(current).add(document.id));
-    try {
-      const moved = await client.moveDocument(workspaceId, document.id);
-      // The document left the currently selected base.
-      setDocuments((current) => current.filter((item) => item.id !== document.id));
-      toast.success(
-        `Filed “${moved.title}” into ${moved.curation?.suggestedBaseName ?? "the suggested base"}`,
-      );
-    } catch (error) {
-      toast.error("Failed to move document", {
-        description: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      setMovingIds((current) => {
-        const next = new Set(current);
-        next.delete(document.id);
-        return next;
-      });
-    }
-  }
-
   async function handleSearch() {
-    if (!selectedBaseId || !query.trim()) return;
+    if (!query.trim()) return;
     setSearching(true);
     try {
-      const response = await client.searchDocuments(workspaceId, selectedBaseId, {
+      const response = await client.searchKnowledge(workspaceId, {
         query: query.trim(),
         limit: 8,
         mode: "hybrid",
@@ -456,7 +365,7 @@ export function DocumentsRoute({
             <div className="flex flex-col gap-2">
               <label className="grid gap-1 text-2xs font-medium text-fg-subtle">
                 Save for
-                <select
+                <Select
                   value={dropAuthorityKind}
                   onChange={(event) =>
                     setDropAuthorityKind(event.target.value as DocumentAuthorityKind)
@@ -470,7 +379,7 @@ export function DocumentsRoute({
                       {option.label}
                     </option>
                   ))}
-                </select>
+                </Select>
               </label>
               <div className="flex gap-2">
                 <input
@@ -502,7 +411,7 @@ export function DocumentsRoute({
                   {dropping ? (
                     <Loader2Icon className="size-3.5 animate-spin" />
                   ) : (
-                    <SparklesIcon className="size-3.5" />
+                    <PlusIcon className="size-3.5" />
                   )}
                   Add
                 </Button>
@@ -516,85 +425,9 @@ export function DocumentsRoute({
           ) : null}
         </div>
 
-        <details className="mt-4 rounded-lg border border-border bg-surface">
-          <summary className="cursor-pointer list-none px-4 py-3 text-sm font-medium text-fg [&::-webkit-details-marker]:hidden">
-            Collections (optional)
-          </summary>
-          <div className="grid gap-4 border-t border-border p-4">
-            <p className="text-xs text-fg-muted">
-              Add directly to a collection when you do not want OpenGeni to organize it
-              automatically.
-            </p>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <FormField label="Collection">
-                <Select
-                  value={selectedBaseId ?? ""}
-                  onChange={(event) => setSelectedBaseId(event.target.value || null)}
-                  disabled={basesView !== "ready"}
-                >
-                  {bases.map((base) => (
-                    <option key={base.id} value={base.id}>
-                      {base.name}
-                    </option>
-                  ))}
-                </Select>
-              </FormField>
-              <FormField label="Create collection">
-                <div className="flex gap-2">
-                  <Input
-                    ref={nameInputRef}
-                    aria-label="New document collection name"
-                    value={name}
-                    onChange={(event) => setName(event.target.value)}
-                    placeholder="Collection name"
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter") void handleCreateBase();
-                    }}
-                  />
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    onClick={() => void handleCreateBase()}
-                    disabled={creatingBase || !name.trim()}
-                  >
-                    {creatingBase ? (
-                      <Loader2Icon className="size-3.5 animate-spin" />
-                    ) : (
-                      <PlusIcon className="size-3.5" />
-                    )}
-                    Create
-                  </Button>
-                </div>
-              </FormField>
-            </div>
-            <div>
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                aria-label="Upload documents to selected collection"
-                className="hidden"
-                onChange={(event) => void handleFiles(event.target.files)}
-              />
-              <Button
-                type="button"
-                disabled={uploading || !fileUploadsEnabled || !selectedBaseId}
-                onClick={() => fileInputRef.current?.click()}
-              >
-                {uploading ? (
-                  <Loader2Icon className="size-3.5 animate-spin" />
-                ) : (
-                  <FilesIcon className="size-3.5" />
-                )}
-                Add files to collection
-              </Button>
-            </div>
-          </div>
-        </details>
-
         <div className="mt-5 grid min-h-0 min-w-0 flex-1 gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]">
           <div className="min-w-0">
-            {selectedBase ? (
+            {basesView === "ready" ? (
               <>
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div className="min-w-0">
@@ -631,9 +464,7 @@ export function DocumentsRoute({
                           type="button"
                           variant="ghost"
                           size="xs"
-                          onClick={() =>
-                            selectedBaseId ? void refreshDocuments(selectedBaseId) : undefined
-                          }
+                          onClick={() => void refreshDocuments(bases)}
                         >
                           <RefreshCwIcon className="size-3" />
                           Refresh
@@ -652,9 +483,7 @@ export function DocumentsRoute({
                     <LoadErrorState
                       title="Couldn't load documents"
                       error={documentsError}
-                      onRetry={() =>
-                        selectedBaseId ? void refreshDocuments(selectedBaseId) : undefined
-                      }
+                      onRetry={() => void refreshDocuments(bases)}
                     />
                   ) : documentsView === "empty" ? (
                     <EmptyState
@@ -681,35 +510,17 @@ export function DocumentsRoute({
                               {document.summary}
                             </p>
                           ) : null}
-                          <div className="mt-1 text-2xs text-fg-subtle">
-                            {document.status} · {document.chunkCount} chunks · {document.parser}
-                          </div>
                           <div className="mt-1 flex flex-wrap gap-1 text-[11px] text-[color:var(--color-fg-subtle)]">
                             <span>{formatToken(document.sourceKind)}</span>
                             {document.sourceTitle ? <span>· {document.sourceTitle}</span> : null}
                             <span className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1">
-                              {document.authorityKind === "personal" ? (
-                                <LockIcon className="size-3" />
-                              ) : null}
-                              Authority: {documentAuthorityLabel(document.authorityKind)}
+                              {documentAuthorityLabel(document.authorityKind)}
                             </span>
-                            <span className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1">
-                              {document.agentAccess === false ? (
-                                <BotOffIcon className="size-3" />
-                              ) : null}
-                              {document.agentAccess
-                                ? document.visibility === "private"
-                                  ? "creator's subject-aware agent can read"
-                                  : "subject-aware agents can read"
-                                : "agents blocked"}
-                            </span>
-                            {document.curationStatus === "auto_filed" ? (
-                              <span className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border)] px-1">
-                                <SparklesIcon className="size-3" />
-                                auto-filed
-                              </span>
+                            {document.status !== "ready" ? <span>{document.status}</span> : null}
+                            {document.agentAccess === false ? (
+                              <span className="text-danger">Agents cannot access this</span>
                             ) : null}
-                            {document.topics.slice(0, 4).map((topic) => (
+                            {document.topics.slice(0, 2).map((topic) => (
                               <span
                                 key={topic}
                                 className="rounded border border-[color:var(--color-border)] px-1"
@@ -718,31 +529,6 @@ export function DocumentsRoute({
                               </span>
                             ))}
                           </div>
-                          {document.curationStatus === "suggested" &&
-                          document.curation?.suggestedBaseId ? (
-                            <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-fg-muted">
-                              <span>
-                                Suggested base: “{document.curation.suggestedBaseName}”
-                                {typeof document.curation.confidence === "number"
-                                  ? ` (${Math.round(document.curation.confidence * 100)}%)`
-                                  : ""}
-                              </span>
-                              <Button
-                                type="button"
-                                variant="secondary"
-                                size="xs"
-                                disabled={movingIds.has(document.id)}
-                                onClick={() => void handleApplySuggestion(document)}
-                              >
-                                {movingIds.has(document.id) ? (
-                                  <Loader2Icon className="size-3 animate-spin" />
-                                ) : (
-                                  <FolderInputIcon className="size-3" />
-                                )}
-                                Move it there
-                              </Button>
-                            </div>
-                          ) : null}
                           {document.status === "failed" && document.error ? (
                             <div className="mt-2 line-clamp-2 max-w-3xl text-xs leading-5 text-danger">
                               {document.error}
@@ -781,8 +567,8 @@ export function DocumentsRoute({
             ) : basesView === "empty" ? (
               <EmptyState
                 icon={<FileSearchIcon className="size-4" />}
-                title="Preparing Default collection"
-                description="OpenGeni creates Default automatically so uploads never require collection setup."
+                title="Preparing document storage"
+                description="OpenGeni is preparing this workspace for document uploads."
                 action={
                   <Button type="button" size="sm" onClick={() => void refreshBases()}>
                     <RefreshCwIcon className="size-3.5" />
@@ -791,10 +577,10 @@ export function DocumentsRoute({
                 }
               />
             ) : (
-              <EmptyState
-                icon={<FileSearchIcon className="size-4" />}
-                title="No collection selected"
-                description="Pick a collection on the left. Default is selected automatically when needed."
+              <LoadErrorState
+                title="Couldn't load documents"
+                error={basesError}
+                onRetry={() => void refreshBases()}
               />
             )}
           </div>
@@ -817,7 +603,6 @@ export function DocumentsRoute({
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder="Search indexed documents"
                 className="h-9 text-sm pointer-coarse:min-h-10"
-                disabled={!selectedBaseId}
                 onKeyDown={(event) => {
                   if (event.key === "Enter") void handleSearch();
                 }}
@@ -826,7 +611,7 @@ export function DocumentsRoute({
                 type="button"
                 size="sm"
                 onClick={() => void handleSearch()}
-                disabled={searching || !selectedBaseId || !query.trim()}
+                disabled={searching || !query.trim()}
                 className="h-9 pointer-coarse:min-h-10"
               >
                 {searching ? (
@@ -882,13 +667,13 @@ export function DocumentsRoute({
 function dropResultDescription(document: Pick<IndexedDocument, "curationStatus">): string {
   switch (document.curationStatus) {
     case "none":
-      return "Curation is disabled; the document stays in Default with its supplied metadata.";
+      return "The document was added and is being prepared for agent search.";
     case "pending":
-      return "The document was added to Default; curation is still processing.";
+      return "The document was added; processing is still in progress.";
     case "suggested":
-      return "Curation suggested a destination; review the suggestion below.";
+      return "The document was added and prepared for search.";
     case "auto_filed":
-      return "Curation named, summarized, and filed the document automatically.";
+      return "The document was named, summarized, and prepared for search.";
     case "failed":
       return "Curation failed softly; the document remains searchable with safe fallback metadata.";
   }

--- a/apps/web/src/routes/documents.tsx
+++ b/apps/web/src/routes/documents.tsx
@@ -473,7 +473,7 @@ export function DocumentsRoute({
                   }
                   disabled={dropping}
                   aria-label="Drop authority"
-                  className="h-8 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-xs font-normal text-[color:var(--color-fg)]"
+                  className="h-8 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-2 text-xs font-normal text-[color:var(--color-fg)] pointer-coarse:min-h-10"
                 >
                   {DOCUMENT_AUTHORITY_OPTIONS.map((option) => (
                     <option key={option.value} value={option.value}>
@@ -497,7 +497,7 @@ export function DocumentsRoute({
                   size="sm"
                   disabled={!fileUploadsEnabled || dropping}
                   onClick={() => dropFileInputRef.current?.click()}
-                  className="h-8"
+                  className="h-8 pointer-coarse:min-h-10"
                 >
                   <FilesIcon className="size-3.5" />
                   Choose files
@@ -507,7 +507,7 @@ export function DocumentsRoute({
                   size="sm"
                   disabled={!fileUploadsEnabled || dropping || !dropText.trim()}
                   onClick={() => void handleDropText()}
-                  className="h-8"
+                  className="h-8 pointer-coarse:min-h-10"
                 >
                   {dropping ? (
                     <Loader2Icon className="size-3.5 animate-spin" />
@@ -668,6 +668,11 @@ export function DocumentsRoute({
                   )}
                 </div>
               </>
+            ) : visibleBasesView === "loading" ? (
+              <div className="flex items-center justify-center gap-2 rounded-lg border border-border p-6 text-xs text-fg-muted">
+                <Loader2Icon className="size-3.5 animate-spin" />
+                Loading documents
+              </div>
             ) : visibleBasesView === "empty" ? (
               <EmptyState
                 icon={<FileSearchIcon className="size-4" />}

--- a/apps/web/src/routes/memory.tsx
+++ b/apps/web/src/routes/memory.tsx
@@ -1,4 +1,5 @@
-import { BrainCircuitIcon } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { ArrowLeftIcon, BrainCircuitIcon } from "lucide-react";
 
 import { PageHeader } from "@/components/common";
 import { MemoryPane } from "@/components/knowledge/memory-pane";
@@ -9,9 +10,11 @@ import { useAppContext } from "@/context";
 export function MemoryRoute({
   workspaceId,
   focusMemoryId,
+  returnToBrain = false,
 }: {
   workspaceId: string;
   focusMemoryId?: string | undefined;
+  returnToBrain?: boolean;
 }) {
   const context = useAppContext();
   const memoryEnabled =
@@ -25,6 +28,17 @@ export function MemoryRoute({
         title="Memory"
         description="Review and curate durable facts, preferences, decisions, and procedures agents carry across sessions."
       />
+      {returnToBrain ? (
+        <Link
+          to="/workspaces/$workspaceId/state"
+          params={{ workspaceId }}
+          search={{}}
+          className="mt-6 inline-flex items-center gap-1 text-xs font-medium text-brand hover:underline"
+        >
+          <ArrowLeftIcon className="size-3" />
+          Back to Agent Brain
+        </Link>
+      ) : null}
       <MemoryPane
         workspaceId={workspaceId}
         memoryEnabled={memoryEnabled}

--- a/apps/web/src/routes/preference-registry-admin.tsx
+++ b/apps/web/src/routes/preference-registry-admin.tsx
@@ -35,6 +35,7 @@ import {
   usePreferenceRegistryDetail,
   usePreferenceRegistryInventory,
 } from "./workspace-state-loader";
+import { AgentBrainPrompt } from "./agent-brain-prompt";
 
 const fieldClass =
   "rounded-md border border-border bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-brand disabled:cursor-not-allowed disabled:opacity-60";
@@ -73,6 +74,15 @@ function normalizedConflictKeys(value: string): string[] {
         .filter(Boolean),
     ),
   ].sort();
+}
+
+function stableKeyFromTitle(value: string): string {
+  const normalized = normalizePreferenceRegistryStableKey(value)
+    .replace(/[^a-z0-9._-]+/gu, "-")
+    .replace(/^[._-]+|[._-]+$/gu, "")
+    .slice(0, PREFERENCE_REGISTRY_STABLE_KEY_MAX_CHARS)
+    .replace(/[._-]+$/gu, "");
+  return normalized || `preference-${crypto.randomUUID().slice(0, 8)}`;
 }
 
 function optionalDateTime(value: string): string | null {
@@ -160,12 +170,16 @@ function PreferenceProposalComposer({
   directHuman,
   canManageOrganization,
   canManageWorkspace,
+  defaultOpen = true,
+  compact = false,
   onCreated,
 }: {
   workspaceId: string;
   directHuman: boolean;
   canManageOrganization: boolean;
   canManageWorkspace: boolean;
+  defaultOpen?: boolean;
+  compact?: boolean;
   onCreated: (preference: PreferenceRegistryRecord) => Promise<void>;
 }) {
   const { client } = useAppContext();
@@ -193,7 +207,7 @@ function PreferenceProposalComposer({
   const submit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();
     if (!canManageScope || submitting) return;
-    const rank = Number(precedenceRank);
+    const rank = compact ? 0 : Number(precedenceRank);
     if (!Number.isInteger(rank) || rank < -1_000 || rank > 1_000) {
       setSubmitError("Precedence rank must be a whole number from -1000 to 1000.");
       return;
@@ -202,8 +216,8 @@ function PreferenceProposalComposer({
     setSubmitError(null);
     setCreatedMessage(null);
     try {
-      const preference = await client.createPreferenceRegistryProposal(workspaceId, {
-        stableKey,
+      let preference = await client.createPreferenceRegistryProposal(workspaceId, {
+        stableKey: compact ? stableKeyFromTitle(title) : stableKey,
         scope,
         title,
         description,
@@ -215,6 +229,23 @@ function PreferenceProposalComposer({
         provenanceSource: "human",
         provenanceSourceId: null,
       });
+      if (compact) {
+        const detail = await client.getPreferenceRegistry(workspaceId, preference.id);
+        const revision = detail.revisions.reduce((latest, candidate) =>
+          candidate.revision > latest.revision ? candidate : latest,
+        );
+        const activated = await client.activatePreferenceRegistryRevision(
+          workspaceId,
+          preference.id,
+          {
+            revisionId: revision.id,
+            expectedCurrentRevisionId: null,
+            expectedScopeVersion: preference.scopeVersion,
+            reason: "Saved by a user from Agent Brain",
+          },
+        );
+        preference = activated.preference;
+      }
       setStableKey("");
       setTitle("");
       setDescription("");
@@ -224,7 +255,9 @@ function PreferenceProposalComposer({
       setConflictsWith("");
       setExpiresAt("");
       setCreatedMessage(
-        `${scopeLabel(preference.target.scope)} proposal created inactive. No prompt behavior changed.`,
+        compact
+          ? `${scopeLabel(preference.target.scope)} preference saved. Agents can now use it.`
+          : `${scopeLabel(preference.target.scope)} proposal created inactive. No prompt behavior changed.`,
       );
       await onCreated(preference);
     } catch (error) {
@@ -235,18 +268,18 @@ function PreferenceProposalComposer({
   };
 
   return (
-    <details open className="rounded-md border border-border bg-surface-2/20">
+    <details open={defaultOpen} className="rounded-md border border-border bg-surface-2/20">
       <summary className="cursor-pointer px-3 py-3 text-sm font-medium text-fg">
-        Create structured preference proposal
+        {compact ? "Write manually" : "Create structured preference proposal"}
       </summary>
       <form
-        aria-label="Create structured preference proposal"
+        aria-label={compact ? "Add preference" : "Create structured preference proposal"}
         className="grid gap-3 border-t border-border p-3"
         onSubmit={(event) => void submit(event)}
       >
-        <div className="grid gap-3 md:grid-cols-3">
+        <div className={compact ? "grid gap-3 md:grid-cols-2" : "grid gap-3 md:grid-cols-3"}>
           <label className="grid gap-1 text-xs font-medium text-fg-muted">
-            Authority scope
+            {compact ? "Who should use it?" : "Authority scope"}
             <select
               className={fieldClass}
               value={scope}
@@ -257,33 +290,52 @@ function PreferenceProposalComposer({
               <ScopeOption scope="user" enabled={directHuman} />
             </select>
           </label>
-          <label className="grid gap-1 text-xs font-medium text-fg-muted md:col-span-2">
-            Stable key
-            <input
-              className={fieldClass}
-              placeholder="response.format"
-              value={stableKey}
-              maxLength={PREFERENCE_REGISTRY_STABLE_KEY_MAX_CHARS}
-              required
-              onChange={(event) => setStableKey(event.target.value)}
-            />
-          </label>
+          {compact ? (
+            <label className="grid gap-1 text-xs font-medium text-fg-muted">
+              Name
+              <input
+                className={fieldClass}
+                placeholder="Concise status updates"
+                value={title}
+                maxLength={PREFERENCE_REGISTRY_TITLE_MAX_CHARS}
+                required
+                onChange={(event) => setTitle(event.target.value)}
+              />
+            </label>
+          ) : (
+            <label className="grid gap-1 text-xs font-medium text-fg-muted md:col-span-2">
+              Stable key
+              <input
+                className={fieldClass}
+                placeholder="response.format"
+                value={stableKey}
+                maxLength={PREFERENCE_REGISTRY_STABLE_KEY_MAX_CHARS}
+                required
+                onChange={(event) => setStableKey(event.target.value)}
+              />
+            </label>
+          )}
         </div>
-        <div className="grid gap-3 md:grid-cols-2">
+        <div className={compact ? "grid gap-3" : "grid gap-3 md:grid-cols-2"}>
+          {compact ? null : (
+            <label className="grid gap-1 text-xs font-medium text-fg-muted">
+              Descriptor title
+              <input
+                className={fieldClass}
+                value={title}
+                maxLength={PREFERENCE_REGISTRY_TITLE_MAX_CHARS}
+                required
+                onChange={(event) => setTitle(event.target.value)}
+              />
+            </label>
+          )}
           <label className="grid gap-1 text-xs font-medium text-fg-muted">
-            Descriptor title
+            {compact ? "Short summary" : "Compact descriptor"}
             <input
               className={fieldClass}
-              value={title}
-              maxLength={PREFERENCE_REGISTRY_TITLE_MAX_CHARS}
-              required
-              onChange={(event) => setTitle(event.target.value)}
-            />
-          </label>
-          <label className="grid gap-1 text-xs font-medium text-fg-muted">
-            Compact descriptor
-            <input
-              className={fieldClass}
+              placeholder={
+                compact ? "Keep progress updates short and lead with the outcome." : undefined
+              }
               value={description}
               maxLength={PREFERENCE_REGISTRY_DESCRIPTOR_DESCRIPTION_MAX_CHARS}
               required
@@ -292,73 +344,82 @@ function PreferenceProposalComposer({
           </label>
         </div>
         <label className="grid gap-1 text-xs font-medium text-fg-muted">
-          Full preference content
+          {compact ? "Instructions" : "Full preference content"}
           <textarea
             className={`${fieldClass} min-h-36 leading-6`}
+            placeholder={
+              compact
+                ? "Use short paragraphs. Mention decisions, blockers, and the next action. Avoid long implementation diaries."
+                : undefined
+            }
             value={content}
             maxLength={PREFERENCE_REGISTRY_CONTENT_MAX_CHARS}
             required
             onChange={(event) => setContent(event.target.value)}
           />
           <span className="font-normal leading-5 text-fg-subtle">
-            The browser sends this once to create an immutable revision. Agents receive only the
-            compact descriptor automatically and retrieve this body on demand from an authorized
-            attempt snapshot.
+            {compact
+              ? "Agents always see the short summary and fetch these instructions when relevant."
+              : "The browser sends this once to create an immutable revision. Agents receive only the compact descriptor automatically and retrieve this body on demand from an authorized attempt snapshot."}
           </span>
         </label>
-        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
-          <label className="grid gap-1 text-xs font-medium text-fg-muted">
-            Precedence rank
-            <input
-              className={fieldClass}
-              type="number"
-              min="-1000"
-              max="1000"
-              step="1"
-              value={precedenceRank}
-              required
-              onChange={(event) => setPrecedenceRank(event.target.value)}
-            />
-          </label>
-          <label className="grid gap-1 text-xs font-medium text-fg-muted">
-            Conflict strategy
-            <select
-              className={fieldClass}
-              value={conflictStrategy}
-              onChange={(event) =>
-                setConflictStrategy(event.target.value as PreferenceRegistryConflictStrategy)
-              }
-            >
-              <option value="override">Override</option>
-              <option value="merge">Merge</option>
-              <option value="reject">Reject</option>
-              <option value="inform">Inform</option>
-            </select>
-          </label>
-          <label className="grid gap-1 text-xs font-medium text-fg-muted">
-            Conflicts with
-            <input
-              className={fieldClass}
-              placeholder="key.one, key.two"
-              value={conflictsWith}
-              onChange={(event) => setConflictsWith(event.target.value)}
-            />
-          </label>
-          <label className="grid gap-1 text-xs font-medium text-fg-muted">
-            Expires at
-            <input
-              className={fieldClass}
-              type="datetime-local"
-              value={expiresAt}
-              onChange={(event) => setExpiresAt(event.target.value)}
-            />
-          </label>
-        </div>
-        <div className="rounded-md border border-status-waiting/30 bg-status-waiting/10 p-3 text-xs leading-5 text-fg-muted">
-          Human-created entries still begin as inactive proposals. Documents, Memory, connectors,
-          and imported evidence cannot activate this registry. Only the separately authorized
-          governed-learning controller may use the automatic-activation seam.
-        </div>
+        {compact ? null : (
+          <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+            <label className="grid gap-1 text-xs font-medium text-fg-muted">
+              Precedence rank
+              <input
+                className={fieldClass}
+                type="number"
+                min="-1000"
+                max="1000"
+                step="1"
+                value={precedenceRank}
+                required
+                onChange={(event) => setPrecedenceRank(event.target.value)}
+              />
+            </label>
+            <label className="grid gap-1 text-xs font-medium text-fg-muted">
+              Conflict strategy
+              <select
+                className={fieldClass}
+                value={conflictStrategy}
+                onChange={(event) =>
+                  setConflictStrategy(event.target.value as PreferenceRegistryConflictStrategy)
+                }
+              >
+                <option value="override">Override</option>
+                <option value="merge">Merge</option>
+                <option value="reject">Reject</option>
+                <option value="inform">Inform</option>
+              </select>
+            </label>
+            <label className="grid gap-1 text-xs font-medium text-fg-muted">
+              Conflicts with
+              <input
+                className={fieldClass}
+                placeholder="key.one, key.two"
+                value={conflictsWith}
+                onChange={(event) => setConflictsWith(event.target.value)}
+              />
+            </label>
+            <label className="grid gap-1 text-xs font-medium text-fg-muted">
+              Expires at
+              <input
+                className={fieldClass}
+                type="datetime-local"
+                value={expiresAt}
+                onChange={(event) => setExpiresAt(event.target.value)}
+              />
+            </label>
+          </div>
+        )}
+        {compact ? null : (
+          <div className="rounded-md border border-status-waiting/30 bg-status-waiting/10 p-3 text-xs leading-5 text-fg-muted">
+            Human-created entries still begin as inactive proposals. Documents, Memory, connectors,
+            and imported evidence cannot activate this registry. Only the separately authorized
+            governed-learning controller may use the automatic-activation seam.
+          </div>
+        )}
         {!directHuman ? (
           <div role="alert" className="text-xs text-status-waiting">
             A direct signed-in human session is required for registry changes. API keys, workers,
@@ -381,7 +442,13 @@ function PreferenceProposalComposer({
             className={primaryButtonClass}
             disabled={!canManageScope || submitting}
           >
-            {submitting ? "Creating proposal…" : "Create inactive proposal"}
+            {submitting
+              ? compact
+                ? "Saving…"
+                : "Creating proposal…"
+              : compact
+                ? "Save preference"
+                : "Create inactive proposal"}
           </button>
         </div>
       </form>
@@ -430,6 +497,27 @@ function PreferenceRecordButton({
         </span>
       )}
     </button>
+  );
+}
+
+function PreferenceExample() {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-surface-2/20 p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium text-fg">Concise status updates</span>
+        <span className="rounded-full border border-border px-2 py-0.5 text-2xs text-fg-muted">
+          Example
+        </span>
+      </div>
+      <p className="mt-2 text-xs leading-5 text-fg-muted">
+        <span className="font-medium text-fg">Always visible summary:</span> Keep progress updates
+        short and lead with the outcome.
+      </p>
+      <p className="mt-2 text-xs leading-5 text-fg-muted">
+        <span className="font-medium text-fg">Fetched when relevant:</span> Use short paragraphs.
+        Mention decisions, blockers, and the next action. Avoid long implementation diaries.
+      </p>
+    </div>
   );
 }
 
@@ -1065,9 +1153,11 @@ function PreferenceDetailPanel({
 export function PreferenceRegistryAdministration({
   workspaceId,
   onWorkspaceStateReload,
+  compact = false,
 }: {
   workspaceId: string;
   onWorkspaceStateReload: () => Promise<void>;
+  compact?: boolean;
 }) {
   const context = useAppContext();
   const { client } = context;
@@ -1124,34 +1214,40 @@ export function PreferenceRegistryAdministration({
   );
 
   return (
-    <section className="rounded-lg border border-border bg-surface p-4">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h2 className="text-sm font-semibold text-fg">Structured preference administration</h2>
-          <p className="mt-1 max-w-4xl text-xs leading-5 text-fg-muted">
-            This is the dedicated organization/workspace/personal registry—not ordinary Memory.
-            Descriptors, precedence, immutable revisions, provenance, and audit state are visible
-            here. Documents and retrieved knowledge remain evidence or inactive proposals only.
-          </p>
+    <section className={compact ? "grid gap-4" : "rounded-lg border border-border bg-surface p-4"}>
+      {compact ? null : (
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold text-fg">Structured preference administration</h2>
+            <p className="mt-1 max-w-4xl text-xs leading-5 text-fg-muted">
+              This is the dedicated organization/workspace/personal registry—not ordinary Memory.
+              Descriptors, precedence, immutable revisions, provenance, and audit state are visible
+              here. Documents and retrieved knowledge remain evidence or inactive proposals only.
+            </p>
+          </div>
+          <button
+            type="button"
+            className={secondaryButtonClass}
+            disabled={inventory.loading || detail.loading}
+            onClick={() => void refreshAll()}
+          >
+            <RefreshCwIcon className="mr-1.5 inline size-3.5" />
+            Refresh registry and detail
+          </button>
         </div>
-        <button
-          type="button"
-          className={secondaryButtonClass}
-          disabled={inventory.loading || detail.loading}
-          onClick={() => void refreshAll()}
-        >
-          <RefreshCwIcon className="mr-1.5 inline size-3.5" />
-          Refresh registry and detail
-        </button>
-      </div>
+      )}
 
-      <div className="mt-4">
-        <ScopeAuthorityNotice
-          directHuman={directHuman}
-          canManageOrganization={canManageOrganization}
-          canManageWorkspace={canManageWorkspace}
-        />
-      </div>
+      {compact ? null : (
+        <div className="mt-4">
+          <ScopeAuthorityNotice
+            directHuman={directHuman}
+            canManageOrganization={canManageOrganization}
+            canManageWorkspace={canManageWorkspace}
+          />
+        </div>
+      )}
+
+      {compact ? <AgentBrainPrompt kind="preference" workspaceId={workspaceId} /> : null}
 
       <div className="mt-4">
         <PreferenceProposalComposer
@@ -1159,6 +1255,8 @@ export function PreferenceRegistryAdministration({
           directHuman={directHuman}
           canManageOrganization={canManageOrganization}
           canManageWorkspace={canManageWorkspace}
+          defaultOpen={!compact}
+          compact={compact}
           onCreated={async (preference) => {
             setSelectedId(preference.id);
             await Promise.all([inventory.reload(), onWorkspaceStateReload()]);
@@ -1166,14 +1264,22 @@ export function PreferenceRegistryAdministration({
         />
       </div>
 
-      <div className="mt-4 grid min-w-0 gap-4 lg:grid-cols-[20rem_minmax(0,1fr)]">
+      <div
+        className={
+          compact && inventory.response?.preferences.length === 0
+            ? "min-w-0"
+            : "grid min-w-0 gap-4 lg:grid-cols-[20rem_minmax(0,1fr)]"
+        }
+      >
         <div className="min-w-0">
-          <div className="mb-2 flex items-center justify-between gap-2">
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-fg-subtle">
-              Authorized registry records
-            </h3>
-            <span className="text-2xs text-fg-subtle">Up to 100 records</span>
-          </div>
+          {compact ? null : (
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-fg-subtle">
+                Authorized registry records
+              </h3>
+              <span className="text-2xs text-fg-subtle">Up to 100 records</span>
+            </div>
+          )}
           {inventory.loading && !inventory.response ? (
             <Skeleton aria-label="Loading preference registry" className="h-40 w-full" />
           ) : null}
@@ -1185,9 +1291,13 @@ export function PreferenceRegistryAdministration({
             />
           ) : null}
           {inventory.response?.preferences.length === 0 ? (
-            <EmptyState>
-              No structured preferences are visible in your authorized scopes.
-            </EmptyState>
+            compact ? (
+              <PreferenceExample />
+            ) : (
+              <EmptyState>
+                No structured preferences are visible in your authorized scopes.
+              </EmptyState>
+            )
           ) : null}
           {inventory.response?.preferences.length ? (
             <div className="max-h-[36rem] divide-y divide-border overflow-y-auto rounded-md border border-border">
@@ -1208,38 +1318,42 @@ export function PreferenceRegistryAdministration({
           ) : null}
         </div>
 
-        <div className="min-w-0">
-          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-fg-subtle">
-            Selected preference
-          </h3>
-          {!selectedId ? <EmptyState>Select a registry record to inspect it.</EmptyState> : null}
-          {selectedId && detail.loading && !detail.response ? (
-            <Skeleton aria-label="Loading preference detail" className="h-64 w-full" />
-          ) : null}
-          {selectedId && detail.error && !detail.response ? (
-            <LoadErrorState
-              title="Couldn't load preference detail"
-              error={detail.error}
-              onRetry={() => void detail.reload()}
-            />
-          ) : null}
-          {detail.response ? (
-            <PreferenceDetailPanel
-              key={`${detail.response.preference.id}:${detail.response.preference.status}:${detail.response.preference.activeRevision?.id ?? "none"}:${detail.response.preference.scopeVersion}:${detail.response.preference.activationVersion}:${manualDetailRefreshVersion}`}
-              workspaceId={workspaceId}
-              detail={detail.response}
-              replacementCandidates={replacementCandidates}
-              canManageScope={canManageScope}
-              canManageOrganization={canManageOrganization}
-              canManageWorkspace={canManageWorkspace}
-              directHuman={directHuman}
-              onMutated={reloadAll}
-            />
-          ) : null}
-          {detail.error && detail.response ? (
-            <p className="mt-2 text-xs text-status-error">Refresh failed: {detail.error.message}</p>
-          ) : null}
-        </div>
+        {compact && !selectedId ? null : (
+          <div className="min-w-0">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-fg-subtle">
+              Selected preference
+            </h3>
+            {!selectedId ? <EmptyState>Select a registry record to inspect it.</EmptyState> : null}
+            {selectedId && detail.loading && !detail.response ? (
+              <Skeleton aria-label="Loading preference detail" className="h-64 w-full" />
+            ) : null}
+            {selectedId && detail.error && !detail.response ? (
+              <LoadErrorState
+                title="Couldn't load preference detail"
+                error={detail.error}
+                onRetry={() => void detail.reload()}
+              />
+            ) : null}
+            {detail.response ? (
+              <PreferenceDetailPanel
+                key={`${detail.response.preference.id}:${detail.response.preference.status}:${detail.response.preference.activeRevision?.id ?? "none"}:${detail.response.preference.scopeVersion}:${detail.response.preference.activationVersion}:${manualDetailRefreshVersion}`}
+                workspaceId={workspaceId}
+                detail={detail.response}
+                replacementCandidates={replacementCandidates}
+                canManageScope={canManageScope}
+                canManageOrganization={canManageOrganization}
+                canManageWorkspace={canManageWorkspace}
+                directHuman={directHuman}
+                onMutated={reloadAll}
+              />
+            ) : null}
+            {detail.error && detail.response ? (
+              <p className="mt-2 text-xs text-status-error">
+                Refresh failed: {detail.error.message}
+              </p>
+            ) : null}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/apps/web/src/routes/workspace-state.tsx
+++ b/apps/web/src/routes/workspace-state.tsx
@@ -1194,6 +1194,7 @@ function FocusedInstructions({
   const activeHead = state.policy.activeHeads.find(
     (head) => head.kind === "policy" && head.scope === "global" && head.roleKey === null,
   );
+  const activeRevisionId = activeHead?.revisionId ?? null;
   const [content, setContent] = useState("");
   const [loadingContent, setLoadingContent] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -1206,8 +1207,8 @@ function FocusedInstructions({
     setEditorError(null);
     void (async () => {
       try {
-        const nextContent = activeHead
-          ? (await client.getWorkspaceInstructionPolicyRevision(workspaceId, activeHead.revisionId))
+        const nextContent = activeRevisionId
+          ? (await client.getWorkspaceInstructionPolicyRevision(workspaceId, activeRevisionId))
               .content
           : state.policy.legacyRuntime.workspaceOverrideConfigured
             ? ((await client.getWorkspace(workspaceId)).agentInstructions ?? "")
@@ -1225,7 +1226,7 @@ function FocusedInstructions({
       cancelled = true;
     };
   }, [
-    activeHead?.revisionId,
+    activeRevisionId,
     client,
     state.policy.legacyRuntime.workspaceOverrideConfigured,
     workspaceId,

--- a/apps/web/src/routes/workspace-state.tsx
+++ b/apps/web/src/routes/workspace-state.tsx
@@ -16,17 +16,11 @@ import {
 } from "@opengeni/sdk";
 import { Link } from "@tanstack/react-router";
 import {
-  BookOpenIcon,
+  ArrowLeftIcon,
   BrainCircuitIcon,
   ChevronDownIcon,
   CircleAlertIcon,
   Clock3Icon,
-  FileSearchIcon,
-  NetworkIcon,
-  PlugIcon,
-  ServerCogIcon,
-  SettingsIcon,
-  UsersIcon,
 } from "lucide-react";
 import { type FormEvent, type ReactNode, useEffect, useState } from "react";
 
@@ -37,6 +31,7 @@ import { useAppContext } from "@/context";
 import { hasAccountPermission, hasWorkspacePermission } from "@/lib/permissions";
 
 import { BrainOverview } from "./agent-brain-overview";
+import { AgentBrainPrompt } from "./agent-brain-prompt";
 import {
   useCompanyProfileInventory,
   useWorkspaceInstructionPolicyOnboardingProposals,
@@ -1184,59 +1179,159 @@ function KnowledgeInventory({
   );
 }
 
-function ExistingSources({ workspaceId }: { workspaceId: string }) {
-  const links = [
-    { to: "/workspaces/$workspaceId/documents" as const, label: "Documents", icon: FileSearchIcon },
-    { to: "/workspaces/$workspaceId/memory" as const, label: "Memory", icon: BrainCircuitIcon },
-    {
-      to: "/workspaces/$workspaceId/capabilities" as const,
-      label: "Skills & capabilities",
-      icon: PlugIcon,
-    },
-    {
-      to: "/workspaces/$workspaceId/sessions" as const,
-      label: "Sessions & agents",
-      icon: UsersIcon,
-    },
-    { to: "/workspaces/$workspaceId/rigs" as const, label: "Rigs", icon: ServerCogIcon },
-    {
-      to: "/workspaces/$workspaceId/variable-sets" as const,
-      label: "Variable sets",
-      icon: BookOpenIcon,
-    },
-    {
-      to: "/workspaces/$workspaceId/settings" as const,
-      label: "Workspace",
-      icon: SettingsIcon,
-    },
-  ];
+function FocusedInstructions({
+  state,
+  workspaceId,
+  onWorkspaceStateReload,
+}: {
+  state: WorkspaceStateResponse;
+  workspaceId: string;
+  onWorkspaceStateReload: () => Promise<void>;
+}) {
+  const context = useAppContext();
+  const { client } = context;
+  const canEdit = hasWorkspacePermission(context.accessContext, workspaceId, "workspace:admin");
+  const activeHead = state.policy.activeHeads.find(
+    (head) => head.kind === "policy" && head.scope === "global" && head.roleKey === null,
+  );
+  const [content, setContent] = useState("");
+  const [loadingContent, setLoadingContent] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [editorError, setEditorError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingContent(true);
+    setEditorError(null);
+    void (async () => {
+      try {
+        const nextContent = activeHead
+          ? (await client.getWorkspaceInstructionPolicyRevision(workspaceId, activeHead.revisionId))
+              .content
+          : state.policy.legacyRuntime.workspaceOverrideConfigured
+            ? ((await client.getWorkspace(workspaceId)).agentInstructions ?? "")
+            : "";
+        if (!cancelled) setContent(nextContent);
+      } catch (error) {
+        if (!cancelled) {
+          setEditorError(error instanceof Error ? error.message : String(error));
+        }
+      } finally {
+        if (!cancelled) setLoadingContent(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeHead?.revisionId,
+    client,
+    state.policy.legacyRuntime.workspaceOverrideConfigured,
+    workspaceId,
+  ]);
+
+  const save = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+    if (!canEdit || saving || !content.trim()) return;
+    setSaving(true);
+    setMessage(null);
+    setEditorError(null);
+    try {
+      const draft = await client.createWorkspaceInstructionPolicyDraft(workspaceId, {
+        operationId: crypto.randomUUID(),
+        kind: "policy",
+        scope: "global",
+        roleKey: null,
+        content,
+        provenanceSource: "human",
+        provenanceSourceId: null,
+        supersedesRevisionId: activeHead?.revisionId ?? null,
+      });
+      await client.activateWorkspaceInstructionPolicyRevision(workspaceId, draft.id, {
+        operationId: crypto.randomUUID(),
+        expectedCurrentRevisionId: activeHead?.revisionId ?? null,
+        expectedActivationVersion: activeHead?.activationVersion ?? 0,
+        reason: "Updated by a workspace admin from Agent Brain",
+      });
+      await onWorkspaceStateReload();
+      setMessage("Saved. New agent turns will use these workspace instructions.");
+    } catch (error) {
+      setEditorError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
-    <StateCard
-      title="Authoritative source surfaces"
-      description="Agent Brain is an overview, not a duplicate editor. Use each authority's existing surface or canonical lifecycle panel for detail and permitted changes."
-    >
-      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-        {links.map((item) => (
-          <Link
-            key={item.to}
-            to={item.to}
-            params={{ workspaceId }}
-            className="flex items-center gap-2 rounded-md border border-border p-3 text-sm font-medium text-fg transition-colors hover:bg-surface-2"
-          >
-            <item.icon className="size-4 text-brand" />
-            {item.label}
-          </Link>
-        ))}
-      </div>
-    </StateCard>
+    <div className="grid gap-4">
+      <AgentBrainPrompt kind="workspace_instructions" workspaceId={workspaceId} />
+      <details className="group rounded-lg border border-border bg-surface">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-fg [&::-webkit-details-marker]:hidden">
+          Write manually
+          <ChevronDownIcon className="size-4 text-fg-muted transition-transform group-open:rotate-180" />
+        </summary>
+        <form
+          className="grid gap-3 border-t border-border p-4"
+          onSubmit={(event) => void save(event)}
+        >
+          <label className="grid gap-1 text-xs font-medium text-fg-muted">
+            Instructions for this workspace
+            <textarea
+              className="min-h-48 rounded-md border border-border bg-surface px-3 py-2 text-sm leading-6 text-fg outline-none focus:border-brand disabled:cursor-not-allowed disabled:opacity-60"
+              value={content}
+              maxLength={WORKSPACE_INSTRUCTION_POLICY_CONTENT_MAX_CHARS}
+              disabled={!canEdit || loadingContent || saving}
+              placeholder="For example: Keep updates concise, explain important decisions, and surface blockers early."
+              onChange={(event) => setContent(event.target.value)}
+            />
+          </label>
+          <p className="text-xs leading-5 text-fg-subtle">
+            These instructions are included automatically for agents working in this workspace.
+            Changes are versioned and can be audited or rolled back.
+          </p>
+          {!canEdit ? (
+            <p className="text-xs text-status-waiting">
+              Workspace admin access is required to edit.
+            </p>
+          ) : null}
+          {editorError ? (
+            <p role="alert" className="text-xs text-status-error">
+              {editorError}
+            </p>
+          ) : null}
+          {message ? (
+            <p role="status" className="text-xs text-status-success">
+              {message}
+            </p>
+          ) : null}
+          <div>
+            <button
+              type="submit"
+              className="rounded-md bg-brand px-3 py-2 text-sm font-medium text-white hover:bg-brand/90 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={!canEdit || loadingContent || saving || !content.trim()}
+            >
+              {saving ? "Saving…" : "Save instructions"}
+            </button>
+          </div>
+        </form>
+      </details>
+    </div>
   );
 }
 
-export function WorkspaceStateRoute({ workspaceId }: { workspaceId: string }) {
+export function WorkspaceStateRoute({
+  workspaceId,
+  view,
+}: {
+  workspaceId: string;
+  view?: "company" | "instructions" | "preferences";
+}) {
   const { client } = useAppContext();
   const [attemptInput, setAttemptInput] = useState("");
   const [attemptId, setAttemptId] = useState<string | undefined>();
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
+  const companyProfile = useCompanyProfileInventory(client, workspaceId);
   const { state, error, loading, reload } = useWorkspaceStateInventory(
     client,
     workspaceId,
@@ -1250,84 +1345,142 @@ export function WorkspaceStateRoute({ workspaceId }: { workspaceId: string }) {
     setAttemptInput("");
     setAttemptId(undefined);
   };
+  const companyProfileStatus = companyProfile.loading
+    ? { label: "Loading…" }
+    : companyProfile.error
+      ? { label: "Unavailable", tone: "warning" as const }
+      : companyProfile.response?.current
+        ? { label: "Configured" }
+        : { label: "Not configured" };
 
   return (
     <ContentPage width="standard">
       <PageHeader
         icon={<BrainCircuitIcon className="size-4" />}
-        title="Agent Brain"
-        description="Understand what agents always know, what they retrieve when relevant, and which authority owns every change."
+        title={
+          view === "company"
+            ? "Company profile & goals"
+            : view === "instructions"
+              ? "Workspace instructions"
+              : view === "preferences"
+                ? "Preferences"
+                : "Agent Brain"
+        }
+        description={
+          view === "company"
+            ? "Set the essential organization context every agent should know."
+            : view === "instructions"
+              ? "Set how agents should work in this workspace."
+              : view === "preferences"
+                ? "Save reusable instructions agents can apply when relevant."
+                : "What every agent starts with, and what it can find when needed."
+        }
       />
-      {loading && !state ? <WorkspaceStateLoading /> : null}
-      {error && !state ? (
-        <LoadErrorState
-          title="Couldn't load Agent Brain"
-          error={error}
-          onRetry={() => void reload()}
-        />
-      ) : null}
-      {state ? (
-        <div className="grid gap-4">
-          {error ? (
-            <LoadErrorState
-              title="Couldn't refresh Agent Brain"
-              error={error}
-              onRetry={() => void reload()}
-            />
-          ) : null}
-          <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-surface-2/30 px-3 py-2 text-xs text-fg-muted">
-            <NetworkIcon className="size-3.5 text-brand" />
-            Generated {formatDate(state.generatedAt)} from a read-time projection. Registry and
-            onboarding mutations use explicit canonical lifecycle APIs; imported evidence never
-            activates prompt authority directly.
-          </div>
-          <BrainOverview
-            state={state}
-            workspaceId={workspaceId}
-            onOpenDiagnostics={() => setDiagnosticsOpen(true)}
-          />
-          <CompanyProfileInventory workspaceId={workspaceId} />
-          <details
-            id="brain-diagnostics"
-            className="group scroll-mt-4 rounded-lg border border-border bg-surface"
-            open={diagnosticsOpen}
-            onToggle={(event) => setDiagnosticsOpen(event.currentTarget.open)}
+      <div className="mt-6">
+        {view ? (
+          <Link
+            to="/workspaces/$workspaceId/state"
+            params={{ workspaceId }}
+            search={{}}
+            className="mb-4 inline-flex items-center gap-1 text-xs font-medium text-brand hover:underline"
           >
-            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-surface-2/50 [&::-webkit-details-marker]:hidden">
-              <div>
-                <h2 className="text-sm font-semibold text-fg">Advanced & diagnostics</h2>
-                <p className="mt-1 text-xs leading-5 text-fg-muted">
-                  Authority inventories, structured preference lifecycle controls, immutable hashes,
-                  accepted-attempt drift, inactive policy drafts, and bounded structural gaps.
-                </p>
+            <ArrowLeftIcon className="size-3" />
+            Back to Agent Brain
+          </Link>
+        ) : null}
+        {loading && !state ? <WorkspaceStateLoading /> : null}
+        {error && !state ? (
+          <LoadErrorState
+            title="Couldn't load Agent Brain"
+            error={error}
+            onRetry={() => void reload()}
+          />
+        ) : null}
+        {state ? (
+          <div className="grid gap-4">
+            {error ? (
+              <LoadErrorState
+                title="Couldn't refresh Agent Brain"
+                error={error}
+                onRetry={() => void reload()}
+              />
+            ) : null}
+            {view === "company" ? (
+              <div className="grid gap-4">
+                <AgentBrainPrompt kind="company_profile" workspaceId={workspaceId} />
+                <details className="rounded-lg border border-border bg-surface">
+                  <summary className="cursor-pointer list-none px-4 py-3 text-sm font-medium text-fg [&::-webkit-details-marker]:hidden">
+                    Edit manually and view history
+                  </summary>
+                  <div className="border-t border-border p-4">
+                    <CompanyProfileInventory workspaceId={workspaceId} />
+                  </div>
+                </details>
               </div>
-              <ChevronDownIcon className="size-4 shrink-0 text-fg-muted transition-transform group-open:rotate-180" />
-            </summary>
-            <div className="grid gap-4 border-t border-border p-4">
-              <PolicyInventory state={state} />
-              <PreferenceInventory state={state} />
+            ) : null}
+            {view === "instructions" ? (
+              <FocusedInstructions
+                state={state}
+                workspaceId={workspaceId}
+                onWorkspaceStateReload={reload}
+              />
+            ) : null}
+            {view === "preferences" ? (
               <PreferenceRegistryAdministration
                 workspaceId={workspaceId}
                 onWorkspaceStateReload={reload}
+                compact
               />
-              <OnboardingProposalInventory
-                state={state}
-                workspaceId={workspaceId}
-                onWorkspaceStateReload={reload}
-              />
-              <AttemptGovernanceInventory
-                state={state}
-                attemptInput={attemptInput}
-                onAttemptInput={setAttemptInput}
-                onInspect={inspectAttempt}
-                onClear={clearAttempt}
-              />
-              <KnowledgeInventory state={state} workspaceId={workspaceId} />
-              <ExistingSources workspaceId={workspaceId} />
-            </div>
-          </details>
-        </div>
-      ) : null}
+            ) : null}
+            {!view ? (
+              <>
+                <BrainOverview
+                  state={state}
+                  workspaceId={workspaceId}
+                  companyProfileStatus={companyProfileStatus}
+                />
+                <details
+                  id="brain-diagnostics"
+                  className="group scroll-mt-4 rounded-lg border border-border bg-surface"
+                  open={diagnosticsOpen}
+                  onToggle={(event) => setDiagnosticsOpen(event.currentTarget.open)}
+                >
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-surface-2/50 [&::-webkit-details-marker]:hidden">
+                    <div>
+                      <h2 className="text-sm font-semibold text-fg">Advanced & diagnostics</h2>
+                      <p className="mt-1 text-xs leading-5 text-fg-muted">
+                        Technical details, audit history and administration.
+                      </p>
+                    </div>
+                    <ChevronDownIcon className="size-4 shrink-0 text-fg-muted transition-transform group-open:rotate-180" />
+                  </summary>
+                  <div className="grid gap-4 border-t border-border p-4">
+                    <PolicyInventory state={state} />
+                    <PreferenceInventory state={state} />
+                    <PreferenceRegistryAdministration
+                      workspaceId={workspaceId}
+                      onWorkspaceStateReload={reload}
+                    />
+                    <OnboardingProposalInventory
+                      state={state}
+                      workspaceId={workspaceId}
+                      onWorkspaceStateReload={reload}
+                    />
+                    <AttemptGovernanceInventory
+                      state={state}
+                      attemptInput={attemptInput}
+                      onAttemptInput={setAttemptInput}
+                      onInspect={inspectAttempt}
+                      onClear={clearAttempt}
+                    />
+                    <KnowledgeInventory state={state} workspaceId={workspaceId} />
+                  </div>
+                </details>
+              </>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
     </ContentPage>
   );
 }

--- a/apps/web/src/workspace-route-scroll-contract.test.ts
+++ b/apps/web/src/workspace-route-scroll-contract.test.ts
@@ -8,6 +8,7 @@ type ScrollContract =
 const workspaceRouteContracts = {
   workspaceIndexRoute: { kind: "redirect" },
   workspaceAgentRoute: { kind: "redirect" },
+  workspaceAgentsRoute: { kind: "page", source: "routes/agents.tsx" },
   workspaceSessionsRoute: { kind: "self-managed", source: "routes/sessions-index.tsx" },
   workspaceSessionRoute: { kind: "self-managed", source: "routes/session.tsx" },
   workspaceVariableSetsRoute: { kind: "page", source: "routes/variable-sets.tsx" },

--- a/apps/web/src/workspace-state-surface.test.ts
+++ b/apps/web/src/workspace-state-surface.test.ts
@@ -17,36 +17,35 @@ describe("Agent Brain authority surface", () => {
     expect(navigation).toContain('description: "What agents always know and retrieve"');
   });
 
-  test("makes four bounded authorities plain while preserving canonical governance APIs", async () => {
-    const [route, overview, loader, preferences] = await Promise.all([
+  test("keeps the default Agent Brain simple while preserving canonical governance APIs", async () => {
+    const [route, overview, prompt, loader, preferences] = await Promise.all([
       source("routes/workspace-state.tsx"),
       source("routes/agent-brain-overview.tsx"),
+      source("routes/agent-brain-prompt.tsx"),
       source("routes/workspace-state-loader.ts"),
       source("routes/preference-registry-admin.tsx"),
     ]);
     for (const required of [
       "Loading Agent Brain",
       "Couldn't load Agent Brain",
-      "Four authorities, two ways agents use them",
-      "Always known",
-      "Retrieved when relevant",
-      "Charter & policy",
-      "Preference Registry",
-      "Documents / RAG",
+      "What every agent starts with, and what it can find when needed.",
+      "Included automatically",
+      "Company profile & goals",
+      "Not configured",
+      "Workspace instructions",
+      "Not set",
+      "Preferences",
+      "Short summaries are always known; full instructions are fetched when needed.",
+      "Back to Agent Brain",
+      "Instructions for this workspace",
+      "Save instructions",
+      "Changes are versioned and can be audited or rolled back.",
+      "Available when needed",
+      "Documents",
       "Memory",
-      "Bounded descriptor metadata plus exact retrieval handle",
-      "On demand; never loaded by this overview",
-      "Not projected; no combined effective source is inferred",
-      "No structured active heads",
-      "Partial ·",
-      "Unavailable · permission",
-      "Empty sample",
-      "Partial sample ·",
-      "Searchable evidence",
-      "Learned facts and decisions",
-      "Pending changes",
-      "History & rollback",
+      "Facts, decisions and observations learned across agent work.",
       "Advanced & diagnostics",
+      "Technical details, audit history and administration.",
       "No instruction-policy revisions exist yet.",
       "Preference authority inventory",
       "PreferenceRegistryAdministration",
@@ -61,9 +60,6 @@ describe("Agent Brain authority surface", () => {
       "Deterministic drift compares stable IDs",
       "Base list truncated",
       "Memory sample reached",
-      "Open Documents",
-      "Skills & capabilities",
-      "Sessions & agents",
       "Create draft proposal",
       "Proposals never activate themselves",
       "Inactive proposal",
@@ -71,12 +67,28 @@ describe("Agent Brain authority surface", () => {
       expect(`${route}\n${overview}`).toContain(required);
     }
     expect(route.indexOf("<BrainOverview")).toBeLessThan(route.indexOf('id="brain-diagnostics"'));
-    expect(overview).toContain("it is not another knowledge store and never merges or");
-    expect(overview).toContain("the Brain never performs a cross-authority rollback");
-    expect(overview).toContain("organization profile is not projected here");
-    expect(overview).toContain("onOpenDiagnostics");
+    expect(overview).toContain("search={{ view }}");
+    expect(overview).toContain('view="company"');
+    expect(overview).toContain('view="instructions"');
+    expect(overview).toContain('view="preferences"');
+    expect(route).toContain("compact");
+    expect(preferences).toContain("Write manually");
+    expect(preferences).toContain("Save preference");
+    expect(preferences).toContain("Always visible summary");
+    expect(prompt).toContain("Tell OpenGeni what you want it to remember");
+    expect(prompt).toContain("Tell OpenGeni how agents should work");
+    expect(prompt).toContain("Tell OpenGeni about your company and goals");
+    expect(prompt).toContain("show you the result before saving it");
+    expect(prompt).toContain("context.startSession");
+    expect(prompt).toContain("canonical durable-learning");
+    expect(prompt).toContain("Never save the preference as ordinary Memory");
+    expect(overview).not.toContain("workspace_instruction_policy_heads");
+    expect(overview).not.toContain("Runtime composition");
+    expect(overview).not.toContain("Four authorities, two ways agents use them");
+    expect(route).not.toContain("Authoritative source surfaces");
+    expect(route).not.toContain("Generated {formatDate(state.generatedAt)}");
     expect(route).toContain("open={diagnosticsOpen}");
-    expect(route.indexOf("<PreferenceRegistryAdministration")).toBeGreaterThan(
+    expect(route.lastIndexOf("<PreferenceRegistryAdministration")).toBeGreaterThan(
       route.indexOf('id="brain-diagnostics"'),
     );
     expect(overview).not.toMatch(/getPreferenceRegistry|preference_registry_get/);
@@ -145,8 +157,10 @@ describe("Agent Brain authority surface", () => {
     ]) {
       expect(preferences).toContain(operation);
     }
+    expect(route).toContain("createWorkspaceInstructionPolicyDraft");
+    expect(route).toContain("activateWorkspaceInstructionPolicyRevision");
     expect(`${route}\n${overview}\n${loader}\n${preferences}`).not.toMatch(
-      /activateWorkspaceInstruction|updateKnowledgeMemory|createKnowledgeMemory/,
+      /updateKnowledgeMemory|createKnowledgeMemory/,
     );
     expect(route).not.toMatch(/method:\s*["'](?:POST|PATCH|PUT|DELETE)/);
     expect(route).not.toContain("policy snapshots are not implemented");

--- a/docs/workspace-state.md
+++ b/docs/workspace-state.md
@@ -13,9 +13,9 @@ The overview links to focused workspace-instruction and preference views rather
 than opening the diagnostic inventory. Both focused views are prompt-first: the
 user describes the desired behavior in plain language and continues in a real
 OpenGeni session that asks essential follow-ups and proposes the structured
-result before saving. This flow depends on OPE-183/OPE-184's canonical durable
-learning write tools; it must never substitute ordinary Memory for preference
-or instruction authority.
+result before saving. This flow depends on the canonical durable learning write
+tools; it must never substitute ordinary Memory for preference or instruction
+authority.
 
 Direct workspace-instruction and preference editors remain available under a
 collapsed **Write manually** disclosure. Manual workspace saves create and

--- a/docs/workspace-state.md
+++ b/docs/workspace-state.md
@@ -1,17 +1,32 @@
 # Agent Brain overview (Workspace State projection)
 
-The Agent Brain page is a plain-language, read-time overview of existing
-workspace authorities, backed by the Workspace State projection. Its default
-view explains the four canonical authorities and the two ways agents use them:
+The Agent Brain page is a plain-language overview of existing workspace
+authorities, backed by the Workspace State projection. Its default view groups
+them by the two ways agents use them:
 
 - bounded charter/policy context and preference descriptors are always-known
   governance;
 - Documents/RAG evidence and Memory records remain searchable and are retrieved
   when relevant.
 
-The overview helps ordinary users understand effective status, scope,
-provenance, freshness, lifecycle signals, and the correct authority-specific
-entry point without combining those authorities or creating another store.
+The overview links to focused workspace-instruction and preference views rather
+than opening the diagnostic inventory. Both focused views are prompt-first: the
+user describes the desired behavior in plain language and continues in a real
+OpenGeni session that asks essential follow-ups and proposes the structured
+result before saving. This flow depends on OPE-183/OPE-184's canonical durable
+learning write tools; it must never substitute ordinary Memory for preference
+or instruction authority.
+
+Direct workspace-instruction and preference editors remain available under a
+collapsed **Write manually** disclosure. Manual workspace saves create and
+activate an immutable global policy revision through the existing
+instruction-policy API. Manual preference saves derive the stable key and
+default conflict metadata, then activate the explicit human-authored revision.
+Full governance controls remain available in Advanced.
+
+The overview helps ordinary users understand effective status, scope, and the
+correct authority-specific entry point without combining those authorities or
+creating another store.
 Hashes, accepted-attempt lookup, raw inventories, structural gaps, and
 onboarding internals live under **Advanced & diagnostics**. The underlying
 projection and export remain read-only. Advanced & diagnostics preserves two
@@ -21,9 +36,9 @@ structured preference governance for explicit organization/workspace/personal
 proposal and lifecycle operations. Neither seam creates another storage
 authority, background synthesizer, or runtime prompt source.
 
-The current slice is additive and dependency-safe. Wider policy authoring,
-proposal review workflows, learning-policy history, and source administration
-remain later phases.
+The current slice is additive and dependency-safe. Role-specific policy
+authoring, proposal review workflows, learning-policy history, and source
+administration remain later phases.
 
 ## Authority boundaries
 
@@ -255,31 +270,22 @@ changes. Gaps are not persisted and cannot activate policy.
 
 `/workspaces/:workspaceId/state` is labeled **Agent Brain** in the console and
 renders loading, empty, permission-unavailable, error/retry, partial-coverage,
-freshness, and accepted-attempt governance states. The default page is grouped
-by use at runtime. Status badges explicitly distinguish unavailable, partial or
-truncated, processing, failed, and empty projections from complete non-empty
-ones:
+freshness, and accepted-attempt governance states. The default page is a compact
+mental model rather than a diagnostic inventory:
 
-1. **Always known** shows bounded charter/policy active-head scope, the latest
-   revision's state and provenance, and the legacy source configuration as three
-   separate facts. Because `runtimeComposition.status` is `not_implemented`, it
-   never labels the latest inactive revision or legacy fallback as the composed
-   effective runtime source. It also shows structured preference descriptor
-   counts by organization/workspace/user scope. Runtime descriptors contain
-   bounded identity, title/description, scope/version/hash,
-   precedence/conflict/provenance metadata, expiry, and an exact retrieval
-   handle; this overview requests and renders only aggregate count/scope/hash
-   metadata. Full preference bodies remain on demand. The current projection
-   does not infer or synthesize an organization company profile when that
-   authority is not present in the response contract.
-2. **Retrieved when relevant** shows Documents/RAG indexing and immutable
-   authority coverage separately from a bounded Memory lifecycle/kind sample.
-3. **Pending changes** explicitly says that the current projection has no
-   unified governed-learning suggestion queue. Existing onboarding drafts remain
-   separate inactive policy evidence rather than being presented as automatic
-   learning.
-4. **History & rollback** directs users to the authority-specific surfaces and
-   states that the Brain never performs a cross-authority rollback.
+1. **Always known** lists company profile and goals, workspace instructions, and
+   preference summaries. Company profile status comes from the dedicated
+   organization authority; **Manage** opens an agent-assisted prompt, with the
+   versioned manual editor and history kept under a disclosure. Preferences show
+   only the active summary count and explain that full instructions are fetched
+   when needed.
+2. **Available when needed** links to Documents and Memory with a single status
+   line for each. Documents summarize indexing health; Memory summarizes the
+   newest authorized sample.
+
+Hashes, provenance, authority table names, truncation mechanics, accepted-
+attempt drift, onboarding drafts, and lifecycle controls do not appear in the
+default overview.
 
 **Advanced & diagnostics** preserves the detailed policy and structured-
 preference inventories, the canonical Preference Registry administration panel,
@@ -321,9 +327,9 @@ activate registry state. The separately authorized governed-learning controller
 is the sole future automatic-activation seam.
 
 There is no instruction-policy activation/rollback UI, Memory promotion,
-Documents promotion, or general policy editor. Deep links lead to the existing
-Documents, Memory, Capabilities/Skills, Sessions/Agents, Rigs, Variable Sets,
-and Workspace Settings surfaces.
+Documents promotion, or general policy editor. The default overview links only
+to Documents and Memory; technical administration remains under the collapsed
+Advanced section.
 
 ## Explicit non-goals
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1279,12 +1279,7 @@ export * from "./transcription-recordings";
 export const CodexCompactionMode = z.enum(["remote_v2", "portable"]);
 export type CodexCompactionMode = z.infer<typeof CodexCompactionMode>;
 
-export const SlackReactionEmojiName = z
-  .string()
-  .trim()
-  .min(1)
-  .max(64)
-  .regex(/^[a-z0-9_+-]+$/, "use the exact Slack emoji name without surrounding colons");
+export const SlackReactionEmojiName = z.literal("genie");
 export type SlackReactionEmojiName = z.infer<typeof SlackReactionEmojiName>;
 
 export const WorkspaceSlackReactionChannelPolicy = z.discriminatedUnion("mode", [

--- a/packages/contracts/test/slack-reaction-settings.test.ts
+++ b/packages/contracts/test/slack-reaction-settings.test.ts
@@ -25,12 +25,21 @@ describe("Slack reaction summon workspace settings", () => {
     ).toEqual(DEFAULT_WORKSPACE_SLACK_REACTION_SUMMON_SETTINGS);
   });
 
-  test("validates exact emoji names and normalizes allowlist duplicates", () => {
+  test("accepts only the genie emoji and normalizes allowlist duplicates", () => {
     expect(
       UpdateWorkspaceSettingsRequest.safeParse({
         slackReactionSummon: {
           enabled: true,
           emoji: ":genie:",
+          channelPolicy: { mode: "bot_member" },
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      UpdateWorkspaceSettingsRequest.safeParse({
+        slackReactionSummon: {
+          enabled: true,
+          emoji: "sparkles",
           channelPolicy: { mode: "bot_member" },
         },
       }).success,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -2905,7 +2905,7 @@ export type WorkspaceSettings = {
 
 export type WorkspaceSlackReactionSummonSettings = {
   enabled: boolean;
-  emoji: string;
+  emoji: "genie";
   channelPolicy: { mode: "bot_member" } | { mode: "allowlist"; channelIds: string[] };
 };
 

--- a/test/e2e/knowledge-surfaces.browser.e2e.ts
+++ b/test/e2e/knowledge-surfaces.browser.e2e.ts
@@ -359,7 +359,7 @@ describe("responsive knowledge surfaces (real API + PostgreSQL)", () => {
     await page.route(basesPattern, delayedBases);
     await page.goto(surfaceUrl(webBaseUrl, workspaceId, "documents", fixtures));
     await basesRequest;
-    await page.getByText("Loading collections", { exact: true }).waitFor();
+    await page.getByText("Loading documents", { exact: true }).waitFor();
     releaseBases();
     await page.getByText("No documents yet", { exact: true }).waitFor();
     await page.unroute(basesPattern, delayedBases);
@@ -786,16 +786,14 @@ async function openSurface(
     await page.getByText(longVariableSetName, { exact: true }).waitFor();
     await ensureVariableSetExpanded(page);
   } else if (surface === "documents") {
-    await page.getByText(longBaseName, { exact: true }).waitFor();
     await page.getByText("No documents yet", { exact: true }).waitFor();
-    const bases = page.getByRole("complementary", {
-      name: "Collections (optional)",
-      exact: true,
-    });
     const search = page.getByRole("complementary", { name: "Search", exact: true });
-    await bases.waitFor();
     await search.waitFor();
-    await search.getByRole("textbox", { name: "ACL tags", exact: true }).waitFor();
+    await search.getByRole("textbox", { name: "Search indexed documents", exact: true }).waitFor();
+    expect(await page.getByRole("complementary", { name: "Collections (optional)" }).count()).toBe(
+      0,
+    );
+    expect(await search.getByRole("textbox", { name: "ACL tags", exact: true }).count()).toBe(0);
     expect(await page.getByRole("heading", { name: "Working set" }).count()).toBe(0);
   } else {
     await page
@@ -963,8 +961,8 @@ async function expectOwnedTouchTargets(page: Page, surface: Surface): Promise<vo
         ]
       : surface === "documents"
         ? [
-            page.locator("summary").getByText("New collectionoptional", { exact: true }),
-            page.getByRole("button", { name: longBaseName, exact: true }),
+            page.getByRole("button", { name: "Choose files", exact: true }),
+            page.getByRole("combobox", { name: "Drop authority", exact: true }),
           ]
         : [page.getByRole("button", { name: "Add memory", exact: true })];
   for (const target of targets) {


### PR DESCRIPTION
## Summary
- replace the governance-heavy Workspace State default with a simple Agent Brain overview and guided prompt flows
- make Documents scope-first, remove collection and ACL clutter, add realistic local previews, and keep canonical routes available
- standardize Capabilities app tiles and simplify Slack and Google Drive connection states, actions, scopes, and local previews
- fix the Slack reaction shortcut to the genie emoji and keep workspace-bot imports within workspace or organization authority

## Linked work
OPE-186, OPE-141, OPE-144, OPE-124, OPE-16

## Verification
- bun run format:check
- bun run lint
- bun run typecheck
- 148 focused web, contract, and SDK assertions
- bun run --cwd apps/web build, including bundle budgets
- local browser review of Agent Brain, Documents, Slack disconnected/connected, and Google Drive disconnected/connected previews

## Coordination
PR #1286 has one additive overlap in the Capabilities route. This PR intentionally lands the simplified surface first; #1286 should rebase and place its Memory-to-Slack card within the new Slack settings layout.