### PR TITLE
ci: share browser build work across architectures

### DIFF
--- a/docker/desktop.Dockerfile
+++ b/docker/desktop.Dockerfile
@@ -26,29 +26,13 @@ RUN set -eux; \
     mkdir -p /out; \
     install -m 0755 target/release/opengeni-computer-native /out/opengeni-computer-native
 
-FROM oven/bun:1.3.14 AS browserd-build
+FROM oven/bun:1.3.14 AS bun-runtime
 
-ARG TARGETARCH
+FROM --platform=$BUILDPLATFORM oven/bun:1.3.14 AS browserd-build
+
 WORKDIR /src
 COPY . .
 RUN bun install --frozen-lockfile
-RUN set -eux; \
-    cd packages/browserd; \
-    bun run build:binary; \
-    mkdir -p /out; \
-    install -m 0755 dist/opengeni-browserd /out/opengeni-browserd; \
-    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
-    case "$arch" in \
-      amd64) native=agent-browser-linux-x64; expected=b7bc3dfcf0a7326c1f5a60423163259ba2349eebfa5bd2e70e111af743da4a49 ;; \
-      arm64) native=agent-browser-linux-arm64; expected=6ccaba1eb26a0e6f5c23c59d2c63e6e0237fde82713cfdb543ba506490cac9c1 ;; \
-      *) echo "unsupported browser controller architecture=${arch}" >&2; exit 1 ;; \
-    esac; \
-    install -m 0755 "node_modules/agent-browser/bin/${native}" /out/agent-browser; \
-    test "$(sha256sum /out/agent-browser | awk '{print $1}')" = "$expected"; \
-    { \
-      printf '%s  %s\n' "$(sha256sum /out/opengeni-browserd | awk '{print $1}')" /usr/local/bin/opengeni-browserd; \
-      printf '%s  %s\n' "$expected" /usr/local/lib/opengeni/agent-browser; \
-    } > /out/SHA256SUMS
 
 # Install the exact lock-resolved Codemode package closure for ordinary Bun
 # programs. The CLI and imported module therefore share source, catalog rules,
@@ -72,6 +56,27 @@ RUN set -eux; \
     test -f "$runtime/node_modules/@opengeni/codemode/src/index.ts"
 
 RUN cd packages/ogtool && bun run build
+
+ARG TARGETARCH
+COPY --from=bun-runtime /usr/local/bin/bun /tmp/opengeni-target-bun
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "$arch" in \
+      amd64) native=agent-browser-linux-x64; expected=b7bc3dfcf0a7326c1f5a60423163259ba2349eebfa5bd2e70e111af743da4a49 ;; \
+      arm64) native=agent-browser-linux-arm64; expected=6ccaba1eb26a0e6f5c23c59d2c63e6e0237fde82713cfdb543ba506490cac9c1 ;; \
+      *) echo "unsupported browser controller architecture=${arch}" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /out; \
+    bun build --compile --compile-executable-path=/tmp/opengeni-target-bun \
+      packages/browserd/src/main.ts \
+      --outfile /out/opengeni-browserd; \
+    chmod 0755 /out/opengeni-browserd; \
+    install -m 0755 "node_modules/agent-browser/bin/${native}" /out/agent-browser; \
+    test "$(sha256sum /out/agent-browser | awk '{print $1}')" = "$expected"; \
+    { \
+      printf '%s  %s\n' "$(sha256sum /out/opengeni-browserd | awk '{print $1}')" /usr/local/bin/opengeni-browserd; \
+      printf '%s  %s\n' "$expected" /usr/local/lib/opengeni/agent-browser; \
+    } > /out/SHA256SUMS
 
 COPY --from=computer-native-build /out/opengeni-computer-native /out/opengeni-computer-native
 RUN printf '%s  %s\n' \
@@ -320,7 +325,7 @@ COPY docker/opengeni-git-askpass              /usr/local/bin/opengeni-git-askpas
 COPY packages/ogtool/package.json             /opt/opengeni/ogtool/package.json
 COPY --from=browserd-build /src/packages/ogtool/dist/bin/ogtool.cjs /opt/opengeni/ogtool/bin/ogtool.cjs
 COPY --from=browserd-build /out/opengeni-browserd /usr/local/bin/opengeni-browserd
