### PR TITLE
docs: remove committed merge-conflict markers from main

### DIFF
--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -520,7 +520,6 @@ human, both owned by their own issues and only counted here). Integers only;
 the seam never returns identities, names, keys, or values, and it rejects a
 cross-organization request.
 
-<<<<<<< HEAD
 #### Variable Sets, Rigs, and Connected Machines need no data rewrite
 
 These three families are already terminally classified, and the phase D
@@ -575,7 +574,6 @@ matches zero rows and reports success on such a deployment, and only appears to
 work in the test harness, which migrates as a superuser for whom FORCE RLS never
 engages. Any future classification work on these tables must run behind the same
 kind of capability-claiming seam.
-=======
 **There is no "unclassified" count for Variable Sets, Rigs, or Connected
 Machines, and one must not be reintroduced without new schema.** 0285 reported
 one, defined as `authority_id IS NULL`; 0292 removed it. The authority shape
@@ -610,7 +608,6 @@ tables - contrast the documents gate, whose
 `authority_kind = 'personal' AND authority_id IS NULL` names a genuine
 post-migration invariant violation (`documents_authority_chk`, 0258) and is
 therefore truthful and drainable.
->>>>>>> origin/main
 
 ### E. Validate
 


### PR DESCRIPTION
`docs/organization-tenancy.md` on `main` contains literal merge-conflict markers at lines 523, 578, and 613, splitting the phase-D classification section in two.

Introduced by #1600's merge, which I performed - so this is my defect.

Both sides are disjoint and both correct:
- **HEAD side** (#1600): "Variable Sets, Rigs, and Connected Machines need no data rewrite" - the classification-assertion reasoning.
- **origin/main side** (0292): "There is no 'unclassified' count ... and one must not be reintroduced without new schema."

So the fix keeps both bodies and deletes only the three marker lines. **No prose is added, removed, or reordered** - the diff is exactly `3 deletions`.

Found by an agent re-pinning the release-schema ladder across four PRs. Worth noting why it went unnoticed: every open migration PR inherits the markers through its merge of `main`, so they never appear in any candidate's diff, and `check:docs-refs` does not scan for conflict markers.

`bun run check:docs-refs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca7x2FyxheguVcdENGs8ji