### PR TITLE
fix(integrations): project exact facet ownership

### DIFF
--- a/.changeset/wise-facets-own.md
+++ b/.changeset/wise-facets-own.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/contracts": patch
+"@opengeni/db": patch
+"@opengeni/sdk": patch
+---
+
+Project exact Integration Facet ownership so shared or externally managed bindings are read-only and direct removal reports retained owners truthfully.

--- a/apps/api/test/api-integrations-routes.test.ts
+++ b/apps/api/test/api-integrations-routes.test.ts
@@ -605,7 +605,10 @@ describe("API Integration routes", () => {
         ],
       },
     });
-    const legacyConfigured = structuredClone(configured);
+    const legacyConfigured = {
+      ...configured,
+      binding: { ...configured.binding },
+    };
     delete legacyConfigured.binding.directlyOwned;
     delete legacyConfigured.binding.owners;
     await shared!.admin`

--- a/apps/api/test/api-integrations-routes.test.ts
+++ b/apps/api/test/api-integrations-routes.test.ts
@@ -605,6 +605,15 @@ describe("API Integration routes", () => {
         ],
       },
     });
+    const legacyConfigured = structuredClone(configured);
+    delete legacyConfigured.binding.directlyOwned;
+    delete legacyConfigured.binding.owners;
+    await shared!.admin`
+      update capability_operations
+      set result = ${shared!.admin.json(legacyConfigured)}
+      where workspace_id = ${workspaceId}::uuid
+        and idempotency_key = ${configureKey}
+    `;
     const replay = await request(`${base}/inventory-source`, {
       method: "PUT",
       body: JSON.stringify({

--- a/apps/api/test/api-integrations-routes.test.ts
+++ b/apps/api/test/api-integrations-routes.test.ts
@@ -591,7 +591,19 @@ describe("API Integration routes", () => {
     const configured = await configuredResponse.json();
     expect(configured).toMatchObject({
       status: "configured",
-      binding: { connectionId: connection.id, status: "active", version: 1 },
+      binding: {
+        connectionId: connection.id,
+        status: "active",
+        version: 1,
+        directlyOwned: true,
+        owners: [
+          {
+            kind: "direct",
+            id: expect.stringMatching(/^facet:[0-9a-f]{64}$/),
+            removable: true,
+          },
+        ],
+      },
     });
     const replay = await request(`${base}/inventory-source`, {
       method: "PUT",
@@ -638,7 +650,12 @@ describe("API Integration routes", () => {
     const paused = await pausedResponse.json();
     expect(paused).toMatchObject({
       status: "paused",
-      binding: { status: "paused", version: 2 },
+      binding: {
+        status: "paused",
+        version: 2,
+        directlyOwned: true,
+        owners: configured.binding.owners,
+      },
     });
 
     const staleResume = await request(`${base}/inventory-source/resume`, {
@@ -660,7 +677,12 @@ describe("API Integration routes", () => {
     const resumed = await resumedResponse.json();
     expect(resumed).toMatchObject({
       status: "active",
-      binding: { status: "active", version: 3 },
+      binding: {
+        status: "active",
+        version: 3,
+        directlyOwned: true,
+        owners: configured.binding.owners,
+      },
     });
 
     const removed = await request(`${base}/inventory-source`, {
@@ -673,7 +695,7 @@ describe("API Integration routes", () => {
     expect(removed.status).toBe(200);
     expect(await removed.json()).toMatchObject({
       status: "removed",
-      binding: { status: "disabled", version: 4 },
+      binding: { status: "disabled", version: 4, directlyOwned: false, owners: [] },
       remainingOwners: [],
     });
   }, 60_000);

--- a/apps/web/src/components/capabilities/google-drive-knowledge-source-dialog-lifecycle.test.tsx
+++ b/apps/web/src/components/capabilities/google-drive-knowledge-source-dialog-lifecycle.test.tsx
@@ -1,0 +1,234 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, type ComponentProps, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+
+import type {
+  ApiIntegrationInstallationSummary,
+  GoogleDriveBrowseResponse,
+  IntegrationFacetDefinitionSummary,
+} from "@/types";
+
+const toastError = mock(() => undefined);
+const toastWarning = mock(() => undefined);
+
+mock.module("sonner", () => ({
+  toast: {
+    success: mock(() => undefined),
+    error: toastError,
+    info: mock(() => undefined),
+    warning: toastWarning,
+  },
+}));
+
+mock.module("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div data-dialog>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <footer>{children}</footer>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+const { GoogleDriveKnowledgeSourceDialog } = await import("./google-drive-knowledge-source-dialog");
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  mock.restore();
+  GlobalRegistrator.unregister();
+});
+
+beforeEach(() => {
+  toastError.mockClear();
+  toastWarning.mockClear();
+});
+
+describe("Google Drive knowledge-source browse ownership", () => {
+  test("ignores an old browse failure after the dialog closes and reopens", async () => {
+    const firstBrowse = deferred<GoogleDriveBrowseResponse>();
+    const secondBrowse = deferred<GoogleDriveBrowseResponse>();
+    let browseCount = 0;
+    const browseGoogleDriveFacetSource = mock(async () => {
+      browseCount += 1;
+      return await (browseCount === 1 ? firstBrowse.promise : secondBrowse.promise);
+    });
+    const client = { browseGoogleDriveFacetSource } as unknown as OpenGeniCoreClient;
+    const rendered = await renderDialog({ client, entry });
+    try {
+      await waitFor(() => browseGoogleDriveFacetSource.mock.calls.length === 1);
+
+      await rendered.rerender({ client, entry: null });
+      await rendered.rerender({ client, entry: { ...entry } });
+      await waitFor(() => browseGoogleDriveFacetSource.mock.calls.length === 2);
+      await waitFor(() => rendered.container.textContent?.includes("Loading folders") === true);
+
+      await act(async () => {
+        firstBrowse.reject(new Error("stale provider failure"));
+        await Promise.resolve();
+      });
+      await act(async () => await Bun.sleep(0));
+
+      expect(toastError).not.toHaveBeenCalled();
+      expect(toastWarning).not.toHaveBeenCalled();
+      expect(rendered.container.textContent).toContain("Loading folders");
+
+      await act(async () => {
+        secondBrowse.resolve(browseResponse("Current Drive"));
+        await Promise.resolve();
+      });
+      await waitFor(() => rendered.container.textContent?.includes("Current Drive") === true);
+
+      expect(rendered.container.textContent).not.toContain("Loading folders");
+      expect(toastError).not.toHaveBeenCalled();
+    } finally {
+      await rendered.unmount();
+    }
+  });
+});
+
+async function renderDialog(
+  props: Partial<ComponentProps<typeof GoogleDriveKnowledgeSourceDialog>> = {},
+) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const render = async (
+    nextProps: Partial<ComponentProps<typeof GoogleDriveKnowledgeSourceDialog>> = props,
+  ) => {
+    await act(async () => {
+      root.render(
+        <GoogleDriveKnowledgeSourceDialog
+          client={{} as OpenGeniCoreClient}
+          workspaceId="00000000-0000-4000-8000-000000000101"
+          instance={instance}
+          entry={null}
+          canManage
+          canManagePersonalDestination
+          canManageWorkspaceDestination
+          canManageOrganizationDestination={false}
+          onClose={() => undefined}
+          onMutationStart={() => ({
+            apply: () => true,
+            isCurrent: () => true,
+            finish: () => undefined,
+          })}
+          {...nextProps}
+        />,
+      );
+      await Promise.resolve();
+    });
+  };
+  await render();
+  return {
+    container,
+    rerender: render,
+    unmount: async () => {
+      await act(async () => root.unmount());
+      container.remove();
+      document.body.replaceChildren();
+    },
+  };
+}
+
+function browseResponse(name: string): GoogleDriveBrowseResponse {
+  const current = {
+    id: "root",
+    name,
+    mimeType: "application/vnd.google-apps.folder",
+    kind: "folder" as const,
+    driveId: null,
+    modifiedTime: null,
+    size: null,
+    webViewLink: null,
+  };
+  return {
+    connection: {
+      id: instance.connectionId!,
+      accountId: "00000000-0000-4000-8000-000000000105",
+      workspaceId: "00000000-0000-4000-8000-000000000101",
+      subjectId: "user:caller",
+      providerDomain: "drive.google.com",
+      kind: "oauth2",
+      status: "active",
+      grantedScopes: [],
+      expiresAt: null,
+      lastRefreshAt: null,
+      lastUsedAt: null,
+      lastError: null,
+      version: 1,
+      metadata: {},
+      createdBySubjectId: "user:caller",
+      updatedBySubjectId: "user:caller",
+      createdAt: "2026-08-14T00:00:00.000Z",
+      updatedAt: "2026-08-14T00:00:00.000Z",
+    },
+    parentId: "root",
+    current,
+    items: [],
+    nextPageToken: null,
+    incompleteSearch: false,
+  };
+}
+
+function deferred<Value>() {
+  let resolve!: (value: Value) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (predicate()) return;
+    await act(async () => await Bun.sleep(0));
+  }
+  throw new Error("Timed out waiting for Google Drive dialog state");
+}
+
+const definition: IntegrationFacetDefinitionSummary = {
+  facetKey: "drive-content",
+  kind: "knowledge_source",
+  configSchema: { type: "object", properties: {} },
+  capabilities: { provider: "google-drive" },
+};
+
+const entry = { definition, binding: null };
+
+const instance: ApiIntegrationInstallationSummary = {
+  capabilityId: "api:google-drive",
+  pluginKey: "integration/google-drive",
+  installationVersion: 1,
+  instanceId: "00000000-0000-4000-8000-000000000104",
+  instanceKey: "finance",
+  displayName: "Google Drive — Finance",
+  instanceVersion: 1,
+  serverId: "google_drive_finance",
+  name: "Google Drive",
+  description: "Google Drive Integration",
+  protocol: "openapi",
+  definitionId: "google-drive",
+  definitionProvenance: "curated",
+  providerDomain: "drive.google.com",
+  baseUrl: "https://www.googleapis.com/drive/v3/",
+  sourceUrl: "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
+  connected: true,
+  requiresConnection: true,
+  connectionId: "00000000-0000-4000-8000-000000000103",
+  ownership: "personal",
+  allowedTools: ["files.list"],
+  toolCount: 1,
+  approvalRequiredToolCount: 0,
+  revisionId: "openapi:fixture",
+  contentSha256: "a".repeat(64),
+};

--- a/apps/web/src/components/capabilities/google-drive-knowledge-source-dialog.tsx
+++ b/apps/web/src/components/capabilities/google-drive-knowledge-source-dialog.tsx
@@ -1,6 +1,6 @@
 import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
 import { FolderOpenIcon, Loader2Icon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -75,6 +75,7 @@ export function GoogleDriveKnowledgeSourceDialog({
   const [folderIdDraft, setFolderIdDraft] = useState("");
   const [syncCadence, setSyncCadence] = useState<GoogleDriveSyncCadence>("hourly");
   const [readPolicy, setReadPolicy] = useState<GoogleDriveReadPolicy>("allow");
+  const browseGeneration = useRef(0);
 
   const folderItems = useMemo(() => items.filter((item) => item.kind === "folder"), [items]);
 
@@ -85,6 +86,7 @@ export function GoogleDriveKnowledgeSourceDialog({
       pageToken?: string,
     ): Promise<GoogleDriveBrowseItem | null> => {
       if (!entry) return null;
+      const generation = ++browseGeneration.current;
       setBrowseBusy(true);
       try {
         const response = await client.browseGoogleDriveFacetSource(
@@ -97,6 +99,7 @@ export function GoogleDriveKnowledgeSourceDialog({
             ...(pageToken ? { pageToken } : {}),
           },
         );
+        if (generation !== browseGeneration.current) return null;
         setItems((current) =>
           mode === "append" ? [...current, ...response.items] : response.items,
         );
@@ -117,19 +120,24 @@ export function GoogleDriveKnowledgeSourceDialog({
         }
         return response.current;
       } catch (error) {
+        if (generation !== browseGeneration.current) return null;
         toast.error("Google Drive folder could not be opened", {
           description: error instanceof Error ? error.message : String(error),
         });
         return null;
       } finally {
-        setBrowseBusy(false);
+        if (generation === browseGeneration.current) setBrowseBusy(false);
       }
     },
     [client, entry, instance.capabilityId, instance.instanceKey, workspaceId],
   );
 
   useEffect(() => {
-    if (!entry) return;
+    ++browseGeneration.current;
+    if (!entry) {
+      setBrowseBusy(false);
+      return;
+    }
     const config = googleDriveKnowledgeSourceConfig(entry.binding?.config);
     setSelectedSources(configuredGoogleDriveKnowledgeSources(entry.binding?.config));
     setAuthorityKind(
@@ -148,6 +156,9 @@ export function GoogleDriveKnowledgeSourceDialog({
     setNextPageToken(null);
     setFolderIdDraft("");
     void loadFolder({ id: "root", name: "My Drive" });
+    return () => {
+      ++browseGeneration.current;
+    };
   }, [
     canManageOrganizationDestination,
     canManagePersonalDestination,
@@ -260,7 +271,7 @@ export function GoogleDriveKnowledgeSourceDialog({
         });
       }
     } finally {
-      setBusy(false);
+      if (mutation.isCurrent()) setBusy(false);
       mutation.finish();
     }
   }

--- a/apps/web/src/components/capabilities/google-drive-knowledge-source-dialog.tsx
+++ b/apps/web/src/components/capabilities/google-drive-knowledge-source-dialog.tsx
@@ -156,8 +156,9 @@ export function GoogleDriveKnowledgeSourceDialog({
     setNextPageToken(null);
     setFolderIdDraft("");
     void loadFolder({ id: "root", name: "My Drive" });
+    const browseGenerationRef = browseGeneration;
     return () => {
-      ++browseGeneration.current;
+      ++browseGenerationRef.current;
     };
   }, [
     canManageOrganizationDestination,

--- a/apps/web/src/components/capabilities/integration-control-center-load.test.tsx
+++ b/apps/web/src/components/capabilities/integration-control-center-load.test.tsx
@@ -4,7 +4,18 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act, type ComponentProps } from "react";
 import { createRoot } from "react-dom/client";
 
-import type { IntegrationDefinitionSummary } from "@/types";
+import type { ApiIntegrationInstallationSummary, IntegrationDefinitionSummary } from "@/types";
+
+type ControlCenterViewProbe = {
+  workspaceId: string;
+  definitions: IntegrationDefinitionSummary[];
+  loading: boolean;
+  removeTarget: { instance: ApiIntegrationInstallationSummary } | null;
+  onPreviewRemove: (instance: ApiIntegrationInstallationSummary) => void;
+  onRemoveInstance: () => Promise<boolean>;
+};
+
+let latestControlCenterView: ControlCenterViewProbe | null = null;
 
 const context: {
   client: OpenGeniCoreClient;
@@ -27,19 +38,14 @@ mock.module("@/context", () => ({
 }));
 
 mock.module("@/components/capabilities/integration-control-center-view", () => ({
-  IntegrationControlCenterView: ({
-    workspaceId,
-    definitions,
-    loading,
-  }: {
-    workspaceId: string;
-    definitions: IntegrationDefinitionSummary[];
-    loading: boolean;
-  }) => (
-    <div data-workspace-id={workspaceId} data-loading={String(loading)}>
-      {definitions.map((candidate) => candidate.name).join(",")}
-    </div>
-  ),
+  IntegrationControlCenterView: (props: ControlCenterViewProbe) => {
+    latestControlCenterView = props;
+    return (
+      <div data-workspace-id={props.workspaceId} data-loading={String(props.loading)}>
+        {props.definitions.map((candidate) => candidate.name).join(",")}
+      </div>
+    );
+  },
 }));
 
 const { IntegrationControlCenter } = await import("./integration-control-center");
@@ -118,6 +124,105 @@ describe("Integration Control Center load ownership", () => {
       await rendered.unmount();
     }
   });
+
+  test("does not let a stale workspace operation invalidate the current workspace load", async () => {
+    const instanceA = integrationInstance("definition-a", "Workspace A");
+    const staleDefinitionsReloadA = deferred<{
+      definitions: IntegrationDefinitionSummary[];
+    }>();
+    const staleInstancesReloadA = deferred<{ integrations: [] }>();
+    const definitionsB = deferred<{ definitions: IntegrationDefinitionSummary[] }>();
+    const instancesB = deferred<{ integrations: [] }>();
+    const uninstallA = deferred<void>();
+    let definitionCallsA = 0;
+    let instanceCallsA = 0;
+    const listIntegrationDefinitionsA = mock(async () => {
+      definitionCallsA += 1;
+      return definitionCallsA === 1
+        ? { definitions: [integrationDefinition("definition-a", "Workspace A")] }
+        : await staleDefinitionsReloadA.promise;
+    });
+    const listApiIntegrationsA = mock(async () => {
+      instanceCallsA += 1;
+      return instanceCallsA === 1
+        ? { integrations: [instanceA] }
+        : await staleInstancesReloadA.promise;
+    });
+    const previewApiIntegrationUninstallA = mock(async () => ({ removesDefinition: false }));
+    const uninstallApiIntegrationA = mock(async () => await uninstallA.promise);
+    const listIntegrationDefinitionsB = mock(async () => await definitionsB.promise);
+    const listApiIntegrationsB = mock(async () => await instancesB.promise);
+    const onChanged = mock(async () => undefined);
+    const clientA = {
+      listIntegrationDefinitions: listIntegrationDefinitionsA,
+      listApiIntegrations: listApiIntegrationsA,
+      previewApiIntegrationUninstall: previewApiIntegrationUninstallA,
+      uninstallApiIntegration: uninstallApiIntegrationA,
+    } as unknown as OpenGeniCoreClient;
+    const clientB = {
+      listIntegrationDefinitions: listIntegrationDefinitionsB,
+      listApiIntegrations: listApiIntegrationsB,
+    } as unknown as OpenGeniCoreClient;
+    context.client = clientA;
+    latestControlCenterView = null;
+    const rendered = await renderControlCenter({ workspaceId: "workspace-a", onChanged });
+    try {
+      await waitFor(
+        () => rendered.container.textContent === "Workspace A" && latestControlCenterView !== null,
+      );
+
+      await act(async () => {
+        latestControlCenterView!.onPreviewRemove(instanceA);
+        await Promise.resolve();
+      });
+      await waitFor(
+        () =>
+          previewApiIntegrationUninstallA.mock.calls.length === 1 &&
+          latestControlCenterView?.removeTarget?.instance === instanceA,
+      );
+
+      let removalPromise!: Promise<boolean>;
+      await act(async () => {
+        removalPromise = latestControlCenterView!.onRemoveInstance();
+        await Promise.resolve();
+      });
+      await waitFor(() => uninstallApiIntegrationA.mock.calls.length === 1);
+
+      context.client = clientB;
+      await rendered.rerender({ workspaceId: "workspace-b", onChanged });
+      await waitFor(
+        () =>
+          listIntegrationDefinitionsB.mock.calls.length === 1 &&
+          listApiIntegrationsB.mock.calls.length === 1,
+      );
+
+      await act(async () => {
+        uninstallA.resolve();
+        await Promise.resolve();
+      });
+      await act(async () => await Bun.sleep(0));
+
+      expect(listIntegrationDefinitionsA.mock.calls.length).toBe(1);
+      expect(listApiIntegrationsA.mock.calls.length).toBe(1);
+      expect(await removalPromise).toBe(false);
+      expect(onChanged.mock.calls.length).toBe(0);
+
+      await act(async () => {
+        definitionsB.resolve({
+          definitions: [integrationDefinition("definition-b", "Workspace B")],
+        });
+        instancesB.resolve({ integrations: [] });
+        await Promise.resolve();
+      });
+      await waitFor(() => rendered.container.textContent === "Workspace B");
+
+      const view = rendered.container.querySelector<HTMLElement>("[data-workspace-id]");
+      expect(view?.dataset.workspaceId).toBe("workspace-b");
+      expect(view?.dataset.loading).toBe("false");
+    } finally {
+      await rendered.unmount();
+    }
+  });
 });
 
 async function renderControlCenter(
@@ -163,6 +268,39 @@ function integrationDefinition(id: string, name: string): IntegrationDefinitionS
     provider: { id: "google", domain: `${id}.example.com` },
     authentication: { kind: "oauth2", scopes: [] },
     facets: [],
+  };
+}
+
+function integrationInstance(
+  definitionId: string,
+  displayName: string,
+): ApiIntegrationInstallationSummary {
+  return {
+    capabilityId: `api:${definitionId}`,
+    pluginKey: `integration/${definitionId}`,
+    installationVersion: 1,
+    instanceId: "00000000-0000-4000-8000-000000000104",
+    instanceKey: "primary",
+    displayName,
+    instanceVersion: 1,
+    serverId: `${definitionId}_primary`,
+    name: displayName,
+    description: `${displayName} integration`,
+    protocol: "openapi",
+    definitionId,
+    definitionProvenance: "curated",
+    providerDomain: `${definitionId}.example.com`,
+    baseUrl: `https://${definitionId}.example.com/v1/`,
+    sourceUrl: `https://${definitionId}.example.com/openapi.json`,
+    connected: true,
+    requiresConnection: true,
+    connectionId: "00000000-0000-4000-8000-000000000103",
+    ownership: "personal",
+    allowedTools: ["list_items"],
+    toolCount: 1,
+    approvalRequiredToolCount: 0,
+    revisionId: "openapi:fixture",
+    contentSha256: "a".repeat(64),
   };
 }
 

