### PR TITLE
feat(db): fenced workspace-membership removal (OPE-203 slice 2)

### DIFF
--- a/.changeset/removal-becomes-teardown.md
+++ b/.changeset/removal-becomes-teardown.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": minor
+---
+
+Workspace-membership removal is now one fenced SECURITY DEFINER teardown (migration 0278): the removed member's queued/live turns in that workspace are cancelled, live attempts interrupted, realtime modes ended, private-session authority epochs advanced, workflow wakes registered, and per-workspace personal rows plus the membership deleted in one transaction. Self-removal, last-admin removal, and non-administering actors fail closed in the database seam.

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -468,8 +468,14 @@ export function registerWorkspaceRoutes(app: Hono, deps: ApiRouteDeps): void {
     const subjectId = decodeURIComponent(c.req.param("subjectId"));
     const members = await listWorkspaceMembers(deps.db, workspaceId);
     // Never remove yourself, and never remove the last administering member.
+    // The fenced removal command re-enforces both guards fail-closed.
     assertWorkspaceMemberRemovable({ members, subjectId, callerSubjectId: grant.subjectId });
-    await removeWorkspaceMember(deps.db, workspaceId, subjectId);
+    await removeWorkspaceMember(deps.db, {
+      accountId: grant.accountId,
+      workspaceId,
+      actorSubjectId: grant.subjectId,
+      targetSubjectId: subjectId,
+    });
     return c.body(null, 204);
   });
 }

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -1112,7 +1112,7 @@ export function mapChannelAError(error: unknown, waitSignal?: AbortSignal): unkn
     return new HTTPException(409, { message: error.message });
   const authorityFence = workspaceMutationAuthorityFenceCode(error);
   // A revoked grant is an authorization outcome, not a server fault; an
-  // unattributed pre-0276 writer is a conflict the caller resolves by starting
+  // unattributed pre-0277 writer is a conflict the caller resolves by starting
   // fresh work. Both must be visible instead of surfacing as a 500.
   if (authorityFence === "authority_revoked")
     return new HTTPException(403, { message: (error as Error).message });

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -198,7 +198,19 @@ also on the bounded idle timer. A buffered or replayed event therefore fails
 closed after suspension or offboarding instead of retaining the grant captured
 when the HTTP request began.
 Reactivation restores only active organization and personal-workspace access,
-never old grants. Offboarding applies the same canonical
+never old grants.
+Removing one workspace membership (migration 0278) is the same canonical
+teardown scoped to exactly that workspace and subject: the
+`workspace_membership_removal_command` SECURITY DEFINER seam cancels the
+removed member's queued/live turns there, interrupts live attempts, ends their
+active realtime modes, pauses their created scheduled tasks and owned-session
+goals, revokes their workspace-scoped resource grants, advances their private
+sessions' authority epochs with `session.authority.revoked` events, registers
+workflow wakes, deletes their per-workspace personal rows, and deletes the
+membership - in one transaction, behind the same prepare/settle protocol for
+pending tool calls. Self-removal, removing the last administering member, and
+a non-administering actor fail closed in the seam itself. Other workspaces,
+organization membership status, and retention are untouched. Offboarding applies the same canonical
 workspace/session/turn/attempt teardown, then terminally revokes membership and
 retains resource authority and physical data. Owned-session authority epochs
 advance with content-free audit events; unrelated users' shared-session state

--- a/packages/db/drizzle/0278_workspace_membership_removal_fencing.sql
+++ b/packages/db/drizzle/0278_workspace_membership_removal_fencing.sql
@@ -99,6 +99,38 @@ BEGIN
   WHERE workspace.account_id = account_id_value
     AND workspace.id = workspace_id_value
   FOR KEY SHARE;
+  -- Scheduled-task rows before session rows, exactly the 0275 wrapper's
+  -- per-workspace task/session prefix: the scheduled-task writers lock
+  -- task -> session -> membership, so removal must never hold the membership
+  -- (or session) rows while waiting on a task row.
+  PERFORM 1 FROM scheduled_tasks task
+  WHERE task.account_id = account_id_value
+    AND task.workspace_id = workspace_id_value
+    AND task.deleted_at IS NULL
+    AND task.status = 'active'
+    AND (
+      (task.created_by_kind = 'subject' AND task.created_by_subject_id = target_subject)
+      OR EXISTS (
+        SELECT 1 FROM scheduled_task_revision_authorities authority
+        WHERE authority.task_id = task.id
+          AND authority.task_authority_revision = task.authority_revision
+          AND authority.subject_id = target_subject
+      )
+      OR EXISTS (
+        SELECT 1 FROM scheduled_task_personal_resource_authorities authority
+        WHERE authority.task_id = task.id
+          AND authority.task_authority_revision = task.authority_revision
+          AND authority.initiating_human_subject_id = target_subject
+      )
+      OR EXISTS (
+        SELECT 1 FROM scheduled_task_connection_authority_snapshots snapshot
+        WHERE snapshot.task_id = task.id
+          AND snapshot.task_authority_revision = task.authority_revision
+          AND snapshot.owner_subject_id = target_subject
+      )
+    )
+  ORDER BY task.id
+  FOR UPDATE;
   PERFORM 1 FROM sessions affected
   WHERE affected.account_id = account_id_value
     AND affected.workspace_id = workspace_id_value
@@ -200,7 +232,13 @@ $body$;
 
 -- 2. Shared actor/guard authority. The exact application guards, restated as
 -- fail-closed database authority so no future caller can skip them:
