### PR TITLE
fix(machines): safely detach sessions before removal

### DIFF
--- a/.changeset/safe-machines-detach.md
+++ b/.changeset/safe-machines-detach.md
@@ -6,4 +6,4 @@
 "@opengeni/sdk": patch
 ---
 
-Make connected-machine removal show every dependent session and support an explicit atomic move-to-default-sandbox confirmation before revocation. Surface typed sandbox swap rejections as visible React mutation errors instead of treating resolved failures as success.
+Make connected-machine removal show every dependent session and support an explicit canonical move-to-default-sandbox confirmation before revocation. Default moves prove managed sandbox readiness through the existing fleet route, active turns remain fail-closed, and typed swap rejections surface as visible errors instead of false success.

--- a/.changeset/safe-machines-detach.md
+++ b/.changeset/safe-machines-detach.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/contracts": patch
+"@opengeni/db": patch
+"@opengeni/react": patch
+"@opengeni/sdk": patch
+---
+
+Make connected-machine removal show every dependent session and support an explicit atomic move-to-default-sandbox confirmation before revocation. Surface typed sandbox swap rejections as visible React mutation errors instead of treating resolved failures as success.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -2407,22 +2407,20 @@ function registerConnectedMachineTools(
     "connected_machine_remove",
     {
       description:
-        "Remove one enrolled self-hosted machine while it is offline. Access is revoked, future heartbeat/reconnect credentials are rejected, session/route/lease/archive history is retained, and a fresh human-approved device-flow enrollment is required to reconnect. Pass the enrollmentId from the Machines surface, never a Modal sandbox id. Blocked outcomes include every dependent session and the action needed before retrying. Set moveSessionsToDefaultSandbox only after explicitly reviewing those sessions; the removal then atomically repoints them before revocation.",
+        "Remove one enrolled self-hosted machine while it is offline. Access is revoked, future heartbeat/reconnect credentials are rejected, session/route/lease/archive history is retained, and a fresh human-approved device-flow enrollment is required to reconnect. Pass the enrollmentId from the Machines surface, never a Modal sandbox id. Blocked outcomes include every dependent session and the action needed before retrying. Move each dependent session through the canonical sandbox_swap target=default path before retrying removal; the removal authority never rewrites routes directly.",
       inputSchema: {
         enrollmentId: z4.string().uuid(),
         expectedUpdatedAt: z4.string().datetime({ offset: true }).optional(),
         idempotencyKey: z4.string().trim().min(1).max(200).optional(),
-        moveSessionsToDefaultSandbox: z4.boolean().optional(),
       },
     },
-    async ({ enrollmentId, expectedUpdatedAt, idempotencyKey, moveSessionsToDefaultSandbox }) => {
+    async ({ enrollmentId, expectedUpdatedAt, idempotencyKey }) => {
       const result = await removeEnrollment(deps.db, {
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         enrollmentId,
         operationKey: idempotencyKey?.trim() || randomUUID(),
         ...(expectedUpdatedAt ? { expectedUpdatedAt } : {}),
-        moveSessionsToDefaultSandbox: moveSessionsToDefaultSandbox ?? false,
         subjectId: grant.subjectId,
       });
       if (!result) {

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -2407,20 +2407,22 @@ function registerConnectedMachineTools(
     "connected_machine_remove",
     {
       description:
-        "Remove one enrolled self-hosted machine while it is offline. Access is revoked, future heartbeat/reconnect credentials are rejected, session/route/lease/archive history is retained, and a fresh human-approved device-flow enrollment is required to reconnect. Pass the enrollmentId from the Machines surface, never a Modal sandbox id. Blocked outcomes include the exact active dependency and the action needed before retrying.",
+        "Remove one enrolled self-hosted machine while it is offline. Access is revoked, future heartbeat/reconnect credentials are rejected, session/route/lease/archive history is retained, and a fresh human-approved device-flow enrollment is required to reconnect. Pass the enrollmentId from the Machines surface, never a Modal sandbox id. Blocked outcomes include every dependent session and the action needed before retrying. Set moveSessionsToDefaultSandbox only after explicitly reviewing those sessions; the removal then atomically repoints them before revocation.",
       inputSchema: {
         enrollmentId: z4.string().uuid(),
         expectedUpdatedAt: z4.string().datetime({ offset: true }).optional(),
         idempotencyKey: z4.string().trim().min(1).max(200).optional(),
+        moveSessionsToDefaultSandbox: z4.boolean().optional(),
       },
     },
-    async ({ enrollmentId, expectedUpdatedAt, idempotencyKey }) => {
+    async ({ enrollmentId, expectedUpdatedAt, idempotencyKey, moveSessionsToDefaultSandbox }) => {
       const result = await removeEnrollment(deps.db, {
         accountId: grant.accountId,
         workspaceId: grant.workspaceId,
         enrollmentId,
         operationKey: idempotencyKey?.trim() || randomUUID(),
         ...(expectedUpdatedAt ? { expectedUpdatedAt } : {}),
+        moveSessionsToDefaultSandbox: moveSessionsToDefaultSandbox ?? false,
         subjectId: grant.subjectId,
       });
       if (!result) {

--- a/apps/api/src/routes/enrollments.ts
+++ b/apps/api/src/routes/enrollments.ts
@@ -357,6 +357,7 @@ export function registerEnrollmentRoutes(app: Hono, deps: ApiRouteDeps): void {
         ...(parsed.data.expectedUpdatedAt
           ? { expectedUpdatedAt: parsed.data.expectedUpdatedAt }
           : {}),
+        moveSessionsToDefaultSandbox: parsed.data.moveSessionsToDefaultSandbox ?? false,
         subjectId: grant.subjectId,
       });
       if (!result) {

--- a/apps/api/src/routes/enrollments.ts
+++ b/apps/api/src/routes/enrollments.ts
@@ -357,7 +357,6 @@ export function registerEnrollmentRoutes(app: Hono, deps: ApiRouteDeps): void {
         ...(parsed.data.expectedUpdatedAt
           ? { expectedUpdatedAt: parsed.data.expectedUpdatedAt }
           : {}),
-        moveSessionsToDefaultSandbox: parsed.data.moveSessionsToDefaultSandbox ?? false,
         subjectId: grant.subjectId,
       });
       if (!result) {

--- a/apps/api/test/enrollment-routes.test.ts
+++ b/apps/api/test/enrollment-routes.test.ts
@@ -408,6 +408,7 @@ describe("M5 list + revoke + idempotent re-enroll", () => {
       outcome: "removed",
       enrollmentId: approve.enrollmentId,
       machineName: "node-a",
+      dependentSessions: [],
     });
     expect(revoke.message).toMatch(/history/i);
     expect(revoke.action).toMatch(/fresh human-approved/i);

--- a/apps/web/src/routes/machines-removal.test.tsx
+++ b/apps/web/src/routes/machines-removal.test.tsx
@@ -4,7 +4,7 @@ import type { RemoveEnrollmentResponse } from "@opengeni/sdk";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MachineRemovalBlockNotice, machineRemovalRequest } from "./machines";
+import { MachineRemovalBlockNotice, moveDependentSessionsToDefault } from "./machines";
 
 const blocked: RemoveEnrollmentResponse = {
   revoked: false,
@@ -63,9 +63,70 @@ describe("connected machine removal conflict", () => {
     container.remove();
   });
 
-  test("requires the explicit move flag only after an active-route blocker", () => {
-    expect(machineRemovalRequest(null)).toEqual({});
-    expect(machineRemovalRequest(blocked)).toEqual({ moveSessionsToDefaultSandbox: true });
-    expect(machineRemovalRequest({ ...blocked, code: "active_lease" })).toEqual({});
+  test("moves every dependency through the canonical default-sandbox endpoint", async () => {
+    const calls: Array<{ workspaceId: string; sessionId: string; target: string }> = [];
+    await moveDependentSessionsToDefault(
+      {
+        swapActiveSandbox: async (workspaceId, sessionId, request) => {
+          calls.push({ workspaceId, sessionId, target: request.target });
+          return { swapped: true, activeSandboxId: null, activeEpoch: calls.length };
+        },
+      },
+      "workspace-a",
+      blocked.dependentSessions,
+    );
+    expect(calls).toEqual([
+      {
+        workspaceId: "workspace-a",
+        sessionId: "22222222-2222-4222-8222-222222222222",
+        target: "default",
+      },
+      {
+        workspaceId: "workspace-a",
+        sessionId: "33333333-3333-4333-8333-333333333333",
+        target: "default",
+      },
+    ]);
+  });
+
+  test("stops before removal when a default sandbox is not verified ready", async () => {
+    await expect(
+      moveDependentSessionsToDefault(
+        {
+          swapActiveSandbox: async () => ({
+            swapped: false,
+            activeSandboxId: "44444444-4444-4444-8444-444444444444",
+            activeEpoch: 7,
+            code: "recovery_in_progress",
+            reason: "The managed sandbox is still restoring.",
+          }),
+        },
+        "workspace-a",
+        blocked.dependentSessions,
+      ),
+    ).rejects.toThrow("The managed sandbox is still restoring.");
+  });
+
+  test("renders a machine-home blocker without offering a false managed-home action", async () => {
+    const machineHome = {
+      ...blocked,
+      code: "machine_home" as const,
+      message: "Machine is the durable home sandbox for Capacity planning.",
+      action: "Keep the machine enrolled until a managed-home migration exists.",
+    };
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<MachineRemovalBlockNotice workspaceId="workspace-a" result={machineHome} />);
+    });
+
+    expect(container.textContent).toContain("Not safe yet");
+    expect(container.textContent).toContain("durable home sandbox");
+    expect(container.textContent).toContain("managed-home migration");
+
+    await act(async () => root.unmount());
+    container.remove();
   });
 });

--- a/apps/web/src/routes/machines-removal.test.tsx
+++ b/apps/web/src/routes/machines-removal.test.tsx
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import type { RemoveEnrollmentResponse } from "@opengeni/sdk";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { MachineRemovalBlockNotice, machineRemovalRequest } from "./machines";
+
+const blocked: RemoveEnrollmentResponse = {
+  revoked: false,
+  outcome: "blocked",
+  enrollmentId: "11111111-1111-4111-8111-111111111111",
+  machineName: "Jrgens-MacBook-Pro-2.local",
+  lastSeenAt: "2026-08-04T09:13:46.102Z",
+  revokedAt: null,
+  code: "active_route",
+  message: "Machine is still selected by 2 sessions.",
+  action: "Review the affected sessions, then explicitly move them.",
+  dependentSessions: [
+    {
+      id: "22222222-2222-4222-8222-222222222222",
+      title: "Capacity planning",
+    },
+    {
+      id: "33333333-3333-4333-8333-333333333333",
+      title: null,
+    },
+  ],
+};
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  GlobalRegistrator.unregister();
+});
+
+describe("connected machine removal conflict", () => {
+  test("renders every dependent session inline with direct session links", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<MachineRemovalBlockNotice workspaceId="workspace-a" result={blocked} />);
+    });
+
+    expect(container.textContent).toContain("Sessions still use this machine");
+    expect(container.textContent).toContain("Capacity planning");
+    expect(container.textContent).toContain("33333333-3333-4333-8333-333333333333");
+    expect(
+      Array.from(container.querySelectorAll("a")).map((link) => link.getAttribute("href")),
+    ).toEqual([
+      "/workspaces/workspace-a/sessions/22222222-2222-4222-8222-222222222222",
+      "/workspaces/workspace-a/sessions/33333333-3333-4333-8333-333333333333",
+    ]);
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  test("requires the explicit move flag only after an active-route blocker", () => {
+    expect(machineRemovalRequest(null)).toEqual({});
+    expect(machineRemovalRequest(blocked)).toEqual({ moveSessionsToDefaultSandbox: true });
+    expect(machineRemovalRequest({ ...blocked, code: "active_lease" })).toEqual({});
+  });
+});

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -30,8 +30,8 @@ import { toast } from "sonner";
 
 import {
   OpenGeniApiError,
-  type RemoveEnrollmentRequest,
   type RemoveEnrollmentResponse,
+  type SwapActiveSandboxResponse,
 } from "@opengeni/sdk";
 
 import { apiBaseUrl } from "@/api";
@@ -65,11 +65,13 @@ async function copyToClipboard(text: string, successMessage: string) {
 }
 
 export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
+  const { client } = useAppContext();
   const machines = useMachines({ pollIntervalMs: 5000 });
   const pageLive = usePageLiveActivity();
   const [enrollOpen, setEnrollOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<MachineView | null>(null);
   const [removeBlocked, setRemoveBlocked] = useState<RemoveEnrollmentResponse | null>(null);
+  const [removeMoveError, setRemoveMoveError] = useState<Error | null>(null);
 
   // The machine whose telemetry detail is open (by sandboxId), and its history.
   const [detailId, setDetailId] = useState<string | null>(null);
@@ -229,6 +231,7 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
                   onRemove: (machine: MachineView) => {
                     machines.clearMutationError();
                     setRemoveBlocked(null);
+                    setRemoveMoveError(null);
                     setRemoveTarget(machine);
                   },
                 }
@@ -278,6 +281,7 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
           if (!open) {
             setRemoveTarget(null);
             setRemoveBlocked(null);
+            setRemoveMoveError(null);
             machines.clearMutationError();
           }
         }}