-COPY --from=browserd-build /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=bun-runtime /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=browserd-build /out/agent-browser /usr/local/lib/opengeni/agent-browser
 COPY --from=browserd-build /out/opengeni-computer-native /usr/local/lib/opengeni/opengeni-computer-native
 COPY --from=browserd-build /out/SHA256SUMS /usr/local/share/opengeni/browserd-SHA256SUMS

--- a/docker/desktop.Dockerfile
+++ b/docker/desktop.Dockerfile
@@ -71,7 +71,7 @@ RUN set -eux; \
       packages/browserd/src/main.ts \
       --outfile /out/opengeni-browserd; \
     chmod 0755 /out/opengeni-browserd; \
-    install -m 0755 "node_modules/agent-browser/bin/${native}" /out/agent-browser; \
+    install -m 0755 "packages/browserd/node_modules/agent-browser/bin/${native}" /out/agent-browser; \
     test "$(sha256sum /out/agent-browser | awk '{print $1}')" = "$expected"; \
     { \
       printf '%s  %s\n' "$(sha256sum /out/opengeni-browserd | awk '{print $1}')" /usr/local/bin/opengeni-browserd; \

--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -51,7 +51,7 @@ RUN set -eux; \
       packages/browserd/src/main.ts \
       --outfile /out/opengeni-browserd; \
     chmod 0755 /out/opengeni-browserd; \
-    install -m 0755 "node_modules/agent-browser/bin/${native}" /out/agent-browser; \
+    install -m 0755 "packages/browserd/node_modules/agent-browser/bin/${native}" /out/agent-browser; \
     test "$(sha256sum /out/agent-browser | awk '{print $1}')" = "$expected"; \
     { \
       printf '%s  %s\n' "$(sha256sum /out/opengeni-browserd | awk '{print $1}')" /usr/local/bin/opengeni-browserd; \

--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -6,29 +6,13 @@ RUN set -eux; \
     python -m venv /opt/checkov; \
     /opt/checkov/bin/pip install --no-cache-dir "checkov==${CHECKOV_VERSION}"
 
-FROM oven/bun:1.3.14 AS browserd-build
+FROM oven/bun:1.3.14 AS bun-runtime
 
-ARG TARGETARCH
+FROM --platform=$BUILDPLATFORM oven/bun:1.3.14 AS browserd-build
+
 WORKDIR /src
 COPY . .
 RUN bun install --frozen-lockfile
-RUN set -eux; \
-    cd packages/browserd; \
-    bun run build:binary; \
-    mkdir -p /out; \
-    install -m 0755 dist/opengeni-browserd /out/opengeni-browserd; \
-    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
-    case "$arch" in \
-      amd64) native=agent-browser-linux-x64; expected=b7bc3dfcf0a7326c1f5a60423163259ba2349eebfa5bd2e70e111af743da4a49 ;; \
-      arm64) native=agent-browser-linux-arm64; expected=6ccaba1eb26a0e6f5c23c59d2c63e6e0237fde82713cfdb543ba506490cac9c1 ;; \
-      *) echo "unsupported browser controller architecture=${arch}" >&2; exit 1 ;; \
-    esac; \
-    install -m 0755 "node_modules/agent-browser/bin/${native}" /out/agent-browser; \
-    test "$(sha256sum /out/agent-browser | awk '{print $1}')" = "$expected"; \
-    { \
-      printf '%s  %s\n' "$(sha256sum /out/opengeni-browserd | awk '{print $1}')" /usr/local/bin/opengeni-browserd; \
-      printf '%s  %s\n' "$expected" /usr/local/lib/opengeni/agent-browser; \
-    } > /out/SHA256SUMS
 
 # Install the exact lock-resolved Codemode package closure for ordinary Bun
 # programs. The CLI and imported module therefore share source, catalog rules,
@@ -52,6 +36,27 @@ RUN set -eux; \
     test -f "$runtime/node_modules/@opengeni/codemode/src/index.ts"
 
 RUN cd packages/ogtool && bun run build
