### PR TITLE
Fix managed agent enrollment and bundle publication

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -418,6 +418,26 @@ jobs:
           rcodesign staple "$APP"
           rm -f "OpenGeni-Agent.app.zip"
           ditto -c -k --keepParent "$APP" "OpenGeni-Agent.app.zip"
+          # Validate the FINAL post-staple archive rather than trusting the
+          # staging tree. Missing interaction helpers make screen/browser control
+          # unusable and must fail publication before signatures are generated.
+          VERIFY_DIR="$(mktemp -d)"
+          trap 'rm -rf "$VERIFY_DIR"; rm -f /tmp/cert.p12 /tmp/asc.json' EXIT
+          ditto -x -k "OpenGeni-Agent.app.zip" "$VERIFY_DIR"
+          for executable in \
+            "Contents/MacOS/opengeni-agent" \
+            "Contents/Helpers/opengeni-browserd" \
+            "Contents/Helpers/agent-browser" \
+            "Contents/Helpers/opengeni-computer-native"
+          do
+            if [ ! -x "$VERIFY_DIR/$APP/$executable" ]; then
+              echo "::error::final macOS app archive is missing executable $executable" >&2
+              exit 1
+            fi
+          done
+          test -f "$VERIFY_DIR/$APP/Contents/Info.plist"
+          codesign --verify --deep --strict "$VERIFY_DIR/$APP"
+          rm -rf "$VERIFY_DIR"
           rm -f /tmp/cert.p12 /tmp/asc.json
 
       # ---- Windows Authenticode (POLISH, guarded). ----

--- a/agent/README.md
+++ b/agent/README.md
@@ -22,14 +22,14 @@ never `git clone`s a repo onto the machine.
 
 ## Crates
 
-| Crate | Role |
+| Crate                     | Role                                                                                                                         |
 |---|---|
-| `opengeni-agent-proto` | Generated wire-protocol types (Rust side of the codegen). |
-| `opengeni-agent` | The binary: `run`/`connect`/`connections`/`disconnect`/`service`/`update`/`uninstall`, plus the exact-attempt `codemode list|call` client; multi-deployment dial, RPC dispatch, supervisor. |
-| `opengeni-agent-platform` | Per-OS `Platform` + the `service` (systemd/launchd/SCM) renderer. |
-| `opengeni-agent-stream` | Relay-edge stream transport + pty/framebuffer pumps. |
-| `opengeni-agent-update` | Self-update: signed-manifest discovery, minisign+sha256 verify, atomic replace, rollback. |
-| `opengeni-relay` | The stateless stream-relay edge image. |
+| `opengeni-agent-proto`    | Generated wire-protocol types (Rust side of the codegen).                                                                    |
+| `opengeni-agent`          | The binary: `run`/`connect`/`connections`/`disconnect`/`service`/`update`/`uninstall`, plus the exact-attempt `codemode list | call` client; multi-deployment dial, RPC dispatch, supervisor. |
+| `opengeni-agent-platform` | Per-OS `Platform` + the `service` (systemd/launchd/SCM) renderer.                                                            |
+| `opengeni-agent-stream`   | Relay-edge stream transport + pty/framebuffer pumps.                                                                         |
+| `opengeni-agent-update`   | Self-update: signed-manifest discovery, minisign+sha256 verify, atomic replace, rollback.                                    |
+| `opengeni-relay`          | The stateless stream-relay edge image.                                                                                       |
 
 ## Distribution + self-update (M11)
 
@@ -43,7 +43,10 @@ The agent reaches a user's machine via one trusted line and keeps itself current
   requested workspace, and leaves the ordinary background service running. It
   contains **no secrets**. Read it before
   piping. `OPENGENI_INSTALL_BASE_URL` overrides the asset base (e.g. a local mock
-  dir or the direct GitHub-Releases URL). [`install/uninstall.sh`](install/uninstall.sh)
+  dir or the direct GitHub-Releases URL). A script served by a deployment also
+  defaults `OPENGENI_API_URL` to that deployment's public origin; the committed
+  managed-cloud fallback is `https://app.opengeni.ai`.
+  [`install/uninstall.sh`](install/uninstall.sh)
   removes it (`--purge` also deletes credentials + deactivates the enrollment).
 - **Signing key** — the minisign **public** key is committed at
   [`install/opengeni-agent-minisign.pub`](install/opengeni-agent-minisign.pub) and
@@ -128,6 +131,13 @@ the background-service definition when a release requires it): matching
 per-connection channels are used automatically, while mixed `stable`/`beta` links
 require an explicit `opengeni-agent update --channel …` choice instead of silently
 picking one.
+
+If the control plane rejects a saved enrollment bearer, refresh only that exact
+deployment/workspace connection with the force flag shown in the agent log:
+
+```sh
+opengeni-agent connect --force --api-url https://<deployment> --workspace-id <workspace-uuid>
+```
 
 ## Wire protocol — single source of truth
 

--- a/agent/crates/opengeni-agent/src/cli.rs
+++ b/agent/crates/opengeni-agent/src/cli.rs
@@ -27,8 +27,9 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// The control-plane API base URL used for enrollment (e.g.
-    /// `https://api.opengeni.ai`). Falls back to `$OPENGENI_API_URL`.
+    /// The control-plane API base URL used for enrollment (for managed OpenGeni,
+    /// `https://app.opengeni.ai`). Falls back to `$OPENGENI_API_URL`, then the
+    /// managed OpenGeni origin.
     #[arg(long, global = true, env = "OPENGENI_API_URL")]
     pub api_url: Option<String>,
 }
@@ -307,6 +308,11 @@ mod tests {
     fn cli_definition_is_valid() {
         // clap's own assert catches duplicate args / bad definitions at test time.
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn managed_cloud_default_is_the_reachable_app_origin() {
+        assert_eq!(crate::DEFAULT_API_URL, "https://app.opengeni.ai");
     }
 
     #[test]

--- a/agent/crates/opengeni-agent/src/enrollment.rs
+++ b/agent/crates/opengeni-agent/src/enrollment.rs
@@ -73,7 +73,7 @@ pub struct EnrollmentOffer {
 /// Inputs to a device-flow enrollment.
 #[derive(Debug, Clone)]
 pub struct EnrollmentRequest {
-    /// The control-plane API base URL (e.g. `https://api.opengeni.ai`).
+    /// The control-plane API base URL (e.g. `https://app.opengeni.ai`).
     pub api_base_url: String,
     /// The workspace (UUID) this machine enrolls into. REQUIRED by the API's
     /// device/start: the user who approves must hold a grant in THIS workspace, and

--- a/agent/crates/opengeni-agent/src/main.rs
+++ b/agent/crates/opengeni-agent/src/main.rs
@@ -74,7 +74,7 @@ use supervisor::{Supervisor, SupervisorLink};
 
 /// The default control-plane API base URL when neither `--api-url` nor
 /// `$OPENGENI_API_URL` is set.
-const DEFAULT_API_URL: &str = "https://api.opengeni.ai";
+pub(crate) const DEFAULT_API_URL: &str = "https://app.opengeni.ai";
 
 /// Local connection-file reconciliation cadence. This is a responsiveness
 /// setpoint, not a network or operation timeout.

--- a/agent/crates/opengeni-agent/src/supervisor.rs
+++ b/agent/crates/opengeni-agent/src/supervisor.rs
@@ -109,6 +109,32 @@ fn message_is_authentication_denial(message: &str) -> bool {
         || lower.contains("auth violation")
 }
 
+/// Build the exact refresh command for a rejected durable enrollment bearer.
+/// Persisted connection metadata predates strict URL validation, so unexpected
+/// shell metacharacters are replaced by a visible placeholder instead of being
+/// reflected into copy/pasteable operator guidance.
+fn rejected_bearer_reconnect_command(api_url: Option<&str>, workspace_id: &str) -> String {
+    fn safe_argument(value: &str) -> bool {
+        !value.is_empty()
+            && value.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b':' | b'/' | b'.' | b'_' | b'-')
+            })
+    }
+
+    let api_url = api_url.unwrap_or(crate::DEFAULT_API_URL);
+    let api_url = if safe_argument(api_url) {
+        api_url
+    } else {
+        "<api-url>"
+    };
+    let workspace_id = if safe_argument(workspace_id) {
+        workspace_id
+    } else {
+        "<workspace-id>"
+    };
+    format!("opengeni-agent connect --force --api-url {api_url} --workspace-id {workspace_id}")
+}
+
 /// NATS emits this server error when the intentionally short-lived user JWT
 /// reaches its expiry. The enrollment bearer remains valid and reconnecting
 /// mints a fresh user JWT, so this is planned credential rotation rather than
@@ -692,7 +718,15 @@ impl<P: Platform + 'static> Supervisor<P> {
                 // knows a re-enroll may be needed, then treat it as a (slow) retry —
                 // a re-enroll can rotate the bearer in place and the next attempt
                 // re-presents it.
-                error!(connection_id = %link.connection_id, error = %e, "control plane rejected the enrollment bearer; will keep retrying — reconnect if this persists");
+                let reconnect_command = rejected_bearer_reconnect_command(
+                    link.api_url.as_deref(),
+                    &link.creds.workspace_id,
+                );
+                error!(
+                    connection_id = %link.connection_id,
+                    error = %e,
+                    "control plane rejected the enrollment bearer; run `{reconnect_command}` to replace the rejected credential (the agent will keep retrying in the meantime)"
+                );
                 return ConnectionOutcome::Disconnected(e.to_string());
             }
             Err(e) => return ConnectionOutcome::Disconnected(e.to_string()),
