### PR TITLE
feat(db): add user resource authority foundation

### DIFF
--- a/packages/db/drizzle/0230_user_scoped_variable_sets_rigs.sql
+++ b/packages/db/drizzle/0230_user_scoped_variable_sets_rigs.sql
@@ -1,0 +1,84 @@
+-- deployment-mode: rolling
+-- Inert authority identity foundation for Variable Sets and Rigs. This slice
+-- changes no runtime authorization, RLS policy, lifecycle GUC, API/DAO path,
+-- runnable snapshot, grant consumption, or worker materialization behavior.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+ALTER TABLE "workspace_variable_sets"
+  ADD COLUMN "authority_scope" text NOT NULL DEFAULT 'workspace',
+  ADD COLUMN "authority_id" uuid,
+  ADD COLUMN "owner_organization_membership_id" uuid,
+  ADD COLUMN "origin_workspace_id" uuid;
+
+ALTER TABLE "rigs"
+  ADD COLUMN "authority_scope" text NOT NULL DEFAULT 'workspace',
+  ADD COLUMN "authority_id" uuid,
+  ADD COLUMN "owner_organization_membership_id" uuid,
+  ADD COLUMN "origin_workspace_id" uuid;
+
+ALTER TABLE "workspace_variable_sets"
+  ADD CONSTRAINT "workspace_variable_sets_authority_scope_check"
+    CHECK ("authority_scope" IN ('workspace', 'user')) NOT VALID,
+  ADD CONSTRAINT "workspace_variable_sets_authority_shape_check" CHECK (
+    (
+      "authority_scope" = 'workspace'
+      AND "authority_id" IS NULL
+      AND "owner_organization_membership_id" IS NULL
+    ) OR (
+      "authority_scope" = 'user'
+      AND "authority_id" IS NOT NULL
+      AND "owner_organization_membership_id" IS NOT NULL
+    )
+  ) NOT VALID,
+  ADD CONSTRAINT "workspace_variable_sets_authority_fk" FOREIGN KEY (
+    "authority_id", "account_id", "owner_organization_membership_id"
+  ) REFERENCES "organization_user_resource_authorities"(
+    "id", "account_id", "organization_membership_id"
+  ) ON DELETE RESTRICT NOT VALID,
+  ADD CONSTRAINT "workspace_variable_sets_origin_workspace_fk" FOREIGN KEY (
+    "origin_workspace_id", "account_id"
+  ) REFERENCES "workspaces"("id", "account_id")
+    ON DELETE SET NULL ("origin_workspace_id") NOT VALID;
+
+ALTER TABLE "rigs"
+  ADD CONSTRAINT "rigs_authority_scope_check"
+    CHECK ("authority_scope" IN ('workspace', 'user')) NOT VALID,
+  ADD CONSTRAINT "rigs_authority_shape_check" CHECK (
+    (
+      "authority_scope" = 'workspace'
+      AND "authority_id" IS NULL
+      AND "owner_organization_membership_id" IS NULL
+    ) OR (
+      "authority_scope" = 'user'
+      AND "authority_id" IS NOT NULL
+      AND "owner_organization_membership_id" IS NOT NULL
+    )
+  ) NOT VALID,
+  ADD CONSTRAINT "rigs_authority_fk" FOREIGN KEY (
+    "authority_id", "account_id", "owner_organization_membership_id"
+  ) REFERENCES "organization_user_resource_authorities"(
+    "id", "account_id", "organization_membership_id"
+  ) ON DELETE RESTRICT NOT VALID,
+  ADD CONSTRAINT "rigs_origin_workspace_fk" FOREIGN KEY (
+    "origin_workspace_id", "account_id"
+  ) REFERENCES "workspaces"("id", "account_id")
+    ON DELETE SET NULL ("origin_workspace_id") NOT VALID;
+
+ALTER TABLE "workspace_variable_sets"
+  VALIDATE CONSTRAINT "workspace_variable_sets_authority_scope_check",
+  VALIDATE CONSTRAINT "workspace_variable_sets_authority_shape_check",
+  VALIDATE CONSTRAINT "workspace_variable_sets_authority_fk",
+  VALIDATE CONSTRAINT "workspace_variable_sets_origin_workspace_fk";
+
+ALTER TABLE "rigs"
+  VALIDATE CONSTRAINT "rigs_authority_scope_check",
+  VALIDATE CONSTRAINT "rigs_authority_shape_check",
+  VALIDATE CONSTRAINT "rigs_authority_fk",
+  VALIDATE CONSTRAINT "rigs_origin_workspace_fk";
+
+COMMENT ON COLUMN "workspace_variable_sets"."authority_scope" IS
+  'Inert authority identity foundation. Runtime access remains workspace-scoped until a later activation migration.';
+COMMENT ON COLUMN "rigs"."authority_scope" IS
+  'Inert authority identity foundation. Runtime access remains workspace-scoped until a later activation migration.';

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -619,6 +619,13 @@ export const workspaceVariableSets = pgTable(
       .references(() => workspaces.id, { onDelete: "cascade" }),
     name: text("name").notNull(),
     description: text("description"),
+    // Migration 0230 is schema-only: all shipped CRUD continues to omit these
+    // fields and therefore remains workspace-scoped. A later activation slice
+    // must provide the complete owner authority and runtime protocol.
+    authorityScope: text("authority_scope").notNull().default("workspace"),
+    authorityId: uuid("authority_id"),
+    ownerOrganizationMembershipId: uuid("owner_organization_membership_id"),
+    originWorkspaceId: uuid("origin_workspace_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -631,6 +638,33 @@ export const workspaceVariableSets = pgTable(
       table.workspaceId,
       table.createdAt,
     ),
+    authorityShape: check(
+      "workspace_variable_sets_authority_shape_check",
+      sql`(
+          ${table.authorityScope} = 'workspace'
+          and ${table.authorityId} is null
+          and ${table.ownerOrganizationMembershipId} is null
+        ) or (
+          ${table.authorityScope} = 'user'
+          and ${table.authorityId} is not null
+          and ${table.ownerOrganizationMembershipId} is not null
+        )`,
+    ),
+    authorityScopeValid: check(
+      "workspace_variable_sets_authority_scope_check",
+      sql`${table.authorityScope} in ('workspace', 'user')`,
+    ),
+    authority: foreignKey({
+      name: "workspace_variable_sets_authority_fk",
+      columns: [table.authorityId, table.accountId, table.ownerOrganizationMembershipId],
+      foreignColumns: [
+        organizationUserResourceAuthorities.id,
+        organizationUserResourceAuthorities.accountId,
+        organizationUserResourceAuthorities.organizationMembershipId,
+      ],
+    }).onDelete("restrict"),
+    // PostgreSQL's column-subset SET NULL action preserves account_id; Drizzle
+    // cannot represent that action, so migration 0230 owns the origin FK.
   }),
 );
 
