### PR TITLE
test(web): classify the agents route scroll owner

### DIFF
--- a/apps/web/src/workspace-route-scroll-contract.test.ts
+++ b/apps/web/src/workspace-route-scroll-contract.test.ts
@@ -8,6 +8,7 @@ type ScrollContract =
 const workspaceRouteContracts = {
   workspaceIndexRoute: { kind: "redirect" },
   workspaceAgentRoute: { kind: "redirect" },
+  workspaceAgentsRoute: { kind: "page", source: "routes/agents.tsx" },
   workspaceSessionsRoute: { kind: "self-managed", source: "routes/sessions-index.tsx" },
   workspaceSessionRoute: { kind: "self-managed", source: "routes/session.tsx" },
   workspaceVariableSetsRoute: { kind: "page", source: "routes/variable-sets.tsx" },


### PR DESCRIPTION
## Summary

- classify `workspaceAgentsRoute` in the fixed-canvas scroll ownership contract
- bind it to `routes/agents.tsx`, which renders the canonical `ContentPage`

## Validation

- `bun test apps/web/src/workspace-route-scroll-contract.test.ts` — 3 pass, 0 fail
- `bunx oxfmt --check apps/web/src/workspace-route-scroll-contract.test.ts` — pass
- `git diff --check` — pass

This repairs the deterministic Unit shard 4 failure already present on protected `main`; it is intentionally separate from PR #1302.
