### PR TITLE
fix(goals): allow replacing completed goals

### DIFF
--- a/.changeset/fresh-goals-restart.md
+++ b/.changeset/fresh-goals-restart.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/api-router": patch
+"@opengeni/db": patch
+"@opengeni/runtime": patch
+---
+
+Allow agent `goal_set` to replace completed goals while continuing to protect
+active and paused goal intent.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -2334,7 +2334,7 @@ function registerGoalTools(
     "goal_set",
     {
       description:
-        "Create a goal when this session has none. While active, idle moments synthesize continuation turns until goal_complete or goal_pause. To change an existing goal, use goal_update with its objective revision, a change kind, and rationale.",
+        "Create a goal when this session has none, or replace a completed goal with a new one. While active, idle moments synthesize continuation turns until goal_complete or goal_pause. To change an active or paused goal, use goal_update with its objective revision, a change kind, and rationale.",
       inputSchema: {
         text: goalText,
         successCriteria: successCriteriaSchema.optional(),
@@ -2345,9 +2345,9 @@ function registerGoalTools(
       await authorizeFirstPartySession(deps, grant, sessionId, "session.goal.write");
       await requireSession(deps.db, grant.workspaceId, sessionId);
       const existing = await getSessionGoal(deps.db, grant.workspaceId, sessionId);
-      if (existing) {
+      if (existing && existing.status !== "completed") {
         throw new Error(
-          `this session already has a goal at objective revision ${existing.objectiveRevision}; use goal_update to revise it`,
+          `this session's goal is ${existing.status} at objective revision ${existing.objectiveRevision}; use goal_update to revise it`,
         );
       }
       const callerTurnId =

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -35,8 +35,9 @@ A goal is `active`, `paused`, or `completed`.
   `ScheduledTaskAgentConfig.goal` create it. Setting a goal on a session that
   already has one remains a supported low-level/API/scheduler redirect: it
   re-activates the goal, resets continuation counters, and arms a wake. The
-  agent-facing `goal_set` creates only; an existing goal is changed through the
-  policy-fenced `goal_update`, so an incidental set cannot silently redirect it.
+  agent-facing `goal_set` creates when no goal exists or replaces a completed
+  goal. Active and paused goals are changed through the policy-fenced
+  `goal_update`, so an incidental set cannot silently redirect live intent.
 - `goal_update` declares `refinement`, `adaptation`, or `replacement`, a
   rationale, and the expected objective revision. `review_changes` always
   records an immutable proposal; `preserve_intent` directly applies only a

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -45773,6 +45773,7 @@ export async function upsertSessionGoalWithEvent(
           const [existing] = await tx
             .select({
               objectiveRevision: schema.sessionGoals.objectiveRevision,
+              status: schema.sessionGoals.status,
             })
             .from(schema.sessionGoals)
             .where(
@@ -45783,9 +45784,9 @@ export async function upsertSessionGoalWithEvent(
             )
             .for("update")
             .limit(1);
-          if (existing) {
+          if (existing && existing.status !== "completed") {
             throw new SessionControlConflictError(
-              `agent goal_set is create-only; goal exists at objective revision ${existing.objectiveRevision}`,
+              `agent goal_set cannot replace a goal while it is ${existing.status} at objective revision ${existing.objectiveRevision}; use goal_update to revise it`,
             );
           }
         }

--- a/packages/db/test/durable-goal-wake.test.ts
+++ b/packages/db/test/durable-goal-wake.test.ts
@@ -232,7 +232,7 @@ async function counts(ctx: GoalFixture) {
 }
 
 describe("durable active-goal wake", () => {
-  test("the locked agent goal_set path is create-only while API redirect remains available", async () => {
+  test("agent goal_set rejects live goals and replaces completed goals", async () => {
     const ctx = await runningGoalFixture();
     await expect(
       upsertSessionGoalWithEvent(client.db, {
@@ -243,11 +243,33 @@ describe("durable active-goal wake", () => {
         createdBy: "agent",
         actor: "agent",
       }),
-    ).rejects.toThrow("agent goal_set is create-only");
+    ).rejects.toThrow("agent goal_set cannot replace a goal while it is active");
     expect(
       (await getSessionGoalWithContinuation(client.db, ctx.grant.workspaceId!, ctx.session.id))
         ?.text,
     ).toBe("Finish the durable wake proof");
+
+    await setSessionGoalStatusWithEvent(client.db, ctx.grant.workspaceId!, ctx.session.id, {
+      status: "completed",
+      evidence: "The original objective is done",
+      event: { type: "goal.completed", evidence: "The original objective is done" },
+    });
+    const replacement = await upsertSessionGoalWithEvent(client.db, {
+      accountId: ctx.grant.accountId,
+      workspaceId: ctx.grant.workspaceId!,
+      sessionId: ctx.session.id,
+      text: "Pursue the next durable objective",
+      createdBy: "agent",
+      actor: "agent",
+    });
+    expect(replacement.replaced).toBe(true);
+    expect(replacement.goal).toMatchObject({
+      status: "active",
+      text: "Pursue the next durable objective",
+      evidence: null,
+      objectiveRevision: 2,
+    });
+    expect(replacement.events.map((event) => event.type)).toEqual(["goal.set"]);
   });
 
   test("accepted turns freeze exact goal or no-goal authority and recovery reuses it", async () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1737,6 +1737,9 @@ export function appendSessionInstructions(composed: string, sessionInstructions?
  */
 export function appendSessionGoal(composed: string, snapshot?: SessionGoalSnapshot): string {
   if (!snapshot || snapshot.state === "none") return composed;
+  if (snapshot.state === "completed") {
+    return `${composed} Previous session goal (frozen at logical-turn acceptance; objective revision ${snapshot.objectiveRevision}; status completed): ${snapshot.text}\nSuccess criteria: ${snapshot.successCriteria ?? "none specified"}. This goal is complete and remains as historical context. If the user provides a new long-running objective, create it with opengeni__goal_set; goal_update cannot revise a completed goal.`;
+  }
   const policy =
     snapshot.mutationPolicy === "review_changes"
       ? "Semantic changes are proposals until a user applies them."

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -3291,6 +3291,19 @@ describe("runtime event normalization", () => {
     expect(instructions).toContain("Ship the durable goal boundary");
     expect(instructions).toContain("Semantic changes are proposals until a user applies them");
     expect(instructions).toContain("opengeni__goal_progress");
+
+    const completedInstructions = appendSessionGoal("base", {
+      state: "completed",
+      goalId: "11111111-1111-4111-8111-111111111111",
+      objectiveRevision: 8,
+      text: "Ship the durable goal boundary",
+      successCriteria: "Recovery sees revision seven",
+      mutationPolicy: "review_changes",
+      capturedAt,
+    });
+    expect(completedInstructions).toContain("remains as historical context");
+    expect(completedInstructions).toContain("create it with opengeni__goal_set");
+    expect(completedInstructions).toContain("goal_update cannot revise a completed goal");
   });
 
   // ── generic programmatic-tool-calling (codemode) substrate directive ──────

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -985,6 +985,16 @@ describe("API component integration", () => {
         idempotencyKey: crypto.randomUUID(),
       }),
     ).rejects.toThrow("completed");
+    const replacementGoal = await callMcpTool<McpMutationReceiptType>(mcp, "goal_set", {
+      text: "ship the next main pipeline improvement",
+      successCriteria: "the next improvement is verified on main",
+    });
+    expect(replacementGoal).toMatchObject({
+      outcome: "updated",
+      changed: true,
+      resource: { state: "active" },
+      facts: { replaced: true },
+    });
 
     const events = await listSessionEvents(dbClient.db, baseGrant.workspaceId, session.id);
     expect(
@@ -996,10 +1006,13 @@ describe("API component integration", () => {
       "goal.paused",
       "goal.updated",
       "goal.completed",
+      "goal.set",
     ]);
-    expect((await getSessionGoal(dbClient.db, baseGrant.workspaceId, session.id))?.status).toBe(
-      "completed",
-    );
+    expect(await getSessionGoal(dbClient.db, baseGrant.workspaceId, session.id)).toMatchObject({
+      status: "active",
+      text: "ship the next main pipeline improvement",
+      evidence: null,
+    });
   });
 
   test("managed email/password auth bootstraps account access and workspace API keys", async () => {


### PR DESCRIPTION
## Summary
- allow goal_set to replace completed goals while protecting active and paused goals
- align completed-goal model guidance and lifecycle docs
- add DB, runtime, and MCP regression coverage

## Verification
- bun run typecheck
- bun run format:check
- bun run check:docs-refs
- focused durable-goal DB test
- focused runtime instruction test
- focused MCP integration test