### PR TITLE
chore(release): bump product version to 0.23.5

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.4
-appVersion: "0.23.4"
+version: 0.23.5
+appVersion: "0.23.5"


### PR DESCRIPTION
Bump the source-controlled Helm chart and application version together for the next immutable product release.\n\nLocal verification:\n- `bun test scripts/release-version.test.ts scripts/package-release-chart.test.ts scripts/helm-upgrade-contract.test.ts deploy/helm/opengeni/test/prometheusrule.test.ts`\n- `helm lint deploy/helm/opengeni`