### PR TITLE
perf(turns): instrument and reduce startup latency

### DIFF
--- a/.changeset/quick-turn-startup.md
+++ b/.changeset/quick-turn-startup.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/codemode": patch
+"@opengeni/codex": patch
+"@opengeni/runtime": patch
+"@opengeni/worker-bundle": patch
+---
+
+Reduce and attribute turn startup latency with lazy sandbox defaults for local development, bounded validator reuse, parallel durable input reads, exact stale-Docker recovery, and low-cardinality worker, runtime, credential, and provider preparation diagnostics.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -383,7 +383,7 @@ import {
   recordSessionEventPublishLatency,
   recordTurnSandboxEstablishPolicy,
   recordTurnStartupPhase,
-  recordTurnPreModelTotal,
+  recordTurnWorkerPreparationTotal,
   runtimeMetricsHooksForObservability,
   StreamTimingMetrics,
   turnLifecycleMetricsFor,
@@ -4480,7 +4480,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         count: 2,
       });
       turnStartedPublished = true;
-      const preModelStartedAt = performance.now();
+      const workerPreparationStartedAt = performance.now();
 
       // Multi-account (P1): resolve the effective Codex account for this turn
       // (session-pin > workspace active) and stamp it on the session so the
@@ -8646,7 +8646,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // calling runStreamAttempt again; resetting this state there would reuse
       // the first no-response-ID fallback key and suppress a real model call.
       const modelResponseState = createModelResponseEventState(claimedModelUsageSourceKeys);
