### PR TITLE
fix(worker): omit unavailable subscription image tools

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -2342,6 +2342,21 @@ export function hostedWebSearchForTurn(
   return resolvedModel?.configured.hostedWebSearch ?? deploymentWebSearchEnabled;
 }
 
+/**
+ * Image generation is an optional connected-account capability. A delegated
+ * subscription may still authorize the text model without carrying the local
+ * credential identity required for paid image operations; that must narrow the
+ * tool catalog, not reject an otherwise valid turn.
+ */
+export function connectedSubscriptionImageGenerationAuthority<T>(
+  credentialContext: T | null | undefined,
+  credentialId: string | null | undefined,
+): { credentialContext: T; credentialId: string } | null {
+  if (credentialContext == null || typeof credentialId !== "string" || credentialId.length === 0)
+    return null;
+  return { credentialContext, credentialId };
+}
+
 /** Direct OpenAI hosted image IDs are reusable only by the exact API credential. */
 export function openAiHostedImageProviderBindingForTurn(
   settings: Pick<Settings, "openaiProvider" | "openaiApiKey" | "openaiBaseUrl">,
@@ -7063,13 +7078,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         }
 
         if (resolvedModel?.provider.kind === "codex-subscription") {
-          const codexImageContext = codexContext;
-          const codexImageCredentialId = effectiveCodexCredentialId;
-          if (!codexImageContext || !codexImageCredentialId) {
-            throw new CodexReloginRequired(
-              "Codex image generation requires a connected subscription account",
-            );
-          }
+          const imageAuthority = connectedSubscriptionImageGenerationAuthority(
+            codexContext,
+            effectiveCodexCredentialId,
+          );
+          if (!imageAuthority) return {};
           return {
             imageGeneration: {
               kind: "provider_adapter",
@@ -7086,8 +7099,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   toolCallId,
                   prompt,
                   references: resolvedReferences,
-                  credentialId: codexImageCredentialId,
-                  codexContext: codexImageContext,
+                  credentialId: imageAuthority.credentialId,
+                  codexContext: imageAuthority.credentialContext,
                   ...(runtimeCancellationSignal ? { abortSignal: runtimeCancellationSignal } : {}),
                 });
                 generatedImageReceiptsByArtifactId.set(receipt.artifact.artifactId, receipt);
@@ -7099,11 +7112,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         }
 
         if (resolvedModel?.provider.kind === "xai-subscription") {
-          const xaiImageContext = xaiRequestContext;
-          const xaiImageCredentialId = effectiveXaiCredentialId;
-          if (!xaiImageContext || !xaiImageCredentialId) {
-            throw new Error("SuperGrok image generation requires a connected subscription account");
-          }
+          const imageAuthority = connectedSubscriptionImageGenerationAuthority(
+            xaiRequestContext,
+            effectiveXaiCredentialId,
+          );
+          if (!imageAuthority) return {};
           return {
             imageGeneration: {
               kind: "provider_adapter",
@@ -7120,8 +7133,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   toolCallId,
                   prompt,
                   references: resolvedReferences,
-                  credentialId: xaiImageCredentialId,
-                  xaiContext: xaiImageContext,
+                  credentialId: imageAuthority.credentialId,
+                  xaiContext: imageAuthority.credentialContext,
                   ...(runtimeCancellationSignal ? { abortSignal: runtimeCancellationSignal } : {}),
                 });
                 generatedImageReceiptsByArtifactId.set(receipt.artifact.artifactId, receipt);

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -63,6 +63,7 @@ import {
   escapedMcpTimeoutRecoveryFailure,
   filterUnmaterializedSandboxFileDownloads,
   finalizeDurableTurnOpStreams,
+  connectedSubscriptionImageGenerationAuthority,
   historyRowsToAppend,
   hostedWebSearchForTurn,
   isLazySandboxProvisionRetryable,
@@ -4264,6 +4265,21 @@ describe("hostedWebSearchForTurn (provider support)", () => {
   test("applies the deployment capability gate to the legacy built-in path", () => {
     expect(hostedWebSearchForTurn(null, true)).toBe(true);
     expect(hostedWebSearchForTurn(null, false)).toBe(false);
+  });
+});
+
+describe("connectedSubscriptionImageGenerationAuthority", () => {
+  test("omits the optional tool when delegated model authority has no connected credential", () => {
+    expect(connectedSubscriptionImageGenerationAuthority({}, null)).toBeNull();
+    expect(connectedSubscriptionImageGenerationAuthority(null, "credential-id")).toBeNull();
+  });
+
+  test("exposes the optional tool only with both execution context and credential identity", () => {
+    const context = { getToken: true };
+    expect(connectedSubscriptionImageGenerationAuthority(context, "credential-id")).toEqual({
+      credentialContext: context,
+      credentialId: "credential-id",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- treat subscription-backed image generation as an optional capability
- omit the image tool when a text-model delegation has no local connected credential identity
- preserve full text turns for both Codex and xAI subscriptions

## Verification
- worker TypeScript check
- 173 focused worker tests
- lint, format, diff, and public-hygiene checks