### PR TITLE
Stop attached Chrome reconnects from leaking ScreenCaptureKit helpers

### DIFF
--- a/.changeset/attached-chrome-generation-terminalize.md
+++ b/.changeset/attached-chrome-generation-terminalize.md
@@ -1,0 +1,7 @@
+---
+"@opengeni/db": patch
+"@opengeni/react": patch
+"@opengeni/browserd": patch
+---
+
+Terminalize attached Chrome Browser/Computer sessions when the device connection generation changes, stop Reconnect from retrying the stale placement, and physically stop ScreenCaptureKit helpers so replayd cannot accumulate.

--- a/apps/api/src/routes/browser-sessions.ts
+++ b/apps/api/src/routes/browser-sessions.ts
@@ -2636,7 +2636,11 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
       if (!enrollment || enrollment.status !== "active" || !enrollment.connectionInstanceId) {
         throw new BrowserSessionStateError("Attached browser machine is unavailable");
       }
-      assertPlacementInstance(expectedPlacementInstanceId, device.connectionGeneration);
+      const placementInstanceId = attachedEndPlacementInstanceId(
+        operation,
+        expectedPlacementInstanceId,
+        device.connectionGeneration,
+      );
       const built = await buildSelfhostedBackendSession({
         workspaceId: sourceSession.workspaceId,
         agentId: device.enrollmentId,
@@ -2669,13 +2673,13 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
       return await callback({
         placement: expectedPlacement,
         controllerHostSandboxGroupId: null,
-        placementInstanceId: device.connectionGeneration,
+        placementInstanceId,
         session: built.session as unknown as BrowserControlPlacementSession,
         lease: null,
         transport: {
           kind: "attached_chrome",
           deviceId: device.id,
-          connectionGeneration: device.connectionGeneration,
+          connectionGeneration: placementInstanceId,
           browserName: device.browserName,
           browserVersion: device.browserVersion,
         },
@@ -4024,6 +4028,20 @@ function assertPlacementInstance(expected: string | null, actual: string): void 
   if (expected !== null && expected !== actual) {
     throw new BrowserSessionStateError("BrowserSession placement instance changed");
   }
+}
+
+/** End keeps the original controller token fence so a later Chrome generation
+ *  can still dispose the stale browserd session. */
+function attachedEndPlacementInstanceId(
+  operation: ChannelAOperation,
+  expectedPlacementInstanceId: string | null,
+  liveGeneration: string,
+): string {
+  if (operation === "browser.end" && expectedPlacementInstanceId) {
+    return expectedPlacementInstanceId;
+  }
+  assertPlacementInstance(expectedPlacementInstanceId, liveGeneration);
+  return liveGeneration;
 }
 
 function isTerminalOperation(state: string): boolean {

--- a/apps/api/src/routes/computer-sessions.ts
+++ b/apps/api/src/routes/computer-sessions.ts
@@ -827,7 +827,11 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
       if (operation !== "computer.end") {
         assertConnectedMachineComputerAccess(enrollment, operation);
       }
-      assertPlacementInstance(expectedPlacementInstanceId, device.connectionGeneration);
+      const placementInstanceId = attachedEndPlacementInstanceId(
+        operation,
+        expectedPlacementInstanceId,
+        device.connectionGeneration,
+      );
       const built = await buildSelfhostedBackendSession({
         workspaceId: sourceSession.workspaceId,
         agentId: device.enrollmentId,
@@ -856,7 +860,7 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
       waitSignal.throwIfAborted();
       return await callback({
         placement: expectedPlacement,
-        placementInstanceId: device.connectionGeneration,
+        placementInstanceId,
         session: built.session as unknown as BrowserControlPlacementSession,
         lease: null,
       });
@@ -1570,6 +1574,20 @@ function assertPlacementInstance(expected: string | null, actual: string): void 
   if (expected !== null && expected !== actual) {
     throw new ComputerSessionStateError("ComputerSession placement instance changed");
   }
+}
+
+/** End must still reach the live agent with the session's original token
+ *  fence. A later Chrome generation must not block ScreenCaptureKit teardown. */
+function attachedEndPlacementInstanceId(
+  operation: ChannelAOperation,
+  expectedPlacementInstanceId: string | null,
+  liveGeneration: string,
+): string {
+  if (operation === "computer.end" && expectedPlacementInstanceId) {
+    return expectedPlacementInstanceId;
+  }
+  assertPlacementInstance(expectedPlacementInstanceId, liveGeneration);
+  return liveGeneration;
 }
 
 function assertConnectedMachineComputerAccess(

--- a/apps/api/test/browser-session-routes.test.ts
+++ b/apps/api/test/browser-session-routes.test.ts
@@ -117,6 +117,16 @@ describe("BrowserSession route discipline", () => {
     expect(create).toContain('identity.status !== "active"');
   });
 
+  test("routes attached-device BrowserSession end through the original placement fence", async () => {
+    const source = await readFile(routeUrl, "utf8");
+    const placement = source.slice(
+      source.indexOf("async function withBrowserPlacement"),
+      source.indexOf("async function withActiveBrowserController"),
+    );
+    expect(placement).toContain("attachedEndPlacementInstanceId(");
+    expect(source).toContain('operation === "browser.end" && expectedPlacementInstanceId');
+  });
+
   test("admits every controller call through the durable generation fence", async () => {
     const source = await readFile(routeUrl, "utf8");
     expect(source).toContain("touchBrowserSessionController(deps.db");

--- a/apps/api/test/computer-session-routes.test.ts
+++ b/apps/api/test/computer-session-routes.test.ts
@@ -96,10 +96,9 @@ describe("ComputerSession route discipline", () => {
     expect(placement).toContain("enrollment.connectionInstanceId");
     expect(placement).toContain("buildSelfhostedBackendSession({");
     expect(placement).toContain("new NatsControlRpc(");
-    expect(placement).toMatch(
-      /assertPlacementInstance\(\s*expectedPlacementInstanceId,\s*device\.connectionGeneration,?\s*\)/u,
-    );
-    expect(placement).toContain("placementInstanceId: device.connectionGeneration");
+    expect(placement).toContain("attachedEndPlacementInstanceId(");
+    expect(placement).toContain("device.connectionGeneration");
+    expect(source).toContain('operation === "computer.end" && expectedPlacementInstanceId');
   });
 
   test("dispatches lifecycle authority before physical mutation and preserves unknown outcomes", async () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -920,9 +920,20 @@ container DNS identity plus its original port. A public browser must never recei
 that internal address: Docker frame and RFB attachments cross the API's bounded
 bidirectional WebSocket proxy with a short-lived encrypted, origin-bound grant.
 Modal retains its provider-scoped direct tunnel; Connected Machines retain their
-native relay. Canonical: `packages/runtime/src/sandbox/index.ts`,
-`apps/api/src/interaction-frame-proxy.ts`, and the Browser/Computer attachment
-routes.
+native relay. Attached Chrome freezes `connectionGeneration` as
+`placementInstanceId`. A later inventory announcement with a new generation
+atomically marks those BrowserSessions/ComputerSessions `lost` with
+`controller_transition_expired` and never rebinds the old controller token.
+In-flight `/end` stays `ending` so physical teardown can finish. Heartbeats
+validate the live device generation before pulsing. `/end` still reaches the
+live agent with the original token fence so browserd can `stopCapture` and
+kill `opengeni-computer-native`; a later generation must not leave
+ScreenCaptureKit/`replayd` streams running. Shared-seat (macOS attached)
+browserd serializes create-and-displace so two helpers cannot start on the
+same seat. Replacement is a new BrowserSession via **Browser → New browser →
+Connected Chrome**, not Reconnect. Canonical: `packages/runtime/src/sandbox/index.ts`,
+`apps/api/src/interaction-frame-proxy.ts`, `packages/db/src/attached-browser-devices.ts`,
+and the Browser/Computer attachment routes.
 
 Scheduled incident-telemetry tasks use an explicit `incident_telemetry`
 execution class plus a contracts-owned preflight declaration. Core admission
@@ -1377,6 +1388,7 @@ A typed `DeploymentContract` (`@opengeni/deployment`) turns an abstract profile 
 | SSE / streaming semantics                                                   | `apps/api/src/http/sse.ts`, `packages/sdk/src/stream.ts`                                                                                                                                                                                                    | —                                                                                  |
 | Sandbox backends / the registry                                             | `packages/runtime/src/sandbox/providers/index.ts`, `packages/contracts` (the enum)                                                                                                                                                                          | [`../AGENTS.md`](../AGENTS.md) Sandbox Notes                                       |
 | Selfhosted / BYO-compute control plane                                      | `packages/runtime/src/sandbox/selfhosted/`, `agent/proto/opengeni_agent.proto`                                                                                                                                                                              | [`connected-machines.md`](connected-machines.md)                                  |
+| Attached Chrome inventory / BrowserSession+ComputerSession generation fence | `packages/db/src/attached-browser-devices.ts`, `packages/db/src/browser-sessions.ts`, `packages/db/src/computer-sessions.ts`, `apps/api/src/routes/browser-sessions.ts`, `apps/api/src/routes/computer-sessions.ts`, `packages/browserd/src/computer-supervisor.ts`, `packages/browserd/src/computer-driver.ts` | [`connected-machines.md`](connected-machines.md) |
 | The relay / pixel+terminal data plane                                       | `agent/crates/opengeni-relay/`, `apps/api/src/sandbox/viewer.ts`                                                                                                                                                                                            | [`connected-machines.md`](connected-machines.md)                                  |
 | Sandbox lease / reaper                                                      | `apps/worker/src/activities/sandbox-lease.ts`, `apps/worker/src/sandbox-resume.ts`                                                                                                                                                                          | —                                                                                  |
 | The agent loop / model routing / instructions                               | `packages/runtime/src/index.ts`; provider facade and cohesive leaves in `packages/runtime/src/model-provider*.ts`; final model-wire shaping in `packages/runtime/src/model-input.ts`; stream/usage/interruption normalization in `packages/runtime/src/run-events.ts`                                      | [`model-providers.md`](model-providers.md)                                         |

--- a/docs/connected-machines.md
+++ b/docs/connected-machines.md
@@ -77,6 +77,20 @@ ScreenCaptureKit/CGEvent desktop feature as the release build. This is the suppo
 an agent binary next to arbitrary helpers can create a protocol-skewed runtime
 that production installation and managed updates deliberately forbid.
 
+Attached Chrome profiles are a separate physical placement. Inventory reports a
+`connectionGeneration` that becomes the BrowserSession/ComputerSession
+`placementInstanceId`. When that generation changes, OpenGeni marks the exact
+device's still-live sessions `lost` with `controller_transition_expired` and
+never rebinds the old controller token. In-flight `/end` (`ending`) is left
+to finish physical teardown instead of being rewritten to `lost`. Heartbeats
+must prove the live generation before they pulse. `/end` still talks to the
+live agent with that original fence so the Mac helper can `stopCapture` and
+exit; otherwise ScreenCaptureKit leaves `replayd` and multiple
+`opengeni-computer-native` processes running. A new shared-seat
+ComputerSession displaces the previous helper. Open a replacement through
+**Browser → New browser → Connected Chrome**; generic New desktop does not
+infer the Chrome device.
+
 Machine availability is also not a turn-admission dependency. A text-only turn
 can start while the selected machine is offline. If the model invokes a machine
 operation, the typed offline/timeout result returns to the model in-band so it

--- a/packages/browserd/src/computer-driver.ts
+++ b/packages/browserd/src/computer-driver.ts
@@ -429,6 +429,22 @@ export class NativeComputerDriver implements ComputerInteractionDriver {
     return group.sourceClient;
   }
 
+  private async stopCapturesOnClient(client: ComputerNativeTransport): Promise<void> {
+    await Promise.allSettled(
+      [...this.frameStreams.entries()].map(async ([targetId, group]) => {
+        await group.sourceTransition.catch(() => undefined);
+        if (group.sourceClient !== client) return;
+        try {
+          await client.stopCapture(targetId);
+        } catch {
+          // Closing/replacing the helper is the remaining teardown fence.
+        }
+        group.sourceClient = null;
+        group.sourceKey = null;
+      }),
+    );
+  }
+
   private beginStopFrameGroup(targetId: string, group: TargetFrameGroup): void {
     if (group.stopping) return;
     group.stopping = true;
@@ -500,6 +516,9 @@ export class NativeComputerDriver implements ComputerInteractionDriver {
       throw new Error("native computer helper recovery is unavailable");
     }
     const recovery = (async () => {
+      // EOF/SIGKILL without StopCapture leaves ScreenCaptureKit streams in
+      // replayd. Stop every live producer on this incarnation first.
+      await this.stopCapturesOnClient(failedClient);
       await failedClient.close().catch(() => undefined);
       const replacement = await this.clientFactory!();
       if (

--- a/packages/browserd/src/computer-supervisor.ts
+++ b/packages/browserd/src/computer-supervisor.ts
@@ -73,6 +73,9 @@ export type ComputerSupervisorOptions = {
   rootDirectory: string;
   nativeBinaryPath?: string;
   maxSessions?: number;
+  /** Shared physical seat (macOS attached desktop). A new ComputerSession
+   *  displaces every other helper so ScreenCaptureKit cannot accumulate. */
+  displaceExistingSessions?: boolean;
   environmentAllocator?: ComputerEnvironmentAllocator;
   baseEnvironment?: NodeJS.ProcessEnv;
   createDriver?: (context: ComputerSupervisorDriverContext) => Promise<ComputerSupervisorDriver>;
@@ -97,11 +100,13 @@ export class ComputerSupervisor {
   private readonly createDriver: (
     context: ComputerSupervisorDriverContext,
   ) => Promise<ComputerSupervisorDriver>;
+  private readonly displaceExistingSessions: boolean;
   private readonly environmentAllocator: ComputerEnvironmentAllocator;
   private readonly baseEnvironment: NodeJS.ProcessEnv;
   private readonly sessions = new Map<string, Runtime>();
   private readonly creating = new Map<string, Promise<Runtime>>();
   private readonly ending = new Map<string, Promise<void>>();
+  private displaceGate: Promise<void> = Promise.resolve();
   private closed = false;
 
   private constructor(options: ComputerSupervisorOptions) {
@@ -110,6 +115,7 @@ export class ComputerSupervisor {
       options.maxSessions ?? DEFAULT_MAX_SESSIONS,
       "maxSessions",
     );
+    this.displaceExistingSessions = options.displaceExistingSessions === true;
     this.environmentAllocator =
       options.environmentAllocator ?? new ExistingComputerEnvironmentAllocator();
     this.baseEnvironment = { ...(options.baseEnvironment ?? process.env) };
@@ -161,31 +167,26 @@ export class ComputerSupervisor {
       this.assertSameBinding(runtime, options);
       return await this.describe(runtime);
     }
-    if (this.sessions.size + this.creating.size >= this.maxSessions) {
-      throw new InteractionControllerError(
-        "resource_unavailable",
-        "computer supervisor session capacity is exhausted",
-        true,
-      );
+    if (this.displaceExistingSessions) {
+      const displaced = this.displaceGate.then(async () => {
+        const current = this.sessions.get(options.computerSessionId);
+        if (current) {
+          this.assertSameBinding(current, options);
+          return await this.describe(current);
+        }
+        const currentPending = this.creating.get(options.computerSessionId);
+        if (currentPending) {
+          const runtime = await currentPending;
+          this.assertSameBinding(runtime, options);
+          return await this.describe(runtime);
+        }
+        await this.displaceOtherSessions(options.computerSessionId);
+        return await this.installSession(options);
+      });
+      this.displaceGate = displaced.then(() => undefined).catch(() => undefined);
+      return await displaced;
     }
-    const creation = this.buildRuntime(options);
-    this.creating.set(options.computerSessionId, creation);
-    try {
-      const runtime = await creation;
-      if (this.closed) {
-        await this.disposeRuntime(runtime, false);
-        throw new InteractionControllerError(
-          "resource_unavailable",
-          "computer supervisor is closed",
-        );
-      }
-      this.sessions.set(options.computerSessionId, runtime);
-      return await this.describe(runtime);
-    } finally {
-      if (this.creating.get(options.computerSessionId) === creation) {
-        this.creating.delete(options.computerSessionId);
-      }
-    }
+    return await this.installSession(options);
   }
 
   listSessions(): Array<
@@ -315,6 +316,54 @@ export class ComputerSupervisor {
     );
     if (failures.length > 0) {
       throw new AggregateError(failures, "computer supervisor shutdown failed");
+    }
+  }
+
+  private async installSession(
+    options: ValidatedSessionOptions,
+  ): Promise<ComputerSupervisorSession> {
+    if (this.sessions.size + this.creating.size >= this.maxSessions) {
+      throw new InteractionControllerError(
+        "resource_unavailable",
+        "computer supervisor session capacity is exhausted",
+        true,
+      );
+    }
+    const creation = this.buildRuntime(options);
+    this.creating.set(options.computerSessionId, creation);
+    try {
+      const runtime = await creation;
+      if (this.closed) {
+        await this.disposeRuntime(runtime, false);
+        throw new InteractionControllerError(
+          "resource_unavailable",
+          "computer supervisor is closed",
+        );
+      }
+      this.sessions.set(options.computerSessionId, runtime);
+      return await this.describe(runtime);
+    } finally {
+      if (this.creating.get(options.computerSessionId) === creation) {
+        this.creating.delete(options.computerSessionId);
+      }
+    }
+  }
+
+  private async displaceOtherSessions(computerSessionId: string): Promise<void> {
+    for (const [id, pending] of this.creating) {
+      if (id === computerSessionId) continue;
+      await pending.catch(() => undefined);
+    }
+    const others = [...this.sessions.values()].filter(
+      (runtime) =>
+        runtime.lifecycle === "active" && runtime.options.computerSessionId !== computerSessionId,
+    );
+    for (const runtime of others) {
+      await this.endSession(binding(runtime));
+    }
+    for (const [id, ending] of this.ending) {
+      if (id === computerSessionId) continue;
+      await ending.catch(() => undefined);
     }
   }
 

--- a/packages/browserd/src/main.ts
+++ b/packages/browserd/src/main.ts
@@ -43,6 +43,7 @@ export async function runBrowserd(environment: NodeJS.ProcessEnv = process.env):
         rootDirectory: config.rootDirectory,
         nativeBinaryPath: computerNativeBinaryPath,
         maxSessions: config.maxComputerSessions,
+        displaceExistingSessions: config.computerEnvironmentMode === "existing",
         environmentAllocator:
           config.computerEnvironmentMode === "isolated_linux"
             ? new LinuxVirtualComputerEnvironmentAllocator()

--- a/packages/browserd/test/computer-driver.test.ts
+++ b/packages/browserd/test/computer-driver.test.ts
@@ -218,6 +218,38 @@ describe("NativeComputerDriver", () => {
     }
   });
 
+  test("stops live capture on a poisoned helper before opening a replacement", async () => {
+    const poisoned = new FixtureNativeTransport();
+    poisoned.captureError = new NativeComputerError(
+      "timeout",
+      "ScreenCaptureKit frame wait timed out",
+      true,
+      false,
+    );
+    const replacement = new FixtureNativeTransport();
+    const driver = new NativeComputerDriver({
+      computerSessionId,
+      controllerGeneration,
+      client: poisoned,
+      clientFactory: async () => replacement,
+    });
+    try {
+      const frames = await driver.subscribeFrames("window-1");
+      await expect(frames[Symbol.asyncIterator]().next()).resolves.toMatchObject({
+        done: false,
+        value: { frameId: "frame-2", sequence: 1 },
+      });
+      await frames.close();
+      expect(poisoned.stoppedCaptures).toBeGreaterThanOrEqual(1);
+      expect(poisoned.closed).toBe(true);
+      expect(poisoned.teardown[0]).toBe("stop");
+      expect(poisoned.teardown.at(-1)).toBe("close");
+      expect(poisoned.teardown.indexOf("stop")).toBeLessThan(poisoned.teardown.indexOf("close"));
+    } finally {
+      await driver.close();
+    }
+  });
+
   test("replaces a poisoned native helper once for safe target reads", async () => {
     const poisoned = new FixtureNativeTransport();
     poisoned.targetsError = new Error("native computer helper returned a malformed response");
@@ -303,11 +335,13 @@ class FixtureNativeTransport implements ComputerNativeTransport {
   dispatched: NativeComputerActionCommand | null = null;
   validateError: Error | null = null;
   startCaptureError: Error | null = null;
+  captureError: Error | null = null;
   targetsError: Error | null = null;
   dispatchObservation: ReturnType<typeof observation> | null = observation("observation-2");
   dispatchError: Error | null = null;
   closed = false;
   stoppedCaptures = 0;
+  teardown: Array<"stop" | "close"> = [];
   startedCaptureOptions: NativeComputerCaptureOptions[] = [];
   observationFrameId: string | null = "frame-1";
   captures = 0;
@@ -326,6 +360,7 @@ class FixtureNativeTransport implements ComputerNativeTransport {
   }
 
   async capture(_targetId: string, options?: NativeComputerCaptureOptions) {
+    if (this.captureError) throw this.captureError;
     this.captures += 1;
     const width = Math.min(20, options?.maxWidth ?? 20);
     const height = Math.min(10, Math.max(1, Math.floor((width / 20) * 10)));
@@ -349,6 +384,7 @@ class FixtureNativeTransport implements ComputerNativeTransport {
 
   async stopCapture(): Promise<void> {
     this.stoppedCaptures += 1;
+    this.teardown.push("stop");
   }
 
   async clipboard() {
@@ -367,6 +403,7 @@ class FixtureNativeTransport implements ComputerNativeTransport {
   }
 
   async close(): Promise<void> {
+    this.teardown.push("close");
     this.closed = true;
   }
 }

--- a/packages/browserd/test/computer-supervisor.test.ts
+++ b/packages/browserd/test/computer-supervisor.test.ts
@@ -84,6 +84,106 @@ describe("ComputerSupervisor", () => {
     }
   });
 
+  test("displaces other shared-seat helpers when a new ComputerSession is created", async () => {
+    const rootDirectory = await mkdtemp("/tmp/og-computer-displace-");
+    const drivers: FixtureComputerDriver[] = [];
+    const supervisor = await ComputerSupervisor.open({
+      rootDirectory,
+      displaceExistingSessions: true,
+      environmentAllocator: fixtureEnvironmentAllocator(),
+      createDriver: async (context) => {
+        const driver = new FixtureComputerDriver(
+          context.computerSessionId,
+          context.controllerGeneration,
+        );
+        drivers.push(driver);
+        return driver;
+      },
+    });
+    try {
+      await supervisor.createSession(options());
+      await supervisor.createSession({
+        ...options(),
+        computerSessionId: "33333333-3333-4333-8333-333333333333",
+        controllerGeneration: "controller-2",
+      });
+      expect(supervisor.listSessions()).toEqual([
+        expect.objectContaining({
+          computerSessionId: "33333333-3333-4333-8333-333333333333",
+        }),
+      ]);
+      expect(drivers[0]?.closed).toBe(true);
+      expect(drivers[1]?.closed).toBe(false);
+    } finally {
+      await supervisor.close();
+      await rm(rootDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("serializes concurrent shared-seat creates so only one helper survives", async () => {
+    const rootDirectory = await mkdtemp("/tmp/og-computer-displace-race-");
+    const drivers: FixtureComputerDriver[] = [];
+    const supervisor = await ComputerSupervisor.open({
+      rootDirectory,
+      displaceExistingSessions: true,
+      environmentAllocator: fixtureEnvironmentAllocator(),
+      createDriver: async (context) => {
+        const driver = new FixtureComputerDriver(
+          context.computerSessionId,
+          context.controllerGeneration,
+        );
+        drivers.push(driver);
+        return driver;
+      },
+    });
+    try {
+      await Promise.all([
+        supervisor.createSession(options()),
+        supervisor.createSession({
+          ...options(),
+          computerSessionId: "33333333-3333-4333-8333-333333333333",
+          controllerGeneration: "controller-2",
+        }),
+      ]);
+      expect(supervisor.listSessions()).toHaveLength(1);
+      expect(drivers.filter((driver) => !driver.closed)).toHaveLength(1);
+      expect(drivers.filter((driver) => driver.closed)).toHaveLength(1);
+    } finally {
+      await supervisor.close();
+      await rm(rootDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps isolated-seat ComputerSessions side by side", async () => {
+    const rootDirectory = await mkdtemp("/tmp/og-computer-isolated-");
+    const drivers: FixtureComputerDriver[] = [];
+    const supervisor = await ComputerSupervisor.open({
+      rootDirectory,
+      environmentAllocator: fixtureEnvironmentAllocator(),
+      createDriver: async (context) => {
+        const driver = new FixtureComputerDriver(
+          context.computerSessionId,
+          context.controllerGeneration,
+        );
+        drivers.push(driver);
+        return driver;
+      },
+    });
+    try {
+      await supervisor.createSession(options());
+      await supervisor.createSession({
+        ...options(),
+        computerSessionId: "33333333-3333-4333-8333-333333333333",
+        controllerGeneration: "controller-2",
+      });
+      expect(supervisor.listSessions()).toHaveLength(2);
+      expect(drivers.every((driver) => !driver.closed)).toBe(true);
+    } finally {
+      await supervisor.close();
+      await rm(rootDirectory, { recursive: true, force: true });
+    }
+  });
+
   test("enforces placement capacity across independent ComputerSessions", async () => {
     const rootDirectory = await mkdtemp("/tmp/og-computer-capacity-");
     const supervisor = await ComputerSupervisor.open({
@@ -126,6 +226,7 @@ class FixtureComputerDriver implements ComputerSupervisorDriver {
   };
   dispatches = 0;
   listTargetCalls = 0;
+  closed = false;
 
   constructor(
     private readonly sessionId: string,
@@ -168,7 +269,9 @@ class FixtureComputerDriver implements ComputerSupervisorDriver {
     throw new Error("unused");
   }
 
-  async close(): Promise<void> {}
+  async close(): Promise<void> {
+    this.closed = true;
+  }
 
   private targetValue(): ComputerTarget {
     return {

--- a/packages/db/src/attached-browser-devices.ts
+++ b/packages/db/src/attached-browser-devices.ts
@@ -8,13 +8,24 @@ import {
   type AttachedBrowserDeviceListResponse as AttachedBrowserDeviceListResponseValue,
   type AttachedBrowserInventorySnapshot as AttachedBrowserInventorySnapshotValue,
 } from "@opengeni/contracts";
-import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { type Database, withRlsContext } from "./database";
 import {
   advanceWorkspaceInteractionRevision,
   readWorkspaceInteractionRevision,
 } from "./interaction-revisions";
 import * as schema from "./schema";
+
+const ATTACHED_DEVICE_LIVE_LIFECYCLES = [
+  "starting",
+  "active",
+  "suspending",
+  "restoring",
+] as const;
+// `ending` stays off this list so an in-flight `/end` can finish physical
+// teardown (`stopCapture` + helper exit) after Chrome reconnects.
+
+const CONTROLLER_TRANSITION_EXPIRED = "controller_transition_expired";
 
 type DeviceRow = typeof schema.attachedBrowserDevices.$inferSelect;
 
@@ -156,6 +167,7 @@ export async function reconcileAttachedBrowserInventory(
           .where(eq(schema.attachedBrowserDevices.workspaceId, input.workspaceId))
           .for("update");
         const byId = new Map(rows.map((row) => [row.id, row]));
+        const generationChangedDeviceIds = new Set<string>();
         let changed = false;
         for (const device of snapshot.devices) {
           const existing = byId.get(device.id);
@@ -204,6 +216,9 @@ export async function reconcileAttachedBrowserInventory(
             changed = true;
             continue;
           }
+          if (existing.connectionGeneration !== device.connectionGeneration) {
+            generationChangedDeviceIds.add(device.id);
+          }
           const materialChanged =
             reclaimingRevokedEnrollment || !sameAnnouncement(existing, device);
           await tx
@@ -232,6 +247,15 @@ export async function reconcileAttachedBrowserInventory(
               ),
             );
           changed ||= materialChanged;
+        }
+
+        if (
+          await terminalizeStaleAttachedDeviceSessions(tx, {
+            workspaceId: input.workspaceId,
+            deviceIds: [...generationChangedDeviceIds],
+          })
+        ) {
+          changed = true;
         }
 
         const announced = new Set(snapshot.devices.map((device) => device.id));
@@ -290,6 +314,153 @@ export async function reconcileAttachedBrowserInventory(
         return { accepted: true, changed, revision };
       }),
   );
+}
+
+/** A new physical Chrome generation cannot inherit a prior controller token.
+ *  Mark every still-live BrowserSession/ComputerSession on that exact device
+ *  lost in place. Never rewrite placementInstanceId onto the successor. */
+async function terminalizeStaleAttachedDeviceSessions(
+  tx: Database,
+  input: { workspaceId: string; deviceIds: readonly string[] },
+): Promise<boolean> {
+  if (input.deviceIds.length === 0) return false;
+
+  const browserRows = await tx
+    .select({ id: schema.browserSessions.id })
+    .from(schema.browserSessions)
+    .where(
+      and(
+        eq(schema.browserSessions.workspaceId, input.workspaceId),
+        eq(schema.browserSessions.placementKind, "attached_device"),
+        inArray(schema.browserSessions.deviceId, [...input.deviceIds]),
+        inArray(schema.browserSessions.lifecycle, [...ATTACHED_DEVICE_LIVE_LIFECYCLES]),
+      ),
+    );
+  const computerRows = await tx
+    .select({ id: schema.computerSessions.id })
+    .from(schema.computerSessions)
+    .where(
+      and(
+        eq(schema.computerSessions.workspaceId, input.workspaceId),
+        eq(schema.computerSessions.placementKind, "attached_device"),
+        inArray(schema.computerSessions.deviceId, [...input.deviceIds]),
+        inArray(schema.computerSessions.lifecycle, [...ATTACHED_DEVICE_LIVE_LIFECYCLES]),
+      ),
+    );
+  if (browserRows.length === 0 && computerRows.length === 0) return false;
+
+  const browserIds = browserRows.map((row) => row.id).sort();
+  const computerIds = computerRows.map((row) => row.id).sort();
+  const resourceIds = [...browserIds, ...computerIds];
+  const operations = await tx
+    .select({ operationId: schema.interactionOperations.operationId })
+    .from(schema.interactionOperations)
+    .where(
+      and(
+        eq(schema.interactionOperations.workspaceId, input.workspaceId),
+        inArray(schema.interactionOperations.resourceId, resourceIds),
+        inArray(schema.interactionOperations.state, ["prepared", "dispatched"]),
+      ),
+    );
+  const operationIds = operations.map((row) => row.operationId).sort();
+  for (const operationId of operationIds) {
+    await tx.execute(sql`
+      select operation_id from interaction_operations
+      where workspace_id = ${input.workspaceId} and operation_id = ${operationId}
+      for update
+    `);
+  }
+  for (const browserSessionId of browserIds) {
+    await tx.execute(sql`
+      select id from browser_sessions
+      where workspace_id = ${input.workspaceId} and id = ${browserSessionId}
+      for update
+    `);
+  }
+  for (const computerSessionId of computerIds) {
+    await tx.execute(sql`
+      select id from computer_sessions
+      where workspace_id = ${input.workspaceId} and id = ${computerSessionId}
+      for update
+    `);
+  }
+
+  const now = new Date();
+  if (operationIds.length > 0) {
+    await tx
+      .update(schema.interactionOperations)
+      .set({
+        state: "outcome_unknown",
+        errorCode: CONTROLLER_TRANSITION_EXPIRED,
+        errorMessage: "Attached Chrome connection generation changed",
+        errorRetryable: false,
+        errorDetails: { reason: "connection_generation_changed" },
+        settledAt: now,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(schema.interactionOperations.workspaceId, input.workspaceId),
+          inArray(schema.interactionOperations.operationId, operationIds),
+          inArray(schema.interactionOperations.state, ["prepared", "dispatched"]),
+        ),
+      );
+  }
+  if (browserIds.length > 0) {
+    await tx
+      .update(schema.browserSessions)
+      .set({
+        lifecycle: "lost",
+        failureCode: CONTROLLER_TRANSITION_EXPIRED,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(schema.browserSessions.workspaceId, input.workspaceId),
+          inArray(schema.browserSessions.id, browserIds),
+          inArray(schema.browserSessions.lifecycle, [...ATTACHED_DEVICE_LIVE_LIFECYCLES]),
+        ),
+      );
+  }
+  if (computerIds.length > 0) {
+    await tx
+      .update(schema.computerSessions)
+      .set({
+        lifecycle: "lost",
+        failureCode: CONTROLLER_TRANSITION_EXPIRED,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(schema.computerSessions.workspaceId, input.workspaceId),
+          inArray(schema.computerSessions.id, computerIds),
+          inArray(schema.computerSessions.lifecycle, [...ATTACHED_DEVICE_LIVE_LIFECYCLES]),
+        ),
+      );
+  }
+  return true;
+}
+
+/** Lock the device row first (same order as inventory) and prove the live
+ *  physical generation still matches this controller placement. */
+export async function attachedDeviceGenerationMatches(
+  tx: Database,
+  input: { workspaceId: string; deviceId: string; placementInstanceId: string },
+): Promise<boolean> {
+  const [device] = await tx
+    .select({
+      connectionGeneration: schema.attachedBrowserDevices.connectionGeneration,
+    })
+    .from(schema.attachedBrowserDevices)
+    .where(
+      and(
+        eq(schema.attachedBrowserDevices.workspaceId, input.workspaceId),
+        eq(schema.attachedBrowserDevices.id, input.deviceId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  return device?.connectionGeneration === input.placementInstanceId;
 }
 
 /** Immediately mark every live Chrome profile on a cleanly disconnected agent

--- a/packages/db/src/attached-browser-devices.ts
+++ b/packages/db/src/attached-browser-devices.ts
@@ -16,12 +16,7 @@ import {
 } from "./interaction-revisions";
 import * as schema from "./schema";
 
-const ATTACHED_DEVICE_LIVE_LIFECYCLES = [
-  "starting",
-  "active",
-  "suspending",
-  "restoring",
-] as const;
+const ATTACHED_DEVICE_LIVE_LIFECYCLES = ["starting", "active", "suspending", "restoring"] as const;
 // `ending` stays off this list so an in-flight `/end` can finish physical
 // teardown (`stopCapture` + helper exit) after Chrome reconnects.
 

--- a/packages/db/src/browser-sessions.ts
+++ b/packages/db/src/browser-sessions.ts
@@ -23,6 +23,7 @@ import {
   type NetworkRouteConsistency as NetworkRouteConsistencyValue,
 } from "@opengeni/contracts";
 import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { attachedDeviceGenerationMatches } from "./attached-browser-devices";
 import { type Database, withRlsContext } from "./database";
 import {
   advanceWorkspaceInteractionRevision,
@@ -2194,6 +2195,15 @@ export async function touchBrowserSessionController(
           )
           .limit(1);
         if (!observed) return false;
+        if (observed.placementKind === "attached_device") {
+          if (!observed.deviceId || !observed.placementInstanceId) return false;
+          const current = await attachedDeviceGenerationMatches(tx, {
+            workspaceId: input.workspaceId,
+            deviceId: observed.deviceId,
+            placementInstanceId: observed.placementInstanceId,
+          });
+          if (!current) return false;
+        }
         if (observed.controllerHostSandboxGroupId) {
           // Match the reaper's exact lease -> holder -> BrowserSession lock
           // order. The pre-lock observation is only a locator; every authority

--- a/packages/db/src/computer-sessions.ts
+++ b/packages/db/src/computer-sessions.ts
@@ -17,6 +17,7 @@ import {
   type InteractionPlacement,
 } from "@opengeni/contracts";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { attachedDeviceGenerationMatches } from "./attached-browser-devices";
 import { type Database, withRlsContext } from "./database";
 import {
   advanceWorkspaceInteractionRevision,
@@ -846,7 +847,6 @@ export async function prepareComputerSessionEnd(
                 "suspended",
                 "restoring",
                 "repair_required",
-                "lost",
                 "ending",
               ]),
             ),
@@ -1037,6 +1037,15 @@ export async function touchComputerSessionController(
         )
         .limit(1);
       if (!observed) return false;
+      if (observed.placementKind === "attached_device") {
+        if (!observed.deviceId || !observed.placementInstanceId) return false;
+        const current = await attachedDeviceGenerationMatches(tx, {
+          workspaceId: input.workspaceId,
+          deviceId: observed.deviceId,
+          placementInstanceId: observed.placementInstanceId,
+        });
+        if (!current) return false;
+      }
       if (observed.placementKind === "sandbox_group") {
         const lease = await tx.execute<{ id: string }>(sql`
           select lease.id

--- a/packages/db/test/attached-browser-devices.test.ts
+++ b/packages/db/test/attached-browser-devices.test.ts
@@ -1,15 +1,28 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { acquireSharedTestDatabase, type SharedTestDatabase } from "@opengeni/testing";
 import {
+  ATTACHED_BROWSER_SESSION_CAPABILITIES,
   AttachedBrowserInventoryConflictError,
+  activateBrowserSession,
+  activateComputerSession,
   bootstrapWorkspace,
   createDb,
   createEnrollment,
+  createSession,
   disconnectAttachedBrowserDevices,
+  dispatchBrowserSessionOperation,
+  dispatchComputerSessionOperation,
   getAttachedBrowserDevice,
+  getBrowserSession,
+  getComputerSessionControlRecord,
   listAttachedBrowserDevices,
+  prepareBrowserSessionCreate,
+  prepareComputerSessionCreate,
+  prepareComputerSessionEnd,
   reconcileAttachedBrowserInventory,
   revokeEnrollment,
+  touchBrowserSessionController,
+  touchComputerSessionController,
 } from "../src";
 
 let available = true;
@@ -50,9 +63,20 @@ async function fixture() {
     os: "macos",
     arch: "arm64",
   });
+  const session = await createSession(client.db, {
+    accountId: grant.accountId,
+    workspaceId: grant.workspaceId!,
+    initialMessage: "initial",
+    resources: [],
+    metadata: {},
+    model: "scripted-model",
+    sandboxBackend: "none",
+  });
   return {
     accountId: grant.accountId,
     workspaceId: grant.workspaceId!,
+    subjectId: grant.subjectId,
+    sessionId: session.id,
     enrollmentId: enrollment.id,
   };
 }
@@ -69,7 +93,12 @@ const capabilities = {
   linkedComputer: true,
 } as const;
 
-function device(id: string, name: string, inventoryRevision = 1) {
+function device(
+  id: string,
+  name: string,
+  inventoryRevision = 1,
+  connectionGeneration = "extension-1",
+) {
   return {
     id,
     name,
@@ -79,11 +108,134 @@ function device(id: string, name: string, inventoryRevision = 1) {
     extensionVersion: "1.0.0",
     platform: "macos" as const,
     architecture: "arm64" as const,
-    connectionGeneration: "extension-1",
+    connectionGeneration,
     inventoryRevision,
     tabCount: 2,
     capabilities,
   };
+}
+
+async function announceDevice(
+  scope: Awaited<ReturnType<typeof fixture>>,
+  deviceId: string,
+  connectionGeneration: string,
+  revision: number,
+) {
+  return await reconcileAttachedBrowserInventory(client.db, {
+    accountId: scope.accountId,
+    workspaceId: scope.workspaceId,
+    enrollmentId: scope.enrollmentId,
+    snapshot: {
+      bridgeGeneration: "bridge-1",
+      revision,
+      devices: [device(deviceId, "Primary Chrome", revision, connectionGeneration)],
+    },
+  });
+}
+
+const computerCapabilities = {
+  semanticObservation: true,
+  appDiscovery: true,
+  appLaunch: true,
+  windowCapture: true,
+  screenCapture: true,
+  semanticActions: true,
+  pointerInput: true,
+  keyboardInput: true,
+  clipboard: true,
+  backgroundActions: true,
+  parallelApps: true,
+} as const;
+
+async function activateAttachedComputer(
+  scope: Awaited<ReturnType<typeof fixture>>,
+  deviceId: string,
+  placementInstanceId: string,
+) {
+  const operationId = crypto.randomUUID();
+  const prepared = await prepareComputerSessionCreate(client.db, {
+    accountId: scope.accountId,
+    workspaceId: scope.workspaceId,
+    operationId,
+    associatedSessionId: scope.sessionId,
+    actorSubjectId: scope.subjectId,
+    name: "Attached Chrome computer",
+    placement: { kind: "attached_device", deviceId },
+  });
+  const controller = {
+    controllerId: "browserd:attached-test",
+    controllerGeneration: crypto.randomUUID(),
+    placementInstanceId,
+  };
+  await dispatchComputerSessionOperation(client.db, {
+    accountId: scope.accountId,
+    workspaceId: scope.workspaceId,
+    operationId,
+    computerSessionId: prepared.session.id,
+    controllerGeneration: controller.controllerGeneration,
+    controller,
+  });
+  await activateComputerSession(client.db, {
+    accountId: scope.accountId,
+    workspaceId: scope.workspaceId,
+    operationId,
+    computerSessionId: prepared.session.id,
+    controller,
+    platform: "macos",
+    adapter: "opengeni.ax.v1",
+    seatId: "console",
+    displayId: "main",
+    capabilities: computerCapabilities,
+  });
+  return { computerSessionId: prepared.session.id, controller };
+}
+
+async function activateAttachedBrowser(
+  scope: Awaited<ReturnType<typeof fixture>>,
+  deviceId: string,
+  placementInstanceId: string,
+  linkedComputerSessionId?: string,
+) {
+  const operationId = crypto.randomUUID();
+  const prepared = await prepareBrowserSessionCreate(client.db, {
+    accountId: scope.accountId,
+    workspaceId: scope.workspaceId,
+    operationId,
+    associatedSessionId: scope.sessionId,
+    actorSubjectId: scope.subjectId,
+    name: "Attached Chrome",
+    initialUrl: null,
+    placement: { kind: "attached_device", deviceId },
+    driverId: "opengeni.attached-chrome.v1",
+    engine: "chrome",
+    headless: false,
+    identityId: null,
+    baseRevisionId: null,
+    linkedComputerSessionId,
+    capabilities: ATTACHED_BROWSER_SESSION_CAPABILITIES,
+  });
+  const controller = {
+    controllerId: "browserd:attached-test",
+    controllerGeneration: crypto.randomUUID(),
+    placementInstanceId,
+  };
+  await dispatchBrowserSessionOperation(client.db, {
+    accountId: scope.accountId,
+    workspaceId: scope.workspaceId,
+    operationId,
+    browserSessionId: prepared.session.id,
+    controllerGeneration: controller.controllerGeneration,
+    controller,
+  });
+  await activateBrowserSession(client.db, {
+    accountId: scope.accountId,
+    workspaceId: scope.workspaceId,
+    operationId,
+    browserSessionId: prepared.session.id,
+    controller,
+    engineVersion: "151.0.7922.108",
+  });
+  return { browserSessionId: prepared.session.id, controller };
 }
 
 describe("attached browser endpoint registry", () => {
@@ -294,6 +446,244 @@ describe("attached browser endpoint registry", () => {
       name: "Chrome after reinstall",
       state: "connected",
       inventoryRevision: 0,
+    });
+  });
+
+  test("terminalizes a linked BrowserSession/ComputerSession pair when generation changes", async () => {
+    if (!available) return;
+    const scope = await fixture();
+    const deviceId = crypto.randomUUID();
+    await announceDevice(scope, deviceId, "extension-1", 1);
+    const computer = await activateAttachedComputer(scope, deviceId, "extension-1");
+    const browser = await activateAttachedBrowser(
+      scope,
+      deviceId,
+      "extension-1",
+      computer.computerSessionId,
+    );
+
+    const rotated = await announceDevice(scope, deviceId, "extension-2", 2);
+    expect(rotated).toMatchObject({ accepted: true, changed: true });
+
+    const lostBrowser = await getBrowserSession(client.db, {
+      accountId: scope.accountId,
+      workspaceId: scope.workspaceId,
+      browserSessionId: browser.browserSessionId,
+    });
+    const lostComputer = (
+      await getComputerSessionControlRecord(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        computerSessionId: computer.computerSessionId,
+      })
+    ).session;
+    expect(lostBrowser).toMatchObject({
+      lifecycle: "lost",
+      failureCode: "controller_transition_expired",
+      placement: { kind: "attached_device", deviceId },
+      controller: {
+        placementInstanceId: "extension-1",
+      },
+    });
+    expect(lostComputer).toMatchObject({
+      lifecycle: "lost",
+      failureCode: "controller_transition_expired",
+      placement: { kind: "attached_device", deviceId },
+      controller: {
+        placementInstanceId: "extension-1",
+      },
+    });
+    expect(
+      await touchBrowserSessionController(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        browserSessionId: browser.browserSessionId,
+        controllerGeneration: browser.controller.controllerGeneration,
+      }),
+    ).toBe(false);
+    expect(
+      await touchComputerSessionController(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        computerSessionId: computer.computerSessionId,
+        controllerGeneration: computer.controller.controllerGeneration,
+      }),
+    ).toBe(false);
+  });
+
+  test("terminalizes a browser-only attached session when generation changes", async () => {
+    if (!available) return;
+    const scope = await fixture();
+    const deviceId = crypto.randomUUID();
+    await announceDevice(scope, deviceId, "extension-1", 1);
+    const browser = await activateAttachedBrowser(scope, deviceId, "extension-1");
+
+    await announceDevice(scope, deviceId, "extension-2", 2);
+    expect(
+      await getBrowserSession(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        browserSessionId: browser.browserSessionId,
+      }),
+    ).toMatchObject({
+      lifecycle: "lost",
+      failureCode: "controller_transition_expired",
+      controller: { placementInstanceId: "extension-1" },
+    });
+  });
+
+  test("leaves an in-flight ComputerSession end untouched when generation changes", async () => {
+    if (!available) return;
+    const scope = await fixture();
+    const deviceId = crypto.randomUUID();
+    await announceDevice(scope, deviceId, "extension-1", 1);
+    const computer = await activateAttachedComputer(scope, deviceId, "extension-1");
+    const ending = await prepareComputerSessionEnd(client.db, {
+      accountId: scope.accountId,
+      workspaceId: scope.workspaceId,
+      computerSessionId: computer.computerSessionId,
+      operationId: crypto.randomUUID(),
+      actorSubjectId: scope.subjectId,
+    });
+    expect(ending.session.lifecycle).toBe("ending");
+
+    await announceDevice(scope, deviceId, "extension-2", 2);
+    expect(
+      (
+        await getComputerSessionControlRecord(client.db, {
+          accountId: scope.accountId,
+          workspaceId: scope.workspaceId,
+          computerSessionId: computer.computerSessionId,
+        })
+      ).session,
+    ).toMatchObject({
+      lifecycle: "ending",
+      failureCode: null,
+      controller: { placementInstanceId: "extension-1" },
+    });
+  });
+
+  test("a lost linked BrowserSession does not block ComputerSession end after generation change", async () => {
+    if (!available) return;
+    const scope = await fixture();
+    const deviceId = crypto.randomUUID();
+    await announceDevice(scope, deviceId, "extension-1", 1);
+    const computer = await activateAttachedComputer(scope, deviceId, "extension-1");
+    await activateAttachedBrowser(scope, deviceId, "extension-1", computer.computerSessionId);
+    await announceDevice(scope, deviceId, "extension-2", 2);
+
+    const ended = await prepareComputerSessionEnd(client.db, {
+      accountId: scope.accountId,
+      workspaceId: scope.workspaceId,
+      computerSessionId: computer.computerSessionId,
+      operationId: crypto.randomUUID(),
+      actorSubjectId: scope.subjectId,
+    });
+    expect(ended.session).toMatchObject({
+      id: computer.computerSessionId,
+      lifecycle: "ending",
+    });
+  });
+
+  test("same-generation inventory refresh leaves live attached sessions untouched", async () => {
+    if (!available) return;
+    const scope = await fixture();
+    const deviceId = crypto.randomUUID();
+    await announceDevice(scope, deviceId, "extension-1", 1);
+    const computer = await activateAttachedComputer(scope, deviceId, "extension-1");
+    const browser = await activateAttachedBrowser(
+      scope,
+      deviceId,
+      "extension-1",
+      computer.computerSessionId,
+    );
+
+    const refreshed = await announceDevice(scope, deviceId, "extension-1", 1);
+    expect(refreshed.accepted).toBe(true);
+    expect(
+      await getBrowserSession(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        browserSessionId: browser.browserSessionId,
+      }),
+    ).toMatchObject({
+      lifecycle: "active",
+      failureCode: null,
+      controller: { placementInstanceId: "extension-1" },
+    });
+    expect(
+      (
+        await getComputerSessionControlRecord(client.db, {
+          accountId: scope.accountId,
+          workspaceId: scope.workspaceId,
+          computerSessionId: computer.computerSessionId,
+        })
+      ).session,
+    ).toMatchObject({
+      lifecycle: "active",
+      failureCode: null,
+      controller: { placementInstanceId: "extension-1" },
+    });
+    expect(
+      await touchBrowserSessionController(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        browserSessionId: browser.browserSessionId,
+        controllerGeneration: browser.controller.controllerGeneration,
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects a controller heartbeat whose placement generation is already stale", async () => {
+    if (!available) return;
+    const scope = await fixture();
+    const deviceId = crypto.randomUUID();
+    await announceDevice(scope, deviceId, "extension-1", 1);
+    const browser = await activateAttachedBrowser(scope, deviceId, "extension-1");
+    const computer = await activateAttachedComputer(scope, deviceId, "extension-1");
+
+    await shared!.admin`
+      update attached_browser_devices
+      set connection_generation = 'extension-stale'
+      where workspace_id = ${scope.workspaceId} and id = ${deviceId}`;
+
+    expect(
+      await touchBrowserSessionController(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        browserSessionId: browser.browserSessionId,
+        controllerGeneration: browser.controller.controllerGeneration,
+      }),
+    ).toBe(false);
+    expect(
+      await touchComputerSessionController(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        computerSessionId: computer.computerSessionId,
+        controllerGeneration: computer.controller.controllerGeneration,
+      }),
+    ).toBe(false);
+    expect(
+      await getBrowserSession(client.db, {
+        accountId: scope.accountId,
+        workspaceId: scope.workspaceId,
+        browserSessionId: browser.browserSessionId,
+      }),
+    ).toMatchObject({
+      lifecycle: "active",
+      controller: { placementInstanceId: "extension-1" },
+    });
+    expect(
+      (
+        await getComputerSessionControlRecord(client.db, {
+          accountId: scope.accountId,
+          workspaceId: scope.workspaceId,
+          computerSessionId: computer.computerSessionId,
+        })
+      ).session,
+    ).toMatchObject({
+      lifecycle: "active",
+      controller: { placementInstanceId: "extension-1" },
     });
   });
 });

--- a/packages/db/test/attached-browser-devices.test.ts
+++ b/packages/db/test/attached-browser-devices.test.ts
@@ -211,7 +211,7 @@ async function activateAttachedBrowser(
     headless: false,
     identityId: null,
     baseRevisionId: null,
-    linkedComputerSessionId,
+    linkedComputerSessionId: linkedComputerSessionId ?? null,
     capabilities: ATTACHED_BROWSER_SESSION_CAPABILITIES,
   });
   const controller = {

--- a/packages/react/src/components/browser-viewer.tsx
+++ b/packages/react/src/components/browser-viewer.tsx
@@ -166,6 +166,35 @@ export function BrowserViewer({
     () => registry.sessions.filter((session) => isLiveBrowser(session)),
     [registry.sessions],
   );
+  const attachedGenerationLoss = useMemo(
+    () => attachedChromeGenerationLoss(registry.sessions),
+    [registry.sessions],
+  );
+  const endedGenerationLossRef = useRef(new Set<string>());
+  const endStaleBrowser = registry.end;
+  useEffect(() => {
+    if (!enabled) return;
+    for (const session of registry.sessions) {
+      if (
+        session.lifecycle !== "lost" ||
+        session.failureCode !== "controller_transition_expired" ||
+        session.placement.kind !== "attached_device"
+      ) {
+        continue;
+      }
+      if (endedGenerationLossRef.current.has(session.id)) continue;
+      endedGenerationLossRef.current.add(session.id);
+      void endStaleBrowser(session.id).catch(() => {
+        endedGenerationLossRef.current.delete(session.id);
+      });
+    }
+  }, [enabled, endStaleBrowser, registry.sessions]);
+  const replacementChromeDevice = useMemo(() => {
+    if (!attachedGenerationLoss) return null;
+    return (
+      attached.devices.find((candidate) => candidate.id === attachedGenerationLoss.deviceId) ?? null
+    );
+  }, [attached.devices, attachedGenerationLoss]);
   const relevant = useMemo(
     () => registry.relevantSessions.filter((session) => isLiveBrowser(session)),
     [registry.relevantSessions],
@@ -709,9 +738,15 @@ export function BrowserViewer({
           <span className="mx-auto grid size-10 place-items-center rounded-og-md border border-og-border bg-og-surface-1 text-og-muted">
             <Globe2Icon className="size-4.5" />
           </span>
-          <p className="mt-3 text-og-menu font-medium text-og-fg">No browser open</p>
+          <p className="mt-3 text-og-menu font-medium text-og-fg">
+            {attachedGenerationLoss
+              ? "Chrome reconnected—open a fresh browser/desktop."
+              : "No browser open"}
+          </p>
           <p className="mt-1 text-og-control leading-5 text-og-muted">
-            A browser appears here when this agent—or another agent in the workspace—opens one.
+            {attachedGenerationLoss
+              ? "This Chrome profile is live again, but the previous browser cannot move to the new connection. Use Browser → New browser → Connected Chrome."
+              : "A browser appears here when this agent—or another agent in the workspace—opens one."}
           </p>
           <BrowserLaunchMenu
             attachedBridges={onlineAttachedBridges}
@@ -850,7 +885,26 @@ export function BrowserViewer({
               return receipt;
             }}
             onReadClipboard={browser.readClipboard}
-            onReconnect={frames.reconnect}
+            onReconnect={
+              attachedGenerationLoss || isAttachedChromeGenerationLossError(frames.error)
+                ? () => {
+                    if (replacementChromeDevice) {
+                      createBrowser({ kind: "attached", device: replacementChromeDevice });
+                    }
+                  }
+                : frames.reconnect
+            }
+            reconnectLabel={
+              (attachedGenerationLoss || isAttachedChromeGenerationLossError(frames.error)) &&
+              replacementChromeDevice
+                ? "Open a fresh Connected Chrome"
+                : undefined
+            }
+            reconnectMessage={
+              attachedGenerationLoss || isAttachedChromeGenerationLossError(frames.error)
+                ? "Chrome reconnected—open a fresh browser/desktop."
+                : undefined
+            }
             onError={(cause) => notifyError(cause, "Browser input failed.")}
           />
           <BrowserStatusBar
@@ -1769,6 +1823,8 @@ function BrowserViewport(props: {
   onAction: (action: BrowserAction, frame: BrowserFrame | null) => Promise<BrowserActionReceipt>;
   onReadClipboard: () => Promise<{ text: string }>;
   onReconnect: () => void;
+  reconnectLabel?: string | undefined;
+  reconnectMessage?: string | undefined;
   onError: (cause: unknown) => void;
 }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -2139,6 +2195,8 @@ function BrowserViewport(props: {
           error={props.connectionError}
           onAction={(action) => enqueue(action, null)}
           onReconnect={props.onReconnect}
+          reconnectLabel={props.reconnectLabel}
+          reconnectMessage={props.reconnectMessage}
         />
       ) : null}
       {props.mutating ? (
@@ -2157,8 +2215,12 @@ function SemanticBrowserFallback(props: {
   error: Error | null;
   onAction: (action: BrowserAction) => void;
   onReconnect: () => void;
+  reconnectLabel?: string | undefined;
+  reconnectMessage?: string | undefined;
 }) {
   const controlFailure = interactionControlFailureFromError(props.error);
+  const generationLoss =
+    Boolean(props.reconnectMessage) || isAttachedChromeGenerationLossError(props.error);
   const nodes = semanticNodes(
     props.observation?.semantic?.kind === "snapshot" ? props.observation.semantic.roots : [],
   );
@@ -2175,16 +2237,18 @@ function SemanticBrowserFallback(props: {
             <LoaderCircleIcon className="size-4 animate-spin text-og-muted" />
           )}
           <p className="text-og-menu font-medium text-og-fg">
-            {props.error
-              ? "Live view disconnected"
-              : props.supportsLiveFrames
-                ? browserConnectionLabel(props.connectionState)
-                : "Semantic browser"}
+            {generationLoss
+              ? "Chrome reconnected—open a fresh browser/desktop."
+              : props.error
+                ? "Live view disconnected"
+                : props.supportsLiveFrames
+                  ? browserConnectionLabel(props.connectionState)
+                  : "Semantic browser"}
           </p>
         </div>
-        {props.error ? (
+        {props.error || props.reconnectMessage ? (
           <p className="mt-2 text-og-control leading-5 text-og-muted">
-            {controlFailure?.message ?? props.error.message}
+            {props.reconnectMessage ?? controlFailure?.message ?? props.error?.message}
           </p>
         ) : null}
         {interactive.length > 0 ? (
@@ -2213,13 +2277,16 @@ function SemanticBrowserFallback(props: {
             </div>
           </div>
         ) : null}
-        {props.error && props.supportsLiveFrames ? (
+        {props.error &&
+        props.supportsLiveFrames &&
+        (!generationLoss || props.reconnectLabel) ? (
           <button
             type="button"
             onClick={props.onReconnect}
             className="mt-3 text-og-control font-medium text-og-accent hover:underline"
           >
-            {controlFailure?.retryable === false ? "Try again" : "Reconnect"}
+            {props.reconnectLabel ??
+              (controlFailure?.retryable === false ? "Try again" : "Reconnect")}
           </button>
         ) : null}
       </div>
@@ -2851,6 +2918,23 @@ function sameOptionalBrowserFrame(left: BrowserFrame | null, right: BrowserFrame
 
 function isLiveBrowser(session: BrowserSession): boolean {
   return !["ending", "ended", "failed", "lost"].includes(session.lifecycle);
+}
+
+function attachedChromeGenerationLoss(
+  sessions: readonly BrowserSession[],
+): { deviceId: string } | null {
+  const lost = sessions.find(
+    (session) =>
+      session.lifecycle === "lost" &&
+      session.failureCode === "controller_transition_expired" &&
+      session.placement.kind === "attached_device",
+  );
+  return lost?.placement.kind === "attached_device" ? { deviceId: lost.placement.deviceId } : null;
+}
+
+function isAttachedChromeGenerationLossError(error: Error | null): boolean {
+  if (!error) return false;
+  return /placement instance changed|controller authority changed/i.test(error.message);
 }
 
 function countInterventions(

--- a/packages/react/src/components/browser-viewer.tsx
+++ b/packages/react/src/components/browser-viewer.tsx
@@ -2277,9 +2277,7 @@ function SemanticBrowserFallback(props: {
             </div>
           </div>
         ) : null}
-        {props.error &&
-        props.supportsLiveFrames &&
-        (!generationLoss || props.reconnectLabel) ? (
+        {props.error && props.supportsLiveFrames && (!generationLoss || props.reconnectLabel) ? (
           <button
             type="button"
             onClick={props.onReconnect}

--- a/packages/react/src/components/computer-viewer.tsx
+++ b/packages/react/src/components/computer-viewer.tsx
@@ -135,6 +135,21 @@ export function ComputerViewer({
   const createInFlightRef = useRef(false);
   const autoCreateSessionRef = useRef<string | null>(null);
   const emptyCatalogConfirmationRef = useRef<string | null>(null);
+  const endedGenerationLossRef = useRef(new Set<string>());
+  const [suppressGenericCreate, setSuppressGenericCreate] = useState(false);
+  const endStaleComputer = registry.end;
+  useEffect(() => {
+    if (!enabled) return;
+    for (const session of registry.sessions) {
+      if (!isAttachedChromeGenerationLoss(session)) continue;
+      setSuppressGenericCreate(true);
+      if (endedGenerationLossRef.current.has(session.id)) continue;
+      endedGenerationLossRef.current.add(session.id);
+      void endStaleComputer(session.id).catch(() => {
+        endedGenerationLossRef.current.delete(session.id);
+      });
+    }
+  }, [enabled, endStaleComputer, registry.sessions]);
 
   const notifyError = useCallback(
     (cause: unknown, fallback: string) => {
@@ -152,6 +167,7 @@ export function ComputerViewer({
     handledRequestRef.current = null;
     autoCreateSessionRef.current = null;
     emptyCatalogConfirmationRef.current = null;
+    setSuppressGenericCreate(false);
     setCreateError(null);
     setSelection(
       initialComputerSessionId ? { sessionId: initialComputerSessionId, pinned: true } : null,
@@ -340,6 +356,7 @@ export function ComputerViewer({
       registry.refreshing ||
       registry.error ||
       relevant.length > 0 ||
+      suppressGenericCreate ||
       autoCreateSessionRef.current === sessionId
     ) {
       return;
@@ -365,6 +382,7 @@ export function ComputerViewer({
     registry.refreshing,
     relevant.length,
     sessionId,
+    suppressGenericCreate,
   ]);
 
   const perform = useCallback(
@@ -416,6 +434,12 @@ export function ComputerViewer({
     [computer, notifyError, perform, rfbStream],
   );
 
+  const hideGenericCreate =
+    suppressGenericCreate && liveRelevant.length === 0;
+  const generationLossSelected =
+    selectedRegistrySession !== null && isAttachedChromeGenerationLoss(selectedRegistrySession);
+  const generationLossFrames = isAttachedChromeGenerationLossError(frames.error);
+
   if (!enabled) return null;
   if (registry.loading && liveSessions.length === 0) {
     return (
@@ -427,6 +451,22 @@ export function ComputerViewer({
     );
   }
   if (liveSessions.length === 0) {
+    if (hideGenericCreate) {
+      return (
+        <div className={cn("grid h-full place-items-center bg-og-bg p-6", className)}>
+          <div className="max-w-sm text-center">
+            <CircleAlertIcon className="mx-auto size-5 text-og-status-error" />
+            <p className="mt-3 text-og-menu font-medium text-og-fg">
+              Chrome reconnected—open a fresh browser/desktop.
+            </p>
+            <p className="mt-1 text-og-control leading-5 text-og-muted">
+              This Chrome profile is live again, but the previous desktop cannot move to the new
+              connection. Use Browser → New browser → Connected Chrome.
+            </p>
+          </div>
+        </div>
+      );
+    }
     if (renderEmpty) return renderEmpty(createComputer, creating);
     const error = createError ?? registry.error;
     return (
@@ -480,7 +520,7 @@ export function ComputerViewer({
         onFollow={() => {
           if (relevant[0]) selectComputerSession({ sessionId: relevant[0].id, pinned: false });
         }}
-        onCreate={createComputer}
+        onCreate={hideGenericCreate ? undefined : createComputer}
         onRefresh={() => void Promise.all([refreshRegistry(), refreshComputer()])}
       />
       <InteractionInterventionBanner
@@ -499,6 +539,7 @@ export function ComputerViewer({
           peerCount={liveSessions.length}
           creating={creating}
           error={createError}
+          generationLoss={suppressGenericCreate}
           onCreate={createComputer}
         />
       ) : !controllerReady ? (
@@ -546,7 +587,9 @@ export function ComputerViewer({
                 clipboardEnabled={computer.session?.capabilities?.clipboard === true}
                 onAction={perform}
                 onReadClipboard={computer.readClipboard}
-                onReconnect={frames.reconnect}
+                onReconnect={
+                  generationLossSelected || generationLossFrames ? () => undefined : frames.reconnect
+                }
                 onError={(cause) => notifyError(cause, "Desktop input failed.")}
               />
             )}
@@ -581,28 +624,35 @@ function ComputerUnselectedPanel(props: {
   peerCount: number;
   creating: boolean;
   error: Error | null;
+  generationLoss: boolean;
   onCreate: () => void;
 }) {
   return (
     <div className="grid min-h-0 flex-1 place-items-center bg-og-bg p-6 text-center">
       <div className="max-w-sm">
         <span className="mx-auto grid size-10 place-items-center rounded-og-md border border-og-border bg-og-surface-1 text-og-muted">
-          {props.error ? (
+          {props.error || props.generationLoss ? (
             <CircleAlertIcon className="size-4.5 text-og-status-error" />
           ) : (
             <LoaderCircleIcon className="size-4.5 animate-spin" />
           )}
         </span>
         <p className="mt-3 text-og-menu font-medium text-og-fg">
-          {props.error ? "Desktop didn’t open" : "Opening desktop…"}
+          {props.generationLoss
+            ? "Chrome reconnected—open a fresh browser/desktop."
+            : props.error
+              ? "Desktop didn’t open"
+              : "Opening desktop…"}
         </p>
         <p className="mt-1 text-og-control leading-5 text-og-muted">
-          {props.error?.message ??
-            (props.peerCount === 1
-              ? "Preparing this agent’s desktop. One peer desktop remains available from the menu."
-              : `Preparing this agent’s desktop. ${props.peerCount} peer desktops remain available from the menu.`)}
+          {props.generationLoss
+            ? "This Chrome profile is live again, but the previous desktop cannot move to the new connection. Use Browser → New browser → Connected Chrome."
+            : (props.error?.message ??
+              (props.peerCount === 1
+                ? "Preparing this agent’s desktop. One peer desktop remains available from the menu."
+                : `Preparing this agent’s desktop. ${props.peerCount} peer desktops remain available from the menu.`))}
         </p>
-        {props.error ? (
+        {props.error && !props.generationLoss ? (
           <button
             type="button"
             disabled={props.creating}
@@ -631,7 +681,7 @@ function ComputerToolbar(props: {
   interventionCounts: Map<string, number>;
   onSelect: (id: string) => void;
   onFollow: () => void;
-  onCreate: () => void;
+  onCreate?: (() => void) | undefined;
   onRefresh: () => void;
 }) {
   const detailsRef = useRef<HTMLDetailsElement | null>(null);
@@ -674,9 +724,11 @@ function ComputerToolbar(props: {
             {current.length > 0 ? (
               <MenuButton onClick={props.onFollow}>Follow agent</MenuButton>
             ) : null}
-            <MenuButton onClick={props.onCreate} disabled={props.creating}>
-              <PlusIcon className="size-3.5" /> New desktop
-            </MenuButton>
+            {props.onCreate ? (
+              <MenuButton onClick={props.onCreate} disabled={props.creating}>
+                <PlusIcon className="size-3.5" /> New desktop
+              </MenuButton>
+            ) : null}
           </div>
         </div>
       </details>
@@ -691,19 +743,21 @@ function ComputerToolbar(props: {
       >
         <RefreshCwIcon className={cn("size-3.5", props.refreshing && "animate-spin")} />
       </button>
-      <button
-        type="button"
-        onClick={props.onCreate}
-        disabled={props.creating}
-        className="grid size-7 place-items-center rounded-og-sm text-og-muted transition hover:bg-og-surface-2 hover:text-og-fg disabled:opacity-40"
-        aria-label="Open a new desktop"
-      >
-        {props.creating ? (
-          <LoaderCircleIcon className="size-3.5 animate-spin" />
-        ) : (
-          <PlusIcon className="size-3.5" />
-        )}
-      </button>
+      {props.onCreate ? (
+        <button
+          type="button"
+          onClick={props.onCreate}
+          disabled={props.creating}
+          className="grid size-7 place-items-center rounded-og-sm text-og-muted transition hover:bg-og-surface-2 hover:text-og-fg disabled:opacity-40"
+          aria-label="Open a new desktop"
+        >
+          {props.creating ? (
+            <LoaderCircleIcon className="size-3.5 animate-spin" />
+          ) : (
+            <PlusIcon className="size-3.5" />
+          )}
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -838,6 +892,7 @@ function ComputerLifecyclePanel(props: {
   onRefresh: () => Promise<void>;
   onRetry: () => void;
 }) {
+  const generationLoss = isAttachedChromeGenerationLoss(props.session);
   const failed = ["failed", "lost", "repair_required"].includes(props.session.lifecycle);
   const retryCreatesSession = ["failed", "lost"].includes(props.session.lifecycle);
   return (
@@ -849,13 +904,19 @@ function ComputerLifecyclePanel(props: {
           <LoaderCircleIcon className="mx-auto size-5 animate-spin text-og-muted" />
         )}
         <p className="mt-3 text-og-menu font-medium text-og-fg">
-          {failed ? "Desktop needs attention" : lifecycleLabel(props.session.lifecycle)}
+          {generationLoss
+            ? "Chrome reconnected—open a fresh browser/desktop."
+            : failed
+              ? "Desktop needs attention"
+              : lifecycleLabel(props.session.lifecycle)}
         </p>
         <p className="mt-1 text-og-control leading-5 text-og-muted">
-          {computerFailureMessage(props.session) ??
-            "The desktop is being prepared on its placement. It will appear here when ready."}
+          {generationLoss
+            ? "This Chrome profile is live again, but the previous desktop cannot move to the new connection. Use Browser → New browser → Connected Chrome."
+            : (computerFailureMessage(props.session) ??
+              "The desktop is being prepared on its placement. It will appear here when ready.")}
         </p>
-        {failed ? (
+        {failed && !generationLoss ? (
           <button
             type="button"
             onClick={() => (retryCreatesSession ? props.onRetry() : void props.onRefresh())}
@@ -1345,14 +1406,18 @@ function ComputerViewportFallback(props: {
             <LoaderCircleIcon className="size-4 animate-spin text-og-muted" />
           )}
           <p className="text-og-menu font-medium text-og-fg">
-            {props.error
-              ? "Live view disconnected"
-              : computerConnectionLabel(props.connectionState)}
+            {isAttachedChromeGenerationLossError(props.error)
+              ? "Chrome reconnected—open a fresh browser/desktop."
+              : props.error
+                ? "Live view disconnected"
+                : computerConnectionLabel(props.connectionState)}
           </p>
         </div>
         {props.error ? (
           <p className="mt-2 text-og-control leading-5 text-og-muted">
-            {controlFailure?.message ?? props.error.message}
+            {isAttachedChromeGenerationLossError(props.error)
+              ? "Chrome reconnected—open a fresh browser/desktop. Use Browser → New browser → Connected Chrome."
+              : (controlFailure?.message ?? props.error.message)}
           </p>
         ) : null}
         {interactive.length > 0 ? (
@@ -1375,7 +1440,7 @@ function ComputerViewportFallback(props: {
             </div>
           </div>
         ) : null}
-        {props.error ? (
+        {props.error && !isAttachedChromeGenerationLossError(props.error) ? (
           <button
             type="button"
             onClick={props.onReconnect}
@@ -1669,11 +1734,28 @@ function computerFailureMessage(session: ComputerSession): string | null {
       return "Unlock the connected Mac, then try again.";
     case "controller_heartbeat_expired":
       return "The desktop connection was lost. Try opening it again.";
+    case "controller_transition_expired":
+      return session.placement.kind === "attached_device"
+        ? "Chrome reconnected—open a fresh browser/desktop. Use Browser → New browser → Connected Chrome."
+        : "The desktop connection expired. Open a new desktop.";
     case null:
       return null;
     default:
       return "The desktop could not be opened. Try again.";
   }
+}
+
+function isAttachedChromeGenerationLoss(session: ComputerSession): boolean {
+  return (
+    session.lifecycle === "lost" &&
+    session.failureCode === "controller_transition_expired" &&
+    session.placement.kind === "attached_device"
+  );
+}
+
+function isAttachedChromeGenerationLossError(error: Error | null): boolean {
+  if (!error) return false;
+  return /placement instance changed|controller authority changed/i.test(error.message);
 }
 
 function countInterventions(

--- a/packages/react/src/components/computer-viewer.tsx
+++ b/packages/react/src/components/computer-viewer.tsx
@@ -434,8 +434,7 @@ export function ComputerViewer({
     [computer, notifyError, perform, rfbStream],
   );
 
-  const hideGenericCreate =
-    suppressGenericCreate && liveRelevant.length === 0;
+  const hideGenericCreate = suppressGenericCreate && liveRelevant.length === 0;
   const generationLossSelected =
     selectedRegistrySession !== null && isAttachedChromeGenerationLoss(selectedRegistrySession);
   const generationLossFrames = isAttachedChromeGenerationLossError(frames.error);
@@ -588,7 +587,9 @@ export function ComputerViewer({
                 onAction={perform}
                 onReadClipboard={computer.readClipboard}
                 onReconnect={
-                  generationLossSelected || generationLossFrames ? () => undefined : frames.reconnect
+                  generationLossSelected || generationLossFrames
+                    ? () => undefined
+                    : frames.reconnect
                 }
                 onError={(cause) => notifyError(cause, "Desktop input failed.")}
               />

--- a/packages/react/src/hooks/use-browser-frame-stream.ts
+++ b/packages/react/src/hooks/use-browser-frame-stream.ts
@@ -389,7 +389,7 @@ export function useBrowserFrameStream(
         connectSocket();
       } catch (cause) {
         if (attachmentAbort.signal.aborted || disposed) return;
-        fail(cause);
+        fail(cause, !isPlacementGenerationLossError(cause));
       }
     };
 
@@ -422,4 +422,9 @@ async function messageBytes(value: unknown): Promise<Uint8Array> {
     return new Uint8Array(await value.arrayBuffer());
   }
   throw new Error("browser frame stream returned a non-binary message");
+}
+
+function isPlacementGenerationLossError(cause: unknown): boolean {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  return /placement instance changed|controller authority changed/i.test(message);
 }

--- a/packages/react/src/hooks/use-computer-frame-stream.ts
+++ b/packages/react/src/hooks/use-computer-frame-stream.ts
@@ -397,7 +397,7 @@ export function useComputerFrameStream(
         connectSocket();
       } catch (cause) {
         if (attachmentAbort.signal.aborted || disposed) return;
-        fail(cause);
+        fail(cause, !isPlacementGenerationLossError(cause));
       }
     };
 
@@ -431,4 +431,9 @@ async function messageBytes(value: unknown): Promise<Uint8Array> {
     return new Uint8Array(await value.arrayBuffer());
   }
   throw new Error("desktop frame stream returned a non-binary message");
+}
+
+function isPlacementGenerationLossError(cause: unknown): boolean {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  return /placement instance changed|controller authority changed/i.test(message);
 }

--- a/packages/react/test/computer-interaction.test.tsx
+++ b/packages/react/test/computer-interaction.test.tsx
@@ -30,6 +30,7 @@ const PEER_COMPUTER_SESSION_ID = "55555555-5555-4555-8555-555555555555";
 const PEER_SESSION_ID = "33333333-3333-4333-8333-333333333333";
 const ACCOUNT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const SANDBOX_GROUP_ID = "66666666-6666-4666-8666-666666666666";
+const ATTACHED_DEVICE_ID = "77777777-7777-4777-8777-777777777777";
 const NOW = "2026-08-10T12:00:00.000Z";
 const PNG_SHA256 = "431ced6916a2a21a156e38701afe55bbd7f88969fbbfc56d7fe099d47f265460";
 
@@ -81,6 +82,20 @@ function computerSession(
     createdAt: NOW,
     lastUsedAt: NOW,
     failureCode: null,
+  };
+}
+
+function lostAttachedComputer(
+  id = COMPUTER_SESSION_ID,
+  associationSessionId = SESSION_ID,
+): ComputerSession {
+  return {
+    ...computerSession(id, associationSessionId),
+    lifecycle: "lost",
+    failureCode: "controller_transition_expired",
+    placement: { kind: "attached_device", deviceId: ATTACHED_DEVICE_ID },
+    platform: "macos",
+    adapter: "opengeni.ax.v1",
   };
 }
 
@@ -590,6 +605,36 @@ describe("ComputerSession frame stream", () => {
     expect(sockets[0]?.closed).toBe(true);
     await hook.unmount();
   });
+
+  test("does not auto-reconnect after a placement-generation 409", async () => {
+    let attachCalls = 0;
+    const client = fakeClient({
+      attachComputerSession: async () => {
+        attachCalls += 1;
+        throw new OpenGeniApiError(
+          409,
+          JSON.stringify({ message: "ComputerSession placement instance changed" }),
+        );
+      },
+    });
+    const hook = await renderHook(
+      () =>
+        useComputerFrameStream({
+          client,
+          workspaceId: WORKSPACE_ID,
+          computerSessionId: COMPUTER_SESSION_ID,
+          targetId: "window-1",
+        }),
+      undefined,
+    );
+    await flush(80);
+    expect(attachCalls).toBe(1);
+    expect(hook.result.current.state).toBe("error");
+    expect(hook.result.current.error?.message).toMatch(/placement instance changed/i);
+    await flush(400);
+    expect(attachCalls).toBe(1);
+    await hook.unmount();
+  });
 });
 
 describe("ComputerViewer", () => {
@@ -741,6 +786,41 @@ describe("ComputerViewer", () => {
     expect(createRequests[0]).toMatchObject({ sessionId: SESSION_ID, name: "Desktop" });
     expect(rendered.container.textContent).toContain("Opening desktop");
     expect(rendered.container.textContent).not.toContain("No computer for this agent");
+    await rendered.unmount();
+  });
+
+  test("does not create a generic desktop after attached Chrome generation loss", async () => {
+    let createCalls = 0;
+    let endCalls = 0;
+    const lost = lostAttachedComputer();
+    const client = fakeClient({
+      listComputerSessions: async () => ({ revision: 1, sessions: [lost] }),
+      createComputerSession: async () => {
+        createCalls += 1;
+        return mutation(startingComputerSession());
+      },
+      endComputerSession: async () => {
+        endCalls += 1;
+        return mutation({ ...lost, lifecycle: "ended", failureCode: null }, "end");
+      },
+    });
+
+    const rendered = await renderComponent(
+      <ComputerViewer client={client} workspaceId={WORKSPACE_ID} sessionId={SESSION_ID} />,
+    );
+    await flush(80);
+
+    expect(createCalls).toBe(0);
+    expect(endCalls).toBe(1);
+    expect(rendered.container.textContent).toContain("Chrome reconnected");
+    expect(rendered.container.textContent).toContain("Connected Chrome");
+    expect(
+      [...rendered.container.querySelectorAll("button")].some(
+        (button) =>
+          button.textContent?.includes("Try again") ||
+          button.getAttribute("aria-label") === "Open a new desktop",
+      ),
+    ).toBe(false);
     await rendered.unmount();
   });
 


### PR DESCRIPTION
## Summary
- Terminalize attached Chrome Browser/Computer sessions when `connectionGeneration` changes, without rebinding the stale placement.
- Fence heartbeats and keep `/end` on the original token so browserd can `stopCapture` and kill `opengeni-computer-native`; shared-seat creates serialize and displace leftover helpers.
- Stop UI Reconnect / generic New desktop from retrying the dead generation. Replacement is Browser → New browser → Connected Chrome.

## Test plan
- [x] `bun test packages/db/test/attached-browser-devices.test.ts`
- [x] `bun test packages/browserd/test/computer-driver.test.ts packages/browserd/test/computer-supervisor.test.ts`
- [x] `bun test apps/api/test/computer-session-routes.test.ts apps/api/test/browser-session-routes.test.ts`
- [x] `bun test packages/react/test/computer-interaction.test.tsx`
- [ ] After merge: Jorgebot-only dogfood — reconnect Chrome, confirm old pair stays lost, no extra `opengeni-computer-native`/`replayd`, open a fresh Connected Chrome


Made with [Cursor](https://cursor.com)