### PR TITLE
fix(supergrok): persist device tokens without userinfo

### DIFF
--- a/apps/api/src/routes/supergrok.ts
+++ b/apps/api/src/routes/supergrok.ts
@@ -31,11 +31,11 @@ import {
   XAI_CLIENT_VERSION,
   XaiSubscriptionError,
   fetchXaiSubscriptionModels,
-  fetchXaiVerifiedIdentity,
   pollXaiDeviceCode,
   refreshXaiToken,
   requestXaiDeviceCode,
   xaiAccessTokenExpiry,
+  xaiIdentityFromDeviceTokens,
   type XaiFetch,
   type XaiProxyAuthContext,
 } from "@opengeni/xai-subscription";
@@ -392,6 +392,7 @@ export function registerSuperGrokRoutes(app: Hono, deps: ApiRouteDeps): void {
     if (Math.floor(Date.now() / 1_000) >= state.expiresAt) {
       return c.json({ status: "expired" as const });
     }
+    let phase = "device_token_exchange";
     try {
       const poll = await pollXaiDeviceCode(
         {
@@ -401,9 +402,9 @@ export function registerSuperGrokRoutes(app: Hono, deps: ApiRouteDeps): void {
         { fetch: (deps.xaiFetch ?? fetch) as XaiFetch },
       );
       if (poll.status !== "authorized") return c.json(poll);
-      const identity = await fetchXaiVerifiedIdentity(poll.tokens.accessToken, {
-        fetch: (deps.xaiFetch ?? fetch) as XaiFetch,
-      });
+      phase = "token_identity";
+      const identity = xaiIdentityFromDeviceTokens(poll.tokens);
+      phase = "credential_persist";
       const encryptionKey = environmentsEncryptionKeyBytes(deps.settings);
       if (!encryptionKey) {
         throw new HTTPException(500, {
@@ -458,6 +459,24 @@ export function registerSuperGrokRoutes(app: Hono, deps: ApiRouteDeps): void {
         email: identity.email,
       });
     } catch (error) {
+      deps.observability?.warn("SuperGrok connection operation failed", {
+        provider: "xai",
+        providerApi: "oauth",
+        op: phase,
+        outcome: "failed",
+        reason:
+          error instanceof XaiSubscriptionError
+            ? error.kind
+            : error instanceof HTTPException
+              ? "http_exception"
+              : "unexpected",
+        status:
+          error instanceof XaiSubscriptionError
+            ? error.status
+            : error instanceof HTTPException
+              ? error.status
+              : undefined,
+      });
       throw xaiHttpError(error, "SuperGrok device login failed");
     }
   });

--- a/apps/api/test/supergrok-routes.test.ts
+++ b/apps/api/test/supergrok-routes.test.ts
@@ -37,6 +37,7 @@ let managedSubjectId = "";
 let managedApp: Hono | null = null;
 let available = true;
 let deviceSequence = 0;
+let userinfoRequests = 0;
 
 const settings = testSettings({
   productAccessMode: "configured",
@@ -51,6 +52,10 @@ const managedSettings = testSettings({
   publicBaseUrl: PUBLIC_ORIGIN,
   supergrokSubscriptionEnabled: true,
 });
+
+function jwt(payload: Record<string, unknown>): string {
+  return `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+}
 
 const xaiFetch: typeof fetch = async (input, init) => {
   const url = String(input);
@@ -75,18 +80,24 @@ const xaiFetch: typeof fetch = async (input, init) => {
       });
     }
     return Response.json({
-      access_token: `access-${deviceSequence}`,
+      access_token: jwt({
+        principal_type: "User",
+        principal_id: "xai-user-1",
+        exp: Math.floor(Date.now() / 1_000) + 3_600,
+      }),
       refresh_token: `refresh-${deviceSequence}`,
+      id_token: jwt({
+        sub: "xai-user-1",
+        email: "owner@example.com",
+        email_verified: true,
+        name: "Owner",
+      }),
       expires_in: 3600,
     });
   }
   if (url.endsWith("/oauth2/userinfo")) {
-    return Response.json({
-      sub: "xai-user-1",
-      email: "owner@example.com",
-      email_verified: true,
-      name: "Owner",
-    });
+    userinfoRequests += 1;
+    throw new Error("device connection must not call xAI userinfo");
   }
   if (url.endsWith("/models")) {
     return Response.json({
@@ -346,6 +357,7 @@ describe("SuperGrok subscription routes", () => {
     expect(serialized).not.toContain("access-");
     expect(serialized).not.toContain("refresh-");
     expect(serialized).not.toContain("credentialEncrypted");
+    expect(userinfoRequests).toBe(0);
 
     const status = await request("/supergrok/status");
     expect(status.status).toBe(200);

--- a/apps/web/src/components/supergrok-connection.tsx
+++ b/apps/web/src/components/supergrok-connection.tsx
@@ -23,6 +23,8 @@ import { MetaChip } from "@/components/ui/meta-chip";
 import { Select } from "@/components/ui/select";
 import { useAppContext } from "@/context";
 
+import { pollSuperGrokDeviceLogin } from "./supergrok-device-poll";
+
 type PendingDeviceCode = {
   userCode: string;
   verificationUri: string;
@@ -84,6 +86,7 @@ export function SuperGrokSubscriptionsCard({
   const [editing, setEditing] = useState<{ id: string; value: string } | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const cancelled = useRef(false);
+  const pollAbort = useRef<AbortController | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -101,6 +104,8 @@ export function SuperGrokSubscriptionsCard({
     void refresh();
     return () => {
       cancelled.current = true;
+      pollAbort.current?.abort();
+      pollAbort.current = null;
     };
   }, [refresh]);
 
@@ -117,42 +122,38 @@ export function SuperGrokSubscriptionsCard({
         "_blank",
         "noopener,noreferrer",
       );
-      const poll = async (delaySeconds: number): Promise<void> => {
-        let result: Awaited<ReturnType<typeof client.supergrokConnectPoll>>;
-        try {
-          result = await client.supergrokConnectPoll(workspaceId, start.state);
-        } catch (error) {
-          if (!cancelled.current) {
-            setPending(null);
-            toast.error(error instanceof Error ? error.message : "Failed to verify xAI login");
-          }
-          return;
-        }
-        if (result.status === "connected") {
-          if (!cancelled.current) {
-            setPending(null);
+      pollAbort.current?.abort();
+      const controller = new AbortController();
+      pollAbort.current = controller;
+      void pollSuperGrokDeviceLogin({
+        poll: () => client.supergrokConnectPoll(workspaceId, start.state),
+        initialIntervalSeconds: start.intervalSeconds,
+        expiresAtMs: Date.now() + start.expiresInSeconds * 1_000,
+        signal: controller.signal,
+      })
+        .then(async (result) => {
+          if (!result || controller.signal.aborted || cancelled.current) return;
+          setPending(null);
+          if (result.status === "connected") {
             toast.success(
               result.scope === "workspace"
                 ? "SuperGrok connected for the workspace"
                 : "Private SuperGrok account connected",
             );
             await refresh();
+            return;
           }
-          return;
-        }
-        if (result.status === "expired" || result.status === "denied") {
-          if (!cancelled.current) {
+          toast.error(result.status === "expired" ? "The xAI code expired" : "xAI login denied");
+        })
+        .catch((error) => {
+          if (!controller.signal.aborted && !cancelled.current) {
             setPending(null);
-            toast.error(result.status === "expired" ? "The xAI code expired" : "xAI login denied");
+            toast.error(error instanceof Error ? error.message : "Failed to verify xAI login");
           }
-          return;
-        }
-        if (result.status === "pending" || result.status === "slow_down") {
-          const nextDelay = Math.max(1, result.intervalSeconds ?? delaySeconds);
-          setTimeout(() => void poll(nextDelay), nextDelay * 1_000);
-        }
-      };
-      setTimeout(() => void poll(start.intervalSeconds), start.intervalSeconds * 1_000);
+        })
+        .finally(() => {
+          if (pollAbort.current === controller) pollAbort.current = null;
+        });
     } catch (error) {
       setPending(null);
       toast.error(error instanceof Error ? error.message : "Failed to start xAI login");

--- a/apps/web/src/components/supergrok-device-poll.test.ts
+++ b/apps/web/src/components/supergrok-device-poll.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { OpenGeniApiError } from "@opengeni/sdk";
+
+import { pollSuperGrokDeviceLogin } from "./supergrok-device-poll";
+
+describe("SuperGrok device polling", () => {
+  test("backs off after retryable API errors and continues to connection", async () => {
+    let now = 0;
+    const delays: number[] = [];
+    const responses = [
+      new OpenGeniApiError(502, "", { retryable: true, mutation: true }),
+      { status: "pending" as const, intervalSeconds: 5 },
+      {
+        status: "connected" as const,
+        accountId: "account-1",
+        scope: "workspace" as const,
+        isActive: true,
+      },
+    ];
+    const result = await pollSuperGrokDeviceLogin({
+      initialIntervalSeconds: 5,
+      expiresAtMs: 60_000,
+      signal: new AbortController().signal,
+      now: () => now,
+      wait: async (delayMs) => {
+        delays.push(delayMs);
+        now += delayMs;
+        return true;
+      },
+      poll: async () => {
+        const response = responses.shift();
+        if (response instanceof Error) throw response;
+        return response!;
+      },
+    });
+
+    expect(result).toEqual({
+      status: "connected",
+      accountId: "account-1",
+      scope: "workspace",
+      isActive: true,
+    });
+    expect(delays).toEqual([5_000, 10_000, 5_000]);
+  });
+
+  test("surfaces non-retryable API errors", async () => {
+    const error = new OpenGeniApiError(403, JSON.stringify({ message: "forbidden" }), {
+      mutation: true,
+    });
+    await expect(
+      pollSuperGrokDeviceLogin({
+        initialIntervalSeconds: 1,
+        expiresAtMs: 60_000,
+        signal: new AbortController().signal,
+        now: () => 0,
+        wait: async () => true,
+        poll: async () => {
+          throw error;
+        },
+      }),
+    ).rejects.toBe(error);
+  });
+
+  test("stops at the provider deadline without another poll", async () => {
+    let now = 0;
+    let polls = 0;
+    const result = await pollSuperGrokDeviceLogin({
+      initialIntervalSeconds: 5,
+      expiresAtMs: 2_000,
+      signal: new AbortController().signal,
+      now: () => now,
+      wait: async (delayMs) => {
+        now += delayMs;
+        return true;
+      },
+      poll: async () => {
+        polls += 1;
+        return { status: "pending", intervalSeconds: 5 };
+      },
+    });
+
+    expect(result).toEqual({ status: "expired" });
+    expect(polls).toBe(0);
+  });
+});

--- a/apps/web/src/components/supergrok-device-poll.ts
+++ b/apps/web/src/components/supergrok-device-poll.ts
@@ -1,0 +1,62 @@
+import { OpenGeniApiError, type SuperGrokConnectPoll } from "@opengeni/sdk";
+
+type WaitForDelay = (delayMs: number, signal: AbortSignal) => Promise<boolean>;
+
+async function waitForDelay(delayMs: number, signal: AbortSignal): Promise<boolean> {
+  if (signal.aborted) return false;
+  return await new Promise<boolean>((resolve) => {
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", abort);
+      resolve(true);
+    }, delayMs);
+    const abort = () => {
+      clearTimeout(timeout);
+      resolve(false);
+    };
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function isRetryablePollError(error: unknown): boolean {
+  return error instanceof TypeError || (error instanceof OpenGeniApiError && error.retryable);
+}
+
+export async function pollSuperGrokDeviceLogin(options: {
+  poll: () => Promise<SuperGrokConnectPoll>;
+  initialIntervalSeconds: number;
+  expiresAtMs: number;
+  signal: AbortSignal;
+  now?: () => number;
+  wait?: WaitForDelay;
+  maxRetryDelaySeconds?: number;
+}): Promise<SuperGrokConnectPoll | null> {
+  const now = options.now ?? Date.now;
+  const wait = options.wait ?? waitForDelay;
+  const initialIntervalSeconds = Math.max(1, options.initialIntervalSeconds);
+  const maxRetryDelaySeconds = Math.max(initialIntervalSeconds, options.maxRetryDelaySeconds ?? 30);
+  let nextDelaySeconds = initialIntervalSeconds;
+
+  while (!options.signal.aborted) {
+    const remainingMs = options.expiresAtMs - now();
+    if (remainingMs <= 0) return { status: "expired" };
+    const elapsed = await wait(Math.min(nextDelaySeconds * 1_000, remainingMs), options.signal);
+    if (!elapsed || options.signal.aborted) return null;
+    if (now() >= options.expiresAtMs) return { status: "expired" };
+
+    let result: SuperGrokConnectPoll;
+    try {
+      result = await options.poll();
+    } catch (error) {
+      if (!isRetryablePollError(error)) throw error;
+      nextDelaySeconds = Math.min(
+        maxRetryDelaySeconds,
+        Math.max(initialIntervalSeconds, nextDelaySeconds * 2),
+      );
+      continue;
+    }
+    if (options.signal.aborted) return null;
+    if (result.status !== "pending" && result.status !== "slow_down") return result;
+    nextDelaySeconds = Math.max(1, result.intervalSeconds ?? nextDelaySeconds);
+  }
+  return null;
+}

--- a/docs/supergrok-subscription.md
+++ b/docs/supergrok-subscription.md
@@ -26,10 +26,20 @@ is authenticated-encrypted at rest, so a stable
 materialization can succeed.
 
 Connection uses xAI's OAuth device flow. The API returns a user code and
-verification URI, polls the provider server-side, verifies the OIDC user-info
-identity, and upserts the encrypted credential by provider identity. List,
-status, SDK, React, and web surfaces are metadata-only; access tokens, refresh
-tokens, cookies, encrypted blobs, and provider response bodies never cross them.
+verification URI, polls the provider server-side, derives the selected
+user/team/organization identity from the token claims returned directly by the
+xAI HTTPS token endpoint, and upserts the encrypted credential by that provider
+identity without a second user-info request. xAI validates the access token on
+provider API use. The browser honors the provider interval and keeps polling
+through retryable gateway or network failures with bounded backoff until the
+device code's absolute expiry. List, status, SDK, React, and web surfaces are
+metadata-only; access tokens, refresh tokens, cookies, encrypted blobs, and
+provider response bodies never cross them.
+
+Connection failures emit only fixed provider/phase/outcome fields and the
+grammar-validated HTTP correlation id when structured logs are enabled. OAuth
+material, workspace or subject identifiers, provider bodies, and raw exception
+messages are never projected into public logs.
 
 ## Authority model
 

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -292,6 +292,7 @@ const PUBLIC_TELEMETRY_ATTRIBUTE_KEYS = new Set([
  * caller accidentally publish a raw identifier under that name. */
 const PUBLIC_TELEMETRY_OPAQUE_ATTRIBUTE_PATTERNS = new Map<string, RegExp>([
   ["sandboxLeaseKey", /^slk_[0-9a-f]{32}$/],
+  ["correlationId", /^[A-Za-z0-9._:-]{1,128}$/],
 ]);
 
 const PUBLIC_CHANNEL_A_OPERATIONS = new Set([
@@ -1141,6 +1142,7 @@ function projectPublicDiagnosticAttributes(attributes: Attributes): Attributes {
   const errorCode = attributes.errorCode;
   const status = attributes.status;
   const origin = attributes.origin;
+  const correlationId = attributes.correlationId;
   return {
     errorClass:
       typeof errorClass === "string" && PUBLIC_TELEMETRY_ERROR_CLASSES.has(errorClass)
@@ -1153,6 +1155,10 @@ function projectPublicDiagnosticAttributes(attributes: Attributes): Attributes {
       ? { status }
       : {}),
     ...(typeof origin === "string" && PUBLIC_TELEMETRY_ERROR_ORIGINS.has(origin) ? { origin } : {}),
+    ...(typeof correlationId === "string" &&
+    PUBLIC_TELEMETRY_OPAQUE_ATTRIBUTE_PATTERNS.get("correlationId")?.test(correlationId)
+      ? { correlationId }
+      : {}),
   };
 }
 

--- a/packages/observability/test/observability.test.ts
+++ b/packages/observability/test/observability.test.ts
@@ -516,6 +516,40 @@ describe("observability", () => {
     expect(JSON.parse(observed[1]!)).not.toHaveProperty("sandboxLeaseKey");
   });
 
+  test("public structured logs retain only grammar-validated request correlation ids", () => {
+    const observed: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => observed.push(String(message));
+    try {
+      const obs = createObservability(settings, { component: "api", now: () => 1 });
+      obs.warn("valid", {
+        correlationId: "request.2026-08-19:abc_123",
+        errorClass: "HttpOperationError",
+        errorCode: "internal_error",
+        status: 502,
+        workspaceId: "workspace-must-not-leak",
+      });
+      obs.warn("invalid", {
+        correlationId: "request id with spaces and bearer material",
+        errorClass: "HttpOperationError",
+        errorCode: "internal_error",
+        status: 502,
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(JSON.parse(observed[0]!)).toMatchObject({
+      message: "valid",
+      correlationId: "request.2026-08-19:abc_123",
+      errorClass: "HttpOperationError",
+      errorCode: "internal_error",
+      status: 502,
+    });
+    expect(JSON.parse(observed[0]!)).not.toHaveProperty("workspaceId");
+    expect(JSON.parse(observed[1]!)).not.toHaveProperty("correlationId");
+  });
+
   test("physical cancellation logs retain duration and safe sandbox correlation", () => {
     const observed: string[] = [];
     const originalLog = console.log;

--- a/packages/xai-subscription/src/oauth.ts
+++ b/packages/xai-subscription/src/oauth.ts
@@ -316,6 +316,41 @@ export async function fetchXaiVerifiedIdentity(
   };
 }
 
+/**
+ * Derive stable account metadata from the token response returned directly by
+ * xAI's HTTPS device-token endpoint. The access-token principal identifies the
+ * selected user/team/org account when present; ID-token claims provide the
+ * human-readable profile metadata. Provider requests still validate the access
+ * token before any subscription capability is used.
+ */
+export function xaiIdentityFromDeviceTokens(tokens: XaiOAuthTokens): XaiVerifiedIdentity {
+  const accessClaims = decodeXaiJwtPayload(tokens.accessToken);
+  const idClaims = tokens.idToken ? decodeXaiJwtPayload(tokens.idToken) : null;
+  const subject =
+    nullableString(accessClaims?.principal_id) ??
+    nullableString(accessClaims?.principalId) ??
+    nullableString(idClaims?.sub) ??
+    nullableString(accessClaims?.sub);
+  if (!subject) {
+    throw new XaiSubscriptionError(
+      "invalid_response",
+      "xAI OAuth token response is missing account identity",
+    );
+  }
+  const givenName =
+    nullableString(idClaims?.given_name) ?? nullableString(accessClaims?.given_name);
+  const familyName =
+    nullableString(idClaims?.family_name) ?? nullableString(accessClaims?.family_name);
+  const combinedName = [givenName, familyName].filter(Boolean).join(" ") || null;
+  const emailVerifiedClaim = idClaims?.email_verified ?? accessClaims?.email_verified;
+  return {
+    subject,
+    email: nullableString(idClaims?.email) ?? nullableString(accessClaims?.email),
+    emailVerified: typeof emailVerifiedClaim === "boolean" ? emailVerifiedClaim : null,
+    name: nullableString(idClaims?.name) ?? nullableString(accessClaims?.name) ?? combinedName,
+  };
+}
+
 export function decodeXaiJwtPayload(jwt: string): Record<string, unknown> | null {
   const payload = jwt.split(".")[1];
   if (!payload) return null;

--- a/packages/xai-subscription/test/oauth.test.ts
+++ b/packages/xai-subscription/test/oauth.test.ts
@@ -10,7 +10,9 @@ import {
   XAI_OAUTH_SCOPES,
   XaiSubscriptionReloginRequired,
   xaiAccessTokenExpiry,
+  xaiIdentityFromDeviceTokens,
   type XaiFetch,
+  type XaiOAuthTokens,
 } from "../src";
 
 type Call = { input: string | URL | Request; init?: RequestInit };
@@ -24,6 +26,21 @@ function recorder(handler: (call: Call) => Response): { fetch: XaiFetch; calls: 
       calls.push(call);
       return handler(call);
     },
+  };
+}
+
+function jwt(payload: Record<string, unknown>): string {
+  return `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+}
+
+function tokens(input: Partial<XaiOAuthTokens> = {}): XaiOAuthTokens {
+  return {
+    accessToken: input.accessToken ?? jwt({ sub: "access-user" }),
+    refreshToken: input.refreshToken ?? "refresh",
+    idToken: input.idToken ?? null,
+    tokenType: input.tokenType ?? "Bearer",
+    scope: input.scope ?? null,
+    expiresInSeconds: input.expiresInSeconds ?? 3_600,
   };
 }
 
@@ -134,6 +151,53 @@ describe("xAI refresh and identity", () => {
       emailVerified: true,
       name: "Jane",
     });
+  });
+
+  test("derives personal identity from the direct token response", () => {
+    expect(
+      xaiIdentityFromDeviceTokens(
+        tokens({
+          accessToken: jwt({ sub: "access-user" }),
+          idToken: jwt({
+            sub: "user-123",
+            email: "jane@example.com",
+            email_verified: true,
+            name: "Jane",
+          }),
+        }),
+      ),
+    ).toEqual({
+      subject: "user-123",
+      email: "jane@example.com",
+      emailVerified: true,
+      name: "Jane",
+    });
+  });
+
+  test("prefers the selected access-token principal for team or organization accounts", () => {
+    expect(
+      xaiIdentityFromDeviceTokens(
+        tokens({
+          accessToken: jwt({
+            principalType: "Team",
+            principalId: "team-456",
+            sub: "user-123",
+          }),
+          idToken: jwt({ sub: "user-123", given_name: "Jane", family_name: "Doe" }),
+        }),
+      ),
+    ).toEqual({
+      subject: "team-456",
+      email: null,
+      emailVerified: null,
+      name: "Jane Doe",
+    });
+  });
+
+  test("rejects a token response without a stable account identity", () => {
+    expect(() =>
+      xaiIdentityFromDeviceTokens(tokens({ accessToken: "opaque", idToken: null })),
+    ).toThrow("account identity");
   });
 
   test("decodes access-token exp only for refresh scheduling", () => {


### PR DESCRIPTION
## Summary
- derive the selected xAI user/team/org identity from claims returned by the device-token response and persist immediately, removing the failing post-token `/oauth2/userinfo` dependency
- keep browser device polling alive through retryable gateway/network failures with bounded backoff until provider expiry
- retain grammar-validated HTTP correlation IDs in structured diagnostic logs and add safe fixed-phase SuperGrok failure telemetry

## Validation
- `bun test packages/xai-subscription/test/oauth.test.ts --timeout 30000`
- `bun test apps/web/src/components/supergrok-device-poll.test.ts apps/web/src/components/supergrok-connection.test.tsx --timeout 30000`
- `bun test packages/observability/test/observability.test.ts --timeout 30000`
- `bun test apps/api/test/supergrok-routes.test.ts --timeout 180000`
- `bun run typecheck`
- targeted `oxlint --deny-warnings`
- `bun run check:docs-refs`
- conflict-free merge tree against current `origin/main`
