### PR TITLE
fix(ci): ignore Git replacement objects in graph checks

### DIFF
--- a/.github/actions/playwright-browsers/action.yml
+++ b/.github/actions/playwright-browsers/action.yml
@@ -98,6 +98,7 @@ runs:
         PLAYWRIGHT_ONLY_SHELL: ${{ inputs.only-shell }}
         ATTEMPT_TIMEOUT_SECONDS: ${{ inputs.attempt-timeout-seconds }}
         ATTEMPTS: ${{ inputs.attempts }}
+        KILL_AFTER_SECONDS: "15"
       run: |
         set -uo pipefail
         only_shell=""
@@ -112,7 +113,7 @@ runs:
           # `|| status=$?` guard the first failing attempt aborts the script,
           # so the retry, the warnings, and the error summary never run.
           status=0
-          timeout --kill-after=15s "${ATTEMPT_TIMEOUT_SECONDS}s" \
+          timeout --kill-after="${KILL_AFTER_SECONDS}s" "${ATTEMPT_TIMEOUT_SECONDS}s" \
             bun x playwright install --with-deps ${only_shell} ${PLAYWRIGHT_BROWSERS} || status=$?
           echo "::endgroup::"
           if [ "${status}" -eq 0 ]; then
@@ -137,9 +138,13 @@ runs:
     # step. One step is sufficient because it reduces the re-run to a
     # single-browser download, which has never breached the bound - but it does
     # mean a partial set persists for the life of this Playwright version.
