### PR TITLE
feat: provision managed human tenancy lifecycle

### DIFF
--- a/.changeset/managed-human-tenancy-lifecycle.md
+++ b/.changeset/managed-human-tenancy-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/db": minor
+---
+
+Add the managed-human organization-membership and personal-workspace lifecycle
+provisioning capability while preserving legacy workspace access behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,14 +79,16 @@ MinIO is the local S3-compatible object storage default for Docker Compose and o
 For a map of every app, package, and how the parts fit together, start at [`docs/architecture.md`](docs/architecture.md) and follow its links to the focused topic docs.
 
 - Public clients talk only to the API.
-- Organization-tenancy Slice A names the future `Organization → Workspace → User`
-  authority hierarchy without activating it: `managed_accounts.id` remains the
-  physical organization id, organization membership is distinct from workspace
-  access, a personal workspace is lifecycle metadata rather than the ownership
-  anchor for user resources, and the new authority/grant tables are deny-all
-  FORCE-RLS scaffolding. Existing APIs, resources, sessions, and RLS behavior
-  remain workspace-owned/workspace-shared until later reviewed activation
-  slices. See `docs/organization-tenancy.md`.
+- Organization-tenancy Slices A+B stage the `Organization → Workspace → User`
+  authority hierarchy without activating personal runtime access:
+  `managed_accounts.id` remains the physical organization id, organization
+  membership is distinct from workspace access, managed-human provisioning
+  creates one same-org personal workspace pointer plus its normal control row,
+  and the personal workspace receives no `workspace_memberships` row. The four
+  authority/grant tables remain FORCE-RLS with zero direct app DML; only the
+  exact lifecycle SECURITY DEFINER seam may create the membership. Existing
+  APIs, resources, sessions, lists, and RLS behavior remain
+  workspace-owned/workspace-shared. See `docs/organization-tenancy.md`.
 - Domain/access/billing helpers now live in `@opengeni/core` under `packages/core/src`; `apps/api` routes are HTTP adapters over them.
 - Browser streaming uses `GET /v1/workspaces/:workspaceId/sessions/:id/events/stream` with SSE.
 - Session goals support `GET`, `PATCH(status paused|active)`, and idempotent `DELETE` clear on `/v1/workspaces/:workspaceId/sessions/:id/goal`; clearing removes the goal row and emits `goal.cleared`.

