### PR TITLE
Fix duplicate client tool-search identities

### DIFF
--- a/packages/runtime/src/codex-tool-search.ts
+++ b/packages/runtime/src/codex-tool-search.ts
@@ -371,7 +371,11 @@ export function searchMcpTools(
  * paths keep their narrower MCP selection before entering this shared bound.
  */
 export function searchToolPool(availableTools: Tool[], rawArguments: unknown): Tool[] {
-  const searchable = availableTools.filter(
+  // The Agents SDK can present the same configured tool reference more than once
+  // while resolving multiple client tool_search calls from one model response.
+  // Collapse only referential duplicates here: distinct objects with the same
+  // routed identity must still reach the SDK's conflict checks and fail closed.
+  const searchable = [...new Set(availableTools)].filter(
     (tool): tool is Tool & { name: string } =>
       tool.type === "function" && typeof (tool as { name?: unknown }).name === "string",
   );

--- a/packages/runtime/test/codex-tool-search.test.ts
+++ b/packages/runtime/test/codex-tool-search.test.ts
@@ -19,6 +19,7 @@ import {
   isCodexAppsFunctionTool,
   isSearchableMcpFunctionTool,
   renderSearchToolDescription,
+  searchToolPool,
 } from "../src/codex-tool-search";
 import {
   buildOpenGeniAgent,
@@ -97,6 +98,11 @@ const POOL: Tool[] = [
 ];
 
 describe("bm25RankTools", () => {
+  test("collapses an identical tool reference repeated in the callback pool", () => {
+    const repeated = POOL[0]!;
+    expect(searchToolPool([repeated, repeated], { query: "send an email" })).toEqual([repeated]);
+  });
+
   test("ranks the capability-relevant tool first", () => {
     const top = bm25RankTools(POOL, "send an email to someone", 3)[0] as { name: string };
     expect(top.name).toBe("codex_apps__gmail_send_email");

--- a/packages/runtime/test/lazy-tool-transport.test.ts
+++ b/packages/runtime/test/lazy-tool-transport.test.ts
@@ -6,6 +6,7 @@ import {
   Runner,
   Usage,
   tool,
+  toolSearchTool,
   type Model,
   type ModelProvider,
   type ModelRequest,
@@ -732,6 +733,264 @@ describe("generic lazy tool dispatch", () => {
 });
 
 describe("OpenAI/Azure native client tool search", () => {
+  test("keeps the callback tool pool unique across multiple searches in one response", async () => {
+    const deferredTool = weatherTool();
+    (deferredTool as { deferLoading?: boolean }).deferLoading = true;
+    const matchingCounts: number[] = [];
+    const searchTool = toolSearchTool({
+      execution: "client",
+      description: "Search available tools",
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+        additionalProperties: false,
+      },
+      execute: async ({ availableTools }) => {
+        const matches = availableTools.filter(
+          (candidate) => candidate.type === "function" && candidate.name === WEATHER_TOOL,
+        );
+        matchingCounts.push(matches.length);
+        return matches;
+      },
+    });
+    const agent = new Agent({
+      name: "same-response-tool-search-test",
+      instructions: "Search for tools.",
+      model: "scripted",
+      tools: [deferredTool, searchTool],
+    });
+    const model = new ScriptedStreamingModel([
+      [
+        {
+          type: "tool_search_call",
+          call_id: "search-one",
+          execution: "client",
+          status: "completed",
+          arguments: { query: "weather" },
+        },
+        {
+          type: "tool_search_call",
+          call_id: "search-two",
+          execution: "client",
+          status: "completed",
+          arguments: { query: "weather" },
+        },
+      ],
+      [finalMessage("done")],
+    ]);
+    const result = await new Runner({ modelProvider: providerFor(model) }).run(
+      agent,
+      "Find weather tools twice.",
+      {
+        stream: true,
+        historyOwnership: "external",
+        maxTurns: 4,
+      },
+    );
+    for await (const _event of result.toStream()) void _event;
+    await result.completed;
+
+    expect(result.finalOutput).toBe("done");
+    expect(matchingCounts).toEqual([1, 1]);
+    const disclosedHistory = JSON.stringify(model.requests[1]!.input);
+    expect(disclosedHistory.match(/tool_search_output/g)).toHaveLength(2);
+  });
+
+  test("replaces a callback-created tool by routed identity within one response", async () => {
+    const dynamicName = "dynamic__lookup";
+    const firstDefinition = tool({
+      name: dynamicName,
+      description: "First definition",
+      parameters: {
+        type: "object",
+        properties: { old_query: { type: "string" } },
+        required: ["old_query"],
+        additionalProperties: false,
+      },
+      strict: false,
+      execute: () => "unused",
+    }) as unknown as Tool;
+    const currentDefinition = tool({
+      name: dynamicName,
+      description: "Current definition",
+      parameters: {
+        type: "object",
+        properties: { current_query: { type: "string" } },
+        required: ["current_query"],
+        additionalProperties: false,
+      },
+      strict: false,
+      execute: () => "unused",
+    }) as unknown as Tool;
+    const observedDefinitions: string[][] = [];
+    const searchTool = toolSearchTool({
+      execution: "client",
+      description: "Search dynamic tools",
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+        additionalProperties: false,
+      },
+      execute: async ({ availableTools, toolCall }) => {
+        const query = (toolCall.arguments as { query?: string }).query;
+        observedDefinitions.push(
+          availableTools
+            .filter((candidate) => candidate.type === "function" && candidate.name === dynamicName)
+            .map((candidate) => candidate.description),
+        );
+        if (query === "first") return [firstDefinition];
+        if (query === "replace") return [currentDefinition];
+        return availableTools.filter(
+          (candidate) => candidate.type === "function" && candidate.name === dynamicName,
+        );
+      },
+    });
+    const agent = new Agent({
+      name: "same-response-tool-replacement-test",
+      instructions: "Search for dynamic tools.",
+      model: "scripted",
+      tools: [searchTool],
+    });
+    const model = new ScriptedStreamingModel([
+      [
+        {
+          type: "tool_search_call",
+          call_id: "dynamic-first",
+          execution: "client",
+          status: "completed",
+          arguments: { query: "first" },
+        },
+        {
+          type: "tool_search_call",
+          call_id: "dynamic-replace",
+          execution: "client",
+          status: "completed",
+          arguments: { query: "replace" },
+        },
+        {
+          type: "tool_search_call",
+          call_id: "dynamic-current",
+          execution: "client",
+          status: "completed",
+          arguments: { query: "current" },
+        },
+      ],
+      [finalMessage("done")],
+    ]);
+    const result = await new Runner({ modelProvider: providerFor(model) }).run(
+      agent,
+      "Refresh the dynamic tool.",
+      {
+        stream: true,
+        historyOwnership: "external",
+        maxTurns: 4,
+      },
+    );
+    for await (const _event of result.toStream()) void _event;
+    await result.completed;
+
+    expect(result.finalOutput).toBe("done");
+    expect(observedDefinitions).toEqual([[], ["First definition"], ["Current definition"]]);
+  });
+
+  test("rebinds historical disclosure to today's same-identity tool definition", async () => {
+    let executedInput: { city: string; units: string } | undefined;
+    const currentTool = tool({
+      name: WEATHER_TOOL,
+      description: "Look up weather using the current units-aware schema",
+      parameters: {
+        type: "object",
+        properties: {
+          city: { type: "string" },
+          units: { type: "string" },
+        },
+        required: ["city", "units"],
+        additionalProperties: false,
+      },
+      strict: false,
+      execute: (input) => {
+        executedInput = input as { city: string; units: string };
+        return `${executedInput.city}:${executedInput.units}`;
+      },
+    }) as unknown as Tool;
+    (currentTool as { deferLoading?: boolean }).deferLoading = true;
+    const searchTool = toolSearchTool({
+      execution: "client",
+      execute: async () => [currentTool],
+    });
+    const agent = new Agent({
+      name: "historical-tool-refresh-test",
+      instructions: "Use current tools.",
+      model: "scripted",
+      tools: [currentTool, searchTool],
+    });
+    const model = new ScriptedStreamingModel([
+      [
+        {
+          type: "function_call",
+          callId: "current-weather-call",
+          name: WEATHER_TOOL,
+          arguments: JSON.stringify({ city: "Oslo", units: "metric" }),
+        },
+      ],
+      [finalMessage("current-definition-used")],
+    ]);
+    const historicalInput = [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "Old weather request" }],
+      },
+      {
+        type: "tool_search_call",
+        call_id: "old-weather-search",
+        execution: "client",
+        status: "completed",
+        arguments: { query: "weather" },
+      },
+      {
+        type: "tool_search_output",
+        call_id: "old-weather-search",
+        execution: "client",
+        status: "completed",
+        tools: [
+          {
+            type: "function",
+            name: WEATHER_TOOL,
+            description: "Old city-only weather schema",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string" } },
+              required: ["city"],
+              additionalProperties: false,
+            },
+          },
+        ],
+      },
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "Use metric units now" }],
+      },
+    ];
+    const result = await new Runner({ modelProvider: providerFor(model) }).run(
+      agent,
+      historicalInput as never,
+      {
+        stream: true,
+        historyOwnership: "external",
+        maxTurns: 4,
+      },
+    );
+    for await (const _event of result.toStream()) void _event;
+    await result.completed;
+
+    expect(result.finalOutput).toBe("current-definition-used");
+    expect(executedInput).toEqual({ city: "Oslo", units: "metric" });
+  });
+
   test("omits lazy schemas on the wire, discloses real tool objects, and executes normally", async () => {
     let approvalChecks = 0;
     let executions = 0;

--- a/patches/@openai%2Fagents-core@0.14.3.patch
+++ b/patches/@openai%2Fagents-core@0.14.3.patch
@@ -1055,3 +1055,97 @@ index 773f1fc48bf8758d642bd51f8c062efbf08f5c45..3540413d2bdac08df13084f0b98545bc
          const consumedExactClones = new WeakSet();
          const injectedExactCloneIndexes = new Set();
          // Preserve a pointer to the original object backing each filtered clone so downstream
+diff --git a/dist/runner/modelOutputs.js b/dist/runner/modelOutputs.js
+index c9d44147563f79619b754013800494811c180e22..ddd315188141369162b826bf6fa80c7fb5ca31da 100644
+--- a/dist/runner/modelOutputs.js
++++ b/dist/runner/modelOutputs.js
+@@ -274,6 +274,33 @@ function buildGeneratedClientToolSearchOutputMap(modelResponse, tools, hasClient
+     }
+     return generatedOutputs;
+ }
++function mergeClientToolSearchExecutionTools(availableTools, runtimeTools) {
++    const availableIndexByKey = new Map();
++    for (let index = 0; index < availableTools.length; index++) {
++        const key = (0, tool_1.getToolSearchRuntimeRoutingKey)(availableTools[index]);
++        if (key && !availableIndexByKey.has(key)) {
++            availableIndexByKey.set(key, index);
++        }
++    }
++    for (const runtimeTool of runtimeTools) {
++        const key = (0, tool_1.getToolSearchRuntimeRoutingKey)(runtimeTool);
++        if (!key) {
++            if (!availableTools.includes(runtimeTool)) {
++                availableTools.push(runtimeTool);
++            }
++            continue;
++        }
++        const existingIndex = availableIndexByKey.get(key);
++        if (existingIndex === undefined) {
++            availableIndexByKey.set(key, availableTools.length);
++            availableTools.push(runtimeTool);
++            continue;
++        }
++        if (availableTools[existingIndex] !== runtimeTool) {
++            availableTools[existingIndex] = runtimeTool;
++        }
++    }
++}
+ async function buildGeneratedClientToolSearchOutputMapAsync(args) {
+     const { agent, handoffs, modelResponse, replaceableRuntimeToolKeys, runContext, tools, } = args;
+     const clientToolSearchTool = (0, toolSearch_1.getClientToolSearchHelper)(tools);
+@@ -307,7 +334,7 @@ async function buildGeneratedClientToolSearchOutputMapAsync(args) {
+                 runtimeTools: generatedOutput.runtimeTools,
+             });
+             generatedOutputs.set(toolSearchCall, generatedOutput);
+-            executionTools.push(...generatedOutput.callbackRuntimeTools);
++            mergeClientToolSearchExecutionTools(executionTools, generatedOutput.callbackRuntimeTools);
+             continue;
+         }
+         generatedOutputs.set(toolSearchCall, {
+diff --git a/dist/runner/modelOutputs.mjs b/dist/runner/modelOutputs.mjs
+index 34dc1b761aee009ea97f2a26529f7246c44d018e..24a929cfd887fdb913992293e4129bbd10ce4646 100644
+--- a/dist/runner/modelOutputs.mjs
++++ b/dist/runner/modelOutputs.mjs
+@@ -270,6 +270,33 @@ function buildGeneratedClientToolSearchOutputMap(modelResponse, tools, hasClient
+     }
+     return generatedOutputs;
+ }
++function mergeClientToolSearchExecutionTools(availableTools, runtimeTools) {
++    const availableIndexByKey = new Map();
++    for (let index = 0; index < availableTools.length; index++) {
++        const key = getToolSearchRuntimeRoutingKey(availableTools[index]);
++        if (key && !availableIndexByKey.has(key)) {
++            availableIndexByKey.set(key, index);
++        }
++    }
++    for (const runtimeTool of runtimeTools) {
++        const key = getToolSearchRuntimeRoutingKey(runtimeTool);
++        if (!key) {
++            if (!availableTools.includes(runtimeTool)) {
++                availableTools.push(runtimeTool);
++            }
++            continue;
++        }
++        const existingIndex = availableIndexByKey.get(key);
++        if (existingIndex === undefined) {
++            availableIndexByKey.set(key, availableTools.length);
++            availableTools.push(runtimeTool);
++            continue;
++        }
++        if (availableTools[existingIndex] !== runtimeTool) {
++            availableTools[existingIndex] = runtimeTool;
++        }
++    }
++}
+ async function buildGeneratedClientToolSearchOutputMapAsync(args) {
+     const { agent, handoffs, modelResponse, replaceableRuntimeToolKeys, runContext, tools, } = args;
+     const clientToolSearchTool = getClientToolSearchHelper(tools);
+@@ -303,7 +330,7 @@ async function buildGeneratedClientToolSearchOutputMapAsync(args) {
+                 runtimeTools: generatedOutput.runtimeTools,
+             });
+             generatedOutputs.set(toolSearchCall, generatedOutput);
+-            executionTools.push(...generatedOutput.callbackRuntimeTools);
++            mergeClientToolSearchExecutionTools(executionTools, generatedOutput.callbackRuntimeTools);
+             continue;
+         }
+         generatedOutputs.set(toolSearchCall, {


### PR DESCRIPTION
## Summary

- Reconcile callback tools by routed identity after SDK validation: identical references are idempotent; the latest admitted runtime definition replaces its predecessor.
- Defensively deduplicate identical OpenGeni callback-pool references while preserving fail-closed behavior for distinct conflicting tools.
- Keep current attempt tool definitions authoritative over historical tool-search disclosures.

## Testing

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test packages/runtime/test` — 1,375 pass, 19 skip, 0 fail
- [x] Forced `bun install --force --frozen-lockfile`, then focused regressions — 57 pass, 0 fail; CJS and ESM patch present
- [x] Full `bun test` sweep — 9,384 pass, 66 skip; 5 concurrency-only failures. Isolated rerun of all affected files: 294 pass, 0 fail.

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] Candidate head is frozen at `8da68b16622c20d78bde96e14d9f3386657505b1`; current-base compatibility will be verified without source mutation.

## Notes

- No history rewriting or historical tool-list comparison. A new attempt uses its freshly resolved authorized catalog; historical tool-search output remains immutable conversation evidence.