+
+ARG TARGETARCH
+COPY --from=bun-runtime /usr/local/bin/bun /tmp/opengeni-target-bun
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "$arch" in \
+      amd64) native=agent-browser-linux-x64; expected=b7bc3dfcf0a7326c1f5a60423163259ba2349eebfa5bd2e70e111af743da4a49 ;; \
+      arm64) native=agent-browser-linux-arm64; expected=6ccaba1eb26a0e6f5c23c59d2c63e6e0237fde82713cfdb543ba506490cac9c1 ;; \
+      *) echo "unsupported browser controller architecture=${arch}" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /out; \
+    bun build --compile --compile-executable-path=/tmp/opengeni-target-bun \
+      packages/browserd/src/main.ts \
+      --outfile /out/opengeni-browserd; \
+    chmod 0755 /out/opengeni-browserd; \
+    install -m 0755 "node_modules/agent-browser/bin/${native}" /out/agent-browser; \
+    test "$(sha256sum /out/agent-browser | awk '{print $1}')" = "$expected"; \
+    { \
+      printf '%s  %s\n' "$(sha256sum /out/opengeni-browserd | awk '{print $1}')" /usr/local/bin/opengeni-browserd; \
+      printf '%s  %s\n' "$expected" /usr/local/lib/opengeni/agent-browser; \
+    } > /out/SHA256SUMS
 
 FROM node:22.22.0-bookworm-slim AS node-runtime
 
@@ -158,7 +163,7 @@ RUN set -eux; \
 # ogtool requires a supported Node runtime. Ordinary typed Codemode programs
 # use the exact Bun binary from the already-pinned build image.
 COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
-COPY --from=browserd-build /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=bun-runtime /usr/local/bin/bun /usr/local/bin/bun
 RUN test "$(node --version)" = "v22.22.0"
 
 RUN set -eux; \

--- a/scripts/browserd-image-build-contract.test.ts
+++ b/scripts/browserd-image-build-contract.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dir, "..");
+const imagePaths = ["docker/sandbox.Dockerfile", "docker/desktop.Dockerfile"] as const;
+
+function buildsBrowserControllerOnBuildPlatform(dockerfile: string): boolean {
+  const buildStage = dockerfile.indexOf(
+    "FROM --platform=$BUILDPLATFORM oven/bun:1.3.14 AS browserd-build",
+  );
+  const sourceCopy = dockerfile.indexOf("COPY . .", buildStage);
+  const install = dockerfile.indexOf("RUN bun install --frozen-lockfile", buildStage);
+  const codemode = dockerfile.indexOf("runtime=/out/codemode-runtime", buildStage);
+  const ogtool = dockerfile.indexOf("RUN cd packages/ogtool && bun run build", buildStage);
+  const targetArchitecture = dockerfile.indexOf("\nARG TARGETARCH\n", buildStage);
+  const targetCompiler = dockerfile.indexOf(
+    "COPY --from=bun-runtime /usr/local/bin/bun /tmp/opengeni-target-bun",
+    targetArchitecture,
+  );
+  const crossCompile = dockerfile.indexOf(
+    "bun build --compile --compile-executable-path=/tmp/opengeni-target-bun",
+    targetCompiler,
+  );
+  const nextStage = dockerfile.indexOf("\nFROM ", crossCompile);
+  const bunRuntime = dockerfile.indexOf("FROM oven/bun:1.3.14 AS bun-runtime");
+  const targetBunCopy = dockerfile.indexOf(
+    "COPY --from=bun-runtime /usr/local/bin/bun /usr/local/bin/bun",
+    nextStage,
+  );
+
+  return (
+    buildStage >= 0 &&
+    sourceCopy > buildStage &&
+    install > sourceCopy &&
+    codemode > install &&
+    ogtool > codemode &&
+    targetArchitecture > ogtool &&
+    targetCompiler > targetArchitecture &&
+    crossCompile > targetCompiler &&
+    nextStage > crossCompile &&
+    bunRuntime >= 0 &&
+    bunRuntime < buildStage &&
+    targetBunCopy > nextStage &&
+    !dockerfile.includes("COPY --from=browserd-build /usr/local/bin/bun /usr/local/bin/bun")
+  );
+}
+
+describe("browser controller image build contract", () => {
+  for (const imagePath of imagePaths) {
+    test(`${imagePath} shares build-platform work before target-specific compilation`, async () => {
+      const dockerfile = await readFile(resolve(root, imagePath), "utf8");
+
+      expect(buildsBrowserControllerOnBuildPlatform(dockerfile)).toBe(true);
+
+      const targetSpecificInstall = dockerfile.replace(
+        "FROM --platform=$BUILDPLATFORM oven/bun:1.3.14 AS browserd-build\n\nWORKDIR /src",
+        "FROM --platform=$BUILDPLATFORM oven/bun:1.3.14 AS browserd-build\n\nARG TARGETARCH\nWORKDIR /src",
+      );
+      const emulatedBuilder = dockerfile.replace(
+        "FROM --platform=$BUILDPLATFORM oven/bun:1.3.14 AS browserd-build",
+        "FROM oven/bun:1.3.14 AS browserd-build",
+      );
+
+      expect(buildsBrowserControllerOnBuildPlatform(targetSpecificInstall)).toBe(false);
+      expect(buildsBrowserControllerOnBuildPlatform(emulatedBuilder)).toBe(false);
+    });
+  }
+});

