### PR TITLE
chore(release): reissue MCP fidelity source

### DIFF
--- a/.changeset/calm-tools-reissue.md
+++ b/.changeset/calm-tools-reissue.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Reissue the complete MCP result fidelity release source after the prior automated Version PR was merged without the required provider-native approval.


### PR DESCRIPTION
## Summary

- add a minimal Changesets entry to reissue the complete MCP result fidelity release source
- preserve the existing release provenance gate after Version PR #1404 was merged without a provider-native approval
- patch-bump `@opengeni/runtime`; Changesets propagates required internal patch releases

## Verification

- `bun test scripts/release-schema-contract.test.ts scripts/check-release-pr-automation.test.ts` (87 pass)
- lockfile-pinned `changeset status` resolves runtime 0.22.1 plus required internal patch propagation
- `git diff --check`