### PR TITLE
fix(runtime): treat absent Modal app as empty sweep

### DIFF
--- a/packages/runtime/src/sandbox/providers/modal.ts
+++ b/packages/runtime/src/sandbox/providers/modal.ts
@@ -1135,10 +1135,20 @@ export async function sweepModalOrphanSandboxes(
   const ownedClient = options.client ? null : await createModalClient(settings);
   const modal = (options.client ?? ownedClient)! as ModalCpListClient;
   try {
-    const app = await modal.apps.fromName(settings.modalAppName, {
-      createIfMissing: false,
-      ...(settings.modalEnvironment ? { environment: settings.modalEnvironment } : {}),
-    });
+    let app: Awaited<ReturnType<typeof modal.apps.fromName>>;
+    try {
+      app = await modal.apps.fromName(settings.modalAppName, {
+        createIfMissing: false,
+        ...(settings.modalEnvironment ? { environment: settings.modalEnvironment } : {}),
+      });
+    } catch (error) {
+      // A new deployment has no Modal app until its first sandbox is created.
+      // That is an empty provider inventory, not a failed orphan sweep.
+      if (isModalNotFoundError(error)) {
+        return { examined: 0, terminated: [], skipped: 0 };
+      }
+      throw error;
+    }
     const appId = app.appId;
     if (!appId) {
       return { examined: 0, terminated: [], skipped: 0 };

--- a/packages/runtime/test/modal-orphan-sweep.test.ts
+++ b/packages/runtime/test/modal-orphan-sweep.test.ts
@@ -73,6 +73,43 @@ const LIVE_LEASE: LiveModalSandboxLeaseAttribution = {
 };
 
 describe("sweepModalOrphanSandboxes live-instance guard", () => {
+  test("treats an app that has not been created yet as an empty inventory", async () => {
+    const client = {
+      apps: {
+        fromName: async () => {
+          const error = new Error("app absent");
+          error.name = "NotFoundError";
+          throw error;
+        },
+      },
+      close: () => {},
+    };
+
+    await expect(
+      sweepModalOrphanSandboxes(testSettings(MODAL_SETTINGS), [], {
+        client: client as any,
+      }),
+    ).resolves.toEqual({ examined: 0, terminated: [], skipped: 0 });
+  });
+
+  test("does not hide unrelated app lookup failures", async () => {
+    const failure = new Error("Modal authentication failed");
+    const client = {
+      apps: {
+        fromName: async () => {
+          throw failure;
+        },
+      },
+      close: () => {},
+    };
+
+    await expect(
+      sweepModalOrphanSandboxes(testSettings(MODAL_SETTINGS), [], {
+        client: client as any,
+      }),
+    ).rejects.toBe(failure);
+  });
+
   test("never terminates an UNTAGGED box a live lease points at — and heals its tags", async () => {
     // The incident shape: the box lost/never got its attribution tags, is past
     // the unattributed grace, but a live lease resumes it by id every turn.


### PR DESCRIPTION
## Summary
- treat a never-created Modal app as an empty orphan inventory
- preserve failures for auth, network, and unrelated lookup errors
- cover both paths with focused regression tests

## Verification
- bun test packages/runtime/test/modal-orphan-sweep.test.ts
- bun run typecheck
- bun run lint
- bun run format:check