### PR TITLE
fix(db): stage session-channel FK validation

### DIFF
--- a/.changeset/quiet-channel-fk-validation.md
+++ b/.changeset/quiet-channel-fk-validation.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Stage and validate the session-channel foreign key without retaining the column-addition lock across a populated sessions-table scan.

--- a/apps/worker/test/retained-process-reconciliation.test.ts
+++ b/apps/worker/test/retained-process-reconciliation.test.ts
@@ -939,7 +939,7 @@ describe("retained-process terminal-owner reconciliation", () => {
     expect(candidatePlan).toContain('"Node Type":"Limit"');
     expect(candidatePlan).toContain('"Actual Rows":7');
     expect(candidatePlan).toMatch(
-      /session_turn_attempts_(?:workspace_id_uq|pkey|latest_session_idx)/,
+      /session_turn_attempts_(?:workspace_id_uq|pkey|latest_session_idx|authority_epoch_idx)/,
     );
     expect(candidatePlan).not.toContain('"Actual Loops":128');
     expect(JSON.stringify(plans.retainedInventory)).toContain(

--- a/packages/db/drizzle/0220_session_channels.sql
+++ b/packages/db/drizzle/0220_session_channels.sql
@@ -45,12 +45,10 @@ END
 $grants$;
 
 -- A root session may be filed into one channel; NULL means unfiled (the
--- inbox). The single-column ON DELETE SET NULL follows the variable_set_id
--- precedent; workspace scoping is enforced by RLS plus the application
--- create/update boundary, which resolves the channel workspace-scoped.
--- The supporting sessions index is built CONCURRENTLY in migration 0221 —
--- a plain CREATE INDEX here would hold the ADD COLUMN's ACCESS EXCLUSIVE
--- lock on the live sessions table for a full-table scan.
+-- inbox). Keep this transaction to the metadata-only nullable column addition:
+-- both the supporting index and the foreign-key validation need table scans,
+-- so migrations 0221-0223 perform those steps without retaining this ADD
+-- COLUMN transaction's ACCESS EXCLUSIVE lock for the duration of a scan.
 SET LOCAL lock_timeout = '5s';
 ALTER TABLE "sessions"
-  ADD COLUMN "channel_id" uuid REFERENCES "channels"("id") ON DELETE SET NULL;
+  ADD COLUMN "channel_id" uuid;

--- a/packages/db/drizzle/0222_sessions_channel_fk.sql
+++ b/packages/db/drizzle/0222_sessions_channel_fk.sql
@@ -5,13 +5,61 @@
 --
 -- The equivalent auto-named constraint may already exist on a database that
 -- applied the original unreleased 0220 migration. Preserve that validated
--- constraint instead of installing a duplicate.
+-- constraint only when its complete catalog semantics match this migration.
 SET LOCAL lock_timeout = '5s';
 
 DO $migration$
+DECLARE
+  same_name_count integer;
+  exact_count integer;
 BEGIN
-  IF NOT EXISTS (
-    SELECT 1
+  SELECT count(*)::integer
+  INTO same_name_count
+  FROM pg_catalog.pg_constraint AS constraint_row
+  WHERE constraint_row.conrelid = 'sessions'::regclass
+    AND constraint_row.conname IN ('sessions_channel_id_fk', 'sessions_channel_id_fkey');
+
+  SELECT count(*)::integer
+  INTO exact_count
+  FROM pg_catalog.pg_constraint AS constraint_row
+  JOIN pg_catalog.pg_attribute AS local_column
+    ON local_column.attrelid = constraint_row.conrelid
+   AND local_column.attnum = constraint_row.conkey[1]
+  JOIN pg_catalog.pg_attribute AS referenced_column
+    ON referenced_column.attrelid = constraint_row.confrelid
+   AND referenced_column.attnum = constraint_row.confkey[1]
+  WHERE constraint_row.conrelid = 'sessions'::regclass
+    AND constraint_row.confrelid = 'channels'::regclass
+    AND constraint_row.contype = 'f'
+    AND constraint_row.conname IN ('sessions_channel_id_fk', 'sessions_channel_id_fkey')
+    AND cardinality(constraint_row.conkey) = 1
+    AND cardinality(constraint_row.confkey) = 1
+    AND local_column.attname = 'channel_id'
+    AND referenced_column.attname = 'id'
+    AND constraint_row.confdeltype = 'n'
+    AND constraint_row.confupdtype = 'a'
+    AND constraint_row.confmatchtype = 's'
+    AND NOT constraint_row.condeferrable
+    AND NOT constraint_row.condeferred;
+
+  IF same_name_count <> exact_count OR exact_count > 1 THEN
+    RAISE EXCEPTION
+      'sessions channel foreign key name is occupied by an incompatible constraint';
+  END IF;
+
+  IF exact_count = 0 THEN
+    ALTER TABLE "sessions"
+      ADD CONSTRAINT "sessions_channel_id_fk"
+      FOREIGN KEY ("channel_id")
+      REFERENCES "channels"("id")
+      MATCH SIMPLE
+      ON UPDATE NO ACTION
+      ON DELETE SET NULL
+      NOT DEFERRABLE
+      NOT VALID;
+
+    SELECT count(*)::integer
+    INTO exact_count
     FROM pg_catalog.pg_constraint AS constraint_row
     JOIN pg_catalog.pg_attribute AS local_column
       ON local_column.attrelid = constraint_row.conrelid
@@ -22,21 +70,20 @@ BEGIN
     WHERE constraint_row.conrelid = 'sessions'::regclass
       AND constraint_row.confrelid = 'channels'::regclass
       AND constraint_row.contype = 'f'
-      AND constraint_row.conname IN ('sessions_channel_id_fk', 'sessions_channel_id_fkey')
+      AND constraint_row.conname = 'sessions_channel_id_fk'
       AND cardinality(constraint_row.conkey) = 1
       AND cardinality(constraint_row.confkey) = 1
       AND local_column.attname = 'channel_id'
       AND referenced_column.attname = 'id'
       AND constraint_row.confdeltype = 'n'
+      AND constraint_row.confupdtype = 'a'
+      AND constraint_row.confmatchtype = 's'
       AND NOT constraint_row.condeferrable
-      AND NOT constraint_row.condeferred
-  ) THEN
-    ALTER TABLE "sessions"
-      ADD CONSTRAINT "sessions_channel_id_fk"
-      FOREIGN KEY ("channel_id")
-      REFERENCES "channels"("id")
-      ON DELETE SET NULL
-      NOT VALID;
+      AND NOT constraint_row.condeferred;
+
+    IF exact_count <> 1 THEN
+      RAISE EXCEPTION 'failed to install the exact sessions channel foreign key';
+    END IF;
   END IF;
 END
 $migration$;

--- a/packages/db/drizzle/0222_sessions_channel_fk.sql
+++ b/packages/db/drizzle/0222_sessions_channel_fk.sql
@@ -1,0 +1,42 @@
+-- deployment-mode: rolling
+-- Install the channel foreign key without scanning the populated sessions
+-- table while holding ACCESS EXCLUSIVE. New writes are checked immediately;
+-- migration 0223 performs the bounded online validation scan separately.
+--
+-- The equivalent auto-named constraint may already exist on a database that
+-- applied the original unreleased 0220 migration. Preserve that validated
+-- constraint instead of installing a duplicate.
+SET LOCAL lock_timeout = '5s';
+
+DO $migration$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint AS constraint_row
+    JOIN pg_catalog.pg_attribute AS local_column
+      ON local_column.attrelid = constraint_row.conrelid
+     AND local_column.attnum = constraint_row.conkey[1]
+    JOIN pg_catalog.pg_attribute AS referenced_column
+      ON referenced_column.attrelid = constraint_row.confrelid
+     AND referenced_column.attnum = constraint_row.confkey[1]
+    WHERE constraint_row.conrelid = 'sessions'::regclass
+      AND constraint_row.confrelid = 'channels'::regclass
+      AND constraint_row.contype = 'f'
+      AND constraint_row.conname IN ('sessions_channel_id_fk', 'sessions_channel_id_fkey')
+      AND cardinality(constraint_row.conkey) = 1
+      AND cardinality(constraint_row.confkey) = 1
+      AND local_column.attname = 'channel_id'
+      AND referenced_column.attname = 'id'
+      AND constraint_row.confdeltype = 'n'
+      AND NOT constraint_row.condeferrable
+      AND NOT constraint_row.condeferred
+  ) THEN
+    ALTER TABLE "sessions"
+      ADD CONSTRAINT "sessions_channel_id_fk"
+      FOREIGN KEY ("channel_id")
+      REFERENCES "channels"("id")
+      ON DELETE SET NULL
+      NOT VALID;
+  END IF;
+END
+$migration$;

--- a/packages/db/drizzle/0223_sessions_channel_fk_validate.sql
+++ b/packages/db/drizzle/0223_sessions_channel_fk_validate.sql
@@ -1,0 +1,39 @@
+-- deployment-mode: rolling
+-- Validate only the staged NOT VALID constraint. PostgreSQL performs this scan
+-- with SHARE UPDATE EXCLUSIVE rather than retaining the column-addition
+-- transaction's ACCESS EXCLUSIVE lock across the populated sessions table.
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+DO $migration$
+DECLARE constraint_name text;
+BEGIN
+  FOR constraint_name IN
+    SELECT constraint_row.conname
+    FROM pg_catalog.pg_constraint AS constraint_row
+    JOIN pg_catalog.pg_attribute AS local_column
+      ON local_column.attrelid = constraint_row.conrelid
+     AND local_column.attnum = constraint_row.conkey[1]
+    JOIN pg_catalog.pg_attribute AS referenced_column
+      ON referenced_column.attrelid = constraint_row.confrelid
+     AND referenced_column.attnum = constraint_row.confkey[1]
+    WHERE constraint_row.conrelid = 'sessions'::regclass
+      AND constraint_row.confrelid = 'channels'::regclass
+      AND constraint_row.contype = 'f'
+      AND constraint_row.conname IN ('sessions_channel_id_fk', 'sessions_channel_id_fkey')
+      AND cardinality(constraint_row.conkey) = 1
+      AND cardinality(constraint_row.confkey) = 1
+      AND local_column.attname = 'channel_id'
+      AND referenced_column.attname = 'id'
+      AND constraint_row.confdeltype = 'n'
+      AND NOT constraint_row.condeferrable
+      AND NOT constraint_row.condeferred
+      AND NOT constraint_row.convalidated
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE "sessions" VALIDATE CONSTRAINT %I',
+      constraint_name
+    );
+  END LOOP;
+END
+$migration$;

