### PR TITLE
fix(integrations): fence personal instance rebinds

### DIFF
--- a/.changeset/secure-personal-instances.md
+++ b/.changeset/secure-personal-instances.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Prevent workspace administrators from rebinding another subject's personal API Integration instance.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -197,8 +197,11 @@ instance has a stable `instanceKey`, human-editable display name, collision-free
 runtime MCP id, exact Connection/configuration, optimistic version, and owner
 ledger. This supports two Gmail accounts, two Linear workspaces, or several
 resource-scoped configurations without copying the schema or overwriting a
-sibling. Reconnect and uninstall operate on the exact instance; the underlying
-Connection and shared definition survive unless separately removed.
+sibling. A personal instance's Connection may be rebound only by its exact
+subject, and the replacement Connection must retain that same subject; workspace
+administration alone never transfers it. Reconnect and uninstall operate on the
+exact instance; the underlying Connection and shared definition survive unless
+separately removed.
 
 Provider adapters may also publish immutable generic facet definitions for
 Knowledge Sources, Inbound Triggers, Delivery Destinations, and Identity Links.

--- a/packages/db/drizzle/0246_integration_personal_instance_authority.sql
+++ b/packages/db/drizzle/0246_integration_personal_instance_authority.sql
@@ -1,0 +1,70 @@
+-- deployment-mode: rolling
+-- Bind every personal Integration Facet instance Connection replacement to the
+-- exact current Connection subject. The application also checks this before
+-- its upsert; this trigger is the fail-closed boundary for direct SQL writers.
+
+CREATE OR REPLACE FUNCTION capability_v2_validate_facet_binding()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  previous_connection_subject_id text;
+  requested_connection_subject_id text;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM integration_facet_definitions definition
+    JOIN capability_facet_installations installation
+      ON installation.id = NEW.integration_facet_installation_id
+     AND installation.facet_id = definition.integration_facet_id
+    WHERE definition.id = NEW.facet_definition_id
+      AND installation.account_id = NEW.account_id
+      AND installation.workspace_id = NEW.workspace_id
+  ) THEN
+    RAISE EXCEPTION 'Facet binding does not match its Integration installation or tenant'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.connection_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM connections connection
+    WHERE connection.id = NEW.connection_id
+      AND connection.account_id = NEW.account_id
+      AND connection.workspace_id = NEW.workspace_id
+  ) THEN
+    RAISE EXCEPTION 'Facet binding Connection belongs to another tenant'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+    AND OLD.connection_id IS NOT NULL
+    AND NEW.connection_id IS DISTINCT FROM OLD.connection_id
+  THEN
+    SELECT connection.subject_id
+    INTO previous_connection_subject_id
+    FROM connections connection
+    WHERE connection.id = OLD.connection_id
+      AND connection.account_id = OLD.account_id
+      AND connection.workspace_id = OLD.workspace_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Personal Integration instance belongs to another subject'
+        USING ERRCODE = '42501';
+    END IF;
+    IF previous_connection_subject_id IS NOT NULL THEN
+      IF NEW.connection_id IS NOT NULL THEN
+        SELECT connection.subject_id
+        INTO requested_connection_subject_id
+        FROM connections connection
+        WHERE connection.id = NEW.connection_id
+          AND connection.account_id = NEW.account_id
+          AND connection.workspace_id = NEW.workspace_id;
+      END IF;
+      IF requested_connection_subject_id IS DISTINCT FROM previous_connection_subject_id THEN
+        RAISE EXCEPTION 'Personal Integration instance Connection ownership cannot be changed'
+          USING ERRCODE = '42501';
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;

--- a/packages/db/src/integration-bindings.ts
+++ b/packages/db/src/integration-bindings.ts
@@ -184,6 +184,7 @@ export async function upsertIntegrationFacetBinding(
     await addIntegrationFacetBindingOwner(db, created.id, input);
     return { row: created, changed: true };
   }
