### PR TITLE
fix(release): retain source build runtime inputs

### DIFF
--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -411,6 +411,34 @@ jobs:
           bun install --frozen-lockfile
           bun run build:packages
 
+      - name: Download and verify source-bound artifact runtime inputs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+        run: |
+          set -euo pipefail
+          artifact_name="artifact-runtime-containers-${SOURCE_SHA}"
+          runtime_root=".release/artifact-runtime"
+          archive=".release/opengeni-artifact-runtime-${SOURCE_SHA}.tgz"
+          rm -rf "$runtime_root"
+          gh run download "$CANDIDATE_RUN_ID" \
+            --name "$artifact_name" \
+            --dir "$runtime_root"
+          for architecture in amd64 arm64; do
+            bun scripts/verify-artifact-runtime-container-inputs.ts \
+              --root "$GITHUB_WORKSPACE/$runtime_root" \
+              --source-sha "$SOURCE_SHA" \
+              --architecture "$architecture"
+          done
+          tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner \
+            -C .release -cf - artifact-runtime \
+            | gzip -n > "$archive"
+          printf '%s  %s\n' \
+            "$(sha256sum "$archive" | awk '{print $1}')" \
+            "$(basename "$archive")" \
+            > "${archive}.sha256"
+
       - name: Restore the controller after package preparation
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -620,7 +648,7 @@ jobs:
           )
           printf '%s  %s\n' \
             "$(sha256sum evidence/release-bom.json | awk '{print $1}')" \
-            evidence/release-bom.json \
+            release-bom.json \
             > evidence/release-bom.sha256
 
       - name: Compare an existing immutable distribution before image mutation
@@ -645,9 +673,15 @@ jobs:
               --dir .release/existing-release/assets \
               --pattern release-bom.json \
               --pattern release-bom.sha256 \
+              --pattern "opengeni-artifact-runtime-${SOURCE_SHA}.tgz" \
+              --pattern "opengeni-artifact-runtime-${SOURCE_SHA}.tgz.sha256" \
               --pattern "opengeni-${RELEASE_VERSION}.tgz"
             cmp evidence/release-bom.json .release/existing-release/assets/release-bom.json
             cmp evidence/release-bom.sha256 .release/existing-release/assets/release-bom.sha256
+            cmp ".release/opengeni-artifact-runtime-${SOURCE_SHA}.tgz" \
+              ".release/existing-release/assets/opengeni-artifact-runtime-${SOURCE_SHA}.tgz"
+            cmp ".release/opengeni-artifact-runtime-${SOURCE_SHA}.tgz.sha256" \
+              ".release/existing-release/assets/opengeni-artifact-runtime-${SOURCE_SHA}.tgz.sha256"
             cmp ".release/opengeni-${RELEASE_VERSION}.tgz" \
               ".release/existing-release/assets/opengeni-${RELEASE_VERSION}.tgz"
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -731,6 +765,8 @@ jobs:
             evidence/package-publication-verified.json
             evidence/release-packages-verified.json
             .release/opengeni-${{ steps.meta.outputs.version }}.tgz
+            .release/opengeni-artifact-runtime-${{ inputs.source_sha }}.tgz
+            .release/opengeni-artifact-runtime-${{ inputs.source_sha }}.tgz.sha256
           if-no-files-found: error
           retention-days: 90
 
@@ -754,9 +790,11 @@ jobs:
               evidence/release-bom.json \
               evidence/release-bom.sha256 \
               ".release/opengeni-${RELEASE_VERSION}.tgz" \
+              ".release/opengeni-artifact-runtime-${SOURCE_SHA}.tgz" \
+              ".release/opengeni-artifact-runtime-${SOURCE_SHA}.tgz.sha256" \
               --target "$SOURCE_SHA" \
               --title "OpenGeni embedded distribution ${RELEASE_VERSION} (${SOURCE_SHA::12})" \
-              --notes "Source-bound npm packages, Helm chart, images, and BOM for embedded consumers." \
+              --notes "Source-bound npm packages, Helm chart, images, native runtime build inputs, and BOM for embedded consumers." \
               --latest=false
           else
             echo "immutable distribution preflight produced an invalid state" >&2

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -938,7 +938,12 @@ caller-selected receipt URL or digest. The workflow re-runs the public package
 gates, verifies npm `gitHead` and integrity, publishes or reconciles the exact
 candidate chart, promotes the receipt's unchanged manifests to version and
 full-source-SHA tags, and writes one source-bound package/image/chart BOM. It
-deliberately does not create or update `latest`, and its immutable distribution
+also retains the candidate's verified amd64/arm64 native artifact-runtime inputs
+as `opengeni-artifact-runtime-<full-source-sha>.tgz` with a portable SHA-256
+sidecar. Source builders can therefore reproduce API, worker, materializer, and
+sandbox images after the short-lived Actions artifact expires without weakening
+the runtime integrity chain or rebuilding foreign-architecture binaries.
+It deliberately does not create or update `latest`, and its immutable distribution
 receipt makes no hosted Workbench, staging, production, or canary claim.
 
 An application-only embedded release additionally supplies the exact source SHA
