### PR TITLE
chore(release): prepare product 0.23.9

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.8
-appVersion: "0.23.8"
+version: 0.23.9
+appVersion: "0.23.9"


### PR DESCRIPTION
Advance the immutable product release identity from 0.23.8 to 0.23.9 after the generated package Version PR. This keeps the already-published 0.23.8 OCI/chart namespace immutable and gives the latest reviewed main tree a fresh ordinary-release candidate version.\n\nValidation: Helm lint passes; the release-version reader returns 0.23.9; no pending changesets remain; diff check is clean.