### PR TITLE
fix(web): make agent children visible by default

### DIFF
--- a/apps/web/src/lib/agent-topology.test.ts
+++ b/apps/web/src/lib/agent-topology.test.ts
@@ -4,10 +4,12 @@ import type { AgentTopologySession } from "@opengeni/sdk";
 import {
   AGENT_DIAGRAM_NODE_HEIGHT,
   AGENT_DIAGRAM_NODE_WIDTH,
+  agentHasMatchingDescendants,
   buildAgentTopology,
   filterAgentTopology,
   layoutAgentTopologyDiagram,
   limitAgentTopology,
+  mergeAgentTopologySessions,
   summarizeAgentTopology,
 } from "./agent-topology";
 
@@ -62,7 +64,10 @@ describe("agent topology", () => {
 
   test("active filtering retains the ancestor path", () => {
     const root = session("root");
-    const child = session("child", { parentSessionId: "root", status: "running" });
+    const child = session("child", {
+      parentSessionId: "root",
+      status: "running",
+    });
     const filtered = filterAgentTopology(buildAgentTopology([root, child]), "active", "");
     expect(filtered[0]?.session.id).toBe("root");
     expect(filtered[0]?.children[0]?.session.id).toBe("child");
@@ -74,6 +79,34 @@ describe("agent topology", () => {
     root.children.totalDescendants = 1;
     const filtered = filterAgentTopology(buildAgentTopology([root]), "active", "");
     expect(filtered.map((node) => node.session.id)).toEqual(["root"]);
+  });
+
+  test("uses server aggregates to decide which filtered branches should open automatically", () => {
+    const root = session("root");
+    root.children.directChildren = 4;
+    root.children.runningDescendants = 1;
+    root.children.pausedDescendants = 2;
+    expect(agentHasMatchingDescendants(root, "all")).toBe(true);
+    expect(agentHasMatchingDescendants(root, "active")).toBe(true);
+    expect(agentHasMatchingDescendants(root, "paused")).toBe(true);
+    expect(agentHasMatchingDescendants(root, "attention")).toBe(false);
+    expect(agentHasMatchingDescendants(root, "failed")).toBe(false);
+  });
+
+  test("keeps previously paged agents when the first page refreshes", () => {
+    const rootA = session("root-a");
+    const rootB = session("root-b");
+    const child = session("child", { parentSessionId: "root-a" });
+    const refreshedRootA = { ...rootA, title: "refreshed" };
+    expect(mergeAgentTopologySessions([rootA, rootB, child], [refreshedRootA], 200)).toEqual([
+      refreshedRootA,
+      rootB,
+      child,
+    ]);
+    expect(mergeAgentTopologySessions([rootA], [rootB, child], 2).map((item) => item.id)).toEqual([
+      "root-a",
+      "root-b",
+    ]);
   });
 
   test("summarizes paused work separately from active statuses", () => {

--- a/apps/web/src/lib/agent-topology.test.ts
+++ b/apps/web/src/lib/agent-topology.test.ts
@@ -6,10 +6,12 @@ import {
   AGENT_DIAGRAM_NODE_WIDTH,
   agentHasMatchingDescendants,
   buildAgentTopology,
+  canStartAgentTopologyRootRead,
   filterAgentTopology,
   layoutAgentTopologyDiagram,
   limitAgentTopology,
   mergeAgentTopologySessions,
+  selectAgentTopologyBranchesToLoad,
   summarizeAgentTopology,
 } from "./agent-topology";
 
@@ -107,6 +109,30 @@ describe("agent topology", () => {
       "root-a",
       "root-b",
     ]);
+  });
+
+  test("fills only the available global auto-expand request slots", () => {
+    expect(
+      selectAgentTopologyBranchesToLoad(
+        ["loaded", "active", "next", "later"],
+        new Set(["loaded"]),
+        new Set(["active", "manual"]),
+        4,
+      ),
+    ).toEqual(["next", "later"]);
+    expect(
+      selectAgentTopologyBranchesToLoad(
+        ["one", "two"],
+        new Set(),
+        new Set(["a", "b", "c", "d"]),
+        4,
+      ),
+    ).toEqual([]);
+  });
+
+  test("keeps first-page refresh and root pagination on one request lane", () => {
+    expect(canStartAgentTopologyRootRead(false)).toBe(true);
+    expect(canStartAgentTopologyRootRead(true)).toBe(false);
   });
 
   test("summarizes paused work separately from active statuses", () => {

--- a/apps/web/src/lib/agent-topology.ts
+++ b/apps/web/src/lib/agent-topology.ts
@@ -89,6 +89,20 @@ export function summarizeAgentTopology(sessions: AgentTopologySession[]): AgentT
   return summary;
 }
 
+/** Merge a refreshed or paged compact response without dropping prior pages. */
+export function mergeAgentTopologySessions(
+  current: AgentTopologySession[],
+  incoming: AgentTopologySession[],
+  maxSessions: number,
+): AgentTopologySession[] {
+  const sessions = new Map(current.map((session) => [session.id, session]));
+  for (const session of incoming) {
+    if (sessions.size >= maxSessions && !sessions.has(session.id)) break;
+    sessions.set(session.id, session);
+  }
+  return [...sessions.values()];
+}
+
 function compareAgentSessions(left: AgentTopologySession, right: AgentTopologySession): number {
   const activeDelta = Number(isActiveAgent(right)) - Number(isActiveAgent(left));
   if (activeDelta !== 0) return activeDelta;
@@ -104,7 +118,12 @@ export function buildAgentTopology(sessions: AgentTopologySession[]): AgentTopol
   const unique = new Map(sessions.map((session) => [session.id, session]));
   const nodes = new Map<string, AgentTopologyNode>();
   for (const session of unique.values()) {
-    nodes.set(session.id, { session, children: [], detached: false, cycle: false });
+    nodes.set(session.id, {
+      session,
+      children: [],
+      detached: false,
+      cycle: false,
+    });
   }
 
   const roots: AgentTopologyNode[] = [];
@@ -179,6 +198,25 @@ export function agentMatchesFilter(
     (!isPausedAgent(session) && session.status === "failed") ||
     session.children.failedDescendants > 0
   );
+}
+
+/** Whether expanding this node can reveal a descendant selected by the current filter. */
+export function agentHasMatchingDescendants(
+  session: AgentTopologySession,
+  filter: AgentTopologyFilter,
+): boolean {
+  if (filter === "all") return session.children.directChildren > 0;
+  if (filter === "active") {
+    return (
+      session.children.runningDescendants +
+        session.children.queuedDescendants +
+        session.children.attentionDescendants >
+      0
+    );
+  }
+  if (filter === "attention") return session.children.attentionDescendants > 0;
+  if (filter === "paused") return session.children.pausedDescendants > 0;
+  return session.children.failedDescendants > 0;
 }
 
 /** Keep ancestors of matching nodes so filtered results retain their branch context. */

--- a/apps/web/src/lib/agent-topology.ts
+++ b/apps/web/src/lib/agent-topology.ts
@@ -103,6 +103,23 @@ export function mergeAgentTopologySessions(
   return [...sessions.values()];
 }
 
+export function canStartAgentTopologyRootRead(requestInFlight: boolean): boolean {
+  return !requestInFlight;
+}
+
+export function selectAgentTopologyBranchesToLoad(
+  candidates: string[],
+  loadedBranches: ReadonlySet<string>,
+  inFlightBranches: ReadonlySet<string>,
+  maxConcurrency: number,
+): string[] {
+  const available = Math.max(0, maxConcurrency - inFlightBranches.size);
+  if (available === 0) return [];
+  return candidates
+    .filter((id) => !loadedBranches.has(id) && !inFlightBranches.has(id))
+    .slice(0, available);
+}
+
 function compareAgentSessions(left: AgentTopologySession, right: AgentTopologySession): number {
   const activeDelta = Number(isActiveAgent(right)) - Number(isActiveAgent(left));
   if (activeDelta !== 0) return activeDelta;

--- a/apps/web/src/routes/agents.tsx
+++ b/apps/web/src/routes/agents.tsx
@@ -27,6 +27,7 @@ import { useAppContext } from "@/context";
 import {
   AGENT_DIAGRAM_NODE_HEIGHT,
   AGENT_DIAGRAM_NODE_WIDTH,
+  agentHasMatchingDescendants,
   buildAgentTopology,
   countTopologyDescendants,
   filterAgentTopology,
@@ -34,17 +35,20 @@ import {
   isPausedAgent,
   layoutAgentTopologyDiagram,
   limitAgentTopology,
+  mergeAgentTopologySessions,
   summarizeAgentTopology,
   type AgentTopologyFilter,
   type AgentTopologyNode,
 } from "@/lib/agent-topology";
 import { relativeTimeLabel } from "@/lib/sessions-group";
 import { cn } from "@/lib/utils";
-import type { AgentTopologySession } from "@opengeni/sdk";
+import { OpenGeniApiError, type AgentTopologySession } from "@opengeni/sdk";
 
 const ROOT_PAGE_LIMIT = 25;
+const CHILD_PAGE_LIMIT = 100;
 const MAX_LOADED_AGENTS = 200;
 const MAX_RENDERED_AGENTS = 200;
+const AUTO_EXPAND_CONCURRENCY = 4;
 
 type AgentTopologyView = "outline" | "diagram";
 
@@ -52,6 +56,7 @@ type AgentTopologyData = {
   sessions: AgentTopologySession[];
   loading: boolean;
   refreshing: boolean;
+  loadingMore: boolean;
   total: number;
   hasMore: boolean;
   nextCursor: string | null;
@@ -70,6 +75,7 @@ const EMPTY_DATA: AgentTopologyData = {
   sessions: [],
   loading: true,
   refreshing: false,
+  loadingMore: false,
   total: 0,
   hasMore: false,
   nextCursor: null,
@@ -79,6 +85,9 @@ const EMPTY_DATA: AgentTopologyData = {
 export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
   const context = useAppContext();
   const requestSequence = useRef(0);
+  const dataGeneration = useRef(0);
+  const rootPageRequest = useRef<symbol | null>(null);
+  const branchRequests = useRef(new Map<string, symbol>());
   const [data, setData] = useState<AgentTopologyData>(EMPTY_DATA);
   const [branchPages, setBranchPages] = useState<ReadonlyMap<string, AgentTopologyBranchPage>>(
     () => new Map(),
@@ -86,17 +95,21 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
   const [filter, setFilter] = useState<AgentTopologyFilter>("active");
   const [query, setQuery] = useState("");
   const [view, setView] = useState<AgentTopologyView>("outline");
-  const [maxDepth, setMaxDepth] = useState<number | null>(3);
-  const [maxChildren, setMaxChildren] = useState<number | null>(5);
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
+  const [manuallyCollapsed, setManuallyCollapsed] = useState<ReadonlySet<string>>(() => new Set());
 
   const refresh = useCallback(
     async (cursor?: string) => {
-      const request = ++requestSequence.current;
+      const generation = dataGeneration.current;
+      const loadingMore = !!cursor;
+      if (loadingMore && rootPageRequest.current) return;
+      const request = loadingMore ? Symbol("root-page") : ++requestSequence.current;
+      if (loadingMore) rootPageRequest.current = request as symbol;
       setData((current) => ({
         ...current,
         loading: !cursor && current.sessions.length === 0,
         refreshing: !cursor && current.sessions.length > 0,
+        loadingMore: loadingMore || current.loadingMore,
         error: null,
       }));
       try {
@@ -106,24 +119,25 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
           ...(cursor ? { cursor } : {}),
           ...(search ? { search } : { parentSessionId: null }),
         });
-        if (request !== requestSequence.current) return;
+        if (
+          generation !== dataGeneration.current ||
+          (!loadingMore && request !== requestSequence.current) ||
+          (loadingMore && rootPageRequest.current !== request)
+        )
+          return;
         setData((current) => {
-          const sessions = new Map<string, AgentTopologySession>();
-          if (cursor) {
-            for (const session of current.sessions) sessions.set(session.id, session);
-          } else if (!search) {
-            for (const session of current.sessions) {
-              if (session.parentSessionId !== null) sessions.set(session.id, session);
-            }
-          }
-          for (const session of page.sessions) {
-            if (sessions.size >= MAX_LOADED_AGENTS && !sessions.has(session.id)) break;
-            sessions.set(session.id, session);
-          }
+          // Keep already paged roots during the 15-second first-page refresh.
+          // Query/workspace changes reset the collection before starting a new
+          // generation, so preserving here cannot mix different result sets.
           return {
-            sessions: [...sessions.values()],
+            sessions: mergeAgentTopologySessions(
+              current.sessions,
+              page.sessions,
+              MAX_LOADED_AGENTS,
+            ),
             loading: false,
             refreshing: false,
+            loadingMore: loadingMore ? false : current.loadingMore,
             total: page.total,
             hasMore: page.hasMore,
             nextCursor: page.nextCursor,
@@ -135,21 +149,33 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
           setBranchPages(new Map());
         }
       } catch (error) {
-        if (request !== requestSequence.current) return;
+        if (
+          generation !== dataGeneration.current ||
+          (!loadingMore && request !== requestSequence.current) ||
+          (loadingMore && rootPageRequest.current !== request)
+        )
+          return;
         setData((current) => ({
           ...current,
           loading: false,
           refreshing: false,
+          loadingMore: loadingMore ? false : current.loadingMore,
           error: error instanceof Error ? error : new Error(String(error)),
         }));
+      } finally {
+        if (loadingMore && rootPageRequest.current === request) rootPageRequest.current = null;
       }
     },
     [context.client, query, workspaceId],
   );
 
   useEffect(() => {
+    dataGeneration.current += 1;
+    rootPageRequest.current = null;
+    branchRequests.current.clear();
     setData(EMPTY_DATA);
     setExpanded(new Set());
+    setManuallyCollapsed(new Set());
     setBranchPages(new Map());
     const start = window.setTimeout(() => void refresh(), query.trim() ? 250 : 0);
     const interval = query.trim() ? undefined : window.setInterval(() => void refresh(), 15_000);
@@ -162,8 +188,12 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
 
   const loadChildren = useCallback(
     async (parentSessionId: string, cursor?: string) => {
+      if (branchRequests.current.has(parentSessionId)) return;
       const remaining = MAX_LOADED_AGENTS - data.sessions.length;
       if (remaining <= 0) return;
+      const generation = dataGeneration.current;
+      const request = Symbol(parentSessionId);
+      branchRequests.current.set(parentSessionId, request);
       setBranchPages((current) =>
         new Map(current).set(parentSessionId, {
           ...(current.get(parentSessionId) ?? {
@@ -177,18 +207,32 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
         }),
       );
       try {
-        const page = await context.client.listAgentTopology(workspaceId, {
-          parentSessionId,
-          limit: Math.min(remaining, maxChildren ?? 25),
-          ...(cursor ? { cursor } : {}),
-        });
+        const read = () =>
+          context.client.listAgentTopology(workspaceId, {
+            parentSessionId,
+            limit: Math.min(remaining, CHILD_PAGE_LIMIT),
+            ...(cursor ? { cursor } : {}),
+          });
+        const page = await readAgentTopologyWithRetry(
+          read,
+          () =>
+            generation === dataGeneration.current &&
+            branchRequests.current.get(parentSessionId) === request,
+        );
+        if (
+          generation !== dataGeneration.current ||
+          branchRequests.current.get(parentSessionId) !== request
+        )
+          return;
         setData((current) => {
-          const sessions = new Map(current.sessions.map((session) => [session.id, session]));
-          for (const session of page.sessions) {
-            if (sessions.size >= MAX_LOADED_AGENTS && !sessions.has(session.id)) break;
-            sessions.set(session.id, session);
-          }
-          return { ...current, sessions: [...sessions.values()] };
+          return {
+            ...current,
+            sessions: mergeAgentTopologySessions(
+              current.sessions,
+              page.sessions,
+              MAX_LOADED_AGENTS,
+            ),
+          };
         });
         setBranchPages((current) =>
           new Map(current).set(parentSessionId, {
@@ -200,6 +244,11 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
           }),
         );
       } catch (error) {
+        if (
+          generation !== dataGeneration.current ||
+          branchRequests.current.get(parentSessionId) !== request
+        )
+          return;
         setBranchPages((current) =>
           new Map(current).set(parentSessionId, {
             ...(current.get(parentSessionId) ?? {
@@ -211,9 +260,13 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
             error: error instanceof Error ? error : new Error(String(error)),
           }),
         );
+      } finally {
+        if (branchRequests.current.get(parentSessionId) === request) {
+          branchRequests.current.delete(parentSessionId);
+        }
       }
     },
-    [context.client, data.sessions.length, maxChildren, workspaceId],
+    [context.client, data.sessions.length, workspaceId],
   );
 
   const forest = useMemo(() => buildAgentTopology(data.sessions), [data.sessions]);
@@ -221,14 +274,22 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
   const limitedTopology = useMemo(
     () =>
       limitAgentTopology(filteredForest, {
-        maxDepth,
-        maxChildren,
+        maxDepth: null,
+        maxChildren: null,
         maxNodes: MAX_RENDERED_AGENTS,
       }),
-    [filteredForest, maxChildren, maxDepth],
+    [filteredForest],
   );
   const visibleForest = limitedTopology.roots;
   const summary = useMemo(() => summarizeAgentTopology(data.sessions), [data.sessions]);
+  const loadedChildrenByParent = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const session of data.sessions) {
+      if (!session.parentSessionId) continue;
+      counts.set(session.parentSessionId, (counts.get(session.parentSessionId) ?? 0) + 1);
+    }
+    return counts;
+  }, [data.sessions]);
   const collapsed = useMemo(
     () =>
       new Set(
@@ -240,6 +301,12 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
   );
   const toggleCollapsed = (sessionId: string) => {
     const willExpand = !expanded.has(sessionId);
+    setManuallyCollapsed((current) => {
+      const next = new Set(current);
+      if (willExpand) next.delete(sessionId);
+      else next.add(sessionId);
+      return next;
+    });
     setExpanded((current) => {
       const next = new Set(current);
       if (next.has(sessionId)) next.delete(sessionId);
@@ -248,6 +315,46 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
     });
     if (willExpand && !branchPages.has(sessionId)) void loadChildren(sessionId);
   };
+
+  // The ordinary view opens the matching workstreams for the user. Fetches
+  // remain bounded and branch-local, but descendants no longer appear absent
+  // until every root is manually expanded.
+  useEffect(() => {
+    if (query.trim() || data.loading || data.sessions.length >= MAX_LOADED_AGENTS) return;
+    const candidates: string[] = [];
+    const visit = (nodes: AgentTopologyNode[]) => {
+      for (const node of nodes) {
+        if (
+          agentHasMatchingDescendants(node.session, filter) &&
+          !manuallyCollapsed.has(node.session.id)
+        ) {
+          candidates.push(node.session.id);
+        }
+        visit(node.children);
+      }
+    };
+    visit(filteredForest);
+    if (candidates.length === 0) return;
+    setExpanded((current) => {
+      const next = new Set(current);
+      for (const sessionId of candidates) next.add(sessionId);
+      return next;
+    });
+    for (const sessionId of candidates
+      .filter((id) => !branchPages.has(id) && !branchRequests.current.has(id))
+      .slice(0, AUTO_EXPAND_CONCURRENCY)) {
+      void loadChildren(sessionId);
+    }
+  }, [
+    branchPages,
+    data.loading,
+    data.sessions.length,
+    filter,
+    filteredForest,
+    loadChildren,
+    manuallyCollapsed,
+    query,
+  ]);
 
   return (
     <ContentPage width="wide" className="gap-5" data-agent-topology>
@@ -289,12 +396,6 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
         <div className="flex min-w-0 flex-col gap-3 border-b border-border px-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-4">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <AgentViewToggle value={view} onChange={setView} />
-            <TopologyLimitControls
-              maxDepth={maxDepth}
-              maxChildren={maxChildren}
-              onMaxDepthChange={setMaxDepth}
-              onMaxChildrenChange={setMaxChildren}
-            />
             <div
               className="flex min-w-0 flex-wrap items-center gap-1"
               role="group"
@@ -354,14 +455,6 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
           </span>
         </div>
 
-        {data.hasMore || data.sessions.length >= MAX_LOADED_AGENTS ? (
-          <div className="mx-3 rounded-md border border-status-waiting/30 bg-status-waiting/10 px-3 py-2 text-xs text-status-waiting">
-            The browser keeps at most {MAX_LOADED_AGENTS} agents in memory. Expand only the branches
-            you need; omitted descendant counts remain server-authored
-            {data.hasMore ? ", and more roots are available" : ""}.
-          </div>
-        ) : null}
-
         <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-4 sm:px-4">
           {data.loading ? (
             <AgentTreeSkeleton />
@@ -392,6 +485,8 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
                   onToggle={toggleCollapsed}
                   hiddenByParent={limitedTopology.hiddenByParent}
                   branchPages={branchPages}
+                  loadedChildrenByParent={loadedChildrenByParent}
+                  canLoadMore={data.sessions.length < MAX_LOADED_AGENTS}
                   onLoadMore={(parentSessionId, cursor) =>
                     void loadChildren(parentSessionId, cursor)
                   }
@@ -402,9 +497,11 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
                   variant="outline"
                   size="sm"
                   onClick={() => void refresh(data.nextCursor ?? undefined)}
-                  disabled={data.loading || data.refreshing}
+                  disabled={data.loading || data.refreshing || data.loadingMore}
                 >
-                  Load more {query.trim() ? "matches" : "root agents"}
+                  {data.loadingMore
+                    ? "Loading more agents…"
+                    : `Load more ${query.trim() ? "matches" : "agents"}`}
                 </Button>
               ) : null}
             </div>
@@ -456,53 +553,6 @@ function AgentViewToggle({
           {label}
         </button>
       ))}
-    </div>
-  );
-}
-
-function TopologyLimitControls({
-  maxDepth,
-  maxChildren,
-  onMaxDepthChange,
-  onMaxChildrenChange,
-}: {
-  maxDepth: number | null;
-  maxChildren: number | null;
-  onMaxDepthChange: (value: number | null) => void;
-  onMaxChildrenChange: (value: number | null) => void;
-}) {
-  return (
-    <div className="flex items-center gap-1.5" aria-label="Topology display limits">
-      <label>
-        <span className="sr-only">Maximum nested depth</span>
-        <select
-          value={maxDepth ?? "all"}
-          onChange={(event) =>
-            onMaxDepthChange(event.target.value === "all" ? null : Number(event.target.value))
-          }
-          className="h-8 rounded-md border border-border bg-surface/50 px-2 text-xs text-fg outline-none focus-visible:border-brand/50"
-        >
-          <option value="2">Depth 2</option>
-          <option value="3">Depth 3</option>
-          <option value="5">Depth 5</option>
-          <option value="all">Any depth</option>
-        </select>
-      </label>
-      <label>
-        <span className="sr-only">Maximum children per agent</span>
-        <select
-          value={maxChildren ?? "all"}
-          onChange={(event) =>
-            onMaxChildrenChange(event.target.value === "all" ? null : Number(event.target.value))
-          }
-          className="h-8 rounded-md border border-border bg-surface/50 px-2 text-xs text-fg outline-none focus-visible:border-brand/50"
-        >
-          <option value="5">5 per agent</option>
-          <option value="10">10 per agent</option>
-          <option value="25">25 per agent</option>
-          <option value="all">All children</option>
-        </select>
-      </label>
     </div>
   );
 }
@@ -695,6 +745,8 @@ function AgentBranch({
   onToggle,
   hiddenByParent,
   branchPages,
+  loadedChildrenByParent,
+  canLoadMore,
   onLoadMore,
 }: {
   node: AgentTopologyNode;
@@ -704,6 +756,8 @@ function AgentBranch({
   onToggle: (sessionId: string) => void;
   hiddenByParent: ReadonlyMap<string, number>;
   branchPages: ReadonlyMap<string, AgentTopologyBranchPage>;
+  loadedChildrenByParent: ReadonlyMap<string, number>;
+  canLoadMore: boolean;
   onLoadMore: (parentSessionId: string, cursor: string) => void;
 }) {
   const hasChildren = node.session.children.directChildren > 0 || node.children.length > 0;
@@ -820,10 +874,12 @@ function AgentBranch({
               onToggle={onToggle}
               hiddenByParent={hiddenByParent}
               branchPages={branchPages}
+              loadedChildrenByParent={loadedChildrenByParent}
+              canLoadMore={canLoadMore}
               onLoadMore={onLoadMore}
             />
           ))}
-          {branchPage?.loading ? (
+          {!canLoadMore ? null : branchPage?.loading ? (
             <div className="px-2 py-1 text-xs text-fg-subtle">Loading children…</div>
           ) : branchPage?.error ? (
             <button
@@ -839,13 +895,34 @@ function AgentBranch({
               className="px-2 py-1 text-left text-xs text-fg-muted hover:text-fg hover:underline"
               onClick={() => onLoadMore(node.session.id, branchPage.nextCursor!)}
             >
-              Load more children
+              Load up to{" "}
+              {Math.min(
+                CHILD_PAGE_LIMIT,
+                Math.max(0, branchPage.total - (loadedChildrenByParent.get(node.session.id) ?? 0)),
+              ).toLocaleString()}{" "}
+              more children
             </button>
           ) : null}
         </div>
       ) : null}
     </div>
   );
+}
+
+async function readAgentTopologyWithRetry<T>(
+  read: () => Promise<T>,
+  isCurrent: () => boolean,
+): Promise<T> {
+  try {
+    return await read();
+  } catch (error) {
+    const retryable =
+      (error instanceof OpenGeniApiError && error.retryable) || error instanceof TypeError;
+    if (!retryable || !isCurrent()) throw error;
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    if (!isCurrent()) throw error;
+    return await read();
+  }
 }
 
 function agentStatus(session: AgentTopologySession): {
@@ -865,19 +942,44 @@ function agentStatus(session: AgentTopologySession): {
     return { label, tone: "idle", pulse: false, textClass: "text-fg-subtle" };
   }
   if (session.status === "running") {
-    return { label: "Running", tone: "running", pulse: true, textClass: "text-status-running" };
+    return {
+      label: "Running",
+      tone: "running",
+      pulse: true,
+      textClass: "text-status-running",
+    };
   }
   if (session.status === "queued") {
-    return { label: "Queued", tone: "queued", pulse: false, textClass: "text-status-queued" };
+    return {
+      label: "Queued",
+      tone: "queued",
+      pulse: false,
+      textClass: "text-status-queued",
+    };
   }
   if (session.status === "requires_action") {
-    return { label: "Needs you", tone: "waiting", pulse: false, textClass: "text-status-waiting" };
+    return {
+      label: "Needs you",
+      tone: "waiting",
+      pulse: false,
+      textClass: "text-status-waiting",
+    };
   }
   if (session.status === "failed") {
-    return { label: "Failed", tone: "failed", pulse: false, textClass: "text-status-failed" };
+    return {
+      label: "Failed",
+      tone: "failed",
+      pulse: false,
+      textClass: "text-status-failed",
+    };
   }
   if (session.status === "cancelled") {
-    return { label: "Cancelled", tone: "cancelled", pulse: false, textClass: "text-fg-subtle" };
+    return {
+      label: "Cancelled",
+      tone: "cancelled",
+      pulse: false,
+      textClass: "text-fg-subtle",
+    };
   }
   return {
     label: isActiveAgent(session) ? "Active" : "Idle",
@@ -905,18 +1007,16 @@ export function AgentTopologyPreviewRoute() {
   const sessions = useMemo(() => previewSessions(), []);
   const fullForest = useMemo(() => buildAgentTopology(sessions), [sessions]);
   const summary = useMemo(() => summarizeAgentTopology(sessions), [sessions]);
-  const [view, setView] = useState<AgentTopologyView>("diagram");
-  const [maxDepth, setMaxDepth] = useState<number | null>(3);
-  const [maxChildren, setMaxChildren] = useState<number | null>(5);
+  const [view, setView] = useState<AgentTopologyView>("outline");
   const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(() => new Set());
   const limitedTopology = useMemo(
     () =>
       limitAgentTopology(fullForest, {
-        maxDepth,
-        maxChildren,
+        maxDepth: null,
+        maxChildren: null,
         maxNodes: MAX_RENDERED_AGENTS,
       }),
-    [fullForest, maxChildren, maxDepth],
+    [fullForest],
   );
   const forest = limitedTopology.roots;
   const toggleCollapsed = (sessionId: string) => {
@@ -970,12 +1070,6 @@ export function AgentTopologyPreviewRoute() {
                 {limitedTopology.hiddenCount.toLocaleString()} summarized
               </span>
               <AgentViewToggle value={view} onChange={setView} />
-              <TopologyLimitControls
-                maxDepth={maxDepth}
-                maxChildren={maxChildren}
-                onMaxDepthChange={setMaxDepth}
-                onMaxChildrenChange={setMaxChildren}
-              />
             </div>
           </div>
           {view === "outline" ? (
@@ -990,6 +1084,8 @@ export function AgentTopologyPreviewRoute() {
                   onToggle={toggleCollapsed}
                   hiddenByParent={limitedTopology.hiddenByParent}
                   branchPages={new Map()}
+                  loadedChildrenByParent={new Map()}
+                  canLoadMore={false}
                   onLoadMore={() => {}}
                 />
               ))}

--- a/apps/web/src/routes/agents.tsx
+++ b/apps/web/src/routes/agents.tsx
@@ -29,6 +29,7 @@ import {
   AGENT_DIAGRAM_NODE_WIDTH,
   agentHasMatchingDescendants,
   buildAgentTopology,
+  canStartAgentTopologyRootRead,
   countTopologyDescendants,
   filterAgentTopology,
   isActiveAgent,
@@ -36,6 +37,7 @@ import {
   layoutAgentTopologyDiagram,
   limitAgentTopology,
   mergeAgentTopologySessions,
+  selectAgentTopologyBranchesToLoad,
   summarizeAgentTopology,
   type AgentTopologyFilter,
   type AgentTopologyNode,
@@ -84,9 +86,8 @@ const EMPTY_DATA: AgentTopologyData = {
 
 export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
   const context = useAppContext();
-  const requestSequence = useRef(0);
   const dataGeneration = useRef(0);
-  const rootPageRequest = useRef<symbol | null>(null);
+  const rootRequest = useRef<symbol | null>(null);
   const branchRequests = useRef(new Map<string, symbol>());
   const [data, setData] = useState<AgentTopologyData>(EMPTY_DATA);
   const [branchPages, setBranchPages] = useState<ReadonlyMap<string, AgentTopologyBranchPage>>(
@@ -102,9 +103,9 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
     async (cursor?: string) => {
       const generation = dataGeneration.current;
       const loadingMore = !!cursor;
-      if (loadingMore && rootPageRequest.current) return;
-      const request = loadingMore ? Symbol("root-page") : ++requestSequence.current;
-      if (loadingMore) rootPageRequest.current = request as symbol;
+      if (!canStartAgentTopologyRootRead(rootRequest.current !== null)) return;
+      const request = Symbol(loadingMore ? "root-page" : "root-refresh");
+      rootRequest.current = request;
       setData((current) => ({
         ...current,
         loading: !cursor && current.sessions.length === 0,
@@ -119,12 +120,7 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
           ...(cursor ? { cursor } : {}),
           ...(search ? { search } : { parentSessionId: null }),
         });
-        if (
-          generation !== dataGeneration.current ||
-          (!loadingMore && request !== requestSequence.current) ||
-          (loadingMore && rootPageRequest.current !== request)
-        )
-          return;
+        if (generation !== dataGeneration.current || rootRequest.current !== request) return;
         setData((current) => {
           // Keep already paged roots during the 15-second first-page refresh.
           // Query/workspace changes reset the collection before starting a new
@@ -149,12 +145,7 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
           setBranchPages(new Map());
         }
       } catch (error) {
-        if (
-          generation !== dataGeneration.current ||
-          (!loadingMore && request !== requestSequence.current) ||
-          (loadingMore && rootPageRequest.current !== request)
-        )
-          return;
+        if (generation !== dataGeneration.current || rootRequest.current !== request) return;
         setData((current) => ({
           ...current,
           loading: false,
@@ -163,7 +154,7 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
           error: error instanceof Error ? error : new Error(String(error)),
         }));
       } finally {
-        if (loadingMore && rootPageRequest.current === request) rootPageRequest.current = null;
+        if (rootRequest.current === request) rootRequest.current = null;
       }
     },
     [context.client, query, workspaceId],
@@ -171,7 +162,7 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
 
   useEffect(() => {
     dataGeneration.current += 1;
-    rootPageRequest.current = null;
+    rootRequest.current = null;
     branchRequests.current.clear();
     setData(EMPTY_DATA);
     setExpanded(new Set());
@@ -180,7 +171,6 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
     const start = window.setTimeout(() => void refresh(), query.trim() ? 250 : 0);
     const interval = query.trim() ? undefined : window.setInterval(() => void refresh(), 15_000);
     return () => {
-      requestSequence.current += 1;
       window.clearTimeout(start);
       if (interval !== undefined) window.clearInterval(interval);
     };
@@ -340,9 +330,12 @@ export function AgentsRoute({ workspaceId }: { workspaceId: string }) {
       for (const sessionId of candidates) next.add(sessionId);
       return next;
     });
-    for (const sessionId of candidates
-      .filter((id) => !branchPages.has(id) && !branchRequests.current.has(id))
-      .slice(0, AUTO_EXPAND_CONCURRENCY)) {
+    for (const sessionId of selectAgentTopologyBranchesToLoad(
+      candidates,
+      new Set(branchPages.keys()),
+      new Set(branchRequests.current.keys()),
+      AUTO_EXPAND_CONCURRENCY,
+    )) {
       void loadChildren(sessionId);
     }
   }, [


### PR DESCRIPTION
## Summary

- Automatically expand and lazy-load matching Active agent branches so child work is visible by default.
- Remove the depth and children selectors plus the technical browser-memory warning.
- Make child and root pagination single-flight, progress-truthful, retryable, and stable across refreshes.

## Verification

- `bun test apps/web/src/lib/agent-topology.test.ts` (10 passed)
- `bun run --cwd apps/web typecheck`
- `bun run lint`
- `bun run format:check -- apps/web/src/routes/agents.tsx apps/web/src/lib/agent-topology.ts apps/web/src/lib/agent-topology.test.ts`
- `bun run --cwd apps/web build`
- Browser harness: 200 tree items rendered, collapse/expand restored 1/200 items, Depth 1 and Depth 2 children visible, Outline/Tree switch verified, no obsolete selectors or technical warning, and no warning/error logs.

Linear: OPE-189