### PR TITLE
OPE-126: fix reproduced knowledge sync edge cases

### DIFF
--- a/apps/worker/src/activities/knowledge-source-sync.ts
+++ b/apps/worker/src/activities/knowledge-source-sync.ts
@@ -1,7 +1,11 @@
 import { createHash } from "node:crypto";
 import { heartbeat } from "@temporalio/activity";
 import type { Settings } from "@opengeni/config";
-import { KnowledgeSourceSyncRunSummary, type ScheduledTask } from "@opengeni/contracts";
+import {
+  KnowledgeSourceSyncRunSummary,
+  type ScheduledTask,
+  type ScopedKnowledgeScope,
+} from "@opengeni/contracts";
 import {
   ATLASSIAN_PROVIDER_DOMAIN,
   AtlassianConnectionMetadata,
@@ -62,6 +66,7 @@ import {
   releaseKnowledgeSourceSyncLeaseForRetry,
   restoreKnowledgeSourceObject,
   retryKnowledgeSourceSyncIndexObligation,
+  scopedKnowledgeScopeKey,
   settleKnowledgeSourceSyncLease,
   settleKnowledgeSourceSyncIndexObligation,
   updateKnowledgeSourceDocumentObservationMetadata,
@@ -194,7 +199,10 @@ export function createKnowledgeSourceSyncActivities(
         if (!resolved || resolved.source.lifecycleState !== "active") {
           throw new SyncFailure("authority_changed", false);
         }
-        if (JSON.stringify(resolved.source.scope) !== JSON.stringify(action.destination)) {
+        if (
+          scopedKnowledgeScopeKey(resolved.source.scope) !==
+          scopedKnowledgeScopeKey(action.destination)
+        ) {
           throw new SyncFailure("authority_changed", false);
         }
         const liveState = await reconcileKnowledgeSourceSyncLiveGeneration(db, {
@@ -449,7 +457,7 @@ export function createKnowledgeSourceSyncActivities(
           if (details.indexRequired) {
             summary.phase = "index";
             try {
-              await documentActivities.indexDocument({
+              const indexedDocument = await documentActivities.indexDocument({
                 accountId: input.accountId,
                 workspaceId: input.workspaceId,
                 documentId: details.version.documentId,
@@ -457,6 +465,9 @@ export function createKnowledgeSourceSyncActivities(
                 authorityWorkspaceId: action.destination.workspaceId,
                 authoritySubjectId: action.destination.subjectId,
               });
+              if (indexedDocument.status !== "ready") {
+                throw new Error("document indexing did not complete");
+              }
             } catch {
               await settleKnowledgeSourceSyncIndexObligation(db, {
                 accountId: input.accountId,
@@ -1261,11 +1272,11 @@ async function resolveKnowledgeSyncProvider(input: {
     !initialSource.syncEnabled ||
     initialSource.configGeneration !== action.sourceConfigGeneration ||
     !initialSource.destination ||
-    JSON.stringify(
+    scopedKnowledgeScopeKey(
       googleInitial?.success
         ? googleDriveKnowledgeScope(initialSource.destination)
         : atlassianKnowledgeScope(initialSource.destination),
-    ) !== JSON.stringify(action.destination)
+    ) !== scopedKnowledgeScopeKey(action.destination)
   ) {
     throw new SyncFailure("authority_changed", false);
   }
@@ -1381,14 +1392,15 @@ async function resolveKnowledgeSyncProvider(input: {
 function validSelectedSource<Source extends GoogleDriveSelectedSource | AtlassianSelectedSource>(
   source: Source | null,
   action: Extract<ScheduledTask["action"], { kind: "knowledge_source_sync" }>,
-  scope: (destination: NonNullable<Source["destination"]>) => unknown,
+  scope: (destination: NonNullable<Source["destination"]>) => ScopedKnowledgeScope,
 ): source is Source & { destination: NonNullable<Source["destination"]> } {
   return Boolean(
     source &&
     source.syncEnabled &&
     source.configGeneration === action.sourceConfigGeneration &&
     source.destination &&
-    JSON.stringify(scope(source.destination)) === JSON.stringify(action.destination),
+    scopedKnowledgeScopeKey(scope(source.destination)) ===
+      scopedKnowledgeScopeKey(action.destination),
   );
 }
 

--- a/apps/worker/test/knowledge-source-schedule-dispatch.test.ts
+++ b/apps/worker/test/knowledge-source-schedule-dispatch.test.ts
@@ -221,6 +221,9 @@ describe("knowledge-source schedule dispatch", () => {
       sourceId: source.id,
       overlapPolicy: "buffer_one",
     });
+    if (result.action !== "knowledge_source_sync") {
+      throw new Error("knowledge source dispatch was not created");
+    }
     const [facts] = await admin<
       Array<{ sessions: number; agentUsage: number; syncUsage: number; syncStates: number }>
     >`
@@ -233,6 +236,79 @@ describe("knowledge-source schedule dispatch", () => {
         (select count(*)::int from knowledge_source_sync_states
           where workspace_id = ${workspace!.id}) as "syncStates"`;
     expect(facts).toEqual({ sessions: 0, agentUsage: 0, syncUsage: 1, syncStates: 1 });
+
+    const firstLease = await claimKnowledgeSourceSyncLease(client.db, {
+      accountId: account!.id,
+      workspaceId: workspace!.id,
+      sourceId: source.id,
+      scheduledTaskRunId: result.scheduledTaskRunId,
+      overlapPolicy: "buffer_one",
+    });
+    expect(firstLease.action).toBe("claimed");
+    const bufferedDispatch = await activities.dispatchScheduledTaskRun({
+      workspaceId: workspace!.id,
+      taskId: task.id,
+      triggerType: "scheduled",
+      producerKey: "knowledge-dispatch-buffered",
+    });
+    if (bufferedDispatch.action !== "knowledge_source_sync") {
+      throw new Error("buffered knowledge source dispatch was not created");
+    }
+    const bufferedLease = await claimKnowledgeSourceSyncLease(client.db, {
+      accountId: account!.id,
+      workspaceId: workspace!.id,
+      sourceId: source.id,
+      scheduledTaskRunId: bufferedDispatch.scheduledTaskRunId,
+      overlapPolicy: "buffer_one",
+    });
+    expect(bufferedLease.action).toBe("buffered");
+    await admin`
+      update knowledge_source_sync_states
+      set lease_until = now() - interval '1 second'
+      where source_id = ${source.id}`;
+    const reclaimedLease = await claimKnowledgeSourceSyncLease(client.db, {
+      accountId: account!.id,
+      workspaceId: workspace!.id,
+      sourceId: source.id,
+      scheduledTaskRunId: bufferedDispatch.scheduledTaskRunId,
+      overlapPolicy: "buffer_one",
+    });
+    expect(reclaimedLease).toMatchObject({
+      action: "claimed",
+      state: {
+        bufferedWake: false,
+        bufferedScheduledTaskRunId: null,
+      },
+    });
+    await settleKnowledgeSourceSyncLease(client.db, {
+      accountId: account!.id,
+      workspaceId: workspace!.id,
+      sourceId: source.id,
+      scheduledTaskRunId: bufferedDispatch.scheduledTaskRunId,
+      status: "failed",
+      summary: {
+        phase: "failed",
+        scanned: 0,
+        imported: 0,
+        unchanged: 0,
+        skipped: 0,
+        failed: 1,
+        bytes: 0,
+        providerRequests: 0,
+        elapsedMs: 1,
+        indexed: 0,
+        aclPending: 0,
+        retryable: false,
+        limitReached: null,
+        checkpointed: false,
+        reconnectRequired: false,
+        failures: [],
+      },
+      error: "test_cleanup",
+      sourceConfigGeneration: 1,
+      sourceLifecycleGeneration: source.lifecycleGeneration,
+      sourceSyncGeneration: source.syncGeneration,
+    });
   }, 60_000);
 
   test("discovers every connection task beyond 500 rows on a stable created_at/id keyset", async () => {

--- a/packages/core/src/domain/scheduled-tasks.ts
+++ b/packages/core/src/domain/scheduled-tasks.ts
@@ -23,6 +23,7 @@ import {
   getScheduledTaskPersonalConnectionDelegations,
   getSession,
   requireWorkspace,
+  scopedKnowledgeScopeKey,
   updateScheduledTask,
   type Database,
   type UpdateScheduledTaskInput,
@@ -620,7 +621,8 @@ async function validateKnowledgeSourceSyncAction(input: {
   if (
     resolved.source.syncGeneration !== input.action.sourceGeneration ||
     resolved.source.lifecycleGeneration !== input.action.sourceLifecycleGeneration ||
-    JSON.stringify(resolved.source.scope) !== JSON.stringify(input.action.destination)
+    scopedKnowledgeScopeKey(resolved.source.scope) !==
+      scopedKnowledgeScopeKey(input.action.destination)
   ) {
     throw new HTTPException(409, {
       message: "knowledge source authority or generation changed",

--- a/packages/db/src/knowledge-source-sync.ts
+++ b/packages/db/src/knowledge-source-sync.ts
@@ -347,6 +347,7 @@ export async function claimKnowledgeSourceSyncLease(
             leaseId: input.scheduledTaskRunId,
             leaseUntil,
             bufferedWake: false,
+            bufferedScheduledTaskRunId: null,
             activeScanGeneration: sql`case
               when ${schema.knowledgeSourceSyncStates.leaseId} = ${input.scheduledTaskRunId}::uuid
                 then ${schema.knowledgeSourceSyncStates.activeScanGeneration}


### PR DESCRIPTION
Follow-up to #1315 for three defects reproduced during local Google Drive acceptance.

- Clear a buffered scheduled-run id when an expired lease is taken over.
- Compare scoped knowledge destinations with their canonical scope key.
- Treat a non-ready document indexing result as a failed obligation.

Verification:
- `bun test apps/worker/test/knowledge-source-schedule-dispatch.test.ts` (6 pass, 86 expectations)
- `bun run typecheck` (29 projects clean)
- `bunx oxlint` on touched files
- `git diff --check`

Linear: OPE-126