### PR TITLE
test: wait on Slack acceptance UI readiness

### DIFF
--- a/packages/react/test/message-timeline-pagination.test.tsx
+++ b/packages/react/test/message-timeline-pagination.test.tsx
@@ -2033,13 +2033,15 @@ function mockScrollerLayout(
       tipTopInScroller = topInScroller;
     },
     tipBottomGap() {
-      const tip = findTip();
-      if (!tip) {
+      if (!findTip()) {
         throw new Error("expected tip element");
       }
-      const tipRect = tip.getBoundingClientRect();
-      const nodeRect = scroller.getBoundingClientRect();
-      return Math.abs(tipRect.bottom - (nodeRect.bottom - options.paddingBottom));
+      // The helper owns this synthetic layout. Derive both edges from that
+      // state so an unrelated test's process-global DOM rect stub cannot make
+      // a correctly parked camera appear one padding-width short of the tip.
+      const tipBottom = scrollerTop + tipTopInScroller - currentScrollTop + options.tipHeight;
+      const viewportBottom = scrollerTop + options.clientHeight - options.paddingBottom;
+      return Math.abs(tipBottom - viewportBottom);
     },
     restore() {
       Element.prototype.getBoundingClientRect = scrollerElementRect;

--- a/scripts/ci/impact.test.ts
+++ b/scripts/ci/impact.test.ts
@@ -236,6 +236,15 @@ describe("fail-closed change impact", () => {
     expect(tests.e2e).not.toContain("test/e2e/opstream-runner.e2e.ts");
   });
 
+  test("a changed E2E test stays out of the unit tier", () => {
+    const path = "test/e2e/slack-installation-binding.browser.e2e.ts";
+    const plan = createImpactPlan([path]);
+
+    expect(plan.mode).toBe("focused");
+    expect(plan.e2eTests).toContain(path);
+    expect(plan.unitTests).not.toContain(path);
+  });
+
   test("full plans exhaustively own discovered tests and buildable projects", () => {
     const plan = createImpactPlan([], { forceFull: true });
     const tests = discoverTestFiles();

--- a/scripts/ci/impact.ts
+++ b/scripts/ci/impact.ts
@@ -581,7 +581,8 @@ export function createImpactPlan(
   }
 
   const affected = transitiveDependents(graph, direct);
-  const unit = new Set(changedTests);
+  const unitTestSet = new Set(tests.unit);
+  const unit = new Set([...changedTests].filter((path) => unitTestSet.has(path)));
   for (const path of tests.unit) {
     const pkg = workspaceForPath(graph, path);
     if (pkg && affected.has(pkg.name)) unit.add(path);

--- a/test/e2e/custom-api-control-center.browser.e2e.ts
+++ b/test/e2e/custom-api-control-center.browser.e2e.ts
@@ -777,6 +777,6 @@ async function expectVisible(locator: import("playwright").Locator): Promise<voi
 }
 
 async function expectText(locator: import("playwright").Locator, expected: string): Promise<void> {
-  await expectVisible(locator);
+  await locator.filter({ hasText: expected }).waitFor({ state: "visible", timeout: 15_000 });
   expect((await locator.textContent()) ?? "").toContain(expected);
 }

--- a/test/e2e/slack-installation-binding.browser.e2e.ts
+++ b/test/e2e/slack-installation-binding.browser.e2e.ts
@@ -79,7 +79,7 @@ describe("Slack installation binding browser acceptance", () => {
       await installApiFixture(page, state);
       const capabilitiesUrl = `${webBaseUrl}/workspaces/${workspaceId}/capabilities`;
 
-      await page.goto(capabilitiesUrl, { waitUntil: "networkidle" });
+      await page.goto(capabilitiesUrl, { waitUntil: "domcontentloaded" });
       let settings = await openSlackSettings(page);
       await openConnectionDetails(settings);
       await expectText(settings, "Slack Binding Team · T_BINDING_BROWSER");
@@ -92,7 +92,7 @@ describe("Slack installation binding browser acceptance", () => {
 
       state.bindingState = "quarantined";
       state.connectionStatus = "needs_reauth";
-      await page.goto(capabilitiesUrl, { waitUntil: "networkidle" });
+      await page.goto(capabilitiesUrl, { waitUntil: "domcontentloaded" });
       settings = await openSlackSettings(page);
       await openConnectionDetails(settings);
       await expectText(settings, "quarantined · version 3");
@@ -100,7 +100,7 @@ describe("Slack installation binding browser acceptance", () => {
       expect(await settings.getByRole("button", { name: "Reconnect" }).isDisabled()).toBe(true);
 
       state.bindingState = null;
-      await page.goto(capabilitiesUrl, { waitUntil: "networkidle" });
+      await page.goto(capabilitiesUrl, { waitUntil: "domcontentloaded" });
       settings = await openSlackSettings(page);
       await openConnectionDetails(settings);
       await expectText(settings, "No verified installation binding is available");


### PR DESCRIPTION
## Summary

- replace `networkidle` navigation waits in Slack installation-binding acceptance with `domcontentloaded` while retaining UI-visible readiness and security assertions
- keep changed E2E files in the E2E tier instead of also handing their custom suffixes to Bun's unit runner
- derive synthetic timeline tip geometry from its owned layout state so unrelated process-global DOM stubs cannot create a false 24 px gap
- wait for the requested control-center text state itself after asynchronous feature mutations
- unblock the next Changesets Version PR without retry-to-green

## Evidence

- reproduced the Version PR's same-URL `networkidle` timeout
- Slack browser acceptance passed 5/5 before the PR and again after the complete fix (13 assertions per run)
- impact planner regression suite: 34 passed, including changed-E2E tier ownership
- message timeline suite: 10/10 consecutive complete-file passes with the exact bottom-follow assertion retained
- complete custom-API browser suite passed, then the formerly failing Gmail feature pass passed 10/10 additional runs
- formatting and `git diff --check` pass

These are test synchronization, selection, and synthetic-layout corrections; no product assertion is skipped or weakened.
