### PR TITLE
fix(browser): reclaim profiles after machine reenrollment

### DIFF
--- a/.changeset/fix-attached-browser-reenrollment.md
+++ b/.changeset/fix-attached-browser-reenrollment.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/db": patch
+---
+
+Allow a connected Chrome profile to move from a revoked machine enrollment to its replacement enrollment.

--- a/packages/db/drizzle/0288_attached_browser_reenrollment.sql
+++ b/packages/db/drizzle/0288_attached_browser_reenrollment.sql
@@ -1,0 +1,64 @@
+-- deployment-mode: rolling
+-- A Chrome profile keeps one stable device id across OpenGeni Agent reinstalls.
+-- Re-enrollment creates a new enrollment row, so let the live enrollment reclaim
+-- that endpoint only after its previous enrollment has been revoked. Active-to-
+-- active reassignment remains forbidden.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+CREATE OR REPLACE FUNCTION opengeni_private.attached_browser_devices_update_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path FROM CURRENT
+AS $guard$
+DECLARE
+  enrollment_transfer_allowed boolean;
+BEGIN
+  IF ROW(
+    NEW.id, NEW.account_id, NEW.workspace_id, NEW.created_at
+  ) IS DISTINCT FROM ROW(
+    OLD.id, OLD.account_id, OLD.workspace_id, OLD.created_at
+  ) THEN
+    RAISE EXCEPTION 'Attached browser endpoint identity cannot change'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.enrollment_id IS DISTINCT FROM OLD.enrollment_id THEN
+    SELECT
+      EXISTS (
+        SELECT 1
+        FROM enrollments previous_enrollment
+        WHERE previous_enrollment.id = OLD.enrollment_id
+          AND previous_enrollment.account_id = OLD.account_id
+          AND previous_enrollment.workspace_id = OLD.workspace_id
+          AND previous_enrollment.status = 'revoked'
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM enrollments next_enrollment
+        WHERE next_enrollment.id = NEW.enrollment_id
+          AND next_enrollment.account_id = NEW.account_id
+          AND next_enrollment.workspace_id = NEW.workspace_id
+          AND next_enrollment.status = 'active'
+      )
+    INTO enrollment_transfer_allowed;
+
+    IF NOT coalesce(enrollment_transfer_allowed, false) THEN
+      RAISE EXCEPTION 'Attached browser endpoint enrollment can move only from revoked to active'
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF NEW.last_seen_at < OLD.last_seen_at OR NEW.updated_at < OLD.updated_at THEN
+    RAISE EXCEPTION 'Attached browser endpoint time cannot move backwards'
+      USING ERRCODE = '23514';
+  END IF;
+  IF NEW.connection_generation = OLD.connection_generation
+     AND NEW.inventory_revision < OLD.inventory_revision THEN
+    RAISE EXCEPTION 'Attached browser inventory revision cannot move backwards'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END
+$guard$;

