### PR TITLE
test(sessions): cover documented child machine-target placement

### DIFF
--- a/apps/api/test/machine-home-backend.test.ts
+++ b/apps/api/test/machine-home-backend.test.ts
@@ -13,6 +13,9 @@
 //   - sandbox_os is derived from the targeted machine's enrollment OS on the SAME
 //     guards: a macOS machine target ⇒ 'macos', a linux machine target ⇒ 'linux',
 //     and a flags-off create leaves the "linux" default (worker ignores the pointer).
+//   - a child of backend:'none' or a boxed (modal) parent, with only
+//     targetSandboxId (sandbox + sandboxBackend omitted) ⇒ own selfhosted home,
+//     own group, pointer seeded — honest-label, not caller sandboxBackend.
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import postgres from "postgres";
@@ -363,7 +366,7 @@ describe("Stage-D honest label: machine-targeted home sandbox_backend", () => {
     expect(turnRow?.sandbox_backend).toBe("modal");
   }, 60_000);
 
-  test("a child of a backend:'none' manager with a machine target (sandbox omitted) ⇒ own selfhosted home", async () => {
+  test("a child of a backend:'none' manager with a machine target (sandbox and sandboxBackend omitted) ⇒ own selfhosted home", async () => {
     if (!available) return;
     const { accountId, workspaceId, sandboxId, bus } = await seedMachine();
     const parent = await createSessionForRequest(
@@ -377,13 +380,46 @@ describe("Stage-D honest label: machine-targeted home sandbox_backend", () => {
     );
     expect(parent.sandboxBackend).toBe("none");
 
+    // Documented client path: omit sandbox and sandboxBackend; only name the
+    // machine. Honest-label must still win over the "modal" deployment default.
     const child = await createSessionForRequest(
       deps(bus),
       grant(accountId, workspaceId, parent.id),
       workspaceId,
       {
         initialMessage: "run the worker on the connected machine",
-        sandboxBackend: "selfhosted",
+        targetSandboxId: sandboxId,
+      },
+    );
+    expect(child.parentSessionId).toBe(parent.id);
+    expect(child.sandboxBackend).toBe("selfhosted");
+    expect(child.sandboxGroupId).toBe(child.id);
+    expect(child.sandboxGroupId).not.toBe(parent.sandboxGroupId);
+    expect(child.activeSandboxId).toBe(sandboxId);
+    const [turnRow] = await admin<{ sandbox_backend: string }[]>`
+      select sandbox_backend from session_turns where session_id = ${child.id} limit 1`;
+    expect(turnRow?.sandbox_backend).toBe("selfhosted");
+  }, 60_000);
+
+  test("a child of a boxed (modal) manager with a machine target (sandbox omitted) ⇒ own selfhosted home, not the parent's group", async () => {
+    if (!available) return;
+    const { accountId, workspaceId, sandboxId, bus } = await seedMachine();
+    const parent = await createSessionForRequest(
+      deps(bus),
+      grant(accountId, workspaceId),
+      workspaceId,
+      {
+        initialMessage: "manager on the cloud box",
+      },
+    );
+    expect(parent.sandboxBackend).toBe("modal");
+
+    const child = await createSessionForRequest(
+      deps(bus),
+      grant(accountId, workspaceId, parent.id),
+      workspaceId,
+      {
+        initialMessage: "run the worker on the connected machine",
         targetSandboxId: sandboxId,
       },
     );

--- a/apps/api/test/sandbox-shared-and-viewer.test.ts
+++ b/apps/api/test/sandbox-shared-and-viewer.test.ts
@@ -650,6 +650,29 @@ describe("P1.4 shared-sandbox create resolution (real createSessionForRequest + 
     });
   }, 60_000);
 
+  test("explicit {groupId} plus targetSandboxId ⇒ 422 (a machine target cannot join a sibling group)", async () => {
+    if (!available) return;
+    const { accountId, workspaceId } = await freshWorkspace();
+    const bus = new MemoryEventBus();
+    const parent = await createSessionForRequest(
+      deps(bus),
+      grant(accountId, workspaceId),
+      workspaceId,
+      { initialMessage: "manager" },
+    );
+    await expect(
+      createSessionForRequest(deps(bus), grant(accountId, workspaceId, parent.id), workspaceId, {
+        initialMessage: "pin to a machine while joining a group",
+        sandbox: { groupId: parent.sandboxGroupId },
+        targetSandboxId: crypto.randomUUID(),
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message:
+        "targetSandboxId requires an own sandbox (omit sandbox or pass 'new'); it cannot join a shared group",
+    });
+  }, 60_000);
+
   test("targetSandboxId is consumed (seedTargetSandbox path) — rejects on a backend:'none' session", async () => {
     if (!available) return;
     const { accountId, workspaceId } = await freshWorkspace();

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1960,15 +1960,16 @@ export async function createSessionForRequestWithOutcome(
   // so the session row + first turn honestly reflect where the agent runs (the
   // Machines dashboard, the turn's warm-metering, and the file-download plane all
   // key off this). GUARDS: (1) only when not inheriting a shared box
-  // (inheritedBackend undefined) — a shared/{groupId} spawn is literally the
-  // creator's box and must NOT be relabeled; a named targetSandboxId already
-  // forced an own-box default above, so child machine targets take this path
-  // too; (2) only when the target's kind is actually "selfhosted" —
-  // targetSandboxId also accepts a first-class MODAL sandbox id (resolveTarget),
-  // which must never be mislabeled. A not-found / non-selfhosted / modal target
-  // falls through to the default; the seed swap in createAndStartSession still
-  // validates ownership/liveness and 422s a bad target. (3) only when the feature
-  // flags that make the worker actually take the machine-primary path are ON
+  // (inheritedBackend undefined). Named targetSandboxId already 422s
+  // shared/{groupId} and defaults omission to own-box above, so this check is a
+  // backstop if those placement rules change; a shared spawn without a target
+  // is still literally the creator's box and must NOT be relabeled; (2) only
+  // when the target's kind is actually "selfhosted" — targetSandboxId also
+  // accepts a first-class MODAL sandbox id (resolveTarget), which must never be
+  // mislabeled. A not-found / non-selfhosted / modal target falls through to the
+  // default; the seed swap in createAndStartSession still validates
+  // ownership/liveness and 422s a bad target. (3) only when the feature flags
+  // that make the worker actually take the machine-primary path are ON
   // (sandboxOwnershipEnabled + sandboxSelfhostedEnabled/routing) — otherwise the
   // worker ignores the active pointer and a home="selfhosted" turn would fall to
   // the registry client with no bound agentId and throw; with the flags off we


### PR DESCRIPTION
## Summary
- Prove a child `machineTarget` with sandbox and `sandboxBackend` omitted still gets an own `selfhosted` home via honest-label, for both `backend: none` and boxed (modal) parents.
- Prove explicit `{groupId}` plus `targetSandboxId` 422s the same as `"shared"`.
- Clarify that the `inheritedBackend` honest-label guard is a backstop after share+target already 422s.

## Test plan
- [x] `bun test apps/api/test/machine-home-backend.test.ts apps/api/test/sandbox-shared-and-viewer.test.ts`


Made with [Cursor](https://cursor.com)