### PR TITLE
fix(learning): accept the frozen initiating human in the rule draft trigger

### DIFF
--- a/packages/core/test/remember-router-service-subject-postgres.test.ts
+++ b/packages/core/test/remember-router-service-subject-postgres.test.ts
@@ -1,0 +1,175 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  activateWorkspaceLearningPolicyRevision,
+  createDb,
+  createSession,
+  createWorkspaceLearningPolicyRevision,
+  ensureManagedAccessForUser,
+  withSessionRlsActorContext,
+  type DbClient,
+} from "@opengeni/db";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import { createRememberRouter } from "../src/domain/remember";
+
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+let shared: SharedTestDatabase | null = null;
+let client: DbClient | null = null;
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("core-remember-service-subject");
+  if (!shared && requireRealDatabase) throw new Error("PostgreSQL is unavailable");
+  if (shared) client = createDb(shared.appUrl, { max: 8 });
+}, 180_000);
+
+afterAll(async () => {
+  await client?.close().catch(() => undefined);
+  await shared?.release();
+}, 180_000);
+
+async function fixture() {
+  if (!shared || !client) throw new Error("test database unavailable");
+  const suffix = crypto.randomUUID();
+  const ownerUserId = `remember-service-${suffix}`;
+  const ownerSubjectId = `user:${ownerUserId}`;
+  const access = await ensureManagedAccessForUser(client.db, {
+    userId: ownerUserId,
+    email: `${ownerUserId}@example.test`,
+    name: "Remember service-subject owner",
+  });
+  const grant = access.workspaceGrants[0]!;
+  const session = await withSessionRlsActorContext({ subjectId: ownerSubjectId }, async () =>
+    createSession(client!.db, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      initialMessage: "remember under a service subject",
+      resources: [],
+      metadata: {},
+      model: "test-model",
+      sandboxBackend: "none",
+      createdBy: { kind: "subject", subjectId: ownerSubjectId },
+      createdByContext: {},
+    }),
+  );
+  const revision = await createWorkspaceLearningPolicyRevision(client.db, {
+    accountId: grant.accountId,
+    workspaceId: grant.workspaceId,
+    workspaceMode: "suggest",
+    actorSubjectId: ownerSubjectId,
+    principalKind: "human_session",
+  });
+  await activateWorkspaceLearningPolicyRevision(client.db, {
+    accountId: grant.accountId,
+    workspaceId: grant.workspaceId,
+    revisionId: revision.id,
+    expectedCurrentRevisionId: null,
+    expectedActivationVersion: 0,
+    actorSubjectId: ownerSubjectId,
+    principalKind: "human_session",
+    reason: "Enable suggest learning in this fixture.",
+  });
+  const turnId = crypto.randomUUID();
+  const attemptId = crypto.randomUUID();
+  await shared.admin.begin(async (sql) => {
+    await sql`select set_config('opengeni.session_inference_claim', '1', true)`;
+    await sql`
+      insert into session_turns (
+        id, account_id, workspace_id, session_id, trigger_event_id,
+        temporal_workflow_id, status, source, position, prompt, model,
+        reasoning_effort, sandbox_backend, execution_generation,
+        initiator_kind, initiator_subject_id, initiator_context,
+        initiating_human_subject_id
+      ) values (
+        ${turnId}, ${grant.accountId}, ${grant.workspaceId}, ${session.id},
+        ${crypto.randomUUID()}, ${`remember-service-${turnId}`}, 'running', 'user', 1,
+        'remember', 'test-model', 'medium', 'none', 1, 'subject',
+        ${ownerSubjectId}, '{}'::jsonb, ${ownerSubjectId}
+      )
+    `;
+    await sql`update sessions set active_turn_id = ${turnId}, status = 'running'
+      where workspace_id = ${grant.workspaceId} and id = ${session.id}`;
+    await sql`update session_turns set active_attempt_id = ${attemptId}
+      where workspace_id = ${grant.workspaceId} and id = ${turnId}`;
+    await sql`
+      insert into session_turn_attempts (
+        id, account_id, workspace_id, session_id, turn_id, execution_generation,
+        state, temporal_workflow_id, temporal_workflow_run_id,
+        temporal_activity_id, verified_control_revision, mcp_approval_policies
+      ) values (
+        ${attemptId}, ${grant.accountId}, ${grant.workspaceId}, ${session.id},
+        ${turnId}, 1, 'running', ${`remember-service-${turnId}`}, ${`run-${attemptId}`},
+        ${`activity-${attemptId}`}, 0, '{}'::jsonb
+      )
+    `;
+  });
+  return {
+    ownerSubjectId,
+    attempt: {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      sessionId: session.id,
+      turnId,
+      attemptId,
+      executionGeneration: 1,
+    },
+  };
+}
+
+describe("remember router under the first-party MCP service subject (real PostgreSQL)", () => {
+  // The API executes agent-attempt MCP calls inside
+  // withSessionRlsActorContext({ subjectId: <service grant subject>,
+  // initiatingHumanSubjectId: <frozen human> }) (apps/api/src/app.ts,
+  // withAccessGrantSessionRlsContext). The onboarding-proposal trigger used to
+  // compare the proposal's frozen human against `opengeni.subject_id`, which on
+  // this path is the service subject, so every real rule call failed with
+  // SQLSTATE 23514 while the in-process router (no actor context) passed.
+  test("a user-directed rule proposes under the service subject + frozen human context", async () => {
+    if (!shared || !client) return;
+    const f = await fixture();
+    const router = createRememberRouter({ db: client.db });
+    const rule = await withSessionRlsActorContext(
+      {
+        subjectId: "worker:first-party-mcp",
+        initiatingHumanSubjectId: f.ownerSubjectId,
+      },
+      async () =>
+        router.remember({
+          attempt: f.attempt,
+          request: {
+            operationId: crypto.randomUUID(),
+            lane: "instruction_policy",
+            scope: "workspace",
+            content: "Never push directly to main.",
+            reason: "The user said this is a hard rule.",
+          },
+        }),
+    );
+    expect(rule.status).toBe("confirmation_required");
+    if (rule.status !== "confirmation_required") return;
+    expect(rule.proposalId).not.toBeNull();
+    expect(rule.humanInput.questions[0]!.prompt).toContain("mandatory workspace rule");
+  }, 180_000);
+
+  // A direct human writer (subject GUC = the human, no initiating-human GUC)
+  // must keep working after the trigger change falls back to
+  // `opengeni.subject_id`.
+  test("a user-directed rule still proposes under a direct human subject context", async () => {
+    if (!shared || !client) return;
+    const f = await fixture();
+    const router = createRememberRouter({ db: client.db });
+    const rule = await withSessionRlsActorContext({ subjectId: f.ownerSubjectId }, async () =>
+      router.remember({
+        attempt: f.attempt,
+        request: {
+          operationId: crypto.randomUUID(),
+          lane: "instruction_policy",
+          scope: "workspace",
+          content: "Always request a review before merging.",
+          reason: "The user said this is a hard rule.",
+        },
+      }),
+    );
+    expect(rule.status).toBe("confirmation_required");
+    if (rule.status !== "confirmation_required") return;
+    expect(rule.proposalId).not.toBeNull();
+  }, 180_000);
+});

