### PR TITLE
fix(react): preserve human input drafts on refresh

### DIFF
--- a/.changeset/steady-human-input-drafts.md
+++ b/.changeset/steady-human-input-drafts.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/react": patch
+---
+
+Preserve in-progress structured human-input answers when live session updates refresh the same pending request.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,6 +527,25 @@ jobs:
         with:
           name: ci-impact-plan
 
+      - name: Stabilize Ubuntu package downloads
+        run: |
+          for source_file in \
+            /etc/apt/apt-mirrors.txt \
+            /etc/apt/sources.list \
+            /etc/apt/sources.list.d/ubuntu.sources; do
+            if [[ -f "$source_file" ]]; then
+              sudo sed -i \
+                -e 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+                -e 's|https://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+                "$source_file"
+            fi
+          done
+          printf '%s\n' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "30";' \
+            'Acquire::https::Timeout "30";' \
+            | sudo tee /etc/apt/apt.conf.d/99opengeni-ci-network >/dev/null
+
       # Firefox is included because the impact plan can select the artifact
       # browser E2E tests (artifact-spreadsheet-*.browser.e2e.ts), which
       # launch Firefox; a Chromium-only install fails those shards on any
@@ -641,6 +660,25 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Stabilize Ubuntu package downloads
+        run: |
+          for source_file in \
+            /etc/apt/apt-mirrors.txt \
+            /etc/apt/sources.list \
+            /etc/apt/sources.list.d/ubuntu.sources; do
+            if [[ -f "$source_file" ]]; then
+              sudo sed -i \
+                -e 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+                -e 's|https://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+                "$source_file"
+            fi
+          done
+          printf '%s\n' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "30";' \
+            'Acquire::https::Timeout "30";' \
+            | sudo tee /etc/apt/apt.conf.d/99opengeni-ci-network >/dev/null
 
       - name: Install pinned Chromium runtime
         if: ${{ matrix.lane != 'workbench' }}
@@ -887,6 +925,25 @@ jobs:
 
       - name: Reproduce committed modality WASM packages from clean Rust sources
         run: bun scripts/rebuild-artifact-kernel-wasm-packages.ts --check
+
+      - name: Stabilize Ubuntu package downloads
+        run: |
+          for source_file in \
+            /etc/apt/apt-mirrors.txt \
+            /etc/apt/sources.list \
+            /etc/apt/sources.list.d/ubuntu.sources; do
+            if [[ -f "$source_file" ]]; then
+              sudo sed -i \
+                -e 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+                -e 's|https://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+                "$source_file"
+            fi
+          done
+          printf '%s\n' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "30";' \
+            'Acquire::https::Timeout "30";' \
+            | sudo tee /etc/apt/apt.conf.d/99opengeni-ci-network >/dev/null
 
       - name: Install Chromium for packed WASM package proof
         run: bun x playwright install --with-deps --only-shell chromium

