### PR TITLE
Route Codemode through every execution placement

### DIFF
--- a/agent/crates/opengeni-agent/src/codemode.rs
+++ b/agent/crates/opengeni-agent/src/codemode.rs
@@ -16,7 +16,7 @@ use tokio::time::{sleep, Instant};
 use uuid::Uuid;
 
 use crate::cli::{CodemodeAction, CodemodeArgs, CodemodeCallArgs};
-use opengeni_agent_proto::v1::ExecRequest;
+use opengeni_agent_proto::v1::{self, ControlRequest, ExecRequest};
 
 const URL_ENV: &str = "OPENGENI_CODEMODE_URL";
 const TOKEN_ENV: &str = "OPENGENI_CODEMODE_TOKEN";
@@ -45,6 +45,46 @@ pub fn expose_native_client(request: &mut ExecRequest) {
         request
             .env
             .insert(NATIVE_CLIENT_ENV.to_string(), executable.to_string());
+    }
+}
+
+/// Bind an attempt-scoped Codemode exec to the deployment origin of the exact
+/// Connected Machine link carrying it. The control plane cannot safely infer
+/// this route: one runner may serve several deployments, while `localhost` has
+/// a different meaning on each host. A legacy connection has no authoritative
+/// origin and therefore never calls this function.
+pub fn bind_connection_origin(
+    request: &mut ControlRequest,
+    api_base_url: &str,
+    workspace_id: &str,
+) {
+    let Some(exec) = request_exec_mut(request) else {
+        return;
+    };
+    if !exec.env.contains_key(TOKEN_ENV) {
+        return;
+    }
+    let Ok(mut url) = Url::parse(api_base_url) else {
+        return;
+    };
+    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+        return;
+    }
+    let prefix = url.path().trim_end_matches('/');
+    url.set_path(&format!("{prefix}/v1/workspaces/{workspace_id}/codemode"));
+    url.set_query(None);
+    url.set_fragment(None);
+    exec.env.insert(URL_ENV.to_string(), url.to_string());
+}
+
+fn request_exec_mut(request: &mut ControlRequest) -> Option<&mut ExecRequest> {
+    match request.op.as_mut()? {
+        v1::control_request::Op::Exec(exec) => Some(exec),
+        v1::control_request::Op::OpStart(start) => match start.op.as_mut()? {
+            v1::op_start::Op::Exec(exec) => Some(exec),
+            _ => None,
+        },
+        _ => None,
     }
 }
 
@@ -614,6 +654,89 @@ mod tests {
         let executable = ordinary.env.get(NATIVE_CLIENT_ENV).expect("native client");
         assert!(std::path::Path::new(executable).is_absolute());
         assert!(!executable.contains("attempt-secret"));
+    }
+
+    #[test]
+    fn connected_machine_exec_uses_the_exact_link_origin() {
+        let mut exec = ExecRequest::default();
+        exec.env.insert(
+            URL_ENV.to_string(),
+            "http://127.0.0.1:8000/stale".to_string(),
+        );
+        exec.env
+            .insert(TOKEN_ENV.to_string(), "attempt-secret".to_string());
+        let mut request = ControlRequest {
+            op: Some(v1::control_request::Op::Exec(exec)),
+            ..ControlRequest::default()
+        };
+
+        bind_connection_origin(
+            &mut request,
+            "https://machine.example.test/opengeni/",
+            "workspace-1",
+        );
+
+        let Some(v1::control_request::Op::Exec(exec)) = request.op else {
+            panic!("exec request");
+        };
+        assert_eq!(
+            exec.env.get(URL_ENV).map(String::as_str),
+            Some("https://machine.example.test/opengeni/v1/workspaces/workspace-1/codemode")
+        );
+    }
+
+    #[test]
+    fn connected_machine_origin_is_not_projected_without_attempt_authority() {
+        let mut exec = ExecRequest::default();
+        exec.env.insert(
+            URL_ENV.to_string(),
+            "https://worker.example.test/codemode".to_string(),
+        );
+        let mut request = ControlRequest {
+            op: Some(v1::control_request::Op::Exec(exec)),
+            ..ControlRequest::default()
+        };
+
+        bind_connection_origin(&mut request, "https://machine.example.test", "workspace-1");
+
+        let Some(v1::control_request::Op::Exec(exec)) = request.op else {
+            panic!("exec request");
+        };
+        assert_eq!(
+            exec.env.get(URL_ENV).map(String::as_str),
+            Some("https://worker.example.test/codemode")
+        );
+    }
+
+    #[test]
+    fn connected_machine_streamed_exec_uses_the_exact_link_origin() {
+        let mut exec = ExecRequest::default();
+        exec.env
+            .insert(TOKEN_ENV.to_string(), "attempt-secret".to_string());
+        let mut request = ControlRequest {
+            op: Some(v1::control_request::Op::OpStart(v1::OpStart {
+                op: Some(v1::op_start::Op::Exec(exec)),
+                ..v1::OpStart::default()
+            })),
+            ..ControlRequest::default()
+        };
+
+        bind_connection_origin(
+            &mut request,
+            "https://machine.example.test/opengeni",
+            "workspace-1",
+        );
+
+        let Some(v1::control_request::Op::OpStart(start)) = request.op else {
+            panic!("op start request");
+        };
+        let Some(v1::op_start::Op::Exec(exec)) = start.op else {
+            panic!("streamed exec request");
+        };
+        assert_eq!(
+            exec.env.get(URL_ENV).map(String::as_str),
+            Some("https://machine.example.test/opengeni/v1/workspaces/workspace-1/codemode")
+        );
     }
 
     #[tokio::test]

