### PR TITLE
fix(ci): bake agent into dogfood API images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1164,6 +1164,33 @@ jobs:
           name: ${{ needs.artifact-runtime.outputs.artifact_name }}
           path: .release/artifact-runtime
 
+      # Jorgebot and other exact-main-SHA dogfood deployments install their
+      # connected-machine agent from this API image. Bake the signed agent only
+      # for a protected main push: PR, scheduled, and automation image builds are
+      # never deployed under dogfood-sha-* and must not receive the signing key.
+      - name: Install Rust toolchain for dogfood agent bake
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          rustup toolchain install 1.97.1 --profile minimal --no-self-update
+          rustup default 1.97.1
+
+      - name: Bake and sign exact-SHA dogfood agent
+        if: ${{ github.event_name == 'push' }}
+        env:
+          OPENGENI_AGENT_MINISIGN_KEY: ${{ secrets.OPENGENI_AGENT_MINISIGN_KEY }}
+        run: scripts/bake-agent.sh
+
+      - name: Require complete exact-SHA dogfood agent bake
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          set -euo pipefail
+          for target in x86_64-unknown-linux-musl aarch64-unknown-linux-musl; do
+            asset="agent/install/baked/opengeni-agent-$target"
+            test -s "$asset"
+            test -s "$asset.sha256"
+            test -s "$asset.minisig"
+          done
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -439,6 +439,7 @@ describe("release image workflow contract", () => {
           if?: string;
           steps?: Array<{
             name?: string;
+            if?: string;
             env?: Record<string, string>;
             run?: string;
             with?: Record<string, unknown>;
@@ -500,6 +501,25 @@ describe("release image workflow contract", () => {
         password: "${{ secrets.GITHUB_TOKEN }}",
       });
     }
+    const apiSteps = parsed.jobs["api-image"]?.steps ?? [];
+    const bake = apiSteps.find((step) => step.name === "Bake and sign exact-SHA dogfood agent");
+    expect(bake?.if).toBe("${{ github.event_name == 'push' }}");
+    expect(bake?.env).toEqual({
+      OPENGENI_AGENT_MINISIGN_KEY: "${{ secrets.OPENGENI_AGENT_MINISIGN_KEY }}",
+    });
+    expect(bake?.run).toBe("scripts/bake-agent.sh");
+    const requireBake = apiSteps.find(
+      (step) => step.name === "Require complete exact-SHA dogfood agent bake",
+    );
+    expect(requireBake?.if).toBe("${{ github.event_name == 'push' }}");
+    expect(requireBake?.run).toContain("x86_64-unknown-linux-musl aarch64-unknown-linux-musl");
+    expect(requireBake?.run).toContain('test -s "$asset.minisig"');
+    expect(apiSteps.indexOf(bake!)).toBeLessThan(
+      apiSteps.findIndex((step) => step.name === "Build API image"),
+    );
+    expect(apiSteps.indexOf(requireBake!)).toBeLessThan(
+      apiSteps.findIndex((step) => step.name === "Build API image"),
+    );
     expect(images).toContain("Require every workload image build");
     expect(images).toContain("API_IMAGE_RESULT: ${{ needs.api-image.result }}");
     expect(images).toContain("WORKER_WEB_IMAGES_RESULT: ${{ needs.worker-web-images.result }}");


### PR DESCRIPTION
## What

Bake and sign the exact-SHA Linux connected-machine agents before protected-main dogfood API image builds. Fail closed unless both architectures and their checksum/signature sidecars exist. PR, scheduled, and automation image builds never receive the signing key.

## Why

Jorgebot deploys `dogfood-sha-*` images. That CI path skipped `scripts/bake-agent.sh`, so `/agent/latest/...` redirected to the older public stable release even though release-candidate images correctly contained the matching agent.

## Verification

- `bun test scripts/release-image-workflow-contract.test.ts scripts/ci/impact.test.ts` (51 pass)
- `git diff --check`