### PR TITLE
chore(release): bump product version to 0.23.4

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.3
-appVersion: "0.23.3"
+version: 0.23.4
+appVersion: "0.23.4"


### PR DESCRIPTION
## Summary
- bump the source-controlled OpenGeni Helm chart and app version from `0.23.3` to `0.23.4`
- create a fresh current-main release source after the prior 0.23.3 candidate gate correctly rejected main movement before candidate sealing

## Validation
- `bun scripts/release-version.ts deploy/helm/opengeni/Chart.yaml`
- `bun test scripts/release-version.test.ts scripts/package-release-chart.test.ts scripts/release-candidate.test.ts scripts/release-image-workflow-contract.test.ts`
- `helm lint deploy/helm/opengeni`
- `helm template opengeni deploy/helm/opengeni ...`
- `git diff --check`

## Release scope
One source-controlled metadata file only. No package version, migration, application runtime, deployment, cloud, or provider mutation is included in this PR.