### PR TITLE
Fix capabilities production chunk crash

### DIFF
--- a/apps/web/src/components/capabilities/integration-control-center-view.tsx
+++ b/apps/web/src/components/capabilities/integration-control-center-view.tsx
@@ -45,8 +45,6 @@ import type {
   ConnectionOwnership,
 } from "@/types";
 
-export { SourcePackagesSectionView } from "@/components/capabilities/source-packages-view";
-
 export type IntegrationRemoveTarget = {
   instance: ApiIntegrationInstallationSummary;
   removesDefinition: boolean;

--- a/apps/web/src/components/capabilities/source-packages-section.tsx
+++ b/apps/web/src/components/capabilities/source-packages-section.tsx
@@ -36,7 +36,7 @@ export type SourceRemoveTarget =
     };
 
 const SourcePackagesSectionView = lazy(async () => {
-  const module = await import("@/components/capabilities/integration-control-center-view");
+  const module = await import("@/components/capabilities/source-packages-view");
   return { default: module.SourcePackagesSectionView };
 });
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -66,17 +66,6 @@ export default defineConfig({
               entriesAwareMergeThreshold: 128 * 1024,
               priority: 3,
             },
-            {
-              // Keep the capabilities service-card presentation behind its
-              // local React.lazy boundary. Rolldown otherwise coalesces this
-              // view-only module back into the route chunk, making every
-              // startup pay for account cards and setup dialogs before the
-              // preset inventory is visible.
-              name: "capabilities-services",
-              test: /src[\\/]components[\\/]capabilities[\\/]integration-control-center-view\.tsx$/,
-              includeDependenciesRecursively: false,
-              priority: 4,
-            },
           ],
         },
       },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -66,6 +66,14 @@ export default defineConfig({
               entriesAwareMergeThreshold: 128 * 1024,
               priority: 3,
             },
+            {
+              // Keep schema parsing from being folded into a larger shared
+              // startup chunk when a lazy route changes its import boundary.
+              name: "schema-runtime",
+              test: /(?:node_modules|\.bun)[\\/]zod(?:@|[\\/])/,
+              includeDependenciesRecursively: false,
+              priority: 4,
+            },
           ],
         },
       },

--- a/test/e2e/capabilities.browser.e2e.ts
+++ b/test/e2e/capabilities.browser.e2e.ts
@@ -1,10 +1,10 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import AxeBuilder from "@axe-core/playwright";
 import { existsSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readdir, readFile } from "node:fs/promises";
 import { chromium, type Browser, type Page } from "playwright";
 
-import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+import { freePort, runCommand, startProcess, type StartedProcess } from "@opengeni/testing";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
 const workspaceId = "00000000-0000-4000-8000-000000000017";
@@ -49,12 +49,25 @@ describe("capabilities browser e2e", () => {
       mkdir(evidenceDir, { recursive: true }),
       mkdir(mobbinEvidenceDir, { recursive: true }),
     ]);
