### PR TITLE
feat(release): retain post-source controllers

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       controller_sha:
-        description: Exact retained trusted Version-PR base SHA.
+        description: Exact retained trusted controller SHA.
         required: true
         type: string
 

--- a/.github/workflows/release-source-admission.yml
+++ b/.github/workflows/release-source-admission.yml
@@ -1,6 +1,6 @@
 name: Release source admission
 
-# This reusable gate is loaded from the caller's immutable trusted-base ref.
+# This reusable gate is loaded from the caller's immutable retained controller ref.
 # It executes no release-source bytes and grants no mutation authority.
 on:
   workflow_call:
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       controller_sha:
-        description: Exact retained trusted Version-PR base running this workflow.
+        description: Exact retained trusted controller running this workflow.
         required: true
         type: string
 

--- a/.github/workflows/retain-release-controller.yml
+++ b/.github/workflows/retain-release-controller.yml
@@ -1,0 +1,38 @@
+name: Retain Release Controller
+run-name: retain-release-controller:${{ inputs.controller_sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      controller_sha:
+        description: Exact current main SHA to retain as immutable workflow authority.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: retain-release-controller-${{ inputs.controller_sha }}
+  cancel-in-progress: false
+
+jobs:
+  retain:
+    name: Retain exact current-main controller
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Check out trusted current main
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Retain exact current-main workflow authority
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_CONTROLLER_SHA: ${{ inputs.controller_sha }}
+        run: node scripts/check-release-pr-automation.mjs retain-release-controller

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -29,6 +29,7 @@ export const RELEASE_AUTOMATION_CONTRACT = Object.freeze({
   ciWorkflowPath: ".github/workflows/ci.yml",
   ciWorkflowFile: "ci.yml",
   sealWorkflowPath: ".github/workflows/seal-release-head.yml",
+  retainControllerWorkflowPath: ".github/workflows/retain-release-controller.yml",
   sourceAdmissionWorkflowPath: ".github/workflows/source-admission.yml",
   releaseHeadTagPrefix: "opengeni-release-head-",
   releaseHeadReleaseNamePrefix: "Retained OpenGeni release head ",
@@ -1215,6 +1216,57 @@ export async function sealReleaseHeadEvidence(options = {}) {
   };
 }
 
+function retainedControllerContext(env, suppliedControllerSha) {
+  const github = baseGithubContext(
+    env,
+    RELEASE_AUTOMATION_CONTRACT.retainControllerWorkflowPath,
+    "workflow_dispatch",
+  );
+  requiredEnvironment(env, ["GITHUB_REF"]);
+  const controllerSha = assertSha(
+    suppliedControllerSha ?? env.RELEASE_CONTROLLER_SHA,
+    "retained controller SHA",
+  );
+  invariant(
+    env.GITHUB_REF === `refs/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`,
+    "retained controller workflow is not running from the default branch",
+  );
+  invariant(github.sha === controllerSha, "retained controller differs from workflow SHA");
+  return { ...github, controllerSha };
+}
+
+export async function retainCurrentMainControllerEvidence(options = {}) {
+  const env = options.env ?? process.env;
+  const logger = options.logger ?? console;
+  const context = retainedControllerContext(env, options.controllerSha);
+  const api = githubClient(options.fetchImpl ?? globalThis.fetch, context.token);
+  const [repository, main, controller] = await Promise.all([
+    api.get(repositoryPath("")),
+    api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
+    api.get(repositoryPath(`/git/commits/${context.controllerSha}`)),
+  ]);
+  assertRepository(repository);
+  assertMainRef(main, context.controllerSha, "retained controller default branch");
+  assertCommit(controller, context.controllerSha, "retained controller commit");
+
+  const releaseHead = await ensureReleaseHeadRef(api, context.controllerSha);
+  const releaseHeadRelease = await ensureReleaseHeadRelease(api, context.controllerSha);
+  const [terminalMain, terminalRef, terminalRelease] = await Promise.all([
+    api.get(repositoryPath(`/git/ref/heads/${RELEASE_AUTOMATION_CONTRACT.defaultBranch}`)),
+    api.get(repositoryPath(`/git/ref/tags/${releaseHead.name}`)),
+    api.get(repositoryPath(`/releases/tags/${releaseHead.name}`)),
+  ]);
+  assertMainRef(terminalMain, context.controllerSha, "terminal retained controller default branch");
+  assertReleaseHeadRef(terminalRef, context.controllerSha);
+  const verifiedRelease = assertReleaseHeadRelease(terminalRelease, context.controllerSha);
+  invariant(
+    JSON.stringify(verifiedRelease) === JSON.stringify(releaseHeadRelease),
+    "retained controller immutable release moved during retention",
+  );
+  logger.log(`Retained current main ${context.controllerSha} as an immutable release controller.`);
+  return { ...context, releaseHead, releaseHeadRelease };
+}
+
 function checkIdentity(kind, context) {
   invariant(
     kind === "source-admission" ||
@@ -2328,6 +2380,17 @@ async function runCommand(env = process.env) {
         release_head_sha: result.headSha,
         release_head_ref: result.releaseHead.ref,
         release_head_merged_source_sha: result.sourceSha,
+      },
+      env,
+    );
+    return;
+  }
+  if (command === "retain-release-controller") {
+    const result = await retainCurrentMainControllerEvidence({ env });
+    writeOutputs(
+      {
+        release_controller_sha: result.controllerSha,
+        release_controller_ref: result.releaseHead.ref,
       },
       env,
     );

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -6,6 +6,7 @@ import {
   beginVersionPrChecks,
   completeVersionPrChecks,
   recoverReleaseHeadEvidence,
+  retainCurrentMainControllerEvidence,
   sealReleaseHeadEvidence,
   validateVersionPrCiAdmission,
   validateVersionPrDispatch,
@@ -16,6 +17,10 @@ const root = join(import.meta.dir, "..");
 const releaseWorkflowPath = join(root, RELEASE_AUTOMATION_CONTRACT.releaseWorkflowPath);
 const ciWorkflowPath = join(root, RELEASE_AUTOMATION_CONTRACT.ciWorkflowPath);
 const sealWorkflowPath = join(root, RELEASE_AUTOMATION_CONTRACT.sealWorkflowPath);
+const retainControllerWorkflowPath = join(
+  root,
+  RELEASE_AUTOMATION_CONTRACT.retainControllerWorkflowPath,
+);
 const releaseSourceAdmissionPath = join(root, ".github/workflows/release-source-admission.yml");
 const releasePublicationAdmissionPath = join(
   root,
@@ -855,6 +860,115 @@ describe("release head evidence retention", () => {
       }),
     ).rejects.toThrow("workflow source SHA differs from its event SHA");
     expect(drift.requests).toHaveLength(0);
+  });
+});
+
+function retainControllerEnv(overrides: Record<string, string> = {}) {
+  return {
+    GITHUB_API_URL: RELEASE_AUTOMATION_CONTRACT.apiUrl,
+    GITHUB_EVENT_NAME: "workflow_dispatch",
+    GITHUB_REF: "refs/heads/main",
+    GITHUB_REPOSITORY: RELEASE_AUTOMATION_CONTRACT.repository,
+    GITHUB_SERVER_URL: RELEASE_AUTOMATION_CONTRACT.serverUrl,
+    GITHUB_SHA: headSha,
+    GITHUB_TOKEN: "fixture-token",
+    GITHUB_WORKFLOW_REF:
+      `${RELEASE_AUTOMATION_CONTRACT.repository}/` +
+      `${RELEASE_AUTOMATION_CONTRACT.retainControllerWorkflowPath}@refs/heads/main`,
+    GITHUB_WORKFLOW_SHA: headSha,
+    RELEASE_CONTROLLER_SHA: headSha,
+    ...overrides,
+  };
+}
+
+function retainControllerFixture() {
+  const requests: RequestRecord[] = [];
+  let refRetained = false;
+  let releaseRetained = false;
+  const prefix = `/repos/${RELEASE_AUTOMATION_CONTRACT.repository}`;
+  async function fetchImpl(input: string | URL | Request, init?: RequestInit) {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    requests.push({ method, path: url.pathname, query: url.searchParams, body });
+    if (method === "POST" && url.pathname === `${prefix}/git/refs`) {
+      refRetained = true;
+      return response({ ref: body?.ref, object: { type: "commit", sha: body?.sha } }, 201);
+    }
+    if (method === "POST" && url.pathname === `${prefix}/releases`) {
+      releaseRetained = true;
+      return response(releaseHeadRelease(headSha), 201);
+    }
+    if (method !== "GET") return response({ message: "unsupported" }, 405);
+    if (url.pathname === prefix) return response(repository());
+    if (url.pathname === `${prefix}/git/ref/heads/main`) return response(mainRef(headSha));
+    if (url.pathname === `${prefix}/git/commits/${headSha}`)
+      return response({
+        sha: headSha,
+        tree: { sha: headTreeSha },
+        parents: [{ sha: baseSha }],
+      });
+    if (
+      url.pathname ===
+      `${prefix}/git/ref/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${headSha}`
+    ) {
+      return refRetained
+        ? response({
+            ref: `refs/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${headSha}`,
+            object: { type: "commit", sha: headSha },
+          })
+        : response({ message: "missing" }, 404);
+    }
+    if (
+      url.pathname ===
+      `${prefix}/releases/tags/${RELEASE_AUTOMATION_CONTRACT.releaseHeadTagPrefix}${headSha}`
+    ) {
+      return releaseRetained
+        ? response(releaseHeadRelease(headSha))
+        : response({ message: "missing" }, 404);
+    }
+    return response({ message: `unexpected ${method} ${url.pathname}` }, 404);
+  }
+  return { fetchImpl, requests };
+}
+
+describe("current-main release controller retention", () => {
+  test("idempotently retains only the exact current workflow SHA", async () => {
+    const fixture = retainControllerFixture();
+    const first = await retainCurrentMainControllerEvidence({
+      env: retainControllerEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+    });
+    const second = await retainCurrentMainControllerEvidence({
+      env: retainControllerEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+    });
+    expect(first.controllerSha).toBe(headSha);
+    expect(first.releaseHead.sha).toBe(headSha);
+    expect(second.releaseHeadRelease).toEqual(first.releaseHeadRelease);
+    expect(
+      fixture.requests.filter(
+        (request) => request.method === "POST" && request.path.endsWith("/git/refs"),
+      ),
+    ).toHaveLength(1);
+    expect(
+      fixture.requests.filter(
+        (request) => request.method === "POST" && request.path.endsWith("/releases"),
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("rejects a target that differs from the workflow SHA before provider access", async () => {
+    const fixture = retainControllerFixture();
+    await expect(
+      retainCurrentMainControllerEvidence({
+        env: retainControllerEnv({ RELEASE_CONTROLLER_SHA: baseSha }),
+        fetchImpl: fixture.fetchImpl,
+      }),
+    ).rejects.toThrow("retained controller differs from workflow SHA");
+    expect(fixture.requests).toHaveLength(0);
   });
 });
 
@@ -3358,12 +3472,14 @@ describe("workflow contracts", () => {
   const releaseText = readFileSync(releaseWorkflowPath, "utf8");
   const ciText = readFileSync(ciWorkflowPath, "utf8");
   const sealText = readFileSync(sealWorkflowPath, "utf8");
+  const retainControllerText = readFileSync(retainControllerWorkflowPath, "utf8");
   const releaseSourceAdmissionText = readFileSync(releaseSourceAdmissionPath, "utf8");
   const releasePublicationAdmissionText = readFileSync(releasePublicationAdmissionPath, "utf8");
   const releaseAutomationText = readFileSync(releaseAutomationPath, "utf8");
   const release = Bun.YAML.parse(releaseText) as any;
   const ci = Bun.YAML.parse(ciText) as any;
   const seal = Bun.YAML.parse(sealText) as any;
+  const retainController = Bun.YAML.parse(retainControllerText) as any;
 
   test("uses only the scoped token for Changesets and grants narrow dispatch rights", () => {
     expect(releaseText).not.toContain("RELEASE_PAT");
@@ -3941,6 +4057,18 @@ describe("workflow contracts", () => {
         "persist-credentials": false,
       }),
     );
+  });
+
+  test("retains only exact current main as post-source workflow authority", () => {
+    expect(retainController.on.workflow_dispatch.inputs).toEqual({
+      controller_sha: expect.objectContaining({ required: true }),
+    });
+    expect(retainController.permissions).toEqual({ contents: "read" });
+    expect(retainController.jobs.retain.permissions).toEqual({ contents: "write" });
+    expect(retainController.jobs.retain.if).toBe("${{ github.ref == 'refs/heads/main' }}");
+    expect(retainControllerText).toContain("retain-release-controller");
+    expect(retainControllerText).not.toContain("pull_request_target");
+    expect(retainControllerText).not.toContain("pull-requests: write");
   });
 
   test("binds explicit source-admission and aggregate reports to the exact head", () => {


### PR DESCRIPTION
Add a narrowly scoped current-main retention workflow for the release verifier’s already-supported post-source controller path. The workflow can retain only its own exact current `main` SHA as immutable GitHub-Actions-authored authority; it cannot select another ref, change source bytes, or deploy anything. Also correct the stale Version-PR-base-only wording.\n\nThis unblocks ordinary releases when immutable source remains an older reviewed main ancestor and the trusted controller must postdate it.\n\nValidation: 84 release-automation tests pass; formatter and diff checks pass.