### PR TITLE
feat(tenancy): expose managed organization memberships

### DIFF
--- a/.changeset/managed-organization-membership-discovery.md
+++ b/.changeset/managed-organization-membership-discovery.md
@@ -1,0 +1,13 @@
+---
+"@opengeni/contracts": minor
+"@opengeni/db": minor
+"@opengeni/api-router": minor
+"@opengeni/sdk": minor
+"@opengeni/react": minor
+---
+
+Add managed-human organization membership discovery. Expose the exact active
+self-membership and personal-workspace identity returned by the existing
+narrow provisioning capability through a managed-session-only API route and
+typed SDK method, while denying delegated/API-key principals and terminal
+memberships.

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Core endpoints:
 - `GET /healthz`
 - `GET /v1/config/client`
 - `GET /v1/access/me`
+- `GET /v1/organization-memberships` (managed-human self membership and personal-workspace identity)
 - `GET /v1/workspaces`
 - `POST /v1/workspaces`
 - `POST /v1/workspaces/:workspaceId/sessions`

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -113,6 +113,7 @@ import { registerTranscriptionRoutes } from "./routes/transcriptions";
 import { registerEditableArtifactRoutes } from "./routes/editable-artifacts";
 import { registerVideoGenerationRoutes } from "./routes/video-generation";
 import { registerCanonicalHumanIdentityRoutes } from "./routes/canonical-human-identities";
+import { registerOrganizationMembershipRoutes } from "./routes/organization-memberships";
 import { projectClientModel } from "./model-catalog";
 import { createTranscriptionService } from "./transcription/service";
 import { createFfmpegTranscriptionSegmenter } from "./transcription/segmenter";
