### PR TITLE
fix(react): deduplicate realtime catalog loads

### DIFF
--- a/.changeset/calm-radios-listen.md
+++ b/.changeset/calm-radios-listen.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Deduplicate realtime model catalog loads and reuse settled catalogs across embedded control remounts.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -353,7 +353,9 @@ exported `EmbeddedRealtimeSessionClientLike` requires only catalog, begin,
 Codex/Gateway negotiation, activation, heartbeat, ledger sync, and end. For
 custom layouts, use `useSessionRealtime`, `useRealtimeModelSelection`,
 `RealtimeVoiceControl`, and `RealtimeModelPickerMenu`; the batteries-included
-wrappers remain the recommended path.
+wrappers remain the recommended path. Concurrent catalog reads are deduplicated
+per client and workspace, and successful results are reused for a short bounded
+window so embedded controls can remount without refetching.
 
 The reference consumer is `demo/realtime.html`. Run `bun run demo` from
 `packages/react`, then open `http://localhost:3100/realtime.html?mode=mock` for

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -98,8 +98,107 @@ const REALTIME_PROVIDER_META: Record<
   "Your Gateway": { billingClass: "byok", hint: "Billed to your AI Gateway" },
 };
 const REALTIME_MODEL_STORAGE_PREFIX = "opengeni:realtime-model";
+const REALTIME_MODEL_CATALOG_CACHE_TTL_MS = 60_000;
+const REALTIME_MODEL_CATALOG_CACHE_MAX_WORKSPACES = 64;
 
 type RealtimeControllerClient = EmbeddedRealtimeSessionClientLike & SessionRealtimeClientLike;
