### PR TITLE
fix(capabilities): bind facet receipts to exact subject

### DIFF
--- a/.changeset/fresh-facets-bind.md
+++ b/.changeset/fresh-facets-bind.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Bind Integration facet idempotency receipts to the subject that created them so another workspace administrator cannot replay a personal facet result.

--- a/apps/api/test/api-integrations-routes.test.ts
+++ b/apps/api/test/api-integrations-routes.test.ts
@@ -603,6 +603,19 @@ describe("API Integration routes", () => {
     });
     expect(replay.status).toBe(201);
     expect(await replay.json()).toEqual(configured);
+    const crossSubjectReplay = await request(
+      `${base}/inventory-source`,
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          displayName: "Finance inventory",
+          config: { collection: "finance", includeArchived: false },
+          idempotencyKey: configureKey,
+        }),
+      },
+      "user:api-integration-route-other-admin",
+    );
+    expect(crossSubjectReplay.status).toBe(409);
 
     const invalid = await request(`${base}/inventory-source`, {
       method: "PUT",

--- a/packages/db/src/integration-facets.ts
+++ b/packages/db/src/integration-facets.ts
@@ -445,7 +445,10 @@ async function withFacetOperation<T extends Record<string, unknown>>(
           .for("update")
           .limit(1);
         if (existing) {
-          if (existing.requestDigest !== requestDigest) {
+          if (
+            existing.createdBySubjectId !== input.subjectId ||
+            existing.requestDigest !== requestDigest
+          ) {
             throw new IntegrationFacetOperationIdempotencyError(
               "Integration facet idempotency key was reused",
             );

--- a/packages/db/test/api-integrations.test.ts
+++ b/packages/db/test/api-integrations.test.ts
@@ -780,6 +780,27 @@ describe("API Integration persistence", () => {
       configureIntegrationFacet(client.db, {
         accountId: first.accountId,
         workspaceId: first.workspaceId,
+        subjectId: "user:api-integration-facet-other-admin",
+        capabilityId: googleInput.capabilityId,
+        instanceKey: "finance",
+        facetKey: "drive-content",
+        displayName: "Finance source",
+        config: {
+          sources: [
+            {
+              sourceId: "folder:finance",
+              sourceKind: "folder",
+              includeDescendants: true,
+            },
+          ],
+        },
+        idempotencyKey: configureKey,
+      }),
+    ).rejects.toBeInstanceOf(IntegrationFacetOperationIdempotencyError);
+    await expect(
+      configureIntegrationFacet(client.db, {
+        accountId: first.accountId,
+        workspaceId: first.workspaceId,
         subjectId: first.subjectId,
         capabilityId: googleInput.capabilityId,
         instanceKey: "finance",


### PR DESCRIPTION
## Summary

Fix-forward from the fresh-eyes OPE-16 / PR #1377 post-merge audit.

- bind completed Integration facet idempotency receipts to their exact `createdBySubjectId`
- reject cross-subject replay before returning the stored result
- preserve same-subject idempotent retries and existing receipt digests
- add real-PostgreSQL persistence and public-route regressions

## Finding

The facet mutation receipt lookup was workspace-scoped and compared only the idempotency key plus request digest. A different workspace administrator who supplied the same receipt key and request could receive the completed result for a subject-owned Integration facet without passing the facet's subject visibility lookup.

No credential material was returned, but the stored result can include personal facet configuration and Connection identity. The fix uses the already-persisted immutable receipt actor rather than changing receipt digests, so deployed same-subject retries remain compatible.

## Verification

- `bun run typecheck` — 31/31 projects clean
- `bunx oxfmt --check packages/db/src/integration-facets.ts packages/db/test/api-integrations.test.ts apps/api/test/api-integrations-routes.test.ts`
- `bunx oxlint --deny-warnings packages/db/src/integration-facets.ts packages/db/test/api-integrations.test.ts apps/api/test/api-integrations-routes.test.ts`
- real PostgreSQL 16 + pgvector, FORCE-RLS app role:
  - `packages/db/test/api-integrations.test.ts` — 5 pass / 46 assertions
  - `apps/api/test/api-integrations-routes.test.ts` — 5 pass / 52 assertions
- changeset plan validates `@opengeni/db` patch propagation

No schema migration or deployment mutation is included.
