### PR TITLE
Persist session dock navigation

### DIFF
--- a/apps/web/src/components/session/editable-artifacts-workspace.test.tsx
+++ b/apps/web/src/components/session/editable-artifacts-workspace.test.tsx
@@ -27,6 +27,55 @@ afterAll(() => {
 });
 
 describe("SessionEditableArtifactsWorkspace empty states", () => {
+  test("restores and reports the selected artifact", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const onSelectionChange = mock(() => undefined);
+    const firstId = "a".repeat(32);
+    const secondId = "b".repeat(32);
+    const route = createRootRoute({
+      component: () => (
+        <SessionEditableArtifactsWorkspace
+          workspaceId="11111111-1111-4111-8111-111111111111"
+          artifacts={[
+            { id: firstId, modality: "document", title: "Plan" },
+            { id: secondId, modality: "spreadsheet", title: "Budget" },
+          ]}
+          status="ready"
+          onRetry={() => undefined}
+          initialSelectedArtifactId={secondId}
+          onSelectedArtifactIdChange={onSelectionChange}
+        />
+      ),
+    });
+    const router = createRouter({
+      routeTree: route,
+      history: createMemoryHistory({ initialEntries: ["/"] }),
+    });
+
+    try {
+      await act(async () => {
+        await router.load();
+        root.render(<RouterProvider router={router} />);
+      });
+      const select = container.querySelector<HTMLSelectElement>(
+        'select[aria-label="Choose editable artifact"]',
+      );
+      expect(select?.value).toBe(secondId);
+
+      await act(async () => {
+        if (!select) return;
+        select.value = firstId;
+        select.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      expect(onSelectionChange).toHaveBeenCalledWith(firstId);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
   test("keeps the first-class artifact surface discoverable before one exists", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/apps/web/src/components/session/editable-artifacts-workspace.tsx
+++ b/apps/web/src/components/session/editable-artifacts-workspace.tsx
@@ -27,22 +27,29 @@ export function SessionEditableArtifactsWorkspace({
   artifacts,
   status,
   onRetry,
+  initialSelectedArtifactId,
+  onSelectedArtifactIdChange,
 }: Readonly<{
   workspaceId: string;
   artifacts: readonly SessionEditableArtifactSummary[];
   status: SessionEditableArtifactsStatus;
   onRetry: () => void;
+  initialSelectedArtifactId?: string | null;
+  onSelectedArtifactIdChange?: (artifactId: string | null) => void;
 }>) {
-  const [selectedArtifactId, setSelectedArtifactId] = useState(() => artifacts[0]?.id ?? null);
+  const [selectedArtifactId, setSelectedArtifactId] = useState(
+    () => initialSelectedArtifactId ?? artifacts[0]?.id ?? null,
+  );
 
   useEffect(() => {
-    setSelectedArtifactId((current) => {
-      if (current && artifacts.some((artifact) => artifact.id === current)) {
-        return current;
-      }
-      return artifacts[0]?.id ?? null;
-    });
-  }, [artifacts]);
+    if (status === "loading") return;
+    if (selectedArtifactId && artifacts.some((artifact) => artifact.id === selectedArtifactId)) {
+      return;
+    }
+    const next = artifacts[0]?.id ?? null;
+    setSelectedArtifactId(next);
+    onSelectedArtifactIdChange?.(next);
+  }, [artifacts, onSelectedArtifactIdChange, selectedArtifactId, status]);
 
   const artifact =
     artifacts.find((candidate) => candidate.id === selectedArtifactId) ?? artifacts[0];
@@ -96,7 +103,10 @@ export function SessionEditableArtifactsWorkspace({
               aria-label="Choose editable artifact"
               className="h-8 min-w-0 border-0 bg-transparent pl-1 font-medium shadow-none"
               value={artifact.id}
-              onChange={(event) => setSelectedArtifactId(event.target.value)}
+              onChange={(event) => {
+                setSelectedArtifactId(event.target.value);
+                onSelectedArtifactIdChange?.(event.target.value);
+              }}
             >
               {artifacts.map((candidate) => (
                 <option key={candidate.id} value={candidate.id}>

--- a/apps/web/src/components/session/sandbox-workspace.tsx
+++ b/apps/web/src/components/session/sandbox-workspace.tsx
@@ -7,11 +7,21 @@
 //   1. the sonner-backed notification sink (the package has no toast dependency);
 //   2. app-injected extra tabs (Run / Debug) passed as leading/trailing tabs.
 import { SandboxWorkspace, type WorkspaceNotification, type WorkspaceTab } from "@opengeni/react";
-import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { toast } from "sonner";
 import {
   readSessionDockCollapsed,
+  readSessionDockNavigation,
   sessionDockLayoutStorageId,
+  updateSessionDockNavigation,
   writeSessionDockCollapsed,
 } from "@/lib/session-dock-preferences";
 import type { SessionEvent } from "@/types";
@@ -48,6 +58,29 @@ export function SessionWorkspace(props: {
   mobileLeadingControl?: ReactNode;
 }) {
   const layoutStorageId = sessionDockLayoutStorageId(props.preferenceOwnerId, props.sessionId);
+  const navigation = useMemo(() => readSessionDockNavigation(layoutStorageId), [layoutStorageId]);
+  const initialTab = navigation.activeTab ?? props.initialTab;
+  const rememberNavigation = useCallback(
+    (patch: Parameters<typeof updateSessionDockNavigation>[1]) =>
+      updateSessionDockNavigation(layoutStorageId, patch),
+    [layoutStorageId],
+  );
+  const rememberActiveTab = useCallback(
+    (activeTab: string) => rememberNavigation({ activeTab }),
+    [rememberNavigation],
+  );
+  const rememberFilePath = useCallback(
+    (filePath: string | null) => rememberNavigation({ filePath }),
+    [rememberNavigation],
+  );
+  const rememberBrowserSession = useCallback(
+    (browserSessionId: string | null) => rememberNavigation({ browserSessionId }),
+    [rememberNavigation],
+  );
+  const rememberDesktopSession = useCallback(
+    (desktopSessionId: string | null) => rememberNavigation({ desktopSessionId }),
+    [rememberNavigation],
+  );
   const [restoredStorageId, setRestoredStorageId] = useState<string | null>(null);
   const collapsedRef = useRef(props.collapsed);
   const onCollapsedChangeRef = useRef(props.onCollapsedChange);
@@ -81,7 +114,14 @@ export function SessionWorkspace(props: {
       primary={props.primary}
       {...(props.leadingTabs ? { leadingTabs: props.leadingTabs } : {})}
       {...(props.trailingTabs ? { trailingTabs: props.trailingTabs } : {})}
-      {...(props.initialTab ? { initialTab: props.initialTab } : {})}
+      {...(initialTab ? { initialTab } : {})}
+      onActiveTabChange={rememberActiveTab}
+      initialFilePath={navigation.filePath}
+      onFilePathChange={rememberFilePath}
+      initialBrowserSessionId={navigation.browserSessionId}
+      onBrowserSessionIdChange={rememberBrowserSession}
+      initialComputerSessionId={navigation.desktopSessionId}
+      onComputerSessionIdChange={rememberDesktopSession}
       collapsed={effectiveCollapsed}
       onCollapsedChange={props.onCollapsedChange}
       {...(props.mobileLeadingControl ? { mobileLeadingControl: props.mobileLeadingControl } : {})}

--- a/apps/web/src/lib/session-dock-preferences.test.ts
+++ b/apps/web/src/lib/session-dock-preferences.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
   readSessionDockCollapsed,
+  readSessionDockNavigation,
   sessionDockLayoutStorageId,
+  updateSessionDockNavigation,
   writeSessionDockCollapsed,
 } from "./session-dock-preferences";
 
@@ -33,5 +35,42 @@ describe("session dock preferences", () => {
     expect(readSessionDockCollapsed(id, storage)).toBe(true);
     writeSessionDockCollapsed(id, false, storage);
     expect(readSessionDockCollapsed(id, storage)).toBe(false);
+  });
+
+  test("merges navigation choices and clears stale resources", () => {
+    const storage = memoryStorage();
+    const id = sessionDockLayoutStorageId("user:one", "session-a");
+
+    updateSessionDockNavigation(
+      id,
+      { activeTab: "browser", browserSessionId: "browser-a" },
+      storage,
+    );
+    updateSessionDockNavigation(
+      id,
+      { artifactId: "artifact-a", filePath: "src/index.ts" },
+      storage,
+    );
+    expect(readSessionDockNavigation(id, storage)).toEqual({
+      activeTab: "browser",
+      browserSessionId: "browser-a",
+      artifactId: "artifact-a",
+      filePath: "src/index.ts",
+    });
+
+    updateSessionDockNavigation(id, { browserSessionId: null }, storage);
+    expect(readSessionDockNavigation(id, storage).browserSessionId).toBeUndefined();
+    expect(readSessionDockNavigation(id, storage).artifactId).toBe("artifact-a");
+  });
+
+  test("ignores malformed navigation records", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+    const id = sessionDockLayoutStorageId("user:one", "session-a");
+    storage.setItem(`${id}:navigation`, "not-json");
+    expect(readSessionDockNavigation(id, storage)).toEqual({});
   });
 });

--- a/apps/web/src/lib/session-dock-preferences.ts
+++ b/apps/web/src/lib/session-dock-preferences.ts
@@ -2,6 +2,18 @@ const SESSION_DOCK_PREFERENCE_VERSION = 1;
 
 type DockPreferenceStorage = Pick<Storage, "getItem" | "setItem">;
 
+export type SessionDockNavigation = Readonly<{
+  activeTab?: string;
+  browserSessionId?: string;
+  desktopSessionId?: string;
+  artifactId?: string;
+  filePath?: string;
+}>;
+
+export type SessionDockNavigationPatch = Partial<
+  Record<keyof SessionDockNavigation, string | null>
+>;
+
 export function sessionDockLayoutStorageId(subjectId: string, sessionId: string): string {
   return [
     "og.session.dock",
@@ -39,8 +51,61 @@ export function writeSessionDockCollapsed(
   }
 }
 
+export function readSessionDockNavigation(
+  layoutStorageId: string,
+  storage: DockPreferenceStorage | null = browserStorage(),
+): SessionDockNavigation {
+  if (!storage) return {};
+  try {
+    const raw = storage.getItem(navigationStorageKey(layoutStorageId));
+    if (!raw) return {};
+    const value: unknown = JSON.parse(raw);
+    if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+    return Object.fromEntries(
+      navigationKeys.flatMap((key) => {
+        const candidate = (value as Record<string, unknown>)[key];
+        return typeof candidate === "string" && candidate.length > 0 ? [[key, candidate]] : [];
+      }),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function updateSessionDockNavigation(
+  layoutStorageId: string,
+  patch: SessionDockNavigationPatch,
+  storage: DockPreferenceStorage | null = browserStorage(),
+): void {
+  if (!storage) return;
+  try {
+    const next: Record<string, string> = { ...readSessionDockNavigation(layoutStorageId, storage) };
+    for (const key of navigationKeys) {
+      if (!(key in patch)) continue;
+      const value = patch[key];
+      if (typeof value === "string" && value.length > 0) next[key] = value;
+      else delete next[key];
+    }
+    storage.setItem(navigationStorageKey(layoutStorageId), JSON.stringify(next));
+  } catch {
+    // Navigation remains usable when persistence is blocked or quota is exhausted.
+  }
+}
+
+const navigationKeys = [
+  "activeTab",
+  "browserSessionId",
+  "desktopSessionId",
+  "artifactId",
+  "filePath",
+] as const satisfies readonly (keyof SessionDockNavigation)[];
+
 function collapsedStorageKey(layoutStorageId: string): string {
   return `${layoutStorageId}:collapsed`;
+}
+
+function navigationStorageKey(layoutStorageId: string): string {
+  return `${layoutStorageId}:navigation`;
 }
 
 function browserStorage(): Storage | null {

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -87,6 +87,11 @@ import { createWorkspaceRetainedArtifactLoader } from "@/lib/retained-artifact-l
 import { createSessionRetainedScreenshotLoader } from "@/lib/retained-screenshot-loader";
 import { createWorkspaceRetainedVideoLoader } from "@/lib/retained-video-loader";
 import {
+  readSessionDockNavigation,
+  sessionDockLayoutStorageId,
+  updateSessionDockNavigation,
+} from "@/lib/session-dock-preferences";
+import {
   clientFirstPartyMcpToolPolicy,
   firstPartySessionToolOptionsFor,
   isIntelligenceEffort,
@@ -619,6 +624,18 @@ function SessionDock(props: {
   onOpenNavigation: () => void;
 }) {
   const context = useAppContext();
+  const dockLayoutStorageId = sessionDockLayoutStorageId(
+    context.accessContext.subjectId,
+    props.sessionId,
+  );
+  const dockNavigation = useMemo(
+    () => readSessionDockNavigation(dockLayoutStorageId),
+    [dockLayoutStorageId],
+  );
+  const rememberArtifact = useCallback(
+    (artifactId: string | null) => updateSessionDockNavigation(dockLayoutStorageId, { artifactId }),
+    [dockLayoutStorageId],
+  );
   // The workbench (Changes | Files | Terminal | Desktop + machine chip) lives in
   // the package now; the app injects durable artifacts and Debug around it.
   // Heavy editor/runtime code stays lazy until the user opens the tab.
@@ -664,10 +681,13 @@ function SessionDock(props: {
       content: (
         <Suspense fallback={<LoadingPanel label="Opening artifact" />}>
           <LazySessionEditableArtifactsWorkspace
+            key={props.sessionId}
             workspaceId={props.workspaceId}
             artifacts={artifactSummaries}
             status={artifactState.status}
             onRetry={artifactState.retry}
+            initialSelectedArtifactId={dockNavigation.artifactId}
+            onSelectedArtifactIdChange={rememberArtifact}
           />
         </Suspense>
       ),

--- a/packages/react/src/components/browser-viewer.tsx
+++ b/packages/react/src/components/browser-viewer.tsx
@@ -97,6 +97,9 @@ export type BrowserViewerProps = EmbeddedBrowserInteractionClientOverride & {
     | undefined;
   /** Navigate to the exact linked ComputerSession; never a lookalike desktop. */
   onOpenComputer?: ((computerSessionId: string) => void) | undefined;
+  /** Restore and report the BrowserSession selected in this task's dock. */
+  initialBrowserSessionId?: string | null | undefined;
+  onBrowserSessionIdChange?: ((browserSessionId: string | null) => void) | undefined;
   /** Host-owned install/setup surface for attaching an existing Chrome profile.
    * The machine bridge remains discoverable even when this URL is omitted. */
   browserExtensionSetupUrl?: string | undefined;
@@ -141,6 +144,8 @@ export function BrowserViewer({
   renderEmpty,
   createLinkedComputer,
   onOpenComputer,
+  initialBrowserSessionId,
+  onBrowserSessionIdChange,
   browserExtensionSetupUrl,
   ...override
 }: BrowserViewerProps) {
@@ -165,7 +170,16 @@ export function BrowserViewer({
     () => registry.relevantSessions.filter((session) => isLiveBrowser(session)),
     [registry.relevantSessions],
   );
-  const [selection, setSelection] = useState<BrowserSelection>(null);
+  const [selection, setSelection] = useState<BrowserSelection>(() =>
+    initialBrowserSessionId ? { sessionId: initialBrowserSessionId, pinned: true } : null,
+  );
+  const selectBrowserSession = useCallback(
+    (next: BrowserSelection) => {
+      setSelection(next);
+      onBrowserSessionIdChange?.(next?.sessionId ?? null);
+    },
+    [onBrowserSessionIdChange],
+  );
   const interventions = useInteractionInterventions({
     ...override,
     enabled,
@@ -200,11 +214,14 @@ export function BrowserViewer({
   useEffect(() => {
     if (previousSessionIdRef.current !== sessionId) {
       previousSessionIdRef.current = sessionId;
-      setSelection(null);
+      setSelection(
+        initialBrowserSessionId ? { sessionId: initialBrowserSessionId, pinned: true } : null,
+      );
     }
-  }, [sessionId]);
+  }, [initialBrowserSessionId, sessionId]);
 
   useEffect(() => {
+    if (!enabled || registry.loading) return;
     const selectedStillLive = liveSessions.some((session) => session.id === selection?.sessionId);
     // A manually selected workspace browser stays selected, but an unrelated
     // browser must never become the implicit browser for this agent. That made
@@ -212,15 +229,15 @@ export function BrowserViewer({
     if (selection?.pinned && selectedStillLive) return;
     const preferred = relevant[0] ?? null;
     if (!preferred) {
-      if (selection) setSelection(null);
+      if (selection) selectBrowserSession(null);
       return;
     }
     if (!selectedStillLive || !selection?.pinned) {
       if (selection?.sessionId !== preferred.id || selection.pinned) {
-        setSelection({ sessionId: preferred.id, pinned: false });
+        selectBrowserSession({ sessionId: preferred.id, pinned: false });
       }
     }
-  }, [liveSessions, relevant, selection]);
+  }, [enabled, liveSessions, registry.loading, relevant, selectBrowserSession, selection]);
 
   const selectedRegistrySession = useMemo(
     () => liveSessions.find((session) => session.id === selection?.sessionId) ?? null,
@@ -551,7 +568,7 @@ export function BrowserViewer({
               }
             : {}),
         });
-        setSelection({ sessionId: response.session.id, pinned: true });
+        selectBrowserSession({ sessionId: response.session.id, pinned: true });
         if (computerViewUnavailable) {
           onNotify?.({
             kind: "info",
@@ -568,6 +585,7 @@ export function BrowserViewer({
       creating,
       notifyError,
       onNotify,
+      selectBrowserSession,
       profiles.identities,
       sessionId,
     ],
@@ -733,10 +751,12 @@ export function BrowserViewer({
         savingProfile={savingProfile}
         refreshing={registry.refreshing || attached.refreshing}
         interventionCounts={interventionCounts}
-        onSelect={(browserSessionId) => setSelection({ sessionId: browserSessionId, pinned: true })}
+        onSelect={(browserSessionId) =>
+          selectBrowserSession({ sessionId: browserSessionId, pinned: true })
+        }
         onFollow={() => {
           const preferred = relevant[0];
-          if (preferred) setSelection({ sessionId: preferred.id, pinned: false });
+          if (preferred) selectBrowserSession({ sessionId: preferred.id, pinned: false });
         }}
         onCreate={createBrowser}
         onSaveProfile={saveProfileVersion}

--- a/packages/react/src/components/computer-viewer.tsx
+++ b/packages/react/src/components/computer-viewer.tsx
@@ -63,6 +63,9 @@ export type ComputerViewerProps = EmbeddedComputerInteractionClientOverride & {
   /** Host navigation request for one exact ComputerSession. */
   requestedComputerSessionId?: string | null | undefined;
   requestedComputerRequestId?: string | number | null | undefined;
+  /** Restore and report the Desktop session selected in this task's dock. */
+  initialComputerSessionId?: string | null | undefined;
+  onComputerSessionIdChange?: ((computerSessionId: string | null) => void) | undefined;
 };
 
 type ComputerSelection = { sessionId: string; pinned: boolean } | null;
@@ -79,6 +82,8 @@ export function ComputerViewer({
   renderEmpty,
   requestedComputerSessionId,
   requestedComputerRequestId,
+  initialComputerSessionId,
+  onComputerSessionIdChange,
   ...override
 }: ComputerViewerProps) {
   const registry = useComputerSessions({ ...override, sessionId, enabled });
@@ -106,7 +111,16 @@ export function ComputerViewer({
       liveRelevant.length > 0 ? liveRelevant : recentRelevantFailure ? [recentRelevantFailure] : [],
     [liveRelevant, recentRelevantFailure],
   );
-  const [selection, setSelection] = useState<ComputerSelection>(null);
+  const [selection, setSelection] = useState<ComputerSelection>(() =>
+    initialComputerSessionId ? { sessionId: initialComputerSessionId, pinned: true } : null,
+  );
+  const selectComputerSession = useCallback(
+    (next: ComputerSelection) => {
+      setSelection(next);
+      onComputerSessionIdChange?.(next?.sessionId ?? null);
+    },
+    [onComputerSessionIdChange],
+  );
   const interventions = useInteractionInterventions({
     ...override,
     enabled,
@@ -139,10 +153,13 @@ export function ComputerViewer({
     autoCreateSessionRef.current = null;
     emptyCatalogConfirmationRef.current = null;
     setCreateError(null);
-    setSelection(null);
-  }, [sessionId]);
+    setSelection(
+      initialComputerSessionId ? { sessionId: initialComputerSessionId, pinned: true } : null,
+    );
+  }, [initialComputerSessionId, sessionId]);
 
   useEffect(() => {
+    if (!enabled || registry.loading) return;
     const requested = requestedComputerSessionId
       ? (liveSessions.find((session) => session.id === requestedComputerSessionId) ?? null)
       : null;
@@ -151,7 +168,7 @@ export function ComputerViewer({
       : null;
     if (requested && requestKey && handledRequestRef.current !== requestKey) {
       handledRequestRef.current = requestKey;
-      setSelection({ sessionId: requested.id, pinned: true });
+      selectComputerSession({ sessionId: requested.id, pinned: true });
       return;
     }
 
@@ -162,15 +179,24 @@ export function ComputerViewer({
     if (selection?.pinned && selectedStillLive) return;
     const preferred = relevant[0] ?? null;
     if (!preferred) {
-      if (selection) setSelection(null);
+      if (selection) selectComputerSession(null);
       return;
     }
     if (!selectedStillLive || !selection?.pinned) {
       if (selection?.sessionId !== preferred.id || selection.pinned) {
-        setSelection({ sessionId: preferred.id, pinned: false });
+        selectComputerSession({ sessionId: preferred.id, pinned: false });
       }
     }
-  }, [liveSessions, relevant, requestedComputerRequestId, requestedComputerSessionId, selection]);
+  }, [
+    liveSessions,
+    enabled,
+    registry.loading,
+    relevant,
+    requestedComputerRequestId,
+    requestedComputerSessionId,
+    selectComputerSession,
+    selection,
+  ]);
 
   const selectedRegistrySession = useMemo(
     () => liveSessions.find((session) => session.id === selection?.sessionId) ?? null,
@@ -282,7 +308,7 @@ export function ComputerViewer({
     setCreating(true);
     void createSession({ sessionId, name: "Desktop" })
       .then((response) => {
-        setSelection({ sessionId: response.session.id, pinned: false });
+        selectComputerSession({ sessionId: response.session.id, pinned: false });
       })
       .catch((cause) => {
         const error = cause instanceof Error ? cause : new Error("Could not open a desktop.");
@@ -293,7 +319,7 @@ export function ComputerViewer({
         createInFlightRef.current = false;
         setCreating(false);
       });
-  }, [createSession, notifyError, sessionId]);
+  }, [createSession, notifyError, selectComputerSession, sessionId]);
 
   useEffect(() => {
     // Once this task's Desktop has been observed, a later transient empty
@@ -449,10 +475,10 @@ export function ComputerViewer({
         refreshing={registry.refreshing}
         interventionCounts={interventionCounts}
         onSelect={(computerSessionId) =>
-          setSelection({ sessionId: computerSessionId, pinned: true })
+          selectComputerSession({ sessionId: computerSessionId, pinned: true })
         }
         onFollow={() => {
-          if (relevant[0]) setSelection({ sessionId: relevant[0].id, pinned: false });
+          if (relevant[0]) selectComputerSession({ sessionId: relevant[0].id, pinned: false });
         }}
         onCreate={createComputer}
         onRefresh={() => void Promise.all([refreshRegistry(), refreshComputer()])}

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -32,6 +32,10 @@ export type SandboxFilesProps = {
    *  dock warms the box on this so the save lands fast; opening/reading never fires
    *  it. Browsing the tree/diff must not warm a box. */
   onEditIntent?: (() => void) | undefined;
+  /** Restore the file last viewed in this task. Invalid/missing paths still
+   * surface the ordinary file-view error instead of changing files silently. */
+  initialSelectedPath?: string | null | undefined;
+  onSelectedPathChange?: ((path: string | null) => void) | undefined;
   /** A guarded diff path routed here by the parent workspace. */
   requestedPath?: string | undefined;
   /** Identity for one guarded-file request. Increment this when the same path is
@@ -67,6 +71,8 @@ export function SandboxFiles({
   usePierre = true,
   editable = true,
   onEditIntent,
+  initialSelectedPath,
+  onSelectedPathChange,
   requestedPath,
   requestedPathRequestId,
   requestedPathReady = true,
@@ -77,7 +83,7 @@ export function SandboxFiles({
   themeType,
   className,
 }: SandboxFilesProps) {
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(() => initialSelectedPath ?? null);
   // View vs Edit for the selected file. Resets to View on every new selection so
   // opening a file never lands you in a stale dirty editor for a different path.
   const [editMode, setEditMode] = useState(false);
@@ -103,8 +109,9 @@ export function SandboxFiles({
     handledRequestRef.current = requestKey;
     pendingRequestRef.current = null;
     setSelected(requestedPath);
+    onSelectedPathChange?.(requestedPath);
     setEditMode(false);
-  }, [requestKey, requestedPath, requestedPathReady]);
+  }, [onSelectedPathChange, requestKey, requestedPath, requestedPathReady]);
 
   // Side-by-side (tree left, viewer right) once the surface is wide enough;
   // stacked (tree over viewer) on a narrow dock. Tracked off the container so it
@@ -154,16 +161,20 @@ export function SandboxFiles({
   // an editor whose buffer belongs to the previously-selected path. Manual
   // navigation also consumes a pending guarded-file request: a late cold→warm
   // transition must never pull the user away from the file they chose meanwhile.
-  const selectFile = useCallback((path: string) => {
-    if (pendingRequestRef.current !== null) {
-      handledRequestRef.current = pendingRequestRef.current;
-      pendingRequestRef.current = null;
-    }
-    setSelected(path);
-    setEditMode(false);
-    setLiveRequestedPath(null);
-    setViewReloadRevision(0);
-  }, []);
+  const selectFile = useCallback(
+    (path: string) => {
+      if (pendingRequestRef.current !== null) {
+        handledRequestRef.current = pendingRequestRef.current;
+        pendingRequestRef.current = null;
+      }
+      setSelected(path);
+      onSelectedPathChange?.(path);
+      setEditMode(false);
+      setLiveRequestedPath(null);
+      setViewReloadRevision(0);
+    },
+    [onSelectedPathChange],
+  );
 
   // A tree file is editable only when it is a real, fully-loaded text file: not
   // binary (would corrupt on save) and not truncated (we only hold a PREFIX). The

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -307,6 +307,13 @@ export type UseSandboxWorkspaceTabsOptions = ClientOverride & {
   requestedFileRequestId?: string | number | null | undefined;
   /** Route a guarded diff into the host's Files tab. */
   onOpenFile?: ((path: string) => void) | undefined;
+  /** Restore and report navigation inside the built-in workbench surfaces. */
+  initialFilePath?: string | null | undefined;
+  onFilePathChange?: ((path: string | null) => void) | undefined;
+  initialBrowserSessionId?: string | null | undefined;
+  onBrowserSessionIdChange?: ((browserSessionId: string | null) => void) | undefined;
+  initialComputerSessionId?: string | null | undefined;
+  onComputerSessionIdChange?: ((computerSessionId: string | null) => void) | undefined;
   /** Navigate the host dock to one exact linked ComputerSession. */
   onOpenComputerSession?: ((computerSessionId: string) => void) | undefined;
   requestedComputerSessionId?: string | null | undefined;
@@ -360,6 +367,12 @@ export function useSandboxWorkspaceTabs(
     requestedFilePath,
     requestedFileRequestId,
     onOpenFile,
+    initialFilePath,
+    onFilePathChange,
+    initialBrowserSessionId,
+    onBrowserSessionIdChange,
+    initialComputerSessionId,
+    onComputerSessionIdChange,
     onOpenComputerSession,
     requestedComputerSessionId,
     requestedComputerRequestId,
@@ -763,6 +776,8 @@ export function useSandboxWorkspaceTabs(
             // Ordinary capture browsing does not warm a box. The first edit — or an
             // explicit guarded-file open from Changes — is deliberate live-file intent.
             onEditIntent={() => requestWarmIntent("warmFiles")}
+            initialSelectedPath={initialFilePath}
+            onSelectedPathChange={onFilePathChange}
             className="h-full"
           />
         ),
@@ -815,6 +830,8 @@ export function useSandboxWorkspaceTabs(
               // user/agent first visits it.
               enabled={workspaceVisible}
               onNotify={onNotify}
+              initialBrowserSessionId={initialBrowserSessionId}
+              onBrowserSessionIdChange={onBrowserSessionIdChange}
               {...(desktopEnabled ? { createLinkedComputer } : {})}
               {...(onOpenComputerSession ? { onOpenComputer: onOpenComputerSession } : {})}
               {...(browserWebSocketFactory ? { webSocketFactory: browserWebSocketFactory } : {})}
@@ -845,6 +862,8 @@ export function useSandboxWorkspaceTabs(
               // second and later Computer opens local-machine fast.
               enabled={workspaceVisible}
               onNotify={onNotify}
+              initialComputerSessionId={initialComputerSessionId}
+              onComputerSessionIdChange={onComputerSessionIdChange}
               requestedComputerSessionId={requestedComputerSessionId}
               requestedComputerRequestId={requestedComputerRequestId}
               {...(computerWebSocketFactory ? { webSocketFactory: computerWebSocketFactory } : {})}
@@ -870,6 +889,12 @@ export function useSandboxWorkspaceTabs(
     requestedFilePath,
     requestedFileRequestId,
     onOpenFile,
+    initialFilePath,
+    onFilePathChange,
+    initialBrowserSessionId,
+    onBrowserSessionIdChange,
+    initialComputerSessionId,
+    onComputerSessionIdChange,
     onOpenComputerSession,
     requestedComputerSessionId,
     requestedComputerRequestId,
@@ -928,6 +953,13 @@ export type SandboxWorkspaceProps = ClientOverride & {
   /** Override the pre-paint default tab (e.g. a host landing tab id). When
    *  omitted the workbench decides from the durable workspace capture. */
   initialTab?: string | undefined;
+  onActiveTabChange?: ((activeTab: string) => void) | undefined;
+  initialFilePath?: string | null | undefined;
+  onFilePathChange?: ((path: string | null) => void) | undefined;
+  initialBrowserSessionId?: string | null | undefined;
+  onBrowserSessionIdChange?: ((browserSessionId: string | null) => void) | undefined;
+  initialComputerSessionId?: string | null | undefined;
+  onComputerSessionIdChange?: ((computerSessionId: string | null) => void) | undefined;
   /** Host-routed notifications (no toast dependency in the package). */
   onNotify?: ((notification: WorkspaceNotification) => void) | undefined;
   /** Alternate Browser frame transport for non-browser runtimes and deterministic tests. */
@@ -966,6 +998,13 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
     leadingTabs,
     trailingTabs,
     initialTab,
+    onActiveTabChange,
+    initialFilePath,
+    onFilePathChange,
+    initialBrowserSessionId,
+    onBrowserSessionIdChange,
+    initialComputerSessionId,
+    onComputerSessionIdChange,
     onNotify,
     browserWebSocketFactory,
     computerWebSocketFactory,
@@ -1004,8 +1043,10 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
       nextFileRequestId.current += 1;
       setRequestedFile({ sessionId, path, requestId: nextFileRequestId.current });
       setStoredSelection({ sessionId, tab: WORKBENCH_TAB_FILES });
+      onActiveTabChange?.(WORKBENCH_TAB_FILES);
+      onFilePathChange?.(path);
     },
-    [sessionId],
+    [onActiveTabChange, onFilePathChange, sessionId],
   );
   const openComputer = useCallback(
     (computerSessionId: string) => {
@@ -1016,8 +1057,10 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
         requestId: nextComputerRequestId.current,
       });
       setStoredSelection({ sessionId, tab: WORKBENCH_TAB_DESKTOP });
+      onActiveTabChange?.(WORKBENCH_TAB_DESKTOP);
+      onComputerSessionIdChange?.(computerSessionId);
     },
-    [sessionId],
+    [onActiveTabChange, onComputerSessionIdChange, sessionId],
   );
 
   const {
@@ -1037,6 +1080,12 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
     ...(browserWebSocketFactory ? { browserWebSocketFactory } : {}),
     ...(computerWebSocketFactory ? { computerWebSocketFactory } : {}),
     ...(browserExtensionSetupUrl ? { browserExtensionSetupUrl } : {}),
+    initialFilePath,
+    onFilePathChange,
+    initialBrowserSessionId,
+    onBrowserSessionIdChange,
+    initialComputerSessionId,
+    onComputerSessionIdChange,
     requestedFilePath: requestedFile?.sessionId === sessionId ? requestedFile.path : null,
     requestedFileRequestId: requestedFile?.sessionId === sessionId ? requestedFile.requestId : null,
     onOpenFile: openFile,
@@ -1057,8 +1106,11 @@ export function SandboxWorkspace(props: SandboxWorkspaceProps): ReactNode {
   const activeTab =
     preferredTab && tabs.some((tab) => tab.id === preferredTab) ? preferredTab : tabs[0]?.id;
   const selectTab = useCallback(
-    (tab: string) => setStoredSelection({ sessionId, tab }),
-    [sessionId],
+    (tab: string) => {
+      setStoredSelection({ sessionId, tab });
+      onActiveTabChange?.(tab);
+    },
+    [onActiveTabChange, sessionId],
   );
   useEffect(() => {
     if (selectedTab !== null || defaultTab === null) return;

--- a/packages/react/src/hooks/use-browser-sessions.ts
+++ b/packages/react/src/hooks/use-browser-sessions.ts
@@ -60,6 +60,7 @@ export function useBrowserSessions(
   const enabled = options.enabled ?? true;
   const [state, setState] = useState<{
     workspaceId: string;
+    active: boolean;
     revision: number;
     sessions: BrowserSession[];
     loading: boolean;
@@ -89,6 +90,7 @@ export function useBrowserSessions(
       requestRef.current = { id, controller };
       setState((current) => ({
         ...(current.workspaceId === workspaceId ? current : emptyState(workspaceId, true)),
+        active: true,
         loading: foreground,
         refreshing: !foreground,
         error: foreground || current.workspaceId !== workspaceId ? null : current.error,
@@ -100,6 +102,7 @@ export function useBrowserSessions(
         if (!mountedRef.current || requestRef.current.id !== id) return;
         setState({
           workspaceId,
+          active: true,
           revision: response.revision,
           sessions: sortBrowserSessions(response.sessions),
           loading: false,
@@ -229,7 +232,9 @@ export function useBrowserSessions(
     revision: visibleState.revision,
     sessions: visibleState.sessions,
     relevantSessions,
-    loading: visibleState.loading,
+    // A disabled registry is deliberately empty. Expose the first re-enabled
+    // render as loading so consumers do not reconcile against that empty gap.
+    loading: enabled ? !visibleState.active || visibleState.loading : false,
     refreshing: visibleState.refreshing,
     error: visibleState.error,
     refresh,
@@ -243,6 +248,7 @@ export function useBrowserSessions(
 function emptyState(workspaceId: string, loading: boolean) {
   return {
     workspaceId,
+    active: false,
     revision: 0,
     sessions: [] as BrowserSession[],
     loading,

--- a/packages/react/test/browser-interaction.test.tsx
+++ b/packages/react/test/browser-interaction.test.tsx
@@ -1022,6 +1022,43 @@ describe("BrowserSession frame stream", () => {
 });
 
 describe("BrowserViewer", () => {
+  test("restores the task's last selected BrowserSession", async () => {
+    const current = browserSession();
+    const peer = browserSession(PEER_BROWSER_SESSION_ID, PEER_SESSION_ID, "Peer browser");
+    const client = fakeClient({
+      listBrowserSessions: async () => ({ revision: 1, sessions: [current, peer] }),
+      getBrowserSession: async (_workspaceId, browserSessionId) =>
+        browserSessionId === peer.id ? peer : current,
+      listBrowserTargets: async (_workspaceId, browserSessionId) => ({
+        browserSessionId,
+        controllerGeneration: "controller-1",
+        targets: [],
+      }),
+    });
+    const changes: Array<string | null> = [];
+    const viewer = (enabled: boolean) => (
+      <BrowserViewer
+        client={client}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        enabled={enabled}
+        initialBrowserSessionId={peer.id}
+        onBrowserSessionIdChange={(browserSessionId) => changes.push(browserSessionId)}
+      />
+    );
+    const rendered = await renderComponent(viewer(true));
+    await flush(40);
+
+    expect(rendered.container.querySelector("summary")?.textContent).toContain("Peer browser");
+    await rendered.rerender(viewer(false));
+    await flush(10);
+    await rendered.rerender(viewer(true));
+    await flush(40);
+    expect(rendered.container.querySelector("summary")?.textContent).toContain("Peer browser");
+    expect(changes).toEqual([]);
+    await rendered.unmount();
+  });
+
   test("ignores standalone modifier keydowns before a browser shortcut", () => {
     const event = (key: string, overrides: Partial<Parameters<typeof browserKey>[0]> = {}) => ({
       altKey: false,

--- a/packages/react/test/computer-interaction.test.tsx
+++ b/packages/react/test/computer-interaction.test.tsx
@@ -593,6 +593,43 @@ describe("ComputerSession frame stream", () => {
 });
 
 describe("ComputerViewer", () => {
+  test("restores the task's last selected Desktop session", async () => {
+    const current = computerSession();
+    const peer = computerSession(PEER_COMPUTER_SESSION_ID, PEER_SESSION_ID, "Peer Mac");
+    const client = fakeClient({
+      listComputerSessions: async () => ({ revision: 1, sessions: [current, peer] }),
+      getComputerSession: async (_workspaceId, computerSessionId) =>
+        computerSessionId === peer.id ? peer : current,
+      listComputerTargets: async (_workspaceId, computerSessionId) => ({
+        computerSessionId,
+        controllerGeneration: "controller-1",
+        targets: [],
+      }),
+    });
+    const changes: Array<string | null> = [];
+    const viewer = (enabled: boolean) => (
+      <ComputerViewer
+        client={client}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        enabled={enabled}
+        initialComputerSessionId={peer.id}
+        onComputerSessionIdChange={(computerSessionId) => changes.push(computerSessionId)}
+      />
+    );
+    const rendered = await renderComponent(viewer(true));
+    await flush(40);
+
+    expect(rendered.container.querySelector("summary")?.textContent).toContain("Peer Mac");
+    await rendered.rerender(viewer(false));
+    await flush(10);
+    await rendered.rerender(viewer(true));
+    await flush(40);
+    expect(rendered.container.querySelector("summary")?.textContent).toContain("Peer Mac");
+    expect(changes).toEqual([]);
+    await rendered.unmount();
+  });
+
   test("reuses the task desktop when a hidden surface is enabled", async () => {
     let createCalls = 0;
     const current = computerSession();

--- a/packages/react/test/sandbox-components.test.tsx
+++ b/packages/react/test/sandbox-components.test.tsx
@@ -190,6 +190,24 @@ describe("FileBrowser", () => {
 });
 
 describe("SandboxFiles guarded-file routing", () => {
+  test("restores and reports the selected file", async () => {
+    const selected: Array<string | null> = [];
+    const r = await renderComponent(
+      <SandboxFiles
+        files={filesResult()}
+        git={gitResult()}
+        initialSelectedPath="src/app.ts"
+        onSelectedPathChange={(path) => selected.push(path)}
+      />,
+    );
+    await flush();
+    expect(selectedFile(r.container)).toContain("src/app.ts");
+
+    await actRun(() => fileButton(r.container, "README.md").click());
+    expect(selected).toEqual(["README.md"]);
+    await r.unmount();
+  });
+
   test("capture-only untouched files expose an explicit live-open action", async () => {
     let wakeCalls = 0;
     const files = filesResult({

--- a/packages/react/test/workbench-prewarm.test.tsx
+++ b/packages/react/test/workbench-prewarm.test.tsx
@@ -1333,6 +1333,37 @@ describe("SandboxWorkspace capture-driven default renders with no content switch
     await rendered.unmount();
   });
 
+  test("restores a host-selected tab and reports later navigation", async () => {
+    const selected: string[] = [];
+    const { client } = coldClient({
+      getWorkspaceCapture: async () => captureAvailable(fakeManifest(2)),
+    });
+    const rendered = await renderComponent(
+      withProvider(
+        client,
+        <SandboxWorkspace
+          sessionId={SESSION_ID}
+          events={[]}
+          primary={<div>chat</div>}
+          initialTab="files"
+          onActiveTabChange={(tab) => selected.push(tab)}
+          autoSaveId="og.test.prewarm.restored-tab"
+        />,
+      ),
+    );
+    await flush();
+    expect(selectedTabText(rendered.container)).toContain("Files");
+
+    const changesTab = [...rendered.container.querySelectorAll<HTMLElement>('[role="tab"]')].find(
+      (element) => element.textContent?.includes("Changes"),
+    );
+    await act(async () => {
+      changesTab?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(selected).toEqual(["changes"]);
+    await rendered.unmount();
+  });
+
   test("warm provider failure keeps captured Changes visible with an accessible retry state", async () => {
     const { client } = coldClient({
       getStreamCapabilities: async () => fakeCapabilities(),


### PR DESCRIPTION
## Summary
- remember the selected dock tab per user and task
- restore the selected browser, desktop, artifact, and file
- preserve restored browser/desktop selections across dock hide/show and registry loading

## Verification
- focused React/web tests
- full typecheck, lint, format check
- local browser reload verification on localhost:3200
- full unit suite running