### PR TITLE
fix(react): unify durable composer attachments

### DIFF
--- a/.changeset/clean-composer-attachments.md
+++ b/.changeset/clean-composer-attachments.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Render durable composer files through the attachment-card owner, hydrate restored filename and image preview metadata, and preserve exact custom mounts and local previews across draft reconciliation.

--- a/apps/web/src/lib/use-new-session-draft.test.tsx
+++ b/apps/web/src/lib/use-new-session-draft.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type {
   FileAsset,
+  FileResourceRef,
   NewSessionDraft,
   OpenGeniClient,
   SaveNewSessionDraftRequest,
@@ -70,14 +71,18 @@ function renderDraftHook(draftClient: DraftClient, workspaceId = WORKSPACE_A) {
     (props: { client: DraftClient; workspaceId: string }) => {
       const [value, setValue] = useState(() => editable());
       const [files, setFiles] = useState<FileAsset[]>([]);
+      const [fileResources, setFileResources] = useState<FileResourceRef[]>([]);
       const draft = useNewSessionDraft({
         client: props.client,
         workspaceId: props.workspaceId,
         value,
         onApplyRemote: setValue,
-        restoreReadyFiles: (next) => setFiles([...next]),
+        restoreReadyFiles: (next, resources) => {
+          setFiles([...next]);
+          setFileResources([...(resources ?? [])]);
+        },
       });
-      return { draft, value, setValue, files };
+      return { draft, value, setValue, files, fileResources };
     },
     { client: draftClient, workspaceId },
   );
@@ -154,11 +159,45 @@ describe("useNewSessionDraft", () => {
     expect(hook.result.current.value.text).toBe("restore me");
     expect(hook.result.current.value.resources).toEqual([
       { kind: "repository", uri: "https://example.com/repo.git", ref: "main" },
-      { kind: "file", fileId: readyId },
+      { kind: "file", fileId: readyId, mountPath: `files/${readyId}` },
     ]);
     expect(hook.result.current.files.map((file) => file.id)).toEqual([readyId]);
+    expect(hook.result.current.fileResources).toEqual([
+      { kind: "file", fileId: readyId, mountPath: `files/${readyId}` },
+    ]);
     expect(hook.result.current.draft.loading).toBe(false);
     expect(saves).toHaveLength(0);
+    await hook.unmount();
+  });
+
+  test("retains distinct mounts for one revalidated file while reading metadata once", async () => {
+    const fileId = "00000000-0000-4000-8000-000000000021";
+    let reads = 0;
+    const hook = await renderDraftHook(
+      client({
+        getNewSessionDraft: async () =>
+          remote(3, {
+            resources: [
+              { kind: "file", fileId, mountPath: "inputs/primary.png" },
+              { kind: "file", fileId, mountPath: "inputs/reference.png" },
+            ],
+          }),
+        getFile: async () => {
+          reads += 1;
+          return asset(fileId, { filename: "shared.png", contentType: "image/png" });
+        },
+      }),
+    );
+    await flush();
+
+    const expected: FileResourceRef[] = [
+      { kind: "file", fileId, mountPath: "inputs/primary.png" },
+      { kind: "file", fileId, mountPath: "inputs/reference.png" },
+    ];
+    expect(reads).toBe(1);
+    expect(hook.result.current.value.resources).toEqual(expected);
+    expect(hook.result.current.files.map((file) => file.id)).toEqual([fileId]);
+    expect(hook.result.current.fileResources).toEqual(expected);
     await hook.unmount();
   });
 

--- a/apps/web/src/lib/use-new-session-draft.ts
+++ b/apps/web/src/lib/use-new-session-draft.ts
@@ -1,6 +1,7 @@
 import { stableJson } from "@opengeni/contracts";
 import type {
   FileAsset,
+  FileResourceRef,
   NewSessionDraft,
   OpenGeniClient,
   ResourceRef,
@@ -19,7 +20,7 @@ export type UseNewSessionDraftOptions = {
   /** Apply a remote value to the controlled text/model/tool/options state. */
   onApplyRemote: (value: NewSessionDraftEditable) => void;
   /** Replace finalized attachments with freshly revalidated server assets. */
-  restoreReadyFiles: (files: Iterable<FileAsset>) => void;
+  restoreReadyFiles: (files: Iterable<FileAsset>, resources?: Iterable<FileResourceRef>) => void;
   /** Revalidate non-file resource identities against the current UI catalog. */
   hydrateResources?: (resources: ResourceRef[]) => ResourceRef[] | Promise<ResourceRef[]>;
   /** Keep the first read pending until catalogs needed for hydration are ready. */
@@ -61,6 +62,7 @@ type ValidatedRemoteDraft = {
   draft: NewSessionDraft;
   editable: NewSessionDraftEditable;
   files: FileAsset[];
+  fileResources: FileResourceRef[];
 };
 
 /**
@@ -107,31 +109,33 @@ export function useNewSessionDraft(options: UseNewSessionDraftOptions): UseNewSe
         ? await hydrateResources(remote.resources)
         : remote.resources;
       if (generation !== targetGeneration.current) return null;
-      const seen = new Set<string>();
-      const fileRefs = hydratedResources.flatMap((resource) => {
-        if (resource.kind !== "file" || seen.has(resource.fileId)) return [];
-        seen.add(resource.fileId);
-        return [resource];
-      });
+      const fileResources = hydratedResources.filter(
+        (resource): resource is FileResourceRef => resource.kind === "file",
+      );
+      const fileIds = [...new Set(fileResources.map((resource) => resource.fileId))];
       const settled = await Promise.allSettled(
-        fileRefs.map((resource) => client.getFile(workspaceId, resource.fileId)),
+        fileIds.map((fileId) => client.getFile(workspaceId, fileId)),
       );
       if (generation !== targetGeneration.current) return null;
       const files = settled.flatMap((result, index) => {
         if (result.status !== "fulfilled") return [];
         const file = result.value;
-        const expected = fileRefs[index]?.fileId;
+        const expected = fileIds[index];
         return file.id === expected && file.workspaceId === workspaceId && file.status === "ready"
           ? [file]
           : [];
       });
+      const readyFileIds = new Set(files.map((file) => file.id));
+      const readyFileResources = fileResources.filter((resource) =>
+        readyFileIds.has(resource.fileId),
+      );
       return {
         draft: remote,
         editable: {
           text: remote.text,
           resources: [
             ...hydratedResources.filter((resource) => resource.kind === "repository"),
-            ...files.map((file): ResourceRef => ({ kind: "file", fileId: file.id })),
+            ...readyFileResources,
           ],
           tools: remote.tools,
           toolsProvided: remote.toolsProvided,
@@ -141,6 +145,7 @@ export function useNewSessionDraft(options: UseNewSessionDraftOptions): UseNewSe
           options: remote.options,
         },
         files,
+        fileResources: readyFileResources,
       };
     },
     [client, hydrateResources, resourceHydrationReady, workspaceId],
@@ -166,7 +171,7 @@ export function useNewSessionDraft(options: UseNewSessionDraftOptions): UseNewSe
       setDraft(remote.draft);
       setCurrentConflict(null);
       setError(null);
-      restoreReadyFilesRef.current(remote.files);
+      restoreReadyFilesRef.current(remote.files, remote.fileResources);
       onApplyRemoteRef.current(remote.editable);
     },
     [setCurrentConflict],

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1176,9 +1176,7 @@ function SessionChatPane(props: {
     // draft, while retry keeps the original resource refs in the failed bubble.
     onSubmitted: (_text, input) => {
       attachments.removeReadyFiles(
-        (input.resources ?? []).flatMap((resource) =>
-          resource.kind === "file" ? [resource.fileId] : [],
-        ),
+        (input.resources ?? []).filter((resource) => resource.kind === "file"),
       );
       repositories.commitSent(input.resources ?? []);
     },

--- a/apps/web/src/routes/sessions-index.tsx
+++ b/apps/web/src/routes/sessions-index.tsx
@@ -346,9 +346,7 @@ function SessionsIndexRouteContent({
                   setMessage("");
                   setDraft(emptySessionDraft());
                   attachments.removeReadyFiles(
-                    submittedResources.flatMap((resource) =>
-                      resource.kind === "file" ? [resource.fileId] : [],
-                    ),
+                    submittedResources.filter((resource) => resource.kind === "file"),
                   );
                 } else if (
                   !acknowledged ||

--- a/examples/northstar-support/src/support-agent-panel.tsx
+++ b/examples/northstar-support/src/support-agent-panel.tsx
@@ -356,9 +356,7 @@ function LiveAgentSession({
     sendBlocked: () => attachments.hasUnresolved,
     onSent: (_text, input) =>
       attachments.removeReadyFiles(
-        (input.resources ?? []).flatMap((resource) =>
-          resource.kind === "file" ? [resource.fileId] : [],
-        ),
+        (input.resources ?? []).filter((resource) => resource.kind === "file"),
       ),
   });
   const status = sessionStatus ?? session?.status ?? null;

--- a/packages/react/demo/composer-attachments-harness.tsx
+++ b/packages/react/demo/composer-attachments-harness.tsx
@@ -1,0 +1,169 @@
+import {
+  DEFAULT_FILE_RESOURCE_MOUNT_ROOT,
+  type ComposerDraft,
+  type FileAsset,
+  type FileDownloadUrlResponse,
+  type SaveComposerDraftRequest,
+  type UploadFileInput,
+} from "@opengeni/sdk";
+import { ChatComposer, useComposer, useFileAttachments } from "@opengeni/react";
+import { createRoot } from "react-dom/client";
+
+import { MockOpenGeniClient } from "./mock";
+import "./styles.css";
+
+const WORKSPACE_ID = "11111111-2222-4333-8444-555555555555";
+const SESSION_ID = "99999999-8888-4777-8666-555555555555";
+const FILE_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const DRAFT_KEY = "opengeni:demo:composer-attachment-draft";
+const FILE_KEY = "opengeni:demo:composer-attachment-file";
+const VALID_IMAGE_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Z1xkAAAAASUVORK5CYII=";
+
+const params = new URLSearchParams(window.location.search);
+if (params.get("reset") === "1") {
+  localStorage.removeItem(DRAFT_KEY);
+  localStorage.removeItem(FILE_KEY);
+}
+const brokenPreview = params.get("preview") === "broken";
+
+function emptyDraft(): ComposerDraft {
+  return {
+    revision: 0,
+    text: "",
+    resources: [],
+    annotations: [],
+    model: "gpt-5.2",
+    reasoningEffort: "medium",
+    latencyMode: "standard",
+    sourceTurnId: null,
+    sourceTurnVersion: null,
+    updatedAt: null,
+  };
+}
+
+function readStored<T>(key: string): T | null {
+  const value = localStorage.getItem(key);
+  return value ? (JSON.parse(value) as T) : null;
+}
+
+class AttachmentFixtureClient extends MockOpenGeniClient {
+  override async getComposerDraft(
+    _workspaceId: string,
+    _sessionId: string,
+  ): Promise<ComposerDraft> {
+    return readStored<ComposerDraft>(DRAFT_KEY) ?? emptyDraft();
+  }
+
+  override async saveComposerDraft(
+    _workspaceId: string,
+    _sessionId: string,
+    request: any,
+  ): Promise<ComposerDraft> {
+    const input = request as SaveComposerDraftRequest;
+    const current = await this.getComposerDraft(WORKSPACE_ID, SESSION_ID);
+    const saved: ComposerDraft = {
+      revision: current.revision + 1,
+      text: input.text,
+      resources: input.resources.map((resource) =>
+        resource.kind === "file"
+          ? {
+              ...resource,
+              mountPath:
+                resource.mountPath ?? `${DEFAULT_FILE_RESOURCE_MOUNT_ROOT}/${resource.fileId}`,
+            }
+          : resource,
+      ),
+      annotations: input.annotations,
+      model: input.model,
+      reasoningEffort: input.reasoningEffort,
+      latencyMode: input.latencyMode,
+      sourceTurnId: null,
+      sourceTurnVersion: null,
+      updatedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(saved));
+    document.documentElement.dataset.savedDraftResources = String(saved.resources.length);
+    return saved;
+  }
+
+  override async uploadFile(workspaceId: string, input: UploadFileInput): Promise<FileAsset> {
+    const sizeBytes = input.data instanceof Blob ? input.data.size : 0;
+    const file: FileAsset = {
+      id: FILE_ID,
+      workspaceId,
+      status: "ready",
+      filename: input.filename,
+      safeFilename: input.filename,
+      contentType: input.contentType,
+      sizeBytes,
+      sha256: null,
+      bucket: "demo-files",
+      objectKey: FILE_ID,
+      createdAt: "2026-08-12T00:00:00.000Z",
+      updatedAt: "2026-08-12T00:00:00.000Z",
+    };
+    localStorage.setItem(FILE_KEY, JSON.stringify(file));
+    return file;
+  }
+
+  override async getFile(_workspaceId: string, fileId: string): Promise<FileAsset> {
+    const file = readStored<FileAsset>(FILE_KEY);
+    if (!file || file.id !== fileId) throw new Error("file not found");
+    return file;
+  }
+
+  override async createFileDownloadUrl(
+    _workspaceId: string,
+    _fileId: string,
+  ): Promise<FileDownloadUrlResponse> {
+    return {
+      url: brokenPreview ? "/missing-composer-preview.png" : VALID_IMAGE_DATA_URL,
+      expiresAt: "2026-08-12T12:00:00.000Z",
+    };
+  }
+}
+
+const client = new AttachmentFixtureClient();
+
+function AttachmentHarness() {
+  const attachments = useFileAttachments({ client, workspaceId: WORKSPACE_ID });
+  const composer = useComposer(SESSION_ID, {
+    client,
+    workspaceId: WORKSPACE_ID,
+    events: [],
+    sendExtras: () => ({
+      resources: attachments.readyResources,
+      model: "gpt-5.2",
+      reasoningEffort: "medium",
+      latencyMode: "standard",
+    }),
+    sendBlocked: () => attachments.hasUnresolved,
+  });
+
+  return (
+    <main className="og-root min-h-dvh bg-og-bg p-8 text-og-fg">
+      <section
+        data-testid="attachment-harness"
+        data-attachment-count={attachments.attachments.length}
+        data-ready-resource-count={attachments.readyResources.length}
+        data-restored-resource-count={composer.restoredResources.length}
+        data-draft-resource-count={composer.draft?.resources.length ?? 0}
+        data-draft-revision={composer.draftRevision}
+        className="mx-auto flex max-w-3xl flex-col gap-4"
+      >
+        <h1 className="text-og-md font-semibold">Durable composer attachments</h1>
+        <button
+          type="button"
+          onClick={() => void composer.reloadDraft()}
+          className="w-fit rounded-og-md border border-og-border px-3 py-2 text-og-xs"
+        >
+          Reload draft
+        </button>
+        <ChatComposer composer={composer} attachments={attachments} />
+      </section>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<AttachmentHarness />);

--- a/packages/react/demo/composer-attachments.html
+++ b/packages/react/demo/composer-attachments.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="data:," />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@opengeni/react — durable composer attachments</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/composer-attachments-harness.tsx"></script>
+  </body>
+</html>

--- a/packages/react/demo/vite.config.ts
+++ b/packages/react/demo/vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
         browser: resolve(__dirname, "browser.html"),
         computer: resolve(__dirname, "computer.html"),
         composerResponsive: resolve(__dirname, "composer-responsive.html"),
+        composerAttachments: resolve(__dirname, "composer-attachments.html"),
       },
     },
   },

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -235,7 +235,8 @@ export type EmbeddedSessionLineageClientLike = EmbeddedSessionEventClientLike &
   Pick<OpenGeniClient, "getSessionLineage">;
 
 /** Exact client surface required by {@link useFileAttachments}. */
-export type EmbeddedFileAttachmentClientLike = Pick<OpenGeniClient, "uploadFile">;
+export type EmbeddedFileAttachmentClientLike = Pick<OpenGeniClient, "uploadFile"> &
+  Partial<Pick<OpenGeniClient, "getFile" | "createFileDownloadUrl">>;
 
 /** Exact client surface required by structured human-input hooks. */
 export type EmbeddedHumanInputSessionClientLike = EmbeddedSessionEventClientLike &

--- a/packages/react/src/components/composer.tsx
+++ b/packages/react/src/components/composer.tsx
@@ -45,6 +45,7 @@ import {
   type SlashCommandContext,
 } from "../hooks/use-slash-commands";
 import { cn } from "../lib/cn";
+import { fileResourceIdentity } from "../lib/resource-identity";
 import {
   ComposerResponsiveContext,
   type ResponsiveBasis,
@@ -77,6 +78,7 @@ export type ComposerDelivery = Pick<
 
 export type ComposerDraftState = Pick<
   ComposerState,
+  | "draftPersistence"
   | "draftConflict"
   | "draftSaving"
   | "resolveDraftConflict"
@@ -375,6 +377,61 @@ export function useChatComposerController({
     };
   }, []);
 
+  const hydratesRestoredFiles =
+    draft?.draftPersistence === "durable" && attachments?.restoreResources !== undefined;
+  const restoredFileResources = useMemo(
+    () =>
+      draft?.draftPersistence === "durable"
+        ? draft.restoredResources.filter((resource) => resource.kind === "file")
+        : [],
+    [draft?.draftPersistence, draft?.restoredResources],
+  );
+  const restoredFileSignature = restoredFileResources.map(fileResourceIdentity).join("\n");
+  useEffect(() => {
+    if (hydratesRestoredFiles) attachments.restoreResources?.(restoredFileResources);
+    // The serialized identity is the semantic dependency. Draft reloads often
+    // replace the array object without changing the selected file set; do not
+    // remint signed preview URLs for that incidental projection churn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attachments?.restoreResources, hydratesRestoredFiles, restoredFileSignature]);
+
+  const attachmentResourceKeys = useMemo(
+    () =>
+      new Set(
+        attachments?.attachments.flatMap((attachment) => {
+          const resource = attachmentResource(attachment);
+          return resource ? [fileResourceIdentity(resource)] : [];
+        }) ?? [],
+      ),
+    [attachments?.attachments],
+  );
+  const visibleRestoredResources = useMemo(
+    () =>
+      draft?.restoredResources.filter(
+        (resource) =>
+          resource.kind !== "file" ||
+          (!hydratesRestoredFiles && !attachmentResourceKeys.has(fileResourceIdentity(resource))),
+      ) ?? [],
+    [attachmentResourceKeys, draft?.restoredResources, hydratesRestoredFiles],
+  );
+
+  const removeAttachment = useCallback(
+    (attachmentId: string) => {
+      const attachment = attachments?.attachments.find(
+        (candidate) => candidate.id === attachmentId,
+      );
+      attachments?.remove(attachmentId);
+      const resource = attachment ? attachmentResource(attachment) : undefined;
+      if (!resource || !draft?.removeRestoredResource) return;
+      const key = fileResourceIdentity(resource);
+      const matching = draft.restoredResources.flatMap((candidate, index) =>
+        candidate.kind === "file" && fileResourceIdentity(candidate) === key ? [index] : [],
+      );
+      for (const index of matching.reverse()) draft.removeRestoredResource(index);
+    },
+    [attachments, draft],
+  );
+
   useEffect(() => {
     const openControl = (event: Event) => {
       const requestedId =
@@ -662,7 +719,7 @@ export function useChatComposerController({
     hasDraftState: draft !== undefined,
     draftConflict: draft?.draftConflict ?? null,
     draftSaving: draft?.draftSaving ?? false,
-    restoredResources: draft?.restoredResources ?? [],
+    restoredResources: visibleRestoredResources,
     removeRestoredResource: draft?.removeRestoredResource,
     resolveDraftConflict: draft?.resolveDraftConflict,
     hasControl: control !== undefined,
@@ -696,6 +753,7 @@ export function useChatComposerController({
     handlePaste,
     handleFileChange,
     focusInput: () => textareaRef.current?.focus(),
+    removeAttachment,
     setValue: delivery.setValue,
     value: delivery.value,
   };
@@ -909,8 +967,9 @@ export function Attachments() {
     <AttachmentChips
       attachments={controller.attachments.attachments}
       messages={controller.messages}
-      onRemove={controller.attachments.remove}
+      onRemove={controller.removeAttachment}
       onRetry={controller.attachments.retry}
+      onPreviewError={controller.attachments.failPreview}
     />
   );
 }
@@ -1601,18 +1660,26 @@ function AttachmentChips({
   messages,
   onRemove,
   onRetry,
+  onPreviewError,
 }: {
   attachments: UseFileAttachmentsResult["attachments"];
   messages: ChatComposerMessages;
   onRemove: (id: string) => void;
   onRetry?: ((id: string) => void) | undefined;
+  onPreviewError?: ((id: string) => void) | undefined;
 }) {
   return (
     <div className="flex flex-wrap gap-2 px-3 py-2">
       {attachments.map((attachment) => {
         const failed = attachment.status === "failed";
-        const statusText =
-          attachment.status === "uploading"
+        const fallbackFileId = attachment.resource?.fileId;
+        const displayName =
+          attachment.metadataStatus && fallbackFileId
+            ? messages.restoredFile(fallbackFileId)
+            : attachment.name;
+        const statusText = attachment.metadataStatus
+          ? ""
+          : attachment.status === "uploading"
             ? messages.uploading
             : failed
               ? attachment.error || messages.uploadFailed
@@ -1631,6 +1698,7 @@ function AttachmentChips({
               <img
                 src={attachment.previewUrl}
                 alt=""
+                onError={() => onPreviewError?.(attachment.id)}
                 className="size-8 shrink-0 rounded object-cover"
               />
             ) : attachment.contentType.startsWith("image/") ? (
@@ -1639,14 +1707,14 @@ function AttachmentChips({
               <FileIcon className="size-4 shrink-0 text-og-fg-muted" />
             )}
             <div className="min-w-0 flex-1">
-              <div className="truncate font-medium text-og-fg">{attachment.name}</div>
+              <div className="truncate font-medium text-og-fg">{displayName}</div>
               {failed ? (
                 <ComposerTip tip={statusText}>
                   <div className="truncate text-og-xs text-og-status-failed">{statusText}</div>
                 </ComposerTip>
-              ) : (
+              ) : statusText ? (
                 <div className="truncate text-og-xs text-og-fg-subtle">{statusText}</div>
-              )}
+              ) : null}
             </div>
             {attachment.status === "uploading" ? (
               <LoaderCircleIcon className="size-3.5 shrink-0 animate-og-spin" />
@@ -1667,7 +1735,7 @@ function AttachmentChips({
               type="button"
               onClick={() => onRemove(attachment.id)}
               className="shrink-0 rounded-og-xs p-1 text-og-fg-muted hover:bg-og-surface-1 hover:text-og-fg pointer-coarse:size-10"
-              aria-label={messages.removeAttachment(attachment.name)}
+              aria-label={messages.removeAttachment(displayName)}
             >
               <XIcon className="size-3.5" />
             </button>
@@ -1675,6 +1743,13 @@ function AttachmentChips({
         );
       })}
     </div>
+  );
+}
+
+function attachmentResource(attachment: UseFileAttachmentsResult["attachments"][number]) {
+  return (
+    attachment.resource ??
+    (attachment.file ? ({ kind: "file", fileId: attachment.file.id } as const) : undefined)
   );
 }
 

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -1,5 +1,4 @@
 import {
-  DEFAULT_FILE_RESOURCE_MOUNT_ROOT,
   type ComposerDraft,
   type DraftTimelineAnnotation,
   type EffectiveControlResumeOption,
@@ -12,6 +11,7 @@ import {
 } from "@opengeni/sdk";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useEmbeddedSession, type EmbeddedSessionClientOverride } from "../session-context";
+import { resourceIdentity } from "../lib/resource-identity";
 import { useSessionEventTrigger, type SessionEventFeedOptions } from "./internal";
 
 export type ComposerSendExtras = Omit<SendMessageInput, "text" | "clientEventId" | "annotations">;
@@ -2258,10 +2258,7 @@ function mergeResources(base: ResourceRef[], additions: ResourceRef[]): Resource
     // preserving the first representation keeps custom mounts and ordering
     // intact while preventing the draft and command paths from seeing
     // different duplicate counts after server normalization.
-    const key =
-      resource.kind === "file"
-        ? `file:${resource.fileId}\u0000${resource.mountPath ?? `${DEFAULT_FILE_RESOURCE_MOUNT_ROOT}/${resource.fileId}`}`
-        : JSON.stringify(resource);
+    const key = resourceIdentity(resource);
     if (seen.has(key)) return false;
     seen.add(key);
     return true;

--- a/packages/react/src/hooks/use-file-attachments.ts
+++ b/packages/react/src/hooks/use-file-attachments.ts
@@ -1,5 +1,15 @@
 import type { FileAsset, FileResourceRef } from "@opengeni/sdk";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import type { EmbeddedFileAttachmentClientLike } from "../client";
+import { fileResourceIdentity } from "../lib/resource-identity";
 import {
   useEmbeddedFileAttachments,
   type EmbeddedFileAttachmentClientOverride,
@@ -24,8 +34,16 @@ export type FileAttachment = {
   status: "uploading" | "ready" | "failed";
   /** The SDK `FileAsset` once the upload finishes. */
   file?: FileAsset | undefined;
+  /** Exact durable resource identity, including an optional custom mount. */
+  resource?: FileResourceRef | undefined;
+  /** True when this entry was reconstructed from durable resource authority. */
+  restored?: boolean | undefined;
+  /** Metadata hydration state for a durable reference that has no local File. */
+  metadataStatus?: "loading" | "failed" | undefined;
   /** Object-URL for an inline preview; minted for `image/*` files only. */
   previewUrl?: string | undefined;
+  /** A local or signed image URL failed to load; render the typed icon instead. */
+  previewFailed?: boolean | undefined;
   error?: string | undefined;
 };
 
@@ -48,8 +66,18 @@ export type UseFileAttachmentsResult = {
   addFiles: (files: Iterable<File>) => void;
   /** Clipboard path — applies `pasteFilter` (default `image/*`) then uploads. */
   addFromPaste: (event: { clipboardData: DataTransfer | null }) => void;
-  /** Restore already-ready server assets without recreating browser-local bytes. */
-  restoreReadyFiles: (files: Iterable<FileAsset>) => void;
+  /**
+   * Replace finalized attachments with already-revalidated server assets.
+   * Optional resources preserve custom mount identities; omitted resources use
+   * each file's canonical default mount.
+   */
+  restoreReadyFiles: (files: Iterable<FileAsset>, resources?: Iterable<FileResourceRef>) => void;
+  /**
+   * Reconstruct durable file references when only ResourceRef authority is
+   * available. Metadata and image previews hydrate opportunistically when the
+   * host exposes `getFile` / `createFileDownloadUrl`.
+   */
+  restoreResources?: ((resources: Iterable<FileResourceRef>) => void) | undefined;
   /**
    * Re-run the upload for a `failed` attachment, in place (same id, same
    * source file). No-op for an id that isn't a known failed upload.
@@ -57,12 +85,14 @@ export type UseFileAttachmentsResult = {
   retry: (id: string) => void;
   /** Remove one attachment; revokes its object-URL. */
   remove: (id: string) => void;
+  /** Drop a failed preview URL while preserving the underlying attachment. */
+  failPreview?: ((id: string) => void) | undefined;
   /**
    * Remove only finalized files whose durable ids were accepted by a send.
    * Attachments added while that request was in flight remain queued for the
    * next message.
    */
-  removeReadyFiles: (fileIds: Iterable<string>) => void;
+  removeReadyFiles: (resources: Iterable<string | FileResourceRef>) => void;
   /** Remove all attachments and revoke every object-URL. */
   clear: () => void;
 };
@@ -84,6 +114,8 @@ export function useFileAttachments(
   const { client, workspaceId } = useEmbeddedFileAttachments(options);
   const pasteFilter = options.pasteFilter ?? isImage;
   const [attachments, setAttachments] = useState<FileAttachment[]>([]);
+  const committedAttachments = useRef<FileAttachment[]>([]);
+  const fileMetadata = useRef<Map<string, FileAsset>>(new Map());
   // Keep the source File per attachment id so a failed upload can be retried
   // in place. Cleared on remove/clear so it never outlives its attachment.
   const sources = useRef<Map<string, File>>(new Map());
@@ -91,6 +123,10 @@ export function useFileAttachments(
   // state update when its component unmounts in the same batch that minted the
   // preview. The registry remains available to cleanup even before a render.
   const previewUrls = useRef<Map<string, string>>(new Map());
+  const restoreGeneration = useRef(0);
+  useLayoutEffect(() => {
+    committedAttachments.current = attachments;
+  }, [attachments]);
   const revokePreview = useCallback((id: string) => {
     const previewUrl = previewUrls.current.get(id);
     if (!previewUrl) return;
@@ -125,7 +161,9 @@ export function useFileAttachments(
     if (previous.client === client && previous.workspaceId === workspaceId) return;
     previousScope.current = { client, workspaceId };
     scopeGeneration.current += 1;
+    restoreGeneration.current += 1;
     sources.current.clear();
+    fileMetadata.current.clear();
     revokeAllPreviews();
     setAttachments([]);
   }, [client, revokeAllPreviews, workspaceId]);
@@ -133,7 +171,9 @@ export function useFileAttachments(
   useEffect(
     () => () => {
       scopeGeneration.current += 1;
+      restoreGeneration.current += 1;
       sources.current.clear();
+      fileMetadata.current.clear();
       revokeAllPreviews();
     },
     [revokeAllPreviews],
@@ -157,6 +197,7 @@ export function useFileAttachments(
           // Drop the source File immediately; restored/ready attachments must
           // never retain browser-local byte authority.
           sources.current.delete(id);
+          fileMetadata.current.set(asset.id, asset);
           setAttachments((current) =>
             current.map((attachment) =>
               attachment.id === id
@@ -164,6 +205,7 @@ export function useFileAttachments(
                     ...attachment,
                     status: "ready",
                     file: asset,
+                    resource: { kind: "file", fileId: asset.id },
                     name: asset.filename,
                     contentType: asset.contentType,
                     sizeBytes: asset.sizeBytes,
@@ -248,24 +290,37 @@ export function useFileAttachments(
   );
 
   const restoreReadyFiles = useCallback(
-    (files: Iterable<FileAsset>) => {
-      const incoming = new Map<string, FileAsset>();
+    (files: Iterable<FileAsset>, resources?: Iterable<FileResourceRef>) => {
+      const incomingFiles = new Map<string, FileAsset>();
       for (const file of files) {
         if (file.status === "ready" && file.workspaceId === workspaceId) {
-          incoming.set(file.id, file);
+          incomingFiles.set(file.id, file);
         }
       }
+      const incomingResources = resources
+        ? dedupeFileResources(resources).filter((resource) => incomingFiles.has(resource.fileId))
+        : [...incomingFiles.keys()].map((fileId): FileResourceRef => ({ kind: "file", fileId }));
+      for (const file of incomingFiles.values()) fileMetadata.current.set(file.id, file);
+      const existingReady = new Map(
+        committedAttachments.current.flatMap((attachment) =>
+          attachment.status === "ready" && attachment.resource
+            ? ([[fileResourceIdentity(attachment.resource), attachment]] as const)
+            : [],
+        ),
+      );
+      const generation = ++restoreGeneration.current;
       setAttachments((current) => {
         const unresolved = current.filter((attachment) => attachment.status !== "ready");
-        const existingReady = new Map(
+        const currentReady = new Map(
           current.flatMap((attachment) =>
-            attachment.status === "ready" && attachment.file
-              ? ([[attachment.file.id, attachment]] as const)
+            attachment.status === "ready" && attachment.resource
+              ? ([[fileResourceIdentity(attachment.resource), attachment]] as const)
               : [],
           ),
         );
-        const restored = [...incoming.values()].map((file): FileAttachment => {
-          const existing = existingReady.get(file.id);
+        const restored = incomingResources.map((resource): FileAttachment => {
+          const file = incomingFiles.get(resource.fileId)!;
+          const existing = currentReady.get(fileResourceIdentity(resource));
           return existing
             ? {
                 ...existing,
@@ -274,15 +329,19 @@ export function useFileAttachments(
                 sizeBytes: file.sizeBytes,
                 status: "ready",
                 file,
+                resource,
                 error: undefined,
+                metadataStatus: undefined,
               }
             : {
-                id: `restored:${file.id}`,
+                id: restoredAttachmentId(resource),
                 name: file.filename,
                 contentType: file.contentType,
                 sizeBytes: file.sizeBytes,
                 status: "ready",
                 file,
+                resource,
+                restored: true,
                 // No source File and no object URL: server metadata is the
                 // only authority restored across page/device boundaries.
               };
@@ -292,8 +351,202 @@ export function useFileAttachments(
         // those unresolved entries while replacing the ready set exactly.
         return [...unresolved, ...restored];
       });
+      const resourcesByFile = groupPreviewResources(
+        incomingResources.filter((resource) => {
+          const existing = existingReady.get(fileResourceIdentity(resource));
+          return (
+            !existing ||
+            (existing.restored === true && !existing.previewUrl && !existing.previewFailed)
+          );
+        }),
+      );
+      for (const [fileId, previewResources] of resourcesByFile) {
+        hydrateRemotePreview({
+          client,
+          workspaceId,
+          file: incomingFiles.get(fileId)!,
+          resources: previewResources,
+          generation,
+          restoreGeneration,
+          setAttachments,
+        });
+      }
     },
-    [workspaceId],
+    [client, workspaceId],
+  );
+
+  const restoreResources = useCallback(
+    (resources: Iterable<FileResourceRef>) => {
+      const getFile = optionalGetFile(client);
+      const incoming = dedupeFileResources(resources);
+      const incomingKeys = new Set(incoming.map(fileResourceIdentity));
+      const snapshot = committedAttachments.current;
+      const localKeys = new Set(
+        snapshot.flatMap((attachment) =>
+          attachment.restored !== true && attachment.resource
+            ? [fileResourceIdentity(attachment.resource)]
+            : [],
+        ),
+      );
+      const generation = ++restoreGeneration.current;
+      setAttachments((current) => {
+        const existingByKey = new Map(
+          current.flatMap((attachment) =>
+            attachment.resource
+              ? ([[fileResourceIdentity(attachment.resource), attachment]] as const)
+              : [],
+          ),
+        );
+        const local = current.filter((attachment) => attachment.restored !== true);
+        const currentLocalKeys = new Set(
+          local.flatMap((attachment) =>
+            attachment.resource ? [fileResourceIdentity(attachment.resource)] : [],
+          ),
+        );
+        const restored = incoming.flatMap((resource): FileAttachment[] => {
+          const key = fileResourceIdentity(resource);
+          if (currentLocalKeys.has(key)) return [];
+          const existing = existingByKey.get(key);
+          const file = existing?.file ?? fileMetadata.current.get(resource.fileId);
+          if (file) {
+            return [
+              {
+                ...existing,
+                id: existing?.id ?? restoredAttachmentId(resource),
+                name: file.filename,
+                contentType: file.contentType,
+                sizeBytes: file.sizeBytes,
+                status: "ready",
+                file,
+                resource,
+                restored: true,
+                metadataStatus: undefined,
+              },
+            ];
+          }
+          return [
+            existing
+              ? { ...existing, resource, restored: true, metadataStatus: "loading" }
+              : {
+                  id: restoredAttachmentId(resource),
+                  name: resource.fileId,
+                  contentType: "application/octet-stream",
+                  sizeBytes: 0,
+                  status: "ready",
+                  resource,
+                  restored: true,
+                  metadataStatus: "loading",
+                },
+          ];
+        });
+        return [
+          ...local,
+          ...restored.filter((attachment) =>
+            attachment.resource
+              ? incomingKeys.has(fileResourceIdentity(attachment.resource))
+              : false,
+          ),
+        ];
+      });
+
+      const missingFileIds = [
+        ...new Set(
+          incoming
+            .filter(
+              (resource) =>
+                !localKeys.has(fileResourceIdentity(resource)) &&
+                !fileMetadata.current.has(resource.fileId),
+            )
+            .map((resource) => resource.fileId),
+        ),
+      ];
+      hydrateCachedPreviews({
+        client,
+        workspaceId,
+        resources: incoming.filter(
+          (resource) =>
+            !localKeys.has(fileResourceIdentity(resource)) &&
+            fileMetadata.current.has(resource.fileId) &&
+            !snapshot.some(
+              (attachment) =>
+                attachment.resource &&
+                fileResourceIdentity(attachment.resource) === fileResourceIdentity(resource) &&
+                (attachment.previewUrl !== undefined || attachment.previewFailed === true),
+            ),
+        ),
+        fileMetadata: fileMetadata.current,
+        generation,
+        restoreGeneration,
+        setAttachments,
+      });
+
+      if (!getFile || missingFileIds.length === 0) {
+        if (!getFile && missingFileIds.length > 0) {
+          setAttachments((current) =>
+            current.map((attachment) =>
+              attachment.restored === true &&
+              attachment.metadataStatus === "loading" &&
+              missingFileIds.includes(attachment.resource?.fileId ?? "")
+                ? { ...attachment, metadataStatus: "failed" }
+                : attachment,
+            ),
+          );
+        }
+        return;
+      }
+      void Promise.allSettled(missingFileIds.map((fileId) => getFile(workspaceId, fileId))).then(
+        (settled) => {
+          if (restoreGeneration.current !== generation) return;
+          const hydrated = new Map<string, FileAsset>();
+          const failed = new Set<string>();
+          settled.forEach((result, index) => {
+            const fileId = missingFileIds[index];
+            if (!fileId) return;
+            if (
+              result.status === "fulfilled" &&
+              result.value.id === fileId &&
+              result.value.workspaceId === workspaceId &&
+              result.value.status === "ready"
+            ) {
+              hydrated.set(fileId, result.value);
+              fileMetadata.current.set(fileId, result.value);
+            } else {
+              failed.add(fileId);
+            }
+          });
+          setAttachments((current) =>
+            current.map((attachment) => {
+              if (attachment.restored !== true || !attachment.resource) return attachment;
+              const file = hydrated.get(attachment.resource.fileId);
+              if (file) {
+                return {
+                  ...attachment,
+                  name: file.filename,
+                  contentType: file.contentType,
+                  sizeBytes: file.sizeBytes,
+                  file,
+                  metadataStatus: undefined,
+                  error: undefined,
+                };
+              }
+              return failed.has(attachment.resource.fileId)
+                ? { ...attachment, metadataStatus: "failed" }
+                : attachment;
+            }),
+          );
+          hydrateCachedPreviews({
+            client,
+            workspaceId,
+            resources: incoming.filter((resource) => hydrated.has(resource.fileId)),
+            fileMetadata: hydrated,
+            generation,
+            restoreGeneration,
+            setAttachments,
+          });
+        },
+      );
+    },
+    [client, workspaceId],
   );
 
   const remove = useCallback(
@@ -305,15 +558,34 @@ export function useFileAttachments(
     [revokePreview],
   );
 
-  const removeReadyFiles = useCallback((fileIds: Iterable<string>) => {
-    const accepted = new Set(fileIds);
-    if (accepted.size === 0) return;
+  const failPreview = useCallback(
+    (id: string) => {
+      revokePreview(id);
+      setAttachments((current) =>
+        current.map((attachment) =>
+          attachment.id === id
+            ? { ...attachment, previewUrl: undefined, previewFailed: true }
+            : attachment,
+        ),
+      );
+    },
+    [revokePreview],
+  );
+
+  const removeReadyFiles = useCallback((resources: Iterable<string | FileResourceRef>) => {
+    const acceptedFileIds = new Set<string>();
+    const acceptedResourceKeys = new Set<string>();
+    for (const resource of resources) {
+      if (typeof resource === "string") acceptedFileIds.add(resource);
+      else acceptedResourceKeys.add(fileResourceIdentity(resource));
+    }
+    if (acceptedFileIds.size === 0 && acceptedResourceKeys.size === 0) return;
     setAttachments((current) =>
       current.filter((attachment) => {
+        if (attachment.status !== "ready" || !attachment.resource) return true;
         return !(
-          attachment.status === "ready" &&
-          attachment.file !== undefined &&
-          accepted.has(attachment.file.id)
+          acceptedFileIds.has(attachment.resource.fileId) ||
+          acceptedResourceKeys.has(fileResourceIdentity(attachment.resource))
         );
       }),
     );
@@ -328,18 +600,139 @@ export function useFileAttachments(
   return {
     attachments,
     readyResources: attachments.flatMap((attachment): FileResourceRef[] =>
-      attachment.status === "ready" && attachment.file
-        ? [{ kind: "file", fileId: attachment.file.id }]
-        : [],
+      attachment.status === "ready" && attachment.resource ? [attachment.resource] : [],
     ),
     uploading: attachments.some((attachment) => attachment.status === "uploading"),
     hasUnresolved: attachments.some((attachment) => attachment.status !== "ready"),
     addFiles,
     addFromPaste,
     restoreReadyFiles,
+    restoreResources,
     retry,
     remove,
+    failPreview,
     removeReadyFiles,
     clear,
   };
+}
+
+function dedupeFileResources(resources: Iterable<FileResourceRef>): FileResourceRef[] {
+  const seen = new Set<string>();
+  return [...resources].filter((resource) => {
+    const key = fileResourceIdentity(resource);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function restoredAttachmentId(resource: FileResourceRef): string {
+  return `restored:${resource.fileId}:${resource.mountPath ?? "default"}`;
+}
+
+function groupPreviewResources(
+  resources: Iterable<FileResourceRef>,
+): Map<string, FileResourceRef[]> {
+  const grouped = new Map<string, FileResourceRef[]>();
+  for (const resource of resources) {
+    const current = grouped.get(resource.fileId) ?? [];
+    current.push(resource);
+    grouped.set(resource.fileId, current);
+  }
+  return grouped;
+}
+
+function hydrateCachedPreviews({
+  client,
+  workspaceId,
+  resources,
+  fileMetadata,
+  generation,
+  restoreGeneration,
+  setAttachments,
+}: {
+  client: EmbeddedFileAttachmentClientLike;
+  workspaceId: string;
+  resources: Iterable<FileResourceRef>;
+  fileMetadata: ReadonlyMap<string, FileAsset>;
+  generation: number;
+  restoreGeneration: { current: number };
+  setAttachments: Dispatch<SetStateAction<FileAttachment[]>>;
+}): void {
+  for (const [fileId, previewResources] of groupPreviewResources(resources)) {
+    const file = fileMetadata.get(fileId);
+    if (!file) continue;
+    hydrateRemotePreview({
+      client,
+      workspaceId,
+      file,
+      resources: previewResources,
+      generation,
+      restoreGeneration,
+      setAttachments,
+    });
+  }
+}
+
+function hydrateRemotePreview({
+  client,
+  workspaceId,
+  file,
+  resources,
+  generation,
+  restoreGeneration,
+  setAttachments,
+}: {
+  client: EmbeddedFileAttachmentClientLike;
+  workspaceId: string;
+  file: FileAsset;
+  resources: FileResourceRef[];
+  generation: number;
+  restoreGeneration: { current: number };
+  setAttachments: Dispatch<SetStateAction<FileAttachment[]>>;
+}): void {
+  const createFileDownloadUrl = optionalCreateFileDownloadUrl(client);
+  if (!file.contentType.startsWith("image/") || !createFileDownloadUrl) return;
+  const keys = new Set(resources.map(fileResourceIdentity));
+  void createFileDownloadUrl(workspaceId, file.id)
+    .then((signed) => {
+      if (restoreGeneration.current !== generation) return;
+      setAttachments((current) =>
+        current.map((attachment) =>
+          attachment.restored === true &&
+          attachment.resource &&
+          keys.has(fileResourceIdentity(attachment.resource))
+            ? { ...attachment, previewUrl: signed.url, previewFailed: undefined }
+            : attachment,
+        ),
+      );
+    })
+    .catch(() => {
+      if (restoreGeneration.current !== generation) return;
+      setAttachments((current) =>
+        current.map((attachment) =>
+          attachment.restored === true &&
+          attachment.resource &&
+          keys.has(fileResourceIdentity(attachment.resource))
+            ? { ...attachment, previewFailed: true }
+            : attachment,
+        ),
+      );
+    });
+}
+
+function optionalGetFile(
+  client: EmbeddedFileAttachmentClientLike,
+): NonNullable<EmbeddedFileAttachmentClientLike["getFile"]> | undefined {
+  if (!("getFile" in client) || typeof client.getFile !== "function") return undefined;
+  return client.getFile.bind(client);
+}
+
+function optionalCreateFileDownloadUrl(
+  client: EmbeddedFileAttachmentClientLike,
+): NonNullable<EmbeddedFileAttachmentClientLike["createFileDownloadUrl"]> | undefined {
+  if (!("createFileDownloadUrl" in client) || typeof client.createFileDownloadUrl !== "function") {
+    return undefined;
+  }
+  return client.createFileDownloadUrl.bind(client);
 }

--- a/packages/react/src/lib/resource-identity.ts
+++ b/packages/react/src/lib/resource-identity.ts
@@ -1,0 +1,23 @@
+import {
+  DEFAULT_FILE_RESOURCE_MOUNT_ROOT,
+  type FileResourceRef,
+  type ResourceRef,
+} from "@opengeni/sdk";
+
+/**
+ * Stable identity for one logical file attachment.
+ *
+ * A file id alone is insufficient: callers may mount the same durable file at
+ * multiple explicit paths. Keep this key byte-for-byte aligned with the
+ * composer draft/send dedupe rule so persistence and presentation cannot
+ * disagree about whether two resources are the same attachment.
+ */
+export function fileResourceIdentity(resource: FileResourceRef): string {
+  return `file:${resource.fileId}\u0000${
+    resource.mountPath ?? `${DEFAULT_FILE_RESOURCE_MOUNT_ROOT}/${resource.fileId}`
+  }`;
+}
+
+export function resourceIdentity(resource: ResourceRef): string {
+  return resource.kind === "file" ? fileResourceIdentity(resource) : JSON.stringify(resource);
+}

--- a/packages/react/test/artifact-public-boundary.test.ts
+++ b/packages/react/test/artifact-public-boundary.test.ts
@@ -2,24 +2,35 @@ import { describe, expect, test } from "bun:test";
 import { resolve } from "node:path";
 
 const PACKAGE_ROOT = resolve(import.meta.dir, "..");
+const BUILD_FIXTURE = resolve(import.meta.dir, "fixtures/artifact-public-boundary-build.ts");
 const ENTRIES = {
   document: "src/artifacts-document.ts",
   presentation: "src/artifacts-presentation.ts",
   spreadsheet: "src/artifacts-spreadsheet.ts",
 } as const;
 
+async function buildBrowserBoundary(entry: string): Promise<string> {
+  // Bun.build shares process-global loader state with bun:test. Keep this public
+  // closure proof isolated from unrelated package tests and their module state.
+  const child = Bun.spawn([process.execPath, BUILD_FIXTURE, resolve(PACKAGE_ROOT, entry)], {
+    cwd: PACKAGE_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [output, errorOutput, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(errorOutput || `Artifact boundary build exited with code ${exitCode}`);
+  }
+  return output;
+}
+
 describe("artifact public browser boundaries", () => {
   test("unified workbench is exported without the artifact tool runtime", async () => {
-    const result = await Bun.build({
-      entrypoints: [resolve(PACKAGE_ROOT, "src/artifacts.ts")],
-      target: "browser",
-      format: "esm",
-      splitting: false,
-      minify: false,
-      external: ["@opengeni/*", "react", "react/*", "lucide-react"],
-    });
-    expect(result.success).toBe(true);
-    const output = (await Promise.all(result.outputs.map((item) => item.text()))).join("\n");
+    const output = await buildBrowserBoundary("src/artifacts.ts");
 
     expect(output).toContain("EditableArtifactWorkbench");
     expect(output).toContain("BrowserEditableArtifactWorkbench");
@@ -28,16 +39,7 @@ describe("artifact public browser boundaries", () => {
 
   for (const [modality, entry] of Object.entries(ENTRIES)) {
     test(`${modality} entry is isolated and artifact-runtime-free`, async () => {
-      const result = await Bun.build({
-        entrypoints: [resolve(PACKAGE_ROOT, entry)],
-        target: "browser",
-        format: "esm",
-        splitting: false,
-        minify: false,
-        external: ["@opengeni/*", "react", "react/*", "lucide-react"],
-      });
-      expect(result.success).toBe(true);
-      const output = (await Promise.all(result.outputs.map((item) => item.text()))).join("\n");
+      const output = await buildBrowserBoundary(entry);
 
       expect(output).not.toContain("@opengeni/artifact-tool");
       expect(output).not.toContain("@opengeni/contracts");

--- a/packages/react/test/chat-composer-uploads.test.tsx
+++ b/packages/react/test/chat-composer-uploads.test.tsx
@@ -87,6 +87,8 @@ function readyChip(name: string): FileAttachment {
   };
 }
 
+const RESTORED_FILE_ID = "00000000-0000-4000-8000-000000000123";
+
 async function mount(node: React.ReactElement): Promise<HTMLElement> {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -183,6 +185,78 @@ describe("ChatComposer attachments", () => {
       (b) => b.getAttribute("aria-label") === "Remove screenshot.png",
     );
     expect(remove).toBeTruthy();
+  });
+
+  test("one logical file has one card and one remove action across durable and live state", async () => {
+    const removedAttachments: string[] = [];
+    const removedResources: number[] = [];
+    const attachment: FileAttachment = {
+      ...readyChip("restored-image.png"),
+      id: "live-restored-image",
+      file: {
+        id: RESTORED_FILE_ID,
+        workspaceId: "00000000-0000-4000-8000-000000000001",
+        status: "ready",
+        filename: "restored-image.png",
+        safeFilename: "restored-image.png",
+        contentType: "image/png",
+        sizeBytes: 2048,
+        sha256: null,
+        bucket: "files",
+        objectKey: "restored-image.png",
+        createdAt: "2026-08-12T00:00:00.000Z",
+        updatedAt: "2026-08-12T00:00:00.000Z",
+      },
+      previewUrl: "blob:restored-image",
+    };
+    const container = await mount(
+      <ChatComposer
+        composer={makeComposer({
+          restoredResources: [
+            { kind: "repository", uri: "https://example.com/repo.git", ref: "main" },
+            { kind: "file", fileId: RESTORED_FILE_ID },
+          ],
+          removeRestoredResource: (index) => removedResources.push(index),
+        })}
+        attachments={makeAttachments({
+          attachments: [attachment],
+          readyResources: [{ kind: "file", fileId: RESTORED_FILE_ID }],
+          remove: (id) => removedAttachments.push(id),
+        })}
+      />,
+    );
+
+    expect(container.textContent ?? "").toContain("example.com/repo.git");
+    expect(container.textContent ?? "").not.toContain(`File ${RESTORED_FILE_ID.slice(0, 8)}`);
+    expect(container.querySelectorAll('img[src="blob:restored-image"]')).toHaveLength(1);
+    expect(container.querySelectorAll('[aria-label="Remove restored-image.png"]')).toHaveLength(1);
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="Remove restored-image.png"]')
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(removedAttachments).toEqual(["live-restored-image"]);
+    expect(removedResources).toEqual([1]);
+  });
+
+  test("a non-durable composer does not clear attachments owned by its external draft hook", async () => {
+    const restoredCalls: unknown[][] = [];
+    const container = await mount(
+      <ChatComposer
+        composer={makeComposer({ draftPersistence: "disabled", restoredResources: [] })}
+        attachments={makeAttachments({
+          attachments: [readyChip("pre-session.png")],
+          restoreResources: (resources) => restoredCalls.push([...resources]),
+        })}
+      />,
+    );
+    await act(async () => await Promise.resolve());
+
+    expect(restoredCalls).toEqual([]);
+    expect(container.querySelectorAll('[aria-label="Remove pre-session.png"]')).toHaveLength(1);
   });
 
   test("a managed-credit rejection is actionable and keeps the ready attachment visible", async () => {

--- a/packages/react/test/fixtures/artifact-public-boundary-build.ts
+++ b/packages/react/test/fixtures/artifact-public-boundary-build.ts
@@ -1,0 +1,23 @@
+export {};
+
+const entry = process.argv[2];
+if (!entry) {
+  console.error("Expected an artifact boundary entrypoint");
+  process.exit(2);
+}
+
+const result = await Bun.build({
+  entrypoints: [entry],
+  target: "browser",
+  format: "esm",
+  splitting: false,
+  minify: false,
+  external: ["@opengeni/*", "react", "react/*", "lucide-react"],
+});
+
+if (!result.success) {
+  for (const log of result.logs) console.error(log);
+  process.exit(1);
+}
+
+for (const output of result.outputs) process.stdout.write(await output.text());

--- a/packages/react/test/session-entry.test.ts
+++ b/packages/react/test/session-entry.test.ts
@@ -91,11 +91,12 @@ describe("session-only entry", () => {
     expect(reactSources.some((id) => id.endsWith("/src/timeline/index.ts"))).toBe(false);
     expect(reactSources.some((id) => id.endsWith("/src/provider.tsx"))).toBe(false);
     expect(reactSources.some((id) => id.endsWith("/src/session-context.ts"))).toBe(true);
+    expect(reactSources.some((id) => id.endsWith("/src/lib/resource-identity.ts"))).toBe(true);
     expect(reactSources.some((id) => id.includes("/src/components/"))).toBe(false);
     expect(reactSources.some((id) => id.includes("/src/commands/"))).toBe(false);
     // Keep the session-only closure explicit: adding a source requires reviewing
     // whether it belongs to this provider-neutral public subpath.
-    expect(reactSources.length).toBe(19);
+    expect(reactSources.length).toBe(20);
 
     const chunks = result.output.filter((item) => item.type === "chunk");
     expect(chunks).toHaveLength(1);

--- a/packages/react/test/use-file-attachments.test.tsx
+++ b/packages/react/test/use-file-attachments.test.tsx
@@ -461,12 +461,14 @@ describe("useFileAttachments", () => {
       status: "uploading",
     });
     expect(hook.result.current.attachments[1]).toEqual({
-      id: "restored:restored-ready",
+      id: "restored:restored-ready:default",
       name: "restored.png",
       contentType: ready.contentType,
       sizeBytes: ready.sizeBytes,
       status: "ready",
       file: ready,
+      resource: { kind: "file", fileId: "restored-ready" },
+      restored: true,
     });
     expect(hook.result.current.attachments[1]?.previewUrl).toBeUndefined();
     expect(hook.result.current.uploading).toBe(true);
@@ -475,6 +477,284 @@ describe("useFileAttachments", () => {
     ]);
 
     await flushing(() => resolveUpload(fakeAsset({ id: "local-ready" })));
+    await hook.unmount();
+  });
+
+  test("hydrates a durable image into one named card with a signed preview", async () => {
+    const asset = fakeAsset({ id: "durable-image", filename: "durable.png", sizeBytes: 4096 });
+    const getFileCalls: string[] = [];
+    const downloadCalls: string[] = [];
+    const client = fakeClient({
+      uploadFile: async () => asset,
+      getFile: async (_workspaceId, fileId) => {
+        getFileCalls.push(fileId);
+        return asset;
+      },
+      createFileDownloadUrl: async (_workspaceId, fileId) => {
+        downloadCalls.push(fileId);
+        return {
+          url: "https://files.example.test/durable-image",
+          expiresAt: "2026-08-12T12:00:00.000Z",
+        };
+      },
+    });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+
+    await flushing(() =>
+      hook.result.current.restoreResources?.([{ kind: "file", fileId: asset.id }]),
+    );
+    await flush();
+
+    expect(hook.result.current.attachments).toHaveLength(1);
+    expect(hook.result.current.attachments[0]).toMatchObject({
+      id: "restored:durable-image:default",
+      name: "durable.png",
+      contentType: "image/png",
+      sizeBytes: 4096,
+      status: "ready",
+      file: asset,
+      resource: { kind: "file", fileId: asset.id },
+      restored: true,
+      previewUrl: "https://files.example.test/durable-image",
+    });
+    expect(hook.result.current.attachments[0]?.metadataStatus).toBeUndefined();
+    expect(hook.result.current.readyResources).toEqual([{ kind: "file", fileId: asset.id }]);
+    expect(getFileCalls).toEqual([asset.id]);
+    expect(downloadCalls).toEqual([asset.id]);
+
+    await flushing(() =>
+      hook.result.current.restoreResources?.([{ kind: "file", fileId: asset.id }]),
+    );
+    await flush();
+    expect(getFileCalls).toEqual([asset.id]);
+    expect(downloadCalls).toEqual([asset.id]);
+    await hook.unmount();
+  });
+
+  test("preserves exact custom mounts while hydrating shared file metadata once", async () => {
+    const asset = fakeAsset({ id: "shared-file", filename: "shared.png" });
+    let getFileCalls = 0;
+    let downloadCalls = 0;
+    const client = fakeClient({
+      uploadFile: async () => asset,
+      getFile: async () => {
+        getFileCalls += 1;
+        return asset;
+      },
+      createFileDownloadUrl: async () => {
+        downloadCalls += 1;
+        return {
+          url: "https://files.example.test/shared",
+          expiresAt: "2026-08-12T12:00:00.000Z",
+        };
+      },
+    });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+    const resources = [
+      { kind: "file", fileId: asset.id, mountPath: "input/one.png" },
+      { kind: "file", fileId: asset.id, mountPath: "input/two.png" },
+      { kind: "file", fileId: asset.id, mountPath: "input/one.png" },
+    ] as const;
+
+    await flushing(() => hook.result.current.restoreResources?.(resources));
+    await flush();
+
+    expect(hook.result.current.attachments).toHaveLength(2);
+    expect(hook.result.current.attachments.map((attachment) => attachment.resource)).toEqual(
+      resources.slice(0, 2),
+    );
+    expect(hook.result.current.attachments.map((attachment) => attachment.previewUrl)).toEqual([
+      "https://files.example.test/shared",
+      "https://files.example.test/shared",
+    ]);
+    expect(hook.result.current.readyResources).toEqual(resources.slice(0, 2));
+    expect(getFileCalls).toBe(1);
+    expect(downloadCalls).toBe(1);
+    await hook.unmount();
+  });
+
+  test("exact accepted mount cleanup preserves a later mount of the same file", async () => {
+    const asset = fakeAsset({ id: "mounted-file", filename: "mounted.png" });
+    const client = fakeClient({ uploadFile: async () => asset });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+    const accepted = { kind: "file", fileId: asset.id, mountPath: "inputs/accepted.png" } as const;
+    const later = { kind: "file", fileId: asset.id, mountPath: "inputs/later.png" } as const;
+
+    await flushing(() => hook.result.current.restoreReadyFiles([asset], [accepted, later]));
+    await flushing(() => hook.result.current.removeReadyFiles([accepted]));
+
+    expect(hook.result.current.attachments).toHaveLength(1);
+    expect(hook.result.current.attachments[0]?.resource).toEqual(later);
+    expect(hook.result.current.readyResources).toEqual([later]);
+    await hook.unmount();
+  });
+
+  test("a stale metadata request cannot resurrect an older durable resource set", async () => {
+    let resolveFirst!: (file: FileAsset) => void;
+    let resolveSecond!: (file: FileAsset) => void;
+    const first = new Promise<FileAsset>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const second = new Promise<FileAsset>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const client = fakeClient({
+      uploadFile: async () => fakeAsset(),
+      getFile: async (_workspaceId, fileId) => await (fileId === "first-durable" ? first : second),
+    });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+
+    await flushing(() =>
+      hook.result.current.restoreResources?.([{ kind: "file", fileId: "first-durable" }]),
+    );
+    await flushing(() =>
+      hook.result.current.restoreResources?.([{ kind: "file", fileId: "second-durable" }]),
+    );
+    await flushing(() =>
+      resolveSecond(fakeAsset({ id: "second-durable", filename: "second.png" })),
+    );
+    await flush();
+    await flushing(() => resolveFirst(fakeAsset({ id: "first-durable", filename: "first.png" })));
+    await flush();
+
+    expect(hook.result.current.attachments).toHaveLength(1);
+    expect(hook.result.current.attachments[0]).toMatchObject({
+      name: "second.png",
+      resource: { kind: "file", fileId: "second-durable" },
+    });
+    expect(hook.result.current.readyResources).toEqual([
+      { kind: "file", fileId: "second-durable" },
+    ]);
+    await hook.unmount();
+  });
+
+  test("soft reconciliation preserves the local object URL and does not mint a signed preview", async () => {
+    const asset = fakeAsset({ id: "local-image", filename: "local.png" });
+    let downloadCalls = 0;
+    const client = fakeClient({
+      uploadFile: async () => asset,
+      createFileDownloadUrl: async () => {
+        downloadCalls += 1;
+        return {
+          url: "https://files.example.test/local-image",
+          expiresAt: "2026-08-12T12:00:00.000Z",
+        };
+      },
+    });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+
+    await flushing(() => hook.result.current.addFiles([imageFile("local.png")]));
+    await flush();
+    const attachmentId = hook.result.current.attachments[0]!.id;
+    const localPreview = hook.result.current.attachments[0]!.previewUrl;
+
+    await flushing(() =>
+      hook.result.current.restoreReadyFiles([asset], [{ kind: "file", fileId: asset.id }]),
+    );
+    await flush();
+
+    expect(hook.result.current.attachments).toHaveLength(1);
+    expect(hook.result.current.attachments[0]).toMatchObject({
+      id: attachmentId,
+      file: asset,
+      resource: { kind: "file", fileId: asset.id },
+      previewUrl: localPreview,
+    });
+    expect(downloadCalls).toBe(0);
+    expect(revoked).not.toContain(localPreview);
+    await hook.unmount();
+  });
+
+  test("a minimal upload-only client degrades a durable ref to one coherent fallback card", async () => {
+    const client = fakeClient({ uploadFile: async () => fakeAsset() });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+
+    await flushing(() =>
+      hook.result.current.restoreResources?.([{ kind: "file", fileId: "fallback-file" }]),
+    );
+
+    expect(hook.result.current.attachments).toEqual([
+      {
+        id: "restored:fallback-file:default",
+        name: "fallback-file",
+        contentType: "application/octet-stream",
+        sizeBytes: 0,
+        status: "ready",
+        resource: { kind: "file", fileId: "fallback-file" },
+        restored: true,
+        metadataStatus: "failed",
+      },
+    ]);
+    expect(hook.result.current.readyResources).toEqual([{ kind: "file", fileId: "fallback-file" }]);
+    await hook.unmount();
+  });
+
+  test("a failed signed preview keeps hydrated image metadata and falls back safely", async () => {
+    const asset = fakeAsset({ id: "broken-preview", filename: "still-named.png" });
+    const client = fakeClient({
+      uploadFile: async () => asset,
+      getFile: async () => asset,
+      createFileDownloadUrl: async () => {
+        throw new Error("signing unavailable");
+      },
+    });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+
+    await flushing(() =>
+      hook.result.current.restoreResources?.([{ kind: "file", fileId: asset.id }]),
+    );
+    await flush();
+
+    expect(hook.result.current.attachments[0]).toMatchObject({
+      name: "still-named.png",
+      contentType: "image/png",
+      file: asset,
+      previewFailed: true,
+    });
+    expect(hook.result.current.attachments[0]?.previewUrl).toBeUndefined();
+    await hook.unmount();
+  });
+
+  test("removeReadyFiles clears restored resources that have no browser-local File", async () => {
+    const asset = fakeAsset({ id: "restored-accepted", filename: "accepted.png" });
+    const client = fakeClient({
+      uploadFile: async () => asset,
+      getFile: async () => asset,
+    });
+    const hook = await renderHook(
+      () => useFileAttachments({ client, workspaceId: WORKSPACE_ID }),
+      undefined,
+    );
+
+    await flushing(() =>
+      hook.result.current.restoreResources?.([{ kind: "file", fileId: asset.id }]),
+    );
+    await flush();
+    await flushing(() => hook.result.current.removeReadyFiles([asset.id]));
+
+    expect(hook.result.current.attachments).toEqual([]);
+    expect(hook.result.current.readyResources).toEqual([]);
     await hook.unmount();
   });
 

--- a/scripts/ci/impact.test.ts
+++ b/scripts/ci/impact.test.ts
@@ -78,6 +78,7 @@ describe("fail-closed change impact", () => {
     expect(sdk.unitTests).toContain("packages/sdk/test/client.test.ts");
     expect(sdk.e2eTests).toEqual([
       "test/e2e/code-editor.browser.e2e.ts",
+      "test/e2e/composer-attachments.browser.e2e.ts",
       "test/e2e/composer-responsive.browser.e2e.ts",
       "test/e2e/connected-machine-removal.browser.e2e.ts",
       "test/e2e/react-compiled-css.browser.e2e.ts",
@@ -225,6 +226,7 @@ describe("fail-closed change impact", () => {
     expect(tests.integration.length).toBeGreaterThan(0);
     expect(tests.e2e).toEqual([
       "test/e2e/code-editor.browser.e2e.ts",
+      "test/e2e/composer-attachments.browser.e2e.ts",
       "test/e2e/composer-responsive.browser.e2e.ts",
       "test/e2e/connected-machine-removal.browser.e2e.ts",
       "test/e2e/react-compiled-css.browser.e2e.ts",

--- a/scripts/ci/impact.ts
+++ b/scripts/ci/impact.ts
@@ -173,6 +173,7 @@ const ROOT_TEST_DEPENDENCIES: Record<string, string[]> = {
     "@opengeni/testing",
   ],
   "test/e2e/code-editor.browser.e2e.ts": ["@opengeni/react", "@opengeni/testing"],
+  "test/e2e/composer-attachments.browser.e2e.ts": ["@opengeni/react", "@opengeni/testing"],
   "test/e2e/composer-responsive.browser.e2e.ts": ["@opengeni/react", "@opengeni/testing"],
   "test/e2e/connected-machine-removal.browser.e2e.ts": [
     "opengeni-web",

--- a/scripts/run-browser-e2e.ts
+++ b/scripts/run-browser-e2e.ts
@@ -14,6 +14,7 @@ const testFiles =
         "./test/e2e/knowledge-surfaces.browser.e2e.ts",
         "./test/e2e/codex-overview.e2e.ts",
         "./test/e2e/code-editor.browser.e2e.ts",
+        "./test/e2e/composer-attachments.browser.e2e.ts",
         "./test/e2e/queue-surface.browser.e2e.ts",
         "./test/e2e/react-compiled-css.browser.e2e.ts",
         "./test/e2e/react-demo-mobile.browser.e2e.ts",

--- a/test/e2e/composer-attachments.browser.e2e.ts
+++ b/test/e2e/composer-attachments.browser.e2e.ts
@@ -1,0 +1,191 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { chromium, type Browser, type Page } from "playwright";
+import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+
+const repoRoot = new URL("../..", import.meta.url).pathname;
+const FILE_ID_PREFIX = "aaaaaaaa";
+const PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Z1xkAAAAASUVORK5CYII=",
+  "base64",
+);
+
+type AttachmentState = {
+  attachmentCount: number;
+  readyResourceCount: number;
+  restoredResourceCount: number;
+  draftResourceCount: number;
+  removeButtonCount: number;
+  blobImageCount: number;
+  dataImageCount: number;
+  imageCount: number;
+  hasGenericFileLabel: boolean;
+  hasDurableFilename: boolean;
+};
+
+async function attachmentState(page: Page): Promise<AttachmentState> {
+  return await page.evaluate((fileIdPrefix) => {
+    const harness = document.querySelector<HTMLElement>('[data-testid="attachment-harness"]');
+    const images = [...document.querySelectorAll<HTMLImageElement>("img")];
+    const text = document.body.textContent ?? "";
+    return {
+      attachmentCount: Number(harness?.dataset.attachmentCount ?? -1),
+      readyResourceCount: Number(harness?.dataset.readyResourceCount ?? -1),
+      restoredResourceCount: Number(harness?.dataset.restoredResourceCount ?? -1),
+      draftResourceCount: Number(harness?.dataset.draftResourceCount ?? -1),
+      removeButtonCount: document.querySelectorAll('button[aria-label="Remove durable.png"]')
+        .length,
+      blobImageCount: images.filter((image) => image.src.startsWith("blob:")).length,
+      dataImageCount: images.filter((image) => image.src.startsWith("data:image/png")).length,
+      imageCount: images.length,
+      hasGenericFileLabel: text.includes(`File ${fileIdPrefix}`),
+      hasDurableFilename: text.includes("durable.png"),
+    };
+  }, FILE_ID_PREFIX);
+}
+
+async function waitForAttachmentState(
+  page: Page,
+  expected: Partial<AttachmentState>,
+  timeout = 5_000,
+): Promise<void> {
+  await page.waitForFunction(
+    ({ expectedState, fileIdPrefix }) => {
+      const harness = document.querySelector<HTMLElement>('[data-testid="attachment-harness"]');
+      if (!harness) return false;
+      const images = [...document.querySelectorAll<HTMLImageElement>("img")];
+      const text = document.body.textContent ?? "";
+      const current: AttachmentState = {
+        attachmentCount: Number(harness.dataset.attachmentCount ?? -1),
+        readyResourceCount: Number(harness.dataset.readyResourceCount ?? -1),
+        restoredResourceCount: Number(harness.dataset.restoredResourceCount ?? -1),
+        draftResourceCount: Number(harness.dataset.draftResourceCount ?? -1),
+        removeButtonCount: document.querySelectorAll('button[aria-label="Remove durable.png"]')
+          .length,
+        blobImageCount: images.filter((image) => image.src.startsWith("blob:")).length,
+        dataImageCount: images.filter((image) => image.src.startsWith("data:image/png")).length,
+        imageCount: images.length,
+        hasGenericFileLabel: text.includes(`File ${fileIdPrefix}`),
+        hasDurableFilename: text.includes("durable.png"),
+      };
+      return Object.entries(expectedState).every(
+        ([key, value]) => current[key as keyof AttachmentState] === value,
+      );
+    },
+    { expectedState: expected, fileIdPrefix: FILE_ID_PREFIX },
+    { timeout },
+  );
+  expect(await attachmentState(page)).toMatchObject(expected);
+}
+
+describe("durable composer attachment presentation", () => {
+  let browser: Browser;
+  let demo: StartedProcess;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    const configuredChromium = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+    const sandboxChromium = "/usr/local/bin/chromium";
+    const executablePath =
+      configuredChromium ?? (existsSync(sandboxChromium) ? sandboxChromium : undefined);
+    browser = await chromium.launch(executablePath ? { executablePath } : undefined);
+    demo = await startProcess(
+      [
+        "bun",
+        "run",
+        "vite",
+        "dev",
+        "demo",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(port),
+        "--strictPort",
+        "--force",
+      ],
+      {
+        cwd: `${repoRoot}/packages/react`,
+        ready: async () =>
+          (
+            await fetch(`${baseUrl}/composer-attachments.html`, {
+              signal: AbortSignal.timeout(2_000),
+            }).catch(() => null)
+          )?.ok === true,
+        timeoutMs: 45_000,
+      },
+    );
+  }, 60_000);
+
+  afterAll(async () => {
+    await Promise.allSettled([demo?.stop(), browser?.close()]);
+  }, 30_000);
+
+  test("one image stays one card through autosave, soft reload, hard refresh, fallback, and removal", async () => {
+    const context = await browser.newContext({
+      viewport: { width: 900, height: 700 },
+      reducedMotion: "reduce",
+    });
+    const page = await context.newPage();
+    await page.goto(`${baseUrl}/composer-attachments.html?reset=1`, {
+      waitUntil: "networkidle",
+    });
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "durable.png",
+      mimeType: "image/png",
+      buffer: PNG,
+    });
+
+    await waitForAttachmentState(page, {
+      attachmentCount: 1,
+      readyResourceCount: 1,
+      draftResourceCount: 1,
+      removeButtonCount: 1,
+      blobImageCount: 1,
+      hasGenericFileLabel: false,
+    });
+
+    await page.getByRole("button", { name: "Reload draft" }).click();
+    await waitForAttachmentState(page, {
+      attachmentCount: 1,
+      readyResourceCount: 1,
+      restoredResourceCount: 1,
+      removeButtonCount: 1,
+      blobImageCount: 1,
+      hasGenericFileLabel: false,
+    });
+
+    await page.goto(`${baseUrl}/composer-attachments.html`, { waitUntil: "networkidle" });
+    await waitForAttachmentState(page, {
+      attachmentCount: 1,
+      readyResourceCount: 1,
+      removeButtonCount: 1,
+      dataImageCount: 1,
+      hasGenericFileLabel: false,
+    });
+
+    await page.goto(`${baseUrl}/composer-attachments.html?preview=broken`, {
+      waitUntil: "networkidle",
+    });
+    await waitForAttachmentState(page, {
+      attachmentCount: 1,
+      removeButtonCount: 1,
+      imageCount: 0,
+      hasGenericFileLabel: false,
+      hasDurableFilename: true,
+    });
+
+    await page.getByRole("button", { name: "Remove durable.png" }).click();
+    await waitForAttachmentState(page, {
+      attachmentCount: 0,
+      readyResourceCount: 0,
+      draftResourceCount: 0,
+      removeButtonCount: 0,
+    });
+
+    await page.reload({ waitUntil: "networkidle" });
+    await waitForAttachmentState(page, { attachmentCount: 0, removeButtonCount: 0 });
+    await context.close();
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

- render durable file refs through the composer attachment-card owner instead of a second generic restored-resource strip
- hydrate restored `FileAsset` metadata and signed image previews after refresh while preserving live blob previews during soft draft reconciliation
- keep exact default/custom mount identity through draft hydration, removal, and accepted-send cleanup
- add unit and Chromium coverage for upload → autosave → soft reload → hard refresh → preview failure fallback → removal
- register the browser regression in the fail-closed CI impact map and isolate public-boundary bundle proofs from suite-global loader state

## Testing

- [x] `bun run typecheck` (all 30 projects passed during the broad local check)
- [x] `bun run --cwd packages/react typecheck`
- [x] `bun run test:react:clean` (1,290 passed, 0 failed, no runtime warnings)
- [x] `bun test packages/react/test/use-file-attachments.test.tsx packages/react/test/chat-composer-uploads.test.tsx apps/web/src/lib/use-new-session-draft.test.tsx scripts/ci/impact.test.ts` (97 passed)
- [x] `bun test packages/react/test/artifact-public-boundary.test.ts packages/react/test/session-entry.test.ts` (6 passed; boundary pair also passed 10 consecutive runs)
- [x] `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=... bun scripts/run-browser-e2e.ts ./test/e2e/composer-attachments.browser.e2e.ts`
- [x] React/web/example TypeScript checks, oxlint, oxfmt, `git diff --check`
- [x] `bun run --cwd packages/react demo:build`
- [x] Broad local `bun test`: 8,456 passed; remaining failures required unavailable Docker/PostgreSQL services. The candidate-owned CI impact and React boundary failures found by that run were repaired and their exact gates now pass.
- [x] Disposable computed merge against current-main ancestry passed targeted type/test/build/browser gates; current-base source admission remains the authoritative moving-main gate.

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] `main` advanced after candidate creation; the source head stayed focused and current-base mergeability/material compatibility were verified without rebasing unrelated commits.

## Notes

- Exact candidate head: `c218086db6f1123bdc0ec09046b3d11fb0edb4b7`
- No deployment is included in this change.
