### PR TITLE
test(ci): stabilize authority proof gate

### DIFF
--- a/scripts/ci/run-unit-shard.test.ts
+++ b/scripts/ci/run-unit-shard.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import {
+  explicitUnitTestPaths,
   planUnitTestProcesses,
   runBoundedTestProcesses,
   sourceMutatesSharedPostgresRole,
@@ -62,6 +63,20 @@ describe("bounded unit process execution", () => {
 });
 
 describe("unit process planning", () => {
+  test("passes custom test suffixes to Bun as explicit repository paths", () => {
+    expect(
+      explicitUnitTestPaths([
+        "packages/core/test/example.test.ts",
+        "test/integration/api.integration.ts",
+        "./test/e2e/browser.e2e.ts",
+      ]),
+    ).toEqual([
+      "./packages/core/test/example.test.ts",
+      "./test/integration/api.integration.ts",
+      "./test/e2e/browser.e2e.ts",
+    ]);
+  });
+
   test("recognizes authored concurrent-test syntax without matching prose", () => {
     expect(sourceUsesExplicitTestConcurrency("test.concurrent('race', () => {})")).toBe(true);
     expect(sourceUsesExplicitTestConcurrency("it ['concurrent']('race', () => {})")).toBe(true);

--- a/scripts/ci/run-unit-shard.ts
+++ b/scripts/ci/run-unit-shard.ts
@@ -13,6 +13,7 @@ import {
   deterministicShards,
   fileUsesProcessGlobalTestState,
 } from "./workspace";
+import { explicitBunTestPath } from "./run-test-shard";
 
 export type UnitTestProcess = {
   files: string[];
@@ -25,6 +26,10 @@ export type UnitTestProcessPlan = {
   wallClockSensitive: UnitTestProcess[];
   clusterRoleSensitive: UnitTestProcess[];
 };
+
+export function explicitUnitTestPaths(files: readonly string[]): string[] {
+  return files.map(explicitBunTestPath);
+}
 
 export function sanitizedTestEnvironment(
   source: Readonly<Record<string, string | undefined>> = process.env,
@@ -210,7 +215,7 @@ async function run(
     "--no-orphans",
     "--timeout=30000",
     concurrencyArgument,
-    ...files,
+    ...explicitUnitTestPaths(files),
   ];
   process.stdout.write(
     `[unit-shard] ${isolated ? "isolated" : "batch"}: ${describeTestConcurrencyBudget(budget)} processPool=${processConcurrency} innerConcurrency=${innerConcurrency} files=${files.join(", ")}\n`,

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -5451,7 +5451,7 @@ describe("API component integration", () => {
     const refreshedContext = await defaultAccessContext(app);
 
     const authorityCheckedAt = new Date();
-    const authorityExpiresAt = new Date(Date.now() + 10 * 60_000);
+    const authorityExpiresAt = new Date(authorityCheckedAt.getTime() + 10 * 60_000);
     // One GitHub installation can be deliberately delegated into two OpenGeni
     // workspaces, but each workspace owns an independent exact allowlist and
     // an independent consumed owner-authority proof.


### PR DESCRIPTION
## Summary

- derive the GitHub owner-authority proof expiry from the already captured checked-at instant
- preserve the exact 10-minute production proof-window invariant
- pass repository-relative test files to Bun as explicit paths in the unit shard runner
- add a regression test covering custom `.integration.ts` and `.e2e.ts` suffixes

## Why

Main CI exposed a millisecond race in the authority-proof fixture: a second `Date.now()` could place expiry just beyond the exact 10-minute production maximum. The first PR run then exposed a separate fail-closed CI defect: focused impact planning included `test/integration/api.integration.ts` in a unit shard, but the unit runner passed the bare repository path and Bun interpreted it as a filter, running zero tests and exiting 1.

## Verification

- named authority-proof API integration test: 5 consecutive passes
- full `test/integration/api.integration.ts`: 91 pass, 0 fail, 1181 expectations
- custom-suffix file through `scripts/ci/run-unit-shard.ts`: pass; the complete API integration file executed
- `bun test ./scripts/ci/run-unit-shard.test.ts ./scripts/ci/impact.test.ts`
- Prettier check for the unit runner and regression test
- `git diff --check`

Application runtime behavior is unchanged. The additional CI change only makes the selected test-file boundary execute what the impact plan already required.
