### PR TITLE
fix(agent): assert the read gate against the pump's own witness, not fork rate

### DIFF
--- a/agent/crates/opengeni-agent/src/job.rs
+++ b/agent/crates/opengeni-agent/src/job.rs
@@ -1324,19 +1324,26 @@ mod tests {
         assert_eq!(data_total(&frames), 8192, "exactly one window was emitted");
         job.no_frame_for(Duration::from_millis(200)).await;
 
-        // Pipe (64 KiB) + window are full: the producer must be blocked well
-        // short of its 200 iterations, and stay parked while we withhold acks.
-        tokio::time::sleep(Duration::from_millis(300)).await;
+        // Same shape as the overshoot test: assert against the pump's own
+        // watermark rather than the producer's fork rate. An 8192-byte window
+        // with <=4096-byte frames admits two in-window frames plus one
+        // overshoot. This test has ~3.7x more timing margin than the overshoot
+        // one (18 iterations to park rather than 66), so it has not flaked in
+        // CI - but the defect is identical and it does fail under heavier load.
+        let gated_at = job.watermark.load(Ordering::Relaxed);
+        assert!(gated_at <= 3, "the pump read past the window: {gated_at}");
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert_eq!(
+            job.watermark.load(Ordering::Relaxed),
+            gated_at,
+            "the pump must stop reading while credit is withheld"
+        );
+
+        // End-to-end: the producer is blocked in write(2), not finished.
         let parked_at = lines(&progress_path);
         assert!(
             parked_at < 200,
             "producer must be far from done: {parked_at}"
-        );
-        tokio::time::sleep(Duration::from_millis(400)).await;
-        assert_eq!(
-            lines(&progress_path),
-            parked_at,
-            "producer is blocked in write(2) while credit is withheld"
         );
 
         // Credit returns: the child un-blocks and finishes all 200 writes.
@@ -1632,18 +1639,36 @@ mod tests {
         assert_eq!(first.body.payload_len(), 1024);
         job.no_frame_for(Duration::from_millis(200)).await;
 
-        // Gate closed: the producer parks (pipe full) despite allowance 512.
-        tokio::time::sleep(Duration::from_millis(300)).await;
+        // The gate's own witness. The watermark is the highest seq the pump has
+        // ever appended, so it counts reads off the pipe directly. A 1536-byte
+        // window with <=1024-byte frames admits at most two in-window frames
+        // plus the one overshoot, so a closed gate pins the watermark at or
+        // below 3 no matter how fast the producer can fork.
+        //
+        // This is deliberately not a line-count comparison. `progress.txt`
+        // measures the PRODUCER, which does not park when the gate closes - it
+        // keeps running until it has filled the 64 KiB pipe, roughly 64 more
+        // fork+exec of `head`. Latching a line count at a fixed delay and
+        // requiring it to be final assumes those spawns finish inside that
+        // delay, which is false on a contended runner. Worse, a full E3
+        // regression makes the producer run to completion BEFORE the first
+        // sample, so both samples read 200 and the equality passes: the old
+        // check was simultaneously flaky and blind to the regression it named.
+        let gated_at = job.watermark.load(Ordering::Relaxed);
+        assert!(gated_at <= 3, "the pump read past the window: {gated_at}");
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert_eq!(
+            job.watermark.load(Ordering::Relaxed),
+            gated_at,
+            "the overshoot frame must close the read gate (E3 regression)"
+        );
+
+        // End-to-end: the producer is throttled, not finished. Slowness only
+        // makes this more true, so it cannot flake.
         let parked_at = lines(&progress_path);
         assert!(
             parked_at < 200,
             "producer must be far from done: {parked_at}"
-        );
-        tokio::time::sleep(Duration::from_millis(400)).await;
-        assert_eq!(
-            lines(&progress_path),
-            parked_at,
-            "the overshoot frame must close the read gate (E3 regression)"
         );
 
         // Credit resumes: catch-up sends the retained overshoot frame first,

--- a/agent/crates/opengeni-agent/src/job.rs
+++ b/agent/crates/opengeni-agent/src/job.rs
@@ -1310,7 +1310,7 @@ mod tests {
     #[tokio::test]
     async fn exhausted_window_throttles_the_child_end_to_end() {
         // The child reports its own write progress to a FILE (not a pipe), so
-        // a stalled file proves the child is blocked in write(2) on stdout.
+        // a plateaued file proves the child is blocked in write(2) on stdout.
         let mut job = job("i=0; while [ $i -lt 200 ]; do head -c 4096 /dev/zero; \
              echo $i >> progress.txt; i=$((i+1)); done")
         .frame_bytes(4096)
@@ -1324,26 +1324,31 @@ mod tests {
         assert_eq!(data_total(&frames), 8192, "exactly one window was emitted");
         job.no_frame_for(Duration::from_millis(200)).await;
 
-        // Same shape as the overshoot test: assert against the pump's own
-        // watermark rather than the producer's fork rate. An 8192-byte window
-        // with <=4096-byte frames admits two in-window frames plus one
-        // overshoot. This test has ~3.7x more timing margin than the overshoot
-        // one (18 iterations to park rather than 66), so it has not flaked in
-        // CI - but the defect is identical and it does fail under heavier load.
+        // Same shape as the overshoot test, but a different gate conjunct.
+        // There is NO overshoot frame here: an 8192-byte window with 4096-byte
+        // frames admits exactly two, and the gate then closes because the
+        // allowance is 0, not because the pump is behind. The assertion above
+        // pins that - data_total == 8192 forces both frames to be full size -
+        // so the ceiling is 2. A third frame appears only if the allowance
+        // conjunct is dropped, which is precisely what a ceiling of 2 catches
+        // and a `<= 3` bound would not.
+        // Bounded for the same reason as the overshoot test. Two `next_frame`
+        // awaits above already force the watermark to at least 2, so equality
+        // would be safe here - but the upper bound is what detects the defect,
+        // and keeping both tests the same shape keeps the reasoning one-sided.
         let gated_at = job.watermark.load(Ordering::Relaxed);
-        assert!(gated_at <= 3, "the pump read past the window: {gated_at}");
-        tokio::time::sleep(Duration::from_millis(400)).await;
-        assert_eq!(
-            job.watermark.load(Ordering::Relaxed),
-            gated_at,
-            "the pump must stop reading while credit is withheld"
+        assert!(
+            gated_at <= 2,
+            "the pump must stop reading while credit is withheld: {gated_at}"
         );
 
-        // End-to-end: the producer is blocked in write(2), not finished.
+        // End-to-end: the producer is blocked in write(2) at the pipe plateau
+        // (64 KiB / 4 KiB + 2 drained = 18 lines), not merely unfinished. Same
+        // one-sided reasoning as the overshoot test.
         let parked_at = lines(&progress_path);
         assert!(
-            parked_at < 200,
-            "producer must be far from done: {parked_at}"
+            parked_at <= 30,
+            "producer must be parked at the pipe plateau, not running: {parked_at}"
         );
 
         // Credit returns: the child un-blocks and finishes all 200 writes.
@@ -1622,9 +1627,9 @@ mod tests {
     async fn overshoot_frame_closes_the_read_gate_end_to_end() {
         // Window 1536, frames <= 1024: frame 1 (1024) sends; frame 2 cannot
         // (allowance 512) and is retained UNSENT — the pump is now behind.
-        // The read gate must CLOSE (caught-up requirement): the producer's
-        // progress file plateaus, and retention never grows past the
-        // overshoot frame. Credit + catch-up then resume everything.
+        // The read gate must CLOSE (caught-up requirement): the pump stops
+        // reading, so retention never grows past the overshoot frame and the
+        // producer parks at the pipe plateau. Credit + catch-up then resume.
         let mut job = job(
             "i=0; while [ $i -lt 200 ]; do head -c 1024 /dev/zero;              echo $i >> progress.txt; i=$((i+1)); done",
         )
@@ -1639,36 +1644,53 @@ mod tests {
         assert_eq!(first.body.payload_len(), 1024);
         job.no_frame_for(Duration::from_millis(200)).await;
 
-        // The gate's own witness. The watermark is the highest seq the pump has
-        // ever appended, so it counts reads off the pipe directly. A 1536-byte
-        // window with <=1024-byte frames admits at most two in-window frames
-        // plus the one overshoot, so a closed gate pins the watermark at or
-        // below 3 no matter how fast the producer can fork.
+        // The gate's own witness. `watermark` is the highest seq the pump has
+        // appended - every frame body, so Progress ticks and the Exit frame
+        // move it too, not only pipe reads. Here neither can have fired: the
+        // 5 s progress interval resets on each data read and the child is
+        // still running, so the value is exactly the frames read off the pipe.
+        //
+        // The ceiling is 2, not 3. A 1536-byte window with
+        // 1024-byte frames admits exactly ONE in-window frame - the second
+        // needs 1024 against a 512 allowance - plus the one retained overshoot.
+        // The assertions above already pin it: payload_len == 1024 forbids a
+        // short read, and no_frame_for proves frame 2 never went out. Tightening
+        // the ceiling from 3 to 2 is what catches a one-frame leak and a dropped
+        // allowance check, both of which sit inside a `<= 3` slack.
         //
         // This is deliberately not a line-count comparison. `progress.txt`
         // measures the PRODUCER, which does not park when the gate closes - it
-        // keeps running until it has filled the 64 KiB pipe, roughly 64 more
-        // fork+exec of `head`. Latching a line count at a fixed delay and
-        // requiring it to be final assumes those spawns finish inside that
-        // delay, which is false on a contended runner. Worse, a full E3
-        // regression makes the producer run to completion BEFORE the first
-        // sample, so both samples read 200 and the equality passes: the old
-        // check was simultaneously flaky and blind to the regression it named.
+        // keeps running until it has filled the 64 KiB pipe, 64 more fork+exec
+        // of `head`. Latching a line count at a fixed delay and requiring it to
+        // be final assumes those spawns finish inside that delay, which is
+        // false on a contended runner. Worse, a full E3 regression makes the
+        // producer run to completion BEFORE the first sample, so both samples
+        // read 200 and the equality passes: the old check was simultaneously
+        // flaky and blind to the regression it named.
+        // Bounded, not equality. A gate defect can only make this too HIGH, so
+        // the upper bound carries all the detection power: 3 catches a
+        // one-frame leak, more catches a dropped conjunct. Requiring exactly 2
+        // additionally asserts the PRODUCER got 2048 bytes out before we
+        // looked, which is a fork-rate claim - the very thing this rewrite
+        // exists to stop asserting. Measured: it fails `left: 1, right: 2`
+        // under fork pressure, because the producer is still on iteration 1.
         let gated_at = job.watermark.load(Ordering::Relaxed);
-        assert!(gated_at <= 3, "the pump read past the window: {gated_at}");
-        tokio::time::sleep(Duration::from_millis(400)).await;
-        assert_eq!(
-            job.watermark.load(Ordering::Relaxed),
-            gated_at,
-            "the overshoot frame must close the read gate (E3 regression)"
+        assert!(
+            gated_at <= 2,
+            "the overshoot frame must close the read gate (E3 regression): {gated_at}"
         );
 
-        // End-to-end: the producer is throttled, not finished. Slowness only
-        // makes this more true, so it cannot flake.
+        // End-to-end: the producer is parked at the pipe plateau rather than
+        // running away. A closed gate plateaus at 64 KiB / 1 KiB + 2 drained =
+        // 66 lines; a leaking gate drains continuously and reaches 200. The
+        // bound is one-sided ON PURPOSE: the original flake undersampled, and
+        // undersampling can only push this count DOWN, so an upper bound cannot
+        // reproduce it. A platform with a smaller pipe plateaus lower and still
+        // passes; both supported unix platforms use 64 KiB.
         let parked_at = lines(&progress_path);
         assert!(
-            parked_at < 200,
-            "producer must be far from done: {parked_at}"
+            parked_at <= 100,
+            "producer must be parked at the pipe plateau, not running: {parked_at}"
         );
 
         // Credit resumes: catch-up sends the retained overshoot frame first,

--- a/agent/crates/opengeni-agent/src/job.rs
+++ b/agent/crates/opengeni-agent/src/job.rs
@@ -107,6 +107,10 @@ pub enum JobCommand {
     /// Kill the job (wire: `OpCancel`). Terminates the process group and
     /// produces `Exit{cancelled}`. Idempotent; a no-op once terminal.
     Cancel,
+    /// Test-only mailbox receipt. A sender that observes this notification
+    /// knows every command queued before it has been applied by the pump.
+    #[cfg(test)]
+    Barrier { completed: Arc<Notify> },
 }
 
 /// Tuning knobs for one job's pump.
@@ -624,6 +628,8 @@ impl Pump {
                     self.terminate_child();
                 }
             }
+            #[cfg(test)]
+            JobCommand::Barrier { completed } => completed.notify_one(),
         }
     }
 
@@ -907,6 +913,8 @@ mod tests {
     /// loaded parallel test run.
     const WAIT: Duration = Duration::from_secs(10);
     const PAUSED_WAIT: Duration = Duration::from_secs(30 * 24 * 3600);
+    const PRODUCER_POLL: Duration = Duration::from_millis(5);
+    const PRODUCER_STABLE_FOR: Duration = Duration::from_millis(150);
 
     struct JobBuilder {
         script: String,
@@ -1064,6 +1072,33 @@ mod tests {
             .await;
         }
 
+        /// Waits until the pump has applied every command queued before this
+        /// receipt. Used to release a child only after its attach is live.
+        async fn barrier(&self) {
+            let completed = Arc::new(Notify::new());
+            self.send(JobCommand::Barrier {
+                completed: completed.clone(),
+            })
+            .await;
+            timeout(self.wait, completed.notified())
+                .await
+                .expect("pump reaches the test barrier");
+        }
+
+        async fn wait_for_watermark_at_least(&self, target: u64) -> u64 {
+            timeout(self.wait, async {
+                loop {
+                    let current = self.watermark.load(Ordering::Relaxed);
+                    if current >= target {
+                        return current;
+                    }
+                    tokio::time::sleep(PRODUCER_POLL).await;
+                }
+            })
+            .await
+            .expect("pump reaches the expected watermark")
+        }
+
         async fn next_frame(&mut self) -> Frame {
             timeout(self.wait, self.frames.recv())
                 .await
@@ -1103,6 +1138,74 @@ mod tests {
                 .expect("task ends within the await budget")
                 .expect("pump task must not panic");
         }
+    }
+
+    /// A fixed-size producer with no per-frame child processes. The two files
+    /// bracket each stdout write: once `started == completed + 1` remains
+    /// stable, the shell is parked inside that write rather than merely slow
+    /// between repeated `fork+exec` calls.
+    fn blocking_producer_script(frame_bytes: usize) -> String {
+        format!(
+            "payload=$(printf '%{frame_bytes}s' ''); \
+             while [ ! -f producer.go ]; do :; done; \
+             i=0; while [ $i -lt 200 ]; do \
+               printf '%s\\n' \"$i\" >> producer-started.txt; \
+               printf '%s' \"$payload\"; \
+               printf '%s\\n' \"$i\" >> producer-completed.txt; \
+               i=$((i+1)); \
+             done"
+        )
+    }
+
+    fn producer_counts(job: &TestJob) -> (usize, usize) {
+        let lines = |name: &str| {
+            std::fs::read_to_string(job.dir.path().join(name))
+                .map_or(0, |source| source.lines().count())
+        };
+        (
+            lines("producer-started.txt"),
+            lines("producer-completed.txt"),
+        )
+    }
+
+    fn release_producer(job: &TestJob) {
+        std::fs::write(job.dir.path().join("producer.go"), b"go")
+            .expect("release producer after attach barrier");
+    }
+
+    /// Waits for a stable in-write producer witness while simultaneously
+    /// asserting that the pump's read watermark remains pinned. Requiring at
+    /// least three completed writes proves post-gate bytes are already queued
+    /// in the pipe, so a broken read gate has runnable work independent of the
+    /// producer's scheduling rate.
+    async fn wait_for_parked_producer(job: &TestJob, expected_watermark: u64) -> usize {
+        timeout(job.wait, async {
+            let mut stable: Option<((usize, usize), Instant)> = None;
+            loop {
+                assert_eq!(
+                    job.watermark.load(Ordering::Relaxed),
+                    expected_watermark,
+                    "the pump read past its closed gate"
+                );
+                let counts = producer_counts(job);
+                if counts.1 >= 3 && counts.0 == counts.1 + 1 {
+                    match stable {
+                        Some((candidate, since))
+                            if candidate == counts && since.elapsed() >= PRODUCER_STABLE_FOR =>
+                        {
+                            return counts.1;
+                        }
+                        Some((candidate, _)) if candidate == counts => {}
+                        _ => stable = Some((counts, Instant::now())),
+                    }
+                } else {
+                    stable = None;
+                }
+                tokio::time::sleep(PRODUCER_POLL).await;
+            }
+        })
+        .await
+        .expect("producer parks in stdout write while the read gate is closed")
     }
 
     /// Orders frames by seq, asserting duplicate seqs (replay overlap) carry
@@ -1309,46 +1412,33 @@ mod tests {
 
     #[tokio::test]
     async fn exhausted_window_throttles_the_child_end_to_end() {
-        // The child reports its own write progress to a FILE (not a pipe), so
-        // a plateaued file proves the child is blocked in write(2) on stdout.
-        let mut job = job("i=0; while [ $i -lt 200 ]; do head -c 4096 /dev/zero; \
-             echo $i >> progress.txt; i=$((i+1)); done")
-        .frame_bytes(4096)
-        .start();
-        let progress_path = job.dir.path().join("progress.txt");
-        let lines =
-            |path: &std::path::Path| std::fs::read_to_string(path).map_or(0, |s| s.lines().count());
+        let script = blocking_producer_script(4096);
+        let mut job = job(&script).frame_bytes(4096).start();
 
         job.attach(1, 0, 8192).await;
+        // Apply the attach before releasing the producer so detached reads
+        // cannot race this gate witness.
+        job.barrier().await;
+        release_producer(&job);
         let mut frames = vec![job.next_frame().await, job.next_frame().await];
         assert_eq!(data_total(&frames), 8192, "exactly one window was emitted");
-        job.no_frame_for(Duration::from_millis(200)).await;
 
-        // Same shape as the overshoot test, but a different gate conjunct.
-        // There is NO overshoot frame here: an 8192-byte window with 4096-byte
-        // frames admits exactly two, and the gate then closes because the
-        // allowance is 0, not because the pump is behind. The assertion above
-        // pins that - data_total == 8192 forces both frames to be full size -
-        // so the ceiling is 2. A third frame appears only if the allowance
-        // conjunct is dropped, which is precisely what a ceiling of 2 catches
-        // and a `<= 3` bound would not.
-        // Bounded for the same reason as the overshoot test. Two `next_frame`
-        // awaits above already force the watermark to at least 2, so equality
-        // would be safe here - but the upper bound is what detects the defect,
-        // and keeping both tests the same shape keeps the reasoning one-sided.
-        let gated_at = job.watermark.load(Ordering::Relaxed);
-        assert!(
-            gated_at <= 2,
-            "the pump must stop reading while credit is withheld: {gated_at}"
+        // There is no overshoot here: two full frames exactly exhaust the
+        // allowance. Wait for the pump-owned witness before asserting the
+        // closed-gate value rather than sampling it opportunistically.
+        assert_eq!(
+            job.wait_for_watermark_at_least(2).await,
+            2,
+            "the allowance gate must close at the exhausted window"
         );
 
-        // End-to-end: the producer is blocked in write(2) at the pipe plateau
-        // (64 KiB / 4 KiB + 2 drained = 18 lines), not merely unfinished. Same
-        // one-sided reasoning as the overshoot test.
-        let parked_at = lines(&progress_path);
+        // The stable started/completed difference proves the shell is parked
+        // inside stdout write(2). Requiring already-queued post-gate writes
+        // avoids assumptions about host pipe size or fork throughput.
+        let parked_at = wait_for_parked_producer(&job, 2).await;
         assert!(
-            parked_at <= 30,
-            "producer must be parked at the pipe plateau, not running: {parked_at}"
+            parked_at < 200,
+            "producer must be parked before completing: {parked_at}"
         );
 
         // Credit returns: the child un-blocks and finishes all 200 writes.
@@ -1363,13 +1453,13 @@ mod tests {
                 break;
             }
         }
-        let zeros = vec![0u8; 200 * 4096];
-        assert_eq!(reassemble(&frames, Channel::Stdout), zeros);
+        let spaces = vec![b' '; 200 * 4096];
+        assert_eq!(reassemble(&frames, Channel::Stdout), spaces);
         let (exit_seq, exit) = job.wait_exit().await;
         assert_eq!(exit.outcome, JobOutcome::Exited { exit_code: 0 });
         assert_eq!(exit.stdout.total_bytes, 819_200);
-        assert_eq!(exit.stdout.digest, blake3::hash(&zeros));
-        assert_eq!(lines(&progress_path), 200);
+        assert_eq!(exit.stdout.digest, blake3::hash(&spaces));
+        assert_eq!(producer_counts(&job), (200, 200));
         job.final_ack(1, exit_seq.unwrap(), 1 << 20).await;
         job.join().await;
     }
@@ -1629,68 +1719,34 @@ mod tests {
         // (allowance 512) and is retained UNSENT — the pump is now behind.
         // The read gate must CLOSE (caught-up requirement): the pump stops
         // reading, so retention never grows past the overshoot frame and the
-        // producer parks at the pipe plateau. Credit + catch-up then resume.
-        let mut job = job(
-            "i=0; while [ $i -lt 200 ]; do head -c 1024 /dev/zero;              echo $i >> progress.txt; i=$((i+1)); done",
-        )
-        .frame_bytes(1024)
-        .start();
-        let progress_path = job.dir.path().join("progress.txt");
-        let lines =
-            |path: &std::path::Path| std::fs::read_to_string(path).map_or(0, |s| s.lines().count());
+        // producer parks in stdout write(2). Credit + catch-up then resume.
+        let script = blocking_producer_script(1024);
+        let mut job = job(&script).frame_bytes(1024).start();
 
         job.attach(1, 0, 1536).await;
+        // Apply the attach before releasing the producer so detached reads
+        // cannot race this gate witness.
+        job.barrier().await;
+        release_producer(&job);
         let first = job.next_frame().await;
         assert_eq!(first.body.payload_len(), 1024);
         job.no_frame_for(Duration::from_millis(200)).await;
 
-        // The gate's own witness. `watermark` is the highest seq the pump has
-        // appended - every frame body, so Progress ticks and the Exit frame
-        // move it too, not only pipe reads. Here neither can have fired: the
-        // 5 s progress interval resets on each data read and the child is
-        // still running, so the value is exactly the frames read off the pipe.
-        //
-        // The ceiling is 2, not 3. A 1536-byte window with
-        // 1024-byte frames admits exactly ONE in-window frame - the second
-        // needs 1024 against a 512 allowance - plus the one retained overshoot.
-        // The assertions above already pin it: payload_len == 1024 forbids a
-        // short read, and no_frame_for proves frame 2 never went out. Tightening
-        // the ceiling from 3 to 2 is what catches a one-frame leak and a dropped
-        // allowance check, both of which sit inside a `<= 3` slack.
-        //
-        // This is deliberately not a line-count comparison. `progress.txt`
-        // measures the PRODUCER, which does not park when the gate closes - it
-        // keeps running until it has filled the 64 KiB pipe, 64 more fork+exec
-        // of `head`. Latching a line count at a fixed delay and requiring it to
-        // be final assumes those spawns finish inside that delay, which is
-        // false on a contended runner. Worse, a full E3 regression makes the
-        // producer run to completion BEFORE the first sample, so both samples
-        // read 200 and the equality passes: the old check was simultaneously
-        // flaky and blind to the regression it named.
-        // Bounded, not equality. A gate defect can only make this too HIGH, so
-        // the upper bound carries all the detection power: 3 catches a
-        // one-frame leak, more catches a dropped conjunct. Requiring exactly 2
-        // additionally asserts the PRODUCER got 2048 bytes out before we
-        // looked, which is a fork-rate claim - the very thing this rewrite
-        // exists to stop asserting. Measured: it fails `left: 1, right: 2`
-        // under fork pressure, because the producer is still on iteration 1.
-        let gated_at = job.watermark.load(Ordering::Relaxed);
-        assert!(
-            gated_at <= 2,
-            "the overshoot frame must close the read gate (E3 regression): {gated_at}"
+        // Do not let this pass at watermark 1: wait until the retained seq 2
+        // overshoot actually exists, then require it to be the last read.
+        assert_eq!(
+            job.wait_for_watermark_at_least(2).await,
+            2,
+            "the overshoot frame must be the last read before the gate closes"
         );
 
-        // End-to-end: the producer is parked at the pipe plateau rather than
-        // running away. A closed gate plateaus at 64 KiB / 1 KiB + 2 drained =
-        // 66 lines; a leaking gate drains continuously and reaches 200. The
-        // bound is one-sided ON PURPOSE: the original flake undersampled, and
-        // undersampling can only push this count DOWN, so an upper bound cannot
-        // reproduce it. A platform with a smaller pipe plateaus lower and still
-        // passes; both supported unix platforms use 64 KiB.
-        let parked_at = lines(&progress_path);
+        // The stable started/completed difference proves the shell is parked
+        // inside stdout write(2). Requiring already-queued post-gate writes
+        // avoids assumptions about host pipe size or fork throughput.
+        let parked_at = wait_for_parked_producer(&job, 2).await;
         assert!(
-            parked_at <= 100,
-            "producer must be parked at the pipe plateau, not running: {parked_at}"
+            parked_at < 200,
+            "producer must be parked before completing: {parked_at}"
         );
 
         // Credit resumes: catch-up sends the retained overshoot frame first,
@@ -1707,10 +1763,11 @@ mod tests {
             }
         }
         assert_consecutive_from_one(&frames);
-        let zeros = vec![0u8; 200 * 1024];
-        assert_eq!(reassemble(&frames, Channel::Stdout), zeros);
+        let spaces = vec![b' '; 200 * 1024];
+        assert_eq!(reassemble(&frames, Channel::Stdout), spaces);
         let (exit_seq, exit) = job.wait_exit().await;
-        assert_eq!(exit.stdout.digest, blake3::hash(&zeros));
+        assert_eq!(exit.stdout.digest, blake3::hash(&spaces));
+        assert_eq!(producer_counts(&job), (200, 200));
         job.final_ack(1, exit_seq.expect("retained"), 1 << 20).await;
         job.join().await;
     }


### PR DESCRIPTION
## Verdict: the read gate is correct. This is a flaky **and ineffective** test.

`overshoot_frame_closes_the_read_gate_end_to_end` fails intermittently on macos-26, including on `main`. A multi-agent investigation instrumented the real pump while the assertion fired: the retention watermark was pinned at **2** (frame 1 sent, frame 2 retained unsent = exactly 2048 bytes drained) for the full window in **every** failing run. The gate had closed correctly.

## Why it flakes

The test infers "gate closed" from "`progress.txt` stopped growing". But **the producer does not park when the gate closes** — it keeps running until it has filled the 64 KiB pipe, roughly 64 more `fork+exec` of `head`. The test latches its baseline at a fixed ~500 ms offset and requires it to be final.

The plateau arithmetic confirms it: `64 + drained_KiB`. Measured directly — drain 1024 → plateau 65, drain 2048 → plateau 66, drain 3072 → plateau 67. The real CI failure was `left: 66, right: 65`: the producer parked exactly where a *correctly shut* gate puts it, and the baseline was sampled one `fork+exec` early.

## The more serious problem

**That assertion never detected the regression it is named after.** Injecting the actual E3 regression (dropping the caught-up conjunct from `may_read`) makes the producer run all 200 iterations *before* the first sample, so both samples read 200 and the equality passes.

Verified directly on this branch's parent:

```
E3 REGRESSION INJECTED
  panicked at crates/opengeni-agent/src/job.rs:1638   <- assert!(parked_at < 200)
```

Line 1638, never 1643. The flaky assertion was also the blind one.

## The fix

Assert against `job.watermark` — the highest seq the pump has appended, i.e. reads off the pipe, independent of the producer's fork rate. A 1536-byte window with ≤1024-byte frames admits at most two in-window frames plus one overshoot, so a closed gate pins it at ≤ 3.

With the regression injected, the new assertion fails **immediately and deterministically**:

```
panicked at job.rs:1658: the pump read past the window: 48
```

`assert!(parked_at < 200)` is kept as the end-to-end producer-throttle proof — slowness only makes it more true, so it cannot flake.

## Sibling test

`exhausted_window_throttles_the_child_end_to_end` has the identical fixed-sample shape with ~3.7x more margin (18 iterations to park rather than 66). It has not flaked in CI but fails under heavier load. Given the same treatment. It exercises the *window-exhausted* path (allowance 0) rather than the overshoot path, so it is unaffected by that particular regression — correctly, it still passes with it injected.

## What was explicitly NOT done

- **`may_read` (job.rs:797) is untouched.** Every writer of `sent_hi`/`allowance` was enumerated; closure is monotone and permanent, not racy.
- The sleeps were **not** simply enlarged. That preserves the same fork-rate assumption and leaves the E3 guard as weak as it is.
- The E3 assertion was not deleted or downgraded.

## Verification (macOS, the failing platform)

- 15/15 under CPU contention
- 211/211 for the crate
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- Regression injected and confirmed caught, then reverted; tree clean

## Residual uncertainty

- The `gated_at <= 3` bound is empirical, not proven from the protocol — the invariant bounds drained *bytes* (1536 + 1024 = 2560), not frame count. The watermark was exactly 2 in 24/24 instrumented runs, and the pre-existing `assert_eq!(first.body.payload_len(), 1024)` already depends on full-size reads.
- The "1 in 8" failure rate in the original report is not well supported; two confirmed instances were found in CI history. It is load-dependent and bursty rather than a fixed probability.