@@ -1444,7 +1478,7 @@ impl<P: Platform + 'static> Supervisor<P> {
             // No bearer means the control plane never minted one (an enrollment from
             // before the credential plane was configured). Surface a clear, typed
             // disconnect rather than dial with an empty token the callout will deny.
-            return Err(SupervisorError::Connect(
+            return Err(SupervisorError::Authentication(
                 "no enrollment bearer; re-enroll to obtain a control-plane credential".to_string(),
             ));
         }
@@ -2076,6 +2110,28 @@ mod tests {
         // A plain transport drop is NOT an auth denial.
         assert!(!message_is_authentication_denial("connection refused"));
         assert!(!message_is_authentication_denial("broken pipe"));
+    }
+
+    #[test]
+    fn rejected_bearer_guidance_is_forceful_and_deployment_specific() {
+        assert_eq!(
+            rejected_bearer_reconnect_command(
+                Some("https://app.opengeni.ai"),
+                "9c7b6e0e-7e3b-4aa3-9530-f3d914c08736",
+            ),
+            "opengeni-agent connect --force --api-url https://app.opengeni.ai --workspace-id 9c7b6e0e-7e3b-4aa3-9530-f3d914c08736",
+        );
+        assert_eq!(
+            rejected_bearer_reconnect_command(None, "workspace-id"),
+            "opengeni-agent connect --force --api-url https://app.opengeni.ai --workspace-id workspace-id",
+        );
+        assert_eq!(
+            rejected_bearer_reconnect_command(
+                Some("https://safe.example\nmalicious"),
+                "workspace-id"
+            ),
+            "opengeni-agent connect --force --api-url <api-url> --workspace-id workspace-id",
+        );
     }
 
     #[test]

--- a/agent/crates/opengeni-agent/src/update.rs
+++ b/agent/crates/opengeni-agent/src/update.rs
@@ -23,6 +23,7 @@ use tracing::{info, warn};
 use crate::cli::UpdateArgs;
 use crate::config::{self, StoredConnection};
 use crate::enrollment::InstallIdentity;
+use crate::DEFAULT_API_URL;
 
 /// Public fallback used only before the machine has any enrolled deployment.
 const DEFAULT_BASE_URL: &str = "https://get.opengeni.ai";
@@ -137,7 +138,7 @@ fn persist_completed_update_receipt_at(
 /// Returns a human-facing error string on any fetch/verify/apply failure.
 pub fn run(args: &UpdateArgs) -> Result<(), String> {
     let legacy_api_url =
-        std::env::var("OPENGENI_API_URL").unwrap_or_else(|_| "https://api.opengeni.ai".to_string());
+        std::env::var("OPENGENI_API_URL").unwrap_or_else(|_| DEFAULT_API_URL.to_string());
     let connections = config::load_connections(&legacy_api_url)
         .map_err(|e| format!("could not load connections: {e}"))?;
 

--- a/agent/install/install.ps1
+++ b/agent/install/install.ps1
@@ -58,6 +58,10 @@ function Get-EnvOr($name, $default) {
 $OpengeniInstallDefaultBaseUrl = 'https://get.opengeni.ai'
 $BaseUrl = Get-EnvOr 'OPENGENI_INSTALL_BASE_URL' $OpengeniInstallDefaultBaseUrl
 $Version = Get-EnvOr 'OPENGENI_AGENT_VERSION' 'latest'
+# A served installer rewrites this stable marker to the deployment that served
+# it. Keep the caller override process-local and avoid mutating the parent shell.
+$OpengeniApiDefaultUrl = 'https://app.opengeni.ai'
+$script:ApiUrl = Get-EnvOr 'OPENGENI_API_URL' $OpengeniApiDefaultUrl
 $script:AgentWasUpgraded = $false
 
 function Log($msg)  { Write-Host "opengeni-install: $msg" }
@@ -339,12 +343,7 @@ function Complete-Install($bin) {
     Log "non-interactive connection (OPENGENI_ENROLL_TOKEN set)"
     # This upserts only the token's deployment/workspace connection; unrelated
     # OpenGeni connections remain configured and online.
-    $apiUrl = [Environment]::GetEnvironmentVariable('OPENGENI_API_URL')
-    if ([string]::IsNullOrEmpty($apiUrl)) {
-      & $bin connect --token $enrollToken --non-interactive
-    } else {
-      & $bin --api-url $apiUrl connect --token $enrollToken --non-interactive
-    }
+    & $bin --api-url $script:ApiUrl connect --token $enrollToken --non-interactive
     if ($LASTEXITCODE -ne 0) { Fail 7 "machine connection failed; background service was not changed" }
     Start-BackgroundAgent $bin
     return
@@ -352,12 +351,7 @@ function Complete-Install($bin) {
 
   $workspaceId = [Environment]::GetEnvironmentVariable('OPENGENI_WORKSPACE_ID')
   if (-not [string]::IsNullOrEmpty($workspaceId)) {
-    $apiUrl = [Environment]::GetEnvironmentVariable('OPENGENI_API_URL')
-    if ([string]::IsNullOrEmpty($apiUrl)) {
-      & $bin connect --workspace-id $workspaceId
-    } else {
-      & $bin --api-url $apiUrl connect --workspace-id $workspaceId
-    }
+    & $bin --api-url $script:ApiUrl connect --workspace-id $workspaceId
     if ($LASTEXITCODE -ne 0) { Fail 7 "machine connection failed; background service was not changed" }
     Start-BackgroundAgent $bin
     return

--- a/agent/install/install.ps1
+++ b/agent/install/install.ps1
@@ -357,9 +357,14 @@ function Complete-Install($bin) {
     return
   }
 
+  # The installer process's environment does not survive into the command the
+  # operator pastes later. Preserve this served deployment explicitly, including
+  # paths/origins containing PowerShell's single-quote character.
+  $quotedBin = ([string]$bin).Replace("'", "''")
+  $quotedApiUrl = ([string]$script:ApiUrl).Replace("'", "''")
   Write-Host "opengeni-agent installed at: $bin"
   Write-Host ""
-  Write-Host "Next: $bin connect; if (`$?) { $bin start }"
+  Write-Host "Next: & '$quotedBin' --api-url '$quotedApiUrl' connect; if (`$?) { & '$quotedBin' start }"
   Write-Host "Use '$bin run' only when you explicitly want foreground mode."
   Write-Host "Uninstall any time:  $bin uninstall"
 }

--- a/agent/install/install.sh
+++ b/agent/install/install.sh
@@ -45,9 +45,10 @@
 #                              background service (use `opengeni-agent run`).
 #   OPENGENI_API_URL           Control-plane API base URL for connection. Carried
 #                              into both non-interactive and device-flow `connect`
-#                              calls (the agent also reads it via clap). Set it
-#                              to target a specific deployment instead of the
-#                              api.opengeni.ai default.
+#                              calls (the agent also reads it via clap). A script
+#                              served by a deployment defaults this to that same
+#                              origin; the committed managed-cloud default is
+#                              https://app.opengeni.ai.
 #   OPENGENI_WORKSPACE_ID      The workspace (UUID) an INTERACTIVE device-flow
 #                              connection binds to (the approver must hold a grant
 #                              in it). Honored by the agent's `connect`/`run`
@@ -104,6 +105,12 @@ OPENGENI_MINISIGN_PUBKEY='RWSaqgF1EVFuci7hXvDJO7cBh2xf2k0XKhCpvl23aWKG+nMAGfZ6D2
 OPENGENI_INSTALL_DEFAULT_BASE_URL="https://get.opengeni.ai"
 BASE_URL="${OPENGENI_INSTALL_BASE_URL:-$OPENGENI_INSTALL_DEFAULT_BASE_URL}"
 VERSION="${OPENGENI_AGENT_VERSION:-latest}"
+# Default connection origin. A deployed control plane rewrites this marker next
+# to the asset marker above, so fetching its installer also pins enrollment to
+# that exact deployment without requiring a caller-supplied environment variable.
+# Keep the line shape stable for apps/api/src/routes/install.ts.
+OPENGENI_API_DEFAULT_URL="https://app.opengeni.ai"
+OPENGENI_API_URL="${OPENGENI_API_URL:-$OPENGENI_API_DEFAULT_URL}"
 
 # --- macOS app-bundle identity (constants) -----------------------------------
 # The bundle id is the STABLE anchor for macOS TCC (Screen Recording /
@@ -913,7 +920,7 @@ finish() {
   if [ -n "${OPENGENI_ENROLL_TOKEN:-}" ]; then
     log "non-interactive connection (OPENGENI_ENROLL_TOKEN set)"
     # Forward OPENGENI_API_URL explicitly so the exchange targets THIS deployment
-    # (not the api.opengeni.ai default) even when the agent's env-inherit path is
+    # even when the agent's env-inherit path is
     # ever bypassed. The agent also reads $OPENGENI_API_URL via clap, so the env
     # alone would suffice — this is belt-and-suspenders. The workspace is encoded
     # in the token, so no --workspace-id is needed on this path. A supplied token

--- a/apps/api/src/routes/enrollments.ts
+++ b/apps/api/src/routes/enrollments.ts
@@ -130,8 +130,10 @@ export function registerEnrollmentRoutes(app: Hono, deps: ApiRouteDeps): void {
         machineName: body.machineName ?? null,
         canOfferDisplay: body.canOfferDisplay,
         requestsScreenControl: body.requestsScreenControl,
-        // The approve page is served at the SAME origin as this request.
-        verificationOrigin: new URL(c.req.url).origin,
+        // Prefer the externally configured deployment origin. Behind a TLS-
+        // terminating proxy c.req.url can carry the internal http scheme, which
+        // must never leak into the device-flow command shown to the operator.
+        verificationOrigin: settings.publicBaseUrl ?? new URL(c.req.url).origin,
       },
     );
     return c.json(result, 201);

--- a/apps/api/src/routes/install.ts
+++ b/apps/api/src/routes/install.ts
@@ -44,9 +44,18 @@ const BAKED_DIR = new URL("baked/", INSTALL_DIR);
 // The static text artifacts served verbatim, with their content types. Each is
 // read once at first request and memoized (committed files; immutable per deploy).
 const TEXT_ASSETS: Record<string, { file: string; contentType: string }> = {
-  "/install.sh": { file: "install.sh", contentType: "text/x-shellscript; charset=utf-8" },
-  "/install.ps1": { file: "install.ps1", contentType: "text/plain; charset=utf-8" },
-  "/uninstall.sh": { file: "uninstall.sh", contentType: "text/x-shellscript; charset=utf-8" },
+  "/install.sh": {
+    file: "install.sh",
+    contentType: "text/x-shellscript; charset=utf-8",
+  },
+  "/install.ps1": {
+    file: "install.ps1",
+    contentType: "text/plain; charset=utf-8",
+  },
+  "/uninstall.sh": {
+    file: "uninstall.sh",
+    contentType: "text/x-shellscript; charset=utf-8",
+  },
   "/opengeni-agent-minisign.pub": {
     file: "opengeni-agent-minisign.pub",
     contentType: "text/plain; charset=utf-8",
@@ -73,26 +82,40 @@ async function loadAsset(file: string): Promise<string> {
 // `curl https://<this-host>/install.sh | sh` installs the exact agent that
 // matches the API it enrolls against, with NO dependency on a public CDN (which a
 // private/air-gapped deploy may not even resolve). When a public base URL is
-// configured we therefore rewrite each script's default-base-URL marker line to
-// that origin before serving. The user's OPENGENI_INSTALL_BASE_URL env override
-// still wins at run time (the scripts use `:-default`); only the built-in DEFAULT
-// changes. The marker lines are kept shape-stable in agent/install/install.{sh,ps1}.
-const DEFAULT_BASE_REWRITES: Record<string, (base: string) => { from: string; to: string }> = {
-  "install.sh": (base) => ({
-    from: 'OPENGENI_INSTALL_DEFAULT_BASE_URL="https://get.opengeni.ai"',
-    to: `OPENGENI_INSTALL_DEFAULT_BASE_URL="${base}"`,
-  }),
-  "install.ps1": (base) => ({
-    from: "$OpengeniInstallDefaultBaseUrl = 'https://get.opengeni.ai'",
-    to: `$OpengeniInstallDefaultBaseUrl = '${base}'`,
-  }),
+// configured we therefore rewrite each script's release-asset AND connection-API
+// default markers to that origin before serving. The user's
+// OPENGENI_INSTALL_BASE_URL / OPENGENI_API_URL overrides still win at run time;
+// only the built-in defaults change. The marker lines are kept shape-stable in
+// agent/install/install.{sh,ps1}.
+type DefaultRewrite = { from: string; to: string };
+
+const DEFAULT_BASE_REWRITES: Record<string, (base: string) => DefaultRewrite[]> = {
+  "install.sh": (base) => [
+    {
+      from: 'OPENGENI_INSTALL_DEFAULT_BASE_URL="https://get.opengeni.ai"',
+      to: `OPENGENI_INSTALL_DEFAULT_BASE_URL="${base}"`,
+    },
+    {
+      from: 'OPENGENI_API_DEFAULT_URL="https://app.opengeni.ai"',
+      to: `OPENGENI_API_DEFAULT_URL="${base}"`,
+    },
+  ],
+  "install.ps1": (base) => [
+    {
+      from: "$OpengeniInstallDefaultBaseUrl = 'https://get.opengeni.ai'",
+      to: `$OpengeniInstallDefaultBaseUrl = '${base}'`,
+    },
+    {
+      from: "$OpengeniApiDefaultUrl = 'https://app.opengeni.ai'",
+      to: `$OpengeniApiDefaultUrl = '${base}'`,
+    },
+  ],
 };
 
-// Rewrite a served script's default release-asset base URL to this deployment's
-// own public origin. A no-op when no public base URL is configured (the public
-// archive default stands), when the URL is not absolute http(s) (never serve a
-// script with a broken base), or when the file has no marker (script drift — fail
-// safe to serving it verbatim rather than crashing the install surface).
+// Rewrite a served script's default release-asset and connection-API URLs to this
+// deployment's own public origin. A no-op when no public base URL is configured,
+// when the URL is not absolute http(s), or when either marker is absent (script
+// drift — fail safe to serving it verbatim rather than splitting the two origins).
 function rewriteDefaultBaseUrl(
   file: string,
   body: string,
@@ -102,11 +125,11 @@ function rewriteDefaultBaseUrl(
     return body;
   }
   const base = publicBaseUrl.replace(/\/+$/, "");
-  const rule = DEFAULT_BASE_REWRITES[file]?.(base);
-  if (!rule || !body.includes(rule.from)) {
+  const rules = DEFAULT_BASE_REWRITES[file]?.(base);
+  if (!rules || rules.some((rule) => !body.includes(rule.from))) {
     return body;
   }
-  return body.replace(rule.from, rule.to);
+  return rules.reduce((rewritten, rule) => rewritten.replace(rule.from, rule.to), body);
 }
 
 // The content type for a baked release asset. The binary is an
@@ -189,7 +212,10 @@ export function registerInstallRoutes(app: Hono, deps: ApiRouteDeps): void {
     }
     // Not baked here → the GitHub Release is the source of truth (the public
     // archive + the documented install.sh fallback). 302 so the client refetches.
-    return new Response(null, { status: 302, headers: { location: redirectUrl } });
+    return new Response(null, {
+      status: 302,
+      headers: { location: redirectUrl },
+    });
   }
 
   // `latest` → the BAKED binary if present, else the operator-selected immutable
@@ -217,10 +243,14 @@ export function registerInstallRoutes(app: Hono, deps: ApiRouteDeps): void {
     app.get(`/agent/${channel}/:manifestAsset`, (c) => {
       const manifestAsset = c.req.param("manifestAsset");
       if (manifestAsset !== "manifest.json" && manifestAsset !== "manifest.json.minisig") {
-        throw new HTTPException(404, { message: "update manifest asset not found" });
+        throw new HTTPException(404, {
+          message: "update manifest asset not found",
+        });
       }
       if (!version) {
-        throw new HTTPException(404, { message: `${channel} agent channel is not configured` });
+        throw new HTTPException(404, {
+          message: `${channel} agent channel is not configured`,
+        });
       }
       return new Response(null, {
         status: 302,
@@ -240,7 +270,9 @@ export function registerInstallRoutes(app: Hono, deps: ApiRouteDeps): void {
     // `/agent/latest/<asset>` is handled by the more specific route above; any
     // other version segment must be the `v<ver>` shape.
     if (!VERSION_SEG.test(versionSeg) || !ASSET_NAME.test(asset)) {
-      throw new HTTPException(400, { message: "invalid version or asset name" });
+      throw new HTTPException(400, {
+        message: "invalid version or asset name",
+      });
     }
     return serveAsset(asset, `${releasesBase}/download/agent-${versionSeg}/${asset}`);
   });

--- a/apps/api/src/sandbox/enrollment.ts
+++ b/apps/api/src/sandbox/enrollment.ts
@@ -172,7 +172,7 @@ export async function startDeviceEnrollment(
     throw lastError instanceof Error ? lastError : new Error("failed to start device enrollment");
   }
 
-  const base = input.verificationOrigin.replace(/\/$/, "");
+  const base = input.verificationOrigin.replace(/\/+$/, "");
   const verificationUri = `${base}/device`;
   const verificationUriComplete = `${verificationUri}?user_code=${encodeURIComponent(request.userCode)}`;
   return {

--- a/apps/api/test/enrollment-routes.test.ts
+++ b/apps/api/test/enrollment-routes.test.ts
@@ -46,6 +46,7 @@ const settings = testSettings({
   selfhostedNatsUrl: "nats://control.example:4222",
   selfhostedRelayUrl: "wss://relay.example",
   agentUpdatePublicKey: "minisign-pub-key",
+  publicBaseUrl: "https://app.opengeni.example/",
 });
 
 function appFor(overrides: Partial<AppDependencies> = {}) {
@@ -70,7 +71,10 @@ function appFor(overrides: Partial<AppDependencies> = {}) {
   return createApp(deps);
 }
 
-async function freshWorkspace(): Promise<{ accountId: string; workspaceId: string }> {
+async function freshWorkspace(): Promise<{
+  accountId: string;
+  workspaceId: string;
+}> {
   const [a] = await admin<
     { id: string }[]
   >`insert into managed_accounts (name) values ('acct') returning id`;
@@ -159,7 +163,10 @@ describe("M5 device-flow happy path: start -> approve -> poll -> EnrollmentCrede
     };
     expect(start.deviceCode).toBeTruthy();
     expect(start.userCode).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/);
-    expect(start.verificationUri).toContain("/device");
+    expect(start.verificationUri).toBe("https://app.opengeni.example/device");
+    expect(start.verificationUriComplete).toBe(
+      `https://app.opengeni.example/device?user_code=${encodeURIComponent(start.userCode)}`,
+    );
     expect(start.intervalSeconds).toBeGreaterThan(0);
 
     // 2. POLL before approve → pending.
@@ -180,7 +187,10 @@ describe("M5 device-flow happy path: start -> approve -> poll -> EnrollmentCrede
           "content-type": "application/json",
           authorization: `Bearer ${await bearer(accountId, workspaceId, ["enrollments:manage"])}`,
         },
-        body: JSON.stringify({ userCode: start.userCode, allowScreenControl: true }),
+        body: JSON.stringify({
+          userCode: start.userCode,
+          allowScreenControl: true,
+        }),
       },
     );
     expect(approveRes.status).toBe(201);
@@ -266,7 +276,10 @@ describe("M5 device-flow happy path: start -> approve -> poll -> EnrollmentCrede
         "content-type": "application/json",
         authorization: `Bearer ${await bearer(accountId, workspaceId, ["enrollments:manage"])}`,
       },
-      body: JSON.stringify({ userCode: start.userCode, allowScreenControl: false }),
+      body: JSON.stringify({
+        userCode: start.userCode,
+        allowScreenControl: false,
+      }),
     });
     const poll = (await (
       await app.request("/v1/enrollments/device/poll", {
@@ -276,7 +289,10 @@ describe("M5 device-flow happy path: start -> approve -> poll -> EnrollmentCrede
       })
     ).json()) as {
       state: string;
-      credentials?: { consentedScreenControl: boolean; consentedWholeMachine: boolean };
+      credentials?: {
+        consentedScreenControl: boolean;
+        consentedWholeMachine: boolean;
+      };
     };
     expect(poll.state).toBe("authorized");
     expect(poll.credentials!.consentedWholeMachine).toBe(true);
@@ -292,7 +308,10 @@ describe("M5 authz: unauthenticated + cross-workspace approve are rejected", () 
     const res = await app.request(`/v1/workspaces/${workspaceId}/enrollments/device/approve`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ userCode: "AAAA-BBBB", allowScreenControl: false }),
+      body: JSON.stringify({
+        userCode: "AAAA-BBBB",
+        allowScreenControl: false,
+      }),
     });
     expect(res.status).toBe(401);
   }, 60_000);
@@ -307,7 +326,10 @@ describe("M5 authz: unauthenticated + cross-workspace approve are rejected", () 
         "content-type": "application/json",
         authorization: `Bearer ${await bearer(accountId, workspaceId, ["sessions:read"])}`,
       },
-      body: JSON.stringify({ userCode: "AAAA-BBBB", allowScreenControl: false }),
+      body: JSON.stringify({
+        userCode: "AAAA-BBBB",
+        allowScreenControl: false,
+      }),
     });
     expect(res.status).toBe(403);
   }, 60_000);
@@ -381,7 +403,10 @@ describe("M5 authz: unauthenticated + cross-workspace approve are rejected", () 
       await app.request("/v1/enrollments/device/start", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ publicKey: "ed25519:XWS", workspaceId: a.workspaceId }),
+        body: JSON.stringify({
+          publicKey: "ed25519:XWS",
+          workspaceId: a.workspaceId,
+        }),
       })
     ).json()) as { userCode: string };
     // A user authenticated to workspace B tries to approve A's user_code IN B.
@@ -391,7 +416,10 @@ describe("M5 authz: unauthenticated + cross-workspace approve are rejected", () 
         "content-type": "application/json",
         authorization: `Bearer ${await bearer(b.accountId, b.workspaceId, ["enrollments:manage"])}`,
       },
-      body: JSON.stringify({ userCode: start.userCode, allowScreenControl: false }),
+      body: JSON.stringify({
+        userCode: start.userCode,
+        allowScreenControl: false,
+      }),
     });
     // The user_code lookup is workspace-scoped → no pending request in B → 404.
     expect(resInB.status).toBe(404);
