### PR TITLE
feat(web): add guided integration connection journey

### DIFF
--- a/apps/web/src/components/capabilities/integration-connect-dialog.test.tsx
+++ b/apps/web/src/components/capabilities/integration-connect-dialog.test.tsx
@@ -1,0 +1,195 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { IntegrationConnectRequest } from "./integration-connect-dialog";
+import type { IntegrationDefinitionSummary } from "@/types";
+
+let IntegrationConnectDialog: typeof import("./integration-connect-dialog").IntegrationConnectDialog;
+let integrationConnectFocusTarget: typeof import("./integration-connect-dialog").integrationConnectFocusTarget;
+
+beforeAll(async () => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  ({ IntegrationConnectDialog, integrationConnectFocusTarget } =
+    await import("./integration-connect-dialog"));
+});
+
+afterAll(() => GlobalRegistrator.unregister());
+
+describe("integration connection dialog", () => {
+  test("uses an accessible stepped review and keeps OAuth scopes progressive", async () => {
+    const requests: IntegrationConnectRequest[] = [];
+    const rendered = await render(
+      <IntegrationConnectDialog
+        open
+        definition={gmailDefinition()}
+        initialAccountLabel="Gmail — Account 2"
+        canConnectPersonal
+        canConnectWorkspace
+        onOpenChange={() => {}}
+        onConnect={async (request) => {
+          requests.push(request);
+        }}
+      />,
+    );
+    try {
+      const dialog = requiredElement<HTMLElement>('[role="dialog"]');
+      expect(dialog.getAttribute("aria-labelledby")).toBeTruthy();
+      expect(dialog.textContent).toContain("Name the account and choose who can use it");
+      expect(requiredElement<HTMLInputElement>('input[value="personal"]').checked).toBe(true);
+      expect(requiredElement<HTMLElement>('[aria-current="step"]').textContent).toContain(
+        "Account",
+      );
+
+      await clickButton("Continue");
+      expect(dialog.textContent).toContain("Find and understand mail");
+      expect(dialog.textContent).toContain("Work with your Gmail mailbox");
+      const details = requiredElement<HTMLDetailsElement>("details");
+      expect(details.open).toBe(false);
+      expect(details.textContent).toContain("https://mail.google.com/");
+
+      await clickButton("Continue");
+      expect(dialog.textContent).toContain("Review the connection");
+      expect(dialog.textContent).toContain("Gmail — Account 2");
+      expect(dialog.textContent).toContain("Personal — usable only through your delegated");
+      await clickButton("Back");
+      expect(dialog.textContent).toContain("What agents can do");
+      await act(async () => {
+        requiredElement<HTMLButtonElement>("ol button").click();
+        await Promise.resolve();
+      });
+      expect(dialog.textContent).toContain("Name the account and choose who can use it");
+      expect(requests).toEqual([]);
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("shows administrator remediation when both ownership choices are unavailable", async () => {
+    const rendered = await render(
+      <IntegrationConnectDialog
+        open
+        definition={gmailDefinition()}
+        initialAccountLabel="Gmail"
+        canConnectPersonal={false}
+        canConnectWorkspace={false}
+        onOpenChange={() => {}}
+        onConnect={async () => {}}
+      />,
+    );
+    try {
+      expect(document.body.textContent).toContain("Administrator setup is required");
+      expect(document.body.textContent).toContain("close this guide without changing anything");
+      expect(requiredElement<HTMLInputElement>('input[value="personal"]').disabled).toBe(true);
+      expect(requiredElement<HTMLInputElement>('input[value="workspace"]').disabled).toBe(true);
+      expect(button("Continue").disabled).toBe(true);
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("retries a failed start with the same reviewed request and a safe error", async () => {
+    const requests: IntegrationConnectRequest[] = [];
+    let attempt = 0;
+    const rendered = await render(
+      <IntegrationConnectDialog
+        open
+        definition={gmailDefinition()}
+        initialAccountLabel="Gmail — Finance"
+        canConnectPersonal
+        canConnectWorkspace
+        onOpenChange={() => {}}
+        onConnect={async (request) => {
+          requests.push(request);
+          attempt += 1;
+          if (attempt === 1) throw new Error("provider body containing credential-shaped data");
+        }}
+      />,
+    );
+    try {
+      await clickButton("Continue");
+      await clickButton("Continue");
+      await clickButton("Continue to Google");
+      const alert = requiredElement<HTMLElement>('[role="alert"]');
+      expect(alert.textContent).toContain("Check your network and try again");
+      expect(alert.textContent).not.toContain("provider body");
+      expect(button("Try again").disabled).toBe(false);
+
+      await clickButton("Try again");
+      expect(document.body.textContent).toContain("Opening Google");
+      expect(requests).toEqual([
+        { accountLabel: "Gmail — Finance", ownership: "personal" },
+        { accountLabel: "Gmail — Finance", ownership: "personal" },
+      ]);
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("prefers the exact opening trigger and falls back only when it is gone", () => {
+    const trigger = document.createElement("button");
+    const fallback = document.createElement("section");
+    document.body.append(trigger, fallback);
+    expect(integrationConnectFocusTarget(trigger, fallback)).toBe(trigger);
+    trigger.remove();
+    expect(integrationConnectFocusTarget(trigger, fallback)).toBe(fallback);
+    fallback.remove();
+    expect(integrationConnectFocusTarget(trigger, fallback)).toBeNull();
+  });
+});
+
+async function render(element: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(element);
+    await Promise.resolve();
+  });
+  return {
+    unmount: async () => {
+      await act(async () => root.unmount());
+      document.body.replaceChildren();
+    },
+  };
+}
+
+async function clickButton(name: string) {
+  await act(async () => {
+    button(name).click();
+    await Promise.resolve();
+  });
+}
+
+function button(name: string): HTMLButtonElement {
+  const match = Array.from(document.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.replace(/\s+/g, " ").trim() === name,
+  );
+  if (!(match instanceof HTMLButtonElement)) throw new Error(`Missing button: ${name}`);
+  return match;
+}
+
+function requiredElement<T extends Element>(selector: string): T {
+  const element = document.querySelector(selector);
+  if (!element) throw new Error(`Missing element: ${selector}`);
+  return element as T;
+}
+
+function gmailDefinition(): IntegrationDefinitionSummary {
+  return {
+    id: "google-gmail",
+    name: "Gmail",
+    summary: "Gmail messages, labels, drafts, and delivery.",
+    protocol: "openapi",
+    provider: { id: "google", domain: "gmail.googleapis.com" },
+    authentication: {
+      kind: "oauth2",
+      scopes: ["openid", "email", "profile", "https://mail.google.com/"],
+    },
+    facets: [],
+  };
+}

--- a/apps/web/src/components/capabilities/integration-connect-dialog.tsx
+++ b/apps/web/src/components/capabilities/integration-connect-dialog.tsx
@@ -1,0 +1,685 @@
+import {
+  CalendarDaysIcon,
+  CheckIcon,
+  CloudIcon,
+  ContactRoundIcon,
+  HardDriveIcon,
+  Loader2Icon,
+  LockKeyholeIcon,
+  MailIcon,
+  ShieldCheckIcon,
+  UserRoundIcon,
+  UsersRoundIcon,
+} from "lucide-react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useReducer,
+  useRef,
+  type ComponentType,
+  type FormEvent,
+  type RefObject,
+} from "react";
+
+import {
+  initialIntegrationConnectFlow,
+  INTEGRATION_ACCOUNT_LABEL_MAX_LENGTH,
+  integrationConnectFlowReducer,
+  integrationConnectStepNumber,
+  integrationConnectValidationError,
+  type IntegrationConnectStep,
+} from "@/components/capabilities/integration-connect-flow";
+import {
+  integrationExperience,
+  type IntegrationExperienceDescriptor,
+  type IntegrationExperienceIcon as IntegrationExperienceIconName,
+} from "@/components/capabilities/integration-experience";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import type { ConnectionOwnership, IntegrationDefinitionSummary } from "@/types";
+
+export type IntegrationConnectRequest = {
+  accountLabel: string;
+  ownership: ConnectionOwnership;
+};
+
+const SAFE_START_ERROR =
+  "We couldn't start the secure connection. Check your network and try again. If it keeps failing, ask a workspace administrator for help.";
+
+const STEPS: readonly { id: IntegrationConnectStep; label: string }[] = [
+  { id: "account", label: "Account" },
+  { id: "access", label: "Access" },
+  { id: "review", label: "Review" },
+];
+
+const ICONS: Record<
+  IntegrationExperienceIconName,
+  ComponentType<{ className?: string; "aria-hidden"?: boolean }>
+> = {
+  calendar: CalendarDaysIcon,
+  cloud: CloudIcon,
+  contacts: ContactRoundIcon,
+  files: HardDriveIcon,
+  mail: MailIcon,
+};
+
+export function IntegrationExperienceIcon({
+  icon,
+  className,
+}: {
+  icon: IntegrationExperienceIconName;
+  className?: string;
+}) {
+  const Icon = ICONS[icon];
+  return <Icon className={className} aria-hidden />;
+}
+
+export function integrationConnectFocusTarget(
+  trigger: HTMLElement | null,
+  fallback: HTMLElement | null,
+): HTMLElement | null {
+  if (trigger?.isConnected) return trigger;
+  return fallback?.isConnected ? fallback : null;
+}
+
+export function IntegrationConnectDialog({
+  open,
+  definition,
+  initialAccountLabel,
+  canConnectPersonal,
+  canConnectWorkspace,
+  restoreFocusRef,
+  restoreFocusFallbackRef,
+  onOpenChange,
+  onConnect,
+}: {
+  open: boolean;
+  definition: IntegrationDefinitionSummary | null;
+  initialAccountLabel: string;
+  canConnectPersonal: boolean;
+  canConnectWorkspace: boolean;
+  restoreFocusRef?: RefObject<HTMLElement | null>;
+  restoreFocusFallbackRef?: RefObject<HTMLElement | null>;
+  onOpenChange: (open: boolean) => void;
+  onConnect: (request: IntegrationConnectRequest) => Promise<void>;
+}) {
+  const input = useMemo(
+    () => ({
+      accountLabel: initialAccountLabel,
+      preferredOwnership: "personal" as const,
+      availability: {
+        personal: canConnectPersonal,
+        workspace: canConnectWorkspace,
+      },
+    }),
+    [canConnectPersonal, canConnectWorkspace, initialAccountLabel],
+  );
+  const [state, dispatch] = useReducer(
+    integrationConnectFlowReducer,
+    input,
+    initialIntegrationConnectFlow,
+  );
+  const experience = useMemo(
+    () => (definition ? integrationExperience(definition) : null),
+    [definition],
+  );
+  const accountInputRef = useRef<HTMLInputElement>(null);
+  const stepHeadingRef = useRef<HTMLHeadingElement>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
+  const id = useId();
+  const busy = state.status === "submitting" || state.status === "redirecting";
+
+  useEffect(() => {
+    if (open) dispatch({ type: "reset", input });
+  }, [definition?.id, input, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (state.status === "submitting" || state.status === "redirecting") return;
+    const frame = window.requestAnimationFrame(() => {
+      if (state.status === "error") {
+        errorRef.current?.focus();
+      } else if (state.step === "account") {
+        accountInputRef.current?.focus();
+      } else {
+        stepHeadingRef.current?.focus();
+      }
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [open, state.status, state.step]);
+
+  if (!experience) {
+    return <Dialog open={false} onOpenChange={onOpenChange} />;
+  }
+
+  const validationError = integrationConnectValidationError(state);
+  const stepNumber = integrationConnectStepNumber(state.step);
+  const primaryLabel =
+    state.status === "submitting"
+      ? "Starting secure connection…"
+      : state.status === "redirecting"
+        ? `Opening ${experience.providerName}…`
+        : state.status === "error"
+          ? "Try again"
+          : state.step === "review"
+            ? `Continue to ${experience.providerName}`
+            : "Continue";
+
+  function changeOpen(next: boolean) {
+    if (busy) return;
+    onOpenChange(next);
+  }
+
+  function advance(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (state.step === "review") {
+      void submit();
+      return;
+    }
+    dispatch({ type: "next" });
+  }
+
+  async function submit() {
+    if (state.step !== "review" || validationError || busy) return;
+    const submissionId = state.submissionSequence + 1;
+    dispatch({ type: "submit", submissionId });
+    try {
+      await onConnect({
+        accountLabel: state.accountLabel.trim(),
+        ownership: state.ownership,
+      });
+      dispatch({ type: "redirecting", submissionId });
+    } catch {
+      dispatch({ type: "submit_failed", submissionId, message: SAFE_START_ERROR });
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={changeOpen}>
+      <DialogContent
+        showCloseButton={false}
+        className="grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden p-0 motion-reduce:animate-none motion-reduce:transition-none sm:max-w-2xl sm:p-0"
+        onEscapeKeyDown={(event) => busy && event.preventDefault()}
+        onPointerDownOutside={(event) => busy && event.preventDefault()}
+        onCloseAutoFocus={(event) => {
+          const destination = integrationConnectFocusTarget(
+            restoreFocusRef?.current ?? null,
+            restoreFocusFallbackRef?.current ?? null,
+          );
+          if (!destination) return;
+          event.preventDefault();
+          destination.focus();
+        }}
+      >
+        <div className="border-b border-border bg-brand/5 px-5 py-5 sm:px-6">
+          <DialogHeader className="pr-0 text-left">
+            <div className="flex items-start gap-3">
+              <span className="grid size-11 shrink-0 place-items-center rounded-xl border border-brand/20 bg-surface text-brand shadow-sm forced-colors:outline forced-colors:outline-2">
+                <IntegrationExperienceIcon icon={experience.icon} className="size-5" />
+              </span>
+              <div className="min-w-0">
+                <DialogTitle className="text-lg">Connect {experience.serviceName}</DialogTitle>
+                <DialogDescription className="mt-1 leading-5">
+                  {experience.introduction}
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <ol className="mt-5 grid grid-cols-3 gap-2" aria-label="Connection setup progress">
+            {STEPS.map((step, index) => {
+              const currentIndex = stepNumber - 1;
+              const complete = index < currentIndex;
+              const current = step.id === state.step;
+              const content = (
+                <>
+                  <span
+                    className={cn(
+                      "grid size-6 shrink-0 place-items-center rounded-full border text-2xs font-semibold",
+                      current || complete
+                        ? "border-brand bg-brand text-white forced-colors:border-[Highlight] forced-colors:bg-[Highlight] forced-colors:text-[HighlightText]"
+                        : "border-border bg-surface text-fg-subtle",
+                    )}
+                    aria-hidden
+                  >
+                    {complete ? <CheckIcon className="size-3.5" /> : index + 1}
+                  </span>
+                  <span aria-hidden className="hidden text-xs font-medium text-fg sm:inline">
+                    {step.label}
+                  </span>
+                  <span className="sr-only">
+                    {step.label}, step {index + 1} of {STEPS.length}
+                    {complete ? ", completed" : ""}
+                  </span>
+                </>
+              );
+              return (
+                <li key={step.id} className="min-w-0">
+                  {complete && !busy ? (
+                    <button
+                      type="button"
+                      className="flex min-h-9 w-full items-center justify-center gap-2 rounded-lg text-left hover:bg-surface/70 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand sm:justify-start sm:px-2"
+                      onClick={() => dispatch({ type: "go_to", step: step.id })}
+                    >
+                      {content}
+                    </button>
+                  ) : (
+                    <span
+                      className="flex min-h-9 items-center justify-center gap-2 rounded-lg sm:justify-start sm:px-2"
+                      {...(current ? { "aria-current": "step" as const } : {})}
+                    >
+                      {content}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+
+        <form
+          className="grid min-h-0 grid-rows-[minmax(0,1fr)_auto] overflow-hidden"
+          onSubmit={advance}
+        >
+          <div
+            role="region"
+            tabIndex={0}
+            aria-label={`${STEPS[stepNumber - 1]!.label} connection setup content`}
+            className="max-h-[55dvh] overflow-y-auto px-5 py-5 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand sm:max-h-[52vh] sm:px-6"
+          >
+            {state.step === "account" ? (
+              <AccountStep
+                id={id}
+                inputRef={accountInputRef}
+                accountLabel={state.accountLabel}
+                ownership={state.ownership}
+                canConnectPersonal={canConnectPersonal}
+                canConnectWorkspace={canConnectWorkspace}
+                onAccountLabelChange={(value) => dispatch({ type: "account_label_changed", value })}
+                onOwnershipChange={(value) => dispatch({ type: "ownership_changed", value })}
+              />
+            ) : state.step === "access" ? (
+              <AccessStep id={id} experience={experience} headingRef={stepHeadingRef} />
+            ) : (
+              <ReviewStep
+                id={id}
+                experience={experience}
+                accountLabel={state.accountLabel.trim()}
+                ownership={state.ownership}
+                headingRef={stepHeadingRef}
+              />
+            )}
+
+            {state.error ? (
+              <div
+                ref={errorRef}
+                tabIndex={-1}
+                className="mt-5 rounded-xl border border-danger/40 bg-danger/5 p-3 text-sm leading-5 text-fg outline-none"
+                role="alert"
+              >
+                <p className="font-medium">Connection could not start</p>
+                <p className="mt-1 text-xs text-fg-muted">{state.error}</p>
+              </div>
+            ) : null}
+          </div>
+
+          <DialogFooter className="border-t border-border bg-surface/70 px-5 py-4 sm:px-6">
+            <Button
+              type="button"
+              variant="ghost"
+              className="min-h-11"
+              disabled={busy}
+              onClick={() => changeOpen(false)}
+            >
+              Cancel
+            </Button>
+            {state.step !== "account" ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="min-h-11"
+                disabled={busy}
+                onClick={() => dispatch({ type: "back" })}
+              >
+                Back
+              </Button>
+            ) : null}
+            <Button
+              type="submit"
+              className="min-h-11"
+              disabled={Boolean(validationError) || busy}
+              aria-busy={busy}
+              aria-describedby={validationError ? `${id}-validation` : undefined}
+            >
+              {busy ? (
+                <Loader2Icon className="animate-spin motion-reduce:animate-none" />
+              ) : state.step === "review" ? (
+                <ShieldCheckIcon />
+              ) : null}
+              <span aria-live="polite" aria-atomic="true">
+                {primaryLabel}
+              </span>
+            </Button>
+            {validationError ? (
+              <span id={`${id}-validation`} className="sr-only">
+                {validationError}
+              </span>
+            ) : null}
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AccountStep({
+  id,
+  inputRef,
+  accountLabel,
+  ownership,
+  canConnectPersonal,
+  canConnectWorkspace,
+  onAccountLabelChange,
+  onOwnershipChange,
+}: {
+  id: string;
+  inputRef: RefObject<HTMLInputElement | null>;
+  accountLabel: string;
+  ownership: ConnectionOwnership;
+  canConnectPersonal: boolean;
+  canConnectWorkspace: boolean;
+  onAccountLabelChange: (value: string) => void;
+  onOwnershipChange: (value: ConnectionOwnership) => void;
+}) {
+  const unavailable = !canConnectPersonal && !canConnectWorkspace;
+  return (
+    <section aria-labelledby={`${id}-account-heading`}>
+      <h2 id={`${id}-account-heading`} className="text-base font-semibold text-fg">
+        Name the account and choose who can use it
+      </h2>
+      <p className="mt-1 text-sm leading-5 text-fg-muted">
+        The label distinguishes this account from connected siblings. It never changes the provider
+        identity or grants access.
+      </p>
+
+      <div className="mt-5 grid gap-1.5">
+        <Label htmlFor={`${id}-account-label`}>Account label</Label>
+        <Input
+          ref={inputRef}
+          id={`${id}-account-label`}
+          value={accountLabel}
+          onChange={(event) => onAccountLabelChange(event.target.value)}
+          placeholder="e.g. Gmail — Finance"
+          maxLength={INTEGRATION_ACCOUNT_LABEL_MAX_LENGTH}
+          autoComplete="off"
+        />
+        <p className="text-2xs leading-4 text-fg-subtle">
+          Use a team, purpose, or mailbox name—not a password or credential.
+        </p>
+      </div>
+
+      <fieldset className="mt-5 grid gap-2">
+        <legend className="text-xs font-medium text-fg-muted">Who can use this account?</legend>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <OwnershipOption
+            id={`${id}-personal`}
+            name={`${id}-ownership`}
+            value="personal"
+            checked={ownership === "personal"}
+            disabled={!canConnectPersonal}
+            icon={UserRoundIcon}
+            title="Personal"
+            description="Only your sessions and work explicitly delegated from you can use it. Teammates connect their own account."
+            onChange={onOwnershipChange}
+          />
+          <OwnershipOption
+            id={`${id}-workspace`}
+            name={`${id}-ownership`}
+            value="workspace"
+            checked={ownership === "workspace"}
+            disabled={!canConnectWorkspace}
+            icon={UsersRoundIcon}
+            title="Workspace"
+            description="Authorized workspace members and workspace automations can use the shared account."
+            onChange={onOwnershipChange}
+          />
+        </div>
+      </fieldset>
+
+      {unavailable ? (
+        <div className="mt-4 rounded-xl border border-warning/40 bg-warning/10 p-3 text-xs leading-5 text-fg-muted">
+          <p className="font-medium text-fg">Administrator setup is required</p>
+          <p className="mt-1">
+            Ask a workspace administrator to connect this account or grant you permission to manage
+            integrations. You can close this guide without changing anything.
+          </p>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function OwnershipOption({
+  id,
+  name,
+  value,
+  checked,
+  disabled,
+  icon: Icon,
+  title,
+  description,
+  onChange,
+}: {
+  id: string;
+  name: string;
+  value: ConnectionOwnership;
+  checked: boolean;
+  disabled: boolean;
+  icon: ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+  onChange: (value: ConnectionOwnership) => void;
+}) {
+  return (
+    <div className="relative">
+      <input
+        className="peer sr-only"
+        type="radio"
+        id={id}
+        name={name}
+        value={value}
+        checked={checked}
+        disabled={disabled}
+        onChange={() => onChange(value)}
+      />
+      <label
+        htmlFor={id}
+        className={cn(
+          "block min-h-32 rounded-xl border p-3 text-left transition-colors motion-reduce:transition-none",
+          "peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-brand",
+          checked
+            ? "border-brand bg-brand/5 shadow-sm forced-colors:border-[Highlight]"
+            : "border-border bg-surface/50",
+          disabled ? "cursor-not-allowed opacity-55" : "cursor-pointer hover:border-border-strong",
+        )}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold text-fg">
+          <Icon className={cn("size-4", checked ? "text-brand" : "text-fg-subtle")} />
+          {title}
+          {disabled ? <span className="sr-only">Unavailable</span> : null}
+        </span>
+        <span className="mt-1 block text-2xs leading-4 text-fg-muted">{description}</span>
+      </label>
+    </div>
+  );
+}
+
+function AccessStep({
+  id,
+  experience,
+  headingRef,
+}: {
+  id: string;
+  experience: IntegrationExperienceDescriptor;
+  headingRef: RefObject<HTMLHeadingElement | null>;
+}) {
+  return (
+    <section aria-labelledby={`${id}-access-heading`}>
+      <h2
+        ref={headingRef}
+        id={`${id}-access-heading`}
+        tabIndex={-1}
+        className="text-base font-semibold text-fg outline-none"
+      >
+        What agents can do
+      </h2>
+      <p className="mt-1 text-sm leading-5 text-fg-muted">
+        These descriptions explain the reviewed integration surface. Your provider account and
+        workspace policies still decide what is actually allowed.
+      </p>
+
+      <ul className="mt-4 grid gap-2 sm:grid-cols-2">
+        {experience.capabilities.map((capability) => (
+          <li key={capability.title} className="rounded-xl border border-border bg-surface p-3">
+            <p className="text-sm font-medium text-fg">{capability.title}</p>
+            <p className="mt-1 text-xs leading-5 text-fg-muted">{capability.description}</p>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-5 rounded-xl border border-brand/20 bg-brand/5 p-4">
+        <div className="flex items-start gap-3">
+          <LockKeyholeIcon className="mt-0.5 size-4 shrink-0 text-brand" aria-hidden />
+          <div>
+            <h3 className="text-sm font-medium text-fg">Permission explanation</h3>
+            <p className="mt-1 text-xs leading-5 text-fg-muted">{experience.permissionSummary}</p>
+          </div>
+        </div>
+        {experience.permissions.length > 0 ? (
+          <ul className="mt-3 grid gap-2">
+            {experience.permissions.map((permission) => (
+              <li key={permission.label} className="flex gap-2 text-xs leading-5 text-fg-muted">
+                <CheckIcon className="mt-1 size-3.5 shrink-0 text-success" aria-hidden />
+                <span>
+                  <strong className="font-medium text-fg">{permission.label}.</strong>{" "}
+                  {permission.description}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+
+      <details className="group mt-4 rounded-xl border border-border bg-bg p-3">
+        <summary className="cursor-pointer text-xs font-medium text-fg-muted">
+          Technical details
+        </summary>
+        <div className="mt-3 grid gap-3 text-2xs leading-5 text-fg-subtle">
+          <div>
+            <p className="font-medium text-fg-muted">Provider domain</p>
+            <code className="break-all">{experience.technicalDetails.providerDomain}</code>
+          </div>
+          <div>
+            <p className="font-medium text-fg-muted">OAuth scopes requested</p>
+            {experience.technicalDetails.oauthScopes.length > 0 ? (
+              <ul className="mt-1 grid gap-1">
+                {experience.technicalDetails.oauthScopes.map((scope) => (
+                  <li key={scope}>
+                    <code className="break-all">{scope}</code>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>None published.</p>
+            )}
+          </div>
+          <p>
+            These values describe the provider request. They are not credentials and do not grant
+            access by themselves.
+          </p>
+        </div>
+      </details>
+    </section>
+  );
+}
+
+function ReviewStep({
+  id,
+  experience,
+  accountLabel,
+  ownership,
+  headingRef,
+}: {
+  id: string;
+  experience: IntegrationExperienceDescriptor;
+  accountLabel: string;
+  ownership: ConnectionOwnership;
+  headingRef: RefObject<HTMLHeadingElement | null>;
+}) {
+  return (
+    <section aria-labelledby={`${id}-review-heading`}>
+      <h2
+        ref={headingRef}
+        id={`${id}-review-heading`}
+        tabIndex={-1}
+        className="text-base font-semibold text-fg outline-none"
+      >
+        Review the connection
+      </h2>
+      <p className="mt-1 text-sm leading-5 text-fg-muted">
+        Nothing has been connected yet. Check the details before continuing to the provider.
+      </p>
+
+      <dl className="mt-4 divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
+        <ReviewRow
+          term="Service"
+          detail={`${experience.serviceName} by ${experience.providerName}`}
+        />
+        <ReviewRow term="Account label" detail={accountLabel} />
+        <ReviewRow
+          term="Ownership"
+          detail={
+            ownership === "personal"
+              ? "Personal — usable only through your delegated account access"
+              : "Workspace — shared with authorized workspace members and automations"
+          }
+        />
+        <ReviewRow
+          term="Capabilities"
+          detail={experience.capabilities.map((capability) => capability.title).join(", ")}
+        />
+      </dl>
+
+      <div className="mt-4 flex gap-3 rounded-xl border border-brand/20 bg-brand/5 p-4">
+        <ShieldCheckIcon className="mt-0.5 size-4 shrink-0 text-brand" aria-hidden />
+        <div>
+          <p className="text-sm font-medium text-fg">Next, continue to {experience.providerName}</p>
+          <p className="mt-1 text-xs leading-5 text-fg-muted">
+            {experience.providerName} will show its consent screen. Review it there before
+            approving. OpenGeni stores the resulting connection separately from this display label.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ReviewRow({ term, detail }: { term: string; detail: string }) {
+  return (
+    <div className="grid gap-1 px-4 py-3 sm:grid-cols-[8rem_1fr] sm:gap-4">
+      <dt className="text-xs font-medium text-fg-subtle">{term}</dt>
+      <dd className="break-words text-sm text-fg">{detail}</dd>
+    </div>
+  );
+}

--- a/apps/web/src/components/capabilities/integration-connect-flow.test.ts
+++ b/apps/web/src/components/capabilities/integration-connect-flow.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  initialIntegrationConnectFlow,
+  integrationConnectFlowReducer,
+  integrationConnectValidationError,
+  type IntegrationConnectFlowAction,
+  type IntegrationConnectFlowInput,
+} from "./integration-connect-flow";
+
+describe("integration connection flow", () => {
+  test("validates the account and unavailable ownership before advancing", () => {
+    let state = initialIntegrationConnectFlow(input({ accountLabel: "   " }));
+    expect(integrationConnectValidationError(state)).toBe("Enter an account label.");
+    state = integrationConnectFlowReducer(state, { type: "next" });
+    expect(state.step).toBe("account");
+
+    state = integrationConnectFlowReducer(state, {
+      type: "account_label_changed",
+      value: "Gmail — Finance",
+    });
+    state = integrationConnectFlowReducer(state, {
+      type: "ownership_changed",
+      value: "workspace",
+    });
+    expect(state.ownership).toBe("personal");
+    expect(integrationConnectValidationError(state)).toBeNull();
+
+    const unavailable = initialIntegrationConnectFlow(
+      input({ availability: { personal: false, workspace: false } }),
+    );
+    expect(integrationConnectValidationError(unavailable)).toBe(
+      "A workspace administrator must connect this account.",
+    );
+  });
+
+  test("moves deterministically through review and permits only backward step jumps", () => {
+    let state = initialIntegrationConnectFlow(input());
+    state = reduce(state, [{ type: "next" }, { type: "next" }]);
+    expect(state.step).toBe("review");
+
+    state = integrationConnectFlowReducer(state, { type: "go_to", step: "account" });
+    expect(state.step).toBe("account");
+    state = integrationConnectFlowReducer(state, { type: "go_to", step: "review" });
+    expect(state.step).toBe("account");
+
+    state = reduce(state, [{ type: "next" }, { type: "back" }]);
+    expect(state.step).toBe("account");
+  });
+
+  test("ignores duplicate and stale submission outcomes across reset and retry", () => {
+    let state = reduce(initialIntegrationConnectFlow(input()), [
+      { type: "next" },
+      { type: "next" },
+      { type: "submit", submissionId: 1 },
+    ]);
+    expect(state.status).toBe("submitting");
+
+    const duplicate = integrationConnectFlowReducer(state, {
+      type: "submit",
+      submissionId: 2,
+    });
+    expect(duplicate).toBe(state);
+
+    state = integrationConnectFlowReducer(state, {
+      type: "reset",
+      input: input({ accountLabel: "Gmail — Sales" }),
+    });
+    expect(state).toMatchObject({
+      step: "account",
+      accountLabel: "Gmail — Sales",
+      status: "idle",
+      submissionSequence: 2,
+      activeSubmissionId: null,
+    });
+    const stale = integrationConnectFlowReducer(state, {
+      type: "submit_failed",
+      submissionId: 1,
+      message: "stale provider failure",
+    });
+    expect(stale).toBe(state);
+
+    state = reduce(state, [
+      { type: "next" },
+      { type: "next" },
+      { type: "submit", submissionId: 3 },
+      { type: "submit_failed", submissionId: 3, message: "Try safely again" },
+    ]);
+    expect(state).toMatchObject({ status: "error", error: "Try safely again" });
+
+    state = integrationConnectFlowReducer(state, { type: "submit", submissionId: 4 });
+    state = integrationConnectFlowReducer(state, {
+      type: "redirecting",
+      submissionId: 4,
+    });
+    expect(state.status).toBe("redirecting");
+    expect(
+      integrationConnectFlowReducer(state, {
+        type: "submit_failed",
+        submissionId: 3,
+        message: "late failure",
+      }),
+    ).toBe(state);
+  });
+});
+
+function input(overrides: Partial<IntegrationConnectFlowInput> = {}): IntegrationConnectFlowInput {
+  return {
+    accountLabel: "Gmail — Account 2",
+    availability: { personal: true, workspace: false },
+    ...overrides,
+  };
+}
+
+function reduce(
+  initial: ReturnType<typeof initialIntegrationConnectFlow>,
+  actions: IntegrationConnectFlowAction[],
+) {
+  return actions.reduce(integrationConnectFlowReducer, initial);
+}

--- a/apps/web/src/components/capabilities/integration-connect-flow.ts
+++ b/apps/web/src/components/capabilities/integration-connect-flow.ts
@@ -1,0 +1,153 @@
+import type { ConnectionOwnership } from "@/types";
+
+export const INTEGRATION_ACCOUNT_LABEL_MAX_LENGTH = 200;
+
+export type IntegrationConnectStep = "account" | "access" | "review";
+export type IntegrationConnectStatus = "idle" | "submitting" | "redirecting" | "error";
+
+export type IntegrationConnectAvailability = Record<ConnectionOwnership, boolean>;
+
+export type IntegrationConnectFlowInput = {
+  accountLabel: string;
+  preferredOwnership?: ConnectionOwnership;
+  availability: IntegrationConnectAvailability;
+};
+
+export type IntegrationConnectFlowState = {
+  step: IntegrationConnectStep;
+  accountLabel: string;
+  ownership: ConnectionOwnership;
+  availability: IntegrationConnectAvailability;
+  status: IntegrationConnectStatus;
+  error: string | null;
+  submissionSequence: number;
+  activeSubmissionId: number | null;
+};
+
+export type IntegrationConnectFlowAction =
+  | { type: "reset"; input: IntegrationConnectFlowInput }
+  | { type: "account_label_changed"; value: string }
+  | { type: "ownership_changed"; value: ConnectionOwnership }
+  | { type: "next" }
+  | { type: "back" }
+  | { type: "go_to"; step: IntegrationConnectStep }
+  | { type: "submit"; submissionId: number }
+  | { type: "redirecting"; submissionId: number }
+  | { type: "submit_failed"; submissionId: number; message: string };
+
+const STEP_ORDER: readonly IntegrationConnectStep[] = ["account", "access", "review"];
+
+export function initialIntegrationConnectFlow(
+  input: IntegrationConnectFlowInput,
+): IntegrationConnectFlowState {
+  return initialState(input, 0);
+}
+
+export function integrationConnectFlowReducer(
+  state: IntegrationConnectFlowState,
+  action: IntegrationConnectFlowAction,
+): IntegrationConnectFlowState {
+  if (action.type === "reset") {
+    // Advance the sequence so an async failure from the prior open cannot
+    // overwrite a freshly reset journey, even when the old request settles late.
+    return initialState(action.input, state.submissionSequence + 1);
+  }
+
+  const busy = state.status === "submitting" || state.status === "redirecting";
+  if (busy && action.type !== "redirecting" && action.type !== "submit_failed") return state;
+
+  switch (action.type) {
+    case "account_label_changed":
+      return { ...state, accountLabel: action.value, status: "idle", error: null };
+    case "ownership_changed":
+      if (!state.availability[action.value]) return state;
+      return { ...state, ownership: action.value, status: "idle", error: null };
+    case "next": {
+      if (integrationConnectValidationError(state)) return state;
+      const index = STEP_ORDER.indexOf(state.step);
+      const next = STEP_ORDER[index + 1];
+      return next ? { ...state, step: next, status: "idle", error: null } : state;
+    }
+    case "back": {
+      const index = STEP_ORDER.indexOf(state.step);
+      const previous = STEP_ORDER[index - 1];
+      return previous ? { ...state, step: previous, status: "idle", error: null } : state;
+    }
+    case "go_to": {
+      const currentIndex = STEP_ORDER.indexOf(state.step);
+      const targetIndex = STEP_ORDER.indexOf(action.step);
+      if (targetIndex < 0 || targetIndex >= currentIndex) return state;
+      return { ...state, step: action.step, status: "idle", error: null };
+    }
+    case "submit":
+      if (
+        state.step !== "review" ||
+        integrationConnectValidationError(state) ||
+        action.submissionId <= state.submissionSequence
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        status: "submitting",
+        error: null,
+        submissionSequence: action.submissionId,
+        activeSubmissionId: action.submissionId,
+      };
+    case "redirecting":
+      if (state.activeSubmissionId !== action.submissionId || state.status !== "submitting") {
+        return state;
+      }
+      return { ...state, status: "redirecting" };
+    case "submit_failed":
+      if (state.activeSubmissionId !== action.submissionId) return state;
+      return {
+        ...state,
+        status: "error",
+        error: action.message,
+        activeSubmissionId: null,
+      };
+  }
+}
+
+export function integrationConnectValidationError(
+  state: Pick<IntegrationConnectFlowState, "accountLabel" | "ownership" | "availability">,
+): string | null {
+  const label = state.accountLabel.trim();
+  if (!label) return "Enter an account label.";
+  if (label.length > INTEGRATION_ACCOUNT_LABEL_MAX_LENGTH) {
+    return `Keep the account label to ${INTEGRATION_ACCOUNT_LABEL_MAX_LENGTH} characters or fewer.`;
+  }
+  if (!state.availability[state.ownership]) {
+    return "A workspace administrator must connect this account.";
+  }
+  return null;
+}
+
+export function integrationConnectStepNumber(step: IntegrationConnectStep): number {
+  return STEP_ORDER.indexOf(step) + 1;
+}
+
+function initialState(
+  input: IntegrationConnectFlowInput,
+  submissionSequence: number,
+): IntegrationConnectFlowState {
+  const preferred = input.preferredOwnership ?? "personal";
+  const ownership = input.availability[preferred]
+    ? preferred
+    : input.availability.personal
+      ? "personal"
+      : input.availability.workspace
+        ? "workspace"
+        : preferred;
+  return {
+    step: "account",
+    accountLabel: input.accountLabel,
+    ownership,
+    availability: { ...input.availability },
+    status: "idle",
+    error: null,
+    submissionSequence,
+    activeSubmissionId: null,
+  };
+}

--- a/apps/web/src/components/capabilities/integration-control-center-view.tsx
+++ b/apps/web/src/components/capabilities/integration-control-center-view.tsx
@@ -1,64 +1,41 @@
 import {
   AlertTriangleIcon,
-  CalendarDaysIcon,
   CheckCircle2Icon,
   CloudIcon,
-  ContactRoundIcon,
-  HardDriveIcon,
   Layers3Icon,
   Loader2Icon,
-  MailIcon,
   PlusIcon,
   RefreshCwIcon,
-  ShieldCheckIcon,
   Trash2Icon,
-  UserRoundIcon,
-  UsersRoundIcon,
 } from "lucide-react";
 import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
-import type { ComponentType, FormEvent, RefObject } from "react";
+import type { RefObject } from "react";
 
 import { CustomApiSection } from "@/components/capabilities/custom-api-section";
 import { CustomApiSetupDialog } from "@/components/capabilities/custom-api-setup-dialog";
 import type { CustomApiFlowState } from "@/components/capabilities/custom-api-flow";
 import { GoogleDriveKnowledgeSourceDialog } from "@/components/capabilities/google-drive-knowledge-source-dialog";
+import {
+  IntegrationConnectDialog,
+  IntegrationExperienceIcon,
+  type IntegrationConnectRequest,
+} from "@/components/capabilities/integration-connect-dialog";
 import { IntegrationFacetsPanel } from "@/components/capabilities/integration-facets-panel";
+import { integrationExperience } from "@/components/capabilities/integration-experience";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import type {
   ApiIntegrationInstallationSummary,
   IntegrationDefinitionSummary,
   ConnectionMetadata,
-  ConnectionOwnership,
 } from "@/types";
 
 export type IntegrationRemoveTarget = {
   instance: ApiIntegrationInstallationSummary;
   removesDefinition: boolean;
-};
-
-type DefinitionVisual = { icon: ComponentType<{ className?: string }> };
-
-const DEFINITION_VISUALS: Record<string, DefinitionVisual> = {
-  "google-gmail": { icon: MailIcon },
-  "google-drive": { icon: HardDriveIcon },
-  "microsoft-outlook-mail": { icon: MailIcon },
-  "microsoft-outlook-calendar": { icon: CalendarDaysIcon },
-  "microsoft-outlook-contacts": { icon: ContactRoundIcon },
-  "microsoft-onedrive": { icon: CloudIcon },
 };
 
 export function IntegrationControlCenterView({
@@ -77,8 +54,7 @@ export function IntegrationControlCenterView({
   busyKey,
   callbackBusy,
   setupDefinition,
-  displayName,
-  ownership,
+  setupInitialAccountLabel,
   removeTarget,
   customApi,
   embedded,
@@ -88,12 +64,11 @@ export function IntegrationControlCenterView({
   onReconnect,
   onPreviewRemove,
   onSetupClose,
-  onDisplayNameChange,
-  onOwnershipChange,
   onConnectSetup,
   onRemoveClose,
   onRemoveInstance,
   removeTriggerRef,
+  setupTriggerRef,
   focusFallbackRef,
   onOpenCustomApi,
   onUpdateCustomApi,
@@ -121,8 +96,7 @@ export function IntegrationControlCenterView({
   busyKey: string | null;
   callbackBusy: boolean;
   setupDefinition: IntegrationDefinitionSummary | null;
-  displayName: string;
-  ownership: ConnectionOwnership;
+  setupInitialAccountLabel: string;
   removeTarget: IntegrationRemoveTarget | null;
   customApi: CustomApiFlowState;
   embedded: boolean;
@@ -132,12 +106,11 @@ export function IntegrationControlCenterView({
   onReconnect: (instance: ApiIntegrationInstallationSummary) => void;
   onPreviewRemove: (instance: ApiIntegrationInstallationSummary) => void;
   onSetupClose: () => void;
-  onDisplayNameChange: (value: string) => void;
-  onOwnershipChange: (value: ConnectionOwnership) => void;
-  onConnectSetup: () => void;
+  onConnectSetup: (request: IntegrationConnectRequest) => Promise<void>;
   onRemoveClose: () => void;
   onRemoveInstance: () => Promise<boolean>;
   removeTriggerRef: RefObject<HTMLElement | null>;
+  setupTriggerRef: RefObject<HTMLElement | null>;
   focusFallbackRef: RefObject<HTMLElement | null>;
   onOpenCustomApi: () => void;
   onUpdateCustomApi: (instance: ApiIntegrationInstallationSummary) => void;
@@ -150,11 +123,6 @@ export function IntegrationControlCenterView({
   onCustomApiBack: () => void;
   onCustomApiToggleTool: (toolId: string, selected: boolean) => void;
 }) {
-  function submitSetup(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    onConnectSetup();
-  }
-
   return (
     <section
       ref={focusFallbackRef}
@@ -275,82 +243,17 @@ export function IntegrationControlCenterView({
         />
       ) : null}
 
-      <Dialog open={setupDefinition !== null} onOpenChange={(open) => !open && onSetupClose()}>
-        <DialogContent className="sm:max-w-lg">
-          <DialogHeader>
-            <DialogTitle>
-              {setupDefinition ? `Connect ${setupDefinition.name}` : "Connect service"}
-            </DialogTitle>
-            <DialogDescription>
-              Name this account so agents and teammates can choose the right one without seeing
-              credentials.
-            </DialogDescription>
-          </DialogHeader>
-          <form className="grid gap-5" onSubmit={submitSetup}>
-            <div className="grid gap-1.5">
-              <Label htmlFor="integration-instance-name">Account label</Label>
-              <Input
-                id="integration-instance-name"
-                value={displayName}
-                onChange={(event) => onDisplayNameChange(event.target.value)}
-                placeholder="e.g. Gmail — Finance"
-                autoFocus
-                maxLength={200}
-              />
-              <p className="text-2xs text-fg-subtle">
-                Labels are editable presentation; the underlying runtime identity remains stable.
-              </p>
-            </div>
-
-            <fieldset className="grid gap-2">
-              <legend className="text-xs font-medium text-fg-muted">
-                Who can use this account?
-              </legend>
-              <div className="grid gap-2 sm:grid-cols-2">
-                <OwnershipChoice
-                  selected={ownership === "personal"}
-                  icon={UserRoundIcon}
-                  title="Personal"
-                  description="Only you and explicitly delegated runs"
-                  onClick={() => onOwnershipChange("personal")}
-                />
-                <OwnershipChoice
-                  selected={ownership === "workspace"}
-                  icon={UsersRoundIcon}
-                  title="Workspace"
-                  description="Available to authorized workspace members"
-                  onClick={() => onOwnershipChange("workspace")}
-                />
-              </div>
-            </fieldset>
-
-            <details className="group rounded-lg border border-border bg-bg p-3">
-              <summary className="cursor-pointer text-xs font-medium text-fg-muted">
-                Permissions requested
-              </summary>
-              <p className="mt-2 break-words font-mono text-2xs leading-5 text-fg-subtle">
-                {setupDefinition?.authentication.scopes.join(", ")}
-              </p>
-            </details>
-
-            {!canManage ? (
-              <p className="rounded-lg border border-warning/30 bg-warning/10 p-3 text-xs leading-5 text-fg-muted">
-                Ask a workspace administrator to add this account.
-              </p>
-            ) : null}
-
-            <DialogFooter>
-              <Button type="button" variant="ghost" onClick={onSetupClose}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={!canManage || !displayName.trim()}>
-                <ShieldCheckIcon />
-                Continue to provider
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
+      <IntegrationConnectDialog
+        open={setupDefinition !== null}
+        definition={setupDefinition}
+        initialAccountLabel={setupInitialAccountLabel}
+        canConnectPersonal={canManage}
+        canConnectWorkspace={canManage}
+        restoreFocusRef={setupTriggerRef}
+        restoreFocusFallbackRef={focusFallbackRef}
+        onOpenChange={(open) => !open && onSetupClose()}
+        onConnect={onConnectSetup}
+      />
 
       <ConfirmDialog
         open={removeTarget !== null}
@@ -415,14 +318,14 @@ function DefinitionCard({
   onReconnect: (instance: ApiIntegrationInstallationSummary) => void;
   onRemove: (instance: ApiIntegrationInstallationSummary) => void;
 }) {
-  const Icon = (DEFINITION_VISUALS[definition.id] ?? { icon: CloudIcon }).icon;
+  const experience = integrationExperience(definition);
   const connectionById = new Map((connections ?? []).map((entry) => [entry.id, entry]));
   return (
     <article className="relative flex h-full flex-col overflow-hidden rounded-xl border border-border bg-bg/50 p-4 transition-colors hover:border-border-strong">
       <div className="flex items-start justify-between gap-3">
         <div className="flex min-w-0 items-start gap-3">
           <span className="grid size-10 shrink-0 place-items-center rounded-xl border border-brand/20 bg-brand/5 text-brand shadow-sm">
-            <Icon className="size-5" />
+            <IntegrationExperienceIcon icon={experience.icon} className="size-5" />
           </span>
           <div className="min-w-0">
             <h3 className="truncate text-sm font-semibold text-fg">{definition.name}</h3>
@@ -432,7 +335,7 @@ function DefinitionCard({
           </div>
         </div>
         <Badge variant="outline" className="bg-surface/50 text-2xs text-fg-subtle">
-          {definition.provider.id === "google" ? "Google" : "Microsoft"}
+          {experience.providerName}
         </Badge>
       </div>
 
@@ -539,47 +442,21 @@ function DefinitionCard({
         variant={instances.length > 0 ? "outline" : "default"}
         size="sm"
         className="mt-auto w-full"
-        disabled={!canManage || busyKey !== null}
+        disabled={busyKey !== null}
         onClick={onAdd}
       >
         <PlusIcon />
-        {instances.length > 0 ? "Add another account" : `Connect ${definition.name}`}
+        {!canManage
+          ? `Review ${definition.name} setup`
+          : instances.length > 0
+            ? "Add another account"
+            : `Connect ${definition.name}`}
       </Button>
+      {!canManage ? (
+        <p className="mt-2 text-center text-2xs leading-4 text-fg-subtle">
+          A workspace administrator must complete the connection.
+        </p>
+      ) : null}
     </article>
-  );
-}
-
-function OwnershipChoice({
-  selected,
-  icon: Icon,
-  title,
-  description,
-  onClick,
-}: {
-  selected: boolean;
-  icon: ComponentType<{ className?: string }>;
-  title: string;
-  description: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={selected}
-      onClick={onClick}
-      className={cn(
-        "rounded-xl border p-3 text-left transition-colors",
-        selected
-          ? "border-brand bg-brand/5 shadow-sm"
-          : "border-border bg-surface/50 hover:border-border-strong",
-      )}
-    >
-      <span className="flex items-center gap-2 text-sm font-semibold text-fg">
-        <Icon className={cn("size-4", selected ? "text-brand" : "text-fg-subtle")} />
-        {title}
-      </span>
-      <span className="mt-1 block text-2xs leading-4 text-fg-muted">{description}</span>
-    </button>
   );
 }

--- a/apps/web/src/components/capabilities/integration-control-center.tsx
+++ b/apps/web/src/components/capabilities/integration-control-center.tsx
@@ -19,6 +19,7 @@ import {
   customApiSourceFromDraft,
   initialCustomApiFlowState,
 } from "@/components/capabilities/custom-api-flow";
+import type { IntegrationConnectRequest } from "@/components/capabilities/integration-connect-dialog";
 import type { IntegrationRemoveTarget } from "@/components/capabilities/integration-control-center-view";
 import { useAppContext } from "@/context";
 import { hasAccountPermission } from "@/lib/permissions";
@@ -149,8 +150,7 @@ export function IntegrationControlCenter({
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [setupDefinition, setSetupDefinition] = useState<IntegrationDefinitionSummary | null>(null);
-  const [displayName, setDisplayName] = useState("");
-  const [ownership, setOwnership] = useState<ConnectionOwnership>("personal");
+  const [setupInitialAccountLabel, setSetupInitialAccountLabel] = useState("");
   const [busyKey, setBusyKey] = useState<string | null>(null);
   const [callbackBusy, setCallbackBusy] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<IntegrationRemoveTarget | null>(null);
@@ -160,6 +160,8 @@ export function IntegrationControlCenter({
     initialCustomApiFlowState,
   );
   const callbackHandled = useRef(false);
+  const setupInstanceKeyRef = useRef<string | null>(null);
+  const setupTriggerRef = useRef<HTMLElement | null>(null);
   const removeTriggerRef = useRef<HTMLElement | null>(null);
   const focusFallbackRef = useRef<HTMLElement | null>(null);
 
@@ -261,9 +263,13 @@ export function IntegrationControlCenter({
 
   function openSetup(definition: IntegrationDefinitionSummary) {
     const count = instancesByDefinition.get(definition.id)?.length ?? 0;
+    const active = document.activeElement;
+    setupTriggerRef.current = active instanceof HTMLElement ? active : null;
+    setupInstanceKeyRef.current = `account-${crypto.randomUUID()}`;
     setSetupDefinition(definition);
-    setDisplayName(count === 0 ? definition.name : `${definition.name} — Account ${count + 1}`);
-    setOwnership("personal");
+    setSetupInitialAccountLabel(
+      count === 0 ? definition.name : `${definition.name} — Account ${count + 1}`,
+    );
   }
 
   async function startOAuth(
@@ -301,9 +307,7 @@ export function IntegrationControlCenter({
       window.location.assign(response.authorizationUrl);
     } catch (error) {
       setBusyKey(null);
-      toast.error("Couldn't start account connection", {
-        description: error instanceof Error ? error.message : String(error),
-      });
+      throw error;
     }
   }
 
@@ -317,13 +321,19 @@ export function IntegrationControlCenter({
       toast.error("This instance cannot be reconnected automatically");
       return;
     }
-    await startOAuth(definition, {
-      instanceKey: instance.instanceKey,
-      displayName: instance.displayName,
-      ownership: instance.ownership,
-      connectionId: instance.connectionId,
-      expectedInstanceVersion: instance.instanceVersion,
-    });
+    try {
+      await startOAuth(definition, {
+        instanceKey: instance.instanceKey,
+        displayName: instance.displayName,
+        ownership: instance.ownership,
+        connectionId: instance.connectionId,
+        expectedInstanceVersion: instance.instanceVersion,
+      });
+    } catch (error) {
+      toast.error("Couldn't start account connection", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   async function previewRemove(instance: ApiIntegrationInstallationSummary) {
@@ -517,15 +527,22 @@ export function IntegrationControlCenter({
     dispatchCustomApi({ type: "tools", selectedTools: next });
   }
 
-  function connectSetup() {
-    if (!setupDefinition || !displayName.trim() || !canManage) return;
-    const definition = setupDefinition;
-    setSetupDefinition(null);
-    void startOAuth(definition, {
-      instanceKey: `account-${crypto.randomUUID()}`,
-      displayName: displayName.trim(),
-      ownership,
+  async function connectSetup(request: IntegrationConnectRequest) {
+    if (!setupDefinition || !canManage) {
+      throw new Error("A workspace administrator must connect this account.");
+    }
+    const instanceKey = setupInstanceKeyRef.current;
+    if (!instanceKey) throw new Error("The connection journey is no longer current.");
+    await startOAuth(setupDefinition, {
+      instanceKey,
+      displayName: request.accountLabel,
+      ownership: request.ownership,
     });
+  }
+
+  function closeSetup() {
+    setSetupDefinition(null);
+    setupInstanceKeyRef.current = null;
   }
 
   return (
@@ -554,8 +571,7 @@ export function IntegrationControlCenter({
         busyKey={busyKey}
         callbackBusy={callbackBusy}
         setupDefinition={setupDefinition}
-        displayName={displayName}
-        ownership={ownership}
+        setupInitialAccountLabel={setupInitialAccountLabel}
         removeTarget={removeTarget}
         customApi={customApi}
         embedded={embedded}
@@ -564,13 +580,12 @@ export function IntegrationControlCenter({
         onOpenSetup={openSetup}
         onReconnect={(instance) => void reconnect(instance)}
         onPreviewRemove={(instance) => void previewRemove(instance)}
-        onSetupClose={() => setSetupDefinition(null)}
-        onDisplayNameChange={setDisplayName}
-        onOwnershipChange={setOwnership}
+        onSetupClose={closeSetup}
         onConnectSetup={connectSetup}
         onRemoveClose={() => setRemoveTarget(null)}
         onRemoveInstance={removeInstance}
         removeTriggerRef={removeTriggerRef}
+        setupTriggerRef={setupTriggerRef}
         focusFallbackRef={focusFallbackRef}
         onOpenCustomApi={openCustomApi}
         onUpdateCustomApi={(instance) => editCustomApi(instance, "update")}

--- a/apps/web/src/components/capabilities/integration-experience.test.ts
+++ b/apps/web/src/components/capabilities/integration-experience.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+import { integrationExperience } from "./integration-experience";
+import type { IntegrationDefinitionSummary } from "@/types";
+
+describe("integration experience descriptors", () => {
+  test("presents reviewed Gmail capabilities without using raw scopes as the interface", () => {
+    const experience = integrationExperience(gmailDefinition());
+
+    expect(experience).toMatchObject({
+      serviceName: "Gmail",
+      providerName: "Google",
+      icon: "mail",
+    });
+    expect(experience.capabilities.map((item) => item.title)).toEqual([
+      "Find and understand mail",
+      "Draft and send messages",
+      "Organize the mailbox",
+    ]);
+    expect(experience.permissions.map((item) => item.label)).toContain(
+      "Work with your Gmail mailbox",
+    );
+
+    const defaultCopy = JSON.stringify({
+      introduction: experience.introduction,
+      capabilities: experience.capabilities,
+      permissionSummary: experience.permissionSummary,
+      permissions: experience.permissions,
+    });
+    expect(defaultCopy).not.toContain("https://mail.google.com/");
+    expect(experience.technicalDetails.oauthScopes).toContain("https://mail.google.com/");
+  });
+
+  test("falls back safely for a future provider without turning its schema into UX copy", () => {
+    const experience = integrationExperience({
+      id: "hubspot-crm-v3",
+      name: "HubSpot CRM",
+      summary: "Find and update customer records through reviewed tools.",
+      provider: { id: "hubspot", domain: "api.hubapi.com" },
+      authentication: {
+        scopes: ["openid", "crm.objects.contacts.write"],
+      },
+    } as Parameters<typeof integrationExperience>[0]);
+
+    expect(experience.providerName).toBe("HubSpot");
+    expect(experience.icon).toBe("cloud");
+    expect(experience.capabilities).toEqual([
+      {
+        title: "Use HubSpot CRM with agents",
+        description: "Find and update customer records through reviewed tools.",
+      },
+    ]);
+    expect(experience.permissions.map((item) => item.label)).toEqual(["Confirm your account"]);
+    expect(JSON.stringify(experience.permissions)).not.toContain("crm.objects.contacts.write");
+    expect(experience.technicalDetails).toEqual({
+      providerDomain: "api.hubapi.com",
+      oauthScopes: ["openid", "crm.objects.contacts.write"],
+    });
+  });
+});
+
+function gmailDefinition(): IntegrationDefinitionSummary {
+  return {
+    id: "google-gmail",
+    name: "Gmail",
+    summary: "Gmail messages, labels, drafts, and delivery.",
+    protocol: "openapi",
+    provider: { id: "google", domain: "gmail.googleapis.com" },
+    authentication: {
+      kind: "oauth2",
+      scopes: ["openid", "email", "profile", "https://mail.google.com/"],
+    },
+    facets: [],
+  };
+}

--- a/apps/web/src/components/capabilities/integration-experience.ts
+++ b/apps/web/src/components/capabilities/integration-experience.ts
@@ -1,0 +1,325 @@
+import type { IntegrationDefinitionSummary } from "@/types";
+
+export type IntegrationExperienceIcon = "calendar" | "cloud" | "contacts" | "files" | "mail";
+
+export type IntegrationExperienceCapability = {
+  title: string;
+  description: string;
+};
+
+export type IntegrationExperiencePermission = {
+  label: string;
+  description: string;
+};
+
+export type IntegrationExperienceDescriptor = {
+  serviceName: string;
+  providerName: string;
+  icon: IntegrationExperienceIcon;
+  introduction: string;
+  capabilities: IntegrationExperienceCapability[];
+  permissionSummary: string;
+  permissions: IntegrationExperiencePermission[];
+  technicalDetails: {
+    providerDomain: string;
+    oauthScopes: string[];
+  };
+};
+
+type PresentationDefinition = Pick<IntegrationDefinitionSummary, "id" | "name" | "summary"> & {
+  provider: { id: string; domain: string };
+  authentication: { scopes: string[] };
+};
+
+type ReviewedIntegrationExperience = Omit<
+  IntegrationExperienceDescriptor,
+  "serviceName" | "technicalDetails" | "permissions"
+> & {
+  scopeLabels: Readonly<Record<string, { label: string; description: string }>>;
+};
+
+const COMMON_SCOPE_LABELS: Readonly<Record<string, { label: string; description: string }>> = {
+  openid: {
+    label: "Confirm your account",
+    description: "Match the connection to the provider account you approve.",
+  },
+  email: {
+    label: "See your account email",
+    description: "Show which provider account is connected.",
+  },
+  profile: {
+    label: "See your basic profile",
+    description: "Use the provider's basic account identity for a clear account label.",
+  },
+  offline_access: {
+    label: "Keep the connection working",
+    description: "Refresh access when you are not actively using OpenGeni.",
+  },
+  "User.Read": {
+    label: "Confirm your Microsoft account",
+    description: "Show which Microsoft account is connected.",
+  },
+};
+
+const PROVIDER_NAMES: Readonly<Record<string, string>> = {
+  discord: "Discord",
+  google: "Google",
+  hubspot: "HubSpot",
+  microsoft: "Microsoft",
+  notion: "Notion",
+  stripe: "Stripe",
+};
+
+const REVIEWED_INTEGRATION_EXPERIENCES: Readonly<Record<string, ReviewedIntegrationExperience>> = {
+  "google-gmail": {
+    providerName: "Google",
+    icon: "mail",
+    introduction: "Let agents work with the Gmail account you choose.",
+    capabilities: [
+      {
+        title: "Find and understand mail",
+        description: "Search messages and threads, then use them as context for your work.",
+      },
+      {
+        title: "Draft and send messages",
+        description: "Prepare replies and send mail through the reviewed Gmail tools.",
+      },
+      {
+        title: "Organize the mailbox",
+        description: "Work with labels, drafts, messages, and threads.",
+      },
+    ],
+    permissionSummary:
+      "Google grants broad mailbox access. OpenGeni still exposes only the reviewed tools configured for this integration.",
+    scopeLabels: {
+      "https://mail.google.com/": {
+        label: "Work with your Gmail mailbox",
+        description: "Read, organize, draft, and send mail for the account you approve.",
+      },
+    },
+  },
+  "google-drive": {
+    providerName: "Google",
+    icon: "files",
+    introduction: "Let agents work with files in the Google Drive account you choose.",
+    capabilities: [
+      {
+        title: "Find files and folders",
+        description: "Browse and search content in My Drive and shared drives.",
+      },
+      {
+        title: "Create and update content",
+        description: "Work with files and folders through the reviewed Drive tools.",
+      },
+      {
+        title: "Manage sharing",
+        description: "Review and update links, permissions, and shared-drive content.",
+      },
+    ],
+    permissionSummary:
+      "Google asks for access to the Drive account you approve, including files shared with that account.",
+    scopeLabels: {
+      "https://www.googleapis.com/auth/drive": {
+        label: "Work with Google Drive files",
+        description: "See, create, edit, organize, and share files available to this account.",
+      },
+    },
+  },
+  "microsoft-outlook-mail": {
+    providerName: "Microsoft",
+    icon: "mail",
+    introduction: "Let agents work with mail in the Microsoft account you choose.",
+    capabilities: [
+      {
+        title: "Find and understand mail",
+        description: "Search messages, folders, and attachments for useful context.",
+      },
+      {
+        title: "Draft and send messages",
+        description: "Prepare, update, and send mail through the reviewed Outlook tools.",
+      },
+      {
+        title: "Manage mailbox settings",
+        description: "Work with supported folders, classifications, and mailbox preferences.",
+      },
+    ],
+    permissionSummary:
+      "Microsoft asks for mail and mailbox-setting access for the account you approve.",
+    scopeLabels: {
+      "Mail.ReadWrite": {
+        label: "Read and update mail",
+        description: "Work with messages, folders, and attachments in this mailbox.",
+      },
+      "Mail.Send": {
+        label: "Send mail",
+        description: "Send messages as the connected Microsoft account.",
+      },
+      "MailboxSettings.ReadWrite": {
+        label: "Manage mailbox settings",
+        description: "Read and update supported Outlook mailbox preferences.",
+      },
+    },
+  },
+  "microsoft-outlook-calendar": {
+    providerName: "Microsoft",
+    icon: "calendar",
+    introduction: "Let agents help coordinate the calendars in your Microsoft account.",
+    capabilities: [
+      {
+        title: "Understand your schedule",
+        description: "Review calendars, events, availability, and reminders.",
+      },
+      {
+        title: "Plan meetings",
+        description: "Find suitable times and coordinate calendar activity.",
+      },
+      {
+        title: "Manage events",
+        description: "Create and update events through the reviewed calendar tools.",
+      },
+    ],
+    permissionSummary:
+      "Microsoft asks for permission to view and manage calendars for the account you approve.",
+    scopeLabels: {
+      "Calendars.ReadWrite": {
+        label: "View and manage calendars",
+        description: "Read, create, update, and organize calendar events.",
+      },
+    },
+  },
+  "microsoft-outlook-contacts": {
+    providerName: "Microsoft",
+    icon: "contacts",
+    introduction: "Let agents work with contacts in your Microsoft account.",
+    capabilities: [
+      {
+        title: "Find people",
+        description: "Look up contacts and relevant people suggestions.",
+      },
+      {
+        title: "Organize contacts",
+        description: "Work with contacts and contact folders.",
+      },
+      {
+        title: "Keep details current",
+        description: "Create or update contact information through reviewed tools.",
+      },
+    ],
+    permissionSummary:
+      "Microsoft asks for contact access and people suggestions for the account you approve.",
+    scopeLabels: {
+      "Contacts.ReadWrite": {
+        label: "View and manage contacts",
+        description: "Read, create, update, and organize contacts and contact folders.",
+      },
+      "People.Read.All": {
+        label: "Find relevant people",
+        description: "Use people suggestions available to the connected account.",
+      },
+    },
+  },
+  "microsoft-onedrive": {
+    providerName: "Microsoft",
+    icon: "cloud",
+    introduction: "Let agents work with files in the Microsoft account you choose.",
+    capabilities: [
+      {
+        title: "Find files and folders",
+        description: "Browse drives, folders, shared items, and sites available to the account.",
+      },
+      {
+        title: "Create and update content",
+        description: "Work with OneDrive and SharePoint files through reviewed tools.",
+      },
+      {
+        title: "Manage sharing",
+        description: "Review and update sharing links and permissions.",
+      },
+    ],
+    permissionSummary:
+      "Microsoft asks for file and site access anywhere the connected account already has access.",
+    scopeLabels: {
+      "Files.ReadWrite.All": {
+        label: "Work with accessible files",
+        description: "Read, create, update, and organize files available to this account.",
+      },
+      "Sites.ReadWrite.All": {
+        label: "Work with accessible sites",
+        description: "Read and update files in SharePoint sites available to this account.",
+      },
+    },
+  },
+};
+
+/**
+ * Builds presentation-only copy from a Definition. The returned metadata never
+ * grants a scope, selects a Connection, or replaces server-side authorization.
+ */
+export function integrationExperience(
+  definition: PresentationDefinition,
+): IntegrationExperienceDescriptor {
+  const reviewed = REVIEWED_INTEGRATION_EXPERIENCES[definition.id];
+  const providerName = reviewed?.providerName ?? friendlyProviderName(definition.provider);
+  const scopeLabels = { ...COMMON_SCOPE_LABELS, ...(reviewed?.scopeLabels ?? {}) };
+  const permissions = definition.authentication.scopes.flatMap((scope) => {
+    const copy = scopeLabels[scope];
+    return copy ? [copy] : [];
+  });
+
+  return {
+    serviceName: definition.name,
+    providerName,
+    icon: reviewed?.icon ?? "cloud",
+    introduction:
+      reviewed?.introduction ?? `Let agents use ${definition.name} through the account you choose.`,
+    capabilities: reviewed?.capabilities ?? [
+      {
+        title: `Use ${definition.name} with agents`,
+        description:
+          definition.summary.trim() ||
+          "Use the reviewed tools published by this integration without exposing credentials.",
+      },
+    ],
+    permissionSummary:
+      reviewed?.permissionSummary ??
+      `${providerName} will show the exact access request before you approve it. OpenGeni uses that access only through this integration's reviewed tools.`,
+    permissions: deduplicatePermissions(permissions),
+    technicalDetails: {
+      providerDomain: definition.provider.domain,
+      oauthScopes: [...definition.authentication.scopes],
+    },
+  };
+}
+
+function friendlyProviderName(provider: { id: string; domain: string }): string {
+  const id = provider.id.trim();
+  const reviewedName = PROVIDER_NAMES[id.toLowerCase()];
+  if (reviewedName) return reviewedName;
+  if (id) return titleCase(id.replaceAll(/[-_]+/g, " "));
+  const domainPart = provider.domain
+    .replace(/^www\./, "")
+    .split(".")
+    .filter(Boolean)
+    .at(-2);
+  return domainPart ? titleCase(domainPart) : "the provider";
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}`)
+    .join(" ");
+}
+
+function deduplicatePermissions(
+  permissions: IntegrationExperiencePermission[],
+): IntegrationExperiencePermission[] {
+  const seen = new Set<string>();
+  return permissions.filter((permission) => {
+    const key = `${permission.label}\u0000${permission.description}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -139,6 +139,28 @@ token when the provider omits a replacement, and CAS-update or duplicate-safe
 create the normal encrypted Connection. Emulator-backed tests are merge proof;
 provider-live consent remains a separately labeled operational check.
 
+In the web control center, curated Definitions enter that flow through one
+reusable three-step connection journey. The account step gives every sibling
+account a human label and explains the consequences of Personal and Workspace
+ownership; users without integration-management permission may open the
+journey but receive administrator remediation instead of a mutation action. The
+access step describes reviewed agent use cases and permissions in plain
+language. Exact OAuth scopes and the provider domain remain available under
+progressive **Technical details**, rather than becoming the default interface.
+The review step repeats the provider, label, ownership, and capabilities before
+the user continues to the provider consent screen.
+
+The journey descriptor is presentation metadata only: it cannot grant scopes,
+select a Connection, or replace the Definition and Connection authority above.
+Its deterministic web reducer resets between account attempts and ignores stale
+submission outcomes. The existing controller still mints and preserves the
+exact instance key across a failed-start retry, owns the OAuth return path, and
+performs callback preview/install for that exact instance. The shared shell owns
+navigation, cancellation, accessible focus and progress semantics, loading, and
+safe errors; future thin provider adapters may add reviewed resource pickers or
+provider details without turning the shell into a generic schema form or
+changing the backend lifecycle.
+
 The normalized rows store the protocol-compiled revision, tools, Integration
 and API Facets, Facet installations, and owners under FORCE RLS. They are the
 only Integration Definition installation authority; generic API catalog and

--- a/test/e2e/custom-api-control-center.browser.e2e.ts
+++ b/test/e2e/custom-api-control-center.browser.e2e.ts
@@ -24,6 +24,12 @@ type UiState = {
   dense: boolean;
   loading: boolean;
   mailInboxBinding: ReturnType<typeof mailInboxBinding> | null;
+  oauthFailuresRemaining: number;
+  oauthStarts: Array<{
+    definitionId: string;
+    ownership: "personal" | "workspace";
+    returnPath: string;
+  }>;
 };
 
 describe("custom API control center browser acceptance", () => {
@@ -261,6 +267,146 @@ describe("custom API control center browser acceptance", () => {
       await context.close();
     }
   }, 60_000);
+
+  test("pass 7: guided Gmail setup reviews access and retries one exact account", async () => {
+    const context = await browser.newContext({ viewport: { width: 1180, height: 960 } });
+    const page = await context.newPage();
+    const state = readyState();
+    try {
+      await installApi(page, state);
+      await openCapabilities(page);
+      await setTheme(page, "light");
+
+      const gmailCard = page.locator("article").filter({
+        has: page.getByRole("heading", { name: "Gmail", exact: true }),
+      });
+      const addAccount = gmailCard.getByRole("button", { name: "Add another account" });
+      await addAccount.click();
+      let dialog = page.getByRole("dialog");
+      await expectVisible(dialog);
+      expect(await dialog.getByLabel("Account label").inputValue()).toBe("Gmail — Account 2");
+      expect(
+        await dialog
+          .getByLabel("Account label")
+          .evaluate((element) => element === document.activeElement),
+      ).toBe(true);
+      await expectText(dialog.locator('[aria-current="step"]'), "Account");
+      expect(await dialog.locator('input[value="personal"]').isChecked()).toBe(true);
+      await expectText(dialog, "Only your sessions and work explicitly delegated from you");
+      await expectText(dialog, "Authorized workspace members and workspace automations");
+      await dialog.getByLabel("Account label").press("Tab");
+      expect(
+        await dialog
+          .locator('input[value="personal"]')
+          .evaluate((element) => element === document.activeElement),
+      ).toBe(true);
+      await page.keyboard.press("ArrowRight");
+      expect(await dialog.locator('input[value="workspace"]').isChecked()).toBe(true);
+      await page.keyboard.press("ArrowLeft");
+      expect(await dialog.locator('input[value="personal"]').isChecked()).toBe(true);
+
+      const rawScope = dialog.getByText("https://mail.google.com/", { exact: true });
+      expect(await rawScope.isVisible()).toBe(false);
+      await dialog.getByLabel("Account label").fill("Gmail — Product");
+      await dialog.getByText("Workspace", { exact: true }).click();
+      await dialog.getByLabel("Account label").press("Enter");
+      await expectText(dialog, "What agents can do");
+      await expectText(dialog, "Draft and send messages");
+      expect(await rawScope.isVisible()).toBe(false);
+      await dialog.getByText("Technical details", { exact: true }).click();
+      expect(await rawScope.isVisible()).toBe(true);
+      await dialog.getByRole("button", { name: "Continue" }).click();
+      await expectText(dialog, "Review the connection");
+      await expectText(dialog, "Gmail — Product");
+      await expectText(dialog, "Workspace — shared with authorized workspace members");
+      await dialog.getByRole("button", { name: "Back" }).click();
+      await expectText(dialog, "What agents can do");
+      await page.keyboard.press("Escape");
+      await dialog.waitFor({ state: "hidden" });
+      expect(await addAccount.evaluate((element) => element === document.activeElement)).toBe(true);
+
+      await addAccount.click();
+      dialog = page.getByRole("dialog");
+      expect(await dialog.getByLabel("Account label").inputValue()).toBe("Gmail — Account 2");
+      await dialog.getByRole("button", { name: "Continue" }).click();
+      await dialog.getByRole("button", { name: "Continue" }).click();
+      state.oauthFailuresRemaining = 1;
+      await dialog.getByRole("button", { name: "Continue to Google" }).click();
+      await expectText(dialog.getByRole("alert"), "Check your network and try again");
+      expect((await dialog.getByRole("alert").textContent()) ?? "").not.toContain(
+        "provider-oauth-debug-body",
+      );
+      await expectText(
+        page.locator('[data-integration-instance="account-finance"]'),
+        "Gmail — Finance",
+      );
+      expect(state.oauthStarts).toHaveLength(1);
+
+      await assertAccessibleAndBounded(page, '[role="dialog"]');
+      await page.screenshot({
+        path: `${evidenceDir}pass-7-guided-connect-retry.png`,
+        fullPage: true,
+      });
+      await dialog.getByRole("button", { name: "Try again" }).click();
+      await page.waitForURL(`${webBaseUrl}/provider-consent`);
+      expect(state.oauthStarts).toHaveLength(2);
+      const firstReturn = new URL(state.oauthStarts[0]!.returnPath, webBaseUrl);
+      const retriedReturn = new URL(state.oauthStarts[1]!.returnPath, webBaseUrl);
+      expect(firstReturn.searchParams.get("api_integration_instance")).toMatch(/^account-/);
+      expect(retriedReturn.searchParams.get("api_integration_instance")).toBe(
+        firstReturn.searchParams.get("api_integration_instance"),
+      );
+      expect(retriedReturn.searchParams.get("api_integration_name")).toBe("Gmail — Account 2");
+      expect(state.oauthStarts[1]).toMatchObject({
+        definitionId: "google-gmail",
+        ownership: "personal",
+      });
+    } finally {
+      await context.close();
+    }
+  }, 60_000);
+
+  test("pass 8: mobile permission-disabled journey remains usable and bounded", async () => {
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      hasTouch: true,
+      isMobile: true,
+      colorScheme: "dark",
+      forcedColors: "active",
+      reducedMotion: "reduce",
+    });
+    const page = await context.newPage();
+    try {
+      await installApi(page, { ...readyState(), canManage: false });
+      await openCapabilities(page);
+      await setTheme(page, "dark");
+
+      const reviewSetup = page.getByRole("button", { name: "Review Gmail setup" });
+      expect(await reviewSetup.isDisabled()).toBe(false);
+      await reviewSetup.click();
+      const dialog = page.getByRole("dialog");
+      await expectText(dialog, "Administrator setup is required");
+      expect(await dialog.locator('input[value="personal"]').isDisabled()).toBe(true);
+      expect(await dialog.locator('input[value="workspace"]').isDisabled()).toBe(true);
+      expect(await dialog.getByRole("button", { name: "Continue" }).isDisabled()).toBe(true);
+      const box = await dialog.boundingBox();
+      expect(box?.width ?? 0).toBeLessThanOrEqual(390);
+      expect(box?.height ?? 0).toBeLessThanOrEqual(844);
+      await assertAccessibleAndBounded(page, '[role="dialog"]');
+      await page.screenshot({
+        path: `${evidenceDir}pass-8-mobile-permission-forced-colors.png`,
+        fullPage: true,
+      });
+
+      await page.keyboard.press("Escape");
+      await dialog.waitFor({ state: "hidden" });
+      expect(await reviewSetup.evaluate((element) => element === document.activeElement)).toBe(
+        true,
+      );
+    } finally {
+      await context.close();
+    }
+  }, 60_000);
 });
 
 function readyState(): UiState {
@@ -270,6 +416,8 @@ function readyState(): UiState {
     dense: false,
     loading: false,
     mailInboxBinding: null,
+    oauthFailuresRemaining: 0,
+    oauthStarts: [],
   };
 }
 
@@ -301,6 +449,13 @@ async function expectCustomInstances(page: Page): Promise<void> {
 }
 
 async function installApi(page: Page, state: UiState): Promise<void> {
+  await page.route(`${webBaseUrl}/provider-consent`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<!doctype html><title>Provider consent</title><h1>Provider consent</h1>",
+    }),
+  );
   await page.route("http://127.0.0.1:9/**", async (route) => {
     const request = route.request();
     const url = new URL(request.url());
@@ -359,6 +514,23 @@ async function installApi(page: Page, state: UiState): Promise<void> {
     if (url.pathname === `/v1/workspaces/${workspaceId}/integrations`) {
       if (state.loading) await new Promise((resolve) => setTimeout(resolve, 8_000));
       return json({ integrations: instances(state.dense) });
+    }
+    if (
+      request.method() === "POST" &&
+      url.pathname === `/v1/workspaces/${workspaceId}/integrations/oauth/start`
+    ) {
+      state.oauthStarts.push(
+        request.postDataJSON() as {
+          definitionId: string;
+          ownership: "personal" | "workspace";
+          returnPath: string;
+        },
+      );
+      if (state.oauthFailuresRemaining > 0) {
+        state.oauthFailuresRemaining -= 1;
+        return json({ message: "provider-oauth-debug-body" }, 503);
+      }
+      return json({ authorizationUrl: `${webBaseUrl}/provider-consent` });
     }
     if (
       request.method() === "GET" &&
@@ -497,6 +669,30 @@ function workspace() {
 }
 
 function integrationDefinitions() {
+  const scopes: Record<string, string[]> = {
+    "google-gmail": ["openid", "email", "profile", "https://mail.google.com/"],
+    "google-drive": ["openid", "email", "profile", "https://www.googleapis.com/auth/drive"],
+    "microsoft-outlook-mail": [
+      "offline_access",
+      "User.Read",
+      "Mail.ReadWrite",
+      "Mail.Send",
+      "MailboxSettings.ReadWrite",
+    ],
+    "microsoft-outlook-calendar": ["offline_access", "User.Read", "Calendars.ReadWrite"],
+    "microsoft-outlook-contacts": [
+      "offline_access",
+      "User.Read",
+      "Contacts.ReadWrite",
+      "People.Read.All",
+    ],
+    "microsoft-onedrive": [
+      "offline_access",
+      "User.Read",
+      "Files.ReadWrite.All",
+      "Sites.ReadWrite.All",
+    ],
+  };
   return [
     ["google-gmail", "Gmail", "google", "gmail.googleapis.com"],
     ["google-drive", "Google Drive", "google", "www.googleapis.com"],
@@ -510,7 +706,7 @@ function integrationDefinitions() {
     summary: `${name} Integration Definition`,
     protocol: "openapi",
     provider: { id: providerId, domain: providerDomain },
-    authentication: { kind: "oauth2", scopes: ["read"] },
+    authentication: { kind: "oauth2", scopes: scopes[id!] ?? [] },
     facets: id === "google-gmail" ? gmailFacetDefinitions() : [],
   }));
 }


### PR DESCRIPTION
## Summary
- add a pure provider-neutral presentation descriptor with reviewed Gmail, Google Drive, Outlook, and OneDrive copy plus a safe future-provider fallback
- replace the raw curated integration modal with a deterministic, accessible Account / Access / Review journey
- preserve the existing OAuth start, callback preview, and exact-instance install authority while keeping one instance key across failed-start retry
- document the web-only shell and future thin native-adapter boundary

## Verification
- focused Bun tests: 12 passed, 67 assertions
- isolated Chromium acceptance: 8 passed, 80 assertions (desktop/mobile, light/dark/forced-colors, reduced motion, axe, keyboard navigation, Escape/focus restoration, progressive technical details, permission remediation, sibling isolation, failed-start retry)
- apps/web TypeScript: passed
- repository TypeScript: all 31 projects clean
- oxlint with denied warnings: passed
- repository format check: passed
- production web build and bundle budgets: passed
- docs reference freshness: passed
- public repository hygiene: passed
- changeset status against origin/main: no package bumps required
- git diff check: passed

## Scope and compatibility
- no provider OAuth/callback routes, backend authority, DB/migrations, SDK/contracts, Slack, knowledge sync, integration facet lifecycle, or integration-features-panel changes
- latest origin/main adds only a changeset file; merge-tree compatibility is clean with no source overlap, so this branch was not source-mutated to absorb it
- full local stack was not run because the isolated browser harness covers the changed web/controller boundary

Linear: OPE-235