--- a/packages/core/test/remember-router-service-subject-postgres.test.ts
+++ b/packages/core/test/remember-router-service-subject-postgres.test.ts
@@ -145,8 +145,28 @@ describe("remember router under the first-party MCP service subject (real Postgr
     );
     expect(rule.status).toBe("confirmation_required");
     if (rule.status !== "confirmation_required") return;
-    expect(rule.proposalId).not.toBeNull();
+    expect(typeof rule.proposalId).toBe("string");
     expect(rule.humanInput.questions[0]!.prompt).toContain("mandatory workspace rule");
+    // The durable artifacts must exist and bind the frozen human, not the
+    // service subject: the knowledge-change proposal carries the initiating
+    // human, and the onboarding-proposal row the trigger guards references it.
+    const [claimProposal] = await shared!.admin<
+      { status: string; initiating_human_subject_id: string; actor_kind: string }[]
+    >`
+      select status, initiating_human_subject_id, actor_kind
+      from knowledge_change_proposals
+      where id = ${rule.proposalId} and scope_workspace_id = ${f.attempt.workspaceId}
+    `;
+    expect(claimProposal).toMatchObject({
+      status: "proposed",
+      initiating_human_subject_id: f.ownerSubjectId,
+      actor_kind: "service",
+    });
+    const [onboarding] = await shared!.admin<{ status: string }[]>`
+      select status from workspace_instruction_policy_onboarding_proposals
+      where workspace_id = ${f.attempt.workspaceId} and source_id = ${rule.proposalId}
+    `;
+    expect(onboarding).toMatchObject({ status: "proposed" });
   }, 180_000);
 
   // A direct human writer (subject GUC = the human, no initiating-human GUC)