--- a/apps/worker/test/embedded-lifecycle.test.ts
+++ b/apps/worker/test/embedded-lifecycle.test.ts
@@ -386,6 +386,13 @@ describe("embedded worker lifecycle contract", () => {
           public_execute: false,
           security_definer: true,
         },
+        {
+          name: "ensure_managed_human_personal_workspace(uuid, text, uuid)",
+          owner: "opengeni_migrator",
+          can_execute: true,
+          public_execute: false,
+          security_definer: true,
+        },
       ],
       [
         {
@@ -420,6 +427,10 @@ describe("embedded worker lifecycle contract", () => {
       tablePrivileges: {},
       protectedNoDirectDmlTables: [],
     })();
+    expect((catalogResults[6] as Array<{ name: string }>).map((routine) => routine.name)).toEqual([
+      "knowledge_source_sync_lock_authority(uuid, uuid, uuid)",
+      "ensure_managed_human_personal_workspace(uuid, text, uuid)",
+    ]);
     expect(catalogQueries).toBe(catalogResults.length);
     expect(directExecutions).toBe(0);
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,18 +211,24 @@ Workspace State is an additive read-only projection over those existing authorit
 
 Effective retrieval has one composition boundary: `searchEffectiveDocuments`. The authenticated immutable initiating subject is bound outside request/tool input, then `/knowledge/search`, SDK `searchKnowledge`, and docs-MCP `knowledge_search` compose authorized organization + current-workspace + initiating-user personal Documents before vector/keyword ranking and limits. Typed results retain source metadata and immutable authority provenance. The single-record compatibility predicate applies the same exact authority tuple: legacy personal authority remains anchored to its originating workspace, workspace authority requires that workspace, and incomplete, non-canonical, overlong, or unknown tuples deny rather than becoming visible. Agent calls additionally require `agent_access=true`; Documents remain explicit RAG evidence and never enter prompts or memories automatically. Docs-MCP `list_indexed_documents` applies that same effective agent scope and returns source plus authority/ingestion provenance in database-assigned indexing-completion order. Its opaque checkpoint is bound to the account, requesting workspace, and immutable initiating subject; callers persist `nextCheckpoint` only after processing the page. Migration `0202_document_index_checkpoints.sql` stamps the sequence only on transitions to `ready`, so metadata refreshes and collection moves do not manufacture new review work while a successful reindex does. Canonical: `packages/documents/src/index.ts`, `apps/api/src/routes/documents.ts`, `apps/api/src/mcp/documents.ts`, `packages/contracts/src/index.ts`, `packages/db/src/schema.ts`, `packages/sdk/src/client.ts`.
 
-Migration 0218 adds the inert organization-tenancy Slice A foundation. The
-physical `managed_accounts.id` remains the organization identifier; new
-organization memberships carry one personal-workspace lifecycle pointer, while
-stable user-resource authority belongs to the organization membership rather
-than that workspace. Separate deny-all FORCE-RLS tables, each with one
-explicit `organization_tenancy_system_only` policy using
-`USING (false) WITH CHECK (false)`, name user-resource authority, owner-bound
-action grants, and configurable personal retention.
+Migrations 0218 and 0219 add the staged organization-tenancy foundation and
+managed-human lifecycle dual-write. The physical `managed_accounts.id` remains
+the organization identifier; each Better Auth managed human now converges on
+one same-organization `organization_memberships` row and one deterministic
+personal-workspace lifecycle pointer, while stable user-resource authority
+still belongs to the organization membership rather than that workspace.
+The four tenancy tables remain FORCE-RLS with no direct `opengeni_app` table
+DML; the only runtime write path is the target-schema-local,
+PUBLIC-revoked `ensure_managed_human_personal_workspace` SECURITY DEFINER
+capability, which validates the exact account, `user:<id>` subject, existing
+owner membership, workspace identity, and control row before the lifecycle
+write.
 Grant rows carry the owning membership and a canonical action; `once` and
 `session` are fenced to one exact session plus positive authority epoch, while
 `always` is a standing grant with null session and epoch. A later activation
-slice must consume `once` grants atomically before accepting use.
+slice must consume `once` grants atomically before accepting use. Slice B does
+not create any authority or grant rows, and the personal workspace remains
+absent from runtime workspace access.
 Sessions gain additive owner, `user_private|workspace_shared` visibility,
 authority-epoch, and independent-fork provenance columns; every existing row
 defaults to workspace-shared epoch 1 with no owner or fork authority. This slice

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -30,6 +30,37 @@ receives no direct table DML. Privileged migration/operator connections can
 inspect the scaffold. No API, SDK, worker, MCP, UI, or resource DAO uses it in
 Slice A.
 
+## Slice B: managed-human lifecycle provisioning
+
+Migration `0219_organization_tenancy_managed_human_provisioning.sql` adds the
+first narrow dual-write seam without activating personal-workspace runtime
+access. The existing Better Auth managed-human hook
+`ensureManagedAccessForUser` now converges, in one transaction, on:
+
+- exactly one `organization_memberships` row for the existing
+  `managed_accounts` organization and the derived `user:<id>` subject;
+- exactly one deterministic same-organization personal workspace with a normal
+  `workspace_inference_controls` row; and
+- an active membership pointer to that workspace.
+
+The personal workspace is lifecycle metadata only in this slice. It receives no
+`workspace_memberships` row, is absent from `AccessContext.workspaceGrants`,
+`defaultWorkspaceId`, subject workspace lists, and existing runtime resource
+paths, and does not create user-resource authority or grant rows. The legacy
+Better Auth default workspace remains the sole runtime-access workspace.
+
+Organization-table writes use one target-schema-local
+`ensure_managed_human_personal_workspace(uuid, text, uuid)` SECURITY DEFINER
+capability with a fixed schema-plus-`pg_catalog` search path, PUBLIC execution
+revoked, and explicit `opengeni_app` EXECUTE. Its transaction-local RLS marker,
+exact account/subject binding to the existing managed-human owner membership,
+deterministic workspace identity, control-row validation, and row lock make
+first, repeated, and concurrent provisioning converge. Suspended or revoked
+memberships, foreign accounts, wrong subjects/workspaces, existing runtime
+access on the personal workspace, and malformed subjects fail closed. The app
+role still has zero direct SELECT/INSERT/UPDATE/DELETE privileges on all four
+organization-tenancy tables.
+
 ## Legacy behavior
 
 Existing resources retain their current workspace foreign keys and RLS. Slice
@@ -74,13 +105,12 @@ the access path.
 
 ## Later migration phases
 
-### B. Dual-write
+### B. Dual-write (0219 current)
 
-Introduce lifecycle-only organization membership administration and exact
-server-derived user authority creation. New resource writes may record an
-authority id while continuing to write the existing workspace-owned row. New
-session writes may record owner/visibility, but old writers remain accepted.
-No read path changes yet.
+Managed-human membership and personal-workspace lifecycle metadata now use the
+narrow provisioning seam described above. Resource authority/grant dual-write,
+new-session owner/visibility writes, and all read-path changes remain future
+work; old writers remain accepted.
 
 ### C. Backfill
 
@@ -114,9 +144,11 @@ Only after all writers/readers are activated and audited may legacy
 workspace-owned assumptions be removed. Resource FKs are never destructively
 rewritten in the same release that first activates user authority.
 
-## Non-goals in Slice A
+## Non-goals in Slices A and B
 
 - organization/member API or UI;
+- personal-workspace runtime access or a personal `workspace_memberships` row;
+- user-resource authority/grant writes, discovery, or sharing;
 - resource CRUD or discovery changes;
 - session sharing/fork runtime;
 - turn/task cancellation or authority-epoch claim checks;

--- a/packages/db/drizzle/0219_organization_tenancy_managed_human_provisioning.sql
+++ b/packages/db/drizzle/0219_organization_tenancy_managed_human_provisioning.sql
@@ -1,0 +1,317 @@
+-- deployment-mode: rolling
+-- Activate only the managed-human provisioning seam for organization tenancy.
+-- This migration does not expose organization/member CRUD, resource authority or
+-- grant writes, session sharing, or personal-workspace runtime access.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+-- Keep all four Slice A tables FORCE-RLS and replace the inert deny-all policy
+-- with one transaction-local capability marker. The marker is set only inside
+-- the exact SECURITY DEFINER lifecycle routine below; opengeni_app still has
+-- no direct table privileges on any of these tables.
+DROP POLICY IF EXISTS organization_tenancy_system_only ON "organization_memberships";
+CREATE POLICY organization_tenancy_lifecycle ON "organization_memberships"
+  USING (
+    current_setting('opengeni.organization_tenancy_lifecycle', true)
+      = 'managed_human_provisioning'
+  )
+  WITH CHECK (
+    current_setting('opengeni.organization_tenancy_lifecycle', true)
+      = 'managed_human_provisioning'
+  );
+
+DROP POLICY IF EXISTS organization_tenancy_system_only ON "organization_user_retention_policies";
+CREATE POLICY organization_tenancy_lifecycle ON "organization_user_retention_policies"
+  USING (
+    current_setting('opengeni.organization_tenancy_lifecycle', true)
+      = 'managed_human_provisioning'
+  )
+  WITH CHECK (
+    current_setting('opengeni.organization_tenancy_lifecycle', true)
+      = 'managed_human_provisioning'
+  );
+
+DROP POLICY IF EXISTS organization_tenancy_system_only ON "organization_user_resource_authorities";
+CREATE POLICY organization_tenancy_lifecycle ON "organization_user_resource_authorities"
+  USING (
+    current_setting('opengeni.organization_tenancy_lifecycle', true)
+      = 'managed_human_provisioning'
+  )
+  WITH CHECK (
+    current_setting('opengeni.organization_tenancy_lifecycle', true)
+      = 'managed_human_provisioning'
+  );
+
+DROP POLICY IF EXISTS organization_tenancy_system_only ON "organization_user_resource_grants";
+CREATE POLICY organization_tenancy_lifecycle ON "organization_user_resource_grants"
+  USING (
+    current_setting('opengeni.organization_tenancy_lifecycle', true)
+      = 'managed_human_provisioning'
+  )
+  WITH CHECK (
+    current_setting('opengeni.organization_tenancy_lifecycle', true)
+      = 'managed_human_provisioning'
+  );
+
+DO $organization_tenancy_managed_human_provisioning$
+DECLARE
+  data_schema text := current_schema();
+BEGIN
+  EXECUTE format($ddl$
+    CREATE OR REPLACE FUNCTION %1$I.ensure_managed_human_personal_workspace(
+      p_account_id uuid,
+      p_subject_id text,
+      p_personal_workspace_id uuid
+    )
+    RETURNS TABLE (
+      organization_membership_id uuid,
+      personal_workspace_id uuid
+    )
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = %1$I, pg_catalog
+    AS $body$
+    DECLARE
+      expected_external_id text;
+      membership_row organization_memberships%%ROWTYPE;
+      workspace_row workspaces%%ROWTYPE;
+      previous_workspace_id text := pg_catalog.current_setting(
+        'opengeni.workspace_id',
+        true
+      );
+      previous_lifecycle_marker text := pg_catalog.current_setting(
+        'opengeni.organization_tenancy_lifecycle',
+        true
+      );
+    BEGIN
+      IF p_account_id IS NULL
+        OR p_subject_id IS NULL
+        OR p_personal_workspace_id IS NULL
+      THEN
+        RAISE EXCEPTION 'managed-human provisioning requires complete identity'
+          USING ERRCODE = '42501';
+      END IF;
+
+      IF p_subject_id <> pg_catalog.btrim(p_subject_id)
+        OR pg_catalog.length(p_subject_id) NOT BETWEEN 1 AND 1024
+        OR p_subject_id NOT LIKE 'user:%%'
+      THEN
+        RAISE EXCEPTION 'managed-human provisioning subject is invalid'
+          USING ERRCODE = '42501';
+      END IF;
+
+      expected_external_id := pg_catalog.substr(p_subject_id, 6);
+      IF expected_external_id IS NULL OR pg_catalog.length(expected_external_id) < 1 THEN
+        RAISE EXCEPTION 'managed-human provisioning subject is invalid'
+          USING ERRCODE = '42501';
+      END IF;
+
+      IF p_account_id IS DISTINCT FROM opengeni_private.current_account_id() THEN
+        RAISE EXCEPTION 'managed-human provisioning account authority is invalid'
+          USING ERRCODE = '42501';
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1
+        FROM managed_accounts account_row
+        WHERE account_row.id = p_account_id
+          AND account_row.external_source = 'better-auth:user'
+          AND account_row.external_id = expected_external_id
+      ) THEN
+        RAISE EXCEPTION 'managed-human provisioning account identity is invalid'
+          USING ERRCODE = '42501';
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1
+        FROM workspace_memberships owner_membership
+        INNER JOIN workspaces owner_workspace
+          ON owner_workspace.id = owner_membership.workspace_id
+         AND owner_workspace.account_id = owner_membership.account_id
+        WHERE owner_membership.account_id = p_account_id
+          AND owner_membership.subject_id = p_subject_id
+          AND owner_membership.role = 'owner'
+      ) THEN
+        RAISE EXCEPTION 'managed-human provisioning owner membership is invalid'
+          USING ERRCODE = '42501';
+      END IF;
+
+      SELECT *
+      INTO workspace_row
+      FROM workspaces candidate_workspace
+      WHERE candidate_workspace.id = p_personal_workspace_id
+      FOR UPDATE;
+      IF NOT FOUND
+        OR workspace_row.account_id IS DISTINCT FROM p_account_id
+        OR workspace_row.external_source IS DISTINCT FROM 'opengeni:organization-membership'
+        OR workspace_row.external_id IS DISTINCT FROM (
+          p_account_id::text || ':' || p_subject_id
+        )
+      THEN
+        RAISE EXCEPTION 'managed-human provisioning personal workspace identity is invalid'
+          USING ERRCODE = '42501';
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM workspaces conflicting_workspace
+        WHERE conflicting_workspace.external_source = 'opengeni:organization-membership'
+          AND conflicting_workspace.external_id = (
+            p_account_id::text || ':' || p_subject_id
+          )
+          AND conflicting_workspace.id <> p_personal_workspace_id
+      ) THEN
+        RAISE EXCEPTION 'managed-human provisioning personal workspace identity conflicts'
+          USING ERRCODE = '23505';
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM workspace_memberships personal_access
+        WHERE personal_access.workspace_id = p_personal_workspace_id
+      ) THEN
+        RAISE EXCEPTION 'managed-human personal workspace already has runtime access'
+          USING ERRCODE = '42501';
+      END IF;
+
+      -- workspace_inference_controls is FORCE-RLS and needs the exact workspace
+      -- context for this structural validation. Restore the caller context on
+      -- both success and error before returning from this capability.
+      PERFORM pg_catalog.set_config(
+        'opengeni.workspace_id',
+        p_personal_workspace_id::text,
+        true
+      );
+      IF NOT EXISTS (
+        SELECT 1
+        FROM workspace_inference_controls control_row
+        WHERE control_row.workspace_id = p_personal_workspace_id
+          AND control_row.account_id = p_account_id
+      ) THEN
+        RAISE EXCEPTION 'managed-human personal workspace control is missing'
+          USING ERRCODE = '42501';
+      END IF;
+
+      PERFORM pg_catalog.set_config(
+        'opengeni.organization_tenancy_lifecycle',
+        'managed_human_provisioning',
+        true
+      );
+
+      INSERT INTO organization_memberships (
+        account_id,
+        subject_id,
+        status,
+        personal_workspace_id
+      ) VALUES (
+        p_account_id,
+        p_subject_id,
+        'active',
+        p_personal_workspace_id
+      )
+      ON CONFLICT (account_id, subject_id) DO NOTHING;
+
+      SELECT *
+      INTO membership_row
+      FROM organization_memberships candidate_membership
+      WHERE candidate_membership.account_id = p_account_id
+        AND candidate_membership.subject_id = p_subject_id
+      FOR UPDATE;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'managed-human organization membership was not created'
+          USING ERRCODE = 'P0002';
+      END IF;
+
+      IF membership_row.status IN ('suspended', 'revoked') THEN
+        RAISE EXCEPTION 'managed-human organization membership is not active'
+          USING ERRCODE = '42501';
+      END IF;
+      IF membership_row.status = 'active'
+        AND membership_row.personal_workspace_id IS DISTINCT FROM p_personal_workspace_id
+      THEN
+        RAISE EXCEPTION 'managed-human organization membership personal workspace conflicts'
+          USING ERRCODE = '23505';
+      END IF;
+      IF membership_row.status = 'provisioning'
+        AND membership_row.personal_workspace_id IS NOT NULL
+        AND membership_row.personal_workspace_id IS DISTINCT FROM p_personal_workspace_id
+      THEN
+        RAISE EXCEPTION 'managed-human organization membership personal workspace conflicts'
+          USING ERRCODE = '23505';
+      END IF;
+
+      IF membership_row.status = 'provisioning' THEN
+        UPDATE organization_memberships
+        SET status = 'active',
+            personal_workspace_id = p_personal_workspace_id,
+            updated_at = pg_catalog.clock_timestamp()
+        WHERE id = membership_row.id;
+        membership_row.status := 'active';
+        membership_row.personal_workspace_id := p_personal_workspace_id;
+      END IF;
+
+      IF membership_row.status <> 'active'
+        OR membership_row.personal_workspace_id IS DISTINCT FROM p_personal_workspace_id
+      THEN
+        RAISE EXCEPTION 'managed-human organization membership did not converge'
+          USING ERRCODE = '42501';
+      END IF;
+
+      PERFORM pg_catalog.set_config(
+        'opengeni.workspace_id',
+        CASE
+          WHEN previous_workspace_id IS NULL THEN ''
+          ELSE previous_workspace_id
+        END,
+        true
+      );
+      PERFORM pg_catalog.set_config(
+        'opengeni.organization_tenancy_lifecycle',
+        CASE
+          WHEN previous_lifecycle_marker IS NULL THEN ''
+          ELSE previous_lifecycle_marker
+        END,
+        true
+      );
+
+      organization_membership_id := membership_row.id;
+      personal_workspace_id := membership_row.personal_workspace_id;
+      RETURN NEXT;
+    EXCEPTION WHEN OTHERS THEN
+      PERFORM pg_catalog.set_config(
+        'opengeni.workspace_id',
+        CASE
+          WHEN previous_workspace_id IS NULL THEN ''
+          ELSE previous_workspace_id
+        END,
+        true
+      );
+      PERFORM pg_catalog.set_config(
+        'opengeni.organization_tenancy_lifecycle',
+        CASE
+          WHEN previous_lifecycle_marker IS NULL THEN ''
+          ELSE previous_lifecycle_marker
+        END,
+        true
+      );
+      RAISE;
+    END;
+    $body$;
+  $ddl$, data_schema);
+
+  EXECUTE format(
+    'REVOKE ALL ON FUNCTION %I.ensure_managed_human_personal_workspace(uuid,text,uuid) FROM PUBLIC',
+    data_schema
+  );
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    EXECUTE format(
+      'GRANT EXECUTE ON FUNCTION %I.ensure_managed_human_personal_workspace(uuid,text,uuid) TO opengeni_app',
+      data_schema
+    );
+  END IF;
+END
+$organization_tenancy_managed_human_provisioning$;
+
+COMMENT ON FUNCTION ensure_managed_human_personal_workspace(uuid, text, uuid) IS
+  'Lifecycle-only managed-human organization membership and personal-workspace provisioning; no workspace access grant.';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1452,6 +1452,95 @@ export async function ensureManagedAccessForUser(
         })
         .where(eq(schema.workspaceMemberships.id, membership.id));
     }
