### PR TITLE
fix(web): add Codex code copy action

### DIFF
--- a/apps/web/src/components/codex-connection.test.tsx
+++ b/apps/web/src/components/codex-connection.test.tsx
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
-import { act } from "react";
+import { act, type ComponentProps } from "react";
 import { createRoot } from "react-dom/client";
 
 import { CodexDeviceCodePanel } from "./codex-connection";
@@ -34,17 +34,17 @@ function setClipboard(writeText: (value: string) => Promise<void>): void {
   });
 }
 
-async function renderPanel() {
+const defaultPanelProps = {
+  userCode: "ABCD-1234",
+  verificationUri: "https://auth.openai.com/codex/device",
+} satisfies ComponentProps<typeof CodexDeviceCodePanel>;
+
+async function renderPanel(props: ComponentProps<typeof CodexDeviceCodePanel> = defaultPanelProps) {
   const container = document.createElement("div");
   document.body.append(container);
   const root = createRoot(container);
   await act(async () => {
-    root.render(
-      <CodexDeviceCodePanel
-        userCode="ABCD-1234"
-        verificationUri="https://auth.openai.com/codex/device"
-      />,
-    );
+    root.render(<CodexDeviceCodePanel {...props} />);
   });
   return { container, root };
 }
@@ -147,5 +147,79 @@ describe("CodexDeviceCodePanel", () => {
       await act(async () => root.unmount());
       container.remove();
     }
+  });
+
+  test("does not copy an expired code if it changes while the helper loads", async () => {
+    let resolveLoad!: (module: {
+      copyTextToClipboard: (value: string) => Promise<boolean>;
+    }) => void;
+    const writes: string[] = [];
+    const loadClipboard = () =>
+      new Promise<{ copyTextToClipboard: (value: string) => Promise<boolean> }>((resolve) => {
+        resolveLoad = resolve;
+      });
+    const { container, root } = await renderPanel({ ...defaultPanelProps, loadClipboard });
+
+    try {
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]')!.click();
+        await Promise.resolve();
+      });
+      await act(async () => {
+        root.render(
+          <CodexDeviceCodePanel
+            {...defaultPanelProps}
+            userCode="WXYZ-5678"
+            loadClipboard={loadClipboard}
+          />,
+        );
+      });
+      await act(async () => {
+        resolveLoad({
+          copyTextToClipboard: async (value) => {
+            writes.push(value);
+            return true;
+          },
+        });
+        await Promise.resolve();
+      });
+
+      expect(writes).toEqual([]);
+      expect(container.querySelector("[data-codex-device-code]")?.textContent).toBe("WXYZ-5678");
+      expect(container.querySelector('button[aria-label="Code copied"]')).toBeNull();
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("does not copy after unmount while the helper loads", async () => {
+    let resolveLoad!: (module: {
+      copyTextToClipboard: (value: string) => Promise<boolean>;
+    }) => void;
+    const writes: string[] = [];
+    const loadClipboard = () =>
+      new Promise<{ copyTextToClipboard: (value: string) => Promise<boolean> }>((resolve) => {
+        resolveLoad = resolve;
+      });
+    const { container, root } = await renderPanel({ ...defaultPanelProps, loadClipboard });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]')!.click();
+      await Promise.resolve();
+    });
+    await act(async () => root.unmount());
+    await act(async () => {
+      resolveLoad({
+        copyTextToClipboard: async (value) => {
+          writes.push(value);
+          return true;
+        },
+      });
+      await Promise.resolve();
+    });
+
+    expect(writes).toEqual([]);
+    container.remove();
   });
 });

--- a/apps/web/src/components/codex-connection.test.tsx
+++ b/apps/web/src/components/codex-connection.test.tsx
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
@@ -16,31 +16,48 @@ afterAll(() => {
   GlobalRegistrator.unregister();
 });
 