+
+type RealtimeModelCatalogCacheEntry =
+  | { state: "loading"; promise: Promise<RealtimeModelOption[]> }
+  | { state: "ready"; models: RealtimeModelOption[]; expiresAt: number };
+
+// Scope advisory availability to the exact client object and workspace. The
+// server still authorizes every realtime operation; changing principals should
+// replace the client just as it does for the rest of the SDK state.
+const realtimeModelCatalogCache = new WeakMap<
+  RealtimeControllerClient,
+  Map<string, RealtimeModelCatalogCacheEntry>
+>();
+
+function realtimeModelFallback(codexConnected: boolean): RealtimeModelOption[] {
+  return [
+    {
+      ...CODEX_LIVE_MODEL,
+      available: codexConnected,
+      unavailableReason: codexConnected ? null : CODEX_LIVE_MODEL.unavailableReason,
+    },
+  ];
+}
+
+function realtimeModelCatalogCacheFor(
+  client: RealtimeControllerClient,
+): Map<string, RealtimeModelCatalogCacheEntry> {
+  const existing = realtimeModelCatalogCache.get(client);
+  if (existing) return existing;
+  const created = new Map<string, RealtimeModelCatalogCacheEntry>();
+  realtimeModelCatalogCache.set(client, created);
+  return created;
+}
+
+function readCachedRealtimeModelCatalog(
+  client: RealtimeControllerClient,
+  workspaceId: string,
+  now = Date.now(),
+): RealtimeModelOption[] | null {
+  const cache = realtimeModelCatalogCache.get(client);
+  const entry = cache?.get(workspaceId);
+  if (!entry || entry.state === "loading") return null;
+  if (entry.expiresAt > now) return entry.models;
+  cache?.delete(workspaceId);
+  return null;
+}
+
+function pruneRealtimeModelCatalogCache(
+  cache: Map<string, RealtimeModelCatalogCacheEntry>,
+  now: number,
+): void {
+  for (const [workspaceId, entry] of cache) {
+    if (entry.state === "ready" && entry.expiresAt <= now) cache.delete(workspaceId);
+  }
+  while (cache.size >= REALTIME_MODEL_CATALOG_CACHE_MAX_WORKSPACES) {
+    const oldestWorkspaceId = cache.keys().next().value;
+    if (oldestWorkspaceId === undefined) return;
+    cache.delete(oldestWorkspaceId);
+  }
+}
+
+function loadRealtimeModelCatalog(
+  client: RealtimeControllerClient,
+  workspaceId: string,
+): Promise<RealtimeModelOption[]> | null {
+  const load = client.getWorkspaceRealtimeModelCatalog;
+  if (!load) return null;
+  const now = Date.now();
+  const cache = realtimeModelCatalogCacheFor(client);
+  const entry = cache.get(workspaceId);
+  if (entry?.state === "loading") return entry.promise;
+  if (entry?.state === "ready" && entry.expiresAt > now) return Promise.resolve(entry.models);
+  if (entry) cache.delete(workspaceId);
+  pruneRealtimeModelCatalogCache(cache, now);
+
+  const promise = load
+    .call(client, workspaceId)
+    .then((response) => response.models.map(toRealtimeModelOption))
+    .then((models) => {
+      const current = cache.get(workspaceId);
+      if (current?.state === "loading" && current.promise === promise) {
+        cache.delete(workspaceId);
+        cache.set(workspaceId, {
+          state: "ready",
+          models,
+          expiresAt: Date.now() + REALTIME_MODEL_CATALOG_CACHE_TTL_MS,
+        });
+      }
+      return models;
+    })
+    .catch((error: unknown) => {
+      const current = cache.get(workspaceId);
+      if (current?.state === "loading" && current.promise === promise) cache.delete(workspaceId);
+      throw error;
+    });
+  cache.set(workspaceId, { state: "loading", promise });
+  return promise;
+}
 
 export type SessionRealtimeControllerFactory = (
   options: CreateSessionRealtimeControllerOptions,
@@ -411,31 +510,52 @@ export function useRealtimeModelSelection(options: {
     workspaceId: options.workspaceId,
   });
   const activeModel = options.activeModel;
-  const [catalog, setCatalog] = useState<RealtimeModelOption[]>(() => [
-    {
-      ...CODEX_LIVE_MODEL,
-      available: options.codexConnected,
-      unavailableReason: options.codexConnected ? null : CODEX_LIVE_MODEL.unavailableReason,
-    },
-  ]);
-  const [selectedModelId, setSelectedModelId] = useState<SessionRealtimeModel>(
-    () => readRealtimeModelPreference(workspaceId) ?? CODEX_LIVE_MODEL.id,
+  const initialCachedCatalog = readCachedRealtimeModelCatalog(client, workspaceId);
+  const [catalog, setCatalog] = useState<RealtimeModelOption[]>(
+    () => initialCachedCatalog ?? realtimeModelFallback(options.codexConnected),
   );
+  const catalogScopeRef = useRef({
+    client,
+    workspaceId,
+    source: initialCachedCatalog ? ("cache" as const) : ("fallback" as const),
+  });
+  const [selectedModelId, setSelectedModelId] = useState<SessionRealtimeModel>(() => {
+    const preferred = readRealtimeModelPreference(workspaceId) ?? CODEX_LIVE_MODEL.id;
+    if (!initialCachedCatalog) return preferred;
+    if (initialCachedCatalog.some((model) => model.id === preferred && model.available)) {
+      return preferred;
+    }
+    return initialCachedCatalog.find((model) => model.available)?.id ?? CODEX_LIVE_MODEL.id;
+  });
 
   useEffect(() => {
     let disposed = false;
-    const load = client.getWorkspaceRealtimeModelCatalog;
-    if (!load) return;
-    void load
-      .call(client, workspaceId)
-      .then((response) => {
+    const applyCatalog = (models: RealtimeModelOption[]) => {
+      catalogScopeRef.current = { client, workspaceId, source: "cache" };
+      setCatalog(models);
+      setSelectedModelId((current) => {
+        if (models.some((model) => model.id === current && model.available)) return current;
+        return models.find((model) => model.available)?.id ?? CODEX_LIVE_MODEL.id;
+      });
+    };
+    const cached = readCachedRealtimeModelCatalog(client, workspaceId);
+    if (cached) {
+      const scope = catalogScopeRef.current;
+      if (
+        scope.client !== client ||
+        scope.workspaceId !== workspaceId ||
+        scope.source !== "cache"
+      ) {
+        applyCatalog(cached);
+      }
+      return;
+    }
+    const loading = loadRealtimeModelCatalog(client, workspaceId);
+    if (!loading) return;
+    void loading
+      .then((models) => {
         if (disposed) return;
-        const models = response.models.map(toRealtimeModelOption);
-        setCatalog(models);
-        setSelectedModelId((current) => {
-          if (models.some((model) => model.id === current && model.available)) return current;
-          return models.find((model) => model.available)?.id ?? CODEX_LIVE_MODEL.id;
-        });
+        applyCatalog(models);
       })
       .catch(() => undefined);
     return () => {

--- a/packages/react/test/realtime-control.test.tsx
+++ b/packages/react/test/realtime-control.test.tsx
@@ -498,6 +498,146 @@ describe("ordinary session Codex realtime control", () => {
     ).toBe("supergrok/grok-voice-think-fast-2.0");
   });
 
+  test("deduplicates catalog loads and reuses the settled catalog across remounts", async () => {
+    const workspaceId = "66666666-6666-4666-8666-666666666666";
+    let requests = 0;
+    const now = spyOn(Date, "now").mockReturnValue(1_000_000);
+    const client = {
+      getWorkspaceRealtimeModelCatalog: async () => {
+        requests += 1;
+        return {
+          models: [
+            {
+              id: "supergrok/grok-voice-think-fast-2.0" as const,
+              label: "Grok Voice",
+              provider: "Connected SuperGrok" as const,
+              description: "Fast native Grok speech-to-speech",
+              available: true,
+              unavailableReason: null,
+              recommended: true,
+            },
+          ],
+        };
+      },
+    } as unknown as OpenGeniClient;
+
+    function Selection() {
+      const selection = useRealtimeModelSelection({ client, workspaceId, codexConnected: false });
+      return <output>{selection.selectedModel.label}</output>;
+    }
+
+    try {
+      for (let episode = 0; episode < 25; episode += 1) {
+        await act(async () => root.render(<Selection key={episode} />));
+        await act(async () => await new Promise((resolve) => setTimeout(resolve, 0)));
+        expect(container.querySelector("output")?.textContent).toBe("Grok Voice");
+      }
+      expect(requests).toBe(1);
+
+      now.mockReturnValue(1_060_001);
+      await act(async () => root.render(<Selection key="expired" />));
+      await act(async () => await new Promise((resolve) => setTimeout(resolve, 0)));
+      expect(requests).toBe(2);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  test("shares an in-flight catalog load between concurrent controls", async () => {
+    const workspaceId = "77777777-7777-4777-8777-777777777777";
+    let requests = 0;
+    let resolveCatalog!: (value: {
+      models: Array<{
+        id: "gpt-live-1-boulder-alpha";
+        label: string;
+        provider: "Connected Codex";
+        description: string;
+        available: boolean;
+        unavailableReason: null;
+        recommended: boolean;
+      }>;
+    }) => void;
+    const response = new Promise<Parameters<typeof resolveCatalog>[0]>((resolve) => {
+      resolveCatalog = resolve;
+    });
+    const client = {
+      getWorkspaceRealtimeModelCatalog: async () => {
+        requests += 1;
+        return await response;
+      },
+    } as unknown as OpenGeniClient;
+
+    function Selection() {
+      const selection = useRealtimeModelSelection({ client, workspaceId, codexConnected: true });
+      return <output>{selection.selectedModel.label}</output>;
+    }
+
+    await act(async () =>
+      root.render(
+        <>
+          <Selection />
+          <Selection />
+        </>,
+      ),
+    );
+    expect(requests).toBe(1);
+    await act(async () => {
+      resolveCatalog({
+        models: [
+          {
+            id: "gpt-live-1-boulder-alpha",
+            label: "Codex Live",
+            provider: "Connected Codex",
+            description: "Deep session integration",
+            available: true,
+            unavailableReason: null,
+            recommended: false,
+          },
+        ],
+      });
+      await response;
+    });
+    expect(container.querySelectorAll("output")).toHaveLength(2);
+    expect(requests).toBe(1);
+  });
+
+  test("does not cache a failed catalog load", async () => {
+    const workspaceId = "88888888-8888-4888-8888-888888888888";
+    let requests = 0;
+    const client = {
+      getWorkspaceRealtimeModelCatalog: async () => {
+        requests += 1;
+        if (requests === 1) throw new Error("catalog temporarily unavailable");
+        return {
+          models: [
+            {
+              id: "gpt-live-1-boulder-alpha" as const,
+              label: "Codex Live",
+              provider: "Connected Codex" as const,
+              description: "Deep session integration",
+              available: true,
+              unavailableReason: null,
+              recommended: false,
+            },
+          ],
+        };
+      },
+    } as unknown as OpenGeniClient;
+
+    function Selection() {
+      const selection = useRealtimeModelSelection({ client, workspaceId, codexConnected: true });
+      return <output>{selection.selectedModel.label}</output>;
+    }
+
+    await act(async () => root.render(<Selection key="failed" />));
+    await act(async () => await new Promise((resolve) => setTimeout(resolve, 0)));
+    expect(requests).toBe(1);
+    await act(async () => root.render(<Selection key="retry" />));
+    await act(async () => await new Promise((resolve) => setTimeout(resolve, 0)));
+    expect(requests).toBe(2);
+    expect(container.querySelector("output")?.textContent).toBe("Codex Live");
+  });
+
   test("configures the voice model picker below the new-session composer", async () => {
     await act(async () => {
       root.render(


### PR DESCRIPTION
## Summary
- coalesce concurrent realtime catalog reads by client and workspace
- reuse successful catalogs briefly across control remounts
- bound cache lifetime and size while keeping failures retryable

## Verification
- `bun test packages/react/test/realtime-control.test.tsx`
- `bun run --cwd packages/react typecheck`
- `bun run --cwd packages/react build`
- `bun test apps/web/src/components/capabilities/integration-connect-dialog.test.tsx`