### PR TITLE
Preserve unit safety timeout evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,7 +429,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && github.event_name != 'pull_request' && needs.plan.outputs.unit_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -467,7 +467,7 @@ jobs:
           bun scripts/ci/profile-command.ts
           --name unit-safety
           --output ci-profile/unit-safety.json
-          --timeout-seconds 1800
+          --timeout-seconds 2100
           -- bun scripts/ci/run-unit-shard.ts --plan impact-plan.json
           --shard 0 --shards 1
 

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -3023,6 +3023,9 @@ describe("workflow contracts", () => {
     expect(safetyStep.env).toEqual({ OPENGENI_REQUIRE_REAL_DB: "1" });
     expect(safetyStep.run).toContain("scripts/ci/run-unit-shard.ts --plan impact-plan.json");
     expect(safetyStep.run).toContain("--shard 0 --shards 1");
+    const safetyTimeoutSeconds = Number(safetyStep.run.match(/--timeout-seconds\s+(\d+)/)?.[1]);
+    expect(safetyTimeoutSeconds).toBe(2100);
+    expect(safety["timeout-minutes"] * 60 - safetyTimeoutSeconds).toBeGreaterThanOrEqual(300);
 
     const integration = ci.jobs["integration-shards"];
     expect(integration.strategy.matrix.include).toBe(


### PR DESCRIPTION
## Summary

- give the monolithic unit-safety job a 40-minute outer budget
- give its profiler a 35-minute command budget
- enforce at least five minutes between the command and job deadlines so timeout evidence and teardown can complete

## Why

The job previously used the same 30-minute budget for both layers. The outer runner could therefore cancel the job before the profiler reported its own timeout or uploaded diagnostics. This keeps the safety gate intact while making its terminal state and evidence recoverable.

## Verification

- `bun test scripts/check-release-pr-automation.test.ts` (69 tests, 414 assertions)
- `bun prep`
- structured autoreview: GPT-5.6 Luna, max reasoning, no actionable findings (0.98 correctness confidence)