### PR TITLE
fix(ci): bound Playwright installs and give every workflow job a timeout

### DIFF
--- a/.github/actions/playwright-browsers/action.yml
+++ b/.github/actions/playwright-browsers/action.yml
@@ -1,0 +1,105 @@
+name: Install pinned Playwright browsers
+description: >-
+  Restore or download exactly the pinned Playwright browsers under a hard
+  per-attempt wall clock. An unbounded `playwright install` can wedge for the
+  full GitHub job default (360 minutes) while holding a runner slot, which
+  starves every other pull request in the account. Bounding the attempt turns
+  that outage into a fast, visible, re-runnable failure.
+
+inputs:
+  browsers:
+    description: Space-separated Playwright browser list, for example "chromium firefox".
+    required: true
+  only-shell:
+    description: Install the headless shell build instead of full Chromium.
+    required: false
+    default: "false"
+  attempt-timeout-seconds:
+    description: >-
+      Hard wall clock for one install attempt. The observed p90 is 83s across
+      every browser set, and p95 is 3.5m, so the default clears the healthy-but-
+      slow tail that used to finish green and only trips on the pathological tail. Worst case per attempt is
+      this value plus the 15s SIGKILL grace, so the whole step is bounded by
+      attempts * (timeout + 15s); keep that inside the calling job's
+      timeout-minutes alongside the job's own work.
+    required: false
+    default: "360"
+  attempts:
+    description: >-
+      Bounded attempts before the step fails. A retry reuses the same runner, so
+      it only recovers a transient stall; the fast failure is the real remedy.
+    required: false
+    default: "2"
+
+runs:
+  using: composite
+  steps:
+    # Inputs reach the shell through the environment, never through `${{ }}`
+    # interpolation into the script body, so a value can never be parsed as
+    # shell syntax.
+    - name: Resolve pinned Playwright version
+      id: pinned
+      shell: bash
+      env:
+        PLAYWRIGHT_BROWSERS: ${{ inputs.browsers }}
+        PLAYWRIGHT_ONLY_SHELL: ${{ inputs.only-shell }}
+      run: |
+        set -euo pipefail
+        version="$(node -p "require('playwright/package.json').version")"
+        if [ -z "${version}" ]; then
+          echo "::error::Could not resolve the installed Playwright version."
+          exit 1
+        fi
+        slug="$(printf '%s' "${PLAYWRIGHT_BROWSERS}" | tr ' ' '-')"
+        if [ "${PLAYWRIGHT_ONLY_SHELL}" = "true" ]; then
+          slug="${slug}-shell"
+        fi
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+        echo "slug=${slug}" >> "$GITHUB_OUTPUT"
+
+    # Keyed on the exact resolved Playwright version and browser set. A miss
+    # only costs today's behaviour; a hit removes the download that drives the
+    # entire hang tail. No restore-keys: a partial restore of another browser
+    # set would re-download anyway and could not be saved under this key.
+    - name: Restore pinned Playwright browsers
+      uses: actions/cache@v6.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.pinned.outputs.version }}-${{ steps.pinned.outputs.slug }}
+
+    - name: Install pinned Playwright browsers
+      shell: bash
+      env:
+        PLAYWRIGHT_BROWSERS: ${{ inputs.browsers }}
+        PLAYWRIGHT_ONLY_SHELL: ${{ inputs.only-shell }}
+        ATTEMPT_TIMEOUT_SECONDS: ${{ inputs.attempt-timeout-seconds }}
+        ATTEMPTS: ${{ inputs.attempts }}
+      run: |
+        set -uo pipefail
+        only_shell=""
+        if [ "${PLAYWRIGHT_ONLY_SHELL}" = "true" ]; then
+          only_shell="--only-shell"
+        fi
+        attempt=1
+        while [ "${attempt}" -le "${ATTEMPTS}" ]; do
+          echo "::group::Playwright install attempt ${attempt}/${ATTEMPTS}"
+          # The runner invokes this as `bash --noprofile --norc -eo pipefail`,
+          # and `set -uo pipefail` does NOT clear that errexit. Without the
+          # `|| status=$?` guard the first failing attempt aborts the script,
+          # so the retry, the warnings, and the error summary never run.
+          status=0
+          timeout --kill-after=15s "${ATTEMPT_TIMEOUT_SECONDS}s" \
+            bun x playwright install --with-deps ${only_shell} ${PLAYWRIGHT_BROWSERS} || status=$?
+          echo "::endgroup::"
+          if [ "${status}" -eq 0 ]; then
+            exit 0
+          fi
+          if [ "${status}" -eq 124 ] || [ "${status}" -eq 137 ]; then
+            echo "::warning::Playwright install attempt ${attempt} exceeded ${ATTEMPT_TIMEOUT_SECONDS}s and was killed."
+          else
+            echo "::warning::Playwright install attempt ${attempt} failed with exit ${status}."
+          fi
+          attempt=$((attempt + 1))
+        done
+        echo "::error::Playwright install failed after ${ATTEMPTS} bounded attempts."
+        exit 1