--- a/agent/crates/opengeni-agent/src/main.rs
+++ b/agent/crates/opengeni-agent/src/main.rs
@@ -464,7 +464,13 @@ fn supervisor_links(
                 allow_screen_control: credentials.consented_screen_control,
             });
             let link_platform = Arc::new(platform.clone().with_stream_registry(Arc::new(hub)));
-            SupervisorLink::new(connection.connection_id.clone(), link_platform, credentials)
+            let link =
+                SupervisorLink::new(connection.connection_id.clone(), link_platform, credentials);
+            if connection.legacy_origin {
+                link
+            } else {
+                link.with_api_url(connection.api_url.clone())
+            }
         })
         .collect()
 }

--- a/agent/crates/opengeni-agent/src/supervisor.rs
+++ b/agent/crates/opengeni-agent/src/supervisor.rs
@@ -254,6 +254,8 @@ pub struct SupervisorLink<P: Platform> {
     pub platform: Arc<P>,
     /// Workspace-scoped control-plane credentials.
     pub credentials: StoredCredentials,
+    /// Authoritative deployment origin persisted by a non-legacy enrollment.
+    pub api_url: Option<String>,
 }
 
 impl<P: Platform> Clone for SupervisorLink<P> {
@@ -262,6 +264,7 @@ impl<P: Platform> Clone for SupervisorLink<P> {
             connection_id: self.connection_id.clone(),
             platform: self.platform.clone(),
             credentials: self.credentials.clone(),
+            api_url: self.api_url.clone(),
         }
     }
 }
@@ -278,7 +281,15 @@ impl<P: Platform> SupervisorLink<P> {
             connection_id: connection_id.into(),
             platform,
             credentials,
+            api_url: None,
         }
+    }
+
+    /// Attach the deployment origin that this exact link enrolled against.
+    #[must_use]
+    pub fn with_api_url(mut self, api_url: impl Into<String>) -> Self {
+        self.api_url = Some(api_url.into());
+        self
     }
 }
 