@@ -404,7 +432,10 @@ describe("M5 authz: unauthenticated + cross-workspace approve are rejected", () 
           "content-type": "application/json",
           authorization: `Bearer ${await bearer(b.accountId, b.workspaceId, ["enrollments:manage"])}`,
         },
-        body: JSON.stringify({ userCode: start.userCode, allowScreenControl: false }),
+        body: JSON.stringify({
+          userCode: start.userCode,
+          allowScreenControl: false,
+        }),
       },
     );
     expect(resCrossRoute.status).toBe(403);
@@ -422,14 +453,24 @@ describe("M5 list + revoke + idempotent re-enroll", () => {
       await app.request("/v1/enrollments/device/start", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ publicKey: "ed25519:LIST", machineName: "node-a", workspaceId }),
+        body: JSON.stringify({
+          publicKey: "ed25519:LIST",
+          machineName: "node-a",
+          workspaceId,
+        }),
       })
     ).json()) as { deviceCode: string; userCode: string };
     const approve = (await (
       await app.request(`/v1/workspaces/${workspaceId}/enrollments/device/approve`, {
         method: "POST",
-        headers: { "content-type": "application/json", authorization: manageBearer },
-        body: JSON.stringify({ userCode: start.userCode, allowScreenControl: false }),
+        headers: {
+          "content-type": "application/json",
+          authorization: manageBearer,
+        },
+        body: JSON.stringify({
+          userCode: start.userCode,
+          allowScreenControl: false,
+        }),
       })
     ).json()) as { enrollmentId: string };
 