-    # A SIGKILLed install can leave a stale __dirlock behind. Playwright only
-    # treats it as stale after ~5 minutes, so baking it into an immutable cache
-    # would tax every later run against this key.
+    # A SIGKILLed install can leave a stale __dirlock behind. Playwright locks
+    # the registry through proper-lockfile passing only retries/onCompromised/
+    # lockfilePath, so the default `stale: 10000` applies - the lock clears
+    # after ~10 seconds, not the ~5 minutes an earlier revision of this comment
+    # claimed. Removing it is therefore cheap hygiene rather than a large
+    # saving: it keeps a lock out of an immutable cache entry and avoids the
+    # onCompromised path entirely.
     - name: Drop stale Playwright dirlock before saving
       if: ${{ always() && steps.restore.outputs.cache-hit != 'true' }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
           bun-version-file: .bun-version
 
       - name: Install exact dependency tree
+        timeout-minutes: 11
         env:
           BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/opengeni-bun-store
         run: >-
@@ -295,7 +296,9 @@ jobs:
             bun-${{ runner.os }}-
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: |
+          bun install --frozen-lockfile --ignore-scripts
+          bun scripts/workflow-execution-graph.ts --git-tree 'HEAD^{tree}'
 
       - name: Download exact impact plan
         uses: actions/download-artifact@v4
@@ -359,6 +362,7 @@ jobs:
           fi
 
       - name: Profile impacted TypeScript 7 projects
+        timeout-minutes: 11
         run: >-
           bun scripts/ci/profile-command.ts
           --name typecheck
@@ -368,6 +372,7 @@ jobs:
           --plan ${{ runner.temp }}/ci-impact-plan/impact-plan.json
 
       - name: Run exactly the explained source guards
+        timeout-minutes: 16
         run: >-
           bun scripts/ci/profile-command.ts
           --name guards
@@ -436,6 +441,7 @@ jobs:
           name: ci-impact-plan
 
       - name: Unit test shard
+        timeout-minutes: 21
         env:
           # The per-subject FORCE-RLS/OCC suite remains fail-closed on every shard.
           OPENGENI_REQUIRE_REAL_DB: "1"
@@ -487,6 +493,7 @@ jobs:
           name: ci-impact-plan
 
       - name: Run real PostgreSQL, pgvector, Temporal, NATS, and object-storage tests
+        timeout-minutes: 31
         run: >-
           bun scripts/ci/profile-command.ts
           --name integration-${{ matrix.number }}
@@ -570,10 +577,12 @@ jobs:
       # web-broad candidate.
       - name: Install pinned browser runtimes
         uses: ./.github/actions/playwright-browsers
+        timeout-minutes: 17
         with:
           browsers: chromium firefox
 
       - name: Run exactly the impacted E2E tests
+        timeout-minutes: 13
         run: >-
           bun scripts/ci/profile-command.ts
           --name e2e-${{ matrix.number }}
@@ -628,6 +637,7 @@ jobs:
         run: bun run test:react:clean
 
       - name: Real workspace capture acceptance
+        timeout-minutes: 13
         run: >-
           bun test --max-concurrency=1 --timeout 720000
           --test-name-pattern
@@ -639,6 +649,7 @@ jobs:
       # suite split cannot silently drop either the exactly-once/active-goal proof
       # or the real-Postgres shrink proof.
       - name: Recovery integration regressions
+        timeout-minutes: 5
         run: |
           bun test --timeout 30000 \
             --test-name-pattern \
@@ -702,17 +713,11 @@ jobs:
             'Acquire::https::Timeout "30";' \
             | sudo tee /etc/apt/apt.conf.d/99opengeni-ci-network >/dev/null
 
-      - name: Install pinned Chromium runtime
-        if: ${{ matrix.lane != 'workbench' }}
+      - name: Install pinned lane browser runtimes
         uses: ./.github/actions/playwright-browsers
+        timeout-minutes: 17
         with:
-          browsers: chromium
-
-      - name: Install pinned cross-browser runtimes
-        if: ${{ matrix.lane == 'workbench' }}
-        uses: ./.github/actions/playwright-browsers
-        with:
-          browsers: chromium firefox webkit
+          browsers: ${{ matrix.lane == 'workbench' && 'chromium firefox webkit' || 'chromium' }}
 
       - name: Editable artifact browser acceptance
         if: ${{ matrix.lane == 'workbench' }}
@@ -770,6 +775,7 @@ jobs:
       - name: Session pin browser acceptance
         if: ${{ matrix.lane == 'knowledge' }}
         id: session_pin_browser
+        timeout-minutes: 4
         env:
           # This browser gate must fail when its real PostgreSQL boundary is unavailable.
           OPENGENI_REQUIRE_REAL_DB: "1"
@@ -777,6 +783,7 @@ jobs:
 
       - name: Responsive knowledge surfaces browser acceptance
         if: ${{ matrix.lane == 'knowledge' }}
+        timeout-minutes: 6
         env:
           # This gate traverses the public configured-principal API and must fail
           # rather than skip when its real PostgreSQL boundary is unavailable.
@@ -786,6 +793,7 @@ jobs:
       - name: Workbench browser acceptance
         if: ${{ matrix.lane == 'workbench' }}
         id: workbench_browser
+        timeout-minutes: 4
         run: bun test --max-concurrency=1 --timeout 180000 ./test/e2e/workbench.browser.e2e.ts
 
       - name: Upload session pin visual evidence
@@ -938,6 +946,7 @@ jobs:
             bun run --cwd packages/artifact-tool test:production-native
 
       - name: Build client packages (contracts + SDK + React)
+        timeout-minutes: 21
         env:
           OPENGENI_BUILD_CACHE_REPORT: ci-profile/package-cache.json
         run: >-
@@ -974,6 +983,7 @@ jobs:
 
       - name: Install Chromium for packed WASM package proof
         uses: ./.github/actions/playwright-browsers
+        timeout-minutes: 17
         with:
           browsers: chromium
           only-shell: "true"

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -47,4 +47,5 @@ jobs:
       # live-Modal half stays skipped (no OPENGENI_P41_LIVE_MODAL). Docker is
       # available on ubuntu-latest, so dockerAvailable() is true here.
       - name: Desktop image e2e
+        timeout-minutes: 36
         run: bun test --timeout 2100000 ./apps/worker/test/desktop-image.e2e.ts

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -89,7 +89,8 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Verify publishable closure
         run: |

--- a/bun.lock
+++ b/bun.lock
@@ -56,11 +56,12 @@
         "playwright": "^1.61.1",
         "postgres": "^3.4.9",
         "typescript": "7.0.2",
+        "yaml": "2.9.0",
       },
     },
     "apps/api": {
       "name": "@opengeni/api-router",
-      "version": "0.31.2",
+      "version": "1.0.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",
@@ -160,7 +161,7 @@
     },
     "apps/worker": {
       "name": "@opengeni/worker-bundle",
-      "version": "0.20.6",
+      "version": "0.20.13",
       "bin": {
         "opengeni-artifact-materializer-worker": "./src/artifact-materializer-entry.ts",
         "opengeni-artifact-outbox-dispatcher": "./src/artifact-outbox-entry.ts",
@@ -199,7 +200,7 @@
     },
     "examples/northstar-support": {
       "name": "@opengeni/example-northstar-support",
-      "version": "0.0.110",
+      "version": "0.0.115",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opengeni/react": "workspace:*",
@@ -234,19 +235,19 @@
     },
     "packages/artifact-kernel-wasm-document": {
       "name": "@opengeni/artifact-kernel-wasm-document",
-      "version": "0.2.11",
+      "version": "0.3.1",
     },
     "packages/artifact-kernel-wasm-presentation": {
       "name": "@opengeni/artifact-kernel-wasm-presentation",
-      "version": "0.2.11",
+      "version": "0.3.1",
     },
     "packages/artifact-kernel-wasm-spreadsheet": {
       "name": "@opengeni/artifact-kernel-wasm-spreadsheet",
-      "version": "0.2.11",
+      "version": "0.3.1",
     },
     "packages/artifact-tool": {
       "name": "@opengeni/artifact-tool",
-      "version": "0.2.11",
+      "version": "0.3.1",
       "bin": {
         "opengeni-artifact-materializer": "./src/materializer-cli-entry.ts",
         "opengeni-artifact-runtime": "./src/runtime-cli-entry.ts",
@@ -268,7 +269,7 @@
     },
     "packages/browserd": {
       "name": "@opengeni/browserd",
-      "version": "0.1.12",
+      "version": "0.1.16",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "@opengeni/interaction": "workspace:*",
@@ -295,7 +296,7 @@
     },
     "packages/codemode": {
       "name": "@opengeni/codemode",
-      "version": "0.4.5",
+      "version": "0.4.9",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "ajv": "^8.20.0",
@@ -319,7 +320,7 @@
     },
     "packages/config": {
       "name": "@opengeni/config",
-      "version": "0.16.5",
+      "version": "0.17.1",
       "dependencies": {
         "@opengeni/codex": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -333,7 +334,7 @@
     },
     "packages/contracts": {
       "name": "@opengeni/contracts",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
         "zod": "^4.2.1",
@@ -345,7 +346,7 @@
     },
     "packages/core": {
       "name": "@opengeni/core",
-      "version": "1.1.0",
+      "version": "1.5.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opengeni/codex": "workspace:*",
@@ -367,7 +368,7 @@
     },
     "packages/db": {
       "name": "@opengeni/db",
-      "version": "1.0.2",
+      "version": "2.1.0",
       "dependencies": {
         "@opengeni/codemode": "workspace:*",
         "@opengeni/codex": "workspace:*",
@@ -397,7 +398,7 @@
     },
     "packages/documents": {
       "name": "@opengeni/documents",
-      "version": "0.5.42",
+      "version": "0.6.6",
       "dependencies": {
         "@llamaindex/liteparse": "^1.5.3",
         "@opengeni/config": "workspace:*",
@@ -415,7 +416,7 @@
     },
     "packages/events": {
       "name": "@opengeni/events",
-      "version": "0.3.113",
+      "version": "0.3.120",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "@opengeni/db": "workspace:*",
@@ -428,7 +429,7 @@
     },
     "packages/github": {
       "name": "@opengeni/github",
-      "version": "0.4.60",
+      "version": "0.4.65",
       "dependencies": {
         "@opengeni/config": "workspace:*",
         "@opengeni/contracts": "workspace:*",
@@ -441,7 +442,7 @@
     },
     "packages/interaction": {
       "name": "@opengeni/interaction",
-      "version": "0.4.4",
+      "version": "0.4.8",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
       },
@@ -463,7 +464,7 @@
     },
     "packages/observability": {
       "name": "@opengeni/observability",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
         "prom-client": "^15.1.3",
@@ -475,7 +476,7 @@
     },
     "packages/ogtool": {
       "name": "@opengeni/ogtool",
-      "version": "0.3.9",
+      "version": "0.3.13",
       "bin": {
         "ogtool": "./dist/bin/ogtool.cjs",
       },
@@ -489,7 +490,7 @@
     },
     "packages/react": {
       "name": "@opengeni/react",
-      "version": "1.0.3",
+      "version": "2.0.1",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
         "@dnd-kit/core": "6.3.1",
@@ -581,7 +582,7 @@
     },
     "packages/runtime": {
       "name": "@opengeni/runtime",
-      "version": "1.0.2",
+      "version": "1.1.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@noble/hashes": "^1.8.0",
@@ -610,7 +611,7 @@
     },
     "packages/sdk": {
       "name": "@opengeni/sdk",
-      "version": "1.0.2",
+      "version": "2.0.1",
       "dependencies": {
         "@opengeni/contracts": "workspace:*",
       },
@@ -628,7 +629,7 @@
     },
     "packages/storage": {
       "name": "@opengeni/storage",
-      "version": "0.2.97",
+      "version": "0.2.102",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1044.0",
         "@aws-sdk/s3-request-presigner": "^3.1044.0",
@@ -3650,6 +3651,8 @@
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 

--- a/package.json
+++ b/package.json
@@ -117,6 +117,8 @@
     "check:docs-refs": "bun scripts/check-docs-refs.ts",
     "check:model-pricing": "bun scripts/check-model-pricing.ts",
     "check:public-hygiene": "bun scripts/check-public-repo-hygiene.ts",
+    "check:workflow-graph": "bun scripts/workflow-execution-graph.ts",
+    "workflow-graph:refresh": "bun scripts/workflow-execution-graph.ts --write",
     "check:migration-ordinals": "bun scripts/check-migration-ordinals.ts",
     "check:migration-rls-backfills": "bun scripts/check-migration-rls-backfills.ts",
     "migration:renumber": "bun scripts/renumber-migration.ts",
@@ -175,7 +177,8 @@
     "oxlint": "1.73.0",
     "playwright": "^1.61.1",
     "postgres": "^3.4.9",
-    "typescript": "7.0.2"
+    "typescript": "7.0.2",
+    "yaml": "2.9.0"
   },
   "overrides": {
     "@codemirror/state": "6.7.1",

--- a/scripts/artifact-runtime-workflow-contract.test.ts
+++ b/scripts/artifact-runtime-workflow-contract.test.ts
@@ -78,7 +78,9 @@ describe("artifact runtime workflow contract", () => {
     }
     expect(candidate).toContain("cancel-in-progress: false");
     expect(ci).toContain("github.event_name != 'workflow_dispatch'");
-    expect(ci).toContain("browsers: chromium firefox webkit");
+    expect(ci).toContain(
+      "browsers: ${{ matrix.lane == 'workbench' && 'chromium firefox webkit' || 'chromium' }}",
+    );
     for (const suite of [
       "artifact-spreadsheet-canvas.browser.e2e.ts",
       "artifact-spreadsheet-scroll.browser.e2e.ts",

--- a/scripts/check-release-pr-automation.test.ts
+++ b/scripts/check-release-pr-automation.test.ts
@@ -3572,6 +3572,16 @@ describe("workflow contracts", () => {
 
     const source = ci.jobs["source-contracts"];
     expect(source.needs).toEqual(["automation-admission", "plan"]);
+    const sourceInstallIndex = source.steps.findIndex(
+      (step: any) => step.name === "Install dependencies",
+    );
+    const sourceInstall = source.steps[sourceInstallIndex];
+    expect(sourceInstall.run.trim().split("\n")).toEqual([
+      "bun install --frozen-lockfile --ignore-scripts",
+      "bun scripts/workflow-execution-graph.ts --git-tree 'HEAD^{tree}'",
+    ]);
+    expect(source.steps.slice(0, sourceInstallIndex).filter((step: any) => step.run)).toEqual([]);
+    expect(source.steps.filter((step: any) => step.run)[0]?.name).toBe("Install dependencies");
     for (const stepName of [
       "Validate changeset release plan",
       "Profile impacted TypeScript 7 projects",
@@ -3651,8 +3661,7 @@ describe("workflow contracts", () => {
       ],
       "browser-acceptance": [
         "Stabilize Ubuntu package downloads",
-        "Install pinned Chromium runtime",
-        "Install pinned cross-browser runtimes",
+        "Install pinned lane browser runtimes",
         "Editable artifact browser acceptance",
         "Install pinned artifact native toolchain",
         "Editable artifact full-stack browser acceptance",
@@ -3779,16 +3788,12 @@ describe("workflow contracts", () => {
     );
     expect(browserInstalls).toEqual([
       {
-        name: "Install pinned Chromium runtime",
-        if: "${{ matrix.lane != 'workbench' }}",
+        name: "Install pinned lane browser runtimes",
         uses: "./.github/actions/playwright-browsers",
-        with: { browsers: "chromium" },
-      },
-      {
-        name: "Install pinned cross-browser runtimes",
-        if: "${{ matrix.lane == 'workbench' }}",
-        uses: "./.github/actions/playwright-browsers",
-        with: { browsers: "chromium firefox webkit" },
+        "timeout-minutes": 17,
+        with: {
+          browsers: "${{ matrix.lane == 'workbench' && 'chromium firefox webkit' || 'chromium' }}",
+        },
       },
     ]);
     expect(

--- a/scripts/workflow-execution-graph-manifest.json
+++ b/scripts/workflow-execution-graph-manifest.json
@@ -1,0 +1,1309 @@
+{
+  "schemaVersion": 1,
+  "domain": "opengeni.workflow-execution-graph.v1",
+  "canonicalization": "restricted-yaml-1.2-sorted-json-v1",
+  "hashAlgorithm": "sha256",
+  "workflows": [
+    {
+      "path": ".github/workflows/agent-ci.yml",
+      "sha256": "d932992a63da8accc4d3a35cfa87596f40e1f88cb3aafb1cb1f927271d2d5f38"
+    },
+    {
+      "path": ".github/workflows/agent-release.yml",
+      "sha256": "35441ce078a5d5b5710ff2746a5d2d3e6ee0989f6547d3d1bf772c248e3f51ad"
+    },
+    {
+      "path": ".github/workflows/artifact-runtime.yml",
+      "sha256": "792b3a37eb60d66c3bca69f12e5c5820a268b5b6e6229b93650a9f243c1e9138"
+    },
+    {
+      "path": ".github/workflows/ci.yml",
+      "sha256": "8c73674389bd6dba5ee5f452bc567076a68966f2f36c0c20787d50e6f6d9afef"
+    },
+    {
+      "path": ".github/workflows/desktop-e2e.yml",
+      "sha256": "9aae9ecd5dff90589d8fbadb98b4afcfefe433a6c359fac03556f6fc2ba89a45"
+    },
+    {
+      "path": ".github/workflows/open-version-pr.yml",
+      "sha256": "62238197b7ad8ac2dbb1c188692d70ab658c993ef5087a491a73cd6e8e19da22"
+    },
+    {
+      "path": ".github/workflows/production-pr-heads.yml",
+      "sha256": "48a8726756c75dc74b33e4824adcd0fdad9bc50fa1f55da1e410375e7dd2db3a"
+    },
+    {
+      "path": ".github/workflows/publish-canary.yml",
+      "sha256": "98e63b20977ab223f7ccf737a5d8b2aabeb0df02783eb6395646170681382a83"
+    },
+    {
+      "path": ".github/workflows/publish-desktop-image.yml",
+      "sha256": "06c13c4bb0f87e04303e07c1d39082ff3463e19cecc44d60f94496e33cfaade6"
+    },
+    {
+      "path": ".github/workflows/publish-packages.yml",
+      "sha256": "ed111afddcb1980a4c7f7a8b8c0d821a98bc0826b5db2058d2d90e19d5fd5660"
+    },
+    {
+      "path": ".github/workflows/release-acceptance.yml",
+      "sha256": "b2f3fd253fa2e8fb833e4f7af4d09616ca9feb9233e7528e4d75674bd57e1589"
+    },
+    {
+      "path": ".github/workflows/release-candidate.yml",
+      "sha256": "6270b3a82413ba9c40d7011c653f468e98c33df997bc9ea195367d25bf3f4f96"
+    },
+    {
+      "path": ".github/workflows/release-embedded.yml",
+      "sha256": "197b48efce02b7ba6c1fc36f02a626c9fe597e1600f3b5e1b6cf5c7317e286ce"
+    },
+    {
+      "path": ".github/workflows/release-publication-admission.yml",
+      "sha256": "1e34b409940a9c11d44bf25de320bfc7d8bcbe35d19cf88a27a0f99ad95688bc"
+    },
+    {
+      "path": ".github/workflows/release-source-admission.yml",
+      "sha256": "2812ab07372c1b8a594a6823eccf845e5bc68a672c2f72d4b9a19096f1b988d2"
+    },
+    {
+      "path": ".github/workflows/release.yml",
+      "sha256": "30a86a0b8f1af49c9c448a19917f56b42ba0d4628631214bbfd35d91c7b1a2df"
+    },
+    {
+      "path": ".github/workflows/retain-release-controller.yml",
+      "sha256": "0e23abea6dedd011ac5280d5bf9c6abab2c91bffc06e77a5fc251c409b05e23c"
+    },
+    {
+      "path": ".github/workflows/seal-release-head.yml",
+      "sha256": "62dc8c926a23692a931c6257100a4ded7d4d80d2e127868255c057e1a123a022"
+    },
+    {
+      "path": ".github/workflows/source-admission.yml",
+      "sha256": "f18606d2da2fef8dc7726958e5fbe753b4567a7df043f5549f650ef491310673"
+    },
+    {
+      "path": ".github/workflows/staging-canary-dispatch.yml",
+      "sha256": "63024dbfb1d46c8a8f19e269556b4c575de14de8ba806637de36ae5b553b2396"
+    },
+    {
+      "path": ".github/workflows/verify-public-container-packages.yml",
+      "sha256": "4b1f305f95190ccb428338e77413359707d70dead3c9bc64902a0685485bbad4"
+    }
+  ],
+  "actions": [
+    {
+      "path": ".github/actions/playwright-browsers/action.yml",
+      "sha256": "1d1865cf748e6cfa686eb69216057d6aa02037549f4728ae05a63828397942c7"
+    },
+    {
+      "path": ".github/actions/public-oci-login/action.yml",
+      "sha256": "2c4c1bcbac559a67a1bf74b5e3199ad82a32ee91ec593881f6d27786b51a37ea"
+    }
+  ],
+  "generatedLocalTargets": [
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Log in to the public OCI registry",
+      "target": "./.release/controller/.github/actions/public-oci-login",
+      "authority": "retained-release-controller"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Log in to the public OCI registry",
+      "target": "./.release/controller/.github/actions/public-oci-login",
+      "authority": "retained-release-controller"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "images",
+      "step": "Log in to the public OCI registry",
+      "target": "./.release/controller/.github/actions/public-oci-login",
+      "authority": "retained-release-controller"
+    }
+  ],
+  "uncappedRuns": [
+    {
+      "workflow": ".github/workflows/agent-ci.yml",
+      "job": "install-smoke",
+      "step": "Build the agent binary",
+      "sha256": "e9513a6a0b8d0d899e23abf99c6bd6c677869ad04795f12c58cac1d535c9c697"
+    },
+    {
+      "workflow": ".github/workflows/agent-ci.yml",
+      "job": "install-smoke",
+      "step": "Install minisign (Unix)",
+      "sha256": "06b8e12438bced8581b36f9b5e368eae3f5b4f39e9ec44b968975da67c96b884"
+    },
+    {
+      "workflow": ".github/workflows/agent-ci.yml",
+      "job": "install-smoke",
+      "step": "Install minisign (Windows)",
+      "sha256": "c71c235421aa81e82593804ced090331f86e13adef10e754f314e07eb3ce8c96"
+    },
+    {
+      "workflow": ".github/workflows/agent-ci.yml",
+      "job": "install-smoke",
+      "step": "Simulate the macOS app-bundle assembly (mocked codesign/security)",
+      "sha256": "83697adcf34fd96da796ff30c2ab38e86e0891e6cc32e38ee96b0daa595b6299"
+    },
+    {
+      "workflow": ".github/workflows/agent-ci.yml",
+      "job": "install-smoke",
+      "step": "Smoke the install script (Unix)",
+      "sha256": "e4499cffc236e1b07c7914ae240ecf7e00ff30cf9a82cbfba2d5ec2e41c481a1"
+    },
+    {
+      "workflow": ".github/workflows/agent-ci.yml",
+      "job": "install-smoke",
+      "step": "Smoke the install script (Windows)",
+      "sha256": "845a9f7d2614d90a274f578f5b72e617c08240e5dec7b53f08561f3552707675"
+    },
+    {
+      "workflow": ".github/workflows/agent-ci.yml",
+      "job": "lint",
+      "step": "cargo clippy -D warnings",
+      "sha256": "2cf7adee7363c2732053a7775787cfa0630ba5e38286709965ce1ebbaa50a3fe"
+    },
+    {
+      "workflow": ".github/workflows/agent-ci.yml",
+      "job": "lint",
+      "step": "cargo fmt --check",
+      "sha256": "3e081fcdee4a209500929094880b5aa5666629b7294f7d8f473e3dafe0a0c468"
+    },
+    {
+      "workflow": ".github/workflows/agent-ci.yml",
+      "job": "msrv",
+      "step": "Compile the locked workspace",
+      "sha256": "10d270add60cd3d6597560d62e54b433e58f3f18af43deb0ca652ec857298ded"
+    },
+    {
+      "workflow": ".github/workflows/agent-ci.yml",
+      "job": "test",
+      "step": "cargo build --release --workspace",
+      "sha256": "edf73b5fcb65b446c151c1bef82227f31164cbf8a4321051d2f1f535ffa4e2f6"
+    },
+    {
+      "workflow": ".github/workflows/agent-ci.yml",
+      "job": "test",
+      "step": "cargo test --workspace",
+      "sha256": "6670c980f74155967c09fd3c8fe0be8c8882ee56bc5b23f56b80ef27fd7f669a"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Build (Linux musl static)",
+      "sha256": "d89ddd6baa6b20ae87b6430992c376c5f28e08c81a7d384ce16c9b77f4262ecf"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Build (macOS universal)",
+      "sha256": "f711b2d4069f2f090ff87edd5f93fe08905dde6465d9ea0dadc11ea3928bae55"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Build (Windows MSVC)",
+      "sha256": "47e82ccc9bf5233331015516e93808bcc105a3425b80ddbb85ededac49b20c3b"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Build interaction helpers (Linux glibc)",
+      "sha256": "c223939a65f128e9c5eba3163d85e03acc2f21ea52d8183e4de741e0e2a7e4b6"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Build interaction helpers (macOS universal)",
+      "sha256": "c6d3fe6759106ce4d97dd131b7cff51174284b2194851234d67f98adfdce70ad"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Build interaction helpers (Windows x64)",
+      "sha256": "db7bc69a7fc8af6b65a787d7984388c06a04a6589f6f87243a5d6c49f6340d9d"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Detect signing creds",
+      "sha256": "361786f3ad958c06709a22cd6fc6a1b3493ba614e94fad9fe4b09f4929378eff"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Install workspace dependencies",
+      "sha256": "8087ab5145312bf0747fbb8f871326960427169b20a5eff1b178cdc3704fe5ff"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Intel cargo test (macOS coverage)",
+      "sha256": "fd05d9ba821478e273f62c755c4a70dbf21f49e1b5e8b727a5cef441997bcfb2"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "macOS assemble + sign + notarize .app bundle (if creds present)",
+      "sha256": "91450a7a2bd6992a76b161a598065e5bbb80c39f9158bae167b3d2ebb57b5792"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "macOS codesign + notarize (if creds present)",
+      "sha256": "04409b0e9e5fec5243e7686dc8c4c43ce5628c8a45b2a1785b6ebdac17696d06"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "macOS unsigned note (no creds)",
+      "sha256": "033d97dd8c17e376d934781eea91a6919e98d67bb58a48df16b41858ad8234a2"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "minisign-sign + sha256 the artifact",
+      "sha256": "cb1fd351611f75e34b60f4bb824222f5e3db37a733d30675bcb14df9891af8fa"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Require the release signing key",
+      "sha256": "00118c74da0966d2f2a1fca2fe58f3c05e63394aafdc041a3e835643961df0c4"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Windows Authenticode (if cert present)",
+      "sha256": "db7fb389f907959e01aaaaa62498f2acefd3eb6556df714dd35eef889ec56779"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "build",
+      "step": "Windows unsigned note (no cert)",
+      "sha256": "704096f4d643358ca1200e07fabae60d6862764f321582099054cdf76b26f270"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "guard",
+      "step": "Resolve + verify the version",
+      "sha256": "0e03cb9a6c1d0a47d59984b9b1b5ec0bf32fa53e18389e77aa6e7bee4dadbc28"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "publish",
+      "step": "Assemble SHA256SUMS",
+      "sha256": "f4846b9760231e51e840da34150ab4c5884cb325a62a2fbdb6430d6803c64862"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "publish",
+      "step": "Build and sign the stable update manifest",
+      "sha256": "5ab7a487c5f60332081350a17b61bf22edfb12172c1dbb0f7197b4168d896b54"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "publish",
+      "step": "Detect signing creds",
+      "sha256": "bbb7ba46dfc89ae6888dd3e917b71d50d34db4c95256728f2982db03fccc813a"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "publish",
+      "step": "Require the release signing key",
+      "sha256": "f5a4abfbf9dd4157dfb24c011f207ed7af065677063711d3cfcd3a121d3bc3e8"
+    },
+    {
+      "workflow": ".github/workflows/agent-release.yml",
+      "job": "publish",
+      "step": "Sign SHA256SUMS (if the key is present)",
+      "sha256": "baf152da95882ffab53a0fa3f530623802a8d20c66f89620e99c184530b6fd7c"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "aggregate",
+      "step": "Assemble exact OCI architecture inputs",
+      "sha256": "a7fa226afd353c9d0e086d59aa785006e5326ecb5fad66b8bf494079d8dda57a"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "aggregate",
+      "step": "Build and pack exact artifact-tool",
+      "sha256": "9c132a688793f1042d80f81f60e7082a6b3d954ad779e375491581237dad8822"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "aggregate",
+      "step": "Install dependencies",
+      "sha256": "0f78327a8ba923d047e2700008f04549979cbe8b34759afb71f3bf0fcaff5e65"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "aggregate",
+      "step": "Materialize complete release matrix",
+      "sha256": "bd8c47ee02d2211c86df4ae234e1feeeb71feca452f47d3eff9fedbe721df51e"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "aggregate",
+      "step": "Name run-local runtime input artifact",
+      "sha256": "ca3b31938a0b3d5fa1a8f18930c99ac16b8205d1a2061d3b74908b0b605fab29"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "aggregate",
+      "step": "Prove Docker target mapping and doctor on both architectures",
+      "sha256": "c6c898f9f9ff191938adac8fc05bc641842861aa402f1fa2035250aaf531f7b9"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "aggregate",
+      "step": "Require the complete target receipt matrix",
+      "sha256": "a82eab786466eba380d5ee8c6d8d05ef8d307997ee21817179d576f9e977bdfb"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "aggregate",
+      "step": "Strict host locator and doctor",
+      "sha256": "dc8d1fe6011e894725c62d5379b6d40f49b08d97790dbd49dd038cf86435c824"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "aggregate",
+      "step": "Verify exact source",
+      "sha256": "81008de3211b15fe1bf2ace962528003f0deea03d3a1ca4e49b86eb068d1760c"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "musl",
+      "step": "Build and smoke in exact musl userspace",
+      "sha256": "720f81713f39dde007ce1f37c62765988bbfcbf1d61f2ac104922b6641c80717"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "musl",
+      "step": "Verify exact source",
+      "sha256": "984a7936ace1f2a6345fd7959a2a0f31188e54f1285eee4019664513274332b2"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "native",
+      "step": "Build and smoke exact target",
+      "sha256": "da6a21aa6501003753f1cdc39a164daa04f937cc2e9b11beafbf25c4e07dcd3f"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "native",
+      "step": "Install dependencies",
+      "sha256": "f27fb534817b6b3f8b65c5a07ab99ae8c6ea1abf48a9d85b81347088d2b8b6e3"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "native",
+      "step": "Install pinned Rust toolchain",
+      "sha256": "fe1b6eaabd6d9b517800a2c8355adc2385ed20062328fb604e44990f4efcd6ae"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "native",
+      "step": "Verify exact source",
+      "sha256": "fa1840741698c9025a1c6853fd22ebf961cb05f3299ae54ec026527fe4141b7e"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "wasm",
+      "step": "Build and smoke exact target",
+      "sha256": "690bb84fd0249802cea5dca6d5588519ce021d589d1d17f2830a084a1ab6494e"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "wasm",
+      "step": "Install dependencies",
+      "sha256": "3ef2070b5e575c31cc2bad59eb302296a8087bb006eda04134ef31ad80b18d08"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "wasm",
+      "step": "Install pinned WASM toolchain",
+      "sha256": "fd8bfebde6edfa39494abfba5fd1a93a554570025a7f5080def35966db36a160"
+    },
+    {
+      "workflow": ".github/workflows/artifact-runtime.yml",
+      "job": "wasm",
+      "step": "Verify exact source",
+      "sha256": "7c01541f3dc7c536488a007902ea1453cd191ebb6c348edcbac345077c0dcb25"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "api-image",
+      "step": "Bake and sign exact-SHA canary agent",
+      "sha256": "d29339f15f4e729950ec900b531bb5577ea9150a45f34298c19d4a748f7d5952"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "api-image",
+      "step": "Install Rust toolchain for canary agent bake",
+      "sha256": "e2ddf5461ac0ed0837eecfce5fb7a0301a153fec5b620c74cf9f613cd518084e"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "api-image",
+      "step": "Require complete exact-SHA canary agent bake",
+      "sha256": "47df19770be17260ddc5eaafaa3bec4c3693c72107502a9df0405537b68620d6"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "automation-admission",
+      "step": "Admit trusted dispatch and exact source tree",
+      "sha256": "37bff3be6545202ad9da84c5ce6eab5f37364fa6979460e0cd3543cf0b9ca08b"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "automation-admission",
+      "step": "Begin exact-head automation checks",
+      "sha256": "81d3798aa81b98dbf6cc65c1c95f8ab147db1c4d7e8c8ae032dd1e628bf4b54a"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "automation-admission",
+      "step": "Complete exact-head source-admission check",
+      "sha256": "2c1883cf9025221f4d0c7a6373e8b16053731cfe3066edaa132ce4412e05c255"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "automation-admission",
+      "step": "Install trusted-base dependencies",
+      "sha256": "34e6d3dd78f13da6151074b3e304d24fa5c81576a5413327b5a402bf78dbf151"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "automation-admission",
+      "step": "Reproduce deterministic Version PR tree",
+      "sha256": "ec8f3406f284587176adb5180b9c8f63e7747e6b57198adbb68fb2522eeef971"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "automation-report",
+      "step": "Complete exact-head automation CI check",
+      "sha256": "dcdc181521aaa90b02a3abe81d25af741f76924204ad28e1fd35dd3fc679cc4c"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "browser-acceptance",
+      "step": "Capabilities control-center browser acceptance",
+      "sha256": "fa2d16a4ad98e618faf02d3a01621110009be34290ccaa3488e224f6027bb937"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "browser-acceptance",
+      "step": "Codex quota and entitlement browser acceptance",
+      "sha256": "fd3952eafc7f28972d1313c83f9526a35edcabe179526d5ced04dee26731fa7f"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "browser-acceptance",
+      "step": "Editable artifact browser acceptance",
+      "sha256": "07108d4c2f508e5b2d0c8f042098adacc04d8f998c43c5d93cf60b0f7c9140b1"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "browser-acceptance",
+      "step": "Editable artifact full-stack browser acceptance",
+      "sha256": "aec77af91c54739fdb8f5d0f35831a3b9401b871c6e11568c642759a7ad7f694"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "browser-acceptance",
+      "step": "Install dependencies",
+      "sha256": "9dc2fb5bd77f5a2a3f1400a3a6411a437f95954e7ae0bb45ed7adb539da9fbbb"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "browser-acceptance",
+      "step": "Install pinned artifact native toolchain",
+      "sha256": "ca2c2c49237ff95707be54cd6e91f2a72ebd94193b7e9ba2386d732d8edcc704"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "browser-acceptance",
+      "step": "Long user-message disclosure browser acceptance",
+      "sha256": "739c84e9bac7302d3c170004ffc7de7de6b4dc3306dc8556c5a14b9e10134ec2"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "browser-acceptance",
+      "step": "Public realtime SDK demo browser acceptance",
+      "sha256": "bcd0219a8019bc01d7ab093ef8a772aa18c13510254538b758506ba0be844cd6"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "browser-acceptance",
+      "step": "Queue surface browser acceptance",
+      "sha256": "e01d34dfa1b0c05fe42e775b79a39571ddf9ef7e0826999a2f49aefa84b8b549"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "browser-acceptance",
+      "step": "Stabilize Ubuntu package downloads",
+      "sha256": "fab7e78dd1d412f10650b97447bc8742deff4000c1f2ca13c40d21ce4edaf912"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "deployment",
+      "step": "Install dependencies",
+      "sha256": "c002a6d527c30937cac224d77e729583974d8a4fba6e2e515a2b56231aa499a4"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "deployment",
+      "step": "Validate deployment profiles",
+      "sha256": "64f9fffe0325d49903b424f4092bb3249adbdca73a493ea50a56f5ff9d8e6030"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "deployment",
+      "step": "Validate Helm chart",
+      "sha256": "6a4a178aa8a1af109f3fdc299a921c33bffbaf109efe75360af8cfb4ebf69140"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "deployment",
+      "step": "Validate Terraform",
+      "sha256": "de947484bd04df5f1bee6ed285290f6ce3007c3cbc5ddc85197b63b40417d6e9"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "e2e-shards",
+      "step": "Install dependencies",
+      "sha256": "1d7e772f27cb0541a9370d9b2821a04e9f73a075ba77c2f659b2f52b0026d8fd"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "e2e-shards",
+      "step": "Stabilize Ubuntu package downloads",
+      "sha256": "ad9bed9b4b78a32de8973d0897f2616c37ff69d93d2e0e87168023385d84e3d0"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "images",
+      "step": "Require every workload image build",
+      "sha256": "e71506956e77d0c0cb1eee25ae8b1895d284614c349a9aa062892a046923e606"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "images",
+      "step": "Write exact-main-SHA canary receipt",
+      "sha256": "b5030683a20f69f187a9ae6337e5359c45af4544112182c6f05b5cd9bba265b8"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "integration-shards",
+      "step": "Install dependencies",
+      "sha256": "65141fa57adc4b2d61605a21690d287eb6b334ed6033355d6809e2bc8fef7258"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Build React demo harness",
+      "sha256": "70903471db4d7508f1e7e3e60e06259d1a936bc290469ed38f117692e45d548e"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Clean published consumer",
+      "sha256": "d326dc84fc2a13a7f0c9d41e79fbc52abc77750b39811c0e882acfe42a99810c"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Install dependencies",
+      "sha256": "fb4b6b8c7c9a00df764a5355b27033e20df9cf1b10c2af60979b8487fb762cd3"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Install pinned artifact-kernel build toolchain",
+      "sha256": "c705850093d508e42e7bbbe77ba9f0af2cd426359d0e7a563e3024b8996a5dbb"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Packed SDK Worker and modality WASM packages",
+      "sha256": "94e77db5289d42eb588a856e071dad9bc64a867a4d501dd4c05c5b4a55f19c99"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Portable ogtool package",
+      "sha256": "030c79cfece7aa1bc05262e204a36c09c0947c39bf21a0c72e4bc20332bf843b"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Production native artifact contracts",
+      "sha256": "f21110979b00d2aa646be43a998d8a019861c73ad26ab21ba379652a7aec866a"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Publish closure guard",
+      "sha256": "9183a8eea2e8c163fa98b03cf6193f44a5d8258f9f1b07b751412b6141361785"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "React Native Metro to Hermes session bundle",
+      "sha256": "9cf92763ca740af1fd88793a21615322f6955f480ffdfda9aa05fa7cc65acfbe"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Reproduce committed modality WASM packages from clean Rust sources",
+      "sha256": "ed8b4ba80431f552affb1ca65fc46621d50c3c222fb8be82a8b707c445b34002"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Runtime embedding consumer",
+      "sha256": "8a141b4f43851075c4f062f05fb3f3416fe14a0d41e9533e802379c0509833e1"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Stabilize Ubuntu package downloads",
+      "sha256": "800cc2c8d80db689b820401048709214bac2c11b19c1134cac1370df7512ecbc"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "package-contracts",
+      "step": "Web bundle budget",
+      "sha256": "496db0deee4830c03022abdfdc9aa5c679352d631445a9e9a2291b2dcceebff5"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "plan",
+      "step": "Build fail-closed impact plan",
+      "sha256": "65417e12aa310fdda747063ba8c0dc71546ca0deab02384a710f9a6c4c4eb96f"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "plan",
+      "step": "Record dependency cache outcome",
+      "sha256": "d62d858d5e25fa401e05c9dc846f4dcb3aa730f279cd7b64df76765af634124b"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "source-contracts",
+      "step": "Impact, resource, and profiling contracts",
+      "sha256": "c2d190b02b8c0d2abb536b7622ce6bc5497e57fddcf8a2bb093afa2c07999167"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "source-contracts",
+      "step": "Install dependencies",
+      "sha256": "914c30f10278b442754d6346aeb4f197b648d41cd9aa8c9d7e6b88fec7ca3dc0"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "source-contracts",
+      "step": "Validate changeset release plan",
+      "sha256": "c5654a8fbce26ca93c0f42308c8ec77bec4f02dc63db52db5c40f53041f2b25d"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "test-suite",
+      "step": "Install dependencies",
+      "sha256": "ab53a2a00d8ed91a73967cd79ce99418e65ad120990bba906a2b0dc6cb9b127b"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "test-suite",
+      "step": "React warning-free test gate",
+      "sha256": "20feeee1b61274d565e0e155da58ffabfa957e6360d1e785b0c4529320717904"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "test",
+      "step": "Require every split CI lane",
+      "sha256": "149f04b6ac3d2b425a1852edb335b3cabb9b3d86f642393efc3fe25129aeae5c"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "test",
+      "step": "Require successful impact planning before candidate execution",
+      "sha256": "5a0aeaffb88605eb7ea06372b92911a99bbd4e9a3f9f281eb6d297f7cf7380d3"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "unit-shards",
+      "step": "Install dependencies",
+      "sha256": "7cb809eb1ef393bbc5a2636bd2b170fa2e07cb82a5abc8a5d8bf3b6c16444b71"
+    },
+    {
+      "workflow": ".github/workflows/desktop-e2e.yml",
+      "job": "desktop-image",
+      "step": "Install dependencies",
+      "sha256": "13753204e14b60ac778c84fa19b0c08b7a529710253a322d3ef40f64119448fa"
+    },
+    {
+      "workflow": ".github/workflows/open-version-pr.yml",
+      "job": "version",
+      "step": "Detect versionable changesets",
+      "sha256": "f30f84a04bf35ef767b3c16abe8ce271d78f3048ef86f68ced90f9642b83ae79"
+    },
+    {
+      "workflow": ".github/workflows/open-version-pr.yml",
+      "job": "version",
+      "step": "Dispatch exact-head Version PR CI",
+      "sha256": "382691ebd189b1576a8dca66899797a174245de57d1d41c7b0ea7bf1f3950b46"
+    },
+    {
+      "workflow": ".github/workflows/open-version-pr.yml",
+      "job": "version",
+      "step": "Install dependencies",
+      "sha256": "d49a8117b6f9103df4e23d9b163453bde1977e4bbf8b612304d7e3eab784cbae"
+    },
+    {
+      "workflow": ".github/workflows/production-pr-heads.yml",
+      "job": "admit-head",
+      "step": "Require main or hotfix/* head",
+      "sha256": "908ca29300a102728fbafc0c6b501bfe098c335138c8be1dbf852e40dd46f5b0"
+    },
+    {
+      "workflow": ".github/workflows/publish-canary.yml",
+      "job": "publish",
+      "step": "Install dependencies",
+      "sha256": "f8bcca05a8977b957eae51d4f41a09276a319cab0e4adba860584025f55132cc"
+    },
+    {
+      "workflow": ".github/workflows/publish-canary.yml",
+      "job": "publish",
+      "step": "Publish canary versions",
+      "sha256": "dc8ac6d56268cd6bdf86da4b418c393a303f90851923c24b9d5a995bb4bd0244"
+    },
+    {
+      "workflow": ".github/workflows/publish-packages.yml",
+      "job": "publish",
+      "step": "Install dependencies",
+      "sha256": "92948fdb1f2dbed220997ea2b6fe3ea57eebc740f02ef7adcadaba935c0d28ff"
+    },
+    {
+      "workflow": ".github/workflows/publish-packages.yml",
+      "job": "publish",
+      "step": "Plan exact package publication",
+      "sha256": "170df5636612e5ad5795fe7749240b4cca89cc86b72140fc40df4483a54f9cbd"
+    },
+    {
+      "workflow": ".github/workflows/publish-packages.yml",
+      "job": "publish",
+      "step": "Reconcile exact registry package identity",
+      "sha256": "f624f094db63fdb254a153a734f5838ad0fc7d9f51821febf3a1b049da9b6a30"
+    },
+    {
+      "workflow": ".github/workflows/publish-packages.yml",
+      "job": "publish",
+      "step": "Require successful protected source CI",
+      "sha256": "13237f597321e1a7030bc3f8b27e24c50675432f202f2faee9e9f627cb4ec3b5"
+    },
+    {
+      "workflow": ".github/workflows/publish-packages.yml",
+      "job": "publish",
+      "step": "Verify exact versioned main",
+      "sha256": "f81d5a2cc8ed43e80b40306aba89b330dd61226791dc1f825e03c1c00af2a55a"
+    },
+    {
+      "workflow": ".github/workflows/publish-packages.yml",
+      "job": "publish",
+      "step": "Verify publishable closure",
+      "sha256": "c18d0e2815c7263404fd08bd381f6afc66620c8bbba61f13828a0f6f6b22eda4"
+    },
+    {
+      "workflow": ".github/workflows/release-acceptance.yml",
+      "job": "acceptance",
+      "step": "Assemble and validate the canonical acceptance bundle",
+      "sha256": "3b92a9f2520ba30149503d7108aeb7ab591aabb002a8778acb6e069b54d1f8e2"
+    },
+    {
+      "workflow": ".github/workflows/release-acceptance.yml",
+      "job": "acceptance",
+      "step": "Download the exact candidate receipt",
+      "sha256": "ed7ea22719532fc6c6f5cffb6a4d73852bcfac93c4f0d02f3f4d1bd13589d868"
+    },
+    {
+      "workflow": ".github/workflows/release-acceptance.yml",
+      "job": "acceptance",
+      "step": "Download the exact sanitized operator bundle",
+      "sha256": "9192193963337d075e1f2128ec69381150290dfb3e1b507eeebb6e24041585a9"
+    },
+    {
+      "workflow": ".github/workflows/release-acceptance.yml",
+      "job": "acceptance",
+      "step": "Validate source identity",
+      "sha256": "d50e3fe6c983ca6f80c094eea4eae5df61e7924d53fdf5554c901627e16cdc3e"
+    },
+    {
+      "workflow": ".github/workflows/release-acceptance.yml",
+      "job": "acceptance",
+      "step": "Verify the candidate producer before acceptance",
+      "sha256": "aa670e4963e2c8594acca99ab083159164516c30cf6df6827ad834fbf46d7d4d"
+    },
+    {
+      "workflow": ".github/workflows/release-acceptance.yml",
+      "job": "acceptance",
+      "step": "Verify the protected operator acceptance producer",
+      "sha256": "5d83a318fa0e7f0f8a948d6607e203d48a9c6f2a3b6da958bc4bddceab74215a"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Bake and sign per-SHA agent binaries",
+      "sha256": "2f778ce0ca667ac7edbac85b0aa8db8794a5b6ea9c7ecbec51e9696c746979de"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Freeze candidate producer identity",
+      "sha256": "5f30aa97d3c41528bdf284b19ff68599187ce5bce3273c41c0d5780be602498f"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Install the Rust toolchain",
+      "sha256": "04668970a84ecacceb45e9514a1a0c2e9e9d1bc24a641aa9988397b26d87d611"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Package the deterministic immutable Helm chart candidate",
+      "sha256": "1ee9fe40597a905e62b682be2032058b38bbce0f4028e2ad95fa46350315038d"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Plan exact package publication",
+      "sha256": "956927c38b7e7155d39dd6b573215a411974bfe4fc039f0a35eb16c230c8d664"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Publish immutable source-SHA candidate receipt",
+      "sha256": "d75b0aea38ca6703654cf9b2063f838045264b148845bfdb3ab3c6227343ade1"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Refuse an occupied product release version",
+      "sha256": "78f2331526635b6a5b120dfbfc760ed668428b7a2610e3ce0124fac329f46f50"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Refuse occupied run-scoped candidate tags",
+      "sha256": "470b6fba1bda98f6d67392f9e7ec1df30c946506ec9c23f457f3449f8ead3b98"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Refuse to rerun a completed immutable candidate",
+      "sha256": "ad3910c3ede99144e244d5825bc533fde532e35c7c0d05ce8fef19ff8af7bbf3"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Resolve API candidate digest",
+      "sha256": "14471804891efb9b5aa9e380b404441b6d5bae5f51e15ef710ad38961cdda475"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Resolve artifact materializer candidate digest",
+      "sha256": "b0cc8bbb09f96db09b5f04bf37ccec18974326d0f42204527a255cd2a19abe34"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Resolve artifact outbox dispatcher candidate digest",
+      "sha256": "db8bec6ffd48620c3d5f96f8277a060967b5d44644339761cda51ee3cb3fbbf0"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Resolve candidate identity",
+      "sha256": "acc453965326f8aa632c3e648a347f5b46c4f209f5ae5e978a5978657b68bb7d"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Resolve relay candidate digest",
+      "sha256": "352aa7bdc5d0b4c8aaea46a6f86290de502048f8f0c24006de6503973dda7e81"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Resolve sandbox candidate digest",
+      "sha256": "3a0da3f5bac441003f22556b3c169596082eb2d9cf4f9370e02337c7ff50db3f"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Resolve web candidate digest",
+      "sha256": "b799321a09055039bfaa593b74b6b45f6fd58f7a650fc749f07665613f4626d4"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Resolve worker candidate digest",
+      "sha256": "6d69ec8f79a7cd9fd4c46f2a1ad1acd55486c859122aeac146000d554b5043fc"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Validate exact retained versioned main source",
+      "sha256": "e655c70e80fafae8f0e0b649999f37c8e0b6be79bc70ac41fa30c278f5fbbc0e"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Verify candidate images support anonymous pull",
+      "sha256": "9a113e744aee2a393d378f25d93311502df7070015343cdc4d1039f58006de27"
+    },
+    {
+      "workflow": ".github/workflows/release-candidate.yml",
+      "job": "candidate",
+      "step": "Write immutable candidate receipt",
+      "sha256": "c80c8ecf4981402f8fb66945a4e8938e73947679de014a53ba2706c338b71d6c"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Compare an existing immutable distribution before image mutation",
+      "sha256": "b55e3ba6c5f19d120fedbdde534fb5641c9ec276ebfa4e62b5715aefdd2d1a2f"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Download and validate immutable candidate",
+      "sha256": "2e6524b546c4bedc573804ca5dab1300b1d30c45065f290bb18e7df9ae15a18f"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Download and verify source-bound artifact runtime inputs",
+      "sha256": "aae5e9a9ea514db071b916a9a3de810a03972527dbfb230ef46b224a5dc1e2f5"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Download immutable package publication evidence",
+      "sha256": "edd68e7e9e3f3c7af8c5d4f2efad44dd18d685fcb6187c7a74fe91096fb8b002"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Plan exact package publication",
+      "sha256": "a3167fc974eaf9d6e9bd57b26494e2230392a9faf13e83d7eb57e18b026a4dd0"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Prepare admitted package bytes for publication",
+      "sha256": "334b6454b041c0c606d143d323cc7713e9b8c7afd1454db87274746cf7b52fac"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Promote exact candidate manifests",
+      "sha256": "7ee1b5484d3d59d5d255adf9b47e5babdefb2a7e563b58893a6977160599565b"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Publish immutable source-bound release receipt",
+      "sha256": "be482695a3c2ba909981c6bd7b46824f0ebabe0ab05ca5491a38652bdc391be8"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Publish or reconcile the exact candidate chart",
+      "sha256": "2e5d774f5107aad5d030a97af8c4d014207e583723d290b393551d8db957358c"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Reconcile an existing distribution chart before publication",
+      "sha256": "527624c2724638751f940c36fcff419f257b1b06b9bc6930469ed250a3593692"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Reconcile existing distribution aliases before publication",
+      "sha256": "3e85cda62d0ed8706b82fcdbfb26d265aa53a3a5602eeefff524fbeb48ac8b42"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Reconcile npm package identity",
+      "sha256": "5c8c23cd33af45d476aff8bbc37a26cc695a7a8873b5c0cde6032cd6aa163de1"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Resolve distribution version",
+      "sha256": "44b3538cc3c1293fe6c4594a95615b7408f8f3e9a8c7d41eaa695192a42208cf"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Resolve trusted candidate provenance",
+      "sha256": "c371babba78d1bcbcc392c44c9a7c2aa84fcacf4f949c68e343e01c824c03813"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Resolve trusted package publication provenance",
+      "sha256": "143b6ec923fc4d71d21c911313884c6d2b261a51b00f41bad13e21b545f415b3"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Validate exact released source",
+      "sha256": "71d82468fe5096d529f9331177698d6583a911031095c282f04459f776d3b9fd"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Verify anonymous distribution pulls",
+      "sha256": "7c3ba0866c2a45fd0f8cf0db20e6ae8bd963ed4443d0f256fa5b9654237215a1"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Verify complete package evidence",
+      "sha256": "3fbf6da7f3efb656c646c3bbd5e9e95040bc2d693405b21094016f686ad2f7ed"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "release",
+      "step": "Write complete source-bound BOM",
+      "sha256": "7a81f29fa28868f56925bdcca5c2193b5e8e09b518a79b19a24e835eaaf58439"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "source-verification",
+      "step": "Admit the candidate before source execution",
+      "sha256": "6f057bfa9b71c5e09c93e67d8e04ad0fe76527a7e5efffbdc412a502da6a9703"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "source-verification",
+      "step": "Download and validate the admitted candidate receipt",
+      "sha256": "01bb51f005de051217eb734fcf61aafe26a7b8a589dcfb743ca6b0530dade00e"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "source-verification",
+      "step": "Install admitted source dependencies",
+      "sha256": "80a3ff89821fdab8904435f0e657308f8365cc4bb560f0abeb278af0ae7dceaa"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "source-verification",
+      "step": "Run source package gates",
+      "sha256": "4adf8a750974d48f67843ad18f76e816c2cce01c01d70f900b1b6b9e61757b1a"
+    },
+    {
+      "workflow": ".github/workflows/release-embedded.yml",
+      "job": "source-verification",
+      "step": "Verify publish closure from the restored controller",
+      "sha256": "cac4b7e6c8564c510cddc28f38404bfc9b9c79c50294503133be76582c0a4645"
+    },
+    {
+      "workflow": ".github/workflows/release-publication-admission.yml",
+      "job": "verify",
+      "step": "Re-prove the accepted historical release train",
+      "sha256": "359d0fea7433144434aa35b31f193a2b23b6acedb06335905dc94b5a0ae6bacd"
+    },
+    {
+      "workflow": ".github/workflows/release-source-admission.yml",
+      "job": "verify",
+      "step": "Verify controller identity and exact reviewed merge provenance",
+      "sha256": "46e8543cfaf9a0fcd101cc4996e20e36a7605b8938cab4afdb09a4ffc48416c3"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "images",
+      "step": "Compare existing immutable BOM before aliases",
+      "sha256": "9ea41acede37ab153f618be15906c58f823ce640a208f2acc059f14bc1b1958e"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "images",
+      "step": "Download and validate accepted candidate receipt",
+      "sha256": "a34018de6316073c3f1796ceed1ac8340c919eb715e02cb7af25fafdddc189a6"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "images",
+      "step": "Promote exact accepted manifests",
+      "sha256": "8a8bb937af19f22c9d41e9e2cd850d61e8fa6febafbe2cdab342ddef337af159"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "images",
+      "step": "Publish immutable source-SHA release BOM",
+      "sha256": "fe9931253109f6ffc6455c25343cfaaecd07d181f68404977e57303db33e64e9"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "images",
+      "step": "Publish or reconcile the exact accepted Helm chart",
+      "sha256": "e887a54c4e3df5b15a7b0f8e250c6c04c17a272de25a36d19fb3f4a0567a4646"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "images",
+      "step": "Reconcile existing product image aliases before mutation",
+      "sha256": "a4802ba30f13c2327964dbd740ca4dfacf6fbcefc8db07d2006f12406aff39ab"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "images",
+      "step": "Verify official images support anonymous pull",
+      "sha256": "05431bd41e7afb482f95897646ab15a23f1521713e313314cc4fe70a7ddb4037"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "images",
+      "step": "Write expected release BOM before alias mutation",
+      "sha256": "3a93bffa3faae7116ee70c21eb017cc3d71e294518259c31505e65607087b5d7"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "Build publishable packages",
+      "sha256": "48726512ee6bb0591591eb4ff32cb8a18f9a780a246b2004b236af710b1c928d"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "Download and validate the complete acceptance bundle",
+      "sha256": "462062e649d5dcb9d56a3313325fb9aa4026414ca9c03292fd534bd96b88ca91"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "Install admitted source dependencies",
+      "sha256": "a8c9dec56244960b145e735ed4d97ba3b1b782e7c2d1f3f99d5368eab0bc06c6"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "Plan exact package publication",
+      "sha256": "3571c535bc2f8f755fc4deb43770479a49d589497bdf5747c6e7d12543dad1e8"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "Publish closure guard",
+      "sha256": "5e781d52fb8a5cb302466572a16b7c14449c76cad8a6048c3ffcfa077e37865e"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "Reconcile registry package identity",
+      "sha256": "553bfd42ea87faab04329afded1673ee1212c128087a665c46cde016e245bbea"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "Runtime embedding consumer",
+      "sha256": "ea9db548a8ffe7075a29ed4aae2d819cb09fc012506e02c95b28b1c56b529e20"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "SDK contract-parity test",
+      "sha256": "38bf0b944843de2ce491675f6d0e48635b59dbb5fce940c5337895cac240c7c8"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "Typecheck",
+      "sha256": "366cc227cea5c3c8f1de82ac8b3cab6a871d2a31f4295cff150681a696fbbf55"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "Validate release identity and acceptance receipts",
+      "sha256": "b6c628ae3ce619cc5b25e78c5913185f73efdb9e87bd2063ae0704e82db7bba4"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "Write pre-publication release plan",
+      "sha256": "1d45e1212363898fcc5a10d1dbe7c158ebc7271e99879913813a42442cfdb6d1"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "publish",
+      "step": "Write verified release receipt",
+      "sha256": "39491ceb2ac8e0b9ebab5d1dc9ed0a96e0184d3c1af40c98085dc4a96513c1be"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "version",
+      "step": "Detect versionable changesets",
+      "sha256": "af9263d458912dc7b8262e6e7bca918439b44b99ad8edb59bb92d0db4730131a"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "version",
+      "step": "Dispatch exact-head Version PR CI",
+      "sha256": "bf7d7d92f98dcf716c5f60dfd9ce9604922e3ffcdb40c39eee7c301fc512a8ab"
+    },
+    {
+      "workflow": ".github/workflows/release.yml",
+      "job": "version",
+      "step": "Install dependencies",
+      "sha256": "ae81b50fb72800b4cce5c87fa96b31638ea908158bc0b6f3c3d5503ab38a1513"
+    },
+    {
+      "workflow": ".github/workflows/retain-release-controller.yml",
+      "job": "retain",
+      "step": "Retain exact current-main workflow authority",
+      "sha256": "ef34014d19f61bc9bd00e3aa06615e8b4f396c7c6d3ca798f65face133452cd8"
+    },
+    {
+      "workflow": ".github/workflows/seal-release-head.yml",
+      "job": "seal",
+      "step": "Revalidate and retain exact release head",
+      "sha256": "94d706b57bea2fc0f592b3fb27704a59bc3765a7536003ec4af169e0efc78077"
+    },
+    {
+      "workflow": ".github/workflows/source-admission.yml",
+      "job": "report",
+      "step": "Publish skip-success or require hotfix verify",
+      "sha256": "1e505ea0173da28067e1677f776b48937dc18f4a66b9880c7bd44b621087c713"
+    },
+    {
+      "workflow": ".github/workflows/source-admission.yml",
+      "job": "verify",
+      "step": "Execute the exact base-owned admission verifier",
+      "sha256": "48befe1e1f09b43c7f5951b3a31776fe7d28ac20945291a2afe7e8beaa10abdf"
+    },
+    {
+      "workflow": ".github/workflows/staging-canary-dispatch.yml",
+      "job": "receipt",
+      "step": "Require lowercase SHA and canary-sha tags",
+      "sha256": "5835652950f8689f55770b19a94add134bfdd4214ad5ed17e65d1746607994e0"
+    },
+    {
+      "workflow": ".github/workflows/verify-public-container-packages.yml",
+      "job": "verify",
+      "step": "Verify anonymous image discovery",
+      "sha256": "91371275f8173d2dcd42929125baa49f2cb97286071cec04bb509a26f6e3c5d1"
+    }
+  ]
+}

--- a/scripts/workflow-execution-graph.test.ts
+++ b/scripts/workflow-execution-graph.test.ts
@@ -1,0 +1,1440 @@
+import { describe, expect, test } from "bun:test";
+import {
+  appendFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  symlink,
+  truncate,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { stringify } from "yaml";
+import {
+  GRAPH_MANIFEST_PATH,
+  WORKFLOW_GRAPH_LIMITS,
+  canonicalJson,
+  compareWorkflowExecutionManifest,
+  inspectWorkflowExecutionGitTreeRepository,
+  inspectWorkflowExecutionRepository,
+  inspectWorkflowExecutionSources,
+  loadWorkflowExecutionSources,
+  parseRestrictedYaml,
+  type WorkflowExecutionGraphManifest,
+} from "./workflow-execution-graph";
+
+const root = resolve(import.meta.dir, "..");
+const workflowPath = ".github/workflows/fixture.yml";
+const actionPath = ".github/actions/probe/action.yml";
+const discoveryActionPath = ".github/actions/probe/action.yaml";
+
+const minimalWorkflow = [
+  "name: Fixture",
+  "on: push",
+  "jobs:",
+  "  build:",
+  "    timeout-minutes: 5",
+  "    steps:",
+  "      - name: Run",
+  "        run: echo fixture",
+  "",
+].join("\n");
+
+const minimalAction = [
+  "name: Fixture action",
+  "runs:",
+  "  using: composite",
+  "  steps:",
+  "    - name: Run",
+  "      shell: bash",
+  "      run: echo fixture",
+  "",
+].join("\n");
+
+function padAscii(source: string, bytes: number): string {
+  const current = new TextEncoder().encode(source).byteLength;
+  if (current > bytes) throw new Error("fixture exceeds requested byte size");
+  if (current === bytes) return source;
+  return `${source}#${"x".repeat(bytes - current - 1)}`;
+}
+
+function exactNodeLimitYaml(extraLeafScalars = 0): string {
+  const rows = Array.from({ length: 999 }, () => `  - [${"0,".repeat(18)}0]`);
+  rows.push(`  - [${"0,".repeat(14 + extraLeafScalars)}0]`);
+  return `root:\n${rows.join("\n")}\n`;
+}
+
+async function createDiscoveryFixture(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "workflow-graph-discovery-"));
+  await mkdir(join(directory, ".github/workflows"), { recursive: true });
+  await mkdir(join(directory, ".github/actions/probe"), { recursive: true });
+  await writeFile(join(directory, ".github/workflows/fixture.yml"), minimalWorkflow);
+  await writeFile(join(directory, ".github/actions/probe/action.yaml"), minimalAction);
+  return directory;
+}
+
+async function runFixtureGit(
+  directory: string,
+  args: readonly string[],
+  input?: string | Uint8Array,
+): Promise<string> {
+  const child = Bun.spawn(["git", ...args], {
+    cwd: directory,
+    stdin: input === undefined ? "ignore" : new Blob([input as BlobPart]),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0) throw new Error(`fixture Git failed: ${stderr.trim()}`);
+  return stdout.trim();
+}
+
+async function writeDiscoveryManifest(directory: string): Promise<void> {
+  const inspection = await inspectWorkflowExecutionRepository(directory);
+  expect(inspection.violations).toEqual([]);
+  await writeFile(
+    join(directory, GRAPH_MANIFEST_PATH),
+    `${JSON.stringify(inspection.manifest, null, 2)}\n`,
+  );
+}
+
+async function createCommittedDiscoveryFixture(): Promise<string> {
+  const directory = await createDiscoveryFixture();
+  await mkdir(join(directory, "scripts"), { recursive: true });
+  await writeDiscoveryManifest(directory);
+  await runFixtureGit(directory, ["init", "--quiet"]);
+  await runFixtureGit(directory, ["config", "user.email", "workflow-graph@example.invalid"]);
+  await runFixtureGit(directory, ["config", "user.name", "Workflow Graph Test"]);
+  await runFixtureGit(directory, ["add", "-A"]);
+  await runFixtureGit(directory, ["commit", "--quiet", "-m", "fixture"]);
+  return directory;
+}
+
+async function commitFixture(directory: string, message: string): Promise<void> {
+  await runFixtureGit(directory, ["add", "-A"]);
+  await runFixtureGit(directory, ["commit", "--quiet", "-m", message]);
+}
+
+function gitInspectionViolations(
+  result: Awaited<ReturnType<typeof inspectWorkflowExecutionGitTreeRepository>>,
+): readonly string[] {
+  return [...result.inspection.violations, ...result.manifestViolations];
+}
+
+function fixtureSources(): Record<string, string> {
+  return {
+    [workflowPath]: [
+      "name: Fixture",
+      "on: push",
+      "jobs:",
+      "  build:",
+      "    timeout-minutes: 30",
+      "    strategy:",
+      "      matrix:",
+      "        lane: [one, two]",
+      "    outputs:",
+      "      result: result-a",
+      "    env:",
+      "      SHARED: env-a",
+      "    steps:",
+      "      - name: Produce",
+      "        id: produce",
+      "        env:",
+      '          VALUE: "1"',
+      '        run: "echo producer"',
+      "      - name: Consume",
+      "        env:",
+      "          RESULT: output-a",
+      '        run: "echo consumer"',
+      "      - name: Invoke local",
+      "        uses: ./.github/actions/probe",
+      "        with:",
+      "          input: input-a",
+      "  downstream:",
+      "    timeout-minutes: 10",
+      "    needs: build",
+      "    steps:",
+      "      - name: Downstream",
+      '        run: "echo downstream"',
+      "",
+    ].join("\n"),
+    [actionPath]: [
+      "name: Probe",
+      "inputs:",
+      "  input:",
+      "    required: true",
+      "runs:",
+      "  using: composite",
+      "  steps:",
+      "    - name: Action run",
+      "      shell: bash",
+      "      env:",
+      "        ACTION_ENV: action-env-a",
+      '      run: "echo action-a"',
+      "",
+    ].join("\n"),
+  };
+}
+
+function replaceOnce(source: string, before: string, after: string): string {
+  expect(source.split(before)).toHaveLength(2);
+  return source.replace(before, () => after);
+}
+
+function workflowDigest(manifest: WorkflowExecutionGraphManifest): string {
+  const record = manifest.workflows.find((candidate) => candidate.path === workflowPath);
+  expect(record).toBeDefined();
+  return record?.sha256 ?? "";
+}
+
+function actionDigest(manifest: WorkflowExecutionGraphManifest): string {
+  const record = manifest.actions.find((candidate) => candidate.path === actionPath);
+  expect(record).toBeDefined();
+  return record?.sha256 ?? "";
+}
+
+describe("workflow execution graph manifest", () => {
+  test("the checked-in manifest exactly describes the repository graph", async () => {
+    const inspection = await inspectWorkflowExecutionRepository(root);
+    const committed = JSON.parse(
+      await readFile(resolve(root, GRAPH_MANIFEST_PATH), "utf8"),
+    ) as unknown;
+
+    expect(inspection.violations).toEqual([]);
+    expect(compareWorkflowExecutionManifest(committed, inspection.manifest)).toEqual([]);
+    expect(inspection.manifest.workflows).toHaveLength(21);
+    expect(inspection.manifest.actions).toHaveLength(2);
+    expect(inspection.manifest.uncappedRuns).toHaveLength(197);
+    expect(inspection.manifest.generatedLocalTargets).toHaveLength(3);
+    for (const record of [
+      ...inspection.manifest.workflows,
+      ...inspection.manifest.actions,
+      ...inspection.manifest.uncappedRuns,
+    ]) {
+      expect(record.sha256).toMatch(/^[0-9a-f]{64}$/u);
+    }
+  });
+
+  test("restricted YAML rejects malformed or identity-ambiguous constructs", () => {
+    const rejected = [
+      "a: 1\na: 2\n",
+      "a: &value 1\n",
+      "a: &value 1\nb: *value\n",
+      "a: 1\nb:\n  <<: { c: 2 }\n",
+      "a: !!str 1\n",
+      "a: [\n",
+    ];
+    for (const source of rejected) {
+      expect(() => parseRestrictedYaml(source, workflowPath)).toThrow();
+    }
+  });
+
+  test("canonicalization sorts mappings while preserving sequences and scalar types", () => {
+    expect(canonicalJson({ b: 2, a: 1 })).toBe(canonicalJson({ a: 1, b: 2 }));
+    expect(canonicalJson({ steps: ["one", "two"] })).not.toBe(
+      canonicalJson({ steps: ["two", "one"] }),
+    );
+    expect(canonicalJson({ value: "1" })).not.toBe(canonicalJson({ value: 1 }));
+
+    const baseline = inspectWorkflowExecutionSources(fixtureSources());
+    const reordered = fixtureSources();
+    reordered[workflowPath] = replaceOnce(
+      reordered[workflowPath] ?? "",
+      [
+        "      - name: Produce",
+        "        id: produce",
+        "        env:",
+        '          VALUE: "1"',
+        '        run: "echo producer"',
+        "      - name: Consume",
+        "        env:",
+        "          RESULT: output-a",
+        '        run: "echo consumer"',
+      ].join("\n"),
+      [
+        "      - name: Consume",
+        "        env:",
+        "          RESULT: output-a",
+        '        run: "echo consumer"',
+        "      - name: Produce",
+        "        id: produce",
+        "        env:",
+        '          VALUE: "1"',
+        '        run: "echo producer"',
+      ].join("\n"),
+    );
+    const reorderedInspection = inspectWorkflowExecutionSources(reordered);
+    expect(baseline.violations).toEqual([]);
+    expect(reorderedInspection.violations).toEqual([]);
+    expect(workflowDigest(reorderedInspection.manifest)).not.toBe(
+      workflowDigest(baseline.manifest),
+    );
+  });
+
+  test("canonical mappings preserve prototype-shaped own keys without collisions", () => {
+    const parsed = parseRestrictedYaml(
+      [
+        "__proto__: proto-value",
+        "constructor: constructor-value",
+        "prototype: prototype-value",
+        "toString: tostring-value",
+        "ordinary: ordinary-value",
+        "",
+      ].join("\n"),
+      workflowPath,
+    );
+    expect(Object.keys(parsed).sort()).toEqual([
+      "__proto__",
+      "constructor",
+      "ordinary",
+      "prototype",
+      "toString",
+    ]);
+    const canonical = JSON.parse(canonicalJson(parsed)) as Record<string, unknown>;
+    expect(Object.hasOwn(canonical, "__proto__")).toBe(true);
+    expect(canonical.__proto__).toBe("proto-value");
+    expect(canonical.constructor).toBe("constructor-value");
+    expect(canonical.prototype).toBe("prototype-value");
+    expect(canonical.toString).toBe("tostring-value");
+    expect(
+      new Set(
+        ["__proto__", "constructor", "prototype", "toString"].map((key) =>
+          canonicalJson(parseRestrictedYaml(`${key}: value\n`, workflowPath)),
+        ),
+      ).size,
+    ).toBe(4);
+  });
+
+  test("numeric YAML accepts only injective finite safe integers", () => {
+    for (const source of [
+      "value: 9007199254740992\n",
+      "value: 9007199254740993\n",
+      "value: 999999999999999999999999999999999999\n",
+      "value: 1e100\n",
+      "value: 0.1\n",
+      "value: 0.10000000000000001\n",
+      "value: -0\n",
+      "value: .nan\n",
+      "value: .inf\n",
+    ]) {
+      expect(() => parseRestrictedYaml(source, workflowPath), source.trim()).toThrow(
+        "numeric scalar outside the safe-integer domain",
+      );
+    }
+    expect(parseRestrictedYaml("value: 9007199254740991\n", workflowPath)).toEqual({
+      value: 9007199254740991,
+    });
+    expect(parseRestrictedYaml("value: -9007199254740991\n", workflowPath)).toEqual({
+      value: -9007199254740991,
+    });
+    expect(parseRestrictedYaml('value: "0.10000000000000001"\n', workflowPath)).toEqual({
+      value: "0.10000000000000001",
+    });
+    expect(() => canonicalJson({ value: 0.1 })).toThrow("safe-integer domain");
+    expect(() => canonicalJson({ value: -0 })).toThrow("safe-integer domain");
+  });
+
+  test("source-count and UTF-8 byte bounds are exact and pre-parse", () => {
+    const exactSource = padAscii(minimalWorkflow, WORKFLOW_GRAPH_LIMITS.maxSourceBytes);
+    expect(inspectWorkflowExecutionSources({ [workflowPath]: exactSource }).violations).toEqual([]);
+    expect(
+      inspectWorkflowExecutionSources({ [`${workflowPath}`]: `${exactSource}x` }).violations,
+    ).toContain(`${workflowPath} exceeds the per-source UTF-8 byte limit`);
+
+    const exactCount = Object.fromEntries(
+      Array.from({ length: WORKFLOW_GRAPH_LIMITS.maxSources }, (_, index) => [
+        `.github/workflows/count-${index}.yml`,
+        minimalWorkflow,
+      ]),
+    );
+    expect(inspectWorkflowExecutionSources(exactCount).violations).toEqual([]);
+    expect(
+      inspectWorkflowExecutionSources({
+        ...exactCount,
+        ".github/workflows/count-overflow.yml": minimalWorkflow,
+      }).violations,
+    ).toContain("workflow execution graph exceeds the source-count limit");
+
+    const totalParts = 5;
+    const baseSize = Math.floor(WORKFLOW_GRAPH_LIMITS.maxTotalSourceBytes / totalParts);
+    const exactTotal = Object.fromEntries(
+      Array.from({ length: totalParts }, (_, index) => [
+        `.github/workflows/total-${index}.yml`,
+        padAscii(
+          minimalWorkflow,
+          baseSize +
+            (index === totalParts - 1 ? WORKFLOW_GRAPH_LIMITS.maxTotalSourceBytes % totalParts : 0),
+        ),
+      ]),
+    );
+    expect(inspectWorkflowExecutionSources(exactTotal).violations).toEqual([]);
+    const totalOverflow = { ...exactTotal };
+    totalOverflow[".github/workflows/total-0.yml"] =
+      `${totalOverflow[".github/workflows/total-0.yml"]}x`;
+    expect(inspectWorkflowExecutionSources(totalOverflow).violations).toContain(
+      "workflow execution graph exceeds the total UTF-8 byte limit",
+    );
+  });
+
+  test("AST node, collection-width, and nesting-depth bounds are exact", () => {
+    expect(() => parseRestrictedYaml(exactNodeLimitYaml(), workflowPath)).not.toThrow();
+    expect(() => parseRestrictedYaml(exactNodeLimitYaml(1), workflowPath)).toThrow(
+      "AST node limit",
+    );
+
+    const exactMap = `root:\n${Array.from(
+      { length: WORKFLOW_GRAPH_LIMITS.maxCollectionWidth },
+      (_, index) => `  key-${index}: value`,
+    ).join("\n")}\n`;
+    expect(() => parseRestrictedYaml(exactMap, workflowPath)).not.toThrow();
+    expect(() => parseRestrictedYaml(`${exactMap}  key-overflow: value\n`, workflowPath)).toThrow(
+      "collection-width limit",
+    );
+    const exactSequence = `root: [${Array.from(
+      { length: WORKFLOW_GRAPH_LIMITS.maxCollectionWidth },
+      () => "value",
+    ).join(",")}]\n`;
+    expect(() => parseRestrictedYaml(exactSequence, workflowPath)).not.toThrow();
+    expect(() =>
+      parseRestrictedYaml(
+        `root: [${Array.from(
+          { length: WORKFLOW_GRAPH_LIMITS.maxCollectionWidth + 1 },
+          () => "value",
+        ).join(",")}]\n`,
+        workflowPath,
+      ),
+    ).toThrow("collection-width limit");
+
+    const exactFlowDepth = WORKFLOW_GRAPH_LIMITS.maxNestingDepth - 3;
+    expect(() =>
+      parseRestrictedYaml(
+        `root: ${"[".repeat(exactFlowDepth)}value${"]".repeat(exactFlowDepth)}\n`,
+        workflowPath,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      parseRestrictedYaml(
+        `root: ${"[".repeat(exactFlowDepth + 1)}value${"]".repeat(exactFlowDepth + 1)}\n`,
+        workflowPath,
+      ),
+    ).toThrow("nesting-depth limit");
+    const deepBlock = `${Array.from(
+      { length: WORKFLOW_GRAPH_LIMITS.maxNestingDepth },
+      (_, index) => `${"  ".repeat(index)}key-${index}:`,
+    ).join("\n")}\n${"  ".repeat(WORKFLOW_GRAPH_LIMITS.maxNestingDepth)}value\n`;
+    expect(() => parseRestrictedYaml(deepBlock, workflowPath)).toThrow("nesting-depth limit");
+  });
+
+  test("the aggregate AST node budget fails closed across individually valid sources", () => {
+    const payload = Array.from({ length: 850 }, () => `  - [${"0,".repeat(18)}0]`).join("\n");
+    const source = `${minimalWorkflow}padding:\n${payload}\n`;
+    expect(() => parseRestrictedYaml(source, workflowPath)).not.toThrow();
+    const sources = Object.fromEntries(
+      Array.from({ length: 6 }, (_, index) => [`.github/workflows/nodes-${index}.yml`, source]),
+    );
+    expect(inspectWorkflowExecutionSources(sources).violations.join("\n")).toContain(
+      "total AST node limit",
+    );
+  });
+
+  test("large wide input is rejected by byte bounds before YAML traversal", () => {
+    const sentinel = "SECRET_WIDE_VALUE";
+    const wide = `${minimalWorkflow}${Array.from(
+      { length: 100_000 },
+      (_, index) => `wide-${index}: ${sentinel}-${index}`,
+    ).join("\n")}\n`;
+    expect(new TextEncoder().encode(wide).byteLength).toBeGreaterThan(2_500_000);
+    const startedAt = performance.now();
+    const violations = inspectWorkflowExecutionSources({ [workflowPath]: wide }).violations;
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+    expect(violations).toContain(`${workflowPath} exceeds the per-source UTF-8 byte limit`);
+    expect(violations.join("\n")).not.toContain(sentinel);
+  });
+
+  test("cross-step execution dependencies and order all invalidate the graph digest", () => {
+    const baselineSources = fixtureSources();
+    const baseline = inspectWorkflowExecutionSources(baselineSources);
+    expect(baseline.violations).toEqual([]);
+
+    const mutations: Array<readonly [string, (sources: Record<string, string>) => void]> = [
+      [
+        "producer",
+        (sources) => {
+          sources[workflowPath] = replaceOnce(
+            sources[workflowPath] ?? "",
+            "echo producer",
+            "echo producer-b",
+          );
+        },
+      ],
+      [
+        "environment",
+        (sources) => {
+          sources[workflowPath] = replaceOnce(
+            sources[workflowPath] ?? "",
+            'VALUE: "1"',
+            'VALUE: "2"',
+          );
+        },
+      ],
+      [
+        "output",
+        (sources) => {
+          sources[workflowPath] = replaceOnce(
+            sources[workflowPath] ?? "",
+            "result: result-a",
+            "result: result-b",
+          );
+        },
+      ],
+      [
+        "matrix",
+        (sources) => {
+          sources[workflowPath] = replaceOnce(
+            sources[workflowPath] ?? "",
+            "lane: [one, two]",
+            "lane: [one, three]",
+          );
+        },
+      ],
+      [
+        "input",
+        (sources) => {
+          sources[workflowPath] = replaceOnce(
+            sources[workflowPath] ?? "",
+            "input: input-a",
+            "input: input-b",
+          );
+        },
+      ],
+      [
+        "needs",
+        (sources) => {
+          sources[workflowPath] = replaceOnce(
+            sources[workflowPath] ?? "",
+            "needs: build",
+            "needs: producer",
+          );
+        },
+      ],
+      [
+        "action",
+        (sources) => {
+          sources[actionPath] = replaceOnce(
+            sources[actionPath] ?? "",
+            "echo action-a",
+            "echo action-b",
+          );
+        },
+      ],
+      [
+        "order",
+        (sources) => {
+          sources[workflowPath] = replaceOnce(
+            sources[workflowPath] ?? "",
+            "      - name: Produce\n        id: produce",
+            "      - name: Produce after mutation\n        id: produce",
+          );
+        },
+      ],
+    ];
+
+    for (const [label, mutate] of mutations) {
+      const sources = fixtureSources();
+      mutate(sources);
+      const current = inspectWorkflowExecutionSources(sources);
+      expect(current.violations, label).toEqual([]);
+      expect(workflowDigest(current.manifest), label).not.toBe(workflowDigest(baseline.manifest));
+      expect(
+        compareWorkflowExecutionManifest(baseline.manifest, current.manifest),
+        label,
+      ).not.toEqual([]);
+      if (label === "action") {
+        expect(actionDigest(current.manifest)).not.toBe(actionDigest(baseline.manifest));
+      }
+    }
+  });
+
+  test("local targets must be present, unambiguous, bounded, and acyclic", () => {
+    const missing = fixtureSources();
+    delete missing[actionPath];
+    expect(inspectWorkflowExecutionSources(missing).violations).toContain(
+      `${workflowPath}:build:Invoke local has a missing local action target`,
+    );
+
+    const ambiguous = fixtureSources();
+    ambiguous[".github/actions/probe/action.yaml"] = ambiguous[actionPath] ?? "";
+    expect(inspectWorkflowExecutionSources(ambiguous).violations).toContain(
+      `${workflowPath}:build:Invoke local has a ambiguous local action target`,
+    );
+
+    for (const target of ["../probe", "/absolute/probe"]) {
+      const escaped = fixtureSources();
+      escaped[workflowPath] = replaceOnce(
+        escaped[workflowPath] ?? "",
+        "./.github/actions/probe",
+        target,
+      );
+      expect(inspectWorkflowExecutionSources(escaped).violations.join("\n"), target).toContain(
+        "path-escaping local target",
+      );
+    }
+
+    const missingWorkflow = fixtureSources();
+    missingWorkflow[workflowPath] = [
+      "name: Fixture",
+      "on: push",
+      "jobs:",
+      "  call:",
+      "    uses: ./.github/workflows/missing.yml",
+      "",
+    ].join("\n");
+    expect(inspectWorkflowExecutionSources(missingWorkflow).violations).toContain(
+      `${workflowPath}:call:reusable-workflow has a missing local workflow target`,
+    );
+
+    const cyclic = fixtureSources();
+    cyclic[actionPath] = replaceOnce(
+      cyclic[actionPath] ?? "",
+      "      shell: bash\n      env:",
+      "      uses: ./.github/actions/probe\n      env:",
+    );
+    expect(inspectWorkflowExecutionSources(cyclic).violations.join("\n")).toContain(
+      "participates in a local workflow/action target cycle",
+    );
+  });
+
+  test("filesystem discovery rejects action and workflow symlinks before inventory", async () => {
+    const dual = await createDiscoveryFixture();
+    try {
+      await writeFile(join(dual, ".github/actions/probe/payload.txt"), minimalAction);
+      await symlink("payload.txt", join(dual, ".github/actions/probe/action.yml"));
+      await expect(loadWorkflowExecutionSources(dual)).rejects.toThrow(
+        ".github/actions/probe/action.yml is a forbidden symlink in action discovery",
+      );
+    } finally {
+      await rm(dual, { recursive: true, force: true });
+    }
+
+    const symlinkOnly = await createDiscoveryFixture();
+    try {
+      await rm(join(symlinkOnly, ".github/actions/probe/action.yaml"));
+      await writeFile(join(symlinkOnly, ".github/actions/probe/payload.txt"), minimalAction);
+      await symlink("payload.txt", join(symlinkOnly, ".github/actions/probe/action.yml"));
+      await expect(loadWorkflowExecutionSources(symlinkOnly)).rejects.toThrow(
+        "forbidden symlink in action discovery",
+      );
+    } finally {
+      await rm(symlinkOnly, { recursive: true, force: true });
+    }
+
+    const directoryEscape = await createDiscoveryFixture();
+    try {
+      await mkdir(join(directoryEscape, "outside"));
+      await writeFile(join(directoryEscape, "outside/action.yml"), minimalAction);
+      await symlink("../../outside", join(directoryEscape, ".github/actions/escape"));
+      await expect(loadWorkflowExecutionSources(directoryEscape)).rejects.toThrow(
+        ".github/actions/escape is a forbidden symlink in action discovery",
+      );
+    } finally {
+      await rm(directoryEscape, { recursive: true, force: true });
+    }
+
+    const workflowLink = await createDiscoveryFixture();
+    try {
+      await rm(join(workflowLink, ".github/workflows/fixture.yml"));
+      await writeFile(join(workflowLink, "workflow-payload.yml"), minimalWorkflow);
+      await symlink(
+        "../../workflow-payload.yml",
+        join(workflowLink, ".github/workflows/fixture.yml"),
+      );
+      await expect(loadWorkflowExecutionSources(workflowLink)).rejects.toThrow(
+        ".github/workflows/fixture.yml is a forbidden symlink in workflow discovery",
+      );
+    } finally {
+      await rm(workflowLink, { recursive: true, force: true });
+    }
+  });
+
+  test("filesystem discovery entry bounds accept the exact boundary and reject one more", async () => {
+    const directory = await createDiscoveryFixture();
+    try {
+      const actionFillers = WORKFLOW_GRAPH_LIMITS.maxActionDiscoveryEntries - 2;
+      await Promise.all(
+        Array.from({ length: actionFillers }, (_, index) =>
+          writeFile(join(directory, `.github/actions/filler-${index}.txt`), ""),
+        ),
+      );
+      await expect(loadWorkflowExecutionSources(directory)).resolves.toBeDefined();
+      await writeFile(join(directory, ".github/actions/action-overflow.txt"), "");
+      await expect(loadWorkflowExecutionSources(directory)).rejects.toThrow(
+        "action discovery exceeds the directory-entry limit",
+      );
+      await rm(join(directory, ".github/actions/action-overflow.txt"));
+
+      const workflowFillers = WORKFLOW_GRAPH_LIMITS.maxWorkflowDiscoveryEntries - 1;
+      await Promise.all(
+        Array.from({ length: workflowFillers }, (_, index) =>
+          writeFile(join(directory, `.github/workflows/filler-${index}.txt`), ""),
+        ),
+      );
+      await expect(loadWorkflowExecutionSources(directory)).resolves.toBeDefined();
+      await writeFile(join(directory, ".github/workflows/workflow-overflow.txt"), "");
+      await expect(loadWorkflowExecutionSources(directory)).rejects.toThrow(
+        "workflow discovery exceeds the directory-entry limit",
+      );
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+
+    const depthDirectory = await createDiscoveryFixture();
+    try {
+      let nested = join(depthDirectory, ".github/actions");
+      for (let index = 0; index < WORKFLOW_GRAPH_LIMITS.maxActionDiscoveryDepth; index += 1) {
+        nested = join(nested, `depth-${index}`);
+        await mkdir(nested);
+      }
+      await writeFile(join(nested, "action.yml"), minimalAction);
+      await expect(loadWorkflowExecutionSources(depthDirectory)).resolves.toBeDefined();
+      await mkdir(join(nested, "overflow"));
+      await expect(loadWorkflowExecutionSources(depthDirectory)).rejects.toThrow(
+        "action discovery exceeds the directory-depth limit",
+      );
+    } finally {
+      await rm(depthDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("streaming discovery stops at the first over-limit action entry", async () => {
+    const directory = await createDiscoveryFixture();
+    try {
+      await Promise.all(
+        Array.from({ length: WORKFLOW_GRAPH_LIMITS.maxActionDiscoveryEntries + 100 }, (_, index) =>
+          writeFile(join(directory, `.github/actions/stream-${index}.txt`), ""),
+        ),
+      );
+      let observedActionEntries = 0;
+      const closedDirectories: string[] = [];
+      await expect(
+        loadWorkflowExecutionSources(directory, {
+          onDiscoveryEntry(kind) {
+            if (kind === "action") observedActionEntries += 1;
+          },
+          onDirectoryHandleClosed(kind, path) {
+            closedDirectories.push(`${kind}:${path}`);
+          },
+        }),
+      ).rejects.toThrow("action discovery exceeds the directory-entry limit");
+      expect(observedActionEntries).toBe(WORKFLOW_GRAPH_LIMITS.maxActionDiscoveryEntries + 1);
+      expect(closedDirectories).toContain("workflow:.github/workflows");
+      expect(closedDirectories).toContain("action:.github/actions");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("filesystem byte preflight rejects per-file and total overflow before reads", async () => {
+    const oversized = await createDiscoveryFixture();
+    try {
+      await writeFile(
+        join(oversized, ".github/workflows/fixture.yml"),
+        new Uint8Array(WORKFLOW_GRAPH_LIMITS.maxSourceBytes + 1),
+      );
+      let reads = 0;
+      const closed: string[] = [];
+      await expect(
+        loadWorkflowExecutionSources(oversized, {
+          beforeRead() {
+            reads += 1;
+          },
+          onFileHandleClosed(path) {
+            closed.push(path);
+          },
+        }),
+      ).rejects.toThrow("exceeds the per-source UTF-8 byte limit");
+      expect(reads).toBe(0);
+      expect(closed).toEqual([discoveryActionPath]);
+    } finally {
+      await rm(oversized, { recursive: true, force: true });
+    }
+
+    const totalOverflow = await createDiscoveryFixture();
+    try {
+      const sourceBytes = 220 * 1024;
+      for (let index = 0; index < 5; index += 1) {
+        await writeFile(
+          join(totalOverflow, `.github/workflows/large-${index}.yml`),
+          new Uint8Array(sourceBytes),
+        );
+      }
+      let reads = 0;
+      const closed: string[] = [];
+      await expect(
+        loadWorkflowExecutionSources(totalOverflow, {
+          beforeRead() {
+            reads += 1;
+          },
+          onFileHandleClosed(path) {
+            closed.push(path);
+          },
+        }),
+      ).rejects.toThrow("exceeds the total UTF-8 byte limit");
+      expect(reads).toBe(0);
+      expect(closed.sort()).toEqual(
+        [
+          discoveryActionPath,
+          workflowPath,
+          ...Array.from({ length: 5 }, (_, index) => `.github/workflows/large-${index}.yml`),
+        ].sort(),
+      );
+    } finally {
+      await rm(totalOverflow, { recursive: true, force: true });
+    }
+  });
+
+  test("filesystem loader rejects malformed UTF-8 without disclosing bytes", async () => {
+    const errors: string[] = [];
+    for (const malformedByte of [0x80, 0x81]) {
+      const directory = await createDiscoveryFixture();
+      try {
+        await writeFile(
+          join(directory, ".github/workflows/fixture.yml"),
+          Uint8Array.of(malformedByte),
+        );
+        let error: unknown;
+        try {
+          await loadWorkflowExecutionSources(directory);
+        } catch (caught) {
+          error = caught;
+        }
+        expect(error).toBeInstanceOf(Error);
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).toBe(`${workflowPath} contains invalid UTF-8`);
+        expect(message).not.toContain(String(malformedByte));
+        errors.push(message);
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    }
+    expect(new Set(errors)).toEqual(new Set([`${workflowPath} contains invalid UTF-8`]));
+  });
+
+  test("filesystem loader bounds shrink, growth, and replacement races and closes handles", async () => {
+    const mutations = [
+      {
+        name: "shrink",
+        mutate: (path: string) => truncate(path, 1),
+        expected: "changed size while reading graph source",
+      },
+      {
+        name: "growth",
+        mutate: (path: string) => appendFile(path, "x"),
+        expected: "changed size while reading graph source",
+      },
+      {
+        name: "replacement",
+        mutate: async (path: string) => {
+          await rename(path, `${path}.replaced`);
+          await writeFile(path, minimalWorkflow);
+        },
+        expected: "changed while reading graph source",
+      },
+    ] as const;
+
+    for (const mutation of mutations) {
+      const directory = await createDiscoveryFixture();
+      const closed: string[] = [];
+      try {
+        await expect(
+          loadWorkflowExecutionSources(directory, {
+            async afterPreflight() {
+              await mutation.mutate(join(directory, ".github/workflows/fixture.yml"));
+            },
+            onFileHandleClosed(path) {
+              closed.push(path);
+            },
+          }),
+          mutation.name,
+        ).rejects.toThrow(mutation.expected);
+        expect(closed.sort(), mutation.name).toEqual([discoveryActionPath, workflowPath].sort());
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("Git-tree mode captures one immutable snapshot despite hostile worktree replacement", async () => {
+    const directory = await createCommittedDiscoveryFixture();
+    const outside = await mkdtemp(join(tmpdir(), "workflow-graph-outside-"));
+    try {
+      const committedWorkflow = await readFile(
+        join(directory, ".github/workflows/fixture.yml"),
+        "utf8",
+      );
+      await mkdir(join(outside, "workflows"), { recursive: true });
+      await mkdir(join(outside, "action"), { recursive: true });
+      await writeFile(join(outside, "workflows/fixture.yml"), `${minimalWorkflow}# outside\n`);
+      await writeFile(join(outside, "action/action.yaml"), `${minimalAction}# outside\n`);
+
+      const checked = await inspectWorkflowExecutionGitTreeRepository(directory, "HEAD^{tree}", {
+        async afterTreeCapture() {
+          await rm(join(directory, ".github/workflows"), { recursive: true, force: true });
+          await rm(join(directory, ".github/actions/probe"), { recursive: true, force: true });
+          await symlink(join(outside, "workflows"), join(directory, ".github/workflows"), "dir");
+          await symlink(join(outside, "action"), join(directory, ".github/actions/probe"), "dir");
+          await writeFile(join(directory, GRAPH_MANIFEST_PATH), "{}\n");
+          await commitFixture(directory, "move HEAD after tree capture");
+        },
+      });
+      expect(gitInspectionViolations(checked)).toEqual([]);
+      expect(checked.inspection.manifest.workflows).toHaveLength(1);
+      expect(checked.inspection.manifest.actions).toHaveLength(1);
+      expect(committedWorkflow).toBe(minimalWorkflow);
+      await expect(loadWorkflowExecutionSources(directory)).rejects.toThrow(
+        "workflow discovery root must be a regular directory",
+      );
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("Git-tree mode ignores replacement refs for inventories, blobs, and the manifest", async () => {
+    const directory = await createCommittedDiscoveryFixture();
+    try {
+      const originalTree = await runFixtureGit(directory, ["rev-parse", "HEAD^{tree}"]);
+      const originalWorkflow = await runFixtureGit(directory, [
+        "rev-parse",
+        `${originalTree}:${workflowPath}`,
+      ]);
+      const originalAction = await runFixtureGit(directory, [
+        "rev-parse",
+        `${originalTree}:${discoveryActionPath}`,
+      ]);
+      const originalManifest = await runFixtureGit(directory, [
+        "rev-parse",
+        `${originalTree}:${GRAPH_MANIFEST_PATH}`,
+      ]);
+      const expected = await inspectWorkflowExecutionGitTreeRepository(directory, originalTree);
+      expect(gitInspectionViolations(expected)).toEqual([]);
+
+      await writeFile(
+        join(directory, workflowPath),
+        minimalWorkflow.replace("echo fixture", "echo replacement-workflow"),
+      );
+      await writeFile(
+        join(directory, discoveryActionPath),
+        minimalAction.replace("echo fixture", "echo replacement-action"),
+      );
+      await writeDiscoveryManifest(directory);
+      await commitFixture(directory, "replacement graph");
+
+      const replacementTree = await runFixtureGit(directory, ["rev-parse", "HEAD^{tree}"]);
+      const replacementWorkflow = await runFixtureGit(directory, [
+        "rev-parse",
+        `${replacementTree}:${workflowPath}`,
+      ]);
+      const replacementAction = await runFixtureGit(directory, [
+        "rev-parse",
+        `${replacementTree}:${discoveryActionPath}`,
+      ]);
+      const replacementManifest = await runFixtureGit(directory, [
+        "rev-parse",
+        `${replacementTree}:${GRAPH_MANIFEST_PATH}`,
+      ]);
+
+      for (const [original, replacement] of [
+        [originalWorkflow, replacementWorkflow],
+        [originalAction, replacementAction],
+        [originalManifest, replacementManifest],
+      ]) {
+        await runFixtureGit(directory, ["replace", original, replacement]);
+      }
+      expect(await runFixtureGit(directory, ["show", `${originalTree}:${workflowPath}`])).toContain(
+        "replacement-workflow",
+      );
+      const blobProtected = await inspectWorkflowExecutionGitTreeRepository(
+        directory,
+        originalTree,
+      );
+      expect(gitInspectionViolations(blobProtected)).toEqual([]);
+      expect(blobProtected.inspection.manifest).toEqual(expected.inspection.manifest);
+
+      await runFixtureGit(directory, [
+        "replace",
+        "-d",
+        originalWorkflow,
+        originalAction,
+        originalManifest,
+      ]);
+      await runFixtureGit(directory, ["replace", originalTree, replacementTree]);
+      expect(await runFixtureGit(directory, ["show", `${originalTree}:${workflowPath}`])).toContain(
+        "replacement-workflow",
+      );
+      const treeProtected = await inspectWorkflowExecutionGitTreeRepository(
+        directory,
+        originalTree,
+      );
+      expect(gitInspectionViolations(treeProtected)).toEqual([]);
+      expect(treeProtected.inspection.manifest).toEqual(expected.inspection.manifest);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("Git-tree mode ignores dirty state while local mode detects add, edit, delete, and rename", async () => {
+    const mutations = [
+      async (directory: string) => {
+        await writeFile(join(directory, ".github/workflows/added.yml"), minimalWorkflow);
+      },
+      async (directory: string) => {
+        await writeFile(
+          join(directory, ".github/workflows/fixture.yml"),
+          minimalWorkflow.replace("echo fixture", "echo edited"),
+        );
+      },
+      async (directory: string) => {
+        await rm(join(directory, ".github/workflows/fixture.yml"));
+      },
+      async (directory: string) => {
+        await rename(
+          join(directory, ".github/workflows/fixture.yml"),
+          join(directory, ".github/workflows/renamed.yml"),
+        );
+      },
+    ] as const;
+
+    for (const [index, mutate] of mutations.entries()) {
+      const directory = await createCommittedDiscoveryFixture();
+      try {
+        const committed = JSON.parse(
+          await readFile(join(directory, GRAPH_MANIFEST_PATH), "utf8"),
+        ) as unknown;
+        await mutate(directory);
+        expect(await runFixtureGit(directory, ["status", "--porcelain"]), String(index)).not.toBe(
+          "",
+        );
+        const local = await inspectWorkflowExecutionRepository(directory);
+        expect(
+          [...local.violations, ...compareWorkflowExecutionManifest(committed, local.manifest)],
+          String(index),
+        ).not.toEqual([]);
+        const gitTree = await inspectWorkflowExecutionGitTreeRepository(directory, "HEAD^{tree}");
+        expect(gitInspectionViolations(gitTree), String(index)).toEqual([]);
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("Git-tree inventory rejects symlink, non-blob, and dual action definitions", async () => {
+    const symlinkDirectory = await createCommittedDiscoveryFixture();
+    try {
+      const action = join(symlinkDirectory, ".github/actions/probe/action.yaml");
+      await rm(action);
+      await writeFile(join(symlinkDirectory, ".github/actions/probe/payload.txt"), minimalAction);
+      await symlink("payload.txt", action);
+      await commitFixture(symlinkDirectory, "symlink action");
+      await expect(
+        inspectWorkflowExecutionGitTreeRepository(symlinkDirectory, "HEAD^{tree}"),
+      ).rejects.toThrow("forbidden symlink in the Git tree");
+    } finally {
+      await rm(symlinkDirectory, { recursive: true, force: true });
+    }
+
+    const nonBlobDirectory = await createCommittedDiscoveryFixture();
+    try {
+      const head = await runFixtureGit(nonBlobDirectory, ["rev-parse", "HEAD"]);
+      await rm(join(nonBlobDirectory, ".github/workflows/fixture.yml"));
+      await runFixtureGit(nonBlobDirectory, [
+        "update-index",
+        "--add",
+        "--cacheinfo",
+        `160000,${head},.github/workflows/fixture.yml`,
+      ]);
+      await runFixtureGit(nonBlobDirectory, ["commit", "--quiet", "-m", "gitlink workflow"]);
+      await expect(
+        inspectWorkflowExecutionGitTreeRepository(nonBlobDirectory, "HEAD^{tree}"),
+      ).rejects.toThrow("is not a regular Git blob");
+    } finally {
+      await rm(nonBlobDirectory, { recursive: true, force: true });
+    }
+
+    const dualDirectory = await createCommittedDiscoveryFixture();
+    try {
+      await writeFile(join(dualDirectory, ".github/actions/probe/action.yml"), minimalAction);
+      await commitFixture(dualDirectory, "dual action manifests");
+      await expect(
+        inspectWorkflowExecutionGitTreeRepository(dualDirectory, "HEAD^{tree}"),
+      ).rejects.toThrow("ambiguous action definitions");
+    } finally {
+      await rm(dualDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("Git-tree manifest comparison is bound to the same committed tree", async () => {
+    const directory = await createCommittedDiscoveryFixture();
+    try {
+      const priorManifest = await readFile(join(directory, GRAPH_MANIFEST_PATH), "utf8");
+      await writeFile(
+        join(directory, ".github/workflows/fixture.yml"),
+        minimalWorkflow.replace("echo fixture", "echo committed-change"),
+      );
+      await writeDiscoveryManifest(directory);
+      await writeFile(join(directory, GRAPH_MANIFEST_PATH), priorManifest);
+      await commitFixture(directory, "stale same-tree manifest");
+      const checked = await inspectWorkflowExecutionGitTreeRepository(directory, "HEAD^{tree}");
+      expect(checked.inspection.violations).toEqual([]);
+      expect(checked.manifestViolations).toContain(
+        "workflow digest changed for .github/workflows/fixture.yml",
+      );
+      await writeFile(join(directory, GRAPH_MANIFEST_PATH), "{}\n");
+      const repeated = await inspectWorkflowExecutionGitTreeRepository(directory, "HEAD^{tree}");
+      expect(repeated.manifestViolations).toEqual(checked.manifestViolations);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("Git-tree blob preflight rejects byte limits before every content read", async () => {
+    const oversized = await createCommittedDiscoveryFixture();
+    try {
+      await writeFile(
+        join(oversized, ".github/workflows/fixture.yml"),
+        new Uint8Array(WORKFLOW_GRAPH_LIMITS.maxSourceBytes + 1),
+      );
+      await commitFixture(oversized, "oversized workflow");
+      let reads = 0;
+      await expect(
+        inspectWorkflowExecutionGitTreeRepository(oversized, "HEAD^{tree}", {
+          beforeBlobRead() {
+            reads += 1;
+          },
+        }),
+      ).rejects.toThrow("exceeds the per-source UTF-8 byte limit");
+      expect(reads).toBe(0);
+    } finally {
+      await rm(oversized, { recursive: true, force: true });
+    }
+
+    const aggregate = await createCommittedDiscoveryFixture();
+    try {
+      for (let index = 0; index < 4; index += 1) {
+        await writeFile(
+          join(aggregate, `.github/workflows/large-${index}.yml`),
+          padAscii(minimalWorkflow, WORKFLOW_GRAPH_LIMITS.maxSourceBytes),
+        );
+      }
+      await commitFixture(aggregate, "aggregate overflow");
+      let reads = 0;
+      await expect(
+        inspectWorkflowExecutionGitTreeRepository(aggregate, "HEAD^{tree}", {
+          beforeBlobRead() {
+            reads += 1;
+          },
+        }),
+      ).rejects.toThrow("exceeds the total UTF-8 byte limit");
+      expect(reads).toBe(0);
+    } finally {
+      await rm(aggregate, { recursive: true, force: true });
+    }
+  });
+
+  test("Git-tree mode fatally rejects invalid content and path UTF-8 without disclosure", async () => {
+    const invalidContent = await createCommittedDiscoveryFixture();
+    try {
+      await writeFile(
+        join(invalidContent, ".github/workflows/fixture.yml"),
+        Uint8Array.of(0x80, 0x81),
+      );
+      await commitFixture(invalidContent, "invalid content utf8");
+      await expect(
+        inspectWorkflowExecutionGitTreeRepository(invalidContent, "HEAD^{tree}"),
+      ).rejects.toThrow(`${workflowPath} contains invalid UTF-8`);
+    } finally {
+      await rm(invalidContent, { recursive: true, force: true });
+    }
+
+    const invalidPath = await createCommittedDiscoveryFixture();
+    try {
+      const workflowBlob = await runFixtureGit(invalidPath, [
+        "rev-parse",
+        "HEAD:.github/workflows/fixture.yml",
+      ]);
+      const actionsTree = await runFixtureGit(invalidPath, ["rev-parse", "HEAD:.github/actions"]);
+      const scriptsTree = await runFixtureGit(invalidPath, ["rev-parse", "HEAD:scripts"]);
+      const workflowTree = await runFixtureGit(
+        invalidPath,
+        ["mktree", "-z"],
+        Buffer.concat([
+          Buffer.from(`100644 blob ${workflowBlob}\tfixture.yml\0`),
+          Buffer.from(`100644 blob ${workflowBlob}\tinvalid-`),
+          Buffer.from([0x80]),
+          Buffer.from(".yml\0"),
+        ]),
+      );
+      const githubTree = await runFixtureGit(
+        invalidPath,
+        ["mktree", "-z"],
+        [`040000 tree ${actionsTree}\tactions\0`, `040000 tree ${workflowTree}\tworkflows\0`].join(
+          "",
+        ),
+      );
+      const rootTree = await runFixtureGit(
+        invalidPath,
+        ["mktree", "-z"],
+        [`040000 tree ${githubTree}\t.github\0`, `040000 tree ${scriptsTree}\tscripts\0`].join(""),
+      );
+      await expect(
+        inspectWorkflowExecutionGitTreeRepository(invalidPath, rootTree),
+      ).rejects.toThrow("Git tree path contains invalid UTF-8");
+    } finally {
+      await rm(invalidPath, { recursive: true, force: true });
+    }
+  });
+
+  test("Git-tree discovery enforces path, entry, source, and depth bounds", async () => {
+    const invalidPath = await createCommittedDiscoveryFixture();
+    try {
+      await writeFile(join(invalidPath, ".github/workflows/control\nname.yml"), minimalWorkflow);
+      await commitFixture(invalidPath, "control path");
+      await expect(
+        inspectWorkflowExecutionGitTreeRepository(invalidPath, "HEAD^{tree}"),
+      ).rejects.toThrow("contains an invalid path");
+    } finally {
+      await rm(invalidPath, { recursive: true, force: true });
+    }
+
+    const entryOverflow = await createCommittedDiscoveryFixture();
+    try {
+      await Promise.all(
+        Array.from({ length: WORKFLOW_GRAPH_LIMITS.maxWorkflowDiscoveryEntries }, (_, index) =>
+          writeFile(join(entryOverflow, `.github/workflows/filler-${index}.txt`), ""),
+        ),
+      );
+      await commitFixture(entryOverflow, "workflow entry overflow");
+      await expect(
+        inspectWorkflowExecutionGitTreeRepository(entryOverflow, "HEAD^{tree}"),
+      ).rejects.toThrow("workflow Git tree discovery exceeds the directory-entry limit");
+    } finally {
+      await rm(entryOverflow, { recursive: true, force: true });
+    }
+
+    const sourceOverflow = await createCommittedDiscoveryFixture();
+    try {
+      await Promise.all(
+        Array.from({ length: WORKFLOW_GRAPH_LIMITS.maxSources - 1 }, (_, index) =>
+          writeFile(join(sourceOverflow, `.github/workflows/source-${index}.yml`), minimalWorkflow),
+        ),
+      );
+      await commitFixture(sourceOverflow, "source overflow");
+      await expect(
+        inspectWorkflowExecutionGitTreeRepository(sourceOverflow, "HEAD^{tree}"),
+      ).rejects.toThrow("exceeds the source-count limit in the Git tree");
+    } finally {
+      await rm(sourceOverflow, { recursive: true, force: true });
+    }
+
+    const depthOverflow = await createCommittedDiscoveryFixture();
+    try {
+      let nested = join(depthOverflow, ".github/actions");
+      for (let index = 0; index <= WORKFLOW_GRAPH_LIMITS.maxActionDiscoveryDepth; index += 1) {
+        nested = join(nested, `depth-${index}`);
+      }
+      await mkdir(nested, { recursive: true });
+      await writeFile(join(nested, "action.yml"), minimalAction);
+      await commitFixture(depthOverflow, "action depth overflow");
+      await expect(
+        inspectWorkflowExecutionGitTreeRepository(depthOverflow, "HEAD^{tree}"),
+      ).rejects.toThrow("action Git tree discovery exceeds the directory-depth limit");
+    } finally {
+      await rm(depthOverflow, { recursive: true, force: true });
+    }
+  });
+
+  test("former shell-assembly probes are ordinary source changes, never interpreted", () => {
+    const probes = [
+      String.raw`cat <<EOF\n$(timeout 10h job)\nEOF`,
+      String.raw`echo "$(timeout 10h job)"`,
+      String.raw`VALUE="$(timeout 10h job)"`,
+      String.raw`consume "$(timeout 10h job)"`,
+      String.raw`eval 'timeout 10h job'`,
+      String.raw`time""out 10h job`,
+      String.raw`ti\meout 10h job`,
+      "time\\\nout 10h job",
+      String.raw`bun test --time""out 720000`,
+      String.raw`cmd=timeout; "$cmd" 10h job`,
+      String.raw`gtimeout 10h job`,
+      "time$''out 10h job",
+      "time$'\\x6f'ut 10h job",
+      "$'time\\x6fut' 10h job",
+      "EMPTY=; time${EMPTY}out 10h job",
+      String.raw`cmd=time; cmd+=out; "$cmd" 10h job`,
+      String.raw`time$(printf "")out 10h job`,
+      "ti$''me$''out 10h job",
+      "ti${A}me${B}out 10h job",
+      "$'\\x74\\x69\\x6d\\x65\\x6f\\x75\\x74' 10h job",
+      "t$'\\x69'm$'\\x65'o$'\\x75't 10h job",
+      String.raw`cmd=t; cmd+=i; cmd+=m; cmd+=e; cmd+=o; cmd+=u; cmd+=t; "$cmd" 10h job`,
+      "gti${A}me${B}out 10h job",
+      "--ti${A}me${B}out-seconds 10",
+    ];
+    const baselineSources = fixtureSources();
+    const baseline = inspectWorkflowExecutionSources(baselineSources);
+
+    for (const [index, probe] of probes.entries()) {
+      const sources = fixtureSources();
+      sources[workflowPath] = replaceOnce(
+        sources[workflowPath] ?? "",
+        'run: "echo producer"',
+        `run: ${JSON.stringify(probe)}`,
+      );
+      const current = inspectWorkflowExecutionSources(sources);
+      expect(current.violations, `probe ${index}`).toEqual([]);
+      expect(workflowDigest(current.manifest), `probe ${index}`).not.toBe(
+        workflowDigest(baseline.manifest),
+      );
+      expect(current.manifest.uncappedRuns).toHaveLength(baseline.manifest.uncappedRuns.length);
+    }
+  });
+
+  test("manifest identity, staleness, cap mutations, and invalid caps fail closed", () => {
+    const baselineSources = fixtureSources();
+    const baseline = inspectWorkflowExecutionSources(baselineSources);
+    expect(baseline.violations).toEqual([]);
+
+    const changedPath = {
+      ...baseline.manifest,
+      workflows: baseline.manifest.workflows.map((row, index) =>
+        index === 0 ? { ...row, path: ".github/workflows/renamed.yml" } : row,
+      ),
+    };
+    expect(compareWorkflowExecutionManifest(changedPath, baseline.manifest)).not.toEqual([]);
+
+    const changedDigest = {
+      ...baseline.manifest,
+      workflows: baseline.manifest.workflows.map((row, index) =>
+        index === 0 ? { ...row, sha256: "0".repeat(64) } : row,
+      ),
+    };
+    expect(compareWorkflowExecutionManifest(changedDigest, baseline.manifest)).not.toEqual([]);
+
+    const duplicate = {
+      ...baseline.manifest,
+      uncappedRuns: [...baseline.manifest.uncappedRuns, baseline.manifest.uncappedRuns[0]!],
+    };
+    expect(compareWorkflowExecutionManifest(duplicate, baseline.manifest).join("\n")).toContain(
+      "duplicates uncapped run",
+    );
+
+    const malformed = { ...structuredClone(baseline.manifest), unexpected: true };
+    expect(compareWorkflowExecutionManifest(malformed, baseline.manifest)).toEqual([
+      "workflow execution manifest has an invalid shape",
+    ]);
+
+    for (const cap of [0, -1, 1.5, 121, "30", "${{ matrix.timeout }}"]) {
+      const sources = fixtureSources();
+      sources[workflowPath] = replaceOnce(
+        sources[workflowPath] ?? "",
+        "timeout-minutes: 30",
+        `timeout-minutes: ${JSON.stringify(cap)}`,
+      );
+      expect(inspectWorkflowExecutionSources(sources).violations.join("\n"), String(cap)).toMatch(
+        /job timeout-minutes must be a static integer|numeric scalar outside the safe-integer domain/u,
+      );
+    }
+    for (const cap of [0, -1, 1.5, 361, "12", "${{ inputs.timeout }}"]) {
+      const sources = fixtureSources();
+      sources[workflowPath] = replaceOnce(
+        sources[workflowPath] ?? "",
+        'run: "echo producer"',
+        `timeout-minutes: ${JSON.stringify(cap)}\n        run: "echo producer"`,
+      );
+      expect(inspectWorkflowExecutionSources(sources).violations.join("\n"), String(cap)).toMatch(
+        /timeout-minutes must be a static integer|numeric scalar outside the safe-integer domain/u,
+      );
+    }
+
+    const capped = fixtureSources();
+    capped[workflowPath] = replaceOnce(
+      capped[workflowPath] ?? "",
+      'run: "echo producer"',
+      'timeout-minutes: 12\n        run: "echo producer"',
+    );
+    const cappedInspection = inspectWorkflowExecutionSources(capped);
+    expect(cappedInspection.violations).toEqual([]);
+    expect(cappedInspection.manifest.uncappedRuns).toHaveLength(
+      baseline.manifest.uncappedRuns.length - 1,
+    );
+    expect(
+      compareWorkflowExecutionManifest(baseline.manifest, cappedInspection.manifest),
+    ).not.toEqual([]);
+    expect(
+      compareWorkflowExecutionManifest(cappedInspection.manifest, baseline.manifest),
+    ).not.toEqual([]);
+  });
+
+  test("removing any one of the 16 approved caps invalidates the committed graph", async () => {
+    type MutableStep = { "timeout-minutes"?: unknown; run?: unknown; uses?: unknown };
+    type MutableWorkflow = { jobs?: Record<string, { steps?: MutableStep[] }> };
+    const sources = await loadWorkflowExecutionSources(root);
+    const committed = JSON.parse(
+      await readFile(resolve(root, GRAPH_MANIFEST_PATH), "utf8"),
+    ) as unknown;
+    const capped: Array<readonly [string, number, number]> = [];
+    for (const [path, source] of Object.entries(sources)) {
+      if (!path.startsWith(".github/workflows/")) continue;
+      const workflow = Bun.YAML.parse(source) as MutableWorkflow;
+      for (const [jobIndex, job] of Object.values(workflow.jobs ?? {}).entries()) {
+        for (const [stepIndex, step] of (job.steps ?? []).entries()) {
+          if (step["timeout-minutes"] !== undefined) capped.push([path, jobIndex, stepIndex]);
+        }
+      }
+    }
+    expect(capped).toHaveLength(16);
+
+    for (const [path, jobIndex, stepIndex] of capped) {
+      const mutatedSources = { ...sources };
+      const workflow = Bun.YAML.parse(mutatedSources[path] ?? "") as MutableWorkflow;
+      const job = Object.values(workflow.jobs ?? {})[jobIndex];
+      const step = job?.steps?.[stepIndex];
+      expect(step).toBeDefined();
+      delete step?.["timeout-minutes"];
+      mutatedSources[path] = stringify(workflow);
+      const inspection = inspectWorkflowExecutionSources(mutatedSources);
+      expect(inspection.violations, `${path}:${jobIndex}:${stepIndex}`).toEqual([]);
+      expect(
+        compareWorkflowExecutionManifest(committed, inspection.manifest),
+        `${path}:${jobIndex}:${stepIndex}`,
+      ).not.toEqual([]);
+    }
+  });
+
+  test("diagnostics disclose identities but never command or environment content", () => {
+    const sentinelCommand = "SECRET_COMMAND_SENTINEL";
+    const sentinelEnvironment = "SECRET_ENV_SENTINEL";
+    const sources = fixtureSources();
+    sources[workflowPath] = replaceOnce(
+      sources[workflowPath] ?? "",
+      "echo producer",
+      sentinelCommand,
+    );
+    sources[workflowPath] = replaceOnce(sources[workflowPath] ?? "", "env-a", sentinelEnvironment);
+    const current = inspectWorkflowExecutionSources(sources);
+    const baseline = inspectWorkflowExecutionSources(fixtureSources());
+    const diagnostics = compareWorkflowExecutionManifest(baseline.manifest, current.manifest).join(
+      "\n",
+    );
+
+    expect(diagnostics).toContain(workflowPath);
+    expect(diagnostics).not.toContain(sentinelCommand);
+    expect(diagnostics).not.toContain(sentinelEnvironment);
+  });
+});

--- a/scripts/workflow-execution-graph.ts
+++ b/scripts/workflow-execution-graph.ts
@@ -1,0 +1,1569 @@
+import { createHash } from "node:crypto";
+import { lstat, open, opendir, readFile, writeFile } from "node:fs/promises";
+import { posix, relative, resolve, sep } from "node:path";
+import { isAlias, isMap, isPair, isScalar, isSeq, parseDocument } from "yaml";
+
+export const GRAPH_SCHEMA_VERSION = 1 as const;
+export const GRAPH_DOMAIN = "opengeni.workflow-execution-graph.v1" as const;
+export const GRAPH_CANONICALIZATION = "restricted-yaml-1.2-sorted-json-v1" as const;
+export const GRAPH_MANIFEST_PATH = "scripts/workflow-execution-graph-manifest.json" as const;
+export const MAX_JOB_TIMEOUT_MINUTES = 120;
+export const MAX_STEP_TIMEOUT_MINUTES = 360;
+
+// The current graph is 23 sources / ~293 KiB total; its largest source is
+// ~82 KiB, largest AST is 3,165 nodes, widest collection is 37 entries, and
+// deepest AST path is 14 nodes. These limits leave substantial authored-growth
+// margin while bounding every attacker-controlled dimension before recursive
+// conversion or canonicalization.
+export const WORKFLOW_GRAPH_LIMITS = {
+  maxSources: 64,
+  maxSourceBytes: 256 * 1024,
+  maxTotalSourceBytes: 1024 * 1024,
+  maxAstNodesPerSource: 20_000,
+  maxTotalAstNodes: 100_000,
+  maxCollectionWidth: 1024,
+  maxNestingDepth: 64,
+  maxActionDiscoveryEntries: 1024,
+  maxActionDiscoveryDepth: 16,
+  maxWorkflowDiscoveryEntries: 128,
+  maxGitProtocolBytes: 2 * 1024 * 1024,
+  maxGitDiagnosticBytes: 16 * 1024,
+  maxGitRevisionBytes: 256,
+  maxGitPathBytes: 4096,
+} as const;
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+type YamlObject = Record<string, unknown>;
+
+type WorkflowSourceLoaderHooks = Readonly<{
+  afterPreflight?: (
+    sources: readonly Readonly<{ path: string; bytes: number }>[],
+  ) => void | Promise<void>;
+  beforeRead?: (path: string) => void | Promise<void>;
+  onDiscoveryEntry?: (kind: "workflow" | "action", path: string) => void;
+  onDirectoryHandleClosed?: (kind: "workflow" | "action", path: string) => void;
+  onFileHandleClosed?: (path: string) => void;
+}>;
+
+type OpenGraphSource = Readonly<{
+  path: string;
+  absolutePath: string;
+  bytes: number;
+  device: number | bigint;
+  inode: number | bigint;
+  handle: Awaited<ReturnType<typeof open>>;
+}>;
+
+export type WorkflowGitTreeLoaderHooks = Readonly<{
+  afterTreeCapture?: (treeOid: string) => void | Promise<void>;
+  afterBlobPreflight?: (
+    sources: readonly Readonly<{ path: string; bytes: number }>[],
+  ) => void | Promise<void>;
+  beforeBlobRead?: (path: string) => void | Promise<void>;
+}>;
+
+type GitTreeEntry = Readonly<{
+  path: string;
+  mode: string;
+  type: string;
+  oid: string;
+}>;
+
+type GitBlobSource = Readonly<{
+  path: string;
+  mode: "100644" | "100755";
+  oid: string;
+  bytes: number;
+}>;
+
+export type GraphDigestRecord = Readonly<{ path: string; sha256: string }>;
+export type UncappedRunRecord = Readonly<{
+  workflow: string;
+  job: string;
+  step: string;
+  sha256: string;
+}>;
+export type GeneratedLocalTargetRecord = Readonly<{
+  workflow: string;
+  job: string;
+  step: string;
+  target: string;
+  authority: "retained-release-controller";
+}>;
+
+export type WorkflowExecutionGraphManifest = Readonly<{
+  schemaVersion: typeof GRAPH_SCHEMA_VERSION;
+  domain: typeof GRAPH_DOMAIN;
+  canonicalization: typeof GRAPH_CANONICALIZATION;
+  hashAlgorithm: "sha256";
+  workflows: readonly GraphDigestRecord[];
+  actions: readonly GraphDigestRecord[];
+  generatedLocalTargets: readonly GeneratedLocalTargetRecord[];
+  uncappedRuns: readonly UncappedRunRecord[];
+}>;
+
+export type WorkflowExecutionGraphInspection = Readonly<{
+  manifest: WorkflowExecutionGraphManifest;
+  violations: readonly string[];
+}>;
+
+export type WorkflowGitTreeInspection = Readonly<{
+  treeOid: string;
+  inspection: WorkflowExecutionGraphInspection;
+  manifestViolations: readonly string[];
+}>;
+
+type LocalTargetEdge = Readonly<{
+  identity: string;
+  target: string;
+  resolvedPath?: string;
+  generatedAuthority?: GeneratedLocalTargetRecord["authority"];
+}>;
+
+type ParsedGraphSource = Readonly<{
+  path: string;
+  kind: "workflow" | "action";
+  document: YamlObject;
+  edges: readonly LocalTargetEdge[];
+}>;
+
+const EXPECTED_GENERATED_LOCAL_TARGETS: readonly GeneratedLocalTargetRecord[] = [
+  {
+    workflow: ".github/workflows/release-candidate.yml",
+    job: "candidate",
+    step: "Log in to the public OCI registry",
+    target: "./.release/controller/.github/actions/public-oci-login",
+    authority: "retained-release-controller",
+  },
+  {
+    workflow: ".github/workflows/release-embedded.yml",
+    job: "release",
+    step: "Log in to the public OCI registry",
+    target: "./.release/controller/.github/actions/public-oci-login",
+    authority: "retained-release-controller",
+  },
+  {
+    workflow: ".github/workflows/release.yml",
+    job: "images",
+    step: "Log in to the public OCI registry",
+    target: "./.release/controller/.github/actions/public-oci-login",
+    authority: "retained-release-controller",
+  },
+] as const;
+
+function isObject(value: unknown): value is YamlObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function canonicalValue(value: unknown, location = "root"): JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || Object.is(value, -0)) {
+      throw new Error(`${location} contains a number outside the safe-integer domain`);
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, index) => canonicalValue(entry, `${location}[${index}]`));
+  }
+  if (!isObject(value)) throw new Error(`${location} contains an unsupported YAML value`);
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${location} contains a non-plain YAML mapping`);
+  }
+  // A normal object treats `__proto__` assignment as prototype mutation. A
+  // null-prototype mapping preserves every own YAML key without changing the
+  // canonical JSON emitted for the ordinary corpus.
+  const canonical = Object.create(null) as Record<string, JsonValue>;
+  for (const key of Object.keys(value).sort()) {
+    canonical[key] = canonicalValue(value[key], `${location}.${key}`);
+  }
+  return canonical;
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalValue(value));
+}
+
+function sha256(kind: string, identity: string, value: unknown): string {
+  const hash = createHash("sha256");
+  hash.update(`${GRAPH_DOMAIN}\0${GRAPH_SCHEMA_VERSION}\0${kind}\0${identity}\0`, "utf8");
+  hash.update(typeof value === "string" ? value : canonicalJson(value), "utf8");
+  return hash.digest("hex");
+}
+
+function utf8Bytes(source: string): number {
+  return new TextEncoder().encode(source).byteLength;
+}
+
+function assertSourceByteBound(source: string, sourcePath: string): number {
+  const bytes = utf8Bytes(source);
+  if (bytes > WORKFLOW_GRAPH_LIMITS.maxSourceBytes) {
+    throw new Error(`${sourcePath} exceeds the per-source UTF-8 byte limit`);
+  }
+  return bytes;
+}
+
+function assertRestrictedStructure(
+  value: unknown,
+  sourcePath: string,
+  nodeLimit = WORKFLOW_GRAPH_LIMITS.maxAstNodesPerSource,
+  nodeLimitCategory = "AST node",
+): number {
+  let nodeCount = 0;
+  const stack: Array<Readonly<{ value: unknown; depth: number }>> = [{ value, depth: 1 }];
+  while (stack.length > 0) {
+    const entry = stack.pop();
+    if (!entry || entry.value === null || entry.value === undefined) continue;
+    nodeCount += 1;
+    if (nodeCount > nodeLimit) {
+      throw new Error(`${sourcePath} exceeds the ${nodeLimitCategory} limit`);
+    }
+    if (entry.depth > WORKFLOW_GRAPH_LIMITS.maxNestingDepth) {
+      throw new Error(`${sourcePath} exceeds the AST nesting-depth limit`);
+    }
+    if (isAlias(entry.value)) throw new Error(`${sourcePath} uses a YAML alias`);
+
+    const node = entry.value as { anchor?: unknown; tag?: unknown };
+    if (typeof node.anchor === "string" && node.anchor.length > 0) {
+      throw new Error(`${sourcePath} uses a YAML anchor`);
+    }
+    if (typeof node.tag === "string" && node.tag.length > 0) {
+      throw new Error(`${sourcePath} uses an explicit YAML tag`);
+    }
+
+    if (isScalar(entry.value)) {
+      if (
+        typeof entry.value.value === "number" &&
+        (!Number.isSafeInteger(entry.value.value) || Object.is(entry.value.value, -0))
+      ) {
+        throw new Error(`${sourcePath} uses a numeric scalar outside the safe-integer domain`);
+      }
+      continue;
+    }
+    if (isPair(entry.value)) {
+      if (!isScalar(entry.value.key) || typeof entry.value.key.value !== "string") {
+        throw new Error(`${sourcePath} uses a non-string YAML mapping key`);
+      }
+      if (entry.value.key.value === "<<") {
+        throw new Error(`${sourcePath} uses a YAML merge key`);
+      }
+      stack.push(
+        { value: entry.value.value, depth: entry.depth + 1 },
+        { value: entry.value.key, depth: entry.depth + 1 },
+      );
+      continue;
+    }
+    if (isMap(entry.value) || isSeq(entry.value)) {
+      if (entry.value.items.length > WORKFLOW_GRAPH_LIMITS.maxCollectionWidth) {
+        throw new Error(`${sourcePath} exceeds the YAML collection-width limit`);
+      }
+      for (let index = entry.value.items.length - 1; index >= 0; index -= 1) {
+        stack.push({ value: entry.value.items[index], depth: entry.depth + 1 });
+      }
+    }
+  }
+  return nodeCount;
+}
+
+function parseRestrictedYamlWithStats(
+  source: string,
+  sourcePath: string,
+  nodeLimit = WORKFLOW_GRAPH_LIMITS.maxAstNodesPerSource,
+  nodeLimitCategory = "AST node",
+): Readonly<{ parsed: YamlObject; nodeCount: number }> {
+  assertSourceByteBound(source, sourcePath);
+  let document;
+  try {
+    document = parseDocument(source, {
+      merge: false,
+      prettyErrors: false,
+      strict: true,
+      uniqueKeys: true,
+      version: "1.2",
+    });
+  } catch {
+    throw new Error(`${sourcePath} is malformed YAML`);
+  }
+  if (document.errors.length > 0 || document.warnings.length > 0) {
+    throw new Error(`${sourcePath} is malformed or unsupported YAML`);
+  }
+  if (!document.contents || !isMap(document.contents)) {
+    throw new Error(`${sourcePath} must contain one YAML mapping document`);
+  }
+  const nodeCount = assertRestrictedStructure(
+    document.contents,
+    sourcePath,
+    nodeLimit,
+    nodeLimitCategory,
+  );
+  const parsed = document.toJS({ maxAliasCount: 0 }) as unknown;
+  if (!isObject(parsed)) throw new Error(`${sourcePath} must contain one YAML mapping document`);
+  canonicalValue(parsed, sourcePath);
+  return { parsed, nodeCount };
+}
+
+export function parseRestrictedYaml(source: string, sourcePath: string): YamlObject {
+  return parseRestrictedYamlWithStats(source, sourcePath).parsed;
+}
+
+function normalizedLocalPath(target: string): string | null {
+  if (!target.startsWith("./")) return null;
+  const normalized = posix.normalize(target.slice(2));
+  if (
+    normalized.length === 0 ||
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    posix.isAbsolute(normalized)
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function isPotentialLocalTarget(target: string): boolean {
+  return target.startsWith(".") || target.startsWith("/");
+}
+
+function generatedIdentity(record: GeneratedLocalTargetRecord): string {
+  return `${record.workflow}\0${record.job}\0${record.step}\0${record.target}`;
+}
+
+function runIdentity(record: Pick<UncappedRunRecord, "workflow" | "job" | "step">): string {
+  return `${record.workflow}\0${record.job}\0${record.step}`;
+}
+
+function resolveLocalTarget(
+  sourcePath: string,
+  job: string,
+  step: string,
+  target: string,
+  sourcePaths: ReadonlySet<string>,
+  violations: string[],
+  generatedTargets: GeneratedLocalTargetRecord[],
+): LocalTargetEdge | null {
+  const normalized = normalizedLocalPath(target);
+  const identity = `${job}:${step}`;
+  if (normalized === null) {
+    violations.push(`${sourcePath}:${identity} has a path-escaping local target`);
+    return null;
+  }
+
+  const expectedGenerated = EXPECTED_GENERATED_LOCAL_TARGETS.find(
+    (candidate) =>
+      candidate.workflow === sourcePath &&
+      candidate.job === job &&
+      candidate.step === step &&
+      candidate.target === target,
+  );
+  if (expectedGenerated) {
+    generatedTargets.push(expectedGenerated);
+    return {
+      identity,
+      target,
+      generatedAuthority: expectedGenerated.authority,
+    };
+  }
+
+  if (/\.ya?ml$/u.test(normalized)) {
+    if (!sourcePaths.has(normalized)) {
+      violations.push(`${sourcePath}:${identity} has a missing local workflow target`);
+      return null;
+    }
+    return { identity, target, resolvedPath: normalized };
+  }
+
+  const candidates = [`${normalized}/action.yml`, `${normalized}/action.yaml`].filter((candidate) =>
+    sourcePaths.has(candidate),
+  );
+  if (candidates.length !== 1) {
+    violations.push(
+      `${sourcePath}:${identity} has a ${candidates.length === 0 ? "missing" : "ambiguous"} local action target`,
+    );
+    return null;
+  }
+  return { identity, target, resolvedPath: candidates[0] };
+}
+
+function positiveIntegerTimeout(value: unknown, maximum: number): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 && value <= maximum;
+}
+
+function scanWorkflow(
+  path: string,
+  workflow: YamlObject,
+  sourcePaths: ReadonlySet<string>,
+  violations: string[],
+  uncappedRuns: UncappedRunRecord[],
+  generatedTargets: GeneratedLocalTargetRecord[],
+): readonly LocalTargetEdge[] {
+  const jobs = workflow.jobs;
+  if (!isObject(jobs)) {
+    violations.push(`${path} must define a jobs mapping`);
+    return [];
+  }
+
+  const edges: LocalTargetEdge[] = [];
+  for (const [jobKey, rawJob] of Object.entries(jobs)) {
+    if (!isObject(rawJob)) {
+      violations.push(`${path}:${jobKey} must be a job mapping`);
+      continue;
+    }
+
+    if (rawJob.uses !== undefined) {
+      if (typeof rawJob.uses !== "string") {
+        violations.push(`${path}:${jobKey} has a non-string reusable workflow target`);
+      } else if (isPotentialLocalTarget(rawJob.uses)) {
+        const edge = resolveLocalTarget(
+          path,
+          jobKey,
+          "reusable-workflow",
+          rawJob.uses,
+          sourcePaths,
+          violations,
+          generatedTargets,
+        );
+        if (edge) edges.push(edge);
+      }
+      continue;
+    }
+
+    if (!positiveIntegerTimeout(rawJob["timeout-minutes"], MAX_JOB_TIMEOUT_MINUTES)) {
+      violations.push(`${path}:${jobKey} job timeout-minutes must be a static integer in 1..120`);
+    }
+
+    if (!Array.isArray(rawJob.steps)) {
+      violations.push(`${path}:${jobKey} must define a steps sequence`);
+      continue;
+    }
+
+    const runNames = new Set<string>();
+    for (const [stepIndex, rawStep] of rawJob.steps.entries()) {
+      if (!isObject(rawStep)) {
+        violations.push(`${path}:${jobKey}:step-${stepIndex + 1} must be a step mapping`);
+        continue;
+      }
+      const diagnosticName =
+        typeof rawStep.name === "string" && rawStep.name.length > 0
+          ? rawStep.name
+          : `step-${stepIndex + 1}`;
+
+      const hasCap = Object.hasOwn(rawStep, "timeout-minutes");
+      if (hasCap && !positiveIntegerTimeout(rawStep["timeout-minutes"], MAX_STEP_TIMEOUT_MINUTES)) {
+        violations.push(
+          `${path}:${jobKey}:${diagnosticName} timeout-minutes must be a static integer in 1..360`,
+        );
+      }
+
+      if (rawStep.uses !== undefined) {
+        if (typeof rawStep.uses !== "string") {
+          violations.push(`${path}:${jobKey}:${diagnosticName} has a non-string action target`);
+        } else if (isPotentialLocalTarget(rawStep.uses)) {
+          const edge = resolveLocalTarget(
+            path,
+            jobKey,
+            diagnosticName,
+            rawStep.uses,
+            sourcePaths,
+            violations,
+            generatedTargets,
+          );
+          if (edge) edges.push(edge);
+        }
+      }
+
+      if (rawStep.run === undefined) continue;
+      if (typeof rawStep.run !== "string") {
+        violations.push(`${path}:${jobKey}:${diagnosticName} has a non-string run value`);
+        continue;
+      }
+      if (
+        typeof rawStep.name !== "string" ||
+        rawStep.name.trim().length === 0 ||
+        rawStep.name.includes("${{")
+      ) {
+        violations.push(`${path}:${jobKey}:${diagnosticName} run step needs a static name`);
+        continue;
+      }
+      if (runNames.has(rawStep.name)) {
+        violations.push(`${path}:${jobKey}:${rawStep.name} duplicates a run step identity`);
+        continue;
+      }
+      runNames.add(rawStep.name);
+
+      if (!hasCap) {
+        const execution = { ...rawStep };
+        delete execution.name;
+        delete execution["timeout-minutes"];
+        uncappedRuns.push({
+          workflow: path,
+          job: jobKey,
+          step: rawStep.name,
+          sha256: sha256("uncapped-run", `${path}\0${jobKey}\0${rawStep.name}`, execution),
+        });
+      }
+    }
+  }
+  return edges;
+}
+
+function scanAction(
+  path: string,
+  action: YamlObject,
+  sourcePaths: ReadonlySet<string>,
+  violations: string[],
+  generatedTargets: GeneratedLocalTargetRecord[],
+): readonly LocalTargetEdge[] {
+  if (!isObject(action.runs)) {
+    violations.push(`${path} must define a runs mapping`);
+    return [];
+  }
+  if (action.runs.using !== "composite" || !Array.isArray(action.runs.steps)) {
+    violations.push(`${path} must be a composite action with a steps sequence`);
+    return [];
+  }
+  const edges: LocalTargetEdge[] = [];
+  for (const [stepIndex, rawStep] of action.runs.steps.entries()) {
+    if (!isObject(rawStep)) {
+      violations.push(`${path}:composite:step-${stepIndex + 1} must be a step mapping`);
+      continue;
+    }
+    if (rawStep.uses === undefined) continue;
+    const diagnosticName =
+      typeof rawStep.name === "string" && rawStep.name.length > 0
+        ? rawStep.name
+        : `step-${stepIndex + 1}`;
+    if (typeof rawStep.uses !== "string") {
+      violations.push(`${path}:composite:${diagnosticName} has a non-string action target`);
+    } else if (isPotentialLocalTarget(rawStep.uses)) {
+      const edge = resolveLocalTarget(
+        path,
+        "composite",
+        diagnosticName,
+        rawStep.uses,
+        sourcePaths,
+        violations,
+        generatedTargets,
+      );
+      if (edge) edges.push(edge);
+    }
+  }
+  return edges;
+}
+
+function graphDigest(
+  path: string,
+  parsedSources: ReadonlyMap<string, ParsedGraphSource>,
+  memo: Map<string, string>,
+  visiting: Set<string>,
+  violations: string[],
+): string | null {
+  const existing = memo.get(path);
+  if (existing) return existing;
+  if (visiting.has(path)) {
+    violations.push(`${path} participates in a local workflow/action target cycle`);
+    return null;
+  }
+  const source = parsedSources.get(path);
+  if (!source) return null;
+  visiting.add(path);
+  const localTargets: Array<Record<string, string>> = [];
+  for (const edge of [...source.edges].sort((left, right) =>
+    `${left.identity}\0${left.target}`.localeCompare(`${right.identity}\0${right.target}`),
+  )) {
+    if (edge.generatedAuthority) {
+      localTargets.push({
+        identity: edge.identity,
+        target: edge.target,
+        generatedAuthority: edge.generatedAuthority,
+      });
+      continue;
+    }
+    if (!edge.resolvedPath) continue;
+    const targetDigest = graphDigest(edge.resolvedPath, parsedSources, memo, visiting, violations);
+    if (targetDigest) {
+      localTargets.push({
+        identity: edge.identity,
+        target: edge.target,
+        resolvedPath: edge.resolvedPath,
+        sha256: targetDigest,
+      });
+    }
+  }
+  visiting.delete(path);
+  const digest = sha256(`graph-${source.kind}`, path, {
+    document: source.document,
+    localTargets,
+  });
+  memo.set(path, digest);
+  return digest;
+}
+
+export function inspectWorkflowExecutionSources(
+  sources: Readonly<Record<string, string>>,
+): WorkflowExecutionGraphInspection {
+  const violations: string[] = [];
+  const uncappedRuns: UncappedRunRecord[] = [];
+  const generatedTargets: GeneratedLocalTargetRecord[] = [];
+  const sourceEntries = Object.entries(sources).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  const sourcePaths = new Set(sourceEntries.map(([path]) => path));
+  const parsedSources = new Map<string, ParsedGraphSource>();
+
+  if (sourceEntries.length > WORKFLOW_GRAPH_LIMITS.maxSources) {
+    violations.push("workflow execution graph exceeds the source-count limit");
+  } else {
+    let totalBytes = 0;
+    for (const [path, source] of sourceEntries) {
+      const bytes = utf8Bytes(source);
+      totalBytes += bytes;
+      if (bytes > WORKFLOW_GRAPH_LIMITS.maxSourceBytes) {
+        violations.push(`${path} exceeds the per-source UTF-8 byte limit`);
+      }
+    }
+    if (totalBytes > WORKFLOW_GRAPH_LIMITS.maxTotalSourceBytes) {
+      violations.push("workflow execution graph exceeds the total UTF-8 byte limit");
+    }
+  }
+
+  if (violations.length > 0) {
+    return {
+      manifest: {
+        schemaVersion: GRAPH_SCHEMA_VERSION,
+        domain: GRAPH_DOMAIN,
+        canonicalization: GRAPH_CANONICALIZATION,
+        hashAlgorithm: "sha256",
+        workflows: [],
+        actions: [],
+        generatedLocalTargets: [],
+        uncappedRuns: [],
+      },
+      violations,
+    };
+  }
+
+  let totalAstNodes = 0;
+  for (const [path, source] of sourceEntries) {
+    const kind = path.startsWith(".github/workflows/")
+      ? "workflow"
+      : /^\.github\/actions\/.+\/action\.ya?ml$/u.test(path)
+        ? "action"
+        : null;
+    if (!kind) {
+      violations.push(`${path} is outside the workflow execution graph`);
+      continue;
+    }
+    let document: YamlObject;
+    try {
+      const remainingNodes = WORKFLOW_GRAPH_LIMITS.maxTotalAstNodes - totalAstNodes;
+      const sourceNodeLimit = Math.min(WORKFLOW_GRAPH_LIMITS.maxAstNodesPerSource, remainingNodes);
+      const parsed = parseRestrictedYamlWithStats(
+        source,
+        path,
+        sourceNodeLimit,
+        sourceNodeLimit < WORKFLOW_GRAPH_LIMITS.maxAstNodesPerSource
+          ? "total AST node"
+          : "AST node",
+      );
+      document = parsed.parsed;
+      totalAstNodes += parsed.nodeCount;
+    } catch (error) {
+      violations.push(error instanceof Error ? error.message : `${path} is invalid YAML`);
+      continue;
+    }
+    const edges =
+      kind === "workflow"
+        ? scanWorkflow(path, document, sourcePaths, violations, uncappedRuns, generatedTargets)
+        : scanAction(path, document, sourcePaths, violations, generatedTargets);
+    parsedSources.set(path, { path, kind, document, edges });
+  }
+
+  const observedGenerated = new Set(generatedTargets.map(generatedIdentity));
+  for (const expected of EXPECTED_GENERATED_LOCAL_TARGETS) {
+    if (sourcePaths.has(expected.workflow) && !observedGenerated.has(generatedIdentity(expected))) {
+      violations.push(
+        `${expected.workflow}:${expected.job}:${expected.step} is missing its retained-controller target classification`,
+      );
+    }
+  }
+  if (observedGenerated.size !== generatedTargets.length) {
+    violations.push("generated local target classifications must be unique");
+  }
+
+  const memo = new Map<string, string>();
+  const workflowDigests: GraphDigestRecord[] = [];
+  const actionDigests: GraphDigestRecord[] = [];
+  for (const [path, source] of [...parsedSources].sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    const digest = graphDigest(path, parsedSources, memo, new Set(), violations);
+    if (!digest) continue;
+    (source.kind === "workflow" ? workflowDigests : actionDigests).push({
+      path,
+      sha256: digest,
+    });
+  }
+
+  uncappedRuns.sort((left, right) => runIdentity(left).localeCompare(runIdentity(right)));
+  generatedTargets.sort((left, right) =>
+    generatedIdentity(left).localeCompare(generatedIdentity(right)),
+  );
+
+  return {
+    manifest: {
+      schemaVersion: GRAPH_SCHEMA_VERSION,
+      domain: GRAPH_DOMAIN,
+      canonicalization: GRAPH_CANONICALIZATION,
+      hashAlgorithm: "sha256",
+      workflows: workflowDigests,
+      actions: actionDigests,
+      generatedLocalTargets: generatedTargets,
+      uncappedRuns,
+    },
+    violations,
+  };
+}
+
+function repositoryIdentity(root: string, absolute: string): string {
+  const identity = relative(root, absolute).split(sep).join("/");
+  if (identity === ".." || identity.startsWith("../") || posix.isAbsolute(identity)) {
+    throw new Error("workflow execution graph discovery escaped the repository root");
+  }
+  return identity;
+}
+
+async function closeDirectory(
+  directory: Awaited<ReturnType<typeof opendir>>,
+  hooks: WorkflowSourceLoaderHooks,
+  kind: "workflow" | "action",
+  path: string,
+): Promise<void> {
+  try {
+    await directory.close();
+  } catch (error) {
+    if (
+      !isObject(error) ||
+      !("code" in error) ||
+      (error as { code?: unknown }).code !== "ERR_DIR_CLOSED"
+    ) {
+      throw error;
+    }
+  }
+  hooks.onDirectoryHandleClosed?.(kind, path);
+}
+
+async function actionDefinitionPaths(
+  root: string,
+  hooks: WorkflowSourceLoaderHooks,
+): Promise<readonly string[]> {
+  const actionRoot = resolve(root, ".github/actions");
+  const actionRootMetadata = await lstat(actionRoot);
+  if (actionRootMetadata.isSymbolicLink() || !actionRootMetadata.isDirectory()) {
+    throw new Error("action discovery root must be a regular directory");
+  }
+  const found: string[] = [];
+  let discoveredEntries = 0;
+  async function walk(directory: string, depth: number): Promise<void> {
+    if (depth > WORKFLOW_GRAPH_LIMITS.maxActionDiscoveryDepth) {
+      throw new Error("action discovery exceeds the directory-depth limit");
+    }
+    const handle = await opendir(directory);
+    try {
+      while (true) {
+        const entry = await handle.read();
+        if (!entry) break;
+        const absolute = resolve(directory, entry.name);
+        const identity = repositoryIdentity(root, absolute);
+        discoveredEntries += 1;
+        hooks.onDiscoveryEntry?.("action", identity);
+        if (discoveredEntries > WORKFLOW_GRAPH_LIMITS.maxActionDiscoveryEntries) {
+          throw new Error("action discovery exceeds the directory-entry limit");
+        }
+        if (entry.isSymbolicLink()) {
+          throw new Error(`${identity} is a forbidden symlink in action discovery`);
+        }
+        if (entry.isDirectory()) await walk(absolute, depth + 1);
+        else if (/^action\.ya?ml$/u.test(entry.name)) {
+          if (!entry.isFile()) {
+            throw new Error(`${identity} must be a regular action definition file`);
+          }
+          found.push(identity);
+        }
+      }
+    } finally {
+      await closeDirectory(handle, hooks, "action", repositoryIdentity(root, directory));
+    }
+  }
+  await walk(actionRoot, 0);
+  return found.sort();
+}
+
+async function workflowDefinitionPaths(
+  root: string,
+  hooks: WorkflowSourceLoaderHooks,
+): Promise<readonly string[]> {
+  const workflowRoot = resolve(root, ".github/workflows");
+  const workflowRootMetadata = await lstat(workflowRoot);
+  if (workflowRootMetadata.isSymbolicLink() || !workflowRootMetadata.isDirectory()) {
+    throw new Error("workflow discovery root must be a regular directory");
+  }
+  const found: string[] = [];
+  let discoveredEntries = 0;
+  const handle = await opendir(workflowRoot);
+  try {
+    while (true) {
+      const entry = await handle.read();
+      if (!entry) break;
+      const absolute = resolve(workflowRoot, entry.name);
+      const identity = repositoryIdentity(root, absolute);
+      discoveredEntries += 1;
+      hooks.onDiscoveryEntry?.("workflow", identity);
+      if (discoveredEntries > WORKFLOW_GRAPH_LIMITS.maxWorkflowDiscoveryEntries) {
+        throw new Error("workflow discovery exceeds the directory-entry limit");
+      }
+      if (entry.isSymbolicLink()) {
+        throw new Error(`${identity} is a forbidden symlink in workflow discovery`);
+      }
+      if (/\.ya?ml$/u.test(entry.name)) {
+        if (!entry.isFile()) {
+          throw new Error(`${identity} must be a regular workflow definition file`);
+        }
+        found.push(identity);
+      }
+    }
+  } finally {
+    await closeDirectory(handle, hooks, "workflow", repositoryIdentity(root, workflowRoot));
+  }
+  return found.sort();
+}
+
+async function closeGraphSourceHandles(
+  sources: readonly OpenGraphSource[],
+  hooks: WorkflowSourceLoaderHooks,
+): Promise<unknown> {
+  let firstError: unknown;
+  for (const source of sources) {
+    try {
+      await source.handle.close();
+      hooks.onFileHandleClosed?.(source.path);
+    } catch (error) {
+      firstError ??= error;
+    }
+  }
+  return firstError;
+}
+
+async function openGraphSources(
+  root: string,
+  paths: readonly string[],
+  hooks: WorkflowSourceLoaderHooks,
+): Promise<readonly OpenGraphSource[]> {
+  const sources: OpenGraphSource[] = [];
+  let totalBytes = 0;
+  try {
+    for (const path of paths) {
+      const absolutePath = resolve(root, path);
+      repositoryIdentity(root, absolutePath);
+      const pathMetadata = await lstat(absolutePath);
+      if (pathMetadata.isSymbolicLink() || !pathMetadata.isFile()) {
+        throw new Error(`${path} must be a regular non-symlink graph source`);
+      }
+      if (pathMetadata.size > WORKFLOW_GRAPH_LIMITS.maxSourceBytes) {
+        throw new Error(`${path} exceeds the per-source UTF-8 byte limit`);
+      }
+
+      const handle = await open(absolutePath, "r");
+      let handleMetadata: Awaited<ReturnType<typeof handle.stat>>;
+      try {
+        handleMetadata = await handle.stat();
+        if (
+          !handleMetadata.isFile() ||
+          handleMetadata.dev !== pathMetadata.dev ||
+          handleMetadata.ino !== pathMetadata.ino ||
+          handleMetadata.size !== pathMetadata.size
+        ) {
+          throw new Error(`${path} changed during graph source preflight`);
+        }
+        if (handleMetadata.size > WORKFLOW_GRAPH_LIMITS.maxSourceBytes) {
+          throw new Error(`${path} exceeds the per-source UTF-8 byte limit`);
+        }
+        totalBytes += handleMetadata.size;
+        if (totalBytes > WORKFLOW_GRAPH_LIMITS.maxTotalSourceBytes) {
+          throw new Error("workflow execution graph exceeds the total UTF-8 byte limit");
+        }
+      } catch (error) {
+        await handle.close();
+        hooks.onFileHandleClosed?.(path);
+        throw error;
+      }
+      sources.push({
+        path,
+        absolutePath,
+        bytes: handleMetadata.size,
+        device: handleMetadata.dev,
+        inode: handleMetadata.ino,
+        handle,
+      });
+    }
+    return sources;
+  } catch (error) {
+    await closeGraphSourceHandles(sources, hooks);
+    throw error;
+  }
+}
+
+async function readGraphSource(
+  root: string,
+  source: OpenGraphSource,
+  hooks: WorkflowSourceLoaderHooks,
+): Promise<string> {
+  await hooks.beforeRead?.(source.path);
+  const bytes = new Uint8Array(source.bytes + 1);
+  let offset = 0;
+  while (offset < bytes.byteLength) {
+    const result = await source.handle.read(bytes, offset, bytes.byteLength - offset, offset);
+    if (result.bytesRead === 0) break;
+    offset += result.bytesRead;
+  }
+  if (offset !== source.bytes) {
+    throw new Error(`${source.path} changed size while reading graph source`);
+  }
+  const finalHandleMetadata = await source.handle.stat();
+  const finalPathMetadata = await lstat(source.absolutePath);
+  if (
+    !finalHandleMetadata.isFile() ||
+    finalHandleMetadata.size !== source.bytes ||
+    finalHandleMetadata.dev !== source.device ||
+    finalHandleMetadata.ino !== source.inode ||
+    finalPathMetadata.isSymbolicLink() ||
+    !finalPathMetadata.isFile() ||
+    finalPathMetadata.size !== source.bytes ||
+    finalPathMetadata.dev !== source.device ||
+    finalPathMetadata.ino !== source.inode ||
+    repositoryIdentity(root, source.absolutePath) !== source.path
+  ) {
+    throw new Error(`${source.path} changed while reading graph source`);
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes.subarray(0, source.bytes));
+  } catch {
+    throw new Error(`${source.path} contains invalid UTF-8`);
+  }
+}
+
+export async function loadWorkflowExecutionSources(
+  root: string,
+  hooks: WorkflowSourceLoaderHooks = {},
+): Promise<Record<string, string>> {
+  // Local authoring mode intentionally observes the checkout. It supports
+  // dirty additions, removals, renames, and edits, and therefore requires a
+  // stable/quiescent worktree while discovery and reads are in progress. CI's
+  // hostile-mutation boundary is the immutable Git-tree mode below.
+  const paths = [
+    ...(await workflowDefinitionPaths(root, hooks)),
+    ...(await actionDefinitionPaths(root, hooks)),
+  ].sort();
+  if (paths.length > WORKFLOW_GRAPH_LIMITS.maxSources) {
+    throw new Error("workflow execution graph exceeds the source-count limit during discovery");
+  }
+  const openSources = await openGraphSources(root, paths, hooks);
+  let result: Record<string, string> | undefined;
+  let operationError: unknown;
+  try {
+    await hooks.afterPreflight?.(openSources.map(({ path, bytes }) => ({ path, bytes })));
+    const entries: Array<readonly [string, string]> = [];
+    for (const source of openSources) {
+      entries.push([source.path, await readGraphSource(root, source, hooks)]);
+    }
+    result = Object.fromEntries(entries);
+  } catch (error) {
+    operationError = error;
+  }
+  const closeError = await closeGraphSourceHandles(openSources, hooks);
+  if (operationError !== undefined) throw operationError;
+  if (closeError !== undefined) throw closeError;
+  return result ?? {};
+}
+
+async function collectBoundedGitOutput(
+  stream: ReadableStream<Uint8Array>,
+  maximumBytes: number,
+  onOverflow: () => void,
+): Promise<Readonly<{ bytes: Uint8Array; overflow: boolean }>> {
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  let overflow = false;
+  const reader = stream.getReader();
+  while (true) {
+    const result = await reader.read();
+    if (result.done) break;
+    totalBytes += result.value.byteLength;
+    if (totalBytes > maximumBytes) {
+      if (!overflow) onOverflow();
+      overflow = true;
+      continue;
+    }
+    if (!overflow) chunks.push(result.value);
+  }
+  if (overflow) return { bytes: new Uint8Array(), overflow: true };
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { bytes, overflow: false };
+}
+
+async function runBoundedGit(
+  root: string,
+  args: readonly string[],
+  category: string,
+  maximumOutputBytes = WORKFLOW_GRAPH_LIMITS.maxGitProtocolBytes,
+  input?: string,
+): Promise<Uint8Array> {
+  const inheritedEnvironment = Object.fromEntries(
+    Object.entries(Bun.env).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined && !entry[0].startsWith("GIT_"),
+    ),
+  );
+  const child = Bun.spawn(["git", ...args], {
+    cwd: root,
+    env: {
+      ...inheritedEnvironment,
+      GIT_CONFIG_COUNT: "0",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_NO_REPLACE_OBJECTS: "1",
+      GIT_OPTIONAL_LOCKS: "0",
+      LC_ALL: "C",
+    },
+    stdin: input === undefined ? "ignore" : new Blob([input]),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stop = () => {
+    try {
+      child.kill();
+    } catch {
+      // The process may have exited between the bounded read and cancellation.
+    }
+  };
+  const [stdout, stderr, exitCode] = await Promise.all([
+    collectBoundedGitOutput(child.stdout as ReadableStream<Uint8Array>, maximumOutputBytes, stop),
+    collectBoundedGitOutput(
+      child.stderr as ReadableStream<Uint8Array>,
+      WORKFLOW_GRAPH_LIMITS.maxGitDiagnosticBytes,
+      stop,
+    ),
+    child.exited,
+  ]);
+  if (stdout.overflow || stderr.overflow) {
+    throw new Error(`${category} exceeded the bounded Git protocol limit`);
+  }
+  if (exitCode !== 0) throw new Error(`${category} failed`);
+  return stdout.bytes;
+}
+
+function decodeGitUtf8(bytes: Uint8Array, category: string): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error(`${category} contains invalid UTF-8`);
+  }
+}
+
+function assertGitPath(path: string, pathBytes: number): void {
+  if (pathBytes === 0 || pathBytes > WORKFLOW_GRAPH_LIMITS.maxGitPathBytes) {
+    throw new Error("Git tree inventory contains an invalid path length");
+  }
+  if (/^[/]|[\u0000-\u001f\u007f]/u.test(path)) {
+    throw new Error("Git tree inventory contains an invalid path");
+  }
+  const components = path.split("/");
+  if (
+    components.some(
+      (component) => component.length === 0 || component === "." || component === "..",
+    )
+  ) {
+    throw new Error("Git tree inventory contains a path escape");
+  }
+}
+
+function parseGitTreeEntries(bytes: Uint8Array): readonly GitTreeEntry[] {
+  if (bytes.byteLength === 0) return [];
+  if (bytes[bytes.byteLength - 1] !== 0) {
+    throw new Error("Git tree inventory has a truncated protocol record");
+  }
+  const entries: GitTreeEntry[] = [];
+  let start = 0;
+  for (let index = 0; index < bytes.byteLength; index += 1) {
+    if (bytes[index] !== 0) continue;
+    const record = bytes.subarray(start, index);
+    start = index + 1;
+    let tab = -1;
+    for (let cursor = 0; cursor < record.byteLength; cursor += 1) {
+      if (record[cursor] === 9) {
+        tab = cursor;
+        break;
+      }
+    }
+    if (tab <= 0 || tab === record.byteLength - 1) {
+      throw new Error("Git tree inventory has a malformed protocol record");
+    }
+    const header = decodeGitUtf8(record.subarray(0, tab), "Git tree metadata");
+    const match = /^(\d{6}) (blob|tree|commit) ([0-9a-f]{40}|[0-9a-f]{64})$/u.exec(header);
+    if (!match) throw new Error("Git tree inventory has invalid object metadata");
+    const pathBytes = record.subarray(tab + 1);
+    const path = decodeGitUtf8(pathBytes, "Git tree path");
+    assertGitPath(path, pathBytes.byteLength);
+    entries.push({ mode: match[1] ?? "", type: match[2] ?? "", oid: match[3] ?? "", path });
+  }
+  return entries;
+}
+
+function assertRegularGitBlob(entry: GitTreeEntry): asserts entry is GitTreeEntry & {
+  mode: "100644" | "100755";
+  type: "blob";
+} {
+  if (entry.mode === "120000") {
+    throw new Error(`${entry.path} is a forbidden symlink in the Git tree`);
+  }
+  if (entry.type !== "blob" || (entry.mode !== "100644" && entry.mode !== "100755")) {
+    throw new Error(`${entry.path} is not a regular Git blob`);
+  }
+}
+
+async function resolveGitTree(root: string, revision: string): Promise<string> {
+  const revisionBytes = new TextEncoder().encode(revision).byteLength;
+  if (
+    revisionBytes === 0 ||
+    revisionBytes > WORKFLOW_GRAPH_LIMITS.maxGitRevisionBytes ||
+    /[\u0000\r\n]/u.test(revision)
+  ) {
+    throw new Error("Git tree revision is invalid");
+  }
+  const output = await runBoundedGit(
+    root,
+    ["rev-parse", "--verify", "--end-of-options", revision],
+    "Git tree resolution",
+    128,
+  );
+  const oid = decodeGitUtf8(output, "Git tree resolution").trim();
+  if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u.test(oid)) {
+    throw new Error("Git tree resolution returned an invalid object identity");
+  }
+  const type = decodeGitUtf8(
+    await runBoundedGit(root, ["cat-file", "-t", oid], "Git tree type check", 32),
+    "Git tree type check",
+  ).trim();
+  if (type !== "tree") throw new Error("Git tree revision did not resolve to a tree");
+  return oid;
+}
+
+async function listGitTreeDirectory(
+  root: string,
+  treeOid: string,
+  path: ".github/workflows" | ".github/actions",
+  recursive: boolean,
+): Promise<readonly GitTreeEntry[]> {
+  const args = recursive
+    ? ["ls-tree", "-rtz", "--full-tree", `${treeOid}:${path}`]
+    : ["ls-tree", "-z", `${treeOid}:${path}`];
+  return parseGitTreeEntries(await runBoundedGit(root, args, `${path} Git tree inventory`));
+}
+
+async function gitTreeGraphEntries(
+  root: string,
+  treeOid: string,
+): Promise<readonly GitTreeEntry[]> {
+  const workflowEntries = await listGitTreeDirectory(root, treeOid, ".github/workflows", false);
+  if (workflowEntries.length > WORKFLOW_GRAPH_LIMITS.maxWorkflowDiscoveryEntries) {
+    throw new Error("workflow Git tree discovery exceeds the directory-entry limit");
+  }
+  const selected: GitTreeEntry[] = [];
+  for (const entry of workflowEntries) {
+    const path = `.github/workflows/${entry.path}`;
+    const identified = { ...entry, path };
+    assertGitPath(path, new TextEncoder().encode(path).byteLength);
+    assertRegularGitBlob(identified);
+    if (/\.ya?ml$/u.test(entry.path)) selected.push(identified);
+  }
+
+  const actionEntries = await listGitTreeDirectory(root, treeOid, ".github/actions", true);
+  if (actionEntries.length > WORKFLOW_GRAPH_LIMITS.maxActionDiscoveryEntries) {
+    throw new Error("action Git tree discovery exceeds the directory-entry limit");
+  }
+  const actionDefinitions = new Map<string, GitTreeEntry[]>();
+  for (const entry of actionEntries) {
+    const components = entry.path.split("/");
+    const depth = entry.type === "tree" ? components.length : components.length - 1;
+    if (depth > WORKFLOW_GRAPH_LIMITS.maxActionDiscoveryDepth) {
+      throw new Error("action Git tree discovery exceeds the directory-depth limit");
+    }
+    const path = `.github/actions/${entry.path}`;
+    const identified = { ...entry, path };
+    assertGitPath(path, new TextEncoder().encode(path).byteLength);
+    if (entry.type === "tree" && entry.mode === "040000") continue;
+    assertRegularGitBlob(identified);
+    if (!/^action\.ya?ml$/u.test(components.at(-1) ?? "")) continue;
+    const parent = posix.dirname(path);
+    const definitions = actionDefinitions.get(parent) ?? [];
+    definitions.push(identified);
+    actionDefinitions.set(parent, definitions);
+  }
+  for (const definitions of actionDefinitions.values()) {
+    if (definitions.length !== 1) {
+      throw new Error("Git tree action discovery found ambiguous action definitions");
+    }
+    selected.push(definitions[0] as GitTreeEntry);
+  }
+  if (selected.length > WORKFLOW_GRAPH_LIMITS.maxSources) {
+    throw new Error("workflow execution graph exceeds the source-count limit in the Git tree");
+  }
+  const paths = new Set<string>();
+  for (const entry of selected) {
+    if (paths.has(entry.path))
+      throw new Error("Git tree inventory contains a duplicate source path");
+    paths.add(entry.path);
+  }
+  return selected.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+async function gitTreeManifestEntry(root: string, treeOid: string): Promise<GitTreeEntry> {
+  const entries = parseGitTreeEntries(
+    await runBoundedGit(
+      root,
+      ["ls-tree", "-z", "--full-tree", treeOid, "--", GRAPH_MANIFEST_PATH],
+      "workflow graph manifest Git tree lookup",
+    ),
+  );
+  if (entries.length !== 1 || entries[0]?.path !== GRAPH_MANIFEST_PATH) {
+    throw new Error("workflow graph manifest is missing or ambiguous in the Git tree");
+  }
+  const entry = entries[0];
+  assertRegularGitBlob(entry);
+  return entry;
+}
+
+async function preflightGitBlobs(
+  root: string,
+  entries: readonly GitTreeEntry[],
+): Promise<readonly GitBlobSource[]> {
+  const input = `${entries.map((entry) => entry.oid).join("\n")}\n`;
+  const output = decodeGitUtf8(
+    await runBoundedGit(
+      root,
+      ["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
+      "Git blob preflight",
+      Math.min(WORKFLOW_GRAPH_LIMITS.maxGitProtocolBytes, entries.length * 160),
+      input,
+    ),
+    "Git blob preflight",
+  );
+  const rows = output.endsWith("\n") ? output.slice(0, -1).split("\n") : [];
+  if (rows.length !== entries.length)
+    throw new Error("Git blob preflight returned an invalid count");
+  let totalBytes = 0;
+  const sources: GitBlobSource[] = [];
+  for (const [index, entry] of entries.entries()) {
+    assertRegularGitBlob(entry);
+    const match = /^([0-9a-f]{40}|[0-9a-f]{64}) blob ([0-9]+)$/u.exec(rows[index] ?? "");
+    if (!match || match[1] !== entry.oid) {
+      throw new Error(`${entry.path} failed Git blob identity preflight`);
+    }
+    const bytes = Number(match[2]);
+    if (!Number.isSafeInteger(bytes) || bytes < 0) {
+      throw new Error(`${entry.path} has an invalid Git blob size`);
+    }
+    if (bytes > WORKFLOW_GRAPH_LIMITS.maxSourceBytes) {
+      throw new Error(`${entry.path} exceeds the per-source UTF-8 byte limit`);
+    }
+    totalBytes += bytes;
+    if (totalBytes > WORKFLOW_GRAPH_LIMITS.maxTotalSourceBytes) {
+      throw new Error("workflow execution Git tree exceeds the total UTF-8 byte limit");
+    }
+    sources.push({ path: entry.path, mode: entry.mode, oid: entry.oid, bytes });
+  }
+  return sources;
+}
+
+function gitBlobIdentity(bytes: Uint8Array, oidLength: number): string {
+  const algorithm = oidLength === 64 ? "sha256" : "sha1";
+  const hash = createHash(algorithm);
+  hash.update(`blob ${bytes.byteLength}\0`, "utf8");
+  hash.update(bytes);
+  return hash.digest("hex");
+}
+
+async function readGitBlob(root: string, source: GitBlobSource): Promise<string> {
+  const bytes = await runBoundedGit(
+    root,
+    ["cat-file", "blob", source.oid],
+    `${source.path} Git blob read`,
+    source.bytes + 1,
+  );
+  if (
+    bytes.byteLength !== source.bytes ||
+    gitBlobIdentity(bytes, source.oid.length) !== source.oid
+  ) {
+    throw new Error(`${source.path} failed Git blob length or identity verification`);
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error(`${source.path} contains invalid UTF-8`);
+  }
+}
+
+async function loadWorkflowExecutionGitTree(
+  root: string,
+  treeOid: string,
+  hooks: WorkflowGitTreeLoaderHooks,
+): Promise<Readonly<{ sources: Record<string, string>; committedManifest: unknown }>> {
+  const graphEntries = await gitTreeGraphEntries(root, treeOid);
+  const manifestEntry = await gitTreeManifestEntry(root, treeOid);
+  const blobs = await preflightGitBlobs(root, [...graphEntries, manifestEntry]);
+  await hooks.afterBlobPreflight?.(blobs.map(({ path, bytes }) => ({ path, bytes })));
+  const sources: Array<readonly [string, string]> = [];
+  let manifestSource: string | undefined;
+  for (const blob of blobs) {
+    await hooks.beforeBlobRead?.(blob.path);
+    const source = await readGitBlob(root, blob);
+    if (blob.path === GRAPH_MANIFEST_PATH) manifestSource = source;
+    else sources.push([blob.path, source]);
+  }
+  let committedManifest: unknown;
+  try {
+    committedManifest = JSON.parse(manifestSource ?? "");
+  } catch {
+    throw new Error("workflow graph manifest is malformed in the Git tree");
+  }
+  return { sources: Object.fromEntries(sources), committedManifest };
+}
+
+function compareRows(
+  kind: string,
+  committed: readonly GraphDigestRecord[],
+  current: readonly GraphDigestRecord[],
+): string[] {
+  const violations: string[] = [];
+  const committedMap = new Map<string, string>();
+  for (const row of committed) {
+    if (committedMap.has(row.path)) violations.push(`manifest duplicates ${kind} ${row.path}`);
+    committedMap.set(row.path, row.sha256);
+  }
+  const currentMap = new Map(current.map((row) => [row.path, row.sha256]));
+  for (const [path, digest] of currentMap) {
+    if (!committedMap.has(path)) violations.push(`manifest is missing ${kind} ${path}`);
+    else if (committedMap.get(path) !== digest)
+      violations.push(`${kind} digest changed for ${path}`);
+  }
+  for (const path of committedMap.keys()) {
+    if (!currentMap.has(path)) violations.push(`manifest has stale ${kind} ${path}`);
+  }
+  return violations;
+}
+
+function compareRuns(
+  committed: readonly UncappedRunRecord[],
+  current: readonly UncappedRunRecord[],
+): string[] {
+  const violations: string[] = [];
+  const committedMap = new Map<string, string>();
+  for (const row of committed) {
+    const identity = runIdentity(row);
+    if (committedMap.has(identity)) {
+      violations.push(`manifest duplicates uncapped run ${row.workflow}:${row.job}:${row.step}`);
+    }
+    committedMap.set(identity, row.sha256);
+  }
+  const currentMap = new Map(current.map((row) => [runIdentity(row), row]));
+  for (const [identity, row] of currentMap) {
+    const digest = committedMap.get(identity);
+    if (digest === undefined) {
+      violations.push(`manifest is missing uncapped run ${row.workflow}:${row.job}:${row.step}`);
+    } else if (digest !== row.sha256) {
+      violations.push(`uncapped run digest changed for ${row.workflow}:${row.job}:${row.step}`);
+    }
+  }
+  for (const row of committed) {
+    if (!currentMap.has(runIdentity(row))) {
+      violations.push(`manifest has stale uncapped run ${row.workflow}:${row.job}:${row.step}`);
+    }
+  }
+  return violations;
+}
+
+function manifestShape(value: unknown): value is WorkflowExecutionGraphManifest {
+  if (!isObject(value)) return false;
+  const hasOnlyKeys = (candidate: YamlObject, expected: readonly string[]) =>
+    Object.keys(candidate).sort().join("\0") === [...expected].sort().join("\0");
+  const isDigest = (candidate: unknown): candidate is GraphDigestRecord =>
+    isObject(candidate) &&
+    hasOnlyKeys(candidate, ["path", "sha256"]) &&
+    typeof candidate.path === "string" &&
+    /^[0-9a-f]{64}$/u.test(String(candidate.sha256));
+  const isRun = (candidate: unknown): candidate is UncappedRunRecord =>
+    isObject(candidate) &&
+    hasOnlyKeys(candidate, ["workflow", "job", "step", "sha256"]) &&
+    typeof candidate.workflow === "string" &&
+    typeof candidate.job === "string" &&
+    typeof candidate.step === "string" &&
+    /^[0-9a-f]{64}$/u.test(String(candidate.sha256));
+  const isGenerated = (candidate: unknown): candidate is GeneratedLocalTargetRecord =>
+    isObject(candidate) &&
+    hasOnlyKeys(candidate, ["workflow", "job", "step", "target", "authority"]) &&
+    typeof candidate.workflow === "string" &&
+    typeof candidate.job === "string" &&
+    typeof candidate.step === "string" &&
+    typeof candidate.target === "string" &&
+    candidate.authority === "retained-release-controller";
+  return (
+    hasOnlyKeys(value, [
+      "schemaVersion",
+      "domain",
+      "canonicalization",
+      "hashAlgorithm",
+      "workflows",
+      "actions",
+      "generatedLocalTargets",
+      "uncappedRuns",
+    ]) &&
+    value.schemaVersion === GRAPH_SCHEMA_VERSION &&
+    value.domain === GRAPH_DOMAIN &&
+    value.canonicalization === GRAPH_CANONICALIZATION &&
+    value.hashAlgorithm === "sha256" &&
+    Array.isArray(value.workflows) &&
+    value.workflows.every(isDigest) &&
+    Array.isArray(value.actions) &&
+    value.actions.every(isDigest) &&
+    Array.isArray(value.generatedLocalTargets) &&
+    value.generatedLocalTargets.every(isGenerated) &&
+    Array.isArray(value.uncappedRuns) &&
+    value.uncappedRuns.every(isRun)
+  );
+}
+
+export function compareWorkflowExecutionManifest(
+  committedValue: unknown,
+  current: WorkflowExecutionGraphManifest,
+): readonly string[] {
+  if (!manifestShape(committedValue)) return ["workflow execution manifest has an invalid shape"];
+  const committed = committedValue;
+  const violations = [
+    ...compareRows("workflow", committed.workflows, current.workflows),
+    ...compareRows("action", committed.actions, current.actions),
+    ...compareRuns(committed.uncappedRuns, current.uncappedRuns),
+  ];
+  const committedGenerated = committed.generatedLocalTargets.map(generatedIdentity).sort();
+  const currentGenerated = current.generatedLocalTargets.map(generatedIdentity).sort();
+  if (new Set(committedGenerated).size !== committedGenerated.length) {
+    violations.push("manifest duplicates a generated local target classification");
+  }
+  if (canonicalJson(committedGenerated) !== canonicalJson(currentGenerated)) {
+    violations.push("generated local target classifications changed");
+  }
+  return violations;
+}
+
+export async function inspectWorkflowExecutionGitTreeRepository(
+  root: string,
+  revision: string,
+  hooks: WorkflowGitTreeLoaderHooks = {},
+): Promise<WorkflowGitTreeInspection> {
+  const treeOid = await resolveGitTree(root, revision);
+  await hooks.afterTreeCapture?.(treeOid);
+  const loaded = await loadWorkflowExecutionGitTree(root, treeOid, hooks);
+  const inspection = inspectWorkflowExecutionSources(loaded.sources);
+  return {
+    treeOid,
+    inspection,
+    manifestViolations: compareWorkflowExecutionManifest(
+      loaded.committedManifest,
+      inspection.manifest,
+    ),
+  };
+}
+
+export async function inspectWorkflowExecutionRepository(
+  root: string,
+): Promise<WorkflowExecutionGraphInspection> {
+  return inspectWorkflowExecutionSources(await loadWorkflowExecutionSources(root));
+}
+
+async function main(): Promise<void> {
+  const root = resolve(import.meta.dir, "..");
+  const arguments_ = process.argv.slice(2);
+  const gitTreeIndex = arguments_.indexOf("--git-tree");
+  if (gitTreeIndex !== -1) {
+    if (
+      arguments_.includes("--write") ||
+      gitTreeIndex !== 0 ||
+      arguments_.length !== 2 ||
+      !arguments_[1]
+    ) {
+      console.error(
+        "workflow graph: --git-tree requires one revision and is incompatible with --write",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    let checked: WorkflowGitTreeInspection;
+    try {
+      checked = await inspectWorkflowExecutionGitTreeRepository(root, arguments_[1]);
+    } catch (error) {
+      console.error(
+        `workflow graph: ${error instanceof Error ? error.message : "Git-tree inspection failed"}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    const violations = [...checked.inspection.violations, ...checked.manifestViolations];
+    if (violations.length > 0) {
+      for (const violation of violations) console.error(`workflow graph: ${violation}`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(
+      `verified ${checked.inspection.manifest.workflows.length} workflows, ${checked.inspection.manifest.actions.length} actions, and ${checked.inspection.manifest.uncappedRuns.length} uncapped runs from Git tree ${checked.treeOid}`,
+    );
+    return;
+  }
+  const inspection = await inspectWorkflowExecutionRepository(root);
+  if (inspection.violations.length > 0) {
+    for (const violation of inspection.violations) console.error(`workflow graph: ${violation}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (process.argv.includes("--write")) {
+    await writeFile(
+      resolve(root, GRAPH_MANIFEST_PATH),
+      `${JSON.stringify(inspection.manifest, null, 2)}\n`,
+    );
+    console.log(
+      `wrote ${inspection.manifest.workflows.length} workflows, ${inspection.manifest.actions.length} actions, and ${inspection.manifest.uncappedRuns.length} uncapped runs`,
+    );
+    return;
+  }
+  let committed: unknown;
+  try {
+    committed = JSON.parse(await readFile(resolve(root, GRAPH_MANIFEST_PATH), "utf8"));
+  } catch {
+    console.error("workflow graph: manifest is missing or malformed");
+    process.exitCode = 1;
+    return;
+  }
+  const violations = compareWorkflowExecutionManifest(committed, inspection.manifest);
+  if (violations.length > 0) {
+    for (const violation of violations) console.error(`workflow graph: ${violation}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `verified ${inspection.manifest.workflows.length} workflows, ${inspection.manifest.actions.length} actions, and ${inspection.manifest.uncappedRuns.length} uncapped runs`,
+  );
+}
+
+if (import.meta.main) await main();

--- a/scripts/workflow-timeout-contract.test.ts
+++ b/scripts/workflow-timeout-contract.test.ts
@@ -1,191 +1,207 @@
 import { describe, expect, test } from "bun:test";
 import { chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 
 const root = resolve(import.meta.dir, "..");
 const workflowDir = resolve(root, ".github/workflows");
+const playwrightActionPath = resolve(root, ".github/actions/playwright-browsers/action.yml");
+const PLAYWRIGHT_ACTION = "./.github/actions/playwright-browsers";
+const MAX_JOB_TIMEOUT_MINUTES = 120;
 
-// GitHub's default job timeout is 360 minutes. A job that wedges - the observed
-// case is an unbounded `playwright install` whose download stalls - therefore
-// holds a runner slot for six hours. Because GitHub-hosted concurrency is an
-// account-level pool, a handful of wedged jobs stop every other pull request in
-// the repository from being dispatched at all. Every job must bound itself so a
-// hang degrades to one visible, re-runnable failure instead of a repo outage.
-const MAX_TIMEOUT_MINUTES = 120;
-
+type Step = Readonly<{
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Readonly<Record<string, unknown>>;
+  "timeout-minutes"?: unknown;
+}>;
 type Job = Readonly<{
   uses?: string;
-  "timeout-minutes"?: number;
+  steps?: readonly Step[];
+  "timeout-minutes"?: unknown;
 }>;
+type Workflow = Readonly<{ jobs?: Readonly<Record<string, Job>> }>;
 
-type Step = Readonly<{ run?: string; uses?: string }>;
+const EXPECTED_CAPS = [
+  ["ci.yml", "plan", "Install exact dependency tree", 11, "run"],
+  ["ci.yml", "source-contracts", "Profile impacted TypeScript 7 projects", 11, "run"],
+  ["ci.yml", "source-contracts", "Run exactly the explained source guards", 16, "run"],
+  ["ci.yml", "unit-shards", "Unit test shard", 21, "run"],
+  [
+    "ci.yml",
+    "integration-shards",
+    "Run real PostgreSQL, pgvector, Temporal, NATS, and object-storage tests",
+    31,
+    "run",
+  ],
+  ["ci.yml", "e2e-shards", "Run exactly the impacted E2E tests", 13, "run"],
+  ["ci.yml", "package-contracts", "Build client packages (contracts + SDK + React)", 21, "run"],
+  ["ci.yml", "test-suite", "Real workspace capture acceptance", 13, "run"],
+  ["ci.yml", "test-suite", "Recovery integration regressions", 5, "run"],
+  ["ci.yml", "browser-acceptance", "Session pin browser acceptance", 4, "run"],
+  ["ci.yml", "browser-acceptance", "Responsive knowledge surfaces browser acceptance", 6, "run"],
+  ["ci.yml", "browser-acceptance", "Workbench browser acceptance", 4, "run"],
+  ["desktop-e2e.yml", "desktop-image", "Desktop image e2e", 36, "run"],
+  ["ci.yml", "e2e-shards", "Install pinned browser runtimes", 17, "action"],
+  ["ci.yml", "browser-acceptance", "Install pinned lane browser runtimes", 17, "action"],
+  ["ci.yml", "package-contracts", "Install Chromium for packed WASM package proof", 17, "action"],
+] as const;
 
-async function workflowFiles(): Promise<readonly string[]> {
-  const entries = await readdir(workflowDir);
-  return entries.filter((entry) => entry.endsWith(".yml") || entry.endsWith(".yaml")).sort();
+const EXPECTED_JOB_BUDGETS = {
+  "ci.yml:plan": { stepCaps: 11, needed: 12, jobCap: 15 },
+  "ci.yml:source-contracts": { stepCaps: 27, needed: 28, jobCap: 35 },
+  "ci.yml:unit-shards": { stepCaps: 21, needed: 22, jobCap: 30 },
+  "ci.yml:integration-shards": { stepCaps: 31, needed: 32, jobCap: 40 },
+  "ci.yml:e2e-shards": { stepCaps: 30, needed: 31, jobCap: 35 },
+  "ci.yml:test-suite": { stepCaps: 18, needed: 19, jobCap: 30 },
+  "ci.yml:browser-acceptance": { stepCaps: 31, needed: 32, jobCap: 35 },
+  "ci.yml:package-contracts": { stepCaps: 38, needed: 39, jobCap: 55 },
+  "desktop-e2e.yml:desktop-image": { stepCaps: 36, needed: 37, jobCap: 45 },
+} as const;
+
+async function loadWorkflows(): Promise<Record<string, Workflow>> {
+  const files = (await readdir(workflowDir)).filter((entry) => /\.ya?ml$/u.test(entry)).sort();
+  return Object.fromEntries(
+    await Promise.all(
+      files.map(async (file) => [
+        file,
+        Bun.YAML.parse(await readFile(resolve(workflowDir, file), "utf8")) as Workflow,
+      ]),
+    ),
+  );
+}
+
+function numericCap(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : null;
 }
 
 describe("workflow timeout contract", () => {
-  test("every job bounds itself well below the 360-minute GitHub default", async () => {
-    const files = await workflowFiles();
-    expect(files.length).toBeGreaterThan(0);
-
+  test("all jobs and the exact 13 run plus 3 action steps use static native caps", async () => {
+    const workflows = await loadWorkflows();
+    const capped: Array<readonly [string, string, string, number, "run" | "action"]> = [];
+    const budgets: Record<string, { stepCaps: number; needed: number; jobCap: number }> = {};
     const violations: string[] = [];
-    for (const file of files) {
-      const parsed = Bun.YAML.parse(await readFile(resolve(workflowDir, file), "utf8")) as {
-        jobs?: Record<string, Job>;
-      };
-      for (const [name, job] of Object.entries(parsed.jobs ?? {})) {
-        // A reusable-workflow call cannot carry timeout-minutes; the called
-        // workflow's own jobs are covered by this same test.
-        if (job?.uses) continue;
-        const timeout = job?.["timeout-minutes"];
-        if (typeof timeout !== "number") {
-          violations.push(`${file}:${name} has no timeout-minutes`);
+
+    for (const [file, workflow] of Object.entries(workflows)) {
+      for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+        if (job.uses) continue;
+        const jobCap = numericCap(job["timeout-minutes"]);
+        if (jobCap === null || jobCap > MAX_JOB_TIMEOUT_MINUTES) {
+          violations.push(`${file}:${jobName} has an invalid job cap`);
           continue;
         }
-        if (timeout <= 0 || timeout > MAX_TIMEOUT_MINUTES) {
-          violations.push(
-            `${file}:${name} has timeout-minutes ${timeout}, outside 1..${MAX_TIMEOUT_MINUTES}`,
-          );
-        }
-      }
-    }
-    expect(violations).toEqual([]);
-  });
-
-  test("every Playwright install is bounded and cached through the shared action", async () => {
-    const files = await workflowFiles();
-    const inlineInstalls: string[] = [];
-    for (const file of files) {
-      const source = await readFile(resolve(workflowDir, file), "utf8");
-      if (source.includes("playwright install")) {
-        inlineInstalls.push(file);
-      }
-    }
-    // An inline `playwright install` is unbounded: it has no per-attempt wall
-    // clock and no browser cache, which is exactly the wedge this guards.
-    expect(inlineInstalls).toEqual([]);
-
-    const action = await readFile(
-      resolve(root, ".github/actions/playwright-browsers/action.yml"),
-      "utf8",
-    );
-    expect(action).toContain("timeout --kill-after=15s");
-    expect(action).toContain("path: ~/.cache/ms-playwright");
-    // `--with-deps` was previously locked by the four inline call sites. Moving
-    // the command into one shared place removed that lock, so re-assert it here.
-    expect(action).toContain("playwright install --with-deps");
-    // actions/cache's post step is `post-if: success()`, so the combined action
-    // never saves after a bounded failure and a cold key on a degraded network
-    // can never converge. The split restore/save with always() is what makes a
-    // timed-out install genuinely re-runnable.
-    expect(action).toContain("actions/cache/restore@");
-    expect(action).toContain("actions/cache/save@");
-    expect(action).toMatch(
-      /if: \$\{\{ always\(\) && steps\.restore\.outputs\.cache-hit != 'true' \}\}/u,
-    );
-  });
-
-  // A job cap below the job's own declared step budgets is worse than no cap:
-  // the job is CANCELLED rather than failed, and `if: failure()` artifact
-  // uploads do not run on cancellation, so the diagnostics that explain the
-  // hang are destroyed exactly when they are needed.
-  test("no job cap sits below its own declared inner step budgets", async () => {
-    const installBoundMinutes = await (async () => {
-      const action = Bun.YAML.parse(
-        await readFile(resolve(root, ".github/actions/playwright-browsers/action.yml"), "utf8"),
-      ) as { inputs: Record<string, { default?: string }> };
-      const perAttempt = Number(action.inputs["attempt-timeout-seconds"]?.default);
-      const attempts = Number(action.inputs.attempts?.default);
-      expect(Number.isFinite(perAttempt) && Number.isFinite(attempts)).toBe(true);
-      // 15s is the SIGKILL grace in `timeout --kill-after=15s`.
-      return ((perAttempt + 15) * attempts) / 60;
-    })();
-
-    const violations: string[] = [];
-    for (const file of await workflowFiles()) {
-      const parsed = Bun.YAML.parse(await readFile(resolve(workflowDir, file), "utf8")) as {
-        jobs?: Record<
-          string,
-          { uses?: string; "timeout-minutes"?: number; steps?: readonly Step[] }
-        >;
-      };
-      for (const [name, job] of Object.entries(parsed.jobs ?? {})) {
-        if (job?.uses) continue;
-        const cap = job?.["timeout-minutes"];
-        if (typeof cap !== "number") continue;
-        let inner = 0;
-        let usesBoundedInstall = false;
+        let stepCaps = 0;
         for (const step of job.steps ?? []) {
-          const run = String(step.run ?? "");
-          for (const m of run.matchAll(/--timeout-seconds\s+(\d+)/gu)) inner += Number(m[1]) / 60;
-          for (const m of run.matchAll(/--timeout\s+(\d{5,})/gu)) inner += Number(m[1]) / 60_000;
-          if (String(step.uses ?? "").includes("playwright-browsers")) usesBoundedInstall = true;
+          const cap = numericCap(step["timeout-minutes"]);
+          if (step["timeout-minutes"] !== undefined && cap === null) {
+            violations.push(`${file}:${jobName}:${step.name ?? "unnamed"} has an invalid step cap`);
+          }
+          if (cap === null) continue;
+          stepCaps += cap;
+          const kind = step.run ? "run" : step.uses === PLAYWRIGHT_ACTION ? "action" : null;
+          if (!kind || !step.name) {
+            violations.push(`${file}:${jobName} has a capped step outside the approved corpus`);
+          } else {
+            capped.push([file, jobName, step.name, cap, kind]);
+          }
         }
-        // A job using the bounded install must be checked even with no declared
-        // inner budget, or a browser lane with a small cap and no test budget is
-        // endorsed despite being guaranteed to cancel mid-install.
-        if (inner === 0 && !usesBoundedInstall) continue;
-        // 1 minute covers checkout + toolchain + dependency install.
-        const needed = 1 + inner + (usesBoundedInstall ? installBoundMinutes : 0);
-        if (cap < needed) {
-          violations.push(
-            `${file}:${name} cap ${cap}m is below its own budgets (${needed.toFixed(1)}m needed)`,
-          );
-        }
+        budgets[`${file}:${jobName}`] = { stepCaps, needed: stepCaps + 1, jobCap };
+        if (jobCap < stepCaps + 1) violations.push(`${file}:${jobName} cap is below native steps`);
       }
     }
+
     expect(violations).toEqual([]);
+    const byIdentity = (
+      left: readonly [string, string, string, number, "run" | "action"],
+      right: readonly [string, string, string, number, "run" | "action"],
+    ) => left.slice(0, 3).join("\0").localeCompare(right.slice(0, 3).join("\0"));
+    expect(capped.toSorted(byIdentity)).toEqual(EXPECTED_CAPS.toSorted(byIdentity));
+    expect(capped.filter((row) => row[4] === "run")).toHaveLength(13);
+    expect(capped.filter((row) => row[4] === "action")).toHaveLength(3);
+    for (const [job, expected] of Object.entries(EXPECTED_JOB_BUDGETS)) {
+      expect(budgets[job], job).toEqual(expected);
+    }
   });
 
-  // The runner executes `shell: bash` steps as
-  // `bash --noprofile --norc -eo pipefail {0}`. That errexit is applied by the
-  // runner and is NOT cleared by a `set -uo pipefail` inside the script, so a
-  // retry loop written without an explicit guard silently becomes one attempt
-  // with no diagnostic output. Assert the real behaviour by running the real
-  // script under the real shell rather than trusting a plain `bash script.sh`.
-  test("the install retry loop survives the runner's errexit shell", async () => {
-    const action = Bun.YAML.parse(
-      await readFile(resolve(root, ".github/actions/playwright-browsers/action.yml"), "utf8"),
-    ) as { runs: { steps: readonly { name?: string; run?: string }[] } };
+  test("the consolidated browser lane and Playwright runtime budget stay structurally bound", async () => {
+    const workflows = await loadWorkflows();
+    const callers = Object.entries(workflows).flatMap(([file, workflow]) =>
+      Object.entries(workflow.jobs ?? {}).flatMap(([job, definition]) =>
+        (definition.steps ?? [])
+          .filter((step) => step.uses === PLAYWRIGHT_ACTION)
+          .map((step) => ({ file, job, step })),
+      ),
+    );
+    expect(callers).toHaveLength(3);
+    expect(callers.find(({ job }) => job === "browser-acceptance")?.step.with?.browsers).toBe(
+      "${{ matrix.lane == 'workbench' && 'chromium firefox webkit' || 'chromium' }}",
+    );
+
+    const action = Bun.YAML.parse(await readFile(playwrightActionPath, "utf8")) as {
+      inputs: Record<string, { default?: unknown }>;
+      runs: { steps: Array<{ name?: string; env?: Record<string, unknown>; run?: string }> };
+    };
+    const install = action.runs.steps.find(
+      (step) => step.name === "Install pinned Playwright browsers",
+    );
+    expect(install?.env).toMatchObject({
+      ATTEMPT_TIMEOUT_SECONDS: "${{ inputs.attempt-timeout-seconds }}",
+      ATTEMPTS: "${{ inputs.attempts }}",
+      KILL_AFTER_SECONDS: "15",
+    });
+    const command = String(install?.run ?? "").replace(/\\\r?\n\s*/gu, " ");
+    expect(command).toContain(
+      'timeout --kill-after="${KILL_AFTER_SECONDS}s" "${ATTEMPT_TIMEOUT_SECONDS}s"',
+    );
+    const duration = Number(action.inputs["attempt-timeout-seconds"]?.default);
+    const attempts = Number(action.inputs.attempts?.default);
+    expect(((duration + 15) * attempts) / 60).toBeLessThanOrEqual(17);
+  });
+
+  test("Playwright retry, cache, and dirlock cleanup behavior stays intact", async () => {
+    for (const file of Object.keys(await loadWorkflows())) {
+      expect(await readFile(resolve(workflowDir, file), "utf8")).not.toContain(
+        "playwright install",
+      );
+    }
+    const actionSource = await readFile(playwrightActionPath, "utf8");
+    expect(actionSource).toContain("playwright install --with-deps");
+    expect(actionSource).toContain("actions/cache/restore@");
+    expect(actionSource).toContain("actions/cache/save@");
+    expect(actionSource).toContain("rm -rf ~/.cache/ms-playwright/__dirlock");
+
+    const action = Bun.YAML.parse(actionSource) as {
+      runs: { steps: Array<{ name?: string; run?: string }> };
+    };
     const script = action.runs.steps.find(
       (step) => step.name === "Install pinned Playwright browsers",
     )?.run;
     expect(typeof script).toBe("string");
-
     const dir = await mkdtemp(join(tmpdir(), "playwright-install-contract-"));
     try {
       const scriptPath = join(dir, "install.sh");
       const binDir = join(dir, "bin");
       await mkdir(binDir);
       await writeFile(scriptPath, script as string);
-      // `timeout` is GNU-only; stub it so this test runs on any host. The stub
-      // drops the flags and duration, then execs the command.
-      const timeoutStub = [
-        "#!/bin/bash",
-        'while [[ "$1" == --* ]]; do shift; done',
-        "shift",
-        '"$@"',
-        "",
-      ].join("\n");
-      await writeFile(join(binDir, "timeout"), timeoutStub);
-      // Fail every attempt with 124, the exit code GNU timeout uses on expiry.
+      await writeFile(
+        join(binDir, "timeout"),
+        ["#!/bin/bash", 'while [[ "$1" == --* ]]; do shift; done', "shift", '"$@"', ""].join("\n"),
+      );
       const counter = join(dir, "n");
-      const bunStub = [
-        "#!/bin/bash",
-        `n=$(cat ${counter} 2>/dev/null || echo 0)`,
-        "n=$((n+1))",
-        `echo "$n" > ${counter}`,
-        "exit 124",
-        "",
-      ].join("\n");
-      await writeFile(join(binDir, "bun"), bunStub);
+      await writeFile(
+        join(binDir, "bun"),
+        [
+          "#!/bin/bash",
+          `n=$(cat ${counter} 2>/dev/null || echo 0)`,
+          "n=$((n+1))",
+          `echo "$n" > ${counter}`,
+          "exit 124",
+          "",
+        ].join("\n"),
+      );
       await chmod(join(binDir, "timeout"), 0o755);
       await chmod(join(binDir, "bun"), 0o755);
-
       const proc = Bun.spawn(["bash", "--noprofile", "--norc", "-eo", "pipefail", scriptPath], {
         env: {
           ...process.env,
@@ -194,20 +210,17 @@ describe("workflow timeout contract", () => {
           PLAYWRIGHT_ONLY_SHELL: "false",
           ATTEMPT_TIMEOUT_SECONDS: "360",
           ATTEMPTS: "2",
+          KILL_AFTER_SECONDS: "15",
         },
         stdout: "pipe",
         stderr: "pipe",
       });
       const stdout = await new Response(proc.stdout).text();
       expect(await proc.exited).toBe(1);
-
-      // Both attempts must actually run.
-      expect((await readFile(join(dir, "n"), "utf8")).trim()).toBe("2");
-      // And the operator must be told what the bound was, not just "exit 124".
+      expect(await readFile(counter, "utf8")).toBe("2\n");
       expect(stdout).toContain("attempt 1/2");
       expect(stdout).toContain("attempt 2/2");
       expect(stdout).toContain("exceeded 360s and was killed");
-      expect(stdout).toContain("::error::");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- port the approved workflow execution graph manifest, native step caps, and Playwright budget wiring from closed PR #1667 onto current main
- verify the CI workflow graph from one immutable bounded Git tree before lifecycle-enabled dependency installation
- disable Git replacement objects for every revision, inventory, preflight, blob, and manifest plumbing invocation
- prove replacement refs cannot substitute workflow, action, or manifest bytes while ordinary Git observes those replacements

## Validation

- `bun install --frozen-lockfile`
- `bun test scripts/workflow-execution-graph.test.ts` (29 pass, 669 assertions)
- focused timeout, release automation, and artifact workflow contracts (89 pass, 571 assertions)
- `bun test scripts/` (666 pass, 1 intentional skip, 5164 assertions)
- `bun run typecheck` (31 projects)
- `bun run lint`
- `bun run format:check`
- `bun run check:public-hygiene`
- `git diff --check`
- graph CLI in worktree and committed Git-tree modes (21 workflows, 2 actions, 197 uncapped runs)

Replaces closed PR #1667.