### PR TITLE
fix(xai): drain fragmented SSE events

### DIFF
--- a/packages/xai-subscription/src/fetch.ts
+++ b/packages/xai-subscription/src/fetch.ts
@@ -305,48 +305,71 @@ async function normalizeResponse(
     async pull(controller) {
       if (audit.terminal) return;
       try {
-        const chunk = await reader.read();
-        if (audit.terminal) return;
-        pending += decoder.decode(chunk.value, { stream: !chunk.done });
-        const parts = pending.split(/\r?\n\r?\n/);
-        pending = parts.pop() ?? "";
-        if (chunk.done && pending) {
-          parts.push(pending);
-          pending = "";
-        }
-        for (const part of parts) {
-          const progress = sseProgress(part);
-          controller.enqueue(encoder.encode(`${normalizeSseEvent(part, onFinalContextUsage)}\n\n`));
-          if (!progress.valid) continue;
-          clearIdleTimer();
-          const now = performance.now();
-          const interEventGapMs = Math.max(0, now - (audit.lastProgressAt ?? audit.startedAt));
-          audit.eventCount = Math.min(Number.MAX_SAFE_INTEGER, audit.eventCount + 1);
-          audit.lastEventType = progress.eventType;
-          audit.lastProgressAt = now;
-          silenceStartedAt = now;
-          if (audit.eventCount === 1) {
-            await emitRequestEvent(audit, {
-              phase: "first_event",
-              responseObserved: true,
-              status: response.status,
-              ...providerRequestIdFields(response.headers),
-            });
-          } else {
-            emitDiagnosticEvent(audit, {
-              phase: "progress",
-              responseObserved: true,
-              status: response.status,
-              interEventGapMs,
-              ...providerRequestIdFields(response.headers),
-            });
+        // A provider may split one SSE event across several network chunks. A
+        // pull that returns without enqueueing anything can leave the pending
+        // downstream read parked indefinitely in Bun, so keep reading until we
+        // can satisfy it with at least one complete block (or settle the stream).
+        while (!audit.terminal) {
+          const chunk = await reader.read();
+          if (audit.terminal) return;
+          pending += decoder.decode(chunk.value, { stream: !chunk.done });
+          const parts = pending.split(/\r?\n\r?\n/);
+          pending = parts.pop() ?? "";
+          if (chunk.done && pending) {
+            parts.push(pending);
+            pending = "";
           }
-          if (progress.terminal) {
+          let enqueued = false;
+          for (const part of parts) {
+            const progress = sseProgress(part);
+            controller.enqueue(
+              encoder.encode(`${normalizeSseEvent(part, onFinalContextUsage)}\n\n`),
+            );
+            enqueued = true;
+            if (!progress.valid) continue;
+            clearIdleTimer();
+            const now = performance.now();
+            const interEventGapMs = Math.max(0, now - (audit.lastProgressAt ?? audit.startedAt));
+            audit.eventCount = Math.min(Number.MAX_SAFE_INTEGER, audit.eventCount + 1);
+            audit.lastEventType = progress.eventType;
+            audit.lastProgressAt = now;
+            silenceStartedAt = now;
+            if (audit.eventCount === 1) {
+              await emitRequestEvent(audit, {
+                phase: "first_event",
+                responseObserved: true,
+                status: response.status,
+                ...providerRequestIdFields(response.headers),
+              });
+            } else {
+              emitDiagnosticEvent(audit, {
+                phase: "progress",
+                responseObserved: true,
+                status: response.status,
+                interEventGapMs,
+                ...providerRequestIdFields(response.headers),
+              });
+            }
+            if (progress.terminal) {
+              audit.terminal = true;
+              clearIdleTimer();
+              await reader.cancel().catch(() => undefined);
+              await emitRequestEvent(audit, {
+                phase: progress.terminal,
+                responseObserved: true,
+                status: response.status,
+                ...providerRequestIdFields(response.headers),
+              });
+              closeStream();
+              return;
+            }
+            armIdleTimer();
+          }
+          if (chunk.done) {
             audit.terminal = true;
             clearIdleTimer();
-            await reader.cancel().catch(() => undefined);
             await emitRequestEvent(audit, {
-              phase: progress.terminal,
+              phase: "failed",
               responseObserved: true,
               status: response.status,
               ...providerRequestIdFields(response.headers),
@@ -354,18 +377,7 @@ async function normalizeResponse(
             closeStream();
             return;
           }
-          armIdleTimer();
-        }
-        if (chunk.done) {
-          audit.terminal = true;
-          clearIdleTimer();
-          await emitRequestEvent(audit, {
-            phase: "failed",
-            responseObserved: true,
-            status: response.status,
-            ...providerRequestIdFields(response.headers),
-          });
-          closeStream();
+          if (enqueued) return;
         }
       } catch (error) {
         if (audit.terminal) {

--- a/packages/xai-subscription/test/transport.test.ts
+++ b/packages/xai-subscription/test/transport.test.ts
@@ -253,6 +253,62 @@ describe("SuperGrok subscription fetch", () => {
     expect(text).toContain("response.completed");
   });
 
+  test("keeps reading when the first SSE event spans multiple upstream chunks", async () => {
+    const encoder = new TextEncoder();
+    const payload = encoder.encode(
+      `data: ${JSON.stringify({
+        type: "response.created",
+        response: {
+          id: "response-fragmented",
+          status: "in_progress",
+          instructions: "x".repeat(15_000),
+        },
+      })}\n\n` +
+        `data: ${JSON.stringify({
+          type: "response.completed",
+          response: { id: "response-fragmented", output: [], usage: {} },
+        })}\n\n`,
+    );
+    const boundaries = [6_839, 8_186, 12_287, payload.byteLength];
+    const chunks = boundaries.map((end, index) => payload.slice(boundaries[index - 1] ?? 0, end));
+    let index = 0;
+    const wrapped = xaiSubscriptionFetch(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              const chunk = chunks[index++];
+              if (chunk) {
+                controller.enqueue(chunk);
+                return;
+              }
+              controller.close();
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+    );
+    const response = await xaiSubscriptionRequestStorage.run(
+      {
+        clientVersion: "1.0.1",
+        sessionId: "session-1",
+        turnId: "turn-1",
+        getToken: async () => ({ accessToken: "access", userId: "user-1" }),
+        refresh: async () => ({ accessToken: "fresh", userId: "user-1" }),
+        resolveModel: (slug) => slug,
+        streamIdleTimeoutMs: 50,
+      },
+      async () =>
+        await wrapped("https://cli-chat-proxy.grok.com/v1/responses", {
+          method: "POST",
+          body: JSON.stringify({ model: "supergrok/grok-4.6", input: "hello" }),
+        }),
+    );
+    const text = await response.text();
+    expect(text).toContain("response.created");
+    expect(text).toContain("response.completed");
+  });
+
   test("closes a terminal SSE response even if the upstream socket stays open", async () => {
     const wrapped = xaiSubscriptionFetch(
       async () =>


### PR DESCRIPTION
## Summary
- keep the SuperGrok SSE response pump reading upstream chunks until it can enqueue at least one complete SSE block
- preserve the existing idle-timeout rule: partial bytes and malformed events do not reset liveness
- add a regression where a large `response.created` event spans four upstream chunks before its first `\n\n` delimiter

## Root cause
Grok 4.6 responses with the workspace's 9,919-byte standing-memory block produced a large first `response.created` event. In production evidence, the first SSE delimiter arrived at byte 14,879 across four network chunks. `xaiSubscriptionFetch` read one upstream chunk per downstream `pull()`. When that chunk contained no complete SSE block, it enqueued nothing and returned; under Bun the pending downstream read was not repumped, so the wrapper reported zero events and timed out even though the provider completed normally.

A tee of the live upstream stream proved the provider delivered 92 valid events and `response.completed` in 3.7 seconds while the current wrapper forwarded zero and timed out. Offline replay reproduced the split exactly: original 19-chunk delivery timed out, while identical bytes in one chunk emitted all 76 events.

## Verification
- pre-fix regression failed with `xai_response_stream_idle_timeout`, zero events
- post-fix named regression passed
- `bun test packages/xai-subscription/test` — 27 pass
- `bun test packages/runtime/test/model-providers.test.ts` — 67 pass
- `bun run --cwd packages/xai-subscription typecheck` — pass
- `bun run --cwd packages/xai-subscription build` — pass
- `bun x oxfmt --check packages/xai-subscription/src/fetch.ts packages/xai-subscription/test/transport.test.ts` — pass
- exact live 14.3 KB memory-bearing request through the temporary patched wrapper completed twice: 91 events / 3.4 s and 103 events / 18.7 s, both `response.completed`

Managed OpenGeni production was not touched. No deployed workload was restarted for diagnosis.
