### PR TITLE
Keep pinned Chromium builds reproducible

### DIFF
--- a/docker/desktop.Dockerfile
+++ b/docker/desktop.Dockerfile
@@ -120,6 +120,7 @@ ARG TTYD_VERSION=1.7.7
 ARG NODE_MAJOR=20
 ARG TARGETARCH
 ARG OPENGENI_CHROMIUM_VERSION=151.0.7922.108-1~deb13u1
+ARG OPENGENI_DEBIAN_SECURITY_SNAPSHOT=20260809T010020Z
 
 # noninteractive + a fixed TZ on EVERY apt layer (mandatory — see header).
 ENV DEBIAN_FRONTEND=noninteractive
@@ -130,6 +131,9 @@ ENV LC_ALL=C.UTF-8
 # ---- Layer 1: headless tool layer (parity with docker/sandbox.Dockerfile) ----
 RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC; \
+    printf '%s\n' \
+      "deb [check-valid-until=no signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] https://snapshot.debian.org/archive/debian-security/${OPENGENI_DEBIAN_SECURITY_SNAPSHOT} trixie-security main" \
+      > /etc/apt/sources.list.d/opengeni-chromium-snapshot.list; \
     base_packages=" \
         bash ca-certificates coreutils curl gpg git jq openssh-client \
         fuse3 procps rclone ripgrep unzip wget python3 python3-pip python3-venv \
@@ -238,7 +242,8 @@ RUN set -eux; \
         for attempt in 1 2 3; do \
             rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/partial/*; \
             apt-get update && apt-get install -y --no-install-recommends \
-                "chromium=${OPENGENI_CHROMIUM_VERSION}" && break; \
+                "chromium=${OPENGENI_CHROMIUM_VERSION}" \
+                "chromium-common=${OPENGENI_CHROMIUM_VERSION}" && break; \
             if [ "$attempt" = "3" ]; then exit 1; fi; sleep $((attempt * 5)); \
         done; \
         BROWSER_BIN="${OPENGENI_BROWSER_BIN_ARM64}"; \

--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -188,8 +188,12 @@ ARG TERRAFORM_VERSION=1.13.3
 ARG TTYD_VERSION=1.7.7
 ARG TARGETARCH
 ARG OPENGENI_CHROMIUM_VERSION=151.0.7922.108-1~deb13u1
+ARG OPENGENI_DEBIAN_SECURITY_SNAPSHOT=20260809T010020Z
 
 RUN set -eux; \
+    printf '%s\n' \
+      "deb [check-valid-until=no signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] https://snapshot.debian.org/archive/debian-security/${OPENGENI_DEBIAN_SECURITY_SNAPSHOT} trixie-security main" \
+      > /etc/apt/sources.list.d/opengeni-chromium-snapshot.list; \
     packages=" \
         bash \
         ca-certificates \
@@ -227,13 +231,17 @@ RUN set -eux; \
         rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/partial/*; \
         apt-get update \
         && apt-get install -y --download-only --no-install-recommends \
-            $packages "chromium=${OPENGENI_CHROMIUM_VERSION}" \
+            $packages \
+            "chromium=${OPENGENI_CHROMIUM_VERSION}" \
+            "chromium-common=${OPENGENI_CHROMIUM_VERSION}" \
         && break; \
         if [ "$attempt" = "3" ]; then exit 1; fi; \
         sleep $((attempt * 5)); \
     done; \
     apt-get install -y --no-install-recommends \
-        $packages "chromium=${OPENGENI_CHROMIUM_VERSION}"; \
+        $packages \
+        "chromium=${OPENGENI_CHROMIUM_VERSION}" \
+        "chromium-common=${OPENGENI_CHROMIUM_VERSION}"; \
     rm -rf /var/lib/apt/lists/*; \
     install -d -m 0755 /etc/opengeni; \
     printf '%s\n' /usr/lib/chromium/chromium > /etc/opengeni/browser-engine; \

--- a/scripts/browserd-image-build-contract.test.ts
+++ b/scripts/browserd-image-build-contract.test.ts
@@ -90,6 +90,24 @@ describe("browser controller image build contract", () => {
     expect(dockerfile).not.toContain("https://dl.google.com/linux/chrome/deb/ stable main");
   });
 
+  test("Debian Chromium remains available from one retained security snapshot", async () => {
+    const dockerfiles = await Promise.all(
+      imagePaths.map((imagePath) => readFile(resolve(root, imagePath), "utf8")),
+    );
+
+    for (const dockerfile of dockerfiles) {
+      expect(dockerfile).toContain("ARG OPENGENI_CHROMIUM_VERSION=151.0.7922.108-1~deb13u1");
+      expect(dockerfile).toContain("ARG OPENGENI_DEBIAN_SECURITY_SNAPSHOT=20260809T010020Z");
+      expect(dockerfile).toContain(
+        "https://snapshot.debian.org/archive/debian-security/${OPENGENI_DEBIAN_SECURITY_SNAPSHOT} trixie-security main",
+      );
+      expect(dockerfile).toContain('"chromium-common=${OPENGENI_CHROMIUM_VERSION}"');
+      expect(dockerfile.indexOf("opengeni-chromium-snapshot.list")).toBeLessThan(
+        dockerfile.indexOf('"chromium=${OPENGENI_CHROMIUM_VERSION}"'),
+      );
+    }
+  });
+
   test("startup distinguishes a live setsid/env child from a completed browserd exec", async () => {
     const source = await readFile(resolve(root, startupScriptPath), "utf8");
     const startupLoop = source.indexOf("for _ in $(seq 1 100); do");


### PR DESCRIPTION
## Summary
- retain the pinned Debian Chromium package through an official Debian security snapshot
- pin the matching `chromium-common` package so newer mirrors cannot create an unsatisfiable mixed-version install
- enforce the shared image-build contract in tests

## Verification
- exact Chromium packages downloaded successfully for linux/amd64 and linux/arm64
- `bun test scripts/browserd-image-build-contract.test.ts scripts/release-image-workflow-contract.test.ts scripts/sandbox-computer-native-build-contract.test.ts scripts/dev-stack-artifact-runtime.test.ts`
- `bun run format --check scripts/browserd-image-build-contract.test.ts`
- `bun run lint -- scripts/browserd-image-build-contract.test.ts`
- `git diff --check`