### PR TITLE
fix(runtime): recover dead sandboxes across image upgrades

### DIFF
--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -38,7 +38,9 @@ import {
   readActiveSandbox,
   readLease,
   releaseLeaseHolder,
+  SandboxImageConflictError,
   SandboxProviderReadLockUnavailableError,
+  SandboxRigConflictError,
   withSandboxProviderReadLock,
   type Database,
   type LeaseSnapshot,
@@ -781,6 +783,54 @@ async function withChannelAOperation<T>(
       });
     }
   } catch (error) {
+    let mappedError: unknown = error;
+    if (error instanceof SandboxImageConflictError) {
+      // A durable Browser/Computer holder can outlive its provider container.
+      // Runtime drift is checked before a new direct holder is admitted, so a
+      // dead old container would otherwise strand the lease behind a permanent
+      // conflict. Probe the exact old identity without replacement; only an
+      // authoritative provider-missing result may retire it and unblock the
+      // next request's cold successor election.
+      const live = await readLease(db, workspaceId, sandboxGroupId).catch(() => null);
+      if (live?.liveness === "warm" && live.instanceId !== null && live.resumeState !== null) {
+        let probe: EstablishedSandboxSession | undefined;
+        try {
+          probe = await establishSandboxSessionFromEnvelope(
+            sandboxRuntime.settings,
+            live.resumeState,
+            {
+              sessionId: session.id,
+              recovery: "resume-only",
+              backendOverride: session.sandboxBackend,
+              environment,
+            },
+          );
+        } catch (probeError) {
+          if (isProviderSandboxNotFoundError(session.sandboxBackend, probeError)) {
+            const marked = await markWarmLeaseInstanceLost(db, {
+              accountId,
+              workspaceId,
+              sandboxGroupId,
+              expectedEpoch: live.leaseEpoch,
+              expectedInstanceId: live.instanceId,
+            }).catch(() => null);
+            if (marked?.status === "marked") {
+              await appendAndPublishEvents(db, bus, workspaceId, session.id, [
+                {
+                  type: "sandbox.box.lost",
+                  payload: { sandboxId: live.instanceId },
+                },
+              ]).catch(() => undefined);
+              mappedError = new HTTPException(409, {
+                message: "sandbox instance was lost; retry to restore it",
+              });
+            }
+          }
+        } finally {
+          await dropEstablishedHandle(probe);
+        }
+      }
+    }
     // Release is idempotent. If acquisition committed before the request was
     // cancelled, this removes that exact direct holder; a transient DB failure
     // must not overwrite the original structural error (holder TTL is the final
@@ -792,10 +842,10 @@ async function withChannelAOperation<T>(
       backend: session.sandboxBackend,
       operation,
       durationMs: performance.now() - operationStartedAt,
-      error,
+      error: mappedError,
       waitSignal: ctx.waitSignal,
     });
-    throw mapChannelAError(error, ctx.waitSignal);
+    throw mapChannelAError(mappedError, ctx.waitSignal);
   }
 
   // Keep the exact direct-request owner visible for the full operation. A
@@ -1098,6 +1148,10 @@ export function mapChannelAError(error: unknown, waitSignal?: AbortSignal): unkn
     return new HTTPException(409, { message: error.message });
   if (error instanceof SandboxProviderReadLockUnavailableError)
     return new HTTPException(503, { message: error.message });
+  if (error instanceof SandboxImageConflictError || error instanceof SandboxRigConflictError)
+    return new HTTPException(409, {
+      message: "sandbox runtime changed while this session still has active operations; retry",
+    });
   if (error instanceof SelfhostedControlError && error.agentOffline)
     return new HTTPException(409, { message: error.message, cause: error });
   if (error instanceof ChannelAUnavailableError)