@@ -170,6 +190,6 @@ describe("remember router under the first-party MCP service subject (real Postgr
     );
     expect(rule.status).toBe("confirmation_required");
     if (rule.status !== "confirmation_required") return;
-    expect(rule.proposalId).not.toBeNull();
+    expect(typeof rule.proposalId).toBe("string");
   }, 180_000);
 });

--- a/packages/db/drizzle/0276_onboarding_proposal_initiating_human_guc.sql
+++ b/packages/db/drizzle/0276_onboarding_proposal_initiating_human_guc.sql
@@ -1,0 +1,198 @@
+-- deployment-mode: rolling
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+-- The onboarding-proposal draft validation trigger bound a knowledge-proposal
+-- draft to `current_setting('opengeni.subject_id')`. On the real first-party
+-- MCP path that GUC carries the *service* subject (`worker:first-party-mcp`)
+-- while the frozen human travels in `opengeni.initiating_human_subject_id`,
+-- so every real agent `remember` rule call failed the draft check with
+-- SQLSTATE 23514 regardless of workspace state. Compare against the canonical
+-- initiating-human GUC first (the pattern every authority migration since
+-- 0225 uses), falling back to `opengeni.subject_id` for direct human writers
+-- that never set the initiating-human GUC. The rest of the function body is
+-- byte-identical to migration 0269.
+
+CREATE OR REPLACE FUNCTION workspace_instruction_policy_validate_onboarding_proposal()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.baseline_revision_id IS NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM workspace_instruction_policy_heads head
+      WHERE head.account_id = NEW.account_id
+        AND head.workspace_id = NEW.workspace_id
+        AND head.kind = NEW.kind
+        AND head.scope = NEW.scope
+        AND head.role_key IS NOT DISTINCT FROM NEW.role_key
+    ) THEN
+      RAISE EXCEPTION 'instruction-policy proposal must capture the exact active head baseline'
+        USING ERRCODE = '23514';
+    END IF;
+    IF NOT (
+      (
+        NEW.baseline_activation_version = 0
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_instruction_policy_heads head
+          WHERE head.account_id = NEW.account_id
+            AND head.workspace_id = NEW.workspace_id
+            AND head.kind = NEW.kind
+            AND head.scope = NEW.scope
+            AND head.role_key IS NOT DISTINCT FROM NEW.role_key
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_instruction_policy_deactivation_events event
+          WHERE event.account_id = NEW.account_id
+            AND event.workspace_id = NEW.workspace_id
+            AND event.kind = NEW.kind
+            AND event.scope = NEW.scope
+            AND event.role_key IS NOT DISTINCT FROM NEW.role_key
+        )
+      ) OR (
+        NEW.baseline_activation_version > 0
+        AND NOT EXISTS (
+          SELECT 1 FROM workspace_instruction_policy_heads head
+          WHERE head.account_id = NEW.account_id
+            AND head.workspace_id = NEW.workspace_id
+            AND head.kind = NEW.kind
+            AND head.scope = NEW.scope
+            AND head.role_key IS NOT DISTINCT FROM NEW.role_key
+        )
+        AND EXISTS (
+          SELECT 1 FROM workspace_instruction_policy_deactivation_events event
+          WHERE event.account_id = NEW.account_id
+            AND event.workspace_id = NEW.workspace_id
+            AND event.kind = NEW.kind
+            AND event.scope = NEW.scope
+            AND event.role_key IS NOT DISTINCT FROM NEW.role_key
+            AND event.activation_version = NEW.baseline_activation_version
+            AND NOT EXISTS (
+              SELECT 1 FROM workspace_instruction_policy_deactivation_events newer
+              WHERE newer.account_id = event.account_id
+                AND newer.workspace_id = event.workspace_id
+                AND newer.kind = event.kind
+                AND newer.scope = event.scope
+                AND newer.role_key IS NOT DISTINCT FROM event.role_key
+                AND newer.activation_version > event.activation_version
+            )
+        )
+      )
+    ) THEN
+      RAISE EXCEPTION 'instruction-policy proposal must capture the exact inactive boundary'
+        USING ERRCODE = '23514';
+    END IF;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM workspace_instruction_policy_heads head
+    WHERE head.account_id = NEW.account_id
+      AND head.workspace_id = NEW.workspace_id
+      AND head.kind = NEW.kind
+      AND head.scope = NEW.scope
+      AND head.role_key IS NOT DISTINCT FROM NEW.role_key
+      AND head.revision_id = NEW.baseline_revision_id
+      AND head.revision = NEW.baseline_revision
+      AND head.content_hash = NEW.baseline_content_hash
+      AND head.activation_version = NEW.baseline_activation_version
+      AND head.activated_at = NEW.baseline_activated_at
+  ) THEN
+    RAISE EXCEPTION 'instruction-policy proposal must capture the exact active head baseline'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.baseline_revision_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM workspace_instruction_policy_revisions revision
+    WHERE revision.id = NEW.baseline_revision_id
+      AND revision.account_id = NEW.account_id
+      AND revision.workspace_id = NEW.workspace_id
+      AND revision.kind = NEW.kind
+      AND revision.scope = NEW.scope
+      AND revision.role_key IS NOT DISTINCT FROM NEW.role_key
+      AND revision.revision = NEW.baseline_revision
+      AND revision.content_hash = NEW.baseline_content_hash
+  ) THEN
+    RAISE EXCEPTION 'instruction-policy proposal has an invalid baseline revision'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM workspace_instruction_policy_revisions revision
+    WHERE revision.id = NEW.draft_revision_id
+      AND revision.operation_id = NEW.operation_id
+      AND revision.request_fingerprint = NEW.request_fingerprint
+      AND revision.account_id = NEW.account_id
+      AND revision.workspace_id = NEW.workspace_id
+      AND revision.kind = NEW.kind
+      AND revision.scope = NEW.scope
+      AND revision.role_key IS NOT DISTINCT FROM NEW.role_key
+      AND revision.revision = NEW.draft_revision
+      AND revision.content_hash = NEW.draft_content_hash
+      AND revision.supersedes_revision_id IS NOT DISTINCT FROM NEW.baseline_revision_id
+      AND revision.created_by_subject_id = NEW.created_by_subject_id
+      AND (
+        (
+          revision.provenance_source = 'onboarding'
+          AND revision.provenance_source_id = NEW.id::text
+        ) OR (
+          revision.provenance_source = 'knowledge_proposal'
+          AND revision.provenance_source_id = NEW.source_id
+          AND NEW.source_version = NEW.draft_content_hash
+          AND EXISTS (
+            SELECT 1 FROM knowledge_change_proposals proposal
+            WHERE proposal.id::text = NEW.source_id
+              AND proposal.account_id = NEW.account_id
+              AND proposal.scope_kind = 'workspace'
+              AND proposal.scope_workspace_id = NEW.workspace_id
+              AND proposal.scope_subject_id IS NULL
+              AND proposal.target_kind = 'instruction_policy'
+              AND proposal.target_scope = NEW.scope
+              AND proposal.target_key IS NOT DISTINCT FROM CASE
+                WHEN NEW.scope = 'role' THEN NEW.role_key
+                ELSE NULL
+              END
+              AND proposal.content_hash = NEW.source_version
+              AND proposal.actor_kind = 'service'
+              AND proposal.actor_subject_id = NEW.created_by_subject_id
+              AND proposal.initiating_human_subject_id = COALESCE(
+                NULLIF(current_setting('opengeni.initiating_human_subject_id', true), ''),
+                current_setting('opengeni.subject_id', true)
+              )
+              AND proposal.claim_id IS NOT NULL
+              AND proposal.evidence_id IS NOT NULL
+              AND proposal.status = 'proposed'
+          )
+        )
+      )
+  ) THEN
+    RAISE EXCEPTION 'instruction-policy proposal must identify its exact inactive draft'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM workspace_instruction_policy_heads head
+    WHERE head.account_id = NEW.account_id
+      AND head.workspace_id = NEW.workspace_id
+      AND head.revision_id = NEW.draft_revision_id
+  ) OR EXISTS (
+    SELECT 1 FROM workspace_instruction_policy_activation_events event
+    WHERE event.account_id = NEW.account_id
+      AND event.workspace_id = NEW.workspace_id
+      AND event.new_revision_id = NEW.draft_revision_id
+  ) THEN
+    RAISE EXCEPTION 'instruction-policy proposal must identify a never-activated inactive draft'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+
+-- CREATE OR REPLACE drops the previously pinned search_path; re-pin it exactly
+-- as migration 0269's hardening block did.
+DO $onboarding_proposal_initiating_human_hardening$
+DECLARE
+  target_schema text := current_schema();
+BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.workspace_instruction_policy_validate_onboarding_proposal() '
+      || 'SET search_path = pg_catalog, %I, pg_temp', target_schema, target_schema
+  );
+END
+$onboarding_proposal_initiating_human_hardening$;

