### PR TITLE
Fix Insights hover alignment and nonnegative smoothing

### DIFF
--- a/apps/web/src/components/insights/charts.test.tsx
+++ b/apps/web/src/components/insights/charts.test.tsx
@@ -92,6 +92,27 @@ describe("AreaChart", () => {
       });
       expect(container.querySelectorAll("circle")).toHaveLength(180);
       expect(container.querySelectorAll("button").length).toBeLessThanOrEqual(8);
+
+      const slider = container.querySelector('[role="slider"]') as SVGSVGElement;
+      expect(slider.getAttribute("aria-valuemax")).toBe("179");
+      await act(async () => {
+        slider.focus();
+        slider.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+      });
+      expect(slider.getAttribute("aria-valuenow")).toBe("179");
+      expect(slider.getAttribute("aria-valuetext")).toBe("day-180. Tokens: 180");
+
+      await act(async () => {
+        slider.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+      });
+      expect(slider.getAttribute("aria-valuenow")).toBe("178");
+      expect(slider.getAttribute("aria-valuetext")).toBe("day-179. Tokens: 179");
+
+      await act(async () => {
+        slider.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+      });
+      expect(slider.getAttribute("aria-valuenow")).toBe("0");
+      expect(slider.getAttribute("aria-valuetext")).toBe("day-1. Tokens: 1.0");
     } finally {
       await act(async () => root.unmount());
       container.remove();
@@ -206,6 +227,11 @@ describe("AreaChart", () => {
       expect(band?.getAttribute("width")).toBe("672");
       expect(activeGuide?.getAttribute("x1")).toBe("372");
       expect(container.querySelector("circle")?.getAttribute("cx")).toBe("372");
+      expect(
+        container
+          .querySelector('[data-chart-tooltip="aligned"]')
+          ?.getAttribute("data-chart-tooltip-position"),
+      ).toBe("50");
     } finally {
       await act(async () => root.unmount());
       container.remove();
@@ -243,6 +269,51 @@ describe("AreaChart", () => {
 
       await act(async () => middleLabel.blur());
       expect(container.querySelector('[data-chart-hover-band="aligned"]')).toBeNull();
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("restores keyboard selection after pointer hover ends", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(
+          <AreaChart
+            labels={["00:00", "01:00", "02:00"]}
+            series={[
+              {
+                id: "tokens",
+                label: "Tokens",
+                values: [0, 1, 0],
+                className: "text-brand",
+              },
+            ]}
+          />,
+        );
+      });
+
+      const labels = container.querySelectorAll("button");
+      const middleLabel = labels[1] as HTMLButtonElement;
+      const firstLabel = labels[0] as HTMLButtonElement;
+      await act(async () => middleLabel.focus());
+      expect([...container.querySelectorAll("svg line")].at(-1)?.getAttribute("x1")).toBe("372");
+
+      await act(async () => {
+        firstLabel.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      });
+      expect([...container.querySelectorAll("svg line")].at(-1)?.getAttribute("x1")).toBe("36");
+
+      await act(async () => {
+        firstLabel.dispatchEvent(
+          new MouseEvent("mouseout", { bubbles: true, relatedTarget: container.firstElementChild }),
+        );
+      });
+      expect([...container.querySelectorAll("svg line")].at(-1)?.getAttribute("x1")).toBe("372");
+      expect(document.activeElement).toBe(middleLabel);
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/components/insights/charts.test.tsx
+++ b/apps/web/src/components/insights/charts.test.tsx
@@ -319,4 +319,49 @@ describe("AreaChart", () => {
       container.remove();
     }
   });
+
+  test("keyboard navigation takes ownership from a stationary pointer", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(
+          <AreaChart
+            labels={["00:00", "01:00", "02:00"]}
+            series={[
+              {
+                id: "tokens",
+                label: "Tokens",
+                values: [1, 2, 3],
+                className: "text-brand",
+              },
+            ]}
+          />,
+        );
+      });
+
+      const firstLabel = container.querySelector("button") as HTMLButtonElement;
+      const slider = container.querySelector('[role="slider"]') as SVGSVGElement;
+      await act(async () => {
+        firstLabel.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      });
+      expect([...container.querySelectorAll("svg line")].at(-1)?.getAttribute("x1")).toBe("36");
+
+      await act(async () => {
+        slider.focus();
+        slider.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+      });
+      expect(slider.getAttribute("aria-valuenow")).toBe("2");
+      expect(slider.getAttribute("aria-valuetext")).toBe("02:00. Tokens: 3.0");
+      expect([...container.querySelectorAll("svg line")].at(-1)?.getAttribute("x1")).toBe("708");
+      const tooltipTexts = [...container.querySelectorAll('[data-chart-tooltip="aligned"]')].map(
+        (tooltip) => tooltip.textContent,
+      );
+      expect(tooltipTexts.some((text) => text?.includes("02:00"))).toBe(true);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
 });

