### PR TITLE
feat: add personal Codex authority foundation

### DIFF
--- a/.changeset/personal-codex-authority-foundation.md
+++ b/.changeset/personal-codex-authority-foundation.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/contracts": minor
+"@opengeni/db": minor
+---
+
+Add the inert personal Codex provider-account authority foundation and opaque
+accepted-work snapshot contract without activating user-scoped consumption.

--- a/docs/codex-provider-account-authority.md
+++ b/docs/codex-provider-account-authority.md
@@ -1,0 +1,51 @@
+# Codex provider-account authority foundation
+
+Migration `0226_personal_codex_authority_foundation.sql` adds the first inert,
+expand-only storage and contract slice for private-by-default personal Codex
+subscription credentials. It does **not** activate personal credential use.
+
+## Credential authority facts
+
+Every `codex_subscription_credentials` row now has an explicit
+`workspace|user` authority scope. Existing rows and omitted new-writer values
+are classified as `workspace`.
+
+- `workspace` requires null owner-membership and user-resource authority facts.
+- `user` requires one active same-account organization membership and the exact
+  active `organization_user_resource_authorities` tuple whose resource kind is
+  `codex_subscription`, resource id is the credential row id, and generation is
+  the stored positive generation.
+
+The validation trigger intentionally uses invoker rights. The runtime role has
+no direct visibility or DML on the FORCE-RLS organization authority tables, so
+this foundation does not give application code a path to manufacture a
+user-scoped credential. A later activation must add a separately reviewed,
+narrow lifecycle capability.
+
+`connected_by_subject_id`, workspace placement, creator/audit metadata, email,
+label, provider account id, and personal-workspace placement are not ownership
+authority and are never used to derive `user` scope.
+
+## Opaque accepted-work snapshot
+
+`CodexProviderAccountAuthoritySnapshotV1` has exactly two forms:
+
+```text
+{ version: 1, scope: "workspace" }
+{ version: 1, scope: "user", authorityGeneration: <positive safe integer> }
+```
+
+The snapshot contains no subject, organization membership, credential,
+provider-account, or provider identifiers; no label, quota, token, or plan
+metadata; and no independent grant to use a credential. It is stored immutably
+on accepted logical turns, scheduled tasks, system updates, and child-result
+system-update outbox rows. All legacy rows backfill to the workspace form, and
+current writers continue to receive that default.
+
+## Deliberately not activated
+
+This slice does not change credential connection, discovery, listing,
+selection, allocation, leases, token loading or refresh, pin/failover,
+capacity, connected Apps, reset-credit redemption, realtime, transcription,
+usage, billing, or consumption. Those paths remain workspace-scoped until a
+later activation revalidates an opaque snapshot against exact live authority.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -42,6 +42,10 @@
       "types": "./src/video-generation.ts",
       "default": "./src/video-generation.ts"
     },