+
+    const personalWorkspaceExternalSource = "opengeni:organization-membership";
+    const personalWorkspaceExternalId = `${account.id}:${subjectId}`;
+    let [personalWorkspace] = await tx
+      .select()
+      .from(schema.workspaces)
+      .where(
+        and(
+          eq(schema.workspaces.externalSource, personalWorkspaceExternalSource),
+          eq(schema.workspaces.externalId, personalWorkspaceExternalId),
+        ),
+      )
+      .limit(1);
+    if (!personalWorkspace) {
+      [personalWorkspace] = await tx
+        .insert(schema.workspaces)
+        .values({
+          accountId: account.id,
+          name: "Personal workspace",
+          slug: null,
+          externalSource: personalWorkspaceExternalSource,
+          externalId: personalWorkspaceExternalId,
+        })
+        .onConflictDoUpdate({
+          target: [schema.workspaces.externalSource, schema.workspaces.externalId],
+          set: { updatedAt: new Date() },
+        })
+        .returning();
+    }
+    if (!personalWorkspace) {
+      throw new Error("Failed to ensure personal workspace");
+    }
+    if (
+      personalWorkspace.accountId !== account.id ||
+      personalWorkspace.externalSource !== personalWorkspaceExternalSource ||
+      personalWorkspace.externalId !== personalWorkspaceExternalId
+    ) {
+      throw new Error("Managed personal workspace identity conflict");
+    }
+
+    await setRlsContext(tx as unknown as Database, {
+      accountId: account.id,
+      workspaceId: personalWorkspace.id,
+    });
+    const [personalWorkspaceControl] = await tx
+      .select({ workspaceId: schema.workspaceInferenceControls.workspaceId })
+      .from(schema.workspaceInferenceControls)
+      .where(eq(schema.workspaceInferenceControls.workspaceId, personalWorkspace.id))
+      .limit(1);
+    if (!personalWorkspaceControl) {
+      await tx
+        .insert(schema.workspaceInferenceControls)
+        .values({
+          workspaceId: personalWorkspace.id,
+          accountId: account.id,
+        })
+        .onConflictDoNothing();
+    }
+    await setRlsContext(tx as unknown as Database, {
+      accountId: account.id,
+      workspaceId: null,
+    });
+
+    const [provisionedMembership] = await rawRows<{
+      organization_membership_id: string;
+      personal_workspace_id: string;
+    }>(
+      tx,
+      sql`
+        select * from ensure_managed_human_personal_workspace(
+          ${account.id},
+          ${subjectId},
+          ${personalWorkspace.id}
+        )
+      `,
+    );
+    if (
+      !provisionedMembership ||
+      provisionedMembership.personal_workspace_id !== personalWorkspace.id
+    ) {
+      throw new Error("Managed organization membership provisioning did not converge");
+    }
+
+    // The personal workspace is lifecycle metadata only in Slice B. Keep the
+    // existing default-workspace access projection and all legacy lists intact.
+    await setRlsContext(tx as unknown as Database, {
+      accountId: account.id,
+      workspaceId: null,
+    });
     const memberships = await tx
       .select({
         membership: schema.workspaceMemberships,

--- a/packages/db/src/provision-roles.ts
+++ b/packages/db/src/provision-roles.ts
@@ -725,6 +725,22 @@ BEGIN
     END IF;
     IF to_regprocedure(
       format(
+        '%I.ensure_managed_human_personal_workspace(uuid,text,uuid)',
+        ${literal(schema)}
+      )
+    ) IS NOT NULL THEN
+      EXECUTE format(
+        'REVOKE ALL ON FUNCTION %I.ensure_managed_human_personal_workspace(uuid, text, uuid) FROM PUBLIC',
+        ${literal(schema)}
+      );
+      EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION %I.ensure_managed_human_personal_workspace(uuid, text, uuid) TO %I',
+        ${literal(schema)},
+        ${literal(role)}
+      );
+    END IF;
+    IF to_regprocedure(
+      format(
         '%I.scoped_knowledge_advance_source_acl(uuid,uuid,bigint,bigint,uuid,text,text,text,text,text,text)',
         ${literal(schema)}
       )

--- a/packages/db/src/runtime-posture.ts
+++ b/packages/db/src/runtime-posture.ts
@@ -48,9 +48,18 @@ const KNOWLEDGE_SOURCE_SYNC_LOCK_AUTHORITY_TABLES = [
   "knowledge_sources",
   "knowledge_source_objects",
 ] as const;
+const MANAGED_HUMAN_PERSONAL_WORKSPACE_ROUTINE =
+  "ensure_managed_human_personal_workspace(uuid, text, uuid)";
+const MANAGED_HUMAN_PERSONAL_WORKSPACE_AUTHORITY_TABLES = [
+  "organization_memberships",
+  "organization_user_retention_policies",
+  "organization_user_resource_authorities",
+  "organization_user_resource_grants",
+] as const;
 
 export const RUNTIME_TARGET_SCHEMA_CAPABILITY_ROUTINES = [
   KNOWLEDGE_SOURCE_SYNC_LOCK_AUTHORITY_ROUTINE,
+  MANAGED_HUMAN_PERSONAL_WORKSPACE_ROUTINE,
 ] as const;
 
 /**
@@ -898,14 +907,16 @@ export async function inspectRuntimeDatabasePosture(
             p.prosecdef as security_definer
           from pg_proc p
           join pg_namespace n on n.oid = p.pronamespace
-          where p.oid = to_regprocedure(
-            format(
-              '%I.knowledge_source_sync_lock_authority(uuid,uuid,uuid)',
-              ${targetSchema}::text
-            )
-          )
-            and n.nspname = ${targetSchema}
+          where n.nspname = ${targetSchema}
             and p.prokind in ('f', 'p')
+            and (p.proname || '(' || pg_catalog.oidvectortypes(p.proargtypes) || ')') = any(
+              array[
+                ${sql.join(
+                  RUNTIME_TARGET_SCHEMA_CAPABILITY_ROUTINES.map((name) => sql`${name}`),
+                  sql`, `,
+                )}
+              ]::text[]
+            )
           order by p.proname, pg_catalog.oidvectortypes(p.proargtypes)
         `),
       ).map((row) => ({
@@ -1153,6 +1164,20 @@ export function evaluateRuntimeDatabasePosture(
             `target-schema runtime capability ${routine.name} owner ${routine.owner} does not match authority table owner ${authorityTables[0]!.owner}`,
           );
         }
+      }
+    } else if (routine.name === MANAGED_HUMAN_PERSONAL_WORKSPACE_ROUTINE) {
+      const authorityTables = MANAGED_HUMAN_PERSONAL_WORKSPACE_AUTHORITY_TABLES.filter(
+        (tableName) => tableByName.has(tableName),
+      ).map((tableName) => tableByName.get(tableName)!);
+      const authorityOwners = new Set(authorityTables.map((table) => table.owner));
+      if (authorityOwners.size > 1) {
+        violations.push(
+          `target-schema runtime capability ${routine.name} authority table owners do not match: ${authorityTables.map((table) => `${table.name}=${table.owner}`).join(", ")}`,
+        );
+      } else if (authorityTables[0] && routine.owner !== authorityTables[0].owner) {
+        violations.push(
+          `target-schema runtime capability ${routine.name} owner ${routine.owner} does not match authority table owner ${authorityTables[0].owner}`,
+        );
       }
     } else if (targetSchemaOwner && routine.owner !== targetSchemaOwner) {
       violations.push(

--- a/packages/db/test/migration-0218-organization-tenancy-foundation.test.ts
+++ b/packages/db/test/migration-0218-organization-tenancy-foundation.test.ts
@@ -26,7 +26,13 @@ const tenancyTables = [
   "organization_user_resource_authorities",
   "organization_user_resource_grants",
 ] as const;
-const tenancySystemOnlyPolicy = "organization_tenancy_system_only";
+// Migration 0218's historical contract is intentionally deny-all. The shared
+// native fixture is cloned from the full current ledger, so its live catalog
+// reflects migration 0219's managed-human lifecycle activation instead.
+const historicalTenancySystemOnlyPolicy = "organization_tenancy_system_only";
+const currentLedgerTenancyLifecyclePolicy = "organization_tenancy_lifecycle";
+const currentLedgerTenancyLifecycleExpression =
+  "(current_setting('opengeni.organization_tenancy_lifecycle'::text, true) = 'managed_human_provisioning'::text)";
 
 let shared: SharedTestDatabase | null = null;
 let client: DbClient | null = null;
@@ -107,7 +113,7 @@ describe("migration 0218 organization tenancy foundation", () => {
       expect(migration).toContain(`CREATE TABLE "${table}"`);
       expect(migration).toContain(`ALTER TABLE "${table}" FORCE ROW LEVEL SECURITY`);
       expect(migration).toContain(
-        `CREATE POLICY ${tenancySystemOnlyPolicy} ON "${table}"\n  USING (false) WITH CHECK (false);`,
+        `CREATE POLICY ${historicalTenancySystemOnlyPolicy} ON "${table}"\n  USING (false) WITH CHECK (false);`,
       );
       expect(FORCE_RLS_TABLES).toContain(table);
       expect(PROTECTED_NO_DIRECT_DML_TABLES).toContain(table);
@@ -119,9 +125,9 @@ describe("migration 0218 organization tenancy foundation", () => {
     expect(migration).toContain(
       `ADD COLUMN IF NOT EXISTS "authority_epoch" integer NOT NULL DEFAULT 1`,
     );
-    expect(migration.match(/CREATE POLICY organization_tenancy_system_only ON /gu)).toHaveLength(
-      tenancyTables.length,
-    );
+    expect(
+      migration.match(new RegExp(`CREATE POLICY ${historicalTenancySystemOnlyPolicy} ON `, "gu")),
+    ).toHaveLength(tenancyTables.length);
     expect(migration).toMatch(
       /"mode" = 'delete_after'\s+AND "retention_days" IS NOT NULL\s+AND "retention_days" BETWEEN 1 AND 3650/u,
     );
@@ -480,16 +486,20 @@ describe("migration 0218 organization tenancy foundation", () => {
       group by c.relname, c.relrowsecurity, c.relforcerowsecurity, c.oid
       order by c.relname
     `;
+    // This shared database contains the complete current migration ledger, not
+    // an isolated replay stopped at 0218. Therefore the live catalog must
+    // assert 0219's lifecycle policy while the static checks above preserve
+    // 0218's historical deny-all contract.
     expect([...policyRows]).toEqual(
       [...tenancyTables].sort().map((tableName) => ({
         tableName,
         rlsEnabled: true,
         rlsForced: true,
         policyCount: 1,
-        policyNames: [tenancySystemOnlyPolicy],
+        policyNames: [currentLedgerTenancyLifecyclePolicy],
         policyCommands: ["*"],
-        usingExpressions: ["false"],
-        checkExpressions: ["false"],
+        usingExpressions: [currentLedgerTenancyLifecycleExpression],
+        checkExpressions: [currentLedgerTenancyLifecycleExpression],
         appSelect: false,
         appInsert: false,
         appUpdate: false,

--- a/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
+++ b/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
@@ -1,0 +1,472 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { sql } from "drizzle-orm";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import postgres from "postgres";
+import {
+  createDb,
+  ensureManagedAccessForUser,
+  listWorkspacesForSubject,
+  nestedPostgresSqlState,
+  setRlsContext,
+  type DbClient,
+} from "../src";
+import { rawRows, type Database } from "../src/database";
+
+const migrationPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../drizzle/0219_organization_tenancy_managed_human_provisioning.sql",
+);
+const posturePath = join(dirname(fileURLToPath(import.meta.url)), "../src/runtime-posture.ts");
+const provisionerPath = join(dirname(fileURLToPath(import.meta.url)), "../src/provision-roles.ts");
+const tenancyTables = [
+  "organization_memberships",
+  "organization_user_retention_policies",
+  "organization_user_resource_authorities",
+  "organization_user_resource_grants",
+] as const;
+
+let shared: SharedTestDatabase | null = null;
+let client: DbClient | null = null;
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+const externalAdminUrl = process.env.OPENGENI_ORG_TENANCY_POSTGRES_ADMIN_URL;
+const externalAppUrl = process.env.OPENGENI_ORG_TENANCY_POSTGRES_APP_URL;
+
+beforeAll(async () => {
+  if ((externalAdminUrl === undefined) !== (externalAppUrl === undefined)) {
+    throw new Error(
+      "set both OPENGENI_ORG_TENANCY_POSTGRES_ADMIN_URL and OPENGENI_ORG_TENANCY_POSTGRES_APP_URL",
+    );
+  }
+  if (externalAdminUrl && externalAppUrl) {
+    const admin = postgres(externalAdminUrl, { max: 8 });
+    shared = {
+      admin,
+      adminUrl: externalAdminUrl,
+      appUrl: externalAppUrl,
+      release: async () => await admin.end(),
+    };
+  } else {
+    shared = await acquireSharedTestDatabase("migration-0219-organization-tenancy");
+  }
+  if (!shared && requireRealDatabase) {
+    throw new Error(
+      "[migration-0219-organization-tenancy] OPENGENI_REQUIRE_REAL_DB=1 but PostgreSQL is unavailable",
+    );
+  }
+  if (shared) client = createDb(shared.appUrl, { max: 8 });
+}, 180_000);
+
+afterAll(async () => {
+  await client?.close().catch(() => undefined);
+  await shared?.release();
+}, 180_000);
+
+async function expectSqlState(action: () => Promise<unknown>, state: string): Promise<void> {
+  let failure: unknown;
+  try {
+    await action();
+  } catch (error) {
+    failure = error;
+  }
+  expect(nestedPostgresSqlState(failure)).toBe(state);
+}
+
+async function callLifecycle(
+  accountId: string,
+  subjectId: string,
+  personalWorkspaceId: string,
+): Promise<unknown> {
+  if (!client) throw new Error("test database unavailable");
+  return await client.db.transaction(async (tx) => {
+    await setRlsContext(tx as unknown as Database, { accountId, workspaceId: null });
+    return await rawRows(
+      tx,
+      sql`
+        select * from ensure_managed_human_personal_workspace(
+          ${accountId},
+          ${subjectId},
+          ${personalWorkspaceId}
+        )
+      `,
+    );
+  });
+}
+
+describe("migration 0219 managed-human organization provisioning", () => {
+  test("pins the rolling lifecycle capability, posture contract, and exact role grant", async () => {
+    const [migration, posture, provisioner] = await Promise.all([
+      readFile(migrationPath, "utf8"),
+      readFile(posturePath, "utf8"),
+      readFile(provisionerPath, "utf8"),
+    ]);
+
+    expect(migration.split(/\r?\n/u, 1)[0]).toBe("-- deployment-mode: rolling");
+    for (const table of tenancyTables) {
+      expect(migration).toContain(`CREATE POLICY organization_tenancy_lifecycle ON "${table}"`);
+      expect(migration).toContain(
+        `current_setting('opengeni.organization_tenancy_lifecycle', true)`,
+      );
+    }
+    expect(migration).toContain(
+      "CREATE OR REPLACE FUNCTION %1$I.ensure_managed_human_personal_workspace(",
+    );
+    expect(migration).toContain("SECURITY DEFINER");
+    expect(migration).toContain("SET search_path = %1$I, pg_catalog");
+    expect(migration).toContain(
+      "REVOKE ALL ON FUNCTION %I.ensure_managed_human_personal_workspace(uuid,text,uuid) FROM PUBLIC",
+    );
+    expect(migration).toContain(
+      "GRANT EXECUTE ON FUNCTION %I.ensure_managed_human_personal_workspace",
+    );
+    expect(migration).toContain("status IN ('suspended', 'revoked')");
+    expect(migration).toContain("managed-human personal workspace already has runtime access");
+    expect(posture).toContain('"ensure_managed_human_personal_workspace(uuid, text, uuid)"');
+    expect(posture).toContain("RUNTIME_TARGET_SCHEMA_CAPABILITY_ROUTINES");
+    expect(provisioner).toContain("ensure_managed_human_personal_workspace(uuid,text,uuid)");
+    expect(provisioner).toContain(
+      "REVOKE ALL ON FUNCTION %I.ensure_managed_human_personal_workspace(uuid, text, uuid) FROM PUBLIC",
+    );
+  });
+
+  test("converges one membership and one private-by-lifecycle workspace without legacy access changes", async () => {
+    if (!shared || !client) return;
+
+    const userId = `slice-b-${crypto.randomUUID()}`;
+    const subjectId = `user:${userId}`;
+    const input = {
+      userId,
+      email: `${userId}@example.test`,
+      name: "Slice B managed human",
+    };
+    const first = await ensureManagedAccessForUser(client.db, input);
+    const repeated = await ensureManagedAccessForUser(client.db, input);
+    const concurrent = await Promise.all(
+      Array.from({ length: 6 }, () => ensureManagedAccessForUser(client!.db, input)),
+    );
+
+    expect(repeated).toEqual(first);
+    expect(concurrent).toEqual(Array.from({ length: 6 }, () => first));
+    expect(first.workspaceGrants).toHaveLength(1);
+    expect((await listWorkspacesForSubject(client.db, subjectId)).map((row) => row.id)).toEqual([
+      first.defaultWorkspaceId!,
+    ]);
+
+    const [account] = await shared.admin<{ id: string }[]>`
+      select id
+      from managed_accounts
+      where external_source = 'better-auth:user'
+        and external_id = ${userId}
+    `;
+    const [defaultWorkspace] = await shared.admin<{ id: string }[]>`
+      select id
+      from workspaces
+      where external_source = 'better-auth:user'
+        and external_id = ${`${userId}:default`}
+    `;
+    const [personalWorkspace] = await shared.admin<
+      {
+        id: string;
+        accountId: string;
+        name: string;
+        externalSource: string;
+        externalId: string;
+      }[]
+    >`
+      select
+        id,
+        account_id as "accountId",
+        name,
+        external_source as "externalSource",
+        external_id as "externalId"
+      from workspaces
+      where external_source = 'opengeni:organization-membership'
+        and external_id = ${`${account!.id}:${subjectId}`}
+    `;
+    const [membership] = await shared.admin<
+      {
+        id: string;
+        accountId: string;
+        subjectId: string;
+        status: string;
+        personalWorkspaceId: string;
+      }[]
+    >`
+      select
+        id,
+        account_id as "accountId",
+        subject_id as "subjectId",
+        status,
+        personal_workspace_id as "personalWorkspaceId"
+      from organization_memberships
+      where account_id = ${account!.id}
+        and subject_id = ${subjectId}
+    `;
+    const [control] = await shared.admin<{ accountId: string }[]>`
+      select account_id as "accountId"
+      from workspace_inference_controls
+      where workspace_id = ${personalWorkspace!.id}
+    `;
+    const [personalAccess] = await shared.admin<{ count: number }[]>`
+      select count(*)::int as count
+      from workspace_memberships
+      where workspace_id = ${personalWorkspace!.id}
+    `;
+    const [defaultAccess] = await shared.admin<{ count: number }[]>`
+      select count(*)::int as count
+      from workspace_memberships
+      where workspace_id = ${defaultWorkspace!.id}
+        and subject_id = ${subjectId}
+    `;
+    const [authorityCount] = await shared.admin<{ count: number }[]>`
+      select count(*)::int as count
+      from organization_user_resource_authorities
+      where account_id = ${account!.id}
+    `;
+    const [grantCount] = await shared.admin<{ count: number }[]>`
+      select count(*)::int as count
+      from organization_user_resource_grants
+      where account_id = ${account!.id}
+    `;
+
+    expect(account?.id).toBe(first.accountGrants[0]?.accountId);
+    expect(defaultWorkspace?.id).toBe(first.defaultWorkspaceId!);
+    expect(personalWorkspace).toEqual({
+      id: membership!.personalWorkspaceId,
+      accountId: account!.id,
+      name: "Personal workspace",
+      externalSource: "opengeni:organization-membership",
+      externalId: `${account!.id}:${subjectId}`,
+    });
+    expect(first.workspaceGrants.map(({ workspaceId }) => workspaceId)).not.toContain(
+      personalWorkspace!.id,
+    );
+    expect(membership).toMatchObject({
+      accountId: account!.id,
+      subjectId,
+      status: "active",
+      personalWorkspaceId: personalWorkspace!.id,
+    });
+    expect(control).toEqual({ accountId: account!.id });
+    expect(personalAccess).toEqual({ count: 0 });
+    expect(defaultAccess).toEqual({ count: 1 });
+    expect(authorityCount).toEqual({ count: 0 });
+    expect(grantCount).toEqual({ count: 0 });
+  });
+
+  test("keeps the capability narrow and fails closed for fabricated, foreign, and terminal authority", async () => {
+    if (!shared || !client) return;
+
+    const firstUserId = `slice-b-adversarial-${crypto.randomUUID()}`;
+    const firstSubjectId = `user:${firstUserId}`;
+    const firstAccess = await ensureManagedAccessForUser(client.db, {
+      userId: firstUserId,
+      email: `${firstUserId}@example.test`,
+      name: "Adversarial managed human",
+    });
+    const firstAccountId = firstAccess.accountGrants[0]!.accountId;
+    const firstPersonalWorkspaceId = (
+      await shared.admin<{ id: string }[]>`
+        select id
+        from workspaces
+        where account_id = ${firstAccountId}
+          and external_source = 'opengeni:organization-membership'
+          and external_id = ${`${firstAccountId}:${firstSubjectId}`}
+      `
+    )[0]!.id;
+
+    await expectSqlState(
+      () => callLifecycle(firstAccountId, `user:${crypto.randomUUID()}`, firstPersonalWorkspaceId),
+      "42501",
+    );
+    await expectSqlState(
+      () => callLifecycle(firstAccountId, "", firstPersonalWorkspaceId),
+      "42501",
+    );
+    await expectSqlState(
+      () => callLifecycle(firstAccountId, `user:${"x".repeat(1024)}`, firstPersonalWorkspaceId),
+      "42501",
+    );
+    await expectSqlState(
+      () => callLifecycle(firstAccountId, firstSubjectId, firstAccess.defaultWorkspaceId!),
+      "42501",
+    );
+    await expectSqlState(
+      () => callLifecycle(crypto.randomUUID(), firstSubjectId, firstPersonalWorkspaceId),
+      "42501",
+    );
+
+    const secondUserId = `slice-b-foreign-${crypto.randomUUID()}`;
+    const secondAccess = await ensureManagedAccessForUser(client.db, {
+      userId: secondUserId,
+      email: `${secondUserId}@example.test`,
+      name: "Foreign managed human",
+    });
+    const secondAccountId = secondAccess.accountGrants[0]!.accountId;
+    const secondPersonalWorkspaceId = (
+      await shared.admin<{ id: string }[]>`
+        select id
+        from workspaces
+        where account_id = ${secondAccountId}
+          and external_source = 'opengeni:organization-membership'
+          and external_id = ${`${secondAccountId}:user:${secondUserId}`}
+      `
+    )[0]!.id;
+    await expectSqlState(
+      () => callLifecycle(firstAccountId, firstSubjectId, secondPersonalWorkspaceId),
+      "42501",
+    );
+
+    await shared.admin`
+      update organization_memberships
+      set status = 'suspended', revoked_at = null
+      where account_id = ${firstAccountId}
+        and subject_id = ${firstSubjectId}
+    `;
+    await expectSqlState(
+      () =>
+        ensureManagedAccessForUser(client!.db, {
+          userId: firstUserId,
+          email: `${firstUserId}@example.test`,
+          name: "Adversarial managed human",
+        }),
+      "42501",
+    );
+
+    await shared.admin`
+      update organization_memberships
+      set status = 'revoked', revoked_at = now()
+      where account_id = ${firstAccountId}
+        and subject_id = ${firstSubjectId}
+    `;
+    await expectSqlState(
+      () =>
+        ensureManagedAccessForUser(client!.db, {
+          userId: firstUserId,
+          email: `${firstUserId}@example.test`,
+          name: "Adversarial managed human",
+        }),
+      "42501",
+    );
+
+    await shared.admin`
+      update organization_memberships
+      set status = 'active', revoked_at = null
+      where account_id = ${firstAccountId}
+        and subject_id = ${firstSubjectId}
+    `;
+    const [fabricatedAccess] = await shared.admin<{ id: string }[]>`
+      insert into workspace_memberships (
+        account_id, workspace_id, subject_id, role, permissions
+      ) values (
+        ${firstAccountId}, ${firstPersonalWorkspaceId}, 'user:fabricated', 'owner', '[]'::jsonb
+      ) returning id
+    `;
+    await expectSqlState(
+      () => callLifecycle(firstAccountId, firstSubjectId, firstPersonalWorkspaceId),
+      "42501",
+    );
+    await shared.admin`delete from workspace_memberships where id = ${fabricatedAccess!.id}`;
+
+    const app = postgres(shared.appUrl, { max: 2 });
+    try {
+      for (const table of tenancyTables) {
+        await expectSqlState(
+          async () => await app.unsafe(`select * from "${table}" limit 1`),
+          "42501",
+        );
+        await expectSqlState(
+          async () => await app.unsafe(`insert into "${table}" default values`),
+          "42501",
+        );
+        await expectSqlState(
+          async () => await app.unsafe(`update "${table}" set updated_at = updated_at`),
+          "42501",
+        );
+        await expectSqlState(async () => await app.unsafe(`delete from "${table}"`), "42501");
+      }
+    } finally {
+      await app.end();
+    }
+  });
+
+  test("records one lifecycle policy and exact routine ACL in native PostgreSQL", async () => {
+    if (!shared) return;
+
+    const [functionRow] = await shared.admin<
+      {
+        owner: string;
+        securityDefiner: boolean;
+        appExecute: boolean;
+        publicExecute: boolean;
+        functionDef: string;
+      }[]
+    >`
+      select
+        pg_get_userbyid(p.proowner)::text as owner,
+        p.prosecdef as "securityDefiner",
+        has_function_privilege('opengeni_app', p.oid, 'EXECUTE') as "appExecute",
+        exists (
+          select 1
+          from aclexplode(coalesce(p.proacl, acldefault('f', p.proowner))) acl
+          where acl.grantee = 0 and acl.privilege_type = 'EXECUTE'
+        ) as "publicExecute",
+        pg_get_functiondef(p.oid)::text as "functionDef"
+      from pg_proc p
+      join pg_namespace n on n.oid = p.pronamespace
+      where n.nspname = current_schema()
+        and p.oid = to_regprocedure(
+          format('%I.ensure_managed_human_personal_workspace(uuid,text,uuid)', current_schema())
+        )
+    `;
+    expect(functionRow).toMatchObject({
+      securityDefiner: true,
+      appExecute: true,
+      publicExecute: false,
+    });
+    expect(functionRow?.functionDef).toContain("SET search_path");
+
+    const policyRows = await shared.admin<
+      {
+        tableName: string;
+        policyName: string;
+        usingExpression: string;
+        checkExpression: string;
+        appSelect: boolean;
+        appInsert: boolean;
+        appUpdate: boolean;
+        appDelete: boolean;
+      }[]
+    >`
+      select
+        c.relname as "tableName",
+        p.polname as "policyName",
+        pg_get_expr(p.polqual, p.polrelid) as "usingExpression",
+        pg_get_expr(p.polwithcheck, p.polrelid) as "checkExpression",
+        has_table_privilege('opengeni_app', c.oid, 'SELECT') as "appSelect",
+        has_table_privilege('opengeni_app', c.oid, 'INSERT') as "appInsert",
+        has_table_privilege('opengeni_app', c.oid, 'UPDATE') as "appUpdate",
+        has_table_privilege('opengeni_app', c.oid, 'DELETE') as "appDelete"
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      join pg_policy p on p.polrelid = c.oid
+      where n.nspname = current_schema()
+        and c.relname = any(${shared.admin.array([...tenancyTables])})
+      order by c.relname
+    `;
+    expect(policyRows).toHaveLength(tenancyTables.length);
+    for (const row of policyRows) {
+      expect(row.policyName).toBe("organization_tenancy_lifecycle");
+      expect(row.usingExpression).toContain("opengeni.organization_tenancy_lifecycle");
+      expect(row.checkExpression).toContain("opengeni.organization_tenancy_lifecycle");
+      expect(row).toMatchObject({
+        appSelect: false,
+        appInsert: false,
+        appUpdate: false,
+        appDelete: false,
+      });
+    }
+  });
+});

--- a/packages/db/test/rls-dedicated-schema-isolation.test.ts
+++ b/packages/db/test/rls-dedicated-schema-isolation.test.ts
@@ -297,6 +297,13 @@ describe("migration replay — RLS isolation under a DEDICATED schema + NON-OWNE
     expect(posture.ownedRelations).toEqual([]);
     expect(posture.targetRoutines).toEqual([
       {
+        name: "ensure_managed_human_personal_workspace(uuid, text, uuid)",
+        owner: "postgres",
+        execute: true,
+        publicExecute: false,
+        securityDefiner: true,
+      },
+      {
         name: "knowledge_source_sync_lock_authority(uuid, uuid, uuid)",
         owner: "postgres",
         execute: true,

--- a/packages/db/test/runtime-posture.test.ts
+++ b/packages/db/test/runtime-posture.test.ts
@@ -109,6 +109,13 @@ function safePosture(): RuntimeDatabasePosture {
         publicExecute: false,
         securityDefiner: true,
       },
+      {
+        name: "ensure_managed_human_personal_workspace(uuid, text, uuid)",
+        owner: "opengeni_migrator",
+        execute: true,
+        publicExecute: false,
+        securityDefiner: true,
+      },
     ],
     privateRoutines: [
       {

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -115,15 +115,17 @@ describe("release schema contract", () => {
       sourceContract.migrations.map((migration) => [migration.path, migration]),
     );
     expect(sourceContract.sha256).toBe(
-      migrations.has("0218_organization_tenancy_foundation.sql")
-        ? "7166f14d681b083e91b1d85608e70286400184887cdf84a4d6e6ae867fd8258b"
-        : migrations.has("0217_capability_definition_delete_authority.sql")
-          ? "49fe063b91ded74174d945fdc2cb7713ba9b5604fee7610b495919179658fab3"
-          : migrations.has("0216_pack_component_ownership.sql")
-            ? "85a5f5320fd7c673bfe16240d4615b93ce635e9724d8f1bc467ce336e5c93022"
-            : migrations.has("0214_session_activity_commit_gate.sql")
-              ? "00b9989ef287e75bceceabc94ddfa1c118a97553ccdbc523485300046058075f"
-              : "e3048091a81b7e122b3c6d17cf52e5ffccff4c082780f6d2d330031742aef792",
+      migrations.has("0219_organization_tenancy_managed_human_provisioning.sql")
+        ? "2cf89e987960aee33f3d6ba7e2731b628b755f2d49133c58c4a29af119441268"
+        : migrations.has("0218_organization_tenancy_foundation.sql")
+          ? "7166f14d681b083e91b1d85608e70286400184887cdf84a4d6e6ae867fd8258b"
+          : migrations.has("0217_capability_definition_delete_authority.sql")
+            ? "49fe063b91ded74174d945fdc2cb7713ba9b5604fee7610b495919179658fab3"
+            : migrations.has("0216_pack_component_ownership.sql")
+              ? "85a5f5320fd7c673bfe16240d4615b93ce635e9724d8f1bc467ce336e5c93022"
+              : migrations.has("0214_session_activity_commit_gate.sql")
+                ? "00b9989ef287e75bceceabc94ddfa1c118a97553ccdbc523485300046058075f"
+                : "e3048091a81b7e122b3c6d17cf52e5ffccff4c082780f6d2d330031742aef792",
     );
     const contract = {
       ...sourceContract,
@@ -295,15 +297,18 @@ describe("release schema contract", () => {
         (migrations.has("0215_capabilities_platform.sql") ? 1 : 0) +
         (migrations.has("0216_pack_component_ownership.sql") ? 1 : 0) +
         (migrations.has("0217_capability_definition_delete_authority.sql") ? 1 : 0) +
-        (migrations.has("0218_organization_tenancy_foundation.sql") ? 1 : 0),
+        (migrations.has("0218_organization_tenancy_foundation.sql") ? 1 : 0) +
+        (migrations.has("0219_organization_tenancy_managed_human_provisioning.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(
       "49fe063b91ded74174d945fdc2cb7713ba9b5604fee7610b495919179658fab3",
     );
     expect(contract.latestMigration).toBe(
-      migrations.has("0218_organization_tenancy_foundation.sql")
-        ? "0218_organization_tenancy_foundation.sql"
-        : "0217_capability_definition_delete_authority.sql",
+      migrations.has("0219_organization_tenancy_managed_human_provisioning.sql")
+        ? "0219_organization_tenancy_managed_human_provisioning.sql"
+        : migrations.has("0218_organization_tenancy_foundation.sql")
+          ? "0218_organization_tenancy_foundation.sql"
+          : "0217_capability_definition_delete_authority.sql",
     );
     expect(migrations.get("0214_session_activity_commit_gate.sql")).toMatchObject({
       sha256: "26c84bc34bc51d19f9532cf3f2c64a649f100a724cb73d968e17e7c4ecf8de36",
@@ -312,6 +317,14 @@ describe("release schema contract", () => {
     if (migrations.has("0218_organization_tenancy_foundation.sql")) {
       expect(migrations.get("0218_organization_tenancy_foundation.sql")).toMatchObject({
         sha256: "6377522b4a7295150828bee39fffc90643adc46fec1907f1acc9671909ad6e75",
+        deploymentMode: "rolling",
+      });
+    }
+    if (migrations.has("0219_organization_tenancy_managed_human_provisioning.sql")) {
+      expect(
+        migrations.get("0219_organization_tenancy_managed_human_provisioning.sql"),
+      ).toMatchObject({
+        sha256: "dcbc4dcf9c09255af4140ef1117938ec21148a1245dad85926aeb52c58e6e88f",
         deploymentMode: "rolling",
       });
     }


### PR DESCRIPTION
## Summary
- add migration 0219 for the narrow managed-human organization-membership/personal-workspace lifecycle seam
- converge Better Auth managed humans on one same-organization membership and one lifecycle-only personal workspace
- preserve the legacy default workspace, runtime workspace grants, workspace lists, resource authority/grant behavior, and session behavior
- keep all four organization-tenancy tables FORCE-RLS with zero direct app DML; expose only the exact PUBLIC-revoked SECURITY DEFINER lifecycle routine
- update runtime posture, role provisioning, release schema contract, documentation, changeset, and native boundary tests

## Verification
- PostgreSQL 17.10 + pgvector 0.8.6 in the ephemeral sandbox
- full Drizzle ledger through 0219 applied with `opengeni_migrator`: exit 0
- canonical `provision-roles.ts` with FORCE-RLS posture: exit 0
- forced real-DB migration-0219/app-role suite: 4 pass, 0 fail, 78 assertions
- focused suite: 27 pass, 0 fail, 222 assertions
- root typecheck: all 30 projects clean
- targeted oxlint: 0 warnings, 0 errors
- formatting, docs-reference guard, and `git diff --check`: pass
- native snapshot: organization authority rows 0, grant rows 0; all four tenancy tables RLS+FORCE-RLS; lifecycle routine SECURITY DEFINER with `search_path = public, pg_catalog`

No deployment, release, cloud/provider/production, ruleset, Linear, review, approval, or merge action was performed.
