### PR TITLE
fix(react): remove bundler-specific diagnostics default

### DIFF
--- a/packages/react/demo/realtime-harness.tsx
+++ b/packages/react/demo/realtime-harness.tsx
@@ -183,6 +183,7 @@ function ExistingSession(props: {
               codexConnected={mode === "mock"}
               realtimeAutostartModel={props.autostartModel ?? undefined}
               onRealtimeAutostartConsumed={props.onAutostartConsumed}
+              showDiagnostics
               controllerFactory={mode === "mock" ? deterministicRealtime.factory : undefined}
             />
           }

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -423,6 +423,8 @@ export function SessionRealtimeControl(props: {
    * `none` never attaches a model menu to the bar button.
    */
   modelMenu?: "split" | "split-desktop" | "none" | undefined;
+  /** Explicitly expose low-level controller diagnostics; disabled by default. */
+  showDiagnostics?: boolean | undefined;
   /** Deterministic browser-test/demo seam. Production hosts should use the SDK default. */
   controllerFactory?: SessionRealtimeControllerFactory | undefined;
 }) {
@@ -492,6 +494,7 @@ export function SessionRealtimeControl(props: {
       modelAvailable={selectedModel.available}
       menuSide="top"
       modelMenu={props.modelMenu ?? "split"}
+      showDiagnostics={props.showDiagnostics}
       audioRef={realtime.audioRef}
       selectedModel={selectedModel}
       models={selection.models}
@@ -709,7 +712,7 @@ export function RealtimeVoiceControl(props: {
    * `none` = start button only.
    */
   modelMenu?: "split" | "split-desktop" | "none" | undefined;
-  showDiagnostics?: boolean;
+  showDiagnostics?: boolean | undefined;
   /** Extra classes on the in-bar mute cluster (e.g. `max-sm:hidden` when mutes live in “+”). */
   muteControlsClassName?: string | undefined;
   audioRef: RefObject<HTMLAudioElement | null>;

--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -763,7 +763,7 @@ export function RealtimeVoiceControl(props: {
       : modeOwned
         ? props.onStop
         : props.onStart;
-  const diagnosticsVisible = props.showDiagnostics ?? import.meta.env.DEV;
+  const diagnosticsVisible = props.showDiagnostics ?? false;
   const modelMenu = props.modelMenu ?? "split";
   const showAttachedModelMenu = modelMenu === "split" || modelMenu === "split-desktop";
   const desktopOnlyModelMenu = modelMenu === "split-desktop";

--- a/packages/react/test/realtime-control.test.tsx
+++ b/packages/react/test/realtime-control.test.tsx
@@ -85,6 +85,13 @@ describe("ordinary session Codex realtime control", () => {
     container.remove();
   });
 
+  test("keeps the shipped control independent of Vite runtime globals", async () => {
+    const source = await Bun.file(
+      new URL("../src/realtime/realtime-control.tsx", import.meta.url),
+    ).text();
+    expect(source).not.toContain("import.meta.env");
+  });
+
   test("admits non-cancelled work states when control and Codex are ready", () => {
     for (const sessionStatus of ["idle", "queued", "running", "requires_action"] as const) {
       expect(
@@ -718,6 +725,7 @@ describe("ordinary session Codex realtime control", () => {
         .querySelector('[role="group"][aria-label="Realtime voice"]')
         ?.getAttribute("data-picker-side"),
     ).toBe("bottom");
+    expect(container.textContent).not.toContain("Realtime diagnostics");
   });
 
   test("exposes an autoplay-blocked retry without starting another realtime call", async () => {


### PR DESCRIPTION
## Summary

- make realtime diagnostics explicitly opt-in
- remove the Vite-only `import.meta.env` dependency from distributable React source
- cover the default behavior and bundler-neutral source contract

## Verification

- `bun test packages/react/test/realtime-control.test.tsx`
- `bun run --cwd packages/react typecheck`