### PR TITLE
Add compact session browse filters and grouping

### DIFF
--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -98,8 +98,7 @@ import {
   groupSessionsForRail,
   mergeSessionForRail,
   relativeTimeLabel,
-  sessionCreatorKey,
-  sessionCreatorLabel,
+  sessionCreatorOptions,
   visibleForestRows,
   visibleTreeRows,
   type SessionTreeNode,
@@ -335,13 +334,7 @@ export function SessionList() {
     return [...source.values()];
   }, [pinOverrides, serverSessions]);
   const creatorOptions = useMemo(() => {
-    const byKey = new Map<string, string>();
-    for (const session of allSessions) {
-      byKey.set(sessionCreatorKey(session), sessionCreatorLabel(session));
-    }
-    return [...byKey.entries()]
-      .map(([value, label]) => ({ value, label }))
-      .sort((left, right) => left.label.localeCompare(right.label));
+    return sessionCreatorOptions(allSessions);
   }, [allSessions]);
   const browseSessions = useMemo(
     () =>
@@ -1181,7 +1174,7 @@ export function SessionList() {
                     : "Anyone"}
                 </span>
               </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="w-52">
+              <DropdownMenuSubContent className="max-h-(--radix-dropdown-menu-content-available-height) w-52 overflow-x-hidden overflow-y-auto">
                 <DropdownMenuRadioGroup
                   value={browseCreator ?? "all"}
                   onValueChange={(value) => setBrowseCreator(value === "all" ? null : value)}

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -98,7 +98,7 @@ import {
   groupSessionsForRail,
   mergeSessionForRail,
   relativeTimeLabel,
-  sessionCreatorOptions,
+  sessionCreatorLabelMap,
   visibleForestRows,
   visibleTreeRows,
   type SessionTreeNode,
@@ -333,9 +333,10 @@ export function SessionList() {
     }
     return [...source.values()];
   }, [pinOverrides, serverSessions]);