--- a/apps/web/src/components/capabilities/integration-control-center-load.test.tsx
+++ b/apps/web/src/components/capabilities/integration-control-center-load.test.tsx
@@ -1,0 +1,181 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, type ComponentProps } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { IntegrationDefinitionSummary } from "@/types";
+
+const context: {
+  client: OpenGeniCoreClient;
+  accessContext: {
+    subjectId: string;
+    accountGrants: [];
+    workspaceGrants: [];
+  };
+} = {
+  client: {} as OpenGeniCoreClient,
+  accessContext: {
+    subjectId: "user:caller",
+    accountGrants: [],
+    workspaceGrants: [],
+  },
+};
+
+mock.module("@/context", () => ({
+  useAppContext: () => context,
+}));
+
+mock.module("@/components/capabilities/integration-control-center-view", () => ({
+  IntegrationControlCenterView: ({
+    workspaceId,
+    definitions,
+    loading,
+  }: {
+    workspaceId: string;
+    definitions: IntegrationDefinitionSummary[];
+    loading: boolean;
+  }) => (
+    <div data-workspace-id={workspaceId} data-loading={String(loading)}>
+      {definitions.map((definition) => definition.name).join(",")}
+    </div>
+  ),
+}));
+
+const { IntegrationControlCenter } = await import("./integration-control-center");
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  mock.restore();
+  GlobalRegistrator.unregister();
+});
+
+describe("Integration Control Center load ownership", () => {
+  test("does not let a stale workspace response overwrite the current workspace", async () => {
+    const definitionsA = deferred<{ definitions: IntegrationDefinitionSummary[] }>();
+    const instancesA = deferred<{ integrations: [] }>();
+    const definitionsB = deferred<{ definitions: IntegrationDefinitionSummary[] }>();
+    const instancesB = deferred<{ integrations: [] }>();
+    const listIntegrationDefinitionsA = mock(async () => await definitionsA.promise);
+    const listApiIntegrationsA = mock(async () => await instancesA.promise);
+    const listIntegrationDefinitionsB = mock(async () => await definitionsB.promise);
+    const listApiIntegrationsB = mock(async () => await instancesB.promise);
+    const clientA = {
+      listIntegrationDefinitions: listIntegrationDefinitionsA,
+      listApiIntegrations: listApiIntegrationsA,
+    } as unknown as OpenGeniCoreClient;
+    const clientB = {
+      listIntegrationDefinitions: listIntegrationDefinitionsB,
+      listApiIntegrations: listApiIntegrationsB,
+    } as unknown as OpenGeniCoreClient;
+    context.client = clientA;
+    const rendered = await renderControlCenter({ workspaceId: "workspace-a" });
+    try {
+      await waitFor(
+        () =>
+          listIntegrationDefinitionsA.mock.calls.length === 1 &&
+          listApiIntegrationsA.mock.calls.length === 1,
+      );
+
+      context.client = clientB;
+      await rendered.rerender({ workspaceId: "workspace-b" });
+      await waitFor(
+        () =>
+          listIntegrationDefinitionsB.mock.calls.length === 1 &&
+          listApiIntegrationsB.mock.calls.length === 1,
+      );
+
+      await act(async () => {
+        definitionsB.resolve({ definitions: [definition("definition-b", "Workspace B")] });
+        instancesB.resolve({ integrations: [] });
+        await Promise.resolve();
+      });
+      await waitFor(() => rendered.container.textContent === "Workspace B");
+
+      await act(async () => {
+        definitionsA.resolve({ definitions: [definition("definition-a", "Workspace A")] });
+        instancesA.resolve({ integrations: [] });
+        await Promise.resolve();
+      });
+      await act(async () => await Bun.sleep(0));
+
+      const view = rendered.container.querySelector<HTMLElement>("[data-workspace-id]");
+      expect(view?.dataset.workspaceId).toBe("workspace-b");
+      expect(view?.dataset.loading).toBe("false");
+      expect(rendered.container.textContent).toBe("Workspace B");
+      expect(rendered.container.textContent).not.toContain("Workspace A");
+    } finally {
+      await rendered.unmount();
+    }
+  });
+});
+
+async function renderControlCenter(
+  props: Partial<ComponentProps<typeof IntegrationControlCenter>> = {},
+) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const render = async (
+    nextProps: Partial<ComponentProps<typeof IntegrationControlCenter>> = props,
+  ) => {
+    await act(async () => {
+      root.render(
+        <IntegrationControlCenter
+          workspaceId="workspace-a"
+          connections={[]}
+          canManage
+          onChanged={() => undefined}
+          {...nextProps}
+        />,
+      );
+      await Promise.resolve();
+    });
+  };
+  await render();
+  return {
+    container,
+    rerender: render,
+    unmount: async () => {
+      await act(async () => root.unmount());
+      container.remove();
+      document.body.replaceChildren();
+    },
+  };
+}
+
+function definition(id: string, name: string): IntegrationDefinitionSummary {
+  return {
+    id,
+    name,
+    summary: `${name} integration`,
+    protocol: "openapi",
+    provider: { id: "google", domain: `${id}.example.com` },
+    authentication: { kind: "oauth2", scopes: [] },
+    facets: [],
+  };
+}
+
+function deferred<Value>() {
+  let resolve!: (value: Value) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (predicate()) return;
+    await act(async () => await Bun.sleep(0));
+  }
+  throw new Error("Timed out waiting for Integration Control Center state");
+}

