### PR TITLE
fix(ci): enforce native step timeout caps

### DIFF
--- a/.github/actions/playwright-browsers/action.yml
+++ b/.github/actions/playwright-browsers/action.yml
@@ -98,6 +98,7 @@ runs:
         PLAYWRIGHT_ONLY_SHELL: ${{ inputs.only-shell }}
         ATTEMPT_TIMEOUT_SECONDS: ${{ inputs.attempt-timeout-seconds }}
         ATTEMPTS: ${{ inputs.attempts }}
+        KILL_AFTER_SECONDS: "15"
       run: |
         set -uo pipefail
         only_shell=""
@@ -112,7 +113,7 @@ runs:
           # `|| status=$?` guard the first failing attempt aborts the script,
           # so the retry, the warnings, and the error summary never run.
           status=0
-          timeout --kill-after=15s "${ATTEMPT_TIMEOUT_SECONDS}s" \
+          timeout --kill-after="${KILL_AFTER_SECONDS}s" "${ATTEMPT_TIMEOUT_SECONDS}s" \
             bun x playwright install --with-deps ${only_shell} ${PLAYWRIGHT_BROWSERS} || status=$?
           echo "::endgroup::"
           if [ "${status}" -eq 0 ]; then

--- a/.github/actions/playwright-browsers/action.yml
+++ b/.github/actions/playwright-browsers/action.yml
@@ -137,9 +137,13 @@ runs:
     # step. One step is sufficient because it reduces the re-run to a
     # single-browser download, which has never breached the bound - but it does
     # mean a partial set persists for the life of this Playwright version.
