### PR TITLE
style: apply oxfmt to seven files that landed unformatted on main

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -483,10 +483,7 @@ import { executeGatewayImageGeneration } from "./gateway-image-generation";
 import { executeCodexImageGeneration } from "./codex-image-generation";
 import { imageProviderBindingHash } from "./image-generation-operation";
 import { resolveImageGenerationReferences } from "./image-generation-references";
-import {
-  interruptionCallIdsFromPause,
-  settleOpenSuffixResumeIfNeeded,
-} from "./open-suffix-resume";
+import { interruptionCallIdsFromPause, settleOpenSuffixResumeIfNeeded } from "./open-suffix-resume";
 import { captureWorkspaceRevision, openFreshWorkspaceCaptureSession } from "./workspace-capture";
 import {
   ChannelAPartialMutationError,

--- a/apps/worker/src/activities/open-suffix-resume.ts
+++ b/apps/worker/src/activities/open-suffix-resume.ts
@@ -139,10 +139,7 @@ export function openSuffixPairPresentInHistory(
       sawCall = true;
       continue;
     }
-    if (
-      sawCall &&
-      (type === "function_call_result" || type === "computer_call_result")
-    ) {
+    if (sawCall && (type === "function_call_result" || type === "computer_call_result")) {
       return true;
     }
   }
@@ -338,12 +335,13 @@ export async function settleOpenSuffixResumeIfNeeded(input: {
   if (!resultItem) {
     throw new Error(`Open suffix resume for ${target.callId} has no result item`);
   }
-  const history = await getActiveSessionHistoryItems(
-    input.db,
-    input.workspaceId,
-    input.sessionId,
-  );
-  if (!openSuffixPairPresentInHistory(history.map((row) => row.item), callId)) {
+  const history = await getActiveSessionHistoryItems(input.db, input.workspaceId, input.sessionId);
+  if (
+    !openSuffixPairPresentInHistory(
+      history.map((row) => row.item),
+      callId,
+    )
+  ) {
     const historyItems = openSuffixHistoryItems(target, resultItem);
     if (historyItems.length === 0) {
       throw new Error(`Open suffix resume for ${target.callId} produced no paired history`);
@@ -372,12 +370,9 @@ export async function settleOpenSuffixResumeIfNeeded(input: {
       return { action: "cancelled" };
     }
   }
-  const remaining = (await listTurnOpenSuffixToolCalls(
-    input.db,
-    input.workspaceId,
-    input.sessionId,
-    input.turnId,
-  )).filter((row) => row.resultItem == null);
+  const remaining = (
+    await listTurnOpenSuffixToolCalls(input.db, input.workspaceId, input.sessionId, input.turnId)
+  ).filter((row) => row.resultItem == null);
   if (remaining.length === 0) {
     return { action: "continue" };
   }

--- a/apps/worker/test/open-suffix-resume.test.ts
+++ b/apps/worker/test/open-suffix-resume.test.ts
@@ -32,7 +32,7 @@ describe("open suffix resume helpers", () => {
       name: "request_human_input",
       callId: "call_human",
       status: "completed",
-      output: { type: "text", text: "{\"requestId\":\"req\"}" },
+      output: { type: "text", text: '{"requestId":"req"}' },
     };
     expect(openSuffixHistoryItems(row, resultItem)).toEqual([
       row.tiedReasoningItems[0],
@@ -161,9 +161,10 @@ describe("open suffix resume helpers", () => {
         raw: remaining[0]!.callItem,
       },
     ]);
-    expect(remainingRunStatePendingApprovalsFromSuffix(remaining).map((item) => (item as { id: string }).id)).toEqual([
-      "call_mcp",
-      "call_interact",
-    ]);
+    expect(
+      remainingRunStatePendingApprovalsFromSuffix(remaining).map(
+        (item) => (item as { id: string }).id,
+      ),
+    ).toEqual(["call_mcp", "call_interact"]);
   });
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -30269,10 +30269,7 @@ export async function recordPendingSessionToolCallResult(
   );
 }
 
-export type OpenSuffixInterruptionKind =
-  | "human_input"
-  | "approval"
-  | "interaction_intervention";
+export type OpenSuffixInterruptionKind = "human_input" | "approval" | "interaction_intervention";
 
 export type OpenSuffixPendingToolCall = {
   callId: string;

--- a/packages/db/test/migration-0287-open-suffix-pending-tool-calls.test.ts
+++ b/packages/db/test/migration-0287-open-suffix-pending-tool-calls.test.ts
@@ -1,20 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { readFile } from "node:fs/promises";
 
-const migrationUrl = new URL(
-  "../drizzle/0287_open_suffix_pending_tool_calls.sql",
-  import.meta.url,
-);
+const migrationUrl = new URL("../drizzle/0287_open_suffix_pending_tool_calls.sql", import.meta.url);
 
 describe("migration 0287 open suffix pending tool calls", () => {
   test("adds interruption kind and tied reasoning on pending receipts", async () => {
     const sql = await readFile(migrationUrl, "utf8");
     expect(sql.startsWith("-- deployment-mode: rolling\n")).toBe(true);
     expect(sql).toContain('ADD COLUMN "interruption_kind" text');
-    expect(sql).toContain('ADD COLUMN "tied_reasoning_items" jsonb NOT NULL DEFAULT \'[]\'::jsonb');
+    expect(sql).toContain("ADD COLUMN \"tied_reasoning_items\" jsonb NOT NULL DEFAULT '[]'::jsonb");
     expect(sql).toContain('ADD COLUMN "tied_reasoning_items_codec_version" integer');
     expect(sql).toContain("human_input");
     expect(sql).toContain("interaction_intervention");
-    expect(sql).toContain('jsonb_typeof("tied_reasoning_items") = \'array\'');
+    expect(sql).toContain("jsonb_typeof(\"tied_reasoning_items\") = 'array'");
   });
 });

--- a/packages/db/test/session-human-input.test.ts
+++ b/packages/db/test/session-human-input.test.ts
@@ -513,7 +513,9 @@ describe("durable structured human input", () => {
         },
       }),
     ).toEqual({ accepted: true, registered: true });
-    const reasoning = [{ type: "reasoning", id: "rs_open", content: [{ type: "input_text", text: "ask" }] }];
+    const reasoning = [
+      { type: "reasoning", id: "rs_open", content: [{ type: "input_text", text: "ask" }] },
+    ];
     expect(
       await attachOpenSuffixToPendingToolCalls(client.db, {
         accountId: grant.accountId,
@@ -566,7 +568,9 @@ describe("durable structured human input", () => {
         sessionStatus: "requires_action",
         activeTurnId: claim.turn.id,
         runState: {
-          serializedRunState: JSON.stringify({ pad: "x".repeat(APPROVAL_RUN_STATE_MAX_JSON_BYTES) }),
+          serializedRunState: JSON.stringify({
+            pad: "x".repeat(APPROVAL_RUN_STATE_MAX_JSON_BYTES),
+          }),
           pendingApprovals: [],
         },
         events: [{ type: "session.status.changed", payload: { status: "requires_action" } }],

--- a/packages/runtime/src/open-suffix.ts
+++ b/packages/runtime/src/open-suffix.ts
@@ -10,10 +10,7 @@ import {
   type OpenSuffixMember,
 } from "./history-sanitizer";
 
-export type OpenSuffixInterruptionKind =
-  | "human_input"
-  | "approval"
-  | "interaction_intervention";
+export type OpenSuffixInterruptionKind = "human_input" | "approval" | "interaction_intervention";
 
 export class OpenSuffixUnresumableError extends Error {
   readonly code = "open_suffix_unresumable";
@@ -44,9 +41,7 @@ export function protocolItemsFromGeneratedItems(generatedItems: unknown): Histor
   return items;
 }
 
-export function extractOpenSuffixFromSerializedRunState(
-  serialized: string,
-): OpenSuffixMember[] {
+export function extractOpenSuffixFromSerializedRunState(serialized: string): OpenSuffixMember[] {
   try {
     const parsed = JSON.parse(serialized) as {
       generatedItems?: unknown;


### PR DESCRIPTION
`bun run format:check` fails on current `main` for seven files, which blocks the `Source and type contracts` gate on every branch cut from it - including main's own CI, which is currently red for this reason.

Verified independently: checking each file out from `origin/main` and running `oxfmt --check` on it in isolation reproduces the failure. They landed via the open-suffix-resume work (#1596); an eighth file from the same batch was fixed separately in the meantime, so this branch was rebuilt from current main.

Pure `bun run format` output. No logic, no behavior, no test changes.

## Note on main's other failure

`main` is also failing `structured human-input HTTP surface (real PostgreSQL) > reads pending requests, rejects invalid responses, and signals one accepted settlement` with `ApprovalRunStateLimitExceededError: Approval run state is not a valid serialized JSON object`. That is a separate, genuine regression from the same PR that introduced these unformatted files, and it is **not** addressed here - this PR is formatting only. Flagging it so it is not mistaken for fallout from this change or from the capabilities work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCpgr6298bGDuRDH3SEhcA