### PR TITLE
feat: session-attach variable-set materialization attribution (OPE-203 slice 7)

### DIFF
--- a/.changeset/session-attach-materialization-audit.md
+++ b/.changeset/session-attach-materialization-audit.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": minor
+---
+
+The API-direct session-attach variable-set materialization lane (viewer attach and direct channel operations cold-creating a box) now records the accepted subject and a `variable_set.materialized` audit fact with the live session authority tuple (migration 0282, rolling; unchanged function signature). Attribution flows through the standard request-context GUCs; an old image that sets no subject records the explicit `service:session` sentinel. Denials keep their fail-closed raise-and-rollback semantics.

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -3535,7 +3535,12 @@ function registerFleetTools(
       const session = await requireSession(deps.db, ctx.workspaceId, ctx.sessionId);
       return await ensureViewerSessionGroupReady(
         { db: deps.db, settings: deps.settings, bus: deps.bus },
-        { accountId: ctx.accountId, workspaceId: ctx.workspaceId, session },
+        {
+          accountId: ctx.accountId,
+          workspaceId: ctx.workspaceId,
+          session,
+          subjectId: ctx.subjectId ?? null,
+        },
       );
     },
   };

--- a/apps/api/src/routes/machines.ts
+++ b/apps/api/src/routes/machines.ts
@@ -376,6 +376,7 @@ export function registerMachineRoutes(app: Hono, deps: ApiRouteDeps): void {
               accountId: fleetCtx.accountId,
               workspaceId: fleetCtx.workspaceId,
               session,
+              subjectId: fleetCtx.subjectId ?? null,
             },
           );
         },

