### PR TITLE
fix(react): preserve durable composer policy during hydration

### DIFF
--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -1210,6 +1210,7 @@ function SessionChatPane(props: {
     sendBlocked: () => attachments.hasUnresolved || repositories.error !== null,
     effectiveControl: props.queue.effectiveControl ?? props.session.effectiveControl,
     onDraftApplied: applyComposerSettings,
+    isPolicyTouched: () => pickerTouchedRef.current,
     // Ordinary Send is acknowledged locally. Clear only resources captured in
     // that immutable optimistic operation; later additions belong to the next
     // draft, while retry keeps the original resource refs in the failed bubble.

--- a/packages/react/src/hooks/use-composer.ts
+++ b/packages/react/src/hooks/use-composer.ts
@@ -38,6 +38,13 @@ export type UseComposerOptions = EmbeddedSessionClientOverride &
     effectiveControl?: EffectiveSessionControl | null | undefined;
     /** Apply durable model/tool/reasoning settings in the host's controlled UI. */
     onDraftApplied?: ((draft: ComposerDraft) => void) | undefined;
+    /**
+     * Return true when a human has explicitly changed the composer policy
+     * (model, effort, or latency) for the current session. Hosts may seed
+     * those values automatically while a draft read is in flight; that must
+     * not be mistaken for a picker change that should beat the draft.
+     */
+    isPolicyTouched?: (() => boolean) | undefined;
     /** Disable remote composer-draft reads and writes for embedded hosts. */
     draftPersistence?: "durable" | "disabled" | undefined;
   };
@@ -561,6 +568,7 @@ export function useComposer(
   const onSent = options.onSent;
   const onSubmitted = options.onSubmitted;
   const onDraftApplied = options.onDraftApplied;
+  const isPolicyTouched = options.isPolicyTouched;
   // Read through a ref so live session/policy projections can replace their
   // apply callback without invalidating the draft loader and re-running its
   // initial-load effect. Publish only committed callbacks: a suspended target
@@ -569,6 +577,10 @@ export function useComposer(
   useLayoutEffect(() => {
     onDraftAppliedRef.current = onDraftApplied;
   }, [onDraftApplied]);
+  const isPolicyTouchedRef = useRef(isPolicyTouched);
+  useLayoutEffect(() => {
+    isPolicyTouchedRef.current = isPolicyTouched;
+  }, [isPolicyTouched]);
   useLayoutEffect(() => {
     steeringRef.current = steering;
   }, [steering]);
@@ -799,6 +811,14 @@ export function useComposer(
               extrasNow.model !== extrasAtStart.model ||
               extrasNow.reasoningEffort !== extrasAtStart.reasoningEffort ||
               extrasNow.latencyMode !== extrasAtStart.latencyMode;
+            // A host can change the controlled policy automatically while
+            // hydrating (for example, by seeding an existing session's
+            // metadata). Only preserve the local policy as authoritative when
+            // the host confirms that a human actually touched the picker.
+            // Keep the historical diff-based behavior for embedders that do
+            // not provide the explicit signal.
+            const pickerChangedByHuman =
+              pickerChangedDuringFetch && (isPolicyTouchedRef.current?.() ?? true);
             valueRef.current = fetched.text;
             restoredResourcesRef.current = fetched.resources;
             annotationsRef.current = fetched.annotations ?? [];
@@ -806,7 +826,7 @@ export function useComposer(
             setValue(fetched.text);
             setRestoredResources(fetched.resources);
             setAnnotations(fetched.annotations ?? []);
-            if (replaceLocal || !pickerChangedDuringFetch) {
+            if (replaceLocal || !pickerChangedByHuman) {
               onDraftAppliedRef.current?.(fetched);
             }
           }

--- a/packages/react/test/hooks.test.tsx
+++ b/packages/react/test/hooks.test.tsx
@@ -6,7 +6,7 @@
    -------------------------------------------------------------------------- */
 import { describe, expect, test } from "bun:test";
 import { act as reactAct } from "react";
-import { startTransition, Suspense, useState } from "react";
+import { startTransition, Suspense, useEffect, useState } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import type {
@@ -2170,6 +2170,81 @@ describe("useComposer durable draft and control binding", () => {
 
     expect(hook.result.current.value).toBe("restored text");
     expect(applied).toEqual([]);
+    await hook.unmount();
+  });
+
+  test("automatic policy initialization does not overwrite the durable draft", async () => {
+    let resolveDraft!: (draft: ComposerDraft) => void;
+    const saved: unknown[] = [];
+    const applied: ComposerDraft[] = [];
+    const client = fakeClient({
+      getComposerDraft: async () =>
+        await new Promise<ComposerDraft>((resolve) => {
+          resolveDraft = resolve;
+        }),
+      saveComposerDraft: async (_workspaceId, _sessionId, request) => {
+        saved.push(request);
+        return {
+          revision: request.expectedRevision + 1,
+          text: request.text,
+          resources: request.resources,
+          annotations: request.annotations ?? [],
+          model: request.model,
+          reasoningEffort: request.reasoningEffort,
+          latencyMode: request.latencyMode,
+          sourceTurnId: null,
+          sourceTurnVersion: null,
+          updatedAt: new Date().toISOString(),
+        } satisfies ComposerDraft;
+      },
+    });
+    const remoteDraft: ComposerDraft = {
+      revision: 7,
+      text: "durable draft",
+      resources: [],
+      model: "model-x",
+      reasoningEffort: "medium",
+      latencyMode: "standard",
+      sourceTurnId: null,
+      sourceTurnVersion: null,
+      updatedAt: new Date().toISOString(),
+    };
+    type Props = { seededLatency: "standard" | "fast" };
+    const hook = await renderHook(
+      (props: Props) => {
+        const [latencyMode, setLatencyMode] = useState<"standard" | "fast">(props.seededLatency);
+        useEffect(() => setLatencyMode(props.seededLatency), [props.seededLatency]);
+        return useComposer(SESSION_ID, {
+          client,
+          workspaceId: WORKSPACE_ID,
+          sendExtras: {
+            model: "model-x",
+            reasoningEffort: "medium",
+            latencyMode,
+          },
+          isPolicyTouched: () => false,
+          onDraftApplied: (draft) => {
+            applied.push(draft);
+            setLatencyMode(draft.latencyMode === "fast" ? "fast" : "standard");
+          },
+        });
+      },
+      { seededLatency: "standard" },
+    );
+
+    await flush();
+    await hook.rerender({ seededLatency: "fast" });
+    await flush();
+    await flushing(async () => {
+      resolveDraft(remoteDraft);
+      await Promise.resolve();
+    });
+    await flush(600);
+
+    expect(applied).toHaveLength(1);
+    expect(applied[0]?.latencyMode).toBe("standard");
+    expect(hook.result.current.value).toBe("durable draft");
+    expect(saved).toEqual([]);
     await hook.unmount();
   });
 


### PR DESCRIPTION
Fixes the refresh-time composer policy regression.

Root cause: automatic session policy seeding during composer-draft hydration was treated as a human picker change, so the fetched durable draft was skipped and autosave persisted stale Fast.

The hook now accepts an explicit human-picker touch signal; automatic initialization yields to the durable draft while real picker changes still win.

Checks:
- targeted composer hydration tests
- packages/react typecheck
- oxfmt check