### PR TITLE
chore(release): version post-release changes

### DIFF
--- a/.changeset/bright-slacks-authorize.md
+++ b/.changeset/bright-slacks-authorize.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/api-router": minor
+"@opengeni/contracts": minor
+"@opengeni/db": minor
+"@opengeni/core": patch
+---
+
+Add workspace-governed Slack shared-conversation task policies with durable enforcement and public contracts, and enforce vertical-only agent session authority across core and persistence.


### PR DESCRIPTION
Adds the missing Changeset for the publishable Slack task-policy surface and vertical session-authority enforcement merged after the previous Version PR. This is release metadata only; it enables Changesets to generate an exact Version PR and trusted retained controller for the 0.23.4 candidate.