### PR TITLE
docs: preserve candidates across moving main

### DIFF
--- a/.agents/skills/opengeni/SKILL.md
+++ b/.agents/skills/opengeni/SKILL.md
@@ -136,6 +136,28 @@ Before editing, identify which layer owns the behavior:
 - Scheduling: scheduled task contracts/routes/core domain helpers, Temporal schedule mapping, dispatch activity.
 - UI: `apps/web` API helpers/types/components.
 
+For pull-request delivery, preserve immutable candidates across a moving base:
+
+- Start from current `main`, but do not merge or rebase `main` again merely
+  because it advances while CI or review runs.
+- “Current-main compatible” requires a fresh mergeability/merge-tree and
+  material-overlap check against current `main`; it does not require current
+  `main` to be present in the candidate's ancestry.
+- Base drift alone does not create a new candidate version or invalidate a
+  head-bound review. Refresh base-bound evidence on the same head when a
+  release contract requires it.
+- Change the source head only for a source defect, actual conflict, or material
+  semantic incompatibility. After two substantive repair revisions, stop for an
+  incident/scope review instead of continuing an unbounded repair loop.
+- Watcher and continuation prompts must explicitly say “verify compatibility
+  without source mutation”; never tell a source owner to “reconcile again” for
+  ordinary protected-branch movement.
+
+The executable contract is `.github/workflows/source-admission.yml` plus
+`scripts/check-source-admission.mjs`: immutable stale-event heads remain
+admissible while protected `main` advances. `AGENTS.md` owns the full repository
+delivery invariant.
+
 After edits, run the smallest relevant verification first, then broader checks if behavior crosses boundaries. Common checks are:
 
 ```bash

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,11 @@
 - [ ] `bun run typecheck`
 - [ ] `bun test`
 
+## Delivery integrity
+
+- [ ] Candidate/version labels represent substantive source changes, not base-only refreshes.
+- [ ] If `main` advanced, I kept the candidate head frozen and verified current-base mergeability/material compatibility, or documented the actual conflict/incompatibility that required a source change.
+
 ## Notes
 
 -

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,46 @@ cutover drains and terminates every old session workflow before the new worker
 starts, so no removed activity/signal identifier or replay adapter belongs in
 the new runtime.
 
+## Pull-request delivery across moving `main`
+
+Treat a candidate as an immutable semantic source revision, not as a snapshot of
+the latest protected branch. Create the branch from current `main` initially,
+then keep the exact head frozen while CI, review, and merge admission run.
+
+- A protected-branch advance alone is **not** a source revision, does not
+  invalidate a head-bound review, and must not produce another candidate label.
+  “Current-main compatible” means that the frozen candidate's patch and
+  resulting merge tree have been checked against current `main`; it does not
+  mean that current `main` must be an ancestor of the candidate head.
+- When `main` moves, leave the source branch untouched. Re-run the base-owned
+  Source Admission check when needed, inspect provider mergeability, and have
+  the merge authority prove the fresh latest-main conflict, patch-equivalence,
+  protected-path, migration/generated-file, and targeted compatibility checks.
+  The source admission contract deliberately accepts immutable stale-event
+  heads while protected `main` advances.
+- Mutate the candidate only for a source defect, an actual merge conflict, or a
+  material semantic incompatibility that requires source changes. Record that
+  reason explicitly. A conflict-free merge or rebase performed only to include
+  unrelated `main` commits is prohibited.
+- A structured release-review artifact that explicitly binds a reviewed base
+  may need replacement evidence when that selected base identity changes. That
+  evidence refresh stays on the same candidate head; it is not permission to
+  merge or rebase `main` into the source branch.
+- Watchers and continuation goals must say “verify compatibility without source
+  mutation.” They must never direct a source owner to “reconcile again” merely
+  because `main` advanced. Candidate/version numbers count substantive source
+  changes only.
+- Run independent review as soon as the candidate is ready; CI and review may
+  proceed concurrently, while merge still waits for both. After two substantive
+  repair revisions, pause for an explicit incident/scope review before creating
+  another source revision.
+
+See the executable moving-main admission contract in
+`.github/workflows/source-admission.yml`, `scripts/check-source-admission.mjs`,
+and `scripts/check-source-admission.test.ts`. Do not weaken it by reintroducing
+an exact-current-main ancestry requirement in prompts, goals, documentation, or
+operator procedure.
+
 ## Keeping these notes current
 
 If a change alters architecture, terminology, the run lifecycle, the memory model, or a "do not" guardrail above, update this file, [`docs/architecture.md`](docs/architecture.md), and the relevant `docs/*.md` in the same change. In particular, structural changes (an app/package/sandbox backend added, removed, or renamed; a moved responsibility; a changed invariant, data-flow, or canonical source) belong in `docs/architecture.md` — see its "Keeping this current" section. An out-of-date AGENTS.md or doc is a bug, not a nicety.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,13 @@ bun run test:e2e
 - Include tests for behavior changes.
 - Update README or docs when setup, public API, configuration, or user-facing behavior changes.
 - Do not commit secrets, local `.env` files, generated credentials, or private infrastructure details.
+- Keep a reviewable candidate head frozen while CI and review run. If `main`
+  advances, verify the frozen head's current-base mergeability and material
+  compatibility; do not merge or rebase unrelated `main` commits into the
+  branch solely to make it look current.
+- Treat candidate/version labels as substantive source revisions. Base-only
+  evidence refreshes stay on the same head. Change the head only for a source
+  defect, actual conflict, or material semantic incompatibility.
 
 ## Keeping Docs True
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ This map defines who each doc tier serves and where volatile facts belong.
 | Connected machines | `docs/connected-machines.md` | `README.md`, `AGENTS.md`, client docs and skills should link. |
 | Deployment | `docs/deployment.md` | `README.md`, `AGENTS.md`, Helm/Terraform notes should link. |
 | Release/publishing | `CONTRIBUTING.md` § Release / Publishing, plus workflow files as executable truth | `README.md`, package READMEs, architecture release notes should link. |
+| Pull-request delivery across moving `main` | `AGENTS.md` § Pull-request delivery across moving `main`; executable admission truth in `.github/workflows/source-admission.yml` and `scripts/check-source-admission.mjs` | `.agents/skills/opengeni/SKILL.md`, `CONTRIBUTING.md`, the PR template, and `docs/deployment.md` must preserve the same immutable-candidate distinction. |
 | Client/SDK integration | `packages/sdk/README.md` | `README.md`, `packages/react/README.md`, and customer integration skills should link. |
 | Composer voice input | `docs/transcription.md` | Architecture, SDK/React docs, and host-app guides should link instead of restating provider selection or microphone lifecycle rules. |
 | Workbench embedding & production acceptance | `docs/embedding-workbench.md`, `docs/workbench-acceptance.md` | Host-app guides should link instead of weakening or restating the live evidence contract. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -632,26 +632,31 @@ body continue to bind the exact base/head verdict.
 For a single-maintainer source PR, generate the exact structured review body
 before merging. Submit the result as a native `COMMENTED` pull-request review;
 the formatter can also print the canonical SHA-256 needed by an external
-operator to bind the same artifact:
+operator to bind the same artifact. Use the exact provider-retained PR base SHA
+from the pull-request detail (`pull.base.sha`) as `--base`; this is the
+reviewed-base identity that the release verifier reconstructs, not the latest
+SHA currently at the tip of protected `main`:
 
 ```bash
 bun scripts/release-review.ts \
-  --base <exact-current-main-sha> \
+  --base <exact-provider-retained-pull.base.sha> \
   --head <exact-reviewed-pr-head-sha> \
   --reviewer <trusted-maintainer-login>
 
 bun scripts/release-review.ts \
-  --base <exact-current-main-sha> \
+  --base <exact-provider-retained-pull.base.sha> \
   --head <exact-reviewed-pr-head-sha> \
   --reviewer <trusted-maintainer-login> \
   --digest
 ```
 
-Regenerate the body and verdict when the candidate head or the explicitly
-selected reviewed-base identity changes. If protected `main` advances while the
-candidate stays unchanged, refresh any required base-bound evidence on that
-same head and let the merge authority perform fresh latest-main compatibility
-checks. Do not merge or rebase `main` into the source branch solely to refresh
+Regenerate the body and verdict when the candidate head or its provider-retained
+`pull.base.sha` (the verifier's exact accepted reviewed-base identity) changes.
+An ordinary protected-`main` advance does not itself change that base-bound
+review artifact. Separately, let the merge authority refresh latest-current-main
+mergeability and material-compatibility evidence on the same candidate head;
+that evidence is not `reviewedBaseSha` and does not require replacing the review
+or mutating the candidate. Do not merge or rebase `main` into the source branch solely to refresh
 evidence, and do not edit a submitted review after merge to manufacture
 evidence retroactively.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -608,8 +608,12 @@ review state, reviewed head, and submission time:
   single-maintainer PR whose author, exact-head reviewer, and merge actor are
   that same human; it is never a substitute for approving a bot-authored
   Version PR;
-- any base/head update invalidates the prior verdict, and a review submitted
-  after merge is not release evidence.
+- a candidate-head update invalidates a head-bound verdict. For the structured
+  admin-PASS form, changing the explicitly selected `reviewedBaseSha` also
+  requires replacement evidence on the same candidate head. Ordinary protected
+  `main` movement is not itself a candidate update and must not trigger a source
+  merge/rebase; and
+- a review submitted after merge is not release evidence.
 
 Candidate or operator admission must fail closed when those provider identities
 do not match; do not weaken the provenance check or recreate approval from a
@@ -643,8 +647,13 @@ bun scripts/release-review.ts \
   --digest
 ```
 
-Regenerate the body and verdict after every head or base movement. Do not edit a
-submitted review after merge to manufacture evidence retroactively.
+Regenerate the body and verdict when the candidate head or the explicitly
+selected reviewed-base identity changes. If protected `main` advances while the
+candidate stays unchanged, refresh any required base-bound evidence on that
+same head and let the merge authority perform fresh latest-main compatibility
+checks. Do not merge or rebase `main` into the source branch solely to refresh
+evidence, and do not edit a submitted review after merge to manufacture
+evidence retroactively.
 
 GitHub check lookup is ref-sensitive: a checked head can become undiscoverable
 after its source branch is deleted or rewritten even though the check itself

--- a/scripts/delivery-process-contract.test.ts
+++ b/scripts/delivery-process-contract.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dir, "..");
+
+async function source(path: string): Promise<string> {
+  return readFile(resolve(root, path), "utf8");
+}
+
+describe("pull-request delivery process contract", () => {
+  test("keeps immutable candidates distinct from moving-main compatibility", async () => {
+    const [agents, skill, contributing, pullRequestTemplate, deployment] = await Promise.all([
+      source("AGENTS.md"),
+      source(".agents/skills/opengeni/SKILL.md"),
+      source("CONTRIBUTING.md"),
+      source(".github/pull_request_template.md"),
+      source("docs/deployment.md"),
+    ]);
+
+    expect(agents).toContain("A protected-branch advance alone is **not** a source revision");
+    expect(agents).toMatch(/verify compatibility without source\s+mutation/);
+    expect(skill).toContain("do not merge or rebase `main` again merely");
+    expect(skill).toContain("Base drift alone does not create a new candidate version");
+    expect(contributing).toMatch(/Base-only\s+evidence refreshes stay on the same head/);
+    expect(pullRequestTemplate).toContain(
+      "Candidate/version labels represent substantive source changes, not base-only refreshes",
+    );
+    expect(deployment).toMatch(
+      /Ordinary protected\s+`main` movement is not itself a candidate update/,
+    );
+    expect(deployment).toContain(
+      "Do not merge or rebase `main` into the source branch solely to refresh",
+    );
+    expect(deployment).not.toContain(
+      "Regenerate the body and verdict after every head or base movement",
+    );
+  });
+
+  test("keeps the agent guidance aligned with executable stale-base admission", async () => {
+    const [workflow, verifier, verifierTests] = await Promise.all([
+      source(".github/workflows/source-admission.yml"),
+      source("scripts/check-source-admission.mjs"),
+      source("scripts/check-source-admission.test.ts"),
+    ]);
+
+    expect(workflow).toContain("verify_immutable_pr_head");
+    expect(workflow).toContain("without requiring continuously moving main");
+    expect(verifier).toContain("current main no longer retains the base-owned workflow SHA");
+    expect(verifierTests).toContain(
+      "admits many stale-event heads concurrently while protected main advances",
+    );
+  });
+});

--- a/scripts/delivery-process-contract.test.ts
+++ b/scripts/delivery-process-contract.test.ts
@@ -35,6 +35,13 @@ describe("pull-request delivery process contract", () => {
     expect(deployment).not.toContain(
       "Regenerate the body and verdict after every head or base movement",
     );
+    expect(deployment.match(/--base <exact-provider-retained-pull\.base\.sha>/g)).toHaveLength(2);
+    expect(deployment).toContain("the verifier's exact accepted reviewed-base identity");
+    expect(deployment).toContain(
+      "refresh latest-current-main\nmergeability and material-compatibility evidence",
+    );
+    expect(deployment).toContain("that evidence is not `reviewedBaseSha`");
+    expect(deployment).not.toContain("--base <exact-current-main-sha>");
   });
 
   test("keeps the agent guidance aligned with executable stale-base admission", async () => {


### PR DESCRIPTION
## Summary

- make immutable PR candidates across moving `main` a load-bearing repository-agent invariant
- clarify that base-bound evidence can be refreshed on the same head without merging/rebasing `main`
- align `AGENTS.md`, the OpenGeni repo skill, contributor guidance, PR template, deployment docs, and docs map
- add a regression test tying those entry points to the existing stale-base Source Admission contract

## Root cause

The executable Source Admission path already admits immutable stale-event heads while protected `main` advances, but the agent-facing entry points did not carry that rule. Ambiguous wording such as “current-main branch/PR,” combined with deployment wording about base movement, allowed source owners and watcher goals to reinterpret ordinary base drift as a required new candidate.

The corrected distinction is:

- source revision: candidate content/head changed
- base advance: compatibility evidence changes; candidate remains frozen

## Testing

- [x] `bun run typecheck` — all 25 projects clean
- [x] `bun test scripts/delivery-process-contract.test.ts scripts/check-source-admission.test.ts` — 20 pass
- [x] `bun run check:docs-refs`
- [x] `bun run check:public-hygiene`
- [x] targeted `oxfmt --check`
- [x] `git diff --check`

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] Candidate head is frozen at `ef0893c5`; future protected-main movement will be handled by compatibility admission, not source mutation.
