### PR TITLE
ci: expand OPE-27 PR unit shards to six

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,9 @@ jobs:
             jq -cn --argjson total "$total" \
               '[range(0; $total) | {index: ., number: (. + 1), total: $total}]'
           }
-          echo "unit_matrix=$(matrix "$(jq '.unitTests | length' impact-plan.json)" 4)" >> "$GITHUB_OUTPUT"
+          # PR unit shards are coverage-identical independent runners. Six is the
+          # smallest measured matrix that keeps source-byte skew off the critical path.
+          echo "unit_matrix=$(matrix "$(jq '.unitTests | length' impact-plan.json)" 6)" >> "$GITHUB_OUTPUT"
           echo "integration_matrix=$(matrix "$(jq '.integrationTests | length' impact-plan.json)" 6)" >> "$GITHUB_OUTPUT"
           {
             echo '### Change-impact plan'

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2967,6 +2967,9 @@ describe("workflow contracts", () => {
     expect(plan.steps.find((step: any) => step.id === "plan").run).toContain(
       "bun scripts/ci/impact.ts --full --output impact-plan.json",
     );
+    expect(plan.steps.find((step: any) => step.id === "plan").run).toContain(
+      "unit_matrix=$(matrix \"$(jq '.unitTests | length' impact-plan.json)\" 6)",
+    );
 
     const source = ci.jobs["source-contracts"];
     expect(source.needs).toEqual(["automation-admission", "plan"]);


### PR DESCRIPTION
## Summary

- increase pull-request unit execution from four independent shards to six
- preserve the complete selected unit-test set, one-file process isolation, FORCE-RLS intent, fail-fast behavior, and the monolithic non-PR safety gate
- lock the six-shard cap in the workflow contract test

## Measurement

Fresh exact-head PR #1332 CI run `31479121001` completed in 12m57s. Its critical path was unit shard 3:

- unit shard 3 job: 11m46s; profiled test wall: 660.6s
- package/bundle job: 8m07s
- all four profiled unit shards: 527.2s, 489.4s, 660.6s, 452.9s
- slow shard resource posture: 0.73 cgroup CPU-seconds/wall-second, 415 MiB max RSS, 89.6 MiB reads, 14.2 GiB writes

The run logs supplied per-file process boundaries for all 889 selected files. Replaying those observed durations through the unchanged deterministic source-byte planner reproduced the exact four-shard assignment. Modeled maxima were:

- 4 shards: 660.5s
- 5 shards: 538.0s
- 6 shards: 421.4s

Six is the smallest matrix that moves the predicted PR critical path below the observed 487s package/bundle job. The natural protected-main run `31480412851` separately confirms that monolithic unit safety dominates non-PR CI; this change intentionally leaves that full mapping-drift safety net unchanged.

## Validation

- `bun test scripts/check-release-pr-automation.test.ts scripts/ci/impact.test.ts` — 102 passed
- `bun run format:check` — passed
- `bun run lint` — zero warnings/errors
- `bun run typecheck` — all 29 projects clean
- `git diff --check` — passed