--- a/packages/db/test/migration-0276-onboarding-proposal-initiating-human.test.ts
+++ b/packages/db/test/migration-0276-onboarding-proposal-initiating-human.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
+const migrationUrl = new URL(
+  "../drizzle/0276_onboarding_proposal_initiating_human_guc.sql",
+  import.meta.url,
+);
+
+describe("migration 0276 onboarding-proposal initiating-human GUC", () => {
+  test("compares the frozen human against the canonical initiating-human GUC", async () => {
+    const sql = await readFile(migrationUrl, "utf8");
+    expect(sql.startsWith("-- deployment-mode: rolling\n")).toBe(true);
+    expect(sql).toContain(
+      "CREATE OR REPLACE FUNCTION workspace_instruction_policy_validate_onboarding_proposal()",
+    );
+    // The one predicate change: initiating-human GUC first, subject-id GUC as
+    // the fallback for direct human writers that never set the former.
+    expect(sql).toContain("AND proposal.initiating_human_subject_id = COALESCE(");
+    expect(sql).toContain(
+      "NULLIF(current_setting('opengeni.initiating_human_subject_id', true), '')",
+    );
+    expect(sql).toContain("current_setting('opengeni.subject_id', true)");
+    // The rest of the 0269 trigger body must survive intact.
+    expect(sql).toContain("instruction-policy proposal must identify its exact inactive draft");
+    expect(sql).toContain(
+      "instruction-policy proposal must identify a never-activated inactive draft",
+    );
+    expect(sql).toContain(
+      "instruction-policy proposal must capture the exact active head baseline",
+    );
+    expect(sql).toContain("instruction-policy proposal must capture the exact inactive boundary");
+    // CREATE OR REPLACE drops the pinned search_path; the hardening block
+    // must re-pin it.
+    expect(sql).toContain(
+      "ALTER FUNCTION %I.workspace_instruction_policy_validate_onboarding_proposal()",
+    );
+    expect(sql).toContain("SET search_path = pg_catalog, %I, pg_temp");
+  });
+});

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -521,6 +521,11 @@ describe("release schema contract", () => {
         : "d54a4ac5b800e0c0578e7fce7d1a09cea1dbed87d3b13bf722549fea0bdc031e";
     };
     const releaseSchemaContractHash = (includesActivation: boolean): string | null => {
+      if (migrations.has("0276_onboarding_proposal_initiating_human_guc.sql")) {
+        return includesActivation
+          ? "cfd46060ee901c35fa53774626f677f107bd2342823c335089b250f77eab55a6"
+          : "a9abad7b40bd8a11b39480a08d5bd7def06e90c720736a284c99ee12ea36c000";
+      }
       if (migrations.has("0275_scheduled_connection_authority.sql")) {
         return includesActivation
           ? "a96c53aab72ae5c409bf3a3cfdb5eee8b4aae573495920bbc7053ea556ddcc5e"
@@ -948,7 +953,8 @@ describe("release schema contract", () => {
         (migrations.has("0272_human_confirmed_learning_activation.sql") ? 1 : 0) +
         (migrations.has("0274_human_confirmed_knowledge_review.sql") ? 1 : 0) +
         (migrations.has("0263_organization_membership_lifecycle.sql") ? 1 : 0) +
-        (migrations.has("0275_scheduled_connection_authority.sql") ? 1 : 0),
+        (migrations.has("0275_scheduled_connection_authority.sql") ? 1 : 0) +
+        (migrations.has("0276_onboarding_proposal_initiating_human_guc.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(releaseSchemaContractHash(false) ?? currentMainContractHash);
     const latestCompatibleMigration = [
@@ -983,45 +989,53 @@ describe("release schema contract", () => {
       "0217_capability_definition_delete_authority.sql",
     ].find((path) => migrations.has(path));
     expect(contract.latestMigration).toBe(
-      migrations.has("0275_scheduled_connection_authority.sql")
-        ? "0275_scheduled_connection_authority.sql"
-        : migrations.has("0274_human_confirmed_knowledge_review.sql")
-          ? "0274_human_confirmed_knowledge_review.sql"
-          : migrations.has("0272_human_confirmed_learning_activation.sql")
-            ? "0272_human_confirmed_learning_activation.sql"
-            : migrations.has("0271_company_brain_retrieval_only_default.sql")
-              ? "0271_company_brain_retrieval_only_default.sql"
-              : migrations.has("0270_governed_learning_history_inspection.sql")
-                ? "0270_governed_learning_history_inspection.sql"
-                : migrations.has("0269_governed_learning_activation_controller.sql")
-                  ? "0269_governed_learning_activation_controller.sql"
-                  : migrations.has("0268_governed_learning_decision_receipts.sql")
-                    ? "0268_governed_learning_decision_receipts.sql"
-                    : migrations.has("0266_company_brain_context_receipt_inspection.sql")
-                      ? "0266_company_brain_context_receipt_inspection.sql"
-                      : migrations.has("0261_preference_knowledge_proposal_actor_binding.sql")
-                        ? "0261_preference_knowledge_proposal_actor_binding.sql"
-                        : migrations.has("0260_task_note_knowledge_promotion.sql")
-                          ? "0260_task_note_knowledge_promotion.sql"
-                          : migrations.has("0259_company_brain_context_selection_receipts.sql")
-                            ? "0259_company_brain_context_selection_receipts.sql"
-                            : migrations.has("0258_three_scope_document_knowledge_authority.sql")
-                              ? "0258_three_scope_document_knowledge_authority.sql"
-                              : migrations.has(
-                                    "0257_goal_revision_decisions_and_root_constraints.sql",
-                                  )
-                                ? "0257_goal_revision_decisions_and_root_constraints.sql"
-                                : migrations.has("0255_company_brain_governed_write_proposals.sql")
-                                  ? "0255_company_brain_governed_write_proposals.sql"
+      migrations.has("0276_onboarding_proposal_initiating_human_guc.sql")
+        ? "0276_onboarding_proposal_initiating_human_guc.sql"
+        : migrations.has("0275_scheduled_connection_authority.sql")
+          ? "0275_scheduled_connection_authority.sql"
+          : migrations.has("0274_human_confirmed_knowledge_review.sql")
+            ? "0274_human_confirmed_knowledge_review.sql"
+            : migrations.has("0272_human_confirmed_learning_activation.sql")
+              ? "0272_human_confirmed_learning_activation.sql"
+              : migrations.has("0271_company_brain_retrieval_only_default.sql")
+                ? "0271_company_brain_retrieval_only_default.sql"
+                : migrations.has("0270_governed_learning_history_inspection.sql")
+                  ? "0270_governed_learning_history_inspection.sql"
+                  : migrations.has("0269_governed_learning_activation_controller.sql")
+                    ? "0269_governed_learning_activation_controller.sql"
+                    : migrations.has("0268_governed_learning_decision_receipts.sql")
+                      ? "0268_governed_learning_decision_receipts.sql"
+                      : migrations.has("0266_company_brain_context_receipt_inspection.sql")
+                        ? "0266_company_brain_context_receipt_inspection.sql"
+                        : migrations.has("0261_preference_knowledge_proposal_actor_binding.sql")
+                          ? "0261_preference_knowledge_proposal_actor_binding.sql"
+                          : migrations.has("0260_task_note_knowledge_promotion.sql")
+                            ? "0260_task_note_knowledge_promotion.sql"
+                            : migrations.has("0259_company_brain_context_selection_receipts.sql")
+                              ? "0259_company_brain_context_selection_receipts.sql"
+                              : migrations.has("0258_three_scope_document_knowledge_authority.sql")
+                                ? "0258_three_scope_document_knowledge_authority.sql"
+                                : migrations.has(
+                                      "0257_goal_revision_decisions_and_root_constraints.sql",
+                                    )
+                                  ? "0257_goal_revision_decisions_and_root_constraints.sql"
                                   : migrations.has(
-                                        "0248_terraform_stacks_component_resolution_fence.sql",
+                                        "0255_company_brain_governed_write_proposals.sql",
                                       )
-                                    ? "0248_terraform_stacks_component_resolution_fence.sql"
-                                    : migrations.has("0247_terraform_stacks_provenance_repair.sql")
-                                      ? "0247_terraform_stacks_provenance_repair.sql"
-                                      : migrations.has("0263_organization_membership_lifecycle.sql")
-                                        ? "0263_organization_membership_lifecycle.sql"
-                                        : latestCompatibleMigration,
+                                    ? "0255_company_brain_governed_write_proposals.sql"
+                                    : migrations.has(
+                                          "0248_terraform_stacks_component_resolution_fence.sql",
+                                        )
+                                      ? "0248_terraform_stacks_component_resolution_fence.sql"
+                                      : migrations.has(
+                                            "0247_terraform_stacks_provenance_repair.sql",
+                                          )
+                                        ? "0247_terraform_stacks_provenance_repair.sql"
+                                        : migrations.has(
+                                              "0263_organization_membership_lifecycle.sql",
+                                            )
+                                          ? "0263_organization_membership_lifecycle.sql"
+                                          : latestCompatibleMigration,
     );
     expect(migrations.get("0263_organization_membership_lifecycle.sql")).toMatchObject({
       sha256: "1119554dc06a768c92f7189a97b438ebdc011747a6c8d7cefc992962f2293593",


### PR DESCRIPTION
## Problem

`remember` with `lane: instruction_policy` fails for **every** real agent call with
`instruction-policy proposal must identify its exact inactive draft` (SQLSTATE 23514),
independent of workspace state - a workspace with no policy head at all still fails.
Found while re-verifying the baseline fix (#1535) against a live stack; that fix is
necessary but not sufficient.

## Root cause

The `workspace_instruction_policy_onboarding_proposals` draft-validation trigger
(latest copy: migration 0269) requires

```sql
AND proposal.initiating_human_subject_id = current_setting('opengeni.subject_id', true)
```

but on the real first-party MCP path `opengeni.subject_id` carries the **service**
subject `worker:first-party-mcp` (the delegated grant subject), while the frozen human
travels in `opengeni.initiating_human_subject_id` (set in the same transaction by
`withAccessGrantSessionRlsContext`, `apps/api/src/app.ts`). The comparison can never hold.

The in-process router path passes only by accident: `withCompanyBrainGovernedWriteAuthority`
sets `opengeni.subject_id` to the resolved initiating human, and without a session-actor
ALS store the nested `withRlsContext` inside `createWorkspaceInstructionPolicyKnowledgeProposal`
does not re-set it. With the ALS store present (the real API path) that nested call clobbers
`subject_id` back to the service subject before the insert fires the trigger - which is why
the existing postgres tests never caught this.

## Fix

Rolling migration `0276_onboarding_proposal_initiating_human_guc.sql` re-creates
`workspace_instruction_policy_validate_onboarding_proposal()` byte-identical to 0269 except
the one predicate, which becomes the canonical pattern every authority migration since 0225 uses:

```sql
AND proposal.initiating_human_subject_id = COALESCE(
  NULLIF(current_setting('opengeni.initiating_human_subject_id', true), ''),
  current_setting('opengeni.subject_id', true)
)
```

The hardening block re-pins the function's `search_path` (CREATE OR REPLACE drops it).
Registered in the release-schema contract (hash branch, count, latestMigration chain).

## Verification

- New `packages/core/test/remember-router-service-subject-postgres.test.ts` drives the
  remember rule lane under the exact service-subject + frozen-human actor context the API
  uses, plus a direct-human-subject control for the fallback branch.
- Negative control (migration file removed): the service-subject test fails with exactly
  SQLSTATE 23514 while the direct-human test passes - the live-stack failure reproduced.
- With the migration: 2 pass. Related suites all green against real PostgreSQL:
  `remember-router-postgres`, `company-brain-learning-router-postgres`,
  `governed-learning-activation-postgres`, `governed-learning-evaluator-postgres`,
  migration tests 0169/0255/0269, and `release-schema-contract` (6 pass / 198 expects).
- `bun run typecheck`, `bun run lint`, `bunx oxfmt --check`, `bun run check:docs-refs`,
  `bun run check:public-hygiene`, `bun run check:migration-ordinals`, `git diff --check`: all clean.

Closes OPE-260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174Vs3Jf8BRcpyFRW6zEtwL