--- self-removal, last-admin, and actor administration.
+-- self-removal, last-admin, and actor administration. The checks themselves
+-- are pure reads: the removal command serializes the administering roster
+-- (ordered FOR UPDATE on every admin/actor/target membership row plus the
+-- actor's organization membership) BEFORE re-running them, so two concurrent
+-- removals of the two last administering members cannot both pass. The
+-- preparation function's earlier call is a friendly unserialized precheck
+-- only and authorizes nothing by itself.
 
 CREATE FUNCTION opengeni_private.assert_workspace_membership_removal_actor(
   p_account_id uuid,
@@ -323,9 +361,6 @@ BEGIN
   SET CONSTRAINTS sessions_activity_insert_commit_guard,
     sessions_activity_update_commit_guard DEFERRED;
 
-  PERFORM opengeni_private.assert_workspace_membership_removal_actor(
-    account_id_value, workspace_id_value, actor_subject, target_subject
-  );
   -- The personal-state fence the pre-0278 delete path took: session listing
   -- takes its shared counterpart and pin mutation the same exclusive one, so
   -- a racing snapshot/pin writer cannot recreate personal rows after this
@@ -333,19 +368,6 @@ BEGIN
   PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(
     'session-personal-state:' || workspace_id_value::text || ':' || target_subject, 0
   ));
-  SELECT membership.id INTO membership_row_id
-  FROM workspace_memberships membership
-  WHERE membership.account_id = account_id_value
-    AND membership.workspace_id = workspace_id_value
-    AND membership.subject_id = target_subject
-  FOR UPDATE;
-  IF membership_row_id IS NULL THEN
-    RETURN pg_catalog.jsonb_build_object('removed', false);
-  END IF;
-  SELECT membership.id INTO target_membership_id
-  FROM organization_memberships membership
-  WHERE membership.account_id = account_id_value
-    AND membership.subject_id = target_subject;
 
   visibility_capability_id := pg_catalog.gen_random_uuid();
   INSERT INTO session_visibility_write_capabilities (
@@ -377,6 +399,89 @@ BEGIN
   WHERE workspace.account_id = account_id_value
     AND workspace.id = workspace_id_value
   FOR KEY SHARE;
+  -- Task rows before membership/session rows (0275 writer order; reentrant
+  -- with the preparation pass in the same transaction).
+  PERFORM 1 FROM scheduled_tasks task
+  WHERE task.account_id = account_id_value
+    AND task.workspace_id = workspace_id_value
+    AND task.deleted_at IS NULL
+    AND task.status = 'active'
+    AND (
+      (task.created_by_kind = 'subject' AND task.created_by_subject_id = target_subject)
+      OR EXISTS (
+        SELECT 1 FROM scheduled_task_revision_authorities authority
+        WHERE authority.task_id = task.id
+          AND authority.task_authority_revision = task.authority_revision
+          AND authority.subject_id = target_subject
+      )
+      OR EXISTS (
+        SELECT 1 FROM scheduled_task_personal_resource_authorities authority
+        WHERE authority.task_id = task.id
+          AND authority.task_authority_revision = task.authority_revision
+          AND authority.initiating_human_subject_id = target_subject
+      )
+      OR EXISTS (
+        SELECT 1 FROM scheduled_task_connection_authority_snapshots snapshot
+        WHERE snapshot.task_id = task.id
+          AND snapshot.task_authority_revision = task.authority_revision
+          AND snapshot.owner_subject_id = target_subject
+      )
+    )
+  ORDER BY task.id
+  FOR UPDATE;
+  -- Serialize the administering roster before re-running the guards: the
+  -- actor's organization membership (shared - the organization lifecycle
+  -- takes it FOR UPDATE) and every admin/actor/target workspace membership
+  -- row in id order. Two concurrent removals of the two last administering
+  -- members therefore serialize, and the loser re-reads a roster with only
+  -- one administering member left and fails closed.
+  PERFORM 1 FROM organization_memberships org_actor
+  WHERE org_actor.account_id = account_id_value
+    AND org_actor.subject_id = actor_subject
+  FOR SHARE;
+  PERFORM 1 FROM workspace_memberships roster
+  WHERE roster.account_id = account_id_value
+    AND roster.workspace_id = workspace_id_value
+    AND (
+      roster.subject_id IN (actor_subject, target_subject)
+      OR roster.permissions ?| ARRAY['workspace:admin', 'members:manage']
+    )
+  ORDER BY roster.id
+  FOR UPDATE;
+  PERFORM opengeni_private.assert_workspace_membership_removal_actor(
+    account_id_value, workspace_id_value, actor_subject, target_subject
+  );
+  SELECT membership.id INTO membership_row_id
+  FROM workspace_memberships membership
+  WHERE membership.account_id = account_id_value
+    AND membership.workspace_id = workspace_id_value
+    AND membership.subject_id = target_subject;
+  IF membership_row_id IS NULL THEN
+    DELETE FROM session_visibility_write_capabilities capability
+    WHERE capability.backend_pid = pg_catalog.pg_backend_pid()
+      AND capability.transaction_id = pg_catalog.pg_current_xact_id()
+      AND capability.capability_id = visibility_capability_id;
+    PERFORM pg_catalog.set_config(
+      'opengeni.session_visibility_write_capability',
+      coalesce(previous_visibility_capability, ''), true
+    );
+    PERFORM pg_catalog.set_config(
+      'opengeni.workspace_id', coalesce(previous_workspace, ''), true
+    );
+    PERFORM pg_catalog.set_config(
+      'opengeni.session_activity_gate_state',
+      coalesce(previous_activity_gate_state, ''), true
+    );
+    PERFORM pg_catalog.set_config(
+      'opengeni.session_activity_gate_workspace_id',
+      coalesce(previous_activity_gate_workspace, ''), true
+    );
+    RETURN pg_catalog.jsonb_build_object('removed', false);
+  END IF;
+  SELECT membership.id INTO target_membership_id
+  FROM organization_memberships membership
+  WHERE membership.account_id = account_id_value
+    AND membership.subject_id = target_subject;
   PERFORM 1 FROM sessions affected
   WHERE affected.account_id = account_id_value
     AND affected.workspace_id = workspace_id_value
@@ -850,9 +955,29 @@ BEGIN
     updated_at = now_value
   WHERE task.account_id = account_id_value
     AND task.workspace_id = workspace_id_value
+    AND task.deleted_at IS NULL
     AND task.status = 'active'
-    AND task.created_by_kind = 'subject'
-    AND task.created_by_subject_id = target_subject;
+    AND (
+      (task.created_by_kind = 'subject' AND task.created_by_subject_id = target_subject)
+      OR EXISTS (
+        SELECT 1 FROM scheduled_task_revision_authorities authority
+        WHERE authority.task_id = task.id
+          AND authority.task_authority_revision = task.authority_revision
+          AND authority.subject_id = target_subject
+      )
+      OR EXISTS (
+        SELECT 1 FROM scheduled_task_personal_resource_authorities authority
+        WHERE authority.task_id = task.id
+          AND authority.task_authority_revision = task.authority_revision
+          AND authority.initiating_human_subject_id = target_subject
+      )
+      OR EXISTS (
+        SELECT 1 FROM scheduled_task_connection_authority_snapshots snapshot
+        WHERE snapshot.task_id = task.id
+          AND snapshot.task_authority_revision = task.authority_revision
+          AND snapshot.owner_subject_id = target_subject
+      )
+    );
   UPDATE organization_user_resource_grants grant_row
   SET status = 'revoked', revoked_at = now_value,
     generation = grant_row.generation + 1, updated_at = now_value
@@ -861,6 +986,19 @@ BEGIN
     AND grant_row.status = 'active'
     AND target_membership_id IS NOT NULL
     AND grant_row.owner_organization_membership_id = target_membership_id;
+  UPDATE organization_user_resource_grants grant_row
+  SET status = 'revoked', revoked_at = now_value,
+    generation = grant_row.generation + 1, updated_at = now_value
+  WHERE grant_row.account_id = account_id_value
+    AND grant_row.workspace_id = workspace_id_value
+    AND grant_row.status = 'active'
+    AND target_membership_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM sessions owned
+      WHERE owned.id = grant_row.session_id
+        AND owned.owner_organization_membership_id = target_membership_id
+        AND owned.authority_epoch = grant_row.authority_epoch
+    );
   IF target_membership_id IS NOT NULL THEN
     WITH advanced AS (
       UPDATE sessions owned SET

--- a/packages/db/drizzle/0278_workspace_membership_removal_fencing.sql
+++ b/packages/db/drizzle/0278_workspace_membership_removal_fencing.sql
@@ -1,0 +1,1036 @@
+-- deployment-mode: rolling
+-- Migration 0278: workspace-membership removal becomes one fenced
+-- SECURITY DEFINER teardown instead of a bare personal-row cleanup + DELETE.
+--
+-- Before this migration `removeWorkspaceMember` deleted the target's
+-- session-list snapshots, pins, drafts and the membership row and fenced
+-- nothing: the removed member's queued/live turns kept running, their
+-- user-private sessions in the workspace kept their authority epoch, their
+-- active realtime modes stayed open, and nothing woke the affected workflows.
+-- Organization offboarding (migration 0263) already performs the canonical
+-- teardown account-wide; this migration is the same teardown scoped to
+-- exactly one workspace and one target subject.
+--
+-- Rolling window. Two new functions only; no table shape changes. An old API
+-- image keeps calling the bare delete path until it is replaced - removal
+-- through the old path stays exactly as weak as before, never weaker, and the
+-- new path composes with every existing invariant:
+--   * the canonical event-write lock order is preserved (control FOR SHARE ->
+--     workspace FOR KEY SHARE -> sessions FOR NO KEY UPDATE -> turns
+--     FOR UPDATE -> attempts FOR UPDATE);
+--   * a turn with pending tool calls and no live attempt must be settled
+--     through the canonical application protocol first - the command fails
+--     closed (55000) exactly like the 0263 command, and the application runs
+--     the same prepare/settle pass before invoking it;
+--   * live attempts are interrupted, never presumed quiesced: the command
+--     records `session_attempt_interruptions` (kind `authority_change`) and
+--     registers workflow wakes; Temporal cancellation semantics are untouched;
+--   * removal never touches other workspaces, other subjects, organization
+--     membership status, personal-workspace pointers, or retention.
+--
+-- Guards, restated from the application layer as fail-closed authority:
+--   * the actor cannot remove their own membership;
+--   * the last member holding an administering permission
+--     ('workspace:admin' or 'members:manage') cannot be removed;
+--   * the actor must either hold an administering permission in this
+--     workspace or be an active organization owner/admin.
+--
+-- Idempotency: the whole command is one transaction. A retry after success
+-- finds no membership row and returns removed=false without re-tearing
+-- anything down; there is no partial state to repair.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+-- 1. Preparation: the same "settle pending tool calls first" contract as the
+-- organization lifecycle, scoped to one workspace + one subject. Returns the
+-- exact turns the application must settle through its canonical protocol
+-- before calling the removal command.
+
+CREATE FUNCTION prepare_workspace_membership_removal_settlements(
+  p_command jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $body$
+DECLARE
+  account_id_value uuid := nullif(p_command ->> 'organizationId', '')::uuid;
+  workspace_id_value uuid := nullif(p_command ->> 'workspaceId', '')::uuid;
+  actor_subject text := p_command ->> 'actorSubjectId';
+  target_subject text := p_command ->> 'targetSubjectId';
+  target_membership_id uuid;
+  result jsonb := '[]'::jsonb;
+  previous_workspace text := pg_catalog.current_setting('opengeni.workspace_id', true);
+BEGIN
+  IF p_command IS NULL
+    OR (p_command ->> 'action') IS DISTINCT FROM 'remove'
+    OR account_id_value IS NULL
+    OR workspace_id_value IS NULL
+    OR actor_subject IS NULL
+    OR target_subject IS NULL
+    OR actor_subject IS DISTINCT FROM opengeni_private.current_subject_id()
+    OR account_id_value IS DISTINCT FROM opengeni_private.current_account_id()
+  THEN
+    RAISE EXCEPTION 'workspace membership removal preparation authority is invalid'
+      USING ERRCODE = '42501';
+  END IF;
+  PERFORM 1 FROM workspaces workspace
+  WHERE workspace.account_id = account_id_value AND workspace.id = workspace_id_value;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'workspace not found' USING ERRCODE = 'P0002';
+  END IF;
+  PERFORM opengeni_private.assert_workspace_membership_removal_actor(
+    account_id_value, workspace_id_value, actor_subject, target_subject
+  );
+  SELECT membership.id INTO target_membership_id
+  FROM organization_memberships membership
+  WHERE membership.account_id = account_id_value
+    AND membership.subject_id = target_subject;
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.workspace_id', workspace_id_value::text, true
+  );
+  PERFORM 1 FROM workspace_inference_controls control
+  WHERE control.account_id = account_id_value
+    AND control.workspace_id = workspace_id_value
+  FOR SHARE;
+  PERFORM 1 FROM workspaces workspace
+  WHERE workspace.account_id = account_id_value
+    AND workspace.id = workspace_id_value
+  FOR KEY SHARE;
+  PERFORM 1 FROM sessions affected
+  WHERE affected.account_id = account_id_value
+    AND affected.workspace_id = workspace_id_value
+    AND (
+      (target_membership_id IS NOT NULL
+        AND affected.owner_organization_membership_id = target_membership_id)
+      OR EXISTS (
+        SELECT 1 FROM session_turns initiated
+        WHERE initiated.session_id = affected.id
+          AND initiated.initiating_human_subject_id = target_subject
+      )
+    )
+  ORDER BY affected.id
+  FOR NO KEY UPDATE;
+  PERFORM 1 FROM session_turns turn_row
+  WHERE turn_row.account_id = account_id_value
+    AND turn_row.workspace_id = workspace_id_value
+    AND EXISTS (
+      SELECT 1 FROM sessions owned
+      WHERE owned.id = turn_row.session_id
+        AND (
+          (target_membership_id IS NOT NULL
+            AND owned.owner_organization_membership_id = target_membership_id)
+          OR turn_row.initiating_human_subject_id = target_subject
+        )
+    )
+  ORDER BY turn_row.id
+  FOR UPDATE;
+  PERFORM 1 FROM session_turn_attempts attempt
+  WHERE attempt.account_id = account_id_value
+    AND attempt.workspace_id = workspace_id_value
+    AND EXISTS (
+      SELECT 1 FROM sessions owned
+      WHERE owned.id = attempt.session_id
+        AND (
+          (target_membership_id IS NOT NULL
+            AND owned.owner_organization_membership_id = target_membership_id)
+          OR EXISTS (
+            SELECT 1 FROM session_turns initiated
+            WHERE initiated.id = attempt.turn_id
+              AND initiated.initiating_human_subject_id = target_subject
+          )
+        )
+    )
+  ORDER BY attempt.id
+  FOR UPDATE;
+  SELECT result || COALESCE(
+    pg_catalog.jsonb_agg(
+      pg_catalog.jsonb_build_object(
+        'accountId', turn_row.account_id,
+        'workspaceId', turn_row.workspace_id,
+        'sessionId', turn_row.session_id,
+        'turnId', turn_row.id,
+        'executionGeneration', turn_row.execution_generation,
+        'turnAssociation', CASE WHEN owned.active_turn_id = turn_row.id
+          THEN 'current' ELSE NULL END
+      ) ORDER BY turn_row.session_id, turn_row.id
+    ), '[]'::jsonb
+  ) INTO result
+  FROM session_turns turn_row
+  JOIN sessions owned ON owned.id = turn_row.session_id
+  WHERE turn_row.account_id = account_id_value
+    AND turn_row.workspace_id = workspace_id_value
+    AND turn_row.status IN (
+      'queued', 'running', 'requires_action', 'recovering', 'waiting_capacity'
+    )
+    AND (
+      (target_membership_id IS NOT NULL
+        AND owned.owner_organization_membership_id = target_membership_id)
+      OR turn_row.initiating_human_subject_id = target_subject
+    )
+    AND EXISTS (
+      SELECT 1 FROM session_pending_tool_calls pending
+      WHERE pending.account_id = turn_row.account_id
+        AND pending.workspace_id = turn_row.workspace_id
+        AND pending.session_id = turn_row.session_id
+        AND pending.turn_id = turn_row.id
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM session_turn_attempts live_attempt
+      WHERE live_attempt.account_id = turn_row.account_id
+        AND live_attempt.workspace_id = turn_row.workspace_id
+        AND live_attempt.session_id = turn_row.session_id
+        AND live_attempt.turn_id = turn_row.id
+        AND live_attempt.id = turn_row.active_attempt_id
+        AND live_attempt.state IN ('claimed', 'running')
+    );
+  PERFORM pg_catalog.set_config(
+    'opengeni.workspace_id', COALESCE(previous_workspace, ''), true
+  );
+  RETURN result;
+EXCEPTION WHEN OTHERS THEN
+  PERFORM pg_catalog.set_config(
+    'opengeni.workspace_id', COALESCE(previous_workspace, ''), true
+  );
+  RAISE;
+END
+$body$;
+
+-- 2. Shared actor/guard authority. The exact application guards, restated as
+-- fail-closed database authority so no future caller can skip them:
+-- self-removal, last-admin, and actor administration.
+
+CREATE FUNCTION opengeni_private.assert_workspace_membership_removal_actor(
+  p_account_id uuid,
+  p_workspace_id uuid,
+  p_actor_subject text,
+  p_target_subject text
+) RETURNS void
+LANGUAGE plpgsql
+AS $body$
+DECLARE
+  actor_can_administer boolean;
+BEGIN
+  IF p_actor_subject = p_target_subject THEN
+    RAISE EXCEPTION 'a member cannot remove their own workspace membership'
+      USING ERRCODE = '55000';
+  END IF;
+  SELECT EXISTS (
+    SELECT 1 FROM workspace_memberships actor_row
+    WHERE actor_row.account_id = p_account_id
+      AND actor_row.workspace_id = p_workspace_id
+      AND actor_row.subject_id = p_actor_subject
+      AND actor_row.permissions ?| ARRAY['workspace:admin', 'members:manage']
+  ) OR EXISTS (
+    SELECT 1 FROM organization_memberships org_actor
+    WHERE org_actor.account_id = p_account_id
+      AND org_actor.subject_id = p_actor_subject
+      AND org_actor.status = 'active'
+      AND org_actor.role IN ('owner', 'admin')
+  ) INTO actor_can_administer;
+  IF NOT actor_can_administer THEN
+    RAISE EXCEPTION 'workspace member administration required' USING ERRCODE = '42501';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM workspace_memberships target_row
+    WHERE target_row.account_id = p_account_id
+      AND target_row.workspace_id = p_workspace_id
+      AND target_row.subject_id = p_target_subject
+      AND target_row.permissions ?| ARRAY['workspace:admin', 'members:manage']
+  ) AND NOT EXISTS (
+    SELECT 1 FROM workspace_memberships other
+    WHERE other.account_id = p_account_id
+      AND other.workspace_id = p_workspace_id
+      AND other.subject_id <> p_target_subject
+      AND other.permissions ?| ARRAY['workspace:admin', 'members:manage']
+  ) THEN
+    RAISE EXCEPTION 'cannot remove the last administering workspace member'
+      USING ERRCODE = '55000';
+  END IF;
+END
+$body$;
+
+-- 3. The removal command itself.
+
+CREATE FUNCTION workspace_membership_removal_command(
+  p_command jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $body$
+DECLARE
+  account_id_value uuid := nullif(p_command ->> 'organizationId', '')::uuid;
+  workspace_id_value uuid := nullif(p_command ->> 'workspaceId', '')::uuid;
+  actor_subject text := p_command ->> 'actorSubjectId';
+  target_subject text := p_command ->> 'targetSubjectId';
+  operation_id_value uuid := nullif(p_command ->> 'operationId', '')::uuid;
+  input_hash_value text;
+  target_membership_id uuid;
+  membership_row_id uuid;
+  now_value timestamptz := pg_catalog.clock_timestamp();
+  affected_session_ids uuid[] := ARRAY[]::uuid[];
+  affected_realtime_ids uuid[] := ARRAY[]::uuid[];
+  cancelled_turn_ids uuid[] := ARRAY[]::uuid[];
+  cancelled_turn record;
+  cancelled_request record;
+  cancelled_sequence bigint;
+  cancelled_association text;
+  settled_update_ids uuid[];
+  settled_history_item_id uuid;
+  interruption_operation_id uuid;
+  visibility_capability_id uuid;
+  activity_revision_value bigint;
+  previous_workspace text := pg_catalog.current_setting('opengeni.workspace_id', true);
+  previous_visibility_capability text := pg_catalog.current_setting(
+    'opengeni.session_visibility_write_capability', true
+  );
+  previous_activity_gate_state text := pg_catalog.current_setting(
+    'opengeni.session_activity_gate_state', true
+  );
+  previous_activity_gate_workspace text := pg_catalog.current_setting(
+    'opengeni.session_activity_gate_workspace_id', true
+  );
+BEGIN
+  IF p_command IS NULL
+    OR (p_command ->> 'action') IS DISTINCT FROM 'remove'
+    OR account_id_value IS NULL
+    OR workspace_id_value IS NULL
+    OR actor_subject IS NULL
+    OR target_subject IS NULL
+    OR operation_id_value IS NULL
+    OR actor_subject IS DISTINCT FROM opengeni_private.current_subject_id()
+    OR account_id_value IS DISTINCT FROM opengeni_private.current_account_id()
+  THEN
+    RAISE EXCEPTION 'workspace membership removal authority is invalid'
+      USING ERRCODE = '42501';
+  END IF;
+  input_hash_value := pg_catalog.encode(
+    pg_catalog.sha256(pg_catalog.convert_to(p_command::text, 'UTF8')), 'hex'
+  );
+  PERFORM 1 FROM workspaces workspace
+  WHERE workspace.account_id = account_id_value AND workspace.id = workspace_id_value;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'workspace not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- The command runs after the application settled the target's pending
+  -- protocol state and finalized that workspace activity gate. Its own gated
+  -- session writes need the commit guards DEFERRED again (exactly the 0275
+  -- wrapper's reasoning).
+  SET CONSTRAINTS sessions_activity_insert_commit_guard,
+    sessions_activity_update_commit_guard DEFERRED;
+
+  PERFORM opengeni_private.assert_workspace_membership_removal_actor(
+    account_id_value, workspace_id_value, actor_subject, target_subject
+  );
+  -- The personal-state fence the pre-0278 delete path took: session listing
+  -- takes its shared counterpart and pin mutation the same exclusive one, so
+  -- a racing snapshot/pin writer cannot recreate personal rows after this
+  -- cleanup. Same key derivation as lockSessionPersonalStateExclusive.
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(
+    'session-personal-state:' || workspace_id_value::text || ':' || target_subject, 0
+  ));
+  SELECT membership.id INTO membership_row_id
+  FROM workspace_memberships membership
+  WHERE membership.account_id = account_id_value
+    AND membership.workspace_id = workspace_id_value
+    AND membership.subject_id = target_subject
+  FOR UPDATE;
+  IF membership_row_id IS NULL THEN
+    RETURN pg_catalog.jsonb_build_object('removed', false);
+  END IF;
+  SELECT membership.id INTO target_membership_id
+  FROM organization_memberships membership
+  WHERE membership.account_id = account_id_value
+    AND membership.subject_id = target_subject;
+
+  visibility_capability_id := pg_catalog.gen_random_uuid();
+  INSERT INTO session_visibility_write_capabilities (
+    backend_pid, transaction_id, capability_id
+  ) VALUES (
+    pg_catalog.pg_backend_pid(), pg_catalog.pg_current_xact_id(),
+    visibility_capability_id
+  );
+  PERFORM pg_catalog.set_config(
+    'opengeni.session_visibility_write_capability',
+    visibility_capability_id::text, true
+  );
+  PERFORM pg_catalog.set_config(
+    'opengeni.workspace_id', workspace_id_value::text, true
+  );
+  PERFORM pg_catalog.set_config(
+    'opengeni.session_activity_gate_state', 'open', true
+  );
+  PERFORM pg_catalog.set_config(
+    'opengeni.session_activity_gate_workspace_id', workspace_id_value::text, true
+  );
+
+  -- Canonical lock prefix for this workspace, then the exact affected rows.
+  PERFORM 1 FROM workspace_inference_controls control
+  WHERE control.account_id = account_id_value
+    AND control.workspace_id = workspace_id_value
+  FOR SHARE;
+  PERFORM 1 FROM workspaces workspace
+  WHERE workspace.account_id = account_id_value
+    AND workspace.id = workspace_id_value
+  FOR KEY SHARE;
+  PERFORM 1 FROM sessions affected
+  WHERE affected.account_id = account_id_value
+    AND affected.workspace_id = workspace_id_value
+    AND (
+      (target_membership_id IS NOT NULL
+        AND affected.owner_organization_membership_id = target_membership_id)
+      OR EXISTS (
+        SELECT 1 FROM session_turns initiated
+        WHERE initiated.session_id = affected.id
+          AND initiated.initiating_human_subject_id = target_subject
+      )
+    )
+  ORDER BY affected.id
+  FOR NO KEY UPDATE;
+  PERFORM 1 FROM session_turns turn_row
+  WHERE turn_row.account_id = account_id_value
+    AND turn_row.workspace_id = workspace_id_value
+    AND EXISTS (
+      SELECT 1 FROM sessions owned
+      WHERE owned.id = turn_row.session_id
+        AND (
+          (target_membership_id IS NOT NULL
+            AND owned.owner_organization_membership_id = target_membership_id)
+          OR turn_row.initiating_human_subject_id = target_subject
+        )
+    )
+  ORDER BY turn_row.id
+  FOR UPDATE;
+  PERFORM 1 FROM session_turn_attempts attempt
+  WHERE attempt.account_id = account_id_value
+    AND attempt.workspace_id = workspace_id_value
+    AND EXISTS (
+      SELECT 1 FROM sessions owned
+      WHERE owned.id = attempt.session_id
+        AND (
+          (target_membership_id IS NOT NULL
+            AND owned.owner_organization_membership_id = target_membership_id)
+          OR EXISTS (
+            SELECT 1 FROM session_turns initiated
+            WHERE initiated.id = attempt.turn_id
+              AND initiated.initiating_human_subject_id = target_subject
+          )
+        )
+    )
+  ORDER BY attempt.id
+  FOR UPDATE;
+  PERFORM 1 FROM session_realtime_modes realtime
+  WHERE realtime.account_id = account_id_value
+    AND realtime.workspace_id = workspace_id_value
+    AND realtime.owner_subject_id = target_subject
+    AND realtime.state = 'active'
+  ORDER BY realtime.id
+  FOR UPDATE;
+  SELECT COALESCE(pg_catalog.array_agg(realtime.id ORDER BY realtime.id), ARRAY[]::uuid[])
+  INTO affected_realtime_ids
+  FROM session_realtime_modes realtime
+  WHERE realtime.account_id = account_id_value
+    AND realtime.workspace_id = workspace_id_value
+    AND realtime.owner_subject_id = target_subject
+    AND realtime.state = 'active';
+  PERFORM 1 FROM session_realtime_connections connection
+  WHERE connection.account_id = account_id_value
+    AND connection.workspace_id = workspace_id_value
+    AND connection.realtime_id = ANY(affected_realtime_ids)
+    AND connection.state IN ('negotiating', 'ready', 'active')
+  ORDER BY connection.id
+  FOR UPDATE;
+
+  -- Pending tool calls with no live attempt need canonical protocol
+  -- settlement first, exactly as the organization lifecycle requires.
+  IF EXISTS (
+    SELECT 1
+    FROM session_turns turn_row
+    JOIN sessions owned ON owned.id = turn_row.session_id
+    WHERE turn_row.account_id = account_id_value
+      AND turn_row.workspace_id = workspace_id_value
+      AND turn_row.status IN (
+        'queued', 'running', 'requires_action', 'recovering', 'waiting_capacity'
+      )
+      AND (
+        (target_membership_id IS NOT NULL
+          AND owned.owner_organization_membership_id = target_membership_id)
+        OR turn_row.initiating_human_subject_id = target_subject
+      )
+      AND EXISTS (
+        SELECT 1 FROM session_pending_tool_calls pending
+        WHERE pending.account_id = turn_row.account_id
+          AND pending.workspace_id = turn_row.workspace_id
+          AND pending.session_id = turn_row.session_id
+          AND pending.turn_id = turn_row.id
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM session_turn_attempts live_attempt
+        WHERE live_attempt.account_id = turn_row.account_id
+          AND live_attempt.workspace_id = turn_row.workspace_id
+          AND live_attempt.session_id = turn_row.session_id
+          AND live_attempt.turn_id = turn_row.id
+          AND live_attempt.id = turn_row.active_attempt_id
+          AND live_attempt.state IN ('claimed', 'running')
+      )
+  ) THEN
+    RAISE EXCEPTION 'pending tool calls require canonical protocol settlement'
+      USING ERRCODE = '55000';
+  END IF;
+
+  SELECT COALESCE(pg_catalog.array_agg(DISTINCT turn_row.session_id), ARRAY[]::uuid[])
+  INTO affected_session_ids
+  FROM session_turns turn_row
+  JOIN sessions owned
+    ON owned.account_id = turn_row.account_id
+   AND owned.workspace_id = turn_row.workspace_id
+   AND owned.id = turn_row.session_id
+  WHERE turn_row.account_id = account_id_value
+    AND turn_row.workspace_id = workspace_id_value
+    AND turn_row.status IN (
+      'queued', 'running', 'requires_action', 'recovering', 'waiting_capacity'
+    )
+    AND (
+      (target_membership_id IS NOT NULL
+        AND owned.owner_organization_membership_id = target_membership_id)
+      OR turn_row.initiating_human_subject_id = target_subject
+    );
+  affected_session_ids := ARRAY(
+    SELECT DISTINCT candidate.session_id
+    FROM (
+      SELECT unnest(affected_session_ids) AS session_id
+      UNION ALL
+      SELECT realtime.session_id
+      FROM session_realtime_modes realtime
+      WHERE realtime.id = ANY(affected_realtime_ids)
+    ) candidate
+    ORDER BY candidate.session_id
+  );
+
+  interruption_operation_id := pg_catalog.gen_random_uuid();
+  INSERT INTO session_command_receipts (
+    id, account_id, workspace_id, actor_type, actor_subject_id,
+    action, operation_key, canonical_request_hash, result
+  ) VALUES (
+    interruption_operation_id, account_id_value, workspace_id_value,
+    'human', actor_subject, 'workspace.membership.remove',
+    'workspace-membership:' || operation_id_value::text,
+    input_hash_value,
+    pg_catalog.jsonb_build_object(
+      'workspaceMembershipOperationId', operation_id_value,
+      'workspaceMembershipId', membership_row_id,
+      'targetSubjectId', target_subject
+    )
+  );
+  INSERT INTO session_attempt_interruptions (
+    account_id, workspace_id, session_id, operation_id, attempt_id,
+    kind, control_revision
+  )
+  SELECT attempt.account_id, attempt.workspace_id, attempt.session_id,
+    interruption_operation_id, attempt.id, 'authority_change',
+    CASE WHEN target_membership_id IS NOT NULL
+      AND owned.owner_organization_membership_id = target_membership_id
+      THEN owned.authority_epoch + 1 ELSE owned.authority_epoch END
+  FROM session_turn_attempts attempt
+  JOIN sessions owned ON owned.id = attempt.session_id
+  JOIN session_turns initiated ON initiated.id = attempt.turn_id
+  WHERE attempt.account_id = account_id_value
+    AND attempt.workspace_id = workspace_id_value
+    AND (
+      (target_membership_id IS NOT NULL
+        AND owned.owner_organization_membership_id = target_membership_id)
+      OR initiated.initiating_human_subject_id = target_subject
+    )
+    AND attempt.state IN ('claimed', 'running')
+  ON CONFLICT ON CONSTRAINT session_attempt_interruptions_operation_attempt_uq
+  DO NOTHING;
+
+  WITH cancelled AS (
+    UPDATE session_turns turn_row
+    SET status = 'cancelled', active_attempt_id = NULL,
+      cancelled_by = actor_subject, cancel_reason = 'authority_changed',
+      finished_at = now_value, updated_at = now_value,
+      version = turn_row.version + 1
+    WHERE turn_row.account_id = account_id_value
+      AND turn_row.workspace_id = workspace_id_value
+      AND turn_row.status IN (
+        'queued', 'running', 'requires_action', 'recovering', 'waiting_capacity'
+      )
+      AND EXISTS (
+        SELECT 1 FROM sessions owned
+        WHERE owned.account_id = turn_row.account_id
+          AND owned.workspace_id = turn_row.workspace_id
+          AND owned.id = turn_row.session_id
+          AND (
+            (target_membership_id IS NOT NULL
+              AND owned.owner_organization_membership_id = target_membership_id)
+            OR turn_row.initiating_human_subject_id = target_subject
+          )
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM session_turn_attempts live_attempt
+        WHERE live_attempt.account_id = turn_row.account_id
+          AND live_attempt.workspace_id = turn_row.workspace_id
+          AND live_attempt.session_id = turn_row.session_id
+          AND live_attempt.turn_id = turn_row.id
+          AND live_attempt.id = turn_row.active_attempt_id
+          AND live_attempt.state IN ('claimed', 'running')
+      )
+    RETURNING turn_row.id
+  )
+  SELECT COALESCE(pg_catalog.array_agg(cancelled.id ORDER BY cancelled.id), ARRAY[]::uuid[])
+  INTO cancelled_turn_ids
+  FROM cancelled;
+
+  FOR cancelled_turn IN
+    SELECT turn_row.id, turn_row.session_id, turn_row.execution_generation
+    FROM session_turns turn_row
+    WHERE turn_row.account_id = account_id_value
+      AND turn_row.workspace_id = workspace_id_value
+      AND turn_row.id = ANY(cancelled_turn_ids)
+    ORDER BY turn_row.session_id, turn_row.id
+  LOOP
+    SELECT affected.last_sequence,
+      CASE WHEN affected.active_turn_id = cancelled_turn.id
+        THEN 'current' ELSE NULL END
+    INTO cancelled_sequence, cancelled_association
+    FROM sessions affected
+    WHERE affected.account_id = account_id_value
+      AND affected.workspace_id = workspace_id_value
+      AND affected.id = cancelled_turn.session_id;
+    FOR cancelled_request IN
+      UPDATE session_human_input_requests request_row
+      SET status = 'cancelled', response = '{"outcome":"cancelled"}'::jsonb,
+        responded_by = actor_subject, responded_at = now_value,
+        updated_at = now_value
+      WHERE request_row.account_id = account_id_value
+        AND request_row.workspace_id = workspace_id_value
+        AND request_row.session_id = cancelled_turn.session_id
+        AND request_row.turn_id = cancelled_turn.id
+        AND request_row.status = 'pending'
+      RETURNING request_row.id, request_row.creation_attempt_id
+    LOOP
+      cancelled_sequence := cancelled_sequence + 1;
+      INSERT INTO session_events (
+        account_id, workspace_id, session_id, sequence, type, payload,
+        payload_codec_version, turn_id, turn_generation,
+        turn_attempt_id, turn_association, occurred_at
+      ) VALUES (
+        account_id_value, workspace_id_value, cancelled_turn.session_id,
+        cancelled_sequence, 'user.humanInputResponse',
+        pg_catalog.jsonb_build_object(
+          'requestId', cancelled_request.id,
+          'response', pg_catalog.jsonb_build_object('outcome', 'cancelled')
+        ), 1, cancelled_turn.id, cancelled_turn.execution_generation,
+        cancelled_request.creation_attempt_id, cancelled_association, now_value
+      );
+    END LOOP;
+    SELECT
+      pg_catalog.array_agg(
+        update_row.id ORDER BY update_row.created_at, update_row.id
+      ),
+      (pg_catalog.array_agg(
+        update_row.delivered_history_item_id
+        ORDER BY update_row.created_at, update_row.id
+      ))[1]
+    INTO settled_update_ids, settled_history_item_id
+    FROM session_system_updates update_row
+    WHERE update_row.account_id = account_id_value
+      AND update_row.workspace_id = workspace_id_value
+      AND update_row.session_id = cancelled_turn.session_id
+      AND update_row.delivered_turn_id = cancelled_turn.id
+      AND update_row.state = 'delivered';
+    IF COALESCE(pg_catalog.array_length(settled_update_ids, 1), 0) > 0
+      AND NOT EXISTS (
+        SELECT 1 FROM session_events prior_settlement
+        WHERE prior_settlement.account_id = account_id_value
+          AND prior_settlement.workspace_id = workspace_id_value
+          AND prior_settlement.session_id = cancelled_turn.session_id
+          AND prior_settlement.turn_id = cancelled_turn.id
+          AND prior_settlement.type = 'system.update.settled'
+      )
+    THEN
+      cancelled_sequence := cancelled_sequence + 1;
+      INSERT INTO session_events (
+        account_id, workspace_id, session_id, sequence, type, payload,
+        payload_codec_version, turn_id, turn_generation,
+        turn_association, occurred_at
+      ) VALUES (
+        account_id_value, workspace_id_value, cancelled_turn.session_id,
+        cancelled_sequence, 'system.update.settled',
+        pg_catalog.jsonb_build_object(
+          'updateIds', pg_catalog.to_jsonb(settled_update_ids),
+          'count', pg_catalog.array_length(settled_update_ids, 1),
+          'historyItemId', settled_history_item_id,
+          'outcome', 'cancelled'
+        ), 1, cancelled_turn.id, cancelled_turn.execution_generation,
+        cancelled_association, now_value
+      );
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM session_events prior_cancel
+      WHERE prior_cancel.account_id = account_id_value
+        AND prior_cancel.workspace_id = workspace_id_value
+        AND prior_cancel.session_id = cancelled_turn.session_id
+        AND prior_cancel.turn_id = cancelled_turn.id
+        AND prior_cancel.type = 'turn.cancelled'
+    ) THEN
+      cancelled_sequence := cancelled_sequence + 1;
+      INSERT INTO session_events (
+        account_id, workspace_id, session_id, sequence, type, payload,
+        payload_codec_version, turn_id, turn_generation,
+        turn_association, occurred_at
+      ) VALUES (
+        account_id_value, workspace_id_value, cancelled_turn.session_id,
+        cancelled_sequence, 'turn.cancelled',
+        pg_catalog.jsonb_build_object('reason', 'authority_changed'),
+        1, cancelled_turn.id, cancelled_turn.execution_generation,
+        cancelled_association, now_value
+      );
+    END IF;
+    UPDATE sessions affected
+    SET last_sequence = cancelled_sequence, updated_at = now_value
+    WHERE affected.account_id = account_id_value
+      AND affected.workspace_id = workspace_id_value
+      AND affected.id = cancelled_turn.session_id;
+  END LOOP;
+
+  UPDATE interaction_interventions intervention
+  SET status = 'cancelled', response_actor_subject_id = actor_subject,
+    version = intervention.version + 1, settled_at = now_value,
+    updated_at = now_value
+  WHERE intervention.account_id = account_id_value
+    AND intervention.workspace_id = workspace_id_value
+    AND intervention.originating_turn_id = ANY(cancelled_turn_ids)
+    AND intervention.status = 'open';
+  DELETE FROM agent_run_states run_state
+  WHERE run_state.account_id = account_id_value
+    AND run_state.workspace_id = workspace_id_value
+    AND run_state.turn_id = ANY(cancelled_turn_ids);
+  UPDATE codex_capacity_waiters waiter
+  SET status = 'superseded', observed_wake_revision = waiter.wake_revision,
+    last_wake_reason = 'workspace_membership_remove',
+    updated_at = now_value
+  WHERE waiter.account_id = account_id_value
+    AND waiter.workspace_id = workspace_id_value
+    AND waiter.blocked_turn_id = ANY(cancelled_turn_ids)
+    AND waiter.status = 'waiting';
+  UPDATE xai_capacity_waiters waiter
+  SET status = 'superseded', observed_wake_revision = waiter.wake_revision,
+    last_wake_reason = 'workspace_membership_remove',
+    updated_at = now_value
+  WHERE waiter.account_id = account_id_value
+    AND waiter.workspace_id = workspace_id_value
+    AND waiter.blocked_turn_id = ANY(cancelled_turn_ids)
+    AND waiter.status = 'waiting';
+  UPDATE session_realtime_connections connection
+  SET state = 'closed', closed_at = now_value, updated_at = now_value
+  WHERE connection.account_id = account_id_value
+    AND connection.workspace_id = workspace_id_value
+    AND connection.realtime_id = ANY(affected_realtime_ids)
+    AND connection.state IN ('negotiating', 'ready', 'active');
+  WITH ended AS (
+    UPDATE session_realtime_modes realtime
+    SET state = 'ended', version = realtime.version + 1,
+      ended_at = now_value, end_reason = 'authority_revoked',
+      updated_at = now_value
+    WHERE realtime.account_id = account_id_value
+      AND realtime.workspace_id = workspace_id_value
+      AND realtime.id = ANY(affected_realtime_ids)
+      AND realtime.state = 'active'
+    RETURNING realtime.id, realtime.session_id, realtime.operation_id,
+      realtime.version, realtime.connection_epoch
+  ), advanced AS (
+    UPDATE sessions affected
+    SET last_sequence = affected.last_sequence + 1, updated_at = now_value
+    FROM ended
+    WHERE affected.account_id = account_id_value
+      AND affected.workspace_id = workspace_id_value
+      AND affected.id = ended.session_id
+    RETURNING affected.id AS session_id, affected.last_sequence,
+      ended.id AS realtime_id, ended.operation_id,
+      ended.version, ended.connection_epoch
+  )
+  INSERT INTO session_events (
+    account_id, workspace_id, session_id, sequence, type, payload, occurred_at
+  )
+  SELECT account_id_value, workspace_id_value, advanced.session_id,
+    advanced.last_sequence, 'session.realtime.ended',
+    pg_catalog.jsonb_build_object(
+      'realtimeId', advanced.realtime_id,
+      'operationId', advanced.operation_id,
+      'reason', 'authority_revoked',
+      'version', advanced.version,
+      'connectionEpoch', advanced.connection_epoch
+    ), now_value
+  FROM advanced;
+  UPDATE sessions affected
+  SET active_turn_id = CASE
+        WHEN affected.active_turn_id = ANY(cancelled_turn_ids) THEN NULL
+        ELSE affected.active_turn_id
+      END,
+    status = CASE
+      WHEN affected.active_turn_id = ANY(cancelled_turn_ids) THEN
+        CASE WHEN EXISTS (
+          SELECT 1 FROM session_turns queued
+          WHERE queued.account_id = affected.account_id
+            AND queued.workspace_id = affected.workspace_id
+            AND queued.session_id = affected.id
+            AND queued.status = 'queued'
+        ) THEN 'queued' ELSE 'idle' END
+      ELSE affected.status
+    END,
+    queue_head_position = COALESCE((
+      SELECT min(queued.position)::bigint FROM session_turns queued
+      WHERE queued.account_id = affected.account_id
+        AND queued.workspace_id = affected.workspace_id
+        AND queued.session_id = affected.id
+        AND queued.status = 'queued'
+    ), 0),
+    queue_tail_position = COALESCE((
+      SELECT max(queued.position)::bigint FROM session_turns queued
+      WHERE queued.account_id = affected.account_id
+        AND queued.workspace_id = affected.workspace_id
+        AND queued.session_id = affected.id
+        AND queued.status = 'queued'
+    ), 0),
+    queue_version = affected.queue_version + 1,
+    updated_at = now_value
+  WHERE affected.account_id = account_id_value
+    AND affected.workspace_id = workspace_id_value
+    AND EXISTS (
+      SELECT 1 FROM session_turns cancelled
+      WHERE cancelled.account_id = affected.account_id
+        AND cancelled.workspace_id = affected.workspace_id
+        AND cancelled.session_id = affected.id
+        AND cancelled.id = ANY(cancelled_turn_ids)
+    );
+  UPDATE session_system_updates update_row SET state = 'cancelled'
+  WHERE update_row.account_id = account_id_value
+    AND update_row.workspace_id = workspace_id_value
+    AND update_row.state = 'pending'
+    AND target_membership_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM sessions owned
+      WHERE owned.id = update_row.session_id
+        AND owned.owner_organization_membership_id = target_membership_id
+    );
+  UPDATE session_system_update_outbox outbox
+  SET status = 'failed', last_error = 'workspace_membership_remove',
+    updated_at = now_value
+  WHERE outbox.account_id = account_id_value
+    AND outbox.workspace_id = workspace_id_value
+    AND outbox.status = 'pending'
+    AND target_membership_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM sessions source_session
+      WHERE source_session.id = outbox.source_session_id
+        AND source_session.owner_organization_membership_id = target_membership_id
+    );
+  UPDATE session_goals goal_row
+  SET status = 'paused', paused_reason = 'api',
+    rationale = 'Workspace membership was removed; explicit reauthorization is required.',
+    version = goal_row.version + 1, updated_at = now_value
+  WHERE goal_row.account_id = account_id_value
+    AND goal_row.workspace_id = workspace_id_value
+    AND goal_row.status = 'active'
+    AND target_membership_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM sessions owned
+      WHERE owned.id = goal_row.session_id
+        AND owned.owner_organization_membership_id = target_membership_id
+    );
+  UPDATE scheduled_tasks task
+  SET status = 'paused', personal_connection_delegations = '[]'::jsonb,
+    authority_revision = task.authority_revision + 1,
+    updated_at = now_value
+  WHERE task.account_id = account_id_value
+    AND task.workspace_id = workspace_id_value
+    AND task.status = 'active'
+    AND task.created_by_kind = 'subject'
+    AND task.created_by_subject_id = target_subject;
+  UPDATE organization_user_resource_grants grant_row
+  SET status = 'revoked', revoked_at = now_value,
+    generation = grant_row.generation + 1, updated_at = now_value
+  WHERE grant_row.account_id = account_id_value
+    AND grant_row.workspace_id = workspace_id_value
+    AND grant_row.status = 'active'
+    AND target_membership_id IS NOT NULL
+    AND grant_row.owner_organization_membership_id = target_membership_id;
+  IF target_membership_id IS NOT NULL THEN
+    WITH advanced AS (
+      UPDATE sessions owned SET
+        authority_epoch = owned.authority_epoch + 1,
+        initial_personal_connection_delegations = '[]'::jsonb,
+        last_sequence = owned.last_sequence + 1
+      WHERE owned.account_id = account_id_value
+        AND owned.workspace_id = workspace_id_value
+        AND owned.owner_organization_membership_id = target_membership_id
+      RETURNING owned.id, owned.workspace_id, owned.last_sequence,
+        owned.authority_epoch
+    )
+    INSERT INTO session_events (
+      account_id, workspace_id, session_id, sequence, type, payload, occurred_at
+    )
+    SELECT account_id_value, advanced.workspace_id, advanced.id,
+      advanced.last_sequence, 'session.authority.revoked',
+      pg_catalog.jsonb_build_object(
+        'operationId', operation_id_value,
+        'organizationMembershipId', target_membership_id,
+        'previousAuthorityEpoch', advanced.authority_epoch - 1,
+        'authorityEpoch', advanced.authority_epoch
+      ), now_value
+    FROM advanced;
+  END IF;
+  INSERT INTO session_workflow_wake_outbox (
+    session_id, account_id, workspace_id, temporal_workflow_id,
+    reason, control_revision
+  )
+  SELECT affected.id, affected.account_id, affected.workspace_id,
+    COALESCE(affected.temporal_workflow_id, 'session-' || affected.id::text),
+    'workspace_membership_remove', 1
+  FROM sessions affected
+  WHERE affected.account_id = account_id_value
+    AND affected.workspace_id = workspace_id_value
+    AND affected.id = ANY(affected_session_ids)
+  ON CONFLICT (session_id) DO UPDATE SET
+    wake_revision = session_workflow_wake_outbox.wake_revision + 1,
+    control_revision = session_workflow_wake_outbox.wake_revision + 1,
+    temporal_workflow_id = EXCLUDED.temporal_workflow_id,
+    reason = EXCLUDED.reason, attempts = 0,
+    next_attempt_at = now_value, last_error = NULL,
+    updated_at = now_value;
+
+  -- Personal per-workspace rows and the membership itself, then the activity
+  -- gate finalization exactly as the organization lifecycle performs it.
+  DELETE FROM session_list_snapshots snapshot
+  WHERE snapshot.workspace_id = workspace_id_value
+    AND snapshot.subject_id = target_subject;
+  DELETE FROM session_pins pin
+  WHERE pin.workspace_id = workspace_id_value
+    AND pin.subject_id = target_subject;
+  DELETE FROM new_session_drafts draft
+  WHERE draft.workspace_id = workspace_id_value
+    AND draft.subject_id = target_subject;
+  DELETE FROM workspace_memberships membership
+  WHERE membership.id = membership_row_id;
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.session_activity_gate_state', 'preparing', true
+  );
+  SET CONSTRAINTS ALL IMMEDIATE;
+  SET CONSTRAINTS sessions_activity_insert_commit_guard,
+    sessions_activity_update_commit_guard DEFERRED;
+  PERFORM pg_catalog.set_config(
+    'opengeni.session_activity_gate_state', 'finalizing', true
+  );
+  UPDATE workspace_session_activity_revisions counter
+  SET revision = counter.revision + 1
+  WHERE counter.workspace_id = workspace_id_value
+  RETURNING counter.revision INTO activity_revision_value;
+  IF activity_revision_value IS NULL THEN
+    RAISE EXCEPTION 'workspace membership session activity counter is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+  UPDATE sessions affected
+  SET activity_revision = activity_revision_value,
+    activity_revision_pending_xid = NULL
+  WHERE affected.account_id = account_id_value
+    AND affected.workspace_id = workspace_id_value
+    AND affected.activity_revision_pending_xid
+      = pg_catalog.pg_current_xact_id()::text::bigint;
+  SET CONSTRAINTS sessions_activity_insert_commit_guard,
+    sessions_activity_update_commit_guard IMMEDIATE;
+
+  DELETE FROM session_visibility_write_capabilities capability
+  WHERE capability.backend_pid = pg_catalog.pg_backend_pid()
+    AND capability.transaction_id = pg_catalog.pg_current_xact_id()
+    AND capability.capability_id = visibility_capability_id;
+  PERFORM pg_catalog.set_config(
+    'opengeni.session_visibility_write_capability',
+    coalesce(previous_visibility_capability, ''), true
+  );
+  PERFORM pg_catalog.set_config(
+    'opengeni.workspace_id', coalesce(previous_workspace, ''), true
+  );
+  PERFORM pg_catalog.set_config(
+    'opengeni.session_activity_gate_state',
+    coalesce(previous_activity_gate_state, ''), true
+  );
+  PERFORM pg_catalog.set_config(
+    'opengeni.session_activity_gate_workspace_id',
+    coalesce(previous_activity_gate_workspace, ''), true
+  );
+  RETURN pg_catalog.jsonb_build_object(
+    'removed', true,
+    'workspaceMembershipId', membership_row_id,
+    'cancelledTurnIds', pg_catalog.to_jsonb(cancelled_turn_ids),
+    'affectedSessionIds', pg_catalog.to_jsonb(affected_session_ids)
+  );
+EXCEPTION WHEN OTHERS THEN
+  PERFORM pg_catalog.set_config(
+    'opengeni.workspace_id', coalesce(previous_workspace, ''), true
+  );
+  PERFORM pg_catalog.set_config(
+    'opengeni.session_visibility_write_capability',
+    coalesce(previous_visibility_capability, ''), true
+  );
+  PERFORM pg_catalog.set_config(
+    'opengeni.session_activity_gate_state',
+    coalesce(previous_activity_gate_state, ''), true
+  );
+  PERFORM pg_catalog.set_config(
+    'opengeni.session_activity_gate_workspace_id',
+    coalesce(previous_activity_gate_workspace, ''), true
+  );
+  RAISE;
+END
+$body$;
+
+-- 4. Hardening + grants. Same posture as every lifecycle seam: pinned
+-- search_path, revoked from PUBLIC, EXECUTE granted only to the runtime role
+-- where it exists (role-free dedicated-schema/embedded replays skip it).
+
+REVOKE ALL ON FUNCTION prepare_workspace_membership_removal_settlements(jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION workspace_membership_removal_command(jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION opengeni_private.assert_workspace_membership_removal_actor(
+  uuid, uuid, text, text
+) FROM PUBLIC;
+
+DO $workspace_membership_removal_seam$
+DECLARE
+  data_schema text := pg_catalog.current_schema();
+BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.prepare_workspace_membership_removal_settlements(jsonb) '
+      || 'SET search_path = pg_catalog, %I, pg_temp',
+    data_schema, data_schema
+  );
+  EXECUTE format(
+    'ALTER FUNCTION %I.workspace_membership_removal_command(jsonb) '
+      || 'SET search_path = pg_catalog, %I, pg_temp',
+    data_schema, data_schema
+  );
+  EXECUTE format(
+    'ALTER FUNCTION opengeni_private.assert_workspace_membership_removal_actor'
+      || '(uuid,uuid,text,text) SET search_path = pg_catalog, %I, pg_temp',
+    data_schema
+  );
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    EXECUTE format(
+      'GRANT EXECUTE ON FUNCTION %I.prepare_workspace_membership_removal_settlements(jsonb) '
+        || 'TO opengeni_app',
+      data_schema
+    );
+    EXECUTE format(
+      'GRANT EXECUTE ON FUNCTION %I.workspace_membership_removal_command(jsonb) '
+        || 'TO opengeni_app',
+      data_schema
+    );
+  END IF;
+END
+$workspace_membership_removal_seam$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2193,75 +2193,8 @@ export async function listWorkspaceMembers(
   });
 }
 
