### PR TITLE
fix(docker): package CLI in API image

### DIFF
--- a/docker/opengeni.Dockerfile
+++ b/docker/opengeni.Dockerfile
@@ -93,9 +93,19 @@ USER bun
 RUN bun packages/artifact-tool/src/runtime-cli-entry.ts doctor --json
 
 FROM artifact-runtime-base AS api
+# API-owned browser/computer sessions use the Docker sandbox adapter directly,
+# including `docker network connect`. Install only the client; the daemon stays
+# outside this image and is reached through the mounted host socket.
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates ffmpeg git openssh-client \
+  && apt-get install -y --no-install-recommends ca-certificates curl ffmpeg git gnupg openssh-client \
+  && install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+  && chmod a+r /etc/apt/keyrings/docker.asc \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends docker-ce-cli \
+  && docker --version \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 RUN bun scripts/build-runtime-processes.ts api

--- a/scripts/workload-image-system-packages-contract.test.ts
+++ b/scripts/workload-image-system-packages-contract.test.ts
@@ -43,8 +43,10 @@ function keepsSpecializedWorkloadPackagesCoalesced(source: string): boolean {
     ) &&
     aptTransactions(api) === 1 &&
     api.includes(
-      "apt-get install -y --no-install-recommends ca-certificates ffmpeg git openssh-client",
+      "apt-get install -y --no-install-recommends ca-certificates curl ffmpeg git gnupg openssh-client",
     ) &&
+    api.includes("apt-get install -y --no-install-recommends docker-ce-cli") &&
+    api.includes("docker --version") &&
     worker.startsWith("FROM source-base AS worker") &&
     aptTransactions(worker) === 1 &&
     worker.includes(
@@ -72,10 +74,16 @@ describe("workload image system package contract", () => {
     expect(keepsSpecializedWorkloadPackagesCoalesced(inheritedCommonInstall)).toBe(false);
 
     const missingApiRuntimeTools = dockerfile.replace(
-      "ca-certificates ffmpeg git openssh-client",
+      "ca-certificates curl ffmpeg git gnupg openssh-client",
       "ffmpeg",
     );
     expect(keepsSpecializedWorkloadPackagesCoalesced(missingApiRuntimeTools)).toBe(false);
+
+    const missingApiDockerCli = dockerfile.replace(
+      "apt-get install -y --no-install-recommends docker-ce-cli",
+      "true",
+    );
+    expect(keepsSpecializedWorkloadPackagesCoalesced(missingApiDockerCli)).toBe(false);
 
     const duplicateApiTransaction = dockerfile.replace(
       "FROM artifact-runtime-base AS api\n",


### PR DESCRIPTION
## Summary
- install Docker CLI in the generic API workload image
- execute `docker --version` inside the image build for both architectures
- make the workload package contract reject an API image without the CLI

The API owns direct Docker browser/computer sessions and calls `docker network connect`; this removes the need for downstream image overlays.

## Verification
- focused contract test
- all 31 typecheck projects
- lint
- format check
- diff check