### PR TITLE
feat(memory): retire memory_save from the default agent surface (OPE-251 phase 1)

### DIFF
--- a/.changeset/retire-memory-save.md
+++ b/.changeset/retire-memory-save.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/contracts": minor
+"@opengeni/api-router": minor
+---
+
+Retire the legacy Memory V1 `memory_save` agent tool from the default retrieval-only surface: it is now compatibility-only, excluded from the default first-party tool catalog, and registered only when a workspace opts into the `legacy_standing` rollback mode. Agents save user-directed knowledge through `remember` and their own findings through task notes and governed promotion; `memory_search` and `memory_correct` remain.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -3210,7 +3210,7 @@ function registerMemoryTools(
     {
       description:
         promptMode === "retrieval_only"
-          ? `${MEMORY_SEARCH_TOOL_DESCRIPTION} Legacy preference-kind records are excluded here because structured preferences are the only behavioral authority.`
+          ? `${MEMORY_SEARCH_TOOL_DESCRIPTION} Legacy preference-kind records are excluded here because structured preferences are the only behavioral authority. To save something the user explicitly asked to keep, use \`remember\`; for your own findings use task notes and their promotion tools.`
           : MEMORY_SEARCH_TOOL_DESCRIPTION,
       inputSchema: {
         query: z4.string().min(1),
@@ -3234,111 +3234,114 @@ function registerMemoryTools(
       }),
   );
 
-  server.registerTool(
-    "memory_save",
-    {
-      description:
-        promptMode === "retrieval_only"
-          ? `${MEMORY_SAVE_TOOL_DESCRIPTION} A preference-kind save is retained only as a legacy observation and cannot become behavioral authority; use the structured preference proposal surface for behavioral guidance.`
-          : MEMORY_SAVE_TOOL_DESCRIPTION,
-      inputSchema: {
-        text: z4.string().min(1),
-        kind: MemoryKindSchema,
-        confidence: z4.number().min(0).max(1).optional(),
-        replaces_id: z4.string().min(1).optional(),
-        slack_publication: publicationInputSchema.optional(),
+  // Memory V1 writes are retired from the default retrieval-only surface:
+  // explicit user-directed knowledge goes through `remember`, agent findings
+  // through task notes and governed promotion. The legacy standing mode keeps
+  // the tool only as the rollback path.
+  if (promptMode === "legacy_standing") {
+    server.registerTool(
+      "memory_save",
+      {
+        description: MEMORY_SAVE_TOOL_DESCRIPTION,
+        inputSchema: {
+          text: z4.string().min(1),
+          kind: MemoryKindSchema,
+          confidence: z4.number().min(0).max(1).optional(),
+          replaces_id: z4.string().min(1).optional(),
+          slack_publication: publicationInputSchema.optional(),
+        },
       },
-    },
-    async ({ text, kind, confidence, replaces_id, slack_publication }) => {
-      const principal = slack_publication ? await publicationActor() : null;
-      const result = await saveWorkspaceMemoryWithSlackPublication(
-        deps.db,
-        {
-          accountId: grant.accountId,
-          workspaceId: grant.workspaceId,
-          sessionId,
-          text,
-          kind,
-          ...(confidence !== undefined ? { confidence } : {}),
-          ...(replaces_id ? { replacesId: replaces_id } : {}),
-          origin: "agent",
-        },
-        slack_publication
-          ? {
-              distribution: MemorySlackPublicationDistribution.parse(slack_publication),
-              actor: principal!.actor,
-              ownerLabel: principal!.ownerLabel,
-            }
-          : null,
-        deps.getDocumentServices().embedder,
-      );
-      await appendAndPublishEvents(deps.db, deps.bus, grant.workspaceId, sessionId, [
-        {
-          type: "memory.saved",
-          payload: {
-            memoryId: result.memory.id,
-            kind: result.memory.kind,
-            preview: memoryPreview(result.memory.text),
-            deduped: result.deduped,
-            ...(result.superseded ? { supersededMemoryId: result.superseded.id } : {}),
+      async ({ text, kind, confidence, replaces_id, slack_publication }) => {
+        const principal = slack_publication ? await publicationActor() : null;
+        const result = await saveWorkspaceMemoryWithSlackPublication(
+          deps.db,
+          {
+            accountId: grant.accountId,
+            workspaceId: grant.workspaceId,
+            sessionId,
+            text,
+            kind,
+            ...(confidence !== undefined ? { confidence } : {}),
+            ...(replaces_id ? { replacesId: replaces_id } : {}),
+            origin: "agent",
           },
-        },
-      ]);
-      const changed = !result.deduped || result.updated || result.superseded !== null;
-      const outcome =
-        result.updated || result.superseded !== null
-          ? "updated"
-          : result.deduped
-            ? "unchanged"
-            : "created";
-      return json(
-        mcpMutationReceipt({
-          operation: "memory_save",
-          committed: true,
-          outcome,
-          changed,
-          resource: {
-            type: "knowledge_memory",
-            id: result.memory.id,
-            state: result.memory.status,
+          slack_publication
+            ? {
+                distribution: MemorySlackPublicationDistribution.parse(slack_publication),
+                actor: principal!.actor,
+                ownerLabel: principal!.ownerLabel,
+              }
+            : null,
+          deps.getDocumentServices().embedder,
+        );
+        await appendAndPublishEvents(deps.db, deps.bus, grant.workspaceId, sessionId, [
+          {
+            type: "memory.saved",
+            payload: {
+              memoryId: result.memory.id,
+              kind: result.memory.kind,
+              preview: memoryPreview(result.memory.text),
+              deduped: result.deduped,
+              ...(result.superseded ? { supersededMemoryId: result.superseded.id } : {}),
+            },
           },
-          relatedResources: result.superseded
-            ? [
-                {
-                  type: "knowledge_memory",
-                  id: result.superseded.id,
-                  state: result.superseded.status,
-                },
-              ]
-            : undefined,
-          timestamp: result.memory.updatedAt,
-          idempotency: { status: "not_supported" },
-          warnings: !result.embedded
-            ? ["Memory committed without a vector embedding; keyword search remains available."]
-            : [],
-          facts: {
-            deduped: result.deduped,
-            dedupeReason: result.dedupeReason,
-            updatedInPlace: result.updated,
-            embedded: result.embedded,
-            slackPublicationDecision: result.slackPublication.decision?.eligible
-              ? "eligible"
-              : (result.slackPublication.decision?.reason ?? "not_requested"),
-            slackPublicationId:
-              result.slackPublication.enqueue?.kind === "enqueued" ||
-              result.slackPublication.enqueue?.kind === "replayed"
-                ? result.slackPublication.enqueue.publication.id
-                : null,
-            slackPublicationState:
-              result.slackPublication.enqueue?.kind === "enqueued" ||
-              result.slackPublication.enqueue?.kind === "replayed"
-                ? result.slackPublication.enqueue.publication.state
-                : null,
-          },
-        }),
-      );
-    },
-  );
+        ]);
+        const changed = !result.deduped || result.updated || result.superseded !== null;
+        const outcome =
+          result.updated || result.superseded !== null
+            ? "updated"
+            : result.deduped
+              ? "unchanged"
+              : "created";
+        return json(
+          mcpMutationReceipt({
+            operation: "memory_save",
+            committed: true,
+            outcome,
+            changed,
+            resource: {
+              type: "knowledge_memory",
+              id: result.memory.id,
+              state: result.memory.status,
+            },
+            relatedResources: result.superseded
+              ? [
+                  {
+                    type: "knowledge_memory",
+                    id: result.superseded.id,
+                    state: result.superseded.status,
+                  },
+                ]
+              : undefined,
+            timestamp: result.memory.updatedAt,
+            idempotency: { status: "not_supported" },
+            warnings: !result.embedded
+              ? ["Memory committed without a vector embedding; keyword search remains available."]
+              : [],
+            facts: {
+              deduped: result.deduped,
+              dedupeReason: result.dedupeReason,
+              updatedInPlace: result.updated,
+              embedded: result.embedded,
+              slackPublicationDecision: result.slackPublication.decision?.eligible
+                ? "eligible"
+                : (result.slackPublication.decision?.reason ?? "not_requested"),
+              slackPublicationId:
+                result.slackPublication.enqueue?.kind === "enqueued" ||
+                result.slackPublication.enqueue?.kind === "replayed"
+                  ? result.slackPublication.enqueue.publication.id
+                  : null,
+              slackPublicationState:
+                result.slackPublication.enqueue?.kind === "enqueued" ||
+                result.slackPublication.enqueue?.kind === "replayed"
+                  ? result.slackPublication.enqueue.publication.state
+                  : null,
+            },
+          }),
+        );
+      },
+    );
+  }
 
   server.registerTool(
     "memory_correct",

--- a/apps/api/test/company-brain-mcp-tool-policy.test.ts
+++ b/apps/api/test/company-brain-mcp-tool-policy.test.ts
@@ -74,9 +74,30 @@ describe("Company Brain first-party MCP policy", () => {
       expect(tools.find((tool) => tool.name === "memory_search")?.description).toContain(
         "structured preferences are the only behavioral authority",
       );
-      expect(tools.find((tool) => tool.name === "memory_save")?.description).toContain(
-        "cannot become behavioral authority",
+      // Memory V1 writes are retired from the default retrieval-only surface;
+      // explicit user-directed knowledge goes through `remember`.
+      expect(tools.find((tool) => tool.name === "memory_save")).toBeUndefined();
+      expect(tools.find((tool) => tool.name === "memory_search")?.description).toContain(
+        "use `remember`",
       );
+    } finally {
+      await Promise.all([client.close(), server.close()]);
+    }
+  });
+
+  test("legacy standing mode keeps memory_save only as the rollback surface", async () => {
+    const server = buildOpenGeniMcpServer(
+      deps(),
+      grant([...Permission.options], ["memory_search", "memory_save"]),
+      { workspaceMemoryEnabled: true, workspaceMemoryPromptMode: "legacy_standing" },
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "memory-legacy-description-test", version: "1" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      const names = (await client.listTools()).tools.map((tool) => tool.name).sort();
+      expect(names).toEqual(["memory_save", "memory_search"]);
     } finally {
       await Promise.all([client.close(), server.close()]);
     }

--- a/docs/hierarchical-memory.md
+++ b/docs/hierarchical-memory.md
@@ -150,8 +150,11 @@ model:
 
 - absent or `retrieval_only` (the default since migration 0271)
   removes the broad standing pinned/recency block from every agent prompt;
-- an explicit `legacy_standing` opt-out preserves the old working-set block and
-  agent search behavior for rollback;
+- an explicit `legacy_standing` opt-out preserves the old working-set block,
+  agent search behavior, and the legacy `memory_save` agent tool for rollback;
+  under the default mode `memory_save` is not registered and durable agent
+  writes go through `remember` and task-note promotion (`memory_search` and
+  `memory_correct` remain);
 - in `retrieval_only`, first-party agent `memory_search` excludes legacy
   `kind = preference` rows, while authorized human search, audit, correction,
   export, and the canonical rows remain unchanged;

--- a/docs/mcp-surfaces.md
+++ b/docs/mcp-surfaces.md
@@ -17,8 +17,9 @@ page exists so you pick the right one in one read.
 First-party OpenGeni MCP memory tools:
 
 - `memory_search` — search the workspace's shared long-lived memory with hybrid semantic + keyword retrieval.
-- `memory_save` — save one durable, future-useful workspace memory through the deterministic write gate.
+- `memory_save` — legacy Memory V1 write; registered only when the workspace opts into the `legacy_standing` rollback mode. Under the default retrieval-only mode agents use `remember` (explicit user-directed) or task notes plus `task_note_promote_*` (their own findings) instead.
 - `memory_correct` — archive or supersede an incorrect/outdated workspace memory by id.
+- `remember` / `remember_confirm` — explicit user-directed durable write with one bound human confirmation when the learning policy does not activate automatically (see [`company-brain-write-routing.md`](company-brain-write-routing.md)).
 
 These tools are session-scoped: they register only when the delegated bearer carries
 a worker-signed `sessionId` claim and the workspace's `settings.memoryEnabled`

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -983,6 +983,8 @@ const FIRST_PARTY_IN_PROCESS_TOOL_NAME_SET = new Set<FirstPartyMcpToolName>(
  */
 const FIRST_PARTY_COMPATIBILITY_ONLY_TOOL_NAMES = [
   "slack_bot_post_message",
+  // Memory V1 write: registered only under the legacy_standing rollback mode.
+  "memory_save",
 ] as const satisfies readonly FirstPartyMcpToolName[];
 
 const FIRST_PARTY_COMPATIBILITY_ONLY_TOOL_NAME_SET = new Set<FirstPartyMcpToolName>(
@@ -1015,6 +1017,10 @@ export const EDITABLE_ARTIFACT_MCP_CODEMODE_PATHS = {
  */
 export const DEFAULT_FIRST_PARTY_MCP_TOOLS = FIRST_PARTY_MCP_TOOL_NAMES.filter(
   (name) =>
+    // Memory V1 writes are retired from the default surface; `remember` and
+    // task-note promotion own durable agent writes. Explicit selection under
+    // the legacy_standing rollback mode still registers memory_save.
+    name !== "memory_save" &&
     !name.startsWith("social_") &&
     !name.startsWith("x_") &&
     !name.startsWith("reddit_") &&

--- a/packages/contracts/test/first-party-mcp-tools.test.ts
+++ b/packages/contracts/test/first-party-mcp-tools.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../src";
 
 const EXPLICIT_ONLY_CONNECTOR_TOOLS = [
+  "memory_save",
   "social_connections_list",
   "social_posts_recent",
   "social_daily_analysis_context",

--- a/test/e2e/codex-overview.e2e.ts
+++ b/test/e2e/codex-overview.e2e.ts
@@ -481,10 +481,15 @@ describe("Codex quota real browser/API/Postgres reset overview", () => {
     const expandAccount = async (name: string) => {
       const card = accountCard(name);
       const show = card.getByRole("button", { name: `Show details for ${name}` });
+      const hide = card.getByRole("button", { name: `Hide details for ${name}` });
+      // Wait for either toggle to render before deciding; an early
+      // `isVisible()` snapshot on a slow runner skipped the click and then
+      // waited forever for the collapsed card to expand itself.
+      await show.or(hide).first().waitFor();
       if (await show.isVisible()) {
         await show.click();
       }
-      await card.getByRole("button", { name: `Hide details for ${name}` }).waitFor();
+      await hide.waitFor();
     };
     await expandAccount("Detailed account");
     await accountCard("Detailed account")

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -7484,8 +7484,11 @@ describe("API component integration", () => {
       await prepared.close();
       prepared = null;
 
+      // This fixture exercises the legacy Memory V1 write surface, which is
+      // retained only under the explicit legacy_standing rollback mode.
       await updateWorkspaceSettings(dbClient.db, workspaceId, {
         memoryEnabled: true,
+        memoryPromptMode: "legacy_standing",
       });
 
       prepared = await prepareAgentTools(settings, [{ kind: "mcp", id: "opengeni" }], {


### PR DESCRIPTION
## Summary

Phase 1 of OPE-251 (Memory V1 retirement), now that `remember` (OPE-184) exists:

- `memory_save` becomes compatibility-only: removed from `DEFAULT_FIRST_PARTY_MCP_TOOLS` and the remote broad catalog (`FIRST_PARTY_COMPATIBILITY_ONLY_TOOL_NAMES`), and `registerMemoryTools` registers it only when the workspace opted into the `legacy_standing` rollback mode.
- Under the default retrieval-only mode agents get `memory_search` (description now points to `remember` for user-directed saves and task notes for their own findings) and `memory_correct`; durable writes go through `remember` / `remember_confirm` and `task_note_promote_*`.
- Historical `memory_save` tool calls still render/suppress correctly in the timeline (unchanged); REST/UI Memory surfaces, Slack publication of Memory decisions, and stored rows are untouched. No migration.
- Docs (`mcp-surfaces.md`, `hierarchical-memory.md`) and changeset.

Not in this PR (OPE-251 phase 2, later): removing the `legacy_standing` mode and the standing-injection SQL/prompt paths themselves, and retiring `memory_search`/`memory_correct` once Knowledge search covers the same records.

Linear: OPE-251

## Verification

- `apps/api/test/company-brain-mcp-tool-policy.test.ts`: retrieval-only registers no `memory_save` and points to `remember`; legacy_standing still registers `memory_save`; visibility/policy suites and contracts suites 441/441
- `test/integration/api.integration.ts` memory MCP + REST lifecycle tests 2/2 (legacy fixture now opts into `legacy_standing`)
- react timeline + worker suites unchanged (one pre-existing unrelated rig-image failure also fails on `main`)
- typecheck 31/31, oxlint, oxfmt, docs refs, public hygiene, `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)