### PR TITLE
chore(release): version web budget repair

### DIFF
--- a/.changeset/steady-release-bundles.md
+++ b/.changeset/steady-release-bundles.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Keep versioned direct-session web builds within the measured release bundle contract.


### PR DESCRIPTION
## Summary

- add the publishable Changesets record for the repaired versioned web bundle contract
- bump `@opengeni/react` (and its dependent example) through the normal Version PR
- make repair source `0f424185` the retained controller for the final release train

## Verification

- `git diff --check`
- `bunx changeset status`

This is the release metadata companion to #1501.