### PR TITLE
fix(web): refresh known agents at topology cap

### DIFF
--- a/apps/web/src/lib/agent-topology.test.ts
+++ b/apps/web/src/lib/agent-topology.test.ts
@@ -111,6 +111,18 @@ describe("agent topology", () => {
     ]);
   });
 
+  test("refreshes known agents after skipping novel agents beyond the cap", () => {
+    const rootA = session("root-a");
+    const rootB = session("root-b");
+    const novel = session("novel");
+    const refreshedRootB = { ...rootB, title: "refreshed" };
+
+    expect(mergeAgentTopologySessions([rootA, rootB], [novel, refreshedRootB], 2)).toEqual([
+      rootA,
+      refreshedRootB,
+    ]);
+  });
+
   test("fills only the available global auto-expand request slots", () => {
     expect(
       selectAgentTopologyBranchesToLoad(

--- a/apps/web/src/lib/agent-topology.ts
+++ b/apps/web/src/lib/agent-topology.ts
@@ -97,7 +97,7 @@ export function mergeAgentTopologySessions(
 ): AgentTopologySession[] {
   const sessions = new Map(current.map((session) => [session.id, session]));
   for (const session of incoming) {
-    if (sessions.size >= maxSessions && !sessions.has(session.id)) break;
+    if (sessions.size >= maxSessions && !sessions.has(session.id)) continue;
     sessions.set(session.id, session);
   }
   return [...sessions.values()];


### PR DESCRIPTION
## Summary
- skip novel sessions once the bounded topology cache reaches its cap
- continue scanning the refresh so already-loaded sessions still receive current status, title, and aggregate data
- add a regression where an over-cap novel session precedes a known-session update

## Verification
- `bun test apps/web/src/lib/agent-topology.test.ts`
- `bun run --cwd apps/web typecheck`
- `git diff --check`

## Provenance
- Base: `0bbbf74b7cd198aaef365460e495d4bf850d40e1`
- Head: `e2eaf1d2864b8d3796460ddd90dd4134308d8c11`
- Tree: `caa6e48756675ca9197cb86c8ba8e1727a8bfab5`
- Repairs the independent P1 found while reviewing Version PR #1411.