### PR TITLE
fix(deployment): surface sandbox rollout controls

### DIFF
--- a/.changeset/bright-sandboxes-report.md
+++ b/.changeset/bright-sandboxes-report.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/observability": patch
+---
+
+Expose bounded configured and effective sandbox rollout state for every API and worker workload revision.

--- a/.env.example
+++ b/.env.example
@@ -418,6 +418,10 @@ OPENGENI_MODAL_TIMEOUT_SECONDS=86400
 OPENGENI_SANDBOX_PREPARATION_PROFILES=none
 # Add extra host env var names to expose to sandbox manifests.
 # OPENGENI_SANDBOX_ENV_ALLOWLIST=TF_VAR_region,CUSTOM_PROVIDER_TOKEN
+# Managed sandbox lease ownership is the prerequisite for lazy provisioning.
+# Keep both off until the staged ownership/reaper rollout is complete.
+# OPENGENI_SANDBOX_OWNERSHIP_ENABLED=false
+# OPENGENI_SANDBOX_LAZY_PROVISION=false
 
 # Session-level MCP tool providers. Clients select these by id with `tools: [{ "kind": "mcp", "id": "docs" }]`.
 # Built-in API MCP defaults to http://127.0.0.1:${OPENGENI_API_PORT}/v1/workspaces/{workspaceId}/mcp and exposes scheduled task tools.

--- a/deploy/helm/opengeni/values.preview-managed.example.yaml
+++ b/deploy/helm/opengeni/values.preview-managed.example.yaml
@@ -69,6 +69,8 @@ config:
   # secret (preview GitHub env), and OPENGENI_MODAL_IMAGE_REF is injected at
   # deploy time via --set to the desktop image ref built by build-preview.
   OPENGENI_SANDBOX_OWNERSHIP_ENABLED: "true"
+  OPENGENI_SANDBOX_LAZY_PROVISION: "true"
+  OPENGENI_RIG_VERIFICATION_LEASE_OWNERSHIP_ENABLED: "false"
   OPENGENI_SANDBOX_DESKTOP_ENABLED: "true"
   OPENGENI_STREAM_CONTROL_ENABLED: "true"
 

--- a/deploy/helm/opengeni/values.single-node.example.yaml
+++ b/deploy/helm/opengeni/values.single-node.example.yaml
@@ -126,6 +126,10 @@ config:
   OPENGENI_OBJECT_STORAGE_S3_PROVIDER: Minio
   OPENGENI_OBJECT_STORAGE_FORCE_PATH_STYLE: "true"
   OPENGENI_SANDBOX_OWNERSHIP_ENABLED: "true"
+  # Selfhosted-primary turns remain eager; keep both later-stage rollout gates
+  # explicit so this example never inherits a workstation shell override.
+  OPENGENI_SANDBOX_LAZY_PROVISION: "false"
+  OPENGENI_RIG_VERIFICATION_LEASE_OWNERSHIP_ENABLED: "false"
   OPENGENI_SANDBOX_BACKEND: selfhosted
   OPENGENI_SANDBOX_PREPARATION_PROFILES: none
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1580,6 +1580,39 @@ Secret delivery should use one of these patterns:
 
 Do not put provider credentials, model keys, storage keys, kubeconfigs, TLS private keys, Terraform state, or generated connection strings in committed values files. Sandbox credentials are opt-in through `OPENGENI_SANDBOX_PREPARATION_PROFILES` and `OPENGENI_SANDBOX_ENV_ALLOWLIST`; keep the default `none` profile unless the run truly needs cloud or GitHub credentials inside the sandbox.
 