--- a/packages/db/drizzle/0223_sessions_channel_fk_validate.sql
+++ b/packages/db/drizzle/0223_sessions_channel_fk_validate.sql
@@ -6,34 +6,113 @@ SET LOCAL lock_timeout = '5s';
 SET LOCAL statement_timeout = '10min';
 
 DO $migration$
-DECLARE constraint_name text;
+DECLARE
+  same_name_count integer;
+  exact_count integer;
+  validated_exact_count integer;
+  constraint_name text;
+  constraint_validated boolean;
 BEGIN
-  FOR constraint_name IN
-    SELECT constraint_row.conname
-    FROM pg_catalog.pg_constraint AS constraint_row
-    JOIN pg_catalog.pg_attribute AS local_column
-      ON local_column.attrelid = constraint_row.conrelid
-     AND local_column.attnum = constraint_row.conkey[1]
-    JOIN pg_catalog.pg_attribute AS referenced_column
-      ON referenced_column.attrelid = constraint_row.confrelid
-     AND referenced_column.attnum = constraint_row.confkey[1]
-    WHERE constraint_row.conrelid = 'sessions'::regclass
-      AND constraint_row.confrelid = 'channels'::regclass
-      AND constraint_row.contype = 'f'
-      AND constraint_row.conname IN ('sessions_channel_id_fk', 'sessions_channel_id_fkey')
-      AND cardinality(constraint_row.conkey) = 1
-      AND cardinality(constraint_row.confkey) = 1
-      AND local_column.attname = 'channel_id'
-      AND referenced_column.attname = 'id'
-      AND constraint_row.confdeltype = 'n'
-      AND NOT constraint_row.condeferrable
-      AND NOT constraint_row.condeferred
-      AND NOT constraint_row.convalidated
-  LOOP
+  SELECT count(*)::integer
+  INTO same_name_count
+  FROM pg_catalog.pg_constraint AS constraint_row
+  WHERE constraint_row.conrelid = 'sessions'::regclass
+    AND constraint_row.conname IN ('sessions_channel_id_fk', 'sessions_channel_id_fkey');
+
+  SELECT count(*)::integer
+  INTO exact_count
+  FROM pg_catalog.pg_constraint AS constraint_row
+  JOIN pg_catalog.pg_attribute AS local_column
+    ON local_column.attrelid = constraint_row.conrelid
+   AND local_column.attnum = constraint_row.conkey[1]
+  JOIN pg_catalog.pg_attribute AS referenced_column
+    ON referenced_column.attrelid = constraint_row.confrelid
+   AND referenced_column.attnum = constraint_row.confkey[1]
+  WHERE constraint_row.conrelid = 'sessions'::regclass
+    AND constraint_row.confrelid = 'channels'::regclass
+    AND constraint_row.contype = 'f'
+    AND constraint_row.conname IN ('sessions_channel_id_fk', 'sessions_channel_id_fkey')
+    AND cardinality(constraint_row.conkey) = 1
+    AND cardinality(constraint_row.confkey) = 1
+    AND local_column.attname = 'channel_id'
+    AND referenced_column.attname = 'id'
+    AND constraint_row.confdeltype = 'n'
+    AND constraint_row.confupdtype = 'a'
+    AND constraint_row.confmatchtype = 's'
+    AND NOT constraint_row.condeferrable
+    AND NOT constraint_row.condeferred;
+
+  IF same_name_count <> exact_count OR exact_count <> 1 THEN
+    RAISE EXCEPTION
+      'expected exactly one compatible sessions channel foreign key, found % compatible among % named constraints',
+      exact_count,
+      same_name_count;
+  END IF;
+
+  SELECT constraint_row.conname, constraint_row.convalidated
+  INTO constraint_name, constraint_validated
+  FROM pg_catalog.pg_constraint AS constraint_row
+  JOIN pg_catalog.pg_attribute AS local_column
+    ON local_column.attrelid = constraint_row.conrelid
+   AND local_column.attnum = constraint_row.conkey[1]
+  JOIN pg_catalog.pg_attribute AS referenced_column
+    ON referenced_column.attrelid = constraint_row.confrelid
+   AND referenced_column.attnum = constraint_row.confkey[1]
+  WHERE constraint_row.conrelid = 'sessions'::regclass
+    AND constraint_row.confrelid = 'channels'::regclass
+    AND constraint_row.contype = 'f'
+    AND constraint_row.conname IN ('sessions_channel_id_fk', 'sessions_channel_id_fkey')
+    AND cardinality(constraint_row.conkey) = 1
+    AND cardinality(constraint_row.confkey) = 1
+    AND local_column.attname = 'channel_id'
+    AND referenced_column.attname = 'id'
+    AND constraint_row.confdeltype = 'n'
+    AND constraint_row.confupdtype = 'a'
+    AND constraint_row.confmatchtype = 's'
+    AND NOT constraint_row.condeferrable
+    AND NOT constraint_row.condeferred;
+
+  IF NOT constraint_validated THEN
     EXECUTE format(
       'ALTER TABLE "sessions" VALIDATE CONSTRAINT %I',
       constraint_name
     );
