### PR TITLE
fix(runtime): keep snapshots off first-request startup

### DIFF
--- a/.changeset/quiet-startup-snapshots.md
+++ b/.changeset/quiet-startup-snapshots.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/config": patch
+"@opengeni/react": patch
+"@opengeni/worker-bundle": patch
+---
+
+Keep periodic workspace snapshots off the first provider-request critical path, clarify the overlapping runtime/model-preparation timing in the session timeline, and promote the complete signed Agent 0.1.16 bundle as the default stable installer target.

--- a/.env.example
+++ b/.env.example
@@ -96,7 +96,7 @@ OPENGENI_USAGE_LIMITS_MODE=none
 # Public agent archive and explicit stable-channel promotion pointer. The stable
 # version must already exist as an `agent-v<version>` release.
 # OPENGENI_AGENT_RELEASES_BASE_URL=https://github.com/Cloudgeni-ai/opengeni/releases
-# OPENGENI_AGENT_STABLE_VERSION=0.1.15
+# OPENGENI_AGENT_STABLE_VERSION=0.1.16
 # OPENGENI_AGENT_BETA_VERSION=
 # OPENGENI_DELEGATION_SECRET=replace-with-long-random-token-signing-secret
 # Optional JSON arrays or comma-separated names. `default` controls omitted

--- a/apps/api/test/install.test.ts
+++ b/apps/api/test/install.test.ts
@@ -117,7 +117,7 @@ describe("get.<domain> install routes", () => {
     );
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(
-      "https://github.com/Cloudgeni-ai/opengeni/releases/download/agent-v0.1.15/opengeni-agent-universal-apple-darwin",
+      "https://github.com/Cloudgeni-ai/opengeni/releases/download/agent-v0.1.16/opengeni-agent-universal-apple-darwin",
     );
   });
 