+### Sandbox rollout configuration authority
+
+Managed staging and production have one authoritative injection path for the
+sandbox rollout controls: set `OPENGENI_SANDBOX_OWNERSHIP_ENABLED`,
+`OPENGENI_SANDBOX_LAZY_PROVISION`, and
+`OPENGENI_RIG_VERIFICATION_LEASE_OWNERSHIP_ENABLED` in the environment consumed
+by `bun run deployment:runtime-artifacts`, then publish the generated
+`opengeni-runtime` Secret through the deployment's configured secret manager.
+The artifact generator preserves explicit `true` and `false`; an unset key is
+omitted and retains the config package's safe default of `false`.
+
+API, control-worker, and turn-worker Pods load the chart ConfigMap first and the
+runtime Secret second, so the Secret wins any duplicate key. Committed example
+values may state explicit local/preview defaults, but they are not production
+rollout authority and must not be copied into a managed production overlay.
+Remove any direct Pod `env`, shell export, or secondary ConfigMap override for
+these three keys before rollout.
+
+Each API and worker `/metrics` endpoint exposes
+`opengeni_sandbox_rollout_config{feature,state}` with the bounded features
+`ownership`, `lazy_provision`, and `rig_verification_lease_ownership` and the
+states `configured` and `effective`. The standard `component` and
+`deployment_revision` labels identify the workload revision without tenant,
+session, credential, or provider identifiers. Lazy provisioning can be
+configured while remaining ineffective until ownership is enabled, which is
+reported explicitly.
+
+Roll out ownership first. After every reaper/verifier consumer reports the
+compatible revision, enable rig-verification lease ownership separately as
+described in [Rig operational rollout](rigs.md#operational-rollout). Enable lazy
+provisioning only after the credential/resource eager-path canaries for the
+target release are green.
+
 ## Observability
 
 OpenGeni emits Prometheus-native metrics. Scrape `/metrics` directly; do not route scraped metrics through OTLP. API and worker processes also emit structured JSON logs and optional OTLP/HTTP JSON traces.
@@ -1662,6 +1695,7 @@ Minimum production dashboards should cover:
 - Turn lifecycle: `opengeni_turns_total{outcome}`, `opengeni_turn_duration_seconds`, `opengeni_turns_inflight`, `opengeni_turn_oldest_inflight_age_seconds`, and `opengeni_turn_oldest_no_progress_age_seconds`.
 - Model, Codex, and sandbox SLIs: `opengeni_model_calls_total{provider,outcome}`, `opengeni_model_call_duration_seconds{provider}`, `opengeni_codex_credential_selections_total{strategy,reason}`, `opengeni_codex_credential_failures_total{kind,outcome}`, `opengeni_codex_pool_observations_total{depth}`, `opengeni_codex_pool_low_total{depth}`, `opengeni_sandbox_creates_total{backend,image_source,outcome}`, `opengeni_sandbox_create_duration_seconds{backend,image_source}`, `opengeni_sandbox_operations_total{backend,op,outcome}` (`ok`, expected path `not_found`, or actual `failed`), `opengeni_sandbox_operation_duration_seconds{backend,op}`, `opengeni_sandbox_inventory_refresh_timestamp_seconds{domain}`, the chart's freshness-filtered `opengeni:*:fresh_max` inventory recording rules, `opengeni_sandbox_warming_timeouts_total{backend,stage}`, and `opengeni_sandbox_orphans_terminated_total`.
 - Queue, admission, and billing: `opengeni_turns_queued`, `opengeni_turn_eligible_backlog`, `opengeni_turn_eligible_backlog_oldest_age_seconds`, `opengeni_turn_slot_saturation_ratio`, `opengeni_credit_balance_micros{account_id}`, `opengeni_credit_micros_total{kind}`, and `opengeni_build_info{version,revision}`.
+- Sandbox rollout state: `opengeni_sandbox_rollout_config{feature,state}` across API, control-worker, and turn-worker revisions; alert on disagreement before advancing a staged rollout.
 - Dependency health: Postgres connection health, Temporal worker poll health, NATS connectivity, object-storage write/read conformance, and sandbox backend readiness.
 - Runtime health: API/worker restarts, continuous turn-worker host/cgroup utilization and RSS reserve consumption, node memory/I/O PSI, swap-out activity, kubelet runtime errors, node readiness, pod pending time, collector scrape/export errors, and OTLP export failures.
 

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -130,14 +130,18 @@ export const SANDBOX_REQUIRED_ENV: Record<SandboxBackend, SandboxEnvBackendSpec>
 // they never enter missingEnvVars:
 //   - OPENGENI_STREAM_TOKEN_SECRET: HMAC secret minting scoped desktop stream
 //     tokens; falls back to OPENGENI_DELEGATION_SECRET when unset.
-//   - the three feature flags default off in @opengeni/config; preview flips
-//     them on through the helm config map, not here.
+//   - rollout flags default off in @opengeni/config. Generated deployment
+//     artifacts carry explicit operator values in the runtime Secret; the
+//     Secret is the authoritative managed-production source because it is the
+//     final envFrom source for API and worker workloads.
 //   - OPENGENI_MODAL_IMAGE_REF is also a modal-backend optional passthrough; it
 //     is injected at deploy time (--set) when a desktop image ref is built.
 export const SANDBOX_SURFACING_PASSTHROUGH_ENV: readonly string[] = [
   "OPENGENI_STREAM_TOKEN_SECRET",
   "OPENGENI_STREAM_CONTROL_ENABLED",
   "OPENGENI_SANDBOX_OWNERSHIP_ENABLED",
+  "OPENGENI_SANDBOX_LAZY_PROVISION",
+  "OPENGENI_RIG_VERIFICATION_LEASE_OWNERSHIP_ENABLED",
   "OPENGENI_SANDBOX_DESKTOP_ENABLED",
 ];
 
@@ -2325,9 +2329,10 @@ function runtimeEnvValues(
   // into runtime.env, but they are valueEnv passthroughs (emitted only when set,
   // never forced into missingEnvVars): OPENGENI_STREAM_TOKEN_SECRET gracefully
   // falls back to OPENGENI_DELEGATION_SECRET when unset (config's
-  // resolveStreamTokenSecret), and the three feature flags default off in
-  // @opengeni/config. Preview turns them ON via the helm config map; here we
-  // ensure the HMAC secret + the modal image ref reach the runtime secret.
+  // resolveStreamTokenSecret), and the rollout flags default off in
+  // @opengeni/config. Explicit rollout values are carried by the generated
+  // runtime Secret, whose later envFrom position makes it authoritative over
+  // any non-production example ConfigMap value.
   for (const key of SANDBOX_SURFACING_PASSTHROUGH_ENV) {
     entries.push(valueEnv(key, env[key]));
   }

--- a/packages/deployment/test/deployment.test.ts
+++ b/packages/deployment/test/deployment.test.ts
@@ -11,6 +11,8 @@ import {
   requiredRuntimeEnvVars,
   SANDBOX_REQUIRED_ENV,
   SANDBOX_LIFECYCLE_PASSTHROUGH_ENV,
+  SANDBOX_SURFACING_PASSTHROUGH_ENV,
+  SecretDeliveryMode,
   stackPlanFor,
 } from "../src/index";
 
@@ -983,6 +985,13 @@ describe("deployment contract", () => {
         "OPENGENI_SANDBOX_WARMING_TIMEOUT_MS",
       ]),
     );
+    expect(SANDBOX_SURFACING_PASSTHROUGH_ENV).toEqual(
+      expect.arrayContaining([
+        "OPENGENI_SANDBOX_OWNERSHIP_ENABLED",
+        "OPENGENI_SANDBOX_LAZY_PROVISION",
+        "OPENGENI_RIG_VERIFICATION_LEASE_OWNERSHIP_ENABLED",
+      ]),
+    );
     expect(EXTERNAL_BROWSER_PROVIDER_PASSTHROUGH_ENV).toEqual([
       "OPENGENI_BROWSERBASE_API_KEY",
       "OPENGENI_KERNEL_API_KEY",
@@ -1136,6 +1145,39 @@ describe("deployment contract", () => {
     for (const key of EXTERNAL_BROWSER_PROVIDER_PASSTHROUGH_ENV) {
       expect(absent.runtimeEnv).not.toContain(`${key}=`);
       expect(absent.missingEnvVars).not.toContain(key);
+    }
+  });
+
+  test("renders explicit sandbox rollout booleans through every deployment delivery mode", () => {
+    const rolloutKeys = [
+      "OPENGENI_SANDBOX_OWNERSHIP_ENABLED",
+      "OPENGENI_SANDBOX_LAZY_PROVISION",
+      "OPENGENI_RIG_VERIFICATION_LEASE_OWNERSHIP_ENABLED",
+    ] as const;
+    for (const secretMode of SecretDeliveryMode.options) {
+      const contract = parseDeploymentContract({
+        ...deploymentProfiles["kubernetes-external"],
+        secrets: { mode: secretMode },
+      });
+      for (const value of ["true", "false"] as const) {
+        const artifacts = generateRuntimeArtifacts(
+          contract,
+          {},
+          Object.fromEntries(rolloutKeys.map((key) => [key, value])),
+        );
+        for (const key of rolloutKeys) {
+          expect(artifacts.runtimeEnv).toContain(`${key}=${value}`);
+          expect(artifacts.summary.runtimeEnvKeys).toContain(key);
+          expect(artifacts.missingEnvVars).not.toContain(key);
+        }
+      }
+
+      const unset = generateRuntimeArtifacts(contract, {}, {});
+      for (const key of rolloutKeys) {
+        expect(unset.runtimeEnv).not.toContain(`${key}=`);
+        expect(unset.summary.runtimeEnvKeys).not.toContain(key);
+        expect(unset.missingEnvVars).not.toContain(key);
+      }
     }
   });
 });

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -13,6 +13,9 @@ export type ObservabilitySettings = {
   observabilityMetricsEnabled: boolean;
   observabilityOtlpEndpoint?: string | undefined;
   observabilityOtlpHeaders: string;
+  sandboxOwnershipEnabled?: boolean | undefined;
+  sandboxLazyProvisionEnabled?: boolean | undefined;
+  rigVerificationLeaseOwnershipEnabled?: boolean | undefined;
 };
 
 export type ObservabilityOptions = {
@@ -418,6 +421,37 @@ export class Observability {
           revision: settings.deploymentRevision ?? "dev",
         },
         value: 1,
+      });
+      this.registerSandboxRolloutConfig();
+    }
+  }
+
+  private registerSandboxRolloutConfig(): void {
+    const ownership = this.settings.sandboxOwnershipEnabled;
+    const lazyConfigured = this.settings.sandboxLazyProvisionEnabled;
+    const rigVerification = this.settings.rigVerificationLeaseOwnershipEnabled;
+    if (
+      typeof ownership !== "boolean" ||
+      typeof lazyConfigured !== "boolean" ||
+      typeof rigVerification !== "boolean"
+    ) {
+      return;
+    }
+
+    const values = [
+      ["ownership", "configured", ownership],
+      ["ownership", "effective", ownership],
+      ["lazy_provision", "configured", lazyConfigured],
+      ["lazy_provision", "effective", ownership && lazyConfigured],
+      ["rig_verification_lease_ownership", "configured", rigVerification],
+      ["rig_verification_lease_ownership", "effective", rigVerification],
+    ] as const;
+    for (const [feature, state, enabled] of values) {
+      this.setGauge({
+        name: "opengeni_sandbox_rollout_config",
+        help: "Configured and effective sandbox rollout state for this workload revision.",
+        labels: { feature, state },
+        value: enabled ? 1 : 0,
       });
     }
   }

