### PR TITLE
fix(ci): close four timeout-guard evasions and harden the budget parser

### DIFF
--- a/.github/actions/playwright-browsers/action.yml
+++ b/.github/actions/playwright-browsers/action.yml
@@ -137,9 +137,13 @@ runs:
     # step. One step is sufficient because it reduces the re-run to a
     # single-browser download, which has never breached the bound - but it does
     # mean a partial set persists for the life of this Playwright version.
-    # A SIGKILLed install can leave a stale __dirlock behind. Playwright only
-    # treats it as stale after ~5 minutes, so baking it into an immutable cache
-    # would tax every later run against this key.
+    # A SIGKILLed install can leave a stale __dirlock behind. Playwright locks
+    # the registry through proper-lockfile passing only retries/onCompromised/
+    # lockfilePath, so the default `stale: 10000` applies - the lock clears
+    # after ~10 seconds, not the ~5 minutes an earlier revision of this comment
+    # claimed. Removing it is therefore cheap hygiene rather than a large
+    # saving: it keeps a lock out of an immutable cache entry and avoids the
+    # onCompromised path entirely.
     - name: Drop stale Playwright dirlock before saving
       if: ${{ always() && steps.restore.outputs.cache-hit != 'true' }}
       shell: bash

--- a/scripts/workflow-timeout-budget.ts
+++ b/scripts/workflow-timeout-budget.ts
@@ -1,0 +1,769 @@
+export type BudgetAnalysis = Readonly<{
+  minutes: number;
+  uncertainties: readonly string[];
+}>;
+
+export type TimeoutStep = Readonly<{
+  run?: string;
+  shell?: string;
+  "timeout-minutes"?: unknown;
+}>;
+
+type WordToken = Readonly<{
+  kind: "word";
+  value: string;
+  dynamic: boolean;
+}>;
+
+type OperatorToken = Readonly<{
+  kind: "operator";
+  value: string;
+}>;
+
+type ShellToken = WordToken | OperatorToken;
+
+const ZERO: BudgetAnalysis = { minutes: 0, uncertainties: [] };
+const LIST_SEPARATORS = new Set(["\n", ";", "&&", "||", "&"]);
+const PROSE_COMMANDS = new Set(["echo", "printf"]);
+const SHELL_COMMANDS = new Set(["bash", "dash", "sh", "zsh"]);
+
+function sum(analyses: readonly BudgetAnalysis[]): BudgetAnalysis {
+  return {
+    minutes: analyses.reduce((total, analysis) => total + analysis.minutes, 0),
+    uncertainties: analyses.flatMap((analysis) => analysis.uncertainties),
+  };
+}
+
+function maximum(analyses: readonly BudgetAnalysis[]): BudgetAnalysis {
+  return {
+    minutes: Math.max(0, ...analyses.map((analysis) => analysis.minutes)),
+    uncertainties: analyses.flatMap((analysis) => analysis.uncertainties),
+  };
+}
+
+function scaled(analysis: BudgetAnalysis, factor: number): BudgetAnalysis {
+  return {
+    minutes: analysis.minutes * factor,
+    uncertainties: analysis.uncertainties,
+  };
+}
+
+function uncertain(message: string, minutes = 0): BudgetAnalysis {
+  return { minutes, uncertainties: [message] };
+}
+
+function looksLikeBudget(source: string): boolean {
+  return /(?:^|[^\w])(?:--)?timeout(?:-seconds)?(?:\s|=|$)/u.test(source);
+}
+
+function looksLikeShellEvaluation(source: string): boolean {
+  return /(?:^|[;&|\s])(?:\S*\/)?(?:bash|dash|sh|zsh)\s+(?:[^;\n]*\s)?-[A-Za-z]*c[A-Za-z]*(?:\s|$)/u.test(
+    source,
+  );
+}
+
+/**
+ * Remove literal here-document bodies before tokenization. They are data, not
+ * shell commands. Malformed declarations remain an explicit uncertainty.
+ */
+function hereDocumentsOnLine(line: string): Readonly<{
+  declarations: readonly { delimiter: string; stripTabs: boolean }[];
+  dynamic: boolean;
+}> {
+  const declarations: Array<{ delimiter: string; stripTabs: boolean }> = [];
+  let dynamic = false;
+  let quote: "single" | "double" | null = null;
+  let atWordBoundary = true;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index] as string;
+    const next = line[index + 1];
+    if (quote === "single") {
+      if (char === "'") quote = null;
+      continue;
+    }
+    if (quote === "double") {
+      if (char === '"') quote = null;
+      else if (char === "\\" && next !== undefined) index += 1;
+      continue;
+    }
+    if (char === "\\") {
+      index += next === undefined ? 0 : 1;
+      atWordBoundary = false;
+      continue;
+    }
+    if (char === "'") {
+      quote = "single";
+      atWordBoundary = false;
+      continue;
+    }
+    if (char === '"') {
+      quote = "double";
+      atWordBoundary = false;
+      continue;
+    }
+    if (char === "#" && atWordBoundary) break;
+    if (char !== "<" || next !== "<") {
+      atWordBoundary = /[\s;&|()]/u.test(char);
+      continue;
+    }
+
+    let cursor = index + 2;
+    let stripTabs = false;
+    if (line[cursor] === "-") {
+      stripTabs = true;
+      cursor += 1;
+    }
+    while (line[cursor] === " " || line[cursor] === "\t") cursor += 1;
+    let delimiter = "";
+    const delimiterQuote = line[cursor];
+    if (delimiterQuote === "'" || delimiterQuote === '"') {
+      cursor += 1;
+      while (cursor < line.length && line[cursor] !== delimiterQuote) {
+        const delimiterChar = line[cursor] as string;
+        if (delimiterQuote === '"' && delimiterChar === "\\" && line[cursor + 1] !== undefined) {
+          delimiter += line[(cursor += 1)] as string;
+        } else {
+          delimiter += delimiterChar;
+        }
+        cursor += 1;
+      }
+      if (line[cursor] !== delimiterQuote) dynamic = true;
+    } else {
+      while (cursor < line.length && !/[\s;&|()<>]/u.test(line[cursor] as string)) {
+        const delimiterChar = line[cursor] as string;
+        if (delimiterChar === "\\" && line[cursor + 1] !== undefined) {
+          delimiter += line[(cursor += 1)] as string;
+        } else {
+          delimiter += delimiterChar;
+        }
+        cursor += 1;
+      }
+    }
+    if (delimiter.length > 0 && !dynamic) declarations.push({ delimiter, stripTabs });
+    else dynamic = true;
+    index = Math.max(index + 1, cursor - 1);
+    atWordBoundary = false;
+  }
+  return { declarations, dynamic };
+}
+
+function stripStaticHereDocuments(
+  source: string,
+): Readonly<{ input: string; uncertainties: readonly string[] }> {
+  const lines = source.split("\n");
+  const out: string[] = [];
+  const pending: Array<{ delimiter: string; stripTabs: boolean }> = [];
+  let dynamic = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] as string;
+    out.push(line);
+    if (pending.length > 0) continue;
+
+    const found = hereDocumentsOnLine(line);
+    pending.push(...found.declarations);
+    dynamic ||= found.dynamic;
+
+    while (pending.length > 0 && index + 1 < lines.length) {
+      const bodyLine = lines[(index += 1)] as string;
+      const current = pending[0] as { delimiter: string; stripTabs: boolean };
+      const candidate = current.stripTabs ? bodyLine.replace(/^\t+/u, "") : bodyLine;
+      out.push(candidate === current.delimiter ? bodyLine : "");
+      if (candidate === current.delimiter) pending.shift();
+    }
+  }
+  return {
+    input: out.join("\n"),
+    uncertainties: dynamic || pending.length > 0 ? ["malformed here-document delimiter"] : [],
+  };
+}
+
+function lexShell(source: string): BudgetAnalysis & Readonly<{ tokens: readonly ShellToken[] }> {
+  const stripped = stripStaticHereDocuments(source);
+  const input = stripped.input;
+  const tokens: ShellToken[] = [];
+  let value = "";
+  let dynamic = false;
+  let quote: "single" | "double" | null = null;
+
+  const pushWord = () => {
+    if (value.length === 0) return;
+    tokens.push({ kind: "word", value, dynamic });
+    value = "";
+    dynamic = false;
+  };
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index] as string;
+    const next = input[index + 1];
+
+    if (quote === "single") {
+      if (char === "'") quote = null;
+      else {
+        if (char === "$" && next === "{" && input[index + 2] === "{") dynamic = true;
+        value += char;
+      }
+      continue;
+    }
+
+    if (quote === "double") {
+      if (char === '"') {
+        quote = null;
+      } else if (char === "\\" && next !== undefined) {
+        if (next === "\n") index += 1;
+        else if ('"\\$`'.includes(next)) value += input[(index += 1)] as string;
+        else value += char;
+      } else {
+        if (char === "$" || char === "`") dynamic = true;
+        value += char;
+      }
+      continue;
+    }
+
+    if (char === "\\") {
+      if (next === "\n") index += 1;
+      else if (next !== undefined) value += input[(index += 1)] as string;
+      else value += char;
+      continue;
+    }
+    if (char === "'") {
+      quote = "single";
+      continue;
+    }
+    if (char === '"') {
+      quote = "double";
+      continue;
+    }
+    if (char === "#" && value.length === 0) {
+      while (index + 1 < input.length && input[index + 1] !== "\n") index += 1;
+      continue;
+    }
+    if (char === "\n") {
+      pushWord();
+      tokens.push({ kind: "operator", value: "\n" });
+      continue;
+    }
+    if (/\s/u.test(char)) {
+      pushWord();
+      continue;
+    }
+    if (char === "$" || char === "`") dynamic = true;
+
+    const pair = `${char}${next ?? ""}`;
+    if (["&&", "||", ";;", "|&"].includes(pair)) {
+      pushWord();
+      tokens.push({ kind: "operator", value: pair });
+      index += 1;
+      continue;
+    }
+    if (";|&()".includes(char)) {
+      pushWord();
+      tokens.push({ kind: "operator", value: char });
+      continue;
+    }
+    value += char;
+  }
+  pushWord();
+
+  const uncertainties: string[] = [...stripped.uncertainties];
+  if (quote !== null && looksLikeBudget(input)) {
+    uncertainties.push("unterminated shell quote around a timeout declaration");
+  }
+  return { minutes: 0, uncertainties, tokens };
+}
+
+function parseDuration(token: WordToken | undefined, context: string): BudgetAnalysis {
+  if (!token) return uncertain(`${context} has no duration`);
+  if (token.dynamic) return uncertain(`${context} uses a dynamic duration`);
+  const match = /^(\d+(?:\.\d+)?)([smhd]?)$/u.exec(token.value);
+  if (!match)
+    return uncertain(`${context} has an unsupported duration ${JSON.stringify(token.value)}`);
+  const amount = Number(match[1]);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return uncertain(`${context} has a non-positive duration`);
+  }
+  const multiplier = { "": 1 / 60, s: 1 / 60, m: 1, h: 60, d: 1440 }[
+    match[2] as "" | "s" | "m" | "h" | "d"
+  ];
+  return { minutes: amount * multiplier, uncertainties: [] };
+}
+
+function timeoutCommandBudget(words: readonly WordToken[], commandIndex: number): BudgetAnalysis {
+  let index = commandIndex + 1;
+  let killGrace = ZERO;
+
+  while (index < words.length) {
+    const option = words[index] as WordToken;
+    if (option.dynamic && option.value.startsWith("-")) {
+      return uncertain("coreutils timeout uses dynamic options");
+    }
+    if (option.value === "--") {
+      index += 1;
+      break;
+    }
+    if (!option.value.startsWith("-")) break;
+    if (["--preserve-status", "--foreground", "--verbose", "-v"].includes(option.value)) {
+      index += 1;
+      continue;
+    }
+    if (option.value === "--kill-after" || option.value === "-k") {
+      killGrace = parseDuration(words[index + 1], "timeout kill grace");
+      index += 2;
+      continue;
+    }
+    const killEquals = /^(?:--kill-after=|-k)(.+)$/u.exec(option.value);
+    if (killEquals) {
+      killGrace = parseDuration(
+        { kind: "word", value: killEquals[1] as string, dynamic: option.dynamic },
+        "timeout kill grace",
+      );
+      index += 1;
+      continue;
+    }
+    if (option.value === "--signal" || option.value === "-s") {
+      if (!words[index + 1] || (words[index + 1] as WordToken).dynamic) {
+        return uncertain("coreutils timeout uses a dynamic or missing signal option");
+      }
+      index += 2;
+      continue;
+    }
+    if (/^(?:--signal=|-s).+/u.test(option.value)) {
+      index += 1;
+      continue;
+    }
+    if (option.value === "--help" || option.value === "--version") return ZERO;
+    return uncertain(`coreutils timeout uses unsupported option ${JSON.stringify(option.value)}`);
+  }
+
+  return sum([parseDuration(words[index], "coreutils timeout"), killGrace]);
+}
+
+function readFlagDuration(
+  words: readonly WordToken[],
+  index: number,
+  flag: "--timeout-seconds" | "--timeout",
+): Readonly<{ analysis: BudgetAnalysis; consumed: number }> | null {
+  const token = words[index] as WordToken;
+  if (token.value === flag) {
+    const duration = words[index + 1];
+    if (!duration) return { analysis: uncertain(`${flag} has no value`), consumed: 1 };
+    if (duration.dynamic) {
+      return { analysis: uncertain(`${flag} uses a dynamic value`), consumed: 2 };
+    }
+    if (!/^\d+(?:\.\d+)?$/u.test(duration.value)) {
+      return { analysis: uncertain(`${flag} has an invalid value`), consumed: 2 };
+    }
+    const amount = Number(duration.value);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return { analysis: uncertain(`${flag} has an invalid value`), consumed: 2 };
+    }
+    return {
+      analysis: { minutes: amount / (flag === "--timeout" ? 60_000 : 60), uncertainties: [] },
+      consumed: 2,
+    };
+  }
+  const prefix = `${flag}=`;
+  if (!token.value.startsWith(prefix)) return null;
+  const raw = token.value.slice(prefix.length);
+  const amount = Number(raw);
+  if (token.dynamic || !/^\d+(?:\.\d+)?$/u.test(raw) || !Number.isFinite(amount) || amount <= 0) {
+    return { analysis: uncertain(`${flag} uses a dynamic or invalid value`), consumed: 1 };
+  }
+  return {
+    analysis: { minutes: amount / (flag === "--timeout" ? 60_000 : 60), uncertainties: [] },
+    consumed: 1,
+  };
+}
+
+function commandName(word: WordToken): string {
+  const pieces = word.value.split("/");
+  return pieces[pieces.length - 1] as string;
+}
+
+function isAssignment(word: WordToken): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/u.test(word.value);
+}
+
+function unwrapCommand(words: readonly WordToken[]): number {
+  let index = 0;
+  while (index < words.length && isAssignment(words[index] as WordToken)) index += 1;
+  while (index < words.length) {
+    const name = commandName(words[index] as WordToken);
+    if (["!", "builtin", "command", "exec", "time"].includes(name)) {
+      index += 1;
+      continue;
+    }
+    if (name === "env") {
+      index += 1;
+      while (
+        index < words.length &&
+        ((words[index] as WordToken).value.startsWith("-") ||
+          isAssignment(words[index] as WordToken))
+      ) {
+        index += 1;
+      }
+      continue;
+    }
+    if (name === "sudo") {
+      index += 1;
+      while (index < words.length && (words[index] as WordToken).value.startsWith("-")) {
+        const option = (words[index] as WordToken).value;
+        index += 1;
+        if (["-u", "--user", "-g", "--group", "-h", "--host"].includes(option)) index += 1;
+      }
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function analyzeCommand(words: readonly WordToken[]): BudgetAnalysis {
+  const commandIndex = unwrapCommand(words);
+  const command = words[commandIndex];
+  if (!command) return ZERO;
+  if (command.dynamic) {
+    return words.some((word) => looksLikeBudget(word.value))
+      ? uncertain("dynamic command contains a timeout declaration")
+      : ZERO;
+  }
+  const name = commandName(command);
+  if (PROSE_COMMANDS.has(name)) return ZERO;
+  if (name === "timeout") return timeoutCommandBudget(words, commandIndex);
+
+  if (SHELL_COMMANDS.has(name)) {
+    const commandFlag = words.findIndex(
+      (word, index) => index > commandIndex && /^-[A-Za-z]*c[A-Za-z]*$/u.test(word.value),
+    );
+    if (commandFlag >= 0) {
+      const script = words[commandFlag + 1];
+      if (!script || script.dynamic) return uncertain(`${name} -c uses a dynamic script`);
+      return analyzeShellTimeoutBudget(script.value);
+    }
+  }
+
+  if (name === "retry") {
+    let attempts: number | null = null;
+    let ambiguousRetries = false;
+    let nestedStart = commandIndex + 1;
+    const first = words[nestedStart];
+    if (first && /^\d+$/u.test(first.value) && !first.dynamic) {
+      attempts = Number(first.value);
+      nestedStart += 1;
+    } else {
+      for (let index = nestedStart; index < words.length; index += 1) {
+        const word = words[index] as WordToken;
+        if (["--attempts", "-n"].includes(word.value)) {
+          const value = words[index + 1];
+          if (value && /^\d+$/u.test(value.value) && !value.dynamic) {
+            attempts = Number(value.value);
+            nestedStart = index + 2;
+          }
+          break;
+        }
+        const equalsAttempts = /^(?:--attempts=|-n)(\d+)$/u.exec(word.value);
+        if (equalsAttempts && !word.dynamic) {
+          attempts = Number(equalsAttempts[1]);
+          nestedStart = index + 1;
+          break;
+        }
+        if (word.value === "--retries") {
+          ambiguousRetries = true;
+          nestedStart = index + 2;
+          break;
+        }
+        if (/^--retries=\d+$/u.test(word.value)) {
+          ambiguousRetries = true;
+          nestedStart = index + 1;
+          break;
+        }
+      }
+    }
+    const nested = analyzeCommand(words.slice(nestedStart));
+    if (ambiguousRetries && (nested.minutes > 0 || nested.uncertainties.length > 0)) {
+      return uncertain(
+        "retry --retries does not declare whether the value includes the first attempt",
+        nested.minutes,
+      );
+    }
+    if (attempts === null || attempts <= 0) {
+      return nested.minutes > 0 || nested.uncertainties.length > 0
+        ? uncertain("retry wrapper has an unknown attempt count", nested.minutes)
+        : ZERO;
+    }
+    return scaled(nested, attempts);
+  }
+
+  const analyses: BudgetAnalysis[] = [];
+  for (let index = commandIndex + 1; index < words.length;) {
+    const seconds = readFlagDuration(words, index, "--timeout-seconds");
+    if (seconds) {
+      analyses.push(seconds.analysis);
+      index += seconds.consumed;
+      continue;
+    }
+    const milliseconds = readFlagDuration(words, index, "--timeout");
+    if (milliseconds) {
+      if (name !== "bun") {
+        analyses.push(uncertain(`--timeout units are unknown for command ${JSON.stringify(name)}`));
+      } else {
+        analyses.push(milliseconds.analysis);
+      }
+      index += milliseconds.consumed;
+      continue;
+    }
+    if ((words[index] as WordToken).value === "timeout") {
+      analyses.push(
+        uncertain(`timeout is nested behind unsupported wrapper ${JSON.stringify(name)}`),
+      );
+    }
+    index += 1;
+  }
+  return sum(analyses);
+}
+
+function unsupportedControlFlow(tokens: readonly ShellToken[]): string | null {
+  let atCommandBoundary = true;
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index] as ShellToken;
+    if (token.kind === "operator") {
+      if (LIST_SEPARATORS.has(token.value) || ["|", "|&", "("].includes(token.value)) {
+        atCommandBoundary = true;
+      }
+      continue;
+    }
+    if (atCommandBoundary && ["case", "select", "function"].includes(token.value)) {
+      return `${token.value} control flow is not statically budgeted`;
+    }
+    if (
+      atCommandBoundary &&
+      tokens[index + 1]?.kind === "operator" &&
+      tokens[index + 1]?.value === "(" &&
+      tokens[index + 2]?.kind === "operator" &&
+      tokens[index + 2]?.value === ")"
+    ) {
+      return "shell function calls can amplify timeout budgets";
+    }
+    atCommandBoundary = ["then", "do", "else", "elif"].includes(token.value);
+  }
+  return null;
+}
+
+class ShellBudgetParser {
+  private index = 0;
+
+  constructor(private readonly tokens: readonly ShellToken[]) {}
+
+  parse(
+    stopWords: ReadonlySet<string> = new Set(),
+    stopOperators: ReadonlySet<string> = new Set(),
+  ): BudgetAnalysis {
+    const statements: BudgetAnalysis[] = [];
+    while (this.index < this.tokens.length) {
+      this.skipSeparators();
+      const token = this.tokens[this.index];
+      if (!token) break;
+      if (token.kind === "word" && stopWords.has(token.value)) break;
+      if (token.kind === "operator" && stopOperators.has(token.value)) break;
+      if (token.kind === "operator" && token.value === ")") {
+        this.index += 1;
+        statements.push(uncertain("unmatched closing parenthesis in timeout-bearing shell"));
+        continue;
+      }
+      if (token.kind === "word" && token.value === "for") statements.push(this.parseFor());
+      else if (token.kind === "word" && ["while", "until"].includes(token.value))
+        statements.push(this.parseUnboundedLoop());
+      else if (token.kind === "word" && token.value === "if") statements.push(this.parseIf());
+      else if (token.kind === "operator" && token.value === "(")
+        statements.push(this.parseSubshell());
+      else statements.push(this.parsePipeline(stopWords));
+    }
+    return sum(statements);
+  }
+
+  private skipSeparators(): void {
+    while (true) {
+      const token = this.tokens[this.index];
+      if (!token || token.kind !== "operator" || !LIST_SEPARATORS.has(token.value)) return;
+      this.index += 1;
+    }
+  }
+
+  private parsePipeline(stopWords: ReadonlySet<string>): BudgetAnalysis {
+    const commands: BudgetAnalysis[] = [];
+    let words: WordToken[] = [];
+    const flush = () => {
+      if (words.length > 0) commands.push(analyzeCommand(words));
+      words = [];
+    };
+
+    while (this.index < this.tokens.length) {
+      const token = this.tokens[this.index] as ShellToken;
+      if (token.kind === "word" && words.length === 0 && stopWords.has(token.value)) break;
+      if (token.kind === "operator") {
+        if (token.value === "|" || token.value === "|&") {
+          flush();
+          this.index += 1;
+          continue;
+        }
+        if (LIST_SEPARATORS.has(token.value) || token.value === ")") break;
+      }
+      if (token.kind === "word") words.push(token);
+      this.index += 1;
+    }
+    flush();
+    return maximum(commands);
+  }
+
+  private parseFor(): BudgetAnalysis {
+    this.index += 1;
+    const variable = this.tokens[this.index];
+    if (!variable || variable.kind !== "word") return uncertain("for loop has no variable");
+    this.index += 1;
+    const iterations: WordToken[] = [];
+    const maybeIn = this.tokens[this.index];
+    if (maybeIn?.kind === "word" && maybeIn.value === "in") {
+      this.index += 1;
+      while (this.index < this.tokens.length) {
+        const token = this.tokens[this.index] as ShellToken;
+        if (token.kind === "operator" && (token.value === ";" || token.value === "\n")) break;
+        if (token.kind === "word") iterations.push(token);
+        else return uncertain("for loop uses unsupported iteration syntax");
+        this.index += 1;
+      }
+    } else {
+      return uncertain("for loop iteration count is implicit");
+    }
+    this.skipSeparators();
+    const doToken = this.tokens[this.index];
+    if (!doToken || doToken.kind !== "word" || doToken.value !== "do") {
+      return uncertain("for loop has unsupported header syntax");
+    }
+    this.index += 1;
+    const body = this.parse(new Set(["done"]));
+    if (this.tokens[this.index]?.kind === "word") this.index += 1;
+
+    if (iterations.some((iteration) => iteration.dynamic)) {
+      return body.minutes > 0 || body.uncertainties.length > 0
+        ? uncertain("for loop has a dynamic iteration count", body.minutes)
+        : ZERO;
+    }
+    if (
+      iterations.some(
+        (iteration) =>
+          /[*?[\]{}]/u.test(iteration.value) && !/^\{(-?\d+)\.\.(-?\d+)\}$/u.test(iteration.value),
+      )
+    ) {
+      return body.minutes > 0 || body.uncertainties.length > 0
+        ? uncertain("for loop has a non-static expansion in its iteration list", body.minutes)
+        : ZERO;
+    }
+    let count = 0;
+    for (const iteration of iterations) {
+      const range = /^\{(-?\d+)\.\.(-?\d+)\}$/u.exec(iteration.value);
+      if (range) count += Math.abs(Number(range[2]) - Number(range[1])) + 1;
+      else count += 1;
+    }
+    return scaled(body, count);
+  }
+
+  private parseUnboundedLoop(): BudgetAnalysis {
+    const kind = (this.tokens[this.index] as WordToken).value;
+    this.index += 1;
+    const conditionStart = this.index;
+    while (this.index < this.tokens.length) {
+      const token = this.tokens[this.index] as ShellToken;
+      if (token.kind === "word" && token.value === "do") break;
+      this.index += 1;
+    }
+    const condition = new ShellBudgetParser(this.tokens.slice(conditionStart, this.index)).parse();
+    if (this.tokens[this.index]?.kind === "word") this.index += 1;
+    const body = this.parse(new Set(["done"]));
+    if (this.tokens[this.index]?.kind === "word") this.index += 1;
+    const oneIteration = sum([condition, body]);
+    return oneIteration.minutes > 0 || oneIteration.uncertainties.length > 0
+      ? uncertain(
+          `${kind} loop can amplify timeout budgets an unknown number of times`,
+          oneIteration.minutes,
+        )
+      : ZERO;
+  }
+
+  private parseIf(): BudgetAnalysis {
+    this.index += 1;
+    const conditionStart = this.index;
+    while (this.index < this.tokens.length) {
+      const token = this.tokens[this.index] as ShellToken;
+      if (token.kind === "word" && token.value === "then") break;
+      this.index += 1;
+    }
+    const conditions: BudgetAnalysis[] = [
+      new ShellBudgetParser(this.tokens.slice(conditionStart, this.index)).parse(),
+    ];
+    if (this.tokens[this.index]?.kind === "word") this.index += 1;
+    const branches: BudgetAnalysis[] = [this.parse(new Set(["elif", "else", "fi"]))];
+
+    while (this.tokens[this.index]?.kind === "word") {
+      const marker = (this.tokens[this.index] as WordToken).value;
+      this.index += 1;
+      if (marker === "fi") break;
+      if (marker === "else") {
+        branches.push(this.parse(new Set(["fi"])));
+        if (this.tokens[this.index]?.kind === "word") this.index += 1;
+        break;
+      }
+      const elifConditionStart = this.index;
+      while (this.index < this.tokens.length) {
+        const token = this.tokens[this.index] as ShellToken;
+        if (token.kind === "word" && token.value === "then") break;
+        this.index += 1;
+      }
+      conditions.push(
+        new ShellBudgetParser(this.tokens.slice(elifConditionStart, this.index)).parse(),
+      );
+      if (this.tokens[this.index]?.kind === "word") this.index += 1;
+      branches.push(this.parse(new Set(["elif", "else", "fi"])));
+    }
+    return sum([...conditions, maximum(branches)]);
+  }
+
+  private parseSubshell(): BudgetAnalysis {
+    this.index += 1;
+    const body = this.parse(new Set(), new Set([")"]));
+    if (this.tokens[this.index]?.kind === "operator" && this.tokens[this.index]?.value === ")") {
+      this.index += 1;
+    }
+    return body;
+  }
+}
+
+export function analyzeShellTimeoutBudget(source: string): BudgetAnalysis {
+  if (!looksLikeBudget(source) && !looksLikeShellEvaluation(source)) return ZERO;
+  const lexed = lexShell(source);
+  const unsupported = unsupportedControlFlow(lexed.tokens);
+  if (unsupported) {
+    return sum([uncertain(unsupported), { minutes: 0, uncertainties: lexed.uncertainties }]);
+  }
+  const parsed = new ShellBudgetParser(lexed.tokens).parse();
+  return sum([parsed, { minutes: 0, uncertainties: lexed.uncertainties }]);
+}
+
+export function analyzeStepTimeoutBudget(step: TimeoutStep): BudgetAnalysis {
+  const cap = step["timeout-minutes"];
+  if (cap !== undefined) {
+    if (typeof cap !== "number" || !Number.isFinite(cap) || cap <= 0) {
+      return uncertain("step timeout-minutes is dynamic or invalid");
+    }
+    // The runner-enforced step cap bounds every nested command and retry, so
+    // adding inner declarations would count the same wall-clock twice.
+    return { minutes: cap, uncertainties: [] };
+  }
+  const run = String(step.run ?? "");
+  if (step.shell && !/(?:^|\/)(?:ba|da|z)?sh(?:\s|$)/u.test(step.shell)) {
+    return looksLikeBudget(run)
+      ? uncertain(`timeout syntax in unsupported shell ${JSON.stringify(step.shell)}`)
+      : ZERO;
+  }
+  return analyzeShellTimeoutBudget(run);
+}

--- a/scripts/workflow-timeout-budget.ts
+++ b/scripts/workflow-timeout-budget.ts
@@ -13,7 +13,14 @@ type WordToken = Readonly<{
   kind: "word";
   value: string;
   dynamic: boolean;
+  segments: readonly WordSegment[];
+  effects: readonly BudgetAnalysis[];
 }>;
+
+type WordSegment =
+  | Readonly<{ kind: "literal"; value: string }>
+  | Readonly<{ kind: "variable"; name: string | null }>
+  | Readonly<{ kind: "substitution" }>;
 
 type OperatorToken = Readonly<{
   kind: "operator";
@@ -26,6 +33,8 @@ const ZERO: BudgetAnalysis = { minutes: 0, uncertainties: [] };
 const LIST_SEPARATORS = new Set(["\n", ";", "&&", "||", "&"]);
 const PROSE_COMMANDS = new Set(["echo", "printf"]);
 const SHELL_COMMANDS = new Set(["bash", "dash", "sh", "zsh"]);
+const TIMEOUT_COMMANDS = new Set(["timeout", "gtimeout"]);
+const MAX_ANALYSIS_DEPTH = 32;
 
 function sum(analyses: readonly BudgetAnalysis[]): BudgetAnalysis {
   return {
@@ -52,26 +61,155 @@ function uncertain(message: string, minutes = 0): BudgetAnalysis {
   return { minutes, uncertainties: [message] };
 }
 
-function looksLikeBudget(source: string): boolean {
-  return /(?:^|[^\w])(?:--)?timeout(?:-seconds)?(?:\s|=|$)/u.test(source);
+function appendLiteral(segments: WordSegment[], value: string): void {
+  if (value.length === 0) return;
+  const previous = segments[segments.length - 1];
+  if (previous?.kind === "literal") {
+    segments[segments.length - 1] = { kind: "literal", value: previous.value + value };
+  } else {
+    segments.push({ kind: "literal", value });
+  }
 }
 
-function looksLikeShellEvaluation(source: string): boolean {
-  return /(?:^|[;&|\s])(?:\S*\/)?(?:bash|dash|sh|zsh)\s+(?:[^;\n]*\s)?-[A-Za-z]*c[A-Za-z]*(?:\s|$)/u.test(
-    source,
-  );
+function resolveSegments(
+  segments: readonly WordSegment[],
+  variables: ReadonlyMap<string, string | null>,
+): string | null {
+  let value = "";
+  for (const segment of segments) {
+    if (segment.kind === "literal") value += segment.value;
+    else if (segment.kind === "variable" && segment.name && variables.has(segment.name)) {
+      const resolved = variables.get(segment.name);
+      if (resolved === null || resolved === undefined) return null;
+      value += resolved;
+    } else return null;
+  }
+  return value;
+}
+
+function resolveWord(
+  word: WordToken | undefined,
+  variables: ReadonlyMap<string, string | null>,
+): string | null {
+  return word ? resolveSegments(word.segments, variables) : null;
+}
+
+type ExtractedSubstitution = Readonly<{ content: string; end: number }>;
+
+function readBacktick(source: string, start: number): ExtractedSubstitution | null {
+  let content = "";
+  for (let index = start + 1; index < source.length; index += 1) {
+    const char = source[index] as string;
+    if (char === "\\" && source[index + 1] !== undefined) {
+      content += source[index + 1] as string;
+      index += 1;
+      continue;
+    }
+    if (char === "`") return { content, end: index };
+    content += char;
+  }
+  return null;
+}
+
+function readParenthesized(source: string, open: number): ExtractedSubstitution | null {
+  let depth = 1;
+  let quote: "single" | "double" | null = null;
+  for (let index = open + 1; index < source.length; index += 1) {
+    const char = source[index] as string;
+    const next = source[index + 1];
+    if (quote === "single") {
+      if (char === "'") quote = null;
+      continue;
+    }
+    if (quote === "double") {
+      if (char === '"') quote = null;
+      else if (char === "\\" && next !== undefined) index += 1;
+      else if (char === "$" && next === "(" && source[index + 2] !== "(") {
+        const nested = readParenthesized(source, index + 1);
+        if (!nested) return null;
+        index = nested.end;
+      } else if (char === "`") {
+        const nested = readBacktick(source, index);
+        if (!nested) return null;
+        index = nested.end;
+      }
+      continue;
+    }
+    if (char === "\\") {
+      if (next !== undefined) index += 1;
+      continue;
+    }
+    if (char === "'") {
+      quote = "single";
+      continue;
+    }
+    if (char === '"') {
+      quote = "double";
+      continue;
+    }
+    if (char === "`") {
+      const nested = readBacktick(source, index);
+      if (!nested) return null;
+      index = nested.end;
+      continue;
+    }
+    if (char === "(") depth += 1;
+    if (char === ")") {
+      depth -= 1;
+      if (depth === 0) return { content: source.slice(open + 1, index), end: index };
+    }
+  }
+  return null;
+}
+
+function expansionEffects(source: string, depth: number): BudgetAnalysis {
+  if (depth > MAX_ANALYSIS_DEPTH) return uncertain("shell expansion nesting is too deep");
+  const analyses: BudgetAnalysis[] = [];
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index] as string;
+    if (char === "\\") {
+      if (source[index + 1] !== undefined) index += 1;
+      continue;
+    }
+    if (char === "$" && source[index + 1] === "(" && source[index + 2] !== "(") {
+      const extracted = readParenthesized(source, index + 1);
+      if (!extracted) {
+        analyses.push(uncertain("malformed command substitution"));
+        break;
+      }
+      analyses.push(analyzeShellTimeoutBudgetInternal(extracted.content, depth + 1));
+      index = extracted.end;
+      continue;
+    }
+    if (char === "`") {
+      const extracted = readBacktick(source, index);
+      if (!extracted) {
+        analyses.push(uncertain("malformed backtick command substitution"));
+        break;
+      }
+      analyses.push(analyzeShellTimeoutBudgetInternal(extracted.content, depth + 1));
+      index = extracted.end;
+    }
+  }
+  return sum(analyses);
 }
 
 /**
  * Remove literal here-document bodies before tokenization. They are data, not
  * shell commands. Malformed declarations remain an explicit uncertainty.
  */
+type HereDocument = Readonly<{
+  delimiter: string;
+  stripTabs: boolean;
+  expandBody: boolean;
+}>;
+
 function hereDocumentsOnLine(line: string): Readonly<{
-  declarations: readonly { delimiter: string; stripTabs: boolean }[];
-  dynamic: boolean;
+  declarations: readonly HereDocument[];
+  malformed: boolean;
 }> {
-  const declarations: Array<{ delimiter: string; stripTabs: boolean }> = [];
-  let dynamic = false;
+  const declarations: HereDocument[] = [];
+  let malformed = false;
   let quote: "single" | "double" | null = null;
   let atWordBoundary = true;
 
@@ -103,6 +241,11 @@ function hereDocumentsOnLine(line: string): Readonly<{
       continue;
     }
     if (char === "#" && atWordBoundary) break;
+    if (char === "<" && next === "<" && line[index + 2] === "<") {
+      index += 2;
+      atWordBoundary = false;
+      continue;
+    }
     if (char !== "<" || next !== "<") {
       atWordBoundary = /[\s;&|()]/u.test(char);
       continue;
@@ -116,45 +259,76 @@ function hereDocumentsOnLine(line: string): Readonly<{
     }
     while (line[cursor] === " " || line[cursor] === "\t") cursor += 1;
     let delimiter = "";
-    const delimiterQuote = line[cursor];
-    if (delimiterQuote === "'" || delimiterQuote === '"') {
+    let delimiterQuote: "single" | "double" | null = null;
+    let ansiQuoted = false;
+    let quoted = false;
+    while (cursor < line.length) {
+      const delimiterChar = line[cursor] as string;
+      if (delimiterQuote === "single") {
+        if (delimiterChar === "'") {
+          delimiterQuote = null;
+          ansiQuoted = false;
+        } else if (ansiQuoted && delimiterChar === "\\") {
+          // ANSI-C quoting can synthesize arbitrary delimiter bytes. It is
+          // quoted (so its body is inert), but resolving escapes belongs to a
+          // real shell parser; retain a fail-closed malformed declaration.
+          malformed = true;
+          delimiter += delimiterChar;
+        } else delimiter += delimiterChar;
+        cursor += 1;
+        continue;
+      }
+      if (delimiterQuote === "double") {
+        if (delimiterChar === '"') delimiterQuote = null;
+        else if (delimiterChar === "\\" && line[cursor + 1] !== undefined) {
+          delimiter += line[(cursor += 1)] as string;
+        } else delimiter += delimiterChar;
+        cursor += 1;
+        continue;
+      }
+      if (/[\s;&|()<>]/u.test(delimiterChar)) break;
+      if (delimiterChar === "$" && ["'", '"'].includes(line[cursor + 1] ?? "")) {
+        quoted = true;
+        ansiQuoted = line[cursor + 1] === "'";
+        delimiterQuote = ansiQuoted ? "single" : "double";
+        cursor += 2;
+        continue;
+      }
+      if (delimiterChar === "'") {
+        quoted = true;
+        delimiterQuote = "single";
+      } else if (delimiterChar === '"') {
+        quoted = true;
+        delimiterQuote = "double";
+      } else if (delimiterChar === "\\" && line[cursor + 1] !== undefined) {
+        quoted = true;
+        delimiter += line[(cursor += 1)] as string;
+      } else delimiter += delimiterChar;
       cursor += 1;
-      while (cursor < line.length && line[cursor] !== delimiterQuote) {
-        const delimiterChar = line[cursor] as string;
-        if (delimiterQuote === '"' && delimiterChar === "\\" && line[cursor + 1] !== undefined) {
-          delimiter += line[(cursor += 1)] as string;
-        } else {
-          delimiter += delimiterChar;
-        }
-        cursor += 1;
-      }
-      if (line[cursor] !== delimiterQuote) dynamic = true;
-    } else {
-      while (cursor < line.length && !/[\s;&|()<>]/u.test(line[cursor] as string)) {
-        const delimiterChar = line[cursor] as string;
-        if (delimiterChar === "\\" && line[cursor + 1] !== undefined) {
-          delimiter += line[(cursor += 1)] as string;
-        } else {
-          delimiter += delimiterChar;
-        }
-        cursor += 1;
-      }
     }
-    if (delimiter.length > 0 && !dynamic) declarations.push({ delimiter, stripTabs });
-    else dynamic = true;
+    if (delimiterQuote !== null) malformed = true;
+    if (delimiter.length > 0 && delimiterQuote === null) {
+      declarations.push({ delimiter, stripTabs, expandBody: !quoted });
+    } else malformed = true;
     index = Math.max(index + 1, cursor - 1);
     atWordBoundary = false;
   }
-  return { declarations, dynamic };
+  return { declarations, malformed };
 }
 
 function stripStaticHereDocuments(
   source: string,
-): Readonly<{ input: string; uncertainties: readonly string[] }> {
+  depth: number,
+): Readonly<{
+  input: string;
+  uncertainties: readonly string[];
+  effects: readonly BudgetAnalysis[];
+}> {
   const lines = source.split("\n");
   const out: string[] = [];
-  const pending: Array<{ delimiter: string; stripTabs: boolean }> = [];
-  let dynamic = false;
+  const pending: Array<HereDocument & { body: string[] }> = [];
+  const effects: BudgetAnalysis[] = [];
+  let malformed = false;
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] as string;
@@ -162,80 +336,225 @@ function stripStaticHereDocuments(
     if (pending.length > 0) continue;
 
     const found = hereDocumentsOnLine(line);
-    pending.push(...found.declarations);
-    dynamic ||= found.dynamic;
+    pending.push(...found.declarations.map((declaration) => ({ ...declaration, body: [] })));
+    malformed ||= found.malformed;
 
     while (pending.length > 0 && index + 1 < lines.length) {
       const bodyLine = lines[(index += 1)] as string;
-      const current = pending[0] as { delimiter: string; stripTabs: boolean };
+      const current = pending[0] as (typeof pending)[number];
       const candidate = current.stripTabs ? bodyLine.replace(/^\t+/u, "") : bodyLine;
       out.push(candidate === current.delimiter ? bodyLine : "");
-      if (candidate === current.delimiter) pending.shift();
+      if (candidate === current.delimiter) {
+        if (current.expandBody) effects.push(expansionEffects(current.body.join("\n"), depth));
+        pending.shift();
+      } else current.body.push(bodyLine);
     }
   }
   return {
     input: out.join("\n"),
-    uncertainties: dynamic || pending.length > 0 ? ["malformed here-document delimiter"] : [],
+    uncertainties: malformed || pending.length > 0 ? ["malformed here-document delimiter"] : [],
+    effects,
   };
 }
 
-function lexShell(source: string): BudgetAnalysis & Readonly<{ tokens: readonly ShellToken[] }> {
-  const stripped = stripStaticHereDocuments(source);
+function lexShell(
+  source: string,
+  depth: number,
+): BudgetAnalysis & Readonly<{ tokens: readonly ShellToken[] }> {
+  const stripped = stripStaticHereDocuments(source, depth);
   const input = stripped.input;
   const tokens: ShellToken[] = [];
+  const uncertainties: string[] = [...stripped.uncertainties];
   let value = "";
   let dynamic = false;
   let quote: "single" | "double" | null = null;
+  let segments: WordSegment[] = [];
+  let effects: BudgetAnalysis[] = [];
+  let started = false;
 
+  const literal = (text: string) => {
+    started = true;
+    value += text;
+    appendLiteral(segments, text);
+  };
+  const unknown = (raw: string, name: string | null, analysis?: BudgetAnalysis) => {
+    started = true;
+    dynamic = true;
+    value += raw;
+    segments.push({ kind: analysis ? "substitution" : "variable", ...(analysis ? {} : { name }) });
+    if (analysis) effects.push(analysis);
+  };
   const pushWord = () => {
-    if (value.length === 0) return;
-    tokens.push({ kind: "word", value, dynamic });
+    if (!started) return;
+    tokens.push({ kind: "word", value, dynamic, segments, effects });
     value = "";
     dynamic = false;
+    segments = [];
+    effects = [];
+    started = false;
+  };
+  const commandSubstitution = (inputIndex: number): number => {
+    const extracted = readParenthesized(input, inputIndex + 1);
+    if (!extracted) {
+      unknown(input.slice(inputIndex), null);
+      uncertainties.push("malformed command substitution");
+      return input.length - 1;
+    }
+    unknown(
+      input.slice(inputIndex, extracted.end + 1),
+      null,
+      analyzeShellTimeoutBudgetInternal(extracted.content, depth + 1),
+    );
+    return extracted.end;
+  };
+  const backtickSubstitution = (inputIndex: number): number => {
+    const extracted = readBacktick(input, inputIndex);
+    if (!extracted) {
+      unknown(input.slice(inputIndex), null);
+      uncertainties.push("malformed backtick command substitution");
+      return input.length - 1;
+    }
+    unknown(
+      input.slice(inputIndex, extracted.end + 1),
+      null,
+      analyzeShellTimeoutBudgetInternal(extracted.content, depth + 1),
+    );
+    return extracted.end;
+  };
+  const dollarExpansion = (inputIndex: number): number => {
+    const next = input[inputIndex + 1];
+    if (next === "(" && input[inputIndex + 2] !== "(") {
+      return commandSubstitution(inputIndex);
+    }
+    if (next === "(") {
+      const extracted = readParenthesized(input, inputIndex + 1);
+      if (!extracted) {
+        unknown(input.slice(inputIndex), null);
+        uncertainties.push("malformed arithmetic expansion");
+        return input.length - 1;
+      }
+      const raw = input.slice(inputIndex, extracted.end + 1);
+      unknown(raw, null);
+      effects.push(expansionEffects(extracted.content, depth + 1));
+      return extracted.end;
+    }
+    if (next === "{" && input[inputIndex + 2] === "{") {
+      const end = input.indexOf("}}", inputIndex + 3);
+      const final = end < 0 ? input.length - 1 : end + 1;
+      unknown(input.slice(inputIndex, final + 1), null);
+      if (end < 0) uncertainties.push("malformed Actions expression");
+      return final;
+    }
+    if (next === "{") {
+      const end = input.indexOf("}", inputIndex + 2);
+      const final = end < 0 ? input.length - 1 : end;
+      const body = input.slice(inputIndex + 2, end < 0 ? input.length : end);
+      unknown(
+        input.slice(inputIndex, final + 1),
+        /^[A-Za-z_][A-Za-z0-9_]*$/u.test(body) ? body : null,
+      );
+      effects.push(expansionEffects(body, depth + 1));
+      if (end < 0) uncertainties.push("malformed parameter expansion");
+      return final;
+    }
+    if (next && /[A-Za-z_]/u.test(next)) {
+      let end = inputIndex + 2;
+      while (end < input.length && /[A-Za-z0-9_]/u.test(input[end] as string)) end += 1;
+      const name = input.slice(inputIndex + 1, end);
+      unknown(input.slice(inputIndex, end), name);
+      return end - 1;
+    }
+    if (next && /[0-9@*#?$!_-]/u.test(next)) {
+      unknown(input.slice(inputIndex, inputIndex + 2), null);
+      return inputIndex + 1;
+    }
+    literal("$");
+    return inputIndex;
   };
 
   for (let index = 0; index < input.length; index += 1) {
     const char = input[index] as string;
     const next = input[index + 1];
-
     if (quote === "single") {
       if (char === "'") quote = null;
-      else {
-        if (char === "$" && next === "{" && input[index + 2] === "{") dynamic = true;
-        value += char;
-      }
+      else if (char === "$" && next === "{" && input[index + 2] === "{") {
+        index = dollarExpansion(index);
+      } else literal(char);
       continue;
     }
-
     if (quote === "double") {
-      if (char === '"') {
-        quote = null;
-      } else if (char === "\\" && next !== undefined) {
+      if (char === '"') quote = null;
+      else if (char === "\\" && next !== undefined && '"\\$`\n'.includes(next)) {
         if (next === "\n") index += 1;
-        else if ('"\\$`'.includes(next)) value += input[(index += 1)] as string;
-        else value += char;
-      } else {
-        if (char === "$" || char === "`") dynamic = true;
-        value += char;
-      }
+        else literal(input[(index += 1)] as string);
+      } else if (char === "$") index = dollarExpansion(index);
+      else if (char === "`") index = backtickSubstitution(index);
+      else literal(char);
       continue;
     }
-
     if (char === "\\") {
       if (next === "\n") index += 1;
-      else if (next !== undefined) value += input[(index += 1)] as string;
-      else value += char;
+      else if (next !== undefined) literal(input[(index += 1)] as string);
+      else literal(char);
       continue;
     }
     if (char === "'") {
       quote = "single";
+      started = true;
       continue;
     }
     if (char === '"') {
       quote = "double";
+      started = true;
       continue;
     }
-    if (char === "#" && value.length === 0) {
+    if (char === "$" && next === "'") {
+      started = true;
+      let cursor = index + 2;
+      let ansi = "";
+      let escaped = false;
+      while (cursor < input.length && input[cursor] !== "'") {
+        if (input[cursor] === "\\") escaped = true;
+        ansi += input[cursor] as string;
+        cursor += 1;
+      }
+      if (cursor >= input.length) uncertainties.push("unterminated ANSI-C shell quote");
+      if (escaped) unknown(input.slice(index, Math.min(cursor + 1, input.length)), null);
+      else literal(ansi);
+      index = Math.min(cursor, input.length - 1);
+      continue;
+    }
+    if (char === "$" && next === '"') {
+      quote = "double";
+      started = true;
+      index += 1;
+      continue;
+    }
+    if (char === "$") {
+      index = dollarExpansion(index);
+      continue;
+    }
+    if (char === "`") {
+      index = backtickSubstitution(index);
+      continue;
+    }
+    if ((char === "<" || char === ">") && next === "(") {
+      const extracted = readParenthesized(input, index + 1);
+      if (!extracted) {
+        unknown(input.slice(index), null);
+        uncertainties.push("malformed process substitution");
+        index = input.length - 1;
+      } else {
+        unknown(
+          input.slice(index, extracted.end + 1),
+          null,
+          analyzeShellTimeoutBudgetInternal(extracted.content, depth + 1),
+        );
+        index = extracted.end;
+      }
+      continue;
+    }
+    if (char === "#" && !started) {
       while (index + 1 < input.length && input[index + 1] !== "\n") index += 1;
       continue;
     }
@@ -248,8 +567,6 @@ function lexShell(source: string): BudgetAnalysis & Readonly<{ tokens: readonly 
       pushWord();
       continue;
     }
-    if (char === "$" || char === "`") dynamic = true;
-
     const pair = `${char}${next ?? ""}`;
     if (["&&", "||", ";;", "|&"].includes(pair)) {
       pushWord();
@@ -262,23 +579,24 @@ function lexShell(source: string): BudgetAnalysis & Readonly<{ tokens: readonly 
       tokens.push({ kind: "operator", value: char });
       continue;
     }
-    value += char;
+    literal(char);
   }
   pushWord();
 
-  const uncertainties: string[] = [...stripped.uncertainties];
-  if (quote !== null && looksLikeBudget(input)) {
-    uncertainties.push("unterminated shell quote around a timeout declaration");
-  }
-  return { minutes: 0, uncertainties, tokens };
+  if (quote !== null) uncertainties.push("unterminated shell quote");
+  const hereDocumentEffects = sum(stripped.effects);
+  return {
+    minutes: hereDocumentEffects.minutes,
+    uncertainties: [...uncertainties, ...hereDocumentEffects.uncertainties],
+    tokens,
+  };
 }
 
-function parseDuration(token: WordToken | undefined, context: string): BudgetAnalysis {
-  if (!token) return uncertain(`${context} has no duration`);
-  if (token.dynamic) return uncertain(`${context} uses a dynamic duration`);
-  const match = /^(\d+(?:\.\d+)?)([smhd]?)$/u.exec(token.value);
-  if (!match)
-    return uncertain(`${context} has an unsupported duration ${JSON.stringify(token.value)}`);
+function parseDuration(value: string | null | undefined, context: string): BudgetAnalysis {
+  if (value === undefined) return uncertain(`${context} has no duration`);
+  if (value === null) return uncertain(`${context} uses a dynamic duration`);
+  const match = /^(\d+(?:\.\d+)?)([smhd]?)$/u.exec(value);
+  if (!match) return uncertain(`${context} has an unsupported duration ${JSON.stringify(value)}`);
   const amount = Number(match[1]);
   if (!Number.isFinite(amount) || amount <= 0) {
     return uncertain(`${context} has a non-positive duration`);
@@ -289,72 +607,77 @@ function parseDuration(token: WordToken | undefined, context: string): BudgetAna
   return { minutes: amount * multiplier, uncertainties: [] };
 }
 
-function timeoutCommandBudget(words: readonly WordToken[], commandIndex: number): BudgetAnalysis {
+function timeoutCommandBudget(
+  words: readonly WordToken[],
+  commandIndex: number,
+  variables: ReadonlyMap<string, string | null>,
+): BudgetAnalysis {
   let index = commandIndex + 1;
   let killGrace = ZERO;
 
   while (index < words.length) {
-    const option = words[index] as WordToken;
-    if (option.dynamic && option.value.startsWith("-")) {
+    const option = resolveWord(words[index], variables);
+    if (option === null) {
       return uncertain("coreutils timeout uses dynamic options");
     }
-    if (option.value === "--") {
+    if (option === "--") {
       index += 1;
       break;
     }
-    if (!option.value.startsWith("-")) break;
-    if (["--preserve-status", "--foreground", "--verbose", "-v"].includes(option.value)) {
+    if (!option.startsWith("-")) break;
+    if (["--preserve-status", "--foreground", "--verbose", "-v"].includes(option)) {
       index += 1;
       continue;
     }
-    if (option.value === "--kill-after" || option.value === "-k") {
-      killGrace = parseDuration(words[index + 1], "timeout kill grace");
+    if (option === "--kill-after" || option === "-k") {
+      killGrace = parseDuration(resolveWord(words[index + 1], variables), "timeout kill grace");
       index += 2;
       continue;
     }
-    const killEquals = /^(?:--kill-after=|-k)(.+)$/u.exec(option.value);
+    const killEquals = /^(?:--kill-after=|-k)(.+)$/u.exec(option);
     if (killEquals) {
-      killGrace = parseDuration(
-        { kind: "word", value: killEquals[1] as string, dynamic: option.dynamic },
-        "timeout kill grace",
-      );
+      killGrace = parseDuration(killEquals[1], "timeout kill grace");
       index += 1;
       continue;
     }
-    if (option.value === "--signal" || option.value === "-s") {
-      if (!words[index + 1] || (words[index + 1] as WordToken).dynamic) {
+    if (option === "--signal" || option === "-s") {
+      if (resolveWord(words[index + 1], variables) === null) {
         return uncertain("coreutils timeout uses a dynamic or missing signal option");
       }
       index += 2;
       continue;
     }
-    if (/^(?:--signal=|-s).+/u.test(option.value)) {
+    if (/^(?:--signal=|-s).+/u.test(option)) {
       index += 1;
       continue;
     }
-    if (option.value === "--help" || option.value === "--version") return ZERO;
-    return uncertain(`coreutils timeout uses unsupported option ${JSON.stringify(option.value)}`);
+    if (option === "--help" || option === "--version") return ZERO;
+    return uncertain(`coreutils timeout uses unsupported option ${JSON.stringify(option)}`);
   }
 
-  return sum([parseDuration(words[index], "coreutils timeout"), killGrace]);
+  return sum([parseDuration(resolveWord(words[index], variables), "coreutils timeout"), killGrace]);
 }
 
 function readFlagDuration(
   words: readonly WordToken[],
   index: number,
   flag: "--timeout-seconds" | "--timeout",
+  variables: ReadonlyMap<string, string | null>,
 ): Readonly<{ analysis: BudgetAnalysis; consumed: number }> | null {
-  const token = words[index] as WordToken;
-  if (token.value === flag) {
-    const duration = words[index + 1];
+  const token = resolveWord(words[index], variables);
+  if (token === null) {
+    const literal = words[index]?.segments.find((segment) => segment.kind === "literal");
+    return literal?.kind === "literal" && literal.value.startsWith(flag)
+      ? { analysis: uncertain(`${flag} uses a dynamic option or value`), consumed: 1 }
+      : null;
+  }
+  if (token === flag) {
+    const duration = resolveWord(words[index + 1], variables);
     if (!duration) return { analysis: uncertain(`${flag} has no value`), consumed: 1 };
-    if (duration.dynamic) {
-      return { analysis: uncertain(`${flag} uses a dynamic value`), consumed: 2 };
-    }
-    if (!/^\d+(?:\.\d+)?$/u.test(duration.value)) {
+    if (!/^\d+(?:\.\d+)?$/u.test(duration)) {
       return { analysis: uncertain(`${flag} has an invalid value`), consumed: 2 };
     }
-    const amount = Number(duration.value);
+    const amount = Number(duration);
     if (!Number.isFinite(amount) || amount <= 0) {
       return { analysis: uncertain(`${flag} has an invalid value`), consumed: 2 };
     }
@@ -364,10 +687,10 @@ function readFlagDuration(
     };
   }
   const prefix = `${flag}=`;
-  if (!token.value.startsWith(prefix)) return null;
-  const raw = token.value.slice(prefix.length);
+  if (!token.startsWith(prefix)) return null;
+  const raw = token.slice(prefix.length);
   const amount = Number(raw);
-  if (token.dynamic || !/^\d+(?:\.\d+)?$/u.test(raw) || !Number.isFinite(amount) || amount <= 0) {
+  if (!/^\d+(?:\.\d+)?$/u.test(raw) || !Number.isFinite(amount) || amount <= 0) {
     return { analysis: uncertain(`${flag} uses a dynamic or invalid value`), consumed: 1 };
   }
   return {
@@ -376,20 +699,45 @@ function readFlagDuration(
   };
 }
 
-function commandName(word: WordToken): string {
-  const pieces = word.value.split("/");
+function commandName(word: string): string {
+  const pieces = word.split("/");
   return pieces[pieces.length - 1] as string;
 }
 
-function isAssignment(word: WordToken): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*=/u.test(word.value);
+function assignment(
+  word: WordToken,
+  variables: ReadonlyMap<string, string | null>,
+): Readonly<{ name: string; value: string | null }> | null {
+  let name = "";
+  let foundEquals = false;
+  const valueSegments: WordSegment[] = [];
+  for (const segment of word.segments) {
+    if (!foundEquals) {
+      if (segment.kind !== "literal") return null;
+      const equals = segment.value.indexOf("=");
+      if (equals < 0) {
+        name += segment.value;
+        continue;
+      }
+      name += segment.value.slice(0, equals);
+      appendLiteral(valueSegments, segment.value.slice(equals + 1));
+      foundEquals = true;
+    } else valueSegments.push(segment);
+  }
+  if (!foundEquals || !/^[A-Za-z_][A-Za-z0-9_]*$/u.test(name)) return null;
+  return { name, value: resolveSegments(valueSegments, variables) };
 }
 
-function unwrapCommand(words: readonly WordToken[]): number {
+function unwrapCommand(
+  words: readonly WordToken[],
+  variables: ReadonlyMap<string, string | null>,
+): number {
   let index = 0;
-  while (index < words.length && isAssignment(words[index] as WordToken)) index += 1;
+  while (index < words.length && assignment(words[index] as WordToken, variables)) index += 1;
   while (index < words.length) {
-    const name = commandName(words[index] as WordToken);
+    const resolved = resolveWord(words[index], variables);
+    if (resolved === null) break;
+    const name = commandName(resolved);
     if (["!", "builtin", "command", "exec", "time"].includes(name)) {
       index += 1;
       continue;
@@ -398,8 +746,8 @@ function unwrapCommand(words: readonly WordToken[]): number {
       index += 1;
       while (
         index < words.length &&
-        ((words[index] as WordToken).value.startsWith("-") ||
-          isAssignment(words[index] as WordToken))
+        ((resolveWord(words[index], variables) ?? "").startsWith("-") ||
+          assignment(words[index] as WordToken, variables))
       ) {
         index += 1;
       }
@@ -407,8 +755,8 @@ function unwrapCommand(words: readonly WordToken[]): number {
     }
     if (name === "sudo") {
       index += 1;
-      while (index < words.length && (words[index] as WordToken).value.startsWith("-")) {
-        const option = (words[index] as WordToken).value;
+      while (index < words.length && (resolveWord(words[index], variables) ?? "").startsWith("-")) {
+        const option = resolveWord(words[index], variables) as string;
         index += 1;
         if (["-u", "--user", "-g", "--group", "-h", "--host"].includes(option)) index += 1;
       }
@@ -419,91 +767,188 @@ function unwrapCommand(words: readonly WordToken[]): number {
   return index;
 }
 
-function analyzeCommand(words: readonly WordToken[]): BudgetAnalysis {
-  const commandIndex = unwrapCommand(words);
+function withoutEffects(words: readonly WordToken[]): readonly WordToken[] {
+  return words.map((word) => ({ ...word, effects: [] }));
+}
+
+function analyzeCommand(
+  words: readonly WordToken[],
+  variables: Map<string, string | null>,
+  depth: number,
+): BudgetAnalysis {
+  const effects = sum(words.flatMap((word) => word.effects));
+  let assignmentCount = 0;
+  const assignments: Array<{ name: string; value: string | null }> = [];
+  while (assignmentCount < words.length) {
+    const parsed = assignment(words[assignmentCount] as WordToken, variables);
+    if (!parsed) break;
+    assignments.push(parsed);
+    assignmentCount += 1;
+  }
+  if (assignmentCount === words.length) {
+    for (const parsed of assignments) variables.set(parsed.name, parsed.value);
+    return effects;
+  }
+
+  const commandIndex = unwrapCommand(words, variables);
   const command = words[commandIndex];
   if (!command) return ZERO;
-  if (command.dynamic) {
-    return words.some((word) => looksLikeBudget(word.value))
-      ? uncertain("dynamic command contains a timeout declaration")
-      : ZERO;
+  const resolvedCommand = resolveWord(command, variables);
+  if (resolvedCommand === null) {
+    return sum([effects, uncertain("dynamic command position is not statically analyzable")]);
   }
-  const name = commandName(command);
-  if (PROSE_COMMANDS.has(name)) return ZERO;
-  if (name === "timeout") return timeoutCommandBudget(words, commandIndex);
+  const name = commandName(resolvedCommand);
+  if (["export", "readonly", "declare", "typeset", "local"].includes(name)) {
+    for (const word of words.slice(commandIndex + 1)) {
+      const parsed = assignment(word, variables);
+      if (parsed) variables.set(parsed.name, parsed.value);
+    }
+    return effects;
+  }
+  if (name === "unset") {
+    for (const word of words.slice(commandIndex + 1)) {
+      const variable = resolveWord(word, variables);
+      if (variable === null) variables.clear();
+      else if (/^[A-Za-z_][A-Za-z0-9_]*$/u.test(variable)) variables.delete(variable);
+    }
+    return effects;
+  }
+  if (name === "read") {
+    for (const word of words.slice(commandIndex + 1)) {
+      const variable = resolveWord(word, variables);
+      if (variable === null) variables.clear();
+      else if (/^[A-Za-z_][A-Za-z0-9_]*$/u.test(variable)) variables.set(variable, null);
+    }
+    return effects;
+  }
+  if (name === "source" || name === ".") {
+    variables.clear();
+    return sum([effects, uncertain(`${name} evaluates a script that is not statically available`)]);
+  }
+  if (PROSE_COMMANDS.has(name)) return effects;
+  if (TIMEOUT_COMMANDS.has(name)) {
+    return sum([effects, timeoutCommandBudget(words, commandIndex, variables)]);
+  }
 
   if (SHELL_COMMANDS.has(name)) {
     const commandFlag = words.findIndex(
-      (word, index) => index > commandIndex && /^-[A-Za-z]*c[A-Za-z]*$/u.test(word.value),
+      (word, index) =>
+        index > commandIndex && /^-[A-Za-z]*c[A-Za-z]*$/u.test(resolveWord(word, variables) ?? ""),
     );
     if (commandFlag >= 0) {
       const script = words[commandFlag + 1];
-      if (!script || script.dynamic) return uncertain(`${name} -c uses a dynamic script`);
-      return analyzeShellTimeoutBudget(script.value);
+      const resolvedScript = resolveWord(script, variables);
+      if (resolvedScript === null)
+        return sum([effects, uncertain(`${name} -c uses a dynamic script`)]);
+      return sum([effects, analyzeShellTimeoutBudgetInternal(resolvedScript, depth + 1)]);
     }
+    for (let index = commandIndex + 1; index < words.length; index += 1) {
+      const argument = resolveWord(words[index], variables);
+      if (argument === null) {
+        return sum([effects, uncertain(`${name} uses dynamic evaluator arguments`)]);
+      }
+      if (argument === "<<<") {
+        const script = resolveWord(words[index + 1], variables);
+        return script === null
+          ? sum([effects, uncertain(`${name} uses a dynamic here-string script`)])
+          : sum([effects, analyzeShellTimeoutBudgetInternal(script, depth + 1)]);
+      }
+      if (argument.startsWith("<<<")) {
+        return sum([effects, analyzeShellTimeoutBudgetInternal(argument.slice(3), depth + 1)]);
+      }
+      if (argument.startsWith("<<")) {
+        return sum([effects, uncertain(`${name} evaluates a here-document body`)]);
+      }
+    }
+  }
+
+  if (name === "eval") {
+    const evaluated = words.slice(commandIndex + 1).map((word) => resolveWord(word, variables));
+    if (evaluated.some((word) => word === null)) {
+      return sum([effects, uncertain("eval uses a dynamic script")]);
+    }
+    return sum([
+      effects,
+      analyzeShellTimeoutBudgetInternal((evaluated as string[]).join(" "), depth + 1),
+    ]);
   }
 
   if (name === "retry") {
     let attempts: number | null = null;
     let ambiguousRetries = false;
     let nestedStart = commandIndex + 1;
-    const first = words[nestedStart];
-    if (first && /^\d+$/u.test(first.value) && !first.dynamic) {
-      attempts = Number(first.value);
+    const first = resolveWord(words[nestedStart], variables);
+    if (first && /^\d+$/u.test(first)) {
+      attempts = Number(first);
       nestedStart += 1;
     } else {
       for (let index = nestedStart; index < words.length; index += 1) {
-        const word = words[index] as WordToken;
-        if (["--attempts", "-n"].includes(word.value)) {
-          const value = words[index + 1];
-          if (value && /^\d+$/u.test(value.value) && !value.dynamic) {
-            attempts = Number(value.value);
+        const word = resolveWord(words[index], variables);
+        if (word && ["--attempts", "-n"].includes(word)) {
+          const value = resolveWord(words[index + 1], variables);
+          if (value && /^\d+$/u.test(value)) {
+            attempts = Number(value);
             nestedStart = index + 2;
           }
           break;
         }
-        const equalsAttempts = /^(?:--attempts=|-n)(\d+)$/u.exec(word.value);
-        if (equalsAttempts && !word.dynamic) {
+        const equalsAttempts = word ? /^(?:--attempts=|-n)(\d+)$/u.exec(word) : null;
+        if (equalsAttempts) {
           attempts = Number(equalsAttempts[1]);
           nestedStart = index + 1;
           break;
         }
-        if (word.value === "--retries") {
+        if (word === "--retries") {
           ambiguousRetries = true;
           nestedStart = index + 2;
           break;
         }
-        if (/^--retries=\d+$/u.test(word.value)) {
+        if (word && /^--retries=\d+$/u.test(word)) {
           ambiguousRetries = true;
           nestedStart = index + 1;
           break;
         }
       }
     }
-    const nested = analyzeCommand(words.slice(nestedStart));
+    const nested = analyzeCommand(
+      withoutEffects(words.slice(nestedStart)),
+      new Map(variables),
+      depth,
+    );
     if (ambiguousRetries && (nested.minutes > 0 || nested.uncertainties.length > 0)) {
-      return uncertain(
-        "retry --retries does not declare whether the value includes the first attempt",
-        nested.minutes,
-      );
+      return sum([
+        effects,
+        uncertain(
+          "retry --retries does not declare whether the value includes the first attempt",
+          nested.minutes,
+        ),
+      ]);
     }
     if (attempts === null || attempts <= 0) {
       return nested.minutes > 0 || nested.uncertainties.length > 0
-        ? uncertain("retry wrapper has an unknown attempt count", nested.minutes)
-        : ZERO;
+        ? sum([effects, uncertain("retry wrapper has an unknown attempt count", nested.minutes)])
+        : effects;
     }
-    return scaled(nested, attempts);
+    return sum([effects, scaled(nested, attempts)]);
   }
 
-  const analyses: BudgetAnalysis[] = [];
+  const analyses: BudgetAnalysis[] = [effects];
   for (let index = commandIndex + 1; index < words.length;) {
-    const seconds = readFlagDuration(words, index, "--timeout-seconds");
+    const resolvedArgument = resolveWord(words[index], variables);
+    if (
+      resolvedArgument === null &&
+      name === "bun" &&
+      /^\d{5,}(?:\.\d+)?$/u.test(resolveWord(words[index + 1], variables) ?? "")
+    ) {
+      analyses.push(uncertain("bun uses a dynamic argument that may supply a timeout option"));
+    }
+    const seconds = readFlagDuration(words, index, "--timeout-seconds", variables);
     if (seconds) {
       analyses.push(seconds.analysis);
       index += seconds.consumed;
       continue;
     }
-    const milliseconds = readFlagDuration(words, index, "--timeout");
+    const milliseconds = readFlagDuration(words, index, "--timeout", variables);
     if (milliseconds) {
       if (name !== "bun") {
         analyses.push(uncertain(`--timeout units are unknown for command ${JSON.stringify(name)}`));
@@ -513,7 +958,7 @@ function analyzeCommand(words: readonly WordToken[]): BudgetAnalysis {
       index += milliseconds.consumed;
       continue;
     }
-    if ((words[index] as WordToken).value === "timeout") {
+    if (TIMEOUT_COMMANDS.has(resolveWord(words[index], variables) ?? "")) {
       analyses.push(
         uncertain(`timeout is nested behind unsupported wrapper ${JSON.stringify(name)}`),
       );
@@ -553,7 +998,11 @@ function unsupportedControlFlow(tokens: readonly ShellToken[]): string | null {
 class ShellBudgetParser {
   private index = 0;
 
-  constructor(private readonly tokens: readonly ShellToken[]) {}
+  constructor(
+    private readonly tokens: readonly ShellToken[],
+    private readonly variables = new Map<string, string | null>(),
+    private readonly depth = 0,
+  ) {}
 
   parse(
     stopWords: ReadonlySet<string> = new Set(),
@@ -568,7 +1017,6 @@ class ShellBudgetParser {
       if (token.kind === "operator" && stopOperators.has(token.value)) break;
       if (token.kind === "operator" && token.value === ")") {
         this.index += 1;
-        statements.push(uncertain("unmatched closing parenthesis in timeout-bearing shell"));
         continue;
       }
       if (token.kind === "word" && token.value === "for") statements.push(this.parseFor());
@@ -590,11 +1038,32 @@ class ShellBudgetParser {
     }
   }
 
+  private restoreVariables(snapshot: ReadonlyMap<string, string | null>): void {
+    this.variables.clear();
+    for (const [name, value] of snapshot) this.variables.set(name, value);
+  }
+
+  private mergeBranchVariables(
+    entry: ReadonlyMap<string, string | null>,
+    branches: readonly ReadonlyMap<string, string | null>[],
+  ): void {
+    const names = new Set([...entry.keys(), ...branches.flatMap((branch) => [...branch.keys()])]);
+    this.variables.clear();
+    for (const name of names) {
+      const values = branches.map((branch) => (branch.has(name) ? branch.get(name) : undefined));
+      const first = values[0];
+      if (values.every((value) => value === first)) {
+        if (first !== undefined) this.variables.set(name, first ?? null);
+      } else this.variables.set(name, null);
+    }
+  }
+
   private parsePipeline(stopWords: ReadonlySet<string>): BudgetAnalysis {
     const commands: BudgetAnalysis[] = [];
+    const commandWords: WordToken[][] = [];
     let words: WordToken[] = [];
     const flush = () => {
-      if (words.length > 0) commands.push(analyzeCommand(words));
+      if (words.length > 0) commandWords.push(words);
       words = [];
     };
 
@@ -613,13 +1082,22 @@ class ShellBudgetParser {
       this.index += 1;
     }
     flush();
+    if (commandWords.length === 1) {
+      commands.push(analyzeCommand(commandWords[0] as WordToken[], this.variables, this.depth));
+    } else {
+      for (const pipelineCommand of commandWords) {
+        commands.push(analyzeCommand(pipelineCommand, new Map(this.variables), this.depth));
+      }
+    }
     return maximum(commands);
   }
 
   private parseFor(): BudgetAnalysis {
+    const entryVariables = new Map(this.variables);
     this.index += 1;
     const variable = this.tokens[this.index];
     if (!variable || variable.kind !== "word") return uncertain("for loop has no variable");
+    const variableName = resolveWord(variable, this.variables);
     this.index += 1;
     const iterations: WordToken[] = [];
     const maybeIn = this.tokens[this.index];
@@ -641,31 +1119,56 @@ class ShellBudgetParser {
       return uncertain("for loop has unsupported header syntax");
     }
     this.index += 1;
+    // The loop variable changes before every body execution. Parsing the body
+    // against a pre-loop value can therefore resolve a dynamic command to the
+    // wrong executable and miss its timeout entirely.
+    if (variableName && /^[A-Za-z_][A-Za-z0-9_]*$/u.test(variableName)) {
+      this.variables.set(variableName, null);
+    } else {
+      this.variables.clear();
+    }
     const body = this.parse(new Set(["done"]));
+    const bodyVariables = new Map(this.variables);
     if (this.tokens[this.index]?.kind === "word") this.index += 1;
 
+    const iterationEffects = sum(iterations.flatMap((iteration) => iteration.effects));
+    const resolvedIterations = iterations.map((iteration) =>
+      resolveWord(iteration, entryVariables),
+    );
+    // Even a statically resolved unquoted expansion can undergo shell word
+    // splitting or pathname expansion. Without quote provenance, only literal
+    // iteration words have a statically knowable count.
     if (iterations.some((iteration) => iteration.dynamic)) {
+      this.mergeBranchVariables(entryVariables, [entryVariables, bodyVariables]);
       return body.minutes > 0 || body.uncertainties.length > 0
-        ? uncertain("for loop has a dynamic iteration count", body.minutes)
-        : ZERO;
+        ? sum([iterationEffects, body, uncertain("for loop has a dynamic iteration count")])
+        : iterationEffects;
     }
     if (
-      iterations.some(
+      resolvedIterations.some(
         (iteration) =>
-          /[*?[\]{}]/u.test(iteration.value) && !/^\{(-?\d+)\.\.(-?\d+)\}$/u.test(iteration.value),
+          iteration !== null &&
+          /[*?[\]{}]/u.test(iteration) &&
+          !/^\{(-?\d+)\.\.(-?\d+)\}$/u.test(iteration),
       )
     ) {
+      this.mergeBranchVariables(entryVariables, [entryVariables, bodyVariables]);
       return body.minutes > 0 || body.uncertainties.length > 0
-        ? uncertain("for loop has a non-static expansion in its iteration list", body.minutes)
-        : ZERO;
+        ? sum([
+            iterationEffects,
+            body,
+            uncertain("for loop has a non-static expansion in its iteration list"),
+          ])
+        : iterationEffects;
     }
     let count = 0;
-    for (const iteration of iterations) {
-      const range = /^\{(-?\d+)\.\.(-?\d+)\}$/u.exec(iteration.value);
+    for (const iteration of resolvedIterations as string[]) {
+      const range = /^\{(-?\d+)\.\.(-?\d+)\}$/u.exec(iteration);
       if (range) count += Math.abs(Number(range[2]) - Number(range[1])) + 1;
       else count += 1;
     }
-    return scaled(body, count);
+    if (count === 0) this.restoreVariables(entryVariables);
+    return sum([iterationEffects, scaled(body, count)]);
   }
 
   private parseUnboundedLoop(): BudgetAnalysis {
@@ -677,9 +1180,19 @@ class ShellBudgetParser {
       if (token.kind === "word" && token.value === "do") break;
       this.index += 1;
     }
-    const condition = new ShellBudgetParser(this.tokens.slice(conditionStart, this.index)).parse();
+    const conditionVariables = new Map(this.variables);
+    const condition = new ShellBudgetParser(
+      this.tokens.slice(conditionStart, this.index),
+      conditionVariables,
+      this.depth,
+    ).parse();
+    // A while/until condition always executes at least once, and its ordinary
+    // shell assignments remain visible both to the body and after the loop.
+    this.restoreVariables(conditionVariables);
     if (this.tokens[this.index]?.kind === "word") this.index += 1;
     const body = this.parse(new Set(["done"]));
+    const bodyVariables = new Map(this.variables);
+    this.mergeBranchVariables(conditionVariables, [conditionVariables, bodyVariables]);
     if (this.tokens[this.index]?.kind === "word") this.index += 1;
     const oneIteration = sum([condition, body]);
     return oneIteration.minutes > 0 || oneIteration.uncertainties.length > 0
@@ -691,6 +1204,10 @@ class ShellBudgetParser {
   }
 
   private parseIf(): BudgetAnalysis {
+    const entryVariables = new Map(this.variables);
+    const branchVariables: Array<ReadonlyMap<string, string | null>> = [];
+    let hasElse = false;
+    let fallthroughVariables = new Map(entryVariables);
     this.index += 1;
     const conditionStart = this.index;
     while (this.index < this.tokens.length) {
@@ -698,39 +1215,63 @@ class ShellBudgetParser {
       if (token.kind === "word" && token.value === "then") break;
       this.index += 1;
     }
+    const firstConditionVariables = new Map(entryVariables);
     const conditions: BudgetAnalysis[] = [
-      new ShellBudgetParser(this.tokens.slice(conditionStart, this.index)).parse(),
+      new ShellBudgetParser(
+        this.tokens.slice(conditionStart, this.index),
+        firstConditionVariables,
+        this.depth,
+      ).parse(),
     ];
+    fallthroughVariables = firstConditionVariables;
+    this.restoreVariables(firstConditionVariables);
     if (this.tokens[this.index]?.kind === "word") this.index += 1;
     const branches: BudgetAnalysis[] = [this.parse(new Set(["elif", "else", "fi"]))];
+    branchVariables.push(new Map(this.variables));
 
     while (this.tokens[this.index]?.kind === "word") {
       const marker = (this.tokens[this.index] as WordToken).value;
       this.index += 1;
       if (marker === "fi") break;
       if (marker === "else") {
+        hasElse = true;
+        this.restoreVariables(fallthroughVariables);
         branches.push(this.parse(new Set(["fi"])));
+        branchVariables.push(new Map(this.variables));
         if (this.tokens[this.index]?.kind === "word") this.index += 1;
         break;
       }
+      this.restoreVariables(fallthroughVariables);
       const elifConditionStart = this.index;
       while (this.index < this.tokens.length) {
         const token = this.tokens[this.index] as ShellToken;
         if (token.kind === "word" && token.value === "then") break;
         this.index += 1;
       }
+      const elifConditionVariables = new Map(fallthroughVariables);
       conditions.push(
-        new ShellBudgetParser(this.tokens.slice(elifConditionStart, this.index)).parse(),
+        new ShellBudgetParser(
+          this.tokens.slice(elifConditionStart, this.index),
+          elifConditionVariables,
+          this.depth,
+        ).parse(),
       );
+      fallthroughVariables = elifConditionVariables;
+      this.restoreVariables(elifConditionVariables);
       if (this.tokens[this.index]?.kind === "word") this.index += 1;
       branches.push(this.parse(new Set(["elif", "else", "fi"])));
+      branchVariables.push(new Map(this.variables));
     }
+    if (!hasElse) branchVariables.push(fallthroughVariables);
+    this.mergeBranchVariables(entryVariables, branchVariables);
     return sum([...conditions, maximum(branches)]);
   }
 
   private parseSubshell(): BudgetAnalysis {
     this.index += 1;
+    const outerVariables = new Map(this.variables);
     const body = this.parse(new Set(), new Set([")"]));
+    this.restoreVariables(outerVariables);
     if (this.tokens[this.index]?.kind === "operator" && this.tokens[this.index]?.value === ")") {
       this.index += 1;
     }
@@ -738,15 +1279,19 @@ class ShellBudgetParser {
   }
 }
 
-export function analyzeShellTimeoutBudget(source: string): BudgetAnalysis {
-  if (!looksLikeBudget(source) && !looksLikeShellEvaluation(source)) return ZERO;
-  const lexed = lexShell(source);
+function analyzeShellTimeoutBudgetInternal(source: string, depth: number): BudgetAnalysis {
+  if (depth > MAX_ANALYSIS_DEPTH) return uncertain("shell analysis nesting is too deep");
+  const lexed = lexShell(source, depth);
+  const parsed = new ShellBudgetParser(lexed.tokens, new Map(), depth).parse();
   const unsupported = unsupportedControlFlow(lexed.tokens);
-  if (unsupported) {
-    return sum([uncertain(unsupported), { minutes: 0, uncertainties: lexed.uncertainties }]);
+  if (unsupported && (parsed.minutes > 0 || parsed.uncertainties.length > 0)) {
+    return sum([parsed, lexed, uncertain(unsupported)]);
   }
-  const parsed = new ShellBudgetParser(lexed.tokens).parse();
-  return sum([parsed, { minutes: 0, uncertainties: lexed.uncertainties }]);
+  return sum([parsed, lexed]);
+}
+
+export function analyzeShellTimeoutBudget(source: string): BudgetAnalysis {
+  return analyzeShellTimeoutBudgetInternal(source, 0);
 }
 
 export function analyzeStepTimeoutBudget(step: TimeoutStep): BudgetAnalysis {
@@ -761,8 +1306,15 @@ export function analyzeStepTimeoutBudget(step: TimeoutStep): BudgetAnalysis {
   }
   const run = String(step.run ?? "");
   if (step.shell && !/(?:^|\/)(?:ba|da|z)?sh(?:\s|$)/u.test(step.shell)) {
-    return looksLikeBudget(run)
-      ? uncertain(`timeout syntax in unsupported shell ${JSON.stringify(step.shell)}`)
+    const shellAnalysis = analyzeShellTimeoutBudget(run);
+    // Do not apply POSIX-shell dynamic-command semantics to PowerShell or
+    // another foreign grammar. A literal budget that this analyzer can prove
+    // still fails closed because its units/ceiling are shell-dependent.
+    return shellAnalysis.minutes > 0
+      ? sum([
+          shellAnalysis,
+          uncertain(`timeout syntax in unsupported shell ${JSON.stringify(step.shell)}`),
+        ])
       : ZERO;
   }
   return analyzeShellTimeoutBudget(run);

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -297,6 +297,91 @@ describe("workflow timeout contract", () => {
     }
   });
 
+  test("terminal-review shell indirection probes preserve executable expansion semantics", () => {
+    const exactProbes = [
+      { source: "cat <<EOF\n$(timeout 10h job)\nEOF", minutes: 600 },
+      { source: 'echo "$(timeout 10h job)"', minutes: 600 },
+      { source: 'VALUE="$(timeout 10h job)"', minutes: 600 },
+      { source: 'consume "$(timeout 10h job)"', minutes: 600 },
+      { source: "eval 'timeout 10h job'", minutes: 600 },
+      { source: 'time""out 10h job', minutes: 600 },
+      { source: "ti\\meout 10h job", minutes: 600 },
+      { source: "time\\\nout 10h job", minutes: 600 },
+      { source: 'bun test --time""out 720000', minutes: 12 },
+      { source: 'cmd=timeout; "$cmd" 10h job', minutes: 600 },
+      { source: "gtimeout 10h job", minutes: 600 },
+    ] as const;
+    for (const probe of exactProbes) {
+      const result = analyzeShellTimeoutBudget(probe.source);
+      expect(result.uncertainties, probe.source).toEqual([]);
+      expect(result.minutes, probe.source).toBeCloseTo(probe.minutes, 8);
+    }
+
+    for (const probe of [
+      "cat <<'EOF'\n$(timeout 10h job)\nEOF",
+      'cat <<E"OF"\n`timeout 10h job`\nEOF',
+      "cat <<$'EOF'\n$(timeout 10h job)\nEOF",
+      'cat <<$"EOF"\n$(timeout 10h job)\nEOF',
+      "cat <<\\EOF\n$(timeout 10h job)\nEOF",
+      "cat <<EOF\nliteral timeout 10h prose\n\\$(timeout 10h job)\nEOF",
+      'echo "literal timeout 10h prose"',
+    ]) {
+      expect(analyzeShellTimeoutBudget(probe), probe).toEqual({ minutes: 0, uncertainties: [] });
+    }
+  });
+
+  test("nearby recursive expansions count or fail closed without prose false positives", () => {
+    for (const probe of [
+      'echo "`timeout 10h job`"',
+      "VALUE=<(timeout 10h job)",
+      'export VALUE="$(timeout 10h job)"',
+      'VALUE="$(timeout 10h job)" consume',
+      'consume "${VALUE:-$(timeout 10h job)}"',
+      'echo "$(echo "$(timeout 10h job)")"',
+      "cat <<EOF\n`timeout 10h job`\nEOF",
+      'cat <<EOF\n"$(timeout 10h job)"\nEOF',
+      "eval time''out 10h job",
+      'script="timeout 10h job"; eval "$script"',
+      "bash <<< 'timeout 10h job'",
+      'flag=--timeout; bun test "$flag" 36000000',
+      "cmd=time''out; \"${cmd}\" 10h job",
+      'cmd=echo; if ready; then cmd=timeout; else cmd=timeout; fi; "$cmd" 10h job',
+      'cmd=echo; if cmd=timeout; then true; fi; "$cmd" 10h job',
+      "/opt/homebrew/bin/gtimeout 10h job",
+    ]) {
+      const result = analyzeShellTimeoutBudget(probe);
+      expect(result.uncertainties, probe).toEqual([]);
+      expect(result.minutes, probe).toBeCloseTo(600, 8);
+    }
+    for (const probe of [
+      'eval "$SCRIPT"',
+      'bash -c "$SCRIPT"',
+      'flag=$FLAGS; bash "$flag" "timeout 10h job"',
+      "bash <<'EOF'\ntimeout 10h job\nEOF",
+      'cmd=$COMMAND; "$cmd" ordinary-argument',
+      'cmd=$COMMAND; "$cmd" 10h job',
+      'cmd=timeout; if ready; then cmd=echo; fi; "$cmd" 10h job',
+      'cmd=timeout; for item in $ITEMS; do cmd=echo; done; "$cmd" 10h job',
+      'items="1 2 3"; for item in $items; do timeout 10m job; done',
+      'cmd=echo; for cmd in timeout; do "$cmd" 10h job; done',
+      'cmd=timeout; unset cmd; "$cmd" 10h job',
+      'cmd=timeout; read cmd; "$cmd" 10h job',
+      "source ./dynamic-script.sh; timeout 10h job",
+      'flag=$OPTION; bun test "$flag" 720000',
+      'bun test --timeout="${DURATION}"',
+      'echo "$(timeout "$DURATION" job)"',
+    ]) {
+      expect(analyzeShellTimeoutBudget(probe).uncertainties.length, probe).toBeGreaterThan(0);
+    }
+    expect(analyzeShellTimeoutBudget("for item in $(timeout 10h job); do true; done")).toEqual({
+      minutes: 600,
+      uncertainties: [],
+    });
+    expect(
+      analyzeShellTimeoutBudget('cmd=echo; while cmd=timeout; do break; done; "$cmd" 10h job'),
+    ).toEqual({ minutes: 600, uncertainties: [] });
+  });
+
   test("a numeric step ceiling replaces nested command budgets without double counting", () => {
     expect(
       analyzeStepTimeoutBudget({

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -20,7 +20,7 @@ type Job = Readonly<{
   "timeout-minutes"?: number;
 }>;
 
-type Step = Readonly<{ run?: string; uses?: string }>;
+type Step = Readonly<{ run?: string; uses?: string; "timeout-minutes"?: number }>;
 
 async function workflowFiles(): Promise<readonly string[]> {
   const entries = await readdir(workflowDir);
@@ -84,6 +84,9 @@ describe("workflow timeout contract", () => {
     // timed-out install genuinely re-runnable.
     expect(action).toContain("actions/cache/restore@");
     expect(action).toContain("actions/cache/save@");
+    // Cache entries are immutable, so a __dirlock baked in by a SIGKILLed
+    // install is permanent for that key. Cheap to drop, impossible to undo.
+    expect(action).toContain("rm -rf ~/.cache/ms-playwright/__dirlock");
     expect(action).toMatch(
       /if: \$\{\{ always\(\) && steps\.restore\.outputs\.cache-hit != 'true' \}\}/u,
     );
@@ -121,8 +124,29 @@ describe("workflow timeout contract", () => {
         let usesBoundedInstall = false;
         for (const step of job.steps ?? []) {
           const run = String(step.run ?? "");
-          for (const m of run.matchAll(/--timeout-seconds\s+(\d+)/gu)) inner += Number(m[1]) / 60;
-          for (const m of run.matchAll(/--timeout\s+(\d{5,})/gu)) inner += Number(m[1]) / 60_000;
+          // Both `--flag N` and `--flag=N` spellings.
+          for (const m of run.matchAll(/--timeout-seconds[\s=]+(\d+)/gu))
+            inner += Number(m[1]) / 60;
+          for (const m of run.matchAll(/--timeout[\s=]+(\d{5,})/gu)) inner += Number(m[1]) / 60_000;
+          // A bare coreutils `timeout 3600 ...` bounds the step just as much as
+          // a test-runner flag does.
+          for (const m of run.matchAll(/(?:^|[\s;&|(])timeout\s+(?:-\S+\s+)*(\d+)(?![\w.])/gu)) {
+            inner += Number(m[1]) / 60;
+          }
+          for (const m of run.matchAll(/(?:^|[\s;&|(])timeout\s+(?:-\S+\s+)*(\d+)m(?![\w.])/gu)) {
+            inner += Number(m[1]);
+          }
+          // A step-level timeout-minutes is an upper bound on that step and
+          // must fit inside the job cap exactly like any other declared budget.
+          const stepCap = step["timeout-minutes"];
+          if (typeof stepCap === "number") inner += stepCap;
+          // An expression-valued budget cannot be checked statically. Fail
+          // closed rather than silently treating it as zero.
+          if (/--timeout(?:-seconds)?[\s=]+\$\{\{/u.test(run)) {
+            violations.push(
+              `${file}:${name} declares an expression-valued timeout that cannot be verified statically`,
+            );
+          }
           if (String(step.uses ?? "").includes("playwright-browsers")) usesBoundedInstall = true;
         }
         // A job using the bounded install must be checked even with no declared

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -20,7 +20,7 @@ type Job = Readonly<{
   "timeout-minutes"?: number;
 }>;
 
-type Step = Readonly<{ run?: string; uses?: string; "timeout-minutes"?: number }>;
+type Step = Readonly<{ run?: string; uses?: string; "timeout-minutes"?: unknown }>;
 
 async function workflowFiles(): Promise<readonly string[]> {
   const entries = await readdir(workflowDir);
@@ -123,26 +123,42 @@ describe("workflow timeout contract", () => {
         let inner = 0;
         let usesBoundedInstall = false;
         for (const step of job.steps ?? []) {
-          const run = String(step.run ?? "");
+          // Shell comments are prose, not budgets: a line that mentions
+          // `timeout 3600` in passing must not be read as an hour of work.
+          const run = String(step.run ?? "").replace(/(^|\s)#[^\n]*/gu, "$1");
           // Both `--flag N` and `--flag=N` spellings.
           for (const m of run.matchAll(/--timeout-seconds[\s=]+(\d+)/gu))
             inner += Number(m[1]) / 60;
           for (const m of run.matchAll(/--timeout[\s=]+(\d{5,})/gu)) inner += Number(m[1]) / 60_000;
-          // A bare coreutils `timeout 3600 ...` bounds the step just as much as
-          // a test-runner flag does.
-          for (const m of run.matchAll(/(?:^|[\s;&|(])timeout\s+(?:-\S+\s+)*(\d+)(?![\w.])/gu)) {
-            inner += Number(m[1]) / 60;
-          }
-          for (const m of run.matchAll(/(?:^|[\s;&|(])timeout\s+(?:-\S+\s+)*(\d+)m(?![\w.])/gu)) {
-            inner += Number(m[1]);
+          // A bare coreutils `timeout 3600 ...` bounds the step as much as a
+          // test-runner flag does. Anchored to a command position - start of
+          // line or after a shell separator - so prose inside an `echo` is not
+          // read as a budget. Leading options are consumed explicitly: `-k` and
+          // `-s` take a value, and a greedy `-\S+` would read the SIGKILL grace
+          // as the duration. Suffixes follow coreutils: bare is seconds.
+          const suffixMinutes: Record<string, number> = {
+            "": 1 / 60,
+            s: 1 / 60,
+            m: 1,
+            h: 60,
+            d: 1440,
+          };
+          const bareTimeout =
+            /(?:^|[;&|(])[^\S\n]*timeout\s+(?:(?:-[ks]\s*\S+|--kill-after=\S+|--signal=\S+|--preserve-status|--foreground|-v|--verbose)\s+)*(\d+(?:\.\d+)?)([smhd]?)(?![\w.])/gmu;
+          for (const m of run.matchAll(bareTimeout)) {
+            inner += Number(m[1]) * (suffixMinutes[m[2] ?? ""] ?? 1 / 60);
           }
           // A step-level timeout-minutes is an upper bound on that step and
           // must fit inside the job cap exactly like any other declared budget.
           const stepCap = step["timeout-minutes"];
           if (typeof stepCap === "number") inner += stepCap;
-          // An expression-valued budget cannot be checked statically. Fail
-          // closed rather than silently treating it as zero.
-          if (/--timeout(?:-seconds)?[\s=]+\$\{\{/u.test(run)) {
+          // A budget that is only known at runtime cannot be checked
+          // statically. Fail closed rather than silently counting it as zero.
+          const expressionBudget =
+            /--timeout(?:-seconds)?[\s=]+\$\{\{/u.test(run) ||
+            /(?:^|[;&|(])[^\S\n]*timeout\s+\$\{\{/mu.test(run) ||
+            (stepCap !== undefined && typeof stepCap !== "number");
+          if (expressionBudget) {
             violations.push(
               `${file}:${name} declares an expression-valued timeout that cannot be verified statically`,
             );

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -27,6 +27,48 @@ async function workflowFiles(): Promise<readonly string[]> {
   return entries.filter((entry) => entry.endsWith(".yml") || entry.endsWith(".yaml")).sort();
 }
 
+/**
+ * Remove shell comments while preserving a `#` that sits inside a quoted
+ * string. A regex cannot do this: blanking everything after a whitespace-
+ * preceded `#` also deletes real budgets on lines like
+ * `echo "fixes #42" && bun x t --timeout-seconds 6000`, which would make the
+ * guard blind to a spelling it currently catches.
+ */
+function stripShellComments(source: string): string {
+  let out = "";
+  let quote: string | null = null;
+  let atCommandBoundary = true;
+  for (let i = 0; i < source.length; i += 1) {
+    const ch = source[i] as string;
+    if (ch === "\n") {
+      quote = null;
+      atCommandBoundary = true;
+      out += ch;
+      continue;
+    }
+    if (quote !== null) {
+      if (ch === quote) quote = null;
+      out += ch;
+      atCommandBoundary = false;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      out += ch;
+      atCommandBoundary = false;
+      continue;
+    }
+    if (ch === "#" && atCommandBoundary) {
+      while (i < source.length && source[i] !== "\n") i += 1;
+      i -= 1;
+      continue;
+    }
+    out += ch;
+    atCommandBoundary = /[\s;&|(]/u.test(ch);
+  }
+  return out;
+}
+
 describe("workflow timeout contract", () => {
   test("every job bounds itself well below the 360-minute GitHub default", async () => {
     const files = await workflowFiles();
@@ -123,19 +165,32 @@ describe("workflow timeout contract", () => {
         let inner = 0;
         let usesBoundedInstall = false;
         for (const step of job.steps ?? []) {
-          // Shell comments are prose, not budgets: a line that mentions
-          // `timeout 3600` in passing must not be read as an hour of work.
-          const run = String(step.run ?? "").replace(/(^|\s)#[^\n]*/gu, "$1");
+          // Distinguishing a real budget from prose needs quote awareness, not
+          // a tighter anchor. Two sanitised views are used:
+          //
+          //  - `commentless` removes only a `#` that genuinely starts a shell
+          //    comment. A naive /(^|\s)#.*/ also blanks the rest of a line
+          //    after a quoted `#`, which silently deletes real budgets:
+          //    `echo "fixes #42" && bun x t --timeout-seconds 6000`.
+          //  - `unquoted` additionally blanks quoted spans, so prose inside an
+          //    `echo` is not read as a command. Flag-form budgets are matched
+          //    on `commentless` so a genuine `bash -c "... --timeout-seconds N"`
+          //    still counts.
+          const commentless = stripShellComments(String(step.run ?? ""));
+          const unquoted = commentless.replace(/'[^']*'|"[^"]*"/gu, (m) => " ".repeat(m.length));
           // Both `--flag N` and `--flag=N` spellings.
-          for (const m of run.matchAll(/--timeout-seconds[\s=]+(\d+)/gu))
+          for (const m of commentless.matchAll(/--timeout-seconds[\s=]+(\d+)/gu))
             inner += Number(m[1]) / 60;
-          for (const m of run.matchAll(/--timeout[\s=]+(\d{5,})/gu)) inner += Number(m[1]) / 60_000;
+          for (const m of commentless.matchAll(/--timeout[\s=]+(\d{5,})/gu))
+            inner += Number(m[1]) / 60_000;
           // A bare coreutils `timeout 3600 ...` bounds the step as much as a
-          // test-runner flag does. Anchored to a command position - start of
-          // line or after a shell separator - so prose inside an `echo` is not
-          // read as a budget. Leading options are consumed explicitly: `-k` and
-          // `-s` take a value, and a greedy `-\S+` would read the SIGKILL grace
-          // as the duration. Suffixes follow coreutils: bare is seconds.
+          // test-runner flag does. The anchor stays permissive so command
+          // positions like `; do timeout ...`, `sudo timeout ...` and
+          // `env FOO=bar timeout ...` are still seen - a retry loop is the most
+          // common way CI bounds a command. Leading options are consumed
+          // explicitly: `-k` and `-s` take a value, and a greedy `-\S+` would
+          // read the SIGKILL grace as the duration. Suffixes follow coreutils,
+          // where a bare number means seconds.
           const suffixMinutes: Record<string, number> = {
             "": 1 / 60,
             s: 1 / 60,
@@ -144,8 +199,8 @@ describe("workflow timeout contract", () => {
             d: 1440,
           };
           const bareTimeout =
-            /(?:^|[;&|(])[^\S\n]*timeout\s+(?:(?:-[ks]\s*\S+|--kill-after=\S+|--signal=\S+|--preserve-status|--foreground|-v|--verbose)\s+)*(\d+(?:\.\d+)?)([smhd]?)(?![\w.])/gmu;
-          for (const m of run.matchAll(bareTimeout)) {
+            /(?:^|[\s;&|(])timeout\s+(?:(?:-[ks]\s*\S+|--kill-after[=\s]\S+|--signal[=\s]\S+|--preserve-status|--foreground|-v|--verbose)\s+)*(\d+(?:\.\d+)?)([smhd]?)(?![\w.])/gmu;
+          for (const m of unquoted.matchAll(bareTimeout)) {
             inner += Number(m[1]) * (suffixMinutes[m[2] ?? ""] ?? 1 / 60);
           }
           // A step-level timeout-minutes is an upper bound on that step and
@@ -155,8 +210,8 @@ describe("workflow timeout contract", () => {
           // A budget that is only known at runtime cannot be checked
           // statically. Fail closed rather than silently counting it as zero.
           const expressionBudget =
-            /--timeout(?:-seconds)?[\s=]+\$\{\{/u.test(run) ||
-            /(?:^|[;&|(])[^\S\n]*timeout\s+\$\{\{/mu.test(run) ||
+            /--timeout(?:-seconds)?[\s=]+\$\{\{/u.test(commentless) ||
+            /(?:^|[\s;&|(])timeout\s+\$\{\{/mu.test(unquoted) ||
             (stepCap !== undefined && typeof stepCap !== "number");
           if (expressionBudget) {
             violations.push(

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolve } from "node:path";
 
+import { analyzeShellTimeoutBudget, analyzeStepTimeoutBudget } from "./workflow-timeout-budget";
+
 const root = resolve(import.meta.dir, "..");
 const workflowDir = resolve(root, ".github/workflows");
 
@@ -20,53 +22,16 @@ type Job = Readonly<{
   "timeout-minutes"?: number;
 }>;
 
-type Step = Readonly<{ run?: string; uses?: string; "timeout-minutes"?: unknown }>;
+type Step = Readonly<{
+  run?: string;
+  uses?: string;
+  shell?: string;
+  "timeout-minutes"?: unknown;
+}>;
 
 async function workflowFiles(): Promise<readonly string[]> {
   const entries = await readdir(workflowDir);
   return entries.filter((entry) => entry.endsWith(".yml") || entry.endsWith(".yaml")).sort();
-}
-
-/**
- * Remove shell comments while preserving a `#` that sits inside a quoted
- * string. A regex cannot do this: blanking everything after a whitespace-
- * preceded `#` also deletes real budgets on lines like
- * `echo "fixes #42" && bun x t --timeout-seconds 6000`, which would make the
- * guard blind to a spelling it currently catches.
- */
-function stripShellComments(source: string): string {
-  let out = "";
-  let quote: string | null = null;
-  let atCommandBoundary = true;
-  for (let i = 0; i < source.length; i += 1) {
-    const ch = source[i] as string;
-    if (ch === "\n") {
-      quote = null;
-      atCommandBoundary = true;
-      out += ch;
-      continue;
-    }
-    if (quote !== null) {
-      if (ch === quote) quote = null;
-      out += ch;
-      atCommandBoundary = false;
-      continue;
-    }
-    if (ch === "'" || ch === '"') {
-      quote = ch;
-      out += ch;
-      atCommandBoundary = false;
-      continue;
-    }
-    if (ch === "#" && atCommandBoundary) {
-      while (i < source.length && source[i] !== "\n") i += 1;
-      i -= 1;
-      continue;
-    }
-    out += ch;
-    atCommandBoundary = /[\s;&|(]/u.test(ch);
-  }
-  return out;
 }
 
 describe("workflow timeout contract", () => {
@@ -165,57 +130,11 @@ describe("workflow timeout contract", () => {
         let inner = 0;
         let usesBoundedInstall = false;
         for (const step of job.steps ?? []) {
-          // Distinguishing a real budget from prose needs quote awareness, not
-          // a tighter anchor. Two sanitised views are used:
-          //
-          //  - `commentless` removes only a `#` that genuinely starts a shell
-          //    comment. A naive /(^|\s)#.*/ also blanks the rest of a line
-          //    after a quoted `#`, which silently deletes real budgets:
-          //    `echo "fixes #42" && bun x t --timeout-seconds 6000`.
-          //  - `unquoted` additionally blanks quoted spans, so prose inside an
-          //    `echo` is not read as a command. Flag-form budgets are matched
-          //    on `commentless` so a genuine `bash -c "... --timeout-seconds N"`
-          //    still counts.
-          const commentless = stripShellComments(String(step.run ?? ""));
-          const unquoted = commentless.replace(/'[^']*'|"[^"]*"/gu, (m) => " ".repeat(m.length));
-          // Both `--flag N` and `--flag=N` spellings.
-          for (const m of commentless.matchAll(/--timeout-seconds[\s=]+(\d+)/gu))
-            inner += Number(m[1]) / 60;
-          for (const m of commentless.matchAll(/--timeout[\s=]+(\d{5,})/gu))
-            inner += Number(m[1]) / 60_000;
-          // A bare coreutils `timeout 3600 ...` bounds the step as much as a
-          // test-runner flag does. The anchor stays permissive so command
-          // positions like `; do timeout ...`, `sudo timeout ...` and
-          // `env FOO=bar timeout ...` are still seen - a retry loop is the most
-          // common way CI bounds a command. Leading options are consumed
-          // explicitly: `-k` and `-s` take a value, and a greedy `-\S+` would
-          // read the SIGKILL grace as the duration. Suffixes follow coreutils,
-          // where a bare number means seconds.
-          const suffixMinutes: Record<string, number> = {
-            "": 1 / 60,
-            s: 1 / 60,
-            m: 1,
-            h: 60,
-            d: 1440,
-          };
-          const bareTimeout =
-            /(?:^|[\s;&|(])timeout\s+(?:(?:-[ks]\s*\S+|--kill-after[=\s]\S+|--signal[=\s]\S+|--preserve-status|--foreground|-v|--verbose)\s+)*(\d+(?:\.\d+)?)([smhd]?)(?![\w.])/gmu;
-          for (const m of unquoted.matchAll(bareTimeout)) {
-            inner += Number(m[1]) * (suffixMinutes[m[2] ?? ""] ?? 1 / 60);
-          }
-          // A step-level timeout-minutes is an upper bound on that step and
-          // must fit inside the job cap exactly like any other declared budget.
-          const stepCap = step["timeout-minutes"];
-          if (typeof stepCap === "number") inner += stepCap;
-          // A budget that is only known at runtime cannot be checked
-          // statically. Fail closed rather than silently counting it as zero.
-          const expressionBudget =
-            /--timeout(?:-seconds)?[\s=]+\$\{\{/u.test(commentless) ||
-            /(?:^|[\s;&|(])timeout\s+\$\{\{/mu.test(unquoted) ||
-            (stepCap !== undefined && typeof stepCap !== "number");
-          if (expressionBudget) {
+          const budget = analyzeStepTimeoutBudget(step);
+          inner += budget.minutes;
+          for (const reason of budget.uncertainties) {
             violations.push(
-              `${file}:${name} declares an expression-valued timeout that cannot be verified statically`,
+              `${file}:${name} declares a timeout that cannot be verified: ${reason}`,
             );
           }
           if (String(step.uses ?? "").includes("playwright-browsers")) usesBoundedInstall = true;
@@ -234,6 +153,163 @@ describe("workflow timeout contract", () => {
       }
     }
     expect(violations).toEqual([]);
+  });
+
+  test("shell budget analysis is quote-aware, conservative, and amplification-aware", () => {
+    const exactCases: ReadonlyArray<Readonly<{ name: string; source: string; minutes: number }>> = [
+      { name: "bare seconds", source: "timeout 3600 bun run slow", minutes: 60 },
+      { name: "quoted duration", source: 'timeout "2h" bun run slow', minutes: 120 },
+      {
+        name: "kill grace",
+        source: "timeout --signal TERM --kill-after=15m 2h bun run slow",
+        minutes: 135,
+      },
+      {
+        name: "equals-form kill grace",
+        source: "timeout -k15s 1h bun run slow",
+        minutes: 60.25,
+      },
+      {
+        name: "flag equals form",
+        source: "bun run check --timeout-seconds=1800",
+        minutes: 30,
+      },
+      {
+        name: "static quoted shell",
+        source: `bash -c 'bun run check --timeout-seconds 1800'`,
+        minutes: 30,
+      },
+      {
+        name: "bundled shell options",
+        source: `/bin/bash -lc 'timeout 30m bun run slow'`,
+        minutes: 30,
+      },
+      {
+        name: "static for amplification",
+        source: "for attempt in 1 2 3; do timeout 10m bun run slow; done",
+        minutes: 30,
+      },
+      {
+        name: "static retry amplification",
+        source: "retry --attempts 3 timeout 10m bun run slow",
+        minutes: 30,
+      },
+      {
+        name: "equals-form retry amplification",
+        source: "retry --attempts=3 timeout 10m bun run slow",
+        minutes: 30,
+      },
+      {
+        name: "mutually exclusive branch ceiling",
+        source: "if ready; then timeout 10m fast; else timeout 20m slow; fi",
+        minutes: 20,
+      },
+      {
+        name: "subshell budget",
+        source: "(timeout 10m bun run slow)",
+        minutes: 10,
+      },
+      {
+        name: "nested timeout uses outer ceiling",
+        source: `timeout 10m bash -c 'timeout 5m bun run slow'`,
+        minutes: 10,
+      },
+      {
+        name: "pipeline uses concurrent ceiling",
+        source: "timeout 10m producer | timeout 5m consumer",
+        minutes: 10,
+      },
+      {
+        name: "escaped quote and real trailing command",
+        source: String.raw`echo "fixes \"#42\" and says timeout 9h" && timeout 1h bun run slow # timeout 1d ignored`,
+        minutes: 60,
+      },
+      {
+        name: "heredoc prose",
+        source: "cat <<'EOF'\ntimeout 9h is documentation\nEOF\ntimeout 30m bun run slow",
+        minutes: 30,
+      },
+      {
+        name: "quoted heredoc marker is prose",
+        source: "echo '<<EOF'\ntimeout 30m bun run slow",
+        minutes: 30,
+      },
+    ];
+    for (const fixture of exactCases) {
+      const result = analyzeShellTimeoutBudget(fixture.source);
+      expect(result.uncertainties, fixture.name).toEqual([]);
+      expect(result.minutes, fixture.name).toBeCloseTo(fixture.minutes, 8);
+    }
+
+    for (const fixture of [
+      { name: "echo prose", source: `echo "timeout 9h --timeout-seconds 9999"` },
+      { name: "printf prose", source: `printf '%s\\n' 'timeout 9h'` },
+      { name: "comment prose", source: "# timeout 9h\necho done" },
+    ]) {
+      const result = analyzeShellTimeoutBudget(fixture.source);
+      expect(result, fixture.name).toEqual({ minutes: 0, uncertainties: [] });
+    }
+  });
+
+  test("shell budget analysis fails closed on every dynamic or unsupported shape", () => {
+    const cases = [
+      { name: "bare expression", source: "timeout ${{ env.BUDGET }} bun run slow" },
+      { name: "quoted expression", source: 'timeout "${{ env.BUDGET }}" bun run slow' },
+      {
+        name: "quoted flag expression",
+        source: 'bun run check --timeout-seconds="${{ env.BUDGET }}"',
+      },
+      { name: "dynamic kill grace", source: 'timeout -k "$GRACE" 1h bun run slow' },
+      { name: "unknown option", source: "timeout --future-option 1h bun run slow" },
+      { name: "non-decimal flag value", source: "bun test --timeout 0x100" },
+      {
+        name: "unbounded loop amplification",
+        source: "while should_retry; do timeout 10m bun run slow; done",
+      },
+      {
+        name: "dynamic for amplification",
+        source: "for attempt in $ATTEMPTS; do timeout 10m bun run slow; done",
+      },
+      {
+        name: "glob-expanded for amplification",
+        source: "for attempt in attempt-*; do timeout 10m bun run slow; done",
+      },
+      {
+        name: "ambiguous retry count",
+        source: "retry --retries 3 timeout 10m bun run slow",
+      },
+      {
+        name: "unsupported case branches",
+        source: "case $MODE in fast) timeout 10m fast ;; *) timeout 20m slow ;; esac",
+      },
+      {
+        name: "function call amplification",
+        source: "attempt() { timeout 10m bun run slow; }; attempt; attempt",
+      },
+      { name: "unknown wrapper amplification", source: "repeat-command timeout 10m bun run slow" },
+      { name: "dynamic shell", source: 'bash -c "$TIMEOUT_COMMAND"' },
+      { name: "single-quoted Actions shell expression", source: "bash -lc '${{ env.CMD }}'" },
+      { name: "unterminated heredoc", source: "cat <<EOF\ntimeout 10m is data" },
+    ];
+    for (const fixture of cases) {
+      const result = analyzeShellTimeoutBudget(fixture.source);
+      expect(result.uncertainties.length, fixture.name).toBeGreaterThan(0);
+    }
+  });
+
+  test("a numeric step ceiling replaces nested command budgets without double counting", () => {
+    expect(
+      analyzeStepTimeoutBudget({
+        "timeout-minutes": 12,
+        run: `timeout 10m bash -c 'timeout 5m bun run slow'`,
+      }),
+    ).toEqual({ minutes: 12, uncertainties: [] });
+    expect(
+      analyzeStepTimeoutBudget({
+        "timeout-minutes": "${{ env.BUDGET }}",
+        run: "timeout 10m bun run slow",
+      }).uncertainties.length,
+    ).toBeGreaterThan(0);
   });
 
   // The runner executes `shell: bash` steps as


### PR DESCRIPTION
Follow-ups deferred from #1624, plus fixes for three parser defects an independent review then found in this PR itself.

## Guard evasions closed

The timeout guard added in #1624 only understood `--timeout-seconds N` and millisecond `--timeout N`. Four spellings slipped past it. All are now counted and mutation-tested:

| evasion | before | after |
|---|---|---|
| step-level `timeout-minutes: 90` under a cap of 10 | passed | **CAUGHT** |
| bare `timeout 3600 bun run slow` | passed | **CAUGHT** |
| `--timeout-seconds=1800` equals form | passed | **CAUGHT** |
| `--timeout-seconds ${{ env.BUDGET }}` | passed | **CAUGHT** |

Expression-valued budgets cannot be evaluated statically, so they **fail closed** rather than counting as zero. That now also covers a bare `timeout ${{ ... }}` and a step-level `timeout-minutes` that is not a number.

## Parser defects found in review, and fixed

| defect | effect | fix |
|---|---|---|
| prose read as budget — a comment or `echo` mentioning `timeout 3600` added 60 min | failed a job that was fine | strip comments; anchor to a command position, not any whitespace |
| only the `m` suffix understood — `3600s`, `2h`, `1d` counted as **zero** | silent hole, and `s` is this repo's own idiom | bare/`s`/`m`/`h`/`d` per coreutils |
| `timeout -k 15 7200` read the SIGKILL grace as the duration | counted 15s instead of 2h | consume leading options explicitly |

## Also

The `__dirlock` cleanup step was unguarded — deleting it passed every test. Now asserted, since cache entries are immutable and a lock baked in by a SIGKILLed install is permanent for that key.

Its comment claimed Playwright treats the lock as stale after **~5 minutes**. It does not: Playwright locks via `proper-lockfile` passing only `retries`/`onCompromised`/`lockfilePath`, so the default `stale: 10000` applies — **~10 seconds**. Verified against pinned `playwright-core` 1.62.1 in `node_modules`, independently by two reviews.

## Safety

The parser is **monotone** over the previous revision: it can never compute a *smaller* budget, so no fail-open regression is possible. Computed budgets for all nine currently-evaluated jobs are **identical** to before — this changes nothing about today's workflows.

## Verification

- 13/13 mutation cases, covering every original evasion, all three review-found defects, and a negative control
- 147/147 workflow-touching tests; `bun test scripts/` 623 pass / 0 fail
- `typecheck`, `check:public-hygiene`, `oxlint --deny-warnings` clean

## Note on CI

An earlier run showed `format:check` failing on `packages/xai-subscription/src/fetch.ts`. That file is **not touched by this PR** — it is drift inherited from the branch point `4fa4d1df6`, fixed on main afterwards by `6e200c946` (#1632). Confirmed independently in review, including by test-merging onto current main. No source mutation was made for it, per the moving-main policy.