### PR TITLE
chore(release): prepare product 0.23.12

### DIFF
--- a/deploy/helm/opengeni/Chart.yaml
+++ b/deploy/helm/opengeni/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opengeni
 description: OpenGeni API, web, worker, and migration workloads.
 type: application
-version: 0.23.11
-appVersion: "0.23.11"
+version: 0.23.12
+appVersion: "0.23.12"


### PR DESCRIPTION
Prepare the immutable OpenGeni 0.23.12 product release from current protected main after the generated package-version merge.

This PR changes only the Helm chart and app version from 0.23.11 to 0.23.12 so managed production (`app.opengeni.ai`) can take the 22 commits currently on main, including maintenance migration 0289.

Verification: `bun test scripts/release-version.test.ts` (2 pass, 0 fail) and `git diff --check`.


Made with [Cursor](https://cursor.com)