+    "./codex-provider-account-authority": {
+      "types": "./src/codex-provider-account-authority.ts",
+      "default": "./src/codex-provider-account-authority.ts"
+    },
     "./editable-artifacts": {
       "types": "./src/editable-artifacts.ts",
       "default": "./src/editable-artifacts.ts"

--- a/packages/contracts/src/codex-provider-account-authority.ts
+++ b/packages/contracts/src/codex-provider-account-authority.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+const PositiveSafeInteger = z.number().int().positive().max(Number.MAX_SAFE_INTEGER);
+
+/**
+ * Opaque authority frozen at a Codex provider-account acceptance boundary.
+ *
+ * The snapshot deliberately carries no organization, membership, credential,
+ * provider-account, subject, label, quota, token, or plan identity. A later
+ * activation slice may use the user generation only together with separately
+ * authorized durable state; this value is never sufficient authority alone.
+ */
+export const CodexProviderAccountAuthoritySnapshotV1 = z.discriminatedUnion("scope", [
+  z
+    .object({
+      version: z.literal(1),
+      scope: z.literal("workspace"),
+    })
+    .strict(),
+  z
+    .object({
+      version: z.literal(1),
+      scope: z.literal("user"),
+      authorityGeneration: PositiveSafeInteger,
+    })
+    .strict(),
+]);
+
+export type CodexProviderAccountAuthoritySnapshotV1 = z.infer<
+  typeof CodexProviderAccountAuthoritySnapshotV1
+>;
+
+/** Explicit compatibility value for all pre-foundation accepted work. */
+export const LEGACY_WORKSPACE_CODEX_PROVIDER_ACCOUNT_AUTHORITY_SNAPSHOT_V1 = {
+  version: 1,
+  scope: "workspace",
+} as const satisfies CodexProviderAccountAuthoritySnapshotV1;

--- a/packages/contracts/test/codex-provider-account-authority.test.ts
+++ b/packages/contracts/test/codex-provider-account-authority.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CodexProviderAccountAuthoritySnapshotV1,
+  LEGACY_WORKSPACE_CODEX_PROVIDER_ACCOUNT_AUTHORITY_SNAPSHOT_V1,
+} from "../src/codex-provider-account-authority";
+
+describe("Codex provider-account authority snapshots", () => {
+  test("accepts only the two strict version-one opaque shapes", () => {
+    expect(
+      CodexProviderAccountAuthoritySnapshotV1.parse(
+        LEGACY_WORKSPACE_CODEX_PROVIDER_ACCOUNT_AUTHORITY_SNAPSHOT_V1,
+      ),
+    ).toEqual({ version: 1, scope: "workspace" });
+    expect(
+      CodexProviderAccountAuthoritySnapshotV1.parse({
+        version: 1,
+        scope: "user",
+        authorityGeneration: 7,
+      }),
+    ).toEqual({ version: 1, scope: "user", authorityGeneration: 7 });
+
+    for (const invalid of [
+      {},
+      { version: 2, scope: "workspace" },
+      { version: 1, scope: "user" },
+      { version: 1, scope: "user", authorityGeneration: 0 },
+      { version: 1, scope: "user", authorityGeneration: 1.5 },
+      {
+        version: 1,
+        scope: "workspace",
+        authorityGeneration: 1,
+      },
+    ]) {
+      expect(CodexProviderAccountAuthoritySnapshotV1.safeParse(invalid).success).toBe(false);
+    }
+  });
+
+  test("rejects every identity, provider, credential, quota, token, and plan field", () => {
+    const forbidden = [
+      "subjectId",
+      "organizationMembershipId",
+      "credentialId",
+      "providerAccountId",
+      "provider",
+      "label",
+      "quota",
+      "token",
+      "plan",
+    ];
+    for (const field of forbidden) {
+      expect(
+        CodexProviderAccountAuthoritySnapshotV1.safeParse({
+          version: 1,
+          scope: "user",
+          authorityGeneration: 1,
+          [field]: "must-not-survive",
+        }).success,
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/contracts/tsup.config.ts
+++ b/packages/contracts/tsup.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     "src/document-artifact-query.ts",
     "src/presentation-artifact-commands.ts",
     "src/presentation-artifact-query.ts",
+    "src/codex-provider-account-authority.ts",
     "src/video-generation.ts",
   ],
   format: ["esm"],

--- a/packages/db/drizzle/0226_personal_codex_authority_foundation.sql
+++ b/packages/db/drizzle/0226_personal_codex_authority_foundation.sql
@@ -1,0 +1,365 @@
+-- deployment-mode: rolling
+-- Add the inert, expand-only personal Codex provider-account authority
+-- foundation. Existing credentials and accepted work are explicitly
+-- workspace-scoped. No runtime path discovers, creates, selects, leases,
+-- materializes, consumes, or reports a user-scoped credential in this slice.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+-- Stable tuple lookup for the credential-side validation trigger. This adds no
+-- privilege and does not change the FORCE-RLS lifecycle of the authority table.
+CREATE UNIQUE INDEX IF NOT EXISTS "organization_user_resource_authorities_codex_tuple_idx"
+  ON "organization_user_resource_authorities" (
+    "id",
+    "account_id",
+    "organization_membership_id",
+    "resource_kind",
+    "resource_id",
+    "generation"
+  );
+
+ALTER TABLE "codex_subscription_credentials"
+  ADD COLUMN "authority_scope" text,
+  ADD COLUMN "owner_organization_membership_id" uuid,
+  ADD COLUMN "organization_user_resource_authority_id" uuid,
+  ADD COLUMN "organization_user_resource_kind" text,
+  ADD COLUMN "organization_user_resource_authority_generation" bigint;
+
+-- This UPDATE is intentionally explicit rather than relying on an ADD COLUMN
+-- default: every pre-foundation provider account is classified workspace-only.
+UPDATE "codex_subscription_credentials"
+SET "authority_scope" = 'workspace'
+WHERE "authority_scope" IS NULL;
+
+ALTER TABLE "codex_subscription_credentials"
+  ALTER COLUMN "authority_scope" SET DEFAULT 'workspace',
+  ALTER COLUMN "authority_scope" SET NOT NULL,
+  ADD CONSTRAINT "codex_credentials_authority_scope_chk" CHECK (
+    "authority_scope" IN ('workspace', 'user')
+  ) NOT VALID,
+  ADD CONSTRAINT "codex_credentials_authority_shape_chk" CHECK (
+    (
+      "authority_scope" = 'workspace'
+      AND "owner_organization_membership_id" IS NULL
+      AND "organization_user_resource_authority_id" IS NULL
+      AND "organization_user_resource_kind" IS NULL
+      AND "organization_user_resource_authority_generation" IS NULL
+    ) OR (
+      "authority_scope" = 'user'
+      AND "owner_organization_membership_id" IS NOT NULL
+      AND "organization_user_resource_authority_id" IS NOT NULL
+      AND "organization_user_resource_kind" = 'codex_subscription'
+      AND "organization_user_resource_authority_generation" IS NOT NULL
+      AND "organization_user_resource_authority_generation" > 0
+    )
+  ) NOT VALID,
+  ADD CONSTRAINT "codex_credentials_owner_membership_fk"
+    FOREIGN KEY ("owner_organization_membership_id", "account_id")
+    REFERENCES "organization_memberships"("id", "account_id")
+    ON DELETE RESTRICT NOT VALID,
+  ADD CONSTRAINT "codex_credentials_user_authority_fk"
+    FOREIGN KEY (
+      "organization_user_resource_authority_id",
+      "account_id",
+      "owner_organization_membership_id",
+      "organization_user_resource_kind",
+      "id",
+      "organization_user_resource_authority_generation"
+    )
+    REFERENCES "organization_user_resource_authorities"(
+      "id",
+      "account_id",
+      "organization_membership_id",
+      "resource_kind",
+      "resource_id",
+      "generation"
+    )
+    ON DELETE RESTRICT NOT VALID;
+
+ALTER TABLE "codex_subscription_credentials"
+  VALIDATE CONSTRAINT "codex_credentials_authority_scope_chk",
+  VALIDATE CONSTRAINT "codex_credentials_authority_shape_chk",
+  VALIDATE CONSTRAINT "codex_credentials_owner_membership_fk",
+  VALIDATE CONSTRAINT "codex_credentials_user_authority_fk";
+
+DO $personal_codex_authority_validation$
+DECLARE
+  data_schema text := current_schema();
+BEGIN
+  EXECUTE format($ddl$
+    CREATE OR REPLACE FUNCTION %1$I.validate_personal_codex_credential_authority()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $body$
+    DECLARE
+      exact_authority boolean;
+    BEGIN
+      IF NEW.authority_scope = 'workspace' THEN
+        RETURN NEW;
+      END IF;
+
+      -- Invoker rights are deliberate in this inert slice. The ordinary app
+      -- role has no direct visibility into either organization authority table,
+      -- so it cannot manufacture a user-scoped credential. A later activation
+      -- slice must introduce a separately reviewed narrow lifecycle capability.
+      SELECT true
+      INTO exact_authority
+      FROM %1$I.organization_memberships membership
+      INNER JOIN %1$I.organization_user_resource_authorities authority
+        ON authority.id = NEW.organization_user_resource_authority_id
+       AND authority.account_id = membership.account_id
+       AND authority.organization_membership_id = membership.id
+      WHERE membership.id = NEW.owner_organization_membership_id
+        AND membership.account_id = NEW.account_id
+        AND membership.status = 'active'
+        AND membership.revoked_at IS NULL
+        AND authority.resource_kind = 'codex_subscription'
+        AND authority.resource_id = NEW.id
+        AND authority.generation = NEW.organization_user_resource_authority_generation
+        AND authority.status = 'active'
+        AND authority.revoked_at IS NULL
+      FOR KEY SHARE OF membership, authority;
+
+      IF exact_authority IS DISTINCT FROM true THEN
+        RAISE EXCEPTION 'personal Codex credential authority tuple is invalid'
+          USING ERRCODE = '23514';
+      END IF;
+      RETURN NEW;
+    END;
+    $body$;
+  $ddl$, data_schema);
+
+  EXECUTE format(
+    'DROP TRIGGER IF EXISTS codex_credentials_validate_user_authority_trg ON %I.codex_subscription_credentials',
+    data_schema
+  );
+  EXECUTE format($ddl$
+    CREATE TRIGGER codex_credentials_validate_user_authority_trg
+    BEFORE INSERT OR UPDATE OF
+      id,
+      account_id,
+      authority_scope,
+      owner_organization_membership_id,
+      organization_user_resource_authority_id,
+      organization_user_resource_kind,
+      organization_user_resource_authority_generation
+    ON %1$I.codex_subscription_credentials
+    FOR EACH ROW
+    EXECUTE FUNCTION %1$I.validate_personal_codex_credential_authority()
+  $ddl$, data_schema);
+END
+$personal_codex_authority_validation$;
+
+-- One strict identifier-free snapshot shape is shared by the accepted turn,
+-- scheduled task, and internal-update boundaries. The user variant stores only
+-- the positive authority generation; it is not executable authority by itself.
+DO $codex_provider_account_snapshot_validator$
+DECLARE
+  data_schema text := current_schema();
+BEGIN
+  EXECUTE format($ddl$
+    CREATE OR REPLACE FUNCTION %1$I.codex_provider_account_authority_snapshot_v1_valid(
+      snapshot jsonb
+    )
+    RETURNS boolean
+    LANGUAGE sql
+    IMMUTABLE
+    STRICT
+    AS $body$
+      SELECT
+        snapshot = '{"version":1,"scope":"workspace"}'::jsonb
+        OR (
+          jsonb_typeof(snapshot) = 'object'
+          AND (SELECT count(*) FROM jsonb_object_keys(snapshot)) = 3
+          AND snapshot ?& ARRAY['version', 'scope', 'authorityGeneration']
+          AND snapshot -> 'version' = '1'::jsonb
+          AND snapshot ->> 'scope' = 'user'
+          AND jsonb_typeof(snapshot -> 'authorityGeneration') = 'number'
+          AND snapshot ->> 'authorityGeneration' ~ '^[1-9][0-9]*$'
+          AND (snapshot ->> 'authorityGeneration')::numeric <= 9007199254740991
+        )
+    $body$;
+  $ddl$, data_schema);
+END
+$codex_provider_account_snapshot_validator$;
+
+ALTER TABLE "session_turns"
+  ADD COLUMN "codex_provider_account_authority_snapshot" jsonb;
+ALTER TABLE "scheduled_tasks"
+  ADD COLUMN "codex_provider_account_authority_snapshot" jsonb;
+ALTER TABLE "session_system_updates"
+  ADD COLUMN "codex_provider_account_authority_snapshot" jsonb;
+ALTER TABLE "session_system_update_outbox"
+  ADD COLUMN "codex_provider_account_authority_snapshot" jsonb;
+
+UPDATE "session_turns"
+SET "codex_provider_account_authority_snapshot" = '{"version":1,"scope":"workspace"}'::jsonb
+WHERE "codex_provider_account_authority_snapshot" IS NULL;
+UPDATE "scheduled_tasks"
+SET "codex_provider_account_authority_snapshot" = '{"version":1,"scope":"workspace"}'::jsonb
+WHERE "codex_provider_account_authority_snapshot" IS NULL;
+UPDATE "session_system_updates"
+SET "codex_provider_account_authority_snapshot" = '{"version":1,"scope":"workspace"}'::jsonb
+WHERE "codex_provider_account_authority_snapshot" IS NULL;
+UPDATE "session_system_update_outbox"
+SET "codex_provider_account_authority_snapshot" = '{"version":1,"scope":"workspace"}'::jsonb
+WHERE "codex_provider_account_authority_snapshot" IS NULL;
+
+ALTER TABLE "session_turns"
+  ALTER COLUMN "codex_provider_account_authority_snapshot"
+    SET DEFAULT '{"version":1,"scope":"workspace"}'::jsonb,
+  ALTER COLUMN "codex_provider_account_authority_snapshot" SET NOT NULL,
+  ADD CONSTRAINT "session_turns_codex_authority_snapshot_chk" CHECK (
+    codex_provider_account_authority_snapshot_v1_valid(
+      "codex_provider_account_authority_snapshot"
+    )
+  ) NOT VALID;
+ALTER TABLE "scheduled_tasks"
+  ALTER COLUMN "codex_provider_account_authority_snapshot"
+    SET DEFAULT '{"version":1,"scope":"workspace"}'::jsonb,
+  ALTER COLUMN "codex_provider_account_authority_snapshot" SET NOT NULL,
+  ADD CONSTRAINT "scheduled_tasks_codex_authority_snapshot_chk" CHECK (
+    codex_provider_account_authority_snapshot_v1_valid(
+      "codex_provider_account_authority_snapshot"
+    )
+  ) NOT VALID;
+ALTER TABLE "session_system_updates"
+  ALTER COLUMN "codex_provider_account_authority_snapshot"
+    SET DEFAULT '{"version":1,"scope":"workspace"}'::jsonb,
+  ALTER COLUMN "codex_provider_account_authority_snapshot" SET NOT NULL,
+  ADD CONSTRAINT "session_updates_codex_authority_snapshot_chk" CHECK (
+    codex_provider_account_authority_snapshot_v1_valid(
+      "codex_provider_account_authority_snapshot"
+    )
+  ) NOT VALID;
+ALTER TABLE "session_system_update_outbox"
+  ALTER COLUMN "codex_provider_account_authority_snapshot"
+    SET DEFAULT '{"version":1,"scope":"workspace"}'::jsonb,
+  ALTER COLUMN "codex_provider_account_authority_snapshot" SET NOT NULL,
+  ADD CONSTRAINT "system_update_outbox_codex_authority_snapshot_chk" CHECK (
+    codex_provider_account_authority_snapshot_v1_valid(
+      "codex_provider_account_authority_snapshot"
+    )
+  ) NOT VALID;
+
+ALTER TABLE "session_turns"
+  VALIDATE CONSTRAINT "session_turns_codex_authority_snapshot_chk";
+ALTER TABLE "scheduled_tasks"
+  VALIDATE CONSTRAINT "scheduled_tasks_codex_authority_snapshot_chk";
+ALTER TABLE "session_system_updates"
+  VALIDATE CONSTRAINT "session_updates_codex_authority_snapshot_chk";
+ALTER TABLE "session_system_update_outbox"
+  VALIDATE CONSTRAINT "system_update_outbox_codex_authority_snapshot_chk";
+
+DO $codex_provider_account_snapshot_immutability$
+DECLARE
+  data_schema text := current_schema();
+BEGIN
+  EXECUTE format($ddl$
+    CREATE OR REPLACE FUNCTION %1$I.prevent_codex_provider_account_authority_snapshot_mutation()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $body$
+    BEGIN
+      IF NEW.codex_provider_account_authority_snapshot
+        IS DISTINCT FROM OLD.codex_provider_account_authority_snapshot
+      THEN
+        RAISE EXCEPTION '%% Codex provider-account authority snapshot is immutable', TG_TABLE_NAME
+          USING ERRCODE = '23514';
+      END IF;
+      RETURN NEW;
+    END;
+    $body$;
+  $ddl$, data_schema);
+
+  EXECUTE format($ddl$
+    CREATE TRIGGER session_turns_codex_authority_snapshot_immutable_trg
+    BEFORE UPDATE OF codex_provider_account_authority_snapshot
+    ON %1$I.session_turns
+    FOR EACH ROW
+    EXECUTE FUNCTION %1$I.prevent_codex_provider_account_authority_snapshot_mutation()
+  $ddl$, data_schema);
+  EXECUTE format($ddl$
+    CREATE TRIGGER scheduled_tasks_codex_authority_snapshot_immutable_trg
+    BEFORE UPDATE OF codex_provider_account_authority_snapshot
+    ON %1$I.scheduled_tasks
+    FOR EACH ROW
+    EXECUTE FUNCTION %1$I.prevent_codex_provider_account_authority_snapshot_mutation()
+  $ddl$, data_schema);
+  EXECUTE format($ddl$
+    CREATE TRIGGER session_updates_codex_authority_snapshot_immutable_trg
+    BEFORE UPDATE OF codex_provider_account_authority_snapshot
+    ON %1$I.session_system_updates
+    FOR EACH ROW
+    EXECUTE FUNCTION %1$I.prevent_codex_provider_account_authority_snapshot_mutation()
+  $ddl$, data_schema);
+  EXECUTE format($ddl$
+    CREATE TRIGGER system_update_outbox_codex_authority_snapshot_immutable_trg
+    BEFORE UPDATE OF codex_provider_account_authority_snapshot
+    ON %1$I.session_system_update_outbox
+    FOR EACH ROW
+    EXECUTE FUNCTION %1$I.prevent_codex_provider_account_authority_snapshot_mutation()
+  $ddl$, data_schema);
+END
+$codex_provider_account_snapshot_immutability$;
+
+-- Preserve the snapshot across the existing global child-result outbox claim.
+-- Returning one additive column is rolling-safe for old consumers and gives a
+-- future activation slice the exact stored boundary rather than a re-derived
+-- ambient value.
+DROP FUNCTION opengeni_private.claim_session_system_update_outbox(integer);
+CREATE FUNCTION opengeni_private.claim_session_system_update_outbox(p_limit integer)
+RETURNS TABLE (
+  id uuid, account_id uuid, workspace_id uuid, source_session_id uuid,
+  target_session_id uuid, dedupe_key text, kind text, classification text,
+  source_id text, summary text, summary_codec_version integer,
+  payload jsonb, payload_codec_version integer, lineage jsonb,
+  personal_connection_delegations jsonb,
+  codex_provider_account_authority_snapshot jsonb
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+BEGIN
+  RETURN QUERY
+    WITH claimed AS (
+      SELECT o.id FROM session_system_update_outbox o
+      WHERE o.status = 'pending'
+      ORDER BY o.created_at, o.id
+      FOR UPDATE SKIP LOCKED
+      LIMIT greatest(1, least(coalesce(p_limit, 100), 100))
+    )
+    UPDATE session_system_update_outbox o
+    SET attempts = o.attempts + 1, updated_at = now()
+    FROM claimed c WHERE o.id = c.id
+    RETURNING o.id, o.account_id, o.workspace_id, o.source_session_id,
+      o.target_session_id, o.dedupe_key, o.kind, o.classification,
+      o.source_id, o.summary, o.summary_codec_version,
+      o.payload, o.payload_codec_version, o.lineage,
+      o.personal_connection_delegations,
+      o.codex_provider_account_authority_snapshot;
+END
+$function$;
+REVOKE ALL ON FUNCTION opengeni_private.claim_session_system_update_outbox(integer) FROM PUBLIC;
+DO $system_update_outbox_role_grant$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT EXECUTE ON FUNCTION opengeni_private.claim_session_system_update_outbox(integer)
+      TO opengeni_app;
+  END IF;
+END
+$system_update_outbox_role_grant$;
+
+COMMENT ON COLUMN "codex_subscription_credentials"."authority_scope" IS
+  'Explicit workspace/user ownership fact. Existing and ordinary runtime-created rows remain workspace.';
+COMMENT ON COLUMN "codex_subscription_credentials"."connected_by_subject_id" IS
+  'Connection audit/redemption attribution only; never Codex credential ownership authority.';
+COMMENT ON COLUMN "session_turns"."codex_provider_account_authority_snapshot" IS
+  'Opaque identifier-free Codex provider-account authority snapshot; inert until a later activation slice.';
+COMMENT ON COLUMN "scheduled_tasks"."codex_provider_account_authority_snapshot" IS
+  'Opaque identifier-free Codex provider-account authority snapshot; legacy and current writers default workspace.';
+COMMENT ON COLUMN "session_system_updates"."codex_provider_account_authority_snapshot" IS
+  'Opaque identifier-free Codex provider-account authority snapshot for an accepted internal update.';
+COMMENT ON COLUMN "session_system_update_outbox"."codex_provider_account_authority_snapshot" IS
+  'Opaque identifier-free Codex provider-account authority snapshot for child-result delivery provenance.';

--- a/packages/db/test/migration-0226-personal-codex-authority-foundation.test.ts
+++ b/packages/db/test/migration-0226-personal-codex-authority-foundation.test.ts
@@ -1,0 +1,371 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import postgres from "postgres";
+
+const migrationPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../drizzle/0226_personal_codex_authority_foundation.sql",
+);
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+
+let migration = "";
+let shared: SharedTestDatabase | null = null;
+let app: ReturnType<typeof postgres> | null = null;
+
+async function expectSqlState(action: () => Promise<unknown>, state: string): Promise<void> {
+  let failure: unknown;
+  try {
+    await action();
+  } catch (error) {
+    failure = error;
+  }
+  expect((failure as { code?: string } | undefined)?.code).toBe(state);
+}
+
+async function setAppContext(accountId: string, workspaceId: string): Promise<void> {
+  if (!app) throw new Error("application database unavailable");
+  await app`select set_config('opengeni.account_id', ${accountId}, false)`;
+  await app`select set_config('opengeni.workspace_id', ${workspaceId}, false)`;
+}
+
+beforeAll(async () => {
+  migration = await readFile(migrationPath, "utf8");
+  shared = await acquireSharedTestDatabase("migration-0226-personal-codex-authority-foundation");
+  if (!shared && requireRealDatabase) {
+    throw new Error(
+      "[migration-0226-personal-codex-authority-foundation] OPENGENI_REQUIRE_REAL_DB=1 but PostgreSQL is unavailable",
+    );
+  }
+  if (shared) app = postgres(shared.appUrl, { max: 4 });
+}, 180_000);
+
+afterAll(async () => {
+  await app?.end().catch(() => undefined);
+  await shared?.release();
+}, 180_000);
+
+describe("migration 0226 personal Codex authority foundation", () => {
+  test("is rolling, explicit, inert, and identifier-free at the snapshot boundary", () => {
+    expect(migration.split(/\r?\n/u, 1)[0]).toBe("-- deployment-mode: rolling");
+    const backfill = migration.indexOf('UPDATE "codex_subscription_credentials"');
+    const notNull = migration.indexOf('ALTER COLUMN "authority_scope" SET NOT NULL');
+    expect(backfill).toBeGreaterThanOrEqual(0);
+    expect(notNull).toBeGreaterThan(backfill);
+    expect(migration).toContain("authority.status = 'active'");
+    expect(migration).toContain("authority.resource_kind = 'codex_subscription'");
+    expect(migration).toContain("authority.resource_id = NEW.id");
+    expect(migration).toContain(
+      "authority.generation = NEW.organization_user_resource_authority_generation",
+    );
+    expect(migration).not.toContain("connected_by_subject_id =");
+    expect(migration).not.toContain("INSERT INTO organization_user_resource_authorities");
+    expect(migration).not.toContain("INSERT INTO organization_user_resource_grants");
+    expect(migration).not.toContain("GRANT SELECT");
+    expect(migration).not.toContain("GRANT INSERT");
+    expect(migration).not.toContain("GRANT UPDATE");
+    expect(migration).not.toContain("GRANT DELETE");
+    for (const forbidden of [
+      "subjectId",
+      "membershipId",
+      "credentialId",
+      "providerAccountId",
+      '"label"',
+      '"quota"',
+      '"token"',
+      '"plan"',
+    ]) {
+      expect(
+        migration.slice(
+          migration.indexOf("codex_provider_account_authority_snapshot_v1_valid"),
+          migration.indexOf("COMMENT ON COLUMN"),
+        ),
+      ).not.toContain(forbidden);
+    }
+  });
+
+  test("keeps legacy and omitted runtime rows workspace-scoped", async () => {
+    if (!shared || !app) return;
+    const [account] = await shared.admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('personal-codex-workspace-default') returning id`;
+    const [workspace] = await shared.admin<{ id: string }[]>`
+      insert into workspaces (account_id, name)
+      values (${account!.id}, 'personal-codex-workspace-default') returning id`;
+    await shared.admin`
+      insert into workspace_inference_controls (workspace_id, account_id)
+      values (${workspace!.id}, ${account!.id})`;
+    await setAppContext(account!.id, workspace!.id);
+    const [credential] = await app<{ id: string }[]>`
+      insert into codex_subscription_credentials (
+        account_id, workspace_id, credential_encrypted, status
+      ) values (
+        ${account!.id}, ${workspace!.id}, 'ciphertext', 'active'
+      ) returning id`;
+    const [stored] = await shared.admin<
+      Array<{
+        scope: string;
+        owner: string | null;
+        authority: string | null;
+        kind: string | null;
+        generation: number | null;
+      }>
+    >`
+      select authority_scope as scope,
+        owner_organization_membership_id as owner,
+        organization_user_resource_authority_id as authority,
+        organization_user_resource_kind as kind,
+        organization_user_resource_authority_generation as generation
+      from codex_subscription_credentials where id = ${credential!.id}`;
+    expect(stored).toEqual({
+      scope: "workspace",
+      owner: null,
+      authority: null,
+      kind: null,
+      generation: null,
+    });
+  });
+
+  test("binds user scope to the exact active same-account membership/resource/generation tuple", async () => {
+    if (!shared) return;
+    const [account] = await shared.admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('personal-codex-user-authority') returning id`;
+    const [workspace] = await shared.admin<{ id: string }[]>`
+      insert into workspaces (account_id, name)
+      values (${account!.id}, 'personal-codex-user-authority') returning id`;
+    const membershipId = crypto.randomUUID();
+    await shared.admin`
+      insert into organization_memberships (
+        id, account_id, subject_id, status, personal_workspace_id
+      ) values (
+        ${membershipId}, ${account!.id}, ${`user:${crypto.randomUUID()}`}, 'active', ${workspace!.id}
+      )`;
+
+    const credentialId = crypto.randomUUID();
+    const authorityId = crypto.randomUUID();
+    await shared.admin`
+      insert into organization_user_resource_authorities (
+        id, account_id, organization_membership_id, resource_kind,
+        resource_id, origin_workspace_id, generation, status
+      ) values (
+        ${authorityId}, ${account!.id}, ${membershipId}, 'codex_subscription',
+        ${credentialId}, ${workspace!.id}, 9, 'active'
+      )`;
+    await shared.admin`
+      insert into codex_subscription_credentials (
+        id, account_id, workspace_id, credential_encrypted, status,
+        authority_scope, owner_organization_membership_id,
+        organization_user_resource_authority_id,
+        organization_user_resource_kind,
+        organization_user_resource_authority_generation
+      ) values (
+        ${credentialId}, ${account!.id}, ${workspace!.id}, 'ciphertext', 'active',
+        'user', ${membershipId}, ${authorityId}, 'codex_subscription', 9
+      )`;
+
+    await expectSqlState(
+      () =>
+        shared!.admin`
+          update codex_subscription_credentials
+          set organization_user_resource_authority_generation = 10
+          where id = ${credentialId}`,
+      "23514",
+    );
+    await expectSqlState(
+      () =>
+        shared!.admin`
+          update organization_user_resource_authorities
+          set resource_kind = 'variable_set'
+          where id = ${authorityId}`,
+      "23503",
+    );
+
+    const otherCredentialId = crypto.randomUUID();
+    await expectSqlState(
+      () =>
+        shared!.admin`
+          insert into codex_subscription_credentials (
+            id, account_id, workspace_id, credential_encrypted, status,
+            authority_scope, owner_organization_membership_id,
+            organization_user_resource_authority_id,
+            organization_user_resource_kind,
+            organization_user_resource_authority_generation
+          ) values (
+            ${otherCredentialId}, ${account!.id}, ${workspace!.id}, 'ciphertext', 'active',
+            'user', ${membershipId}, ${authorityId}, 'codex_subscription', 9
+          )`,
+      "23514",
+    );
+    await expectSqlState(
+      () =>
+        shared!.admin`
+          insert into codex_subscription_credentials (
+            account_id, workspace_id, credential_encrypted, status, authority_scope
+          ) values (${account!.id}, ${workspace!.id}, 'ciphertext', 'active', 'user')`,
+      "23514",
+    );
+  });
+
+  test("does not let the application role manufacture user scope", async () => {
+    if (!shared || !app) return;
+    const [account] = await shared.admin<{ id: string }[]>`
+      insert into managed_accounts (name) values ('personal-codex-app-deny') returning id`;
+    const [workspace] = await shared.admin<{ id: string }[]>`
+      insert into workspaces (account_id, name)
+      values (${account!.id}, 'personal-codex-app-deny') returning id`;
+    await shared.admin`
+      insert into workspace_inference_controls (workspace_id, account_id)
+      values (${workspace!.id}, ${account!.id})`;
+    const membershipId = crypto.randomUUID();
+    const credentialId = crypto.randomUUID();
+    const authorityId = crypto.randomUUID();
+    await shared.admin`
+      insert into organization_memberships (
+        id, account_id, subject_id, status, personal_workspace_id
+      ) values (
+        ${membershipId}, ${account!.id}, ${`user:${crypto.randomUUID()}`}, 'active', ${workspace!.id}
+      )`;
+    await shared.admin`
+      insert into organization_user_resource_authorities (
+        id, account_id, organization_membership_id, resource_kind,
+        resource_id, origin_workspace_id, generation, status
+      ) values (
+        ${authorityId}, ${account!.id}, ${membershipId}, 'codex_subscription',
+        ${credentialId}, ${workspace!.id}, 1, 'active'
+      )`;
+    await setAppContext(account!.id, workspace!.id);
+    await expectSqlState(
+      () =>
+        app!`
+          insert into codex_subscription_credentials (
+            id, account_id, workspace_id, credential_encrypted, status,
+            authority_scope, owner_organization_membership_id,
+            organization_user_resource_authority_id,
+            organization_user_resource_kind,
+            organization_user_resource_authority_generation
+          ) values (
+            ${credentialId}, ${account!.id}, ${workspace!.id}, 'ciphertext', 'active',
+            'user', ${membershipId}, ${authorityId}, 'codex_subscription', 1
+          )`,
+      "42501",
+    );
+  });
+
+  test("enforces strict immutable snapshots on every accepted-work boundary", async () => {
+    if (!shared) return;
+    const rows = await shared.admin<
+      Array<{ tableName: string; columnDefault: string; nullable: string }>
+    >`
+      select table_name as "tableName", column_default as "columnDefault", is_nullable as nullable
+      from information_schema.columns
+      where table_schema = current_schema()
+        and column_name = 'codex_provider_account_authority_snapshot'
+        and table_name = any(array[
+          'session_turns', 'scheduled_tasks', 'session_system_updates',
+          'session_system_update_outbox'
+        ]::text[])
+      order by table_name`;
+    expect(rows).toHaveLength(4);
+    for (const row of rows) {
+      expect(row.nullable).toBe("NO");
+      expect(row.columnDefault).toContain('"scope": "workspace"');
+    }
+
+    const samples = [
+      { name: "empty", value: {}, valid: false },
+      { name: "workspace", value: { version: 1, scope: "workspace" }, valid: true },
+      {
+        name: "workspace with generation",
+        value: { version: 1, scope: "workspace", authorityGeneration: 1 },
+        valid: false,
+      },
+      {
+        name: "user",
+        value: { version: 1, scope: "user", authorityGeneration: 7 },
+        valid: true,
+      },
+      {
+        name: "user with zero generation",
+        value: { version: 1, scope: "user", authorityGeneration: 0 },
+        valid: false,
+      },
+      {
+        name: "user with identifier",
+        value: {
+          version: 1,
+          scope: "user",
+          authorityGeneration: 1,
+          credentialId: crypto.randomUUID(),
+        },
+        valid: false,
+      },
+    ];
+    for (const sample of samples) {
+      const [result] = await shared.admin<{ valid: boolean }[]>`
+        select codex_provider_account_authority_snapshot_v1_valid(
+          ${shared.admin.json(sample.value)}
+        ) as valid`;
+      expect({ name: sample.name, valid: result?.valid }).toEqual({
+        name: sample.name,
+        valid: sample.valid,
+      });
+    }
+
+    const triggerRows = await shared.admin<{ tableName: string }[]>`
+      select event_object_table as "tableName"
+      from information_schema.triggers
+      where trigger_name = any(array[
+        'session_turns_codex_authority_snapshot_immutable_trg',
+        'scheduled_tasks_codex_authority_snapshot_immutable_trg',
+        'session_updates_codex_authority_snapshot_immutable_trg',
+        'system_update_outbox_codex_authority_snapshot_immutable_trg'
+      ]::text[])
+      order by event_object_table`;
+    expect(triggerRows.map((row) => row.tableName)).toEqual([
+      "scheduled_tasks",
+      "session_system_update_outbox",
+      "session_system_updates",
+      "session_turns",
+    ]);
+  });
+
+  test("preserves FORCE RLS and zero direct app DML on organization authority tables", async () => {
+    if (!shared) return;
+    const rows = await shared.admin<
+      Array<{
+        tableName: string;
+        rls: boolean;
+        forceRls: boolean;
+        selectPrivilege: boolean;
+        insertPrivilege: boolean;
+        updatePrivilege: boolean;
+        deletePrivilege: boolean;
+      }>
+    >`
+      select c.relname as "tableName", c.relrowsecurity as rls,
+        c.relforcerowsecurity as "forceRls",
+        has_table_privilege('opengeni_app', c.oid, 'SELECT') as "selectPrivilege",
+        has_table_privilege('opengeni_app', c.oid, 'INSERT') as "insertPrivilege",
+        has_table_privilege('opengeni_app', c.oid, 'UPDATE') as "updatePrivilege",
+        has_table_privilege('opengeni_app', c.oid, 'DELETE') as "deletePrivilege"
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = current_schema()
+        and c.relname = any(array[
+          'organization_user_resource_authorities', 'organization_user_resource_grants'
+        ]::text[])
+      order by c.relname`;
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row).toMatchObject({
+        rls: true,
+        forceRls: true,
+        selectPrivilege: false,
+        insertPrivilege: false,
+        updatePrivilege: false,
+        deletePrivilege: false,
+      });
+    }
+  });
+});

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -116,66 +116,82 @@ describe("release schema contract", () => {
     );
     expect(sourceContract.sha256).toBe(
       migrations.has("0228_slack_task_policy.sql")
-        ? "bbedea10fef52aeaf32d6e16c27d1042a9f68483ba54c241f5184659e86b3c89"
+        ? migrations.has("0226_personal_codex_authority_foundation.sql")
+          ? "7b7fd3a19e1e2a9b5cf98b8ad8e5720f1e3c329ad42f9f012172b028c26e8363"
+          : "bbedea10fef52aeaf32d6e16c27d1042a9f68483ba54c241f5184659e86b3c89"
         : migrations.has("0227_slack_native_actions.sql")
-          ? "32e38ffe1fce657245e30bf413e594f84d967ef68ff9bc4cbd8e08e2bb5ebffc"
-          : migrations.has("0224_slack_post_outcome_reconciliation.sql")
-            ? "8c742400ca1e21ddc4fe1db810d58af7dca037df360406fc71dbd85205eb5a64"
-            : migrations.has("0223_sessions_channel_fk_validate.sql")
-              ? "6bc5dfdf4468f6be4adc5ea7c6ed98397ee865c21a0175106320159b15588a6c"
-              : migrations.has("0221_sessions_channel_index.sql")
-                ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
-                : migrations.has("0220_memory_slack_append_only_cascade.sql")
-                  ? migrations.has("0219_organization_tenancy_managed_human_provisioning.sql")
-                    ? "c9821a930c52d8c40604b9d2f39408227b377f3b2d70b4bb74c14ef93f605756"
-                    : migrations.has("0218_organization_tenancy_foundation.sql")
-                      ? "d78d099f9393a3dcf7d8b54fd75d155448f1a3846712c0aee41d58e7b92b6e9b"
-                      : "85c02e09061ba359a0fa747b1ccffa87a5dd115cbfd8f36ad90c62292ef27bba"
-                  : migrations.has("0219_site_auth_maintenance_sessions.sql")
-                    ? migrations.has("0218_organization_tenancy_foundation.sql")
-                      ? "a002c6b3da822dfff2aca5fd88e76371ecadf87e1fc0c9f5a603b674f67676d1"
-                      : "67238deb9f46f6459e46c882a4dd5231b0ba739f715dfc9e51d8539f54ff3039"
-                    : migrations.has("0218_organization_tenancy_foundation.sql")
-                      ? "eb6d0099f5362add0eb799641deace18326831ac61c8922c3f4f91c6a489f6a9"
-                      : migrations.has("0217_capability_definition_delete_authority.sql")
-                        ? "2d8e3211f1526419a8421c4388f7cf2297839318d7a7dbd194362d81c503c70a"
-                        : migrations.has("0216_pack_component_ownership.sql")
-                          ? "85a5f5320fd7c673bfe16240d4615b93ce635e9724d8f1bc467ce336e5c93022"
-                          : migrations.has("0214_session_activity_commit_gate.sql")
-                            ? "00b9989ef287e75bceceabc94ddfa1c118a97553ccdbc523485300046058075f"
-                            : "e3048091a81b7e122b3c6d17cf52e5ffccff4c082780f6d2d330031742aef792",
+          ? migrations.has("0226_personal_codex_authority_foundation.sql")
+            ? "fb41447bb063da5239197ceb5dc0c179427cc08f6593b77e5c18b98f85804dab"
+            : "32e38ffe1fce657245e30bf413e594f84d967ef68ff9bc4cbd8e08e2bb5ebffc"
+          : migrations.has("0226_personal_codex_authority_foundation.sql")
+            ? migrations.has("0224_slack_post_outcome_reconciliation.sql")
+              ? "b2daba323004014d21b87f53eb20993fda4216c249cd2c07e15a9fdab294742c"
+              : "ad366c52845dde14bc42d9c42e93e02c72ba916b6e7ab7ec15d7e2d5f2f5f14f"
+            : migrations.has("0224_slack_post_outcome_reconciliation.sql")
+              ? "8c742400ca1e21ddc4fe1db810d58af7dca037df360406fc71dbd85205eb5a64"
+              : migrations.has("0223_sessions_channel_fk_validate.sql")
+                ? "6bc5dfdf4468f6be4adc5ea7c6ed98397ee865c21a0175106320159b15588a6c"
+                : migrations.has("0221_sessions_channel_index.sql")
+                  ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
+                  : migrations.has("0220_memory_slack_append_only_cascade.sql")
+                    ? migrations.has("0219_organization_tenancy_managed_human_provisioning.sql")
+                      ? "c9821a930c52d8c40604b9d2f39408227b377f3b2d70b4bb74c14ef93f605756"
+                      : migrations.has("0218_organization_tenancy_foundation.sql")
+                        ? "d78d099f9393a3dcf7d8b54fd75d155448f1a3846712c0aee41d58e7b92b6e9b"
+                        : "85c02e09061ba359a0fa747b1ccffa87a5dd115cbfd8f36ad90c62292ef27bba"
+                    : migrations.has("0219_site_auth_maintenance_sessions.sql")
+                      ? migrations.has("0218_organization_tenancy_foundation.sql")
+                        ? "a002c6b3da822dfff2aca5fd88e76371ecadf87e1fc0c9f5a603b674f67676d1"
+                        : "67238deb9f46f6459e46c882a4dd5231b0ba739f715dfc9e51d8539f54ff3039"
+                      : migrations.has("0218_organization_tenancy_foundation.sql")
+                        ? "eb6d0099f5362add0eb799641deace18326831ac61c8922c3f4f91c6a489f6a9"
+                        : migrations.has("0217_capability_definition_delete_authority.sql")
+                          ? "2d8e3211f1526419a8421c4388f7cf2297839318d7a7dbd194362d81c503c70a"
+                          : migrations.has("0216_pack_component_ownership.sql")
+                            ? "85a5f5320fd7c673bfe16240d4615b93ce635e9724d8f1bc467ce336e5c93022"
+                            : migrations.has("0214_session_activity_commit_gate.sql")
+                              ? "00b9989ef287e75bceceabc94ddfa1c118a97553ccdbc523485300046058075f"
+                              : "e3048091a81b7e122b3c6d17cf52e5ffccff4c082780f6d2d330031742aef792",
     );
     const contract = {
       ...sourceContract,
       sha256: migrations.has("0228_slack_task_policy.sql")
-        ? "bbedea10fef52aeaf32d6e16c27d1042a9f68483ba54c241f5184659e86b3c89"
+        ? migrations.has("0226_personal_codex_authority_foundation.sql")
+          ? "7b7fd3a19e1e2a9b5cf98b8ad8e5720f1e3c329ad42f9f012172b028c26e8363"
+          : "bbedea10fef52aeaf32d6e16c27d1042a9f68483ba54c241f5184659e86b3c89"
         : migrations.has("0227_slack_native_actions.sql")
-          ? "32e38ffe1fce657245e30bf413e594f84d967ef68ff9bc4cbd8e08e2bb5ebffc"
-          : migrations.has("0224_slack_post_outcome_reconciliation.sql")
-            ? "8c742400ca1e21ddc4fe1db810d58af7dca037df360406fc71dbd85205eb5a64"
-            : migrations.has("0223_sessions_channel_fk_validate.sql")
-              ? "6bc5dfdf4468f6be4adc5ea7c6ed98397ee865c21a0175106320159b15588a6c"
-              : migrations.has("0221_sessions_channel_index.sql")
-                ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
-                : migrations.has("0220_memory_slack_append_only_cascade.sql")
-                  ? migrations.has("0219_organization_tenancy_managed_human_provisioning.sql")
-                    ? "c9821a930c52d8c40604b9d2f39408227b377f3b2d70b4bb74c14ef93f605756"
-                    : migrations.has("0218_organization_tenancy_foundation.sql")
-                      ? "d78d099f9393a3dcf7d8b54fd75d155448f1a3846712c0aee41d58e7b92b6e9b"
-                      : "85c02e09061ba359a0fa747b1ccffa87a5dd115cbfd8f36ad90c62292ef27bba"
-                  : migrations.has("0219_site_auth_maintenance_sessions.sql")
-                    ? migrations.has("0218_organization_tenancy_foundation.sql")
-                      ? "a002c6b3da822dfff2aca5fd88e76371ecadf87e1fc0c9f5a603b674f67676d1"
-                      : "67238deb9f46f6459e46c882a4dd5231b0ba739f715dfc9e51d8539f54ff3039"
-                    : migrations.has("0218_organization_tenancy_foundation.sql")
-                      ? "eb6d0099f5362add0eb799641deace18326831ac61c8922c3f4f91c6a489f6a9"
-                      : migrations.has("0217_capability_definition_delete_authority.sql")
-                        ? "2d8e3211f1526419a8421c4388f7cf2297839318d7a7dbd194362d81c503c70a"
-                        : migrations.has("0216_pack_component_ownership.sql")
-                          ? "85a5f5320fd7c673bfe16240d4615b93ce635e9724d8f1bc467ce336e5c93022"
-                          : migrations.has("0214_session_activity_commit_gate.sql")
-                            ? "a00d56c13f4f03a3a48456860a7c63b82de5624970b3afae250e5aed0d6a2d89"
-                            : "c9b19caabb946d91e6e2ec4b34bb48323a61efbfc76628fe338a277f5dcbe343",
+          ? migrations.has("0226_personal_codex_authority_foundation.sql")
+            ? "fb41447bb063da5239197ceb5dc0c179427cc08f6593b77e5c18b98f85804dab"
+            : "32e38ffe1fce657245e30bf413e594f84d967ef68ff9bc4cbd8e08e2bb5ebffc"
+          : migrations.has("0226_personal_codex_authority_foundation.sql")
+            ? migrations.has("0224_slack_post_outcome_reconciliation.sql")
+              ? "b2daba323004014d21b87f53eb20993fda4216c249cd2c07e15a9fdab294742c"
+              : "ad366c52845dde14bc42d9c42e93e02c72ba916b6e7ab7ec15d7e2d5f2f5f14f"
+            : migrations.has("0224_slack_post_outcome_reconciliation.sql")
+              ? "8c742400ca1e21ddc4fe1db810d58af7dca037df360406fc71dbd85205eb5a64"
+              : migrations.has("0223_sessions_channel_fk_validate.sql")
+                ? "6bc5dfdf4468f6be4adc5ea7c6ed98397ee865c21a0175106320159b15588a6c"
+                : migrations.has("0221_sessions_channel_index.sql")
+                  ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
+                  : migrations.has("0220_memory_slack_append_only_cascade.sql")
+                    ? migrations.has("0219_organization_tenancy_managed_human_provisioning.sql")
+                      ? "c9821a930c52d8c40604b9d2f39408227b377f3b2d70b4bb74c14ef93f605756"
+                      : migrations.has("0218_organization_tenancy_foundation.sql")
+                        ? "d78d099f9393a3dcf7d8b54fd75d155448f1a3846712c0aee41d58e7b92b6e9b"
+                        : "85c02e09061ba359a0fa747b1ccffa87a5dd115cbfd8f36ad90c62292ef27bba"
+                    : migrations.has("0219_site_auth_maintenance_sessions.sql")
+                      ? migrations.has("0218_organization_tenancy_foundation.sql")
+                        ? "a002c6b3da822dfff2aca5fd88e76371ecadf87e1fc0c9f5a603b674f67676d1"
+                        : "67238deb9f46f6459e46c882a4dd5231b0ba739f715dfc9e51d8539f54ff3039"
+                      : migrations.has("0218_organization_tenancy_foundation.sql")
+                        ? "eb6d0099f5362add0eb799641deace18326831ac61c8922c3f4f91c6a489f6a9"
+                        : migrations.has("0217_capability_definition_delete_authority.sql")
+                          ? "2d8e3211f1526419a8421c4388f7cf2297839318d7a7dbd194362d81c503c70a"
+                          : migrations.has("0216_pack_component_ownership.sql")
+                            ? "85a5f5320fd7c673bfe16240d4615b93ce635e9724d8f1bc467ce336e5c93022"
+                            : migrations.has("0214_session_activity_commit_gate.sql")
+                              ? "a00d56c13f4f03a3a48456860a7c63b82de5624970b3afae250e5aed0d6a2d89"
+                              : "c9b19caabb946d91e6e2ec4b34bb48323a61efbfc76628fe338a277f5dcbe343",
     };
     expect(migrations.get("0065_codex_subscription_overview.sql")).toMatchObject({
       deploymentMode: "maintenance",
@@ -353,33 +369,42 @@ describe("release schema contract", () => {
         (migrations.has("0222_sessions_channel_fk.sql") ? 1 : 0) +
         (migrations.has("0223_sessions_channel_fk_validate.sql") ? 1 : 0) +
         (migrations.has("0224_slack_post_outcome_reconciliation.sql") ? 1 : 0) +
+        (migrations.has("0226_personal_codex_authority_foundation.sql") ? 1 : 0) +
         (migrations.has("0227_slack_native_actions.sql") ? 1 : 0) +
         (migrations.has("0228_slack_task_policy.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(
       migrations.has("0228_slack_task_policy.sql")
-        ? "bbedea10fef52aeaf32d6e16c27d1042a9f68483ba54c241f5184659e86b3c89"
+        ? migrations.has("0226_personal_codex_authority_foundation.sql")
+          ? "7b7fd3a19e1e2a9b5cf98b8ad8e5720f1e3c329ad42f9f012172b028c26e8363"
+          : "bbedea10fef52aeaf32d6e16c27d1042a9f68483ba54c241f5184659e86b3c89"
         : migrations.has("0227_slack_native_actions.sql")
-          ? "32e38ffe1fce657245e30bf413e594f84d967ef68ff9bc4cbd8e08e2bb5ebffc"
-          : migrations.has("0224_slack_post_outcome_reconciliation.sql")
-            ? "8c742400ca1e21ddc4fe1db810d58af7dca037df360406fc71dbd85205eb5a64"
-            : migrations.has("0223_sessions_channel_fk_validate.sql")
-              ? "6bc5dfdf4468f6be4adc5ea7c6ed98397ee865c21a0175106320159b15588a6c"
-              : migrations.has("0221_sessions_channel_index.sql")
-                ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
-                : migrations.has("0220_memory_slack_append_only_cascade.sql")
-                  ? migrations.has("0219_organization_tenancy_managed_human_provisioning.sql")
-                    ? "c9821a930c52d8c40604b9d2f39408227b377f3b2d70b4bb74c14ef93f605756"
-                    : migrations.has("0218_organization_tenancy_foundation.sql")
-                      ? "d78d099f9393a3dcf7d8b54fd75d155448f1a3846712c0aee41d58e7b92b6e9b"
-                      : "85c02e09061ba359a0fa747b1ccffa87a5dd115cbfd8f36ad90c62292ef27bba"
-                  : migrations.has("0219_site_auth_maintenance_sessions.sql")
-                    ? migrations.has("0218_organization_tenancy_foundation.sql")
-                      ? "a002c6b3da822dfff2aca5fd88e76371ecadf87e1fc0c9f5a603b674f67676d1"
-                      : "67238deb9f46f6459e46c882a4dd5231b0ba739f715dfc9e51d8539f54ff3039"
-                    : migrations.has("0218_organization_tenancy_foundation.sql")
-                      ? "eb6d0099f5362add0eb799641deace18326831ac61c8922c3f4f91c6a489f6a9"
-                      : "2d8e3211f1526419a8421c4388f7cf2297839318d7a7dbd194362d81c503c70a",
+          ? migrations.has("0226_personal_codex_authority_foundation.sql")
+            ? "fb41447bb063da5239197ceb5dc0c179427cc08f6593b77e5c18b98f85804dab"
+            : "32e38ffe1fce657245e30bf413e594f84d967ef68ff9bc4cbd8e08e2bb5ebffc"
+          : migrations.has("0226_personal_codex_authority_foundation.sql")
+            ? migrations.has("0224_slack_post_outcome_reconciliation.sql")
+              ? "b2daba323004014d21b87f53eb20993fda4216c249cd2c07e15a9fdab294742c"
+              : "ad366c52845dde14bc42d9c42e93e02c72ba916b6e7ab7ec15d7e2d5f2f5f14f"
+            : migrations.has("0224_slack_post_outcome_reconciliation.sql")
+              ? "8c742400ca1e21ddc4fe1db810d58af7dca037df360406fc71dbd85205eb5a64"
+              : migrations.has("0223_sessions_channel_fk_validate.sql")
+                ? "6bc5dfdf4468f6be4adc5ea7c6ed98397ee865c21a0175106320159b15588a6c"
+                : migrations.has("0221_sessions_channel_index.sql")
+                  ? "e7beb14a48c19cdc2d185fd27b77052a66e9d2e52fe321bc3e2fc14bba8d8712"
+                  : migrations.has("0220_memory_slack_append_only_cascade.sql")
+                    ? migrations.has("0219_organization_tenancy_managed_human_provisioning.sql")
+                      ? "c9821a930c52d8c40604b9d2f39408227b377f3b2d70b4bb74c14ef93f605756"
+                      : migrations.has("0218_organization_tenancy_foundation.sql")
+                        ? "d78d099f9393a3dcf7d8b54fd75d155448f1a3846712c0aee41d58e7b92b6e9b"
+                        : "85c02e09061ba359a0fa747b1ccffa87a5dd115cbfd8f36ad90c62292ef27bba"
+                    : migrations.has("0219_site_auth_maintenance_sessions.sql")
+                      ? migrations.has("0218_organization_tenancy_foundation.sql")
+                        ? "a002c6b3da822dfff2aca5fd88e76371ecadf87e1fc0c9f5a603b674f67676d1"
+                        : "67238deb9f46f6459e46c882a4dd5231b0ba739f715dfc9e51d8539f54ff3039"
+                      : migrations.has("0218_organization_tenancy_foundation.sql")
+                        ? "eb6d0099f5362add0eb799641deace18326831ac61c8922c3f4f91c6a489f6a9"
+                        : "2d8e3211f1526419a8421c4388f7cf2297839318d7a7dbd194362d81c503c70a",
     );
     expect(contract.latestMigration).toBe(
       migrations.has("0228_slack_task_policy.sql")
@@ -530,6 +555,10 @@ describe("release schema contract", () => {
         deploymentMode: "rolling",
       });
     }
+    expect(migrations.get("0226_personal_codex_authority_foundation.sql")).toMatchObject({
+      sha256: "34b72f6ab031596c90f2f35957c707aaf013c2f52aee8ca92a70fdb8ab9cb9ce",
+      deploymentMode: "rolling",
+    });
     expect(migrations.get("0183_model_call_provider_cost_estimates.sql")).toMatchObject({
       sha256: "2cb087b69996c62e8836f2d65c9e2af3fb580fe1822d327600bf40e3a6977d64",
       deploymentMode: "rolling",


### PR DESCRIPTION
## Summary

- add reserved rolling migration `0226_personal_codex_authority_foundation.sql`
- add explicit `workspace | user` Codex credential authority facts with exact same-account organization membership and `codex_subscription` user-resource authority validation
- add strict, identifier-free `CodexProviderAccountAuthoritySnapshotV1` storage/contracts on accepted-turn, scheduled-task, and system-update boundaries
- explicitly backfill legacy credentials and accepted work to workspace authority

## Inert scope / non-activation

This draft does **not** enable user-scoped credential creation, discovery, listing, selection, allocation, leasing, token materialization or refresh, pin/failover, capacity, connected Apps, reset-credit redemption, realtime, transcription, usage, billing, or consumption. Existing runtime behavior remains workspace-scoped.

The organization authority/grant tables remain FORCE RLS with zero direct application DML. `connected_by_subject_id`, workspace placement, creator metadata, email, label, provider account id, and personal-workspace placement are not ownership authority.

## Validation

- `bun test packages/contracts/test/codex-provider-account-authority.test.ts packages/db/test/migration-0226-personal-codex-authority-foundation.test.ts` — 8 passed, 0 failed
- `bun run --cwd packages/contracts typecheck` — passed
- `git diff --check` — passed

Native PostgreSQL 17 full-ledger/RLS/backfill/negative proof remains a required follow-up gate; the local shared database harness was unavailable for this first source checkpoint.

## Coordination

Shared contracts barrel, DB schema/index mappings, architecture/tenancy docs, and release-schema ledger integration are intentionally deferred until the active tenancy writers' frozen heads are integrated. Migration ordinal `0226` is exclusively reserved for this lane.
