### PR TITLE
fix(capabilities): synchronize feature lifecycle state

### DIFF
--- a/apps/web/src/components/capabilities/integration-features-panel.tsx
+++ b/apps/web/src/components/capabilities/integration-features-panel.tsx
@@ -228,24 +228,37 @@ export function IntegrationFeaturesPanel({
         expectedVersion: entry.binding.version,
         idempotencyKey: crypto.randomUUID(),
       };
-      if (action === "pause") {
-        await client.pauseIntegrationFeature(
-          workspaceId,
-          data!.capabilityId,
-          data!.instanceKey,
-          entry.definition.featureKey,
-          request,
-        );
-      } else {
-        await client.resumeIntegrationFeature(
-          workspaceId,
-          data!.capabilityId,
-          data!.instanceKey,
-          entry.definition.featureKey,
-          request,
-        );
-      }
-      await load();
+      const result =
+        action === "pause"
+          ? await client.pauseIntegrationFeature(
+              workspaceId,
+              data!.capabilityId,
+              data!.instanceKey,
+              entry.definition.featureKey,
+              request,
+            )
+          : await client.resumeIntegrationFeature(
+              workspaceId,
+              data!.capabilityId,
+              data!.instanceKey,
+              entry.definition.featureKey,
+              request,
+            );
+      ++loadSequence.current;
+      loadPromise.current = null;
+      setLoading(false);
+      setData((current) =>
+        current
+          ? {
+              ...current,
+              features: current.features.map((feature) =>
+                feature.definition.featureKey === entry.definition.featureKey
+                  ? { ...feature, binding: result.binding }
+                  : feature,
+              ),
+            }
+          : current,
+      );
       toast.success(
         `${featureTitle(entry.definition)} ${action === "pause" ? "paused" : "resumed"}`,
       );


### PR DESCRIPTION
## Summary
- apply authoritative pause/resume mutation bindings directly to the integration feature panel
- invalidate stale in-flight feature-list requests after lifecycle mutations
- preserve the existing single-flight loading and stale-instance fences

## Exact hosted failure
PR #1331 source CI run 31502003234, job 93816306959 failed Gmail pass 6 after Pause still rendered `Mail inbox Active` instead of `Paused`. The lifecycle endpoint returned the updated binding, but the UI ignored it and refetched, allowing a stale response to overwrite or delay the mutation state.

## Validation
- integration-features-panel unit tests: 4/4
- custom-api-control-center browser acceptance: 6/6 twice consecutively
- slack-installation-binding browser acceptance: 1/1
- apps/web typecheck
- canonical format check
- repository lint
- git diff check

No deployment, provider mutation, or live OAuth operation.