### PR TITLE
fix(release): export BOM environment in subshell

### DIFF
--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -609,12 +609,15 @@ jobs:
         run: |
           set -euo pipefail
           images="$(jq -c '[.images | to_entries[] | .value]' evidence/release-candidate.json)"
-          OPENGENI_RELEASE_BOM_SOURCE_SHA="$SOURCE_SHA" \
-          OPENGENI_RELEASE_BOM_VERSION="$RELEASE_VERSION" \
-          OPENGENI_RELEASE_BOM_PACKAGES="$BOM_PACKAGES" \
-          OPENGENI_RELEASE_BOM_IMAGES="$images" \
-          OPENGENI_RELEASE_BOM_CHART="$RELEASE_CHART" \
-          (cd .release/controller && bun scripts/release-bom.ts)
+          (
+            export OPENGENI_RELEASE_BOM_SOURCE_SHA="$SOURCE_SHA"
+            export OPENGENI_RELEASE_BOM_VERSION="$RELEASE_VERSION"
+            export OPENGENI_RELEASE_BOM_PACKAGES="$BOM_PACKAGES"
+            export OPENGENI_RELEASE_BOM_IMAGES="$images"
+            export OPENGENI_RELEASE_BOM_CHART="$RELEASE_CHART"
+            cd .release/controller
+            bun scripts/release-bom.ts
+          )
           printf '%s  %s\n' \
             "$(sha256sum evidence/release-bom.json | awk '{print $1}')" \
             evidence/release-bom.json \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -737,12 +737,15 @@ jobs:
         run: |
           set -euo pipefail
           images="$(jq -c '[.images | to_entries[] | .value]' evidence/release-candidate.json)"
-          OPENGENI_RELEASE_BOM_SOURCE_SHA="$SOURCE_SHA" \
-          OPENGENI_RELEASE_BOM_VERSION="$RELEASE_VERSION" \
-          OPENGENI_RELEASE_BOM_PACKAGES="$BOM_PACKAGES" \
-          OPENGENI_RELEASE_BOM_IMAGES="$images" \
-          OPENGENI_RELEASE_BOM_CHART="$RELEASE_CHART" \
-          (cd .release/controller && bun scripts/release-bom.ts)
+          (
+            export OPENGENI_RELEASE_BOM_SOURCE_SHA="$SOURCE_SHA"
+            export OPENGENI_RELEASE_BOM_VERSION="$RELEASE_VERSION"
+            export OPENGENI_RELEASE_BOM_PACKAGES="$BOM_PACKAGES"
+            export OPENGENI_RELEASE_BOM_IMAGES="$images"
+            export OPENGENI_RELEASE_BOM_CHART="$RELEASE_CHART"
+            cd .release/controller
+            bun scripts/release-bom.ts
+          )
           printf '%s  %s\n' "$(sha256sum evidence/release-bom.json | awk '{print $1}')" evidence/release-bom.json > evidence/release-bom.sha256
 
       - name: Compare existing immutable BOM before aliases

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -598,6 +598,8 @@ describe("release image workflow contract", () => {
     expect(finalJob).toContain("--prefer-index=false");
     expect(finalJob).toContain("evidence/release-candidate.json");
     expect(finalJob).toContain("bun scripts/release-bom.ts");
+    expect(finalJob).toContain('export OPENGENI_RELEASE_BOM_SOURCE_SHA="$SOURCE_SHA"');
+    expect(finalJob).not.toMatch(/OPENGENI_RELEASE_BOM_CHART=.*\\\n\s*\(cd /);
     expect(finalJob).toContain("release_version=\"$(jq -er '.releaseVersion'");
     expect(finalJob).toContain(
       'source_release_version="$(cd .release/controller && bun scripts/release-version.ts "$GITHUB_WORKSPACE/deploy/helm/opengeni/Chart.yaml")"',
@@ -779,6 +781,8 @@ describe("release image workflow contract", () => {
     expect(release).toContain("bun scripts/resolve-github-release-state.ts");
     expect(release).not.toContain('gh release view "$tag"');
     expect(release).toContain("bun scripts/release-bom.ts");
+    expect(release).toContain('export OPENGENI_RELEASE_BOM_SOURCE_SHA="$SOURCE_SHA"');
+    expect(release).not.toMatch(/OPENGENI_RELEASE_BOM_CHART=.*\\\n\s*\(cd /);
     expect(release).toContain("evidence/release-bom.json");
     expect(release).toContain('docker logout "$REGISTRY"');
     expect(registryReconcile).toBeGreaterThan(-1);


### PR DESCRIPTION
Bash does not allow temporary assignment prefixes directly before a parenthesized compound command. Export the exact BOM inputs inside the isolated subshell in both release paths, and guard the workflow contract against reintroducing the invalid form.