--- a/packages/db/src/attached-browser-devices.ts
+++ b/packages/db/src/attached-browser-devices.ts
@@ -159,10 +159,25 @@ export async function reconcileAttachedBrowserInventory(
         let changed = false;
         for (const device of snapshot.devices) {
           const existing = byId.get(device.id);
+          let reclaimingRevokedEnrollment = false;
           if (existing && existing.enrollmentId !== input.enrollmentId) {
-            throw new AttachedBrowserInventoryConflictError(
-              "attached browser device id is already owned by another enrollment",
-            );
+            const [previousEnrollment] = await tx
+              .select({ status: schema.enrollments.status })
+              .from(schema.enrollments)
+              .where(
+                and(
+                  eq(schema.enrollments.id, existing.enrollmentId),
+                  eq(schema.enrollments.accountId, input.accountId),
+                  eq(schema.enrollments.workspaceId, input.workspaceId),
+                ),
+              )
+              .limit(1);
+            if (previousEnrollment?.status !== "revoked") {
+              throw new AttachedBrowserInventoryConflictError(
+                "attached browser device id is already owned by another active enrollment",
+              );
+            }
+            reclaimingRevokedEnrollment = true;
           }
           if (!existing) {
             await tx.insert(schema.attachedBrowserDevices).values({
@@ -189,10 +204,12 @@ export async function reconcileAttachedBrowserInventory(
             changed = true;
             continue;
           }
-          const materialChanged = !sameAnnouncement(existing, device);
+          const materialChanged =
+            reclaimingRevokedEnrollment || !sameAnnouncement(existing, device);
           await tx
             .update(schema.attachedBrowserDevices)
             .set({
+              enrollmentId: input.enrollmentId,
               name: device.name,
               profileLabel: device.profileLabel,
               browserName: device.browserName,

--- a/packages/db/test/attached-browser-devices.test.ts
+++ b/packages/db/test/attached-browser-devices.test.ts
@@ -9,6 +9,7 @@ import {
   getAttachedBrowserDevice,
   listAttachedBrowserDevices,
   reconcileAttachedBrowserInventory,
+  revokeEnrollment,
 } from "../src";
 
 let available = true;
@@ -236,5 +237,63 @@ describe("attached browser endpoint registry", () => {
         },
       }),
     ).rejects.toBeInstanceOf(AttachedBrowserInventoryConflictError);
+  });
+
+  test("lets a re-enrolled machine reclaim a profile from its revoked enrollment", async () => {
+    if (!available) return;
+    const scope = await fixture();
+    const deviceId = crypto.randomUUID();
+    await reconcileAttachedBrowserInventory(client.db, {
+      ...scope,
+      snapshot: {
+        bridgeGeneration: "bridge-before-reinstall",
+        revision: 1,
+        devices: [device(deviceId, "Chrome before reinstall")],
+      },
+    });
+    expect(
+      await revokeEnrollment(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        enrollmentId: scope.enrollmentId,
+      }),
+    ).toEqual({ revoked: true });
+
+    const replacement = await createEnrollment(client.db, {
+      accountId: scope.accountId,
+      workspaceId: scope.workspaceId,
+      pubkey: `ed25519:${crypto.randomUUID()}`,
+      os: "macos",
+      arch: "arm64",
+    });
+    const reclaimed = await reconcileAttachedBrowserInventory(client.db, {
+      accountId: scope.accountId,
+      workspaceId: scope.workspaceId,
+      enrollmentId: replacement.id,
+      snapshot: {
+        bridgeGeneration: "bridge-after-reinstall",
+        revision: 0,
+        devices: [
+          {
+            ...device(deviceId, "Chrome after reinstall", 0),
+            connectionGeneration: "extension-after-reinstall",
+          },
+        ],
+      },
+    });
+
+    expect(reclaimed).toMatchObject({ accepted: true, changed: true });
+    expect(
+      await getAttachedBrowserDevice(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        deviceId,
+      }),
+    ).toMatchObject({
+      enrollmentId: replacement.id,
+      name: "Chrome after reinstall",
+      state: "connected",
+      inventoryRevision: 0,
+    });
   });
 });

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -521,6 +521,11 @@ describe("release schema contract", () => {
         : "d54a4ac5b800e0c0578e7fce7d1a09cea1dbed87d3b13bf722549fea0bdc031e";
     };
     const releaseSchemaContractHash = (includesActivation: boolean): string | null => {
+      if (migrations.has("0288_attached_browser_reenrollment.sql")) {
+        return includesActivation
+          ? "7bf8653b2dd42c53ac011274a9df81d60d0545020252c2492c8dbc55f7c62cfb"
+          : "dc3a44166456c5a19a42b9d6d98a83730ff08c4322e9d830a1dbcdf517788ce6";
+      }
       if (migrations.has("0287_open_suffix_pending_tool_calls.sql")) {
         return includesActivation
           ? "af2db2108cf92384fbb58a843f6171c78afb47f20c8197f43e080451dfc4218b"
@@ -1020,7 +1025,8 @@ describe("release schema contract", () => {
         (migrations.has("0284_truthful_human_confirmed_review_reason.sql") ? 1 : 0) +
         (migrations.has("0285_organization_tenancy_inventory.sql") ? 1 : 0) +
         (migrations.has("0286_widen_task_note_expiry_ceiling.sql") ? 1 : 0) +
-        (migrations.has("0287_open_suffix_pending_tool_calls.sql") ? 1 : 0),
+        (migrations.has("0287_open_suffix_pending_tool_calls.sql") ? 1 : 0) +
+        (migrations.has("0288_attached_browser_reenrollment.sql") ? 1 : 0),
     );
     expect(contract.sha256).toBe(releaseSchemaContractHash(false) ?? currentMainContractHash);
     const latestCompatibleMigration = [
@@ -1055,94 +1061,102 @@ describe("release schema contract", () => {
       "0217_capability_definition_delete_authority.sql",
     ].find((path) => migrations.has(path));
     expect(contract.latestMigration).toBe(
-      migrations.has("0287_open_suffix_pending_tool_calls.sql")
-        ? "0287_open_suffix_pending_tool_calls.sql"
-        : migrations.has("0286_widen_task_note_expiry_ceiling.sql")
-        ? "0286_widen_task_note_expiry_ceiling.sql"
-        : migrations.has("0285_organization_tenancy_inventory.sql")
-          ? "0285_organization_tenancy_inventory.sql"
-          : migrations.has("0284_truthful_human_confirmed_review_reason.sql")
-            ? "0284_truthful_human_confirmed_review_reason.sql"
-            : migrations.has("0283_editable_spreadsheet_authored_state.sql")
-              ? "0283_editable_spreadsheet_authored_state.sql"
-              : migrations.has("0282_variable_set_session_attach_attribution.sql")
-                ? "0282_variable_set_session_attach_attribution.sql"
-                : migrations.has("0281_viewer_holder_authority_claims.sql")
-                  ? "0281_viewer_holder_authority_claims.sql"
-                  : migrations.has("0280_connection_and_variable_set_audit_attribution.sql")
-                    ? "0280_connection_and_variable_set_audit_attribution.sql"
-                    : migrations.has("0279_workspace_connection_use_lane.sql")
-                      ? "0279_workspace_connection_use_lane.sql"
-                      : migrations.has("0278_workspace_membership_removal_fencing.sql")
-                        ? "0278_workspace_membership_removal_fencing.sql"
-                        : migrations.has("0277_workspace_writer_authority_attribution.sql")
-                          ? "0277_workspace_writer_authority_attribution.sql"
-                          : migrations.has("0276_onboarding_proposal_initiating_human_guc.sql")
-                            ? "0276_onboarding_proposal_initiating_human_guc.sql"
-                            : migrations.has("0275_scheduled_connection_authority.sql")
-                              ? "0275_scheduled_connection_authority.sql"
-                              : migrations.has("0274_human_confirmed_knowledge_review.sql")
-                                ? "0274_human_confirmed_knowledge_review.sql"
-                                : migrations.has("0272_human_confirmed_learning_activation.sql")
-                                  ? "0272_human_confirmed_learning_activation.sql"
-                                  : migrations.has("0271_company_brain_retrieval_only_default.sql")
-                                    ? "0271_company_brain_retrieval_only_default.sql"
-                                    : migrations.has(
-                                          "0270_governed_learning_history_inspection.sql",
-                                        )
-                                      ? "0270_governed_learning_history_inspection.sql"
+      migrations.has("0288_attached_browser_reenrollment.sql")
+        ? "0288_attached_browser_reenrollment.sql"
+        : migrations.has("0287_open_suffix_pending_tool_calls.sql")
+          ? "0287_open_suffix_pending_tool_calls.sql"
+          : migrations.has("0286_widen_task_note_expiry_ceiling.sql")
+            ? "0286_widen_task_note_expiry_ceiling.sql"
+            : migrations.has("0285_organization_tenancy_inventory.sql")
+              ? "0285_organization_tenancy_inventory.sql"
+              : migrations.has("0284_truthful_human_confirmed_review_reason.sql")
+                ? "0284_truthful_human_confirmed_review_reason.sql"
+                : migrations.has("0283_editable_spreadsheet_authored_state.sql")
+                  ? "0283_editable_spreadsheet_authored_state.sql"
+                  : migrations.has("0282_variable_set_session_attach_attribution.sql")
+                    ? "0282_variable_set_session_attach_attribution.sql"
+                    : migrations.has("0281_viewer_holder_authority_claims.sql")
+                      ? "0281_viewer_holder_authority_claims.sql"
+                      : migrations.has("0280_connection_and_variable_set_audit_attribution.sql")
+                        ? "0280_connection_and_variable_set_audit_attribution.sql"
+                        : migrations.has("0279_workspace_connection_use_lane.sql")
+                          ? "0279_workspace_connection_use_lane.sql"
+                          : migrations.has("0278_workspace_membership_removal_fencing.sql")
+                            ? "0278_workspace_membership_removal_fencing.sql"
+                            : migrations.has("0277_workspace_writer_authority_attribution.sql")
+                              ? "0277_workspace_writer_authority_attribution.sql"
+                              : migrations.has("0276_onboarding_proposal_initiating_human_guc.sql")
+                                ? "0276_onboarding_proposal_initiating_human_guc.sql"
+                                : migrations.has("0275_scheduled_connection_authority.sql")
+                                  ? "0275_scheduled_connection_authority.sql"
+                                  : migrations.has("0274_human_confirmed_knowledge_review.sql")
+                                    ? "0274_human_confirmed_knowledge_review.sql"
+                                    : migrations.has("0272_human_confirmed_learning_activation.sql")
+                                      ? "0272_human_confirmed_learning_activation.sql"
                                       : migrations.has(
-                                            "0269_governed_learning_activation_controller.sql",
+                                            "0271_company_brain_retrieval_only_default.sql",
                                           )
-                                        ? "0269_governed_learning_activation_controller.sql"
+                                        ? "0271_company_brain_retrieval_only_default.sql"
                                         : migrations.has(
-                                              "0268_governed_learning_decision_receipts.sql",
+                                              "0270_governed_learning_history_inspection.sql",
                                             )
-                                          ? "0268_governed_learning_decision_receipts.sql"
+                                          ? "0270_governed_learning_history_inspection.sql"
                                           : migrations.has(
-                                                "0266_company_brain_context_receipt_inspection.sql",
+                                                "0269_governed_learning_activation_controller.sql",
                                               )
-                                            ? "0266_company_brain_context_receipt_inspection.sql"
+                                            ? "0269_governed_learning_activation_controller.sql"
                                             : migrations.has(
-                                                  "0261_preference_knowledge_proposal_actor_binding.sql",
+                                                  "0268_governed_learning_decision_receipts.sql",
                                                 )
-                                              ? "0261_preference_knowledge_proposal_actor_binding.sql"
+                                              ? "0268_governed_learning_decision_receipts.sql"
                                               : migrations.has(
-                                                    "0260_task_note_knowledge_promotion.sql",
+                                                    "0266_company_brain_context_receipt_inspection.sql",
                                                   )
-                                                ? "0260_task_note_knowledge_promotion.sql"
+                                                ? "0266_company_brain_context_receipt_inspection.sql"
                                                 : migrations.has(
-                                                      "0259_company_brain_context_selection_receipts.sql",
+                                                      "0261_preference_knowledge_proposal_actor_binding.sql",
                                                     )
-                                                  ? "0259_company_brain_context_selection_receipts.sql"
+                                                  ? "0261_preference_knowledge_proposal_actor_binding.sql"
                                                   : migrations.has(
-                                                        "0258_three_scope_document_knowledge_authority.sql",
+                                                        "0260_task_note_knowledge_promotion.sql",
                                                       )
-                                                    ? "0258_three_scope_document_knowledge_authority.sql"
+                                                    ? "0260_task_note_knowledge_promotion.sql"
                                                     : migrations.has(
-                                                          "0257_goal_revision_decisions_and_root_constraints.sql",
+                                                          "0259_company_brain_context_selection_receipts.sql",
                                                         )
-                                                      ? "0257_goal_revision_decisions_and_root_constraints.sql"
+                                                      ? "0259_company_brain_context_selection_receipts.sql"
                                                       : migrations.has(
-                                                            "0255_company_brain_governed_write_proposals.sql",
+                                                            "0258_three_scope_document_knowledge_authority.sql",
                                                           )
-                                                        ? "0255_company_brain_governed_write_proposals.sql"
+                                                        ? "0258_three_scope_document_knowledge_authority.sql"
                                                         : migrations.has(
-                                                              "0248_terraform_stacks_component_resolution_fence.sql",
+                                                              "0257_goal_revision_decisions_and_root_constraints.sql",
                                                             )
-                                                          ? "0248_terraform_stacks_component_resolution_fence.sql"
+                                                          ? "0257_goal_revision_decisions_and_root_constraints.sql"
                                                           : migrations.has(
-                                                                "0247_terraform_stacks_provenance_repair.sql",
+                                                                "0255_company_brain_governed_write_proposals.sql",
                                                               )
-                                                            ? "0247_terraform_stacks_provenance_repair.sql"
+                                                            ? "0255_company_brain_governed_write_proposals.sql"
                                                             : migrations.has(
-                                                                  "0263_organization_membership_lifecycle.sql",
+                                                                  "0248_terraform_stacks_component_resolution_fence.sql",
                                                                 )
-                                                              ? "0263_organization_membership_lifecycle.sql"
-                                                              : latestCompatibleMigration,
+                                                              ? "0248_terraform_stacks_component_resolution_fence.sql"
+                                                              : migrations.has(
+                                                                    "0247_terraform_stacks_provenance_repair.sql",
+                                                                  )
+                                                                ? "0247_terraform_stacks_provenance_repair.sql"
+                                                                : migrations.has(
+                                                                      "0263_organization_membership_lifecycle.sql",
+                                                                    )
+                                                                  ? "0263_organization_membership_lifecycle.sql"
+                                                                  : latestCompatibleMigration,
     );
     expect(migrations.get("0285_organization_tenancy_inventory.sql")).toMatchObject({
       sha256: "942c606d0d85064f427d2374aba9851c5c3087a49764b9f61bef76d3b8dac0f7",
+      deploymentMode: "rolling",
+    });
+    expect(migrations.get("0288_attached_browser_reenrollment.sql")).toMatchObject({
+      sha256: "a225b10590a065397ee35c810e6fb962e451b1745677ac4a0212431e60f2b3b6",
       deploymentMode: "rolling",
     });
     expect(migrations.get("0283_editable_spreadsheet_authored_state.sql")).toMatchObject({


### PR DESCRIPTION
## What changed

- allow a stable attached-Chrome device id to transfer only from a revoked machine enrollment to its active replacement in the same account/workspace
- retain the active-to-active ownership conflict fence
- enforce the same transition in PostgreSQL
- add regression coverage and migration schema-contract coverage

## Proof

- private Jorgebot source build and Helm revision 38 deployed from the candidate
- existing Chrome profile automatically moved from revoked enrollment to active enrollment
- Browser dock opened the live Chrome profile and listed all 9 tabs
- Mac desktop/computer use remained connected
- focused DB tests: 3 pass
- schema contract: 6 pass
- DB typecheck, lint, formatting, migration ordinal check, diff check: pass

No public production deployment is part of this PR.