### PR TITLE
chore(release): prepare product 0.23.11

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.10
-appVersion: "0.23.10"
+version: 0.23.11
+appVersion: "0.23.11"


### PR DESCRIPTION
Prepare the immutable OpenGeni 0.23.11 product release from current protected main after the generated package-version merge.

This PR changes only the Helm chart and app version from 0.23.10 to 0.23.11. Current-main CI is green at the reviewed base, including the repaired Outlook control-center browser acceptance and complete workload image matrix.

Verification: `bun test scripts/release-version.test.ts` (2 pass, 0 fail) and `git diff --check`.