-export async function removeWorkspaceMember(
-  db: Database,
-  workspaceId: string,
-  subjectId: string,
-): Promise<boolean> {
-  // A removed principal must not regain stale organization preferences if the
-  // same stable subject is invited again later. Set the target subject GUC so
-  // FORCE RLS permits deleting only that member's personal rows, and make the
-  // cleanup + membership removal one transaction.
-  return await withWorkspaceSubjectRls(db, workspaceId, subjectId, async (scopedDb) => {
-    await lockSessionPersonalStateExclusive(scopedDb, workspaceId, subjectId);
-    // Exclusively lock the membership before cleanup so concurrent removals
-    // preserve the previous one-winner/one-no-op behavior while snapshots are
-    // still visible to the subject-scoped FORCE-RLS policy. Session listing takes
-    // the shared counterpart of this subject fence; pin mutation takes the same
-    // exclusive fence. Removal therefore waits for readers/writers, then cleans
-    // every personal row before deleting the membership.
-    const [membership] = await scopedDb
-      .select({ id: schema.workspaceMemberships.id })
-      .from(schema.workspaceMemberships)
-      .where(
-        and(
-          eq(schema.workspaceMemberships.workspaceId, workspaceId),
-          eq(schema.workspaceMemberships.subjectId, subjectId),
-        ),
-      )
-      .for("update")
-      .limit(1);
-    if (!membership) {
-      return false;
-    }
-
-    await scopedDb
-      .delete(schema.sessionListSnapshots)
-      .where(
-        and(
-          eq(schema.sessionListSnapshots.workspaceId, workspaceId),
-          eq(schema.sessionListSnapshots.subjectId, subjectId),
-        ),
-      );
-    await scopedDb
-      .delete(schema.sessionPins)
-      .where(
-        and(
-          eq(schema.sessionPins.workspaceId, workspaceId),
-          eq(schema.sessionPins.subjectId, subjectId),
-        ),
-      );
-    await scopedDb
-      .delete(schema.newSessionDrafts)
-      .where(
-        and(
-          eq(schema.newSessionDrafts.workspaceId, workspaceId),
-          eq(schema.newSessionDrafts.subjectId, subjectId),
-        ),
-      );
-
-    const rows = await scopedDb
-      .delete(schema.workspaceMemberships)
-      .where(
-        and(
-          eq(schema.workspaceMemberships.workspaceId, workspaceId),
-          eq(schema.workspaceMemberships.subjectId, subjectId),
-        ),
-      )
-      .returning({ id: schema.workspaceMemberships.id });
-    return rows.length > 0;
-  });
-}
+// removeWorkspaceMember moved to ./organization-membership-lifecycle: removal is
+// now the fenced SECURITY DEFINER teardown from migration 0278.
 
 /**
  * Resolve a managed user email to its user id.

--- a/packages/db/src/organization-membership-lifecycle.ts
+++ b/packages/db/src/organization-membership-lifecycle.ts
@@ -211,6 +211,77 @@ async function settleOrganizationMembershipProtocols(
   }
 }
 
+/**
+ * Remove one workspace membership through the fenced SECURITY DEFINER
+ * teardown (migration 0278): the same prepare/settle/command protocol as
+ * organization offboarding, scoped to exactly one workspace and one subject.
+ * Cancels the removed member's queued/live turns in the workspace, interrupts
+ * live attempts, ends their realtime modes, advances their private sessions'
+ * authority epochs, registers workflow wakes, deletes their per-workspace
+ * personal rows, and deletes the membership - in one transaction. Returns
+ * false when no membership row exists (idempotent retry).
+ */
+export async function removeWorkspaceMember(
+  db: Database,
+  input: {
+    accountId: string;
+    workspaceId: string;
+    actorSubjectId: string;
+    targetSubjectId: string;
+  },
+): Promise<boolean> {
+  const command = {
+    action: "remove",
+    organizationId: input.accountId,
+    workspaceId: input.workspaceId,
+    actorSubjectId: input.actorSubjectId,
+    targetSubjectId: input.targetSubjectId,
+    operationId: crypto.randomUUID(),
+  };
+  return await db.transaction(async (tx) => {
+    const txDb = tx as unknown as Database;
+    // The personal-state fence first, exactly as the pre-0278 delete path took
+    // it: session listing takes the shared counterpart and pin mutation the
+    // same exclusive one. The removal command re-acquires it (reentrant within
+    // this transaction), but taking it here keeps the wait observable and the
+    // fence ordered before every other lock this transaction takes.
+    await txDb.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(
+        ${`session-personal-state:${input.workspaceId}:${input.targetSubjectId}`}, 0))`,
+    );
+    const settlements = await withRlsContext(
+      txDb,
+      { accountId: input.accountId, workspaceId: null },
+      async (scopedDb) => {
+        await setSubjectRlsContext(scopedDb, input.actorSubjectId);
+        const [row] = await rawRows<{ result: unknown }>(
+          scopedDb,
+          sql`select prepare_workspace_membership_removal_settlements(
+            ${JSON.stringify(command)}::jsonb
+          ) as result`,
+        );
+        return parseOrganizationMembershipProtocolSettlements(row?.result ?? []);
+      },
+    );
+    await settleOrganizationMembershipProtocols(txDb, settlements);
+    return await withRlsContext(
+      txDb,
+      { accountId: input.accountId, workspaceId: null },
+      async (scopedDb) => {
+        await setSubjectRlsContext(scopedDb, input.actorSubjectId);
+        const [row] = await rawRows<{ result: unknown }>(
+          scopedDb,
+          sql`select workspace_membership_removal_command(
+            ${JSON.stringify(command)}::jsonb
+          ) as result`,
+        );
+        if (!row) throw new Error("Workspace membership removal returned no result");
+        return (row.result as { removed?: unknown } | null)?.removed === true;
+      },
+    );
+  });
+}
+
 export async function assertActiveManagedHumanOrganizationMembership(
   db: Database,
   input: { accountId: string; subjectId: string },

--- a/packages/db/src/provision-roles.ts
+++ b/packages/db/src/provision-roles.ts
@@ -493,6 +493,8 @@ async function grantAppRoleIfSchemaExists(
     "prepare_organization_membership_protocol_settlements(jsonb)",
     "assert_active_managed_human_organization_membership(uuid,text)",
     "resolve_workspace_writer_grant_identity(uuid,text)",
+    "prepare_workspace_membership_removal_settlements(jsonb)",
+    "workspace_membership_removal_command(jsonb)",
     "get_organization_retention_policy(uuid,text)",
     "preview_organization_retention_deletions(uuid,integer)",
     "claim_organization_retention_deletion(uuid,uuid,uuid[])",

--- a/packages/db/src/runtime-posture.ts
+++ b/packages/db/src/runtime-posture.ts
@@ -77,6 +77,8 @@ const ORGANIZATION_MEMBERSHIP_LIFECYCLE_ROUTINES = [
   "prepare_organization_membership_protocol_settlements(jsonb)",
   "assert_active_managed_human_organization_membership(uuid, text)",
   "resolve_workspace_writer_grant_identity(uuid, text)",
+  "prepare_workspace_membership_removal_settlements(jsonb)",
+  "workspace_membership_removal_command(jsonb)",
   "get_organization_retention_policy(uuid, text)",
   "preview_organization_retention_deletions(uuid, integer)",
   "claim_organization_retention_deletion(uuid, uuid, uuid[])",

--- a/packages/db/test/migration-0278-workspace-membership-removal.test.ts
+++ b/packages/db/test/migration-0278-workspace-membership-removal.test.ts
@@ -1,0 +1,81 @@
+// Migration 0278: workspace-membership removal is one fenced SECURITY DEFINER
+// teardown. Source contract plus the live definer posture; the behavioral
+// protocol is exercised in workspace-membership-removal.test.ts.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import { readFile } from "node:fs/promises";
+
+const migrationUrl = new URL(
+  "../drizzle/0278_workspace_membership_removal_fencing.sql",
+  import.meta.url,
+);
+
+let shared: SharedTestDatabase | null = null;
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("migration-0278-membership-removal");
+});
+
+afterAll(async () => {
+  await shared?.release();
+});
+
+describe("migration 0278 workspace membership removal fencing", () => {
+  test("declares one rolling fenced-removal protocol", async () => {
+    const source = await readFile(migrationUrl, "utf8");
+    expect(source.split(/\r?\n/u, 1)[0]).toBe("-- deployment-mode: rolling");
+    expect(source).toContain("CREATE FUNCTION prepare_workspace_membership_removal_settlements(");
+    expect(source).toContain("CREATE FUNCTION workspace_membership_removal_command(");
+    expect(source).toContain(
+      "CREATE FUNCTION opengeni_private.assert_workspace_membership_removal_actor(",
+    );
+    // Fail-closed guards, restated from the application layer.
+    expect(source).toContain("a member cannot remove their own workspace membership");
+    expect(source).toContain("cannot remove the last administering workspace member");
+    expect(source).toContain("workspace member administration required");
+    // The canonical settlement contract and lock prefix.
+    expect(source).toContain("pending tool calls require canonical protocol settlement");
+    expect(source).toContain("FOR SHARE");
+    expect(source).toContain("FOR KEY SHARE");
+    expect(source).toContain("FOR NO KEY UPDATE");
+    // The personal-state fence the pre-0278 path took stays load-bearing.
+    expect(source).toContain("session-personal-state:");
+    // Interruption evidence uses the existing kind vocabulary; no constraint
+    // rewrite and no schema shape change in a rolling migration.
+    expect(source).toContain("'authority_change'");
+    expect(source).not.toMatch(/\bALTER TABLE\b/u);
+    expect(source).not.toMatch(/\bDROP TABLE\b/u);
+    expect(source).not.toMatch(/\bTRUNCATE\b/u);
+    // Definer hardening.
+    expect(source).toContain(
+      "REVOKE ALL ON FUNCTION prepare_workspace_membership_removal_settlements(jsonb) FROM PUBLIC",
+    );
+    expect(source).toContain(
+      "REVOKE ALL ON FUNCTION workspace_membership_removal_command(jsonb) FROM PUBLIC",
+    );
+    expect(source).toContain("IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app')");
+  });
+
+  test("both seams are SECURITY DEFINER with a pinned search_path on the live database", async () => {
+    if (!shared) return;
+    const rows = await shared.admin<
+      Array<{ name: string; secdef: boolean; config: string[] | null }>
+    >`
+      select proname as name, prosecdef as secdef, proconfig as config
+      from pg_proc
+      where proname in (
+        'prepare_workspace_membership_removal_settlements',
+        'workspace_membership_removal_command'
+      )
+      order by proname`;
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.secdef).toBe(true);
+      expect(
+        (row.config ?? []).some(
+          (entry) => entry.startsWith("search_path=") && entry.includes("pg_catalog"),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/db/test/new-session-drafts.test.ts
+++ b/packages/db/test/new-session-drafts.test.ts
@@ -13,6 +13,7 @@ import {
   createDb,
   createSession,
   getNewSessionDraftInTransaction,
+  grantWorkspaceAccess,
   initializeSessionStartAtomically,
   NewSessionDraftAccessError,
   NewSessionDraftConflictError,
@@ -454,8 +455,20 @@ describe("actor-private new-session drafts (real PostgreSQL + FORCE RLS)", () =>
     const context = await fixture();
     await saveDraft(context, 0);
 
+    const removerSubjectId = `user:remover-${crypto.randomUUID()}`;
+    await grantWorkspaceAccess(client.db, {
+      accountId: context.grant.accountId,
+      workspaceId: context.grant.workspaceId!,
+      subjectId: removerSubjectId,
+      permissions: ["workspace:admin"],
+    });
     expect(
-      await removeWorkspaceMember(client.db, context.grant.workspaceId!, context.subjectId),
+      await removeWorkspaceMember(client.db, {
+        accountId: context.grant.accountId,
+        workspaceId: context.grant.workspaceId!,
+        actorSubjectId: removerSubjectId,
+        targetSubjectId: context.subjectId,
+      }),
     ).toBe(true);
 
     const [count] = await shared.admin<{ count: number }[]>`

--- a/packages/db/test/session-pins.test.ts
+++ b/packages/db/test/session-pins.test.ts
@@ -68,6 +68,27 @@ async function session(input: {
   });
 }
 
+/** Removal now requires an explicit administering actor (migration 0278). */
+async function removeMemberAsAdmin(
+  handle: Database,
+  workspace: { accountId: string; workspaceId: string },
+  targetSubjectId: string,
+): Promise<boolean> {
+  const actorSubjectId = `user:remover-${crypto.randomUUID()}`;
+  await grantWorkspaceAccess(handle, {
+    accountId: workspace.accountId,
+    workspaceId: workspace.workspaceId,
+    subjectId: actorSubjectId,
+    permissions: ["workspace:admin"],
+  });
+  return await removeWorkspaceMember(handle, {
+    accountId: workspace.accountId,
+    workspaceId: workspace.workspaceId,
+    actorSubjectId,
+    targetSubjectId,
+  });
+}
+
 async function grantMember(
   workspace: { accountId: string; workspaceId: string },
   subjectId: string,
@@ -1031,7 +1052,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       pinned: true,
     });
 
