### PR TITLE
fix(skills): preserve legacy manifest replay

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6464,6 +6464,15 @@ export async function getCapabilityCatalogItem(
   });
 }
 
+function portableSkillManifestIdentity(manifest: Record<string, unknown>): string {
+  // The version column is already the immutable version identity. Older rows
+  // predate the duplicate manifest field, so including it in the digest would
+  // make an unchanged Skill conflict with itself after an upgrade.
+  const identity = { ...manifest };
+  delete identity.version;
+  return stableJson(identity);
+}
+
 /**
  * Install one immutable, already-validated Skill through the authoritative
  * Plugin/Skill-Facet ownership model. Repeating the same exact source is
@@ -6558,7 +6567,12 @@ export async function installPortableSkill(
           )
           .for("update")
           .limit(1);
-        if (versionByName && versionByName.manifestDigest !== manifestDigest) {
+        if (
+          versionByName &&
+          versionByName.manifestDigest !== manifestDigest &&
+          portableSkillManifestIdentity(versionByName.manifest) !==
+            portableSkillManifestIdentity(manifest)
+        ) {
           throw new Error(`Skill version ${version} conflicts with immutable stored content`);
         }
         let pluginVersion = versionByName;

--- a/packages/db/test/portable-skills.test.ts
+++ b/packages/db/test/portable-skills.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { stableJson } from "@opengeni/contracts";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
 import postgres from "postgres";
 
@@ -169,6 +170,45 @@ describe("portable Skill persistence", () => {
       remainingOwners: [],
     });
     expect(await listInstalledPortableSkills(client.db, first.workspaceId)).toEqual([]);
+  }, 60_000);
+
+  test("replays a Skill version stored before the redundant manifest version field", async () => {
+    if (!available || !client || !shared) return;
+    const input = skillInput("legacy-manifest-replay");
+    const installed = await installPortableSkill(client.db, input);
+    const [stored] = await shared.admin<
+      Array<{ manifest: Record<string, postgres.JSONValue | undefined> }>
+    >`
+      select manifest
+      from capability_plugin_versions
+      where id = ${installed.pluginVersionId}
+    `;
+    expect(stored).toBeDefined();
+    const legacyManifest = { ...stored!.manifest };
+    delete legacyManifest.version;
+    await shared.admin.begin(async (tx) => {
+      await tx`set local session_replication_role = replica`;
+      await tx`
+        update capability_plugin_versions
+        set manifest = ${tx.json(legacyManifest)}::jsonb,
+            manifest_digest = ${sha256(stableJson(legacyManifest))}
+        where id = ${installed.pluginVersionId}
+      `;
+    });
+
+    expect(await installPortableSkill(client.db, input)).toEqual({
+      ...installed,
+      created: false,
+    });
+    await expect(
+      installPortableSkill(client.db, { ...input, totalBytes: input.totalBytes + 1 }),
+    ).rejects.toThrow("conflicts with immutable stored content");
+    await uninstallPortableSkill(client.db, {
+      accountId: first.accountId,
+      workspaceId: first.workspaceId,
+      capabilityId: input.capabilityId,
+      expectedInstallationVersion: installed.installationVersion,
+    });
   }, 60_000);
 
   test("removing a direct owner preserves a Skill still owned by a Pack", async () => {


### PR DESCRIPTION
Fix portable Skill idempotency across the manifest schema transition that added the redundant version field.

The authoritative plugin-version column already owns version identity, so replay now compares immutable manifest content without duplicating that field. Exact immutable-content conflicts remain rejected.

Regression coverage exercises a pre-transition stored manifest, successful replay, and continued rejection of changed immutable content.

Validated with:
- bun test packages/db/test/portable-skills.test.ts
- bun run --cwd packages/db typecheck
- oxfmt/oxlint on changed files