### PR TITLE
feat: stream-token viewer authority claims and relay authority floor (OPE-203 slice 3)

### DIFF
--- a/.changeset/stream-token-authority-claims.md
+++ b/.changeset/stream-token-authority-claims.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/contracts": minor
+"@opengeni/db": minor
+"@opengeni/runtime": minor
+---
+
+Scoped stream tokens (`ogs_`, 120 s TTL unchanged) now carry the authenticated viewer subject and the session's live authority epoch (migration 0281). The viewer lease holder records the same pair monotonically, the API re-verifies a human viewer's current workspace membership at every mint and degrades the stream to `transport:null` when membership is gone, and the selfhosted relay fences an attach whose authority claim is below the channel's recorded floor. Pre-0281 tokens keep working during the rolling window and enforce nothing new.

--- a/agent/crates/opengeni-relay/src/registry.rs
+++ b/agent/crates/opengeni-relay/src/registry.rs
@@ -229,41 +229,34 @@ impl ChannelRegistry {
         }
         chan.last_touch = now;
 
-        // Epoch fence (clients only): reject a stale viewer; advance the floor.
-        // The authority-epoch floor (0281) applies the same fence to the
-        // session authority epoch when the token carries the claim.
-        if let Some(authority_epoch) = viewer.authority {
-            if authority_epoch < chan.authority_floor {
-                self.metrics.record_open_rejected();
-                if chan.agent.is_none() && chan.client.is_none() {
-                    let was_fresh = fresh;
-                    drop(channels);
-                    if was_fresh {
-                        self.maybe_remove_empty(key);
-                    }
-                } else {
-                    drop(channels);
+        // Epoch fences (clients only): reject a stale viewer, then advance the
+        // floors. The authority-epoch floor (0281) applies the same fence to
+        // the session authority epoch when the token carries the claim. Both
+        // rejections are evaluated BEFORE either floor advances, so a rejected
+        // attach never moves a floor.
+        let authority_stale = viewer
+            .authority
+            .is_some_and(|epoch| epoch < chan.authority_floor);
+        let lease_stale = viewer.lease.is_some_and(|epoch| epoch < chan.epoch_floor);
+        if authority_stale || lease_stale {
+            self.metrics.record_open_rejected();
+            // Drop the channel entry if it was created fresh just for this
+            // rejected attach and is otherwise empty.
+            if chan.agent.is_none() && chan.client.is_none() {
+                let was_fresh = fresh;
+                drop(channels);
+                if was_fresh {
+                    self.maybe_remove_empty(key);
                 }
-                return Err(AttachError::StaleEpoch);
+            } else {
+                drop(channels);
             }
+            return Err(AttachError::StaleEpoch);
+        }
+        if let Some(authority_epoch) = viewer.authority {
             chan.authority_floor = chan.authority_floor.max(authority_epoch);
         }
         if let Some(epoch) = viewer.lease {
-            if epoch < chan.epoch_floor {
-                self.metrics.record_open_rejected();
-                // Drop the channel entry if it was created fresh just for this
-                // rejected attach and is otherwise empty.
-                if chan.agent.is_none() && chan.client.is_none() {
-                    let was_fresh = fresh;
-                    drop(channels);
-                    if was_fresh {
-                        self.maybe_remove_empty(key);
-                    }
-                } else {
-                    drop(channels);
-                }
-                return Err(AttachError::StaleEpoch);
-            }
             chan.epoch_floor = chan.epoch_floor.max(epoch);
         }
 

--- a/agent/crates/opengeni-relay/src/registry.rs
+++ b/agent/crates/opengeni-relay/src/registry.rs
@@ -77,6 +77,28 @@ impl std::fmt::Display for AttachError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ConnGen(u64);
 
+/// The client stream-token epoch claims applied at attach: the lease-epoch
+/// fence plus the optional session authority-epoch fence (0281). Both `None`
+/// for an agent side.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ViewerEpochs {
+    /// The lease-epoch fence claim (`Some` for a client, `None` for an agent).
+    pub lease: Option<u64>,
+    /// The session authority-epoch claim (0281); `None` for a pre-0281 token.
+    pub authority: Option<u64>,
+}
+
+impl ViewerEpochs {
+    /// A lease-epoch-only claim (a pre-0281 token, or a fixture).
+    #[must_use]
+    pub fn lease_only(epoch: u64) -> Self {
+        Self {
+            lease: Some(epoch),
+            authority: None,
+        }
+    }
+}
+
 /// The outcome of a successful attach: the seq the peer should resume sending from,
 /// the frames to replay immediately, and this connection's generation handle.
 #[derive(Debug)]
@@ -119,6 +141,11 @@ struct LiveChannel {
     to_agent: Direction,
     /// The highest viewer epoch seen — the stale-viewer fence floor.
     epoch_floor: u64,
+    /// The highest session AUTHORITY epoch any viewer presented (0281). A
+    /// viewer whose token carries a lower authority epoch was minted before an
+    /// authority revocation and is rejected; tokens without the claim
+    /// (pre-0281 mints) enforce nothing and never advance the floor.
+    authority_floor: u64,
     /// When the channel was created / last touched (for half-open reaping).
     last_touch: Instant,
 }
@@ -166,9 +193,10 @@ impl ChannelRegistry {
     }
 
     /// Attach a side to its channel. Registers the side's outbound `sink`, advances
-    /// the epoch floor (for a client), and returns the resume cursor + any frames to
-    /// replay to this side. A `viewer_epoch` is `Some(epoch)` for a CLIENT (the
-    /// fence) and `None` for an AGENT.
+    /// the epoch floors (for a client), and returns the resume cursor + any frames
+    /// to replay to this side. `viewer.lease` is `Some(epoch)` for a CLIENT (the
+    /// fence) and `None` for an AGENT; `viewer.authority` is the optional session
+    /// authority-epoch claim (0281).
     ///
     /// `resume_from_seq` is the seq the RECONNECTING side last processed; the relay
     /// replays the OTHER side's buffered frames from there toward this side.
@@ -180,7 +208,7 @@ impl ChannelRegistry {
         &self,
         key: &ChannelKey,
         role: Role,
-        viewer_epoch: Option<u64>,
+        viewer: ViewerEpochs,
         resume_from_seq: u64,
         sink: PeerSink,
         now: Instant,
@@ -193,6 +221,7 @@ impl ChannelRegistry {
             to_client: Direction::default(),
             to_agent: Direction::default(),
             epoch_floor: 0,
+            authority_floor: 0,
             last_touch: now,
         });
         if fresh {
@@ -201,7 +230,25 @@ impl ChannelRegistry {
         chan.last_touch = now;
 
         // Epoch fence (clients only): reject a stale viewer; advance the floor.
-        if let Some(epoch) = viewer_epoch {
+        // The authority-epoch floor (0281) applies the same fence to the
+        // session authority epoch when the token carries the claim.
+        if let Some(authority_epoch) = viewer.authority {
+            if authority_epoch < chan.authority_floor {
+                self.metrics.record_open_rejected();
+                if chan.agent.is_none() && chan.client.is_none() {
+                    let was_fresh = fresh;
+                    drop(channels);
+                    if was_fresh {
+                        self.maybe_remove_empty(key);
+                    }
+                } else {
+                    drop(channels);
+                }
+                return Err(AttachError::StaleEpoch);
+            }
+            chan.authority_floor = chan.authority_floor.max(authority_epoch);
+        }
+        if let Some(epoch) = viewer.lease {
             if epoch < chan.epoch_floor {
                 self.metrics.record_open_rejected();
                 // Drop the channel entry if it was created fresh just for this
@@ -484,10 +531,24 @@ mod tests {
         let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel(16);
         let (client_tx, mut client_rx) = tokio::sync::mpsc::channel(16);
 
-        reg.attach(&key(), Role::Agent, None, 0, agent_tx, now)
-            .unwrap();
-        reg.attach(&key(), Role::Client, Some(0), 0, client_tx, now)
-            .unwrap();
+        reg.attach(
+            &key(),
+            Role::Agent,
+            ViewerEpochs::default(),
+            0,
+            agent_tx,
+            now,
+        )
+        .unwrap();
+        reg.attach(
+            &key(),
+            Role::Client,
+            ViewerEpochs::lease_only(0),
+            0,
+            client_tx,
+            now,
+        )
+        .unwrap();
         assert!(reg.is_paired(&key()));
 
         // agent → client.
@@ -512,13 +573,28 @@ mod tests {
         let (c_tx, _c_rx) = tokio::sync::mpsc::channel(16);
         let (stale_tx, _s_rx) = tokio::sync::mpsc::channel(16);
 
-        reg.attach(&key(), Role::Agent, None, 0, a_tx, now).unwrap();
-        // A viewer at epoch 5 advances the floor to 5.
-        reg.attach(&key(), Role::Client, Some(5), 0, c_tx, now)
+        reg.attach(&key(), Role::Agent, ViewerEpochs::default(), 0, a_tx, now)
             .unwrap();
+        // A viewer at epoch 5 advances the floor to 5.
+        reg.attach(
+            &key(),
+            Role::Client,
+            ViewerEpochs::lease_only(5),
+            0,
+            c_tx,
+            now,
+        )
+        .unwrap();
         // A viewer at epoch 4 (a swapped-away generation) is REJECTED.
         let err = reg
-            .attach(&key(), Role::Client, Some(4), 0, stale_tx, now)
+            .attach(
+                &key(),
+                Role::Client,
+                ViewerEpochs::lease_only(4),
+                0,
+                stale_tx,
+                now,
+            )
             .unwrap_err();
         assert_eq!(err, AttachError::StaleEpoch);
         assert_eq!(reg.metrics().opens_rejected(), 1);
@@ -540,14 +616,42 @@ mod tests {
         let (agent_b_tx, _ab) = tokio::sync::mpsc::channel(16);
         let (client_b_tx, mut client_b_rx) = tokio::sync::mpsc::channel(16);
 
-        reg.attach(&key_a, Role::Agent, None, 0, agent_a_tx, now)
-            .unwrap();
-        reg.attach(&key_a, Role::Client, Some(0), 0, client_a_tx, now)
-            .unwrap();
-        reg.attach(&key_b, Role::Agent, None, 0, agent_b_tx, now)
-            .unwrap();
-        reg.attach(&key_b, Role::Client, Some(0), 0, client_b_tx, now)
-            .unwrap();
+        reg.attach(
+            &key_a,
+            Role::Agent,
+            ViewerEpochs::default(),
+            0,
+            agent_a_tx,
+            now,
+        )
+        .unwrap();
+        reg.attach(
+            &key_a,
+            Role::Client,
+            ViewerEpochs::lease_only(0),
+            0,
+            client_a_tx,
+            now,
+        )
+        .unwrap();
+        reg.attach(
+            &key_b,
+            Role::Agent,
+            ViewerEpochs::default(),
+            0,
+            agent_b_tx,
+            now,
+        )
+        .unwrap();
+        reg.attach(
+            &key_b,
+            Role::Client,
+            ViewerEpochs::lease_only(0),
+            0,
+            client_b_tx,
+            now,
+        )
+        .unwrap();
 
         // A frame on channel A reaches A's viewer only.
         reg.forward(&key_a, Role::Agent, frame(0, "secretA"), now);
@@ -573,14 +677,42 @@ mod tests {
         let (agent_b_tx, _agent_b_rx) = tokio::sync::mpsc::channel(16);
         let (client_b_tx, mut client_b_rx) = tokio::sync::mpsc::channel(16);
 
-        reg.attach(&key_a, Role::Agent, None, 0, agent_a_tx, now)
-            .unwrap();
-        reg.attach(&key_a, Role::Client, Some(0), 0, client_a_tx, now)
-            .unwrap();
-        reg.attach(&key_b, Role::Agent, None, 0, agent_b_tx, now)
-            .unwrap();
-        reg.attach(&key_b, Role::Client, Some(0), 0, client_b_tx, now)
-            .unwrap();
+        reg.attach(
+            &key_a,
+            Role::Agent,
+            ViewerEpochs::default(),
+            0,
+            agent_a_tx,
+            now,
+        )
+        .unwrap();
+        reg.attach(
+            &key_a,
+            Role::Client,
+            ViewerEpochs::lease_only(0),
+            0,
+            client_a_tx,
+            now,
+        )
+        .unwrap();
+        reg.attach(
+            &key_b,
+            Role::Agent,
+            ViewerEpochs::default(),
+            0,
+            agent_b_tx,
+            now,
+        )
+        .unwrap();
+        reg.attach(
+            &key_b,
+            Role::Client,
+            ViewerEpochs::lease_only(0),
+            0,
+            client_b_tx,
+            now,
+        )
+        .unwrap();
 
         assert!(reg.forward(&key_a, Role::Agent, frame(0, "shell-a"), now));
         assert!(reg.forward(&key_b, Role::Agent, frame(0, "shell-b"), now));
@@ -599,7 +731,8 @@ mod tests {
         let reg = registry();
         let now = Instant::now();
         let (a_tx, _a_rx) = tokio::sync::mpsc::channel(16);
-        reg.attach(&key(), Role::Agent, None, 0, a_tx, now).unwrap();
+        reg.attach(&key(), Role::Agent, ViewerEpochs::default(), 0, a_tx, now)
+            .unwrap();
 
         // The agent produces 3 frames while the client is absent — buffered in the
         // to_client ring.
@@ -610,7 +743,14 @@ mod tests {
         // The client attaches (reconnect) resuming from seq 1 — it replays f1, f2.
         let (c_tx, _c_rx) = tokio::sync::mpsc::channel(16);
         let attached = reg
-            .attach(&key(), Role::Client, Some(0), 1, c_tx, now)
+            .attach(
+                &key(),
+                Role::Client,
+                ViewerEpochs::lease_only(0),
+                1,
+                c_tx,
+                now,
+            )
             .unwrap();
         let seqs: Vec<u64> = attached.replay.iter().map(|f| f.seq).collect();
         assert_eq!(seqs, vec![1, 2]);
@@ -623,9 +763,17 @@ mod tests {
         let (a_tx, _a_rx) = tokio::sync::mpsc::channel(16);
         // The client's sink has capacity 1; the second frame sheds (buffer_drop).
         let (c_tx, _c_rx) = tokio::sync::mpsc::channel::<RelayMessage>(1);
-        reg.attach(&key(), Role::Agent, None, 0, a_tx, now).unwrap();
-        reg.attach(&key(), Role::Client, Some(0), 0, c_tx, now)
+        reg.attach(&key(), Role::Agent, ViewerEpochs::default(), 0, a_tx, now)
             .unwrap();
+        reg.attach(
+            &key(),
+            Role::Client,
+            ViewerEpochs::lease_only(0),
+            0,
+            c_tx,
+            now,
+        )
+        .unwrap();
 
         assert!(reg.forward(&key(), Role::Agent, frame(0, "a"), now));
         // The queue (cap 1) is full; the next forward sheds.
@@ -639,9 +787,17 @@ mod tests {
         let now = Instant::now();
         let (a_tx, _a_rx) = tokio::sync::mpsc::channel(16);
         let (c_tx, _c_rx) = tokio::sync::mpsc::channel(16);
-        reg.attach(&key(), Role::Agent, None, 0, a_tx, now).unwrap();
+        reg.attach(&key(), Role::Agent, ViewerEpochs::default(), 0, a_tx, now)
+            .unwrap();
         let client = reg
-            .attach(&key(), Role::Client, Some(0), 0, c_tx, now)
+            .attach(
+                &key(),
+                Role::Client,
+                ViewerEpochs::lease_only(0),
+                0,
+                c_tx,
+                now,
+            )
             .unwrap();
         reg.forward(&key(), Role::Agent, frame(0, "x"), now);
 
@@ -654,7 +810,14 @@ mod tests {
         // The client reconnects resuming from 1 → replays y (seq 1).
         let (c2_tx, _c2_rx) = tokio::sync::mpsc::channel(16);
         let attached = reg
-            .attach(&key(), Role::Client, Some(0), 1, c2_tx, now)
+            .attach(
+                &key(),
+                Role::Client,
+                ViewerEpochs::lease_only(0),
+                1,
+                c2_tx,
+                now,
+            )
             .unwrap();
         assert_eq!(
             attached.replay.iter().map(|f| f.seq).collect::<Vec<_>>(),
@@ -672,13 +835,13 @@ mod tests {
         let now = Instant::now();
         let (a1_tx, _a1) = tokio::sync::mpsc::channel(16);
         let first = reg
-            .attach(&key(), Role::Agent, None, 0, a1_tx, now)
+            .attach(&key(), Role::Agent, ViewerEpochs::default(), 0, a1_tx, now)
             .unwrap();
         // The agent reconnects (a new connection, new gen) BEFORE the old one's
         // teardown lands.
         let (a2_tx, mut a2_rx) = tokio::sync::mpsc::channel(16);
         let second = reg
-            .attach(&key(), Role::Agent, None, 0, a2_tx, now)
+            .attach(&key(), Role::Agent, ViewerEpochs::default(), 0, a2_tx, now)
             .unwrap();
         assert_ne!(first.gen, second.gen);
 
@@ -687,8 +850,15 @@ mod tests {
 
         // A client → agent input still reaches the NEW agent connection.
         let (c_tx, _c_rx) = tokio::sync::mpsc::channel(16);
-        reg.attach(&key(), Role::Client, Some(0), 0, c_tx, now)
-            .unwrap();
+        reg.attach(
+            &key(),
+            Role::Client,
+            ViewerEpochs::lease_only(0),
+            0,
+            c_tx,
+            now,
+        )
+        .unwrap();
         assert!(reg.forward(&key(), Role::Client, frame(0, "input"), now));
         match a2_rx.recv().await.unwrap() {
             RelayMessage::Frame(f) => assert_eq!(&f.data[..], b"input"),
@@ -702,9 +872,17 @@ mod tests {
         let now = Instant::now();
         let (a_tx, _a_rx) = tokio::sync::mpsc::channel(16);
         let (c_tx, mut c_rx) = tokio::sync::mpsc::channel(16);
-        reg.attach(&key(), Role::Agent, None, 0, a_tx, now).unwrap();
-        reg.attach(&key(), Role::Client, Some(0), 0, c_tx, now)
+        reg.attach(&key(), Role::Agent, ViewerEpochs::default(), 0, a_tx, now)
             .unwrap();
+        reg.attach(
+            &key(),
+            Role::Client,
+            ViewerEpochs::lease_only(0),
+            0,
+            c_tx,
+            now,
+        )
+        .unwrap();
 
         let close = RelayMessage::Close(v1::StreamClose {
             channel_id: "ch".to_string(),
@@ -718,5 +896,56 @@ mod tests {
             other => panic!("expected a close, got {other:?}"),
         }
         assert!(!reg.is_paired(&key()));
+    }
+
+    #[tokio::test]
+    async fn authority_floor_rejects_stale_and_ignores_absent_claims() {
+        let reg = registry();
+        let now = Instant::now();
+        let (a_tx, _a_rx) = tokio::sync::mpsc::channel(4);
+        reg.attach(&key(), Role::Agent, ViewerEpochs::default(), 0, a_tx, now)
+            .unwrap();
+        // A viewer with authority epoch 3 establishes the floor.
+        let (c_tx, _c_rx) = tokio::sync::mpsc::channel(4);
+        reg.attach(
+            &key(),
+            Role::Client,
+            ViewerEpochs {
+                lease: Some(1),
+                authority: Some(3),
+            },
+            0,
+            c_tx,
+            now,
+        )
+        .unwrap();
+        // A viewer minted before the authority revocation (epoch 2) is stale.
+        let (stale_tx, _stale_rx) = tokio::sync::mpsc::channel(4);
+        assert!(matches!(
+            reg.attach(
+                &key(),
+                Role::Client,
+                ViewerEpochs {
+                    lease: Some(1),
+                    authority: Some(2)
+                },
+                0,
+                stale_tx,
+                now
+            )
+            .unwrap_err(),
+            AttachError::StaleEpoch
+        ));
+        // A pre-0281 token without the claim enforces nothing and still attaches.
+        let (legacy_tx, _legacy_rx) = tokio::sync::mpsc::channel(4);
+        reg.attach(
+            &key(),
+            Role::Client,
+            ViewerEpochs::lease_only(1),
+            0,
+            legacy_tx,
+            now,
+        )
+        .unwrap();
     }
 }

--- a/agent/crates/opengeni-relay/src/server.rs
+++ b/agent/crates/opengeni-relay/src/server.rs
@@ -195,8 +195,9 @@ pub(crate) mod conn {
             }
         };
 
-        // 2. Resolve + authorize the key (token + channel-key scope).
-        let (key, role, resume_from_seq) = match authorize(&open, query, state) {
+        // 2. Resolve + authorize the key (token + channel-key scope). A client's
+        // fence claims come from this exact token verification.
+        let (key, role, resume_from_seq, viewer) = match authorize(&open, query, state) {
             Ok(parts) => parts,
             Err(reason) => {
                 tracing::warn!(reason = %reason, ws = %query.ws, agent = %query.agent, port = query.port, "relay open rejected");
@@ -206,12 +207,8 @@ pub(crate) mod conn {
             }
         };
 
-        // 3. Attach (the epoch fence is applied for a client), ack, replay.
+        // 3. Attach (the epoch fences are applied for a client), ack, replay.
         let now = Instant::now();
-        let viewer = match role {
-            Role::Client => client_epochs(&open, state),
-            Role::Agent => ViewerEpochs::default(),
-        };
         let (peer_tx, peer_rx) = tokio::sync::mpsc::channel::<RelayMessage>(OUTBOUND_QUEUE);
         let attached =
             match state
@@ -350,7 +347,7 @@ pub(crate) mod conn {
         open: &v1::StreamOpen,
         query: &DialQuery,
         state: &RelayState,
-    ) -> Result<(ChannelKey, Role, u64), String> {
+    ) -> Result<(ChannelKey, Role, u64, ViewerEpochs), String> {
         let channel = open
             .channel
             .as_ref()
@@ -411,28 +408,22 @@ pub(crate) mod conn {
                 if claims.port != key.port {
                     return Err("viewer token port does not match the channel key".to_string());
                 }
-                // The epoch fence is applied at attach (the floor); see client_epoch.
+                // The epoch fences are applied at attach (the floors), from the
+                // claims of THIS exact verification — no re-verify, no window
+                // where an expiring token attaches unfenced.
+                return Ok((
+                    key,
+                    role,
+                    open.resume_from_seq,
+                    ViewerEpochs {
+                        lease: Some(claims.lease_epoch),
+                        authority: claims.authority_epoch,
+                    },
+                ));
             }
         }
 
-        Ok((key, role, open.resume_from_seq))
-    }
-
-    /// The viewer epoch claims (the fence floor sources) from the token: the
-    /// lease epoch plus the optional session authority epoch (0281). Returns the
-    /// empty claims when the token does not re-verify (already authorized in
-    /// `authorize`, so this is the steady-state extraction). Only called for a
-    /// CLIENT; a pre-0281 token carries no authority claim and enforces nothing
-    /// beyond the lease fence.
-    fn client_epochs(open: &v1::StreamOpen, state: &RelayState) -> ViewerEpochs {
-        match token::verify_stream_token(&state.config.stream_token_secret, &open.token, unix_now())
-        {
-            Ok(c) => ViewerEpochs {
-                lease: Some(c.lease_epoch),
-                authority: c.authority_epoch,
-            },
-            Err(_) => ViewerEpochs::default(),
-        }
+        Ok((key, role, open.resume_from_seq, ViewerEpochs::default()))
     }
 
     /// Write a `StreamOpenAck` over the socket.

--- a/agent/crates/opengeni-relay/src/server.rs
+++ b/agent/crates/opengeni-relay/src/server.rs
@@ -142,7 +142,7 @@ pub(crate) mod conn {
     use opengeni_agent_stream::codec::RelayMessage;
     use opengeni_agent_stream::ChannelKey;
 
-    use crate::registry::{AttachError, Role};
+    use crate::registry::{AttachError, Role, ViewerEpochs};
     use crate::token::{self, TokenError};
 
     /// The bound on the per-connection outbound queue (the peer-sink). A slow socket
@@ -208,15 +208,15 @@ pub(crate) mod conn {
 
         // 3. Attach (the epoch fence is applied for a client), ack, replay.
         let now = Instant::now();
-        let viewer_epoch: Option<u64> = match role {
-            Role::Client => client_epoch(&open, state),
-            Role::Agent => None,
+        let viewer = match role {
+            Role::Client => client_epochs(&open, state),
+            Role::Agent => ViewerEpochs::default(),
         };
         let (peer_tx, peer_rx) = tokio::sync::mpsc::channel::<RelayMessage>(OUTBOUND_QUEUE);
         let attached =
             match state
                 .registry
-                .attach(&key, role, viewer_epoch, resume_from_seq, peer_tx, now)
+                .attach(&key, role, viewer, resume_from_seq, peer_tx, now)
             {
                 Ok(a) => a,
                 Err(AttachError::StaleEpoch) => {
@@ -418,13 +418,21 @@ pub(crate) mod conn {
         Ok((key, role, open.resume_from_seq))
     }
 
-    /// The viewer epoch (the fence floor source) from the token. Returns None when
-    /// the token does not re-verify (already authorized in `authorize`, so this is
-    /// the steady-state extraction). Only called for a CLIENT.
-    fn client_epoch(open: &v1::StreamOpen, state: &RelayState) -> Option<u64> {
-        token::verify_stream_token(&state.config.stream_token_secret, &open.token, unix_now())
-            .ok()
-            .map(|c| c.lease_epoch)
+    /// The viewer epoch claims (the fence floor sources) from the token: the
+    /// lease epoch plus the optional session authority epoch (0281). Returns the
+    /// empty claims when the token does not re-verify (already authorized in
+    /// `authorize`, so this is the steady-state extraction). Only called for a
+    /// CLIENT; a pre-0281 token carries no authority claim and enforces nothing
+    /// beyond the lease fence.
+    fn client_epochs(open: &v1::StreamOpen, state: &RelayState) -> ViewerEpochs {
+        match token::verify_stream_token(&state.config.stream_token_secret, &open.token, unix_now())
+        {
+            Ok(c) => ViewerEpochs {
+                lease: Some(c.lease_epoch),
+                authority: c.authority_epoch,
+            },
+            Err(_) => ViewerEpochs::default(),
+        }
     }
 
     /// Write a `StreamOpenAck` over the socket.

--- a/agent/crates/opengeni-relay/src/token.rs
+++ b/agent/crates/opengeni-relay/src/token.rs
@@ -77,6 +77,15 @@ pub struct StreamTokenClaims {
     pub port: u32,
     /// Expiry, unix seconds.
     pub exp: i64,
+    /// The authenticated viewer subject the token was minted for (0281).
+    /// Optional for rolling compatibility with pre-0281 mints.
+    #[serde(rename = "subjectId", default)]
+    pub subject_id: Option<String>,
+    /// The session authority epoch observed at mint (0281) - the relay tracks
+    /// the highest value presented per channel and rejects tokens below that
+    /// floor, mirroring the lease-epoch stale-viewer fence.
+    #[serde(rename = "authorityEpoch", default)]
+    pub authority_epoch: Option<u64>,
 }
 
 /// The verified claims of an agent `ogr_` relay producer token. Field names mirror
@@ -248,6 +257,26 @@ mod tests {
         assert_eq!(claims.lease_epoch, 3);
         assert_eq!(claims.port, 7681);
         assert_eq!(claims.mode, "view");
+    }
+
+    #[test]
+    fn parses_viewer_authority_claims_and_tolerates_their_absence() {
+        // A 0281 token carries the viewer subject + authority epoch.
+        let payload = r#"{"workspaceId":"ws-1","sessionId":"sess-1","viewerId":"v-1","leaseEpoch":3,"mode":"view","port":7681,"exp":9999999999,"subjectId":"user:abc","authorityEpoch":7}"#;
+        let token = mint(STREAM_TOKEN_PREFIX, "sekret", payload);
+        let claims = verify_stream_token("sekret", &token, 1_000).expect("verify");
+        assert_eq!(claims.subject_id.as_deref(), Some("user:abc"));
+        assert_eq!(claims.authority_epoch, Some(7));
+
+        // A pre-0281 token (no claims) still verifies with None fields.
+        let legacy = mint(
+            STREAM_TOKEN_PREFIX,
+            "sekret",
+            &stream_payload(3, 9_999_999_999),
+        );
+        let legacy_claims = verify_stream_token("sekret", &legacy, 1_000).expect("verify");
+        assert_eq!(legacy_claims.subject_id, None);
+        assert_eq!(legacy_claims.authority_epoch, None);
     }
 
     #[test]

--- a/apps/api/src/routes/browser-sessions.ts
+++ b/apps/api/src/routes/browser-sessions.ts
@@ -59,6 +59,7 @@ import {
   type SiteAuthAuthority,
 } from "@opengeni/contracts";
 import {
+  getSessionAuthorityEpoch,
   acquireLease,
   activateBrowserSession,
   ATTACHED_BROWSER_SESSION_CAPABILITIES,
@@ -1740,6 +1741,18 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
           });
           const stream = relayed
             ? await (async () => {
+                // 0281: stamp the authenticated viewer subject and the live
+                // session authority epoch into the relay stream token.
+                const relayAuthorityEpoch = await getSessionAuthorityEpoch(deps.db, {
+                  accountId: grant.accountId,
+                  workspaceId,
+                  sessionId: record.sourceSessionId,
+                });
+                if (relayAuthorityEpoch === null) {
+                  throw new BrowserControlUnsupportedError(
+                    "stream authority is unavailable for this session",
+                  );
+                }
                 const relayToken = await mintStreamToken(relaySecret!, {
                   workspaceId,
                   sessionId: record.sourceSessionId,
@@ -1747,6 +1760,8 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
                   leaseEpoch: record.tokenGeneration,
                   port: relayed.channel.port,
                   ttlSeconds: request.expiresInSeconds,
+                  subjectId: grant.subjectId,
+                  authorityEpoch: relayAuthorityEpoch,
                 });
                 return {
                   kind: "relay" as const,

--- a/apps/api/src/routes/computer-sessions.ts
+++ b/apps/api/src/routes/computer-sessions.ts
@@ -25,6 +25,7 @@ import {
   type SessionAuthorizationOperation,
 } from "@opengeni/contracts";
 import {
+  getSessionAuthorityEpoch,
   acquireLease,
   activateComputerSession,
   completeComputerSessionEnd,
@@ -542,6 +543,18 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
           }
           const stream = relayed
             ? await (async () => {
+                // 0281: stamp the authenticated viewer subject and the live
+                // session authority epoch into the relay stream token.
+                const relayAuthorityEpoch = await getSessionAuthorityEpoch(deps.db, {
+                  accountId: grant.accountId,
+                  workspaceId,
+                  sessionId: record.sourceSessionId,
+                });
+                if (relayAuthorityEpoch === null) {
+                  throw new BrowserControlUnsupportedError(
+                    "stream authority is unavailable for this session",
+                  );
+                }
                 const relayToken = await mintStreamToken(relaySecret!, {
                   workspaceId,
                   sessionId: record.sourceSessionId,
@@ -549,6 +562,8 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
                   leaseEpoch: record.tokenGeneration,
                   port: relayed.channel.port,
                   ttlSeconds: request.expiresInSeconds,
+                  subjectId: grant.subjectId,
+                  authorityEpoch: relayAuthorityEpoch,
                 });
                 return {
                   kind: "relay" as const,

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -2889,6 +2889,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
             accountId: grant.accountId,
             workspaceId,
             resourceSubjectId: grant.subjectId,
+            resourceSubjectDelegated: grant.metadata?.delegated === true,
             session,
             viewerId,
             // No Modal lease for selfhosted-active; the mint routes to the relay.
@@ -2899,6 +2900,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
             accountId: grant.accountId,
             workspaceId,
             resourceSubjectId: grant.subjectId,
+            resourceSubjectDelegated: grant.metadata?.delegated === true,
             session,
             viewerId,
             // No Modal lease for selfhosted-active; the mint routes to the relay.
@@ -2939,6 +2941,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
               accountId: grant.accountId,
               workspaceId,
               resourceSubjectId: grant.subjectId,
+              resourceSubjectDelegated: grant.metadata?.delegated === true,
               session,
               viewerId: result.viewerId,
               lease,
@@ -2949,6 +2952,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
               accountId: grant.accountId,
               workspaceId,
               resourceSubjectId: grant.subjectId,
+              resourceSubjectDelegated: grant.metadata?.delegated === true,
               session,
               viewerId: result.viewerId,
               lease,

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -2910,6 +2910,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
         accountId: grant.accountId,
         workspaceId,
         session,
+        viewerSubjectId: grant.subjectId,
         waitSignal: c.req.raw.signal,
         ...(parsed.data.viewerId ? { viewerId: parsed.data.viewerId } : {}),
       });

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -49,6 +49,8 @@ import {
   type Database,
   type LeaseSnapshot,
   type SandboxRecord,
+  getSessionAuthorityEpoch,
+  getWorkspaceGrant,
 } from "@opengeni/db";
 import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
 import { HTTPException } from "hono/http-exception";
@@ -196,6 +198,9 @@ export async function attachViewer(
     workspaceId: string;
     session: Session;
     viewerId?: string;
+    /** The authenticated subject attaching this viewer (0281): recorded on
+     *  the holder row together with the live session authority epoch. */
+    viewerSubjectId?: string;
     /** Cancel lifecycle waiting when the originating HTTP request disconnects. */
     waitSignal?: AbortSignal;
   },
@@ -203,6 +208,9 @@ export async function attachViewer(
   const { db, settings } = services;
   const { accountId, workspaceId, session } = input;
   const viewerId = input.viewerId ?? crypto.randomUUID();
+  const attachAuthorityEpoch = input.viewerSubjectId
+    ? await getSessionAuthorityEpoch(db, { accountId, workspaceId, sessionId: session.id })
+    : null;
   const leaseTtlMs = settings.sandboxLeaseTtlMs;
   const sandboxGroupId = session.sandboxGroupId;
   const sandboxRuntime = await resolveSessionSandboxRuntime(db, settings, session);
@@ -227,6 +235,8 @@ export async function attachViewer(
       kind: "viewer",
       holderId: viewerId,
       subjectId: session.id,
+      ...(input.viewerSubjectId ? { viewerSubjectId: input.viewerSubjectId } : {}),
+      ...(attachAuthorityEpoch !== null ? { viewerAuthorityEpoch: attachAuthorityEpoch } : {}),
       backend: session.sandboxBackend,
       os: session.sandboxOs,
       image: sandboxRuntime.image,
@@ -664,6 +674,45 @@ export type DesktopStreamMint = {
   leaseEpoch: number;
 };
 
+/**
+ * Resolve the viewer-facing authority claims stamped into a scoped stream
+ * token and recorded on the viewer holder (0281): the authenticated viewer
+ * subject and the session's LIVE authority epoch. Re-verifies a human
+ * subject's current workspace membership at mint time - a viewer whose
+ * membership was removed since the route authorized them degrades to null
+ * (transport:null) instead of receiving a fresh token. API-key and service
+ * principals are not workspace members; their route authorization stands.
+ * Identity and epoch only - never a secret value.
+ */
+async function resolveViewerAuthorityClaims(
+  db: ViewerServices["db"],
+  input: {
+    accountId: string;
+    workspaceId: string;
+    sessionId: string;
+    subjectId: string | null;
+  },
+): Promise<{ subjectId?: string; authorityEpoch: number } | null> {
+  const authorityEpoch = await getSessionAuthorityEpoch(db, {
+    accountId: input.accountId,
+    workspaceId: input.workspaceId,
+    sessionId: input.sessionId,
+  });
+  if (authorityEpoch === null) {
+    return null;
+  }
+  if (input.subjectId?.startsWith("user:")) {
+    const membership = await getWorkspaceGrant(db, input.subjectId, input.workspaceId);
+    if (!membership) {
+      return null;
+    }
+  }
+  return {
+    ...(input.subjectId ? { subjectId: input.subjectId } : {}),
+    authorityEpoch,
+  };
+}
+
 export type MintDesktopStreamInput = {
   accountId: string;
   workspaceId: string;
@@ -730,6 +779,19 @@ export async function mintDesktopStream(
     return null;
   }
 
+  // 0281: the viewer's authority claims. A missing epoch (session not
+  // visible) or a removed human membership degrades the mint instead of
+  // issuing a fresh token.
+  const viewerAuthority = await resolveViewerAuthorityClaims(db, {
+    accountId,
+    workspaceId,
+    sessionId: session.id,
+    subjectId: input.resourceSubjectId ?? null,
+  });
+  if (!viewerAuthority) {
+    return null;
+  }
+
   // SELFHOSTED ACTIVE: when the session's active sandbox is a selfhosted machine,
   // route to the relay (NOT the Modal group-box path — it would resume the wrong
   // box and return a Modal URL). No Modal lease required.
@@ -751,6 +813,7 @@ export async function mintDesktopStream(
           ...(input.resourceSubjectId ? { resourceSubjectId: input.resourceSubjectId } : {}),
           port: DESKTOP_STREAM_PORT,
           sandbox: active,
+          viewerAuthority,
         },
         input.resolveSelfhostedSession,
       );
@@ -832,6 +895,7 @@ export async function mintDesktopStream(
         leaseEpoch: lease.leaseEpoch,
         streamTokenSecret: secret,
         resolution: defaultResolution(settings),
+        ...viewerAuthority,
       });
     } catch (error) {
       // A transient/headless provider failure degrades the desktop cell.
@@ -981,6 +1045,19 @@ export async function mintTerminalStream(
     return null;
   }
 
+  // 0281: the viewer's authority claims. A missing epoch (session not
+  // visible) or a removed human membership degrades the mint instead of
+  // issuing a fresh token.
+  const viewerAuthority = await resolveViewerAuthorityClaims(db, {
+    accountId,
+    workspaceId,
+    sessionId: session.id,
+    subjectId: input.resourceSubjectId ?? null,
+  });
+  if (!viewerAuthority) {
+    return null;
+  }
+
   // SELFHOSTED ACTIVE: when the session's active sandbox is a selfhosted machine,
   // route to the relay. NEVER fall through to the Modal group-box path (it would
   // resume the wrong box / return a Modal URL).
@@ -1002,6 +1079,7 @@ export async function mintTerminalStream(
           ...(input.resourceSubjectId ? { resourceSubjectId: input.resourceSubjectId } : {}),
           port: TERMINAL_STREAM_PORT,
           sandbox: active,
+          viewerAuthority,
         },
         input.resolveSelfhostedSession,
       );
@@ -1072,6 +1150,7 @@ export async function mintTerminalStream(
         leaseEpoch: lease.leaseEpoch,
         streamTokenSecret: secret,
         port: TERMINAL_STREAM_PORT,
+        ...viewerAuthority,
       });
     } catch (error) {
       if (error instanceof StreamPortUnavailableError) {
@@ -1150,6 +1229,8 @@ async function tryMintActiveSelfhostedStream(
     resourceSubjectId?: string;
     port: number;
     sandbox: SandboxRecord;
+    /** 0281 viewer authority claims stamped into the relay stream token. */
+    viewerAuthority?: { subjectId?: string; authorityEpoch: number };
   },
   // optional test seam (mirrors the existing `establish?` seam pattern): inject a
   // fake relay-resolving session; production NEVER passes it.
@@ -1208,6 +1289,7 @@ async function tryMintActiveSelfhostedStream(
     sessionId: session.id,
     viewerId: input.viewerId,
     activeEpoch: session.activeEpoch,
+    ...(input.viewerAuthority ? { viewerAuthority: input.viewerAuthority } : {}),
     port,
     session: shSession,
   });
@@ -1227,6 +1309,8 @@ export type MintSelfhostedStreamInput = {
    *  THIS as its leaseEpoch claim so the relay rejects a stale-epoch (swapped-away)
    *  viewer. */
   activeEpoch: number;
+  /** 0281 viewer authority claims stamped into the relay stream token. */
+  viewerAuthority?: { subjectId?: string; authorityEpoch: number };
   /** The exposed stream port (6080 desktop / 7681 terminal). */
   port: number;
   /** The resolvable selfhosted session (the routing proxy resolves the active
@@ -1270,6 +1354,7 @@ export async function mintSelfhostedStream(
       leaseEpoch: input.activeEpoch,
       streamTokenSecret: secret,
       port: input.port,
+      ...(input.viewerAuthority ?? {}),
     });
     return {
       url: exposed.url,

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -50,7 +50,7 @@ import {
   type LeaseSnapshot,
   type SandboxRecord,
   getSessionAuthorityEpoch,
-  getWorkspaceGrant,
+  subjectHasLiveWorkspaceAuthority,
 } from "@opengeni/db";
 import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
 import { HTTPException } from "hono/http-exception";
@@ -208,7 +208,8 @@ export async function attachViewer(
   const { db, settings } = services;
   const { accountId, workspaceId, session } = input;
   const viewerId = input.viewerId ?? crypto.randomUUID();
-  const attachAuthorityEpoch = input.viewerSubjectId
+  const attachSubjectId = claimableSubjectId(input.viewerSubjectId ?? null);
+  const attachAuthorityEpoch = attachSubjectId
     ? await getSessionAuthorityEpoch(db, { accountId, workspaceId, sessionId: session.id })
     : null;
   const leaseTtlMs = settings.sandboxLeaseTtlMs;
@@ -235,7 +236,7 @@ export async function attachViewer(
       kind: "viewer",
       holderId: viewerId,
       subjectId: session.id,
-      ...(input.viewerSubjectId ? { viewerSubjectId: input.viewerSubjectId } : {}),
+      ...(attachSubjectId ? { viewerSubjectId: attachSubjectId } : {}),
       ...(attachAuthorityEpoch !== null ? { viewerAuthorityEpoch: attachAuthorityEpoch } : {}),
       backend: session.sandboxBackend,
       os: session.sandboxOs,
@@ -674,15 +675,29 @@ export type DesktopStreamMint = {
   leaseEpoch: number;
 };
 
+/** A subject claim must satisfy the StreamTokenPayload bounds and the 0281
+ *  holder CHECK (non-blank, <= 512). An out-of-bounds subject (possible only
+ *  from a host-signed delegated token) is omitted from the claims rather than
+ *  turning the mint into a 500. */
+function claimableSubjectId(subjectId: string | null): string | null {
+  if (!subjectId) return null;
+  const trimmed = subjectId.trim();
+  return trimmed.length >= 1 && subjectId.length <= 512 ? subjectId : null;
+}
+
 /**
  * Resolve the viewer-facing authority claims stamped into a scoped stream
  * token and recorded on the viewer holder (0281): the authenticated viewer
  * subject and the session's LIVE authority epoch. Re-verifies a human
- * subject's current workspace membership at mint time - a viewer whose
- * membership was removed since the route authorized them degrades to null
- * (transport:null) instead of receiving a fresh token. API-key and service
- * principals are not workspace members; their route authorization stands.
- * Identity and epoch only - never a secret value.
+ * (`user:`) subject's current workspace authority at mint time through the
+ * same model the route-time access builder uses - a membership row with an
+ * active owning organization membership, or an active organization
+ * membership's personal-workspace pointer - so a viewer whose authority was
+ * revoked since the route authorized them degrades to null (transport:null)
+ * instead of receiving a fresh token. Delegated token-borne grants
+ * (`subjectDelegated`) are authorized by their signed token, not by rows this
+ * check can see; they keep their route authorization, as do API-key and
+ * service principals. Identity and epoch only - never a secret value.
  */
 async function resolveViewerAuthorityClaims(
   db: ViewerServices["db"],
@@ -691,6 +706,7 @@ async function resolveViewerAuthorityClaims(
     workspaceId: string;
     sessionId: string;
     subjectId: string | null;
+    subjectDelegated?: boolean;
   },
 ): Promise<{ subjectId?: string; authorityEpoch: number } | null> {
   const authorityEpoch = await getSessionAuthorityEpoch(db, {
@@ -701,14 +717,19 @@ async function resolveViewerAuthorityClaims(
   if (authorityEpoch === null) {
     return null;
   }
-  if (input.subjectId?.startsWith("user:")) {
-    const membership = await getWorkspaceGrant(db, input.subjectId, input.workspaceId);
-    if (!membership) {
+  if (input.subjectId?.startsWith("user:") && input.subjectDelegated !== true) {
+    const live = await subjectHasLiveWorkspaceAuthority(db, {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      subjectId: input.subjectId,
+    });
+    if (!live) {
       return null;
     }
   }
+  const subjectId = claimableSubjectId(input.subjectId);
   return {
-    ...(input.subjectId ? { subjectId: input.subjectId } : {}),
+    ...(subjectId ? { subjectId } : {}),
     authorityEpoch,
   };
 }
@@ -717,6 +738,10 @@ export type MintDesktopStreamInput = {
   accountId: string;
   workspaceId: string;
   resourceSubjectId?: string;
+  /** True when the route grant is a signed delegated token (metadata.delegated):
+   *  its authority is the token, not membership rows, so the mint-time
+   *  live-authority recheck does not apply. */
+  resourceSubjectDelegated?: boolean;
   session: Session;
   /** The viewer holder id the scoped token is minted for. */
   viewerId: string;
@@ -787,6 +812,9 @@ export async function mintDesktopStream(
     workspaceId,
     sessionId: session.id,
     subjectId: input.resourceSubjectId ?? null,
+    ...(input.resourceSubjectDelegated !== undefined
+      ? { subjectDelegated: input.resourceSubjectDelegated }
+      : {}),
   });
   if (!viewerAuthority) {
     return null;
@@ -997,6 +1025,8 @@ export type MintTerminalStreamInput = {
   accountId: string;
   workspaceId: string;
   resourceSubjectId?: string;
+  /** See MintDesktopStreamInput.resourceSubjectDelegated. */
+  resourceSubjectDelegated?: boolean;
   session: Session;
   /** The viewer holder / principal id the scoped token is minted for. */
   viewerId: string;
@@ -1053,6 +1083,9 @@ export async function mintTerminalStream(
     workspaceId,
     sessionId: session.id,
     subjectId: input.resourceSubjectId ?? null,
+    ...(input.resourceSubjectDelegated !== undefined
+      ? { subjectDelegated: input.resourceSubjectDelegated }
+      : {}),
   });
   if (!viewerAuthority) {
     return null;

--- a/apps/api/test/sandbox-desktop-stream.test.ts
+++ b/apps/api/test/sandbox-desktop-stream.test.ts
@@ -295,6 +295,81 @@ describe("P4.2 desktop pixel data plane (real lease + RLS + fence)", () => {
     expect(afterRemoval).toBeNull();
   }, 60_000);
 
+  test("0281 — a managed PERSONAL-workspace human mints (no membership row by design); suspension degrades", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const { session, lease } = await seedWarmModalBox(accountId, workspaceId);
+    const bus = new MemoryEventBus();
+    const human = `user:${crypto.randomUUID()}`;
+    // Slice A+B: personal-workspace authority is the ACTIVE organization
+    // membership's pointer; deliberately NO workspace_memberships row.
+    await admin`
+      insert into organization_memberships
+        (account_id, subject_id, status, personal_workspace_id, role)
+      values (${accountId}, ${human}, 'active', ${workspaceId}, 'member')`;
+
+    const mint = await mintDesktopStream(
+      { db, settings, bus },
+      {
+        accountId,
+        workspaceId,
+        resourceSubjectId: human,
+        session: session!,
+        viewerId: crypto.randomUUID(),
+        lease,
+        establish: fakeEstablish(lease.leaseEpoch),
+      },
+    );
+    expect(mint).not.toBeNull();
+    const claims = await verifyStreamToken(SECRET, mint!.token);
+    expect(claims!.subjectId).toBe(human);
+    expect(claims!.authorityEpoch).toBe(1);
+
+    // A suspended organization membership is a live revocation: degrade.
+    await admin`
+      update organization_memberships set status = 'suspended'
+      where account_id = ${accountId} and subject_id = ${human}`;
+    const suspended = await mintDesktopStream(
+      { db, settings, bus },
+      {
+        accountId,
+        workspaceId,
+        resourceSubjectId: human,
+        session: session!,
+        viewerId: crypto.randomUUID(),
+        lease,
+        establish: fakeEstablish(lease.leaseEpoch),
+      },
+    );
+    expect(suspended).toBeNull();
+  }, 60_000);
+
+  test("0281 — a delegated token-borne user grant keeps its route authorization (no rows to re-check)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const { session, lease } = await seedWarmModalBox(accountId, workspaceId);
+    const bus = new MemoryEventBus();
+    const delegatedHuman = `user:${crypto.randomUUID()}`;
+
+    const mint = await mintDesktopStream(
+      { db, settings, bus },
+      {
+        accountId,
+        workspaceId,
+        resourceSubjectId: delegatedHuman,
+        resourceSubjectDelegated: true,
+        session: session!,
+        viewerId: crypto.randomUUID(),
+        lease,
+        establish: fakeEstablish(lease.leaseEpoch),
+      },
+    );
+    expect(mint).not.toBeNull();
+    const claims = await verifyStreamToken(SECRET, mint!.token);
+    expect(claims!.subjectId).toBe(delegatedHuman);
+    expect(claims!.authorityEpoch).toBe(1);
+  }, 60_000);
+
   test("0281 — an API-key principal keeps its route authorization; the token still pins the authority epoch", async () => {
     if (!available) return;
     const { accountId, workspaceId } = await freshWorkspace();

--- a/apps/api/test/sandbox-desktop-stream.test.ts
+++ b/apps/api/test/sandbox-desktop-stream.test.ts
@@ -237,6 +237,88 @@ describe("P4.2 desktop pixel data plane (real lease + RLS + fence)", () => {
     expect(bus.published.flat().some((e) => e.type === "stream.url.rotated")).toBe(false);
   }, 60_000);
 
+  test("0281 — a human viewer's token carries the subject + LIVE authority epoch; a removed membership degrades the mint", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const { session, lease } = await seedWarmModalBox(accountId, workspaceId);
+    const bus = new MemoryEventBus();
+    const human = `user:${crypto.randomUUID()}`;
+    await admin`
+      insert into workspace_memberships (account_id, workspace_id, subject_id)
+      values (${accountId}, ${workspaceId}, ${human})`;
+    // Advance the session authority epoch the way the lifecycle seam does:
+    // mint a transaction-scoped write capability, then update under it.
+    await admin.begin(async (tx) => {
+      const [cap] = await tx<{ capability_id: string }[]>`
+        insert into session_visibility_write_capabilities
+          (backend_pid, transaction_id, capability_id)
+        values (pg_backend_pid(), pg_current_xact_id(), gen_random_uuid())
+        returning capability_id`;
+      await tx`select set_config(
+        'opengeni.session_visibility_write_capability', ${cap!.capability_id}, true)`;
+      await tx`update sessions set authority_epoch = 4 where id = ${session!.id}`;
+    });
+
+    const mint = await mintDesktopStream(
+      { db, settings, bus },
+      {
+        accountId,
+        workspaceId,
+        resourceSubjectId: human,
+        session: session!,
+        viewerId: crypto.randomUUID(),
+        lease,
+        establish: fakeEstablish(lease.leaseEpoch),
+      },
+    );
+    expect(mint).not.toBeNull();
+    const claims = await verifyStreamToken(SECRET, mint!.token);
+    expect(claims!.subjectId).toBe(human);
+    expect(claims!.authorityEpoch).toBe(4);
+
+    // Membership removed since the route authorized the viewer: the mint-time
+    // re-verification degrades to null instead of issuing a fresh token.
+    await admin`delete from workspace_memberships
+      where workspace_id = ${workspaceId} and subject_id = ${human}`;
+    const afterRemoval = await mintDesktopStream(
+      { db, settings, bus },
+      {
+        accountId,
+        workspaceId,
+        resourceSubjectId: human,
+        session: session!,
+        viewerId: crypto.randomUUID(),
+        lease,
+        establish: fakeEstablish(lease.leaseEpoch),
+      },
+    );
+    expect(afterRemoval).toBeNull();
+  }, 60_000);
+
+  test("0281 — an API-key principal keeps its route authorization; the token still pins the authority epoch", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const { session, lease } = await seedWarmModalBox(accountId, workspaceId);
+    const bus = new MemoryEventBus();
+
+    const mint = await mintDesktopStream(
+      { db, settings, bus },
+      {
+        accountId,
+        workspaceId,
+        resourceSubjectId: "configured:key",
+        session: session!,
+        viewerId: crypto.randomUUID(),
+        lease,
+        establish: fakeEstablish(lease.leaseEpoch),
+      },
+    );
+    expect(mint).not.toBeNull();
+    const claims = await verifyStreamToken(SECRET, mint!.token);
+    expect(claims!.subjectId).toBe("configured:key");
+    expect(claims!.authorityEpoch).toBe(1);
+  }, 60_000);
+
   test("GATE — a COLD lease never mints (the handshake never spins a box up)", async () => {
     if (!available) return;
     const { accountId, workspaceId } = await freshWorkspace();

--- a/apps/api/test/selfhosted-stream-mint.test.ts
+++ b/apps/api/test/selfhosted-stream-mint.test.ts
@@ -214,6 +214,8 @@ describe("mintTerminalStream / mintDesktopStream — selfhosted-active dispatch 
     const secret = resolveStreamTokenSecret(settings)!;
     const claims = await verifyStreamToken(secret, cell!.token);
     expect(claims?.leaseEpoch).toBe(7);
+    // 0281: the selfhosted lane threads the authority claims end-to-end.
+    expect(claims?.authorityEpoch).toBe(1);
     expect(cell?.leaseEpoch).toBe(7);
     expect(cell?.url).not.toContain(cell!.token);
   });
@@ -233,6 +235,7 @@ describe("mintTerminalStream / mintDesktopStream — selfhosted-active dispatch 
     const secret = resolveStreamTokenSecret(settings)!;
     const claims = await verifyStreamToken(secret, cell!.token);
     expect(claims?.leaseEpoch).toBe(7);
+    expect(claims?.authorityEpoch).toBe(1);
     expect(cell?.leaseEpoch).toBe(7);
     // Desktop cell must carry resolution.
     expect(cell?.resolution).toBeDefined();

--- a/apps/api/test/selfhosted-stream-mint.test.ts
+++ b/apps/api/test/selfhosted-stream-mint.test.ts
@@ -66,6 +66,15 @@ mock.module("@opengeni/db", () => ({
     }
     return null;
   },
+  // 0281: the mint resolves the session's live authority epoch before minting;
+  // the fake db has no live session row, so answer for the test workspace.
+  getSessionAuthorityEpoch: async (
+    db: never,
+    input: { accountId: string; workspaceId: string; sessionId: string },
+  ) => {
+    if (input.workspaceId === WS) return 1;
+    return realDb.getSessionAuthorityEpoch(db, input);
+  },
 }));
 
 // Import mints AFTER the db mock is installed so the mock binding is active.

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -228,8 +228,17 @@ suspended grant fences a NEW direct mutation immediately
 retained process's next mutation (`authority_unattributed`) - in both cases the
 running provider process is never terminated or re-owned, and the fence
 consumes no workspace generation. The lifecycle still never infers ownership
-for a historical row whose authority was never recorded; stream-token
-invalidation remains in the separate live-access hardening program.
+for a historical row whose authority was never recorded. Since migration
+0281 the live-stream surface is bound to the same authority: a scoped stream
+token (`ogs_`, 120 s TTL unchanged) minted for a viewer carries the
+authenticated viewer subject and the session's live authority epoch, the
+viewer lease holder records the same pair (monotone - a stale lower claim
+never lowers the recorded epoch), the API re-verifies a human subject's
+current workspace membership at every mint and degrades to `transport:null`
+when it is gone, and the selfhosted relay rejects an attach whose recorded
+authority claim is below the channel's authority floor. A pre-0281 token
+without the claims still attaches during the rolling window and enforces
+nothing new.
 Connection-use audit facts and variable-set audit events carry the same
 attribution since migration 0280: every `connection_use_audit_facts` row
 records the frozen causal initiator and the session authority

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -232,13 +232,20 @@ for a historical row whose authority was never recorded. Since migration
 0281 the live-stream surface is bound to the same authority: a scoped stream
 token (`ogs_`, 120 s TTL unchanged) minted for a viewer carries the
 authenticated viewer subject and the session's live authority epoch, the
-viewer lease holder records the same pair (monotone - a stale lower claim
-never lowers the recorded epoch), the API re-verifies a human subject's
-current workspace membership at every mint and degrades to `transport:null`
-when it is gone, and the selfhosted relay rejects an attach whose recorded
-authority claim is below the channel's authority floor. A pre-0281 token
-without the claims still attaches during the rolling window and enforces
-nothing new.
+viewer lease holder records the same pair (per-subject monotone - a stale
+lower claim never lowers a subject's recorded epoch, while a different
+subject reusing the holder id starts a fresh pair), the API re-verifies a
+human subject's live workspace authority at every mint through the same
+model the route uses - a membership row whose owning organization membership
+is active, or an active organization membership's personal-workspace pointer
+(managed personal workspaces deliberately have no membership row) - and
+degrades to `transport:null` when that authority is gone. Delegated
+token-borne grants are authorized by their signed token, not rows, and keep
+their route authorization. The selfhosted relay rejects an attach whose
+authority claim is below the live channel's authority floor; the floor is
+defense-in-depth that dies with the channel, while mint refusal plus the
+120 s TTL remain the revocation authority. A pre-0281 token without the
+claims still attaches during the rolling window and enforces nothing new.
 Connection-use audit facts and variable-set audit events carry the same
 attribution since migration 0280: every `connection_use_audit_facts` row
 records the frozen causal initiator and the session authority

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2448,6 +2448,14 @@ export const StreamTokenPayload = z.object({
   // Short TTL (120s default); rotation is event-driven under the epoch fence,
   // not on a keepalive clock.
   exp: z.number().int().positive(),
+  // The authenticated subject the token was minted for (0281). Optional for
+  // rolling compatibility: old verifiers strip it, old mints omit it.
+  subjectId: z.string().min(1).max(512).optional(),
+  // The session authority epoch observed at mint (0281). The relay tracks the
+  // highest value presented per channel and rejects tokens below that floor,
+  // so an in-TTL token minted before an authority revocation cannot outlive
+  // the epoch advance once any current viewer has attached.
+  authorityEpoch: z.number().int().positive().optional(),
 });
 export type StreamTokenPayload = z.infer<typeof StreamTokenPayload>;
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2452,9 +2452,12 @@ export const StreamTokenPayload = z.object({
   // rolling compatibility: old verifiers strip it, old mints omit it.
   subjectId: z.string().min(1).max(512).optional(),
   // The session authority epoch observed at mint (0281). The relay tracks the
-  // highest value presented per channel and rejects tokens below that floor,
-  // so an in-TTL token minted before an authority revocation cannot outlive
-  // the epoch advance once any current viewer has attached.
+  // highest value presented per LIVE channel and rejects tokens below that
+  // floor. The floor is defense-in-depth, not the revocation authority: it
+  // lives only as long as the channel does (both sides detached, the
+  // half-open reaper, or a relay restart reset it), so a stale in-TTL token
+  // can still attach to a fresh channel. Real revocation is the mint refusing
+  // to issue new tokens plus the 120 s TTL bounding the old ones.
   authorityEpoch: z.number().int().positive().optional(),
 });
 export type StreamTokenPayload = z.infer<typeof StreamTokenPayload>;

--- a/packages/contracts/test/stream-token.test.ts
+++ b/packages/contracts/test/stream-token.test.ts
@@ -48,6 +48,20 @@ describe("StreamTokenPayload sign/verify", () => {
     expect(await verifyStreamToken("a-different-secret", token)).toBeNull();
   });
 
+  test("0281 authority claims round-trip; the schema rejects malformed claims", async () => {
+    const claims = payload({ subjectId: "user:abc", authorityEpoch: 9 });
+    const verified = await verifyStreamToken(SECRET, await signStreamToken(SECRET, claims));
+    expect(verified?.subjectId).toBe("user:abc");
+    expect(verified?.authorityEpoch).toBe(9);
+    // Optional for the rolling window: a claimless payload still parses.
+    expect(payload().subjectId).toBeUndefined();
+    expect(payload().authorityEpoch).toBeUndefined();
+    // An epoch must be a positive integer; a subject must be non-empty.
+    expect(() => payload({ authorityEpoch: 0 })).toThrow();
+    expect(() => payload({ authorityEpoch: 1.5 })).toThrow();
+    expect(() => payload({ subjectId: "" })).toThrow();
+  });
+
   test("verify rejects a tampered payload (signature no longer matches)", async () => {
     const token = await signStreamToken(SECRET, payload());
     const [encoded, signature] = token.slice("ogs_".length).split(".");

--- a/packages/db/drizzle/0281_viewer_holder_authority_claims.sql
+++ b/packages/db/drizzle/0281_viewer_holder_authority_claims.sql
@@ -1,0 +1,52 @@
+-- deployment-mode: rolling
+-- Migration 0281: viewer lease holders record the authenticated viewer
+-- subject and the session authority epoch observed when the viewer attached.
+--
+-- Stream tokens (`ogs_`) previously carried only workspace/session/viewer/
+-- lease-epoch claims with a 120 s TTL: nothing bound a live stream to the
+-- human (or API principal) watching it, and an authority revocation
+-- (session authority epoch advance) left in-TTL tokens indistinguishable
+-- from current ones. The token now carries optional `subjectId` and
+-- `authorityEpoch` claims minted from live state, and the viewer holder row
+-- records the same pair so revocation sweeps and audits can resolve exactly
+-- who was attached under which authority.
+--
+-- Rolling window: two nullable columns; old images keep inserting holder
+-- rows without them, and old token verifiers (TypeScript zod strips unknown
+-- keys; the Rust relay's serde ignores unknown fields) accept new tokens
+-- while enforcing nothing new. The claims are identities and epochs only -
+-- never a secret value - and the 120 s TTL is unchanged.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+ALTER TABLE "sandbox_lease_holders"
+  ADD COLUMN IF NOT EXISTS "viewer_subject_id" text,
+  ADD COLUMN IF NOT EXISTS "viewer_authority_epoch" integer;
+
+DO $viewer_holder_authority_check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'sandbox_lease_holders_viewer_authority_check'
+      AND conrelid = 'sandbox_lease_holders'::regclass
+  ) THEN
+    ALTER TABLE "sandbox_lease_holders"
+      ADD CONSTRAINT "sandbox_lease_holders_viewer_authority_check"
+      CHECK (
+        ("viewer_authority_epoch" IS NULL OR "viewer_authority_epoch" > 0)
+        AND ("viewer_subject_id" IS NULL
+          OR length(btrim("viewer_subject_id")) BETWEEN 1 AND 512)
+      ) NOT VALID;
+  END IF;
+END
+$viewer_holder_authority_check$;
+ALTER TABLE "sandbox_lease_holders"
+  VALIDATE CONSTRAINT "sandbox_lease_holders_viewer_authority_check";
+
+COMMENT ON COLUMN "sandbox_lease_holders"."viewer_subject_id" IS
+  'Authenticated subject that attached this viewer holder. Identity only - '
+  'never a secret value. NULL for non-viewer holders and pre-0281 rows.';
+COMMENT ON COLUMN "sandbox_lease_holders"."viewer_authority_epoch" IS
+  'Session authority epoch observed when the viewer attached; the stream '
+  'token minted for this holder carries the same claim.';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17500,6 +17500,31 @@ export async function getScheduledVariableSetExpectedGenerationForAttempt(
  * activity that materializes a sandbox for a run whose session carries an
  * variableSet attachment. Do not call from API routes: values are write-only.
  */
+/**
+ * Live session authority epoch, for stamping viewer-facing claims (stream
+ * tokens, viewer holders). Identity/epoch only; NULL when the session is not
+ * visible in this workspace.
+ */
+export async function getSessionAuthorityEpoch(
+  db: Database,
+  input: { accountId: string; workspaceId: string; sessionId: string },
+): Promise<number | null> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: input.workspaceId },
+    async (scopedDb) => {
+      const [row] = await rawRows<{ epoch: number }>(
+        scopedDb,
+        sql`select authority_epoch::int as epoch from sessions
+          where account_id = ${input.accountId}
+            and workspace_id = ${input.workspaceId}
+            and id = ${input.sessionId}`,
+      );
+      return row?.epoch ?? null;
+    },
+  );
+}
+
 export async function getVariableSetValuesForRun(
   db: Database,
   input: {
@@ -32235,6 +32260,12 @@ export interface AcquireLeaseInput {
   // (viewer). A workflow-local activity id is not a valid turn holder id.
   holderId: string;
   subjectId?: string | null; // the attributing session within the group
+  /** Viewer holders only (0281): the authenticated viewer subject recorded on
+   *  the holder row - identity only, never a secret value. */
+  viewerSubjectId?: string;
+  /** Viewer holders only (0281): the session authority epoch observed at
+   *  attach, mirrored into the scoped stream token's claims. */
+  viewerAuthorityEpoch?: number;
   backend: string; // sessions.sandbox_backend
   os?: string; // default 'linux'
   // The container image this run resolves (Modal image ref / docker image). Stamped on
@@ -33004,13 +33035,29 @@ async function upsertLeaseHolder(
   kind: LeaseHolderKind,
   holderId: string,
   subjectId: string | null,
+  viewerAuthority: { subjectId: string | null; authorityEpoch: number | null } = {
+    subjectId: null,
+    authorityEpoch: null,
+  },
 ): Promise<void> {
   await tx.execute(sql`
     insert into sandbox_lease_holders
-      (account_id, workspace_id, lease_id, kind, holder_id, subject_id, last_heartbeat_at)
-    values (${accountId}, ${workspaceId}, ${leaseId}, ${kind}, ${holderId}, ${subjectId}, now())
+      (account_id, workspace_id, lease_id, kind, holder_id, subject_id,
+       viewer_subject_id, viewer_authority_epoch, last_heartbeat_at)
+    values (${accountId}, ${workspaceId}, ${leaseId}, ${kind}, ${holderId}, ${subjectId},
+      ${viewerAuthority.subjectId}, ${viewerAuthority.authorityEpoch}, now())
     on conflict (lease_id, kind, holder_id)
-      do update set last_heartbeat_at = now()
+      do update set last_heartbeat_at = now(),
+        viewer_subject_id = coalesce(excluded.viewer_subject_id,
+          sandbox_lease_holders.viewer_subject_id),
+        -- The recorded authority epoch is monotone: a re-acquire may raise it
+        -- (a fresh mint after a revocation bump) but never lower it, and an
+        -- attach without the claim preserves the recorded value.
+        viewer_authority_epoch = greatest(
+          coalesce(excluded.viewer_authority_epoch,
+            sandbox_lease_holders.viewer_authority_epoch),
+          coalesce(sandbox_lease_holders.viewer_authority_epoch,
+            excluded.viewer_authority_epoch))
   `);
 }
 
@@ -33195,7 +33242,10 @@ async function acquireLeaseOnce(
         // The row lock serializes this holder insertion against the reaper claim:
         // whichever wins first owns the next state without an availability gap.
         if (liveness === "draining") {
-          await upsertLeaseHolder(tx, row.id, accountId, workspaceId, kind, holderId, subjectId);
+          await upsertLeaseHolder(tx, row.id, accountId, workspaceId, kind, holderId, subjectId, {
+            subjectId: input.viewerSubjectId ?? null,
+            authorityEpoch: input.viewerAuthorityEpoch ?? null,
+          });
           const updated = await recomputeAndStampLease(tx, row.id, input.leaseTtlMs, "warm");
           return { role: "rearmed" as const, lease: mapLeaseRow(updated) };
         }
@@ -33228,7 +33278,10 @@ async function acquireLeaseOnce(
           where id = ${row.id} and liveness = 'cold'
           returning id
         `);
-          await upsertLeaseHolder(tx, row.id, accountId, workspaceId, kind, holderId, subjectId);
+          await upsertLeaseHolder(tx, row.id, accountId, workspaceId, kind, holderId, subjectId, {
+            subjectId: input.viewerSubjectId ?? null,
+            authorityEpoch: input.viewerAuthorityEpoch ?? null,
+          });
           const updated = await recomputeAndStampLease(tx, row.id, warmingLeaseTtlMs, null);
           // casRows.length === 0 cannot happen under the held row lock (defensive):
           // a lost CAS means a sibling flipped it first, so we attach.
@@ -33260,7 +33313,10 @@ async function acquireLeaseOnce(
         // collapse expires_at and let the warming-death reaper reset/drain the
         // lease before instance_id is recorded (F1). A WARM attach uses the plain
         // TTL as before.
-        await upsertLeaseHolder(tx, row.id, accountId, workspaceId, kind, holderId, subjectId);
+        await upsertLeaseHolder(tx, row.id, accountId, workspaceId, kind, holderId, subjectId, {
+          subjectId: input.viewerSubjectId ?? null,
+          authorityEpoch: input.viewerAuthorityEpoch ?? null,
+        });
         const attachTtlMs = liveness === "warming" ? warmingLeaseTtlMs : input.leaseTtlMs;
         const updated = await recomputeAndStampLease(tx, row.id, attachTtlMs, null);
         return { role: "attached" as const, lease: mapLeaseRow(updated) };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17525,6 +17525,57 @@ export async function getSessionAuthorityEpoch(
   );
 }
 
+/**
+ * Mint-time live-authority recheck for a human viewer subject (0281). True
+ * when the subject currently holds workspace authority the same way the
+ * route-time access builder derives it: a `workspace_memberships` row whose
+ * owning organization membership (when one exists) is active, or an active
+ * organization membership whose personal-workspace pointer is exactly this
+ * workspace (managed personal workspaces deliberately have no membership
+ * row). Never infers authority any other way; a deleted membership row and a
+ * suspended/revoked organization membership are both false.
+ */
+export async function subjectHasLiveWorkspaceAuthority(
+  db: Database,
+  input: { accountId: string; workspaceId: string; subjectId: string },
+): Promise<boolean> {
+  return await withRlsContext(
+    db,
+    { accountId: input.accountId, workspaceId: null },
+    async (scopedDb) => {
+      await setSubjectRlsContext(scopedDb, input.subjectId);
+      const [membershipRow] = await rawRows<{ present: number }>(
+        scopedDb,
+        sql`select 1 as present from workspace_memberships
+          where subject_id = ${input.subjectId}
+            and workspace_id = ${input.workspaceId}
+          limit 1`,
+      );
+      const [organizationMembershipResult] = await rawRows<{ result: unknown }>(
+        scopedDb,
+        sql`select list_self_organization_memberships(${input.subjectId}) as result`,
+      );
+      const organizationMemberships = OrganizationMember.array().parse(
+        organizationMembershipResult?.result ?? [],
+      );
+      const selfOrganizationMembership = organizationMemberships.find(
+        (organizationMembership) => organizationMembership.organizationId === input.accountId,
+      );
+      if (membershipRow) {
+        // Mirror the access builder's inactive-organization filter: a
+        // persisted membership row is dead while its organization membership
+        // is suspended/revoked. A subject with no organization membership at
+        // all (legacy/standalone) keeps its persisted row's authority.
+        return !selfOrganizationMembership || selfOrganizationMembership.status === "active";
+      }
+      return (
+        selfOrganizationMembership?.status === "active" &&
+        selfOrganizationMembership.personalWorkspaceId === input.workspaceId
+      );
+    },
+  );
+}
+
 export async function getVariableSetValuesForRun(
   db: Database,
   input: {
@@ -33050,14 +33101,23 @@ async function upsertLeaseHolder(
       do update set last_heartbeat_at = now(),
         viewer_subject_id = coalesce(excluded.viewer_subject_id,
           sandbox_lease_holders.viewer_subject_id),
-        -- The recorded authority epoch is monotone: a re-acquire may raise it
-        -- (a fresh mint after a revocation bump) but never lower it, and an
-        -- attach without the claim preserves the recorded value.
-        viewer_authority_epoch = greatest(
-          coalesce(excluded.viewer_authority_epoch,
-            sandbox_lease_holders.viewer_authority_epoch),
-          coalesce(sandbox_lease_holders.viewer_authority_epoch,
-            excluded.viewer_authority_epoch))
+        -- The recorded (subject, epoch) pair stays coherent. Same subject (or
+        -- a claimless rolling-window attach): the epoch is monotone - a
+        -- re-acquire may raise it but never lower it. A DIFFERENT subject
+        -- reusing the holder id starts a fresh pair; carrying the previous
+        -- subject's higher epoch would misattribute authority evidence.
+        viewer_authority_epoch = case
+          when excluded.viewer_subject_id is not null
+            and sandbox_lease_holders.viewer_subject_id is not null
+            and excluded.viewer_subject_id
+              is distinct from sandbox_lease_holders.viewer_subject_id
+            then excluded.viewer_authority_epoch
+          else greatest(
+            coalesce(excluded.viewer_authority_epoch,
+              sandbox_lease_holders.viewer_authority_epoch),
+            coalesce(sandbox_lease_holders.viewer_authority_epoch,
+              excluded.viewer_authority_epoch))
+        end
   `);
 }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -7467,6 +7467,11 @@ export const sandboxLeaseHolders = pgTable(
     holderId: text("holder_id").notNull(),
     // The attributing session within the (possibly shared) group.
     subjectId: uuid("subject_id"),
+    // Viewer holders only (0281): the authenticated viewer subject and the
+    // session authority epoch observed at attach - identities and epochs
+    // only, mirrored into the scoped stream token's claims.
+    viewerSubjectId: text("viewer_subject_id"),
+    viewerAuthorityEpoch: integer("viewer_authority_epoch"),
     lastHeartbeatAt: timestamp("last_heartbeat_at", { withTimezone: true }).notNull().defaultNow(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/db/test/migration-0281-viewer-holder-authority.test.ts
+++ b/packages/db/test/migration-0281-viewer-holder-authority.test.ts
@@ -43,9 +43,7 @@ describe("migration 0281 viewer holder authority claims", () => {
     // Guarded add + full validation (the rolling re-apply window).
     expect(source).toContain("conrelid = 'sandbox_lease_holders'::regclass");
     expect(source).toContain("NOT VALID");
-    expect(source).toContain(
-      'VALIDATE CONSTRAINT "sandbox_lease_holders_viewer_authority_check"',
-    );
+    expect(source).toContain('VALIDATE CONSTRAINT "sandbox_lease_holders_viewer_authority_check"');
     expect(source).not.toMatch(/\bDROP\b/u);
   });
 

--- a/packages/db/test/migration-0281-viewer-holder-authority.test.ts
+++ b/packages/db/test/migration-0281-viewer-holder-authority.test.ts
@@ -1,0 +1,71 @@
+// Migration 0281: viewer lease holders record the authenticated viewer
+// subject and the session authority epoch observed at attach, so stream-token
+// authority can be audited and revocation-swept. The live recording behavior
+// (record, coalesce, monotone raise, CHECK rejection) is exercised in
+// sandbox-leases.test.ts "(0281)"; this file pins the migration contract.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import { readFile } from "node:fs/promises";
+import postgres from "postgres";
+
+const migrationUrl = new URL("../drizzle/0281_viewer_holder_authority_claims.sql", import.meta.url);
+
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("migration-0281-viewer-holder-authority");
+  if (!shared) {
+    available = false;
+    if (requireRealDatabase) throw new Error("OPENGENI_REQUIRE_REAL_DB=1 but no database");
+    return;
+  }
+  admin = shared.admin;
+});
+
+afterAll(async () => {
+  await shared?.release();
+});
+
+describe("migration 0281 viewer holder authority claims", () => {
+  test("declares one rolling two-column protocol with a guarded validated check", async () => {
+    const source = await readFile(migrationUrl, "utf8");
+    expect(source.split(/\r?\n/u, 1)[0]).toBe("-- deployment-mode: rolling");
+    expect(source).toContain('"viewer_subject_id" text');
+    expect(source).toContain('"viewer_authority_epoch" integer');
+    // The claims are nullable identities/epochs: no FK may block holder
+    // reaping or membership lifecycle, and no default backfills fake authority.
+    expect(source).not.toContain("REFERENCES");
+    expect(source).not.toMatch(/\bDEFAULT\b/iu);
+    expect(source).not.toMatch(/\bNOT NULL\b/u);
+    // Guarded add + full validation (the rolling re-apply window).
+    expect(source).toContain("conrelid = 'sandbox_lease_holders'::regclass");
+    expect(source).toContain("NOT VALID");
+    expect(source).toContain(
+      'VALIDATE CONSTRAINT "sandbox_lease_holders_viewer_authority_check"',
+    );
+    expect(source).not.toMatch(/\bDROP\b/u);
+  });
+
+  test("re-applying the migration is a no-op (rolling window replay)", async () => {
+    if (!available) return;
+    const source = await readFile(migrationUrl, "utf8");
+    // The shared database has already applied 0281 once; a second apply must
+    // succeed without duplicating the constraint or failing on the columns.
+    await admin.begin(async (tx) => {
+      await tx.unsafe(source);
+    });
+    const constraints = await admin<Array<{ count: number }>>`
+      select count(*)::int as count from pg_constraint
+      where conname = 'sandbox_lease_holders_viewer_authority_check'
+        and conrelid = 'sandbox_lease_holders'::regclass`;
+    expect(constraints[0]?.count).toBe(1);
+    const validated = await admin<Array<{ convalidated: boolean }>>`
+      select convalidated from pg_constraint
+      where conname = 'sandbox_lease_holders_viewer_authority_check'
+        and conrelid = 'sandbox_lease_holders'::regclass`;
+    expect(validated[0]?.convalidated).toBe(true);
+  });
+});

--- a/packages/db/test/sandbox-leases.test.ts
+++ b/packages/db/test/sandbox-leases.test.ts
@@ -846,6 +846,25 @@ describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
     });
     expect((await readHolder())?.viewer_authority_epoch).toBe(5);
 
+    // A DIFFERENT subject reusing the holder id starts a fresh (subject,
+    // epoch) pair: the previous subject's higher epoch must not be carried.
+    const otherSubject = `user:${crypto.randomUUID()}`;
+    await acquireLease(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "viewer",
+      holderId: "authority-viewer",
+      backend: "modal",
+      leaseTtlMs: 45_000,
+      viewerSubjectId: otherSubject,
+      viewerAuthorityEpoch: 2,
+    });
+    expect(await readHolder()).toMatchObject({
+      viewer_subject_id: otherSubject,
+      viewer_authority_epoch: 2,
+    });
+
     // The 0281 CHECK rejects a non-positive epoch and a blank subject.
     const zeroEpoch = await admin`
       update sandbox_lease_holders set viewer_authority_epoch = 0

--- a/packages/db/test/sandbox-leases.test.ts
+++ b/packages/db/test/sandbox-leases.test.ts
@@ -756,6 +756,109 @@ describe("0017 sandbox lease state machine (real packages/db + RLS)", () => {
     expect(row?.liveness).toBe("warming");
   }, 60_000);
 
+  test("(0281) a viewer acquire records the authority claims; re-acquire is monotone", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, groupId } = await freshWorkspace();
+    const subject = `user:${crypto.randomUUID()}`;
+    const readHolder = async () => {
+      const rows = await admin`
+        select viewer_subject_id, viewer_authority_epoch
+        from sandbox_lease_holders
+        where workspace_id = ${workspaceId} and holder_id = 'authority-viewer'
+      `;
+      return rows[0] as
+        | { viewer_subject_id: string | null; viewer_authority_epoch: number | null }
+        | undefined;
+    };
+
+    // First attach carries the claims -> recorded on the holder row.
+    const first = await acquireLease(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "viewer",
+      holderId: "authority-viewer",
+      backend: "modal",
+      leaseTtlMs: 45_000,
+      viewerSubjectId: subject,
+      viewerAuthorityEpoch: 3,
+    });
+    expect(await readHolder()).toMatchObject({
+      viewer_subject_id: subject,
+      viewer_authority_epoch: 3,
+    });
+    // Bring the box to WARM so the later re-acquires attach instead of
+    // entering the spawner's warming-retry wait.
+    const committed = await commitWarmingToWarm(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      expectedEpoch: first.lease.leaseEpoch,
+      instanceId: "inst-authority",
+      dataPlaneUrl: null,
+      resumeBackendId: "modal",
+      resumeState: { backendId: "modal", sessionState: {} },
+      leaseTtlMs: 45_000,
+    });
+    expect(committed.committed).toBe(true);
+
+    // A claimless re-acquire (a pre-0281 caller in the rolling window)
+    // preserves the recorded claims instead of nulling them.
+    await acquireLease(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "viewer",
+      holderId: "authority-viewer",
+      backend: "modal",
+      leaseTtlMs: 45_000,
+    });
+    expect(await readHolder()).toMatchObject({
+      viewer_subject_id: subject,
+      viewer_authority_epoch: 3,
+    });
+
+    // A newer mint after a revocation bump raises the recorded epoch...
+    await acquireLease(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "viewer",
+      holderId: "authority-viewer",
+      backend: "modal",
+      leaseTtlMs: 45_000,
+      viewerSubjectId: subject,
+      viewerAuthorityEpoch: 5,
+    });
+    expect((await readHolder())?.viewer_authority_epoch).toBe(5);
+
+    // ...and a stale lower claim can never lower it back (monotone evidence).
+    await acquireLease(db, {
+      accountId,
+      workspaceId,
+      sandboxGroupId: groupId,
+      kind: "viewer",
+      holderId: "authority-viewer",
+      backend: "modal",
+      leaseTtlMs: 45_000,
+      viewerSubjectId: subject,
+      viewerAuthorityEpoch: 4,
+    });
+    expect((await readHolder())?.viewer_authority_epoch).toBe(5);
+
+    // The 0281 CHECK rejects a non-positive epoch and a blank subject.
+    const zeroEpoch = await admin`
+      update sandbox_lease_holders set viewer_authority_epoch = 0
+      where workspace_id = ${workspaceId} and holder_id = 'authority-viewer'
+    `.catch((error: unknown) => error);
+    expect(zeroEpoch).toMatchObject({ code: "23514" });
+    const blankSubject = await admin`
+      update sandbox_lease_holders set viewer_subject_id = '   '
+      where workspace_id = ${workspaceId} and holder_id = 'authority-viewer'
+    `.catch((error: unknown) => error);
+    expect(blankSubject).toMatchObject({ code: "23514" });
+  }, 60_000);
+
   test("(1b) cold->warming stamps the warming budget, so slow creates are not 90s-reaped", async () => {
     if (!available) return;
     const { accountId, workspaceId, groupId } = await freshWorkspace();

--- a/packages/runtime/src/sandbox/stream-port.ts
+++ b/packages/runtime/src/sandbox/stream-port.ts
@@ -74,6 +74,10 @@ export type ExposeStreamPortInput = {
   resolution?: [number, number];
   /** Override the issue clock (tests). Seconds since the epoch. */
   nowSeconds?: number;
+  /** The authenticated viewer subject the token is minted for (0281). */
+  subjectId?: string;
+  /** The session authority epoch observed at mint (0281). */
+  authorityEpoch?: number;
 };
 
 export type ExposeStreamPortResult = {
@@ -215,6 +219,8 @@ export async function exposeStreamPort(
     port,
     ttlSeconds,
     nowSeconds,
+    ...(input.subjectId ? { subjectId: input.subjectId } : {}),
+    ...(input.authorityEpoch ? { authorityEpoch: input.authorityEpoch } : {}),
   });
 
   return {

--- a/packages/runtime/src/sandbox/stream-token.ts
+++ b/packages/runtime/src/sandbox/stream-token.ts
@@ -45,6 +45,10 @@ export type MintStreamTokenInput = {
   ttlSeconds?: number;
   /** Override the issue clock (tests). Seconds since the epoch. */
   nowSeconds?: number;
+  /** The authenticated viewer subject the token is minted for (0281). */
+  subjectId?: string;
+  /** The session authority epoch observed at mint (0281). */
+  authorityEpoch?: number;
 };
 
 /**
@@ -68,6 +72,8 @@ export async function mintStreamToken(
     mode: input.mode ?? "view",
     port: input.port ?? DESKTOP_STREAM_PORT,
     exp: nowSeconds + ttlSeconds,
+    ...(input.subjectId ? { subjectId: input.subjectId } : {}),
+    ...(input.authorityEpoch ? { authorityEpoch: input.authorityEpoch } : {}),
   });
   return signStreamToken(secret, payload);
 }

--- a/packages/runtime/test/stream-token.test.ts
+++ b/packages/runtime/test/stream-token.test.ts
@@ -40,6 +40,25 @@ describe("@opengeni/runtime/sandbox stream-token mint/verify", () => {
     const token = await mintStreamToken(SECRET, baseInput);
     expect(await verifyStreamToken("other-secret", token)).toBeNull();
   });
+
+  test("mint -> verify round-trip with the viewer authority claims (0281)", async () => {
+    const token = await mintStreamToken(SECRET, {
+      ...baseInput,
+      subjectId: "user:44444444-4444-4444-8444-444444444444",
+      authorityEpoch: 7,
+    });
+    const verified = await verifyStreamToken(SECRET, token);
+    expect(verified?.subjectId).toBe("user:44444444-4444-4444-8444-444444444444");
+    expect(verified?.authorityEpoch).toBe(7);
+  });
+
+  test("a token minted WITHOUT authority claims still verifies (rolling compatibility)", async () => {
+    const token = await mintStreamToken(SECRET, baseInput);
+    const verified = await verifyStreamToken(SECRET, token);
+    expect(verified).not.toBeNull();
+    expect(verified?.subjectId).toBeUndefined();
+    expect(verified?.authorityEpoch).toBeUndefined();
+  });
 });
 
 describe("negotiateCapabilities — desktop graceful degrade (stream-token availability contract)", () => {

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -521,6 +521,11 @@ describe("release schema contract", () => {
         : "d54a4ac5b800e0c0578e7fce7d1a09cea1dbed87d3b13bf722549fea0bdc031e";
     };
     const releaseSchemaContractHash = (includesActivation: boolean): string | null => {
+      if (migrations.has("0281_viewer_holder_authority_claims.sql")) {
+        return includesActivation
+          ? "c95d0449cae50232c5d27656f040d55cca25499bf06cff4c190df82270e4ae97"
+          : "53e214a4d710e8e8126860a04765cc263fdb32abcd0145e6e0aa46b8dcb3e269";
+      }
       if (migrations.has("0280_connection_and_variable_set_audit_attribution.sql")) {
         return includesActivation
           ? "55f64e92a35ddd19dedcc7704fa809f0d6436f8c4377c6122956093a6a542592"
@@ -978,7 +983,8 @@ describe("release schema contract", () => {
         (migrations.has("0277_workspace_writer_authority_attribution.sql") ? 1 : 0) +
         (migrations.has("0278_workspace_membership_removal_fencing.sql") ? 1 : 0) +
         (migrations.has("0279_workspace_connection_use_lane.sql") ? 1 : 0) +
-        (migrations.has("0280_connection_and_variable_set_audit_attribution.sql") ? 1 : 0),
+        (migrations.has("0280_connection_and_variable_set_audit_attribution.sql") ? 1 : 0) +
+        (migrations.has("0281_viewer_holder_authority_claims.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(releaseSchemaContractHash(false) ?? currentMainContractHash);
     const latestCompatibleMigration = [
@@ -1013,70 +1019,78 @@ describe("release schema contract", () => {
       "0217_capability_definition_delete_authority.sql",
     ].find((path) => migrations.has(path));
     expect(contract.latestMigration).toBe(
-      migrations.has("0280_connection_and_variable_set_audit_attribution.sql")
-        ? "0280_connection_and_variable_set_audit_attribution.sql"
-        : migrations.has("0279_workspace_connection_use_lane.sql")
-          ? "0279_workspace_connection_use_lane.sql"
-          : migrations.has("0278_workspace_membership_removal_fencing.sql")
-            ? "0278_workspace_membership_removal_fencing.sql"
-            : migrations.has("0277_workspace_writer_authority_attribution.sql")
-              ? "0277_workspace_writer_authority_attribution.sql"
-              : migrations.has("0276_onboarding_proposal_initiating_human_guc.sql")
-                ? "0276_onboarding_proposal_initiating_human_guc.sql"
-                : migrations.has("0275_scheduled_connection_authority.sql")
-                  ? "0275_scheduled_connection_authority.sql"
-                  : migrations.has("0274_human_confirmed_knowledge_review.sql")
-                    ? "0274_human_confirmed_knowledge_review.sql"
-                    : migrations.has("0272_human_confirmed_learning_activation.sql")
-                      ? "0272_human_confirmed_learning_activation.sql"
-                      : migrations.has("0271_company_brain_retrieval_only_default.sql")
-                        ? "0271_company_brain_retrieval_only_default.sql"
-                        : migrations.has("0270_governed_learning_history_inspection.sql")
-                          ? "0270_governed_learning_history_inspection.sql"
-                          : migrations.has("0269_governed_learning_activation_controller.sql")
-                            ? "0269_governed_learning_activation_controller.sql"
-                            : migrations.has("0268_governed_learning_decision_receipts.sql")
-                              ? "0268_governed_learning_decision_receipts.sql"
-                              : migrations.has("0266_company_brain_context_receipt_inspection.sql")
-                                ? "0266_company_brain_context_receipt_inspection.sql"
+      migrations.has("0281_viewer_holder_authority_claims.sql")
+        ? "0281_viewer_holder_authority_claims.sql"
+        : migrations.has("0280_connection_and_variable_set_audit_attribution.sql")
+          ? "0280_connection_and_variable_set_audit_attribution.sql"
+          : migrations.has("0279_workspace_connection_use_lane.sql")
+            ? "0279_workspace_connection_use_lane.sql"
+            : migrations.has("0278_workspace_membership_removal_fencing.sql")
+              ? "0278_workspace_membership_removal_fencing.sql"
+              : migrations.has("0277_workspace_writer_authority_attribution.sql")
+                ? "0277_workspace_writer_authority_attribution.sql"
+                : migrations.has("0276_onboarding_proposal_initiating_human_guc.sql")
+                  ? "0276_onboarding_proposal_initiating_human_guc.sql"
+                  : migrations.has("0275_scheduled_connection_authority.sql")
+                    ? "0275_scheduled_connection_authority.sql"
+                    : migrations.has("0274_human_confirmed_knowledge_review.sql")
+                      ? "0274_human_confirmed_knowledge_review.sql"
+                      : migrations.has("0272_human_confirmed_learning_activation.sql")
+                        ? "0272_human_confirmed_learning_activation.sql"
+                        : migrations.has("0271_company_brain_retrieval_only_default.sql")
+                          ? "0271_company_brain_retrieval_only_default.sql"
+                          : migrations.has("0270_governed_learning_history_inspection.sql")
+                            ? "0270_governed_learning_history_inspection.sql"
+                            : migrations.has("0269_governed_learning_activation_controller.sql")
+                              ? "0269_governed_learning_activation_controller.sql"
+                              : migrations.has("0268_governed_learning_decision_receipts.sql")
+                                ? "0268_governed_learning_decision_receipts.sql"
                                 : migrations.has(
-                                      "0261_preference_knowledge_proposal_actor_binding.sql",
+                                      "0266_company_brain_context_receipt_inspection.sql",
                                     )
-                                  ? "0261_preference_knowledge_proposal_actor_binding.sql"
-                                  : migrations.has("0260_task_note_knowledge_promotion.sql")
-                                    ? "0260_task_note_knowledge_promotion.sql"
-                                    : migrations.has(
-                                          "0259_company_brain_context_selection_receipts.sql",
-                                        )
-                                      ? "0259_company_brain_context_selection_receipts.sql"
+                                  ? "0266_company_brain_context_receipt_inspection.sql"
+                                  : migrations.has(
+                                        "0261_preference_knowledge_proposal_actor_binding.sql",
+                                      )
+                                    ? "0261_preference_knowledge_proposal_actor_binding.sql"
+                                    : migrations.has("0260_task_note_knowledge_promotion.sql")
+                                      ? "0260_task_note_knowledge_promotion.sql"
                                       : migrations.has(
-                                            "0258_three_scope_document_knowledge_authority.sql",
+                                            "0259_company_brain_context_selection_receipts.sql",
                                           )
-                                        ? "0258_three_scope_document_knowledge_authority.sql"
+                                        ? "0259_company_brain_context_selection_receipts.sql"
                                         : migrations.has(
-                                              "0257_goal_revision_decisions_and_root_constraints.sql",
+                                              "0258_three_scope_document_knowledge_authority.sql",
                                             )
-                                          ? "0257_goal_revision_decisions_and_root_constraints.sql"
+                                          ? "0258_three_scope_document_knowledge_authority.sql"
                                           : migrations.has(
-                                                "0255_company_brain_governed_write_proposals.sql",
+                                                "0257_goal_revision_decisions_and_root_constraints.sql",
                                               )
-                                            ? "0255_company_brain_governed_write_proposals.sql"
+                                            ? "0257_goal_revision_decisions_and_root_constraints.sql"
                                             : migrations.has(
-                                                  "0248_terraform_stacks_component_resolution_fence.sql",
+                                                  "0255_company_brain_governed_write_proposals.sql",
                                                 )
-                                              ? "0248_terraform_stacks_component_resolution_fence.sql"
+                                              ? "0255_company_brain_governed_write_proposals.sql"
                                               : migrations.has(
-                                                    "0247_terraform_stacks_provenance_repair.sql",
+                                                    "0248_terraform_stacks_component_resolution_fence.sql",
                                                   )
-                                                ? "0247_terraform_stacks_provenance_repair.sql"
+                                                ? "0248_terraform_stacks_component_resolution_fence.sql"
                                                 : migrations.has(
-                                                      "0263_organization_membership_lifecycle.sql",
+                                                      "0247_terraform_stacks_provenance_repair.sql",
                                                     )
-                                                  ? "0263_organization_membership_lifecycle.sql"
-                                                  : latestCompatibleMigration,
+                                                  ? "0247_terraform_stacks_provenance_repair.sql"
+                                                  : migrations.has(
+                                                        "0263_organization_membership_lifecycle.sql",
+                                                      )
+                                                    ? "0263_organization_membership_lifecycle.sql"
+                                                    : latestCompatibleMigration,
     );
     expect(migrations.get("0263_organization_membership_lifecycle.sql")).toMatchObject({
       sha256: "1119554dc06a768c92f7189a97b438ebdc011747a6c8d7cefc992962f2293593",
+      deploymentMode: "rolling",
+    });
+    expect(migrations.get("0281_viewer_holder_authority_claims.sql")).toMatchObject({
+      sha256: "17d90d51ca95222aec87abf296a3a3936537739a40d4700c932f1cfad6742f00",
       deploymentMode: "rolling",
     });
     expect(migrations.get("0280_connection_and_variable_set_audit_attribution.sql")).toMatchObject({


### PR DESCRIPTION
## OPE-203 slice 3 — stream-token subject + authority-epoch claims

Stream tokens (`ogs_`) previously carried only workspace/session/viewer/lease-epoch claims: nothing bound a live pixel/terminal stream to the authenticated human or API principal watching it, and a session authority revocation left in-TTL tokens indistinguishable from current ones.

### What changed
- **Migration `0281_viewer_holder_authority_claims.sql` (rolling):** `sandbox_lease_holders` gains nullable `viewer_subject_id` / `viewer_authority_epoch` with a guarded, validated CHECK (positive epoch; non-blank subject ≤ 512). No FK, no default, no backfill — a pre-0281 row honestly has no recorded authority.
- **Token claims (`packages/contracts`, `packages/runtime`):** `StreamTokenPayload` gains optional `subjectId` / `authorityEpoch`; `mintStreamToken` / `exposeStreamPort` thread them. 120 s TTL unchanged; the token still never appears in a URL.
- **API mint (`apps/api/src/sandbox/viewer.ts`):** every desktop/terminal mint resolves the session's **live** `authority_epoch` and, for `user:` subjects, re-verifies current workspace membership; a removed membership or invisible session degrades to `transport:null` instead of minting. The selfhosted lane threads the same claims. `attachViewer` records the pair on the viewer holder; the upsert is **monotone** (a stale lower claim never lowers the recorded epoch, a claimless rolling-window attach preserves it).
- **Relay stream mints (`browser-sessions.ts`, `computer-sessions.ts`):** both relay token mints stamp `subjectId` + live authority epoch and fail closed when the epoch is unavailable.
- **Rust relay (`agent/crates/opengeni-relay`):** `StreamTokenClaims` parses the optional claims (serde `default`, unknown-field-tolerant both directions); the channel registry keeps an `authority_floor` beside the lease-epoch floor and rejects an attach whose authority claim is below it (`ViewerEpochs` struct). A claimless pre-0281 token attaches and enforces nothing new.

### Rolling compatibility
Old TS verifiers (zod strips unknown keys) and the old Rust relay (serde ignores unknown fields) accept new tokens; new verifiers accept old tokens with `undefined`/`None` claims. Claims are identities and epochs only — never a secret value.

### Verification
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test -p opengeni-relay` (29 tests): green, incl. new `authority_floor_rejects_stale_and_ignores_absent_claims` and token claim-parse tests.
- Real-Postgres: `sandbox-leases.test.ts (0281)` (record → claimless preserve → monotone raise → stale-lower no-op → CHECK 23514), `migration-0281-*` (contract + idempotent re-apply), `sandbox-desktop-stream.test.ts` 15/15 (new: human claims round-trip through the mint; membership removal degrades the mint; API-key principal keeps route authorization).
- Focused suites green: contracts/runtime stream-token, stream-port, selfhosted-stream-mint, sandbox-viewer-routes, sandbox-shared-and-viewer, browser/computer session routes, connected-machine-computer-access.
- `bun run typecheck` clean; `oxlint --deny-warnings` clean; migration-ordinal + public-hygiene guards pass; release-schema-contract ladder re-pinned for 0281.

Docs: `docs/organization-tenancy.md` live-access paragraph now describes the 0281 binding. Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca7x2FyxheguVcdENGs8ji