@@ -263,7 +263,7 @@ describe("get.<domain> install routes — baked binary serving", () => {
     );
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toContain(
-      "/releases/download/agent-v0.1.15/opengeni-agent-universal-apple-darwin",
+      "/releases/download/agent-v0.1.16/opengeni-agent-universal-apple-darwin",
     );
   });
 });

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -942,6 +942,22 @@ export function shouldRunTurnEndWorkspacePersistence(input: {
 }
 
 /**
+ * Periodic workspace snapshots protect work performed during a long-running
+ * turn. Before the first provider request reaches the wire there is no
+ * mid-turn agent work to protect; snapshotting platform setup at that point can
+ * instead make the request wait behind the snapshot's workspace-write fence.
+ */
+export function shouldStartPeriodicWorkspaceSnapshot(input: {
+  firstProviderRequestStarted: boolean;
+  snapshotInFlight: boolean;
+  turnEndCaptureInProgress: boolean;
+}): boolean {
+  return (
+    input.firstProviderRequestStarted && !input.snapshotInFlight && !input.turnEndCaptureInProgress
+  );
+}
+
+/**
  * Temporal cancellation is delivery/transport state, never proof that the
  * dying activity crossed its mandatory sandbox-tool fence. If that fence
  * fails, surface the fence failure instead of retaining a misleading typed
@@ -3828,6 +3844,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
     // the atomic DB throttle discard the fresher one). Interval throttling
     // itself lives in maybePersistWarmWorkspaceSnapshot / persistWarmSnapshot.
     let snapshotInFlight: Promise<void> | null = null;
+    // The heartbeat snapshot is mid-session durability, not first-request
+    // preparation. Keep it off the startup critical path until a provider
+    // request has actually reached its transport boundary.
+    let firstProviderRequestStarted = false;
     // Turn-end capture needs the lease heartbeat to keep its holder alive, but
     // must prevent that same timer from starting another periodic snapshot
     // while it reads. This gate separates those two responsibilities.
@@ -4078,7 +4098,15 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         // single-flight; throttling lives in the helper.
         const snapshotSession = setupBoxSession;
         const snapshotTurnId = turnId;
-        if (snapshotSession && snapshotTurnId && !snapshotInFlight && !turnEndCaptureInProgress) {
+        if (
+          snapshotSession &&
+          snapshotTurnId &&
+          shouldStartPeriodicWorkspaceSnapshot({
+            firstProviderRequestStarted,
+            snapshotInFlight: Boolean(snapshotInFlight),
+            turnEndCaptureInProgress,
+          })
+        ) {
           snapshotInFlight = maybePersistWarmWorkspaceSnapshot(
             { db, settings },
             {
@@ -6215,6 +6243,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
                   lastCodexRequestOpaqueArtifacts = fingerprints;
                 },
                 onModelRequestDiagnostic: (event) => {
+                  if (event.phase === "started") firstProviderRequestStarted = true;
                   if (
                     event.phase === "started" &&
                     firstModelRequestPreparationStartedAt !== null &&
@@ -6340,6 +6369,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           onModelRequestDiagnostic: (event) => {
             const requestKey = `${event.requestId}:${event.transportAttempt}`;
             if (event.phase === "started") {
+              firstProviderRequestStarted = true;
               modelRequestLifecycleMetricsFor(observability).start(
                 requestKey,
                 "supergrok-subscription",
@@ -9925,6 +9955,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           ) {
             return;
           }
+          firstProviderRequestStarted = true;
           firstModelRequestPreparationRecorded = true;
           const preparationDurationMs = Math.max(
             0,

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -107,6 +107,7 @@ import {
   shouldRecoverCompactionProviderFailure,
   shouldStartOnTurnRecording,
   shouldRunTurnEndWorkspacePersistence,
+  shouldStartPeriodicWorkspaceSnapshot,
   stableHumanInputRequestId,
   structuredToolTransportForTurn,
   toolCallProducesRetainableSessionImage,
@@ -165,6 +166,28 @@ describe("workspace structured human-input policy", () => {
 
   // No-Claim: these pure boundary tests do not prove that a deployed worker has
   // reloaded a workspace setting or that an already-pending request was repaired.
+});
+
+describe("periodic workspace snapshot admission", () => {
+  const ready = {
+    firstProviderRequestStarted: true,
+    snapshotInFlight: false,
+    turnEndCaptureInProgress: false,
+  };
+
+  test("keeps checkpoint maintenance off the first-request critical path", () => {
+    expect(
+      shouldStartPeriodicWorkspaceSnapshot({ ...ready, firstProviderRequestStarted: false }),
+    ).toBe(false);
+    expect(shouldStartPeriodicWorkspaceSnapshot(ready)).toBe(true);
+  });
+
+  test("retains the existing single-flight and turn-end gates", () => {
+    expect(shouldStartPeriodicWorkspaceSnapshot({ ...ready, snapshotInFlight: true })).toBe(false);
+    expect(shouldStartPeriodicWorkspaceSnapshot({ ...ready, turnEndCaptureInProgress: true })).toBe(
+      false,
+    );
+  });
 });
 
 describe("Connected Machine durable stream finalization", () => {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1512,7 +1512,7 @@ and the self-update channel. Route these paths (and an optional `get.<domain>`
 host) to the `api` service in the ingress.
 
 `/agent/latest/<asset>` is a compatibility route backed by the immutable
-versioned release selected by `OPENGENI_AGENT_STABLE_VERSION` (default `0.1.15`).
+versioned release selected by `OPENGENI_AGENT_STABLE_VERSION` (default `0.1.16`).
 `OPENGENI_AGENT_RELEASES_BASE_URL` selects the archive origin. Promote or roll
 back the stable channel by changing the configured version only after the
 corresponding `agent-v<version>` release and its signed assets exist; never move

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1381,6 +1381,18 @@ tool connection and model-request preparation; terminal payloads contain only a
 closed phase name and non-negative `durationMs`. In particular, lazy
 `sandbox.provision` completes as soon as the box is established, before owned
 rig/repository/file setup, so “Starting sandbox” never absorbs unrelated work.
+Model-request preparation is an enclosing span: it begins when control enters
+the runtime and ends at the provider transport boundary, so it may include the
+sandbox, rig, repository, and other setup rows whose starts appear below it.
+The timeline labels that overlap explicitly instead of presenting the parent as
+an additional sequential wait.
+
+The periodic warm-workspace snapshot is mid-session durability. The lease
+heartbeat must not start it until the first provider request has reached its
+transport boundary: before then there is no agent-produced work to protect, and
+the snapshot's workspace fence would make first-request sandbox preparation
+wait behind maintenance. Turn-end capture and the existing single-flight gate
+remain unchanged.
 
 Fleet metrics keep this drill-down identity-free:
 `opengeni_turn_worker_preparation_duration_seconds` measures the platform path,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -325,7 +325,7 @@ const SettingsSchema = z.object({
   agentStableVersion: z
     .string()
     .regex(/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u)
-    .default("0.1.15"),
+    .default("0.1.16"),
   // Optional independent beta-channel pointer. When unset, the beta update
   // manifest route is unavailable rather than silently serving stable.
   agentBetaVersion: z

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -374,7 +374,7 @@ describe("Docker workspace materialization", () => {
 
 describe("agent stable release selection", () => {
   test("uses an exact stable version and supports an explicit operator promotion", () => {
-    expect(withEnv({}, () => getSettings()).agentStableVersion).toBe("0.1.15");
+    expect(withEnv({}, () => getSettings()).agentStableVersion).toBe("0.1.16");
     expect(
       withEnv({ OPENGENI_AGENT_STABLE_VERSION: "1.4.2" }, () => getSettings()).agentStableVersion,
     ).toBe("1.4.2");

--- a/packages/react/src/timeline/platform-activity-row.tsx
+++ b/packages/react/src/timeline/platform-activity-row.tsx
@@ -66,6 +66,10 @@ export default function PlatformActivityRow({
     icon: j(BotIcon, { className: "size-3.5" }),
     iconTone: failed ? "failed" : running ? "running" : "muted",
     title: startupPhaseTitle(item.phase, item.status, item.outcome),
+    preview:
+      item.phase === "model_preparation"
+        ? "Includes overlapping sandbox, rig, repository, and runtime setup shown below."
+        : undefined,
     running,
     failed,
     cancelled: item.status === "cancelled",
@@ -174,10 +178,10 @@ const STARTUP_PHASE_TITLES: Record<
     "Tools ready",
   ],
   model_preparation: [
-    "Preparing model request",
-    "Model request preparation failed",
-    "Model request preparation interrupted",
-    "Model request ready",
+    "Preparing runtime and model request",
+    "Runtime/model preparation failed",
+    "Runtime/model preparation interrupted",
+    "Model request dispatched",
   ],
   provider_first_byte: [
     "Waiting for model",

--- a/packages/react/test/timeline-renderers.test.tsx
+++ b/packages/react/test/timeline-renderers.test.tsx
@@ -2121,6 +2121,30 @@ describe("StartupPhaseRow", () => {
 
     await r.unmount();
   });
+
+  test("makes the overlapping model-preparation parent span explicit", async () => {
+    const item: StartupPhaseItem = {
+      kind: "startup-phase",
+      id: "startup-model-1",
+      turnId: "turn-1",
+      phase: "model_preparation",
+      status: "complete",
+      startedAt: new Date(0).toISOString(),
+      completedAt: new Date(27_500).toISOString(),
+      durationMs: 27_500,
+      outcome: null,
+      occurredAt: new Date(0).toISOString(),
+    };
+    const r = await renderComponent(<ActivityRail items={[item]} />);
+    await flush();
+
+    const text = r.container.textContent ?? "";
+    expect(text).toContain("Model request dispatched");
+    expect(text).toContain("Includes overlapping sandbox, rig, repository, and runtime setup");
+    expect(text).toContain("27.5s");
+
+    await r.unmount();
+  });
 });
 
 function memoryItem(overrides: Partial<MemoryItem>): MemoryItem {

--- a/packages/testing/src/settings.ts
+++ b/packages/testing/src/settings.ts
@@ -45,7 +45,7 @@ export function testSettings(overrides: Partial<Settings> = {}): Settings {
     authAllowMetrics: false,
     publicBaseUrl: "http://127.0.0.1:3000",
     agentReleasesBaseUrl: "https://github.com/Cloudgeni-ai/opengeni/releases",
-    agentStableVersion: "0.1.15",
+    agentStableVersion: "0.1.16",
     agentBetaVersion: undefined,
     productAccessMode: "local",
     billingMode: "disabled",


### PR DESCRIPTION
Fixes the measured first-turn startup regression where the 10-second lease heartbeat could begin a Modal workspace snapshot before the first provider request, forcing lazy sandbox setup to wait behind checkpoint maintenance.

- gate periodic snapshots until the first provider transport boundary
- preserve the existing single-flight and turn-end capture gates
- make the enclosing runtime/model-preparation span explicit in the timeline
- promote the complete signed agent 0.1.16 bundle as the default stable pointer

Validated: worker tests, config tests, React timeline tests, affected package typechecks, oxlint, oxfmt, and diff check.