@@ -288,6 +299,7 @@ struct WorkspaceLink<P: Platform> {
     connection_id: String,
     platform: Arc<P>,
     creds: StoredCredentials,
+    api_url: Option<String>,
     epoch: Arc<EpochCell>,
     shutdown: ShutdownSignal,
     /// The CURRENT generation's bulk frame channel (op-frame publishes ride a
@@ -304,6 +316,7 @@ impl<P: Platform> WorkspaceLink<P> {
             connection_id: definition.connection_id,
             platform: definition.platform,
             creds: definition.credentials,
+            api_url: definition.api_url,
             epoch: Arc::new(EpochCell::default()),
             shutdown: ShutdownSignal::default(),
             bulk_tx: Arc::new(std::sync::RwLock::new(None)),
@@ -847,7 +860,7 @@ impl<P: Platform + 'static> Supervisor<P> {
             return;
         };
         let max_payload = client.server_info().max_payload;
-        let request = match ControlRequest::decode(message.payload.as_ref()) {
+        let mut request = match ControlRequest::decode(message.payload.as_ref()) {
             Ok(request) => request,
             Err(decode_error) => {
                 error!(error = %decode_error, "undecodable ControlRequest");
@@ -862,6 +875,13 @@ impl<P: Platform + 'static> Supervisor<P> {
                 return;
             }
         };
+        if let Some(api_url) = link.api_url.as_deref() {
+            crate::codemode::bind_connection_origin(
+                &mut request,
+                api_url,
+                &link.creds.workspace_id,
+            );
+        }
         let request_id = request.request_id.clone();
         let label = op_label(&request);
         match classify(&request) {

--- a/apps/worker/test/codemode-token.test.ts
+++ b/apps/worker/test/codemode-token.test.ts
@@ -91,7 +91,7 @@ describe("codemode token mint and sandbox delivery pointers", () => {
       "/workspace/.opengeni/codemode-token",
     );
     expect(result.environment.OPENGENI_CODEMODE_URL).toBe(
-      `http://127.0.0.1:8000/v1/workspaces/${workspaceId}/codemode`,
+      `http://127.0.0.1:3000/v1/workspaces/${workspaceId}/codemode`,
     );
     expect(Object.values(result.environment)).not.toContain(result.codemodeToken);
 
@@ -177,5 +177,25 @@ describe("codemode token mint and sandbox delivery pointers", () => {
       `https://app.opengeni.example/v1/workspaces/${workspaceId}/codemode`,
     );
     expect(result.environment.OPENGENI_CODEMODE_URL).not.toContain("127.0.0.1");
+  });
+
+  test("remote managed sandboxes default to the deployment public origin", async () => {
+    const result = await sandboxEnvironmentForRun(
+      testSettings({
+        sandboxBackend: "modal",
+        delegationSecret: "codemode-secret",
+        publicBaseUrl: "https://app.opengeni.example/",
+      }),
+      [],
+      {},
+      {
+        scope: { accountId, workspaceId },
+        codemodeAuthority: authority,
+      },
+    );
+
+    expect(result.environment.OPENGENI_CODEMODE_URL).toBe(
+      `https://app.opengeni.example/v1/workspaces/${workspaceId}/codemode`,
+    );
   });
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4612,11 +4612,30 @@ export function firstPartyMcpWorkspaceUrl(settings: Settings, workspaceId: strin
 }
 
 export function codemodeWorkspaceUrl(settings: Settings, workspaceId: string): string {
-  const url = new URL(firstPartyMcpWorkspaceUrl(settings, workspaceId));
-  if (!url.pathname.endsWith("/mcp")) {
-    throw new Error("First-party MCP URL cannot be projected to the Codemode endpoint");
+  if (settings.opengeniMcpUrl) {
+    const url = new URL(firstPartyMcpWorkspaceUrl(settings, workspaceId));
+    if (!url.pathname.endsWith("/mcp")) {
+      throw new Error("First-party MCP URL cannot be projected to the Codemode endpoint");
+    }
+    url.pathname = `${url.pathname.slice(0, -4)}/codemode`;
+    return url.toString();
   }
-  url.pathname = `${url.pathname.slice(0, -4)}/codemode`;
+
+  // Codemode executes inside the selected placement, not beside the worker.
+  // Local Docker reaches the host through Docker's canonical host alias; an
+  // in-process local sandbox uses loopback; remote managed providers use the
+  // deployment's public origin. `OPENGENI_MCP_URL` above remains the explicit
+  // escape hatch for mounted deployments and local remote-provider tunnels.
+  const executionOrigin =
+    settings.sandboxBackend === "docker"
+      ? `http://host.docker.internal:${settings.apiPort}`
+      : settings.sandboxBackend === "local"
+        ? `http://127.0.0.1:${settings.apiPort}`
+        : (settings.publicBaseUrl ?? `http://127.0.0.1:${settings.apiPort}`);
+  const url = new URL(executionOrigin);
+  url.pathname = `${url.pathname.replace(/\/+$/u, "")}/v1/workspaces/${workspaceId}/codemode`;
+  url.search = "";
+  url.hash = "";
   return url.toString();
 }
 

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -915,7 +915,7 @@ describe("sandbox preparation profiles", () => {
     expect(local.ogtoolPackageSpec).toBeUndefined();
     expect(stableSandboxEnvironmentForRun(local, {}, { workspaceId: "ws-1" })).toMatchObject({
       OPENGENI_CODEMODE_TOKEN_FILE: "/workspace/.opengeni/codemode-token",
-      OPENGENI_CODEMODE_URL: "http://127.0.0.1:8000/v1/workspaces/ws-1/codemode",
+      OPENGENI_CODEMODE_URL: "http://host.docker.internal:8000/v1/workspaces/ws-1/codemode",
     });
 
     const configured = withEnv(
@@ -930,7 +930,7 @@ describe("sandbox preparation profiles", () => {
     expect(configured.codemodeMaxCallsPerTurn).toBe(17);
     expect(stableSandboxEnvironmentForRun(configured, {}, { workspaceId: "ws-1" })).toMatchObject({
       OPENGENI_CODEMODE_TOKEN_FILE: "/workspace/.opengeni/codemode-token",
-      OPENGENI_CODEMODE_URL: "http://127.0.0.1:8000/v1/workspaces/ws-1/codemode",
+      OPENGENI_CODEMODE_URL: "http://host.docker.internal:8000/v1/workspaces/ws-1/codemode",
       OPENGENI_OGTOOL_PACKAGE_SPEC: "@opengeni/ogtool@0.1.0",
     });
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -5338,6 +5338,7 @@ export async function runAgentStream(
         : input;
   const environment = overrides.sandboxEnvironment ?? collectSandboxEnvironment(settings);
   const codemodeTokenFile = codemodeTokenFileForAgent(agent, environment);
+  const codemodeUrl = environment.OPENGENI_CODEMODE_URL;
   const genesisTitleInputFilter = takeGenesisTitleInputFilter(agent);
   if (overrides.onRunCredentialSessionReady && !overrides.runCredentialSessionId) {
     throw new Error("runCredentialSessionId is required when run credential setup is enabled");
@@ -5364,13 +5365,13 @@ export async function runAgentStream(
       ? withRunCredentialsSession(session as SandboxSessionLike, overrides.runCredentialSessionId)
       : (session as SandboxSessionLike);
     const agentSession = codemodeTokenFile
-      ? withCodemodeTokenSession(credentialAgentSession, codemodeTokenFile)
+      ? withCodemodeTokenSession(credentialAgentSession, codemodeTokenFile, codemodeUrl)
       : credentialAgentSession;
     const credentialSetupSession = overrides.runCredentialSessionId
       ? withRunCredentialsSession(setupSession, overrides.runCredentialSessionId)
       : setupSession;
     const decoratedSetupSession = codemodeTokenFile
-      ? withCodemodeTokenSession(credentialSetupSession, codemodeTokenFile)
+      ? withCodemodeTokenSession(credentialSetupSession, codemodeTokenFile, codemodeUrl)
       : credentialSetupSession;
     // Platform setup (manifest-env pin + beforeAgentStart hooks + file downloads)
     // against the UN-proxied established box — the ONE-TRUTH helper shared with the
@@ -5458,7 +5459,7 @@ export async function runAgentStream(
         )
       : resourceClient;
     const codemodeResourceClient = codemodeTokenFile
-      ? withCodemodeTokenClient(credentialResourceClient, codemodeTokenFile)
+      ? withCodemodeTokenClient(credentialResourceClient, codemodeTokenFile, codemodeUrl)
       : credentialResourceClient;
     const decoratedClient = withSandboxLifecycleHooks(
       codemodeResourceClient,
@@ -5536,7 +5537,7 @@ export async function runAgentStream(
       : resourceClient;
   const codemodeClient =
     credentialClient && codemodeTokenFile
-      ? withCodemodeTokenClient(credentialClient, codemodeTokenFile)
+      ? withCodemodeTokenClient(credentialClient, codemodeTokenFile, codemodeUrl)
       : credentialClient;
   // TOKEN-BROKER (B1): the per-turn git token seed, forwarded OFF-MANIFEST so the
   // repository-clone hook seeds it to the box's token file before the clone.

--- a/packages/runtime/src/sandbox/codemode-token.ts
+++ b/packages/runtime/src/sandbox/codemode-token.ts
@@ -73,13 +73,33 @@ export function codemodeTokenFileFromEnvironment(
   return codemodeTokenFileForSession(manifestTokenFile, sessionId);
 }
 
-/** Prefix one sandbox command with its session-specific Codemode pointer. */
-export function withCodemodeTokenEnvironment(cmd: string, tokenFile: string): string {
-  return [`export OPENGENI_CODEMODE_TOKEN_FILE=${shellCodemodePath(tokenFile)}`, cmd].join("\n");
+/**
+ * Prefix one sandbox command with its attempt-current Codemode routing.
+ *
+ * The token pointer is session-specific. The URL is deliberately projected on
+ * every exec too: a warm managed box keeps its baked manifest environment, but
+ * the externally reachable deployment/tunnel origin may change between turns.
+ * Per-command export makes a resumed box use the current route without an
+ * illegal live-manifest environment mutation.
+ */
+export function withCodemodeTokenEnvironment(
+  cmd: string,
+  tokenFile: string,
+  codemodeUrl?: string,
+): string {
+  return [
+    `export OPENGENI_CODEMODE_TOKEN_FILE=${shellCodemodePath(tokenFile)}`,
+    ...(codemodeUrl ? [`export OPENGENI_CODEMODE_URL=${shellQuote(codemodeUrl)}`] : []),
+    cmd,
+  ].join("\n");
 }
 
 /** Preserve provider identity/capabilities while decorating command creation. */
-export function withCodemodeTokenSession<T extends object>(session: T, tokenFile: string): T {
+export function withCodemodeTokenSession<T extends object>(
+  session: T,
+  tokenFile: string,
+  codemodeUrl?: string,
+): T {
   return new Proxy(session, {
     get(target, property, receiver) {
       if (property === "exec" || property === "execCommand") {
@@ -90,7 +110,7 @@ export function withCodemodeTokenSession<T extends object>(session: T, tokenFile
         return async (args: ExecCommandArgs) =>
           await command.call(target, {
             ...args,
-            cmd: withCodemodeTokenEnvironment(args.cmd, tokenFile),
+            cmd: withCodemodeTokenEnvironment(args.cmd, tokenFile, codemodeUrl),
           });
       }
       const value = Reflect.get(target, property, receiver) as unknown;
@@ -100,12 +120,16 @@ export function withCodemodeTokenSession<T extends object>(session: T, tokenFile
 }
 
 /** Decorate every client-created/resumed session with one session pointer. */
-export function withCodemodeTokenClient(client: SandboxClient, tokenFile: string): SandboxClient {
+export function withCodemodeTokenClient(
+  client: SandboxClient,
+  tokenFile: string,
+  codemodeUrl?: string,
+): SandboxClient {
   const decorated = new WeakMap<object, SandboxSessionLike>();
   const wrap = <T extends SandboxSessionLike>(session: T): T => {
     const existing = decorated.get(session);
     if (existing) return existing as T;
-    const wrapped = withCodemodeTokenSession(session, tokenFile);
+    const wrapped = withCodemodeTokenSession(session, tokenFile, codemodeUrl);
     decorated.set(session, wrapped);
     return wrapped;
   };

--- a/packages/runtime/test/codemode-session-pointer.test.ts
+++ b/packages/runtime/test/codemode-session-pointer.test.ts
@@ -74,6 +74,7 @@ describe("session-specific Codemode token pointers", () => {
 
   test("decorates client create/resume sessions and preserves lifecycle methods", async () => {
     const tokenFile = "/workspace/.opengeni/codemode-tokens/" + "a".repeat(64);
+    const codemodeUrl = "https://sandbox-route.example/v1/workspaces/ws/codemode";
     const commands: string[] = [];
     const rawSession = {
       exec: async (args: { cmd: string }) => {
@@ -111,7 +112,7 @@ describe("session-specific Codemode token pointers", () => {
         return { restored: true };
       },
     };
-    const client = withCodemodeTokenClient(rawClient as never, tokenFile) as any;
+    const client = withCodemodeTokenClient(rawClient as never, tokenFile, codemodeUrl) as any;
     const created = await client.create({});
     const resumed = await client.resume({});
 
@@ -119,8 +120,8 @@ describe("session-specific Codemode token pointers", () => {
     await created.exec({ cmd: "echo exec" });
     await created.execCommand({ cmd: "echo exec-command" });
     expect(commands).toEqual([
-      `export OPENGENI_CODEMODE_TOKEN_FILE='${tokenFile}'\necho exec`,
-      `export OPENGENI_CODEMODE_TOKEN_FILE='${tokenFile}'\necho exec-command`,
+      `export OPENGENI_CODEMODE_TOKEN_FILE='${tokenFile}'\nexport OPENGENI_CODEMODE_URL='${codemodeUrl}'\necho exec`,
+      `export OPENGENI_CODEMODE_TOKEN_FILE='${tokenFile}'\nexport OPENGENI_CODEMODE_URL='${codemodeUrl}'\necho exec-command`,
     ]);
     await client.delete({});
     await client.serializeSessionState({}, {});

--- a/scripts/dev-sandbox-edge.ts
+++ b/scripts/dev-sandbox-edge.ts
@@ -1,0 +1,51 @@
+import { createServer, request as upstreamRequest } from "node:http";
+
+const port = Number.parseInt(Bun.env.OPENGENI_SANDBOX_EDGE_PORT ?? "", 10);
+const api = new URL(Bun.env.OPENGENI_SANDBOX_EDGE_API_ORIGIN ?? "");
+const objects = new URL(Bun.env.OPENGENI_SANDBOX_EDGE_OBJECT_ORIGIN ?? "");
+
+if (!Number.isInteger(port) || port <= 0) {
+  throw new Error("OPENGENI_SANDBOX_EDGE_PORT must be a positive integer");
+}
+
+const server = createServer((incoming, outgoing) => {
+  const incomingUrl = new URL(incoming.url ?? "/", "http://opengeni.local");
+  if (incomingUrl.pathname === "/__opengeni_edge_health") {
+    outgoing.writeHead(200, { "content-type": "application/json" });
+    outgoing.end('{"ok":true}');
+    return;
+  }
+
+  const origin = /^\/v1(?:\/|$)/u.test(incomingUrl.pathname) ? api : objects;
+  const target = new URL(`${incomingUrl.pathname}${incomingUrl.search}`, origin);
+  const request = upstreamRequest(
+    target,
+    {
+      method: incoming.method,
+      // Preserve the public Host header. MinIO includes it in presigned-request
+      // verification; replacing it with loopback would invalidate every URL.
+      headers: incoming.headers,
+    },
+    (response) => {
+      outgoing.writeHead(response.statusCode ?? 502, response.headers);
+      response.pipe(outgoing);
+    },
+  );
+  request.on("error", (error) => {
+    if (!outgoing.headersSent) {
+      outgoing.writeHead(502, { "content-type": "application/json" });
+    }
+    outgoing.end(
+      JSON.stringify({ error: "development upstream unavailable", detail: error.message }),
+    );
+  });
+  incoming.pipe(request);
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`OpenGeni sandbox development edge listening on 127.0.0.1:${port}`);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -303,17 +303,15 @@ choose_port OPENGENI_TURN_WORKER_HTTP_PORT 8002
 choose_port OPENGENI_ARTIFACT_MATERIALIZER_HTTP_PORT 9465
 choose_port OPENGENI_ARTIFACT_OUTBOX_HTTP_PORT 9466
 choose_port OPENGENI_WEB_PORT 3000
+if [ "${OPENGENI_SANDBOX_BACKEND:-docker}" = "modal" ]; then
+  choose_port OPENGENI_SANDBOX_EDGE_PORT 10080
+fi
 if [ "${OPENGENI_SANDBOX_SELFHOSTED_ENABLED:-false}" = "true" ]; then
   choose_port OPENGENI_RELAY_HOST_PORT 8280
 fi
 
 pids=()
-owned_ngrok_tunnel_name=""
 cleanup() {
-  if [ -n "$owned_ngrok_tunnel_name" ]; then
-    curl -fsS -X DELETE "http://127.0.0.1:4040/api/tunnels/${owned_ngrok_tunnel_name}" \
-      >/dev/null 2>&1 || true
-  fi
   if [ "${#pids[@]}" -gt 0 ]; then
     kill "${pids[@]}" >/dev/null 2>&1 || true
   fi
@@ -484,68 +482,80 @@ if [ "${OPENGENI_SANDBOX_BACKEND:-docker}" = "modal" ]; then
     [ "$sandbox_object_host" = "localhost" ] ||
     [[ "$sandbox_object_host" = *.ngrok-free.app ]] ||
     [[ "$sandbox_object_host" = *.ngrok-free.dev ]] ||
-    [[ "$sandbox_object_host" = *.ngrok.io ]]; then
-    if ! command -v ngrok >/dev/null 2>&1; then
-      echo "Modal local development needs ngrok or an externally reachable OPENGENI_OBJECT_STORAGE_SANDBOX_ENDPOINT." >&2
+    [[ "$sandbox_object_host" = *.ngrok.io ]] ||
+    [[ "$sandbox_object_host" = *.trycloudflare.com ]]; then
+    needs_modal_object_route=1
+  else
+    needs_modal_object_route=0
+  fi
+
+  # The API/worker live on the developer host while Modal executes remotely.
+  # Publish one exact worktree-scoped edge for presigned objects plus
+  # MCP/Codemode; browser/UI origins and Connected Machine enrollment remain
+  # unchanged.
+  mcp_host="$({
+    OPENGENI_LOCAL_MCP_URL="${OPENGENI_MCP_URL:-http://127.0.0.1:${OPENGENI_API_PORT}}" bun -e '
+      const url = new URL(Bun.env.OPENGENI_LOCAL_MCP_URL.replace("{workspaceId}", "workspace"));
+      process.stdout.write(url.hostname.toLowerCase());
+    '
+  })"
+  if [ -z "${OPENGENI_MCP_URL:-}" ] ||
+    [ "$mcp_host" = "127.0.0.1" ] ||
+    [ "$mcp_host" = "localhost" ] ||
+    [ "$mcp_host" = "host.docker.internal" ] ||
+    [[ "$mcp_host" = *.ngrok-free.app ]] ||
+    [[ "$mcp_host" = *.ngrok-free.dev ]] ||
+    [[ "$mcp_host" = *.ngrok.io ]] ||
+    [[ "$mcp_host" = *.trycloudflare.com ]]; then
+    needs_modal_api_route=1
+  else
+    needs_modal_api_route=0
+  fi
+
+  if [ "$needs_modal_object_route" = "1" ] || [ "$needs_modal_api_route" = "1" ]; then
+    if ! command -v cloudflared >/dev/null 2>&1; then
+      echo "Modal local development needs cloudflared or explicit sandbox-reachable object and MCP endpoints." >&2
       exit 1
     fi
-
-    ngrok_tunnel_url() {
-      local tunnels
-      tunnels="$(curl -fsS http://127.0.0.1:4040/api/tunnels 2>/dev/null || true)"
-      if [ -z "$tunnels" ]; then
-        return 0
-      fi
-      OPENGENI_NGROK_TUNNELS="$tunnels" OPENGENI_NGROK_TARGET_PORT="$OPENGENI_MINIO_HOST_PORT" bun -e '
-        const value = JSON.parse(Bun.env.OPENGENI_NGROK_TUNNELS);
-        const port = Bun.env.OPENGENI_NGROK_TARGET_PORT;
-        const tunnel = value.tunnels?.find((candidate) => {
-          try {
-            const target = new URL(candidate.config?.addr);
-            return (target.port || (target.protocol === "https:" ? "443" : "80")) === port;
-          } catch {
-            return false;
-          }
-        });
-        if (typeof tunnel?.public_url === "string" && tunnel.public_url.startsWith("https://")) {
-          process.stdout.write(tunnel.public_url);
-        }
-      '
+    mkdir -p .opengeni
+    edge_log=".opengeni/cloudflared-sandbox-edge.log"
+    : >"$edge_log"
+    OPENGENI_SANDBOX_EDGE_API_ORIGIN="http://127.0.0.1:${OPENGENI_API_PORT}" \
+      OPENGENI_SANDBOX_EDGE_OBJECT_ORIGIN="http://127.0.0.1:${OPENGENI_MINIO_HOST_PORT}" \
+      bun scripts/dev-sandbox-edge.ts &
+    pids+=("$!")
+    for _attempt in $(seq 1 100); do
+      curl -fsS "http://127.0.0.1:${OPENGENI_SANDBOX_EDGE_PORT}/__opengeni_edge_health" \
+        >/dev/null 2>&1 && break
+      sleep 0.05
+    done
+    curl -fsS "http://127.0.0.1:${OPENGENI_SANDBOX_EDGE_PORT}/__opengeni_edge_health" \
+      >/dev/null || {
+      echo "Could not start the local Modal sandbox edge." >&2
+      exit 1
     }
-
-    sandbox_object_tunnel_url="$(ngrok_tunnel_url)"
-    if [ -z "$sandbox_object_tunnel_url" ]; then
-      if curl -fsS http://127.0.0.1:4040/api/tunnels >/dev/null 2>&1; then
-        owned_ngrok_tunnel_name="opengeni-${COMPOSE_PROJECT_NAME}-minio"
-        ngrok_request="$({
-          OPENGENI_NGROK_NAME="$owned_ngrok_tunnel_name" OPENGENI_NGROK_TARGET_PORT="$OPENGENI_MINIO_HOST_PORT" bun -e '
-            process.stdout.write(JSON.stringify({
-              name: Bun.env.OPENGENI_NGROK_NAME,
-              proto: "http",
-              addr: `http://127.0.0.1:${Bun.env.OPENGENI_NGROK_TARGET_PORT}`,
-            }));
-          '
-        })"
-        curl -fsS -X POST -H "content-type: application/json" --data "$ngrok_request" \
-          http://127.0.0.1:4040/api/tunnels >/dev/null
-      else
-        mkdir -p .opengeni
-        ngrok http "http://127.0.0.1:${OPENGENI_MINIO_HOST_PORT}" \
-          --log ".opengeni/ngrok-object-storage.log" --log-format json &
-        pids+=("$!")
-      fi
-      for _attempt in $(seq 1 100); do
-        sandbox_object_tunnel_url="$(ngrok_tunnel_url)"
-        [ -n "$sandbox_object_tunnel_url" ] && break
-        sleep 0.1
-      done
-    fi
-    if [ -z "$sandbox_object_tunnel_url" ]; then
-      echo "Could not establish the Modal-to-MinIO development tunnel." >&2
+    cloudflared tunnel --no-autoupdate \
+      --url "http://127.0.0.1:${OPENGENI_SANDBOX_EDGE_PORT}" \
+      --logfile "$edge_log" --loglevel info >/dev/null 2>&1 &
+    pids+=("$!")
+    sandbox_edge_url=""
+    for _attempt in $(seq 1 200); do
+      sandbox_edge_url="$(grep -Eo 'https://[-a-z0-9]+\.trycloudflare\.com' "$edge_log" | tail -n 1 || true)"
+      [ -n "$sandbox_edge_url" ] && break
+      sleep 0.1
+    done
+    if [ -z "$sandbox_edge_url" ]; then
+      echo "Could not establish the remote Modal sandbox edge." >&2
       exit 1
     fi
-    export OPENGENI_OBJECT_STORAGE_SANDBOX_ENDPOINT="$sandbox_object_tunnel_url"
-    echo "  modal-object-storage=${OPENGENI_OBJECT_STORAGE_SANDBOX_ENDPOINT}"
+    if [ "$needs_modal_object_route" = "1" ]; then
+      export OPENGENI_OBJECT_STORAGE_SANDBOX_ENDPOINT="$sandbox_edge_url"
+      echo "  modal-object-storage=${OPENGENI_OBJECT_STORAGE_SANDBOX_ENDPOINT}"
+    fi
+    if [ "$needs_modal_api_route" = "1" ]; then
+      export OPENGENI_MCP_URL="${sandbox_edge_url}/v1/workspaces/{workspaceId}/mcp"
+      echo "  modal-opengeni-api=${sandbox_edge_url}"
+    fi
   fi
 fi
 
@@ -724,6 +734,9 @@ fi
   printf 'OPENGENI_ARTIFACT_MATERIALIZER_HTTP_PORT=%s\n' "${OPENGENI_ARTIFACT_MATERIALIZER_HTTP_PORT}"
   printf 'OPENGENI_ARTIFACT_OUTBOX_HTTP_PORT=%s\n' "${OPENGENI_ARTIFACT_OUTBOX_HTTP_PORT}"
   printf 'OPENGENI_WEB_PORT=%s\n' "${OPENGENI_WEB_PORT}"
+  if [ -n "${OPENGENI_SANDBOX_EDGE_PORT:-}" ]; then
+    printf 'OPENGENI_SANDBOX_EDGE_PORT=%s\n' "${OPENGENI_SANDBOX_EDGE_PORT}"
+  fi
   if [ "${OPENGENI_SANDBOX_SELFHOSTED_ENABLED:-false}" = "true" ]; then
     printf 'OPENGENI_RELAY_HOST_PORT=%s\n' "${OPENGENI_RELAY_HOST_PORT}"
     printf 'OPENGENI_SELFHOSTED_NATS_URL=%s\n' "${OPENGENI_SELFHOSTED_NATS_URL}"
@@ -741,6 +754,9 @@ fi
   printf 'OPENGENI_OBJECT_STORAGE_ENDPOINT=%s\n' "${OPENGENI_OBJECT_STORAGE_ENDPOINT}"
   printf 'OPENGENI_OBJECT_STORAGE_INTERNAL_ENDPOINT=%s\n' "${OPENGENI_OBJECT_STORAGE_INTERNAL_ENDPOINT}"
   printf 'OPENGENI_OBJECT_STORAGE_SANDBOX_ENDPOINT=%s\n' "${OPENGENI_OBJECT_STORAGE_SANDBOX_ENDPOINT}"
+  if [ -n "${OPENGENI_MCP_URL:-}" ]; then
+    printf 'OPENGENI_MCP_URL=%s\n' "${OPENGENI_MCP_URL}"
+  fi
   printf 'OPENGENI_CODEX_SUBSCRIPTION_ENABLED=%s\n' "${OPENGENI_CODEX_SUBSCRIPTION_ENABLED}"
   printf 'NODE_ENV=%s\n' "${NODE_ENV}"
   printf 'OPENGENI_ARTIFACT_DEVELOPMENT_RUNTIME_MANIFEST=%s\n' "${OPENGENI_ARTIFACT_DEVELOPMENT_RUNTIME_MANIFEST}"


### PR DESCRIPTION
## Summary
- resolve Codemode against the selected sandbox placement
- project the current route into warm managed-box commands and exact Connected Machine enrollment origins
- give local Modal development one sandbox-reachable edge for API and presigned objects

## Validation
- exact existing Modal session: `EXIT=0 HOST=printed-weekly-julia-hist.trycloudflare.com`
- `cargo test -p opengeni-agent codemode::tests --no-default-features`
- focused Bun config/runtime/worker/dev-stack tests (122 passing)
- shell syntax, edge bundle, and diff checks