### PR TITLE
fix: serialize workspace refresh and harden sandbox readiness

### DIFF
--- a/apps/api/src/routes/browser-sessions.ts
+++ b/apps/api/src/routes/browser-sessions.ts
@@ -95,6 +95,7 @@ import {
   findBrowserDownloadSave,
   getBrowserSessionControlRecord,
   getComputerSessionControlRecord,
+  getBrowserIdentity,
   getBrowserPrivateCheckpointAuthority,
   getAttachedBrowserDevice,
   getBrowserRevisionArtifactAuthority,
@@ -326,6 +327,20 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
         const parsed = BrowserSessionMutationResponse.parse(prepared);
         observeLifecycleResult(deps.observability, startedAtMs, parsed);
         return context.json(parsed, 200);
+      }
+
+      // Reject an unavailable explicit identity before acquiring or waking the
+      // browser placement. prepareBrowserSessionCreate repeats this check in its
+      // transaction, so an archive racing this preflight is still fenced.
+      if (!existing && request.identityId) {
+        const identity = await getBrowserIdentity(deps.db, {
+          accountId: grant.accountId,
+          workspaceId,
+          identityId: request.identityId,
+        });
+        if (identity.status !== "active") {
+          throw new BrowserIdentityStateError("BrowserIdentity is archived");
+        }
       }
 
       const sourceSession = await requireSourceSession(deps, workspaceId, request.sessionId);

--- a/apps/api/test/browser-session-routes.test.ts
+++ b/apps/api/test/browser-session-routes.test.ts
@@ -103,6 +103,18 @@ describe("BrowserSession route discipline", () => {
     expect(attachment).toContain("client.addAllowedOrigins([origin])");
   });
 
