### PR TITLE
chore(release): bump product version to 0.23.3

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.2
-appVersion: "0.23.2"
+version: 0.23.3
+appVersion: "0.23.3"


### PR DESCRIPTION
Bump the source-controlled OpenGeni product/chart identity from `0.23.2` to `0.23.3` before producing the next immutable release candidate.

Validation:
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml` → `0.23.3`
- 21 focused release/chart contract tests pass
- Helm `v4.2.3` lint and render pass
- `0.23.3` is absent across all seven official GHCR image roles and the official chart repository
- `git diff --check` passes

This is a focused release-identity change; npm package versioning remains owned by the Changesets Version PR.