@@ -1050,15 +1055,26 @@ byte for byte and fails instead of overwriting them. No moving BOM alias is
 created. Ordinary pushes to `main` can open/update the Version PR but cannot
 publish.
 
-The stock sandbox remains a separate workload image. The public release binds
-its immutable digest and its exact native artifact-runtime inputs to the same
-source SHA. Build it only with the verified `.release/artifact-runtime` bundle:
+The stock sandbox remains a separate workload image. The embedded public release
+binds its exact native artifact-runtime inputs to the same source SHA. Verify and
+extract that release asset so it creates `.release/artifact-runtime`, then build
+all source images only with that bundle:
 
 ```bash
+sha256sum --check "opengeni-artifact-runtime-${SOURCE_SHA}.tgz.sha256"
+tar -xzf "opengeni-artifact-runtime-${SOURCE_SHA}.tgz" -C .release
+
 docker build \
-  --build-arg OPENGENI_SOURCE_SHA="$(git rev-parse HEAD)" \
+  --build-arg OPENGENI_SERVER_VERSION="${SOURCE_SHA:0:12}" \
+  -f docker/opengeni.Dockerfile \
+  --target api \
+  -t opengeni-api:local-"${SOURCE_SHA:0:12}" \
+  .
+
+docker build \
+  --build-arg OPENGENI_SOURCE_SHA="$SOURCE_SHA" \
   -f docker/sandbox.Dockerfile \
-  -t opengeni-sandbox:local-"$(git rev-parse --short=12 HEAD)" \
+  -t opengeni-sandbox:local-"${SOURCE_SHA:0:12}" \
   .
 ```
 

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -740,8 +740,8 @@ describe("release image workflow contract", () => {
     expect(release).toContain('artifact_name="artifact-runtime-containers-${SOURCE_SHA}"');
     expect(release).toContain('gh run download "$CANDIDATE_RUN_ID"');
     expect(release).toContain('--source-sha "$SOURCE_SHA"');
-    expect(release).toContain('for architecture in amd64 arm64');
-    expect(release).toContain('opengeni-artifact-runtime-${SOURCE_SHA}.tgz');
+    expect(release).toContain("for architecture in amd64 arm64");
+    expect(release).toContain("opengeni-artifact-runtime-${SOURCE_SHA}.tgz");
     expect(release).toContain("--sort=name --mtime='UTC 1970-01-01'");
     expect(release).toContain('"$(basename "$archive")"');
     expect(release).toContain("release-bom.json \\");

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -710,6 +710,9 @@ describe("release image workflow contract", () => {
       "Restore the controller after package preparation",
     );
     const registryReconcile = release.indexOf("Reconcile npm package identity");
+    const runtimeInputs = release.indexOf(
+      "Download and verify source-bound artifact runtime inputs",
+    );
     const existingReleasePreflight = release.indexOf(
       "Compare an existing immutable distribution before image mutation",
     );
@@ -731,6 +734,17 @@ describe("release image workflow contract", () => {
     expect(sourceInstall).toBeGreaterThan(candidateReceipt);
     expect(sourceControllerRestore).toBeGreaterThan(sourceInstall);
     expect(packageControllerRestore).toBeGreaterThan(packagePreparation);
+    expect(runtimeInputs).toBeGreaterThan(packagePreparation);
+    expect(packageControllerRestore).toBeGreaterThan(runtimeInputs);
+    expect(existingReleasePreflight).toBeGreaterThan(runtimeInputs);
+    expect(release).toContain('artifact_name="artifact-runtime-containers-${SOURCE_SHA}"');
+    expect(release).toContain('gh run download "$CANDIDATE_RUN_ID"');
+    expect(release).toContain('--source-sha "$SOURCE_SHA"');
+    expect(release).toContain('for architecture in amd64 arm64');
+    expect(release).toContain('opengeni-artifact-runtime-${SOURCE_SHA}.tgz');
+    expect(release).toContain("--sort=name --mtime='UTC 1970-01-01'");
+    expect(release).toContain('"$(basename "$archive")"');
+    expect(release).toContain("release-bom.json \\");
     expect(release).toContain("--kind package");
     expect(release).toContain("CANDIDATE_ARTIFACT_ID:");
     expect(release).toContain("CANDIDATE_ARTIFACT_DIGEST:");


### PR DESCRIPTION
## Summary
- publish the candidate-verified native runtime inputs with immutable embedded releases
- preserve a deterministic archive and portable checksum for later exact-source image builds
- document the source-build path and enforce it in release workflow contracts

## Verification
- `bun test scripts/release-image-workflow-contract.test.ts scripts/artifact-runtime-workflow-contract.test.ts`
- `git diff --check`