### PR TITLE
fix: fence Slack and Fiken provider calls (OPE-199)

### DIFF
--- a/apps/api/src/integrations/fiken.ts
+++ b/apps/api/src/integrations/fiken.ts
@@ -27,6 +27,7 @@ import {
   getConnectionMetadata,
   getWorkspaceGrant,
   listConnectionsMetadata,
+  loadConnectionCredentialForBroker,
   recordAuditEvent,
   setConnectionStatus,
   updateConnection,
@@ -634,41 +635,17 @@ export class FikenClient {
         url.searchParams.set(key, value);
       }
       const result = await serializedPerConnection(this.connection.id, async () => {
-        const current = await getConnectionMetadata(
-          this.db,
-          this.context.workspaceId,
-          this.connection.id,
-          null,
-        );
-        if (
-          !current ||
-          current.accountId !== this.context.accountId ||
-          current.status !== "active" ||
-          current.version !== this.expectedConnectionVersion ||
-          !isFikenConnection(current)
-        ) {
-          throw new Error("the Fiken connection authority changed");
-        }
+        const authority = await this.currentAuthority(this.expectedConnectionVersion);
         const credential = await this.credentialFor(operation, url.toString());
-        const rechecked = await getConnectionMetadata(
-          this.db,
-          this.context.workspaceId,
-          this.connection.id,
-          null,
-        );
-        if (
-          !rechecked ||
-          rechecked.accountId !== this.context.accountId ||
-          rechecked.status !== "active" ||
-          rechecked.version !== credential.connectionVersion ||
-          !isFikenConnection(rechecked)
-        ) {
-          throw new Error("the Fiken connection authority changed");
-        }
-        if (credential.authorizeProviderRequest && !(await credential.authorizeProviderRequest())) {
+        await this.currentAuthority(credential.connectionVersion, authority.authorityGeneration);
+        // The adapter callback is a fallible preflight. The canonical
+        // credential callback below records the physical-use fact, so it must
+        // be the final await before the target fetch.
+        if (this.authorizeProviderRequest && (await this.authorizeProviderRequest()) === false) {
           throw new Error("the Fiken provider request is no longer authorized");
         }
-        if (this.authorizeProviderRequest && (await this.authorizeProviderRequest()) === false) {
+        await this.currentAuthority(credential.connectionVersion, authority.authorityGeneration);
+        if (credential.authorizeProviderRequest && !(await credential.authorizeProviderRequest())) {
           throw new Error("the Fiken provider request is no longer authorized");
         }
         this.expectedConnectionVersion = credential.connectionVersion;
@@ -690,7 +667,7 @@ export class FikenClient {
         } catch {
           throw new FikenProviderError("transport_error");
         }
-        return await this.readResponse(operation, response);
+        return await this.readResponse(operation, response, credential.connectionVersion);
       });
       await this.recordAudit(operation, "succeeded");
       return result;
@@ -703,15 +680,14 @@ export class FikenClient {
   private async readResponse(
     operation: FikenOperation,
     response: Response,
+    credentialVersion: number,
   ): Promise<{ payload: unknown; page: FikenPage | null; locationId: number | null }> {
     if (response.status === 401) {
       await response.body?.cancel().catch(() => undefined);
-      // A 401 after resolution means the credential is genuinely rejected
-      // (revoked token or revoked OAuth grant). setConnectionStatus is a
-      // strict version CAS and a broker refresh may have bumped the version
-      // since this client resolved the row, so re-read the current version
-      // instead of using the resolution-time snapshot.
-      await this.markNeedsReauth().catch(() => undefined);
+      // Only the exact active credential generation sent on this request may
+      // transition. A late 401 must not poison a reconnect or revocation that
+      // became current while the provider response was in flight.
+      await this.markNeedsReauth(credentialVersion).catch(() => undefined);
       throw new FikenProviderError("credential_rejected", 401);
     }
     if (response.status === 429) {
@@ -747,21 +723,57 @@ export class FikenClient {
     return { payload, page: pageFromHeaders(response.headers), locationId };
   }
 
-  private async markNeedsReauth(): Promise<void> {
+  private async markNeedsReauth(credentialVersion: number): Promise<void> {
     const current = await getConnectionMetadata(
       this.db,
       this.context.workspaceId,
       this.connection.id,
       null,
     );
-    if (!current || current.status === "needs_reauth") return;
+    if (
+      !current ||
+      current.status !== "active" ||
+      current.version !== credentialVersion ||
+      !isFikenConnection(current)
+    ) {
+      return;
+    }
     await setConnectionStatus(
       this.db,
       this.context.workspaceId,
       "needs_reauth",
       "Fiken rejected the credential",
-      { id: current.id, version: current.version, subjectId: null },
+      { id: current.id, version: credentialVersion, subjectId: null },
     );
+  }
+
+  private async currentAuthority(
+    expectedVersion: number,
+    expectedAuthorityGeneration?: number,
+  ): Promise<{ version: number; authorityGeneration: number }> {
+    const current = await loadConnectionCredentialForBroker(this.db, this.settings, {
+      workspaceId: this.context.workspaceId,
+      connectionId: this.connection.id,
+      providerDomain: FIKEN_PROVIDER_DOMAIN,
+      kind: this.connection.kind === "oauth2" ? "oauth2" : "api_key",
+      subjectId: null,
+      ...(expectedAuthorityGeneration !== undefined ? { expectedAuthorityGeneration } : {}),
+    });
+    if (
+      !current ||
+      current.accountId !== this.context.accountId ||
+      current.workspaceId !== this.context.workspaceId ||
+      current.subjectId !== null ||
+      current.providerDomain !== FIKEN_PROVIDER_DOMAIN ||
+      current.kind !== this.connection.kind ||
+      current.status !== "active" ||
+      current.version !== expectedVersion ||
+      current.authorityGeneration === undefined ||
+      !fikenConnectionMetadata(current.metadata)
+    ) {
+      throw new Error("the Fiken connection authority changed");
+    }
+    return { version: current.version, authorityGeneration: current.authorityGeneration };
   }
 
   private async credentialFor(

--- a/apps/api/src/integrations/fiken.ts
+++ b/apps/api/src/integrations/fiken.ts
@@ -102,6 +102,8 @@ type FikenContext = {
   sessionId: string | null;
 };
 
+type FikenProviderAuthorization = () => Promise<boolean | void>;
+
 /**
  * Fiken allows only a single concurrent API request per credential; concurrent
  * requests can 429 and repeated violations can get the token banned. Serialize
@@ -281,6 +283,7 @@ export type FikenListInput = {
 
 export class FikenClient {
   private readonly resolveCredential: ReturnType<typeof buildConnectionTokenResolver>;
+  private expectedConnectionVersion: number;
 
   constructor(
     private readonly db: Database,
@@ -289,11 +292,22 @@ export class FikenClient {
     private readonly metadata: FikenConnectionMetadata,
     private readonly context: FikenContext,
     private readonly fetchImpl: FetchLike = fetch,
+    private readonly authorizeProviderRequest?: FikenProviderAuthorization,
   ) {
+    this.expectedConnectionVersion = connection.version;
     // OAuth-kind connections refresh through the generic broker; route that
-    // token-endpoint transport through the same injectable Fiken fetch.
+    // token-endpoint transport through the same injectable Fiken fetch. Keep
+    // the optional authorization immediately before actual refresh I/O.
+    const refreshFetch: FetchLike = this.authorizeProviderRequest
+      ? async (input, init) => {
+          if ((await this.authorizeProviderRequest?.()) === false) {
+            throw new Error("the Fiken credential refresh is no longer authorized");
+          }
+          return await this.fetchImpl(input, init);
+        }
+      : fetchImpl;
     this.resolveCredential = buildConnectionTokenResolver(db, settings, undefined, {
-      refreshTransport: { fetchImpl },
+      refreshTransport: { fetchImpl: refreshFetch },
     });
   }
 
@@ -619,17 +633,51 @@ export class FikenClient {
       for (const [key, value] of Object.entries(input.query ?? {})) {
         url.searchParams.set(key, value);
       }
-      // Credential resolution (DB read + possible broker refresh) happens
-      // outside the serialization chain: only the provider HTTP call itself
-      // must obey Fiken's single-concurrent-request rule.
-      const headers = await this.headersFor(operation, url.toString());
       const result = await serializedPerConnection(this.connection.id, async () => {
+        const current = await getConnectionMetadata(
+          this.db,
+          this.context.workspaceId,
+          this.connection.id,
+          null,
+        );
+        if (
+          !current ||
+          current.accountId !== this.context.accountId ||
+          current.status !== "active" ||
+          current.version !== this.expectedConnectionVersion ||
+          !isFikenConnection(current)
+        ) {
+          throw new Error("the Fiken connection authority changed");
+        }
+        const credential = await this.credentialFor(operation, url.toString());
+        const rechecked = await getConnectionMetadata(
+          this.db,
+          this.context.workspaceId,
+          this.connection.id,
+          null,
+        );
+        if (
+          !rechecked ||
+          rechecked.accountId !== this.context.accountId ||
+          rechecked.status !== "active" ||
+          rechecked.version !== credential.connectionVersion ||
+          !isFikenConnection(rechecked)
+        ) {
+          throw new Error("the Fiken connection authority changed");
+        }
+        if (credential.authorizeProviderRequest && !(await credential.authorizeProviderRequest())) {
+          throw new Error("the Fiken provider request is no longer authorized");
+        }
+        if (this.authorizeProviderRequest && (await this.authorizeProviderRequest()) === false) {
+          throw new Error("the Fiken provider request is no longer authorized");
+        }
+        this.expectedConnectionVersion = credential.connectionVersion;
         let response: Response;
         try {
           response = await this.fetchImpl(url, {
             method,
             headers: {
-              ...headers,
+              ...credential.headers,
               accept: "application/json",
               ...(input.body !== undefined ? { "content-type": "application/json" } : {}),
             },
@@ -716,10 +764,14 @@ export class FikenClient {
     );
   }
 
-  private async headersFor(
+  private async credentialFor(
     operation: FikenOperation,
     destinationUrl: string,
-  ): Promise<Record<string, string>> {
+  ): Promise<{
+    headers: Record<string, string>;
+    connectionVersion: number;
+    authorizeProviderRequest?: () => Promise<boolean>;
+  }> {
     const result = await this.resolveCredential({
       workspaceId: this.context.workspaceId,
       serverId: "opengeni-fiken",
@@ -732,10 +784,20 @@ export class FikenClient {
       },
       destinationUrl,
     });
-    if (result.status !== "ok" || result.connectionId !== this.connection.id) {
+    if (
+      result.status !== "ok" ||
+      result.connectionId !== this.connection.id ||
+      result.connectionVersion === undefined
+    ) {
       throw new Error("the Fiken connection needs to be reconnected");
     }
-    return result.headers;
+    return {
+      headers: result.headers,
+      connectionVersion: result.connectionVersion,
+      ...(result.authorizeProviderRequest
+        ? { authorizeProviderRequest: result.authorizeProviderRequest }
+        : {}),
+    };
   }
 
   private receipt(operation: FikenOperation, operationId?: string) {
@@ -771,7 +833,12 @@ export class FikenClient {
 }
 
 export function createFikenClient(
-  deps: { db: Database; settings: Settings; fikenFetch?: typeof fetch },
+  deps: {
+    db: Database;
+    settings: Settings;
+    fikenFetch?: typeof fetch;
+    authorizeProviderRequest?: FikenProviderAuthorization;
+  },
   resolved: Awaited<ReturnType<typeof resolveFikenConnectionForTool>>,
 ): FikenClient {
   return new FikenClient(
@@ -781,6 +848,7 @@ export function createFikenClient(
     resolved.metadata,
     resolved.context,
     deps.fikenFetch,
+    deps.authorizeProviderRequest,
   );
 }
 

--- a/apps/api/src/integrations/slack-bot.ts
+++ b/apps/api/src/integrations/slack-bot.ts
@@ -1566,10 +1566,12 @@ export class OpenGeniSlackBotClient {
     ) {
       throw new Error("OpenGeni Slack bot connection authority changed");
     }
-    if (result.authorizeProviderRequest && !(await result.authorizeProviderRequest())) {
+    // The adapter callback is a fallible preflight. The canonical credential
+    // callback must remain the final await before the physical fetch.
+    if (this.authorizeProviderRequest && (await this.authorizeProviderRequest()) === false) {
       throw new Error("OpenGeni Slack bot provider request is no longer authorized");
     }
-    if (this.authorizeProviderRequest && (await this.authorizeProviderRequest()) === false) {
+    if (result.authorizeProviderRequest && !(await result.authorizeProviderRequest())) {
       throw new Error("OpenGeni Slack bot provider request is no longer authorized");
     }
     return result.headers;
@@ -1614,8 +1616,8 @@ export class OpenGeniSlackBotClient {
     } catch {
       throw new SlackBotProviderError("invalid_file_url");
     }
-    const headers = await this.headersForDestination(operation, url.toString());
     await authorizeBeforeFetch?.();
+    const headers = await this.headersForDestination(operation, url.toString());
     let response: Response;
     try {
       response = await this.fetchImpl(url, {

--- a/apps/api/src/integrations/slack-bot.ts
+++ b/apps/api/src/integrations/slack-bot.ts
@@ -246,6 +246,9 @@ type SlackBotContext = {
   scheduledTaskId?: string | null;
 };
 
+type SlackCallAuthority = Readonly<{ operation: SlackBotOperation }>;
+type SlackProviderAuthorization = () => Promise<boolean | void>;
+
 export type SlackReactionContextCheckpointBinding = {
   inboxId: string;
   accountId: string;
@@ -492,6 +495,7 @@ export class OpenGeniSlackBotClient {
     private readonly metadata: OpenGeniSlackBotConnectionMetadata,
     private readonly context: SlackBotContext,
     private readonly fetchImpl: FetchLike = fetch,
+    private readonly authorizeProviderRequest?: SlackProviderAuthorization,
   ) {
     this.resolveCredential = buildConnectionTokenResolver(db, settings);
   }
@@ -1309,10 +1313,7 @@ export class OpenGeniSlackBotClient {
   }
 
   private async slackMessageExists(channelId: string, timestamp: string): Promise<boolean> {
-    const headers = await this.headersForDestination(
-      "message.delete",
-      `${SLACK_API_BASE}chat.getPermalink`,
-    );
+    const headers = await this.headersFor("message.delete");
     try {
       await this.call(headers, "chat.getPermalink", {
         channel: channelId,
@@ -1334,7 +1335,7 @@ export class OpenGeniSlackBotClient {
     text: string;
   }): Promise<{ timestamp: string }> {
     const method = input.threadTimestamp ? "conversations.replies" : "conversations.history";
-    const headers = await this.headersForDestination("message.post", `${SLACK_API_BASE}${method}`);
+    const headers = await this.headersFor("message.post");
     const seenCursors = new Set<string>();
     let cursor: string | null = null;
     let matchedTimestamp: string | null = null;
@@ -1382,7 +1383,7 @@ export class OpenGeniSlackBotClient {
     return { timestamp: matchedTimestamp };
   }
 
-  private async requireMemberChannel(headers: Record<string, string>, channelId: string) {
+  private async requireMemberChannel(headers: SlackCallAuthority, channelId: string) {
     const payload = await this.call(headers, "conversations.info", {
       channel: channelId,
     });
@@ -1397,7 +1398,7 @@ export class OpenGeniSlackBotClient {
   }
 
   private async requireActiveNonSharedMemberChannel(
-    headers: Record<string, string>,
+    headers: SlackCallAuthority,
     channelId: string,
   ) {
     const projected = await this.requireMemberChannel(headers, channelId);
@@ -1411,7 +1412,7 @@ export class OpenGeniSlackBotClient {
   }
 
   private async requireFileForChannel(
-    headers: Record<string, string>,
+    headers: SlackCallAuthority,
     operation: "file.info" | "file.content.read",
     input: { channelId: string; fileId: string; parentFileId?: string },
   ) {
@@ -1488,11 +1489,15 @@ export class OpenGeniSlackBotClient {
   }
 
   private async call(
-    headers: Record<string, string>,
+    authority: SlackCallAuthority,
     method: string,
     params: Record<string, string>,
   ): Promise<SlackPayload> {
     try {
+      const headers = await this.headersForDestination(
+        authority.operation,
+        `${SLACK_API_BASE}${method}`,
+      );
       return (await slackApiFetchWithHeaders(this.fetchImpl, method, headers, params)).payload;
     } catch (error) {
       if (slackCredentialRejected(error)) {
@@ -1508,11 +1513,10 @@ export class OpenGeniSlackBotClient {
 
   private async withAudit<T extends Record<string, unknown>>(
     operation: SlackBotOperation,
-    run: (headers: Record<string, string>) => Promise<T>,
+    run: (authority: SlackCallAuthority) => Promise<T>,
   ): Promise<T & { receipt: SlackBotReceipt }> {
     try {
-      const headers = await this.headersFor(operation);
-      const result = await run(headers);
+      const result = await run(await this.headersFor(operation));
       await this.recordAudit(operation, "succeeded");
       return { ...result, receipt: this.receipt(operation) };
     } catch (error) {
@@ -1521,11 +1525,8 @@ export class OpenGeniSlackBotClient {
     }
   }
 
-  private async headersFor(operation: SlackBotOperation): Promise<Record<string, string>> {
-    return await this.headersForDestination(
-      operation,
-      `${SLACK_API_BASE}${slackMethodForOperation(operation)}`,
-    );
+  private async headersFor(operation: SlackBotOperation): Promise<SlackCallAuthority> {
+    return Object.freeze({ operation });
   }
 
   private async headersForDestination(
@@ -1547,6 +1548,29 @@ export class OpenGeniSlackBotClient {
     });
     if (result.status !== "ok" || result.connectionId !== this.connection.id) {
       throw new Error("OpenGeni Slack bot connection needs to be reinstalled");
+    }
+    const current = await requireOpenGeniSlackBotConnection(
+      this.db,
+      this.context.workspaceId,
+      this.connection.id,
+    );
+    const currentMetadata = openGeniSlackBotMetadata(current.metadata);
+    if (
+      current.accountId !== this.context.accountId ||
+      current.version !== this.connection.version ||
+      result.connectionVersion !== this.connection.version ||
+      !currentMetadata ||
+      currentMetadata.slackTeamId !== this.metadata.slackTeamId ||
+      currentMetadata.botId !== this.metadata.botId ||
+      currentMetadata.botUserId !== this.metadata.botUserId
+    ) {
+      throw new Error("OpenGeni Slack bot connection authority changed");
+    }
+    if (result.authorizeProviderRequest && !(await result.authorizeProviderRequest())) {
+      throw new Error("OpenGeni Slack bot provider request is no longer authorized");
+    }
+    if (this.authorizeProviderRequest && (await this.authorizeProviderRequest()) === false) {
+      throw new Error("OpenGeni Slack bot provider request is no longer authorized");
     }
     return result.headers;
   }
@@ -1802,7 +1826,12 @@ export class OpenGeniSlackBotClient {
 }
 
 export function createOpenGeniSlackBotClient(
-  deps: { db: Database; settings: Settings; slackFetch?: typeof fetch },
+  deps: {
+    db: Database;
+    settings: Settings;
+    slackFetch?: typeof fetch;
+    authorizeProviderRequest?: SlackProviderAuthorization;
+  },
   resolved: Awaited<ReturnType<typeof resolveSlackBotConnectionForTool>>,
 ): OpenGeniSlackBotClient {
   return new OpenGeniSlackBotClient(
@@ -1812,11 +1841,17 @@ export function createOpenGeniSlackBotClient(
     resolved.metadata,
     resolved.context,
     deps.slackFetch,
+    deps.authorizeProviderRequest,
   );
 }
 
 export async function createOpenGeniSlackBotInteractionClient(
-  deps: { db: Database; settings: Settings; slackFetch?: typeof fetch },
+  deps: {
+    db: Database;
+    settings: Settings;
+    slackFetch?: typeof fetch;
+    authorizeProviderRequest?: SlackProviderAuthorization;
+  },
   input: {
     accountId: string;
     workspaceId: string;
@@ -1848,6 +1883,7 @@ export async function createOpenGeniSlackBotInteractionClient(
       scheduledTaskId: null,
     },
     deps.slackFetch,
+    deps.authorizeProviderRequest,
   );
 }
 
@@ -2800,32 +2836,6 @@ export function nextSlackFilesListPage(
     throw new SlackBotProviderError("invalid_files_paging");
   }
   return nextPage;
-}
-
-function slackMethodForOperation(operation: SlackBotOperation): string {
-  switch (operation) {
-    case "channels.list":
-      return "conversations.list";
-    case "channel_history.read":
-      return "conversations.history";
-    case "thread_replies.read":
-      return "conversations.replies";
-    case "users.list":
-      return "users.list";
-    case "files.list":
-      return "files.list";
-    case "file.info":
-    case "file.content.read":
-      return "files.info";
-    case "home.publish":
-      return "views.publish";
-    case "message.post":
-      return "chat.postMessage";
-    case "message.update":
-      return "chat.update";
-    case "message.delete":
-      return "chat.delete";
-  }
 }
 
 function validateSlackMessageBlocks(

--- a/apps/api/test/fiken.test.ts
+++ b/apps/api/test/fiken.test.ts
@@ -501,6 +501,52 @@ describe("FikenClient", () => {
     };
   }
 
+  async function expiredOAuthClient(
+    workspace: { accountId: string; workspaceId: string },
+    fikenFetch: typeof globalThis.fetch,
+  ) {
+    const installed = await installFiken(workspace, fakeFiken().fetch, {
+      defaultCompanySlug: "demo-as",
+    });
+    const current = await getConnectionMetadata(
+      client.db,
+      workspace.workspaceId,
+      installed.body.connection!.id,
+      null,
+    );
+    if (!current) throw new Error("expected current Fiken connection");
+    const expired = await updateConnection(client.db, {
+      workspaceId: workspace.workspaceId,
+      connectionId: current.id,
+      visibleToSubjectId: null,
+      kind: "oauth2",
+      credentialEncrypted: encryptEnvironmentValue(
+        Buffer.from(ENCRYPTION_KEY, "base64"),
+        JSON.stringify({
+          access_token: "expired-access",
+          refresh_token: "refresh-fixture",
+          token_endpoint: "https://fiken.no/oauth/token",
+          client_id: "fiken-client-id",
+          client_secret: "fiken-client-secret",
+          token_endpoint_auth_method: "client_secret_basic",
+          token_type: "bearer",
+        }),
+      ),
+      expiresAt: new Date(0),
+      metadata: { ...current.metadata },
+    });
+    if (!expired) throw new Error("expected expired OAuth fixture");
+    const resolved = await resolveFikenConnectionForTool({
+      db: client.db,
+      grant: grantFor(workspace),
+      sessionId: null,
+    });
+    return {
+      connection: expired,
+      fiken: createFikenClient({ db: client.db, settings: oauthSettings, fikenFetch }, resolved),
+    };
+  }
+
   test("lists contacts with pagination facts and stripped blobs", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
@@ -626,41 +672,6 @@ describe("FikenClient", () => {
   test("rechecks revocation after a delayed OAuth refresh before target I/O", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
-    const installed = await installFiken(workspace, fakeFiken().fetch, {
-      defaultCompanySlug: "demo-as",
-    });
-    const current = await getConnectionMetadata(
-      client.db,
-      workspace.workspaceId,
-      installed.body.connection!.id,
-      null,
-    );
-    if (!current) throw new Error("expected current Fiken connection");
-    await updateConnection(client.db, {
-      workspaceId: workspace.workspaceId,
-      connectionId: current.id,
-      visibleToSubjectId: null,
-      kind: "oauth2",
-      credentialEncrypted: encryptEnvironmentValue(
-        Buffer.from(ENCRYPTION_KEY, "base64"),
-        JSON.stringify({
-          access_token: "expired-access",
-          refresh_token: "refresh-fixture",
-          token_endpoint: "https://fiken.no/oauth/token",
-          client_id: "fiken-client-id",
-          client_secret: "fiken-client-secret",
-          token_endpoint_auth_method: "client_secret_basic",
-          token_type: "bearer",
-        }),
-      ),
-      expiresAt: new Date(0),
-      metadata: { ...current.metadata },
-    });
-    const resolved = await resolveFikenConnectionForTool({
-      db: client.db,
-      grant: grantFor(workspace),
-      sessionId: null,
-    });
     let releaseRefresh!: () => void;
     let signalRefresh!: () => void;
     const refreshEntered = new Promise<void>((resolve) => {
@@ -687,16 +698,13 @@ describe("FikenClient", () => {
       targetCalls += 1;
       return await fakeFiken().fetch(input, init);
     }) as typeof globalThis.fetch;
-    const fiken = createFikenClient(
-      { db: client.db, settings: oauthSettings, fikenFetch: gatedFetch },
-      resolved,
-    );
+    const { fiken, connection } = await expiredOAuthClient(workspace, gatedFetch);
     const request = fiken.listContacts({ companySlug: "demo-as" });
     await refreshEntered;
     const duringRefresh = await getConnectionMetadata(
       client.db,
       workspace.workspaceId,
-      current.id,
+      connection.id,
       null,
     );
     if (!duringRefresh) throw new Error("expected Fiken connection during refresh");
@@ -711,6 +719,150 @@ describe("FikenClient", () => {
     await expect(request).rejects.toThrow();
     expect(refreshCalls).toBe(1);
     expect(targetCalls).toBe(0);
+  });
+
+  test("rejects a reconnect winner after delayed OAuth refresh without target I/O", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    let releaseRefresh!: () => void;
+    let signalRefresh!: () => void;
+    const refreshEntered = new Promise<void>((resolve) => {
+      signalRefresh = resolve;
+    });
+    const refreshReleased = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    let refreshCalls = 0;
+    let targetCalls = 0;
+    const gatedFetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.hostname === "fiken.no" && url.pathname === "/oauth/token") {
+        refreshCalls += 1;
+        signalRefresh();
+        await refreshReleased;
+        return Response.json({
+          access_token: "refreshed-access",
+          refresh_token: "refresh-fixture",
+          token_type: "bearer",
+          expires_in: 86_400,
+        });
+      }
+      targetCalls += 1;
+      return await fakeFiken().fetch(input, init);
+    }) as typeof globalThis.fetch;
+    const { fiken, connection } = await expiredOAuthClient(workspace, gatedFetch);
+    const request = fiken.listContacts({ companySlug: "demo-as" });
+    await refreshEntered;
+    const duringRefresh = await getConnectionMetadata(
+      client.db,
+      workspace.workspaceId,
+      connection.id,
+      null,
+    );
+    if (!duringRefresh) throw new Error("expected Fiken connection during refresh");
+    const reconnected = await updateConnection(client.db, {
+      workspaceId: workspace.workspaceId,
+      connectionId: duringRefresh.id,
+      visibleToSubjectId: null,
+      kind: "oauth2",
+      credentialEncrypted: encryptEnvironmentValue(
+        Buffer.from(ENCRYPTION_KEY, "base64"),
+        JSON.stringify({
+          access_token: "reconnected-access",
+          refresh_token: "reconnected-refresh",
+          token_endpoint: "https://fiken.no/oauth/token",
+          client_id: "fiken-client-id",
+          client_secret: "fiken-client-secret",
+          token_endpoint_auth_method: "client_secret_basic",
+          token_type: "bearer",
+        }),
+      ),
+      expiresAt: new Date(Date.now() + 86_400_000),
+      metadata: { ...duringRefresh.metadata },
+    });
+    if (!reconnected) throw new Error("expected Fiken reconnect winner");
+    releaseRefresh();
+    await expect(request).rejects.toThrow(/authority changed|reconnected/);
+    const final = await getConnectionMetadata(
+      client.db,
+      workspace.workspaceId,
+      connection.id,
+      null,
+    );
+    expect(final).toMatchObject({ status: "active", version: reconnected.version });
+    expect(refreshCalls).toBe(1);
+    expect(targetCalls).toBe(0);
+  });
+
+  test("does not let a stale in-flight 401 poison reconnect or revocation truth", async () => {
+    if (!available) return;
+    for (const transition of ["reconnect", "revoke"] as const) {
+      const workspace = await freshWorkspace();
+      let releaseResponse!: () => void;
+      let signalEntered!: () => void;
+      const targetEntered = new Promise<void>((resolve) => {
+        signalEntered = resolve;
+      });
+      const responseReleased = new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      });
+      let targetCalls = 0;
+      const delayed401 = (async () => {
+        targetCalls += 1;
+        signalEntered();
+        await responseReleased;
+        return Response.json({ message: "stale credential" }, { status: 401 });
+      }) as typeof globalThis.fetch;
+      const { fiken, resolved } = await connectedClient(workspace, delayed401, {
+        defaultCompanySlug: "demo-as",
+      });
+      const request = fiken.listContacts({});
+      await targetEntered;
+      const current = await getConnectionMetadata(
+        client.db,
+        workspace.workspaceId,
+        resolved.connection.id,
+        null,
+      );
+      if (!current) throw new Error("expected current Fiken connection");
+      let expectedVersion: number;
+      if (transition === "reconnect") {
+        const reconnected = await updateConnection(client.db, {
+          workspaceId: workspace.workspaceId,
+          connectionId: current.id,
+          visibleToSubjectId: null,
+          credentialEncrypted: encryptEnvironmentValue(
+            Buffer.from(ENCRYPTION_KEY, "base64"),
+            JSON.stringify(fikenCredentialBundle(`${FIXTURE_TOKEN}-401-reconnect`)),
+          ),
+          metadata: { ...current.metadata },
+        });
+        if (!reconnected) throw new Error("expected Fiken reconnect winner");
+        expectedVersion = reconnected.version;
+      } else {
+        expect(
+          await setConnectionStatus(client.db, workspace.workspaceId, "revoked", null, {
+            id: current.id,
+            version: current.version,
+            subjectId: null,
+          }),
+        ).toBe(true);
+        expectedVersion = current.version + 1;
+      }
+      releaseResponse();
+      await expect(request).rejects.toThrow(/credential_rejected/);
+      const final = await getConnectionMetadata(
+        client.db,
+        workspace.workspaceId,
+        resolved.connection.id,
+        null,
+      );
+      expect(final).toMatchObject({
+        status: transition === "reconnect" ? "active" : "revoked",
+        version: expectedVersion,
+      });
+      expect(targetCalls).toBe(1);
+    }
   });
 
   test("marks the connection needs_reauth on 401 and stays active on 429/500", async () => {

--- a/apps/api/test/fiken.test.ts
+++ b/apps/api/test/fiken.test.ts
@@ -16,6 +16,7 @@ import {
   encryptEnvironmentValue,
   getConnectionMetadata,
   refreshOAuthConnectionCredential,
+  setConnectionStatus,
   updateConnection,
   type DbClient,
 } from "@opengeni/db";
@@ -483,6 +484,7 @@ describe("FikenClient", () => {
     workspace: { accountId: string; workspaceId: string },
     fikenFetch: typeof globalThis.fetch,
     installPayload: Record<string, unknown> = {},
+    authorizeProviderRequest?: () => Promise<boolean | void>,
   ) {
     await installFiken(workspace, fakeFiken().fetch, installPayload);
     const resolved = await resolveFikenConnectionForTool({
@@ -492,7 +494,10 @@ describe("FikenClient", () => {
     });
     return {
       resolved,
-      fiken: createFikenClient({ db: client.db, settings, fikenFetch }, resolved),
+      fiken: createFikenClient(
+        { db: client.db, settings, fikenFetch, authorizeProviderRequest },
+        resolved,
+      ),
     };
   }
 
@@ -538,11 +543,174 @@ describe("FikenClient", () => {
     if (!available) return;
     const workspace = await freshWorkspace();
     const provider = fakeFiken();
-    const { fiken } = await connectedClient(workspace, provider.fetch, {
-      defaultCompanySlug: "demo-as",
-    });
+    let authorizations = 0;
+    const { fiken } = await connectedClient(
+      workspace,
+      provider.fetch,
+      { defaultCompanySlug: "demo-as" },
+      async () => {
+        authorizations += 1;
+        return true;
+      },
+    );
     await Promise.all([fiken.listCompanies(), fiken.listContacts({}), fiken.listCompanies()]);
     expect(provider.maxInFlight()).toBe(1);
+    expect(authorizations).toBe(provider.calls.length);
+  });
+
+  test("denies queued calls after revoke or reconnect without stale provider I/O", async () => {
+    if (!available) return;
+    for (const transition of ["revoke", "reconnect"] as const) {
+      const workspace = await freshWorkspace();
+      const provider = fakeFiken();
+      let releaseFirst!: () => void;
+      let signalEntered!: () => void;
+      const entered = new Promise<void>((resolve) => {
+        signalEntered = resolve;
+      });
+      const released = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let targetCalls = 0;
+      const gatedFetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+        if (url.hostname === "api.fiken.no") {
+          targetCalls += 1;
+          if (targetCalls === 1) {
+            signalEntered();
+            await released;
+          }
+        }
+        return await provider.fetch(input, init);
+      }) as typeof globalThis.fetch;
+      const { fiken, resolved } = await connectedClient(workspace, gatedFetch, {
+        defaultCompanySlug: "demo-as",
+      });
+      const first = fiken.listCompanies();
+      await entered;
+      const queued = fiken.listContacts({});
+      const current = await getConnectionMetadata(
+        client.db,
+        workspace.workspaceId,
+        resolved.connection.id,
+        null,
+      );
+      if (!current) throw new Error("expected current Fiken connection");
+      if (transition === "revoke") {
+        expect(
+          await setConnectionStatus(client.db, workspace.workspaceId, "revoked", null, {
+            id: current.id,
+            version: current.version,
+            subjectId: null,
+          }),
+        ).toBe(true);
+      } else {
+        await updateConnection(client.db, {
+          workspaceId: workspace.workspaceId,
+          connectionId: current.id,
+          visibleToSubjectId: null,
+          credentialEncrypted: encryptEnvironmentValue(
+            Buffer.from(ENCRYPTION_KEY, "base64"),
+            JSON.stringify(fikenCredentialBundle(`${FIXTURE_TOKEN}-reconnected`)),
+          ),
+          metadata: { ...current.metadata },
+        });
+      }
+      releaseFirst();
+      await expect(first).resolves.toBeDefined();
+      await expect(queued).rejects.toThrow(/authority changed|reconnected/);
+      expect(targetCalls).toBe(1);
+    }
+  });
+
+  test("rechecks revocation after a delayed OAuth refresh before target I/O", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const installed = await installFiken(workspace, fakeFiken().fetch, {
+      defaultCompanySlug: "demo-as",
+    });
+    const current = await getConnectionMetadata(
+      client.db,
+      workspace.workspaceId,
+      installed.body.connection!.id,
+      null,
+    );
+    if (!current) throw new Error("expected current Fiken connection");
+    await updateConnection(client.db, {
+      workspaceId: workspace.workspaceId,
+      connectionId: current.id,
+      visibleToSubjectId: null,
+      kind: "oauth2",
+      credentialEncrypted: encryptEnvironmentValue(
+        Buffer.from(ENCRYPTION_KEY, "base64"),
+        JSON.stringify({
+          access_token: "expired-access",
+          refresh_token: "refresh-fixture",
+          token_endpoint: "https://fiken.no/oauth/token",
+          client_id: "fiken-client-id",
+          client_secret: "fiken-client-secret",
+          token_endpoint_auth_method: "client_secret_basic",
+          token_type: "bearer",
+        }),
+      ),
+      expiresAt: new Date(0),
+      metadata: { ...current.metadata },
+    });
+    const resolved = await resolveFikenConnectionForTool({
+      db: client.db,
+      grant: grantFor(workspace),
+      sessionId: null,
+    });
+    let releaseRefresh!: () => void;
+    let signalRefresh!: () => void;
+    const refreshEntered = new Promise<void>((resolve) => {
+      signalRefresh = resolve;
+    });
+    const refreshReleased = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    let refreshCalls = 0;
+    let targetCalls = 0;
+    const gatedFetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.hostname === "fiken.no" && url.pathname === "/oauth/token") {
+        refreshCalls += 1;
+        signalRefresh();
+        await refreshReleased;
+        return Response.json({
+          access_token: "refreshed-access",
+          refresh_token: "refresh-fixture",
+          token_type: "bearer",
+          expires_in: 86_400,
+        });
+      }
+      targetCalls += 1;
+      return await fakeFiken().fetch(input, init);
+    }) as typeof globalThis.fetch;
+    const fiken = createFikenClient(
+      { db: client.db, settings: oauthSettings, fikenFetch: gatedFetch },
+      resolved,
+    );
+    const request = fiken.listContacts({ companySlug: "demo-as" });
+    await refreshEntered;
+    const duringRefresh = await getConnectionMetadata(
+      client.db,
+      workspace.workspaceId,
+      current.id,
+      null,
+    );
+    if (!duringRefresh) throw new Error("expected Fiken connection during refresh");
+    expect(
+      await setConnectionStatus(client.db, workspace.workspaceId, "revoked", null, {
+        id: duringRefresh.id,
+        version: duringRefresh.version,
+        subjectId: null,
+      }),
+    ).toBe(true);
+    releaseRefresh();
+    await expect(request).rejects.toThrow();
+    expect(refreshCalls).toBe(1);
+    expect(targetCalls).toBe(0);
   });
 
   test("marks the connection needs_reauth on 401 and stays active on 429/500", async () => {
@@ -596,6 +764,28 @@ describe("FikenClient", () => {
     expect(post.body).toEqual({ name: "Ny Kunde", customer: true });
   });
 
+  test("does not replay an outcome-unknown contact creation", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const provider = fakeFiken();
+    let contactPosts = 0;
+    const losePostResponse = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if ((init?.method ?? "GET") === "POST" && url.pathname.endsWith("/contacts")) {
+        contactPosts += 1;
+        throw new Error("response lost after provider acceptance");
+      }
+      return await provider.fetch(input, init);
+    }) as typeof globalThis.fetch;
+    const { fiken } = await connectedClient(workspace, losePostResponse, {
+      defaultCompanySlug: "demo-as",
+    });
+    await expect(fiken.createContact({ name: "Unknown Outcome" })).rejects.toThrow(
+      /transport_error/,
+    );
+    expect(contactPosts).toBe(1);
+  });
+
   test("rejects fiken reserved metadata on the generic connection routes", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
@@ -633,30 +823,38 @@ describe("FikenClient", () => {
     expect(patched.status).toBe(422);
   });
 
-  test("marks needs_reauth on 401 even when the row version moved after resolution", async () => {
+  test("denies a stale client before provider I/O when the connection version moved", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
-    const failing = (async () =>
-      Response.json({ message: "revoked" }, { status: 401 })) as typeof globalThis.fetch;
+    let providerCalls = 0;
+    const failing = (async () => {
+      providerCalls += 1;
+      return Response.json({ message: "revoked" }, { status: 401 });
+    }) as typeof globalThis.fetch;
     const { fiken, resolved } = await connectedClient(workspace, failing, {
       defaultCompanySlug: "demo-as",
     });
-    // Simulate a concurrent writer (e.g. a broker refresh) bumping the version
-    // after this client resolved the row.
+    // Simulate a reconnect writer bumping the version after this client
+    // resolved the row. The stale 401 fixture must never be reached.
     await updateConnection(client.db, {
       workspaceId: workspace.workspaceId,
       connectionId: resolved.connection.id,
       visibleToSubjectId: null,
+      credentialEncrypted: encryptEnvironmentValue(
+        Buffer.from(ENCRYPTION_KEY, "base64"),
+        JSON.stringify(fikenCredentialBundle(`${FIXTURE_TOKEN}-moved`)),
+      ),
       metadata: { ...resolved.connection.metadata },
     });
-    await expect(fiken.listContacts({})).rejects.toThrow(/credential_rejected/);
+    await expect(fiken.listContacts({})).rejects.toThrow(/authority changed/);
     const after = await getConnectionMetadata(
       client.db,
       workspace.workspaceId,
       resolved.connection.id,
       null,
     );
-    expect(after?.status).toBe("needs_reauth");
+    expect(after?.status).toBe("active");
+    expect(providerCalls).toBe(0);
   });
 
   test("draft idempotency ignores unrelated drafts when the provider drops the uuid filter", async () => {
@@ -705,9 +903,16 @@ describe("FikenClient", () => {
     if (!available) return;
     const workspace = await freshWorkspace();
     const provider = fakeFiken();
-    const { fiken } = await connectedClient(workspace, provider.fetch, {
-      defaultCompanySlug: "demo-as",
-    });
+    let authorizations = 0;
+    const { fiken } = await connectedClient(
+      workspace,
+      provider.fetch,
+      { defaultCompanySlug: "demo-as" },
+      async () => {
+        authorizations += 1;
+        return true;
+      },
+    );
     const operationId = crypto.randomUUID();
     const draft = {
       operationId,
@@ -731,6 +936,7 @@ describe("FikenClient", () => {
       (entry) => entry.method === "POST" && entry.url.pathname.endsWith("/invoices/drafts"),
     );
     expect(posts).toHaveLength(1);
+    expect(authorizations).toBe(provider.calls.length);
     expect(posts[0]!.body).toMatchObject({
       type: "invoice",
       uuid: operationId,

--- a/apps/api/test/slack-bot.test.ts
+++ b/apps/api/test/slack-bot.test.ts
@@ -2352,6 +2352,44 @@ describe("OpenGeni Slack bot connection", () => {
     expect(privateFileCalls).toBe(1);
   });
 
+  test("denies a private-file preflight before recording provider use or fetching", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const slack = fakeSlack();
+    let privateFileCalls = 0;
+    const countingFetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.hostname === "files.slack.com") privateFileCalls += 1;
+      return await slack.fetch(input, init);
+    }) as typeof globalThis.fetch;
+    let providerAuthorizations = 0;
+    const { bot } = await connectedTestBot(workspace, countingFetch, async () => {
+      providerAuthorizations += 1;
+      return true;
+    });
+    let sharedPreflights = 0;
+    await expect(
+      bot.downloadReactionImage(
+        {
+          fileId: "F_IMAGE",
+          filename: "image.png",
+          declaredMimeType: "image/png",
+          declaredSizeBytes: null,
+          downloadUrl: new URL(
+            "https://files.slack.com/files-pri/T_OPEN_GENI-F_IMAGE/download/image.png",
+          ),
+        },
+        async () => {
+          sharedPreflights += 1;
+          throw new Error("shared read authority changed");
+        },
+      ),
+    ).rejects.toThrow(/shared read authority changed/);
+    expect(sharedPreflights).toBe(1);
+    expect(providerAuthorizations).toBe(0);
+    expect(privateFileCalls).toBe(0);
+  });
+
   test("rejects malformed, mixed, and non-advancing files.list paging", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();

--- a/apps/api/test/slack-bot.test.ts
+++ b/apps/api/test/slack-bot.test.ts
@@ -972,6 +972,7 @@ async function connectBot(
 async function connectedTestBot(
   workspace: { accountId: string; workspaceId: string },
   slackFetch: typeof globalThis.fetch,
+  authorizeProviderRequest?: () => Promise<boolean | void>,
 ) {
   const connected = await connectBot(workspace, slackFetch);
   const connection = await getConnectionMetadata(
@@ -994,7 +995,15 @@ async function connectedTestBot(
   });
   return {
     connection,
-    bot: createOpenGeniSlackBotClient({ db: client.db, settings, slackFetch }, resolved),
+    bot: createOpenGeniSlackBotClient(
+      {
+        db: client.db,
+        settings,
+        slackFetch,
+        ...(authorizeProviderRequest ? { authorizeProviderRequest } : {}),
+      },
+      resolved,
+    ),
   };
 }
 
@@ -2249,6 +2258,100 @@ describe("OpenGeni Slack bot connection", () => {
     expect(slack.calls.filter((call) => call.method === "files.list")).toHaveLength(3);
   });
 
+  test("authorizes every physical Slack call and denies a revoked continuation page", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const slack = fakeSlack({
+      fileListResponse: ({ count, page }) => ({
+        files: [{ id: `F_PAGE_${page}` }],
+        paging: { count, total: 2, page, pages: 2 },
+      }),
+    });
+    let authorizations = 0;
+    const { bot, connection } = await connectedTestBot(workspace, slack.fetch, async () => {
+      authorizations += 1;
+      return true;
+    });
+    const before = slack.calls.length;
+    const first = await bot.listFiles({ channelId: "C_MEMBER", limit: 1 });
+    expect(authorizations).toBe(slack.calls.length - before);
+    expect(first.nextCursor).toBeString();
+    const current = await getConnectionMetadata(
+      client.db,
+      workspace.workspaceId,
+      connection.id,
+      null,
+    );
+    if (!current) throw new Error("expected current Slack connection");
+    expect(
+      await setConnectionStatus(client.db, workspace.workspaceId, "revoked", null, {
+        id: current.id,
+        version: current.version,
+        subjectId: null,
+      }),
+    ).toBe(true);
+    const callCount = slack.calls.length;
+    await expect(
+      bot.listFiles({ channelId: "C_MEMBER", cursor: first.nextCursor! }),
+    ).rejects.toThrow(/reinstalled|authority changed/);
+    expect(slack.calls).toHaveLength(callCount);
+  });
+
+  test("rechecks authority before a private-file redirect leg", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const slack = fakeSlack();
+    const connected = await connectBot(workspace, slack.fetch);
+    const resolved = await resolveSlackBotConnectionForTool({
+      db: client.db,
+      grant: {
+        ...workspace,
+        subjectId: "subject-a",
+        permissions: ["connections:read"],
+        metadata: {},
+      },
+      sessionId: null,
+      requestedConnectionId: connected.body.connection.id,
+    });
+    let privateFileCalls = 0;
+    const redirectingFetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.hostname === "files.slack.com") {
+        privateFileCalls += 1;
+        const current = await getConnectionMetadata(
+          client.db,
+          workspace.workspaceId,
+          connected.body.connection.id,
+          null,
+        );
+        if (!current) throw new Error("expected current Slack connection");
+        expect(
+          await setConnectionStatus(client.db, workspace.workspaceId, "revoked", null, {
+            id: current.id,
+            version: current.version,
+            subjectId: null,
+          }),
+        ).toBe(true);
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location:
+              "https://files.slack.com/files-pri/T_OPEN_GENI-F_CANVAS/download/redirected.html",
+          },
+        });
+      }
+      return await slack.fetch(input, init);
+    }) as typeof globalThis.fetch;
+    const bot = createOpenGeniSlackBotClient(
+      { db: client.db, settings, slackFetch: redirectingFetch },
+      resolved,
+    );
+    await expect(bot.fileContent({ channelId: "C_MEMBER", fileId: "F_CANVAS" })).rejects.toThrow(
+      /reinstalled|authority changed/,
+    );
+    expect(privateFileCalls).toBe(1);
+  });
+
   test("rejects malformed, mixed, and non-advancing files.list paging", async () => {
     if (!available) return;
     const workspace = await freshWorkspace();
@@ -3297,7 +3400,30 @@ describe("OpenGeni Slack bot connection", () => {
         ).toBe(true);
       }
 
-      await expect(bot.deleteMessage(request)).resolves.toMatchObject({
+      let completionBot = bot;
+      let expectedAttempts = 3;
+      if (failure === "headers") {
+        const callsBeforeStaleRetry = slack.calls.length;
+        await expect(bot.deleteMessage(request)).rejects.toThrow(/authority changed/);
+        expect(slack.calls).toHaveLength(callsBeforeStaleRetry);
+        const refreshed = await resolveSlackBotConnectionForTool({
+          db: client.db,
+          grant: {
+            ...workspace,
+            subjectId: "subject-a",
+            permissions: ["connections:read"],
+            metadata: {},
+          },
+          sessionId: null,
+          requestedConnectionId: connected.body.connection.id,
+        });
+        completionBot = createOpenGeniSlackBotClient(
+          { db: client.db, settings, slackFetch: slack.fetch },
+          refreshed,
+        );
+        expectedAttempts = 4;
+      }
+      await expect(completionBot.deleteMessage(request)).resolves.toMatchObject({
         deleted: true,
       });
       expect(slack.calls.filter((call) => call.method === "chat.getPermalink")).toHaveLength(1);
@@ -3309,7 +3435,7 @@ describe("OpenGeni Slack bot connection", () => {
           connected.body.connection.id,
           operationId,
         ),
-      ).toMatchObject({ status: "completed", attemptCount: 3 });
+      ).toMatchObject({ status: "completed", attemptCount: expectedAttempts });
     }
   });
 


### PR DESCRIPTION
## Summary
- resolve and revalidate Slack bot credentials, installation version, and Slack team/bot binding immediately before every physical Web API request and each private-file origin/redirect fetch
- move Fiken credential resolution, refresh transport authorization, exact authority-generation/version fences, and target authorization inside the per-connection serialization boundary
- bind Fiken 401 reauthentication transitions to the exact credential version sent so late responses cannot overwrite reconnect or revocation truth
- order optional adapter preflights before the canonical credential callback, leaving the canonical physical-use callback as the final await before provider I/O
- add adversarial coverage for queued revoke/reconnect, delayed OAuth refresh versus revoke/reconnect, stale in-flight 401 versus reconnect/revoke, Slack continuation/redirect revocation, denied private-file preflight ordering, callback-to-fetch parity, and mutation no-blind-replay behavior

## Scope
This is provider-boundary hardening required by OPE-199. It does **not** by itself complete OPE-199. Shared accepted connection-use/physical-request resolver wiring remains a separate successor before OPE-199 can close.

No contracts, database schema/index/posture, migrations, scheduler, MCP registration, or docs are changed.

## Verification
- `bun test apps/api/test/fiken.test.ts apps/api/test/slack-bot.test.ts` — 88 pass
- `bunx tsc -p apps/api/tsconfig.json --noEmit`
- `bun run lint`
- `bunx oxfmt --check apps/api/src/integrations/fiken.ts apps/api/src/integrations/slack-bot.ts apps/api/test/fiken.test.ts apps/api/test/slack-bot.test.ts`
- `bun run check:public-hygiene`
- `bun test test/source-hygiene.test.ts scripts/check-public-repo-hygiene.test.ts` — 12 pass
- `bun scripts/check-workspace-billing-static.ts`
- `git diff --check`

Base: `0633ac10decc125bde671724c75ed3195294204c`
Head: `725293e9fa49e038569bf57ed742ffb966f713e8`
Tree: `e031b6252ed2cdc118d6523add3bfe21ecfe1a7a`
