### PR TITLE
chore(release): bump product version to 0.23.7

### DIFF
--- a/.changeset/fresh-products-mail.md
+++ b/.changeset/fresh-products-mail.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/capabilities": patch
+---
+
+Publish the Gmail integration visibility fix with product release 0.23.7.

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.6
-appVersion: "0.23.6"
+version: 0.23.7
+appVersion: "0.23.7"


### PR DESCRIPTION
## Summary

- advance Helm chart and app version from 0.23.6 to 0.23.7
- add the publishable Gmail capabilities changeset for the fresh product train
- avoid overwriting the already-occupied 0.23.6 OCI release aliases

## Verification

- `git diff --check`
- `bunx changeset status`
- `helm lint deploy/helm/opengeni`

Candidate run 31913326923 failed closed before image creation because 0.23.6 is occupied.