### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/bright-gmail-release.md
+++ b/.changeset/bright-gmail-release.md
@@ -1,5 +1,0 @@
----
-"@opengeni/capabilities": patch
----
-
-Publish the Gmail integration visibility fix with product release 0.23.8.

--- a/apps/api/CHANGELOG.md
+++ b/apps/api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @opengeni/api-router
 
+## 0.31.2
+
+### Patch Changes
+
+- Updated dependencies [b06071c]
+  - @opengeni/capabilities@0.2.3
+
 ## 0.31.1
 
 ### Patch Changes

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/api-router",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "description": "OpenGeni HTTP surface: the Hono adapter/router (createApp), routes, MCP HTTP transport, and HTTP access adapters over @opengeni/core. An engine-distribution surface — its runtime closure includes engine-internal packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/apps/worker/CHANGELOG.md
+++ b/apps/worker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @opengeni/worker-bundle
 
+## 0.20.6
+
+### Patch Changes
+
+- Updated dependencies [b06071c]
+  - @opengeni/capabilities@0.2.3
+
 ## 0.20.5
 
 ### Patch Changes

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/worker-bundle",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "description": "OpenGeni worker entry and reusable embedded lifecycle, shipped with a release-coherent pre-bundled Temporal workflow artifact.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/capabilities/CHANGELOG.md
+++ b/packages/capabilities/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opengeni/capabilities
 
+## 0.2.3
+
+### Patch Changes
+
+- b06071c: Publish the Gmail integration visibility fix with product release 0.23.8.
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengeni/capabilities",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Protocol-neutral capability integration compilers and local MCP adapters for OpenGeni.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Apply the exact generated Changesets tree for product release 0.23.8 on the canonical Version branch. This fresh head replaces the closed automation head whose provider check evidence became ambiguous during a release-head retention visibility race.\n\nThe tree is byte-identical to the generated projection and includes the Gmail integration visibility fix in `@opengeni/capabilities` 0.2.3.