### PR TITLE
fix(runtime): let bundled skills shadow workspace copies

### DIFF
--- a/.changeset/calm-skills-shadow.md
+++ b/.changeset/calm-skills-shadow.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Let bundled OpenGeni skills deterministically shadow same-name workspace copies while preserving fail-closed conflicts for user-configured skills.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2777,17 +2777,23 @@ export function buildAgentCapabilities(
     }),
   );
   if (options.workspaceSkillPaths?.length) {
+    const bundledWorkspaceSkillNames = [
+      ...bundledSkillDirNames(bundledSkillsDir()),
+      ...(options.editableArtifactToolsAvailable
+        ? bundledSkillDirNames(bundledArtifactSkillsDir())
+        : []),
+      ...(options.videoGenerationAvailable ? bundledSkillDirNames(bundledVideoSkillsDir()) : []),
+    ];
     caps.push(
-      workspaceSkills(options.workspaceSkillPaths, [
-        ...bundledSkillDirNames(bundledSkillsDir()),
-        ...(options.editableArtifactToolsAvailable
-          ? bundledSkillDirNames(bundledArtifactSkillsDir())
-          : []),
-        ...(options.videoGenerationAvailable ? bundledSkillDirNames(bundledVideoSkillsDir()) : []),
-        ...(options.skillLibrarySkills ?? []).map((skill) => skill.name),
-        ...packSkills.map((skill) => skill.name),
-        ...sessionSkills.map((skill) => skill.name),
-      ]),
+      workspaceSkills(
+        options.workspaceSkillPaths,
+        [
+          ...(options.skillLibrarySkills ?? []).map((skill) => skill.name),
+          ...packSkills.map((skill) => skill.name),
+          ...sessionSkills.map((skill) => skill.name),
+        ],
+        bundledWorkspaceSkillNames,
+      ),
     );
   }
   // P4.3 computer-use: the agent drives the SAME :0 humans watch (xdotool/XTEST +

--- a/packages/runtime/src/workspace-skills.ts
+++ b/packages/runtime/src/workspace-skills.ts
@@ -36,6 +36,7 @@ export class WorkspaceSkillsCapability extends Capability {
   constructor(
     private readonly searchPaths: readonly WorkspaceSkillSearchPath[],
     private readonly reservedNames: ReadonlySet<string> = new Set(),
+    private readonly shadowedNames: ReadonlySet<string> = new Set(),
   ) {
     super();
   }
@@ -47,6 +48,7 @@ export class WorkspaceSkillsCapability extends Capability {
       this.searchPaths,
       this.reservedNames,
       this._runAs,
+      this.shadowedNames,
     );
     const skills = await this.discovery;
     if (skills.length === 0) return null;
@@ -72,10 +74,12 @@ ${available}
 export function workspaceSkills(
   searchPaths: readonly WorkspaceSkillSearchPath[],
   reservedNames: Iterable<string> = [],
+  shadowedNames: Iterable<string> = [],
 ): WorkspaceSkillsCapability {
   return new WorkspaceSkillsCapability(
     searchPaths,
     new Set([...reservedNames].map((name) => name.toLowerCase())),
+    new Set([...shadowedNames].map((name) => name.toLowerCase())),
   );
 }
 
@@ -84,6 +88,7 @@ export async function discoverWorkspaceSkills(
   searchPaths: readonly WorkspaceSkillSearchPath[],
   reservedNames: ReadonlySet<string> = new Set(),
   runAs?: string,
+  shadowedNames: ReadonlySet<string> = new Set(),
 ): Promise<readonly WorkspaceSkill[]> {
   if (!session.listDir || !session.readFile) {
     throw new Error("Workspace skill discovery requires sandbox listDir() and readFile() support");
@@ -119,11 +124,12 @@ export async function discoverWorkspaceSkills(
       if (name.length > 64 || !SAFE_SKILL_NAME.test(name)) {
         throw new Error(`Repository skill has an invalid name: ${name.slice(0, 64)}`);
       }
+      const key = name.toLowerCase();
+      if (shadowedNames.has(key)) continue;
       const description = frontmatter.description?.trim() || "No description provided.";
       if (description.length > 2_048 || /[\r\n]/.test(description)) {
         throw new Error(`Repository skill "${name}" has an invalid description`);
       }
-      const key = name.toLowerCase();
       if (reservedNames.has(key)) {
         throw new Error(`Workspace skill "${name}" conflicts with a configured OpenGeni skill`);
       }

--- a/packages/runtime/test/workspace-skills.test.ts
+++ b/packages/runtime/test/workspace-skills.test.ts
@@ -103,6 +103,29 @@ description: Prepare a safe release.
     ).rejects.toThrow('Workspace skill "release" conflicts with a configured OpenGeni skill');
   });
 
+  test("lets bundled OpenGeni skills deterministically shadow workspace copies", async () => {
+    const session = fakeSession({
+      ".agents/skills/opengeni-documents/SKILL.md":
+        "---\nname: opengeni-documents\ndescription: Repository copy.\n---\n",
+      ".agents/skills/release/SKILL.md":
+        "---\nname: release\ndescription: Repository release instructions.\n---\n",
+    });
+    await expect(
+      discoverWorkspaceSkills(
+        session,
+        [{ path: ".agents/skills", source: ".agents/skills" }],
+        new Set(),
+        undefined,
+        new Set(["opengeni-documents"]),
+      ),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        name: "release",
+        description: "Repository release instructions.",
+      }),
+    ]);
+  });
+
   test("deduplicates identical inline session skills and rejects conflicts", () => {
     const release = {
       name: "release",


### PR DESCRIPTION
## Summary
- let built-in OpenGeni skills deterministically shadow same-name repository copies
- preserve fail-closed collisions for selected library, Pack, and session skills
- add focused regression coverage and a runtime patch changeset

## Production impact
A Codex-subscription canary on the restored production worker passed the prior JSON-schema boundary but failed because the OpenGeni repository contains byte-identical copies of the bundled artifact skills. This change keeps the bundled copy authoritative and omits the workspace duplicate.

## Verification
- `bun test packages/runtime/test/workspace-skills.test.ts scripts/build-runtime-processes.test.ts`
- `bun run --cwd packages/runtime typecheck`
- `bunx oxfmt --check packages/runtime/src/index.ts packages/runtime/src/workspace-skills.ts packages/runtime/test/workspace-skills.test.ts`
- `bunx changeset status`
- `git diff --check`

Linear: OPE-209