### PR TITLE
feat: Gateway Gemini 3.7 Flash, GLM 5.3, and compact settings chrome

### DIFF
--- a/.changeset/gateway-gemini-glm.md
+++ b/.changeset/gateway-gemini-glm.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/config": patch
+---
+
+Add curated Vercel AI Gateway catalog entries for Gemini 3.7 Flash and GLM 5.3, with reviewed Google→Vertex and Z.AI routes, conservative credit fallbacks, and Kimi/DeepSeek-style vision split.

--- a/.env.example
+++ b/.env.example
@@ -225,8 +225,9 @@ OPENGENI_OPENAI_REASONING_EFFORT=low
 OPENGENI_OPENAI_ALLOWED_MODELS=gpt-5.6-sol,gpt-5.6-terra,gpt-5.6-luna
 OPENGENI_OPENAI_ALLOWED_REASONING_EFFORTS=low,medium,high,xhigh,max
 OPENGENI_OPENAI_API_KEY=your-key
-# Optional OpenGeni-managed AI Gateway key. Adds the curated DeepSeek and Kimi
-# models; workspace-owned Gateway keys are connected encrypted in Settings.
+# Optional OpenGeni-managed AI Gateway key. Adds the curated DeepSeek, Kimi,
+# Gemini 3.7 Flash, and GLM 5.3 models; workspace-owned Gateway keys are
+# connected encrypted in Settings.
 # OPENGENI_VERCEL_AI_GATEWAY_API_KEY=vck_...
 # Image model used only by the workspace-owned Gateway image adapter. Direct
 # OpenAI and connected Codex use their native/account-scoped GPT Image 2 paths.

--- a/apps/api/test/model-catalog.test.ts
+++ b/apps/api/test/model-catalog.test.ts
@@ -57,15 +57,32 @@ describe("workspace model catalog availability", () => {
     });
     expect(managed.deployment).toBeUndefined();
     expect(managed.credentialSource).toBeUndefined();
+    const gemini = disconnected.models.find((model) => model.id === "gemini-3.7-flash")!;
+    const glm = disconnected.models.find((model) => model.id === "glm-5.3")!;
+    expect(gemini).toMatchObject({
+      label: "Gemini 3.7 Flash",
+      shortLabel: "3.7 Flash",
+      source: "opengeni",
+    });
+    expect(glm).toMatchObject({
+      label: "GLM 5.3",
+      shortLabel: "GLM 5.3",
+      source: "opengeni",
+    });
     const publicManagedModel = JSON.stringify(managed);
+    const publicNewModels = JSON.stringify([gemini, glm]);
     for (const internalName of [
       "baseten",
       "novita",
       "deepinfra",
       "fireworks",
+      "google",
+      "vertex",
+      "zai",
       "ai-gateway.vercel.sh",
     ]) {
       expect(publicManagedModel).not.toContain(internalName);
+      expect(publicNewModels).not.toContain(internalName);
     }
 
     const workspaceModel = disconnected.models.find(

--- a/apps/web/src/components/model-access-policy.test.tsx
+++ b/apps/web/src/components/model-access-policy.test.tsx
@@ -223,6 +223,24 @@ describe("workspace model access policy editor", () => {
     });
   });
 