@@ -9000,12 +9034,44 @@ export const rigs = pgTable(
     description: text("description"),
     // Attribution string: 'user:<subject>' | 'session:<id>' | 'system'.
     createdBy: text("created_by"),
+    // Inert migration-0230 identity foundation. Existing DAO/API/runtime paths
+    // omit these fields and keep their historical workspace authority.
+    authorityScope: text("authority_scope").notNull().default("workspace"),
+    authorityId: uuid("authority_id"),
+    ownerOrganizationMembershipId: uuid("owner_organization_membership_id"),
+    originWorkspaceId: uuid("origin_workspace_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     workspaceName: uniqueIndex("rigs_workspace_name_idx").on(table.workspaceId, table.name),
     workspaceCreated: index("rigs_workspace_created_idx").on(table.workspaceId, table.createdAt),
+    authorityShape: check(
+      "rigs_authority_shape_check",
+      sql`(
+          ${table.authorityScope} = 'workspace'
+          and ${table.authorityId} is null
+          and ${table.ownerOrganizationMembershipId} is null
+        ) or (
+          ${table.authorityScope} = 'user'
+          and ${table.authorityId} is not null
+          and ${table.ownerOrganizationMembershipId} is not null
+        )`,
+    ),
+    authorityScopeValid: check(
+      "rigs_authority_scope_check",
+      sql`${table.authorityScope} in ('workspace', 'user')`,
+    ),
+    authority: foreignKey({
+      name: "rigs_authority_fk",
+      columns: [table.authorityId, table.accountId, table.ownerOrganizationMembershipId],
+      foreignColumns: [
+        organizationUserResourceAuthorities.id,
+        organizationUserResourceAuthorities.accountId,
+        organizationUserResourceAuthorities.organizationMembershipId,
+      ],
+    }).onDelete("restrict"),
+    // Migration 0230 owns the origin-workspace FK's column-subset SET NULL.
   }),
 );
 

