### PR TITLE
fix(web): fence workspace transitions (OPE-205)

### DIFF
--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -189,6 +189,7 @@ export function SwitcherBlock() {
       >
         <button
           type="button"
+          aria-label={`Workspace: ${activeWorkspace?.name ?? "none"}. Switch workspace`}
           className="group flex w-full items-center gap-2 rounded-md border border-border bg-surface-2/50 px-2 py-1.5 text-left transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
         >
           <Avatar size="sm" className="rounded-md">
@@ -255,6 +256,7 @@ function OrgLine(props: {
         {props.orgs.map((org) => (
           <DropdownMenuItem
             key={org.accountId}
+            aria-current={org.accountId === props.activeAccountId ? "true" : undefined}
             onSelect={() => {
               if (org.accountId !== props.activeAccountId) {
                 rail.openOrg(org.accountId);
@@ -317,7 +319,11 @@ function WorkspaceMenu(props: {
       >
         <DropdownMenuLabel className="text-fg-subtle">Workspaces</DropdownMenuLabel>
         {props.workspaces.map((workspace) => (
-          <DropdownMenuItem key={workspace.id} onSelect={() => props.onSelect(workspace.id)}>
+          <DropdownMenuItem
+            key={workspace.id}
+            aria-current={workspace.id === props.activeWorkspaceId ? "page" : undefined}
+            onSelect={() => props.onSelect(workspace.id)}
+          >
             <span className="flex size-5 items-center justify-center rounded bg-surface-3 text-2xs font-semibold">
               {workspaceInitial(workspace)}
             </span>

--- a/apps/web/src/components/workspace-tenant-boundary.test.tsx
+++ b/apps/web/src/components/workspace-tenant-boundary.test.tsx
@@ -1,0 +1,55 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { WorkspaceTenantBoundary } from "./workspace-tenant-boundary";
+
+GlobalRegistrator.register();
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+afterAll(() => {
+  GlobalRegistrator.unregister();
+});
+
+describe("WorkspaceTenantBoundary", () => {
+  test("never commits the previous workspace surface under a new route", async () => {
+    const transitions: string[] = [];
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <WorkspaceTenantBoundary
+          workspaceId="workspace-b"
+          stateOwnerWorkspaceId="workspace-a"
+          prepareTransition={(workspaceId) => transitions.push(workspaceId)}
+        >
+          <button type="button">Workspace A action</button>
+        </WorkspaceTenantBoundary>,
+      );
+    });
+
+    expect(container.textContent).toContain("Switching workspace");
+    expect(container.textContent).not.toContain("Workspace A action");
+    expect(transitions).toEqual(["workspace-b"]);
+
+    await act(async () => {
+      root.render(
+        <WorkspaceTenantBoundary
+          workspaceId="workspace-b"
+          stateOwnerWorkspaceId="workspace-b"
+          prepareTransition={(workspaceId) => transitions.push(workspaceId)}
+        >
+          <button type="button">Workspace B action</button>
+        </WorkspaceTenantBoundary>,
+      );
+    });
+
+    expect(container.textContent).toContain("Workspace B action");
+    expect(container.textContent).not.toContain("Switching workspace");
+    expect(transitions).toEqual(["workspace-b"]);
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/components/workspace-tenant-boundary.tsx
+++ b/apps/web/src/components/workspace-tenant-boundary.tsx
@@ -1,0 +1,31 @@
+import { useLayoutEffect, type ReactNode } from "react";
+
+import { LoadingPanel } from "@/components/common";
+
+/**
+ * A display-only fence between the routed workspace and mutable console state.
+ * Server grants remain the authority. This boundary only prevents a newly
+ * routed workspace from rendering with the previous workspace's cached UI
+ * state while the provider clears that state.
+ */
+export function WorkspaceTenantBoundary(props: {
+  workspaceId: string;
+  stateOwnerWorkspaceId: string | null;
+  prepareTransition: (workspaceId: string) => void;
+  children: ReactNode;
+}) {
+  const { children, prepareTransition, stateOwnerWorkspaceId, workspaceId } = props;
+  const ready = stateOwnerWorkspaceId === workspaceId;
+
+  useLayoutEffect(() => {
+    if (!ready) {
+      prepareTransition(workspaceId);
+    }
+  }, [prepareTransition, ready, workspaceId]);
+
+  if (!ready) {
+    return <LoadingPanel label="Switching workspace" />;
+  }
+
+  return children;
+}

--- a/apps/web/src/context-principal-transition.test.ts
+++ b/apps/web/src/context-principal-transition.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  beginWorkspaceOperation,
+  beginWorkspaceTransition,
+  invalidateWorkspaceTransition,
+  ownsWorkspaceOperation,
+  settleWorkspaceOperation,
+} from "./lib/workspace-transition";
+
+const contextSource = await Bun.file(`${import.meta.dir}/context.tsx`).text();
+
+function sourceBetween(start: string, end: string): string {
+  const startIndex = contextSource.indexOf(start);
+  const endIndex = contextSource.indexOf(end, startIndex + start.length);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return contextSource.slice(startIndex, endIndex);
+}
+
+describe("principal transition contract", () => {
+  test("every credential and managed-principal mutation uses the complete invalidation seam", () => {
+    expect(sourceBetween("function saveAccessKey()", "function forgetAccessKey()")).toContain(
+      "invalidatePrincipalWorkspaceState();",
+    );
+    expect(
+      sourceBetween("function forgetAccessKey()", "async function handleManagedAuth("),
+    ).toContain("invalidatePrincipalWorkspaceState();");
+    expect(
+      sourceBetween("async function handleManagedAuth(", "async function handleManagedSignOut()"),
+    ).toContain("invalidatePrincipalWorkspaceState();");
+    expect(
+      sourceBetween("async function handleManagedSignOut()", "const contextAddManualRepository"),
+    ).toContain("invalidatePrincipalWorkspaceState();");
+
+    const invalidation = sourceBetween(
+      "const invalidatePrincipalWorkspaceState",
+      "useEffect(() => {",
+    );
+    expect(invalidation).toContain("resetWorkspaceState(null, true)");
+
+    const reset = sourceBetween("const resetWorkspaceState", "const prepareWorkspaceTransition");
+    for (const requiredFence of [
+      "activeCreateOperation.current = null",
+      "pendingCreateAttempt.current = null",
+      "githubRefreshId.current += 1",
+      "mcpRefreshId.current += 1",
+      "setManualRepos([])",
+      "setSelectedRepoIds(new Set())",
+      "setSelectedCapabilityToolIds(new Set())",
+      "setWorkspaceStateOwnerId(workspaceId)",
+    ]) {
+      expect(reset).toContain(requiredFence);
+    }
+  });
+
+  test("an old-credential create cannot install after same-route principal replacement", () => {
+    const original = beginWorkspaceTransition({ workspaceId: null, revision: 0 }, "workspace-a");
+    const started = beginWorkspaceOperation(0, original.identity);
+
+    // Access-key replacement, sign-out, and sign-in all run this same forced
+    // invalidation before the route is rebound to the new principal.
+    const invalidated = invalidateWorkspaceTransition(original.identity);
+    const rebound = beginWorkspaceTransition(invalidated, "workspace-a");
+    const active = null;
+
+    expect(ownsWorkspaceOperation(active, rebound.identity, started.operation, "workspace-a")).toBe(
+      false,
+    );
+    expect(settleWorkspaceOperation(active, started.operation)).toEqual({
+      active: null,
+      settledCurrent: false,
+    });
+  });
+
+  test("session creation and MCP refresh consume the shared transition fences", () => {
+    const startSession = sourceBetween(
+      "async function startSession(",
+      "async function startGitHubAppManifestFlow",
+    );
+    expect(startSession).toContain("beginWorkspaceOperation(");
+    expect(startSession).toContain("activeCreateOperation.current = operation");
+    expect(startSession.match(/ownsWorkspaceOperation\(/g)).toHaveLength(2);
+    expect(startSession).toContain(
+      "settleWorkspaceOperation(activeCreateOperation.current, operation)",
+    );
+
+    const refreshMcp = sourceBetween(
+      "const refreshWorkspaceMcpServers",
+      "async function startSession(",
+    );
+    expect(refreshMcp).toContain("runCurrentWorkspaceRequest({");
+    expect(refreshMcp).toContain("currentRequestId: () => mcpRefreshId.current");
+  });
+});

--- a/apps/web/src/context-principal-transition.test.ts
+++ b/apps/web/src/context-principal-transition.test.ts
@@ -92,4 +92,52 @@ describe("principal transition contract", () => {
     expect(refreshMcp).toContain("runCurrentWorkspaceRequest({");
     expect(refreshMcp).toContain("currentRequestId: () => mcpRefreshId.current");
   });
+
+  test("every asynchronous GitHub mutation is invocation-bound before UI effects", () => {
+    const refresh = sourceBetween("const refreshGitHub", "const refreshWorkspaceMcpServers");
+    expect(refresh).toContain("const acceptedTransition = workspaceTransitionIdentity.current");
+    expect(refresh).toContain("!ownsRefresh()");
+
+    const manifest = sourceBetween(
+      "async function startGitHubAppManifestFlow",
+      "async function disconnectGitHubInstallation",
+    );
+    expect(manifest).toContain("runCurrentWorkspaceOperation({");
+    expect(manifest.indexOf("ownsWorkspaceOperation(")).toBeLessThan(
+      manifest.indexOf("submitGitHubManifest("),
+    );
+
+    const disconnect = sourceBetween(
+      "async function disconnectGitHubInstallation",
+      "function toggleGitHubRepository",
+    );
+    expect(disconnect).toContain("runCurrentWorkspaceOperation({");
+    expect(disconnect.indexOf("ownsWorkspaceOperation(")).toBeLessThan(
+      disconnect.indexOf("await refreshGitHub("),
+    );
+  });
+
+  test("workspace refreshes used by Slack cannot upsert after their route transition", () => {
+    const refreshWorkspace = sourceBetween(
+      "const refreshWorkspace = useCallback",
+      "async function updateWorkspaceSettings",
+    );
+    expect(refreshWorkspace).toContain("captureWorkspaceInvocation(workspaceId)");
+    expect(refreshWorkspace.indexOf("ownsWorkspaceInvocation(")).toBeLessThan(
+      refreshWorkspace.indexOf("setWorkspaces("),
+    );
+  });
+
+  test("ambiguous managed sign-out reconciles the cookie before access reload", () => {
+    const signOut = sourceBetween(
+      "async function handleManagedSignOut()",
+      "const contextAddManualRepository",
+    );
+    expect(signOut).not.toContain("previousAuthSession");
+    expect(signOut).toContain("signOutWithAuthoritativeReconciliation<AuthSession>");
+    expect(signOut).toContain("readSession: fetchAuthSession");
+    expect(signOut.indexOf("setAuthSession(result.session)")).toBeLessThan(
+      signOut.indexOf("setAccessKeyVersion((version) => version + 1)"),
+    );
+  });
 });

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -71,8 +71,13 @@ import {
 } from "@/lib/session-tools";
 import { upsertWorkspace } from "@/lib/workspaces";
 import {
+  beginWorkspaceOperation,
   beginWorkspaceTransition,
-  ownsWorkspaceTransition,
+  invalidateWorkspaceTransition,
+  ownsWorkspaceOperation,
+  runCurrentWorkspaceRequest,
+  settleWorkspaceOperation,
+  type WorkspaceOperationIdentity,
   type WorkspaceTransitionIdentity,
 } from "@/lib/workspace-transition";
 import type {
@@ -424,6 +429,10 @@ export function RootRouteComponent() {
     workspaceId: null,
     revision: 0,
   });
+  const workspaceOperationSequence = useRef(0);
+  const activeCreateOperation = useRef<WorkspaceOperationIdentity | null>(null);
+  const authPrincipalIdRef = useRef<string | null>(null);
+  const accessPrincipalIdRef = useRef<string | null>(null);
   // Every available tool is selected when it first appears. Explicit
   // deselections survive subsequent catalog refreshes.
   const previousCapabilityToolIds = useRef<Set<string>>(new Set());
@@ -488,6 +497,72 @@ export function RootRouteComponent() {
     });
   }, []);
 
+  const resetSessionView = useCallback(() => {
+    setSession(null);
+    setConnectionState("idle");
+    sessionEventFeedStore.set(null);
+  }, [sessionEventFeedStore, setSession]);
+
+  const resetWorkspaceIntegrations = useCallback(() => {
+    setGithubStatus(null);
+    setGithubStatusFailed(false);
+    setGithubRepos([]);
+    setGithubCatalogReady(false);
+    setWorkspaceMcpServers([]);
+    setWorkspaceCapabilityCatalog([]);
+    setWorkspaceMcpCatalogReady(false);
+  }, []);
+
+  const resetWorkspaceState = useCallback(
+    (workspaceId: string | null, force: boolean) => {
+      const transition =
+        workspaceId === null
+          ? {
+              identity: invalidateWorkspaceTransition(workspaceTransitionIdentity.current),
+              changed: true,
+            }
+          : beginWorkspaceTransition(workspaceTransitionIdentity.current, workspaceId);
+      if (!force && !transition.changed) {
+        return;
+      }
+      workspaceTransitionIdentity.current = transition.identity;
+      activeCreateOperation.current = null;
+      // Fence late non-abortable catalog/status responses before clearing the
+      // projections they would otherwise be able to repopulate.
+      githubRefreshId.current += 1;
+      mcpRefreshId.current += 1;
+      pendingCreateAttempt.current = null;
+      resetSessionView();
+      setInspectorOpen(false);
+      setManualRepos([]);
+      setManualReposOpen(false);
+      setNextRepoId(1);
+      setSelectedRepoIds(new Set());
+      setSelectedRepoRefs({});
+      setSelectedCapabilityToolIds(new Set());
+      previousCapabilityToolIds.current = new Set();
+      setGithubAppOpen(false);
+      setGithubOrg("");
+      setBusy(false);
+      setRepoBusy(false);
+      setGithubAppBusy(false);
+      resetWorkspaceIntegrations();
+      setWorkspaceStateOwnerId(workspaceId);
+    },
+    [resetSessionView, resetWorkspaceIntegrations],
+  );
+
+  const prepareWorkspaceTransition = useCallback(
+    (workspaceId: string) => resetWorkspaceState(workspaceId, false),
+    [resetWorkspaceState],
+  );
+
+  const invalidatePrincipalWorkspaceState = useCallback(() => {
+    authPrincipalIdRef.current = null;
+    accessPrincipalIdRef.current = null;
+    resetWorkspaceState(null, true);
+  }, [resetWorkspaceState]);
+
   useEffect(() => {
     if (isPublicDevHarness) return;
     let cancelled = false;
@@ -524,6 +599,9 @@ export function RootRouteComponent() {
       return;
     }
     if (clientConfig.auth.mode !== "managedSession") {
+      if (authPrincipalIdRef.current !== null) {
+        invalidatePrincipalWorkspaceState();
+      }
       setAuthSession(null);
       return;
     }
@@ -532,6 +610,14 @@ export function RootRouteComponent() {
     void fetchAuthSession()
       .then((nextSession) => {
         if (!cancelled) {
+          const nextPrincipalId = nextSession?.user.id ?? null;
+          if (
+            authPrincipalIdRef.current !== null &&
+            authPrincipalIdRef.current !== nextPrincipalId
+          ) {
+            invalidatePrincipalWorkspaceState();
+          }
+          authPrincipalIdRef.current = nextPrincipalId;
           setAuthSession(nextSession);
         }
       })
@@ -543,7 +629,7 @@ export function RootRouteComponent() {
     return () => {
       cancelled = true;
     };
-  }, [clientConfig]);
+  }, [clientConfig, invalidatePrincipalWorkspaceState]);
 
   useEffect(() => {
     if (!clientConfig || !authReady) {
@@ -561,6 +647,13 @@ export function RootRouteComponent() {
         if (cancelled) {
           return;
         }
+        if (
+          accessPrincipalIdRef.current !== null &&
+          accessPrincipalIdRef.current !== context.subjectId
+        ) {
+          invalidatePrincipalWorkspaceState();
+        }
+        accessPrincipalIdRef.current = context.subjectId;
         setAccessContext(context);
         setWorkspaces(nextWorkspaces);
       })
@@ -583,7 +676,7 @@ export function RootRouteComponent() {
     return () => {
       cancelled = true;
     };
-  }, [clientConfig, authReady, client]);
+  }, [clientConfig, authReady, client, invalidatePrincipalWorkspaceState]);
 
   const selectedInstalledRepositories = githubRepos.filter((repo) => selectedRepoIds.has(repo.id));
   const selectedInstallationId = selectedInstalledRepositories[0]?.installationId ?? null;
@@ -911,17 +1004,24 @@ export function RootRouteComponent() {
       const refreshId = mcpRefreshId.current + 1;
       mcpRefreshId.current = refreshId;
       const requestKey = `${accessKeyVersion}:${workspaceId}`;
-      const [catalog, apiIntegrations] = await Promise.all([
-        runSingleFlight(
-          mcpCatalogRequests.current,
-          requestKey,
-          async () => await client.listCapabilities(workspaceId),
-        ),
-        client.listApiIntegrations(workspaceId),
-      ]);
-      if (signal?.aborted || mcpRefreshId.current !== refreshId) {
+      const result = await runCurrentWorkspaceRequest({
+        signal,
+        requestId: refreshId,
+        currentRequestId: () => mcpRefreshId.current,
+        request: async () =>
+          await Promise.all([
+            runSingleFlight(
+              mcpCatalogRequests.current,
+              requestKey,
+              async () => await client.listCapabilities(workspaceId),
+            ),
+            client.listApiIntegrations(workspaceId),
+          ]),
+      });
+      if (!result) {
         return;
       }
+      const [catalog, apiIntegrations] = result;
       setWorkspaceMcpServers(
         mergeMcpServerOptions(
           enabledWorkspaceCapabilityMcpServers(catalog.items),
@@ -948,7 +1048,13 @@ export function RootRouteComponent() {
       startMode?: "realtime";
     },
   ): Promise<Session | null> {
-    const acceptedWorkspaceTransition = workspaceTransitionIdentity.current;
+    const startedOperation = beginWorkspaceOperation(
+      workspaceOperationSequence.current,
+      workspaceTransitionIdentity.current,
+    );
+    workspaceOperationSequence.current = startedOperation.sequence;
+    const operation = startedOperation.operation;
+    activeCreateOperation.current = operation;
     setBusy(true);
     try {
       const sessionTools = options?.sessionTools;
@@ -996,9 +1102,10 @@ export function RootRouteComponent() {
       // server result remains valid, but it must not repopulate or navigate the
       // new workspace's UI with the previous tenant's session.
       if (
-        !ownsWorkspaceTransition(
+        !ownsWorkspaceOperation(
+          activeCreateOperation.current,
           workspaceTransitionIdentity.current,
-          acceptedWorkspaceTransition,
+          operation,
           workspaceId,
         )
       ) {
@@ -1018,12 +1125,26 @@ export function RootRouteComponent() {
     } catch (error) {
       // Keep the attempt on failure. An exact retry dedups against a create that
       // may have landed server-side; an edited request acquires a fresh key.
-      toast.error("Failed to start session", {
-        description: error instanceof Error ? composerSubmissionErrorMessage(error) : String(error),
-      });
+      if (
+        ownsWorkspaceOperation(
+          activeCreateOperation.current,
+          workspaceTransitionIdentity.current,
+          operation,
+          workspaceId,
+        )
+      ) {
+        toast.error("Failed to start session", {
+          description:
+            error instanceof Error ? composerSubmissionErrorMessage(error) : String(error),
+        });
+      }
       return null;
     } finally {
-      setBusy(false);
+      const settlement = settleWorkspaceOperation(activeCreateOperation.current, operation);
+      activeCreateOperation.current = settlement.active;
+      if (settlement.settledCurrent) {
+        setBusy(false);
+      }
     }
   }
 
@@ -1115,6 +1236,7 @@ export function RootRouteComponent() {
       toast.error("Enter an access key");
       return;
     }
+    invalidatePrincipalWorkspaceState();
     setStoredAccessKey(key);
     setHasAccessKey(true);
     setAccessKeyDraft("");
@@ -1123,6 +1245,7 @@ export function RootRouteComponent() {
   }
 
   function forgetAccessKey() {
+    invalidatePrincipalWorkspaceState();
     clearStoredAccessKey();
     setHasAccessKey(false);
     setSession(null);
@@ -1136,6 +1259,7 @@ export function RootRouteComponent() {
     mode: "signin" | "signup",
     input: { name: string; email: string; password: string },
   ) {
+    invalidatePrincipalWorkspaceState();
     if (mode === "signup") {
       await signUpEmail(input);
       captureProductAnalyticsEvent("signup_submitted", {
@@ -1150,6 +1274,7 @@ export function RootRouteComponent() {
       });
     }
     const nextSession = await fetchAuthSession();
+    authPrincipalIdRef.current = nextSession?.user.id ?? null;
     setAuthSession(nextSession);
     setAccessKeyVersion((version) => version + 1);
     if (!nextSession && mode === "signup") {
@@ -1158,7 +1283,19 @@ export function RootRouteComponent() {
   }
 
   async function handleManagedSignOut() {
-    await signOutManaged();
+    const previousAuthSession = authSession;
+    invalidatePrincipalWorkspaceState();
+    // Hide the authenticated tree while the cookie mutation is in flight. If
+    // the request fails, force a fresh authoritative session/access read rather
+    // than reopening the cached principal.
+    setAuthSession(undefined);
+    try {
+      await signOutManaged();
+    } catch (error) {
+      setAuthSession(previousAuthSession);
+      setAccessKeyVersion((version) => version + 1);
+      throw error;
+    }
     setAuthSession(null);
     setAccessContext(null);
     setWorkspaces([]);
@@ -1167,54 +1304,6 @@ export function RootRouteComponent() {
     setAccessKeyVersion((version) => version + 1);
     await navigate({ to: "/", replace: true });
   }
-
-  const resetSessionView = useCallback(() => {
-    setSession(null);
-    setConnectionState("idle");
-    sessionEventFeedStore.set(null);
-  }, [sessionEventFeedStore, setSession]);
-
-  const resetWorkspaceIntegrations = useCallback(() => {
-    setGithubStatus(null);
-    setGithubStatusFailed(false);
-    setGithubRepos([]);
-    setGithubCatalogReady(false);
-    setWorkspaceMcpServers([]);
-    setWorkspaceCapabilityCatalog([]);
-    setWorkspaceMcpCatalogReady(false);
-  }, []);
-
-  const prepareWorkspaceTransition = useCallback(
-    (workspaceId: string) => {
-      const transition = beginWorkspaceTransition(workspaceTransitionIdentity.current, workspaceId);
-      if (!transition.changed) {
-        return;
-      }
-      workspaceTransitionIdentity.current = transition.identity;
-      // Fence late non-abortable catalog/status responses before clearing the
-      // projections they would otherwise be able to repopulate.
-      githubRefreshId.current += 1;
-      mcpRefreshId.current += 1;
-      pendingCreateAttempt.current = null;
-      resetSessionView();
-      setInspectorOpen(false);
-      setManualRepos([]);
-      setManualReposOpen(false);
-      setNextRepoId(1);
-      setSelectedRepoIds(new Set());
-      setSelectedRepoRefs({});
-      setSelectedCapabilityToolIds(new Set());
-      previousCapabilityToolIds.current = new Set();
-      setGithubAppOpen(false);
-      setGithubOrg("");
-      setBusy(false);
-      setRepoBusy(false);
-      setGithubAppBusy(false);
-      resetWorkspaceIntegrations();
-      setWorkspaceStateOwnerId(workspaceId);
-    },
-    [resetSessionView, resetWorkspaceIntegrations],
-  );
 
   // Context actions keep one identity while reading the newest committed state
   // through the callback ref. This prevents unrelated provider renders

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -70,6 +70,11 @@ import {
   type RepositoryGroup,
 } from "@/lib/session-tools";
 import { upsertWorkspace } from "@/lib/workspaces";
+import {
+  beginWorkspaceTransition,
+  ownsWorkspaceTransition,
+  type WorkspaceTransitionIdentity,
+} from "@/lib/workspace-transition";
 import type {
   AccessContext,
   AuthSession,
@@ -166,6 +171,13 @@ export type AppContextValue = {
   /** The authoritative workspace catalog, shared by tool policy and timeline presentation. */
   workspaceCapabilityCatalog: CapabilityCatalogItem[];
   currentResources: ResourceRef[];
+  /**
+   * Workspace whose mutable console state is currently safe to render.
+   * This is a display fence only; server access grants remain authoritative.
+   */
+  workspaceStateOwnerId: string | null;
+  /** Clear and rebind every workspace/session-local draft and cache before display. */
+  prepareWorkspaceTransition: (workspaceId: string) => void;
   addManualRepository: () => void;
   forgetAccessKey: () => void;
   handleManagedSignOut: () => Promise<void>;
@@ -407,6 +419,11 @@ export function RootRouteComponent() {
   const [selectedCapabilityToolIds, setSelectedCapabilityToolIds] = useState<Set<string>>(
     () => new Set(),
   );
+  const [workspaceStateOwnerId, setWorkspaceStateOwnerId] = useState<string | null>(null);
+  const workspaceTransitionIdentity = useRef<WorkspaceTransitionIdentity>({
+    workspaceId: null,
+    revision: 0,
+  });
   // Every available tool is selected when it first appears. Explicit
   // deselections survive subsequent catalog refreshes.
   const previousCapabilityToolIds = useRef<Set<string>>(new Set());
@@ -931,6 +948,7 @@ export function RootRouteComponent() {
       startMode?: "realtime";
     },
   ): Promise<Session | null> {
+    const acceptedWorkspaceTransition = workspaceTransitionIdentity.current;
     setBusy(true);
     try {
       const sessionTools = options?.sessionTools;
@@ -973,6 +991,18 @@ export function RootRouteComponent() {
       // Do not clear a newer concurrent attempt that replaced this one.
       if (pendingCreateAttempt.current?.idempotencyKey === attempt.pending.idempotencyKey) {
         pendingCreateAttempt.current = null;
+      }
+      // The create may commit after the operator has switched workspaces. The
+      // server result remains valid, but it must not repopulate or navigate the
+      // new workspace's UI with the previous tenant's session.
+      if (
+        !ownsWorkspaceTransition(
+          workspaceTransitionIdentity.current,
+          acceptedWorkspaceTransition,
+          workspaceId,
+        )
+      ) {
+        return null;
       }
       setSession(created);
       setConnectionState("idle");
@@ -1154,6 +1184,38 @@ export function RootRouteComponent() {
     setWorkspaceMcpCatalogReady(false);
   }, []);
 
+  const prepareWorkspaceTransition = useCallback(
+    (workspaceId: string) => {
+      const transition = beginWorkspaceTransition(workspaceTransitionIdentity.current, workspaceId);
+      if (!transition.changed) {
+        return;
+      }
+      workspaceTransitionIdentity.current = transition.identity;
+      // Fence late non-abortable catalog/status responses before clearing the
+      // projections they would otherwise be able to repopulate.
+      githubRefreshId.current += 1;
+      mcpRefreshId.current += 1;
+      pendingCreateAttempt.current = null;
+      resetSessionView();
+      setInspectorOpen(false);
+      setManualRepos([]);
+      setManualReposOpen(false);
+      setNextRepoId(1);
+      setSelectedRepoIds(new Set());
+      setSelectedRepoRefs({});
+      setSelectedCapabilityToolIds(new Set());
+      previousCapabilityToolIds.current = new Set();
+      setGithubAppOpen(false);
+      setGithubOrg("");
+      setBusy(false);
+      setRepoBusy(false);
+      setGithubAppBusy(false);
+      resetWorkspaceIntegrations();
+      setWorkspaceStateOwnerId(workspaceId);
+    },
+    [resetSessionView, resetWorkspaceIntegrations],
+  );
+
   // Context actions keep one identity while reading the newest committed state
   // through the callback ref. This prevents unrelated provider renders
   // (for example, an access-key draft keystroke) from invalidating the entire
@@ -1240,6 +1302,8 @@ export function RootRouteComponent() {
           workspaceMcpCatalogReady,
           workspaceCapabilityCatalog,
           currentResources,
+          workspaceStateOwnerId,
+          prepareWorkspaceTransition,
           addManualRepository: contextAddManualRepository,
           forgetAccessKey: contextForgetAccessKey,
           handleManagedSignOut: contextHandleManagedSignOut,
@@ -1300,6 +1364,7 @@ export function RootRouteComponent() {
     manualReposOpen,
     model,
     preparePendingSlackLink,
+    prepareWorkspaceTransition,
     slackLinkContinuationWorkspaceId,
     latencyMode,
     reasoningEffort,
@@ -1320,6 +1385,7 @@ export function RootRouteComponent() {
     toolMcpServers,
     workspaceMcpCatalogReady,
     workspaceCapabilityCatalog,
+    workspaceStateOwnerId,
     workspaces,
   ]);
 

--- a/apps/web/src/context.tsx
+++ b/apps/web/src/context.tsx
@@ -41,6 +41,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { AnalyticsEventName, AnalyticsProperties } from "@/lib/analytics";
+import { signOutWithAuthoritativeReconciliation } from "@/lib/managed-auth-transition";
 import { sameSessionForContext } from "@/lib/session-context";
 import { runSingleFlight } from "@/lib/single-flight";
 import {
@@ -75,6 +76,8 @@ import {
   beginWorkspaceTransition,
   invalidateWorkspaceTransition,
   ownsWorkspaceOperation,
+  ownsWorkspaceTransition,
+  runCurrentWorkspaceOperation,
   runCurrentWorkspaceRequest,
   settleWorkspaceOperation,
   type WorkspaceOperationIdentity,
@@ -183,6 +186,10 @@ export type AppContextValue = {
   workspaceStateOwnerId: string | null;
   /** Clear and rebind every workspace/session-local draft and cache before display. */
   prepareWorkspaceTransition: (workspaceId: string) => void;
+  /** Capture the exact routed workspace/principal transition for one async invocation. */
+  captureWorkspaceInvocation: (workspaceId: string) => WorkspaceTransitionIdentity | null;
+  /** True only while an invocation still owns the routed workspace/principal UI. */
+  ownsWorkspaceInvocation: (workspaceId: string, accepted: WorkspaceTransitionIdentity) => boolean;
   addManualRepository: () => void;
   forgetAccessKey: () => void;
   handleManagedSignOut: () => Promise<void>;
@@ -431,6 +438,10 @@ export function RootRouteComponent() {
   });
   const workspaceOperationSequence = useRef(0);
   const activeCreateOperation = useRef<WorkspaceOperationIdentity | null>(null);
+  const githubManifestOperationSequence = useRef(0);
+  const activeGitHubManifestOperation = useRef<WorkspaceOperationIdentity | null>(null);
+  const githubDisconnectOperationSequence = useRef(0);
+  const activeGitHubDisconnectOperation = useRef<WorkspaceOperationIdentity | null>(null);
   const authPrincipalIdRef = useRef<string | null>(null);
   const accessPrincipalIdRef = useRef<string | null>(null);
   // Every available tool is selected when it first appears. Explicit
@@ -527,6 +538,8 @@ export function RootRouteComponent() {
       }
       workspaceTransitionIdentity.current = transition.identity;
       activeCreateOperation.current = null;
+      activeGitHubManifestOperation.current = null;
+      activeGitHubDisconnectOperation.current = null;
       // Fence late non-abortable catalog/status responses before clearing the
       // projections they would otherwise be able to repopulate.
       githubRefreshId.current += 1;
@@ -555,6 +568,20 @@ export function RootRouteComponent() {
   const prepareWorkspaceTransition = useCallback(
     (workspaceId: string) => resetWorkspaceState(workspaceId, false),
     [resetWorkspaceState],
+  );
+
+  const captureWorkspaceInvocation = useCallback(
+    (workspaceId: string): WorkspaceTransitionIdentity | null => {
+      const accepted = workspaceTransitionIdentity.current;
+      return ownsWorkspaceTransition(accepted, accepted, workspaceId) ? accepted : null;
+    },
+    [],
+  );
+
+  const ownsWorkspaceInvocation = useCallback(
+    (workspaceId: string, accepted: WorkspaceTransitionIdentity): boolean =>
+      ownsWorkspaceTransition(workspaceTransitionIdentity.current, accepted, workspaceId),
+    [],
   );
 
   const invalidatePrincipalWorkspaceState = useCallback(() => {
@@ -776,10 +803,13 @@ export function RootRouteComponent() {
 
   const refreshWorkspace = useCallback(
     async (workspaceId: string): Promise<void> => {
+      const acceptedTransition = captureWorkspaceInvocation(workspaceId);
+      if (!acceptedTransition) return;
       const updated = await client.getWorkspace(workspaceId);
+      if (!ownsWorkspaceInvocation(workspaceId, acceptedTransition)) return;
       setWorkspaces((current) => upsertWorkspace(current, updated));
     },
-    [client],
+    [captureWorkspaceInvocation, client, ownsWorkspaceInvocation],
   );
 
   // Settings PATCH deep-merges server-side; upsert the returned workspace so the
@@ -951,12 +981,22 @@ export function RootRouteComponent() {
 
   const refreshGitHub = useCallback(
     async (workspaceId: string, signal?: AbortSignal, options?: { sync?: boolean }) => {
+      const acceptedTransition = workspaceTransitionIdentity.current;
+      if (!ownsWorkspaceTransition(acceptedTransition, acceptedTransition, workspaceId)) {
+        return;
+      }
+      const ownsRefresh = () =>
+        ownsWorkspaceTransition(
+          workspaceTransitionIdentity.current,
+          acceptedTransition,
+          workspaceId,
+        );
       const refreshId = githubRefreshId.current + 1;
       githubRefreshId.current = refreshId;
       setRepoBusy(true);
       try {
         const status = await client.getGitHubApp(workspaceId);
-        if (signal?.aborted || githubRefreshId.current !== refreshId) {
+        if (signal?.aborted || githubRefreshId.current !== refreshId || !ownsRefresh()) {
           return;
         }
         setGithubStatus(status);
@@ -969,7 +1009,7 @@ export function RootRouteComponent() {
           const { repositories } = options?.sync
             ? await client.syncGitHubRepositories(workspaceId)
             : await client.listGitHubRepositories(workspaceId);
-          if (signal?.aborted || githubRefreshId.current !== refreshId) {
+          if (signal?.aborted || githubRefreshId.current !== refreshId || !ownsRefresh()) {
             return;
           }
           setGithubRepos(repositories);
@@ -979,7 +1019,12 @@ export function RootRouteComponent() {
           setGithubCatalogReady(true);
         }
       } catch (error) {
-        if (isAbortError(error) || signal?.aborted || githubRefreshId.current !== refreshId) {
+        if (
+          isAbortError(error) ||
+          signal?.aborted ||
+          githubRefreshId.current !== refreshId ||
+          !ownsRefresh()
+        ) {
           return;
         }
         // A failed status/catalog request is unavailable/unknown, not proof
@@ -991,7 +1036,7 @@ export function RootRouteComponent() {
           description: String(error),
         });
       } finally {
-        if (githubRefreshId.current === refreshId) {
+        if (githubRefreshId.current === refreshId && ownsRefresh()) {
           setRepoBusy(false);
         }
       }
@@ -1149,19 +1194,60 @@ export function RootRouteComponent() {
   }
 
   async function startGitHubAppManifestFlow(workspaceId: string) {
+    const acceptedTransition = captureWorkspaceInvocation(workspaceId);
+    if (!acceptedTransition) return;
+    const started = beginWorkspaceOperation(
+      githubManifestOperationSequence.current,
+      acceptedTransition,
+    );
+    githubManifestOperationSequence.current = started.sequence;
+    const operation = started.operation;
+    activeGitHubManifestOperation.current = operation;
     setGithubAppBusy(true);
     try {
-      const result = await client.createGitHubAppManifest(workspaceId, {
-        ...(githubOrg.trim() ? { organization: githubOrg.trim() } : {}),
-        public: false,
-        includeCiPermissions: true,
+      const result = await runCurrentWorkspaceOperation({
+        activeOperation: () => activeGitHubManifestOperation.current,
+        currentTransition: () => workspaceTransitionIdentity.current,
+        operation,
+        workspaceId,
+        request: async () =>
+          await client.createGitHubAppManifest(workspaceId, {
+            ...(githubOrg.trim() ? { organization: githubOrg.trim() } : {}),
+            public: false,
+            includeCiPermissions: true,
+          }),
       });
-      submitGitHubManifest(result.actionUrl, result.manifest);
+      if (
+        result.status === "stale" ||
+        !ownsWorkspaceOperation(
+          activeGitHubManifestOperation.current,
+          workspaceTransitionIdentity.current,
+          operation,
+          workspaceId,
+        )
+      ) {
+        return;
+      }
+      submitGitHubManifest(result.value.actionUrl, result.value.manifest);
     } catch (error) {
-      toast.error("GitHub App setup failed", {
-        description: error instanceof Error ? error.message : String(error),
-      });
-      setGithubAppBusy(false);
+      if (
+        ownsWorkspaceOperation(
+          activeGitHubManifestOperation.current,
+          workspaceTransitionIdentity.current,
+          operation,
+          workspaceId,
+        )
+      ) {
+        toast.error("GitHub App setup failed", {
+          description: error instanceof Error ? error.message : String(error),
+        });
+      }
+    } finally {
+      const settlement = settleWorkspaceOperation(activeGitHubManifestOperation.current, operation);
+      activeGitHubManifestOperation.current = settlement.active;
+      if (settlement.settledCurrent) {
+        setGithubAppBusy(false);
+      }
     }
   }
 
@@ -1169,8 +1255,34 @@ export function RootRouteComponent() {
     workspaceId: string,
     installationId: number,
   ): Promise<boolean> {
+    const acceptedTransition = captureWorkspaceInvocation(workspaceId);
+    if (!acceptedTransition) return false;
+    const started = beginWorkspaceOperation(
+      githubDisconnectOperationSequence.current,
+      acceptedTransition,
+    );
+    githubDisconnectOperationSequence.current = started.sequence;
+    const operation = started.operation;
+    activeGitHubDisconnectOperation.current = operation;
     try {
-      await client.unlinkGitHubInstallation(workspaceId, installationId);
+      const unlink = await runCurrentWorkspaceOperation({
+        activeOperation: () => activeGitHubDisconnectOperation.current,
+        currentTransition: () => workspaceTransitionIdentity.current,
+        operation,
+        workspaceId,
+        request: async () => await client.unlinkGitHubInstallation(workspaceId, installationId),
+      });
+      if (
+        unlink.status === "stale" ||
+        !ownsWorkspaceOperation(
+          activeGitHubDisconnectOperation.current,
+          workspaceTransitionIdentity.current,
+          operation,
+          workspaceId,
+        )
+      ) {
+        return false;
+      }
       const removedRepositoryIds = new Set(
         githubRepos
           .filter((repository) => repository.installationId === installationId)
@@ -1188,13 +1300,38 @@ export function RootRouteComponent() {
         ),
       );
       await refreshGitHub(workspaceId, undefined, { sync: true });
+      if (
+        !ownsWorkspaceOperation(
+          activeGitHubDisconnectOperation.current,
+          workspaceTransitionIdentity.current,
+          operation,
+          workspaceId,
+        )
+      ) {
+        return false;
+      }
       toast.success("GitHub installation unlinked from this workspace");
       return true;
     } catch (error) {
-      toast.error("Failed to unlink GitHub installation", {
-        description: error instanceof Error ? error.message : String(error),
-      });
+      if (
+        ownsWorkspaceOperation(
+          activeGitHubDisconnectOperation.current,
+          workspaceTransitionIdentity.current,
+          operation,
+          workspaceId,
+        )
+      ) {
+        toast.error("Failed to unlink GitHub installation", {
+          description: error instanceof Error ? error.message : String(error),
+        });
+      }
       return false;
+    } finally {
+      const settlement = settleWorkspaceOperation(
+        activeGitHubDisconnectOperation.current,
+        operation,
+      );
+      activeGitHubDisconnectOperation.current = settlement.active;
     }
   }
 
@@ -1283,25 +1420,26 @@ export function RootRouteComponent() {
   }
 
   async function handleManagedSignOut() {
-    const previousAuthSession = authSession;
     invalidatePrincipalWorkspaceState();
-    // Hide the authenticated tree while the cookie mutation is in flight. If
-    // the request fails, force a fresh authoritative session/access read rather
-    // than reopening the cached principal.
+    // Keep the authenticated tree hidden until an ambiguous response has been
+    // reconciled against the authoritative cookie session.
     setAuthSession(undefined);
-    try {
-      await signOutManaged();
-    } catch (error) {
-      setAuthSession(previousAuthSession);
-      setAccessKeyVersion((version) => version + 1);
-      throw error;
-    }
-    setAuthSession(null);
     setAccessContext(null);
     setWorkspaces([]);
-    setSession(null);
     setAccessError(null);
+    const result = await signOutWithAuthoritativeReconciliation<AuthSession>({
+      signOut: signOutManaged,
+      readSession: fetchAuthSession,
+    });
+    authPrincipalIdRef.current = result.session?.user.id ?? null;
+    setAuthSession(result.session);
+    // A definitive failure may restore the same user id. Rotate the client
+    // identity anyway so access is loaded from the reconciled cookie result.
     setAccessKeyVersion((version) => version + 1);
+    if (result.status === "reconciled_failure") {
+      throw result.error;
+    }
+    setSession(null);
     await navigate({ to: "/", replace: true });
   }
 
@@ -1393,6 +1531,8 @@ export function RootRouteComponent() {
           currentResources,
           workspaceStateOwnerId,
           prepareWorkspaceTransition,
+          captureWorkspaceInvocation,
+          ownsWorkspaceInvocation,
           addManualRepository: contextAddManualRepository,
           forgetAccessKey: contextForgetAccessKey,
           handleManagedSignOut: contextHandleManagedSignOut,
@@ -1420,6 +1560,7 @@ export function RootRouteComponent() {
     accessKeyVersion,
     authSession,
     busy,
+    captureWorkspaceInvocation,
     clearSlackLinkContinuation,
     client,
     clientConfig,
@@ -1452,6 +1593,7 @@ export function RootRouteComponent() {
     manualRepos,
     manualReposOpen,
     model,
+    ownsWorkspaceInvocation,
     preparePendingSlackLink,
     prepareWorkspaceTransition,
     slackLinkContinuationWorkspaceId,

--- a/apps/web/src/lib/managed-auth-transition.test.ts
+++ b/apps/web/src/lib/managed-auth-transition.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import { signOutWithAuthoritativeReconciliation } from "./managed-auth-transition";
+
+describe("managed sign-out reconciliation", () => {
+  test("committed sign-out with a lost response remains gated until the authoritative null", async () => {
+    let releaseRead!: () => void;
+    const readStarted = Promise.withResolvers<void>();
+    const readRelease = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    let settled = false;
+    const result = signOutWithAuthoritativeReconciliation({
+      signOut: async () => {
+        throw new Error("response lost");
+      },
+      readSession: async () => {
+        readStarted.resolve();
+        await readRelease;
+        return null;
+      },
+    }).finally(() => {
+      settled = true;
+    });
+
+    await readStarted.promise;
+    expect(settled).toBe(false);
+    releaseRead();
+    const reconciled = await result;
+    expect(reconciled.status).toBe("reconciled_failure");
+    expect(reconciled.session).toBeNull();
+  });
+
+  test("definitive failure restores only the session returned by the authoritative read", async () => {
+    const authoritative = { userId: "current-cookie-user" };
+    const result = await signOutWithAuthoritativeReconciliation({
+      signOut: async () => {
+        throw new Error("sign-out rejected");
+      },
+      readSession: async () => authoritative,
+    });
+
+    expect(result).toMatchObject({
+      status: "reconciled_failure",
+      session: authoritative,
+    });
+  });
+
+  test("successful sign-out does not perform a redundant session read", async () => {
+    let reads = 0;
+    const result = await signOutWithAuthoritativeReconciliation({
+      signOut: async () => {},
+      readSession: async () => {
+        reads += 1;
+        return { userId: "unexpected" };
+      },
+    });
+
+    expect(result).toEqual({ status: "signed_out", session: null });
+    expect(reads).toBe(0);
+  });
+});

--- a/apps/web/src/lib/managed-auth-transition.ts
+++ b/apps/web/src/lib/managed-auth-transition.ts
@@ -1,0 +1,21 @@
+export type ManagedSignOutResult<Session> =
+  | { status: "signed_out"; session: null }
+  | { status: "reconciled_failure"; session: Session | null; error: unknown };
+
+/**
+ * A failed sign-out response is ambiguous: the cookie mutation may still have
+ * committed. Resolve that ambiguity from the authoritative session endpoint
+ * before allowing an authenticated UI to render again.
+ */
+export async function signOutWithAuthoritativeReconciliation<Session>(input: {
+  signOut: () => Promise<unknown>;
+  readSession: () => Promise<Session | null>;
+}): Promise<ManagedSignOutResult<Session>> {
+  try {
+    await input.signOut();
+    return { status: "signed_out", session: null };
+  } catch (error) {
+    const session = await input.readSession();
+    return { status: "reconciled_failure", session, error };
+  }
+}

--- a/apps/web/src/lib/workspace-owned-state.test.ts
+++ b/apps/web/src/lib/workspace-owned-state.test.ts
@@ -95,5 +95,11 @@ describe("workspace-owned local state", () => {
     expect(workspaceRouteSource).toContain("updateWorkspaceOwnedState(current, ownedWorkspaceId");
     expect(workspaceRouteSource).toContain("captureWorkspaceInvocation(workspaceId)");
     expect(workspaceRouteSource).toContain("ownsWorkspaceInvocation(workspaceId");
+    expect(workspaceRouteSource).toContain(
+      "options?.polling === true && slackMutationBusy.current",
+    );
+    expect(workspaceRouteSource).toContain(
+      'if (slackAccessBusy || slackAccessRequest?.status !== "pending") return;',
+    );
   });
 });

--- a/apps/web/src/lib/workspace-owned-state.test.ts
+++ b/apps/web/src/lib/workspace-owned-state.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  updateWorkspaceOwnedState,
+  workspaceOwnedValue,
+  type WorkspaceOwnedState,
+} from "./workspace-owned-state";
+
+const workspaceRouteSource = await Bun.file(`${import.meta.dir}/../routes/workspace.tsx`).text();
+
+type SlackState = { requestName: string | null; error: string | null; busy: boolean };
+
+const emptySlackState = (): SlackState => ({ requestName: null, error: null, busy: false });
+
+describe("workspace-owned local state", () => {
+  test("never projects workspace A Slack UI under an authorized or unavailable B route", () => {
+    const pendingA: WorkspaceOwnedState<SlackState> = {
+      workspaceId: "workspace-a",
+      value: { requestName: "Workspace A", error: null, busy: true },
+    };
+
+    expect(workspaceOwnedValue(pendingA, "workspace-b", emptySlackState())).toEqual(
+      emptySlackState(),
+    );
+  });
+
+  test("a stale A polling completion cannot mutate B state", () => {
+    const readyB: WorkspaceOwnedState<SlackState> = {
+      workspaceId: "workspace-b",
+      value: emptySlackState(),
+    };
+    const afterStaleResponse = updateWorkspaceOwnedState(readyB, "workspace-a", () => ({
+      requestName: "Workspace A",
+      error: null,
+      busy: false,
+    }));
+    const afterStaleError = updateWorkspaceOwnedState(
+      afterStaleResponse,
+      "workspace-a",
+      (value) => ({
+        ...value,
+        error: "stale A polling failed",
+      }),
+    );
+
+    expect(afterStaleResponse).toBe(readyB);
+    expect(afterStaleError).toBe(readyB);
+    expect(workspaceOwnedValue(afterStaleError, "workspace-b", emptySlackState())).toEqual(
+      emptySlackState(),
+    );
+  });
+
+  for (const lateOutcome of ["response", "error"] as const) {
+    test(`ignores a delayed workspace A Slack polling ${lateOutcome} after B owns state`, async () => {
+      let state: WorkspaceOwnedState<SlackState> = {
+        workspaceId: "workspace-a",
+        value: { requestName: "Workspace A", error: null, busy: true },
+      };
+      let resolvePoll!: (value: string) => void;
+      let rejectPoll!: (error: Error) => void;
+      const polling = new Promise<string>((resolve, reject) => {
+        resolvePoll = resolve;
+        rejectPoll = reject;
+      }).then(
+        (requestName) => {
+          state = updateWorkspaceOwnedState(state, "workspace-a", (value) => ({
+            ...value,
+            requestName,
+          }));
+        },
+        (error: Error) => {
+          state = updateWorkspaceOwnedState(state, "workspace-a", (value) => ({
+            ...value,
+            error: error.message,
+          }));
+        },
+      );
+
+      state = { workspaceId: "workspace-b", value: emptySlackState() };
+      if (lateOutcome === "response") {
+        resolvePoll("Workspace A late response");
+      } else {
+        rejectPoll(new Error("Workspace A late failure"));
+      }
+      await polling;
+
+      expect(state).toEqual({ workspaceId: "workspace-b", value: emptySlackState() });
+    });
+  }
+
+  test("the Slack route binds render state and async effects to these guards", () => {
+    expect(workspaceRouteSource).toContain(
+      "workspaceOwnedValue(ownedSlackAccess, workspaceId, emptySlackAccessState())",
+    );
+    expect(workspaceRouteSource).toContain("updateWorkspaceOwnedState(current, ownedWorkspaceId");
+    expect(workspaceRouteSource).toContain("captureWorkspaceInvocation(workspaceId)");
+    expect(workspaceRouteSource).toContain("ownsWorkspaceInvocation(workspaceId");
+  });
+});

--- a/apps/web/src/lib/workspace-owned-state.ts
+++ b/apps/web/src/lib/workspace-owned-state.ts
@@ -1,0 +1,20 @@
+export type WorkspaceOwnedState<Value> = {
+  workspaceId: string;
+  value: Value;
+};
+
+export function workspaceOwnedValue<Value>(
+  state: WorkspaceOwnedState<Value>,
+  workspaceId: string,
+  fallback: Value,
+): Value {
+  return state.workspaceId === workspaceId ? state.value : fallback;
+}
+
+export function updateWorkspaceOwnedState<Value>(
+  state: WorkspaceOwnedState<Value>,
+  workspaceId: string,
+  update: (value: Value) => Value,
+): WorkspaceOwnedState<Value> {
+  return state.workspaceId === workspaceId ? { workspaceId, value: update(state.value) } : state;
+}

--- a/apps/web/src/lib/workspace-transition.test.ts
+++ b/apps/web/src/lib/workspace-transition.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
-import { beginWorkspaceTransition, ownsWorkspaceTransition } from "./workspace-transition";
+import {
+  beginWorkspaceOperation,
+  beginWorkspaceTransition,
+  invalidateWorkspaceTransition,
+  ownsWorkspaceOperation,
+  ownsWorkspaceTransition,
+  runCurrentWorkspaceRequest,
+  settleWorkspaceOperation,
+  type WorkspaceOperationIdentity,
+} from "./workspace-transition";
 
 describe("workspace transition identity", () => {
   test("invalidates an accepted operation when the route changes tenant", () => {
@@ -19,5 +28,69 @@ describe("workspace transition identity", () => {
 
     expect(repeated).toEqual({ identity: current, changed: false });
     expect(ownsWorkspaceTransition(repeated.identity, current, "workspace-a")).toBe(true);
+  });
+
+  test("credential invalidation advances identity even when the route id will stay the same", () => {
+    const accepted = { workspaceId: "workspace-a", revision: 4 };
+    const invalidated = invalidateWorkspaceTransition(accepted);
+    const rebound = beginWorkspaceTransition(invalidated, "workspace-a");
+
+    expect(invalidated).toEqual({ workspaceId: null, revision: 5 });
+    expect(rebound.identity).toEqual({ workspaceId: "workspace-a", revision: 6 });
+    expect(ownsWorkspaceTransition(rebound.identity, accepted, "workspace-a")).toBe(false);
+  });
+
+  test("a superseded create cannot toast or settle a newer create's busy state", () => {
+    const transitionA = { workspaceId: "workspace-a", revision: 1 };
+    const first = beginWorkspaceOperation(0, transitionA);
+    const transitionB = { workspaceId: "workspace-b", revision: 2 };
+    const second = beginWorkspaceOperation(first.sequence, transitionB);
+    let active: WorkspaceOperationIdentity | null = second.operation;
+    let busy = true;
+    let failureToasts = 0;
+
+    // Workspace A rejects after B has begun. The catch and finally branches
+    // both consult these helpers before mutating destination UI.
+    if (ownsWorkspaceOperation(active, transitionB, first.operation, "workspace-a")) {
+      failureToasts += 1;
+    }
+    const staleSettlement = settleWorkspaceOperation(active, first.operation);
+    active = staleSettlement.active;
+    if (staleSettlement.settledCurrent) busy = false;
+
+    expect(failureToasts).toBe(0);
+    expect(active).toEqual(second.operation);
+    expect(busy).toBe(true);
+
+    const currentSettlement = settleWorkspaceOperation(active, second.operation);
+    active = currentSettlement.active;
+    if (currentSettlement.settledCurrent) busy = false;
+    expect(active).toBeNull();
+    expect(busy).toBe(false);
+  });
+
+  test("suppresses both late resolve and late reject after abort or generation change", async () => {
+    const aborted = new AbortController();
+    let rejectOld!: (error: Error) => void;
+    const oldRejection = new Promise<string>((_resolve, reject) => {
+      rejectOld = reject;
+    });
+    const staleReject = runCurrentWorkspaceRequest({
+      signal: aborted.signal,
+      requestId: 1,
+      currentRequestId: () => 2,
+      request: () => oldRejection,
+    });
+    aborted.abort();
+    rejectOld(new Error("workspace A failed"));
+    expect(await staleReject).toBeNull();
+
+    expect(
+      await runCurrentWorkspaceRequest({
+        requestId: 3,
+        currentRequestId: () => 4,
+        request: async () => "workspace A catalog",
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/lib/workspace-transition.test.ts
+++ b/apps/web/src/lib/workspace-transition.test.ts
@@ -7,6 +7,7 @@ import {
   ownsWorkspaceOperation,
   ownsWorkspaceTransition,
   runCurrentWorkspaceRequest,
+  runCurrentWorkspaceOperation,
   settleWorkspaceOperation,
   type WorkspaceOperationIdentity,
 } from "./workspace-transition";
@@ -93,4 +94,42 @@ describe("workspace transition identity", () => {
       }),
     ).toBeNull();
   });
+
+  for (const lateOutcome of ["resolve", "reject"] as const) {
+    test(`prevents a delayed GitHub mutation ${lateOutcome} from refreshing or redirecting after a switch`, async () => {
+      const transitionA = { workspaceId: "workspace-a", revision: 1 };
+      const started = beginWorkspaceOperation(0, transitionA);
+      let currentTransition = transitionA;
+      let active: WorkspaceOperationIdentity | null = started.operation;
+      let resolveRequest!: (value: string) => void;
+      let rejectRequest!: (error: Error) => void;
+      const request = new Promise<string>((resolve, reject) => {
+        resolveRequest = resolve;
+        rejectRequest = reject;
+      });
+      const result = runCurrentWorkspaceOperation({
+        activeOperation: () => active,
+        currentTransition: () => currentTransition,
+        operation: started.operation,
+        workspaceId: "workspace-a",
+        request: () => request,
+      });
+
+      currentTransition = { workspaceId: "workspace-b", revision: 2 };
+      active = null;
+      if (lateOutcome === "resolve") {
+        resolveRequest("workspace-a result");
+      } else {
+        rejectRequest(new Error("workspace-a failed"));
+      }
+
+      let destinationEffects = 0;
+      const settled = await result;
+      if (settled.status === "current") {
+        destinationEffects += 1;
+      }
+      expect(settled).toEqual({ status: "stale" });
+      expect(destinationEffects).toBe(0);
+    });
+  }
 });

--- a/apps/web/src/lib/workspace-transition.test.ts
+++ b/apps/web/src/lib/workspace-transition.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   beginWorkspaceOperation,
+  beginWorkspaceOperationUnlessBlocked,
   beginWorkspaceTransition,
   invalidateWorkspaceTransition,
   ownsWorkspaceOperation,
@@ -130,6 +131,55 @@ describe("workspace transition identity", () => {
       }
       expect(settled).toEqual({ status: "stale" });
       expect(destinationEffects).toBe(0);
+    });
+  }
+
+  for (const mutation of ["request", "cancel"] as const) {
+    test(`a polling timer cannot supersede an in-flight Slack ${mutation} mutation`, async () => {
+      const transition = { workspaceId: "workspace-a", revision: 1 };
+      const startedMutation = beginWorkspaceOperation(0, transition);
+      let active: WorkspaceOperationIdentity | null = startedMutation.operation;
+      let sequence = startedMutation.sequence;
+      let mutationBusy = true;
+      let requestProjectionEligible = false;
+      let continuationEligible = false;
+      let navigationEligible = false;
+      let resolveMutation!: () => void;
+      const delayedMutation = new Promise<void>((resolve) => {
+        resolveMutation = resolve;
+      }).then(() => {
+        if (ownsWorkspaceOperation(active, transition, startedMutation.operation, "workspace-a")) {
+          if (mutation === "request") {
+            requestProjectionEligible = true;
+          } else {
+            continuationEligible = true;
+            navigationEligible = true;
+          }
+        }
+      });
+
+      // A timer callback already queued before React tears down the interval
+      // still consults the synchronous mutation-busy fence.
+      const timerTick = beginWorkspaceOperationUnlessBlocked(sequence, transition, mutationBusy);
+      if (timerTick) {
+        sequence = timerTick.sequence;
+        active = timerTick.operation;
+      }
+      expect(timerTick).toBeNull();
+      expect(active).toEqual(startedMutation.operation);
+
+      resolveMutation();
+      await delayedMutation;
+      const settlement = settleWorkspaceOperation(active, startedMutation.operation);
+      active = settlement.active;
+      if (settlement.settledCurrent) mutationBusy = false;
+
+      expect(requestProjectionEligible).toBe(mutation === "request");
+      expect(continuationEligible).toBe(mutation === "cancel");
+      expect(navigationEligible).toBe(mutation === "cancel");
+      expect(mutationBusy).toBe(false);
+      expect(active).toBeNull();
+      expect(sequence).toBe(startedMutation.sequence);
     });
   }
 });

--- a/apps/web/src/lib/workspace-transition.test.ts
+++ b/apps/web/src/lib/workspace-transition.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { beginWorkspaceTransition, ownsWorkspaceTransition } from "./workspace-transition";
+
+describe("workspace transition identity", () => {
+  test("invalidates an accepted operation when the route changes tenant", () => {
+    const initial = beginWorkspaceTransition({ workspaceId: null, revision: 0 }, "workspace-a");
+    const accepted = initial.identity;
+    const switched = beginWorkspaceTransition(accepted, "workspace-b");
+
+    expect(initial.changed).toBe(true);
+    expect(switched.changed).toBe(true);
+    expect(ownsWorkspaceTransition(switched.identity, accepted, "workspace-a")).toBe(false);
+  });
+
+  test("keeps same-workspace rerenders on the same transition identity", () => {
+    const current = { workspaceId: "workspace-a", revision: 4 };
+    const repeated = beginWorkspaceTransition(current, "workspace-a");
+
+    expect(repeated).toEqual({ identity: current, changed: false });
+    expect(ownsWorkspaceTransition(repeated.identity, current, "workspace-a")).toBe(true);
+  });
+});

--- a/apps/web/src/lib/workspace-transition.ts
+++ b/apps/web/src/lib/workspace-transition.ts
@@ -47,6 +47,14 @@ export function beginWorkspaceOperation(
   return { sequence, operation: { id: sequence, transition } };
 }
 
+export function beginWorkspaceOperationUnlessBlocked(
+  previousSequence: number,
+  transition: WorkspaceTransitionIdentity,
+  blocked: boolean,
+): { sequence: number; operation: WorkspaceOperationIdentity } | null {
+  return blocked ? null : beginWorkspaceOperation(previousSequence, transition);
+}
+
 export function ownsWorkspaceOperation(
   active: WorkspaceOperationIdentity | null,
   currentTransition: WorkspaceTransitionIdentity,

--- a/apps/web/src/lib/workspace-transition.ts
+++ b/apps/web/src/lib/workspace-transition.ts
@@ -1,0 +1,29 @@
+export type WorkspaceTransitionIdentity = {
+  workspaceId: string | null;
+  revision: number;
+};
+
+export function beginWorkspaceTransition(
+  current: WorkspaceTransitionIdentity,
+  workspaceId: string,
+): { identity: WorkspaceTransitionIdentity; changed: boolean } {
+  if (current.workspaceId === workspaceId) {
+    return { identity: current, changed: false };
+  }
+  return {
+    identity: { workspaceId, revision: current.revision + 1 },
+    changed: true,
+  };
+}
+
+export function ownsWorkspaceTransition(
+  current: WorkspaceTransitionIdentity,
+  accepted: WorkspaceTransitionIdentity,
+  workspaceId: string,
+): boolean {
+  return (
+    current.workspaceId === workspaceId &&
+    accepted.workspaceId === workspaceId &&
+    current.revision === accepted.revision
+  );
+}

--- a/apps/web/src/lib/workspace-transition.ts
+++ b/apps/web/src/lib/workspace-transition.ts
@@ -69,6 +69,47 @@ export function settleWorkspaceOperation(
   return { active: null, settledCurrent: true };
 }
 
+export type CurrentWorkspaceOperationResult<T> =
+  | { status: "current"; value: T }
+  | { status: "stale" };
+
+/**
+ * Run a request owned by one exact workspace operation. Both fulfillment and
+ * rejection become inert once a newer operation, workspace, or principal owns
+ * the destination UI.
+ */
+export async function runCurrentWorkspaceOperation<T>(input: {
+  activeOperation: () => WorkspaceOperationIdentity | null;
+  currentTransition: () => WorkspaceTransitionIdentity;
+  operation: WorkspaceOperationIdentity;
+  workspaceId: string;
+  request: () => Promise<T>;
+}): Promise<CurrentWorkspaceOperationResult<T>> {
+  try {
+    const value = await input.request();
+    return ownsWorkspaceOperation(
+      input.activeOperation(),
+      input.currentTransition(),
+      input.operation,
+      input.workspaceId,
+    )
+      ? { status: "current", value }
+      : { status: "stale" };
+  } catch (error) {
+    if (
+      !ownsWorkspaceOperation(
+        input.activeOperation(),
+        input.currentTransition(),
+        input.operation,
+        input.workspaceId,
+      )
+    ) {
+      return { status: "stale" };
+    }
+    throw error;
+  }
+}
+
 /**
  * Resolve or reject one non-abortable request only while its route-owned
  * generation is current. A stale rejection becomes an inert null result so a

--- a/apps/web/src/lib/workspace-transition.ts
+++ b/apps/web/src/lib/workspace-transition.ts
@@ -3,6 +3,11 @@ export type WorkspaceTransitionIdentity = {
   revision: number;
 };
 
+export type WorkspaceOperationIdentity = {
+  id: number;
+  transition: WorkspaceTransitionIdentity;
+};
+
 export function beginWorkspaceTransition(
   current: WorkspaceTransitionIdentity,
   workspaceId: string,
@@ -16,6 +21,12 @@ export function beginWorkspaceTransition(
   };
 }
 
+export function invalidateWorkspaceTransition(
+  current: WorkspaceTransitionIdentity,
+): WorkspaceTransitionIdentity {
+  return { workspaceId: null, revision: current.revision + 1 };
+}
+
 export function ownsWorkspaceTransition(
   current: WorkspaceTransitionIdentity,
   accepted: WorkspaceTransitionIdentity,
@@ -26,4 +37,56 @@ export function ownsWorkspaceTransition(
     accepted.workspaceId === workspaceId &&
     current.revision === accepted.revision
   );
+}
+
+export function beginWorkspaceOperation(
+  previousSequence: number,
+  transition: WorkspaceTransitionIdentity,
+): { sequence: number; operation: WorkspaceOperationIdentity } {
+  const sequence = previousSequence + 1;
+  return { sequence, operation: { id: sequence, transition } };
+}
+
+export function ownsWorkspaceOperation(
+  active: WorkspaceOperationIdentity | null,
+  currentTransition: WorkspaceTransitionIdentity,
+  operation: WorkspaceOperationIdentity,
+  workspaceId: string,
+): boolean {
+  return (
+    active?.id === operation.id &&
+    ownsWorkspaceTransition(currentTransition, operation.transition, workspaceId)
+  );
+}
+
+export function settleWorkspaceOperation(
+  active: WorkspaceOperationIdentity | null,
+  operation: WorkspaceOperationIdentity,
+): { active: WorkspaceOperationIdentity | null; settledCurrent: boolean } {
+  if (active?.id !== operation.id) {
+    return { active, settledCurrent: false };
+  }
+  return { active: null, settledCurrent: true };
+}
+
+/**
+ * Resolve or reject one non-abortable request only while its route-owned
+ * generation is current. A stale rejection becomes an inert null result so a
+ * caller cannot surface the previous workspace's failure after transition.
+ */
+export async function runCurrentWorkspaceRequest<T>(input: {
+  signal?: AbortSignal | undefined;
+  requestId: number;
+  currentRequestId: () => number;
+  request: () => Promise<T>;
+}): Promise<T | null> {
+  try {
+    const value = await input.request();
+    return input.signal?.aborted || input.currentRequestId() !== input.requestId ? null : value;
+  } catch (error) {
+    if (input.signal?.aborted || input.currentRequestId() !== input.requestId) {
+      return null;
+    }
+    throw error;
+  }
 }

--- a/apps/web/src/routes/workspace.tsx
+++ b/apps/web/src/routes/workspace.tsx
@@ -3,13 +3,14 @@
 // session-contextual actions around every workspace-scoped route.
 import { OpenGeniProvider } from "@opengeni/react";
 import { Link, Outlet, useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { LoadingPanel, ProblemPanel } from "@/components/common";
 import { RailProvider } from "@/components/rail/rail-context";
 import { RailShell } from "@/components/rail/rail-shell";
 import { Button } from "@/components/ui/button";
+import { WorkspaceTenantBoundary } from "@/components/workspace-tenant-boundary";
 import { useAppContext } from "@/context";
 import { useGitHubHistoryRefresh } from "@/lib/use-github-history-refresh";
 import { isAbortError } from "@/lib/session-tools";
@@ -31,20 +32,23 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
   const activeWorkspaceId = activeWorkspace?.id ?? null;
   const {
     accessKeyVersion,
-    resetSessionView,
     resetWorkspaceIntegrations,
     setSelectedRepoIds,
     setSelectedRepoRefs,
     refreshGitHub,
     refreshWorkspaceMcpServers,
   } = context;
-  const previousWorkspaceId = useRef<string | null>(null);
   const [slackAccessRequest, setSlackAccessRequest] = useState<SlackUserLinkAccessRequest | null>(
     null,
   );
   const [slackAccessError, setSlackAccessError] = useState<string | null>(null);
   const [slackAccessBusy, setSlackAccessBusy] = useState(false);
-  useGitHubHistoryRefresh(workspaceId, activeWorkspaceId !== null, refreshGitHub);
+  const workspaceStateReady = context.workspaceStateOwnerId === workspaceId;
+  useGitHubHistoryRefresh(
+    workspaceId,
+    activeWorkspaceId !== null && workspaceStateReady,
+    refreshGitHub,
+  );
 
   const hasSlackLinkContinuation = context.slackLinkContinuationWorkspaceId === workspaceId;
 
@@ -145,14 +149,10 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
   }
 
   useEffect(() => {
-    if (!activeWorkspaceId) {
+    if (!activeWorkspaceId || !workspaceStateReady) {
       return;
     }
     const abortController = new AbortController();
-    if (previousWorkspaceId.current !== workspaceId) {
-      resetSessionView();
-    }
-    previousWorkspaceId.current = workspaceId;
     resetWorkspaceIntegrations();
     setSelectedRepoIds(new Set());
     setSelectedRepoRefs({});
@@ -168,12 +168,24 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
     activeWorkspaceId,
     refreshGitHub,
     refreshWorkspaceMcpServers,
-    resetSessionView,
     resetWorkspaceIntegrations,
     setSelectedRepoIds,
     setSelectedRepoRefs,
+    workspaceStateReady,
     workspaceId,
   ]);
+
+  if (!workspaceStateReady) {
+    return (
+      <WorkspaceTenantBoundary
+        workspaceId={workspaceId}
+        stateOwnerWorkspaceId={context.workspaceStateOwnerId}
+        prepareTransition={context.prepareWorkspaceTransition}
+      >
+        {null}
+      </WorkspaceTenantBoundary>
+    );
+  }
 
   if (!activeWorkspace) {
     if (hasSlackLinkContinuation || slackAccessRequest || slackAccessError) {

--- a/apps/web/src/routes/workspace.tsx
+++ b/apps/web/src/routes/workspace.tsx
@@ -20,7 +20,7 @@ import {
   type WorkspaceOwnedState,
 } from "@/lib/workspace-owned-state";
 import {
-  beginWorkspaceOperation,
+  beginWorkspaceOperationUnlessBlocked,
   type WorkspaceOperationIdentity,
 } from "@/lib/workspace-transition";
 import type { SlackUserLinkAccessRequest } from "@/types";
@@ -68,6 +68,7 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
   );
   const slackOperationSequence = useRef(0);
   const activeSlackOperation = useRef<WorkspaceOperationIdentity | null>(null);
+  const slackMutationBusy = useRef(false);
   if (activeSlackOperation.current?.transition.workspaceId !== workspaceId) {
     activeSlackOperation.current = null;
   }
@@ -83,14 +84,22 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
     },
     [],
   );
-  const beginSlackOperation = useCallback((): WorkspaceOperationIdentity | null => {
-    const accepted = captureWorkspaceInvocation(workspaceId);
-    if (!accepted) return null;
-    const started = beginWorkspaceOperation(slackOperationSequence.current, accepted);
-    slackOperationSequence.current = started.sequence;
-    activeSlackOperation.current = started.operation;
-    return started.operation;
-  }, [captureWorkspaceInvocation, workspaceId]);
+  const beginSlackOperation = useCallback(
+    (options?: { polling?: boolean }): WorkspaceOperationIdentity | null => {
+      const accepted = captureWorkspaceInvocation(workspaceId);
+      if (!accepted) return null;
+      const started = beginWorkspaceOperationUnlessBlocked(
+        slackOperationSequence.current,
+        accepted,
+        options?.polling === true && slackMutationBusy.current,
+      );
+      if (!started) return null;
+      slackOperationSequence.current = started.sequence;
+      activeSlackOperation.current = started.operation;
+      return started.operation;
+    },
+    [captureWorkspaceInvocation, workspaceId],
+  );
   const ownsSlackOperation = useCallback(
     (operation: WorkspaceOperationIdentity): boolean =>
       activeSlackOperation.current?.id === operation.id &&
@@ -108,12 +117,13 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
 
   useEffect(() => {
     activeSlackOperation.current = null;
+    slackMutationBusy.current = false;
     setOwnedSlackAccess({ workspaceId, value: emptySlackAccessState() });
   }, [context.accessKeyVersion, workspaceId]);
 
   const refreshSlackAccess = useCallback(
-    async (request: SlackUserLinkAccessRequest) => {
-      const operation = beginSlackOperation();
+    async (request: SlackUserLinkAccessRequest, options?: { polling?: boolean }) => {
+      const operation = beginSlackOperation(options);
       if (!operation) return null;
       let next: SlackUserLinkAccessRequest;
       try {
@@ -194,17 +204,18 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
   ]);
 
   useEffect(() => {
-    if (slackAccessRequest?.status !== "pending") return;
+    if (slackAccessBusy || slackAccessRequest?.status !== "pending") return;
     const interval = window.setInterval(() => {
-      void refreshSlackAccess(slackAccessRequest);
+      void refreshSlackAccess(slackAccessRequest, { polling: true });
     }, 3_000);
     return () => window.clearInterval(interval);
-  }, [refreshSlackAccess, slackAccessRequest]);
+  }, [refreshSlackAccess, slackAccessBusy, slackAccessRequest]);
 
   async function requestAccess() {
     if (!slackAccessRequest || slackAccessRequest.status !== "prepared") return;
     const operation = beginSlackOperation();
     if (!operation) return;
+    slackMutationBusy.current = true;
     updateSlackAccess(workspaceId, (current) => ({ ...current, busy: true }));
     try {
       const request = await client.requestSlackUserLinkWorkspaceAccess(
@@ -228,6 +239,7 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
     } finally {
       if (ownsSlackOperation(operation)) {
         activeSlackOperation.current = null;
+        slackMutationBusy.current = false;
         updateSlackAccess(workspaceId, (current) => ({ ...current, busy: false }));
       }
     }
@@ -242,6 +254,7 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
     }
     const operation = beginSlackOperation();
     if (!operation) return;
+    slackMutationBusy.current = true;
     updateSlackAccess(workspaceId, (current) => ({ ...current, busy: true }));
     try {
       await client.cancelSlackUserLinkAccess(workspaceId, slackAccessRequest.id, {
@@ -262,6 +275,7 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
     } finally {
       if (ownsSlackOperation(operation)) {
         activeSlackOperation.current = null;
+        slackMutationBusy.current = false;
         updateSlackAccess(workspaceId, (current) => ({ ...current, busy: false }));
       }
     }

--- a/apps/web/src/routes/workspace.tsx
+++ b/apps/web/src/routes/workspace.tsx
@@ -158,7 +158,7 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
     setSelectedRepoRefs({});
     void refreshGitHub(workspaceId, abortController.signal);
     void refreshWorkspaceMcpServers(workspaceId, abortController.signal).catch((error) => {
-      if (!isAbortError(error)) {
+      if (!abortController.signal.aborted && !isAbortError(error)) {
         toast.error("Failed to load workspace MCP tools", { description: String(error) });
       }
     });

--- a/apps/web/src/routes/workspace.tsx
+++ b/apps/web/src/routes/workspace.tsx
@@ -3,7 +3,7 @@
 // session-contextual actions around every workspace-scoped route.
 import { OpenGeniProvider } from "@opengeni/react";
 import { Link, Outlet, useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { LoadingPanel, ProblemPanel } from "@/components/common";
@@ -14,7 +14,26 @@ import { WorkspaceTenantBoundary } from "@/components/workspace-tenant-boundary"
 import { useAppContext } from "@/context";
 import { useGitHubHistoryRefresh } from "@/lib/use-github-history-refresh";
 import { isAbortError } from "@/lib/session-tools";
+import {
+  updateWorkspaceOwnedState,
+  workspaceOwnedValue,
+  type WorkspaceOwnedState,
+} from "@/lib/workspace-owned-state";
+import {
+  beginWorkspaceOperation,
+  type WorkspaceOperationIdentity,
+} from "@/lib/workspace-transition";
 import type { SlackUserLinkAccessRequest } from "@/types";
+
+type SlackAccessState = {
+  request: SlackUserLinkAccessRequest | null;
+  error: string | null;
+  busy: boolean;
+};
+
+function emptySlackAccessState(): SlackAccessState {
+  return { request: null, error: null, busy: false };
+}
 
 export function SlackLinkAccessRequiredDescription({ workspaceName }: { workspaceName: string }) {
   return (
@@ -32,17 +51,52 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
   const activeWorkspaceId = activeWorkspace?.id ?? null;
   const {
     accessKeyVersion,
+    captureWorkspaceInvocation,
+    clearSlackLinkContinuation,
+    client,
+    ownsWorkspaceInvocation,
+    preparePendingSlackLink,
     resetWorkspaceIntegrations,
+    refreshWorkspace,
     setSelectedRepoIds,
     setSelectedRepoRefs,
     refreshGitHub,
     refreshWorkspaceMcpServers,
   } = context;
-  const [slackAccessRequest, setSlackAccessRequest] = useState<SlackUserLinkAccessRequest | null>(
-    null,
+  const [ownedSlackAccess, setOwnedSlackAccess] = useState<WorkspaceOwnedState<SlackAccessState>>(
+    () => ({ workspaceId, value: emptySlackAccessState() }),
   );
-  const [slackAccessError, setSlackAccessError] = useState<string | null>(null);
-  const [slackAccessBusy, setSlackAccessBusy] = useState(false);
+  const slackOperationSequence = useRef(0);
+  const activeSlackOperation = useRef<WorkspaceOperationIdentity | null>(null);
+  if (activeSlackOperation.current?.transition.workspaceId !== workspaceId) {
+    activeSlackOperation.current = null;
+  }
+  const slackAccess = workspaceOwnedValue(ownedSlackAccess, workspaceId, emptySlackAccessState());
+  const slackAccessRequest = slackAccess.request;
+  const slackAccessError = slackAccess.error;
+  const slackAccessBusy = slackAccess.busy;
+  const updateSlackAccess = useCallback(
+    (ownedWorkspaceId: string, update: (value: SlackAccessState) => SlackAccessState) => {
+      setOwnedSlackAccess((current) =>
+        updateWorkspaceOwnedState(current, ownedWorkspaceId, update),
+      );
+    },
+    [],
+  );
+  const beginSlackOperation = useCallback((): WorkspaceOperationIdentity | null => {
+    const accepted = captureWorkspaceInvocation(workspaceId);
+    if (!accepted) return null;
+    const started = beginWorkspaceOperation(slackOperationSequence.current, accepted);
+    slackOperationSequence.current = started.sequence;
+    activeSlackOperation.current = started.operation;
+    return started.operation;
+  }, [captureWorkspaceInvocation, workspaceId]);
+  const ownsSlackOperation = useCallback(
+    (operation: WorkspaceOperationIdentity): boolean =>
+      activeSlackOperation.current?.id === operation.id &&
+      ownsWorkspaceInvocation(workspaceId, operation.transition),
+    [ownsWorkspaceInvocation, workspaceId],
+  );
   const workspaceStateReady = context.workspaceStateOwnerId === workspaceId;
   useGitHubHistoryRefresh(
     workspaceId,
@@ -52,77 +106,130 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
 
   const hasSlackLinkContinuation = context.slackLinkContinuationWorkspaceId === workspaceId;
 
+  useEffect(() => {
+    activeSlackOperation.current = null;
+    setOwnedSlackAccess({ workspaceId, value: emptySlackAccessState() });
+  }, [context.accessKeyVersion, workspaceId]);
+
   const refreshSlackAccess = useCallback(
     async (request: SlackUserLinkAccessRequest) => {
-      const next = await context.client.getSlackUserLinkAccess(workspaceId, request.id);
-      setSlackAccessRequest(next);
+      const operation = beginSlackOperation();
+      if (!operation) return null;
+      let next: SlackUserLinkAccessRequest;
+      try {
+        next = await client.getSlackUserLinkAccess(workspaceId, request.id);
+      } catch (error) {
+        if (ownsSlackOperation(operation)) {
+          updateSlackAccess(workspaceId, (current) => ({
+            ...current,
+            error: error instanceof Error ? error.message : String(error),
+          }));
+        }
+        return null;
+      }
+      if (!ownsSlackOperation(operation)) return null;
+      updateSlackAccess(workspaceId, (current) => ({ ...current, request: next }));
       if (next.status === "completed") {
         toast.success("Slack identity linked", {
           description: "You can return to Slack and invoke OpenGeni again.",
         });
-        await context.refreshWorkspace(workspaceId);
-        context.clearSlackLinkContinuation();
+        await refreshWorkspace(workspaceId);
+        if (!ownsSlackOperation(operation)) return null;
+        clearSlackLinkContinuation();
       }
       return next;
     },
-    [context, workspaceId],
+    [
+      beginSlackOperation,
+      clearSlackLinkContinuation,
+      client,
+      ownsSlackOperation,
+      refreshWorkspace,
+      updateSlackAccess,
+      workspaceId,
+    ],
   );
 
   useEffect(() => {
     if (!hasSlackLinkContinuation) return;
     let disposed = false;
-    setSlackAccessError(null);
-    void context
-      .preparePendingSlackLink(workspaceId)
+    const operation = beginSlackOperation();
+    if (!operation) return;
+    updateSlackAccess(workspaceId, (current) => ({ ...current, error: null }));
+    void preparePendingSlackLink(workspaceId)
       .then(async (request) => {
-        if (disposed || !request) return;
-        setSlackAccessRequest(request);
+        if (disposed || !request || !ownsSlackOperation(operation)) return;
+        updateSlackAccess(workspaceId, (current) => ({ ...current, request }));
         if (request.status === "completed") {
           toast.success("Slack identity linked", {
             description: "You can return to Slack and invoke OpenGeni again.",
           });
-          await context.refreshWorkspace(workspaceId);
-          context.clearSlackLinkContinuation();
+          await refreshWorkspace(workspaceId);
+          if (disposed || !ownsSlackOperation(operation)) return;
+          clearSlackLinkContinuation();
         }
       })
       .catch((error) => {
-        if (disposed) return;
-        setSlackAccessError(error instanceof Error ? error.message : String(error));
+        if (disposed || !ownsSlackOperation(operation)) return;
+        updateSlackAccess(workspaceId, (current) => ({
+          ...current,
+          error: error instanceof Error ? error.message : String(error),
+        }));
       });
     return () => {
       disposed = true;
+      if (activeSlackOperation.current?.id === operation.id) {
+        activeSlackOperation.current = null;
+      }
     };
-  }, [context, hasSlackLinkContinuation, workspaceId]);
+  }, [
+    beginSlackOperation,
+    clearSlackLinkContinuation,
+    hasSlackLinkContinuation,
+    ownsSlackOperation,
+    preparePendingSlackLink,
+    refreshWorkspace,
+    updateSlackAccess,
+    workspaceId,
+  ]);
 
   useEffect(() => {
     if (slackAccessRequest?.status !== "pending") return;
     const interval = window.setInterval(() => {
-      void refreshSlackAccess(slackAccessRequest).catch((error) => {
-        setSlackAccessError(error instanceof Error ? error.message : String(error));
-      });
+      void refreshSlackAccess(slackAccessRequest);
     }, 3_000);
     return () => window.clearInterval(interval);
   }, [refreshSlackAccess, slackAccessRequest]);
 
   async function requestAccess() {
     if (!slackAccessRequest || slackAccessRequest.status !== "prepared") return;
-    setSlackAccessBusy(true);
+    const operation = beginSlackOperation();
+    if (!operation) return;
+    updateSlackAccess(workspaceId, (current) => ({ ...current, busy: true }));
     try {
-      setSlackAccessRequest(
-        await context.client.requestSlackUserLinkWorkspaceAccess(
-          workspaceId,
-          slackAccessRequest.id,
-          {
-            expectedVersion: slackAccessRequest.version,
-            idempotencyKey: crypto.randomUUID(),
-          },
-        ),
+      const request = await client.requestSlackUserLinkWorkspaceAccess(
+        workspaceId,
+        slackAccessRequest.id,
+        {
+          expectedVersion: slackAccessRequest.version,
+          idempotencyKey: crypto.randomUUID(),
+        },
       );
+      if (!ownsSlackOperation(operation)) return;
+      updateSlackAccess(workspaceId, (current) => ({ ...current, request }));
       toast.success("Access request sent");
     } catch (error) {
-      setSlackAccessError(error instanceof Error ? error.message : String(error));
+      if (ownsSlackOperation(operation)) {
+        updateSlackAccess(workspaceId, (current) => ({
+          ...current,
+          error: error instanceof Error ? error.message : String(error),
+        }));
+      }
     } finally {
-      setSlackAccessBusy(false);
+      if (ownsSlackOperation(operation)) {
+        activeSlackOperation.current = null;
+        updateSlackAccess(workspaceId, (current) => ({ ...current, busy: false }));
+      }
     }
   }
 
@@ -133,18 +240,30 @@ export function WorkspaceShellRoute({ workspaceId }: { workspaceId: string }) {
     ) {
       return;
     }
-    setSlackAccessBusy(true);
+    const operation = beginSlackOperation();
+    if (!operation) return;
+    updateSlackAccess(workspaceId, (current) => ({ ...current, busy: true }));
     try {
-      await context.client.cancelSlackUserLinkAccess(workspaceId, slackAccessRequest.id, {
+      await client.cancelSlackUserLinkAccess(workspaceId, slackAccessRequest.id, {
         expectedVersion: slackAccessRequest.version,
         idempotencyKey: crypto.randomUUID(),
       });
-      context.clearSlackLinkContinuation();
+      if (!ownsSlackOperation(operation)) return;
+      clearSlackLinkContinuation();
+      if (!ownsSlackOperation(operation)) return;
       await navigate({ to: "/", replace: true });
     } catch (error) {
-      setSlackAccessError(error instanceof Error ? error.message : String(error));
+      if (ownsSlackOperation(operation)) {
+        updateSlackAccess(workspaceId, (current) => ({
+          ...current,
+          error: error instanceof Error ? error.message : String(error),
+        }));
+      }
     } finally {
-      setSlackAccessBusy(false);
+      if (ownsSlackOperation(operation)) {
+        activeSlackOperation.current = null;
+        updateSlackAccess(workspaceId, (current) => ({ ...current, busy: false }));
+      }
     }
   }
 

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -38,8 +38,8 @@ const budgets = {
   // graph to a worst observed 2,042,520 raw bytes. Truthful zero-step lifecycle
   // copy, the shared large-history disclosure scheduler, and durable sandbox-file
   // receipt/download controls bring the configured graph to 2,052,836 raw bytes
-  // and 571,587 gzip bytes on both macOS/arm64 and Linux/x64. OPE-205's
-  // always-loaded tenant-transition boundary, invocation fences, and selected
+  // and 571,587 gzip bytes on both macOS/arm64 and Linux/x64. The always-loaded
+  // tenant-transition boundary, invocation fences, and selected
   // context semantics bring the direct-session graph to 2,056,813 raw bytes on
   // macOS/arm64. The 2,010/559 KiB envelopes retain a narrow raw-byte margin
   // without relaxing the independently bounded gzip graph.

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -38,8 +38,11 @@ const budgets = {
   // graph to a worst observed 2,042,520 raw bytes. Truthful zero-step lifecycle
   // copy, the shared large-history disclosure scheduler, and durable sandbox-file
   // receipt/download controls bring the configured graph to 2,052,836 raw bytes
-  // and 571,587 gzip bytes on both macOS/arm64 and Linux/x64. The 2,006/559 KiB
-  // envelopes retain 1,308/829 bytes of headroom.
+  // and 571,587 gzip bytes on both macOS/arm64 and Linux/x64. OPE-205's
+  // always-loaded tenant-transition boundary, invocation fences, and selected
+  // context semantics bring the direct-session graph to 2,056,813 raw bytes on
+  // macOS/arm64. The 2,010/559 KiB envelopes retain a narrow raw-byte margin
+  // without relaxing the independently bounded gzip graph.
   initialRaw: 1448 * kib,
   initialGzip: 400 * kib,
   // 77 KiB: the largest shared chunk sits 22 bytes over 76 KiB under CI's
@@ -47,7 +50,7 @@ const budgets = {
   // still bound the aggregate.
   initialFileGzip: 77 * kib,
   initialFiles: 17,
-  directSessionRaw: 2006 * kib,
+  directSessionRaw: 2010 * kib,
   directSessionGzip: 559 * kib,
   directSessionFiles: 19,
   lazyChunkRaw: 800 * kib,


### PR DESCRIPTION
## Summary

- add a display-only tenant boundary before a routed workspace can render mutable console state
- clear workspace/session drafts and caches and fence late session-create, GitHub, MCP, and Slack projections across workspace or principal switches
- keep managed sign-out gated until an ambiguous response is reconciled against the authoritative cookie session
- prevent Slack polling from superseding an in-flight Request or Cancel mutation
- expose the active workspace to assistive technology and mark selected organization/workspace menu items

## Authority boundary

This is UI isolation, not frontend authorization. Server grants remain authoritative. The boundary prevents stale state and actions from the prior workspace from appearing under the destination route.

## Verification

- 27 focused transition/race tests pass
- web TypeScript check passes
- targeted oxfmt and oxlint pass
- production web build passes the documented raw/gzip/file-count bundle contracts; the always-loaded transition boundary uses a narrow 2,010 KiB direct-session raw envelope while the 559 KiB gzip cap is unchanged
- current-main merge tree is clean against `fba437f71`

No changeset is required because this changes only the internal web application. No architecture map update is required because no system component, data flow, invariant, or canonical change-area mapping changed.

## Review repair and residual audit

Independent review found and verified repairs for stale operation classes in session creation, MCP, GitHub, Slack, and managed sign-out. A final narrow repair ensures a queued Slack polling tick cannot steal ownership from an in-flight Request or Cancel.

The audit also identified a separate pre-existing class: generic workspace CRUD callbacks can still late-update the global workspace collection across a principal replacement. That principal-generation audit is intentionally the next OPE-205 slice; this PR does not claim it complete. The current review must treat that boundary explicitly and block this slice if the residual cannot safely land as a follow-up.

## OPE-205 scope

This is slice 1: tenant-safe organization/workspace switching and selected-context accessibility. Personal-workspace labeling, organization administration IA, visibility/fork activation, and personal-resource grant UX remain separate reviewed slices.
