### PR TITLE
feat(sessions): double instruction limit

### DIFF
--- a/.changeset/warm-wolves-instruct.md
+++ b/.changeset/warm-wolves-instruct.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/api-router": minor
+"@opengeni/contracts": minor
+---
+
+Raise the durable per-session system-instruction limit from 32768 to 65536 characters across the public and first-party MCP contracts.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -38,6 +38,7 @@ import {
   SESSION_GOAL_RATIONALE_MAX_BYTES,
   SESSION_GOAL_SUCCESS_CRITERIA_MAX_BYTES,
   SESSION_GOAL_TEXT_MAX_BYTES,
+  SESSION_INSTRUCTIONS_MAX_CHARACTERS,
   sessionGoalUtf8Bytes,
   TASK_NOTE_LIST_DEFAULT_LIMIT,
   TASK_NOTE_LIST_MAX_LIMIT,
@@ -4297,7 +4298,7 @@ function registerWorkspaceOrchestrationTools(
     const sessionCreateInput = z4
       .object({
         initialMessage: z4.string().min(1),
-        instructions: z4.string().min(1).max(32768).optional(),
+        instructions: z4.string().min(1).max(SESSION_INSTRUCTIONS_MAX_CHARACTERS).optional(),
         goal: z4.unknown().optional(),
         resources: z4.array(z4.unknown()).optional(),
         tools: z4.array(z4.unknown()).optional(),

--- a/apps/api/test/first-party-mcp-tool-policy.test.ts
+++ b/apps/api/test/first-party-mcp-tool-policy.test.ts
@@ -5,6 +5,7 @@ import {
   FIRST_PARTY_MCP_TOOL_NAMES,
   FIRST_PARTY_REMOTE_MCP_TOOL_NAMES,
   Permission,
+  SESSION_INSTRUCTIONS_MAX_CHARACTERS,
   type AccessGrant,
   type FirstPartyMcpToolName,
 } from "@opengeni/contracts";
@@ -251,6 +252,11 @@ describe("first-party MCP tool visibility policy", () => {
       expect(serialized).toContain("targetSandboxId");
       expect(serialized).toContain("workingDir");
       expect(serialized).toContain('"required":["targetSandboxId"]');
+      expect(tool?.inputSchema).toMatchObject({
+        properties: {
+          instructions: { maxLength: SESSION_INSTRUCTIONS_MAX_CHARACTERS },
+        },
+      });
       for (const arguments_ of [
         { initialMessage: "bad cwd", workingDir: "/tmp" },
         {

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -69,7 +69,7 @@ non-bypassable CORE (goal-loop ownership + variable set block) always
 substituted in. Exact-message application context does not enter this prefix.
 
 - **Workspace `agentInstructions`** (`Workspace.agentInstructions`, set at workspace create/update) — the white-label persona for _every_ session in a workspace. Use it for stable, tenant-wide branding/behavior. It may embed the `{{core}}` marker to place the non-bypassable CORE; if it omits the marker, CORE is appended.
-- **Per-session `instructions`** (`CreateSessionRequest.instructions`) — an optional, per-_session_ refinement layered after the workspace persona. Use it to deliver a **per-agent-type prompt** (reviewer vs. planner vs. fixer) when many personas share one workspace, without minting a workspace per persona. It is org-visible metadata (returned on the session record, exposed like `title`/`goal`), never a timeline event, and carries system-level authority.
+- **Per-session `instructions`** (`CreateSessionRequest.instructions`) — an optional, per-_session_ refinement layered after the workspace persona. Use it to deliver a **per-agent-type prompt** (reviewer vs. planner vs. fixer) when many personas share one workspace, without minting a workspace per persona. It is org-visible metadata (returned on the session record, exposed like `title`/`goal`), never a timeline event, carries system-level authority, and is capped at 65536 characters.
 - **Per-message `modelContext`** (`CreateSessionRequest.modelContext`,
   `SendMessageInput.modelContext`, and supported realtime inbound entries) —
   optional application context for one exact accepted message. OpenGeni stores

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12124,6 +12124,8 @@ export const SessionControlResponse = z.object({
 });
 export type SessionControlResponse = z.infer<typeof SessionControlResponse>;
 
+export const SESSION_INSTRUCTIONS_MAX_CHARACTERS = 65_536;
+
 export const CreateSessionRequest = withVariableSetIdAlias(
   {
     /**
@@ -12147,10 +12149,10 @@ export const CreateSessionRequest = withVariableSetIdAlias(
     // agentInstructions rides, composed AFTER the workspace persona so it refines
     // it for this one session — how a host delivers per-agent-type prompts without
     // leaking them into the user-visible timeline (it is NEVER emitted as an
-    // event, unlike goal/initialMessage). Trimmed, non-empty. The 32768-char cap
-    // matches the codebase's largest free-form string convention (workspace
-    // variable set variable values). Absent ⇒ byte-identical to today.
-    instructions: z.string().trim().min(1).max(32768).optional(),
+    // event, unlike goal/initialMessage). Trimmed, non-empty, and bounded by the
+    // shared durable session-instruction contract. Absent ⇒ byte-identical to
+    // today.
+    instructions: z.string().trim().min(1).max(SESSION_INSTRUCTIONS_MAX_CHARACTERS).optional(),
     // Immutable prompt-policy role binding for matching one activated role
     // policy. This never derives from or grants a human workspace membership
     // role. Existing callers may continue to use normalized metadata.role as a

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -52,6 +52,7 @@ import {
   SESSION_MCP_APPROVAL_POLICY_MAX_TOOL_NAMES,
   SESSION_MCP_APPROVAL_TOOL_NAME_MAX_BYTES,
   SESSION_MCP_SERVERS_MAX,
+  SESSION_INSTRUCTIONS_MAX_CHARACTERS,
   Session,
   SessionGoal,
   SessionRealtimeInboundEntry,
@@ -1162,19 +1163,19 @@ describe("contracts", () => {
     ).toThrow();
   });
 
-  test("rejects per-session instructions over the 32768-char cap", () => {
+  test("accepts 65536-character per-session instructions and rejects larger values", () => {
     expect(() =>
       CreateSessionRequest.parse({
         initialMessage: "inspect repo",
-        instructions: "x".repeat(32769),
+        instructions: "x".repeat(SESSION_INSTRUCTIONS_MAX_CHARACTERS + 1),
       }),
     ).toThrow();
     // Exactly at the cap is accepted.
     const payload = CreateSessionRequest.parse({
       initialMessage: "inspect repo",
-      instructions: "x".repeat(32768),
+      instructions: "x".repeat(SESSION_INSTRUCTIONS_MAX_CHARACTERS),
     });
-    expect(payload.instructions?.length).toBe(32768);
+    expect(payload.instructions?.length).toBe(SESSION_INSTRUCTIONS_MAX_CHARACTERS);
   });
 
   test("rejects the removed turnInstructions request field", () => {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -2378,7 +2378,7 @@ export type CreateSessionRequest = {
   // Per-session agent persona/system instructions (org-visible metadata, not a
   // secret). Delivered system-level, composed AFTER the per-workspace persona —
   // how a host supplies per-agent-type prompts without leaking them into the
-  // user-visible timeline. Trimmed, non-empty, max 32768 chars.
+  // user-visible timeline. Trimmed, non-empty, max 65536 chars.
   instructions?: string | undefined;
   /** Immutable normalized prompt-policy role; distinct from membership roles. */
   policyRole?: string | undefined;


### PR DESCRIPTION
## Summary
- raise durable per-session system instructions from 32,768 to 65,536 characters
- share the boundary between the public contract and first-party MCP schema
- document the new limit and add exact-boundary regression coverage

## Verification
- `bun test packages/contracts/test/contracts.test.ts`
- `bun test apps/api/test/first-party-mcp-tool-policy.test.ts`
- `bun run --cwd packages/contracts typecheck`
- `bun run --cwd apps/api typecheck`
- `bun run lint`
- `bun run check:docs-refs`
- targeted `bun run format:check`