### PR TITLE
fix(codex): fence model request terminal outcomes

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -347,6 +347,7 @@ import {
   recordCreditMicros,
   recordModelCacheTokens,
   recordModelInputTokens,
+  recordModelRequestPhase,
   recordSessionEventAppendLatency,
   recordSessionEventPublishLatency,
   runtimeMetricsHooksForObservability,
@@ -5132,6 +5133,31 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 }, // latest wins; flushed once in finally
                 onRequestOpaqueArtifacts: ({ fingerprints }) => {
                   lastCodexRequestOpaqueArtifacts = fingerprints;
+                },
+                onModelRequestDiagnostic: (event) => {
+                  const phase =
+                    event.phase === "headers"
+                      ? "headers"
+                      : event.phase === "first_byte"
+                        ? "first_byte"
+                        : event.phase === "completed" ||
+                            event.phase === "failed" ||
+                            event.phase === "timed_out"
+                          ? "terminal"
+                          : null;
+                  if (!phase) return;
+                  recordModelRequestPhase(observability, {
+                    provider: "codex-subscription",
+                    phase,
+                    ...(event.phase === "completed"
+                      ? { outcome: "completed" as const }
+                      : event.phase === "failed"
+                        ? { outcome: "failed" as const }
+                        : event.phase === "timed_out"
+                          ? { outcome: "timed_out" as const }
+                          : {}),
+                    durationSeconds: event.durationMs / 1000,
+                  });
                 },
                 nextRequestId: () => `${dispatchId}:${++codexModelRequestSequence}`,
                 onModelRequestEvent: async (event) => {

--- a/apps/worker/src/observability-metrics.ts
+++ b/apps/worker/src/observability-metrics.ts
@@ -806,6 +806,39 @@ export function recordCreditMicros(
   });
 }
 
+const MODEL_REQUEST_PHASE_BUCKETS = [
+  0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.35, 0.5, 1, 2, 5, 10, 30, 60, 300,
+];
+
+/**
+ * Record provider lifecycle diagnostics from the synchronous transport observer.
+ * Provider ids come from the resolved provider registry; phase/outcome are closed
+ * enums. This function never performs I/O outside the in-memory metrics registry.
+ */
+export function recordModelRequestPhase(
+  observability: Observability,
+  input: {
+    provider: string;
+    phase: "headers" | "first_byte" | "terminal";
+    outcome?: "completed" | "failed" | "timed_out";
+    durationSeconds: number;
+  },
+): void {
+  const outcome = input.outcome ?? "";
+  observability.incrementCounter({
+    name: "opengeni_model_request_phases_total",
+    help: "Provider model-request lifecycle phases by bounded phase and outcome.",
+    labels: { provider: input.provider, phase: input.phase, outcome },
+  });
+  observability.observeHistogram({
+    name: "opengeni_model_request_phase_duration_seconds",
+    help: "Monotonic seconds from provider dispatch to a model-request lifecycle phase.",
+    buckets: MODEL_REQUEST_PHASE_BUCKETS,
+    labels: { provider: input.provider, phase: input.phase },
+    value: Math.max(0, input.durationSeconds),
+  });
+}
+
 // ── Streaming SLIs ────────────────────────────────────────────────────────────
 // Instruments the token-streaming pipeline so "streaming is sluggish" is a number,
 // not a vibe. Split across the three attributable stages so an operator can tell

--- a/apps/worker/test/streaming-slis.test.ts
+++ b/apps/worker/test/streaming-slis.test.ts
@@ -5,6 +5,7 @@ import {
   recordBatchFlush,
   recordContextCompaction,
   recordModelInputTokens,
+  recordModelRequestPhase,
   recordSessionEventAppendLatency,
   recordSessionEventPublishLatency,
   StreamTimingMetrics,
@@ -92,6 +93,40 @@ describe("StreamTimingMetrics — TTFT + inter-delta gaps", () => {
     expect(metrics).toMatch(
       /opengeni_stream_inter_delta_gap_seconds_count\{[^}]*class="reasoning"[^}]*\} 1\b/,
     );
+  });
+});
+
+describe("provider request lifecycle diagnostics", () => {
+  test("records bounded phase/outcome labels and monotonic duration", async () => {
+    const observability = worker();
+    recordModelRequestPhase(observability, {
+      provider: "codex-subscription",
+      phase: "headers",
+      durationSeconds: 0.12,
+    });
+    recordModelRequestPhase(observability, {
+      provider: "codex-subscription",
+      phase: "first_byte",
+      durationSeconds: 0.34,
+    });
+    recordModelRequestPhase(observability, {
+      provider: "codex-subscription",
+      phase: "terminal",
+      outcome: "completed",
+      durationSeconds: 1.2,
+    });
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_model_request_phases_total\{[^}]*outcome=""[^}]*phase="headers"[^}]*provider="codex-subscription"[^}]*\} 1\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_model_request_phases_total\{[^}]*outcome="completed"[^}]*phase="terminal"[^}]*provider="codex-subscription"[^}]*\} 1\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_model_request_phase_duration_seconds_count\{[^}]*phase="first_byte"[^}]*provider="codex-subscription"[^}]*\} 1\b/,
+    );
+    expect(metrics).not.toContain("requestId");
   });
 });
 

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1191,3 +1191,9 @@ types its wire protocol cannot represent. Historical `tool_search` and other
 tool call/output pairs are completed facts, not authorization to execute again.
 The projection is discarded after the request. Portable sessions may switch
 between supported providers; `remote_v2` sessions remain Codex-only.
+
+## Agent-loop request lifecycle observability
+
+Provider request lifecycle diagnostics are synchronous, bounded, and best-effort. The Codex transport reports `headers`, `first_byte`, and one semantic `terminal` phase with a monotonic elapsed duration; terminal outcomes are `completed`, `failed`, or `timed_out`. The worker maps these to `opengeni_model_request_phases_total{provider,phase,outcome}` and `opengeni_model_request_phase_duration_seconds{provider,phase}`. Provider ids come from the resolved provider registry; request ids, model bodies, credentials, session ids, and token content are not metric labels.
+
+The diagnostic observer runs before the existing awaited `agent.model.request` durable audit callback and cannot block or change it. Durable append/publish fencing and ordering therefore remain the source of audit truth. A Codex `response.completed`/`response.done` terminal is latched before downstream stream cleanup; if the consumer cancels after parsing that semantic terminal, the audit remains `completed` rather than producing a misleading trailing `failed`. Actual provider failure/incomplete/error, transport failure, timeout, or caller abort remains failed/timed out.

