### PR TITLE
fix(release): require strict pre-merge review

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -823,6 +823,13 @@ release evidence and cannot rehabilitate that source commit; stop that train
 and use a fresh, normally reviewed release-source PR instead of retrying or
 weakening admission.
 
+Immediately before merge, re-read `baseRefOid`, `headRefOid`, `state`, and
+`autoMergeRequest` from the PR and the exact-head review from the provider API.
+Require the PR to remain open, auto-merge to remain null, and the canonical
+review to bind the unchanged head with a strictly earlier provider timestamp;
+equal review and merge timestamps are not ordering evidence. Then merge with an
+exact head-SHA fence. Never rely on an earlier UI observation for this boundary.
+
 The exact source must separately have one successful GitHub Actions result for
 each required candidate check:
 `Typecheck and unit tests`, `Deployment artifacts`, and `Workload image

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -2126,7 +2126,7 @@ export async function verifyApprovedMerge(options = {}) {
   invariant(decisions.length > 0, "trusted reviewer did not review the exact PR head");
   const decision = decisions.at(-1);
   invariant(
-    decision.submittedAt <= pullIdentity.mergedAt,
+    decision.submittedAt < pullIdentity.mergedAt,
     "trusted approval was not submitted before merge",
   );
   assertIdentity(decision.review.user, decision.releaseApprover, "trusted reviewer");

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2979,6 +2979,10 @@ describe("release approval provenance", () => {
     await expect(
       verifyApprovedMerge({ env: approvalEnv(), fetchImpl: stale.fetchImpl }),
     ).rejects.toThrow("did not review the exact PR head");
+    const sameSecond = approvalFixture({ reviewTime: "2026-07-23T12:00:00Z" });
+    await expect(
+      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: sameSecond.fetchImpl }),
+    ).rejects.toThrow("was not submitted before merge");
     const late = approvalFixture({ reviewTime: "2026-07-23T12:01:00Z" });
     await expect(
       verifyApprovedMerge({ env: approvalEnv(), fetchImpl: late.fetchImpl }),


### PR DESCRIPTION
## Summary

- require the decisive exact-head review timestamp to be strictly earlier than merge
- reject same-second review/merge equality because GitHub timestamps are second-granular
- add the equality regression and an actionable pre-merge provider-state checklist

## Verification

- `bun test scripts/check-release-pr-automation.test.ts`
- `bun run format:check`
- `bun run check:docs-refs`
- `git diff --check`

Release-tooling and documentation correction; no publishable package changeset required. This PR will be merged with a true merge commit so its sealed head remains a retained descendant release controller.