### PR TITLE
docs(agents): require stable CI head triage

### DIFF
--- a/.agents/skills/opengeni/SKILL.md
+++ b/.agents/skills/opengeni/SKILL.md
@@ -138,17 +138,27 @@ Before editing, identify which layer owns the behavior:
 
 For pull-request delivery, preserve immutable candidates across a moving base:
 
+- Before any push or exact-head rotation, inspect the leaf failed jobs and
+  steps; aggregate or dependent gates are consequences, not independent root
+  causes. Classify each leaf as candidate-caused, base-caused, transient
+  runner/dependency, or superseded/cancelled.
+- For an identical-head transient install, extraction, dependency, or runner
+  failure, rerun failed jobs only. Do not edit source or rotate the head to
+  manufacture new evidence.
 - Start from current `main`, but do not merge or rebase `main` again merely
   because it advances while CI or review runs.
 - “Current-main compatible” requires a fresh mergeability/merge-tree and
-  material-overlap check against current `main`; it does not require current
-  `main` to be present in the candidate's ancestry.
+  material-overlap check against current `main`; prove it with a disposable
+  current-main merge and inspect the integrated tree. It does not require
+  current `main` to be present in the candidate's ancestry.
 - Base drift alone does not create a new candidate version or invalidate a
   head-bound review. Refresh base-bound evidence on the same head when a
   release contract requires it.
 - Change the source head only for a source defect, actual conflict, or material
-  semantic incompatibility. After two substantive repair revisions, stop for an
-  incident/scope review instead of continuing an unbounded repair loop.
+  semantic incompatibility. Create a commit only to repair that real defect or
+  conflict; never create an empty or evidence-only head rotation. After two
+  substantive repair revisions, stop for an incident/scope review instead of
+  continuing an unbounded repair loop.
 - Watcher and continuation prompts must explicitly say “verify compatibility
   without source mutation”; never tell a source owner to “reconcile again” for
   ordinary protected-branch movement.

--- a/scripts/check-source-admission.test.ts
+++ b/scripts/check-source-admission.test.ts
@@ -7,6 +7,7 @@ import { CONTRACT, directTreeManifest, verifySourceAdmission } from "./check-sou
 const repositoryRoot = join(import.meta.dir, "..");
 const workflowPath = join(repositoryRoot, CONTRACT.workflowPath);
 const helperPath = join(repositoryRoot, CONTRACT.helperPath);
+const skillPath = join(repositoryRoot, ".agents/skills/opengeni/SKILL.md");
 const baseSha = "b".repeat(40);
 const headSha = "c".repeat(40);
 const baseTreeSha = "d".repeat(40);
@@ -488,5 +489,20 @@ describe("source admission", () => {
     expect(workflow).toContain(`ADMISSION_HELPER_SHA256: ${helperSha256}`);
     expect(workflow).toContain("ref=$GITHUB_WORKFLOW_SHA");
     expect(workflow).toContain('node "$helper"');
+  });
+
+  test("repository skill requires leaf-cause triage and immutable-head delivery", () => {
+    const skill = readFileSync(skillPath, "utf8");
+    expect(skill).toContain("Before any push or exact-head rotation");
+    expect(skill).toContain("aggregate or dependent gates are consequences");
+    expect(skill).toContain(
+      "candidate-caused, base-caused, transient\n  runner/dependency, or superseded/cancelled",
+    );
+    expect(skill).toContain("rerun failed jobs only");
+    expect(skill).toContain("Do not edit source or rotate the head");
+    expect(skill).toContain("disposable\n  current-main merge and inspect the integrated tree");
+    expect(skill).toContain("do not merge or rebase `main` again merely");
+    expect(skill).toContain("Create a commit only to repair that real defect or\n  conflict");
+    expect(skill).toContain("never create an empty or evidence-only head rotation");
   });
 });

--- a/scripts/check-source-admission.test.ts
+++ b/scripts/check-source-admission.test.ts
@@ -493,12 +493,22 @@ describe("source admission", () => {
 
   test("repository skill requires leaf-cause triage and immutable-head delivery", () => {
     const skill = readFileSync(skillPath, "utf8");
+    const normalizedSkill = skill.replace(/\s+/g, " ").trim();
     expect(skill).toContain("Before any push or exact-head rotation");
     expect(skill).toContain("aggregate or dependent gates are consequences");
     expect(skill).toContain(
       "candidate-caused, base-caused, transient\n  runner/dependency, or superseded/cancelled",
     );
     expect(skill).toContain("rerun failed jobs only");
+    expect(normalizedSkill).toContain(
+      "Before any push or exact-head rotation, inspect the leaf failed jobs and steps;",
+    );
+    expect(normalizedSkill).toContain(
+      "aggregate or dependent gates are consequences, not independent root causes.",
+    );
+    expect(normalizedSkill).toContain(
+      "For an identical-head transient install, extraction, dependency, or runner failure, rerun failed jobs only.",
+    );
     expect(skill).toContain("Do not edit source or rotate the head");
     expect(skill).toContain("disposable\n  current-main merge and inspect the integrated tree");
     expect(skill).toContain("do not merge or rebase `main` again merely");


### PR DESCRIPTION
## Summary
- require leaf-job/root-cause inspection before any push or exact-head rotation
- preserve identical candidate heads for transient runner, install, extraction, and dependency failures
- require disposable current-main integration proof and prohibit empty/evidence-only commits
- pin the repository-agent contract with a deterministic source-admission test

## Scope
- changes only `.agents/skills/opengeni/SKILL.md` and `scripts/check-source-admission.test.ts`
- does not modify `.github/workflows/ci.yml`
- does not overlap the exact paths owned by open PRs #1306 or #1324

## Validation
- `bun test scripts/check-source-admission.test.ts` (19 pass, 0 fail)
- `bun run lint` (0 warnings/errors)
- `bun run format:check`
- `bun run check:docs-refs`
- `bun run typecheck` (29 projects clean)
- isolated load-timeout rerun: 1 pass, 0 fail
- full `bun test`: 7,928 pass, 36 skip, 57 local-environment failures; leaf roots were unavailable Rust/Cargo, Docker/PostgreSQL, platform-specific shell fixtures, plus one suite-load timeout that passed alone