-    # A SIGKILLed install can leave a stale __dirlock behind. Playwright only
-    # treats it as stale after ~5 minutes, so baking it into an immutable cache
-    # would tax every later run against this key.
+    # A SIGKILLed install can leave a stale __dirlock behind. Playwright locks
+    # the registry through proper-lockfile passing only retries/onCompromised/
+    # lockfilePath, so the default `stale: 10000` applies - the lock clears
+    # after ~10 seconds, not the ~5 minutes an earlier revision of this comment
+    # claimed. Removing it is therefore cheap hygiene rather than a large
+    # saving: it keeps a lock out of an immutable cache entry and avoids the
+    # onCompromised path entirely.
     - name: Drop stale Playwright dirlock before saving
       if: ${{ always() && steps.restore.outputs.cache-hit != 'true' }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
           bun-version-file: .bun-version
 
       - name: Install exact dependency tree
+        timeout-minutes: 11
         env:
           BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/opengeni-bun-store
         run: >-
@@ -359,6 +360,7 @@ jobs:
           fi
 
       - name: Profile impacted TypeScript 7 projects
+        timeout-minutes: 11
         run: >-
           bun scripts/ci/profile-command.ts
           --name typecheck
@@ -368,6 +370,7 @@ jobs:
           --plan ${{ runner.temp }}/ci-impact-plan/impact-plan.json
 
       - name: Run exactly the explained source guards
+        timeout-minutes: 16
         run: >-
           bun scripts/ci/profile-command.ts
           --name guards
@@ -436,6 +439,7 @@ jobs:
           name: ci-impact-plan
 
       - name: Unit test shard
+        timeout-minutes: 21
         env:
           # The per-subject FORCE-RLS/OCC suite remains fail-closed on every shard.
           OPENGENI_REQUIRE_REAL_DB: "1"
@@ -487,6 +491,7 @@ jobs:
           name: ci-impact-plan
 
       - name: Run real PostgreSQL, pgvector, Temporal, NATS, and object-storage tests
+        timeout-minutes: 31
         run: >-
           bun scripts/ci/profile-command.ts
           --name integration-${{ matrix.number }}
@@ -570,10 +575,12 @@ jobs:
       # web-broad candidate.
       - name: Install pinned browser runtimes
         uses: ./.github/actions/playwright-browsers
+        timeout-minutes: 17
         with:
           browsers: chromium firefox
 
       - name: Run exactly the impacted E2E tests
+        timeout-minutes: 13
         run: >-
           bun scripts/ci/profile-command.ts
           --name e2e-${{ matrix.number }}
@@ -628,6 +635,7 @@ jobs:
         run: bun run test:react:clean
 
       - name: Real workspace capture acceptance
+        timeout-minutes: 13
         run: >-
           bun test --max-concurrency=1 --timeout 720000
           --test-name-pattern
@@ -639,6 +647,7 @@ jobs:
       # suite split cannot silently drop either the exactly-once/active-goal proof
       # or the real-Postgres shrink proof.
       - name: Recovery integration regressions
+        timeout-minutes: 5
         run: |
           bun test --timeout 30000 \
             --test-name-pattern \
@@ -702,17 +711,11 @@ jobs:
             'Acquire::https::Timeout "30";' \
             | sudo tee /etc/apt/apt.conf.d/99opengeni-ci-network >/dev/null
 
-      - name: Install pinned Chromium runtime
-        if: ${{ matrix.lane != 'workbench' }}
+      - name: Install pinned lane browser runtimes
         uses: ./.github/actions/playwright-browsers
+        timeout-minutes: 17
         with:
-          browsers: chromium
-
-      - name: Install pinned cross-browser runtimes
-        if: ${{ matrix.lane == 'workbench' }}
-        uses: ./.github/actions/playwright-browsers
-        with:
-          browsers: chromium firefox webkit
+          browsers: ${{ matrix.lane == 'workbench' && 'chromium firefox webkit' || 'chromium' }}
 
       - name: Editable artifact browser acceptance
         if: ${{ matrix.lane == 'workbench' }}
@@ -770,6 +773,7 @@ jobs:
       - name: Session pin browser acceptance
         if: ${{ matrix.lane == 'knowledge' }}
         id: session_pin_browser
+        timeout-minutes: 4
         env:
           # This browser gate must fail when its real PostgreSQL boundary is unavailable.
           OPENGENI_REQUIRE_REAL_DB: "1"
@@ -777,6 +781,7 @@ jobs:
 
       - name: Responsive knowledge surfaces browser acceptance
         if: ${{ matrix.lane == 'knowledge' }}
+        timeout-minutes: 6
         env:
           # This gate traverses the public configured-principal API and must fail
           # rather than skip when its real PostgreSQL boundary is unavailable.
@@ -786,6 +791,7 @@ jobs:
       - name: Workbench browser acceptance
         if: ${{ matrix.lane == 'workbench' }}
         id: workbench_browser
+        timeout-minutes: 4
         run: bun test --max-concurrency=1 --timeout 180000 ./test/e2e/workbench.browser.e2e.ts
 
       - name: Upload session pin visual evidence
@@ -938,6 +944,7 @@ jobs:
             bun run --cwd packages/artifact-tool test:production-native
 
       - name: Build client packages (contracts + SDK + React)
+        timeout-minutes: 21
         env:
           OPENGENI_BUILD_CACHE_REPORT: ci-profile/package-cache.json
         run: >-
@@ -974,6 +981,7 @@ jobs:
 
       - name: Install Chromium for packed WASM package proof
         uses: ./.github/actions/playwright-browsers
+        timeout-minutes: 17
         with:
           browsers: chromium
           only-shell: "true"

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -47,4 +47,5 @@ jobs:
       # live-Modal half stays skipped (no OPENGENI_P41_LIVE_MODAL). Docker is
       # available on ubuntu-latest, so dockerAvailable() is true here.
       - name: Desktop image e2e
+        timeout-minutes: 36
         run: bun test --timeout 2100000 ./apps/worker/test/desktop-image.e2e.ts

--- a/scripts/artifact-runtime-workflow-contract.test.ts
+++ b/scripts/artifact-runtime-workflow-contract.test.ts
@@ -78,7 +78,9 @@ describe("artifact runtime workflow contract", () => {
     }
     expect(candidate).toContain("cancel-in-progress: false");
     expect(ci).toContain("github.event_name != 'workflow_dispatch'");
-    expect(ci).toContain("browsers: chromium firefox webkit");
+    expect(ci).toContain(
+      "browsers: ${{ matrix.lane == 'workbench' && 'chromium firefox webkit' || 'chromium' }}",
+    );
     for (const suite of [
       "artifact-spreadsheet-canvas.browser.e2e.ts",
       "artifact-spreadsheet-scroll.browser.e2e.ts",

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -3651,8 +3651,7 @@ describe("workflow contracts", () => {
       ],
       "browser-acceptance": [
         "Stabilize Ubuntu package downloads",
-        "Install pinned Chromium runtime",
-        "Install pinned cross-browser runtimes",
+        "Install pinned lane browser runtimes",
         "Editable artifact browser acceptance",
         "Install pinned artifact native toolchain",
         "Editable artifact full-stack browser acceptance",
@@ -3779,16 +3778,12 @@ describe("workflow contracts", () => {
     );
     expect(browserInstalls).toEqual([
       {
-        name: "Install pinned Chromium runtime",
-        if: "${{ matrix.lane != 'workbench' }}",
+        name: "Install pinned lane browser runtimes",
         uses: "./.github/actions/playwright-browsers",
-        with: { browsers: "chromium" },
-      },
-      {
-        name: "Install pinned cross-browser runtimes",
-        if: "${{ matrix.lane == 'workbench' }}",
-        uses: "./.github/actions/playwright-browsers",
-        with: { browsers: "chromium firefox webkit" },
+        "timeout-minutes": 17,
+        with: {
+          browsers: "${{ matrix.lane == 'workbench' && 'chromium firefox webkit' || 'chromium' }}",
+        },
       },
     ]);
     expect(

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -9,11 +9,23 @@ const playwrightActionPath = resolve(root, ".github/actions/playwright-browsers/
 const PLAYWRIGHT_ACTION = "./.github/actions/playwright-browsers";
 const MAX_TIMEOUT_MINUTES = 120;
 const JOB_SETUP_ALLOWANCE_MINUTES = 1;
-const AMBIGUOUS_SHELL_TEXT = "\0";
-const ASSEMBLY_FRAGMENT_WINDOW = 24;
 const TIMEOUT_SPELLINGS = ["timeout", "gtimeout", "--timeout", "--timeout-seconds"] as const;
+const MAX_INTERPRETED_ANSI_BODY_CHARS = 128;
 const ATTEMPT_TIMEOUT_INPUT = "${{ inputs.attempt-timeout-seconds }}";
 const ATTEMPTS_INPUT = "${{ inputs.attempts }}";
+
+const TIMEOUT_TARGETS = TIMEOUT_SPELLINGS.map((spelling) => {
+  const literalMasks = new Map<string, number>();
+  for (const [index, character] of [...spelling].entries()) {
+    literalMasks.set(character, (literalMasks.get(character) ?? 0) | (1 << index));
+  }
+  return {
+    spelling,
+    literalMasks,
+    endBit: 1 << spelling.length,
+    allPositionsMask: (1 << (spelling.length + 1)) - 1,
+  } as const;
+});
 
 type Step = Readonly<{
   name?: string;
@@ -160,82 +172,291 @@ function positiveNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
 }
 
-function ambiguousShellProjection(source: string): string {
-  return source
-    .replace(
-      /\$'((?:\\[\s\S]|[^']){0,128})'/gu,
-      (_whole, body: string) =>
-        AMBIGUOUS_SHELL_TEXT +
-        body.replace(/\\(?:x[0-9A-Fa-f]{1,2}|u[0-9A-Fa-f]{1,4}|[\s\S])/gu, AMBIGUOUS_SHELL_TEXT) +
-        AMBIGUOUS_SHELL_TEXT,
-    )
-    .replace(/\$\{[^}\r\n]{0,128}\}/gu, AMBIGUOUS_SHELL_TEXT)
-    .replace(/\$\([^\r\n)]{0,128}\)/gu, AMBIGUOUS_SHELL_TEXT)
-    .replace(/;\s*[A-Za-z_][A-Za-z0-9_]*\s*\+=/gu, AMBIGUOUS_SHELL_TEXT)
-    .replace(/\$[A-Za-z_][A-Za-z0-9_]*/gu, AMBIGUOUS_SHELL_TEXT)
-    .replace(/["']/gu, "");
+function isAsciiLetter(character: string): boolean {
+  const code = character.charCodeAt(0);
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
 }
 
-function hasAmbiguousTimeoutAssembly(source: string): boolean {
-  const projection = ambiguousShellProjection(source);
-  for (const ambiguity of projection.matchAll(/\0+/gu)) {
-    const index = ambiguity.index;
-    if (index === undefined) continue;
-    const left =
-      /(?:--)?[A-Za-z-]+$/u.exec(
-        projection.slice(Math.max(0, index - ASSEMBLY_FRAGMENT_WINDOW), index),
-      )?.[0] ?? "";
-    const right =
-      /^(?:--)?[A-Za-z-]+/u.exec(
-        projection.slice(index + ambiguity[0].length, index + ASSEMBLY_FRAGMENT_WINDOW),
-      )?.[0] ?? "";
-    for (const target of TIMEOUT_SPELLINGS) {
-      for (
-        let leftLength = 0;
-        leftLength <= Math.min(left.length, target.length);
-        leftLength += 1
-      ) {
-        const prefix = leftLength === 0 ? "" : left.slice(-leftLength);
-        if (leftLength > 0 && !target.startsWith(prefix)) continue;
-        for (
-          let rightLength = 0;
-          rightLength <= Math.min(right.length, target.length - leftLength);
-          rightLength += 1
-        ) {
-          const suffix = right.slice(0, rightLength);
-          if (leftLength + rightLength >= 4 && (rightLength === 0 || target.endsWith(suffix))) {
-            return true;
-          }
-        }
-      }
-    }
+function isTokenCharacter(character: string): boolean {
+  const code = character.charCodeAt(0);
+  return (
+    isAsciiLetter(character) || (code >= 48 && code <= 57) || character === "_" || character === "-"
+  );
+}
+
+function isIdentifierStart(character: string): boolean {
+  return isAsciiLetter(character) || character === "_";
+}
+
+function isIdentifierContinuation(character: string): boolean {
+  const code = character.charCodeAt(0);
+  return isIdentifierStart(character) || (code >= 48 && code <= 57);
+}
+
+function isSpecialShellParameter(character: string): boolean {
+  const code = character.charCodeAt(0);
+  return (
+    (code >= 48 && code <= 57) ||
+    character === "@" ||
+    character === "*" ||
+    character === "#" ||
+    character === "?" ||
+    character === "-" ||
+    character === "$" ||
+    character === "!"
+  );
+}
+
+function isHorizontalShellWhitespace(character: string): boolean {
+  return character === " " || character === "\t" || character === "\r";
+}
+
+function isHexDigit(character: string): boolean {
+  const code = character.charCodeAt(0);
+  return (code >= 48 && code <= 57) || (code >= 65 && code <= 70) || (code >= 97 && code <= 102);
+}
+
+function ansiEscapeEnd(source: string, backslashIndex: number, limit: number): number {
+  const escapeKind = source[backslashIndex + 1];
+  if (escapeKind === undefined || backslashIndex + 1 >= limit) return backslashIndex + 1;
+
+  let maxDigits = 0;
+  let index = backslashIndex + 2;
+  if (escapeKind === "x") maxDigits = 2;
+  else if (escapeKind === "u") maxDigits = 4;
+  else if (escapeKind === "U") maxDigits = 8;
+  else if (escapeKind >= "0" && escapeKind <= "7") {
+    maxDigits = 2;
+    index = backslashIndex + 2;
+  } else {
+    return backslashIndex + 2;
   }
-  return false;
+
+  let consumedDigits = 0;
+  while (
+    index < limit &&
+    consumedDigits < maxDigits &&
+    (escapeKind === "x" || escapeKind === "u" || escapeKind === "U"
+      ? isHexDigit(source[index] ?? "")
+      : (source[index] ?? "") >= "0" && (source[index] ?? "") <= "7")
+  ) {
+    index += 1;
+    consumedDigits += 1;
+  }
+  return index;
+}
+
+function appendValueStart(source: string, separatorIndex: number): number | null {
+  const separator = source[separatorIndex];
+  if (separator !== ";" && separator !== "\n") return null;
+
+  let index = separatorIndex + 1;
+  while (index < source.length && isHorizontalShellWhitespace(source[index] ?? "")) index += 1;
+  if (!isIdentifierStart(source[index] ?? "")) return null;
+  index += 1;
+  while (index < source.length && isIdentifierContinuation(source[index] ?? "")) index += 1;
+  while (index < source.length && isHorizontalShellWhitespace(source[index] ?? "")) index += 1;
+  return source[index] === "+" && source[index + 1] === "=" ? index + 2 : null;
+}
+
+function shellExpansionEnd(
+  source: string,
+  startIndex: number,
+  closingCharacter: "}" | ")",
+): number {
+  let index = startIndex;
+  while (index < source.length && source[index] !== "\n" && source[index] !== closingCharacter) {
+    index += 1;
+  }
+  return source[index] === closingCharacter ? index + 1 : index;
+}
+
+function hasDirectTimeoutSpelling(source: string): boolean {
+  let targetMasks = TIMEOUT_TARGETS.map(() => 1);
+  let quote: "'" | '"' | null = null;
+
+  const finishToken = () => {
+    const found = TIMEOUT_TARGETS.some(
+      (target, index) => (targetMasks[index] & target.endBit) !== 0,
+    );
+    targetMasks = TIMEOUT_TARGETS.map(() => 1);
+    return found;
+  };
+
+  const feedLiteral = (character: string) => {
+    for (const [index, target] of TIMEOUT_TARGETS.entries()) {
+      targetMasks[index] = (targetMasks[index] & (target.literalMasks.get(character) ?? 0)) << 1;
+    }
+  };
+
+  let index = 0;
+  while (index < source.length) {
+    const character = source[index] ?? "";
+    if (character === "'" || character === '"') {
+      if (quote === null) quote = character;
+      else if (quote === character) quote = null;
+      index += 1;
+      continue;
+    }
+    if (character === "\\" && (source[index + 1] === "\n" || source[index + 1] === "\r")) {
+      index += source[index + 1] === "\r" && source[index + 2] === "\n" ? 3 : 2;
+      continue;
+    }
+    if (character === "\\" && isTokenCharacter(source[index + 1] ?? "")) {
+      feedLiteral(source[index + 1] ?? "");
+      index += 2;
+      continue;
+    }
+    if (isTokenCharacter(character)) feedLiteral(character);
+    else if (finishToken()) return true;
+    index += 1;
+  }
+  return finishToken();
 }
 
 /**
  * This is deliberately lexical, not a shell parser. It joins line continuations
  * and removes quote/backslash spelling noise so known timeout words cannot hide,
  * but it never tries to execute, branch, expand, or add inner command budgets.
+ * Each target owns a fixed bitset of at most 18 prefix positions. A literal
+ * advances matching bits; a recognized ambiguity opens the remaining suffix.
+ * Repeating an ambiguity is therefore constant work, and a generic ambiguity
+ * cannot close a token without a literal boundary on its far side.
  */
 function hasTimeoutSpelling(source: string): boolean {
-  const normalized = source
-    .replace(/\\\r?\n/gu, "")
-    .replace(/\\(?=[A-Za-z-])/gu, "")
-    .replace(/["']/gu, "");
-  if (
-    /(^|[^A-Za-z0-9_])(?:gtimeout|timeout|--timeout(?:-seconds)?)(?=$|[^A-Za-z0-9_])/u.test(
-      normalized,
-    )
-  ) {
-    return true;
-  }
+  if (hasDirectTimeoutSpelling(source)) return true;
 
-  // This bounded ambiguity projection is not shell evaluation. It collapses
-  // nearby expansions, ANSI escapes, and append-shaped text to one marker, then
-  // asks whether that marker could complete a known spelling. It never decodes
-  // the middle, follows a variable, or infers an inner duration.
-  return hasAmbiguousTimeoutAssembly(source);
+  let targetMasks = TIMEOUT_TARGETS.map(() => 1);
+  let terminalKind: "literal" | "bridge" | "ansi" | null = null;
+  let quote: "'" | '"' | null = null;
+  let matched = false;
+
+  const finishToken = () => {
+    for (const [index, target] of TIMEOUT_TARGETS.entries()) {
+      if (
+        (terminalKind === "literal" || terminalKind === "ansi") &&
+        (targetMasks[index] & target.endBit) !== 0
+      ) {
+        matched = true;
+      }
+    }
+    targetMasks = TIMEOUT_TARGETS.map(() => 1);
+    terminalKind = null;
+  };
+
+  const feedLiteral = (character: string) => {
+    for (const [index, target] of TIMEOUT_TARGETS.entries()) {
+      targetMasks[index] = (targetMasks[index] & (target.literalMasks.get(character) ?? 0)) << 1;
+    }
+    terminalKind = "literal";
+  };
+
+  const feedAmbiguity = (kind: "bridge" | "ansi") => {
+    for (const [index, target] of TIMEOUT_TARGETS.entries()) {
+      const mask = targetMasks[index];
+      if (mask === 0) continue;
+      const lowestPositionBit = mask & -mask;
+      targetMasks[index] = target.allPositionsMask & ~(lowestPositionBit - 1);
+    }
+    terminalKind = kind;
+  };
+
+  const feedSourceCharacter = (character: string) => {
+    if (isTokenCharacter(character)) feedLiteral(character);
+    else finishToken();
+  };
+
+  let index = 0;
+  while (index < source.length) {
+    if (matched) return true;
+    const appendStart = appendValueStart(source, index);
+    if (appendStart !== null) {
+      feedAmbiguity("bridge");
+      index = appendStart;
+      continue;
+    }
+
+    const character = source[index] ?? "";
+    if (character === "\\" && (source[index + 1] === "\n" || source[index + 1] === "\r")) {
+      index += source[index + 1] === "\r" && source[index + 2] === "\n" ? 3 : 2;
+      continue;
+    }
+    if (character === "\\" && isTokenCharacter(source[index + 1] ?? "")) {
+      feedLiteral(source[index + 1] ?? "");
+      index += 2;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      if (quote === null) quote = character;
+      else if (quote === character) quote = null;
+      index += 1;
+      continue;
+    }
+
+    if (character === "$" && source[index + 1] === "'" && quote === null) {
+      const bodyStart = index + 2;
+      let bodyEnd = bodyStart;
+      let closed = false;
+      while (bodyEnd < source.length) {
+        if (source[bodyEnd] === "\\") {
+          bodyEnd = ansiEscapeEnd(source, bodyEnd, source.length);
+          continue;
+        }
+        if (source[bodyEnd] === "'") {
+          closed = true;
+          break;
+        }
+        bodyEnd += 1;
+      }
+
+      if (!closed || bodyEnd - bodyStart > MAX_INTERPRETED_ANSI_BODY_CHARS) {
+        feedAmbiguity("ansi");
+        index = closed ? bodyEnd + 1 : source.length;
+        continue;
+      }
+      if (bodyEnd === bodyStart) feedAmbiguity("bridge");
+      let bodyIndex = bodyStart;
+      while (bodyIndex < bodyEnd) {
+        if (source[bodyIndex] === "\\") {
+          feedAmbiguity("ansi");
+          bodyIndex = ansiEscapeEnd(source, bodyIndex, bodyEnd);
+        } else {
+          feedSourceCharacter(source[bodyIndex] ?? "");
+          bodyIndex += 1;
+        }
+        if (matched) break;
+      }
+      index = bodyEnd + 1;
+      continue;
+    }
+
+    if (character === "$" && source[index + 1] === "{") {
+      feedAmbiguity("bridge");
+      index = shellExpansionEnd(source, index + 2, "}");
+      continue;
+    }
+    if (character === "$" && source[index + 1] === "(") {
+      feedAmbiguity("bridge");
+      index = shellExpansionEnd(source, index + 2, ")");
+      continue;
+    }
+    if (character === "$" && isIdentifierStart(source[index + 1] ?? "")) {
+      feedAmbiguity("bridge");
+      index += 2;
+      while (index < source.length && isIdentifierContinuation(source[index] ?? "")) index += 1;
+      continue;
+    }
+    if (character === "$" && isSpecialShellParameter(source[index + 1] ?? "")) {
+      feedAmbiguity("bridge");
+      index += 2;
+      continue;
+    }
+
+    feedSourceCharacter(character);
+    index += 1;
+  }
+  finishToken();
+  return matched;
 }
 
 async function loadWorkflows(): Promise<Workflows> {
@@ -566,6 +787,17 @@ describe("workflow timeout contract", () => {
       "gti${EMPTY}meout 10h job",
       'bun test --timeo$(printf "")ut 720000',
       'flag=--ti; flag+=meout-seconds; bun test "$flag" 720',
+      "ti$''me$''out 10h job",
+      "EMPTY=; ti${EMPTY}me${EMPTY}out 10h job",
+      "ti$(printf '')me$(printf '')out 10h job",
+      "t$''i$''m$''e$''o$''u$''t 10h job",
+      "t${EMPTY}i${EMPTY}m${EMPTY}e${EMPTY}o${EMPTY}u${EMPTY}t 10h job",
+      "ti$8me$9out 10h job",
+      "$'\\x74\\x69\\x6d\\x65\\x6f\\x75\\x74' 10h job",
+      "$'\\164\\151\\155\\145\\157\\165\\164' 10h job",
+      'cmd=t; cmd+=i; cmd+=m; cmd+=e; cmd+=o; cmd+=u; cmd+=t; "$cmd" 10h job',
+      'cmd=t\ncmd+=i\ncmd+=m\ncmd+=e\ncmd+=o\ncmd+=u\ncmd+=t\n"$cmd" 10h job',
+      'flag=-; flag+=-; flag+=t; flag+=i; flag+=m; flag+=e; flag+=o; flag+=u; flag+=t; flag+=-seconds; bun test "$flag" 720',
     ];
     for (const probe of probes) {
       expect(inspectWorkflowCaps(syntheticWorkflow(probe), action).violations.length, probe).toBe(
@@ -579,6 +811,48 @@ describe("workflow timeout contract", () => {
         jobCap: 60,
       });
     }
+  });
+
+  test("lexical ambiguity stays token-bound and rejects ordinary suffix expansions", async () => {
+    const action = await loadPlaywrightAction();
+    const probes = [
+      "echo runtime${VERSION}",
+      "echo uptime${SECONDS}",
+      "echo time${ZONE}",
+      "echo ${PREFIX}timeoutish",
+      "echo gtimeoutish",
+      "echo my-timeout",
+      "echo --timeout-seconds-extra",
+      "echo runtime$'\\x74'",
+      "echo $'\\x74\\x69\\x6d\\x65\\x6f\\x75\\x74'ish",
+      "echo time$'\\x6f'utish",
+      'cmd=runtime; cmd+=version; echo "$cmd"',
+    ];
+    for (const probe of probes) {
+      expect(inspectWorkflowCaps(syntheticWorkflow(probe), action).violations, probe).toEqual([]);
+    }
+  });
+
+  test("the lexical scanner is bounded on malformed and dense ambiguity input", () => {
+    expect(hasTimeoutSpelling("echo $'unterminated")).toBe(true);
+    expect(hasTimeoutSpelling("echo runtime${BROKEN")).toBe(false);
+    expect(hasTimeoutSpelling("echo uptime$(broken")).toBe(false);
+
+    const denseFalsePositiveProbe = "runtime${VERSION};".repeat(100_000);
+    expect(denseFalsePositiveProbe.length).toBeGreaterThan(1_000_000);
+    const falsePositiveStartedAt = performance.now();
+    expect(hasTimeoutSpelling(denseFalsePositiveProbe)).toBe(false);
+    expect(performance.now() - falsePositiveStartedAt).toBeLessThan(5_000);
+
+    const repeatedMarkerProbe = `ti${"$''".repeat(100_000)}meout`;
+    const repeatedMarkerStartedAt = performance.now();
+    expect(hasTimeoutSpelling(repeatedMarkerProbe)).toBe(true);
+    expect(performance.now() - repeatedMarkerStartedAt).toBeLessThan(5_000);
+
+    const denseMalformedStatements = "\n".repeat(1_100_000);
+    const malformedStatementsStartedAt = performance.now();
+    expect(hasTimeoutSpelling(denseMalformedStatements)).toBe(false);
+    expect(performance.now() - malformedStatementsStartedAt).toBeLessThan(5_000);
   });
 
   test("shell structure never creates inferred inner sums", async () => {

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -1,157 +1,517 @@
 import { describe, expect, test } from "bun:test";
 import { chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 
 const root = resolve(import.meta.dir, "..");
 const workflowDir = resolve(root, ".github/workflows");
-
-// GitHub's default job timeout is 360 minutes. A job that wedges - the observed
-// case is an unbounded `playwright install` whose download stalls - therefore
-// holds a runner slot for six hours. Because GitHub-hosted concurrency is an
-// account-level pool, a handful of wedged jobs stop every other pull request in
-// the repository from being dispatched at all. Every job must bound itself so a
-// hang degrades to one visible, re-runnable failure instead of a repo outage.
+const playwrightActionPath = resolve(root, ".github/actions/playwright-browsers/action.yml");
+const PLAYWRIGHT_ACTION = "./.github/actions/playwright-browsers";
 const MAX_TIMEOUT_MINUTES = 120;
+const JOB_SETUP_ALLOWANCE_MINUTES = 1;
+
+type Step = Readonly<{
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Readonly<Record<string, unknown>>;
+  "timeout-minutes"?: unknown;
+}>;
 
 type Job = Readonly<{
   uses?: string;
-  "timeout-minutes"?: number;
+  steps?: readonly Step[];
+  "timeout-minutes"?: unknown;
 }>;
 
-type Step = Readonly<{ run?: string; uses?: string }>;
+type Workflow = Readonly<{ jobs?: Readonly<Record<string, Job>> }>;
+type Workflows = Readonly<Record<string, Workflow>>;
 
-async function workflowFiles(): Promise<readonly string[]> {
-  const entries = await readdir(workflowDir);
-  return entries.filter((entry) => entry.endsWith(".yml") || entry.endsWith(".yaml")).sort();
+type PlaywrightAction = Readonly<{
+  inputs?: Readonly<Record<string, Readonly<{ default?: unknown }>>>;
+  runs?: Readonly<{ steps?: readonly Readonly<{ name?: string; run?: string }>[] }>;
+}>;
+
+type StepIdentity = Readonly<{
+  file: string;
+  job: string;
+  name: string;
+  cap: number;
+}>;
+
+const EXPECTED_CAPPED_STEPS: readonly StepIdentity[] = [
+  { file: "ci.yml", job: "plan", name: "Install exact dependency tree", cap: 11 },
+  {
+    file: "ci.yml",
+    job: "source-contracts",
+    name: "Profile impacted TypeScript 7 projects",
+    cap: 11,
+  },
+  {
+    file: "ci.yml",
+    job: "source-contracts",
+    name: "Run exactly the explained source guards",
+    cap: 16,
+  },
+  { file: "ci.yml", job: "unit-shards", name: "Unit test shard", cap: 21 },
+  {
+    file: "ci.yml",
+    job: "integration-shards",
+    name: "Run real PostgreSQL, pgvector, Temporal, NATS, and object-storage tests",
+    cap: 31,
+  },
+  {
+    file: "ci.yml",
+    job: "e2e-shards",
+    name: "Run exactly the impacted E2E tests",
+    cap: 13,
+  },
+  {
+    file: "ci.yml",
+    job: "package-contracts",
+    name: "Build client packages (contracts + SDK + React)",
+    cap: 21,
+  },
+  {
+    file: "ci.yml",
+    job: "test-suite",
+    name: "Real workspace capture acceptance",
+    cap: 13,
+  },
+  {
+    file: "ci.yml",
+    job: "test-suite",
+    name: "Recovery integration regressions",
+    cap: 5,
+  },
+  {
+    file: "ci.yml",
+    job: "browser-acceptance",
+    name: "Session pin browser acceptance",
+    cap: 4,
+  },
+  {
+    file: "ci.yml",
+    job: "browser-acceptance",
+    name: "Responsive knowledge surfaces browser acceptance",
+    cap: 6,
+  },
+  {
+    file: "ci.yml",
+    job: "browser-acceptance",
+    name: "Workbench browser acceptance",
+    cap: 4,
+  },
+  {
+    file: "desktop-e2e.yml",
+    job: "desktop-image",
+    name: "Desktop image e2e",
+    cap: 36,
+  },
+  {
+    file: "ci.yml",
+    job: "e2e-shards",
+    name: "Install pinned browser runtimes",
+    cap: 17,
+  },
+  {
+    file: "ci.yml",
+    job: "browser-acceptance",
+    name: "Install pinned lane browser runtimes",
+    cap: 17,
+  },
+  {
+    file: "ci.yml",
+    job: "package-contracts",
+    name: "Install Chromium for packed WASM package proof",
+    cap: 17,
+  },
+];
+
+const EXPECTED_JOB_BUDGETS = {
+  "ci.yml:plan": { stepCaps: 11, needed: 12, jobCap: 15 },
+  "ci.yml:source-contracts": { stepCaps: 27, needed: 28, jobCap: 35 },
+  "ci.yml:unit-shards": { stepCaps: 21, needed: 22, jobCap: 30 },
+  "ci.yml:integration-shards": { stepCaps: 31, needed: 32, jobCap: 40 },
+  "ci.yml:e2e-shards": { stepCaps: 30, needed: 31, jobCap: 35 },
+  "ci.yml:test-suite": { stepCaps: 18, needed: 19, jobCap: 30 },
+  "ci.yml:browser-acceptance": { stepCaps: 31, needed: 32, jobCap: 35 },
+  "ci.yml:package-contracts": { stepCaps: 38, needed: 39, jobCap: 55 },
+  "desktop-e2e.yml:desktop-image": { stepCaps: 36, needed: 37, jobCap: 45 },
+} as const;
+
+function positiveNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+/**
+ * This is deliberately lexical, not a shell parser. It joins line continuations
+ * and removes quote/backslash spelling noise so known timeout words cannot hide,
+ * but it never tries to execute, branch, expand, or add inner command budgets.
+ */
+function hasTimeoutSpelling(source: string): boolean {
+  const normalized = source
+    .replace(/\\\r?\n/gu, "")
+    .replace(/\\(?=[A-Za-z-])/gu, "")
+    .replace(/["']/gu, "");
+  return /(^|[^A-Za-z0-9_])(?:gtimeout|timeout|--timeout(?:-seconds)?)(?=$|[^A-Za-z0-9_])/u.test(
+    normalized,
+  );
+}
+
+async function loadWorkflows(): Promise<Workflows> {
+  const files = (await readdir(workflowDir))
+    .filter((entry) => entry.endsWith(".yml") || entry.endsWith(".yaml"))
+    .sort();
+  return Object.fromEntries(
+    await Promise.all(
+      files.map(async (file) => [
+        file,
+        Bun.YAML.parse(await readFile(resolve(workflowDir, file), "utf8")) as Workflow,
+      ]),
+    ),
+  );
+}
+
+async function loadPlaywrightAction(): Promise<PlaywrightAction> {
+  return Bun.YAML.parse(await readFile(playwrightActionPath, "utf8")) as PlaywrightAction;
+}
+
+function playwrightBoundMinutes(
+  action: PlaywrightAction,
+  caller: Step,
+): Readonly<{ minutes: number | null; reason?: string }> {
+  const duration = Number(
+    caller.with?.["attempt-timeout-seconds"] ?? action.inputs?.["attempt-timeout-seconds"]?.default,
+  );
+  const attempts = Number(caller.with?.attempts ?? action.inputs?.attempts?.default);
+  const install = action.runs?.steps?.find(
+    (step) => step.name === "Install pinned Playwright browsers",
+  )?.run;
+  const graceMatch = /--kill-after=(\d+(?:\.\d+)?)s/u.exec(String(install ?? ""));
+  const grace = Number(graceMatch?.[1]);
+  if (
+    !Number.isFinite(duration) ||
+    duration <= 0 ||
+    !Number.isSafeInteger(attempts) ||
+    attempts <= 0 ||
+    !Number.isFinite(grace) ||
+    grace < 0
+  ) {
+    return { minutes: null, reason: "Playwright install budget is not statically numeric" };
+  }
+  return { minutes: ((duration + grace) * attempts) / 60 };
+}
+
+type Inspection = Readonly<{
+  violations: readonly string[];
+  cappedSteps: readonly string[];
+  playwrightCallers: readonly string[];
+  jobs: Readonly<Record<string, Readonly<{ stepCaps: number; needed: number; jobCap: number }>>>;
+}>;
+
+function inspectWorkflowCaps(workflows: Workflows, action: PlaywrightAction): Inspection {
+  const violations: string[] = [];
+  const cappedSteps: string[] = [];
+  const playwrightCallers: string[] = [];
+  const jobs: Record<string, { stepCaps: number; needed: number; jobCap: number }> = {};
+
+  for (const [file, workflow] of Object.entries(workflows)) {
+    for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+      if (job.uses) continue;
+      const jobId = `${file}:${jobName}`;
+      const jobCap = positiveNumber(job["timeout-minutes"]);
+      if (jobCap === null) {
+        violations.push(`${jobId} job timeout-minutes must be a positive static number`);
+      }
+
+      let stepCaps = 0;
+      for (const [stepIndex, step] of (job.steps ?? []).entries()) {
+        const stepName = step.name ?? `step-${stepIndex + 1}`;
+        const stepId = `${jobId}:${stepName}`;
+        const rawCap = step["timeout-minutes"];
+        const stepCap = positiveNumber(rawCap);
+        if (rawCap !== undefined && stepCap === null) {
+          violations.push(`${stepId} timeout-minutes must be a positive static number`);
+        }
+        if (stepCap !== null) {
+          stepCaps += stepCap;
+          cappedSteps.push(stepId);
+        }
+
+        if (step.run && hasTimeoutSpelling(step.run) && stepCap === null) {
+          violations.push(`${stepId} contains a timeout spelling and requires timeout-minutes`);
+        }
+
+        if (step.uses === PLAYWRIGHT_ACTION) {
+          playwrightCallers.push(stepId);
+          if (stepCap === null) {
+            violations.push(
+              `${stepId} calls the local Playwright action and requires timeout-minutes`,
+            );
+          } else {
+            const bound = playwrightBoundMinutes(action, step);
+            if (bound.minutes === null) {
+              violations.push(`${stepId} ${bound.reason ?? "has an invalid Playwright bound"}`);
+            } else if (stepCap < bound.minutes) {
+              violations.push(
+                `${stepId} cap ${stepCap}m is below the Playwright install bound ${bound.minutes.toFixed(2)}m`,
+              );
+            }
+          }
+        }
+      }
+
+      const needed = JOB_SETUP_ALLOWANCE_MINUTES + stepCaps;
+      if (jobCap !== null) {
+        jobs[jobId] = { stepCaps, needed, jobCap };
+        if (jobCap < needed) {
+          violations.push(
+            `${jobId} cap ${jobCap}m is below 1m setup plus step caps (${needed}m needed)`,
+          );
+        }
+      }
+    }
+  }
+
+  return { violations, cappedSteps, playwrightCallers, jobs };
+}
+
+function mutableWorkflows(workflows: Workflows): Record<string, { jobs?: Record<string, Job> }> {
+  return structuredClone(workflows) as Record<string, { jobs?: Record<string, Job> }>;
+}
+
+function findStep(
+  workflows: Record<string, { jobs?: Record<string, Job> }>,
+  id: StepIdentity,
+): Step {
+  const step = workflows[id.file]?.jobs?.[id.job]?.steps?.find(
+    (candidate) => candidate.name === id.name,
+  );
+  if (!step) throw new Error(`missing fixture step ${id.file}:${id.job}:${id.name}`);
+  return step;
+}
+
+function syntheticWorkflow(run: string, stepCap?: unknown): Workflows {
+  return {
+    "fixture.yml": {
+      jobs: {
+        fixture: {
+          "timeout-minutes": 60,
+          steps: [
+            {
+              name: "fixture",
+              run,
+              ...(stepCap === undefined ? {} : { "timeout-minutes": stepCap }),
+            },
+          ],
+        },
+      },
+    },
+  };
 }
 
 describe("workflow timeout contract", () => {
-  test("every job bounds itself well below the 360-minute GitHub default", async () => {
-    const files = await workflowFiles();
-    expect(files.length).toBeGreaterThan(0);
-
+  test("every ordinary job has a positive bounded timeout", async () => {
     const violations: string[] = [];
-    for (const file of files) {
-      const parsed = Bun.YAML.parse(await readFile(resolve(workflowDir, file), "utf8")) as {
-        jobs?: Record<string, Job>;
-      };
-      for (const [name, job] of Object.entries(parsed.jobs ?? {})) {
-        // A reusable-workflow call cannot carry timeout-minutes; the called
-        // workflow's own jobs are covered by this same test.
-        if (job?.uses) continue;
-        const timeout = job?.["timeout-minutes"];
-        if (typeof timeout !== "number") {
-          violations.push(`${file}:${name} has no timeout-minutes`);
-          continue;
-        }
-        if (timeout <= 0 || timeout > MAX_TIMEOUT_MINUTES) {
-          violations.push(
-            `${file}:${name} has timeout-minutes ${timeout}, outside 1..${MAX_TIMEOUT_MINUTES}`,
-          );
+    for (const [file, workflow] of Object.entries(await loadWorkflows())) {
+      for (const [name, job] of Object.entries(workflow.jobs ?? {})) {
+        if (job.uses) continue;
+        const timeout = positiveNumber(job["timeout-minutes"]);
+        if (timeout === null || timeout > MAX_TIMEOUT_MINUTES) {
+          violations.push(`${file}:${name} timeout-minutes is outside 0..${MAX_TIMEOUT_MINUTES}`);
         }
       }
     }
     expect(violations).toEqual([]);
   });
 
-  test("every Playwright install is bounded and cached through the shared action", async () => {
-    const files = await workflowFiles();
+  test("Playwright installation remains bounded, cached, and lock-clean", async () => {
     const inlineInstalls: string[] = [];
-    for (const file of files) {
+    for (const [file] of Object.entries(await loadWorkflows())) {
       const source = await readFile(resolve(workflowDir, file), "utf8");
-      if (source.includes("playwright install")) {
-        inlineInstalls.push(file);
-      }
+      if (source.includes("playwright install")) inlineInstalls.push(file);
     }
-    // An inline `playwright install` is unbounded: it has no per-attempt wall
-    // clock and no browser cache, which is exactly the wedge this guards.
     expect(inlineInstalls).toEqual([]);
 
-    const action = await readFile(
-      resolve(root, ".github/actions/playwright-browsers/action.yml"),
-      "utf8",
-    );
+    const action = await readFile(playwrightActionPath, "utf8");
     expect(action).toContain("timeout --kill-after=15s");
-    expect(action).toContain("path: ~/.cache/ms-playwright");
-    // `--with-deps` was previously locked by the four inline call sites. Moving
-    // the command into one shared place removed that lock, so re-assert it here.
     expect(action).toContain("playwright install --with-deps");
-    // actions/cache's post step is `post-if: success()`, so the combined action
-    // never saves after a bounded failure and a cold key on a degraded network
-    // can never converge. The split restore/save with always() is what makes a
-    // timed-out install genuinely re-runnable.
     expect(action).toContain("actions/cache/restore@");
     expect(action).toContain("actions/cache/save@");
+    expect(action).toContain("path: ~/.cache/ms-playwright");
+    // Cache entries are immutable, so a __dirlock baked in by a SIGKILLed
+    // install is permanent for that key. Cheap to drop, impossible to undo.
+    expect(action).toContain("rm -rf ~/.cache/ms-playwright/__dirlock");
     expect(action).toMatch(
       /if: \$\{\{ always\(\) && steps\.restore\.outputs\.cache-hit != 'true' \}\}/u,
     );
   });
 
-  // A job cap below the job's own declared step budgets is worse than no cap:
-  // the job is CANCELLED rather than failed, and `if: failure()` artifact
-  // uploads do not run on cancellation, so the diagnostics that explain the
-  // hang are destroyed exactly when they are needed.
-  test("no job cap sits below its own declared inner step budgets", async () => {
-    const installBoundMinutes = await (async () => {
-      const action = Bun.YAML.parse(
-        await readFile(resolve(root, ".github/actions/playwright-browsers/action.yml"), "utf8"),
-      ) as { inputs: Record<string, { default?: string }> };
-      const perAttempt = Number(action.inputs["attempt-timeout-seconds"]?.default);
-      const attempts = Number(action.inputs.attempts?.default);
-      expect(Number.isFinite(perAttempt) && Number.isFinite(attempts)).toBe(true);
-      // 15s is the SIGKILL grace in `timeout --kill-after=15s`.
-      return ((perAttempt + 15) * attempts) / 60;
-    })();
+  test("the exact 16-step workflow corpus uses native caps once", async () => {
+    const workflows = await loadWorkflows();
+    const inspection = inspectWorkflowCaps(workflows, await loadPlaywrightAction());
+    expect(inspection.violations).toEqual([]);
+    expect(inspection.cappedSteps).toHaveLength(16);
+    expect(inspection.playwrightCallers).toHaveLength(3);
 
-    const violations: string[] = [];
-    for (const file of await workflowFiles()) {
-      const parsed = Bun.YAML.parse(await readFile(resolve(workflowDir, file), "utf8")) as {
-        jobs?: Record<
-          string,
-          { uses?: string; "timeout-minutes"?: number; steps?: readonly Step[] }
-        >;
-      };
-      for (const [name, job] of Object.entries(parsed.jobs ?? {})) {
-        if (job?.uses) continue;
-        const cap = job?.["timeout-minutes"];
-        if (typeof cap !== "number") continue;
-        let inner = 0;
-        let usesBoundedInstall = false;
-        for (const step of job.steps ?? []) {
-          const run = String(step.run ?? "");
-          for (const m of run.matchAll(/--timeout-seconds\s+(\d+)/gu)) inner += Number(m[1]) / 60;
-          for (const m of run.matchAll(/--timeout\s+(\d{5,})/gu)) inner += Number(m[1]) / 60_000;
-          if (String(step.uses ?? "").includes("playwright-browsers")) usesBoundedInstall = true;
-        }
-        // A job using the bounded install must be checked even with no declared
-        // inner budget, or a browser lane with a small cap and no test budget is
-        // endorsed despite being guaranteed to cancel mid-install.
-        if (inner === 0 && !usesBoundedInstall) continue;
-        // 1 minute covers checkout + toolchain + dependency install.
-        const needed = 1 + inner + (usesBoundedInstall ? installBoundMinutes : 0);
-        if (cap < needed) {
-          violations.push(
-            `${file}:${name} cap ${cap}m is below its own budgets (${needed.toFixed(1)}m needed)`,
-          );
-        }
-      }
+    const mutable = mutableWorkflows(workflows);
+    const allSteps = Object.values(mutable).flatMap((workflow) =>
+      Object.values(workflow.jobs ?? {}).flatMap((job) => job.steps ?? []),
+    );
+    expect(
+      allSteps.filter((step) => step.run && positiveNumber(step["timeout-minutes"]) !== null),
+    ).toHaveLength(13);
+    expect(
+      allSteps.filter(
+        (step) =>
+          step.uses === PLAYWRIGHT_ACTION && positiveNumber(step["timeout-minutes"]) !== null,
+      ),
+    ).toHaveLength(3);
+    for (const expected of EXPECTED_CAPPED_STEPS) {
+      expect(findStep(mutable, expected)["timeout-minutes"], expected.name).toBe(expected.cap);
     }
-    expect(violations).toEqual([]);
+    for (const [job, expected] of Object.entries(EXPECTED_JOB_BUDGETS)) {
+      expect(inspection.jobs[job], job).toEqual(expected);
+    }
+
+    const browserSteps = mutable["ci.yml"]?.jobs?.["browser-acceptance"]?.steps ?? [];
+    const browserCallers = browserSteps.filter((step) => step.uses === PLAYWRIGHT_ACTION);
+    expect(browserCallers).toHaveLength(1);
+    expect(browserCallers[0]?.with?.browsers).toBe(
+      "${{ matrix.lane == 'workbench' && 'chromium firefox webkit' || 'chromium' }}",
+    );
+  });
+
+  test("removing any one of the 16 native caps fails closed", async () => {
+    const workflows = await loadWorkflows();
+    const action = await loadPlaywrightAction();
+    for (const expected of EXPECTED_CAPPED_STEPS) {
+      const mutated = mutableWorkflows(workflows);
+      delete (findStep(mutated, expected) as { "timeout-minutes"?: unknown })["timeout-minutes"];
+      const inspection = inspectWorkflowCaps(mutated, action);
+      expect(
+        inspection.violations.some((violation) =>
+          violation.includes(`${expected.file}:${expected.job}:${expected.name}`),
+        ),
+        expected.name,
+      ).toBe(true);
+    }
+  });
+
+  test("dynamic and non-positive step caps fail", async () => {
+    const action = await loadPlaywrightAction();
+    for (const cap of [0, -1, Number.NaN, "${{ env.TIMEOUT_MINUTES }}", null]) {
+      const inspection = inspectWorkflowCaps(syntheticWorkflow("timeout 10m job", cap), action);
+      expect(inspection.violations.length, String(cap)).toBeGreaterThan(0);
+    }
+  });
+
+  test("lowering any affected job below one minute plus its step caps fails", async () => {
+    const workflows = await loadWorkflows();
+    const action = await loadPlaywrightAction();
+    for (const [jobId, expected] of Object.entries(EXPECTED_JOB_BUDGETS)) {
+      const mutated = mutableWorkflows(workflows);
+      const [file, jobName] = jobId.split(":") as [string, string];
+      const job = mutated[file]?.jobs?.[jobName];
+      if (!job) throw new Error(`missing fixture job ${jobId}`);
+      (job as { "timeout-minutes"?: unknown })["timeout-minutes"] = expected.needed - 1;
+      expect(
+        inspectWorkflowCaps(mutated, action).violations.some((violation) =>
+          violation.includes(`${jobId} cap ${expected.needed - 1}m is below`),
+        ),
+        jobId,
+      ).toBe(true);
+    }
+  });
+
+  test("normalized timeout spellings require a cap and then count only that cap", async () => {
+    const action = await loadPlaywrightAction();
+    const probes = [
+      "cat <<EOF\n$(timeout 10h job)\nEOF",
+      'echo "$(timeout 10h job)"',
+      'VALUE="$(timeout 10h job)"',
+      'consume "$(timeout 10h job)"',
+      "eval 'timeout 10h job'",
+      'time""out 10h job',
+      "ti\\meout 10h job",
+      "time\\\nout 10h job",
+      'bun test --time""out 720000',
+      'cmd=timeout; "$cmd" 10h job',
+      "gtimeout 10h job",
+      'timeout "${{ env.BUDGET }}" job',
+      'bun test --timeout="${{ env.BUDGET }}"',
+      'bun test --timeout-seconds="${{ env.BUDGET }}"',
+    ];
+    for (const probe of probes) {
+      expect(inspectWorkflowCaps(syntheticWorkflow(probe), action).violations.length, probe).toBe(
+        1,
+      );
+      const capped = inspectWorkflowCaps(syntheticWorkflow(probe, 12), action);
+      expect(capped.violations, probe).toEqual([]);
+      expect(capped.jobs["fixture.yml:fixture"], probe).toEqual({
+        stepCaps: 12,
+        needed: 13,
+        jobCap: 60,
+      });
+    }
+  });
+
+  test("shell structure never creates inferred inner sums", async () => {
+    const action = await loadPlaywrightAction();
+    const probes = [
+      "timeout 10m bash -c 'timeout 5m job'",
+      "retry --attempts 3 timeout 10m job",
+      "timeout 10m producer | timeout 5m consumer",
+      "while retrying; do timeout 10m job; done",
+      "cat <<EOF\ntimeout 10m is data\nEOF",
+      "alias t=timeout; t 10m job",
+      "eval 'timeout 10m job'",
+      'cmd=timeout; "$cmd" 10m job',
+    ];
+    for (const probe of probes) {
+      const inspection = inspectWorkflowCaps(syntheticWorkflow(probe, 12), action);
+      expect(inspection.violations, probe).toEqual([]);
+      // Nested 10m + 5m is still one native 12m step, never 27m.
+      expect(inspection.jobs["fixture.yml:fixture"]?.stepCaps, probe).toBe(12);
+      expect(inspection.jobs["fixture.yml:fixture"]?.needed, probe).toBe(13);
+    }
+  });
+
+  test("Playwright duration, attempts, and kill grace must fit the 17-minute caller cap", async () => {
+    const workflows = await loadWorkflows();
+    const action = await loadPlaywrightAction();
+    expect(inspectWorkflowCaps(workflows, action).violations).toEqual([]);
+
+    const tooLong = structuredClone(action) as {
+      inputs: Record<string, { default?: unknown }>;
+    } & PlaywrightAction;
+    tooLong.inputs["attempt-timeout-seconds"] = { default: "1006" };
+    expect(inspectWorkflowCaps(workflows, tooLong).violations.length).toBeGreaterThan(0);
+
+    const tooMany = structuredClone(action) as {
+      inputs: Record<string, { default?: unknown }>;
+    } & PlaywrightAction;
+    tooMany.inputs.attempts = { default: "2" };
+    expect(inspectWorkflowCaps(workflows, tooMany).violations.length).toBeGreaterThan(0);
+
+    const tooMuchGrace = structuredClone(action) as {
+      runs: { steps: Array<{ name?: string; run?: string }> };
+    } & PlaywrightAction;
+    const install = tooMuchGrace.runs.steps.find(
+      (step) => step.name === "Install pinned Playwright browsers",
+    );
+    if (!install?.run) throw new Error("missing Playwright install fixture");
+    install.run = install.run.replace("--kill-after=15s", "--kill-after=121s");
+    expect(inspectWorkflowCaps(workflows, tooMuchGrace).violations.length).toBeGreaterThan(0);
   });
 
   // The runner executes `shell: bash` steps as
-  // `bash --noprofile --norc -eo pipefail {0}`. That errexit is applied by the
-  // runner and is NOT cleared by a `set -uo pipefail` inside the script, so a
-  // retry loop written without an explicit guard silently becomes one attempt
-  // with no diagnostic output. Assert the real behaviour by running the real
-  // script under the real shell rather than trusting a plain `bash script.sh`.
+  // `bash --noprofile --norc -eo pipefail {0}`. Assert the real retry behavior
+  // rather than trusting a plain `bash script.sh` invocation.
   test("the install retry loop survives the runner's errexit shell", async () => {
-    const action = Bun.YAML.parse(
-      await readFile(resolve(root, ".github/actions/playwright-browsers/action.yml"), "utf8"),
-    ) as { runs: { steps: readonly { name?: string; run?: string }[] } };
-    const script = action.runs.steps.find(
+    const action = await loadPlaywrightAction();
+    const script = action.runs?.steps?.find(
       (step) => step.name === "Install pinned Playwright browsers",
     )?.run;
     expect(typeof script).toBe("string");
@@ -162,8 +522,6 @@ describe("workflow timeout contract", () => {
       const binDir = join(dir, "bin");
       await mkdir(binDir);
       await writeFile(scriptPath, script as string);
-      // `timeout` is GNU-only; stub it so this test runs on any host. The stub
-      // drops the flags and duration, then execs the command.
       const timeoutStub = [
         "#!/bin/bash",
         'while [[ "$1" == --* ]]; do shift; done',
@@ -172,7 +530,6 @@ describe("workflow timeout contract", () => {
         "",
       ].join("\n");
       await writeFile(join(binDir, "timeout"), timeoutStub);
-      // Fail every attempt with 124, the exit code GNU timeout uses on expiry.
       const counter = join(dir, "n");
       const bunStub = [
         "#!/bin/bash",
@@ -200,10 +557,7 @@ describe("workflow timeout contract", () => {
       });
       const stdout = await new Response(proc.stdout).text();
       expect(await proc.exited).toBe(1);
-
-      // Both attempts must actually run.
-      expect((await readFile(join(dir, "n"), "utf8")).trim()).toBe("2");
-      // And the operator must be told what the bound was, not just "exit 124".
+      expect(await readFile(join(dir, "n"), "utf8")).toBe("2\n");
       expect(stdout).toContain("attempt 1/2");
       expect(stdout).toContain("attempt 2/2");
       expect(stdout).toContain("exceeded 360s and was killed");

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -9,6 +9,11 @@ const playwrightActionPath = resolve(root, ".github/actions/playwright-browsers/
 const PLAYWRIGHT_ACTION = "./.github/actions/playwright-browsers";
 const MAX_TIMEOUT_MINUTES = 120;
 const JOB_SETUP_ALLOWANCE_MINUTES = 1;
+const AMBIGUOUS_SHELL_TEXT = "\0";
+const ASSEMBLY_FRAGMENT_WINDOW = 24;
+const TIMEOUT_SPELLINGS = ["timeout", "gtimeout", "--timeout", "--timeout-seconds"] as const;
+const ATTEMPT_TIMEOUT_INPUT = "${{ inputs.attempt-timeout-seconds }}";
+const ATTEMPTS_INPUT = "${{ inputs.attempts }}";
 
 type Step = Readonly<{
   name?: string;
@@ -29,8 +34,19 @@ type Workflows = Readonly<Record<string, Workflow>>;
 
 type PlaywrightAction = Readonly<{
   inputs?: Readonly<Record<string, Readonly<{ default?: unknown }>>>;
-  runs?: Readonly<{ steps?: readonly Readonly<{ name?: string; run?: string }>[] }>;
+  runs?: Readonly<{
+    steps?: readonly Readonly<{
+      name?: string;
+      env?: Readonly<Record<string, unknown>>;
+      run?: string;
+    }>[];
+  }>;
 }>;
+
+type MutablePlaywrightAction = {
+  inputs: Record<string, { default?: unknown }>;
+  runs: { steps: Array<{ name?: string; env?: Record<string, unknown>; run?: string }> };
+};
 
 type StepIdentity = Readonly<{
   file: string;
@@ -144,6 +160,59 @@ function positiveNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
 }
 
+function ambiguousShellProjection(source: string): string {
+  return source
+    .replace(
+      /\$'((?:\\[\s\S]|[^']){0,128})'/gu,
+      (_whole, body: string) =>
+        AMBIGUOUS_SHELL_TEXT +
+        body.replace(/\\(?:x[0-9A-Fa-f]{1,2}|u[0-9A-Fa-f]{1,4}|[\s\S])/gu, AMBIGUOUS_SHELL_TEXT) +
+        AMBIGUOUS_SHELL_TEXT,
+    )
+    .replace(/\$\{[^}\r\n]{0,128}\}/gu, AMBIGUOUS_SHELL_TEXT)
+    .replace(/\$\([^\r\n)]{0,128}\)/gu, AMBIGUOUS_SHELL_TEXT)
+    .replace(/;\s*[A-Za-z_][A-Za-z0-9_]*\s*\+=/gu, AMBIGUOUS_SHELL_TEXT)
+    .replace(/\$[A-Za-z_][A-Za-z0-9_]*/gu, AMBIGUOUS_SHELL_TEXT)
+    .replace(/["']/gu, "");
+}
+
+function hasAmbiguousTimeoutAssembly(source: string): boolean {
+  const projection = ambiguousShellProjection(source);
+  for (const ambiguity of projection.matchAll(/\0+/gu)) {
+    const index = ambiguity.index;
+    if (index === undefined) continue;
+    const left =
+      /(?:--)?[A-Za-z-]+$/u.exec(
+        projection.slice(Math.max(0, index - ASSEMBLY_FRAGMENT_WINDOW), index),
+      )?.[0] ?? "";
+    const right =
+      /^(?:--)?[A-Za-z-]+/u.exec(
+        projection.slice(index + ambiguity[0].length, index + ASSEMBLY_FRAGMENT_WINDOW),
+      )?.[0] ?? "";
+    for (const target of TIMEOUT_SPELLINGS) {
+      for (
+        let leftLength = 0;
+        leftLength <= Math.min(left.length, target.length);
+        leftLength += 1
+      ) {
+        const prefix = leftLength === 0 ? "" : left.slice(-leftLength);
+        if (leftLength > 0 && !target.startsWith(prefix)) continue;
+        for (
+          let rightLength = 0;
+          rightLength <= Math.min(right.length, target.length - leftLength);
+          rightLength += 1
+        ) {
+          const suffix = right.slice(0, rightLength);
+          if (leftLength + rightLength >= 4 && (rightLength === 0 || target.endsWith(suffix))) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
 /**
  * This is deliberately lexical, not a shell parser. It joins line continuations
  * and removes quote/backslash spelling noise so known timeout words cannot hide,
@@ -154,9 +223,19 @@ function hasTimeoutSpelling(source: string): boolean {
     .replace(/\\\r?\n/gu, "")
     .replace(/\\(?=[A-Za-z-])/gu, "")
     .replace(/["']/gu, "");
-  return /(^|[^A-Za-z0-9_])(?:gtimeout|timeout|--timeout(?:-seconds)?)(?=$|[^A-Za-z0-9_])/u.test(
-    normalized,
-  );
+  if (
+    /(^|[^A-Za-z0-9_])(?:gtimeout|timeout|--timeout(?:-seconds)?)(?=$|[^A-Za-z0-9_])/u.test(
+      normalized,
+    )
+  ) {
+    return true;
+  }
+
+  // This bounded ambiguity projection is not shell evaluation. It collapses
+  // nearby expansions, ANSI escapes, and append-shaped text to one marker, then
+  // asks whether that marker could complete a known spelling. It never decodes
+  // the middle, follows a variable, or infers an inner duration.
+  return hasAmbiguousTimeoutAssembly(source);
 }
 
 async function loadWorkflows(): Promise<Workflows> {
@@ -177,26 +256,53 @@ async function loadPlaywrightAction(): Promise<PlaywrightAction> {
   return Bun.YAML.parse(await readFile(playwrightActionPath, "utf8")) as PlaywrightAction;
 }
 
+function mutablePlaywrightAction(action: PlaywrightAction): MutablePlaywrightAction {
+  return structuredClone(action) as MutablePlaywrightAction;
+}
+
+function mutableInstallStep(action: MutablePlaywrightAction) {
+  const step = action.runs.steps.find(
+    (candidate) => candidate.name === "Install pinned Playwright browsers",
+  );
+  if (!step?.env || !step.run) throw new Error("missing Playwright install fixture");
+  return step;
+}
+
 function playwrightBoundMinutes(
   action: PlaywrightAction,
   caller: Step,
 ): Readonly<{ minutes: number | null; reason?: string }> {
+  const install = action.runs?.steps?.find(
+    (step) => step.name === "Install pinned Playwright browsers",
+  );
+  if (install?.env?.ATTEMPT_TIMEOUT_SECONDS !== ATTEMPT_TIMEOUT_INPUT) {
+    return { minutes: null, reason: "Playwright attempt timeout input is not bound to runtime" };
+  }
+  if (install.env.ATTEMPTS !== ATTEMPTS_INPUT) {
+    return { minutes: null, reason: "Playwright attempts input is not bound to runtime" };
+  }
+  const grace = Number(install.env.KILL_AFTER_SECONDS);
+  if (!Number.isFinite(grace) || grace < 0) {
+    return { minutes: null, reason: "Playwright kill grace is not statically numeric" };
+  }
+  const command = String(install.run ?? "").replace(/\\\r?\n\s*/gu, " ");
+  if (
+    !/\btimeout --kill-after="\$\{KILL_AFTER_SECONDS\}s" "\$\{ATTEMPT_TIMEOUT_SECONDS\}s"(?:\s|$)/u.test(
+      command,
+    )
+  ) {
+    return { minutes: null, reason: "Playwright timeout command is not bound to runtime inputs" };
+  }
   const duration = Number(
     caller.with?.["attempt-timeout-seconds"] ?? action.inputs?.["attempt-timeout-seconds"]?.default,
   );
   const attempts = Number(caller.with?.attempts ?? action.inputs?.attempts?.default);
-  const install = action.runs?.steps?.find(
-    (step) => step.name === "Install pinned Playwright browsers",
-  )?.run;
-  const graceMatch = /--kill-after=(\d+(?:\.\d+)?)s/u.exec(String(install ?? ""));
-  const grace = Number(graceMatch?.[1]);
   if (
     !Number.isFinite(duration) ||
     duration <= 0 ||
     !Number.isSafeInteger(attempts) ||
     attempts <= 0 ||
-    !Number.isFinite(grace) ||
-    grace < 0
+    !Number.isFinite(grace)
   ) {
     return { minutes: null, reason: "Playwright install budget is not statically numeric" };
   }
@@ -335,7 +441,10 @@ describe("workflow timeout contract", () => {
     expect(inlineInstalls).toEqual([]);
 
     const action = await readFile(playwrightActionPath, "utf8");
-    expect(action).toContain("timeout --kill-after=15s");
+    expect(action).toContain('KILL_AFTER_SECONDS: "15"');
+    expect(action).toContain(
+      'timeout --kill-after="${KILL_AFTER_SECONDS}s" "${ATTEMPT_TIMEOUT_SECONDS}s"',
+    );
     expect(action).toContain("playwright install --with-deps");
     expect(action).toContain("actions/cache/restore@");
     expect(action).toContain("actions/cache/save@");
@@ -442,6 +551,21 @@ describe("workflow timeout contract", () => {
       'timeout "${{ env.BUDGET }}" job',
       'bun test --timeout="${{ env.BUDGET }}"',
       'bun test --timeout-seconds="${{ env.BUDGET }}"',
+      "time$''out 10h job",
+      "time$'\\x6f'ut 10h job",
+      "$'time\\x6fut' 10h job",
+      "EMPTY=; time${EMPTY}out 10h job",
+      'cmd=time; cmd+=out; "$cmd" 10h job',
+      'time$(printf "")out 10h job',
+      "gtime$''out 10h job",
+      "gtime$'\\x6f'ut 10h job",
+      "bun test --time${EMPTY}out 720000",
+      "bun test --time$'\\x6f'ut-seconds 720",
+      'flag=--time; flag+=out-seconds; bun test "$flag" 720',
+      "ti$''meout 10h job",
+      "gti${EMPTY}meout 10h job",
+      'bun test --timeo$(printf "")ut 720000',
+      'flag=--ti; flag+=meout-seconds; bun test "$flag" 720',
     ];
     for (const probe of probes) {
       expect(inspectWorkflowCaps(syntheticWorkflow(probe), action).violations.length, probe).toBe(
@@ -483,27 +607,40 @@ describe("workflow timeout contract", () => {
     const action = await loadPlaywrightAction();
     expect(inspectWorkflowCaps(workflows, action).violations).toEqual([]);
 
-    const tooLong = structuredClone(action) as {
-      inputs: Record<string, { default?: unknown }>;
-    } & PlaywrightAction;
+    const tooLong = mutablePlaywrightAction(action);
     tooLong.inputs["attempt-timeout-seconds"] = { default: "1006" };
     expect(inspectWorkflowCaps(workflows, tooLong).violations.length).toBeGreaterThan(0);
 
-    const tooMany = structuredClone(action) as {
-      inputs: Record<string, { default?: unknown }>;
-    } & PlaywrightAction;
+    const tooMany = mutablePlaywrightAction(action);
     tooMany.inputs.attempts = { default: "2" };
     expect(inspectWorkflowCaps(workflows, tooMany).violations.length).toBeGreaterThan(0);
 
-    const tooMuchGrace = structuredClone(action) as {
-      runs: { steps: Array<{ name?: string; run?: string }> };
-    } & PlaywrightAction;
-    const install = tooMuchGrace.runs.steps.find(
-      (step) => step.name === "Install pinned Playwright browsers",
-    );
-    if (!install?.run) throw new Error("missing Playwright install fixture");
-    install.run = install.run.replace("--kill-after=15s", "--kill-after=121s");
+    const tooMuchGrace = mutablePlaywrightAction(action);
+    const install = mutableInstallStep(tooMuchGrace);
+    install.env.KILL_AFTER_SECONDS = "121";
     expect(inspectWorkflowCaps(workflows, tooMuchGrace).violations.length).toBeGreaterThan(0);
+
+    for (const literal of ["900", "1006"]) {
+      const unbound = mutablePlaywrightAction(action);
+      const step = mutableInstallStep(unbound);
+      step.env.ATTEMPT_TIMEOUT_SECONDS = literal;
+      expect(inspectWorkflowCaps(workflows, unbound).violations.length, literal).toBeGreaterThan(0);
+    }
+
+    const literalDuration = mutablePlaywrightAction(action);
+    const literalStep = mutableInstallStep(literalDuration);
+    literalStep.run = literalStep.run.replace('"${ATTEMPT_TIMEOUT_SECONDS}s"', '"900s"');
+    expect(inspectWorkflowCaps(workflows, literalDuration).violations.length).toBeGreaterThan(0);
+
+    const literalGrace = mutablePlaywrightAction(action);
+    const literalGraceStep = mutableInstallStep(literalGrace);
+    literalGraceStep.run = literalGraceStep.run.replace('"${KILL_AFTER_SECONDS}s"', '"15s"');
+    expect(inspectWorkflowCaps(workflows, literalGrace).violations.length).toBeGreaterThan(0);
+
+    const literalAttempts = mutablePlaywrightAction(action);
+    const literalAttemptsStep = mutableInstallStep(literalAttempts);
+    literalAttemptsStep.env.ATTEMPTS = "1";
+    expect(inspectWorkflowCaps(workflows, literalAttempts).violations.length).toBeGreaterThan(0);
   });
 
   // The runner executes `shell: bash` steps as
@@ -551,6 +688,7 @@ describe("workflow timeout contract", () => {
           PLAYWRIGHT_ONLY_SHELL: "false",
           ATTEMPT_TIMEOUT_SECONDS: "360",
           ATTEMPTS: "2",
+          KILL_AFTER_SECONDS: "15",
         },
         stdout: "pipe",
         stderr: "pipe",


### PR DESCRIPTION
## Summary

- add native numeric `timeout-minutes` caps to the 13 budget-bearing `run:` steps
- consolidate the mutually exclusive browser runtime installers and cap all 3 local Playwright action callers
- replace semantic shell analysis with a YAML-only contract that counts each native step cap once and enforces job headroom
- correct the Playwright `__dirlock` stale-time comment and preserve the existing retry/process-group coverage

## Budget mapping

Profile-wrapper caps: 11, 11, 16, 21, 31, 13, 21 minutes.
Direct Bun caps: 13, 5, 4, 6, 4, 36 minutes.
Playwright callers: 17 minutes each.

Preserved job needed/cap pairs: plan 12/15, source-contracts 28/35, unit 22/30, integration 32/40, e2e 31/35, test-suite 19/30, browser 32/35, packages 39/55, desktop 37/45.

## Verification

- focused workflow/profile/release/artifact contracts: 107 pass
- explicit cap mutation matrix: 7 pass, 132 assertions
- all scripts: 638 pass, 1 intentional skip, 0 fail
- typecheck: all 31 projects clean
- lint, format check, public hygiene, and diff check: clean
- synthetic merge with current main `c22116fa`: focused 107 pass; scripts 638 pass/1 skip; typecheck clean