### PR TITLE
fix(agent): ship Linux browserd as glibc, not Alpine musl

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -135,22 +135,39 @@ jobs:
             "../opengeni-computer-native-${{ matrix.target }}"
           file "../${{ matrix.asset }}"
 
-      - name: Build interaction helpers (Linux musl)
+      # Linux interaction helpers must be OS-native glibc, matching Mac's host libc
+      # join. The agent itself stays static musl (portable parent). Bun's musl
+      # compile is dynamically linked against /lib/ld-musl-*.so.1, which Ubuntu,
+      # Fedora, Arch, and NixOS do not ship, so connected-machine browser sessions
+      # fail with ENOENT/driver_failed. A static musl parent can exec a glibc child.
+      - name: Build interaction helpers (Linux glibc)
         if: matrix.kind == 'linux'
         shell: bash
         run: |
           set -euo pipefail
           case "${{ matrix.target }}" in
-            x86_64-*) bun_target=bun-linux-x64-musl; browser_arch=x64 ;;
-            aarch64-*) bun_target=bun-linux-arm64-musl; browser_arch=arm64 ;;
+            x86_64-*) bun_target=bun-linux-x64; browser_arch=x64 ;;
+            aarch64-*) bun_target=bun-linux-arm64; browser_arch=arm64 ;;
             *) echo "unsupported Linux interaction target" >&2; exit 1 ;;
           esac
           bun build --compile --target="$bun_target" packages/browserd/src/main.ts \
             --define "process.env.OPENGENI_RUNTIME_BUILD_ID=\"${GITHUB_SHA}\"" \
             --outfile "opengeni-browserd-${{ matrix.target }}"
+          interp="$(readelf -l "opengeni-browserd-${{ matrix.target }}" | sed -n 's/.*program interpreter: \(.*\)]/\1/p')"
+          case "$interp" in
+            /lib64/ld-linux-x86-64.so.2|/lib/ld-linux-aarch64.so.1) ;;
+            *)
+              echo "::error::linux browserd must use the glibc dynamic linker; got ${interp:-<missing>}" >&2
+              exit 1
+              ;;
+          esac
+          if readelf -d "opengeni-browserd-${{ matrix.target }}" | grep -F 'libc.musl'; then
+            echo "::error::linux browserd must not link musl libc" >&2
+            exit 1
+          fi
           OPENGENI_BROWSERD_TARGET_PLATFORM=linux \
           OPENGENI_BROWSERD_TARGET_ARCH="$browser_arch" \
-          OPENGENI_BROWSERD_TARGET_MUSL=true \
+          OPENGENI_BROWSERD_TARGET_MUSL=false \
           OPENGENI_BROWSERD_AGENT_BROWSER_OUTPUT="opengeni-agent-browser-${{ matrix.target }}" \
             bun packages/browserd/scripts/stage-agent-browser.ts
           mv "packages/browserd/dist/opengeni-agent-browser-${{ matrix.target }}" .

--- a/scripts/release-image-workflow-contract.test.ts
+++ b/scripts/release-image-workflow-contract.test.ts
@@ -989,6 +989,20 @@ describe("release image workflow contract", () => {
     expect(agentRelease).not.toContain("releases/download/agent-latest");
   });
 
+  test("linux agent release embeds a glibc browserd sidecar", async () => {
+    const agentRelease = await workflow("agent-release.yml");
+
+    expect(agentRelease).toContain("Build interaction helpers (Linux glibc)");
+    expect(agentRelease).toContain("bun_target=bun-linux-x64;");
+    expect(agentRelease).toContain("bun_target=bun-linux-arm64;");
+    expect(agentRelease).toContain("OPENGENI_BROWSERD_TARGET_MUSL=false");
+    expect(agentRelease).toContain("linux browserd must use the glibc dynamic linker");
+    expect(agentRelease).not.toContain("bun-linux-x64-musl");
+    expect(agentRelease).not.toContain("bun-linux-arm64-musl");
+    expect(agentRelease).not.toContain("OPENGENI_BROWSERD_TARGET_MUSL=true");
+    expect(agentRelease).not.toContain("Build interaction helpers (Linux musl)");
+  });
+
   test("release-state parsing accepts a valid absent release without weakening type checks", async () => {
     const candidate = await workflow("release-candidate.yml");
     const release = await workflow("release.yml");


### PR DESCRIPTION
## Why

Connected-machine Linux `browserd` was compiled with `bun-linux-*-musl`. That Bun target is **dynamically** linked against `/lib/ld-musl-*.so.1`. Ubuntu, Fedora, Arch, and NixOS do not ship that loader, so `Command::spawn` returns ENOENT and BrowserSessions die as `driver_failed` before Chromium starts.

This is not NixOS-specific. The static musl **agent** is portable; the sidecar was not. Docker images already compile `browserd` on Debian/glibc. macOS already embeds an OS-native sidecar.

## Change

- Compile Linux helpers with `bun-linux-x64` / `bun-linux-arm64`.
- Stage `agent-browser` with `OPENGENI_BROWSERD_TARGET_MUSL=false`.
- Fail the release job if the sidecar still requests `ld-musl` or links `libc.musl`.
- Contract-test the workflow so this cannot regress.

The Rust agent remains `x86_64-unknown-linux-musl` via cargo-zigbuild. A static musl parent can exec a glibc child.

## Verify

On jorgebot (NixOS, no musl loader):

- old sidecar: `zsh: no such file or directory`
- new `bun-linux-x64` sidecar: INTERP `/lib64/ld-linux-x86-64.so.2`
- `POST /v1/browser-sessions` with `initialUrl=https://example.com` returned **HTTP 201**, title **Example Domain**
- workflow contract test: 19 pass

After merge, cut `agent-v0.1.17` so enrolled machines pick this up.