### PR TITLE
fix(db): correct personal resource delegation authority

### DIFF
--- a/packages/db/drizzle/0249_personal_resource_delegation_authority_correction.sql
+++ b/packages/db/drizzle/0249_personal_resource_delegation_authority_correction.sql
@@ -1,0 +1,662 @@
+-- deployment-mode: rolling
+-- Correct personal-resource delegation authority without rewriting migration 0241.
+-- Personal-workspace owners use their exact active organization membership;
+-- every non-personal target still requires ordinary workspace membership, and
+-- only a running turn may own admission or resolution for an active attempt.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+DO $personal_resource_delegation_authority_correction$
+DECLARE
+  data_schema text := current_schema();
+BEGIN
+  EXECUTE format($ddl$
+    CREATE OR REPLACE FUNCTION %1$I.admit_session_attempt_personal_resources()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = %1$I, pg_catalog
+    AS $body$
+    DECLARE
+      session_row sessions%%ROWTYPE;
+      turn_row session_turns%%ROWTYPE;
+      member_row organization_memberships%%ROWTYPE;
+      resource_row record;
+      grant_row organization_user_resource_grants%%ROWTYPE;
+      resource_total integer := 0;
+      snapshot_total integer := 0;
+      initiating_subject text;
+      affected integer;
+    BEGIN
+      INSERT INTO opengeni_private.personal_resource_delegation_capabilities (
+        backend_pid, transaction_id, capability_kind
+      ) VALUES (pg_catalog.pg_backend_pid(), pg_catalog.pg_current_xact_id(), 'admit')
+      ON CONFLICT DO NOTHING;
+
+      SELECT session_value.* INTO STRICT session_row
+      FROM sessions session_value
+      WHERE session_value.id = NEW.session_id
+        AND session_value.account_id = NEW.account_id
+        AND session_value.workspace_id = NEW.workspace_id
+      FOR SHARE;
+
+      SELECT turn_value.* INTO STRICT turn_row
+      FROM session_turns turn_value
+      WHERE turn_value.id = NEW.turn_id
+        AND turn_value.account_id = NEW.account_id
+        AND turn_value.workspace_id = NEW.workspace_id
+        AND turn_value.session_id = NEW.session_id
+      FOR SHARE;
+
+      SELECT count(*)::integer INTO resource_total
+      FROM (
+        SELECT DISTINCT selected.resource_kind, selected.resource_id
+        FROM (
+        SELECT 'variable_set'::text AS resource_kind, variable_set.id AS resource_id
+        FROM workspace_variable_sets variable_set
+        WHERE variable_set.id = session_row.variable_set_id
+          AND variable_set.account_id = NEW.account_id
+          AND variable_set.authority_scope = 'user'
+        UNION ALL
+        SELECT 'rig'::text, rig.id
+        FROM rigs rig
+        WHERE rig.id = session_row.rig_id
+          AND rig.account_id = NEW.account_id
+          AND rig.authority_scope = 'user'
+        UNION ALL
+        SELECT 'variable_set'::text, default_variable_set.id
+        FROM rig_versions rig_version
+        CROSS JOIN LATERAL jsonb_array_elements_text(
+          rig_version.default_variable_set_ids
+        ) default_id(value)
+        JOIN workspace_variable_sets default_variable_set
+          ON default_variable_set.id = default_id.value::uuid
+         AND default_variable_set.account_id = NEW.account_id
+         AND default_variable_set.authority_scope = 'user'
+        WHERE rig_version.id = session_row.rig_version_id
+          AND rig_version.rig_id = session_row.rig_id
+          AND rig_version.account_id = NEW.account_id
+        ) selected
+      ) selected_personal_resources;
+
+      IF resource_total = 0 THEN
+        DELETE FROM opengeni_private.personal_resource_delegation_capabilities
+        WHERE backend_pid = pg_catalog.pg_backend_pid()
+          AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+          AND capability_kind = 'admit';
+        RETURN NEW;
+      END IF;
+
+      IF NEW.execution_generation <= 0
+        OR NEW.state NOT IN ('claimed', 'running')
+        OR NEW.closed_at IS NOT NULL
+        OR NEW.quiesced_at IS NOT NULL
+        OR session_row.active_turn_id IS DISTINCT FROM NEW.turn_id
+        OR turn_row.active_attempt_id IS DISTINCT FROM NEW.id
+        OR turn_row.execution_generation IS DISTINCT FROM NEW.execution_generation
+        OR turn_row.status <> 'running'
+        OR EXISTS (
+          SELECT 1
+          FROM session_attempt_interruptions interruption
+          WHERE interruption.account_id = NEW.account_id
+            AND interruption.workspace_id = NEW.workspace_id
+            AND interruption.session_id = NEW.session_id
+            AND interruption.attempt_id = NEW.id
+            AND interruption.state IN ('pending', 'delivered', 'acknowledged')
+        )
+      THEN
+        RAISE EXCEPTION 'personal-resource admission requires the exact current uninterrupted attempt'
+          USING ERRCODE = '42501';
+      END IF;
+
+      IF NEW.authority_visibility IS DISTINCT FROM session_row.visibility
+        OR NEW.authority_epoch IS DISTINCT FROM session_row.authority_epoch
+        OR NEW.authority_owner_organization_membership_id
+          IS DISTINCT FROM session_row.owner_organization_membership_id
+      THEN
+        RAISE EXCEPTION 'personal-resource admission requires the exact session authority'
+          USING ERRCODE = '42501';
+      END IF;
+
+      initiating_subject := coalesce(
+        nullif(btrim(turn_row.initiating_human_subject_id), ''),
+        CASE WHEN turn_row.initiator_kind = 'subject'
+          THEN nullif(btrim(turn_row.initiator_subject_id), '') END
+      );
+      IF initiating_subject IS NULL THEN
+        RAISE EXCEPTION 'personal-resource admission requires an initiating human subject'
+          USING ERRCODE = '42501';
+      END IF;
+
+      SELECT membership.* INTO STRICT member_row
+      FROM organization_memberships membership
+      WHERE membership.account_id = NEW.account_id
+        AND membership.subject_id = initiating_subject
+        AND membership.status = 'active'
+        AND membership.revoked_at IS NULL
+        AND membership.personal_workspace_id IS NOT NULL
+      FOR SHARE;
+
+      IF member_row.personal_workspace_id IS DISTINCT FROM NEW.workspace_id THEN
+        PERFORM 1
+        FROM workspace_memberships workspace_membership
+        WHERE workspace_membership.account_id = NEW.account_id
+          AND workspace_membership.workspace_id = NEW.workspace_id
+          AND workspace_membership.subject_id = initiating_subject
+        FOR KEY SHARE;
+        IF NOT FOUND THEN
+          RAISE EXCEPTION 'initiating human lacks target-workspace membership'
+            USING ERRCODE = '42501';
+        END IF;
+      END IF;
+
+      INSERT INTO session_attempt_personal_resource_admissions (
+        attempt_id, account_id, workspace_id, session_id, turn_id,
+        execution_generation, initiating_human_subject_id,
+        owner_organization_membership_id, membership_authorization_revision,
+        session_visibility, session_authority_epoch, resource_count
+      ) VALUES (
+        NEW.id, NEW.account_id, NEW.workspace_id, NEW.session_id, NEW.turn_id,
+        NEW.execution_generation, initiating_subject, member_row.id,
+        member_row.authorization_revision, session_row.visibility,
+        session_row.authority_epoch, resource_total
+      );
+
+      FOR resource_row IN
+        WITH selected AS (
+          SELECT
+            'variable_set'::text AS resource_kind,
+            variable_set.id AS resource_id,
+            NULL::uuid AS resource_version_id,
+            'variable_set.use'::text AS action,
+            'session_variable_set'::text AS selection_source,
+            variable_set.workspace_id AS resource_workspace_id,
+            variable_set.authority_id,
+            variable_set.owner_organization_membership_id,
+            variable_set.origin_workspace_id
+          FROM workspace_variable_sets variable_set
+          WHERE variable_set.id = session_row.variable_set_id
+            AND variable_set.account_id = NEW.account_id
+            AND variable_set.authority_scope = 'user'
+          UNION ALL
+          SELECT
+            'rig'::text, rig.id, session_row.rig_version_id, 'rig.use'::text,
+            'session_rig'::text, rig.workspace_id, rig.authority_id,
+            rig.owner_organization_membership_id, rig.origin_workspace_id
+          FROM rigs rig
+          WHERE rig.id = session_row.rig_id
+            AND rig.account_id = NEW.account_id
+            AND rig.authority_scope = 'user'
+          UNION ALL
+          SELECT
+            'variable_set'::text, default_variable_set.id, NULL::uuid,
+            'variable_set.use'::text,
+            ('rig_default_variable_set:' || default_id.ordinality::text)::text,
+            default_variable_set.workspace_id, default_variable_set.authority_id,
+            default_variable_set.owner_organization_membership_id,
+            default_variable_set.origin_workspace_id
+          FROM rig_versions rig_version
+          CROSS JOIN LATERAL jsonb_array_elements_text(
+            rig_version.default_variable_set_ids
+          ) WITH ORDINALITY default_id(value, ordinality)
+          JOIN workspace_variable_sets default_variable_set
+            ON default_variable_set.id = default_id.value::uuid
+           AND default_variable_set.account_id = NEW.account_id
+           AND default_variable_set.authority_scope = 'user'
+          WHERE rig_version.id = session_row.rig_version_id
+            AND rig_version.rig_id = session_row.rig_id
+            AND rig_version.account_id = NEW.account_id
+        )
+        SELECT resource_kind, resource_id,
+          min(resource_version_id::text)::uuid AS resource_version_id,
+          action, array_agg(selection_source ORDER BY selection_source) AS selection_sources,
+          min(resource_workspace_id::text)::uuid AS resource_workspace_id,
+          min(authority_id::text)::uuid AS authority_id,
+          min(owner_organization_membership_id::text)::uuid
+            AS owner_organization_membership_id,
+          min(origin_workspace_id::text)::uuid AS origin_workspace_id
+        FROM selected
+        GROUP BY resource_kind, resource_id, action
+        ORDER BY resource_kind, resource_id
+      LOOP
+        IF resource_row.owner_organization_membership_id IS DISTINCT FROM member_row.id
+          OR resource_row.resource_workspace_id IS DISTINCT FROM member_row.personal_workspace_id
+          OR resource_row.origin_workspace_id IS DISTINCT FROM member_row.personal_workspace_id
+        THEN
+          RAISE EXCEPTION 'personal resource owner/origin does not match initiating membership'
+            USING ERRCODE = '42501';
+        END IF;
+
+        IF resource_row.resource_kind = 'variable_set' THEN
+          PERFORM 1 FROM workspace_variable_sets variable_set
+          WHERE variable_set.id = resource_row.resource_id
+            AND variable_set.account_id = NEW.account_id
+            AND variable_set.workspace_id = member_row.personal_workspace_id
+            AND variable_set.authority_scope = 'user'
+            AND variable_set.authority_id = resource_row.authority_id
+            AND variable_set.owner_organization_membership_id = member_row.id
+            AND variable_set.origin_workspace_id = member_row.personal_workspace_id
+          FOR SHARE;
+        ELSE
+          PERFORM 1 FROM rigs rig
+          WHERE rig.id = resource_row.resource_id
+            AND rig.account_id = NEW.account_id
+            AND rig.workspace_id = member_row.personal_workspace_id
+            AND rig.authority_scope = 'user'
+            AND rig.authority_id = resource_row.authority_id
+            AND rig.owner_organization_membership_id = member_row.id
+            AND rig.origin_workspace_id = member_row.personal_workspace_id
+          FOR SHARE;
+          IF FOUND THEN
+            PERFORM 1 FROM rig_versions rig_version
+            WHERE rig_version.id = resource_row.resource_version_id
+              AND rig_version.account_id = NEW.account_id
+              AND rig_version.rig_id = resource_row.resource_id
+              AND rig_version.workspace_id = member_row.personal_workspace_id
+            FOR SHARE;
+          END IF;
+        END IF;
+        IF NOT FOUND THEN
+          RAISE EXCEPTION 'personal resource identity changed during admission'
+            USING ERRCODE = '42501';
+        END IF;
+
+        PERFORM 1
+        FROM organization_user_resource_authorities authority
+        WHERE authority.id = resource_row.authority_id
+          AND authority.account_id = NEW.account_id
+          AND authority.organization_membership_id = member_row.id
+          AND authority.resource_kind = resource_row.resource_kind
+          AND authority.resource_id = resource_row.resource_id
+          AND authority.origin_workspace_id = member_row.personal_workspace_id
+          AND authority.status = 'active'
+          AND authority.revoked_at IS NULL
+        FOR SHARE;
+        IF NOT FOUND THEN
+          RAISE EXCEPTION 'personal resource authority is not live'
+            USING ERRCODE = '42501';
+        END IF;
+
+        SELECT grant_value.* INTO grant_row
+        FROM organization_user_resource_grants grant_value
+        WHERE grant_value.account_id = NEW.account_id
+          AND grant_value.authority_id = resource_row.authority_id
+          AND grant_value.owner_organization_membership_id = member_row.id
+          AND grant_value.workspace_id = NEW.workspace_id
+          AND grant_value.action = resource_row.action
+          AND grant_value.context = session_row.visibility
+          AND grant_value.status = 'active'
+          AND (grant_value.expires_at IS NULL OR grant_value.expires_at > clock_timestamp())
+          AND (
+            (
+              grant_value.mode IN ('once', 'session')
+              AND grant_value.session_id = NEW.session_id
+              AND grant_value.authority_epoch = session_row.authority_epoch
+            ) OR (
+              grant_value.mode = 'always'
+              AND grant_value.session_id IS NULL
+              AND grant_value.authority_epoch IS NULL
+            )
+          )
+        ORDER BY
+          CASE grant_value.mode WHEN 'once' THEN 1 WHEN 'session' THEN 2 ELSE 3 END,
+          grant_value.generation DESC,
+          grant_value.id
+        LIMIT 1
+        FOR UPDATE;
+        IF NOT FOUND THEN
+          RAISE EXCEPTION 'matching personal-resource grant required'
+            USING ERRCODE = '42501';
+        END IF;
+
+        INSERT INTO session_attempt_personal_resource_snapshots (
+          attempt_id, account_id, workspace_id, session_id, turn_id,
+          execution_generation, resource_kind, resource_id, resource_version_id,
+          selection_sources, action, origin_workspace_id,
+          owner_organization_membership_id, membership_authorization_revision,
+          authority_id, authority_generation, target_workspace_id,
+          session_visibility, session_authority_epoch, grant_id, grant_generation,
+          grant_mode, grant_context, grant_session_id, grant_authority_epoch
+        )
+        SELECT
+          NEW.id, NEW.account_id, NEW.workspace_id, NEW.session_id, NEW.turn_id,
+          NEW.execution_generation, resource_row.resource_kind, resource_row.resource_id,
+          resource_row.resource_version_id, resource_row.selection_sources,
+          resource_row.action, member_row.personal_workspace_id, member_row.id,
+          member_row.authorization_revision, authority.id, authority.generation,
+          NEW.workspace_id, session_row.visibility, session_row.authority_epoch,
+          grant_row.id, grant_row.generation, grant_row.mode, grant_row.context,
+          grant_row.session_id, grant_row.authority_epoch
+        FROM organization_user_resource_authorities authority
+        WHERE authority.id = resource_row.authority_id
+          AND authority.account_id = NEW.account_id;
+
+        IF grant_row.mode = 'once' THEN
+          UPDATE organization_user_resource_grants
+          SET status = 'consumed', updated_at = clock_timestamp()
+          WHERE id = grant_row.id
+            AND account_id = NEW.account_id
+            AND generation = grant_row.generation
+            AND status = 'active';
+          GET DIAGNOSTICS affected = ROW_COUNT;
+          IF affected <> 1 THEN
+            RAISE EXCEPTION 'once grant lost its first-use race'
+              USING ERRCODE = '40001';
+          END IF;
+          INSERT INTO personal_resource_once_consumption_receipts (
+            grant_id, account_id, attempt_id, workspace_id, session_id, turn_id,
+            execution_generation, authority_id, authority_generation, grant_generation
+          ) SELECT
+            grant_row.id, NEW.account_id, NEW.id, NEW.workspace_id, NEW.session_id,
+            NEW.turn_id, NEW.execution_generation, authority.id, authority.generation,
+            grant_row.generation
+          FROM organization_user_resource_authorities authority
+          WHERE authority.id = resource_row.authority_id
+            AND authority.account_id = NEW.account_id;
+        END IF;
+        snapshot_total := snapshot_total + 1;
+      END LOOP;
+
+      IF snapshot_total <> resource_total THEN
+        RAISE EXCEPTION 'personal-resource snapshot collection is not exact'
+          USING ERRCODE = '23514';
+      END IF;
+
+      DELETE FROM opengeni_private.personal_resource_delegation_capabilities
+      WHERE backend_pid = pg_catalog.pg_backend_pid()
+        AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+        AND capability_kind = 'admit';
+      RETURN NEW;
+    EXCEPTION WHEN OTHERS THEN
+      DELETE FROM opengeni_private.personal_resource_delegation_capabilities
+      WHERE backend_pid = pg_catalog.pg_backend_pid()
+        AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+        AND capability_kind = 'admit';
+      RAISE;
+    END;
+    $body$;
+  $ddl$, data_schema);
+
+  EXECUTE format($ddl$
+    CREATE OR REPLACE FUNCTION %1$I.resolve_session_attempt_personal_resources(
+      p_account_id uuid,
+      p_workspace_id uuid,
+      p_attempt_id uuid
+    ) RETURNS TABLE (
+      resource_kind text,
+      resource_id uuid,
+      resource_version_id uuid,
+      selection_sources text[],
+      action text,
+      authority_id uuid,
+      authority_generation bigint,
+      grant_id uuid,
+      grant_generation bigint,
+      grant_mode text
+    )
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = %1$I, pg_catalog
+    AS $body$
+    DECLARE
+      admission_row session_attempt_personal_resource_admissions%%ROWTYPE;
+      invalid_count integer;
+      caller_subject text := coalesce(
+        nullif(pg_catalog.current_setting('opengeni.initiating_human_subject_id', true), ''),
+        nullif(pg_catalog.current_setting('opengeni.subject_id', true), '')
+      );
+    BEGIN
+      IF p_account_id IS DISTINCT FROM nullif(
+          pg_catalog.current_setting('opengeni.account_id', true), ''
+        )::uuid
+        OR p_workspace_id IS DISTINCT FROM nullif(
+          pg_catalog.current_setting('opengeni.workspace_id', true), ''
+        )::uuid
+      THEN
+        RAISE EXCEPTION 'personal-resource resolve scope mismatch'
+          USING ERRCODE = '42501';
+      END IF;
+
+      INSERT INTO opengeni_private.personal_resource_delegation_capabilities (
+        backend_pid, transaction_id, capability_kind
+      ) VALUES (pg_catalog.pg_backend_pid(), pg_catalog.pg_current_xact_id(), 'resolve')
+      ON CONFLICT DO NOTHING;
+
+      SELECT admission.* INTO STRICT admission_row
+      FROM session_attempt_personal_resource_admissions admission
+      WHERE admission.attempt_id = p_attempt_id
+        AND admission.account_id = p_account_id
+        AND admission.workspace_id = p_workspace_id;
+
+      IF caller_subject IS DISTINCT FROM admission_row.initiating_human_subject_id THEN
+        RAISE EXCEPTION 'personal-resource resolve initiating human mismatch'
+          USING ERRCODE = '42501';
+      END IF;
+
+      PERFORM 1
+      FROM sessions session_value
+      JOIN session_turns turn_value
+        ON turn_value.account_id = session_value.account_id
+       AND turn_value.workspace_id = session_value.workspace_id
+       AND turn_value.session_id = session_value.id
+      JOIN session_turn_attempts attempt
+        ON attempt.account_id = turn_value.account_id
+       AND attempt.workspace_id = turn_value.workspace_id
+       AND attempt.session_id = turn_value.session_id
+       AND attempt.turn_id = turn_value.id
+      WHERE session_value.id = admission_row.session_id
+        AND session_value.account_id = admission_row.account_id
+        AND session_value.workspace_id = admission_row.workspace_id
+        AND session_value.active_turn_id = admission_row.turn_id
+        AND turn_value.id = admission_row.turn_id
+        AND turn_value.active_attempt_id = admission_row.attempt_id
+        AND turn_value.execution_generation = admission_row.execution_generation
+        AND turn_value.status = 'running'
+        AND attempt.id = admission_row.attempt_id
+        AND attempt.execution_generation = admission_row.execution_generation
+        AND attempt.state IN ('claimed', 'running')
+        AND attempt.closed_at IS NULL
+        AND attempt.quiesced_at IS NULL
+      FOR SHARE OF session_value, turn_value
+      FOR UPDATE OF attempt;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'personal-resource resolve requires the exact current uninterrupted attempt'
+          USING ERRCODE = '42501';
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM session_attempt_interruptions interruption
+        WHERE interruption.account_id = admission_row.account_id
+          AND interruption.workspace_id = admission_row.workspace_id
+          AND interruption.session_id = admission_row.session_id
+          AND interruption.attempt_id = admission_row.attempt_id
+          AND interruption.state IN ('pending', 'delivered', 'acknowledged')
+      )
+      THEN
+        RAISE EXCEPTION 'personal-resource resolve requires the exact current uninterrupted attempt'
+          USING ERRCODE = '42501';
+      END IF;
+
+      SELECT count(*)::integer INTO invalid_count
+      FROM session_attempt_personal_resource_snapshots snapshot
+      WHERE snapshot.attempt_id = admission_row.attempt_id
+        AND NOT (
+          EXISTS (
+            SELECT 1
+            FROM session_turn_attempts attempt
+            JOIN sessions session_value
+              ON session_value.id = attempt.session_id
+             AND session_value.account_id = attempt.account_id
+             AND session_value.workspace_id = attempt.workspace_id
+            JOIN session_turns turn_value
+              ON turn_value.id = attempt.turn_id
+             AND turn_value.account_id = attempt.account_id
+             AND turn_value.workspace_id = attempt.workspace_id
+             AND turn_value.session_id = attempt.session_id
+            WHERE attempt.id = snapshot.attempt_id
+              AND attempt.account_id = snapshot.account_id
+              AND attempt.workspace_id = snapshot.workspace_id
+              AND attempt.session_id = snapshot.session_id
+              AND attempt.turn_id = snapshot.turn_id
+              AND attempt.execution_generation = snapshot.execution_generation
+              AND attempt.state IN ('claimed', 'running')
+              AND attempt.quiesced_at IS NULL
+              AND attempt.authority_visibility = snapshot.session_visibility
+              AND attempt.authority_epoch = snapshot.session_authority_epoch
+              AND session_value.visibility = snapshot.session_visibility
+              AND session_value.authority_epoch = snapshot.session_authority_epoch
+              AND coalesce(
+                nullif(btrim(turn_value.initiating_human_subject_id), ''),
+                CASE WHEN turn_value.initiator_kind = 'subject'
+                  THEN nullif(btrim(turn_value.initiator_subject_id), '') END
+              ) = admission_row.initiating_human_subject_id
+          )
+          AND EXISTS (
+            SELECT 1
+            FROM organization_memberships membership
+            WHERE membership.id = snapshot.owner_organization_membership_id
+              AND membership.account_id = snapshot.account_id
+              AND membership.subject_id = admission_row.initiating_human_subject_id
+              AND membership.status = 'active'
+              AND membership.revoked_at IS NULL
+              AND membership.personal_workspace_id = snapshot.origin_workspace_id
+              AND membership.authorization_revision
+                = snapshot.membership_authorization_revision
+              AND (
+                membership.personal_workspace_id = snapshot.workspace_id
+                OR EXISTS (
+                  SELECT 1
+                  FROM workspace_memberships workspace_membership
+                  WHERE workspace_membership.account_id = membership.account_id
+                    AND workspace_membership.workspace_id = snapshot.workspace_id
+                    AND workspace_membership.subject_id = membership.subject_id
+                )
+              )
+          )
+          AND EXISTS (
+            SELECT 1
+            FROM organization_user_resource_authorities authority
+            WHERE authority.id = snapshot.authority_id
+              AND authority.account_id = snapshot.account_id
+              AND authority.organization_membership_id
+                = snapshot.owner_organization_membership_id
+              AND authority.resource_kind = snapshot.resource_kind
+              AND authority.resource_id = snapshot.resource_id
+              AND authority.origin_workspace_id = snapshot.origin_workspace_id
+              AND authority.generation = snapshot.authority_generation
+              AND authority.status = 'active'
+              AND authority.revoked_at IS NULL
+          )
+          AND (
+            (
+              snapshot.resource_kind = 'variable_set'
+              AND EXISTS (
+                SELECT 1 FROM workspace_variable_sets variable_set
+                WHERE variable_set.id = snapshot.resource_id
+                  AND variable_set.account_id = snapshot.account_id
+                  AND variable_set.workspace_id = snapshot.origin_workspace_id
+                  AND variable_set.authority_scope = 'user'
+                  AND variable_set.authority_id = snapshot.authority_id
+                  AND variable_set.owner_organization_membership_id
+                    = snapshot.owner_organization_membership_id
+                  AND variable_set.origin_workspace_id = snapshot.origin_workspace_id
+              )
+            ) OR (
+              snapshot.resource_kind = 'rig'
+              AND EXISTS (
+                SELECT 1 FROM rigs rig
+                JOIN rig_versions rig_version
+                  ON rig_version.id = snapshot.resource_version_id
+                 AND rig_version.rig_id = rig.id
+                 AND rig_version.account_id = rig.account_id
+                 AND rig_version.workspace_id = snapshot.origin_workspace_id
+                WHERE rig.id = snapshot.resource_id
+                  AND rig.account_id = snapshot.account_id
+                  AND rig.workspace_id = snapshot.origin_workspace_id
+                  AND rig.authority_scope = 'user'
+                  AND rig.authority_id = snapshot.authority_id
+                  AND rig.owner_organization_membership_id
+                    = snapshot.owner_organization_membership_id
+                  AND rig.origin_workspace_id = snapshot.origin_workspace_id
+              )
+            )
+          )
+          AND EXISTS (
+            SELECT 1
+            FROM organization_user_resource_grants grant_value
+            WHERE grant_value.id = snapshot.grant_id
+              AND grant_value.account_id = snapshot.account_id
+              AND grant_value.authority_id = snapshot.authority_id
+              AND grant_value.owner_organization_membership_id
+                = snapshot.owner_organization_membership_id
+              AND grant_value.workspace_id = snapshot.target_workspace_id
+              AND grant_value.action = snapshot.action
+              AND grant_value.mode = snapshot.grant_mode
+              AND grant_value.context = snapshot.grant_context
+              AND grant_value.generation = snapshot.grant_generation
+              AND grant_value.session_id IS NOT DISTINCT FROM snapshot.grant_session_id
+              AND grant_value.authority_epoch
+                IS NOT DISTINCT FROM snapshot.grant_authority_epoch
+              AND (grant_value.expires_at IS NULL OR grant_value.expires_at > clock_timestamp())
+              AND (
+                (
+                  snapshot.grant_mode = 'once'
+                  AND grant_value.status = 'consumed'
+                  AND EXISTS (
+                    SELECT 1 FROM personal_resource_once_consumption_receipts receipt
+                    WHERE receipt.grant_id = snapshot.grant_id
+                      AND receipt.account_id = snapshot.account_id
+                      AND receipt.attempt_id = snapshot.attempt_id
+                      AND receipt.authority_id = snapshot.authority_id
+                      AND receipt.authority_generation = snapshot.authority_generation
+                      AND receipt.grant_generation = snapshot.grant_generation
+                  )
+                ) OR (
+                  snapshot.grant_mode IN ('session', 'always')
+                  AND grant_value.status = 'active'
+                )
+              )
+          )
+        );
+
+      IF invalid_count <> 0 THEN
+        RAISE EXCEPTION 'personal-resource authority snapshot is no longer live'
+          USING ERRCODE = '42501';
+      END IF;
+
+      SELECT count(*)::integer INTO invalid_count
+      FROM session_attempt_personal_resource_snapshots snapshot
+      WHERE snapshot.attempt_id = admission_row.attempt_id;
+      IF invalid_count <> admission_row.resource_count THEN
+        RAISE EXCEPTION 'personal-resource snapshot collection is incomplete'
+          USING ERRCODE = '42501';
+      END IF;
+
+      RETURN QUERY
+      SELECT snapshot.resource_kind, snapshot.resource_id,
+        snapshot.resource_version_id, snapshot.selection_sources, snapshot.action,
+        snapshot.authority_id, snapshot.authority_generation, snapshot.grant_id,
+        snapshot.grant_generation, snapshot.grant_mode
+      FROM session_attempt_personal_resource_snapshots snapshot
+      WHERE snapshot.attempt_id = admission_row.attempt_id
+      ORDER BY snapshot.resource_kind, snapshot.resource_id;
+
+      DELETE FROM opengeni_private.personal_resource_delegation_capabilities
+      WHERE backend_pid = pg_catalog.pg_backend_pid()
+        AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+        AND capability_kind = 'resolve';
+      RETURN;
+    EXCEPTION WHEN OTHERS THEN
+      DELETE FROM opengeni_private.personal_resource_delegation_capabilities
+      WHERE backend_pid = pg_catalog.pg_backend_pid()
+        AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+        AND capability_kind = 'resolve';
+      RAISE;
+    END;
+    $body$;
+  $ddl$, data_schema);
+
+END
+$personal_resource_delegation_authority_correction$;