--- a/packages/db/test/migration-0230-user-scoped-variable-sets-rigs.test.ts
+++ b/packages/db/test/migration-0230-user-scoped-variable-sets-rigs.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from "bun:test";
+import { acquireBlankTestDatabase } from "@opengeni/testing";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+import { migrate } from "../src/migrate";
+
+const migrationName = "0230_user_scoped_variable_sets_rigs.sql";
+const migrationUrl = new URL(`../drizzle/${migrationName}`, import.meta.url);
+const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), "../drizzle");
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+
+type SessionAuthorityCatalog = {
+  policies: Array<{
+    tableName: string;
+    usingExpression: string | null;
+    checkExpression: string | null;
+  }>;
+  routines: Array<{
+    name: string;
+    securityDefiner: boolean;
+    acl: string | null;
+    definition: string;
+  }>;
+};
+
+async function sessionAuthorityCatalog(sql: postgres.Sql): Promise<SessionAuthorityCatalog> {
+  const policies = await sql<SessionAuthorityCatalog["policies"]>`
+    select tablename as "tableName", qual as "usingExpression",
+      with_check as "checkExpression"
+    from pg_policies
+    where schemaname = current_schema()
+      and policyname = 'organization_tenancy_lifecycle'
+      and tablename in (
+        'organization_memberships', 'organization_user_resource_grants'
+      )
+    order by tablename
+  `;
+  const routines = await sql<SessionAuthorityCatalog["routines"]>`
+    select procedure.proname as name,
+      procedure.prosecdef as "securityDefiner",
+      procedure.proacl::text as acl,
+      pg_get_functiondef(procedure.oid) as definition
+    from pg_proc procedure
+    join pg_namespace namespace on namespace.oid = procedure.pronamespace
+    where namespace.nspname = current_schema()
+      and procedure.proname in (
+        'transition_session_visibility', 'fork_session_content'
+      )
+    order by procedure.proname
+  `;
+  return { policies: Array.from(policies), routines: Array.from(routines) };
+}
+
+describe("migration 0230 Variable Set and Rig authority foundation", () => {
+  test("is an inert additive foundation that preserves migration 0225 authority", async () => {
+    const source = await readFile(migrationUrl, "utf8");
+    const executableSource = source.replace(/^--.*$/gmu, "");
+    expect(source.split(/\r?\n/u, 1)[0]).toBe("-- deployment-mode: rolling");
+    expect(source).toContain('ALTER TABLE "workspace_variable_sets"');
+    expect(source).toContain('ALTER TABLE "rigs"');
+    expect(source).toContain("\"authority_scope\" text NOT NULL DEFAULT 'workspace'");
+    expect(source).toContain("workspace_variable_sets_authority_shape_check");
+    expect(source).toContain("rigs_authority_shape_check");
+    expect(source).toContain("organization_user_resource_authorities");
+    expect(source).toContain('ON DELETE SET NULL ("origin_workspace_id")');
+    expect(executableSource).not.toMatch(/organization_tenancy_lifecycle/u);
+    expect(executableSource).not.toMatch(/CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION/iu);
+    expect(executableSource).not.toMatch(/CREATE\s+POLICY|DROP\s+POLICY/iu);
+    expect(executableSource).not.toMatch(/\bGRANT\b|\bREVOKE\b/iu);
+    expect(executableSource).not.toMatch(/session_turn_attempts|scheduled_task_runs/u);
+    expect(executableSource).not.toMatch(/user_resource_runtime_capabilities/u);
+    expect(executableSource).not.toMatch(
+      /bind_user_resource_authority|resolve_user_resource_authority/u,
+    );
+    expect(executableSource).not.toMatch(/value_encrypted|plaintext|secret_value/u);
+
+    const blank = await acquireBlankTestDatabase(
+      "migration-0230-user-resource-authority-foundation",
+    );
+    if (!blank && requireRealDatabase) {
+      throw new Error(
+        "[migration-0230-user-resource-authority-foundation] OPENGENI_REQUIRE_REAL_DB=1 but PostgreSQL is unavailable",
+      );
+    }
+    if (!blank) return;
+
+    const sql = postgres(blank.databaseUrl, { max: 1, onnotice: () => undefined });
+    try {
+      // Use the real migration runner for every special directive, but mark
+      // 0230 and later migrations as already applied so we can capture an exact
+      // catalog checkpoint immediately after the predecessors (including 0225).
+      const laterMigrations = (await readdir(migrationsDir))
+        .filter((file) => file.endsWith(".sql") && file >= migrationName)
+        .sort();
+      await sql.unsafe(
+        "create table if not exists schema_migrations (name text primary key, applied_at timestamptz not null default now())",
+      );
+      for (const file of laterMigrations) {
+        await sql`insert into schema_migrations (name) values (${file}) on conflict do nothing`;
+      }
+      await migrate(blank.databaseUrl);
+      const before0230 = await sessionAuthorityCatalog(sql);
+
+      await sql.unsafe(source);
+      const after0230 = await sessionAuthorityCatalog(sql);
+      expect(after0230).toEqual(before0230);
+
+      expect(after0230.policies).toHaveLength(2);
+      for (const policy of after0230.policies) {
+        expect(policy.usingExpression).toContain("managed_human_provisioning");
+        expect(policy.usingExpression).toContain("session_visibility_activation");
+        expect(policy.checkExpression).toBe(policy.usingExpression);
+      }
+      expect(
+        after0230.routines.map(({ name, securityDefiner }) => ({
+          name,
+          securityDefiner,
+        })),
+      ).toEqual([
+        { name: "fork_session_content", securityDefiner: true },
+        { name: "transition_session_visibility", securityDefiner: true },
+      ]);
+      for (const routine of after0230.routines) {
+        expect(routine.definition).toContain("opengeni.organization_tenancy_lifecycle");
+        expect(routine.definition).toContain("session_visibility_activation");
+      }
+
+      const columns = await sql<
+        Array<{
+          tableName: string;
+          columnName: string;
+          nullable: boolean;
+          defaultValue: string | null;
+        }>
+      >`
+        select table_name as "tableName", column_name as "columnName",
+          is_nullable = 'YES' as nullable, column_default as "defaultValue"
+        from information_schema.columns
+        where table_schema = current_schema()
+          and table_name in ('workspace_variable_sets', 'rigs')
+          and column_name in (
+            'authority_scope', 'authority_id',
+            'owner_organization_membership_id', 'origin_workspace_id'
+          )
+        order by table_name, column_name
+      `;
+      expect(columns).toHaveLength(8);
+      for (const tableName of ["rigs", "workspace_variable_sets"]) {
+        expect(
+          columns.find(
+            (column) => column.tableName === tableName && column.columnName === "authority_scope",
+          ),
+        ).toMatchObject({ nullable: false, defaultValue: "'workspace'::text" });
+      }
+
+      const [account] = await sql<{ id: string }[]>`
+        insert into managed_accounts (name) values ('migration-0230-account') returning id
+      `;
+      const [workspace] = await sql<{ id: string }[]>`
+        insert into workspaces (account_id, name)
+        values (${account!.id}, 'migration-0230-workspace') returning id
+      `;
+      const [variableSet] = await sql<
+        Array<{
+          authorityScope: string;
+          authorityId: string | null;
+          ownerMembershipId: string | null;
+          originWorkspaceId: string | null;
+        }>
+      >`
+        insert into workspace_variable_sets (account_id, workspace_id, name)
+        values (${account!.id}, ${workspace!.id}, 'default-workspace-variable-set')
+        returning authority_scope as "authorityScope", authority_id as "authorityId",
+          owner_organization_membership_id as "ownerMembershipId",
+          origin_workspace_id as "originWorkspaceId"
+      `;
+      const [rig] = await sql<
+        Array<{
+          authorityScope: string;
+          authorityId: string | null;
+          ownerMembershipId: string | null;
+          originWorkspaceId: string | null;
+        }>
+      >`
+        insert into rigs (account_id, workspace_id, name)
+        values (${account!.id}, ${workspace!.id}, 'default-workspace-rig')
+        returning authority_scope as "authorityScope", authority_id as "authorityId",
+          owner_organization_membership_id as "ownerMembershipId",
+          origin_workspace_id as "originWorkspaceId"
+      `;
+      const expectedWorkspaceAuthority = {
+        authorityScope: "workspace",
+        authorityId: null,
+        ownerMembershipId: null,
+        originWorkspaceId: null,
+      };
+      expect(variableSet).toEqual(expectedWorkspaceAuthority);
+      expect(rig).toEqual(expectedWorkspaceAuthority);
+
+      const [inert] = await sql<
+        Array<{
+          bindRoutine: boolean;
+          resolveRoutine: boolean;
+          privateCapabilities: boolean;
+          attemptSnapshots: number;
+          scheduledSnapshots: number;
+        }>
+      >`
+        select
+          to_regprocedure(
+            'bind_user_resource_authority(uuid,uuid,text,text,uuid)'
+          ) is not null as "bindRoutine",
+          to_regprocedure(
+            'resolve_user_resource_authority(uuid,uuid,text,text,uuid,text,uuid,integer,boolean)'
+          ) is not null as "resolveRoutine",
+          to_regclass('opengeni_private.user_resource_runtime_capabilities') is not null
+            as "privateCapabilities",
+          (
+            select count(*)::int from information_schema.columns
+            where table_schema = current_schema()
+              and table_name = 'session_turn_attempts'
+              and column_name like 'variable_set_authority_%'
+          ) as "attemptSnapshots",
+          (
+            select count(*)::int from information_schema.columns
+            where table_schema = current_schema()
+              and table_name = 'scheduled_task_runs'
+              and column_name like 'variable_set_authority_%'
+          ) as "scheduledSnapshots"
+      `;
+      expect(inert).toEqual({
+        bindRoutine: false,
+        resolveRoutine: false,
+        privateCapabilities: false,
+        attemptSnapshots: 0,
+        scheduledSnapshots: 0,
+      });
+    } finally {
+      await sql.end();
+      await blank.release();
+    }
+  }, 300_000);
+});

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -127,8 +127,8 @@ describe("release schema contract", () => {
       if (!migrations.has("0236_session_visibility_slack_policy.sql")) return null;
       if (migrations.has("0228_interaction_controller_data_plane.sql")) {
         return includesActivation
-          ? "cd849d761b5d79454d213a3c26d5d20ab0906db3ba1462866dfa7893f2ff417b"
-          : "71ec3a7b1a61c681eba76d88d22dae8e1f3c3d1f194f1732e1b5ba4ffe703238";
+          ? "2f0bfa7a465e47bbca27a79cc594f953e59a94e42ff704ab11e258523d19ad42"
+          : "712d1680b4aa6e22346fc2f2ef33458543e8fcd0025b5d793d996ef5ec586452";
       }
       if (migrations.has("0229_slack_inbox_file_fact.sql")) {
         return includesActivation
@@ -411,6 +411,7 @@ describe("release schema contract", () => {
         (migrations.has("0228_slack_task_policy.sql") ? 1 : 0) +
         (migrations.has("0228_interaction_controller_data_plane.sql") ? 1 : 0) +
         (migrations.has("0229_slack_inbox_file_fact.sql") ? 1 : 0) +
+        (migrations.has("0230_user_scoped_variable_sets_rigs.sql") ? 1 : 0) +
         (migrations.has("0231_integration_definition_identity_cutover.sql") ? 1 : 0) +
         (migrations.has("0232_integration_facet_authority_cutover.sql") ? 1 : 0) +
         (migrations.has("0233_skill_and_integration_authority_cutover.sql") ? 1 : 0) +
@@ -434,25 +435,27 @@ describe("release schema contract", () => {
                 ? "0232_integration_facet_authority_cutover.sql"
                 : migrations.has("0231_integration_definition_identity_cutover.sql")
                   ? "0231_integration_definition_identity_cutover.sql"
-                  : migrations.has("0228_slack_task_policy.sql")
-                    ? "0228_slack_task_policy.sql"
-                    : migrations.has("0229_slack_inbox_file_fact.sql")
-                      ? "0229_slack_inbox_file_fact.sql"
-                      : migrations.has("0227_slack_native_actions.sql")
-                        ? "0227_slack_native_actions.sql"
-                        : migrations.has("0224_slack_post_outcome_reconciliation.sql")
-                          ? "0224_slack_post_outcome_reconciliation.sql"
-                          : migrations.has("0223_sessions_channel_fk_validate.sql")
-                            ? "0223_sessions_channel_fk_validate.sql"
-                            : migrations.has("0221_sessions_channel_index.sql")
-                              ? "0221_sessions_channel_index.sql"
-                              : migrations.has("0220_memory_slack_append_only_cascade.sql")
-                                ? "0220_memory_slack_append_only_cascade.sql"
-                                : migrations.has("0219_site_auth_maintenance_sessions.sql")
-                                  ? "0219_site_auth_maintenance_sessions.sql"
-                                  : migrations.has("0218_organization_tenancy_foundation.sql")
-                                    ? "0218_organization_tenancy_foundation.sql"
-                                    : "0217_capability_definition_delete_authority.sql",
+                  : migrations.has("0230_user_scoped_variable_sets_rigs.sql")
+                    ? "0230_user_scoped_variable_sets_rigs.sql"
+                    : migrations.has("0228_slack_task_policy.sql")
+                      ? "0228_slack_task_policy.sql"
+                      : migrations.has("0229_slack_inbox_file_fact.sql")
+                        ? "0229_slack_inbox_file_fact.sql"
+                        : migrations.has("0227_slack_native_actions.sql")
+                          ? "0227_slack_native_actions.sql"
+                          : migrations.has("0224_slack_post_outcome_reconciliation.sql")
+                            ? "0224_slack_post_outcome_reconciliation.sql"
+                            : migrations.has("0223_sessions_channel_fk_validate.sql")
+                              ? "0223_sessions_channel_fk_validate.sql"
+                              : migrations.has("0221_sessions_channel_index.sql")
+                                ? "0221_sessions_channel_index.sql"
+                                : migrations.has("0220_memory_slack_append_only_cascade.sql")
+                                  ? "0220_memory_slack_append_only_cascade.sql"
+                                  : migrations.has("0219_site_auth_maintenance_sessions.sql")
+                                    ? "0219_site_auth_maintenance_sessions.sql"
+                                    : migrations.has("0218_organization_tenancy_foundation.sql")
+                                      ? "0218_organization_tenancy_foundation.sql"
+                                      : "0217_capability_definition_delete_authority.sql",
     );
     expect(migrations.get("0214_session_activity_commit_gate.sql")).toMatchObject({
       sha256: "26c84bc34bc51d19f9532cf3f2c64a649f100a724cb73d968e17e7c4ecf8de36",
@@ -590,6 +593,10 @@ describe("release schema contract", () => {
         deploymentMode: "rolling",
       });
     }
+    expect(migrations.get("0230_user_scoped_variable_sets_rigs.sql")).toMatchObject({
+      sha256: "560adbe658efa212ec44ad18f6af22ac874568d60a331beddae4102d00a09e5f",
+      deploymentMode: "rolling",
+    });
     expect(migrations.get("0226_personal_codex_authority_foundation.sql")).toMatchObject({
       sha256: "34b72f6ab031596c90f2f35957c707aaf013c2f52aee8ca92a70fdb8ab9cb9ce",
       deploymentMode: "rolling",


### PR DESCRIPTION
## Summary

- add the inert schema foundation for explicit `workspace | user` authority on Variable Sets and Rigs
- add owner identity plus authority-shape constraints/FKs for `workspace_variable_sets` and `rigs`
- preserve the existing migration-0225 organization-tenancy lifecycle catalog, policies, routines, and runtime posture
- reserve unique rolling migration `0230_user_scoped_variable_sets_rigs.sql` for this bounded foundation

## Scope

This is the narrowed **OPE-231** foundation only. It does **not** activate user-scoped CRUD, materialization, bind/resolve behavior, session or scheduled-task delegation snapshots, worker execution, transitive Rig-default authority, or atomic once-grant consumption. Those behaviors are intentionally split into dependent follow-up issues, including OPE-232 and OPE-233.

Changed paths are limited to:

- `packages/db/drizzle/0230_user_scoped_variable_sets_rigs.sql`
- `packages/db/src/schema.ts`
- `packages/db/test/migration-0230-user-scoped-variable-sets-rigs.test.ts`
- `scripts/release-schema-contract.test.ts`

## Validation

- focused migration and release-schema tests: 7 pass, 0 fail
- database package typecheck and build
- migration/runtime-posture preservation checks
- changed-file formatting and `git diff --check`
- forbidden runtime-activation audit: clean
- migration SHA-256: `560adbe658efa212ec44ad18f6af22ac874568d60a331beddae4102d00a09e5f`

## Current-main compatibility

The exact head `eb0b1fa1011f4132a3685e1fcf995c886302b494` has zero changed-path overlap with protected `main` advancement through `5397e3169fda8d97a260d760e122df6971029558`. A disposable no-commit merge completed cleanly with integrated tree `57cb17d9a0d447cbc966b57ca23d06d690579d30`.

No deployment, release, cloud/provider, production, ruleset, workflow-rerun, or unrelated mutation is part of this PR.

Linear: OPE-231
