### PR TITLE
perf(ci): cross-build sandbox computer helper

### DIFF
--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -13,14 +13,27 @@ ADD --checksum=sha256:8d7b3a1d7b9024beef94e7fc7ce854030ee4d6def5f802b8e0e8824731
 ADD --checksum=sha256:a5005b353a1738dd3d239234841cfcc808a7ec9faaebfcede3528f9fab3ae058 https://github.com/lightpanda-io/browser/archive/refs/tags/0.3.5.tar.gz /lightpanda-0.3.5-source.tar.gz
 ADD --checksum=sha256:8486a10c4393cee1c25392769ddd3b2d6c242d6ec7928e1414efff7dfb2f07ef https://raw.githubusercontent.com/lightpanda-io/browser/0.3.5/LICENSE /lightpanda-LICENSE
 
-FROM rust:1.82-bookworm AS computer-native-build
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx
+FROM --platform=$BUILDPLATFORM rust:1.82-bookworm AS computer-native-build
+
+COPY --from=xx / /
+
+# Keep the large Rust release build on the native GitHub runner. `xx-cargo`
+# selects the requested OCI target and configures clang/lld for its glibc ABI;
+# `xx-verify` fails closed if the copied helper is not actually target-native.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends clang lld \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src/agent
 COPY agent .
+ARG TARGETPLATFORM
 RUN set -eux; \
-    cargo build --locked --release -p opengeni-computer-native; \
+    rust_target="$(xx-cargo --print-target-triple)"; \
+    xx-cargo build --locked --release --target-dir /src/agent/target -p opengeni-computer-native; \
     mkdir -p /out; \
-    install -m 0755 target/release/opengeni-computer-native /out/opengeni-computer-native
+    install -m 0755 "target/${rust_target}/release/opengeni-computer-native" /out/opengeni-computer-native; \
+    xx-verify /out/opengeni-computer-native
 
 FROM oven/bun:1.3.14 AS bun-runtime
 

--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -26,8 +26,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src/agent
-COPY agent .
 ARG TARGETPLATFORM
+RUN xx-apt-get install -y --no-install-recommends xx-c-essentials
+COPY agent .
 RUN set -eux; \
     rust_target="$(xx-cargo --print-target-triple)"; \
     xx-cargo build --locked --release --target-dir /src/agent/target -p opengeni-computer-native; \

--- a/scripts/sandbox-computer-native-build-contract.test.ts
+++ b/scripts/sandbox-computer-native-build-contract.test.ts
@@ -1,0 +1,67 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const root = resolve(import.meta.dir, "..");
+const dockerfilePath = resolve(root, "docker/sandbox.Dockerfile");
+
+function computerNativeStage(source: string): string {
+  const start = source.indexOf(
+    "FROM --platform=$BUILDPLATFORM rust:1.82-bookworm AS computer-native-build",
+  );
+  if (start < 0) return "";
+  const next = source.indexOf("\nFROM ", start + 1);
+  return next < 0 ? source.slice(start) : source.slice(start, next);
+}
+
+function keepsComputerNativeBuildOnTheNativeRunner(source: string): boolean {
+  const xxStage =
+    "FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx";
+  const stage = computerNativeStage(source);
+  const target = stage.indexOf("ARG TARGETPLATFORM");
+  const triple = stage.indexOf('rust_target="$(xx-cargo --print-target-triple)"', target);
+  const build = stage.indexOf(
+    "xx-cargo build --locked --release --target-dir /src/agent/target -p opengeni-computer-native",
+    triple,
+  );
+  const install = stage.indexOf(
+    'install -m 0755 "target/${rust_target}/release/opengeni-computer-native" /out/opengeni-computer-native',
+    build,
+  );
+  const verify = stage.indexOf("xx-verify /out/opengeni-computer-native", install);
+
+  return (
+    source.includes(xxStage) &&
+    stage.includes("COPY --from=xx / /") &&
+    stage.includes("apt-get install -y --no-install-recommends clang lld") &&
+    target >= 0 &&
+    triple > target &&
+    build > triple &&
+    install > build &&
+    verify > install &&
+    !stage.includes("cargo build --locked --release -p opengeni-computer-native") &&
+    !stage.includes("target/release/opengeni-computer-native /out/opengeni-computer-native")
+  );
+}
+
+describe("sandbox native computer image build contract", () => {
+  test("cross-compiles the target helper on the native build platform", async () => {
+    const source = await readFile(dockerfilePath, "utf8");
+
+    expect(keepsComputerNativeBuildOnTheNativeRunner(source)).toBe(true);
+
+    const emulatedStage = source.replace(
+      "FROM --platform=$BUILDPLATFORM rust:1.82-bookworm AS computer-native-build",
+      "FROM rust:1.82-bookworm AS computer-native-build",
+    );
+    const unverifiedOutput = source.replace(
+      "    xx-verify /out/opengeni-computer-native",
+      "    file /out/opengeni-computer-native",
+    );
+    const unlockedBuild = source.replace("xx-cargo build --locked", "xx-cargo build");
+
+    expect(keepsComputerNativeBuildOnTheNativeRunner(emulatedStage)).toBe(false);
+    expect(keepsComputerNativeBuildOnTheNativeRunner(unverifiedOutput)).toBe(false);
+    expect(keepsComputerNativeBuildOnTheNativeRunner(unlockedBuild)).toBe(false);
+  });
+});

