### PR TITLE
chore(release): prepare product 0.23.8

### DIFF
--- a/.changeset/bright-gmail-release.md
+++ b/.changeset/bright-gmail-release.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/capabilities": patch
+---
+
+Publish the Gmail integration visibility fix with product release 0.23.8.

--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.7
-appVersion: "0.23.7"
+version: 0.23.8
+appVersion: "0.23.8"


### PR DESCRIPTION
Prepare a fresh release train for the Gmail integration visibility fix after the prior candidate lacked promotable pre-merge review evidence.\n\n- bump the Helm product version to 0.23.8\n- add an explicit capabilities changeset for the Gmail visibility fix\n\nValidated with `bunx changeset status`, `helm lint deploy/helm/opengeni`, and `git diff --check`.