### PR TITLE
Add ordered image generation references

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -388,9 +388,10 @@ import {
 import { executeGatewayImageGeneration } from "./gateway-image-generation";
 import { executeCodexImageGeneration } from "./codex-image-generation";
 import { imageProviderBindingHash } from "./image-generation-operation";
+import { resolveImageGenerationReferences } from "./image-generation-references";
 import { executeEditableArtifactPublication } from "./editable-artifact-publication";
 import { captureWorkspaceRevision, openFreshWorkspaceCaptureSession } from "./workspace-capture";
-import type { ChannelASession } from "@opengeni/runtime/sandbox";
+import { SandboxChannelAService, type ChannelASession } from "@opengeni/runtime/sandbox";
 import { createObjectStorage, type ObjectStorage } from "@opengeni/storage";
 import {
   desktopCapableBackend,
@@ -6413,6 +6414,37 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             }
           : {};
       const hostedWebSearch = hostedWebSearchForTurn(resolvedModel, runSettings.webSearchEnabled);
+      const resolveImageReferences = async (
+        references: Parameters<typeof resolveImageGenerationReferences>[0]["references"],
+      ) =>
+        await resolveImageGenerationReferences({
+          db,
+          objectStorage: objectStorage!,
+          workspaceId: input.workspaceId,
+          references,
+          readSandboxFile: async (path, maxBytes) => {
+            const imageReferenceSession = (setupBoxSession ??
+              sdkOwnedSandboxSession) as ChannelASession | null;
+            if (!imageReferenceSession) {
+              throw new Error("Sandbox image reference is unavailable");
+            }
+            const relativePath = path.slice("/workspace/".length);
+            const referenceRunAs = sandboxRunAs(modelRunSettings);
+            const channel = new SandboxChannelAService({
+              session: imageReferenceSession,
+              workspaceRoot: "/workspace",
+              leaseEpoch: resolvedSandbox?.leaseEpoch ?? 0,
+              ...(referenceRunAs ? { runAs: referenceRunAs } : {}),
+            });
+            const read = await channel.fsRead({
+              path: relativePath,
+              encoding: "base64",
+              maxBytes,
+            });
+            if (read.truncated) throw new Error("Sandbox image reference exceeds the byte limit");
+            return Uint8Array.from(Buffer.from(read.content, "base64"));
+          },
+        });
       const imageGenerationOption: Pick<BuildAgentOptions, "imageGeneration"> = (() => {
         // Never expose a paid image operation unless its permanent artifact can
         // be committed. Failing after provider execution would leave an
@@ -6439,7 +6471,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           return {
             imageGeneration: {
               kind: "provider_adapter",
-              execute: async ({ prompt }, { toolCallId }) => {
+              execute: async ({ prompt, references }, { toolCallId }) => {
+                const resolvedReferences = await resolveImageReferences(references);
                 const receipt = await executeCodexImageGeneration({
                   db,
                   objectStorage,
@@ -6450,6 +6483,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   attemptId: input.attemptId,
                   toolCallId,
                   prompt,
+                  references: resolvedReferences,
                   credentialId: codexImageCredentialId,
                   codexContext: codexImageContext,
                   ...(runtimeCancellationSignal ? { abortSignal: runtimeCancellationSignal } : {}),
@@ -6472,7 +6506,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         return {
           imageGeneration: {
             kind: "provider_adapter",
-            execute: async ({ prompt }, { toolCallId }) => {
+            execute: async ({ prompt, references }, { toolCallId }) => {
+              const resolvedReferences = await resolveImageReferences(references);
               const receipt = await executeGatewayImageGeneration({
                 db,
                 objectStorage,
@@ -6484,6 +6519,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 apiKey: gatewayApiKey,
                 modelId: capabilitySettings.imageGenerationModel,
                 prompt,
+                references: resolvedReferences,
                 toolCallId,
                 ...(runtimeCancellationSignal ? { abortSignal: runtimeCancellationSignal } : {}),
               });

--- a/apps/worker/src/activities/codex-image-generation.ts
+++ b/apps/worker/src/activities/codex-image-generation.ts
@@ -10,6 +10,7 @@ import {
   executeImageGenerationOperation,
   imageProviderBindingHash,
 } from "./image-generation-operation";
+import type { ResolvedImageGenerationReference } from "./image-generation-references";
 
 const CODEX_IMAGE_MODEL = "gpt-image-2";
 
@@ -24,6 +25,7 @@ export async function executeCodexImageGeneration(input: {
   attemptId: string;
   toolCallId: string;
   prompt: string;
+  references?: readonly ResolvedImageGenerationReference[];
   credentialId: string;
   codexContext: Pick<CodexRequestContext, "clientVersion" | "getToken" | "refresh">;
   abortSignal?: AbortSignal;
@@ -34,9 +36,11 @@ export async function executeCodexImageGeneration(input: {
     providerId: CODEX_PROVIDER_ID,
     providerBindingHash,
     modelId: CODEX_IMAGE_MODEL,
+    ...(input.references ? { referenceDigests: input.references } : {}),
     generate: async () => {
       const generated = await generateCodexSubscriptionImage({
         prompt: input.prompt,
+        ...(input.references ? { references: input.references } : {}),
         turnId: input.turnId,
         context: input.codexContext,
         ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),

--- a/apps/worker/src/activities/gateway-image-generation.ts
+++ b/apps/worker/src/activities/gateway-image-generation.ts
@@ -6,6 +6,7 @@ import {
   executeImageGenerationOperation,
   imageProviderBindingHash,
 } from "./image-generation-operation";
+import type { ResolvedImageGenerationReference } from "./image-generation-references";
 
 const GATEWAY_IMAGE_PROVIDER_ID = "vercel-ai-gateway";
 const GATEWAY_IMAGE_URL = "https://ai-gateway.vercel.sh/v3/ai/image-model";
@@ -36,6 +37,7 @@ export async function executeGatewayImageGeneration(input: {
   apiKey: string;
   modelId: string;
   prompt: string;
+  references?: readonly ResolvedImageGenerationReference[];
   toolCallId: string;
   abortSignal?: AbortSignal;
 }): Promise<GeneratedImageReceipt> {
@@ -44,11 +46,13 @@ export async function executeGatewayImageGeneration(input: {
     ...input,
     providerId: GATEWAY_IMAGE_PROVIDER_ID,
     providerBindingHash,
+    ...(input.references ? { referenceDigests: input.references } : {}),
     generate: async () =>
       await generateGatewayImage({
         apiKey: input.apiKey,
         modelId: input.modelId,
         prompt: input.prompt,
+        ...(input.references ? { references: input.references } : {}),
         toolCallId: input.toolCallId,
         ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
       }),
@@ -65,6 +69,7 @@ export async function generateGatewayImage(input: {
   apiKey: string;
   modelId: string;
   prompt: string;
+  references?: readonly ResolvedImageGenerationReference[];
   toolCallId: string;
   abortSignal?: AbortSignal;
   fetch?: FetchLike;
@@ -84,7 +89,19 @@ export async function generateGatewayImage(input: {
       "ai-model-id": input.modelId,
       "user-agent": "opengeni/image-generation",
     },
-    body: JSON.stringify({ prompt: input.prompt, n: 1 }),
+    body: JSON.stringify({
+      prompt: input.prompt,
+      n: 1,
+      ...(input.references?.length
+        ? {
+            files: input.references.map((reference) => ({
+              type: "file",
+              mediaType: reference.mediaType,
+              data: Buffer.from(reference.bytes).toString("base64"),
+            })),
+          }
+        : {}),
+    }),
     ...(input.abortSignal ? { signal: input.abortSignal } : {}),
   });
   if (!response.ok) {

--- a/apps/worker/src/activities/image-generation-operation.ts
+++ b/apps/worker/src/activities/image-generation-operation.ts
@@ -82,6 +82,7 @@ export type ExecuteImageGenerationOperationInput = {
   providerBindingHash: string;
   modelId: string;
   prompt: string;
+  referenceDigests?: readonly Readonly<{ mediaType: string; sha256: string }>[];
   generate: () => Promise<GeneratedImageOutput>;
 };
 
@@ -97,6 +98,7 @@ export async function executeImageGenerationOperation(
     providerBindingHash: input.providerBindingHash,
     modelId: input.modelId,
     prompt: input.prompt,
+    ...(input.referenceDigests ? { referenceDigests: input.referenceDigests } : {}),
     toolCallId: input.toolCallId,
   });
   const prepared = await ports.prepare(input.db, {
@@ -221,17 +223,23 @@ export function imageGenerationOperationIdentity(input: {
   providerBindingHash: string;
   modelId: string;
   prompt: string;
+  referenceDigests?: readonly Readonly<{ mediaType: string; sha256: string }>[];
 }): {
   operationId: string;
   operationKey: string;
   requestDigest: string;
   artifactId: string;
 } {
-  const requestDigest = digest(
-    "opengeni:image-generation-request:v1\0",
-    input.modelId,
-    input.prompt,
-  );
+  const referenceDigests = input.referenceDigests ?? [];
+  const requestDigest =
+    referenceDigests.length === 0
+      ? digest("opengeni:image-generation-request:v1\0", input.modelId, input.prompt)
+      : digest(
+          "opengeni:image-generation-request:v2\0",
+          input.modelId,
+          input.prompt,
+          ...referenceDigests.flatMap((reference) => [reference.mediaType, reference.sha256]),
+        );
   const operationKey = digest(
     "opengeni:image-generation-operation:v2\0",
     input.workspaceId,

--- a/apps/worker/src/activities/image-generation-references.ts
+++ b/apps/worker/src/activities/image-generation-references.ts
@@ -1,0 +1,118 @@
+import { type ImageGenerationReference, type FileAsset } from "@opengeni/contracts";
+import { getGeneratedImageArtifact, requireFile, type Database } from "@opengeni/db";
+import type { ObjectStorage } from "@opengeni/storage";
+import { validateGeneratedImage, type GeneratedImageMediaType } from "./generated-images";
+
+export const IMAGE_GENERATION_REFERENCE_MAX_BYTES = 30 * 1024 * 1024;
+export const IMAGE_GENERATION_REFERENCES_MAX_TOTAL_BYTES = 64 * 1024 * 1024;
+
+export type ResolvedImageGenerationReference = Readonly<{
+  mediaType: GeneratedImageMediaType;
+  bytes: Uint8Array;
+  sizeBytes: number;
+  sha256: string;
+}>;
+
+export type SandboxImageReferenceReader = (path: string, maxBytes: number) => Promise<Uint8Array>;
+
+/**
+ * Resolve ordered model-facing references without accepting arbitrary URLs.
+ * Stored files remain workspace-RLS scoped; sandbox reads stay rooted beneath
+ * /workspace. Provider adapters receive only validated immutable bytes.
+ */
+export async function resolveImageGenerationReferences(input: {
+  db: Database;
+  objectStorage: ObjectStorage;
+  workspaceId: string;
+  references: readonly ImageGenerationReference[];
+  readSandboxFile?: SandboxImageReferenceReader;
+}): Promise<ResolvedImageGenerationReference[]> {
+  const resolved: ResolvedImageGenerationReference[] = [];
+  let totalBytes = 0;
+
+  for (const reference of input.references) {
+    const source = await referenceBytes(input, reference);
+    if (source.bytes.byteLength > IMAGE_GENERATION_REFERENCE_MAX_BYTES) {
+      throw new Error("Image reference exceeds the per-image byte limit");
+    }
+    totalBytes += source.bytes.byteLength;
+    if (totalBytes > IMAGE_GENERATION_REFERENCES_MAX_TOTAL_BYTES) {
+      throw new Error("Image references exceed the combined byte limit");
+    }
+
+    const image = validateGeneratedImage({ bytes: source.bytes });
+    if (source.file) assertStoredFileMatches(source.file, image);
+    resolved.push({
+      mediaType: image.mediaType,
+      bytes: source.bytes,
+      sizeBytes: image.sizeBytes,
+      sha256: image.sha256,
+    });
+  }
+
+  return resolved;
+}
+
+async function referenceBytes(
+  input: {
+    db: Database;
+    objectStorage: ObjectStorage;
+    workspaceId: string;
+    readSandboxFile?: SandboxImageReferenceReader;
+  },
+  reference: ImageGenerationReference,
+): Promise<{ bytes: Uint8Array; file?: FileAsset }> {
+  if (reference.kind === "sandbox_path") {
+    if (!input.readSandboxFile) {
+      throw new Error("Sandbox image references require an active sandbox");
+    }
+    return {
+      bytes: await input.readSandboxFile(reference.path, IMAGE_GENERATION_REFERENCE_MAX_BYTES + 1),
+    };
+  }
+
+  const file =
+    reference.kind === "file"
+      ? await requireFile(input.db, input.workspaceId, reference.fileId)
+      : await artifactFile(input.db, input.workspaceId, reference.artifactId);
+  if (file.status !== "ready" || !file.sha256) {
+    throw new Error("Image reference file is not durably ready");
+  }
+  if (file.sizeBytes <= 0 || file.sizeBytes > IMAGE_GENERATION_REFERENCE_MAX_BYTES) {
+    throw new Error("Image reference file exceeds the supported size");
+  }
+  return {
+    bytes: await readStoredFile(input.objectStorage, file),
+    file,
+  };
+}
+
+async function readStoredFile(objectStorage: ObjectStorage, file: FileAsset): Promise<Uint8Array> {
+  const bytes = await objectStorage.getFileRange(file, {
+    start: 0,
+    end: file.sizeBytes - 1,
+  });
+  if (!bytes) throw new Error("Image reference file bytes are unavailable");
+  return bytes;
+}
+
+async function artifactFile(
+  db: Database,
+  workspaceId: string,
+  artifactId: string,
+): Promise<FileAsset> {
+  const artifact = await getGeneratedImageArtifact(db, workspaceId, artifactId);
+  if (!artifact || artifact.status !== "ready") {
+    throw new Error(`Generated image artifact not found or unavailable: ${artifactId}`);
+  }
+  return artifact.file;
+}
+
+function assertStoredFileMatches(
+  file: FileAsset,
+  image: Pick<ResolvedImageGenerationReference, "sizeBytes" | "sha256">,
+): void {
+  if (file.sizeBytes !== image.sizeBytes || file.sha256 !== image.sha256) {
+    throw new Error("Image reference bytes do not match their durable file metadata");
+  }
+}

--- a/apps/worker/test/gateway-image-generation.test.ts
+++ b/apps/worker/test/gateway-image-generation.test.ts
@@ -74,4 +74,41 @@ describe("Vercel AI Gateway image adapter", () => {
     );
     expect(calls).toBe(1);
   });
+
+  test("sends ordered validated image references through the v3 files contract", async () => {
+    let requestBody: unknown;
+    await generateGatewayImage({
+      apiKey: "gateway-secret",
+      modelId: "openai/gpt-image-2",
+      prompt: "Use reference one for the subject and two for the visual style",
+      references: [
+        {
+          mediaType: "image/png",
+          bytes: Uint8Array.from([1, 2, 3]),
+          sizeBytes: 3,
+          sha256: "a".repeat(64),
+        },
+        {
+          mediaType: "image/webp",
+          bytes: Uint8Array.from([4, 5, 6]),
+          sizeBytes: 3,
+          sha256: "b".repeat(64),
+        },
+      ],
+      toolCallId: "call-image-edit-1",
+      fetch: async (_url, init) => {
+        requestBody = JSON.parse(String(init?.body));
+        return Response.json({ images: ["aW1hZ2U="] });
+      },
+    });
+
+    expect(requestBody).toEqual({
+      prompt: "Use reference one for the subject and two for the visual style",
+      n: 1,
+      files: [
+        { type: "file", mediaType: "image/png", data: "AQID" },
+        { type: "file", mediaType: "image/webp", data: "BAUG" },
+      ],
+    });
+  });
 });

--- a/apps/worker/test/image-generation-operation.test.ts
+++ b/apps/worker/test/image-generation-operation.test.ts
@@ -106,6 +106,24 @@ describe("image generation operation identity", () => {
     expect(changedPrompt.artifactId).toBe(original.artifactId);
     expect(changedPrompt.requestDigest).not.toBe(original.requestDigest);
 
+    const withReferences = imageGenerationOperationIdentity({
+      ...base,
+      referenceDigests: [
+        { mediaType: "image/png", sha256: "a".repeat(64) },
+        { mediaType: "image/jpeg", sha256: "b".repeat(64) },
+      ],
+    });
+    const reversedReferences = imageGenerationOperationIdentity({
+      ...base,
+      referenceDigests: [
+        { mediaType: "image/jpeg", sha256: "b".repeat(64) },
+        { mediaType: "image/png", sha256: "a".repeat(64) },
+      ],
+    });
+    expect(withReferences.operationKey).toBe(original.operationKey);
+    expect(withReferences.requestDigest).not.toBe(original.requestDigest);
+    expect(reversedReferences.requestDigest).not.toBe(withReferences.requestDigest);
+
     const changedCall = imageGenerationOperationIdentity({
       ...base,
       toolCallId: "call_generate_2",

--- a/apps/worker/test/image-generation-references.test.ts
+++ b/apps/worker/test/image-generation-references.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { resolveImageGenerationReferences } from "../src/activities/image-generation-references";
+
+const PNG_1X1 = Uint8Array.from(
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+  ),
+);
+
+describe("image generation references", () => {
+  test("validates sandbox images and preserves caller order", async () => {
+    const paths: string[] = [];
+    const references = await resolveImageGenerationReferences({
+      db: {} as never,
+      objectStorage: {} as never,
+      workspaceId: "11111111-1111-4111-8111-111111111111",
+      references: [
+        { kind: "sandbox_path", path: "/workspace/first.png" },
+        { kind: "sandbox_path", path: "/workspace/second.png" },
+      ],
+      readSandboxFile: async (path) => {
+        paths.push(path);
+        return PNG_1X1;
+      },
+    });
+
+    expect(paths).toEqual(["/workspace/first.png", "/workspace/second.png"]);
+    expect(references).toHaveLength(2);
+    expect(references.map((reference) => reference.mediaType)).toEqual(["image/png", "image/png"]);
+    expect(references[0]?.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("fails before provider execution when sandbox bytes are not an image", async () => {
+    await expect(
+      resolveImageGenerationReferences({
+        db: {} as never,
+        objectStorage: {} as never,
+        workspaceId: "11111111-1111-4111-8111-111111111111",
+        references: [{ kind: "sandbox_path", path: "/workspace/not-an-image.txt" }],
+        readSandboxFile: async () => new TextEncoder().encode("not an image"),
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/docs/image-generation.md
+++ b/docs/image-generation.md
@@ -37,9 +37,18 @@ Selection is deterministic for the accepted turn:
 
 The ordinary text model and image model are intentionally independent. The
 tool is omitted unless permanent object storage and one verified route above
-are available. Generation currently accepts one bounded text prompt and
-returns one image. Editing, masks, and reference-image inputs are not silently
-emulated.
+are available. Adapter-backed generation accepts one bounded text prompt and
+up to four ordered PNG, JPEG, or WebP references. A reference may be an exact
+`/workspace` path, a workspace File ID, or a generated-image artifact ID. The
+worker resolves workspace ownership, range-reads bounded bytes, validates the
+actual image signature and durable hash, then sends those images in order.
+Arbitrary URLs are never accepted. The prompt states what each ordered image
+contributes. Masks and provider-specific edit controls are not emulated.
+
+Codex subscriptions use `/images/generations` without references and the
+Codex-compatible `/images/edits` request when references are present. Gateway
+uses the pinned v3 image model `files` input. The no-reference request and
+durable operation digest remain byte-for-byte compatible with earlier turns.
 
 The selected text provider does not change the generated-image artifact or UI
 contract. Current route availability is:

--- a/packages/codex/src/images.ts
+++ b/packages/codex/src/images.ts
@@ -8,6 +8,7 @@ const CODEX_IMAGE_RESPONSE_MAX_BYTES = 90 * 1024 * 1024;
 const CODEX_IMAGE_ERROR_MAX_BYTES = 64 * 1024;
 const CODEX_IMAGE_MAX_BYTES = 64 * 1024 * 1024;
 const CODEX_IMAGE_REQUEST_TIMEOUT_MS = 5 * 60_000;
+const CODEX_IMAGE_MAX_REFERENCES = 5;
 
 const codexImageFetch: FetchLike = async (input, init) =>
   await pinnedFetch(
@@ -27,6 +28,11 @@ export type CodexGeneratedImage = {
   bytes: Uint8Array;
   declaredMediaType: "image/png";
 };
+
+export type CodexImageReferenceInput = Readonly<{
+  mediaType: "image/png" | "image/jpeg" | "image/webp";
+  bytes: Uint8Array;
+}>;
 
 export class CodexImageApiError extends Error {
   constructor(
@@ -53,6 +59,7 @@ export class CodexImageRequestTimeoutError extends Error {
  */
 export async function generateCodexSubscriptionImage(input: {
   prompt: string;
+  references?: readonly CodexImageReferenceInput[];
   turnId: string;
   context: Pick<CodexRequestContext, "clientVersion" | "getToken" | "refresh">;
   abortSignal?: AbortSignal;
@@ -65,6 +72,15 @@ export async function generateCodexSubscriptionImage(input: {
   if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
     throw new RangeError("Codex image request timeout must be a positive safe integer");
   }
+  const references = input.references ?? [];
+  if (references.length > CODEX_IMAGE_MAX_REFERENCES) {
+    throw new RangeError(
+      `Codex image editing accepts at most ${CODEX_IMAGE_MAX_REFERENCES} images`,
+    );
+  }
+  for (const reference of references) {
+    if (reference.bytes.byteLength === 0) throw new Error("Codex image reference is empty");
+  }
   const deadline = new AbortController();
   const timer = setTimeout(
     () => deadline.abort(new CodexImageRequestTimeoutError(timeoutMs)),
@@ -75,19 +91,35 @@ export async function generateCodexSubscriptionImage(input: {
     : deadline.signal;
   const request = async (auth: CodexTokenSnapshot): Promise<Response> => {
     const headers = codexImageHeaders(auth, input.context.clientVersion, input.turnId);
-    return await fetchImpl(`${CODEX_RESPONSES_BASE}/images/generations`, {
-      method: "POST",
-      redirect: "error",
-      headers,
-      body: JSON.stringify({
-        prompt: input.prompt,
-        background: "auto",
-        model: CODEX_IMAGE_MODEL,
-        quality: "auto",
-        size: "auto",
-      }),
-      signal,
-    });
+    return await fetchImpl(
+      `${CODEX_RESPONSES_BASE}/${references.length > 0 ? "images/edits" : "images/generations"}`,
+      {
+        method: "POST",
+        redirect: "error",
+        headers,
+        body: JSON.stringify(
+          references.length > 0
+            ? {
+                images: references.map((reference) => ({
+                  image_url: `data:${reference.mediaType};base64,${Buffer.from(reference.bytes).toString("base64")}`,
+                })),
+                prompt: input.prompt,
+                background: "auto",
+                model: CODEX_IMAGE_MODEL,
+                quality: "auto",
+                size: "auto",
+              }
+            : {
+                prompt: input.prompt,
+                background: "auto",
+                model: CODEX_IMAGE_MODEL,
+                quality: "auto",
+                size: "auto",
+              },
+        ),
+        signal,
+      },
+    );
   };
 
   const operation = (async (): Promise<CodexGeneratedImage> => {

--- a/packages/codex/test/images.test.ts
+++ b/packages/codex/test/images.test.ts
@@ -50,6 +50,40 @@ describe("generateCodexSubscriptionImage", () => {
     });
   });
 
+  test("uses the subscription edit endpoint with ordered reference images", async () => {
+    let captured: { url: string; init: RequestInit | undefined } | undefined;
+    await generateCodexSubscriptionImage({
+      prompt: "Use the first image's subject and the second image's style",
+      references: [
+        { mediaType: "image/png", bytes: Uint8Array.from([1, 2, 3]) },
+        { mediaType: "image/jpeg", bytes: Uint8Array.from([4, 5, 6]) },
+      ],
+      turnId: "turn-edit-1",
+      context: {
+        clientVersion: "0.145.0",
+        getToken: async () => token("access-1"),
+        refresh: async () => token("access-2"),
+      },
+      fetch: async (input, init) => {
+        captured = { url: String(input), init };
+        return Response.json({ data: [{ b64_json: "aW1hZ2U=" }] });
+      },
+    });
+
+    expect(captured?.url).toBe(`${CODEX_RESPONSES_BASE}/images/edits`);
+    expect(JSON.parse(String(captured?.init?.body))).toEqual({
+      images: [
+        { image_url: "data:image/png;base64,AQID" },
+        { image_url: "data:image/jpeg;base64,BAUG" },
+      ],
+      prompt: "Use the first image's subject and the second image's style",
+      background: "auto",
+      model: "gpt-image-2",
+      quality: "auto",
+      size: "auto",
+    });
+  });
+
   test("refreshes only after a definitive 401", async () => {
     const authorizations: string[] = [];
     let refreshes = 0;

--- a/packages/contracts/src/image-generation.ts
+++ b/packages/contracts/src/image-generation.ts
@@ -1,10 +1,45 @@
 import { z } from "zod";
 import { RETAINED_OUTPUT_MAX_PAGE_BYTES, RetainedArtifactReferenceSchema } from "./retained-output";
 
+// Codex accepts five references, while the current Gateway GPT Image 2 route
+// accepts four. Keep the provider-neutral tool at the reliable shared limit.
+export const IMAGE_GENERATION_MAX_REFERENCES = 4;
+
+/** One ordered, workspace-owned input used to guide or edit an image. */
+export const ImageGenerationReferenceSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("sandbox_path"),
+      path: z
+        .string()
+        .max(512)
+        .regex(/^\/workspace\/(?!\.{1,2}(?:\/|$))(?!.*\/\.{1,2}(?:\/|$)).+$/),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("file"),
+      fileId: z.string().uuid(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("artifact"),
+      artifactId: z.string().uuid(),
+    })
+    .strict(),
+]);
+export type ImageGenerationReference = z.infer<typeof ImageGenerationReferenceSchema>;
+
 /** Provider-neutral minimum shared by native and adapter-backed image tools. */
 export const GenerateImageToolInput = z
   .object({
     prompt: z.string().trim().min(1).max(32_000),
+    references: z
+      .array(ImageGenerationReferenceSchema)
+      .max(IMAGE_GENERATION_MAX_REFERENCES)
+      .optional()
+      .default([]),
   })
   .strict();
 export type GenerateImageToolInput = z.infer<typeof GenerateImageToolInput>;

--- a/packages/contracts/test/image-generation.test.ts
+++ b/packages/contracts/test/image-generation.test.ts
@@ -1,8 +1,48 @@
 import { describe, expect, test } from "bun:test";
-import { GeneratedImageReceiptSchema } from "../src/image-generation";
+import {
+  GenerateImageToolInput,
+  GeneratedImageReceiptSchema,
+  IMAGE_GENERATION_MAX_REFERENCES,
+} from "../src/image-generation";
 
 const workspaceId = "11111111-1111-4111-8111-111111111111";
 const artifactId = "55555555-5555-4555-8555-555555555555";
+
+describe("GenerateImageToolInput", () => {
+  test("accepts ordered sandbox, File, and generated-artifact references", () => {
+    const input = {
+      prompt: "Use the subject from the first image and style from the second",
+      references: [
+        { kind: "sandbox_path" as const, path: "/workspace/assets/subject.png" },
+        { kind: "file" as const, fileId: "33333333-3333-4333-8333-333333333333" },
+        { kind: "artifact" as const, artifactId },
+      ],
+    };
+    expect(GenerateImageToolInput.parse(input)).toEqual(input);
+  });
+
+  test("defaults to generation without references and rejects unsafe or excessive paths", () => {
+    expect(GenerateImageToolInput.parse({ prompt: "A blue sphere" })).toEqual({
+      prompt: "A blue sphere",
+      references: [],
+    });
+    expect(
+      GenerateImageToolInput.safeParse({
+        prompt: "unsafe",
+        references: [{ kind: "sandbox_path", path: "/workspace/../secret.png" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      GenerateImageToolInput.safeParse({
+        prompt: "too many",
+        references: Array.from({ length: IMAGE_GENERATION_MAX_REFERENCES + 1 }, (_, index) => ({
+          kind: "sandbox_path",
+          path: `/workspace/reference-${index}.png`,
+        })),
+      }).success,
+    ).toBe(false);
+  });
+});
 
 function receipt() {
   return {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1336,7 +1336,10 @@ export type BuildAgentOptions = {
     | { kind: "native_hosted" }
     | {
         kind: "provider_adapter";
-        execute: (input: { prompt: string }, context: { toolCallId: string }) => Promise<unknown>;
+        execute: (
+          input: GenerateImageToolInput,
+          context: { toolCallId: string },
+        ) => Promise<unknown>;
       };
   /** Host-owned durable asynchronous video-generation boundary for this turn. */
   videoGeneration?: {
@@ -1939,7 +1942,7 @@ export function buildOpenGeniAgent(
       ? agentTool({
           name: "generate_image",
           description:
-            "Generate exactly one image from the requested visual description. Use this when the user asks to create an image. The result is a permanent image artifact and its exact sandbox path. Do not call it repeatedly unless the user requested multiple distinct images.",
+            "Generate or edit exactly one image. Optionally provide up to four ordered references using exact /workspace paths, workspace File IDs, or generated-image artifact IDs; describe each reference's role by position in the prompt. The result is a permanent image artifact and its exact sandbox path. Do not call repeatedly unless the user requested multiple distinct images.",
           parameters: GenerateImageToolInput,
           errorFunction: null,
           execute: async (input, _context, details) => {

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -1590,7 +1590,7 @@ describe("multi-provider gating in buildOpenGeniAgent", () => {
       native.tools.some((tool) => tool.type === "function" && tool.name === "generate_image"),
     ).toBe(false);
 
-    const calls: Array<{ prompt: string; toolCallId: string }> = [];
+    const calls: Array<{ prompt: string; references: unknown[]; toolCallId: string }> = [];
     const adapter = buildOpenGeniAgent(settings, [], {
       imageGeneration: {
         kind: "provider_adapter",
@@ -1626,7 +1626,9 @@ describe("multi-provider gating in buildOpenGeniAgent", () => {
         },
       },
     );
-    expect(calls).toEqual([{ prompt: "a blue sphere", toolCallId: "call-image-1" }]);
+    expect(calls).toEqual([
+      { prompt: "a blue sphere", references: [], toolCallId: "call-image-1" },
+    ]);
     expect(output).toEqual({ type: "generated_image", artifact: { artifactId: "artifact-1" } });
   });
 


### PR DESCRIPTION
## Summary
- add ordered sandbox path, workspace file, and generated-image artifact references
- support reference editing through Codex subscriptions and Vercel AI Gateway
- validate ownership, bytes, media type, size, and hash before provider execution
- preserve existing no-reference generation and durable operation identity

## Verification
- targeted image/runtime tests
- full typecheck, lint, formatting, and build
- live reference-image canaries through Codex and Gateway