### PR TITLE
ci: admit manual Open Version PR as trusted CI producer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      actions: read # authenticate the exact push-triggered Release run
+      actions: read # authenticate the exact Version PR producer run
       checks: write # publish idempotent checks on the candidate head SHA
       contents: write # retain the exact head before any check can make the Version PR mergeable
       pull-requests: read # authenticate the bot PR and provider projection

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -26,6 +26,7 @@ export const RELEASE_AUTOMATION_CONTRACT = Object.freeze({
   defaultBranch: "main",
   versionBranch: "changeset-release/main",
   releaseWorkflowPath: ".github/workflows/release.yml",
+  openVersionPrWorkflowPath: ".github/workflows/open-version-pr.yml",
   ciWorkflowPath: ".github/workflows/ci.yml",
   ciWorkflowFile: "ci.yml",
   sealWorkflowPath: ".github/workflows/seal-release-head.yml",
@@ -468,6 +469,21 @@ function releasePushContext(env) {
   };
 }
 
+function versionPrDispatchContext(env) {
+  if (env.GITHUB_EVENT_NAME === "push") return releasePushContext(env);
+  const context = baseGithubContext(
+    env,
+    RELEASE_AUTOMATION_CONTRACT.openVersionPrWorkflowPath,
+    "workflow_dispatch",
+  );
+  requiredEnvironment(env, ["GITHUB_RUN_ATTEMPT", "GITHUB_RUN_ID"]);
+  return {
+    ...context,
+    runAttempt: assertPositiveInteger(env.GITHUB_RUN_ATTEMPT, "GITHUB_RUN_ATTEMPT"),
+    runId: assertPositiveInteger(env.GITHUB_RUN_ID, "GITHUB_RUN_ID"),
+  };
+}
+
 function automationInputs(env, suppliedInputs) {
   const values = suppliedInputs ?? {
     prNumber: env.AUTOMATION_PR_NUMBER,
@@ -628,7 +644,7 @@ async function convergedVersionHeadSha(api, context, options = {}) {
 export async function validateVersionPrDispatch(options = {}) {
   const env = options.env ?? process.env;
   const logger = options.logger ?? console;
-  const context = releasePushContext(env);
+  const context = versionPrDispatchContext(env);
   const prNumber = assertPositiveInteger(
     options.prNumber ?? env.VERSION_PR_NUMBER,
     "Version PR number",
@@ -676,15 +692,16 @@ export async function validateVersionPrDispatch(options = {}) {
 function assertSourceRun(run, context) {
   invariant(run?.id === context.sourceRunId, "source Release run ID changed");
   invariant(run?.run_attempt === context.sourceRunAttempt, "source Release run attempt changed");
-  invariant(run?.event === "push", "source Release run was not triggered by a push");
+  const pushRelease =
+    run?.event === "push" && run?.path === RELEASE_AUTOMATION_CONTRACT.releaseWorkflowPath;
+  const dispatchedVersion =
+    run?.event === "workflow_dispatch" &&
+    run?.path === RELEASE_AUTOMATION_CONTRACT.openVersionPrWorkflowPath;
+  invariant(pushRelease || dispatchedVersion, "source run is not a trusted Version PR producer");
   invariant(
     (run?.status === "in_progress" && run.conclusion === null) ||
       (run?.status === "completed" && run.conclusion === "success"),
     "source Release run is neither in progress nor successfully completed",
-  );
-  invariant(
-    run?.path === RELEASE_AUTOMATION_CONTRACT.releaseWorkflowPath,
-    "source run did not execute the Release workflow",
   );
   invariant(
     run?.head_branch === RELEASE_AUTOMATION_CONTRACT.defaultBranch,

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -198,6 +198,16 @@ function releasePushEnv(overrides: Record<string, string> = {}) {
   };
 }
 
+function openVersionPrEnv(overrides: Record<string, string> = {}) {
+  return releasePushEnv({
+    GITHUB_EVENT_NAME: "workflow_dispatch",
+    GITHUB_WORKFLOW_REF:
+      `${RELEASE_AUTOMATION_CONTRACT.repository}/` +
+      `${RELEASE_AUTOMATION_CONTRACT.openVersionPrWorkflowPath}@refs/heads/main`,
+    ...overrides,
+  });
+}
+
 function automationCiEnv(overrides: Record<string, string> = {}) {
   return {
     GITHUB_API_URL: RELEASE_AUTOMATION_CONTRACT.apiUrl,
@@ -295,6 +305,27 @@ describe("Version PR dispatch identity", () => {
     const fixture = dispatchFixture();
     const result = await validateVersionPrDispatch({
       env: releasePushEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+    });
+    expect(result).toEqual({ prNumber: pullNumber, headSha, baseSha });
+    const dispatch = fixture.requests.find((request) => request.method === "POST");
+    expect(dispatch?.body).toEqual({
+      ref: "main",
+      inputs: {
+        automation_pr_number: String(pullNumber),
+        automation_head_sha: headSha,
+        automation_base_sha: baseSha,
+        source_release_run_id: String(runId),
+        source_release_run_attempt: String(runAttempt),
+      },
+    });
+  });
+
+  test("dispatches trusted main CI from the manual Open Version PR workflow", async () => {
+    const fixture = dispatchFixture();
+    const result = await validateVersionPrDispatch({
+      env: openVersionPrEnv(),
       fetchImpl: fixture.fetchImpl,
       logger: { log() {} },
     });
@@ -438,6 +469,7 @@ function admissionFixture(
     sourceAdmissionConclusion?: string;
     sourceConclusion?: string | null;
     sourceEvent?: string;
+    sourcePath?: string;
     sourceStatus?: string;
     pullBaseSha?: string;
     pullBaseTreeSha?: string;
@@ -512,7 +544,7 @@ function admissionFixture(
         event: options.sourceEvent ?? "push",
         status: options.sourceStatus ?? "completed",
         conclusion: options.sourceConclusion === undefined ? "success" : options.sourceConclusion,
-        path: RELEASE_AUTOMATION_CONTRACT.releaseWorkflowPath,
+        path: options.sourcePath ?? RELEASE_AUTOMATION_CONTRACT.releaseWorkflowPath,
         head_branch: "main",
         head_sha: baseSha,
         repository: { full_name: RELEASE_AUTOMATION_CONTRACT.repository },
@@ -647,15 +679,28 @@ describe("automation CI admission", () => {
     expect(fixture.requests.every((request) => request.method === "GET")).toBe(true);
   });
 
-  test("rejects a source run that was not an exact push-triggered Release run", async () => {
-    const fixture = admissionFixture({ sourceEvent: "workflow_dispatch" });
+  test("rejects a source run that is not a trusted Version PR producer", async () => {
+    const fixture = admissionFixture({ sourceEvent: "pull_request" });
     await expect(
       validateVersionPrCiAdmission({
         env: automationCiEnv(),
         fetchImpl: fixture.fetchImpl,
         logger: { log() {} },
       }),
-    ).rejects.toThrow("source Release run was not triggered by a push");
+    ).rejects.toThrow("source run is not a trusted Version PR producer");
+  });
+
+  test("admits a workflow_dispatch Open Version PR producer run", async () => {
+    const fixture = admissionFixture({
+      sourceEvent: "workflow_dispatch",
+      sourcePath: RELEASE_AUTOMATION_CONTRACT.openVersionPrWorkflowPath,
+    });
+    const result = await validateVersionPrCiAdmission({
+      env: automationCiEnv(),
+      fetchImpl: fixture.fetchImpl,
+      logger: { log() {} },
+    });
+    expect(result).toMatchObject({ prNumber: pullNumber, baseSha, headSha });
   });
 
   test("rejects a failed source Release run", async () => {


### PR DESCRIPTION
## Summary
- \`open-version-pr.yml\` is now a trusted Version PR producer alongside push-triggered \`release.yml\`.
- Exact-head CI admission accepts that \`workflow_dispatch\` run instead of requiring a Release push.

## Test plan
- [x] \`bun test scripts/check-release-pr-automation.test.ts scripts/staging-production-split-contract.test.ts\`
- [ ] After merge, re-dispatch \`open-version-pr.yml\` and confirm Version PR #1620 gets Automation PR CI


Made with [Cursor](https://cursor.com)