### PR TITLE
fix(release): admit successful CI reruns

### DIFF
--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -1515,6 +1515,149 @@ function assertSuccessfulCheck(checks, name, sha) {
   });
 }
 
+function actionsJobIdentity(check, name, sha) {
+  invariant(check?.head_sha === sha, `${name} is bound to another commit`);
+  assertGitHubActionsApp(check?.app, name);
+  const checkId = assertPositiveInteger(check?.id, `${name} check-run ID`);
+  const checkSuiteId = assertPositiveInteger(check?.check_suite?.id, `${name} check-suite ID`);
+  const detailsUrl = assertString(check?.details_url, `${name} details URL`);
+  const parsedDetailsUrl = new URL(detailsUrl);
+  invariant(
+    parsedDetailsUrl.origin === RELEASE_AUTOMATION_CONTRACT.serverUrl &&
+      parsedDetailsUrl.search === "" &&
+      parsedDetailsUrl.hash === "",
+    `${name} details URL is not an exact GitHub Actions job URL`,
+  );
+  const match = parsedDetailsUrl.pathname.match(
+    new RegExp(
+      `^/${RELEASE_AUTOMATION_CONTRACT.repository}/actions/runs/` +
+        `([1-9][0-9]*)/job/([1-9][0-9]*)$`,
+    ),
+  );
+  invariant(match !== null, `${name} details URL is not an exact GitHub Actions job URL`);
+  const runId = assertPositiveInteger(match[1], `${name} workflow run ID`);
+  const jobId = assertPositiveInteger(match[2], `${name} workflow job ID`);
+  invariant(checkId === jobId, `${name} check-run ID differs from its workflow job URL`);
+  return { check, checkId, checkSuiteId, detailsUrl, jobId, runId };
+}
+
+async function paginatedWorkflowAttemptJobs(api, runId, runAttempt) {
+  const rows = [];
+  for (let page = 1; page <= maximumPages; page += 1) {
+    const value = await api.get(
+      repositoryPath(
+        `/actions/runs/${runId}/attempts/${runAttempt}/jobs?per_page=${recordsPerPage}&page=${page}`,
+      ),
+    );
+    invariant(Array.isArray(value?.jobs), "workflow-attempt job listing is invalid");
+    rows.push(...value.jobs);
+    if (value.jobs.length < recordsPerPage) return rows;
+  }
+  throw new Error(`workflow-attempt job listing exceeded ${maximumPages * recordsPerPage} records`);
+}
+
+async function verifySuccessfulSourceChecks(api, checks, names, sha) {
+  // GitHub failed-job reruns retain historical check runs under one workflow
+  // run/check suite. Bind to that provider-owned run, then require its latest
+  // attempt and exact aggregate jobs to be successful instead of trusting a
+  // timestamp-selected check or rejecting legitimate retry history outright.
+  const identitiesByName = new Map();
+  const allIdentities = [];
+  for (const name of names) {
+    const selected = checks.filter((check) => check?.name === name);
+    invariant(selected.length > 0, `${name} check run is missing on ${sha}`);
+    const identities = selected.map((check) => actionsJobIdentity(check, name, sha));
+    identitiesByName.set(name, identities);
+    allIdentities.push(...identities);
+  }
+
+  const runIds = new Set(allIdentities.map((identity) => identity.runId));
+  invariant(runIds.size === 1, "required source checks do not share one workflow run");
+  const checkSuiteIds = new Set(allIdentities.map((identity) => identity.checkSuiteId));
+  invariant(checkSuiteIds.size === 1, "required source checks do not share one check suite");
+  const runId = allIdentities[0].runId;
+  const checkSuiteId = allIdentities[0].checkSuiteId;
+  const run = record(
+    await api.get(repositoryPath(`/actions/runs/${runId}`)),
+    "required source workflow run",
+  );
+  invariant(run.id === runId, "required source workflow run ID changed");
+  invariant(
+    run.check_suite_id === checkSuiteId,
+    "required source workflow run check-suite identity changed",
+  );
+  invariant(run.event === "push", "required source workflow run was not triggered by a push");
+  invariant(
+    run.path === RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath,
+    "required source checks did not execute the CI workflow",
+  );
+  invariant(
+    run.head_branch === RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+    "required source workflow branch changed",
+  );
+  invariant(run.head_sha === sha, "required source workflow run is bound to another commit");
+  invariant(
+    run.repository?.full_name === RELEASE_AUTOMATION_CONTRACT.repository &&
+      run.head_repository?.full_name === RELEASE_AUTOMATION_CONTRACT.repository,
+    "required source workflow repository changed",
+  );
+  invariant(
+    run.html_url ===
+      `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+        `/actions/runs/${runId}`,
+    "required source workflow URL changed",
+  );
+  const runAttempt = assertPositiveInteger(run.run_attempt, "required source workflow attempt");
+  invariant(
+    run.status === "completed" && run.conclusion === "success",
+    "required source workflow did not complete successfully",
+  );
+
+  const jobs = await paginatedWorkflowAttemptJobs(api, runId, runAttempt);
+  return names.map((name) => {
+    const selectedJobs = jobs.filter((job) => job?.name === name);
+    invariant(
+      selectedJobs.length === 1,
+      `${name} is not represented by exactly one job in the authoritative workflow attempt`,
+    );
+    const job = selectedJobs[0];
+    const jobId = assertPositiveInteger(job?.id, `${name} authoritative workflow job ID`);
+    invariant(
+      job.status === "completed" && job.conclusion === "success",
+      `${name} did not complete successfully in the authoritative workflow attempt`,
+    );
+    invariant(
+      job.html_url ===
+        `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+          `/actions/runs/${runId}/job/${jobId}`,
+      `${name} authoritative workflow job URL changed`,
+    );
+    invariant(
+      job.check_run_url ===
+        `${RELEASE_AUTOMATION_CONTRACT.apiUrl}/repos/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+          `/check-runs/${jobId}`,
+      `${name} authoritative workflow job check-run URL changed`,
+    );
+    const latest = identitiesByName.get(name).filter((identity) => identity.jobId === jobId);
+    invariant(
+      latest.length === 1,
+      `${name} authoritative workflow job is not represented by exactly one check run`,
+    );
+    invariant(
+      latest[0].check.status === "completed" && latest[0].check.conclusion === "success",
+      `${name} authoritative check run did not complete successfully`,
+    );
+    return Object.freeze({
+      name,
+      appSlug: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.slug,
+      appId: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.id,
+      workflowRunId: runId,
+      workflowRunAttempt: runAttempt,
+      workflowJobId: jobId,
+    });
+  });
+}
+
 function assertSuccessfulCheckRun(check, name, sha, externalId) {
   invariant(check !== undefined, `${name} canonical check run is missing on ${sha}`);
   invariant(check?.name === name, `${name} canonical check has another name`);
@@ -2041,8 +2184,11 @@ export async function verifyApprovedMerge(options = {}) {
     fetchImpl: options.fetchImpl ?? globalThis.fetch,
     logger,
   });
-  const requiredSourceChecks = RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name) =>
-    assertSuccessfulCheck(sourceChecks, name, context.sourceSha),
+  const requiredSourceChecks = await verifySuccessfulSourceChecks(
+    api,
+    sourceChecks,
+    RELEASE_AUTOMATION_CONTRACT.checks.requiredSource,
+    context.sourceSha,
   );
   const terminalMain = await api.get(repositoryPath("/git/ref/heads/main"));
   await assertReleaseMainRef(api, terminalMain, context.sourceSha, "terminal release main");

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -40,6 +40,9 @@ const runAttempt = 2;
 const recoveryRunId = 790;
 const recoveryRunAttempt = 3;
 const releaseHeadReleaseId = 7654321;
+const sourceCiRunId = 654321;
+const sourceCiRunAttempt = 1;
+const sourceCiCheckSuiteId = 876543;
 
 function recoveredSourceAdmissionExternalId(
   workflowRunId = recoveryRunId,
@@ -87,6 +90,41 @@ function releaseHeadRelease(sha = headSha) {
     html_url:
       `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
       `/releases/tag/${tagName}`,
+  };
+}
+
+function sourceCiCheck(name: string, index: number, overrides: Record<string, unknown> = {}) {
+  const jobId = Number(overrides.id ?? 7000 + index);
+  return {
+    id: jobId,
+    name,
+    head_sha: mergeSha,
+    status: "completed",
+    conclusion: "success",
+    external_id: `source-ci-${jobId}`,
+    details_url:
+      `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+      `/actions/runs/${sourceCiRunId}/job/${jobId}`,
+    check_suite: { id: sourceCiCheckSuiteId },
+    app: RELEASE_AUTOMATION_CONTRACT.githubActionsApp,
+    ...overrides,
+  };
+}
+
+function sourceCiJob(name: string, index: number, overrides: Record<string, unknown> = {}) {
+  const jobId = Number(overrides.id ?? 7000 + index);
+  return {
+    id: jobId,
+    name,
+    status: "completed",
+    conclusion: "success",
+    html_url:
+      `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+      `/actions/runs/${sourceCiRunId}/job/${jobId}`,
+    check_run_url:
+      `${RELEASE_AUTOMATION_CONTRACT.apiUrl}/repos/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+      `/check-runs/${jobId}`,
+    ...overrides,
   };
 }
 
@@ -2064,6 +2102,8 @@ function approvalFixture(
     sourceChecks?: Array<Record<string, unknown>>;
     historicalHeadChecks?: Array<Record<string, unknown>>;
     historicalSourceChecks?: Array<Record<string, unknown>>;
+    sourceRun?: Record<string, unknown>;
+    sourceAttemptJobs?: Array<Record<string, unknown>>;
     releaseHeadRefSha?: string | null;
     release?: Record<string, unknown> | null;
     reviewedBaseSha?: string;
@@ -2323,6 +2363,37 @@ function approvalFixture(
         ...review,
         user: options.reviewDetailReviewer ?? review.user,
       });
+    if (method === "GET" && url.pathname === `${prefix}/actions/runs/${sourceCiRunId}`)
+      return response(
+        options.sourceRun ?? {
+          id: sourceCiRunId,
+          run_attempt: sourceCiRunAttempt,
+          status: "completed",
+          conclusion: "success",
+          event: "push",
+          path: RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath,
+          head_sha: mergeSha,
+          head_branch: RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+          check_suite_id: sourceCiCheckSuiteId,
+          html_url:
+            `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+            `/actions/runs/${sourceCiRunId}`,
+          repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+          head_repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+        },
+      );
+    if (
+      method === "GET" &&
+      url.pathname === `${prefix}/actions/runs/${sourceCiRunId}/attempts/${sourceCiRunAttempt}/jobs`
+    )
+      return response({
+        total_count: (options.sourceAttemptJobs ?? []).length,
+        jobs:
+          options.sourceAttemptJobs ??
+          RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name, index) =>
+            sourceCiJob(name, index),
+          ),
+      });
     if (
       method === "GET" &&
       url.pathname ===
@@ -2382,8 +2453,8 @@ function approvalFixture(
       return response({
         check_runs: [
           ...(options.sourceChecks ??
-            RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name) =>
-              successfulCheck(name, mergeSha),
+            RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name, index) =>
+              sourceCiCheck(name, index),
             )),
           ...(url.searchParams.get("filter") === "all"
             ? (options.historicalSourceChecks ?? [])
@@ -2972,12 +3043,107 @@ describe("release approval provenance", () => {
         env: approvalEnv(),
         fetchImpl: approvalFixture({
           sourceChecks: RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name, index) => ({
-            ...success(name, mergeSha),
+            ...sourceCiCheck(name, index),
             conclusion: index === 0 ? "failure" : "success",
           })),
         }).fetchImpl,
       }),
-    ).rejects.toThrow("did not complete successfully");
+    ).rejects.toThrow("authoritative check run did not complete successfully");
+  });
+
+  test("accepts official failed-job retry history when the latest CI attempt succeeds", async () => {
+    const latestChecks = RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name, index) =>
+      sourceCiCheck(name, index, { id: 7100 + index }),
+    );
+    const historicalChecks = RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name, index) =>
+      sourceCiCheck(name, index, {
+        id: 7000 + index,
+        conclusion: index === 0 ? "failure" : "success",
+      }),
+    );
+    const fixture = approvalFixture({
+      sourceChecks: latestChecks,
+      historicalSourceChecks: historicalChecks,
+      sourceRun: {
+        id: sourceCiRunId,
+        run_attempt: sourceCiRunAttempt,
+        status: "completed",
+        conclusion: "success",
+        event: "push",
+        path: RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath,
+        head_sha: mergeSha,
+        head_branch: RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+        check_suite_id: sourceCiCheckSuiteId,
+        html_url:
+          `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+          `/actions/runs/${sourceCiRunId}`,
+        repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+        head_repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+      },
+      sourceAttemptJobs: RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name, index) =>
+        sourceCiJob(name, index, { id: 7100 + index }),
+      ),
+    });
+
+    const result = await verifyApprovedMerge({
+      env: approvalEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+    });
+
+    expect(result.requiredSourceChecks).toEqual(
+      RELEASE_AUTOMATION_CONTRACT.checks.requiredSource.map((name, index) => ({
+        name,
+        appSlug: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.slug,
+        appId: RELEASE_AUTOMATION_CONTRACT.githubActionsApp.id,
+        workflowRunId: sourceCiRunId,
+        workflowRunAttempt: sourceCiRunAttempt,
+        workflowJobId: 7100 + index,
+      })),
+    );
+  });
+
+  test("rejects failed latest CI attempts and source checks from another workflow run", async () => {
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          sourceRun: {
+            id: sourceCiRunId,
+            run_attempt: sourceCiRunAttempt,
+            status: "completed",
+            conclusion: "failure",
+            event: "push",
+            path: RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath,
+            head_sha: mergeSha,
+            head_branch: RELEASE_AUTOMATION_CONTRACT.defaultBranch,
+            check_suite_id: sourceCiCheckSuiteId,
+            html_url:
+              `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+              `/actions/runs/${sourceCiRunId}`,
+            repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+            head_repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
+          },
+        }).fetchImpl,
+      }),
+    ).rejects.toThrow("required source workflow did not complete successfully");
+
+    await expect(
+      verifyApprovedMerge({
+        env: approvalEnv(),
+        fetchImpl: approvalFixture({
+          historicalSourceChecks: [
+            sourceCiCheck(RELEASE_AUTOMATION_CONTRACT.checks.requiredSource[0], 50, {
+              id: 8050,
+              details_url:
+                `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
+                "/actions/runs/999999/job/8050",
+              check_suite: { id: 999999 },
+            }),
+          ],
+        }).fetchImpl,
+      }),
+    ).rejects.toThrow("required source checks do not share one workflow run");
   });
 
   test("requires the immutable reviewed-head evidence ref", async () => {


### PR DESCRIPTION
## Summary

- accept ordinary GitHub Actions failed-job retry history for the three merged-source release checks
- bind every historical aggregate check to one official CI workflow run and check suite
- require that run's latest provider-reported attempt and exact aggregate jobs to complete successfully
- continue rejecting foreign runs, ambiguous suites, failed latest attempts, mismatched job URLs, and duplicate authoritative checks

## Incident

Candidate run `31643599256` failed before building or publishing because merged source `31ed30c66a64ff9251f0eefb3f692323d1d76953` had multiple `Typecheck and unit tests` check-run records after failed-job reruns. The existing verifier requested `filter=all` but then required exactly one historical check record, making normal GitHub retry history permanently inadmissible.

No candidate artifact or registry publication occurred.

## Validation

- `bun test scripts/check-release-pr-automation.test.ts scripts/release-image-workflow-contract.test.ts` — 97 pass
- `bun run typecheck` — 30/30 projects clean
- `bun run lint` — 0 warnings, 0 errors
- `bunx oxfmt --check scripts/check-release-pr-automation.mjs scripts/check-release-pr-automation.test.ts`
- `git diff --check`