### PR TITLE
chore(agent): prepare v0.1.17 release

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1986,7 +1986,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opengeni-agent"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-linux-ffi"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "libc",
  "tokio",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-macos-ffi"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "accessibility-sys",
  "block2",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-platform"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "async-trait",
  "command-group",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-proto"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "prost",
  "prost-build",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-stream"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-agent-update"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "blake3",
  "hex",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-computer-native"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "arboard",
  "async-lock",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "opengeni-relay"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "async-trait",
  "axum",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 # we lean on clippy::pedantic at the workspace level and silence only the few
 # lints that fight generated code or add no value here.
 [workspace.package]
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"


### PR DESCRIPTION
Prepare Connected Machine agent v0.1.17 from current main so the next `agent-v0.1.17` tag builds the Linux glibc `opengeni-browserd` sidecar from #1649.

Linux helpers were previously compiled with Bun musl (`/lib/ld-musl-x86_64.so.1`). That interpreter is not present on NixOS, Ubuntu, Fedora, or Arch, so `browserd` failed with `ENOENT`. #1649 already switched the release workflow to glibc; this bump is the version cut that lets a signed agent release ship that sidecar.

Changes:
- bump the Rust agent workspace version to 0.1.17
- refresh workspace package versions in Cargo.lock

Intentionally unchanged:
- `packages/config` default `agentStableVersion` remains `0.1.16`
- `docs/deployment.md` / `.env.example` still document `0.1.16`

Promote `/agent/latest` only after the GitHub `agent-v0.1.17` release and signed assets exist.

Verification:
- lockfile edit is limited to workspace crates that inherit `version.workspace = true` (`opengeni-agent`, FFI, platform, proto, stream, update, computer-native, relay)
- `opengeni-agent-engine` (0.1.0) and `opengeni-agent-harness` (0.0.0) keep independent versions
- agent-release guard requires crate version == tag, so this must merge before tagging `agent-v0.1.17`