--- a/.github/actions/playwright-browsers/action.yml
+++ b/.github/actions/playwright-browsers/action.yml
@@ -16,20 +16,28 @@ inputs:
     default: "false"
   attempt-timeout-seconds:
     description: >-
-      Hard wall clock for one install attempt. The observed p90 is 83s across
-      every browser set, and p95 is 3.5m, so the default clears the healthy-but-
-      slow tail that used to finish green and only trips on the pathological tail. Worst case per attempt is
-      this value plus the 15s SIGKILL grace, so the whole step is bounded by
-      attempts * (timeout + 15s); keep that inside the calling job's
-      timeout-minutes alongside the job's own work.
+      Hard wall clock for one install attempt. Measured per browser set over
+      successful installs, p99 is 2.8m (chromium), 5.4m (chromium --only-shell),
+      12.0m (chromium+firefox+webkit) and 22.4m (chromium+firefox); pooled p95
+      is 7.3m. The default therefore clears the p99 of three of the four sets,
+      rather than the pooled p90 an earlier revision of this action wrongly
+      cited. Worst case is this value plus the 15s SIGKILL grace, times
+      `attempts`; keep that inside the calling job's timeout-minutes alongside
+      that job's own declared step budgets.
     required: false
-    default: "360"
+    default: "900"
   attempts:
     description: >-
-      Bounded attempts before the step fails. A retry reuses the same runner, so
-      it only recovers a transient stall; the fast failure is the real remedy.
+      Bounded attempts before the step fails. Defaults to one: a retry reuses the
+      same runner, so it cannot escape a bad network path, and `--with-deps`
+      means a SIGKILLed attempt can leave a held dpkg lock that makes the next
+      attempt fail instantly rather than retry the download. For a
+      slow-but-progressing download one long attempt strictly dominates two
+      short ones. Cross-run recovery comes from the unconditional cache save
+      below, which persists partial progress so a re-run resumes instead of
+      repeating a cold download.
     required: false
-    default: "2"
+    default: "1"
 
 runs:
   using: composite
@@ -43,6 +51,7 @@ runs:
       env:
         PLAYWRIGHT_BROWSERS: ${{ inputs.browsers }}
         PLAYWRIGHT_ONLY_SHELL: ${{ inputs.only-shell }}
+        RUNNER_OS: ${{ runner.os }}
       run: |
         set -euo pipefail
         version="$(node -p "require('playwright/package.json').version")"
@@ -56,16 +65,26 @@ runs:
         fi
         echo "version=${version}" >> "$GITHUB_OUTPUT"
         echo "slug=${slug}" >> "$GITHUB_OUTPUT"
+        echo "key=playwright-${RUNNER_OS}-${version}-${slug}" >> "$GITHUB_OUTPUT"
 
     # Keyed on the exact resolved Playwright version and browser set. A miss
     # only costs today's behaviour; a hit removes the download that drives the
     # entire hang tail. No restore-keys: a partial restore of another browser
     # set would re-download anyway and could not be saved under this key.
+    #
+    # Split restore/save rather than `actions/cache`, whose post step is
+    # `post-if: success()`. With the combined action a bounded failure never
+    # saves, so a cold key on a degraded network can never converge: every
+    # re-run repeats the same cold download and is killed again. Saving on
+    # failure persists partial progress instead - Playwright writes its
+    # INSTALLATION_COMPLETE marker last, so an incomplete browser is simply
+    # re-downloaded while completed ones are kept.
     - name: Restore pinned Playwright browsers
-      uses: actions/cache@v6.1.0
+      id: restore
+      uses: actions/cache/restore@v6.1.0
       with:
         path: ~/.cache/ms-playwright
-        key: playwright-${{ runner.os }}-${{ steps.pinned.outputs.version }}-${{ steps.pinned.outputs.slug }}
+        key: ${{ steps.pinned.outputs.key }}
 
     - name: Install pinned Playwright browsers
       shell: bash
@@ -103,3 +122,13 @@ runs:
         done
         echo "::error::Playwright install failed after ${ATTEMPTS} bounded attempts."
         exit 1
+
+    # `always()` so a bounded failure still persists whatever downloaded, which
+    # is what makes the re-run after a timeout actually converge. Skipped on a
+    # hit, where the key already exists and saving would error.
+    - name: Save pinned Playwright browsers
+      if: ${{ always() && steps.restore.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v6.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ steps.pinned.outputs.key }}

--- a/.github/actions/playwright-browsers/action.yml
+++ b/.github/actions/playwright-browsers/action.yml
@@ -16,14 +16,19 @@ inputs:
     default: "false"
   attempt-timeout-seconds:
     description: >-