--- a/apps/web/src/components/capabilities/integration-control-center-load.test.tsx
+++ b/apps/web/src/components/capabilities/integration-control-center-load.test.tsx
@@ -37,7 +37,7 @@ mock.module("@/components/capabilities/integration-control-center-view", () => (
     loading: boolean;
   }) => (
     <div data-workspace-id={workspaceId} data-loading={String(loading)}>
-      {definitions.map((definition) => definition.name).join(",")}
+      {definitions.map((candidate) => candidate.name).join(",")}
     </div>
   ),
 }));
@@ -92,14 +92,18 @@ describe("Integration Control Center load ownership", () => {
       );
 
       await act(async () => {
-        definitionsB.resolve({ definitions: [definition("definition-b", "Workspace B")] });
+        definitionsB.resolve({
+          definitions: [integrationDefinition("definition-b", "Workspace B")],
+        });
         instancesB.resolve({ integrations: [] });
         await Promise.resolve();
       });
       await waitFor(() => rendered.container.textContent === "Workspace B");
 
       await act(async () => {
-        definitionsA.resolve({ definitions: [definition("definition-a", "Workspace A")] });
+        definitionsA.resolve({
+          definitions: [integrationDefinition("definition-a", "Workspace A")],
+        });
         instancesA.resolve({ integrations: [] });
         await Promise.resolve();
       });
@@ -150,7 +154,7 @@ async function renderControlCenter(
   };
 }
 