--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -539,7 +539,7 @@ async function withChannelAOperation<T>(
     accountId,
     workspaceId,
     variableSetId: session.environmentId,
-    authority: { kind: "session_attach", sessionId: session.id },
+    authority: { kind: "session_attach", sessionId: session.id, subjectId: ctx.subjectId },
   });
   const settingsForSession =
     session.sandboxBackend !== settings.sandboxBackend

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -470,13 +470,26 @@ export type SessionGroupReadinessHold = {
  * it. */
 export async function ensureSessionGroupReady(
   services: ViewerServices,
-  input: { accountId: string; workspaceId: string; session: Session },
+  input: {
+    accountId: string;
+    workspaceId: string;
+    session: Session;
+    /** The authenticated subject driving the fleet attach/swap (0282): recorded
+     *  on the viewer holder and the materialization audit fact. Omitting it
+     *  records the explicit service sentinel, so forward the route subject. */
+    subjectId?: string | null;
+  },
 ): Promise<SessionGroupReadinessHold> {
   let lastError: unknown;
   for (let attempt = 0; attempt < 2; attempt += 1) {
     let release: (() => Promise<void>) | undefined;
     try {
-      const attached = await attachViewer(services, input);
+      const attached = await attachViewer(services, {
+        accountId: input.accountId,
+        workspaceId: input.workspaceId,
+        session: input.session,
+        ...(input.subjectId ? { viewerSubjectId: input.subjectId } : {}),
+      });
       let releasePromise: Promise<void> | undefined;
       release = () =>
         (releasePromise ??= detachViewer(services, {

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -144,6 +144,9 @@ export async function sessionAttachEnvironment(
   services: ViewerServices,
   workspaceId: string,
   session: Session,
+  /** The authenticated route subject driving this attach (0282); recorded on
+   *  the materialization audit fact. Null records the legacy service sentinel. */
+  attachSubjectId: string | null,
 ): Promise<Record<string, string>> {
   const workspaceEnvironment = await loadWorkspaceEnvironmentForRun(
     services.db,
@@ -152,7 +155,7 @@ export async function sessionAttachEnvironment(
       accountId: session.accountId,
       workspaceId,
       variableSetId: session.environmentId,
-      authority: { kind: "session_attach", sessionId: session.id },
+      authority: { kind: "session_attach", sessionId: session.id, subjectId: attachSubjectId },
     },
   );
   // Build the env with the SESSION's backend, not the deployment default: the
@@ -293,7 +296,12 @@ export async function attachViewer(
       // so the next turn's agent-manifest apply finds an EMPTY environment delta in
       // the SDK's validateNoEnvironmentDelta (otherwise: "Live sandbox sessions
       // cannot change manifest environment variables").
-      const environment = await sessionAttachEnvironment(services, workspaceId, session);
+      const environment = await sessionAttachEnvironment(
+        services,
+        workspaceId,
+        session,
+        input.viewerSubjectId ?? null,
+      );
       const providerSettings = await providerSettingsForSessionSandboxRuntime(
         sandboxRuntime,
         session.sandboxBackend,
@@ -380,7 +388,12 @@ export async function attachViewer(
         message: `sandbox is ${live.recovery.restore.status} at epoch ${live.leaseEpoch}`,
       });
     }
-    const environment = await sessionAttachEnvironment(services, workspaceId, session);
+    const environment = await sessionAttachEnvironment(
+      services,
+      workspaceId,
+      session,
+      input.viewerSubjectId ?? null,
+    );
     let observed: EstablishedSandboxSession | undefined;
     try {
       const establish = services.establishSandboxSession ?? establishSandboxSessionFromEnvelope;
@@ -873,7 +886,12 @@ export async function mintDesktopStream(
   try {
     // On a cold-restore (the lease's box is gone) this create() must carry the
     // SAME stable run-env the turn declares, so a later turn finds no env delta.
-    const environment = await sessionAttachEnvironment(services, workspaceId, session);
+    const environment = await sessionAttachEnvironment(
+      services,
+      workspaceId,
+      session,
+      input.resourceSubjectId ?? null,
+    );
     try {
       const establish = () =>
         (services.establishSandboxSession ?? establishSandboxSessionFromEnvelope)(
@@ -1134,7 +1152,12 @@ export async function mintTerminalStream(
   try {
     // On a cold-restore this create() must carry the SAME stable run-env the turn
     // declares, so a later turn finds no manifest-env delta.
-    const environment = await sessionAttachEnvironment(services, workspaceId, session);
+    const environment = await sessionAttachEnvironment(
+      services,
+      workspaceId,
+      session,
+      input.resourceSubjectId ?? null,
+    );
     try {
       const establish = () =>
         (services.establishSandboxSession ?? establishSandboxSessionFromEnvelope)(

--- a/apps/api/test/attach-env-git-pointers.test.ts
+++ b/apps/api/test/attach-env-git-pointers.test.ts
@@ -48,6 +48,7 @@ describe("sessionAttachEnvironment — repo-attached git-pointer parity", () => 
           githubRepositoryId: 456,
         },
       ]),
+      null,
     );
     const expected = applyGitAuthPointerEnvironment(
       stableSandboxEnvironmentForRun(settings, {}, { workspaceId: "ws" }),
@@ -59,7 +60,7 @@ describe("sessionAttachEnvironment — repo-attached git-pointer parity", () => 
   });
 
   test("a session with NO GitHub-App repo keeps the plain stable base (no pointers)", async () => {
-    const attachEnv = await sessionAttachEnvironment(services, "ws", sessionWith([]));
+    const attachEnv = await sessionAttachEnvironment(services, "ws", sessionWith([]), null);
     expect(attachEnv).toEqual(stableSandboxEnvironmentForRun(settings, {}, { workspaceId: "ws" }));
     expect(attachEnv.GIT_ASKPASS).toBeUndefined();
   });
@@ -77,6 +78,7 @@ describe("sessionAttachEnvironment — repo-attached git-pointer parity", () => 
           repositoryId: "gl-123",
         },
       ]),
+      null,
     );
     const expected = applyGitAuthPointerEnvironment(
       stableSandboxEnvironmentForRun(settings, {}, { workspaceId: "ws" }),
@@ -135,6 +137,7 @@ describe("sessionAttachEnvironment — repo-attached git-pointer parity", () => 
           ref: "main",
         },
       ]),
+      null,
     );
     expect(attachEnv.GIT_ASKPASS).toBeUndefined();
   });

--- a/apps/api/test/sandbox-shared-and-viewer.test.ts
+++ b/apps/api/test/sandbox-shared-and-viewer.test.ts
@@ -1253,12 +1253,21 @@ describe("P1.4 API-direct viewer-holder lifecycle (real lease + reaper)", () => 
     const { accountId, workspaceId } = await freshWorkspace();
     const { sandboxGroupId, sessionId } = await seedWarmBox(accountId, workspaceId);
     const session = await getSession(db, workspaceId, sessionId);
+    const readinessSubject = `user:fleet-${crypto.randomUUID()}`;
     const hold = await ensureSessionGroupReady(
       { db, settings },
-      { accountId, workspaceId, session: session! },
+      { accountId, workspaceId, session: session!, subjectId: readinessSubject },
     );
 
     expect(hold.lease.liveness).toBe("warm");
+    // 0282: the fleet readiness attach records the driving subject on its
+    // viewer holder, so its materialization/audit lane never masks the human
+    // behind the service sentinel.
+    const [holder] = await admin<Array<{ viewer_subject_id: string | null }>>`
+      select viewer_subject_id from sandbox_lease_holders
+      where workspace_id = ${workspaceId} and kind = 'viewer'
+      order by last_heartbeat_at desc limit 1`;
+    expect(holder?.viewer_subject_id).toBe(readinessSubject);
     const held = await readLease(db, workspaceId, sandboxGroupId);
     expect(held).toMatchObject({
       liveness: "warm",

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -255,7 +255,13 @@ variable-set materialization/secret-read audits carry the causal human,
 attempt authority triple, and owner authority identity. Variable-set denials
 raise and roll their transaction back by design; the application records the
 metadata-only denial fact in a fresh transaction instead of weakening the
-fail-closed seam. `retain`
+fail-closed seam. Since migration 0282 the API-direct session-attach
+materialization lane records the same fact: the seam reads the request
+subject and causal human from the standard context GUCs, writes a
+`variable_set.materialized` audit event with actor kind `session_attach` and
+the live session authority tuple from the exact locked session row, and an
+old image that sets no subject records the explicit `service:session`
+sentinel rather than nothing. `retain`
 has no deletion deadline;
 `delete_after` accepts the initial 30–90 day policy window and stamps a bounded
 future deadline. Destructive expiry is an explicit operator lifecycle, not an

--- a/packages/db/drizzle/0282_variable_set_session_attach_attribution.sql
+++ b/packages/db/drizzle/0282_variable_set_session_attach_attribution.sql
@@ -1,0 +1,178 @@
+-- deployment-mode: rolling
+-- Migration 0282: the session-attach variable-set materialization records the
+-- accepted subject and an audit fact.
+--
+-- `materialize_scoped_variable_set_for_session` (0254) is the API-direct
+-- lane: a viewer attach or a direct channel operation cold-creating a box
+-- materializes the session's variable set so the manifest environment matches
+-- the next turn's. Unlike the attempt lane (0254/0280), it validated only the
+-- session linkage - it took no subject and wrote no audit event, so a
+-- materialization through this lane was invisible to the audit timeline.
+--
+-- The function keeps its exact signature and grants. Attribution arrives
+-- through the standard request context GUCs (`opengeni.subject_id`,
+-- `opengeni.initiating_human_subject_id`) that the application wrapper sets,
+-- and the function now writes the same `variable_set.materialized` audit fact
+-- the attempt lane writes: actor kind `session_attach`, the caller subject,
+-- the derived causal human, and the live session authority tuple
+-- (epoch/visibility/owner membership) read from the exact session row this
+-- transaction already locks FOR SHARE. Metadata only - never a value.
+--
+-- Rolling window: unchanged signature; an old image calls without the subject
+-- GUC and the audit row records the explicit legacy subject
+-- `service:session` (the same honest sentinel the application's denial
+-- recorder already uses for this lane) with NULL causal human. Denials keep
+-- RAISE + rollback semantics; denial recording remains with the application
+-- caller in a fresh transaction.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+CREATE OR REPLACE FUNCTION materialize_scoped_variable_set_for_session(
+  p_account_id uuid,
+  p_workspace_id uuid,
+  p_session_id uuid,
+  p_variable_set_id uuid
+) RETURNS TABLE (
+  variable_set_id uuid,
+  variable_set_name text,
+  variable_set_description text,
+  authority_scope text,
+  variable_set_generation bigint,
+  variable_name text,
+  value_encrypted text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $$
+DECLARE
+  selected_row record;
+  variable_set_row workspace_variable_sets%ROWTYPE;
+  session_authority_epoch integer;
+  session_authority_visibility text;
+  session_owner_membership uuid;
+  audit_subject text;
+  causal_human text;
+BEGIN
+  IF p_account_id IS DISTINCT FROM nullif(
+      pg_catalog.current_setting('opengeni.account_id', true), ''
+    )::uuid
+    OR p_workspace_id IS DISTINCT FROM nullif(
+      pg_catalog.current_setting('opengeni.workspace_id', true), ''
+    )::uuid
+  THEN
+    RAISE EXCEPTION 'variable-set session materialization scope mismatch'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Attribution (0282): the request subject from the standard context GUCs.
+  -- An old image that sets no subject records the explicit legacy sentinel.
+  audit_subject := coalesce(
+    nullif(pg_catalog.current_setting('opengeni.subject_id', true), ''),
+    'service:session'
+  );
+  causal_human := coalesce(
+    nullif(pg_catalog.current_setting('opengeni.initiating_human_subject_id', true), ''),
+    CASE WHEN audit_subject LIKE 'user:%' THEN audit_subject END
+  );
+
+  INSERT INTO opengeni_private.variable_set_authority_capabilities (
+    backend_pid, transaction_id, capability_kind
+  ) VALUES (pg_catalog.pg_backend_pid(), pg_catalog.pg_current_xact_id(), 'materialize')
+  ON CONFLICT DO NOTHING;
+
+  SELECT variable_set AS selected_set,
+    session_value.authority_epoch AS session_epoch,
+    session_value.visibility AS session_visibility,
+    session_value.owner_organization_membership_id AS session_owner_membership
+  INTO STRICT selected_row
+  FROM sessions session_value
+  JOIN workspace_variable_sets variable_set
+    ON variable_set.id = p_variable_set_id
+   AND variable_set.account_id = session_value.account_id
+  WHERE session_value.id = p_session_id
+    AND session_value.account_id = p_account_id
+    AND session_value.workspace_id = p_workspace_id
+    AND session_value.variable_set_id = p_variable_set_id
+    AND session_value.status IN (
+      'queued', 'running', 'idle', 'requires_action', 'recovering', 'waiting_capacity'
+    )
+    AND variable_set.status = 'active'
+    AND (
+      variable_set.authority_scope = 'organization'
+      OR (
+        variable_set.authority_scope = 'workspace'
+        AND variable_set.workspace_id = p_workspace_id
+      )
+    )
+  FOR SHARE OF session_value, variable_set;
+  variable_set_row := selected_row.selected_set;
+  session_authority_epoch := selected_row.session_epoch;
+  session_authority_visibility := selected_row.session_visibility;
+  session_owner_membership := selected_row.session_owner_membership;
+
+  -- The audit fact (0282): same action as the attempt lane, actor kind
+  -- session_attach, live session authority from the row locked above.
+  -- Metadata only - never a variable value.
+  INSERT INTO audit_events (
+    account_id, workspace_id, subject_id, action, target_type, target_id,
+    metadata, metadata_codec_version
+  ) VALUES (
+    p_account_id, p_workspace_id, audit_subject,
+    'variable_set.materialized', 'workspace_variable_set',
+    variable_set_row.id::text,
+    pg_catalog.jsonb_build_object(
+      'variableSetId', variable_set_row.id,
+      'scope', variable_set_row.authority_scope,
+      'generation', variable_set_row.generation,
+      'actorKind', 'session_attach',
+      'sessionId', p_session_id,
+      'causalHumanSubjectId', causal_human,
+      'authorityEpoch', session_authority_epoch,
+      'authorityVisibility', session_authority_visibility,
+      'authorityOwnerOrganizationMembershipId', session_owner_membership,
+      'ownerAuthorityId', variable_set_row.authority_id,
+      'ownerOrganizationMembershipId', variable_set_row.owner_organization_membership_id,
+      'originWorkspaceId', variable_set_row.origin_workspace_id
+    ),
+    1
+  );
+
+  RETURN QUERY
+  SELECT selected.id, selected.name, selected.description,
+    selected.authority_scope, selected.generation,
+    variable.name, variable.value_encrypted
+  FROM workspace_variable_sets selected
+  LEFT JOIN workspace_variable_set_variables variable
+    ON variable.account_id = selected.account_id
+   AND variable.variable_set_id = selected.id
+  WHERE selected.id = variable_set_row.id
+  ORDER BY variable.name;
+
+  DELETE FROM opengeni_private.variable_set_authority_capabilities
+  WHERE backend_pid = pg_catalog.pg_backend_pid()
+    AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+    AND capability_kind = 'materialize';
+  RETURN;
+EXCEPTION WHEN OTHERS THEN
+  DELETE FROM opengeni_private.variable_set_authority_capabilities
+  WHERE backend_pid = pg_catalog.pg_backend_pid()
+    AND transaction_id = pg_catalog.pg_current_xact_id_if_assigned()
+    AND capability_kind = 'materialize';
+  RAISE;
+END
+$$;
+
+REVOKE ALL ON FUNCTION materialize_scoped_variable_set_for_session(
+  uuid, uuid, uuid, uuid
+) FROM PUBLIC;
+DO $session_materialize_attribution_grant$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    GRANT EXECUTE ON FUNCTION materialize_scoped_variable_set_for_session(
+      uuid, uuid, uuid, uuid
+    ) TO opengeni_app;
+  END IF;
+END
+$session_materialize_attribution_grant$;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17592,7 +17592,14 @@ export async function getVariableSetValuesForRun(
           executionGeneration: number;
           initiatingHumanSubjectId?: string | null;
         }
-      | { kind: "session_attach"; sessionId: string };
+      | {
+          kind: "session_attach";
+          sessionId: string;
+          /** The authenticated route subject driving the attach (0282); null
+           *  records the explicit legacy sentinel `service:session`. */
+          subjectId: string | null;
+          initiatingHumanSubjectId?: string | null;
+        };
   },
 ): Promise<{
   variableSet: {
@@ -17618,7 +17625,9 @@ export async function getVariableSetValuesForRun(
         action: "variable_set.materialize.denied",
         variableSetId: input.variableSetId,
         subjectId:
-          input.authority.kind === "agent_attempt" ? input.authority.subjectId : "service:session",
+          input.authority.kind === "agent_attempt"
+            ? input.authority.subjectId
+            : (input.authority.subjectId ?? "service:session"),
         ...(input.authority.kind === "agent_attempt"
           ? {
               sessionId: input.authority.sessionId,
@@ -17681,6 +17690,18 @@ async function getVariableSetValuesForRunInTransaction(
   input: Parameters<typeof getVariableSetValuesForRun>[1],
 ): ReturnType<typeof getVariableSetValuesForRun> {
   return await withRlsContext(db, input, async (scopedDb) => {
+    if (input.authority.kind === "session_attach") {
+      // 0282: the seam reads the request subject + causal human from the
+      // standard context GUCs and records the materialization audit fact.
+      if (input.authority.subjectId) {
+        await setSubjectRlsContext(scopedDb, input.authority.subjectId);
+      }
+      if (input.authority.initiatingHumanSubjectId) {
+        await scopedDb.execute(sql`select set_config(
+          'opengeni.initiating_human_subject_id',
+          ${input.authority.initiatingHumanSubjectId}, true)`);
+      }
+    }
     if (input.authority.kind === "agent_attempt") {
       await setSubjectRlsContext(scopedDb, input.authority.subjectId);
       await scopedDb.execute(sql`select set_config(
@@ -17832,7 +17853,14 @@ export async function loadVariableSetForRun(
           executionGeneration: number;
           initiatingHumanSubjectId?: string | null;
         }
-      | { kind: "session_attach"; sessionId: string };
+      | {
+          kind: "session_attach";
+          sessionId: string;
+          /** The authenticated route subject driving the attach (0282); null
+           *  records the explicit legacy sentinel `service:session`. */
+          subjectId: string | null;
+          initiatingHumanSubjectId?: string | null;
+        };
   },
 ): Promise<VariableSetForRun | null> {
   if (!input.variableSetId) {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17692,9 +17692,13 @@ async function getVariableSetValuesForRunInTransaction(
   return await withRlsContext(db, input, async (scopedDb) => {
     if (input.authority.kind === "session_attach") {
       // 0282: the seam reads the request subject + causal human from the
-      // standard context GUCs and records the materialization audit fact.
+      // standard context GUCs and records the materialization audit fact. A
+      // null subject explicitly clears the GUC so a reused transaction handle
+      // can never attribute this materialization to an earlier subject.
       if (input.authority.subjectId) {
         await setSubjectRlsContext(scopedDb, input.authority.subjectId);
+      } else {
+        await scopedDb.execute(sql`select set_config('opengeni.subject_id', '', true)`);
       }
       if (input.authority.initiatingHumanSubjectId) {
         await scopedDb.execute(sql`select set_config(

--- a/packages/db/test/migration-0282-session-attach-attribution.test.ts
+++ b/packages/db/test/migration-0282-session-attach-attribution.test.ts
@@ -185,7 +185,12 @@ describe("migration 0282 session-attach materialization attribution", () => {
     // The STRICT session-selection join raises P0002 (not 42501): the
     // transaction rolls back, no materialized fact survives, and the 42501-only
     // denial filter records no false denial evidence for a linkage miss.
-    await expect(attempt).rejects.toBeTruthy();
+    const failure = await attempt.then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(failure).not.toBeNull();
+    expect(JSON.stringify(failure)).toContain("P0002");
     const [counts] = await admin<Array<{ materialized: number; denied: number }>>`
       select
         count(*) filter (where action = 'variable_set.materialized')::int as materialized,

--- a/packages/db/test/migration-0282-session-attach-attribution.test.ts
+++ b/packages/db/test/migration-0282-session-attach-attribution.test.ts
@@ -1,0 +1,197 @@
+// Migration 0282: the session-attach variable-set materialization records the
+// accepted subject and a `variable_set.materialized` audit fact with the live
+// session authority tuple, closing the API-direct lane that previously
+// materialized values with no subject and no audit event.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
+import { readFile } from "node:fs/promises";
+import postgres from "postgres";
+import {
+  createDb,
+  createSession,
+  getVariableSetValuesForRun,
+  initializeSessionStartAtomically,
+  type Database,
+  type DbClient,
+} from "../src";
+
+const migrationUrl = new URL(
+  "../drizzle/0282_variable_set_session_attach_attribution.sql",
+  import.meta.url,
+);
+
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let admin: postgres.Sql;
+let client: DbClient;
+let db: Database;
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("migration-0282-session-attach-attribution");
+  if (!shared) {
+    available = false;
+    if (requireRealDatabase) throw new Error("OPENGENI_REQUIRE_REAL_DB=1 but no database");
+    return;
+  }
+  admin = shared.admin;
+  client = createDb(shared.appUrl);
+  db = client.db;
+});
+
+afterAll(async () => {
+  await client?.close();
+  await shared?.release();
+});
+
+async function sessionFixture(): Promise<{
+  accountId: string;
+  workspaceId: string;
+  sessionId: string;
+  variableSetId: string;
+}> {
+  const [account] = await admin<{ id: string }[]>`
+    insert into managed_accounts (name) values ('session-attach-attribution') returning id`;
+  const [workspace] = await admin<{ id: string }[]>`
+    insert into workspaces (account_id, name)
+    values (${account!.id}, 'session-attach-workspace') returning id`;
+  await admin`
+    insert into workspace_inference_controls (workspace_id, account_id)
+    values (${workspace!.id}, ${account!.id})`;
+  const session = await createSession(db, {
+    accountId: account!.id,
+    workspaceId: workspace!.id,
+    initialMessage: "attach me",
+    resources: [],
+    metadata: {},
+    model: "test-model",
+    sandboxBackend: "none",
+  });
+  await initializeSessionStartAtomically(db, {
+    accountId: account!.id,
+    workspaceId: workspace!.id,
+    sessionId: session.id,
+    reasoningEffortFallback: "low",
+    createdEventPayload: {},
+  });
+  const [variableSet] = await admin<{ id: string }[]>`
+    insert into workspace_variable_sets (account_id, workspace_id, name, origin_workspace_id)
+    values (${account!.id}, ${workspace!.id}, 'attach set', ${workspace!.id})
+    returning id`;
+  await admin`
+    insert into workspace_variable_set_variables (
+      account_id, workspace_id, variable_set_id, name, value_encrypted
+    ) values (
+      ${account!.id}, ${workspace!.id}, ${variableSet!.id}, 'TOKEN', 'ciphertext'
+    )`;
+  await admin`
+    update sessions set variable_set_id = ${variableSet!.id} where id = ${session.id}`;
+  return {
+    accountId: account!.id,
+    workspaceId: workspace!.id,
+    sessionId: session.id,
+    variableSetId: variableSet!.id,
+  };
+}
+
+describe("migration 0282 session-attach materialization attribution", () => {
+  test("declares one rolling GUC-attributed protocol with an unchanged signature", async () => {
+    const source = await readFile(migrationUrl, "utf8");
+    expect(source.split(/\r?\n/u, 1)[0]).toBe("-- deployment-mode: rolling");
+    expect(source).toContain(
+      "CREATE OR REPLACE FUNCTION materialize_scoped_variable_set_for_session(",
+    );
+    // The signature and grants are unchanged (rolling: old images keep calling).
+    expect(source).not.toContain("p_subject_id");
+    expect(source).toContain("current_setting('opengeni.subject_id', true)");
+    expect(source).toContain("current_setting('opengeni.initiating_human_subject_id', true)");
+    expect(source).toContain("'service:session'");
+    expect(source).toContain("'variable_set.materialized'");
+    expect(source).toContain("'actorKind', 'session_attach'");
+    // Live session authority tuple from the exact locked session row.
+    expect(source).toContain("session_value.authority_epoch");
+    expect(source).toContain("session_value.owner_organization_membership_id");
+    expect(source).toContain("FOR SHARE OF session_value, variable_set");
+    expect(source).not.toMatch(/\bDROP\b/u);
+    expect(source).not.toContain("value_encrypted'"); // metadata never carries a value key
+  });
+
+  test("a subject-attributed session attach materializes and records the audit fact", async () => {
+    if (!available) return;
+    const fixture = await sessionFixture();
+    const human = `user:attach-${crypto.randomUUID()}`;
+    const result = await getVariableSetValuesForRun(db, {
+      accountId: fixture.accountId,
+      workspaceId: fixture.workspaceId,
+      variableSetId: fixture.variableSetId,
+      authority: { kind: "session_attach", sessionId: fixture.sessionId, subjectId: human },
+    });
+    expect(result?.values).toEqual({ TOKEN: "ciphertext" });
+    const [audit] = await admin<Array<{ subject_id: string; metadata: Record<string, unknown> }>>`
+      select subject_id, metadata from audit_events
+      where workspace_id = ${fixture.workspaceId}
+        and action = 'variable_set.materialized'
+      order by occurred_at desc limit 1`;
+    expect(audit!.subject_id).toBe(human);
+    expect(audit!.metadata).toMatchObject({
+      variableSetId: fixture.variableSetId,
+      actorKind: "session_attach",
+      sessionId: fixture.sessionId,
+      causalHumanSubjectId: human,
+      authorityEpoch: 1,
+      authorityVisibility: "workspace_shared",
+      originWorkspaceId: fixture.workspaceId,
+    });
+    // Metadata is attribution only - never the variable value.
+    expect(JSON.stringify(audit!.metadata)).not.toContain("ciphertext");
+  });
+
+  test("a claimless (legacy/rolling) attach records the explicit service sentinel", async () => {
+    if (!available) return;
+    const fixture = await sessionFixture();
+    const result = await getVariableSetValuesForRun(db, {
+      accountId: fixture.accountId,
+      workspaceId: fixture.workspaceId,
+      variableSetId: fixture.variableSetId,
+      authority: { kind: "session_attach", sessionId: fixture.sessionId, subjectId: null },
+    });
+    expect(result?.values).toEqual({ TOKEN: "ciphertext" });
+    const [audit] = await admin<Array<{ subject_id: string; metadata: Record<string, unknown> }>>`
+      select subject_id, metadata from audit_events
+      where workspace_id = ${fixture.workspaceId}
+        and action = 'variable_set.materialized'
+      order by occurred_at desc limit 1`;
+    expect(audit!.subject_id).toBe("service:session");
+    expect(audit!.metadata.causalHumanSubjectId).toBeNull();
+  });
+
+  test("an unselected set still fails without manufacturing audit facts", async () => {
+    if (!available) return;
+    const fixture = await sessionFixture();
+    const [otherSet] = await admin<{ id: string }[]>`
+      insert into workspace_variable_sets (account_id, workspace_id, name, origin_workspace_id)
+      values (${fixture.accountId}, ${fixture.workspaceId}, 'unselected', ${fixture.workspaceId})
+      returning id`;
+    const attempt = getVariableSetValuesForRun(db, {
+      accountId: fixture.accountId,
+      workspaceId: fixture.workspaceId,
+      variableSetId: otherSet!.id,
+      authority: {
+        kind: "session_attach",
+        sessionId: fixture.sessionId,
+        subjectId: `user:deny-${crypto.randomUUID()}`,
+      },
+    });
+    // The STRICT session-selection join raises P0002 (not 42501): the
+    // transaction rolls back, no materialized fact survives, and the 42501-only
+    // denial filter records no false denial evidence for a linkage miss.
+    await expect(attempt).rejects.toBeTruthy();
+    const [counts] = await admin<Array<{ materialized: number; denied: number }>>`
+      select
+        count(*) filter (where action = 'variable_set.materialized')::int as materialized,
+        count(*) filter (where action = 'variable_set.materialize.denied')::int as denied
+      from audit_events
+      where workspace_id = ${fixture.workspaceId}`;
+    expect(counts!).toMatchObject({ materialized: 0, denied: 0 });
+  });
+});

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -521,6 +521,11 @@ describe("release schema contract", () => {
         : "d54a4ac5b800e0c0578e7fce7d1a09cea1dbed87d3b13bf722549fea0bdc031e";
     };
     const releaseSchemaContractHash = (includesActivation: boolean): string | null => {
+      if (migrations.has("0282_variable_set_session_attach_attribution.sql")) {
+        return includesActivation
+          ? "a5e8ed9034e5a9ff7dcd2aa93ec94dcef535fbbb06f84ea54d0fa26db519a1ad"
+          : "37331cb616cdb135701df535414d6eeac212760e4b1ca9c53a2da5252c1610f4";
+      }
       if (migrations.has("0281_viewer_holder_authority_claims.sql")) {
         return includesActivation
           ? "c95d0449cae50232c5d27656f040d55cca25499bf06cff4c190df82270e4ae97"
@@ -984,7 +989,8 @@ describe("release schema contract", () => {
         (migrations.has("0278_workspace_membership_removal_fencing.sql") ? 1 : 0) +
         (migrations.has("0279_workspace_connection_use_lane.sql") ? 1 : 0) +
         (migrations.has("0280_connection_and_variable_set_audit_attribution.sql") ? 1 : 0) +
-        (migrations.has("0281_viewer_holder_authority_claims.sql") ? 1 : 0),
+        (migrations.has("0281_viewer_holder_authority_claims.sql") ? 1 : 0) +
+        (migrations.has("0282_variable_set_session_attach_attribution.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(releaseSchemaContractHash(false) ?? currentMainContractHash);
     const latestCompatibleMigration = [
@@ -1019,74 +1025,80 @@ describe("release schema contract", () => {
       "0217_capability_definition_delete_authority.sql",
     ].find((path) => migrations.has(path));
     expect(contract.latestMigration).toBe(
-      migrations.has("0281_viewer_holder_authority_claims.sql")
-        ? "0281_viewer_holder_authority_claims.sql"
-        : migrations.has("0280_connection_and_variable_set_audit_attribution.sql")
-          ? "0280_connection_and_variable_set_audit_attribution.sql"
-          : migrations.has("0279_workspace_connection_use_lane.sql")
-            ? "0279_workspace_connection_use_lane.sql"
-            : migrations.has("0278_workspace_membership_removal_fencing.sql")
-              ? "0278_workspace_membership_removal_fencing.sql"
-              : migrations.has("0277_workspace_writer_authority_attribution.sql")
-                ? "0277_workspace_writer_authority_attribution.sql"
-                : migrations.has("0276_onboarding_proposal_initiating_human_guc.sql")
-                  ? "0276_onboarding_proposal_initiating_human_guc.sql"
-                  : migrations.has("0275_scheduled_connection_authority.sql")
-                    ? "0275_scheduled_connection_authority.sql"
-                    : migrations.has("0274_human_confirmed_knowledge_review.sql")
-                      ? "0274_human_confirmed_knowledge_review.sql"
-                      : migrations.has("0272_human_confirmed_learning_activation.sql")
-                        ? "0272_human_confirmed_learning_activation.sql"
-                        : migrations.has("0271_company_brain_retrieval_only_default.sql")
-                          ? "0271_company_brain_retrieval_only_default.sql"
-                          : migrations.has("0270_governed_learning_history_inspection.sql")
-                            ? "0270_governed_learning_history_inspection.sql"
-                            : migrations.has("0269_governed_learning_activation_controller.sql")
-                              ? "0269_governed_learning_activation_controller.sql"
-                              : migrations.has("0268_governed_learning_decision_receipts.sql")
-                                ? "0268_governed_learning_decision_receipts.sql"
-                                : migrations.has(
-                                      "0266_company_brain_context_receipt_inspection.sql",
-                                    )
-                                  ? "0266_company_brain_context_receipt_inspection.sql"
+      migrations.has("0282_variable_set_session_attach_attribution.sql")
+        ? "0282_variable_set_session_attach_attribution.sql"
+        : migrations.has("0281_viewer_holder_authority_claims.sql")
+          ? "0281_viewer_holder_authority_claims.sql"
+          : migrations.has("0280_connection_and_variable_set_audit_attribution.sql")
+            ? "0280_connection_and_variable_set_audit_attribution.sql"
+            : migrations.has("0279_workspace_connection_use_lane.sql")
+              ? "0279_workspace_connection_use_lane.sql"
+              : migrations.has("0278_workspace_membership_removal_fencing.sql")
+                ? "0278_workspace_membership_removal_fencing.sql"
+                : migrations.has("0277_workspace_writer_authority_attribution.sql")
+                  ? "0277_workspace_writer_authority_attribution.sql"
+                  : migrations.has("0276_onboarding_proposal_initiating_human_guc.sql")
+                    ? "0276_onboarding_proposal_initiating_human_guc.sql"
+                    : migrations.has("0275_scheduled_connection_authority.sql")
+                      ? "0275_scheduled_connection_authority.sql"
+                      : migrations.has("0274_human_confirmed_knowledge_review.sql")
+                        ? "0274_human_confirmed_knowledge_review.sql"
+                        : migrations.has("0272_human_confirmed_learning_activation.sql")
+                          ? "0272_human_confirmed_learning_activation.sql"
+                          : migrations.has("0271_company_brain_retrieval_only_default.sql")
+                            ? "0271_company_brain_retrieval_only_default.sql"
+                            : migrations.has("0270_governed_learning_history_inspection.sql")
+                              ? "0270_governed_learning_history_inspection.sql"
+                              : migrations.has("0269_governed_learning_activation_controller.sql")
+                                ? "0269_governed_learning_activation_controller.sql"
+                                : migrations.has("0268_governed_learning_decision_receipts.sql")
+                                  ? "0268_governed_learning_decision_receipts.sql"
                                   : migrations.has(
-                                        "0261_preference_knowledge_proposal_actor_binding.sql",
+                                        "0266_company_brain_context_receipt_inspection.sql",
                                       )
-                                    ? "0261_preference_knowledge_proposal_actor_binding.sql"
-                                    : migrations.has("0260_task_note_knowledge_promotion.sql")
-                                      ? "0260_task_note_knowledge_promotion.sql"
-                                      : migrations.has(
-                                            "0259_company_brain_context_selection_receipts.sql",
-                                          )
-                                        ? "0259_company_brain_context_selection_receipts.sql"
+                                    ? "0266_company_brain_context_receipt_inspection.sql"
+                                    : migrations.has(
+                                          "0261_preference_knowledge_proposal_actor_binding.sql",
+                                        )
+                                      ? "0261_preference_knowledge_proposal_actor_binding.sql"
+                                      : migrations.has("0260_task_note_knowledge_promotion.sql")
+                                        ? "0260_task_note_knowledge_promotion.sql"
                                         : migrations.has(
-                                              "0258_three_scope_document_knowledge_authority.sql",
+                                              "0259_company_brain_context_selection_receipts.sql",
                                             )
-                                          ? "0258_three_scope_document_knowledge_authority.sql"
+                                          ? "0259_company_brain_context_selection_receipts.sql"
                                           : migrations.has(
-                                                "0257_goal_revision_decisions_and_root_constraints.sql",
+                                                "0258_three_scope_document_knowledge_authority.sql",
                                               )
-                                            ? "0257_goal_revision_decisions_and_root_constraints.sql"
+                                            ? "0258_three_scope_document_knowledge_authority.sql"
                                             : migrations.has(
-                                                  "0255_company_brain_governed_write_proposals.sql",
+                                                  "0257_goal_revision_decisions_and_root_constraints.sql",
                                                 )
-                                              ? "0255_company_brain_governed_write_proposals.sql"
+                                              ? "0257_goal_revision_decisions_and_root_constraints.sql"
                                               : migrations.has(
-                                                    "0248_terraform_stacks_component_resolution_fence.sql",
+                                                    "0255_company_brain_governed_write_proposals.sql",
                                                   )
-                                                ? "0248_terraform_stacks_component_resolution_fence.sql"
+                                                ? "0255_company_brain_governed_write_proposals.sql"
                                                 : migrations.has(
-                                                      "0247_terraform_stacks_provenance_repair.sql",
+                                                      "0248_terraform_stacks_component_resolution_fence.sql",
                                                     )
-                                                  ? "0247_terraform_stacks_provenance_repair.sql"
+                                                  ? "0248_terraform_stacks_component_resolution_fence.sql"
                                                   : migrations.has(
-                                                        "0263_organization_membership_lifecycle.sql",
+                                                        "0247_terraform_stacks_provenance_repair.sql",
                                                       )
-                                                    ? "0263_organization_membership_lifecycle.sql"
-                                                    : latestCompatibleMigration,
+                                                    ? "0247_terraform_stacks_provenance_repair.sql"
+                                                    : migrations.has(
+                                                          "0263_organization_membership_lifecycle.sql",
+                                                        )
+                                                      ? "0263_organization_membership_lifecycle.sql"
+                                                      : latestCompatibleMigration,
     );
     expect(migrations.get("0263_organization_membership_lifecycle.sql")).toMatchObject({
       sha256: "1119554dc06a768c92f7189a97b438ebdc011747a6c8d7cefc992962f2293593",
+      deploymentMode: "rolling",
+    });
+    expect(migrations.get("0282_variable_set_session_attach_attribution.sql")).toMatchObject({
+      sha256: "ad47dfc672380757da5a46a049b56ff72af54a7fffb73e929e364c6ae29cfda7",
       deploymentMode: "rolling",
     });
     expect(migrations.get("0281_viewer_holder_authority_claims.sql")).toMatchObject({


### PR DESCRIPTION
## OPE-203 slice 7 — session-attach variable-set materialization attribution

`materialize_scoped_variable_set_for_session` (0254) is the API-direct lane: a viewer attach or a direct channel operation cold-creating a box materializes the session's variable set so the manifest environment matches the next turn's. Unlike the attempt lane (0254/0280) it validated only the session linkage — no subject, no audit event — so these materializations were invisible to the audit timeline.

### What changed
- **Migration `0282_variable_set_session_attach_attribution.sql` (rolling):** `CREATE OR REPLACE` of the session materializer with an **unchanged signature and grants**. Attribution arrives through the standard request-context GUCs (`opengeni.subject_id`, `opengeni.initiating_human_subject_id`); the function writes the same `variable_set.materialized` audit fact as the attempt lane with `actorKind: session_attach`, the caller subject, derived causal human, the live session authority tuple (epoch/visibility/owner membership) from the exact session row the transaction already locks FOR SHARE, and the set's owner authority identity. Metadata only — never a value.
- **Rolling window:** an old image calls without the subject GUC and the audit row records the explicit legacy sentinel `service:session` (the same sentinel the application's denial recorder already uses for this lane) with NULL causal human. Denials keep RAISE + rollback; denial recording stays with the application in a fresh transaction, and a session-linkage miss still raises STRICT `P0002` without manufacturing a false denial fact (42501-only filter, unchanged from slice 5).
- **TypeScript:** the `session_attach` authority gains a required `subjectId: string | null` (+ optional `initiatingHumanSubjectId`); the wrapper sets the GUCs; the denial audit records the real subject. `sessionAttachEnvironment` takes the authenticated route subject (threaded from `viewerSubjectId` in attachViewer and `resourceSubjectId` in the mints), and channel-A passes `ctx.subjectId`.

### Verification
- New real-PG suite `migration-0282-session-attach-attribution.test.ts` (4 tests): source contract; subject-attributed attach records the audit fact (and metadata never contains the value); claimless legacy attach records `service:session` with NULL causal human; an unselected set fails without manufacturing `materialized` or `denied` facts.
- Regression green: migration-0280 + variable-set-secret-read (11), sandbox-attach-env-parity + sandbox-desktop-stream (26), rls-dedicated-schema-isolation + runtime-posture (40), channel-a-routes (40), attach-env-git-pointers (5).
- Full `bun run typecheck` clean; oxfmt/oxlint clean; migration-ordinal + public-hygiene guards pass; release-schema ladder re-pinned for 0282 (SHA-256 `ad47dfc672380757da5a46a049b56ff72af54a7fffb73e929e364c6ae29cfda7`).

Docs: `docs/organization-tenancy.md` audit-attribution paragraph extended. Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca7x2FyxheguVcdENGs8ji