--- a/apps/web/src/components/insights/charts.test.tsx
+++ b/apps/web/src/components/insights/charts.test.tsx
@@ -30,7 +30,7 @@ afterAll(() => {
 });
 
 describe("AreaChart", () => {
-  test("keeps smoothing control points inside each nonnegative segment", () => {
+  test("keeps smoothing control points inside long zero runs around a spike", () => {
     const path = smoothLine([
       { x: 0, y: 10 },
       { x: 1, y: 10 },
@@ -38,6 +38,7 @@ describe("AreaChart", () => {
       { x: 3, y: 0 },
       { x: 4, y: 10 },
       { x: 5, y: 10 },
+      { x: 6, y: 10 },
     ]);
     const renderedY = [...path.matchAll(/-?\d+(?:\.\d+)?,(-?\d+(?:\.\d+)?)/g)].map((match) =>
       Number(match[1]),
@@ -129,7 +130,7 @@ describe("AreaChart", () => {
     }
   });
 
-  test("positions the hover band once instead of translating it a second time", async () => {
+  test("uses nearest-point hover cells without translating them a second time", async () => {
     const container = document.createElement("div");
     document.body.append(container);
     const root = createRoot(container);
@@ -151,14 +152,60 @@ describe("AreaChart", () => {
       });
 
       const labels = container.querySelectorAll("button");
+      for (const [index, expected] of [
+        [0, { x: "36", width: "168" }],
+        [1, { x: "204", width: "336" }],
+        [2, { x: "540", width: "168" }],
+      ] as const) {
+        await act(async () => {
+          labels[index]?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+        });
+
+        const band = container.querySelector('[data-chart-hover-band="aligned"]');
+        expect(band?.getAttribute("x")).toBe(expected.x);
+        expect(band?.getAttribute("width")).toBe(expected.width);
+        expect(band?.getAttribute("transform")).toBeNull();
+        expect(band?.getAttribute("style")).toBeNull();
+      }
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("centers a single bucket while highlighting the full plot", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    try {
       await act(async () => {
-        labels[1]?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+        root.render(
+          <AreaChart
+            labels={["00:00"]}
+            series={[
+              {
+                id: "tokens",
+                label: "Tokens",
+                values: [1],
+                className: "text-brand",
+              },
+            ]}
+          />,
+        );
+      });
+
+      await act(async () => {
+        container
+          .querySelector("button")
+          ?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
       });
 
       const band = container.querySelector('[data-chart-hover-band="aligned"]');
-      expect(band?.getAttribute("x")).toBe("260");
-      expect(band?.getAttribute("transform")).toBeNull();
-      expect(band?.getAttribute("style")).toBeNull();
+      const activeGuide = [...container.querySelectorAll("svg line")].at(-1);
+      expect(band?.getAttribute("x")).toBe("36");
+      expect(band?.getAttribute("width")).toBe("672");
+      expect(activeGuide?.getAttribute("x1")).toBe("372");
+      expect(container.querySelector("circle")?.getAttribute("cx")).toBe("372");
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/components/insights/charts.test.tsx
+++ b/apps/web/src/components/insights/charts.test.tsx
@@ -211,4 +211,41 @@ describe("AreaChart", () => {
       container.remove();
     }
   });
+
+  test("exposes point values and hover geometry to keyboard focus", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(
+          <AreaChart
+            labels={["00:00", "01:00", "02:00"]}
+            series={[
+              {
+                id: "tokens",
+                label: "Tokens",
+                values: [0, 1, 0],
+                className: "text-brand",
+              },
+            ]}
+          />,
+        );
+      });
+
+      const middleLabel = container.querySelectorAll("button")[1] as HTMLButtonElement;
+      expect(middleLabel.getAttribute("aria-label")).toBe("01:00. Tokens: 1.0");
+
+      await act(async () => middleLabel.focus());
+      expect(container.querySelector('[data-chart-hover-band="aligned"]')).not.toBeNull();
+      expect(container.textContent).toContain("Tokens");
+      expect(container.textContent).toContain("1.0");
+
+      await act(async () => middleLabel.blur());
+      expect(container.querySelector('[data-chart-hover-band="aligned"]')).toBeNull();
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
 });

--- a/apps/web/src/components/insights/charts.test.tsx
+++ b/apps/web/src/components/insights/charts.test.tsx
@@ -3,7 +3,7 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 
-import { AreaChart } from "./charts";
+import { AreaChart, smoothLine } from "./charts";
 
 beforeAll(() => {
   GlobalRegistrator.register();
@@ -30,6 +30,23 @@ afterAll(() => {
 });
 
 describe("AreaChart", () => {
+  test("keeps smoothing control points inside each nonnegative segment", () => {
+    const path = smoothLine([
+      { x: 0, y: 10 },
+      { x: 1, y: 10 },
+      { x: 2, y: 10 },
+      { x: 3, y: 0 },
+      { x: 4, y: 10 },
+      { x: 5, y: 10 },
+    ]);
+    const renderedY = [...path.matchAll(/-?\d+(?:\.\d+)?,(-?\d+(?:\.\d+)?)/g)].map((match) =>
+      Number(match[1]),
+    );
+
+    expect(Math.min(...renderedY)).toBeGreaterThanOrEqual(0);
+    expect(Math.max(...renderedY)).toBeLessThanOrEqual(10);
+  });
+
   test("renders an explicit empty state instead of building invalid SVG paths", async () => {
     const container = document.createElement("div");
     document.body.append(container);
@@ -106,6 +123,42 @@ describe("AreaChart", () => {
       expect(clipPath).not.toBeNull();
       expect(highlight?.getAttribute("clip-path")).toBe(`url(#${clipPath?.id})`);
       expect(container.querySelector("svg")?.classList.contains("overflow-hidden")).toBe(true);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("positions the hover band once instead of translating it a second time", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(
+          <AreaChart
+            labels={["00:00", "01:00", "02:00"]}
+            series={[
+              {
+                id: "tokens",
+                label: "Tokens",
+                values: [0, 1, 0],
+                className: "text-brand",
+              },
+            ]}
+          />,
+        );
+      });
+
+      const labels = container.querySelectorAll("button");
+      await act(async () => {
+        labels[1]?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      });
+
+      const band = container.querySelector('[data-chart-hover-band="aligned"]');
+      expect(band?.getAttribute("x")).toBe("260");
+      expect(band?.getAttribute("transform")).toBeNull();
+      expect(band?.getAttribute("style")).toBeNull();
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/apps/web/src/components/insights/charts.tsx
+++ b/apps/web/src/components/insights/charts.tsx
@@ -3,6 +3,7 @@ import {
   useId,
   useMemo,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
@@ -81,7 +82,9 @@ export function AreaChart(props: {
   const reduceMotion = useReducedMotion();
   const gradId = useId();
   const plotClipId = useId();
-  const [active, setActive] = useState<number | null>(null);
+  const [pointerActive, setPointerActive] = useState<number | null>(null);
+  const [keyboardActive, setKeyboardActive] = useState<number | null>(null);
+  const active = pointerActive ?? keyboardActive;
   const height = props.height ?? 220;
   const width = 720;
   const padL = 36;
@@ -119,14 +122,13 @@ export function AreaChart(props: {
     const localX = ((event.clientX - rect.left) / rect.width) * width;
     const ratio = (localX - padL) / innerW;
     const index = Math.round(ratio * (props.labels.length - 1));
-    setActive(Math.max(0, Math.min(props.labels.length - 1, index)));
+    setPointerActive(Math.max(0, Math.min(props.labels.length - 1, index)));
   };
 
-  const activeX =
-    active == null
-      ? null
-      : padL +
-        (props.labels.length === 1 ? innerW / 2 : (active / (props.labels.length - 1)) * innerW);
+  const activeRatio =
+    active == null ? null : props.labels.length === 1 ? 0.5 : active / (props.labels.length - 1);
+  const activeX = activeRatio == null ? null : padL + activeRatio * innerW;
+  const tooltipPositionPercent = (activeRatio ?? 0) * 100;
   const activeCell = (() => {
     if (active == null || activeX == null) return null;
     if (props.labels.length === 1) return { x: padL, width: innerW };
@@ -141,6 +143,21 @@ export function AreaChart(props: {
     props.formatValue
       ? props.formatValue(value)
       : `${props.valuePrefix ?? ""}${formatChartNumber(value, props.valueDigits)}${props.valueSuffix ?? ""}`;
+  const pointDescription = (index: number) =>
+    `${props.labels[index]}. ${props.series
+      .map((series) => `${series.label}: ${formattedValue(series.values[index] ?? 0)}`)
+      .join(", ")}`;
+  const onChartKeyDown = (event: ReactKeyboardEvent<SVGSVGElement>) => {
+    const current = keyboardActive ?? pointerActive ?? 0;
+    let next: number | null = null;
+    if (event.key === "ArrowLeft" || event.key === "ArrowDown") next = current - 1;
+    if (event.key === "ArrowRight" || event.key === "ArrowUp") next = current + 1;
+    if (event.key === "Home") next = 0;
+    if (event.key === "End") next = props.labels.length - 1;
+    if (next == null) return;
+    event.preventDefault();
+    setKeyboardActive(Math.max(0, Math.min(props.labels.length - 1, next)));
+  };
   const labelStride = Math.max(1, Math.ceil(props.labels.length / 6));
   const visibleLabels = props.labels
     .map((label, index) => ({ label, index }))
@@ -164,9 +181,7 @@ export function AreaChart(props: {
   return (
     <div
       className={cn("relative w-full", props.className)}
-      onPointerLeave={(event) => {
-        if (!event.currentTarget.contains(document.activeElement)) setActive(null);
-      }}
+      onPointerLeave={() => setPointerActive(null)}
     >
       <AnimatePresence>
         {active != null ? (
@@ -177,8 +192,10 @@ export function AreaChart(props: {
             exit={{ opacity: 0, y: 2 }}
             transition={{ duration: 0.15 }}
             className="pointer-events-none absolute top-0 z-10 min-w-[7.5rem] rounded-lg border border-border bg-surface-3/95 px-2.5 py-2 shadow-sm backdrop-blur-md"
+            data-chart-tooltip="aligned"
+            data-chart-tooltip-position={tooltipPositionPercent}
             style={{
-              left: `clamp(0px, calc(${(active / Math.max(props.labels.length - 1, 1)) * 100}% - 40px), calc(100% - 130px))`,
+              left: `clamp(0px, calc(${tooltipPositionPercent}% - 40px), calc(100% - 130px))`,
             }}
           >
             <p className="text-2xs font-medium text-fg-subtle">{props.labels[active]}</p>
@@ -202,8 +219,17 @@ export function AreaChart(props: {
       <svg
         viewBox={`0 0 ${width} ${height}`}
         className="h-auto w-full cursor-crosshair overflow-hidden"
-        role="img"
+        role="slider"
         aria-label="Trend chart"
+        aria-orientation="horizontal"
+        aria-valuemin={0}
+        aria-valuemax={props.labels.length - 1}
+        aria-valuenow={keyboardActive ?? pointerActive ?? 0}
+        aria-valuetext={pointDescription(keyboardActive ?? pointerActive ?? 0)}
+        tabIndex={0}
+        onFocus={() => setKeyboardActive((current) => current ?? pointerActive ?? 0)}
+        onBlur={() => setKeyboardActive(null)}
+        onKeyDown={onChartKeyDown}
         onPointerMove={onMove}
       >
         <defs>
@@ -337,13 +363,12 @@ export function AreaChart(props: {
           <button
             key={`${label}-${index}`}
             type="button"
-            onMouseEnter={() => setActive(index)}
-            onFocus={() => setActive(index)}
-            onClick={() => setActive(index)}
-            onBlur={() => setActive(null)}
-            aria-label={`${label}. ${props.series
-              .map((series) => `${series.label}: ${formattedValue(series.values[index] ?? 0)}`)
-              .join(", ")}`}
+            onMouseEnter={() => setPointerActive(index)}
+            onMouseLeave={() => setPointerActive(null)}
+            onFocus={() => setKeyboardActive(index)}
+            onClick={() => setKeyboardActive(index)}
+            onBlur={() => setKeyboardActive(null)}
+            aria-label={pointDescription(index)}
             className={cn(
               "min-w-0 truncate text-2xs transition-colors",
               active === index ? "font-medium text-fg" : "text-fg-subtle",

--- a/apps/web/src/components/insights/charts.tsx
+++ b/apps/web/src/components/insights/charts.tsx
@@ -38,7 +38,7 @@ export function donutTone(index: number): string {
   return DONUT_TONES[index % DONUT_TONES.length]!;
 }
 
-function smoothLine(points: Array<{ x: number; y: number }>): string {
+export function smoothLine(points: Array<{ x: number; y: number }>): string {
   if (points.length === 0) return "";
   if (points.length === 1) return `M${points[0]!.x},${points[0]!.y}`;
   let d = `M${points[0]!.x},${points[0]!.y}`;
@@ -48,9 +48,11 @@ function smoothLine(points: Array<{ x: number; y: number }>): string {
     const p2 = points[i + 1]!;
     const p3 = points[i + 2] ?? p2;
     const cp1x = p1.x + (p2.x - p0.x) / 6;
-    const cp1y = p1.y + (p2.y - p0.y) / 6;
+    const minSegmentY = Math.min(p1.y, p2.y);
+    const maxSegmentY = Math.max(p1.y, p2.y);
+    const cp1y = Math.max(minSegmentY, Math.min(maxSegmentY, p1.y + (p2.y - p0.y) / 6));
     const cp2x = p2.x - (p3.x - p1.x) / 6;
-    const cp2y = p2.y - (p3.y - p1.y) / 6;
+    const cp2y = Math.max(minSegmentY, Math.min(maxSegmentY, p2.y - (p3.y - p1.y) / 6));
     d += ` C${cp1x},${cp1y} ${cp2x},${cp2y} ${p2.x},${p2.y}`;
   }
   return d;
@@ -242,15 +244,13 @@ export function AreaChart(props: {
 
         <g clipPath={`url(#${plotClipId})`} data-chart-plot-highlight="clipped">
           {activeX != null ? (
-            <motion.rect
+            <rect
               x={activeX - innerW / props.labels.length / 2}
               y={padTop}
               width={Math.max(innerW / props.labels.length, 12)}
               height={innerH}
               className="fill-fg/[0.04]"
-              initial={false}
-              animate={{ x: activeX - innerW / props.labels.length / 2 }}
-              transition={{ type: "spring", stiffness: 380, damping: 36 }}
+              data-chart-hover-band="aligned"
             />
           ) : null}
         </g>

--- a/apps/web/src/components/insights/charts.tsx
+++ b/apps/web/src/components/insights/charts.tsx
@@ -123,7 +123,18 @@ export function AreaChart(props: {
   };
 
   const activeX =
-    active == null ? null : padL + (active / Math.max(props.labels.length - 1, 1)) * innerW;
+    active == null
+      ? null
+      : padL +
+        (props.labels.length === 1 ? innerW / 2 : (active / (props.labels.length - 1)) * innerW);
+  const activeCell = (() => {
+    if (active == null || activeX == null) return null;
+    if (props.labels.length === 1) return { x: padL, width: innerW };
+    const pointSpacing = innerW / (props.labels.length - 1);
+    const left = active === 0 ? padL : activeX - pointSpacing / 2;
+    const right = active === props.labels.length - 1 ? padL + innerW : activeX + pointSpacing / 2;
+    return { x: left, width: right - left };
+  })();
 
   const ticks = [0, 0.5, 1];
   const formattedValue = (value: number) =>
@@ -243,11 +254,11 @@ export function AreaChart(props: {
         })}
 
         <g clipPath={`url(#${plotClipId})`} data-chart-plot-highlight="clipped">
-          {activeX != null ? (
+          {activeCell != null ? (
             <rect
-              x={activeX - innerW / props.labels.length / 2}
+              x={activeCell.x}
               y={padTop}
-              width={Math.max(innerW / props.labels.length, 12)}
+              width={activeCell.width}
               height={innerH}
               className="fill-fg/[0.04]"
               data-chart-hover-band="aligned"

--- a/apps/web/src/components/insights/charts.tsx
+++ b/apps/web/src/components/insights/charts.tsx
@@ -156,6 +156,7 @@ export function AreaChart(props: {
     if (event.key === "End") next = props.labels.length - 1;
     if (next == null) return;
     event.preventDefault();
+    setPointerActive(null);
     setKeyboardActive(Math.max(0, Math.min(props.labels.length - 1, next)));
   };
   const labelStride = Math.max(1, Math.ceil(props.labels.length / 6));
@@ -227,7 +228,10 @@ export function AreaChart(props: {
         aria-valuenow={keyboardActive ?? pointerActive ?? 0}
         aria-valuetext={pointDescription(keyboardActive ?? pointerActive ?? 0)}
         tabIndex={0}
-        onFocus={() => setKeyboardActive((current) => current ?? pointerActive ?? 0)}
+        onFocus={() => {
+          setKeyboardActive((current) => current ?? pointerActive ?? 0);
+          setPointerActive(null);
+        }}
         onBlur={() => setKeyboardActive(null)}
         onKeyDown={onChartKeyDown}
         onPointerMove={onMove}
@@ -365,7 +369,10 @@ export function AreaChart(props: {
             type="button"
             onMouseEnter={() => setPointerActive(index)}
             onMouseLeave={() => setPointerActive(null)}
-            onFocus={() => setKeyboardActive(index)}
+            onFocus={() => {
+              setPointerActive(null);
+              setKeyboardActive(index);
+            }}
             onClick={() => setKeyboardActive(index)}
             onBlur={() => setKeyboardActive(null)}
             aria-label={pointDescription(index)}

--- a/apps/web/src/components/insights/charts.tsx
+++ b/apps/web/src/components/insights/charts.tsx
@@ -162,7 +162,12 @@ export function AreaChart(props: {
   }
 
   return (
-    <div className={cn("relative w-full", props.className)} onPointerLeave={() => setActive(null)}>
+    <div
+      className={cn("relative w-full", props.className)}
+      onPointerLeave={(event) => {
+        if (!event.currentTarget.contains(document.activeElement)) setActive(null);
+      }}
+    >
       <AnimatePresence>
         {active != null ? (
           <motion.div
@@ -333,6 +338,12 @@ export function AreaChart(props: {
             key={`${label}-${index}`}
             type="button"
             onMouseEnter={() => setActive(index)}
+            onFocus={() => setActive(index)}
+            onClick={() => setActive(index)}
+            onBlur={() => setActive(null)}
+            aria-label={`${label}. ${props.series
+              .map((series) => `${series.label}: ${formattedValue(series.values[index] ?? 0)}`)
+              .join(", ")}`}
             className={cn(
               "min-w-0 truncate text-2xs transition-colors",
               active === index ? "font-medium text-fg" : "text-fg-subtle",


### PR DESCRIPTION
## Summary
- remove the duplicate SVG x transform that made the hover band move faster than the pointer
- constrain cubic smoothing control points to each nonnegative segment so token and cache curves cannot overshoot below zero
- add focused regressions for both rendering defects

This is a follow-up to #1409.

## Verification
- bun test apps/web/src/components/insights/charts.test.tsx
- bun run --cwd apps/web typecheck
- oxfmt and oxlint on touched files
- browser verification against the local Today Insights chart

Linear: OPE-240