### PR TITLE
fix(worker): raise active history serving envelope

### DIFF
--- a/.changeset/wider-active-histories.md
+++ b/.changeset/wider-active-histories.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Raise the serving envelope for active session history so tool-heavy orchestration turns remain compactable.

--- a/apps/worker/test/context-compaction-activity.test.ts
+++ b/apps/worker/test/context-compaction-activity.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { MODEL_ATTACHMENT_REFS_FIELD } from "@opengeni/contracts";
 import {
+  ACTIVE_SESSION_HISTORY_MAX_JSON_BYTES,
+  ACTIVE_SESSION_HISTORY_MAX_JSON_NODES,
+  ACTIVE_SESSION_HISTORY_MAX_JSON_PROPERTIES,
+  ACTIVE_SESSION_HISTORY_MAX_ROWS,
   ActiveSessionHistoryLimitExceededError,
   ApprovalRunStateLimitExceededError,
   addSessionSystemUpdate,
@@ -85,6 +89,13 @@ describe("standalone context compaction execution", () => {
     await client?.close();
     await shared?.release();
   }, 60_000);
+
+  test("uses the production active-history materialization envelope", () => {
+    expect(ACTIVE_SESSION_HISTORY_MAX_JSON_BYTES).toBe(15 * 1024 * 1024);
+    expect(ACTIVE_SESSION_HISTORY_MAX_ROWS).toBe(8_192);
+    expect(ACTIVE_SESSION_HISTORY_MAX_JSON_NODES).toBe(131_072);
+    expect(ACTIVE_SESSION_HISTORY_MAX_JSON_PROPERTIES).toBe(65_536);
+  });
 
   test("rejects an oversized active UTF-8 JSON transcript before paged item decoding", async () => {
     const suffix = crypto.randomUUID();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,9 +153,9 @@ exact materialized file. Provider ids, object keys, signed URLs, and base64 do
 not enter the model-facing prefix. See
 [`image-generation.md`](image-generation.md).
 
-Serving workers fail closed before decoding an active transcript above 3 MiB,
-4,096 rows, 65,536 JSON nodes, or 32,768 object properties. Approval `RunState`
-uses the same byte/node/property envelope. Oversized state is never silently
+Serving workers fail closed before decoding an active transcript above 15 MiB,
+8,192 rows, 131,072 JSON nodes, or 65,536 object properties. Approval `RunState`
+retains its distinct 3 MiB / 65,536-node / 32,768-property envelope. Oversized state is never silently
 trimmed or compacted inside a serving worker; repair and forensic work belongs
 in a bounded non-serving execution class.
 

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -222,11 +222,11 @@ runtime/native headroom; a finite container that cannot safely admit one turn
 does not start. The invariant is checked both before and after Temporal's native
 worker construction, and live retained-memory growth contracts new slot
 availability. Before decoding model-facing JSONB, PostgreSQL rejects a complete
-active transcript above any of four materialization limits: 3 MiB UTF-8 JSON,
-4,096 rows, 65,536 decoded JSON nodes, or 32,768 object properties. It never
+active transcript above any of four materialization limits: 15 MiB UTF-8 JSON,
+8,192 rows, 131,072 decoded JSON nodes, or 65,536 object properties. It never
 silently trims conversation truth; normal proactive compaction keeps long
-sessions under the boundary. Approval `RunState` uses the same 3 MiB, 65,536-node,
-and 32,768-property serving envelope before SDK decoding. A missing or malformed Temporal task-queue stats
+sessions under the boundary. Approval `RunState` retains its distinct 3 MiB,
+65,536-node, and 32,768-property serving envelope before SDK decoding. A missing or malformed Temporal task-queue stats
 object is a failed read and makes the capacity sample stale; it is never
 normalized into a fresh zero backlog. The release target remains at most
 50 MiB incremental RSS per active turn. A production read-only forensic

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -25936,10 +25936,10 @@ export async function getActiveSessionHistoryItems(
  * deterministically before a Postgres driver decodes it instead of using the
  * pod OOM killer as admission.
  */
-export const ACTIVE_SESSION_HISTORY_MAX_JSON_BYTES = 3 * 1024 * 1024;
-export const ACTIVE_SESSION_HISTORY_MAX_ROWS = 4_096;
-export const ACTIVE_SESSION_HISTORY_MAX_JSON_NODES = 65_536;
-export const ACTIVE_SESSION_HISTORY_MAX_JSON_PROPERTIES = 32_768;
+export const ACTIVE_SESSION_HISTORY_MAX_JSON_BYTES = 15 * 1024 * 1024;
+export const ACTIVE_SESSION_HISTORY_MAX_ROWS = 8_192;
+export const ACTIVE_SESSION_HISTORY_MAX_JSON_NODES = 131_072;
+export const ACTIVE_SESSION_HISTORY_MAX_JSON_PROPERTIES = 65_536;
 
 export type ActiveSessionHistoryLimitKind =
   | "json_bytes"


### PR DESCRIPTION
## Summary
- raise active model-history byte ceiling from 3 MiB to 15 MiB
- double row, JSON-node, and object-property ceilings
- preserve the separate approval RunState envelope
- document and regression-test the production defaults

## Production incident
Session `7644d4b0-7c42-4b57-ac6e-ee4db459d48d` is blocked at 3,426,531 bytes because compaction reads through the same 3 MiB serving guard. The new 15 MiB active-history ceiling admits that session for compaction.

## Verification
- `bun test apps/worker/test/context-compaction-activity.test.ts` (19 pass)
- `bun run typecheck` (30 projects)
- `bun run check:docs-refs`
- `git diff --check`