--- a/packages/db/test/migration-0249-personal-resource-delegation-authority-correction.test.ts
+++ b/packages/db/test/migration-0249-personal-resource-delegation-authority-correction.test.ts
@@ -1,0 +1,453 @@
+import { describe, expect, test } from "bun:test";
+import { acquireBlankTestDatabase, type BlankTestDatabase } from "@opengeni/testing";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import postgres from "postgres";
+import { createDb, createSession } from "../src";
+import { migrate } from "../src/migrate";
+
+const migrationName = "0249_personal_resource_delegation_authority_correction.sql";
+const migrationUrl = new URL(`../drizzle/${migrationName}`, import.meta.url);
+const migration0241Url = new URL(
+  "../drizzle/0241_atomic_personal_resource_delegation.sql",
+  import.meta.url,
+);
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+const explicitAdminDatabaseUrl = process.env.OPENGENI_MIGRATION_0249_TEST_DATABASE_ADMIN_URL;
+
+describe("migration 0249 personal-resource delegation authority correction", () => {
+  test("is a forward-only rolling replacement of only the admission and resolver functions", async () => {
+    const source = await readFile(migrationUrl, "utf8");
+    const migration0241 = await readFile(migration0241Url);
+    const executableSource = source.replace(/^--.*$/gmu, "");
+
+    expect(source.split(/\r?\n/u, 1)[0]).toBe("-- deployment-mode: rolling");
+    expect(createHash("sha256").update(migration0241).digest("hex")).toBe(
+      "4a8e3752decc0a497f8eb00de223923747bf2994a0f76ccb977ce7f3ced9e5be",
+    );
+    expect(executableSource.match(/CREATE OR REPLACE FUNCTION/gu)).toHaveLength(2);
+    expect(executableSource).toContain(
+      "CREATE OR REPLACE FUNCTION %1$I.admit_session_attempt_personal_resources()",
+    );
+    expect(executableSource).toContain(
+      "CREATE OR REPLACE FUNCTION %1$I.resolve_session_attempt_personal_resources(",
+    );
+    expect(executableSource).not.toMatch(
+      /^\s*(?:CREATE\s+TABLE|ALTER\s+TABLE|DROP\s+TRIGGER|CREATE\s+TRIGGER|GRANT\s|REVOKE\s)/imu,
+    );
+    expect(executableSource.match(/SECURITY DEFINER/gu)).toHaveLength(2);
+    expect(executableSource.match(/SET search_path = %1\$I, pg_catalog/gu)).toHaveLength(2);
+
+    expect(source).toContain("OR turn_row.status <> 'running'");
+    expect(source).toContain("AND turn_value.status = 'running'");
+    expect(source).not.toContain(
+      "('running', 'requires_action', 'recovering', 'waiting_capacity')",
+    );
+    expect(source).toContain(
+      "IF member_row.personal_workspace_id IS DISTINCT FROM NEW.workspace_id THEN",
+    );
+    expect(source).toContain("membership.personal_workspace_id = snapshot.workspace_id");
+    expect(source).toContain("workspace_membership.workspace_id = snapshot.workspace_id");
+    expect(source).toContain("workspace_membership.subject_id = membership.subject_id");
+  });
+
+  test("blank databases admit and resolve the exact personal owner without a workspace membership", async () => {
+    await withBlankDatabase("migration-0249-blank-personal", async (sql, databaseUrl) => {
+      await migrate(databaseUrl);
+      const ids = await createFixture(sql, databaseUrl, {
+        target: "personal",
+        workspaceMembership: false,
+      });
+
+      expect(await countWorkspaceMemberships(sql, ids)).toBe(0);
+      expect(ids.authorityOwnerMembershipId).toBeNull();
+      await insertAttempt(sql, ids, ids.attemptId);
+      await setRuntimeScope(sql, ids);
+      expect(await resolve(sql, ids)).toHaveLength(1);
+      expect(await countWorkspaceMemberships(sql, ids)).toBe(0);
+    });
+  }, 180_000);
+
+  test("ordinary targets require membership for both admission and resolution", async () => {
+    await withBlankDatabase("migration-0249-ordinary-membership", async (sql, databaseUrl) => {
+      await migrate(databaseUrl);
+      const ids = await createFixture(sql, databaseUrl, {
+        target: "ordinary",
+        workspaceMembership: false,
+      });
+
+      await expect(insertAttempt(sql, ids, ids.attemptId)).rejects.toThrow(
+        "initiating human lacks target-workspace membership",
+      );
+      await addWorkspaceMembership(sql, ids);
+      await insertAttempt(sql, ids, ids.attemptId);
+      await setRuntimeScope(sql, ids);
+      expect(await resolve(sql, ids)).toHaveLength(1);
+
+      await sql`
+        delete from workspace_memberships
+        where account_id = ${ids.accountId}
+          and workspace_id = ${ids.targetWorkspaceId}
+          and subject_id = ${ids.subjectId}
+      `;
+      await expect(resolve(sql, ids)).rejects.toThrow(
+        "personal-resource authority snapshot is no longer live",
+      );
+      await addWorkspaceMembership(sql, ids);
+      expect(await resolve(sql, ids)).toHaveLength(1);
+    });
+  }, 180_000);
+
+  test("admission and resolution reject every constructible non-running owner state", async () => {
+    await withBlankDatabase("migration-0249-running-attempt-only", async (sql, databaseUrl) => {
+      await migrate(databaseUrl);
+      const nonRunningStatuses = ["requires_action", "recovering", "waiting_capacity"] as const;
+
+      for (const status of nonRunningStatuses) {
+        const ids = await createFixture(sql, databaseUrl, {
+          target: "ordinary",
+          workspaceMembership: true,
+        });
+        await expect(insertAttempt(sql, ids, ids.attemptId, status)).rejects.toThrow(
+          "personal-resource admission requires the exact current uninterrupted attempt",
+        );
+      }
+
+      const ids = await createFixture(sql, databaseUrl, {
+        target: "ordinary",
+        workspaceMembership: true,
+      });
+      await insertAttempt(sql, ids, ids.attemptId);
+      await setRuntimeScope(sql, ids);
+      expect(await resolve(sql, ids)).toHaveLength(1);
+
+      for (const status of nonRunningStatuses) {
+        await setLifecycleStatus(sql, ids, status);
+        const [stored] = await sql<Array<{ status: string; activeAttemptId: string | null }>>`
+          select status, active_attempt_id as "activeAttemptId"
+          from session_turns where id = ${ids.turnId}
+        `;
+        expect(stored).toEqual({ status, activeAttemptId: ids.attemptId });
+        await expect(resolve(sql, ids)).rejects.toThrow(
+          "personal-resource resolve requires the exact current uninterrupted attempt",
+        );
+      }
+    });
+  }, 180_000);
+
+  test("upgrades an existing 0241 database without rewriting its migration", async () => {
+    await withBlankDatabase("migration-0249-upgrade", async (sql, databaseUrl) => {
+      await sql.unsafe(`
+        create table schema_migrations (
+          name text primary key,
+          applied_at timestamptz not null default now()
+        )
+      `);
+      await sql`insert into schema_migrations (name) values (${migrationName})`;
+      await migrate(databaseUrl);
+      await sql`delete from schema_migrations where name = ${migrationName}`;
+
+      const ids = await createFixture(sql, databaseUrl, {
+        target: "personal",
+        workspaceMembership: false,
+      });
+      await expect(insertAttempt(sql, ids, ids.attemptId)).rejects.toThrow(
+        "initiating human lacks target-workspace membership",
+      );
+
+      await migrate(databaseUrl);
+      const [receipt] = await sql<Array<{ count: number }>>`
+        select count(*)::int as count from schema_migrations where name = ${migrationName}
+      `;
+      expect(receipt?.count).toBe(1);
+      expect(await countWorkspaceMemberships(sql, ids)).toBe(0);
+      await insertAttempt(sql, ids, ids.attemptId);
+      await setRuntimeScope(sql, ids);
+      expect(await resolve(sql, ids)).toHaveLength(1);
+    });
+  }, 180_000);
+});
+
+type FixtureIds = {
+  accountId: string;
+  targetWorkspaceId: string;
+  authorityOwnerMembershipId: string | null;
+  subjectId: string;
+  sessionId: string;
+  turnId: string;
+  attemptId: string;
+};
+
+async function createFixture(
+  sql: postgres.Sql,
+  databaseUrl: string,
+  options: { target: "personal" | "ordinary"; workspaceMembership: boolean },
+): Promise<FixtureIds> {
+  const subjectId = `human:${crypto.randomUUID()}`;
+  const [account] = await sql<Array<{ id: string }>>`
+    insert into managed_accounts (name)
+    values (${`delegation-0249-${crypto.randomUUID()}`})
+    returning id
+  `;
+  const [personalWorkspace] = await sql<Array<{ id: string }>>`
+    insert into workspaces (account_id, name)
+    values (${account!.id}, 'personal')
+    returning id
+  `;
+  const [ordinaryWorkspace] =
+    options.target === "ordinary"
+      ? await sql<Array<{ id: string }>>`
+          insert into workspaces (account_id, name)
+          values (${account!.id}, 'ordinary')
+          returning id
+        `
+      : [personalWorkspace!];
+  const targetWorkspaceId = ordinaryWorkspace!.id;
+
+  await sql`
+    insert into workspace_inference_controls (workspace_id, account_id)
+    values (${personalWorkspace!.id}, ${account!.id})
+  `;
+  if (targetWorkspaceId !== personalWorkspace!.id) {
+    await sql`
+      insert into workspace_inference_controls (workspace_id, account_id)
+      values (${targetWorkspaceId}, ${account!.id})
+    `;
+  }
+
+  const [membership] = await sql<Array<{ id: string }>>`
+    insert into organization_memberships (
+      account_id, subject_id, status, personal_workspace_id, authorization_revision
+    ) values (${account!.id}, ${subjectId}, 'active', ${personalWorkspace!.id}, 7)
+    returning id
+  `;
+  if (options.workspaceMembership) {
+    await sql`
+      insert into workspace_memberships (account_id, workspace_id, subject_id)
+      values (${account!.id}, ${targetWorkspaceId}, ${subjectId})
+    `;
+  }
+
+  const [variableSet] = await sql<Array<{ id: string }>>`
+    insert into workspace_variable_sets (account_id, workspace_id, name)
+    values (${account!.id}, ${personalWorkspace!.id}, 'personal variable set')
+    returning id
+  `;
+  const [authority] = await sql<Array<{ id: string }>>`
+    insert into organization_user_resource_authorities (
+      account_id, organization_membership_id, resource_kind, resource_id,
+      origin_workspace_id, generation, status
+    ) values (
+      ${account!.id}, ${membership!.id}, 'variable_set', ${variableSet!.id},
+      ${personalWorkspace!.id}, 11, 'active'
+    ) returning id
+  `;
+  await sql`
+    update workspace_variable_sets
+    set authority_scope = 'user', authority_id = ${authority!.id},
+      owner_organization_membership_id = ${membership!.id},
+      origin_workspace_id = ${personalWorkspace!.id}
+    where id = ${variableSet!.id}
+  `;
+
+  const client = createDb(databaseUrl, { max: 1 });
+  let sessionId: string;
+  try {
+    const session = await createSession(client.db, {
+      requestedSessionId: crypto.randomUUID(),
+      accountId: account!.id,
+      workspaceId: targetWorkspaceId,
+      initialMessage: "migration 0249 authority fixture",
+      resources: [],
+      metadata: {},
+      createdBy: { kind: "subject", subjectId },
+      subjectId,
+      model: "test-model",
+      sandboxBackend: "modal",
+      variableSetId: variableSet!.id,
+      firstPartyMcpTools: [],
+    });
+    sessionId = session.id;
+  } finally {
+    await client.close();
+  }
+  const [sessionAuthority] = await sql<Array<{ ownerOrganizationMembershipId: string | null }>>`
+    select owner_organization_membership_id as "ownerOrganizationMembershipId"
+    from sessions where id = ${sessionId}
+  `;
+
+  const [turn] = await sql<Array<{ id: string }>>`
+    insert into session_turns (
+      account_id, workspace_id, session_id, trigger_event_id, temporal_workflow_id,
+      status, position, prompt, model, reasoning_effort, latency_mode,
+      sandbox_backend, initiator_kind, initiator_subject_id,
+      initiating_human_subject_id
+    ) values (
+      ${account!.id}, ${targetWorkspaceId}, ${sessionId}, ${crypto.randomUUID()},
+      'migration-0249-workflow', 'running', 1, 'test', 'test-model', 'medium',
+      'standard', 'modal', 'subject', ${subjectId}, ${subjectId}
+    ) returning id
+  `;
+  await sql`
+    insert into organization_user_resource_grants (
+      account_id, authority_id, owner_organization_membership_id, workspace_id,
+      session_id, action, mode, context, authority_epoch, generation, status
+    ) values (
+      ${account!.id}, ${authority!.id}, ${membership!.id}, ${targetWorkspaceId},
+      ${sessionId}, 'variable_set.use', 'session', 'workspace_shared', 1, 13, 'active'
+    )
+  `;
+
+  return {
+    accountId: account!.id,
+    targetWorkspaceId,
+    authorityOwnerMembershipId: sessionAuthority?.ownerOrganizationMembershipId ?? null,
+    subjectId,
+    sessionId,
+    turnId: turn!.id,
+    attemptId: crypto.randomUUID(),
+  };
+}
+
+async function insertAttempt(
+  sql: postgres.Sql,
+  ids: FixtureIds,
+  attemptId: string,
+  turnStatus = "running",
+) {
+  return await sql.begin(async (tx) => {
+    await tx.unsafe("set local opengeni.session_inference_claim = '1'");
+    await tx`
+      update sessions
+      set active_turn_id = ${ids.turnId}, status = ${turnStatus}
+      where id = ${ids.sessionId}
+        and account_id = ${ids.accountId}
+        and workspace_id = ${ids.targetWorkspaceId}
+    `;
+    await tx`
+      update session_turns
+      set active_attempt_id = ${attemptId}, execution_generation = 1,
+        status = ${turnStatus}
+      where id = ${ids.turnId}
+        and account_id = ${ids.accountId}
+        and workspace_id = ${ids.targetWorkspaceId}
+        and session_id = ${ids.sessionId}
+    `;
+    return await tx`
+      insert into session_turn_attempts (
+        id, account_id, workspace_id, session_id, turn_id, execution_generation,
+        temporal_workflow_id, temporal_workflow_run_id, temporal_activity_id,
+        verified_control_revision, authority_epoch, authority_visibility,
+        authority_owner_organization_membership_id, mcp_approval_policies,
+        connector_action_policies
+      ) values (
+        ${attemptId}, ${ids.accountId}, ${ids.targetWorkspaceId}, ${ids.sessionId},
+        ${ids.turnId}, 1, 'migration-0249-workflow', ${`run-${attemptId}`},
+        ${`activity-${attemptId}`}, 1, 1, 'workspace_shared',
+        ${ids.authorityOwnerMembershipId}, '{}'::jsonb, '[]'::jsonb
+      )
+    `;
+  });
+}
+
+async function setLifecycleStatus(sql: postgres.Sql, ids: FixtureIds, status: string) {
+  await sql.begin(async (tx) => {
+    await tx.unsafe("set local opengeni.session_inference_claim = '1'");
+    await tx`update sessions set status = ${status} where id = ${ids.sessionId}`;
+    await tx`update session_turns set status = ${status} where id = ${ids.turnId}`;
+  });
+}
+
+async function addWorkspaceMembership(sql: postgres.Sql, ids: FixtureIds) {
+  await sql`
+    insert into workspace_memberships (account_id, workspace_id, subject_id)
+    values (${ids.accountId}, ${ids.targetWorkspaceId}, ${ids.subjectId})
+  `;
+}
+
+async function countWorkspaceMemberships(sql: postgres.Sql, ids: FixtureIds): Promise<number> {
+  const [row] = await sql<Array<{ count: number }>>`
+    select count(*)::int as count
+    from workspace_memberships
+    where account_id = ${ids.accountId}
+      and workspace_id = ${ids.targetWorkspaceId}
+      and subject_id = ${ids.subjectId}
+  `;
+  return row?.count ?? -1;
+}
+
+async function setRuntimeScope(sql: postgres.Sql, ids: FixtureIds) {
+  await sql`select set_config('opengeni.account_id', ${ids.accountId}, false)`;
+  await sql`select set_config('opengeni.workspace_id', ${ids.targetWorkspaceId}, false)`;
+  await sql`select set_config('opengeni.subject_id', ${ids.subjectId}, false)`;
+  await sql`select set_config('opengeni.initiating_human_subject_id', ${ids.subjectId}, false)`;
+}
+
+async function resolve(sql: postgres.Sql, ids: FixtureIds) {
+  return await sql`
+    select * from resolve_session_attempt_personal_resources(
+      ${ids.accountId}, ${ids.targetWorkspaceId}, ${ids.attemptId}
+    )
+  `;
+}
+
+async function withBlankDatabase(
+  label: string,
+  callback: (sql: postgres.Sql, databaseUrl: string) => Promise<void>,
+): Promise<void> {
+  const blank = await acquireMigrationTestDatabase(label);
+  if (!blank) return;
+  const sql = postgres(blank.databaseUrl, {
+    max: 4,
+    prepare: false,
+    onnotice: () => undefined,
+  });
+  try {
+    await callback(sql, blank.databaseUrl);
+  } finally {
+    await sql.end({ timeout: 5 }).catch(() => undefined);
+    await blank.release();
+  }
+}
+
+async function acquireMigrationTestDatabase(label: string): Promise<BlankTestDatabase | null> {
+  if (!explicitAdminDatabaseUrl) {
+    const blank = await acquireBlankTestDatabase(label);
+    if (!blank && requireRealDatabase) {
+      throw new Error(
+        `[migration-0249-personal-resource-delegation-authority-correction] OPENGENI_REQUIRE_REAL_DB=1 but PostgreSQL is unavailable for ${label}`,
+      );
+    }
+    return blank;
+  }
+
+  const databaseName = `opengeni_0249_${label.replaceAll(/[^a-zA-Z0-9]/g, "_")}_${crypto
+    .randomUUID()
+    .replaceAll("-", "")}`.slice(0, 63);
+  const control = postgres(explicitAdminDatabaseUrl, { max: 1, prepare: false });
+  await control.unsafe(`create database ${quoteIdentifier(databaseName)}`);
+  const databaseUrl = new URL(explicitAdminDatabaseUrl);
+  databaseUrl.pathname = `/${databaseName}`;
+  let released = false;
+  return {
+    databaseUrl: databaseUrl.toString(),
+    release: async () => {
+      if (released) return;
+      released = true;
+      try {
+        await control`
+          select pg_terminate_backend(pid)
+          from pg_stat_activity
+          where datname = ${databaseName} and pid <> pg_backend_pid()
+        `;
+        await control.unsafe(`drop database if exists ${quoteIdentifier(databaseName)}`);
+      } finally {
+        await control.end({ timeout: 5 }).catch(() => undefined);
+      }
+    },
+  };
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -133,6 +133,7 @@ describe("release schema contract", () => {
       "0238_supergrok_realtime_model.sql",
       "0239_supergrok_video_funding.sql",
       "0240_model_context_user_messages.sql",
+      "0249_personal_resource_delegation_authority_correction.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -207,6 +208,15 @@ describe("release schema contract", () => {
       ),
     ).toMatchObject({
       sha256: "1717d5cdaa298501f20463eef43822a2b1421984f30cab7cb381c2773c505388",
+      deploymentMode: "rolling",
+    });
+    expect(
+      completeSourceContract.migrations.find(
+        (migration) =>
+          migration.path === "0249_personal_resource_delegation_authority_correction.sql",
+      ),
+    ).toMatchObject({
+      sha256: "98b1e6059e955b7a8022ff45f977b44075a7f854828422e06d9879a8487d62f7",
       deploymentMode: "rolling",
     });
     const migrations = new Map(


### PR DESCRIPTION
## Summary
- fix forward from merged migration 0241 without rewriting migration history
- allow the active organization member to admit and resolve their own user-scoped resource in their managed personal workspace, which intentionally has no `workspace_memberships` row
- preserve ordinary workspace membership requirements for non-personal workspaces
- require the exact active turn state `running` for both admission and resolution

## Safety boundaries
- rolling `CREATE OR REPLACE FUNCTION` migration only
- preserves immutable snapshot, account/workspace/session/turn/attempt/generation/visibility/authority/grant, interruption, once/session/always, concurrency, FORCE RLS, SECURITY DEFINER, capability cleanup, and no-direct-app-DML fences
- merged migration `0241_atomic_personal_resource_delegation.sql` remains unchanged

## Verification
- PostgreSQL 16.15 + pgvector guarded focused suite: 11/11
- migration 0249 real-DB bodies: 5/5
- existing migration 0241 contract harness: 9/9
- DB package typecheck: pass
- repository-wide typechecks: 31/31
- targeted lint, format, and diff checks: pass
- release schema contract: pass

Linear: OPE-242

Candidate: `0efc5098035bb7abbbb2a46db456f2b9f87e661c`
Base: `234a5e70fdf6b845a5f3a8ef437024bac177d5fd`
