### PR TITLE
ci: coalesce worker system package installs

### DIFF
--- a/docker/opengeni.Dockerfile
+++ b/docker/opengeni.Dockerfile
@@ -46,8 +46,8 @@ ENV NODE_ENV=production
 USER bun
 
 # Most workloads share the same network/source-control tools. Keep that stable
-# package layer reusable, while artifact-runtime workloads inherit source-base
-# directly and install their complete target-specific package union once.
+# package layer reusable, while workloads with larger target-specific package
+# unions inherit source-base directly and install their complete union once.
 FROM source-base AS base
 USER root
 RUN apt-get update \
@@ -110,14 +110,14 @@ RUN bun scripts/build-runtime-processes.ts api
 EXPOSE 8000
 CMD ["bun", "apps/api/dist/process/index.js"]
 
-FROM base AS worker
+FROM source-base AS worker
 # The docker sandbox backend needs the Docker CLI to talk to the mounted host
 # daemon socket. Interactive/cancellable commands use the Agents SDK's
 # host-side Python PTY bridge, so Python must live in this worker image rather
 # than only inside the sandbox. The daemon remains outside this image.
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl ffmpeg gnupg python3 \
+  && apt-get install -y --no-install-recommends ca-certificates curl ffmpeg git gnupg openssh-client python3 \
   && install -m 0755 -d /etc/apt/keyrings \
   && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
   && chmod a+r /etc/apt/keyrings/docker.asc \

--- a/scripts/workload-image-system-packages-contract.test.ts
+++ b/scripts/workload-image-system-packages-contract.test.ts
@@ -19,11 +19,12 @@ function aptTransactions(source: string): number {
   return source.match(/RUN apt-get update/gmu)?.length ?? 0;
 }
 