@@ -291,10 +295,20 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
         onConfirm={async () => {
           const target = removeTarget;
           if (!target?.enrollmentId) return false;
-          const result = await machines.remove(
-            target.enrollmentId,
-            machineRemovalRequest(removeBlocked),
-          );
+          const sessionsToMove =
+            removeBlocked?.code === "active_route" ? removeBlocked.dependentSessions : [];
+          if (sessionsToMove.length > 0) {
+            try {
+              setRemoveMoveError(null);
+              await moveDependentSessionsToDefault(client, workspaceId, sessionsToMove);
+            } catch (error) {
+              setRemoveMoveError(
+                error instanceof Error ? error : new Error("A session could not be moved."),
+              );
+              return false;
+            }
+          }
+          const result = await machines.remove(target.enrollmentId);
           if (!result) {
             return false;
           }
@@ -308,13 +322,15 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
               : `${target.name} removed`,
             {
               description:
-                result.dependentSessions.length > 0
-                  ? `${result.dependentSessions.length} ${result.dependentSessions.length === 1 ? "session now uses its" : "sessions now use their"} default managed sandbox.`
+                sessionsToMove.length > 0
+                  ? `${sessionsToMove.length} ${sessionsToMove.length === 1 ? "session now uses its" : "sessions now use their"} verified default managed sandbox.`
                   : "It will disappear from the active machine list.",
             },
           );
           setRemoveTarget(null);
           setDetailId(null);
+          setRemoveBlocked(null);
+          setRemoveMoveError(null);
           return true;
         }}
       >
@@ -331,6 +347,11 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
                   : "Never connected"}
               </p>
             </div>
+            {removeMoveError ? (
+              <Notice tone="failed" title="Couldn't move every session">
+                {removeMoveError.message}
+              </Notice>
+            ) : null}
             {removeBlocked ? (
               <MachineRemovalBlockNotice workspaceId={workspaceId} result={removeBlocked} />
             ) : machines.mutationError ? (
@@ -345,10 +366,31 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
   );
 }
 
