### PR TITLE
fix(web): give workspace settings cards distinct React keys

### DIFF
--- a/apps/web/src/routes/workspace-settings.tsx
+++ b/apps/web/src/routes/workspace-settings.tsx
@@ -380,14 +380,14 @@ export function WorkspaceSettingsRoute({ workspaceId }: { workspaceId: string })
         </section>
 
         <ModelAccessPolicySection
-          key={workspaceId}
+          key={`model-access:${workspaceId}`}
           workspaceId={workspaceId}
           canManage={canDeleteWorkspace}
         />
 
         {/* Codex live overview is intentionally once-per-mount; remount at tenant boundary. */}
         <CodexSubscriptionsCard
-          key={workspaceId}
+          key={`codex-subscriptions:${workspaceId}`}
           workspaceId={workspaceId}
           canManage={canDeleteWorkspace}
         />


### PR DESCRIPTION
## Problem

`/workspaces/:workspaceId/settings` logged a React duplicate-key error on every render:

```
Encountered two children with the same key, `<workspaceId>`.
```

`ModelAccessPolicySection` and `CodexSubscriptionsCard` are siblings in the same parent and both used a bare `key={workspaceId}`, so the two keys were identical. The adjacent `SuperGrokSubscriptionsCard` already namespaces its key as `supergrok:${workspaceId}`, so the convention existed and these two missed it.

## Fix

The keys are deliberate - the inline comment notes the Codex overview is once-per-mount and must remount at the tenant boundary - so the fix namespaces both keys rather than dropping them:

- `` key={`model-access:${workspaceId}`} ``
- `` key={`codex-subscriptions:${workspaceId}`} ``

Per-workspace remount behavior is unchanged.

## Verification

Reproduced and verified end-to-end against a local stack, not only by reading code:

1. Loaded `/workspaces/<id>/settings` in a clean browser tab, confirmed the settings page rendered, captured the duplicate-key error with the workspace UUID as the key.
2. Applied the fix, loaded the same route in a fresh tab (clean console buffer), confirmed the page renders with zero duplicate-key errors.

Also run locally:

- `bun run typecheck` - all projects clean
- `bun test apps/web/src/routes` - 74 pass, 0 fail

## Notes

The key is a workspace UUID, so this initially looked like `listWorkspacesForSubject` might be returning a duplicate row. That was ruled out: the membership table had exactly one row for the workspace, and `setWorkspaces` takes the API response directly. The duplicate is purely two static JSX siblings sharing a literal key.

Linear: OPE-279

🤖 Generated with [Claude Code](https://claude.com/claude-code)