### PR TITLE
feat: audit principal-facing signed object-storage URL issuance (OPE-203 slice 8)

### DIFF
--- a/.changeset/signed-url-issuance-audit.md
+++ b/.changeset/signed-url-issuance-audit.md
@@ -2,4 +2,4 @@
 "@opengeni/storage": patch
 ---
 
-Every principal-facing signed object-storage URL issuance (file download/upload mints, video playback sources, document originals, the files-MCP download tool) now records a metadata-only audit fact - subject, target, expiry; never the URL or object key - before the bearer URL leaves the platform. The short default TTLs (download 300 s, upload 900 s) are pinned as the deliberate post-revocation residual window; worker- and provider-internal signed URLs keep their attempt/session-scoped authority unchanged.
+Every principal-facing signed object-storage URL issuance (file download/upload mints, video playback sources, document originals, the files-MCP download tool, workspace-capture manifest/file serves) now records a metadata-only audit fact - subject, target, expiry; never the URL or object key - before the bearer URL leaves the platform. The short default TTLs (download 300 s, upload 900 s) are pinned as the deliberate post-revocation residual window; worker- and provider-internal signed URLs keep their attempt/session-scoped authority unchanged.

--- a/.changeset/signed-url-issuance-audit.md
+++ b/.changeset/signed-url-issuance-audit.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/storage": patch
+---
+
+Every principal-facing signed object-storage URL issuance (file download/upload mints, video playback sources, document originals, the files-MCP download tool) now records a metadata-only audit fact - subject, target, expiry; never the URL or object key - before the bearer URL leaves the platform. The short default TTLs (download 300 s, upload 900 s) are pinned as the deliberate post-revocation residual window; worker- and provider-internal signed URLs keep their attempt/session-scoped authority unchanged.

--- a/apps/api/src/mcp/files.ts
+++ b/apps/api/src/mcp/files.ts
@@ -47,7 +47,7 @@ export function buildFilesMcpServer(deps: ApiRouteDeps, grant: AccessGrant): Mcp
         throw new Error(`file is ${file.status}`);
       }
       const signed = await deps.objectStorage.createGetUrl({ key: file.objectKey });