@@ -692,6 +693,7 @@ export function createAppComposition(deps: AppDependencies): {
   registerEditableArtifactRoutes(app, routeDeps);
   registerVideoGenerationRoutes(app, routeDeps);
   registerCanonicalHumanIdentityRoutes(app, routeDeps);
+  registerOrganizationMembershipRoutes(app, routeDeps);
   registerSlackInteractionRoutes(app, routeDeps);
 
   app.notFound((c) => {

--- a/apps/api/src/routes/organization-memberships.ts
+++ b/apps/api/src/routes/organization-memberships.ts
@@ -1,0 +1,53 @@
+import { ListManagedOrganizationMembershipsResponse } from "@opengeni/contracts";
+import { getManagedSession, type ApiRouteDeps } from "@opengeni/core";
+import {
+  ensureManagedAccessForUserWithOrganizationMemberships,
+  nestedPostgresSqlState,
+} from "@opengeni/db";
+import type { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+export function registerOrganizationMembershipRoutes(app: Hono, deps: ApiRouteDeps): void {
+  app.get("/v1/organization-memberships", async (context) => {
+    if (
+      deps.settings.productAccessMode !== "managed" ||
+      !deps.managedAuth ||
+      !context.req.header("cookie") ||
+      context.req.header("authorization")
+    ) {
+      throw new HTTPException(401, {
+        message: "managed human session required",
+      });
+    }
+
+    const session = await getManagedSession(context, deps.managedAuth, {
+      db: deps.db,
+    });
+    if (!session?.user) {
+      throw new HTTPException(401, {
+        message: "managed human session required",
+      });
+    }
+
+    let result;
+    try {
+      result = await ensureManagedAccessForUserWithOrganizationMemberships(deps.db, {
+        userId: session.user.id,
+        email: session.user.email,
+        name: session.user.name,
+      });
+    } catch (error) {
+      if (nestedPostgresSqlState(error) === "42501") {
+        throw new HTTPException(403, {
+          message: "organization membership is not active",
+        });
+      }
+      throw error;
+    }
+    return context.json(
+      ListManagedOrganizationMembershipsResponse.parse({
+        memberships: result.organizationMemberships,
+      }),
+    );
+  });
+}

--- a/apps/api/test/organization-memberships-routes.test.ts
+++ b/apps/api/test/organization-memberships-routes.test.ts
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { ApiRouteDeps } from "@opengeni/core";
+import { createDb, type DbClient } from "@opengeni/db";
+import { synchronizeCanonicalHumanLoginBindings } from "@opengeni/db/canonical-human-identities";
+import {
+  acquireSharedTestDatabase,
+  testSettings,
+  type SharedTestDatabase,
+} from "@opengeni/testing";
+import { Hono } from "hono";
+import { registerOrganizationMembershipRoutes } from "../src/routes/organization-memberships";
+
+let shared: SharedTestDatabase | null = null;
+let client: DbClient | null = null;
+let app: Hono | null = null;
+let userId = "";
+let subjectId = "";
+let accountId = "";
+let authSessionId = "";
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("api-organization-memberships");
+  if (!shared) return;
+
+  client = createDb(shared.appUrl);
+  userId = `organization-membership-${crypto.randomUUID()}`;
+  subjectId = `user:${userId}`;
+  authSessionId = `session-${crypto.randomUUID()}`;
+  const email = `${userId}@example.test`;
+
+  await shared.admin`
+    insert into auth_users (id, name, email, email_verified)
+    values (${userId}, 'Organization member', ${email}, true)`;
+  await shared.admin`
+    insert into auth_identities (id, user_id, provider_id, account_id)
+    values (${crypto.randomUUID()}, ${userId}, 'credential', ${userId})`;
+  const identity = await synchronizeCanonicalHumanLoginBindings(client.db, userId);
+  await shared.admin`
+    insert into auth_sessions (
+      id, user_id, token, expires_at,
+      identity_id, identity_revision, auth_revision
+    ) values (
+      ${authSessionId}, ${userId}, ${crypto.randomUUID()}, now() + interval '1 hour',
+      ${identity.identityId}, ${identity.identityRevision}, ${identity.authRevision}
+    )`;
+
+  app = new Hono();
+  registerOrganizationMembershipRoutes(app, {
+    db: client.db,
+    settings: testSettings({ productAccessMode: "managed" }),
+    managedAuth: {
+      api: {
+        getSession: async () => ({
+          headers: new Headers(),
+          response: {
+            session: { id: authSessionId },
+            user: { id: userId, email, name: "Organization member" },
+          },
+        }),
+      },
+    } as never,
+  } as ApiRouteDeps);
+}, 180_000);
+
+afterAll(async () => {
+  if (shared && accountId) {
+    await shared.admin`delete from managed_accounts where id = ${accountId}`.catch(() => undefined);
+  }
+  if (shared && userId) {
+    await shared.admin`delete from auth_users where id = ${userId}`.catch(() => undefined);
+  }
+  await client?.close().catch(() => undefined);
+  await shared?.release();
+}, 60_000);
+
+describe("organization membership routes", () => {
+  test("denies non-managed and delegated principals before database access", async () => {
+    const configured = new Hono();
+    registerOrganizationMembershipRoutes(configured, {
+      db: {} as never,
+      settings: testSettings({ productAccessMode: "configured" }),
+      managedAuth: null,
+    } as ApiRouteDeps);
+    expect((await configured.request("http://x/v1/organization-memberships")).status).toBe(401);
+
+    const delegated = new Hono();
+    registerOrganizationMembershipRoutes(delegated, {
+      db: {} as never,
+      settings: testSettings({ productAccessMode: "managed" }),
+      managedAuth: {} as never,
+    } as ApiRouteDeps);
+    expect(
+      (
+        await delegated.request("http://x/v1/organization-memberships", {
+          headers: {
+            authorization: "Bearer delegated",
+            cookie: "session=present",
+          },
+        })
+      ).status,
+    ).toBe(401);
+  });
+
+  test("returns only the current active membership and denies terminal membership state", async () => {
+    if (!shared || !app) return;
+
+    const response = await app.request("http://x/v1/organization-memberships", {
+      headers: { cookie: "session=present" },
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      memberships: Array<{
+        id: string;
+        organizationId: string;
+        status: string;
+        personalWorkspaceId: string;
+      }>;
+    };
+    expect(body.memberships).toHaveLength(1);
+    accountId = body.memberships[0]!.organizationId;
+
+    const [stored] = await shared.admin<
+      Array<{
+        id: string;
+        accountId: string;
+        status: string;
+        personalWorkspaceId: string;
+      }>
+    >`
+      select
+        id,
+        account_id as "accountId",
+        status,
+        personal_workspace_id as "personalWorkspaceId"
+      from organization_memberships
+      where account_id = ${accountId}
+        and subject_id = ${subjectId}`;
+    expect(body).toEqual({
+      memberships: [
+        {
+          id: stored!.id,
+          organizationId: stored!.accountId,
+          status: "active",
+          personalWorkspaceId: stored!.personalWorkspaceId,
+        },
+      ],
+    });
+    expect(JSON.stringify(body)).not.toContain(subjectId);
+    expect(JSON.stringify(body)).not.toContain("retention");
+
+    await shared.admin`
+      update organization_memberships
+      set status = 'suspended', revoked_at = null
+      where account_id = ${accountId}
+        and subject_id = ${subjectId}`;
+    const denied = await app.request("http://x/v1/organization-memberships", {
+      headers: { cookie: "session=present" },
+    });
+    expect(denied.status).toBe(403);
+    expect(await denied.json()).toEqual({
+      message: "organization membership is not active",
+    });
+  });
+});

--- a/apps/api/test/organization-memberships-routes.test.ts
+++ b/apps/api/test/organization-memberships-routes.test.ts
@@ -157,8 +157,8 @@ describe("organization membership routes", () => {
       headers: { cookie: "session=present" },
     });
     expect(denied.status).toBe(403);
-    expect(await denied.json()).toEqual({
-      message: "organization membership is not active",
-    });
+    // This minimal route harness has no application-level JSON error adapter,
+    // so bare Hono renders HTTPException messages as plain text.
+    expect(await denied.text()).toBe("organization membership is not active");
   });
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -238,6 +238,10 @@ Grant rows carry the owning membership and a canonical action; `once` and
 slice must consume `once` grants atomically before accepting use. Slice B does
 not create any authority or grant rows, and the personal workspace remains
 absent from runtime workspace access.
+The managed-human-only `GET /v1/organization-memberships` route exposes just
+the exact active membership, organization, and personal-workspace identifiers
+returned by that provisioning capability; it is unavailable to API keys and
+delegated principals and does not expose retention, grant, or resource state.
 Sessions gain additive owner, `user_private|workspace_shared` visibility,
 authority-epoch, and independent-fork provenance columns; every existing row
 defaults to workspace-shared epoch 1 with no owner or fork authority. This slice

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -61,6 +61,14 @@ access on the personal workspace, and malformed subjects fail closed. The app
 role still has zero direct SELECT/INSERT/UPDATE/DELETE privileges on all four
 organization-tenancy tables.
 
+`GET /v1/organization-memberships` is the first read-only managed-human
+discovery surface. It accepts only a current Better Auth human session and
+returns the exact active membership id, organization id, and personal-workspace
+id emitted by that same narrow provisioning capability. API keys, delegated
+bearers, configured/local access, and missing or terminal memberships fail
+closed. The response intentionally omits subjects, retention state, grants,
+resource authority, and personal-workspace runtime access.
+
 ## Canonical human identity and login bindings
 
 Migration `0235_canonical_human_login_bindings.sql` adds a separate,
@@ -185,7 +193,7 @@ rewritten in the same release that first activates user authority.
 
 ## Non-goals in Slices A and B
 
-- organization/member API or UI;
+- organization invitation, role/admin, offboarding, or member-management UI;
 - personal-workspace runtime access or a personal `workspace_memberships` row;
 - user-resource authority/grant writes, discovery, or sharing;
 - resource CRUD or discovery changes;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1129,6 +1129,28 @@ export const OrganizationMembershipProjection = z.object({
 export type OrganizationMembershipProjection = z.infer<typeof OrganizationMembershipProjection>;
 
 /**
+ * Exact active-membership facts returned by managed-human login provisioning.
+ * Retention is intentionally absent because the narrow provisioning capability
+ * neither reads nor mutates offboarding policy.
+ */
+export const ManagedOrganizationMembershipProjection = z.object({
+  id: z.string().uuid(),
+  organizationId: z.string().uuid(),
+  status: z.literal("active"),
+  personalWorkspaceId: z.string().uuid(),
+});
+export type ManagedOrganizationMembershipProjection = z.infer<
+  typeof ManagedOrganizationMembershipProjection
+>;
+
+export const ListManagedOrganizationMembershipsResponse = z.object({
+  memberships: z.array(ManagedOrganizationMembershipProjection),
+});
+export type ListManagedOrganizationMembershipsResponse = z.infer<
+  typeof ListManagedOrganizationMembershipsResponse
+>;
+
+/**
  * Opaque user-resource authority projection. Ownership is represented by the
  * server-issued authority id, never a raw subject or membership id.
  */

--- a/packages/contracts/test/organization-tenancy-foundation.test.ts
+++ b/packages/contracts/test/organization-tenancy-foundation.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
+  ListManagedOrganizationMembershipsResponse,
+  ManagedOrganizationMembershipProjection,
   OrganizationMembershipProjection,
   ResourceAuthorityEnvelope,
   ResourceAuthorityListScope,
@@ -139,6 +141,27 @@ describe("organization tenancy foundation contracts", () => {
     expect(serialized).not.toContain("subjectId");
     expect(serialized).not.toContain("organizationMembershipId");
     expect(serialized).not.toContain("ownerOrganizationMembershipId");
+  });
+
+  test("projects only exact managed-human bootstrap facts", () => {
+    const membership = ManagedOrganizationMembershipProjection.parse({
+      id: ids.membership,
+      organizationId: ids.organization,
+      status: "active",
+      personalWorkspaceId: ids.workspace,
+      subjectId: "must-not-survive",
+      personalRetentionUntil: "2026-09-13T00:00:00.000Z",
+    });
+
+    expect(membership).toEqual({
+      id: ids.membership,
+      organizationId: ids.organization,
+      status: "active",
+      personalWorkspaceId: ids.workspace,
+    });
+    expect(ListManagedOrganizationMembershipsResponse.parse({ memberships: [membership] })).toEqual(
+      { memberships: [membership] },
+    );
   });
 
   test("rejects illegal grant fences and allows only exact standing/session forms", () => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -40,6 +40,7 @@ import type {
   HostUsageExport,
   HostUsageExportBatch,
   ManagedAccount,
+  ManagedOrganizationMembershipProjection,
   McpPersonalConnectionDelegation,
   Permission,
   PackInstallation,
@@ -1330,6 +1331,22 @@ export async function ensureManagedAccessForUser(
     name: string;
   },
 ): Promise<AccessContext> {
+  return (await ensureManagedAccessForUserWithOrganizationMemberships(db, input)).accessContext;
+}
+
+export type ManagedAccessProvisioningResult = {
+  accessContext: AccessContext;
+  organizationMemberships: ManagedOrganizationMembershipProjection[];
+};
+
+export async function ensureManagedAccessForUserWithOrganizationMemberships(
+  db: Database,
+  input: {
+    userId: string;
+    email: string;
+    name: string;
+  },
+): Promise<ManagedAccessProvisioningResult> {
   const subjectId = `user:${input.userId}`;
   const subjectLabel = input.email || input.name;
   return await db.transaction(async (tx) => {
@@ -1575,28 +1592,38 @@ export async function ensureManagedAccessForUser(
       .where(eq(schema.workspaceMemberships.subjectId, subjectId))
       .orderBy(desc(schema.workspaces.createdAt));
     return {
-      mode: "managed",
-      subjectId,
-      subjectLabel,
-      accountGrants: [
-        {
-          accountId: account.id,
-          subjectId,
-          subjectLabel,
-          role: "owner",
-          permissions: allAccountPermissions,
-        },
-      ],
-      workspaceGrants: memberships.map((row) => ({
-        workspaceId: row.workspace.id,
-        accountId: row.workspace.accountId,
+      accessContext: {
+        mode: "managed",
         subjectId,
         subjectLabel,
-        permissions: row.membership.permissions as Permission[],
-        principalKind: "human_session",
-      })),
-      defaultAccountId: account.id,
-      defaultWorkspaceId: defaultWorkspace.id,
+        accountGrants: [
+          {
+            accountId: account.id,
+            subjectId,
+            subjectLabel,
+            role: "owner",
+            permissions: allAccountPermissions,
+          },
+        ],
+        workspaceGrants: memberships.map((row) => ({
+          workspaceId: row.workspace.id,
+          accountId: row.workspace.accountId,
+          subjectId,
+          subjectLabel,
+          permissions: row.membership.permissions as Permission[],
+          principalKind: "human_session",
+        })),
+        defaultAccountId: account.id,
+        defaultWorkspaceId: defaultWorkspace.id,
+      },
+      organizationMemberships: [
+        {
+          id: provisionedMembership.organization_membership_id,
+          organizationId: account.id,
+          status: "active",
+          personalWorkspaceId: provisionedMembership.personal_workspace_id,
+        },
+      ],
     };
   });
 }

--- a/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
+++ b/packages/db/test/migration-0219-organization-tenancy-managed-human-provisioning.test.ts
@@ -8,6 +8,7 @@ import postgres from "postgres";
 import {
   createDb,
   ensureManagedAccessForUser,
+  ensureManagedAccessForUserWithOrganizationMemberships,
   listWorkspacesForSubject,
   nestedPostgresSqlState,
   setRlsContext,
@@ -142,12 +143,17 @@ describe("migration 0219 managed-human organization provisioning", () => {
       name: "Slice B managed human",
     };
     const first = await ensureManagedAccessForUser(client.db, input);
+    const provisioned = await ensureManagedAccessForUserWithOrganizationMemberships(
+      client.db,
+      input,
+    );
     const repeated = await ensureManagedAccessForUser(client.db, input);
     const concurrent = await Promise.all(
       Array.from({ length: 6 }, () => ensureManagedAccessForUser(client!.db, input)),
     );
 
     expect(repeated).toEqual(first);
+    expect(provisioned.accessContext).toEqual(first);
     expect(concurrent).toEqual(Array.from({ length: 6 }, () => first));
     expect(first.workspaceGrants).toHaveLength(1);
     expect((await listWorkspacesForSubject(client.db, subjectId)).map((row) => row.id)).toEqual([
@@ -249,6 +255,14 @@ describe("migration 0219 managed-human organization provisioning", () => {
       status: "active",
       personalWorkspaceId: personalWorkspace!.id,
     });
+    expect(provisioned.organizationMemberships).toEqual([
+      {
+        id: membership!.id,
+        organizationId: account!.id,
+        status: "active",
+        personalWorkspaceId: personalWorkspace!.id,
+      },
+    ]);
     expect(control).toEqual({ accountId: account!.id });
     expect(personalAccess).toEqual({ count: 0 });
     expect(defaultAccess).toEqual({ count: 1 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -219,6 +219,7 @@ import type {
   KnowledgeMemory,
   KnowledgeMemorySearchRequest,
   ListApiKeysResponse,
+  ListManagedOrganizationMembershipsResponse,
   ListPacksResponse,
   // Bring-your-own-compute: the Machines dashboard + per-machine metrics (M10).
   MachinesResponse,
@@ -3282,6 +3283,14 @@ export class OpenGeniClient {
   /** The caller's access context: subject, account + workspace grants, defaults. */
   async getAccessContext(): Promise<AccessContext> {
     return await this.requestJson<AccessContext>("GET", "/v1/access/me");
+  }
+
+  /** Active organization memberships proven by the current managed-human session. */
+  async listOrganizationMemberships(): Promise<ListManagedOrganizationMembershipsResponse> {
+    return await this.requestJson<ListManagedOrganizationMembershipsResponse>(
+      "GET",
+      "/v1/organization-memberships",
+    );
   }
 
   async listWorkspaces(): Promise<Workspace[]> {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -319,6 +319,8 @@ export type {
   BillingEntitlementsResponse,
   BillingMode,
   BillingSummary,
+  ListManagedOrganizationMembershipsResponse,
+  ManagedOrganizationMembership,
   BillingUsageResponse,
   InsightsRange,
   InsightsBillingPath,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -3157,6 +3157,17 @@ export type AccessContext = {
   defaultWorkspaceId: string | null;
 };
 
+export type ManagedOrganizationMembership = {
+  id: string;
+  organizationId: string;
+  status: "active";
+  personalWorkspaceId: string;
+};
+
+export type ListManagedOrganizationMembershipsResponse = {
+  memberships: ManagedOrganizationMembership[];
+};
+
 export type Workspace = {
   id: string;
   accountId: string;

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -306,6 +306,7 @@ describe("OpenGeniClient access + workspaces", () => {
       return jsonResponse({ id: WORKSPACE_ID, name: "Ops" });
     });
     await client.getAccessContext();
+    await client.listOrganizationMemberships();
     await client.listWorkspaces();
     await client.createWorkspace({ name: "Ops" });
     await client.getWorkspace(WORKSPACE_ID);
@@ -316,6 +317,7 @@ describe("OpenGeniClient access + workspaces", () => {
     expect(requests.map((request) => `${request.method} ${new URL(request.url).pathname}`)).toEqual(
       [
         "GET /v1/access/me",
+        "GET /v1/organization-memberships",
         "GET /v1/workspaces",
         "POST /v1/workspaces",
         `GET /v1/workspaces/${WORKSPACE_ID}`,
@@ -323,11 +325,11 @@ describe("OpenGeniClient access + workspaces", () => {
         `PUT /v1/workspaces/${WORKSPACE_ID}/default-rig`,
       ],
     );
-    expect(JSON.parse(requests[4]!.body!)).toEqual({
+    expect(JSON.parse(requests[5]!.body!)).toEqual({
       name: "Ops 2",
       slug: null,
     });
-    expect(JSON.parse(requests[5]!.body!)).toEqual({
+    expect(JSON.parse(requests[6]!.body!)).toEqual({
       rigId: "22222222-2222-4222-8222-222222222222",
     });
   });

--- a/packages/sdk/test/contract-parity-coverage.test.ts
+++ b/packages/sdk/test/contract-parity-coverage.test.ts
@@ -42,6 +42,7 @@ import {
   GitHubInstallationLifecycle as ContractGitHubInstallationLifecycle,
   GitHubRepository as ContractGitHubRepository,
   GitHubRepositoryScope as ContractGitHubRepositoryScope,
+  ListManagedOrganizationMembershipsResponse as ContractListManagedOrganizationMembershipsResponse,
   PackInstallation as ContractPackInstallation,
   PackInstallationStatus as ContractPackInstallationStatus,
   Permission as ContractPermission,
@@ -114,6 +115,7 @@ import type {
   GitHubInstallationBinding,
   GitHubInstallationLifecycle,
   GitHubRepositoryScope,
+  ListManagedOrganizationMembershipsResponse,
   PackInstallation,
   PackInstallationStatus,
   ProductAccessMode,
@@ -221,6 +223,9 @@ describe("SDK / contracts parity (full coverage)", () => {
   test("contract-parsed responses are assignable to SDK types (compile-time)", () => {
     const acceptAccessContext = (value: z.infer<typeof ContractAccessContext>): AccessContext =>
       value;
+    const acceptOrganizationMemberships = (
+      value: z.infer<typeof ContractListManagedOrganizationMembershipsResponse>,
+    ): ListManagedOrganizationMembershipsResponse => value;
     const acceptWorkspace = (value: z.infer<typeof ContractWorkspace>): Workspace => value;
     const acceptApiKey = (value: z.infer<typeof ContractApiKey>): ApiKey => value;
     const acceptGoal = (value: z.infer<typeof ContractSessionGoal>): SessionGoal => value;
@@ -278,6 +283,7 @@ describe("SDK / contracts parity (full coverage)", () => {
     ): CreateCheckoutResponse => value;
     const checks = [
       acceptAccessContext,
+      acceptOrganizationMemberships,
       acceptWorkspace,
       acceptApiKey,
       acceptGoal,


### PR DESCRIPTION
## Summary

- add a managed-human-only `GET /v1/organization-memberships` discovery route
- return the exact active organization membership and personal-workspace identity already produced by canonical login provisioning
- add typed contracts and SDK support while preserving the existing `ensureManagedAccessForUser` API
- deny configured mode, missing-cookie, Authorization/delegated/API-key principals, missing sessions, and terminal organization membership states

## Scope

Partial foundational slice for **OPE-195** and **OPE-196**. This does **not** complete organization administration, invitations, role management, offboarding/retention, workspace grant lifecycle, or access-loss behavior.

No schema migration is included. This branch has zero changed-path overlap with PR #1373 and does not touch migration 0230 or its frozen source/test paths.

## Validation

- `git diff --check`
- focused contracts/DB/API/SDK tests and parity: 87 pass, 0 fail, 389 assertions
- contracts, DB, API router, and SDK typechecks
- changed-file `oxlint --deny-warnings`: 0 warnings/errors
- changed-file `oxfmt --check`
- source-admission and release-schema tests: 25 pass, 0 fail
- workspace billing static check
- docs reference check
- changeset status
- publish-closure guard and full required package/build sequence

The shared PostgreSQL harness test is present but local Docker was unavailable, so local live-PostgreSQL execution was not independently forced; hosted CI remains authoritative for that environment.
