### PR TITLE
Fix workspace members loading when Slack requests fail

### DIFF
--- a/apps/web/src/routes/workspace-settings.test.tsx
+++ b/apps/web/src/routes/workspace-settings.test.tsx
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
-import { act, type ReactNode } from "react";
+import { act, type ReactNode, useLayoutEffect } from "react";
 import { createRoot } from "react-dom/client";
 
 import type { SlackUserLinkAccessRequest, WorkspaceMember } from "@/types";
@@ -121,7 +121,37 @@ async function renderMembers(canManage: boolean, workspaceId = workspaceA) {
   };
 }
 
+function MembersBoundaryProbe({
+  canManage,
+  onBoundaryLayout,
+  workspaceId,
+}: {
+  canManage: boolean;
+  onBoundaryLayout: () => void;
+  workspaceId: string;
+}) {
+  useLayoutEffect(() => {
+    onBoundaryLayout();
+  }, [onBoundaryLayout, workspaceId]);
+
+  return <MembersSection workspaceId={workspaceId} canManage={canManage} />;
+}
+
 describe("workspace members loading", () => {
+  test("renders the primary roster while the auxiliary Slack request is still pending", async () => {
+    const pendingSlackAccessRequests = deferred<SlackUserLinkAccessRequest[]>();
+    listSlackUserLinkAccessRequests.mockImplementation(() => pendingSlackAccessRequests.promise);
+    const rendered = await renderMembers(true);
+
+    try {
+      expect(rendered.container.textContent).toContain("Ada Member");
+      expect(rendered.container.textContent).not.toContain("Loading members");
+      expect(rendered.container.textContent).not.toContain("Couldn't load members");
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
   test("keeps loaded members visible when Slack access requests fail", async () => {
     listSlackUserLinkAccessRequests.mockImplementation(async () => {
       throw new Error("Slack returned 500");
@@ -138,7 +168,7 @@ describe("workspace members loading", () => {
     }
   });
 
-  test("preserves the primary member error when members fail", async () => {
+  test("preserves the primary member error alongside independently loaded Slack requests", async () => {
     listWorkspaceMembers.mockImplementation(async () => {
       throw new Error("Members returned 500");
     });
@@ -147,10 +177,11 @@ describe("workspace members loading", () => {
     try {
       expect(rendered.container.textContent).toContain("Couldn't load members");
       expect(rendered.container.textContent).toContain("Members returned 500");
-      expect(rendered.container.textContent).not.toContain("Slack Requester");
+      expect(rendered.container.textContent).toContain("Slack Requester");
       expect(rendered.container.textContent).not.toContain(
         "Pending Slack access requests unavailable",
       );
+      expect(rendered.container.textContent).not.toContain("Loading members");
     } finally {
       await rendered.unmount();
     }
@@ -317,6 +348,73 @@ describe("workspace members loading", () => {
       expect(rendered.container.textContent).toContain("Bea Member");
     } finally {
       await rendered.unmount();
+    }
+  });
+
+  test("does not commit prior-workspace state before passive effects at the workspace boundary", async () => {
+    listSlackUserLinkAccessRequests.mockImplementation(async () => {
+      throw new Error("Workspace A Slack returned 500");
+    });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const boundaryLayouts: string[] = [];
+    const captureBoundaryLayout = () => {
+      boundaryLayouts.push(container.textContent ?? "");
+    };
+
+    try {
+      await act(async () => {
+        root.render(
+          <MembersBoundaryProbe
+            workspaceId={workspaceA}
+            canManage={true}
+            onBoundaryLayout={captureBoundaryLayout}
+          />,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      const editButton = [...container.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "Edit",
+      );
+      expect(editButton).toBeDefined();
+      await act(async () => {
+        editButton?.click();
+      });
+
+      const removeButton = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Remove Ada Member"]',
+      );
+      expect(removeButton).not.toBeNull();
+      await act(async () => {
+        removeButton?.click();
+      });
+
+      const currentMembers = deferred<WorkspaceMember[]>();
+      const currentSlackAccessRequests = deferred<SlackUserLinkAccessRequest[]>();
+      listWorkspaceMembers.mockImplementation(() => currentMembers.promise);
+      listSlackUserLinkAccessRequests.mockImplementation(() => currentSlackAccessRequests.promise);
+
+      act(() => {
+        root.render(
+          <MembersBoundaryProbe
+            workspaceId={workspaceB}
+            canManage={true}
+            onBoundaryLayout={captureBoundaryLayout}
+          />,
+        );
+      });
+
+      const workspaceBoundaryLayout = boundaryLayouts.at(-1) ?? "";
+      expect(workspaceBoundaryLayout).toContain("Loading members");
+      expect(workspaceBoundaryLayout).not.toContain("Ada Member");
+      expect(workspaceBoundaryLayout).not.toContain("Save");
+      expect(workspaceBoundaryLayout).not.toContain("Workspace A Slack returned 500");
+      expect(workspaceBoundaryLayout).not.toContain("Remove Ada Member from this workspace?");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
     }
   });
 

--- a/apps/web/src/routes/workspace-settings.test.tsx
+++ b/apps/web/src/routes/workspace-settings.test.tsx
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { SlackUserLinkAccessRequest, WorkspaceMember } from "@/types";
+
+const member: WorkspaceMember = {
+  subjectId: "user:member-a",
+  subjectLabel: "Ada Member",
+  role: "member",
+  permissions: ["sessions:read"],
+  createdAt: "2026-08-11T12:00:00.000Z",
+};
+
+const slackAccessRequest: SlackUserLinkAccessRequest = {
+  id: "11111111-1111-4111-8111-111111111111",
+  workspaceId: "22222222-2222-4222-8222-222222222222",
+  workspaceDisplayName: "Workspace A",
+  subjectLabel: "Slack Requester",
+  status: "pending",
+  version: 1,
+  expiresAt: "2026-08-12T12:00:00.000Z",
+  requestedAt: "2026-08-11T12:00:00.000Z",
+  decidedAt: null,
+  completedAt: null,
+  createdAt: "2026-08-11T12:00:00.000Z",
+  updatedAt: "2026-08-11T12:00:00.000Z",
+};
+
+const listWorkspaceMembers = mock(
+  async (_workspaceId: string): Promise<WorkspaceMember[]> => [member],
+);
+const listSlackUserLinkAccessRequests = mock(
+  async (_workspaceId: string): Promise<SlackUserLinkAccessRequest[]> => [slackAccessRequest],
+);
+const context = {
+  client: {
+    listWorkspaceMembers,
+    listSlackUserLinkAccessRequests,
+  },
+  accessContext: { subjectId: "user:caller" },
+};
+
+mock.module("@/context", () => ({
+  useAppContext: () => context,
+}));
+
+const { MembersSection } = await import("./workspace-settings");
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  mock.restore();
+  GlobalRegistrator.unregister();
+});
+
+beforeEach(() => {
+  listWorkspaceMembers.mockClear();
+  listSlackUserLinkAccessRequests.mockClear();
+  listWorkspaceMembers.mockImplementation(async () => [member]);
+  listSlackUserLinkAccessRequests.mockImplementation(async () => [slackAccessRequest]);
+});
+
+async function renderMembers(canManage: boolean) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <MembersSection workspaceId="22222222-2222-4222-8222-222222222222" canManage={canManage} />,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("workspace members loading", () => {
+  test("keeps loaded members visible when Slack access requests fail", async () => {
+    listSlackUserLinkAccessRequests.mockImplementation(async () => {
+      throw new Error("Slack returned 500");
+    });
+    const rendered = await renderMembers(true);
+
+    try {
+      expect(rendered.container.textContent).toContain("Ada Member");
+      expect(rendered.container.textContent).toContain("Pending Slack access requests unavailable");
+      expect(rendered.container.textContent).toContain("Slack returned 500");
+      expect(rendered.container.textContent).not.toContain("Couldn't load members");
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("preserves the primary member error when members fail", async () => {
+    listWorkspaceMembers.mockImplementation(async () => {
+      throw new Error("Members returned 500");
+    });
+    const rendered = await renderMembers(true);
+
+    try {
+      expect(rendered.container.textContent).toContain("Couldn't load members");
+      expect(rendered.container.textContent).toContain("Members returned 500");
+      expect(rendered.container.textContent).not.toContain("Slack Requester");
+      expect(rendered.container.textContent).not.toContain(
+        "Pending Slack access requests unavailable",
+      );
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("skips Slack access requests for non-managers", async () => {
+    const rendered = await renderMembers(false);
+
+    try {
+      expect(listWorkspaceMembers).toHaveBeenCalledWith("22222222-2222-4222-8222-222222222222");
+      expect(listSlackUserLinkAccessRequests).not.toHaveBeenCalled();
+      expect(rendered.container.textContent).toContain("Ada Member");
+      expect(rendered.container.textContent).not.toContain("Slack Requester");
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("renders members and pending Slack access requests when both load", async () => {
+    const rendered = await renderMembers(true);
+
+    try {
+      expect(rendered.container.textContent).toContain("Ada Member");
+      expect(rendered.container.textContent).toContain("Pending Slack access requests");
+      expect(rendered.container.textContent).toContain("Slack Requester");
+      expect(rendered.container.textContent).not.toContain("Couldn't load members");
+    } finally {
+      await rendered.unmount();
+    }
+  });
+});

--- a/apps/web/src/routes/workspace-settings.test.tsx
+++ b/apps/web/src/routes/workspace-settings.test.tsx
@@ -1,9 +1,12 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
-import { act } from "react";
+import { act, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 
 import type { SlackUserLinkAccessRequest, WorkspaceMember } from "@/types";
+
+const workspaceA = "22222222-2222-4222-8222-222222222222";
+const workspaceB = "33333333-3333-4333-8333-333333333333";
 
 const member: WorkspaceMember = {
   subjectId: "user:member-a",
@@ -12,10 +15,15 @@ const member: WorkspaceMember = {
   permissions: ["sessions:read"],
   createdAt: "2026-08-11T12:00:00.000Z",
 };
+const nextWorkspaceMember: WorkspaceMember = {
+  ...member,
+  subjectId: "user:member-b",
+  subjectLabel: "Bea Member",
+};
 
 const slackAccessRequest: SlackUserLinkAccessRequest = {
   id: "11111111-1111-4111-8111-111111111111",
-  workspaceId: "22222222-2222-4222-8222-222222222222",
+  workspaceId: workspaceA,
   workspaceDisplayName: "Workspace A",
   subjectLabel: "Slack Requester",
   status: "pending",
@@ -26,6 +34,13 @@ const slackAccessRequest: SlackUserLinkAccessRequest = {
   completedAt: null,
   createdAt: "2026-08-11T12:00:00.000Z",
   updatedAt: "2026-08-11T12:00:00.000Z",
+};
+const nextWorkspaceSlackAccessRequest: SlackUserLinkAccessRequest = {
+  ...slackAccessRequest,
+  id: "44444444-4444-4444-8444-444444444444",
+  workspaceId: workspaceB,
+  workspaceDisplayName: "Workspace B",
+  subjectLabel: "Current Slack Applicant",
 };
 
 const listWorkspaceMembers = mock(
@@ -44,6 +59,11 @@ const context = {
 
 mock.module("@/context", () => ({
   useAppContext: () => context,
+}));
+
+mock.module("@/components/ui/confirm-dialog", () => ({
+  ConfirmDialog: ({ open, title }: { open: boolean; title: ReactNode }) =>
+    open ? <div data-testid="confirm-dialog">{title}</div> : null,
 }));
 
 const { MembersSection } = await import("./workspace-settings");
@@ -67,20 +87,33 @@ beforeEach(() => {
   listSlackUserLinkAccessRequests.mockImplementation(async () => [slackAccessRequest]);
 });
 
-async function renderMembers(canManage: boolean) {
+function deferred<Value>() {
+  let resolve!: (value: Value) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function renderMembers(canManage: boolean, workspaceId = workspaceA) {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
 
-  await act(async () => {
-    root.render(
-      <MembersSection workspaceId="22222222-2222-4222-8222-222222222222" canManage={canManage} />,
-    );
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
+  async function render(nextWorkspaceId: string, nextCanManage: boolean) {
+    await act(async () => {
+      root.render(<MembersSection workspaceId={nextWorkspaceId} canManage={nextCanManage} />);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+
+  await render(workspaceId, canManage);
 
   return {
     container,
+    rerender: render,
     unmount: async () => {
       await act(async () => root.unmount());
       container.remove();
@@ -127,7 +160,7 @@ describe("workspace members loading", () => {
     const rendered = await renderMembers(false);
 
     try {
-      expect(listWorkspaceMembers).toHaveBeenCalledWith("22222222-2222-4222-8222-222222222222");
+      expect(listWorkspaceMembers).toHaveBeenCalledWith(workspaceA);
       expect(listSlackUserLinkAccessRequests).not.toHaveBeenCalled();
       expect(rendered.container.textContent).toContain("Ada Member");
       expect(rendered.container.textContent).not.toContain("Slack Requester");
@@ -144,6 +177,247 @@ describe("workspace members loading", () => {
       expect(rendered.container.textContent).toContain("Pending Slack access requests");
       expect(rendered.container.textContent).toContain("Slack Requester");
       expect(rendered.container.textContent).not.toContain("Couldn't load members");
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  for (const staleSlackOutcome of ["response", "error"] as const) {
+    test(`ignores stale workspace members and Slack ${staleSlackOutcome} after switching workspaces`, async () => {
+      const staleMembers = deferred<WorkspaceMember[]>();
+      const staleSlackAccessRequests = deferred<SlackUserLinkAccessRequest[]>();
+      listWorkspaceMembers.mockImplementation((workspaceId) =>
+        workspaceId === workspaceA ? staleMembers.promise : Promise.resolve([nextWorkspaceMember]),
+      );
+      listSlackUserLinkAccessRequests.mockImplementation((workspaceId) =>
+        workspaceId === workspaceA
+          ? staleSlackAccessRequests.promise
+          : Promise.resolve([nextWorkspaceSlackAccessRequest]),
+      );
+      const rendered = await renderMembers(true, workspaceA);
+
+      try {
+        await rendered.rerender(workspaceB, true);
+        expect(rendered.container.textContent).toContain("Bea Member");
+        expect(rendered.container.textContent).toContain("Current Slack Applicant");
+
+        await act(async () => {
+          staleMembers.resolve([member]);
+          if (staleSlackOutcome === "response") {
+            staleSlackAccessRequests.resolve([slackAccessRequest]);
+          } else {
+            staleSlackAccessRequests.reject(new Error("Stale Slack returned 500"));
+          }
+          await Promise.allSettled([staleMembers.promise, staleSlackAccessRequests.promise]);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        expect(rendered.container.textContent).toContain("Bea Member");
+        expect(rendered.container.textContent).toContain("Current Slack Applicant");
+        expect(rendered.container.textContent).not.toContain("Ada Member");
+        expect(rendered.container.textContent).not.toContain("Slack Requester");
+        expect(rendered.container.textContent).not.toContain("Stale Slack returned 500");
+        expect(rendered.container.textContent).not.toContain(
+          "Pending Slack access requests unavailable",
+        );
+      } finally {
+        await rendered.unmount();
+      }
+    });
+  }
+
+  test("ignores a stale primary member error after switching workspaces", async () => {
+    const staleMembers = deferred<WorkspaceMember[]>();
+    const staleSlackAccessRequests = deferred<SlackUserLinkAccessRequest[]>();
+    listWorkspaceMembers.mockImplementation((workspaceId) =>
+      workspaceId === workspaceA ? staleMembers.promise : Promise.resolve([nextWorkspaceMember]),
+    );
+    listSlackUserLinkAccessRequests.mockImplementation((workspaceId) =>
+      workspaceId === workspaceA
+        ? staleSlackAccessRequests.promise
+        : Promise.resolve([nextWorkspaceSlackAccessRequest]),
+    );
+    const rendered = await renderMembers(true, workspaceA);
+
+    try {
+      await rendered.rerender(workspaceB, true);
+      expect(rendered.container.textContent).toContain("Bea Member");
+      expect(rendered.container.textContent).toContain("Current Slack Applicant");
+
+      await act(async () => {
+        staleMembers.reject(new Error("Stale members returned 500"));
+        staleSlackAccessRequests.resolve([slackAccessRequest]);
+        await Promise.allSettled([staleMembers.promise, staleSlackAccessRequests.promise]);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(rendered.container.textContent).toContain("Bea Member");
+      expect(rendered.container.textContent).toContain("Current Slack Applicant");
+      expect(rendered.container.textContent).not.toContain("Couldn't load members");
+      expect(rendered.container.textContent).not.toContain("Stale members returned 500");
+      expect(rendered.container.textContent).not.toContain("Slack Requester");
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("clears stale member, Slack error, edit, and removal state at the workspace boundary", async () => {
+    listSlackUserLinkAccessRequests.mockImplementation(async () => {
+      throw new Error("Workspace A Slack returned 500");
+    });
+    const rendered = await renderMembers(true, workspaceA);
+
+    try {
+      const editButton = [...rendered.container.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "Edit",
+      );
+      expect(editButton).toBeDefined();
+
+      await act(async () => {
+        editButton?.click();
+      });
+      expect(rendered.container.textContent).toContain("Save");
+
+      const removeButton = rendered.container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Remove Ada Member"]',
+      );
+      expect(removeButton).not.toBeNull();
+      await act(async () => {
+        removeButton?.click();
+      });
+      expect(document.body.textContent).toContain("Remove Ada Member from this workspace?");
+      expect(rendered.container.textContent).toContain("Workspace A Slack returned 500");
+
+      const currentMembers = deferred<WorkspaceMember[]>();
+      const currentSlackAccessRequests = deferred<SlackUserLinkAccessRequest[]>();
+      listWorkspaceMembers.mockImplementation((workspaceId) =>
+        workspaceId === workspaceB ? currentMembers.promise : Promise.resolve([member]),
+      );
+      listSlackUserLinkAccessRequests.mockImplementation((workspaceId) =>
+        workspaceId === workspaceB
+          ? currentSlackAccessRequests.promise
+          : Promise.resolve([slackAccessRequest]),
+      );
+
+      await rendered.rerender(workspaceB, true);
+
+      expect(rendered.container.textContent).toContain("Loading members");
+      expect(rendered.container.textContent).not.toContain("Ada Member");
+      expect(rendered.container.textContent).not.toContain("Save");
+      expect(rendered.container.textContent).not.toContain("Workspace A Slack returned 500");
+      expect(document.body.textContent).not.toContain("Remove Ada Member from this workspace?");
+
+      await act(async () => {
+        currentMembers.resolve([nextWorkspaceMember]);
+        currentSlackAccessRequests.resolve([nextWorkspaceSlackAccessRequest]);
+        await Promise.all([currentMembers.promise, currentSlackAccessRequests.promise]);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(rendered.container.textContent).toContain("Bea Member");
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("clears a stale primary member error while the next workspace loads", async () => {
+    listWorkspaceMembers.mockImplementation(async () => {
+      throw new Error("Workspace A members returned 500");
+    });
+    const rendered = await renderMembers(true, workspaceA);
+
+    try {
+      expect(rendered.container.textContent).toContain("Couldn't load members");
+      expect(rendered.container.textContent).toContain("Workspace A members returned 500");
+
+      const currentMembers = deferred<WorkspaceMember[]>();
+      const currentSlackAccessRequests = deferred<SlackUserLinkAccessRequest[]>();
+      listWorkspaceMembers.mockImplementation(() => currentMembers.promise);
+      listSlackUserLinkAccessRequests.mockImplementation(() => currentSlackAccessRequests.promise);
+
+      await rendered.rerender(workspaceB, true);
+
+      expect(rendered.container.textContent).toContain("Loading members");
+      expect(rendered.container.textContent).not.toContain("Couldn't load members");
+      expect(rendered.container.textContent).not.toContain("Workspace A members returned 500");
+
+      await act(async () => {
+        currentMembers.resolve([nextWorkspaceMember]);
+        currentSlackAccessRequests.resolve([nextWorkspaceSlackAccessRequest]);
+        await Promise.all([currentMembers.promise, currentSlackAccessRequests.promise]);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(rendered.container.textContent).toContain("Bea Member");
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("keeps the newest overlapping refresh authoritative in the same workspace", async () => {
+    listSlackUserLinkAccessRequests.mockImplementation(async () => {
+      throw new Error("Initial Slack returned 500");
+    });
+    const rendered = await renderMembers(true, workspaceA);
+
+    try {
+      const olderMembers = deferred<WorkspaceMember[]>();
+      const olderSlackAccessRequests = deferred<SlackUserLinkAccessRequest[]>();
+      const newerMembers = deferred<WorkspaceMember[]>();
+      const newerSlackAccessRequests = deferred<SlackUserLinkAccessRequest[]>();
+      let membersRefresh = 0;
+      let slackRefresh = 0;
+      listWorkspaceMembers.mockImplementation(() =>
+        ++membersRefresh === 1 ? olderMembers.promise : newerMembers.promise,
+      );
+      listSlackUserLinkAccessRequests.mockImplementation(() =>
+        ++slackRefresh === 1 ? olderSlackAccessRequests.promise : newerSlackAccessRequests.promise,
+      );
+
+      const retryButton = [...rendered.container.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "Retry",
+      );
+      expect(retryButton).toBeDefined();
+      await act(async () => {
+        retryButton?.click();
+        retryButton?.click();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(rendered.container.textContent).toContain("Loading members");
+      expect(rendered.container.textContent).not.toContain("Initial Slack returned 500");
+
+      const newestSlackAccessRequest = {
+        ...slackAccessRequest,
+        id: "55555555-5555-4555-8555-555555555555",
+        subjectLabel: "Newest Slack Applicant",
+      };
+      await act(async () => {
+        newerMembers.resolve([nextWorkspaceMember]);
+        newerSlackAccessRequests.resolve([newestSlackAccessRequest]);
+        await Promise.all([newerMembers.promise, newerSlackAccessRequests.promise]);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(rendered.container.textContent).toContain("Bea Member");
+      expect(rendered.container.textContent).toContain("Newest Slack Applicant");
+      expect(rendered.container.textContent).not.toContain("Loading members");
+
+      await act(async () => {
+        olderMembers.resolve([member]);
+        olderSlackAccessRequests.reject(new Error("Older Slack returned 500"));
+        await Promise.allSettled([olderMembers.promise, olderSlackAccessRequests.promise]);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(rendered.container.textContent).toContain("Bea Member");
+      expect(rendered.container.textContent).toContain("Newest Slack Applicant");
+      expect(rendered.container.textContent).not.toContain("Ada Member");
+      expect(rendered.container.textContent).not.toContain("Older Slack returned 500");
+      expect(rendered.container.textContent).not.toContain(
+        "Pending Slack access requests unavailable",
+      );
+      expect(rendered.container.textContent).not.toContain("Loading members");
     } finally {
       await rendered.unmount();
     }

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -19,7 +19,7 @@ import {
   UserPlusIcon,
   UsersIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { CodexSubscriptionsCard } from "@/components/codex-connection";
@@ -586,12 +586,44 @@ export function MembersSection({
   const [editPermissions, setEditPermissions] = useState<Set<string>>(() => new Set());
   const [removingMember, setRemovingMember] = useState<WorkspaceMember | null>(null);
   const callerSubjectId = context.accessContext.subjectId;
+  const refreshGenerationRef = useRef(0);
+  const currentRefreshScopeRef = useRef<{
+    canManage: boolean;
+    client: typeof client;
+    workspaceId: string;
+  }>({ canManage, client, workspaceId });
+  currentRefreshScopeRef.current = { canManage, client, workspaceId };
 
   // Only USER subjects are people; api_key subjects belong to the API keys
   // section above and are excluded here.
   const userMembers = members.filter((member) => member.subjectId.startsWith("user:"));
 
   const refresh = useCallback(async () => {
+    const currentScope = currentRefreshScopeRef.current;
+    if (
+      !currentScope ||
+      currentScope.workspaceId !== workspaceId ||
+      currentScope.canManage !== canManage ||
+      currentScope.client !== client
+    ) {
+      return;
+    }
+    const generation = ++refreshGenerationRef.current;
+    const isCurrentRefresh = () => {
+      const nextScope = currentRefreshScopeRef.current;
+      return (
+        refreshGenerationRef.current === generation &&
+        nextScope?.workspaceId === workspaceId &&
+        nextScope.canManage === canManage &&
+        nextScope.client === client
+      );
+    };
+    setMembers([]);
+    setSlackAccessRequests([]);
+    setSlackAccessRequestsError(null);
+    setError(null);
+    setLoaded(false);
+
     try {
       // The member roster is primary; pending Slack requests are a manager-only
       // auxiliary surface and must not turn their provider outage into a roster failure.
@@ -599,6 +631,9 @@ export function MembersSection({
         client.listWorkspaceMembers(workspaceId),
         canManage ? client.listSlackUserLinkAccessRequests(workspaceId) : Promise.resolve([]),
       ]);
+      if (!isCurrentRefresh()) {
+        return;
+      }
 
       if (membersResult.status === "rejected") {
         setMembers([]);
@@ -627,12 +662,26 @@ export function MembersSection({
         );
       }
     } finally {
-      setLoaded(true);
+      if (isCurrentRefresh()) {
+        setLoaded(true);
+      }
     }
   }, [canManage, client, workspaceId]);
 
   useEffect(() => {
+    refreshGenerationRef.current += 1;
+    setMembers([]);
+    setSlackAccessRequests([]);
+    setSlackAccessRequestsError(null);
+    setError(null);
+    setLoaded(false);
+    setEditing(null);
+    setEditPermissions(new Set());
+    setRemovingMember(null);
     void refresh();
+    return () => {
+      refreshGenerationRef.current += 1;
+    };
   }, [refresh]);
 
   async function addMember() {

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -566,7 +566,11 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
 }
 
 /** "People with access": the workspace's USER members, with add/edit/remove. */
-export function MembersSection({
+export function MembersSection(props: { workspaceId: string; canManage: boolean }) {
+  return <MembersSectionContent key={props.workspaceId} {...props} />;
+}
+
+function MembersSectionContent({
   workspaceId,
   canManage,
 }: {
@@ -624,43 +628,49 @@ export function MembersSection({
     setError(null);
     setLoaded(false);
 
+    // The member roster is primary; pending Slack requests are a manager-only
+    // auxiliary surface. Start both concurrently, but settle their UI state independently.
+    const membersPromise = Promise.resolve().then(() => client.listWorkspaceMembers(workspaceId));
+    const slackAccessRequestsOutcomePromise = canManage
+      ? Promise.resolve()
+          .then(() => client.listSlackUserLinkAccessRequests(workspaceId))
+          .then(
+            (value) => ({ status: "fulfilled", value }) as const,
+            (reason) => ({ status: "rejected", reason }) as const,
+          )
+      : null;
+
+    if (slackAccessRequestsOutcomePromise) {
+      void slackAccessRequestsOutcomePromise.then((outcome) => {
+        if (!isCurrentRefresh()) {
+          return;
+        }
+        if (outcome.status === "fulfilled") {
+          setSlackAccessRequests(outcome.value);
+          setSlackAccessRequestsError(null);
+        } else {
+          setSlackAccessRequests([]);
+          setSlackAccessRequestsError(
+            outcome.reason instanceof Error ? outcome.reason : new Error(String(outcome.reason)),
+          );
+        }
+      });
+    }
+
     try {
-      // The member roster is primary; pending Slack requests are a manager-only
-      // auxiliary surface and must not turn their provider outage into a roster failure.
-      const [membersResult, slackAccessRequestsResult] = await Promise.allSettled([
-        client.listWorkspaceMembers(workspaceId),
-        canManage ? client.listSlackUserLinkAccessRequests(workspaceId) : Promise.resolve([]),
-      ]);
+      const nextMembers = await membersPromise;
       if (!isCurrentRefresh()) {
         return;
       }
-
-      if (membersResult.status === "rejected") {
-        setMembers([]);
-        setSlackAccessRequests([]);
-        setSlackAccessRequestsError(null);
-        setError(
-          membersResult.reason instanceof Error
-            ? membersResult.reason
-            : new Error(String(membersResult.reason)),
-        );
+      setMembers(nextMembers);
+      setError(null);
+    } catch (caught) {
+      if (!isCurrentRefresh()) {
         return;
       }
-
-      setMembers(membersResult.value);
-      setError(null);
-
-      if (slackAccessRequestsResult.status === "fulfilled") {
-        setSlackAccessRequests(slackAccessRequestsResult.value);
-        setSlackAccessRequestsError(null);
-      } else {
-        setSlackAccessRequests([]);
-        setSlackAccessRequestsError(
-          slackAccessRequestsResult.reason instanceof Error
-            ? slackAccessRequestsResult.reason
-            : new Error(String(slackAccessRequestsResult.reason)),
-        );
-      }
+      setMembers([]);
+      setError(caught instanceof Error ? caught : new Error(String(caught)));
+      return;
     } finally {
       if (isCurrentRefresh()) {
         setLoaded(true);

--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -566,11 +566,18 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
 }
 
 /** "People with access": the workspace's USER members, with add/edit/remove. */
-function MembersSection({ workspaceId, canManage }: { workspaceId: string; canManage: boolean }) {
+export function MembersSection({
+  workspaceId,
+  canManage,
+}: {
+  workspaceId: string;
+  canManage: boolean;
+}) {
   const context = useAppContext();
   const client = context.client;
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [slackAccessRequests, setSlackAccessRequests] = useState<SlackUserLinkAccessRequest[]>([]);
+  const [slackAccessRequestsError, setSlackAccessRequestsError] = useState<Error | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [email, setEmail] = useState("");
@@ -586,17 +593,39 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
 
   const refresh = useCallback(async () => {
     try {
-      const [nextMembers, nextSlackAccessRequests] = await Promise.all([
+      // The member roster is primary; pending Slack requests are a manager-only
+      // auxiliary surface and must not turn their provider outage into a roster failure.
+      const [membersResult, slackAccessRequestsResult] = await Promise.allSettled([
         client.listWorkspaceMembers(workspaceId),
         canManage ? client.listSlackUserLinkAccessRequests(workspaceId) : Promise.resolve([]),
       ]);
-      setMembers(nextMembers);
-      setSlackAccessRequests(nextSlackAccessRequests);
+
+      if (membersResult.status === "rejected") {
+        setMembers([]);
+        setSlackAccessRequests([]);
+        setSlackAccessRequestsError(null);
+        setError(
+          membersResult.reason instanceof Error
+            ? membersResult.reason
+            : new Error(String(membersResult.reason)),
+        );
+        return;
+      }
+
+      setMembers(membersResult.value);
       setError(null);
-    } catch (caught) {
-      setMembers([]);
-      setSlackAccessRequests([]);
-      setError(caught instanceof Error ? caught : new Error(String(caught)));
+
+      if (slackAccessRequestsResult.status === "fulfilled") {
+        setSlackAccessRequests(slackAccessRequestsResult.value);
+        setSlackAccessRequestsError(null);
+      } else {
+        setSlackAccessRequests([]);
+        setSlackAccessRequestsError(
+          slackAccessRequestsResult.reason instanceof Error
+            ? slackAccessRequestsResult.reason
+            : new Error(String(slackAccessRequestsResult.reason)),
+        );
+      }
     } finally {
       setLoaded(true);
     }
@@ -820,6 +849,19 @@ function MembersSection({ workspaceId, canManage }: { workspaceId: string; canMa
             </div>
           ))}
         </div>
+      ) : null}
+
+      {canManage && slackAccessRequestsError ? (
+        <Notice
+          title="Pending Slack access requests unavailable"
+          action={
+            <Button type="button" size="sm" variant="ghost" onClick={() => void refresh()}>
+              Retry
+            </Button>
+          }
+        >
+          {slackAccessRequestsError.message}
+        </Notice>
       ) : null}
 
       {error ? (


### PR DESCRIPTION
## Summary

- settle workspace-member and pending Slack access-request loads independently
- preserve the existing primary member error when the roster itself fails
- keep successfully loaded members visible when the auxiliary Slack request endpoint fails, with a quiet retry notice
- skip the Slack access-request endpoint entirely for non-managers
- add focused regressions for both-success, each single-failure, and non-manager behavior

## Validation

- `bun test apps/web/src/routes/workspace-settings.test.tsx` — 4 passed
- `bun test apps/web/src --max-concurrency=8 --timeout=30000` — 499 passed
- `bun run lint` — passed
- `bun run format:check` — passed
- `bun run typecheck` — all 30 projects passed
- `bun scripts/check-workspace-billing-static.ts` — passed
- `cd apps/web && bun run build` — passed, including React demo, precompression, and bundle budgets

## Broader-suite environment blockers

`bun test --max-concurrency=8 --timeout=30000` completed with 8,162 passes, 36 skips, and 48 failures. The failures are outside this web change and include unavailable sandbox prerequisites (`rustc`/`cargo`, Docker/PostgreSQL, and host macOS tools), plus unrelated Codemode/IndexedDB concurrency or timeout failures. The focused route tests and complete `apps/web` inventory are green.

No deployment, release, merge, or provider/cloud mutation was performed.
