### PR TITLE
Fix Browser/Desktop origin and Connected Machine preflight

### DIFF
--- a/apps/api/src/connected-machine-computer-access.ts
+++ b/apps/api/src/connected-machine-computer-access.ts
@@ -1,0 +1,33 @@
+export type ConnectedMachineComputerAccessState = {
+  hasDisplay: boolean;
+  desktopUnavailableReason: string | null;
+  allowScreenControl: boolean;
+};
+
+export type ConnectedMachineComputerAccessError = {
+  status: 403 | 409;
+  message: string;
+};
+
+/** Keep passive desktop viewing separate from input consent. */
+export function connectedMachineComputerAccessError(
+  state: ConnectedMachineComputerAccessState,
+  requiresControl: boolean,
+): ConnectedMachineComputerAccessError | null {
+  if (!state.hasDisplay) {
+    const reason = state.desktopUnavailableReason?.trim();
+    return {
+      status: 409,
+      message: reason
+        ? `Connected Machine desktop is unavailable. ${reason}`
+        : "Connected Machine desktop is unavailable because this machine has no capturable display.",
+    };
+  }
+  if (requiresControl && !state.allowScreenControl) {
+    return {
+      status: 403,
+      message: "Screen control is not enabled for this Connected Machine.",
+    };
+  }
+  return null;
+}

--- a/apps/api/src/http/cors.ts
+++ b/apps/api/src/http/cors.ts
@@ -1,3 +1,38 @@
+import { HTTPException } from "hono/http-exception";
+
 export function allowedCorsOrigin(pattern: string, origin: string): boolean {
   return new RegExp(`^(?:${pattern})$`).test(origin);
+}
+
+export function validateInteractionRequestOrigin(
+  value: string | undefined,
+  input: {
+    corsAllowOriginRegex: string;
+    publicBaseUrl?: string | undefined;
+    webBaseUrl?: string | undefined;
+  },
+): string | null {
+  if (!value) return null;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new HTTPException(400, { message: "invalid request origin" });
+  }
+  if (
+    url.origin === "null" ||
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    url.origin !== value
+  ) {
+    throw new HTTPException(400, { message: "invalid request origin" });
+  }
+  if (
+    allowedCorsOrigin(input.corsAllowOriginRegex, url.origin) ||
+    [input.publicBaseUrl, input.webBaseUrl].some((baseUrl) =>
+      baseUrl ? new URL(baseUrl).origin === url.origin : false,
+    )
+  ) {
+    return url.origin;
+  }
+  throw new HTTPException(403, { message: "request origin is not allowed" });
 }

--- a/apps/api/src/routes/browser-sessions.ts
+++ b/apps/api/src/routes/browser-sessions.ts
@@ -195,7 +195,7 @@ import {
   resolveProtectedAuthFieldValues,
 } from "../browser-auth-broker";
 import { managedNetworkRouteForPlacement } from "../browser-network-route";
