### PR TITLE
fix(release): target worker bundle changeset

### DIFF
--- a/.changeset/quiet-turn-memory.md
+++ b/.changeset/quiet-turn-memory.md
@@ -1,5 +1,5 @@
 ---
-"@opengeni/worker": patch
+"@opengeni/worker-bundle": patch
 ---
 
 Reclaim combined heap and external allocations after completed turn activity stacks unwind.


### PR DESCRIPTION
## Summary

- correct `quiet-turn-memory` to target the actual workspace package `@opengeni/worker-bundle`
- unblock Changesets status and Version PR regeneration

## Validation

- `bunx changeset status`
- `git diff --check`