### PR TITLE
perf(turn): overlap repo-turn sandbox create with first-token prep

### DIFF
--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -2175,6 +2175,31 @@ export function sandboxEstablishPolicyDecision(input: {
 }
 
 /**
+ * Repo-backed workspace skills bind into the first-request prompt-cache prefix
+ * (`WorkspaceSkillsCapability.instructions()` listDirs the live box). Starting
+ * the managed-box establish as soon as its inputs exist lets Modal create overlap
+ * tools/history/agent; `get()` still owns clone/setup after `buildAgent`.
+ *
+ * Do not flip those turns to eager: that serializes create BEFORE tools and
+ * increases first-token latency. Chat-only turns without a repository still
+ * never create a box. Portable `/compact` returns before this path. Connected
+ * Machines and `backend: none` have no managed Modal/docker create to overlap.
+ */
+export function shouldPrefetchManagedSandbox(input: {
+  establishPolicy: "eager" | "on-demand";
+  machinePrimary: boolean;
+  groupBoxBackend: Settings["sandboxBackend"];
+  hasRepositoryResources: boolean;
+}): boolean {
+  if (input.establishPolicy !== "on-demand") return false;
+  if (input.machinePrimary) return false;
+  if (input.groupBoxBackend === "none" || input.groupBoxBackend === "selfhosted") {
+    return false;
+  }
+  return input.hasRepositoryResources;
+}
+
+/**
  * Classify a persisted active-sandbox pointer for TURN-START RECONCILE (issue #341
  * invariant B). Returns the typed reason to RESET the pointer to the session HOME,
  * or null to leave it in place. STRUCTURAL unestablishability only:
@@ -3599,6 +3624,9 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       durationSeconds: number;
     }> = [];
     let turnSandboxProvisioner: TurnSandboxProvisioner<ResumedTurnSandbox> | null = null;
+    let resumeManagedGroupBox: (() => Promise<ResumedTurnSandbox>) | null = null;
+    let prefetchedManagedBox: Promise<ResumedTurnSandbox> | null = null;
+    let prefetchedManagedBoxResult: ResumedTurnSandbox | null = null;
     // The UN-PROXIED established box session, captured BEFORE wrapTurnBoxWithRouting.
     // Platform setup (beforeAgentStart hooks + file materialization) execs against
     // THIS handle so a mid-turn sandbox_swap can never re-route those execs onto a
@@ -3949,6 +3977,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       sandbox: ResumedTurnSandbox,
       warmBackend: Settings["sandboxBackend"] | undefined,
     ): void => {
+      if (leaseHeartbeatTimer) return;
       if (!sandboxHolderId || !sandboxGroupId) {
         return;
       }
@@ -5861,46 +5890,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         attemptId: input.attemptId,
       });
 
-      // Pack-scoped runtime: enabled packs may declare the sandbox image this
-      // workspace's sessions run in and skills for the sandbox skill index.
-      // Resolved after turn.started so a composition conflict (two enabled
-      // packs declaring images) fails the turn with its plain error instead
-      // of failing the activity opaquely.
-      const [packRuntime, installedSkillRuntime] = await Promise.all([
-        resolveWorkspacePackRuntime(db, input.workspaceId),
-        resolveWorkspaceInstalledSkillRuntime(db, input.workspaceId),
-      ]);
-      // RIG BINDING (M3): load the session's FROZEN rig version (resolved+frozen
-      // at create). Everything rig-derived below (image precedence, env default
-      // sets, setup hook, credential hooks, doctrine, lease/telemetry stamps) is
-      // gated on this being non-null, so a rig-less session takes a zero-cost
-      // branch that is byte-for-byte today's turn. Both ids are frozen together;
-      // a defensive null (e.g. a since-deleted rig FK-nulled the columns) simply
-      // runs the turn rig-less.
-      const rigMaterialization =
-        session.rigId && session.rigVersionId
-          ? await materializeRigVersionForAttempt(db, {
-              accountId: input.accountId,
-              workspaceId: input.workspaceId,
-              subjectId: fileAuthoritySubjectId,
-              sessionId: input.sessionId,
-              turnId: turn.id,
-              attemptId: input.attemptId,
-              executionGeneration: turn.executionGeneration,
-            })
-          : null;
-      const rigVersion = rigMaterialization?.version ?? null;
-      // Rig display name for the doctrine block + setup events/errors (only on a
-      // rig-bound turn; null-safe fallback keeps the turn alive if the rig row is
-      // gone). Loaded once here alongside the version.
-      const rigName = rigVersion ? (rigMaterialization?.rigName ?? "rig") : null;
-      // Telemetry: stamp the frozen rig binding (empty for a rig-less turn).
-      rigId = session.rigId ?? "";
-      rigVersionId = session.rigVersionId ?? "";
-      // Workspace tier of the agent-persona resolution (session > workspace >
-      // deployment default). null means the workspace has no override, so the
-      // runtime falls back to runSettings.agentInstructionsTemplate (the
-      // deployment default, byte-identical to the historical preamble).
       const governanceClaims = {
         accountId: input.accountId,
         workspaceId: input.workspaceId,
@@ -5909,8 +5898,32 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         attemptId: input.attemptId,
         executionGeneration: turn.executionGeneration,
       };
-      const [workspace, companyProfileSnapshot, instructionPolicySnapshot, preferenceSnapshot] =
-        await Promise.all([
+      // Independent workspace reads after the personal-resource fence. Pack,
+      // installed skills, frozen rig, governance snapshots, and model policy do
+      // not depend on each other. Company-brain selection still waits on the
+      // snapshots below so its receipt stays exact.
+      const [
+        packRuntime,
+        installedSkillRuntime,
+        rigMaterialization,
+        [workspace, companyProfileSnapshot, instructionPolicySnapshot, preferenceSnapshot],
+        workspaceModelPolicy,
+      ] = await Promise.all([
+        resolveWorkspacePackRuntime(db, input.workspaceId),
+        resolveWorkspaceInstalledSkillRuntime(db, input.workspaceId),
+        session.rigId && session.rigVersionId
+          ? (async () =>
+              await materializeRigVersionForAttempt(db, {
+                accountId: input.accountId,
+                workspaceId: input.workspaceId,
+                subjectId: fileAuthoritySubjectId,
+                sessionId: input.sessionId,
+                turnId: turn.id,
+                attemptId: input.attemptId,
+                executionGeneration: turn.executionGeneration,
+              }))()
+          : Promise.resolve(null),
+        Promise.all([
           getWorkspace(db, input.workspaceId),
           getOrCreateCompanyProfileSnapshot(db, governanceClaims),
           getOrCreateWorkspaceInstructionPolicySnapshot(db, governanceClaims),
@@ -5918,7 +5931,17 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             if (error instanceof PreferenceRegistryInitiatorError) return null;
             throw error;
           }),
-        ]);
+        ]),
+        getWorkspaceModelPolicy(db, input.workspaceId),
+      ]);
+      const rigVersion = rigMaterialization?.version ?? null;
+      // Rig display name for the doctrine block + setup events/errors (only on a
+      // rig-bound turn; null-safe fallback keeps the turn alive if the rig row is
+      // gone). Loaded once here alongside the version.
+      const rigName = rigVersion ? (rigMaterialization?.rigName ?? "rig") : null;
+      // Telemetry: stamp the frozen rig binding (empty for a rig-less turn).
+      rigId = session.rigId ?? "";
+      rigVersionId = session.rigVersionId ?? "";
       if (!workspace) throw new Error(`Workspace not found: ${input.workspaceId}`);
       const agentHumanInputEnabled = resolveWorkspaceAgentHumanInputEnabled(workspace.settings);
       const contextSelection = await resolveCompanyBrainContextSelection(db, governanceClaims);
@@ -6083,7 +6106,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // the attribution source even if an injected test runtime returns no
       // concrete resolved model. Fail-loud, never a silent remap.
       {
-        const workspaceModelPolicy = await getWorkspaceModelPolicy(db, input.workspaceId);
         if (workspaceModelPolicy) {
           const verdict = evaluateWorkspaceModelPolicy(workspaceModelPolicy, {
             providerId: turnExecutionPolicy.providerId,
@@ -7053,11 +7075,23 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         ? runCredentialModelNote(initialRunCredentialMaterial)
         : undefined;
       throwIfTurnOperationCancelled(cancellationSignal);
-      await waitForTurnOperation(
-        ensureTurnModalRegistryImage(runSettings, sandboxCreationBackend),
-        cancellationSignal,
-        undefined,
-      );
+      await Promise.all([
+        waitForTurnOperation(
+          ensureTurnModalRegistryImage(runSettings, sandboxCreationBackend),
+          cancellationSignal,
+          undefined,
+        ),
+        activeSandboxBackend !== "selfhosted"
+          ? assertGitHubResourcesRemainAuthorized(db, input.workspaceId, turnResources)
+          : Promise.resolve(),
+        assertFileResourcesRemainAuthorized(
+          db,
+          input.accountId,
+          input.workspaceId,
+          fileAuthoritySubjectId,
+          turn.resources,
+        ),
+      ]);
       // Computed exactly ONCE per turn and reused for BOTH the box manifest
       // (resumeBoxForTurn -> establishSandboxSessionFromEnvelope, below) AND the
       // agent (runtime.buildAgent, below). sandboxEnvironmentForRun mints a FRESH
@@ -7077,16 +7111,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       // provider may supply it; unset still self-mints GitHub from settings.
       // gitToken/gitTokens are undefined on the selfhosted skip path (the machine
       // uses its own git creds).
-      if (activeSandboxBackend !== "selfhosted") {
-        await assertGitHubResourcesRemainAuthorized(db, input.workspaceId, turnResources);
-      }
-      await assertFileResourcesRemainAuthorized(
-        db,
-        input.accountId,
-        input.workspaceId,
-        fileAuthoritySubjectId,
-        turn.resources,
-      );
       const authorizeGitHubTokenMint: GitHubTokenMintAuthorization = async (selection) => {
         await assertGitHubTokenMintSelectionAuthorized(
           db,
@@ -7193,6 +7217,25 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               expiresAt: sandboxGitTokenExpiresAt ?? {},
             }
           : undefined;
+      // Lazy cloud provision mints the run-scoped git token while Modal create
+      // runs. Chat-only turns never call get(), so this stays unstarted there.
+      let runGitCredentialsMint: Promise<MintedRunGitCredentials | undefined> | undefined;
+      const startRunGitCredentialsMint = (): Promise<MintedRunGitCredentials | undefined> => {
+        if (activeSandboxBackend === "selfhosted") {
+          return Promise.resolve(undefined);
+        }
+        runGitCredentialsMint ??= waitForTurnOperation(
+          mintRunGitCredentials(runSettings, turnResources, {
+            scope: connectionScope,
+            ...(gitCredentialAuthority ? { authority: gitCredentialAuthority } : {}),
+            gitCredentials: connectionCredentials?.gitCredentials,
+            authorizeGitHubTokenMint,
+          }),
+          cancellationSignal,
+          undefined,
+        );
+        return runGitCredentialsMint;
+      };
       const attachGitCredentialRenewal = async (
         tokenSession: GitCredentialTokenWriterSession,
         initial: MintedRunGitCredentials | undefined,
@@ -7732,6 +7775,76 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             // but the lease acquire + box establish + setup move behind the routing
             // proxy's first default-pointer op. A chat-only turn never calls it, so
             // no lease row, no provider box, no warm-meter interval.
+            //
+            // A repository still forces that first default-pointer op before HTTP
+            // (workspace-skill catalog in Agent.instructions). Start create now and
+            // join it at get(); do not await here or we serialize Modal before tools.
+            if (sandboxHolderId && sandboxGroupId) {
+              const lazyHolderId = sandboxHolderId;
+              const lazyGroupId = sandboxGroupId;
+              resumeManagedGroupBox = () =>
+                resumeBoxForTurn(
+                  {
+                    db,
+                    settings: runSettings,
+                    logicalFallbackSettings: logicalSandboxSettings,
+                    cancellationSignal: sandboxResumeSignal,
+                    sandboxMetrics: runtimeMetricsHooksForObservability(observability),
+                    onSandboxLost: publishSandboxLost,
+                  },
+                  {
+                    accountId: input.accountId,
+                    workspaceId: input.workspaceId,
+                    sandboxGroupId: lazyGroupId,
+                    sessionId: input.sessionId,
+                    backend: groupBoxBackend,
+                    os: session.sandboxOs,
+                    environment: sandboxEnvironment,
+                    ...(groupBoxImage
+                      ? {
+                          image: groupBoxImage,
+                        }
+                      : {}),
+                    // The lazy acquire must enforce the same frozen rig authority
+                    // as the eager acquire; otherwise a warm box for another rig
+                    // can bypass the shared-state conflict/rotation fence.
+                    ...(rigVersion ? { rigVersionId: rigVersion.id } : {}),
+                  },
+                  "turn",
+                  lazyHolderId,
+                );
+              if (
+                shouldPrefetchManagedSandbox({
+                  establishPolicy,
+                  machinePrimary,
+                  groupBoxBackend,
+                  hasRepositoryResources: turnResources.some(
+                    (resource) => resource.kind === "repository",
+                  ),
+                })
+              ) {
+                startRunGitCredentialsMint();
+                const started = waitForTurnOperation(
+                  resumeManagedGroupBox(),
+                  sandboxResumeSignal,
+                  releaseLateSandbox,
+                );
+                const joined = started.catch((error) => {
+                  if (isLazySandboxProvisionRetryable(error)) {
+                    prefetchedManagedBox = null;
+                  }
+                  throw error;
+                });
+                prefetchedManagedBox = joined;
+                void joined.then(
+                  (box) => {
+                    if (sandboxResumeSignal.aborted) return;
+                    startLeaseHeartbeat(box, activeSandboxBackend ?? groupBoxBackend);
+                  },
+                  () => undefined,
+                );
+              }
+            }
           } else {
             await publish!(
               [
@@ -8924,8 +9037,6 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         );
       }
       if (establishPolicy === "on-demand" && sandboxHolderId && sandboxGroupId) {
-        const lazyHolderId = sandboxHolderId;
-        const lazyGroupId = sandboxGroupId;
         const agentDefaultManifest = (agent as { defaultManifest?: unknown }).defaultManifest;
         if (!agentDefaultManifest) {
           throw new Error("Lazy sandbox provisioning requires a SandboxAgent defaultManifest");
@@ -8938,36 +9049,11 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
           async () => {
             throwIfWorkerShuttingDown();
             throwIfTurnCancelled();
-            const provisioned = await resumeBoxForTurn(
-              {
-                db,
-                settings: runSettings,
-                logicalFallbackSettings: logicalSandboxSettings,
-                cancellationSignal: sandboxResumeSignal,
-                sandboxMetrics: runtimeMetricsHooksForObservability(observability),
-                onSandboxLost: publishSandboxLost,
-              },
-              {
-                accountId: input.accountId,
-                workspaceId: input.workspaceId,
-                sandboxGroupId: lazyGroupId,
-                sessionId: input.sessionId,
-                backend: groupBoxBackend,
-                os: session.sandboxOs,
-                environment: sandboxEnvironment,
-                ...(groupBoxImage
-                  ? {
-                      image: groupBoxImage,
-                    }
-                  : {}),
-                // The lazy acquire must enforce the same frozen rig authority
-                // as the eager acquire; otherwise a warm box for another rig
-                // can bypass the shared-state conflict/rotation fence.
-                ...(rigVersion ? { rigVersionId: rigVersion.id } : {}),
-              },
-              "turn",
-              lazyHolderId,
-            );
+            if (!resumeManagedGroupBox) {
+              throw new Error("Lazy sandbox provisioning requires a managed group-box resume");
+            }
+            startRunGitCredentialsMint();
+            const provisioned = await (prefetchedManagedBox ?? resumeManagedGroupBox());
             await publishSandboxLifecycleEvents(provisioned);
             // Return the REAL established box (NOT a copy whose session is the routing
             // proxy). resolveActiveBackend dispatches ops to `provisioned.established.session`;
@@ -9058,12 +9144,7 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
               const lazyGitCredentials =
                 activeSandboxBackend === "selfhosted"
                   ? undefined
-                  : await mintRunGitCredentials(runSettings, turnResources, {
-                      scope: connectionScope,
-                      ...(gitCredentialAuthority ? { authority: gitCredentialAuthority } : {}),
-                      gitCredentials: connectionCredentials?.gitCredentials,
-                      authorizeGitHubTokenMint,
-                    });
+                  : await startRunGitCredentialsMint();
               const lazyGitTokens = lazyGitCredentials?.gitTokens;
               const lazyCodemodeToken = sandboxCodemodeToken
                 ? await mintSandboxCodemodeToken(runSettings, connectionScope, codemodeAuthority)
@@ -12762,6 +12843,18 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
             turnSandboxProvisioner.waitForSettled(30_000),
             finalizerSignal,
           );
+        } else if (prefetchedManagedBox) {
+          // Create finished (or was aborted) before get()/setup. Join so a
+          // successful prefetch cannot leak a holder after this attempt ends.
+          await waitForTurnFinalizerStep(
+            prefetchedManagedBox.then(
+              (box) => {
+                prefetchedManagedBoxResult = box;
+              },
+              () => undefined,
+            ),
+            finalizerSignal,
+          );
         }
         // P1.2: stop the lease-TTL refresh, release the turn holder (idempotent
         // delete-my-row; refcount-- and warm->draining if it hit 0 with no turns),
@@ -12855,7 +12948,10 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
         if (resolvedSandbox) {
           sandboxReleaseTargets.add(resolvedSandbox);
           resolvedSandbox = null;
+        } else if (prefetchedManagedBoxResult) {
+          sandboxReleaseTargets.add(prefetchedManagedBoxResult);
         }
+        prefetchedManagedBoxResult = null;
         if (attemptWritersDrained) {
           for (const sandboxToRelease of sandboxReleaseTargets) {
             try {

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -2844,10 +2844,18 @@ describe("lazy sandbox provisioner single-flight", () => {
       "Independent workspace reads after the personal-resource fence",
       authorize,
     );
-    const packRead = source.indexOf("resolveWorkspacePackRuntime(db, input.workspaceId)", overlappedReads);
+    const packRead = source.indexOf(
+      "resolveWorkspacePackRuntime(db, input.workspaceId)",
+      overlappedReads,
+    );
     const rigRead = source.indexOf("await materializeRigVersionForAttempt(db", overlappedReads);
-    const policyRead = source.indexOf("getWorkspaceModelPolicy(db, input.workspaceId)", overlappedReads);
-    const imageEnsure = source.indexOf("ensureTurnModalRegistryImage(runSettings, sandboxCreationBackend)");
+    const policyRead = source.indexOf(
+      "getWorkspaceModelPolicy(db, input.workspaceId)",
+      overlappedReads,
+    );
+    const imageEnsure = source.indexOf(
+      "ensureTurnModalRegistryImage(runSettings, sandboxCreationBackend)",
+    );
     const gitAssert = source.indexOf(
       "assertGitHubResourcesRemainAuthorized(db, input.workspaceId, turnResources)",
     );

--- a/apps/worker/test/agent-turn.test.ts
+++ b/apps/worker/test/agent-turn.test.ts
@@ -103,6 +103,7 @@ import {
   sandboxArtifactRuntimeAdmission,
   sandboxDeadlineRotationRecoveryDelayMs,
   shouldEstablishSandboxForTurn,
+  shouldPrefetchManagedSandbox,
   shouldDeferNonEagerToolPreparation,
   shouldRecoverCompactionProviderFailure,
   shouldStartOnTurnRecording,
@@ -2749,6 +2750,23 @@ describe("lazy sandbox provisioner single-flight", () => {
     ).toEqual({ policy: "eager", reason: "signed_file_resources" });
   });
 
+  test("managed-box prefetch is only for on-demand repository turns", () => {
+    const base = {
+      establishPolicy: "on-demand" as const,
+      machinePrimary: false,
+      groupBoxBackend: "modal" as const,
+      hasRepositoryResources: true,
+    };
+
+    expect(shouldPrefetchManagedSandbox(base)).toBe(true);
+    expect(shouldPrefetchManagedSandbox({ ...base, groupBoxBackend: "docker" })).toBe(true);
+    expect(shouldPrefetchManagedSandbox({ ...base, establishPolicy: "eager" })).toBe(false);
+    expect(shouldPrefetchManagedSandbox({ ...base, machinePrimary: true })).toBe(false);
+    expect(shouldPrefetchManagedSandbox({ ...base, groupBoxBackend: "none" })).toBe(false);
+    expect(shouldPrefetchManagedSandbox({ ...base, groupBoxBackend: "selfhosted" })).toBe(false);
+    expect(shouldPrefetchManagedSandbox({ ...base, hasRepositoryResources: false })).toBe(false);
+  });
+
   test("credential-bearing lazy turns resolve context once and materialize at the first shared operation", async () => {
     const steps: string[] = [];
     let resolves = 0;
@@ -2815,6 +2833,82 @@ describe("lazy sandbox provisioner single-flight", () => {
     expect(lazyCredentialAttachAt).toBeGreaterThan(provisionerAt);
     expect(lazyProvisionerPrefix).not.toContain("runCredentialResolver.resolve(");
     expect(lazyProvisionerPrefix).toContain("initialRunCredentialMaterial");
+  });
+
+  test("runtime preparation overlaps independent workspace reads after the personal-resource fence", async () => {
+    const source = await Bun.file(
+      new URL("../src/activities/agent-turn.ts", import.meta.url),
+    ).text();
+    const authorize = source.indexOf("await resolveSessionAttemptPersonalResources(db");
+    const overlappedReads = source.indexOf(
+      "Independent workspace reads after the personal-resource fence",
+      authorize,
+    );
+    const packRead = source.indexOf("resolveWorkspacePackRuntime(db, input.workspaceId)", overlappedReads);
+    const rigRead = source.indexOf("await materializeRigVersionForAttempt(db", overlappedReads);
+    const policyRead = source.indexOf("getWorkspaceModelPolicy(db, input.workspaceId)", overlappedReads);
+    const imageEnsure = source.indexOf("ensureTurnModalRegistryImage(runSettings, sandboxCreationBackend)");
+    const gitAssert = source.indexOf(
+      "assertGitHubResourcesRemainAuthorized(db, input.workspaceId, turnResources)",
+    );
+    expect(authorize).toBeGreaterThan(0);
+    expect(overlappedReads).toBeGreaterThan(authorize);
+    expect(packRead).toBeGreaterThan(overlappedReads);
+    expect(rigRead).toBeGreaterThan(packRead);
+    expect(policyRead).toBeGreaterThan(rigRead);
+    expect(imageEnsure).toBeGreaterThan(policyRead);
+    expect(gitAssert).toBeGreaterThan(imageEnsure);
+    expect(source.slice(imageEnsure - 80, gitAssert)).toContain("Promise.all");
+  });
+
+  test("lazy git token mint starts before the box establish returns", async () => {
+    const source = await Bun.file(
+      new URL("../src/activities/agent-turn.ts", import.meta.url),
+    ).text();
+    const provisionerAt = source.indexOf(
+      "turnSandboxProvisioner = createTurnSandboxProvisioner<ResumedTurnSandbox>",
+    );
+    const resumeAt = source.indexOf(
+      "const provisioned = await (prefetchedManagedBox ?? resumeManagedGroupBox())",
+      provisionerAt,
+    );
+    const mintStartAt = source.lastIndexOf("startRunGitCredentialsMint();", resumeAt);
+    const mintAwaitAt = source.indexOf("await startRunGitCredentialsMint()", resumeAt);
+    expect(provisionerAt).toBeGreaterThan(-1);
+    expect(resumeAt).toBeGreaterThan(provisionerAt);
+    expect(mintStartAt).toBeGreaterThan(provisionerAt);
+    expect(mintStartAt).toBeLessThan(resumeAt);
+    expect(mintAwaitAt).toBeGreaterThan(resumeAt);
+  });
+
+  test("repository on-demand turns prefetch managed-box create before tools", async () => {
+    const source = await Bun.file(
+      new URL("../src/activities/agent-turn.ts", import.meta.url),
+    ).text();
+    const onDemandAt = source.indexOf('} else if (establishPolicy === "on-demand")');
+    const prefetchAt = source.indexOf("shouldPrefetchManagedSandbox({", onDemandAt);
+    const toolsAt = source.indexOf('phase: "tools"', prefetchAt);
+    const provisionerAt = source.indexOf(
+      "turnSandboxProvisioner = createTurnSandboxProvisioner<ResumedTurnSandbox>",
+      toolsAt,
+    );
+    const joinAt = source.indexOf(
+      "const provisioned = await (prefetchedManagedBox ?? resumeManagedGroupBox())",
+      provisionerAt,
+    );
+    const prefetchMintAt = source.indexOf("startRunGitCredentialsMint();", prefetchAt);
+    const prefetchResumeAt = source.indexOf("resumeManagedGroupBox()", prefetchMintAt);
+
+    expect(onDemandAt).toBeGreaterThan(-1);
+    expect(prefetchAt).toBeGreaterThan(onDemandAt);
+    expect(toolsAt).toBeGreaterThan(prefetchAt);
+    expect(provisionerAt).toBeGreaterThan(toolsAt);
+    expect(joinAt).toBeGreaterThan(provisionerAt);
+    expect(prefetchMintAt).toBeGreaterThan(prefetchAt);
+    expect(prefetchMintAt).toBeLessThan(prefetchResumeAt);
+    expect(prefetchResumeAt).toBeLessThan(toolsAt);
+    expect(source.slice(onDemandAt, toolsAt)).not.toContain("await resumeManagedGroupBox()");
+    expect(source.slice(onDemandAt, toolsAt)).not.toContain("await resumeBoxForTurn(");
   });
 
   test("deadline rotation uses only short anti-churn pacing", () => {

--- a/packages/runtime/src/workspace-skills.ts
+++ b/packages/runtime/src/workspace-skills.ts
@@ -17,9 +17,17 @@ type WorkspaceSkill = Readonly<{
   name: string;
   description: string;
   path: string;
-  fingerprint: string;
   source: string;
 }>;
+
+type DiscoveredWorkspaceSkill = {
+  name: string;
+  description: string;
+  path: string;
+  source: string;
+  directory: string;
+  fingerprint?: string;
+};
 
 /**
  * Index skills that already exist in the live workspace.
@@ -93,7 +101,7 @@ export async function discoverWorkspaceSkills(
   if (!session.listDir || !session.readFile) {
     throw new Error("Workspace skill discovery requires sandbox listDir() and readFile() support");
   }
-  const discovered = new Map<string, WorkspaceSkill>();
+  const discovered = new Map<string, DiscoveredWorkspaceSkill>();
   let candidates = 0;
   for (const searchPath of searchPaths) {
     let entries;
@@ -133,26 +141,39 @@ export async function discoverWorkspaceSkills(
       if (reservedNames.has(key)) {
         throw new Error(`Workspace skill "${name}" conflicts with a configured OpenGeni skill`);
       }
-      const candidate: WorkspaceSkill = {
+      const candidate: DiscoveredWorkspaceSkill = {
         name,
         description,
         path: skillMarkdownPath,
-        fingerprint: await fingerprintWorkspaceDirectory(session, entry.path, runAs),
         source: searchPath.source,
+        directory: entry.path,
       };
       const existing = discovered.get(key);
       if (!existing) {
         discovered.set(key, candidate);
         continue;
       }
-      if (existing.fingerprint !== candidate.fingerprint) {
+      // Unique names only need SKILL.md frontmatter for the prompt-cache prefix.
+      // Hash both trees only when the same name appears in two search paths.
+      const existingFingerprint =
+        existing.fingerprint ??
+        (await fingerprintWorkspaceDirectory(session, existing.directory, runAs));
+      const candidateFingerprint = await fingerprintWorkspaceDirectory(
+        session,
+        candidate.directory,
+        runAs,
+      );
+      if (existingFingerprint !== candidateFingerprint) {
         throw new Error(
           `Workspace skill "${name}" has conflicting definitions in ${existing.source} and ${candidate.source}`,
         );
       }
+      existing.fingerprint = existingFingerprint;
     }
   }
-  return [...discovered.values()].sort((left, right) => left.name.localeCompare(right.name));
+  return [...discovered.values()]
+    .map(({ name, description, path, source }) => ({ name, description, path, source }))
+    .sort((left, right) => left.name.localeCompare(right.name));
 }
 
 async function fingerprintWorkspaceDirectory(

--- a/packages/runtime/test/workspace-skills.test.ts
+++ b/packages/runtime/test/workspace-skills.test.ts
@@ -72,12 +72,70 @@ description: Prepare a safe release.
     });
   });
 
+  test("unique skill names do not hash helper files", async () => {
+    const skill = `---
+name: release
+description: Prepare a safe release.
+---
+`;
+    const session = fakeSession({
+      ".agents/skills/release/SKILL.md": skill,
+      ".agents/skills/release/references/checklist.md": "verify\n",
+      ".agents/skills/deploy/SKILL.md":
+        "---\nname: deploy\ndescription: Deploy the service.\n---\n",
+      ".agents/skills/deploy/scripts/run.sh": "echo deploy\n",
+    });
+    const reads: string[] = [];
+    const listed: string[] = [];
+    const originalRead = session.readFile!;
+    const originalList = session.listDir!;
+    session.readFile = async (args) => {
+      reads.push(normalize(args.path));
+      return await originalRead(args);
+    };
+    session.listDir = async (args) => {
+      listed.push(normalize(args.path));
+      return await originalList(args);
+    };
+    const skills = await discoverWorkspaceSkills(session, [
+      { path: ".agents/skills", source: ".agents/skills" },
+    ]);
+    expect(skills.map((entry) => entry.name)).toEqual(["deploy", "release"]);
+    expect(listed).toEqual([".agents/skills"]);
+    expect(reads).toEqual([
+      ".agents/skills/deploy/SKILL.md",
+      ".agents/skills/release/SKILL.md",
+    ]);
+  });
+
   test("fails when the same skill name has different contents", async () => {
     const session = fakeSession({
       ".agents/skills/release/SKILL.md":
         "---\nname: release\ndescription: First definition.\n---\n",
       ".claude/skills/release/SKILL.md":
         "---\nname: release\ndescription: Different definition.\n---\n",
+    });
+    await expect(
+      discoverWorkspaceSkills(session, [
+        { path: ".agents/skills", source: ".agents/skills" },
+        { path: ".claude/skills", source: ".claude/skills" },
+      ]),
+    ).rejects.toThrow(
+      'Workspace skill "release" has conflicting definitions in .agents/skills and .claude/skills',
+    );
+  });
+
+  test("same name with identical SKILL.md but different helpers still conflicts", async () => {
+    const skill = `---
+name: release
+description: Prepare a safe release.
+---
+`;
+    const session = fakeSession({
+      ".agents/skills/release/SKILL.md": skill,
+      ".agents/skills/release/helper.sh": "echo a\n",
+      ".claude/skills/release/SKILL.md": skill,
+      ".claude/skills/release/helper.sh": "echo b\n",
     });
     await expect(
       discoverWorkspaceSkills(session, [

--- a/packages/runtime/test/workspace-skills.test.ts
+++ b/packages/runtime/test/workspace-skills.test.ts
@@ -102,10 +102,7 @@ description: Prepare a safe release.
     ]);
     expect(skills.map((entry) => entry.name)).toEqual(["deploy", "release"]);
     expect(listed).toEqual([".agents/skills"]);
-    expect(reads).toEqual([
-      ".agents/skills/deploy/SKILL.md",
-      ".agents/skills/release/SKILL.md",
-    ]);
+    expect(reads).toEqual([".agents/skills/deploy/SKILL.md", ".agents/skills/release/SKILL.md"]);
   });
 
   test("fails when the same skill name has different contents", async () => {


### PR DESCRIPTION
## Summary
- Overlap independent `runtime_preparation` reads and start GitHub token mint when lazy Modal create starts.
- Prefetch managed-box create for on-demand repository turns so it runs during tools/history/agent instead of after them (`get()` still owns clone/setup after `buildAgent`).
- Catalog unique repository skills from `SKILL.md` frontmatter only; hash skill trees only when the same name appears in two search paths.

## Test plan
- [x] `bun test packages/runtime/test/workspace-skills.test.ts apps/worker/test/agent-turn.test.ts apps/worker/test/pack-sandbox-runtime-settings.test.ts apps/worker/test/personal-resource-pre-read-authority.test.ts`
- [ ] Repo-backed on-demand Modal turn: first-token path still clones before HTTP, but create starts before tools and unique skills do not walk helper files
- [ ] Chat-only turn with no repository still never creates a box
- [ ] Same skill name in `.agents` and `.claude` with different helpers still fails closed


Made with [Cursor](https://cursor.com)