### PR TITLE
ci: coalesce artifact workload apt installs

### DIFF
--- a/docker/opengeni.Dockerfile
+++ b/docker/opengeni.Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.14 AS base
+FROM oven/bun:1.3.14 AS source-base
 
 WORKDIR /app
 
@@ -42,11 +42,17 @@ RUN bun install --frozen-lockfile
 
 COPY --chown=bun:bun . .
 
+ENV NODE_ENV=production
+USER bun
+
+# Most workloads share the same network/source-control tools. Keep that stable
+# package layer reusable, while artifact-runtime workloads inherit source-base
+# directly and install their complete target-specific package union once.
+FROM source-base AS base
+USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates git openssh-client \
   && rm -rf /var/lib/apt/lists/*
-
-ENV NODE_ENV=production
 USER bun
 
 FROM base AS northstar-demo-build
@@ -62,7 +68,7 @@ CMD ["bun", "run", "--cwd", "examples/northstar-support", "start"]
 # architecture at `.release/artifact-runtime/<amd64|arm64>/`. The bundle is
 # root-owned/read-only, and both API and materializer image builds fail before
 # publication if its complete release/install chain or facade probe is invalid.
-FROM base AS artifact-runtime-base
+FROM source-base AS artifact-runtime-base
 ARG TARGETARCH
 ARG OPENGENI_ARTIFACT_RUNTIME_BUNDLE=.release/artifact-runtime
 USER root
@@ -87,7 +93,7 @@ RUN bun packages/artifact-tool/src/runtime-cli-entry.ts doctor --json
 FROM artifact-runtime-base AS api
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ffmpeg \
+  && apt-get install -y --no-install-recommends ca-certificates ffmpeg git openssh-client \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 RUN bun scripts/build-runtime-processes.ts api
@@ -140,7 +146,7 @@ CMD ["bun", "apps/worker/dist/process/artifact-outbox/artifact-outbox-entry.js"]
 FROM artifact-runtime-base AS artifact-materializer
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends bubblewrap util-linux \
+  && apt-get install -y --no-install-recommends bubblewrap ca-certificates git openssh-client util-linux \
   && rm -rf /var/lib/apt/lists/* \
   && install -d -o bun -g bun -m 0755 /opt/opengeni/bin
 USER bun

--- a/scripts/workload-image-system-packages-contract.test.ts
+++ b/scripts/workload-image-system-packages-contract.test.ts
@@ -1,0 +1,78 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function stage(source: string, name: string): string {
+  const marker = new RegExp(`^FROM\\s+.+\\s+AS\\s+${name}$`, "mu");
+  const match = marker.exec(source);
+  if (!match) return "";
+  const next = source.slice(match.index + match[0].length).search(/^FROM\s+/mu);
+  return next < 0
+    ? source.slice(match.index)
+    : source.slice(match.index, match.index + match[0].length + next);
+}
+
+function aptTransactions(source: string): number {
+  return source.match(/RUN apt-get update/gmu)?.length ?? 0;
+}
+
+function keepsArtifactWorkloadPackagesCoalesced(source: string): boolean {
+  const sourceBase = stage(source, "source-base");
+  const base = stage(source, "base");
+  const artifactRuntimeBase = stage(source, "artifact-runtime-base");
+  const api = stage(source, "api");
+  const materializer = stage(source, "artifact-materializer");
+
+  return (
+    sourceBase.startsWith("FROM oven/bun:1.3.14 AS source-base") &&
+    sourceBase.includes("RUN bun install --frozen-lockfile") &&
+    aptTransactions(sourceBase) === 0 &&
+    base.startsWith("FROM source-base AS base") &&
+    aptTransactions(base) === 1 &&
+    base.includes(
+      "apt-get install -y --no-install-recommends ca-certificates git openssh-client",
+    ) &&
+    artifactRuntimeBase.startsWith("FROM source-base AS artifact-runtime-base") &&
+    aptTransactions(artifactRuntimeBase) === 0 &&
+    artifactRuntimeBase.includes(
+      "RUN bun packages/artifact-tool/src/runtime-cli-entry.ts doctor --json",
+    ) &&
+    aptTransactions(api) === 1 &&
+    api.includes(
+      "apt-get install -y --no-install-recommends ca-certificates ffmpeg git openssh-client",
+    ) &&
+    aptTransactions(materializer) === 1 &&
+    materializer.includes(
+      "apt-get install -y --no-install-recommends bubblewrap ca-certificates git openssh-client util-linux",
+    )
+  );
+}
+
+describe("workload image system package contract", () => {
+  test("coalesces artifact-runtime workload packages without weakening their runtime base", async () => {
+    const dockerfile = await readFile(resolve(root, "docker/opengeni.Dockerfile"), "utf8");
+
+    expect(keepsArtifactWorkloadPackagesCoalesced(dockerfile)).toBe(true);
+
+    const inheritedCommonInstall = dockerfile.replace(
+      "FROM source-base AS artifact-runtime-base",
+      "FROM base AS artifact-runtime-base",
+    );
+    expect(keepsArtifactWorkloadPackagesCoalesced(inheritedCommonInstall)).toBe(false);
+
+    const missingApiRuntimeTools = dockerfile.replace(
+      "ca-certificates ffmpeg git openssh-client",
+      "ffmpeg",
+    );
+    expect(keepsArtifactWorkloadPackagesCoalesced(missingApiRuntimeTools)).toBe(false);
+
+    const duplicateApiTransaction = dockerfile.replace(
+      "FROM artifact-runtime-base AS api\n",
+      "FROM artifact-runtime-base AS api\nRUN apt-get update && rm -rf /var/lib/apt/lists/*\n",
+    );
+    expect(keepsArtifactWorkloadPackagesCoalesced(duplicateApiTransaction)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- split the workload source/dependency stage from the reusable common system-package stage
- let artifact-runtime workloads inherit the source stage directly
- install the API and materializer's unchanged complete package unions in one APT transaction each
- preserve the exact artifact-runtime target mapping, read-only bundle, doctor, runtime commands, and all final workload packages
- add a planted-negative structural contract for the one-APT topology and package closure

## Measured bottleneck

Natural-main API image job `93648581596` spent:

- `106.9s` in the inherited arm64 `ca-certificates git openssh-client` APT layer
- `158.8s` in the arm64 API `ffmpeg` APT layer

Exact PR #1320 API job `93641618746` showed the same shape:

- `111.9s` inherited common APT
- `160.9s` API ffmpeg APT

This change removes the inherited common APT transaction from the API and materializer target graphs while retaining the same package union in their single target-specific install. Exact-head job `93655992105` measured the combined arm64 API APT transaction at `232.9s`, versus `272.8s` across the two separate arm64 transactions in exact PR #1320 job `93641618746`: an attributable structural saving of `39.9s`. The full API image job improved from `349s` to `302s` (`47s`). The larger natural-main comparison is not claimed as attributable because cache/export paths differ.

## Safety / non-overlap

- no workflow or required-check topology changes
- no gate, architecture, target, doctor, checksum, publication, or deployment changes
- no overlap with open PR #1306, which owns `.github/workflows/ci.yml` and `scripts/release-image-workflow-contract.test.ts`
- `artifact-runtime-base` still verifies the exact OCI-specific bundle and runs the facade doctor before either final workload stage
- API retains `ca-certificates`, `ffmpeg`, `git`, and `openssh-client`
- materializer retains `bubblewrap`, `ca-certificates`, `git`, `openssh-client`, and `util-linux`

## Local verification

- `bun test scripts/workload-image-system-packages-contract.test.ts scripts/release-image-workflow-contract.test.ts scripts/artifact-runtime-workflow-contract.test.ts scripts/browserd-image-build-contract.test.ts` — 25 pass
- `bun run typecheck` — all 29 projects clean
- `bun run lint` — 0 warnings / 0 errors across 2,102 files
- `bun run format:check -- scripts/workload-image-system-packages-contract.test.ts` — pass
- `bun run check:public-hygiene` — pass
- `git diff --check` — pass

The full unit command is not authoritative in this bare rig: it lacks Rust, Docker, PostgreSQL, generated ogtool output, and built workspace package outputs. The new contract passed inside that run before it was stopped. GitHub exact-head multi-platform image CI is the runtime proof.

Tracks OPE-27.

