### PR TITLE
fix(runtime): retain complete MCP tool results

### DIFF
--- a/.changeset/bright-tools-retain.md
+++ b/.changeset/bright-tools-retain.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Preserve complete MCP tool results in durable runtime events without changing model-visible output.

--- a/.changeset/bright-tools-retain.md
+++ b/.changeset/bright-tools-retain.md
@@ -4,4 +4,4 @@
 "@opengeni/worker-bundle": patch
 ---
 
-Preserve complete MCP tool results through the runtime, durable database settlement, and worker recovery path without changing model-visible output, including nested prefixed servers and compact approval snapshots.
+Preserve complete MCP tool results through the runtime, durable database settlement, and worker recovery path without changing model-visible output, including nested prefixed servers, compact approval snapshots, and bounded live-memory retention after durable capture.

--- a/.changeset/bright-tools-retain.md
+++ b/.changeset/bright-tools-retain.md
@@ -4,4 +4,4 @@
 "@opengeni/worker-bundle": patch
 ---
 
-Preserve complete MCP tool results through the runtime, durable database settlement, and worker recovery path without changing model-visible output.
+Preserve complete MCP tool results through the runtime, durable database settlement, and worker recovery path without changing model-visible output, including nested prefixed servers and compact approval snapshots.

--- a/.changeset/bright-tools-retain.md
+++ b/.changeset/bright-tools-retain.md
@@ -1,5 +1,7 @@
 ---
 "@opengeni/runtime": patch
+"@opengeni/db": patch
+"@opengeni/worker-bundle": patch
 ---
 
-Preserve complete MCP tool results in durable runtime events without changing model-visible output.
+Preserve complete MCP tool results through the runtime, durable database settlement, and worker recovery path without changing model-visible output.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -8267,6 +8267,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             let stableToolCallIdsToClear: string[] | null = null;
             let completedCurrentToolBatch = false;
             let retainedScreenshotMetadata: RetainedArtifactMetadata | null = null;
+            let normalizedSdkEvents: ReturnType<typeof normalizeSdkEvent> | null = null;
             const generatedImage = generatedImageFromSdkEvent(next.value);
             if (isCompletedGeneratedImageSdkEvent(next.value) && !generatedImage) {
               throw new Error(
@@ -8439,6 +8440,30 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   retainedScreenshotMetadata,
                 );
               }
