### PR TITLE
fix(release): resolve embedded candidate receipt from workspace

### DIFF
--- a/.changeset/safe-embedded-receipts.md
+++ b/.changeset/safe-embedded-receipts.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Reissue the embedded distribution through corrected source-bound candidate receipt validation.

--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -392,7 +392,7 @@ jobs:
             '.sourceSha == $sourceSha and .sourceTreeSha == $sourceTreeSha and .producer == $producer[0].producer' \
             evidence/release-candidate.json >/dev/null
           candidate_verify_args=(
-            --verify evidence/release-candidate.json
+            --verify "$GITHUB_WORKSPACE/evidence/release-candidate.json"
             --source-sha "$SOURCE_SHA"
           )
           if [ -n "$EXPECTED_PACKAGES" ]; then

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -745,6 +745,10 @@ describe("release image workflow contract", () => {
     expect(release).toContain('if [ -n "$EXPECTED_PACKAGES" ]; then');
     expect(release).toContain('candidate_verify_args+=(--expected-packages "$EXPECTED_PACKAGES")');
     expect(release).toContain('bun scripts/release-candidate.ts "${candidate_verify_args[@]}"');
+    expect(
+      release.match(/--verify "\$GITHUB_WORKSPACE\/evidence\/release-candidate\.json"/g),
+    ).toHaveLength(2);
+    expect(release).not.toContain("--verify evidence/release-candidate.json");
     expect(release).toContain(
       'bun scripts/release-version.ts "$GITHUB_WORKSPACE/deploy/helm/opengeni/Chart.yaml"',
     );


### PR DESCRIPTION
## Summary

- verify the embedded release candidate receipt using its absolute workspace path after switching into the retained controller checkout
- add a workflow contract regression that requires both embedded verification phases to use that absolute path

## Release incident

Embedded distribution run 31691361997 failed before publication because the protected job resolved `evidence/release-candidate.json` relative to `.release/controller`. The candidate artifact and its digest validated successfully, and every mutation step was skipped.

## Verification

- `bun test scripts/release-image-workflow-contract.test.ts`
- `git diff --check`