### PR TITLE
fix(react): keep mobile transcription stop visible

### DIFF
--- a/.changeset/clear-voices-stop.md
+++ b/.changeset/clear-voices-stop.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Keep mobile voice-input Cancel and Stop controls visible while recording in crowded composer footers.

--- a/packages/react/demo/transcription-harness.tsx
+++ b/packages/react/demo/transcription-harness.tsx
@@ -1,4 +1,4 @@
-import type { ClientVoiceInputConfig } from "@opengeni/sdk";
+import type { ClientVoiceInputConfig, EffectiveSessionControl } from "@opengeni/sdk";
 import { useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { ChatComposer, type ComposerState } from "@opengeni/react";
@@ -9,6 +9,7 @@ type FixtureMode = "normal" | "denied" | "hanging";
 const params = new URLSearchParams(window.location.search);
 const theme = params.get("theme") === "light" ? "light" : "dark";
 const requestedMode = params.get("mode");
+const crowdedChrome = params.get("chrome") === "crowded";
 const initialMode: FixtureMode =
   requestedMode === "denied" || requestedMode === "hanging" ? requestedMode : "normal";
 if (theme === "light") document.documentElement.dataset.ogTheme = "light";
@@ -19,6 +20,19 @@ const capability: ClientVoiceInputConfig = {
   maxDurationSeconds: 60,
   maxSizeBytes: 25 * 1024 * 1024,
   acceptedMimeTypes: ["audio/webm", "audio/webm;codecs=opus", "audio/mp4", "audio/ogg;codecs=opus"],
+};
+
+const activeControl: EffectiveSessionControl = {
+  state: "active",
+  controlVersion: 0,
+  controlEtag: "active",
+  directState: "active",
+  primaryBlocker: null,
+  additionalBlockerCount: 0,
+  blockers: [],
+  resumeOptions: [],
+  override: null,
+  settlement: null,
 };
 
 class FixtureMediaRecorder {
@@ -168,12 +182,46 @@ function App() {
       {sent ? <p>Sent: {sent}</p> : null}
       <ChatComposer
         composer={composer}
+        effectiveControl={crowdedChrome ? activeControl : undefined}
         transcription={{
           client: client as never,
           workspaceId: "11111111-1111-4111-8111-111111111111",
           capability,
           workspaceEnabled: true,
         }}
+        controlsLeading={
+          crowdedChrome ? (
+            <button
+              type="button"
+              aria-label="Open composer tools"
+              className="inline-flex size-8 shrink-0 items-center justify-center rounded-og-md border border-og-border pointer-coarse:size-11"
+            >
+              +
+            </button>
+          ) : undefined
+        }
+        controlsStart={
+          crowdedChrome ? (
+            <button
+              type="button"
+              aria-label="Model and effort"
+              className="inline-flex h-8 min-w-24 shrink-0 items-center justify-center rounded-og-md border border-og-border px-2 text-og-xs pointer-coarse:h-11"
+            >
+              Model
+            </button>
+          ) : undefined
+        }
+        actionsStart={
+          crowdedChrome ? (
+            <button
+              type="button"
+              aria-label="Start realtime voice"
+              className="inline-flex size-8 shrink-0 items-center justify-center rounded-og-md border border-og-border pointer-coarse:size-11"
+            >
+              R
+            </button>
+          ) : undefined
+        }
       />
     </main>
   );

--- a/packages/react/src/components/composer-transcription-control.tsx
+++ b/packages/react/src/components/composer-transcription-control.tsx
@@ -143,6 +143,7 @@ export function ComposerTranscriptionControl({
   });
   const { status } = transcription;
   const retrying = status === "retrying";
+  const capturing = status === "requesting-permission" || status === "recording";
 
   const cancelTranscription = transcription.cancel;
   useEffect(() => {
@@ -151,11 +152,7 @@ export function ComposerTranscriptionControl({
       cancelTranscription();
     }
   }, [cancelTranscription, status, suppressed]);
-  const active =
-    status === "requesting-permission" ||
-    status === "recording" ||
-    status === "saving" ||
-    status === "transcribing";
+  const active = capturing || status === "saving" || status === "transcribing";
   const recoverable =
     transcription.hasRecoverableRecording &&
     (retrying || status === "recovered" || status === "transcript-ready" || status === "error");
@@ -207,8 +204,15 @@ export function ComposerTranscriptionControl({
           animate={{ opacity: 1, width: "auto" }}
           exit={{ opacity: 0, width: 0 }}
           transition={{ duration: 0.36, ease: [0.22, 1, 0.36, 1] }}
-          className={cn("inline-flex min-w-0 overflow-hidden", className)}
+          className={cn(
+            "inline-flex min-w-0 overflow-hidden",
+            // Mobile capture mode reserves the footer for this control. Keep the
+            // shell itself from shrinking and clipping its trailing actions.
+            capturing && "shrink-0",
+            className,
+          )}
           data-transcription-status={status}
+          data-transcription-capturing={capturing ? "" : undefined}
         >
           <span className="inline-flex min-w-0 items-center gap-1.5">
             <AnimatePresence mode="popLayout" initial={false}>

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -5026,6 +5026,14 @@
     animation-delay: 0ms !important;
   }
 }
+@media (max-width: 39.999rem) {
+  :where(.og-root).og-composer-footer:has([data-transcription-capturing]) .og-composer-controls > :not([data-transcription-capturing]),:where(.og-root) .og-composer-footer:has([data-transcription-capturing]) .og-composer-controls > :not([data-transcription-capturing]) {
+    display: none;
+  }
+  :where(.og-root).og-composer-footer:has([data-transcription-capturing]) .og-composer-actions,:where(.og-root) .og-composer-footer:has([data-transcription-capturing]) .og-composer-actions {
+    display: none;
+  }
+}
 @media (forced-colors: active) {
   :where(.og-root) {
     --og-color-bg: Canvas;
@@ -5181,6 +5189,12 @@
     border-radius: var(--og-radius-md);
   }
   :where(.og-root)[data-og-responsive-basis="container"] .og-realtime-control[data-model-menu="split-desktop"] .og-realtime-model-trigger,:where(.og-root) [data-og-responsive-basis="container"] .og-realtime-control[data-model-menu="split-desktop"] .og-realtime-model-trigger {
+    display: none;
+  }
+  :where(.og-root)[data-og-responsive-basis="container"] .og-composer-footer:has([data-transcription-capturing]) .og-composer-controls > :not([data-transcription-capturing]),:where(.og-root) [data-og-responsive-basis="container"] .og-composer-footer:has([data-transcription-capturing]) .og-composer-controls > :not([data-transcription-capturing]) {
+    display: none;
+  }
+  :where(.og-root)[data-og-responsive-basis="container"] .og-composer-footer:has([data-transcription-capturing]) .og-composer-actions,:where(.og-root) [data-og-responsive-basis="container"] .og-composer-footer:has([data-transcription-capturing]) .og-composer-actions {
     display: none;
   }
 }

--- a/packages/react/styles/index.css
+++ b/packages/react/styles/index.css
@@ -475,6 +475,21 @@
   }
 }
 
+/* A phone footer cannot fit capture chrome beside model, realtime, Pause, and
+   Send controls. While voice input owns the microphone, reserve the row for its
+   Cancel/Stop actions so unrelated Pause chrome cannot masquerade as Stop. */
+@media (max-width: 39.999rem) {
+  .og-composer-footer:has([data-transcription-capturing])
+    .og-composer-controls
+    > :not([data-transcription-capturing]) {
+    display: none;
+  }
+
+  .og-composer-footer:has([data-transcription-capturing]) .og-composer-actions {
+    display: none;
+  }
+}
+
 @media (forced-colors: active) {
   /* Forced-colors can replace a painted background with Canvas while custom
      properties retain their authored dark/light values. That combination is

--- a/packages/react/styles/responsive.css
+++ b/packages/react/styles/responsive.css
@@ -147,6 +147,19 @@
     .og-realtime-model-trigger {
     display: none;
   }
+
+  [data-og-responsive-basis="container"]
+    .og-composer-footer:has([data-transcription-capturing])
+    .og-composer-controls
+    > :not([data-transcription-capturing]) {
+    display: none;
+  }
+
+  [data-og-responsive-basis="container"]
+    .og-composer-footer:has([data-transcription-capturing])
+    .og-composer-actions {
+    display: none;
+  }
 }
 
 @container og-composer (max-width: 24.999rem) {
@@ -193,4 +206,3 @@
   );
   max-width: calc(100vw - 1rem);
 }
-

--- a/test/e2e/transcription.browser.e2e.ts
+++ b/test/e2e/transcription.browser.e2e.ts
@@ -159,6 +159,97 @@ describe("native composer voice-input browser acceptance", () => {
     await context.close();
   });
 
+  test("mobile recording keeps Cancel and Stop visible in a crowded composer", async () => {
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      hasTouch: true,
+      isMobile: true,
+      reducedMotion: "reduce",
+    });
+    const page = await context.newPage();
+    await page.goto(`${baseUrl}/transcription.html?theme=dark&chrome=crowded`, {
+      waitUntil: "networkidle",
+    });
+
+    await page.getByRole("button", { name: "Start voice input" }).click();
+    const stop = page.getByRole("button", { name: "Stop and transcribe" });
+    const cancel = page.getByRole("button", { name: "Cancel recording" });
+    await stop.waitFor();
+
+    const audit = await page.locator(".og-composer-footer").evaluate((footer) => {
+      const button = (label: string) =>
+        footer.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+      const stopButton = button("Stop and transcribe");
+      const cancelButton = button("Cancel recording");
+      const stopRect = stopButton?.getBoundingClientRect();
+      const cancelRect = cancelButton?.getBoundingClientRect();
+      const footerRect = footer.getBoundingClientRect();
+      const transcriptionRect = footer
+        .querySelector<HTMLElement>("[data-transcription-capturing]")
+        ?.getBoundingClientRect();
+      const visible = (label: string) => {
+        const element = footer.querySelector<HTMLElement>(`button[aria-label="${label}"]`);
+        return element?.checkVisibility() ?? null;
+      };
+      return {
+        overflow: footer.scrollWidth - footer.clientWidth,
+        stop: stopRect
+          ? {
+              width: stopButton?.offsetWidth ?? 0,
+              height: stopButton?.offsetHeight ?? 0,
+              fullyVisible:
+                stopRect.left >= footerRect.left &&
+                stopRect.right <= footerRect.right &&
+                transcriptionRect !== undefined &&
+                stopRect.left >= transcriptionRect.left &&
+                stopRect.right <= transcriptionRect.right,
+            }
+          : null,
+        cancel: cancelRect
+          ? {
+              width: cancelButton?.offsetWidth ?? 0,
+              height: cancelButton?.offsetHeight ?? 0,
+              fullyVisible:
+                cancelRect.left >= footerRect.left &&
+                cancelRect.right <= footerRect.right &&
+                transcriptionRect !== undefined &&
+                cancelRect.left >= transcriptionRect.left &&
+                cancelRect.right <= transcriptionRect.right,
+            }
+          : null,
+        toolsVisible: visible("Open composer tools"),
+        modelVisible: visible("Model and effort"),
+        realtimeVisible: visible("Start realtime voice"),
+        pauseVisible: visible("Pause this workstream"),
+        sendVisible: visible("Send message"),
+      };
+    });
+
+    expect(audit.overflow).toBeLessThanOrEqual(1);
+    expect(audit.stop?.fullyVisible).toBe(true);
+    expect(audit.cancel?.fullyVisible).toBe(true);
+    expect(Math.min(audit.stop?.width ?? 0, audit.stop?.height ?? 0)).toBeGreaterThanOrEqual(44);
+    expect(Math.min(audit.cancel?.width ?? 0, audit.cancel?.height ?? 0)).toBeGreaterThanOrEqual(
+      44,
+    );
+    expect(audit.toolsVisible).toBe(false);
+    expect(audit.modelVisible).toBe(false);
+    expect(audit.realtimeVisible).toBe(false);
+    expect(audit.pauseVisible).toBe(false);
+    expect(audit.sendVisible).toBe(false);
+
+    await cancel.click();
+    await page.getByRole("button", { name: "Start voice input" }).waitFor();
+    expect(await page.getByRole("button", { name: "Open composer tools" }).isVisible()).toBe(true);
+    expect(await page.getByRole("button", { name: "Model and effort" }).isVisible()).toBe(true);
+    expect(await page.getByRole("button", { name: "Start realtime voice" }).isVisible()).toBe(true);
+    expect(await page.getByRole("button", { name: "Pause this workstream" }).isVisible()).toBe(
+      true,
+    );
+    expect(await page.getByRole("button", { name: "Send message" }).isVisible()).toBe(true);
+    await context.close();
+  });
+
   test("reload recovers a timesliced recording without reopening the microphone", async () => {
     const context = await browser.newContext({ viewport: { width: 768, height: 960 } });
     const page = await context.newPage();


### PR DESCRIPTION
## Summary

- keep mobile voice-input Cancel and Stop fully visible in crowded composer footers
- reserve the mobile footer for recording controls, then restore normal controls after capture
- add a 390×844 touch-layout regression and React package changeset

## Testing

- [x] `bun run typecheck`
- [x] `bun run --cwd packages/react build`
- [x] `bun run --cwd apps/web build`
- [x] 40 targeted React/composer tests
- [x] mobile transcription browser regression
- [x] phone-width browser visual/error check

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] Rebased on current `main` before push.
