### PR TITLE
fix(web): identify the active organization (OPE-205)

### DIFF
--- a/apps/web/src/components/rail/switcher-block.tsx
+++ b/apps/web/src/components/rail/switcher-block.tsx
@@ -31,31 +31,28 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAppContext } from "@/context";
 import { useRail } from "@/components/rail/rail-context";
-import { organizationsForSubject, workspacesInOrg } from "@/lib/org";
+import {
+  organizationsForSubject,
+  shortAccountId,
+  workspacesInOrg,
+  type OrgOption,
+} from "@/lib/org";
 import { isPersonalWorkspace, type ManagedSelfContext } from "@/lib/managed-self-context";
 import { workspaceCreationAccountId } from "@/lib/workspaces";
-import type { AccountGrant, Workspace } from "@/types";
+import type { Workspace } from "@/types";
 
 function workspaceInitial(workspace: Workspace | null): string {
   return (workspace?.name.trim()[0] ?? "W").toUpperCase();
 }
 
-/**
- * The org's human name if the access grant carries one, else null. The
- * always-visible switcher line prefers this and falls back to a generic
- * "Organization" — never a raw account id (the id stays available in the
- * org-switch menu and settings, which keep `orgLabel`'s id fallback).
- */
-function orgDisplayName(accountId: string | null, grants: AccountGrant[]): string | null {
-  if (!accountId) {
-    return null;
+function activeOrganizationLabel(orgs: OrgOption[], activeAccountId: string | null): string {
+  if (!activeAccountId) {
+    return "Organization";
   }
-  const grant = grants.find((candidate) => candidate.accountId === accountId);
-  const name =
-    grant?.metadata && typeof grant.metadata.accountName === "string"
-      ? grant.metadata.accountName
-      : undefined;
-  return name?.trim() || null;
+  return (
+    orgs.find((organization) => organization.accountId === activeAccountId)?.label ??
+    `Org ${shortAccountId(activeAccountId)}`
+  );
 }
 
 export function SwitcherBlock() {
@@ -67,8 +64,7 @@ export function SwitcherBlock() {
     activeWorkspace?.accountId ?? context.accessContext.defaultAccountId ?? null;
 
   const orgs = organizationsForSubject(context.accessContext, context.workspaces);
-  const currentOrgLabel =
-    orgDisplayName(activeAccountId, context.accessContext.accountGrants) ?? "Organization";
+  const currentOrgLabel = activeOrganizationLabel(orgs, activeAccountId);
   const orgWorkspaces = activeAccountId
     ? workspacesInOrg(context.workspaces, activeAccountId)
     : context.workspaces;
@@ -163,17 +159,12 @@ export function SwitcherBlock() {
           onToggleControl={() => void toggleWorkspaceControl()}
           align="start"
         >
-          <button
-            type="button"
-            aria-label={
-              activeIsPersonal
-                ? `Personal workspace: ${activeWorkspace?.name ?? "switch workspace"}`
-                : `Workspace: ${activeWorkspace?.name ?? "switch workspace"}`
-            }
-            className="mx-auto flex size-9 items-center justify-center rounded-md border border-border bg-surface-2/60 text-sm font-semibold text-fg transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
-          >
-            {workspaceInitial(activeWorkspace)}
-          </button>
+          <WorkspaceSwitcherTrigger
+            activeWorkspace={activeWorkspace}
+            activeOrganizationLabel={currentOrgLabel}
+            personal={activeIsPersonal}
+            collapsed
+          />
         </WorkspaceMenu>
         <WorkspaceNameDialog
           mode={dialog}
@@ -189,7 +180,13 @@ export function SwitcherBlock() {
 
   return (
     <div className="grid gap-1.5 px-3 pt-1">
-      <OrgLine orgs={orgs} currentLabel={currentOrgLabel} activeAccountId={activeAccountId} />
+      <OrganizationSwitcherLine
+        orgs={orgs}
+        currentLabel={currentOrgLabel}
+        activeAccountId={activeAccountId}
+        onSelect={rail.openOrg}
+        workspaceId={rail.workspaceId}
+      />
 
       <WorkspaceMenu
         workspaces={orgWorkspaces}
@@ -204,29 +201,12 @@ export function SwitcherBlock() {
         onToggleControl={() => void toggleWorkspaceControl()}
         align="start"
       >
-        <button
-          type="button"
-          aria-label={
-            activeIsPersonal
-              ? `Personal workspace: ${activeWorkspace?.name ?? "none"}. Switch workspace`
-              : `Workspace: ${activeWorkspace?.name ?? "none"}. Switch workspace`
-          }
-          className="group flex w-full items-center gap-2 rounded-md border border-border bg-surface-2/50 px-2 py-1.5 text-left transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
-        >
-          <Avatar size="sm" className="rounded-md">
-            <AvatarFallback className="rounded-md bg-brand-strong/25 text-2xs font-semibold text-brand">
-              {workspaceInitial(activeWorkspace)}
-            </AvatarFallback>
-          </Avatar>
-          <span
-            className="min-w-0 flex-1 truncate text-sm font-medium"
-            title={activeWorkspace?.name}
-          >
-            {activeWorkspace?.name ?? "Select workspace"}
-          </span>
-          {activeIsPersonal ? <PersonalWorkspaceBadge decorative /> : null}
-          <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-subtle" />
-        </button>
+        <WorkspaceSwitcherTrigger
+          activeWorkspace={activeWorkspace}
+          activeOrganizationLabel={currentOrgLabel}
+          personal={activeIsPersonal}
+          collapsed={false}
+        />
       </WorkspaceMenu>
 
       <WorkspaceNameDialog
@@ -241,12 +221,13 @@ export function SwitcherBlock() {
   );
 }
 
-function OrgLine(props: {
-  orgs: ReturnType<typeof organizationsForSubject>;
+export function OrganizationSwitcherLine(props: {
+  orgs: OrgOption[];
   currentLabel: string;
   activeAccountId: string | null;
+  onSelect: (accountId: string) => void;
+  workspaceId: string | null;
 }) {
-  const rail = useRail();
   // The org *name* renders in normal case (it's a name, not a section caption).
   // Exactly one org: a static muted label, no useless switcher.
   if (props.orgs.length <= 1) {
@@ -265,7 +246,7 @@ function OrgLine(props: {
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          aria-label="Switch organization"
+          aria-label={`${props.currentLabel}. Switch organization`}
           className="flex min-w-0 items-center gap-1 rounded px-0.5 py-0.5 text-2xs font-medium text-fg-subtle transition-colors hover:text-fg-muted focus-visible:outline-none"
         >
           <BuildingIcon className="size-3 shrink-0" />
@@ -281,11 +262,14 @@ function OrgLine(props: {
             aria-current={org.accountId === props.activeAccountId ? "true" : undefined}
             onSelect={() => {
               if (org.accountId !== props.activeAccountId) {
-                rail.openOrg(org.accountId);
+                props.onSelect(org.accountId);
               }
             }}
           >
-            <span className="flex size-5 items-center justify-center rounded bg-surface-3 text-2xs font-semibold">
+            <span
+              aria-hidden="true"
+              className="flex size-5 items-center justify-center rounded bg-surface-3 text-2xs font-semibold"
+            >
               {org.label
                 .replace(/^Org\s+/, "")
                 .slice(0, 2)
@@ -293,22 +277,73 @@ function OrgLine(props: {
             </span>
             <span className="min-w-0 flex-1 truncate">{org.label}</span>
             {org.accountId === props.activeAccountId ? (
-              <CheckIcon className="size-4 text-brand" />
+              <CheckIcon aria-hidden="true" className="size-4 text-brand" />
             ) : null}
           </DropdownMenuItem>
         ))}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
-          <Link
-            to="/workspaces/$workspaceId/organization"
-            params={{ workspaceId: rail.workspaceId }}
-          >
-            <SettingsIcon className="size-4" />
-            Organization settings
-          </Link>
-        </DropdownMenuItem>
+        {props.workspaceId ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <Link
+                to="/workspaces/$workspaceId/organization"
+                params={{ workspaceId: props.workspaceId }}
+              >
+                <SettingsIcon className="size-4" />
+                Organization settings
+              </Link>
+            </DropdownMenuItem>
+          </>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+export function WorkspaceSwitcherTrigger(props: {
+  activeWorkspace: Workspace | null;
+  activeOrganizationLabel: string;
+  personal: boolean;
+  collapsed: boolean;
+}) {
+  const workspaceLabel =
+    props.activeWorkspace?.name ?? (props.collapsed ? "switch workspace" : "none");
+  const accessibleLabel = `${props.activeOrganizationLabel}. ${
+    props.personal ? "Personal workspace" : "Workspace"
+  }: ${workspaceLabel}. Switch workspace`;
+
+  if (props.collapsed) {
+    return (
+      <button
+        type="button"
+        aria-label={accessibleLabel}
+        className="mx-auto flex size-9 items-center justify-center rounded-md border border-border bg-surface-2/60 text-sm font-semibold text-fg transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
+      >
+        {workspaceInitial(props.activeWorkspace)}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={accessibleLabel}
+      className="group flex w-full items-center gap-2 rounded-md border border-border bg-surface-2/50 px-2 py-1.5 text-left transition-colors hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none"
+    >
+      <Avatar size="sm" className="rounded-md">
+        <AvatarFallback className="rounded-md bg-brand-strong/25 text-2xs font-semibold text-brand">
+          {workspaceInitial(props.activeWorkspace)}
+        </AvatarFallback>
+      </Avatar>
+      <span
+        className="min-w-0 flex-1 truncate text-sm font-medium"
+        title={props.activeWorkspace?.name}
+      >
+        {props.activeWorkspace?.name ?? "Select workspace"}
+      </span>
+      {props.personal ? <PersonalWorkspaceBadge decorative /> : null}
+      <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-subtle" />
+    </button>
   );
 }
 

--- a/apps/web/test/active-organization-switcher-fixture.tsx
+++ b/apps/web/test/active-organization-switcher-fixture.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+import {
+  OrganizationSwitcherLine,
+  WorkspaceSwitcherTrigger,
+} from "../src/components/rail/switcher-block";
+import { orgLabel, type OrgOption } from "../src/lib/org";
+import type { Workspace } from "../src/types";
+import "../src/styles.css";
+
+const firstAccountId = "11111111-1111-4111-8111-111111111111";
+const secondAccountId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+const organizations: OrgOption[] = [firstAccountId, secondAccountId].map((accountId) => ({
+  accountId,
+  label: orgLabel(accountId, []),
+  canManage: false,
+}));
+
+function workspace(id: string, accountId: string, name: string): Workspace {
+  return {
+    id,
+    accountId,
+    name,
+    slug: null,
+    externalSource: null,
+    externalId: null,
+    agentInstructions: null,
+    settings: {},
+    inferenceControl: {
+      state: "active",
+      revision: 1,
+      reason: null,
+      changedBy: null,
+      changedAt: "2026-08-20T08:00:00.000Z",
+    },
+    createdAt: "2026-08-20T08:00:00.000Z",
+    updatedAt: "2026-08-20T08:00:00.000Z",
+  };
+}
+
+const workspaces = new Map([
+  [firstAccountId, workspace("workspace-one", firstAccountId, "Atlas")],
+  [secondAccountId, workspace("workspace-two", secondAccountId, "Beacon")],
+]);
+
+function ActiveOrganizationSwitcherFixture() {
+  const [activeAccountId, setActiveAccountId] = useState(firstAccountId);
+  const activeOrganization = organizations.find(
+    (organization) => organization.accountId === activeAccountId,
+  )!;
+  const activeWorkspace = workspaces.get(activeAccountId)!;
+
+  return (
+    <main className="grid max-w-72 gap-8 p-6">
+      <section id="expanded-org-switcher" aria-label="Expanded organization switcher">
+        <OrganizationSwitcherLine
+          orgs={organizations}
+          currentLabel={activeOrganization.label}
+          activeAccountId={activeAccountId}
+          onSelect={setActiveAccountId}
+          workspaceId={null}
+        />
+      </section>
+      <section id="collapsed-org-switcher" aria-label="Collapsed organization switcher">
+        <WorkspaceSwitcherTrigger
+          activeWorkspace={activeWorkspace}
+          activeOrganizationLabel={activeOrganization.label}
+          personal={false}
+          collapsed
+        />
+      </section>
+      <output data-testid="active-account-id">{activeAccountId}</output>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<ActiveOrganizationSwitcherFixture />);

--- a/apps/web/test/active-organization-switcher.html
+++ b/apps/web/test/active-organization-switcher.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Active organization switcher fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/test/active-organization-switcher-fixture.tsx"></script>
+  </body>
+</html>

--- a/scripts/ci/impact.ts
+++ b/scripts/ci/impact.ts
@@ -239,7 +239,7 @@ const ROOT_TEST_DEPENDENCIES: Record<string, string[]> = {
     "@opengeni/sdk",
     "@opengeni/testing",
   ],
-  "test/e2e/personal-workspace-accessibility.browser.e2e.ts": ["opengeni-web"],
+  "test/e2e/personal-workspace-accessibility.browser.e2e.ts": ["opengeni-web", "@opengeni/testing"],
   "test/e2e/workbench.browser.e2e.ts": ["@opengeni/react", "@opengeni/testing"],
   "test/e2e/opstream-runner.e2e.ts": ["@opengeni/runtime", "@opengeni/api-router"],
   "test/e2e/channel-a.e2e.ts": ["@opengeni/runtime", "@opengeni/api-router"],

--- a/test/e2e/personal-workspace-accessibility.browser.e2e.ts
+++ b/test/e2e/personal-workspace-accessibility.browser.e2e.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { freePort, startProcess, type StartedProcess } from "@opengeni/testing";
 import { chromium, type Browser, type Page } from "playwright";
 
 import { renderPersonalWorkspaceAccessibilityFixture } from "../../apps/web/test/personal-workspace-accessibility-fixture";
@@ -6,15 +7,97 @@ import { renderPersonalWorkspaceAccessibilityFixture } from "../../apps/web/test
 describe("Personal workspace accessibility in Chromium", () => {
   let browser: Browser;
   let page: Page;
+  let switcherPage: Page;
+  let web: StartedProcess;
 
   beforeAll(async () => {
+    const port = await freePort();
+    const baseUrl = `http://127.0.0.1:${port}`;
+    web = await startProcess(
+      [
+        "bun",
+        "run",
+        "vite",
+        "dev",
+        ".",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(port),
+        "--strictPort",
+      ],
+      {
+        cwd: `${new URL("../..", import.meta.url).pathname}/apps/web`,
+        ready: async () =>
+          (
+            await fetch(`${baseUrl}/test/active-organization-switcher.html`, {
+              signal: AbortSignal.timeout(2_000),
+            }).catch(() => null)
+          )?.ok === true,
+        timeoutMs: 45_000,
+      },
+    );
     browser = await chromium.launch({ headless: true });
     page = await browser.newPage();
     await page.setContent(renderPersonalWorkspaceAccessibilityFixture());
-  });
+    switcherPage = await browser.newPage();
+    await switcherPage.goto(`${baseUrl}/test/active-organization-switcher.html`, {
+      waitUntil: "networkidle",
+    });
+  }, 60_000);
 
   afterAll(async () => {
-    await browser?.close();
+    await Promise.allSettled([browser?.close(), web?.stop()]);
+  }, 30_000);
+
+  test("unnamed organizations stay identifiable when expanded, collapsed, and switched", async () => {
+    const expanded = switcherPage.getByRole("region", {
+      name: "Expanded organization switcher",
+    });
+    const collapsed = switcherPage.getByRole("region", {
+      name: "Collapsed organization switcher",
+    });
+
+    const firstTrigger = expanded.getByRole("button", {
+      name: "Org 11111111. Switch organization",
+      exact: true,
+    });
+    expect(await firstTrigger.isVisible()).toBe(true);
+    expect(await firstTrigger.textContent()).toContain("Org 11111111");
+    expect(
+      await collapsed
+        .getByRole("button", {
+          name: "Org 11111111. Workspace: Atlas. Switch workspace",
+          exact: true,
+        })
+        .count(),
+    ).toBe(1);
+
+    await firstTrigger.click();
+    const firstItem = switcherPage.getByRole("menuitem", { name: "Org 11111111", exact: true });
+    const secondItem = switcherPage.getByRole("menuitem", { name: "Org aaaaaaaa", exact: true });
+    expect(await firstItem.getAttribute("aria-current")).toBe("true");
+    expect(await secondItem.getAttribute("aria-current")).toBeNull();
+
+    await secondItem.click();
+    await expanded
+      .getByRole("button", {
+        name: "Org aaaaaaaa. Switch organization",
+        exact: true,
+      })
+      .waitFor();
+    expect(await expanded.textContent()).toContain("Org aaaaaaaa");
+    expect(
+      await collapsed
+        .getByRole("button", {
+          name: "Org aaaaaaaa. Workspace: Beacon. Switch workspace",
+          exact: true,
+        })
+        .count(),
+    ).toBe(1);
+    expect(await switcherPage.getByTestId("active-account-id").textContent()).toBe(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    );
   });
 
   test("the generic badge exposes Personal workspace through the accessibility tree", async () => {


### PR DESCRIPTION
## Summary

- show the active organization name in the expanded workspace switcher
- use a stable `Org <short-id>` fallback when the backend has no organization display name
- expose active organization + workspace identity in the collapsed switcher's accessible name without changing its visual footprint
- keep organization switching on the existing principal-fenced `rail.openOrg` path

## Verification

- full web suite: 767 passed
- real Chromium multi-organization switcher acceptance: 6 passed
- CI impact contracts: 35 passed
- web typecheck
- production build and bundle budgets
- lint, format, public hygiene, and diff check

No backend name projection or authority behavior changes.