-    expect(await removeWorkspaceMember(db, workspace.workspaceId, subjectId)).toBe(true);
+    expect(await removeMemberAsAdmin(db, workspace, subjectId)).toBe(true);
     const [counts] = await admin<{ memberships: number; pins: number }[]>`
       select
         (select count(*)::int from workspace_memberships
@@ -1108,7 +1129,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       sessionId: staleTarget.id,
       pinned: true,
     });
-    expect(await removeWorkspaceMember(db, workspace.workspaceId, staleSubject)).toBe(true);
+    expect(await removeMemberAsAdmin(db, workspace, staleSubject)).toBe(true);
     await expect(
       listSessionsForSubject(db, workspace.workspaceId, {
         subjectId: staleSubject,
@@ -1189,14 +1210,12 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       await waitForAdvisoryWait(admin, barrierClass, listingLock);
 
       let removalSettled = false;
-      removalPromise = removeWorkspaceMember(
-        removalClient.db,
-        workspace.workspaceId,
-        lockedSubject,
-      ).then((removed) => {
-        removalSettled = true;
-        return removed;
-      });
+      removalPromise = removeMemberAsAdmin(removalClient.db, workspace, lockedSubject).then(
+        (removed) => {
+          removalSettled = true;
+          return removed;
+        },
+      );
 
       await barrier`select pg_advisory_unlock(${barrierClass}, ${listingLock})`;
       const listed = await listingPromise;
@@ -1318,7 +1337,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       `);
       await barrier`select pg_advisory_lock(${barrierClass}, ${removalLock})`;
 
