### PR TITLE
perf(ci): parallelize unit test processes

### DIFF
--- a/scripts/ci/run-unit-shard.test.ts
+++ b/scripts/ci/run-unit-shard.test.ts
@@ -1,0 +1,103 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  planUnitTestProcesses,
+  runBoundedTestProcesses,
+  sourceUsesExplicitTestConcurrency,
+} from "./run-unit-shard";
+
+describe("bounded unit process execution", () => {
+  test("runs every task exactly once within the configured process bound", async () => {
+    const started: number[] = [];
+    const completed: number[] = [];
+    let active = 0;
+    let maximumActive = 0;
+    const status = await runBoundedTestProcesses([0, 1, 2, 3, 4, 5], 2, async (task) => {
+      started.push(task);
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await Bun.sleep(task % 2 === 0 ? 4 : 1);
+      active -= 1;
+      completed.push(task);
+      return 0;
+    });
+
+    expect(status).toBe(0);
+    expect(started).toEqual([0, 1, 2, 3, 4, 5]);
+    expect([...completed].sort((left, right) => left - right)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(maximumActive).toBe(2);
+  });
+
+  test("stops admitting new work after a failure while settling in-flight tasks", async () => {
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const started: number[] = [];
+    const execution = runBoundedTestProcesses([0, 1, 2, 3], 2, async (task) => {
+      started.push(task);
+      if (task === 0) return 7;
+      await gate;
+      return 0;
+    });
+    while (started.length < 2) await Bun.sleep(1);
+    await Bun.sleep(1);
+    release();
+
+    expect(await execution).toBe(7);
+    expect(started).toEqual([0, 1]);
+  });
+
+  test("rejects an invalid process bound", async () => {
+    await expect(runBoundedTestProcesses([1], 0, async () => 0)).rejects.toThrow(
+      "positive integer",
+    );
+  });
+});
+
+describe("unit process planning", () => {
+  test("recognizes authored concurrent-test syntax without matching prose", () => {
+    expect(sourceUsesExplicitTestConcurrency("test.concurrent('race', () => {})")).toBe(true);
+    expect(sourceUsesExplicitTestConcurrency("it ['concurrent']('race', () => {})")).toBe(true);
+    expect(
+      sourceUsesExplicitTestConcurrency("describe.concurrent.each([])('race', () => {})"),
+    ).toBe(true);
+    expect(sourceUsesExplicitTestConcurrency("const { concurrent: race } = test;")).toBe(true);
+    expect(sourceUsesExplicitTestConcurrency("test('concurrent sessions', () => {})")).toBe(false);
+  });
+
+  test("keeps explicit concurrency serial while every other file retains a fresh process", () => {
+    const root = mkdtempSync(join(tmpdir(), "opengeni-unit-process-plan-"));
+    try {
+      for (const path of ["batch-a.test.ts", "batch-b.test.ts", "isolated-a.test.ts"]) {
+        writeFileSync(join(root, path), "test('ordinary', () => {});\n");
+      }
+      mkdirSync(join(root, "nested"));
+      writeFileSync(
+        join(root, "nested/concurrent.test.ts"),
+        "test.concurrent('authored race', () => {});\n",
+      );
+      const plan = planUnitTestProcesses(
+        root,
+        ["batch-a.test.ts", "nested/concurrent.test.ts", "batch-b.test.ts"],
+        ["isolated-a.test.ts"],
+        1,
+      );
+
+      expect(plan).toEqual({
+        parallel: [
+          { files: ["batch-a.test.ts"], isolated: false },
+          { files: ["batch-b.test.ts"], isolated: false },
+          { files: ["isolated-a.test.ts"], isolated: true },
+        ],
+        explicitConcurrency: [{ files: ["nested/concurrent.test.ts"], isolated: false }],
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/ci/run-unit-shard.test.ts
+++ b/scripts/ci/run-unit-shard.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from "bun:test";
 import {
   planUnitTestProcesses,
   runBoundedTestProcesses,
+  sourceMutatesSharedPostgresRole,
   sourceUsesExplicitTestConcurrency,
   sourceUsesWallClockPerformanceAssertion,
 } from "./run-unit-shard";
@@ -86,7 +87,25 @@ describe("unit process planning", () => {
     expect(sourceUsesWallClockPerformanceAssertion("expect(rows).toBeLessThan(100);")).toBe(false);
   });
 
-  test("keeps explicit concurrency and wall-clock assertions out of the parallel pool", () => {
+  test("recognizes only shared-container cluster-role mutations", () => {
+    expect(
+      sourceMutatesSharedPostgresRole(
+        "await sql.unsafe(`alter role opengeni_app with password 'test'`);",
+      ),
+    ).toBe(true);
+    expect(
+      sourceMutatesSharedPostgresRole(
+        "const blank = await acquireBlankTestDatabase('x'); await provisionRoles(blank.databaseUrl, {});",
+      ),
+    ).toBe(true);
+    expect(
+      sourceMutatesSharedPostgresRole(
+        "const shared = await acquireSharedTestDatabase('x'); if (externalUrl) await provisionRoles(externalUrl, {});",
+      ),
+    ).toBe(false);
+  });
+
+  test("keeps explicit concurrency, wall clocks, and cluster roles out of the parallel pool", () => {
     const root = mkdtempSync(join(tmpdir(), "opengeni-unit-process-plan-"));
     try {
       for (const path of ["batch-a.test.ts", "isolated-a.test.ts"]) {
@@ -96,6 +115,10 @@ describe("unit process planning", () => {
         join(root, "timed.test.ts"),
         "const started = performance.now(); expect(performance.now() - started).toBeLessThan(100);\n",
       );
+      writeFileSync(
+        join(root, "role.test.ts"),
+        "await sql.unsafe(`alter role opengeni_app with password 'test'`);\n",
+      );
       mkdirSync(join(root, "nested"));
       writeFileSync(
         join(root, "nested/concurrent.test.ts"),
@@ -103,7 +126,7 @@ describe("unit process planning", () => {
       );
       const plan = planUnitTestProcesses(
         root,
-        ["batch-a.test.ts", "nested/concurrent.test.ts", "timed.test.ts"],
+        ["batch-a.test.ts", "nested/concurrent.test.ts", "timed.test.ts", "role.test.ts"],
         ["isolated-a.test.ts"],
         1,
       );
@@ -115,6 +138,7 @@ describe("unit process planning", () => {
         ],
         explicitConcurrency: [{ files: ["nested/concurrent.test.ts"], isolated: false }],
         wallClockSensitive: [{ files: ["timed.test.ts"], isolated: false }],
+        clusterRoleSensitive: [{ files: ["role.test.ts"], isolated: false }],
       });
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/scripts/ci/run-unit-shard.test.ts
+++ b/scripts/ci/run-unit-shard.test.ts
@@ -100,6 +100,11 @@ describe("unit process planning", () => {
     ).toBe(true);
     expect(
       sourceMutatesSharedPostgresRole(
+        "const shared = await acquireSharedTestDatabase('x'); await provisionRoles(shared.adminUrl, {});",
+      ),
+    ).toBe(true);
+    expect(
+      sourceMutatesSharedPostgresRole(
         "await shared.admin.unsafe(`create role ${quotedRole} nologin`);",
       ),
     ).toBe(true);
@@ -115,9 +120,12 @@ describe("unit process planning", () => {
     ).toBe(false);
   });
 
-  test("classifies generated shared-cluster role DDL in the real test corpus", () => {
+  test("classifies generated and helper-driven shared-cluster role DDL in the real corpus", () => {
     const root = join(import.meta.dir, "../..");
     for (const path of [
+      "apps/worker/test/editable-artifact-outbox-posture-postgres.test.ts",
+      "packages/db/test/editable-artifact-materialization-postgres.test.ts",
+      "packages/db/test/editable-artifacts-postgres.test.ts",
       "packages/db/test/session-activity-commit-gate.test.ts",
       "packages/db/test/migration-0120-durable-goal-wake.test.ts",
       "packages/db/test/migration-0138-sandbox-checkpoints.test.ts",
@@ -138,7 +146,7 @@ describe("unit process planning", () => {
       );
       writeFileSync(
         join(root, "role.test.ts"),
-        "await sql.unsafe(`create role ${quoteIdentifier(generatedRole)} nologin`);\n",
+        "const shared = await acquireSharedTestDatabase('x'); await provisionRoles(shared.adminUrl, {});\n",
       );
       mkdirSync(join(root, "nested"));
       writeFileSync(

--- a/scripts/ci/run-unit-shard.test.ts
+++ b/scripts/ci/run-unit-shard.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -100,9 +100,30 @@ describe("unit process planning", () => {
     ).toBe(true);
     expect(
       sourceMutatesSharedPostgresRole(
+        "await shared.admin.unsafe(`create role ${quotedRole} nologin`);",
+      ),
+    ).toBe(true);
+    expect(
+      sourceMutatesSharedPostgresRole(
+        "await sql.unsafe(`DROP ROLE IF EXISTS ${quoteIdentifier(migrationRole)}`);",
+      ),
+    ).toBe(true);
+    expect(
+      sourceMutatesSharedPostgresRole(
         "const shared = await acquireSharedTestDatabase('x'); if (externalUrl) await provisionRoles(externalUrl, {});",
       ),
     ).toBe(false);
+  });
+
+  test("classifies generated shared-cluster role DDL in the real test corpus", () => {
+    const root = join(import.meta.dir, "../..");
+    for (const path of [
+      "packages/db/test/session-activity-commit-gate.test.ts",
+      "packages/db/test/migration-0120-durable-goal-wake.test.ts",
+      "packages/db/test/migration-0138-sandbox-checkpoints.test.ts",
+    ]) {
+      expect(sourceMutatesSharedPostgresRole(readFileSync(join(root, path), "utf8"))).toBe(true);
+    }
   });
 
   test("keeps explicit concurrency, wall clocks, and cluster roles out of the parallel pool", () => {
@@ -117,7 +138,7 @@ describe("unit process planning", () => {
       );
       writeFileSync(
         join(root, "role.test.ts"),
-        "await sql.unsafe(`alter role opengeni_app with password 'test'`);\n",
+        "await sql.unsafe(`create role ${quoteIdentifier(generatedRole)} nologin`);\n",
       );
       mkdirSync(join(root, "nested"));
       writeFileSync(

--- a/scripts/ci/run-unit-shard.test.ts
+++ b/scripts/ci/run-unit-shard.test.ts
@@ -8,6 +8,7 @@ import {
   planUnitTestProcesses,
   runBoundedTestProcesses,
   sourceUsesExplicitTestConcurrency,
+  sourceUsesWallClockPerformanceAssertion,
 } from "./run-unit-shard";
 
 describe("bounded unit process execution", () => {
@@ -70,12 +71,31 @@ describe("unit process planning", () => {
     expect(sourceUsesExplicitTestConcurrency("test('concurrent sessions', () => {})")).toBe(false);
   });
 
-  test("keeps explicit concurrency serial while every other file retains a fresh process", () => {
+  test("recognizes real wall-clock upper bounds without matching unrelated clocks", () => {
+    expect(
+      sourceUsesWallClockPerformanceAssertion(
+        "const started = Bun.nanoseconds(); expect(elapsed).toBeLessThan(1500);",
+      ),
+    ).toBe(true);
+    expect(
+      sourceUsesWallClockPerformanceAssertion(
+        "const started = performance.now(); expect(elapsed).toBeLessThanOrEqual(100);",
+      ),
+    ).toBe(true);
+    expect(sourceUsesWallClockPerformanceAssertion("const now = Date.now();")).toBe(false);
+    expect(sourceUsesWallClockPerformanceAssertion("expect(rows).toBeLessThan(100);")).toBe(false);
+  });
+
+  test("keeps explicit concurrency and wall-clock assertions out of the parallel pool", () => {
     const root = mkdtempSync(join(tmpdir(), "opengeni-unit-process-plan-"));
     try {
-      for (const path of ["batch-a.test.ts", "batch-b.test.ts", "isolated-a.test.ts"]) {
+      for (const path of ["batch-a.test.ts", "isolated-a.test.ts"]) {
         writeFileSync(join(root, path), "test('ordinary', () => {});\n");
       }
+      writeFileSync(
+        join(root, "timed.test.ts"),
+        "const started = performance.now(); expect(performance.now() - started).toBeLessThan(100);\n",
+      );
       mkdirSync(join(root, "nested"));
       writeFileSync(
         join(root, "nested/concurrent.test.ts"),
@@ -83,7 +103,7 @@ describe("unit process planning", () => {
       );
       const plan = planUnitTestProcesses(
         root,
-        ["batch-a.test.ts", "nested/concurrent.test.ts", "batch-b.test.ts"],
+        ["batch-a.test.ts", "nested/concurrent.test.ts", "timed.test.ts"],
         ["isolated-a.test.ts"],
         1,
       );
@@ -91,10 +111,10 @@ describe("unit process planning", () => {
       expect(plan).toEqual({
         parallel: [
           { files: ["batch-a.test.ts"], isolated: false },
-          { files: ["batch-b.test.ts"], isolated: false },
           { files: ["isolated-a.test.ts"], isolated: true },
         ],
         explicitConcurrency: [{ files: ["nested/concurrent.test.ts"], isolated: false }],
+        wallClockSensitive: [{ files: ["timed.test.ts"], isolated: false }],
       });
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/scripts/ci/run-unit-shard.ts
+++ b/scripts/ci/run-unit-shard.ts
@@ -22,6 +22,7 @@ export type UnitTestProcess = {
 export type UnitTestProcessPlan = {
   parallel: UnitTestProcess[];
   explicitConcurrency: UnitTestProcess[];
+  wallClockSensitive: UnitTestProcess[];
 };
 
 export function sanitizedTestEnvironment(
@@ -52,22 +53,47 @@ export function sourceUsesExplicitTestConcurrency(source: string): boolean {
   );
 }
 
+export function sourceUsesWallClockPerformanceAssertion(source: string): boolean {
+  return (
+    /\b(?:Bun\.nanoseconds|performance\.now|Date\.now)\s*\(/.test(source) &&
+    /\.toBeLessThan(?:OrEqual)?\s*\(/.test(source)
+  );
+}
+
 export function planUnitTestProcesses(
   root: string,
   batch: readonly string[],
   isolated: readonly string[],
   batchSize: number,
 ): UnitTestProcessPlan {
+  const sources = new Map(
+    [...batch, ...isolated].map((path) => [path, readFileSync(join(root, path), "utf8")] as const),
+  );
   const explicitConcurrency = new Set(
-    [...batch, ...isolated].filter((path) =>
-      sourceUsesExplicitTestConcurrency(readFileSync(join(root, path), "utf8")),
-    ),
+    [...sources]
+      .filter(([, source]) => sourceUsesExplicitTestConcurrency(source))
+      .map(([path]) => path),
+  );
+  const wallClockSensitive = new Set(
+    [...sources]
+      .filter(
+        ([path, source]) =>
+          !explicitConcurrency.has(path) && sourceUsesWallClockPerformanceAssertion(source),
+      )
+      .map(([path]) => path),
   );
   const usesExplicitConcurrency = (path: string): boolean => explicitConcurrency.has(path);
-  const parallelBatch = batch.filter((path) => !usesExplicitConcurrency(path));
+  const usesWallClock = (path: string): boolean => wallClockSensitive.has(path);
+  const parallelBatch = batch.filter(
+    (path) => !usesExplicitConcurrency(path) && !usesWallClock(path),
+  );
   const concurrentBatch = batch.filter(usesExplicitConcurrency);
-  const parallelIsolated = isolated.filter((path) => !usesExplicitConcurrency(path));
+  const wallClockBatch = batch.filter(usesWallClock);
+  const parallelIsolated = isolated.filter(
+    (path) => !usesExplicitConcurrency(path) && !usesWallClock(path),
+  );
   const concurrentIsolated = isolated.filter(usesExplicitConcurrency);
+  const wallClockIsolated = isolated.filter(usesWallClock);
   return {
     parallel: [
       ...deterministicFileBatches(parallelBatch, batchSize).map((files) => ({
@@ -83,6 +109,13 @@ export function planUnitTestProcesses(
     explicitConcurrency: [
       ...concurrentBatch.map((path) => ({ files: [path], isolated: false })),
       ...concurrentIsolated.map((path) => ({ files: [path], isolated: true })),
+    ],
+    // Wall-clock assertions measure the tested operation, not unrelated CPU
+    // contention from sibling files. Keep their existing limits unchanged and
+    // run those files alone with ordinary serial Bun semantics.
+    wallClockSensitive: [
+      ...wallClockBatch.map((path) => ({ files: [path], isolated: false })),
+      ...wallClockIsolated.map((path) => ({ files: [path], isolated: true })),
     ],
   };
 }
@@ -177,7 +210,7 @@ async function main(): Promise<void> {
   const budget = testConcurrencyBudget();
   const processes = planUnitTestProcesses(process.cwd(), batch, isolated, configuredBatchSize);
   process.stdout.write(
-    `[unit-shard] process plan: ${describeTestConcurrencyBudget(budget)} parallel=${processes.parallel.length} explicitConcurrency=${processes.explicitConcurrency.length}\n`,
+    `[unit-shard] process plan: ${describeTestConcurrencyBudget(budget)} parallel=${processes.parallel.length} explicitConcurrency=${processes.explicitConcurrency.length} wallClockSensitive=${processes.wallClockSensitive.length}\n`,
   );
   const parallelStatus = await runBoundedTestProcesses(
     processes.parallel,
@@ -189,6 +222,10 @@ async function main(): Promise<void> {
     run(task, budget, 1, budget.concurrency),
   );
   if (explicitStatus !== 0) process.exit(explicitStatus);
+  const wallClockStatus = await runBoundedTestProcesses(processes.wallClockSensitive, 1, (task) =>
+    run(task, budget, 1, 1),
+  );
+  if (wallClockStatus !== 0) process.exit(wallClockStatus);
   process.stdout.write(
     `[unit-shard] shard ${index + 1}/${count} passed (${selected.length} files)\n`,
   );

--- a/scripts/ci/run-unit-shard.ts
+++ b/scripts/ci/run-unit-shard.ts
@@ -1,13 +1,28 @@
 #!/usr/bin/env bun
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import type { ImpactPlan } from "./impact";
-import { describeTestConcurrencyBudget, testConcurrencyBudget } from "./resource-budget";
+import {
+  describeTestConcurrencyBudget,
+  testConcurrencyBudget,
+  type TestConcurrencyBudget,
+} from "./resource-budget";
 import {
   deterministicFileBatches,
   deterministicShards,
   fileUsesProcessGlobalTestState,
 } from "./workspace";
+
+export type UnitTestProcess = {
+  files: string[];
+  isolated: boolean;
+};
+
+export type UnitTestProcessPlan = {
+  parallel: UnitTestProcess[];
+  explicitConcurrency: UnitTestProcess[];
+};
 
 export function sanitizedTestEnvironment(
   source: Readonly<Record<string, string | undefined>> = process.env,
@@ -30,24 +45,92 @@ export function sanitizedTestEnvironment(
   return environment;
 }
 
-async function run(files: string[], isolated: boolean): Promise<number> {
+export function sourceUsesExplicitTestConcurrency(source: string): boolean {
+  return (
+    /\.\s*concurrent\b|\[\s*["']concurrent["']\s*\]/.test(source) ||
+    /\{[^}]*\bconcurrent\b[^}]*\}\s*=\s*(?:test|it|describe)\b/.test(source)
+  );
+}
+
+export function planUnitTestProcesses(
+  root: string,
+  batch: readonly string[],
+  isolated: readonly string[],
+  batchSize: number,
+): UnitTestProcessPlan {
+  const explicitConcurrency = new Set(
+    [...batch, ...isolated].filter((path) =>
+      sourceUsesExplicitTestConcurrency(readFileSync(join(root, path), "utf8")),
+    ),
+  );
+  const usesExplicitConcurrency = (path: string): boolean => explicitConcurrency.has(path);
+  const parallelBatch = batch.filter((path) => !usesExplicitConcurrency(path));
+  const concurrentBatch = batch.filter(usesExplicitConcurrency);
+  const parallelIsolated = isolated.filter((path) => !usesExplicitConcurrency(path));
+  const concurrentIsolated = isolated.filter(usesExplicitConcurrency);
+  return {
+    parallel: [
+      ...deterministicFileBatches(parallelBatch, batchSize).map((files) => ({
+        files,
+        isolated: false,
+      })),
+      ...parallelIsolated.map((path) => ({ files: [path], isolated: true })),
+    ],
+    // Explicitly concurrent tests retain the complete inner Bun concurrency
+    // budget and therefore run one process at a time. Ordinary files have no
+    // authored concurrent tests, so separate processes may safely share that
+    // same total budget with inner concurrency fixed to one.
+    explicitConcurrency: [
+      ...concurrentBatch.map((path) => ({ files: [path], isolated: false })),
+      ...concurrentIsolated.map((path) => ({ files: [path], isolated: true })),
+    ],
+  };
+}
+
+export async function runBoundedTestProcesses<T>(
+  tasks: readonly T[],
+  concurrency: number,
+  execute: (task: T, index: number) => Promise<number>,
+): Promise<number> {
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1) {
+    throw new Error("unit process concurrency must be a positive integer");
+  }
+  let next = 0;
+  let failure = 0;
+  const workers = Array.from({ length: Math.min(concurrency, tasks.length) }, async () => {
+    while (failure === 0) {
+      const index = next;
+      next += 1;
+      if (index >= tasks.length) return;
+      const task = tasks[index]!;
+      const status = await execute(task, index);
+      if (status !== 0 && failure === 0) failure = status;
+    }
+  });
+  await Promise.all(workers);
+  return failure;
+}
+
+async function run(
+  task: UnitTestProcess,
+  budget: TestConcurrencyBudget,
+  processConcurrency: number,
+  innerConcurrency: number,
+): Promise<number> {
+  const { files, isolated } = task;
   if (files.length === 0) return 0;
-  const budget = testConcurrencyBudget();
   // One file worker per runner prevents Bun's CPU-count default from launching
   // the whole repository at once. A fresh global per file contains mock.module,
   // Happy DOM, fake timers, and process-global teardown. Tests within one file
   // remain bounded as well; individual tests are still serial unless authored
   // with test.concurrent.
-  const args = [
-    "bun",
-    "test",
-    "--no-orphans",
-    "--timeout=30000",
-    `--max-concurrency=${budget.concurrency}`,
-    ...files,
-  ];
+  const concurrencyArgument =
+    innerConcurrency === budget.concurrency
+      ? `--max-concurrency=${budget.concurrency}`
+      : `--max-concurrency=${innerConcurrency}`;
+  const args = ["bun", "test", "--no-orphans", "--timeout=30000", concurrencyArgument, ...files];
   process.stdout.write(
-    `[unit-shard] ${isolated ? "isolated" : "batch"}: ${describeTestConcurrencyBudget(budget)} files=${files.join(", ")}\n`,
+    `[unit-shard] ${isolated ? "isolated" : "batch"}: ${describeTestConcurrencyBudget(budget)} processPool=${processConcurrency} innerConcurrency=${innerConcurrency} files=${files.join(", ")}\n`,
   );
   const child = Bun.spawn(args, {
     cwd: process.cwd(),
@@ -91,14 +174,21 @@ async function main(): Promise<void> {
   // full-suite cgroup peak substantially. Measured larger runners may opt into
   // a higher, still deterministic batch size explicitly.
   const configuredBatchSize = Number(process.env.OPENGENI_TEST_FILES_PER_PROCESS ?? "1");
-  for (const files of deterministicFileBatches(batch, configuredBatchSize)) {
-    const batchStatus = await run(files, false);
-    if (batchStatus !== 0) process.exit(batchStatus);
-  }
-  for (const path of isolated) {
-    const status = await run([path], true);
-    if (status !== 0) process.exit(status);
-  }
+  const budget = testConcurrencyBudget();
+  const processes = planUnitTestProcesses(process.cwd(), batch, isolated, configuredBatchSize);
+  process.stdout.write(
+    `[unit-shard] process plan: ${describeTestConcurrencyBudget(budget)} parallel=${processes.parallel.length} explicitConcurrency=${processes.explicitConcurrency.length}\n`,
+  );
+  const parallelStatus = await runBoundedTestProcesses(
+    processes.parallel,
+    budget.concurrency,
+    (task) => run(task, budget, budget.concurrency, 1),
+  );
+  if (parallelStatus !== 0) process.exit(parallelStatus);
+  const explicitStatus = await runBoundedTestProcesses(processes.explicitConcurrency, 1, (task) =>
+    run(task, budget, 1, budget.concurrency),
+  );
+  if (explicitStatus !== 0) process.exit(explicitStatus);
   process.stdout.write(
     `[unit-shard] shard ${index + 1}/${count} passed (${selected.length} files)\n`,
   );

--- a/scripts/ci/run-unit-shard.ts
+++ b/scripts/ci/run-unit-shard.ts
@@ -61,10 +61,23 @@ export function sourceUsesWallClockPerformanceAssertion(source: string): boolean
   );
 }
 
+function sourceProvisionsRolesOnSharedDatabase(source: string): boolean {
+  for (const match of source.matchAll(
+    /\b([A-Za-z_$][\w$]*)\s*=\s*await\s+acquireSharedTestDatabase\s*\(/g,
+  )) {
+    const sharedDatabase = match[1]!;
+    if (new RegExp(`\\bprovisionRoles\\s*\\(\\s*${sharedDatabase}\\.adminUrl\\b`).test(source)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function sourceMutatesSharedPostgresRole(source: string): boolean {
   return (
     /\b(?:create|alter|drop)\s+role\b/i.test(source) ||
-    (/\bacquireBlankTestDatabase\b/.test(source) && /\bprovisionRoles\s*\(/.test(source))
+    (/\bacquireBlankTestDatabase\b/.test(source) && /\bprovisionRoles\s*\(/.test(source)) ||
+    sourceProvisionsRolesOnSharedDatabase(source)
   );
 }
 

--- a/scripts/ci/run-unit-shard.ts
+++ b/scripts/ci/run-unit-shard.ts
@@ -23,6 +23,7 @@ export type UnitTestProcessPlan = {
   parallel: UnitTestProcess[];
   explicitConcurrency: UnitTestProcess[];
   wallClockSensitive: UnitTestProcess[];
+  clusterRoleSensitive: UnitTestProcess[];
 };
 
 export function sanitizedTestEnvironment(
@@ -60,6 +61,13 @@ export function sourceUsesWallClockPerformanceAssertion(source: string): boolean
   );
 }
 
+export function sourceMutatesSharedPostgresRole(source: string): boolean {
+  return (
+    /\b(?:create|alter|drop)\s+role\s+opengeni_app\b/i.test(source) ||
+    (/\bacquireBlankTestDatabase\b/.test(source) && /\bprovisionRoles\s*\(/.test(source))
+  );
+}
+
 export function planUnitTestProcesses(
   root: string,
   batch: readonly string[],
@@ -82,18 +90,31 @@ export function planUnitTestProcesses(
       )
       .map(([path]) => path),
   );
+  const clusterRoleSensitive = new Set(
+    [...sources]
+      .filter(
+        ([path, source]) =>
+          !explicitConcurrency.has(path) &&
+          !wallClockSensitive.has(path) &&
+          sourceMutatesSharedPostgresRole(source),
+      )
+      .map(([path]) => path),
+  );
   const usesExplicitConcurrency = (path: string): boolean => explicitConcurrency.has(path);
   const usesWallClock = (path: string): boolean => wallClockSensitive.has(path);
+  const mutatesClusterRole = (path: string): boolean => clusterRoleSensitive.has(path);
   const parallelBatch = batch.filter(
-    (path) => !usesExplicitConcurrency(path) && !usesWallClock(path),
+    (path) => !usesExplicitConcurrency(path) && !usesWallClock(path) && !mutatesClusterRole(path),
   );
   const concurrentBatch = batch.filter(usesExplicitConcurrency);
   const wallClockBatch = batch.filter(usesWallClock);
+  const clusterRoleBatch = batch.filter(mutatesClusterRole);
   const parallelIsolated = isolated.filter(
-    (path) => !usesExplicitConcurrency(path) && !usesWallClock(path),
+    (path) => !usesExplicitConcurrency(path) && !usesWallClock(path) && !mutatesClusterRole(path),
   );
   const concurrentIsolated = isolated.filter(usesExplicitConcurrency);
   const wallClockIsolated = isolated.filter(usesWallClock);
+  const clusterRoleIsolated = isolated.filter(mutatesClusterRole);
   return {
     parallel: [
       ...deterministicFileBatches(parallelBatch, batchSize).map((files) => ({
@@ -116,6 +137,14 @@ export function planUnitTestProcesses(
     wallClockSensitive: [
       ...wallClockBatch.map((path) => ({ files: [path], isolated: false })),
       ...wallClockIsolated.map((path) => ({ files: [path], isolated: true })),
+    ],
+    // PostgreSQL roles are cluster-global even when every test file owns a
+    // distinct database. Run role-password/DDL mutation tests last and alone,
+    // after every shared app-role connection has closed. Each blank-database
+    // acquisition then resets the canonical role before its own mutation.
+    clusterRoleSensitive: [
+      ...clusterRoleBatch.map((path) => ({ files: [path], isolated: false })),
+      ...clusterRoleIsolated.map((path) => ({ files: [path], isolated: true })),
     ],
   };
 }
@@ -210,7 +239,7 @@ async function main(): Promise<void> {
   const budget = testConcurrencyBudget();
   const processes = planUnitTestProcesses(process.cwd(), batch, isolated, configuredBatchSize);
   process.stdout.write(
-    `[unit-shard] process plan: ${describeTestConcurrencyBudget(budget)} parallel=${processes.parallel.length} explicitConcurrency=${processes.explicitConcurrency.length} wallClockSensitive=${processes.wallClockSensitive.length}\n`,
+    `[unit-shard] process plan: ${describeTestConcurrencyBudget(budget)} parallel=${processes.parallel.length} explicitConcurrency=${processes.explicitConcurrency.length} wallClockSensitive=${processes.wallClockSensitive.length} clusterRoleSensitive=${processes.clusterRoleSensitive.length}\n`,
   );
   const parallelStatus = await runBoundedTestProcesses(
     processes.parallel,
@@ -226,6 +255,12 @@ async function main(): Promise<void> {
     run(task, budget, 1, 1),
   );
   if (wallClockStatus !== 0) process.exit(wallClockStatus);
+  const clusterRoleStatus = await runBoundedTestProcesses(
+    processes.clusterRoleSensitive,
+    1,
+    (task) => run(task, budget, 1, 1),
+  );
+  if (clusterRoleStatus !== 0) process.exit(clusterRoleStatus);
   process.stdout.write(
     `[unit-shard] shard ${index + 1}/${count} passed (${selected.length} files)\n`,
   );

--- a/scripts/ci/run-unit-shard.ts
+++ b/scripts/ci/run-unit-shard.ts
@@ -63,7 +63,7 @@ export function sourceUsesWallClockPerformanceAssertion(source: string): boolean
 
 export function sourceMutatesSharedPostgresRole(source: string): boolean {
   return (
-    /\b(?:create|alter|drop)\s+role\s+opengeni_app\b/i.test(source) ||
+    /\b(?:create|alter|drop)\s+role\b/i.test(source) ||
     (/\bacquireBlankTestDatabase\b/.test(source) && /\bprovisionRoles\s*\(/.test(source))
   );
 }


### PR DESCRIPTION
## OPE-27 CI performance slice

Parallelize the existing one-file-per-Bun-process unit runner under the already-established cgroup/CPU resource budget.

### What changes

- schedules ordinary unit-file processes through a bounded worker pool using `testConcurrencyBudget().concurrency`
- keeps every file in a fresh Bun process, including files with process-global mocks, timers, DOM registration, or environment mutation
- fixes ordinary child `--max-concurrency` at 1 so total authored test concurrency stays bounded by the existing process budget
- detects explicit `.concurrent`/bracket/destructured concurrent-test syntax and runs those files one process at a time with the complete inner Bun concurrency budget
- detects tests that measure real wall-clock duration and enforce an upper bound, then runs only those files serially so their existing limits measure the operation rather than sibling-file CPU contention
- detects test sources containing any `CREATE ROLE`, `ALTER ROLE`, or `DROP ROLE` statement, plus blank shared-database tests that call `provisionRoles`, then runs those cluster-global role mutators last and serially after every ordinary app-role connection has closed
- stops admitting new files after the first non-zero child result while settling already-running children
- adds behavioral contracts for exact-once bounded scheduling, failure admission, invalid budgets, explicit-concurrency detection, wall-clock detection, and process-plan partitioning

This does not change test discovery, impact selection, shard assignment, required results, performance budgets, timeouts, workflow topology, or any release/deployment behavior. It does not touch the workflow/impact/workspace files owned by open PR #1306.

### Exact-head repair evidence

The first candidate head made a pre-existing artifact performance contract run concurrently with three other file processes. Exact CI correctly failed `dense numeric SVG rendering reuses bounded formatters` at 1,665ms against its unchanged `<1,500ms` budget. The wall-clock repair keeps the budget intact and places upper-bound tests in the serial timing lane; that exact file passes alone at 848ms locally.

The next exact run proved unit shards 4/1/2 successful in 210s/219s/217s. Shard 3 failed at 234s because `migration-0153` directly changed the cluster-global `opengeni_app` password while `migration-0157` held connections using the canonical shared-harness password. The final repair classifies only direct `opengeni_app` role DDL or `acquireBlankTestDatabase` plus `provisionRoles` (1/2/3/1 files across shards) and runs those mutators last. External-database-only provisioning branches remain parallel.

The sole exact-head review correctly failed the prior head because generated-role DDL in `session-activity-commit-gate`, `migration-0120-durable-goal-wake`, and `migration-0138-sandbox-checkpoints` still entered the process pool. The repair at `ff796a974f7ef91d98575f491444d37f204b6759` classifies any role DDL regardless of identifier spelling, adds inline generated-role contracts plus direct real-corpus coverage, and moves the repaired full-plan cluster-role lanes to 5/5/2/1 files across shards 1–4. No second review is requested.

### Measured evidence

Same-source/same-machine local comparison on an identical representative 164-file subset of the exact historical worst shard (only files requiring unavailable local PostgreSQL, Docker, or Rust tooling were excluded from both samples):

- pool=1: 144.869s wall, 221.64 CPU-s, 0.60 GiB sampled peak-memory delta
- pool=4: 56.676s wall, 234.90 CPU-s, 1.50 GiB sampled peak-memory delta
- attributable result: **88.193s saved, 60.88% wall reduction, 2.56x speedup**
- both runs passed every selected test and reported no leaked process group

The repository shared-PostgreSQL harness already coordinates parallel per-file processes through a cross-process lock, one shared container, unique databases, and refcounted cleanup. Exact-head Actions remains authoritative for the complete PostgreSQL/Docker/Rust-backed full shard because those providers are unavailable in this sandbox.

### V3 reviewer repair (`a180fc2a`)

- `OPE27_PR1324_REVIEW_REPAIR_V8`: V2 review `4903340949` correctly found three helper-driven role-DDL tests still admitted to the parallel pool.
- The classifier now binds variables assigned from `acquireSharedTestDatabase(...)` and recognizes `provisionRoles(<same variable>.adminUrl, ...)`, while unrelated external provisioning remains parallel.
- Direct real-corpus assertions cover all six V1/V2 findings; plan coverage exercises the shared-helper path.
- Local proof: focused 50/50, broader CI/release 210/210, 29/29 typecheck projects, lint 0/0 across 2,104 files, format 2,184 files, public hygiene and diff checks green.

### V3 exact-head CI block (`a180fc2a`)

- `OPE27_PR1324_V3_CI_BLOCK_V9`: Source Admission `31463955659` passed; exact-head CI `31463956934` failed only because workbench job `93692947610` timed out in the two-replica live-convergence browser test. The preceding single-browser artifact test passed, and both replicas reported healthy workers, WASM, WebSockets, API, and NATS state.
- All unit shards passed in 217s / 253s / 255s / 416s. Exact logs prove all six V1/V2 role-DDL corpus cases ran in the final `processPool=1` lane. The 416s shard means sub-five-minute reliability is not proven.
- Per the bounded reconciliation policy, no failed-job rerun, V3 review request, merge, rebase, Release/deployment inspection, timeout change, or gate weakening was performed.

### Validation

- broader CI/release contracts: 210/210 pass
- focused runner/impact/resource contracts: 50/50 pass
- exact failed artifact performance file: 10/10 pass alone, including 848ms against the unchanged 1,500ms limit
- all 29 typecheck projects clean
- lint: 0 warnings / 0 errors across 2,104 files
- format: 2,184 files correct
- public repository hygiene: pass
- `git diff --check`: clean

### Boundary

No deployment, release, provider mutation, gate weakening, timeout increase, tolerance widening, or generated-golden refresh is included or authorized.



