### PR TITLE
Harden API contract and release provenance guidance

### DIFF
--- a/.changeset/clean-contract-fixtures.md
+++ b/.changeset/clean-contract-fixtures.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/sdk": patch
+"@opengeni/react": patch
+---
+
+Keep embedded client configurations synchronized with the exported API contract revision and document the fail-closed host integration boundary.

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Permission } from "@opengeni/contracts";
+import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 
 import {
   capabilityErrorToast,
@@ -1314,7 +1315,7 @@ describe("composer reasoning-effort picker (full host enum)", () => {
   function clientConfig(patch: Partial<ClientConfig> = {}): ClientConfig {
     return {
       deploymentRevision: "rev-1",
-      apiContractRevision: "2026-08-model-context-v1",
+      apiContractRevision: OPENGENI_API_CONTRACT_REVISION,
       defaultModel: "gpt-5.6-sol",
       allowedModels: ["gpt-5.6-sol"],
       models: [],

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 import {
   authHeadersForAccessKey,
   configureClientAuth,
@@ -147,7 +148,7 @@ describe("web API auth helpers", () => {
     );
     expect(request!.init?.credentials).toBe("include");
     expect(new Headers(request!.init?.headers).get("x-opengeni-api-contract")).toBe(
-      "2026-08-model-context-v1",
+      OPENGENI_API_CONTRACT_REVISION,
     );
     expect(new Headers(request!.init?.headers).get("authorization")).toBeNull();
     expect(new Headers(request!.init?.headers).get("x-opengeni-access-key")).toBeNull();
@@ -205,7 +206,7 @@ describe("createOpenGeniClient", () => {
     expect(request!.init?.credentials).toBe("include");
     expect(new Headers(request!.init?.headers).get("x-opengeni-access-key")).toBe("secret-key");
     expect(new Headers(request!.init?.headers).get("x-opengeni-api-contract")).toBe(
-      "2026-08-model-context-v1",
+      OPENGENI_API_CONTRACT_REVISION,
     );
   });
 

--- a/docs/workbench-acceptance.md
+++ b/docs/workbench-acceptance.md
@@ -370,8 +370,12 @@ before branch cleanup and is only a durable check-lookup anchor, never a
 replacement for review or acceptance.
 
 1. Merge reviewed source to `main`.
-2. Merge the generated Version PR so the release source has exact package
-   versions and no pending changesets.
+2. Wait for trusted Version-PR CI to finish against one unchanged head, then
+   submit a native approving review bound to that exact head **before** merging
+   the generated Version PR. Verify the review's commit SHA and submission time;
+   approval added after merge cannot establish release provenance. Merge only
+   after that evidence exists so the release source has exact package versions
+   and no pending changesets.
 3. Dispatch `release-candidate.yml` from the immutable retained tag for the
    Version PR's trusted base. Supply that exact base SHA as `controller_sha` and
    the exact current `main` SHA as `source_sha`. Build

--- a/packages/react/demo/mock.ts
+++ b/packages/react/demo/mock.ts
@@ -169,6 +169,7 @@ import type {
   WorkspaceRegisteredPack,
   WorkspaceRealtimeModelCatalogResponse,
 } from "@opengeni/sdk";
+import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 import type { SessionClientLike } from "@opengeni/react";
 import type { MachinesResponse } from "@opengeni/react/machines";
 
@@ -3970,7 +3971,7 @@ const ACCOUNT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
  */
 const CLIENT_CONFIG: ClientConfig = {
   deploymentRevision: "demo",
-  apiContractRevision: "2026-08-model-context-v1",
+  apiContractRevision: OPENGENI_API_CONTRACT_REVISION,
   defaultModel: "gpt-5.6-sol",
   allowedModels: ["gpt-5.6-sol", "accounts/fireworks/models/glm-5p2"],
   models: [

--- a/packages/react/test/fake-client.ts
+++ b/packages/react/test/fake-client.ts
@@ -1,3 +1,4 @@
+import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 import type { ComposerDraft, SessionGoal, SessionTurn } from "@opengeni/sdk";
 import type { SessionClientLike } from "../src/client";
 
@@ -23,7 +24,7 @@ export function fakeClient(partial: Partial<SessionClientLike>): SessionClientLi
     getClientConfig: async () =>
       ({
         deploymentRevision: "test",
-        apiContractRevision: "2026-08-model-context-v1",
+        apiContractRevision: OPENGENI_API_CONTRACT_REVISION,
         defaultModel: "model-x",
         allowedModels: ["model-x"],
         models: [],

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -614,3 +614,9 @@ packages. `test/contract-parity.test.ts` pins them to `@opengeni/contracts`,
 so contract drift fails the repo gate instead of shipping. `SessionEvent.type`
 is an open union: unknown event types from newer servers flow through instead
 of breaking older SDK consumers.
+
+Hosts, test doubles, and same-origin proxies must import
+`OPENGENI_API_CONTRACT_REVISION` from `@opengeni/sdk` when constructing a client
+configuration or contract header. Do not copy its string value: the revision is
+an executable compatibility boundary, and `getClientConfig()` intentionally
+fails closed when server and SDK revisions differ.

--- a/packages/sdk/test/client-coverage.test.ts
+++ b/packages/sdk/test/client-coverage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { OpenGeniClient } from "../src/client";
 import { OpenGeniApiError } from "../src/errors";
 import {
+  OPENGENI_API_CONTRACT_REVISION,
   OPENGENI_CORRELATION_HEADER,
   RETAINED_OUTPUT_MAX_PAGE_BYTES,
   type ConnectionMetadata,
@@ -337,7 +338,7 @@ describe("OpenGeniClient access + workspaces", () => {
   test("getClientConfig fetches the public bootstrap endpoint and returns the provider-grouped models", async () => {
     const config = {
       deploymentRevision: "rev-1",
-      apiContractRevision: "2026-08-model-context-v1",
+      apiContractRevision: OPENGENI_API_CONTRACT_REVISION,
       defaultModel: "gpt-5.6-sol",
       allowedModels: ["gpt-5.6-sol", "accounts/fireworks/models/glm-5p2"],
       models: [

--- a/test/e2e/capabilities.browser.e2e.ts
+++ b/test/e2e/capabilities.browser.e2e.ts
@@ -5,6 +5,7 @@ import { mkdir, readdir, readFile } from "node:fs/promises";
 import { chromium, type Browser, type Page } from "playwright";
 
 import { freePort, runCommand, startProcess, type StartedProcess } from "@opengeni/testing";
+import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
 const workspaceId = "00000000-0000-4000-8000-000000000017";
@@ -17,7 +18,7 @@ const driveConnectionId = "00000000-0000-4000-8000-000000000130";
 const driveInstanceId = "00000000-0000-4000-8000-000000000131";
 const evidenceDir = new URL("../../.agent/evidence/capabilities-focus/", import.meta.url).pathname;
 const mobbinEvidenceDir = new URL("../../.agent/evidence/mobbin-mcp/", import.meta.url).pathname;
-const apiContractRevision = "2026-08-model-context-v1";
+const apiContractRevision = OPENGENI_API_CONTRACT_REVISION;
 
 type CapabilityState = {
   enabled: boolean;

--- a/test/e2e/custom-api-control-center.browser.e2e.ts
+++ b/test/e2e/custom-api-control-center.browser.e2e.ts
@@ -5,6 +5,7 @@ import { mkdir } from "node:fs/promises";
 import { chromium, type Browser, type Page } from "playwright";
 
 import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
 const evidenceDir = new URL("../../.agent/evidence/capabilities-custom-api/", import.meta.url)
@@ -15,7 +16,7 @@ const subjectId = "user:capabilities-browser";
 const financeConnectionId = "00000000-0000-4000-8000-000000000619";
 const salesConnectionId = "00000000-0000-4000-8000-000000000620";
 const gmailConnectionId = "00000000-0000-4000-8000-000000000621";
-const apiContractRevision = "2026-08-model-context-v1";
+const apiContractRevision = OPENGENI_API_CONTRACT_REVISION;
 let webBaseUrl = "";
 
 type UiState = {

--- a/test/e2e/slack-access-link.browser.e2e.ts
+++ b/test/e2e/slack-access-link.browser.e2e.ts
@@ -3,13 +3,14 @@ import { existsSync } from "node:fs";
 import { chromium, type Browser, type Page } from "playwright";
 
 import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
 const workspaceId = "00000000-0000-4000-8000-000000000241";
 const requestId = "00000000-0000-4000-8000-000000000242";
 const defaultWorkspaceId = "00000000-0000-4000-8000-000000000243";
 const defaultAccountId = "00000000-0000-4000-8000-000000000244";
-const apiContractRevision = "2026-08-model-context-v1";
+const apiContractRevision = OPENGENI_API_CONTRACT_REVISION;
 const signedLink = "signed.slack.browser.bearer";
 
 type AccessUiState = {

--- a/test/e2e/slack-installation-binding.browser.e2e.ts
+++ b/test/e2e/slack-installation-binding.browser.e2e.ts
@@ -8,6 +8,7 @@ import {
   OPENGENI_SLACK_BOT_REQUIRED_SCOPES,
   type ConnectionStatus,
 } from "@opengeni/contracts";
+import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
@@ -15,7 +16,7 @@ const workspaceId = "00000000-0000-4000-8000-000000000231";
 const accountId = "00000000-0000-4000-8000-000000000232";
 const connectionId = "00000000-0000-4000-8000-000000000233";
 const bindingId = "00000000-0000-4000-8000-000000000234";
-const apiContractRevision = "2026-08-model-context-v1";
+const apiContractRevision = OPENGENI_API_CONTRACT_REVISION;
 
 type FixtureState = {
   bindingState: "active" | "quarantined" | null;

--- a/test/e2e/slack-oauth.browser.e2e.ts
+++ b/test/e2e/slack-oauth.browser.e2e.ts
@@ -8,6 +8,7 @@ import {
   OPENGENI_SLACK_BOT_REQUIRED_SCOPES,
   type ConnectionMetadata,
 } from "@opengeni/contracts";
+import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
@@ -16,7 +17,7 @@ const accountId = "00000000-0000-4000-8000-000000000218";
 const botConnectionId = "00000000-0000-4000-8000-000000000219";
 const personalConnectionId = "00000000-0000-4000-8000-000000000220";
 const personalSlackCapabilityId = "mcp:slack-personal-browser-fixture";
-const apiContractRevision = "2026-08-model-context-v1";
+const apiContractRevision = OPENGENI_API_CONTRACT_REVISION;
 const slackAuthorizationUrl =
   "https://slack.com/oauth/v2/authorize?client_id=browser-fixture&scope=chat%3Awrite&state=server-signed-browser-fixture";
 

--- a/test/e2e/source-packages-control-center.browser.e2e.ts
+++ b/test/e2e/source-packages-control-center.browser.e2e.ts
@@ -5,6 +5,7 @@ import { mkdir } from "node:fs/promises";
 import { chromium, type Browser, type Page } from "playwright";
 
 import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
+import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
 const evidenceDir = new URL("../../.agent/evidence/capabilities-source-packages/", import.meta.url)
@@ -18,7 +19,7 @@ const skillCapabilityId = "skill:release-operator-browser";
 const pluginKey = "example/research";
 const skillUrl = "https://github.com/acme/skills/tree/main/release-operator";
 const pluginUrl = "https://plugins.example.test/research.json";
-const apiContractRevision = "2026-08-model-context-v1";
+const apiContractRevision = OPENGENI_API_CONTRACT_REVISION;
 let webBaseUrl = "";
 
 type UiState = {


### PR DESCRIPTION
## Summary
- derive host and fixture API revisions from the SDK contract export
- document the fail-closed embedding boundary
- make exact-head pre-merge approval explicit in the release sequence

## Verification
- `bun run typecheck`
- `bun test --timeout 30000 apps/web/src/api.test.ts apps/web/src/App.test.ts packages/sdk/test/client-coverage.test.ts packages/react/test` (1,467 pass)
- `bun run format:check`
- `bun run check:public-hygiene`
- `bun x changeset status`