+              normalizedSdkEvents = normalizeSdkEvent(
+                durableSdkEvent as typeof next.value,
+                retainedScreenshotMetadata
+                  ? {
+                      toolOutputOverride: retainedScreenshotMetadata,
+                      retainedOutputEvidence: retainedScreenshotMetadata.available
+                        ? retainedScreenshotMetadata
+                        : {
+                            available: false,
+                            reason: retainedScreenshotMetadata.reason,
+                          },
+                    }
+                  : {},
+              );
+              const normalizedToolOutput = normalizedSdkEvents.find(
+                (event) =>
+                  event.type === "agent.toolCall.output" &&
+                  (event.payload as { id?: unknown }).id === completedToolCall.callId,
+              )?.payload as { output?: unknown } | undefined;
+              if (!normalizedToolOutput || !Object.hasOwn(normalizedToolOutput, "output")) {
+                throw new Error(
+                  `Completed SDK tool call ${completedToolCall.callId} produced no durable output projection`,
+                );
+              }
               const durableResultItem = retainedScreenshotMetadata
                 ? (compactRetainedScreenshotHistory(
                     [completedToolCall.resultItem],
@@ -8460,6 +8485,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 callId: completedToolCall.callId,
                 modelToolOutputTruncationTokens: modelRunSettings.modelToolOutputTruncationTokens,
                 resultItem: durableResultItem as Record<string, unknown>,
+                eventOutput: normalizedToolOutput.output,
                 ...(videoGenerationAcceptancesByCallId.has(completedToolCall.callId)
                   ? {
                       videoGenerationAcceptance: videoGenerationAcceptancesByCallId.get(
@@ -8514,20 +8540,22 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 completedCurrentToolBatch = currentBatchIsStable;
               }
             }
-            const normalized = normalizeSdkEvent(
-              durableSdkEvent as typeof next.value,
-              retainedScreenshotMetadata
-                ? {
-                    toolOutputOverride: retainedScreenshotMetadata,
-                    retainedOutputEvidence: retainedScreenshotMetadata.available
-                      ? retainedScreenshotMetadata
-                      : {
-                          available: false,
-                          reason: retainedScreenshotMetadata.reason,
-                        },
-                  }
-                : {},
-            );
+            const normalized =
+              normalizedSdkEvents ??
+              normalizeSdkEvent(
+                durableSdkEvent as typeof next.value,
+                retainedScreenshotMetadata
+                  ? {
+                      toolOutputOverride: retainedScreenshotMetadata,
+                      retainedOutputEvidence: retainedScreenshotMetadata.available
+                        ? retainedScreenshotMetadata
+                        : {
+                            available: false,
+                            reason: retainedScreenshotMetadata.reason,
+                          },
+                    }
+                  : {},
+              );
             for (const event of normalized) {
               streamTiming.onEvent(event.type);
               await batcher.push(event);

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -115,6 +115,7 @@ import {
   normalizeModelCallUsage,
   normalizeSdkEvent,
   normalizeProtocolJsonValue,
+  compactMcpResultCustomDataRunState,
   projectHistoryForProvider,
   restoreGenericDispatchHistoryItems,
   sanitizeHistoryItemsForModel,
@@ -3837,6 +3838,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         compactRetainedScreenshotRunState(serialized, retainedScreenshotReceiptsByCallId),
         generatedImageReceiptsByProviderItemId,
       );
+    const compactApprovalRunState = (serialized: string): string =>
+      compactMcpResultCustomDataRunState(compactMediaRunState(serialized));
     // Explicit image-producing tools cross the durable session-media boundary.
     // Incidental frames returned by click/scroll actions remain unretained; an
     // intentional computer_screenshot or view_image result must never be lost
@@ -8789,7 +8792,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               sessionStatus: "requires_action",
               activeTurnId,
               runState: {
-                serializedRunState: compactMediaRunState(stream.state.toString()),
+                serializedRunState: compactApprovalRunState(stream.state.toString()),
                 pendingApprovals,
                 humanInputRequests: humanInputRequests.map(
                   ({ isNew: _isNew, ...request }) => request,

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -116,6 +116,7 @@ import {
   normalizeSdkEvent,
   normalizeProtocolJsonValue,
   compactMcpResultCustomDataRunState,
+  releaseMcpResultCustomDataFromSdkEvent,
   projectHistoryForProvider,
   restoreGenericDispatchHistoryItems,
   sanitizeHistoryItemsForModel,
@@ -8563,6 +8564,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               streamTiming.onEvent(event.type);
               await batcher.push(event);
             }
+            // Structural tool-output events await their durable append before
+            // push returns. The complete result is now retained in the event
+            // row and pending-call recovery receipt, so release only our
+            // duplicate live SDK marker before a long turn accumulates it.
+            releaseMcpResultCustomDataFromSdkEvent(durableSdkEvent);
             if (stableToolCallIdsToClear) {
               const cleared = await clearDurablePendingSessionToolCalls(db, {
                 accountId: input.accountId,

--- a/apps/worker/test/api-integrations.test.ts
+++ b/apps/worker/test/api-integrations.test.ts
@@ -143,7 +143,7 @@ describe("installed API Integration worker adapters", () => {
       expect((await prepared.mcpServers[0]!.listTools()).map((tool) => tool.name)).toEqual([
         "inventory_api__list_items",
       ]);
-      const result = await prepared.mcpServers[0]!.callTool("inventory_api__list_items", {});
+      const result = await prepared.mcpServers[0]!.callToolResult!("inventory_api__list_items", {});
       expect(result).toMatchObject({ isError: false });
       expect(resolved).toEqual([
         {
@@ -204,7 +204,7 @@ describe("installed API Integration worker adapters", () => {
       { localMcpServers },
     );
     try {
-      const result = await prepared.mcpServers[0]!.callTool("inventory_api__list_items", {});
+      const result = await prepared.mcpServers[0]!.callToolResult!("inventory_api__list_items", {});
       expect(result).toMatchObject({ isError: true });
       expect(providerCalls).toBe(0);
       expect(authNeeded).toEqual([

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,7 +144,11 @@ projections use the same protocol-JSON boundary as canonical history before
 strict lossless storage. JavaScript-only `undefined` object properties are
 omitted without mutating the SDK item; undefined array entries and every other
 non-JSON graph still fail with an exact path. The database codec remains strict
-and never silently repairs arbitrary callers.
+and never silently repairs arbitrary callers. Completed pending tool receipts
+retain the model-facing SDK result item separately from the exact
+`agent.toolCall.output` audit value, allowing worker-death recovery to publish
+the same complete event projection as the live path without exposing its extra
+MCP fields to later model requests.
 
 Generated image bytes are permanent workspace artifacts, not another memory
 store. Native provider base64 is replaced before durable history/event/RunState

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -468,6 +468,13 @@ without mutating the SDK object, while undefined array entries and every other
 non-JSON graph fail with the exact offending path. The lossless database codec
 stays strict rather than silently changing arbitrary input.
 
+A completed pending tool receipt retains two deliberately separate lossless
+projections: the bounded SDK result item that may become model-visible history,
+and the exact `agent.toolCall.output` value used by the durable audit event.
+Normal publication and crash recovery consume the same retained event value, so
+recovery cannot reconstruct a poorer MCP result from model-facing content or
+drop open protocol extension fields.
+
 Before a personal MCP is attached, the worker/Codemode boundary revalidates the
 delegation's exact workspace membership, connection id, provider domain, kind,
 owner subject, and active status. A missing, revoked, transferred, or otherwise

--- a/packages/db/drizzle/0223_pending_tool_event_output.sql
+++ b/packages/db/drizzle/0223_pending_tool_event_output.sql
@@ -23,3 +23,27 @@ COMMENT ON COLUMN session_pending_tool_calls.event_output IS
   'Lossless {value} envelope for the exact agent.toolCall.output projection retained until live publish or recovery.';
 COMMENT ON COLUMN session_pending_tool_calls.event_output_codec_version IS
   'Out-of-band lossless JSON codec version for event_output; NULL denotes an older writer or no retained event output.';
+
+CREATE OR REPLACE FUNCTION opengeni_private.guard_pending_tool_event_output_delete()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF OLD.event_output IS NOT NULL
+    AND nullif(current_setting('opengeni.account_id', true), '') IS NOT NULL
+    AND current_setting('opengeni.pending_tool_event_output_v1', true) IS DISTINCT FROM '1' THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '55000',
+      MESSAGE = 'rich pending tool output requires a v1-aware settlement worker';
+  END IF;
+  RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER session_pending_tool_calls_event_output_delete_guard
+BEFORE DELETE ON session_pending_tool_calls
+FOR EACH ROW
+EXECUTE FUNCTION opengeni_private.guard_pending_tool_event_output_delete();
+
+REVOKE ALL ON FUNCTION opengeni_private.guard_pending_tool_event_output_delete() FROM PUBLIC;

--- a/packages/db/drizzle/0223_pending_tool_event_output.sql
+++ b/packages/db/drizzle/0223_pending_tool_event_output.sql
@@ -10,6 +10,9 @@ ALTER TABLE session_pending_tool_calls
   ADD COLUMN IF NOT EXISTS event_output_codec_version integer;
 
 ALTER TABLE session_pending_tool_calls
+  DROP CONSTRAINT IF EXISTS session_pending_tool_calls_event_output_codec_version_chk;
+
+ALTER TABLE session_pending_tool_calls
   ADD CONSTRAINT session_pending_tool_calls_event_output_codec_version_chk
   CHECK (
     (event_output IS NULL AND event_output_codec_version IS NULL)
@@ -40,6 +43,9 @@ BEGIN
   RETURN OLD;
 END;
 $$;
+
+DROP TRIGGER IF EXISTS session_pending_tool_calls_event_output_delete_guard
+  ON session_pending_tool_calls;
 
 CREATE TRIGGER session_pending_tool_calls_event_output_delete_guard
 BEFORE DELETE ON session_pending_tool_calls

--- a/packages/db/drizzle/0223_pending_tool_event_output.sql
+++ b/packages/db/drizzle/0223_pending_tool_event_output.sql
@@ -1,0 +1,25 @@
+-- deployment-mode: rolling
+-- Preserve the exact audit-event output separately from the bounded
+-- model-facing result item so crash recovery can reproduce the live event.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '10min';
+
+ALTER TABLE session_pending_tool_calls
+  ADD COLUMN IF NOT EXISTS event_output jsonb,
+  ADD COLUMN IF NOT EXISTS event_output_codec_version integer;
+
+ALTER TABLE session_pending_tool_calls
+  ADD CONSTRAINT session_pending_tool_calls_event_output_codec_version_chk
+  CHECK (
+    (event_output IS NULL AND event_output_codec_version IS NULL)
+    OR (event_output IS NOT NULL AND event_output_codec_version = 1)
+  ) NOT VALID;
+
+ALTER TABLE session_pending_tool_calls
+  VALIDATE CONSTRAINT session_pending_tool_calls_event_output_codec_version_chk;
+
+COMMENT ON COLUMN session_pending_tool_calls.event_output IS
+  'Lossless {value} envelope for the exact agent.toolCall.output projection retained until live publish or recovery.';
+COMMENT ON COLUMN session_pending_tool_calls.event_output_codec_version IS
+  'Out-of-band lossless JSON codec version for event_output; NULL denotes an older writer or no retained event output.';

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -330,6 +330,7 @@ export async function setRlsContext(db: Database, context: RlsContext): Promise<
   // fences can distinguish their partial writes without inspecting content.
   await db.execute(sql`select set_config('opengeni.lossless_content_writer', '1', true)`);
   await db.execute(sql`select set_config('opengeni.sandbox_recovery_protocol_v2', '1', true)`);
+  await db.execute(sql`select set_config('opengeni.pending_tool_event_output_v1', '1', true)`);
 }
 
 async function readRlsContextSettings(db: Database): Promise<RlsContextSettings> {

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -329,8 +329,9 @@ export async function setRlsContext(db: Database, context: RlsContext): Promise<
   // Old OpenGeni binaries do not set this GUC, so migration-installed update
   // fences can distinguish their partial writes without inspecting content.
   await db.execute(sql`select set_config('opengeni.lossless_content_writer', '1', true)`);
-  await db.execute(sql`select set_config('opengeni.sandbox_recovery_protocol_v2', '1', true)`);
-  await db.execute(sql`select set_config('opengeni.pending_tool_event_output_v1', '1', true)`);
+  await db.execute(sql`select
+    set_config('opengeni.sandbox_recovery_protocol_v2', '1', true),
+    set_config('opengeni.pending_tool_event_output_v1', '1', true)`);
 }
 
 async function readRlsContextSettings(db: Database): Promise<RlsContextSettings> {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -27624,6 +27624,8 @@ export async function recordPendingSessionToolCallResult(
   db: Database,
   input: Omit<PendingSessionToolCallInput, "callType" | "callItem"> & {
     resultItem: Record<string, unknown>;
+    /** Exact agent.toolCall.output value, separate from model-facing history. */
+    eventOutput?: unknown;
     /** Commit a durable async-video acceptance fence with this exact result. */
     videoGenerationAcceptance?: {
       operationId: string;
@@ -27684,18 +27686,27 @@ export async function recordPendingSessionToolCallResult(
         ) {
           throw new Error(`SDK tool result does not settle ${pending.callType}:${input.callId}`);
         }
+        const resultUpdate = withLosslessContentWriteVersion(
+          {
+            resultItem: input.resultItem,
+            resultRecordedAt: new Date(),
+          },
+          "resultItem",
+          "resultItemCodecVersion",
+        );
+        const update = Object.hasOwn(input, "eventOutput")
+          ? withLosslessContentWriteVersion(
+              {
+                ...resultUpdate,
+                eventOutput: { value: input.eventOutput },
+              },
+              "eventOutput",
+              "eventOutputCodecVersion",
+            )
+          : resultUpdate;
         const recorded = await tx
           .update(schema.sessionPendingToolCalls)
-          .set(
-            withLosslessContentWriteVersion(
-              {
-                resultItem: input.resultItem,
-                resultRecordedAt: new Date(),
-              },
-              "resultItem",
-              "resultItemCodecVersion",
-            ),
-          )
+          .set(update)
           .where(
             and(
               eq(schema.sessionPendingToolCalls.id, pending.id),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -6068,6 +6068,8 @@ export const sessionPendingToolCalls = pgTable(
     modelToolOutputTruncationTokens: integer("model_tool_output_truncation_tokens"),
     resultItem: losslessJsonb("result_item").$type<Record<string, unknown>>(),
     resultItemCodecVersion: losslessCodecVersion("result_item_codec_version"),
+    eventOutput: losslessJsonb("event_output").$type<{ value: unknown }>(),
+    eventOutputCodecVersion: losslessCodecVersion("event_output_codec_version"),
     resultRecordedAt: timestamp("result_recorded_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/db/src/session-tool-call-settlement.ts
+++ b/packages/db/src/session-tool-call-settlement.ts
@@ -135,6 +135,10 @@ export async function closePendingSessionToolCallsInTransaction(
       row.resultItem === null
         ? null
         : fromPostgresLosslessJson(row.resultItem, row.resultItemCodecVersion),
+    eventOutput:
+      row.eventOutput === null
+        ? null
+        : fromPostgresLosslessJson(row.eventOutput, row.eventOutputCodecVersion).value,
   }));
   if (pending.length === 0) return { sequence: input.sequence, events: [], closed: 0 };
 
@@ -306,7 +310,8 @@ export async function closePendingSessionToolCallsInTransaction(
                 },
               ],
             }
-          : ((resolution.existingResult?.item ?? resolution.call.resultItem)?.output ??
+          : (resolution.call.eventOutput ??
+            (resolution.existingResult?.item ?? resolution.call.resultItem)?.output ??
             resolution.existingResult?.item ??
             resolution.call.resultItem),
         recovery: {

--- a/packages/db/src/session-tool-call-settlement.ts
+++ b/packages/db/src/session-tool-call-settlement.ts
@@ -138,7 +138,7 @@ export async function closePendingSessionToolCallsInTransaction(
     eventOutput:
       row.eventOutput === null
         ? null
-        : fromPostgresLosslessJson(row.eventOutput, row.eventOutputCodecVersion).value,
+        : fromPostgresLosslessJson(row.eventOutput, row.eventOutputCodecVersion),
   }));
   if (pending.length === 0) return { sequence: input.sequence, events: [], closed: 0 };
 
@@ -310,10 +310,11 @@ export async function closePendingSessionToolCallsInTransaction(
                 },
               ],
             }
-          : (resolution.call.eventOutput ??
-            (resolution.existingResult?.item ?? resolution.call.resultItem)?.output ??
-            resolution.existingResult?.item ??
-            resolution.call.resultItem),
+          : resolution.call.eventOutput !== null
+            ? resolution.call.eventOutput.value
+            : ((resolution.existingResult?.item ?? resolution.call.resultItem)?.output ??
+              resolution.existingResult?.item ??
+              resolution.call.resultItem),
         recovery: {
           interrupted: resolution.interrupted,
           outcome: resolution.interrupted ? "unknown" : "durable_result_found",

--- a/packages/db/test/lossless-json-postgres.test.ts
+++ b/packages/db/test/lossless-json-postgres.test.ts
@@ -794,6 +794,12 @@ describe("lossless canonical JSON PostgreSQL boundary", () => {
       callId,
       output: { type: "text", text: unsafeText },
     };
+    const eventOutput = {
+      content: [{ type: "text", text: unsafeText }],
+      structuredContent: { exactCommand },
+      isError: false,
+      vendorReceipt: { id: unsafeText },
+    };
     expect(
       await registerPendingSessionToolCall(app.db, {
         accountId: grant.accountId,
@@ -817,6 +823,7 @@ describe("lossless canonical JSON PostgreSQL boundary", () => {
         attemptId,
         callId,
         resultItem,
+        eventOutput,
       }),
     ).toEqual({ accepted: true, recorded: true });
     const [pending] = await withWorkspaceRls(app.db, workspaceId, (db) =>
@@ -826,14 +833,19 @@ describe("lossless canonical JSON PostgreSQL boundary", () => {
           callItemCodecVersion: schema.sessionPendingToolCalls.callItemCodecVersion,
           resultItem: schema.sessionPendingToolCalls.resultItem,
           resultItemCodecVersion: schema.sessionPendingToolCalls.resultItemCodecVersion,
+          eventOutput: schema.sessionPendingToolCalls.eventOutput,
+          eventOutputCodecVersion: schema.sessionPendingToolCalls.eventOutputCodecVersion,
         })
         .from(schema.sessionPendingToolCalls)
         .where(eq(schema.sessionPendingToolCalls.callId, callId)),
     );
+    if (!pending?.eventOutput) throw new Error("Pending tool event output was not retained");
     expect({
-      callItem: fromPostgresLosslessJson(pending!.callItem, pending!.callItemCodecVersion),
-      resultItem: fromPostgresLosslessJson(pending!.resultItem, pending!.resultItemCodecVersion),
-    }).toEqual({ callItem, resultItem });
+      callItem: fromPostgresLosslessJson(pending.callItem, pending.callItemCodecVersion),
+      resultItem: fromPostgresLosslessJson(pending.resultItem, pending.resultItemCodecVersion),
+      eventOutput: fromPostgresLosslessJson(pending.eventOutput, pending.eventOutputCodecVersion)
+        .value,
+    }).toEqual({ callItem, resultItem, eventOutput });
     const [rawPending] = await shared.admin<
       Array<{ callType: string | null; resultType: string | null }>
     >`
@@ -868,6 +880,12 @@ describe("lossless canonical JSON PostgreSQL boundary", () => {
       }),
     );
     expect(settled.closed).toBe(1);
+    expect(settled.events).toContainEqual(
+      expect.objectContaining({
+        type: "agent.toolCall.output",
+        payload: expect.objectContaining({ id: callId, output: eventOutput }),
+      }),
+    );
     const settledHistory = await withWorkspaceRls(app.db, workspaceId, (db) =>
       db
         .select({

--- a/packages/db/test/lossless-json-postgres.test.ts
+++ b/packages/db/test/lossless-json-postgres.test.ts
@@ -855,6 +855,22 @@ describe("lossless canonical JSON PostgreSQL boundary", () => {
       callType: "function_call",
       resultType: "function_call_result",
     });
+    const legacyApp = postgres(shared.appUrl, { max: 1, onnotice: () => undefined });
+    try {
+      await expect(
+        legacyApp.begin(async (sql) => {
+          await sql`select set_config('opengeni.account_id', ${grant.accountId}, true)`;
+          await sql`select set_config('opengeni.workspace_id', ${workspaceId}, true)`;
+          await sql`delete from session_pending_tool_calls where call_id = ${callId}`;
+        }),
+      ).rejects.toThrow("rich pending tool output requires a v1-aware settlement worker");
+    } finally {
+      await legacyApp.end();
+    }
+    const [retainedAfterLegacyDelete] = await shared.admin<Array<{ eventOutput: unknown | null }>>`
+      select event_output as "eventOutput"
+      from session_pending_tool_calls where call_id = ${callId}`;
+    expect(retainedAfterLegacyDelete?.eventOutput).not.toBeNull();
 
     const settled = await withWorkspaceRls(app.db, workspaceId, (db) =>
       db.transaction(async (tx) => {

--- a/packages/db/test/migration-0223-pending-tool-event-output.test.ts
+++ b/packages/db/test/migration-0223-pending-tool-event-output.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { acquireBlankTestDatabase } from "@opengeni/testing";
+import { readFile } from "node:fs/promises";
+import postgres from "postgres";
+import { migrate } from "../src/migrate";
+
+const migrationName = "0223_pending_tool_event_output.sql";
+const migrationUrl = new URL(`../drizzle/${migrationName}`, import.meta.url);
+
+describe("migration 0223 pending tool event output", () => {
+  test("reconciles its constraint and trigger after SQL commits before the ledger marker", async () => {
+    const source = await readFile(migrationUrl, "utf8");
+    expect(source.startsWith("-- deployment-mode: rolling\n")).toBe(true);
+    expect(source).toContain(
+      "DROP CONSTRAINT IF EXISTS session_pending_tool_calls_event_output_codec_version_chk",
+    );
+    expect(source).toContain(
+      "DROP TRIGGER IF EXISTS session_pending_tool_calls_event_output_delete_guard",
+    );
+
+    const blank = await acquireBlankTestDatabase("migration-0223-pending-tool-event-output");
+    if (!blank) return;
+    const sql = postgres(blank.databaseUrl, {
+      max: 1,
+      onnotice: () => undefined,
+    });
+    try {
+      await sql.unsafe(`
+        create table schema_migrations (
+          name text primary key,
+          applied_at timestamptz not null default now()
+        )
+      `);
+      await sql`insert into schema_migrations (name) values (${migrationName})`;
+      await migrate(blank.databaseUrl);
+
+      await sql`delete from schema_migrations where name = ${migrationName}`;
+      await sql.unsafe(source);
+
+      // Simulate process/connection loss after the migration transaction
+      // committed but before the runner inserted schema_migrations. The next
+      // process must reconcile the exact DDL and record the marker cleanly.
+      await migrate(blank.databaseUrl);
+      await migrate(blank.databaseUrl);
+
+      const [marker] = await sql<{ count: number }[]>`
+        select count(*)::integer as count
+        from schema_migrations
+        where name = ${migrationName}`;
+      expect(marker?.count).toBe(1);
+
+      const [constraint] = await sql<{ definition: string; validated: boolean }[]>`
+        select pg_get_constraintdef(oid) as definition,
+               convalidated as validated
+        from pg_constraint
+        where conrelid = 'session_pending_tool_calls'::regclass
+          and conname = 'session_pending_tool_calls_event_output_codec_version_chk'`;
+      expect(constraint?.definition).toContain("event_output_codec_version = 1");
+      expect(constraint?.validated).toBe(true);
+
+      const [trigger] = await sql<{ definition: string; enabled: string }[]>`
+        select pg_get_triggerdef(oid) as definition,
+               tgenabled as enabled
+        from pg_trigger
+        where tgrelid = 'session_pending_tool_calls'::regclass
+          and tgname = 'session_pending_tool_calls_event_output_delete_guard'
+          and not tgisinternal`;
+      expect(trigger?.definition).toContain("BEFORE DELETE");
+      expect(trigger?.definition).toContain("guard_pending_tool_event_output_delete");
+      expect(trigger?.enabled).toBe("O");
+    } finally {
+      await sql.end();
+      await blank.release();
+    }
+  }, 180_000);
+});

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -1583,6 +1583,39 @@ describe("clean session control plane", () => {
       },
       eventOutput: pendingRichEventOutput,
     });
+    expect(
+      await registerPendingSessionToolCall(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn!.id,
+        executionGeneration: turn!.executionGeneration,
+        attemptId,
+        callId: "pending-null-call",
+        callType: "function_call",
+        callItem: {
+          type: "function_call",
+          callId: "pending-null-call",
+          name: "null_tool",
+          arguments: "{}",
+        },
+      }),
+    ).toEqual({ accepted: true, registered: true });
+    await recordPendingSessionToolCallResult(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      turnId: turn!.id,
+      executionGeneration: turn!.executionGeneration,
+      attemptId,
+      callId: "pending-null-call",
+      resultItem: {
+        type: "function_call_result",
+        callId: "pending-null-call",
+        output: null,
+      },
+      eventOutput: null,
+    });
     const pendingMixedResultItem = {
       type: "function_call_result",
       callId: "pending-mixed-call",
@@ -1727,6 +1760,14 @@ describe("clean session control plane", () => {
       output: pendingRichEventOutput,
       recovery: { interrupted: false, outcome: "durable_result_found" },
     });
+    const nullRecoveryOutput = recovery.events.find(
+      (event) =>
+        event.type === "agent.toolCall.output" &&
+        (event.payload as { id?: unknown }).id === "pending-null-call",
+    )?.payload as { output?: unknown } | undefined;
+    if (!nullRecoveryOutput) throw new Error("Missing recovered null tool output event");
+    expect(Object.hasOwn(nullRecoveryOutput, "output")).toBe(true);
+    expect(nullRecoveryOutput.output).toBeNull();
     expect(sessionEventPayloadTruncation(mixedRecoveryOutput)).toBeNull();
     const mixedRecoveryPreview = boundSessionEventPayload(mixedRecoveryOutput, {
       surface: "durable_audit",

--- a/packages/db/test/session-control-plane.test.ts
+++ b/packages/db/test/session-control-plane.test.ts
@@ -1543,6 +1543,46 @@ describe("clean session control plane", () => {
       modelToolOutputTruncationTokens: 100,
       resultItem: pendingTextResultItem,
     });
+    const pendingRichEventOutput = {
+      content: [{ type: "text", text: "model-visible content" }],
+      structuredContent: { receiptId: "recovery-receipt-1" },
+      isError: false,
+      _meta: { providerTrace: "recovery-trace-1" },
+      vendorReceipt: { id: "vendor-recovery-1", committed: true },
+    };
+    expect(
+      await registerPendingSessionToolCall(client.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId!,
+        sessionId: session.id,
+        turnId: turn!.id,
+        executionGeneration: turn!.executionGeneration,
+        attemptId,
+        callId: "pending-rich-call",
+        callType: "function_call",
+        callItem: {
+          type: "function_call",
+          callId: "pending-rich-call",
+          name: "rich_tool",
+          arguments: "{}",
+        },
+      }),
+    ).toEqual({ accepted: true, registered: true });
+    await recordPendingSessionToolCallResult(client.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId!,
+      sessionId: session.id,
+      turnId: turn!.id,
+      executionGeneration: turn!.executionGeneration,
+      attemptId,
+      callId: "pending-rich-call",
+      resultItem: {
+        type: "function_call_result",
+        callId: "pending-rich-call",
+        output: { type: "text", text: "model-visible content" },
+      },
+      eventOutput: pendingRichEventOutput,
+    });
     const pendingMixedResultItem = {
       type: "function_call_result",
       callId: "pending-mixed-call",
@@ -1676,6 +1716,17 @@ describe("clean session control plane", () => {
     };
     expect(mixedRecoveryOutput.output).toEqual(mixedOutput);
     expect(mixedRecoveryOutput.recovery.outcome).toBe("durable_result_found");
+    expect(
+      recovery.events.find(
+        (event) =>
+          event.type === "agent.toolCall.output" &&
+          (event.payload as { id?: unknown }).id === "pending-rich-call",
+      )?.payload,
+    ).toMatchObject({
+      id: "pending-rich-call",
+      output: pendingRichEventOutput,
+      recovery: { interrupted: false, outcome: "durable_result_found" },
+    });
     expect(sessionEventPayloadTruncation(mixedRecoveryOutput)).toBeNull();
     const mixedRecoveryPreview = boundSessionEventPayload(mixedRecoveryOutput, {
       surface: "durable_audit",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -4798,6 +4798,7 @@ export class PrefixedMcpServer implements MCPServer {
     this.resultCustomDataBridge = new McpResultCustomDataBridge({
       innerServer: inner,
       unprefixToolName: (toolName) => this.unprefixToolName(toolName),
+      sdkModelOutput: "result",
     });
     this.customDataExtractor = this.resultCustomDataBridge.customDataExtractor;
     this.toolMetaResolver = this.resultCustomDataBridge.toolMetaResolver;
@@ -4933,7 +4934,7 @@ export class PrefixedMcpServer implements MCPServer {
     meta?: Record<string, unknown> | null,
     options?: { signal?: AbortSignal },
   ): Promise<any> {
-    return (await this.callToolResult(toolName, args, meta, options)).content;
+    return await this.callToolResult(toolName, args, meta, options);
   }
 
   async callToolResult(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -77,6 +77,7 @@ import {
   type LazyToolTransport,
 } from "./lazy-tool-transport";
 import { GmailRestMcpServer, isOfficialGmailMcpConfig } from "./gmail-rest-mcp";
+import { createMcpResultCustomDataExtractor } from "./mcp-result-custom-data";
 export {
   GMAIL_REST_API_BASE,
   GMAIL_REST_MCP_TOOLS,
@@ -368,6 +369,11 @@ export {
   serializeHumanInputRequests,
   serializeInteractionInterventionRequests,
 } from "./run-events";
+export {
+  OPENGENI_INNER_MCP_CUSTOM_DATA_KEY,
+  OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY,
+  mcpResultFromCustomData,
+} from "./mcp-result-custom-data";
 export type {
   ModelResponseServiceTierEvent,
   ModelResponseUsage,
@@ -4662,6 +4668,7 @@ function logPublicMcpLifecycleFailure(error: Error): void {
  */
 class AttemptDefinitionMcpServer implements MCPServer {
   readonly cacheToolsList = true;
+  readonly customDataExtractor = createMcpResultCustomDataExtractor();
   readonly name = "opengeni-attempt-local-tools";
   private readonly tools: RuntimeMcpTool[];
   private environment: AttemptToolEnvironment | null = null;
@@ -4748,6 +4755,7 @@ class AttemptDefinitionMcpServer implements MCPServer {
 /** @internal Exported for exact SDK-boundary conformance tests. */
 export class PrefixedMcpServer implements MCPServer {
   readonly cacheToolsList: boolean;
+  readonly customDataExtractor: NonNullable<MCPServer["customDataExtractor"]>;
   readonly name: string;
   readonly prefix: string;
   readonly registryId: string;
@@ -4781,6 +4789,10 @@ export class PrefixedMcpServer implements MCPServer {
     this.name = `${MCP_SDK_LIFECYCLE_NAME}:${safeMcpServerIdentity(registryId)}`;
     this.prefix = prefixedMcpToolName(registryId, "");
     this.cacheToolsList = inner.cacheToolsList;
+    this.customDataExtractor = createMcpResultCustomDataExtractor({
+      innerServer: inner,
+      unprefixToolName: (toolName) => this.unprefixToolName(toolName),
+    });
     this.allowedTools = allowedTools ? new Set(allowedTools) : undefined;
     this.bestEffort = bestEffort;
   }
@@ -4926,7 +4938,7 @@ export class PrefixedMcpServer implements MCPServer {
           ...(options?.signal ? { signal: options.signal } : {}),
         })
       : await this.executeCatalogTool(unprefixed, args ?? {}, meta, options);
-    return result;
+    return result.content;
   }
 
   async callToolResult(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -77,7 +77,7 @@ import {
   type LazyToolTransport,
 } from "./lazy-tool-transport";
 import { GmailRestMcpServer, isOfficialGmailMcpConfig } from "./gmail-rest-mcp";
-import { McpResultCustomDataBridge } from "./mcp-result-custom-data";
+import { McpResultCustomDataBridge, unwrapSdkMcpResultProjection } from "./mcp-result-custom-data";
 export {
   GMAIL_REST_API_BASE,
   GMAIL_REST_MCP_TOOLS,
@@ -370,6 +370,7 @@ export {
   serializeInteractionInterventionRequests,
 } from "./run-events";
 export {
+  compactMcpResultCustomDataRunState,
   OPENGENI_INNER_MCP_CUSTOM_DATA_KEY,
   OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY,
   mcpResultFromCustomData,
@@ -4970,9 +4971,10 @@ export class PrefixedMcpServer implements MCPServer {
       throw new Error(`MCP tool ${unprefixed} is not allowed for server ${this.registryId}`);
     }
     try {
-      const output = this.inner.callToolResult
+      const projectedOutput = this.inner.callToolResult
         ? await this.inner.callToolResult(unprefixed, args, meta, options)
         : mcpContentAsResult(await this.inner.callTool(unprefixed, args, meta, options));
+      const output = unwrapSdkMcpResultProjection(projectedOutput);
       assertMcpPayloadWithinBytes(output, MCP_MAX_TOOL_RESULT_BYTES, "MCP tool result");
       return AttemptToolResult.parse(output);
     } catch (error) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -77,7 +77,7 @@ import {
   type LazyToolTransport,
 } from "./lazy-tool-transport";
 import { GmailRestMcpServer, isOfficialGmailMcpConfig } from "./gmail-rest-mcp";
-import { createMcpResultCustomDataExtractor } from "./mcp-result-custom-data";
+import { McpResultCustomDataBridge } from "./mcp-result-custom-data";
 export {
   GMAIL_REST_API_BASE,
   GMAIL_REST_MCP_TOOLS,
@@ -4668,7 +4668,9 @@ function logPublicMcpLifecycleFailure(error: Error): void {
  */
 class AttemptDefinitionMcpServer implements MCPServer {
   readonly cacheToolsList = true;
-  readonly customDataExtractor = createMcpResultCustomDataExtractor();
+  private readonly resultCustomDataBridge = new McpResultCustomDataBridge();
+  readonly customDataExtractor = this.resultCustomDataBridge.customDataExtractor;
+  readonly toolMetaResolver = this.resultCustomDataBridge.toolMetaResolver;
   readonly name = "opengeni-attempt-local-tools";
   private readonly tools: RuntimeMcpTool[];
   private environment: AttemptToolEnvironment | null = null;
@@ -4738,13 +4740,15 @@ class AttemptDefinitionMcpServer implements MCPServer {
     if (!this.environment) {
       throw new Error("local model tool server has no exact attempt authority");
     }
-    return await this.environment.callModel({
-      modelName: toolName,
-      arguments: args ?? {},
-      subjectId: this.subjectId,
-      ...(meta === undefined ? {} : { transportMeta: meta }),
-      ...(options?.signal ? { signal: options.signal } : {}),
-    });
+    return await this.resultCustomDataBridge.captureResult(args, async (cleanArgs) =>
+      this.environment!.callModel({
+        modelName: toolName,
+        arguments: cleanArgs ?? {},
+        subjectId: this.subjectId,
+        ...(meta === undefined ? {} : { transportMeta: meta }),
+        ...(options?.signal ? { signal: options.signal } : {}),
+      }),
+    );
   }
 
   async invalidateToolsCache(): Promise<void> {
@@ -4756,6 +4760,7 @@ class AttemptDefinitionMcpServer implements MCPServer {
 export class PrefixedMcpServer implements MCPServer {
   readonly cacheToolsList: boolean;
   readonly customDataExtractor: NonNullable<MCPServer["customDataExtractor"]>;
+  readonly toolMetaResolver: NonNullable<MCPServer["toolMetaResolver"]>;
   readonly name: string;
   readonly prefix: string;
   readonly registryId: string;
@@ -4771,6 +4776,7 @@ export class PrefixedMcpServer implements MCPServer {
   private frozenTools: Promise<RuntimeMcpTool[]> | null = null;
   private attemptToolEnvironment: AttemptToolEnvironment | null = null;
   private attemptToolSubjectId = "worker:mcp-model";
+  private readonly resultCustomDataBridge: McpResultCustomDataBridge;
   private readonly lifecycleFailures: Partial<Record<McpLifecyclePhase, McpLifecycleFailure>> = {};
 
   constructor(
@@ -4789,10 +4795,12 @@ export class PrefixedMcpServer implements MCPServer {
     this.name = `${MCP_SDK_LIFECYCLE_NAME}:${safeMcpServerIdentity(registryId)}`;
     this.prefix = prefixedMcpToolName(registryId, "");
     this.cacheToolsList = inner.cacheToolsList;
-    this.customDataExtractor = createMcpResultCustomDataExtractor({
+    this.resultCustomDataBridge = new McpResultCustomDataBridge({
       innerServer: inner,
       unprefixToolName: (toolName) => this.unprefixToolName(toolName),
     });
+    this.customDataExtractor = this.resultCustomDataBridge.customDataExtractor;
+    this.toolMetaResolver = this.resultCustomDataBridge.toolMetaResolver;
     this.allowedTools = allowedTools ? new Set(allowedTools) : undefined;
     this.bestEffort = bestEffort;
   }
@@ -4925,20 +4933,7 @@ export class PrefixedMcpServer implements MCPServer {
     meta?: Record<string, unknown> | null,
     options?: { signal?: AbortSignal },
   ): Promise<any> {
-    const unprefixed = this.unprefixToolName(toolName);
-    if (!this.isAllowed(unprefixed)) {
-      throw new Error(`MCP tool ${unprefixed} is not allowed for server ${this.registryId}`);
-    }
-    const result = this.attemptToolEnvironment
-      ? await this.attemptToolEnvironment.callModel({
-          modelName: toolName,
-          arguments: args ?? {},
-          subjectId: this.attemptToolSubjectId,
-          ...(meta === undefined ? {} : { transportMeta: meta }),
-          ...(options?.signal ? { signal: options.signal } : {}),
-        })
-      : await this.executeCatalogTool(unprefixed, args ?? {}, meta, options);
-    return result.content;
+    return (await this.callToolResult(toolName, args, meta, options)).content;
   }
 
   async callToolResult(
@@ -4951,15 +4946,17 @@ export class PrefixedMcpServer implements MCPServer {
     if (!this.isAllowed(unprefixed)) {
       throw new Error(`MCP tool ${unprefixed} is not allowed for server ${this.registryId}`);
     }
-    return this.attemptToolEnvironment
-      ? await this.attemptToolEnvironment.callModel({
-          modelName: toolName,
-          arguments: args ?? {},
-          subjectId: this.attemptToolSubjectId,
-          ...(meta === undefined ? {} : { transportMeta: meta }),
-          ...(options?.signal ? { signal: options.signal } : {}),
-        })
-      : await this.executeCatalogTool(unprefixed, args ?? {}, meta, options);
+    return await this.resultCustomDataBridge.captureResult(args, async (cleanArgs) =>
+      this.attemptToolEnvironment
+        ? this.attemptToolEnvironment.callModel({
+            modelName: toolName,
+            arguments: cleanArgs ?? {},
+            subjectId: this.attemptToolSubjectId,
+            ...(meta === undefined ? {} : { transportMeta: meta }),
+            ...(options?.signal ? { signal: options.signal } : {}),
+          })
+        : this.executeCatalogTool(unprefixed, cleanArgs ?? {}, meta, options),
+    );
   }
 
   async executeCatalogTool(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -374,6 +374,7 @@ export {
   OPENGENI_INNER_MCP_CUSTOM_DATA_KEY,
   OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY,
   mcpResultFromCustomData,
+  releaseMcpResultCustomDataFromSdkEvent,
 } from "./mcp-result-custom-data";
 export type {
   ModelResponseServiceTierEvent,

--- a/packages/runtime/src/mcp-result-custom-data.ts
+++ b/packages/runtime/src/mcp-result-custom-data.ts
@@ -310,6 +310,26 @@ function compactSerializedRunItem(item: unknown): boolean {
 }
 
 /**
+ * Release OpenGeni's duplicate full-result marker from the live SDK run item
+ * after its normalized event has crossed the durable append boundary. The SDK
+ * output and any inner extractor custom data remain available for subsequent
+ * model calls and approval resume.
+ */
+export function releaseMcpResultCustomDataFromSdkEvent(event: unknown): boolean {
+  if (!event || typeof event !== "object" || Array.isArray(event)) return false;
+  if ((event as { type?: unknown }).type !== "run_item_stream_event") return false;
+  const item = (event as { item?: unknown }).item;
+  if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+  const runItem = item as { type?: unknown; customData?: unknown };
+  if (runItem.type !== "tool_call_output_item") return false;
+  if (!stripMcpResultMarkerFromCustomData(runItem.customData)) return false;
+  if (isPlainRecord(runItem.customData) && Object.keys(runItem.customData).length === 0) {
+    delete runItem.customData;
+  }
+  return true;
+}
+
+/**
  * Remove only OpenGeni's redundant full-result marker from an approval
  * RunState after the worker has durably recorded the exact event output. The
  * SDK's model-visible output, protocol raw item, and any inner custom data stay

--- a/packages/runtime/src/mcp-result-custom-data.ts
+++ b/packages/runtime/src/mcp-result-custom-data.ts
@@ -35,6 +35,7 @@ export class McpResultCustomDataBridge {
     private readonly input?: {
       innerServer?: MCPServer;
       unprefixToolName?: (toolName: string) => string;
+      sdkModelOutput?: "content" | "result";
     },
   ) {
     this.toolMetaResolver = async (context) => {
@@ -101,11 +102,17 @@ export class McpResultCustomDataBridge {
   async captureResult(
     args: Record<string, unknown> | null,
     invoke: (cleanArgs: Record<string, unknown> | null) => Promise<unknown>,
-  ): Promise<AttemptToolResultValue> {
+  ): Promise<unknown> {
     const token = this.takeToken(args);
     try {
       const result = AttemptToolResult.parse(await invoke(args));
       if (token) this.resultsByToken.set(token, result);
+      if (token && this.input?.sdkModelOutput === "result") {
+        // The prefixed server historically exposed the complete MCP result as
+        // model output. Keep that shape while the SDK reads the standard result
+        // fields and the bridge retains the exact audit copy out of band.
+        return { ...result, content: result };
+      }
       return result;
     } finally {
       if (args && token) {

--- a/packages/runtime/src/mcp-result-custom-data.ts
+++ b/packages/runtime/src/mcp-result-custom-data.ts
@@ -2,7 +2,7 @@ import {
   AttemptToolResult,
   type AttemptToolResult as AttemptToolResultValue,
 } from "@opengeni/contracts";
-import type { MCPServer } from "@openai/agents";
+import { UserError, type MCPServer } from "@openai/agents";
 import { randomUUID } from "node:crypto";
 
 export const OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY = "__opengeniMcpResultV1" as const;
@@ -26,6 +26,66 @@ function sdkModelOutputForServer(server: MCPServer, result: AttemptToolResultVal
     return JSON.stringify(result.structuredContent);
   }
   return result.content.length === 1 ? result.content[0] : result.content;
+}
+
+function cloneSdkMcpCustomDataContextValue<T>(value: T): T {
+  try {
+    return structuredClone(value);
+  } catch {
+    return value;
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function assertSdkJsonCompatible(value: unknown): void {
+  if (value == null) return;
+  const valueType = typeof value;
+  if (valueType === "string" || valueType === "boolean") return;
+  if (valueType === "number") {
+    if (!Number.isFinite(value)) {
+      throw new UserError("customDataExtractor must return JSON-compatible data.");
+    }
+    return;
+  }
+  if (
+    valueType === "undefined" ||
+    valueType === "function" ||
+    valueType === "symbol" ||
+    valueType === "bigint"
+  ) {
+    throw new UserError("customDataExtractor must return JSON-compatible data.");
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) assertSdkJsonCompatible(entry);
+    return;
+  }
+  if (!isPlainRecord(value)) {
+    throw new UserError("customDataExtractor must return JSON-compatible data.");
+  }
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== "string") {
+      throw new UserError("customDataExtractor must return JSON-compatible data.");
+    }
+    assertSdkJsonCompatible(value[key]);
+  }
+}
+
+function normalizeSdkToolOutputCustomData(value: unknown): Record<string, unknown> | undefined {
+  if (value == null) return undefined;
+  if (!isPlainRecord(value)) {
+    throw new UserError("customDataExtractor must return an object or null.");
+  }
+  if (Reflect.ownKeys(value).some((key) => typeof key !== "string")) {
+    throw new UserError("customDataExtractor must return an object with string keys.");
+  }
+  if (Object.keys(value).length === 0) return undefined;
+  assertSdkJsonCompatible(value);
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
 }
 
 /**
@@ -79,7 +139,7 @@ export class McpResultCustomDataBridge {
           ...(context.resultMeta === undefined ? {} : { _meta: context.resultMeta }),
         });
 
-      let innerCustomData: Record<string, unknown> | null | undefined;
+      let innerCustomData: Record<string, unknown> | undefined;
       const innerExtractor = this.input?.innerServer?.customDataExtractor;
       if (innerExtractor && this.input?.innerServer) {
         const {
@@ -94,19 +154,25 @@ export class McpResultCustomDataBridge {
           arguments: cleanArguments,
           serverName: this.input.innerServer.name,
           toolName: this.input.unprefixToolName?.(context.toolName) ?? context.toolName,
-          toolOutput: sdkModelOutputForServer(this.input.innerServer, result),
+          toolOutput: cloneSdkMcpCustomDataContextValue(
+            sdkModelOutputForServer(this.input.innerServer, result),
+          ),
           ...(result.structuredContent === undefined
             ? {}
-            : { structuredContent: result.structuredContent }),
+            : {
+                structuredContent: cloneSdkMcpCustomDataContextValue(result.structuredContent),
+              }),
           ...(result.isError === undefined ? {} : { isError: result.isError }),
-          ...(result._meta === undefined ? {} : { resultMeta: result._meta }),
+          ...(result._meta === undefined
+            ? {}
+            : { resultMeta: cloneSdkMcpCustomDataContextValue(result._meta) }),
         };
-        innerCustomData = await innerExtractor(innerContext);
+        innerCustomData = normalizeSdkToolOutputCustomData(await innerExtractor(innerContext));
       }
 
       return {
         [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: result,
-        ...(innerCustomData == null
+        ...(innerCustomData === undefined
           ? {}
           : { [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: innerCustomData }),
       };

--- a/packages/runtime/src/mcp-result-custom-data.ts
+++ b/packages/runtime/src/mcp-result-custom-data.ts
@@ -3,6 +3,7 @@ import {
   type AttemptToolResult as AttemptToolResultValue,
 } from "@opengeni/contracts";
 import type { MCPServer } from "@openai/agents";
+import { randomUUID } from "node:crypto";
 
 export const OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY = "__opengeniMcpResultV1" as const;
 export const OPENGENI_INNER_MCP_CUSTOM_DATA_KEY = "__opengeniInnerMcpCustomData" as const;
@@ -16,6 +17,17 @@ function contentFromModelOutput(output: unknown): unknown[] {
   return Array.isArray(output) ? output : [output];
 }
 
+function sdkModelOutputForServer(server: MCPServer, result: AttemptToolResultValue): unknown {
+  if (
+    server.useStructuredContent === true &&
+    result.isError !== true &&
+    result.structuredContent !== undefined
+  ) {
+    return JSON.stringify(result.structuredContent);
+  }
+  return result.content.length === 1 ? result.content[0] : result.content;
+}
+
 /**
  * The Agents SDK custom-data callback receives only the standard MCP result
  * fields. This bridge binds the original full result to the SDK invocation by
@@ -24,7 +36,7 @@ function contentFromModelOutput(output: unknown): unknown[] {
  * before an inner custom-data extractor runs, so neither boundary observes it.
  */
 export class McpResultCustomDataBridge {
-  private readonly argumentKey = `__opengeniMcpResultCall_${crypto.randomUUID()}`;
+  private readonly argumentKey = `__opengeniMcpResultCall_${randomUUID()}`;
   private readonly resultsByToken = new Map<string, AttemptToolResultValue>();
   private nextToken = 0;
 
@@ -74,6 +86,7 @@ export class McpResultCustomDataBridge {
           resultMeta: _resultMeta,
           structuredContent: _structuredContent,
           isError: _isError,
+          toolOutput: _toolOutput,
           ...baseContext
         } = context;
         const innerContext: McpCustomDataContext = {
@@ -81,6 +94,7 @@ export class McpResultCustomDataBridge {
           arguments: cleanArguments,
           serverName: this.input.innerServer.name,
           toolName: this.input.unprefixToolName?.(context.toolName) ?? context.toolName,
+          toolOutput: sdkModelOutputForServer(this.input.innerServer, result),
           ...(result.structuredContent === undefined
             ? {}
             : { structuredContent: result.structuredContent }),

--- a/packages/runtime/src/mcp-result-custom-data.ts
+++ b/packages/runtime/src/mcp-result-custom-data.ts
@@ -10,6 +10,7 @@ export const OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY = "__opengeniMcpResultV1" as co
 export const OPENGENI_INNER_MCP_CUSTOM_DATA_KEY = "__opengeniInnerMcpCustomData" as const;
 
 const SDK_RESULT_PROJECTION = Symbol("opengeni.sdkMcpResultProjection");
+const MCP_RESULT_BRIDGE_EXTRACTORS = new WeakSet<McpCustomDataExtractor>();
 
 type McpCustomDataExtractor = NonNullable<MCPServer["customDataExtractor"]>;
 type McpCustomDataContext = Parameters<McpCustomDataExtractor>[0];
@@ -179,6 +180,7 @@ export class McpResultCustomDataBridge {
         );
         if (
           normalizedInnerCustomData &&
+          MCP_RESULT_BRIDGE_EXTRACTORS.has(innerExtractor) &&
           Object.hasOwn(normalizedInnerCustomData, OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY)
         ) {
           // A PrefixedMcpServer may itself be wrapped by another prefixed
@@ -202,43 +204,33 @@ export class McpResultCustomDataBridge {
           : { [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: innerCustomData }),
       };
     };
+    MCP_RESULT_BRIDGE_EXTRACTORS.add(this.customDataExtractor);
   }
 
   async captureResult(
     args: Record<string, unknown> | null,
     invoke: (cleanArgs: Record<string, unknown> | null) => Promise<unknown>,
   ): Promise<unknown> {
-    const token = this.takeToken(args);
-    try {
-      const invoked = await invoke(args);
-      const result = normalizeMcpResult(isSdkResultProjection(invoked) ? invoked.content : invoked);
-      if (token) this.resultsByToken.set(token, result);
-      if (token && this.input?.sdkModelOutput === "result") {
-        // The prefixed server historically exposed the complete MCP result as
-        // model output. Keep that shape while the SDK reads the standard result
-        // fields and the bridge retains the exact audit copy out of band. Mark
-        // the compatibility projection privately so another prefixed wrapper
-        // can recover the raw result before parsing it at its own boundary.
-        const projected = { ...result, content: result } as Record<PropertyKey, unknown>;
-        Object.defineProperty(projected, SDK_RESULT_PROJECTION, {
-          value: true,
-          enumerable: false,
-          configurable: false,
-          writable: false,
-        });
-        return projected;
-      }
-      return result;
-    } finally {
-      if (args && token) {
-        Object.defineProperty(args, this.argumentKey, {
-          value: token,
-          enumerable: true,
-          configurable: true,
-          writable: false,
-        });
-      }
+    const { arguments: cleanArguments, token } = this.copyArgumentsWithoutToken(args);
+    const invoked = await invoke(cleanArguments);
+    const result = normalizeMcpResult(isSdkResultProjection(invoked) ? invoked.content : invoked);
+    if (token) this.resultsByToken.set(token, result);
+    if (token && this.input?.sdkModelOutput === "result") {
+      // The prefixed server historically exposed the complete MCP result as
+      // model output. Keep that shape while the SDK reads the standard result
+      // fields and the bridge retains the exact audit copy out of band. Mark
+      // the compatibility projection privately so another prefixed wrapper
+      // can recover the raw result before parsing it at its own boundary.
+      const projected = { ...result, content: result } as Record<PropertyKey, unknown>;
+      Object.defineProperty(projected, SDK_RESULT_PROJECTION, {
+        value: true,
+        enumerable: false,
+        configurable: false,
+        writable: false,
+      });
+      return projected;
     }
+    return result;
   }
 
   private async resolveInnerMeta(
@@ -253,12 +245,17 @@ export class McpResultCustomDataBridge {
     });
   }
 
-  private takeToken(args: Record<string, unknown> | null): string | null {
-    if (!args) return null;
-    const token = args[this.argumentKey];
-    if (typeof token !== "string") return null;
-    delete args[this.argumentKey];
-    return token;
+  private copyArgumentsWithoutToken(args: Record<string, unknown> | null): {
+    arguments: Record<string, unknown> | null;
+    token: string | null;
+  } {
+    if (!args || typeof args[this.argumentKey] !== "string") {
+      return { arguments: args, token: null };
+    }
+    const token = args[this.argumentKey] as string;
+    const cleanArguments = { ...args };
+    delete cleanArguments[this.argumentKey];
+    return { arguments: cleanArguments, token };
   }
 
   private consumeArguments(args: Record<string, unknown> | null): {
@@ -292,14 +289,9 @@ export function unwrapSdkMcpResultProjection(value: unknown): unknown {
 
 function stripMcpResultMarkerFromCustomData(customData: unknown): boolean {
   if (!isPlainRecord(customData)) return false;
-  let changed = false;
-  if (Object.hasOwn(customData, OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY)) {
-    delete customData[OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY];
-    changed = true;
-  }
-  const inner = customData[OPENGENI_INNER_MCP_CUSTOM_DATA_KEY];
-  if (stripMcpResultMarkerFromCustomData(inner)) changed = true;
-  return changed;
+  if (!Object.hasOwn(customData, OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY)) return false;
+  delete customData[OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY];
+  return true;
 }
 
 function compactSerializedRunItem(item: unknown): boolean {

--- a/packages/runtime/src/mcp-result-custom-data.ts
+++ b/packages/runtime/src/mcp-result-custom-data.ts
@@ -4,6 +4,7 @@ import {
 } from "@opengeni/contracts";
 import { UserError, type MCPServer } from "@openai/agents";
 import { randomUUID } from "node:crypto";
+import { normalizeProtocolJsonValue } from "./protocol-json";
 
 export const OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY = "__opengeniMcpResultV1" as const;
 export const OPENGENI_INNER_MCP_CUSTOM_DATA_KEY = "__opengeniInnerMcpCustomData" as const;
@@ -90,6 +91,10 @@ function normalizeSdkToolOutputCustomData(value: unknown): Record<string, unknow
   return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
 }
 
+function normalizeMcpResult(value: unknown): AttemptToolResultValue {
+  return normalizeProtocolJsonValue(AttemptToolResult.parse(value), "$.mcpResult");
+}
+
 /**
  * The Agents SDK custom-data callback receives only the standard MCP result
  * fields. This bridge binds the original full result to the SDK invocation by
@@ -132,7 +137,7 @@ export class McpResultCustomDataBridge {
       if (token) this.resultsByToken.delete(token);
       const result =
         bridgedResult ??
-        AttemptToolResult.parse({
+        normalizeMcpResult({
           content: contentFromModelOutput(context.toolOutput),
           ...(context.structuredContent === undefined
             ? {}
@@ -206,9 +211,7 @@ export class McpResultCustomDataBridge {
     const token = this.takeToken(args);
     try {
       const invoked = await invoke(args);
-      const result = AttemptToolResult.parse(
-        isSdkResultProjection(invoked) ? invoked.content : invoked,
-      );
+      const result = normalizeMcpResult(isSdkResultProjection(invoked) ? invoked.content : invoked);
       if (token) this.resultsByToken.set(token, result);
       if (token && this.input?.sdkModelOutput === "result") {
         // The prefixed server historically exposed the complete MCP result as

--- a/packages/runtime/src/mcp-result-custom-data.ts
+++ b/packages/runtime/src/mcp-result-custom-data.ts
@@ -8,6 +8,8 @@ import { randomUUID } from "node:crypto";
 export const OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY = "__opengeniMcpResultV1" as const;
 export const OPENGENI_INNER_MCP_CUSTOM_DATA_KEY = "__opengeniInnerMcpCustomData" as const;
 
+const SDK_RESULT_PROJECTION = Symbol("opengeni.sdkMcpResultProjection");
+
 type McpCustomDataExtractor = NonNullable<MCPServer["customDataExtractor"]>;
 type McpCustomDataContext = Parameters<McpCustomDataExtractor>[0];
 type McpToolMetaResolver = NonNullable<MCPServer["toolMetaResolver"]>;
@@ -61,7 +63,7 @@ function assertSdkJsonCompatible(value: unknown): void {
     throw new UserError("customDataExtractor must return JSON-compatible data.");
   }
   if (Array.isArray(value)) {
-    for (const entry of value) assertSdkJsonCompatible(entry);
+    value.forEach((entry) => assertSdkJsonCompatible(entry));
     return;
   }
   if (!isPlainRecord(value)) {
@@ -167,7 +169,25 @@ export class McpResultCustomDataBridge {
             ? {}
             : { resultMeta: cloneSdkMcpCustomDataContextValue(result._meta) }),
         };
-        innerCustomData = normalizeSdkToolOutputCustomData(await innerExtractor(innerContext));
+        const normalizedInnerCustomData = normalizeSdkToolOutputCustomData(
+          await innerExtractor(innerContext),
+        );
+        if (
+          normalizedInnerCustomData &&
+          Object.hasOwn(normalizedInnerCustomData, OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY)
+        ) {
+          // A PrefixedMcpServer may itself be wrapped by another prefixed
+          // server. The outer bridge already retains the exact result, so do
+          // not nest another copy of OpenGeni's private marker. Preserve only
+          // the actual extractor payload carried through the inner bridge.
+          const nestedInnerCustomData =
+            normalizedInnerCustomData[OPENGENI_INNER_MCP_CUSTOM_DATA_KEY];
+          innerCustomData = isPlainRecord(nestedInnerCustomData)
+            ? nestedInnerCustomData
+            : undefined;
+        } else {
+          innerCustomData = normalizedInnerCustomData;
+        }
       }
 
       return {
@@ -185,13 +205,25 @@ export class McpResultCustomDataBridge {
   ): Promise<unknown> {
     const token = this.takeToken(args);
     try {
-      const result = AttemptToolResult.parse(await invoke(args));
+      const invoked = await invoke(args);
+      const result = AttemptToolResult.parse(
+        isSdkResultProjection(invoked) ? invoked.content : invoked,
+      );
       if (token) this.resultsByToken.set(token, result);
       if (token && this.input?.sdkModelOutput === "result") {
         // The prefixed server historically exposed the complete MCP result as
         // model output. Keep that shape while the SDK reads the standard result
-        // fields and the bridge retains the exact audit copy out of band.
-        return { ...result, content: result };
+        // fields and the bridge retains the exact audit copy out of band. Mark
+        // the compatibility projection privately so another prefixed wrapper
+        // can recover the raw result before parsing it at its own boundary.
+        const projected = { ...result, content: result } as Record<PropertyKey, unknown>;
+        Object.defineProperty(projected, SDK_RESULT_PROJECTION, {
+          value: true,
+          enumerable: false,
+          configurable: false,
+          writable: false,
+        });
+        return projected;
       }
       return result;
     } finally {
@@ -238,6 +270,86 @@ export class McpResultCustomDataBridge {
     delete cleanArguments[this.argumentKey];
     return { arguments: cleanArguments, token };
   }
+}
+
+function isSdkResultProjection(
+  value: unknown,
+): value is Record<PropertyKey, unknown> & { content: unknown } {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as Record<PropertyKey, unknown>)[SDK_RESULT_PROJECTION] === true,
+  );
+}
+
+export function unwrapSdkMcpResultProjection(value: unknown): unknown {
+  return isSdkResultProjection(value) ? value.content : value;
+}
+
+function stripMcpResultMarkerFromCustomData(customData: unknown): boolean {
+  if (!isPlainRecord(customData)) return false;
+  let changed = false;
+  if (Object.hasOwn(customData, OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY)) {
+    delete customData[OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY];
+    changed = true;
+  }
+  const inner = customData[OPENGENI_INNER_MCP_CUSTOM_DATA_KEY];
+  if (stripMcpResultMarkerFromCustomData(inner)) changed = true;
+  return changed;
+}
+
+function compactSerializedRunItem(item: unknown): boolean {
+  if (!isPlainRecord(item) || item.type !== "tool_call_output_item") return false;
+  const customData = item.customData;
+  if (!stripMcpResultMarkerFromCustomData(customData)) return false;
+  if (isPlainRecord(customData) && Object.keys(customData).length === 0) {
+    delete item.customData;
+  }
+  return true;
+}
+
+/**
+ * Remove only OpenGeni's redundant full-result marker from an approval
+ * RunState after the worker has durably recorded the exact event output. The
+ * SDK's model-visible output, protocol raw item, and any inner custom data stay
+ * intact, so approval resume behavior is unchanged without triplicating a
+ * near-limit MCP result inside the 3 MiB approval-state envelope.
+ */
+export function compactMcpResultCustomDataRunState(serialized: string): string {
+  let parsed: Record<string, unknown>;
+  try {
+    const value: unknown = JSON.parse(serialized);
+    if (!isPlainRecord(value)) return serialized;
+    parsed = value;
+  } catch {
+    return serialized;
+  }
+
+  let changed = false;
+  const compactItems = (items: unknown): void => {
+    if (!Array.isArray(items)) return;
+    for (const item of items) {
+      if (compactSerializedRunItem(item)) changed = true;
+    }
+  };
+  compactItems(parsed.generatedItems);
+  if (isPlainRecord(parsed.lastProcessedResponse)) {
+    compactItems(parsed.lastProcessedResponse.newItems);
+  }
+
+  if (isPlainRecord(parsed.pendingAgentToolRuns)) {
+    for (const [key, nested] of Object.entries(parsed.pendingAgentToolRuns)) {
+      if (typeof nested !== "string") continue;
+      const compacted = compactMcpResultCustomDataRunState(nested);
+      if (compacted !== nested) {
+        parsed.pendingAgentToolRuns[key] = compacted;
+        changed = true;
+      }
+    }
+  }
+
+  return changed ? JSON.stringify(parsed) : serialized;
 }
 
 export function mcpResultFromCustomData(customData: unknown): AttemptToolResultValue | null {

--- a/packages/runtime/src/mcp-result-custom-data.ts
+++ b/packages/runtime/src/mcp-result-custom-data.ts
@@ -1,0 +1,58 @@
+import {
+  AttemptToolResult,
+  type AttemptToolResult as AttemptToolResultValue,
+} from "@opengeni/contracts";
+import type { MCPServer } from "@openai/agents";
+
+export const OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY = "__opengeniMcpResultV1" as const;
+export const OPENGENI_INNER_MCP_CUSTOM_DATA_KEY = "__opengeniInnerMcpCustomData" as const;
+
+type McpCustomDataExtractor = NonNullable<MCPServer["customDataExtractor"]>;
+type McpCustomDataContext = Parameters<McpCustomDataExtractor>[0];
+
+function contentFromModelOutput(output: unknown): unknown[] {
+  return Array.isArray(output) ? output : [output];
+}
+
+/**
+ * Build the SDK-only bridge that retains the complete MCP result while leaving
+ * the model-visible output on the SDK's existing content-based path.
+ */
+export function createMcpResultCustomDataExtractor(input?: {
+  innerServer?: MCPServer;
+  unprefixToolName?: (toolName: string) => string;
+}): McpCustomDataExtractor {
+  const innerExtractor = input?.innerServer?.customDataExtractor;
+  return async (context) => {
+    const result = AttemptToolResult.parse({
+      content: contentFromModelOutput(context.toolOutput),
+      ...(context.structuredContent === undefined
+        ? {}
+        : { structuredContent: context.structuredContent }),
+      ...(typeof context.isError === "boolean" ? { isError: context.isError } : {}),
+      ...(context.resultMeta === undefined ? {} : { _meta: context.resultMeta }),
+    });
+
+    let innerCustomData: Record<string, unknown> | null | undefined;
+    if (innerExtractor && input?.innerServer) {
+      const innerContext: McpCustomDataContext = {
+        ...context,
+        serverName: input.innerServer.name,
+        toolName: input.unprefixToolName?.(context.toolName) ?? context.toolName,
+      };
+      innerCustomData = await innerExtractor(innerContext);
+    }
+
+    return {
+      [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: result,
+      ...(innerCustomData == null ? {} : { [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: innerCustomData }),
+    };
+  };
+}
+
+export function mcpResultFromCustomData(customData: unknown): AttemptToolResultValue | null {
+  if (!customData || typeof customData !== "object" || Array.isArray(customData)) return null;
+  const marker = (customData as Record<string, unknown>)[OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY];
+  const parsed = AttemptToolResult.safeParse(marker);
+  return parsed.success ? parsed.data : null;
+}

--- a/packages/runtime/src/mcp-result-custom-data.ts
+++ b/packages/runtime/src/mcp-result-custom-data.ts
@@ -9,45 +9,148 @@ export const OPENGENI_INNER_MCP_CUSTOM_DATA_KEY = "__opengeniInnerMcpCustomData"
 
 type McpCustomDataExtractor = NonNullable<MCPServer["customDataExtractor"]>;
 type McpCustomDataContext = Parameters<McpCustomDataExtractor>[0];
+type McpToolMetaResolver = NonNullable<MCPServer["toolMetaResolver"]>;
+type McpToolMetaContext = Parameters<McpToolMetaResolver>[0];
 
 function contentFromModelOutput(output: unknown): unknown[] {
   return Array.isArray(output) ? output : [output];
 }
 
 /**
- * Build the SDK-only bridge that retains the complete MCP result while leaving
- * the model-visible output on the SDK's existing content-based path.
+ * The Agents SDK custom-data callback receives only the standard MCP result
+ * fields. This bridge binds the original full result to the SDK invocation by
+ * temporarily adding one instance-private key to the parsed argument object.
+ * The key is removed before the MCP server sees the arguments and is consumed
+ * before an inner custom-data extractor runs, so neither boundary observes it.
  */
-export function createMcpResultCustomDataExtractor(input?: {
-  innerServer?: MCPServer;
-  unprefixToolName?: (toolName: string) => string;
-}): McpCustomDataExtractor {
-  const innerExtractor = input?.innerServer?.customDataExtractor;
-  return async (context) => {
-    const result = AttemptToolResult.parse({
-      content: contentFromModelOutput(context.toolOutput),
-      ...(context.structuredContent === undefined
-        ? {}
-        : { structuredContent: context.structuredContent }),
-      ...(typeof context.isError === "boolean" ? { isError: context.isError } : {}),
-      ...(context.resultMeta === undefined ? {} : { _meta: context.resultMeta }),
-    });
+export class McpResultCustomDataBridge {
+  private readonly argumentKey = `__opengeniMcpResultCall_${crypto.randomUUID()}`;
+  private readonly resultsByToken = new Map<string, AttemptToolResultValue>();
+  private nextToken = 0;
 
-    let innerCustomData: Record<string, unknown> | null | undefined;
-    if (innerExtractor && input?.innerServer) {
-      const innerContext: McpCustomDataContext = {
-        ...context,
-        serverName: input.innerServer.name,
-        toolName: input.unprefixToolName?.(context.toolName) ?? context.toolName,
-      };
-      innerCustomData = await innerExtractor(innerContext);
-    }
+  readonly toolMetaResolver: McpToolMetaResolver;
+  readonly customDataExtractor: McpCustomDataExtractor;
 
-    return {
-      [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: result,
-      ...(innerCustomData == null ? {} : { [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: innerCustomData }),
+  constructor(
+    private readonly input?: {
+      innerServer?: MCPServer;
+      unprefixToolName?: (toolName: string) => string;
+    },
+  ) {
+    this.toolMetaResolver = async (context) => {
+      const innerMeta = await this.resolveInnerMeta(context);
+      const args = context.arguments;
+      if (!args || !Object.isExtensible(args)) return innerMeta;
+      const token = `${++this.nextToken}`;
+      Object.defineProperty(args, this.argumentKey, {
+        value: token,
+        enumerable: true,
+        configurable: true,
+        writable: false,
+      });
+      return innerMeta;
     };
-  };
+
+    this.customDataExtractor = async (context) => {
+      const { arguments: cleanArguments, token } = this.consumeArguments(context.arguments);
+      const bridgedResult = token ? this.resultsByToken.get(token) : undefined;
+      if (token) this.resultsByToken.delete(token);
+      const result =
+        bridgedResult ??
+        AttemptToolResult.parse({
+          content: contentFromModelOutput(context.toolOutput),
+          ...(context.structuredContent === undefined
+            ? {}
+            : { structuredContent: context.structuredContent }),
+          ...(typeof context.isError === "boolean" ? { isError: context.isError } : {}),
+          ...(context.resultMeta === undefined ? {} : { _meta: context.resultMeta }),
+        });
+
+      let innerCustomData: Record<string, unknown> | null | undefined;
+      const innerExtractor = this.input?.innerServer?.customDataExtractor;
+      if (innerExtractor && this.input?.innerServer) {
+        const {
+          resultMeta: _resultMeta,
+          structuredContent: _structuredContent,
+          isError: _isError,
+          ...baseContext
+        } = context;
+        const innerContext: McpCustomDataContext = {
+          ...baseContext,
+          arguments: cleanArguments,
+          serverName: this.input.innerServer.name,
+          toolName: this.input.unprefixToolName?.(context.toolName) ?? context.toolName,
+          ...(result.structuredContent === undefined
+            ? {}
+            : { structuredContent: result.structuredContent }),
+          ...(result.isError === undefined ? {} : { isError: result.isError }),
+          ...(result._meta === undefined ? {} : { resultMeta: result._meta }),
+        };
+        innerCustomData = await innerExtractor(innerContext);
+      }
+
+      return {
+        [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: result,
+        ...(innerCustomData == null
+          ? {}
+          : { [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: innerCustomData }),
+      };
+    };
+  }
+
+  async captureResult(
+    args: Record<string, unknown> | null,
+    invoke: (cleanArgs: Record<string, unknown> | null) => Promise<unknown>,
+  ): Promise<AttemptToolResultValue> {
+    const token = this.takeToken(args);
+    try {
+      const result = AttemptToolResult.parse(await invoke(args));
+      if (token) this.resultsByToken.set(token, result);
+      return result;
+    } finally {
+      if (args && token) {
+        Object.defineProperty(args, this.argumentKey, {
+          value: token,
+          enumerable: true,
+          configurable: true,
+          writable: false,
+        });
+      }
+    }
+  }
+
+  private async resolveInnerMeta(
+    context: McpToolMetaContext,
+  ): Promise<Record<string, unknown> | null | undefined> {
+    const innerResolver = this.input?.innerServer?.toolMetaResolver;
+    if (!innerResolver || !this.input?.innerServer) return undefined;
+    return await innerResolver({
+      ...context,
+      serverName: this.input.innerServer.name,
+      toolName: this.input.unprefixToolName?.(context.toolName) ?? context.toolName,
+    });
+  }
+
+  private takeToken(args: Record<string, unknown> | null): string | null {
+    if (!args) return null;
+    const token = args[this.argumentKey];
+    if (typeof token !== "string") return null;
+    delete args[this.argumentKey];
+    return token;
+  }
+
+  private consumeArguments(args: Record<string, unknown> | null): {
+    arguments: Record<string, unknown> | null;
+    token: string | null;
+  } {
+    if (!args || typeof args[this.argumentKey] !== "string") {
+      return { arguments: args, token: null };
+    }
+    const token = args[this.argumentKey] as string;
+    const cleanArguments = { ...args };
+    delete cleanArguments[this.argumentKey];
+    return { arguments: cleanArguments, token };
+  }
 }
 
 export function mcpResultFromCustomData(customData: unknown): AttemptToolResultValue | null {

--- a/packages/runtime/src/run-events.ts
+++ b/packages/runtime/src/run-events.ts
@@ -11,6 +11,7 @@ import {
 } from "@opengeni/contracts";
 
 import { normalizeProtocolJsonValue } from "./protocol-json";
+import { mcpResultFromCustomData } from "./mcp-result-custom-data";
 
 export type NormalizedRuntimeEvent = {
   type: SessionEventType;
@@ -118,6 +119,31 @@ function toolOutputMediaPreview(value: unknown): SessionEventMediaPreview | null
     if (typeof url !== "string" || url.length === 0) return null;
     return sessionEventMediaPreviewFromDataUrl(url) ?? sessionEventMediaPreview("image/*", null);
   }
+  if ((record.type === "image" || record.type === "audio") && typeof record.data === "string") {
+    const mediaType =
+      typeof record.mimeType === "string" && record.mimeType.length > 0
+        ? record.mimeType
+        : record.type === "audio"
+          ? "audio/*"
+          : "image/png";
+    return (
+      sessionEventMediaPreviewFromDataUrl(record.data) ??
+      sessionEventMediaPreview(mediaType, base64DecodedByteLength(record.data))
+    );
+  }
+  if (record.type === "resource" && record.resource && typeof record.resource === "object") {
+    const resource = record.resource as Record<string, unknown>;
+    if (typeof resource.blob === "string") {
+      const mediaType =
+        typeof resource.mimeType === "string" && resource.mimeType.length > 0
+          ? resource.mimeType
+          : "application/octet-stream";
+      return (
+        sessionEventMediaPreviewFromDataUrl(resource.blob) ??
+        sessionEventMediaPreview(mediaType, base64DecodedByteLength(resource.blob))
+      );
+    }
+  }
   if (record.type !== "image" || !record.image || typeof record.image !== "object") return null;
   const image = record.image as Record<string, unknown>;
   const mediaType =
@@ -156,6 +182,15 @@ export function normalizeToolOutputForEvent(output: unknown): unknown {
       return normalized[0];
     }
     return normalized;
+  }
+  if (output && typeof output === "object") {
+    const record = output as Record<string, unknown>;
+    if (Array.isArray(record.content)) {
+      return {
+        ...record,
+        content: record.content.map((el) => toolOutputMediaPreview(el) ?? el),
+      };
+    }
   }
   return output;
 }
@@ -281,6 +316,7 @@ export function normalizeSdkEvent(
       },
     });
   } else if (item.type === "tool_call_output_item") {
+    const retainedMcpResult = mcpResultFromCustomData(item.customData);
     pushProtocolEvent({
       type: "agent.toolCall.output",
       payload: {
@@ -290,7 +326,7 @@ export function normalizeSdkEvent(
         output:
           "toolOutputOverride" in options
             ? options.toolOutputOverride
-            : normalizeToolOutputForEvent(item.output),
+            : normalizeToolOutputForEvent(retainedMcpResult ?? item.output),
       },
       ...(options.retainedOutputEvidence !== undefined
         ? { retainedOutputEvidence: options.retainedOutputEvidence }

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -4648,13 +4648,24 @@ describe("runtime event normalization", () => {
       structuredContent: { receiptId: "receipt-1", structuredOnly: true },
       isError: false,
       _meta: { providerTrace: "trace-1" },
+      vendorReceipt: { id: "vendor-receipt-1", committed: true },
     };
-    const innerContexts: Array<{ serverName: string; toolName: string }> = [];
+    const innerContexts: Array<{
+      serverName: string;
+      toolName: string;
+      arguments: Record<string, unknown> | null;
+      resultMeta: Record<string, unknown> | undefined;
+    }> = [];
     const inner: MCPServer = {
       name: "rich-inner",
       cacheToolsList: false,
       customDataExtractor: async (context) => {
-        innerContexts.push({ serverName: context.serverName, toolName: context.toolName });
+        innerContexts.push({
+          serverName: context.serverName,
+          toolName: context.toolName,
+          arguments: context.arguments,
+          resultMeta: context.resultMeta,
+        });
         return { innerReceipt: "inner-1" };
       },
       async connect() {},
@@ -4704,7 +4715,14 @@ describe("runtime event normalization", () => {
       [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: fullResult,
       [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: { innerReceipt: "inner-1" },
     });
-    expect(innerContexts).toEqual([{ serverName: "rich-inner", toolName: "inspect" }]);
+    expect(innerContexts).toEqual([
+      {
+        serverName: "rich-inner",
+        toolName: "inspect",
+        arguments: {},
+        resultMeta: { providerTrace: "trace-1" },
+      },
+    ]);
 
     const [durable] = normalizeSdkEvent(outputEvent);
     expect((durable!.payload as { output?: unknown }).output).toEqual(fullResult);
@@ -4713,6 +4731,7 @@ describe("runtime event normalization", () => {
     expect(secondRequest).toContain("model-visible content");
     expect(secondRequest).not.toContain("structuredOnly");
     expect(secondRequest).not.toContain("providerTrace");
+    expect(secondRequest).not.toContain("vendor-receipt-1");
   });
 
   test("connects to real Streamable HTTP MCP servers with prefixes and allowed tool filtering", async () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -78,6 +78,8 @@ import {
   modelResponseUsageFromResponse,
   normalizeSdkEvent,
   normalizeToolOutputForEvent,
+  OPENGENI_INNER_MCP_CUSTOM_DATA_KEY,
+  OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY,
   PrefixedMcpServer,
   prepareRunInput,
   runAgentStream,
@@ -1257,6 +1259,102 @@ describe("runtime event normalization", () => {
     expect(Object.hasOwn(output, "structuredContent")).toBe(true);
   });
 
+  test("prefers a validated complete MCP result marker while preserving explicit false", () => {
+    const [event] = normalizeSdkEvent({
+      type: "run_item_stream_event",
+      item: {
+        id: "item-mcp-result",
+        type: "tool_call_output_item",
+        rawItem: { callId: "call-mcp-result", type: "function_call_result" },
+        output: { type: "text", text: "model-visible content" },
+        customData: {
+          [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: {
+            content: [{ type: "text", text: "model-visible content" }],
+            structuredContent: { receiptId: "receipt-1" },
+            isError: false,
+            _meta: { providerTrace: "trace-1" },
+          },
+        },
+      },
+    } as any);
+
+    expect(event?.type).toBe("agent.toolCall.output");
+    expect((event!.payload as { output?: unknown }).output).toEqual({
+      content: [{ type: "text", text: "model-visible content" }],
+      structuredContent: { receiptId: "receipt-1" },
+      isError: false,
+      _meta: { providerTrace: "trace-1" },
+    });
+  });
+
+  test("preserves explicit MCP errors and does not invent a missing outcome", () => {
+    const events = [true, undefined].map((isError, index) => {
+      const result = {
+        content: [{ type: "text", text: `result-${index}` }],
+        ...(isError === undefined ? {} : { isError }),
+      };
+      return normalizeSdkEvent({
+        type: "run_item_stream_event",
+        item: {
+          id: `item-mcp-outcome-${index}`,
+          type: "tool_call_output_item",
+          rawItem: { callId: `call-mcp-outcome-${index}`, type: "function_call_result" },
+          output: result.content[0],
+          customData: { [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: result },
+        },
+      } as any)[0];
+    });
+
+    const failed = (events[0]!.payload as { output: Record<string, unknown> }).output;
+    const unknown = (events[1]!.payload as { output: Record<string, unknown> }).output;
+    expect(failed.isError).toBe(true);
+    expect(Object.hasOwn(unknown, "isError")).toBe(false);
+  });
+
+  test("trusted tool output overrides take precedence over retained MCP custom data", () => {
+    const override = { type: "generated_image", artifactId: "artifact-1" };
+    const [event] = normalizeSdkEvent(
+      {
+        type: "run_item_stream_event",
+        item: {
+          id: "item-override",
+          type: "tool_call_output_item",
+          rawItem: { callId: "call-override", type: "function_call_result" },
+          output: { type: "text", text: "model output" },
+          customData: {
+            [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: {
+              content: [{ type: "text", text: "retained result" }],
+              isError: false,
+            },
+          },
+        },
+      } as any,
+      { toolOutputOverride: override },
+    );
+
+    expect((event!.payload as { output?: unknown }).output).toEqual(override);
+  });
+
+  test("ignores invalid MCP result markers and falls back to the SDK output", () => {
+    const fallback = { type: "text", text: "sdk output" };
+    const [event] = normalizeSdkEvent({
+      type: "run_item_stream_event",
+      item: {
+        id: "item-invalid-mcp-result",
+        type: "tool_call_output_item",
+        rawItem: { callId: "call-invalid-mcp-result", type: "function_call_result" },
+        output: fallback,
+        customData: {
+          [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: {
+            content: [{ type: "unsupported", value: "not MCP content" }],
+          },
+        },
+      },
+    } as any);
+
+    expect((event!.payload as { output?: unknown }).output).toEqual(fallback);
+  });
+
   test("compacts a codex computer_screenshot Uint8Array output to a non-retained media fact", () => {
     const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
     const [event] = normalizeSdkEvent({
@@ -1409,6 +1507,51 @@ describe("runtime event normalization", () => {
         content: [{ type: "text", text: "delivery failed" }],
       };
       expect(normalizeToolOutputForEvent(mcp)).toEqual(mcp);
+    });
+
+    test("MCP result media blocks become content-free previews without losing result fields", () => {
+      const normalized = normalizeToolOutputForEvent({
+        content: [
+          { type: "text", text: "capture" },
+          { type: "image", data: "aGk=", mimeType: "image/png" },
+          { type: "audio", data: "aGk=", mimeType: "audio/wav" },
+          {
+            type: "resource",
+            resource: {
+              uri: "file:///capture.bin",
+              blob: "aGk=",
+              mimeType: "application/octet-stream",
+            },
+          },
+        ],
+        structuredContent: { captureId: "capture-1" },
+        isError: false,
+        _meta: { providerTrace: "trace-1" },
+      });
+      expect(normalized).toEqual({
+        content: [
+          { type: "text", text: "capture" },
+          expect.objectContaining({
+            type: "media_preview",
+            mediaType: "image/png",
+            inlineBytes: 2,
+          }),
+          expect.objectContaining({
+            type: "media_preview",
+            mediaType: "audio/wav",
+            inlineBytes: 2,
+          }),
+          expect.objectContaining({
+            type: "media_preview",
+            mediaType: "application/octet-stream",
+            inlineBytes: 2,
+          }),
+        ],
+        structuredContent: { captureId: "capture-1" },
+        isError: false,
+        _meta: { providerTrace: "trace-1" },
+      });
+      expect(JSON.stringify(normalized)).not.toContain("aGk=");
     });
   });
 
@@ -4464,6 +4607,114 @@ describe("runtime event normalization", () => {
     );
   });
 
+  test("PrefixedMcpServer exposes content through callTool and the complete result through callToolResult", async () => {
+    const fullResult = {
+      content: [{ type: "text" as const, text: "model-visible content" }],
+      structuredContent: { receiptId: "receipt-1" },
+      isError: false,
+      _meta: { providerTrace: "trace-1" },
+    };
+    const inner: MCPServer = {
+      name: "rich-inner",
+      cacheToolsList: false,
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "inspect",
+            description: "Inspect one item.",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ];
+      },
+      async callTool() {
+        return fullResult.content;
+      },
+      async callToolResult() {
+        return fullResult;
+      },
+      async invalidateToolsCache() {},
+    };
+    const wrapped = new PrefixedMcpServer(inner, "rich");
+
+    expect(await wrapped.callTool("rich__inspect", {})).toEqual(fullResult.content);
+    expect(await wrapped.callToolResult("rich__inspect", {})).toEqual(fullResult);
+  });
+
+  test("the Agents SDK keeps MCP content model-visible and retains the complete result as custom data", async () => {
+    const fullResult = {
+      content: [{ type: "text" as const, text: "model-visible content" }],
+      structuredContent: { receiptId: "receipt-1", structuredOnly: true },
+      isError: false,
+      _meta: { providerTrace: "trace-1" },
+    };
+    const innerContexts: Array<{ serverName: string; toolName: string }> = [];
+    const inner: MCPServer = {
+      name: "rich-inner",
+      cacheToolsList: false,
+      customDataExtractor: async (context) => {
+        innerContexts.push({ serverName: context.serverName, toolName: context.toolName });
+        return { innerReceipt: "inner-1" };
+      },
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "inspect",
+            description: "Inspect one item.",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ];
+      },
+      async callTool() {
+        return fullResult.content;
+      },
+      async callToolResult() {
+        return fullResult;
+      },
+      async invalidateToolsCache() {},
+    };
+    const wrapped = new PrefixedMcpServer(inner, "rich");
+    const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
+    const model = new ScriptedModel([
+      {
+        output: [scriptedFunctionCall("rich__inspect", {}, "rich-call")],
+      },
+      { outputText: "done" },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], {
+      model,
+      hostedWebSearch: false,
+      mcpServers: [wrapped],
+    });
+
+    const result = await runAgentStream(agent, "Inspect it", settings);
+    const streamed: any[] = [];
+    for await (const event of result.toStream()) streamed.push(event);
+    await result.completed;
+
+    const outputEvent = streamed.find(
+      (event) =>
+        event.type === "run_item_stream_event" && event.item?.type === "tool_call_output_item",
+    );
+    expect(outputEvent?.item.output).toEqual(fullResult.content[0]);
+    expect(outputEvent?.item.customData).toEqual({
+      [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: fullResult,
+      [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: { innerReceipt: "inner-1" },
+    });
+    expect(innerContexts).toEqual([{ serverName: "rich-inner", toolName: "inspect" }]);
+
+    const [durable] = normalizeSdkEvent(outputEvent);
+    expect((durable!.payload as { output?: unknown }).output).toEqual(fullResult);
+
+    const secondRequest = JSON.stringify(model.requests[1]?.input);
+    expect(secondRequest).toContain("model-visible content");
+    expect(secondRequest).not.toContain("structuredOnly");
+    expect(secondRequest).not.toContain("providerTrace");
+  });
+
   test("connects to real Streamable HTTP MCP servers with prefixes and allowed tool filtering", async () => {
     const mcp = startTestMcpServer();
     const prepared = await prepareAgentTools(
@@ -5240,9 +5491,12 @@ describe("runtime event normalization", () => {
       },
     );
     try {
-      const result = await prepared.mcpServers[0]!.callTool("cap-uncertain__search_documents", {
-        query: "do not duplicate",
-      });
+      const result = await prepared.mcpServers[0]!.callToolResult!(
+        "cap-uncertain__search_documents",
+        {
+          query: "do not duplicate",
+        },
+      );
       expect(result).toMatchObject({ isError: true });
       const text = JSON.stringify(result);
       expect(text).toMatch(/outcome uncertain/i);
@@ -5305,7 +5559,7 @@ describe("runtime event normalization", () => {
     );
     try {
       await prepared.mcpServers[0]!.listTools();
-      const result = await prepared.mcpServers[0]!.callTool("cap-scoped__search_documents", {
+      const result = await prepared.mcpServers[0]!.callToolResult!("cap-scoped__search_documents", {
         query: "scope",
       });
       expect(result).toMatchObject({ isError: true });
@@ -5370,9 +5624,12 @@ describe("runtime event normalization", () => {
       // invocation isolation degrades the tool-call failure to an isError result
       // the model sees rather than throwing out of the turn — and it must still
       // NOT be misclassified as an auth-needed.
-      const result = await prepared.mcpServers[0]!.callTool("cap-forbidden__search_documents", {
-        query: "scope",
-      });
+      const result = await prepared.mcpServers[0]!.callToolResult!(
+        "cap-forbidden__search_documents",
+        {
+          query: "scope",
+        },
+      );
       expect(result).toMatchObject({ isError: true });
       expect(authNeeded).toEqual([]);
     } finally {
@@ -5428,9 +5685,12 @@ describe("runtime event normalization", () => {
     );
     try {
       await prepared.mcpServers[0]!.listTools();
-      const result = await prepared.mcpServers[0]!.callTool("cap-auth-needed__search_documents", {
-        query: "auth",
-      });
+      const result = await prepared.mcpServers[0]!.callToolResult!(
+        "cap-auth-needed__search_documents",
+        {
+          query: "auth",
+        },
+      );
       expect(result).toMatchObject({
         isError: true,
         content: [
@@ -5881,7 +6141,7 @@ describe("runtime event normalization", () => {
       expect(prepared.mcpServers).toHaveLength(1);
       await prepared.mcpServers[0]!.listTools();
       authorized = false;
-      const result = await prepared.mcpServers[0]!.callTool("codex_apps__search_documents", {
+      const result = await prepared.mcpServers[0]!.callToolResult!("codex_apps__search_documents", {
         query: "must-not-run",
       });
       expect(result).toMatchObject({ isError: true });
@@ -6854,7 +7114,7 @@ describe("runtime event normalization", () => {
       const cap = prepared.mcpServers.find((server) => runtimeMcpServerId(server) === "cap")!;
       const docs = prepared.mcpServers.find((server) => runtimeMcpServerId(server) === "docs")!;
       await cap.listTools();
-      const result = await cap.callTool("cap__search_documents", {
+      const result = await cap.callToolResult!("cap__search_documents", {
         query: "x",
       });
       expect(result).toMatchObject({ isError: true });
@@ -6920,7 +7180,7 @@ describe("runtime event normalization", () => {
         )!;
         const docs = prepared.mcpServers.find((server) => runtimeMcpServerId(server) === "docs")!;
         await flakySrv.listTools(); // fine — only tools/call 401s
-        const result = await flakySrv.callTool("flaky__search_documents", {
+        const result = await flakySrv.callToolResult!("flaky__search_documents", {
           query: "x",
         });
         expect(result).toMatchObject({ isError: true });
@@ -6993,7 +7253,7 @@ describe("runtime event normalization", () => {
       try {
         const flakySrv = prepared.mcpServers[0]!;
         await flakySrv.listTools(); // fine — only tools/call 500s
-        const result = await flakySrv.callTool("flaky__search_documents", {
+        const result = await flakySrv.callToolResult!("flaky__search_documents", {
           query: "x",
         });
         expect(result).toMatchObject({ isError: true });

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -4607,7 +4607,7 @@ describe("runtime event normalization", () => {
     );
   });
 
-  test("PrefixedMcpServer exposes content through callTool and the complete result through callToolResult", async () => {
+  test("PrefixedMcpServer preserves the complete legacy callTool result and callToolResult", async () => {
     const fullResult = {
       content: [{ type: "text" as const, text: "model-visible content" }],
       structuredContent: { receiptId: "receipt-1" },
@@ -4638,11 +4638,11 @@ describe("runtime event normalization", () => {
     };
     const wrapped = new PrefixedMcpServer(inner, "rich");
 
-    expect(await wrapped.callTool("rich__inspect", {})).toEqual(fullResult.content);
+    expect(await wrapped.callTool("rich__inspect", {})).toEqual(fullResult);
     expect(await wrapped.callToolResult("rich__inspect", {})).toEqual(fullResult);
   });
 
-  test("the Agents SDK keeps MCP content model-visible and retains the complete result as custom data", async () => {
+  test("the Agents SDK preserves prefixed MCP model output and retains the audit result as custom data", async () => {
     const fullResult = {
       content: [{ type: "text" as const, text: "model-visible content" }],
       structuredContent: { receiptId: "receipt-1", structuredOnly: true },
@@ -4710,7 +4710,7 @@ describe("runtime event normalization", () => {
       (event) =>
         event.type === "run_item_stream_event" && event.item?.type === "tool_call_output_item",
     );
-    expect(outputEvent?.item.output).toEqual(fullResult.content[0]);
+    expect(outputEvent?.item.output).toEqual(fullResult);
     expect(outputEvent?.item.customData).toEqual({
       [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: fullResult,
       [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: { innerReceipt: "inner-1" },
@@ -4729,9 +4729,60 @@ describe("runtime event normalization", () => {
 
     const secondRequest = JSON.stringify(model.requests[1]?.input);
     expect(secondRequest).toContain("model-visible content");
-    expect(secondRequest).not.toContain("structuredOnly");
-    expect(secondRequest).not.toContain("providerTrace");
-    expect(secondRequest).not.toContain("vendor-receipt-1");
+    expect(secondRequest).toContain("structuredOnly");
+    expect(secondRequest).toContain("providerTrace");
+    expect(secondRequest).toContain("vendor-receipt-1");
+  });
+
+  test("the Agents SDK preserves structured-content-only prefixed MCP model output", async () => {
+    const fullResult = {
+      content: [],
+      structuredContent: { structuredOnly: true },
+      isError: false,
+      _meta: { providerTrace: "structured-only-trace" },
+    };
+    const inner: MCPServer = {
+      name: "structured-only-inner",
+      cacheToolsList: false,
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "inspect",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ];
+      },
+      async callTool() {
+        return fullResult.content;
+      },
+      async callToolResult() {
+        return fullResult;
+      },
+      async invalidateToolsCache() {},
+    };
+    const wrapped = new PrefixedMcpServer(inner, "structured_only");
+    const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
+    const model = new ScriptedModel([
+      { output: [scriptedFunctionCall("structured_only__inspect", {}, "structured-call")] },
+      { outputText: "done" },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], {
+      model,
+      hostedWebSearch: false,
+      mcpServers: [wrapped],
+    });
+
+    const result = await runAgentStream(agent, "Inspect it", settings);
+    for await (const _event of result.toStream()) {
+      // Consume the stream so the second model request is available.
+    }
+    await result.completed;
+
+    const secondRequest = JSON.stringify(model.requests[1]?.input);
+    expect(secondRequest).toContain("structuredOnly");
+    expect(secondRequest).toContain("structured-only-trace");
   });
 
   test("connects to real Streamable HTTP MCP servers with prefixes and allowed tool filtering", async () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -103,6 +103,7 @@ import {
   serializeHumanInputRequests,
   serializeInteractionInterventionRequests,
   refreshCodemodeTokenFile,
+  releaseMcpResultCustomDataFromSdkEvent,
   withStructuredViewImageFunctionResults,
   sandboxCommandExitCode,
   sandboxArtifactRuntimeDoctorHooks,
@@ -4737,6 +4738,69 @@ describe("runtime event normalization", () => {
     expect(secondRequest).toContain("structuredOnly");
     expect(secondRequest).toContain("providerTrace");
     expect(secondRequest).toContain("vendor-receipt-1");
+  });
+
+  test("releases only the live MCP audit marker after durable event capture", async () => {
+    const fullResult = {
+      content: [{ type: "text" as const, text: "release after durable capture" }],
+      structuredContent: { receiptId: "release-receipt-1" },
+      isError: false,
+      _meta: { providerTrace: "release-trace-1" },
+    };
+    const inner: MCPServer = {
+      name: "release-inner",
+      cacheToolsList: false,
+      customDataExtractor: async () => ({ innerReceipt: "retain-inner-1" }),
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "inspect",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ];
+      },
+      async callTool() {
+        return fullResult.content;
+      },
+      async callToolResult() {
+        return fullResult;
+      },
+      async invalidateToolsCache() {},
+    };
+    const wrapped = new PrefixedMcpServer(inner, "release");
+    const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
+    const model = new ScriptedModel([
+      { output: [scriptedFunctionCall("release__inspect", {}, "release-call")] },
+      { outputText: "done" },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], {
+      model,
+      hostedWebSearch: false,
+      mcpServers: [wrapped],
+    });
+
+    const result = await runAgentStream(agent, "Inspect it", settings);
+    const streamed: any[] = [];
+    for await (const event of result.toStream()) streamed.push(event);
+    await result.completed;
+
+    const outputEvent = streamed.find(
+      (event) =>
+        event.type === "run_item_stream_event" && event.item?.type === "tool_call_output_item",
+    );
+    const [durable] = normalizeSdkEvent(outputEvent);
+    expect((durable!.payload as { output?: unknown }).output).toEqual(fullResult);
+    expect(result.state.toString()).toContain(OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY);
+
+    expect(releaseMcpResultCustomDataFromSdkEvent(outputEvent)).toBe(true);
+    expect(outputEvent.item.customData).toEqual({
+      [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: { innerReceipt: "retain-inner-1" },
+    });
+    expect(result.state.toString()).not.toContain(OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY);
+    expect(result.state.toString()).toContain("retain-inner-1");
+    expect(releaseMcpResultCustomDataFromSdkEvent(outputEvent)).toBe(false);
   });
 
   test("nested prefixed servers preserve one exact result marker and the innermost custom data", async () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -18,6 +18,7 @@ import {
   OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE,
   RunContext,
   RunRawModelStreamEvent,
+  RunState,
   getAllMcpTools,
   getLogger,
   invalidateServerToolsCache,
@@ -47,6 +48,7 @@ import {
   buildOpenGeniAgent,
   HUMAN_INPUT_TOOL_NAME,
   buildManifest,
+  compactMcpResultCustomDataRunState,
   composeAgentInstructions,
   connectMcpServersInBatches,
   coreInstructions,
@@ -4737,6 +4739,65 @@ describe("runtime event normalization", () => {
     expect(secondRequest).toContain("vendor-receipt-1");
   });
 
+  test("nested prefixed servers preserve one exact result marker and the innermost custom data", async () => {
+    const fullResult = {
+      content: [{ type: "text" as const, text: "nested model-visible content" }],
+      structuredContent: { receiptId: "nested-receipt-1" },
+      isError: false,
+      _meta: { providerTrace: "nested-trace-1" },
+      vendorReceipt: { id: "nested-vendor-1" },
+    };
+    const base: MCPServer = {
+      name: "nested-base",
+      cacheToolsList: false,
+      customDataExtractor: async () => ({ baseReceipt: "base-1" }),
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "inspect",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ];
+      },
+      async callTool() {
+        return fullResult.content;
+      },
+      async callToolResult() {
+        return fullResult;
+      },
+      async invalidateToolsCache() {},
+    };
+    const inner = new PrefixedMcpServer(base, "inner");
+    const outer = new PrefixedMcpServer(inner, "outer");
+    const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
+    const model = new ScriptedModel([
+      { output: [scriptedFunctionCall("outer__inner__inspect", {}, "nested-call")] },
+      { outputText: "done" },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], {
+      model,
+      hostedWebSearch: false,
+      mcpServers: [outer],
+    });
+
+    const result = await runAgentStream(agent, "Inspect it", settings);
+    const streamed: any[] = [];
+    for await (const event of result.toStream()) streamed.push(event);
+    await result.completed;
+
+    const outputEvent = streamed.find(
+      (event) =>
+        event.type === "run_item_stream_event" && event.item?.type === "tool_call_output_item",
+    );
+    expect(outputEvent?.item.output).toEqual(fullResult);
+    expect(outputEvent?.item.customData).toEqual({
+      [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: fullResult,
+      [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: { baseReceipt: "base-1" },
+    });
+  });
+
   test("the Agents SDK preserves structured-content-only prefixed MCP model output", async () => {
     const fullResult = {
       content: [],
@@ -4967,6 +5028,146 @@ describe("runtime event normalization", () => {
     await expect(runOnce("normalized-invalid")).rejects.toThrow(
       "customDataExtractor must return an object or null.",
     );
+  });
+
+  test("a prefixed inner extractor mirrors the SDK sparse-array JSON boundary", async () => {
+    const sparse = new Array(2);
+    const inner: MCPServer = {
+      name: "sparse-inner",
+      cacheToolsList: false,
+      customDataExtractor: async () => ({ sparse }),
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "inspect",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ];
+      },
+      async callTool() {
+        return [{ type: "text" as const, text: "content" }];
+      },
+      async callToolResult() {
+        return { content: [{ type: "text" as const, text: "content" }] };
+      },
+      async invalidateToolsCache() {},
+    };
+    const wrapped = new PrefixedMcpServer(inner, "sparse");
+    const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
+    const model = new ScriptedModel([
+      { output: [scriptedFunctionCall("sparse__inspect", {}, "sparse-call")] },
+      { outputText: "done" },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], {
+      model,
+      hostedWebSearch: false,
+      mcpServers: [wrapped],
+    });
+
+    const result = await runAgentStream(agent, "Inspect it", settings);
+    const streamed: any[] = [];
+    for await (const event of result.toStream()) streamed.push(event);
+    await result.completed;
+
+    const outputEvent = streamed.find(
+      (event) =>
+        event.type === "run_item_stream_event" && event.item?.type === "tool_call_output_item",
+    );
+    expect(outputEvent?.item.customData).toEqual({
+      [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: {
+        content: [{ type: "text", text: "content" }],
+      },
+      [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: { sparse: [null, null] },
+    });
+  });
+
+  test("approval RunState compaction removes only the redundant MCP result marker", async () => {
+    const largeText = "x".repeat(1_047_000);
+    const fullResult = {
+      content: [{ type: "text" as const, text: largeText }],
+      isError: false,
+      _meta: { providerTrace: "large-trace-1" },
+    };
+    const inner: MCPServer = {
+      name: "large-inner",
+      cacheToolsList: false,
+      customDataExtractor: async () => ({ innerReceipt: "keep-me" }),
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "inspect",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+          {
+            name: "mutate",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ];
+      },
+      async callTool(toolName) {
+        return toolName === "inspect"
+          ? fullResult.content
+          : [{ type: "text" as const, text: "mutated" }];
+      },
+      async callToolResult(toolName) {
+        return toolName === "inspect"
+          ? fullResult
+          : { content: [{ type: "text" as const, text: "mutated" }] };
+      },
+      async invalidateToolsCache() {},
+    };
+    const wrapped = new PrefixedMcpServer(inner, "large");
+    const settings = testSettings({
+      sandboxBackend: "none",
+      webSearchEnabled: false,
+      mcpServers: [
+        {
+          id: "large",
+          name: "Large result",
+          url: "https://large.invalid/mcp",
+          cacheToolsList: false,
+          requireApproval: ["mutate"],
+        },
+      ],
+    });
+    const model = new ScriptedModel([
+      {
+        output: [
+          scriptedFunctionCall("large__inspect", {}, "large-inspect-call"),
+          scriptedFunctionCall("large__mutate", {}, "large-mutate-call"),
+        ],
+      },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], {
+      model,
+      hostedWebSearch: false,
+      mcpServers: [wrapped],
+    });
+
+    const result = await runAgentStream(agent, "Inspect then mutate", settings);
+    for await (const _event of result.toStream()) {
+      // Drain the completed inspect result before the approval interruption.
+    }
+    await result.completed;
+    expect(result.interruptions).toHaveLength(1);
+
+    const serialized = result.state.toString();
+    expect(serialized).toContain(OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY);
+    expect(Buffer.byteLength(serialized, "utf8")).toBeGreaterThan(3 * 1024 * 1024);
+
+    const compacted = compactMcpResultCustomDataRunState(serialized);
+    expect(compacted).not.toContain(OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY);
+    expect(compacted).toContain(OPENGENI_INNER_MCP_CUSTOM_DATA_KEY);
+    expect(compacted).toContain("keep-me");
+    expect(compacted).toContain("large-trace-1");
+    expect(Buffer.byteLength(compacted, "utf8")).toBeLessThan(3 * 1024 * 1024);
+
+    const resumed = await RunState.fromString(agent, compacted);
+    expect(resumed.getInterruptions()).toHaveLength(1);
   });
 
   test("connects to real Streamable HTTP MCP servers with prefixes and allowed tool filtering", async () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -4876,6 +4876,142 @@ describe("runtime event normalization", () => {
     });
   });
 
+  test("an ordinary inner extractor may own OpenGeni-looking custom-data keys", async () => {
+    const fullResult = {
+      content: [{ type: "text" as const, text: "caller-owned marker content" }],
+      isError: false,
+    };
+    const callerOwnedCustomData = {
+      [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: { callerOwned: true },
+      callerReceipt: "retain-caller-marker",
+    };
+    const inner: MCPServer = {
+      name: "caller-marker-inner",
+      cacheToolsList: false,
+      customDataExtractor: async () => callerOwnedCustomData,
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "inspect",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ];
+      },
+      async callTool() {
+        return fullResult.content;
+      },
+      async callToolResult() {
+        return fullResult;
+      },
+      async invalidateToolsCache() {},
+    };
+    const wrapped = new PrefixedMcpServer(inner, "caller_marker");
+    const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
+    const model = new ScriptedModel([
+      { output: [scriptedFunctionCall("caller_marker__inspect", {}, "caller-marker-call")] },
+      { outputText: "done" },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], {
+      model,
+      hostedWebSearch: false,
+      mcpServers: [wrapped],
+    });
+
+    const result = await runAgentStream(agent, "Inspect it", settings);
+    const streamed: any[] = [];
+    for await (const event of result.toStream()) streamed.push(event);
+    await result.completed;
+
+    const outputEvent = streamed.find(
+      (event) =>
+        event.type === "run_item_stream_event" && event.item?.type === "tool_call_output_item",
+    );
+    expect(outputEvent?.item.customData).toEqual({
+      [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: fullResult,
+      [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: callerOwnedCustomData,
+    });
+    expect(releaseMcpResultCustomDataFromSdkEvent(outputEvent)).toBe(true);
+    expect(outputEvent?.item.customData).toEqual({
+      [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: callerOwnedCustomData,
+    });
+  });
+
+  test("a custom server may freeze its clean arguments after a successful call", async () => {
+    const fullResult = {
+      content: [{ type: "text" as const, text: "frozen arguments accepted" }],
+      structuredContent: { receiptId: "frozen-arguments-1" },
+      isError: false,
+    };
+    const receivedArguments: Array<Record<string, unknown> | null> = [];
+    const inner: MCPServer = {
+      name: "freezing-arguments-inner",
+      cacheToolsList: false,
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "commit",
+            inputSchema: {
+              type: "object",
+              properties: { value: { type: "string" } },
+              required: ["value"],
+              additionalProperties: false,
+            },
+          },
+        ];
+      },
+      async callTool(_toolName, args) {
+        receivedArguments.push(args);
+        if (args) Object.freeze(args);
+        return fullResult.content;
+      },
+      async callToolResult(_toolName, args) {
+        receivedArguments.push(args);
+        if (args) Object.freeze(args);
+        return fullResult;
+      },
+      async invalidateToolsCache() {},
+    };
+    const wrapped = new PrefixedMcpServer(inner, "freezing_arguments");
+    const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
+    const model = new ScriptedModel([
+      {
+        output: [
+          scriptedFunctionCall(
+            "freezing_arguments__commit",
+            { value: "committed" },
+            "freezing-arguments-call",
+          ),
+        ],
+      },
+      { outputText: "done" },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], {
+      model,
+      hostedWebSearch: false,
+      mcpServers: [wrapped],
+    });
+
+    const result = await runAgentStream(agent, "Commit it", settings);
+    const streamed: any[] = [];
+    for await (const event of result.toStream()) streamed.push(event);
+    await result.completed;
+
+    const outputEvent = streamed.find(
+      (event) =>
+        event.type === "run_item_stream_event" && event.item?.type === "tool_call_output_item",
+    );
+    expect(outputEvent?.item.output).toEqual(fullResult);
+    expect(outputEvent?.item.customData).toEqual({
+      [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: fullResult,
+    });
+    expect(receivedArguments).toEqual([{ value: "committed" }]);
+    expect(Object.isFrozen(receivedArguments[0])).toBe(true);
+  });
+
   test("the Agents SDK preserves structured-content-only prefixed MCP model output", async () => {
     const fullResult = {
       content: [],

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -117,6 +117,7 @@ import {
   type ResolveConnectionCredentialResult,
   type ConnectorActionPolicyHooks,
 } from "../src/index";
+import { McpResultCustomDataBridge } from "../src/mcp-result-custom-data";
 
 import { Manifest } from "@openai/agents/sandbox";
 import { createAttemptToolEnvironment } from "@opengeni/codemode";
@@ -4738,6 +4739,19 @@ describe("runtime event normalization", () => {
     expect(secondRequest).toContain("structuredOnly");
     expect(secondRequest).toContain("providerTrace");
     expect(secondRequest).toContain("vendor-receipt-1");
+  });
+
+  test("rejects MCP result values the Agents SDK custom-data boundary would rewrite", async () => {
+    const bridge = new McpResultCustomDataBridge();
+
+    await expect(
+      bridge.captureResult(null, async () => ({
+        content: [{ type: "text" as const, text: "negative zero" }],
+        structuredContent: { exactValue: -0 },
+      })),
+    ).rejects.toThrow(
+      'Protocol JSON value at $.mcpResult["structuredContent"]["exactValue"] must be a finite number other than negative zero',
+    );
   });
 
   test("releases only the live MCP audit marker after durable event capture", async () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -4842,6 +4842,133 @@ describe("runtime event normalization", () => {
     expect(innerToolOutputs).toEqual([JSON.stringify(fullResult.structuredContent)]);
   });
 
+  test("a prefixed inner extractor cannot mutate the retained MCP result", async () => {
+    const fullResult = {
+      content: [{ type: "text" as const, text: "immutable content" }],
+      structuredContent: { receipt: { id: "structured-1" } },
+      isError: false,
+      _meta: { trace: { id: "trace-1" } },
+    };
+    const inner: MCPServer = {
+      name: "mutating-inner",
+      cacheToolsList: false,
+      customDataExtractor: async (context) => {
+        (context.resultMeta!.trace as { id: string }).id = "mutated-trace";
+        (context.structuredContent!.receipt as { id: string }).id = "mutated-structured";
+        (context.toolOutput as { text: string }).text = "mutated content";
+        return { retained: true };
+      },
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "inspect",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ];
+      },
+      async callTool() {
+        return fullResult.content;
+      },
+      async callToolResult() {
+        return fullResult;
+      },
+      async invalidateToolsCache() {},
+    };
+    const wrapped = new PrefixedMcpServer(inner, "mutating");
+    const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
+    const model = new ScriptedModel([
+      { output: [scriptedFunctionCall("mutating__inspect", {}, "mutating-call")] },
+      { outputText: "done" },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], {
+      model,
+      hostedWebSearch: false,
+      mcpServers: [wrapped],
+    });
+
+    const result = await runAgentStream(agent, "Inspect it", settings);
+    const streamed: any[] = [];
+    for await (const event of result.toStream()) streamed.push(event);
+    await result.completed;
+
+    const outputEvent = streamed.find(
+      (event) =>
+        event.type === "run_item_stream_event" && event.item?.type === "tool_call_output_item",
+    );
+    expect(outputEvent?.item.output).toEqual(fullResult);
+    expect(outputEvent?.item.customData).toEqual({
+      [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: fullResult,
+      [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: { retained: true },
+    });
+  });
+
+  test("a prefixed inner extractor applies the SDK custom-data normalization boundary", async () => {
+    const extractorResults: unknown[] = [{}, { retained: true }, ["invalid"]];
+    const inner: MCPServer = {
+      name: "normalized-inner",
+      cacheToolsList: false,
+      customDataExtractor: async () => extractorResults.shift() as Record<string, unknown>,
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "inspect",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ];
+      },
+      async callTool() {
+        return [{ type: "text" as const, text: "content" }];
+      },
+      async callToolResult() {
+        return { content: [{ type: "text" as const, text: "content" }] };
+      },
+      async invalidateToolsCache() {},
+    };
+    const wrapped = new PrefixedMcpServer(inner, "normalized");
+    const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
+
+    const runOnce = async (callId: string) => {
+      const model = new ScriptedModel([
+        { output: [scriptedFunctionCall("normalized__inspect", {}, callId)] },
+        { outputText: "done" },
+      ]);
+      const agent = buildOpenGeniAgent(settings, [], {
+        model,
+        hostedWebSearch: false,
+        mcpServers: [wrapped],
+      });
+      const result = await runAgentStream(agent, "Inspect it", settings);
+      const streamed: any[] = [];
+      for await (const event of result.toStream()) streamed.push(event);
+      await result.completed;
+      return streamed.find(
+        (event) =>
+          event.type === "run_item_stream_event" && event.item?.type === "tool_call_output_item",
+      );
+    };
+
+    const empty = await runOnce("normalized-empty");
+    expect(empty?.item.customData).toEqual({
+      [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: {
+        content: [{ type: "text", text: "content" }],
+      },
+    });
+    const retained = await runOnce("normalized-retained");
+    expect(retained?.item.customData).toEqual({
+      [OPENGENI_MCP_RESULT_CUSTOM_DATA_KEY]: {
+        content: [{ type: "text", text: "content" }],
+      },
+      [OPENGENI_INNER_MCP_CUSTOM_DATA_KEY]: { retained: true },
+    });
+    await expect(runOnce("normalized-invalid")).rejects.toThrow(
+      "customDataExtractor must return an object or null.",
+    );
+  });
+
   test("connects to real Streamable HTTP MCP servers with prefixes and allowed tool filtering", async () => {
     const mcp = startTestMcpServer();
     const prepared = await prepareAgentTools(

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -4655,6 +4655,7 @@ describe("runtime event normalization", () => {
       toolName: string;
       arguments: Record<string, unknown> | null;
       resultMeta: Record<string, unknown> | undefined;
+      toolOutput: unknown;
     }> = [];
     const inner: MCPServer = {
       name: "rich-inner",
@@ -4665,6 +4666,7 @@ describe("runtime event normalization", () => {
           toolName: context.toolName,
           arguments: context.arguments,
           resultMeta: context.resultMeta,
+          toolOutput: context.toolOutput,
         });
         return { innerReceipt: "inner-1" };
       },
@@ -4721,6 +4723,7 @@ describe("runtime event normalization", () => {
         toolName: "inspect",
         arguments: {},
         resultMeta: { providerTrace: "trace-1" },
+        toolOutput: fullResult.content[0],
       },
     ]);
 
@@ -4783,6 +4786,60 @@ describe("runtime event normalization", () => {
     const secondRequest = JSON.stringify(model.requests[1]?.input);
     expect(secondRequest).toContain("structuredOnly");
     expect(secondRequest).toContain("structured-only-trace");
+  });
+
+  test("a prefixed server forwards the inner SDK structured-content projection to its extractor", async () => {
+    const fullResult = {
+      content: [{ type: "text" as const, text: "fallback content" }],
+      structuredContent: { receiptId: "structured-receipt-1" },
+      isError: false,
+    };
+    const innerToolOutputs: unknown[] = [];
+    const inner: MCPServer = {
+      name: "structured-inner",
+      cacheToolsList: false,
+      useStructuredContent: true,
+      customDataExtractor: async (context) => {
+        innerToolOutputs.push(context.toolOutput);
+        return { retained: true };
+      },
+      async connect() {},
+      async close() {},
+      async listTools() {
+        return [
+          {
+            name: "inspect",
+            inputSchema: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ];
+      },
+      async callTool() {
+        return fullResult.content;
+      },
+      async callToolResult() {
+        return fullResult;
+      },
+      async invalidateToolsCache() {},
+    };
+    const wrapped = new PrefixedMcpServer(inner, "structured");
+    const settings = testSettings({ sandboxBackend: "none", webSearchEnabled: false });
+    const model = new ScriptedModel([
+      { output: [scriptedFunctionCall("structured__inspect", {}, "structured-inner-call")] },
+      { outputText: "done" },
+    ]);
+    const agent = buildOpenGeniAgent(settings, [], {
+      model,
+      hostedWebSearch: false,
+      mcpServers: [wrapped],
+    });
+
+    const result = await runAgentStream(agent, "Inspect it", settings);
+    for await (const _event of result.toStream()) {
+      // Consume the stream so the custom-data extractor runs.
+    }
+    await result.completed;
+
+    expect(innerToolOutputs).toEqual([JSON.stringify(fullResult.structuredContent)]);
   });
 
   test("connects to real Streamable HTTP MCP servers with prefixes and allowed tool filtering", async () => {

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -117,12 +117,20 @@ describe("release schema contract", () => {
     expect(sourceContract.sha256).toBe(
       migrations.has("0235_canonical_human_login_bindings.sql")
         ? migrations.has("0234_xai_subscription_authority.sql")
-          ? "5450adec25b4684b082ce97c0ab5ce76f33b15de2e943945b5e73534ff67be82"
-          : "e0f7b19f681fee92ea7813660fee0227fef4ed885032a134f36b399591888d8c"
+          ? migrations.has("0223_pending_tool_event_output.sql")
+            ? "94db34c0bd7ee7a3fe9c7a44f7e2705de9bdbe39d1503fa79ec52b024d71ad42"
+            : "5450adec25b4684b082ce97c0ab5ce76f33b15de2e943945b5e73534ff67be82"
+          : migrations.has("0223_pending_tool_event_output.sql")
+            ? "bdf9243aad43605eb2cc380992f564a706aa06ffea885854f6be5911abe2f5c3"
+            : "e0f7b19f681fee92ea7813660fee0227fef4ed885032a134f36b399591888d8c"
         : migrations.has("0234_xai_subscription_authority.sql")
-          ? "035c70dfee83fe5b0962697bf7167bfd09b77d69ea3d3b0e25907998f58d7005"
+          ? migrations.has("0223_pending_tool_event_output.sql")
+            ? "f6370d47ee43da07781d21a67fe07ffb353c9c8ea4e22ec3bf75ba3793f7634a"
+            : "035c70dfee83fe5b0962697bf7167bfd09b77d69ea3d3b0e25907998f58d7005"
           : migrations.has("0233_skill_and_integration_authority_cutover.sql")
-            ? "03b2633febc6805e697fb5aa2002136a80c8699181f9b4c65b3b559ef6726d18"
+            ? migrations.has("0223_pending_tool_event_output.sql")
+              ? "2ec6043704c9f0b8c635ff989d5155e2f047a2377b6a8784139c98b006bcc487"
+              : "03b2633febc6805e697fb5aa2002136a80c8699181f9b4c65b3b559ef6726d18"
             : migrations.has("0232_integration_facet_authority_cutover.sql")
               ? "329a693f62feec5c85716be710791c98c24933796f542a33fae8af82ccfba927"
               : migrations.has("0231_integration_definition_identity_cutover.sql")
@@ -173,12 +181,20 @@ describe("release schema contract", () => {
       ...sourceContract,
       sha256: migrations.has("0235_canonical_human_login_bindings.sql")
         ? migrations.has("0234_xai_subscription_authority.sql")
-          ? "5450adec25b4684b082ce97c0ab5ce76f33b15de2e943945b5e73534ff67be82"
-          : "e0f7b19f681fee92ea7813660fee0227fef4ed885032a134f36b399591888d8c"
+          ? migrations.has("0223_pending_tool_event_output.sql")
+            ? "94db34c0bd7ee7a3fe9c7a44f7e2705de9bdbe39d1503fa79ec52b024d71ad42"
+            : "5450adec25b4684b082ce97c0ab5ce76f33b15de2e943945b5e73534ff67be82"
+          : migrations.has("0223_pending_tool_event_output.sql")
+            ? "bdf9243aad43605eb2cc380992f564a706aa06ffea885854f6be5911abe2f5c3"
+            : "e0f7b19f681fee92ea7813660fee0227fef4ed885032a134f36b399591888d8c"
         : migrations.has("0234_xai_subscription_authority.sql")
-          ? "035c70dfee83fe5b0962697bf7167bfd09b77d69ea3d3b0e25907998f58d7005"
+          ? migrations.has("0223_pending_tool_event_output.sql")
+            ? "f6370d47ee43da07781d21a67fe07ffb353c9c8ea4e22ec3bf75ba3793f7634a"
+            : "035c70dfee83fe5b0962697bf7167bfd09b77d69ea3d3b0e25907998f58d7005"
           : migrations.has("0233_skill_and_integration_authority_cutover.sql")
-            ? "03b2633febc6805e697fb5aa2002136a80c8699181f9b4c65b3b559ef6726d18"
+            ? migrations.has("0223_pending_tool_event_output.sql")
+              ? "2ec6043704c9f0b8c635ff989d5155e2f047a2377b6a8784139c98b006bcc487"
+              : "03b2633febc6805e697fb5aa2002136a80c8699181f9b4c65b3b559ef6726d18"
             : migrations.has("0232_integration_facet_authority_cutover.sql")
               ? "329a693f62feec5c85716be710791c98c24933796f542a33fae8af82ccfba927"
               : migrations.has("0231_integration_definition_identity_cutover.sql")
@@ -398,6 +414,7 @@ describe("release schema contract", () => {
         (migrations.has("0220_session_channels.sql") ? 1 : 0) +
         (migrations.has("0221_sessions_channel_index.sql") ? 1 : 0) +
         (migrations.has("0222_session_visibility_authority_epochs.sql") ? 1 : 0) +
+        (migrations.has("0223_pending_tool_event_output.sql") ? 1 : 0) +
         (migrations.has("0222_sessions_channel_fk.sql") ? 1 : 0) +
         (migrations.has("0223_sessions_channel_fk_validate.sql") ? 1 : 0) +
         (migrations.has("0224_slack_post_outcome_reconciliation.sql") ? 1 : 0) +
@@ -413,12 +430,20 @@ describe("release schema contract", () => {
     expect(contract.sha256).toBe(
       migrations.has("0235_canonical_human_login_bindings.sql")
         ? migrations.has("0234_xai_subscription_authority.sql")
-          ? "5450adec25b4684b082ce97c0ab5ce76f33b15de2e943945b5e73534ff67be82"
-          : "e0f7b19f681fee92ea7813660fee0227fef4ed885032a134f36b399591888d8c"
+          ? migrations.has("0223_pending_tool_event_output.sql")
+            ? "94db34c0bd7ee7a3fe9c7a44f7e2705de9bdbe39d1503fa79ec52b024d71ad42"
+            : "5450adec25b4684b082ce97c0ab5ce76f33b15de2e943945b5e73534ff67be82"
+          : migrations.has("0223_pending_tool_event_output.sql")
+            ? "bdf9243aad43605eb2cc380992f564a706aa06ffea885854f6be5911abe2f5c3"
+            : "e0f7b19f681fee92ea7813660fee0227fef4ed885032a134f36b399591888d8c"
         : migrations.has("0234_xai_subscription_authority.sql")
-          ? "035c70dfee83fe5b0962697bf7167bfd09b77d69ea3d3b0e25907998f58d7005"
+          ? migrations.has("0223_pending_tool_event_output.sql")
+            ? "f6370d47ee43da07781d21a67fe07ffb353c9c8ea4e22ec3bf75ba3793f7634a"
+            : "035c70dfee83fe5b0962697bf7167bfd09b77d69ea3d3b0e25907998f58d7005"
           : migrations.has("0233_skill_and_integration_authority_cutover.sql")
-            ? "03b2633febc6805e697fb5aa2002136a80c8699181f9b4c65b3b559ef6726d18"
+            ? migrations.has("0223_pending_tool_event_output.sql")
+              ? "2ec6043704c9f0b8c635ff989d5155e2f047a2377b6a8784139c98b006bcc487"
+              : "03b2633febc6805e697fb5aa2002136a80c8699181f9b4c65b3b559ef6726d18"
             : migrations.has("0232_integration_facet_authority_cutover.sql")
               ? "329a693f62feec5c85716be710791c98c24933796f542a33fae8af82ccfba927"
               : migrations.has("0231_integration_definition_identity_cutover.sql")
@@ -632,6 +657,12 @@ describe("release schema contract", () => {
       sha256: "26ed3d2ffcaf572623ad263aaa0103625b4ed1e9d28bcb7b5d35eb972d9762d1",
       deploymentMode: "maintenance",
     });
+    if (migrations.has("0223_pending_tool_event_output.sql")) {
+      expect(migrations.get("0223_pending_tool_event_output.sql")).toMatchObject({
+        sha256: "851cdb5dfe14f1cf6323e6cf59e55269b87d2db4406ea2ad10147553635eb707",
+        deploymentMode: "rolling",
+      });
+    }
     if (migrations.has("0234_xai_subscription_authority.sql")) {
       expect(migrations.get("0234_xai_subscription_authority.sql")).toMatchObject({
         sha256: "be0c23d624d545226068ce7627a2b458fe9aad996ea7ee750753c81eeb8988a8",


### PR DESCRIPTION
## Summary
- retain complete MCP tool result envelopes in SDK custom data while keeping model-visible output content-only
- persist validated `content`, `structuredContent`, explicit `isError`, and `_meta` fields in tool output events
- compose provider custom-data extractors without collisions and compact inline MCP media/blob bytes into audit previews
- update direct wrapper assertions to use the SDK's `callToolResult` contract

## Verification
- `bun run typecheck`
- `bun x oxfmt --check packages/runtime/src/index.ts packages/runtime/src/run-events.ts packages/runtime/src/mcp-result-custom-data.ts packages/runtime/test/runtime.test.ts apps/worker/test/api-integrations.test.ts .changeset/bright-tools-retain.md`
- `bun x oxlint --deny-warnings packages/runtime/src/index.ts packages/runtime/src/run-events.ts packages/runtime/src/mcp-result-custom-data.ts packages/runtime/test/runtime.test.ts apps/worker/test/api-integrations.test.ts`
- `bun test packages/runtime/test/runtime.test.ts apps/worker/test/api-integrations.test.ts --timeout 30000` (255 pass)
