### PR TITLE
chore(config): stop changelog italics from eating view_image

### DIFF
--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Patch Changes
 
-- f4afa19: Advertise SuperGrok image input so Grok and Gateway Kimi receive attachments, view*image, and computer*\* screenshots. DeepSeek stays text-only.
+- f4afa19: Advertise SuperGrok image input so Grok and Gateway Kimi receive attachments, `view_image`, and `computer_*` screenshots. DeepSeek stays text-only.
 - Updated dependencies [1c78ed0]
 - Updated dependencies [f4afa19]
 - Updated dependencies [8583779]


### PR DESCRIPTION
Changesets markdown-round-tripped `view_image` / `computer_*` into `view*image` / `computer*\*` in `@opengeni/config` 0.17.0. That one-line drift is also what blocked Version PR tree reproduction.

Wrap the identifiers in backticks so the unpublished 0.17.0 notes match the source changeset. Needed so we can retain a later main SHA as the ordinary-release controller for 0.23.12 (controller must differ from source).


Made with [Cursor](https://cursor.com)