### PR TITLE
Fix production Codex turn blockers (OPE-207)

### DIFF
--- a/.changeset/calm-codex-turns.md
+++ b/.changeset/calm-codex-turns.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/runtime": patch
+---
+
+Keep Codex image-tool schemas within the provider-supported regex subset and
+restore all bundled runtime skills to production API and worker process builds.

--- a/packages/contracts/src/image-generation.ts
+++ b/packages/contracts/src/image-generation.ts
@@ -5,15 +5,25 @@ import { RETAINED_OUTPUT_MAX_PAGE_BYTES, RetainedArtifactReferenceSchema } from 
 // accepts four. Keep the provider-neutral tool at the reliable shared limit.
 export const IMAGE_GENERATION_MAX_REFERENCES = 4;
 
+const WorkspaceImagePathSchema = z
+  .string()
+  .max(512)
+  // Keep the provider-visible pattern within the portable JSON Schema regex
+  // subset. Codex rejects lookaround before inference.
+  .regex(/^\/workspace\/.+$/)
+  // Path traversal remains an exact runtime validation concern. Zod does not
+  // project custom refinements into JSON Schema, so this preserves the guard
+  // without sending unsupported regex syntax to model providers.
+  .refine((path) => path.split("/").every((segment) => segment !== "." && segment !== ".."), {
+    message: "Sandbox image paths cannot contain dot segments",
+  });
+
 /** One ordered, workspace-owned input used to guide or edit an image. */
 export const ImageGenerationReferenceSchema = z.discriminatedUnion("kind", [
   z
     .object({
       kind: z.literal("sandbox_path"),
-      path: z
-        .string()
-        .max(512)
-        .regex(/^\/workspace\/(?!\.{1,2}(?:\/|$))(?!.*\/\.{1,2}(?:\/|$)).+$/),
+      path: WorkspaceImagePathSchema,
     })
     .strict(),
   z

--- a/packages/contracts/test/image-generation.test.ts
+++ b/packages/contracts/test/image-generation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { z } from "zod";
 import {
   GenerateImageToolInput,
   GeneratedImageReceiptSchema,
@@ -34,6 +35,18 @@ describe("GenerateImageToolInput", () => {
     ).toBe(false);
     expect(
       GenerateImageToolInput.safeParse({
+        prompt: "unsafe nested path",
+        references: [{ kind: "sandbox_path", path: "/workspace/assets/../secret.png" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      GenerateImageToolInput.safeParse({
+        prompt: "unsafe current directory",
+        references: [{ kind: "sandbox_path", path: "/workspace/./image.png" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      GenerateImageToolInput.safeParse({
         prompt: "too many",
         references: Array.from({ length: IMAGE_GENERATION_MAX_REFERENCES + 1 }, (_, index) => ({
           kind: "sandbox_path",
@@ -41,6 +54,16 @@ describe("GenerateImageToolInput", () => {
         })),
       }).success,
     ).toBe(false);
+  });
+
+  test("emits a provider-portable path pattern without regex lookaround", () => {
+    const schema = z.toJSONSchema(GenerateImageToolInput, { target: "draft-2020-12" });
+    const serialized = JSON.stringify(schema);
+    expect(serialized).not.toContain("(?!");
+    expect(serialized).not.toContain("(?=");
+    expect(serialized).not.toContain("(?<=");
+    expect(serialized).not.toContain("(?<!");
+    expect(serialized).toContain(String.raw`^\\/workspace\\/.+$`);
   });
 });
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8553,15 +8553,19 @@ let stagedBundledSkillsDir: string | null = null;
 let stagedBundledArtifactSkillsDir: string | null = null;
 let stagedBundledVideoSkillsDir: string | null = null;
 
-function bundledSkillsDir(): string {
+function packagedBundledSkillsDir(directoryName: string): string {
   const moduleDir = dirname(fileURLToPath(import.meta.url));
-  const packaged =
+  return (
     [
-      join(moduleDir, "assets", "runtime", "bundled_hashicorp_terraform_skills"),
-      join(moduleDir, "bundled_hashicorp_terraform_skills"),
-      join(moduleDir, "..", "src", "bundled_hashicorp_terraform_skills"),
-    ].find((candidate) => existsSync(candidate)) ??
-    join(moduleDir, "bundled_hashicorp_terraform_skills");
+      join(moduleDir, "assets", "runtime", directoryName),
+      join(moduleDir, directoryName),
+      join(moduleDir, "..", "src", directoryName),
+    ].find((candidate) => existsSync(candidate)) ?? join(moduleDir, directoryName)
+  );
+}
+
+function bundledSkillsDir(): string {
+  const packaged = packagedBundledSkillsDir("bundled_hashicorp_terraform_skills");
   if (isPathWithin(process.cwd(), packaged)) return packaged;
   if (!stagedBundledSkillsDir) {
     stagedBundledSkillsDir = stageBundledSkills(
@@ -8573,12 +8577,7 @@ function bundledSkillsDir(): string {
 }
 
 function bundledArtifactSkillsDir(): string {
-  const moduleDir = dirname(fileURLToPath(import.meta.url));
-  const packaged =
-    [
-      join(moduleDir, "bundled_artifact_skills"),
-      join(moduleDir, "..", "src", "bundled_artifact_skills"),
-    ].find((candidate) => existsSync(candidate)) ?? join(moduleDir, "bundled_artifact_skills");
+  const packaged = packagedBundledSkillsDir("bundled_artifact_skills");
   if (isPathWithin(process.cwd(), packaged)) return packaged;
   if (!stagedBundledArtifactSkillsDir) {
     stagedBundledArtifactSkillsDir = stageBundledSkills(
@@ -8590,12 +8589,7 @@ function bundledArtifactSkillsDir(): string {
 }
 
 function bundledVideoSkillsDir(): string {
-  const moduleDir = dirname(fileURLToPath(import.meta.url));
-  const packaged =
-    [
-      join(moduleDir, "bundled_video_skills"),
-      join(moduleDir, "..", "src", "bundled_video_skills"),
-    ].find((candidate) => existsSync(candidate)) ?? join(moduleDir, "bundled_video_skills");
+  const packaged = packagedBundledSkillsDir("bundled_video_skills");
   if (isPathWithin(process.cwd(), packaged)) return packaged;
   if (!stagedBundledVideoSkillsDir) {
     stagedBundledVideoSkillsDir = stageBundledSkills(

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -1526,6 +1526,11 @@ describe("multi-provider gating in buildOpenGeniAgent", () => {
       (candidate) => candidate.type === "function" && candidate.name === "generate_image",
     );
     if (!tool || tool.type !== "function") throw new Error("generate_image tool missing");
+    const serializedParameters = JSON.stringify(tool.parameters);
+    expect(serializedParameters).not.toContain("(?!");
+    expect(serializedParameters).not.toContain("(?=");
+    expect(serializedParameters).not.toContain("(?<=");
+    expect(serializedParameters).not.toContain("(?<!");
     const output = await tool.invoke(
       new RunContext(),
       JSON.stringify({ prompt: "a blue sphere" }),

--- a/scripts/build-runtime-processes.test.ts
+++ b/scripts/build-runtime-processes.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  copyRuntimeSkillAssets,
+  RUNTIME_SKILL_ASSET_DIRECTORY_NAMES,
+} from "./build-runtime-processes";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("production process bundles retain every runtime skill asset directory", async () => {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), "opengeni-runtime-process-assets-"));
+  try {
+    const outdir = join(temporaryRoot, "dist", "process");
+    await copyRuntimeSkillAssets(repositoryRoot, outdir);
+
+    expect(RUNTIME_SKILL_ASSET_DIRECTORY_NAMES).toEqual([
+      "bundled_hashicorp_terraform_skills",
+      "bundled_skill_library",
+      "bundled_artifact_skills",
+      "bundled_video_skills",
+    ]);
+    for (const [directoryName, skillName] of [
+      ["bundled_hashicorp_terraform_skills", "checkov"],
+      ["bundled_skill_library", "azure-verified-modules"],
+      ["bundled_artifact_skills", "opengeni-spreadsheets"],
+      ["bundled_video_skills", "opengeni-video-generation"],
+    ] as const) {
+      const skill = await readFile(
+        join(outdir, "assets", "runtime", directoryName, skillName, "SKILL.md"),
+        "utf8",
+      );
+      expect(skill).toContain(`name: ${skillName}`);
+    }
+
+    const builder = await readFile(
+      join(repositoryRoot, "scripts/build-runtime-processes.ts"),
+      "utf8",
+    );
+    expect(builder.match(/await copyRuntimeSkillAssets\(repositoryRoot, outdir\);/g)).toHaveLength(
+      2,
+    );
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/build-runtime-processes.ts
+++ b/scripts/build-runtime-processes.ts
@@ -6,6 +6,13 @@ import { fileURLToPath } from "node:url";
 
 type ProcessTarget = "api" | "worker" | "artifact-materializer" | "artifact-outbox";
 
+export const RUNTIME_SKILL_ASSET_DIRECTORY_NAMES = [
+  "bundled_hashicorp_terraform_skills",
+  "bundled_skill_library",
+  "bundled_artifact_skills",
+  "bundled_video_skills",
+] as const;
+
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const requested = process.argv.slice(2);
 const targets: ProcessTarget[] =
@@ -35,6 +42,17 @@ async function copyDirectory(source: string, destination: string): Promise<void>
   await cp(source, destination, { recursive: true, force: true });
 }
 
+export async function copyRuntimeSkillAssets(root: string, outdir: string): Promise<void> {
+  await Promise.all(
+    RUNTIME_SKILL_ASSET_DIRECTORY_NAMES.map((directoryName) =>
+      copyDirectory(
+        join(root, "packages/runtime/src", directoryName),
+        join(outdir, "assets/runtime", directoryName),
+      ),
+    ),
+  );
+}
+
 const sharedBuild = {
   target: "bun" as const,
   format: "esm" as const,
@@ -62,10 +80,7 @@ async function buildApi(): Promise<void> {
     external: [...nativeRuntimeExternals, "better-auth", "better-auth/*", "@better-auth/*"],
   });
   await copyDirectory(join(repositoryRoot, "agent/install"), join(outdir, "assets/agent-install"));
-  await copyDirectory(
-    join(repositoryRoot, "packages/runtime/src/bundled_skill_library"),
-    join(outdir, "assets/runtime/bundled_skill_library"),
-  );
+  await copyRuntimeSkillAssets(repositoryRoot, outdir);
 }
 
 async function buildWorker(): Promise<void> {
@@ -94,10 +109,7 @@ async function buildWorker(): Promise<void> {
     join(repositoryRoot, "apps/worker/dist/workflow-bundle.js"),
     join(outdir, "workflow-bundle.js"),
   );
-  await copyDirectory(
-    join(repositoryRoot, "packages/runtime/src/bundled_skill_library"),
-    join(outdir, "assets/runtime/bundled_skill_library"),
-  );
+  await copyRuntimeSkillAssets(repositoryRoot, outdir);
 }
 
 async function buildArtifactSidecar(
@@ -120,9 +132,11 @@ async function buildArtifactSidecar(
   });
 }
 
-for (const target of targets) {
-  if (target === "api") await buildApi();
-  else if (target === "worker") await buildWorker();
-  else await buildArtifactSidecar(target);
-  process.stdout.write(`[runtime-process] built ${target}\n`);
+if (import.meta.main) {
+  for (const target of targets) {
+    if (target === "api") await buildApi();
+    else if (target === "worker") await buildWorker();
+    else await buildArtifactSidecar(target);
+    process.stdout.write(`[runtime-process] built ${target}\n`);
+  }
 }


### PR DESCRIPTION
## Summary

- restore every runtime skill asset directory to packaged API and worker processes, including artifact and video skills
- resolve packaged artifact/video skills from the production `assets/runtime` location
- keep image-reference traversal validation at runtime while emitting a Codex-compatible JSON Schema pattern
- add regression coverage for packaged assets and the actual Agents SDK tool schema

## Testing

- [x] `bun run typecheck`
- [x] targeted tests: 331 passed across contract, runtime, provider, process-build, and release-image suites
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun scripts/build-runtime-processes.ts api`
- [x] `bun scripts/build-runtime-processes.ts worker`
- [x] verified all four skill asset families in both production process outputs
- [ ] full `bun test` (delegated to protected CI)

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] `main` remained at `5c5ea4af` through the first push; candidate is based directly on it.

## Notes

- Linear: [OPE-207](https://linear.app/cloudgeni/issue/OPE-207/codex-turns-fail-before-inference-from-missing-bundled-skills-and)
- Both bugs occurred before inference, so failed turns had no model usage.