-export function machineRemovalRequest(
-  blocked: RemoveEnrollmentResponse | null,
-): RemoveEnrollmentRequest {
-  return blocked?.code === "active_route" ? { moveSessionsToDefaultSandbox: true } : {};
+type DefaultSandboxClient = {
+  swapActiveSandbox: (
+    workspaceId: string,
+    sessionId: string,
+    request: { target: string },
+  ) => Promise<SwapActiveSandboxResponse>;
+};
+
+export async function moveDependentSessionsToDefault(
+  client: DefaultSandboxClient,
+  workspaceId: string,
+  sessions: Array<{ id: string; title: string | null }>,
+): Promise<void> {
+  for (const session of sessions) {
+    const result = await client.swapActiveSandbox(workspaceId, session.id, {
+      target: "default",
+    });
+    if (!result.swapped) {
+      const sessionName = session.title?.trim() || session.id;
+      throw new Error(
+        result.reason?.trim() ||
+          `Session ${sessionName} could not reach a verified default managed sandbox${result.code ? ` (${result.code})` : ""}.`,
+      );
+    }
+  }
 }
 
 export function MachineRemovalBlockNotice({

--- a/apps/web/src/routes/machines.tsx
+++ b/apps/web/src/routes/machines.tsx
@@ -28,7 +28,11 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { OpenGeniApiError } from "@opengeni/sdk";
+import {
+  OpenGeniApiError,
+  type RemoveEnrollmentRequest,
+  type RemoveEnrollmentResponse,
+} from "@opengeni/sdk";
 
 import { apiBaseUrl } from "@/api";
 import { PageHeader } from "@/components/common";
@@ -65,6 +69,7 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
   const pageLive = usePageLiveActivity();
   const [enrollOpen, setEnrollOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<MachineView | null>(null);
+  const [removeBlocked, setRemoveBlocked] = useState<RemoveEnrollmentResponse | null>(null);
 
   // The machine whose telemetry detail is open (by sandboxId), and its history.
   const [detailId, setDetailId] = useState<string | null>(null);
@@ -220,7 +225,13 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
             loadingSeries={detailLoading}
             onBack={() => setDetailId(null)}
             {...(machines.canRemove
-              ? { onRemove: (machine: MachineView) => setRemoveTarget(machine) }
+              ? {
+                  onRemove: (machine: MachineView) => {
+                    machines.clearMutationError();
+                    setRemoveBlocked(null);
+                    setRemoveTarget(machine);
+                  },
+                }
               : {})}
             now={now}
           />
@@ -264,30 +275,43 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
       <ConfirmDialog
         open={removeTarget !== null}
         onOpenChange={(open) => {
-          if (!open) setRemoveTarget(null);
+          if (!open) {
+            setRemoveTarget(null);
+            setRemoveBlocked(null);
+            machines.clearMutationError();
+          }
         }}
         title={removeTarget ? `Remove machine “${removeTarget.name}”?` : "Remove machine?"}
         description="Access will be revoked immediately while the machine is offline. Its session, route, lease, archive, and audit history will be kept; reconnecting later requires a fresh human-approved enrollment."
-        confirmLabel="Remove machine"
+        confirmLabel={
+          removeBlocked?.code === "active_route"
+            ? "Move sessions and remove machine"
+            : "Remove machine"
+        }
         onConfirm={async () => {
           const target = removeTarget;
           if (!target?.enrollmentId) return false;
-          const result = await machines.remove(target.enrollmentId);
+          const result = await machines.remove(
+            target.enrollmentId,
+            machineRemovalRequest(removeBlocked),
+          );
           if (!result) {
-            toast.error("Machine removal is unavailable", {
-              description: "Refresh the page and try again.",
-            });
             return false;
           }
           if (result.outcome === "blocked") {
-            toast.error(result.message, { description: result.action });
+            setRemoveBlocked(result);
             return false;
           }
           toast.success(
             result.outcome === "already_removed"
               ? `${target.name} was already removed`
               : `${target.name} removed`,
-            { description: "It will disappear from the active machine list." },
+            {
+              description:
+                result.dependentSessions.length > 0
+                  ? `${result.dependentSessions.length} ${result.dependentSessions.length === 1 ? "session now uses its" : "sessions now use their"} default managed sandbox.`
+                  : "It will disappear from the active machine list.",
+            },
           );
           setRemoveTarget(null);
           setDetailId(null);
@@ -295,20 +319,67 @@ export function MachinesRoute({ workspaceId }: { workspaceId: string }) {
         }}
       >
         {removeTarget ? (
-          <div className="space-y-2 rounded-og-md border border-og-border bg-og-surface-2/40 px-3 py-2 text-og-sm text-og-fg-muted">
-            <p>
-              <span className="font-medium text-og-fg">Machine:</span> {removeTarget.name}
-            </p>
-            <p>
-              <span className="font-medium text-og-fg">Last seen:</span>{" "}
-              {removeTarget.lastSeenAt
-                ? new Date(removeTarget.lastSeenAt).toLocaleString()
-                : "Never connected"}
-            </p>
+          <div className="space-y-3">
+            <div className="space-y-2 rounded-og-md border border-og-border bg-og-surface-2/40 px-3 py-2 text-og-sm text-og-fg-muted">
+              <p>
+                <span className="font-medium text-og-fg">Machine:</span> {removeTarget.name}
+              </p>
+              <p>
+                <span className="font-medium text-og-fg">Last seen:</span>{" "}
+                {removeTarget.lastSeenAt
+                  ? new Date(removeTarget.lastSeenAt).toLocaleString()
+                  : "Never connected"}
+              </p>
+            </div>
+            {removeBlocked ? (
+              <MachineRemovalBlockNotice workspaceId={workspaceId} result={removeBlocked} />
+            ) : machines.mutationError ? (
+              <Notice tone="failed" title="Removal failed">
+                {machines.mutationError.message}
+              </Notice>
+            ) : null}
           </div>
         ) : null}
       </ConfirmDialog>
     </ContentPage>
+  );
+}
+
+export function machineRemovalRequest(
+  blocked: RemoveEnrollmentResponse | null,
+): RemoveEnrollmentRequest {
+  return blocked?.code === "active_route" ? { moveSessionsToDefaultSandbox: true } : {};
+}
+
+export function MachineRemovalBlockNotice({
+  workspaceId,
+  result,
+}: {
+  workspaceId: string;
+  result: RemoveEnrollmentResponse;
+}) {
+  return (
+    <Notice
+      tone="waiting"
+      title={result.code === "active_route" ? "Sessions still use this machine" : "Not safe yet"}
+    >
+      <p>{result.message}</p>
+      {result.dependentSessions.length > 0 ? (
+        <ul className="mt-2 space-y-1">
+          {result.dependentSessions.map((session) => (
+            <li key={session.id}>
+              <a
+                href={`/workspaces/${workspaceId}/sessions/${session.id}`}
+                className="font-medium text-fg underline decoration-border-strong underline-offset-2 hover:text-brand"
+              >
+                {session.title?.trim() || session.id}
+              </a>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <p className="mt-2">{result.action}</p>
+    </Notice>
   );
 }
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10298,7 +10298,14 @@ export const RevokeEnrollmentResponse = z.object({
   lastSeenAt: z.string().datetime({ offset: true }).nullable(),
   revokedAt: z.string().datetime({ offset: true }).nullable(),
   code: z
-    .enum(["active_route", "active_commands", "active_lease", "recovery_pending", "not_selfhosted"])
+    .enum([
+      "active_route",
+      "active_commands",
+      "machine_home",
+      "active_lease",
+      "recovery_pending",
+      "not_selfhosted",
+    ])
     .nullable(),
   message: z.string(),
   action: z.string(),
@@ -10315,7 +10322,6 @@ export type RevokeEnrollmentResponse = z.infer<typeof RevokeEnrollmentResponse>;
 export const RemoveEnrollmentRequest = z.object({
   expectedUpdatedAt: z.string().datetime({ offset: true }).optional(),
   idempotencyKey: z.string().trim().min(1).max(200).optional(),
-  moveSessionsToDefaultSandbox: z.boolean().optional(),
 });
 export type RemoveEnrollmentRequest = z.infer<typeof RemoveEnrollmentRequest>;
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10302,6 +10302,12 @@ export const RevokeEnrollmentResponse = z.object({
     .nullable(),
   message: z.string(),
   action: z.string(),
+  dependentSessions: z.array(
+    z.object({
+      id: z.string().uuid(),
+      title: z.string().nullable(),
+    }),
+  ),
 });
 export type RevokeEnrollmentResponse = z.infer<typeof RevokeEnrollmentResponse>;
 
@@ -10309,6 +10315,7 @@ export type RevokeEnrollmentResponse = z.infer<typeof RevokeEnrollmentResponse>;
 export const RemoveEnrollmentRequest = z.object({
   expectedUpdatedAt: z.string().datetime({ offset: true }).optional(),
   idempotencyKey: z.string().trim().min(1).max(200).optional(),
+  moveSessionsToDefaultSandbox: z.boolean().optional(),
 });
 export type RemoveEnrollmentRequest = z.infer<typeof RemoveEnrollmentRequest>;
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -37097,6 +37097,7 @@ export type MachineRemovalResult = {
   code: MachineRemovalBlockCode | null;
   message: string;
   action: string;
+  dependentSessions: Array<{ id: string; title: string | null }>;
 };
 
 export class MachineRemovalIdempotencyError extends Error {
@@ -37114,12 +37115,17 @@ export class MachineRemovalRevisionConflictError extends Error {
   }
 }
 
-function machineRemovalFingerprint(enrollmentId: string, expectedUpdatedAt?: string): string {
+function machineRemovalFingerprint(
+  enrollmentId: string,
+  expectedUpdatedAt?: string,
+  moveSessionsToDefaultSandbox = false,
+): string {
   return createHash("sha256")
     .update(
       JSON.stringify({
         enrollmentId,
         expectedUpdatedAt: expectedUpdatedAt ?? null,
+        moveSessionsToDefaultSandbox,
       }),
     )
     .digest("hex");
@@ -37130,6 +37136,7 @@ function machineRemovalResultFromStored(value: unknown): MachineRemovalResult {
     throw new Error("Invalid stored machine removal result");
   }
   const result = value as Partial<MachineRemovalResult>;
+  const dependentSessions = result.dependentSessions ?? [];
   if (
     typeof result.enrollmentId !== "string" ||
     (result.outcome !== "removed" &&
@@ -37146,11 +37153,19 @@ function machineRemovalResultFromStored(value: unknown): MachineRemovalResult {
       result.code !== "recovery_pending" &&
       result.code !== "not_selfhosted") ||
     typeof result.message !== "string" ||
-    typeof result.action !== "string"
+    typeof result.action !== "string" ||
+    !Array.isArray(dependentSessions) ||
+    dependentSessions.some(
+      (session) =>
+        !session ||
+        typeof session !== "object" ||
+        typeof session.id !== "string" ||
+        (session.title !== null && typeof session.title !== "string"),
+    )
   ) {
     throw new Error("Invalid stored machine removal result");
   }
-  return result as MachineRemovalResult;
+  return { ...(result as MachineRemovalResult), dependentSessions };
 }
 
 /**
@@ -37173,6 +37188,7 @@ export async function removeEnrollment(
     enrollmentId: string;
     operationKey: string;
     expectedUpdatedAt?: string;
+    moveSessionsToDefaultSandbox?: boolean;
     subjectId?: string | null;
   },
 ): Promise<MachineRemovalResult | null> {
@@ -37180,7 +37196,11 @@ export async function removeEnrollment(
   if (operationKey.length === 0 || operationKey.length > 200) {
     throw new Error("machine removal operation key must be 1-200 characters");
   }
-  const requestFingerprint = machineRemovalFingerprint(input.enrollmentId, input.expectedUpdatedAt);
+  const requestFingerprint = machineRemovalFingerprint(
+    input.enrollmentId,
+    input.expectedUpdatedAt,
+    input.moveSessionsToDefaultSandbox ?? false,
+  );
   return await withRlsContext(
     db,
     { accountId: input.accountId, workspaceId: input.workspaceId },
@@ -37261,11 +37281,13 @@ export async function removeEnrollment(
         .for("share");
       const nonSelfhosted = sandboxes.find((sandbox) => sandbox.kind !== "selfhosted");
       const machine = sandboxes.find((sandbox) => sandbox.kind === "selfhosted") ?? null;
+      const dependentSessions: Array<{ id: string; title: string | null }> = [];
       const baseResult = {
         enrollmentId: enrollment.id,
         machineName: machine?.name ?? null,
         lastSeenAt: enrollment.lastSeenAt?.toISOString() ?? null,
         revokedAt: enrollment.revokedAt?.toISOString() ?? null,
+        dependentSessions,
       };
 
       if (nonSelfhosted) {
@@ -37330,7 +37352,7 @@ export async function removeEnrollment(
       }
 
       if (machine) {
-        const [activePointer] = await scopedDb.execute<{
+        const activePointers = await scopedDb.execute<{
           session_id: string;
           title: string | null;
         }>(sql`
@@ -37339,42 +37361,14 @@ export async function removeEnrollment(
           where workspace_id = ${input.workspaceId}
             and active_sandbox_id = ${machine.id}
           order by created_at asc, id asc
-          limit 1
           for update
         `);
-        if (activePointer) {
-          const result: MachineRemovalResult = {
-            ...baseResult,
-            outcome: "blocked",
-            removed: false,
-            code: "active_route",
-            message: `Machine is still selected by session ${activePointer.title?.trim() || activePointer.session_id}.`,
-            action: "Move that session back to its managed sandbox, then retry removal.",
-          };
-          await scopedDb.insert(schema.machineRemovalOperations).values({
-            accountId: input.accountId,
-            workspaceId: input.workspaceId,
-            enrollmentId: enrollment.id,
-            operationKey,
-            requestFingerprint,
-            outcome: result.outcome,
-            result,
-          });
-          await scopedDb.insert(schema.auditEvents).values({
-            accountId: input.accountId,
-            workspaceId: input.workspaceId,
-            subjectId: input.subjectId ?? null,
-            action: "connected_machine.removal_blocked",
-            targetType: "enrollment",
-            targetId: enrollment.id,
-            metadata: {
-              code: result.code,
-              sessionId: activePointer.session_id,
-              message: result.message,
-            },
-          });
-          return result;
-        }
+        dependentSessions.push(
+          ...activePointers.map((pointer: { session_id: string; title: string | null }) => ({
+            id: pointer.session_id,
+            title: pointer.title?.trim() || null,
+          })),
+        );
 
         const [activeGroup] = await scopedDb.execute<{
           session_id: string;
@@ -37493,6 +37487,57 @@ export async function removeEnrollment(
           });
           return result;
         }
+
+        if (dependentSessions.length > 0 && !input.moveSessionsToDefaultSandbox) {
+          const count = dependentSessions.length;
+          const result: MachineRemovalResult = {
+            ...baseResult,
+            outcome: "blocked",
+            removed: false,
+            code: "active_route",
+            message: `Machine is still selected by ${count} ${count === 1 ? "session" : "sessions"}.`,
+            action:
+              "Review the affected sessions, then explicitly move them to their default managed sandbox and remove the machine.",
+          };
+          await scopedDb.insert(schema.machineRemovalOperations).values({
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            enrollmentId: enrollment.id,
+            operationKey,
+            requestFingerprint,
+            outcome: result.outcome,
+            result,
+          });
+          await scopedDb.insert(schema.auditEvents).values({
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            subjectId: input.subjectId ?? null,
+            action: "connected_machine.removal_blocked",
+            targetType: "enrollment",
+            targetId: enrollment.id,
+            metadata: {
+              code: result.code,
+              sessionIds: dependentSessions.map((session) => session.id),
+              message: result.message,
+            },
+          });
+          return result;
+        }
+
+        if (dependentSessions.length > 0) {
+          const moved = await scopedDb.execute<{ id: string }>(sql`
+            update sessions
+            set active_sandbox_id = null,
+                active_epoch = active_epoch + 1,
+                updated_at = now()
+            where workspace_id = ${input.workspaceId}
+              and active_sandbox_id = ${machine.id}
+            returning id
+          `);
+          if (moved.length !== dependentSessions.length) {
+            throw new Error("dependent session routes changed while the removal lock was held");
+          }
+        }
       }
 
       const now = new Date();
@@ -37516,7 +37561,10 @@ export async function removeEnrollment(
         removed: true,
         revokedAt: now.toISOString(),
         code: null,
-        message: "Machine access was revoked. History was retained for audit.",
+        message:
+          dependentSessions.length > 0
+            ? `Moved ${dependentSessions.length} ${dependentSessions.length === 1 ? "session" : "sessions"} to their default managed sandbox and revoked machine access. History was retained for audit.`
+            : "Machine access was revoked. History was retained for audit.",
         action: "A fresh human-approved device-flow enrollment is required to reconnect.",
       };
       await scopedDb.insert(schema.machineRemovalOperations).values({
@@ -37539,6 +37587,7 @@ export async function removeEnrollment(
           machineName: result.machineName,
           lastSeenAt: result.lastSeenAt,
           credentialGeneration: Number(updated.credentialGeneration),
+          movedSessionIds: dependentSessions.map((session) => session.id),
         },
       });
       return result;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1857,7 +1857,10 @@ export type TemporalScheduleCleanupClaim = {
 };
 
 export type DeleteWorkspaceIfQuiescentResult =
-  | { status: "deleted"; temporalScheduleCleanups: TemporalScheduleCleanupClaim[] }
+  | {
+      status: "deleted";
+      temporalScheduleCleanups: TemporalScheduleCleanupClaim[];
+    }
   | {
       status: "not_found" | "only_workspace" | "active_sessions" | "live_sandboxes";
     };
@@ -2020,7 +2023,9 @@ export async function deleteWorkspaceIfQuiescent(
           }
 
           const schedules = await tx
-            .select({ temporalScheduleId: schema.scheduledTasks.temporalScheduleId })
+            .select({
+              temporalScheduleId: schema.scheduledTasks.temporalScheduleId,
+            })
             .from(schema.scheduledTasks)
             .where(eq(schema.scheduledTasks.workspaceId, input.workspaceId))
             .for("update", { noWait: true });
@@ -4097,7 +4102,11 @@ export async function prepareEditableArtifactSourceFile(
           .limit(1);
         if (existing) {
           assertEditableArtifactSourceFileMatches(existing.file, existing.upload, input);
-          return { file: mapFile(existing.file), uploadId: existing.upload.id, created: false };
+          return {
+            file: mapFile(existing.file),
+            uploadId: existing.upload.id,
+            created: false,
+          };
         }
 
         const [file] = await tx
@@ -4222,7 +4231,9 @@ export function durableUserHistoryItem(
     content: renderTimelineAnnotationsForModel(prompt, annotations),
     ...(attachmentRefs.length > 0 ? { [MODEL_ATTACHMENT_REFS_FIELD]: attachmentRefs } : {}),
     ...(annotations.length > 0
-      ? { [MODEL_TIMELINE_ANNOTATIONS_FIELD]: TimelineAnnotations.parse(annotations) }
+      ? {
+          [MODEL_TIMELINE_ANNOTATIONS_FIELD]: TimelineAnnotations.parse(annotations),
+        }
       : {}),
   };
 }
@@ -4362,11 +4373,19 @@ export async function prepareRetainedScreenshotArtifact(
       await scopedDb.transaction(async (tx) => {
         await tx
           .insert(schema.workspaceScreenshotQuotas)
-          .values({ accountId: input.accountId, workspaceId: input.workspaceId })
-          .onConflictDoNothing({ target: schema.workspaceScreenshotQuotas.workspaceId });
+          .values({
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+          })
+          .onConflictDoNothing({
+            target: schema.workspaceScreenshotQuotas.workspaceId,
+          });
 
         const [existing] = await tx
-          .select({ artifact: schema.retainedScreenshotArtifacts, file: schema.files })
+          .select({
+            artifact: schema.retainedScreenshotArtifacts,
+            file: schema.files,
+          })
           .from(schema.retainedScreenshotArtifacts)
           .innerJoin(
             schema.files,
@@ -4612,7 +4631,10 @@ export async function getRetainedScreenshotArtifact(
 ): Promise<RetainedScreenshotArtifact | null> {
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     const [row] = await scopedDb
-      .select({ artifact: schema.retainedScreenshotArtifacts, file: schema.files })
+      .select({
+        artifact: schema.retainedScreenshotArtifacts,
+        file: schema.files,
+      })
       .from(schema.retainedScreenshotArtifacts)
       .innerJoin(
         schema.files,
@@ -4730,7 +4752,9 @@ export async function promoteRetainedScreenshotMaintenanceCleanup(
             eq(schema.retainedScreenshotArtifacts.maintenanceClaimId, input.claimId),
           ),
         )
-        .returning({ artifactId: schema.retainedScreenshotArtifacts.artifactId });
+        .returning({
+          artifactId: schema.retainedScreenshotArtifacts.artifactId,
+        });
       return updated !== undefined;
     },
   );
@@ -4941,7 +4965,10 @@ async function getRetainedScreenshotArtifactByWorkspace(
 ): Promise<RetainedScreenshotArtifact | null> {
   return await withRlsContext(db, { accountId, workspaceId }, async (scopedDb) => {
     const [row] = await scopedDb
-      .select({ artifact: schema.retainedScreenshotArtifacts, file: schema.files })
+      .select({
+        artifact: schema.retainedScreenshotArtifacts,
+        file: schema.files,
+      })
       .from(schema.retainedScreenshotArtifacts)
       .innerJoin(schema.files, eq(schema.files.id, schema.retainedScreenshotArtifacts.artifactId))
       .where(
@@ -12580,7 +12607,10 @@ export async function getRigVersionById(
 
 export type RigProviderImageBuildClaim =
   | { status: "claimed"; image: RigProviderImage }
-  | { status: "ready" | "in_progress" | "unsupported" | "conflict"; image: RigProviderImage };
+  | {
+      status: "ready" | "in_progress" | "unsupported" | "conflict";
+      image: RigProviderImage;
+    };
 
 async function retainRigProviderImageArtifacts(
   db: Database,
@@ -34013,7 +34043,10 @@ export async function acquireSandboxLeaseReaperHold(
       await scopedDb.transaction(async (txRaw) => {
         const tx = txRaw as unknown as Database;
         const rows = await tx.execute<
-          LeaseRow & { reaper_hold_active: boolean; provider_hold_safe: boolean }
+          LeaseRow & {
+            reaper_hold_active: boolean;
+            provider_hold_safe: boolean;
+          }
         >(sql`
           select lease.*,
             (lease.reaper_hold_id is not null and lease.reaper_hold_until > now())
@@ -34049,16 +34082,28 @@ export async function acquireSandboxLeaseReaperHold(
           return { status: "held_by_other" as const, lease: mapLeaseRow(row) };
         }
         if (renewing && row.reaper_hold_reason !== reason) {
-          return { status: "reason_conflict" as const, lease: mapLeaseRow(row) };
+          return {
+            status: "reason_conflict" as const,
+            lease: mapLeaseRow(row),
+          };
         }
         if (row.archive_capture_id !== null || row.rotation_reason === "teardown_claim") {
-          return { status: "teardown_in_progress" as const, lease: mapLeaseRow(row) };
+          return {
+            status: "teardown_in_progress" as const,
+            lease: mapLeaseRow(row),
+          };
         }
         if (row.rotation_requested_at !== null) {
-          return { status: "rotation_in_progress" as const, lease: mapLeaseRow(row) };
+          return {
+            status: "rotation_in_progress" as const,
+            lease: mapLeaseRow(row),
+          };
         }
         if (!row.provider_hold_safe) {
-          return { status: "provider_deadline_conflict" as const, lease: mapLeaseRow(row) };
+          return {
+            status: "provider_deadline_conflict" as const,
+            lease: mapLeaseRow(row),
+          };
         }
         const held = await tx.execute<LeaseRow>(sql`
           update sandbox_leases set
@@ -34076,7 +34121,11 @@ export async function acquireSandboxLeaseReaperHold(
         if (!lease) {
           return { status: "lease_fenced" as const, lease: mapLeaseRow(row) };
         }
-        return { status: "held" as const, renewed: renewing, lease: mapLeaseRow(lease) };
+        return {
+          status: "held" as const,
+          renewed: renewing,
+          lease: mapLeaseRow(lease),
+        };
       }),
   );
 }
@@ -37355,8 +37404,9 @@ export async function removeEnrollment(
         const activePointers = await scopedDb.execute<{
           session_id: string;
           title: string | null;
+          active_turn_id: string | null;
         }>(sql`
-          select id as session_id, title
+          select id as session_id, title, active_turn_id
           from sessions
           where workspace_id = ${input.workspaceId}
             and active_sandbox_id = ${machine.id}
@@ -37369,6 +37419,44 @@ export async function removeEnrollment(
             title: pointer.title?.trim() || null,
           })),
         );
+
+        const activePointerTurn = activePointers.find(
+          (pointer: { active_turn_id: string | null }) => pointer.active_turn_id !== null,
+        );
+        if (activePointerTurn) {
+          const result: MachineRemovalResult = {
+            ...baseResult,
+            outcome: "blocked",
+            removed: false,
+            code: "active_commands",
+            message: `Machine is selected by session ${activePointerTurn.title?.trim() || activePointerTurn.session_id} while it has an active turn.`,
+            action: "Wait for or stop the active turn, then retry removal.",
+          };
+          await scopedDb.insert(schema.machineRemovalOperations).values({
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            enrollmentId: enrollment.id,
+            operationKey,
+            requestFingerprint,
+            outcome: result.outcome,
+            result,
+          });
+          await scopedDb.insert(schema.auditEvents).values({
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            subjectId: input.subjectId ?? null,
+            action: "connected_machine.removal_blocked",
+            targetType: "enrollment",
+            targetId: enrollment.id,
+            metadata: {
+              code: result.code,
+              sessionId: activePointerTurn.session_id,
+              turnId: activePointerTurn.active_turn_id,
+              message: result.message,
+            },
+          });
+          return result;
+        }
 
         const [activeGroup] = await scopedDb.execute<{
           session_id: string;
@@ -44516,7 +44604,10 @@ export async function settleSessionAttemptInterruptions(
                       turnGeneration: turn.executionGeneration,
                       turnAttemptId: attemptId,
                       turnAssociation: null,
-                      payload: { status: "idle", reason: "paused_recovery_settled" },
+                      payload: {
+                        status: "idle",
+                        reason: "paused_recovery_settled",
+                      },
                       clientEventId: `opengeni:paused-recovery-settled:${attemptId}`,
                       occurredAt: now,
                     },

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -37083,6 +37083,7 @@ export type MachineRemovalOutcome = (typeof schema.machineRemovalOperationOutcom
 export type MachineRemovalBlockCode =
   | "active_route"
   | "active_commands"
+  | "machine_home"
   | "active_lease"
   | "recovery_pending"
   | "not_selfhosted";
@@ -37115,17 +37116,12 @@ export class MachineRemovalRevisionConflictError extends Error {
   }
 }
 
-function machineRemovalFingerprint(
-  enrollmentId: string,
-  expectedUpdatedAt?: string,
-  moveSessionsToDefaultSandbox = false,
-): string {
+function machineRemovalFingerprint(enrollmentId: string, expectedUpdatedAt?: string): string {
   return createHash("sha256")
     .update(
       JSON.stringify({
         enrollmentId,
         expectedUpdatedAt: expectedUpdatedAt ?? null,
-        moveSessionsToDefaultSandbox,
       }),
     )
     .digest("hex");
@@ -37149,6 +37145,7 @@ function machineRemovalResultFromStored(value: unknown): MachineRemovalResult {
     (result.code !== null &&
       result.code !== "active_route" &&
       result.code !== "active_commands" &&
+      result.code !== "machine_home" &&
       result.code !== "active_lease" &&
       result.code !== "recovery_pending" &&
       result.code !== "not_selfhosted") ||
@@ -37188,7 +37185,6 @@ export async function removeEnrollment(
     enrollmentId: string;
     operationKey: string;
     expectedUpdatedAt?: string;
-    moveSessionsToDefaultSandbox?: boolean;
     subjectId?: string | null;
   },
 ): Promise<MachineRemovalResult | null> {
@@ -37196,11 +37192,7 @@ export async function removeEnrollment(
   if (operationKey.length === 0 || operationKey.length > 200) {
     throw new Error("machine removal operation key must be 1-200 characters");
   }
-  const requestFingerprint = machineRemovalFingerprint(
-    input.enrollmentId,
-    input.expectedUpdatedAt,
-    input.moveSessionsToDefaultSandbox ?? false,
-  );
+  const requestFingerprint = machineRemovalFingerprint(input.enrollmentId, input.expectedUpdatedAt);
   return await withRlsContext(
     db,
     { accountId: input.accountId, workspaceId: input.workspaceId },
@@ -37356,8 +37348,9 @@ export async function removeEnrollment(
           session_id: string;
           title: string | null;
           active_turn_id: string | null;
+          sandbox_backend: string;
         }>(sql`
-          select id as session_id, title, active_turn_id
+          select id as session_id, title, active_turn_id, sandbox_backend
           from sessions
           where workspace_id = ${input.workspaceId}
             and active_sandbox_id = ${machine.id}
@@ -37403,6 +37396,44 @@ export async function removeEnrollment(
               code: result.code,
               sessionId: activePointerTurn.session_id,
               turnId: activePointerTurn.active_turn_id,
+              message: result.message,
+            },
+          });
+          return result;
+        }
+
+        const machineHome = activePointers.find(
+          (pointer: { sandbox_backend: string }) => pointer.sandbox_backend === "selfhosted",
+        );
+        if (machineHome) {
+          const result: MachineRemovalResult = {
+            ...baseResult,
+            outcome: "blocked",
+            removed: false,
+            code: "machine_home",
+            message: `Machine is the durable home sandbox for session ${machineHome.title?.trim() || machineHome.session_id}.`,
+            action:
+              "Keep the machine enrolled until that session has a supported managed-home migration or is no longer needed.",
+          };
+          await scopedDb.insert(schema.machineRemovalOperations).values({
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            enrollmentId: enrollment.id,
+            operationKey,
+            requestFingerprint,
+            outcome: result.outcome,
+            result,
+          });
+          await scopedDb.insert(schema.auditEvents).values({
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            subjectId: input.subjectId ?? null,
+            action: "connected_machine.removal_blocked",
+            targetType: "enrollment",
+            targetId: enrollment.id,
+            metadata: {
+              code: result.code,
+              sessionId: machineHome.session_id,
               message: result.message,
             },
           });
@@ -37527,7 +37558,7 @@ export async function removeEnrollment(
           return result;
         }
 
-        if (dependentSessions.length > 0 && !input.moveSessionsToDefaultSandbox) {
+        if (dependentSessions.length > 0) {
           const count = dependentSessions.length;
           const result: MachineRemovalResult = {
             ...baseResult,
@@ -37562,21 +37593,6 @@ export async function removeEnrollment(
           });
           return result;
         }
-
-        if (dependentSessions.length > 0) {
-          const moved = await scopedDb.execute<{ id: string }>(sql`
-            update sessions
-            set active_sandbox_id = null,
-                active_epoch = active_epoch + 1,
-                updated_at = now()
-            where workspace_id = ${input.workspaceId}
-              and active_sandbox_id = ${machine.id}
-            returning id
-          `);
-          if (moved.length !== dependentSessions.length) {
-            throw new Error("dependent session routes changed while the removal lock was held");
-          }
-        }
       }
 
       const now = new Date();
@@ -37600,10 +37616,7 @@ export async function removeEnrollment(
         removed: true,
         revokedAt: now.toISOString(),
         code: null,
-        message:
-          dependentSessions.length > 0
-            ? `Moved ${dependentSessions.length} ${dependentSessions.length === 1 ? "session" : "sessions"} to their default managed sandbox and revoked machine access. History was retained for audit.`
-            : "Machine access was revoked. History was retained for audit.",
+        message: "Machine access was revoked. History was retained for audit.",
         action: "A fresh human-approved device-flow enrollment is required to reconnect.",
       };
       await scopedDb.insert(schema.machineRemovalOperations).values({
@@ -37626,7 +37639,6 @@ export async function removeEnrollment(
           machineName: result.machineName,
           lastSeenAt: result.lastSeenAt,
           credentialGeneration: Number(updated.credentialGeneration),
-          movedSessionIds: dependentSessions.map((session) => session.id),
         },
       });
       return result;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1857,10 +1857,7 @@ export type TemporalScheduleCleanupClaim = {
 };
 
 export type DeleteWorkspaceIfQuiescentResult =
-  | {
-      status: "deleted";
-      temporalScheduleCleanups: TemporalScheduleCleanupClaim[];
-    }
+  | { status: "deleted"; temporalScheduleCleanups: TemporalScheduleCleanupClaim[] }
   | {
       status: "not_found" | "only_workspace" | "active_sessions" | "live_sandboxes";
     };
@@ -2023,9 +2020,7 @@ export async function deleteWorkspaceIfQuiescent(
           }
 
           const schedules = await tx
-            .select({
-              temporalScheduleId: schema.scheduledTasks.temporalScheduleId,
-            })
+            .select({ temporalScheduleId: schema.scheduledTasks.temporalScheduleId })
             .from(schema.scheduledTasks)
             .where(eq(schema.scheduledTasks.workspaceId, input.workspaceId))
             .for("update", { noWait: true });
@@ -4102,11 +4097,7 @@ export async function prepareEditableArtifactSourceFile(
           .limit(1);
         if (existing) {
           assertEditableArtifactSourceFileMatches(existing.file, existing.upload, input);
-          return {
-            file: mapFile(existing.file),
-            uploadId: existing.upload.id,
-            created: false,
-          };
+          return { file: mapFile(existing.file), uploadId: existing.upload.id, created: false };
         }
 
         const [file] = await tx
@@ -4231,9 +4222,7 @@ export function durableUserHistoryItem(
     content: renderTimelineAnnotationsForModel(prompt, annotations),
     ...(attachmentRefs.length > 0 ? { [MODEL_ATTACHMENT_REFS_FIELD]: attachmentRefs } : {}),
     ...(annotations.length > 0
-      ? {
-          [MODEL_TIMELINE_ANNOTATIONS_FIELD]: TimelineAnnotations.parse(annotations),
-        }
+      ? { [MODEL_TIMELINE_ANNOTATIONS_FIELD]: TimelineAnnotations.parse(annotations) }
       : {}),
   };
 }
@@ -4373,19 +4362,11 @@ export async function prepareRetainedScreenshotArtifact(
       await scopedDb.transaction(async (tx) => {
         await tx
           .insert(schema.workspaceScreenshotQuotas)
-          .values({
-            accountId: input.accountId,
-            workspaceId: input.workspaceId,
-          })
-          .onConflictDoNothing({
-            target: schema.workspaceScreenshotQuotas.workspaceId,
-          });
+          .values({ accountId: input.accountId, workspaceId: input.workspaceId })
+          .onConflictDoNothing({ target: schema.workspaceScreenshotQuotas.workspaceId });
 
         const [existing] = await tx
-          .select({
-            artifact: schema.retainedScreenshotArtifacts,
-            file: schema.files,
-          })
+          .select({ artifact: schema.retainedScreenshotArtifacts, file: schema.files })
           .from(schema.retainedScreenshotArtifacts)
           .innerJoin(
             schema.files,
@@ -4631,10 +4612,7 @@ export async function getRetainedScreenshotArtifact(
 ): Promise<RetainedScreenshotArtifact | null> {
   return await withWorkspaceRls(db, workspaceId, async (scopedDb) => {
     const [row] = await scopedDb
-      .select({
-        artifact: schema.retainedScreenshotArtifacts,
-        file: schema.files,
-      })
+      .select({ artifact: schema.retainedScreenshotArtifacts, file: schema.files })
       .from(schema.retainedScreenshotArtifacts)
       .innerJoin(
         schema.files,
@@ -4752,9 +4730,7 @@ export async function promoteRetainedScreenshotMaintenanceCleanup(
             eq(schema.retainedScreenshotArtifacts.maintenanceClaimId, input.claimId),
           ),
         )
-        .returning({
-          artifactId: schema.retainedScreenshotArtifacts.artifactId,
-        });
+        .returning({ artifactId: schema.retainedScreenshotArtifacts.artifactId });
       return updated !== undefined;
     },
   );
@@ -4965,10 +4941,7 @@ async function getRetainedScreenshotArtifactByWorkspace(
 ): Promise<RetainedScreenshotArtifact | null> {
   return await withRlsContext(db, { accountId, workspaceId }, async (scopedDb) => {
     const [row] = await scopedDb
-      .select({
-        artifact: schema.retainedScreenshotArtifacts,
-        file: schema.files,
-      })
+      .select({ artifact: schema.retainedScreenshotArtifacts, file: schema.files })
       .from(schema.retainedScreenshotArtifacts)
       .innerJoin(schema.files, eq(schema.files.id, schema.retainedScreenshotArtifacts.artifactId))
       .where(
@@ -12607,10 +12580,7 @@ export async function getRigVersionById(
 
 export type RigProviderImageBuildClaim =
   | { status: "claimed"; image: RigProviderImage }
-  | {
-      status: "ready" | "in_progress" | "unsupported" | "conflict";
-      image: RigProviderImage;
-    };
+  | { status: "ready" | "in_progress" | "unsupported" | "conflict"; image: RigProviderImage };
 
 async function retainRigProviderImageArtifacts(
   db: Database,
@@ -34043,10 +34013,7 @@ export async function acquireSandboxLeaseReaperHold(
       await scopedDb.transaction(async (txRaw) => {
         const tx = txRaw as unknown as Database;
         const rows = await tx.execute<
-          LeaseRow & {
-            reaper_hold_active: boolean;
-            provider_hold_safe: boolean;
-          }
+          LeaseRow & { reaper_hold_active: boolean; provider_hold_safe: boolean }
         >(sql`
           select lease.*,
             (lease.reaper_hold_id is not null and lease.reaper_hold_until > now())
@@ -34082,28 +34049,16 @@ export async function acquireSandboxLeaseReaperHold(
           return { status: "held_by_other" as const, lease: mapLeaseRow(row) };
         }
         if (renewing && row.reaper_hold_reason !== reason) {
-          return {
-            status: "reason_conflict" as const,
-            lease: mapLeaseRow(row),
-          };
+          return { status: "reason_conflict" as const, lease: mapLeaseRow(row) };
         }
         if (row.archive_capture_id !== null || row.rotation_reason === "teardown_claim") {
-          return {
-            status: "teardown_in_progress" as const,
-            lease: mapLeaseRow(row),
-          };
+          return { status: "teardown_in_progress" as const, lease: mapLeaseRow(row) };
         }
         if (row.rotation_requested_at !== null) {
-          return {
-            status: "rotation_in_progress" as const,
-            lease: mapLeaseRow(row),
-          };
+          return { status: "rotation_in_progress" as const, lease: mapLeaseRow(row) };
         }
         if (!row.provider_hold_safe) {
-          return {
-            status: "provider_deadline_conflict" as const,
-            lease: mapLeaseRow(row),
-          };
+          return { status: "provider_deadline_conflict" as const, lease: mapLeaseRow(row) };
         }
         const held = await tx.execute<LeaseRow>(sql`
           update sandbox_leases set
@@ -34121,11 +34076,7 @@ export async function acquireSandboxLeaseReaperHold(
         if (!lease) {
           return { status: "lease_fenced" as const, lease: mapLeaseRow(row) };
         }
-        return {
-          status: "held" as const,
-          renewed: renewing,
-          lease: mapLeaseRow(lease),
-        };
+        return { status: "held" as const, renewed: renewing, lease: mapLeaseRow(lease) };
       }),
   );
 }
@@ -44604,10 +44555,7 @@ export async function settleSessionAttemptInterruptions(
                       turnGeneration: turn.executionGeneration,
                       turnAttemptId: attemptId,
                       turnAssociation: null,
-                      payload: {
-                        status: "idle",
-                        reason: "paused_recovery_settled",
-                      },
+                      payload: { status: "idle", reason: "paused_recovery_settled" },
                       clientEventId: `opengeni:paused-recovery-settled:${attemptId}`,
                       occurredAt: now,
                     },

--- a/packages/db/test/connected-machine-removal.test.ts
+++ b/packages/db/test/connected-machine-removal.test.ts
@@ -34,10 +34,7 @@ let admin: postgres.Sql;
 let client: DbClient;
 let db: Database;
 
-async function freshWorkspace(): Promise<{
-  accountId: string;
-  workspaceId: string;
-}> {
+async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
   const [account] = await admin<{ id: string }[]>`
     insert into managed_accounts (name) values ('connected-machine-removal') returning id`;
   const [workspace] = await admin<{ id: string }[]>`
@@ -174,10 +171,7 @@ describe("connected machine removal lifecycle", () => {
       select action, target_id from audit_events
       where workspace_id = ${workspaceId} and target_id = ${enrollment.id}
       order by occurred_at desc limit 1`;
-    expect(audit).toEqual({
-      action: "connected_machine.removed",
-      target_id: enrollment.id,
-    });
+    expect(audit).toEqual({ action: "connected_machine.removed", target_id: enrollment.id });
   }, 60_000);
 
   test("removes only the selected duplicate enrollment", async () => {
@@ -489,10 +483,7 @@ describe("connected machine removal lifecycle", () => {
       enrollmentId: leasedEnrollment.id,
       operationKey: "lease-blocked",
     });
-    expect(leaseBlocked).toMatchObject({
-      outcome: "blocked",
-      code: "active_lease",
-    });
+    expect(leaseBlocked).toMatchObject({ outcome: "blocked", code: "active_lease" });
     await admin`
       update sandbox_leases set liveness = 'cold', refcount = 0
       where workspace_id = ${workspaceId} and sandbox_group_id = ${leasedMachine.id}`;

--- a/packages/db/test/connected-machine-removal.test.ts
+++ b/packages/db/test/connected-machine-removal.test.ts
@@ -34,7 +34,10 @@ let admin: postgres.Sql;
 let client: DbClient;
 let db: Database;
 
-async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
+async function freshWorkspace(): Promise<{
+  accountId: string;
+  workspaceId: string;
+}> {
   const [account] = await admin<{ id: string }[]>`
     insert into managed_accounts (name) values ('connected-machine-removal') returning id`;
   const [workspace] = await admin<{ id: string }[]>`
@@ -171,7 +174,10 @@ describe("connected machine removal lifecycle", () => {
       select action, target_id from audit_events
       where workspace_id = ${workspaceId} and target_id = ${enrollment.id}
       order by occurred_at desc limit 1`;
-    expect(audit).toEqual({ action: "connected_machine.removed", target_id: enrollment.id });
+    expect(audit).toEqual({
+      action: "connected_machine.removed",
+      target_id: enrollment.id,
+    });
   }, 60_000);
 
   test("removes only the selected duplicate enrollment", async () => {
@@ -370,6 +376,45 @@ describe("connected machine removal lifecycle", () => {
       }),
     ).rejects.toBeInstanceOf(MachineRemovalIdempotencyError);
 
+    const activeTurnId = crypto.randomUUID();
+    await admin`
+      update sessions
+      set active_turn_id = ${activeTurnId}, status = 'running'
+      where id = ${session.id}`;
+    const activeTurnBlocked = await removeEnrollment(db, {
+      accountId,
+      workspaceId,
+      enrollmentId: routedEnrollment.id,
+      operationKey: "route-active-turn-blocked",
+      moveSessionsToDefaultSandbox: true,
+    });
+    expect(activeTurnBlocked).toMatchObject({
+      outcome: "blocked",
+      removed: false,
+      code: "active_commands",
+      dependentSessions: [
+        { id: session.id, title: null },
+        { id: secondSession.id, title: "Second routed session" },
+      ],
+    });
+    const [blockedSession] = await admin<
+      {
+        active_sandbox_id: string | null;
+        active_epoch: number;
+      }[]
+    >`
+      select active_sandbox_id, active_epoch
+      from sessions where id = ${session.id}`;
+    expect(blockedSession).toEqual({
+      active_sandbox_id: routedMachine.id,
+      active_epoch: routed.pointer!.activeEpoch,
+    });
+    expect((await getEnrollment(db, workspaceId, routedEnrollment.id))?.status).toBe("active");
+    await admin`
+      update sessions
+      set active_turn_id = null, status = 'idle'
+      where id = ${session.id}`;
+
     const [beforeMove] = await admin<
       {
         id: string;
@@ -444,7 +489,10 @@ describe("connected machine removal lifecycle", () => {
       enrollmentId: leasedEnrollment.id,
       operationKey: "lease-blocked",
     });
-    expect(leaseBlocked).toMatchObject({ outcome: "blocked", code: "active_lease" });
+    expect(leaseBlocked).toMatchObject({
+      outcome: "blocked",
+      code: "active_lease",
+    });
     await admin`
       update sandbox_leases set liveness = 'cold', refcount = 0
       where workspace_id = ${workspaceId} and sandbox_group_id = ${leasedMachine.id}`;

--- a/packages/db/test/connected-machine-removal.test.ts
+++ b/packages/db/test/connected-machine-removal.test.ts
@@ -220,6 +220,61 @@ describe("connected machine removal lifecycle", () => {
     );
   }, 60_000);
 
+  test("blocks removal when the machine is a session's durable home sandbox", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const enrollment = await createEnrollment(db, {
+      accountId,
+      workspaceId,
+      pubkey: `ed25519:machine-home-${crypto.randomUUID()}`,
+    });
+    const machine = await createSandbox(db, {
+      accountId,
+      workspaceId,
+      kind: "selfhosted",
+      name: "Machine-Home.local",
+      enrollmentId: enrollment.id,
+    });
+    const session = await createSession(db, {
+      accountId,
+      workspaceId,
+      initialMessage: "machine home fixture",
+      resources: [],
+      metadata: {},
+      model: "gpt",
+      sandboxBackend: "selfhosted",
+    });
+    await admin`update sessions set title = 'Machine home session' where id = ${session.id}`;
+    const routed = await setActiveSandbox(db, {
+      accountId,
+      workspaceId,
+      sessionId: session.id,
+      targetSandboxId: machine.id,
+      expectedEpoch: session.activeEpoch,
+    });
+    expect(routed.swapped).toBe(true);
+
+    const blocked = await removeEnrollment(db, {
+      accountId,
+      workspaceId,
+      enrollmentId: enrollment.id,
+      operationKey: "machine-home-blocked",
+    });
+    expect(blocked).toMatchObject({
+      outcome: "blocked",
+      removed: false,
+      code: "machine_home",
+      dependentSessions: [{ id: session.id, title: "Machine home session" }],
+    });
+    const [pointer] = await admin<{ active_sandbox_id: string | null; active_epoch: number }[]>`
+      select active_sandbox_id, active_epoch from sessions where id = ${session.id}`;
+    expect(pointer).toEqual({
+      active_sandbox_id: machine.id,
+      active_epoch: routed.pointer!.activeEpoch,
+    });
+    expect((await getEnrollment(db, workspaceId, enrollment.id))?.status).toBe("active");
+  }, 60_000);
+
   test("fences idempotency keys by enrollment with omitted and equal revisions", async () => {
     if (!available) return;
     const { accountId, workspaceId } = await freshWorkspace();
@@ -360,15 +415,14 @@ describe("connected machine removal lifecycle", () => {
         { id: secondSession.id, title: "Second routed session" },
       ],
     });
-    await expect(
-      removeEnrollment(db, {
+    expect(
+      await removeEnrollment(db, {
         accountId,
         workspaceId,
         enrollmentId: routedEnrollment.id,
         operationKey: "route-blocked",
-        moveSessionsToDefaultSandbox: true,
       }),
-    ).rejects.toBeInstanceOf(MachineRemovalIdempotencyError);
+    ).toEqual(routeBlocked);
 
     const activeTurnId = crypto.randomUUID();
     await admin`
@@ -380,7 +434,6 @@ describe("connected machine removal lifecycle", () => {
       workspaceId,
       enrollmentId: routedEnrollment.id,
       operationKey: "route-active-turn-blocked",
-      moveSessionsToDefaultSandbox: true,
     });
     expect(activeTurnBlocked).toMatchObject({
       outcome: "blocked",
@@ -423,20 +476,32 @@ describe("connected machine removal lifecycle", () => {
       select id, status, active_turn_id, queue_version, queue_head_position,
              queue_tail_position, last_sequence
       from sessions where id = ${session.id}`;
-    const forced = await removeEnrollment(db, {
+    const movedFirst = await setActiveSandbox(db, {
+      accountId,
+      workspaceId,
+      sessionId: session.id,
+      targetSandboxId: null,
+      expectedEpoch: routed.pointer!.activeEpoch,
+    });
+    const movedSecond = await setActiveSandbox(db, {
+      accountId,
+      workspaceId,
+      sessionId: secondSession.id,
+      targetSandboxId: null,
+      expectedEpoch: secondRouted.pointer!.activeEpoch,
+    });
+    expect(movedFirst.swapped).toBe(true);
+    expect(movedSecond.swapped).toBe(true);
+    const removedAfterMoves = await removeEnrollment(db, {
       accountId,
       workspaceId,
       enrollmentId: routedEnrollment.id,
-      operationKey: "route-force-move",
-      moveSessionsToDefaultSandbox: true,
+      operationKey: "route-remove-after-moves",
     });
-    expect(forced).toMatchObject({
+    expect(removedAfterMoves).toMatchObject({
       outcome: "removed",
       removed: true,
-      dependentSessions: [
-        { id: session.id, title: null },
-        { id: secondSession.id, title: "Second routed session" },
-      ],
+      dependentSessions: [],
     });
     const movedSessions = await admin<
       {
@@ -455,8 +520,8 @@ describe("connected machine removal lifecycle", () => {
              queue_version, queue_head_position, queue_tail_position, last_sequence
       from sessions where id in (${session.id}, ${secondSession.id}) order by created_at, id`;
     expect(movedSessions.map((row) => [row.id, row.active_sandbox_id, row.active_epoch])).toEqual([
-      [session.id, null, routed.pointer!.activeEpoch + 1],
-      [secondSession.id, null, secondRouted.pointer!.activeEpoch + 1],
+      [session.id, null, movedFirst.pointer!.activeEpoch],
+      [secondSession.id, null, movedSecond.pointer!.activeEpoch],
     ]);
     expect(movedSessions[0]).toMatchObject(beforeMove!);
 

--- a/packages/db/test/connected-machine-removal.test.ts
+++ b/packages/db/test/connected-machine-removal.test.ts
@@ -328,21 +328,98 @@ describe("connected machine removal lifecycle", () => {
       expectedEpoch: session.activeEpoch,
     });
     expect(routed.swapped).toBe(true);
+    const secondSession = await createSession(db, {
+      accountId,
+      workspaceId,
+      initialMessage: "second active route fixture",
+      resources: [],
+      metadata: {},
+      model: "gpt",
+      sandboxBackend: "modal",
+    });
+    await admin`update sessions set title = 'Second routed session' where id = ${secondSession.id}`;
+    const secondRouted = await setActiveSandbox(db, {
+      accountId,
+      workspaceId,
+      sessionId: secondSession.id,
+      targetSandboxId: routedMachine.id,
+      expectedEpoch: secondSession.activeEpoch,
+    });
+    expect(secondRouted.swapped).toBe(true);
     const routeBlocked = await removeEnrollment(db, {
       accountId,
       workspaceId,
       enrollmentId: routedEnrollment.id,
       operationKey: "route-blocked",
     });
-    expect(routeBlocked).toMatchObject({ outcome: "blocked", code: "active_route" });
-    const detached = await setActiveSandbox(db, {
+    expect(routeBlocked).toMatchObject({
+      outcome: "blocked",
+      code: "active_route",
+      dependentSessions: [
+        { id: session.id, title: null },
+        { id: secondSession.id, title: "Second routed session" },
+      ],
+    });
+    await expect(
+      removeEnrollment(db, {
+        accountId,
+        workspaceId,
+        enrollmentId: routedEnrollment.id,
+        operationKey: "route-blocked",
+        moveSessionsToDefaultSandbox: true,
+      }),
+    ).rejects.toBeInstanceOf(MachineRemovalIdempotencyError);
+
+    const [beforeMove] = await admin<
+      {
+        id: string;
+        status: string;
+        active_turn_id: string | null;
+        queue_version: number;
+        queue_head_position: string;
+        queue_tail_position: string;
+        last_sequence: number;
+      }[]
+    >`
+      select id, status, active_turn_id, queue_version, queue_head_position,
+             queue_tail_position, last_sequence
+      from sessions where id = ${session.id}`;
+    const forced = await removeEnrollment(db, {
       accountId,
       workspaceId,
-      sessionId: session.id,
-      targetSandboxId: null,
-      expectedEpoch: routed.pointer!.activeEpoch,
+      enrollmentId: routedEnrollment.id,
+      operationKey: "route-force-move",
+      moveSessionsToDefaultSandbox: true,
     });
-    expect(detached.swapped).toBe(true);
+    expect(forced).toMatchObject({
+      outcome: "removed",
+      removed: true,
+      dependentSessions: [
+        { id: session.id, title: null },
+        { id: secondSession.id, title: "Second routed session" },
+      ],
+    });
+    const movedSessions = await admin<
+      {
+        id: string;
+        active_sandbox_id: string | null;
+        active_epoch: number;
+        status: string;
+        active_turn_id: string | null;
+        queue_version: number;
+        queue_head_position: string;
+        queue_tail_position: string;
+        last_sequence: number;
+      }[]
+    >`
+      select id, active_sandbox_id, active_epoch, status, active_turn_id,
+             queue_version, queue_head_position, queue_tail_position, last_sequence
+      from sessions where id in (${session.id}, ${secondSession.id}) order by created_at, id`;
+    expect(movedSessions.map((row) => [row.id, row.active_sandbox_id, row.active_epoch])).toEqual([
+      [session.id, null, routed.pointer!.activeEpoch + 1],
+      [secondSession.id, null, secondRouted.pointer!.activeEpoch + 1],
+    ]);
+    expect(movedSessions[0]).toMatchObject(beforeMove!);
 
     const leasedEnrollment = await createEnrollment(db, {
       accountId,

--- a/packages/react/src/hooks/use-machines.ts
+++ b/packages/react/src/hooks/use-machines.ts
@@ -1,5 +1,9 @@
 import { useCallback, useRef, useState } from "react";
-import type { RemoveEnrollmentRequest, RemoveEnrollmentResponse } from "@opengeni/sdk";
+import type {
+  RemoveEnrollmentRequest,
+  RemoveEnrollmentResponse,
+  SwapActiveSandboxResponse,
+} from "@opengeni/sdk";
 import { useOpenGeni, type ClientOverride } from "../provider";
 import { useMutationRunner, usePolledValue } from "./internal";
 import type { MachinesResponse, MachineView, MetricSample } from "../types/machines";
@@ -46,7 +50,7 @@ export type MachinesClientLike = {
     workspaceId: string,
     sessionId: string,
     request: { target: string },
-  ) => Promise<unknown>;
+  ) => Promise<SwapActiveSandboxResponse>;
   /**
    * Host-supplied swap adapter (an escape hatch). When present it wins over the
    * default `swapActiveSandbox` path. Session-scoped, like the swap it backs.
@@ -98,6 +102,24 @@ export type UseMachinesResult = {
 };
 
 const EMPTY: MachinesResponse = { activeSandboxId: null, activeEpoch: 0, machines: [] };
+
+function swapFailureMessage(result: SwapActiveSandboxResponse): string {
+  if (result.reason?.trim()) return result.reason;
+  switch (result.code) {
+    case "recovery_in_progress":
+      return "The managed sandbox is still recovering. Try again shortly.";
+    case "recovery_degraded":
+      return "The managed sandbox recovery is degraded and needs attention.";
+    case "recovery_unrecoverable":
+      return "The managed sandbox could not be recovered.";
+    case "offline_enrollment":
+      return "The selected machine is offline.";
+    case "concurrent_swap":
+      return "The session route changed concurrently. Refresh and try again.";
+    default:
+      return "The session stayed on its current sandbox.";
+  }
+}
 
 /**
  * The workspace Machines fleet: the selfhosted enrollments + the session's Modal
@@ -171,7 +193,15 @@ export function useMachines(options: UseMachinesOptions = {}): UseMachinesResult
       const ownedIdentity = identityKey;
       setAttachState({ identity: ownedIdentity, sandboxId });
       const result = await run(async () => {
-        await runSwap();
+        const response = await runSwap();
+        if (
+          response &&
+          typeof response === "object" &&
+          "swapped" in response &&
+          response.swapped === false
+        ) {
+          throw new Error(swapFailureMessage(response as SwapActiveSandboxResponse));
+        }
         return true;
       });
       if (identityRef.current === ownedIdentity) {

--- a/packages/react/test/use-machines.test.tsx
+++ b/packages/react/test/use-machines.test.tsx
@@ -9,6 +9,7 @@ import { actRun, registerDom, renderHook, flush } from "./render-hook";
 import { fakeClient, WORKSPACE_ID } from "./fake-client";
 import { useMachines, type MachinesClientLike } from "../src/hooks/use-machines";
 import type { MachinesResponse, MachineView } from "../src/types/machines";
+import type { SwapActiveSandboxResponse } from "@opengeni/sdk";
 
 registerDom();
 
@@ -84,6 +85,35 @@ describe("useMachines", () => {
     expect(ok).toBe(true);
     expect(swappedTo).toEqual([{ sessionId: "sess-1", target: "sh-1" }]);
     expect(hook.result.current.activeSandboxId).toBe("sh-1");
+    await hook.unmount();
+  });
+
+  test("attach surfaces a resolved swapped:false response as an actionable mutation error", async () => {
+    const machinesClient: MachinesClientLike = {
+      listMachines: async () => response,
+      swapActiveSandbox: async () => ({
+        swapped: false,
+        activeSandboxId: "sh-1",
+        activeEpoch: 3,
+        code: "recovery_in_progress",
+        reason: "The managed sandbox restore is still verifying.",
+      }),
+    };
+    const hook = await renderHook(
+      () => useMachines({ client, workspaceId: WORKSPACE_ID, machinesClient, sessionId: "sess-1" }),
+      undefined,
+    );
+    await flush();
+
+    const ok = await actRun(() => hook.result.current.attach("modal-box"));
+    await flush();
+
+    expect(ok).toBe(false);
+    expect(hook.result.current.mutationError?.message).toBe(
+      "The managed sandbox restore is still verifying.",
+    );
+    expect(hook.result.current.attaching).toBe(false);
+    expect(hook.result.current.attachingSandboxId).toBeNull();
     await hook.unmount();
   });
 
@@ -229,11 +259,11 @@ describe("useMachines", () => {
   test("a late attach settlement from the old session cannot clear the new session spinner", async () => {
     let resolveOld: () => void = () => {};
     let resolveNew: () => void = () => {};
-    const oldSwap = new Promise<void>((resolve) => {
-      resolveOld = resolve;
+    const oldSwap = new Promise<SwapActiveSandboxResponse>((resolve) => {
+      resolveOld = () => resolve({ swapped: true, activeSandboxId: "old-box", activeEpoch: 4 });
     });
-    const newSwap = new Promise<void>((resolve) => {
-      resolveNew = resolve;
+    const newSwap = new Promise<SwapActiveSandboxResponse>((resolve) => {
+      resolveNew = () => resolve({ swapped: true, activeSandboxId: "new-box", activeEpoch: 5 });
     });
     const machinesClient: MachinesClientLike = {
       listMachines: async () => response,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -4838,9 +4838,6 @@ export type MachineMetricsSeriesResponse = {
 export type RemoveEnrollmentRequest = {
   expectedUpdatedAt?: string;
   idempotencyKey?: string;
-  /** Explicit confirmation to repoint dependent sessions to their default
-   * managed sandbox before revoking the connected machine. */
-  moveSessionsToDefaultSandbox?: boolean;
 };
 
 /** Typed removal/revocation outcome. Blocked outcomes preserve the exact
@@ -4855,6 +4852,7 @@ export type RemoveEnrollmentResponse = {
   code:
     | "active_route"
     | "active_commands"
+    | "machine_home"
     | "active_lease"
     | "recovery_pending"
     | "not_selfhosted"

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -4838,6 +4838,9 @@ export type MachineMetricsSeriesResponse = {
 export type RemoveEnrollmentRequest = {
   expectedUpdatedAt?: string;
   idempotencyKey?: string;
+  /** Explicit confirmation to repoint dependent sessions to their default
+   * managed sandbox before revoking the connected machine. */
+  moveSessionsToDefaultSandbox?: boolean;
 };
 
 /** Typed removal/revocation outcome. Blocked outcomes preserve the exact
@@ -4858,6 +4861,7 @@ export type RemoveEnrollmentResponse = {
     | null;
   message: string;
   action: string;
+  dependentSessions: Array<{ id: string; title: string | null }>;
 };
 
 /** POST /v1/workspaces/:ws/sessions/:sessionId/active-sandbox — swap a session's

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -132,7 +132,6 @@ describe("OpenGeniClient", () => {
     const result = await client.removeEnrollment(WORKSPACE_ID, enrollmentId, {
       expectedUpdatedAt: "2026-08-04T09:00:00.000Z",
       idempotencyKey: "remove-sdk-contract-1",
-      moveSessionsToDefaultSandbox: true,
     });
 
     expect(result).toEqual(response);
@@ -143,7 +142,6 @@ describe("OpenGeniClient", () => {
     expect(JSON.parse(requests[0]!.body!)).toEqual({
       expectedUpdatedAt: "2026-08-04T09:00:00.000Z",
       idempotencyKey: "remove-sdk-contract-1",
-      moveSessionsToDefaultSandbox: true,
     });
   });
 

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   OPENGENI_API_CONTRACT_HEADER,
   OPENGENI_API_CONTRACT_REVISION,
+  type RemoveEnrollmentResponse,
   type Session,
   OPENGENI_CORRELATION_HEADER,
   type ComposerDraft,
@@ -115,7 +116,7 @@ describe("OpenGeniClient", () => {
 
   test("removeEnrollment posts the workspace-scoped idempotent removal contract", async () => {
     const enrollmentId = "11111111-1111-4111-8111-111111111111";
-    const response = {
+    const response: RemoveEnrollmentResponse = {
       revoked: true,
       outcome: "removed",
       enrollmentId,
@@ -125,11 +126,13 @@ describe("OpenGeniClient", () => {
       code: null,
       message: "Machine access was revoked. History was retained for audit.",
       action: "A fresh human-approved device-flow enrollment is required to reconnect.",
-    } as const;
+      dependentSessions: [],
+    };
     const { client, requests } = makeClient(() => jsonResponse(response));
     const result = await client.removeEnrollment(WORKSPACE_ID, enrollmentId, {
       expectedUpdatedAt: "2026-08-04T09:00:00.000Z",
       idempotencyKey: "remove-sdk-contract-1",
+      moveSessionsToDefaultSandbox: true,
     });
 
     expect(result).toEqual(response);
@@ -140,6 +143,7 @@ describe("OpenGeniClient", () => {
     expect(JSON.parse(requests[0]!.body!)).toEqual({
       expectedUpdatedAt: "2026-08-04T09:00:00.000Z",
       idempotencyKey: "remove-sdk-contract-1",
+      moveSessionsToDefaultSandbox: true,
     });
   });
 


### PR DESCRIPTION
## Summary

- return every session that still routes through a connected machine instead of reporting only the first dependency
- add an explicit `moveSessionsToDefaultSandbox` confirmation that atomically clears those route pointers, advances their active epochs, and revokes the machine only after lease/recovery blockers are clear
- render linked dependent sessions and the follow-up action inline in the removal dialog
- treat resolved `swapped: false` sandbox-switch responses as visible mutation errors rather than silent success

This is a focused follow-up to the removal lifecycle landed in #1017. It does not revive or broaden #466.

## Safety

- keeps session history, goals, events, queue state, working directories, sandbox groups, and recovery/archive state intact
- uses the existing epoch fence when moving routes
- retains existing active-command, active-lease, and recovery-pending blockers
- includes the explicit move choice in the idempotency fingerprint
- no deployment changes

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:public-hygiene`
- `bun test packages/react/test/use-machines.test.tsx apps/web/src/routes/machines-removal.test.tsx packages/sdk/test/client.test.ts -t 'useMachines|connected machine removal conflict|removeEnrollment posts'`
- `bun run build` in `packages/sdk`
- `bun run build` in `packages/react`
- `bun run build` in `apps/web`

The focused DB/API integration cases are included, but this local sandbox has no Docker/PostgreSQL fixture. The repository-wide unit sweep also reaches unrelated suites that require Docker/PostgreSQL and `@temporalio/workflow`; those setup-only failures are left to service-backed CI.
