### PR TITLE
fix(release): admit successor controllers

### DIFF
--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -2008,7 +2008,12 @@ export async function verifyApprovedMerge(options = {}) {
     api.get(repositoryPath(`/git/ref/tags/${controllerTag}`)),
     api.get(repositoryPath(`/releases/tags/${controllerTag}`)),
   ]);
-  await assertReleaseMainRef(api, initialMain, context.sourceSha, "initial release main");
+  const initialMainSha = await assertReleaseMainRef(
+    api,
+    initialMain,
+    context.sourceSha,
+    "initial release main",
+  );
   const controller = assertCommit(
     controllerValue,
     context.controllerSha,
@@ -2050,10 +2055,23 @@ export async function verifyApprovedMerge(options = {}) {
     "pull-request timeline",
   );
   assertProviderMergeEvent(timeline, context.sourceSha, pullIdentity);
-  invariant(
-    context.controllerSha === pullIdentity.baseSha,
-    "release controller SHA differs from the exact reviewed base SHA",
-  );
+  const controllerIsReviewedBase = context.controllerSha === pullIdentity.baseSha;
+  if (!controllerIsReviewedBase) {
+    await assertSourceAncestorOfCurrentMain(
+      api,
+      context.sourceSha,
+      context.controllerSha,
+      "release controller",
+      "admitted source",
+    );
+    await assertSourceAncestorOfCurrentMain(
+      api,
+      context.controllerSha,
+      initialMainSha,
+      "initial release main",
+      "release controller",
+    );
+  }
   const [base, head] = await Promise.all([
     api
       .get(repositoryPath(`/git/commits/${pullIdentity.baseSha}`))
@@ -2062,10 +2080,12 @@ export async function verifyApprovedMerge(options = {}) {
       .get(repositoryPath(`/git/commits/${pullIdentity.headSha}`))
       .then((value) => assertCommit(value, pullIdentity.headSha, "reviewed head commit")),
   ]);
-  invariant(
-    controller.treeSha === base.treeSha,
-    "release controller tree differs from the exact reviewed base tree",
-  );
+  if (controllerIsReviewedBase) {
+    invariant(
+      controller.treeSha === base.treeSha,
+      "release controller tree differs from the exact reviewed base tree",
+    );
+  }
   invariant(
     source.treeSha === head.treeSha,
     "release source tree differs from the exact reviewed head",
@@ -2191,7 +2211,21 @@ export async function verifyApprovedMerge(options = {}) {
     context.sourceSha,
   );
   const terminalMain = await api.get(repositoryPath("/git/ref/heads/main"));
-  await assertReleaseMainRef(api, terminalMain, context.sourceSha, "terminal release main");
+  const terminalMainSha = await assertReleaseMainRef(
+    api,
+    terminalMain,
+    context.sourceSha,
+    "terminal release main",
+  );
+  if (!controllerIsReviewedBase) {
+    await assertSourceAncestorOfCurrentMain(
+      api,
+      context.controllerSha,
+      terminalMainSha,
+      "terminal release main",
+      "release controller",
+    );
+  }
 
   const provenance = {
     version: 2,

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2080,6 +2080,7 @@ function approvalFixture(
     mergeCommitSha?: string;
     pullHeadSha?: string;
     sourceTreeSha?: string;
+    controllerSha?: string;
     controllerTreeSha?: string;
     controllerRefSha?: string | null;
     controllerRelease?: Record<string, unknown> | null;
@@ -2087,6 +2088,8 @@ function approvalFixture(
     terminalMainSha?: string;
     sourceAncestorMainShas?: string[];
     sourceAncestorTotalCommitsByMainSha?: Record<string, number | null>;
+    controllerAncestorMainShas?: string[];
+    controllerAncestorTotalCommitsByMainSha?: Record<string, number | null>;
     reviewCommit?: string;
     reviewState?: string;
     reviewTime?: string;
@@ -2116,6 +2119,7 @@ function approvalFixture(
   const mergeMethod = options.mergeMethod ?? "merge";
   const pullHeadSha = options.pullHeadSha ?? headSha;
   const reviewedBaseSha = options.reviewedBaseSha ?? baseSha;
+  const retainedControllerSha = options.controllerSha ?? controllerSha;
   const pullCommitCount = mergeMethod === "single" ? 1 : 2;
   const sourceParents =
     mergeMethod === "merge"
@@ -2213,9 +2217,9 @@ function approvalFixture(
         tree: { sha: baseTreeSha },
         parents: [{ sha: "1".repeat(40) }],
       });
-    if (method === "GET" && url.pathname === `${prefix}/git/commits/${controllerSha}`)
+    if (method === "GET" && url.pathname === `${prefix}/git/commits/${retainedControllerSha}`)
       return response({
-        sha: controllerSha,
+        sha: retainedControllerSha,
         tree: { sha: options.controllerTreeSha ?? baseTreeSha },
         parents: [{ sha: "3".repeat(40) }],
       });
@@ -2356,6 +2360,41 @@ function approvalFixture(
             },
       );
     }
+    const controllerMainComparisonPrefix = `${prefix}/compare/${retainedControllerSha}...`;
+    if (
+      options.controllerSha !== undefined &&
+      method === "GET" &&
+      url.pathname.startsWith(controllerMainComparisonPrefix)
+    ) {
+      const observedMainSha = url.pathname.slice(controllerMainComparisonPrefix.length);
+      const retained = options.controllerAncestorMainShas?.includes(observedMainSha) ?? false;
+      return response(
+        retained
+          ? {
+              status: "ahead",
+              base_commit: { sha: retainedControllerSha },
+              merge_base_commit: { sha: retainedControllerSha },
+              ahead_by: 1,
+              behind_by: 0,
+              total_commits: Object.prototype.hasOwnProperty.call(
+                options.controllerAncestorTotalCommitsByMainSha ?? {},
+                observedMainSha,
+              )
+                ? options.controllerAncestorTotalCommitsByMainSha?.[observedMainSha]
+                : 1,
+              commits: [{ sha: observedMainSha, parents: [{ sha: retainedControllerSha }] }],
+            }
+          : {
+              status: "diverged",
+              base_commit: { sha: retainedControllerSha },
+              merge_base_commit: { sha: "6".repeat(40) },
+              ahead_by: 1,
+              behind_by: 1,
+              total_commits: 1,
+              commits: [{ sha: observedMainSha, parents: [{ sha: "6".repeat(40) }] }],
+            },
+      );
+    }
     if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}/reviews`)
       return response([review]);
     if (method === "GET" && url.pathname === `${prefix}/pulls/${pullNumber}/reviews/9001`)
@@ -2397,26 +2436,26 @@ function approvalFixture(
     if (
       method === "GET" &&
       url.pathname ===
-        `${prefix}/git/ref/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${controllerSha}`
+        `${prefix}/git/ref/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${retainedControllerSha}`
     ) {
       if (options.controllerRefSha === null)
         return response({ message: "missing controller ref" }, 404);
       return response({
-        ref: `refs/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${controllerSha}`,
+        ref: `refs/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${retainedControllerSha}`,
         object: {
           type: "commit",
-          sha: options.controllerRefSha ?? controllerSha,
+          sha: options.controllerRefSha ?? retainedControllerSha,
         },
       });
     }
     if (
       method === "GET" &&
       url.pathname ===
-        `${prefix}/releases/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${controllerSha}`
+        `${prefix}/releases/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${retainedControllerSha}`
     )
       return options.controllerRelease === null
         ? response({ message: "missing controller release" }, 404)
-        : response(options.controllerRelease ?? releaseHeadRelease(controllerSha));
+        : response(options.controllerRelease ?? releaseHeadRelease(retainedControllerSha));
     if (
       method === "GET" &&
       url.pathname ===
@@ -2483,18 +2522,71 @@ describe("release approval provenance", () => {
     ).rejects.toThrow("not running from the retained controller ref");
   });
 
-  test("rejects a retained controller that is not the exact reviewed base commit", async () => {
+  test("accepts a retained controller after the source on protected main ancestry", async () => {
+    const retainedControllerSha = "4".repeat(40);
+    const initialMainSha = "5".repeat(40);
+    const terminalMainSha = "6".repeat(40);
     const fixture = approvalFixture({
-      mergeMethod: "squash",
-      reviewedBaseSha: "9".repeat(40),
+      controllerSha: retainedControllerSha,
+      controllerTreeSha: "7".repeat(40),
+      initialMainSha,
+      terminalMainSha,
+      sourceAncestorMainShas: [retainedControllerSha, initialMainSha, terminalMainSha],
+      controllerAncestorMainShas: [initialMainSha, terminalMainSha],
     });
     await expect(
       verifyApprovedMerge({
-        env: approvalEnv(),
+        env: approvalEnv({
+          GITHUB_REF:
+            `refs/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}` + retainedControllerSha,
+          GITHUB_SHA: retainedControllerSha,
+          GITHUB_WORKFLOW_SHA: retainedControllerSha,
+          RELEASE_CONTROLLER_SHA: retainedControllerSha,
+        }),
         fetchImpl: fixture.fetchImpl,
         logger: { log() {} },
       }),
-    ).rejects.toThrow("release controller SHA differs from the exact reviewed base SHA");
+    ).resolves.toEqual(
+      expect.objectContaining({
+        controller: expect.objectContaining({
+          sha: retainedControllerSha,
+          treeSha: "7".repeat(40),
+        }),
+      }),
+    );
+  });
+
+  test("rejects a retained controller outside the admitted source to protected main chain", async () => {
+    const retainedControllerSha = "4".repeat(40);
+    const initialMainSha = "5".repeat(40);
+    const env = approvalEnv({
+      GITHUB_REF:
+        `refs/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}` + retainedControllerSha,
+      GITHUB_SHA: retainedControllerSha,
+      GITHUB_WORKFLOW_SHA: retainedControllerSha,
+      RELEASE_CONTROLLER_SHA: retainedControllerSha,
+    });
+    await expect(
+      verifyApprovedMerge({
+        env,
+        fetchImpl: approvalFixture({
+          controllerSha: retainedControllerSha,
+          initialMainSha,
+          sourceAncestorMainShas: [initialMainSha],
+        }).fetchImpl,
+      }),
+    ).rejects.toThrow("release controller is not ahead of the admitted source");
+
+    await expect(
+      verifyApprovedMerge({
+        env,
+        fetchImpl: approvalFixture({
+          controllerSha: retainedControllerSha,
+          initialMainSha,
+          sourceAncestorMainShas: [retainedControllerSha, initialMainSha],
+        }).fetchImpl,
+      }),
+    ).rejects.toThrow("initial release main is not ahead of the release controller");
   });
 
   test("requires immutable retained evidence for the workflow controller", async () => {


### PR DESCRIPTION
## Summary
- permit an immutable release controller later than the reviewed source only when the source is its exact ancestor
- require that successor controller to remain an exact ancestor of protected `main` at both initial and terminal release fences
- preserve the original exact-reviewed-base controller/tree path unchanged
- retain PR #1385's stronger provider-bound GitHub Actions rerun verifier unchanged

## Release blocker
The original release source is `31ed30c66a64ff9251f0eefb3f692323d1d76953`. PR #1385 fixed authoritative failed-job rerun admission after that source was created, so executing the fix requires a later retained controller. The old verifier required `controller_sha === reviewedBaseSha`, making a fixed controller impossible to use.

## Supersession / repair
The first PR #1386 head also implemented rerun selection. Protected main then merged stronger focused PR #1385, creating a real overlap conflict. This repaired head is rebuilt from current protected main `0a919a45564bf8ea3c4bfe12643c0808b527b1a6` and contains only the still-missing successor-controller ancestry seam.

## Verification
- `bun test scripts/check-release-pr-automation.test.ts scripts/release-image-workflow-contract.test.ts` — 98 passed
- pinned `oxfmt 0.58.0 --check` on both changed files
- pinned `oxlint 1.73.0 --deny-warnings` on both changed files
- `git diff --check`

No package or product version changes; release-controller admission logic only.