--- a/packages/observability/test/observability.test.ts
+++ b/packages/observability/test/observability.test.ts
@@ -49,6 +49,51 @@ describe("observability", () => {
     expect(metrics).toContain("opengeni_process_cpu_user_seconds_total");
   });
 
+  test("reports bounded configured and effective sandbox rollout state", async () => {
+    const obs = createObservability(
+      {
+        ...settings,
+        sandboxOwnershipEnabled: true,
+        sandboxLazyProvisionEnabled: true,
+        rigVerificationLeaseOwnershipEnabled: false,
+      },
+      { component: "worker-turn", now: () => 1 },
+    );
+
+    const metrics = await obs.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_sandbox_rollout_config\{[^}]*feature="ownership"[^}]*state="effective"[^}]*\} 1\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_sandbox_rollout_config\{[^}]*feature="lazy_provision"[^}]*state="effective"[^}]*\} 1\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_sandbox_rollout_config\{[^}]*feature="rig_verification_lease_ownership"[^}]*state="effective"[^}]*\} 0\b/,
+    );
+    expect(metrics).toContain('deployment_revision="revision-test"');
+    expect(metrics).toContain('component="worker-turn"');
+  });
+
+  test("reports lazy provisioning as configured but ineffective without ownership", async () => {
+    const obs = createObservability(
+      {
+        ...settings,
+        sandboxOwnershipEnabled: false,
+        sandboxLazyProvisionEnabled: true,
+        rigVerificationLeaseOwnershipEnabled: false,
+      },
+      { component: "api", now: () => 1 },
+    );
+
+    const metrics = await obs.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_sandbox_rollout_config\{[^}]*feature="lazy_provision"[^}]*state="configured"[^}]*\} 1\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_sandbox_rollout_config\{[^}]*feature="lazy_provision"[^}]*state="effective"[^}]*\} 0\b/,
+    );
+  });
+
   test("registers generic counters gauges and histograms with bounded labels", async () => {
     const obs = createObservability(settings, { component: "worker", now: () => 1 });
     obs.incrementCounter({


### PR DESCRIPTION
Closes OPE-243.

Adds the ownership, lazy-provisioning, and rig-verification rollout flags to the provider-neutral runtime artifact path while preserving explicit true/false and safe unset defaults across every supported delivery mode. Exposes bounded configured/effective rollout state on API and worker metrics by component and deployment revision, makes preview/single-node examples explicit, and documents the generated runtime Secret as managed production authority.

Verification:
- bun test packages/deployment/test/deployment.test.ts packages/observability/test/observability.test.ts
- bun run --filter @opengeni/deployment typecheck
- bun run --filter @opengeni/observability typecheck
- bun test scripts/helm-upgrade-contract.test.ts
- bunx oxfmt --check on changed source/tests
- git diff --check