### PR TITLE
fix(workbench): stop live tabs hanging on credit drain

### DIFF
--- a/.changeset/workbench-credit-drain-hangs.md
+++ b/.changeset/workbench-credit-drain-hangs.md
@@ -1,0 +1,8 @@
+---
+"@opengeni/contracts": patch
+"@opengeni/react": patch
+---
+
+Stop the workbench Changes/Files/Terminal/Browser/Desktop surfaces from hanging when a workspace is force-drained for credits.
+
+Browser and Desktop creates now map `SandboxViewerAdmissionBlockedError` to the same 402/429 `/viewers` already returns, instead of a generic 500. The workbench treats a 402 handshake as a credit-exhaustion error, keeps the machine chip Offline instead of Waking forever, and parses older BrowserSession capability documents that omit `permissions`.

--- a/apps/api/src/http/sandbox-viewer-admission-error.ts
+++ b/apps/api/src/http/sandbox-viewer-admission-error.ts
@@ -1,0 +1,18 @@
+import { SandboxViewerAdmissionBlockedError } from "@opengeni/db";
+import { HTTPException } from "hono/http-exception";
+
+/** Viewer and interaction holders share the workspace drain fence. Map it to
+ *  the same 402/429 the `/viewers` attach path already returns so Browser and
+ *  Desktop creates cannot become generic 500s with leftover `starting` rows. */
+export function httpExceptionForSandboxViewerAdmission(
+  error: unknown,
+): HTTPException | null {
+  if (!(error instanceof SandboxViewerAdmissionBlockedError)) return null;
+  return new HTTPException(error.reason === "balance" ? 402 : 429, {
+    message:
+      error.reason === "balance"
+        ? "insufficient OpenGeni credits for an idle sandbox viewer"
+        : "workspace sandbox warm allowance exhausted",
+    cause: error,
+  });
+}

--- a/apps/api/src/routes/browser-sessions.ts
+++ b/apps/api/src/routes/browser-sessions.ts
@@ -130,6 +130,7 @@ import {
   loadConnectionCredentialForBroker,
   markProtectedAuthFillOutcomeUnknown,
   startAuthRun,
+  SandboxViewerAdmissionBlockedError,
   touchBrowserSessionController,
   verifyAuthRun,
   settleBrowserDownloadSaveFailure,
@@ -199,6 +200,7 @@ import {
 import { managedNetworkRouteForPlacement } from "../browser-network-route";
 import { validateInteractionRequestOrigin } from "../http/cors";
 import { interactionControlApiError } from "../http/interaction-control-error";
+import { httpExceptionForSandboxViewerAdmission } from "../http/sandbox-viewer-admission-error";
 import { createInteractionFrameProxyAttachment } from "../interaction-frame-proxy";
 import {
   observeAuthMutation,
@@ -393,14 +395,32 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
               rootSecret: authority,
               placement: placement.placement,
             });
-            const interactionHeld = await ensureInteractionHolder(
-              deps,
-              grant,
-              sourceSession,
-              prepared.session.id,
-              placement,
-              context.req.raw.signal,
-            );
+            let interactionHeld = false;
+            try {
+              interactionHeld = await ensureInteractionHolder(
+                deps,
+                grant,
+                sourceSession,
+                prepared.session.id,
+                placement,
+                context.req.raw.signal,
+              );
+            } catch (error) {
+              if (error instanceof SandboxViewerAdmissionBlockedError) {
+                await failBrowserSessionOperation(deps.db, {
+                  accountId: grant.accountId,
+                  workspaceId,
+                  operationId: request.operationId,
+                  browserSessionId: prepared.session.id,
+                  error: {
+                    code: "resource_unavailable",
+                    message: error.message,
+                    retryable: false,
+                  },
+                });
+              }
+              throw error;
+            }
             const record = await ensureDispatchedGeneration(
               deps,
               grant,
@@ -2335,14 +2355,32 @@ export function registerBrowserSessionRoutes(app: Hono, deps: ApiRouteDeps): voi
               rootSecret: authority,
               placement: placement.placement,
             });