@@ -498,14 +539,24 @@ describe("M5 list + revoke + idempotent re-enroll", () => {
       await app.request("/v1/enrollments/device/start", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ publicKey: "ed25519:LIST", machineName: "node-a", workspaceId }),
+        body: JSON.stringify({
+          publicKey: "ed25519:LIST",
+          machineName: "node-a",
+          workspaceId,
+        }),
       })
     ).json()) as { userCode: string };
     const approve2 = (await (
       await app.request(`/v1/workspaces/${workspaceId}/enrollments/device/approve`, {
         method: "POST",
-        headers: { "content-type": "application/json", authorization: manageBearer },
-        body: JSON.stringify({ userCode: start2.userCode, allowScreenControl: true }),
+        headers: {
+          "content-type": "application/json",
+          authorization: manageBearer,
+        },
+        body: JSON.stringify({
+          userCode: start2.userCode,
+          allowScreenControl: true,
+        }),
       })
     ).json()) as { enrollmentId: string };
     expect(approve2.enrollmentId).toBe(approve.enrollmentId); // same machine, re-activated
@@ -550,8 +601,14 @@ describe("M5 flag gate: selfhosted OFF -> routes 404", () => {
       `/v1/workspaces/${workspaceId}/enrollments/device/approve`,
       {
         method: "POST",
-        headers: { "content-type": "application/json", authorization: manageBearer },
-        body: JSON.stringify({ userCode: "AAAA-BBBB", allowScreenControl: false }),
+        headers: {
+          "content-type": "application/json",
+          authorization: manageBearer,
+        },
+        body: JSON.stringify({
+          userCode: "AAAA-BBBB",
+          allowScreenControl: false,
+        }),
       },
     );
     expect(approveRes.status).toBe(404);
@@ -559,19 +616,28 @@ describe("M5 flag gate: selfhosted OFF -> routes 404", () => {
     // The enrollment-UX additions are gated the same.
     const lookupRes = await app.request("/v1/enrollments/device/lookup", {
       method: "POST",
-      headers: { "content-type": "application/json", authorization: manageBearer },
+      headers: {
+        "content-type": "application/json",
+        authorization: manageBearer,
+      },
       body: JSON.stringify({ userCode: "AAAA-BBBB" }),
     });
     expect(lookupRes.status).toBe(404);
     const denyRes = await app.request(`/v1/workspaces/${workspaceId}/enrollments/device/deny`, {
       method: "POST",
-      headers: { "content-type": "application/json", authorization: manageBearer },
+      headers: {
+        "content-type": "application/json",
+        authorization: manageBearer,
+      },
       body: JSON.stringify({ userCode: "AAAA-BBBB" }),
     });
     expect(denyRes.status).toBe(404);
     const mintRes = await app.request(`/v1/workspaces/${workspaceId}/enrollments/token`, {
       method: "POST",
-      headers: { "content-type": "application/json", authorization: manageBearer },
+      headers: {
+        "content-type": "application/json",
+        authorization: manageBearer,
+      },
       body: JSON.stringify({ allowScreenControl: false }),
     });
     expect(mintRes.status).toBe(404);
@@ -620,7 +686,10 @@ describe("design-11 B.1 lookup: resolve a pending flow by user_code (no workspac
 
     const lookupRes = await app.request("/v1/enrollments/device/lookup", {
       method: "POST",
-      headers: { "content-type": "application/json", authorization: readBearer },
+      headers: {
+        "content-type": "application/json",
+        authorization: readBearer,
+      },
       body: JSON.stringify({ userCode: start.userCode }),
     });
     expect(lookupRes.status).toBe(200);
@@ -662,7 +731,10 @@ describe("design-11 B.1 lookup: resolve a pending flow by user_code (no workspac
     const readBearer = `Bearer ${await bearer(accountId, workspaceId, ["enrollments:read"])}`;
     const unknown = await app.request("/v1/enrollments/device/lookup", {
       method: "POST",
-      headers: { "content-type": "application/json", authorization: readBearer },
+      headers: {
+        "content-type": "application/json",
+        authorization: readBearer,
+      },
       body: JSON.stringify({ userCode: "ZZZZ-ZZZZ" }),
     });
     expect(unknown.status).toBe(404);
@@ -675,7 +747,10 @@ describe("design-11 B.1 lookup: resolve a pending flow by user_code (no workspac
       await app.request("/v1/enrollments/device/start", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ publicKey: "ed25519:NOAUTHLOOKUP", workspaceId }),
+        body: JSON.stringify({
+          publicKey: "ed25519:NOAUTHLOOKUP",
+          workspaceId,
+        }),
       })
     ).json()) as { userCode: string };
     const noAuth = await app.request("/v1/enrollments/device/lookup", {
@@ -695,7 +770,10 @@ describe("design-11 B.1 lookup: resolve a pending flow by user_code (no workspac
       await app.request("/v1/enrollments/device/start", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ publicKey: "ed25519:XWSLOOKUP", workspaceId: a.workspaceId }),
+        body: JSON.stringify({
+          publicKey: "ed25519:XWSLOOKUP",
+          workspaceId: a.workspaceId,
+        }),
       })
     ).json()) as { userCode: string };
     // The code resolves to workspace A; a user holding a grant only in B must get a
