### PR TITLE
fix(capabilities): replay completed facet receipts first

### DIFF
--- a/.changeset/swift-facets-replay.md
+++ b/.changeset/swift-facets-replay.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/db": patch
+---
+
+Replay exact completed Integration facet configure receipts before mutable instance, Connection, or provider validation while preserving request conflicts and exact-subject isolation.

--- a/apps/api/src/integrations/google-drive.ts
+++ b/apps/api/src/integrations/google-drive.ts
@@ -7,6 +7,7 @@ import {
 import type { AccessGrant, ScheduledTask, ScheduledTaskScheduleSpec } from "@opengeni/contracts";
 import {
   bindConnectorDocumentDestination,
+  type ConnectorDocumentDestination,
   type ConnectorDocumentDestinationSelection,
 } from "@opengeni/contracts/connector-destinations";
 import {
@@ -55,6 +56,7 @@ import type { ApiRouteDeps } from "@opengeni/core";
 import {
   buildConnectionTokenResolver,
   configureIntegrationFacet,
+  integrationFacetConfigureRequestDigest,
   appendKnowledgeSourceAclVersion,
   deauthorizeKnowledgeSourceRetrieval,
   ConnectionDisconnectGenerationError,
@@ -72,6 +74,7 @@ import {
   listKnowledgeSourceSyncTasksForConnection,
   loadConnectionCredentialForBroker,
   listIntegrationInstanceFacets,
+  replayCompletedIntegrationFacetOperation,
   transitionConnectionState,
   updateConnection,
   updateScheduledTask,
@@ -832,43 +835,42 @@ export async function saveGoogleDriveFacetSource(
     throw new HTTPException(400, { message: "invalid Google Drive source selection" });
   }
   const payload = parsedPayload.data;
+  const requestedDestination = bindGoogleDriveDocumentDestination(input, payload);
+  const requestedConfig = googleDriveFacetConfig(payload.sources, requestedDestination, payload);
+  const replayed = await replayCompletedIntegrationFacetOperation<IntegrationFacetMutationResult>(
+    deps.db,
+    {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      subjectId: input.subjectId,
+      capabilityId: input.capabilityId,
+      instanceKey: input.instanceKey,
+      facetKey: input.facetKey,
+      idempotencyKey: payload.idempotencyKey,
+      kind: "configure",
+      expectedRequestDigest: (result) => {
+        const receipt = IntegrationFacetMutationResult.parse(result);
+        return integrationFacetConfigureRequestDigest({
+          capabilityId: input.capabilityId,
+          instanceKey: input.instanceKey,
+          facetKey: input.facetKey,
+          displayName: receipt.binding.displayName,
+          config: requestedConfig,
+          ...(payload.expectedVersion !== undefined
+            ? { expectedVersion: payload.expectedVersion }
+            : {}),
+        });
+      },
+    },
+  );
+  if (replayed) return IntegrationFacetMutationResult.parse(replayed);
   const context = await requireGoogleDriveIntegrationFacet(deps, input);
-  const documentDestination = googleDriveDocumentDestination(input, payload);
-  const verifiedSources = await verifyGoogleDriveSources(deps, {
+  googleDriveDocumentDestination(input, payload);
+  await verifyGoogleDriveSources(deps, {
     workspaceId: input.workspaceId,
     subjectId: input.subjectId,
     connectionId: context.connection.id,
     sources: payload.sources,
-  });
-  const config = GoogleDriveKnowledgeSourceConfig.parse({
-    sources: verifiedSources.map((verified) => ({
-      id: verified.id,
-      name: verified.name,
-      mimeType: verified.mimeType,
-      ...(verified.driveId ? { driveId: verified.driveId } : {}),
-      sourceKind:
-        verified.id === "root"
-          ? "my_drive"
-          : verified.driveId === verified.id
-            ? "shared_drive"
-            : "folder",
-      includeDescendants: true,
-    })),
-    destination: {
-      authorityKind: documentDestination.authorityKind,
-      authorityAccountId: documentDestination.authorityAccountId,
-      ...(documentDestination.authorityWorkspaceId
-        ? { authorityWorkspaceId: documentDestination.authorityWorkspaceId }
-        : {}),
-      ...(documentDestination.authoritySubjectId
-        ? { authoritySubjectId: documentDestination.authoritySubjectId }
-        : {}),
-      ...(documentDestination.collectionId
-        ? { collectionId: documentDestination.collectionId }
-        : {}),
-    },
-    syncCadence: payload.syncCadence,
-    readPolicy: payload.readPolicy,
   });
   return IntegrationFacetMutationResult.parse(
     await configureIntegrationFacet(deps.db, {
@@ -880,7 +882,7 @@ export async function saveGoogleDriveFacetSource(
       facetKey: input.facetKey,
       displayName:
         context.facet.binding?.displayName ?? `${input.instanceKey} — Google Drive content`,
-      config,
+      config: requestedConfig,
       ...(payload.expectedVersion !== undefined
         ? { expectedVersion: payload.expectedVersion }
         : {}),
@@ -1111,10 +1113,73 @@ function googleDriveDocumentDestination(
   if (destinationSelection.authorityKind === "personal" && !input.canManagePersonalDestination) {
     throw new HTTPException(403, { message: "personal destination requires the exact actor" });
   }
+  return bindGoogleDriveDocumentDestination(input, payload);
+}
+
+function bindGoogleDriveDocumentDestination(
+  input: {
+    accountId: string;
+    workspaceId: string;
+    subjectId: string;
+  },
+  payload: {
+    destination?: ConnectorDocumentDestinationSelection | undefined;
+    targetScope?: "user" | "workspace" | "organization" | undefined;
+  },
+): ConnectorDocumentDestination {
+  const destinationSelection: ConnectorDocumentDestinationSelection = payload.destination ?? {
+    authorityKind: "workspace",
+    collectionId: null,
+  };
   return bindConnectorDocumentDestination(destinationSelection, {
     accountId: input.accountId,
     workspaceId: input.workspaceId,
     initiatingSubjectId: input.subjectId,
+  });
+}
+
+function googleDriveFacetConfig(
+  sources: ReadonlyArray<{
+    id: string;
+    name: string;
+    mimeType: string;
+    driveId: string | null;
+  }>,
+  documentDestination: ConnectorDocumentDestination,
+  payload: {
+    syncCadence: "manual" | "hourly" | "daily";
+    readPolicy: "allow" | "ask" | "block";
+  },
+) {
+  return GoogleDriveKnowledgeSourceConfig.parse({
+    sources: sources.map((source) => ({
+      id: source.id,
+      name: source.name,
+      mimeType: source.mimeType,
+      ...(source.driveId ? { driveId: source.driveId } : {}),
+      sourceKind:
+        source.id === "root"
+          ? "my_drive"
+          : source.driveId === source.id
+            ? "shared_drive"
+            : "folder",
+      includeDescendants: true,
+    })),
+    destination: {
+      authorityKind: documentDestination.authorityKind,
+      authorityAccountId: documentDestination.authorityAccountId,
+      ...(documentDestination.authorityWorkspaceId
+        ? { authorityWorkspaceId: documentDestination.authorityWorkspaceId }
+        : {}),
+      ...(documentDestination.authoritySubjectId
+        ? { authoritySubjectId: documentDestination.authoritySubjectId }
+        : {}),
+      ...(documentDestination.collectionId
+        ? { collectionId: documentDestination.collectionId }
+        : {}),
+    },
+    syncCadence: payload.syncCadence,
+    readPolicy: payload.readPolicy,
   });
 }
 

--- a/apps/api/src/integrations/google-drive.ts
+++ b/apps/api/src/integrations/google-drive.ts
@@ -835,11 +835,14 @@ export async function saveGoogleDriveFacetSource(
     throw new HTTPException(400, { message: "invalid Google Drive source selection" });
   }
   const payload = parsedPayload.data;
-  const requestedDestination = bindGoogleDriveDocumentDestination(input, payload);
   const requestedSources = payload.sources.map((source) => ({
     ...source,
     id: validDriveId(source.id, "source.id"),
   }));
+  if (new Set(requestedSources.map((source) => source.id)).size !== requestedSources.length) {
+    throw new HTTPException(400, { message: "Google Drive sources must be unique" });
+  }
+  const requestedDestination = bindGoogleDriveDocumentDestination(input, payload);
   const requestedConfig = googleDriveFacetConfig(requestedSources, requestedDestination, payload);
   const replayed = await replayCompletedIntegrationFacetOperation<IntegrationFacetMutationResult>(
     deps.db,

--- a/apps/api/src/integrations/google-drive.ts
+++ b/apps/api/src/integrations/google-drive.ts
@@ -836,7 +836,11 @@ export async function saveGoogleDriveFacetSource(
   }
   const payload = parsedPayload.data;
   const requestedDestination = bindGoogleDriveDocumentDestination(input, payload);
-  const requestedConfig = googleDriveFacetConfig(payload.sources, requestedDestination, payload);
+  const requestedSources = payload.sources.map((source) => ({
+    ...source,
+    id: validDriveId(source.id, "source.id"),
+  }));
+  const requestedConfig = googleDriveFacetConfig(requestedSources, requestedDestination, payload);
   const replayed = await replayCompletedIntegrationFacetOperation<IntegrationFacetMutationResult>(
     deps.db,
     {
@@ -849,12 +853,13 @@ export async function saveGoogleDriveFacetSource(
       idempotencyKey: payload.idempotencyKey,
       kind: "configure",
       expectedRequestDigest: (result) => {
-        const receipt = IntegrationFacetMutationResult.parse(result);
+        const displayName = integrationFacetReceiptDisplayName(result);
+        if (displayName === null) return "invalid-integration-facet-receipt";
         return integrationFacetConfigureRequestDigest({
           capabilityId: input.capabilityId,
           instanceKey: input.instanceKey,
           facetKey: input.facetKey,
-          displayName: receipt.binding.displayName,
+          displayName,
           config: requestedConfig,
           ...(payload.expectedVersion !== undefined
             ? { expectedVersion: payload.expectedVersion }
@@ -870,7 +875,7 @@ export async function saveGoogleDriveFacetSource(
     workspaceId: input.workspaceId,
     subjectId: input.subjectId,
     connectionId: context.connection.id,
-    sources: payload.sources,
+    sources: requestedSources,
   });
   return IntegrationFacetMutationResult.parse(
     await configureIntegrationFacet(deps.db, {
@@ -889,6 +894,13 @@ export async function saveGoogleDriveFacetSource(
       idempotencyKey: payload.idempotencyKey,
     }),
   );
+}
+
+function integrationFacetReceiptDisplayName(result: Record<string, unknown>): string | null {
+  const binding = result.binding;
+  if (!binding || typeof binding !== "object" || Array.isArray(binding)) return null;
+  const bindingRecord = binding as Record<string, unknown>;
+  return typeof bindingRecord.displayName === "string" ? bindingRecord.displayName : null;
 }
 
 export async function saveGoogleDriveSource(

--- a/apps/api/src/routes/integration-facets.ts
+++ b/apps/api/src/routes/integration-facets.ts
@@ -13,6 +13,7 @@ import {
 } from "@opengeni/core";
 import {
   configureIntegrationFacet,
+  integrationFacetConfigureRequestDigest,
   IntegrationFacetBindingOwnershipConflictError,
   IntegrationFacetBindingVersionConflictError,
   IntegrationFacetBindingVersionRequiredError,
@@ -22,6 +23,7 @@ import {
   IntegrationFacetOperationIdempotencyError,
   listIntegrationInstanceFacets,
   removeIntegrationFacet,
+  replayCompletedIntegrationFacetOperation,
   setIntegrationFacetLifecycle,
 } from "@opengeni/db";
 import type { Hono } from "hono";
@@ -126,6 +128,33 @@ export function registerIntegrationFacetRoutes(app: Hono, deps: ApiRouteDeps): v
       const instanceKey = decoded(c.req.param("instanceKey"));
       const facetKey = decoded(c.req.param("facetKey"));
       try {
+        const replayed =
+          await replayCompletedIntegrationFacetOperation<IntegrationFacetMutationResult>(deps.db, {
+            accountId: grant.accountId,
+            workspaceId,
+            subjectId: grant.subjectId,
+            capabilityId,
+            instanceKey,
+            facetKey,
+            idempotencyKey: payload.idempotencyKey,
+            kind: "configure",
+            expectedRequestDigest: integrationFacetConfigureRequestDigest({
+              capabilityId,
+              instanceKey,
+              facetKey,
+              displayName: payload.displayName,
+              config: payload.config,
+              ...(payload.expectedVersion !== undefined
+                ? { expectedVersion: payload.expectedVersion }
+                : {}),
+            }),
+          });
+        if (replayed) {
+          return c.json(
+            IntegrationFacetMutationResult.parse(replayed),
+            payload.expectedVersion === undefined ? 201 : 200,
+          );
+        }
         const instance = await listIntegrationInstanceFacets(
           deps.db,
           workspaceId,

--- a/apps/api/test/api-integrations-routes.test.ts
+++ b/apps/api/test/api-integrations-routes.test.ts
@@ -848,6 +848,43 @@ describe("API Integration routes", () => {
       },
     });
     const endpoint = `/integrations/${encodeURIComponent(installed.capabilityId)}/instances/${installed.instanceKey}/facets/drive-content/source`;
+    const aliasCollisionKey = crypto.randomUUID();
+    const aliasCollision = await request(endpoint, {
+      method: "PUT",
+      body: JSON.stringify({
+        sources: [
+          {
+            id: "folder-1",
+            name: "Product",
+            mimeType: "application/vnd.google-apps.folder",
+            driveId: null,
+          },
+          {
+            id: "https://drive.google.com/drive/folders/folder-1",
+            name: "Product",
+            mimeType: "application/vnd.google-apps.folder",
+            driveId: null,
+          },
+        ],
+        destination: { authorityKind: "workspace", collectionId: null },
+        syncCadence: "hourly",
+        syncEnabled: true,
+        readPolicy: "allow",
+        idempotencyKey: aliasCollisionKey,
+      }),
+    });
+    expect(aliasCollision.status).toBe(400);
+    expect(await aliasCollision.text()).toBe("Google Drive sources must be unique");
+    expect(googleDriveProviderRequests).toHaveLength(0);
+    expect(
+      await shared!.admin<Array<{ count: number }>>`
+        select count(*)::int as count
+        from capability_operations
+        where workspace_id = ${workspaceId}::uuid
+          and idempotency_key = ${aliasCollisionKey}
+      `,
+    ).toEqual([{ count: 0 }]);
+
     const idempotencyKey = crypto.randomUUID();
     const payload = {
       sources: [

--- a/apps/api/test/api-integrations-routes.test.ts
+++ b/apps/api/test/api-integrations-routes.test.ts
@@ -852,7 +852,7 @@ describe("API Integration routes", () => {
     const payload = {
       sources: [
         {
-          id: "folder-1",
+          id: "https://drive.google.com/drive/folders/folder-1",
           name: "Product",
           mimeType: "application/vnd.google-apps.folder",
           driveId: null,
@@ -872,9 +872,27 @@ describe("API Integration routes", () => {
     const configured = await configuredResponse.json();
     expect(configured).toMatchObject({
       status: "configured",
-      binding: { connectionId: connection.id, status: "active", version: 1 },
+      binding: {
+        connectionId: connection.id,
+        status: "active",
+        version: 1,
+        config: { sources: [{ id: "folder-1" }] },
+      },
     });
     expect(googleDriveProviderRequests).toHaveLength(1);
+
+    const legacyConfigured = {
+      ...configured,
+      binding: { ...configured.binding },
+    };
+    delete legacyConfigured.binding.directlyOwned;
+    delete legacyConfigured.binding.owners;
+    await shared!.admin`
+      update capability_operations
+      set result = ${shared!.admin.json(legacyConfigured)}
+      where workspace_id = ${workspaceId}::uuid
+        and idempotency_key = ${idempotencyKey}
+    `;
 
     googleDriveFolderName = "Renamed Product";
     await shared!.admin`

--- a/apps/api/test/api-integrations-routes.test.ts
+++ b/apps/api/test/api-integrations-routes.test.ts
@@ -1,4 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { GOOGLE_DRIVE_INTEGRATION_DEFINITION } from "@opengeni/capabilities";
+import {
+  GOOGLE_DRIVE_CREDENTIAL_LABEL,
+  GOOGLE_DRIVE_CREDENTIAL_ROLE,
+  GOOGLE_DRIVE_READONLY_SCOPE,
+  GoogleDriveConnectionMetadata,
+} from "@opengeni/contracts/google-drive";
 import { signDelegatedAccessToken } from "@opengeni/contracts";
 import type { ApiRouteDeps } from "@opengeni/core";
 import {
@@ -6,6 +13,7 @@ import {
   createConnection,
   createDb,
   deleteWorkspace,
+  encryptEnvironmentValue,
   installApiIntegration,
   type DbClient,
 } from "@opengeni/db";
@@ -25,7 +33,10 @@ import {
 import { registerIntegrationFacetRoutes } from "../src/routes/integration-facets";
 
 const delegationSecret = "api-integration-route-secret";
+const environmentsEncryptionKey = new Uint8Array(32).fill(19);
 let sourceVersion = "1.0.0";
+let googleDriveFolderName = "Product";
+const googleDriveProviderRequests: string[] = [];
 let shared: SharedTestDatabase | null = null;
 let client: DbClient | null = null;
 let app: Hono | null = null;
@@ -158,7 +169,23 @@ beforeAll(async () => {
     settings: testSettings({
       productAccessMode: "managed",
       delegationSecret,
+      environmentsEncryptionKey: Buffer.from(environmentsEncryptionKey).toString("base64"),
     }),
+    googleDriveFetch: async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      googleDriveProviderRequests.push(url.href);
+      if (url.pathname === "/drive/v3/files/folder-1") {
+        return Response.json({
+          id: "folder-1",
+          name: googleDriveFolderName,
+          mimeType: "application/vnd.google-apps.folder",
+          modifiedTime: "2026-08-14T06:00:00.000Z",
+          webViewLink: "https://drive.google.com/drive/folders/folder-1",
+          trashed: false,
+        });
+      }
+      throw new Error(`unexpected Google Drive provider request: ${url.href}`);
+    },
   } as ApiRouteDeps);
 }, 180_000);
 
@@ -710,5 +737,176 @@ describe("API Integration routes", () => {
       binding: { status: "disabled", version: 4, directlyOwned: false, owners: [] },
       remainingOwners: [],
     });
+
+    await shared!.admin`
+      update capability_plugin_installations
+      set status = 'disabled', updated_at = now()
+      where id = ${installed.pluginInstallationId}
+    `;
+    expect((await request(base)).status).toBe(404);
+    const replayAfterInstanceDrift = await request(`${base}/inventory-source`, {
+      method: "PUT",
+      body: JSON.stringify({
+        displayName: "Finance inventory",
+        config: { collection: "finance", includeArchived: false },
+        idempotencyKey: configureKey,
+      }),
+    });
+    expect(replayAfterInstanceDrift.status).toBe(201);
+    expect(await replayAfterInstanceDrift.json()).toEqual(configured);
+    const conflictAfterInstanceDrift = await request(`${base}/inventory-source`, {
+      method: "PUT",
+      body: JSON.stringify({
+        displayName: "Changed inventory",
+        config: { collection: "finance", includeArchived: false },
+        idempotencyKey: configureKey,
+      }),
+    });
+    expect(conflictAfterInstanceDrift.status).toBe(409);
+  }, 60_000);
+
+  test("replays completed Google Drive facet saves before provider and Connection validation", async () => {
+    if (!available || !client) return;
+    googleDriveFolderName = "Product";
+    googleDriveProviderRequests.length = 0;
+    const connection = await createConnection(client.db, {
+      accountId,
+      workspaceId,
+      subjectId,
+      providerDomain: "googleapis.com",
+      kind: "oauth2",
+      credentialEncrypted: encryptEnvironmentValue(
+        environmentsEncryptionKey,
+        JSON.stringify({ access_token: "route-google-access", token_type: "Bearer" }),
+      ),
+      grantedScopes: [GOOGLE_DRIVE_READONLY_SCOPE],
+      expiresAt: new Date(Date.now() + 60 * 60_000),
+      metadata: GoogleDriveConnectionMetadata.parse({
+        credentialRole: GOOGLE_DRIVE_CREDENTIAL_ROLE,
+        credentialLabel: GOOGLE_DRIVE_CREDENTIAL_LABEL,
+        googlePermissionId: "route-google-permission",
+        googleEmail: "route-google@example.com",
+        googleDisplayName: "Route Google",
+        verifiedAt: "2026-08-14T06:00:00.000Z",
+        accessMode: "readonly",
+        lifecycle: {
+          state: "active",
+          recoverable: true,
+          observedAt: "2026-08-14T06:00:00.000Z",
+        },
+      }),
+      createdBySubjectId: subjectId,
+    });
+    const installed = await installApiIntegration(client.db, {
+      accountId,
+      workspaceId,
+      subjectId,
+      capabilityId: "api:route-google-drive-facet",
+      pluginKey: "integration/route-google-drive-facet",
+      serverId: "route_google_drive_facet",
+      name: "Route Google Drive",
+      description: "Exercises provider-specific facet receipt replay.",
+      definitionId: "route-google-drive-facet",
+      definitionProvenance: "workspace",
+      providerDomain: "googleapis.com",
+      protocol: "openapi",
+      baseUrl: GOOGLE_DRIVE_INTEGRATION_DEFINITION.baseUrl,
+      sourceUrl: "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
+      authScheme: { kind: "oauth2" },
+      connectionId: connection.id,
+      instanceKey: "finance",
+      requiredScopes: [GOOGLE_DRIVE_READONLY_SCOPE],
+      ownership: "subject",
+      facetDefinitions: GOOGLE_DRIVE_INTEGRATION_DEFINITION.facets,
+      revision: {
+        id: "openapi:444444444444444444444444",
+        protocol: "openapi",
+        definitionId: "route-google-drive-facet",
+        contentSha256: "4".repeat(64),
+        source: { url: "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest" },
+        title: "Route Google Drive",
+        tools: [
+          {
+            id: "files_get",
+            operationKey: "drive.files.get",
+            name: "Get file",
+            description: "Get Drive metadata.",
+            inputSchema: { type: "object", properties: {} },
+            safety: "read",
+            approvalMode: "never",
+            deprecated: false,
+          },
+        ],
+        bindings: {
+          files_get: {
+            method: "get",
+            pathTemplate: "/files/{fileId}",
+            serverUrl: GOOGLE_DRIVE_INTEGRATION_DEFINITION.baseUrl,
+            parameters: [],
+          },
+        },
+      },
+    });
+    const endpoint = `/integrations/${encodeURIComponent(installed.capabilityId)}/instances/${installed.instanceKey}/facets/drive-content/source`;
+    const idempotencyKey = crypto.randomUUID();
+    const payload = {
+      sources: [
+        {
+          id: "folder-1",
+          name: "Product",
+          mimeType: "application/vnd.google-apps.folder",
+          driveId: null,
+        },
+      ],
+      destination: { authorityKind: "workspace", collectionId: null },
+      syncCadence: "hourly",
+      syncEnabled: true,
+      readPolicy: "allow",
+      idempotencyKey,
+    };
+    const configuredResponse = await request(endpoint, {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    });
+    expect(configuredResponse.status).toBe(200);
+    const configured = await configuredResponse.json();
+    expect(configured).toMatchObject({
+      status: "configured",
+      binding: { connectionId: connection.id, status: "active", version: 1 },
+    });
+    expect(googleDriveProviderRequests).toHaveLength(1);
+
+    googleDriveFolderName = "Renamed Product";
+    await shared!.admin`
+      update connections
+      set status = 'revoked', version = version + 1, updated_at = now()
+      where id = ${connection.id}
+    `;
+    const providerRequestCount = googleDriveProviderRequests.length;
+    const replay = await request(endpoint, {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    });
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toEqual(configured);
+    expect(googleDriveProviderRequests).toHaveLength(providerRequestCount);
+
+    const conflict = await request(endpoint, {
+      method: "PUT",
+      body: JSON.stringify({
+        ...payload,
+        sources: [{ ...payload.sources[0], name: "Renamed Product" }],
+      }),
+    });
+    expect(conflict.status).toBe(409);
+    expect(googleDriveProviderRequests).toHaveLength(providerRequestCount);
+
+    const crossSubjectReplay = await request(
+      endpoint,
+      { method: "PUT", body: JSON.stringify(payload) },
+      "user:api-integration-route-other-admin",
+    );
+    expect(crossSubjectReplay.status).toBe(409);
+    expect(googleDriveProviderRequests).toHaveLength(providerRequestCount);
   }, 60_000);
 });

--- a/packages/db/src/integration-facets.ts
+++ b/packages/db/src/integration-facets.ts
@@ -100,6 +100,72 @@ export class IntegrationFacetOperationIdempotencyError extends Error {
   readonly name = "IntegrationFacetOperationIdempotencyError";
 }
 
+type IntegrationFacetOperationKind = "configure" | "update" | "disconnect";
+
+type IntegrationFacetOperationIdentity = {
+  accountId: string;
+  workspaceId: string;
+  subjectId: string;
+  capabilityId: string;
+  instanceKey: string;
+  facetKey: string;
+  idempotencyKey: string;
+};
+
+export function integrationFacetConfigureRequestDigest(input: {
+  capabilityId: string;
+  instanceKey: string;
+  facetKey: string;
+  displayName: string;
+  config: Record<string, unknown>;
+  expectedVersion?: number;
+}): string {
+  return sha256(
+    stableJson({
+      action: "configure",
+      capabilityId: input.capabilityId,
+      instanceKey: input.instanceKey,
+      facetKey: input.facetKey,
+      displayName: input.displayName,
+      config: input.config,
+      expectedVersion: input.expectedVersion ?? null,
+    }),
+  );
+}
+
+/**
+ * Replays only an exact completed Integration Facet receipt. This intentionally
+ * runs before mutable instance/Connection/provider validation at HTTP edges.
+ */
+export async function replayCompletedIntegrationFacetOperation<T extends Record<string, unknown>>(
+  db: Database,
+  input: IntegrationFacetOperationIdentity & {
+    kind: IntegrationFacetOperationKind;
+    expectedRequestDigest: string | ((result: T) => string);
+  },
+): Promise<T | null> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      await setSubjectRlsContext(scopedDb, input.subjectId);
+      return await scopedDb.transaction(async (txRaw) => {
+        const tx = txRaw as unknown as Database;
+        await lockFacetOperation(tx, input);
+        const existing = await loadFacetOperation(tx, input);
+        if (!existing) return null;
+        const result = replayFacetOperation<T>(
+          existing,
+          input,
+          input.kind,
+          input.expectedRequestDigest,
+        );
+        return await hydrateFacetOperationResult(tx, input, result);
+      });
+    },
+  );
+}
+
 type IntegrationInstanceContext = {
   accountId: string;
   integrationFacetInstallationId: string;
@@ -226,17 +292,7 @@ export async function configureIntegrationFacet(
     idempotencyKey: string;
   },
 ): Promise<IntegrationFacetMutationResult> {
-  const requestDigest = sha256(
-    stableJson({
-      action: "configure",
-      capabilityId: input.capabilityId,
-      instanceKey: input.instanceKey,
-      facetKey: input.facetKey,
-      displayName: input.displayName,
-      config: input.config,
-      expectedVersion: input.expectedVersion ?? null,
-    }),
-  );
+  const requestDigest = integrationFacetConfigureRequestDigest(input);
   return await withFacetOperation(db, input, requestDigest, "configure", async (tx) => {
     const context = await requireMutationContext(tx, input);
     const definition = await requireFacetDefinition(tx, context, input.facetKey);
@@ -443,17 +499,9 @@ export async function removeIntegrationFacet(
 
 async function withFacetOperation<T extends Record<string, unknown>>(
   db: Database,
-  input: {
-    accountId: string;
-    workspaceId: string;
-    subjectId: string;
-    capabilityId: string;
-    instanceKey: string;
-    facetKey: string;
-    idempotencyKey: string;
-  },
+  input: IntegrationFacetOperationIdentity,
   requestDigest: string,
-  kind: string,
+  kind: IntegrationFacetOperationKind,
   execute: (tx: Database) => Promise<T>,
 ): Promise<T> {
   return await withRlsContext(
@@ -463,35 +511,11 @@ async function withFacetOperation<T extends Record<string, unknown>>(
       await setSubjectRlsContext(scopedDb, input.subjectId);
       return await scopedDb.transaction(async (txRaw) => {
         const tx = txRaw as unknown as Database;
-        await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${`capability-operation:${input.workspaceId}:${input.idempotencyKey}`}, 0))`,
-        );
-        const [existing] = await tx
-          .select()
-          .from(schema.capabilityOperations)
-          .where(
-            and(
-              eq(schema.capabilityOperations.workspaceId, input.workspaceId),
-              eq(schema.capabilityOperations.idempotencyKey, input.idempotencyKey),
-            ),
-          )
-          .for("update")
-          .limit(1);
+        await lockFacetOperation(tx, input);
+        const existing = await loadFacetOperation(tx, input);
         if (existing) {
-          if (
-            existing.createdBySubjectId !== input.subjectId ||
-            existing.requestDigest !== requestDigest
-          ) {
-            throw new IntegrationFacetOperationIdempotencyError(
-              "Integration facet idempotency key was reused",
-            );
-          }
-          if (existing.status === "completed" && existing.result) {
-            return await hydrateFacetOperationResult(tx, input, existing.result as T);
-          }
-          throw new IntegrationFacetOperationIdempotencyError(
-            "Integration facet operation is already in progress",
-          );
+          const result = replayFacetOperation<T>(existing, input, kind, requestDigest);
+          return await hydrateFacetOperationResult(tx, input, result);
         }
         const result = await execute(tx);
         await tx.insert(schema.capabilityOperations).values({
@@ -501,9 +525,7 @@ async function withFacetOperation<T extends Record<string, unknown>>(
           requestDigest,
           kind,
           targetKind: "facet_binding",
-          targetId: `facet:${sha256(
-            `${input.capabilityId}\0${input.instanceKey}\0${input.facetKey}`,
-          )}`,
+          targetId: facetOperationTargetId(input),
           status: "completed",
           phase: "completed",
           result,
@@ -514,6 +536,82 @@ async function withFacetOperation<T extends Record<string, unknown>>(
       });
     },
   );
+}
+
+async function lockFacetOperation(
+  db: Database,
+  input: Pick<IntegrationFacetOperationIdentity, "workspaceId" | "idempotencyKey">,
+): Promise<void> {
+  await db.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${`capability-operation:${input.workspaceId}:${input.idempotencyKey}`}, 0))`,
+  );
+}
+
+async function loadFacetOperation(
+  db: Database,
+  input: Pick<IntegrationFacetOperationIdentity, "accountId" | "workspaceId" | "idempotencyKey">,
+) {
+  const [existing] = await db
+    .select()
+    .from(schema.capabilityOperations)
+    .where(
+      and(
+        eq(schema.capabilityOperations.accountId, input.accountId),
+        eq(schema.capabilityOperations.workspaceId, input.workspaceId),
+        eq(schema.capabilityOperations.idempotencyKey, input.idempotencyKey),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  return existing;
+}
+
+function replayFacetOperation<T extends Record<string, unknown>>(
+  existing: typeof schema.capabilityOperations.$inferSelect,
+  input: IntegrationFacetOperationIdentity,
+  kind: IntegrationFacetOperationKind,
+  expectedRequestDigest: string | ((result: T) => string),
+): T {
+  if (
+    existing.createdBySubjectId !== input.subjectId ||
+    existing.kind !== kind ||
+    existing.targetKind !== "facet_binding" ||
+    existing.targetId !== facetOperationTargetId(input)
+  ) {
+    throw new IntegrationFacetOperationIdempotencyError(
+      "Integration facet idempotency key was reused",
+    );
+  }
+  if (
+    typeof expectedRequestDigest === "string" &&
+    existing.requestDigest !== expectedRequestDigest
+  ) {
+    throw new IntegrationFacetOperationIdempotencyError(
+      "Integration facet idempotency key was reused",
+    );
+  }
+  if (existing.status !== "completed" || !existing.result) {
+    throw new IntegrationFacetOperationIdempotencyError(
+      "Integration facet operation is already in progress",
+    );
+  }
+  const result = existing.result as T;
+  const requestDigest =
+    typeof expectedRequestDigest === "string"
+      ? expectedRequestDigest
+      : expectedRequestDigest(result);
+  if (existing.requestDigest !== requestDigest) {
+    throw new IntegrationFacetOperationIdempotencyError(
+      "Integration facet idempotency key was reused",
+    );
+  }
+  return result;
+}
+
+function facetOperationTargetId(
+  input: Pick<IntegrationFacetOperationIdentity, "capabilityId" | "instanceKey" | "facetKey">,
+): string {
+  return `facet:${sha256(`${input.capabilityId}\0${input.instanceKey}\0${input.facetKey}`)}`;
 }
 
 async function hydrateFacetOperationResult<T extends Record<string, unknown>>(


### PR DESCRIPTION
## Summary

- replay exact completed Integration Facet operation receipts before mutable instance, Connection, or provider validation
- bind replay to the exact account, workspace, subject, operation kind, target identity, and request digest
- preserve PR #1458's owner-ledger projection and legacy receipt hydration after replay validation
- cover generic facet and Google Drive replay after the live provider/Connection state has changed

## Validation

- `bun scripts/typecheck.ts --project packages/db --project apps/api`
- `bun test --timeout 120000 --max-concurrency=1 packages/db/test/api-integrations.test.ts apps/api/test/api-integrations-routes.test.ts` — 12 pass, 0 fail
- targeted `oxfmt --check`
- `git diff --check HEAD^ HEAD`

The local sandbox has no usable Docker daemon, so PostgreSQL-backed test bodies skipped locally. Hosted real-service/DB CI remains required before merge.

## Scope

No deployment, release, provider, cloud, OAuth, or production mutation is included.