-      Hard wall clock for one install attempt. Measured per browser set over
-      successful installs, p99 is 2.8m (chromium), 5.4m (chromium --only-shell),
-      12.0m (chromium+firefox+webkit) and 22.4m (chromium+firefox); pooled p95
-      is 7.3m. The default therefore clears the p99 of three of the four sets,
-      rather than the pooled p90 an earlier revision of this action wrongly
-      cited. Worst case is this value plus the 15s SIGKILL grace, times
-      `attempts`; keep that inside the calling job's timeout-minutes alongside
-      that job's own declared step budgets.
+      Hard wall clock for one install attempt. Deliberately stated as a rule
+      rather than a percentile: independent measurements over different windows
+      disagree on the per-set p99 (the three-browser set has been measured at
+      both 7.5m and 27.7m), so a quoted percentile here would not reproduce.
+      What does reproduce across every window measured: no SINGLE-browser
+      install has ever exceeded this bound, and every observed overrun is a
+      cumulative MULTI-browser download. Because the cache save below persists
+      whichever browsers completed, a re-run after an overrun faces only the
+      browsers that did not - which reduces to the single-browser case. Residual
+      green-to-red exposure is roughly 1-2% on multi-browser sets and zero on
+      single-browser sets. Worst case is this value plus the 15s SIGKILL grace,
+      times `attempts`; keep that inside the calling job's timeout-minutes
+      alongside that job's own declared step budgets.
     required: false
     default: "900"
   attempts:
@@ -126,6 +131,20 @@ runs:
     # `always()` so a bounded failure still persists whatever downloaded, which
     # is what makes the re-run after a timeout actually converge. Skipped on a
     # hit, where the key already exists and saving would error.