-      removalPromise = removeWorkspaceMember(removalClient.db, workspace.workspaceId, subjectId);
+      removalPromise = removeMemberAsAdmin(removalClient.db, workspace, subjectId);
       await waitForAdvisoryWait(admin, barrierClass, removalLock);
 
       // Start listing while removal owns the personal-state fence. The list must
@@ -1702,7 +1721,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
       `);
       await barrier`select pg_advisory_lock(${barrierClass}, ${removalLock})`;
 
-      removalPromise = removeWorkspaceMember(removalClient.db, workspace.workspaceId, subjectId);
+      removalPromise = removeMemberAsAdmin(removalClient.db, workspace, subjectId);
       await waitForAdvisoryWait(admin, barrierClass, removalLock);
 
       // The API grant is intentionally stale: the pin transaction must wait on
@@ -1810,7 +1829,7 @@ describe("session pins (real PostgreSQL + FORCE RLS)", () => {
 
       // Pin mutation owns membership first; removal waits, then cleans the
       // committed pin after the insert barrier is released.
-      removalPromise = removeWorkspaceMember(removalClient.db, workspace.workspaceId, subjectId);
+      removalPromise = removeMemberAsAdmin(removalClient.db, workspace, subjectId);
       await waitForDatabaseQueryWait(admin, "pg_advisory_xact_lock");
 
       await barrier`select pg_advisory_unlock(${barrierClass}, ${pinInsertLock})`;

--- a/packages/db/test/workspace-membership-removal.test.ts
+++ b/packages/db/test/workspace-membership-removal.test.ts
@@ -67,6 +67,19 @@ async function grantAdmin(workspace: Workspace): Promise<string> {
   return subjectId;
 }
 
+/** An active organization admin who is not a workspace member. */
+async function grantOrgAdmin(workspace: Workspace): Promise<string> {
+  const subjectId = `user:org-admin-${crypto.randomUUID()}`;
+  const [personal] = await admin<{ id: string }[]>`
+    insert into workspaces (account_id, name)
+    values (${workspace.accountId}, ${`personal-${subjectId}`}) returning id`;
+  await admin`
+    insert into organization_memberships (
+      account_id, subject_id, role, status, personal_workspace_id, authorization_revision
+    ) values (${workspace.accountId}, ${subjectId}, 'admin', 'active', ${personal!.id}, 1)`;
+  return subjectId;
+}
+
 async function grantOrdinaryMember(workspace: Workspace, subjectId: string): Promise<void> {
   await grantWorkspaceAccess(db, {
     ...workspace,
@@ -410,6 +423,57 @@ describe("workspace membership removal fencing", () => {
       pendingToolCalls: 0,
       sessionStatus: "idle",
     });
+  });
+
+  test("two concurrent removals of the two last administering members leave one standing", async () => {
+    if (!available || !shared) return;
+    const workspace = await freshWorkspace();
+    const adminA = await grantAdmin(workspace);
+    const adminB = await grantAdmin(workspace);
+    // Two independent organization-admin actors race to remove A and B. The
+    // roster locks serialize them: exactly one removal commits and the loser
+    // fails closed on the last-admin guard (55000) - never zero admins left.
+    const actorX = await grantOrgAdmin(workspace);
+    const actorY = await grantOrgAdmin(workspace);
+    const clientX = createDb(shared.appUrl, { max: 1 });
+    const clientY = createDb(shared.appUrl, { max: 1 });
+    try {
+      const [first, second] = await Promise.allSettled([
+        removeWorkspaceMember(clientX.db, {
+          accountId: workspace.accountId,
+          workspaceId: workspace.workspaceId,
+          actorSubjectId: actorX,
+          targetSubjectId: adminA,
+        }),
+        removeWorkspaceMember(clientY.db, {
+          accountId: workspace.accountId,
+          workspaceId: workspace.workspaceId,
+          actorSubjectId: actorY,
+          targetSubjectId: adminB,
+        }),
+      ]);
+      const outcomes = [first!, second!];
+      const fulfilled = outcomes.filter(
+        (candidate): candidate is PromiseFulfilledResult<boolean> =>
+          candidate.status === "fulfilled",
+      );
+      const rejected = outcomes.filter(
+        (candidate): candidate is PromiseRejectedResult => candidate.status === "rejected",
+      );
+      expect(fulfilled).toHaveLength(1);
+      expect(fulfilled[0]!.value).toBe(true);
+      expect(rejected).toHaveLength(1);
+      expect(postgresCode(rejected[0]!.reason)).toBe("55000");
+      const [roster] = await admin<{ admins: number }[]>`
+        select count(*)::int as admins
+        from workspace_memberships
+        where workspace_id = ${workspace.workspaceId}
+          and permissions ?| array['workspace:admin', 'members:manage']`;
+      expect(roster!.admins).toBe(1);
+    } finally {
+      await clientX.close();
+      await clientY.close();
+    }
   });
 
   test("refuses self-removal, last-admin removal, and a non-administering actor", async () => {

--- a/packages/db/test/workspace-membership-removal.test.ts
+++ b/packages/db/test/workspace-membership-removal.test.ts
@@ -1,0 +1,490 @@
+// Workspace-membership removal is the fenced SECURITY DEFINER teardown from
+// migration 0278: the removed member's queued/live work in that workspace is
+// cancelled and fenced, their private sessions' authority epochs advance, and
+// the guards (self-removal, last admin, actor administration) fail closed.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import postgres from "postgres";
+import {
+  acceptOrganizationInvitation,
+  createDb,
+  createOrganizationInvitation,
+  createSession,
+  ensureManagedAccessForUser,
+  grantWorkspaceAccess,
+  listSelfOrganizationMemberships,
+  removeWorkspaceMember,
+  transitionSessionVisibility,
+  type Database,
+  type DbClient,
+} from "../src";
+
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+let client: DbClient;
+let db: Database;
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("workspace-membership-removal");
+  if (!shared) {
+    available = false;
+    if (requireRealDatabase) throw new Error("OPENGENI_REQUIRE_REAL_DB=1 but no database");
+    return;
+  }
+  admin = shared.admin;
+  client = createDb(shared.appUrl, { max: 4 });
+  db = client.db;
+});
+
+afterAll(async () => {
+  await client?.close();
+  await shared?.release();
+});
+
+type Workspace = { accountId: string; workspaceId: string };
+
+async function freshWorkspace(): Promise<Workspace> {
+  const [account] = await admin<{ id: string }[]>`
+    insert into managed_accounts (name) values ('workspace-membership-removal') returning id`;
+  const [workspace] = await admin<{ id: string }[]>`
+    insert into workspaces (account_id, name)
+    values (${account!.id}, 'membership-removal-workspace') returning id`;
+  await admin`
+    insert into workspace_inference_controls (workspace_id, account_id)
+    values (${workspace!.id}, ${account!.id})`;
+  return { accountId: account!.id, workspaceId: workspace!.id };
+}
+
+async function grantAdmin(workspace: Workspace): Promise<string> {
+  const subjectId = `user:admin-${crypto.randomUUID()}`;
+  await grantWorkspaceAccess(db, {
+    ...workspace,
+    subjectId,
+    permissions: ["workspace:admin"],
+  });
+  return subjectId;
+}
+
+async function grantOrdinaryMember(workspace: Workspace, subjectId: string): Promise<void> {
+  await grantWorkspaceAccess(db, {
+    ...workspace,
+    subjectId,
+    permissions: ["sessions:read", "sessions:create"],
+  });
+}
+
+async function insertQueuedTurn(
+  workspace: Workspace,
+  sessionId: string,
+  initiatingHuman: string,
+): Promise<string> {
+  const turnId = crypto.randomUUID();
+  await admin`
+    insert into session_turns (
+      id, account_id, workspace_id, session_id, trigger_event_id,
+      temporal_workflow_id, status, execution_generation, position, prompt,
+      model, reasoning_effort, latency_mode, sandbox_backend, initiator_kind,
+      initiator_subject_id, initiating_human_subject_id
+    ) values (
+      ${turnId}, ${workspace.accountId}, ${workspace.workspaceId}, ${sessionId},
+      ${crypto.randomUUID()}, ${`removal-${crypto.randomUUID()}`},
+      'queued', 1, 1, 'member work', 'test-model', 'medium', 'standard',
+      'none', 'subject', ${initiatingHuman}, ${initiatingHuman}
+    )`;
+  return turnId;
+}
+
+function postgresCode(error: unknown): string | null {
+  const seen = new Set<object>();
+  let candidate: unknown = error;
+  while (typeof candidate === "object" && candidate !== null && !seen.has(candidate)) {
+    seen.add(candidate);
+    const code = (candidate as { code?: unknown }).code;
+    if (typeof code === "string") return code;
+    candidate = (candidate as { cause?: unknown }).cause;
+  }
+  return null;
+}
+
+async function expectRemovalRejection(
+  attempt: Promise<unknown>,
+  expectedCode: string,
+): Promise<void> {
+  try {
+    await attempt;
+  } catch (error) {
+    expect(postgresCode(error)).toBe(expectedCode);
+    return;
+  }
+  throw new Error(`expected removal to be rejected with SQLSTATE ${expectedCode}`);
+}
+
+describe("workspace membership removal fencing", () => {
+  test("cancels the removed member's queued turn, wakes the workflow, and leaves others alone", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const actor = await grantAdmin(workspace);
+    const target = `user:removed-${crypto.randomUUID()}`;
+    const bystander = `user:bystander-${crypto.randomUUID()}`;
+    await grantOrdinaryMember(workspace, target);
+    await grantOrdinaryMember(workspace, bystander);
+    const targetSession = await createSession(db, {
+      accountId: workspace.accountId,
+      workspaceId: workspace.workspaceId,
+      initialMessage: "target work",
+      resources: [],
+      metadata: {},
+      createdBy: { kind: "subject", subjectId: target },
+      subjectId: target,
+      model: "test-model",
+      sandboxBackend: "none",
+    });
+    const bystanderSession = await createSession(db, {
+      accountId: workspace.accountId,
+      workspaceId: workspace.workspaceId,
+      initialMessage: "bystander work",
+      resources: [],
+      metadata: {},
+      createdBy: { kind: "subject", subjectId: bystander },
+      subjectId: bystander,
+      model: "test-model",
+      sandboxBackend: "none",
+    });
+    const targetTurn = await insertQueuedTurn(workspace, targetSession.id, target);
+    const bystanderTurn = await insertQueuedTurn(workspace, bystanderSession.id, bystander);
+
+    expect(
+      await removeWorkspaceMember(db, {
+        accountId: workspace.accountId,
+        workspaceId: workspace.workspaceId,
+        actorSubjectId: actor,
+        targetSubjectId: target,
+      }),
+    ).toBe(true);
+
+    const [after] = await admin<
+      Array<{
+        membership: number;
+        targetTurn: string;
+        bystanderTurn: string;
+        cancelEvents: number;
+        wakeRows: number;
+      }>
+    >`
+      select
+        (select count(*)::int from workspace_memberships
+          where workspace_id = ${workspace.workspaceId} and subject_id = ${target}) as membership,
+        (select status from session_turns where id = ${targetTurn}) as "targetTurn",
+        (select status from session_turns where id = ${bystanderTurn}) as "bystanderTurn",
+        (select count(*)::int from session_events
+          where session_id = ${targetSession.id} and type = 'turn.cancelled') as "cancelEvents",
+        (select count(*)::int from session_workflow_wake_outbox
+          where session_id = ${targetSession.id}) as "wakeRows"`;
+    expect(after).toEqual({
+      membership: 0,
+      targetTurn: "cancelled",
+      bystanderTurn: "queued",
+      cancelEvents: 1,
+      wakeRows: 1,
+    });
+  });
+
+  test("advances the removed managed human's private-session authority epoch in that workspace only", async () => {
+    if (!available) return;
+    const ownerId = `removal-owner-${crypto.randomUUID()}`;
+    const targetId = `removal-target-${crypto.randomUUID()}`;
+    const ownerSubject = `user:${ownerId}`;
+    const targetSubject = `user:${targetId}`;
+    await ensureManagedAccessForUser(db, {
+      userId: ownerId,
+      email: `${ownerId}@example.test`,
+      name: ownerId,
+    });
+    const [owner] = await listSelfOrganizationMemberships(db, ownerSubject);
+    const organizationId = owner!.organizationId;
+    const invitation = await createOrganizationInvitation(db, {
+      organizationId,
+      actorSubjectId: ownerSubject,
+      operationId: crypto.randomUUID(),
+      targetSubjectId: targetSubject,
+      targetEmail: `${targetId}@example.test`,
+      role: "member",
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+    const member = (
+      await acceptOrganizationInvitation(db, {
+        organizationId,
+        actorSubjectId: targetSubject,
+        operationId: crypto.randomUUID(),
+        invitationId: invitation.id,
+        expectedRevision: invitation.revision,
+      })
+    ).membership;
+    const [workspaceRow] = await admin<{ id: string }[]>`
+      insert into workspaces (account_id, name, external_source, external_id)
+      values (${organizationId}, 'removal shared', 'test', ${crypto.randomUUID()})
+      returning id`;
+    const workspaceId = workspaceRow!.id;
+    await admin`
+      insert into workspace_inference_controls (account_id, workspace_id)
+      values (${organizationId}, ${workspaceId})`;
+    const [otherWorkspaceRow] = await admin<{ id: string }[]>`
+      insert into workspaces (account_id, name, external_source, external_id)
+      values (${organizationId}, 'removal other', 'test', ${crypto.randomUUID()})
+      returning id`;
+    await admin`
+      insert into workspace_inference_controls (account_id, workspace_id)
+      values (${organizationId}, ${otherWorkspaceRow!.id})`;
+    await admin`
+      insert into workspace_memberships (account_id, workspace_id, subject_id, role, permissions)
+      values
+        (${organizationId}, ${workspaceId}, ${ownerSubject}, 'owner',
+          '["workspace:admin"]'::jsonb),
+        (${organizationId}, ${workspaceId}, ${targetSubject}, 'member',
+          '["sessions:read"]'::jsonb),
+        (${organizationId}, ${otherWorkspaceRow!.id}, ${targetSubject}, 'member',
+          '["sessions:read"]'::jsonb)`;
+
+    const privateSession = await createSession(db, {
+      accountId: organizationId,
+      workspaceId,
+      initialMessage: "private work",
+      resources: [],
+      metadata: {},
+      createdBy: { kind: "subject", subjectId: targetSubject },
+      subjectId: targetSubject,
+      model: "test-model",
+      sandboxBackend: "none",
+    });
+    const transition = await transitionSessionVisibility(db, {
+      workspaceId,
+      sessionId: privateSession.id,
+      actorSubjectId: targetSubject,
+      targetVisibility: "user_private",
+      expectedAuthorityEpoch: 1,
+      operationKey: `private:${crypto.randomUUID()}`,
+    });
+    expect(transition.authorityEpoch).toBe(2);
+    const otherSession = await createSession(db, {
+      accountId: organizationId,
+      workspaceId: otherWorkspaceRow!.id,
+      initialMessage: "other-workspace work",
+      resources: [],
+      metadata: {},
+      createdBy: { kind: "subject", subjectId: targetSubject },
+      subjectId: targetSubject,
+      model: "test-model",
+      sandboxBackend: "none",
+    });
+
+    expect(
+      await removeWorkspaceMember(db, {
+        accountId: organizationId,
+        workspaceId,
+        actorSubjectId: ownerSubject,
+        targetSubjectId: targetSubject,
+      }),
+    ).toBe(true);
+
+    const [after] = await admin<
+      Array<{
+        epoch: number;
+        revokedEvents: number;
+        otherEpoch: number;
+        otherMembership: number;
+        orgStatus: string;
+      }>
+    >`
+      select
+        (select authority_epoch::int from sessions where id = ${privateSession.id}) as epoch,
+        (select count(*)::int from session_events
+          where session_id = ${privateSession.id}
+            and type = 'session.authority.revoked') as "revokedEvents",
+        (select authority_epoch::int from sessions where id = ${otherSession.id}) as "otherEpoch",
+        (select count(*)::int from workspace_memberships
+          where workspace_id = ${otherWorkspaceRow!.id}
+            and subject_id = ${targetSubject}) as "otherMembership",
+        (select status from organization_memberships where id = ${member.id}) as "orgStatus"`;
+    expect(after).toEqual({
+      epoch: 3,
+      revokedEvents: 1,
+      otherEpoch: 1,
+      otherMembership: 1,
+      orgStatus: "active",
+    });
+  });
+
+  test("settles a requires_action turn with pending tool calls through the canonical protocol", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const actor = await grantAdmin(workspace);
+    const target = `user:settled-${crypto.randomUUID()}`;
+    await grantOrdinaryMember(workspace, target);
+    const session = await createSession(db, {
+      accountId: workspace.accountId,
+      workspaceId: workspace.workspaceId,
+      initialMessage: "requires action work",
+      resources: [],
+      metadata: {},
+      createdBy: { kind: "subject", subjectId: target },
+      subjectId: target,
+      model: "test-model",
+      sandboxBackend: "none",
+    });
+    const turnId = crypto.randomUUID();
+    const attemptId = crypto.randomUUID();
+    const callId = `call-${crypto.randomUUID()}`;
+    await admin`
+      insert into session_turns (
+        id, account_id, workspace_id, session_id, trigger_event_id,
+        temporal_workflow_id, status, execution_generation, position, prompt,
+        model, reasoning_effort, latency_mode, sandbox_backend, initiator_kind,
+        initiator_subject_id, initiating_human_subject_id
+      ) values (
+        ${turnId}, ${workspace.accountId}, ${workspace.workspaceId}, ${session.id},
+        ${crypto.randomUUID()}, ${`removal-${crypto.randomUUID()}`},
+        'running', 1, 1, 'requires action work', 'test-model', 'medium',
+        'standard', 'none', 'subject', ${target}, ${target}
+      )`;
+    await admin.begin(async (tx) => {
+      await tx`update sessions set active_turn_id = ${turnId}, status = 'running'
+        where id = ${session.id}`;
+      await tx`update session_turns set active_attempt_id = ${attemptId}
+        where id = ${turnId}`;
+      await tx`
+        insert into session_turn_attempts (
+          id, account_id, workspace_id, session_id, turn_id, execution_generation,
+          state, temporal_workflow_id, temporal_workflow_run_id,
+          temporal_activity_id, verified_control_revision, mcp_approval_policies
+        ) values (
+          ${attemptId}, ${workspace.accountId}, ${workspace.workspaceId},
+          ${session.id}, ${turnId}, 1, 'running',
+          ${`removal-${turnId}`}, ${`run-${attemptId}`},
+          ${`activity-${attemptId}`}, 0, '{}'::jsonb
+        )`;
+      await tx`update session_turn_attempts
+        set state = 'closed', outcome = 'requires_action', closed_at = now()
+        where id = ${attemptId}`;
+      await tx`update session_turns
+        set status = 'requires_action', active_attempt_id = null
+        where id = ${turnId}`;
+      await tx`update sessions set status = 'requires_action' where id = ${session.id}`;
+    });
+    await admin`
+      insert into session_pending_tool_calls (
+        account_id, workspace_id, session_id, turn_id, execution_generation,
+        attempt_id, call_id, call_type, call_item, call_item_codec_version
+      ) values (
+        ${workspace.accountId}, ${workspace.workspaceId}, ${session.id},
+        ${turnId}, 1, ${attemptId}, ${callId}, 'function_call',
+        ${admin.json({
+          type: "function_call",
+          name: "request_human_input",
+          callId,
+          arguments: "{}",
+        })},
+        1
+      )`;
+
+    expect(
+      await removeWorkspaceMember(db, {
+        accountId: workspace.accountId,
+        workspaceId: workspace.workspaceId,
+        actorSubjectId: actor,
+        targetSubjectId: target,
+      }),
+    ).toBe(true);
+
+    const [after] = await admin<
+      Array<{ turn: string; pendingToolCalls: number; sessionStatus: string }>
+    >`
+      select
+        (select status from session_turns where id = ${turnId}) as turn,
+        (select count(*)::int from session_pending_tool_calls
+          where turn_id = ${turnId}) as "pendingToolCalls",
+        (select status from sessions where id = ${session.id}) as "sessionStatus"`;
+    expect(after).toEqual({
+      turn: "cancelled",
+      pendingToolCalls: 0,
+      sessionStatus: "idle",
+    });
+  });
+
+  test("refuses self-removal, last-admin removal, and a non-administering actor", async () => {
+    if (!available) return;
+    const workspace = await freshWorkspace();
+    const admin1 = await grantAdmin(workspace);
+    const ordinary = `user:plain-${crypto.randomUUID()}`;
+    await grantOrdinaryMember(workspace, ordinary);
+
+    await expectRemovalRejection(
+      removeWorkspaceMember(db, {
+        accountId: workspace.accountId,
+        workspaceId: workspace.workspaceId,
+        actorSubjectId: admin1,
+        targetSubjectId: admin1,
+      }),
+      "55000",
+    );
+    await expectRemovalRejection(
+      removeWorkspaceMember(db, {
+        accountId: workspace.accountId,
+        workspaceId: workspace.workspaceId,
+        actorSubjectId: ordinary,
+        targetSubjectId: admin1,
+      }),
+      "42501",
+    );
+
+    // A second admin exists -> the first admin becomes removable; removing the
+    // final administering member fails closed.
+    const admin2 = await grantAdmin(workspace);
+    expect(
+      await removeWorkspaceMember(db, {
+        accountId: workspace.accountId,
+        workspaceId: workspace.workspaceId,
+        actorSubjectId: admin2,
+        targetSubjectId: admin1,
+      }),
+    ).toBe(true);
+    const outsideActor = await grantAdminInOtherContext(workspace, admin2);
+    await expectRemovalRejection(
+      removeWorkspaceMember(db, {
+        accountId: workspace.accountId,
+        workspaceId: workspace.workspaceId,
+        actorSubjectId: outsideActor,
+        targetSubjectId: admin2,
+      }),
+      "55000",
+    );
+    // Removing a non-member is an idempotent no-op.
+    expect(
+      await removeWorkspaceMember(db, {
+        accountId: workspace.accountId,
+        workspaceId: workspace.workspaceId,
+        actorSubjectId: admin2,
+        targetSubjectId: `user:absent-${crypto.randomUUID()}`,
+      }),
+    ).toBe(false);
+  });
+});
+
+/** An organization owner/admin may administer without workspace membership;
+ * give the account an active org admin to act from outside the roster. */
+async function grantAdminInOtherContext(
+  workspace: Workspace,
+  excludedSubject: string,
+): Promise<string> {
+  const subjectId = `user:org-admin-${crypto.randomUUID()}`;
+  const [personal] = await admin<{ id: string }[]>`
+    insert into workspaces (account_id, name)
+    values (${workspace.accountId}, ${`personal-${subjectId}`}) returning id`;
+  await admin`
+    insert into organization_memberships (
+      account_id, subject_id, role, status, personal_workspace_id, authorization_revision
+    ) values (${workspace.accountId}, ${subjectId}, 'admin', 'active', ${personal!.id}, 1)`;
+  void excludedSubject;
+  return subjectId;
+}

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -523,8 +523,8 @@ describe("release schema contract", () => {
     const releaseSchemaContractHash = (includesActivation: boolean): string | null => {
       if (migrations.has("0278_workspace_membership_removal_fencing.sql")) {
         return includesActivation
-          ? "4518a8dd6935f916eea354eb848103796b0b9b5376e4f22c6ae8b58374418a49"
-          : "6d45c017d20b8d50a919437bf0b4075996f66fa8e04e11f8ee70cc83246f3a87";
+          ? "4c6764abf9ef587d79e9c9666bd7e11a329927cb74d794ab8ff0717fd35778a7"
+          : "29df8eda7a6b888e03c665ec13227c0c4900b140eade63042d93032f39319b57";
       }
       if (migrations.has("0277_workspace_writer_authority_attribution.sql")) {
         return includesActivation
@@ -1062,7 +1062,7 @@ describe("release schema contract", () => {
       deploymentMode: "rolling",
     });
     expect(migrations.get("0278_workspace_membership_removal_fencing.sql")).toMatchObject({
-      sha256: "204b266f09fff7e2884a75f1e408b5be8a606ab284204dcc08e69c3324f46de9",
+      sha256: "d16d4e0632ed1315ae32ba928d84a218729421e7d2ccfad5ad5806eb44ab0771",
       deploymentMode: "rolling",
     });
     expect(migrations.get("0277_workspace_writer_authority_attribution.sql")).toMatchObject({

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -521,6 +521,11 @@ describe("release schema contract", () => {
         : "d54a4ac5b800e0c0578e7fce7d1a09cea1dbed87d3b13bf722549fea0bdc031e";
     };
     const releaseSchemaContractHash = (includesActivation: boolean): string | null => {
+      if (migrations.has("0278_workspace_membership_removal_fencing.sql")) {
+        return includesActivation
+          ? "4518a8dd6935f916eea354eb848103796b0b9b5376e4f22c6ae8b58374418a49"
+          : "6d45c017d20b8d50a919437bf0b4075996f66fa8e04e11f8ee70cc83246f3a87";
+      }
       if (migrations.has("0277_workspace_writer_authority_attribution.sql")) {
         return includesActivation
           ? "b2a805760b1f09c2618b49b952a5cb323812a742dd748c11e48b14699e6deb69"
@@ -960,7 +965,8 @@ describe("release schema contract", () => {
         (migrations.has("0263_organization_membership_lifecycle.sql") ? 1 : 0) +
         (migrations.has("0275_scheduled_connection_authority.sql") ? 1 : 0) +
         (migrations.has("0276_onboarding_proposal_initiating_human_guc.sql") ? 1 : 0) +
-        (migrations.has("0277_workspace_writer_authority_attribution.sql") ? 1 : 0),
+        (migrations.has("0277_workspace_writer_authority_attribution.sql") ? 1 : 0) +
+        (migrations.has("0278_workspace_membership_removal_fencing.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(releaseSchemaContractHash(false) ?? currentMainContractHash);
     const latestCompatibleMigration = [
@@ -995,60 +1001,68 @@ describe("release schema contract", () => {
       "0217_capability_definition_delete_authority.sql",
     ].find((path) => migrations.has(path));
     expect(contract.latestMigration).toBe(
-      migrations.has("0277_workspace_writer_authority_attribution.sql")
-        ? "0277_workspace_writer_authority_attribution.sql"
-        : migrations.has("0276_onboarding_proposal_initiating_human_guc.sql")
-          ? "0276_onboarding_proposal_initiating_human_guc.sql"
-          : migrations.has("0275_scheduled_connection_authority.sql")
-            ? "0275_scheduled_connection_authority.sql"
-            : migrations.has("0274_human_confirmed_knowledge_review.sql")
-              ? "0274_human_confirmed_knowledge_review.sql"
-              : migrations.has("0272_human_confirmed_learning_activation.sql")
-                ? "0272_human_confirmed_learning_activation.sql"
-                : migrations.has("0271_company_brain_retrieval_only_default.sql")
-                  ? "0271_company_brain_retrieval_only_default.sql"
-                  : migrations.has("0270_governed_learning_history_inspection.sql")
-                    ? "0270_governed_learning_history_inspection.sql"
-                    : migrations.has("0269_governed_learning_activation_controller.sql")
-                      ? "0269_governed_learning_activation_controller.sql"
-                      : migrations.has("0268_governed_learning_decision_receipts.sql")
-                        ? "0268_governed_learning_decision_receipts.sql"
-                        : migrations.has("0266_company_brain_context_receipt_inspection.sql")
-                          ? "0266_company_brain_context_receipt_inspection.sql"
-                          : migrations.has("0261_preference_knowledge_proposal_actor_binding.sql")
-                            ? "0261_preference_knowledge_proposal_actor_binding.sql"
-                            : migrations.has("0260_task_note_knowledge_promotion.sql")
-                              ? "0260_task_note_knowledge_promotion.sql"
-                              : migrations.has("0259_company_brain_context_selection_receipts.sql")
-                                ? "0259_company_brain_context_selection_receipts.sql"
+      migrations.has("0278_workspace_membership_removal_fencing.sql")
+        ? "0278_workspace_membership_removal_fencing.sql"
+        : migrations.has("0277_workspace_writer_authority_attribution.sql")
+          ? "0277_workspace_writer_authority_attribution.sql"
+          : migrations.has("0276_onboarding_proposal_initiating_human_guc.sql")
+            ? "0276_onboarding_proposal_initiating_human_guc.sql"
+            : migrations.has("0275_scheduled_connection_authority.sql")
+              ? "0275_scheduled_connection_authority.sql"
+              : migrations.has("0274_human_confirmed_knowledge_review.sql")
+                ? "0274_human_confirmed_knowledge_review.sql"
+                : migrations.has("0272_human_confirmed_learning_activation.sql")
+                  ? "0272_human_confirmed_learning_activation.sql"
+                  : migrations.has("0271_company_brain_retrieval_only_default.sql")
+                    ? "0271_company_brain_retrieval_only_default.sql"
+                    : migrations.has("0270_governed_learning_history_inspection.sql")
+                      ? "0270_governed_learning_history_inspection.sql"
+                      : migrations.has("0269_governed_learning_activation_controller.sql")
+                        ? "0269_governed_learning_activation_controller.sql"
+                        : migrations.has("0268_governed_learning_decision_receipts.sql")
+                          ? "0268_governed_learning_decision_receipts.sql"
+                          : migrations.has("0266_company_brain_context_receipt_inspection.sql")
+                            ? "0266_company_brain_context_receipt_inspection.sql"
+                            : migrations.has("0261_preference_knowledge_proposal_actor_binding.sql")
+                              ? "0261_preference_knowledge_proposal_actor_binding.sql"
+                              : migrations.has("0260_task_note_knowledge_promotion.sql")
+                                ? "0260_task_note_knowledge_promotion.sql"
                                 : migrations.has(
-                                      "0258_three_scope_document_knowledge_authority.sql",
+                                      "0259_company_brain_context_selection_receipts.sql",
                                     )
-                                  ? "0258_three_scope_document_knowledge_authority.sql"
+                                  ? "0259_company_brain_context_selection_receipts.sql"
                                   : migrations.has(
-                                        "0257_goal_revision_decisions_and_root_constraints.sql",
+                                        "0258_three_scope_document_knowledge_authority.sql",
                                       )
-                                    ? "0257_goal_revision_decisions_and_root_constraints.sql"
+                                    ? "0258_three_scope_document_knowledge_authority.sql"
                                     : migrations.has(
-                                          "0255_company_brain_governed_write_proposals.sql",
+                                          "0257_goal_revision_decisions_and_root_constraints.sql",
                                         )
-                                      ? "0255_company_brain_governed_write_proposals.sql"
+                                      ? "0257_goal_revision_decisions_and_root_constraints.sql"
                                       : migrations.has(
-                                            "0248_terraform_stacks_component_resolution_fence.sql",
+                                            "0255_company_brain_governed_write_proposals.sql",
                                           )
-                                        ? "0248_terraform_stacks_component_resolution_fence.sql"
+                                        ? "0255_company_brain_governed_write_proposals.sql"
                                         : migrations.has(
-                                              "0247_terraform_stacks_provenance_repair.sql",
+                                              "0248_terraform_stacks_component_resolution_fence.sql",
                                             )
-                                          ? "0247_terraform_stacks_provenance_repair.sql"
+                                          ? "0248_terraform_stacks_component_resolution_fence.sql"
                                           : migrations.has(
-                                                "0263_organization_membership_lifecycle.sql",
+                                                "0247_terraform_stacks_provenance_repair.sql",
                                               )
-                                            ? "0263_organization_membership_lifecycle.sql"
-                                            : latestCompatibleMigration,
+                                            ? "0247_terraform_stacks_provenance_repair.sql"
+                                            : migrations.has(
+                                                  "0263_organization_membership_lifecycle.sql",
+                                                )
+                                              ? "0263_organization_membership_lifecycle.sql"
+                                              : latestCompatibleMigration,
     );
     expect(migrations.get("0263_organization_membership_lifecycle.sql")).toMatchObject({
       sha256: "1119554dc06a768c92f7189a97b438ebdc011747a6c8d7cefc992962f2293593",
+      deploymentMode: "rolling",
+    });
+    expect(migrations.get("0278_workspace_membership_removal_fencing.sql")).toMatchObject({
+      sha256: "204b266f09fff7e2884a75f1e408b5be8a606ab284204dcc08e69c3324f46de9",
       deploymentMode: "rolling",
     });
     expect(migrations.get("0277_workspace_writer_authority_attribution.sql")).toMatchObject({

--- a/test/e2e/session-pins.browser.e2e.ts
+++ b/test/e2e/session-pins.browser.e2e.ts
@@ -1287,7 +1287,21 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       `);
       await barrier`select pg_advisory_lock(${barrierClass}, ${removalLock})`;
 