+afterEach(() => {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: undefined,
+  });
+});
+
+function setClipboard(writeText: (value: string) => Promise<void>): void {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: () => false,
+  });
+}
+
+async function renderPanel() {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <CodexDeviceCodePanel
+        userCode="ABCD-1234"
+        verificationUri="https://auth.openai.com/codex/device"
+      />,
+    );
+  });
+  return { container, root };
+}
+
 describe("CodexDeviceCodePanel", () => {
   test("copies the exact device code and confirms the action", async () => {
     const copies: string[] = [];
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: {
-        writeText: async (value: string) => {
-          copies.push(value);
-        },
-      },
+    setClipboard(async (value) => {
+      copies.push(value);
     });
-    const container = document.createElement("div");
-    document.body.append(container);
-    const root = createRoot(container);
+    const { container, root } = await renderPanel();
 
     try {
-      await act(async () => {
-        root.render(
-          <CodexDeviceCodePanel
-            userCode="ABCD-1234"
-            verificationUri="https://auth.openai.com/codex/device"
-          />,
-        );
-      });
-
       expect(container.querySelector("[data-codex-device-code]")?.textContent).toBe("ABCD-1234");
       const button = container.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]');
       expect(button?.type).toBe("button");
@@ -57,6 +74,75 @@ describe("CodexDeviceCodePanel", () => {
       const authLink = container.querySelector<HTMLAnchorElement>("a");
       expect(authLink?.href).toBe("https://auth.openai.com/codex/device");
       expect(authLink?.target).toBe("_blank");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("clears prior success feedback when a later copy fails", async () => {
+    let shouldFail = false;
+    setClipboard(async () => {
+      if (shouldFail) throw new Error("clipboard denied");
+    });
+    const { container, root } = await renderPanel();
+
+    try {
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]')!.click();
+        await Promise.resolve();
+      });
+      expect(container.querySelector('button[aria-label="Code copied"]')).not.toBeNull();
+
+      shouldFail = true;
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>('button[aria-label="Code copied"]')!.click();
+        await Promise.resolve();
+      });
+
+      expect(container.querySelector('button[aria-label="Code copied"]')).toBeNull();
+      expect(container.querySelector('button[aria-label="Copy code"]')?.textContent).toContain(
+        "Copy code",
+      );
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("ignores an older copy completion after a newer attempt fails", async () => {
+    let resolveFirst!: () => void;
+    let calls = 0;
+    setClipboard(() => {
+      calls += 1;
+      if (calls === 1) {
+        return new Promise<void>((resolve) => {
+          resolveFirst = resolve;
+        });
+      }
+      return Promise.reject(new Error("clipboard denied"));
+    });
+    const { container, root } = await renderPanel();
+
+    try {
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]')!.click();
+        await Promise.resolve();
+      });
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]')!.click();
+        await Promise.resolve();
+      });
+      expect(container.querySelector('button[aria-label="Code copied"]')).toBeNull();
+
+      await act(async () => {
+        resolveFirst();
+        await Promise.resolve();
+      });
+
+      expect(calls).toBe(2);
+      expect(container.querySelector('button[aria-label="Code copied"]')).toBeNull();
+      expect(container.querySelector('button[aria-label="Copy code"]')).not.toBeNull();
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/components/codex-connection.test.tsx
+++ b/apps/web/src/components/codex-connection.test.tsx
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { CodexDeviceCodePanel } from "./codex-connection";
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  GlobalRegistrator.unregister();
+});
+
+describe("CodexDeviceCodePanel", () => {
+  test("copies the exact device code and confirms the action", async () => {
+    const copies: string[] = [];
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (value: string) => {
+          copies.push(value);
+        },
+      },
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <CodexDeviceCodePanel
+            userCode="ABCD-1234"
+            verificationUri="https://auth.openai.com/codex/device"
+          />,
+        );
+      });
+
+      expect(container.querySelector("[data-codex-device-code]")?.textContent).toBe("ABCD-1234");
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]');
+      expect(button?.type).toBe("button");
+
+      await act(async () => {
+        button!.click();
+        await Promise.resolve();
+      });
+
+      expect(copies).toEqual(["ABCD-1234"]);
+      expect(container.querySelector('button[aria-label="Code copied"]')?.textContent).toContain(
+        "Copied",
+      );
+      const authLink = container.querySelector<HTMLAnchorElement>("a");
+      expect(authLink?.href).toBe("https://auth.openai.com/codex/device");
+      expect(authLink?.target).toBe("_blank");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+});

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -638,10 +638,13 @@ export function CodexDeviceCodePanel({
 }) {
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const copyAttemptRef = useRef(0);
 
   useEffect(() => {
+    copyAttemptRef.current += 1;
     setCopied(false);
     return () => {
+      copyAttemptRef.current += 1;
       if (copiedTimerRef.current !== null) {
         clearTimeout(copiedTimerRef.current);
         copiedTimerRef.current = null;
@@ -650,9 +653,19 @@ export function CodexDeviceCodePanel({
   }, [userCode]);
 
   const copyCode = useCallback(async () => {
+    const attempt = ++copyAttemptRef.current;
+    if (copiedTimerRef.current !== null) {
+      clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = null;
+    }
+    setCopied(false);
+
     const ok = await copyTextToClipboard(userCode);
+    if (attempt !== copyAttemptRef.current) return;
     if (!ok) {
-      toast.error("Couldn't copy the code", { description: "Copy it manually instead." });
+      toast.error("Couldn't copy the code", {
+        description: "Copy it manually instead.",
+      });
       return;
     }
     setCopied(true);
@@ -661,6 +674,7 @@ export function CodexDeviceCodePanel({
       clearTimeout(copiedTimerRef.current);
     }
     copiedTimerRef.current = setTimeout(() => {
+      if (attempt !== copyAttemptRef.current) return;
       copiedTimerRef.current = null;
       setCopied(false);
     }, CODE_COPIED_FEEDBACK_MS);

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -14,8 +14,11 @@ import type {
   CodexUsageMap,
   CodexUsageWindow,
 } from "@opengeni/sdk";
+import { copyTextToClipboard } from "@opengeni/react";
 import {
+  CheckIcon,
   ChevronDownIcon,
+  CopyIcon,
   ExternalLinkIcon,
   Loader2Icon,
   PencilIcon,
@@ -624,6 +627,85 @@ function resetBadgeTone(remainingMs: number | null): "urgent" | "soon" | "ok" {
   return "ok";
 }
 
+const CODE_COPIED_FEEDBACK_MS = 1600;
+
+export function CodexDeviceCodePanel({
+  userCode,
+  verificationUri,
+}: {
+  userCode: string;
+  verificationUri: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setCopied(false);
+    return () => {
+      if (copiedTimerRef.current !== null) {
+        clearTimeout(copiedTimerRef.current);
+        copiedTimerRef.current = null;
+      }
+    };
+  }, [userCode]);
+
+  const copyCode = useCallback(async () => {
+    const ok = await copyTextToClipboard(userCode);
+    if (!ok) {
+      toast.error("Couldn't copy the code", { description: "Copy it manually instead." });
+      return;
+    }
+    setCopied(true);
+    toast.success("Code copied");
+    if (copiedTimerRef.current !== null) {
+      clearTimeout(copiedTimerRef.current);
+    }
+    copiedTimerRef.current = setTimeout(() => {
+      copiedTimerRef.current = null;
+      setCopied(false);
+    }, CODE_COPIED_FEEDBACK_MS);
+  }, [userCode]);
+
+  return (
+    <div className="grid gap-2 rounded-md border border-border bg-bg p-3">
+      <div className="text-xs text-fg-muted">
+        Enter this code at the OpenAI page (opened in a new tab). Authorization continues if you
+        navigate away.
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <code
+          data-codex-device-code=""
+          className="rounded bg-surface-2 px-3 py-1.5 text-lg font-semibold tracking-widest"
+        >
+          {userCode}
+        </code>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          aria-label={copied ? "Code copied" : "Copy code"}
+          onClick={() => void copyCode()}
+        >
+          {copied ? (
+            <CheckIcon className="size-3.5" aria-hidden="true" />
+          ) : (
+            <CopyIcon className="size-3.5" aria-hidden="true" />
+          )}
+          {copied ? "Copied" : "Copy code"}
+        </Button>
+        <Button asChild type="button" variant="secondary" size="sm">
+          <a href={verificationUri} target="_blank" rel="noopener noreferrer">
+            Open auth page <ExternalLinkIcon className="size-3.5" />
+          </a>
+        </Button>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-fg-subtle">
+        <Loader2Icon className="size-3.5 animate-spin" /> Waiting for authorization…
+      </div>
+    </div>
+  );
+}
+
 export function CodexSubscriptionsCard({
   workspaceId,
   canManage,
@@ -1112,25 +1194,10 @@ export function CodexSubscriptionsCard({
           <Loader2Icon className="size-3.5 animate-spin" /> Loading subscriptions…
         </div>
       ) : pending ? (
-        <div className="grid gap-2 rounded-md border border-border bg-bg p-3">
-          <div className="text-xs text-fg-muted">
-            Enter this code at the OpenAI page (opened in a new tab). Authorization continues if you
-            navigate away.
-          </div>
-          <div className="flex items-center gap-2">
-            <code className="rounded bg-surface-2 px-3 py-1.5 text-lg font-semibold tracking-widest">
-              {pending.userCode}
-            </code>
-            <Button asChild type="button" variant="secondary" size="sm">
-              <a href={pending.verificationUri} target="_blank" rel="noopener noreferrer">
-                Open auth page <ExternalLinkIcon className="size-3.5" />
-              </a>
-            </Button>
-          </div>
-          <div className="flex items-center gap-2 text-xs text-fg-subtle">
-            <Loader2Icon className="size-3.5 animate-spin" /> Waiting for authorization…
-          </div>
-        </div>
+        <CodexDeviceCodePanel
+          userCode={pending.userCode}
+          verificationUri={pending.verificationUri}
+        />
       ) : accounts.length === 0 ? (
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-xs text-fg-subtle">

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -628,12 +628,20 @@ function resetBadgeTone(remainingMs: number | null): "urgent" | "soon" | "ok" {
 
 const CODE_COPIED_FEEDBACK_MS = 1600;
 
+type ClipboardModule = {
+  copyTextToClipboard: (text: string) => Promise<boolean>;
+};
+
+const loadSharedClipboard = (): Promise<ClipboardModule> => import("@opengeni/react/clipboard");
+
 export function CodexDeviceCodePanel({
   userCode,
   verificationUri,
+  loadClipboard = loadSharedClipboard,
 }: {
   userCode: string;
   verificationUri: string;
+  loadClipboard?: () => Promise<ClipboardModule>;
 }) {
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -659,7 +667,8 @@ export function CodexDeviceCodePanel({
     }
     setCopied(false);
 
-    const { copyTextToClipboard } = await import("@opengeni/react/clipboard");
+    const { copyTextToClipboard } = await loadClipboard();
+    if (attempt !== copyAttemptRef.current) return;
     const ok = await copyTextToClipboard(userCode);
     if (attempt !== copyAttemptRef.current) return;
     if (!ok) {
@@ -678,7 +687,7 @@ export function CodexDeviceCodePanel({
       copiedTimerRef.current = null;
       setCopied(false);
     }, CODE_COPIED_FEEDBACK_MS);
-  }, [userCode]);
+  }, [loadClipboard, userCode]);
 
   return (
     <div className="grid gap-2 rounded-md border border-border bg-bg p-3">

--- a/apps/web/src/components/codex-connection.tsx
+++ b/apps/web/src/components/codex-connection.tsx
@@ -14,7 +14,6 @@ import type {
   CodexUsageMap,
   CodexUsageWindow,
 } from "@opengeni/sdk";
-import { copyTextToClipboard } from "@opengeni/react";
 import {
   CheckIcon,
   ChevronDownIcon,
@@ -660,6 +659,7 @@ export function CodexDeviceCodePanel({
     }
     setCopied(false);
 
+    const { copyTextToClipboard } = await import("@opengeni/react/clipboard");
     const ok = await copyTextToClipboard(userCode);
     if (attempt !== copyAttemptRef.current) return;
     if (!ok) {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -70,6 +70,10 @@
       "types": "./src/interaction.ts",
       "default": "./src/interaction.ts"
     },
+    "./clipboard": {
+      "types": "./src/clipboard.ts",
+      "default": "./src/clipboard.ts"
+    },
     "./styles.css": {
       "types": "./styles/index.d.ts",
       "style": "./styles/index.css",

--- a/packages/react/src/clipboard.ts
+++ b/packages/react/src/clipboard.ts
@@ -1,0 +1,2 @@
+// @opengeni/react/clipboard — narrow clipboard helpers without the root UI barrel.
+export { copyTextToClipboard } from "./lib/clipboard";

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
     "src/artifacts-document.ts",
     "src/artifacts-presentation.ts",
     "src/interaction.ts",
+    "src/clipboard.ts",
   ],
   format: ["esm"],
   target: "es2022",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -70,6 +70,7 @@
       "@opengeni/react/artifacts/document": ["./packages/react/src/artifacts-document.ts"],
       "@opengeni/react/artifacts/presentation": ["./packages/react/src/artifacts-presentation.ts"],
       "@opengeni/react/artifacts/spreadsheet": ["./packages/react/src/artifacts-spreadsheet.ts"],
+      "@opengeni/react/clipboard": ["./packages/react/src/clipboard.ts"],
       "@opengeni/sdk": ["./packages/sdk/src/index.ts"],
       "@opengeni/sdk/editable-artifacts": ["./packages/sdk/src/editable-artifacts.ts"],
       "@opengeni/sdk/editable-artifacts/worker": [


### PR DESCRIPTION
## Summary

- add a visible, keyboard-accessible **Copy code** action beside the pending Codex subscription device code
- copy the exact code through the shared clipboard helper, including its fallback path
- show `Copied` confirmation and a clear manual-copy error when clipboard access fails
- preserve the existing OpenAI auth link and authorization polling behavior

Linear: OPE-192

## Verification

- `bun test apps/web/src/components/codex-connection.test.tsx test/codex-quota-redemption-surface.test.ts` — 3 pass, 0 fail
- `bun run typecheck` — all 25 projects clean
- `bun run lint` — 0 warnings/errors
- `bun run format:check` — clean
- `bun run --cwd apps/web build` — production build, React demo build, precompression, and bundle budgets passed
