### PR TITLE
fix(api): retry lost sandbox recovery

### DIFF
--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -52,6 +52,7 @@ import {
   type Observability,
 } from "@opengeni/observability";
 import { HTTPException } from "hono/http-exception";
+import { ApiHttpError } from "../http/api-error";
 
 import {
   buildSelfhostedBackendSession,
@@ -821,8 +822,10 @@ async function withChannelAOperation<T>(
                   payload: { sandboxId: live.instanceId },
                 },
               ]).catch(() => undefined);
-              mappedError = new HTTPException(409, {
+              mappedError = new ApiHttpError(409, {
+                code: "conflict",
                 message: "sandbox instance was lost; retry to restore it",
+                retryable: true,
               });
             }
           }
@@ -912,8 +915,10 @@ async function withChannelAOperation<T>(
           },
         ]);
       }
-      throw new HTTPException(409, {
+      throw new ApiHttpError(409, {
+        code: "conflict",
         message: `sandbox instance was lost; retry to restore it`,
+        retryable: true,
       });
     }
   };
@@ -1149,8 +1154,10 @@ export function mapChannelAError(error: unknown, waitSignal?: AbortSignal): unkn
   if (error instanceof SandboxProviderReadLockUnavailableError)
     return new HTTPException(503, { message: error.message });
   if (error instanceof SandboxImageConflictError || error instanceof SandboxRigConflictError)
-    return new HTTPException(409, {
+    return new ApiHttpError(409, {
+      code: "conflict",
       message: "sandbox runtime changed while this session still has active operations; retry",
+      retryable: true,
     });
   if (error instanceof SelfhostedControlError && error.agentOffline)
     return new HTTPException(409, { message: error.message, cause: error });

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -267,6 +267,7 @@ describe("P4.4 Channel-A route discipline", () => {
       expect((mapped as HTTPException).message).toBe(
         "sandbox runtime changed while this session still has active operations; retry",
       );
+      expect(mapped).toMatchObject({ code: "conflict", retryable: true });
     }
   });
 


### PR DESCRIPTION
The stale-provider recovery path correctly repairs the lease but emitted a structured 409 with `retryable:false`, preventing the SDK cold-restart retry. Emit an explicit retryable conflict and assert it.

Verification:
- `bun test apps/api/test/channel-a-routes.test.ts packages/runtime/test/sandbox-provider-registry.test.ts` (100 pass)
- API/runtime typechecks pass; full typecheck retains the pre-existing catalog-curation error in packages/db