### PR TITLE
fix(demo): speed up Northstar first load

### DIFF
--- a/.changeset/northstar-fast-first-load.md
+++ b/.changeset/northstar-fast-first-load.md
@@ -1,0 +1,4 @@
+---
+---
+
+Speed up the public Northstar demo first load with gzip static assets and a deferred OpenGeni panel. No published package release.

--- a/examples/northstar-support/package.json
+++ b/examples/northstar-support/package.json
@@ -7,7 +7,7 @@
     "dev": "vite --host 127.0.0.1 --port 3101",
     "server": "bun --env-file=.env.local src/server.ts",
     "start": "bun src/server.ts",
-    "build": "vite build",
+    "build": "vite build && bun ../../scripts/precompress-web-dist.ts dist",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/examples/northstar-support/src/main.tsx
+++ b/examples/northstar-support/src/main.tsx
@@ -1,17 +1,17 @@
-import { OpenGeniProvider } from "@opengeni/react";
-import { OpenGeniClient } from "@opengeni/sdk";
 import { CheckIcon, LifeBuoyIcon, RotateCcwIcon, SparklesIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { SupportAgentPanel } from "./support-agent-panel";
 import { SupportInbox } from "./support-inbox";
 import { SupportTicketView } from "./support-ticket";
 import type { SupportCase } from "./types";
 import { useSupportDemo } from "./use-support-demo";
 import "./styles.css";
 
-const client = new OpenGeniClient({ baseUrl: "/api/opengeni" });
+const SupportAgentPanel = lazy(async () => {
+  const mod = await import("./support-agent-panel");
+  return { default: mod.SupportAgentPanel };
+});
 
 declare global {
   interface Window {
@@ -44,65 +44,65 @@ function NorthstarApp() {
   const selectedState = { revision: demo.state.revision, ...selectedCase };
 
   return (
-    <OpenGeniProvider client={client} workspaceId={demo.health?.workspaceId ?? "unconfigured"}>
-      <div
-        className={
-          agentEnabled
-            ? agentPanelExpanded
-              ? "northstar grid h-dvh min-w-[1120px] grid-cols-[240px_minmax(360px,1fr)_620px] overflow-hidden bg-[#f7f7f5] transition-[grid-template-columns] duration-300 ease-out"
-              : "northstar grid h-dvh min-w-[1120px] grid-cols-[260px_minmax(460px,1fr)_420px] overflow-hidden bg-[#f7f7f5] transition-[grid-template-columns] duration-300 ease-out"
-            : "northstar grid h-dvh min-w-[980px] grid-cols-[320px_minmax(0,1fr)] overflow-hidden bg-[#f7f7f5] transition-[grid-template-columns] duration-300 ease-out"
-        }
-        data-agent-enabled={agentEnabled}
-        data-og-density="compact"
-        data-og-theme="light"
-      >
-        <SupportInbox
-          state={demo.state}
-          selectedTicketId={selectedCase.ticket.id}
+    <div
+      className={
+        agentEnabled
+          ? agentPanelExpanded
+            ? "northstar grid h-dvh min-w-[1120px] grid-cols-[240px_minmax(360px,1fr)_620px] overflow-hidden bg-[#f7f7f5] transition-[grid-template-columns] duration-300 ease-out"
+            : "northstar grid h-dvh min-w-[1120px] grid-cols-[260px_minmax(460px,1fr)_420px] overflow-hidden bg-[#f7f7f5] transition-[grid-template-columns] duration-300 ease-out"
+          : "northstar grid h-dvh min-w-[980px] grid-cols-[320px_minmax(0,1fr)] overflow-hidden bg-[#f7f7f5] transition-[grid-template-columns] duration-300 ease-out"
+      }
+      data-agent-enabled={agentEnabled}
+      data-og-density="compact"
+      data-og-theme="light"
+    >
+      <SupportInbox
+        state={demo.state}
+        selectedTicketId={selectedCase.ticket.id}
+        agentEnabled={agentEnabled}
+        onSelectTicket={(ticketId) => {
+          setSelectedTicketId(ticketId);
+          setSessionId(null);
+        }}
+      />
+
+      <main className="flex min-h-0 min-w-0 flex-col bg-[#f7f7f5]">
+        <ProductHeader
+          supportCase={selectedCase}
           agentEnabled={agentEnabled}
-          onSelectTicket={(ticketId) => {
-            setSelectedTicketId(ticketId);
+          onAgentEnabledChange={(enabled) => {
+            setAgentEnabled(enabled);
+            if (!enabled) setAgentPanelExpanded(false);
             setSessionId(null);
           }}
+          onReset={() => {
+            setSessionId(null);
+            setSelectedTicketId("TKT-2847");
+            void demo.reset();
+          }}
         />
+        <SupportTicketView
+          key={selectedCase.ticket.id}
+          state={selectedState}
+          lastEvent={demo.lastEvent?.ticketId === selectedCase.ticket.id ? demo.lastEvent : null}
+          agentEnabled={agentEnabled}
+          onUpdateTicket={(changes) => demo.updateTicket(selectedCase.ticket.id, changes)}
+          onAddNote={(body) => demo.addNote(selectedCase.ticket.id, body)}
+          onSendReply={(body) => demo.sendReply(selectedCase.ticket.id, body)}
+        />
+      </main>
 
-        <main className="flex min-h-0 min-w-0 flex-col bg-[#f7f7f5]">
-          <ProductHeader
-            supportCase={selectedCase}
-            agentEnabled={agentEnabled}
-            onAgentEnabledChange={(enabled) => {
-              setAgentEnabled(enabled);
-              if (!enabled) setAgentPanelExpanded(false);
-              setSessionId(null);
-            }}
-            onReset={() => {
-              setSessionId(null);
-              setSelectedTicketId("TKT-2847");
-              void demo.reset();
-            }}
-          />
-          <SupportTicketView
-            key={selectedCase.ticket.id}
-            state={selectedState}
-            lastEvent={demo.lastEvent?.ticketId === selectedCase.ticket.id ? demo.lastEvent : null}
-            agentEnabled={agentEnabled}
-            onUpdateTicket={(changes) => demo.updateTicket(selectedCase.ticket.id, changes)}
-            onAddNote={(body) => demo.addNote(selectedCase.ticket.id, body)}
-            onSendReply={(body) => demo.sendReply(selectedCase.ticket.id, body)}
-          />
-        </main>
-
-        <AnimatePresence initial={false}>
-          {agentEnabled ? (
-            <motion.div
-              key="opengeni-panel"
-              initial={{ opacity: 0, x: 56 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: 56 }}
-              transition={{ duration: 0.34, ease: [0.22, 1, 0.36, 1] }}
-              className="min-h-0 min-w-0 overflow-hidden"
-            >
+      <AnimatePresence initial={false}>
+        {agentEnabled ? (
+          <motion.div
+            key="opengeni-panel"
+            initial={{ opacity: 0, x: 56 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: 56 }}
+            transition={{ duration: 0.34, ease: [0.22, 1, 0.36, 1] }}
+            className="min-h-0 min-w-0 overflow-hidden"
+          >
+            <Suspense fallback={<AgentPanelSkeleton />}>
               <SupportAgentPanel
                 health={demo.health}
                 supportCase={selectedCase}
@@ -112,11 +112,11 @@ function NorthstarApp() {
                 onSessionCreated={setSessionId}
                 onClearSession={() => setSessionId(null)}
               />
-            </motion.div>
-          ) : null}
-        </AnimatePresence>
-      </div>
-    </OpenGeniProvider>
+            </Suspense>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
   );
 }
 
@@ -219,6 +219,17 @@ function LoadingScreen() {
         <p className="mt-4 text-sm text-[#7c848b]">Opening Northstar…</p>
       </div>
     </div>
+  );
+}
+
+function AgentPanelSkeleton() {
+  return (
+    <aside className="flex h-full min-h-0 flex-col border-l border-[#302a40] bg-white">
+      <div className="flex h-[72px] items-center gap-3 border-b border-[#302a40] bg-[#252131] px-5">
+        <div className="size-8 animate-pulse rounded-lg bg-white/15" />
+        <div className="h-3 w-24 animate-pulse rounded bg-white/20" />
+      </div>
+    </aside>
   );
 }
 

--- a/examples/northstar-support/src/server.test.ts
+++ b/examples/northstar-support/src/server.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { staticResponse } from "./server";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("Northstar production static serving", () => {
+  test("serves precompressed hashed assets and HEAD without streaming directories", async () => {
+    const root = await fixture();
+    const asset = await staticResponse(
+      new Request("https://demo.opengeni.ai/assets/app-abc123.js", {
+        headers: { "accept-encoding": "br, gzip" },
+      }),
+      "/assets/app-abc123.js",
+      root,
+    );
+    expect(asset.status).toBe(200);
+    expect(asset.headers.get("content-encoding")).toBe("gzip");
+    expect(asset.headers.get("vary")).toBe("Accept-Encoding");
+    expect(asset.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+    expect(
+      await new Response(asset.body!.pipeThrough(new DecompressionStream("gzip"))).text(),
+    ).toBe("export const ready = true;\n");
+
+    const identity = await staticResponse(
+      new Request("https://demo.opengeni.ai/assets/app-abc123.js"),
+      "/assets/app-abc123.js",
+      root,
+    );
+    expect(identity.headers.get("content-encoding")).toBeNull();
+    expect(await identity.text()).toBe("export const ready = true;\n");
+
+    const head = await staticResponse(
+      new Request("https://demo.opengeni.ai/", { method: "HEAD" }),
+      "/",
+      root,
+    );
+    expect(head.status).toBe(200);
+    expect(head.body).toBeNull();
+    expect(head.headers.get("cache-control")).toBe("no-cache");
+
+    const directory = await staticResponse(
+      new Request("https://demo.opengeni.ai/assets/"),
+      "/assets/",
+      root,
+    );
+    expect(directory.status).toBe(404);
+  });
+
+  test("does not turn missing assets or path traversal into the SPA shell", async () => {
+    const root = await fixture();
+    expect(
+      (
+        await staticResponse(
+          new Request("https://demo.opengeni.ai/assets/missing.js"),
+          "/assets/missing.js",
+          root,
+        )
+      ).status,
+    ).toBe(404);
+    expect(
+      (
+        await staticResponse(
+          new Request("https://demo.opengeni.ai/%2e%2e%2fsecret"),
+          "/%2e%2e%2fsecret",
+          root,
+        )
+      ).status,
+    ).toBe(404);
+    const spa = await staticResponse(
+      new Request("https://demo.opengeni.ai/inbox/TKT-2847"),
+      "/inbox/TKT-2847",
+      root,
+    );
+    expect(spa.status).toBe(200);
+    expect(await spa.text()).toContain("Northstar");
+    expect(spa.headers.get("cache-control")).toBe("no-cache");
+  });
+});
+
+async function fixture(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "northstar-static-"));
+  roots.push(root);
+  await mkdir(join(root, "assets"));
+  const js = "export const ready = true;\n";
+  await Bun.write(join(root, "index.html"), "<!doctype html><title>Northstar</title>");
+  await Bun.write(join(root, "assets", "app-abc123.js"), js);
+  await Bun.write(join(root, "assets", "app-abc123.js.gz"), Bun.gzipSync(js));
+  return root;
+}

--- a/examples/northstar-support/src/server.ts
+++ b/examples/northstar-support/src/server.ts
@@ -1,7 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { OpenGeniClient, type CreateSessionRequest } from "@opengeni/sdk";
-import { join, normalize } from "node:path";
+import { stat } from "node:fs/promises";
+import { extname, join, resolve, sep } from "node:path";
 import * as z from "zod/v4";
 import type {
   SupportCase,
@@ -21,6 +22,8 @@ const PRODUCT_APP_ORIGIN = (
 ).replace(/\/+$/, "");
 const STATIC_ROOT = join(import.meta.dir, "../dist");
 const MCP_SERVER_ID = "northstar_support";
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const REVALIDATE_CACHE_CONTROL = "no-cache";
 const MCP_TOOLS = ["get_ticket", "get_customer", "update_ticket", "add_internal_note"];
 const encoder = new TextEncoder();
 
@@ -274,25 +277,98 @@ function json(value: unknown, status = 200): Response {
   });
 }
 
-function staticResponse(pathname: string): Response {
-  const requested = pathname === "/" ? "index.html" : pathname.replace(/^\/+/, "");
-  const safePath = normalize(requested);
-  if (safePath.startsWith("..") || safePath.includes("/../")) {
+function safeStaticPath(root: string, pathname: string): string | null {
+  const candidate = resolve(root, `.${pathname}`);
+  return candidate === root || candidate.startsWith(`${root}${sep}`) ? candidate : null;
+}
+
+function cacheControlFor(pathname: string): string {
+  if (pathname.startsWith("/assets/")) return IMMUTABLE_CACHE_CONTROL;
+  if (pathname === "/" || extname(pathname) === ".html") return REVALIDATE_CACHE_CONTROL;
+  return IMMUTABLE_CACHE_CONTROL;
+}
+
+function acceptsEncoding(header: string | null, encoding: string): boolean {
+  if (!header) return false;
+  for (const entry of header.split(",")) {
+    const segments = entry.trim().split(";");
+    const name = segments[0]?.toLowerCase();
+    if (name !== encoding.toLowerCase() && name !== "*") continue;
+    const parameters = segments.slice(1);
+    const quality = parameters
+      .map((parameter) => parameter.trim())
+      .find((parameter) => parameter.startsWith("q="));
+    return quality ? Number(quality.slice(2)) > 0 : true;
+  }
+  return false;
+}
+
+async function isRegularFile(path: string): Promise<boolean> {
+  const source = Bun.file(path);
+  if (!(await source.exists())) return false;
+  try {
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function serveStaticFile(
+  request: Request,
+  path: string,
+  cacheControl: string,
+): Promise<Response | null> {
+  if (!(await isRegularFile(path))) return null;
+  const source = Bun.file(path);
+  const acceptsGzip =
+    !request.headers.has("range") &&
+    acceptsEncoding(request.headers.get("accept-encoding"), "gzip");
+  const gzip = Bun.file(`${path}.gz`);
+  const encoded = acceptsGzip && (await gzip.exists()) ? gzip : null;
+  const body = encoded ?? source;
+  const headers = new Headers({
+    "cache-control": cacheControl,
+    "content-type": source.type || "application/octet-stream",
+    vary: "Accept-Encoding",
+  });
+  if (encoded) headers.set("content-encoding", "gzip");
+  if (request.method === "HEAD") {
+    headers.set("content-length", String(body.size));
+    return new Response(null, { headers });
+  }
+  return new Response(body, { headers });
+}
+
+export async function staticResponse(
+  request: Request,
+  pathname: string,
+  root = STATIC_ROOT,
+): Promise<Response> {
+  let requested = pathname;
+  try {
+    requested = decodeURIComponent(pathname);
+  } catch {
     return new Response("Not found", { status: 404 });
   }
-  const asset = Bun.file(join(STATIC_ROOT, safePath));
-  if (asset.size > 0) {
-    return new Response(asset, {
-      headers: {
-        "cache-control":
-          safePath === "index.html" ? "no-cache" : "public, max-age=31536000, immutable",
-      },
-    });
+  if (requested.split("/").includes("..")) {
+    return new Response("Not found", { status: 404 });
   }
-  const index = Bun.file(join(STATIC_ROOT, "index.html"));
-  return index.size > 0
-    ? new Response(index, { headers: { "cache-control": "no-cache" } })
-    : new Response("Not found", { status: 404 });
+  requested = requested === "/" ? "/index.html" : requested;
+  const filePath = safeStaticPath(root, requested);
+  if (!filePath) {
+    return new Response("Not found", { status: 404 });
+  }
+  const exact = await serveStaticFile(request, filePath, cacheControlFor(requested));
+  if (exact) return exact;
+  if (requested.startsWith("/assets/")) {
+    return new Response("Not found", { status: 404 });
+  }
+  const indexPath = safeStaticPath(root, "/index.html");
+  if (!indexPath) return new Response("Not found", { status: 404 });
+  return (
+    (await serveStaticFile(request, indexPath, REVALIDATE_CACHE_CONTROL)) ??
+    new Response("Not found", { status: 404 })
+  );
 }
 
 function emit(
@@ -524,7 +600,7 @@ async function productRequest(request: Request): Promise<Response> {
       status: 204,
       headers: {
         "access-control-allow-origin": PRODUCT_APP_ORIGIN,
-        "access-control-allow-methods": "GET, POST, PATCH, OPTIONS",
+        "access-control-allow-methods": "GET, HEAD, POST, PATCH, OPTIONS",
         "access-control-allow-headers": "content-type",
         "access-control-max-age": "86400",
       },
@@ -642,7 +718,9 @@ async function productRequest(request: Request): Promise<Response> {
     emit("demo.reset", "Demo data reset", "all");
     return json(state);
   }
-  if (UNIFIED_SERVER && request.method === "GET") return staticResponse(url.pathname);
+  if (UNIFIED_SERVER && (request.method === "GET" || request.method === "HEAD")) {
+    return await staticResponse(request, url.pathname);
+  }
   return new Response("Not found", { status: 404 });
 }
 
@@ -791,28 +869,30 @@ async function mcpRequest(request: Request): Promise<Response> {
   return await transport.handleRequest(request);
 }
 
-const productServer = Bun.serve({
-  hostname: UNIFIED_SERVER ? "0.0.0.0" : "127.0.0.1",
-  port: PRODUCT_PORT,
-  idleTimeout: 255,
-  fetch: async (request) => {
-    if (UNIFIED_SERVER && new URL(request.url).pathname === "/mcp") {
-      return await mcpRequest(request);
-    }
-    return await productRequest(request);
-  },
-});
-const mcpServer = UNIFIED_SERVER
-  ? productServer
-  : Bun.serve({
-      hostname: "127.0.0.1",
-      port: MCP_PORT,
-      idleTimeout: 255,
-      fetch: mcpRequest,
-    });
+if (import.meta.main) {
+  const productServer = Bun.serve({
+    hostname: UNIFIED_SERVER ? "0.0.0.0" : "127.0.0.1",
+    port: PRODUCT_PORT,
+    idleTimeout: 255,
+    fetch: async (request) => {
+      if (UNIFIED_SERVER && new URL(request.url).pathname === "/mcp") {
+        return await mcpRequest(request);
+      }
+      return await productRequest(request);
+    },
+  });
+  const mcpServer = UNIFIED_SERVER
+    ? productServer
+    : Bun.serve({
+        hostname: "127.0.0.1",
+        port: MCP_PORT,
+        idleTimeout: 255,
+        fetch: mcpRequest,
+      });
 
-console.log(`Northstar product API  http://127.0.0.1:${productServer.port}/api/demo/health`);
-console.log(`Northstar MCP server   http://127.0.0.1:${mcpServer.port}/mcp`);
-console.log("MCP auth               ", mcpToken ? "configured" : "MISSING");
-console.log("OpenGeni auth          ", apiKey ? "configured" : "MISSING");
-console.log("OpenGeni workspace     ", workspaceId || "MISSING");
+  console.log(`Northstar product API  http://127.0.0.1:${productServer.port}/api/demo/health`);
+  console.log(`Northstar MCP server   http://127.0.0.1:${mcpServer.port}/mcp`);
+  console.log("MCP auth               ", mcpToken ? "configured" : "MISSING");
+  console.log("OpenGeni auth          ", apiKey ? "configured" : "MISSING");
+  console.log("OpenGeni workspace     ", workspaceId || "MISSING");
+}

--- a/examples/northstar-support/src/support-agent-panel.tsx
+++ b/examples/northstar-support/src/support-agent-panel.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
+  OpenGeniProvider,
   Markdown,
   MessageTimeline,
   ModelPolicyPicker,
@@ -23,12 +24,18 @@ import {
 } from "@opengeni/react";
 import * as Composer from "@opengeni/react/composer";
 import { SessionRealtimeControl } from "@opengeni/react/realtime";
-import type { EffectiveSessionControl, LatencyMode, ReasoningEffort } from "@opengeni/sdk";
+import {
+  OpenGeniClient,
+  type EffectiveSessionControl,
+  type LatencyMode,
+  type ReasoningEffort,
+} from "@opengeni/sdk";
 import type { DemoHealth, SupportCase } from "./types";
 import { createDemoSession } from "./use-support-demo";
 import { supportToolRegistry } from "./support-tool-renderers";
 
 const DEFAULT_CODEX_MODEL = "codex/gpt-5.6-luna";
+const client = new OpenGeniClient({ baseUrl: "/api/opengeni" });
 
 function demoPrompt(supportCase: SupportCase): string {
   const { ticket, customer } = supportCase;
@@ -39,15 +46,7 @@ function renderNorthstarMessage(text: string) {
   return <Markdown className="northstar-agent-copy">{text}</Markdown>;
 }
 
-export function SupportAgentPanel({
-  health,
-  supportCase,
-  sessionId,
-  expanded,
-  onExpandedChange,
-  onSessionCreated,
-  onClearSession,
-}: {
+type SupportAgentPanelProps = {
   health: DemoHealth | null;
   supportCase: SupportCase;
   sessionId: string | null;
@@ -55,7 +54,25 @@ export function SupportAgentPanel({
   onExpandedChange: (expanded: boolean) => void;
   onSessionCreated: (sessionId: string) => void;
   onClearSession: () => void;
-}) {
+};
+
+export function SupportAgentPanel(props: SupportAgentPanelProps) {
+  return (
+    <OpenGeniProvider client={client} workspaceId={props.health?.workspaceId ?? "unconfigured"}>
+      <SupportAgentPanelView {...props} />
+    </OpenGeniProvider>
+  );
+}
+
+function SupportAgentPanelView({
+  health,
+  supportCase,
+  sessionId,
+  expanded,
+  onExpandedChange,
+  onSessionCreated,
+  onClearSession,
+}: SupportAgentPanelProps) {
   const [starting, setStarting] = useState(false);
   const [startError, setStartError] = useState<Error | null>(null);
   const [selectedModel, setSelectedModel] = useState<string | null>(null);

--- a/examples/northstar-support/src/use-support-demo.ts
+++ b/examples/northstar-support/src/use-support-demo.ts
@@ -73,7 +73,7 @@ export function useSupportDemo(): SupportDemoResult {
         .catch((cause: unknown) => {
           setError(cause instanceof Error ? cause : new Error(String(cause)));
         });
-    }, 3_000);
+    }, 15_000);
     const onDomainEvent = (event: MessageEvent<string>) => {
       try {
         const parsed = JSON.parse(event.data) as SupportDomainEvent;


### PR DESCRIPTION
## Why
`https://demo.opengeni.ai` was serving the 1.0 MB Northstar JS bundle uncompressed (no `Content-Encoding`) while `app.opengeni.ai` already serves precompressed gzip. HEAD returned 404, `/assets/` logged `EISDIR`, and opening the product with OpenGeni **off** still mounted `OpenGeniProvider` (client config + workspace live stream) and pulled the agent UI into the initial graph.

Measured from this sandbox:
- `index-*.js` 1,034,710 B raw → 295,738 B gzip
- `index-*.css` 129,218 B raw → 20,253 B gzip
- TTFB ~250–350 ms, but the uncompressed JS download dominated first load

## What
- Serve hashed assets from the same precompressed `.gz` path as production web (`scripts/precompress-web-dist.ts` after Vite).
- Handle GET/HEAD, refuse directory bodies and path traversal, and 404 missing `/assets/*` instead of returning the SPA shell.
- Lazy-load the OpenGeni panel and mount the provider only after the switch is on.
- Reconcile product state every 15s (SSE remains the live path) instead of polling every 3s.

## Verify
- `bun test examples/northstar-support`
- `bun run --cwd examples/northstar-support typecheck`

After merge, redeploy with `opengeni-ops` **Deploy Northstar Demo** using this SHA so `demo.opengeni.ai` picks up gzip + deferred OpenGeni.