### PR TITLE
fix(release): preserve artifact peer compatibility

### DIFF
--- a/.changeset/tough-artifacts-project.md
+++ b/.changeset/tough-artifacts-project.md
@@ -7,4 +7,4 @@
 "@opengeni/sdk": minor
 ---
 
-Hard-cut editable spreadsheets to authored-only canonical state, deterministic formula projections, and explicit current compatibility protocols.
+Hard-cut editable spreadsheets to authored-only canonical state, deterministic formula projections, and explicit current compatibility protocols. Preserve React compatibility with artifact-tool 0.1 and 0.2 while adding the 0.3 line.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -171,7 +171,7 @@
     "@codemirror/lang-markdown": "^6.0.0",
     "@codemirror/lang-python": "^6.0.0",
     "@novnc/novnc": "^1.7.0",
-    "@opengeni/artifact-tool": ">=0.1.0 <0.3.0",
+    "@opengeni/artifact-tool": ">=0.1.0 <0.4.0",
     "@pierre/diffs": "^1.2.11",
     "@uiw/react-codemirror": "^4.23.0",
     "@xterm/addon-fit": "^0.11.0",

--- a/scripts/build-artifact-kernel-wasm-packages.test.ts
+++ b/scripts/build-artifact-kernel-wasm-packages.test.ts
@@ -153,7 +153,7 @@ test("version automation regenerates WASM identity without forcing peer dependen
     changesetConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
       ?.onlyUpdatePeerDependentsWhenOutOfRange,
   ).toBe(true);
-  expect(reactPackage.peerDependencies?.["@opengeni/artifact-tool"]).toBe(">=0.1.0 <0.3.0");
+  expect(reactPackage.peerDependencies?.["@opengeni/artifact-tool"]).toBe(">=0.1.0 <0.4.0");
   expect(
     ciWorkflow.match(
       /@changesets\/cli\/bin\.js" version\n\s+bun scripts\/build-artifact-kernel-wasm-packages\.ts --refresh-package-identities/gu,

--- a/scripts/publish-closure-guard.ts
+++ b/scripts/publish-closure-guard.ts
@@ -349,9 +349,9 @@ if (!reactOpengeniDeps.includes("@opengeni/sdk")) {
   failures.push(`@opengeni/react must keep @opengeni/sdk as a runtime dependency.`);
 }
 const reactPeerDependencies = reactPkg.peerDependencies ?? {};
-if (reactPeerDependencies["@opengeni/artifact-tool"] !== ">=0.1.0 <0.3.0") {
+if (reactPeerDependencies["@opengeni/artifact-tool"] !== ">=0.1.0 <0.4.0") {
   failures.push(
-    `@opengeni/react must expose the supported @opengeni/artifact-tool 0.1 and 0.2 lines as a compatible peer.`,
+    `@opengeni/react must expose the supported @opengeni/artifact-tool 0.1, 0.2, and 0.3 lines as a compatible peer.`,
   );
 }
 const reactPeerMetadata = (


### PR DESCRIPTION
The pending artifact-tool changeset promotes 0.2 to 0.3. Keep @opengeni/react compatible with the already-supported 0.1/0.2 lines while admitting 0.3, so Changesets produces the intended React/SDK minor release instead of an accidental major.

Focused proof: 6/6 version/identity tests pass; formatting and diff checks are clean.