### PR TITLE
fix(runtime): restore connected-machine browser transport

### DIFF
--- a/.changeset/fix-connected-machine-browser-staging.md
+++ b/.changeset/fix-connected-machine-browser-staging.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/runtime": patch
+---
+
+Stage connected-machine browser-control request files inside the placement-private path accepted by the self-hosted agent, restoring browser and computer-use session creation without weakening the private filesystem boundary.

--- a/packages/runtime/src/sandbox/browser-control-client.ts
+++ b/packages/runtime/src/sandbox/browser-control-client.ts
@@ -72,7 +72,7 @@ import {
 import { parseExecResponseBanner } from "./exec-banner";
 import { buildStreamUrl, type ExposedPortEndpoint } from "./stream-port";
 
-const CLIENT_ROOT = "/tmp/opengeni-browser-control-client";
+const CLIENT_ROOT = "/tmp/opengeni-private/browser-control-client";
 export const BROWSER_CONTROL_ADMIN_TOKEN_FILE = "/tmp/opengeni-browserd/authority/admin-token";
 const COMMAND_OK = "OPENGENI_BROWSER_CONTROL_CLIENT_OK";
 const TOKEN_PATTERN = /^[A-Za-z0-9._~-]{32,2048}$/u;

--- a/packages/runtime/test/browser-control-client.test.ts
+++ b/packages/runtime/test/browser-control-client.test.ts
@@ -76,7 +76,7 @@ describe("BrowserControlClient", () => {
         return success({ browserSessionId, controllerGeneration, observation }, 201);
       },
     });
-    const placement = await localPlacement();
+    const placement = await localPlacement({ placementPrivateWrites: true });
     try {
       const client = new BrowserControlClient(placement.session, {
         adminToken,
@@ -561,7 +561,7 @@ describe("BrowserControlClient", () => {
       );
       expect(placement.finalizations).toBe(0);
       for (const path of placement.writes.map((entry) => dirname(entry.path))) {
-        if (!path.includes("opengeni-browser-control-client")) continue;
+        if (!path.includes("opengeni-private/browser-control-client")) continue;
         await expect(stat(path)).rejects.toThrow();
       }
     } finally {
@@ -1008,6 +1008,7 @@ async function localPlacement(
   options: {
     confinePrivateReads?: boolean;
     fakeControllerStartup?: boolean;
+    placementPrivateWrites?: boolean;
     streamWrites?: boolean;
   } = {},
 ): Promise<{
@@ -1085,8 +1086,22 @@ async function localPlacement(
             return typeof content === "string" ? Buffer.byteLength(content) : content.byteLength;
           },
         }),
+    ...(options.placementPrivateWrites
+      ? {
+          async writePlacementPrivate({ path, content, createParents }) {
+            if (!path.startsWith("/tmp/opengeni-private/")) {
+              throw new TypeError("placement-private path is invalid");
+            }
+            if (createParents) await mkdir(dirname(path), { recursive: true });
+            const value = typeof content === "string" ? content : new TextDecoder().decode(content);
+            fixture.writes.push({ path, content: value });
+            await writeFile(path, content, { mode: 0o600 });
+            return typeof content === "string" ? Buffer.byteLength(content) : content.byteLength;
+          },
+        }
+      : {}),
     async readFile({ path, maxBytes }) {
-      if (options.confinePrivateReads && path.includes("opengeni-browser-control-client")) {
+      if (options.confinePrivateReads && path.includes("opengeni-private/browser-control-client")) {
         throw new Error("fixture confines native reads to its workspace");
       }
       const value = await readFile(path);


### PR DESCRIPTION
Connected-machine browser and computer-use session creation staged curl request files outside the only private prefix accepted by `SelfhostedSession.writePlacementPrivate`. The request therefore failed before reaching a healthy local browserd and was masked as a generic transport failure.

This moves the staging root under `/tmp/opengeni-private/` and makes the regression fixture enforce that same boundary. No permission or private-filesystem boundary is widened.

Verification:
- `bun test packages/runtime/test/browser-control-client.test.ts packages/runtime/test/selfhosted-session.test.ts` (78 pass)
- `bun run --cwd packages/runtime typecheck`
- targeted oxfmt + `git diff --check`

The repository-wide prep was stopped after 20 minutes because parallel untouched database suites were deleting each other’s test databases; it had already produced unrelated cross-suite failures. Hosted CI remains the clean broad verdict.