### PR TITLE
test: allow cold Rust conformance compile

### DIFF
--- a/packages/artifact-tool/kernel/bindings/spreadsheet-adapter.test.ts
+++ b/packages/artifact-tool/kernel/bindings/spreadsheet-adapter.test.ts
@@ -4,6 +4,8 @@ import { ArtifactCommandBatchCodec, type ArtifactCommandBatch } from "../../src/
 import { lowerSpreadsheetOperationEnvelope } from "./spreadsheet-adapter";
 
 describe("public spreadsheet operation to kernel ABI lowering", () => {
+  // This assertion cold-compiles the pinned Rust fixture. Shared CI runners can
+  // legitimately exceed the ordinary 30-second unit-test limit.
   test("matches the direct Rust command envelope byte-for-byte", async () => {
     const fixture = await directKernelFixture();
     const namespace = 0x0123_4567_89ab_cdefn;
@@ -56,7 +58,7 @@ describe("public spreadsheet operation to kernel ABI lowering", () => {
           expect(transaction.requestHash).toBe(`sha256:${toHex(new Uint8Array(expected))}`);
         });
     });
-  });
+  }, 120_000);
 
   test("rejects unsupported modality, commands, malformed ids, and unordered ranges", () => {
     const base: ArtifactCommandBatch = {


### PR DESCRIPTION
## Summary

- preserve the byte-for-byte Rust/TypeScript spreadsheet ABI conformance assertion
- allow the test file 120 seconds for a first-run compile of its pinned Rust fixture
- retain the repository-wide 30-second default for ordinary unit tests

## Failure mode

The exact `main` unit shard failed twice because the cold `cargo run --locked` fixture compile reached Bun's 30-second default while sharing the runner with other test processes. The same test passed locally from an empty Rust target in about 8 seconds; the assertion itself did not fail.

## Verification

- checksum-verified Bun 1.3.14
- `bun --no-env-file test --no-orphans --timeout=30000 --max-concurrency=1 packages/artifact-tool/kernel/bindings/spreadsheet-adapter.test.ts` from a deleted Rust target
- `bun run typecheck` (30 projects)
- `bun test scripts/ci/run-unit-shard.test.ts`
- `bun x oxfmt --check packages/artifact-tool/kernel/bindings/spreadsheet-adapter.test.ts`
- `bun run check:public-hygiene`
- `git diff --check`