@@ -1162,6 +1216,13 @@ export function channelAOperationFailureDiagnostic(
       reason: "provider_read_busy",
       status: 503,
       errorCode: "sandbox_channel_a_provider_busy",
+    };
+  }
+  if (error instanceof SandboxImageConflictError || error instanceof SandboxRigConflictError) {
+    return {
+      reason: "lifecycle_conflict",
+      status: 409,
+      errorCode: "sandbox_channel_a_lifecycle_conflict",
     };
   }
   if (error instanceof ChannelAUnavailableError) {

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -3,7 +3,11 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { HTTPException } from "hono/http-exception";
-import { SandboxProviderReadLockUnavailableError } from "@opengeni/db";
+import {
+  SandboxImageConflictError,
+  SandboxProviderReadLockUnavailableError,
+  SandboxRigConflictError,
+} from "@opengeni/db";
 import {
   ChannelAConflictError,
   ChannelAUnavailableError,
@@ -245,6 +249,25 @@ describe("P4.4 Channel-A route discipline", () => {
     expect(mapped).toBeInstanceOf(HTTPException);
     expect((mapped as HTTPException).status).toBe(499);
     expect((mapped as HTTPException).message).toBe("request cancelled");
+  });
+
+  test("runtime drift is an explicit retryable lifecycle conflict, never a 500", () => {
+    for (const error of [
+      new SandboxImageConflictError("group", "old", "new"),
+      new SandboxRigConflictError("group", "old", "new"),
+    ]) {
+      expect(channelAOperationFailureDiagnostic(error)).toEqual({
+        reason: "lifecycle_conflict",
+        status: 409,
+        errorCode: "sandbox_channel_a_lifecycle_conflict",
+      });
+      const mapped = mapChannelAError(error);
+      expect(mapped).toBeInstanceOf(HTTPException);
+      expect((mapped as HTTPException).status).toBe(409);
+      expect((mapped as HTTPException).message).toBe(
+        "sandbox runtime changed while this session still has active operations; retry",
+      );
+    }
   });
 
   test("an unrelated provider AbortError is not misreported as a client cancellation", () => {

--- a/packages/runtime/src/sandbox/providers/docker.ts
+++ b/packages/runtime/src/sandbox/providers/docker.ts
@@ -17,10 +17,25 @@ const DOCKER_INSTANCE_ID = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/;
 
 type DockerResumeState = {
   containerId?: unknown;
+  image?: unknown;
   workspaceRootPath?: unknown;
   workspaceRootOwned?: unknown;
   snapshot?: unknown;
 };
+
+/** A cold continuity owner is the only caller allowed to replace a missing
+ * Docker execution wrapper while preserving its host workspace. The durable
+ * provider state carries the image of the missing container; prefer the
+ * currently configured image for the replacement so a deployment upgrade
+ * cannot publish a new lease image while silently restarting the old one. */
+export function dockerContinuityResumeStateForImage<T>(
+  state: T,
+  configuredImage: string | undefined,
+): T {
+  const image = configuredImage?.trim();
+  if (!image || !state || typeof state !== "object" || Array.isArray(state)) return state;
+  return { ...state, image };
+}
 
 function dockerContinuityKey(state: unknown): string | null {
   if (!state || typeof state !== "object" || Array.isArray(state)) return null;
@@ -62,6 +77,18 @@ class OpenGeniDockerSandboxClient extends DockerSandboxClient {
   constructor(options: DockerSandboxClientOptions = {}) {
     super(options);
     this.#openGeniOptions = options;
+  }
+
+  /** Ordinary resume is reserved by OpenGeni for the elected cold continuity
+   * owner. Exact live attachment uses resumeExact() below and never reimages. */
+  override async resume(
+    state: Parameters<DockerSandboxClient["resume"]>[0],
+    options?: Parameters<DockerSandboxClient["resume"]>[1],
+  ) {
+    return await super.resume(
+      dockerContinuityResumeStateForImage(state, this.#openGeniOptions.image),
+      options,
+    );
   }
 
   /** Exact attach must not call the SDK's ordinary resume when the persisted

--- a/packages/runtime/test/sandbox-provider-registry.test.ts
+++ b/packages/runtime/test/sandbox-provider-registry.test.ts
@@ -23,7 +23,10 @@ import {
   sdkBackendIdForSandboxBackend,
   selectBackend,
 } from "../src/sandbox";
-import { dockerInspectProvesMissing } from "../src/sandbox/providers/docker";
+import {
+  dockerContinuityResumeStateForImage,
+  dockerInspectProvesMissing,
+} from "../src/sandbox/providers/docker";
 
 // Per-provider credential stubs so build() can run without real creds. Only the
 // fields validateCredentials requires per backend are present.
@@ -141,6 +144,25 @@ describe("provider registry — descriptor invariants + backendId assertion", ()
     const tarSession = { state: { workspacePersistence: "tar", sandboxId: "box" } };
     prepareProviderForTeardownAfterCapture("vercel", tarSession);
     expect(tarSession.state).toEqual({ workspacePersistence: "tar", sandboxId: "box" });
+  });
+});
+
+describe("Docker continuity image selection", () => {
+  test("a cold replacement uses the configured image without mutating persisted state", () => {
+    const persisted = { containerId: "old-box", image: "sandbox:old", workspaceRootOwned: true };
+    const resumed = dockerContinuityResumeStateForImage(persisted, " sandbox:new ");
+    expect(resumed).toEqual({
+      containerId: "old-box",
+      image: "sandbox:new",
+      workspaceRootOwned: true,
+    });
+    expect(persisted.image).toBe("sandbox:old");
+  });
+
+  test("an unset configured image preserves the provider state", () => {
+    const persisted = { image: "sandbox:old" };
+    expect(dockerContinuityResumeStateForImage(persisted, undefined)).toBe(persisted);
+    expect(dockerContinuityResumeStateForImage(persisted, "   ")).toBe(persisted);
   });
 });
 


### PR DESCRIPTION
Fixes the production browser-create failure after a sandbox image rollout.

- probe the exact prior provider identity on image conflict
- retire only authoritatively missing instances so stale interaction holders cannot strand a lease
- restart Docker continuity on the currently configured image
- map remaining runtime/rig drift to explicit HTTP 409, never generic 500

Verification:
- targeted API/runtime tests: 100 pass
- apps/api and packages/runtime typecheck pass
- focused oxlint + oxfmt pass
- full typecheck only has the pre-existing packages/db catalog-curation.ts exactOptionalPropertyTypes error on current main