### PR TITLE
fix(capabilities): apply facet mutation state immediately

### DIFF
--- a/apps/web/src/components/capabilities/google-drive-knowledge-source-dialog.tsx
+++ b/apps/web/src/components/capabilities/google-drive-knowledge-source-dialog.tsx
@@ -55,7 +55,7 @@ export function GoogleDriveKnowledgeSourceDialog({
   canManageOrganizationDestination: boolean;
   onClose: () => void;
   onBusyChange: (busy: boolean) => void;
-  onSaved: () => Promise<void>;
+  onSaved: (binding: IntegrationFacetBindingSummary) => void;
 }) {
   const [busy, setBusy] = useState(false);
   const [browseBusy, setBrowseBusy] = useState(false);
@@ -221,7 +221,7 @@ export function GoogleDriveKnowledgeSourceDialog({
     setBusy(true);
     onBusyChange(true);
     try {
-      await client.saveGoogleDriveFacetSource(
+      const result = await client.saveGoogleDriveFacetSource(
         workspaceId,
         instance.capabilityId,
         instance.instanceKey,
@@ -241,7 +241,7 @@ export function GoogleDriveKnowledgeSourceDialog({
           idempotencyKey: crypto.randomUUID(),
         },
       );
-      await onSaved();
+      onSaved(result.binding);
       onClose();
       toast.success("Google Drive locations saved", {
         description: `Only ${instance.displayName} was updated; sibling Drive accounts were unchanged.`,

--- a/apps/web/src/components/capabilities/google-drive-knowledge-source-dialog.tsx
+++ b/apps/web/src/components/capabilities/google-drive-knowledge-source-dialog.tsx
@@ -32,6 +32,25 @@ export type GoogleDriveFacetEntry = {
   binding: IntegrationFacetBindingSummary | null;
 };
 
+export type GoogleDriveFacetMutation = {
+  apply: (binding: IntegrationFacetBindingSummary) => boolean;
+  isCurrent: () => boolean;
+  finish: () => void;
+};
+
+export type GoogleDriveKnowledgeSourceDialogProps = {
+  client: OpenGeniCoreClient;
+  workspaceId: string;
+  instance: ApiIntegrationInstallationSummary;
+  entry: GoogleDriveFacetEntry | null;
+  canManage: boolean;
+  canManagePersonalDestination: boolean;
+  canManageWorkspaceDestination: boolean;
+  canManageOrganizationDestination: boolean;
+  onClose: () => void;
+  onMutationStart: () => GoogleDriveFacetMutation;
+};
+
 export function GoogleDriveKnowledgeSourceDialog({
   client,
   workspaceId,
@@ -42,21 +61,8 @@ export function GoogleDriveKnowledgeSourceDialog({
   canManageWorkspaceDestination,
   canManageOrganizationDestination,
   onClose,
-  onBusyChange,
-  onSaved,
-}: {
-  client: OpenGeniCoreClient;
-  workspaceId: string;
-  instance: ApiIntegrationInstallationSummary;
-  entry: GoogleDriveFacetEntry | null;
-  canManage: boolean;
-  canManagePersonalDestination: boolean;
-  canManageWorkspaceDestination: boolean;
-  canManageOrganizationDestination: boolean;
-  onClose: () => void;
-  onBusyChange: (busy: boolean) => void;
-  onSaved: (binding: IntegrationFacetBindingSummary) => void;
-}) {
+  onMutationStart,
+}: GoogleDriveKnowledgeSourceDialogProps) {
   const [busy, setBusy] = useState(false);
   const [browseBusy, setBrowseBusy] = useState(false);
   const [items, setItems] = useState<GoogleDriveBrowseItem[]>([]);
@@ -218,8 +224,8 @@ export function GoogleDriveKnowledgeSourceDialog({
 
   async function saveSelection(): Promise<void> {
     if (!entry || selectedSources.length === 0 || destinationDisabled || !canManage) return;
+    const mutation = onMutationStart();
     setBusy(true);
-    onBusyChange(true);
     try {
       const result = await client.saveGoogleDriveFacetSource(
         workspaceId,
@@ -241,18 +247,21 @@ export function GoogleDriveKnowledgeSourceDialog({
           idempotencyKey: crypto.randomUUID(),
         },
       );
-      onSaved(result.binding);
-      onClose();
-      toast.success("Google Drive locations saved", {
-        description: `Only ${instance.displayName} was updated; sibling Drive accounts were unchanged.`,
-      });
+      if (mutation.apply(result.binding)) {
+        onClose();
+        toast.success("Google Drive locations saved", {
+          description: `Only ${instance.displayName} was updated; sibling Drive accounts were unchanged.`,
+        });
+      }
     } catch (error) {
-      toast.error("Google Drive locations could not be saved", {
-        description: error instanceof Error ? error.message : String(error),
-      });
+      if (mutation.isCurrent()) {
+        toast.error("Google Drive locations could not be saved", {
+          description: error instanceof Error ? error.message : String(error),
+        });
+      }
     } finally {
       setBusy(false);
-      onBusyChange(false);
+      mutation.finish();
     }
   }
 

--- a/apps/web/src/components/capabilities/integration-facets-panel-lifecycle.test.tsx
+++ b/apps/web/src/components/capabilities/integration-facets-panel-lifecycle.test.tsx
@@ -1,0 +1,173 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, type ComponentProps } from "react";
+import { createRoot } from "react-dom/client";
+
+import type {
+  ApiIntegrationInstallationSummary,
+  IntegrationFacetBindingSummary,
+  IntegrationInstanceFacetsResponse,
+} from "@/types";
+
+import { IntegrationFacetsPanel } from "./integration-facets-panel";
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => GlobalRegistrator.unregister());
+
+describe("Integration Facet lifecycle state", () => {
+  test("applies the authoritative lifecycle result without a stale list refetch", async () => {
+    const active = binding("active", 1);
+    const paused = binding("paused", 2);
+    const listIntegrationFacets = mock(async () => response(active));
+    const pauseIntegrationFacet = mock(async () => ({
+      capabilityId: instance.capabilityId,
+      instanceKey: instance.instanceKey,
+      facetKey: "inventory-source",
+      status: "paused" as const,
+      binding: paused,
+    }));
+    const client = {
+      listIntegrationFacets,
+      pauseIntegrationFacet,
+    } as unknown as OpenGeniCoreClient;
+    const rendered = await renderPanel({ client });
+    try {
+      await act(async () => button(rendered.container, "Manage facets").click());
+      await waitFor(() => rendered.container.textContent?.includes("Active") === true);
+
+      await act(async () => button(rendered.container, "Pause").click());
+      await waitFor(() => rendered.container.textContent?.includes("Paused") === true);
+
+      expect(pauseIntegrationFacet).toHaveBeenCalledTimes(1);
+      expect(listIntegrationFacets).toHaveBeenCalledTimes(1);
+      expect(rendered.container.textContent).not.toContain("Active");
+    } finally {
+      await rendered.unmount();
+    }
+  });
+});
+
+async function renderPanel(props: Partial<ComponentProps<typeof IntegrationFacetsPanel>> = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <IntegrationFacetsPanel
+        client={{} as OpenGeniCoreClient}
+        workspaceId="00000000-0000-4000-8000-000000000101"
+        instance={instance}
+        facetCount={1}
+        canManage
+        canManagePersonalDestination
+        canManageWorkspaceDestination
+        canManageOrganizationDestination={false}
+        GoogleDriveDialog={() => null}
+        {...props}
+      />,
+    );
+  });
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => root.unmount());
+      container.remove();
+      document.body.replaceChildren();
+    },
+  };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (predicate()) return;
+    await act(async () => await Bun.sleep(0));
+  }
+  throw new Error("Timed out waiting for Integration Facet state");
+}
+
+function button(container: ParentNode, label: string): HTMLButtonElement {
+  const match = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+    (candidate) =>
+      candidate.getAttribute("aria-label")?.includes(label) ||
+      candidate.textContent?.includes(label),
+  );
+  if (!match) throw new Error(`Missing button: ${label}`);
+  return match;
+}
+
+function response(bindingValue: IntegrationFacetBindingSummary): IntegrationInstanceFacetsResponse {
+  return {
+    capabilityId: instance.capabilityId,
+    instanceKey: instance.instanceKey,
+    providerDomain: instance.providerDomain,
+    connectionId: instance.connectionId,
+    facets: [
+      {
+        definition: {
+          facetKey: "inventory-source",
+          kind: "knowledge_source",
+          configSchema: { type: "object", properties: {} },
+          capabilities: {},
+        },
+        binding: bindingValue,
+      },
+    ],
+  };
+}
+
+function binding(
+  status: IntegrationFacetBindingSummary["status"],
+  version: number,
+): IntegrationFacetBindingSummary {
+  return {
+    id: "00000000-0000-4000-8000-000000000102",
+    facetKey: "inventory-source",
+    kind: "knowledge_source",
+    bindingKey: "finance",
+    displayName: "Finance inventory",
+    connectionId: "00000000-0000-4000-8000-000000000103",
+    status,
+    config: { collection: "finance" },
+    version,
+    hasCursor: false,
+    lastSuccessAt: null,
+    lastErrorCode: null,
+    createdAt: "2026-08-14T00:00:00.000Z",
+    updatedAt: "2026-08-14T00:00:00.000Z",
+  };
+}
+
+const instance: ApiIntegrationInstallationSummary = {
+  capabilityId: "api:inventory",
+  pluginKey: "integration/inventory",
+  installationVersion: 1,
+  instanceId: "00000000-0000-4000-8000-000000000104",
+  instanceKey: "finance",
+  displayName: "Inventory — Finance",
+  instanceVersion: 1,
+  serverId: "inventory_finance",
+  name: "Inventory",
+  description: "Inventory Integration",
+  protocol: "openapi",
+  definitionId: "inventory",
+  definitionProvenance: "workspace",
+  providerDomain: "inventory.example.com",
+  baseUrl: "https://inventory.example.com/v1/",
+  sourceUrl: "https://inventory.example.com/openapi.json",
+  connected: true,
+  requiresConnection: true,
+  connectionId: "00000000-0000-4000-8000-000000000103",
+  ownership: "personal",
+  allowedTools: ["list_items"],
+  toolCount: 1,
+  approvalRequiredToolCount: 0,
+  revisionId: "openapi:fixture",
+  contentSha256: "a".repeat(64),
+};

--- a/apps/web/src/components/capabilities/integration-facets-panel-lifecycle.test.tsx
+++ b/apps/web/src/components/capabilities/integration-facets-panel-lifecycle.test.tsx
@@ -52,30 +52,94 @@ describe("Integration Facet lifecycle state", () => {
       await rendered.unmount();
     }
   });
+
+  test("ignores an older lifecycle result after a newer instance list wins", async () => {
+    const active = binding("active", 1);
+    const paused = binding("paused", 2);
+    const newerActive = binding("active", 3);
+    let listCount = 0;
+    const listIntegrationFacets = mock(async () =>
+      response(listCount++ === 0 ? active : newerActive),
+    );
+    type LifecycleResult = {
+      capabilityId: string;
+      instanceKey: string;
+      facetKey: string;
+      status: "paused";
+      binding: IntegrationFacetBindingSummary;
+    };
+    let resolvePause: (result: LifecycleResult) => void = () => undefined;
+    const pauseResult = new Promise<LifecycleResult>((resolve) => {
+      resolvePause = resolve;
+    });
+    const pauseIntegrationFacet = mock(async () => await pauseResult);
+    const client = {
+      listIntegrationFacets,
+      pauseIntegrationFacet,
+    } as unknown as OpenGeniCoreClient;
+    const rendered = await renderPanel({ client });
+    try {
+      await act(async () => button(rendered.container, "Manage facets").click());
+      await waitFor(() => rendered.container.textContent?.includes("Active") === true);
+
+      await act(async () => button(rendered.container, "Pause").click());
+      await waitFor(() => pauseIntegrationFacet.mock.calls.length === 1);
+
+      await rendered.rerender({
+        client,
+        instance: { ...instance, instanceVersion: 2 },
+      });
+      await act(async () => button(rendered.container, "Manage facets").click());
+      await waitFor(() => listIntegrationFacets.mock.calls.length === 2);
+      await waitFor(() => rendered.container.textContent?.includes("Active") === true);
+
+      await act(async () =>
+        resolvePause({
+          capabilityId: instance.capabilityId,
+          instanceKey: instance.instanceKey,
+          facetKey: "inventory-source",
+          status: "paused",
+          binding: paused,
+        }),
+      );
+      await act(async () => await Bun.sleep(0));
+
+      expect(rendered.container.textContent).toContain("Active");
+      expect(rendered.container.textContent).not.toContain("Paused");
+    } finally {
+      await rendered.unmount();
+    }
+  });
 });
 
 async function renderPanel(props: Partial<ComponentProps<typeof IntegrationFacetsPanel>> = {}) {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
-  await act(async () => {
-    root.render(
-      <IntegrationFacetsPanel
-        client={{} as OpenGeniCoreClient}
-        workspaceId="00000000-0000-4000-8000-000000000101"
-        instance={instance}
-        facetCount={1}
-        canManage
-        canManagePersonalDestination
-        canManageWorkspaceDestination
-        canManageOrganizationDestination={false}
-        GoogleDriveDialog={() => null}
-        {...props}
-      />,
-    );
-  });
+  const render = async (
+    nextProps: Partial<ComponentProps<typeof IntegrationFacetsPanel>> = props,
+  ): Promise<void> => {
+    await act(async () => {
+      root.render(
+        <IntegrationFacetsPanel
+          client={{} as OpenGeniCoreClient}
+          workspaceId="00000000-0000-4000-8000-000000000101"
+          instance={instance}
+          facetCount={1}
+          canManage
+          canManagePersonalDestination
+          canManageWorkspaceDestination
+          canManageOrganizationDestination={false}
+          GoogleDriveDialog={() => null}
+          {...nextProps}
+        />,
+      );
+    });
+  };
+  await render();
   return {
     container,
+    rerender: render,
     unmount: async () => {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/components/capabilities/integration-facets-panel-lifecycle.test.tsx
+++ b/apps/web/src/components/capabilities/integration-facets-panel-lifecycle.test.tsx
@@ -110,6 +110,78 @@ describe("Integration Facet lifecycle state", () => {
       await rendered.unmount();
     }
   });
+
+  test("applies concurrent lifecycle results for different facets independently", async () => {
+    const firstActive = binding("active", 1, "inventory-source", "102");
+    const secondActive = binding("active", 1, "orders-source", "105");
+    const firstPaused = binding("paused", 2, "inventory-source", "102");
+    const secondPaused = binding("paused", 2, "orders-source", "105");
+    type LifecycleResult = {
+      capabilityId: string;
+      instanceKey: string;
+      facetKey: string;
+      status: "paused";
+      binding: IntegrationFacetBindingSummary;
+    };
+    const resolvers = new Map<string, (result: LifecycleResult) => void>();
+    const pauseIntegrationFacet = mock(
+      async (_workspaceId: string, _capabilityId: string, _instanceKey: string, facetKey: string) =>
+        await new Promise<LifecycleResult>((resolve) => {
+          resolvers.set(facetKey, resolve);
+        }),
+    );
+    const client = {
+      listIntegrationFacets: mock(async () => response(firstActive, secondActive)),
+      pauseIntegrationFacet,
+    } as unknown as OpenGeniCoreClient;
+    const rendered = await renderPanel({ client, facetCount: 2 });
+    try {
+      await act(async () => button(rendered.container, "Manage facets").click());
+      await waitFor(() => facet(rendered.container, "inventory-source") !== null);
+
+      await act(async () =>
+        button(requiredFacet(rendered.container, "inventory-source"), "Pause").click(),
+      );
+      await waitFor(() => resolvers.has("inventory-source"));
+      await act(async () =>
+        button(requiredFacet(rendered.container, "orders-source"), "Pause").click(),
+      );
+      await waitFor(() => resolvers.has("orders-source"));
+
+      await act(async () =>
+        resolvers.get("orders-source")?.({
+          capabilityId: instance.capabilityId,
+          instanceKey: instance.instanceKey,
+          facetKey: "orders-source",
+          status: "paused",
+          binding: secondPaused,
+        }),
+      );
+      await waitFor(
+        () => facet(rendered.container, "orders-source")?.textContent?.includes("Paused") === true,
+      );
+
+      await act(async () =>
+        resolvers.get("inventory-source")?.({
+          capabilityId: instance.capabilityId,
+          instanceKey: instance.instanceKey,
+          facetKey: "inventory-source",
+          status: "paused",
+          binding: firstPaused,
+        }),
+      );
+      await waitFor(
+        () =>
+          facet(rendered.container, "inventory-source")?.textContent?.includes("Paused") === true,
+      );
+
+      expect(pauseIntegrationFacet).toHaveBeenCalledTimes(2);
+      expect(facet(rendered.container, "inventory-source")?.textContent).toContain("Paused");
+      expect(facet(rendered.container, "orders-source")?.textContent).toContain("Paused");
+    } finally {
+      await rendered.unmount();
+    }
+  });
 });
 
 async function renderPanel(props: Partial<ComponentProps<typeof IntegrationFacetsPanel>> = {}) {
@@ -166,33 +238,45 @@ function button(container: ParentNode, label: string): HTMLButtonElement {
   return match;
 }
 
-function response(bindingValue: IntegrationFacetBindingSummary): IntegrationInstanceFacetsResponse {
+function facet(container: ParentNode, facetKey: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-integration-facet="${facetKey}"]`);
+}
+
+function requiredFacet(container: ParentNode, facetKey: string): HTMLElement {
+  const match = facet(container, facetKey);
+  if (!match) throw new Error(`Missing facet: ${facetKey}`);
+  return match;
+}
+
+function response(
+  ...bindingValues: IntegrationFacetBindingSummary[]
+): IntegrationInstanceFacetsResponse {
   return {
     capabilityId: instance.capabilityId,
     instanceKey: instance.instanceKey,
     providerDomain: instance.providerDomain,
     connectionId: instance.connectionId,
-    facets: [
-      {
-        definition: {
-          facetKey: "inventory-source",
-          kind: "knowledge_source",
-          configSchema: { type: "object", properties: {} },
-          capabilities: {},
-        },
-        binding: bindingValue,
+    facets: bindingValues.map((bindingValue) => ({
+      definition: {
+        facetKey: bindingValue.facetKey,
+        kind: "knowledge_source",
+        configSchema: { type: "object", properties: {} },
+        capabilities: {},
       },
-    ],
+      binding: bindingValue,
+    })),
   };
 }
 
 function binding(
   status: IntegrationFacetBindingSummary["status"],
   version: number,
+  facetKey = "inventory-source",
+  idSuffix = "102",
 ): IntegrationFacetBindingSummary {
   return {
-    id: "00000000-0000-4000-8000-000000000102",
-    facetKey: "inventory-source",
+    id: `00000000-0000-4000-8000-000000000${idSuffix}`,
+    facetKey,
     kind: "knowledge_source",
     bindingKey: "finance",
     displayName: "Finance inventory",

--- a/apps/web/src/components/capabilities/integration-facets-panel-lifecycle.test.tsx
+++ b/apps/web/src/components/capabilities/integration-facets-panel-lifecycle.test.tsx
@@ -10,6 +10,10 @@ import type {
   IntegrationInstanceFacetsResponse,
 } from "@/types";
 
+import type {
+  GoogleDriveFacetMutation,
+  GoogleDriveKnowledgeSourceDialogProps,
+} from "./google-drive-knowledge-source-dialog";
 import { IntegrationFacetsPanel } from "./integration-facets-panel";
 
 beforeAll(() => {
@@ -182,7 +186,163 @@ describe("Integration Facet lifecycle state", () => {
       await rendered.unmount();
     }
   });
+
+  test("keeps an older Google Drive success and close scoped to its originating instance", async () => {
+    const instanceA = instance;
+    const instanceB = {
+      ...instance,
+      instanceId: "00000000-0000-4000-8000-000000000204",
+      instanceKey: "operations",
+      displayName: "Inventory — Operations",
+      instanceVersion: 2,
+    };
+    const activeA = binding("active", 1, "drive-content", "202");
+    const pausedA = binding("paused", 2, "drive-content", "202");
+    const activeB = binding("active", 1, "drive-content", "205");
+    const pausedB = binding("paused", 2, "drive-content", "205");
+    const listIntegrationFacets = mock(
+      async (_workspaceId: string, _capabilityId: string, instanceKey: string) =>
+        googleDriveResponse(
+          instanceKey === instanceA.instanceKey ? instanceA : instanceB,
+          {
+            [instanceA.instanceKey]: activeA,
+            [instanceB.instanceKey]: activeB,
+          }[instanceKey]!,
+        ),
+    );
+    let dialogA: GoogleDriveKnowledgeSourceDialogProps | null = null;
+    let dialogB: GoogleDriveKnowledgeSourceDialogProps | null = null;
+    const GoogleDriveDialog = (props: GoogleDriveKnowledgeSourceDialogProps) => {
+      if (props.instance.instanceKey === instanceA.instanceKey) dialogA = props;
+      else dialogB = props;
+      return <div data-google-drive-dialog={props.instance.instanceKey} />;
+    };
+    const client = { listIntegrationFacets } as unknown as OpenGeniCoreClient;
+    const rendered = await renderPanel({ client, instance: instanceA, GoogleDriveDialog });
+    try {
+      await openGoogleDriveEditor(rendered.container, instanceA.instanceKey);
+      let oldMutation!: GoogleDriveFacetMutation;
+      await act(async () => {
+        oldMutation = requiredDialog(dialogA).onMutationStart();
+      });
+
+      await rendered.rerender({ client, instance: instanceB, GoogleDriveDialog });
+      await openGoogleDriveEditor(rendered.container, instanceB.instanceKey);
+      const currentDialog = requiredDialog(dialogB);
+      let currentMutation!: GoogleDriveFacetMutation;
+      await act(async () => {
+        currentMutation = currentDialog.onMutationStart();
+      });
+
+      let oldApplied = true;
+      await act(async () => {
+        oldApplied = oldMutation.apply(pausedA);
+        requiredDialog(dialogA).onClose();
+        oldMutation.finish();
+      });
+
+      expect(oldApplied).toBe(false);
+      expect(currentMutation.isCurrent()).toBe(true);
+      expect(
+        rendered.container.querySelector(`[data-google-drive-dialog="${instanceB.instanceKey}"]`),
+      ).not.toBeNull();
+      expect(requiredFacet(rendered.container, "drive-content").textContent).toContain("Active");
+
+      await act(async () => {
+        expect(currentMutation.apply(pausedB)).toBe(true);
+        currentDialog.onClose();
+        currentMutation.finish();
+      });
+      await waitFor(
+        () =>
+          requiredFacet(rendered.container, "drive-content").textContent?.includes("Paused") ===
+          true,
+      );
+
+      expect(rendered.container.querySelector("[data-google-drive-dialog]")).toBeNull();
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("does not let an older Google Drive finally consume a newer instance mutation", async () => {
+    const instanceA = instance;
+    const instanceB = {
+      ...instance,
+      instanceId: "00000000-0000-4000-8000-000000000304",
+      instanceKey: "operations",
+      displayName: "Inventory — Operations",
+      instanceVersion: 2,
+    };
+    const activeA = binding("active", 1, "drive-content", "302");
+    const activeB = binding("active", 1, "drive-content", "305");
+    const pausedB = binding("paused", 2, "drive-content", "305");
+    const listIntegrationFacets = mock(
+      async (_workspaceId: string, _capabilityId: string, instanceKey: string) =>
+        googleDriveResponse(
+          instanceKey === instanceA.instanceKey ? instanceA : instanceB,
+          {
+            [instanceA.instanceKey]: activeA,
+            [instanceB.instanceKey]: activeB,
+          }[instanceKey]!,
+        ),
+    );
+    let dialogA: GoogleDriveKnowledgeSourceDialogProps | null = null;
+    let dialogB: GoogleDriveKnowledgeSourceDialogProps | null = null;
+    const GoogleDriveDialog = (props: GoogleDriveKnowledgeSourceDialogProps) => {
+      if (props.instance.instanceKey === instanceA.instanceKey) dialogA = props;
+      else dialogB = props;
+      return <div data-google-drive-dialog={props.instance.instanceKey} />;
+    };
+    const client = { listIntegrationFacets } as unknown as OpenGeniCoreClient;
+    const rendered = await renderPanel({ client, instance: instanceA, GoogleDriveDialog });
+    try {
+      await openGoogleDriveEditor(rendered.container, instanceA.instanceKey);
+      let oldMutation!: GoogleDriveFacetMutation;
+      await act(async () => {
+        oldMutation = requiredDialog(dialogA).onMutationStart();
+      });
+
+      await rendered.rerender({ client, instance: instanceB, GoogleDriveDialog });
+      await openGoogleDriveEditor(rendered.container, instanceB.instanceKey);
+      let currentMutation!: GoogleDriveFacetMutation;
+      await act(async () => {
+        currentMutation = requiredDialog(dialogB).onMutationStart();
+      });
+
+      await act(async () => oldMutation.finish());
+
+      expect(currentMutation.isCurrent()).toBe(true);
+      await act(async () => {
+        expect(currentMutation.apply(pausedB)).toBe(true);
+        currentMutation.finish();
+      });
+      await waitFor(
+        () =>
+          requiredFacet(rendered.container, "drive-content").textContent?.includes("Paused") ===
+          true,
+      );
+    } finally {
+      await rendered.unmount();
+    }
+  });
 });
+
+async function openGoogleDriveEditor(container: ParentNode, instanceKey: string): Promise<void> {
+  await act(async () => button(container, "Manage facets").click());
+  await waitFor(() => facet(container, "drive-content") !== null);
+  await act(async () => button(requiredFacet(container, "drive-content"), "Edit").click());
+  await waitFor(
+    () => container.querySelector(`[data-google-drive-dialog="${instanceKey}"]`) !== null,
+  );
+}
+
+function requiredDialog(
+  dialog: GoogleDriveKnowledgeSourceDialogProps | null,
+): GoogleDriveKnowledgeSourceDialogProps {
+  if (!dialog) throw new Error("Missing Google Drive dialog props");
+  return dialog;
+}
 
 async function renderPanel(props: Partial<ComponentProps<typeof IntegrationFacetsPanel>> = {}) {
   const container = document.createElement("div");
@@ -265,6 +425,29 @@ function response(
       },
       binding: bindingValue,
     })),
+  };
+}
+
+function googleDriveResponse(
+  targetInstance: ApiIntegrationInstallationSummary,
+  bindingValue: IntegrationFacetBindingSummary,
+): IntegrationInstanceFacetsResponse {
+  return {
+    capabilityId: targetInstance.capabilityId,
+    instanceKey: targetInstance.instanceKey,
+    providerDomain: targetInstance.providerDomain,
+    connectionId: targetInstance.connectionId,
+    facets: [
+      {
+        definition: {
+          facetKey: "drive-content",
+          kind: "knowledge_source",
+          configSchema: { type: "object", properties: {} },
+          capabilities: { provider: "google-drive" },
+        },
+        binding: bindingValue,
+      },
+    ],
   };
 }
 

--- a/apps/web/src/components/capabilities/integration-facets-panel.tsx
+++ b/apps/web/src/components/capabilities/integration-facets-panel.tsx
@@ -52,7 +52,7 @@ type GoogleDriveDialogProps = {
   canManageOrganizationDestination: boolean;
   onClose: () => void;
   onBusyChange: (busy: boolean) => void;
-  onSaved: () => Promise<void>;
+  onSaved: (binding: IntegrationFacetBindingSummary) => void;
 };
 
 const KIND_DETAILS: Record<
@@ -175,6 +175,18 @@ export function IntegrationFacetsPanel({
     setForm(facetFormState(entry.definition, entry.binding));
   }
 
+  function applyMutationBinding(
+    facetKey: string,
+    binding: IntegrationFacetBindingSummary | null,
+  ): void {
+    ++loadSequence.current;
+    loadPromise.current = null;
+    setLoading(false);
+    setData((current) =>
+      current ? replaceIntegrationFacetBinding(current, facetKey, binding) : current,
+    );
+  }
+
   async function save(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
     if (!editor) return;
@@ -192,21 +204,7 @@ export function IntegrationFacetsPanel({
           idempotencyKey: crypto.randomUUID(),
         },
       );
-      ++loadSequence.current;
-      loadPromise.current = null;
-      setLoading(false);
-      setData((current) =>
-        current
-          ? {
-              ...current,
-              facets: current.facets.map((entry) =>
-                entry.definition.facetKey === editor.definition.facetKey
-                  ? { ...entry, binding: configured.binding }
-                  : entry,
-              ),
-            }
-          : current,
-      );
+      applyMutationBinding(editor.definition.facetKey, configured.binding);
       setEditor(null);
       toast.success(`${facetTitle(editor.definition)} configured`, {
         description: `This setting applies only to ${instance.displayName}.`,
@@ -228,24 +226,23 @@ export function IntegrationFacetsPanel({
         expectedVersion: entry.binding.version,
         idempotencyKey: crypto.randomUUID(),
       };
-      if (action === "pause") {
-        await client.pauseIntegrationFacet(
-          workspaceId,
-          data!.capabilityId,
-          data!.instanceKey,
-          entry.definition.facetKey,
-          request,
-        );
-      } else {
-        await client.resumeIntegrationFacet(
-          workspaceId,
-          data!.capabilityId,
-          data!.instanceKey,
-          entry.definition.facetKey,
-          request,
-        );
-      }
-      await load();
+      const result =
+        action === "pause"
+          ? await client.pauseIntegrationFacet(
+              workspaceId,
+              data!.capabilityId,
+              data!.instanceKey,
+              entry.definition.facetKey,
+              request,
+            )
+          : await client.resumeIntegrationFacet(
+              workspaceId,
+              data!.capabilityId,
+              data!.instanceKey,
+              entry.definition.facetKey,
+              request,
+            );
+      applyMutationBinding(entry.definition.facetKey, result.binding);
       toast.success(`${facetTitle(entry.definition)} ${action === "pause" ? "paused" : "resumed"}`);
     } catch (lifecycleError) {
       toast.error(`Couldn't ${action} this facet`, {
@@ -261,7 +258,7 @@ export function IntegrationFacetsPanel({
     if (!removeTarget?.binding || !data) return false;
     setBusyFacetKey(removeTarget.definition.facetKey);
     try {
-      await client.removeIntegrationFacet(
+      const result = await client.removeIntegrationFacet(
         workspaceId,
         data.capabilityId,
         data.instanceKey,
@@ -271,8 +268,8 @@ export function IntegrationFacetsPanel({
           idempotencyKey: crypto.randomUUID(),
         },
       );
+      applyMutationBinding(removeTarget.definition.facetKey, result.binding);
       setRemoveTarget(null);
-      await load();
       toast.success(`${facetTitle(removeTarget.definition)} removed`, {
         description: `${instance.displayName} and its Connection remain intact.`,
       });
@@ -375,7 +372,9 @@ export function IntegrationFacetsPanel({
               busy && googleDriveEditor ? googleDriveEditor.definition.facetKey : null,
             )
           }
-          onSaved={load}
+          onSaved={(binding) =>
+            applyMutationBinding(googleDriveEditor.definition.facetKey, binding)
+          }
         />
       ) : null}
 
@@ -390,6 +389,19 @@ export function IntegrationFacetsPanel({
       />
     </>
   );
+}
+
+export function replaceIntegrationFacetBinding(
+  data: IntegrationInstanceFacetsResponse,
+  facetKey: string,
+  binding: IntegrationFacetBindingSummary | null,
+): IntegrationInstanceFacetsResponse {
+  return {
+    ...data,
+    facets: data.facets.map((entry) =>
+      entry.definition.facetKey === facetKey ? { ...entry, binding } : entry,
+    ),
+  };
 }
 
 function FacetRow({

--- a/apps/web/src/components/capabilities/integration-facets-panel.tsx
+++ b/apps/web/src/components/capabilities/integration-facets-panel.tsx
@@ -15,6 +15,7 @@ import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
 import { useEffect, useMemo, useRef, useState, type ComponentType, type FormEvent } from "react";
 import { toast } from "sonner";
 
+import type { GoogleDriveKnowledgeSourceDialogProps } from "@/components/capabilities/google-drive-knowledge-source-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -46,19 +47,7 @@ type FacetMutationToken = {
   generation: number;
   sequence: number;
 };
-type GoogleDriveDialogProps = {
-  client: OpenGeniCoreClient;
-  workspaceId: string;
-  instance: ApiIntegrationInstallationSummary;
-  entry: FacetEntry | null;
-  canManage: boolean;
-  canManagePersonalDestination: boolean;
-  canManageWorkspaceDestination: boolean;
-  canManageOrganizationDestination: boolean;
-  onClose: () => void;
-  onBusyChange: (busy: boolean) => void;
-  onSaved: (binding: IntegrationFacetBindingSummary) => void;
-};
+type GoogleDriveDialogProps = GoogleDriveKnowledgeSourceDialogProps;
 
 const KIND_DETAILS: Record<
   IntegrationFacetDefinitionSummary["kind"],
@@ -124,13 +113,11 @@ export function IntegrationFacetsPanel({
   const nextMutationSequence = useRef(0);
   const mutationSequenceByFacet = useRef(new Map<string, number>());
   const loadPromise = useRef<Promise<void> | null>(null);
-  const googleDriveMutationToken = useRef<FacetMutationToken | null>(null);
 
   useEffect(() => {
     ++operationGeneration.current;
     mutationSequenceByFacet.current.clear();
     loadPromise.current = null;
-    googleDriveMutationToken.current = null;
     setData(null);
     setLoading(false);
     setError(null);
@@ -153,7 +140,6 @@ export function IntegrationFacetsPanel({
     if (loadPromise.current) return await loadPromise.current;
     const generation = ++operationGeneration.current;
     mutationSequenceByFacet.current.clear();
-    googleDriveMutationToken.current = null;
     setBusyFacetKeys(new Set());
     const pending = (async () => {
       setLoading(true);
@@ -417,23 +403,16 @@ export function IntegrationFacetsPanel({
           canManagePersonalDestination={canManagePersonalDestination}
           canManageWorkspaceDestination={canManageWorkspaceDestination}
           canManageOrganizationDestination={canManageOrganizationDestination}
-          onClose={() => setGoogleDriveEditor(null)}
-          onBusyChange={(busy) => {
-            if (busy) {
-              googleDriveMutationToken.current = beginMutation(
-                googleDriveEditor.definition.facetKey,
-              );
-              return;
-            }
-            const token = googleDriveMutationToken.current;
-            googleDriveMutationToken.current = null;
-            if (token !== null) finishMutation(token);
-          }}
-          onSaved={(binding) => {
-            const token = googleDriveMutationToken.current;
-            if (token !== null) {
-              applyMutationBinding(token, binding);
-            }
+          onClose={() =>
+            setGoogleDriveEditor((current) => (current === googleDriveEditor ? null : current))
+          }
+          onMutationStart={() => {
+            const token = beginMutation(googleDriveEditor.definition.facetKey);
+            return {
+              apply: (binding) => applyMutationBinding(token, binding),
+              isCurrent: () => isCurrentMutation(token),
+              finish: () => finishMutation(token),
+            };
           }}
         />
       ) : null}

--- a/apps/web/src/components/capabilities/integration-facets-panel.tsx
+++ b/apps/web/src/components/capabilities/integration-facets-panel.tsx
@@ -115,18 +115,22 @@ export function IntegrationFacetsPanel({
   const [googleDriveEditor, setGoogleDriveEditor] = useState<FacetEntry | null>(null);
   const [form, setForm] = useState<FacetFormState>({});
   const [removeTarget, setRemoveTarget] = useState<FacetEntry | null>(null);
-  const loadSequence = useRef(0);
+  const operationSequence = useRef(0);
   const loadPromise = useRef<Promise<void> | null>(null);
+  const googleDriveMutationSequence = useRef<number | null>(null);
 
   useEffect(() => {
-    ++loadSequence.current;
+    ++operationSequence.current;
     loadPromise.current = null;
+    googleDriveMutationSequence.current = null;
     setData(null);
     setLoading(false);
     setError(null);
+    setBusyFacetKey(null);
     setOpen(false);
     setEditor(null);
     setGoogleDriveEditor(null);
+    setRemoveTarget(null);
   }, [instance.capabilityId, instance.instanceKey, instance.instanceVersion]);
 
   useEffect(() => {
@@ -139,7 +143,9 @@ export function IntegrationFacetsPanel({
 
   async function load(): Promise<void> {
     if (loadPromise.current) return await loadPromise.current;
-    const sequence = ++loadSequence.current;
+    const sequence = ++operationSequence.current;
+    googleDriveMutationSequence.current = null;
+    setBusyFacetKey(null);
     const pending = (async () => {
       setLoading(true);
       try {
@@ -148,14 +154,14 @@ export function IntegrationFacetsPanel({
           instance.capabilityId,
           instance.instanceKey,
         );
-        if (sequence !== loadSequence.current) return;
+        if (sequence !== operationSequence.current) return;
         setData(response);
         setError(null);
       } catch (loadError) {
-        if (sequence !== loadSequence.current) return;
+        if (sequence !== operationSequence.current) return;
         setError(loadError instanceof Error ? loadError.message : String(loadError));
       } finally {
-        if (sequence === loadSequence.current) setLoading(false);
+        if (sequence === operationSequence.current) setLoading(false);
       }
     })();
     loadPromise.current = pending;
@@ -175,51 +181,69 @@ export function IntegrationFacetsPanel({
     setForm(facetFormState(entry.definition, entry.binding));
   }
 
+  function beginMutation(): number {
+    const sequence = ++operationSequence.current;
+    loadPromise.current = null;
+    googleDriveMutationSequence.current = null;
+    setLoading(false);
+    return sequence;
+  }
+
   function applyMutationBinding(
+    sequence: number,
     facetKey: string,
     binding: IntegrationFacetBindingSummary | null,
-  ): void {
-    ++loadSequence.current;
-    loadPromise.current = null;
-    setLoading(false);
+  ): boolean {
+    if (sequence !== operationSequence.current) return false;
     setData((current) =>
       current ? replaceIntegrationFacetBinding(current, facetKey, binding) : current,
     );
+    return true;
+  }
+
+  function finishMutation(sequence: number): void {
+    if (sequence === operationSequence.current) setBusyFacetKey(null);
   }
 
   async function save(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
-    if (!editor) return;
-    setBusyFacetKey(editor.definition.facetKey);
+    if (!editor || !data) return;
+    const target = editor;
+    const currentData = data;
+    const sequence = beginMutation();
+    setBusyFacetKey(target.definition.facetKey);
     try {
       const configured = await client.configureIntegrationFacet(
         workspaceId,
-        data!.capabilityId,
-        data!.instanceKey,
-        editor.definition.facetKey,
+        currentData.capabilityId,
+        currentData.instanceKey,
+        target.definition.facetKey,
         {
-          displayName: `${instance.displayName} — ${facetTitle(editor.definition)}`,
-          config: facetConfigFromForm(editor.definition, form),
-          ...(editor.binding ? { expectedVersion: editor.binding.version } : {}),
+          displayName: `${instance.displayName} — ${facetTitle(target.definition)}`,
+          config: facetConfigFromForm(target.definition, form),
+          ...(target.binding ? { expectedVersion: target.binding.version } : {}),
           idempotencyKey: crypto.randomUUID(),
         },
       );
-      applyMutationBinding(editor.definition.facetKey, configured.binding);
+      if (!applyMutationBinding(sequence, target.definition.facetKey, configured.binding)) return;
       setEditor(null);
-      toast.success(`${facetTitle(editor.definition)} configured`, {
+      toast.success(`${facetTitle(target.definition)} configured`, {
         description: `This setting applies only to ${instance.displayName}.`,
       });
     } catch (saveError) {
+      if (sequence !== operationSequence.current) return;
       toast.error("Couldn't save this facet", {
         description: saveError instanceof Error ? saveError.message : String(saveError),
       });
     } finally {
-      setBusyFacetKey(null);
+      finishMutation(sequence);
     }
   }
 
   async function changeLifecycle(entry: FacetEntry, action: "pause" | "resume"): Promise<void> {
-    if (!entry.binding) return;
+    if (!entry.binding || !data) return;
+    const currentData = data;
+    const sequence = beginMutation();
     setBusyFacetKey(entry.definition.facetKey);
     try {
       const request = {
@@ -230,57 +254,63 @@ export function IntegrationFacetsPanel({
         action === "pause"
           ? await client.pauseIntegrationFacet(
               workspaceId,
-              data!.capabilityId,
-              data!.instanceKey,
+              currentData.capabilityId,
+              currentData.instanceKey,
               entry.definition.facetKey,
               request,
             )
           : await client.resumeIntegrationFacet(
               workspaceId,
-              data!.capabilityId,
-              data!.instanceKey,
+              currentData.capabilityId,
+              currentData.instanceKey,
               entry.definition.facetKey,
               request,
             );
-      applyMutationBinding(entry.definition.facetKey, result.binding);
+      if (!applyMutationBinding(sequence, entry.definition.facetKey, result.binding)) return;
       toast.success(`${facetTitle(entry.definition)} ${action === "pause" ? "paused" : "resumed"}`);
     } catch (lifecycleError) {
+      if (sequence !== operationSequence.current) return;
       toast.error(`Couldn't ${action} this facet`, {
         description:
           lifecycleError instanceof Error ? lifecycleError.message : String(lifecycleError),
       });
     } finally {
-      setBusyFacetKey(null);
+      finishMutation(sequence);
     }
   }
 
   async function remove(): Promise<boolean> {
     if (!removeTarget?.binding || !data) return false;
-    setBusyFacetKey(removeTarget.definition.facetKey);
+    const target = removeTarget;
+    const targetBinding = removeTarget.binding;
+    const currentData = data;
+    const sequence = beginMutation();
+    setBusyFacetKey(target.definition.facetKey);
     try {
       const result = await client.removeIntegrationFacet(
         workspaceId,
-        data.capabilityId,
-        data.instanceKey,
-        removeTarget.definition.facetKey,
+        currentData.capabilityId,
+        currentData.instanceKey,
+        target.definition.facetKey,
         {
-          expectedVersion: removeTarget.binding.version,
+          expectedVersion: targetBinding.version,
           idempotencyKey: crypto.randomUUID(),
         },
       );
-      applyMutationBinding(removeTarget.definition.facetKey, result.binding);
+      if (!applyMutationBinding(sequence, target.definition.facetKey, result.binding)) return false;
       setRemoveTarget(null);
-      toast.success(`${facetTitle(removeTarget.definition)} removed`, {
+      toast.success(`${facetTitle(target.definition)} removed`, {
         description: `${instance.displayName} and its Connection remain intact.`,
       });
       return true;
     } catch (removeError) {
+      if (sequence !== operationSequence.current) return false;
       toast.error("Couldn't remove this facet", {
         description: removeError instanceof Error ? removeError.message : String(removeError),
       });
       return false;
     } finally {
-      setBusyFacetKey(null);
+      finishMutation(sequence);
     }
   }
 
@@ -367,14 +397,23 @@ export function IntegrationFacetsPanel({
           canManageWorkspaceDestination={canManageWorkspaceDestination}
           canManageOrganizationDestination={canManageOrganizationDestination}
           onClose={() => setGoogleDriveEditor(null)}
-          onBusyChange={(busy) =>
-            setBusyFacetKey(
-              busy && googleDriveEditor ? googleDriveEditor.definition.facetKey : null,
-            )
-          }
-          onSaved={(binding) =>
-            applyMutationBinding(googleDriveEditor.definition.facetKey, binding)
-          }
+          onBusyChange={(busy) => {
+            if (busy) {
+              const sequence = beginMutation();
+              googleDriveMutationSequence.current = sequence;
+              setBusyFacetKey(googleDriveEditor.definition.facetKey);
+              return;
+            }
+            const sequence = googleDriveMutationSequence.current;
+            googleDriveMutationSequence.current = null;
+            if (sequence !== null) finishMutation(sequence);
+          }}
+          onSaved={(binding) => {
+            const sequence = googleDriveMutationSequence.current;
+            if (sequence !== null) {
+              applyMutationBinding(sequence, googleDriveEditor.definition.facetKey, binding);
+            }
+          }}
         />
       ) : null}
 

--- a/apps/web/src/components/capabilities/integration-facets-panel.tsx
+++ b/apps/web/src/components/capabilities/integration-facets-panel.tsx
@@ -41,6 +41,11 @@ import type {
 type FacetEntry = IntegrationInstanceFacetsResponse["facets"][number];
 type FormValue = string | boolean;
 type FacetFormState = Record<string, FormValue>;
+type FacetMutationToken = {
+  facetKey: string;
+  generation: number;
+  sequence: number;
+};
 type GoogleDriveDialogProps = {
   client: OpenGeniCoreClient;
   workspaceId: string;
@@ -110,23 +115,26 @@ export function IntegrationFacetsPanel({
   const [data, setData] = useState<IntegrationInstanceFacetsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [busyFacetKey, setBusyFacetKey] = useState<string | null>(null);
+  const [busyFacetKeys, setBusyFacetKeys] = useState<ReadonlySet<string>>(() => new Set());
   const [editor, setEditor] = useState<FacetEntry | null>(null);
   const [googleDriveEditor, setGoogleDriveEditor] = useState<FacetEntry | null>(null);
   const [form, setForm] = useState<FacetFormState>({});
   const [removeTarget, setRemoveTarget] = useState<FacetEntry | null>(null);
-  const operationSequence = useRef(0);
+  const operationGeneration = useRef(0);
+  const nextMutationSequence = useRef(0);
+  const mutationSequenceByFacet = useRef(new Map<string, number>());
   const loadPromise = useRef<Promise<void> | null>(null);
-  const googleDriveMutationSequence = useRef<number | null>(null);
+  const googleDriveMutationToken = useRef<FacetMutationToken | null>(null);
 
   useEffect(() => {
-    ++operationSequence.current;
+    ++operationGeneration.current;
+    mutationSequenceByFacet.current.clear();
     loadPromise.current = null;
-    googleDriveMutationSequence.current = null;
+    googleDriveMutationToken.current = null;
     setData(null);
     setLoading(false);
     setError(null);
-    setBusyFacetKey(null);
+    setBusyFacetKeys(new Set());
     setOpen(false);
     setEditor(null);
     setGoogleDriveEditor(null);
@@ -143,9 +151,10 @@ export function IntegrationFacetsPanel({
 
   async function load(): Promise<void> {
     if (loadPromise.current) return await loadPromise.current;
-    const sequence = ++operationSequence.current;
-    googleDriveMutationSequence.current = null;
-    setBusyFacetKey(null);
+    const generation = ++operationGeneration.current;
+    mutationSequenceByFacet.current.clear();
+    googleDriveMutationToken.current = null;
+    setBusyFacetKeys(new Set());
     const pending = (async () => {
       setLoading(true);
       try {
@@ -154,14 +163,14 @@ export function IntegrationFacetsPanel({
           instance.capabilityId,
           instance.instanceKey,
         );
-        if (sequence !== operationSequence.current) return;
+        if (generation !== operationGeneration.current) return;
         setData(response);
         setError(null);
       } catch (loadError) {
-        if (sequence !== operationSequence.current) return;
+        if (generation !== operationGeneration.current) return;
         setError(loadError instanceof Error ? loadError.message : String(loadError));
       } finally {
-        if (sequence === operationSequence.current) setLoading(false);
+        if (generation === operationGeneration.current) setLoading(false);
       }
     })();
     loadPromise.current = pending;
@@ -181,28 +190,43 @@ export function IntegrationFacetsPanel({
     setForm(facetFormState(entry.definition, entry.binding));
   }
 
-  function beginMutation(): number {
-    const sequence = ++operationSequence.current;
-    loadPromise.current = null;
-    googleDriveMutationSequence.current = null;
-    setLoading(false);
-    return sequence;
+  function beginMutation(facetKey: string): FacetMutationToken {
+    const token = {
+      facetKey,
+      generation: operationGeneration.current,
+      sequence: ++nextMutationSequence.current,
+    };
+    mutationSequenceByFacet.current.set(facetKey, token.sequence);
+    setBusyFacetKeys((current) => new Set(current).add(facetKey));
+    return token;
+  }
+
+  function isCurrentMutation(token: FacetMutationToken): boolean {
+    return (
+      token.generation === operationGeneration.current &&
+      mutationSequenceByFacet.current.get(token.facetKey) === token.sequence
+    );
   }
 
   function applyMutationBinding(
-    sequence: number,
-    facetKey: string,
+    token: FacetMutationToken,
     binding: IntegrationFacetBindingSummary | null,
   ): boolean {
-    if (sequence !== operationSequence.current) return false;
+    if (!isCurrentMutation(token)) return false;
     setData((current) =>
-      current ? replaceIntegrationFacetBinding(current, facetKey, binding) : current,
+      current ? replaceIntegrationFacetBinding(current, token.facetKey, binding) : current,
     );
     return true;
   }
 
-  function finishMutation(sequence: number): void {
-    if (sequence === operationSequence.current) setBusyFacetKey(null);
+  function finishMutation(token: FacetMutationToken): void {
+    if (!isCurrentMutation(token)) return;
+    mutationSequenceByFacet.current.delete(token.facetKey);
+    setBusyFacetKeys((current) => {
+      const next = new Set(current);
+      next.delete(token.facetKey);
+      return next;
+    });
   }
 
   async function save(event: FormEvent<HTMLFormElement>): Promise<void> {
@@ -210,8 +234,7 @@ export function IntegrationFacetsPanel({
     if (!editor || !data) return;
     const target = editor;
     const currentData = data;
-    const sequence = beginMutation();
-    setBusyFacetKey(target.definition.facetKey);
+    const token = beginMutation(target.definition.facetKey);
     try {
       const configured = await client.configureIntegrationFacet(
         workspaceId,
@@ -225,26 +248,25 @@ export function IntegrationFacetsPanel({
           idempotencyKey: crypto.randomUUID(),
         },
       );
-      if (!applyMutationBinding(sequence, target.definition.facetKey, configured.binding)) return;
+      if (!applyMutationBinding(token, configured.binding)) return;
       setEditor(null);
       toast.success(`${facetTitle(target.definition)} configured`, {
         description: `This setting applies only to ${instance.displayName}.`,
       });
     } catch (saveError) {
-      if (sequence !== operationSequence.current) return;
+      if (!isCurrentMutation(token)) return;
       toast.error("Couldn't save this facet", {
         description: saveError instanceof Error ? saveError.message : String(saveError),
       });
     } finally {
-      finishMutation(sequence);
+      finishMutation(token);
     }
   }
 
   async function changeLifecycle(entry: FacetEntry, action: "pause" | "resume"): Promise<void> {
     if (!entry.binding || !data) return;
     const currentData = data;
-    const sequence = beginMutation();
-    setBusyFacetKey(entry.definition.facetKey);
+    const token = beginMutation(entry.definition.facetKey);
     try {
       const request = {
         expectedVersion: entry.binding.version,
@@ -266,16 +288,16 @@ export function IntegrationFacetsPanel({
               entry.definition.facetKey,
               request,
             );
-      if (!applyMutationBinding(sequence, entry.definition.facetKey, result.binding)) return;
+      if (!applyMutationBinding(token, result.binding)) return;
       toast.success(`${facetTitle(entry.definition)} ${action === "pause" ? "paused" : "resumed"}`);
     } catch (lifecycleError) {
-      if (sequence !== operationSequence.current) return;
+      if (!isCurrentMutation(token)) return;
       toast.error(`Couldn't ${action} this facet`, {
         description:
           lifecycleError instanceof Error ? lifecycleError.message : String(lifecycleError),
       });
     } finally {
-      finishMutation(sequence);
+      finishMutation(token);
     }
   }
 
@@ -284,8 +306,7 @@ export function IntegrationFacetsPanel({
     const target = removeTarget;
     const targetBinding = removeTarget.binding;
     const currentData = data;
-    const sequence = beginMutation();
-    setBusyFacetKey(target.definition.facetKey);
+    const token = beginMutation(target.definition.facetKey);
     try {
       const result = await client.removeIntegrationFacet(
         workspaceId,
@@ -297,20 +318,20 @@ export function IntegrationFacetsPanel({
           idempotencyKey: crypto.randomUUID(),
         },
       );
-      if (!applyMutationBinding(sequence, target.definition.facetKey, result.binding)) return false;
+      if (!applyMutationBinding(token, result.binding)) return false;
       setRemoveTarget(null);
       toast.success(`${facetTitle(target.definition)} removed`, {
         description: `${instance.displayName} and its Connection remain intact.`,
       });
       return true;
     } catch (removeError) {
-      if (sequence !== operationSequence.current) return false;
+      if (!isCurrentMutation(token)) return false;
       toast.error("Couldn't remove this facet", {
         description: removeError instanceof Error ? removeError.message : String(removeError),
       });
       return false;
     } finally {
-      finishMutation(sequence);
+      finishMutation(token);
     }
   }
 
@@ -362,7 +383,7 @@ export function IntegrationFacetsPanel({
                 <FacetRow
                   key={entry.definition.facetKey}
                   entry={entry}
-                  busy={busyFacetKey === entry.definition.facetKey}
+                  busy={busyFacetKeys.has(entry.definition.facetKey)}
                   canManage={canManage}
                   onEdit={() => edit(entry)}
                   onPause={() => void changeLifecycle(entry, "pause")}
@@ -380,7 +401,7 @@ export function IntegrationFacetsPanel({
       <FacetEditorDialog
         entry={editor}
         form={form}
-        busy={editor ? busyFacetKey === editor.definition.facetKey : false}
+        busy={editor ? busyFacetKeys.has(editor.definition.facetKey) : false}
         onFormChange={(key, value) => setForm((current) => ({ ...current, [key]: value }))}
         onClose={() => setEditor(null)}
         onSubmit={save}
@@ -399,19 +420,19 @@ export function IntegrationFacetsPanel({
           onClose={() => setGoogleDriveEditor(null)}
           onBusyChange={(busy) => {
             if (busy) {
-              const sequence = beginMutation();
-              googleDriveMutationSequence.current = sequence;
-              setBusyFacetKey(googleDriveEditor.definition.facetKey);
+              googleDriveMutationToken.current = beginMutation(
+                googleDriveEditor.definition.facetKey,
+              );
               return;
             }
-            const sequence = googleDriveMutationSequence.current;
-            googleDriveMutationSequence.current = null;
-            if (sequence !== null) finishMutation(sequence);
+            const token = googleDriveMutationToken.current;
+            googleDriveMutationToken.current = null;
+            if (token !== null) finishMutation(token);
           }}
           onSaved={(binding) => {
-            const sequence = googleDriveMutationSequence.current;
-            if (sequence !== null) {
-              applyMutationBinding(sequence, googleDriveEditor.definition.facetKey, binding);
+            const token = googleDriveMutationToken.current;
+            if (token !== null) {
+              applyMutationBinding(token, binding);
             }
           }}
         />


### PR DESCRIPTION
## Summary

Current-main replacement for the stale pre-cutover UI lane in #1341, found again during the fresh-eyes OPE-16 / PR #1377 post-merge audit.

- apply authoritative configure, pause/resume, remove, and Google Drive facet mutation bindings immediately
- invalidate stale in-flight/single-flight facet-list responses after every successful mutation
- avoid refetching an eventually-consistent or already-settled list promise to determine mutation state
- add a DOM regression proving Pause renders `Paused` without a stale list refetch

## Finding

The Facet panel already applied generic configure results directly, but pause/resume and remove discarded their authoritative API results and called `load()` again. Google Drive save did the same through `onSaved={load}`. A stale or already-settled list request could therefore leave the panel rendering the pre-mutation status after the server had accepted the change.

PR #1341 documented the exact predecessor failure (`Pause` returned success while the panel stayed `Active`), but that branch targeted the removed Integration Feature surface and never merged. This PR carries the complete fix onto the authoritative Integration Facet model.

## Verification

- `bun run typecheck` — 31/31 projects clean
- targeted format and lint — clean
- 21 adjacent Capabilities UI tests — pass / 60 assertions
- new happy-dom lifecycle regression proves:
  - Pause result changes `Active` to `Paused`
  - no second/stale `listIntegrationFacets` call is used
- changeset status — no releases (private `opengeni-web` only)

No API, schema, provider, deployment, or live OAuth mutation is included.

Supersedes #1341.
