### PR TITLE
style: repair oxfmt drift in xai-subscription fetch

### DIFF
--- a/packages/xai-subscription/src/fetch.ts
+++ b/packages/xai-subscription/src/fetch.ts
@@ -575,8 +575,7 @@ function xaiSseTerminalError(
     eventType,
     requestId: audit.requestId,
     status,
-    diagnosticTruncated:
-      eventTypeField.truncated || codeField.truncated || messageField.truncated,
+    diagnosticTruncated: eventTypeField.truncated || codeField.truncated || messageField.truncated,
     headers,
   });
 }


### PR DESCRIPTION
## Problem

`bun run format:check` fails on a **pristine `origin/main` checkout**:

```
packages/xai-subscription/src/fetch.ts (1ms)
Format issues found in above 1 files.
```

`format:check` runs for every pull request, so this fails CI on branches that never touch this file. It blocks unrelated work.

## Fix

The literal output of `bun run format`, with no manual editing: one property assignment rejoined onto a single line.

```diff
-    diagnosticTruncated:
-      eventTypeField.truncated || codeField.truncated || messageField.truncated,
+    diagnosticTruncated: eventTypeField.truncated || codeField.truncated || messageField.truncated,
```

No semantic change — whitespace only. No changeset: nothing ships.

## Verification

`bun run format:check` passes on this branch; it fails on `origin/main` at the same commit this branched from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca7x2FyxheguVcdENGs8ji