--- a/packages/codex/src/fetch.ts
+++ b/packages/codex/src/fetch.ts
@@ -200,9 +200,131 @@ type RequestAudit = {
   transportAttempt: number;
   model?: string;
   logicalStartedAt: number;
-  attemptStartedAt: number;
+  attemptStartedAtMonotonic: number;
   policy: CodexResponseTimeoutPolicy;
+  terminalOutcome: RequestTerminalOutcome | null;
 };
+
+type RequestTerminalOutcome = "completed" | "failed" | "timed_out";
+
+type SemanticTerminalState = {
+  phase: "completed" | "failed" | null;
+  /** Non-streaming callers must parse the complete SSE body before settling. */
+  deferTransportTerminal: boolean;
+};
+
+type CodexSseEvent = {
+  type?: string;
+  response?: Record<string, unknown>;
+  error?: unknown;
+  code?: unknown;
+  message?: unknown;
+  param?: unknown;
+  item?: unknown;
+};
+
+type CodexSseTerminalClassification =
+  | { phase: "completed" }
+  | {
+      phase: "failed";
+      rawError: unknown;
+      fallbackCode: string;
+      fallbackMessage: string;
+    }
+  | null;
+
+function classifyCodexSseTerminal(ev: CodexSseEvent): CodexSseTerminalClassification {
+  if (ev.type === "response.failed") {
+    return {
+      phase: "failed",
+      rawError: ev.response?.error,
+      fallbackCode: "response_failed",
+      fallbackMessage: "The Codex response failed",
+    };
+  }
+  if (ev.type === "error" || ev.type === "response.error") {
+    return {
+      phase: "failed",
+      rawError: ev.error ?? ev.response?.error ?? ev,
+      fallbackCode: "response_error",
+      fallbackMessage: "The Codex response stream reported an error",
+    };
+  }
+  if (ev.type === "response.incomplete") {
+    const details = ev.response?.incomplete_details;
+    const reason =
+      details && typeof details === "object"
+        ? (details as Record<string, unknown>).reason
+        : undefined;
+    return {
+      phase: "failed",
+      rawError: {
+        code: "response_incomplete",
+        message:
+          typeof reason === "string" && reason.length > 0
+            ? `The Codex response was incomplete (${reason})`
+            : "The Codex response was incomplete",
+      },
+      fallbackCode: "response_incomplete",
+      fallbackMessage: "The Codex response was incomplete",
+    };
+  }
+  if (ev.type !== "response.completed" && ev.type !== "response.done") {
+    return null;
+  }
+  if (!ev.response) {
+    return null;
+  }
+
+  const responseStatus = ev.response.status;
+  if (
+    (responseStatus !== undefined && responseStatus !== "completed") ||
+    (ev.response.error !== null && ev.response.error !== undefined)
+  ) {
+    const incomplete = responseStatus === "incomplete";
+    return {
+      phase: "failed",
+      rawError: ev.response.error,
+      fallbackCode: incomplete ? "response_incomplete" : "response_failed",
+      fallbackMessage: incomplete
+        ? "The Codex response was incomplete"
+        : "The Codex response failed",
+    };
+  }
+  return { phase: "completed" };
+}
+
+function markSemanticTerminal(state: SemanticTerminalState, phase: "completed" | "failed"): void {
+  if (state.phase === null) {
+    state.phase = phase;
+  }
+}
+
+function terminalOutcomeForPhase(
+  phase: CodexModelRequestEvent["phase"],
+): RequestTerminalOutcome | null {
+  if (phase === "completed" || phase === "failed" || phase === "timed_out") {
+    return phase;
+  }
+  return null;
+}
+
+function requestEventFor(
+  audit: RequestAudit,
+  event: Omit<
+    CodexModelRequestEvent,
+    "requestId" | "transportAttempt" | "model" | "durationMs" | "timeoutPolicy"
+  >,
+): CodexModelRequestEvent {
+  return {
+    requestId: audit.requestId,
+    transportAttempt: audit.transportAttempt,
+    ...(audit.model ? { model: audit.model } : {}),
+    durationMs: Math.max(0, performance.now() - audit.attemptStartedAtMonotonic),
+    timeoutPolicy: audit.policy,
+    ...event,
+  };
+}
 
 async function emitRequestEvent(
   audit: RequestAudit,
@@ -210,15 +332,25 @@ async function emitRequestEvent(
     CodexModelRequestEvent,
     "requestId" | "transportAttempt" | "model" | "durationMs" | "timeoutPolicy"
   >,
-): Promise<void> {
-  await audit.ctx.onModelRequestEvent?.({
-    requestId: audit.requestId,
-    transportAttempt: audit.transportAttempt,
-    ...(audit.model ? { model: audit.model } : {}),
-    durationMs: Math.max(0, Date.now() - audit.attemptStartedAt),
-    timeoutPolicy: audit.policy,
-    ...event,
-  });
+): Promise<boolean> {
+  const terminalOutcome = terminalOutcomeForPhase(event.phase);
+  if (terminalOutcome !== null) {
+    if (audit.terminalOutcome !== null) {
+      return false;
+    }
+    // Fence before invoking either observer. The durable observer may reject,
+    // but a later transport callback must never turn that one terminal into a
+    // contradictory second terminal.
+    audit.terminalOutcome = terminalOutcome;
+  }
+  const observed = requestEventFor(audit, event);
+  try {
+    audit.ctx.onModelRequestDiagnostic?.(observed);
+  } catch {
+    // Diagnostic observers are strictly non-blocking and cannot affect transport.
+  }
+  await audit.ctx.onModelRequestEvent?.(observed);
+  return true;
 }
 
 function providerRequestId(headers: Headers): string | undefined {
@@ -275,11 +407,13 @@ async function observedResponse(
   res: Response,
   audit: RequestAudit,
   externalSignal: AbortSignal | null | undefined,
+  semanticTerminal?: SemanticTerminalState,
 ): Promise<Response> {
   const requestId = providerRequestId(res.headers);
   if (!res.body) {
+    if (semanticTerminal) markSemanticTerminal(semanticTerminal, "failed");
     await emitRequestEvent(audit, {
-      phase: res.ok ? "completed" : "failed",
+      phase: semanticTerminal?.phase ?? (res.ok ? "completed" : "failed"),
       responseObserved: true,
       status: res.status,
       ...(requestId ? { providerRequestId: requestId } : {}),
@@ -307,17 +441,19 @@ async function observedResponse(
         if (terminal) return;
         terminal = true;
         clearTimers();
+        const semanticPhase = semanticTerminal?.phase;
+        const phase = semanticPhase ?? "timed_out";
         const error = new CodexResponseTimeoutError(klass, audit.requestId, true);
         void reader.cancel(error).catch(() => undefined);
         void emitRequestEvent(audit, {
-          phase: "timed_out",
+          phase,
           responseObserved: true,
-          timeoutClass: klass,
+          ...(phase === "timed_out" ? { timeoutClass: klass } : {}),
           status: res.status,
           ...(requestId ? { providerRequestId: requestId } : {}),
         }).then(
-          () => controller.error(error),
-          () => controller.error(error),
+          () => (phase === "completed" ? controller.close() : controller.error(error)),
+          () => (phase === "completed" ? controller.close() : controller.error(error)),
         );
       };
       armIdle = () => {
@@ -337,13 +473,15 @@ async function observedResponse(
         const reason = externalSignal?.reason ?? new DOMException("Aborted", "AbortError");
         void reader.cancel(reason).catch(() => undefined);
         void emitRequestEvent(audit, {
-          phase: "failed",
+          phase: semanticTerminal?.phase ?? "failed",
           responseObserved: true,
           status: res.status,
           ...(requestId ? { providerRequestId: requestId } : {}),
         }).then(
-          () => controller.error(reason),
-          () => controller.error(reason),
+          () =>
+            semanticTerminal?.phase === "completed" ? controller.close() : controller.error(reason),
+          () =>
+            semanticTerminal?.phase === "completed" ? controller.close() : controller.error(reason),
         );
       };
       if (externalSignal?.aborted) {
@@ -362,12 +500,19 @@ async function observedResponse(
         if (chunk.done) {
           terminal = true;
           clearTimers();
-          await emitRequestEvent(audit, {
-            phase: res.ok ? "completed" : "failed",
-            responseObserved: true,
-            status: res.status,
-            ...(requestId ? { providerRequestId: requestId } : {}),
-          });
+          if (semanticTerminal && semanticTerminal.phase === null) {
+            if (!semanticTerminal.deferTransportTerminal) {
+              markSemanticTerminal(semanticTerminal, "failed");
+            }
+          }
+          if (!semanticTerminal?.deferTransportTerminal || semanticTerminal.phase !== null) {
+            await emitRequestEvent(audit, {
+              phase: semanticTerminal?.phase ?? (res.ok ? "completed" : "failed"),
+              responseObserved: true,
+              status: res.status,
+              ...(requestId ? { providerRequestId: requestId } : {}),
+            });
+          }
           controller.close();
           return;
         }
@@ -392,21 +537,32 @@ async function observedResponse(
         if (terminal) return;
         terminal = true;
         clearTimers();
+        const semanticPhase = semanticTerminal?.phase;
+        if (semanticTerminal && semanticPhase === null) {
+          markSemanticTerminal(semanticTerminal, "failed");
+        }
         await emitRequestEvent(audit, {
-          phase: "failed",
+          phase: semanticPhase ?? "failed",
           responseObserved: true,
           status: res.status,
           ...(requestId ? { providerRequestId: requestId } : {}),
         });
-        controller.error(error);
+        if (semanticPhase === "completed") {
+          controller.close();
+        } else {
+          controller.error(error);
+        }
       }
     },
     async cancel(reason) {
       if (!terminal) {
         terminal = true;
         clearTimers();
+        if (semanticTerminal && semanticTerminal.phase === null) {
+          markSemanticTerminal(semanticTerminal, "failed");
+        }
         await emitRequestEvent(audit, {
-          phase: "failed",
+          phase: semanticTerminal?.phase ?? "failed",
           responseObserved: true,
           status: res.status,
           ...(requestId ? { providerRequestId: requestId } : {}),
@@ -566,13 +722,18 @@ export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): Fetc
         transportAttempt,
         ...(model ? { model } : {}),
         logicalStartedAt,
-        attemptStartedAt: Date.now(),
+        attemptStartedAtMonotonic: performance.now(),
         policy,
+        terminalOutcome: null,
       };
       await emitRequestEvent(audit, {
         phase: "started",
         responseObserved: false,
       });
+      const semanticTerminal: SemanticTerminalState = {
+        phase: null,
+        deferTransportTerminal: !callerWantsStream,
+      };
       try {
         res = await fetchBeforeHeaders(base, rewritten, nextInit, audit);
         const upstreamRequestId = providerRequestId(res.headers);
@@ -582,8 +743,7 @@ export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): Fetc
           status: res.status,
           ...(upstreamRequestId ? { providerRequestId: upstreamRequestId } : {}),
         });
-        const observed = await observedResponse(res, audit, nextInit.signal);
-        res = observed;
+        res = await observedResponse(res, audit, nextInit.signal, semanticTerminal);
       } catch (error) {
         if (nextInit.signal?.aborted) {
           await emitRequestEvent(audit, {
@@ -645,9 +805,25 @@ export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): Fetc
         // Response lets the SDK reconstruct error.error for EVERY codex error
         // (401/400/5xx too). For a hard usage cap we also pin x-should-retry:false
         // so the SDK does not burn its retry budget on a limit that won't lift.
-        return await bufferCodexErrorResponse(res);
+        const buffered = await bufferCodexErrorResponse(res);
+        const upstreamRequestId = providerRequestId(res.headers);
+        markSemanticTerminal(semanticTerminal, "failed");
+        await emitRequestEvent(audit, {
+          phase: "failed",
+          responseObserved: true,
+          status: res.status,
+          ...(upstreamRequestId ? { providerRequestId: upstreamRequestId } : {}),
+        }).catch(() => undefined);
+        return buffered;
       }
-      return callerWantsStream ? validateCodexStream(res) : await sseToJsonResponse(res);
+      if (callerWantsStream) {
+        res = validateCodexStream(res, (phase) => {
+          markSemanticTerminal(semanticTerminal, phase);
+        });
+      } else {
+        res = await sseToJsonResponse(res, audit, semanticTerminal);
+      }
+      return res;
     };
 
     try {
@@ -808,7 +984,12 @@ async function readBoundedResponseText(
  * non-streaming `responses.create` caller expects: the terminal response.*
  * event carries the full `response` payload.
  */
-async function sseToJsonResponse(res: Response): Promise<Response> {
+async function sseToJsonResponse(
+  res: Response,
+  audit: RequestAudit,
+  semanticTerminal: SemanticTerminalState,
+): Promise<Response> {
+  const upstreamRequestId = providerRequestId(res.headers);
   const text = await res.text();
   let final: Record<string, unknown> | null = null;
   let terminalError: Response | null = null;
@@ -819,75 +1000,49 @@ async function sseToJsonResponse(res: Response): Promise<Response> {
       continue;
     }
     try {
-      const ev = JSON.parse(data) as {
-        type?: string;
-        response?: Record<string, unknown>;
-        error?: unknown;
-        code?: unknown;
-        message?: unknown;
-        param?: unknown;
-        item?: unknown;
-      };
+      const ev = JSON.parse(data) as CodexSseEvent;
       if (ev.type === "response.output_item.done" && ev.item !== undefined) {
         items.push(ev.item);
-      } else if (ev.type === "response.failed") {
-        terminalError = codexSseFailureResponse(
-          res,
-          ev.response?.error,
-          "response_failed",
-          "The Codex response failed",
-          {
-            eventType: ev.type,
-            responseId: ev.response?.id,
-            responseStatus: ev.response?.status,
-          },
-        );
-      } else if (ev.type === "error" || ev.type === "response.error") {
-        terminalError = codexSseFailureResponse(
-          res,
-          ev.error ?? ev.response?.error ?? ev,
-          "response_error",
-          "The Codex response stream reported an error",
-          {
-            eventType: ev.type,
-            responseId: ev.response?.id,
-            responseStatus: ev.response?.status,
-          },
-        );
-      } else if (ev.type === "response.incomplete") {
-        const details = ev.response?.incomplete_details;
-        const reason =
-          details && typeof details === "object"
-            ? (details as Record<string, unknown>).reason
-            : undefined;
-        terminalError = codexSseFailureResponse(
-          res,
-          {
-            code: "response_incomplete",
-            message:
-              typeof reason === "string" && reason.length > 0
-                ? `The Codex response was incomplete (${reason})`
-                : "The Codex response was incomplete",
-          },
-          "response_incomplete",
-          "The Codex response was incomplete",
-          {
-            eventType: ev.type,
-            responseId: ev.response?.id,
-            responseStatus: ev.response?.status,
-          },
-        );
-      } else if (ev.type === "response.completed" || ev.type === "response.done") {
-        final = ev.response ?? null;
+      } else {
+        const terminal = classifyCodexSseTerminal(ev);
+        if (terminal?.phase === "failed") {
+          terminalError = codexSseFailureResponse(
+            res,
+            terminal.rawError,
+            terminal.fallbackCode,
+            terminal.fallbackMessage,
+            {
+              eventType: ev.type,
+              responseId: ev.response?.id,
+              responseStatus: ev.response?.status,
+            },
+          );
+        } else if (terminal?.phase === "completed") {
+          final = ev.response ?? null;
+        }
       }
     } catch {
       /* ignore non-JSON keepalive lines */
     }
   }
   if (terminalError) {
+    markSemanticTerminal(semanticTerminal, "failed");
+    await emitRequestEvent(audit, {
+      phase: "failed",
+      responseObserved: true,
+      status: res.status,
+      ...(upstreamRequestId ? { providerRequestId: upstreamRequestId } : {}),
+    });
     return terminalError;
   }
   if (!final) {
+    markSemanticTerminal(semanticTerminal, "failed");
+    await emitRequestEvent(audit, {
+      phase: "failed",
+      responseObserved: true,
+      status: res.status,
+      ...(upstreamRequestId ? { providerRequestId: upstreamRequestId } : {}),
+    });
     return codexSseFailureResponse(
       res,
       null,
@@ -903,6 +1058,13 @@ async function sseToJsonResponse(res: Response): Promise<Response> {
       `[codex-debug] sse->json items=${items.length} outputLen=${Array.isArray(final?.output) ? (final.output as unknown[]).length : "?"}`,
     );
   }
+  markSemanticTerminal(semanticTerminal, "completed");
+  await emitRequestEvent(audit, {
+    phase: "completed",
+    responseObserved: true,
+    status: res.status,
+    ...(upstreamRequestId ? { providerRequestId: upstreamRequestId } : {}),
+  });
   const headers = new Headers(res.headers);
   headers.set("content-type", "application/json");
   headers.delete("content-length");
@@ -1178,8 +1340,12 @@ function codexSseFailureError(
  * output reconstruction belongs to the model reducer, so this layer retains no
  * duplicate output-item graph.
  */
-function validateCodexStream(res: Response): Response {
+function validateCodexStream(
+  res: Response,
+  onSemanticTerminal?: (phase: "completed" | "failed") => void,
+): Response {
   if (!res.body) {
+    onSemanticTerminal?.("failed");
     const error = codexSseFailureError(
       res,
       null,
@@ -1212,7 +1378,7 @@ function validateCodexStream(res: Response): Response {
       const block = buffer.slice(0, boundary.start);
       const separator = buffer.slice(boundary.start, boundary.end);
       buffer = buffer.slice(boundary.end);
-      successfulTerminalSeen ||= inspectCodexSseBlock(block, res);
+      successfulTerminalSeen ||= inspectCodexSseBlock(block, res, onSemanticTerminal);
       controller.enqueue(encoder.encode(`${block}${separator}`));
       boundary = findSseBlockBoundary(buffer, final);
     }
@@ -1226,7 +1392,7 @@ function validateCodexStream(res: Response): Response {
       buffer += decoder.decode();
       emitCompleteBlocks(controller, true);
       if (buffer.length > 0) {
-        successfulTerminalSeen ||= inspectCodexSseBlock(buffer, res);
+        successfulTerminalSeen ||= inspectCodexSseBlock(buffer, res, onSemanticTerminal);
         controller.enqueue(encoder.encode(buffer));
         buffer = "";
       }
@@ -1293,7 +1459,11 @@ const CODEX_TERMINAL_TYPE_HINTS = [
  * without object allocation; failed/error/incomplete terminals throw before the
  * model can mistake them for an ordinary response_done event.
  */
-function inspectCodexSseBlock(block: string, source: Response): boolean {
+function inspectCodexSseBlock(
+  block: string,
+  source: Response,
+  onSemanticTerminal?: (phase: "completed" | "failed") => void,
+): boolean {
   const lines = block.split(/\r\n|\r|\n/);
   const dataStr = lines
     .filter((l) => l.startsWith("data:"))
@@ -1305,26 +1475,20 @@ function inspectCodexSseBlock(block: string, source: Response): boolean {
   if (!CODEX_TERMINAL_TYPE_HINTS.some((terminalType) => dataStr.includes(terminalType))) {
     return false;
   }
-  let ev: {
-    type?: string;
-    item?: unknown;
-    response?: Record<string, unknown>;
-    error?: unknown;
-    code?: unknown;
-    message?: unknown;
-    param?: unknown;
-  };
+  let ev: CodexSseEvent;
   try {
     ev = JSON.parse(dataStr);
   } catch {
     return false;
   }
-  if (ev.type === "response.failed") {
+  const terminal = classifyCodexSseTerminal(ev);
+  if (terminal?.phase === "failed") {
+    onSemanticTerminal?.("failed");
     throw codexSseFailureError(
       source,
-      ev.response?.error,
-      "response_failed",
-      "The Codex response failed",
+      terminal.rawError,
+      terminal.fallbackCode,
+      terminal.fallbackMessage,
       {
         eventType: ev.type,
         responseId: ev.response?.id,
@@ -1332,62 +1496,8 @@ function inspectCodexSseBlock(block: string, source: Response): boolean {
       },
     );
   }
-  if (ev.type === "error" || ev.type === "response.error") {
-    throw codexSseFailureError(
-      source,
-      ev.error ?? ev.response?.error ?? ev,
-      "response_error",
-      "The Codex response stream reported an error",
-      {
-        eventType: ev.type,
-        responseId: ev.response?.id,
-        responseStatus: ev.response?.status,
-      },
-    );
-  }
-  if (ev.type === "response.incomplete") {
-    const details = ev.response?.incomplete_details;
-    const reason =
-      details && typeof details === "object"
-        ? (details as Record<string, unknown>).reason
-        : undefined;
-    throw codexSseFailureError(
-      source,
-      {
-        code: "response_incomplete",
-        message:
-          typeof reason === "string" && reason.length > 0
-            ? `The Codex response was incomplete (${reason})`
-            : "The Codex response was incomplete",
-      },
-      "response_incomplete",
-      "The Codex response was incomplete",
-      {
-        eventType: ev.type,
-        responseId: ev.response?.id,
-        responseStatus: ev.response?.status,
-      },
-    );
-  }
-  if ((ev.type === "response.completed" || ev.type === "response.done") && ev.response) {
-    if (
-      (ev.response.status !== undefined && ev.response.status !== "completed") ||
-      (ev.response.error !== null && ev.response.error !== undefined)
-    ) {
-      throw codexSseFailureError(
-        source,
-        ev.response.error,
-        ev.response.status === "incomplete" ? "response_incomplete" : "response_failed",
-        ev.response.status === "incomplete"
-          ? "The Codex response was incomplete"
-          : "The Codex response failed",
-        {
-          eventType: ev.type,
-          responseId: ev.response.id,
-          responseStatus: ev.response.status,
-        },
-      );
-    }
+  if (terminal?.phase === "completed") {
+    onSemanticTerminal?.("completed");
     return true;
   }
   return false;

--- a/packages/codex/src/request-context.ts
+++ b/packages/codex/src/request-context.ts
@@ -97,6 +97,12 @@ export type CodexRequestContext = {
   onUsageHeaders?: (snapshot: CodexUsageHeaderSnapshot) => void;
   /** Optional per-run override, primarily for deterministic transport tests. */
   responseTimeoutPolicy?: Partial<CodexResponseTimeoutPolicy>;
+  /**
+   * Synchronous, best-effort diagnostics for the request lifecycle. This hook
+   * runs before the durable audit sink and MUST remain non-blocking: a throw is
+   * swallowed by the transport and it must never receive request bodies/auth.
+   */
+  onModelRequestDiagnostic?: (event: CodexModelRequestEvent) => void;
   /** Worker-owned durable audit sink; payloads never contain request bodies or auth. */
   onModelRequestEvent?: (event: CodexModelRequestEvent) => Promise<void> | void;
   /** Exact opaque artifacts on the normalized wire request, never their ciphertext. */

--- a/packages/codex/test/fetch.test.ts
+++ b/packages/codex/test/fetch.test.ts
@@ -20,6 +20,36 @@ import {
 } from "../src";
 
 type Capture = { url: string; init?: RequestInit | undefined };
+type TerminalPhase = Extract<CodexModelRequestEvent["phase"], "completed" | "failed" | "timed_out">;
+
+function expectExactlyOneTerminalPerAttempt(
+  events: readonly CodexModelRequestEvent[],
+  expected: ReadonlyArray<{
+    requestId?: string;
+    transportAttempt: number;
+    phase: TerminalPhase;
+  }>,
+): void {
+  const terminalEvents = events.filter(
+    (event): event is CodexModelRequestEvent & { phase: TerminalPhase } =>
+      event.phase === "completed" || event.phase === "failed" || event.phase === "timed_out",
+  );
+  expect(terminalEvents).toHaveLength(expected.length);
+  expect(
+    new Set(terminalEvents.map((event) => `${event.requestId}:${event.transportAttempt}`)).size,
+  ).toBe(expected.length);
+  expect(
+    terminalEvents.map((event) => ({
+      transportAttempt: event.transportAttempt,
+      phase: event.phase,
+    })),
+  ).toEqual(expected.map(({ transportAttempt, phase }) => ({ transportAttempt, phase })));
+  for (const [index, expectation] of expected.entries()) {
+    if (expectation.requestId !== undefined) {
+      expect(terminalEvents[index]?.requestId).toBe(expectation.requestId);
+    }
+  }
+}
 
 function baseRecorder(statuses: number[] = [200]): {
   base: FetchLike;
@@ -303,10 +333,15 @@ describe("codexSubscriptionFetch", () => {
 
   test("retries once with a refreshed token on 401", async () => {
     const { base, captures } = baseRecorder([401, 200]);
+    const events: CodexModelRequestEvent[] = [];
     let refreshed = 0;
     const fetchImpl = codexSubscriptionFetch(base);
     const res = await codexRequestStorage.run(
       ctx({
+        nextRequestId: () => "dispatch-401",
+        onModelRequestEvent: (event) => {
+          events.push(event);
+        },
         refresh: async () => {
           refreshed += 1;
           return {
@@ -329,6 +364,10 @@ describe("codexSubscriptionFetch", () => {
       new Headers(captures[1]?.init?.headers).get("idempotency-key"),
     );
     expect(res.status).toBe(200);
+    expectExactlyOneTerminalPerAttempt(events, [
+      { requestId: "dispatch-401", transportAttempt: 1, phase: "failed" },
+      { requestId: "dispatch-401", transportAttempt: 2, phase: "completed" },
+    ]);
   });
 
   test("replays a pristine streamed JSON body on the 401 refresh retry", async () => {
@@ -534,6 +573,61 @@ describe("codexSubscriptionFetch", () => {
     });
   });
 
+  test.each([
+    [
+      "response.failed",
+      {
+        type: "response.failed",
+        response: {
+          id: "resp_nonstream_failed",
+          status: "failed",
+          error: { code: "provider_failed", message: "provider failed" },
+        },
+      },
+    ],
+    [
+      "response.incomplete",
+      {
+        type: "response.incomplete",
+        response: {
+          id: "resp_nonstream_incomplete",
+          status: "incomplete",
+          incomplete_details: { reason: "max_output_tokens" },
+        },
+      },
+    ],
+    ["top-level error", { type: "error", code: "provider_error", message: "provider error" }],
+    [
+      "response.error",
+      { type: "response.error", error: { code: "response_error", message: "response error" } },
+    ],
+  ] as const)("non-streaming %s emits exactly one failed terminal", async (_name, event) => {
+    const events: CodexModelRequestEvent[] = [];
+    const response = await codexRequestStorage.run(
+      ctx({
+        nextRequestId: () => `nonstream-${_name}`,
+        onModelRequestEvent: (observed) => {
+          events.push(observed);
+        },
+      }),
+      () =>
+        codexSubscriptionFetch(
+          async () =>
+            new Response(`data: ${JSON.stringify(event)}\n\n`, {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            }),
+        )("https://chatgpt.com/backend-api/responses", {
+          method: "POST",
+          body: JSON.stringify({ model: "gpt-5.6-sol", stream: false, input: [] }),
+        }),
+    );
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    await response.text();
+    expectExactlyOneTerminalPerAttempt(events, [{ transportAttempt: 1, phase: "failed" }]);
+  });
+
   test("partial streaming body failure is surfaced without a transport replay", async () => {
     let calls = 0;
     const body = new ReadableStream<Uint8Array>({
@@ -611,6 +705,7 @@ describe("codexSubscriptionFetch", () => {
     expect(events.map((event) => event.phase)).toEqual(["started", "timed_out"]);
     expect(events[0]?.timeoutPolicy.noByteRetries).toBe(0);
     expect(events[1]?.willRetry).toBe(false);
+    expectExactlyOneTerminalPerAttempt(events, [{ transportAttempt: 1, phase: "timed_out" }]);
   });
 
   test("a late response after a pre-headers timeout does not trigger a second upstream call", async () => {
@@ -787,6 +882,7 @@ describe("codexSubscriptionFetch", () => {
       timeoutClass: "idle_stream",
       responseObserved: true,
     });
+    expectExactlyOneTerminalPerAttempt(events, [{ transportAttempt: 1, phase: "timed_out" }]);
   });
 
   test("slow first-byte audit persistence cannot manufacture an idle timeout", async () => {
@@ -857,6 +953,7 @@ describe("codexSubscriptionFetch", () => {
       timeoutClass: "whole_request",
       responseObserved: true,
     });
+    expectExactlyOneTerminalPerAttempt(events, [{ transportAttempt: 1, phase: "timed_out" }]);
   });
 
   test("external cancellation after headers cancels the body without a timeout retry", async () => {
@@ -903,6 +1000,7 @@ describe("codexSubscriptionFetch", () => {
     expect(events.some((event) => event.phase === "timed_out")).toBe(false);
     expect(events.at(-1)?.phase).toBe("failed");
     expect(observed).toBe(abortReason);
+    expectExactlyOneTerminalPerAttempt(events, [{ transportAttempt: 1, phase: "failed" }]);
   });
 
   // A realistic stream: response.completed leaves output empty and the assistant
@@ -946,6 +1044,144 @@ describe("codexSubscriptionFetch", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ id: "r1", status: "completed" });
   });
+
+  test.each([
+    [
+      "response.completed with embedded failed",
+      {
+        type: "response.completed",
+        response: {
+          id: "resp_failed_completed",
+          status: "failed",
+          error: { code: "provider_failed", message: "provider failed" },
+        },
+      },
+      "failed",
+      "provider_failed",
+    ],
+    [
+      "response.done with embedded incomplete",
+      {
+        type: "response.done",
+        response: {
+          id: "resp_incomplete_done",
+          status: "incomplete",
+          incomplete_details: { reason: "max_output_tokens" },
+        },
+      },
+      "incomplete",
+      "response_incomplete",
+    ],
+  ] as const)(
+    "non-streaming success-spelled terminal honors embedded %s status",
+    async (_name, event, responseStatus, errorCode) => {
+      const events: CodexModelRequestEvent[] = [];
+      const response = await codexRequestStorage.run(
+        ctx({
+          nextRequestId: () => `nonstream-contradictory-${responseStatus}`,
+          onModelRequestEvent: (observed) => {
+            events.push(observed);
+          },
+        }),
+        () =>
+          codexSubscriptionFetch(
+            async () =>
+              new Response(`data: ${JSON.stringify(event)}\n\n`, {
+                status: 200,
+                headers: { "content-type": "text/event-stream" },
+              }),
+          )("https://chatgpt.com/backend-api/responses", {
+            method: "POST",
+            body: JSON.stringify({ model: "gpt-5.6-sol", stream: false, input: [] }),
+          }),
+      );
+
+      expect(response.status).toBe(502);
+      expect(await response.json()).toMatchObject({
+        error: {
+          code: errorCode,
+          response_status: responseStatus,
+        },
+      });
+      expect(events.map((observed) => observed.phase)).toEqual([
+        "started",
+        "headers",
+        "first_byte",
+        "failed",
+      ]);
+      expectExactlyOneTerminalPerAttempt(events, [{ transportAttempt: 1, phase: "failed" }]);
+    },
+  );
+
+  test.each([
+    [
+      "response.completed with embedded failed",
+      {
+        type: "response.completed",
+        response: {
+          id: "resp_failed_completed_stream",
+          status: "failed",
+          error: { code: "provider_failed", message: "provider failed" },
+        },
+      },
+      "failed",
+      "provider_failed",
+    ],
+    [
+      "response.done with embedded incomplete",
+      {
+        type: "response.done",
+        response: {
+          id: "resp_incomplete_done_stream",
+          status: "incomplete",
+          incomplete_details: { reason: "max_output_tokens" },
+        },
+      },
+      "incomplete",
+      "response_incomplete",
+    ],
+  ] as const)(
+    "streaming success-spelled terminal honors embedded %s status",
+    async (_name, terminalEvent, _responseStatus, errorCode) => {
+      const events: CodexModelRequestEvent[] = [];
+      const response = await codexRequestStorage.run(
+        ctx({
+          nextRequestId: () => `stream-contradictory-${errorCode}`,
+          onModelRequestEvent: (observed) => {
+            events.push(observed);
+          },
+        }),
+        () =>
+          codexSubscriptionFetch(
+            async () =>
+              new Response(`data: ${JSON.stringify(terminalEvent)}\n\n`, {
+                status: 200,
+                headers: { "content-type": "text/event-stream" },
+              }),
+          )("https://chatgpt.com/backend-api/responses", {
+            method: "POST",
+            body: JSON.stringify({ model: "gpt-5.6-sol", stream: true, input: [] }),
+          }),
+      );
+
+      let observed: unknown;
+      try {
+        await response.text();
+      } catch (error) {
+        observed = error;
+      }
+      expect(response.status).toBe(200);
+      expect(observed).toMatchObject({ status: 502, code: errorCode });
+      expect(isCodexTransportError(observed)).toBe(true);
+      expect(events.map((observedEvent) => observedEvent.phase)).toEqual([
+        "started",
+        "headers",
+        "first_byte",
+        "failed",
+      ]);
+      expectExactlyOneTerminalPerAttempt(events, [{ transportAttempt: 1, phase: "failed" }]);
+    },
+  );
 
   test("non-streaming caller: response.failed becomes a marked non-retried provider error", async () => {
     let calls = 0;
@@ -1154,6 +1390,85 @@ describe("codexSubscriptionFetch", () => {
     });
     expect(body).not.toContain("stack");
     expect(body).not.toContain("nested");
+  });
+
+  test("semantic success remains completed when downstream cleanup cancels after response.completed", async () => {
+    const auditEvents: CodexModelRequestEvent[] = [];
+    const diagnosticEvents: CodexModelRequestEvent[] = [];
+    const response = await codexRequestStorage.run(
+      ctx({
+        onModelRequestDiagnostic: (event) => diagnosticEvents.push(event),
+        onModelRequestEvent: (event) => {
+          auditEvents.push(event);
+        },
+      }),
+      () =>
+        codexSubscriptionFetch(codexBase)("https://chatgpt.com/backend-api/responses", {
+          method: "POST",
+          body: JSON.stringify({ model: "gpt-5.6-sol", stream: true, input: [] }),
+        }),
+    );
+
+    const reader = response.body!.getReader();
+    await reader.read();
+    await reader.cancel("downstream parsed the semantic terminal");
+
+    expect(auditEvents.map((event) => event.phase)).toEqual([
+      "started",
+      "headers",
+      "first_byte",
+      "completed",
+    ]);
+    expect(diagnosticEvents.map((event) => event.phase)).toEqual(
+      auditEvents.map((event) => event.phase),
+    );
+    expect(auditEvents.at(-1)?.phase).toBe("completed");
+    expect(auditEvents.filter((event) => event.phase === "failed")).toHaveLength(0);
+    expect(auditEvents.every((event) => event.durationMs >= 0)).toBe(true);
+  });
+
+  test("semantic success remains completed when the stream is fully drained", async () => {
+    const auditEvents: CodexModelRequestEvent[] = [];
+    const response = await codexRequestStorage.run(
+      ctx({
+        onModelRequestEvent: (event) => {
+          auditEvents.push(event);
+        },
+      }),
+      () =>
+        codexSubscriptionFetch(codexBase)("https://chatgpt.com/backend-api/responses", {
+          method: "POST",
+          body: JSON.stringify({ model: "gpt-5.6-sol", stream: true, input: [] }),
+        }),
+    );
+
+    await response.text();
+
+    expect(auditEvents.at(-1)?.phase).toBe("completed");
+    expect(auditEvents.filter((event) => event.phase === "failed")).toHaveLength(0);
+  });
+
+  test("diagnostic observer is synchronous/no-throw and runs before durable audit", async () => {
+    const order: string[] = [];
+    const response = await codexRequestStorage.run(
+      ctx({
+        onModelRequestDiagnostic: () => {
+          order.push("diagnostic");
+          throw new Error("metrics exporter failure");
+        },
+        onModelRequestEvent: (event) => {
+          order.push(`audit:${event.phase}`);
+        },
+      }),
+      () =>
+        codexSubscriptionFetch(codexBase)("https://chatgpt.com/backend-api/responses", {
+          method: "POST",
+          body: JSON.stringify({ model: "gpt-5.6-sol", input: [] }),
+        }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(order.slice(0, 2)).toEqual(["diagnostic", "audit:started"]);
   });
 
   test("streaming caller: successful bytes pass through for model-level reconstruction", async () => {


### PR DESCRIPTION
## Summary

- Fence Codex model-request terminal outcomes so one admitted request cannot emit conflicting terminal truth or leave the turn running after a terminal failure.
- Preserve first-write-wins for one terminal outcome per `(requestId, transportAttempt)`, including late stream cleanup, cancellation, timeout, and 401-refresh paths.
- Capture bounded provider-request lifecycle observability with fixed-cardinality metric labels; request identifiers, bodies, credentials, session ids, and token content are never metric labels or payloads.
- **Semantic remediation:** terminal event spelling no longer overrides embedded provider response semantics. `response.failed`, `response.incomplete`, and `response.error` are failed; `response.completed`/`response.done` are completed only when embedded response semantics are successful. Contradictory success-spelled terminals now fail truthfully.

## Root cause and fix

`packages/codex/src/fetch.ts` classified contradictory `response.completed`/`response.done` events correctly for streaming callers, but the non-streaming SSE-to-JSON path treated either event spelling as successful. That allowed non-stream callers to return HTTP 200/body status `failed` or `incomplete` while lifecycle diagnostics ended in `completed`.

The repair uses one shared terminal classifier for both non-streaming and streaming paths. Embedded `response.status` and `response.error` take precedence over event spelling; valid successful terminals remain `completed`, while failed/incomplete/error semantics become one terminal `failed` outcome.

## Scope

The final diff is exactly one focused commit across exactly seven paths:

- `apps/worker/src/activities/agent-turn.ts`
- `apps/worker/src/observability-metrics.ts`
- `apps/worker/test/streaming-slis.test.ts`
- `docs/run-lifecycle.md`
- `packages/codex/src/fetch.ts`
- `packages/codex/src/request-context.ts`
- `packages/codex/test/fetch.test.ts`

The change does not independently implement the database deadlock fix; latest protected `main` already includes #1367 (`fix(db): avoid session activity deadlocks`) and the newer #1368 Slack native task-actions commit.

## Final delivery identity

- Protected latest `main`: `ad8286e781da77d2d2315c93aa79f50bb972c7b5`
  - tree: `5a9f9fa3bfc9bdc69c12a44da1b3407ba5a210e3`
  - sole parent: `30c3d958898b4f8964109886153282cc935e7512`
  - subject: `feat(slack): add native task actions (#1368)`
- Final PR head after exact-latest-main replay: `cfb02ff81177b017f9fe24d2bcdc10e95dd51526`
  - tree: `0aaea6317bc0f9d4fb27ddad63979d09eb9f0e5a`
  - sole parent/base: `ad8286e781da77d2d2315c93aa79f50bb972c7b5`
  - subject: `fix(codex): fence model request terminal outcomes`
- PR #1369 is open, non-draft, unmerged, mergeable, and has exactly one commit and seven changed files. The head was updated with an explicit `--force-with-lease` against the verified prior remote head `79d974d3f055703f696abfcdaba09e69168ccf9b`.

## Regression coverage

Added non-vacuous tests for the exact contradictory-terminal cases:

- Non-stream `response.completed` with embedded `response.status = "failed"` and error payload.
- Non-stream `response.done` with embedded `response.status = "incomplete"`.
- Streaming equivalents for both contradictory terminal spellings.
- Each asserts one terminal lifecycle outcome with phase `failed`.

Existing coverage remains green for cancellation after semantic success, timeout and missing-terminal handling, pre-header/network failures, 401 attempt correlation, monotonic durations, diagnostic-before-awaited-durable ordering, bounded labels, and fixed-cardinality metrics.

## Validation on final replayed tree

- `bun install --frozen-lockfile` — PASS; no dependency or lockfile changes.
- `bun test packages/codex/test` — PASS; **227 passed, 0 failed** across 11 files.
- `bun test apps/worker/test/agent-turn.test.ts apps/worker/test/streaming-slis.test.ts` — PASS; **179 passed, 0 failed**.
- `bun run typecheck` — PASS; **all 30 projects clean**.
- `bun run lint` — PASS; **0 warnings, 0 errors** across 2,287 files.
- `bunx oxfmt --check` supplied all seven changed paths — PASS; six formatter-supported files checked, with the Markdown documentation path not treated as an oxfmt input.
- `git diff --check ad8286e781da77d2d2315c93aa79f50bb972c7b5...HEAD` — PASS.
- Exact seven-path diff and final working tree — PASS; working tree clean.

## Independent contradictory-terminal probe

All four cases produced exactly one terminal lifecycle phase and the expected typed failure:

- Non-stream `response.completed` + embedded `failed`: HTTP **502**, code `provider_failed`, phases `[started, headers, first_byte, failed]`.
- Non-stream `response.done` + embedded `incomplete`: HTTP **502**, code `response_incomplete`, phases `[started, headers, first_byte, failed]`.
- Streaming `response.completed` + embedded `failed`: outer HTTP **200**; body consumption raises typed status **502**/code `provider_failed`, phases `[started, headers, first_byte, failed]`.
- Streaming `response.done` + embedded `incomplete`: outer HTTP **200**; body consumption raises typed status **502**/code `response_incomplete`, phases `[started, headers, first_byte, failed]`.

## Checks and safety

- Final current-base source admission passed for `cfb02ff8…`: run **31602532239**.
- New exact-head CI run **31602535683** was pending at handoff; no jobs were exposed yet. No workflow rerun was requested.
- Issue #1358 comments verified through the GitHub API: **0**. PR #1369 has **0** comments and **0** review comments.
- No merge, approval, deploy, release, cloud/provider/production mutation, or issue mutation was performed.