--- a/scripts/sandbox-computer-native-build-contract.test.ts
+++ b/scripts/sandbox-computer-native-build-contract.test.ts
@@ -19,7 +19,12 @@ function keepsComputerNativeBuildOnTheNativeRunner(source: string): boolean {
     "FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx";
   const stage = computerNativeStage(source);
   const target = stage.indexOf("ARG TARGETPLATFORM");
-  const triple = stage.indexOf('rust_target="$(xx-cargo --print-target-triple)"', target);
+  const targetLibraries = stage.indexOf(
+    "RUN xx-apt-get install -y --no-install-recommends xx-c-essentials",
+    target,
+  );
+  const sourceCopy = stage.indexOf("COPY agent .", targetLibraries);
+  const triple = stage.indexOf('rust_target="$(xx-cargo --print-target-triple)"', sourceCopy);
   const build = stage.indexOf(
     "xx-cargo build --locked --release --target-dir /src/agent/target -p opengeni-computer-native",
     triple,
@@ -35,7 +40,9 @@ function keepsComputerNativeBuildOnTheNativeRunner(source: string): boolean {
     stage.includes("COPY --from=xx / /") &&
     stage.includes("apt-get install -y --no-install-recommends clang lld") &&
     target >= 0 &&
-    triple > target &&
+    targetLibraries > target &&
+    sourceCopy > targetLibraries &&
+    triple > sourceCopy &&
     build > triple &&
     install > build &&
     verify > install &&
@@ -59,9 +66,14 @@ describe("sandbox native computer image build contract", () => {
       "    file /out/opengeni-computer-native",
     );
     const unlockedBuild = source.replace("xx-cargo build --locked", "xx-cargo build");
+    const missingTargetLibraries = source.replace(
+      "RUN xx-apt-get install -y --no-install-recommends xx-c-essentials\n",
+      "",
+    );
 
     expect(keepsComputerNativeBuildOnTheNativeRunner(emulatedStage)).toBe(false);
     expect(keepsComputerNativeBuildOnTheNativeRunner(unverifiedOutput)).toBe(false);
     expect(keepsComputerNativeBuildOnTheNativeRunner(unlockedBuild)).toBe(false);
+    expect(keepsComputerNativeBuildOnTheNativeRunner(missingTargetLibraries)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- build `opengeni-computer-native` on the GitHub runner's native architecture instead of executing the ARM64 Rust release build under QEMU
- use the repository-established, digest-pinned `tonistiigi/xx` cross-build pattern with Rust 1.82, `clang`/`lld`, target-scoped `xx-c-essentials`, locked Cargo resolution, and `xx-verify`
- add a contract test that fails if the stage returns to target-platform emulation, drops the lockfile gate, copies the wrong target path, omits target libraries, or omits target verification

## Exact hosted result

OPE-27 natural-main baseline run `31648432426`, job `94288552523`:

- ARM64 `computer-native-build`: **1,997.2s**
- AMD64 `computer-native-build`: **224.5s**
- complete headless sandbox image job: **2,164s**

PR V2 exact-head run `31656259169`, job `94312267645`:

- ARM64 cross-build plus `xx-verify`: **240.6s**
- AMD64 native build plus `xx-verify`: **265.2s**
- complete headless sandbox image job: **416s**

The ARM64 critical vertex improved by **1,756.6s (88.0%)**. The complete job improved by **1,748s (80.8%)**, from 36m04s to 6m56s. The exact run also produced and verified both target binaries successfully.

This focused slice does not by itself bring all required CI under five minutes. In the same exact run, the next larger paths were worker/web image builds at about 10m51s, real-service shard 4 at 8m00s, and package/bundle contracts at 7m54s.

## Safety

- no workflow, test selection, timeout, retry, publication, or required-check gate changes
- Rust version and `Cargo.lock` enforcement stay unchanged
- target C/linker startup objects and libraries are installed before copying source so they remain cacheable
- the produced helper is read from the target-specific Cargo path
- `xx-verify` fails the image build if the binary architecture does not match the OCI target
- `tonistiigi/xx` is pinned by tag and digest

## Verification

- Source Admission `31656258017` — success
- exact-head CI `31656259169` — success; all required leaf jobs passed
- `bun test scripts/sandbox-computer-native-build-contract.test.ts scripts/browserd-image-build-contract.test.ts scripts/release-image-workflow-contract.test.ts scripts/workload-image-system-packages-contract.test.ts` — 23 pass, 0 fail
- `bun run test:unit` — pass
- `bun run typecheck` — all 30 projects clean
- `bun run lint` — 0 warnings, 0 errors
- `bun run format:check` — pass
- `bun run check:public-hygiene` — pass
- manual pinned-wrapper locked cross-builds for `aarch64-unknown-linux-gnu` and `x86_64-unknown-linux-gnu` — pass with `xx-verify`; outputs use the expected target ELF interpreters

The exact Docker build cannot run in this isolated gVisor sandbox because BuildKit bind mounts fail with `operation not permitted` before the Dockerfile is evaluated. Hosted CI is the authoritative exact multi-platform build and timing check.
