### PR TITLE
fix(release): repair first-party MCP CI regressions

### DIFF
--- a/.changeset/swift-tools-start.md
+++ b/.changeset/swift-tools-start.md
@@ -12,4 +12,5 @@ Start fresh progressive-disclosure turns with only local tools, `tool_search`,
 and MCP servers explicitly marked eager by the session. Prepare every other
 strict or optional MCP concurrently, join the exact catalog only when searched
 or invoked, and keep worker first-party MCP traffic on an internal endpoint
-instead of a sandbox-facing public route.
+instead of a sandbox-facing public route while preserving the distinct root,
+documents, and files MCP paths.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -5272,8 +5272,8 @@ function firstPartyMcpServerUrlForRun(
   }
   const rawBase = firstPartyMcpInternalWorkspaceUrl(settings, workspaceId);
   const url = new URL(rawBase);
-  if (config.id === "docs") {
-    url.pathname = `${url.pathname.replace(/\/+$/, "")}/docs`;
+  if (config.id === "docs" || config.id === "files") {
+    url.pathname = `${url.pathname.replace(/\/+$/, "")}/${config.id}`;
   }
   return url.toString();
 }
@@ -5287,10 +5287,12 @@ function firstPartyMcpUrls(settings: Settings): string[] {
     const base = normalizeUrl(candidate);
     if (!base) continue;
     urls.add(base);
-    const docs = new URL(base);
-    docs.pathname = `${docs.pathname.replace(/\/+$/, "")}/docs`;
-    const normalizedDocs = normalizeUrl(docs.toString());
-    if (normalizedDocs) urls.add(normalizedDocs);
+    for (const suffix of ["docs", "files"] as const) {
+      const scoped = new URL(base);
+      scoped.pathname = `${scoped.pathname.replace(/\/+$/, "")}/${suffix}`;
+      const normalizedScoped = normalizeUrl(scoped.toString());
+      if (normalizedScoped) urls.add(normalizedScoped);
+    }
   }
   return [...urls];
 }

--- a/scripts/catalog-curation.ts
+++ b/scripts/catalog-curation.ts
@@ -259,7 +259,7 @@ function parsePresentation(raw: unknown, where: string): CuratedPresentation {
         `${where}: presentation.icon must be one of ${[...PRESENTATION_ICONS].join(", ")}`,
       );
     }
-    presentation.icon = record.icon as CuratedPresentation["icon"];
+    presentation.icon = record.icon as NonNullable<CuratedPresentation["icon"]>;
   }
   if (record.capabilities !== undefined) {
     if (

--- a/test/e2e/custom-api-control-center.browser.e2e.ts
+++ b/test/e2e/custom-api-control-center.browser.e2e.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { chromium, type Browser, type Page } from "playwright";
 
+import { INTEGRATION_DEFINITION_PRESENTATIONS } from "@opengeni/capabilities";
 import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
 import { OPENGENI_API_CONTRACT_REVISION } from "@opengeni/sdk";
 
@@ -708,6 +709,9 @@ function integrationDefinitions() {
     protocol: "openapi",
     provider: { id: providerId, domain: providerDomain },
     authentication: { kind: "oauth2", scopes: scopes[id!] ?? [] },
+    ...(INTEGRATION_DEFINITION_PRESENTATIONS[id!]
+      ? { presentation: INTEGRATION_DEFINITION_PRESENTATIONS[id!] }
+      : {}),
     facets: id === "google-gmail" ? gmailFacetDefinitions() : [],
   }));
 }

--- a/test/integration/api.integration.ts
+++ b/test/integration/api.integration.ts
@@ -1327,6 +1327,7 @@ describe("API component integration", () => {
       prepared = await prepareAgentTools(
         {
           ...settings,
+          opengeniMcpInternalUrl: `http://127.0.0.1:${server.port}/v1/workspaces/{workspaceId}/mcp`,
           mcpServers: [
             {
               id: "opengeni",
@@ -7196,6 +7197,7 @@ describe("API component integration", () => {
     });
     const settings = {
       ...appSettings,
+      opengeniMcpInternalUrl: `http://127.0.0.1:${server.port}/v1/workspaces/{workspaceId}/mcp`,
       mcpServers: [
         {
           id: "docs",
@@ -7435,6 +7437,7 @@ describe("API component integration", () => {
     });
     const settings = {
       ...appSettings,
+      opengeniMcpInternalUrl: `http://127.0.0.1:${server.port}/v1/workspaces/{workspaceId}/mcp`,
       mcpServers: [
         {
           id: "opengeni",
@@ -8917,6 +8920,7 @@ describe("API component integration", () => {
     try {
       const runtimeSettings = {
         ...appSettings,
+        opengeniMcpInternalUrl: `http://127.0.0.1:${server.port}/v1/workspaces/{workspaceId}/mcp`,
         mcpServers: [
           {
             id: "opengeni",
@@ -10546,6 +10550,7 @@ describe("API component integration", () => {
     const settings = testSettings({
       databaseUrl: services.databaseUrl,
       delegationSecret: "test-delegation-secret",
+      opengeniMcpInternalUrl: `http://127.0.0.1:${server.port}/v1/workspaces/{workspaceId}/mcp`,
       mcpServers: [
         {
           id: "files",


### PR DESCRIPTION
## Summary

- preserve the internal first-party MCP route suffix for both documents and files
- bind first-party MCP integration fixtures to their live test server
- source browser acceptance presentation data from the canonical capabilities package
- satisfy exact optional property typing in catalog curation

## Verification

- `bun --filter @opengeni/runtime typecheck`
- `bun --filter @opengeni/db typecheck`
- `bun test scripts/catalog-curation.test.ts` (28 passed)
- affected API integration tests (5 passed)
- custom API browser acceptance (8 passed, twice)