### PR TITLE
fix(learning): bind remember rules to the current instruction-policy baseline (OPE-184)

### DIFF
--- a/.changeset/remember-instruction-baseline.md
+++ b/.changeset/remember-instruction-baseline.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/core": patch
+"@opengeni/db": patch
+---
+
+`remember` with `lane: instruction_policy` now binds the draft to the target's current activation baseline (active head revision and CAS version, including a deactivated-to-null boundary) instead of assuming an empty workspace, so user-directed rules work in workspaces that already have an active policy.

--- a/.changeset/remember-instruction-baseline.md
+++ b/.changeset/remember-instruction-baseline.md
@@ -3,4 +3,4 @@
 "@opengeni/db": patch
 ---
 
-`remember` with `lane: instruction_policy` now binds the draft to the target's current activation baseline (active head revision and CAS version, including a deactivated-to-null boundary) instead of assuming an empty workspace, so user-directed rules work in workspaces that already have an active policy.
+`remember` with `lane: instruction_policy` now binds the draft to the target's current activation baseline (active head revision and CAS version, including a deactivated-to-null boundary) instead of assuming an empty workspace, so a user-directed rule can be proposed and confirmed in a workspace that already has an active policy.

--- a/packages/core/src/domain/remember.ts
+++ b/packages/core/src/domain/remember.ts
@@ -19,6 +19,7 @@ import {
   activateHumanConfirmedLearningDecision,
   confirmRememberKnowledgeClaim,
   createTaskNote,
+  getWorkspaceInstructionPolicyBaseline,
   getWorkspaceKnowledgeChangeProposalSummary,
   getWorkspaceKnowledgeClaimInitiatingHuman,
 } from "@opengeni/db";
