### PR TITLE
chore(release): prepare product 0.23.10

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.9
-appVersion: "0.23.9"
+version: 0.23.10
+appVersion: "0.23.10"


### PR DESCRIPTION
Prepare the reviewed latest-main train for immutable OpenGeni product release 0.23.10 by advancing the Helm chart and app version together.

Focused proof: release-version contract tests 2/2 pass; diff check clean.