-  END LOOP;
+  END IF;
+
+  SELECT
+    count(*)::integer,
+    count(*) FILTER (WHERE constraint_row.convalidated)::integer
+  INTO exact_count, validated_exact_count
+  FROM pg_catalog.pg_constraint AS constraint_row
+  JOIN pg_catalog.pg_attribute AS local_column
+    ON local_column.attrelid = constraint_row.conrelid
+   AND local_column.attnum = constraint_row.conkey[1]
+  JOIN pg_catalog.pg_attribute AS referenced_column
+    ON referenced_column.attrelid = constraint_row.confrelid
+   AND referenced_column.attnum = constraint_row.confkey[1]
+  WHERE constraint_row.conrelid = 'sessions'::regclass
+    AND constraint_row.confrelid = 'channels'::regclass
+    AND constraint_row.contype = 'f'
+    AND constraint_row.conname IN ('sessions_channel_id_fk', 'sessions_channel_id_fkey')
+    AND cardinality(constraint_row.conkey) = 1
+    AND cardinality(constraint_row.confkey) = 1
+    AND local_column.attname = 'channel_id'
+    AND referenced_column.attname = 'id'
+    AND constraint_row.confdeltype = 'n'
+    AND constraint_row.confupdtype = 'a'
+    AND constraint_row.confmatchtype = 's'
+    AND NOT constraint_row.condeferrable
+    AND NOT constraint_row.condeferred;
+
+  SELECT count(*)::integer
+  INTO same_name_count
+  FROM pg_catalog.pg_constraint AS constraint_row
+  WHERE constraint_row.conrelid = 'sessions'::regclass
+    AND constraint_row.conname IN ('sessions_channel_id_fk', 'sessions_channel_id_fkey');
+
+  IF same_name_count <> 1 OR exact_count <> 1 OR validated_exact_count <> 1 THEN
+    RAISE EXCEPTION
+      'sessions channel foreign key validation did not produce exactly one validated exact constraint';
+  END IF;
 END
 $migration$;