--- a/packages/react/src/components/human-input-form.tsx
+++ b/packages/react/src/components/human-input-form.tsx
@@ -87,7 +87,15 @@ export type HumanInputFormProps = {
  * options, sticky ask/submit chrome. Hosts can replace title/description or
  * use `useHumanInputRequests` headlessly.
  */
-export function HumanInputForm({
+export function HumanInputForm(props: HumanInputFormProps) {
+  // The pending-request read model is refreshed after session events and
+  // returns newly allocated question arrays for the same durable request.
+  // Key the state owner by that request's lifecycle identity so reconciliation
+  // cannot erase an answer that the operator is still typing.
+  return <HumanInputRequestForm key={props.request.id} {...props} />;
+}
+
+function HumanInputRequestForm({
   request,
   onSubmit,
   submitting = false,
@@ -134,16 +142,6 @@ export function HumanInputForm({
   const submissionInFlight = useRef(false);
   const submissionGeneration = useRef(0);
   const busy = submitting || submittingInternally;
-
-  useEffect(() => {
-    submissionGeneration.current += 1;
-    submissionInFlight.current = false;
-    setDrafts(initialDrafts(request.questions));
-    setValidationErrors({});
-    setSubmissionError(null);
-    setSubmittingInternally(false);
-    setCollapsed(defaultCollapsed);
-  }, [request.id, request.questions, defaultCollapsed]);
 
   useEffect(() => {
     if (collapsed) {

--- a/packages/react/test/human-input.test.ts
+++ b/packages/react/test/human-input.test.ts
@@ -254,6 +254,68 @@ describe("HumanInputForm async host boundary", () => {
     expect(document.activeElement).toBe(mounted.container.querySelector("textarea"));
   });
 
+  test("preserves an in-progress answer when the same request is refreshed", async () => {
+    mounted = await renderComponent(
+      createElement(HumanInputForm, {
+        request,
+        onSubmit: () => undefined,
+        autoFocus: false,
+      }),
+    );
+    const textarea = mounted.container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      setter?.call(textarea, "Keep this answer while the session updates.");
+      const reactPropsKey = Object.keys(textarea!).find((key) => key.startsWith("__reactProps$"));
+      expect(reactPropsKey).toBeDefined();
+      const onChange = (
+        textarea as unknown as Record<
+          string,
+          { onChange?: (event: { target: HTMLTextAreaElement }) => void }
+        >
+      )[reactPropsKey!]!.onChange;
+      expect(typeof onChange).toBe("function");
+      onChange!({ target: textarea! });
+    });
+    expect(textarea?.value).toBe("Keep this answer while the session updates.");
+
+    await mounted.rerender(
+      createElement(HumanInputForm, {
+        request: {
+          ...request,
+          questions: request.questions.map((question) => ({
+            ...question,
+            options: [...question.options],
+          })),
+        },
+        onSubmit: () => undefined,
+        autoFocus: false,
+      }),
+    );
+
+    const refreshedTextarea = mounted.container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(refreshedTextarea).toBe(textarea);
+    expect(refreshedTextarea?.value).toBe("Keep this answer while the session updates.");
+
+    await mounted.rerender(
+      createElement(HumanInputForm, {
+        request: {
+          ...request,
+          id: "request-form-next",
+          questions: request.questions.map((question) => ({
+            ...question,
+            prompt: "A different durable request",
+          })),
+        },
+        onSubmit: () => undefined,
+        autoFocus: false,
+      }),
+    );
+    expect(mounted.container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("");
+    expect(mounted.container.textContent).toContain("A different durable request");
+  });
+
   test("HumanInputSurface shows one pending request at a time with progress", async () => {
     const base = {
       workspaceId: "workspace-1",

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -3731,6 +3731,18 @@ describe("workflow contracts", () => {
       e2e.steps.find((step: any) => step.name === "Run exactly the impacted E2E tests").run,
     ).toContain("scripts/ci/run-test-shard.ts --plan impact-plan.json --tier e2e");
 
+    for (const jobName of ["e2e-shards", "browser-acceptance", "package-contracts"]) {
+      const aptStabilizer = ci.jobs[jobName].steps.find(
+        (step: any) => step.name === "Stabilize Ubuntu package downloads",
+      );
+      expect(aptStabilizer.run).toContain(
+        "https://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu",
+      );
+      expect(aptStabilizer.run).toContain('Acquire::Retries "3";');
+      expect(aptStabilizer.run).toContain('Acquire::http::Timeout "30";');
+      expect(aptStabilizer.run).toContain('Acquire::https::Timeout "30";');
+    }
+
     const expectedGateNames = {
       "test-suite": [
         "React warning-free test gate",
@@ -3738,6 +3750,7 @@ describe("workflow contracts", () => {
         "Recovery integration regressions",
       ],
       "browser-acceptance": [
+        "Stabilize Ubuntu package downloads",
         "Install pinned Chromium runtime",
         "Install pinned cross-browser runtimes",
         "Editable artifact browser acceptance",
@@ -3761,6 +3774,7 @@ describe("workflow contracts", () => {
         "Production native artifact contracts",
         "Build client packages (contracts + SDK + React)",
         "Reproduce committed modality WASM packages from clean Rust sources",
+        "Stabilize Ubuntu package downloads",
         "Install Chromium for packed WASM package proof",
         "Packed SDK Worker and modality WASM packages",
         "Publish closure guard",


### PR DESCRIPTION
## Summary\n\n- Preserve in-progress structured human-input answers when live session events refresh the same pending request.\n- Reset form state only when the durable request ID changes.\n- Add regression coverage for same-request refreshes and next-request resets.\n- Stabilize Playwright system-dependency installation by replacing the repeatedly stalled Azure Ubuntu mirror and bounding apt retries/timeouts in every affected CI lane.\n- Add workflow-contract coverage requiring that stabilization in impacted E2E, browser acceptance, and packed WASM proof jobs.\n\n## Correctness\n\n- The durable human-input request ID is the form-state boundary.\n- Refreshing the same request preserves drafts, validation, collapse, and submission state.\n- A new request ID remounts clean request-local state.\n- Current main has no material overlap in the changed paths, and the synthetic merge tree is clean.\n\n## Testing\n\n- [x] Exact-head CI: source/type contracts, all unit and real-service shards, all impacted E2E shards, all browser acceptance lanes, package/bundle contracts, deployment artifacts, and workload images\n- [x] bun run typecheck\n- [x] bun test packages/react/test/human-input.test.ts packages/react/test/hooks.test.tsx (99 passed)\n- [x] bun test scripts/check-release-pr-automation.test.ts test/ci-impact-contract.test.ts (123 passed)\n- [x] oxlint, oxfmt check, and git diff --check on the changed files\n\n## Delivery integrity\n\n- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.\n- [x] origin/main is the candidate ancestor, and a fresh merge-tree check is clean.\n- [x] Adds a patch changeset for @opengeni/react.\n\n## CI diagnosis\n\nThe initial exact-head runs repeatedly stalled before tests while Playwright installed Ubuntu packages from the Azure mirror. Commit c19f3c321 bounds apt retries/timeouts and switches those CI lanes to the canonical Ubuntu archive. Every previously affected lane passed afterward. One unrelated ARM64 registry tarball extraction failed once and passed on the failed-job rerun without a source change.