-            const interactionHeld = await ensureInteractionHolder(
-              deps,
-              grant,
-              sourceSession,
-              browserSessionId,
-              placement,
-              context.req.raw.signal,
-            );
+            let interactionHeld = false;
+            try {
+              interactionHeld = await ensureInteractionHolder(
+                deps,
+                grant,
+                sourceSession,
+                browserSessionId,
+                placement,
+                context.req.raw.signal,
+              );
+            } catch (error) {
+              if (error instanceof SandboxViewerAdmissionBlockedError) {
+                await failBrowserSessionResumePreparation(deps.db, {
+                  accountId: grant.accountId,
+                  workspaceId,
+                  operationId: request.operationId,
+                  browserSessionId,
+                  error: {
+                    code: "resource_unavailable",
+                    message: error.message,
+                    retryable: false,
+                  },
+                });
+              }
+              throw error;
+            }
             const record = await ensureDispatchedGeneration(
               deps,
               grant,
@@ -4553,6 +4591,8 @@ async function recordBrowserDownloadFileUsage(
 }
 
 function browserRouteError(error: unknown): HTTPException {
+  const admission = httpExceptionForSandboxViewerAdmission(error);
+  if (admission) return admission;
   const connectedMachineError = interactionControlApiError(error, "browser");
   if (connectedMachineError) return connectedMachineError;
   if (error instanceof HTTPException) return error;

--- a/apps/api/src/routes/computer-sessions.ts
+++ b/apps/api/src/routes/computer-sessions.ts
@@ -46,6 +46,7 @@ import {
   releaseLeaseHolder,
   readLease,
   recordLeaseControllerDataPlaneUrl,
+  SandboxViewerAdmissionBlockedError,
   touchComputerSessionController,
   type ComputerSessionControlRecord,
   type LeaseSnapshot,
@@ -89,6 +90,7 @@ import { withCachedController } from "../controller-data-plane";
 import { withInteractionHolderHeartbeat } from "../interaction-holder-heartbeat";
 import { validateInteractionRequestOrigin } from "../http/cors";
 import { interactionControlApiError } from "../http/interaction-control-error";
+import { httpExceptionForSandboxViewerAdmission } from "../http/sandbox-viewer-admission-error";
 import { createInteractionFrameProxyAttachment } from "../interaction-frame-proxy";
 import { observeComputerActionResult, observeLifecycleResult } from "../interaction-metrics";
 import { withChannelA, withChannelARead, type ChannelAOperation } from "../sandbox/channel-a";
@@ -191,13 +193,31 @@ export function registerComputerSessionRoutes(app: Hono, deps: ApiRouteDeps): vo
           }
           if (isTerminalOperation(prepared.operation.state)) return prepared;
 
-          const interactionHeld = await ensureInteractionHolder(
-            grant,
-            sourceSession,
-            prepared.session.id,
-            placement,
-            context.req.raw.signal,
-          );
+          let interactionHeld = false;
+          try {
+            interactionHeld = await ensureInteractionHolder(
+              grant,
+              sourceSession,
+              prepared.session.id,
+              placement,
+              context.req.raw.signal,
+            );
+          } catch (error) {
+            if (error instanceof SandboxViewerAdmissionBlockedError) {
+              await failComputerSessionOperation(deps.db, {
+                accountId: grant.accountId,
+                workspaceId,
+                operationId: request.operationId,
+                computerSessionId: prepared.session.id,
+                error: {
+                  code: "resource_unavailable",
+                  message: error.message,
+                  retryable: false,
+                },
+              });
+            }
+            throw error;
+          }
           const record = await ensureDispatchedGeneration(
             grant,
             workspaceId,
@@ -1658,6 +1678,8 @@ function interactionFailure(error: unknown) {
 }
 
 function computerRouteError(error: unknown): HTTPException {
+  const admission = httpExceptionForSandboxViewerAdmission(error);
+  if (admission) return admission;
   const connectedMachineError = interactionControlApiError(error, "computer");
   if (connectedMachineError) return connectedMachineError;
   if (error instanceof HTTPException) return error;

--- a/apps/api/src/sandbox/viewer.ts
+++ b/apps/api/src/sandbox/viewer.ts
@@ -45,7 +45,6 @@ import {
   recordLeaseTerminalDataPlaneUrl,
   releaseLeaseHolder,
   SandboxLeaseSupersededError,
-  SandboxViewerAdmissionBlockedError,
   type Database,
   type LeaseSnapshot,
   type SandboxRecord,
@@ -54,6 +53,8 @@ import {
 } from "@opengeni/db";
 import { appendAndPublishEvents, type EventBus } from "@opengeni/events";
 import { HTTPException } from "hono/http-exception";
+
+import { httpExceptionForSandboxViewerAdmission } from "../http/sandbox-viewer-admission-error";
 
 // The leaf — agent-loop-free. apps/api imports sandbox symbols ONLY from here
 // (enforced by sandbox-access-import-guard.test.ts).
@@ -251,15 +252,8 @@ export async function attachViewer(
       ...(input.waitSignal ? { waitSignal: input.waitSignal } : {}),
     });
   } catch (error) {
-    if (error instanceof SandboxViewerAdmissionBlockedError) {
-      throw new HTTPException(error.reason === "balance" ? 402 : 429, {
-        message:
-          error.reason === "balance"
-            ? "insufficient OpenGeni credits for an idle sandbox viewer"
-            : "workspace sandbox warm allowance exhausted",
-        cause: error,
-      });
-    }
+    const admission = httpExceptionForSandboxViewerAdmission(error);
+    if (admission) throw admission;
     throw error;
   }
 

--- a/apps/api/test/sandbox-viewer-admission-error.test.ts
+++ b/apps/api/test/sandbox-viewer-admission-error.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { SandboxViewerAdmissionBlockedError } from "@opengeni/db";
+import { httpExceptionForSandboxViewerAdmission } from "../src/http/sandbox-viewer-admission-error";
+
+describe("sandbox viewer admission errors", () => {
+  test("maps a credit drain to 402", () => {
+    const error = new SandboxViewerAdmissionBlockedError(
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+      "balance",
+    );
+    const mapped = httpExceptionForSandboxViewerAdmission(error);
+    expect(mapped).not.toBeNull();
+    expect(mapped!.status).toBe(402);
+    expect(mapped!.message).toBe("insufficient OpenGeni credits for an idle sandbox viewer");
+  });
+
+  test("maps a warm-cap drain to 429", () => {
+    const error = new SandboxViewerAdmissionBlockedError(
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+      "warm_cap",
+    );
+    const mapped = httpExceptionForSandboxViewerAdmission(error);
+    expect(mapped).not.toBeNull();
+    expect(mapped!.status).toBe(429);
+    expect(mapped!.message).toBe("workspace sandbox warm allowance exhausted");
+  });
+
+  test("ignores unrelated errors", () => {
+    expect(httpExceptionForSandboxViewerAdmission(new Error("nope"))).toBeNull();
+  });
+});

--- a/packages/contracts/src/interaction.ts
+++ b/packages/contracts/src/interaction.ts
@@ -191,7 +191,9 @@ export const BrowserSessionCapabilities = z
     downloads: z.boolean(),
     uploads: z.boolean(),
     clipboard: z.boolean(),
-    permissions: z.boolean(),
+    // Rows created before this capability existed omit the key. Treat that as
+    // unsupported rather than failing the whole BrowserSession list.
+    permissions: z.boolean().default(false),
     diagnostics: z.boolean(),
     rawCdp: z.boolean(),
     linkedComputer: z.boolean(),

--- a/packages/react/src/components/sandbox-files.tsx
+++ b/packages/react/src/components/sandbox-files.tsx
@@ -1,4 +1,4 @@
-import { FileCode2Icon, FileWarningIcon, LoaderCircleIcon } from "lucide-react";
+import { FileCode2Icon, FileWarningIcon, LoaderCircleIcon, TriangleAlertIcon } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { cn } from "../lib/cn";
@@ -49,6 +49,9 @@ export type SandboxFilesProps = {
   workspaceResting?: boolean | undefined;
   /** A deliberate wake has started but the live file surface is not ready yet. */
   workspaceWaking?: boolean | undefined;
+  /** Capability handshake failure (including credit drain). Beats the wake spinner. */
+  capabilitiesError?: Error | null | undefined;
+  onRetryCapabilities?: (() => void) | undefined;
   /** Whether live reads are currently authoritative. */
   liveWorkspaceReady?: boolean | undefined;
   /** Deliberately wake the machine to read content absent from the capture. */
@@ -78,6 +81,8 @@ export function SandboxFiles({
   requestedPathReady = true,
   workspaceResting = false,
   workspaceWaking = false,
+  capabilitiesError = null,
+  onRetryCapabilities,
   liveWorkspaceReady = true,
   onWakeWorkspace,
   themeType,
@@ -195,6 +200,23 @@ export function SandboxFiles({
     liveRequestedPath === viewPath &&
     (!liveWorkspaceReady || files.loading) &&
     captureFileUnavailable !== null;
+
+  if (capabilitiesError) {
+    return (
+      <div className={cn("h-full", className)} data-opengeni-workspace-error>
+        <Notice
+          icon={<TriangleAlertIcon className="size-5" aria-hidden />}
+          title="Sandbox unavailable"
+          announce="alert"
+        >
+          <p>{capabilitiesError.message || "Couldn't reach the sandbox for this session."}</p>
+          {onRetryCapabilities ? (
+            <WakeButton onClick={onRetryCapabilities}>Retry</WakeButton>
+          ) : null}
+        </Notice>
+      </div>
+    );
+  }
 
   if (workspaceResting || workspaceWaking) {
     return (

--- a/packages/react/src/components/sandbox-workspace.tsx
+++ b/packages/react/src/components/sandbox-workspace.tsx
@@ -764,6 +764,8 @@ export function useSandboxWorkspaceTabs(
             workspaceWaking={!liveWorkspaceExpected && !captureAvailable && workspaceWaking}
             liveWorkspaceReady={liveWorkspaceExpected}
             onWakeWorkspace={() => requestWarmIntent("warmFiles")}
+            capabilitiesError={caps.error}
+            onRetryCapabilities={caps.renegotiate}
             {...(requestedFilePath
               ? {
                   requestedPath: requestedFilePath,

--- a/packages/react/src/hooks/use-machine-chip.ts
+++ b/packages/react/src/hooks/use-machine-chip.ts
@@ -86,6 +86,12 @@ export function deriveMachineChip(input: DeriveMachineChipInput): MachineChip {
   const selfhostedOffline =
     input.activeIsSelfhosted === true && input.activeMachineState === "offline";
 
+  // A failed capability handshake (including 402 credit drain) is not an in-flight
+  // warm-up. Keep wantsWarm from pinning the chip on "Waking…" forever.
+  if (input.capabilitiesState === "error") {
+    return { state: "offline", label: offlineLabel, asOf };
+  }
+
   // 2. Actively coming up: negotiation in flight, an edit/terminal is warming, or
   //    the active machine is (re)connecting. Never when self-hosted is hard-offline.
   const machineWarming =

--- a/packages/react/src/hooks/use-session-capabilities.ts
+++ b/packages/react/src/hooks/use-session-capabilities.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useOpenGeni, type ClientOverride } from "../provider";
 import { sandboxAcceptsLiveIo } from "../lib/sandbox-liveness";
 import { terminalCanAcquirePty } from "../lib/terminal-capability";
+import { CREDIT_EXHAUSTION_MESSAGE } from "../lib/format";
 import { usePageLiveActivity } from "./internal";
 
 // "on-demand" is the boxless-benign resting state: the lease is not currently
@@ -424,6 +425,10 @@ export function useSessionCapabilities(
                 setState("error");
                 setError(cause);
                 return;
+              } else if (cause.status === 402) {
+                setState("error");
+                setError(new Error(CREDIT_EXHAUSTION_MESSAGE));
+                return;
               } else {
                 throw cause;
               }
@@ -466,6 +471,11 @@ export function useSessionCapabilities(
         if (cause instanceof OpenGeniApiError && cause.status === 403) {
           setState("error");
           setError(new Error("not permitted to view this session's sandbox"));
+          return;
+        }
+        if (cause instanceof OpenGeniApiError && cause.status === 402) {
+          setState("error");
+          setError(new Error(CREDIT_EXHAUSTION_MESSAGE));
           return;
         }
         setState("error");

--- a/packages/react/test/workspace-capture-hooks.test.tsx
+++ b/packages/react/test/workspace-capture-hooks.test.tsx
@@ -2530,6 +2530,18 @@ describe("deriveMachineChip", () => {
     expect(chip.label).toBe("Offline — as of 1h ago");
   });
 
+  test("capability error is honest offline even if warm was requested", () => {
+    const chip = deriveMachineChip({
+      liveness: "cold",
+      capabilitiesState: "error",
+      wantsWarm: true,
+      capturedAt: "2026-07-08T12:00:00.000Z",
+      now: NOW,
+    });
+    expect(chip.state).toBe("offline");
+    expect(chip.label).toBe("Offline — as of 5m ago");
+  });
+
   test("offline with no capture time reads a bare 'Offline'", () => {
     expect(deriveMachineChip({ liveness: "cold" }).label).toBe("Offline");
   });


### PR DESCRIPTION
## Summary

Production session https://app.opengeni.ai/workspaces/39c4e556-344d-46f3-804b-749febed7473/sessions/bf9918c4-bb43-4388-9035-83423b79c3ea hangs on **Changes / Files / Terminal / Browser / Desktop** because the workspace has been force-drained for empty managed credits since 2026-08-04.

Live evidence against that session:

- `POST /sessions/:id/viewers` → **402** `insufficient OpenGeni credits for an idle sandbox viewer`
- Files/Terminal stay on **Waking workspace** instead of showing the credit error
- `POST /browser-sessions` and `POST /computer-sessions` → **500** (`SandboxViewerAdmissionBlockedError` unmapped)
- create persists a `lifecycle=starting` row first, so the UI then shows **Starting browser… / Opening desktop…** forever

## Fix

- Map the shared viewer/interaction admission fence to the same **402/429** `/viewers` already returns
- Fail the prepared Browser/Desktop session on that fence so it cannot stick in `starting`
- Treat handshake **402** as credit exhaustion in the workbench
- Keep the machine chip **Offline** after a failed handshake (`wantsWarm` no longer pins Waking forever)
- Parse older BrowserSession capability documents that omit `permissions` (this was 500ing `GET /browser-sessions` for one production row)

Existing drained workspaces still need credits (or the drain cleared) before live I/O can succeed. This change makes that failure explicit instead of hanging the dock.

## Test plan

- [x] `bun test apps/api/test/sandbox-viewer-admission-error.test.ts`
- [x] `bun test apps/api/test/browser-session-routes.test.ts apps/api/test/computer-session-routes.test.ts`
- [x] `bun test packages/react/test/workspace-capture-hooks.test.tsx` (includes new chip error case)
- [ ] After deploy: open a drained workspace session, click Files / Browser / Desktop, confirm credit error instead of infinite Starting/Waking