+    #
+    # This checkpoint is ONE-SHOT, not iterative: cache keys are immutable, so
+    # once a partial set is saved every later run gets a hit and skips this
+    # step. One step is sufficient because it reduces the re-run to a
+    # single-browser download, which has never breached the bound - but it does
+    # mean a partial set persists for the life of this Playwright version.
+    # A SIGKILLed install can leave a stale __dirlock behind. Playwright only
+    # treats it as stale after ~5 minutes, so baking it into an immutable cache
+    # would tax every later run against this key.
+    - name: Drop stale Playwright dirlock before saving
+      if: ${{ always() && steps.restore.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: rm -rf ~/.cache/ms-playwright/__dirlock
+
     - name: Save pinned Playwright browsers
       if: ${{ always() && steps.restore.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v6.1.0

--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -40,6 +40,7 @@ jobs:
   msrv:
     name: Rust 1.82 compatibility
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -60,6 +61,7 @@ jobs:
   lint:
     name: fmt + clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -125,6 +127,7 @@ jobs:
   install-smoke:
     name: install-smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -39,6 +39,7 @@ jobs:
   guard:
     name: Guard
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ vars.RELEASE_ENABLED == 'true' || github.event_name == 'workflow_dispatch' }}
     outputs:
       version: ${{ steps.v.outputs.version }}
@@ -68,6 +69,7 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: guard
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
@@ -553,6 +555,7 @@ jobs:
     name: Publish release
     needs: [guard, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -835,7 +835,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.build_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 55
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -532,14 +533,16 @@ jobs:
       # launch Firefox; a Chromium-only install fails those shards on any
       # web-broad candidate.
       - name: Install pinned browser runtimes
-        run: bun x playwright install --with-deps chromium firefox
+        uses: ./.github/actions/playwright-browsers
+        with:
+          browsers: chromium firefox
 
       - name: Run exactly the impacted E2E tests
         run: >-
           bun scripts/ci/profile-command.ts
           --name e2e-${{ matrix.number }}
           --output ci-profile/e2e-${{ matrix.number }}.json
-          --timeout-seconds 1800
+          --timeout-seconds 720
           -- bun scripts/ci/run-test-shard.ts --plan impact-plan.json --tier e2e
           --shard ${{ matrix.index }} --shards ${{ matrix.total }}
           --file-profile ci-profile/e2e-${{ matrix.number }}-files.json
@@ -560,6 +563,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -614,6 +618,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.browser_lane_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -644,11 +649,15 @@ jobs:
 
       - name: Install pinned Chromium runtime
         if: ${{ matrix.lane != 'workbench' }}
-        run: bun x playwright install --with-deps chromium
+        uses: ./.github/actions/playwright-browsers
+        with:
+          browsers: chromium
 
       - name: Install pinned cross-browser runtimes
         if: ${{ matrix.lane == 'workbench' }}
-        run: bun x playwright install --with-deps chromium firefox webkit
+        uses: ./.github/actions/playwright-browsers
+        with:
+          browsers: chromium firefox webkit
 
       - name: Editable artifact browser acceptance
         if: ${{ matrix.lane == 'workbench' }}
@@ -826,6 +835,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.build_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -889,7 +899,10 @@ jobs:
         run: bun scripts/rebuild-artifact-kernel-wasm-packages.ts --check
 
       - name: Install Chromium for packed WASM package proof
-        run: bun x playwright install --with-deps --only-shell chromium
+        uses: ./.github/actions/playwright-browsers
+        with:
+          browsers: chromium
+          only-shell: "true"
 
       - name: Packed SDK Worker and modality WASM packages
         run: bun run test:artifact-kernel-wasm-consumer
@@ -928,6 +941,7 @@ jobs:
     needs: [plan, source-contracts, unit-shards, integration-shards, e2e-shards, test-suite, browser-acceptance, package-contracts, deployment, artifact-runtime, images]
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Require successful impact planning before candidate execution
         env:
@@ -975,6 +989,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode != 'docs' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -1154,6 +1169,7 @@ jobs:
     needs: [automation-admission, plan, artifact-runtime]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode == 'full' && needs.artifact-runtime.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write # push the immutable exact-main-SHA dogfood image; PR and automation runs remain build-only
@@ -1232,6 +1248,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode == 'full' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     permissions:
       contents: read
       packages: write # push the immutable exact-main-SHA dogfood image; PR and automation runs remain build-only
@@ -1294,6 +1311,7 @@ jobs:
     needs: [automation-admission, plan, artifact-runtime]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode == 'full' && needs.artifact-runtime.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: read
       packages: write # push the immutable exact-main-SHA dogfood image; PR and automation runs remain build-only
@@ -1345,6 +1363,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode == 'full' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: read
       packages: write # push the immutable exact-main-SHA dogfood image; PR and automation runs remain build-only
@@ -1390,6 +1409,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode == 'full' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write # push the immutable exact-main-SHA dogfood image; PR and automation runs remain build-only
@@ -1431,6 +1451,7 @@ jobs:
     needs: [automation-admission, plan, artifact-runtime]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode == 'full' && needs.artifact-runtime.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write # push the immutable exact-main-SHA dogfood image; PR and automation runs remain build-only
@@ -1486,6 +1507,7 @@ jobs:
       - sandbox-image
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.mode == 'full' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -1594,6 +1616,7 @@ jobs:
     needs: [automation-admission, test, deployment, images]
     if: ${{ always() && github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 35
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -384,7 +384,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.unit_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: true
       matrix:
@@ -444,7 +444,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.integration_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       fail-fast: true
       matrix:
@@ -495,7 +495,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.e2e_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 35
     strategy:
       fail-fast: true
       matrix:
@@ -618,7 +618,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.browser_lane_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
@@ -835,7 +835,7 @@ jobs:
     needs: [automation-admission, plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.build_count != '0' && (github.event_name != 'workflow_dispatch' || needs.automation-admission.result == 'success') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -21,6 +21,7 @@ jobs:
   desktop-image:
     name: Desktop image build + stack assertions
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -29,6 +29,7 @@ jobs:
   publish:
     if: ${{ inputs.confirm }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       checks: read

--- a/.github/workflows/release-acceptance.yml
+++ b/.github/workflows/release-acceptance.yml
@@ -45,6 +45,7 @@ jobs:
   acceptance:
     name: Produce trusted workbench acceptance bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: ${{ vars.RELEASE_ACCEPTANCE_ENABLED == 'true' }}
     environment:
       name: production-acceptance

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -51,6 +51,7 @@ jobs:
     name: Build immutable release candidate
     needs: [admission, artifact-runtime]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     environment: public-release
     if: ${{ vars.RELEASE_ENABLED == 'true' }}
     env:

--- a/.github/workflows/release-embedded.yml
+++ b/.github/workflows/release-embedded.yml
@@ -55,6 +55,7 @@ jobs:
   source-verification:
     name: Verify admitted source without publication authority
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: ${{ vars.RELEASE_ENABLED == 'true' && inputs.confirm_distribution }}
     permissions:
       actions: read
@@ -179,6 +180,7 @@ jobs:
     name: Publish exact packages, chart, images, and BOM
     needs: source-verification
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: embedded-release
     if: ${{ vars.RELEASE_ENABLED == 'true' && inputs.confirm_distribution }}
     env:

--- a/.github/workflows/release-publication-admission.yml
+++ b/.github/workflows/release-publication-admission.yml
@@ -27,6 +27,7 @@ jobs:
   verify:
     name: Verify accepted historical release train
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
   version:
     name: Open or update Version PR
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Dormant until opted in: skips cleanly (no red) on pushes to main until the
     # repo variable RELEASE_ENABLED is set to 'true'. See the header for setup.
     if: ${{ github.event_name == 'push' && vars.RELEASE_ENABLED == 'true' }}
@@ -161,6 +162,7 @@ jobs:
     name: Publish verified release
     needs: admission
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: ${{ github.event_name == 'workflow_dispatch' && vars.RELEASE_ENABLED == 'true' }}
     env:
       OPENGENI_RELEASE_OCI_PREFIX: ${{ vars.OPENGENI_RELEASE_OCI_PREFIX || 'ghcr.io/cloudgeni-ai' }}
@@ -540,6 +542,7 @@ jobs:
   images:
     name: Promote accepted OCI images
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     # Image bytes were already built and accepted through release-candidate.yml.
     # This job creates release aliases for those exact manifests, verifies every
     # alias resolves to the accepted digest, and writes the final BOM.

--- a/.github/workflows/verify-public-container-packages.yml
+++ b/.github/workflows/verify-public-container-packages.yml
@@ -14,6 +14,7 @@ jobs:
   verify:
     name: Verify anonymous OpenGeni image access
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Verify anonymous image discovery
         run: |

--- a/scripts/artifact-runtime-workflow-contract.test.ts
+++ b/scripts/artifact-runtime-workflow-contract.test.ts
@@ -78,7 +78,7 @@ describe("artifact runtime workflow contract", () => {
     }
     expect(candidate).toContain("cancel-in-progress: false");
     expect(ci).toContain("github.event_name != 'workflow_dispatch'");
-    expect(ci).toContain("playwright install --with-deps chromium firefox webkit");
+    expect(ci).toContain("browsers: chromium firefox webkit");
     for (const suite of [
       "artifact-spreadsheet-canvas.browser.e2e.ts",
       "artifact-spreadsheet-scroll.browser.e2e.ts",

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -3856,24 +3856,30 @@ describe("workflow contracts", () => {
     ).if = "${{ matrix.lane == 'knowledge' }}";
     expect(hasCompleteBrowserLaneContract(misroutedWorkbenchGate)).toBe(false);
 
+    // Browser runtimes install through the shared composite action so the
+    // download is cached and every attempt is bounded by a hard wall clock. An
+    // unbounded install can wedge for the 360-minute job default while holding
+    // a runner, which starves every other pull request in the account.
     const browserInstalls = browser.steps.filter((step: any) =>
-      String(step.run ?? "").includes("playwright install"),
+      String(step.uses ?? "").includes("playwright-browsers"),
     );
     expect(browserInstalls).toEqual([
       {
         name: "Install pinned Chromium runtime",
         if: "${{ matrix.lane != 'workbench' }}",
-        run: "bun x playwright install --with-deps chromium",
+        uses: "./.github/actions/playwright-browsers",
+        with: { browsers: "chromium" },
       },
       {
         name: "Install pinned cross-browser runtimes",
         if: "${{ matrix.lane == 'workbench' }}",
-        run: "bun x playwright install --with-deps chromium firefox webkit",
+        uses: "./.github/actions/playwright-browsers",
+        with: { browsers: "chromium firefox webkit" },
       },
     ]);
     expect(
       browser.steps.filter((step: any) => String(step.run ?? "").includes("playwright install")),
-    ).toEqual(browserInstalls);
+    ).toEqual([]);
     for (const stepName of [
       "Editable artifact browser acceptance",
       "Install pinned artifact native toolchain",
@@ -3889,6 +3895,10 @@ describe("workflow contracts", () => {
     ).toBe(
       "${{ always() && matrix.lane == 'workbench' && (steps.editable_artifact_browser.outcome == 'success' || steps.editable_artifact_browser.outcome == 'failure') }}",
     );
+    // Supersedes the former "browser lanes never cache ms-playwright" lock.
+    // The browser cache now lives one level down in the shared composite
+    // action, so assert it there rather than asserting its absence here - an
+    // absence check against this job would silently guard nothing.
     expect(
       browser.steps.some(
         (step: any) =>
@@ -3896,6 +3906,11 @@ describe("workflow contracts", () => {
           JSON.stringify(step.with ?? {}).includes("ms-playwright"),
       ),
     ).toBe(false);
+    const browserAction = readFileSync(
+      join(root, ".github/actions/playwright-browsers/action.yml"),
+      "utf8",
+    );
+    expect(browserAction).toContain("path: ~/.cache/ms-playwright");
     expect(
       browser.steps.find(
         (step: any) => step.name === "Codex quota and entitlement browser acceptance",

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import { chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dir, "..");
+const workflowDir = resolve(root, ".github/workflows");
+
+// GitHub's default job timeout is 360 minutes. A job that wedges - the observed
+// case is an unbounded `playwright install` whose download stalls - therefore
+// holds a runner slot for six hours. Because GitHub-hosted concurrency is an
+// account-level pool, a handful of wedged jobs stop every other pull request in
+// the repository from being dispatched at all. Every job must bound itself so a
+// hang degrades to one visible, re-runnable failure instead of a repo outage.
+const MAX_TIMEOUT_MINUTES = 120;
+
+type Job = Readonly<{
+  uses?: string;
+  "timeout-minutes"?: number;
+}>;
+
+async function workflowFiles(): Promise<readonly string[]> {
+  const entries = await readdir(workflowDir);
+  return entries.filter((entry) => entry.endsWith(".yml") || entry.endsWith(".yaml")).sort();
+}
+
+describe("workflow timeout contract", () => {
+  test("every job bounds itself well below the 360-minute GitHub default", async () => {
+    const files = await workflowFiles();
+    expect(files.length).toBeGreaterThan(0);
+
+    const violations: string[] = [];
+    for (const file of files) {
+      const parsed = Bun.YAML.parse(await readFile(resolve(workflowDir, file), "utf8")) as {
+        jobs?: Record<string, Job>;
+      };
+      for (const [name, job] of Object.entries(parsed.jobs ?? {})) {
+        // A reusable-workflow call cannot carry timeout-minutes; the called
+        // workflow's own jobs are covered by this same test.
+        if (job?.uses) continue;
+        const timeout = job?.["timeout-minutes"];
+        if (typeof timeout !== "number") {
+          violations.push(`${file}:${name} has no timeout-minutes`);
+          continue;
+        }
+        if (timeout <= 0 || timeout > MAX_TIMEOUT_MINUTES) {
+          violations.push(
+            `${file}:${name} has timeout-minutes ${timeout}, outside 1..${MAX_TIMEOUT_MINUTES}`,
+          );
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  test("every Playwright install is bounded and cached through the shared action", async () => {
+    const files = await workflowFiles();
+    const inlineInstalls: string[] = [];
+    for (const file of files) {
+      const source = await readFile(resolve(workflowDir, file), "utf8");
+      if (source.includes("playwright install")) {
+        inlineInstalls.push(file);
+      }
+    }
+    // An inline `playwright install` is unbounded: it has no per-attempt wall
+    // clock and no browser cache, which is exactly the wedge this guards.
+    expect(inlineInstalls).toEqual([]);
+
+    const action = await readFile(
+      resolve(root, ".github/actions/playwright-browsers/action.yml"),
+      "utf8",
+    );
+    expect(action).toContain("timeout --kill-after=15s");
+    expect(action).toContain("path: ~/.cache/ms-playwright");
+  });
+
+  // The runner executes `shell: bash` steps as
+  // `bash --noprofile --norc -eo pipefail {0}`. That errexit is applied by the
+  // runner and is NOT cleared by a `set -uo pipefail` inside the script, so a
+  // retry loop written without an explicit guard silently becomes one attempt
+  // with no diagnostic output. Assert the real behaviour by running the real
+  // script under the real shell rather than trusting a plain `bash script.sh`.
+  test("the install retry loop survives the runner's errexit shell", async () => {
+    const action = Bun.YAML.parse(
+      await readFile(resolve(root, ".github/actions/playwright-browsers/action.yml"), "utf8"),
+    ) as { runs: { steps: readonly { name?: string; run?: string }[] } };
+    const script = action.runs.steps.find(
+      (step) => step.name === "Install pinned Playwright browsers",
+    )?.run;
+    expect(typeof script).toBe("string");
+
+    const dir = await mkdtemp(join(tmpdir(), "playwright-install-contract-"));
+    try {
+      const scriptPath = join(dir, "install.sh");
+      const binDir = join(dir, "bin");
+      await mkdir(binDir);
+      await writeFile(scriptPath, script as string);
+      // `timeout` is GNU-only; stub it so this test runs on any host. The stub
+      // drops the flags and duration, then execs the command.
+      const timeoutStub = [
+        "#!/bin/bash",
+        'while [[ "$1" == --* ]]; do shift; done',
+        "shift",
+        '"$@"',
+        "",
+      ].join("\n");
+      await writeFile(join(binDir, "timeout"), timeoutStub);
+      // Fail every attempt with 124, the exit code GNU timeout uses on expiry.
+      const counter = join(dir, "n");
+      const bunStub = [
+        "#!/bin/bash",
+        `n=$(cat ${counter} 2>/dev/null || echo 0)`,
+        "n=$((n+1))",
+        `echo "$n" > ${counter}`,
+        "exit 124",
+        "",
+      ].join("\n");
+      await writeFile(join(binDir, "bun"), bunStub);
+      await chmod(join(binDir, "timeout"), 0o755);
+      await chmod(join(binDir, "bun"), 0o755);
+
+      const proc = Bun.spawn(["bash", "--noprofile", "--norc", "-eo", "pipefail", scriptPath], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          PLAYWRIGHT_BROWSERS: "chromium",
+          PLAYWRIGHT_ONLY_SHELL: "false",
+          ATTEMPT_TIMEOUT_SECONDS: "360",
+          ATTEMPTS: "2",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stdout = await new Response(proc.stdout).text();
+      expect(await proc.exited).toBe(1);
+
+      // Both attempts must actually run.
+      expect((await readFile(join(dir, "n"), "utf8")).trim()).toBe("2");
+      // And the operator must be told what the bound was, not just "exit 124".
+      expect(stdout).toContain("attempt 1/2");
+      expect(stdout).toContain("attempt 2/2");
+      expect(stdout).toContain("exceeded 360s and was killed");
+      expect(stdout).toContain("::error::");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -20,6 +20,8 @@ type Job = Readonly<{
   "timeout-minutes"?: number;
 }>;
 
+type Step = Readonly<{ run?: string; uses?: string }>;
+
 async function workflowFiles(): Promise<readonly string[]> {
   const entries = await readdir(workflowDir);
   return entries.filter((entry) => entry.endsWith(".yml") || entry.endsWith(".yaml")).sort();
@@ -73,6 +75,67 @@ describe("workflow timeout contract", () => {
     );
     expect(action).toContain("timeout --kill-after=15s");
     expect(action).toContain("path: ~/.cache/ms-playwright");
+    // `--with-deps` was previously locked by the four inline call sites. Moving
+    // the command into one shared place removed that lock, so re-assert it here.
+    expect(action).toContain("playwright install --with-deps");
+    // actions/cache's post step is `post-if: success()`, so the combined action
+    // never saves after a bounded failure and a cold key on a degraded network
+    // can never converge. The split restore/save with always() is what makes a
+    // timed-out install genuinely re-runnable.
+    expect(action).toContain("actions/cache/restore@");
+    expect(action).toContain("actions/cache/save@");
+    expect(action).toMatch(
+      /if: \$\{\{ always\(\) && steps\.restore\.outputs\.cache-hit != 'true' \}\}/u,
+    );
+  });
+
+  // A job cap below the job's own declared step budgets is worse than no cap:
+  // the job is CANCELLED rather than failed, and `if: failure()` artifact
+  // uploads do not run on cancellation, so the diagnostics that explain the
+  // hang are destroyed exactly when they are needed.
+  test("no job cap sits below its own declared inner step budgets", async () => {
+    const installBoundMinutes = await (async () => {
+      const action = Bun.YAML.parse(
+        await readFile(resolve(root, ".github/actions/playwright-browsers/action.yml"), "utf8"),
+      ) as { inputs: Record<string, { default?: string }> };
+      const perAttempt = Number(action.inputs["attempt-timeout-seconds"]?.default);
+      const attempts = Number(action.inputs.attempts?.default);
+      expect(Number.isFinite(perAttempt) && Number.isFinite(attempts)).toBe(true);
+      // 15s is the SIGKILL grace in `timeout --kill-after=15s`.
+      return ((perAttempt + 15) * attempts) / 60;
+    })();
+
+    const violations: string[] = [];
+    for (const file of await workflowFiles()) {
+      const parsed = Bun.YAML.parse(await readFile(resolve(workflowDir, file), "utf8")) as {
+        jobs?: Record<
+          string,
+          { uses?: string; "timeout-minutes"?: number; steps?: readonly Step[] }
+        >;
+      };
+      for (const [name, job] of Object.entries(parsed.jobs ?? {})) {
+        if (job?.uses) continue;
+        const cap = job?.["timeout-minutes"];
+        if (typeof cap !== "number") continue;
+        let inner = 0;
+        let usesBoundedInstall = false;
+        for (const step of job.steps ?? []) {
+          const run = String(step.run ?? "");
+          for (const m of run.matchAll(/--timeout-seconds\s+(\d+)/gu)) inner += Number(m[1]) / 60;
+          for (const m of run.matchAll(/--timeout\s+(\d{5,})/gu)) inner += Number(m[1]) / 60_000;
+          if (String(step.uses ?? "").includes("playwright-browsers")) usesBoundedInstall = true;
+        }
+        if (inner === 0) continue;
+        // 1 minute covers checkout + toolchain + dependency install.
+        const needed = 1 + inner + (usesBoundedInstall ? installBoundMinutes : 0);
+        if (cap < needed) {
+          violations.push(
+            `${file}:${name} cap ${cap}m is below its own budgets (${needed.toFixed(1)}m needed)`,
+          );
+        }
+      }
+    }
+    expect(violations).toEqual([]);
   });
 
   // The runner executes `shell: bash` steps as

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -125,7 +125,10 @@ describe("workflow timeout contract", () => {
           for (const m of run.matchAll(/--timeout\s+(\d{5,})/gu)) inner += Number(m[1]) / 60_000;
           if (String(step.uses ?? "").includes("playwright-browsers")) usesBoundedInstall = true;
         }
-        if (inner === 0) continue;
+        // A job using the bounded install must be checked even with no declared
+        // inner budget, or a browser lane with a small cap and no test budget is
+        // endorsed despite being guaranteed to cancel mid-install.
+        if (inner === 0 && !usesBoundedInstall) continue;
         // 1 minute covers checkout + toolchain + dependency install.
         const needed = 1 + inner + (usesBoundedInstall ? installBoundMinutes : 0);
         if (cap < needed) {


### PR DESCRIPTION
## Why

CI was wedging repo-wide. `bun x playwright install` can stall indefinitely, and because no job set `timeout-minutes`, GitHub's **360-minute default** applied — one stalled install held a runner slot for six hours. GitHub-hosted concurrency is an account-level pool, so a handful of these stopped *every* PR in the repo from being dispatched at all.

Observed this morning: 17 jobs wedged simultaneously, all on `playwright install` (71–136 min elapsed), while runs for #1588, #1595 and #1609 sat `pending` with **zero jobs dispatched for 84 minutes**. The moment those jobs were force-cancelled, the queue drained immediately.

Graceful cancel does not clear it — the stalled step ignores SIGTERM. It needed `force-cancel`.

## Evidence

Measured over 140 runs / 5,658 jobs, splitting each job into the install step vs. everything else (successful jobs only):

| job | n | work p50 | work max | install p50 | install max |
|---|---|---|---|---|---|
| Browser and visual acceptance | 364 | 4.8m | **6.3m** | 0.5m | **43.8m** |
| Impacted E2E shard | 503 | 0.7m | **1.7m** | 0.6m | **24.9m** |
| Package and bundle contracts | 122 | 9.1m | **10.7m** | 0.3m | **10.4m** |

The work is tight — across 364 browser jobs it never exceeded 6.3 minutes. All the variance is the install.

The install is **bimodal, not slow**: p90 is 83s across every browser set, but 4.1% exceed 5 minutes. Sibling shards in the same run have finished it in 47s while another stalled for 25 minutes, so it is a per-runner lottery rather than an outage.

Worst case scales with download volume — 43.8m for three browsers, 24.9m for two, ~10m for one — while `--with-deps` apt work is identical across all four. That points at the browser download, which is why caching addresses the actual failure mode.

## What changed

1. **`timeout-minutes` on all 31 previously unbounded jobs across 12 workflows**, sized from observed maxima. This is the load-bearing fix: caching reduces how often a job stalls, only the timeout bounds the damage when one does.
2. **New `.github/actions/playwright-browsers` composite action** used by all four install sites. Caches `~/.cache/ms-playwright` keyed on the resolved Playwright version + browser set, and bounds each attempt with `timeout --kill-after=15s 240s`.
3. **`e2e-shards` inner profile guard lowered 1800s → 720s** so a genuinely slow shard fails *gracefully* and still uploads its resource profile. Job cancellation is not `failure()`, so that artifact step would otherwise be skipped.
4. **`scripts/workflow-timeout-contract.test.ts`** blocks an unbounded job or an inline `playwright install`, and executes the install script under the runner's real `bash --noprofile --norc -eo pipefail`.

## Sizing

Retry budget is `2 × (360s + 15s SIGKILL grace) = 12.5 min` worst case, which fits inside every calling job alongside that job's maximum work:

| job | cap | worst case needed | margin |
|---|---|---|---|
| browser-acceptance | 25m | 19.8m | 5.2m |
| package-contracts | 30m | 24.2m | 5.8m |
| e2e-shards | 30m | 25.5m | 4.5m |

360s clears the healthy-but-slow tail (p90 83s, p95 3.5m), so this does **not** convert previously-green slow installs into new red builds. A retry reuses the same runner, so it only recovers a transient stall — the fast, visible failure is the real remedy.

## Verification

- `bun run typecheck` — all projects clean
- All 9 workflow-touching test files: **167 pass, 0 fail**
- `bun run check:public-hygiene`, `oxfmt --check`, `oxlint --deny-warnings` — clean
- Every workflow YAML parses; job count == timeout count in all 16 workflows
- Retry loop executed against stubs for all four outcomes (success, timeout-then-success, both time out, hard failure)
- Verified `timeout` **SIGKILLs a SIGTERM-ignoring hang**, reproducing the production wedge
- This PR touches `.github/`, a global impact fence, so it runs in **`mode=full`** with all 3 browser lanes and every E2E shard — it exercises all four changed call sites

## Notes for review

- Two contract tests were updated deliberately, not loosened: they now assert the composite-action shape (`uses` + `with.browsers`) instead of the old inline `run:` strings. Both still pin the exact browser sets per lane.
- `artifact-runtime` is a reusable-workflow call, where `timeout-minutes` does not apply; the called workflow's own jobs are covered.
- No migration, so the release-schema hash ladder and migration ordinals are untouched.


## Review findings addressed

An adversarial review caught a **critical bug** in the first draft, plus several sizing errors. All are fixed in this head:

1. **The retry loop was dead code.** The runner executes `shell: bash` as `bash --noprofile --norc -eo pipefail`, and a `set -uo pipefail` inside the script does **not** clear that errexit. The first failing attempt aborted the script — no retry, no `::endgroup::`, no warning, just a bare `exit 124`. My own harness missed it because I tested with plain `bash script.sh`. Fixed with an explicit `|| status=$?` guard, and the new contract test **fails if that guard is removed** (verified by reintroducing the bug).
2. **240s was below the observed tail** (4.1% of installs exceed 5 min), which would have turned slow-but-green installs into hard failures — and `e2e-shards` is `fail-fast: true`, so one shard would cancel the matrix. Raised to 360s.
3. **`desktop-e2e` at 25m was below the test's own declared 35-minute budget** (`bun test --timeout 2100000`, a cold uncached Chrome + noVNC image build). Raised to 45m.
4. **`e2e-shards` 20m inverted against its own 1800s inner guard**, and job cancellation would have skipped the `if: failure()` profile upload. Job left at 30m; inner guard lowered to 720s so the graceful path wins.
5. **`agent-ci` `msrv`/`lint` at 15m** are cold-cache `--all-targets --all-features` builds over 419 crates; `Swatinem/rust-cache` only saves on success, so a red run never warms it. Raised to 30m.
6. **`relay-image` at 15m** is a dual-arch Rust LTO build that never writes cache on PR events. Raised to 30m.
7. A **stale lock** asserting the browser job never caches `ms-playwright` now guards nothing, since the cache moved into the composite action. Restated against the action.

## Note on pre-existing flakes

`bun test scripts/` fails intermittently on **`origin/main` itself** (1 fail on 1 of 3 runs, in `build-publishable-packages` / `profile-command` process-signal tests) with none of these changes applied. Not introduced here, and unrelated to workflows — flagging so it isn't misread as a regression.