-      let preModelTotalRecorded = false;
+      let workerPreparationTotalRecorded = false;
       const runStreamAttempt = async (): Promise<RunAgentTurnResult> => {
         if (!runInput) {
           throw new Error("Run input was not prepared");
@@ -8747,17 +8747,19 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           const providerDispatchStartedAt = performance.now();
           let providerDispatchOutcome: "completed" | "failed" = "completed";
           try {
-            // This histogram describes turn startup through the first provider
-            // dispatch. Context-compaction recovery re-enters runStreamAttempt;
-            // recording again would fold the prior request and compaction into a
-            // bogus second "startup" sample.
-            if (!preModelTotalRecorded) {
-              preModelTotalRecorded = true;
-              recordTurnPreModelTotal(observability, {
+            // This histogram describes worker preparation until the first entry
+            // into the runtime. Lazy SDK request preparation and the durable
+            // model-request audit happen after this boundary and have their own
+            // phase metrics. Context-compaction recovery re-enters
+            // runStreamAttempt; recording again would fold the prior request and
+            // compaction into a bogus second startup sample.
+            if (!workerPreparationTotalRecorded) {
+              workerPreparationTotalRecorded = true;
+              recordTurnWorkerPreparationTotal(observability, {
                 provider: turnExecutionPolicy.providerId,
                 backend: activeSandboxBackend ?? groupBoxBackend,
                 outcome: "completed",
-                durationSeconds: (performance.now() - preModelStartedAt) / 1_000,
+                durationSeconds: (performance.now() - workerPreparationStartedAt) / 1_000,
               });
             }
             modelRequestStarted = true;

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -381,10 +381,14 @@ import {
   recordCompanyBrainContributions,
   recordSessionEventAppendLatency,
   recordSessionEventPublishLatency,
+  recordTurnSandboxEstablishPolicy,
+  recordTurnStartupPhase,
+  recordTurnPreModelTotal,
   runtimeMetricsHooksForObservability,
   StreamTimingMetrics,
   turnLifecycleMetricsFor,
   type TurnOutcome,
+  type TurnSandboxEstablishReason,
 } from "../observability-metrics";
 import { buildCompanyBrainContributionReceipt } from "../model-context-contributions";
 import {
@@ -1996,6 +2000,25 @@ export function shouldEstablishSandboxForTurn(
   machinePrimary: boolean,
 ): boolean {
   return sandboxOwnershipEnabled && (homeBackend !== "none" || machinePrimary);
+}
+
+export function sandboxEstablishPolicyDecision(input: {
+  lazyEnabled: boolean;
+  machinePrimary: boolean;
+  sandboxBackend: Settings["sandboxBackend"];
+  hasInitialRunCredentialMaterial: boolean;
+  generatedVideoFileCount: number;
+}): { policy: "eager" | "on-demand"; reason: TurnSandboxEstablishReason } {
+  if (!input.lazyEnabled) return { policy: "eager", reason: "lazy_disabled" };
+  if (input.machinePrimary) return { policy: "eager", reason: "machine_primary" };
+  if (input.sandboxBackend === "none") return { policy: "eager", reason: "backend_none" };
+  if (input.hasInitialRunCredentialMaterial) {
+    return { policy: "eager", reason: "initial_run_credentials" };
+  }
+  if (input.generatedVideoFileCount > 0) {
+    return { policy: "eager", reason: "generated_video_files" };
+  }
+  return { policy: "on-demand", reason: "eligible" };
 }
 
 /**
@@ -4410,6 +4433,14 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // on a healthy worker.
       throwIfWorkerShuttingDown();
       throwIfTurnCancelled();
+      recordTurnStartupPhase(observability, {
+        phase: "claim_and_policy",
+        provider: turnExecutionPolicy.providerId,
+        backend: turn.sandboxBackend,
+        outcome: "completed",
+        durationSeconds: (performance.now() - activityStarted) / 1_000,
+      });
+      const turnStartSettlementStartedAt = performance.now();
       if (
         !(await settle({
           events: [
@@ -4426,7 +4457,16 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       ) {
         return claimedResult({ status: "cancelled" });
       }
+      recordTurnStartupPhase(observability, {
+        phase: "turn_start_settlement",
+        provider: turnExecutionPolicy.providerId,
+        backend: turn.sandboxBackend,
+        outcome: "completed",
+        durationSeconds: (performance.now() - turnStartSettlementStartedAt) / 1_000,
+        count: 2,
+      });
       turnStartedPublished = true;
+      const preModelStartedAt = performance.now();
 
       // Multi-account (P1): resolve the effective Codex account for this turn
       // (session-pin > workspace active) and stamp it on the session so the
@@ -4434,80 +4474,28 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // when it changed from the prior run's account so the pill flips live.
       // Gated on the codex-billed predicate — non-codex turns never touch this.
       if (isCodexTurn) {
-        const sessionCodex = await getSessionCodexState(db, input.workspaceId, input.sessionId);
-        const sessionPin = sessionCodex?.pinnedCredentialId ?? null;
-        const sessionPinSource = sessionCodex?.pinSource ?? null;
-        const selectForTurn = (context: CodexCredentialLeaseSelectionContext) =>
-          selectCodexCredentialLeaseForTurn({
-            context,
-            leasingEnabled: settings.codexCredentialLeasingEnabled,
-            sessionId: input.sessionId,
-            sessionPinnedCredentialId: sessionPin,
-            sessionPinSource,
-            sessionLastCredentialId: sessionCodex?.lastCredentialId ?? null,
-            now: new Date(),
-          });
+        const credentialSelectionStartedAt = performance.now();
+        let credentialSelectionOutcome: "completed" | "failed" = "completed";
+        try {
+          const sessionCodex = await getSessionCodexState(db, input.workspaceId, input.sessionId);
+          const sessionPin = sessionCodex?.pinnedCredentialId ?? null;
+          const sessionPinSource = sessionCodex?.pinSource ?? null;
+          const selectForTurn = (context: CodexCredentialLeaseSelectionContext) =>
+            selectCodexCredentialLeaseForTurn({
+              context,
+              leasingEnabled: settings.codexCredentialLeasingEnabled,
+              sessionId: input.sessionId,
+              sessionPinnedCredentialId: sessionPin,
+              sessionPinSource,
+              sessionLastCredentialId: sessionCodex?.lastCredentialId ?? null,
+              now: new Date(),
+            });
 
-        // Rollout/rollback path is intentionally table-inert. With the flag off,
-        // old and new workers both use legacy pin > active-pointer selection and
-        // neither reads nor writes the additive lease/cursor schema.
-        let leased: CodexCredentialLeaseResult<RotationDecision>;
-        let leaseAcquisitionStartedAtMs: number | null = null;
-        if (settings.codexCredentialLeasingEnabled) {
-          leaseAcquisitionStartedAtMs = performance.now();
-          leased = await acquireCodexCredentialLease(
-            db,
-            {
-              accountId: input.accountId,
-              workspaceId: input.workspaceId,
-              turnId,
-              holderId: codexLeaseHolderId,
-              advanceActivePointer: sessionPin === null,
-            },
-            selectForTurn,
-          );
-        } else {
-          const [rotation, accounts] = await Promise.all([
-            getCodexRotationSettings(db, input.workspaceId),
-            listCodexAccountStatuses(db, input.workspaceId),
-          ]);
-          const leaseAccounts = accounts.map((account) => ({
-            ...account,
-            activeLeaseCount: 0,
-            selectionCount: 0,
-            lastSelectedAt: null,
-          }));
-          const activeCredentialId = rotation?.activeCredentialId ?? null;
-          const selected = selectForTurn({
-            accounts: leaseAccounts,
-            activeCredentialId,
-            rotationEnabled: rotation?.rotationEnabled ?? false,
-            leaseRotationEnabled: false,
-            rotationStrategy: rotation?.rotationStrategy ?? "most_remaining",
-            existingCredentialId: null,
-            policyScope: null,
-            unavailableDiagnostics: [],
-          });
-          leased = {
-            ...selected,
-            accounts: leaseAccounts,
-            activeCredentialId,
-            rotationEnabled: rotation?.rotationEnabled ?? false,
-            rotationStrategy: rotation?.rotationStrategy ?? "most_remaining",
-            reused: false,
-            holderId: null,
-            generation: null,
-            leasedUntil: null,
-            unavailableDiagnostics: [],
-            advanceActivePointer: selected.advanceActivePointer !== false,
-          };
-        }
-        if (leased.decision.kind === "allCapped") {
-          // Bounded self-heal of stale usage cache, then ONE new atomic selection.
-          await refreshCappedCodexUsageRows(db, settings, input.workspaceId, leased.accounts, {
-            signalCodexCapacityWorkflow,
-            wakeSessionWorkflow,
-          });
+          // Rollout/rollback path is intentionally table-inert. With the flag off,
+          // old and new workers both use legacy pin > active-pointer selection and
+          // neither reads nor writes the additive lease/cursor schema.
+          let leased: CodexCredentialLeaseResult<RotationDecision>;
+          let leaseAcquisitionStartedAtMs: number | null = null;
           if (settings.codexCredentialLeasingEnabled) {
             leaseAcquisitionStartedAtMs = performance.now();
             leased = await acquireCodexCredentialLease(
@@ -4532,9 +4520,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               selectionCount: 0,
               lastSelectedAt: null,
             }));
+            const activeCredentialId = rotation?.activeCredentialId ?? null;
             const selected = selectForTurn({
               accounts: leaseAccounts,
-              activeCredentialId: rotation?.activeCredentialId ?? null,
+              activeCredentialId,
               rotationEnabled: rotation?.rotationEnabled ?? false,
               leaseRotationEnabled: false,
               rotationStrategy: rotation?.rotationStrategy ?? "most_remaining",
@@ -4545,7 +4534,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             leased = {
               ...selected,
               accounts: leaseAccounts,
-              activeCredentialId: rotation?.activeCredentialId ?? null,
+              activeCredentialId,
               rotationEnabled: rotation?.rotationEnabled ?? false,
               rotationStrategy: rotation?.rotationStrategy ?? "most_remaining",
               reused: false,
@@ -4556,212 +4545,334 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               advanceActivePointer: selected.advanceActivePointer !== false,
             };
           }
-        }
-        const rotationDecision = leased.decision;
-        const selectedPinDisposition = classifyCodexPin({
-          pinnedCredentialId: sessionPin,
-          pinSource: sessionPinSource,
-          strategy: leased.rotationStrategy as CodexRotationStrategy,
-          rotationEnabled: leased.rotationEnabled,
-        });
-        // pin policy pin persistence follows the atomic credential allocator selection. The selector
-        // already ran exact-turn reuse before policy filtering and vetoed pointer
-        // movement for manual/policy homes; this write only records the NEXT turn's
-        // policy home (or clears a policy pin whose strategy is no longer active).
-        if (
-          selectedPinDisposition === "sharded" &&
-          leased.credentialId !== null &&
-          (sessionPinSource !== "policy" || sessionPin !== leased.credentialId)
-        ) {
-          const pinMutation = await withSessionCodexCapacityMutation(
-            db,
-            {
-              workspaceId: input.workspaceId,
-              reason: "codex_policy_pin_changed",
-            },
-            async (tx) => {
-              const changed = await setSessionCodexPinInTransaction(
-                tx,
-                input.workspaceId,
-                input.sessionId,
-                leased.credentialId,
-                "policy",
+          if (leased.decision.kind === "allCapped") {
+            // Bounded self-heal of stale usage cache, then ONE new atomic selection.
+            await refreshCappedCodexUsageRows(db, settings, input.workspaceId, leased.accounts, {
+              signalCodexCapacityWorkflow,
+              wakeSessionWorkflow,
+            });
+            if (settings.codexCredentialLeasingEnabled) {
+              leaseAcquisitionStartedAtMs = performance.now();
+              leased = await acquireCodexCredentialLease(
+                db,
                 {
-                  expected: {
-                    pinnedCredentialId: sessionPin,
-                    pinSource: sessionPinSource,
-                  },
+                  accountId: input.accountId,
+                  workspaceId: input.workspaceId,
+                  turnId,
+                  holderId: codexLeaseHolderId,
+                  advanceActivePointer: sessionPin === null,
                 },
+                selectForTurn,
               );
-              return { result: changed, changed };
+            } else {
+              const [rotation, accounts] = await Promise.all([
+                getCodexRotationSettings(db, input.workspaceId),
+                listCodexAccountStatuses(db, input.workspaceId),
+              ]);
+              const leaseAccounts = accounts.map((account) => ({
+                ...account,
+                activeLeaseCount: 0,
+                selectionCount: 0,
+                lastSelectedAt: null,
+              }));
+              const selected = selectForTurn({
+                accounts: leaseAccounts,
+                activeCredentialId: rotation?.activeCredentialId ?? null,
+                rotationEnabled: rotation?.rotationEnabled ?? false,
+                leaseRotationEnabled: false,
+                rotationStrategy: rotation?.rotationStrategy ?? "most_remaining",
+                existingCredentialId: null,
+                policyScope: null,
+                unavailableDiagnostics: [],
+              });
+              leased = {
+                ...selected,
+                accounts: leaseAccounts,
+                activeCredentialId: rotation?.activeCredentialId ?? null,
+                rotationEnabled: rotation?.rotationEnabled ?? false,
+                rotationStrategy: rotation?.rotationStrategy ?? "most_remaining",
+                reused: false,
+                holderId: null,
+                generation: null,
+                leasedUntil: null,
+                unavailableDiagnostics: [],
+                advanceActivePointer: selected.advanceActivePointer !== false,
+              };
+            }
+          }
+          const rotationDecision = leased.decision;
+          const selectedPinDisposition = classifyCodexPin({
+            pinnedCredentialId: sessionPin,
+            pinSource: sessionPinSource,
+            strategy: leased.rotationStrategy as CodexRotationStrategy,
+            rotationEnabled: leased.rotationEnabled,
+          });
+          // pin policy pin persistence follows the atomic credential allocator selection. The selector
+          // already ran exact-turn reuse before policy filtering and vetoed pointer
+          // movement for manual/policy homes; this write only records the NEXT turn's
+          // policy home (or clears a policy pin whose strategy is no longer active).
+          if (
+            selectedPinDisposition === "sharded" &&
+            leased.credentialId !== null &&
+            (sessionPinSource !== "policy" || sessionPin !== leased.credentialId)
+          ) {
+            const pinMutation = await withSessionCodexCapacityMutation(
+              db,
+              {
+                workspaceId: input.workspaceId,
+                reason: "codex_policy_pin_changed",
+              },
+              async (tx) => {
+                const changed = await setSessionCodexPinInTransaction(
+                  tx,
+                  input.workspaceId,
+                  input.sessionId,
+                  leased.credentialId,
+                  "policy",
+                  {
+                    expected: {
+                      pinnedCredentialId: sessionPin,
+                      pinSource: sessionPinSource,
+                    },
+                  },
+                );
+                return { result: changed, changed };
+              },
+            );
+            await signalCodexCapacityWakeTargets(
+              { signalCodexCapacityWorkflow, wakeSessionWorkflow },
+              pinMutation.wakeTargets,
+            );
+          } else if (selectedPinDisposition === "clearStale") {
+            const pinMutation = await withSessionCodexCapacityMutation(
+              db,
+              {
+                workspaceId: input.workspaceId,
+                reason: "codex_stale_policy_pin_cleared",
+              },
+              async (tx) => {
+                const changed = await setSessionCodexPinInTransaction(
+                  tx,
+                  input.workspaceId,
+                  input.sessionId,
+                  null,
+                  "policy",
+                  {
+                    expected: {
+                      pinnedCredentialId: sessionPin,
+                      pinSource: sessionPinSource,
+                    },
+                  },
+                );
+                return { result: changed, changed };
+              },
+            );
+            await signalCodexCapacityWakeTargets(
+              { signalCodexCapacityWorkflow, wakeSessionWorkflow },
+              pinMutation.wakeTargets,
+            );
+          }
+          if (
+            !settings.codexCredentialLeasingEnabled &&
+            leased.advanceActivePointer &&
+            sessionPin === null &&
+            rotationDecision.kind === "active" &&
+            rotationDecision.moved
+          ) {
+            await setActiveCodexCredential(db, input.workspaceId, rotationDecision.credentialId);
+          }
+          effectiveCodexCredentialId = leased.credentialId;
+          codexLeaseGeneration = leased.generation;
+          codexLeaseConfirmedUntilMs =
+            leased.leasedUntil && leaseAcquisitionStartedAtMs !== null
+              ? leaseAcquisitionStartedAtMs + CODEX_CREDENTIAL_LEASE_TTL_MS
+              : null;
+          codexLeaseHeld =
+            effectiveCodexCredentialId !== null &&
+            leased.holderId !== null &&
+            leased.generation !== null &&
+            codexLeaseConfirmedUntilMs !== null;
+          if (codexLeaseHeld) startCodexLeaseHeartbeat();
+
+          const actualOutcome = effectiveCodexCredentialId
+            ? "selected"
+            : rotationDecision.kind === "allCapped"
+              ? "waiting"
+              : "none";
+          const actualReason = effectiveCodexCredentialId
+            ? leased.reused
+              ? "lease_reused"
+              : sessionPin === effectiveCodexCredentialId
+                ? "pin"
+                : rotationDecision.kind === "active" && rotationDecision.moved
+                  ? "rotation"
+                  : "active"
+            : rotationDecision.kind === "allCapped"
+              ? "all_capped"
+              : "none";
+          const fencedInFlight = leased.reused;
+          const shadowResult = await publishCodexFleetShadowDecisionV1({
+            enabled: settings.codexFleetPolicyShadowEnabled,
+            decision: {
+              accounts: leased.accounts,
+              actualCredentialId: effectiveCodexCredentialId,
+              actualOutcome,
+              actualReason,
+              affinityCredentialId: fencedInFlight
+                ? effectiveCodexCredentialId
+                : (sessionPin ?? sessionCodex?.lastCredentialId ?? null),
+              fencedInFlight,
+              nearExhaustionPct: settings.codexRotationNearExhaustionPct,
+              now: new Date(),
+              aliasSeed: randomUUID(),
             },
-          );
-          await signalCodexCapacityWakeTargets(
-            { signalCodexCapacityWorkflow, wakeSessionWorkflow },
-            pinMutation.wakeTargets,
-          );
-        } else if (selectedPinDisposition === "clearStale") {
-          const pinMutation = await withSessionCodexCapacityMutation(
-            db,
-            {
+            publish,
+          });
+          if (shadowResult.outcome === "published") {
+            const shadowPayload = shadowResult.payload;
+            observability.incrementCounter({
+              name: "opengeni_codex_fleet_shadow_decisions_total",
+              help: "Shadow decisions by bounded actual/shadow outcome and comparison.",
+              labels: codexFleetShadowDecisionMetricLabelsV1(shadowPayload),
+            });
+            observability.info("Codex adaptive fleet shadow decision", {
               workspaceId: input.workspaceId,
-              reason: "codex_stale_policy_pin_cleared",
-            },
-            async (tx) => {
-              const changed = await setSessionCodexPinInTransaction(
-                tx,
-                input.workspaceId,
-                input.sessionId,
-                null,
-                "policy",
-                {
-                  expected: {
-                    pinnedCredentialId: sessionPin,
-                    pinSource: sessionPinSource,
-                  },
-                },
-              );
-              return { result: changed, changed };
-            },
-          );
-          await signalCodexCapacityWakeTargets(
-            { signalCodexCapacityWorkflow, wakeSessionWorkflow },
-            pinMutation.wakeTargets,
-          );
-        }
-        if (
-          !settings.codexCredentialLeasingEnabled &&
-          leased.advanceActivePointer &&
-          sessionPin === null &&
-          rotationDecision.kind === "active" &&
-          rotationDecision.moved
-        ) {
-          await setActiveCodexCredential(db, input.workspaceId, rotationDecision.credentialId);
-        }
-        effectiveCodexCredentialId = leased.credentialId;
-        codexLeaseGeneration = leased.generation;
-        codexLeaseConfirmedUntilMs =
-          leased.leasedUntil && leaseAcquisitionStartedAtMs !== null
-            ? leaseAcquisitionStartedAtMs + CODEX_CREDENTIAL_LEASE_TTL_MS
-            : null;
-        codexLeaseHeld =
-          effectiveCodexCredentialId !== null &&
-          leased.holderId !== null &&
-          leased.generation !== null &&
-          codexLeaseConfirmedUntilMs !== null;
-        if (codexLeaseHeld) startCodexLeaseHeartbeat();
+              policyVersion: shadowPayload.replay.policyVersion,
+              inputFingerprint: shadowPayload.replay.inputFingerprint,
+              decisionFingerprint: shadowPayload.replay.decisionFingerprint,
+              actualOutcome: shadowPayload.actual.outcome,
+              shadowOutcome: shadowPayload.replay.decision.outcome,
+              comparison: shadowPayload.comparison,
+              candidateCount: shadowPayload.replay.input.candidates.length,
+              truncatedCandidateCount: shadowPayload.replay.truncatedCandidateCount,
+              payloadBytes: shadowResult.payloadBytes,
+            });
+          } else if (shadowResult.outcome === "failed") {
+            // Shadow observability is explicitly non-authoritative. A malformed
+            // snapshot or event-write fault must never change the authoritative lease,
+            // capacity wait, failover, or the account serving this fenced turn.
+            observability.incrementCounter({
+              name: "opengeni_codex_fleet_shadow_errors_total",
+              help: "Shadow decision build/publication failures.",
+              labels: codexFleetShadowErrorMetricLabelsV1(shadowResult),
+            });
+            observability.warn("Codex adaptive fleet shadow decision failed open", {
+              stage: shadowResult.stage,
+              reason: shadowResult.reason,
+              errorClass: "CodexFleetShadowOperationError",
+              errorCode: "codex_fleet_shadow_failed",
+              origin: "worker",
+              payloadBytes: shadowResult.payloadBytes,
+            });
+          }
 
-        const actualOutcome = effectiveCodexCredentialId
-          ? "selected"
-          : rotationDecision.kind === "allCapped"
-            ? "waiting"
-            : "none";
-        const actualReason = effectiveCodexCredentialId
-          ? leased.reused
-            ? "lease_reused"
-            : sessionPin === effectiveCodexCredentialId
-              ? "pin"
-              : rotationDecision.kind === "active" && rotationDecision.moved
-                ? "rotation"
-                : "active"
-          : rotationDecision.kind === "allCapped"
-            ? "all_capped"
-            : "none";
-        const fencedInFlight = leased.reused;
-        const shadowResult = await publishCodexFleetShadowDecisionV1({
-          enabled: settings.codexFleetPolicyShadowEnabled,
-          decision: {
-            accounts: leased.accounts,
-            actualCredentialId: effectiveCodexCredentialId,
-            actualOutcome,
-            actualReason,
-            affinityCredentialId: fencedInFlight
-              ? effectiveCodexCredentialId
-              : (sessionPin ?? sessionCodex?.lastCredentialId ?? null),
-            fencedInFlight,
-            nearExhaustionPct: settings.codexRotationNearExhaustionPct,
-            now: new Date(),
-            aliasSeed: randomUUID(),
-          },
-          publish,
-        });
-        if (shadowResult.outcome === "published") {
-          const shadowPayload = shadowResult.payload;
+          const eligibleCount = leased.accounts.filter((account) =>
+            isCodexCredentialEligible(account, new Date()),
+          ).length;
+          const poolDepth = eligibleCount === 0 ? "zero" : eligibleCount === 1 ? "one" : "many";
           observability.incrementCounter({
-            name: "opengeni_codex_fleet_shadow_decisions_total",
-            help: "Shadow decisions by bounded actual/shadow outcome and comparison.",
-            labels: codexFleetShadowDecisionMetricLabelsV1(shadowPayload),
-          });
-          observability.info("Codex adaptive fleet shadow decision", {
-            workspaceId: input.workspaceId,
-            policyVersion: shadowPayload.replay.policyVersion,
-            inputFingerprint: shadowPayload.replay.inputFingerprint,
-            decisionFingerprint: shadowPayload.replay.decisionFingerprint,
-            actualOutcome: shadowPayload.actual.outcome,
-            shadowOutcome: shadowPayload.replay.decision.outcome,
-            comparison: shadowPayload.comparison,
-            candidateCount: shadowPayload.replay.input.candidates.length,
-            truncatedCandidateCount: shadowPayload.replay.truncatedCandidateCount,
-            payloadBytes: shadowResult.payloadBytes,
-          });
-        } else if (shadowResult.outcome === "failed") {
-          // Shadow observability is explicitly non-authoritative. A malformed
-          // snapshot or event-write fault must never change the authoritative lease,
-          // capacity wait, failover, or the account serving this fenced turn.
-          observability.incrementCounter({
-            name: "opengeni_codex_fleet_shadow_errors_total",
-            help: "Shadow decision build/publication failures.",
-            labels: codexFleetShadowErrorMetricLabelsV1(shadowResult),
-          });
-          observability.warn("Codex adaptive fleet shadow decision failed open", {
-            stage: shadowResult.stage,
-            reason: shadowResult.reason,
-            errorClass: "CodexFleetShadowOperationError",
-            errorCode: "codex_fleet_shadow_failed",
-            origin: "worker",
-            payloadBytes: shadowResult.payloadBytes,
-          });
-        }
-
-        const eligibleCount = leased.accounts.filter((account) =>
-          isCodexCredentialEligible(account, new Date()),
-        ).length;
-        const poolDepth = eligibleCount === 0 ? "zero" : eligibleCount === 1 ? "one" : "many";
-        observability.incrementCounter({
-          name: "opengeni_codex_pool_observations_total",
-          help: "Observed eligible Codex pool depth buckets at turn selection.",
-          labels: { workspace_key: codexWorkspaceKey, depth: poolDepth },
-        });
-        if (eligibleCount <= 1) {
-          observability.incrementCounter({
-            name: "opengeni_codex_pool_low_total",
-            help: "Alert signal emitted when the eligible Codex pool is zero or one.",
+            name: "opengeni_codex_pool_observations_total",
+            help: "Observed eligible Codex pool depth buckets at turn selection.",
             labels: { workspace_key: codexWorkspaceKey, depth: poolDepth },
           });
-          observability.warn("Codex eligible credential pool is low", {
-            workspaceId: input.workspaceId,
-            eligibleCount,
-            connectedCount: leased.accounts.length,
-            depth: poolDepth,
-          });
-        }
+          if (eligibleCount <= 1) {
+            observability.incrementCounter({
+              name: "opengeni_codex_pool_low_total",
+              help: "Alert signal emitted when the eligible Codex pool is zero or one.",
+              labels: { workspace_key: codexWorkspaceKey, depth: poolDepth },
+            });
+            observability.warn("Codex eligible credential pool is low", {
+              workspaceId: input.workspaceId,
+              eligibleCount,
+              connectedCount: leased.accounts.length,
+              depth: poolDepth,
+            });
+          }
 
-        if (
-          effectiveCodexCredentialId === null &&
-          leased.accounts.length > 0 &&
-          leased.accounts.every((account) => !account.allocatorEnabled) &&
-          turnId
-        ) {
-          if (turn.source === "compaction") {
+          if (
+            effectiveCodexCredentialId === null &&
+            leased.accounts.length > 0 &&
+            leased.accounts.every((account) => !account.allocatorEnabled) &&
+            turnId
+          ) {
+            if (turn.source === "compaction") {
+              if (
+                !(await settle!({
+                  events: [
+                    {
+                      type: "turn.cancelled",
+                      payload: {
+                        maintenance: "context_compaction",
+                        reason: "codex_allocator_disabled",
+                        requestPreserved: true,
+                      },
+                    },
+                    {
+                      type: "session.status.changed",
+                      payload: { status: "idle" },
+                    },
+                  ],
+                  turnStatus: "cancelled",
+                  sessionStatus: "idle",
+                  activeTurnId: null,
+                }))
+              ) {
+                return claimedResult({ status: "cancelled" });
+              }
+              turnMetricOutcome = "cancelled";
+              activityStatus = "idle";
+              return claimedResult({ status: "idle", deferredUntilWake: true });
+            }
+            const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(
+              () => null,
+            );
+            const activeGoal = goal?.status === "active" ? goal : null;
+            const armed = await armCodexCapacityWait(db, {
+              accountId: input.accountId,
+              workspaceId: input.workspaceId,
+              sessionId: input.sessionId,
+              turnId,
+              attemptId: input.attemptId,
+              workflowId: input.workflowId,
+              goalId: activeGoal?.id ?? null,
+              goalVersion: activeGoal?.version ?? null,
+              earliestResetAt: null,
+              resetKind: "bounded_refresh",
+              failurePayload: {
+                error: "All connected Codex subscriptions are disabled for new allocations.",
+                code: "codex_allocator_disabled",
+                detail: "waiting for a credential to be re-enabled, reconnected, or added",
+              },
+            });
+            if (armed.action === "waiting") {
+              await publishDurableSessionEvents(
+                bus,
+                input.workspaceId,
+                input.sessionId,
+                armed.events,
+              );
+              turnMetricOutcome = "recovering";
+              activityStatus = "waiting_capacity";
+              return claimedResult({
+                status: "waiting_capacity",
+                capacityWait: {
+                  waiterId: armed.waiter.id,
+                  generation: armed.waiter.generation,
+                  nextCheckAt: armed.waiter.nextCheckAt.toISOString(),
+                  wakeRevision: armed.waiter.wakeRevision,
+                },
+              });
+            }
             if (
               !(await settle!({
                 events: [
                   {
-                    type: "turn.cancelled",
+                    type: "turn.failed",
                     payload: {
-                      maintenance: "context_compaction",
-                      reason: "codex_allocator_disabled",
-                      requestPreserved: true,
+                      error: "All connected Codex subscriptions are disabled for new allocations.",
+                      code: "codex_allocator_disabled",
+                      retryable: false,
+                      recovery: "user_message",
                     },
                   },
                   {
@@ -4769,94 +4880,119 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                     payload: { status: "idle" },
                   },
                 ],
-                turnStatus: "cancelled",
+                turnStatus: "failed",
                 sessionStatus: "idle",
                 activeTurnId: null,
               }))
             ) {
               return claimedResult({ status: "cancelled" });
             }
-            turnMetricOutcome = "cancelled";
+            turnMetricOutcome = "failed";
             activityStatus = "idle";
-            return claimedResult({ status: "idle", deferredUntilWake: true });
+            return claimedResult({ status: "idle" });
           }
-          const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(
-            () => null,
-          );
-          const activeGoal = goal?.status === "active" ? goal : null;
-          const armed = await armCodexCapacityWait(db, {
-            accountId: input.accountId,
-            workspaceId: input.workspaceId,
-            sessionId: input.sessionId,
-            turnId,
-            attemptId: input.attemptId,
-            workflowId: input.workflowId,
-            goalId: activeGoal?.id ?? null,
-            goalVersion: activeGoal?.version ?? null,
-            earliestResetAt: null,
-            resetKind: "bounded_refresh",
-            failurePayload: {
-              error: "All connected Codex subscriptions are disabled for new allocations.",
-              code: "codex_allocator_disabled",
-              detail: "waiting for a credential to be re-enabled, reconnected, or added",
-            },
-          });
-          if (armed.action === "waiting") {
-            await publishDurableSessionEvents(
-              bus,
-              input.workspaceId,
-              input.sessionId,
-              armed.events,
-            );
-            turnMetricOutcome = "recovering";
-            activityStatus = "waiting_capacity";
-            return claimedResult({
-              status: "waiting_capacity",
-              capacityWait: {
-                waiterId: armed.waiter.id,
-                generation: armed.waiter.generation,
-                nextCheckAt: armed.waiter.nextCheckAt.toISOString(),
-                wakeRevision: armed.waiter.wakeRevision,
-              },
-            });
-          }
-          if (
-            !(await settle!({
-              events: [
-                {
-                  type: "turn.failed",
-                  payload: {
-                    error: "All connected Codex subscriptions are disabled for new allocations.",
-                    code: "codex_allocator_disabled",
-                    retryable: false,
-                    recovery: "user_message",
-                  },
-                },
-                { type: "session.status.changed", payload: { status: "idle" } },
-              ],
-              turnStatus: "failed",
-              sessionStatus: "idle",
-              activeTurnId: null,
-            }))
-          ) {
-            return claimedResult({ status: "cancelled" });
-          }
-          turnMetricOutcome = "failed";
-          activityStatus = "idle";
-          return claimedResult({ status: "idle" });
-        }
 
-        if (rotationDecision.kind === "allCapped" && turnId) {
-          if (turn.source === "compaction") {
+          if (rotationDecision.kind === "allCapped" && turnId) {
+            if (turn.source === "compaction") {
+              if (
+                !(await settle!({
+                  events: [
+                    {
+                      type: "turn.cancelled",
+                      payload: {
+                        maintenance: "context_compaction",
+                        reason: "codex_capacity_unavailable",
+                        requestPreserved: true,
+                      },
+                    },
+                    {
+                      type: "session.status.changed",
+                      payload: { status: "idle" },
+                    },
+                  ],
+                  turnStatus: "cancelled",
+                  sessionStatus: "idle",
+                  activeTurnId: null,
+                }))
+              ) {
+                return claimedResult({ status: "cancelled" });
+              }
+              turnMetricOutcome = "cancelled";
+              activityStatus = "idle";
+              return claimedResult({ status: "idle", deferredUntilWake: true });
+            }
+            // Every eligible account is capped/cooling (and a usage refresh did NOT
+            // surface a reset): idle the turn AT THE BOUNDARY (no wasted model/sandbox
+            // build) until the EARLIEST reset across all accounts — the multi-account
+            // generalization of #143's single-account idle-until-reset. No saveRunState:
+            // no model ran, nothing to freeze.
+            const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(
+              () => null,
+            );
+            const goalActive = Boolean(goal && goal.status === "active");
+            // BOUNDED + POSITIVE: clamp to [MIN_IDLE_MS, max] so a null/elapsed/unknown
+            // reset can never yield a 0 (which session.ts would treat as "continue now",
+            // re-entering this path in a tight CPU/DB-hammering loop).
+            const resumeMs = computeIdleDelayMs(
+              rotationDecision.earliestResetAt,
+              new Date(),
+              CODEX_USAGE_LIMIT_MAX_RESUME_MS,
+            );
+            const failurePayload = codexUsageLimitFailurePayload(
+              { resetsInSeconds: Math.ceil(resumeMs / 1000) },
+              "all connected Codex subscriptions are rate-limited",
+              { allAccounts: true },
+            );
+            const authoritativeResetAt = authoritativeCodexCapacityResetAt(
+              leased.accounts,
+              new Date(),
+            );
+            const armed = await armCodexCapacityWait(db, {
+              accountId: input.accountId,
+              workspaceId: input.workspaceId,
+              sessionId: input.sessionId,
+              turnId,
+              attemptId: input.attemptId,
+              workflowId: input.workflowId,
+              goalId: goalActive && goal ? goal.id : null,
+              goalVersion: goalActive && goal ? goal.version : null,
+              earliestResetAt: authoritativeResetAt,
+              resetKind: authoritativeResetAt ? "authoritative" : "bounded_refresh",
+              failurePayload,
+            });
+            if (armed.action === "waiting") {
+              await publishDurableSessionEvents(
+                bus,
+                input.workspaceId,
+                input.sessionId,
+                armed.events,
+              );
+              turnMetricOutcome = "recovering";
+              activityStatus = "waiting_capacity";
+              return claimedResult({
+                status: "waiting_capacity",
+                capacityWait: {
+                  waiterId: armed.waiter.id,
+                  generation: armed.waiter.generation,
+                  nextCheckAt: armed.waiter.nextCheckAt.toISOString(),
+                  wakeRevision: armed.waiter.wakeRevision,
+                },
+              });
+            }
             if (
               !(await settle!({
                 events: [
+                  // `rotated:true` (Finding 2): the proactive all-capped wait is the SAME
+                  // rotation-wait state as the reactive all-capped path, so it must freeze
+                  // autoContinuations identically (evaluateGoalContinuation reads this marker)
+                  // — a goal waiting out a long reset must not burn its continuation budget on
+                  // the proactive path while the reactive path spares it.
                   {
-                    type: "turn.cancelled",
+                    type: "turn.failed",
                     payload: {
-                      maintenance: "context_compaction",
-                      reason: "codex_capacity_unavailable",
-                      requestPreserved: true,
+                      ...failurePayload,
+                      recovery: goalActive ? "goal_continuation" : "user_message",
+                      rotated: true,
                     },
                   },
                   {
@@ -4864,165 +5000,90 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                     payload: { status: "idle" },
                   },
                 ],
-                turnStatus: "cancelled",
+                turnStatus: "failed",
                 sessionStatus: "idle",
                 activeTurnId: null,
               }))
             ) {
               return claimedResult({ status: "cancelled" });
             }
-            turnMetricOutcome = "cancelled";
+            turnMetricOutcome = "failed";
             activityStatus = "idle";
-            return claimedResult({ status: "idle", deferredUntilWake: true });
+            // idleUntilReset marks this a MANDATORY hold: session.ts must wait the full
+            // resumeMs even if a future change made it 0 — never a tight re-dispatch.
+            return claimedResult(
+              goalActive
+                ? {
+                    status: "idle",
+                    continueDelayMs: resumeMs,
+                    idleUntilReset: true,
+                  }
+                : { status: "idle" },
+            );
           }
-          // Every eligible account is capped/cooling (and a usage refresh did NOT
-          // surface a reset): idle the turn AT THE BOUNDARY (no wasted model/sandbox
-          // build) until the EARLIEST reset across all accounts — the multi-account
-          // generalization of #143's single-account idle-until-reset. No saveRunState:
-          // no model ran, nothing to freeze.
-          const goal = await getSessionGoal(db, input.workspaceId, input.sessionId).catch(
-            () => null,
-          );
-          const goalActive = Boolean(goal && goal.status === "active");
-          // BOUNDED + POSITIVE: clamp to [MIN_IDLE_MS, max] so a null/elapsed/unknown
-          // reset can never yield a 0 (which session.ts would treat as "continue now",
-          // re-entering this path in a tight CPU/DB-hammering loop).
-          const resumeMs = computeIdleDelayMs(
-            rotationDecision.earliestResetAt,
-            new Date(),
-            CODEX_USAGE_LIMIT_MAX_RESUME_MS,
-          );
-          const failurePayload = codexUsageLimitFailurePayload(
-            { resetsInSeconds: Math.ceil(resumeMs / 1000) },
-            "all connected Codex subscriptions are rate-limited",
-            { allAccounts: true },
-          );
-          const authoritativeResetAt = authoritativeCodexCapacityResetAt(
-            leased.accounts,
-            new Date(),
-          );
-          const armed = await armCodexCapacityWait(db, {
-            accountId: input.accountId,
-            workspaceId: input.workspaceId,
-            sessionId: input.sessionId,
-            turnId,
-            attemptId: input.attemptId,
-            workflowId: input.workflowId,
-            goalId: goalActive && goal ? goal.id : null,
-            goalVersion: goalActive && goal ? goal.version : null,
-            earliestResetAt: authoritativeResetAt,
-            resetKind: authoritativeResetAt ? "authoritative" : "bounded_refresh",
-            failurePayload,
-          });
-          if (armed.action === "waiting") {
-            await publishDurableSessionEvents(
-              bus,
+          if (effectiveCodexCredentialId) {
+            const priorAccountId = sessionCodex?.lastCredentialId ?? null;
+            await recordSessionActiveCodexCredential(
+              db,
               input.workspaceId,
               input.sessionId,
-              armed.events,
+              effectiveCodexCredentialId,
             );
-            turnMetricOutcome = "recovering";
-            activityStatus = "waiting_capacity";
-            return claimedResult({
-              status: "waiting_capacity",
-              capacityWait: {
-                waiterId: armed.waiter.id,
-                generation: armed.waiter.generation,
-                nextCheckAt: armed.waiter.nextCheckAt.toISOString(),
-                wakeRevision: armed.waiter.wakeRevision,
-              },
-            });
-          }
-          if (
-            !(await settle!({
-              events: [
-                // `rotated:true` (Finding 2): the proactive all-capped wait is the SAME
-                // rotation-wait state as the reactive all-capped path, so it must freeze
-                // autoContinuations identically (evaluateGoalContinuation reads this marker)
-                // — a goal waiting out a long reset must not burn its continuation budget on
-                // the proactive path while the reactive path spares it.
+            if (priorAccountId !== effectiveCodexCredentialId) {
+              const rotated = rotationDecision.kind === "active" && rotationDecision.moved;
+              await publish([
                 {
-                  type: "turn.failed",
+                  type: "codex.account.switched",
                   payload: {
-                    ...failurePayload,
-                    recovery: goalActive ? "goal_continuation" : "user_message",
-                    rotated: true,
+                    fromAccountId: priorAccountId,
+                    toAccountId: effectiveCodexCredentialId,
+                    reason: rotated ? "rotation" : "manual",
                   },
                 },
-                { type: "session.status.changed", payload: { status: "idle" } },
-              ],
-              turnStatus: "failed",
-              sessionStatus: "idle",
-              activeTurnId: null,
-            }))
-          ) {
-            return claimedResult({ status: "cancelled" });
-          }
-          turnMetricOutcome = "failed";
-          activityStatus = "idle";
-          // idleUntilReset marks this a MANDATORY hold: session.ts must wait the full
-          // resumeMs even if a future change made it 0 — never a tight re-dispatch.
-          return claimedResult(
-            goalActive
-              ? {
-                  status: "idle",
-                  continueDelayMs: resumeMs,
-                  idleUntilReset: true,
-                }
-              : { status: "idle" },
-          );
-        }
-        if (effectiveCodexCredentialId) {
-          const priorAccountId = sessionCodex?.lastCredentialId ?? null;
-          await recordSessionActiveCodexCredential(
-            db,
-            input.workspaceId,
-            input.sessionId,
-            effectiveCodexCredentialId,
-          );
-          if (priorAccountId !== effectiveCodexCredentialId) {
-            const rotated = rotationDecision.kind === "active" && rotationDecision.moved;
+              ]);
+            }
+
+            const selectionReason = leased.reused
+              ? "lease_reused"
+              : sessionPin === effectiveCodexCredentialId
+                ? "pin"
+                : rotationDecision.kind === "active" && rotationDecision.moved
+                  ? "rotation"
+                  : "active";
+            observability.incrementCounter({
+              name: "opengeni_codex_credential_selections_total",
+              help: "Codex credential selections by strategy and reason.",
+              labels: {
+                workspace_key: codexWorkspaceKey,
+                strategy: leased.rotationStrategy,
+                reason: selectionReason,
+              },
+            });
             await publish([
               {
-                type: "codex.account.switched",
+                type: "codex.credential.selected",
                 payload: {
-                  fromAccountId: priorAccountId,
-                  toAccountId: effectiveCodexCredentialId,
-                  reason: rotated ? "rotation" : "manual",
+                  credentialId: effectiveCodexCredentialId,
+                  strategy: leased.rotationStrategy,
+                  reason: selectionReason,
+                  eligibleCount,
+                  connectedCount: leased.accounts.length,
+                  reused: leased.reused,
                 },
               },
             ]);
           }
-
-          const selectionReason = leased.reused
-            ? "lease_reused"
-            : sessionPin === effectiveCodexCredentialId
-              ? "pin"
-              : rotationDecision.kind === "active" && rotationDecision.moved
-                ? "rotation"
-                : "active";
-          observability.incrementCounter({
-            name: "opengeni_codex_credential_selections_total",
-            help: "Codex credential selections by strategy and reason.",
-            labels: {
-              workspace_key: codexWorkspaceKey,
-              strategy: leased.rotationStrategy,
-              reason: selectionReason,
-            },
+        } catch (error) {
+          credentialSelectionOutcome = "failed";
+          throw error;
+        } finally {
+          recordTurnStartupPhase(observability, {
+            phase: "credential_selection",
+            provider: "codex-subscription",
+            backend: turn.sandboxBackend,
+            outcome: credentialSelectionOutcome,
+            durationSeconds: (performance.now() - credentialSelectionStartedAt) / 1_000,
           });
-          await publish([
-            {
-              type: "codex.credential.selected",
-              payload: {
-                credentialId: effectiveCodexCredentialId,
-                strategy: leased.rotationStrategy,
-                reason: selectionReason,
-                eligibleCount,
-                connectedCount: leased.accounts.length,
-                reused: leased.reused,
-              },
-            },
-          ]);
         }
       }
 
@@ -5231,6 +5292,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           credentialId: effectiveXaiCredentialId,
         });
       }
+
+      const runtimePreparationStartedAt = performance.now();
 
       // Pack-scoped runtime: enabled packs may declare the sandbox image this
       // workspace's sessions run in and skills for the sandbox skill index.
@@ -5469,6 +5532,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // call on the same codex client) and the main run; otherwise the summarizer
       // would hit the codex backend unauthenticated.
       let codexModelRequestSequence = 0;
+      let firstModelRequestPreparationStartedAt: number | null = null;
+      let firstModelRequestPreparationRecorded = false;
+      let firstModelRequestAuditRecorded = false;
+      let firstModelRequestCheckpointAt: number | null = null;
+      const firstModelRequestCheckpoints = new Set<string>();
       const codexContext: CodexRequestContext | null =
         resolvedModel?.provider.kind === "codex-subscription"
           ? ((): CodexRequestContext => {
@@ -5499,10 +5567,51 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 onUsageHeaders: (snapshot) => {
                   latestCodexUsage = snapshot;
                 }, // latest wins; flushed once in finally
+                onRequestPreparationDiagnostic: (phase) => {
+                  if (
+                    firstModelRequestCheckpointAt === null ||
+                    firstModelRequestCheckpoints.has(phase)
+                  ) {
+                    return;
+                  }
+                  const now = performance.now();
+                  const metricPhase =
+                    phase === "transport_entry"
+                      ? "model_sdk_serialization"
+                      : phase === "credential_ready"
+                        ? "model_credential_resolution"
+                        : "model_wire_normalization";
+                  firstModelRequestCheckpoints.add(phase);
+                  recordTurnStartupPhase(observability, {
+                    phase: metricPhase,
+                    provider: turnExecutionPolicy.providerId,
+                    backend: activeSandboxBackend ?? groupBoxBackend,
+                    outcome: "completed",
+                    durationSeconds: (now - firstModelRequestCheckpointAt) / 1_000,
+                    count: turnTools.length,
+                  });
+                  firstModelRequestCheckpointAt = now;
+                },
                 onRequestOpaqueArtifacts: ({ fingerprints }) => {
                   lastCodexRequestOpaqueArtifacts = fingerprints;
                 },
                 onModelRequestDiagnostic: (event) => {
+                  if (
+                    event.phase === "started" &&
+                    firstModelRequestPreparationStartedAt !== null &&
+                    !firstModelRequestPreparationRecorded
+                  ) {
+                    firstModelRequestPreparationRecorded = true;
+                    recordTurnStartupPhase(observability, {
+                      phase: "model_request_preparation",
+                      provider: turnExecutionPolicy.providerId,
+                      backend: activeSandboxBackend ?? groupBoxBackend,
+                      outcome: "completed",
+                      durationSeconds:
+                        (performance.now() - firstModelRequestPreparationStartedAt) / 1_000,
+                      count: turnTools.length,
+                    });
+                  }
                   const phase =
                     event.phase === "headers"
                       ? "headers"
@@ -5532,19 +5641,42 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   if (!publish || !turnId) {
                     throw new Error("Codex model request started before the turn event producer");
                   }
-                  await publish([
-                    {
-                      type: "agent.model.request",
-                      payload: {
-                        ...event,
-                        provider: "codex-subscription",
-                        turnId,
-                        attemptId: input.attemptId,
-                        dispatchId,
-                        executionGeneration,
+                  const shouldRecordStartedAudit =
+                    event.phase === "started" && !firstModelRequestAuditRecorded;
+                  if (shouldRecordStartedAudit) {
+                    firstModelRequestAuditRecorded = true;
+                  }
+                  const auditStartedAt = shouldRecordStartedAudit ? performance.now() : null;
+                  let auditOutcome: "completed" | "failed" = "completed";
+                  try {
+                    await publish([
+                      {
+                        type: "agent.model.request",
+                        payload: {
+                          ...event,
+                          provider: "codex-subscription",
+                          turnId,
+                          attemptId: input.attemptId,
+                          dispatchId,
+                          executionGeneration,
+                        },
                       },
-                    },
-                  ]);
+                    ]);
+                  } catch (error) {
+                    auditOutcome = "failed";
+                    throw error;
+                  } finally {
+                    if (auditStartedAt !== null) {
+                      recordTurnStartupPhase(observability, {
+                        phase: "model_request_audit",
+                        provider: turnExecutionPolicy.providerId,
+                        backend: activeSandboxBackend ?? groupBoxBackend,
+                        outcome: auditOutcome,
+                        durationSeconds: (performance.now() - auditStartedAt) / 1_000,
+                        count: turnTools.length,
+                      });
+                    }
+                  }
                 },
               };
             })()
@@ -6085,17 +6217,22 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         cancellationSignal,
         undefined,
       );
-      const establishPolicy: "eager" | "on-demand" =
-        lazyProvisionEnabled(settings) &&
-        !machinePrimary &&
-        runSettings.sandboxBackend !== "none" &&
+      const establishDecision = sandboxEstablishPolicyDecision({
+        lazyEnabled: lazyProvisionEnabled(settings),
+        machinePrimary,
+        sandboxBackend: runSettings.sandboxBackend,
         // Resolved run credentials must be written to one exact leased sandbox
         // before agent execution. A warm active pointer can bypass the lazy
         // provisioner entirely, which previously skipped materialization.
-        !initialRunCredentialMaterial &&
-        requiredGeneratedVideoFiles.length === 0
-          ? "on-demand"
-          : "eager";
+        hasInitialRunCredentialMaterial: initialRunCredentialMaterial !== null,
+        generatedVideoFileCount: requiredGeneratedVideoFiles.length,
+      });
+      const establishPolicy = establishDecision.policy;
+      recordTurnSandboxEstablishPolicy(observability, {
+        policy: establishDecision.policy,
+        reason: establishDecision.reason,
+        backend: machinePrimary ? "selfhosted" : groupBoxBackend,
+      });
       // Computed exactly ONCE per turn and reused for BOTH the box manifest
       // (resumeBoxForTurn -> establishSandboxSessionFromEnvelope, below) AND the
       // agent (runtime.buildAgent, below). sandboxEnvironmentForRun mints a FRESH
@@ -6568,6 +6705,13 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // applies the agent's manifest to this provided session and throws on ANY
       // variableSet delta (validateNoEnvironmentDelta). Passing sandboxEnvironment
       // here makes current==target so the delta is empty.
+      recordTurnStartupPhase(observability, {
+        phase: "runtime_preparation",
+        provider: turnExecutionPolicy.providerId,
+        backend: activeSandboxBackend ?? groupBoxBackend,
+        outcome: "completed",
+        durationSeconds: (performance.now() - runtimePreparationStartedAt) / 1_000,
+      });
       if (
         shouldEstablishSandboxForTurn(
           settings.sandboxOwnershipEnabled,
@@ -6575,242 +6719,275 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           machinePrimary,
         )
       ) {
-        const managedOwnership = managedSandboxOwnershipForTurn(
-          machinePrimary,
-          input.attemptId,
-          session.sandboxGroupId,
-        );
-        sandboxHolderId = managedOwnership?.holderId ?? null;
-        sandboxGroupId = managedOwnership?.sandboxGroupId ?? null;
-        // STAGE D honest-label guard: a machine-home session carries
-        // turn.sandboxBackend "selfhosted", but a turn is only machine-PRIMARY
-        // when a live machine pointer resolves (activeSandboxBackend==='selfhosted'
-        // + enrollmentId). When it is NOT primary — the agent swapped back to the
-        // group box (sandbox_swap 'session'/'default'/groupId clears the pointer) or
-        // selfhosted routing is flag-OFF (the pointer is ignored) — the else-branch
-        // must resume a REAL cloud group box, not a "selfhosted" one: the registry
-        // SelfhostedSandboxClient has no bound agentId and throws. Fall the group-box
-        // backend back to the deployment default cloud backend so swap-away / flag-off
-        // degrade to a genuine cloud box exactly like today (home=modal did).
-        if (machinePrimary) {
-          // STAGE D D1-lite: the active sandbox is a connected machine, so DO NOT
-          // establish OR lease the managed home box. The active-sandbox pointer is
-          // the machine route's own epoch fence; the managed-home lease separately
-          // owns cloud recovery, snapshots, billing, and reaping. Mixing those two
-          // ownership domains lets an unrelated degraded cloud archive block a
-          // healthy explicitly selected machine.
-          // Whether the machine's latest Hello advertised the op-stream engine
-          // (refreshed on every connect). Read only when the server flag is on —
-          // one indexed lookup, and the flag off keeps this path byte-identical.
-          const machineOpStream =
-            settings.agentOpStreamEnabled === true
-              ? (await getEnrollment(db, input.workspaceId, activeSandboxRecord!.enrollmentId!))
-                  ?.opStream === true
-              : false;
-          const established = await establishSelfhostedTurnSession(
-            {
-              db,
-              settings,
-              bus,
-              onOp: machineOpObserver.observer,
-              onSandboxOperation: sandboxOperationObserver,
-              opJournal,
-            },
-            {
-              workspaceId: input.workspaceId,
-              agentId: activeSandboxRecord!.enrollmentId!,
-              opStream: machineOpStream,
-              epoch: activeSandboxPointer!.activeEpoch,
-              environment: sandboxEnvironment,
-              ...(transientCodemodeEnvironment
-                ? { transientExecEnvironment: transientCodemodeEnvironment }
-                : {}),
-              workingDir: activeSandboxPointer!.workingDir,
-            },
+        const sandboxEstablishStartedAt = performance.now();
+        let sandboxEstablishOutcome: "completed" | "failed" = "completed";
+        try {
+          const managedOwnership = managedSandboxOwnershipForTurn(
+            machinePrimary,
+            input.attemptId,
+            session.sandboxGroupId,
           );
-          // The machine-primary establish narrows `session` to SelfhostedSession
-          // (buildSelfhostedBackendSession); EstablishedSandboxSession widens it.
-          machinePrimarySession =
-            established.session as import("@opengeni/runtime").SelfhostedSession;
-          setupBoxSession = established.session;
-          resolvedSandbox = {
-            // Wrap in the SAME routing proxy so a mid-turn swap (to another machine
-            // or back to the group box) still re-routes per op. PIN this established
-            // SelfhostedSession for the machine pointer so the turn-start manifest
-            // write (via the proxy's `state` getter) and the per-op reads hit ONE
-            // instance — no two-instance manifest divergence.
-            established: wrapTurnBoxWithRouting(
+          sandboxHolderId = managedOwnership?.holderId ?? null;
+          sandboxGroupId = managedOwnership?.sandboxGroupId ?? null;
+          // STAGE D honest-label guard: a machine-home session carries
+          // turn.sandboxBackend "selfhosted", but a turn is only machine-PRIMARY
+          // when a live machine pointer resolves (activeSandboxBackend==='selfhosted'
+          // + enrollmentId). When it is NOT primary — the agent swapped back to the
+          // group box (sandbox_swap 'session'/'default'/groupId clears the pointer) or
+          // selfhosted routing is flag-OFF (the pointer is ignored) — the else-branch
+          // must resume a REAL cloud group box, not a "selfhosted" one: the registry
+          // SelfhostedSandboxClient has no bound agentId and throws. Fall the group-box
+          // backend back to the deployment default cloud backend so swap-away / flag-off
+          // degrade to a genuine cloud box exactly like today (home=modal did).
+          if (machinePrimary) {
+            // STAGE D D1-lite: the active sandbox is a connected machine, so DO NOT
+            // establish OR lease the managed home box. The active-sandbox pointer is
+            // the machine route's own epoch fence; the managed-home lease separately
+            // owns cloud recovery, snapshots, billing, and reaping. Mixing those two
+            // ownership domains lets an unrelated degraded cloud archive block a
+            // healthy explicitly selected machine.
+            // Whether the machine's latest Hello advertised the op-stream engine
+            // (refreshed on every connect). Read only when the server flag is on —
+            // one indexed lookup, and the flag off keeps this path byte-identical.
+            const machineOpStream =
+              settings.agentOpStreamEnabled === true
+                ? (await getEnrollment(db, input.workspaceId, activeSandboxRecord!.enrollmentId!))
+                    ?.opStream === true
+                : false;
+            const established = await establishSelfhostedTurnSession(
               {
                 db,
                 settings,
                 bus,
-                opJournal,
                 onOp: machineOpObserver.observer,
                 onSandboxOperation: sandboxOperationObserver,
-                onHomeSandboxRebound,
-                ...(runtimeCancellationSignal ? { waitSignal: runtimeCancellationSignal } : {}),
-              },
-              {
-                workspaceId: input.workspaceId,
-                sessionId: input.sessionId,
-                environment: sandboxEnvironment,
-                ...(transientCodemodeEnvironment
-                  ? { transientExecEnvironment: transientCodemodeEnvironment }
-                  : {}),
-                workspaceMutationFence: {
-                  accountId: input.accountId,
-                  turnId: turn.id,
-                  executionGeneration,
-                  attemptId: input.attemptId,
-                },
-                pinnedSelfhosted: {
-                  sandboxId: activeSandboxPointer!.activeSandboxId!,
-                  epoch: activeSandboxPointer!.activeEpoch,
-                },
-                // HOME semantics for a mid-turn clear-to-null: only a genuine
-                // machine-HOME session (its home IS this machine, session.sandboxBackend
-                // === "selfhosted") resolves null back to the pinned machine. A Modal-HOME
-                // session merely PINNED to a machine this turn never established its group
-                // box, so defaultIsHome:false makes a clear-to-null fail typed
-                // (`home_unavailable_this_turn`) rather than silently serving the machine;
-                // the detach takes effect next turn. (Lazy home-box establishment on such a
-                // clear is a deferred follow-up; issue #341.)
-                defaultIsHome: session.sandboxBackend === "selfhosted",
-              },
-              established,
-            ),
-            // For a machine route this is the active-pointer epoch, not a cloud
-            // lease epoch. Cloud-only heartbeat/snapshot/capture paths require
-            // sandboxGroupId and remain disabled for this branch.
-            leaseEpoch: activeSandboxPointer!.activeEpoch,
-            release: async () => undefined,
-          };
-        } else if (establishPolicy === "on-demand") {
-          // Lazy sandbox provisioning: holder/group ids are fixed at turn start,
-          // but the lease acquire + box establish + setup move behind the routing
-          // proxy's first default-pointer op. A chat-only turn never calls it, so
-          // no lease row, no provider box, no warm-meter interval.
-        } else {
-          resolvedSandbox = await waitForTurnOperation(
-            resumeBoxForTurn(
-              {
-                db,
-                settings: runSettings,
-                logicalFallbackSettings: logicalSandboxSettings,
-                cancellationSignal: sandboxResumeSignal,
-                sandboxMetrics: runtimeMetricsHooksForObservability(observability),
-                onSandboxLost: publishSandboxLost,
-              },
-              {
-                accountId: input.accountId,
-                workspaceId: input.workspaceId,
-                sandboxGroupId: session.sandboxGroupId,
-                sessionId: input.sessionId,
-                // groupBoxBackend, not turn.sandboxBackend: a machine-home turn that
-                // is not machine-primary resumes a real cloud group box (the
-                // deployment default), never a "selfhosted" box (which would throw
-                // for lack of a bound agentId).
-                backend: groupBoxBackend,
-                os: session.sandboxOs,
-                environment: sandboxEnvironment,
-                // IMAGE IS SHARED STATE (B3, Modal warm-box path only): the container image
-                // this run resolves. The lease stamps it + conflicts on a live shared box
-                // running a DIFFERENT image (solo → durable rotation; N-holders →
-                // SandboxImageConflictError surfaced as an actionable turn error). Prefer
-                // the explicit Modal image ref, else the docker image. The selfhosted branch
-                // (establishSelfhostedTurnSession) NEVER passes
-                // an image — B3 lives only on this Modal else-branch.
-                ...((runSettings.modalImageRef ?? runSettings.dockerImage)
-                  ? {
-                      image: runSettings.modalImageRef ?? runSettings.dockerImage,
-                    }
-                  : {}),
-                // RIG IS SHARED STATE (M3): stamp the frozen rig version so the lease
-                // conflicts on a live shared box set up under a different rig (solo
-                // durable rotation / N-holders SandboxRigConflictError). Omitted for a
-                // rig-less turn -> never stamped or enforced (shares exactly as today).
-                ...(rigVersion ? { rigVersionId: rigVersion.id } : {}),
-              },
-              "turn",
-              managedOwnership!.holderId,
-            ),
-            sandboxResumeSignal,
-            releaseLateSandbox,
-          );
-          setupBoxSession = resolvedSandbox.established.session;
-          // Durable box-lifecycle events (sandbox-file-persistence observability):
-          // record every box transition in session_events so the NEXT box loss is
-          // attributable from the DB alone — worker logs rotate within hours, which
-          // left both 2026-07-06 incidents without a durable trace. Best-effort.
-          await publishSandboxLifecycleEvents(resolvedSandbox);
-          // M7 hot-swap: when the selfhosted feature is on, wrap the established
-          // group box in the STABLE routing proxy before it is injected NON-OWNED
-          // into the run. The SDK binds to this ONE object once and calls its
-          // methods per tool call; the proxy re-reads (active_sandbox_id,
-          // active_epoch) per op and dispatches to the currently-active backend, so
-          // a sandbox_swap mid-turn lands the NEXT tool call on the new box. With
-          // the flag off the established group box is injected unchanged (today's
-          // path). The lease still owns the group box lifecycle — the proxy is a
-          // routing veneer, not an owner.
-          resolvedSandbox = {
-            ...resolvedSandbox,
-            established: wrapTurnBoxWithRouting(
-              {
-                db,
-                settings,
-                bus,
                 opJournal,
-                onSandboxOperation: sandboxOperationObserver,
-                onHomeSandboxLost: publishSandboxLost,
-                onHomeSandboxRebound,
-                ...(runtimeCancellationSignal ? { waitSignal: runtimeCancellationSignal } : {}),
               },
-              // Thread the SAME declared environment the group box was created with
-              // (resumeBoxForTurn, above) so a selfhosted swap target's manifest
-              // carries it too — the SDK's per-turn manifest-env delta stays empty
-              // (no "cannot change manifest environment variables" throw).
               {
                 workspaceId: input.workspaceId,
-                sessionId: input.sessionId,
+                agentId: activeSandboxRecord!.enrollmentId!,
+                opStream: machineOpStream,
+                epoch: activeSandboxPointer!.activeEpoch,
                 environment: sandboxEnvironment,
                 ...(transientCodemodeEnvironment
                   ? { transientExecEnvironment: transientCodemodeEnvironment }
                   : {}),
-                workspaceMutationFence: {
-                  accountId: input.accountId,
-                  turnId: turn.id,
-                  executionGeneration,
-                  attemptId: input.attemptId,
-                },
-                homeLease: {
-                  accountId: input.accountId,
-                  sandboxGroupId: session.sandboxGroupId,
-                  leaseEpoch: resolvedSandbox.leaseEpoch,
-                  instanceId: resolvedSandbox.established.instanceId,
-                  backend: groupBoxBackend,
-                },
+                workingDir: activeSandboxPointer!.workingDir,
               },
-              resolvedSandbox.established,
-            ),
-          };
-        }
-        if (resolvedSandbox) {
-          startLeaseHeartbeat(resolvedSandbox, activeSandboxBackend ?? groupBoxBackend);
+            );
+            // The machine-primary establish narrows `session` to SelfhostedSession
+            // (buildSelfhostedBackendSession); EstablishedSandboxSession widens it.
+            machinePrimarySession =
+              established.session as import("@opengeni/runtime").SelfhostedSession;
+            setupBoxSession = established.session;
+            resolvedSandbox = {
+              // Wrap in the SAME routing proxy so a mid-turn swap (to another machine
+              // or back to the group box) still re-routes per op. PIN this established
+              // SelfhostedSession for the machine pointer so the turn-start manifest
+              // write (via the proxy's `state` getter) and the per-op reads hit ONE
+              // instance — no two-instance manifest divergence.
+              established: wrapTurnBoxWithRouting(
+                {
+                  db,
+                  settings,
+                  bus,
+                  opJournal,
+                  onOp: machineOpObserver.observer,
+                  onSandboxOperation: sandboxOperationObserver,
+                  onHomeSandboxRebound,
+                  ...(runtimeCancellationSignal ? { waitSignal: runtimeCancellationSignal } : {}),
+                },
+                {
+                  workspaceId: input.workspaceId,
+                  sessionId: input.sessionId,
+                  environment: sandboxEnvironment,
+                  ...(transientCodemodeEnvironment
+                    ? { transientExecEnvironment: transientCodemodeEnvironment }
+                    : {}),
+                  workspaceMutationFence: {
+                    accountId: input.accountId,
+                    turnId: turn.id,
+                    executionGeneration,
+                    attemptId: input.attemptId,
+                  },
+                  pinnedSelfhosted: {
+                    sandboxId: activeSandboxPointer!.activeSandboxId!,
+                    epoch: activeSandboxPointer!.activeEpoch,
+                  },
+                  // HOME semantics for a mid-turn clear-to-null: only a genuine
+                  // machine-HOME session (its home IS this machine, session.sandboxBackend
+                  // === "selfhosted") resolves null back to the pinned machine. A Modal-HOME
+                  // session merely PINNED to a machine this turn never established its group
+                  // box, so defaultIsHome:false makes a clear-to-null fail typed
+                  // (`home_unavailable_this_turn`) rather than silently serving the machine;
+                  // the detach takes effect next turn. (Lazy home-box establishment on such a
+                  // clear is a deferred follow-up; issue #341.)
+                  defaultIsHome: session.sandboxBackend === "selfhosted",
+                },
+                established,
+              ),
+              // For a machine route this is the active-pointer epoch, not a cloud
+              // lease epoch. Cloud-only heartbeat/snapshot/capture paths require
+              // sandboxGroupId and remain disabled for this branch.
+              leaseEpoch: activeSandboxPointer!.activeEpoch,
+              release: async () => undefined,
+            };
+          } else if (establishPolicy === "on-demand") {
+            // Lazy sandbox provisioning: holder/group ids are fixed at turn start,
+            // but the lease acquire + box establish + setup move behind the routing
+            // proxy's first default-pointer op. A chat-only turn never calls it, so
+            // no lease row, no provider box, no warm-meter interval.
+          } else {
+            resolvedSandbox = await waitForTurnOperation(
+              resumeBoxForTurn(
+                {
+                  db,
+                  settings: runSettings,
+                  logicalFallbackSettings: logicalSandboxSettings,
+                  cancellationSignal: sandboxResumeSignal,
+                  sandboxMetrics: runtimeMetricsHooksForObservability(observability),
+                  onSandboxLost: publishSandboxLost,
+                },
+                {
+                  accountId: input.accountId,
+                  workspaceId: input.workspaceId,
+                  sandboxGroupId: session.sandboxGroupId,
+                  sessionId: input.sessionId,
+                  // groupBoxBackend, not turn.sandboxBackend: a machine-home turn that
+                  // is not machine-primary resumes a real cloud group box (the
+                  // deployment default), never a "selfhosted" box (which would throw
+                  // for lack of a bound agentId).
+                  backend: groupBoxBackend,
+                  os: session.sandboxOs,
+                  environment: sandboxEnvironment,
+                  // IMAGE IS SHARED STATE (B3, Modal warm-box path only): the container image
+                  // this run resolves. The lease stamps it + conflicts on a live shared box
+                  // running a DIFFERENT image (solo → durable rotation; N-holders →
+                  // SandboxImageConflictError surfaced as an actionable turn error). Prefer
+                  // the explicit Modal image ref, else the docker image. The selfhosted branch
+                  // (establishSelfhostedTurnSession) NEVER passes
+                  // an image — B3 lives only on this Modal else-branch.
+                  ...((runSettings.modalImageRef ?? runSettings.dockerImage)
+                    ? {
+                        image: runSettings.modalImageRef ?? runSettings.dockerImage,
+                      }
+                    : {}),
+                  // RIG IS SHARED STATE (M3): stamp the frozen rig version so the lease
+                  // conflicts on a live shared box set up under a different rig (solo
+                  // durable rotation / N-holders SandboxRigConflictError). Omitted for a
+                  // rig-less turn -> never stamped or enforced (shares exactly as today).
+                  ...(rigVersion ? { rigVersionId: rigVersion.id } : {}),
+                },
+                "turn",
+                managedOwnership!.holderId,
+              ),
+              sandboxResumeSignal,
+              releaseLateSandbox,
+            );
+            setupBoxSession = resolvedSandbox.established.session;
+            // Durable box-lifecycle events (sandbox-file-persistence observability):
+            // record every box transition in session_events so the NEXT box loss is
+            // attributable from the DB alone — worker logs rotate within hours, which
+            // left both 2026-07-06 incidents without a durable trace. Best-effort.
+            await publishSandboxLifecycleEvents(resolvedSandbox);
+            // M7 hot-swap: when the selfhosted feature is on, wrap the established
+            // group box in the STABLE routing proxy before it is injected NON-OWNED
+            // into the run. The SDK binds to this ONE object once and calls its
+            // methods per tool call; the proxy re-reads (active_sandbox_id,
+            // active_epoch) per op and dispatches to the currently-active backend, so
+            // a sandbox_swap mid-turn lands the NEXT tool call on the new box. With
+            // the flag off the established group box is injected unchanged (today's
+            // path). The lease still owns the group box lifecycle — the proxy is a
+            // routing veneer, not an owner.
+            resolvedSandbox = {
+              ...resolvedSandbox,
+              established: wrapTurnBoxWithRouting(
+                {
+                  db,
+                  settings,
+                  bus,
+                  opJournal,
+                  onSandboxOperation: sandboxOperationObserver,
+                  onHomeSandboxLost: publishSandboxLost,
+                  onHomeSandboxRebound,
+                  ...(runtimeCancellationSignal ? { waitSignal: runtimeCancellationSignal } : {}),
+                },
+                // Thread the SAME declared environment the group box was created with
+                // (resumeBoxForTurn, above) so a selfhosted swap target's manifest
+                // carries it too — the SDK's per-turn manifest-env delta stays empty
+                // (no "cannot change manifest environment variables" throw).
+                {
+                  workspaceId: input.workspaceId,
+                  sessionId: input.sessionId,
+                  environment: sandboxEnvironment,
+                  ...(transientCodemodeEnvironment
+                    ? { transientExecEnvironment: transientCodemodeEnvironment }
+                    : {}),
+                  workspaceMutationFence: {
+                    accountId: input.accountId,
+                    turnId: turn.id,
+                    executionGeneration,
+                    attemptId: input.attemptId,
+                  },
+                  homeLease: {
+                    accountId: input.accountId,
+                    sandboxGroupId: session.sandboxGroupId,
+                    leaseEpoch: resolvedSandbox.leaseEpoch,
+                    instanceId: resolvedSandbox.established.instanceId,
+                    backend: groupBoxBackend,
+                  },
+                },
+                resolvedSandbox.established,
+              ),
+            };
+          }
+          if (resolvedSandbox) {
+            startLeaseHeartbeat(resolvedSandbox, activeSandboxBackend ?? groupBoxBackend);
+          }
+        } catch (error) {
+          sandboxEstablishOutcome = "failed";
+          throw error;
+        } finally {
+          recordTurnStartupPhase(observability, {
+            phase: "sandbox_establish",
+            provider: turnExecutionPolicy.providerId,
+            backend: machinePrimary ? "selfhosted" : groupBoxBackend,
+            outcome: sandboxEstablishOutcome,
+            durationSeconds: (performance.now() - sandboxEstablishStartedAt) / 1_000,
+          });
         }
       }
 
-      const ordinaryFileResourceDownloads = await waitForTurnOperation(
-        sandboxFileDownloadsForRun(
-          runSettings,
-          db,
-          objectStorage,
-          input.workspaceId,
-          turnResources,
-          activeSandboxBackend ?? groupBoxBackend,
-        ),
-        cancellationSignal,
-        undefined,
-      );
+      const ordinaryFileResourceDownloads = await (async () => {
+        const fileResolutionStartedAt = performance.now();
+        let fileResolutionOutcome: "completed" | "failed" = "completed";
+        try {
+          return await waitForTurnOperation(
+            sandboxFileDownloadsForRun(
+              runSettings,
+              db,
+              objectStorage,
+              input.workspaceId,
+              turnResources,
+              activeSandboxBackend ?? groupBoxBackend,
+            ),
+            cancellationSignal,
+            undefined,
+          );
+        } catch (error) {
+          fileResolutionOutcome = "failed";
+          throw error;
+        } finally {
+          recordTurnStartupPhase(observability, {
+            phase: "file_resolution",
+            provider: turnExecutionPolicy.providerId,
+            backend: activeSandboxBackend ?? groupBoxBackend,
+            outcome: fileResolutionOutcome,
+            durationSeconds: (performance.now() - fileResolutionStartedAt) / 1_000,
+            count: turnResources.length,
+          });
+        }
+      })();
       if (requiredGeneratedVideoFiles.length > 0 && !objectStorage) {
         throw new Error("Generated video materialization requires object storage");
       }
@@ -6840,6 +7017,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           ]),
         ).values(),
       ];
+      const toolContextPreparationStartedAt = performance.now();
       throwIfWorkerShuttingDown();
       throwIfTurnCancelled();
       const mcpCredentialRootSessionId =
@@ -6938,59 +7116,94 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         runSettings,
         session.firstPartyMcpTools,
       );
-      preparedTools = await waitForTurnOperation(
-        runtime.prepareTools(runSettings, turnTools, {
-          accountId: input.accountId,
-          workspaceId: input.workspaceId,
-          sessionId: input.sessionId,
-          // Sign the calling turn into the first-party token so tools classify
-          // the caller by its own identity (sacred-pause guard), not the racy
-          // live active pointer.
-          ...(turnId ? { turnId } : {}),
-          attemptId: input.attemptId,
-          executionGeneration,
-          subjectId: "worker:first-party-mcp",
-          subjectLabel: "OpenGeni worker",
-          ...(credentialSubjectId ? { credentialSubjectId } : {}),
-          ...(codexAppsAuth ? { codexAppsAuth } : {}),
-          resolveCredential,
-          onAuthNeeded: publishToolAuthNeeded,
-          localMcpServers,
-          onAttemptToolCatalog: async (catalog) => {
-            await persistAttemptToolCatalog(db, catalog);
-          },
-          // Manager-style sessions carry a creation-validated permission set
-          // for their first-party MCP token; null keeps the fixed default.
-          ...(session.firstPartyMcpPermissions?.length
-            ? { firstPartyPermissions: session.firstPartyMcpPermissions }
-            : {}),
-          firstPartyTools: selectedFirstPartyMcpTools,
-          nestedAgentDepth: session.nestedAgentDepth,
-          effectiveMaxNestedAgentDepth: session.effectiveMaxNestedAgentDepth,
-          attemptToolDefinitions: createFirstPartyInteractionAttemptToolDefinitions({
-            settings: runSettings,
-            scope: {
-              accountId: input.accountId,
-              workspaceId: input.workspaceId,
-              sessionId: input.sessionId,
-              turnId: turn.id,
-              attemptId: input.attemptId,
-              executionGeneration,
-            },
-            ...(session.firstPartyMcpPermissions?.length
-              ? { permissions: session.firstPartyMcpPermissions }
-              : {}),
-            selectedTools: selectedFirstPartyMcpTools,
+      recordTurnStartupPhase(observability, {
+        phase: "tool_context_preparation",
+        provider: turnExecutionPolicy.providerId,
+        backend: activeSandboxBackend ?? groupBoxBackend,
+        outcome: "completed",
+        durationSeconds: (performance.now() - toolContextPreparationStartedAt) / 1_000,
+        count: turnTools.length,
+      });
+      const toolPreparationStartedAt = performance.now();
+      let toolPreparationOutcome: "completed" | "failed" = "completed";
+      try {
+        preparedTools = await waitForTurnOperation(
+          runtime.prepareTools(runSettings, turnTools, {
+            accountId: input.accountId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            // Sign the calling turn into the first-party token so tools classify
+            // the caller by its own identity (sacred-pause guard), not the racy
+            // live active pointer.
+            ...(turnId ? { turnId } : {}),
+            attemptId: input.attemptId,
+            executionGeneration,
             subjectId: "worker:first-party-mcp",
             subjectLabel: "OpenGeni worker",
-            ...(interactionInterventionResume
-              ? { interventionResume: interactionInterventionResume }
+            ...(credentialSubjectId ? { credentialSubjectId } : {}),
+            ...(codexAppsAuth ? { codexAppsAuth } : {}),
+            resolveCredential,
+            onAuthNeeded: publishToolAuthNeeded,
+            localMcpServers,
+            onPreparationPhase: (measurement) => {
+              recordTurnStartupPhase(observability, {
+                phase: `tool_${measurement.phase}`,
+                provider: turnExecutionPolicy.providerId,
+                backend: activeSandboxBackend ?? groupBoxBackend,
+                outcome: measurement.outcome,
+                durationSeconds: measurement.durationSeconds,
+                count: turnTools.length,
+              });
+            },
+            onAttemptToolCatalog: async (catalog) => {
+              await persistAttemptToolCatalog(db, catalog);
+            },
+            // Manager-style sessions carry a creation-validated permission set
+            // for their first-party MCP token; null keeps the fixed default.
+            ...(session.firstPartyMcpPermissions?.length
+              ? { firstPartyPermissions: session.firstPartyMcpPermissions }
               : {}),
+            firstPartyTools: selectedFirstPartyMcpTools,
+            nestedAgentDepth: session.nestedAgentDepth,
+            effectiveMaxNestedAgentDepth: session.effectiveMaxNestedAgentDepth,
+            attemptToolDefinitions: createFirstPartyInteractionAttemptToolDefinitions({
+              settings: runSettings,
+              scope: {
+                accountId: input.accountId,
+                workspaceId: input.workspaceId,
+                sessionId: input.sessionId,
+                turnId: turn.id,
+                attemptId: input.attemptId,
+                executionGeneration,
+              },
+              ...(session.firstPartyMcpPermissions?.length
+                ? { permissions: session.firstPartyMcpPermissions }
+                : {}),
+              selectedTools: selectedFirstPartyMcpTools,
+              subjectId: "worker:first-party-mcp",
+              subjectLabel: "OpenGeni worker",
+              ...(interactionInterventionResume
+                ? { interventionResume: interactionInterventionResume }
+                : {}),
+            }),
           }),
-        }),
-        cancellationSignal,
-        async (latePreparedTools) => await latePreparedTools.close().catch(() => undefined),
-      );
+          cancellationSignal,
+          async (latePreparedTools) => await latePreparedTools.close().catch(() => undefined),
+        );
+      } catch (error) {
+        toolPreparationOutcome = "failed";
+        throw error;
+      } finally {
+        recordTurnStartupPhase(observability, {
+          phase: "tool_preparation",
+          provider: turnExecutionPolicy.providerId,
+          backend: activeSandboxBackend ?? groupBoxBackend,
+          outcome: toolPreparationOutcome,
+          durationSeconds: (performance.now() - toolPreparationStartedAt) / 1_000,
+          count: turnTools.length,
+        });
+      }
+      const postToolPreparationStartedAt = performance.now();
       if (turnId && preparedTools.attemptToolEnvironment) {
         codemodeDispatcher = new CodemodeAttemptDispatcher(
           db,
@@ -7405,176 +7618,201 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           reason: "attached to session",
         })),
       ];
-      const agent = runtime.buildAgent(modelRunSettings, turnResources, {
-        reasoningEffort: turn.reasoningEffort,
-        latencyMode: turnExecutionPolicy.latencyMode,
-        ...(serviceTier ? { serviceTier } : {}),
-        ...(humanInputResume ? { humanInputResponse: humanInputResume } : {}),
-        humanInputEnabled: agentHumanInputEnabled,
-        genesisTitleHint: isGenesisTurn,
-        persistentSessionSettings: {
-          titleIsSet: Boolean(session.title?.trim()),
-        },
-        sandboxEnvironment,
-        ...(preparedTools.attemptToolCatalog
-          ? { attemptToolCatalog: preparedTools.attemptToolCatalog }
-          : {}),
-        ...(sandboxArtifactRuntime.available ? { artifactRuntimeAvailable: true } : {}),
-        ...(cancellationSignal ? { turnCancellationSignal: cancellationSignal } : {}),
-        onToolCancellationFence: (fence) => {
-          toolCancellationFenceRef.current = fence;
-        },
-        // TOKEN-BROKER (B1): forward the per-turn git token OFF-MANIFEST as the clone
-        // seed. ONLY when the effective backend is NOT selfhosted (the connected
-        // machine uses its own git creds — mirrors the skipGitHubToken gate above)
-        // AND the mint actually produced a token (repo resources present). The runtime
-        // seeds it to the box's token file before the repository-clone runs; it never
-        // touches the box/agent manifest env.
-        ...(activeSandboxBackend !== "selfhosted" && sandboxGitTokens
-          ? { gitTokenSeeds: sandboxGitTokens }
-          : {}),
-        ...(activeSandboxBackend !== "selfhosted" && sandboxGitCredentialBindings
-          ? { gitCredentialBindings: sandboxGitCredentialBindings }
-          : {}),
-        ...(activeSandboxBackend !== "selfhosted" && !sandboxGitTokens && sandboxGitToken
-          ? { gitTokenSeed: sandboxGitToken }
-          : {}),
-        ...(sandboxCodemodeToken ? { codemodeAvailable: true } : {}),
-        // Managed boxes receive the bearer through their protected per-session
-        // token file. Connected Machines use transient per-exec delivery above,
-        // so they must not run the file-seeding lifecycle hook.
-        ...(activeSandboxBackend !== "selfhosted" && sandboxCodemodeToken
-          ? {
-              codemodeTokenSeed: sandboxCodemodeToken,
-              codemodeTokenSessionId: input.sessionId,
-            }
-          : {}),
-        ...(activeSandboxBackend ? { activeSandboxBackend } : {}),
-        fileResourceDownloads,
-        mcpServers: preparedTools.mcpServers,
-        resolvedMcpConnectionIds: preparedTools.resolvedMcpConnectionIds,
-        connectorActionPolicy,
-        // LIVE by-reference connector namespaces (fills during this turn's
-        // codex_apps tools/list): the codex tool_search description reads it per
-        // model call so the model sees the account's real connected sources.
-        codexConnectorNamespaces: preparedTools.codexConnectorNamespaces,
-        // Resolved-model routing + gating (legacy defaults when null). The model
-        // is passed as the model *string* (agent.model = runSettings.openaiModel),
-        // NOT a Model instance: an instance only survives the in-process
-        // ("none") run, whereas the SandboxAgent/Modal path drops it and
-        // re-resolves the model *name* through the global MultiProviderModelProvider
-        // configureOpenAI installed — so registry models (Fireworks GLM) route to
-        // their own client instead of 404ing against the built-in Azure/OpenAI
-        // client. The gating still comes from the resolved provider: server-side
-        // store/compaction follow the provider's compaction mode (registry
-        // providers resolve to "client"); encrypted reasoning is only
-        // round-tripped on the Responses wire API; hosted web search is attached
-        // whenever the provider declares it runnable and is independent of the
-        // session's MCP allow-list; the effective context window drives the
-        // compaction threshold.
-        hostedWebSearch,
-        ...imageGenerationOption,
-        ...videoGenerationOption,
-        lazyToolTransport,
-        supportsImageInput,
-        inputFileMediaTypes: modelInputPolicy.inputFileMediaTypes,
-        ...(resolvedModel
-          ? {
-              encryptedReasoning:
-                resolvedModel.provider.api === "responses" &&
-                runSettings.openaiReasoningEncryptedContent,
-              contextWindowTokens:
-                resolvedModel.configured.contextWindowTokens ?? runSettings.contextWindowTokens,
-              // The ChatGPT/Codex backend rejects the SDK's HOSTED apply_patch
-              // tool. Gateway Responses routes likewise expose ordinary function
-              // tools, not OpenAI-hosted sandbox tools. Tell buildAgent to use
-              // function apply_patch and wrap successful view_image results as
-              // typed input_image content. Chat wires have no proven typed image
-              // result transport and therefore receive no view_image tool.
-              structuredToolTransport: structuredToolTransportForTurn(resolvedModel),
-              // EXPLICIT computer-use tool transport, derived from the resolved provider's
-              // authoritative wire identity (codex → function-image, chat → disabled,
-              // responses → hosted) so the runtime never string-sniffs the model instance's
-              // constructor name. See {@link computerToolModeForTurn}.
-              computerToolMode: computerToolModeForTurn(resolvedModel),
-              ...(promptCacheKey ? { promptCacheKey } : {}),
-            }
-          : // LEGACY global-client fallback (resolveTurnModel returned null → the model
-            // is not in the registry, served by the built-in OpenAI/Azure Responses
-            // client). That backend has real hosted support, so pin computerToolMode to
-            // "hosted" EXPLICITLY rather than leaving the runtime to sniff the instance.
-            {
-              computerToolMode: computerToolModeForTurn(null),
-              promptCacheKey: input.sessionId,
-            }),
-        // Lazy computer-use seam: runtime first brings up :0 only after the model
-        // selects a computer tool, then this hook begins the optional proof
-        // recording. Shell/filesystem turns never invoke either operation.
-        onComputerUseReady: async () => {
-          if (!resolvedSandbox) {
-            throw new Error("Computer-use display became ready without a resolved sandbox");
-          }
-          // This callback is the authoritative execution boundary. Record the
-          // action before async ffmpeg startup so transport-event ordering cannot
-          // make settlement misclassify a real computer turn as unused.
-          didComputerUse = true;
-          await maybeStartOnTurnRecording(resolvedSandbox, activeSandboxBackend);
-        },
-        onRetainableSessionImageOutput: retainSessionImageAtToolBoundary,
-        ...(runtimeSkillActivations.length > 0
-          ? { skillActivations: runtimeSkillActivations }
-          : {}),
-        ...(!structuredWorkspacePolicyActive && workspaceAgentInstructions
-          ? { instructionsTemplate: workspaceAgentInstructions }
-          : {}),
-        ...(workspaceGovernance ? { workspaceGovernance } : {}),
-        ...(workspaceMemory ? { workspaceMemory } : {}),
-        goalSnapshot: turn.goalSnapshot,
-        // Per-session persona tier (session > workspace > deployment default).
-        // Composed system-level AFTER the workspace persona so it refines it for
-        // this one session; absent ⇒ byte-identical to today's composition.
-        ...(session.instructions ? { sessionInstructions: session.instructions } : {}),
-        // Exact host context captured when this turn was accepted. It is
-        // system-level and disappears with the turn rather than entering chat.
-        ...(turn.turnInstructions || mcpAvailabilityInstructions
-          ? {
-              turnInstructions: [turn.turnInstructions, mcpAvailabilityInstructions]
-                .filter((value): value is string => Boolean(value))
-                .join(" "),
-            }
-          : {}),
-        ...workspaceEnvironmentOption,
-        // RIG RUNTIME (M3): the doctrine block, the setup-script hook (only when
-        // the frozen version carries a non-empty script), and the rig credential
-        // hooks. All absent for a rig-less turn (byte-for-byte today).
-        ...(rigVersion && rigName
-          ? {
-              rig: { name: rigName, version: rigVersion.version },
-              ...(rigVersion.setupScript && rigVersion.setupScript.trim().length > 0
-                ? {
-                    rigSetup: {
-                      rigId: session.rigId!,
-                      versionId: rigVersion.id,
-                      rigName,
-                      script: rigVersion.setupScript,
-                      timeoutMs: runSettings.rigSetupTimeoutMs,
-                      contentHash: rigProviderImageContentHash({
-                        backend: turn.sandboxBackend,
-                        sourceImage: rigProviderImageSourceImage(
-                          logicalSandboxSettings,
-                          turn.sandboxBackend,
-                        ),
-                        definition: rigVersion,
-                      }),
-                    },
-                  }
-                : {}),
-              ...(rigVersion.credentialHooks.length > 0
-                ? { rigCredentialHookIds: rigVersion.credentialHooks }
-                : {}),
-            }
-          : {}),
+      recordTurnStartupPhase(observability, {
+        phase: "post_tool_preparation",
+        provider: turnExecutionPolicy.providerId,
+        backend: activeSandboxBackend ?? groupBoxBackend,
+        outcome: "completed",
+        durationSeconds: (performance.now() - postToolPreparationStartedAt) / 1_000,
       });
+      const agent = (() => {
+        const agentConstructionStartedAt = performance.now();
+        let agentConstructionOutcome: "completed" | "failed" = "completed";
+        try {
+          return runtime.buildAgent(modelRunSettings, turnResources, {
+            reasoningEffort: turn.reasoningEffort,
+            latencyMode: turnExecutionPolicy.latencyMode,
+            ...(serviceTier ? { serviceTier } : {}),
+            ...(humanInputResume ? { humanInputResponse: humanInputResume } : {}),
+            humanInputEnabled: agentHumanInputEnabled,
+            genesisTitleHint: isGenesisTurn,
+            persistentSessionSettings: {
+              titleIsSet: Boolean(session.title?.trim()),
+            },
+            sandboxEnvironment,
+            ...(preparedTools.attemptToolCatalog
+              ? { attemptToolCatalog: preparedTools.attemptToolCatalog }
+              : {}),
+            ...(sandboxArtifactRuntime.available ? { artifactRuntimeAvailable: true } : {}),
+            ...(cancellationSignal ? { turnCancellationSignal: cancellationSignal } : {}),
+            onToolCancellationFence: (fence) => {
+              toolCancellationFenceRef.current = fence;
+            },
+            // TOKEN-BROKER (B1): forward the per-turn git token OFF-MANIFEST as the clone
+            // seed. ONLY when the effective backend is NOT selfhosted (the connected
+            // machine uses its own git creds — mirrors the skipGitHubToken gate above)
+            // AND the mint actually produced a token (repo resources present). The runtime
+            // seeds it to the box's token file before the repository-clone runs; it never
+            // touches the box/agent manifest env.
+            ...(activeSandboxBackend !== "selfhosted" && sandboxGitTokens
+              ? { gitTokenSeeds: sandboxGitTokens }
+              : {}),
+            ...(activeSandboxBackend !== "selfhosted" && sandboxGitCredentialBindings
+              ? { gitCredentialBindings: sandboxGitCredentialBindings }
+              : {}),
+            ...(activeSandboxBackend !== "selfhosted" && !sandboxGitTokens && sandboxGitToken
+              ? { gitTokenSeed: sandboxGitToken }
+              : {}),
+            ...(sandboxCodemodeToken ? { codemodeAvailable: true } : {}),
+            // Managed boxes receive the bearer through their protected per-session
+            // token file. Connected Machines use transient per-exec delivery above,
+            // so they must not run the file-seeding lifecycle hook.
+            ...(activeSandboxBackend !== "selfhosted" && sandboxCodemodeToken
+              ? {
+                  codemodeTokenSeed: sandboxCodemodeToken,
+                  codemodeTokenSessionId: input.sessionId,
+                }
+              : {}),
+            ...(activeSandboxBackend ? { activeSandboxBackend } : {}),
+            fileResourceDownloads,
+            mcpServers: preparedTools.mcpServers,
+            resolvedMcpConnectionIds: preparedTools.resolvedMcpConnectionIds,
+            connectorActionPolicy,
+            // LIVE by-reference connector namespaces (fills during this turn's
+            // codex_apps tools/list): the codex tool_search description reads it per
+            // model call so the model sees the account's real connected sources.
+            codexConnectorNamespaces: preparedTools.codexConnectorNamespaces,
+            // Resolved-model routing + gating (legacy defaults when null). The model
+            // is passed as the model *string* (agent.model = runSettings.openaiModel),
+            // NOT a Model instance: an instance only survives the in-process
+            // ("none") run, whereas the SandboxAgent/Modal path drops it and
+            // re-resolves the model *name* through the global MultiProviderModelProvider
+            // configureOpenAI installed — so registry models (Fireworks GLM) route to
+            // their own client instead of 404ing against the built-in Azure/OpenAI
+            // client. The gating still comes from the resolved provider: server-side
+            // store/compaction follow the provider's compaction mode (registry
+            // providers resolve to "client"); encrypted reasoning is only
+            // round-tripped on the Responses wire API; hosted web search is attached
+            // whenever the provider declares it runnable and is independent of the
+            // session's MCP allow-list; the effective context window drives the
+            // compaction threshold.
+            hostedWebSearch,
+            ...imageGenerationOption,
+            ...videoGenerationOption,
+            lazyToolTransport,
+            supportsImageInput,
+            inputFileMediaTypes: modelInputPolicy.inputFileMediaTypes,
+            ...(resolvedModel
+              ? {
+                  encryptedReasoning:
+                    resolvedModel.provider.api === "responses" &&
+                    runSettings.openaiReasoningEncryptedContent,
+                  contextWindowTokens:
+                    resolvedModel.configured.contextWindowTokens ?? runSettings.contextWindowTokens,
+                  // The ChatGPT/Codex backend rejects the SDK's HOSTED apply_patch
+                  // tool. Gateway Responses routes likewise expose ordinary function
+                  // tools, not OpenAI-hosted sandbox tools. Tell buildAgent to use
+                  // function apply_patch and wrap successful view_image results as
+                  // typed input_image content. Chat wires have no proven typed image
+                  // result transport and therefore receive no view_image tool.
+                  structuredToolTransport: structuredToolTransportForTurn(resolvedModel),
+                  // EXPLICIT computer-use tool transport, derived from the resolved provider's
+                  // authoritative wire identity (codex → function-image, chat → disabled,
+                  // responses → hosted) so the runtime never string-sniffs the model instance's
+                  // constructor name. See {@link computerToolModeForTurn}.
+                  computerToolMode: computerToolModeForTurn(resolvedModel),
+                  ...(promptCacheKey ? { promptCacheKey } : {}),
+                }
+              : // LEGACY global-client fallback (resolveTurnModel returned null → the model
+                // is not in the registry, served by the built-in OpenAI/Azure Responses
+                // client). That backend has real hosted support, so pin computerToolMode to
+                // "hosted" EXPLICITLY rather than leaving the runtime to sniff the instance.
+                {
+                  computerToolMode: computerToolModeForTurn(null),
+                  promptCacheKey: input.sessionId,
+                }),
+            // Lazy computer-use seam: runtime first brings up :0 only after the model
+            // selects a computer tool, then this hook begins the optional proof
+            // recording. Shell/filesystem turns never invoke either operation.
+            onComputerUseReady: async () => {
+              if (!resolvedSandbox) {
+                throw new Error("Computer-use display became ready without a resolved sandbox");
+              }
+              // This callback is the authoritative execution boundary. Record the
+              // action before async ffmpeg startup so transport-event ordering cannot
+              // make settlement misclassify a real computer turn as unused.
+              didComputerUse = true;
+              await maybeStartOnTurnRecording(resolvedSandbox, activeSandboxBackend);
+            },
+            onRetainableSessionImageOutput: retainSessionImageAtToolBoundary,
+            ...(runtimeSkillActivations.length > 0
+              ? { skillActivations: runtimeSkillActivations }
+              : {}),
+            ...(!structuredWorkspacePolicyActive && workspaceAgentInstructions
+              ? { instructionsTemplate: workspaceAgentInstructions }
+              : {}),
+            ...(workspaceGovernance ? { workspaceGovernance } : {}),
+            ...(workspaceMemory ? { workspaceMemory } : {}),
+            goalSnapshot: turn.goalSnapshot,
+            // Per-session persona tier (session > workspace > deployment default).
+            // Composed system-level AFTER the workspace persona so it refines it for
+            // this one session; absent ⇒ byte-identical to today's composition.
+            ...(session.instructions ? { sessionInstructions: session.instructions } : {}),
+            // Exact host context captured when this turn was accepted. It is
+            // system-level and disappears with the turn rather than entering chat.
+            ...(turn.turnInstructions || mcpAvailabilityInstructions
+              ? {
+                  turnInstructions: [turn.turnInstructions, mcpAvailabilityInstructions]
+                    .filter((value): value is string => Boolean(value))
+                    .join(" "),
+                }
+              : {}),
+            ...workspaceEnvironmentOption,
+            // RIG RUNTIME (M3): the doctrine block, the setup-script hook (only when
+            // the frozen version carries a non-empty script), and the rig credential
+            // hooks. All absent for a rig-less turn (byte-for-byte today).
+            ...(rigVersion && rigName
+              ? {
+                  rig: { name: rigName, version: rigVersion.version },
+                  ...(rigVersion.setupScript && rigVersion.setupScript.trim().length > 0
+                    ? {
+                        rigSetup: {
+                          rigId: session.rigId!,
+                          versionId: rigVersion.id,
+                          rigName,
+                          script: rigVersion.setupScript,
+                          timeoutMs: runSettings.rigSetupTimeoutMs,
+                          contentHash: rigProviderImageContentHash({
+                            backend: turn.sandboxBackend,
+                            sourceImage: rigProviderImageSourceImage(
+                              logicalSandboxSettings,
+                              turn.sandboxBackend,
+                            ),
+                            definition: rigVersion,
+                          }),
+                        },
+                      }
+                    : {}),
+                  ...(rigVersion.credentialHooks.length > 0
+                    ? { rigCredentialHookIds: rigVersion.credentialHooks }
+                    : {}),
+                }
+              : {}),
+          });
+        } catch (error) {
+          agentConstructionOutcome = "failed";
+          throw error;
+        } finally {
+          recordTurnStartupPhase(observability, {
+            phase: "agent_construction",
+            provider: turnExecutionPolicy.providerId,
+            backend: activeSandboxBackend ?? groupBoxBackend,
+            outcome: agentConstructionOutcome,
+            durationSeconds: (performance.now() - agentConstructionStartedAt) / 1_000,
+          });
+        }
+      })();
+      const postAgentPreparationStartedAt = performance.now();
       if (modelRunSettings.sandboxBackend !== "none" && toolCancellationFenceRef.current === null) {
         throw new Error(
           "Sandbox agent construction did not install the mandatory turn tool cancellation fence",
@@ -8083,69 +8321,108 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           return claimedResult({ status: "idle" });
         }
       }
+      recordTurnStartupPhase(observability, {
+        phase: "post_agent_preparation",
+        provider: turnExecutionPolicy.providerId,
+        backend: activeSandboxBackend ?? groupBoxBackend,
+        outcome: "completed",
+        durationSeconds: (performance.now() - postAgentPreparationStartedAt) / 1_000,
+      });
       let fileMaterializationFailures: SandboxFileDownloadFailure[] = [];
       let fileDownloadsMaterializedForRun = false;
       if (resolvedSandbox && setupBoxSession && fileResourceDownloads.length > 0) {
-        const boxInstanceId = resolvedSandbox.established.instanceId;
-        // Managed boxes are immutable platform state, so their durable lease can
-        // memoize successful downloads. A connected machine is user-owned: files
-        // can be changed or removed between turns, so verify/materialize every
-        // attached file each turn instead of trusting the managed-box cache.
+        const fileMaterializationStartedAt = performance.now();
+        let fileMaterializationOutcome: "completed" | "failed" = "completed";
         const cacheMaterialization = resolvedSandbox.established.backendId !== "selfhosted";
-        const alreadyMaterialized = cacheMaterialization
-          ? await getMaterializedSandboxFileResources(db, {
-              accountId: input.accountId,
-              workspaceId: input.workspaceId,
-              sandboxGroupId: session.sandboxGroupId,
-              expectedEpoch: resolvedSandbox.leaseEpoch,
-              instanceId: boxInstanceId,
-            })
-          : new Set<string>();
-        const downloadsToMaterialize = filterUnmaterializedSandboxFileDownloads(
-          fileResourceDownloads,
-          alreadyMaterialized,
-        );
-        const runAs = sandboxRunAs(runSettings);
-        if (downloadsToMaterialize.length > 0) {
-          const materialized = await runWorkspaceMutationForSandbox(
-            resolvedSandbox,
-            "fileMaterialization",
-            async () =>
-              await materializeSandboxFileDownloads(
-                setupBoxSession as CodemodeTokenWriterSession,
-                downloadsToMaterialize,
-                {
-                  onRuntimeEvent: async (event) => {
-                    await publish!([{ type: event.type, payload: event.payload }], true);
-                  },
-                  ...(runAs ? { runAs } : {}),
-                  ...(toolCancellationFenceRef.current
-                    ? {
-                        commandRunner: toolCancellationFenceRef.current.runSandboxCommand.bind(
-                          toolCancellationFenceRef.current,
-                        ),
-                      }
-                    : {}),
-                },
-              ),
+        let fileMaterializationCache: "hit" | "miss" | "disabled" = cacheMaterialization
+          ? "miss"
+          : "disabled";
+        try {
+          const boxInstanceId = resolvedSandbox.established.instanceId;
+          // Managed boxes are immutable platform state, so their durable lease can
+          // memoize successful downloads. A connected machine is user-owned: files
+          // can be changed or removed between turns, so verify/materialize every
+          // attached file each turn instead of trusting the managed-box cache.
+          const alreadyMaterialized = cacheMaterialization
+            ? await getMaterializedSandboxFileResources(db, {
+                accountId: input.accountId,
+                workspaceId: input.workspaceId,
+                sandboxGroupId: session.sandboxGroupId,
+                expectedEpoch: resolvedSandbox.leaseEpoch,
+                instanceId: boxInstanceId,
+              })
+            : new Set<string>();
+          const downloadsToMaterialize = filterUnmaterializedSandboxFileDownloads(
+            fileResourceDownloads,
+            alreadyMaterialized,
           );
-          fileMaterializationFailures = materialized.failures;
-          const failedFileIds = new Set(materialized.failures.map((failure) => failure.fileId));
-          const succeededFileIds = downloadsToMaterialize
-            .map((download) => download.fileId)
-            .filter((fileId) => !failedFileIds.has(fileId));
-          if (cacheMaterialization && succeededFileIds.length > 0) {
-            await markSandboxFileResourcesMaterialized(db, {
-              accountId: input.accountId,
-              workspaceId: input.workspaceId,
-              sandboxGroupId: session.sandboxGroupId,
-              expectedEpoch: resolvedSandbox.leaseEpoch,
-              instanceId: boxInstanceId,
-              fileIds: succeededFileIds,
-            });
+          if (cacheMaterialization && downloadsToMaterialize.length === 0) {
+            fileMaterializationCache = "hit";
           }
+          const runAs = sandboxRunAs(runSettings);
+          if (downloadsToMaterialize.length > 0) {
+            const materialized = await runWorkspaceMutationForSandbox(
+              resolvedSandbox,
+              "fileMaterialization",
+              async () =>
+                await materializeSandboxFileDownloads(
+                  setupBoxSession as CodemodeTokenWriterSession,
+                  downloadsToMaterialize,
+                  {
+                    onRuntimeEvent: async (event) => {
+                      await publish!([{ type: event.type, payload: event.payload }], true);
+                    },
+                    ...(runAs ? { runAs } : {}),
+                    ...(toolCancellationFenceRef.current
+                      ? {
+                          commandRunner: toolCancellationFenceRef.current.runSandboxCommand.bind(
+                            toolCancellationFenceRef.current,
+                          ),
+                        }
+                      : {}),
+                  },
+                ),
+            );
+            fileMaterializationFailures = materialized.failures;
+            const failedFileIds = new Set(materialized.failures.map((failure) => failure.fileId));
+            const succeededFileIds = downloadsToMaterialize
+              .map((download) => download.fileId)
+              .filter((fileId) => !failedFileIds.has(fileId));
+            if (cacheMaterialization && succeededFileIds.length > 0) {
+              await markSandboxFileResourcesMaterialized(db, {
+                accountId: input.accountId,
+                workspaceId: input.workspaceId,
+                sandboxGroupId: session.sandboxGroupId,
+                expectedEpoch: resolvedSandbox.leaseEpoch,
+                instanceId: boxInstanceId,
+                fileIds: succeededFileIds,
+              });
+            }
+          }
+          fileDownloadsMaterializedForRun = true;
+        } catch (error) {
+          fileMaterializationOutcome = "failed";
+          throw error;
+        } finally {
+          recordTurnStartupPhase(observability, {
+            phase: "file_materialization",
+            provider: turnExecutionPolicy.providerId,
+            backend: activeSandboxBackend ?? groupBoxBackend,
+            outcome: fileMaterializationOutcome,
+            durationSeconds: (performance.now() - fileMaterializationStartedAt) / 1_000,
+            count: fileResourceDownloads.length,
+            cache: fileMaterializationCache,
+          });
         }
-        fileDownloadsMaterializedForRun = true;
+      } else {
+        recordTurnStartupPhase(observability, {
+          phase: "file_materialization",
+          provider: turnExecutionPolicy.providerId,
+          backend: activeSandboxBackend ?? groupBoxBackend,
+          outcome: "completed",
+          durationSeconds: 0,
+          count: 0,
+        });
       }
       const requiredVideoFileIds = new Set(requiredGeneratedVideoFiles.map((file) => file.fileId));
       const failedRequiredVideo = fileMaterializationFailures.find((failure) =>
@@ -8190,52 +8467,110 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       }
       let runInput: Awaited<ReturnType<typeof turnInput>>["input"] | null = null;
       const prepareRunAttemptInput = async () => {
-        const prepared = await turnInput(db, runtime, agent, trigger, {
-          turnId: activeTurnId,
-          recovering: turn.executionGeneration > 1,
-          ...(unavailableSandboxFilesNote ? { unavailableSandboxFilesNote } : {}),
-          ...(runCredentialsNote ? { runCredentialsNote } : {}),
-          providerApi,
-          projectCanonicalHistory: generatedImageHistoryProjector,
-          materializeModelHistory: materializeScreenshotHistory,
-          materializeSerializedRunState: materializeScreenshotRunState,
-          projectModelHistory: modelHistoryProjector,
-        });
-        for (const receipt of generatedImageReceiptsByArtifactId.values()) {
-          await materializeGeneratedImage(receipt);
+        const historyPreparationStartedAt = performance.now();
+        let historyPreparationOutcome: "completed" | "failed" = "completed";
+        let preparedHistoryCount: number | null = null;
+        try {
+          const prepared = await turnInput(db, runtime, agent, trigger, {
+            turnId: activeTurnId,
+            recovering: turn.executionGeneration > 1,
+            ...(unavailableSandboxFilesNote ? { unavailableSandboxFilesNote } : {}),
+            ...(runCredentialsNote ? { runCredentialsNote } : {}),
+            providerApi,
+            projectCanonicalHistory: generatedImageHistoryProjector,
+            materializeModelHistory: materializeScreenshotHistory,
+            materializeSerializedRunState: materializeScreenshotRunState,
+            projectModelHistory: modelHistoryProjector,
+            onPreparationPhase: (measurement) => {
+              recordTurnStartupPhase(observability, {
+                phase: `history_${measurement.phase}`,
+                provider: turnExecutionPolicy.providerId,
+                backend: activeSandboxBackend ?? groupBoxBackend,
+                outcome: measurement.outcome,
+                durationSeconds: measurement.durationSeconds,
+              });
+            },
+          });
+          const generatedImageMaterializationStartedAt = performance.now();
+          let generatedImageMaterializationOutcome: "completed" | "failed" = "completed";
+          try {
+            for (const receipt of generatedImageReceiptsByArtifactId.values()) {
+              await materializeGeneratedImage(receipt);
+            }
+          } catch (error) {
+            generatedImageMaterializationOutcome = "failed";
+            throw error;
+          } finally {
+            recordTurnStartupPhase(observability, {
+              phase: "history_generated_image_materialization",
+              provider: turnExecutionPolicy.providerId,
+              backend: activeSandboxBackend ?? groupBoxBackend,
+              outcome: generatedImageMaterializationOutcome,
+              durationSeconds: (performance.now() - generatedImageMaterializationStartedAt) / 1_000,
+              count: generatedImageReceiptsByArtifactId.size,
+            });
+          }
+          runInput = prepared.input;
+          providerArtifactCandidates = prepared.providerArtifactCandidates;
+          // Slice index = the length of the model-facing (active) history this turn
+          // is seeded from; new items beyond it (the trigger message + this turn's
+          // generated items) are the ones to persist. After a compaction this is the
+          // short [summary, ...tail] active set, NOT the total row count. The
+          // absolute write position is tracked separately (next whole number past
+          // the max existing position) because the fractional summary row means
+          // total rows no longer equal max(position)+1. Pre-compaction both reduce to
+          // the old total-count value, so the common path is unchanged.
+          //
+          // CRITICAL: seed from the structurally repaired active-row length, not the raw active
+          // count. `prepareRunInput` builds `state.history` from
+          // `sanitizeHistoryItemsForModel(activeRows)`, so when sanitization drops K
+          // rows (a legacy orphan/dangling pair), the in-memory history this turn
+          // starts from is K shorter than the raw row count. The reconcile slices the
+          // repaired `state.history` off `persistedHistoryCount`; seeding it from
+          // the raw count (K too high) skips K genuinely-new items, and a
+          // `function_call` left in that skipped region can later have its
+          // `function_call_result` persisted alone — the orphan that 400s on replay
+          // and bricks the session (issue-61). The repaired seed is already
+          // orphan-free, so it is a stable prefix of the re-sanitized history and the
+          // slice begins exactly at the first genuinely-new item.
+          // prepareInput already sanitized the exact durable prefix represented
+          // by state.history. Carry its count forward instead of loading and
+          // retaining the full active transcript a second time beside runInput.
+          persistedHistoryCount = prepared.persistedHistoryCount;
+          preparedHistoryCount = prepared.persistedHistoryCount;
+          const historyPositionStartedAt = performance.now();
+          let historyPositionOutcome: "completed" | "failed" = "completed";
+          try {
+            nextHistoryPosition = await nextSessionHistoryPosition(
+              db,
+              input.workspaceId,
+              input.sessionId,
+            );
+          } catch (error) {
+            historyPositionOutcome = "failed";
+            throw error;
+          } finally {
+            recordTurnStartupPhase(observability, {
+              phase: "history_position_load",
+              provider: turnExecutionPolicy.providerId,
+              backend: activeSandboxBackend ?? groupBoxBackend,
+              outcome: historyPositionOutcome,
+              durationSeconds: (performance.now() - historyPositionStartedAt) / 1_000,
+            });
+          }
+        } catch (error) {
+          historyPreparationOutcome = "failed";
+          throw error;
+        } finally {
+          recordTurnStartupPhase(observability, {
+            phase: "history_preparation",
+            provider: turnExecutionPolicy.providerId,
+            backend: activeSandboxBackend ?? groupBoxBackend,
+            outcome: historyPreparationOutcome,
+            durationSeconds: (performance.now() - historyPreparationStartedAt) / 1_000,
+            count: preparedHistoryCount,
+          });
         }
-        runInput = prepared.input;
-        providerArtifactCandidates = prepared.providerArtifactCandidates;
-        // Slice index = the length of the model-facing (active) history this turn
-        // is seeded from; new items beyond it (the trigger message + this turn's
-        // generated items) are the ones to persist. After a compaction this is the
-        // short [summary, ...tail] active set, NOT the total row count. The
-        // absolute write position is tracked separately (next whole number past
-        // the max existing position) because the fractional summary row means
-        // total rows no longer equal max(position)+1. Pre-compaction both reduce to
-        // the old total-count value, so the common path is unchanged.
-        //
-        // CRITICAL: seed from the structurally repaired active-row length, not the raw active
-        // count. `prepareRunInput` builds `state.history` from
-        // `sanitizeHistoryItemsForModel(activeRows)`, so when sanitization drops K
-        // rows (a legacy orphan/dangling pair), the in-memory history this turn
-        // starts from is K shorter than the raw row count. The reconcile slices the
-        // repaired `state.history` off `persistedHistoryCount`; seeding it from
-        // the raw count (K too high) skips K genuinely-new items, and a
-        // `function_call` left in that skipped region can later have its
-        // `function_call_result` persisted alone — the orphan that 400s on replay
-        // and bricks the session (issue-61). The repaired seed is already
-        // orphan-free, so it is a stable prefix of the re-sanitized history and the
-        // slice begins exactly at the first genuinely-new item.
-        // prepareInput already sanitized the exact durable prefix represented
-        // by state.history. Carry its count forward instead of loading and
-        // retaining the full active transcript a second time beside runInput.
-        persistedHistoryCount = prepared.persistedHistoryCount;
-        nextHistoryPosition = await nextSessionHistoryPosition(
-          db,
-          input.workspaceId,
-          input.sessionId,
-        );
       };
 
       const forceContextCompaction = async (
@@ -8313,139 +8648,194 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           // heartbeat capture. Lazy setup already runs under the same wrapper in
           // its first-operation provisioner above.
           if (resolvedSandbox && !lazyOwnedSandbox && ownedEstablished) {
-            const eagerSetupSession = setupBoxSession ?? ownedEstablished.session;
-            // `deferredSetup: true` below tells the runtime that the worker owns
-            // platform setup, so the runtime intentionally skips its credential
-            // session callback. Materialize host-managed run credentials here
-            // before any setup command (including provider login hooks), then
-            // decorate setup commands so they source the active generation.
-            await attachRunCredentialRenewal(
-              eagerSetupSession as RunCredentialCommandSession,
-              resolvedSandbox,
-            );
-            const eagerCredentialSetupSession = initialRunCredentialMaterial
-              ? withRunCredentialsSession(eagerSetupSession as object, input.sessionId)
-              : eagerSetupSession;
-            await runWorkspaceMutationForSandbox(
-              resolvedSandbox,
-              "eagerOwnedSandboxSetup",
-              async () =>
-                await runOwnedSandboxSetup(
-                  agent,
-                  ownedEstablished.session as never,
-                  eagerCredentialSetupSession as never,
-                  {
-                    settings: runSettings,
-                    environment: sandboxEnvironment,
-                    preparedInput: runInput!,
-                    ...(fileDownloadsMaterializedForRun ? { fileDownloadsMaterialized: true } : {}),
-                    onRuntimeEvent: async (event) => {
-                      await renewServingCredentialLease("runtime_event");
-                      if (servingCredentialLeaseLost()) {
-                        throw new Error("Provider credential lease expired during sandbox setup");
-                      }
-                      await publish!([{ type: event.type, payload: event.payload }], true);
-                    },
-                    ...(toolCancellationFenceRef.current
-                      ? {
-                          commandRunner: toolCancellationFenceRef.current.runSandboxCommand.bind(
-                            toolCancellationFenceRef.current,
-                          ),
+            const ownedSandboxSetupStartedAt = performance.now();
+            let ownedSandboxSetupOutcome: "completed" | "failed" = "completed";
+            try {
+              const eagerSetupSession = setupBoxSession ?? ownedEstablished.session;
+              // `deferredSetup: true` below tells the runtime that the worker owns
+              // platform setup, so the runtime intentionally skips its credential
+              // session callback. Materialize host-managed run credentials here
+              // before any setup command (including provider login hooks), then
+              // decorate setup commands so they source the active generation.
+              await attachRunCredentialRenewal(
+                eagerSetupSession as RunCredentialCommandSession,
+                resolvedSandbox,
+              );
+              const eagerCredentialSetupSession = initialRunCredentialMaterial
+                ? withRunCredentialsSession(eagerSetupSession as object, input.sessionId)
+                : eagerSetupSession;
+              await runWorkspaceMutationForSandbox(
+                resolvedSandbox,
+                "eagerOwnedSandboxSetup",
+                async () =>
+                  await runOwnedSandboxSetup(
+                    agent,
+                    ownedEstablished.session as never,
+                    eagerCredentialSetupSession as never,
+                    {
+                      settings: runSettings,
+                      environment: sandboxEnvironment,
+                      preparedInput: runInput!,
+                      ...(fileDownloadsMaterializedForRun
+                        ? { fileDownloadsMaterialized: true }
+                        : {}),
+                      onRuntimeEvent: async (event) => {
+                        await renewServingCredentialLease("runtime_event");
+                        if (servingCredentialLeaseLost()) {
+                          throw new Error("Provider credential lease expired during sandbox setup");
                         }
-                      : {}),
-                  },
-                ),
-            );
-            await attachGitCredentialRenewal(
-              eagerSetupSession as GitCredentialTokenWriterSession,
-              initialGitCredentials,
-            );
+                        await publish!([{ type: event.type, payload: event.payload }], true);
+                      },
+                      ...(toolCancellationFenceRef.current
+                        ? {
+                            commandRunner: toolCancellationFenceRef.current.runSandboxCommand.bind(
+                              toolCancellationFenceRef.current,
+                            ),
+                          }
+                        : {}),
+                    },
+                  ),
+              );
+              await attachGitCredentialRenewal(
+                eagerSetupSession as GitCredentialTokenWriterSession,
+                initialGitCredentials,
+              );
+            } catch (error) {
+              ownedSandboxSetupOutcome = "failed";
+              throw error;
+            } finally {
+              recordTurnStartupPhase(observability, {
+                phase: "owned_sandbox_setup",
+                provider: turnExecutionPolicy.providerId,
+                backend: activeSandboxBackend ?? groupBoxBackend,
+                outcome: ownedSandboxSetupOutcome,
+                durationSeconds: (performance.now() - ownedSandboxSetupStartedAt) / 1_000,
+                count: fileResourceDownloads.length,
+              });
+            }
           }
           // Conservative request boundary: once control enters runStream, the
           // provider may have accepted work even if no response/event follows.
           // Escaped MCP setup timeouts are automatically recoverable only
           // before this line.
           recordCompanyBrainContributionReceiptOnce();
-          modelRequestStarted = true;
-          return await runtime.runStream(agent, runInput!, modelRunSettings, {
-            signal: runtimeCancellationSignal,
-            sandboxEnvironment,
-            onRuntimeEvent: async (event) => {
-              await renewServingCredentialLease("runtime_event");
-              if (servingCredentialLeaseLost()) {
-                throw new Error("Provider credential lease expired during the active turn");
-              }
-              await publish!([{ type: event.type, payload: event.payload }], true);
-            },
-            // P1.2: inject the resumed box NON-OWNED (the SDK never reaps it — the
-            // keystone). Absent when the flag is off -> legacy build-and-discard.
-            ...(ownedEstablished
-              ? {
-                  ownedSandbox: {
-                    client: ownedEstablished.client,
-                    session: ownedEstablished.session,
-                    ...(resolvedSandbox?.established.sessionState
+          const providerDispatchStartedAt = performance.now();
+          let providerDispatchOutcome: "completed" | "failed" = "completed";
+          try {
+            recordTurnPreModelTotal(observability, {
+              provider: turnExecutionPolicy.providerId,
+              backend: activeSandboxBackend ?? groupBoxBackend,
+              outcome: "completed",
+              durationSeconds: (performance.now() - preModelStartedAt) / 1_000,
+            });
+            modelRequestStarted = true;
+            return await runtime.runStream(agent, runInput!, modelRunSettings, {
+              signal: runtimeCancellationSignal,
+              sandboxEnvironment,
+              onRuntimeEvent: async (event) => {
+                await renewServingCredentialLease("runtime_event");
+                if (servingCredentialLeaseLost()) {
+                  throw new Error("Provider credential lease expired during the active turn");
+                }
+                await publish!([{ type: event.type, payload: event.payload }], true);
+              },
+              // P1.2: inject the resumed box NON-OWNED (the SDK never reaps it — the
+              // keystone). Absent when the flag is off -> legacy build-and-discard.
+              ...(ownedEstablished
+                ? {
+                    ownedSandbox: {
+                      client: ownedEstablished.client,
+                      session: ownedEstablished.session,
+                      ...(resolvedSandbox?.established.sessionState
+                        ? {
+                            sessionState: resolvedSandbox.established.sessionState,
+                          }
+                        : {}),
+                      // Pin platform setup (hooks + file materialization) to the un-proxied
+                      // established box — never through the routing proxy, which would
+                      // re-route those execs onto a machine swapped in mid-turn.
+                      ...(setupBoxSession ? { setupSession: setupBoxSession } : {}),
+                      ...(fileDownloadsMaterializedForRun
+                        ? { fileDownloadsMaterialized: true }
+                        : {}),
+                      // Both owned paths execute setup outside runStream: eager just
+                      // above under its exact admission, lazy in the provisioner.
+                      deferredSetup: true,
+                    },
+                  }
+                : {}),
+              ...(activeSandboxBackend !== "selfhosted" &&
+              sandboxCodemodeToken &&
+              sandboxCodemodeTokenExpiresAt &&
+              !lazyOwnedSandbox
+                ? {
+                    onCodemodeTokenSessionReady: async (
+                      tokenSession: CodemodeTokenWriterSession,
+                    ) => {
+                      const renewalSession =
+                        (setupBoxSession as CodemodeTokenWriterSession | null) ?? tokenSession;
+                      await attachCodemodeTokenRenewal(renewalSession);
+                    },
+                  }
+                : {}),
+              ...(runCredentialResolver
+                ? {
+                    runCredentialSessionId: input.sessionId,
+                    ...(!lazyOwnedSandbox
                       ? {
-                          sessionState: resolvedSandbox.established.sessionState,
+                          onRunCredentialSessionReady: async (
+                            credentialSession: RunCredentialCommandSession,
+                          ) => {
+                            const pinnedCredentialSession = setupBoxSession
+                              ? (setupBoxSession as RunCredentialCommandSession)
+                              : credentialSession;
+                            await attachRunCredentialRenewal(pinnedCredentialSession);
+                          },
                         }
                       : {}),
-                    // Pin platform setup (hooks + file materialization) to the un-proxied
-                    // established box — never through the routing proxy, which would
-                    // re-route those execs onto a machine swapped in mid-turn.
-                    ...(setupBoxSession ? { setupSession: setupBoxSession } : {}),
-                    ...(fileDownloadsMaterializedForRun ? { fileDownloadsMaterialized: true } : {}),
-                    // Both owned paths execute setup outside runStream: eager just
-                    // above under its exact admission, lazy in the provisioner.
-                    deferredSetup: true,
-                  },
-                }
-              : {}),
-            ...(activeSandboxBackend !== "selfhosted" &&
-            sandboxCodemodeToken &&
-            sandboxCodemodeTokenExpiresAt &&
-            !lazyOwnedSandbox
-              ? {
-                  onCodemodeTokenSessionReady: async (tokenSession: CodemodeTokenWriterSession) => {
-                    const renewalSession =
-                      (setupBoxSession as CodemodeTokenWriterSession | null) ?? tokenSession;
-                    await attachCodemodeTokenRenewal(renewalSession);
-                  },
-                }
-              : {}),
-            ...(runCredentialResolver
-              ? {
-                  runCredentialSessionId: input.sessionId,
-                  ...(!lazyOwnedSandbox
-                    ? {
-                        onRunCredentialSessionReady: async (
-                          credentialSession: RunCredentialCommandSession,
-                        ) => {
-                          const pinnedCredentialSession = setupBoxSession
-                            ? (setupBoxSession as RunCredentialCommandSession)
-                            : credentialSession;
-                          await attachRunCredentialRenewal(pinnedCredentialSession);
-                        },
+                  }
+                : {}),
+              ...(modelRunSettings.sandboxBackend !== "none"
+                ? {
+                    onSandboxSessionReady: async (sandboxSession: CodemodeTokenWriterSession) => {
+                      sdkOwnedSandboxSession = sandboxSession;
+                      for (const receipt of generatedImageReceiptsByArtifactId.values()) {
+                        await materializeGeneratedImageInOwnedSdkSession(receipt, sandboxSession);
                       }
-                    : {}),
-                }
-              : {}),
-            ...(modelRunSettings.sandboxBackend !== "none"
-              ? {
-                  onSandboxSessionReady: async (sandboxSession: CodemodeTokenWriterSession) => {
-                    sdkOwnedSandboxSession = sandboxSession;
-                    for (const receipt of generatedImageReceiptsByArtifactId.values()) {
-                      await materializeGeneratedImageInOwnedSdkSession(receipt, sandboxSession);
-                    }
-                  },
-                }
-              : {}),
-            contextCompactionSignal: () => modelResponseContextSignal(modelResponseState),
-            contextCompactionRequested: () =>
-              isSessionCompactionRequested(db, input.workspaceId, input.sessionId),
-            ...(toolCancellationFenceRef.current
-              ? { turnToolCancellationFence: toolCancellationFenceRef.current }
-              : {}),
-          });
+                    },
+                  }
+                : {}),
+              contextCompactionSignal: () => modelResponseContextSignal(modelResponseState),
+              contextCompactionRequested: () =>
+                isSessionCompactionRequested(db, input.workspaceId, input.sessionId),
+              onModelPreparationPhase: (measurement) => {
+                recordTurnStartupPhase(observability, {
+                  phase: `model_prepare_${measurement.phase}`,
+                  provider: turnExecutionPolicy.providerId,
+                  backend: activeSandboxBackend ?? groupBoxBackend,
+                  outcome: measurement.outcome,
+                  durationSeconds: measurement.durationSeconds,
+                  ...(measurement.count === undefined ? {} : { count: measurement.count }),
+                });
+              },
+              ...(toolCancellationFenceRef.current
+                ? {
+                    turnToolCancellationFence: toolCancellationFenceRef.current,
+                  }
+                : {}),
+            });
+          } catch (error) {
+            providerDispatchOutcome = "failed";
+            throw error;
+          } finally {
+            recordTurnStartupPhase(observability, {
+              phase: "provider_dispatch",
+              provider: turnExecutionPolicy.providerId,
+              backend: activeSandboxBackend ?? groupBoxBackend,
+              outcome: providerDispatchOutcome,
+              durationSeconds: (performance.now() - providerDispatchStartedAt) / 1_000,
+            });
+          }
         };
         if (codexLeaseLost) {
           throw new Error("Codex credential lease expired before the model run");
@@ -8471,11 +8861,30 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           },
         );
 
+        const streamBootstrapStartedAt = performance.now();
+        let streamBootstrapRecorded = false;
+        const recordStreamBootstrap = (): void => {
+          if (streamBootstrapRecorded) return;
+          streamBootstrapRecorded = true;
+          recordTurnStartupPhase(observability, {
+            phase: "stream_bootstrap",
+            provider: turnExecutionPolicy.providerId,
+            backend: activeSandboxBackend ?? groupBoxBackend,
+            outcome: "completed",
+            durationSeconds: (performance.now() - streamBootstrapStartedAt) / 1_000,
+            count: turnTools.length,
+          });
+        };
+        if (!firstModelRequestPreparationRecorded) {
+          firstModelRequestPreparationStartedAt = performance.now();
+          firstModelRequestCheckpointAt = firstModelRequestPreparationStartedAt;
+        }
         const iterator = stream.toStream()[Symbol.asyncIterator]();
         let streamDone = false;
         try {
           while (true) {
             const next = await nextStreamEvent(iterator, activityContext);
+            recordStreamBootstrap();
             if (next.done) {
               streamDone = true;
               break;

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -733,6 +733,12 @@ export function filterUnmaterializedSandboxFileDownloads(
   return downloads.filter((download) => !materializedFileIds.has(download.fileId));
 }
 
+export function sandboxFileMaterializationOutcome(
+  failures: readonly SandboxFileDownloadFailure[],
+): "completed" | "failed" {
+  return failures.length === 0 ? "completed" : "failed";
+}
+
 /** Fixed-length one-way tenant correlation for metrics/alerts; never a raw id. */
 export function codexWorkspaceMetricKey(workspaceId: string): string {
   return createHash("sha256").update(workspaceId).digest("hex").slice(0, 12);
@@ -2008,6 +2014,7 @@ export function sandboxEstablishPolicyDecision(input: {
   sandboxBackend: Settings["sandboxBackend"];
   hasInitialRunCredentialMaterial: boolean;
   generatedVideoFileCount: number;
+  hasSignedFileResources: boolean;
 }): { policy: "eager" | "on-demand"; reason: TurnSandboxEstablishReason } {
   if (!input.lazyEnabled) return { policy: "eager", reason: "lazy_disabled" };
   if (input.machinePrimary) return { policy: "eager", reason: "machine_primary" };
@@ -2017,6 +2024,13 @@ export function sandboxEstablishPolicyDecision(input: {
   }
   if (input.generatedVideoFileCount > 0) {
     return { policy: "eager", reason: "generated_video_files" };
+  }
+  // Signed file downloads must finish before the first model boundary so any
+  // integrity/download failure is present in the prepared input. Deferring the
+  // box until the first tool call would make that first request advertise a
+  // path whose materialization outcome is not known yet.
+  if (input.hasSignedFileResources) {
+    return { policy: "eager", reason: "signed_file_resources" };
   }
   return { policy: "on-demand", reason: "eligible" };
 }
@@ -6226,6 +6240,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // provisioner entirely, which previously skipped materialization.
         hasInitialRunCredentialMaterial: initialRunCredentialMaterial !== null,
         generatedVideoFileCount: requiredGeneratedVideoFiles.length,
+        hasSignedFileResources:
+          requiresSignedFileResourceDownloads(
+            runSettings,
+            activeSandboxBackend ?? groupBoxBackend,
+          ) && turnResources.some((resource) => resource.kind === "file"),
       });
       const establishPolicy = establishDecision.policy;
       recordTurnSandboxEstablishPolicy(observability, {
@@ -7867,6 +7886,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                       image: runSettings.modalImageRef ?? runSettings.dockerImage,
                     }
                   : {}),
+                // The lazy acquire must enforce the same frozen rig authority
+                // as the eager acquire; otherwise a warm box for another rig
+                // can bypass the shared-state conflict/rotation fence.
+                ...(rigVersion ? { rigVersionId: rigVersion.id } : {}),
               },
               "turn",
               lazyHolderId,
@@ -8384,6 +8407,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                 ),
             );
             fileMaterializationFailures = materialized.failures;
+            fileMaterializationOutcome = sandboxFileMaterializationOutcome(materialized.failures);
             const failedFileIds = new Set(materialized.failures.map((failure) => failure.fileId));
             const succeededFileIds = downloadsToMaterialize
               .map((download) => download.fileId)
@@ -8622,6 +8646,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // calling runStreamAttempt again; resetting this state there would reuse
       // the first no-response-ID fallback key and suppress a real model call.
       const modelResponseState = createModelResponseEventState(claimedModelUsageSourceKeys);
+      let preModelTotalRecorded = false;
       const runStreamAttempt = async (): Promise<RunAgentTurnResult> => {
         if (!runInput) {
           throw new Error("Run input was not prepared");
@@ -8722,12 +8747,19 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           const providerDispatchStartedAt = performance.now();
           let providerDispatchOutcome: "completed" | "failed" = "completed";
           try {
-            recordTurnPreModelTotal(observability, {
-              provider: turnExecutionPolicy.providerId,
-              backend: activeSandboxBackend ?? groupBoxBackend,
-              outcome: "completed",
-              durationSeconds: (performance.now() - preModelStartedAt) / 1_000,
-            });
+            // This histogram describes turn startup through the first provider
+            // dispatch. Context-compaction recovery re-enters runStreamAttempt;
+            // recording again would fold the prior request and compaction into a
+            // bogus second "startup" sample.
+            if (!preModelTotalRecorded) {
+              preModelTotalRecorded = true;
+              recordTurnPreModelTotal(observability, {
+                provider: turnExecutionPolicy.providerId,
+                backend: activeSandboxBackend ?? groupBoxBackend,
+                outcome: "completed",
+                durationSeconds: (performance.now() - preModelStartedAt) / 1_000,
+              });
+            }
             modelRequestStarted = true;
             return await runtime.runStream(agent, runInput!, modelRunSettings, {
               signal: runtimeCancellationSignal,

--- a/apps/worker/src/activities/run-input.ts
+++ b/apps/worker/src/activities/run-input.ts
@@ -85,7 +85,53 @@ export type TurnInputOptions = {
   materializeSerializedRunState?: (serialized: string) => Promise<string>;
   projectModelHistory?: ModelHistoryAttachmentProjector;
   loadActiveHistory?: typeof getActiveSessionHistoryItemsPaged;
+  /** Bounded critical-path timings; telemetry failures never affect preparation. */
+  onPreparationPhase?: (measurement: HistoryPreparationPhaseMeasurement) => void;
 };
+
+export type HistoryPreparationPhase =
+  | "system_update_load"
+  | "current_attachment_resolution"
+  | "durable_history_load"
+  | "sandbox_envelope_load"
+  | "canonical_projection"
+  | "provider_projection"
+  | "attachment_ref_projection"
+  | "screenshot_materialization"
+  | "model_attachment_projection"
+  | "runtime_input_assembly"
+  | "artifact_candidate_scan";
+
+export type HistoryPreparationPhaseMeasurement = {
+  phase: HistoryPreparationPhase;
+  outcome: "completed" | "failed";
+  durationSeconds: number;
+};
+
+async function measureHistoryPreparationPhase<T>(
+  options: Pick<TurnInputOptions, "onPreparationPhase">,
+  phase: HistoryPreparationPhase,
+  operation: () => T | Promise<T>,
+): Promise<T> {
+  const startedAt = performance.now();
+  let outcome: HistoryPreparationPhaseMeasurement["outcome"] = "completed";
+  try {
+    return await operation();
+  } catch (error) {
+    outcome = "failed";
+    throw error;
+  } finally {
+    try {
+      options.onPreparationPhase?.({
+        phase,
+        outcome,
+        durationSeconds: (performance.now() - startedAt) / 1_000,
+      });
+    } catch {
+      // Diagnostics must not change durable history or provider input.
+    }
+  }
+}
 
 export const MAX_INLINE_MODEL_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 
@@ -378,11 +424,16 @@ export async function turnInput(
   if (!trigger) {
     throw new Error("Missing trigger event");
   }
-  const updates = await listSessionSystemUpdatesForTurn(
-    db,
-    trigger.workspaceId,
-    trigger.sessionId,
-    options.turnId,
+  const updates = await measureHistoryPreparationPhase(
+    options,
+    "system_update_load",
+    async () =>
+      await listSessionSystemUpdatesForTurn(
+        db,
+        trigger.workspaceId,
+        trigger.sessionId,
+        options.turnId,
+      ),
   );
   if (updates.length > 0) {
     const historyItemIds = new Set(
@@ -413,10 +464,10 @@ export async function turnInput(
       throw new Error("user.message payload is missing text and annotations");
     }
     const resources = Array.isArray(payload.resources) ? (payload.resources as ResourceRef[]) : [];
-    const fileAttachments = await resolveUserMessageFileAttachments(
-      db,
-      trigger.workspaceId,
-      resources,
+    const fileAttachments = await measureHistoryPreparationPhase(
+      options,
+      "current_attachment_resolution",
+      async () => await resolveUserMessageFileAttachments(db, trigger.workspaceId, resources),
     );
     const attachmentContext = userMessageAttachmentsContext(fileAttachments);
     return await messageInput(
@@ -432,6 +483,7 @@ export async function turnInput(
       options.materializeModelHistory,
       options.projectModelHistory,
       options.loadActiveHistory,
+      options,
     );
   }
   if (trigger.type === "system.update.delivered") {
@@ -451,6 +503,7 @@ export async function turnInput(
       options.materializeModelHistory,
       options.projectModelHistory,
       options.loadActiveHistory,
+      options,
     );
   }
   if (trigger.type === "user.approvalDecision") {
@@ -536,46 +589,85 @@ async function messageInput(
   materializeModelHistory?: ModelHistoryAttachmentProjector,
   projectModelHistory?: ModelHistoryAttachmentProjector,
   loadActiveHistory: typeof getActiveSessionHistoryItemsPaged = getActiveSessionHistoryItemsPaged,
+  preparationOptions: Pick<TurnInputOptions, "onPreparationPhase"> = {},
 ): Promise<PreparedTurnInput> {
-  const stored = await loadActiveHistory(db, trigger.workspaceId, trigger.sessionId);
-  const envelope = await getSandboxSessionEnvelope(db, trigger.workspaceId, trigger.sessionId);
-  const canonicalView = projectRejectedProviderArtifacts(stored);
-  const canonicalProviderView = projectCanonicalHistory
-    ? await projectCanonicalHistory(canonicalView)
-    : canonicalView;
-  const providerView = projectHistoryForProvider(canonicalProviderView, providerApi);
-  const referencedHistory = withCurrentUserAttachmentRefs(providerView, currentAttachmentRefs);
-  const materializedHistory = materializeModelHistory
-    ? await materializeModelHistory(referencedHistory)
-    : referencedHistory;
-  const historyItems = projectModelHistory
-    ? await projectModelHistory(materializedHistory)
-    : materializedHistory;
-  const prepared = await runtime.prepareInput(agent, {
-    kind: "message",
-    ...(text ? { text } : {}),
-    ...(internalContext ? { internalContext } : {}),
-    historyItems: historyItems as any,
-    sandboxEnvelope: envelope,
-    ...(projectModelHistory ? { modelInputAlreadyProjected: true } : {}),
-  });
-  const preparedItems = Array.isArray(prepared.input)
-    ? new Set(prepared.input)
-    : new Set<unknown>();
+  const [stored, envelope] = await Promise.all([
+    measureHistoryPreparationPhase(preparationOptions, "durable_history_load", async () =>
+      loadActiveHistory(db, trigger.workspaceId, trigger.sessionId),
+    ),
+    measureHistoryPreparationPhase(preparationOptions, "sandbox_envelope_load", async () =>
+      getSandboxSessionEnvelope(db, trigger.workspaceId, trigger.sessionId),
+    ),
+  ]);
+  const canonicalView = await measureHistoryPreparationPhase(
+    preparationOptions,
+    "canonical_projection",
+    async () => {
+      const active = projectRejectedProviderArtifacts(stored);
+      return projectCanonicalHistory ? await projectCanonicalHistory(active) : active;
+    },
+  );
+  const providerView = await measureHistoryPreparationPhase(
+    preparationOptions,
+    "provider_projection",
+    () => projectHistoryForProvider(canonicalView, providerApi),
+  );
+  const referencedHistory = await measureHistoryPreparationPhase(
+    preparationOptions,
+    "attachment_ref_projection",
+    () => withCurrentUserAttachmentRefs(providerView, currentAttachmentRefs),
+  );
+  const materializedHistory = await measureHistoryPreparationPhase(
+    preparationOptions,
+    "screenshot_materialization",
+    async () =>
+      materializeModelHistory
+        ? await materializeModelHistory(referencedHistory)
+        : referencedHistory,
+  );
+  const historyItems = await measureHistoryPreparationPhase(
+    preparationOptions,
+    "model_attachment_projection",
+    async () =>
+      projectModelHistory ? await projectModelHistory(materializedHistory) : materializedHistory,
+  );
+  const prepared = await measureHistoryPreparationPhase(
+    preparationOptions,
+    "runtime_input_assembly",
+    async () =>
+      await runtime.prepareInput(agent, {
+        kind: "message",
+        ...(text ? { text } : {}),
+        ...(internalContext ? { internalContext } : {}),
+        historyItems: historyItems as any,
+        sandboxEnvelope: envelope,
+        ...(projectModelHistory ? { modelInputAlreadyProjected: true } : {}),
+      }),
+  );
+  const providerArtifactCandidates = await measureHistoryPreparationPhase(
+    preparationOptions,
+    "artifact_candidate_scan",
+    () => {
+      const preparedItems = Array.isArray(prepared.input)
+        ? new Set(prepared.input)
+        : new Set<unknown>();
+      return {
+        knownHistoryItemIds: stored.map((row) => row.id),
+        historyItemIds: stored
+          .filter(
+            (row) =>
+              row.providerArtifactInvalidatedAt === null &&
+              hasOpaqueProviderArtifact(row.item) &&
+              preparedItems.has(row.item),
+          )
+          .map((row) => row.id),
+      };
+    },
+  );
   return {
     input: prepared,
     persistedHistoryCount: prepared.persistedHistoryCount,
-    providerArtifactCandidates: {
-      knownHistoryItemIds: stored.map((row) => row.id),
-      historyItemIds: stored
-        .filter(
-          (row) =>
-            row.providerArtifactInvalidatedAt === null &&
-            hasOpaqueProviderArtifact(row.item) &&
-            preparedItems.has(row.item),
-        )
-        .map((row) => row.id),
-    },
+    providerArtifactCandidates,
   };
 }
 

--- a/apps/worker/src/observability-metrics.ts
+++ b/apps/worker/src/observability-metrics.ts
@@ -947,7 +947,8 @@ export type TurnSandboxEstablishReason =
   | "machine_primary"
   | "backend_none"
   | "initial_run_credentials"
-  | "generated_video_files";
+  | "generated_video_files"
+  | "signed_file_resources";
 
 const TURN_STARTUP_PHASE_BUCKETS = [
   0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120,

--- a/apps/worker/src/observability-metrics.ts
+++ b/apps/worker/src/observability-metrics.ts
@@ -1020,7 +1020,7 @@ export function recordTurnSandboxEstablishPolicy(
   });
 }
 
-export function recordTurnPreModelTotal(
+export function recordTurnWorkerPreparationTotal(
   observability: Observability,
   input: {
     provider: string;
@@ -1030,8 +1030,8 @@ export function recordTurnPreModelTotal(
   },
 ): void {
   observability.observeHistogram({
-    name: "opengeni_turn_pre_model_duration_seconds",
-    help: "Total turn duration from the durable turn-start boundary to provider dispatch.",
+    name: "opengeni_turn_worker_preparation_duration_seconds",
+    help: "Worker preparation from the durable turn-start boundary until entering the runtime; lazy SDK request preparation and model-request audit are separate phases.",
     buckets: TURN_STARTUP_PHASE_BUCKETS,
     labels: {
       provider: input.provider,

--- a/apps/worker/src/observability-metrics.ts
+++ b/apps/worker/src/observability-metrics.ts
@@ -176,7 +176,12 @@ export function selfhostedOpObserverForMetrics(hooks: RuntimeMetricsHooks): Self
 /** A session-scoped `machine.op.*` event mapped from a completed-op observation. */
 export type MachineOpSessionEvent = {
   type: "machine.op.failed" | "machine.op.recovered";
-  payload: { op: string; faultClass: string; attempts: number; machineId?: string };
+  payload: {
+    op: string;
+    faultClass: string;
+    attempts: number;
+    machineId?: string;
+  };
 };
 
 /** Map an observation to a `machine.op.*` session event, or null if it is not
@@ -254,7 +259,10 @@ export class TurnLifecycleMetrics {
 
   constructor(
     private readonly observability: Observability,
-    private readonly options: { now?: () => number; refreshIntervalMs?: number } = {},
+    private readonly options: {
+      now?: () => number;
+      refreshIntervalMs?: number;
+    } = {},
   ) {}
 
   start(turnId: string): void {
@@ -715,7 +723,11 @@ const RETAINED_PROCESS_OWNER_STATE_SET = new Set<string>(RETAINED_PROCESS_OWNER_
 
 export function recordRetainedProcessInventoryGauges(
   observability: Observability,
-  counts: Array<{ ownerState: string; activeCount: number; terminalOwnerCount: number }>,
+  counts: Array<{
+    ownerState: string;
+    activeCount: number;
+    terminalOwnerCount: number;
+  }>,
 ): void {
   const normalized = new Map<string, { active: number; terminal: number }>();
   for (const ownerState of RETAINED_PROCESS_OWNER_STATES) {
@@ -857,6 +869,174 @@ export function recordModelRequestPhase(
     help: "Monotonic seconds from provider dispatch to a model-request lifecycle phase.",
     buckets: MODEL_REQUEST_PHASE_BUCKETS,
     labels: { provider: input.provider, phase: input.phase },
+    value: Math.max(0, input.durationSeconds),
+  });
+}
+
+export type TurnStartupPhase =
+  | "claim_and_policy"
+  | "turn_start_settlement"
+  | "credential_selection"
+  | "runtime_preparation"
+  | "sandbox_establish"
+  | "file_resolution"
+  | "tool_context_preparation"
+  | "tool_preparation"
+  | "tool_server_construction"
+  | "tool_required_connect"
+  | "tool_optional_connect"
+  | "tool_attempt_catalog_build"
+  | "tool_attempt_catalog_persist"
+  | "post_tool_preparation"
+  | "agent_construction"
+  | "post_agent_preparation"
+  | "file_materialization"
+  | "history_preparation"
+  | "history_system_update_load"
+  | "history_current_attachment_resolution"
+  | "history_durable_history_load"
+  | "history_sandbox_envelope_load"
+  | "history_canonical_projection"
+  | "history_provider_projection"
+  | "history_attachment_ref_projection"
+  | "history_screenshot_materialization"
+  | "history_model_attachment_projection"
+  | "history_runtime_input_assembly"
+  | "history_artifact_candidate_scan"
+  | "history_generated_image_materialization"
+  | "history_position_load"
+  | "owned_sandbox_setup"
+  | "provider_dispatch"
+  | "model_request_preparation"
+  | "model_sdk_serialization"
+  | "model_prepare_sandbox_agent_preparation"
+  | "model_prepare_sandbox_agent_manifest_inventory"
+  | "model_prepare_sandbox_session_manifest_inventory"
+  | "model_prepare_sandbox_manifest_apply"
+  | "model_prepare_sandbox_entry_materialization"
+  | "model_prepare_sandbox_running_check"
+  | "model_prepare_sandbox_start"
+  | "model_prepare_sandbox_client_create"
+  | "model_prepare_sandbox_client_resume"
+  | "model_prepare_sandbox_client_delete"
+  | "model_prepare_sandbox_client_state_serialize"
+  | "model_prepare_sandbox_client_reuse_check"
+  | "model_prepare_runner_before_mcp_tools"
+  | "model_prepare_mcp_tools_snapshot"
+  | "model_prepare_mcp_tools_before_input_filter"
+  | "model_prepare_input_filter_base"
+  | "model_prepare_input_filter_genesis"
+  | "model_prepare_input_filter_host"
+  | "model_prepare_input_filter_tool_output"
+  | "model_prepare_input_filter_modality"
+  | "model_prepare_input_filter_context"
+  | "model_prepare_responses_input_conversion"
+  | "model_prepare_responses_request_build"
+  | "model_credential_resolution"
+  | "model_wire_normalization"
+  | "model_request_audit"
+  | "stream_bootstrap";
+
+export type TurnStartupOutcome = "completed" | "failed";
+export type TurnStartupCache = "hit" | "miss" | "disabled" | "none";
+export type TurnStartupCountBucket = "0" | "1" | "2-5" | "6-20" | "21+" | "unknown";
+export type TurnSandboxEstablishPolicy = "eager" | "on-demand";
+export type TurnSandboxEstablishReason =
+  | "eligible"
+  | "lazy_disabled"
+  | "machine_primary"
+  | "backend_none"
+  | "initial_run_credentials"
+  | "generated_video_files";
+
+const TURN_STARTUP_PHASE_BUCKETS = [
+  0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120,
+];
+
+export function turnStartupCountBucket(count: number | null): TurnStartupCountBucket {
+  if (count === null || !Number.isFinite(count) || count < 0) return "unknown";
+  if (count === 0) return "0";
+  if (count === 1) return "1";
+  if (count <= 5) return "2-5";
+  if (count <= 20) return "6-20";
+  return "21+";
+}
+
+/**
+ * Measure the critical path from a durable turn start to provider dispatch.
+ * Every label is a closed or configuration-derived enum; high-cardinality turn,
+ * session, credential, connection, file, and model identifiers are forbidden.
+ */
+export function recordTurnStartupPhase(
+  observability: Observability,
+  input: {
+    phase: TurnStartupPhase;
+    provider: string;
+    backend: string;
+    outcome: TurnStartupOutcome;
+    durationSeconds: number;
+    count?: number | null;
+    cache?: TurnStartupCache;
+  },
+): void {
+  observability.observeHistogram({
+    name: "opengeni_turn_startup_phase_duration_seconds",
+    help: "Turn startup phase duration before the model response stream begins.",
+    buckets: TURN_STARTUP_PHASE_BUCKETS,
+    labels: {
+      phase: input.phase,
+      provider: input.provider,
+      backend: input.backend,
+      outcome: input.outcome,
+      count_bucket: turnStartupCountBucket(input.count ?? null),
+      cache: input.cache ?? "none",
+    },
+    value: Math.max(0, input.durationSeconds),
+  });
+}
+
+/**
+ * Explain why a turn did or did not keep provider sandbox work off the
+ * pre-model critical path. The reason is a closed enum: never attach session,
+ * sandbox, credential, or file identifiers here.
+ */
+export function recordTurnSandboxEstablishPolicy(
+  observability: Observability,
+  input: {
+    policy: TurnSandboxEstablishPolicy;
+    reason: TurnSandboxEstablishReason;
+    backend: string;
+  },
+): void {
+  observability.incrementCounter({
+    name: "opengeni_turn_sandbox_establish_policy_total",
+    help: "Turn sandbox establish policy decisions by bounded reason.",
+    labels: {
+      policy: input.policy,
+      reason: input.reason,
+      backend: input.backend,
+    },
+  });
+}
+
+export function recordTurnPreModelTotal(
+  observability: Observability,
+  input: {
+    provider: string;
+    backend: string;
+    outcome: TurnStartupOutcome;
+    durationSeconds: number;
+  },
+): void {
+  observability.observeHistogram({
+    name: "opengeni_turn_pre_model_duration_seconds",
+    help: "Total turn duration from the durable turn-start boundary to provider dispatch.",
+    buckets: TURN_STARTUP_PHASE_BUCKETS,
+    labels: {
+      provider: input.provider,
+      backend: input.backend,
+      outcome: input.outcome,
+    },
     value: Math.max(0, input.durationSeconds),
   });
 }

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -90,6 +90,7 @@ import {
   requiresSignedFileResourceDownloads,
   resolveActiveSandboxBackend,
   runMandatoryHistoryPersistenceStep,
+  sandboxEstablishPolicyDecision,
   safeErrorDiagnostic,
   sandboxArtifactRuntimeAdmission,
   sandboxDeadlineRotationRecoveryDelayMs,
@@ -2551,6 +2552,40 @@ describe("on-turn recording gate (selfhosted machines have no in-box capture plu
 });
 
 describe("lazy sandbox provisioner single-flight", () => {
+  test("establish policy reports the first bounded eager reason", () => {
+    const base = {
+      lazyEnabled: true,
+      machinePrimary: false,
+      sandboxBackend: "docker" as const,
+      hasInitialRunCredentialMaterial: false,
+      generatedVideoFileCount: 0,
+    };
+
+    expect(sandboxEstablishPolicyDecision(base)).toEqual({
+      policy: "on-demand",
+      reason: "eligible",
+    });
+    expect(sandboxEstablishPolicyDecision({ ...base, lazyEnabled: false })).toEqual({
+      policy: "eager",
+      reason: "lazy_disabled",
+    });
+    expect(sandboxEstablishPolicyDecision({ ...base, machinePrimary: true })).toEqual({
+      policy: "eager",
+      reason: "machine_primary",
+    });
+    expect(sandboxEstablishPolicyDecision({ ...base, sandboxBackend: "none" })).toEqual({
+      policy: "eager",
+      reason: "backend_none",
+    });
+    expect(
+      sandboxEstablishPolicyDecision({ ...base, hasInitialRunCredentialMaterial: true }),
+    ).toEqual({ policy: "eager", reason: "initial_run_credentials" });
+    expect(sandboxEstablishPolicyDecision({ ...base, generatedVideoFileCount: 1 })).toEqual({
+      policy: "eager",
+      reason: "generated_video_files",
+    });
+  });
+
   test("deadline rotation uses only short anti-churn pacing", () => {
     expect(
       sandboxDeadlineRotationRecoveryDelayMs({

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -91,6 +91,7 @@ import {
   resolveActiveSandboxBackend,
   runMandatoryHistoryPersistenceStep,
   sandboxEstablishPolicyDecision,
+  sandboxFileMaterializationOutcome,
   safeErrorDiagnostic,
   sandboxArtifactRuntimeAdmission,
   sandboxDeadlineRotationRecoveryDelayMs,
@@ -2552,6 +2553,20 @@ describe("on-turn recording gate (selfhosted machines have no in-box capture plu
 });
 
 describe("lazy sandbox provisioner single-flight", () => {
+  test("file materialization metrics fail when any download fails softly", () => {
+    expect(sandboxFileMaterializationOutcome([])).toBe("completed");
+    expect(
+      sandboxFileMaterializationOutcome([
+        {
+          fileId: "file-1",
+          filename: "input.pdf",
+          path: "/workspace/input.pdf",
+          reason: "provider returned unavailable",
+        },
+      ]),
+    ).toBe("failed");
+  });
+
   test("establish policy reports the first bounded eager reason", () => {
     const base = {
       lazyEnabled: true,
@@ -2559,6 +2574,7 @@ describe("lazy sandbox provisioner single-flight", () => {
       sandboxBackend: "docker" as const,
       hasInitialRunCredentialMaterial: false,
       generatedVideoFileCount: 0,
+      hasSignedFileResources: false,
     };
 
     expect(sandboxEstablishPolicyDecision(base)).toEqual({
@@ -2583,6 +2599,10 @@ describe("lazy sandbox provisioner single-flight", () => {
     expect(sandboxEstablishPolicyDecision({ ...base, generatedVideoFileCount: 1 })).toEqual({
       policy: "eager",
       reason: "generated_video_files",
+    });
+    expect(sandboxEstablishPolicyDecision({ ...base, hasSignedFileResources: true })).toEqual({
+      policy: "eager",
+      reason: "signed_file_resources",
     });
   });
 

--- a/apps/worker/test/run-input-attachments.test.ts
+++ b/apps/worker/test/run-input-attachments.test.ts
@@ -358,6 +358,74 @@ describe("durable attachment history projection", () => {
 });
 
 describe("turnInput attachment projection", () => {
+  test("reports bounded history subphases without letting diagnostics change input", async () => {
+    const workspaceId = "00000000-0000-4000-8000-000000000030";
+    const sessionId = "00000000-0000-4000-8000-000000000031";
+    const phases: string[] = [];
+    const listUpdates = spyOn(opengeniDb, "listSessionSystemUpdatesForTurn").mockResolvedValue([]);
+    const getEnvelope = spyOn(opengeniDb, "getSandboxSessionEnvelope").mockResolvedValue(null);
+    const runtime = {
+      prepareInput: async () => ({ input: [], persistedHistoryCount: 1 }),
+    } as unknown as OpenGeniRuntime;
+
+    try {
+      const prepared = await turnInput(
+        {} as Database,
+        runtime,
+        {},
+        {
+          id: "00000000-0000-4000-8000-000000000032",
+          workspaceId,
+          sessionId,
+          sequence: 1,
+          type: "user.message",
+          payload: { text: "measure history", resources: [] },
+          occurredAt: "2026-08-13T00:00:00.000Z",
+        },
+        {
+          turnId: "00000000-0000-4000-8000-000000000033",
+          providerApi: "responses",
+          loadActiveHistory: async () => [
+            {
+              id: "00000000-0000-4000-8000-000000000034",
+              position: 0,
+              item: user("measure history"),
+              providerArtifactInvalidatedAt: null,
+            },
+          ],
+          onPreparationPhase: (measurement) => {
+            phases.push(measurement.phase);
+            expect(measurement.outcome).toBe("completed");
+            expect(measurement.durationSeconds).toBeGreaterThanOrEqual(0);
+            if (measurement.phase === "provider_projection") {
+              throw new Error("diagnostic sink unavailable");
+            }
+          },
+        },
+      );
+
+      expect(prepared.persistedHistoryCount).toBe(1);
+      expect(new Set(phases)).toEqual(
+        new Set([
+          "system_update_load",
+          "current_attachment_resolution",
+          "durable_history_load",
+          "sandbox_envelope_load",
+          "canonical_projection",
+          "provider_projection",
+          "attachment_ref_projection",
+          "screenshot_materialization",
+          "model_attachment_projection",
+          "runtime_input_assembly",
+          "artifact_candidate_scan",
+        ]),
+      );
+    } finally {
+      listUpdates.mockRestore();
+      getEnvelope.mockRestore();
+    }
+  });
+
   test("accepts annotation-only user-message triggers backed by canonical history", async () => {
     const workspaceId = "00000000-0000-4000-8000-000000000040";
     const sessionId = "00000000-0000-4000-8000-000000000041";

--- a/apps/worker/test/streaming-slis.test.ts
+++ b/apps/worker/test/streaming-slis.test.ts
@@ -11,7 +11,7 @@ import {
   recordSessionEventPublishLatency,
   recordTurnSandboxEstablishPolicy,
   recordTurnStartupPhase,
-  recordTurnPreModelTotal,
+  recordTurnWorkerPreparationTotal,
   StreamTimingMetrics,
   turnStartupCountBucket,
 } from "../src/observability-metrics";
@@ -223,9 +223,9 @@ describe("turn startup phase diagnostics", () => {
     );
   });
 
-  test("records the non-overlapping pre-model total separately from leaf phases", async () => {
+  test("records worker preparation separately from lazy request phases", async () => {
     const observability = worker();
-    recordTurnPreModelTotal(observability, {
+    recordTurnWorkerPreparationTotal(observability, {
       provider: "codex-subscription",
       backend: "docker",
       outcome: "completed",
@@ -234,7 +234,7 @@ describe("turn startup phase diagnostics", () => {
 
     const metrics = await observability.prometheusMetrics();
     expect(metrics).toMatch(
-      /opengeni_turn_pre_model_duration_seconds_sum\{[^}]*backend="docker"[^}]*outcome="completed"[^}]*provider="codex-subscription"[^}]*\} 1\.4\b/,
+      /opengeni_turn_worker_preparation_duration_seconds_sum\{[^}]*backend="docker"[^}]*outcome="completed"[^}]*provider="codex-subscription"[^}]*\} 1\.4\b/,
     );
   });
 

--- a/apps/worker/test/streaming-slis.test.ts
+++ b/apps/worker/test/streaming-slis.test.ts
@@ -9,7 +9,11 @@ import {
   recordModelRequestPhase,
   recordSessionEventAppendLatency,
   recordSessionEventPublishLatency,
+  recordTurnSandboxEstablishPolicy,
+  recordTurnStartupPhase,
+  recordTurnPreModelTotal,
   StreamTimingMetrics,
+  turnStartupCountBucket,
 } from "../src/observability-metrics";
 
 // Streaming SLIs: pin that each new metric hook fires with the right series, the
@@ -24,7 +28,10 @@ describe("StreamTimingMetrics — TTFT + inter-delta gaps", () => {
   test("first content delta records TTFT from the response (re)start anchor", async () => {
     const observability = worker();
     let now = 1_000;
-    const timing = new StreamTimingMetrics(observability, { provider: "openai", now: () => now });
+    const timing = new StreamTimingMetrics(observability, {
+      provider: "openai",
+      now: () => now,
+    });
 
     now = 2_000; // 1.0s after construction (≈ runStream start)
     timing.onEvent("agent.message.delta");
@@ -39,7 +46,10 @@ describe("StreamTimingMetrics — TTFT + inter-delta gaps", () => {
   test("re-arms TTFT after a non-content event (a post-tool response measures model restart)", async () => {
     const observability = worker();
     let now = 1_000;
-    const timing = new StreamTimingMetrics(observability, { provider: "openai", now: () => now });
+    const timing = new StreamTimingMetrics(observability, {
+      provider: "openai",
+      now: () => now,
+    });
 
     now = 2_000;
     timing.onEvent("agent.message.delta"); // TTFT #1 = 1.0
@@ -59,7 +69,10 @@ describe("StreamTimingMetrics — TTFT + inter-delta gaps", () => {
   test("inter-delta gaps are measured per class and reset across a boundary", async () => {
     const observability = worker();
     let now = 1_000;
-    const timing = new StreamTimingMetrics(observability, { provider: "azure", now: () => now });
+    const timing = new StreamTimingMetrics(observability, {
+      provider: "azure",
+      now: () => now,
+    });
 
     timing.onEvent("agent.message.delta"); // first — no gap
     now = 1_500;
@@ -84,7 +97,10 @@ describe("StreamTimingMetrics — TTFT + inter-delta gaps", () => {
   test("reasoning and message deltas carry distinct class labels", async () => {
     const observability = worker();
     let now = 0;
-    const timing = new StreamTimingMetrics(observability, { provider: "openai", now: () => now });
+    const timing = new StreamTimingMetrics(observability, {
+      provider: "openai",
+      now: () => now,
+    });
 
     timing.onEvent("agent.reasoning.delta");
     now = 100;
@@ -128,6 +144,132 @@ describe("provider request lifecycle diagnostics", () => {
       /opengeni_model_request_phase_duration_seconds_count\{[^}]*phase="first_byte"[^}]*provider="codex-subscription"[^}]*\} 1\b/,
     );
     expect(metrics).not.toContain("requestId");
+  });
+});
+
+describe("turn startup phase diagnostics", () => {
+  test("records one bounded phase series without request identity", async () => {
+    const observability = worker();
+    recordTurnStartupPhase(observability, {
+      phase: "file_materialization",
+      provider: "codex-subscription",
+      backend: "selfhosted",
+      outcome: "completed",
+      durationSeconds: 0.42,
+      count: 5,
+      cache: "disabled",
+    });
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_turn_startup_phase_duration_seconds_sum\{[^}]*backend="selfhosted"[^}]*cache="disabled"[^}]*count_bucket="2-5"[^}]*outcome="completed"[^}]*phase="file_materialization"[^}]*provider="codex-subscription"[^}]*\} 0\.42\b/,
+    );
+    expect(metrics).not.toContain("sessionId");
+    expect(metrics).not.toContain("turnId");
+    expect(metrics).not.toContain("credentialId");
+  });
+
+  test("separates lazy request preparation from the durable request-start audit", async () => {
+    const observability = worker();
+    recordTurnStartupPhase(observability, {
+      phase: "model_request_preparation",
+      provider: "codex-subscription",
+      backend: "docker",
+      outcome: "completed",
+      durationSeconds: 0.21,
+    });
+    recordTurnStartupPhase(observability, {
+      phase: "model_request_audit",
+      provider: "codex-subscription",
+      backend: "docker",
+      outcome: "completed",
+      durationSeconds: 0.08,
+    });
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_turn_startup_phase_duration_seconds_sum\{[^}]*phase="model_request_preparation"[^}]*\} 0\.21\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_turn_startup_phase_duration_seconds_sum\{[^}]*phase="model_request_audit"[^}]*\} 0\.08\b/,
+    );
+  });
+
+  test("records bounded tool-preparation subphases", async () => {
+    const observability = worker();
+    for (const phase of [
+      "tool_server_construction",
+      "tool_required_connect",
+      "tool_optional_connect",
+      "tool_attempt_catalog_build",
+      "tool_attempt_catalog_persist",
+    ] as const) {
+      recordTurnStartupPhase(observability, {
+        phase,
+        provider: "codex-subscription",
+        backend: "docker",
+        outcome: "completed",
+        durationSeconds: 0.01,
+        count: 1,
+      });
+    }
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_turn_startup_phase_duration_seconds_count\{[^}]*phase="tool_server_construction"[^}]*\} 1\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_turn_startup_phase_duration_seconds_count\{[^}]*phase="tool_attempt_catalog_persist"[^}]*\} 1\b/,
+    );
+  });
+
+  test("records the non-overlapping pre-model total separately from leaf phases", async () => {
+    const observability = worker();
+    recordTurnPreModelTotal(observability, {
+      provider: "codex-subscription",
+      backend: "docker",
+      outcome: "completed",
+      durationSeconds: 1.4,
+    });
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_turn_pre_model_duration_seconds_sum\{[^}]*backend="docker"[^}]*outcome="completed"[^}]*provider="codex-subscription"[^}]*\} 1\.4\b/,
+    );
+  });
+
+  test("records only bounded sandbox establish-policy labels", async () => {
+    const observability = worker();
+    recordTurnSandboxEstablishPolicy(observability, {
+      policy: "on-demand",
+      reason: "eligible",
+      backend: "docker",
+    });
+
+    const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_turn_sandbox_establish_policy_total\{[^}]*backend="docker"[^}]*policy="on-demand"[^}]*reason="eligible"[^}]*\} 1\b/,
+    );
+    expect(metrics).not.toContain("sessionId");
+    expect(metrics).not.toContain("sandboxId");
+    expect(metrics).not.toContain("credentialId");
+  });
+
+  test("buckets setup cardinality without exposing raw counts", () => {
+    expect([-1, Number.NaN, Number.POSITIVE_INFINITY].map(turnStartupCountBucket)).toEqual([
+      "unknown",
+      "unknown",
+      "unknown",
+    ]);
+    expect([0, 1, 2, 5, 6, 20, 21].map(turnStartupCountBucket)).toEqual([
+      "0",
+      "1",
+      "2-5",
+      "2-5",
+      "6-20",
+      "6-20",
+      "21+",
+    ]);
   });
 });
 

--- a/docs/design/turn-startup-latency-investigation.md
+++ b/docs/design/turn-startup-latency-investigation.md
@@ -3,7 +3,7 @@
 Status: active experiment on `codex/investigate-turn-startup-latency`.
 
 Current-main audit: `origin/main` at
-`9f20a56d13cc7286097f35de0dc936c18c429ba8` (2026-08-13). None of the
+`478d7fe8feed740ae155fdc5cf7f253f2606bbb4` (2026-08-13). None of the
 startup-phase metrics, the local lazy-provision defaults, or the stale-Docker
 error repair in this experiment are present there. The sandbox Dockerfile still
 has both broad `COPY . .` build stages.
@@ -40,12 +40,12 @@ model time separately.
 | UI visibility | Confirmed | “Waiting for first step” hides queue reason and pre-model phase progress. | Surface queued/admitted/startup phase and elapsed time from durable low-cardinality milestones. |
 | Local port discovery | Confirmed and reproduced | macOS `lsof` blocked about 20 seconds per probe on an unhealthy OrbStack NFS mount. | Prefer bounded loopback `nc`; retain fallbacks. |
 | Host filesystem health | Confirmed symptom, broader cause unproven | The full repository gate later reported OrbStack NFS `resource temporarily unavailable` while the unchanged Channel-A real-local-box suite accumulated four 26–42 second filesystem/Git failures in a narrow rerun. The worktree itself is on APFS, so the exact cross-mount causal chain is not yet proven. | Keep this separate from turn latency. Add host/mount health to local diagnostics; do not weaken Channel-A confinement or inflate its timeouts to conceal an unhealthy machine. |
-| Remote local-development endpoints | Confirmed and reproduced | Default local enrollment advertises loopback endpoints and binds the relay to loopback, so a remote Connected Machine cannot reach it. | Allow an explicit local relay bind and advertise the Mac's Tailscale API/NATS/relay endpoints. |
+| Remote local-development endpoints | Confirmed and reproduced | Default local enrollment advertises loopback endpoints and binds the relay to loopback, so a remote Connected Machine cannot reach it. | Allow an explicit local relay bind, validate and briefly claim its exact address before startup, and advertise the Mac's Tailscale API/NATS/relay endpoints. |
 | Cold sandbox image build | Confirmed, separate | The first local stack boot builds a large sandbox image and tool runtimes. | Treat as environment setup, cache it, and exclude it from per-turn latency. |
 | Local image rebuild invalidation | Confirmed and reproduced | An ordinary worker/runtime edit invalidates two broad `COPY . .` stages. The latest restart spent about 63 seconds in Docker and about 94 seconds before the full stack was ready; dependency install, artifact-runtime preparation, and multi-gigabyte source copies reran. | Replace broad source dependencies with an exact image-input closure or a content-addressed local image admission receipt. Never skip a build on `HEAD` alone because dirty relevant source must invalidate it. |
 | Exact-head artifact runtime | Confirmed, separate | No successful hosted artifact existed for this main SHA, so local standalone Office artifact operations are disabled. | Record as environment parity; it is not evidence of a turn-start bottleneck. |
 | Provider timing semantics | Confirmed | The existing request `headers` duration begins before the durable `agent.model.request started` append, so it includes audit persistence and is not a pure provider-network measurement. | Keep the durable-before-fetch fence, but report request preparation, start audit, and post-audit provider wait separately. |
-| Lazy sandbox policy | Confirmed defect and fixed locally | Current main leaves lazy provisioning off by default. The first attempted dev fix also used the plausible but wrong `_ENABLED` suffix; config actually reads `OPENGENI_SANDBOX_LAZY_PROVISION`. The new bounded policy-reason metric exposed this immediately as `eager/lazy_disabled`. | Local dev now exports and persists the exact config key plus ownership. Keep the reason metric. Production enablement needs its own staged rollout because credentials and generated-video inputs intentionally remain eager. |
+| Lazy sandbox policy | Confirmed defect and fixed locally | Current main leaves lazy provisioning off by default. The first attempted dev fix also used the plausible but wrong `_ENABLED` suffix; config actually reads `OPENGENI_SANDBOX_LAZY_PROVISION`. The new bounded policy-reason metric exposed this immediately as `eager/lazy_disabled`. | Local dev now exports and persists the exact config key plus ownership. Keep the reason metric. Production enablement needs its own staged rollout because credentials, generated-video inputs, and signed file resources intentionally remain eager. |
 | Stale local Docker identity | Confirmed defect and fixed locally | A resumed session can retain a deleted container id. Docker emits `Error response from daemon: No such container`, but current main only recognizes `Error: No such container`, so the typed recovery path is skipped and the raw error reaches the user. | Accept only the exact container id with either known Docker prefix, then reuse the existing typed unavailable-instance recovery. |
 
 ## Measured local results
@@ -125,9 +125,9 @@ same-session workspace continuity.
 ### Verification state
 
 After rebasing onto the current `origin/main`, the focused changed-path suites
-reported 473 passes, 8 intentional skips, and 0 failures. Worker, runtime,
-Codex, and Codemode typechecks passed; the development-stack shell syntax and
-diff checks also passed.
+reported 716 passes and 0 failures. Worker, runtime, Codex, and Codemode
+typechecks passed; the development-stack shell syntax, formatting, and diff
+checks also passed.
 
 The pre-rebase full `bun prep` reached 9,152 passes and 5 failures across 1,006
 test files. The observed failures were confined to the unchanged Channel-A
@@ -141,7 +141,7 @@ branch without evidence. Hosted CI remains the clean-environment arbiter.
 | Keep / fix | Item | Why |
 | --- | --- | --- |
 | Fix | Recompile identical tool validators every turn | Pure repeated CPU; bounded content-addressed reuse preserves authority. |
-| Fix | Keep local lazy provisioning disabled accidentally | Pure pre-model waste for chat-only turns. Use the exact config key, retain eager exceptions for credentials/video, and expose the bounded reason. |
+| Fix | Keep local lazy provisioning disabled accidentally | Pure pre-model waste for chat-only turns. Use the exact config key, retain eager exceptions for credentials/video/signed files, and expose the bounded reason. |
 | Fix | Let a deleted Docker id escape as a raw inspect error | It prevents the existing typed recovery path; the matcher can remain exact and fail closed. |
 | Fix separately | Rebuild the full sandbox image after unrelated worker edits | It adds about a minute to every instrumentation restart and discourages rigorous testing. Use an exact content closure, not a stale image shortcut. |
 | Investigate then likely fix | Re-project and serialize the full tool surface for every request | Still 0.45–0.80 seconds warm and larger for cold/outlier runs. Any cache must remain attempt-safe. |
@@ -152,7 +152,7 @@ branch without evidence. Hosted CI remains the clean-environment arbiter.
 | Keep | Request wire normalization | Measured below 1 ms. |
 | Keep | Required MCP fail-closed behavior | Security/correctness invariant; optimize implementation, not semantics. |
 | Keep | Exact attempt catalog and durable start audit | Required fencing and forensic truth. Optimize their mechanics, never remove them. |
-| Keep | Eager provisioning for resolved run credentials and generated-video inputs | Those bytes must be materialized into one exact leased box before execution. The new reason metric makes this cost explicit. |
+| Keep | Eager provisioning for resolved run credentials, generated-video inputs, and signed file resources | Those bytes must be materialized into one exact leased box before the first model boundary so failures are represented in model input. The new reason metric makes this cost explicit. |
 | Keep | 5-minute NATS auth-callout JWT | It is a scoped transport credential, not the 30-day enrollment identity. Test reconnect behavior; do not lengthen it merely to hide churn. |
 | Separate | Provider/model response time | Variable and externally controlled; never charge it to local startup work. |
 
@@ -195,6 +195,10 @@ servers, long history, NATS expiry boundaries, and concurrent workers.
 
 - Same-session turns remain ordered.
 - Required MCP servers fail closed.
+- Startup diagnostics fail open: an observer or legacy manifest inventory failure
+  is recorded as failed but can never block provider dispatch.
+- Soft file-download failures keep their model-facing failure note and are also
+  reported as failed startup materialization, never as a successful phase.
 - The exact attempt tool catalog remains frozen and durable.
 - Events remain durable before live publication.
 - File writes remain hash-verified, atomic, and read-only.

--- a/docs/design/turn-startup-latency-investigation.md
+++ b/docs/design/turn-startup-latency-investigation.md
@@ -1,0 +1,203 @@
+# Turn startup latency investigation
+
+Status: active experiment on `codex/investigate-turn-startup-latency`.
+
+Current-main audit: `origin/main` at
+`9f20a56d13cc7286097f35de0dc936c18c429ba8` (2026-08-13). None of the
+startup-phase metrics, the local lazy-provision defaults, or the stale-Docker
+error repair in this experiment are present there. The sandbox Dockerfile still
+has both broad `COPY . .` build stages.
+
+## Goal
+
+Reduce non-model time from an observed roughly 85-second blank startup (about
+74 seconds in the attributable pre-model path) to below 1.5 seconds
+without weakening tenant isolation, same-session ordering, durable events,
+credential fairness, file integrity, or exact per-attempt tool authority. Measure
+model time separately.
+
+## Confidence legend
+
+- **Confirmed**: visible in current code or reproduced locally.
+- **Strong hypothesis**: supported by incident timings and code shape, but missing a
+  phase span.
+- **Unproven**: plausible and worth an experiment; do not optimize yet.
+
+## Complete suspect register
+
+| Area | Confidence | Current finding | Experiment / likely improvement |
+| --- | --- | --- | --- |
+| Queue/admission | Strong hypothesis | A roughly 64-minute delay looks like same-session FIFO, not global capacity. | Record queue reason and eligible/admitted timestamps. Keep same-session serialization; make the reason visible. |
+| Credential selection | Confirmed, currently small | Clean one-account Luna runs selected the account in roughly 68–88 ms; request-time token resolution was 6–13 ms. The broad UI label had overstated this area. | Still split policy lock, fairness, lease, session write, and event append before multi-account/rotation tests. Optimize only if those matrices expose growth. |
+| Event persistence | Strong hypothesis | Incident evidence showed durable append around seconds while NATS publish was tens of milliseconds. | Split DB append/commit/lock-wait from publish. Optimize the DB path but keep durable-before-publish. |
+| Connected-machine files | Confirmed | Current self-hosted path processes files serially. Every file emits start/end events and executes a separate size/SHA check; download happens only on mismatch. Durable cache is intentionally disabled because the user may mutate files. | Test 0/1/5/20 files, present/missing/mutated, and multiple sizes. Prototype one manifest-based batch verification or bounded parallel checks while preserving atomic replacement, hashes, read-only mode, and truthful per-file results. |
+| MCP/tool preparation | Confirmed bottleneck and first improvement | Normal tools cost 927 ms average before the experiment; 630 ms was catalog build, dominated by recompiling JSON-schema validators. A bounded content-addressed validator cache reduced warm tool prep to 243–314 ms. | Keep the cache if the full gauntlet and adversarial review pass. Continue tool-count/permission-set/remote-MCP scaling. Retain the exact attempt catalog and fail-closed required servers. |
+| Agents SDK tool projection | Confirmed | The SDK converts and serializes the full authorized MCP surface before every request. Six Luna samples measured 1.53 seconds average for normal tools versus 1.12 seconds for the minimal surface, with a material cold/JIT effect. Codex `defer_loading` saves provider context but still sends and locally serializes every deferred schema. | Measure the SDK `getAllTools` projection separately. Investigate a safe attempt-local prepared projection or a smaller eager first-party surface; do not cache permission-scoped tools across sessions. |
+| Conversation history | Confirmed shape, latency unproven | The active history is loaded and the full array is projected, attachment-materialized, sanitized, and prepared before inference. A prior case had 267 items, about 922 KB, and 216k input tokens without pre-turn compaction. | Benchmark 0/10/100/250 items and 1k/32k/200k tokens. Add phase spans and consider earlier compaction or incremental prepared-history state. |
+| Post-file gap | Strong hypothesis | Roughly 18 seconds was unattributed between file completion and provider dispatch. | Attribute it across history DB read, attachment projection, agent build, tool catalog persistence, and stream/provider setup. |
+| NATS credentials | Confirmed correction | Enrollment bearer and relay token are 30 days on current main. Auth-callout user JWT is capped at 5 minutes and reminted on reconnect. The earlier “5-minute enrollment credential” description was wrong. | Test before/near/after the 5-minute user-JWT expiry and transport interruption. Ensure reconnect/refresh is proactive or outside the turn critical path. |
+| Worker load balance | Unproven | One production worker previously carried materially more inflight work and memory, but the host was not exhausted. | Measure single-worker first, then controlled two-worker distribution. Do not infer causality from one snapshot. |
+| UI visibility | Confirmed | “Waiting for first step” hides queue reason and pre-model phase progress. | Surface queued/admitted/startup phase and elapsed time from durable low-cardinality milestones. |
+| Local port discovery | Confirmed and reproduced | macOS `lsof` blocked about 20 seconds per probe on an unhealthy OrbStack NFS mount. | Prefer bounded loopback `nc`; retain fallbacks. |
+| Host filesystem health | Confirmed symptom, broader cause unproven | The full repository gate later reported OrbStack NFS `resource temporarily unavailable` while the unchanged Channel-A real-local-box suite accumulated four 26–42 second filesystem/Git failures in a narrow rerun. The worktree itself is on APFS, so the exact cross-mount causal chain is not yet proven. | Keep this separate from turn latency. Add host/mount health to local diagnostics; do not weaken Channel-A confinement or inflate its timeouts to conceal an unhealthy machine. |
+| Remote local-development endpoints | Confirmed and reproduced | Default local enrollment advertises loopback endpoints and binds the relay to loopback, so a remote Connected Machine cannot reach it. | Allow an explicit local relay bind and advertise the Mac's Tailscale API/NATS/relay endpoints. |
+| Cold sandbox image build | Confirmed, separate | The first local stack boot builds a large sandbox image and tool runtimes. | Treat as environment setup, cache it, and exclude it from per-turn latency. |
+| Local image rebuild invalidation | Confirmed and reproduced | An ordinary worker/runtime edit invalidates two broad `COPY . .` stages. The latest restart spent about 63 seconds in Docker and about 94 seconds before the full stack was ready; dependency install, artifact-runtime preparation, and multi-gigabyte source copies reran. | Replace broad source dependencies with an exact image-input closure or a content-addressed local image admission receipt. Never skip a build on `HEAD` alone because dirty relevant source must invalidate it. |
+| Exact-head artifact runtime | Confirmed, separate | No successful hosted artifact existed for this main SHA, so local standalone Office artifact operations are disabled. | Record as environment parity; it is not evidence of a turn-start bottleneck. |
+| Provider timing semantics | Confirmed | The existing request `headers` duration begins before the durable `agent.model.request started` append, so it includes audit persistence and is not a pure provider-network measurement. | Keep the durable-before-fetch fence, but report request preparation, start audit, and post-audit provider wait separately. |
+| Lazy sandbox policy | Confirmed defect and fixed locally | Current main leaves lazy provisioning off by default. The first attempted dev fix also used the plausible but wrong `_ENABLED` suffix; config actually reads `OPENGENI_SANDBOX_LAZY_PROVISION`. The new bounded policy-reason metric exposed this immediately as `eager/lazy_disabled`. | Local dev now exports and persists the exact config key plus ownership. Keep the reason metric. Production enablement needs its own staged rollout because credentials and generated-video inputs intentionally remain eager. |
+| Stale local Docker identity | Confirmed defect and fixed locally | A resumed session can retain a deleted container id. Docker emits `Error response from daemon: No such container`, but current main only recognizes `Error: No such container`, so the typed recovery path is skipped and the raw error reaches the user. | Accept only the exact container id with either known Docker prefix, then reuse the existing typed unavailable-instance recovery. |
+
+## Measured local results
+
+All synthetic calls use `codex/gpt-5.6-luna`, low reasoning, a managed Docker
+sandbox, no file resources, and the same `Reply with exactly ready.` prompt.
+Model/provider time is excluded from the pre-network comparisons.
+
+### Six interleaved samples per tool condition before the cache experiment
+
+| Phase | Minimal tools | Normal 80-tool UI surface | Normal penalty |
+| --- | ---: | ---: | ---: |
+| Required MCP connect | 119 ms | 133 ms | 14 ms |
+| Optional MCP connect | <1 ms | 70 ms | 70 ms |
+| Attempt catalog build | 66 ms | 630 ms | 564 ms |
+| Attempt catalog persist | 10 ms | 79 ms | 69 ms |
+| Total tool preparation | 195 ms | 927 ms | 731 ms |
+| SDK projection/serialization | 1,119 ms | 1,528 ms | 409 ms |
+| Credential resolution at request time | 13 ms | 6 ms | none |
+| Wire normalization | <1 ms | <1 ms | none |
+| Durable model-request start audit | 44 ms | 31 ms | none |
+
+Queue-to-worker handoff was 0.22–0.46 seconds. Warm minimal sessions reached the
+request boundary in 0.94–1.68 seconds; normal sessions were usually 1.33–2.47
+seconds, with one 5.97-second outlier. That outlier remains a required
+per-sample investigation, not noise to discard.
+
+### Bounded validator-cache experiment
+
+`createAttemptToolEnvironment` was recompiling all JSON-schema validators with
+AJV for every attempt. The experiment reuses only exact content-addressed
+validator functions in a 512-entry process-local LRU. Attempt scope, digest,
+executor closures, catalog persistence, and authorization remain newly created
+for every attempt.
+
+| Normal-tool run | Catalog build | Total tool preparation | Turn start → request |
+| --- | ---: | ---: | ---: |
+| First cold run | 576 ms | 981 ms | 2.19 s |
+| Warm range (five runs) | 88–123 ms | 243–314 ms | 0.86–1.31 s |
+
+The warm normal path, including queue handoff, is now roughly 1.1–1.6 seconds.
+This meets the 50× target relative to the 85-second incident for this clean
+Docker/no-file/small-history baseline. It does **not** yet prove the original
+large-history, multi-file, same-session, or Connected Machine cases.
+
+### Lazy-provision correction and repeated Luna proof
+
+Every model call in this investigation is pinned to `codex/gpt-5.6-luna`.
+Non-model probes use no model at all. A bounded policy-decision metric records
+`eager`/`on-demand` and one closed reason without session, credential, file, or
+sandbox identifiers.
+
+Before correcting the local config key, zero-file/no-first-party-tool Luna turns
+reported `eager/lazy_disabled` and paid:
+
+- sandbox establish: 0.73–1.49 seconds;
+- owned sandbox setup: 0.56–0.90 seconds;
+- one Docker sandbox created before the model request.
+
+After exporting the exact `OPENGENI_SANDBOX_LAZY_PROVISION=true` key:
+
+- nine consecutive Luna turns all reported `on-demand/eligible`;
+- average total pre-model work was 0.368 seconds (`3.313 / 9`);
+- average sandbox-establish bookkeeping was 0.020 milliseconds
+  (`0.000176 / 9`);
+- zero Docker sandboxes were created by those chat-only turns;
+- active history grew through the `21+` count bucket without leaving the target.
+
+The first subsequent `exec_command` created exactly one Docker sandbox in
+0.537 seconds. A second turn read and appended the marker from the same exact
+instance
+`fba61104cc50168d379f5c7e8ae4be5dc3720b7b4524a7e07fec71fd1010d3f8`.
+This proves both halves of the contract: chat-only turns do not provision, and
+the first real sandbox operation provisions single-flight without losing
+same-session workspace continuity.
+
+### Verification state
+
+After rebasing onto the current `origin/main`, the focused changed-path suites
+reported 473 passes, 8 intentional skips, and 0 failures. Worker, runtime,
+Codex, and Codemode typechecks passed; the development-stack shell syntax and
+diff checks also passed.
+
+The pre-rebase full `bun prep` reached 9,152 passes and 5 failures across 1,006
+test files. The observed failures were confined to the unchanged Channel-A
+real-local-box suite during the host filesystem incident above. A narrow rerun
+of that unchanged file reported 70 passes, 2 skips, and 4 failures, all in slow
+filesystem/Git cases. This is not called green, and it is not attributed to this
+branch without evidence. Hosted CI remains the clean-environment arbiter.
+
+## Simple decision register
+
+| Keep / fix | Item | Why |
+| --- | --- | --- |
+| Fix | Recompile identical tool validators every turn | Pure repeated CPU; bounded content-addressed reuse preserves authority. |
+| Fix | Keep local lazy provisioning disabled accidentally | Pure pre-model waste for chat-only turns. Use the exact config key, retain eager exceptions for credentials/video, and expose the bounded reason. |
+| Fix | Let a deleted Docker id escape as a raw inspect error | It prevents the existing typed recovery path; the matcher can remain exact and fail closed. |
+| Fix separately | Rebuild the full sandbox image after unrelated worker edits | It adds about a minute to every instrumentation restart and discourages rigorous testing. Use an exact content closure, not a stale image shortcut. |
+| Investigate then likely fix | Re-project and serialize the full tool surface for every request | Still 0.45–0.80 seconds warm and larger for cold/outlier runs. Any cache must remain attempt-safe. |
+| Fix visibility | Blank UI during queue and startup | The user cannot distinguish queueing, local setup, and model time. |
+| Fix if scaling test confirms | Serial Connected Machine file verification | Correct today but likely linear in file count and remote command latency. |
+| Fix if incident reproduces | Slow durable event appends | Clean local audit append is tens of milliseconds; incident evidence was seconds. Durable-before-publish stays. |
+| Keep | Credential resolution itself | Measured 6–13 ms at request time; not a bottleneck. |
+| Keep | Request wire normalization | Measured below 1 ms. |
+| Keep | Required MCP fail-closed behavior | Security/correctness invariant; optimize implementation, not semantics. |
+| Keep | Exact attempt catalog and durable start audit | Required fencing and forensic truth. Optimize their mechanics, never remove them. |
+| Keep | Eager provisioning for resolved run credentials and generated-video inputs | Those bytes must be materialized into one exact leased box before execution. The new reason metric makes this cost explicit. |
+| Keep | 5-minute NATS auth-callout JWT | It is a scoped transport credential, not the 30-day enrollment identity. Test reconnect behavior; do not lengthen it merely to hide churn. |
+| Separate | Provider/model response time | Variable and externally controlled; never charge it to local startup work. |
+
+## Required instrumentation
+
+One end-to-end pre-model histogram/span family with low-cardinality phase labels:
+
+1. queue/admission and reason
+2. turn claim
+3. credential policy lock, selection, lease, session write, event append, token resolution
+4. sandbox establish
+5. file resolve, verify, download
+6. MCP connect, list, catalog freeze, catalog persist
+7. history read, deserialize, sanitize/project, attachment materialize
+8. agent construction
+9. provider dispatch
+
+Implemented phase splits now cover tool server construction, required/optional
+connect, catalog build/persist, detailed history preparation, SDK sandbox/client
+preparation, request-time credential resolution, wire normalization, durable
+request-start audit, provider lifecycle, event append, NATS publication, and the
+bounded sandbox establish-policy reason. Queue-reason, per-file Connected Machine
+work, and credential-selection internals remain.
+
+Labels: provider, sandbox backend, phase, outcome, count bucket, cache hit/miss.
+Attempt/session identifiers belong only in logs and traces.
+
+## Baseline matrix
+
+Use the same prompt, history, attached files, MCP set, and tool policy:
+
+1. One Codex subscription account, rotation off, Docker sandbox.
+2. The same Codex account on one Connected Machine.
+
+Grok/SuperGrok is explicitly out of scope. Only after the two Codex baselines:
+multiple credentials/rotation, many files, many MCP
+servers, long history, NATS expiry boundaries, and concurrent workers.
+
+## Safety invariants to keep
+
+- Same-session turns remain ordered.
+- Required MCP servers fail closed.
+- The exact attempt tool catalog remains frozen and durable.
+- Events remain durable before live publication.
+- File writes remain hash-verified, atomic, and read-only.
+- Connected Machines retain ambient user filesystem and credential authority;
+OpenGeni does not clone a replacement repository or inject platform GitHub
+credentials.

--- a/docs/design/turn-startup-latency-investigation.md
+++ b/docs/design/turn-startup-latency-investigation.md
@@ -1,12 +1,12 @@
 # Turn startup latency investigation
 
-Status: active experiment on `codex/investigate-turn-startup-latency`.
+Status: completed implementation experiment; retained as a measurement record.
 
-Current-main audit: `origin/main` at
+Baseline audit: `origin/main` was
 `478d7fe8feed740ae155fdc5cf7f253f2606bbb4` (2026-08-13). None of the
 startup-phase metrics, the local lazy-provision defaults, or the stale-Docker
-error repair in this experiment are present there. The sandbox Dockerfile still
-has both broad `COPY . .` build stages.
+error repair in this experiment were present in that baseline. The sandbox
+Dockerfile had both broad `COPY . .` build stages.
 
 ## Goal
 
@@ -108,7 +108,9 @@ reported `eager/lazy_disabled` and paid:
 After exporting the exact `OPENGENI_SANDBOX_LAZY_PROVISION=true` key:
 
 - nine consecutive Luna turns all reported `on-demand/eligible`;
-- average total pre-model work was 0.368 seconds (`3.313 / 9`);
+- average worker preparation before entering the runtime was 0.368 seconds
+  (`3.313 / 9`); lazy SDK request preparation and the durable request-start
+  audit were measured separately and are not included in that number;
 - average sandbox-establish bookkeeping was 0.020 milliseconds
   (`0.000176 / 9`);
 - zero Docker sandboxes were created by those chat-only turns;
@@ -124,10 +126,10 @@ same-session workspace continuity.
 
 ### Verification state
 
-After rebasing onto the current `origin/main`, the focused changed-path suites
-reported 716 passes and 0 failures. Worker, runtime, Codex, and Codemode
-typechecks passed; the development-stack shell syntax, formatting, and diff
-checks also passed.
+After the experiment branch was rebased onto the then-current `origin/main`, the
+focused changed-path suites reported 716 passes and 0 failures. Worker, runtime,
+Codex, and Codemode typechecks passed; the development-stack shell syntax,
+formatting, and diff checks also passed.
 
 The pre-rebase full `bun prep` reached 9,152 passes and 5 failures across 1,006
 test files. The observed failures were confined to the unchanged Channel-A
@@ -158,7 +160,7 @@ branch without evidence. Hosted CI remains the clean-environment arbiter.
 
 ## Required instrumentation
 
-One end-to-end pre-model histogram/span family with low-cardinality phase labels:
+One worker-preparation total plus a phase family with low-cardinality labels:
 
 1. queue/admission and reason
 2. turn claim
@@ -169,6 +171,11 @@ One end-to-end pre-model histogram/span family with low-cardinality phase labels
 7. history read, deserialize, sanitize/project, attachment materialize
 8. agent construction
 9. provider dispatch
+
+The worker-preparation total intentionally ends when control enters the runtime.
+Lazy SDK request preparation, the durable model-request audit, and provider wait
+remain separate phase observations; calling the worker-only slice an end-to-end
+pre-model total would understate real non-model latency.
 
 Implemented phase splits now cover tool server construction, required/optional
 connect, catalog build/persist, detailed history preparation, SDK sandbox/client

--- a/packages/codemode/src/index.ts
+++ b/packages/codemode/src/index.ts
@@ -364,7 +364,12 @@ export class CodemodeClient {
       method: "POST",
       ...(signal ? { signal } : {}),
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ operationId, catalogDigest, identity, arguments: argumentsValue }),
+      body: JSON.stringify({
+        operationId,
+        catalogDigest,
+        identity,
+        arguments: argumentsValue,
+      }),
     });
     return CodemodeCallSubmission.parse(await response.json()).operation;
   }
@@ -390,7 +395,9 @@ export class CodemodeClient {
     if (!response.ok) {
       let message = `Codemode request failed with HTTP ${response.status}`;
       try {
-        const payload = (await response.json()) as { error?: { message?: unknown } };
+        const payload = (await response.json()) as {
+          error?: { message?: unknown };
+        };
         if (typeof payload.error?.message === "string") message = payload.error.message;
       } catch {
         // The status is sufficient; never echo an unbounded provider body.
@@ -453,7 +460,10 @@ export class AttemptToolEnvironment {
 
   async call(
     input: AttemptToolCallValue,
-    context: { transportMeta?: Record<string, unknown> | null; signal?: AbortSignal } = {},
+    context: {
+      transportMeta?: Record<string, unknown> | null;
+      signal?: AbortSignal;
+    } = {},
   ): Promise<AttemptToolResultValue> {
     const call = AttemptToolCall.parse(input);
     if (call.catalogDigest !== this.catalog.digest) {
@@ -598,6 +608,15 @@ function assertCatalogSize(catalog: AttemptToolCatalogValue): void {
 
 type SchemaCompiler = { compile(schema: object): ValidateFunction<unknown> };
 
+// Validator compilation is structural and independent of attempt identity,
+// executable closures, credentials, and authorization. Reuse only exact
+// content-addressed validators; the attempt environment and catalog remain
+// freshly bound and digested on every execution. The hard cap prevents an
+// untrusted MCP schema stream from turning this process cache into a memory
+// sink.
+const COMPILED_CATALOG_SCHEMA_CACHE_MAX_ENTRIES = 512;
+const compiledCatalogSchemaCache = new Map<string, ValidateFunction<unknown>>();
+
 function createSchemaValidators(): {
   draft7: SchemaCompiler;
   draft2019: SchemaCompiler;
@@ -622,9 +641,31 @@ function compileCatalogSchema(
   schema: AttemptToolCatalogEntryValue["inputSchema"],
 ): ValidateFunction<unknown> {
   const dialect = typeof schema.$schema === "string" ? schema.$schema : "";
-  if (dialect.includes("2020-12")) return validators.draft2020.compile(schema);
-  if (dialect.includes("2019-09")) return validators.draft2019.compile(schema);
-  return validators.draft7.compile(schema);
+  const family = dialect.includes("2020-12")
+    ? "2020-12"
+    : dialect.includes("2019-09")
+      ? "2019-09"
+      : "draft7";
+  const cacheKey = `${family}:${digestCanonicalJson(schema)}`;
+  const cached = compiledCatalogSchemaCache.get(cacheKey);
+  if (cached) {
+    compiledCatalogSchemaCache.delete(cacheKey);
+    compiledCatalogSchemaCache.set(cacheKey, cached);
+    return cached;
+  }
+  const compiled =
+    family === "2020-12"
+      ? validators.draft2020.compile(schema)
+      : family === "2019-09"
+        ? validators.draft2019.compile(schema)
+        : validators.draft7.compile(schema);
+  while (compiledCatalogSchemaCache.size >= COMPILED_CATALOG_SCHEMA_CACHE_MAX_ENTRIES) {
+    const oldest = compiledCatalogSchemaCache.keys().next().value;
+    if (oldest === undefined) break;
+    compiledCatalogSchemaCache.delete(oldest);
+  }
+  compiledCatalogSchemaCache.set(cacheKey, compiled);
+  return compiled;
 }
 
 function allocateCodemodePaths(definitions: readonly AttemptToolDefinition[]): string[][] {

--- a/packages/codemode/test/environment.test.ts
+++ b/packages/codemode/test/environment.test.ts
@@ -129,6 +129,69 @@ describe("AttemptToolEnvironment", () => {
     expect(calls).toEqual(["model:one", "codemode:two"]);
   });
 
+  test("reuses structural validators without sharing attempt executors", async () => {
+    const calls: string[] = [];
+    const first = createAttemptToolEnvironment({
+      scope,
+      generation: 1,
+      definitions: [
+        {
+          ...definition("docs", "search", async () => {
+            calls.push("first");
+            return { content: [] };
+          }),
+          inputSchema: {
+            type: "object",
+            properties: { query: { type: "string" } },
+            required: ["query"],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+    const second = createAttemptToolEnvironment({
+      scope: {
+        ...scope,
+        attemptId: "77777777-7777-4777-8777-777777777777",
+      },
+      generation: 1,
+      definitions: [
+        {
+          ...definition("docs", "search", async () => {
+            calls.push("second");
+            return { content: [] };
+          }),
+          inputSchema: {
+            type: "object",
+            properties: { query: { type: "string" } },
+            required: ["query"],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+
+    await first.callModel({
+      modelName: "docs__search",
+      arguments: { query: "one" },
+      subjectId: "agent:test",
+    });
+    await second.callModel({
+      modelName: "docs__search",
+      arguments: { query: "two" },
+      subjectId: "agent:test",
+    });
+    await expect(
+      second.callModel({
+        modelName: "docs__search",
+        arguments: { query: 2 },
+        subjectId: "agent:test",
+      }),
+    ).rejects.toBeInstanceOf(AttemptToolInputValidationError);
+    expect(calls).toEqual(["first", "second"]);
+    expect(first.catalog.attemptId).not.toBe(second.catalog.attemptId);
+  });
+
   test("rejects stale catalogs before execution", async () => {
     let executed = false;
     const environment = createAttemptToolEnvironment({
@@ -201,7 +264,9 @@ describe("AttemptToolEnvironment", () => {
             executions += 1;
             return {
               content: [],
-              structuredContent: { count: args.validResult === true ? 1 : "wrong" },
+              structuredContent: {
+                count: args.validResult === true ? 1 : "wrong",
+              },
             };
           }),
           inputSchema: {

--- a/packages/codex/src/fetch.ts
+++ b/packages/codex/src/fetch.ts
@@ -17,11 +17,23 @@ import { opaqueProviderArtifactFingerprints } from "./opaque-artifact";
 import {
   codexRequestStorage,
   type CodexModelRequestEvent,
+  type CodexRequestPreparationPhase,
   type CodexRequestContext,
   type CodexResponseTimeoutPolicy,
   type CodexTokenSnapshot,
   type CodexUsageHeaderSnapshot,
 } from "./request-context";
+
+function emitRequestPreparationDiagnostic(
+  ctx: CodexRequestContext,
+  phase: CodexRequestPreparationPhase,
+): void {
+  try {
+    ctx.onRequestPreparationDiagnostic?.(phase);
+  } catch {
+    // Diagnostic observers are non-blocking and cannot affect transport.
+  }
+}
 import {
   CODEX_RESPONSE_TIMEOUT_ERROR_TYPE,
   CodexResponseTimeoutError,
@@ -614,6 +626,7 @@ export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): Fetc
     if (!ctx) {
       return base(input, init); // not a codex turn — passthrough, untouched
     }
+    emitRequestPreparationDiagnostic(ctx, "transport_entry");
 
     const rawUrl =
       typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
@@ -700,7 +713,10 @@ export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): Fetc
         throw new Error("Model request could not be prepared");
       }
       if (!bodyAlreadyNormalized) {
-        ctx.onRequestOpaqueArtifacts?.({ requestId, fingerprints: requestOpaqueArtifacts });
+        ctx.onRequestOpaqueArtifacts?.({
+          requestId,
+          fingerprints: requestOpaqueArtifacts,
+        });
       }
       headers.set(
         "Idempotency-Key",
@@ -726,6 +742,7 @@ export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): Fetc
         policy,
         terminalOutcome: null,
       };
+      emitRequestPreparationDiagnostic(ctx, "wire_request_ready");
       await emitRequestEvent(audit, {
         phase: "started",
         responseObserved: false,
@@ -827,7 +844,9 @@ export function codexSubscriptionFetch(base: FetchLike = globalThis.fetch): Fetc
     };
 
     try {
-      let res = await attempt(await ctx.getToken(), 0);
+      const token = await ctx.getToken();
+      emitRequestPreparationDiagnostic(ctx, "credential_ready");
+      let res = await attempt(token, 0);
       if (res.status === 401) {
         res = await attempt(await ctx.refresh(), 1); // single refresh-on-401 retry (spec §1.9)
       }

--- a/packages/codex/src/request-context.ts
+++ b/packages/codex/src/request-context.ts
@@ -67,6 +67,11 @@ export type CodexRequestOpaqueArtifacts = {
   fingerprints: readonly string[];
 };
 
+export type CodexRequestPreparationPhase =
+  | "transport_entry"
+  | "credential_ready"
+  | "wire_request_ready";
+
 export type CodexRequestContext = {
   clientVersion: string;
   /**
@@ -103,6 +108,8 @@ export type CodexRequestContext = {
    * swallowed by the transport and it must never receive request bodies/auth.
    */
   onModelRequestDiagnostic?: (event: CodexModelRequestEvent) => void;
+  /** Bounded synchronous checkpoints for pre-network request preparation. */
+  onRequestPreparationDiagnostic?: (phase: CodexRequestPreparationPhase) => void;
   /** Worker-owned durable audit sink; payloads never contain request bodies or auth. */
   onModelRequestEvent?: (event: CodexModelRequestEvent) => Promise<void> | void;
   /** Exact opaque artifacts on the normalized wire request, never their ciphertext. */

--- a/packages/codex/test/fetch.test.ts
+++ b/packages/codex/test/fetch.test.ts
@@ -43,7 +43,12 @@ function expectExactlyOneTerminalPerAttempt(
       transportAttempt: event.transportAttempt,
       phase: event.phase,
     })),
-  ).toEqual(expected.map(({ transportAttempt, phase }) => ({ transportAttempt, phase })));
+  ).toEqual(
+    expected.map(({ transportAttempt, phase }) => ({
+      transportAttempt,
+      phase,
+    })),
+  );
   for (const [index, expectation] of expected.entries()) {
     if (expectation.requestId !== undefined) {
       expect(terminalEvents[index]?.requestId).toBe(expectation.requestId);
@@ -225,7 +230,10 @@ describe("codexSubscriptionFetch", () => {
 
   test("reports only the exact opaque artifacts on the normalized wire request", async () => {
     const { base } = baseRecorder();
-    const observed: Array<{ requestId: string; fingerprints: readonly string[] }> = [];
+    const observed: Array<{
+      requestId: string;
+      fingerprints: readonly string[];
+    }> = [];
     const opaque = {
       type: "reasoning",
       id: "rs-wire",
@@ -294,7 +302,10 @@ describe("codexSubscriptionFetch", () => {
         betaFeatures: ["remote_compaction_v2"],
         turnMetadata: {
           request_kind: "compaction",
-          compaction: { implementation: "responses_compaction_v2", strategy: "memento" },
+          compaction: {
+            implementation: "responses_compaction_v2",
+            strategy: "memento",
+          },
         },
       }),
       () =>
@@ -311,7 +322,10 @@ describe("codexSubscriptionFetch", () => {
     expect(headers.get("x-codex-beta-features")).toBe("remote_compaction_v2");
     expect(JSON.parse(headers.get("x-codex-turn-metadata")!)).toEqual({
       request_kind: "compaction",
-      compaction: { implementation: "responses_compaction_v2", strategy: "memento" },
+      compaction: {
+        implementation: "responses_compaction_v2",
+        strategy: "memento",
+      },
     });
     const body = JSON.parse(captures[0]?.init?.body as string) as {
       input: Array<{ type: string }>;
@@ -384,7 +398,11 @@ describe("codexSubscriptionFetch", () => {
         },
       );
     };
-    const expected = JSON.stringify({ model: "gpt-5.6-sol", stream: true, input: [] });
+    const expected = JSON.stringify({
+      model: "gpt-5.6-sol",
+      stream: true,
+      input: [],
+    });
     const bytes = new TextEncoder().encode(expected);
     const factory = () =>
       new ReadableStream<Uint8Array>({
@@ -599,7 +617,10 @@ describe("codexSubscriptionFetch", () => {
     ["top-level error", { type: "error", code: "provider_error", message: "provider error" }],
     [
       "response.error",
-      { type: "response.error", error: { code: "response_error", message: "response error" } },
+      {
+        type: "response.error",
+        error: { code: "response_error", message: "response error" },
+      },
     ],
   ] as const)("non-streaming %s emits exactly one failed terminal", async (_name, event) => {
     const events: CodexModelRequestEvent[] = [];
@@ -619,7 +640,11 @@ describe("codexSubscriptionFetch", () => {
             }),
         )("https://chatgpt.com/backend-api/responses", {
           method: "POST",
-          body: JSON.stringify({ model: "gpt-5.6-sol", stream: false, input: [] }),
+          body: JSON.stringify({
+            model: "gpt-5.6-sol",
+            stream: false,
+            input: [],
+          }),
         }),
     );
 
@@ -1092,7 +1117,11 @@ describe("codexSubscriptionFetch", () => {
               }),
           )("https://chatgpt.com/backend-api/responses", {
             method: "POST",
-            body: JSON.stringify({ model: "gpt-5.6-sol", stream: false, input: [] }),
+            body: JSON.stringify({
+              model: "gpt-5.6-sol",
+              stream: false,
+              input: [],
+            }),
           }),
       );
 
@@ -1160,7 +1189,11 @@ describe("codexSubscriptionFetch", () => {
               }),
           )("https://chatgpt.com/backend-api/responses", {
             method: "POST",
-            body: JSON.stringify({ model: "gpt-5.6-sol", stream: true, input: [] }),
+            body: JSON.stringify({
+              model: "gpt-5.6-sol",
+              stream: true,
+              input: [],
+            }),
           }),
       );
 
@@ -1405,7 +1438,11 @@ describe("codexSubscriptionFetch", () => {
       () =>
         codexSubscriptionFetch(codexBase)("https://chatgpt.com/backend-api/responses", {
           method: "POST",
-          body: JSON.stringify({ model: "gpt-5.6-sol", stream: true, input: [] }),
+          body: JSON.stringify({
+            model: "gpt-5.6-sol",
+            stream: true,
+            input: [],
+          }),
         }),
     );
 
@@ -1438,7 +1475,11 @@ describe("codexSubscriptionFetch", () => {
       () =>
         codexSubscriptionFetch(codexBase)("https://chatgpt.com/backend-api/responses", {
           method: "POST",
-          body: JSON.stringify({ model: "gpt-5.6-sol", stream: true, input: [] }),
+          body: JSON.stringify({
+            model: "gpt-5.6-sol",
+            stream: true,
+            input: [],
+          }),
         }),
     );
 
@@ -1469,6 +1510,23 @@ describe("codexSubscriptionFetch", () => {
 
     expect(response.status).toBe(200);
     expect(order.slice(0, 2)).toEqual(["diagnostic", "audit:started"]);
+  });
+
+  test("request-preparation diagnostics expose bounded pre-network checkpoints", async () => {
+    const phases: string[] = [];
+    const response = await codexRequestStorage.run(
+      ctx({
+        onRequestPreparationDiagnostic: (phase) => phases.push(phase),
+      }),
+      () =>
+        codexSubscriptionFetch(codexBase)("https://chatgpt.com/backend-api/responses", {
+          method: "POST",
+          body: JSON.stringify({ model: "gpt-5.6-sol", input: [] }),
+        }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(phases).toEqual(["transport_entry", "credential_ready", "wire_request_ready"]);
   });
 
   test("streaming caller: successful bytes pass through for model-level reconstruction", async () => {
@@ -1826,7 +1884,11 @@ describe("codexSubscriptionFetch", () => {
     const res = await codexRequestStorage.run(ctx(), () =>
       codexSubscriptionFetch(base)("https://chatgpt.com/backend-api/responses", {
         method: "POST",
-        body: JSON.stringify({ model: "gpt-5.6-sol", stream: true, input: [] }),
+        body: JSON.stringify({
+          model: "gpt-5.6-sol",
+          stream: true,
+          input: [],
+        }),
       }),
     );
     expect(cancelled).toBe(true);

--- a/packages/runtime/src/append-only-responses-model.ts
+++ b/packages/runtime/src/append-only-responses-model.ts
@@ -1,6 +1,8 @@
 import { OpenAIResponsesModel, type AgentInputItem, type ModelRequest } from "@openai/agents";
 import OpenAI from "openai";
 
+import { recordModelPreparationMeasurement } from "./model-preparation-diagnostics";
+
 /**
  * Responses model optimized for immutable, normally append-only protocol input.
  *
@@ -21,51 +23,65 @@ export class AppendOnlyOpenAIResponsesModel extends OpenAIResponsesModel {
   protected override _getInputItems(
     input: ModelRequest["input"],
   ): OpenAI.Responses.ResponseInputItem[] {
-    if (typeof input === "string") {
-      this.clearConvertedInput();
-      return super._getInputItems(input);
-    }
-
-    const previousProtocolInput = this.previousProtocolInput;
-    const previousResponsesInput = this.previousResponsesInput;
-    let commonPrefixLength = 0;
-    if (previousProtocolInput && previousResponsesInput) {
-      const comparableLength = Math.min(
-        this.previousProtocolInputLength,
-        previousResponsesInput.length,
-        input.length,
-      );
-      while (
-        commonPrefixLength < comparableLength &&
-        previousProtocolInput[commonPrefixLength] === input[commonPrefixLength]
-      ) {
-        commonPrefixLength += 1;
+    const startedAt = performance.now();
+    let outcome: "completed" | "failed" = "completed";
+    try {
+      if (typeof input === "string") {
+        this.clearConvertedInput();
+        return super._getInputItems(input);
       }
-    }
 
-    let converted: OpenAI.Responses.ResponseInputItem[];
-    if (
-      previousResponsesInput &&
-      commonPrefixLength === input.length &&
-      input.length === this.previousProtocolInputLength
-    ) {
-      converted = previousResponsesInput;
-    } else if (previousResponsesInput && commonPrefixLength > 0) {
-      converted = [
-        ...previousResponsesInput.slice(0, commonPrefixLength),
-        ...super._getInputItems(input.slice(commonPrefixLength)),
-      ];
-    } else {
-      converted = super._getInputItems(input);
-    }
+      const previousProtocolInput = this.previousProtocolInput;
+      const previousResponsesInput = this.previousResponsesInput;
+      let commonPrefixLength = 0;
+      if (previousProtocolInput && previousResponsesInput) {
+        const comparableLength = Math.min(
+          this.previousProtocolInputLength,
+          previousResponsesInput.length,
+          input.length,
+        );
+        while (
+          commonPrefixLength < comparableLength &&
+          previousProtocolInput[commonPrefixLength] === input[commonPrefixLength]
+        ) {
+          commonPrefixLength += 1;
+        }
+      }
 
-    // Retain the exact immutable source array and its then-current length. If a
-    // caller appends to the same array, the captured length prevents treating
-    // unconverted items as cached; replacement/divergence is identity-checked.
-    this.previousProtocolInput = input;
-    this.previousProtocolInputLength = input.length;
-    this.previousResponsesInput = converted;
-    return converted;
+      let converted: OpenAI.Responses.ResponseInputItem[];
+      if (
+        previousResponsesInput &&
+        commonPrefixLength === input.length &&
+        input.length === this.previousProtocolInputLength
+      ) {
+        converted = previousResponsesInput;
+      } else if (previousResponsesInput && commonPrefixLength > 0) {
+        converted = [
+          ...previousResponsesInput.slice(0, commonPrefixLength),
+          ...super._getInputItems(input.slice(commonPrefixLength)),
+        ];
+      } else {
+        converted = super._getInputItems(input);
+      }
+
+      // Retain the exact immutable source array and its then-current length. If a
+      // caller appends to the same array, the captured length prevents treating
+      // unconverted items as cached; replacement/divergence is identity-checked.
+      this.previousProtocolInput = input;
+      this.previousProtocolInputLength = input.length;
+      this.previousResponsesInput = converted;
+      return converted;
+    } catch (error) {
+      outcome = "failed";
+      throw error;
+    } finally {
+      recordModelPreparationMeasurement({
+        phase: "responses_input_conversion",
+        outcome,
+        durationSeconds: (performance.now() - startedAt) / 1_000,
+        count: typeof input === "string" ? 1 : input.length,
+      });
+    }
   }
 
   private clearConvertedInput(): void {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3183,55 +3183,55 @@ export async function prepareAgentTools(
     "server_construction",
     async () =>
       await boundedParallelMap(tools, MCP_MAX_CONCURRENT_SERVER_OPERATIONS, async (tool, index) => {
-      const config = registry.get(tool.id);
-      if (!config) {
-        throw new Error(`Unknown MCP server id: ${tool.id}`);
-      }
-      if (config.id === CODEX_APPS_MCP_SERVER_ID && !isCodexAppsMcpServer(config)) {
-        throw new Error("Codex Apps server id is reserved for the canonical endpoint");
-      }
-      const local = localRegistry.get(config.id);
-      if (local) {
-        if (local.resolvedConnectionId) {
-          recordResolvedMcpConnectionId(
-            resolvedMcpConnectionIds,
-            config,
-            local.resolvedConnectionId,
-          );
+        const config = registry.get(tool.id);
+        if (!config) {
+          throw new Error(`Unknown MCP server id: ${tool.id}`);
         }
-        const optional = tool.optional === true;
-        return {
-          server: new PrefixedMcpServer(
-            local.server,
-            config.id,
-            config.allowedTools,
-            optional || Boolean(config.connectionRef),
-            aggregateToolBudget,
-            `${config.id}:${index}`,
-          ),
-          bestEffort: optional || Boolean(config.connectionRef),
-          optional,
-          timeoutMs: config.timeoutMs,
-        };
-      }
+        if (config.id === CODEX_APPS_MCP_SERVER_ID && !isCodexAppsMcpServer(config)) {
+          throw new Error("Codex Apps server id is reserved for the canonical endpoint");
+        }
+        const local = localRegistry.get(config.id);
+        if (local) {
+          if (local.resolvedConnectionId) {
+            recordResolvedMcpConnectionId(
+              resolvedMcpConnectionIds,
+              config,
+              local.resolvedConnectionId,
+            );
+          }
+          const optional = tool.optional === true;
+          return {
+            server: new PrefixedMcpServer(
+              local.server,
+              config.id,
+              config.allowedTools,
+              optional || Boolean(config.connectionRef),
+              aggregateToolBudget,
+              `${config.id}:${index}`,
+            ),
+            bestEffort: optional || Boolean(config.connectionRef),
+            optional,
+            timeoutMs: config.timeoutMs,
+          };
+        }
         const url =
           firstPartyMcpServerUrlForRun(settings, config, options.workspaceId) ?? config.url;
-      const firstParty = isFirstPartyMcpServer(settings, config);
-      const baseFetch = isCodexAppsMcpServer(config)
-        ? codexAppsSanitizingFetch(mcpFetchImpl, codexConnectorNamespaces)
-        : mcpFetchImpl;
-      const guardedFetch = guardedMcpFetch(
-        firstParty ? { ...settings, integrationsAllowPrivateNetworkTargets: true } : settings,
-        baseFetch,
-        {
-          ...(firstParty ? { requireHttpsOutsideLocalTest: false } : {}),
-          ...(useBunNativeFetch ? { pinResolvedDestination: false } : {}),
-        },
-      );
-      const optional = tool.optional === true;
-      const fetchImpl = isCodexAppsMcpServer(config)
-        ? codexAppsAuthFetch(guardedFetch, settings, options)
-        : config.connectionRef
+        const firstParty = isFirstPartyMcpServer(settings, config);
+        const baseFetch = isCodexAppsMcpServer(config)
+          ? codexAppsSanitizingFetch(mcpFetchImpl, codexConnectorNamespaces)
+          : mcpFetchImpl;
+        const guardedFetch = guardedMcpFetch(
+          firstParty ? { ...settings, integrationsAllowPrivateNetworkTargets: true } : settings,
+          baseFetch,
+          {
+            ...(firstParty ? { requireHttpsOutsideLocalTest: false } : {}),
+            ...(useBunNativeFetch ? { pinResolvedDestination: false } : {}),
+          },
+        );
+        const optional = tool.optional === true;
+        const fetchImpl = isCodexAppsMcpServer(config)
+          ? codexAppsAuthFetch(guardedFetch, settings, options)
+          : config.connectionRef
             ? connectionBrokerFetch(
                 guardedFetch,
                 config,
@@ -3239,95 +3239,95 @@ export async function prepareAgentTools(
                 resolvedMcpConnectionIds,
                 optional,
               )
-          : firstParty
-            ? firstPartyAuthFetch(guardedFetch, settings, options)
-            : guardedFetch;
-      // A server is connected BEST-EFFORT (a connect OR tools-list failure drops
-      // it — its tools go unavailable for the turn — instead of failing the turn)
-      // in two cases:
-      //  - codex_apps: connector availability is RUNTIME-DISCOVERED — the
-      //    device-code login may lack the connector scopes, and the backend can
-      //    reject the bearer at the initialize/tools-list handshake, so a 401/403
-      //    (or a missing/failed token) drops the server.
-      //  - an optional ToolRef: either an auto-attached workspace-default
-      //    capability MCP or a client/pack-selected portable ref. A
-      //    broken/expired credential or unavailable endpoint skips the server
-      //    with a warning, never killing the turn before the model runs. Bare
-      //    refs stay strict (below), preserving the fail-loud default.
-      // The connect-time drop is handled by connectMcpServers({ strict: false });
-      // the tools-list-time drop is enforced inside PrefixedMcpServer.listTools —
-      // a best-effort server whose tools/list throws (e.g. an expired connection
-      // credential surfacing as a StreamableHTTP "authentication required" 401)
-      // degrades to zero tools rather than throwing out of the SDK's run-time
-      // getAllMcpTools and failing an unrelated turn. Codex Apps setup-time
-      // auth misses are still published as actionable state because the
-      // workspace catalog explicitly told the user that the surface existed.
-      const bestEffort = isCodexAppsMcpServer(config) || optional || !!config.connectionRef;
-      const useGmailRestAdapter =
-        settings.gmailRestAdapterEnabled &&
-        isOfficialGmailMcpConfig(config.url, config.connectionRef);
-      const innerServer = useGmailRestAdapter
-        ? new GmailRestMcpServer({
-            workspaceId: options.workspaceId ?? "",
-            ...(options.credentialSubjectId ? { subjectId: options.credentialSubjectId } : {}),
-            serverId: config.id,
-            connectionRef: config.connectionRef!,
-            resolveCredential: async (request) =>
-              await resolveConnectionForRequest(
-                options,
-                request.serverId,
-                request.connectionRef,
-                request.destinationUrl,
-                request.toolName,
-                request.forceRefresh === true,
-              ),
-            onAuthNeeded: async (payload) => await publishAuthNeeded(options, payload),
-            onResolvedConnectionId: (connectionId) =>
-              recordResolvedMcpConnectionId(resolvedMcpConnectionIds, config, connectionId),
-            fetchImpl: mcpFetchImpl,
-          })
-        : new MCPServerStreamableHttp({
-            url,
-            name: config.name ?? config.id,
-            cacheToolsList: config.cacheToolsList,
-            // The upstream transport logger receives raw thrown errors, whose
-            // messages may contain response bodies, URLs, headers, or echoed
-            // credentials. Keep its diagnostic surface structural only.
-            logger: mcpTransportLogger(config.id, {
-              // Codex Apps setup is a read-only initialize/tools-list handshake.
-              // A statusless transport failure is safe to retry, while auth
-              // responses remain non-retryable and publish their specific
-              // reconnect reason through codexAppsAuthFetch.
-              recoverySafeSetup: isCodexAppsMcpServer(config),
-            }),
-            // codex_apps returns connector tools with empty `outputSchema: {}` that the
-            // MCP SDK's strict Tool schema rejects (fails the turn during tools/list);
-            // sanitize the response on the wire before validation. The namespace Set
-            // also captures each tool's original connector namespace (P4 Part B.1).
-            fetch: fetchImpl,
-            ...(await mcpServerRequestInit(settings, config)),
-            ...(config.timeoutMs
-              ? {
-                  timeout: config.timeoutMs,
-                  clientSessionTimeoutSeconds: Math.ceil(config.timeoutMs / 1000),
-                }
-              : {}),
-          });
-      const server = new PrefixedMcpServer(
-        innerServer,
-        config.id,
-        config.allowedTools,
-        bestEffort,
-        aggregateToolBudget,
-        `${config.id}:${index}`,
-        firstParty && !bestEffort,
-      );
-      return {
-        server,
-        bestEffort,
-        optional,
-        timeoutMs: config.timeoutMs,
-      };
+            : firstParty
+              ? firstPartyAuthFetch(guardedFetch, settings, options)
+              : guardedFetch;
+        // A server is connected BEST-EFFORT (a connect OR tools-list failure drops
+        // it — its tools go unavailable for the turn — instead of failing the turn)
+        // in two cases:
+        //  - codex_apps: connector availability is RUNTIME-DISCOVERED — the
+        //    device-code login may lack the connector scopes, and the backend can
+        //    reject the bearer at the initialize/tools-list handshake, so a 401/403
+        //    (or a missing/failed token) drops the server.
+        //  - an optional ToolRef: either an auto-attached workspace-default
+        //    capability MCP or a client/pack-selected portable ref. A
+        //    broken/expired credential or unavailable endpoint skips the server
+        //    with a warning, never killing the turn before the model runs. Bare
+        //    refs stay strict (below), preserving the fail-loud default.
+        // The connect-time drop is handled by connectMcpServers({ strict: false });
+        // the tools-list-time drop is enforced inside PrefixedMcpServer.listTools —
+        // a best-effort server whose tools/list throws (e.g. an expired connection
+        // credential surfacing as a StreamableHTTP "authentication required" 401)
+        // degrades to zero tools rather than throwing out of the SDK's run-time
+        // getAllMcpTools and failing an unrelated turn. Codex Apps setup-time
+        // auth misses are still published as actionable state because the
+        // workspace catalog explicitly told the user that the surface existed.
+        const bestEffort = isCodexAppsMcpServer(config) || optional || !!config.connectionRef;
+        const useGmailRestAdapter =
+          settings.gmailRestAdapterEnabled &&
+          isOfficialGmailMcpConfig(config.url, config.connectionRef);
+        const innerServer = useGmailRestAdapter
+          ? new GmailRestMcpServer({
+              workspaceId: options.workspaceId ?? "",
+              ...(options.credentialSubjectId ? { subjectId: options.credentialSubjectId } : {}),
+              serverId: config.id,
+              connectionRef: config.connectionRef!,
+              resolveCredential: async (request) =>
+                await resolveConnectionForRequest(
+                  options,
+                  request.serverId,
+                  request.connectionRef,
+                  request.destinationUrl,
+                  request.toolName,
+                  request.forceRefresh === true,
+                ),
+              onAuthNeeded: async (payload) => await publishAuthNeeded(options, payload),
+              onResolvedConnectionId: (connectionId) =>
+                recordResolvedMcpConnectionId(resolvedMcpConnectionIds, config, connectionId),
+              fetchImpl: mcpFetchImpl,
+            })
+          : new MCPServerStreamableHttp({
+              url,
+              name: config.name ?? config.id,
+              cacheToolsList: config.cacheToolsList,
+              // The upstream transport logger receives raw thrown errors, whose
+              // messages may contain response bodies, URLs, headers, or echoed
+              // credentials. Keep its diagnostic surface structural only.
+              logger: mcpTransportLogger(config.id, {
+                // Codex Apps setup is a read-only initialize/tools-list handshake.
+                // A statusless transport failure is safe to retry, while auth
+                // responses remain non-retryable and publish their specific
+                // reconnect reason through codexAppsAuthFetch.
+                recoverySafeSetup: isCodexAppsMcpServer(config),
+              }),
+              // codex_apps returns connector tools with empty `outputSchema: {}` that the
+              // MCP SDK's strict Tool schema rejects (fails the turn during tools/list);
+              // sanitize the response on the wire before validation. The namespace Set
+              // also captures each tool's original connector namespace (P4 Part B.1).
+              fetch: fetchImpl,
+              ...(await mcpServerRequestInit(settings, config)),
+              ...(config.timeoutMs
+                ? {
+                    timeout: config.timeoutMs,
+                    clientSessionTimeoutSeconds: Math.ceil(config.timeoutMs / 1000),
+                  }
+                : {}),
+            });
+        const server = new PrefixedMcpServer(
+          innerServer,
+          config.id,
+          config.allowedTools,
+          bestEffort,
+          aggregateToolBudget,
+          `${config.id}:${index}`,
+          firstParty && !bestEffort,
+        );
+        return {
+          server,
+          bestEffort,
+          optional,
+          timeoutMs: config.timeoutMs,
+        };
       }),
   );
   const requiredEntries = servers.filter((entry) => !entry.bestEffort);
@@ -3350,20 +3350,20 @@ export async function prepareAgentTools(
     "required_connect",
     async () =>
       await connectMcpServersInBatches(requiredServers, {
-    strict: true,
-    connectTimeoutMs: mcpOuterConnectTimeoutMs(requiredEntries.map((entry) => entry.timeoutMs)),
+        strict: true,
+        connectTimeoutMs: mcpOuterConnectTimeoutMs(requiredEntries.map((entry) => entry.timeoutMs)),
       }),
   );
   let connectedBestEffort: ConnectedMcpServerBatches | null = null;
   try {
     connectedBestEffort = await measureToolPreparationPhase(options, "optional_connect", async () =>
       bestEffortServers.length
-      ? await connectMcpServersInBatches(bestEffortServers, {
-          strict: false,
-          connectTimeoutMs: mcpOuterConnectTimeoutMs(
-            bestEffortEntries.map((entry) => entry.timeoutMs),
-          ),
-        })
+        ? await connectMcpServersInBatches(bestEffortServers, {
+            strict: false,
+            connectTimeoutMs: mcpOuterConnectTimeoutMs(
+              bestEffortEntries.map((entry) => entry.timeoutMs),
+            ),
+          })
         : null,
     );
   } catch (error) {
@@ -4989,7 +4989,7 @@ export class PrefixedMcpServer implements MCPServer {
     let outcome: "completed" | "failed" = "completed";
     let count: number | undefined;
     try {
-    this.frozenTools ??= this.loadAndFreezeTools();
+      this.frozenTools ??= this.loadAndFreezeTools();
       const tools = await this.frozenTools;
       count = tools.length;
       return tools;
@@ -5653,7 +5653,7 @@ export async function runAgentStream(
         // serialization so no extension can bypass the policy.
         measuredModelInputFilter(
           "input_filter_tool_output",
-        boundModelToolOutputsFilterForSettings(settings),
+          boundModelToolOutputsFilterForSettings(settings),
         ),
         measuredModelInputFilter(
           "input_filter_modality",
@@ -5664,19 +5664,19 @@ export async function runAgentStream(
         ),
         measuredModelInputFilter(
           "input_filter_context",
-        contextRobustnessFilterForSettings(settings, {
-          throwOnCompactionNeeded: Boolean(
-            overrides.contextCompactionSignal || overrides.contextCompactionRequested,
-          ),
-          ...(overrides.contextCompactionSignal
-            ? { contextCompactionSignal: overrides.contextCompactionSignal }
-            : {}),
-          ...(overrides.contextCompactionRequested
-            ? {
-                contextCompactionRequested: overrides.contextCompactionRequested,
-              }
-            : {}),
-        }),
+          contextRobustnessFilterForSettings(settings, {
+            throwOnCompactionNeeded: Boolean(
+              overrides.contextCompactionSignal || overrides.contextCompactionRequested,
+            ),
+            ...(overrides.contextCompactionSignal
+              ? { contextCompactionSignal: overrides.contextCompactionSignal }
+              : {}),
+            ...(overrides.contextCompactionRequested
+              ? {
+                  contextCompactionRequested: overrides.contextCompactionRequested,
+                }
+              : {}),
+          }),
         ),
       ].filter((f): f is CallModelInputFilter => Boolean(f)),
     );
@@ -5794,25 +5794,25 @@ export async function runAgentStream(
       measuredModelInputFilter("input_filter_host", overrides.callModelInputFilter),
       measuredModelInputFilter(
         "input_filter_tool_output",
-      boundModelToolOutputsFilterForSettings(settings),
+        boundModelToolOutputsFilterForSettings(settings),
       ),
       measuredModelInputFilter(
         "input_filter_modality",
-      modelModalityProjectionFilterForAgent(agent, prepared.modelInputAlreadyProjected === true),
+        modelModalityProjectionFilterForAgent(agent, prepared.modelInputAlreadyProjected === true),
       ),
       measuredModelInputFilter(
         "input_filter_context",
-      contextRobustnessFilterForSettings(settings, {
-        throwOnCompactionNeeded: Boolean(
-          overrides.contextCompactionSignal || overrides.contextCompactionRequested,
-        ),
-        ...(overrides.contextCompactionSignal
-          ? { contextCompactionSignal: overrides.contextCompactionSignal }
-          : {}),
-        ...(overrides.contextCompactionRequested
-          ? { contextCompactionRequested: overrides.contextCompactionRequested }
-          : {}),
-      }),
+        contextRobustnessFilterForSettings(settings, {
+          throwOnCompactionNeeded: Boolean(
+            overrides.contextCompactionSignal || overrides.contextCompactionRequested,
+          ),
+          ...(overrides.contextCompactionSignal
+            ? { contextCompactionSignal: overrides.contextCompactionSignal }
+            : {}),
+          ...(overrides.contextCompactionRequested
+            ? { contextCompactionRequested: overrides.contextCompactionRequested }
+            : {}),
+        }),
       ),
     ].filter((f): f is CallModelInputFilter => Boolean(f)),
   );

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -239,6 +239,15 @@ import {
   incrementalModelInputProjectionFilter,
 } from "./model-input";
 import {
+  recordModelPreparationManifestInventory,
+  recordModelPreparationMeasurement,
+  withModelPreparationClientDiagnostics,
+  withModelPreparationObserver,
+  withModelPreparationSessionDiagnostics,
+  type ModelPreparationMeasurement,
+  type ModelPreparationPhase,
+} from "./model-preparation-diagnostics";
+import {
   HUMAN_INPUT_TOOL_NAME,
   modelResponseUsageFromResponse,
   serializeApprovals,
@@ -278,6 +287,10 @@ export {
 } from "./skill-library";
 
 export type { RuntimeMetricsHooks } from "./metrics";
+export type {
+  ModelPreparationMeasurement,
+  ModelPreparationPhase,
+} from "./model-preparation-diagnostics";
 export {
   CodexSubscriptionUnavailableError,
   MultiProviderModelProvider,
@@ -2947,6 +2960,19 @@ export type LocalMcpServerRegistration = {
   resolvedConnectionId?: string;
 };
 
+export type ToolPreparationPhase =
+  | "server_construction"
+  | "required_connect"
+  | "optional_connect"
+  | "attempt_catalog_build"
+  | "attempt_catalog_persist";
+
+export type ToolPreparationPhaseMeasurement = {
+  phase: ToolPreparationPhase;
+  outcome: "completed" | "failed";
+  durationSeconds: number;
+};
+
 export type PrepareToolsOptions = {
   accountId?: string;
   workspaceId?: string;
@@ -2994,6 +3020,8 @@ export type PrepareToolsOptions = {
   attemptToolCatalogGeneration?: number;
   /** Durable host seam; completion is required before the model can run. */
   onAttemptToolCatalog?: (catalog: AttemptToolCatalog) => Promise<void> | void;
+  /** Bounded critical-path timings; telemetry failures never affect preparation. */
+  onPreparationPhase?: (measurement: ToolPreparationPhaseMeasurement) => void;
   /**
    * Already-authorized in-process tools (for example Browser/Computer
    * interaction operations). They are projected into the same model MCP list
@@ -3001,6 +3029,31 @@ export type PrepareToolsOptions = {
    */
   attemptToolDefinitions?: readonly AttemptToolDefinition[];
 };
+
+async function measureToolPreparationPhase<T>(
+  options: PrepareToolsOptions,
+  phase: ToolPreparationPhase,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const startedAt = performance.now();
+  let outcome: ToolPreparationPhaseMeasurement["outcome"] = "completed";
+  try {
+    return await operation();
+  } catch (error) {
+    outcome = "failed";
+    throw error;
+  } finally {
+    try {
+      options.onPreparationPhase?.({
+        phase,
+        outcome,
+        durationSeconds: (performance.now() - startedAt) / 1_000,
+      });
+    } catch {
+      // Diagnostics must not change MCP authority or lifecycle behavior.
+    }
+  }
+}
 
 type ConnectedMcpServerBatch = Awaited<ReturnType<typeof connectMcpServers>>;
 
@@ -3125,10 +3178,11 @@ export async function prepareAgentTools(
   const useBunNativeFetch = options.mcpFetchImpl === undefined && !!process.versions.bun;
   const mcpFetchImpl =
     options.mcpFetchImpl ?? (useBunNativeFetch ? globalThis.fetch.bind(globalThis) : undiciFetch);
-  const servers = await boundedParallelMap(
-    tools,
-    MCP_MAX_CONCURRENT_SERVER_OPERATIONS,
-    async (tool, index) => {
+  const servers = await measureToolPreparationPhase(
+    options,
+    "server_construction",
+    async () =>
+      await boundedParallelMap(tools, MCP_MAX_CONCURRENT_SERVER_OPERATIONS, async (tool, index) => {
       const config = registry.get(tool.id);
       if (!config) {
         throw new Error(`Unknown MCP server id: ${tool.id}`);
@@ -3160,7 +3214,8 @@ export async function prepareAgentTools(
           timeoutMs: config.timeoutMs,
         };
       }
-      const url = firstPartyMcpServerUrlForRun(settings, config, options.workspaceId) ?? config.url;
+        const url =
+          firstPartyMcpServerUrlForRun(settings, config, options.workspaceId) ?? config.url;
       const firstParty = isFirstPartyMcpServer(settings, config);
       const baseFetch = isCodexAppsMcpServer(config)
         ? codexAppsSanitizingFetch(mcpFetchImpl, codexConnectorNamespaces)
@@ -3177,7 +3232,13 @@ export async function prepareAgentTools(
       const fetchImpl = isCodexAppsMcpServer(config)
         ? codexAppsAuthFetch(guardedFetch, settings, options)
         : config.connectionRef
-          ? connectionBrokerFetch(guardedFetch, config, options, resolvedMcpConnectionIds, optional)
+            ? connectionBrokerFetch(
+                guardedFetch,
+                config,
+                options,
+                resolvedMcpConnectionIds,
+                optional,
+              )
           : firstParty
             ? firstPartyAuthFetch(guardedFetch, settings, options)
             : guardedFetch;
@@ -3267,7 +3328,7 @@ export async function prepareAgentTools(
         optional,
         timeoutMs: config.timeoutMs,
       };
-    },
+      }),
   );
   const requiredEntries = servers.filter((entry) => !entry.bestEffort);
   const bestEffortEntries = servers.filter((entry) => entry.bestEffort);
@@ -3284,20 +3345,27 @@ export async function prepareAgentTools(
       .filter((server): server is PrefixedMcpServer => server instanceof PrefixedMcpServer)
       .map((server) => server.registryId),
   );
-  const connectedRequired = await connectMcpServersInBatches(requiredServers, {
+  const connectedRequired = await measureToolPreparationPhase(
+    options,
+    "required_connect",
+    async () =>
+      await connectMcpServersInBatches(requiredServers, {
     strict: true,
     connectTimeoutMs: mcpOuterConnectTimeoutMs(requiredEntries.map((entry) => entry.timeoutMs)),
-  });
+      }),
+  );
   let connectedBestEffort: ConnectedMcpServerBatches | null = null;
   try {
-    connectedBestEffort = bestEffortServers.length
+    connectedBestEffort = await measureToolPreparationPhase(options, "optional_connect", async () =>
+      bestEffortServers.length
       ? await connectMcpServersInBatches(bestEffortServers, {
           strict: false,
           connectTimeoutMs: mcpOuterConnectTimeoutMs(
             bestEffortEntries.map((entry) => entry.timeoutMs),
           ),
         })
-      : null;
+        : null,
+    );
   } catch (error) {
     await connectedRequired.close().catch(() => undefined);
     throw error;
@@ -3334,16 +3402,18 @@ export async function prepareAgentTools(
           options.subjectId ?? "worker:mcp-model",
         )
       : null;
-    attemptToolEnvironment = await prepareAttemptToolEnvironment(
-      activeMcpServers,
-      registry,
+    attemptToolEnvironment = await measureToolPreparationPhase(
       options,
+      "attempt_catalog_build",
+      async () => await prepareAttemptToolEnvironment(activeMcpServers, registry, options),
     );
     if (attemptToolEnvironment && localToolServer) {
       localToolServer.bindAttemptToolEnvironment(attemptToolEnvironment);
     }
     if (attemptToolEnvironment) {
-      await options.onAttemptToolCatalog?.(attemptToolEnvironment.catalog);
+      await measureToolPreparationPhase(options, "attempt_catalog_persist", async () => {
+        await options.onAttemptToolCatalog?.(attemptToolEnvironment!.catalog);
+      });
     }
   } catch (error) {
     await localToolServer?.close().catch(() => undefined);
@@ -4914,9 +4984,26 @@ export class PrefixedMcpServer implements MCPServer {
     this.aggregateToolBudget?.remove(this.aggregateSourceId);
   }
 
-  listTools(): Promise<RuntimeMcpTool[]> {
+  async listTools(): Promise<RuntimeMcpTool[]> {
+    const startedAt = performance.now();
+    let outcome: "completed" | "failed" = "completed";
+    let count: number | undefined;
+    try {
     this.frozenTools ??= this.loadAndFreezeTools();
-    return this.frozenTools;
+      const tools = await this.frozenTools;
+      count = tools.length;
+      return tools;
+    } catch (error) {
+      outcome = "failed";
+      throw error;
+    } finally {
+      recordModelPreparationMeasurement({
+        phase: "mcp_tools_snapshot",
+        outcome,
+        durationSeconds: (performance.now() - startedAt) / 1_000,
+        ...(count === undefined ? {} : { count }),
+      });
+    }
   }
 
   freezeTools(): Promise<RuntimeMcpTool[]> {
@@ -5257,6 +5344,8 @@ export async function prepareRunInput(
 export type RunAgentStreamOptions = {
   /** Abort the provider/tool loop when the owning activity is cancelled. */
   signal?: AbortSignal;
+  /** Nonblocking phase measurements for request preparation before provider I/O. */
+  onModelPreparationPhase?: (measurement: ModelPreparationMeasurement) => void;
   sandboxClient?: unknown;
   sandboxEnvironment?: Record<string, string>;
   onRuntimeEvent?: (event: NormalizedRuntimeEvent) => Promise<void> | void;
@@ -5386,6 +5475,30 @@ function modelModalityProjectionFilterForAgent(
     },
     initialInputAlreadyProjected,
   );
+}
+
+function measuredModelInputFilter(
+  phase: ModelPreparationPhase,
+  filter: CallModelInputFilter | undefined,
+): CallModelInputFilter | undefined {
+  if (!filter) return undefined;
+  return async (args) => {
+    const startedAt = performance.now();
+    let outcome: "completed" | "failed" = "completed";
+    try {
+      return await filter(args);
+    } catch (error) {
+      outcome = "failed";
+      throw error;
+    } finally {
+      recordModelPreparationMeasurement({
+        phase,
+        outcome,
+        durationSeconds: (performance.now() - startedAt) / 1_000,
+        count: args.modelData.input.length,
+      });
+    }
+  };
 }
 
 export async function runAgentStream(
@@ -5532,14 +5645,25 @@ export async function runAgentStream(
     );
     const ownedFilter = composeCallModelInputFilters(
       [
-        baseModelInputFilterForSettings(settings),
-        genesisTitleInputFilter,
-        overrides.callModelInputFilter,
+        measuredModelInputFilter("input_filter_base", baseModelInputFilterForSettings(settings)),
+        measuredModelInputFilter("input_filter_genesis", genesisTitleInputFilter),
+        measuredModelInputFilter("input_filter_host", overrides.callModelInputFilter),
         // A caller filter may synthesize model input. Re-apply the idempotent
         // canonical bound at the literal final seam before accounting/provider
         // serialization so no extension can bypass the policy.
+        measuredModelInputFilter(
+          "input_filter_tool_output",
         boundModelToolOutputsFilterForSettings(settings),
-        modelModalityProjectionFilterForAgent(agent, prepared.modelInputAlreadyProjected === true),
+        ),
+        measuredModelInputFilter(
+          "input_filter_modality",
+          modelModalityProjectionFilterForAgent(
+            agent,
+            prepared.modelInputAlreadyProjected === true,
+          ),
+        ),
+        measuredModelInputFilter(
+          "input_filter_context",
         contextRobustnessFilterForSettings(settings, {
           throwOnCompactionNeeded: Boolean(
             overrides.contextCompactionSignal || overrides.contextCompactionRequested,
@@ -5553,6 +5677,7 @@ export async function runAgentStream(
               }
             : {}),
         }),
+        ),
       ].filter((f): f is CallModelInputFilter => Boolean(f)),
     );
     const ownedRunOptions: Parameters<typeof run>[2] = {
@@ -5566,10 +5691,20 @@ export async function runAgentStream(
     };
     ownedRunOptions.sandbox = {
       client: decoratedClient,
-      session: agentSession,
+      session: withModelPreparationSessionDiagnostics(agentSession),
       ...(sessionState ? { sessionState } : {}),
     } as SandboxRunConfig;
-    return await runScopedRunner(settings, agent).run(agent, prepared.input, ownedRunOptions);
+    return await withModelPreparationObserver(overrides.onModelPreparationPhase, () => {
+      recordModelPreparationManifestInventory(
+        "sandbox_agent_manifest_inventory",
+        (agent as { defaultManifest?: Manifest }).defaultManifest,
+      );
+      recordModelPreparationManifestInventory(
+        "sandbox_session_manifest_inventory",
+        (agentSession as { state?: { manifest?: Manifest } }).state?.manifest,
+      );
+      return runScopedRunner(settings, agent).run(agent, prepared.input, ownedRunOptions);
+    });
   }
 
   const rawClient = overrides.sandboxClient ?? createSandboxClient(settings, environment);
@@ -5654,11 +5789,19 @@ export async function runAgentStream(
   // pass an SDK session and reconciles durable truth from the untouched input.
   const callModelInputFilter = composeCallModelInputFilters(
     [
-      baseModelInputFilterForSettings(settings),
-      genesisTitleInputFilter,
-      overrides.callModelInputFilter,
+      measuredModelInputFilter("input_filter_base", baseModelInputFilterForSettings(settings)),
+      measuredModelInputFilter("input_filter_genesis", genesisTitleInputFilter),
+      measuredModelInputFilter("input_filter_host", overrides.callModelInputFilter),
+      measuredModelInputFilter(
+        "input_filter_tool_output",
       boundModelToolOutputsFilterForSettings(settings),
+      ),
+      measuredModelInputFilter(
+        "input_filter_modality",
       modelModalityProjectionFilterForAgent(agent, prepared.modelInputAlreadyProjected === true),
+      ),
+      measuredModelInputFilter(
+        "input_filter_context",
       contextRobustnessFilterForSettings(settings, {
         throwOnCompactionNeeded: Boolean(
           overrides.contextCompactionSignal || overrides.contextCompactionRequested,
@@ -5670,6 +5813,7 @@ export async function runAgentStream(
           ? { contextCompactionRequested: overrides.contextCompactionRequested }
           : {}),
       }),
+      ),
     ].filter((f): f is CallModelInputFilter => Boolean(f)),
   );
   const runOptions: Parameters<typeof run>[2] = {
@@ -5687,11 +5831,17 @@ export async function runAgentStream(
   };
   if (client) {
     runOptions.sandbox = {
-      client,
+      client: withModelPreparationClientDiagnostics(client),
       ...(sandboxSessionState ? { sessionState: sandboxSessionState } : {}),
     } as SandboxRunConfig;
   }
-  return await runScopedRunner(settings, agent).run(agent, prepared.input, runOptions);
+  return await withModelPreparationObserver(overrides.onModelPreparationPhase, () => {
+    recordModelPreparationManifestInventory(
+      "sandbox_agent_manifest_inventory",
+      (agent as { defaultManifest?: Manifest }).defaultManifest,
+    );
+    return runScopedRunner(settings, agent).run(agent, prepared.input, runOptions);
+  });
 }
 
 function appendSandboxFileDownloadFailureNote(

--- a/packages/runtime/src/model-preparation-diagnostics.ts
+++ b/packages/runtime/src/model-preparation-diagnostics.ts
@@ -233,9 +233,8 @@ export function recordModelPreparationManifestInventory(
     ) {
       for (const _entry of manifest.iterEntries()) count += 1;
     }
-  } catch (error) {
+  } catch {
     outcome = "failed";
-    throw error;
   } finally {
     recordModelPreparationMeasurement({
       phase,

--- a/packages/runtime/src/model-preparation-diagnostics.ts
+++ b/packages/runtime/src/model-preparation-diagnostics.ts
@@ -1,0 +1,247 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { addTraceProcessor, type Span, type Trace, type TracingProcessor } from "@openai/agents";
+
+export type ModelPreparationPhase =
+  | "sandbox_agent_preparation"
+  | "sandbox_agent_manifest_inventory"
+  | "sandbox_session_manifest_inventory"
+  | "sandbox_manifest_apply"
+  | "sandbox_entry_materialization"
+  | "sandbox_running_check"
+  | "sandbox_start"
+  | "sandbox_client_create"
+  | "sandbox_client_resume"
+  | "sandbox_client_delete"
+  | "sandbox_client_state_serialize"
+  | "sandbox_client_reuse_check"
+  | "runner_before_mcp_tools"
+  | "mcp_tools_snapshot"
+  | "mcp_tools_before_input_filter"
+  | "input_filter_base"
+  | "input_filter_genesis"
+  | "input_filter_host"
+  | "input_filter_tool_output"
+  | "input_filter_modality"
+  | "input_filter_context"
+  | "responses_input_conversion"
+  | "responses_request_build";
+
+export type ModelPreparationMeasurement = {
+  phase: ModelPreparationPhase;
+  outcome: "completed" | "failed";
+  durationSeconds: number;
+  count?: number;
+};
+
+type ModelPreparationObserver = (measurement: ModelPreparationMeasurement) => void;
+
+type ModelPreparationObservation = {
+  observer: ModelPreparationObserver;
+  startedAt: number;
+  mcpToolsEndedAt?: number;
+  runnerGapRecorded: boolean;
+  postMcpGapRecorded: boolean;
+};
+
+const modelPreparationObserver = new AsyncLocalStorage<ModelPreparationObservation>();
+
+class ModelPreparationTraceProcessor implements TracingProcessor {
+  async onTraceStart(_trace: Trace): Promise<void> {}
+  async onTraceEnd(_trace: Trace): Promise<void> {}
+  async onSpanStart(_span: Span<any>): Promise<void> {}
+
+  async onSpanEnd(span: Span<any>): Promise<void> {
+    if (
+      span.spanData.type !== "custom" ||
+      span.spanData.name !== "sandbox.prepare_agent" ||
+      !span.startedAt ||
+      !span.endedAt
+    ) {
+      return;
+    }
+    recordModelPreparationMeasurement({
+      phase: "sandbox_agent_preparation",
+      outcome: span.error ? "failed" : "completed",
+      durationSeconds: Math.max(0, (Date.parse(span.endedAt) - Date.parse(span.startedAt)) / 1_000),
+    });
+  }
+
+  async shutdown(_timeout?: number): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}
+
+addTraceProcessor(new ModelPreparationTraceProcessor());
+
+export function withModelPreparationObserver<T>(
+  observer: ModelPreparationObserver | undefined,
+  callback: () => T,
+): T {
+  return observer
+    ? modelPreparationObserver.run(
+        {
+          observer,
+          startedAt: performance.now(),
+          runnerGapRecorded: false,
+          postMcpGapRecorded: false,
+        },
+        callback,
+      )
+    : callback();
+}
+
+export function recordModelPreparationMeasurement(measurement: ModelPreparationMeasurement): void {
+  try {
+    const observation = modelPreparationObserver.getStore();
+    if (!observation) return;
+
+    const endedAt = performance.now();
+    const startedAt = endedAt - measurement.durationSeconds * 1_000;
+    if (measurement.phase === "mcp_tools_snapshot") {
+      if (!observation.runnerGapRecorded) {
+        observation.runnerGapRecorded = true;
+        observation.observer({
+          phase: "runner_before_mcp_tools",
+          outcome: measurement.outcome,
+          durationSeconds: Math.max(0, startedAt - observation.startedAt) / 1_000,
+        });
+      }
+      observation.mcpToolsEndedAt = endedAt;
+    } else if (
+      measurement.phase.startsWith("input_filter_") &&
+      !observation.postMcpGapRecorded &&
+      observation.mcpToolsEndedAt !== undefined
+    ) {
+      observation.postMcpGapRecorded = true;
+      observation.observer({
+        phase: "mcp_tools_before_input_filter",
+        outcome: measurement.outcome,
+        durationSeconds: Math.max(0, startedAt - observation.mcpToolsEndedAt) / 1_000,
+      });
+    }
+    observation.observer(measurement);
+  } catch {
+    // Diagnostics must never affect model preparation or provider dispatch.
+  }
+}
+
+/** Observe provider session work performed by the Agents SDK before its first model call. */
+export function withModelPreparationSessionDiagnostics<T extends object>(session: T): T {
+  return new Proxy(session, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver) as unknown;
+      if (
+        typeof value !== "function" ||
+        !["applyManifest", "materializeEntry", "running", "start"].includes(String(property))
+      ) {
+        return typeof value === "function" ? value.bind(target) : value;
+      }
+
+      return async (...args: unknown[]) => {
+        const startedAt = performance.now();
+        let outcome: ModelPreparationMeasurement["outcome"] = "completed";
+        try {
+          return await (value as (...callArgs: unknown[]) => unknown).apply(target, args);
+        } catch (error) {
+          outcome = "failed";
+          throw error;
+        } finally {
+          const phase: ModelPreparationPhase =
+            property === "applyManifest"
+              ? "sandbox_manifest_apply"
+              : property === "materializeEntry"
+                ? "sandbox_entry_materialization"
+                : property === "running"
+                  ? "sandbox_running_check"
+                  : "sandbox_start";
+          recordModelPreparationMeasurement({
+            phase,
+            outcome,
+            durationSeconds: (performance.now() - startedAt) / 1_000,
+          });
+        }
+      };
+    },
+  });
+}
+
+export function withModelPreparationClientDiagnostics<T extends object>(client: T): T {
+  return new Proxy(client, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver) as unknown;
+      const method = String(property);
+      if (
+        typeof value !== "function" ||
+        ![
+          "create",
+          "resume",
+          "delete",
+          "serializeSessionState",
+          "canReusePreservedOwnedSession",
+        ].includes(method)
+      ) {
+        return typeof value === "function" ? value.bind(target) : value;
+      }
+
+      return async (...args: unknown[]) => {
+        const startedAt = performance.now();
+        let outcome: ModelPreparationMeasurement["outcome"] = "completed";
+        try {
+          const result = await (value as (...callArgs: unknown[]) => unknown).apply(target, args);
+          return (method === "create" || method === "resume") &&
+            result &&
+            typeof result === "object"
+            ? withModelPreparationSessionDiagnostics(result)
+            : result;
+        } catch (error) {
+          outcome = "failed";
+          throw error;
+        } finally {
+          const phase: ModelPreparationPhase =
+            method === "create"
+              ? "sandbox_client_create"
+              : method === "resume"
+                ? "sandbox_client_resume"
+                : method === "delete"
+                  ? "sandbox_client_delete"
+                  : method === "serializeSessionState"
+                    ? "sandbox_client_state_serialize"
+                    : "sandbox_client_reuse_check";
+          recordModelPreparationMeasurement({
+            phase,
+            outcome,
+            durationSeconds: (performance.now() - startedAt) / 1_000,
+          });
+        }
+      };
+    },
+  });
+}
+
+export function recordModelPreparationManifestInventory(
+  phase: "sandbox_agent_manifest_inventory" | "sandbox_session_manifest_inventory",
+  manifest: unknown,
+): void {
+  const startedAt = performance.now();
+  let outcome: ModelPreparationMeasurement["outcome"] = "completed";
+  let count = 0;
+  try {
+    if (
+      manifest &&
+      typeof manifest === "object" &&
+      "iterEntries" in manifest &&
+      typeof manifest.iterEntries === "function"
+    ) {
+      for (const _entry of manifest.iterEntries()) count += 1;
+    }
+  } catch (error) {
+    outcome = "failed";
+    throw error;
+  } finally {
+    recordModelPreparationMeasurement({
+      phase,
+      outcome,
+      durationSeconds: (performance.now() - startedAt) / 1_000,
+      count,
+    });
+  }
+}

--- a/packages/runtime/src/model-provider-routing.ts
+++ b/packages/runtime/src/model-provider-routing.ts
@@ -1,11 +1,17 @@
 import type { ConfiguredModel, ResolvedModelProvider, Settings } from "@opengeni/config";
 import { configuredProviders, resolveModelProvider } from "@opengeni/config";
-import { OpenAIChatCompletionsModel, type Model, type ModelProvider } from "@openai/agents";
+import {
+  OpenAIChatCompletionsModel,
+  type Model,
+  type ModelProvider,
+  type ModelRequest,
+} from "@openai/agents";
 import OpenAI from "openai";
 import { CODEX_MODEL_ID_PREFIX } from "@opengeni/codex";
 import { XAI_SUBSCRIPTION_MODEL_ID_PREFIX } from "@opengeni/xai-subscription";
 
 import { AppendOnlyOpenAIResponsesModel } from "./append-only-responses-model";
+import { recordModelPreparationMeasurement } from "./model-preparation-diagnostics";
 import { buildProviderClient } from "./model-provider-client";
 import {
   CodexSubscriptionUnavailableError,
@@ -19,6 +25,24 @@ export class OpenGeniResponsesModel extends AppendOnlyOpenAIResponsesModel {
     protected readonly provider: ResolvedModelProvider,
   ) {
     super(client, model);
+  }
+
+  protected override _buildResponsesCreateRequest(request: ModelRequest, stream: boolean) {
+    const startedAt = performance.now();
+    let outcome: "completed" | "failed" = "completed";
+    try {
+      return super._buildResponsesCreateRequest(request, stream);
+    } catch (error) {
+      outcome = "failed";
+      throw error;
+    } finally {
+      recordModelPreparationMeasurement({
+        phase: "responses_request_build",
+        outcome,
+        durationSeconds: (performance.now() - startedAt) / 1_000,
+        count: typeof request.input === "string" ? 1 : request.input.length,
+      });
+    }
   }
 }
 

--- a/packages/runtime/src/sandbox/providers/docker.ts
+++ b/packages/runtime/src/sandbox/providers/docker.ts
@@ -49,11 +49,11 @@ function dockerInspectMessage(error: unknown): string {
   return typeof stderr === "string" ? stderr.trim() : "";
 }
 
-function dockerInspectProvesMissing(error: unknown, containerId: string): boolean {
+export function dockerInspectProvesMissing(error: unknown, containerId: string): boolean {
   const escaped = containerId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^Error: No such (?:object|container): ${escaped}$`).test(
-    dockerInspectMessage(error),
-  );
+  return new RegExp(
+    `^(?:Error|Error response from daemon): No such (?:object|container): ${escaped}$`,
+  ).test(dockerInspectMessage(error));
 }
 
 class OpenGeniDockerSandboxClient extends DockerSandboxClient {

--- a/packages/runtime/test/model-preparation-diagnostics.test.ts
+++ b/packages/runtime/test/model-preparation-diagnostics.test.ts
@@ -9,7 +9,7 @@ describe("model preparation diagnostics", () => {
   test("manifest inventory remains fail-open when iteration throws", () => {
     const measurements: ModelPreparationMeasurement[] = [];
     const manifest = {
-      *iterEntries(): Generator<never, void, unknown> {
+      iterEntries(): Generator<never, void, unknown> {
         throw new Error("legacy manifest cannot normalize an entry");
       },
     };

--- a/packages/runtime/test/model-preparation-diagnostics.test.ts
+++ b/packages/runtime/test/model-preparation-diagnostics.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import {
+  recordModelPreparationManifestInventory,
+  type ModelPreparationMeasurement,
+  withModelPreparationObserver,
+} from "../src/model-preparation-diagnostics";
+
+describe("model preparation diagnostics", () => {
+  test("manifest inventory remains fail-open when iteration throws", () => {
+    const measurements: ModelPreparationMeasurement[] = [];
+    const manifest = {
+      *iterEntries(): Generator<never, void, unknown> {
+        throw new Error("legacy manifest cannot normalize an entry");
+      },
+    };
+
+    expect(() =>
+      withModelPreparationObserver(
+        (measurement) => measurements.push(measurement),
+        () => recordModelPreparationManifestInventory("sandbox_agent_manifest_inventory", manifest),
+      ),
+    ).not.toThrow();
+    expect(measurements).toHaveLength(1);
+    expect(measurements[0]).toMatchObject({
+      phase: "sandbox_agent_manifest_inventory",
+      outcome: "failed",
+      count: 0,
+    });
+  });
+});

--- a/packages/runtime/test/sandbox-provider-registry.test.ts
+++ b/packages/runtime/test/sandbox-provider-registry.test.ts
@@ -23,6 +23,7 @@ import {
   sdkBackendIdForSandboxBackend,
   selectBackend,
 } from "../src/sandbox";
+import { dockerInspectProvesMissing } from "../src/sandbox/providers/docker";
 
 // Per-provider credential stubs so build() can run without real creds. Only the
 // fields validateCredentials requires per backend are present.
@@ -218,6 +219,35 @@ describe("createSandboxClient — per-backend matrix construction", () => {
     ) as { resumeExact?: unknown };
 
     expect(typeof client.resumeExact).toBe("function");
+  });
+
+  test("docker exact resume recognizes only exact missing-container diagnostics", () => {
+    const containerId = "fba61104cc50168d";
+
+    expect(
+      dockerInspectProvesMissing(
+        { stderr: `Error response from daemon: No such container: ${containerId}\n` },
+        containerId,
+      ),
+    ).toBe(true);
+    expect(
+      dockerInspectProvesMissing(
+        { stderr: `Error: No such container: ${containerId}` },
+        containerId,
+      ),
+    ).toBe(true);
+    expect(
+      dockerInspectProvesMissing(
+        { stderr: `Error response from daemon: No such container: another-container` },
+        containerId,
+      ),
+    ).toBe(false);
+    expect(
+      dockerInspectProvesMissing(
+        { stderr: `permission denied while inspecting ${containerId}` },
+        containerId,
+      ),
+    ).toBe(false);
   });
 
   test("local exact resume never restores or creates a replacement workspace", async () => {

--- a/scripts/dev-stack-artifact-runtime.test.ts
+++ b/scripts/dev-stack-artifact-runtime.test.ts
@@ -109,6 +109,32 @@ describe("local artifact runtime stack contract", () => {
     expect(source).toContain("bash scripts/run-development-relay.sh");
   });
 
+  test("probes local ports without walking unhealthy mounted filesystems", async () => {
+    const source = await Bun.file(scriptPath).text();
+    const netcatProbe = source.indexOf("nc -z -w 1 127.0.0.1");
+    const lsofFallback = source.indexOf("lsof -nP -iTCP");
+
+    expect(netcatProbe).toBeGreaterThan(-1);
+    expect(lsofFallback).toBeGreaterThan(netcatProbe);
+  });
+
+  test("can advertise a remote-reachable development relay while binding it locally", async () => {
+    const source = await Bun.file(scriptPath).text();
+
+    expect(source).toContain('if [ -n "${OPENGENI_RELAY_BIND:-}" ]; then');
+    expect(source).toContain("start_local_relay=1");
+    expect(source).toContain("export OPENGENI_RELAY_BIND OPENGENI_RELAY_TOKEN_SECRET");
+  });
+
+  test("reuses generated ports without restoring stale derived runtime settings", async () => {
+    const source = await Bun.file(scriptPath).text();
+
+    expect(source).not.toContain(". ./.env.runtime");
+    expect(source).toContain("for runtime_port_var in");
+    expect(source).toContain("OPENGENI_RELAY_HOST_PORT");
+    expect(source).toContain('sed -n "s/^${runtime_port_var}=//p" .env.runtime');
+  });
+
   test("enables interactive Browser and Computer surfaces locally by default", async () => {
     const source = await Bun.file(scriptPath).text();
 
@@ -120,6 +146,20 @@ describe("local artifact runtime stack contract", () => {
       expect(source).toContain(`if [ -z "\${${setting}:-}" ]; then`);
       expect(source).toContain(`${setting}=true`);
       expect(source).toContain(`export ${setting}`);
+    }
+  });
+
+  test("uses durable lazy sandbox ownership locally by default", async () => {
+    const source = await Bun.file(scriptPath).text();
+
+    for (const setting of [
+      "OPENGENI_SANDBOX_OWNERSHIP_ENABLED",
+      "OPENGENI_SANDBOX_LAZY_PROVISION",
+    ]) {
+      expect(source).toContain(`if [ -z "\${${setting}:-}" ]; then`);
+      expect(source).toContain(`${setting}=true`);
+      expect(source).toContain(`export ${setting}`);
+      expect(source).toContain(`printf '${setting}=%s\\n'`);
     }
   });
 

--- a/scripts/dev-stack-artifact-runtime.test.ts
+++ b/scripts/dev-stack-artifact-runtime.test.ts
@@ -111,9 +111,12 @@ describe("local artifact runtime stack contract", () => {
 
   test("probes local ports without walking unhealthy mounted filesystems", async () => {
     const source = await Bun.file(scriptPath).text();
+    const netcatCapabilityCheck = source.indexOf("nc_help=");
     const netcatProbe = source.indexOf("nc -z -w 1 127.0.0.1");
     const lsofFallback = source.indexOf("lsof -nP -iTCP");
 
+    expect(netcatCapabilityCheck).toBeGreaterThan(-1);
+    expect(netcatProbe).toBeGreaterThan(netcatCapabilityCheck);
     expect(netcatProbe).toBeGreaterThan(-1);
     expect(lsofFallback).toBeGreaterThan(netcatProbe);
   });
@@ -122,6 +125,9 @@ describe("local artifact runtime stack contract", () => {
     const source = await Bun.file(scriptPath).text();
 
     expect(source).toContain('if [ -n "${OPENGENI_RELAY_BIND:-}" ]; then');
+    expect(source).toContain('explicit_relay_port="$(relay_bind_available');
+    expect(source).toContain('port_claimed "$explicit_relay_port"');
+    expect(source).toContain("OPENGENI_RELAY_BIND must be host:port");
     expect(source).toContain("start_local_relay=1");
     expect(source).toContain("export OPENGENI_RELAY_BIND OPENGENI_RELAY_TOKEN_SECRET");
   });

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -221,11 +221,23 @@ if [ -f .env.runtime ] &&
   reuse_runtime_ports=1
 fi
 
+netcat_probe_supported=0
+if command -v nc >/dev/null 2>&1; then
+  # `nc` is not one implementation: some installed variants reject `-z` or
+  # `-w`. Prove both flags once from its own help before trusting an exit status;
+  # an option-parse failure must use the fallback probes below.
+  nc_help="$(nc -h 2>&1 || true)"
+  if printf '%s\n' "$nc_help" | grep -Eq '(^|[[:space:]])-z([[:space:],]|$)' &&
+    printf '%s\n' "$nc_help" | grep -Eq '(^|[[:space:]])-w([[:space:],]|$)'; then
+    netcat_probe_supported=1
+  fi
+fi
+
 port_available() {
   # `lsof` can block for tens of seconds on macOS when an unrelated filesystem
   # mount is unhealthy. A loopback connect probe answers the question this
   # startup path needs without walking process file tables or mounted volumes.
-  if command -v nc >/dev/null 2>&1; then
+  if [ "$netcat_probe_supported" = "1" ]; then
     ! nc -z -w 1 127.0.0.1 "$1" >/dev/null 2>&1
     return
   fi
@@ -242,6 +254,30 @@ port_available() {
     return
   fi
   ! (echo >"/dev/tcp/127.0.0.1/$1") >/dev/null 2>&1
+}
+
+# Validate and briefly claim the exact configured address, rather than assuming
+# a loopback port probe represents a Tailscale address or another local bind.
+relay_bind_available() {
+  OPENGENI_LOCAL_RELAY_BIND="$1" bun -e '
+    import { createServer } from "node:net";
+    const value = Bun.env.OPENGENI_LOCAL_RELAY_BIND?.trim() ?? "";
+    const bracketed = value.match(/^\[([^\]]+)]:(\d+)$/);
+    const plain = value.match(/^([^:]+):(\d+)$/);
+    const match = bracketed ?? plain;
+    if (!match) throw new Error("OPENGENI_RELAY_BIND must be host:port (IPv6 must use brackets)");
+    const port = Number(match[2]);
+    if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+      throw new Error("OPENGENI_RELAY_BIND port must be between 1 and 65535");
+    }
+    const server = createServer();
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen({ host: match[1], port, exclusive: true }, resolve);
+    });
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    process.stdout.write(String(port));
+  '
 }
 
 # Ports already claimed by this run (avoids MinIO data/console sharing one bind).
@@ -349,7 +385,21 @@ if [ "${OPENGENI_SANDBOX_BACKEND:-docker}" = "modal" ]; then
   choose_port OPENGENI_SANDBOX_EDGE_PORT 10080
 fi
 if [ "${OPENGENI_SANDBOX_SELFHOSTED_ENABLED:-false}" = "true" ]; then
-  choose_port OPENGENI_RELAY_HOST_PORT 8280
+  if [ -n "${OPENGENI_RELAY_BIND:-}" ]; then
+    if ! explicit_relay_port="$(relay_bind_available "$OPENGENI_RELAY_BIND")"; then
+      echo "Configured OPENGENI_RELAY_BIND=${OPENGENI_RELAY_BIND} is invalid or unavailable." >&2
+      exit 1
+    fi
+    if port_claimed "$explicit_relay_port"; then
+      echo "Configured OPENGENI_RELAY_BIND=${OPENGENI_RELAY_BIND} conflicts with another local service." >&2
+      exit 1
+    fi
+    OPENGENI_RELAY_HOST_PORT="$explicit_relay_port"
+    export OPENGENI_RELAY_HOST_PORT
+    claim_port "$explicit_relay_port"
+  else
+    choose_port OPENGENI_RELAY_HOST_PORT 8280
+  fi
 fi
 
 pids=()

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -42,6 +42,20 @@ export OPENGENI_SANDBOX_DESKTOP_ENABLED
 export OPENGENI_SANDBOX_DESKTOP_INTERACTIVE
 export OPENGENI_COMPUTER_USE_ENABLED
 
+# Local development must exercise the same durable same-session ownership path
+# as managed deployments. The config-library defaults stay fail-closed, while
+# an explicit false remains authoritative for legacy-path regression tests.
+# Lazy provisioning keeps sandbox creation/resume off the first-model critical
+# path; the first actual sandbox operation establishes the box single-flight.
+if [ -z "${OPENGENI_SANDBOX_OWNERSHIP_ENABLED:-}" ]; then
+  OPENGENI_SANDBOX_OWNERSHIP_ENABLED=true
+fi
+if [ -z "${OPENGENI_SANDBOX_LAZY_PROVISION:-}" ]; then
+  OPENGENI_SANDBOX_LAZY_PROVISION=true
+fi
+export OPENGENI_SANDBOX_OWNERSHIP_ENABLED
+export OPENGENI_SANDBOX_LAZY_PROVISION
+
 # The Modal SDK natively supports MODAL_TOKEN_* and ~/.modal.toml, while the
 # deployment-facing OpenGeni config intentionally requires explicit credentials.
 # Bridge those standard local sources for this dev process only; never persist
@@ -179,14 +193,42 @@ reuse_runtime_ports=0
 if [ -f .env.runtime ] &&
   [ "$(sed -n 's/^COMPOSE_PROJECT_NAME=//p' .env.runtime | tail -1)" = "$COMPOSE_PROJECT_NAME" ] &&
   [ -n "$(docker compose ps -q 2>/dev/null)" ]; then
-  set -a
-  # shellcheck disable=SC1091
-  . ./.env.runtime
-  set +a
+  # Reuse only generated port assignments. Sourcing the whole runtime file
+  # resurrects stale derived URLs and silently overrides newer operator values
+  # from .env (notably remote-reachable Connected Machine endpoints).
+  for runtime_port_var in \
+    OPENGENI_POSTGRES_HOST_PORT \
+    OPENGENI_NATS_HOST_PORT \
+    OPENGENI_NATS_MONITOR_HOST_PORT \
+    OPENGENI_TEMPORAL_HOST_PORT \
+    OPENGENI_MINIO_HOST_PORT \
+    OPENGENI_MINIO_CONSOLE_HOST_PORT \
+    OPENGENI_API_PORT \
+    OPENGENI_WORKER_HTTP_PORT \
+    OPENGENI_TURN_WORKER_HTTP_PORT \
+    OPENGENI_ARTIFACT_MATERIALIZER_HTTP_PORT \
+    OPENGENI_ARTIFACT_OUTBOX_HTTP_PORT \
+    OPENGENI_WEB_PORT \
+    OPENGENI_RELAY_HOST_PORT; do
+    runtime_port_value="$(
+      sed -n "s/^${runtime_port_var}=//p" .env.runtime | tail -1
+    )"
+    if [ -n "$runtime_port_value" ]; then
+      printf -v "$runtime_port_var" '%s' "$runtime_port_value"
+      export "$runtime_port_var"
+    fi
+  done
   reuse_runtime_ports=1
 fi
 
 port_available() {
+  # `lsof` can block for tens of seconds on macOS when an unrelated filesystem
+  # mount is unhealthy. A loopback connect probe answers the question this
+  # startup path needs without walking process file tables or mounted volumes.
+  if command -v nc >/dev/null 2>&1; then
+    ! nc -z -w 1 127.0.0.1 "$1" >/dev/null 2>&1
+    return
+  fi
   if command -v lsof >/dev/null 2>&1; then
     ! lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1
     return
@@ -584,7 +626,19 @@ if [ "${OPENGENI_SANDBOX_SELFHOSTED_ENABLED:-false}" = "true" ] &&
       process.stdout.write(`${url.hostname}\t${port}\n`);
     '
   )
-  if [ "$relay_hostname" = "127.0.0.1" ] || [ "$relay_hostname" = "localhost" ]; then
+  if [ -n "${OPENGENI_RELAY_BIND:-}" ]; then
+    # An operator may advertise this development relay through a non-loopback
+    # interface (for example the host's Tailscale address) while binding the
+    # process to 0.0.0.0. Treat an explicit bind as ownership of the local relay
+    # instead of assuming every non-loopback URL belongs to an external service.
+    OPENGENI_RELAY_TOKEN_SECRET="${OPENGENI_SELFHOSTED_RELAY_TOKEN_SECRET:-${OPENGENI_STREAM_TOKEN_SECRET:-${OPENGENI_DELEGATION_SECRET:-}}}"
+    if [ -z "$OPENGENI_RELAY_TOKEN_SECRET" ]; then
+      echo "Connected-machine local relay requires OPENGENI_SELFHOSTED_RELAY_TOKEN_SECRET or OPENGENI_STREAM_TOKEN_SECRET." >&2
+      exit 1
+    fi
+    export OPENGENI_RELAY_BIND OPENGENI_RELAY_TOKEN_SECRET
+    start_local_relay=1
+  elif [ "$relay_hostname" = "127.0.0.1" ] || [ "$relay_hostname" = "localhost" ]; then
     OPENGENI_RELAY_BIND="127.0.0.1:${relay_port}"
     OPENGENI_RELAY_TOKEN_SECRET="${OPENGENI_SELFHOSTED_RELAY_TOKEN_SECRET:-${OPENGENI_STREAM_TOKEN_SECRET:-${OPENGENI_DELEGATION_SECRET:-}}}"
     if [ -z "$OPENGENI_RELAY_TOKEN_SECRET" ]; then
@@ -721,6 +775,8 @@ fi
   printf 'OPENGENI_DOCKER_NETWORK=%s\n' "${OPENGENI_DOCKER_NETWORK}"
   printf 'OPENGENI_DOCKER_IMAGE=%s\n' "${OPENGENI_DOCKER_IMAGE:-opengeni-sandbox:local}"
   printf 'OPENGENI_SANDBOX_ARTIFACT_RUNTIME_ENABLED=%s\n' "${OPENGENI_SANDBOX_ARTIFACT_RUNTIME_ENABLED:-false}"
+  printf 'OPENGENI_SANDBOX_OWNERSHIP_ENABLED=%s\n' "${OPENGENI_SANDBOX_OWNERSHIP_ENABLED}"
+  printf 'OPENGENI_SANDBOX_LAZY_PROVISION=%s\n' "${OPENGENI_SANDBOX_LAZY_PROVISION}"
   printf 'OPENGENI_POSTGRES_HOST_PORT=%s\n' "${OPENGENI_POSTGRES_HOST_PORT}"
   printf 'OPENGENI_NATS_HOST_PORT=%s\n' "${OPENGENI_NATS_HOST_PORT}"
   printf 'OPENGENI_NATS_MONITOR_HOST_PORT=%s\n' "${OPENGENI_NATS_MONITOR_HOST_PORT}"


### PR DESCRIPTION
## Why

A production turn showed roughly 85 seconds of blank startup before model output. The old timing surface collapsed queueing, credential selection, sandbox setup, file work, history projection, tool preparation, audit persistence, and provider dispatch into broad labels, making the delay impossible to localize reliably.

## What changed

- adds bounded phase metrics across worker preparation, SDK request preparation, event append versus publish, provider lifecycle, and sandbox establish-policy decisions
- names the worker-only aggregate honestly; lazy SDK request construction and durable request-start audit remain separate rather than being hidden inside a false pre-model total
- parallelizes independent history and envelope reads while preserving canonical ordering and durable fences
- reuses only content-addressed AJV validator functions in a bounded process-local cache; attempt executors, catalogs, authorization, and persistence remain fresh
- enables the exact lazy-sandbox key in local development so chat-only turns do not create Docker sandboxes
- keeps signed file resources, initial credentials, generated videos, and Connected Machines eager where pre-request correctness requires it
- preserves the frozen rig version during lazy resume and prevents compaction retries from duplicating the worker-preparation sample
- recognizes the exact modern Docker missing-container diagnostic and routes it through existing typed recovery
- makes manifest diagnostics fail open, reports soft file-materialization failures truthfully, validates explicit relay binds, and replaces blocking local lsof-first probes with capability-proven nc-first probes
- adds the missing patch Changeset for Codemode, Codex, Runtime, and the worker
- retains the measured suspect register, invariants, and unresolved experiments as a historical design record

## Measured result

- nine consecutive chat-only turns selected on-demand sandbox policy and created zero Docker sandboxes
- worker preparation before entering the runtime averaged 0.368 seconds; SDK request preparation and durable request-start audit were measured separately
- first exec created one Docker sandbox in 0.537 seconds; the next turn reused that exact container and preserved its file
- warm normal-tool preparation fell from 927 ms to 243–314 ms after bounded validator reuse

This proves the clean Docker, no-file, small-history baseline. It does not claim that large-history, multi-file, Connected Machine, or multi-account paths are solved.

## Verification

Exact candidate: `16b7a0b32`
Branch base: `478d7fe8`
Current protected main checked: `618ce79e6`

- exact head: hosted Full CI 42 passed, 2 intentional automation skips, 0 failed or pending
- local correction proof: 16 focused metric tests passed; worker typecheck, formatting, Changesets projection, and diff check passed
- current-main compatibility: automatic merge tree succeeds, diff check is clean, and the overlapping worker recovery change is preserved alongside this instrumentation

## Fresh-eyes review

The direct review rechecked runtime behavior, request instrumentation, lazy sandbox policy, validator-cache authority boundaries, local stack behavior, Docker recovery, package-release metadata, and the semantic merge against current main. It found and fixed two concrete omissions: the misleading aggregate metric and the absent Changeset. No speculative cache, timeout increase, authorization relaxation, or compatibility shim was added.

## Safety

Same-session ordering, durable-before-publish events, required-MCP fail-closed behavior, exact attempt catalogs, file integrity, eager correctness exceptions, and production lazy-provision defaults remain unchanged.