--- a/packages/db/test/migration-0220-session-channels.test.ts
+++ b/packages/db/test/migration-0220-session-channels.test.ts
@@ -53,6 +53,8 @@ describe("migration 0220 session channels", () => {
     expect(addForeignKey).toContain("local_column.attname = 'channel_id'");
     expect(addForeignKey).toContain("referenced_column.attname = 'id'");
     expect(addForeignKey).toContain("constraint_row.confdeltype = 'n'");
+    expect(addForeignKey).toContain("constraint_row.confupdtype = 'a'");
+    expect(addForeignKey).toContain("constraint_row.confmatchtype = 's'");
     expect(addForeignKey).not.toContain("VALIDATE CONSTRAINT");
     const validateForeignKey = await readFile(
       migrationPath.replace("0220_session_channels.sql", "0223_sessions_channel_fk_validate.sql"),
@@ -63,6 +65,9 @@ describe("migration 0220 session channels", () => {
     expect(validateForeignKey).toContain("local_column.attname = 'channel_id'");
     expect(validateForeignKey).toContain("referenced_column.attname = 'id'");
     expect(validateForeignKey).toContain("constraint_row.confdeltype = 'n'");
+    expect(validateForeignKey).toContain("constraint_row.confupdtype = 'a'");
+    expect(validateForeignKey).toContain("constraint_row.confmatchtype = 's'");
+    expect(validateForeignKey).toContain("validated_exact_count <> 1");
     expect(validateForeignKey).toContain("SET LOCAL statement_timeout = '10min'");
 
     const blank = await acquireBlankTestDatabase("migration-0220");
@@ -186,6 +191,108 @@ describe("migration 0220 session channels", () => {
         "0222_sessions_channel_fk.sql",
         "0223_sessions_channel_fk_validate.sql",
       ]);
+    } finally {
+      await sql.end();
+      await blank.release();
+    }
+  }, 180_000);
+
+  test("fails validation when 0222 is receipted but the exact foreign key is absent", async () => {
+    const blank = await acquireBlankTestDatabase("migration-0220-missing-fk");
+    if (!blank) {
+      if (requireRealDatabase) {
+        throw new Error(
+          "OPENGENI_REQUIRE_REAL_DB=1 but the migration 0220 PostgreSQL harness is unavailable",
+        );
+      }
+      return;
+    }
+    const sql = postgres(blank.databaseUrl, { max: 1 });
+    try {
+      await sql.unsafe(`
+        create table schema_migrations (
+          name text primary key,
+          applied_at timestamptz not null default now()
+        )
+      `);
+      await sql`
+        insert into schema_migrations (name)
+        values
+          ('0222_sessions_channel_fk.sql'),
+          ('0223_sessions_channel_fk_validate.sql')`;
+      await migrate(blank.databaseUrl);
+      await sql`
+        delete from schema_migrations
+        where name = '0223_sessions_channel_fk_validate.sql'`;
+
+      await expect(migrate(blank.databaseUrl)).rejects.toThrow(
+        "expected exactly one compatible sessions channel foreign key",
+      );
+
+      const [receipt] = await sql<Array<{ recorded: boolean }>>`
+        select exists (
+          select 1
+          from schema_migrations
+          where name = '0223_sessions_channel_fk_validate.sql'
+        ) as recorded`;
+      expect(receipt?.recorded).toBe(false);
+    } finally {
+      await sql.end();
+      await blank.release();
+    }
+  }, 180_000);
+
+  test("fails closed when the expected name has drifted foreign key semantics", async () => {
+    const blank = await acquireBlankTestDatabase("migration-0220-drifted-fk");
+    if (!blank) {
+      if (requireRealDatabase) {
+        throw new Error(
+          "OPENGENI_REQUIRE_REAL_DB=1 but the migration 0220 PostgreSQL harness is unavailable",
+        );
+      }
+      return;
+    }
+    const sql = postgres(blank.databaseUrl, { max: 1 });
+    try {
+      await sql.unsafe(`
+        create table schema_migrations (
+          name text primary key,
+          applied_at timestamptz not null default now()
+        )
+      `);
+      await sql`
+        insert into schema_migrations (name)
+        values
+          ('0222_sessions_channel_fk.sql'),
+          ('0223_sessions_channel_fk_validate.sql')`;
+      await migrate(blank.databaseUrl);
+      await sql.unsafe(`
+        alter table "sessions"
+          add constraint "sessions_channel_id_fk"
+          foreign key ("channel_id")
+          references "channels"("id")
+          on update cascade
+          on delete set null
+      `);
+      await sql`
+        delete from schema_migrations
+        where name in (
+          '0222_sessions_channel_fk.sql',
+          '0223_sessions_channel_fk_validate.sql'
+        )`;
+
+      await expect(migrate(blank.databaseUrl)).rejects.toThrow(
+        "sessions channel foreign key name is occupied by an incompatible constraint",
+      );
+
+      const receipts = await sql<Array<{ name: string }>>`
+        select name
+        from schema_migrations
+        where name in (
+          '0222_sessions_channel_fk.sql',
+          '0223_sessions_channel_fk_validate.sql'
+        )`;
+      expect(receipts).toHaveLength(0);
     } finally {
       await sql.end();
       await blank.release();

--- a/packages/db/test/migration-0220-session-channels.test.ts
+++ b/packages/db/test/migration-0220-session-channels.test.ts
@@ -23,13 +23,11 @@ describe("migration 0220 session channels", () => {
       'opengeni_private.workspace_rls_visible("account_id", "workspace_id")',
     );
     expect(migration).toContain("GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %I.channels");
-    expect(migration).toContain(
-      'ADD COLUMN "channel_id" uuid REFERENCES "channels"("id") ON DELETE SET NULL',
-    );
-    // Rolling safety: the sessions DDL is guarded by a bounded lock wait, and
-    // the sessions index is NOT built here — a plain CREATE INDEX would hold
-    // the ADD COLUMN's ACCESS EXCLUSIVE lock for a full-table scan. It lives
-    // in 0221 as a concurrent-index migration.
+    expect(migration).toContain('ADD COLUMN "channel_id" uuid');
+    expect(migration).not.toContain('ADD COLUMN "channel_id" uuid REFERENCES');
+    // Rolling safety: no sessions-table scan runs in the ADD COLUMN transaction.
+    // The index is concurrent, then the FK is installed NOT VALID and validated
+    // in its own later transaction.
     expect(migration).toContain("SET LOCAL lock_timeout");
     expect(migration).not.toContain('CREATE INDEX "sessions_');
     const followUp = await readFile(
@@ -43,6 +41,29 @@ describe("migration 0220 session channels", () => {
     expect(followUp).toContain(
       'CREATE INDEX CONCURRENTLY IF NOT EXISTS "sessions_workspace_channel_idx"',
     );
+    const addForeignKey = await readFile(
+      migrationPath.replace("0220_session_channels.sql", "0222_sessions_channel_fk.sql"),
+      "utf8",
+    );
+    expect(addForeignKey.split(/\r?\n/, 1)[0]).toBe("-- deployment-mode: rolling");
+    expect(addForeignKey).toContain('ADD CONSTRAINT "sessions_channel_id_fk"');
+    expect(addForeignKey).toContain('REFERENCES "channels"("id")');
+    expect(addForeignKey).toContain("ON DELETE SET NULL");
+    expect(addForeignKey).toContain("NOT VALID");
+    expect(addForeignKey).toContain("local_column.attname = 'channel_id'");
+    expect(addForeignKey).toContain("referenced_column.attname = 'id'");
+    expect(addForeignKey).toContain("constraint_row.confdeltype = 'n'");
+    expect(addForeignKey).not.toContain("VALIDATE CONSTRAINT");
+    const validateForeignKey = await readFile(
+      migrationPath.replace("0220_session_channels.sql", "0223_sessions_channel_fk_validate.sql"),
+      "utf8",
+    );
+    expect(validateForeignKey.split(/\r?\n/, 1)[0]).toBe("-- deployment-mode: rolling");
+    expect(validateForeignKey).toContain(`'ALTER TABLE "sessions" VALIDATE CONSTRAINT %I'`);
+    expect(validateForeignKey).toContain("local_column.attname = 'channel_id'");
+    expect(validateForeignKey).toContain("referenced_column.attname = 'id'");
+    expect(validateForeignKey).toContain("constraint_row.confdeltype = 'n'");
+    expect(validateForeignKey).toContain("SET LOCAL statement_timeout = '10min'");
 
     const blank = await acquireBlankTestDatabase("migration-0220");
     if (!blank) {
@@ -68,12 +89,13 @@ describe("migration 0220 session channels", () => {
           and table_name = 'sessions'
           and column_name = 'channel_id'`;
       expect(column).toEqual({ dataType: "uuid", nullable: "YES" });
-      const [fk] = await sql<Array<{ definition: string }>>`
-        select pg_get_constraintdef(oid) as definition
+      const [fk] = await sql<Array<{ definition: string; validated: boolean }>>`
+        select pg_get_constraintdef(oid) as definition, convalidated as validated
         from pg_constraint
         where conrelid = 'sessions'::regclass
           and pg_get_constraintdef(oid) like '%channels%'`;
       expect(fk?.definition).toContain("ON DELETE SET NULL");
+      expect(fk?.validated).toBe(true);
       const indexes = await sql<Array<{ indexname: string }>>`
         select indexname from pg_indexes
         where schemaname = 'public' and tablename = 'channels'`;
@@ -86,6 +108,84 @@ describe("migration 0220 session channels", () => {
           and tablename = 'sessions'
           and indexname = 'sessions_workspace_channel_idx'`;
       expect(sessionsIndex?.indexname).toBe("sessions_workspace_channel_idx");
+    } finally {
+      await sql.end();
+      await blank.release();
+    }
+  }, 180_000);
+
+  test("preserves an already-applied original 0220 foreign key without duplicating it", async () => {
+    const blank = await acquireBlankTestDatabase("migration-0220-original-fk");
+    if (!blank) {
+      if (requireRealDatabase) {
+        throw new Error(
+          "OPENGENI_REQUIRE_REAL_DB=1 but the migration 0220 PostgreSQL harness is unavailable",
+        );
+      }
+      return;
+    }
+    const sql = postgres(blank.databaseUrl, { max: 1 });
+    try {
+      // Build the current schema while withholding the two repair migrations,
+      // then recreate the exact auto-named validated FK produced by the
+      // original inline REFERENCES clause in 0220.
+      await sql.unsafe(`
+        create table schema_migrations (
+          name text primary key,
+          applied_at timestamptz not null default now()
+        )
+      `);
+      await sql`
+        insert into schema_migrations (name)
+        values
+          ('0222_sessions_channel_fk.sql'),
+          ('0223_sessions_channel_fk_validate.sql')`;
+      await migrate(blank.databaseUrl);
+      await sql.unsafe(`
+        alter table "sessions"
+          add constraint "sessions_channel_id_fkey"
+          foreign key ("channel_id")
+          references "channels"("id")
+          on delete set null
+      `);
+      await sql`
+        delete from schema_migrations
+        where name in (
+          '0222_sessions_channel_fk.sql',
+          '0223_sessions_channel_fk_validate.sql'
+        )`;
+
+      await migrate(blank.databaseUrl);
+
+      const constraints = await sql<
+        Array<{ name: string; definition: string; validated: boolean }>
+      >`
+        select
+          conname as name,
+          pg_get_constraintdef(oid) as definition,
+          convalidated as validated
+        from pg_constraint
+        where conrelid = 'sessions'::regclass
+          and pg_get_constraintdef(oid) like '%channels%'
+        order by conname`;
+      expect(constraints).toHaveLength(1);
+      expect(constraints[0]).toEqual({
+        name: "sessions_channel_id_fkey",
+        definition: expect.stringContaining("ON DELETE SET NULL"),
+        validated: true,
+      });
+      const receipts = await sql<Array<{ name: string }>>`
+        select name
+        from schema_migrations
+        where name in (
+          '0222_sessions_channel_fk.sql',
+          '0223_sessions_channel_fk_validate.sql'
+        )
+        order by name`;
+      expect(receipts.map((row) => row.name)).toEqual([
+        "0222_sessions_channel_fk.sql",
+        "0223_sessions_channel_fk_validate.sql",
+      ]);
     } finally {
       await sql.end();
       await blank.release();

--- a/scripts/operator/turn-density-profile.test.ts
+++ b/scripts/operator/turn-density-profile.test.ts
@@ -106,14 +106,14 @@ describe("turn density profile release-gate helpers", () => {
       totalRowCount: 2_304,
       compactionTailRowCount: 49,
       persistentActiveInactiveMix: true,
-      maxActiveRows: 4_096,
+      maxActiveRows: 8_192,
       maxRowsPerTurn: 131_072,
     });
     expect(PRODUCTION_ACTIVE_HISTORY_LIMITS).toEqual({
-      jsonBytes: 3 * 1024 * 1024,
-      rows: 4_096,
-      jsonNodes: 65_536,
-      jsonProperties: 32_768,
+      jsonBytes: 15 * 1024 * 1024,
+      rows: 8_192,
+      jsonNodes: 131_072,
+      jsonProperties: 65_536,
     });
 
     const input = {
@@ -146,8 +146,8 @@ describe("turn density profile release-gate helpers", () => {
     expect(inactive[0]?.position).toBe(active.length);
     expect(active[0]?.item.content[0]?.text).toHaveLength(3_896);
     expect(new Set(active.map((row) => row.item.content[0]?.text)).size).toBe(active.length);
-    expect(() => historyRowShape(4_096 * 512 + 1, 0, 512, 200_000)).toThrow(
-      "active history row count must be at most 4096",
+    expect(() => historyRowShape(8_192 * 512 + 1, 0, 512, 200_000)).toThrow(
+      "active history row count must be at most 8192",
     );
   });
 
@@ -464,7 +464,7 @@ describe("turn density profile release-gate helpers", () => {
     ).toThrow("artifact.workload.history.shape does not match");
 
     const productionLimitAltered = JSON.parse(profileArtifactText());
-    productionLimitAltered.workload.history.productionActiveMaterializationLimits.rows = 8_192;
+    productionLimitAltered.workload.history.productionActiveMaterializationLimits.rows = 4_096;
     expect(() =>
       verifyDensityProfileArtifactText(`${JSON.stringify(productionLimitAltered)}\n`, undefined, {
         allowNoncanonical: true,

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -115,8 +115,8 @@ describe("release schema contract", () => {
       sourceContract.migrations.map((migration) => [migration.path, migration]),
     );
     expect(sourceContract.sha256).toBe(
-      migrations.has("0222_session_visibility_authority_epochs.sql")
-        ? "257511509811c24cc2e60afca38362b9a065924101fcd1df52850b01fbe5fafa"
+      migrations.has("0223_sessions_channel_fk_validate.sql")
+        ? "50aaa2d50bd94121d10fa8978bdb2b6bf1f1ebec1c58ebe902291d8c85b1e452"
         : migrations.has("0221_sessions_channel_index.sql")
           ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
           : migrations.has("0220_memory_slack_append_only_cascade.sql")
@@ -141,8 +141,8 @@ describe("release schema contract", () => {
     );
     const contract = {
       ...sourceContract,
-      sha256: migrations.has("0222_session_visibility_authority_epochs.sql")
-        ? "257511509811c24cc2e60afca38362b9a065924101fcd1df52850b01fbe5fafa"
+      sha256: migrations.has("0223_sessions_channel_fk_validate.sql")
+        ? "50aaa2d50bd94121d10fa8978bdb2b6bf1f1ebec1c58ebe902291d8c85b1e452"
         : migrations.has("0221_sessions_channel_index.sql")
           ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
           : migrations.has("0220_memory_slack_append_only_cascade.sql")
@@ -337,11 +337,13 @@ describe("release schema contract", () => {
         (migrations.has("0219_organization_tenancy_managed_human_provisioning.sql") ? 1 : 0) +
         (migrations.has("0220_session_channels.sql") ? 1 : 0) +
         (migrations.has("0221_sessions_channel_index.sql") ? 1 : 0) +
-        (migrations.has("0222_session_visibility_authority_epochs.sql") ? 1 : 0),
+        (migrations.has("0222_session_visibility_authority_epochs.sql") ? 1 : 0) +
+        (migrations.has("0222_sessions_channel_fk.sql") ? 1 : 0) +
+        (migrations.has("0223_sessions_channel_fk_validate.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(
-      migrations.has("0222_session_visibility_authority_epochs.sql")
-        ? "257511509811c24cc2e60afca38362b9a065924101fcd1df52850b01fbe5fafa"
+      migrations.has("0223_sessions_channel_fk_validate.sql")
+        ? "50aaa2d50bd94121d10fa8978bdb2b6bf1f1ebec1c58ebe902291d8c85b1e452"
         : migrations.has("0221_sessions_channel_index.sql")
           ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
           : migrations.has("0220_memory_slack_append_only_cascade.sql")
@@ -359,8 +361,8 @@ describe("release schema contract", () => {
                 : "2d8e3211f1526419a8421c4388f7cf2297839318d7a7dbd194362d81c503c70a",
     );
     expect(contract.latestMigration).toBe(
-      migrations.has("0222_session_visibility_authority_epochs.sql")
-        ? "0222_session_visibility_authority_epochs.sql"
+      migrations.has("0223_sessions_channel_fk_validate.sql")
+        ? "0223_sessions_channel_fk_validate.sql"
         : migrations.has("0221_sessions_channel_index.sql")
           ? "0221_sessions_channel_index.sql"
           : migrations.has("0220_memory_slack_append_only_cascade.sql")

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -116,7 +116,7 @@ describe("release schema contract", () => {
     );
     expect(sourceContract.sha256).toBe(
       migrations.has("0223_sessions_channel_fk_validate.sql")
-        ? "50aaa2d50bd94121d10fa8978bdb2b6bf1f1ebec1c58ebe902291d8c85b1e452"
+        ? "6bc5dfdf4468f6be4adc5ea7c6ed98397ee865c21a0175106320159b15588a6c"
         : migrations.has("0221_sessions_channel_index.sql")
           ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
           : migrations.has("0220_memory_slack_append_only_cascade.sql")
@@ -142,7 +142,7 @@ describe("release schema contract", () => {
     const contract = {
       ...sourceContract,
       sha256: migrations.has("0223_sessions_channel_fk_validate.sql")
-        ? "50aaa2d50bd94121d10fa8978bdb2b6bf1f1ebec1c58ebe902291d8c85b1e452"
+        ? "6bc5dfdf4468f6be4adc5ea7c6ed98397ee865c21a0175106320159b15588a6c"
         : migrations.has("0221_sessions_channel_index.sql")
           ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
           : migrations.has("0220_memory_slack_append_only_cascade.sql")
@@ -343,7 +343,7 @@ describe("release schema contract", () => {
     );
     expect(contract.sha256).toBe(
       migrations.has("0223_sessions_channel_fk_validate.sql")
-        ? "50aaa2d50bd94121d10fa8978bdb2b6bf1f1ebec1c58ebe902291d8c85b1e452"
+        ? "6bc5dfdf4468f6be4adc5ea7c6ed98397ee865c21a0175106320159b15588a6c"
         : migrations.has("0221_sessions_channel_index.sql")
           ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
           : migrations.has("0220_memory_slack_append_only_cascade.sql")


### PR DESCRIPTION
## Summary

- keep migration 0220's `sessions.channel_id` addition metadata-only
- add the channel foreign key as `NOT VALID`, then validate it in a separate rolling migration
- preserve databases that already applied the original auto-named validated foreign key
- align the turn-density release-gate expectations with the active-history serving envelope already on `main`

## Testing

- [x] `bun run typecheck`
- [ ] `bun test` (full suite pending CI)
- [x] `bun test packages/db/test/migration-0220-session-channels.test.ts scripts/release-schema-contract.test.ts`
- [x] `bun test scripts/operator/turn-density-profile.test.ts`
- [x] `bunx changeset status --output /tmp/changeset-status.json`
- [x] `bun run check:docs-refs`
- [x] `bun run check:public-hygiene`
- [x] `bun run format:check`
- [x] `git diff --check`

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] If `main` advanced, I kept the candidate head frozen and verified current-base mergeability/material compatibility, or documented the actual conflict/incompatibility that required a source change.

## Notes

- The real-PostgreSQL migration test covers both a fresh database and a database carrying the original `sessions_channel_id_fkey` plus migration receipts for 0220/0221.