@@ -50,6 +51,7 @@ export type RememberRouterOptions = {
   confirmKnowledgeClaim?: typeof confirmRememberKnowledgeClaim;
   proposalSummary?: typeof getWorkspaceKnowledgeChangeProposalSummary;
   claimInitiatingHuman?: typeof getWorkspaceKnowledgeClaimInitiatingHuman;
+  instructionPolicyBaseline?: typeof getWorkspaceInstructionPolicyBaseline;
   notifyActivation?: (input: {
     db: Database;
     receipt: GovernedLearningActivationReceipt;
@@ -83,6 +85,10 @@ function normalizedKeyFor(noteId: string): string {
 function promotionRequest(
   request: RememberRequest,
   noteId: string,
+  instructionBaseline: {
+    expectedCurrentRevisionId: string | null;
+    expectedActivationVersion: number;
+  },
 ): CompanyBrainGovernedWriteRequest {
   const common = {
     operationId: derivedRememberOperationId(request.operationId, "promotion"),
@@ -118,8 +124,8 @@ function promotionRequest(
         displayName: "User-directed rule",
         predicateKey: "remember.instruction",
         target: request.target,
-        expectedCurrentRevisionId: null,
-        expectedActivationVersion: 0,
+        expectedCurrentRevisionId: instructionBaseline.expectedCurrentRevisionId,
+        expectedActivationVersion: instructionBaseline.expectedActivationVersion,
       };
     case "knowledge":
       return {
@@ -197,6 +203,8 @@ export function createRememberRouter(options: RememberRouterOptions): {
   const proposalSummary = options.proposalSummary ?? getWorkspaceKnowledgeChangeProposalSummary;
   const claimInitiatingHuman =
     options.claimInitiatingHuman ?? getWorkspaceKnowledgeClaimInitiatingHuman;
+  const instructionPolicyBaseline =
+    options.instructionPolicyBaseline ?? getWorkspaceInstructionPolicyBaseline;
   const notifyActivation =
     options.notifyActivation ??
     (async ({ db, receipt, sessionId, attemptId }) =>
@@ -222,9 +230,18 @@ export function createRememberRouter(options: RememberRouterOptions): {
         text: request.content,
         expiresInDays: 30,
       });
+      // A user-directed rule must bind to the exact current activation
+      // baseline of its target; a workspace with an active head is the norm.
+      const instructionBaseline =
+        request.lane === "instruction_policy"
+          ? await instructionPolicyBaseline(options.db, {
+              workspaceId: attempt.workspaceId,
+              target: request.target,
+            })
+          : { expectedCurrentRevisionId: null, expectedActivationVersion: 0 };
       const route: CompanyBrainLearningPolicyRouteReceipt = await learningRouter.write({
         attempt,
-        request: promotionRequest(request, note.note.id),
+        request: promotionRequest(request, note.note.id, instructionBaseline),
       });
       const base = {
         operationId: request.operationId,

--- a/packages/core/test/remember-router-postgres.test.ts
+++ b/packages/core/test/remember-router-postgres.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
+  activateWorkspaceInstructionPolicyRevision,
   activateWorkspaceLearningPolicyRevision,
+  createWorkspaceInstructionPolicyDraft,
   createDb,
   createSession,
   createWorkspaceLearningPolicyRevision,
@@ -415,5 +417,47 @@ describe("remember router (real PostgreSQL)", () => {
         request: { ...confirmRequest, operationId: crypto.randomUUID() },
       }),
     ).rejects.toThrow();
+  }, 180_000);
+
+  test("a user-directed rule binds to the workspace's current active policy head", async () => {
+    if (!shared || !client) return;
+    const f = await fixture("suggest");
+    // Most real workspaces already have an active global policy.
+    const existing = await createWorkspaceInstructionPolicyDraft(client.db, {
+      accountId: f.grant.accountId,
+      workspaceId: f.grant.workspaceId,
+      kind: "policy",
+      scope: "global",
+      roleKey: null,
+      content: "Existing human policy.",
+      provenanceSource: "human",
+      provenanceSourceId: null,
+      supersedesRevisionId: null,
+      createdBySubjectId: f.ownerSubjectId,
+    });
+    await activateWorkspaceInstructionPolicyRevision(client.db, {
+      accountId: f.grant.accountId,
+      workspaceId: f.grant.workspaceId,
+      revisionId: existing.id,
+      expectedCurrentRevisionId: null,
+      expectedActivationVersion: 0,
+      actorSubjectId: f.ownerSubjectId,
+      reason: "Seed an active head.",
+    });
+    const router = createRememberRouter({ db: client.db });
+    const rule = await router.remember({
+      attempt: f.attempt,
+      request: {
+        operationId: crypto.randomUUID(),
+        lane: "instruction_policy",
+        scope: "workspace",
+        content: "Never push directly to main.",
+        reason: "Hard rule stated by the user.",
+      },
+    });
+    expect(rule.status).toBe("confirmation_required");
+    if (rule.status !== "confirmation_required") return;
+    expect(rule.proposalId).not.toBeNull();
+    expect(rule.humanInput.questions[0]!.prompt).toContain("mandatory workspace rule");
   }, 180_000);
 });

--- a/packages/core/test/remember-router-postgres.test.ts
+++ b/packages/core/test/remember-router-postgres.test.ts
@@ -7,6 +7,7 @@ import {
   createSession,
   createWorkspaceLearningPolicyRevision,
   ensureManagedAccessForUser,
+  getWorkspaceInstructionPolicyBaseline,
   listGovernedLearningActivationHistory,
   withSessionRlsActorContext,
   type DbClient,
@@ -459,5 +460,38 @@ describe("remember router (real PostgreSQL)", () => {
     if (rule.status !== "confirmation_required") return;
     expect(rule.proposalId).not.toBeNull();
     expect(rule.humanInput.questions[0]!.prompt).toContain("mandatory workspace rule");
+
+    // The bug this covers is "the rule cannot be saved", so drive it all the way
+    // through activation: the confirmation re-checks the stored baseline against
+    // the live head, and the head must advance past the seeded revision.
+    const humanInputRequestId = await answeredRememberInput(
+      f,
+      rule.proposalId!,
+      "Never push directly to main.",
+      ["save"],
+      "Save this as a mandatory workspace rule for everyone in this workspace?",
+    );
+    const confirmed = await router.confirm({
+      attempt: f.attempt,
+      request: {
+        target: "proposal",
+        operationId: crypto.randomUUID(),
+        proposalId: rule.proposalId!,
+        decisionReceiptId: rule.learning!.receiptId,
+        humanInputRequestId,
+      },
+    });
+    expect(confirmed.status).toBe("activated");
+    if (confirmed.status !== "activated") return;
+    expect(confirmed.activation).toMatchObject({
+      destination: "instruction_policy",
+      authorityKind: "human_confirmed",
+    });
+    const head = await getWorkspaceInstructionPolicyBaseline(client.db, {
+      workspaceId: f.grant.workspaceId,
+      target: { kind: "policy", scope: "global", roleKey: null },
+    });
+    expect(head.expectedActivationVersion).toBe(2);
+    expect(head.expectedCurrentRevisionId).not.toBe(existing.id);
   }, 180_000);
 });

--- a/packages/db/src/workspace-instruction-policies.ts
+++ b/packages/db/src/workspace-instruction-policies.ts
@@ -1832,3 +1832,40 @@ function snapshotEntryMatchesRevision(
     revision.roleKey === entry.roleKey
   );
 }
+
+/**
+ * Current activation baseline for one instruction-policy target: the active
+ * head's revision (or null) and the CAS activation version that a new draft
+ * proposal must expect. A deactivated-to-null target keeps its monotonic
+ * boundary, so the version is the max of the head and latest deactivation.
+ * Read-only under workspace RLS; used by `remember` to bind a user-directed
+ * rule to the exact current baseline instead of assuming an empty workspace.
+ */
+export async function getWorkspaceInstructionPolicyBaseline(
+  db: Database,
+  input: { workspaceId: string; target: WorkspaceInstructionPolicyTarget },
+): Promise<{ expectedCurrentRevisionId: string | null; expectedActivationVersion: number }> {
+  return await withWorkspaceRls(db, input.workspaceId, async (scoped) => {
+    const [head] = await scoped
+      .select()
+      .from(schema.workspaceInstructionPolicyHeads)
+      .where(and(...headTargetConditions(input.workspaceId, input.target)))
+      .limit(1);
+    const [deactivation] = await scoped
+      .select()
+      .from(schema.workspaceInstructionPolicyDeactivationEvents)
+      .where(and(...deactivationTargetConditions(input.workspaceId, input.target)))
+      .orderBy(
+        desc(schema.workspaceInstructionPolicyDeactivationEvents.activationVersion),
+        desc(schema.workspaceInstructionPolicyDeactivationEvents.id),
+      )
+      .limit(1);
+    return {
+      expectedCurrentRevisionId: head?.revisionId ?? null,
+      expectedActivationVersion: Math.max(
+        Number(head?.activationVersion ?? 0),
+        Number(deactivation?.activationVersion ?? 0),
+      ),
+    };
+  });
+}


### PR DESCRIPTION
## Problem

`remember` with `lane: instruction_policy` hard-coded its CAS baseline to "empty workspace":

```ts
expectedCurrentRevisionId: null,
expectedActivationVersion: 0,
```

Any workspace that already has an active instruction-policy head therefore fails the
compare-and-set, so a user-directed rule cannot be saved in a workspace that has ever
activated a policy - which is every workspace past onboarding.

## Fix

`getWorkspaceInstructionPolicyBaseline` (`@opengeni/db`) resolves the target's real
activation baseline under workspace RLS: the active head's revision id and activation
version, taking the max against the newest deactivation event so a
deactivated-to-null boundary still yields the correct next version rather than
silently rewinding to 0. `createRememberRouter` calls it for the `instruction_policy`
lane only and threads the result into the promotion request; the other two lanes are
byte-identical to before.

## Scope change during review (candidate revision 2)

An earlier revision of this branch also derived the default preference `stableKey`
from a content hash. **That hunk has been dropped as a confirmed regression.**

There is no revise path for a workspace preference.
`preference_registry_create_knowledge_proposal_for_attempt`
(`packages/db/drizzle/0261_preference_knowledge_proposal_actor_binding.sql:395-413`)
takes an advisory lock on the stable key and then raises for *any* pre-existing row
with that key, in any status:

```sql
IF FOUND THEN
  RAISE EXCEPTION 'workspace preference key is bound to another proposal' USING ERRCODE = '23505';
END IF;
```

So a content-derived key turns the most likely user behaviour - saying the same thing
twice - from "duplicate preference" into a hard tool failure, and one un-confirmed
`proposed` row permanently poisons that content string. Reproduced against a live
stack through the real first-party MCP server: pass 1 succeeds, pass 2 fails.
The accompanying API-test assertion `^remember\.[0-9a-f]{32}$` also matched the *old*
operationId-derived key, so it asserted nothing. Both are gone; `apps/api` is
untouched by this PR now.

Mutating the candidate is a source defect repair, which the moving-main admission
contract permits.

## Verification

- `packages/core/test/remember-router-postgres.test.ts` now drives the rule lane
  through `router.confirm` and asserts the head advances past the seeded revision -
  the previous version stopped at `confirmation_required` and never proved activation.
  Negative control: with the baseline fix reverted the file is 4 pass / 1 fail on
  exactly this case; with it, 5 pass / 38 expect() calls against real PostgreSQL.
- `bun run typecheck`, `bun run lint`, `bunx oxfmt --check`, `bun run check:docs-refs`,
  `bun run check:public-hygiene`, `git diff --check`: all clean.

## Known follow-ups (not this PR)

- A stale baseline still surfaces as a raw SQLSTATE 40001 with no rebaseline path and
  no typed `RememberError`.
- A failed promotion leaves an orphan 30-day task note.
- Separate production bug found while re-verifying: the
  `workspace_instruction_policy_onboarding_proposals` draft-validation trigger compares
  against `opengeni.subject_id`, but the real first-party MCP path sets that to the
  service subject `worker:first-party-mcp` and carries the frozen human in
  `opengeni.initiating_human_subject_id`. That fails every real agent rule call
  independently of this fix, and needs its own migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174Vs3Jf8BRcpyFRW6zEtwL
