### PR TITLE
ci: admit official cuts from the merged source PR, not a GitHub review PASS.

### DIFF
--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -321,10 +321,6 @@ function assertIdentity(actual, expected, label) {
   return identity;
 }
 
-function hasStableIdentity(actual, expected) {
-  return actual?.id === expected.id && actual?.type === expected.type;
-}
-
 function assertVersionPull(pull, expected) {
   const expectedNumber = expected.prNumber ?? expected.number;
   invariant(pull?.number === expectedNumber, "Version PR number changed");

--- a/scripts/check-release-pr-automation.mjs
+++ b/scripts/check-release-pr-automation.mjs
@@ -61,7 +61,6 @@ export const RELEASE_AUTOMATION_CONTRACT = Object.freeze({
 
 const shaPattern = /^[0-9a-f]{40}$/;
 const positiveIntegerPattern = /^[1-9][0-9]*$/;
-const decisiveReviewStates = new Set(["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]);
 const retryableVersionProjectionErrors = new Set([
   "Version PR base SHA changed",
   "Version PR head SHA changed",
@@ -1909,64 +1908,11 @@ function assertProviderMergeEvent(events, sourceSha, pullIdentity) {
   );
 }
 
-function exactHeadReviewArtifact(baseSha, headSha, releaseApprover) {
-  return {
-    version: 3,
-    kind: "opengeni-exact-head-release-review",
-    repository: RELEASE_AUTOMATION_CONTRACT.repository,
-    reviewedBaseSha: baseSha,
-    reviewedHeadSha: headSha,
-    reviewerLogin: releaseApprover.login,
-    reviewProfile: "exact-head-maintainer-v1",
-    verdict: "PASS",
-  };
-}
-
 function canonicalSha256(value) {
   const canonical = Object.fromEntries(
     Object.entries(value).sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0)),
   );
   return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
-}
-
-function verifyAdminPassBody(body, artifact) {
-  const match =
-    /^<!-- opengeni-exact-head-release-review:v3 -->\n\n?```json\n([\s\S]+)\n```\s*$/.exec(body);
-  invariant(match !== null, "single-maintainer admin PASS body is not canonical");
-  let parsed;
-  try {
-    parsed = JSON.parse(match[1]);
-  } catch {
-    throw new Error("single-maintainer admin PASS body is not valid JSON");
-  }
-  const reviewerLogin = assertString(
-    parsed?.reviewerLogin,
-    "single-maintainer admin PASS reviewer login snapshot",
-  );
-  const boundArtifact = { ...artifact, reviewerLogin };
-  invariant(
-    JSON.stringify(parsed) === JSON.stringify(boundArtifact),
-    "single-maintainer admin PASS does not bind the exact base/head contract",
-  );
-  invariant(
-    body ===
-      `<!-- opengeni-exact-head-release-review:v3 -->\n\n\u0060\u0060\u0060json\n${JSON.stringify(boundArtifact, null, 2)}\n\u0060\u0060\u0060`,
-    "single-maintainer admin PASS body is not canonical",
-  );
-  return canonicalSha256(boundArtifact);
-}
-
-function sameProviderReview(left, right) {
-  return (
-    left?.id === right?.id &&
-    left?.state === right?.state &&
-    left?.commit_id === right?.commit_id &&
-    left?.html_url === right?.html_url &&
-    left?.submitted_at === right?.submitted_at &&
-    left?.body === right?.body &&
-    left?.user?.id === right?.user?.id &&
-    left?.user?.type === right?.user?.type
-  );
 }
 
 function validateLinearCompare(value, baseSha, sourceSha, expectedCommitCount) {
@@ -2160,95 +2106,23 @@ export async function verifyApprovedMerge(options = {}) {
     "release source tree differs from the exact reviewed head",
   );
   const mergeMethod = await classifyMergeOutcome(api, source, pullIdentity);
-
-  const reviews = await paginatedArray(
-    api,
-    repositoryPath(`/pulls/${pullNumber}/reviews`),
-    "pull-request reviews",
-  );
-  const decisions = reviews
-    .flatMap((review) => {
-      const releaseApprover = RELEASE_AUTOMATION_CONTRACT.releaseApprovers.find((candidate) =>
-        hasStableIdentity(review?.user, candidate),
-      );
-      if (
-        releaseApprover === undefined ||
-        review.commit_id !== pullIdentity.headSha ||
-        (!decisiveReviewStates.has(review.state) &&
-          !(
-            review.state === "COMMENTED" &&
-            review.body?.startsWith("<!-- opengeni-exact-head-release-review:v3 -->")
-          ))
-      ) {
-        return [];
-      }
-      return [
-        {
-          id: assertPositiveInteger(review.id, "trusted review ID"),
-          releaseApprover,
-          review,
-          submittedAt: assertTimestamp(review.submitted_at, "trusted review timestamp"),
-        },
-      ];
-    })
-    .sort((left, right) => left.submittedAt - right.submittedAt || left.id - right.id);
-  invariant(decisions.length > 0, "trusted reviewer did not review the exact PR head");
-  const decision = decisions.at(-1);
-  invariant(
-    decision.submittedAt < pullIdentity.mergedAt,
-    "trusted approval was not submitted before merge",
-  );
-  assertIdentity(decision.review.user, decision.releaseApprover, "trusted reviewer");
   const reviewUrl =
     `${RELEASE_AUTOMATION_CONTRACT.serverUrl}/${RELEASE_AUTOMATION_CONTRACT.repository}` +
-    `/pull/${pullNumber}#pullrequestreview-${decision.id}`;
-  invariant(decision.review.html_url === reviewUrl, "trusted review URL changed");
-  const reviewDetail = await api.get(repositoryPath(`/pulls/${pullNumber}/reviews/${decision.id}`));
-  assertIdentity(reviewDetail?.user, decision.review.user, "trusted review detail actor");
-  invariant(
-    sameProviderReview(decision.review, reviewDetail),
-    "trusted review detail differs from provider review history",
-  );
-  invariant(
-    !pull.requested_reviewers.some((candidate) =>
-      hasStableIdentity(candidate, decision.releaseApprover),
-    ),
-    "trusted review is no longer effective because review was re-requested",
-  );
-
-  let reviewType;
-  let reviewEvidenceSha256;
-  if (decision.review.state === "APPROVED") {
-    invariant(
-      pullIdentity.author.id !== decision.releaseApprover.id,
-      "trusted reviewer authored the independently approved pull request",
-    );
-    reviewType = "independent-approval";
-    reviewEvidenceSha256 = canonicalSha256({
+    `/pull/${pullNumber}`;
+  const review = {
+    type: "merged-source",
+    id: pullNumber,
+    url: reviewUrl,
+    evidenceSha256: canonicalSha256({
       version: 1,
+      kind: "merged-source",
       repository: RELEASE_AUTOMATION_CONTRACT.repository,
       pullRequestNumber: pullNumber,
+      sourceSha: context.sourceSha,
       reviewedBaseSha: pullIdentity.baseSha,
       reviewedHeadSha: pullIdentity.headSha,
-      reviewerLogin: decision.releaseApprover.login,
-      reviewId: decision.id,
-      verdict: "APPROVED",
-    });
-  } else {
-    invariant(
-      decision.review.state === "COMMENTED" &&
-        pullIdentity.author.id === decision.releaseApprover.id &&
-        pullIdentity.merger.id === decision.releaseApprover.id &&
-        pullIdentity.author.type === "User" &&
-        pullIdentity.merger.type === "User",
-      "trusted review is neither independent approval nor a provider-bound single-maintainer admin PASS",
-    );
-    reviewType = "single-maintainer-admin-pass";
-    reviewEvidenceSha256 = verifyAdminPassBody(
-      decision.review.body ?? "",
-      exactHeadReviewArtifact(pullIdentity.baseSha, pullIdentity.headSha, decision.releaseApprover),
-    );
-  }
+    }),
+  };
 
   const releaseHeadTag = releaseHeadTagName(pullIdentity.headSha);
   const [headChecks, sourceChecks, releaseHeadRef, releaseHeadReleaseValue] = await Promise.all([
@@ -2321,12 +2195,7 @@ export async function verifyApprovedMerge(options = {}) {
       sha: pullIdentity.headSha,
     },
     releaseHeadRelease,
-    review: {
-      type: reviewType,
-      id: decision.id,
-      url: reviewUrl,
-      evidenceSha256: reviewEvidenceSha256,
-    },
+    review,
     sourceAdmission,
     requiredSourceChecks,
   };

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -2907,7 +2907,7 @@ describe("release approval provenance", () => {
     ).rejects.toThrow("terminal release main ancestry comparison is incomplete");
   });
 
-  test("accepts the provider-bound structured single-maintainer admin PASS", async () => {
+  test("records merged-source identity instead of a GitHub review PASS", async () => {
     const fixture = approvalFixture({
       mergeMethod: "single",
       reviewState: "COMMENTED",
@@ -2922,26 +2922,20 @@ describe("release approval provenance", () => {
       expect.objectContaining({
         mergeMethod: "single-commit-squash-or-rebase",
         review: expect.objectContaining({
-          type: "single-maintainer-admin-pass",
+          type: "merged-source",
+          id: pullNumber,
         }),
       }),
     );
   });
 
-  test("accepts a configured secondary maintainer's provider-bound admin PASS", async () => {
-    const secondaryMaintainer = RELEASE_AUTOMATION_CONTRACT.releaseApprovers[1];
-    expect(secondaryMaintainer).toEqual({
-      login: "davletd",
-      id: 2204825,
-      type: "User",
-    });
+  test("does not require a configured maintainer GitHub review", async () => {
     const fixture = approvalFixture({
       mergeMethod: "single",
       reviewState: "COMMENTED",
-      author: secondaryMaintainer,
-      merger: secondaryMaintainer,
-      reviewer: secondaryMaintainer,
-      reviewerLoginSnapshot: secondaryMaintainer.login,
+      author: RELEASE_AUTOMATION_CONTRACT.releaseApprovers[1],
+      merger: RELEASE_AUTOMATION_CONTRACT.releaseApprovers[1],
+      reviewer: RELEASE_AUTOMATION_CONTRACT.releaseApprovers[1],
     });
     await expect(
       verifyApprovedMerge({
@@ -2953,7 +2947,7 @@ describe("release approval provenance", () => {
       expect.objectContaining({
         mergeMethod: "single-commit-squash-or-rebase",
         review: expect.objectContaining({
-          type: "single-maintainer-admin-pass",
+          type: "merged-source",
         }),
       }),
     );
@@ -3043,129 +3037,6 @@ describe("release approval provenance", () => {
     ).rejects.toThrow("canonical recovered source-admission check is not unique");
   });
 
-  test("accepts reviewer login movement while preserving stable provider identity", async () => {
-    const reviewer = {
-      ...RELEASE_AUTOMATION_CONTRACT.releaseApprover,
-      login: "renamed-maintainer",
-    };
-    const fixture = approvalFixture({
-      reviewer,
-      reviewDetailReviewer: { ...reviewer, login: "Renamed-Maintainer" },
-    });
-    await expect(
-      verifyApprovedMerge({
-        env: approvalEnv(),
-        fetchImpl: fixture.fetchImpl,
-        logger: { log() {} },
-      }),
-    ).resolves.toEqual(
-      expect.objectContaining({
-        review: expect.objectContaining({ type: "independent-approval" }),
-      }),
-    );
-  });
-
-  test("treats the legacy v3 reviewer login as a snapshot, not account authority", async () => {
-    const fixture = approvalFixture({
-      mergeMethod: "single",
-      reviewState: "COMMENTED",
-      reviewer: {
-        ...RELEASE_AUTOMATION_CONTRACT.releaseApprover,
-        login: "renamed-maintainer",
-      },
-      reviewDetailReviewer: {
-        ...RELEASE_AUTOMATION_CONTRACT.releaseApprover,
-        login: "RENAMED-MAINTAINER",
-      },
-      reviewerLoginSnapshot: "former-maintainer-login",
-    });
-    const result = await verifyApprovedMerge({
-      env: approvalEnv(),
-      fetchImpl: fixture.fetchImpl,
-      logger: { log() {} },
-    });
-    expect(result).toEqual(
-      expect.objectContaining({
-        review: expect.objectContaining({
-          type: "single-maintainer-admin-pass",
-        }),
-      }),
-    );
-  });
-
-  test("rejects reviewer identity substitution and missing provider identity", async () => {
-    for (const [reviewDetailReviewer, message] of [
-      [
-        { ...RELEASE_AUTOMATION_CONTRACT.releaseApprover, id: 999 },
-        "trusted review detail actor numeric identity changed",
-      ],
-      [
-        { ...RELEASE_AUTOMATION_CONTRACT.releaseApprover, type: "Bot" },
-        "trusted review detail actor account type changed",
-      ],
-      [
-        {
-          login: RELEASE_AUTOMATION_CONTRACT.releaseApprover.login,
-          type: RELEASE_AUTOMATION_CONTRACT.releaseApprover.type,
-        },
-        "trusted review detail actor numeric identity is not a positive integer",
-      ],
-    ] as const) {
-      const fixture = approvalFixture({ reviewDetailReviewer });
-      await expect(
-        verifyApprovedMerge({
-          env: approvalEnv(),
-          fetchImpl: fixture.fetchImpl,
-        }),
-      ).rejects.toThrow(message);
-    }
-
-    const missingSnapshot = approvalFixture({
-      mergeMethod: "single",
-      reviewState: "COMMENTED",
-      reviewerLoginSnapshot: "",
-    });
-    await expect(
-      verifyApprovedMerge({
-        env: approvalEnv(),
-        fetchImpl: missingSnapshot.fetchImpl,
-      }),
-    ).rejects.toThrow("single-maintainer admin PASS reviewer login snapshot is missing");
-  });
-
-  test("rejects stale-head and post-merge approvals", async () => {
-    const stale = approvalFixture({ reviewCommit: "9".repeat(40) });
-    await expect(
-      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: stale.fetchImpl }),
-    ).rejects.toThrow("did not review the exact PR head");
-    const sameSecond = approvalFixture({ reviewTime: "2026-07-23T12:00:00Z" });
-    await expect(
-      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: sameSecond.fetchImpl }),
-    ).rejects.toThrow("was not submitted before merge");
-    const late = approvalFixture({ reviewTime: "2026-07-23T12:01:00Z" });
-    await expect(
-      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: late.fetchImpl }),
-    ).rejects.toThrow("was not submitted before merge");
-  });
-
-  test("rejects self-approval and a non-approval decision", async () => {
-    const self = approvalFixture({
-      authorId: RELEASE_AUTOMATION_CONTRACT.releaseApprover.id,
-    });
-    await expect(
-      verifyApprovedMerge({ env: approvalEnv(), fetchImpl: self.fetchImpl }),
-    ).rejects.toThrow("trusted reviewer authored the independently approved pull request");
-    const requested = approvalFixture({ reviewState: "CHANGES_REQUESTED" });
-    await expect(
-      verifyApprovedMerge({
-        env: approvalEnv(),
-        fetchImpl: requested.fetchImpl,
-      }),
-    ).rejects.toThrow(
-      "neither independent approval nor a provider-bound single-maintainer admin PASS",
-    );
-  });
-
   test("rejects direct pushes, ambiguous associations, and reopened or unmerged PRs", async () => {
     await expect(
       verifyApprovedMerge({
@@ -3196,7 +3067,7 @@ describe("release approval provenance", () => {
     ).rejects.toThrow("exactly one provider merge event");
   });
 
-  test("rejects tree, head, topology, effective-review, and terminal-main drift", async () => {
+  test("rejects tree, topology, and terminal-main drift", async () => {
     await expect(
       verifyApprovedMerge({
         env: approvalEnv(),
@@ -3207,32 +3078,11 @@ describe("release approval provenance", () => {
       verifyApprovedMerge({
         env: approvalEnv(),
         fetchImpl: approvalFixture({
-          pullHeadSha: "8".repeat(40),
-          reviewCommit: headSha,
-        }).fetchImpl,
-      }),
-    ).rejects.toThrow("did not review the exact PR head");
-    await expect(
-      verifyApprovedMerge({
-        env: approvalEnv(),
-        fetchImpl: approvalFixture({
           mergeMethod: "rebase",
           discontinuousCompare: true,
         }).fetchImpl,
       }),
     ).rejects.toThrow("discontinuity");
-    await expect(
-      verifyApprovedMerge({
-        env: approvalEnv(),
-        fetchImpl: approvalFixture({
-          requestedReview: true,
-          requestedReviewer: {
-            ...RELEASE_AUTOMATION_CONTRACT.releaseApprover,
-            login: "renamed-maintainer",
-          },
-        }).fetchImpl,
-      }),
-    ).rejects.toThrow("review was re-requested");
     await expect(
       verifyApprovedMerge({
         env: approvalEnv(),


### PR DESCRIPTION
## Summary
- Official candidate admission already proves one merged associated PR, trees, and required source checks.
- Drop the structured exact-head GitHub review PASS body from `verify-approved-merge`.

## Test plan
- [x] `bun test scripts/check-release-pr-automation.test.ts`

Made with [Cursor](https://cursor.com)