### PR TITLE
fix(release): admit sealed ancestor candidates

### DIFF
--- a/.changeset/fenced-model-request-lifecycles.md
+++ b/.changeset/fenced-model-request-lifecycles.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/codex": patch
+"@opengeni/worker-bundle": patch
+---
+
+Fence provider model-request terminal outcomes and expose bounded request lifecycle diagnostics for headers, first byte, and semantic completion.

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -891,6 +891,10 @@ async function assertSourceAncestorOfCurrentMain(
     Number.isSafeInteger(comparison?.ahead_by) && comparison.ahead_by > 0,
     `${label} ancestry distance is invalid`,
   );
+  invariant(
+    comparison?.total_commits === comparison.ahead_by,
+    `${label} ancestry comparison is incomplete`,
+  );
 }
 
 async function assertReleaseMainRef(api, value, sourceSha, label) {

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -164,13 +164,17 @@ function assertRepository(value) {
 }
 
 function assertMainRef(value, expectedSha, label = "default branch") {
+  const actualSha = directMainRefSha(value, label);
+  invariant(actualSha === expectedSha, `${label} differs from the admitted base SHA`);
+}
+
+function directMainRefSha(value, label = "default branch") {
   invariant(
     value?.ref === `refs/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`,
     `${label} ref changed`,
   );
   invariant(value?.object?.type === "commit", `${label} is not a direct commit ref`);
-  const actualSha = assertSha(value.object.sha, `${label} SHA`);
-  invariant(actualSha === expectedSha, `${label} differs from the admitted base SHA`);
+  return assertSha(value.object.sha, `${label} SHA`);
 }
 
 function releaseHeadTagName(headSha) {
@@ -868,19 +872,31 @@ function assertRecoveryReleasePull(pull, context, expected) {
   return { ...identity, headRef, headRepository };
 }
 
-async function assertSourceAncestorOfCurrentMain(api, sourceSha, currentMainSha) {
+async function assertSourceAncestorOfCurrentMain(
+  api,
+  sourceSha,
+  currentMainSha,
+  label = "current main",
+  sourceLabel = "merged source",
+) {
   if (sourceSha === currentMainSha) return;
   const comparison = await api.get(repositoryPath(`/compare/${sourceSha}...${currentMainSha}`));
-  invariant(comparison?.status === "ahead", "current main is not ahead of the merged source");
+  invariant(comparison?.status === "ahead", `${label} is not ahead of the ${sourceLabel}`);
   invariant(
     comparison?.base_commit?.sha === sourceSha && comparison?.merge_base_commit?.sha === sourceSha,
-    "current main does not retain the merged source as its exact ancestor",
+    `${label} does not retain the ${sourceLabel} as its exact ancestor`,
   );
-  invariant(comparison?.behind_by === 0, "current main is behind the merged source");
+  invariant(comparison?.behind_by === 0, `${label} is behind the ${sourceLabel}`);
   invariant(
     Number.isSafeInteger(comparison?.ahead_by) && comparison.ahead_by > 0,
-    "current main ancestry distance is invalid",
+    `${label} ancestry distance is invalid`,
   );
+}
+
+async function assertReleaseMainRef(api, value, sourceSha, label) {
+  const currentMainSha = directMainRefSha(value, label);
+  await assertSourceAncestorOfCurrentMain(api, sourceSha, currentMainSha, label, "admitted source");
+  return currentMainSha;
 }
 
 async function readOptionalReleaseHeadEvidence(api, headSha) {
@@ -1845,7 +1861,7 @@ export async function verifyApprovedMerge(options = {}) {
     api.get(repositoryPath(`/git/ref/tags/${controllerTag}`)),
     api.get(repositoryPath(`/releases/tags/${controllerTag}`)),
   ]);
-  assertMainRef(initialMain, context.sourceSha, "initial release main");
+  await assertReleaseMainRef(api, initialMain, context.sourceSha, "initial release main");
   const controller = assertCommit(
     controllerValue,
     context.controllerSha,
@@ -2025,7 +2041,7 @@ export async function verifyApprovedMerge(options = {}) {
     assertSuccessfulCheck(sourceChecks, name, context.sourceSha),
   );
   const terminalMain = await api.get(repositoryPath("/git/ref/heads/main"));
-  assertMainRef(terminalMain, context.sourceSha, "terminal release main");
+  await assertReleaseMainRef(api, terminalMain, context.sourceSha, "terminal release main");
 
   const provenance = {
     version: 2,

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -1273,7 +1273,10 @@ describe("release head retention recovery", () => {
   });
 
   test("creates a clean absent retained pair after every pre-mutation gate and replays idempotently", async () => {
-    const fixture = recoverySealFixture({ releaseHeadRef: null, release: null });
+    const fixture = recoverySealFixture({
+      releaseHeadRef: null,
+      release: null,
+    });
     const options = {
       env: recoverySealEnv(),
       fetchImpl: fixture.fetchImpl,
@@ -1874,7 +1877,10 @@ test("exact-head retention accepts concurrent creation of the same immutable evi
 
   expect(result.releaseHead.sha).toBe(headSha);
   expect(result.releaseController.sha).toBe(baseSha);
-  expect(result.releaseHeadRelease).toMatchObject({ immutable: true, tagName: expect.any(String) });
+  expect(result.releaseHeadRelease).toMatchObject({
+    immutable: true,
+    tagName: expect.any(String),
+  });
   expect(result.releaseControllerRelease).toMatchObject({
     immutable: true,
     tagName: expect.any(String),
@@ -2036,7 +2042,9 @@ function approvalFixture(
     controllerTreeSha?: string;
     controllerRefSha?: string | null;
     controllerRelease?: Record<string, unknown> | null;
+    initialMainSha?: string;
     terminalMainSha?: string;
+    sourceAncestorMainShas?: string[];
     reviewCommit?: string;
     reviewState?: string;
     reviewTime?: string;
@@ -2076,7 +2084,11 @@ function approvalFixture(
     (options.authorId === RELEASE_AUTOMATION_CONTRACT.releaseApprover.id ||
     (options.reviewState === "COMMENTED" && options.authorId === undefined)
       ? RELEASE_AUTOMATION_CONTRACT.releaseApprover
-      : { login: "release-bot", id: options.authorId ?? 41898282, type: "Bot" });
+      : {
+          login: "release-bot",
+          id: options.authorId ?? 41898282,
+          type: "Bot",
+        });
   const merger =
     options.merger ??
     (options.reviewState === "COMMENTED"
@@ -2136,7 +2148,13 @@ function approvalFixture(
     requests.push({ method, path: url.pathname, query: url.searchParams });
     if (method === "GET" && url.pathname === `${prefix}/git/ref/heads/main`) {
       mainReads += 1;
-      return response(mainRef(mainReads === 1 ? mergeSha : (options.terminalMainSha ?? mergeSha)));
+      return response(
+        mainRef(
+          mainReads === 1
+            ? (options.initialMainSha ?? mergeSha)
+            : (options.terminalMainSha ?? mergeSha),
+        ),
+      );
     }
     if (method === "GET" && url.pathname === prefix) return response(repository());
     if (method === "GET" && url.pathname === `${prefix}/git/commits/${mergeSha}`)
@@ -2263,6 +2281,32 @@ function approvalFixture(
         commits,
       });
     }
+    const sourceMainComparisonPrefix = `${prefix}/compare/${mergeSha}...`;
+    if (method === "GET" && url.pathname.startsWith(sourceMainComparisonPrefix)) {
+      const observedMainSha = url.pathname.slice(sourceMainComparisonPrefix.length);
+      const retained = options.sourceAncestorMainShas?.includes(observedMainSha) ?? false;
+      return response(
+        retained
+          ? {
+              status: "ahead",
+              base_commit: { sha: mergeSha },
+              merge_base_commit: { sha: mergeSha },
+              ahead_by: 1,
+              behind_by: 0,
+              total_commits: 1,
+              commits: [{ sha: observedMainSha, parents: [{ sha: mergeSha }] }],
+            }
+          : {
+              status: "diverged",
+              base_commit: { sha: mergeSha },
+              merge_base_commit: { sha: "6".repeat(40) },
+              ahead_by: 1,
+              behind_by: 1,
+              total_commits: 1,
+              commits: [{ sha: observedMainSha, parents: [{ sha: "6".repeat(40) }] }],
+            },
+      );
+    }
     if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}/reviews`)
       return response([review]);
     if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}/reviews/9001`)
@@ -2384,7 +2428,10 @@ describe("release approval provenance", () => {
     ).rejects.toThrow("GitHub API GET");
 
     const mutable = approvalFixture({
-      controllerRelease: { ...releaseHeadRelease(controllerSha), immutable: false },
+      controllerRelease: {
+        ...releaseHeadRelease(controllerSha),
+        immutable: false,
+      },
     });
     await expect(
       verifyApprovedMerge({
@@ -2459,6 +2506,48 @@ describe("release approval provenance", () => {
       ...RELEASE_AUTOMATION_CONTRACT.checks.requiredSource,
     ]);
     expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  test("accepts an exact release source retained as a strict ancestor across both main fences", async () => {
+    const initialMainSha = "4".repeat(40);
+    const terminalMainSha = "5".repeat(40);
+    const fixture = approvalFixture({
+      initialMainSha,
+      terminalMainSha,
+      sourceAncestorMainShas: [initialMainSha, terminalMainSha],
+    });
+
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: fixture.fetchImpl,
+        logger: { log() {} },
+      }),
+    ).resolves.toEqual(expect.objectContaining({ sourceSha: mergeSha }));
+    expect(
+      fixture.requests.filter((request) =>
+        request.path.startsWith(
+          `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}/compare/${mergeSha}...`,
+        ),
+      ),
+    ).toHaveLength(2);
+  });
+
+  test("rejects diverged main at either release-source fence", async () => {
+    const movedMain = "4".repeat(40);
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ initialMainSha: movedMain }).fetchImpl,
+      }),
+    ).rejects.toThrow("initial release main is not ahead of the admitted source");
+
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({ terminalMainSha: movedMain }).fetchImpl,
+      }),
+    ).rejects.toThrow("terminal release main is not ahead of the admitted source");
   });
 
   test("accepts the provider-bound structured single-maintainer admin PASS", async () => {
@@ -2788,7 +2877,7 @@ describe("release approval provenance", () => {
         env: approvalEnv(),
         fetchImpl: approvalFixture({ terminalMainSha: "7".repeat(40) }).fetchImpl,
       }),
-    ).rejects.toThrow("terminal release main differs");
+    ).rejects.toThrow("terminal release main is not ahead of the admitted source");
   });
 
   test("rejects duplicate, failed, or foreign source-admission and source checks", async () => {
@@ -3484,7 +3573,9 @@ describe("workflow contracts", () => {
       "images",
     ]);
     expect(aggregate.if).toBe("${{ always() }}");
-    expect(aggregate.permissions ?? ci.permissions).toEqual({ contents: "read" });
+    expect(aggregate.permissions ?? ci.permissions).toEqual({
+      contents: "read",
+    });
     expect(aggregate.steps.some((step: any) => step.env?.GITHUB_TOKEN)).toBe(false);
     expect(
       aggregate.steps.find(

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -551,6 +551,7 @@ function admissionFixture(
         commits: [{ sha: headSha }],
         behind_by: pullMergeBaseSha === pullBaseSha ? 0 : 4,
         ahead_by: 1,
+        total_commits: 1,
       });
     if (url.pathname === `${prefix}/pulls/${pullNumber}/files`)
       return response([{ filename: "package.json", status: "modified" }]);
@@ -1015,6 +1016,7 @@ function recoverySealFixture(
         },
         behind_by: options.currentMainContainsSource === false ? 1 : 0,
         ahead_by: 1,
+        total_commits: 1,
       });
     if (url.pathname === `${prefix}/compare/${baseSha}...${headSha}`)
       return response({
@@ -1023,6 +1025,7 @@ function recoverySealFixture(
         merge_base_commit: { sha: baseSha },
         behind_by: 0,
         ahead_by: 1,
+        total_commits: 1,
         commits: [{ sha: headSha }],
       });
     if (url.pathname === `${prefix}/pulls/${pullNumber}/files`)
@@ -2045,6 +2048,7 @@ function approvalFixture(
     initialMainSha?: string;
     terminalMainSha?: string;
     sourceAncestorMainShas?: string[];
+    sourceAncestorTotalCommitsByMainSha?: Record<string, number | null>;
     reviewCommit?: string;
     reviewState?: string;
     reviewTime?: string;
@@ -2293,7 +2297,12 @@ function approvalFixture(
               merge_base_commit: { sha: mergeSha },
               ahead_by: 1,
               behind_by: 0,
-              total_commits: 1,
+              total_commits: Object.prototype.hasOwnProperty.call(
+                options.sourceAncestorTotalCommitsByMainSha ?? {},
+                observedMainSha,
+              )
+                ? options.sourceAncestorTotalCommitsByMainSha?.[observedMainSha]
+                : 1,
               commits: [{ sha: observedMainSha, parents: [{ sha: mergeSha }] }],
             }
           : {
@@ -2548,6 +2557,32 @@ describe("release approval provenance", () => {
         fetchImpl: approvalFixture({ terminalMainSha: movedMain }).fetchImpl,
       }),
     ).rejects.toThrow("terminal release main is not ahead of the admitted source");
+  });
+
+  test("rejects incomplete ancestry comparison at either release-source fence", async () => {
+    const initialMainSha = "4".repeat(40);
+    const terminalMainSha = "5".repeat(40);
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          initialMainSha,
+          sourceAncestorMainShas: [initialMainSha],
+          sourceAncestorTotalCommitsByMainSha: { [initialMainSha]: null },
+        }).fetchImpl,
+      }),
+    ).rejects.toThrow("initial release main ancestry comparison is incomplete");
+
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          terminalMainSha,
+          sourceAncestorMainShas: [terminalMainSha],
+          sourceAncestorTotalCommitsByMainSha: { [terminalMainSha]: 2 },
+        }).fetchImpl,
+      }),
+    ).rejects.toThrow("terminal release main ancestry comparison is incomplete");
   });
 
   test("accepts the provider-bound structured single-maintainer admin PASS", async () => {


### PR DESCRIPTION
## Summary

- accept a sealed release source when it remains an exact strict ancestor of current protected `main`
- preserve fail-closed rejection for divergent, rewritten, behind, or invalid comparison states at both initial and terminal fences
- add regression coverage for moving-main acceptance and divergence rejection
- include the lifecycle-diagnostics Changeset omitted from the already-merged instrumentation source

## Why

The retained source `dc4e72a08c79e2ed0856760c290a3acec4c16162` passed its exact source CI, review, and sealing evidence, but candidate run `31622044916` failed before mutation solely because protected `main` had advanced to descendant `3fa3a0bada6f870f63a402fb9536c4e28a5d9e71`. Repository release policy already documents strict-ancestor admission; the verifier still required equality.

## Validation

- `bun run format:check`
- `bun run lint`
- 105 focused release-automation tests across 5 files
- `bun run typecheck` (30/30 projects)
- `bunx changeset status`
