### PR TITLE
fix(release): keep schema history assertions appendable

### DIFF
--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -168,7 +168,6 @@ describe("release schema contract", () => {
     );
     if (modelContextCutover) {
       expect(modelContextCutover).toMatchObject({ deploymentMode: "maintenance" });
-      expect(completeSourceContract.latestMigration).toBe(modelContextCutover.path);
     }
     const migrations = new Map(
       sourceContract.migrations.map((migration) => [migration.path, migration]),


### PR DESCRIPTION
## Summary
- keep the migration-mode assertion for the model-context cutover
- stop treating that historical migration as permanently latest after newer migrations append

## Verification
- `bun test scripts/release-schema-contract.test.ts` (6 pass)
- `bun run format:check`
- `bun run check:public-hygiene`
- `git diff --check`