+  test("collapses the editor by default", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(<ModelAccessPolicySection workspaceId="workspace-a" canManage />);
+        await flush();
+      });
+
+      expect(container.querySelector("details")?.open).toBe(false);
+      expect(container.textContent).toContain("3 of 3");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
   test("keeps provider identities private and confirms before exact-model conversion", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -242,14 +260,14 @@ describe("workspace model access policy editor", () => {
       expect(chooseExact).toBeDefined();
       await act(async () => chooseExact?.click());
       expect(container.textContent).toContain("Replace the provider-level model policy?");
-      expect(container.textContent).not.toContain("Allow selected model IDs");
+      expect(container.textContent).not.toContain("Selected models");
 
       const confirm = [...container.querySelectorAll("button")].find((button) =>
         button.textContent?.includes("Confirm replacement"),
       );
       await act(async () => confirm?.click());
       expect(container.textContent).toContain("Provider-level restriction will be replaced");
-      expect(container.textContent).toContain("Allow selected model IDs");
+      expect(container.textContent).toContain("Selected models");
       expect(container.textContent).not.toContain("private-provider-id");
     } finally {
       await act(async () => root.unmount());
@@ -305,9 +323,7 @@ describe("workspace model access policy editor", () => {
         );
         await flush();
       });
-      expect(container.textContent).toContain(
-        "All configured models are permitted by workspace policy.",
-      );
+      expect(container.textContent).toContain("All models");
       expect(container.textContent).not.toContain("Provider-level restriction active");
 
       await act(async () => {
@@ -319,9 +335,7 @@ describe("workspace model access policy editor", () => {
         await flush();
       });
 
-      expect(container.textContent).toContain(
-        "All configured models are permitted by workspace policy.",
-      );
+      expect(container.textContent).toContain("All models");
       expect(container.textContent).not.toContain("Provider-level restriction active");
       expect(
         getWorkspaceModelAccessPolicy.mock.calls.filter(([workspaceId]) =>

--- a/apps/web/src/components/model-access-policy.tsx
+++ b/apps/web/src/components/model-access-policy.tsx
@@ -1,5 +1,5 @@
 import type { WorkspaceModelAccessPolicy, WorkspaceModelCatalogModel } from "@opengeni/sdk";
-import { CheckIcon, Loader2Icon, LockKeyholeIcon, PlusIcon, XIcon } from "lucide-react";
+import { ChevronDownIcon, Loader2Icon, LockKeyholeIcon, PlusIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -104,6 +104,7 @@ export function ModelAccessPolicySection({
   const [pendingReplacementMode, setPendingReplacementMode] = useState<
     "unrestricted" | "selected" | null
   >(null);
+  const [open, setOpen] = useState(false);
   const loadGeneration = useRef(0);
   const scopeRef = useRef({ client, mounted: false, workspaceId });
 
@@ -219,258 +220,256 @@ export function ModelAccessPolicySection({
 
   const providerRestrictionActive = draft?.originalPolicy.allowedProviders !== null;
   const visiblePolicyAllowedCount = models.filter((model) => model.policyAllowed).length;
+  const summaryStatus = error
+    ? "Unavailable"
+    : loading || !draft
+      ? "…"
+      : draft.mode === "unrestricted"
+        ? "All models"
+        : draft.mode === "selected"
+          ? `${draft.selectedModelIds.size} selected`
+          : draft.policyVerdictComplete
+            ? `${visiblePolicyAllowedCount} of ${models.length}`
+            : "Restricted";
 
   return (
-    <section aria-labelledby="workspace-model-access-heading" className="grid min-w-0 gap-2">
-      <div className="flex items-start gap-2">
-        <LockKeyholeIcon className="mt-0.5 size-4 shrink-0 text-brand" />
-        <div className="min-w-0">
-          <h2 id="workspace-model-access-heading" className="text-sm font-medium">
+    <section aria-labelledby="workspace-model-access-heading">
+      <details
+        className="group rounded-lg border border-border"
+        open={open || error != null}
+        onToggle={(event) => {
+          const next = event.currentTarget.open;
+          if (error != null && !next) {
+            event.currentTarget.open = true;
+            return;
+          }
+          setOpen(next);
+        }}
+      >
+        <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2.5 text-left transition-colors hover:bg-surface-2/60 [&::-webkit-details-marker]:hidden">
+          <LockKeyholeIcon className="size-3.5 shrink-0 text-brand" />
+          <h2
+            id="workspace-model-access-heading"
+            className="min-w-0 flex-1 truncate text-sm font-medium"
+          >
             Model access
           </h2>
-          <p className="text-xs text-fg-subtle">
-            Choose which model IDs may serve turns in this workspace. This is enforced again when a
-            turn runs.
-          </p>
-        </div>
-      </div>
+          <span className="text-2xs text-fg-subtle">{summaryStatus}</span>
+          <ChevronDownIcon className="size-4 shrink-0 text-fg-subtle transition-transform group-open:rotate-180" />
+        </summary>
 
-      <div className="rounded-lg border border-border p-3">
-        {error ? (
-          <LoadErrorState
-            title="Couldn't load model access"
-            error={error}
-            onRetry={() => void load()}
-          />
-        ) : loading || !draft ? (
-          <div className="grid gap-3">
-            <Skeleton className="h-5 w-48" />
-            <Skeleton className="h-16 w-full" />
-            <Skeleton className="h-24 w-full" />
-          </div>
-        ) : (
-          <div className="grid gap-3">
-            {draft.mode === "provider" ? (
-              <>
-                {draft.policyVerdictComplete ? (
-                  <Notice tone="info" title="Provider-level restriction active">
-                    Provider identities stay server-private. The current rule permits{" "}
-                    {visiblePolicyAllowedCount} of {models.length} configured model IDs and may also
-                    cover future models from the same provider.
-                  </Notice>
-                ) : (
-                  <Notice tone="waiting" title="Refresh after the control plane update">
-                    This browser does not yet have a complete model-policy projection. The existing
-                    provider-level restriction remains unchanged, and replacement is disabled.
-                  </Notice>
-                )}
-                {canManage && draft.policyVerdictComplete ? (
-                  <div className="flex flex-wrap justify-end gap-2">
+        <div className="grid gap-3 border-t border-border/70 px-3 py-3">
+          {error ? (
+            <LoadErrorState
+              title="Couldn't load model access"
+              error={error}
+              onRetry={() => void load()}
+            />
+          ) : loading || !draft ? (
+            <div className="grid gap-2">
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-2/3" />
+            </div>
+          ) : draft.mode === "provider" ? (
+            <>
+              {draft.policyVerdictComplete ? (
+                <Notice tone="info" title="Provider-level restriction active">
+                  {visiblePolicyAllowedCount} of {models.length} models allowed. Future models from
+                  the same provider may also run.
+                </Notice>
+              ) : (
+                <Notice tone="waiting" title="Refresh after the control plane update">
+                  This browser does not yet have a complete model-policy projection. The existing
+                  provider-level restriction remains unchanged, and replacement is disabled.
+                </Notice>
+              )}
+              {canManage && draft.policyVerdictComplete ? (
+                <div className="flex flex-wrap justify-end gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => setPendingReplacementMode("unrestricted")}
+                  >
+                    Allow all
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => setPendingReplacementMode("selected")}
+                  >
+                    Choose exact models
+                  </Button>
+                </div>
+              ) : (
+                <span className="text-2xs text-fg-subtle">
+                  {canManage
+                    ? "Provider policy replacement unavailable"
+                    : "Admin required to change"}
+                </span>
+              )}
+            </>
+          ) : (
+            <>
+              {providerRestrictionActive ? (
+                <Notice
+                  tone="waiting"
+                  title="Provider-level restriction will be replaced"
+                  action={
                     <Button
                       type="button"
-                      variant="secondary"
-                      onClick={() => setPendingReplacementMode("unrestricted")}
+                      variant="ghost"
+                      size="xs"
+                      disabled={saving}
+                      onClick={() => {
+                        const next = modelAccessPolicyDraft(draft.originalPolicy, models);
+                        setDraft(next);
+                      }}
                     >
-                      Allow all instead
+                      Cancel
                     </Button>
-                    <Button type="button" onClick={() => setPendingReplacementMode("selected")}>
-                      Choose exact models
-                    </Button>
-                  </div>
-                ) : (
-                  <span className="text-2xs text-fg-subtle">
-                    {canManage
-                      ? "Provider policy replacement unavailable"
-                      : "Workspace admin required to change"}
-                  </span>
-                )}
-              </>
-            ) : (
-              <>
-                {providerRestrictionActive ? (
-                  <Notice
-                    tone="waiting"
-                    title="Provider-level restriction will be replaced"
-                    action={
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        disabled={saving}
-                        onClick={() => {
-                          const next = modelAccessPolicyDraft(draft.originalPolicy, models);
-                          setDraft(next);
-                        }}
-                      >
-                        Cancel
-                      </Button>
-                    }
-                  >
-                    Review the exact model IDs below, then save to confirm the semantic change.
-                  </Notice>
-                ) : null}
+                  }
+                >
+                  Save to replace the provider-wide rule with these IDs.
+                </Notice>
+              ) : null}
 
-                <label className="flex items-start gap-2 rounded-md border border-border/70 p-2.5">
+              <div className="grid gap-0.5">
+                <label className="flex items-center gap-2 py-1">
                   <input
                     type="radio"
                     name={`model-access-${workspaceId}`}
                     checked={draft.mode === "unrestricted"}
                     disabled={!canManage || saving}
                     onChange={() => setMode("unrestricted")}
-                    className="mt-0.5 size-4 accent-brand"
+                    className="size-3.5 accent-brand"
                   />
-                  <span>
-                    <span className="block text-sm font-medium">Allow all configured models</span>
-                    <span className="block text-xs text-fg-subtle">
-                      New models become available automatically when their credentials are ready.
-                    </span>
-                  </span>
+                  <span className="text-sm">All models</span>
                 </label>
-                <label className="flex items-start gap-2 rounded-md border border-border/70 p-2.5">
+                <label className="flex items-center gap-2 py-1">
                   <input
                     type="radio"
                     name={`model-access-${workspaceId}`}
                     checked={draft.mode === "selected"}
                     disabled={!canManage || saving}
                     onChange={() => setMode("selected")}
-                    className="mt-0.5 size-4 accent-brand"
+                    className="size-3.5 accent-brand"
                   />
-                  <span>
-                    <span className="block text-sm font-medium">Allow selected model IDs</span>
-                    <span className="block text-xs text-fg-subtle">
-                      Only the checked or explicitly entered IDs may run.
-                    </span>
-                  </span>
+                  <span className="text-sm">Selected models</span>
                 </label>
+              </div>
 
-                {draft.mode === "selected" ? (
-                  <div className="grid gap-3 border-t border-border/70 pt-3">
-                    {groups.length === 0 ? (
-                      <p className="text-xs text-fg-subtle">No configured models are visible.</p>
-                    ) : (
-                      groups.map(([providerLabel, providerModels]) => (
-                        <fieldset key={providerLabel} className="grid gap-1.5">
-                          <legend className="text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
-                            {providerLabel}
-                          </legend>
-                          {providerModels.map((model) => (
-                            <label
-                              key={model.id}
-                              className="flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 hover:bg-surface-2/60"
-                            >
-                              <input
-                                type="checkbox"
-                                checked={draft.selectedModelIds.has(model.id)}
-                                disabled={!canManage || saving}
-                                onChange={(event) =>
-                                  setModelSelected(model.id, event.target.checked)
-                                }
-                                className="size-4 shrink-0 accent-brand"
-                              />
-                              <span className="min-w-0 flex-1">
-                                <span className="block truncate text-sm">{model.label}</span>
-                                <span className="block truncate font-mono text-2xs text-fg-subtle">
-                                  {model.id}
-                                </span>
-                              </span>
-                              <span className="shrink-0 text-2xs text-fg-subtle">
-                                {model.credentialReadiness.status === "ready"
-                                  ? "Ready"
-                                  : "Not ready"}
-                              </span>
-                            </label>
-                          ))}
-                        </fieldset>
-                      ))
-                    )}
-
-                    {customIds.length > 0 ? (
-                      <div className="grid gap-1.5">
-                        <div className="text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
-                          Other model IDs
-                        </div>
-                        {customIds.map((modelId) => (
-                          <div
-                            key={modelId}
-                            className="flex min-w-0 items-center gap-2 rounded-md bg-surface-2/60 px-2 py-1.5"
+              {draft.mode === "selected" ? (
+                <div className="grid gap-2">
+                  {groups.length === 0 ? (
+                    <p className="text-xs text-fg-subtle">No configured models are visible.</p>
+                  ) : (
+                    groups.map(([providerLabel, providerModels]) => (
+                      <fieldset key={providerLabel} className="grid gap-0.5">
+                        <legend className="text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
+                          {providerLabel}
+                        </legend>
+                        {providerModels.map((model) => (
+                          <label
+                            key={model.id}
+                            title={model.id}
+                            className="flex min-w-0 items-center gap-2 rounded-md px-1 py-1 hover:bg-surface-2/60"
                           >
-                            <code className="min-w-0 flex-1 truncate text-xs">{modelId}</code>
-                            {canManage ? (
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon-sm"
-                                disabled={saving}
-                                aria-label={`Remove ${modelId}`}
-                                onClick={() => setModelSelected(modelId, false)}
-                              >
-                                <XIcon className="size-3.5" />
-                              </Button>
-                            ) : null}
-                          </div>
+                            <input
+                              type="checkbox"
+                              checked={draft.selectedModelIds.has(model.id)}
+                              disabled={!canManage || saving}
+                              onChange={(event) =>
+                                setModelSelected(model.id, event.target.checked)
+                              }
+                              className="size-3.5 shrink-0 accent-brand"
+                            />
+                            <span className="min-w-0 flex-1 truncate text-sm">{model.label}</span>
+                            <span className="shrink-0 text-2xs text-fg-subtle">
+                              {model.credentialReadiness.status === "ready" ? "Ready" : "Not ready"}
+                            </span>
+                          </label>
                         ))}
+                      </fieldset>
+                    ))
+                  )}
+
+                  {customIds.length > 0 ? (
+                    <div className="grid gap-0.5">
+                      <div className="text-2xs font-semibold uppercase tracking-wider text-fg-subtle">
+                        Other IDs
                       </div>
-                    ) : null}
+                      {customIds.map((modelId) => (
+                        <div key={modelId} className="flex min-w-0 items-center gap-2 px-1 py-1">
+                          <code className="min-w-0 flex-1 truncate text-xs">{modelId}</code>
+                          {canManage ? (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              disabled={saving}
+                              aria-label={`Remove ${modelId}`}
+                              onClick={() => setModelSelected(modelId, false)}
+                            >
+                              <XIcon />
+                            </Button>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
 
-                    {canManage ? (
-                      <form
-                        className="flex min-w-0 gap-2"
-                        onSubmit={(event) => {
-                          event.preventDefault();
-                          addCustomModelId();
-                        }}
-                      >
-                        <Input
-                          value={customModelId}
-                          disabled={saving}
-                          placeholder="Future or custom model ID"
-                          aria-label="Add model ID"
-                          onChange={(event) => setCustomModelId(event.target.value)}
-                        />
-                        <Button
-                          type="submit"
-                          variant="secondary"
-                          disabled={saving || !customModelId.trim()}
-                        >
-                          <PlusIcon className="size-3.5" />
-                          Add
-                        </Button>
-                      </form>
-                    ) : null}
-                  </div>
-                ) : null}
-
-                <div className="flex items-center justify-between gap-3 border-t border-border/70 pt-3">
-                  <span className="text-xs text-fg-subtle">
-                    {draft.mode === "unrestricted"
-                      ? "All configured models are permitted by workspace policy."
-                      : `${draft.selectedModelIds.size} model ID${draft.selectedModelIds.size === 1 ? "" : "s"} permitted.`}
-                  </span>
                   {canManage ? (
+                    <form
+                      className="flex min-w-0 gap-2"
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        addCustomModelId();
+                      }}
+                    >
+                      <Input
+                        value={customModelId}
+                        disabled={saving}
+                        placeholder="Custom model ID"
+                        aria-label="Add model ID"
+                        className="h-8"
+                        onChange={(event) => setCustomModelId(event.target.value)}
+                      />
+                      <Button
+                        type="submit"
+                        size="sm"
+                        variant="secondary"
+                        disabled={saving || !customModelId.trim()}
+                      >
+                        <PlusIcon className="size-3.5" />
+                        Add
+                      </Button>
+                    </form>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {canManage ? (
+                dirty || saving ? (
+                  <div className="flex justify-end">
                     <Button
                       type="button"
                       size="sm"
                       disabled={!dirty || saving}
                       onClick={() => void save()}
                     >
-                      {saving ? (
-                        <Loader2Icon className="size-3.5 animate-spin" />
-                      ) : (
-                        <CheckIcon className="size-3.5" />
-                      )}
+                      {saving ? <Loader2Icon className="size-3.5 animate-spin" /> : null}
                       Save
                     </Button>
-                  ) : (
-                    <span className="text-2xs text-fg-subtle">
-                      Workspace admin required to change
-                    </span>
-                  )}
-                </div>
-              </>
-            )}
-          </div>
-        )}
-      </div>
+                  </div>
+                ) : null
+              ) : (
+                <span className="text-2xs text-fg-subtle">Admin required to change</span>
+              )}
+            </>
+          )}
+        </div>
+      </details>
       <ConfirmDialog
         open={pendingReplacementMode !== null}
         onOpenChange={(open) => {

--- a/apps/web/src/components/model-access-policy.tsx
+++ b/apps/web/src/components/model-access-policy.tsx
@@ -472,8 +472,8 @@ export function ModelAccessPolicySection({
       </details>
       <ConfirmDialog
         open={pendingReplacementMode !== null}
-        onOpenChange={(open) => {
-          if (!open) setPendingReplacementMode(null);
+        onOpenChange={(dialogOpen) => {
+          if (!dialogOpen) setPendingReplacementMode(null);
         }}
         title="Replace the provider-level model policy?"
         description={

--- a/apps/web/src/components/model-access-policy.tsx
+++ b/apps/web/src/components/model-access-policy.tsx
@@ -379,9 +379,7 @@ export function ModelAccessPolicySection({
                               type="checkbox"
                               checked={draft.selectedModelIds.has(model.id)}
                               disabled={!canManage || saving}
-                              onChange={(event) =>
-                                setModelSelected(model.id, event.target.checked)
-                              }
+                              onChange={(event) => setModelSelected(model.id, event.target.checked)}
                               className="size-3.5 shrink-0 accent-brand"
                             />
                             <span className="min-w-0 flex-1 truncate text-sm">{model.label}</span>

--- a/apps/web/src/components/supergrok-connection.tsx
+++ b/apps/web/src/components/supergrok-connection.tsx
@@ -12,6 +12,7 @@ import {
   PencilIcon,
   PlusIcon,
   Trash2Icon,
+  TriangleAlertIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -20,8 +21,9 @@ import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { MetaChip } from "@/components/ui/meta-chip";
-import { Select } from "@/components/ui/select";
+import { XaiMark } from "@/components/xai-mark";
 import { useAppContext } from "@/context";
+import { cn } from "@/lib/utils";
 
 import { pollSuperGrokDeviceLogin } from "./supergrok-device-poll";
 
@@ -30,17 +32,57 @@ type PendingDeviceCode = {
   verificationUri: string;
 };
 
+function SuperGrokScopeToggle({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: SuperGrokAccountScope;
+  disabled: boolean;
+  onChange: (scope: SuperGrokAccountScope) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="SuperGrok connection scope"
+      className="flex rounded-md border border-border/70 p-0.5"
+    >
+      {(["workspace", "user"] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          disabled={disabled}
+          className={cn(
+            "h-7 rounded px-2 text-xs disabled:opacity-50",
+            value === option ? "bg-surface-2 text-fg" : "text-fg-subtle hover:text-fg",
+          )}
+          aria-pressed={value === option}
+          onClick={() => onChange(option)}
+        >
+          {option === "workspace" ? "Workspace" : "Only me"}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 export function SuperGrokDeviceCodePanel(props: PendingDeviceCode) {
   const [copied, setCopied] = useState(false);
   return (
-    <div className="grid gap-3 rounded-lg border border-brand/30 bg-brand/5 p-3">
+    <div className="grid gap-2 rounded-md border border-border bg-bg p-3">
+      <div className="text-xs text-fg-muted">
+        Enter this code at the xAI page (opened in a new tab).
+      </div>
       <div className="flex flex-wrap items-center gap-2">
-        <code data-supergrok-device-code="" className="rounded bg-bg px-2 py-1 font-mono text-sm">
+        <code
+          data-supergrok-device-code=""
+          className="rounded bg-surface-2 px-3 py-1.5 font-mono text-lg font-semibold tracking-widest"
+        >
           {props.userCode}
         </code>
         <Button
           type="button"
-          variant="outline"
+          variant="secondary"
           size="sm"
           aria-label={copied ? "Code copied" : "Copy code"}
           onClick={() => {
@@ -53,15 +95,15 @@ export function SuperGrokDeviceCodePanel(props: PendingDeviceCode) {
           {copied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />}
           {copied ? "Copied" : "Copy code"}
         </Button>
-        <Button asChild variant="outline" size="sm">
+        <Button asChild variant="secondary" size="sm">
           <a href={props.verificationUri} target="_blank" rel="noopener noreferrer">
-            Open xAI <ExternalLinkIcon className="size-3.5" />
+            Open auth page <ExternalLinkIcon className="size-3.5" />
           </a>
         </Button>
       </div>
-      <p className="flex items-center gap-2 text-xs text-fg-subtle">
-        <Loader2Icon className="size-3.5 animate-spin" /> Waiting for xAI authorization…
-      </p>
+      <div className="flex items-center gap-2 text-xs text-fg-subtle">
+        <Loader2Icon className="size-3.5 animate-spin" /> Waiting for authorization…
+      </div>
     </div>
   );
 }
@@ -87,6 +129,7 @@ export function SuperGrokSubscriptionsCard({
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const cancelled = useRef(false);
   const pollAbort = useRef<AbortController | null>(null);
+  const autoExpandedReloginRef = useRef(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -179,34 +222,58 @@ export function SuperGrokSubscriptionsCard({
   );
 
   const accounts = data?.accounts ?? [];
+
+  useEffect(() => {
+    autoExpandedReloginRef.current = false;
+    setExpandedId(null);
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (autoExpandedReloginRef.current || expandedId != null || !data) return;
+    const needsRelogin = data.accounts.find(
+      (account) => account.status !== "active" && account.lastError != null,
+    );
+    if (!needsRelogin) return;
+    autoExpandedReloginRef.current = true;
+    setExpandedId(needsRelogin.id);
+  }, [data, expandedId]);
+
+  const connectControls = canManage ? (
+    <div className="flex flex-wrap items-center justify-end gap-2">
+      <SuperGrokScopeToggle value={scope} disabled={busy} onChange={setScope} />
+      {accounts.length === 0 ? (
+        <Button type="button" size="sm" disabled={busy} onClick={connect}>
+          {busy ? (
+            <Loader2Icon className="size-3.5 animate-spin" />
+          ) : (
+            <XaiMark className="size-3.5" />
+          )}{" "}
+          Connect SuperGrok
+        </Button>
+      ) : (
+        <Button type="button" size="sm" variant="ghost" disabled={busy} onClick={connect}>
+          <PlusIcon className="size-3.5" /> Connect
+        </Button>
+      )}
+    </div>
+  ) : null;
+
   return (
-    <section aria-labelledby="supergrok-heading" className="grid gap-2">
+    <section aria-labelledby="supergrok-subscriptions-heading" className="grid gap-2">
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
-          <h2 id="supergrok-heading" className="text-sm font-medium">
+          <h2
+            id="supergrok-subscriptions-heading"
+            className="flex items-center gap-1.5 text-sm font-medium"
+          >
+            <XaiMark className="size-3.5 text-brand" />
             SuperGrok subscriptions
           </h2>
           <p className="mt-0.5 text-2xs text-fg-subtle">
-            xAI plans for Grok models — subscription usage, not OpenGeni credits.
+            xAI plans for Grok models — subscription usage, not API credits.
           </p>
         </div>
-        {canManage && accounts.length > 0 && !pending ? (
-          <div className="flex items-center gap-1">
-            <Select
-              aria-label="SuperGrok connection scope"
-              className="h-8 border-0 bg-transparent text-xs"
-              value={scope}
-              disabled={busy}
-              onChange={(event) => setScope(event.target.value as SuperGrokAccountScope)}
-            >
-              <option value="workspace">Workspace</option>
-              <option value="user">Only me</option>
-            </Select>
-            <Button type="button" size="sm" variant="ghost" disabled={busy} onClick={connect}>
-              <PlusIcon className="size-3.5" /> Connect
-            </Button>
-          </div>
-        ) : null}
+        {accounts.length > 0 && !pending ? connectControls : null}
       </div>
 
       {accounts.length > 1 && canManage ? (
@@ -241,35 +308,17 @@ export function SuperGrokSubscriptionsCard({
         <SuperGrokDeviceCodePanel {...pending} />
       ) : accounts.length === 0 ? (
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className="text-xs text-fg-subtle">No SuperGrok subscriptions connected.</p>
-          {canManage ? (
-            <div className="flex items-center gap-2">
-              <Select
-                aria-label="SuperGrok connection scope"
-                className="h-8 text-xs"
-                value={scope}
-                disabled={busy}
-                onChange={(event) => setScope(event.target.value as SuperGrokAccountScope)}
-              >
-                <option value="workspace">Workspace</option>
-                <option value="user">Only me</option>
-              </Select>
-              <Button type="button" size="sm" disabled={busy} onClick={connect}>
-                {busy ? (
-                  <Loader2Icon className="size-3.5 animate-spin" />
-                ) : (
-                  <PlusIcon className="size-3.5" />
-                )}
-                Connect
-              </Button>
-            </div>
-          ) : null}
+          <p className="text-xs text-fg-subtle">
+            Not connected. Connecting needs admin access and a SuperGrok plan.
+          </p>
+          {connectControls}
         </div>
       ) : (
         <div className="divide-y divide-border/70 overflow-hidden rounded-lg border border-border">
           {accounts.map((account) => {
             const expanded = expandedId === account.id;
             const isActive = account.id === data?.activeAccountId;
+            const needsRelogin = account.status !== "active" && account.lastError != null;
             return (
               <article
                 key={account.id}
@@ -305,13 +354,17 @@ export function SuperGrokSubscriptionsCard({
                         }}
                       />
                     </label>
-                    <div className="flex min-w-0 flex-1 basis-36 items-center gap-1">
+                    <div
+                      className="flex min-w-0 flex-1 basis-36 items-center gap-1"
+                      onClick={(event) => {
+                        if (editing?.id === account.id) event.stopPropagation();
+                      }}
+                    >
                       {editing?.id === account.id ? (
                         <Input
                           autoFocus
                           value={editing.value}
                           className="h-7 text-sm"
-                          onClick={(event) => event.stopPropagation()}
                           onChange={(event) =>
                             setEditing({
                               id: account.id,
@@ -330,6 +383,10 @@ export function SuperGrokSubscriptionsCard({
                                 ),
                               "SuperGrok account renamed",
                             );
+                          }}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") event.currentTarget.blur();
+                            if (event.key === "Escape") setEditing(null);
                           }}
                         />
                       ) : (
@@ -376,7 +433,11 @@ export function SuperGrokSubscriptionsCard({
                         {account.status.replaceAll("_", " ")}
                       </MetaChip>
                     ) : null}
-                    {account.quota?.usedPercent != null ? (
+                    {needsRelogin ? (
+                      <span className="flex items-center gap-1 text-2xs text-status-waiting">
+                        <TriangleAlertIcon className="size-3" /> Reconnect
+                      </span>
+                    ) : account.quota?.usedPercent != null ? (
                       <span className="shrink-0 text-2xs text-fg-subtle">
                         {Math.round(account.quota.usedPercent)}%
                       </span>
@@ -395,13 +456,16 @@ export function SuperGrokSubscriptionsCard({
                         onClick={(event) => event.stopPropagation()}
                       >
                         <ChevronDownIcon
-                          className={`size-4 text-fg-subtle transition-transform ${expanded ? "rotate-180" : ""}`}
+                          className={cn(
+                            "size-4 text-fg-subtle transition-transform",
+                            expanded ? "rotate-180" : "",
+                          )}
                         />
                       </Button>
                     </CollapsibleTrigger>
                   </div>
                   <CollapsibleContent className="grid gap-2 border-t border-border/60 px-2.5 py-2.5">
-                    <label className="flex min-h-10 cursor-pointer items-center justify-between gap-3 rounded-md border border-border/70 bg-surface/50 px-2.5">
+                    <label className="flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-md border border-border/70 bg-surface/50 px-2.5">
                       <span className="text-xs font-medium">Use for new automatic turns</span>
                       <span className="flex items-center gap-2 text-xs text-fg-muted">
                         <input
@@ -425,10 +489,11 @@ export function SuperGrokSubscriptionsCard({
                         </span>
                       </span>
                     </label>
-                    {account.lastError ? (
-                      <p className="rounded-md border border-status-waiting/30 bg-status-waiting/10 p-2 text-xs text-status-waiting">
-                        {account.lastError}
-                      </p>
+                    {needsRelogin ? (
+                      <div className="flex items-center gap-1.5 rounded-md border border-status-waiting/30 bg-status-waiting/10 p-2 text-xs text-status-waiting">
+                        <TriangleAlertIcon className="size-3.5" />{" "}
+                        {account.lastError ?? "Reconnect needed."}
+                      </div>
                     ) : null}
                     {canManage ? (
                       <div>
@@ -458,9 +523,17 @@ export function SuperGrokSubscriptionsCard({
 
       {accounts.length > 0 && !pending && !loading ? (
         <p className="text-2xs text-fg-subtle">
-          {data?.settings.rotationEnabled && accounts.length > 1
-            ? `New sessions rotate across ${accounts.length} eligible subscriptions.`
-            : "The active subscription runs sessions that aren't pinned to a specific account."}
+          {data?.settings.rotationEnabled && accounts.length > 1 ? (
+            <>
+              Sessions are spread across all {accounts.length} subscriptions. Pinned sessions stay
+              on their pin.
+            </>
+          ) : (
+            <>
+              The <span className="font-medium">active</span> subscription runs every session that
+              isn't pinned to a specific one.
+            </>
+          )}
         </p>
       ) : null}
     </section>

--- a/apps/web/src/components/xai-mark.tsx
+++ b/apps/web/src/components/xai-mark.tsx
@@ -1,0 +1,19 @@
+import type { SVGProps } from "react";
+
+/** xAI mark, currentColor so it matches surrounding chrome. */
+export function XaiMark({ className, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 466.04 516.93"
+      className={className}
+      fill="currentColor"
+      aria-hidden="true"
+      {...props}
+    >
+      <polygon points="0.12 182.71 234.14 516.92 338.15 516.92 104.13 182.71 0.12 182.71" />
+      <polygon points="0 516.92 104.08 516.92 156.08 442.67 104.04 368.34 0 516.92" />
+      <polygon points="466.04 0 361.96 0 182.1 256.86 234.15 331.18 466.04 0" />
+      <polygon points="380.78 516.92 466.04 516.92 466.04 37.16 380.78 158.92 380.78 516.92" />
+    </svg>
+  );
+}

--- a/docs/image-generation.md
+++ b/docs/image-generation.md
@@ -58,7 +58,7 @@ contract. Current route availability is:
 | Direct reviewed OpenAI Responses | Native hosted tool | Typed Responses image input |
 | Connected Codex subscription | Codex image adapter | Typed function-image results |
 | Connected SuperGrok/xAI subscription | Native hosted xAI image tool | Typed Responses image input |
-| Managed or workspace Gateway Responses | Workspace Gateway image adapter | Typed image input only for catalogued vision models (Kimi K3 yes; DeepSeek V4 Flash no) |
+| Managed or workspace Gateway Responses | Workspace Gateway image adapter | Typed image input only for catalogued vision models (Kimi K3 and Gemini 3.7 Flash yes; DeepSeek V4 Flash and GLM 5.3 no) |
 | Other registry Responses providers | Workspace Gateway image adapter | Typed image input only when the model declares it |
 | Registry Chat providers | Workspace Gateway image adapter | Disabled until OpenGeni has a proven typed Chat image wire |
 

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -118,8 +118,8 @@ credential broker.
 
 ## Curated AI Gateway models
 
-`OPENGENI_VERCEL_AI_GATEWAY_API_KEY` enables two reviewed OpenGeni-credit
-models. They are siblings of the built-in GPT-5.6 family in the OpenGeni picker
+`OPENGENI_VERCEL_AI_GATEWAY_API_KEY` enables the reviewed OpenGeni-credit
+models below. They are siblings of the built-in GPT-5.6 family in the OpenGeni picker
 rail; the client never receives the Gateway hostname, upstream model slug, or
 endpoint provider.
 
@@ -127,8 +127,12 @@ endpoint provider.
 | --- | --- | --- | --- |
 | DeepSeek V4 Flash 0731 | Baseten → Novita → DeepInfra | Baseten $0.13 / $0.028 / $0.26; Novita $0.14 / $0.028 / $0.28; DeepInfra $0.09 / $0.018 / $0.18 per 1M | $0.175 / $0.035 / $0.35 per 1M (highest approved route) |
 | Kimi K3 | Baseten → Fireworks | $3 / $0.30 / $15 per 1M on both routes | $3.75 / $0.375 / $18.75 per 1M |
+| Gemini 3.7 Flash | Google → Vertex | Google/Vertex intro $0.75 / $0.075 / $3.75; Vertex regional $0.825 / $0.0825 / $4.125 per 1M | $1.03125 / $0.103125 / $5.15625 per 1M (Vertex regional) |
+| GLM 5.3 | Z.AI | $1.40 / $0.26 / $4.40 per 1M | $1.75 / $0.325 / $5.50 per 1M |
 
-Prices are a reviewed 2026-08-03 snapshot from public Gateway endpoint metadata.
+DeepSeek and Kimi prices are a reviewed 2026-08-03 snapshot; Gemini 3.7 Flash
+and GLM 5.3 are a reviewed 2026-08-19 snapshot from public Gateway endpoint
+metadata. Gemini's intro list expires 2026-12-31 and then roughly doubles.
 Managed turns normally debit the exact Gateway-reported inference cost for the
 provider that actually served the response, plus 25%. The static token rates
 above are only a conservative fallback if that response metadata is absent.
@@ -139,7 +143,9 @@ At the post-serialization fence, OpenGeni pairs only complete call/result batche
 by `call_id`. This preserves all fields and parallel execution; it does not
 change the model or provider route. Grouped, name-annotated, and Chat Completions
 continuations were probed on 2026-08-03; only the paired Responses shape kept
-full tool continuity plus Gateway route/cost metadata.
+full tool continuity plus Gateway route/cost metadata. Gemini 3.7 Flash and
+GLM 5.3 accepted both grouped and paired Responses continuations on 2026-08-19,
+so they keep unmodified history.
 
 Every Gateway request replaces caller routing options with the reviewed provider
 list in both `only` and `order`, sends no model fallback list, and disables OpenAI
@@ -148,14 +154,17 @@ Gateway model slugs fail before network I/O. Keep Gateway account-level rewrite
 rules disabled for the managed key because those rules operate outside the
 request body.
 
-Both models request Gateway automatic caching. Kimi remains catalogued as
-image-capable, so the worker also attaches `view_image` and `computer_*`
-screenshot tools. DeepSeek stays text-only. OpenGeni verifies finalized
+All curated Gateway models request Gateway automatic caching. Kimi and Gemini
+3.7 Flash remain catalogued as image-capable, so the worker also attaches
+`view_image` and `computer_*` screenshot tools. DeepSeek and GLM 5.3 stay
+text-only. OpenGeni verifies finalized
 attachment bytes and checksums, then sends images inline as data URLs through
 the standard Responses input surface; it never gives an endpoint provider an
-object-store URL.
+object-store URL. Gemini's Gateway catalog also tags video, audio, and hosted
+web search; those stay non-runnable until OpenGeni has the matching adapters.
+GLM 5.3's Gateway max output is 12,800 tokens.
 
-DeepSeek V4 Flash 0731 and Kimi K3 use OpenGeni's provider-neutral lazy-tool
+DeepSeek V4 Flash 0731, Kimi K3, Gemini 3.7 Flash, and GLM 5.3 use OpenGeni's provider-neutral lazy-tool
 dispatcher on the Responses wire. Their initial tool block contains the stable
 ordinary `tool_search` and `tool_invoke` schemas plus local control tools and
 exact session MCP refs marked `eager: true`, never the deferred MCP catalogue. A search result carries only bounded
@@ -539,7 +548,7 @@ and update `defaultModelPricing` — not as automatic truth to import.
 
 Not covered by the llm-prices canary: Fast/priority multipliers, Fireworks GLM
 defaults, the provider-pinned Gateway snapshots, and the `marginBps` markup.
-Gateway catalogue tests pin the exact Baseten/Wafer rates and caching claims;
+Gateway catalogue tests pin the exact approved-route rates and caching claims;
 offline llm-prices coverage uses
 `scripts/fixtures/llm-prices-current-v1.sample.json`.
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1856,6 +1856,8 @@ export const OPENGENI_GATEWAY_MODELS = {
     shortLabel: "V4 Flash",
     providers: ["baseten", "novita", "deepinfra"],
     implicitCaching: true,
+    vision: false,
+    inputFileMediaTypes: [] as const,
   },
   kimi: {
     productId: "kimi-k3",
@@ -1865,6 +1867,30 @@ export const OPENGENI_GATEWAY_MODELS = {
     shortLabel: "Kimi K3",
     providers: ["baseten", "fireworks"],
     implicitCaching: true,
+    vision: true,
+    inputFileMediaTypes: ["application/pdf"] as const,
+  },
+  gemini: {
+    productId: "gemini-3.7-flash",
+    workspaceProductId: `${WORKSPACE_GATEWAY_MODEL_ID_PREFIX}gemini-3.7-flash`,
+    upstreamModelId: "google/gemini-3.7-flash",
+    label: "Gemini 3.7 Flash",
+    shortLabel: "3.7 Flash",
+    providers: ["google", "vertex"],
+    implicitCaching: true,
+    vision: true,
+    inputFileMediaTypes: ["application/pdf"] as const,
+  },
+  glm: {
+    productId: "glm-5.3",
+    workspaceProductId: `${WORKSPACE_GATEWAY_MODEL_ID_PREFIX}glm-5.3`,
+    upstreamModelId: "zai/glm-5.3",
+    label: "GLM 5.3",
+    shortLabel: "GLM 5.3",
+    providers: ["zai"],
+    implicitCaching: true,
+    vision: false,
+    inputFileMediaTypes: [] as const,
   },
 } as const;
 
@@ -1946,7 +1972,9 @@ export const defaultModelPricing: Record<string, ModelPricingScheduleV1> = {
   // billing uses the exact response Gateway `cost` / `inferenceCost` and applies
   // the same margin. These token rates are used only if that
   // metadata is absent. DeepSeek therefore carries the highest approved route
-  // (Novita); both approved Kimi routes have the same list price.
+  // (Novita); both approved Kimi routes have the same list price; Gemini uses
+  // Vertex regional as the highest approved non-priority route; GLM has one
+  // Z.AI list price.
   [OPENGENI_GATEWAY_MODELS.deepseek.productId]: {
     default: {
       inputMicrosPerMillionTokens: 140_000,
@@ -1960,6 +1988,25 @@ export const defaultModelPricing: Record<string, ModelPricingScheduleV1> = {
       inputMicrosPerMillionTokens: 3_000_000,
       cachedInputMicrosPerMillionTokens: 300_000,
       outputMicrosPerMillionTokens: 15_000_000,
+      marginBps: 2_500,
+    },
+  },
+  // Gemini's approved Google/Vertex intro list is $0.75 / $0.075 / $3.75.
+  // Vertex regional is the highest reviewed non-priority route on that
+  // allowlist, so the metadata-absent fallback uses it.
+  [OPENGENI_GATEWAY_MODELS.gemini.productId]: {
+    default: {
+      inputMicrosPerMillionTokens: 825_000,
+      cachedInputMicrosPerMillionTokens: 82_500,
+      outputMicrosPerMillionTokens: 4_125_000,
+      marginBps: 2_500,
+    },
+  },
+  [OPENGENI_GATEWAY_MODELS.glm.productId]: {
+    default: {
+      inputMicrosPerMillionTokens: 1_400_000,
+      cachedInputMicrosPerMillionTokens: 260_000,
+      outputMicrosPerMillionTokens: 4_400_000,
       marginBps: 2_500,
     },
   },
@@ -2852,7 +2899,7 @@ function gatewayModelCapabilities(
     promptCaching: input.implicitCaching
       ? { upstream: "supported", runnable: true, mode: "implicit" }
       : { upstream: "unsupported", runnable: false, mode: "none" },
-    // Both Gateway products expose one reviewed route policy and no separately
+    // Gateway products expose one reviewed route policy and no separately
     // billed latency mode.
     latencyModes: [{ id: "standard", upstream: "supported", runnable: true }],
   });
@@ -2865,8 +2912,7 @@ function gatewayRegistryProvider(
     | { kind: "vercel-gateway-workspace"; apiKey?: string },
 ): RegistryProvider {
   const workspace = input.kind === "vercel-gateway-workspace";
-  const models = [OPENGENI_GATEWAY_MODELS.deepseek, OPENGENI_GATEWAY_MODELS.kimi].map((model) => {
-    const kimi = model === OPENGENI_GATEWAY_MODELS.kimi;
+  const models = Object.values(OPENGENI_GATEWAY_MODELS).map((model) => {
     return {
       id: workspace ? model.workspaceProductId : model.productId,
       upstreamModelId: model.upstreamModelId,
@@ -2874,8 +2920,8 @@ function gatewayRegistryProvider(
       shortLabel: model.shortLabel,
       capabilities: gatewayModelCapabilities(settings, {
         implicitCaching: model.implicitCaching,
-        vision: kimi,
-        inputFileMediaTypes: kimi ? ["application/pdf"] : [],
+        vision: model.vision,
+        inputFileMediaTypes: [...model.inputFileMediaTypes],
       }),
       contextWindowTokens: 1_000_000,
       effectiveContextWindowTokens: 900_000,

--- a/packages/config/test/model-providers.test.ts
+++ b/packages/config/test/model-providers.test.ts
@@ -79,7 +79,7 @@ const codexRegistry = JSON.stringify([
 ]);
 
 describe("curated AI Gateway catalogue", () => {
-  test("adds the two managed models with exact routes, capabilities, and prices", () => {
+  test("adds the reviewed managed models with exact routes, capabilities, and prices", () => {
     const settings = {
       ...withEnv({}, () => getSettings()),
       modelProvidersJson: "[]",
@@ -95,6 +95,8 @@ describe("curated AI Gateway catalogue", () => {
       (model) => model.id === OPENGENI_GATEWAY_MODELS.deepseek.productId,
     )!;
     const kimi = models.find((model) => model.id === OPENGENI_GATEWAY_MODELS.kimi.productId)!;
+    const gemini = models.find((model) => model.id === OPENGENI_GATEWAY_MODELS.gemini.productId)!;
+    const glm = models.find((model) => model.id === OPENGENI_GATEWAY_MODELS.glm.productId)!;
     expect(deepseek.upstreamModelId).toBe(OPENGENI_GATEWAY_MODELS.deepseek.upstreamModelId);
     expect(deepseek.label).toBe("DeepSeek V4 Flash 0731");
     expect(deepseek.shortLabel).toBe("V4 Flash");
@@ -124,6 +126,30 @@ describe("curated AI Gateway catalogue", () => {
     expect(kimi.capabilities.inputFileMediaTypes).toEqual(["application/pdf"]);
     expect(kimi.capabilities.latencyModes.map((mode) => mode.id)).toEqual(["standard"]);
 
+    expect(gemini.upstreamModelId).toBe("google/gemini-3.7-flash");
+    expect(gemini.label).toBe("Gemini 3.7 Flash");
+    expect(gemini.shortLabel).toBe("3.7 Flash");
+    expect(gemini.requestPolicy).toEqual({
+      gateway: { only: ["google", "vertex"], caching: "auto" },
+    });
+    expect(gemini.capabilities.inputModalities).toEqual(["text", "image"]);
+    expect(gemini.capabilities.inputFileMediaTypes).toEqual(["application/pdf"]);
+    expect(gemini.capabilities.promptCaching).toEqual({
+      upstream: "supported",
+      runnable: true,
+      mode: "implicit",
+    });
+    expect(glm.upstreamModelId).toBe("zai/glm-5.3");
+    expect(glm.label).toBe("GLM 5.3");
+    expect(glm.shortLabel).toBe("GLM 5.3");
+    expect(glm.requestPolicy).toEqual({
+      gateway: { only: ["zai"], caching: "auto" },
+    });
+    expect(glm.capabilities.inputModalities).toEqual(["text"]);
+    expect(glm.capabilities.inputFileMediaTypes).toEqual([]);
+    expect(gemini.hostedWebSearch).toBe(false);
+    expect(glm.hostedWebSearch).toBe(false);
+
     expect(configuredModelPricing(settings)[deepseek.id]).toEqual({
       inputMicrosPerMillionTokens: 140_000,
       cachedInputMicrosPerMillionTokens: 28_000,
@@ -134,6 +160,18 @@ describe("curated AI Gateway catalogue", () => {
       inputMicrosPerMillionTokens: 3_000_000,
       cachedInputMicrosPerMillionTokens: 300_000,
       outputMicrosPerMillionTokens: 15_000_000,
+      marginBps: 2_500,
+    });
+    expect(configuredModelPricing(settings)[gemini.id]).toEqual({
+      inputMicrosPerMillionTokens: 825_000,
+      cachedInputMicrosPerMillionTokens: 82_500,
+      outputMicrosPerMillionTokens: 4_125_000,
+      marginBps: 2_500,
+    });
+    expect(configuredModelPricing(settings)[glm.id]).toEqual({
+      inputMicrosPerMillionTokens: 1_400_000,
+      cachedInputMicrosPerMillionTokens: 260_000,
+      outputMicrosPerMillionTokens: 4_400_000,
       marginBps: 2_500,
     });
   });
@@ -192,6 +230,36 @@ describe("curated AI Gateway catalogue", () => {
         inputTokensDetails: { cached_tokens: 1_000_000 },
       }),
     ).toBe(375_000);
+  });
+
+  test("managed debit fallback uses Vertex regional Gemini rates", () => {
+    const settings = {
+      ...withEnv({}, () => getSettings()),
+      modelProvidersJson: "[]",
+      vercelAiGatewayApiKey: "vck_test",
+    };
+    expect(
+      calculateModelUsageCostMicros(settings, OPENGENI_GATEWAY_MODELS.gemini.productId, {
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        inputTokensDetails: { cached_tokens: 1_000_000 },
+      }),
+    ).toBe(103_125);
+  });
+
+  test("managed debit fallback applies GLM 5.3 cache-read pricing", () => {
+    const settings = {
+      ...withEnv({}, () => getSettings()),
+      modelProvidersJson: "[]",
+      vercelAiGatewayApiKey: "vck_test",
+    };
+    expect(
+      calculateModelUsageCostMicros(settings, OPENGENI_GATEWAY_MODELS.glm.productId, {
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        inputTokensDetails: { cached_tokens: 1_000_000 },
+      }),
+    ).toBe(325_000);
   });
 
   test("managed debit converts exact Gateway cost before applying margin", () => {

--- a/packages/runtime/test/model-providers.test.ts
+++ b/packages/runtime/test/model-providers.test.ts
@@ -101,6 +101,50 @@ describe("Vercel AI Gateway request fence", () => {
     });
   });
 
+  test("orders Gemini across only the approved Google and Vertex routes", async () => {
+    let captured: Record<string, unknown> | null = null;
+    const routed = vercelGatewayRoutingFetch("vercel-gateway-managed", (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      captured = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch);
+    await routed("https://ai-gateway.vercel.sh/v1/responses", {
+      method: "POST",
+      body: JSON.stringify({ model: "google/gemini-3.7-flash" }),
+    });
+    expect(captured?.providerOptions).toEqual({
+      gateway: {
+        only: ["google", "vertex"],
+        order: ["google", "vertex"],
+        caching: "auto",
+      },
+    });
+  });
+
+  test("orders GLM 5.3 across only the approved Z.AI route", async () => {
+    let captured: Record<string, unknown> | null = null;
+    const routed = vercelGatewayRoutingFetch("vercel-gateway-managed", (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      captured = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch);
+    await routed("https://ai-gateway.vercel.sh/v1/responses", {
+      method: "POST",
+      body: JSON.stringify({ model: "zai/glm-5.3" }),
+    });
+    expect(captured?.providerOptions).toEqual({
+      gateway: {
+        only: ["zai"],
+        order: ["zai"],
+        caching: "auto",
+      },
+    });
+  });
+
   test("pairs only complete Kimi parallel call/result batches without changing their fields", async () => {
     let captured: Record<string, unknown> | null = null;
     const routed = vercelGatewayRoutingFetch("vercel-gateway-managed", (async (
@@ -155,7 +199,23 @@ describe("Vercel AI Gateway request fence", () => {
     ]);
   });
 
-  test("does not alter incomplete Kimi or complete DeepSeek call/result batches", async () => {
+  test("does not alter incomplete Kimi or complete DeepSeek, Gemini, or GLM call/result batches", async () => {
+    const grouped = [
+      {
+        type: "function_call",
+        call_id: "a",
+        name: "alpha",
+        arguments: "{}",
+      },
+      {
+        type: "function_call",
+        call_id: "b",
+        name: "beta",
+        arguments: "{}",
+      },
+      { type: "function_call_output", call_id: "a", output: "one" },
+      { type: "function_call_output", call_id: "b", output: "two" },
+    ];
     for (const value of [
       {
         model: "moonshotai/kimi-k3",
@@ -175,25 +235,9 @@ describe("Vercel AI Gateway request fence", () => {
           { type: "function_call_output", call_id: "a", output: "done" },
         ],
       },
-      {
-        model: "deepseek/deepseek-v4-flash-0731",
-        input: [
-          {
-            type: "function_call",
-            call_id: "a",
-            name: "alpha",
-            arguments: "{}",
-          },
-          {
-            type: "function_call",
-            call_id: "b",
-            name: "beta",
-            arguments: "{}",
-          },
-          { type: "function_call_output", call_id: "a", output: "one" },
-          { type: "function_call_output", call_id: "b", output: "two" },
-        ],
-      },
+      { model: "deepseek/deepseek-v4-flash-0731", input: grouped },
+      { model: "google/gemini-3.7-flash", input: grouped },
+      { model: "zai/glm-5.3", input: grouped },
     ]) {
       let captured: Record<string, unknown> | null = null;
       const routed = vercelGatewayRoutingFetch("vercel-gateway-managed", (async (

--- a/scripts/check-model-pricing.ts
+++ b/scripts/check-model-pricing.ts
@@ -72,6 +72,14 @@ const NON_LLM_PRICES_MODELS = [
     id: "kimi-k3",
     reason: "reviewed Gateway routes; exact-cost billing and conservative fallback are tested",
   },
+  {
+    id: "gemini-3.7-flash",
+    reason: "reviewed Gateway routes; exact-cost billing and conservative fallback are tested",
+  },
+  {
+    id: "glm-5.3",
+    reason: "reviewed Gateway routes; exact-cost billing and conservative fallback are tested",
+  },
 ] as const;
 
 function usdToMicros(usd: number): number {


### PR DESCRIPTION
## Summary
- Add curated Vercel AI Gateway catalog entries for Gemini 3.7 Flash (`google/gemini-3.7-flash`, Google→Vertex) and GLM 5.3 (`zai/glm-5.3`), with conservative credit fallbacks and Kimi pairing kept Kimi-only.
- Collapse workspace **Model access** by default and drop nested radio cards.
- Align **SuperGrok** empty/connect chrome with Codex while keeping the explicit Workspace / Only me authority toggle.

## Test plan
- [x] `bun test packages/config/test/model-providers.test.ts packages/runtime/test/model-providers.test.ts apps/api/test/model-catalog.test.ts apps/web/src/components/model-access-policy.test.tsx apps/web/src/components/supergrok-connection.test.tsx`
- [ ] Workspace settings: Model access is one collapsed row; SuperGrok empty state matches Codex (mark + Connect SuperGrok + scope toggle)
- [ ] With a managed Gateway key, picker/catalog includes `gemini-3.7-flash` (vision) and `glm-5.3` (text-only)


Made with [Cursor](https://cursor.com)