### PR TITLE
fix(react): honor parent-owned realtime selection

### DIFF
--- a/packages/react/src/realtime/realtime-control.tsx
+++ b/packages/react/src/realtime/realtime-control.tsx
@@ -612,7 +612,7 @@ const IDLE_REALTIME_SNAPSHOT: SessionRealtimeControllerSnapshot = {
   error: null,
 };
 
-export function NewSessionRealtimeControl(props: {
+type NewSessionRealtimeControlProps = {
   client?: RealtimeControllerClient | undefined;
   workspaceId?: string | undefined;
   codexConnected: boolean;
@@ -630,20 +630,43 @@ export function NewSessionRealtimeControl(props: {
    * `none` never attaches a model menu to the bar button.
    */
   modelMenu?: "split" | "split-desktop" | "none" | undefined;
-}) {
-  const internalSelection = useRealtimeModelSelection({
+};
+
+type NewSessionRealtimeSelection = {
+  models: readonly RealtimeModelOption[];
+  selectedModel: RealtimeModelOption;
+  selectModel: (modelId: string) => void;
+};
+
+export function NewSessionRealtimeControl(props: NewSessionRealtimeControlProps) {
+  if (props.models && props.selectedModel && props.onSelectModel) {
+    return (
+      <NewSessionRealtimeControlView
+        {...props}
+        selection={{
+          models: props.models,
+          selectedModel: props.selectedModel,
+          selectModel: props.onSelectModel,
+        }}
+      />
+    );
+  }
+  return <NewSessionRealtimeControlWithInternalSelection {...props} />;
+}
+
+function NewSessionRealtimeControlWithInternalSelection(props: NewSessionRealtimeControlProps) {
+  const selection = useRealtimeModelSelection({
     client: props.client,
     workspaceId: props.workspaceId,
     codexConnected: props.codexConnected,
   });
-  const selection =
-    props.models && props.selectedModel && props.onSelectModel
-      ? {
-          models: props.models,
-          selectedModel: props.selectedModel,
-          selectModel: props.onSelectModel,
-        }
-      : internalSelection;
+  return <NewSessionRealtimeControlView {...props} selection={selection} />;
+}
+
+function NewSessionRealtimeControlView(
+  props: NewSessionRealtimeControlProps & { selection: NewSessionRealtimeSelection },
+) {
+  const selection = props.selection;
   const audioRef = useRef<HTMLAudioElement>(null);
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/packages/react/test/realtime-control.test.tsx
+++ b/packages/react/test/realtime-control.test.tsx
@@ -6,6 +6,7 @@ import type { EffectiveSessionControl, OpenGeniClient, SessionEvent } from "@ope
 import type { SessionRealtimeControllerSnapshot } from "@opengeni/sdk/realtime";
 
 import {
+  NewSessionRealtimeControl,
   RealtimeVoiceControl,
   RealtimeModelPickerMenu,
   SessionRealtimeControl,
@@ -90,6 +91,42 @@ describe("ordinary session Codex realtime control", () => {
       new URL("../src/realtime/realtime-control.tsx", import.meta.url),
     ).text();
     expect(source).not.toContain("import.meta.env");
+  });
+
+  test("skips the internal catalog when the parent owns new-session selection", async () => {
+    let catalogRequests = 0;
+    const client = {
+      getWorkspaceRealtimeModelCatalog: async () => {
+        catalogRequests += 1;
+        return { models: [] };
+      },
+    } as unknown as OpenGeniClient;
+    const selectedModel: RealtimeModelOption = {
+      id: "gpt-live-1-boulder-alpha",
+      label: "Codex Live",
+      provider: "Connected Codex",
+      description: "Deep session integration",
+      available: true,
+      unavailableReason: null,
+      recommended: true,
+    };
+
+    await act(async () =>
+      root.render(
+        <NewSessionRealtimeControl
+          client={client}
+          workspaceId="11111111-1111-4111-8111-111111111111"
+          codexConnected={true}
+          models={[selectedModel]}
+          selectedModel={selectedModel}
+          onSelectModel={() => undefined}
+          onStart={async () => true}
+        />,
+      ),
+    );
+    await act(async () => await new Promise((resolve) => setTimeout(resolve, 0)));
+
+    expect(catalogRequests).toBe(0);
   });
 
   test("admits non-cancelled work states when control and Codex are ready", () => {


### PR DESCRIPTION
When a host provides the complete new-session realtime model selection, render it directly instead of also mounting the internal catalog hook. This avoids an unnecessary catalog request and prevents unavailable internal catalog state from affecting a fully parent-controlled integration.\n\nAdds a regression test asserting that the catalog is not requested for the controlled path.