-      // OPE-203: principal-facing signed URL issuance is a metadata-only audit
+      // Principal-facing signed URL issuance is a metadata-only audit
       // fact, awaited before the URL leaves the platform. Never the URL/key.
       await recordAuditEvent(deps.db, {
         accountId: grant.accountId,

--- a/apps/api/src/mcp/files.ts
+++ b/apps/api/src/mcp/files.ts
@@ -1,5 +1,5 @@
 import type { AccessGrant } from "@opengeni/contracts";
-import { requireFileForSubject } from "@opengeni/db";
+import { recordAuditEvent, requireFileForSubject } from "@opengeni/db";
 import { hasPermission, type ApiRouteDeps } from "@opengeni/core";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
@@ -47,6 +47,21 @@ export function buildFilesMcpServer(deps: ApiRouteDeps, grant: AccessGrant): Mcp
         throw new Error(`file is ${file.status}`);
       }
       const signed = await deps.objectStorage.createGetUrl({ key: file.objectKey });
+      // OPE-203: principal-facing signed URL issuance is a metadata-only audit
+      // fact, awaited before the URL leaves the platform. Never the URL/key.
+      await recordAuditEvent(deps.db, {
+        accountId: grant.accountId,
+        workspaceId: grant.workspaceId,
+        subjectId: grant.subjectId,
+        action: "file.signed_url.issued",
+        targetType: "workspace_file",
+        targetId: file.id,
+        metadata: {
+          fileId: file.id,
+          kind: "mcp_download",
+          expiresAt: signed.expiresAt.toISOString(),
+        },
+      });
       return {
         content: [
           {

--- a/apps/api/src/routes/documents.ts
+++ b/apps/api/src/routes/documents.ts
@@ -17,6 +17,7 @@ import {
   WorkspaceMemorySearchResponse,
 } from "@opengeni/contracts";
 import {
+  recordAuditEvent,
   completeFileUpload,
   createFileUpload,
   createKnowledgeMemory,
@@ -215,6 +216,19 @@ export function registerDocumentRoutes(app: Hono, deps: ApiRouteDeps): void {
         throw new HTTPException(409, { message: `file is ${file.status}` });
       }
       const signed = await objectStorage.createGetUrl({ key: file.objectKey });
+      await recordAuditEvent(db, {
+        accountId: grant.accountId,
+        workspaceId,
+        subjectId: grant.subjectId,
+        action: "file.signed_url.issued",
+        targetType: "workspace_document",
+        targetId: c.req.param("documentId"),
+        metadata: {
+          fileId: file.id,
+          kind: "document_original",
+          expiresAt: signed.expiresAt.toISOString(),
+        },
+      });
       return c.json(
         FileDownloadUrlResponse.parse({
           url: signed.url,

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -101,7 +101,7 @@ export function registerFileRoutes(app: Hono, deps: ApiRouteDeps): void {
       objectKey,
       expiresAt: signed.expiresAt,
     });
-    // 0283-adjacent (OPE-203): every principal-facing signed URL issuance is a
+    // Every principal-facing signed URL issuance is a
     // metadata-only audit fact. Awaited before the URL leaves the platform:
     // no recorded fact, no bearer capability. Never the URL or object key.
     await recordAuditEvent(db, {

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -23,6 +23,7 @@ import {
   createFileUpload,
   getFileUpload,
   getGeneratedImageArtifact,
+  recordAuditEvent,
   getGeneratedVideoArtifact,
   getFilesForSubject,
   getRetainedFileArtifact,
@@ -99,6 +100,23 @@ export function registerFileRoutes(app: Hono, deps: ApiRouteDeps): void {
       bucket: objectStorage.bucket,
       objectKey,
       expiresAt: signed.expiresAt,
+    });
+    // 0283-adjacent (OPE-203): every principal-facing signed URL issuance is a
+    // metadata-only audit fact. Awaited before the URL leaves the platform:
+    // no recorded fact, no bearer capability. Never the URL or object key.
+    await recordAuditEvent(db, {
+      accountId: grant.accountId,
+      workspaceId,
+      subjectId: grant.subjectId,
+      action: "file.signed_upload.issued",
+      targetType: "workspace_file",
+      targetId: fileId,
+      metadata: {
+        fileId,
+        contentType: payload.contentType,
+        sizeBytes: payload.sizeBytes,
+        expiresAt: signed.expiresAt.toISOString(),
+      },
     });
     return c.json(
       CreateFileUploadResponse.parse({
@@ -324,7 +342,7 @@ export function registerFileRoutes(app: Hono, deps: ApiRouteDeps): void {
 
   app.post("/v1/workspaces/:workspaceId/artifacts/:artifactId/playback-source", async (c) => {
     const workspaceId = c.req.param("workspaceId");
-    await requireAccessGrant(c, deps, workspaceId, "files:read");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "files:read");
     if (!objectStorage) {
       throw new HTTPException(503, { message: "object storage is not configured" });
     }
@@ -341,6 +359,19 @@ export function registerFileRoutes(app: Hono, deps: ApiRouteDeps): void {
       throw new HTTPException(410, { message: "generated video bytes are unavailable" });
     }
     const signed = await objectStorage.createGetUrl({ key: file.objectKey });
+    await recordAuditEvent(db, {
+      accountId: grant.accountId,
+      workspaceId,
+      subjectId: grant.subjectId,
+      action: "file.signed_url.issued",
+      targetType: "retained_artifact",
+      targetId: artifactId,
+      metadata: {
+        artifactId,
+        kind: "video_playback",
+        expiresAt: signed.expiresAt.toISOString(),
+      },
+    });
     return c.json(
       VideoArtifactPlaybackSource.parse({
         schemaVersion: 1,
@@ -417,6 +448,19 @@ export function registerFileRoutes(app: Hono, deps: ApiRouteDeps): void {
       throw new HTTPException(409, { message: `file is ${file.status}` });
     }
     const signed = await objectStorage.createGetUrl({ key: file.objectKey });
+    await recordAuditEvent(db, {
+      accountId: grant.accountId,
+      workspaceId,
+      subjectId: grant.subjectId,
+      action: "file.signed_url.issued",
+      targetType: "workspace_file",
+      targetId: file.id,
+      metadata: {
+        fileId: file.id,
+        kind: "download",
+        expiresAt: signed.expiresAt.toISOString(),
+      },
+    });
     return c.json(
       FileDownloadUrlResponse.parse({
         url: signed.url,

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -77,6 +77,7 @@ import {
 } from "@opengeni/contracts";
 import { streamTokenDegraded } from "@opengeni/config";
 import {
+  recordAuditEvent,
   acceptSessionApprovalDecision,
   acceptSessionHumanInputResponse,
   clearSessionGoal,
@@ -3303,7 +3304,7 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
   // the live/wake path — the feature degrades to today's behavior, never worse.
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/workspace/capture", async (c) => {
     const workspaceId = c.req.param("workspaceId") ?? "";
-    await requireAccessGrant(c, deps, workspaceId, "files:read");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "files:read");
     const sessionId = c.req.param("sessionId") ?? "";
     const lookup = await sessionLatestWorkspaceCapture(db, workspaceId, sessionId);
     if (!lookup.sessionExists) {
@@ -3314,13 +3315,27 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
       return c.json({ available: false });
     }
     return c.json(
-      await serveWorkspaceCapture(lookup.capture, objectStorage, workspaceCaptureManifestCache),
+      await serveWorkspaceCapture(
+        lookup.capture,
+        objectStorage,
+        workspaceCaptureManifestCache,
+        (fact) =>
+          recordAuditEvent(db, {
+            accountId: grant.accountId,
+            workspaceId,
+            subjectId: grant.subjectId,
+            action: "file.signed_url.issued",
+            targetType: "workspace_capture",
+            targetId: sessionId,
+            metadata: { sessionId, ...fact },
+          }),
+      ),
     );
   });
 
   app.get("/v1/workspaces/:workspaceId/sessions/:sessionId/workspace/capture/file", async (c) => {
     const workspaceId = c.req.param("workspaceId") ?? "";
-    await requireAccessGrant(c, deps, workspaceId, "files:read");
+    const grant = await requireAccessGrant(c, deps, workspaceId, "files:read");
     const sessionId = c.req.param("sessionId") ?? "";
     const path = c.req.query("path");
     if (!path) {
@@ -3349,7 +3364,21 @@ export function registerSessionRoutes(app: Hono, deps: SessionRouteDeps): void {
     } else {
       row = await latestWorkspaceCapture(db, workspaceId, sessionId);
     }
-    return c.json(await serveWorkspaceCaptureFile(row, path, objectStorage));
+    return c.json(
+      await serveWorkspaceCaptureFile(row, path, objectStorage, (fact) =>
+        recordAuditEvent(db, {
+          accountId: grant.accountId,
+          workspaceId,
+          subjectId: grant.subjectId,
+          action: "file.signed_url.issued",
+          targetType: "workspace_capture",
+          targetId: sessionId,
+          // The captured PATH is workspace-file identity (like a filename),
+          // not content; the signed URL and object key are never recorded.
+          metadata: { sessionId, path, ...fact },
+        }),
+      ),
+    );
   });
 
   // ── Terminal: synchronous exec ────────────────────────────────────────────

--- a/apps/api/src/routes/workspace-capture.ts
+++ b/apps/api/src/routes/workspace-capture.ts
@@ -215,10 +215,20 @@ async function loadManifest(
  * manifest blob has been GC'd (all graceful cold-fallback states — never errors).
  * Inline manifest for ≤2MB, signed URL above.
  */
+/** Awaited before a signed capture URL is returned to the caller: the route
+ *  records the metadata-only issuance audit fact. A throwing recorder fails
+ *  the serve closed - no recorded fact, no bearer capability. */
+export type CaptureSignedUrlIssuanceRecorder = (fact: {
+  kind: "capture_manifest" | "capture_file";
+  revision: number;
+  expiresAt: string;
+}) => Promise<void>;
+
 export async function serveWorkspaceCapture(
   row: WorkspaceCaptureRow | null,
   storage: CaptureStoragePort,
   cache?: WorkspaceCaptureManifestCache,
+  onSignedUrlIssued?: CaptureSignedUrlIssuanceRecorder,
 ): Promise<GetWorkspaceCaptureResponse> {
   if (!row) {
     return { available: false };
@@ -274,6 +284,11 @@ export async function serveWorkspaceCapture(
     key: row.manifestKey,
     expiresInSeconds: CAPTURE_SIGNED_URL_TTL_SECONDS,
   });
+  await onSignedUrlIssued?.({
+    kind: "capture_manifest",
+    revision: row.revision,
+    expiresAt: signed.expiresAt.toISOString(),
+  });
   return GetWorkspaceCaptureResponse.parse({
     ...meta,
     manifest: null,
@@ -293,6 +308,7 @@ export async function serveWorkspaceCaptureFile(
   row: WorkspaceCaptureRow | null,
   path: string,
   storage: CaptureStoragePort,
+  onSignedUrlIssued?: CaptureSignedUrlIssuanceRecorder,
 ): Promise<GetWorkspaceCaptureFileResponse> {
   const loaded = row ? await loadManifest(row, storage) : null;
   if (!loaded) {
@@ -346,6 +362,11 @@ export async function serveWorkspaceCaptureFile(
   const signed = await storage.createGetUrl({
     key: file.contentRef,
     expiresInSeconds: CAPTURE_SIGNED_URL_TTL_SECONDS,
+  });
+  await onSignedUrlIssued?.({
+    kind: "capture_file",
+    revision: row!.revision,
+    expiresAt: signed.expiresAt.toISOString(),
   });
   return GetWorkspaceCaptureFileResponse.parse({
     ...base,

--- a/apps/api/test/signed-url-issuance-audit.test.ts
+++ b/apps/api/test/signed-url-issuance-audit.test.ts
@@ -1,4 +1,4 @@
-// OPE-203: every principal-facing signed object-storage URL issuance is a
+// Every principal-facing signed object-storage URL issuance is a
 // metadata-only audit fact, recorded before the bearer URL leaves the
 // platform. The fact carries the subject, target file, and expiry - never the
 // signed URL or the object key.

--- a/apps/api/test/signed-url-issuance-audit.test.ts
+++ b/apps/api/test/signed-url-issuance-audit.test.ts
@@ -1,0 +1,209 @@
+// OPE-203: every principal-facing signed object-storage URL issuance is a
+// metadata-only audit fact, recorded before the bearer URL leaves the
+// platform. The fact carries the subject, target file, and expiry - never the
+// signed URL or the object key.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { signDelegatedAccessToken, type Permission } from "@opengeni/contracts";
+import type { ApiRouteDeps } from "@opengeni/core";
+import {
+  bootstrapWorkspace,
+  completeFileUpload,
+  createDb,
+  createFileUpload,
+  type DbClient,
+} from "@opengeni/db";
+import type { ObjectStorage } from "@opengeni/storage";
+import {
+  acquireSharedTestDatabase,
+  testSettings,
+  type SharedTestDatabase,
+} from "@opengeni/testing";
+import { Hono } from "hono";
+import { registerFileRoutes } from "../src/routes/files";
+
+const SECRET = "signed-url-audit-test-secret";
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+
+let available = true;
+let shared: SharedTestDatabase | null = null;
+let client: DbClient;
+
+beforeAll(async () => {
+  shared = await acquireSharedTestDatabase("signed-url-issuance-audit");
+  if (!shared) {
+    if (requireRealDatabase) {
+      throw new Error("PostgreSQL test database unavailable while OPENGENI_REQUIRE_REAL_DB=1");
+    }
+    available = false;
+    return;
+  }
+  client = createDb(shared.appUrl, { max: 2 });
+}, 180_000);
+
+afterAll(async () => {
+  await client?.close();
+  await shared?.release();
+}, 60_000);
+
+const SIGNED_URL = "https://storage.example.test/opaque?signature=do-not-record";
+
+function storageStub(): ObjectStorage {
+  const unavailable = async (): Promise<never> => {
+    throw new Error("unexpected object-storage operation");
+  };
+  return {
+    bucket: "signed-url-test-bucket",
+    backend: "s3-compatible",
+    maxSinglePutSizeBytes: 5_000_000_000,
+    async createPutUrl() {
+      return {
+        url: SIGNED_URL,
+        requiredHeaders: { "content-type": "application/octet-stream" },
+        expiresAt: new Date(Date.now() + 900_000),
+      };
+    },
+    async createGetUrl() {
+      return { url: SIGNED_URL, expiresAt: new Date(Date.now() + 300_000) };
+    },
+    headFile: unavailable,
+    fileExists: async () => true,
+    getFileBytes: unavailable,
+    getFileRange: unavailable,
+    getObjectBytes: unavailable,
+    putObject: unavailable,
+    deleteObject: unavailable,
+  } as unknown as ObjectStorage;
+}
+
+function routeApp(): Hono {
+  const app = new Hono();
+  registerFileRoutes(app, {
+    settings: testSettings({ productAccessMode: "managed", delegationSecret: SECRET }),
+    db: client.db,
+    objectStorage: storageStub(),
+    managedAuth: null,
+  } as unknown as ApiRouteDeps);
+  return app;
+}
+
+async function workspaceFixture(permissions: Permission[]) {
+  const suffix = crypto.randomUUID();
+  const access = await bootstrapWorkspace(client.db, {
+    accountExternalSource: "test",
+    accountExternalId: `signed-url-account-${suffix}`,
+    accountName: "Signed URL audit account",
+    workspaceExternalSource: "test",
+    workspaceExternalId: `signed-url-workspace-${suffix}`,
+    workspaceName: "Signed URL audit workspace",
+    subjectId: `user:signed-url-${suffix}`,
+  });
+  const grant = access.workspaceGrants[0]!;
+  return {
+    ...grant,
+    authorization: `Bearer ${await signDelegatedAccessToken(SECRET, {
+      accountId: grant.accountId,
+      workspaceId: grant.workspaceId,
+      subjectId: grant.subjectId,
+      permissions,
+      principalKind: "human_session",
+      exp: Math.floor(Date.now() / 1000) + 3_600,
+    })}`,
+  };
+}
+
+async function readyFile(workspace: Awaited<ReturnType<typeof workspaceFixture>>) {
+  const fileId = crypto.randomUUID();
+  const objectKey = `workspaces/${workspace.workspaceId}/files/${fileId}/original/data.bin`;
+  const upload = await createFileUpload(client.db, {
+    accountId: workspace.accountId,
+    workspaceId: workspace.workspaceId,
+    fileId,
+    filename: "data.bin",
+    safeFilename: "data.bin",
+    contentType: "application/octet-stream",
+    sizeBytes: 12,
+    sha256: "a".repeat(64),
+    bucket: "signed-url-test-bucket",
+    objectKey,
+    expiresAt: new Date(Date.now() + 60_000),
+  });
+  await completeFileUpload(client.db, workspace.workspaceId, upload.uploadId);
+  return { fileId, objectKey };
+}
+
+describe("signed-URL issuance audit facts", () => {
+  test("download-url records file.signed_url.issued for the exact subject before returning the URL", async () => {
+    if (!available) return;
+    const workspace = await workspaceFixture(["files:read"]);
+    const { fileId, objectKey } = await readyFile(workspace);
+    const app = routeApp();
+
+    const response = await app.request(
+      `http://x/v1/workspaces/${workspace.workspaceId}/files/${fileId}/download-url`,
+      { method: "POST", headers: { authorization: workspace.authorization } },
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { url: string; expiresAt: string };
+    expect(body.url).toBe(SIGNED_URL);
+
+    const [audit] = await shared!.admin<
+      Array<{ subject_id: string; target_id: string; metadata: Record<string, unknown> }>
+    >`
+      select subject_id, target_id, metadata from audit_events
+      where workspace_id = ${workspace.workspaceId}
+        and action = 'file.signed_url.issued'
+      order by occurred_at desc limit 1`;
+    expect(audit).toBeDefined();
+    expect(audit!.subject_id).toBe(workspace.subjectId);
+    expect(audit!.target_id).toBe(fileId);
+    expect(audit!.metadata).toMatchObject({
+      fileId,
+      kind: "download",
+      expiresAt: body.expiresAt,
+    });
+    // The fact is metadata only: never the bearer URL, never the object key.
+    const serialized = JSON.stringify(audit!.metadata);
+    expect(serialized).not.toContain("signature=do-not-record");
+    expect(serialized).not.toContain(objectKey);
+  });
+
+  test("an upload mint records file.signed_upload.issued (size + type, never key/URL)", async () => {
+    if (!available) return;
+    const workspace = await workspaceFixture(["files:upload"]);
+    const app = routeApp();
+
+    const response = await app.request(
+      `http://x/v1/workspaces/${workspace.workspaceId}/files/uploads`,
+      {
+        method: "POST",
+        headers: { authorization: workspace.authorization, "content-type": "application/json" },
+        body: JSON.stringify({
+          filename: "notes.txt",
+          contentType: "text/plain",
+          sizeBytes: 42,
+        }),
+      },
+    );
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as { fileId: string };
+
+    const [audit] = await shared!.admin<
+      Array<{ subject_id: string; target_id: string; metadata: Record<string, unknown> }>
+    >`
+      select subject_id, target_id, metadata from audit_events
+      where workspace_id = ${workspace.workspaceId}
+        and action = 'file.signed_upload.issued'
+      order by occurred_at desc limit 1`;
+    expect(audit).toBeDefined();
+    expect(audit!.subject_id).toBe(workspace.subjectId);
+    expect(audit!.target_id).toBe(body.fileId);
+    expect(audit!.metadata).toMatchObject({
+      fileId: body.fileId,
+      contentType: "text/plain",
+      sizeBytes: 42,
+    });
+    const serialized = JSON.stringify(audit!.metadata);
+    expect(serialized).not.toContain("signature=do-not-record");
+    expect(serialized).not.toContain("/original/");
+  });
+});

--- a/apps/api/test/workspace-capture-routes.test.ts
+++ b/apps/api/test/workspace-capture-routes.test.ts
@@ -379,6 +379,50 @@ describe("serveWorkspaceCapture (manifest response)", () => {
     expect(storage.signed).toEqual([MANIFEST_KEY]);
   });
 
+  test("a signed manifest URL invokes the issuance recorder BEFORE returning; a throwing recorder fails closed", async () => {
+    const manifest = makeManifest([
+      fileEntry({ path: `src/${"x".repeat(CAPTURE_INLINE_MANIFEST_MAX_BYTES)}` }),
+    ]);
+    const big = new TextEncoder().encode(JSON.stringify(manifest));
+    const storage = fakeStorage({ [MANIFEST_KEY]: big });
+    const recorded: Array<{ kind: string; revision: number; expiresAt: string }> = [];
+    const res = await serveWorkspaceCapture(makeRow(), storage, undefined, async (fact) => {
+      recorded.push(fact);
+    });
+    expect(res.available).toBe(true);
+    expect(recorded).toEqual([
+      { kind: "capture_manifest", revision: 3, expiresAt: "2026-07-08T00:05:00.000Z" },
+    ]);
+
+    // Fail closed: no recorded fact, no bearer capability.
+    const failing = serveWorkspaceCapture(
+      makeRow(),
+      fakeStorage({ [MANIFEST_KEY]: big }),
+      undefined,
+      async () => {
+        throw new Error("audit unavailable");
+      },
+    );
+    await expect(failing).rejects.toThrow("audit unavailable");
+
+    // An inline (small) manifest mints nothing and records nothing.
+    const small = makeManifest([fileEntry({})]);
+    const inlineStorage = fakeStorage({
+      [MANIFEST_KEY]: new TextEncoder().encode(JSON.stringify(small)),
+    });
+    const inlineRecorded: unknown[] = [];
+    const inlineRes = await serveWorkspaceCapture(
+      makeRow(),
+      inlineStorage,
+      undefined,
+      async (fact) => {
+        inlineRecorded.push(fact);
+      },
+    );
+    expect(inlineRes.available).toBe(true);
+    expect(inlineRecorded).toEqual([]);
+  });
+
   test("malformed manifest above the inline cap is never signed", async () => {
     const big = new Uint8Array(CAPTURE_INLINE_MANIFEST_MAX_BYTES + 1);
     const storage = fakeStorage({ [MANIFEST_KEY]: big });
@@ -498,6 +542,43 @@ describe("serveWorkspaceCaptureFile (single after-image)", () => {
     expect(res.content).toBeNull();
     expect(res.contentUrl?.url).toContain(BIG_REF);
     expect(storage.signed).toEqual([BIG_REF]);
+  });
+
+  test("a signed file URL invokes the issuance recorder; inline content records nothing", async () => {
+    const storage = storageWith(
+      [
+        fileEntry({
+          path: "big.txt",
+          contentRef: BIG_REF,
+          sizeBytes: CAPTURE_INLINE_FILE_MAX_BYTES + 1,
+        }),
+      ],
+      { [BIG_REF]: new Uint8Array(1) },
+    );
+    const recorded: Array<{ kind: string; revision: number }> = [];
+    const res = await serveWorkspaceCaptureFile(makeRow(), "big.txt", storage, async (fact) => {
+      recorded.push(fact);
+    });
+    expect(res.contentUrl?.url).toContain(BIG_REF);
+    expect(recorded).toEqual([
+      { kind: "capture_file", revision: 3, expiresAt: "2026-07-08T00:05:00.000Z" },
+    ]);
+
+    // Inline content mints no URL and records nothing.
+    const inlineStorage = storageWith([fileEntry({})], {
+      [TEXT_REF]: new TextEncoder().encode("hello world!"),
+    });
+    const inlineRecorded: unknown[] = [];
+    const inlineRes = await serveWorkspaceCaptureFile(
+      makeRow(),
+      "src/app.ts",
+      inlineStorage,
+      async (fact) => {
+        inlineRecorded.push(fact);
+      },
+    );
+    expect(inlineRes.content).not.toBeNull();
+    expect(inlineRecorded).toEqual([]);
   });
 
   test("after-image blob missing (GC race) → marker, no throw", async () => {

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -261,19 +261,22 @@ subject and causal human from the standard context GUCs, writes a
 `variable_set.materialized` audit event with actor kind `session_attach` and
 the live session authority tuple from the exact locked session row, and an
 old image that sets no subject records the explicit `service:session`
-sentinel rather than nothing. Signed object-storage URLs are the remaining
-deliberately-bounded bearer surface: provider-native signing has no
-revocation, so revocation prevents NEW mints immediately (every mint is
-route-time authorized against live grants), every principal-facing issuance -
-file download/upload mints, video playback sources, document originals, and
-the files-MCP download tool - records a metadata-only
+sentinel rather than nothing.
+
+Signed object-storage URLs are the remaining deliberately-bounded bearer
+surface: provider-native signing has no revocation, so revocation prevents
+NEW mints immediately (every mint is route-time authorized against live
+grants), every principal-facing issuance - file download/upload mints, video
+playback sources, document originals, the files-MCP download tool, and the
+workspace-capture manifest/file serves - records a metadata-only
 `file.signed_url.issued`/`file.signed_upload.issued` audit fact (subject,
-target, expiry; never the URL or object key) before the URL leaves the
-platform, and an already-issued URL stays valid only for its short default
-TTL (download 300 s, upload 900 s - pinned in the storage tests). Worker- and
-provider-internal signed URLs (sandbox materialization, capture manifests,
-browser-session plumbing) stay on their attempt/session-scoped authority and
-are not double-recorded. `retain`
+target, expiry; never the URL or object key) awaited before the URL leaves
+the platform, and an already-issued URL stays valid only for its short
+default TTL (download 300 s, upload 900 s - pinned in the storage tests).
+Worker- and provider-internal signed URLs (sandbox materialization,
+server-side capture-manifest loads, browser-session provider plumbing) stay
+on their attempt/session-scoped authority and are not double-recorded.
+Retention policy: `retain`
 has no deletion deadline;
 `delete_after` accepts the initial 30–90 day policy window and stamps a bounded
 future deadline. Destructive expiry is an explicit operator lifecycle, not an

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -261,7 +261,19 @@ subject and causal human from the standard context GUCs, writes a
 `variable_set.materialized` audit event with actor kind `session_attach` and
 the live session authority tuple from the exact locked session row, and an
 old image that sets no subject records the explicit `service:session`
-sentinel rather than nothing. `retain`
+sentinel rather than nothing. Signed object-storage URLs are the remaining
+deliberately-bounded bearer surface: provider-native signing has no
+revocation, so revocation prevents NEW mints immediately (every mint is
+route-time authorized against live grants), every principal-facing issuance -
+file download/upload mints, video playback sources, document originals, and
+the files-MCP download tool - records a metadata-only
+`file.signed_url.issued`/`file.signed_upload.issued` audit fact (subject,
+target, expiry; never the URL or object key) before the URL leaves the
+platform, and an already-issued URL stays valid only for its short default
+TTL (download 300 s, upload 900 s - pinned in the storage tests). Worker- and
+provider-internal signed URLs (sandbox materialization, capture manifests,
+browser-session plumbing) stay on their attempt/session-scoped authority and
+are not double-recorded. `retain`
 has no deletion deadline;
 `delete_after` accepts the initial 30–90 day policy window and stamps a bounded
 future deadline. Destructive expiry is an explicit operator lifecycle, not an

--- a/packages/storage/test/storage.test.ts
+++ b/packages/storage/test/storage.test.ts
@@ -3,7 +3,7 @@ import { getSettings } from "@opengeni/config";
 import { RETAINED_OUTPUT_MAX_PAGE_BYTES, type FileAsset } from "@opengeni/contracts";
 import { createObjectStorage, DOWNLOAD_URL_TTL_SECONDS, UPLOAD_URL_TTL_SECONDS } from "../src";
 
-describe("signed-URL TTL policy (OPE-203)", () => {
+describe("signed-URL TTL policy", () => {
   test("the default TTLs are the revocation residual windows - change deliberately", () => {
     // A signed object-storage URL is a bearer capability with no provider-side
     // revocation: revocation prevents NEW mints immediately (route-time

--- a/packages/storage/test/storage.test.ts
+++ b/packages/storage/test/storage.test.ts
@@ -1,7 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import { getSettings } from "@opengeni/config";
 import { RETAINED_OUTPUT_MAX_PAGE_BYTES, type FileAsset } from "@opengeni/contracts";
-import { createObjectStorage } from "../src";
+import { createObjectStorage, DOWNLOAD_URL_TTL_SECONDS, UPLOAD_URL_TTL_SECONDS } from "../src";
+
+describe("signed-URL TTL policy (OPE-203)", () => {
+  test("the default TTLs are the revocation residual windows - change deliberately", () => {
+    // A signed object-storage URL is a bearer capability with no provider-side
+    // revocation: revocation prevents NEW mints immediately (route-time
+    // authorization + issuance audit facts), while an already-issued URL
+    // remains valid until expiry. These defaults ARE that residual exposure
+    // window, and Modal/S3/GCS sandbox materialization budgets around the
+    // download TTL - do not raise them casually, and never treat a longer TTL
+    // as a convenience fix.
+    expect(DOWNLOAD_URL_TTL_SECONDS).toBe(300);
+    expect(UPLOAD_URL_TTL_SECONDS).toBe(900);
+  });
+});
 
 describe("object storage adapters", () => {
   test("creates S3-compatible storage and signs checksum metadata once", async () => {


### PR DESCRIPTION
## OPE-203 slice 8 — signed object-storage URL issuance audit + TTL policy

Signed object-storage URLs (download 300 s, upload 900 s) are bearer capabilities: provider-native signing (S3/GCS/Azure presign) has no revocation, so an issued in-TTL URL cannot be fenced. What the program requires — and what was missing — is that revocation prevents **new** mints immediately (already true: every mint happens inside a route-time-authorized request) and that every accepted use is **recorded**. Issuance was invisible to the audit timeline.

### What changed
- **Issuance audit facts (app-layer, no migration):** every principal-facing signed-URL mint now records a metadata-only `audit_events` fact **before the URL leaves the platform** (mint → audit → respond; an audit failure fails the request closed, and the minted-but-unreturned URL dies unused at TTL):
  - `POST …/files/uploads` → `file.signed_upload.issued` (fileId, contentType, sizeBytes, expiresAt)
  - `POST …/files/:fileId/download-url` → `file.signed_url.issued` (kind `download`)
  - `POST …/artifacts/:artifactId/playback-source` → `file.signed_url.issued` (kind `video_playback`; the route now binds its grant for exact-subject attribution)
  - `POST …/documents/:documentId/original-file/download-url` → `file.signed_url.issued` (kind `document_original`)
  - files-MCP download tool → `file.signed_url.issued` (kind `mcp_download`)
  - Facts carry subject/target/expiry — **never the signed URL or the object key**.
- **Deliberately not audited:** worker- and provider-internal signed URLs (Modal/S3/GCS sandbox materialization, capture-manifest loads, browser-session provider plumbing, video staging/recording uploads) — they are attempt/session-scoped authority already, and the handoff's warning ("sandbox materialization relies on them") is honored: zero behavior change on those lanes.
- **TTL policy pinned:** `DOWNLOAD_URL_TTL_SECONDS = 300` / `UPLOAD_URL_TTL_SECONDS = 900` are asserted in `packages/storage/test/storage.test.ts` with the revocability rationale, so raising the residual window becomes a deliberate reviewed change.
- Docs: `docs/organization-tenancy.md` gains the signed-URL surface paragraph (revocation = mint refusal + issuance audit + short TTL; internal lanes stay attempt-scoped).

### Verification
- New real-PG suite `apps/api/test/signed-url-issuance-audit.test.ts` (2 tests): download-url records the exact subject/target/expiry and the metadata contains neither the bearer URL nor the object key; upload mint records size/type with the same exclusions. Both fail without the new audit writes.
- Regression green: retained-artifacts-routes (11), first-party-mcp-tool-policy (15), document-bases-default + documents-mcp-effective-scope (6), editable-artifact-workspace-files (2), storage suite (12 incl. the new TTL pin).
- Full `bun run typecheck` clean; oxfmt/oxlint clean; public-hygiene guard passes. No migration, no schema change, no ladder change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca7x2FyxheguVcdENGs8ji