+  test("rejects archived identities before acquiring a browser placement", async () => {
+    const source = await readFile(routeUrl, "utf8");
+    const createStart = source.indexOf('app.post("/v1/workspaces/:workspaceId/browser-sessions"');
+    const createEnd = source.indexOf("app.get(", createStart);
+    const create = source.slice(createStart, createEnd);
+    expect(create).toContain("await getBrowserIdentity(deps.db");
+    expect(create.indexOf("await getBrowserIdentity(deps.db")).toBeLessThan(
+      create.indexOf("await withBrowserPlacement("),
+    );
+    expect(create).toContain('identity.status !== "active"');
+  });
+
   test("admits every controller call through the durable generation fence", async () => {
     const source = await readFile(routeUrl, "utf8");
     expect(source).toContain("touchBrowserSessionController(deps.db");

--- a/apps/worker/test/sandbox-resume-readiness.test.ts
+++ b/apps/worker/test/sandbox-resume-readiness.test.ts
@@ -15,12 +15,18 @@ import {
 function established(
   backendId: string,
   exec: (args: { cmd: string }) => Promise<unknown>,
+  writeStdin?: (args: {
+    sessionId: number;
+    chars?: string;
+    yieldTimeMs?: number;
+    maxOutputTokens?: number;
+  }) => Promise<unknown>,
 ): EstablishedSandboxSession {
   return {
     backendId,
     client: {},
     instanceId: "sandbox-1",
-    session: { exec },
+    session: { exec, ...(writeStdin ? { writeStdin } : {}) },
     sessionState: {},
   };
 }
@@ -54,13 +60,58 @@ describe("sandbox exec readiness", () => {
     ).rejects.toBeInstanceOf(SandboxExecReadinessError);
   });
 
-  test("rejects a resolved Modal exec without an explicit completion status", async () => {
-    await expect(
-      waitForSandboxExecReadiness(
-        established("modal", async () => ({ output: "" })),
-        100,
+  test("retries a transient Modal exec response without a completion status", async () => {
+    let calls = 0;
+    await waitForSandboxExecReadiness(
+      established("modal", async () => {
+        calls += 1;
+        return calls === 1 ? { output: "" } : { output: "", exitCode: 0 };
+      }),
+      500,
+    );
+    expect(calls).toBe(2);
+  });
+
+  test("polls an exact yielded readiness process instead of rejecting it", async () => {
+    const writes: Array<{
+      sessionId: number;
+      chars?: string;
+      yieldTimeMs?: number;
+      maxOutputTokens?: number;
+    }> = [];
+    await waitForSandboxExecReadiness(
+      established(
+        "modal",
+        async () => "Chunk ID: readiness\nProcess running with session ID 7\nOutput:\n",
+        async (args) => {
+          writes.push(args);
+          return "Chunk ID: readiness\nProcess exited with code 0\nOutput:\n";
+        },
       ),
-    ).rejects.toBeInstanceOf(SandboxExecReadinessError);
+      500,
+    );
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      sessionId: 7,
+      chars: "",
+      maxOutputTokens: 1_000,
+    });
+    expect(writes[0]!.yieldTimeMs).toBeGreaterThan(0);
+    expect(writes[0]!.yieldTimeMs).toBeLessThanOrEqual(500);
+  });
+
+  test("bounds repeated statusless Modal responses", async () => {
+    let calls = 0;
+    const error = await waitForSandboxExecReadiness(
+      established("modal", async () => {
+        calls += 1;
+        return { output: "" };
+      }),
+      10,
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(SandboxWarmingTimeoutError);
+    expect(calls).toBe(1);
   });
 
   test("bounds a Modal exec RPC that never returns", async () => {

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -218,6 +218,47 @@ function sandboxProvisionInFlight(events: SessionEvent[]): boolean {
   return inFlight;
 }
 
+/**
+ * Whether this session currently owns an admitted agent turn. Automatic live
+ * Files/Git reads pause across the whole turn: command boundaries are not a safe
+ * gap because the next tool can dispatch before a remote provider read releases
+ * its sandbox holder. Existing/captured content remains usable, and the terminal
+ * turn event resumes one authoritative refresh.
+ */
+function workspaceTurnInFlight(events: SessionEvent[]): boolean {
+  const activeTurnIds = new Set<string>();
+  let anonymousTurnInFlight = false;
+  let sessionOwnsWorkspace = false;
+  for (const event of events) {
+    if (event.type === "session.status.changed") {
+      const status =
+        event.payload && typeof event.payload === "object" && !Array.isArray(event.payload)
+          ? (event.payload as Record<string, unknown>).status
+          : null;
+      sessionOwnsWorkspace = status === "running" || status === "recovering";
+      continue;
+    }
+    if (event.type === "turn.started") {
+      if (event.turnId) activeTurnIds.add(event.turnId);
+      else anonymousTurnInFlight = true;
+      continue;
+    }
+    if (
+      event.type !== "turn.completed" &&
+      event.type !== "turn.failed" &&
+      event.type !== "turn.cancelled" &&
+      event.type !== "turn.superseded"
+    ) {
+      continue;
+    }
+    if (event.turnId) activeTurnIds.delete(event.turnId);
+    else anonymousTurnInFlight = false;
+  }
+  // The retained event window preserves the latest status even after a very
+  // long turn has evicted its original turn.started event.
+  return sessionOwnsWorkspace || anonymousTurnInFlight || activeTurnIds.size > 0;
+}
+
 export type WorkspaceMachine = {
   /** Whether at least one built-in workbench surface is enabled. */
   enabled: boolean;
@@ -276,7 +317,8 @@ export type UseSandboxWorkspaceTabsResult = {
   /** Changes | Files | Terminal | Browser | Desktop (capability-gated where noted). */
   tabs: WorkspaceTab[];
   /** The source-driven default tab: Changes when the first authoritative capture
-   *  or live Git result has changes, else Files (a host `initialTab` overrides).
+   *  has changes, else Files (a host `initialTab` overrides). Choosing a tab
+   *  never performs hidden live workspace I/O.
    *  null while that source resolves, or permanently when neither Changes nor
    *  Files is enabled; the choice latches once. */
   defaultTab: string | null;
@@ -359,6 +401,7 @@ export function useSandboxWorkspaceTabs(
   const resolvedActiveTab = activeTab ?? initialTab;
   const changesActive = resolvedActiveTab === WORKBENCH_TAB_CHANGES;
   const filesActive = resolvedActiveTab === WORKBENCH_TAB_FILES;
+  const turnInFlight = workspaceTurnInFlight(events);
   const surfaceIdentity = WORKBENCH_SURFACES.filter((surface) => surfaceSet.has(surface)).join(",");
 
   // The two box-warming INTENTS, each off by default and each
@@ -512,7 +555,11 @@ export function useSandboxWorkspaceTabs(
     // No passive Channel-A reads while cold, even after a conclusive capture
     // miss. A missing capture gets an explicit "Open live workspace" gate.
     enabled: filesEnabled && (captureAvailable || (fileSystemOn && liveWorkspaceExpected)),
-    active: filesActive,
+    // A cold sandbox can become warm while the first agent command still owns
+    // startup. Do not race that command with an automatic Files read. Keeping
+    // this fence at turn scope also avoids unsafe millisecond gaps between
+    // sequential tool calls; rendered state and explicit user actions remain.
+    active: filesActive && !turnInFlight,
     repoPaths,
     liveness: liveIoLiveness,
     capture: captureState.capture,
@@ -553,10 +600,11 @@ export function useSandboxWorkspaceTabs(
         : changesComparison === "branch"
           ? workspaceDataEnabled && (captureSupportsBranch || (gitOn && liveWorkspaceExpected))
           : workspaceDataEnabled && gitOn && liveWorkspaceExpected,
-    // Before the dock chooses its source-driven default, Git is the sole probe
-    // that may need to resolve that choice on a live workspace. Files remains
-    // dormant, avoiding the old duplicate full-tree read.
-    active: changesActive || resolvedActiveTab === null,
+    // Live Git belongs to the visible Changes surface. In particular, do not
+    // turn an unresolved/default tab into a hidden provider read: that races the
+    // agent's own sandbox commands and used to refresh after every tool output
+    // even while Files was visibly selected.
+    active: changesActive && !turnInFlight,
     repoPaths,
     liveness: liveIoLiveness,
     comparison: changesComparison,
@@ -605,14 +653,12 @@ export function useSandboxWorkspaceTabs(
   });
   const workspaceWaking = chip.state === "waking";
 
-  // The pre-paint default tab is decided from the first AUTHORITATIVE workspace
-  // source. A capture wins immediately on the cold/offline fast path; a warm box
-  // waits for live Git so a prior snapshot can never outrank the current tree.
-  // When the GET says no capture exists, `fileCount: 0` does NOT itself mean the
-  // working tree is clean. A captured-revision announce can
-  // resolve Changes earlier, but a pure embedder with no event preload still gets
-  // the correct live default. The choice latches once so later edits never steal
-  // the user's current tab.
+  // The pre-paint default comes only from the durable capture. Default selection
+  // must never dispatch live provider work: a live Git probe can overlap the
+  // agent's first command, and an uncontrolled dock used to keep that probe
+  // active forever after it visibly selected Files. A capture with reviewable
+  // changes opens Changes; no capture (or an empty one) opens Files. The choice
+  // latches once so later edits never steal the user's current tab.
   const defaultIdentity = `${sessionId}\u0000${surfaceIdentity}`;
   const defaultTabRef = useRef<{ identity: string; value: string | null }>({
     identity: defaultIdentity,
@@ -621,62 +667,25 @@ export function useSandboxWorkspaceTabs(
   if (defaultTabRef.current.identity !== defaultIdentity) {
     defaultTabRef.current = { identity: defaultIdentity, value: null };
   }
-  const captureIsAuthoritative =
-    !liveWorkspaceExpected && (liveness !== undefined || caps.error !== null);
   const captureHasChanges =
     (captureState.fileCount ?? 0) > 0 ||
     (captureState.capture?.repos.some((repo) => (repo.branchDiff?.length ?? 0) > 0) ?? false);
   const captureUnavailable =
     (captureState.fileCount === 0 && !captureHasChanges) || captureState.error !== null;
-  const implicitBranchFallbackPending =
-    changesComparison === "branch" &&
-    git.error !== null &&
-    storedChangesComparison?.sessionId !== sessionId;
   if (defaultTabRef.current.value === null) {
     if (initialTab && (!isWorkbenchSurface(initialTab) || surfaceSet.has(initialTab))) {
       defaultTabRef.current.value = initialTab;
-    } else if (git.source === "live") {
-      defaultTabRef.current.value = sourceDrivenDefaultTab(
-        git.diff.length > 0,
-        changesEnabled,
-        filesEnabled,
-      );
-    } else if (
-      captureIsAuthoritative &&
-      captureState.fileCount !== null &&
-      captureState.available
-    ) {
+    } else if (captureState.fileCount !== null && captureState.available) {
       defaultTabRef.current.value = sourceDrivenDefaultTab(
         captureHasChanges,
         changesEnabled,
         filesEnabled,
       );
-    } else if (
-      captureIsAuthoritative &&
-      captureUnavailable &&
-      initialWorkspaceTab(events) === WORKBENCH_TAB_CHANGES
-    ) {
+    } else if (captureUnavailable && initialWorkspaceTab(events) === WORKBENCH_TAB_CHANGES) {
       defaultTabRef.current.value = sourceDrivenDefaultTab(true, changesEnabled, filesEnabled);
-    } else if (captureUnavailable && caps.error) {
-      // The Changes surface owns the truthful sandbox-unavailable state + retry.
-      // Files would misleadingly describe this as a missing filesystem.
-      defaultTabRef.current.value = sourceDrivenDefaultTab(true, changesEnabled, filesEnabled);
-    } else if (captureIsAuthoritative && captureState.fileCount !== null && captureUnavailable) {
-      // No durable review surface exists and the machine is resting. Files owns
-      // the explicit wake gate; do not issue a live Git probe merely to choose a
-      // tab.
-      defaultTabRef.current.value = sourceDrivenDefaultTab(false, changesEnabled, filesEnabled);
-    } else if (captureState.available && git.error && captureState.fileCount !== null) {
-      // A warm live read failed but the durable capture is intact: retain an
-      // immediate, deterministic review surface instead of hanging unresolved.
-      defaultTabRef.current.value = sourceDrivenDefaultTab(
-        captureHasChanges,
-        changesEnabled,
-        filesEnabled,
-      );
-    } else if (captureUnavailable && git.error && !implicitBranchFallbackPending) {
-      // No capture and live Git failed: Files is the least surprising fallback
-      // after the implicit branch-to-working fallback has also had its chance.
+    } else if (captureState.fileCount !== null || captureState.error !== null) {
+      // No durable review surface exists. Files owns the explicit live-workspace
+      // gate; a user can open Changes deliberately if they need a fresh Git read.
       defaultTabRef.current.value = sourceDrivenDefaultTab(false, changesEnabled, filesEnabled);
     }
   }
@@ -917,7 +926,7 @@ export type SandboxWorkspaceProps = ClientOverride & {
   /** Host tabs injected AFTER the workbench tabs (e.g. a "Debug" tab). */
   trailingTabs?: WorkspaceTab[] | undefined;
   /** Override the pre-paint default tab (e.g. a host landing tab id). When
-   *  omitted the workbench decides from capture, then live Git when no capture exists. */
+   *  omitted the workbench decides from the durable workspace capture. */
   initialTab?: string | undefined;
   /** Host-routed notifications (no toast dependency in the package). */
   onNotify?: ((notification: WorkspaceNotification) => void) | undefined;
@@ -1051,6 +1060,13 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
     (tab: string) => setStoredSelection({ sessionId, tab }),
     [sessionId],
   );
+  useEffect(() => {
+    if (selectedTab !== null || defaultTab === null) return;
+    // Once the source-driven choice resolves, make it the real controlled
+    // selection. Without this handoff the dock could visibly show Files while
+    // the data hooks continued treating the selection as unresolved.
+    setStoredSelection({ sessionId, tab: defaultTab });
+  }, [defaultTab, selectedTab, sessionId]);
 
   return (
     <WorkspaceDock

--- a/packages/react/src/hooks/use-sandbox-files.ts
+++ b/packages/react/src/hooks/use-sandbox-files.ts
@@ -282,21 +282,7 @@ function findNodeByPath(nodes: FileTreeNode[], path: string): FileTreeNode | und
   return undefined;
 }
 
-/** Root plus every directory whose children are currently loaded. Re-listing
- * this small visible frontier refreshes agent shell edits without expanding or
- * traversing hidden directories. */
-function loadedDirectoryPaths(nodes: FileTreeNode[]): string[] {
-  const paths = [""];
-  const walk = (list: FileTreeNode[]) => {
-    for (const node of list) {
-      if (node.kind !== "dir" || node.children === undefined) continue;
-      paths.push(node.path);
-      walk(node.children);
-    }
-  };
-  walk(nodes);
-  return paths;
-}
+const FS_LIST_BATCH_REQUEST_LIMIT = 16;
 
 /** Repository paths are capability-advertised and therefore safe to use as a
  * bounded initial lazy-tree frontier. Listing their ancestors concurrently with
@@ -527,9 +513,9 @@ export function useSandboxFiles(
   const lastSeqRef = useRef(0);
   const pendingParentsRef = useRef<Set<string>>(new Set());
   const pendingGitRef = useRef(false);
-  const pendingAgentToolRef = useRef(false);
+  const eventReconcileInFlightRef = useRef<Promise<void> | null>(null);
+  const eventReconcilePendingRef = useRef(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastCommandRefreshAtRef = useRef(0);
 
   // ── Self-emitted fs.changed de-dupe ───────────────────────────────────────
   // Every one of OUR mutations emits an `fs.changed` event back on the live log
@@ -584,34 +570,15 @@ export function useSandboxFiles(
     setGitLoading(true);
     setError(null);
     try {
-      // Start the optional Git tint and the actual directory listing together.
-      // A remote status read must never block the first useful file-tree paint.
+      // Paint the useful file tree before the optional Git tint. Separate remote
+      // requests for one Modal box are deliberately serialized by the API; firing
+      // both here only made the Git request contend with the file request during
+      // cold starts.
       const frontierPaths = initialDirectoryFrontier(rootPath, repoPaths);
       const listRequests = [rootPath, ...frontierPaths].map((path) => ({
         path,
         depth: 1,
       }));
-      const statusPromise =
-        repoPaths.length > 0
-          ? client
-              .gitReadBatch(
-                workspaceId,
-                sessionId,
-                {
-                  requests: repoPaths.map((root) => ({
-                    status: { path: root },
-                  })),
-                },
-                { signal: refreshAbort.signal },
-              )
-              .then((batch) =>
-                batch.results.map((result, index) => ({
-                  root: repoPaths[index] ?? "",
-                  status: result.status,
-                })),
-              )
-              .catch(() => null)
-          : Promise.resolve([]);
       // Root plus the bounded repository frontier share one API request, one
       // direct holder, and one provider attach. The old per-directory fan-out
       // paid that fixed control-plane cost up to nine times on every Files open.
@@ -644,7 +611,27 @@ export function useSandboxFiles(
       setSource("live");
       setLoading(false);
 
-      const statuses = await statusPromise;
+      const statuses =
+        repoPaths.length > 0
+          ? await client
+              .gitReadBatch(
+                workspaceId,
+                sessionId,
+                {
+                  requests: repoPaths.map((root) => ({
+                    status: { path: root },
+                  })),
+                },
+                { signal: refreshAbort.signal },
+              )
+              .then((batch) =>
+                batch.results.map((result, index) => ({
+                  root: repoPaths[index] ?? "",
+                  status: result.status,
+                })),
+              )
+              .catch(() => null)
+          : [];
       if (refreshGenerationRef.current !== generation) return;
       if (statuses) {
         const overlay = new Map<string, FileTreeStatus>();
@@ -888,6 +875,57 @@ export function useSandboxFiles(
     [client, workspaceId, sessionId, applyStatus],
   );
 
+  // Reconcile the visible directory frontier through bounded batch requests.
+  // One tool completion can affect several expanded directories; issuing one
+  // provider request per directory created a self-inflicted lock convoy.
+  const reconcilePaths = useCallback(
+    async (requestedPaths: readonly string[], requestSignal?: AbortSignal) => {
+      if (!sessionId) return;
+      const identityGeneration = identityGenerationRef.current;
+      const identitySignal = identityAbortRef.current.signal;
+      const signal = requestSignal
+        ? AbortSignal.any([identitySignal, requestSignal])
+        : identitySignal;
+      const paths = [...new Set(requestedPaths)].filter((path) =>
+        parentIsLoaded(treeRef.current, path),
+      );
+      for (let offset = 0; offset < paths.length; offset += FS_LIST_BATCH_REQUEST_LIMIT) {
+        const chunk = paths.slice(offset, offset + FS_LIST_BATCH_REQUEST_LIMIT);
+        try {
+          const listed = await client.fsListBatch(
+            workspaceId,
+            sessionId,
+            { requests: chunk.map((path) => ({ path, depth: 1 })) },
+            { signal },
+          );
+          if (identityGenerationRef.current !== identityGeneration) return;
+          setTree((previous) => {
+            let next = previous;
+            for (const [index, path] of chunk.entries()) {
+              const result = listed.results[index];
+              if (!result) continue;
+              const children = (result.root.children ?? []).map((node) => fsNodeToTree(node));
+              if (path === "") {
+                next = mergeRootChildren(next, children);
+              } else {
+                const existing = findNodeByPath(next, path);
+                const merged = existing?.children
+                  ? mergeChildren(existing.children, children)
+                  : children;
+                next = replaceChildren(next, path, merged);
+              }
+            }
+            return applyStatus(next);
+          });
+        } catch {
+          // Reconciliation is best-effort. Preserve the current visible tree and
+          // let the next real event or explicit refresh reconcile it.
+        }
+      }
+    },
+    [client, workspaceId, sessionId, applyStatus],
+  );
+
   // Run a Channel-A op behind an OPTIMISTIC tree edit. `apply` splices the change
   // in immediately (preserving expansion/selection); the op runs in the
   // background; on failure we revert to the pre-op snapshot and surface a toast.
@@ -1107,14 +1145,14 @@ export function useSandboxFiles(
     const identityChanged = previousIdentityRef.current !== identityKey;
     previousIdentityRef.current = identityKey;
     if (identityChanged || !enabled) {
+      if (identityChanged) eventReconcileInFlightRef.current = null;
       identityAbortRef.current.abort();
       identityAbortRef.current = new AbortController();
       identityGenerationRef.current += 1;
       lastSeqRef.current = 0;
       pendingParentsRef.current = new Set();
       pendingGitRef.current = false;
-      pendingAgentToolRef.current = false;
-      lastCommandRefreshAtRef.current = 0;
+      eventReconcilePendingRef.current = false;
       if (debounceRef.current) {
         clearTimeout(debounceRef.current);
         debounceRef.current = null;
@@ -1155,6 +1193,7 @@ export function useSandboxFiles(
       refreshAbortRef.current = null;
       refreshGenerationRef.current += 1;
       eventReadAbortRef.current.abort();
+      eventReconcilePendingRef.current = false;
     };
   }, [
     enabled,
@@ -1211,6 +1250,44 @@ export function useSandboxFiles(
     [client, workspaceId, sessionId, repoPaths, applyStatus],
   );
 
+  const performEventReconcile = useCallback(async () => {
+    const parents = pendingParentsRef.current;
+    pendingParentsRef.current = new Set();
+    const wantGit = pendingGitRef.current;
+    pendingGitRef.current = false;
+    const signal = eventReadAbortRef.current.signal;
+    const paths = [...parents];
+
+    // File content is the primary Files-tab result. Reconcile it first, then add
+    // the optional Git tint through a second serial request. This matches the
+    // API's exact-provider serialization instead of making the two reads contend.
+    await reconcilePaths(paths, signal);
+    if (wantGit) await refreshGitOverlay(signal);
+  }, [reconcilePaths, refreshGitOverlay]);
+  const performEventReconcileRef = useRef(performEventReconcile);
+  performEventReconcileRef.current = performEventReconcile;
+  const reconcilePendingEvents = useCallback(async () => {
+    eventReconcilePendingRef.current = true;
+    const existing = eventReconcileInFlightRef.current;
+    if (existing) return await existing;
+    const identityGeneration = identityGenerationRef.current;
+    const run = (async () => {
+      while (
+        eventReconcilePendingRef.current &&
+        identityGenerationRef.current === identityGeneration
+      ) {
+        eventReconcilePendingRef.current = false;
+        await performEventReconcileRef.current();
+      }
+    })();
+    eventReconcileInFlightRef.current = run;
+    try {
+      await run;
+    } finally {
+      if (eventReconcileInFlightRef.current === run) eventReconcileInFlightRef.current = null;
+    }
+  }, []);
+
   // Auto-reconcile on fs/git change notifications — TARGETED, never a root
   // collapse-reload, and de-duped against our OWN mutations.
   //
@@ -1221,6 +1298,8 @@ export function useSandboxFiles(
   //     reconciles ONLY the affected parent directories (in place, expansion
   //     preserved). Bursts are debounced into a single reconcile pass.
   //   • A git.changed just re-tints (refreshes the status overlay) — no fs re-list.
+  //   • Generic command/tool output performs no provider reads. The canonical
+  //     turn-end capture refreshes the root once after the command burst settles.
   const events = options.events;
 
   useEffect(() => {
@@ -1238,12 +1317,11 @@ export function useSandboxFiles(
       }
       pendingParentsRef.current = new Set();
       pendingGitRef.current = false;
-      pendingAgentToolRef.current = false;
+      eventReconcilePendingRef.current = false;
       return;
     }
     let sawNew = false;
     let contentChanged = false;
-    let sawCommandDelta = false;
     for (const event of events) {
       if (event.sequence <= lastSeqRef.current) continue;
       if (event.type === "fs.changed") {
@@ -1273,73 +1351,27 @@ export function useSandboxFiles(
         )
           continue;
         pendingGitRef.current = true;
-      } else if (event.type === "agent.toolCall.output") {
-        // Agent shell/apply-patch writes do not necessarily pass through the
-        // structured FS service, so they may have no fs.changed notification.
-        // A completed tool is a bounded invalidation point: refresh only the
-        // currently-loaded directory frontier, never poll and never traverse a
-        // collapsed subtree.
-        sawNew = true;
-        contentChanged = true;
-        pendingAgentToolRef.current = true;
-        // Shell/apply-patch writes bypass the structured Git service too, so no
-        // git.changed event is guaranteed. Refresh the summary/tints alongside
-        // the visible tree frontier; both remote reads can run concurrently.
-        pendingGitRef.current = true;
-      } else if (event.type === "sandbox.command.output.delta") {
-        // Ordinary shell writes can bypass Channel-A and therefore emit no
-        // fs.changed/git.changed event until the command completes. Reconcile
-        // the visible frontier at most once per second while output streams so
-        // Files and Changes stay useful without turning the dock into polling.
-        sawNew = true;
-        contentChanged = true;
-        sawCommandDelta = true;
-        pendingAgentToolRef.current = true;
-        pendingGitRef.current = true;
       }
     }
     // Advance the high-water mark past everything we've folded.
     for (const event of events)
       if (event.sequence > lastSeqRef.current) lastSeqRef.current = event.sequence;
     if (!sawNew) return;
-    if (contentChanged && !sawCommandDelta) setContentRevision((revision) => revision + 1);
+    if (contentChanged) setContentRevision((revision) => revision + 1);
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
     const identityGeneration = identityGenerationRef.current;
-    const delay = sawCommandDelta
-      ? Math.max(0, 1_000 - (Date.now() - lastCommandRefreshAtRef.current))
-      : 150;
     debounceRef.current = setTimeout(() => {
       debounceRef.current = null;
       if (identityGenerationRef.current !== identityGeneration) return;
       if (!acceptsEventReadsRef.current) {
         pendingParentsRef.current = new Set();
         pendingGitRef.current = false;
-        pendingAgentToolRef.current = false;
         return;
       }
-      if (sawCommandDelta) {
-        lastCommandRefreshAtRef.current = Date.now();
-        setContentRevision((revision) => revision + 1);
-      }
-      const parents = pendingParentsRef.current;
-      pendingParentsRef.current = new Set();
-      const wantGit = pendingGitRef.current;
-      pendingGitRef.current = false;
-      const wantAgentTool = pendingAgentToolRef.current;
-      pendingAgentToolRef.current = false;
-      // Reconcile the changed directories and Git overlay concurrently. Both are
-      // independent remote reads; applyStatus makes their completion order safe.
-      const eventReadSignal = eventReadAbortRef.current.signal;
-      void (async () => {
-        const paths = wantAgentTool ? loadedDirectoryPaths(treeRef.current) : [...parents];
-        await Promise.all([
-          wantGit ? refreshGitOverlay(eventReadSignal) : Promise.resolve(),
-          Promise.all(paths.map((path) => reconcilePath(path, eventReadSignal))),
-        ]);
-      })();
-    }, delay);
-  }, [enabled, active, acceptsEventReads, events, reconcilePath, refreshGitOverlay]);
+      void reconcilePendingEvents();
+    }, 150);
+  }, [enabled, active, acceptsEventReads, events, reconcilePendingEvents]);
 
   useEffect(() => {
     if (active && acceptsEventReads) return;
@@ -1349,7 +1381,7 @@ export function useSandboxFiles(
     }
     pendingParentsRef.current = new Set();
     pendingGitRef.current = false;
-    pendingAgentToolRef.current = false;
+    eventReconcilePendingRef.current = false;
   }, [active, acceptsEventReads]);
 
   useEffect(
@@ -1357,6 +1389,7 @@ export function useSandboxFiles(
       refreshAbortRef.current?.abort();
       identityAbortRef.current.abort();
       eventReadAbortRef.current.abort();
+      eventReconcilePendingRef.current = false;
       identityGenerationRef.current += 1;
       if (debounceRef.current) clearTimeout(debounceRef.current);
     },

--- a/packages/react/src/hooks/use-sandbox-git.ts
+++ b/packages/react/src/hooks/use-sandbox-git.ts
@@ -233,12 +233,14 @@ export function useSandboxGit(
   // survive renders, so they must be fenced/reset when that identity changes.
   const refreshGenerationRef = useRef(0);
   const refreshAbortRef = useRef<AbortController | null>(null);
+  const refreshInFlightRef = useRef<Promise<void> | null>(null);
+  const refreshPendingRef = useRef(false);
+  const refreshWorkerEpochRef = useRef(0);
   const lastChangeRef = useRef(0);
-  const commandRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const eventRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const refresh = useCallback(async () => {
+  const performRefresh = useCallback(async () => {
     if (!sessionId) return;
-    refreshAbortRef.current?.abort();
     const refreshAbort = new AbortController();
     refreshAbortRef.current = refreshAbort;
     const generation = (refreshGenerationRef.current += 1);
@@ -377,6 +379,32 @@ export function useSandboxGit(
     comparison,
   ]);
 
+  // Provider reads cannot be undispatched after they reach a remote sandbox.
+  // Keep exactly one refresh in flight and collapse any burst of invalidations
+  // into one trailing read. Aborting and replacing every tool-output refresh
+  // used to leave several Modal reads contending for the same provider lock.
+  const performRefreshRef = useRef(performRefresh);
+  performRefreshRef.current = performRefresh;
+  const refresh = useCallback(async () => {
+    refreshPendingRef.current = true;
+    const existing = refreshInFlightRef.current;
+    if (existing) return await existing;
+
+    const workerEpoch = refreshWorkerEpochRef.current;
+    const run = (async () => {
+      while (refreshPendingRef.current && refreshWorkerEpochRef.current === workerEpoch) {
+        refreshPendingRef.current = false;
+        await performRefreshRef.current();
+      }
+    })();
+    refreshInFlightRef.current = run;
+    try {
+      await run;
+    } finally {
+      if (refreshInFlightRef.current === run) refreshInFlightRef.current = null;
+    }
+  }, []);
+
   // Serve the requested review scope from a capture when that scope exists.
   const seedFromCapture = useCallback(
     (manifest: WorkspaceCaptureManifest) => {
@@ -432,9 +460,17 @@ export function useSandboxGit(
     // true data-identity change clears rendered state and the event high-water mark.
     refreshAbortRef.current?.abort();
     refreshAbortRef.current = null;
+    refreshPendingRef.current = false;
     refreshGenerationRef.current += 1;
     const identityChanged = previousIdentityRef.current !== identityKey;
     previousIdentityRef.current = identityKey;
+    if (identityChanged) {
+      // Different sessions target different provider identities. Fence the old
+      // worker and let the new session load immediately instead of waiting for a
+      // stuck request that has already been aborted.
+      refreshWorkerEpochRef.current += 1;
+      refreshInFlightRef.current = null;
+    }
     if (identityChanged || !enabled) {
       lastChangeRef.current = 0;
       setDiff([]);
@@ -466,6 +502,7 @@ export function useSandboxGit(
     return () => {
       refreshAbortRef.current?.abort();
       refreshAbortRef.current = null;
+      refreshPendingRef.current = false;
       refreshGenerationRef.current += 1;
     };
   }, [
@@ -479,15 +516,15 @@ export function useSandboxGit(
     seedFromCapture,
   ]);
 
-  // git.changed → re-fetch the LIVE diff. Agent tool completion is also an
-  // invalidation point because shell/apply-patch writes can bypass Channel-A and
-  // therefore emit no git.changed event. This is event-driven, never polling.
+  // Structured Git changes are debounced into one live reconcile. Generic
+  // command/tool output performs no provider reads: the canonical turn-end
+  // capture advances `captureRevision`, which refreshes after the burst settles.
   const events = options.events;
   useEffect(() => {
     if (!enabled || !events) {
-      if (commandRefreshTimerRef.current) {
-        clearTimeout(commandRefreshTimerRef.current);
-        commandRefreshTimerRef.current = null;
+      if (eventRefreshTimerRef.current) {
+        clearTimeout(eventRefreshTimerRef.current);
+        eventRefreshTimerRef.current = null;
       }
       return;
     }
@@ -498,43 +535,35 @@ export function useSandboxGit(
       for (const event of events) {
         if (event.sequence > lastChangeRef.current) lastChangeRef.current = event.sequence;
       }
-      if (commandRefreshTimerRef.current) {
-        clearTimeout(commandRefreshTimerRef.current);
-        commandRefreshTimerRef.current = null;
+      if (eventRefreshTimerRef.current) {
+        clearTimeout(eventRefreshTimerRef.current);
+        eventRefreshTimerRef.current = null;
       }
       return;
     }
     let latest = lastChangeRef.current;
-    let immediate = false;
-    let commandDelta = false;
+    let changed = false;
     for (const event of events) {
       if (event.sequence <= latest) continue;
-      if (event.type === "git.changed" || event.type === "agent.toolCall.output") {
+      if (event.type === "git.changed") {
         latest = event.sequence;
-        immediate = true;
-      } else if (event.type === "sandbox.command.output.delta") {
-        latest = event.sequence;
-        commandDelta = true;
+        changed = true;
       }
     }
     if (latest > lastChangeRef.current) {
       lastChangeRef.current = latest;
-      if (immediate) {
-        if (commandRefreshTimerRef.current) clearTimeout(commandRefreshTimerRef.current);
-        commandRefreshTimerRef.current = null;
+      if (!changed) return;
+      if (eventRefreshTimerRef.current) clearTimeout(eventRefreshTimerRef.current);
+      eventRefreshTimerRef.current = setTimeout(() => {
+        eventRefreshTimerRef.current = null;
         if (acceptsEventReadsRef.current) void refresh();
-      } else if (commandDelta && !commandRefreshTimerRef.current) {
-        commandRefreshTimerRef.current = setTimeout(() => {
-          commandRefreshTimerRef.current = null;
-          if (acceptsEventReadsRef.current) void refresh();
-        }, 1_000);
-      }
+      }, 150);
     }
   }, [enabled, active, acceptsEventReads, events, refresh]);
 
   useEffect(
     () => () => {
-      if (commandRefreshTimerRef.current) clearTimeout(commandRefreshTimerRef.current);
+      if (eventRefreshTimerRef.current) clearTimeout(eventRefreshTimerRef.current);
     },
     [],
   );

--- a/packages/react/test/sandbox-hooks.test.tsx
+++ b/packages/react/test/sandbox-hooks.test.tsx
@@ -810,34 +810,55 @@ describe("useSandboxFiles", () => {
   test("lists the tree (depth 1) and overlays git status, expands lazily", async () => {
     const listCalls: string[] = [];
     let batchCalls = 0;
+    let activeProviderReads = 0;
+    let maxActiveProviderReads = 0;
+    const initialReadOrder: string[] = [];
+    const gitStatus: SessionClientLike["gitStatus"] = async () => ({
+      isRepo: true,
+      head: "main",
+      detached: false,
+      upstream: null,
+      ahead: 0,
+      behind: 0,
+      files: [
+        {
+          path: "src/app.ts",
+          oldPath: null,
+          index: null,
+          worktree: "modified",
+          isConflicted: false,
+        },
+      ],
+      revision: 1,
+    });
     const client = fakeClient({
-      gitStatus: async () => ({
-        isRepo: true,
-        head: "main",
-        detached: false,
-        upstream: null,
-        ahead: 0,
-        behind: 0,
-        files: [
-          {
-            path: "src/app.ts",
-            oldPath: null,
-            index: null,
-            worktree: "modified",
-            isConflicted: false,
-          },
-        ],
-        revision: 1,
-      }),
+      gitStatus,
+      gitReadBatch: async (workspaceId, sessionId, request, options) => {
+        activeProviderReads += 1;
+        maxActiveProviderReads = Math.max(maxActiveProviderReads, activeProviderReads);
+        initialReadOrder.push("git");
+        const results = await Promise.all(
+          request.requests.map(async (item) => ({
+            status: await gitStatus(workspaceId, sessionId, item.status, options),
+          })),
+        );
+        activeProviderReads -= 1;
+        return { results };
+      },
       fsListBatch: async (workspaceId, sessionId, request, options) => {
         batchCalls += 1;
-        return {
+        activeProviderReads += 1;
+        maxActiveProviderReads = Math.max(maxActiveProviderReads, activeProviderReads);
+        initialReadOrder.push("files");
+        const response = {
           results: await Promise.all(
             request.requests.map(
               async (item) => await client.fsList(workspaceId, sessionId, item, options),
             ),
           ),
         };
+        activeProviderReads -= 1;
+        return response;
       },
       fsList: async (_ws, _s, req) => {
         listCalls.push(req?.path ?? "");
@@ -916,6 +937,8 @@ describe("useSandboxFiles", () => {
     // The modified file carries the git-status overlay.
     expect(src?.children?.[0]?.status).toBe("modified");
     expect(batchCalls).toBe(1);
+    expect(maxActiveProviderReads).toBe(1);
+    expect(initialReadOrder.slice(0, 2)).toEqual(["files", "git"]);
     expect(listCalls).toContain("src");
     await hook.unmount();
   });

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -7,9 +7,9 @@
    attaches a viewer. This closes a live prod cost (box-hours burned to serve reads
    the capture already answers for free).
 
-   Refinement 2 — the default tab is decided from the first authoritative source:
-   capture stats when present, otherwise live Git. No embedder events-at-mount
-   contract is required and the choice latches before real content paints.
+   Refinement 2 — the default tab is decided from the durable capture, never a
+   hidden live provider read. No embedder events-at-mount contract is required
+   and the choice latches before real content paints.
    -------------------------------------------------------------------------- */
 import { describe, expect, test } from "bun:test";
 import { act, type ReactElement, type ReactNode, useMemo } from "react";
@@ -954,48 +954,143 @@ describe("capture-driven default tab (Refinement 2)", () => {
     await hook.unmount();
   });
 
-  test("warm live changes with no capture → default Changes from authoritative Git", async () => {
+  test("warm workspace with no capture defaults Files without hidden Git I/O", async () => {
     const diff = [fakeFileDiff({ path: "src/live-change.ts" })];
+    let gitReads = 0;
     const { client } = coldClient({
       getStreamCapabilities: async () => fakeCapabilities(),
       getWorkspaceCapture: async () => ({ available: false }),
-      gitStatus: async () => ({
-        isRepo: true,
-        head: "main",
-        detached: false,
-        upstream: "origin/main",
-        ahead: 0,
-        behind: 0,
-        files: [],
-        revision: 1,
-      }),
-      gitDiff: async () => ({ files: diff, revision: 1 }),
-    });
-    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
-    await flush();
-    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
-    await hook.unmount();
-  });
-
-  test("warm clean workspace with no capture → default Files after live Git resolves", async () => {
-    const { client } = coldClient({
-      getStreamCapabilities: async () => fakeCapabilities(),
-      getWorkspaceCapture: async () => ({ available: false }),
-      gitStatus: async () => ({
-        isRepo: true,
-        head: "main",
-        detached: false,
-        upstream: "origin/main",
-        ahead: 0,
-        behind: 0,
-        files: [],
-        revision: 1,
-      }),
-      gitDiff: async () => ({ files: [], revision: 1 }),
+      gitStatus: async () => {
+        gitReads += 1;
+        return {
+          isRepo: true,
+          head: "main",
+          detached: false,
+          upstream: "origin/main",
+          ahead: 0,
+          behind: 0,
+          files: [],
+          revision: 1,
+        };
+      },
+      gitDiff: async () => {
+        gitReads += 1;
+        return { files: diff, revision: 1 };
+      },
     });
     const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
     await flush();
     expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
+    expect(gitReads).toBe(0);
+    await hook.unmount();
+  });
+
+  test("a cold-start turn defers automatic Files reads until the turn settles", async () => {
+    let fileReads = 0;
+    const { client } = coldClient({
+      getStreamCapabilities: async () => fakeCapabilities(),
+      getWorkspaceCapture: async () => ({ available: false }),
+      fsList: async () => {
+        fileReads += 1;
+        return {
+          root: {
+            name: "",
+            path: "",
+            type: "dir",
+            sizeBytes: null,
+            mtimeMs: null,
+            mode: null,
+            truncated: false,
+            children: [],
+          },
+          revision: 1,
+          truncated: false,
+        };
+      },
+      gitStatus: async () => ({
+        isRepo: false,
+        head: null,
+        detached: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        files: [],
+        revision: 1,
+      }),
+    });
+    const running = await renderTabsHook(client, {
+      sessionId: SESSION_ID,
+      events: [fakeEvent(1, "turn.started")],
+      initialTab: WORKBENCH_TAB_FILES,
+    });
+    await flush(60);
+    expect(running.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
+    expect(fileReads).toBe(0);
+    await running.unmount();
+
+    const settled = await renderTabsHook(client, {
+      sessionId: SESSION_ID,
+      events: [fakeEvent(1, "turn.started"), fakeEvent(2, "turn.completed")],
+      initialTab: WORKBENCH_TAB_FILES,
+    });
+    await flush(60);
+    expect(fileReads).toBeGreaterThan(0);
+    await settled.unmount();
+
+    fileReads = 0;
+    const trimmedRunning = await renderTabsHook(client, {
+      sessionId: SESSION_ID,
+      events: [fakeEvent(100, "session.status.changed", { status: "running" })],
+      initialTab: WORKBENCH_TAB_FILES,
+    });
+    await flush(60);
+    expect(fileReads).toBe(0);
+    await trimmedRunning.unmount();
+
+    const trimmedSettled = await renderTabsHook(client, {
+      sessionId: SESSION_ID,
+      events: [
+        fakeEvent(100, "session.status.changed", { status: "running" }),
+        fakeEvent(200, "session.status.changed", { status: "idle" }),
+      ],
+      initialTab: WORKBENCH_TAB_FILES,
+    });
+    await flush(60);
+    expect(fileReads).toBeGreaterThan(0);
+    await trimmedSettled.unmount();
+  });
+
+  test("an explicitly selected Changes tab performs the live Git read", async () => {
+    let gitReads = 0;
+    const { client } = coldClient({
+      getStreamCapabilities: async () => fakeCapabilities(),
+      getWorkspaceCapture: async () => ({ available: false }),
+      gitStatus: async () => {
+        gitReads += 1;
+        return {
+          isRepo: true,
+          head: "main",
+          detached: false,
+          upstream: "origin/main",
+          ahead: 0,
+          behind: 0,
+          files: [],
+          revision: 1,
+        };
+      },
+      gitDiff: async () => {
+        gitReads += 1;
+        return { files: [], revision: 1 };
+      },
+    });
+    const hook = await renderTabsHook(client, {
+      sessionId: SESSION_ID,
+      events: [],
+      initialTab: WORKBENCH_TAB_CHANGES,
+    });
+    await flush();
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
+    expect(gitReads).toBeGreaterThan(0);
     await hook.unmount();
   });
 
@@ -1023,7 +1118,11 @@ describe("capture-driven default tab (Refinement 2)", () => {
         return { files: diff, revision: 1 };
       },
     });
-    const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
+    const hook = await renderTabsHook(client, {
+      sessionId: SESSION_ID,
+      events: [],
+      initialTab: WORKBENCH_TAB_CHANGES,
+    });
     await flush(60);
 
     expect(comparisons).toContain("origin/HEAD");
@@ -1036,29 +1135,28 @@ describe("capture-driven default tab (Refinement 2)", () => {
     await hook.unmount();
   });
 
-  test("warm live Git outranks an empty prior capture", async () => {
+  test("an empty capture defaults Files without a speculative live Git read", async () => {
+    let gitReads = 0;
     const { client } = coldClient({
       getStreamCapabilities: async () => fakeCapabilities(),
       getWorkspaceCapture: async () => captureAvailable(fakeManifest(0)),
-      gitStatus: async () => ({
-        isRepo: true,
-        head: "main",
-        detached: false,
-        upstream: "origin/main",
-        ahead: 0,
-        behind: 0,
-        files: [],
-        revision: 2,
-      }),
-      gitDiff: async () => ({ files: [fakeFileDiff()], revision: 2 }),
+      gitStatus: async () => {
+        gitReads += 1;
+        throw new Error("hidden Git read");
+      },
+      gitDiff: async () => {
+        gitReads += 1;
+        throw new Error("hidden Git read");
+      },
     });
     const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
     await flush();
-    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
+    expect(gitReads).toBe(0);
     await hook.unmount();
   });
 
-  test("a fast empty capture cannot latch Files before warm capability negotiation", async () => {
+  test("a fast empty capture resolves Files without waiting for capability negotiation", async () => {
     let resolveCapabilities: (value: ReturnType<typeof fakeCapabilities>) => void = () => {};
     const capabilitiesPromise = new Promise<ReturnType<typeof fakeCapabilities>>((resolve) => {
       resolveCapabilities = resolve;
@@ -1080,14 +1178,14 @@ describe("capture-driven default tab (Refinement 2)", () => {
     });
     const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
     await flush();
-    expect(hook.result.current.defaultTab).toBeNull();
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
     await act(async () => resolveCapabilities(fakeCapabilities()));
     await flush();
-    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
     await hook.unmount();
   });
 
-  test("warm clean Git outranks a changed prior capture", async () => {
+  test("a changed capture chooses Changes without waiting on live Git", async () => {
     const { client } = coldClient({
       getStreamCapabilities: async () => fakeCapabilities(),
       getWorkspaceCapture: async () => captureAvailable(fakeManifest(2)),
@@ -1105,11 +1203,11 @@ describe("capture-driven default tab (Refinement 2)", () => {
     });
     const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
     await flush();
-    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
     await hook.unmount();
   });
 
-  test("capability failure with no capture → default Changes for the truthful retry state", async () => {
+  test("capability failure with no capture still defaults Files without provider I/O", async () => {
     const { client } = coldClient({
       getStreamCapabilities: async () => {
         throw new Error("sandbox unreachable");
@@ -1118,7 +1216,7 @@ describe("capture-driven default tab (Refinement 2)", () => {
     });
     const hook = await renderTabsHook(client, { sessionId: SESSION_ID, events: [] });
     await flush();
-    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_CHANGES);
+    expect(hook.result.current.defaultTab).toBe(WORKBENCH_TAB_FILES);
     await hook.unmount();
   });
 

--- a/packages/react/test/workspace-capture-hooks.test.tsx
+++ b/packages/react/test/workspace-capture-hooks.test.tsx
@@ -1147,6 +1147,48 @@ describe("useSandboxFiles — capture source", () => {
     await hook.unmount();
   });
 
+  test("generic command and tool output never fans out Files provider reads", async () => {
+    let fsListCalls = 0;
+    let gitBatchCalls = 0;
+    const client = fakeClient({
+      fsList: async () => {
+        fsListCalls += 1;
+        return {
+          root: treeDir("", "", [treeFile("app.py", "app.py", 1)]),
+          revision: 1,
+          truncated: false,
+        };
+      },
+      gitReadBatch: async () => {
+        gitBatchCalls += 1;
+        return { results: [] };
+      },
+    });
+    const hook = await renderHook(
+      (props: { events: SessionEvent[] }) =>
+        useSandboxFiles(SESSION_ID, {
+          ...ctx,
+          client,
+          capture: fakeManifest(),
+          liveness: "warm",
+          events: props.events,
+        }),
+      { events: [] as SessionEvent[] },
+    );
+    await flush();
+    fsListCalls = 0;
+    gitBatchCalls = 0;
+
+    await hook.rerender({
+      events: [fakeEvent(1, "sandbox.command.output.delta"), fakeEvent(2, "agent.toolCall.output")],
+    });
+    await flush(250);
+
+    expect(fsListCalls).toBe(0);
+    expect(gitBatchCalls).toBe(0);
+    await hook.unmount();
+  });
+
   test("warm event reconciliation is cancelled before a draining transition can rearm", async () => {
     let fsListCalls = 0;
     let gitBatchCalls = 0;
@@ -1452,6 +1494,103 @@ describe("useSandboxFiles — capture source", () => {
 // ── use-sandbox-git: source selection + no-flicker ─────────────────────────────
 
 describe("useSandboxGit — capture source", () => {
+  test("rapid structured Git invalidations collapse into one trailing provider read", async () => {
+    let releaseFirst!: () => void;
+    const firstRead = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let calls = 0;
+    let active = 0;
+    let maxActive = 0;
+    const client = fakeClient({
+      gitStatus: async () => {
+        calls += 1;
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        if (calls === 1) await firstRead;
+        active -= 1;
+        return {
+          isRepo: false,
+          head: null,
+          detached: false,
+          upstream: null,
+          ahead: 0,
+          behind: 0,
+          files: [],
+          revision: calls,
+        };
+      },
+    });
+    const hook = await renderHook(
+      (props: { events: SessionEvent[] }) =>
+        useSandboxGit(SESSION_ID, {
+          ...ctx,
+          client,
+          events: props.events,
+          liveness: "warm",
+        }),
+      { events: [] as SessionEvent[] },
+    );
+    await flush(200);
+
+    await hook.rerender({ events: [fakeEvent(1, "agent.toolCall.output")] });
+    await hook.rerender({
+      events: [
+        fakeEvent(1, "agent.toolCall.output"),
+        fakeEvent(2, "agent.toolCall.output"),
+        fakeEvent(3, "git.changed"),
+      ],
+    });
+    await flush(200);
+    expect(calls).toBe(1);
+    expect(maxActive).toBe(1);
+
+    releaseFirst();
+    await flush(50);
+    expect(calls).toBe(2);
+    expect(maxActive).toBe(1);
+    await hook.unmount();
+  });
+
+  test("generic command and tool output never triggers live Git reads", async () => {
+    let calls = 0;
+    const client = fakeClient({
+      gitStatus: async () => {
+        calls += 1;
+        return {
+          isRepo: false,
+          head: null,
+          detached: false,
+          upstream: null,
+          ahead: 0,
+          behind: 0,
+          files: [],
+          revision: calls,
+        };
+      },
+    });
+    const hook = await renderHook(
+      (props: { events: SessionEvent[] }) =>
+        useSandboxGit(SESSION_ID, {
+          ...ctx,
+          client,
+          events: props.events,
+          liveness: "warm",
+        }),
+      { events: [] as SessionEvent[] },
+    );
+    await flush();
+    calls = 0;
+
+    await hook.rerender({
+      events: [fakeEvent(1, "sandbox.command.output.delta"), fakeEvent(2, "agent.toolCall.output")],
+    });
+    await flush(250);
+
+    expect(calls).toBe(0);
+    await hook.unmount();
+  });
+
   test("cold + capture serves the diff from the capture repo (no gitDiff RPC)", async () => {
     let gitDiffCalls = 0;
     const client = fakeClient({
@@ -1475,7 +1614,7 @@ describe("useSandboxGit — capture source", () => {
         useSandboxGit(SESSION_ID, { ...ctx, client, capture: fakeManifest(), liveness: "cold" }),
       undefined,
     );
-    await flush();
+    await flush(200);
     expect(hook.result.current.source).toBe("capture");
     expect(hook.result.current.capturedAt).toBe("2026-07-08T12:00:00.000Z");
     expect(hook.result.current.isRepo).toBe(true);
@@ -1502,7 +1641,7 @@ describe("useSandboxGit — capture source", () => {
       () => useSandboxGit(SESSION_ID, { ...ctx, client, liveness: "cold" }),
       undefined,
     );
-    await flush();
+    await flush(200);
 
     expect(gitStatusCalls).toBe(0);
     expect(gitDiffCalls).toBe(0);
@@ -1860,7 +1999,7 @@ describe("useSandboxGit — capture source", () => {
       sessionId: SECOND_SESSION_ID,
       events: [fakeEvent(1, "git.changed")],
     });
-    await flush();
+    await flush(200);
 
     expect(hook.result.current.diff.map((file) => file.path)).toEqual(["second-new.ts"]);
     await hook.unmount();
@@ -1907,7 +2046,7 @@ describe("useSandboxGit — capture source", () => {
 
     lineText = "new line";
     await hook.rerender({ events: [fakeEvent(1, "git.changed")] });
-    await flush();
+    await flush(200);
 
     expect(hook.result.current.diff[0]?.hunks[0]?.lines[0]?.text).toBe("new line");
     await hook.unmount();

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -58,6 +58,8 @@ import {
 } from "./workspace-archive";
 import type { RuntimeMetricsHooks } from "../metrics";
 import { normalizeProtocolJsonValue } from "../protocol-json";
+import { sandboxCommandExitCode, sandboxCommandStillRunning } from "./command-result";
+import { parseExecBannerSessionId } from "./exec-banner";
 import { runStateCompatibilityProvider, runStateExposedPortsRecord } from "./run-state-compat";
 
 // Re-export the config-owned environment/port helpers from the leaf so the
@@ -1112,29 +1114,14 @@ export class SandboxExecReadinessError extends Error {
  * without publishing the lease warm before command execution is possible. */
 export const MODAL_EXEC_READINESS_TIMEOUT_MS = 60_000;
 
-function sandboxExecProbeExitCode(result: unknown): number | null {
-  if (typeof result === "string") {
-    const match = result.match(/Process exited with code (-?\d+)/);
-    return match ? Number(match[1]) : null;
-  }
+function sandboxExecProbeSessionId(result: unknown): number | null {
+  if (typeof result === "string") return parseExecBannerSessionId(result);
   if (!result || typeof result !== "object") return null;
-  const candidate = result as {
-    exitCode?: unknown;
-    exit_code?: unknown;
-    code?: unknown;
-    status?: unknown;
-  };
-  for (const value of [candidate.exitCode, candidate.exit_code, candidate.code, candidate.status]) {
-    if (typeof value === "number") return value;
+  const candidate = result as { sessionId?: unknown; session_id?: unknown };
+  for (const value of [candidate.sessionId, candidate.session_id]) {
+    if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) return value;
   }
   return null;
-}
-
-function sandboxExecProbeStillRunning(result: unknown): boolean {
-  if (typeof result === "string") return /Process running with session ID \d+/u.test(result);
-  if (!result || typeof result !== "object") return false;
-  const candidate = result as { sessionId?: unknown; session_id?: unknown };
-  return typeof candidate.sessionId === "number" || typeof candidate.session_id === "number";
 }
 
 /** A provider handle is not workspace readiness. Modal can return a handle
@@ -1156,6 +1143,12 @@ export async function verifySandboxExecReadiness(
       yieldTimeMs?: number;
       maxOutputTokens?: number;
     }) => Promise<unknown>;
+    writeStdin?: (args: {
+      sessionId: number;
+      chars?: string;
+      yieldTimeMs?: number;
+      maxOutputTokens?: number;
+    }) => Promise<unknown>;
   };
   const run = session.exec ?? session.execCommand;
   if (!run) {
@@ -1167,33 +1160,45 @@ export async function verifySandboxExecReadiness(
       established.instanceId,
     );
   }
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    const result = await Promise.race([
+  const timeoutError = () =>
+    new SandboxExecReadinessError(
+      established.backendId,
+      "exec_probe_timeout",
+      timeoutMs,
+      null,
+      established.instanceId,
+    );
+  const deadline = Date.now() + timeoutMs;
+  const withinDeadline = async <T>(operation: () => Promise<T>): Promise<T> => {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) throw timeoutError();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        operation(),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(timeoutError()), remainingMs);
+          if (timer && "unref" in timer && typeof timer.unref === "function") timer.unref();
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  };
+  const execProbe = () =>
+    withinDeadline(() =>
       run.call(session, {
         cmd: "true",
-        yieldTimeMs: 1_000,
+        yieldTimeMs: Math.min(1_000, Math.max(1, deadline - Date.now())),
         maxOutputTokens: 1_000,
       }),
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () =>
-            reject(
-              new SandboxExecReadinessError(
-                established.backendId,
-                "exec_probe_timeout",
-                timeoutMs,
-                null,
-                established.instanceId,
-              ),
-            ),
-          timeoutMs,
-        );
-        if (timer && "unref" in timer && typeof timer.unref === "function") timer.unref();
-      }),
-    ]);
-    const exitCode = sandboxExecProbeExitCode(result);
-    if (sandboxExecProbeStillRunning(result) || exitCode !== 0) {
+    );
+
+  let result = await execProbe();
+  while (true) {
+    const exitCode = sandboxCommandExitCode(result);
+    if (exitCode !== null) {
+      if (exitCode === 0) return;
       throw new SandboxExecReadinessError(
         established.backendId,
         "exec_probe_failed",
@@ -1202,8 +1207,25 @@ export async function verifySandboxExecReadiness(
         established.instanceId,
       );
     }
-  } finally {
-    if (timer) clearTimeout(timer);
+
+    const sessionId = sandboxCommandStillRunning(result) ? sandboxExecProbeSessionId(result) : null;
+    const writeStdin = session.writeStdin;
+    if (sessionId !== null && writeStdin) {
+      result = await withinDeadline(() =>
+        writeStdin.call(session, {
+          sessionId,
+          chars: "",
+          yieldTimeMs: Math.min(1_000, Math.max(1, deadline - Date.now())),
+          maxOutputTokens: 1_000,
+        }),
+      );
+      continue;
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) throw timeoutError();
+    await new Promise((resolve) => setTimeout(resolve, Math.min(100, remainingMs)));
+    result = await execProbe();
   }
 }
 


### PR DESCRIPTION
## Summary
- reject archived browser identities before placement
- serialize and fence Files/Git refreshes across long-running turns and session switches
- make Modal readiness retry transient/yielded exec responses within one strict deadline
- choose the initial workspace tab from durable capture without hidden provider I/O

## Verification
- 169 focused regression tests
- all 31 TypeScript projects clean
- live browser/computer UI acceptance: 12/12
- fresh sandbox stock ogtool Code Mode header verification passed