@@ -729,7 +807,10 @@ describe("design-11 B.2 deny: mark a pending flow denied", () => {
 
     const denyRes = await app.request(`/v1/workspaces/${workspaceId}/enrollments/device/deny`, {
       method: "POST",
-      headers: { "content-type": "application/json", authorization: manageBearer },
+      headers: {
+        "content-type": "application/json",
+        authorization: manageBearer,
+      },
       body: JSON.stringify({ userCode: start.userCode }),
     });
     expect(denyRes.status).toBe(200);
@@ -747,7 +828,10 @@ describe("design-11 B.2 deny: mark a pending flow denied", () => {
     // An unknown / already-terminal code is a no-op.
     const denyAgain = await app.request(`/v1/workspaces/${workspaceId}/enrollments/device/deny`, {
       method: "POST",
-      headers: { "content-type": "application/json", authorization: manageBearer },
+      headers: {
+        "content-type": "application/json",
+        authorization: manageBearer,
+      },
       body: JSON.stringify({ userCode: start.userCode }),
     });
     expect(((await denyAgain.json()) as { denied: boolean }).denied).toBe(false);
@@ -779,7 +863,10 @@ describe("design-11 A2 headless: mint enroll token -> exchange -> identical cred
     // 1. MINT (user-authenticated).
     const mintRes = await app.request(`/v1/workspaces/${workspaceId}/enrollments/token`, {
       method: "POST",
-      headers: { "content-type": "application/json", authorization: manageBearer },
+      headers: {
+        "content-type": "application/json",
+        authorization: manageBearer,
+      },
       body: JSON.stringify({ allowScreenControl: true }),
     });
     expect(mintRes.status).toBe(201);
@@ -842,7 +929,13 @@ describe("design-11 A2 headless: mint enroll token -> exchange -> identical cred
       await app.request(`/v1/workspaces/${workspaceId}/enrollments`, {
         headers: { authorization: manageBearer },
       })
-    ).json()) as { enrollments: { id: string; status: string; allowScreenControl: boolean }[] };
+    ).json()) as {
+      enrollments: {
+        id: string;
+        status: string;
+        allowScreenControl: boolean;
+      }[];
+    };
     expect(list.enrollments.length).toBe(1);
     expect(list.enrollments[0]!.id).toBe(creds.agentId);
     expect(list.enrollments[0]!.status).toBe("active");

--- a/apps/api/test/fleet-tools.test.ts
+++ b/apps/api/test/fleet-tools.test.ts
@@ -348,7 +348,10 @@ describe("M7 fleet service — list / attach / swap / run_on / provision", () =>
         and resource_id = ${machine.enrollmentId}
     `;
     const [sessionAuthority] = await admin<
-      Array<{ authorityEpoch: number; visibility: "user_private" | "workspace_shared" }>
+      Array<{
+        authorityEpoch: number;
+        visibility: "user_private" | "workspace_shared";
+      }>
     >`
       select authority_epoch as "authorityEpoch", visibility
       from sessions where id = ${session.id}
@@ -790,8 +793,34 @@ describe("M7 fleet service — list / attach / swap / run_on / provision", () =>
     const self = await provisionSandbox(services, ctx, { kind: "selfhosted" });
     expect(self.kind).toBe("selfhosted");
     if (self.kind === "selfhosted") {
-      expect(self.installCommandUnix).toContain("install.sh");
-      expect(self.verificationUri).toContain("/device");
+      expect(self.installCommandUnix).toBe(
+        `curl -fsSL ${settings.publicBaseUrl}/install.sh | ` +
+          `OPENGENI_API_URL=${settings.publicBaseUrl} ` +
+          `OPENGENI_WORKSPACE_ID=${ctx.workspaceId} sh`,
+      );
+      expect(self.installCommandWindows).toBe(
+        `$env:OPENGENI_API_URL='${settings.publicBaseUrl}'; ` +
+          `$env:OPENGENI_WORKSPACE_ID='${ctx.workspaceId}'; ` +
+          `irm ${settings.publicBaseUrl}/install.ps1 | iex`,
+      );
+      expect(self.instructions).toContain("do not run a second bare `connect`");
+      expect(self.verificationUri).toBe(`${settings.publicBaseUrl}/device`);
+    }
+
+    const managedDefault = await provisionSandbox(
+      {
+        ...services,
+        settings: { ...services.settings, publicBaseUrl: undefined },
+      },
+      ctx,
+      { kind: "selfhosted" },
+    );
+    expect(managedDefault.kind).toBe("selfhosted");
+    if (managedDefault.kind === "selfhosted") {
+      expect(managedDefault.installCommandUnix).toContain(
+        "OPENGENI_API_URL=https://app.opengeni.ai",
+      );
+      expect(managedDefault.verificationUri).toBe("https://app.opengeni.ai/device");
     }
 
     const modal = await provisionSandbox(services, ctx, {

--- a/apps/api/test/install.test.ts
+++ b/apps/api/test/install.test.ts
@@ -55,7 +55,9 @@ describe("get.<domain> install routes", () => {
     const res = await appFor(settings).request("/install.sh");
     const body = await res.text();
     expect(body).toContain('OPENGENI_INSTALL_DEFAULT_BASE_URL="https://cp.example.com"');
+    expect(body).toContain('OPENGENI_API_DEFAULT_URL="https://cp.example.com"');
     expect(body).not.toContain('OPENGENI_INSTALL_DEFAULT_BASE_URL="https://get.opengeni.ai"');
+    expect(body).not.toContain('OPENGENI_API_DEFAULT_URL="https://app.opengeni.ai"');
     // The user-facing override var name is untouched (operator can still repoint).
     expect(body).toContain("OPENGENI_INSTALL_BASE_URL");
   });
@@ -65,7 +67,9 @@ describe("get.<domain> install routes", () => {
     const res = await appFor(settings).request("/install.ps1");
     const body = await res.text();
     expect(body).toContain("$OpengeniInstallDefaultBaseUrl = 'https://cp.example.com'");
+    expect(body).toContain("$OpengeniApiDefaultUrl = 'https://cp.example.com'");
     expect(body).not.toContain("$OpengeniInstallDefaultBaseUrl = 'https://get.opengeni.ai'");
+    expect(body).not.toContain("$OpengeniApiDefaultUrl = 'https://app.opengeni.ai'");
   });
 
   test("GET /install.sh keeps the public-archive default when no public base URL is configured", async () => {
@@ -73,6 +77,9 @@ describe("get.<domain> install routes", () => {
     const res = await appFor(settings).request("/install.sh");
     const body = await res.text();
     expect(body).toContain('OPENGENI_INSTALL_DEFAULT_BASE_URL="https://get.opengeni.ai"');
+    expect(body).toContain('OPENGENI_API_DEFAULT_URL="https://app.opengeni.ai"');
+    const windows = await appFor(settings).request("/install.ps1");
+    expect(await windows.text()).toContain("$OpengeniApiDefaultUrl = 'https://app.opengeni.ai'");
   });
 
   test("GET /install.ps1 serves the Windows installer", async () => {

--- a/apps/api/test/install.test.ts
+++ b/apps/api/test/install.test.ts
@@ -90,6 +90,7 @@ describe("get.<domain> install routes", () => {
     expect(body).toContain("connect --token $enrollToken --non-interactive");
     expect(body).toContain("OPENGENI_ALLOW_DOWNGRADE");
     expect(body).toContain("Test-KeepNewerAgent");
+    expect(body).toContain("--api-url '$quotedApiUrl' connect");
   });
 
   test("GET /uninstall.sh serves the uninstall script", async () => {

--- a/apps/web/src/lib/deployment.ts
+++ b/apps/web/src/lib/deployment.ts
@@ -16,7 +16,7 @@ function originOf(baseUrl: string): string {
  * other OpenGeni instances.
  *
  * It ALWAYS bakes `OPENGENI_API_URL=${origin}` so the agent targets *this*
- * deployment rather than the hardcoded `api.opengeni.ai` default. Pass:
+ * deployment rather than relying on the managed-cloud fallback. Pass:
  *  - `{ workspaceId }` for the interactive (human device-approve) path — adds
  *    `OPENGENI_WORKSPACE_ID` so the user never hand-types the workspace UUID.
  *  - `{ enrollToken }` for the headless / fleet path — adds

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,13 +107,13 @@ hard per-process maximum with resource-based admission and HPA.
 The ordinary dependency services remain private `ClusterIP` services. Five
 one-port NodePort services are the complete private-edge surface:
 
-| NodePort | Destination | Purpose |
+| NodePort | Destination    | Purpose                                      |
 | --- | --- | --- |
-| `30080` | web | browser application |
-| `30081` | API | API, SSE, enrollment, and agent distribution |
-| `30222` | NATS websocket | enrolled-machine command/event transport |
-| `30443` | relay | live terminal/desktop byte streams |
-| `30900` | MinIO API | signed browser file transfer only |
+| `30080`  | web            | browser application                          |
+| `30081`  | API            | API, SSE, enrollment, and agent distribution |
+| `30222`  | NATS websocket | enrolled-machine command/event transport     |
+| `30443`  | relay          | live terminal/desktop byte streams           |
+| `30900`  | MinIO API      | signed browser file transfer only            |
 
 The NATS client/monitor ports and MinIO admin console are not exposed. On K3s,
 bind NodePorts to loopback with
@@ -126,8 +126,8 @@ websocket, relay, and MinIO API their own private TLS ports. Set
 `selfhosted.natsUrl`, `selfhosted.relayUrl`, and `minio.publicEndpoint` to those
 private URLs. Also set `OPENGENI_PUBLIC_BASE_URL` to the browser/API origin. The
 API uses it when serving the installer, so an enrolled machine downloads the
-agent version baked into this deployment rather than falling back to the public
-archive.
+agent version baked into this deployment and connects back to that same external
+HTTPS origin rather than falling back to either public default.
 
 For a tailnet-only deployment, `OPENGENI_AUTH_REQUIRED=false` and
 `OPENGENI_PRODUCT_ACCESS_MODE=local` mean there is no shared deployment access
@@ -1332,14 +1332,14 @@ poll task queues until that Temporal namespace exists.
 
 Use this boundary when building a production cluster:
 
-| Capability | Production source | OpenGeni wiring |
+| Capability    | Production source                                                                                                                 | OpenGeni wiring                                                                                            |
 | --- | --- | --- |
-| NATS | Existing endpoint or official NATS chart from `https://nats-io.github.io/k8s/helm/charts/` | `nats.enabled=false` plus `nats.url` or `OPENGENI_NATS_URL` |
-| Temporal | Temporal Cloud, existing endpoint, or official Temporal chart from `https://go.temporal.io/helm-charts` with external persistence | `temporal.enabled=false` plus `OPENGENI_TEMPORAL_HOST`; add `OPENGENI_TEMPORAL_API_KEY` for Temporal Cloud |
-| Postgres | Managed cloud Postgres, existing database, or CloudNativePG from `https://cloudnative-pg.github.io/charts` | `postgres.enabled=false` plus `OPENGENI_DATABASE_URL` |
-| Secrets | External Secrets Operator from `https://charts.external-secrets.io`, Vault, or cloud-native secret delivery | `externalSecret.enabled=true` or `secret.existingSecret` |
-| TLS | cert-manager, cloud load balancer certificates, or an existing ingress/TLS stack | `ingress.tls` and SSE-safe ingress annotations |
-| Observability | `deploy/observability` pinned Prometheus/Grafana wrapper, an existing compatible platform, or a managed OTLP/Prometheus backend | `/metrics`, OTLP env, `ServiceMonitor`, `PrometheusRule`, canonical dashboard labels |
+| NATS          | Existing endpoint or official NATS chart from `https://nats-io.github.io/k8s/helm/charts/`                                        | `nats.enabled=false` plus `nats.url` or `OPENGENI_NATS_URL`                                                |
+| Temporal      | Temporal Cloud, existing endpoint, or official Temporal chart from `https://go.temporal.io/helm-charts` with external persistence | `temporal.enabled=false` plus `OPENGENI_TEMPORAL_HOST`; add `OPENGENI_TEMPORAL_API_KEY` for Temporal Cloud |
+| Postgres      | Managed cloud Postgres, existing database, or CloudNativePG from `https://cloudnative-pg.github.io/charts`                        | `postgres.enabled=false` plus `OPENGENI_DATABASE_URL`                                                      |
+| Secrets       | External Secrets Operator from `https://charts.external-secrets.io`, Vault, or cloud-native secret delivery                       | `externalSecret.enabled=true` or `secret.existingSecret`                                                   |
+| TLS           | cert-manager, cloud load balancer certificates, or an existing ingress/TLS stack                                                  | `ingress.tls` and SSE-safe ingress annotations                                                             |
+| Observability | `deploy/observability` pinned Prometheus/Grafana wrapper, an existing compatible platform, or a managed OTLP/Prometheus backend   | `/metrics`, OTLP env, `ServiceMonitor`, `PrometheusRule`, canonical dashboard labels                       |
 
 The runtime secret must provide values such as:
 
@@ -1374,10 +1374,10 @@ OpenGeni's storage package intentionally exposes a small provider-neutral bounda
 
 Sandbox file mount support is also backend-specific:
 
-| Sandbox backend | S3-compatible | Azure Blob | AWS S3 | GCS |
+| Sandbox backend                     | S3-compatible          | Azure Blob                      | AWS S3                          | GCS                             |
 | --- | --- | --- | --- | --- |
-| Docker/local in-container sandboxes | rclone mount | rclone mount | signed download materialization | signed download materialization |
-| Modal | SDK cloud bucket mount | signed download materialization | signed download materialization | signed download materialization |
+| Docker/local in-container sandboxes | rclone mount           | rclone mount                    | signed download materialization | signed download materialization |
+| Modal                               | SDK cloud bucket mount | signed download materialization | signed download materialization | signed download materialization |
 
 ## Terraform Registry MCP Docs
 
@@ -1500,9 +1500,11 @@ install script and the per-deploy agent binary at auth-exempt paths
 (`/install.sh`, `/install.ps1`, `/uninstall.sh`, and `/agent/*`), so
 `curl -fsSL https://<host>/install.sh | sh` installs the exact agent build that
 matches the running control plane (the per-SHA binary baked into the API image),
-with no dependency on an external CDN. A public release archive is the fallback
-for other OS/arch assets and the self-update channel. Route these paths (and an
-optional `get.<domain>` host) to the `api` service in the ingress.
+and the served script defaults enrollment to that same public origin. A configured
+`OPENGENI_API_URL` still overrides it, so this works with no dependency on an
+external CDN. A public release archive is the fallback for other OS/arch assets
+and the self-update channel. Route these paths (and an optional `get.<domain>`
+host) to the `api` service in the ingress.
 
 `/agent/latest/<asset>` is a compatibility route backed by the immutable
 versioned release selected by `OPENGENI_AGENT_STABLE_VERSION` (default `0.1.14`).
@@ -1640,12 +1642,12 @@ bun run deployment:health-audit -- \
 The command always prints one bounded
 `opengeni.deployment-health-audit.v1` JSON document and uses stable exit codes:
 
-| Exit | Status | Meaning |
+| Exit | Status        | Meaning                                                                                                                     |
 | ---: | --- | --- |
-| `0` | `healthy` | Every requested read-only check passed. |
-| `1` | `degraded` | The deployment is serving, but recent restarts or warning events need observation. |
-| `2` | `incident` | A workload, endpoint, Helm release, PVC, or deployment-revision invariant failed. |
-| `3` | `audit_error` | The audit itself could not establish trustworthy evidence, for example because inventory JSON was unavailable or malformed. |
+|  `0` | `healthy`     | Every requested read-only check passed.                                                                                     |
+|  `1` | `degraded`    | The deployment is serving, but recent restarts or warning events need observation.                                          |
+|  `2` | `incident`    | A workload, endpoint, Helm release, PVC, or deployment-revision invariant failed.                                           |
+|  `3` | `audit_error` | The audit itself could not establish trustworthy evidence, for example because inventory JSON was unavailable or malformed. |
 
 `--upstream-revision` is context only. A coherent, intentionally pinned
 deployment behind upstream is healthy. `--expected-revision` is declarative
@@ -1883,18 +1885,18 @@ the exact literal `null` for supplied nullable values; omission means “not
 supplied” and blocks. Hashes are 64 lowercase hexadecimal characters and times
 are canonical ISO-8601 UTC strings.
 
-| Fence | Environment variables |
+| Fence                | Environment variables                                                                                                                                                                                                                                |
 | --- | --- |
-| Locator | `OPENGENI_RECOVERY_ACCOUNT_ID`, `OPENGENI_RECOVERY_WORKSPACE_ID`, `OPENGENI_RECOVERY_SESSION_ID`, `OPENGENI_RECOVERY_SANDBOX_GROUP_ID` |
-| Lease/loss | `OPENGENI_RECOVERY_LEASE_ID`, `OPENGENI_RECOVERY_BACKEND`, `OPENGENI_RECOVERY_CURRENT_EPOCH`, `OPENGENI_RECOVERY_LOST_EPOCH`, `OPENGENI_RECOVERY_LOST_INSTANCE_ID`, `OPENGENI_RECOVERY_REFCOUNT`, `OPENGENI_RECOVERY_PROVIDER_BACKEND` |
-| Route | `OPENGENI_RECOVERY_ROUTE_KIND`, `OPENGENI_RECOVERY_ROUTE_TARGET_ID`, `OPENGENI_RECOVERY_ROUTE_EPOCH` |
-| Workspace/restore | `OPENGENI_RECOVERY_WORKSPACE_GENERATION`, `OPENGENI_RECOVERY_WORKSPACE_STATUS`, `OPENGENI_RECOVERY_RESTORE_STATUS`, `OPENGENI_RECOVERY_RESTORE_FAILURE_CODE` |
-| Archive generation | `OPENGENI_RECOVERY_ARCHIVE_GENERATION`, `OPENGENI_RECOVERY_ARCHIVE_COMPLETE` |
-| Descriptor/object | `OPENGENI_RECOVERY_ARCHIVE_DESCRIPTOR_VERSION`, `OPENGENI_RECOVERY_ARCHIVE_REVISION`, `OPENGENI_RECOVERY_ARCHIVE_OBJECT_KIND`, `OPENGENI_RECOVERY_ARCHIVE_OBJECT_ID` |
-| Reference integrity | `OPENGENI_RECOVERY_ARCHIVE_DESCRIPTOR_REFERENCE_BYTES`, `OPENGENI_RECOVERY_ARCHIVE_DESCRIPTOR_REFERENCE_SHA256`, `OPENGENI_RECOVERY_ARCHIVE_REFERENCE_BYTES`, `OPENGENI_RECOVERY_ARCHIVE_REFERENCE_SHA256` |
-| Workspace tree | `OPENGENI_RECOVERY_ARCHIVE_TREE_FINGERPRINT_ALGORITHM`, `OPENGENI_RECOVERY_ARCHIVE_TREE_FINGERPRINT_SHA256`, `OPENGENI_RECOVERY_ARCHIVE_TREE_ENTRY_COUNT`, `OPENGENI_RECOVERY_ARCHIVE_TREE_FILE_COUNT`, `OPENGENI_RECOVERY_ARCHIVE_TOTAL_FILE_BYTES` |
-| Capture/verification | `OPENGENI_RECOVERY_ARCHIVE_CAPTURED_AT`, `OPENGENI_RECOVERY_ARCHIVE_VERIFICATION_STATE`, `OPENGENI_RECOVERY_ARCHIVE_VERIFIED_REVISION`, `OPENGENI_RECOVERY_ARCHIVE_VERIFIED_AT` |
-| External observation | `OPENGENI_RECOVERY_PROVIDER_OBJECT_KIND`, `OPENGENI_RECOVERY_PROVIDER_OBJECT_ID`, `OPENGENI_RECOVERY_PROVIDER_OBJECT_STATUS`, `OPENGENI_RECOVERY_PROVIDER_OBJECT_OBSERVED_AT` |
+| Locator              | `OPENGENI_RECOVERY_ACCOUNT_ID`, `OPENGENI_RECOVERY_WORKSPACE_ID`, `OPENGENI_RECOVERY_SESSION_ID`, `OPENGENI_RECOVERY_SANDBOX_GROUP_ID`                                                                                                               |
+| Lease/loss           | `OPENGENI_RECOVERY_LEASE_ID`, `OPENGENI_RECOVERY_BACKEND`, `OPENGENI_RECOVERY_CURRENT_EPOCH`, `OPENGENI_RECOVERY_LOST_EPOCH`, `OPENGENI_RECOVERY_LOST_INSTANCE_ID`, `OPENGENI_RECOVERY_REFCOUNT`, `OPENGENI_RECOVERY_PROVIDER_BACKEND`               |
+| Route                | `OPENGENI_RECOVERY_ROUTE_KIND`, `OPENGENI_RECOVERY_ROUTE_TARGET_ID`, `OPENGENI_RECOVERY_ROUTE_EPOCH`                                                                                                                                                 |
+| Workspace/restore    | `OPENGENI_RECOVERY_WORKSPACE_GENERATION`, `OPENGENI_RECOVERY_WORKSPACE_STATUS`, `OPENGENI_RECOVERY_RESTORE_STATUS`, `OPENGENI_RECOVERY_RESTORE_FAILURE_CODE`                                                                                         |
+| Archive generation   | `OPENGENI_RECOVERY_ARCHIVE_GENERATION`, `OPENGENI_RECOVERY_ARCHIVE_COMPLETE`                                                                                                                                                                         |
+| Descriptor/object    | `OPENGENI_RECOVERY_ARCHIVE_DESCRIPTOR_VERSION`, `OPENGENI_RECOVERY_ARCHIVE_REVISION`, `OPENGENI_RECOVERY_ARCHIVE_OBJECT_KIND`, `OPENGENI_RECOVERY_ARCHIVE_OBJECT_ID`                                                                                 |
+| Reference integrity  | `OPENGENI_RECOVERY_ARCHIVE_DESCRIPTOR_REFERENCE_BYTES`, `OPENGENI_RECOVERY_ARCHIVE_DESCRIPTOR_REFERENCE_SHA256`, `OPENGENI_RECOVERY_ARCHIVE_REFERENCE_BYTES`, `OPENGENI_RECOVERY_ARCHIVE_REFERENCE_SHA256`                                           |
+| Workspace tree       | `OPENGENI_RECOVERY_ARCHIVE_TREE_FINGERPRINT_ALGORITHM`, `OPENGENI_RECOVERY_ARCHIVE_TREE_FINGERPRINT_SHA256`, `OPENGENI_RECOVERY_ARCHIVE_TREE_ENTRY_COUNT`, `OPENGENI_RECOVERY_ARCHIVE_TREE_FILE_COUNT`, `OPENGENI_RECOVERY_ARCHIVE_TOTAL_FILE_BYTES` |
+| Capture/verification | `OPENGENI_RECOVERY_ARCHIVE_CAPTURED_AT`, `OPENGENI_RECOVERY_ARCHIVE_VERIFICATION_STATE`, `OPENGENI_RECOVERY_ARCHIVE_VERIFIED_REVISION`, `OPENGENI_RECOVERY_ARCHIVE_VERIFIED_AT`                                                                      |
+| External observation | `OPENGENI_RECOVERY_PROVIDER_OBJECT_KIND`, `OPENGENI_RECOVERY_PROVIDER_OBJECT_ID`, `OPENGENI_RECOVERY_PROVIDER_OBJECT_STATUS`, `OPENGENI_RECOVERY_PROVIDER_OBJECT_OBSERVED_AT`                                                                        |
 
 The descriptor's `archiveBytes`/`archiveSha256` describe the opaque provider
 reference payload. Preview independently decodes `workspaceArchive` and

--- a/packages/core/src/sandbox/fleet.ts
+++ b/packages/core/src/sandbox/fleet.ts
@@ -1033,17 +1033,19 @@ export async function provisionSandbox(
   input: { kind: "selfhosted" | "modal"; name?: string },
 ): Promise<ProvisionResult> {
   if (input.kind === "selfhosted") {
-    const base = (services.settings.publicBaseUrl ?? "https://get.opengeni.ai").replace(/\/+$/, "");
+    const base = (services.settings.publicBaseUrl ?? "https://app.opengeni.ai").replace(/\/+$/, "");
+    const unixEnvironment = `OPENGENI_API_URL=${base} OPENGENI_WORKSPACE_ID=${ctx.workspaceId}`;
+    const windowsEnvironment = `$env:OPENGENI_API_URL='${base}'; $env:OPENGENI_WORKSPACE_ID='${ctx.workspaceId}';`;
     return {
       kind: "selfhosted",
       instructions:
-        "Share these instructions with a human operator. They install the OpenGeni agent on the machine, run `opengeni-agent connect`, complete the device-flow at the verification URL (the loud whole-machine + screen-control consent), and the machine then appears here as an attachable selfhosted sandbox. Existing connections to other OpenGeni workspaces or deployments are preserved.",
+        "Share one of these deployment-specific commands with a human operator. It installs the OpenGeni agent and starts `opengeni-agent connect` for this exact deployment and workspace; do not run a second bare `connect`. Complete the device-flow at the verification URL (the loud whole-machine + screen-control consent), and the machine then appears here as an attachable selfhosted sandbox. Existing connections to other OpenGeni workspaces or deployments are preserved.",
       // Install from THIS control plane's origin (not a hardcoded public CDN): the
       // served install script is rewritten to pull the per-SHA agent baked into
       // this exact deployment (see apps/api/src/routes/install.ts), so a deployed
       // env is self-contained and a private/air-gapped one works with no public DNS.
-      installCommandUnix: `curl -fsSL ${base}/install.sh | sh`,
-      installCommandWindows: `irm ${base}/install.ps1 | iex`,
+      installCommandUnix: `curl -fsSL ${base}/install.sh | ${unixEnvironment} sh`,
+      installCommandWindows: `${windowsEnvironment} irm ${base}/install.ps1 | iex`,
       verificationUri: `${base}/device`,
       note: "Whole-machine access requires explicit human consent in the device-flow web page; the agent cannot self-consent.",
     };

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -951,6 +951,26 @@ describe("release image workflow contract", () => {
     expect(agentRelease).not.toContain(
       'rcodesign notary-submit --api-key-path /tmp/asc.json --wait "${{ matrix.asset }}"',
     );
+    const finalBundleArchive = agentRelease.lastIndexOf(
+      'ditto -c -k --keepParent "$APP" "OpenGeni-Agent.app.zip"',
+    );
+    const finalBundleValidation = agentRelease.indexOf(
+      'ditto -x -k "OpenGeni-Agent.app.zip" "$VERIFY_DIR"',
+      finalBundleArchive,
+    );
+    expect(finalBundleArchive).toBeGreaterThan(-1);
+    expect(finalBundleValidation).toBeGreaterThan(finalBundleArchive);
+    for (const executable of [
+      "Contents/MacOS/opengeni-agent",
+      "Contents/Helpers/opengeni-browserd",
+      "Contents/Helpers/agent-browser",
+      "Contents/Helpers/opengeni-computer-native",
+    ]) {
+      expect(agentRelease.slice(finalBundleValidation)).toContain(executable);
+    }
+    expect(agentRelease.slice(finalBundleValidation)).toContain(
+      'codesign --verify --deep --strict "$VERIFY_DIR/$APP"',
+    );
     expect(agentRelease).not.toContain("manifest publish is wired via");
     expect(agentRelease).not.toContain("gh release delete");
     expect(agentRelease).not.toContain("gh release create agent-latest");


### PR DESCRIPTION
## Summary

- use the reachable managed app origin as the native agent fallback and preserve each deployment origin through served POSIX/PowerShell installers
- return deployment- and workspace-specific Connected Machine setup commands, keep device approval URLs on the configured external HTTPS origin, and print an exact connect --force recovery command for rejected enrollment bearers
- reject incomplete final macOS app archives before signing/upload by verifying the agent, all three interaction helpers, Info.plist, and the extracted bundle signature

## Testing

- [x] bun run typecheck
- [ ] bun test (focused affected suites passed; full monorepo suite not run)
- [x] bun run lint
- [x] cargo test -p opengeni-agent (211 passed)
- [x] cargo clippy -p opengeni-agent --all-targets -- -D warnings
- [x] database-backed enrollment and fleet tool suites (29 passed)
- [x] installer routes, deployment helpers, and release workflow contracts (38 passed after rebase)
- [x] macOS bundle simulation (21 passed)

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] Rebased onto current origin/main before push and repeated the focused post-rebase checks.

## Notes

- The Unix signed-install smoke requires minisign, which is not installed in this local environment; CI owns that platform/tooling gate.
- The only remaining api.opengeni.ai strings are deliberate legacy-identity collision fixtures in config tests.