-      removalPromise = removeWorkspaceMember(removalClient.db, workspaceId, raceSubject);
+      removalPromise = (async () => {
+        const removerSubjectId = `user:remover-${crypto.randomUUID()}`;
+        await grantWorkspaceAccess(removalClient.db, {
+          accountId: workspace!.accountId,
+          workspaceId,
+          subjectId: removerSubjectId,
+          permissions: ["workspace:admin"],
+        });
+        return await removeWorkspaceMember(removalClient.db, {
+          accountId: workspace!.accountId,
+          workspaceId,
+          actorSubjectId: removerSubjectId,
+          targetSubjectId: raceSubject,
+        });
+      })();
       await waitForAdvisoryWait(barrier, barrierClass, removalLock);
 
       const listingPromise = raceApp.request(
@@ -1404,7 +1418,21 @@ describe("session pins browser e2e (real API + non-superuser PostgreSQL)", () =>
       `);
       await barrier`select pg_advisory_lock(${barrierClass}, ${removalLock})`;
 
-      removalPromise = removeWorkspaceMember(removalClient.db, workspaceId, raceSubject);
+      removalPromise = (async () => {
+        const removerSubjectId = `user:remover-${crypto.randomUUID()}`;
+        await grantWorkspaceAccess(removalClient.db, {
+          accountId: workspace!.accountId,
+          workspaceId,
+          subjectId: removerSubjectId,
+          permissions: ["workspace:admin"],
+        });
+        return await removeWorkspaceMember(removalClient.db, {
+          accountId: workspace!.accountId,
+          workspaceId,
+          actorSubjectId: removerSubjectId,
+          targetSubjectId: raceSubject,
+        });
+      })();
       await waitForAdvisoryWait(barrier, barrierClass, removalLock);
 
       const pinPromise = raceApp.request(


### PR DESCRIPTION
## What

OPE-203 slice 2: `DELETE /v1/workspaces/:workspaceId/members/:subjectId` previously deleted the target's session-list snapshots, pins, drafts, and the membership row - and fenced nothing. The removed member's queued/live turns kept running, their private sessions kept their authority epoch, active realtime modes stayed open, and no workflow woke.

### Migration `0278_workspace_membership_removal_fencing.sql` (rolling)

Adds three functions and changes no table shapes:

- `workspace_membership_removal_command(jsonb)` - the 0263 organization-offboarding teardown scoped to exactly one workspace and one target subject: canonical lock prefix (control FOR SHARE → workspace FOR KEY SHARE → sessions FOR NO KEY UPDATE → turns FOR UPDATE → attempts FOR UPDATE), live-attempt interruption evidence (`session_attempt_interruptions`, existing kind `authority_change` - no constraint rewrite), turn cancellation with `turn.cancelled` / human-input / system-update settlement events, realtime mode + connection end (`authority_revoked`), goal + scheduled-task pausing, workspace-scoped resource-grant revocation, private-session `authority_epoch` advance with `session.authority.revoked` events, workflow wake outbox registration, per-workspace personal-row cleanup, the membership delete, and the session-activity-gate finalization - one transaction. A turn with pending tool calls and no live attempt fails closed (55000) until the application settles it canonically.
- `prepare_workspace_membership_removal_settlements(jsonb)` - the same prepare contract as `prepare_organization_membership_protocol_settlements`, scoped, so the app settles pending tool calls through the existing canonical protocol before the command runs.
- `opengeni_private.assert_workspace_membership_removal_actor(...)` - the application guards restated fail-closed in the seam: self-removal refused (55000), the last member holding `workspace:admin`/`members:manage` cannot be removed (55000), and the actor must hold an administering permission in the workspace or be an active organization owner/admin (42501).

The pre-0278 personal-state advisory fence (`session-personal-state:<ws>:<subject>`) stays load-bearing: the app takes it first in the same transaction (observable, ordered first) and the command re-acquires it before the membership `FOR UPDATE`, so session listing and pin mutation serialize exactly as before.

### Runtime

- `removeWorkspaceMember` is now the prepare → settle → command protocol in one transaction (`packages/db/src/organization-membership-lifecycle.ts`), reusing the exact settlement machinery organization offboarding uses; the old direct-delete implementation is removed.
- The route passes the authenticated actor and account; the app-side `assertWorkspaceMemberRemovable` 409s remain for friendly errors while the seam enforces the same guards fail-closed.
- Removal is idempotent: no membership row → `removed: false`, nothing torn down.
- Registered in `runtime-posture.ts` and `provision-roles.ts` (conditional `opengeni_app` grant for role-free dedicated-schema replays, per the slice-1 precedent).
- Also fixes the stale "pre-0276" comment in `apps/api/src/sandbox/channel-a.ts` flagged by slice 1's review (that ordinal now names an unrelated migration).

### Scope decisions

- Organization membership status, other workspaces' memberships and sessions, personal-workspace pointers, and retention are untouched - removal is strictly workspace-scoped.
- Shared sessions with turns initiated by the removed subject get those turns cancelled (matching 0263's treatment of frozen initiating humans) but no epoch change; only sessions owned by the subject's organization membership advance their epoch.

## Evidence

- Head: `64e163a02f8b7c808b2ed8d1228acf82463052b2`
- Migration SHA-256: `d16d4e0632ed1315ae32ba928d84a218729421e7d2ccfad5ad5806eb44ab0771`
- `bun run typecheck` - all projects clean; lint, format, hygiene, docs-refs, migration-ordinals - clean
- Real-Postgres suites (all pass): `packages/db/test/workspace-membership-removal.test.ts` (4: queued-turn cancel + wake + bystander isolation; private-session epoch advance scoped to the one workspace with org membership untouched; requires_action + pending-tool-call canonical settlement; self/last-admin/non-admin guard rejections + idempotent no-op), `migration-0278-...` (2), `session-pins.test.ts` (28, including the racing personal-state-fence serialization tests against the NEW removal path), `new-session-drafts.test.ts` (12), `runtime-posture.test.ts` (27), `rls-dedicated-schema-isolation.test.ts` (13), `release-schema-contract.test.ts` (6), `workspace-members-domain.test.ts` (11), `organization-memberships-routes.test.ts` (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca7x2FyxheguVcdENGs8ji
### Revision 2 (dacaac90)

The knowledge-lane browser e2e drove removal through the old 3-argument removeWorkspaceMember signature (the test/e2e tree is outside the typecheck project set), failing at runtime on the empty RLS account id. Fixed by granting a dedicated admin remover and calling the new fenced signature in both racing tests. The third failure in that lane (a 10s waitForResponse timeout in a test that never touches removal) looks like an ordinary browser flake; the rerun on this push will confirm.
### Revision 3 (64e163a0) - adversarial review findings

The independent review of dacaac90 returned BLOCK with a reproduced blocker and one major, both fixed here:

1. Blocker - last-admin guard TOCTOU (reproduced by the reviewer): the guard EXISTS checks ran before any serializing lock, so two concurrent removals of the two last administering members could both pass and leave zero admins. The command now locks the actor organization membership FOR SHARE and every admin/actor/target workspace-membership row in id order FOR UPDATE BEFORE re-running the guards; the prepare-side guard call is explicitly a friendly unserialized precheck that authorizes nothing. New concurrency test: two racing removals of the two last admins - exactly one commits, the loser gets 55000, one admin remains.
2. Major - ABBA deadlock vs the 0275 scheduled-task writer order (task - session - membership): the command previously took the membership FOR UPDATE before touching task rows. Both the preparation pass and the command now lock the target-affecting scheduled-task rows (full 0275 frozen-authority predicate) after the workspace prefix and before session/membership locks.
3. Minor - task-pause predicate: now uses 0275 full predicate (created-by OR frozen revision/personal-resource/connection authority of the target).
4. Minor - grant revocation: restored the 0263 session-epoch-bound sweep alongside the owner-based sweep.

Migration SHA-256 re-pinned to d16d4e0632ed1315ae32ba928d84a218729421e7d2ccfad5ad5806eb44ab0771; ladder hashes updated; all focused suites green including the new concurrency test.
