### PR TITLE
docs(release): require review before merge

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -815,6 +815,14 @@ the candidate. The merge authority separately performs the fresh latest-main
 conflict, canonical patch-equivalence, protected-path, generated/migration,
 identity/manifest, security, and evidence checks immediately before merge.
 
+Do not enable or leave auto-merge armed on a generated Version PR before the
+exact-head release review is submitted. Release admission compares GitHub's
+provider-recorded review and merge timestamps and requires the decisive review
+to precede the merge. A review added after auto-merge is intentionally not
+release evidence and cannot rehabilitate that source commit; stop that train
+and use a fresh, normally reviewed release-source PR instead of retrying or
+weakening admission.
+
 The exact source must separately have one successful GitHub Actions result for
 each required candidate check:
 `Typecheck and unit tests`, `Deployment artifacts`, and `Workload image


### PR DESCRIPTION
## Summary

- require the decisive exact-head release review to be provider-recorded before merge
- explicitly keep auto-merge disabled until that review exists
- document fail-closed recovery when auto-merge wins the timestamp race

## Verification

- `bunx oxfmt --check docs/deployment.md`
- `bun run check:docs-refs`
- `git diff --check`

This is a documentation-only release-source correction and intentionally has no changeset.