-function keepsArtifactWorkloadPackagesCoalesced(source: string): boolean {
+function keepsSpecializedWorkloadPackagesCoalesced(source: string): boolean {
   const sourceBase = stage(source, "source-base");
   const base = stage(source, "base");
   const artifactRuntimeBase = stage(source, "artifact-runtime-base");
   const api = stage(source, "api");
+  const worker = stage(source, "worker");
   const materializer = stage(source, "artifact-materializer");
 
   return (
@@ -44,6 +45,13 @@ function keepsArtifactWorkloadPackagesCoalesced(source: string): boolean {
     api.includes(
       "apt-get install -y --no-install-recommends ca-certificates ffmpeg git openssh-client",
     ) &&
+    worker.startsWith("FROM source-base AS worker") &&
+    aptTransactions(worker) === 1 &&
+    worker.includes(
+      "apt-get install -y --no-install-recommends ca-certificates curl ffmpeg git gnupg openssh-client python3",
+    ) &&
+    worker.includes("apt-get install -y --no-install-recommends docker-ce-cli") &&
+    worker.includes("/usr/bin/python3 -c 'import pty'") &&
     aptTransactions(materializer) === 1 &&
     materializer.includes(
       "apt-get install -y --no-install-recommends bubblewrap ca-certificates git openssh-client util-linux",
@@ -52,27 +60,45 @@ function keepsArtifactWorkloadPackagesCoalesced(source: string): boolean {
 }
 
 describe("workload image system package contract", () => {
-  test("coalesces artifact-runtime workload packages without weakening their runtime base", async () => {
+  test("coalesces specialized workload packages without weakening their runtime base", async () => {
     const dockerfile = await readFile(resolve(root, "docker/opengeni.Dockerfile"), "utf8");
 
-    expect(keepsArtifactWorkloadPackagesCoalesced(dockerfile)).toBe(true);
+    expect(keepsSpecializedWorkloadPackagesCoalesced(dockerfile)).toBe(true);
 
     const inheritedCommonInstall = dockerfile.replace(
       "FROM source-base AS artifact-runtime-base",
       "FROM base AS artifact-runtime-base",
     );
-    expect(keepsArtifactWorkloadPackagesCoalesced(inheritedCommonInstall)).toBe(false);
+    expect(keepsSpecializedWorkloadPackagesCoalesced(inheritedCommonInstall)).toBe(false);
 
     const missingApiRuntimeTools = dockerfile.replace(
       "ca-certificates ffmpeg git openssh-client",
       "ffmpeg",
     );
-    expect(keepsArtifactWorkloadPackagesCoalesced(missingApiRuntimeTools)).toBe(false);
+    expect(keepsSpecializedWorkloadPackagesCoalesced(missingApiRuntimeTools)).toBe(false);
 
     const duplicateApiTransaction = dockerfile.replace(
       "FROM artifact-runtime-base AS api\n",
       "FROM artifact-runtime-base AS api\nRUN apt-get update && rm -rf /var/lib/apt/lists/*\n",
     );
-    expect(keepsArtifactWorkloadPackagesCoalesced(duplicateApiTransaction)).toBe(false);
+    expect(keepsSpecializedWorkloadPackagesCoalesced(duplicateApiTransaction)).toBe(false);
+
+    const inheritedWorkerCommonInstall = dockerfile.replace(
+      "FROM source-base AS worker",
+      "FROM base AS worker",
+    );
+    expect(keepsSpecializedWorkloadPackagesCoalesced(inheritedWorkerCommonInstall)).toBe(false);
+
+    const missingWorkerSourceControlTools = dockerfile.replace(
+      "ca-certificates curl ffmpeg git gnupg openssh-client python3",
+      "ca-certificates curl ffmpeg gnupg python3",
+    );
+    expect(keepsSpecializedWorkloadPackagesCoalesced(missingWorkerSourceControlTools)).toBe(false);
+
+    const duplicateWorkerTransaction = dockerfile.replace(
+      "FROM source-base AS worker\n",
+      "FROM source-base AS worker\nRUN apt-get update && rm -rf /var/lib/apt/lists/*\n",
+    );
+    expect(keepsSpecializedWorkloadPackagesCoalesced(duplicateWorkerTransaction)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- let the worker image inherit the source/dependency stage directly
- install the worker's unchanged complete package union in its existing target-specific system-package layer
- preserve Docker CLI repository setup, Python PTY verification, runtime process build, architectures, and command
- extend the planted-negative workload package contract to reject inherited common packages, missing worker source-control tools, and duplicate worker APT layers

## Measured bottleneck

Exact PR #1322 job `93655068030` (`Build worker and web workload images`) was the longest job at `545s`. Its worker build paid a separate common-package layer before the worker-specific install:

- amd64 inherited common APT: `11.8s`
- arm64 inherited common APT: `110.2s`
- arm64 worker-specific APT: `239.4s`

This change removes the separate inherited common-package boundary while retaining `ca-certificates`, `git`, and `openssh-client` in the worker's existing package install. Exact-head PR #1323 measured the arm64 worker package layer at `322.0s`, versus `349.6s` across the prior `110.2s` common plus `239.4s` worker layers: an attributable `27.6s` structural saving. The amd64 package path varied from `40.8s` separate to `54.9s` combined, while the complete worker build remained essentially flat (`422.9s` to `422.0s`) because the source dependency install was colder (`24.6s` to `47.5s` on the slower architecture). The combined worker/web job rose from `545s` to `633s` because the subsequent web build grew from `85.8s` to `169.1s`; that cache-sensitive web delta is not attributed to this worker change.

## Safety / non-overlap

- no workflow, required-check, architecture, target, publication, release, or deployment changes
- no open PR touches either changed file
- no overlap with PR #1306, which owns workflow impact-selection changes
- worker retains `ca-certificates`, `curl`, `ffmpeg`, `git`, `gnupg`, `openssh-client`, `python3`, and `docker-ce-cli`
- Docker repository/key setup, Python PTY import probe, `OPENAI_AGENTS_PYTHON`, and worker runtime build remain unchanged
- ordinary workloads still reuse `base`; artifact-runtime roles retain their exact coalesced topology

## Local verification

- `bun test scripts/workload-image-system-packages-contract.test.ts scripts/release-image-workflow-contract.test.ts scripts/artifact-runtime-workflow-contract.test.ts scripts/browserd-image-build-contract.test.ts` — 25 pass
- `bun run typecheck` — all 29 projects clean
- `bun run lint` — 0 warnings / 0 errors across 2,102 files
- `bun run format:check -- scripts/workload-image-system-packages-contract.test.ts docker/opengeni.Dockerfile` — pass
- `bun run check:public-hygiene` — pass
- `git diff --check` — pass

GitHub exact-head multi-platform image CI is the runtime proof.

Tracks OPE-27.