--- a/scripts/browserd-image-build-contract.test.ts
+++ b/scripts/browserd-image-build-contract.test.ts
@@ -22,7 +22,11 @@ function buildsBrowserControllerOnBuildPlatform(dockerfile: string): boolean {
     "bun build --compile --compile-executable-path=/tmp/opengeni-target-bun",
     targetCompiler,
   );
-  const nextStage = dockerfile.indexOf("\nFROM ", crossCompile);
+  const targetController = dockerfile.indexOf(
+    'install -m 0755 "packages/browserd/node_modules/agent-browser/bin/${native}"',
+    crossCompile,
+  );
+  const nextStage = dockerfile.indexOf("\nFROM ", targetController);
   const bunRuntime = dockerfile.indexOf("FROM oven/bun:1.3.14 AS bun-runtime");
   const targetBunCopy = dockerfile.indexOf(
     "COPY --from=bun-runtime /usr/local/bin/bun /usr/local/bin/bun",
@@ -38,7 +42,8 @@ function buildsBrowserControllerOnBuildPlatform(dockerfile: string): boolean {
     targetArchitecture > ogtool &&
     targetCompiler > targetArchitecture &&
     crossCompile > targetCompiler &&
-    nextStage > crossCompile &&
+    targetController > crossCompile &&
+    nextStage > targetController &&
     bunRuntime >= 0 &&
     bunRuntime < buildStage &&
     targetBunCopy > nextStage &&


### PR DESCRIPTION
## Summary

- run the architecture-neutral `browserd-build` dependency install, Codemode closure, and ogtool build once on `$BUILDPLATFORM`
- cross-compile each target browserd executable with the exact pinned target-platform Bun binary via `--compile-executable-path`
- preserve target-specific agent-browser selection/digests, final runtime Bun architecture, and image checksum verification
- add a planted-negative Dockerfile contract covering both sandbox and desktop images

## OPE-27 timing evidence

Current-main baseline: `dcfe6eb09aead5ba823cd768e645da3ad7fffc29` (`Build Codemode browser, computer, and artifact collaboration (#1316)`). Its natural CI run `31436122949` completed the sandbox image job `93612101718` in **943 seconds** before the separate main-only monolithic safety job was cancelled at its 30-minute limit.

The cold multi-architecture log showed the newly duplicated browser build work on both targets, including:

- `bun install`: 30.2s on amd64 and 72.0s on arm64/QEMU
- ogtool build: 56.6s on arm64/QEMU
- target-specific browserd compilation and controller selection after those shared steps

This change moves the install, Codemode closure, and ogtool build ahead of `ARG TARGETARCH` in a `$BUILDPLATFORM` stage. The target-specific suffix copies the exact pinned target Bun and uses it as the compiled executable template. The measurable expectation is to eliminate the duplicate arm64/QEMU install and architecture-neutral build work (at least the observed 128.6s from arm64 install + ogtool), without weakening any gate. Exact-head CI must still prove valid amd64/arm64 binaries and all final checksums.

## Validation

- `bun test scripts/browserd-image-build-contract.test.ts scripts/release-image-workflow-contract.test.ts scripts/dev-stack-artifact-runtime.test.ts` — 25 pass, 0 fail
- `bun test packages/browserd/test` — 68 pass, 8 expected e2e skips, 0 fail
- `bun run --cwd packages/browserd typecheck`
- `bun run typecheck`
- `bun run lint` — 0 warnings/errors
- `bun run format:check`
- structured Dockerfile parse for both edited images
- Checkov parsed/scanned both edited Dockerfiles with only the existing baseline findings
- local Bun 1.3.14 cross-compile proof produced valid x86-64 and aarch64 ELF executables using the exact corresponding Bun runtime binaries

Docker/Buildx is not installed in the workspace rig, so the real multi-architecture image build and timing proof is intentionally delegated to exact-head CI.

No release or deployment is included.

Linear: OPE-27