+    const webEnv = {
+      NODE_ENV: "production",
+      VITE_API_BASE_URL: "http://127.0.0.1:9",
+    };
+    const build = await runCommand(["bun", "run", "build"], {
+      cwd: `${repoRoot}/apps/web`,
+      env: webEnv,
+      timeoutMs: 120_000,
+    });
+    if (build.exitCode !== 0) {
+      throw new Error(`Production web build failed:\n${build.stdout}\n${build.stderr}`);
+    }
+    await expectNoCapabilitiesChunkCycle(`${repoRoot}/apps/web/dist/assets`);
     web = await startProcess(
       [
         "bun",
         "run",
         "vite",
-        "dev",
+        "preview",
         "--port",
         String(webPort),
         "--strictPort",
@@ -63,7 +76,7 @@ describe("capabilities browser e2e", () => {
       ],
       {
         cwd: `${repoRoot}/apps/web`,
-        env: { VITE_API_BASE_URL: "http://127.0.0.1:9" },
+        env: webEnv,
         ready: async () =>
           (
             await fetch(webBaseUrl, {
@@ -77,7 +90,7 @@ describe("capabilities browser e2e", () => {
       ? "/usr/local/bin/chromium"
       : undefined;
     browser = await chromium.launch(executablePath ? { executablePath } : undefined);
-  }, 90_000);
+  }, 180_000);
 
   afterAll(async () => {
     await Promise.allSettled([browser?.close(), web?.stop()]);
@@ -588,7 +601,65 @@ async function expectFocused(locator: import("playwright").Locator): Promise<voi
 
 async function expectText(locator: import("playwright").Locator, expected: string): Promise<void> {
   await locator.waitFor({ state: "visible", timeout: 15_000 });
-  expect((await locator.textContent()) ?? "").toContain(expected);
+  const deadline = Date.now() + 15_000;
+  let text = "";
+  while (Date.now() < deadline) {
+    text = (await locator.textContent()) ?? "";
+    if (text.includes(expected)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  expect(text).toContain(expected);
+}
+
+async function expectNoCapabilitiesChunkCycle(assetsDir: string): Promise<void> {
+  const assets = (await readdir(assetsDir)).filter((asset) => asset.endsWith(".js"));
+  const graph = new Map<string, string[]>();
+  await Promise.all(
+    assets.map(async (asset) => {
+      const source = await readFile(`${assetsDir}/${asset}`, "utf8");
+      const imports = [...source.matchAll(/(?:\bfrom|\bimport)["']\.\/([^"']+\.js)["']/g)].map(
+        (match) => match[1]!,
+      );
+      graph.set(asset, imports);
+    }),
+  );
+
+  const active = new Set<string>();
+  const complete = new Set<string>();
+  const path: string[] = [];
+
+  function visit(asset: string): string[] | null {
+    if (active.has(asset)) {
+      const cycle = [...path.slice(path.indexOf(asset)), asset];
+      return cycle.some(
+        (member) =>
+          member.startsWith("capabilities-services-") ||
+          member.startsWith("integration-control-center-view-"),
+      )
+        ? cycle
+        : null;
+    }
+    if (complete.has(asset)) return null;
+    active.add(asset);
+    path.push(asset);
+    for (const dependency of graph.get(asset) ?? []) {
+      const cycle = visit(dependency);
+      if (cycle) return cycle;
+    }
+    path.pop();
+    active.delete(asset);
+    complete.add(asset);
+    return null;
+  }
+
+  for (const asset of assets) {
+    const cycle = visit(asset);
+    if (cycle) {
+      throw new Error(
+        `Capabilities production chunks contain a static import cycle: ${cycle.join(" -> ")}`,
+      );
+    }
+  }
 }
 
 async function installCapabilityApi(

--- a/test/e2e/source-packages-control-center.browser.e2e.ts
+++ b/test/e2e/source-packages-control-center.browser.e2e.ts
@@ -787,5 +787,12 @@ async function expectHidden(locator: import("playwright").Locator): Promise<void
 
 async function expectText(locator: import("playwright").Locator, expected: string): Promise<void> {
   await expectVisible(locator);
-  expect((await locator.textContent()) ?? "").toContain(expected);
+  const deadline = Date.now() + 15_000;
+  let text = "";
+  while (Date.now() < deadline) {
+    text = (await locator.textContent()) ?? "";
+    if (text.includes(expected)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  expect(text).toContain(expected);
 }


### PR DESCRIPTION
## Summary

- remove the forced capabilities service chunk that emitted a static two-way import with the integration view
- load the source-package presentation from its own lazy module instead of re-exporting it through the integration module
- run the capabilities browser suite against a production build and reject capability chunk cycles before preview startup

## Root cause

The deployed capabilities graph contains `capabilities-services -> integration-control-center-view -> capabilities-services`. Depending on module evaluation order, the lazy component resolves as `undefined`, which reaches React as minified error #130.

## Verification

- `bun run --cwd apps/web build`
- `bun run --cwd apps/web typecheck`
- `bun test apps/web/src/components/capabilities/source-packages-section.test.tsx`
- `bun test ./test/e2e/capabilities.browser.e2e.ts --test-name-pattern "successful enable"`
- `bun test ./test/e2e/capabilities.browser.e2e.ts --test-name-pattern "Google Drive folders"`
- `bunx oxfmt --check apps/web/vite.config.ts apps/web/src/components/capabilities/integration-control-center-view.tsx apps/web/src/components/capabilities/source-packages-section.tsx test/e2e/capabilities.browser.e2e.ts`

Related: OPE-16