### PR TITLE
docs: production pointer is already established

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Release and publishing guidance starts here; executable truth lives in [`package
 
 **Hotfix:** PR `hotfix/*` into `production` (freeze-head source admission applies). Then merge `production` → `main` with a merge commit so daily work is not stranded. Squash remains allowed on PRs into `main`.
 
-**Official cut:** dispatch `open-version-pr.yml` on `main` (or set `VERSION_PR_ON_PUSH=true`). Merge the Version PR, promote that SHA to `production`, then `workflow_dispatch` the evidence-bound candidate / acceptance / publication workflows. Do not commit version bumps onto `production`. Official source ancestry is `origin/production`. Bootstrap the pointer once with `git push origin origin/main:refs/heads/production` before the first official cut; that is not a cluster deploy.
+**Official cut:** dispatch `open-version-pr.yml` on `main` (or set `VERSION_PR_ON_PUSH=true`). Merge the Version PR, promote that SHA to `production`, then `workflow_dispatch` the evidence-bound candidate / acceptance / publication workflows. Do not commit version bumps onto `production`. Official source ancestry is `origin/production`. The `production` pointer already exists; do not recreate it and do not force-push.
 
 **Staging:** dispatch `staging-canary-dispatch.yml` with any `main` SHA whose `canary-sha-*` tags already exist. Pending changesets are allowed. Missing tags fail closed; do not rebuild unsigned `:ci` images.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -702,9 +702,8 @@ rebase-and-merge). Hotfix via `hotfix/*` into `production`, then merge
 `production` → `main`. Official cuts: dispatch `open-version-pr.yml` on `main`
 (or `VERSION_PR_ON_PUSH=true`), merge that Version PR, promote, then
 `workflow_dispatch` candidate/acceptance/publication. Official source ancestry
-is `origin/production`. Bootstrap the pointer once with
-`git push origin origin/main:refs/heads/production` before the first official
-cut.
+is `origin/production`. The `production` pointer already exists; do not
+recreate it and do not force-push.
 
 Protect `production`: no force-push; merge commits only (disable squash and
 rebase-and-merge); required checks `Admit production PR head` and


### PR DESCRIPTION
## Summary
- The \`production\` source pointer is live. Drop the one-time bootstrap \`git push origin origin/main:refs/heads/production\` instruction so nobody recreates or force-pushes it.

## Test plan
- [ ] Docs-only CI
- [ ] After merge, main push bakes \`canary-sha-*\` for the dummy staging path


Made with [Cursor](https://cursor.com)