-function definition(id: string, name: string): IntegrationDefinitionSummary {
+function integrationDefinition(id: string, name: string): IntegrationDefinitionSummary {
   return {
     id,
     name,

--- a/apps/web/src/components/capabilities/integration-control-center-view.tsx
+++ b/apps/web/src/components/capabilities/integration-control-center-view.tsx
@@ -59,6 +59,7 @@ export function IntegrationControlCenterView({
   customApi,
   embedded,
   showCustomApis,
+  refreshRevision,
   onRefresh,
   onOpenSetup,
   onReconnect,
@@ -101,6 +102,7 @@ export function IntegrationControlCenterView({
   customApi: CustomApiFlowState;
   embedded: boolean;
   showCustomApis: boolean;
+  refreshRevision: number;
   onRefresh: () => void;
   onOpenSetup: (definition: IntegrationDefinitionSummary) => void;
   onReconnect: (instance: ApiIntegrationInstallationSummary) => void;
@@ -220,6 +222,7 @@ export function IntegrationControlCenterView({
                 canManagePersonalDestination={canManagePersonalDestination}
                 canManageWorkspaceDestination={canManageWorkspaceDestination}
                 canManageOrganizationDestination={canManageOrganizationDestination}
+                refreshRevision={refreshRevision}
                 busyKey={busyKey}
                 onAdd={() => onOpenSetup(definition)}
                 onReconnect={onReconnect}
@@ -299,6 +302,7 @@ function DefinitionCard({
   canManagePersonalDestination,
   canManageWorkspaceDestination,
   canManageOrganizationDestination,
+  refreshRevision,
   busyKey,
   onAdd,
   onReconnect,
@@ -313,6 +317,7 @@ function DefinitionCard({
   canManagePersonalDestination: boolean;
   canManageWorkspaceDestination: boolean;
   canManageOrganizationDestination: boolean;
+  refreshRevision: number;
   busyKey: string | null;
   onAdd: () => void;
   onReconnect: (instance: ApiIntegrationInstallationSummary) => void;
@@ -425,6 +430,7 @@ function DefinitionCard({
                 canManagePersonalDestination={canManagePersonalDestination}
                 canManageWorkspaceDestination={canManageWorkspaceDestination}
                 canManageOrganizationDestination={canManageOrganizationDestination}
+                refreshRevision={refreshRevision}
                 GoogleDriveDialog={GoogleDriveKnowledgeSourceDialog}
               />
             </div>

--- a/apps/web/src/components/capabilities/integration-control-center.tsx
+++ b/apps/web/src/components/capabilities/integration-control-center.tsx
@@ -176,6 +176,9 @@ export function IntegrationControlCenter({
   );
   const callbackHandled = useRef(false);
   const loadRequestGeneration = useRef(0);
+  const mountedRef = useRef(true);
+  const currentOperationScopeRef = useRef({ client, workspaceId });
+  currentOperationScopeRef.current = { client, workspaceId };
   const setupInstanceKeyRef = useRef<string | null>(null);
   const setupTriggerRef = useRef<HTMLElement | null>(null);
   const removeTriggerRef = useRef<HTMLElement | null>(null);
@@ -194,8 +197,16 @@ export function IntegrationControlCenter({
         };
   const { definitions, instances, loading, error: loadError, refreshRevision } = currentLoadState;
 
+  const isCurrentOperationScope = useCallback(() => {
+    const current = currentOperationScopeRef.current;
+    return mountedRef.current && current.client === client && current.workspaceId === workspaceId;
+  }, [client, workspaceId]);
+
   const load = useCallback(async () => {
+    if (!isCurrentOperationScope()) return;
     const generation = ++loadRequestGeneration.current;
+    const isCurrentLoad = () =>
+      generation === loadRequestGeneration.current && isCurrentOperationScope();
     setLoadState((current) =>
       current.client === client && current.workspaceId === workspaceId
         ? { ...current, loading: true, error: null }
@@ -214,7 +225,7 @@ export function IntegrationControlCenter({
         client.listIntegrationDefinitions(workspaceId),
         client.listApiIntegrations(workspaceId),
       ]);
-      if (generation !== loadRequestGeneration.current) return;
+      if (!isCurrentLoad()) return;
       setLoadState((current) => ({
         client,
         workspaceId,
@@ -228,7 +239,7 @@ export function IntegrationControlCenter({
             : 1,
       }));
     } catch (error) {
-      if (generation !== loadRequestGeneration.current) return;
+      if (!isCurrentLoad()) return;
       setLoadState((current) => ({
         ...(current.client === client && current.workspaceId === workspaceId
           ? current
@@ -245,7 +256,15 @@ export function IntegrationControlCenter({
         error: error instanceof Error ? error.message : String(error),
       }));
     }
-  }, [client, workspaceId]);
+  }, [client, isCurrentOperationScope, workspaceId]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    const mounted = mountedRef;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     void load();
@@ -257,6 +276,15 @@ export function IntegrationControlCenter({
 
   useEffect(() => {
     callbackHandled.current = false;
+    setBusyKey(null);
+    setCallbackBusy(false);
+    setRemoveTarget(null);
+    setSetupDefinition(null);
+    setSetupInitialAccountLabel("");
+    setupInstanceKeyRef.current = null;
+    setupTriggerRef.current = null;
+    removeTriggerRef.current = null;
+    dispatchCustomApi({ type: "reset" });
   }, [client, workspaceId]);
 
   useEffect(() => {
@@ -294,12 +322,15 @@ export function IntegrationControlCenter({
           ? { expectedInstanceVersion: pending.expectedInstanceVersion }
           : {}),
       });
+      if (!isCurrentOperationScope()) return;
       await Promise.all([load(), onChanged()]);
+      if (!isCurrentOperationScope()) return;
       toast.success(`${pending.displayName} is ready`, {
         description: `${preview.tools.length} tools are available through this exact account.`,
       });
     })()
       .catch((error) => {
+        if (!isCurrentOperationScope()) return;
         toast.error("Connected, but couldn't finish setup", {
           description:
             error instanceof Error
@@ -308,10 +339,11 @@ export function IntegrationControlCenter({
         });
       })
       .finally(() => {
+        if (!isCurrentOperationScope()) return;
         setCallbackBusy(false);
         setBusyKey(null);
       });
-  }, [client, load, onChanged, workspaceId]);
+  }, [client, isCurrentOperationScope, load, onChanged, workspaceId]);
 
   const instancesByDefinition = useMemo(() => {
     const grouped = new Map<string, ApiIntegrationInstallationSummary[]>();
@@ -357,6 +389,7 @@ export function IntegrationControlCenter({
       expectedInstanceVersion?: number;
     },
   ) {
+    if (!isCurrentOperationScope()) return;
     setBusyKey(input.instanceKey);
     try {
       const returnPath = apiIntegrationOAuthReturnPath(
@@ -378,10 +411,11 @@ export function IntegrationControlCenter({
         returnPath,
         ...(input.connectionId ? { connectionId: input.connectionId } : {}),
       });
+      if (!isCurrentOperationScope()) return;
       if (!response.authorizationUrl) throw new Error("The provider did not return a consent URL.");
       window.location.assign(response.authorizationUrl);
     } catch (error) {
-      setBusyKey(null);
+      if (isCurrentOperationScope()) setBusyKey(null);
       throw error;
     }
   }
@@ -405,6 +439,7 @@ export function IntegrationControlCenter({
         expectedInstanceVersion: instance.instanceVersion,
       });
     } catch (error) {
+      if (!isCurrentOperationScope()) return;
       toast.error("Couldn't start account connection", {
         description: error instanceof Error ? error.message : String(error),
       });
@@ -421,13 +456,15 @@ export function IntegrationControlCenter({
         instance.capabilityId,
         instance.instanceKey,
       );
+      if (!isCurrentOperationScope()) return;
       setRemoveTarget({ instance, removesDefinition: preview.removesDefinition });
     } catch (error) {
+      if (!isCurrentOperationScope()) return;
       toast.error("Couldn't inspect removal impact", {
         description: error instanceof Error ? error.message : String(error),
       });
     } finally {
-      setBusyKey(null);
+      if (isCurrentOperationScope()) setBusyKey(null);
     }
   }
 
@@ -445,19 +482,22 @@ export function IntegrationControlCenter({
           expectedInstanceVersion: instance.instanceVersion,
         },
       );
+      if (!isCurrentOperationScope()) return false;
       setRemoveTarget(null);
       await Promise.all([load(), onChanged()]);
+      if (!isCurrentOperationScope()) return false;
       toast.success(`${instance.displayName} removed`, {
         description: "Its Connection was retained and can be reused or disconnected separately.",
       });
       return true;
     } catch (error) {
+      if (!isCurrentOperationScope()) return false;
       toast.error("Couldn't remove this instance", {
         description: error instanceof Error ? error.message : String(error),
       });
       return false;
     } finally {
-      setBusyKey(null);
+      if (isCurrentOperationScope()) setBusyKey(null);
     }
   }
 
@@ -485,6 +525,7 @@ export function IntegrationControlCenter({
   }
 
   async function previewCustomApi(connection = customApi.connection) {
+    if (!isCurrentOperationScope()) return;
     let source;
     try {
       source = customApiSourceFromDraft(customApi.draft);
@@ -504,8 +545,10 @@ export function IntegrationControlCenter({
           ? { connectionId: connection.id, ownership: customApi.draft.ownership }
           : {}),
       });
+      if (!isCurrentOperationScope()) return;
       dispatchCustomApi({ type: "preview", preview, connection });
     } catch (error) {
+      if (!isCurrentOperationScope()) return;
       dispatchCustomApi({
         type: "preview_error",
         message: error instanceof Error ? error.message : String(error),
@@ -515,6 +558,7 @@ export function IntegrationControlCenter({
   }
 
   async function authenticateCustomApi() {
+    if (!isCurrentOperationScope()) return;
     let connection: ConnectionMetadata;
     dispatchCustomApi({ type: "phase", phase: "creating_connection", error: null });
     try {
@@ -535,11 +579,14 @@ export function IntegrationControlCenter({
             providerDomain,
           }),
         );
+        if (!isCurrentOperationScope()) return;
         await onChanged();
+        if (!isCurrentOperationScope()) return;
       }
       dispatchCustomApi({ type: "connection", connection });
       await previewCustomApi(connection);
     } catch (error) {
+      if (!isCurrentOperationScope()) return;
       dispatchCustomApi({
         type: "phase",
         phase: "auth",
@@ -549,6 +596,7 @@ export function IntegrationControlCenter({
   }
 
   async function installCustomApi() {
+    if (!isCurrentOperationScope()) return;
     const validationError = customApiInstallValidationError(customApi);
     if (validationError) {
       dispatchCustomApi({ type: "phase", phase: "review", error: validationError });
@@ -573,12 +621,15 @@ export function IntegrationControlCenter({
         ...(editing ? { expectedInstanceVersion: editing.instanceVersion } : {}),
         allowedTools: customApi.selectedTools,
       });
+      if (!isCurrentOperationScope()) return;
       await Promise.all([load(), onChanged()]);
+      if (!isCurrentOperationScope()) return;
       toast.success(`${customApi.draft.displayName.trim()} ${editing ? "updated" : "installed"}`, {
         description: `${customApi.selectedTools.length} tools are available through this exact instance.`,
       });
       dispatchCustomApi({ type: "reset" });
     } catch (error) {
+      if (!isCurrentOperationScope()) return;
       dispatchCustomApi({
         type: "phase",
         phase: "review",

--- a/apps/web/src/components/capabilities/integration-control-center.tsx
+++ b/apps/web/src/components/capabilities/integration-control-center.tsx
@@ -249,8 +249,9 @@ export function IntegrationControlCenter({
 
   useEffect(() => {
     void load();
+    const loadRequestGenerationRef = loadRequestGeneration;
     return () => {
-      ++loadRequestGeneration.current;
+      ++loadRequestGenerationRef.current;
     };
   }, [load]);
 

--- a/apps/web/src/components/capabilities/integration-control-center.tsx
+++ b/apps/web/src/components/capabilities/integration-control-center.tsx
@@ -52,6 +52,16 @@ type PendingIntegrationOAuth = {
   expectedInstanceVersion?: number;
 };
 
+type IntegrationLoadState = {
+  client: ReturnType<typeof useAppContext>["client"];
+  workspaceId: string;
+  definitions: IntegrationDefinitionSummary[];
+  instances: ApiIntegrationInstallationSummary[];
+  loading: boolean;
+  error: string | null;
+  refreshRevision: number;
+};
+
 const IntegrationControlCenterView = lazy(async () => {
   const module = await import("@/components/capabilities/integration-control-center-view");
   return { default: module.IntegrationControlCenterView };
@@ -145,10 +155,15 @@ export function IntegrationControlCenter({
     workspaceGrant &&
     hasAccountPermission(context.accessContext, workspaceGrant.accountId, "account:admin"),
   );
-  const [definitions, setDefinitions] = useState<IntegrationDefinitionSummary[]>([]);
-  const [instances, setInstances] = useState<ApiIntegrationInstallationSummary[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadState, setLoadState] = useState<IntegrationLoadState>(() => ({
+    client,
+    workspaceId,
+    definitions: [],
+    instances: [],
+    loading: true,
+    error: null,
+    refreshRevision: 0,
+  }));
   const [setupDefinition, setSetupDefinition] = useState<IntegrationDefinitionSummary | null>(null);
   const [setupInitialAccountLabel, setSetupInitialAccountLabel] = useState("");
   const [busyKey, setBusyKey] = useState<string | null>(null);
@@ -160,29 +175,88 @@ export function IntegrationControlCenter({
     initialCustomApiFlowState,
   );
   const callbackHandled = useRef(false);
+  const loadRequestGeneration = useRef(0);
   const setupInstanceKeyRef = useRef<string | null>(null);
   const setupTriggerRef = useRef<HTMLElement | null>(null);
   const removeTriggerRef = useRef<HTMLElement | null>(null);
   const focusFallbackRef = useRef<HTMLElement | null>(null);
+  const currentLoadState =
+    loadState.client === client && loadState.workspaceId === workspaceId
+      ? loadState
+      : {
+          client,
+          workspaceId,
+          definitions: [],
+          instances: [],
+          loading: true,
+          error: null,
+          refreshRevision: 0,
+        };
+  const { definitions, instances, loading, error: loadError, refreshRevision } = currentLoadState;
 
   const load = useCallback(async () => {
-    setLoading(true);
+    const generation = ++loadRequestGeneration.current;
+    setLoadState((current) =>
+      current.client === client && current.workspaceId === workspaceId
+        ? { ...current, loading: true, error: null }
+        : {
+            client,
+            workspaceId,
+            definitions: [],
+            instances: [],
+            loading: true,
+            error: null,
+            refreshRevision: 0,
+          },
+    );
     try {
       const [definitionResponse, installedResponse] = await Promise.all([
         client.listIntegrationDefinitions(workspaceId),
         client.listApiIntegrations(workspaceId),
       ]);
-      setDefinitions(definitionResponse.definitions);
-      setInstances(installedResponse.integrations);
-      setLoadError(null);
+      if (generation !== loadRequestGeneration.current) return;
+      setLoadState((current) => ({
+        client,
+        workspaceId,
+        definitions: definitionResponse.definitions,
+        instances: installedResponse.integrations,
+        loading: false,
+        error: null,
+        refreshRevision:
+          current.client === client && current.workspaceId === workspaceId
+            ? current.refreshRevision + 1
+            : 1,
+      }));
     } catch (error) {
-      setLoadError(error instanceof Error ? error.message : String(error));
-    } finally {
-      setLoading(false);
+      if (generation !== loadRequestGeneration.current) return;
+      setLoadState((current) => ({
+        ...(current.client === client && current.workspaceId === workspaceId
+          ? current
+          : {
+              client,
+              workspaceId,
+              definitions: [],
+              instances: [],
+              refreshRevision: 0,
+            }),
+        client,
+        workspaceId,
+        loading: false,
+        error: error instanceof Error ? error.message : String(error),
+      }));
     }
   }, [client, workspaceId]);
 
-  useEffect(() => void load(), [load]);
+  useEffect(() => {
+    void load();
+    return () => {
+      ++loadRequestGeneration.current;
+    };
+  }, [load]);
+
+  useEffect(() => {
+    callbackHandled.current = false;
+  }, [client, workspaceId]);
 
   useEffect(() => {
     if (callbackHandled.current) return;
@@ -576,6 +650,7 @@ export function IntegrationControlCenter({
         customApi={customApi}
         embedded={embedded}
         showCustomApis={showCustomApis}
+        refreshRevision={refreshRevision}
         onRefresh={() => void load()}
         onOpenSetup={openSetup}
         onReconnect={(instance) => void reconnect(instance)}

--- a/apps/web/src/components/capabilities/integration-facets-panel-lifecycle.test.tsx
+++ b/apps/web/src/components/capabilities/integration-facets-panel-lifecycle.test.tsx
@@ -1,7 +1,7 @@
-import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { OpenGeniCoreClient } from "@opengeni/sdk/core";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
-import { act, type ComponentProps } from "react";
+import { act, type ComponentProps, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 
 import type {
@@ -14,7 +14,45 @@ import type {
   GoogleDriveFacetMutation,
   GoogleDriveKnowledgeSourceDialogProps,
 } from "./google-drive-knowledge-source-dialog";
-import { IntegrationFacetsPanel } from "./integration-facets-panel";
+
+const toastSuccess = mock(() => undefined);
+const toastError = mock(() => undefined);
+
+mock.module("sonner", () => ({
+  toast: {
+    success: toastSuccess,
+    error: toastError,
+    info: mock(() => undefined),
+    warning: mock(() => undefined),
+  },
+}));
+
+mock.module("@/components/ui/confirm-dialog", () => ({
+  ConfirmDialog: ({
+    open,
+    title,
+    description,
+    confirmLabel,
+    onConfirm,
+  }: {
+    open: boolean;
+    title: ReactNode;
+    description?: ReactNode;
+    confirmLabel: string;
+    onConfirm: () => void | boolean | Promise<void | boolean>;
+  }) =>
+    open ? (
+      <div data-slot="dialog-content">
+        <h2>{title}</h2>
+        <p>{description}</p>
+        <button type="button" onClick={() => void onConfirm()}>
+          {confirmLabel}
+        </button>
+      </div>
+    ) : null,
+}));
+
+const { IntegrationFacetsPanel } = await import("./integration-facets-panel");
 
 beforeAll(() => {
   GlobalRegistrator.register();
@@ -23,7 +61,15 @@ beforeAll(() => {
   ).IS_REACT_ACT_ENVIRONMENT = true;
 });
 
-afterAll(() => GlobalRegistrator.unregister());
+afterAll(() => {
+  mock.restore();
+  GlobalRegistrator.unregister();
+});
+
+beforeEach(() => {
+  toastSuccess.mockClear();
+  toastError.mockClear();
+});
 
 describe("Integration Facet lifecycle state", () => {
   test("applies the authoritative lifecycle result without a stale list refetch", async () => {
@@ -113,6 +159,72 @@ describe("Integration Facet lifecycle state", () => {
     } finally {
       await rendered.unmount();
     }
+  });
+
+  test("refreshes an open facet panel when the parent service list is refreshed", async () => {
+    const active = binding("active", 1);
+    const paused = binding("paused", 2);
+    let listCount = 0;
+    const listIntegrationFacets = mock(async () => response(listCount++ === 0 ? active : paused));
+    const client = { listIntegrationFacets } as unknown as OpenGeniCoreClient;
+    const rendered = await renderPanel({ client });
+    try {
+      await act(async () => button(rendered.container, "Manage facets").click());
+      await waitFor(() => rendered.container.textContent?.includes("Active") === true);
+
+      await rendered.rerender({ client, refreshRevision: 1 });
+      await waitFor(() => listIntegrationFacets.mock.calls.length === 2);
+      await waitFor(() => rendered.container.textContent?.includes("Paused") === true);
+
+      expect(rendered.container.textContent).not.toContain("Active");
+      expect(
+        rendered.container.querySelector('[data-integration-facets="finance"]'),
+      ).not.toBeNull();
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("suppresses a pending lifecycle result and toast after unmount", async () => {
+    const active = binding("active", 1);
+    const paused = binding("paused", 2);
+    type LifecycleResult = {
+      capabilityId: string;
+      instanceKey: string;
+      facetKey: string;
+      status: "paused";
+      binding: IntegrationFacetBindingSummary;
+    };
+    let resolvePause!: (result: LifecycleResult) => void;
+    const pendingPause = new Promise<LifecycleResult>((resolve) => {
+      resolvePause = resolve;
+    });
+    const pauseIntegrationFacet = mock(async () => await pendingPause);
+    const client = {
+      listIntegrationFacets: mock(async () => response(active)),
+      pauseIntegrationFacet,
+    } as unknown as OpenGeniCoreClient;
+    const rendered = await renderPanel({ client });
+
+    await act(async () => button(rendered.container, "Manage facets").click());
+    await waitFor(() => rendered.container.textContent?.includes("Active") === true);
+    await act(async () => button(rendered.container, "Pause").click());
+    await waitFor(() => pauseIntegrationFacet.mock.calls.length === 1);
+
+    await rendered.unmount();
+    await act(async () =>
+      resolvePause({
+        capabilityId: instance.capabilityId,
+        instanceKey: instance.instanceKey,
+        facetKey: "inventory-source",
+        status: "paused",
+        binding: paused,
+      }),
+    );
+    await act(async () => await Bun.sleep(0));
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
   });
 
   test("applies concurrent lifecycle results for different facets independently", async () => {
@@ -326,6 +438,107 @@ describe("Integration Facet lifecycle state", () => {
       await rendered.unmount();
     }
   });
+
+  test("renders a Pack-owned facet as shared and read-only", async () => {
+    const packOwned = binding("active", 1, "inventory-source", "402", [packOwner]);
+    const client = {
+      listIntegrationFacets: mock(async () => response(packOwned)),
+    } as unknown as OpenGeniCoreClient;
+    const rendered = await renderPanel({ client });
+    try {
+      await act(async () => button(rendered.container, "Manage facets").click());
+      await waitFor(() => facet(rendered.container, "inventory-source") !== null);
+
+      const row = requiredFacet(rendered.container, "inventory-source");
+      expect(row.textContent).toContain("Shared");
+      expect(row.textContent).toContain("Managed by another Pack");
+      expect(button(row, "Edit").disabled).toBe(true);
+      expect(optionalButton(row, "Pause")).toBeNull();
+      expect(optionalButton(row, "Remove")).toBeNull();
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("does not treat another direct installation as this facet's owner", async () => {
+    const otherDirectOwner = {
+      kind: "direct" as const,
+      id: "facet:another-direct-installation",
+      removable: true,
+    };
+    const externallyManaged = binding(
+      "active",
+      1,
+      "inventory-source",
+      "452",
+      [otherDirectOwner],
+      false,
+    );
+    const client = {
+      listIntegrationFacets: mock(async () => response(externallyManaged)),
+    } as unknown as OpenGeniCoreClient;
+    const rendered = await renderPanel({ client });
+    try {
+      await act(async () => button(rendered.container, "Manage facets").click());
+      await waitFor(() => facet(rendered.container, "inventory-source") !== null);
+
+      const row = requiredFacet(rendered.container, "inventory-source");
+      expect(row.textContent).toContain("Shared");
+      expect(row.textContent).toContain("Managed by another direct installation");
+      expect(button(row, "Edit").disabled).toBe(true);
+      expect(optionalButton(row, "Pause")).toBeNull();
+      expect(optionalButton(row, "Remove")).toBeNull();
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("removes only direct control when another owner retains the facet", async () => {
+    const directlyShared = binding("active", 1, "inventory-source", "502", [
+      directOwner,
+      packOwner,
+    ]);
+    const retained = binding("active", 1, "inventory-source", "502", [packOwner]);
+    const removeIntegrationFacet = mock(async () => ({
+      capabilityId: instance.capabilityId,
+      instanceKey: instance.instanceKey,
+      facetKey: "inventory-source",
+      status: "retained_by_other_owners" as const,
+      binding: retained,
+      remainingOwners: [packOwner],
+    }));
+    const client = {
+      listIntegrationFacets: mock(async () => response(directlyShared)),
+      removeIntegrationFacet,
+    } as unknown as OpenGeniCoreClient;
+    const rendered = await renderPanel({ client });
+    try {
+      await act(async () => button(rendered.container, "Manage facets").click());
+      await waitFor(() => facet(rendered.container, "inventory-source") !== null);
+
+      const row = requiredFacet(rendered.container, "inventory-source");
+      await act(async () => button(row, "Remove direct control").click());
+      await waitFor(() => document.body.querySelector('[data-slot="dialog-content"]') !== null);
+      const removeDialog = document.body.querySelector('[data-slot="dialog-content"]');
+      if (!removeDialog) throw new Error("Missing remove-direct-control dialog");
+      await act(async () => button(removeDialog, "Remove direct control").click());
+      await waitFor(() => removeIntegrationFacet.mock.calls.length === 1);
+      await waitFor(
+        () =>
+          requiredFacet(rendered.container, "inventory-source").textContent?.includes("Active") ===
+          true,
+      );
+
+      const retainedRow = requiredFacet(rendered.container, "inventory-source");
+      expect(retainedRow.textContent).toContain("Shared");
+      expect(retainedRow.textContent).toContain("Managed by another Pack");
+      expect(button(retainedRow, "Edit").disabled).toBe(true);
+      expect(optionalButton(retainedRow, "Pause")).toBeNull();
+      expect(optionalButton(retainedRow, "Remove")).toBeNull();
+    } finally {
+      await rendered.unmount();
+    }
+  });
 });
 
 async function openGoogleDriveEditor(container: ParentNode, instanceKey: string): Promise<void> {
@@ -362,6 +575,7 @@ async function renderPanel(props: Partial<ComponentProps<typeof IntegrationFacet
           canManagePersonalDestination
           canManageWorkspaceDestination
           canManageOrganizationDestination={false}
+          refreshRevision={0}
           GoogleDriveDialog={() => null}
           {...nextProps}
         />,
@@ -389,13 +603,19 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 }
 
 function button(container: ParentNode, label: string): HTMLButtonElement {
-  const match = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
-    (candidate) =>
-      candidate.getAttribute("aria-label")?.includes(label) ||
-      candidate.textContent?.includes(label),
-  );
+  const match = optionalButton(container, label);
   if (!match) throw new Error(`Missing button: ${label}`);
   return match;
+}
+
+function optionalButton(container: ParentNode, label: string): HTMLButtonElement | null {
+  return (
+    [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+      (candidate) =>
+        candidate.getAttribute("aria-label")?.includes(label) ||
+        candidate.textContent?.includes(label),
+    ) ?? null
+  );
 }
 
 function facet(container: ParentNode, facetKey: string): HTMLElement | null {
@@ -456,6 +676,10 @@ function binding(
   version: number,
   facetKey = "inventory-source",
   idSuffix = "102",
+  owners: IntegrationFacetBindingSummary["owners"] = [directOwner],
+  directlyOwned = owners.some(
+    (owner) => owner.kind === directOwner.kind && owner.id === directOwner.id,
+  ),
 ): IntegrationFacetBindingSummary {
   return {
     id: `00000000-0000-4000-8000-000000000${idSuffix}`,
@@ -472,8 +696,22 @@ function binding(
     lastErrorCode: null,
     createdAt: "2026-08-14T00:00:00.000Z",
     updatedAt: "2026-08-14T00:00:00.000Z",
+    directlyOwned,
+    owners,
   };
 }
+
+const directOwner = {
+  kind: "direct" as const,
+  id: "facet:inventory-source",
+  removable: true,
+};
+
+const packOwner = {
+  kind: "pack" as const,
+  id: "pack:inventory-operations",
+  removable: false,
+};
 
 const instance: ApiIntegrationInstallationSummary = {
   capabilityId: "api:inventory",

--- a/apps/web/src/components/capabilities/integration-facets-panel.test.ts
+++ b/apps/web/src/components/capabilities/integration-facets-panel.test.ts
@@ -107,6 +107,8 @@ describe("Integration facet schema forms", () => {
       lastErrorCode: null,
       createdAt: "2026-08-10T00:00:00.000Z",
       updatedAt: "2026-08-11T00:00:00.000Z",
+      directlyOwned: true,
+      owners: [{ kind: "direct", id: "facet:drive-content", removable: true }],
     };
     expect(facetFormState(driveDefinition, binding)).toEqual({
       sourceId: "shared-drive:finance",

--- a/apps/web/src/components/capabilities/integration-facets-panel.tsx
+++ b/apps/web/src/components/capabilities/integration-facets-panel.tsx
@@ -116,26 +116,59 @@ export function IntegrationFacetsPanel({
   const mutationSequenceByFacet = useRef(new Map<string, number>());
   const loadPromise = useRef<Promise<void> | null>(null);
   const seenRefreshRevision = useRef(refreshRevision);
+  const panelIdentity = useRef({
+    client,
+    workspaceId,
+    capabilityId: instance.capabilityId,
+    instanceKey: instance.instanceKey,
+    instanceVersion: instance.instanceVersion,
+  });
 
   useEffect(() => {
-    ++operationGeneration.current;
-    mutationSequenceByFacet.current.clear();
-    loadPromise.current = null;
-    setData(null);
-    setLoading(false);
-    setError(null);
-    setBusyFacetKeys(new Set());
-    setOpen(false);
-    setEditor(null);
-    setGoogleDriveEditor(null);
-    setRemoveTarget(null);
-    seenRefreshRevision.current = refreshRevision;
-    return () => {
+    const previousIdentity = panelIdentity.current;
+    const identityChanged =
+      previousIdentity.client !== client ||
+      previousIdentity.workspaceId !== workspaceId ||
+      previousIdentity.capabilityId !== instance.capabilityId ||
+      previousIdentity.instanceKey !== instance.instanceKey ||
+      previousIdentity.instanceVersion !== instance.instanceVersion;
+    panelIdentity.current = {
+      client,
+      workspaceId,
+      capabilityId: instance.capabilityId,
+      instanceKey: instance.instanceKey,
+      instanceVersion: instance.instanceVersion,
+    };
+    if (identityChanged) {
       ++operationGeneration.current;
       mutationSequenceByFacet.current.clear();
       loadPromise.current = null;
+      setData(null);
+      setLoading(false);
+      setError(null);
+      setBusyFacetKeys(new Set());
+      setOpen(false);
+      setEditor(null);
+      setGoogleDriveEditor(null);
+      setRemoveTarget(null);
+      seenRefreshRevision.current = refreshRevision;
+    }
+    const operationGenerationRef = operationGeneration;
+    const mutationSequences = mutationSequenceByFacet.current;
+    const loadPromiseRef = loadPromise;
+    return () => {
+      ++operationGenerationRef.current;
+      mutationSequences.clear();
+      loadPromiseRef.current = null;
     };
-  }, [client, instance.capabilityId, instance.instanceKey, instance.instanceVersion, workspaceId]);
+  }, [
+    client,
+    instance.capabilityId,
+    instance.instanceKey,
+    instance.instanceVersion,
+    refreshRevision,
+    workspaceId,
+  ]);
 
   useEffect(() => {
     if (seenRefreshRevision.current === refreshRevision) return;

--- a/apps/web/src/components/capabilities/integration-facets-panel.tsx
+++ b/apps/web/src/components/capabilities/integration-facets-panel.tsx
@@ -88,6 +88,7 @@ export function IntegrationFacetsPanel({
   canManagePersonalDestination,
   canManageWorkspaceDestination,
   canManageOrganizationDestination,
+  refreshRevision,
   GoogleDriveDialog,
 }: {
   client: OpenGeniCoreClient;
@@ -98,6 +99,7 @@ export function IntegrationFacetsPanel({
   canManagePersonalDestination: boolean;
   canManageWorkspaceDestination: boolean;
   canManageOrganizationDestination: boolean;
+  refreshRevision: number;
   GoogleDriveDialog: ComponentType<GoogleDriveDialogProps>;
 }) {
   const [open, setOpen] = useState(false);
@@ -113,6 +115,7 @@ export function IntegrationFacetsPanel({
   const nextMutationSequence = useRef(0);
   const mutationSequenceByFacet = useRef(new Map<string, number>());
   const loadPromise = useRef<Promise<void> | null>(null);
+  const seenRefreshRevision = useRef(refreshRevision);
 
   useEffect(() => {
     ++operationGeneration.current;
@@ -126,7 +129,31 @@ export function IntegrationFacetsPanel({
     setEditor(null);
     setGoogleDriveEditor(null);
     setRemoveTarget(null);
-  }, [instance.capabilityId, instance.instanceKey, instance.instanceVersion]);
+    seenRefreshRevision.current = refreshRevision;
+    return () => {
+      ++operationGeneration.current;
+      mutationSequenceByFacet.current.clear();
+      loadPromise.current = null;
+    };
+  }, [client, instance.capabilityId, instance.instanceKey, instance.instanceVersion, workspaceId]);
+
+  useEffect(() => {
+    if (seenRefreshRevision.current === refreshRevision) return;
+    seenRefreshRevision.current = refreshRevision;
+    ++operationGeneration.current;
+    mutationSequenceByFacet.current.clear();
+    loadPromise.current = null;
+    setData(null);
+    setLoading(false);
+    setError(null);
+    setBusyFacetKeys(new Set());
+    setEditor(null);
+    setGoogleDriveEditor(null);
+    setRemoveTarget(null);
+    if (open) void load();
+    // load is deliberately scoped to the current exact panel identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshRevision]);
 
   useEffect(() => {
     if (open && data === null && !loading) void load();
@@ -306,9 +333,19 @@ export function IntegrationFacetsPanel({
       );
       if (!applyMutationBinding(token, result.binding)) return false;
       setRemoveTarget(null);
-      toast.success(`${facetTitle(target.definition)} removed`, {
-        description: `${instance.displayName} and its Connection remain intact.`,
-      });
+      if (result.status === "retained_by_other_owners") {
+        toast.success(`${facetTitle(target.definition)} direct control removed`, {
+          description: `The facet remains active because ${facetOwnerSummary(result.remainingOwners)} still owns it.`,
+        });
+      } else if (result.status === "not_configured") {
+        toast.info(`${facetTitle(target.definition)} was already managed elsewhere`, {
+          description: `No direct facet control was removed from ${instance.displayName}.`,
+        });
+      } else {
+        toast.success(`${facetTitle(target.definition)} removed`, {
+          description: `${instance.displayName} and its Connection remain intact.`,
+        });
+      }
       return true;
     } catch (removeError) {
       if (!isCurrentMutation(token)) return false;
@@ -421,8 +458,16 @@ export function IntegrationFacetsPanel({
         open={removeTarget !== null}
         onOpenChange={(next) => !next && setRemoveTarget(null)}
         title={removeTarget ? `Remove ${facetTitle(removeTarget.definition)}?` : "Remove facet?"}
-        description={`This removes only this facet from ${instance.displayName}. The account, Connection, tools, and sibling facets remain intact.`}
-        confirmLabel="Remove facet"
+        description={
+          removeTarget && otherFacetOwners(removeTarget.binding).length > 0
+            ? `This removes direct control from ${instance.displayName}. The facet remains active because ${facetOwnerSummary(otherFacetOwners(removeTarget.binding))} also owns it.`
+            : `This removes only this facet from ${instance.displayName}. The account, Connection, tools, and sibling facets remain intact.`
+        }
+        confirmLabel={
+          removeTarget && otherFacetOwners(removeTarget.binding).length > 0
+            ? "Remove direct control"
+            : "Remove facet"
+        }
         destructive
         onConfirm={remove}
       />
@@ -464,6 +509,11 @@ function FacetRow({
   const Icon = detail.icon;
   const binding = entry.binding;
   const configured = binding !== null && binding.status !== "disabled";
+  const directlyOwned = binding?.directlyOwned === true;
+  const otherOwners = otherFacetOwners(binding);
+  const externallyManaged = configured && !directlyOwned;
+  const independentlyMutable = directlyOwned && otherOwners.length === 0;
+  const canConfigure = !configured && otherOwners.length === 0;
   return (
     <article
       className="rounded-lg border border-border bg-bg p-3"
@@ -477,8 +527,24 @@ function FacetRow({
           <div className="flex flex-wrap items-center gap-1.5">
             <p className="text-xs font-semibold text-fg">{facetTitle(entry.definition)}</p>
             <FacetStatusBadge binding={binding} />
+            {otherOwners.length > 0 || externallyManaged ? (
+              <Badge variant="outline" className="text-2xs text-fg-subtle">
+                {otherOwners.length > 0 ? "Shared" : "Managed"}
+              </Badge>
+            ) : null}
           </div>
           <p className="mt-1 text-2xs leading-4 text-fg-muted">{detail.description}</p>
+          {otherOwners.length > 0 ? (
+            <p className="mt-1 text-2xs leading-4 text-fg-subtle">
+              Managed by {facetOwnerSummary(otherOwners)}. Shared configuration and lifecycle are
+              read-only here.
+            </p>
+          ) : externallyManaged ? (
+            <p className="mt-1 text-2xs leading-4 text-fg-subtle">
+              Managed outside this direct installation. Configuration and lifecycle are read-only
+              here.
+            </p>
+          ) : null}
         </div>
         {busy ? <Loader2Icon className="size-3.5 animate-spin text-brand" /> : null}
       </div>
@@ -487,12 +553,12 @@ function FacetRow({
           type="button"
           variant="ghost"
           size="xs"
-          disabled={!canManage || busy}
+          disabled={!canManage || busy || (!canConfigure && !independentlyMutable)}
           onClick={onEdit}
         >
           {configured ? "Edit" : entry.definition.kind === "identity_link" ? "Enable" : "Configure"}
         </Button>
-        {binding?.status === "active" ? (
+        {binding?.status === "active" && independentlyMutable ? (
           <Button
             type="button"
             variant="ghost"
@@ -503,7 +569,8 @@ function FacetRow({
             <CirclePauseIcon />
             Pause
           </Button>
-        ) : binding?.status === "paused" || binding?.status === "needs_attention" ? (
+        ) : (binding?.status === "paused" || binding?.status === "needs_attention") &&
+          independentlyMutable ? (
           <Button
             type="button"
             variant="ghost"
@@ -515,7 +582,7 @@ function FacetRow({
             Resume
           </Button>
         ) : null}
-        {configured ? (
+        {configured && directlyOwned ? (
           <Button
             type="button"
             variant="ghost"
@@ -524,7 +591,7 @@ function FacetRow({
             onClick={onRemove}
           >
             <Trash2Icon />
-            Remove
+            {otherOwners.length > 0 ? "Remove direct control" : "Remove"}
           </Button>
         ) : null}
       </div>
@@ -557,6 +624,33 @@ function FacetStatusBadge({ binding }: { binding: IntegrationFacetBindingSummary
       {label}
     </Badge>
   );
+}
+
+function otherFacetOwners(
+  binding: IntegrationFacetBindingSummary | null,
+): IntegrationFacetBindingSummary["owners"] {
+  if (!binding) return [];
+  let excludedCurrentDirectOwner = !binding.directlyOwned;
+  return binding.owners.filter((owner) => {
+    if (owner.kind === "direct" && !excludedCurrentDirectOwner) {
+      excludedCurrentDirectOwner = true;
+      return false;
+    }
+    return true;
+  });
+}
+
+function facetOwnerSummary(owners: IntegrationFacetBindingSummary["owners"]): string {
+  const kinds = new Set(owners.map((owner) => owner.kind));
+  const labels = [
+    kinds.has("plugin") ? "another Plugin" : null,
+    kinds.has("pack") ? "another Pack" : null,
+    kinds.has("migration") ? "migration authority" : null,
+    kinds.has("direct") ? "another direct installation" : null,
+  ].filter((label): label is string => label !== null);
+  if (labels.length === 0) return "another owner";
+  if (labels.length === 1) return labels[0]!;
+  return `${labels.slice(0, -1).join(", ")} and ${labels.at(-1)}`;
 }
 
 function FacetEditorDialog({

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -209,11 +209,17 @@ rewritten by a browser request. Operators configure only a definition's bounded
 schema on one exact Integration instance, inheriting that instance's exact
 Connection and Personal/workspace authority. Configure, pause, resume, and
 remove use caller UUID idempotency plus exact binding-version OCC. The public
-projection reports only whether a provider cursor exists; page tokens, delta
-links, and other cursor contents remain private durable state. Integration
-definition upgrades migrate same-key facets without losing configuration,
-cursor, lifecycle status, evidence timestamps, or owner edges, and reject an
-upgrade that would silently remove a configured facet.
+projection includes the effective owner ledger plus an exact `directlyOwned`
+decision for the requested capability/instance/facet identity; clients must not
+infer current control from the presence of some unrelated `direct` owner. A
+Pack-, Plugin-, migration-, or other-direct-owned binding is read-only in the
+direct Integration controls. Removing a direct owner reports when another
+owner retains the binding instead of presenting the shared facet as deleted.
+The projection reports only whether a provider cursor exists; page tokens,
+delta links, and other cursor contents remain private durable state.
+Integration definition upgrades migrate same-key facets without losing
+configuration, cursor, lifecycle status, evidence timestamps, or owner edges,
+and reject an upgrade that would silently remove a configured facet.
 
 Google Drive's `drive-content` facet uses a provider-specific editor because
 its required schema contains a bounded array of verified folders/Shared Drives

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -8338,6 +8338,8 @@ export const IntegrationFacetBindingSummary = z
     lastErrorCode: z.string().min(1).max(120).nullable(),
     createdAt: z.string().datetime({ offset: true }),
     updatedAt: z.string().datetime({ offset: true }),
+    directlyOwned: z.boolean(),
+    owners: z.array(CapabilityComponentOwner),
   })
   .strict();
 export type IntegrationFacetBindingSummary = z.infer<typeof IntegrationFacetBindingSummary>;

--- a/packages/db/src/integration-bindings.ts
+++ b/packages/db/src/integration-bindings.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { stableJson } from "@opengeni/contracts";
-import { and, asc, eq, or, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, or, sql } from "drizzle-orm";
 
 import type { Database } from "./database";
 import { effectiveCapabilityOwnerSql } from "./capability-components";
@@ -248,7 +248,14 @@ export async function listIntegrationFacetBindingOwners(
   db: Database,
   bindingId: string,
 ): Promise<IntegrationFacetBindingOwner[]> {
-  return await loadIntegrationFacetBindingOwners(db, bindingId, true);
+  return (await listIntegrationFacetBindingOwnersForBindings(db, [bindingId])).get(bindingId) ?? [];
+}
+
+export async function listIntegrationFacetBindingOwnersForBindings(
+  db: Database,
+  bindingIds: string[],
+): Promise<Map<string, IntegrationFacetBindingOwner[]>> {
+  return await loadIntegrationFacetBindingOwnersForBindings(db, bindingIds, true);
 }
 
 async function loadIntegrationFacetBindingOwners(
@@ -256,8 +263,26 @@ async function loadIntegrationFacetBindingOwners(
   bindingId: string,
   effectiveOnly: boolean,
 ): Promise<IntegrationFacetBindingOwner[]> {
+  return (
+    (await loadIntegrationFacetBindingOwnersForBindings(db, [bindingId], effectiveOnly)).get(
+      bindingId,
+    ) ?? []
+  );
+}
+
+async function loadIntegrationFacetBindingOwnersForBindings(
+  db: Database,
+  bindingIds: string[],
+  effectiveOnly: boolean,
+): Promise<Map<string, IntegrationFacetBindingOwner[]>> {
+  const uniqueBindingIds = [...new Set(bindingIds)];
+  const ownersByBindingId = new Map(
+    uniqueBindingIds.map((bindingId) => [bindingId, [] as IntegrationFacetBindingOwner[]]),
+  );
+  if (uniqueBindingIds.length === 0) return ownersByBindingId;
   const rows = await db
     .select({
+      bindingId: schema.integrationFacetBindingOwners.bindingId,
       kind: schema.integrationFacetBindingOwners.ownerKind,
       id: schema.integrationFacetBindingOwners.ownerId,
       removable: schema.integrationFacetBindingOwners.removable,
@@ -265,7 +290,7 @@ async function loadIntegrationFacetBindingOwners(
     .from(schema.integrationFacetBindingOwners)
     .where(
       and(
-        eq(schema.integrationFacetBindingOwners.bindingId, bindingId),
+        inArray(schema.integrationFacetBindingOwners.bindingId, uniqueBindingIds),
         effectiveOnly
           ? effectiveCapabilityOwnerSql(
               schema.integrationFacetBindingOwners.ownerKind,
@@ -275,10 +300,11 @@ async function loadIntegrationFacetBindingOwners(
       ),
     )
     .orderBy(
+      asc(schema.integrationFacetBindingOwners.bindingId),
       asc(schema.integrationFacetBindingOwners.ownerKind),
       asc(schema.integrationFacetBindingOwners.ownerId),
     );
-  return rows.map((row) => {
+  for (const row of rows) {
     if (
       row.kind !== "direct" &&
       row.kind !== "plugin" &&
@@ -287,8 +313,11 @@ async function loadIntegrationFacetBindingOwners(
     ) {
       throw new Error(`Unknown Integration instance owner kind: ${row.kind}`);
     }
-    return { kind: row.kind, id: row.id, removable: row.removable };
-  });
+    ownersByBindingId
+      .get(row.bindingId)
+      ?.push({ kind: row.kind, id: row.id, removable: row.removable });
+  }
+  return ownersByBindingId;
 }
 
 export async function removeIntegrationFacetBindingOwner(

--- a/packages/db/src/integration-facets.ts
+++ b/packages/db/src/integration-facets.ts
@@ -486,7 +486,9 @@ async function withFacetOperation<T extends Record<string, unknown>>(
               "Integration facet idempotency key was reused",
             );
           }
-          if (existing.status === "completed" && existing.result) return existing.result as T;
+          if (existing.status === "completed" && existing.result) {
+            return await hydrateFacetOperationResult(tx, input, existing.result as T);
+          }
           throw new IntegrationFacetOperationIdempotencyError(
             "Integration facet operation is already in progress",
           );
@@ -512,6 +514,64 @@ async function withFacetOperation<T extends Record<string, unknown>>(
       });
     },
   );
+}
+
+async function hydrateFacetOperationResult<T extends Record<string, unknown>>(
+  db: Database,
+  input: { capabilityId: string; instanceKey: string; facetKey: string },
+  result: T,
+): Promise<T> {
+  const binding = recordValue(result.binding);
+  if (!binding) return result;
+  if (typeof binding.directlyOwned === "boolean" && Array.isArray(binding.owners)) return result;
+
+  const expectedOwner = facetOwner(input.capabilityId, input.instanceKey, input.facetKey);
+  let owners =
+    typeof binding.id === "string" ? await listIntegrationFacetBindingOwners(db, binding.id) : [];
+  if (owners.length === 0) {
+    owners = capabilityComponentOwners(result.remainingOwners);
+  }
+  if (
+    owners.length === 0 &&
+    (result.status === "configured" || result.status === "paused" || result.status === "active")
+  ) {
+    owners = [expectedOwner];
+  }
+  return {
+    ...result,
+    binding: {
+      ...binding,
+      directlyOwned: owners.some(
+        (owner) => owner.kind === expectedOwner.kind && owner.id === expectedOwner.id,
+      ),
+      owners,
+    },
+  } as T;
+}
+
+function capabilityComponentOwners(value: unknown): IntegrationFacetBindingOwner[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    const owner = recordValue(entry);
+    if (
+      !owner ||
+      (owner.kind !== "direct" &&
+        owner.kind !== "plugin" &&
+        owner.kind !== "pack" &&
+        owner.kind !== "migration") ||
+      typeof owner.id !== "string" ||
+      typeof owner.removable !== "boolean"
+    ) {
+      return [];
+    }
+    return [{ kind: owner.kind, id: owner.id, removable: owner.removable }];
+  });
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }
 
 async function requireMutationContext(

--- a/packages/db/src/integration-facets.ts
+++ b/packages/db/src/integration-facets.ts
@@ -13,8 +13,10 @@ import {
   IntegrationFacetBindingOwnershipConflictError,
   IntegrationFacetBindingVersionConflictError,
   listIntegrationFacetBindingOwners,
+  listIntegrationFacetBindingOwnersForBindings,
   removeIntegrationFacetBindingOwner,
   upsertIntegrationFacetBinding,
+  type IntegrationFacetBindingOwner,
 } from "./integration-bindings";
 import * as schema from "./schema";
 
@@ -39,6 +41,8 @@ export type IntegrationFacetBindingSummary = {
   lastErrorCode: string | null;
   createdAt: string;
   updatedAt: string;
+  directlyOwned: boolean;
+  owners: IntegrationFacetBindingOwner[];
 };
 
 export type IntegrationFacetDefinitionSummary = {
@@ -164,6 +168,10 @@ export async function listIntegrationInstanceFacets(
         asc(schema.integrationFacetDefinitions.kind),
         asc(schema.integrationFacetDefinitions.facetKey),
       );
+    const ownersByBindingId = await listIntegrationFacetBindingOwnersForBindings(
+      scopedDb,
+      rows.flatMap((row) => (row.bindingId ? [row.bindingId] : [])),
+    );
     return {
       capabilityId,
       instanceKey,
@@ -177,22 +185,26 @@ export async function listIntegrationInstanceFacets(
           capabilities: row.capabilities,
         },
         binding: row.bindingId
-          ? bindingSummary({
-              id: row.bindingId,
-              facetKey: row.facetKey,
-              kind: row.kind,
-              bindingKey: row.bindingKey!,
-              displayName: row.displayName!,
-              connectionId: row.connectionId ?? null,
-              status: row.status!,
-              config: row.config!,
-              cursor: row.cursor!,
-              version: row.version!,
-              lastSuccessAt: row.lastSuccessAt ?? null,
-              lastErrorCode: row.lastErrorCode ?? null,
-              createdAt: row.createdAt!,
-              updatedAt: row.updatedAt!,
-            })
+          ? bindingSummary(
+              {
+                id: row.bindingId,
+                facetKey: row.facetKey,
+                kind: row.kind,
+                bindingKey: row.bindingKey!,
+                displayName: row.displayName!,
+                connectionId: row.connectionId ?? null,
+                status: row.status!,
+                config: row.config!,
+                cursor: row.cursor!,
+                version: row.version!,
+                lastSuccessAt: row.lastSuccessAt ?? null,
+                lastErrorCode: row.lastErrorCode ?? null,
+                createdAt: row.createdAt!,
+                updatedAt: row.updatedAt!,
+              },
+              ownersByBindingId.get(row.bindingId) ?? [],
+              { capabilityId, instanceKey, facetKey: row.facetKey },
+            )
           : null,
       })),
     };
@@ -244,16 +256,21 @@ export async function configureIntegrationFacet(
       owner: facetOwner(input.capabilityId, input.instanceKey, input.facetKey),
       ...(input.expectedVersion !== undefined ? { expectedVersion: input.expectedVersion } : {}),
     });
+    const owners = await listIntegrationFacetBindingOwners(tx, result.row.id);
     return {
       capabilityId: input.capabilityId,
       instanceKey: input.instanceKey,
       facetKey: input.facetKey,
       status: "configured",
-      binding: bindingSummary({
-        ...result.row,
-        facetKey: definition.facetKey,
-        kind: definition.kind,
-      }),
+      binding: bindingSummary(
+        {
+          ...result.row,
+          facetKey: definition.facetKey,
+          kind: definition.kind,
+        },
+        owners,
+        input,
+      ),
     };
   });
 }
@@ -312,16 +329,21 @@ export async function setIntegrationFacetLifecycle(
       if (!updated) throw new Error("Failed to update Integration facet lifecycle");
       row = updated;
     }
+    const owners = await listIntegrationFacetBindingOwners(tx, row.id);
     return {
       capabilityId: input.capabilityId,
       instanceKey: input.instanceKey,
       facetKey: input.facetKey,
       status: input.action === "pause" ? "paused" : "active",
-      binding: bindingSummary({
-        ...row,
-        facetKey: definition.facetKey,
-        kind: definition.kind,
-      }),
+      binding: bindingSummary(
+        {
+          ...row,
+          facetKey: definition.facetKey,
+          kind: definition.kind,
+        },
+        owners,
+        input,
+      ),
     };
   });
 }
@@ -377,11 +399,15 @@ export async function removeIntegrationFacet(
         instanceKey: input.instanceKey,
         facetKey: input.facetKey,
         status: "not_configured",
-        binding: bindingSummary({
-          ...binding,
-          facetKey: definition.facetKey,
-          kind: definition.kind,
-        }),
+        binding: bindingSummary(
+          {
+            ...binding,
+            facetKey: definition.facetKey,
+            kind: definition.kind,
+          },
+          owners,
+          input,
+        ),
         remainingOwners: owners,
       };
     }
@@ -391,17 +417,24 @@ export async function removeIntegrationFacet(
       owner,
       expectedVersion: input.expectedVersion,
     });
+    const effectiveRemainingOwners = removed.binding
+      ? await listIntegrationFacetBindingOwners(tx, removed.binding.id)
+      : [];
     return {
       capabilityId: input.capabilityId,
       instanceKey: input.instanceKey,
       facetKey: input.facetKey,
       status: removed.remainingOwners.length > 0 ? "retained_by_other_owners" : "removed",
       binding: removed.binding
-        ? bindingSummary({
-            ...removed.binding,
-            facetKey: definition.facetKey,
-            kind: definition.kind,
-          })
+        ? bindingSummary(
+            {
+              ...removed.binding,
+              facetKey: definition.facetKey,
+              kind: definition.kind,
+            },
+            effectiveRemainingOwners,
+            input,
+          )
         : null,
       remainingOwners: removed.remainingOwners,
     };
@@ -708,7 +741,12 @@ type BindingSummaryRow = Pick<
   kind: string;
 };
 
-function bindingSummary(row: BindingSummaryRow): IntegrationFacetBindingSummary {
+function bindingSummary(
+  row: BindingSummaryRow,
+  owners: IntegrationFacetBindingOwner[],
+  identity: { capabilityId: string; instanceKey: string; facetKey: string },
+): IntegrationFacetBindingSummary {
+  const expectedOwner = facetOwner(identity.capabilityId, identity.instanceKey, identity.facetKey);
   return {
     id: row.id,
     facetKey: row.facetKey,
@@ -724,6 +762,10 @@ function bindingSummary(row: BindingSummaryRow): IntegrationFacetBindingSummary 
     lastErrorCode: row.lastErrorCode,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
+    directlyOwned: owners.some(
+      (owner) => owner.kind === expectedOwner.kind && owner.id === expectedOwner.id,
+    ),
+    owners,
   };
 }
 

--- a/packages/db/test/api-integrations.test.ts
+++ b/packages/db/test/api-integrations.test.ts
@@ -797,6 +797,14 @@ describe("API Integration persistence", () => {
         status: "active",
         version: 1,
         hasCursor: false,
+        directlyOwned: true,
+        owners: [
+          {
+            kind: "direct",
+            id: expect.stringMatching(/^facet:[0-9a-f]{64}$/),
+            removable: true,
+          },
+        ],
       },
     });
     expect(
@@ -893,6 +901,8 @@ describe("API Integration persistence", () => {
       id: configured.binding.id,
       version: configured.binding.version + 1,
       status: "active",
+      directlyOwned: true,
+      owners: configured.binding.owners,
       config: {
         sources: [
           {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -5326,6 +5326,8 @@ export type IntegrationFacetBindingSummary = {
   lastErrorCode: string | null;
   createdAt: string;
   updatedAt: string;
+  directlyOwned: boolean;
+  owners: CapabilityComponentOwner[];
 };
 
 export type IntegrationInstanceFacetsResponse = {

--- a/test/e2e/custom-api-control-center.browser.e2e.ts
+++ b/test/e2e/custom-api-control-center.browser.e2e.ts
@@ -863,6 +863,14 @@ function mailInboxBinding(
     lastErrorCode: null,
     createdAt: "2026-08-11T00:00:00.000Z",
     updatedAt: "2026-08-11T00:00:00.000Z",
+    directlyOwned: true,
+    owners: [
+      {
+        kind: "direct" as const,
+        id: "facet:d358a95c79124370ff2e8e3c9d366cd95ff8ddf1f30dfde2c79dffc61d3627af",
+        removable: true,
+      },
+    ],
   };
 }
 


### PR DESCRIPTION
## Summary
- project the effective Integration Facet owner ledger plus exact direct-installation ownership
- keep shared or externally managed facets read-only and report retained ownership truthfully on direct removal
- fence stale control-center, facet mutation, and Google Drive browse results across refresh, navigation, close/reopen, and unmount

## Validation
- package typechecks: `packages/db`, `packages/contracts`, `packages/sdk`, `apps/api`, `apps/web`
- 35 focused API/DB/web/release-schema tests passed
- 745 contracts + SDK tests passed
- focused formatting and `git diff --check` passed

## Environment limitation
- local Docker was unavailable, so real-PostgreSQL bodies in the API/DB test files were skipped; an earlier independent OPE-16 migration audit completed the full 254-migration chain and 0231/0232/0233 replay on PostgreSQL 16.15

Fix-forward for OPE-16 / #1377.