-import { allowedCorsOrigin } from "../http/cors";
+import { validateInteractionRequestOrigin } from "../http/cors";
 import { interactionControlApiError } from "../http/interaction-control-error";
 import {
   observeAuthMutation,
@@ -302,7 +302,7 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
     const request = await parseJsonBody(context, CreateBrowserSessionRequest);
     const startedAtMs = performance.now();
     await authorizeSourceSession(deps, grant, request.sessionId, "session.control");
-    const origin = requestOrigin(context, deps.settings.corsAllowOriginRegex);
+    const origin = requestOrigin(context, deps.settings);
     const authority = browserAuthorityRoot(deps);
 
     try {
@@ -1683,7 +1683,7 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
         context,
         "stream:view",
       );
-      const origin = requestOrigin(context, deps.settings.corsAllowOriginRegex);
+      const origin = requestOrigin(context, deps.settings);
       const request = await parseJsonBody(context, BrowserSessionAttachmentRequest);
       const result = await withActiveBrowserController(
         context,
@@ -1978,7 +1978,7 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
       const browserSessionId = requireUuidParam(context, "browserSessionId");
       const request = await parseJsonBody(context, BrowserSessionLifecycleRequest);
       const startedAtMs = performance.now();
-      const origin = requestOrigin(context, deps.settings.corsAllowOriginRegex);
+      const origin = requestOrigin(context, deps.settings);
       try {
         const before = await getBrowserSessionControlRecord(deps.db, {
           accountId: grant.accountId,
@@ -2204,7 +2204,7 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
       const browserSessionId = requireUuidParam(context, "browserSessionId");
       const request = await parseJsonBody(context, BrowserSessionLifecycleRequest);
       const startedAtMs = performance.now();
-      const origin = requestOrigin(context, deps.settings.corsAllowOriginRegex);
+      const origin = requestOrigin(context, deps.settings);
       let restore: RestorePlacementBrowserStateInput | null = null;
       try {
         let before = await getBrowserSessionControlRecord(deps.db, {
@@ -2447,7 +2447,7 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
       const browserSessionId = requireUuidParam(context, "browserSessionId");
       const request = await parseJsonBody(context, BrowserSessionLifecycleRequest);
       const startedAtMs = performance.now();
-      const origin = requestOrigin(context, deps.settings.corsAllowOriginRegex);
+      const origin = requestOrigin(context, deps.settings);
       try {
         const before = await getBrowserSessionControlRecord(deps.db, {
           accountId: grant.accountId,
@@ -3092,7 +3092,7 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
             grant,
             record,
             placement,
-            requestOrigin(context, deps.settings.corsAllowOriginRegex),
+            requestOrigin(context, deps.settings),
           );
           await endCapturedBrowserController(client, browserSessionId, binding);
           await clearSuspendedBrowserSessionController(deps.db, {
@@ -3963,32 +3963,8 @@ function isUuid(value: unknown): value is string {
   );
 }
 
-function requestOrigin(context: Context, allowedPattern: string): string | null {
-  return validateBrowserRequestOrigin(context.req.header("origin"), allowedPattern);
-}
-
-export function validateBrowserRequestOrigin(
-  value: string | undefined,
-  allowedPattern: string,
-): string | null {
-  if (!value) return null;
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    throw new HTTPException(400, { message: "invalid request origin" });
-  }
-  if (
-    url.origin === "null" ||
-    (url.protocol !== "http:" && url.protocol !== "https:") ||
-    url.origin !== value
-  ) {
-    throw new HTTPException(400, { message: "invalid request origin" });
-  }
-  if (!allowedCorsOrigin(allowedPattern, url.origin)) {
-    throw new HTTPException(403, { message: "request origin is not allowed" });
-  }
-  return url.origin;
+function requestOrigin(context: Context, settings: ApiRouteDeps["settings"]): string | null {
+  return validateInteractionRequestOrigin(context.req.header("origin"), settings);
 }
 
 export function interactionActorForGrant(

--- a/apps/api/src/routes/computer-sessions.ts
+++ b/apps/api/src/routes/computer-sessions.ts
@@ -84,7 +84,7 @@ import {
 } from "../browser-controller-authority";
 import { withCachedController } from "../controller-data-plane";
 import { withInteractionHolderHeartbeat } from "../interaction-holder-heartbeat";
-import { allowedCorsOrigin } from "../http/cors";
+import { validateInteractionRequestOrigin } from "../http/cors";
 import { interactionControlApiError } from "../http/interaction-control-error";
 import { observeComputerActionResult, observeLifecycleResult } from "../interaction-metrics";
 import { withChannelA, withChannelARead, type ChannelAOperation } from "../sandbox/channel-a";
@@ -143,7 +143,7 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
     const request = await parseJsonBody(context, CreateComputerSessionRequest);
     const startedAtMs = performance.now();
     await authorizeSourceSession(deps, grant, request.sessionId, "session.control");
-    const origin = requestOrigin(context, deps.settings.corsAllowOriginRegex);
+    const origin = requestOrigin(context, deps.settings);
     const authority = controllerAuthorityRoot(deps);
 
     try {
@@ -454,7 +454,7 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
     "/v1/workspaces/:workspaceId/computer-sessions/:computerSessionId/attachments",
     async (context) => {
       const { workspaceId, grant, computerSessionId } = await routePreamble(context, "stream:view");
-      const origin = requestOrigin(context, deps.settings.corsAllowOriginRegex);
+      const origin = requestOrigin(context, deps.settings);
       const request = await parseJsonBody(context, ComputerSessionAttachmentRequest);
       const result = await withActiveComputerController(
         context,
@@ -628,7 +628,7 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
       const computerSessionId = requireUuidParam(context, "computerSessionId");
       const request = await parseJsonBody(context, ComputerSessionLifecycleRequest);
       const startedAtMs = performance.now();
-      const origin = requestOrigin(context, deps.settings.corsAllowOriginRegex);
+      const origin = requestOrigin(context, deps.settings);
       try {
         const before = await getComputerSessionControlRecord(deps.db, {
           accountId: grant.accountId,
@@ -1480,26 +1480,8 @@ function requireOpaqueParam(context: Context, name: string): string {
   return value;
 }
 
-function requestOrigin(context: Context, allowedPattern: string): string | null {
-  const value = context.req.header("origin");
-  if (!value) return null;
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    throw new HTTPException(400, { message: "invalid request origin" });
-  }
-  if (
-    url.origin === "null" ||
-    (url.protocol !== "http:" && url.protocol !== "https:") ||
-    url.origin !== value
-  ) {
-    throw new HTTPException(400, { message: "invalid request origin" });
-  }
-  if (!allowedCorsOrigin(allowedPattern, url.origin)) {
-    throw new HTTPException(403, { message: "request origin is not allowed" });
-  }
-  return url.origin;
+function requestOrigin(context: Context, settings: ApiRouteDeps["settings"]): string | null {
+  return validateInteractionRequestOrigin(context.req.header("origin"), settings);
 }
 
 function interactionActorForGrant(grant: AccessGrant): ReturnType<typeof InteractionActor.parse> {

--- a/apps/api/src/routes/computer-sessions.ts
+++ b/apps/api/src/routes/computer-sessions.ts
@@ -268,26 +268,27 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
               () => placement,
             );
           } catch (error) {
-            if (
+            const retryableRequestFailure =
+              error instanceof BrowserControlRequestError &&
+              error.retryable &&
+              error.error.code !== "machine_locked";
+            const outcomeUnknown =
+              error instanceof BrowserControlProtocolError ||
               error instanceof BrowserControlTransportError ||
-              (error instanceof BrowserControlRequestError &&
-                error.retryable &&
-                error.error.code !== "machine_locked") ||
-              isAbort(error)
-            ) {
-              throw error;
-            }
+              isAbort(error);
+            const rethrowAfterFailure =
+              error instanceof BrowserControlTransportError ||
+              retryableRequestFailure ||
+              isAbort(error);
             const failed = await failComputerSessionOperation(deps.db, {
               accountId: grant.accountId,
               workspaceId,
               operationId: request.operationId,
               computerSessionId: preparedSession.id,
-              ...(error instanceof BrowserControlProtocolError
-                ? { state: "outcome_unknown" as const }
-                : {}),
+              ...(outcomeUnknown ? { state: "outcome_unknown" as const } : {}),
               error: interactionFailure(error),
             });
-            if (interactionHeld && !(error instanceof BrowserControlProtocolError)) {
+            if (interactionHeld && !outcomeUnknown) {
               await releaseInteractionHolder(
                 grant,
                 workspaceId,
@@ -295,6 +296,7 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
                 placement.placement,
               ).catch(() => undefined);
             }
+            if (rethrowAfterFailure) throw error;
             return failed;
           }
           // These facts come from the physical adapter after its native helper

--- a/apps/api/src/routes/computer-sessions.ts
+++ b/apps/api/src/routes/computer-sessions.ts
@@ -37,6 +37,7 @@ import {
   getAttachedBrowserDevice,
   getComputerSessionControlRecord,
   getLiveEnrollmentConnection,
+  getSandbox,
   getSession,
   listComputerSessions,
   prepareComputerSessionCreate,
@@ -82,6 +83,7 @@ import {
   deriveComputerSessionControllerTokens,
   deriveComputerViewGrantToken,
 } from "../browser-controller-authority";
+import { connectedMachineComputerAccessError } from "../connected-machine-computer-access";
 import { withCachedController } from "../controller-data-plane";
 import { withInteractionHolderHeartbeat } from "../interaction-holder-heartbeat";
 import { validateInteractionRequestOrigin } from "../http/cors";
@@ -501,7 +503,11 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
             grantId,
             expiresAt,
           });
-          await client.createComputerViewGrant(reference, { grantId, token, expiresAt });
+          await client.createComputerViewGrant(reference, {
+            grantId,
+            token,
+            expiresAt,
+          });
           const relaySecret = placement.session.openComputerFrames
             ? resolveStreamTokenSecret(deps.settings)
             : null;
@@ -787,6 +793,9 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
       if (!enrollment || enrollment.status !== "active" || !enrollment.connectionInstanceId) {
         throw new ComputerSessionStateError("Attached browser machine is unavailable");
       }
+      if (operation !== "computer.end") {
+        assertConnectedMachineComputerAccess(enrollment, operation);
+      }
       assertPlacementInstance(expectedPlacementInstanceId, device.connectionGeneration);
       const built = await buildSelfhostedBackendSession({
         workspaceId: sourceSession.workspaceId,
@@ -857,6 +866,21 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
         }
 
         const resolved = await handle.routingSession.prime();
+        if (operation !== "computer.end" && resolved.kind === "selfhosted" && resolved.sandboxId) {
+          const sandbox = await getSandbox(deps.db, grant, resolved.sandboxId);
+          if (sandbox?.kind !== "selfhosted" || !sandbox.enrollmentId) {
+            throw new ComputerSessionStateError("Connected Machine placement is unavailable");
+          }
+          const enrollment = await getLiveEnrollmentConnection(
+            deps.db,
+            grant,
+            sandbox.enrollmentId,
+          );
+          if (!enrollment?.connectionInstanceId) {
+            throw new ComputerSessionStateError("Connected Machine is unavailable");
+          }
+          assertConnectedMachineComputerAccess(enrollment, operation);
+        }
         if (expectedPlacement?.kind === "connected_machine") {
           if (
             resolved.kind !== "selfhosted" ||
@@ -897,7 +921,10 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
         }
         if (resolved.kind === "selfhosted") {
           return await callback({
-            placement: { kind: "connected_machine", sandboxId: resolved.sandboxId },
+            placement: {
+              kind: "connected_machine",
+              sandboxId: resolved.sandboxId,
+            },
             placementInstanceId: resolved.providerInstanceId ?? resolved.sandboxId,
             session: resolved.session as unknown as BrowserControlPlacementSession,
             lease: null,
@@ -1297,7 +1324,11 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
   async function routePreamble(
     context: Context,
     permission: "sessions:read" | "sessions:control" | "stream:view",
-  ): Promise<{ workspaceId: string; grant: AccessGrant; computerSessionId: string }> {
+  ): Promise<{
+    workspaceId: string;
+    grant: AccessGrant;
+    computerSessionId: string;
+  }> {
     const workspaceId = context.req.param("workspaceId") ?? "";
     const grant = await requireAccessGrant(context, deps, workspaceId, permission);
     return {
@@ -1424,7 +1455,10 @@ async function authorizeSourceSession(
     });
   } catch (error) {
     if (error instanceof SessionAuthorizationDeniedError) {
-      throw new HTTPException(404, { message: "session not found", cause: error });
+      throw new HTTPException(404, {
+        message: "session not found",
+        cause: error,
+      });
     }
     if (error instanceof SessionAuthorizationUnavailableError) {
       throw new HTTPException(503, {
@@ -1507,6 +1541,25 @@ function assertPlacementInstance(expected: string | null, actual: string): void 
   }
 }
 
+function assertConnectedMachineComputerAccess(
+  enrollment: {
+    hasDisplay: boolean;
+    desktopUnavailableReason: string | null;
+    allowScreenControl: boolean;
+  },
+  operation: ChannelAOperation,
+): void {
+  const error = connectedMachineComputerAccessError(
+    enrollment,
+    operation === "computer.action" || operation === "computer.control",
+  );
+  if (!error) return;
+  if (error.status === 403) {
+    throw new HTTPException(403, { message: error.message });
+  }
+  throw new ComputerSessionStateError(error.message);
+}
+
 function isTerminalOperation(state: string): boolean {
   return state === "completed" || state === "failed" || state === "outcome_unknown";
 }
@@ -1527,7 +1580,11 @@ function interactionFailure(error: unknown) {
     error instanceof BrowserControlUnsupportedError ||
     error instanceof BrowserControlServerUnsupportedError
   ) {
-    return { code: "unsupported" as const, message: error.message, retryable: false };
+    return {
+      code: "unsupported" as const,
+      message: error.message,
+      retryable: false,
+    };
   }
   if (error instanceof BrowserControlServerError) {
     return {

--- a/apps/api/test/browser-session-routes.test.ts
+++ b/apps/api/test/browser-session-routes.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { readFile } from "node:fs/promises";
 import type { FileAsset } from "@opengeni/contracts";
 import { HTTPException } from "hono/http-exception";
+import { allowedCorsOrigin, validateInteractionRequestOrigin } from "../src/http/cors";
 import {
   browserFileAuthoritySubjectId,
   interactionActorForGrant,
   requireAuthorizedBrowserUploadFiles,
-  validateBrowserRequestOrigin,
 } from "../src/routes/browser-sessions";
 
 const routeUrl = new URL("../src/routes/browser-sessions.ts", import.meta.url);
@@ -99,7 +99,7 @@ describe("BrowserSession route discipline", () => {
       ),
       source.indexOf('"/v1/workspaces/:workspaceId/browser-sessions/:browserSessionId/heartbeat"'),
     );
-    expect(attachment).toContain("requestOrigin(context, deps.settings.corsAllowOriginRegex)");
+    expect(attachment).toContain("requestOrigin(context, deps.settings)");
     expect(attachment).toContain("client.addAllowedOrigins([origin])");
   });
 
@@ -422,15 +422,27 @@ describe("BrowserSession route discipline", () => {
     });
   });
 
-  test("distinguishes malformed and disallowed browser origins", () => {
-    expect(validateBrowserRequestOrigin(undefined, "https://app\\.opengeni\\.test")).toBeNull();
-    expect(
-      validateBrowserRequestOrigin("https://app.opengeni.test", "https://app\\.opengeni\\.test"),
-    ).toBe("https://app.opengeni.test");
-    expect(() =>
-      validateBrowserRequestOrigin("https://other.test", "https://app\\.opengeni\\.test"),
-    ).toThrow(expect.objectContaining({ status: 403 }));
-    expect(() => validateBrowserRequestOrigin("https://app.opengeni.test/path", ".*")).toThrow(
+  test("accepts first-party interaction origins without widening credentialed CORS", () => {
+    const input = {
+      corsAllowOriginRegex: "https://trusted-embed\\.test",
+      publicBaseUrl: "https://app.opengeni.test/",
+      webBaseUrl: "https://web.opengeni.test",
+    };
+    expect(validateInteractionRequestOrigin(undefined, input)).toBeNull();
+    expect(validateInteractionRequestOrigin("https://app.opengeni.test", input)).toBe(
+      "https://app.opengeni.test",
+    );
+    expect(allowedCorsOrigin(input.corsAllowOriginRegex, "https://app.opengeni.test")).toBe(false);
+    expect(validateInteractionRequestOrigin("https://web.opengeni.test", input)).toBe(
+      "https://web.opengeni.test",
+    );
+    expect(validateInteractionRequestOrigin("https://trusted-embed.test", input)).toBe(
+      "https://trusted-embed.test",
+    );
+    expect(() => validateInteractionRequestOrigin("https://other.test", input)).toThrow(
+      expect.objectContaining({ status: 403 }),
+    );
+    expect(() => validateInteractionRequestOrigin("https://app.opengeni.test/path", input)).toThrow(
       expect.objectContaining({ status: 400 }),
     );
   });

--- a/apps/api/test/computer-session-routes.test.ts
+++ b/apps/api/test/computer-session-routes.test.ts
@@ -36,7 +36,7 @@ describe("ComputerSession route discipline", () => {
         '"/v1/workspaces/:workspaceId/computer-sessions/:computerSessionId/heartbeat"',
       ),
     );
-    expect(attachment).toContain("requestOrigin(context, deps.settings.corsAllowOriginRegex)");
+    expect(attachment).toContain("requestOrigin(context, deps.settings)");
     expect(attachment).toContain("client.addAllowedOrigins([origin])");
     expect(attachment).toContain("sessionClient.listTargets()");
     expect(attachment).toContain('target.kind === "screen"');

--- a/apps/api/test/computer-session-routes.test.ts
+++ b/apps/api/test/computer-session-routes.test.ts
@@ -113,6 +113,12 @@ describe("ComputerSession route discipline", () => {
       create.indexOf("client.createComputerSession"),
     );
     expect(create).toContain('state: "outcome_unknown" as const');
+    expect(create).toContain("const rethrowAfterFailure =");
+    expect(create).toContain("error instanceof BrowserControlTransportError");
+    expect(create).toContain("isAbort(error)");
+    expect(create.indexOf("failComputerSessionOperation")).toBeLessThan(
+      create.indexOf("if (rethrowAfterFailure) throw error"),
+    );
 
     const end = source.slice(
       source.indexOf('"/v1/workspaces/:workspaceId/computer-sessions/:computerSessionId/end"'),

--- a/apps/api/test/computer-session-routes.test.ts
+++ b/apps/api/test/computer-session-routes.test.ts
@@ -94,8 +94,8 @@ describe("ComputerSession route discipline", () => {
     expect(placement).toContain("enrollment.connectionInstanceId");
     expect(placement).toContain("buildSelfhostedBackendSession({");
     expect(placement).toContain("new NatsControlRpc(");
-    expect(placement).toContain(
-      "assertPlacementInstance(expectedPlacementInstanceId, device.connectionGeneration)",
+    expect(placement).toMatch(
+      /assertPlacementInstance\(\s*expectedPlacementInstanceId,\s*device\.connectionGeneration,?\s*\)/u,
     );
     expect(placement).toContain("placementInstanceId: device.connectionGeneration");
   });

--- a/apps/api/test/connected-machine-computer-access.test.ts
+++ b/apps/api/test/connected-machine-computer-access.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { connectedMachineComputerAccessError } from "../src/connected-machine-computer-access";
+
+describe("connected-machine computer access", () => {
+  test("surfaces the agent's actionable display failure before provisioning", () => {
+    expect(
+      connectedMachineComputerAccessError(
+        {
+          hasDisplay: false,
+          desktopUnavailableReason: "Screen Recording permission not granted.",
+          allowScreenControl: false,
+        },
+        false,
+      ),
+    ).toEqual({
+      status: 409,
+      message: "Connected Machine desktop is unavailable. Screen Recording permission not granted.",
+    });
+  });
+
+  test("uses a safe fallback for a headless machine", () => {
+    expect(
+      connectedMachineComputerAccessError(
+        {
+          hasDisplay: false,
+          desktopUnavailableReason: null,
+          allowScreenControl: true,
+        },
+        false,
+      ),
+    ).toEqual({
+      status: 409,
+      message:
+        "Connected Machine desktop is unavailable because this machine has no capturable display.",
+    });
+  });
+
+  test("allows passive viewing but requires explicit consent for input", () => {
+    const state = {
+      hasDisplay: true,
+      desktopUnavailableReason: null,
+      allowScreenControl: false,
+    };
+    expect(connectedMachineComputerAccessError(state, false)).toBeNull();
+    expect(connectedMachineComputerAccessError(state, true)).toEqual({
+      status: 403,
+      message: "Screen control is not enabled for this Connected Machine.",
+    });
+  });
+
+  test("allows control when display and consent are present", () => {
+    expect(
+      connectedMachineComputerAccessError(
+        {
+          hasDisplay: true,
+          desktopUnavailableReason: null,
+          allowScreenControl: true,
+        },
+        true,
+      ),
+    ).toBeNull();
+  });
+});

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -461,6 +461,9 @@ without per-application origin registration. `OPENGENI_CORS_ALLOW_ORIGIN_REGEX`
 is only the allowlist for origins that may send browser cookies cross-origin.
 Keep that regex narrow; unlisted origins receive wildcard, non-credentialed
 CORS responses and therefore cannot use a managed-login session cookie.
+Browser and desktop controller requests also admit the configured
+`OPENGENI_PUBLIC_BASE_URL` and `OPENGENI_WEB_BASE_URL` origins directly; this
+does not grant those origins credentialed cross-origin responses.
 
 For Azure Blob, the blob-service CORS rule must allow origin `*`, method `PUT`
 (plus `GET`, `HEAD`, and `OPTIONS` for the complete file flow), and all request


### PR DESCRIPTION
## Problems
- BrowserSession and ComputerSession reused the credentialed-cookie CORS regex as an unconditional Origin allowlist, rejecting the configured first-party app origin with 403.
- ComputerSession ignored the connected machine display and screen-control capability state, attempted controller startup anyway, and reduced a known screen-capture permission failure to a generic 503.
- Retryable controller/transport failures and caller aborts were rethrown before durable failure settlement, leaving Desktop sessions stuck in starting and the UI spinning until the transition reaper ran.

## Fix
- admit configured public/web origins for interaction requests while retaining the explicit regex for additional trusted origins
- keep credentialed CORS behavior unchanged
- reject a no-display Connected Machine before sidecar provisioning with its actionable availability reason
- preserve read-only viewing without screen-control consent; require consent only for input operations
- leave end/cleanup available if the display later disappears
- settle failed starts as failed or outcome_unknown before preserving the original HTTP error

## Verification
- 84 interaction, machine-home, Hello-ingestion, and Machines route tests passed for the origin/preflight changes
- 31 focused BrowserSession, ComputerSession, connected-machine, and controller-data-plane tests pass after final settlement fix
- API TypeScript typecheck passes
- targeted oxlint, oxfmt, and diff checks pass
- first-party verification reproduced each failure before its fix and confirmed the corrected behavior afterward
