### PR TITLE
Fix prompt admission latency and optimistic sends

### DIFF
--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1171,9 +1171,10 @@ function SessionChatPane(props: {
     sendBlocked: () => attachments.hasUnresolved || repositories.error !== null,
     effectiveControl: props.queue.effectiveControl ?? props.session.effectiveControl,
     onDraftApplied: applyComposerSettings,
-    // Clear only files included in the accepted wire input. A file added while
-    // sendMessage is in flight belongs to the next message and must survive.
-    onSent: (_text, input) => {
+    // Ordinary Send is acknowledged locally. Clear only resources captured in
+    // that immutable optimistic operation; later additions belong to the next
+    // draft, while retry keeps the original resource refs in the failed bubble.
+    onSubmitted: (_text, input) => {
       attachments.removeReadyFiles(
         (input.resources ?? []).flatMap((resource) =>
           resource.kind === "file" ? [resource.fileId] : [],
@@ -1182,6 +1183,38 @@ function SessionChatPane(props: {
       repositories.commitSent(input.resources ?? []);
     },
   });
+  const timelineWithOptimisticSends = useMemo<TimelineItem[]>(() => {
+    const acceptedClientEventIds = new Set(
+      props.events
+        .filter((event) => event.type === "user.message" && event.clientEventId)
+        .map((event) => event.clientEventId as string),
+    );
+    const optimisticItems: UserMessageItem[] = (composer.optimisticMessages ?? [])
+      .filter((message) => !acceptedClientEventIds.has(message.clientEventId))
+      .map((message) => ({
+        kind: "user-message",
+        id: `optimistic:${message.clientEventId}`,
+        text: message.text,
+        annotations: message.annotations.map((annotation, ordinal) => ({
+          ...annotation,
+          ordinal,
+        })),
+        resources: message.resources,
+        tools: [],
+        occurredAt: message.occurredAt,
+        delivery: {
+          state: message.state,
+          ...(message.error ? { error: message.error } : {}),
+          ...(message.state === "failed"
+            ? {
+                onRetry: () => composer.retryOptimisticMessage?.(message.clientEventId),
+                onRemove: () => composer.removeOptimisticMessage?.(message.clientEventId),
+              }
+            : {}),
+        },
+      }));
+    return [...props.timeline, ...optimisticItems];
+  }, [composer, props.events, props.timeline]);
   const repositoryPickerProps = repositories.pickerProps(terminal || composer.sending);
 
   // Slash-command palette context: the operator controls (/goal, /clear,
@@ -1254,7 +1287,7 @@ function SessionChatPane(props: {
           <div data-testid="session-timeline" className="min-h-0 min-w-0 flex-1">
             <MessageTimeline
               className="h-full"
-              items={props.timeline}
+              items={timelineWithOptimisticSends}
               status={props.session.status}
               computeLabel={computeLabel}
               renderMessageText={renderMessageText}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,15 @@ These are the load-bearing, cross-cutting rules. Breaking one tends to be a subt
   authoritative session event without a prior durable append; never reverse the
   order. A fanout failure must not kill an in-flight turn because consumers
   reconcile missed events from the durable log.
+- **Prompt admission acknowledges the durable commit, not transport follow-up.**
+  Send/Steer authorization, policy and limit checks precede one transaction that
+  commits the `user.message`, queued turn, session/queue mutation, audit record,
+  run-usage fact, and workflow-wake outbox revision. The API response is projected
+  from those committed rows without a post-commit reload. NATS/workspace-control
+  fanout and the immediate Temporal wake attempt are replayable post-commit work;
+  they cannot delay or reverse the accepted response. The browser ordinary-Send
+  path likewise acknowledges locally with one `clientEventId`, renders a bounded
+  optimistic message, and reconciles it against the authoritative event stream.
 - **Connected-machine commands also use NATS.** Agent request/reply, streamed
   operation frames, heartbeats, and enrollment auth callout all cross the same
   broker. They are live transport, not durable broker state. A broker restart

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -22,6 +22,25 @@ one non-retryable Temporal `runAgentTurn` activity. Inside the activity the
 OpenAI Agents SDK loop makes as many model calls and tool calls as the work
 needs.
 
+Ordinary Send acknowledges locally before transport completion. The composer
+freezes the exact text, annotations, resources, settings, and one
+`clientEventId`, clears the visible draft immediately, and renders that snapshot
+as `Sending`, `Queued`, or `Not sent`. Rapid distinct sends keep distinct keys
+and preserve order. An outcome-unknown retry first reconciles and reuses the
+same key; a definite rejection retry receives a fresh key. Newer edits are a
+separate draft shadow and survive the in-flight operation and remount. The
+optimistic row disappears when the authoritative `user.message` arrives, so
+HTTP-first, SSE-first, reconnect, and remount paths cannot create duplicate
+visible messages.
+
+On the server, prompt acceptance remains one canonical Postgres transaction:
+the user event, queued turn, session/queue state, optional realtime mirror,
+audit receipt, `agent_run.created` usage fact, and workflow-wake outbox revision
+commit together. The response is built from those returned committed rows.
+NATS and workspace-control fanout plus the immediate Temporal wake attempt are
+scheduled only after commit and are not response-holding; durable event replay
+and the wake outbox recover their failures.
+
 The same ordinary session can add and remove a realtime voice
 conversational transport without creating a second session, queue, or workflow.
 Only the authenticated browser owner/connection is exclusive. Human

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -105,6 +105,8 @@ export type AppDependencies = {
   editableArtifactOfficeImports?: EditableArtifactOfficeImportPort;
   bus: EventBus;
   workflowClient: SessionWorkflowClient;
+  /** Injectable structural seam for replayable prompt fanout and wake work. */
+  schedulePromptPostCommit?: (task: () => Promise<void>) => void;
   /** Optional provider override for deterministic API/object-storage tests. */
   objectStorage?: ObjectStorageDependency;
   documentIndexer?: DocumentIndexClient;
@@ -184,7 +186,7 @@ export type ApiRouteDeps = AppDependencies & {
  */
 export type AcceptSessionUserMessageDependencies = Pick<
   AppDependencies,
-  "settings" | "db" | "bus" | "sessionAuthorization"
+  "settings" | "db" | "bus" | "sessionAuthorization" | "schedulePromptPostCommit"
 > & {
   workflowClient: Pick<SessionWorkflowClient, "wakeSessionWorkflow">;
   objectStorage: ObjectStorageDependency;

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -61,7 +61,6 @@ import {
   getSession,
   SessionIdConflictError,
   getSessionSpawnDenialByIdempotencyKey,
-  getSessionEvent,
   getWorkspaceControlEvent,
   getSessionLineage,
   getSessionTurn,
@@ -1074,6 +1073,8 @@ export async function postUserMessageTurn(input: {
   expectedDraftRevision?: number | null;
   reasoningEffortFallback?: Settings["openaiReasoningEffort"];
   turnExecutionPolicy: TurnExecutionPolicyV1;
+  recordAgentRunUsage?: boolean;
+  schedulePostCommit?: (task: () => Promise<void>) => void;
 }): Promise<{
   accepted: SessionEvent;
   turn: SessionTurn;
@@ -1137,6 +1138,9 @@ export async function postUserMessageTurn(input: {
                 input.reasoningEffortFallback ?? settings.openaiReasoningEffort,
               turnExecutionPolicy: input.turnExecutionPolicy,
               source: input.origin === "operator" ? "api" : "user",
+              ...(input.recordAgentRunUsage !== undefined
+                ? { recordAgentRunUsage: input.recordAgentRunUsage }
+                : {}),
               personalConnectionDelegations: input.personalConnectionDelegations ?? [],
               mcpCredentialUpdates: input.mcpCredentialUpdates ?? [],
             }),
@@ -1157,56 +1161,65 @@ export async function postUserMessageTurn(input: {
     }
     throw error;
   }
-  const events = await Promise.all(
-    result.eventIds.map((eventId) => getSessionEvent(db, workspaceId, eventId)),
-  );
-  if (events.some((event) => event === null)) {
-    throw new Error("Committed prompt events could not be reloaded");
-  }
-  const turn = await getSessionTurn(db, workspaceId, result.turnId);
-  if (!turn) throw new Error("Committed prompt turn could not be reloaded");
-  const accepted = events.find((event) => event?.id === result.acceptedEventId);
-  if (!accepted) throw new Error("Committed user.message event could not be reloaded");
-  await publishDurableSessionEvents(
-    bus,
-    workspaceId,
-    sessionId,
-    events.filter((event): event is SessionEvent => event !== null),
-  );
-  if (result.workspaceControlEventId) {
-    const controlEvent = await getWorkspaceControlEvent(
-      db,
-      workspaceId,
-      result.workspaceControlEventId,
-    );
-    if (!controlEvent) {
-      throw new Error(
-        `Committed workspace control event disappeared: ${result.workspaceControlEventId}`,
-      );
+  const postCommitTask = async () => {
+    try {
+      await publishDurableSessionEvents(bus, workspaceId, sessionId, result.events);
+      if (result.workspaceControlEventId) {
+        const controlEvent = await getWorkspaceControlEvent(
+          db,
+          workspaceId,
+          result.workspaceControlEventId,
+        );
+        if (!controlEvent) {
+          throw new Error(
+            `Committed workspace control event disappeared: ${result.workspaceControlEventId}`,
+          );
+        }
+        await publishDurableWorkspaceControlEvent(bus, workspaceId, controlEvent);
+      }
+    } catch {
+      console.warn("[sessions] prompt event fanout failed; durable rows remain replayable", {
+        errorClass: "PromptEventFanoutOperationError",
+        errorCode: "session_prompt_event_fanout_failed",
+        origin: "core",
+      });
     }
-    await publishDurableWorkspaceControlEvent(bus, workspaceId, controlEvent);
-  }
-  try {
-    await workflowClient.wakeSessionWorkflow({
-      accountId,
-      workspaceId,
-      sessionId,
-      workflowId: turn.temporalWorkflowId,
-      wakeRevision: result.wakeRevision,
-      ...((input.delivery ?? "send") === "steer" || result.interruptionCount > 0
-        ? { interruptionRequested: true }
-        : {}),
+    try {
+      await workflowClient.wakeSessionWorkflow({
+        accountId,
+        workspaceId,
+        sessionId,
+        workflowId: result.turn.temporalWorkflowId,
+        wakeRevision: result.wakeRevision,
+        ...((input.delivery ?? "send") === "steer" || result.interruptionCount > 0
+          ? { interruptionRequested: true }
+          : {}),
+      });
+    } catch {
+      console.warn("[sessions] workflow wake failed; durable outbox will retry", {
+        errorClass: "WorkflowWakeOperationError",
+        errorCode: "session_workflow_wake_failed",
+        origin: "core",
+      });
+    }
+  };
+  const schedulePostCommit =
+    input.schedulePostCommit ??
+    ((task: () => Promise<void>) => {
+      void task();
     });
+  try {
+    schedulePostCommit(postCommitTask);
   } catch {
-    console.warn("[sessions] workflow wake failed; durable outbox will retry", {
-      errorClass: "WorkflowWakeOperationError",
-      errorCode: "session_workflow_wake_failed",
+    console.warn("[sessions] prompt post-commit scheduling failed; durable recovery remains", {
+      errorClass: "PromptPostCommitScheduleError",
+      errorCode: "session_prompt_post_commit_schedule_failed",
       origin: "core",
     });
   }
   return {
-    accepted,
-    turn,
+    accepted: result.accepted,
+    turn: result.turn,
     interruptionCount: result.interruptionCount,
     replay: result.replay,
   };
@@ -2056,22 +2069,8 @@ export async function acceptSessionUserMessageWithOutcome(
       ? { expectedDraftRevision: input.expectedDraftRevision }
       : {}),
     ...(input.clientEventId ? { clientEventId: input.clientEventId } : {}),
-  });
-  await recordWorkspaceUsage(deps, {
-    accountId: grant.accountId,
-    workspaceId,
-    subjectId: grant.subjectId,
-    eventType: "agent_run.created",
-    quantity: 1,
-    unit: "run",
-    sourceResourceType: "session_turn",
-    sourceResourceId: turn.id,
-    sessionId,
-    turnId: turn.id,
-    initiator: turn.initiator,
-    initiatorContext: turn.initiatorContext,
-    origin: turn.source,
-    idempotencyKey: `agent_run.created:${workspaceId}:${turn.id}`,
+    recordAgentRunUsage: true,
+    ...(deps.schedulePromptPostCommit ? { schedulePostCommit: deps.schedulePromptPostCommit } : {}),
   });
   return { accepted, turn, interruptionCount, replay };
 }

--- a/packages/db/src/session-queue-commands.ts
+++ b/packages/db/src/session-queue-commands.ts
@@ -13,12 +13,24 @@ import {
   type DraftTimelineAnnotation,
   type LatencyMode,
   type ReasoningEffort,
+  type SandboxBackend,
+  type SandboxOs,
+  type SessionEvent,
+  type SessionEventType,
+  type SessionTurn,
+  type SessionTurnSource,
+  type SessionTurnStatus,
+  type ToolRef,
   type TurnExecutionPolicyV1,
   type TimelineAnnotation,
 } from "@opengeni/contracts";
 import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import type { Database, SessionActivityDatabase } from "./database";
-import { withLosslessContentWriteVersion } from "./lossless-json";
+import {
+  fromPostgresLosslessJson,
+  fromPostgresLosslessText,
+  withLosslessContentWriteVersion,
+} from "./lossless-json";
 import { closePendingSessionToolCallsInTransaction } from "./session-tool-call-settlement";
 import {
   assertAgentCommandAuthorityInTransaction,
@@ -102,6 +114,10 @@ export type SteerQueueCommandResult = QueueCommandResult & {
 export type SubmitHumanPromptResult = {
   receipt: SessionCommandReceiptRow;
   queueVersion: number;
+  accepted: SessionEvent;
+  events: SessionEvent[];
+  turn: SessionTurn;
+  /** Backward-compatible row identities for lower-level callers. */
   acceptedEventId: string;
   eventIds: string[];
   turnId: string;
@@ -110,6 +126,69 @@ export type SubmitHumanPromptResult = {
   workspaceControlEventId: string | null;
   replay: boolean;
 };
+
+function mapSubmittedPromptEvent(row: typeof schema.sessionEvents.$inferSelect): SessionEvent {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    sessionId: row.sessionId,
+    sequence: row.sequence,
+    type: row.type as SessionEventType,
+    payload: fromPostgresLosslessJson(row.payload, row.payloadCodecVersion),
+    occurredAt: row.occurredAt.toISOString(),
+    clientEventId: row.clientEventId,
+    turnId: row.turnId,
+    turnGeneration: row.turnGeneration,
+    turnAttemptId: row.turnAttemptId,
+    turnAssociation: row.turnAssociation as SessionEvent["turnAssociation"],
+    duplicateOfEventId: row.duplicateOfEventId,
+    duplicateReason: row.duplicateReason,
+  };
+}
+
+function mapSubmittedPromptTurn(row: typeof schema.sessionTurns.$inferSelect): SessionTurn {
+  const personalConnections = McpPersonalConnectionDelegations.parse(
+    row.personalConnectionDelegations,
+  ).map(({ serverId, providerDomain }) => ({ serverId, providerDomain }));
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    sessionId: row.sessionId,
+    triggerEventId: row.triggerEventId,
+    temporalWorkflowId: row.temporalWorkflowId,
+    status: row.status as SessionTurnStatus,
+    source: row.source as SessionTurnSource,
+    position: row.position,
+    prompt: fromPostgresLosslessText(row.prompt, row.promptCodecVersion),
+    annotations: TimelineAnnotations.parse(row.annotations),
+    resources: row.resources as ResourceRef[],
+    tools: row.tools as ToolRef[],
+    toolsProvided: row.toolsProvided,
+    model: row.model,
+    reasoningEffort: row.reasoningEffort as ReasoningEffort,
+    latencyMode: (row.latencyMode as LatencyMode | null | undefined) ?? "standard",
+    sandboxBackend: row.sandboxBackend as SandboxBackend,
+    sandboxOs: (row.sandboxOs as SandboxOs | null) ?? null,
+    metadata: row.metadata,
+    version: row.version,
+    executionGeneration: row.executionGeneration,
+    activeAttemptId: row.activeAttemptId,
+    lineage: row.lineage,
+    initiator: initiatorFromStorage(
+      row.initiatorKind,
+      row.initiatorSubjectId,
+      row.initiatorContext ?? {},
+    ),
+    initiatorContext: row.initiatorContext ?? {},
+    personalConnections,
+    cancelledBy: row.cancelledBy,
+    cancelReason: row.cancelReason,
+    startedAt: row.startedAt ? row.startedAt.toISOString() : null,
+    finishedAt: row.finishedAt ? row.finishedAt.toISOString() : null,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
 
 export type AgentInternalUpdateCommandResult = {
   receipt: SessionCommandReceiptRow;
@@ -1291,6 +1370,8 @@ export async function submitHumanPromptInTransaction(
       context: string;
     };
     source: "user" | "api";
+    /** Record the admitted run's durable usage fact in this transaction. */
+    recordAgentRunUsage?: boolean;
     personalConnectionDelegations?: McpPersonalConnectionDelegation[];
     mcpCredentialUpdates?: Array<{
       id: string;
@@ -1355,9 +1436,39 @@ export async function submitHumanPromptInTransaction(
     if (!turnId || !acceptedEventId || wakeRevision < 1) {
       throw new SessionControlInvariantError("Replayed prompt receipt is incomplete");
     }
+    const replayEvents = await db
+      .select()
+      .from(schema.sessionEvents)
+      .where(
+        and(
+          eq(schema.sessionEvents.workspaceId, input.workspaceId),
+          eq(schema.sessionEvents.sessionId, input.sessionId),
+          inArray(schema.sessionEvents.id, eventIds),
+        ),
+      )
+      .orderBy(asc(schema.sessionEvents.sequence));
+    const [replayTurn] = await db
+      .select()
+      .from(schema.sessionTurns)
+      .where(
+        and(
+          eq(schema.sessionTurns.workspaceId, input.workspaceId),
+          eq(schema.sessionTurns.sessionId, input.sessionId),
+          eq(schema.sessionTurns.id, turnId),
+        ),
+      )
+      .limit(1);
+    const events = replayEvents.map(mapSubmittedPromptEvent);
+    const accepted = events.find((event) => event.id === acceptedEventId);
+    if (!accepted || !replayTurn || events.length !== eventIds.length) {
+      throw new SessionControlInvariantError("Replayed prompt rows are incomplete");
+    }
     return {
       receipt: reserved.receipt,
       queueVersion: Number(reserved.receipt.appliedQueueVersion),
+      accepted,
+      events,
+      turn: mapSubmittedPromptTurn(replayTurn),
       acceptedEventId,
       eventIds,
       turnId,
@@ -1628,6 +1739,7 @@ export async function submitHumanPromptInTransaction(
     )
     .returning();
   if (!turn) throw new SessionControlInvariantError("Prompt turn was not inserted");
+  let committedTurn = turn;
   eventValues.push({
     accountId: input.accountId,
     workspaceId: input.workspaceId,
@@ -1678,7 +1790,7 @@ export async function submitHumanPromptInTransaction(
   // settlement has already cleared sessions.active_turn_id. Do not infer this
   // state from a local request spinner or queue position.
   if (input.delivery === "steer") {
-    await db
+    const [updatedTurn] = await db
       .update(schema.sessionTurns)
       .set({
         metadata: {
@@ -1696,7 +1808,12 @@ export async function submitHumanPromptInTransaction(
           eq(schema.sessionTurns.sessionId, input.sessionId),
           eq(schema.sessionTurns.id, turnId),
         ),
-      );
+      )
+      .returning();
+    if (!updatedTurn) {
+      throw new SessionControlInvariantError("Steer prompt turn metadata was not updated");
+    }
+    committedTurn = updatedTurn;
   }
   if (supersession.replacedTurn) {
     const current = supersession.replacedTurn;
@@ -1838,6 +1955,27 @@ export async function submitHumanPromptInTransaction(
       "metadataCodecVersion",
     ),
   );
+  if (input.recordAgentRunUsage) {
+    await db
+      .insert(schema.usageEvents)
+      .values({
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
+        subjectId: input.subjectId,
+        eventType: "agent_run.created",
+        quantity: 1,
+        unit: "run",
+        sourceResourceType: "session_turn",
+        sourceResourceId: turnId,
+        sessionId: input.sessionId,
+        turnId,
+        ...initiatorColumns(frozenInitiator),
+        origin: input.source,
+        idempotencyKey: `agent_run.created:${input.workspaceId}:${turnId}`,
+        occurredAt: now,
+      })
+      .onConflictDoNothing({ target: schema.usageEvents.idempotencyKey });
+  }
   const eventIds = eventRows.map((event) => event.id);
   const receipt = await updateSessionCommandReceiptResult(db, reserved.receipt.id, {
     controlRevision: resumed.revision,
@@ -1859,9 +1997,17 @@ export async function submitHumanPromptInTransaction(
         : {}),
     },
   });
+  const events = eventRows.map(mapSubmittedPromptEvent);
+  const accepted = events.find((event) => event.id === acceptedEventId);
+  if (!accepted) {
+    throw new SessionControlInvariantError("Inserted user.message event is missing");
+  }
   return {
     receipt,
     queueVersion,
+    accepted,
+    events,
+    turn: mapSubmittedPromptTurn(committedTurn),
     acceptedEventId,
     eventIds,
     turnId,

--- a/packages/react/src/components/message-timeline.tsx
+++ b/packages/react/src/components/message-timeline.tsx
@@ -2380,6 +2380,14 @@ function UserMessageRow({
     | undefined;
 }) {
   const enter = useEntranceAnimation();
+  const deliveryLabel =
+    item.delivery?.state === "sending"
+      ? "Sending…"
+      : item.delivery?.state === "queued"
+        ? "Queued"
+        : item.delivery?.state === "failed"
+          ? "Not sent"
+          : null;
   return (
     <div className={cn(enter && "animate-og-enter", "flex justify-end")}>
       <div className="flex max-w-[85%] min-w-0 flex-col items-end gap-1">
@@ -2414,6 +2422,29 @@ function UserMessageRow({
             ) : null}
           </div>
         </CopyHoverFrame>
+        {deliveryLabel ? (
+          <div className="flex max-w-full items-center gap-2 px-1 text-og-xs text-og-fg-subtle">
+            <span title={item.delivery?.error}>{deliveryLabel}</span>
+            {item.delivery?.state === "failed" && item.delivery.onRetry ? (
+              <button
+                type="button"
+                className="font-medium text-og-fg underline decoration-og-border underline-offset-2 hover:text-og-fg-strong"
+                onClick={item.delivery.onRetry}
+              >
+                Retry
+              </button>
+            ) : null}
+            {item.delivery?.state === "failed" && item.delivery.onRemove ? (
+              <button
+                type="button"
+                className="font-medium text-og-fg-subtle underline decoration-og-border underline-offset-2 hover:text-og-fg"
+                onClick={item.delivery.onRemove}
+              >
+                Remove
+              </button>
+            ) : null}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -18,6 +18,8 @@ export type ComposerSendExtras = Omit<SendMessageInput, "text" | "clientEventId"
 
 export type UseComposerOptions = EmbeddedSessionClientOverride &
   SessionEventFeedOptions & {
+    /** Called synchronously after an ordinary Send is accepted by the local UI. */
+    onSubmitted?: ((text: string, input: SendMessageInput) => void) | undefined;
     /** Called with the exact accepted wire input after a successful send. */
     onSent?: ((text: string, input: SendMessageInput) => void) | undefined;
     /**
@@ -64,13 +66,39 @@ type StoredPendingComposerOperation = Omit<PendingComposerOperation, "input" | "
   hasMcpCredentialUpdates: boolean;
 };
 
+export type ComposerOptimisticMessage = {
+  clientEventId: string;
+  text: string;
+  annotations: DraftTimelineAnnotation[];
+  resources: ResourceRef[];
+  occurredAt: string;
+  state: "sending" | "queued" | "failed";
+  error?: string | undefined;
+  outcomeUnknown?: boolean | undefined;
+};
+
+type OptimisticSendOperation = ComposerOptimisticMessage & {
+  input: SendMessageInput;
+  draftPayload: SaveComposerDraftRequest | null;
+  /** Latest unsent local draft that must survive this operation and remounts. */
+  newerShadow: ComposerDraftShadow;
+  canRetry: boolean;
+};
+
+type StoredOptimisticSendOperation = Omit<OptimisticSendOperation, "input" | "canRetry"> & {
+  input: Omit<SendMessageInput, "mcpCredentialUpdates">;
+  hasMcpCredentialUpdates: boolean;
+};
+
 const PENDING_COMPOSER_STORAGE_PREFIX = "opengeni.pending-composer.v1:";
+const OPTIMISTIC_SEND_STORAGE_PREFIX = "opengeni.optimistic-sends.v1:";
 
 // A remount must not manufacture a new operation while the previous mutation
 // is still outcome-unknown. Keep only non-credential request fields here; the
 // mounted hook retains the exact input, including any credential updates. The
 // safe shadow is also session-scoped so a refresh cannot lose newer edits.
 const pendingComposerOperations = new Map<string, StoredPendingComposerOperation>();
+const optimisticSendOperations = new Map<string, StoredOptimisticSendOperation[]>();
 
 function pendingComposerOperationKey(
   workspaceId: string,
@@ -89,6 +117,78 @@ function pendingComposerStorage(): Storage | null {
 
 function pendingComposerStorageKey(key: string): string {
   return `${PENDING_COMPOSER_STORAGE_PREFIX}${encodeURIComponent(key)}`;
+}
+
+function optimisticSendStorageKey(key: string): string {
+  return `${OPTIMISTIC_SEND_STORAGE_PREFIX}${encodeURIComponent(key)}`;
+}
+
+function restoreOptimisticSendOperations(key: string | null): OptimisticSendOperation[] {
+  if (!key) return [];
+  let stored = optimisticSendOperations.get(key);
+  if (!stored) {
+    const storage = pendingComposerStorage();
+    try {
+      const parsed: unknown = JSON.parse(storage?.getItem(optimisticSendStorageKey(key)) ?? "[]");
+      stored = Array.isArray(parsed)
+        ? (parsed.filter(
+            (candidate): candidate is StoredOptimisticSendOperation =>
+              typeof candidate === "object" &&
+              candidate !== null &&
+              typeof candidate.clientEventId === "string" &&
+              typeof candidate.text === "string" &&
+              typeof candidate.occurredAt === "string" &&
+              (candidate.state === "sending" || candidate.state === "failed") &&
+              typeof candidate.input === "object" &&
+              candidate.input !== null &&
+              typeof candidate.input.text === "string" &&
+              typeof candidate.hasMcpCredentialUpdates === "boolean",
+          ) as StoredOptimisticSendOperation[])
+        : [];
+    } catch {
+      stored = [];
+    }
+  }
+  return stored.map(({ hasMcpCredentialUpdates, ...operation }) => ({
+    ...operation,
+    newerShadow: operation.newerShadow ?? { text: "", resources: [], annotations: [] },
+    state:
+      operation.state === "sending" || operation.state === "queued" ? "sending" : operation.state,
+    outcomeUnknown:
+      operation.state === "sending" || operation.state === "queued"
+        ? true
+        : operation.outcomeUnknown,
+    error:
+      operation.state === "sending"
+        ? "Delivery was interrupted; retry to reconcile this message."
+        : operation.error,
+    input: operation.input,
+    canRetry: !hasMcpCredentialUpdates,
+  }));
+}
+
+function rememberOptimisticSendOperations(
+  key: string | null,
+  operations: OptimisticSendOperation[],
+): void {
+  if (!key) return;
+  const stored = operations
+    .filter((operation) => operation.state !== "queued")
+    .map((operation) => {
+      const { canRetry: _canRetry, input, ...rest } = operation;
+      const { mcpCredentialUpdates: _credentials, ...safeInput } = input;
+      return {
+        ...rest,
+        input: safeInput,
+        hasMcpCredentialUpdates: input.mcpCredentialUpdates !== undefined,
+      } satisfies StoredOptimisticSendOperation;
+    });
+  optimisticSendOperations.set(key, stored);
+  try {
+    pendingComposerStorage()?.setItem(optimisticSendStorageKey(key), JSON.stringify(stored));
+  } catch {
+    // Best effort; the in-memory queue still owns this mount.
+  }
 }
 
 function resourceList(value: unknown): value is ResourceRef[] {
@@ -294,6 +394,10 @@ export type ComposerState = {
   hasDraftContent: () => boolean;
   /** Append the draft behind prompts already visible in the queue. */
   send: (text?: string) => Promise<boolean>;
+  /** Locally acknowledged ordinary sends awaiting durable timeline reconciliation. */
+  optimisticMessages?: ComposerOptimisticMessage[] | undefined;
+  retryOptimisticMessage?: ((clientEventId: string) => void) | undefined;
+  removeOptimisticMessage?: ((clientEventId: string) => void) | undefined;
   /** Supersede current direction with the draft. */
   steer: (text?: string) => Promise<boolean>;
   /** Optimistic-to-durable projection for a Steer that has not started yet. */
@@ -400,7 +504,9 @@ export function useComposer(
   const targetKey = `${workspaceId}\u0000${sessionId ?? ""}\u0000${durableDrafts ? "durable" : "disabled"}`;
   const pendingOperationKey = pendingComposerOperationKey(workspaceId, sessionId);
   const initialPendingOperation = restorePendingComposerOperation(pendingOperationKey);
-  const initialShadow = initialPendingOperation?.newerShadow;
+  const initialOptimisticSends = restoreOptimisticSendOperations(pendingOperationKey);
+  const initialShadow =
+    initialPendingOperation?.newerShadow ?? initialOptimisticSends.at(-1)?.newerShadow;
   const [value, setValue] = useState(() => initialShadow?.text ?? "");
   const [annotations, setAnnotations] = useState<DraftTimelineAnnotation[]>(
     () => initialShadow?.annotations ?? [],
@@ -410,6 +516,8 @@ export function useComposer(
   // a parent may switch sessionId without remounting this public hook.
   const [stateTargetKey, setStateTargetKey] = useState(targetKey);
   const [sending, setSending] = useState(false);
+  const [optimisticSends, setOptimisticSends] =
+    useState<OptimisticSendOperation[]>(initialOptimisticSends);
   const [steering, setSteering] = useState<ComposerSteeringState | null>(() =>
     initialPendingOperation?.delivery === "steer"
       ? {
@@ -433,6 +541,9 @@ export function useComposer(
     () => initialShadow?.resources ?? [],
   );
   const pendingOperationRef = useRef<PendingComposerOperation | null>(initialPendingOperation);
+  const optimisticSendsRef = useRef<OptimisticSendOperation[]>(initialOptimisticSends);
+  const optimisticProcessorBusyRef = useRef(false);
+  const optimisticCallbackIdsRef = useRef(new Set<string>());
   const steeringSettlementEventsRef = useRef<SessionEvent[]>([]);
   const steeringRef = useRef(steering);
   const pendingClientEventId = useRef<string | null>(
@@ -448,6 +559,7 @@ export function useComposer(
   const lastSavedSignature = useRef<string | null>(null);
   const saveChain = useRef<Promise<void>>(Promise.resolve());
   const onSent = options.onSent;
+  const onSubmitted = options.onSubmitted;
   const onDraftApplied = options.onDraftApplied;
   // Read through a ref so live session/policy projections can replace their
   // apply callback without invalidating the draft loader and re-running its
@@ -477,9 +589,14 @@ export function useComposer(
     targetGeneration.current += 1;
     draftReadGeneration.current += 1;
     pendingOperationRef.current = restorePendingComposerOperation(pendingOperationKey);
+    const restoredOptimisticSends = restoreOptimisticSendOperations(pendingOperationKey);
+    optimisticSendsRef.current = restoredOptimisticSends;
+    optimisticProcessorBusyRef.current = false;
+    optimisticCallbackIdsRef.current = new Set();
     steeringSettlementEventsRef.current = [];
     pendingClientEventId.current = pendingOperationRef.current?.input.clientEventId ?? null;
-    const shadow = pendingOperationRef.current?.newerShadow;
+    const shadow =
+      pendingOperationRef.current?.newerShadow ?? restoredOptimisticSends.at(-1)?.newerShadow;
     localEditRevision.current = shadow ? 1 : 0;
     valueRef.current = shadow?.text ?? "";
     annotationsRef.current = shadow?.annotations ?? [];
@@ -494,6 +611,7 @@ export function useComposer(
     setAnnotations(shadow?.annotations ?? []);
     setAnnotationReviewTargetId(null);
     setSending(false);
+    setOptimisticSends(restoredOptimisticSends);
     setSteering(
       pendingOperationRef.current?.delivery === "steer"
         ? {
@@ -515,6 +633,24 @@ export function useComposer(
     setDraftConflict(null);
     setRestoredResources(shadow?.resources ?? []);
   }, [durableDrafts, pendingOperationKey, sessionId, targetKey]);
+
+  const setOptimisticDraftShadow = useCallback(
+    (shadow: ComposerDraftShadow): void => {
+      if (optimisticSendsRef.current.length === 0) return;
+      const next = optimisticSendsRef.current.map((operation) => ({
+        ...operation,
+        newerShadow: {
+          text: shadow.text,
+          resources: [...shadow.resources],
+          annotations: cloneAnnotations(shadow.annotations),
+        },
+      }));
+      optimisticSendsRef.current = next;
+      rememberOptimisticSendOperations(pendingOperationKey, next);
+      setOptimisticSends(next);
+    },
+    [pendingOperationKey],
+  );
 
   const applyDraft = useCallback(
     (next: ComposerDraft): void => {
@@ -542,6 +678,14 @@ export function useComposer(
             annotations: next.annotations ?? [],
           },
         );
+        setOptimisticDraftShadow({
+          text: next.text,
+          resources: mergeResources(
+            next.resources,
+            resolveSendExtras(sendExtrasRef.current).resources ?? [],
+          ),
+          annotations: next.annotations ?? [],
+        });
         setDraftConflict(null);
         return;
       }
@@ -567,10 +711,18 @@ export function useComposer(
           annotations: next.annotations ?? [],
         },
       );
+      setOptimisticDraftShadow({
+        text: next.text,
+        resources: mergeResources(
+          next.resources,
+          resolveSendExtras(sendExtrasRef.current).resources ?? [],
+        ),
+        annotations: next.annotations ?? [],
+      });
       setDraftConflict(null);
       onDraftAppliedRef.current?.(next);
     },
-    [durableDrafts, pendingOperationKey, targetKey],
+    [durableDrafts, pendingOperationKey, setOptimisticDraftShadow, targetKey],
   );
 
   const loadDraft = useCallback(
@@ -621,7 +773,9 @@ export function useComposer(
           draftRef.current = fetched;
           setDraft(fetched);
           setDraftConflict(null);
-          const shadow = pendingOperationRef.current?.newerShadow;
+          const shadow =
+            pendingOperationRef.current?.newerShadow ??
+            optimisticSendsRef.current.at(-1)?.newerShadow;
           if (shadow) {
             // The server can only know the original operation. Never replace
             // newer local edits while that operation is still uncertain.
@@ -877,6 +1031,177 @@ export function useComposer(
     [client, durableDrafts, sessionId, targetKey, workspaceId],
   );
 
+  const replaceOptimisticSends = useCallback(
+    (
+      update: (current: OptimisticSendOperation[]) => OptimisticSendOperation[],
+    ): OptimisticSendOperation[] => {
+      const next = update(optimisticSendsRef.current);
+      optimisticSendsRef.current = next;
+      rememberOptimisticSendOperations(pendingOperationKey, next);
+      setOptimisticSends(next);
+      return next;
+    },
+    [pendingOperationKey],
+  );
+
+  const markOptimisticAccepted = useCallback(
+    (operation: OptimisticSendOperation): void => {
+      if (!optimisticCallbackIdsRef.current.has(operation.clientEventId)) {
+        optimisticCallbackIdsRef.current.add(operation.clientEventId);
+        onSent?.(operation.input.text, operation.input);
+      }
+      replaceOptimisticSends((current) =>
+        current.filter((candidate) => candidate.clientEventId !== operation.clientEventId),
+      );
+    },
+    [onSent, replaceOptimisticSends],
+  );
+
+  useEffect(() => {
+    const acceptedIds = new Set(
+      (options.events ?? [])
+        .filter((event) => event.type === "user.message" && event.clientEventId)
+        .map((event) => event.clientEventId as string),
+    );
+    if (acceptedIds.size === 0) return;
+    const accepted = optimisticSendsRef.current.filter((operation) =>
+      acceptedIds.has(operation.clientEventId),
+    );
+    for (const operation of accepted) markOptimisticAccepted(operation);
+  }, [markOptimisticAccepted, options.events]);
+
+  const processOptimisticSends = useCallback((): void => {
+    if (!sessionId || optimisticProcessorBusyRef.current) return;
+    const currentOperations = optimisticSendsRef.current;
+    const operationIndex = currentOperations.findIndex(
+      (candidate) => candidate.state === "sending",
+    );
+    const operation = operationIndex < 0 ? undefined : currentOperations[operationIndex];
+    if (!operation) return;
+    const ownedTargetKey = targetKey;
+    const ownedGeneration = targetGeneration.current;
+    optimisticProcessorBusyRef.current = true;
+    void (async () => {
+      try {
+        if (operation.outcomeUnknown) {
+          const events = await client.listEvents(workspaceId, sessionId, {
+            includeTypes: ["user.message"],
+            limit: 100,
+            payloadMode: "none",
+          });
+          if (
+            events.some(
+              (event) =>
+                event.type === "user.message" && event.clientEventId === operation.clientEventId,
+            )
+          ) {
+            markOptimisticAccepted(operation);
+            return;
+          }
+          if (!operation.canRetry) {
+            throw new Error(
+              "OpenGeni cannot safely retry this uncertain request after remount; reconcile the session before sending again.",
+            );
+          }
+        }
+        let expectedDraftRevision: number | undefined;
+        if (durableDrafts && operation.draftPayload) {
+          if (!(await persistPayload(operation.draftPayload))) {
+            throw new Error("The message draft could not be saved before delivery.");
+          }
+          expectedDraftRevision = draftRef.current?.revision;
+        }
+        if (
+          targetKeyRef.current !== ownedTargetKey ||
+          targetGeneration.current !== ownedGeneration
+        ) {
+          return;
+        }
+        const wireInput = {
+          ...operation.input,
+          ...(expectedDraftRevision !== undefined ? { expectedDraftRevision } : {}),
+        };
+        await client.sendMessage(workspaceId, sessionId, wireInput);
+        if (
+          targetKeyRef.current !== ownedTargetKey ||
+          targetGeneration.current !== ownedGeneration
+        ) {
+          return;
+        }
+        if (options.events === undefined) {
+          markOptimisticAccepted({ ...operation, input: wireInput });
+        } else {
+          replaceOptimisticSends((current) =>
+            current.map((candidate) =>
+              candidate.clientEventId === operation.clientEventId
+                ? { ...candidate, input: wireInput, state: "queued", error: undefined }
+                : candidate,
+            ),
+          );
+        }
+        if (!optimisticCallbackIdsRef.current.has(operation.clientEventId)) {
+          optimisticCallbackIdsRef.current.add(operation.clientEventId);
+          onSent?.(wireInput.text, wireInput);
+        }
+        if (durableDrafts && draftRef.current) {
+          const cleared = {
+            ...draftRef.current,
+            revision: 0,
+            text: "",
+            resources: [],
+            annotations: [],
+            sourceTurnId: null,
+            sourceTurnVersion: null,
+            updatedAt: null,
+          };
+          draftRef.current = cleared;
+          setDraft(cleared);
+          lastSavedSignature.current = draftSignature(draftPayload(cleared));
+        }
+      } catch (cause) {
+        const problem = asError(cause);
+        const outcomeUnknown = isOutcomeUnknownError(cause) || operation.outcomeUnknown === true;
+        if (
+          targetKeyRef.current === ownedTargetKey &&
+          targetGeneration.current === ownedGeneration
+        ) {
+          replaceOptimisticSends((current) =>
+            current.map((candidate) =>
+              candidate.clientEventId === operation.clientEventId
+                ? {
+                    ...candidate,
+                    state: "failed",
+                    error: problem.message,
+                    outcomeUnknown,
+                  }
+                : candidate,
+            ),
+          );
+        }
+      } finally {
+        optimisticProcessorBusyRef.current = false;
+        if (targetKeyRef.current === ownedTargetKey) {
+          setOptimisticSends([...optimisticSendsRef.current]);
+        }
+      }
+    })();
+  }, [
+    client,
+    durableDrafts,
+    markOptimisticAccepted,
+    onSent,
+    options.events,
+    persistPayload,
+    replaceOptimisticSends,
+    sessionId,
+    targetKey,
+    workspaceId,
+  ]);
+
+  useEffect(() => {
+    processOptimisticSends();
+  }, [optimisticSends, processOptimisticSends]);
+
   // Private durable autosave. A newer local edit is never replaced by an older
   // response; saves serialize and each reads the latest acknowledged revision.
   useEffect(() => {
@@ -903,6 +1228,27 @@ export function useComposer(
       }
       return;
     }
+    const optimistic = optimisticSendsRef.current.at(-1);
+    if (optimistic) {
+      const shadow = {
+        text: valueRef.current,
+        resources: mergeResources(
+          restoredResourcesRef.current,
+          resolveSendExtras(sendExtrasRef.current).resources ?? [],
+        ),
+        annotations: annotationsRef.current,
+      };
+      if (
+        optimistic.newerShadow.text !== shadow.text ||
+        JSON.stringify(optimistic.newerShadow.resources) !== JSON.stringify(shadow.resources) ||
+        JSON.stringify(optimistic.newerShadow.annotations) !== JSON.stringify(shadow.annotations)
+      ) {
+        setOptimisticDraftShadow(shadow);
+      }
+    }
+    if (optimisticSendsRef.current.some((operation) => operation.state === "sending")) {
+      return;
+    }
     if (
       !durableDrafts ||
       !sessionId ||
@@ -924,6 +1270,7 @@ export function useComposer(
     liveExtrasVersion,
     pendingOperationKey,
     persistPayload,
+    setOptimisticDraftShadow,
     sending,
     sessionId,
   ]);
@@ -1229,8 +1576,139 @@ export function useComposer(
     ],
   );
 
-  const send = useCallback(async (text?: string) => await dispatch("send", text), [dispatch]);
+  const send = useCallback(
+    async (explicit?: string): Promise<boolean> => {
+      if (pendingOperationRef.current?.delivery === "send") {
+        return await dispatch("send", explicit);
+      }
+      const rawText = explicit ?? valueRef.current;
+      const annotationsAtSend = cloneAnnotations(annotationsRef.current);
+      const hasText = rawText.trim().length > 0;
+      const hasAnnotations = annotationsAtSend.length > 0;
+      const annotationsComplete = annotationsAtSend.every(
+        (annotation) => annotation.note.trim().length > 0,
+      );
+      const extras = resolveSendExtras(sendExtrasRef.current);
+      const resources = mergeResources(restoredResourcesRef.current, extras.resources ?? []);
+      if (
+        !sessionId ||
+        sending ||
+        !annotationsComplete ||
+        (!hasText && !hasAnnotations && resources.length === 0) ||
+        sendBlockedRef.current?.() === true ||
+        targetKeyRef.current !== targetKey
+      ) {
+        return false;
+      }
+      const sendText = hasText ? rawText : hasAnnotations ? "" : FILE_ONLY_MESSAGE_TEXT;
+      const clientEventId = generateClientEventId();
+      const input = composeSendInput(sendText, clientEventId, extras, {
+        ...(options.effectiveControl?.controlEtag
+          ? { controlEtag: options.effectiveControl.controlEtag }
+          : {}),
+        resources,
+        annotations: annotationsAtSend,
+      });
+      const currentPayload = currentDraftPayload();
+      const operation: OptimisticSendOperation = {
+        clientEventId,
+        text: sendText,
+        annotations: annotationsAtSend,
+        resources,
+        occurredAt: new Date().toISOString(),
+        state: "sending",
+        input,
+        draftPayload: currentPayload ? { ...currentPayload, text: sendText } : null,
+        newerShadow: {
+          text: explicit === undefined ? "" : valueRef.current,
+          resources: explicit === undefined ? [] : [...restoredResourcesRef.current],
+          annotations: explicit === undefined ? [] : cloneAnnotations(annotationsRef.current),
+        },
+        canRetry: true,
+      };
+      replaceOptimisticSends((current) => [...current, operation]);
+      queueMicrotask(processOptimisticSends);
+      setError(null);
+      onSubmitted?.(sendText, input);
+      if (explicit === undefined) {
+        valueRef.current = "";
+        annotationsRef.current = [];
+        restoredResourcesRef.current = [];
+        localEditRevision.current += 1;
+        setValue("");
+        setAnnotations([]);
+        setAnnotationReviewTargetId(null);
+        setRestoredResources([]);
+      }
+      return true;
+    },
+    [
+      currentDraftPayload,
+      dispatch,
+      onSubmitted,
+      options.effectiveControl?.controlEtag,
+      processOptimisticSends,
+      replaceOptimisticSends,
+      sending,
+      sessionId,
+      targetKey,
+    ],
+  );
   const steer = useCallback(async (text?: string) => await dispatch("steer", text), [dispatch]);
+
+  const retryOptimisticMessage = useCallback(
+    (clientEventId: string): void => {
+      replaceOptimisticSends((current) =>
+        current.map((operation) => {
+          if (operation.clientEventId !== clientEventId || operation.state !== "failed") {
+            return operation;
+          }
+          if (operation.outcomeUnknown) {
+            return { ...operation, state: "sending", error: undefined };
+          }
+          const nextClientEventId = generateClientEventId();
+          const retryExtras = resolveSendExtras(sendExtrasRef.current);
+          const retryInput = composeSendInput(operation.text, nextClientEventId, retryExtras, {
+            ...(options.effectiveControl?.controlEtag
+              ? { controlEtag: options.effectiveControl.controlEtag }
+              : {}),
+            resources: operation.resources,
+            annotations: operation.annotations,
+          });
+          return {
+            ...operation,
+            clientEventId: nextClientEventId,
+            input: retryInput,
+            draftPayload: operation.draftPayload
+              ? {
+                  ...operation.draftPayload,
+                  model: retryExtras.model ?? operation.draftPayload.model,
+                  reasoningEffort:
+                    retryExtras.reasoningEffort ?? operation.draftPayload.reasoningEffort,
+                  latencyMode: retryExtras.latencyMode ?? operation.draftPayload.latencyMode,
+                }
+              : null,
+            occurredAt: new Date().toISOString(),
+            state: "sending",
+            error: undefined,
+            outcomeUnknown: false,
+            canRetry: true,
+          };
+        }),
+      );
+      queueMicrotask(processOptimisticSends);
+    },
+    [options.effectiveControl?.controlEtag, processOptimisticSends, replaceOptimisticSends],
+  );
+
+  const removeOptimisticMessage = useCallback(
+    (clientEventId: string): void => {
+      replaceOptimisticSends((current) =>
+        current.filter((operation) => operation.clientEventId !== clientEventId),
+      );
+    },
+    [replaceOptimisticSends],
+  );
 
   // A send is possible with non-empty text OR with ≥1 attached resource (a
   // file-only message). Resources ride in `sendExtras`, so we resolve them here
@@ -1402,9 +1880,17 @@ export function useComposer(
           annotations: annotationsRef.current,
         },
       );
+      setOptimisticDraftShadow({
+        text: next,
+        resources: mergeResources(
+          restoredResourcesRef.current,
+          resolveSendExtras(sendExtrasRef.current).resources ?? [],
+        ),
+        annotations: annotationsRef.current,
+      });
       setValue(next);
     },
-    [pendingOperationKey, targetKey],
+    [pendingOperationKey, setOptimisticDraftShadow, targetKey],
   );
 
   const updateAnnotations = useCallback(
@@ -1424,10 +1910,18 @@ export function useComposer(
           annotations: next,
         },
       );
+      setOptimisticDraftShadow({
+        text: valueRef.current,
+        resources: mergeResources(
+          restoredResourcesRef.current,
+          resolveSendExtras(sendExtrasRef.current).resources ?? [],
+        ),
+        annotations: next,
+      });
       setAnnotations(next);
       setAnnotationReviewTargetId(reviewTargetId);
     },
-    [pendingOperationKey, targetKey],
+    [pendingOperationKey, setOptimisticDraftShadow, targetKey],
   );
 
   const addAnnotation = useCallback(
@@ -1479,9 +1973,14 @@ export function useComposer(
           annotations: annotationsRef.current,
         },
       );
+      setOptimisticDraftShadow({
+        text: valueRef.current,
+        resources: mergeResources(next, resolveSendExtras(sendExtrasRef.current).resources ?? []),
+        annotations: annotationsRef.current,
+      });
       setRestoredResources(next);
     },
-    [pendingOperationKey, targetKey],
+    [pendingOperationKey, setOptimisticDraftShadow, targetKey],
   );
 
   const hasDraftContent = useCallback((): boolean => {
@@ -1549,6 +2048,13 @@ export function useComposer(
     clearAnnotationReviewTarget,
     hasDraftContent,
     send,
+    optimisticMessages: identityMatches
+      ? optimisticSends.map(
+          ({ input: _input, draftPayload: _payload, canRetry: _retry, ...item }) => item,
+        )
+      : [],
+    retryOptimisticMessage,
+    removeOptimisticMessage,
     steer,
     steering: visibleSteering,
     stoppingAttempt: identityMatches

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -40,6 +40,15 @@ export type UserMessageItem = {
   /** Tools requested for the turn this message starts. */
   tools: ToolRef[];
   occurredAt: string;
+  /** Local-only delivery projection; absent for authoritative durable events. */
+  delivery?:
+    | {
+        state: "sending" | "queued" | "failed";
+        error?: string | undefined;
+        onRetry?: (() => void) | undefined;
+        onRemove?: (() => void) | undefined;
+      }
+    | undefined;
 };
 
 export type AgentMessageItem = {

--- a/packages/react/styles/compiled.css
+++ b/packages/react/styles/compiled.css
@@ -2737,6 +2737,9 @@
 :where(.og-root).underline,:where(.og-root) .underline {
     text-decoration-line: underline;
   }
+:where(.og-root).decoration-og-border,:where(.og-root) .decoration-og-border {
+    text-decoration-color: var(--og-color-border);
+  }
 :where(.og-root).decoration-og-border-strong,:where(.og-root) .decoration-og-border-strong {
     text-decoration-color: var(--og-color-border-strong);
   }

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -2704,15 +2704,30 @@ describe("useComposer durable draft and control binding", () => {
       );
       await flush();
 
-      await flushing(async () => expect(await hook.result.current[delivery]()).toBe(false));
-      expect(hook.result.current.error).toMatchObject({
-        status: 402,
-        code: "payment_required",
-        retryable: false,
-        outcomeUnknown: false,
-      });
-      expect(hook.result.current.value).toBe(serverDraft.text);
-      expect(hook.result.current.restoredResources).toEqual([resource]);
+      await flushing(async () =>
+        expect(await hook.result.current[delivery]()).toBe(delivery === "send"),
+      );
+      await flush();
+      if (delivery === "send") {
+        expect(hook.result.current.value).toBe("");
+        expect(hook.result.current.restoredResources).toEqual([]);
+        expect(
+          hook.result.current.optimisticMessages?.find(
+            (message) =>
+              message.resources[0]?.kind === "file" &&
+              message.resources[0].fileId === resource.fileId,
+          ),
+        ).toMatchObject({ state: "failed", resources: [resource], outcomeUnknown: false });
+      } else {
+        expect(hook.result.current.error).toMatchObject({
+          status: 402,
+          code: "payment_required",
+          retryable: false,
+          outcomeUnknown: false,
+        });
+        expect(hook.result.current.value).toBe(serverDraft.text);
+        expect(hook.result.current.restoredResources).toEqual([resource]);
+      }
       expect(attempts).toHaveLength(1);
       expect(attempts[0]).toMatchObject({
         text: "read the exact attached bytes",
@@ -2721,7 +2736,18 @@ describe("useComposer durable draft and control binding", () => {
       });
 
       await hook.rerender("codex/gpt-5.6-sol");
-      await flushing(async () => expect(await hook.result.current[delivery]()).toBe(true));
+      if (delivery === "send") {
+        const failed = hook.result.current.optimisticMessages?.find(
+          (message) =>
+            message.resources[0]?.kind === "file" &&
+            message.resources[0].fileId === resource.fileId,
+        );
+        expect(failed).toBeDefined();
+        await flushing(() => hook.result.current.retryOptimisticMessage?.(failed!.clientEventId));
+        await flush();
+      } else {
+        await flushing(async () => expect(await hook.result.current[delivery]()).toBe(true));
+      }
 
       expect(attempts).toHaveLength(2);
       expect(attempts[1]).toMatchObject({
@@ -2774,12 +2800,23 @@ describe("useComposer durable draft and control binding", () => {
       );
       await flush();
 
-      await flushing(async () => expect(await hook.result.current[delivery]()).toBe(false));
-      expect(hook.result.current.value).toBe(initial.text);
-      expect(hook.result.current.restoredResources).toEqual([resource]);
-      expect(hook.result.current.error).toMatchObject({ outcomeUnknown: true });
-
-      await flushing(async () => expect(await hook.result.current[delivery]()).toBe(true));
+      await flushing(async () =>
+        expect(await hook.result.current[delivery]()).toBe(delivery === "send"),
+      );
+      await flush();
+      if (delivery === "send") {
+        const failed = hook.result.current.optimisticMessages?.find(
+          (message) => message.outcomeUnknown,
+        );
+        expect(failed).toMatchObject({ state: "failed", outcomeUnknown: true });
+        await flushing(() => hook.result.current.retryOptimisticMessage?.(failed!.clientEventId));
+        await flush();
+      } else {
+        expect(hook.result.current.value).toBe(initial.text);
+        expect(hook.result.current.restoredResources).toEqual([resource]);
+        expect(hook.result.current.error).toMatchObject({ outcomeUnknown: true });
+        await flushing(async () => expect(await hook.result.current[delivery]()).toBe(true));
+      }
       expect(attempts).toHaveLength(2);
       expect(attempts[0]!.clientEventId).toBe(attempts[1]!.clientEventId);
       expect(attempts[0]!.resources).toEqual([resource]);
@@ -2825,12 +2862,21 @@ describe("useComposer durable draft and control binding", () => {
       );
       await flush();
 
-      await flushing(async () => expect(await hook.result.current[delivery]()).toBe(false));
+      await flushing(async () =>
+        expect(await hook.result.current[delivery]()).toBe(delivery === "send"),
+      );
+      await flush();
       acceptedEvent = {
         ...makeEvent(1, "user.message"),
         clientEventId: attempts[0]!.clientEventId,
       };
-      await flushing(async () => expect(await hook.result.current[delivery]()).toBe(true));
+      if (delivery === "send") {
+        const failed = hook.result.current.optimisticMessages?.[0];
+        await flushing(() => hook.result.current.retryOptimisticMessage?.(failed!.clientEventId));
+        await flush();
+      } else {
+        await flushing(async () => expect(await hook.result.current[delivery]()).toBe(true));
+      }
 
       expect(attempts).toHaveLength(1);
       expect(hook.result.current.value).toBe("");
@@ -2880,7 +2926,10 @@ describe("useComposer durable draft and control binding", () => {
         undefined,
       );
       await flush();
-      await flushing(async () => expect(await first.result.current[delivery]()).toBe(false));
+      await flushing(async () =>
+        expect(await first.result.current[delivery]()).toBe(delivery === "send"),
+      );
+      await flush();
       await first.unmount();
 
       const second = await renderHook(
@@ -2888,8 +2937,12 @@ describe("useComposer durable draft and control binding", () => {
         undefined,
       );
       await flush();
-      expect(second.result.current.value).toBe("original uncertain prompt");
-      expect(second.result.current.restoredResources).toEqual([originalResource]);
+      expect(second.result.current.value).toBe(
+        delivery === "send" ? "" : "original uncertain prompt",
+      );
+      expect(second.result.current.restoredResources).toEqual(
+        delivery === "send" ? [] : [originalResource],
+      );
       await flushing(() =>
         second.result.current.applyDraft({
           ...initial,
@@ -2899,7 +2952,16 @@ describe("useComposer durable draft and control binding", () => {
       );
       expect(second.result.current.value).toBe("edited after timeout");
       expect(second.result.current.restoredResources).toEqual([newerResource]);
-      await flushing(async () => expect(await second.result.current[delivery]()).toBe(true));
+      if (delivery === "send") {
+        const failed = second.result.current.optimisticMessages?.find(
+          (message) => message.outcomeUnknown,
+        );
+        expect(failed).toBeDefined();
+        await flushing(() => second.result.current.retryOptimisticMessage?.(failed!.clientEventId));
+        await flush();
+      } else {
+        await flushing(async () => expect(await second.result.current[delivery]()).toBe(true));
+      }
 
       expect(attempts).toHaveLength(2);
       expect(attempts[1]!.clientEventId).toBe(attempts[0]!.clientEventId);

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -441,6 +441,48 @@ function fleetDecisionEventPayload(): Record<string, unknown> {
 }
 
 describe("timeline renderer isolation", () => {
+  test("renders failed optimistic user messages with retry and remove actions", async () => {
+    let retries = 0;
+    let removals = 0;
+    const r = await renderComponent(
+      <MessageTimeline
+        items={[
+          {
+            kind: "user-message",
+            id: "optimistic-message",
+            text: "Retry this prompt",
+            resources: [],
+            tools: [],
+            occurredAt: new Date(0).toISOString(),
+            delivery: {
+              state: "failed",
+              error: "Gateway unavailable",
+              onRetry: () => {
+                retries += 1;
+              },
+              onRemove: () => {
+                removals += 1;
+              },
+            },
+          },
+        ]}
+      />,
+    );
+    await flush();
+    expect(r.container.textContent).toContain("Not sent");
+    const buttons = [...r.container.querySelectorAll("button")];
+    const retry = buttons.find((button) => button.textContent === "Retry");
+    const remove = buttons.find((button) => button.textContent === "Remove");
+    expect(retry).toBeDefined();
+    expect(remove).toBeDefined();
+    await act(async () => {
+      retry?.click();
+      remove?.click();
+    });
+    expect({ retries, removals }).toEqual({ retries: 1, removals: 1 });
+    await r.unmount();
+  });
+
   test("keeps neighboring groups visible and recovers when an undefined renderer is replaced", async () => {
     const items: TimelineItem[] = [
       {

--- a/packages/react/test/use-composer-embedding.test.tsx
+++ b/packages/react/test/use-composer-embedding.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { SendMessageInput, SessionEvent } from "@opengeni/sdk";
 
 import { useComposer } from "../src/hooks/use-composer";
 import { fakeClient, SESSION_ID, WORKSPACE_ID } from "./fake-client";
@@ -7,6 +8,79 @@ import { actRun, flush, registerDom, renderHook } from "./render-hook";
 registerDom();
 
 describe("useComposer embedding policy", () => {
+  test("ordinary Send clears immediately and preserves rapid distinct messages in order", async () => {
+    const sessionId = crypto.randomUUID();
+    const attempts: SendMessageInput[] = [];
+    let releaseFirst!: () => void;
+    const firstPending = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const client = fakeClient({
+      sendMessage: async (_workspaceId, _sessionId, input) => {
+        const submitted = typeof input === "string" ? { text: input } : input;
+        attempts.push(submitted);
+        if (attempts.length === 1) await firstPending;
+        return {
+          id: crypto.randomUUID(),
+          workspaceId: WORKSPACE_ID,
+          sessionId,
+          sequence: attempts.length,
+          type: "user.message",
+          clientEventId: submitted.clientEventId,
+          payload: submitted,
+          occurredAt: new Date().toISOString(),
+        };
+      },
+    });
+    const hook = await renderHook(
+      (events: SessionEvent[]) =>
+        useComposer(sessionId, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          draftPersistence: "disabled",
+          events,
+        }),
+      [] as SessionEvent[],
+    );
+
+    await actRun(() => hook.result.current.setValue("first"));
+    expect(await actRun(() => hook.result.current.send())).toBe(true);
+    expect(hook.result.current.value).toBe("");
+    expect(hook.result.current.optimisticMessages).toMatchObject([
+      { text: "first", state: "sending" },
+    ]);
+
+    await actRun(() => hook.result.current.setValue("second"));
+    expect(await actRun(() => hook.result.current.send())).toBe(true);
+    expect(hook.result.current.value).toBe("");
+    const optimistic = hook.result.current.optimisticMessages ?? [];
+    expect(optimistic.map((message) => message.text)).toEqual(["first", "second"]);
+    expect(new Set(optimistic.map((message) => message.clientEventId)).size).toBe(2);
+    expect(attempts.map((attempt) => attempt.text)).toEqual(["first"]);
+
+    releaseFirst();
+    await flush();
+    expect(attempts.map((attempt) => attempt.text)).toEqual(["first", "second"]);
+
+    const accepted = attempts.map((attempt, index) => ({
+      id: crypto.randomUUID(),
+      workspaceId: WORKSPACE_ID,
+      sessionId,
+      sequence: index + 1,
+      type: "user.message" as const,
+      clientEventId: attempt.clientEventId,
+      payload: attempt,
+      occurredAt: new Date().toISOString(),
+    }));
+    await hook.rerender([accepted[0]!]);
+    expect(hook.result.current.optimisticMessages?.map((message) => message.text)).toEqual([
+      "second",
+    ]);
+    await hook.rerender(accepted);
+    expect(hook.result.current.optimisticMessages).toEqual([]);
+    await hook.unmount();
+  });
+
   test("annotation-only send preserves structured source data and clears on acceptance", async () => {
     const sent: unknown[] = [];
     const client = fakeClient({

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -2368,6 +2368,82 @@ describe("API component integration", () => {
     expect(after).toBe(before + 1);
   });
 
+  test("returns a committed prompt before replayable fanout and wake work runs", async () => {
+    class FailingPromptBus extends MemoryEventBus {
+      fail = false;
+
+      override async publish(
+        workspaceId: string,
+        sessionId: string,
+        events: SessionEvent[],
+      ): Promise<void> {
+        if (this.fail) throw new Error("nats unavailable");
+        await super.publish(workspaceId, sessionId, events);
+      }
+    }
+    const bus = new FailingPromptBus();
+    const workflowClient = new FakeWorkflowClient();
+    const postCommitTasks: Array<() => Promise<void>> = [];
+    const app = createApp({
+      settings: testSettings({ databaseUrl: services.databaseUrl }),
+      db: dbClient.db,
+      bus,
+      workflowClient,
+      schedulePromptPostCommit: (task) => postCommitTasks.push(task),
+    });
+    const workspaceId = await defaultWorkspaceId(app);
+    const created = await app.request(workspacePath(workspaceId, "/sessions"), {
+      method: "POST",
+      body: JSON.stringify({ initialMessage: "hello" }),
+      headers: { "content-type": "application/json" },
+    });
+    const session = (await created.json()) as { id: string };
+    await setSessionStatus(dbClient.db, workspaceId, session.id, "idle", null);
+    const publishedBefore = bus.published.length;
+    const wakeupsBefore = workflowClient.wakeups.length;
+    const usageBefore = await sumUsageQuantity(dbClient.db, {
+      workspaceId,
+      eventType: "agent_run.created",
+      since: startOfUtcMonth(),
+    });
+
+    const response = await app.request(
+      workspacePath(workspaceId, `/sessions/${session.id}/events`),
+      {
+        method: "POST",
+        body: JSON.stringify({
+          type: "user.message",
+          clientEventId: "prompt-response-boundary",
+          payload: { text: "commit before fanout" },
+        }),
+        headers: { "content-type": "application/json" },
+      },
+    );
+
+    expect(response.status).toBe(202);
+    expect(postCommitTasks).toHaveLength(1);
+    expect(bus.published).toHaveLength(publishedBefore);
+    expect(workflowClient.wakeups).toHaveLength(wakeupsBefore);
+    const accepted = (await response.json()) as SessionEvent;
+    expect(accepted).toMatchObject({
+      type: "user.message",
+      clientEventId: "prompt-response-boundary",
+    });
+    const durableEvents = await listSessionEvents(dbClient.db, workspaceId, session.id);
+    expect(durableEvents.some((event) => event.id === accepted.id)).toBe(true);
+    expect(
+      await sumUsageQuantity(dbClient.db, {
+        workspaceId,
+        eventType: "agent_run.created",
+        since: startOfUtcMonth(),
+      }),
+    ).toBe(usageBefore + 1);
+
+    bus.fail = true;
+    workflowClient.wakeError = new Error("temporal unavailable");
+    await expect(postCommitTasks[0]!()).resolves.toBeUndefined();
+  });
+
   test("rejects concurrent removed one-turn tool overrides without partial mutation", async () => {
     const mcpServers = Array.from({ length: 12 }, (_, index) => ({
       id: `docs-${index}`,


### PR DESCRIPTION
## Summary

- acknowledge ordinary Send locally with an immutable optimistic message, immediate composer/resource reset, ordered rapid sends, visible Sending/Queued/Not sent states, and retry/remove controls
- reconcile optimistic messages by `clientEventId`, preserving the same key for outcome-unknown reconciliation and allocating a fresh key only after definite rejection
- return prompt admission directly from the durable transaction result; commit the run-usage fact and workflow-wake outbox with the prompt, then isolate NATS/workspace-control fanout and Temporal wake as replayable post-commit work
- document the prompt response boundary and optimistic lifecycle invariants

## Validation

- `bun run typecheck` — 29/29 projects clean
- `bun run lint` — 0 warnings, 0 errors
- focused React/composer/timeline suite — 166 passed, 0 failed, 695 assertions
- compiled CSS contract — 7 passed, 0 failed; `bun run check:css` passed
- `git diff --check` — passed
- read-only three-way merge-tree check against current protected `main` — conflict-free
- Docker-backed API integration test added for response-before-fanout/wake and durable usage/event evidence; local execution is blocked because this sandbox has no Docker executable/daemon

## Source identity

- current source head: `e259d5354ff784ba251ede3e17b02c658bbb757c`
- current source tree: `6f5d6c733e1a923c0ecab08e2992b36345beafa0`
- repair commit parent / implementation commit: `4c0d40fd6286b3df823de4789131b532d06dbab8`
- original protected-main base: `ff7203c22a03c62a8bff2a3954016ed5e3553df9`

No deployment, provider/cloud, production, ruleset, Linear, review, or merge mutation is included.