+  await assertPersonalBindingConnectionRebindAuthority(db, existing, input);
   if (existing.bindingKey !== input.bindingKey) {
     throw new IntegrationFacetBindingOwnershipConflictError(
       "Integration runtime identity is already assigned to another instance",
@@ -242,6 +243,58 @@ export async function upsertIntegrationFacetBinding(
   }
   await addIntegrationFacetBindingOwner(db, row.id, input);
   return { row, changed };
+}
+
+async function assertPersonalBindingConnectionRebindAuthority(
+  db: Database,
+  existing: typeof schema.integrationFacetBindings.$inferSelect,
+  input: Pick<
+    UpsertIntegrationFacetBindingInput,
+    "accountId" | "workspaceId" | "connectionId" | "createdBySubjectId"
+  >,
+): Promise<void> {
+  const nextConnectionId = input.connectionId ?? null;
+  if (!existing.connectionId || existing.connectionId === nextConnectionId) return;
+  // Personal Connections are visible through the app role only to their exact
+  // subject, so a missing current row is an authority failure, not absence.
+  const [currentConnection] = await db
+    .select({ subjectId: schema.connections.subjectId })
+    .from(schema.connections)
+    .where(
+      and(
+        eq(schema.connections.id, existing.connectionId),
+        eq(schema.connections.accountId, input.accountId),
+        eq(schema.connections.workspaceId, input.workspaceId),
+      ),
+    )
+    .limit(1);
+  if (!currentConnection) {
+    throw new IntegrationFacetBindingOwnershipConflictError(
+      "Personal Integration instance belongs to another subject and cannot be changed in place",
+    );
+  }
+  if (!currentConnection.subjectId) return;
+  if (currentConnection.subjectId !== input.createdBySubjectId || nextConnectionId === null) {
+    throw new IntegrationFacetBindingOwnershipConflictError(
+      "Personal Integration instance belongs to another subject and cannot be changed in place",
+    );
+  }
+  const [nextConnection] = await db
+    .select({ subjectId: schema.connections.subjectId })
+    .from(schema.connections)
+    .where(
+      and(
+        eq(schema.connections.id, nextConnectionId),
+        eq(schema.connections.accountId, input.accountId),
+        eq(schema.connections.workspaceId, input.workspaceId),
+      ),
+    )
+    .limit(1);
+  if (!nextConnection || nextConnection.subjectId !== currentConnection.subjectId) {
+    throw new IntegrationFacetBindingOwnershipConflictError(
+      "Personal Integration instance Connection ownership cannot be changed",
+    );
+  }
 }
 
 export async function listIntegrationFacetBindingOwners(

--- a/packages/db/test/api-integrations.test.ts
+++ b/packages/db/test/api-integrations.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import { sql } from "drizzle-orm";
 import postgres from "postgres";
 
 import {
@@ -9,9 +10,11 @@ import {
   createConnection,
   createDb,
   deleteWorkspace,
+  grantWorkspaceAccess,
   getApiIntegrationUninstallPreview,
   getConnectionMetadata,
   installApiIntegration,
+  IntegrationFacetBindingOwnershipConflictError,
   IntegrationFacetBindingVersionConflictError,
   IntegrationFacetConfigError,
   IntegrationFacetNotFoundError,
@@ -21,6 +24,7 @@ import {
   removeIntegrationFacet,
   setIntegrationFacetLifecycle,
   uninstallApiIntegration,
+  withWorkspaceSubjectRls,
   type DbClient,
   type InstallApiIntegrationInput,
 } from "../src";
@@ -268,6 +272,172 @@ describe("API Integration persistence", () => {
       expectedInstallationVersion: installed.installationVersion,
       expectedInstanceVersion: installed.instanceVersion,
     });
+  }, 60_000);
+
+  test("keeps a victim personal instance unchanged across cross-subject rebind attempts", async () => {
+    if (!available || !client || !shared) return;
+    const suffix = crypto.randomUUID();
+    const victimSubjectId = `user:api-integration-rebind-victim-${suffix}`;
+    const attackerSubjectId = `user:api-integration-rebind-attacker-${suffix}`;
+    for (const subjectId of [victimSubjectId, attackerSubjectId]) {
+      await grantWorkspaceAccess(client.db, {
+        accountId: first.accountId,
+        workspaceId: first.workspaceId,
+        subjectId,
+        role: "admin",
+        permissions: ["workspace:read", "workspace:admin"],
+      });
+    }
+    const victimConnection = await createConnection(client.db, {
+      accountId: first.accountId,
+      workspaceId: first.workspaceId,
+      subjectId: victimSubjectId,
+      providerDomain: "inventory.example.com",
+      kind: "api_key",
+      credentialEncrypted: "test-only-victim-personal-encrypted-bundle",
+      grantedScopes: ["inventory.read", "inventory.write"],
+      createdBySubjectId: victimSubjectId,
+    });
+    const replacementVictimConnection = await createConnection(client.db, {
+      accountId: first.accountId,
+      workspaceId: first.workspaceId,
+      subjectId: victimSubjectId,
+      providerDomain: "inventory.example.com",
+      kind: "api_key",
+      credentialEncrypted: "test-only-victim-replacement-encrypted-bundle",
+      grantedScopes: ["inventory.read", "inventory.write"],
+      createdBySubjectId: victimSubjectId,
+    });
+    const attackerConnection = await createConnection(client.db, {
+      accountId: first.accountId,
+      workspaceId: first.workspaceId,
+      subjectId: attackerSubjectId,
+      providerDomain: "inventory.example.com",
+      kind: "api_key",
+      credentialEncrypted: "test-only-attacker-personal-encrypted-bundle",
+      grantedScopes: ["inventory.read", "inventory.write"],
+      createdBySubjectId: attackerSubjectId,
+    });
+    const instanceKey = `personal-${suffix}`;
+    const victimInput: InstallApiIntegrationInput = {
+      ...integrationInput(victimConnection.id, `inventory-personal-rebind-${suffix}`),
+      subjectId: victimSubjectId,
+      ownership: "subject",
+      instanceKey,
+      displayName: "Victim inventory",
+    };
+    const installed = await installApiIntegration(client.db, victimInput);
+    const [before] = await shared.admin<
+      {
+        id: string;
+        runtimeKey: string | null;
+        connectionId: string | null;
+        displayName: string;
+        version: number;
+      }[]
+    >`
+      select
+        id,
+        runtime_key as "runtimeKey",
+        connection_id as "connectionId",
+        display_name as "displayName",
+        version
+      from integration_facet_bindings
+      where id = ${installed.instanceId}`;
+    expect(before).toEqual({
+      id: installed.instanceId,
+      runtimeKey: installed.serverId,
+      connectionId: victimConnection.id,
+      displayName: "Victim inventory",
+      version: installed.instanceVersion,
+    });
+
+    await expect(
+      installApiIntegration(client.db, {
+        ...victimInput,
+        subjectId: attackerSubjectId,
+        connectionId: attackerConnection.id,
+        displayName: "Attacker inventory",
+        expectedInstanceVersion: installed.instanceVersion,
+      }),
+    ).rejects.toBeInstanceOf(IntegrationFacetBindingOwnershipConflictError);
+
+    let boundaryError: unknown = null;
+    try {
+      await withWorkspaceSubjectRls(
+        client.db,
+        first.workspaceId,
+        attackerSubjectId,
+        async (scopedDb) => {
+          await scopedDb.execute(sql`
+            update integration_facet_bindings
+            set connection_id = ${attackerConnection.id},
+                display_name = 'Attacker inventory',
+                version = version + 1,
+                updated_at = now()
+            where id = ${installed.instanceId}
+          `);
+        },
+      );
+    } catch (error) {
+      boundaryError = error;
+    }
+    expect(boundaryError).toMatchObject({ cause: { code: "42501" } });
+
+    const [after] = await shared.admin<
+      {
+        id: string;
+        runtimeKey: string | null;
+        connectionId: string | null;
+        displayName: string;
+        version: number;
+      }[]
+    >`
+      select
+        id,
+        runtime_key as "runtimeKey",
+        connection_id as "connectionId",
+        display_name as "displayName",
+        version
+      from integration_facet_bindings
+      where id = ${installed.instanceId}`;
+    expect(after).toEqual(before);
+    expect(
+      await listInstalledApiIntegrations(client.db, first.workspaceId, victimSubjectId),
+    ).toEqual([
+      expect.objectContaining({
+        instanceId: installed.instanceId,
+        instanceKey,
+        instanceVersion: installed.instanceVersion,
+        serverId: installed.serverId,
+        displayName: "Victim inventory",
+        connectionRef: expect.objectContaining({ connectionId: victimConnection.id }),
+      }),
+    ]);
+    expect(
+      await listInstalledApiIntegrations(client.db, first.workspaceId, attackerSubjectId),
+    ).toEqual([]);
+
+    const reconnected = await installApiIntegration(client.db, {
+      ...victimInput,
+      connectionId: replacementVictimConnection.id,
+      expectedInstanceVersion: installed.instanceVersion,
+    });
+    expect(reconnected).toMatchObject({
+      instanceId: installed.instanceId,
+      instanceKey,
+      serverId: installed.serverId,
+      instanceVersion: installed.instanceVersion + 1,
+    });
+    expect(
+      await listInstalledApiIntegrations(client.db, first.workspaceId, victimSubjectId),
+    ).toEqual([
+      expect.objectContaining({
+        instanceId: installed.instanceId,
+        serverId: installed.serverId,
+        connectionRef: expect.objectContaining({ connectionId: replacementVictimConnection.id }),
+      }),
+    ]);
   }, 60_000);
 
   test("installs idempotently, projects runtime policy, isolates tenants, and OCC-uninstalls", async () => {

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -201,11 +201,24 @@ describe("release schema contract", () => {
       sha256: "437bb07ffe12f9c714bd2a40d0ecd8ed9df1fd9003f4d057fe11101999841f40",
       deploymentMode: "rolling",
     });
+    expect(
+      completeSourceContract.migrations.find(
+        (migration) => migration.path === "0246_integration_personal_instance_authority.sql",
+      ),
+    ).toMatchObject({
+      sha256: "1717d5cdaa298501f20463eef43822a2b1421984f30cab7cb381c2773c505388",
+      deploymentMode: "rolling",
+    });
     const migrations = new Map(
       sourceContract.migrations.map((migration) => [migration.path, migration]),
     );
     const sessionVisibilityContractHash = (includesActivation: boolean): string | null => {
       if (!migrations.has("0236_session_visibility_slack_policy.sql")) return null;
+      if (migrations.has("0246_integration_personal_instance_authority.sql")) {
+        return includesActivation
+          ? "b70c095097581527ba8f694f17b1ef8b4607d57dd5535e1c57193fda28970b8f"
+          : "7a59d00e485087d34bde8473a94d49a895d51a049103244f6a320a750ad49f1b";
+      }
       if (
         migrations.has("0245_model_context_contribution_facts.sql") &&
         migrations.has("0244_slack_app_home_refresh_queue.sql")
@@ -545,10 +558,12 @@ describe("release schema contract", () => {
         (migrations.has("0241_enrollment_agent_runtime.sql") ? 1 : 0) +
         (migrations.has("0243_google_drive_object_acl_authority.sql") ? 1 : 0) +
         (migrations.has("0244_slack_app_home_refresh_queue.sql") ? 1 : 0) +
-        (migrations.has("0245_model_context_contribution_facts.sql") ? 1 : 0),
+        (migrations.has("0245_model_context_contribution_facts.sql") ? 1 : 0) +
+        (migrations.has("0246_integration_personal_instance_authority.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(sessionVisibilityContractHash(false) ?? currentMainContractHash);
     const latestCompatibleMigration = [
+      "0246_integration_personal_instance_authority.sql",
       "0245_model_context_contribution_facts.sql",
       "0244_slack_app_home_refresh_queue.sql",
       "0243_google_drive_object_acl_authority.sql",


### PR DESCRIPTION
## Summary

- prevent a workspace administrator from rebinding another subject's personal API Integration instance
- require both the existing and replacement Connections to retain the exact personal subject at the application boundary
- add a rolling PostgreSQL trigger as a fail-closed defense for direct SQL writers
- document the authority rule and add a two-subject regression plus release-schema contract coverage

## Validation

- `bun scripts/typecheck.ts --project packages/db --project apps/api`
- `bun test --timeout 120000 --max-concurrency=1 packages/db/test/api-integrations.test.ts apps/api/test/api-integrations-routes.test.ts packages/db/test/plugins.test.ts scripts/release-schema-contract.test.ts` — 18 pass, 0 fail
- targeted `oxfmt --check`
- `git diff --check HEAD^ HEAD`

The local sandbox has the Docker CLI but no usable daemon, so PostgreSQL-backed test bodies skipped locally. Hosted real-service/DB CI remains required before merge.

## Scope

No deployment, release, provider, cloud, OAuth, or production mutation is included.