+  const creatorLabels = useMemo(() => sessionCreatorLabelMap(allSessions), [allSessions]);
   const creatorOptions = useMemo(() => {
-    return sessionCreatorOptions(allSessions);
-  }, [allSessions]);
+    return [...creatorLabels].map(([value, label]) => ({ value, label }));
+  }, [creatorLabels]);
   const browseSessions = useMemo(
     () =>
       filterSessionsForBrowse(allSessions, {
@@ -525,8 +526,9 @@ export function SessionList() {
         : groupSessionsForBrowse(
             browseSessions.filter((session) => !session.pinned),
             browseGroupBy,
+            { creatorLabels },
           ),
-    [browseGroupBy, browseSessions, railSections.ordinary],
+    [browseGroupBy, browseSessions, creatorLabels, railSections.ordinary],
   );
   const pinnedNodes = railSections.pinned;
   const channelMode = hierarchyMode && channels.length > 0;

--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -16,6 +16,7 @@ import {
   HashIcon,
   InboxIcon,
   LocateFixedIcon,
+  ListFilterIcon,
   MessagesSquareIcon,
   PencilIcon,
   PinIcon,
@@ -47,7 +48,12 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ChannelCreateDialog } from "@/components/rail/channel-create-dialog";
@@ -87,12 +93,19 @@ import {
 import {
   buildPinnedRailSections,
   channelRailSections,
+  filterSessionsForBrowse,
+  groupSessionsForBrowse,
   groupSessionsForRail,
   mergeSessionForRail,
   relativeTimeLabel,
+  sessionCreatorKey,
+  sessionCreatorLabel,
   visibleForestRows,
   visibleTreeRows,
   type SessionTreeNode,
+  type SessionBrowseDateField,
+  type SessionBrowseDateRange,
+  type SessionBrowseGroupBy,
 } from "@/lib/sessions-group";
 import { creatorHue, creatorInitials } from "@/lib/creator-initials";
 import { sessionDescendantCountAria, sessionDescendantCountText } from "@/lib/session-tree-count";
@@ -161,11 +174,23 @@ export function SessionList() {
   // refresh; the previous index relied on a one-shot load.
   const [searchDraft, setSearchDraft] = useState("");
   const [search, setSearch] = useState("");
+  const [browseGroupBy, setBrowseGroupBy] = useState<SessionBrowseGroupBy>("activity");
+  const [browseDateField, setBrowseDateField] = useState<SessionBrowseDateField>("activity");
+  const [browseDateRange, setBrowseDateRange] = useState<SessionBrowseDateRange>("any");
+  const [browseCreator, setBrowseCreator] = useState<string | null>(null);
   useEffect(() => {
     const timer = window.setTimeout(() => setSearch(searchDraft.trim()), 200);
     return () => window.clearTimeout(timer);
   }, [searchDraft]);
-  const hierarchyMode = search.length === 0;
+  const browseControlsActive =
+    browseGroupBy !== "activity" || browseDateRange !== "any" || browseCreator !== null;
+  const hierarchyMode = search.length === 0 && !browseControlsActive;
+  const clearBrowseControls = useCallback(() => {
+    setBrowseGroupBy("activity");
+    setBrowseDateField("activity");
+    setBrowseDateRange("any");
+    setBrowseCreator(null);
+  }, []);
   const rootPage = useWorkspaceSessions({
     limit: 50,
     search,
@@ -209,10 +234,14 @@ export function SessionList() {
   // Ordinary rows page independently of the complete pinned section. The
   // polled hook owns page one; additional pages are appended and deduplicated.
   // A filter change starts a fresh cursor chain rather than mixing snapshots.
-  // The continuation generation is keyed only to workspace/search. Polling
-  // page one rotates the server's short-lived snapshot, but must not discard
-  // older pages the user already loaded from the prior snapshot.
-  const paginationKey = sessionPageKey(rail.workspaceId, search);
+  // The continuation generation is keyed to workspace/search and whether the
+  // projection is a root hierarchy or flat browse. Polling page one rotates
+  // the server's short-lived snapshot, but must not discard older pages the
+  // user already loaded from the prior snapshot.
+  const paginationKey = sessionPageKey(
+    rail.workspaceId,
+    `${search}\n${hierarchyMode ? "tree" : "browse"}`,
+  );
   const paginationIdentity = useRef({ key: paginationKey, generation: 0 });
   paginationIdentity.current = advanceSessionPageIdentity(
     paginationIdentity.current,
@@ -305,6 +334,24 @@ export function SessionList() {
     }
     return [...source.values()];
   }, [pinOverrides, serverSessions]);
+  const creatorOptions = useMemo(() => {
+    const byKey = new Map<string, string>();
+    for (const session of allSessions) {
+      byKey.set(sessionCreatorKey(session), sessionCreatorLabel(session));
+    }
+    return [...byKey.entries()]
+      .map(([value, label]) => ({ value, label }))
+      .sort((left, right) => left.label.localeCompare(right.label));
+  }, [allSessions]);
+  const browseSessions = useMemo(
+    () =>
+      filterSessionsForBrowse(allSessions, {
+        creator: browseCreator,
+        dateField: browseDateField,
+        dateRange: browseDateRange,
+      }),
+    [allSessions, browseCreator, browseDateField, browseDateRange],
+  );
 
   // A complete pins-only page makes presence authoritative, but absence does
   // not carry the version of a remotely unpinned relation. Loaded child pages
@@ -473,12 +520,21 @@ export function SessionList() {
     () =>
       buildPinnedRailSections(
         hierarchyMode
-          ? allSessions
-          : allSessions.map((session) => ({ ...session, parentSessionId: null })),
+          ? browseSessions
+          : browseSessions.map((session) => ({ ...session, parentSessionId: null })),
       ),
-    [allSessions, hierarchyMode],
+    [browseSessions, hierarchyMode],
   );
-  const forest = railSections.ordinary;
+  const forest = useMemo(
+    () =>
+      browseGroupBy === "activity"
+        ? railSections.ordinary
+        : groupSessionsForBrowse(
+            browseSessions.filter((session) => !session.pinned),
+            browseGroupBy,
+          ),
+    [browseGroupBy, browseSessions, railSections.ordinary],
+  );
   const pinnedNodes = railSections.pinned;
   const channelMode = hierarchyMode && channels.length > 0;
   const channelSections = useMemo(
@@ -991,16 +1047,16 @@ export function SessionList() {
   }, [flat, focusIndex]);
 
   useEffect(() => {
-    if (loading || !search) return;
-    const count = allSessions.length;
+    if (loading || (!search && !browseControlsActive)) return;
+    const count = browseSessions.length;
     setAnnouncement(`${count} matching session${count === 1 ? "" : "s"}.`);
-  }, [allSessions.length, loading, search]);
+  }, [browseControlsActive, browseSessions.length, loading, search]);
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       <div className="flex min-w-0 items-center justify-between gap-2 px-3 pb-1 pt-1">
         <span className="text-2xs font-semibold uppercase tracking-wider text-fg-muted">
-          {hierarchyMode ? "Workstreams" : "Search results"}
+          {hierarchyMode ? "Workstreams" : search ? "Search results" : "Browse sessions"}
         </span>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -1021,33 +1077,142 @@ export function SessionList() {
         </Tooltip>
       </div>
 
-      <label className="relative mx-2 mb-1 block shrink-0">
-        <span className="sr-only">Search sessions</span>
-        <SearchIcon
-          aria-hidden="true"
-          className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-fg-subtle"
-        />
-        <input
-          type="search"
-          value={searchDraft}
-          onChange={(event) => setSearchDraft(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === "Escape" && searchDraft) {
-              event.preventDefault();
-              setSearchDraft("");
-            }
-          }}
-          maxLength={200}
-          placeholder="Search"
-          aria-label="Search sessions"
-          className="h-7 w-full min-w-0 rounded-md border border-border bg-bg/45 pl-7 pr-2 text-xs text-fg outline-none placeholder:text-fg-subtle hover:border-border-strong focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/40 pointer-coarse:h-11 pointer-coarse:text-base"
-        />
-      </label>
+      <div className="mx-2 mb-1 flex shrink-0 items-center gap-1">
+        <label className="relative min-w-0 flex-1">
+          <span className="sr-only">Search sessions</span>
+          <SearchIcon
+            aria-hidden="true"
+            className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-fg-subtle"
+          />
+          <input
+            type="search"
+            value={searchDraft}
+            onChange={(event) => setSearchDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape" && searchDraft) {
+                event.preventDefault();
+                setSearchDraft("");
+              }
+            }}
+            maxLength={200}
+            placeholder="Search"
+            aria-label="Search sessions"
+            className="h-7 w-full min-w-0 rounded-md border border-border bg-bg/45 pl-7 pr-2 text-xs text-fg outline-none placeholder:text-fg-subtle hover:border-border-strong focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/40 pointer-coarse:h-11 pointer-coarse:text-base"
+          />
+        </label>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={browseControlsActive ? "Session filters, active" : "Session filters"}
+              className={cn(
+                "relative shrink-0 text-fg-muted hover:text-fg pointer-coarse:size-11",
+                browseControlsActive && "bg-surface-2 text-fg",
+              )}
+            >
+              <ListFilterIcon className="size-3.5" />
+              {browseControlsActive ? (
+                <span className="absolute right-0.5 top-0.5 size-1.5 rounded-full bg-brand" />
+              ) : null}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuLabel>Group sessions</DropdownMenuLabel>
+            <DropdownMenuRadioGroup
+              value={browseGroupBy}
+              onValueChange={(value) => setBrowseGroupBy(value as SessionBrowseGroupBy)}
+            >
+              <DropdownMenuRadioItem value="activity">Last activity</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="created">Created date</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="creator">Creator</DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                Date field
+                <span className="ml-auto mr-1 text-2xs text-fg-subtle">
+                  {browseDateField === "activity" ? "Activity" : "Created"}
+                </span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-44">
+                <DropdownMenuRadioGroup
+                  value={browseDateField}
+                  onValueChange={(value) => setBrowseDateField(value as SessionBrowseDateField)}
+                >
+                  <DropdownMenuRadioItem value="activity">Last activity</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="created">Created date</DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                Date range
+                <span className="ml-auto mr-1 text-2xs text-fg-subtle">
+                  {browseDateRange === "any"
+                    ? "Any"
+                    : browseDateRange === "today"
+                      ? "Today"
+                      : browseDateRange === "week"
+                        ? "7d"
+                        : "30d"}
+                </span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-40">
+                <DropdownMenuRadioGroup
+                  value={browseDateRange}
+                  onValueChange={(value) => setBrowseDateRange(value as SessionBrowseDateRange)}
+                >
+                  <DropdownMenuRadioItem value="any">Any time</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="today">Today</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="week">Last 7 days</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="month">Last 30 days</DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                Creator
+                <span className="ml-auto mr-1 max-w-20 truncate text-2xs text-fg-subtle">
+                  {browseCreator
+                    ? (creatorOptions.find((option) => option.value === browseCreator)?.label ??
+                      "Selected")
+                    : "Anyone"}
+                </span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-52">
+                <DropdownMenuRadioGroup
+                  value={browseCreator ?? "all"}
+                  onValueChange={(value) => setBrowseCreator(value === "all" ? null : value)}
+                >
+                  <DropdownMenuRadioItem value="all">Anyone</DropdownMenuRadioItem>
+                  {creatorOptions.map((option) => (
+                    <DropdownMenuRadioItem key={option.value} value={option.value}>
+                      <span className="truncate">{option.label}</span>
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            {browseControlsActive ? (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={clearBrowseControls}>Reset view</DropdownMenuItem>
+              </>
+            ) : null}
+            <DropdownMenuSeparator />
+            <p className="px-2 py-1 text-2xs leading-4 text-fg-subtle">
+              Filters cover loaded sessions. Load older sessions to extend the result set.
+            </p>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
 
       <div
         ref={listRef}
         role="region"
-        aria-label={hierarchyMode ? "Workstreams" : "Session search results"}
+        aria-label={hierarchyMode ? "Workstreams" : search ? "Session search results" : "Sessions"}
         data-sessionpin-session-list
         onKeyDown={onKeyDown}
         onPointerDown={() => {
@@ -1084,15 +1249,28 @@ export function SessionList() {
               Retry
             </button>
           </div>
-        ) : flat.length === 0 && search ? (
+        ) : flat.length === 0 && (search || browseControlsActive) ? (
           <div className="px-2 py-4 text-center text-xs text-fg-subtle">
-            <p>No matching sessions.</p>
+            <p>No sessions match this view.</p>
+            {continuationCursor ? (
+              <button
+                type="button"
+                disabled={loadingMore}
+                onClick={() => void loadMore()}
+                className="mt-2 min-h-8 rounded px-2 font-medium text-fg-muted hover:bg-surface-2 hover:text-fg disabled:opacity-60 pointer-coarse:min-h-11"
+              >
+                {loadingMore ? "Loading…" : "Load older sessions"}
+              </button>
+            ) : null}
             <button
               type="button"
               className="mt-2 min-h-8 rounded px-2 underline hover:text-fg pointer-coarse:min-h-11"
-              onClick={() => setSearchDraft("")}
+              onClick={() => {
+                setSearchDraft("");
+                clearBrowseControls();
+              }}
             >
-              Clear search
+              Clear search and filters
             </button>
           </div>
         ) : flat.length === 0 ? (

--- a/apps/web/src/lib/session-browse.test.ts
+++ b/apps/web/src/lib/session-browse.test.ts
@@ -5,6 +5,7 @@ import {
   filterSessionsForBrowse,
   groupSessionsForBrowse,
   sessionCreatorLabel,
+  sessionCreatorOptions,
 } from "./sessions-group";
 
 const NOW = new Date("2026-08-14T12:00:00.000Z");
@@ -86,5 +87,36 @@ describe("session browse projections", () => {
     expect(
       groupSessionsForBrowse([grace, ada], "created", NOW).grouped.map((g) => g.label),
     ).toEqual(["Created today", "Created earlier"]);
+  });
+
+  test("disambiguates duplicate frozen creator labels with opaque identities", () => {
+    const firstAlex = session({
+      id: "first-alex",
+      createdBy: { kind: "subject", subjectId: "tenant-a:alex", label: "Alex" },
+    });
+    const secondAlex = session({
+      id: "second-alex",
+      createdBy: { kind: "subject", subjectId: "tenant-b:alex", label: "Alex" },
+    });
+
+    expect(sessionCreatorOptions([firstAlex, secondAlex])).toEqual([
+      { value: "subject:tenant-a:alex", label: "Alex · Subject · tenant-a:alex" },
+      { value: "subject:tenant-b:alex", label: "Alex · Subject · tenant-b:alex" },
+    ]);
+    expect(
+      groupSessionsForBrowse([firstAlex, secondAlex], "creator", NOW).grouped.map((group) => ({
+        key: group.group,
+        label: group.label,
+      })),
+    ).toEqual([
+      {
+        key: "creator:subject:tenant-a:alex",
+        label: "Alex · Subject · tenant-a:alex",
+      },
+      {
+        key: "creator:subject:tenant-b:alex",
+        label: "Alex · Subject · tenant-b:alex",
+      },
+    ]);
   });
 });

--- a/apps/web/src/lib/session-browse.test.ts
+++ b/apps/web/src/lib/session-browse.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import type { Session } from "@/types";
+
+import {
+  filterSessionsForBrowse,
+  groupSessionsForBrowse,
+  sessionCreatorLabel,
+} from "./sessions-group";
+
+const NOW = new Date("2026-08-14T12:00:00.000Z");
+
+function session(overrides: Partial<Session> & { id: string }): Session {
+  const { id, ...rest } = overrides;
+  return {
+    status: "idle",
+    createdAt: "2026-08-01T12:00:00.000Z",
+    updatedAt: "2026-08-14T10:00:00.000Z",
+    pinned: false,
+    createdBy: { kind: "subject", subjectId: "user:ada", label: "Ada Lovelace" },
+    ...rest,
+    id,
+  } as Session;
+}
+
+describe("session browse projections", () => {
+  test("filters the selected date field without confusing creation and activity", () => {
+    const recentlyActive = session({ id: "recently-active" });
+    const recentlyCreated = session({
+      id: "recently-created",
+      createdAt: "2026-08-14T09:00:00.000Z",
+      updatedAt: "2026-08-14T09:00:00.000Z",
+    });
+
+    expect(
+      filterSessionsForBrowse([recentlyActive, recentlyCreated], {
+        creator: null,
+        dateField: "created",
+        dateRange: "today",
+        now: NOW,
+      }).map((item) => item.id),
+    ).toEqual(["recently-created"]);
+    expect(
+      filterSessionsForBrowse([recentlyActive, recentlyCreated], {
+        creator: null,
+        dateField: "activity",
+        dateRange: "today",
+        now: NOW,
+      }).map((item) => item.id),
+    ).toEqual(["recently-active", "recently-created"]);
+  });
+
+  test("filters by the frozen creator identity and keeps display labels separate", () => {
+    const ada = session({ id: "ada" });
+    const scheduler = session({
+      id: "scheduler",
+      createdBy: { kind: "service", subjectId: "service:scheduler" },
+    });
+
+    expect(
+      filterSessionsForBrowse([ada, scheduler], {
+        creator: "service:service:scheduler",
+        dateField: "activity",
+        dateRange: "any",
+        now: NOW,
+      }).map((item) => item.id),
+    ).toEqual(["scheduler"]);
+    expect(sessionCreatorLabel(scheduler)).toBe("Service · scheduler");
+  });
+
+  test("groups flat browse results by creator or created-date buckets", () => {
+    const ada = session({ id: "ada" });
+    const grace = session({
+      id: "grace",
+      createdAt: "2026-08-14T08:00:00.000Z",
+      createdBy: { kind: "subject", subjectId: "user:grace", label: "Grace Hopper" },
+    });
+
+    expect(
+      groupSessionsForBrowse([grace, ada], "creator", NOW).grouped.map((g) => g.label),
+    ).toEqual(["Ada Lovelace", "Grace Hopper"]);
+    expect(
+      groupSessionsForBrowse([grace, ada], "created", NOW).grouped.map((g) => g.label),
+    ).toEqual(["Created today", "Created earlier"]);
+  });
+});

--- a/apps/web/src/lib/session-browse.test.ts
+++ b/apps/web/src/lib/session-browse.test.ts
@@ -4,6 +4,7 @@ import type { Session } from "@/types";
 import {
   filterSessionsForBrowse,
   groupSessionsForBrowse,
+  sessionCreatorLabelMap,
   sessionCreatorLabel,
   sessionCreatorOptions,
 } from "./sessions-group";
@@ -82,10 +83,10 @@ describe("session browse projections", () => {
     });
 
     expect(
-      groupSessionsForBrowse([grace, ada], "creator", NOW).grouped.map((g) => g.label),
+      groupSessionsForBrowse([grace, ada], "creator", { now: NOW }).grouped.map((g) => g.label),
     ).toEqual(["Ada Lovelace", "Grace Hopper"]);
     expect(
-      groupSessionsForBrowse([grace, ada], "created", NOW).grouped.map((g) => g.label),
+      groupSessionsForBrowse([grace, ada], "created", { now: NOW }).grouped.map((g) => g.label),
     ).toEqual(["Created today", "Created earlier"]);
   });
 
@@ -104,10 +105,12 @@ describe("session browse projections", () => {
       { value: "subject:tenant-b:alex", label: "Alex · Subject · tenant-b:alex" },
     ]);
     expect(
-      groupSessionsForBrowse([firstAlex, secondAlex], "creator", NOW).grouped.map((group) => ({
-        key: group.group,
-        label: group.label,
-      })),
+      groupSessionsForBrowse([firstAlex, secondAlex], "creator", { now: NOW }).grouped.map(
+        (group) => ({
+          key: group.group,
+          label: group.label,
+        }),
+      ),
     ).toEqual([
       {
         key: "creator:subject:tenant-a:alex",
@@ -116,6 +119,37 @@ describe("session browse projections", () => {
       {
         key: "creator:subject:tenant-b:alex",
         label: "Alex · Subject · tenant-b:alex",
+      },
+    ]);
+  });
+
+  test("reuses complete creator labels after filtering and excluding pins", () => {
+    const firstAlex = session({
+      id: "first-alex",
+      createdBy: { kind: "subject", subjectId: "tenant-a:alex", label: "Alex" },
+    });
+    const pinnedAlex = session({
+      id: "pinned-alex",
+      pinned: true,
+      createdBy: { kind: "subject", subjectId: "tenant-b:alex", label: "Alex" },
+    });
+    const complete = [firstAlex, pinnedAlex];
+    const creatorLabels = sessionCreatorLabelMap(complete);
+    const groupedSubset = filterSessionsForBrowse(complete, {
+      creator: "subject:tenant-a:alex",
+      dateField: "activity",
+      dateRange: "any",
+      now: NOW,
+    }).filter((candidate) => !candidate.pinned);
+
+    expect(
+      groupSessionsForBrowse(groupedSubset, "creator", { now: NOW, creatorLabels }).grouped.map(
+        (group) => ({ key: group.group, label: group.label }),
+      ),
+    ).toEqual([
+      {
+        key: "creator:subject:tenant-a:alex",
+        label: "Alex · Subject · tenant-a:alex",
       },
     ]);
   });

--- a/apps/web/src/lib/session-browse.test.ts
+++ b/apps/web/src/lib/session-browse.test.ts
@@ -51,6 +51,10 @@ describe("session browse projections", () => {
 
   test("filters by the frozen creator identity and keeps display labels separate", () => {
     const ada = session({ id: "ada" });
+    const opaqueSubject = session({
+      id: "opaque-subject",
+      createdBy: { kind: "subject", subjectId: "tenant:ada" },
+    });
     const scheduler = session({
       id: "scheduler",
       createdBy: { kind: "service", subjectId: "service:scheduler" },
@@ -64,7 +68,8 @@ describe("session browse projections", () => {
         now: NOW,
       }).map((item) => item.id),
     ).toEqual(["scheduler"]);
-    expect(sessionCreatorLabel(scheduler)).toBe("Service · scheduler");
+    expect(sessionCreatorLabel(opaqueSubject)).toBe("tenant:ada");
+    expect(sessionCreatorLabel(scheduler)).toBe("Service · service:scheduler");
   });
 
   test("groups flat browse results by creator or created-date buckets", () => {

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -199,6 +199,47 @@ export function sessionCreatorLabel(session: Session): string {
   return session.createdBy.subjectId;
 }
 
+export type SessionCreatorOption = {
+  value: string;
+  label: string;
+};
+
+/**
+ * Loaded creator choices with identity-specific labels only when frozen display
+ * labels collide. The subject ID remains opaque; it is displayed, not parsed.
+ */
+export function sessionCreatorOptions(sessions: Session[]): SessionCreatorOption[] {
+  const byKey = new Map<
+    string,
+    { label: string; kind: Session["createdBy"]["kind"]; subjectId: string }
+  >();
+  for (const session of sessions) {
+    byKey.set(sessionCreatorKey(session), {
+      label: sessionCreatorLabel(session),
+      kind: session.createdBy.kind,
+      subjectId: session.createdBy.subjectId,
+    });
+  }
+
+  const labelCounts = new Map<string, number>();
+  for (const creator of byKey.values()) {
+    labelCounts.set(creator.label, (labelCounts.get(creator.label) ?? 0) + 1);
+  }
+
+  return [...byKey.entries()]
+    .map(([value, creator]) => ({
+      value,
+      label:
+        labelCounts.get(creator.label) === 1
+          ? creator.label
+          : `${creator.label} · ${creator.kind === "service" ? "Service" : "Subject"} · ${creator.subjectId}`,
+    }))
+    .sort(
+      (left, right) =>
+        left.label.localeCompare(right.label) || left.value.localeCompare(right.value),
+    );
+}
+
 function browseTimestamp(session: Session, field: SessionBrowseDateField): number {
   if (field === "activity") return sessionActivityTime(session);
   const created = Date.parse(session.createdAt);
@@ -279,10 +320,16 @@ export function groupSessionsForBrowse(
     };
   }
 
+  const creatorLabels = new Map(
+    sessionCreatorOptions(sessions).map((creator) => [creator.value, creator.label]),
+  );
   const creators = new Map<string, { label: string; sessions: Session[] }>();
   for (const session of rest) {
     const key = sessionCreatorKey(session);
-    const bucket = creators.get(key) ?? { label: sessionCreatorLabel(session), sessions: [] };
+    const bucket = creators.get(key) ?? {
+      label: creatorLabels.get(key) ?? sessionCreatorLabel(session),
+      sessions: [],
+    };
     bucket.sessions.push(session);
     creators.set(key, bucket);
   }

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -175,11 +175,136 @@ export function mergeSessionForRail(current: Session, incoming: Session): Sessio
 export type SessionForest = {
   running: SessionTreeNode[];
   grouped: {
-    group: SessionRecencyGroup;
+    group: string;
     label: string;
     sessions: SessionTreeNode[];
   }[];
 };
+
+export type SessionBrowseGroupBy = "activity" | "created" | "creator";
+export type SessionBrowseDateField = "activity" | "created";
+export type SessionBrowseDateRange = "any" | "today" | "week" | "month";
+
+export function sessionCreatorKey(session: Session): string {
+  return `${session.createdBy.kind}:${session.createdBy.subjectId}`;
+}
+
+export function sessionCreatorLabel(session: Session): string {
+  const explicit = session.createdBy.label?.trim();
+  if (explicit) return explicit;
+  if (session.createdBy.subjectId === "unattributed-legacy") return "Unattributed";
+  const separator = session.createdBy.subjectId.indexOf(":");
+  const identity = (
+    separator >= 0 ? session.createdBy.subjectId.slice(separator + 1) : session.createdBy.subjectId
+  ).trim();
+  if (session.createdBy.kind === "service") {
+    return identity ? `Service · ${identity}` : "Service";
+  }
+  return identity || "Unknown creator";
+}
+
+function browseTimestamp(session: Session, field: SessionBrowseDateField): number {
+  if (field === "activity") return sessionActivityTime(session);
+  const created = Date.parse(session.createdAt);
+  return Number.isNaN(created) ? 0 : created;
+}
+
+export function filterSessionsForBrowse(
+  sessions: Session[],
+  options: {
+    creator: string | null;
+    dateField: SessionBrowseDateField;
+    dateRange: SessionBrowseDateRange;
+    now?: Date;
+  },
+): Session[] {
+  const now = options.now ?? new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const threshold =
+    options.dateRange === "today"
+      ? startOfToday
+      : options.dateRange === "week"
+        ? startOfToday - 6 * 24 * 60 * 60 * 1000
+        : options.dateRange === "month"
+          ? startOfToday - 29 * 24 * 60 * 60 * 1000
+          : null;
+  return sessions.filter(
+    (session) =>
+      (!options.creator || sessionCreatorKey(session) === options.creator) &&
+      (threshold === null || browseTimestamp(session, options.dateField) >= threshold),
+  );
+}
+
+/** Flat browse projection used only when the operator selects custom grouping. */
+export function groupSessionsForBrowse(
+  sessions: Session[],
+  groupBy: Exclude<SessionBrowseGroupBy, "activity">,
+  now: Date = new Date(),
+): SessionForest {
+  const running = sessions
+    .filter((session) => isRunningStatus(session.status))
+    .sort(compareSessionActivity)
+    .map((session) => ({ session, children: [], hasActiveDescendant: false }));
+  const rest = sessions.filter((session) => !isRunningStatus(session.status));
+  if (groupBy === "created") {
+    const buckets = new Map<SessionRecencyGroup, Session[]>();
+    for (const session of rest) {
+      const group = recencyGroupFor(browseTimestamp(session, "created"), now);
+      const list = buckets.get(group) ?? [];
+      list.push(session);
+      buckets.set(group, list);
+    }
+    return {
+      running,
+      grouped: SESSION_GROUP_ORDER.flatMap((group) => {
+        const list = buckets.get(group);
+        if (!list?.length) return [];
+        const label =
+          group === "today"
+            ? "Created today"
+            : group === "yesterday"
+              ? "Created yesterday"
+              : group === "previous7"
+                ? "Created in previous 7 days"
+                : "Created earlier";
+        return [
+          {
+            group: `created:${group}`,
+            label,
+            sessions: list
+              .sort(
+                (left, right) =>
+                  browseTimestamp(right, "created") - browseTimestamp(left, "created"),
+              )
+              .map((session) => ({ session, children: [], hasActiveDescendant: false })),
+          },
+        ];
+      }),
+    };
+  }
+
+  const creators = new Map<string, { label: string; sessions: Session[] }>();
+  for (const session of rest) {
+    const key = sessionCreatorKey(session);
+    const bucket = creators.get(key) ?? { label: sessionCreatorLabel(session), sessions: [] };
+    bucket.sessions.push(session);
+    creators.set(key, bucket);
+  }
+  return {
+    running,
+    grouped: [...creators.entries()]
+      .sort(([, left], [, right]) => left.label.localeCompare(right.label))
+      .map(([key, bucket]) => ({
+        group: `creator:${key}`,
+        label: bucket.label,
+        sessions: bucket.sessions.sort(compareSessionActivity).map((session) => ({
+          session,
+          children: [],
+          hasActiveDescendant: false,
+        })),
+      })),
+  };
+}
 
 export type PinnedRailSections = {
   /** Complete loaded hierarchy, used for expansion and lineage lookups. */

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -193,14 +193,10 @@ export function sessionCreatorLabel(session: Session): string {
   const explicit = session.createdBy.label?.trim();
   if (explicit) return explicit;
   if (session.createdBy.subjectId === "unattributed-legacy") return "Unattributed";
-  const separator = session.createdBy.subjectId.indexOf(":");
-  const identity = (
-    separator >= 0 ? session.createdBy.subjectId.slice(separator + 1) : session.createdBy.subjectId
-  ).trim();
   if (session.createdBy.kind === "service") {
-    return identity ? `Service · ${identity}` : "Service";
+    return `Service · ${session.createdBy.subjectId}`;
   }
-  return identity || "Unknown creator";
+  return session.createdBy.subjectId;
 }
 
 function browseTimestamp(session: Session, field: SessionBrowseDateField): number {

--- a/apps/web/src/lib/sessions-group.ts
+++ b/apps/web/src/lib/sessions-group.ts
@@ -208,7 +208,7 @@ export type SessionCreatorOption = {
  * Loaded creator choices with identity-specific labels only when frozen display
  * labels collide. The subject ID remains opaque; it is displayed, not parsed.
  */
-export function sessionCreatorOptions(sessions: Session[]): SessionCreatorOption[] {
+export function sessionCreatorLabelMap(sessions: Session[]): ReadonlyMap<string, string> {
   const byKey = new Map<
     string,
     { label: string; kind: Session["createdBy"]["kind"]; subjectId: string }
@@ -226,18 +226,25 @@ export function sessionCreatorOptions(sessions: Session[]): SessionCreatorOption
     labelCounts.set(creator.label, (labelCounts.get(creator.label) ?? 0) + 1);
   }
 
-  return [...byKey.entries()]
-    .map(([value, creator]) => ({
-      value,
-      label:
-        labelCounts.get(creator.label) === 1
-          ? creator.label
-          : `${creator.label} · ${creator.kind === "service" ? "Service" : "Subject"} · ${creator.subjectId}`,
-    }))
-    .sort(
-      (left, right) =>
-        left.label.localeCompare(right.label) || left.value.localeCompare(right.value),
-    );
+  return new Map(
+    [...byKey.entries()]
+      .map(([value, creator]) => ({
+        value,
+        label:
+          labelCounts.get(creator.label) === 1
+            ? creator.label
+            : `${creator.label} · ${creator.kind === "service" ? "Service" : "Subject"} · ${creator.subjectId}`,
+      }))
+      .sort(
+        (left, right) =>
+          left.label.localeCompare(right.label) || left.value.localeCompare(right.value),
+      )
+      .map((creator) => [creator.value, creator.label]),
+  );
+}
+
+export function sessionCreatorOptions(sessions: Session[]): SessionCreatorOption[] {
+  return [...sessionCreatorLabelMap(sessions)].map(([value, label]) => ({ value, label }));
 }
 
 function browseTimestamp(session: Session, field: SessionBrowseDateField): number {
@@ -276,8 +283,12 @@ export function filterSessionsForBrowse(
 export function groupSessionsForBrowse(
   sessions: Session[],
   groupBy: Exclude<SessionBrowseGroupBy, "activity">,
-  now: Date = new Date(),
+  options: {
+    now?: Date;
+    creatorLabels?: ReadonlyMap<string, string>;
+  } = {},
 ): SessionForest {
+  const now = options.now ?? new Date();
   const running = sessions
     .filter((session) => isRunningStatus(session.status))
     .sort(compareSessionActivity)
@@ -320,9 +331,7 @@ export function groupSessionsForBrowse(
     };
   }
 
-  const creatorLabels = new Map(
-    sessionCreatorOptions(sessions).map((creator) => [creator.value, creator.label]),
-  );
+  const creatorLabels = options.creatorLabels ?? sessionCreatorLabelMap(sessions);
   const creators = new Map<string, { label: string; sessions: Session[] }>();
   for (const session of rest) {
     const key = sessionCreatorKey(session);

--- a/apps/web/src/session-control-surface.test.ts
+++ b/apps/web/src/session-control-surface.test.ts
@@ -63,6 +63,14 @@ describe("session control surface architecture", () => {
     expect(paginationKey).not.toContain("serverSessions");
   });
 
+  test("keeps the loaded creator picker identifiable and reachable", async () => {
+    const list = await source("components/rail/session-list.tsx");
+    expect(list).toContain("sessionCreatorOptions(allSessions)");
+    expect(list).toContain(
+      'className="max-h-(--radix-dropdown-menu-content-available-height) w-52 overflow-x-hidden overflow-y-auto"',
+    );
+  });
+
   test("the retired client-side queue model is gone", async () => {
     expect(await Bun.file(`${import.meta.dir}/lib/queue.ts`).exists()).toBe(false);
   });

--- a/apps/web/src/session-control-surface.test.ts
+++ b/apps/web/src/session-control-surface.test.ts
@@ -56,8 +56,11 @@ describe("session control surface architecture", () => {
     const list = await source("components/rail/session-list.tsx");
     expect(list).toContain("const serverSessions = useMemo");
     expect(list).toContain("const projected = serverSessions.find");
-    expect(list).toContain("const paginationKey = sessionPageKey(rail.workspaceId, search);");
-    expect(list).not.toContain("const paginationKey = `${sessionPageKey");
+    const paginationKey = list.match(/const paginationKey = sessionPageKey\([\s\S]*?\n  \);/)?.[0];
+    expect(paginationKey).toContain("rail.workspaceId");
+    expect(paginationKey).toContain('hierarchyMode ? "tree" : "browse"');
+    expect(paginationKey).not.toContain("pinOverrides");
+    expect(paginationKey).not.toContain("serverSessions");
   });
 
   test("the retired client-side queue model is gone", async () => {

--- a/apps/web/src/session-control-surface.test.ts
+++ b/apps/web/src/session-control-surface.test.ts
@@ -65,7 +65,8 @@ describe("session control surface architecture", () => {
 
   test("keeps the loaded creator picker identifiable and reachable", async () => {
     const list = await source("components/rail/session-list.tsx");
-    expect(list).toContain("sessionCreatorOptions(allSessions)");
+    expect(list).toContain("sessionCreatorLabelMap(allSessions)");
+    expect(list).toContain("{ creatorLabels }");
     expect(list).toContain(
       'className="max-h-(--radix-dropdown-menu-content-available-height) w-52 overflow-x-hidden overflow-y-auto"',
     );


### PR DESCRIPTION
## Summary
- add one compact filter control beside session search
- group loaded sessions by last activity, created date, or creator
- filter by frozen creator plus either created date or last activity over today, 7-day, or 30-day windows
- preserve the current hierarchy and channel layout until a browse choice is active, then use an explicit flat browse projection
- retain pagination with an honest loaded-session note and a Load older path when the current page has no matches

## Verification
- 116 session rail, grouping, browse, channel, and app tests
- web typecheck
- oxfmt and oxlint on touched files
- browser verification against the live local API, including active creator grouping

Linear: OPE-238