### PR TITLE
feat: harden personal resource grant management (OPE-205)

### DIFF
--- a/.changeset/personal-resource-grant-management.md
+++ b/.changeset/personal-resource-grant-management.md
@@ -1,0 +1,9 @@
+---
+"@opengeni/contracts": minor
+"@opengeni/core": minor
+"@opengeni/api-router": minor
+"@opengeni/sdk": minor
+"@opengeni/db": patch
+---
+
+Add activation-gated owner management for personal-resource session and standing grants, with kind-derived actions and permissions, exact session authority epochs, route-workspace-fenced revocation, RFC3339 lifecycle timestamps, bounded keyset pages, complete credential-free delegation receipts, FORCE-RLS-safe expiry and invalid-action settlement, and SDK methods that intentionally exclude standalone `once` and custom expiry.

--- a/apps/api/src/connection-authority-owner.ts
+++ b/apps/api/src/connection-authority-owner.ts
@@ -27,12 +27,16 @@ export function requireConnectionAuthorityOwner(access: AccessGrantAuthorization
 }
 
 /** Removes generic resource kind and refuses non-connection grant actions. */
-export function projectSelfConnectionAuthorities(authorities: UserResourceAuthoritySummary[]) {
+export function projectSelfConnectionAuthorities(page: {
+  authorities: UserResourceAuthoritySummary[];
+  nextCursor: string | null;
+}) {
   return ListConnectionAuthoritiesResponse.parse({
     scope: "user",
-    authorities: authorities
+    authorities: page.authorities
       .filter((authority) => authority.resourceKind === "connection")
       .map(({ resourceKind: _resourceKind, ...authority }) => authority),
+    nextCursor: page.nextCursor,
   });
 }
 
@@ -42,6 +46,7 @@ export function connectionUseGrantLifecycleInput(input: unknown): {
   mode: IssueConnectionUseGrantRequestValue["mode"];
   context: IssueConnectionUseGrantRequestValue["context"];
   sessionId: string | null;
+  expectedAuthorityEpoch: number | null;
   workspaceSharedAcknowledged: boolean;
 } {
   const request = IssueConnectionUseGrantRequest.parse(input);
@@ -50,6 +55,7 @@ export function connectionUseGrantLifecycleInput(input: unknown): {
     mode: request.mode,
     context: request.context,
     sessionId: request.sessionId ?? null,
+    expectedAuthorityEpoch: request.expectedAuthorityEpoch ?? null,
     workspaceSharedAcknowledged: request.workspaceSharedAcknowledged,
   };
 }

--- a/apps/api/src/routes/connection-authorities.ts
+++ b/apps/api/src/routes/connection-authorities.ts
@@ -3,20 +3,26 @@ import {
   ConnectionUseGrantRevocationResponse,
   IssueConnectionUseGrantRequest,
   ListConnectionAuthoritiesQuery,
-  ListConnectionAuthoritiesResponse,
   RevokeConnectionUseGrantQuery,
 } from "@opengeni/contracts/connection-authority";
-import { requireAccessGrantAuthorization, type ApiRouteDeps } from "@opengeni/core";
 import {
-  issueSelfConnectionUseGrant,
-  listSelfConnectionAuthorities,
-  nestedPostgresSqlState,
-  revokeSelfConnectionUseGrant,
-} from "@opengeni/db";
+  issueManagedHumanUserResourceGrant,
+  listManagedHumanUserResourceAuthorities,
+  requireAccessGrantAuthorization,
+  revokeManagedHumanUserResourceGrant,
+  SessionAuthorizationDeniedError,
+  SessionAuthorizationUnavailableError,
+  SessionTenancyManagedHumanRequiredError,
+  type ApiRouteDeps,
+} from "@opengeni/core";
+import { nestedPostgresSqlState, SessionTenancyNotActivatedError } from "@opengeni/db";
 import type { Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
-import { requireConnectionAuthorityOwner } from "../connection-authority-owner";
+import {
+  connectionUseGrantLifecycleInput,
+  projectSelfConnectionAuthorities,
+} from "../connection-authority-owner";
 
 async function body<S extends z.ZodType>(context: Context, schema: S): Promise<z.infer<S>> {
   const parsed = schema.safeParse(await context.req.json().catch(() => null));
@@ -25,6 +31,16 @@ async function body<S extends z.ZodType>(context: Context, schema: S): Promise<z
 }
 
 function lifecycleError(error: unknown): never {
+  if (
+    error instanceof SessionAuthorizationDeniedError ||
+    error instanceof SessionTenancyManagedHumanRequiredError ||
+    error instanceof SessionTenancyNotActivatedError
+  ) {
+    throw new HTTPException(403, { message: "connection authority denied" });
+  }
+  if (error instanceof SessionAuthorizationUnavailableError) {
+    throw new HTTPException(503, { message: "session authorization unavailable" });
+  }
   if (nestedPostgresSqlState(error) === "42501") {
     throw new HTTPException(403, { message: "connection authority denied" });
   }
@@ -40,6 +56,8 @@ export function registerConnectionAuthorityRoutes(app: Hono, deps: ApiRouteDeps)
   app.get(base, async (context) => {
     const query = ListConnectionAuthoritiesQuery.safeParse({
       scope: context.req.query("scope"),
+      cursor: context.req.query("cursor"),
+      limit: context.req.query("limit"),
     });
     if (!query.success) throw new HTTPException(422, { message: "explicit scope=user required" });
     const workspaceId = context.req.param("workspaceId");
@@ -49,17 +67,15 @@ export function registerConnectionAuthorityRoutes(app: Hono, deps: ApiRouteDeps)
       workspaceId,
       "connections:read",
     );
-    const subjectId = requireConnectionAuthorityOwner(access);
     try {
       return context.json(
-        ListConnectionAuthoritiesResponse.parse({
-          scope: "user",
-          authorities: await listSelfConnectionAuthorities(deps.db, {
-            accountId: access.grant.accountId,
-            workspaceId,
-            subjectId,
+        projectSelfConnectionAuthorities(
+          await listManagedHumanUserResourceAuthorities(deps, access, workspaceId, {
+            resourceKind: "connection",
+            cursor: query.data.cursor,
+            limit: query.data.limit,
           }),
-        }),
+        ),
       );
     } catch (error) {
       return lifecycleError(error);
@@ -77,18 +93,19 @@ export function registerConnectionAuthorityRoutes(app: Hono, deps: ApiRouteDeps)
       workspaceId,
       "connections:read",
     );
-    const subjectId = requireConnectionAuthorityOwner(access);
     try {
+      const normalized = connectionUseGrantLifecycleInput(request);
       return context.json(
         ConnectionUseGrantMutationResponse.parse({
           scope: "user",
-          grant: await issueSelfConnectionUseGrant(deps.db, {
-            accountId: access.grant.accountId,
+          grant: await issueManagedHumanUserResourceGrant(
+            deps,
+            access,
             workspaceId,
-            subjectId,
-            authorityId: authorityId.data,
-            request,
-          }),
+            authorityId.data,
+            { scope: "user", resourceKind: "connection", ...normalized },
+            "http",
+          ),
         }),
       );
     } catch (error) {
@@ -106,19 +123,13 @@ export function registerConnectionAuthorityRoutes(app: Hono, deps: ApiRouteDeps)
       context,
       deps,
       workspaceId,
-      "connections:read",
+      "workspace:read",
     );
-    const subjectId = requireConnectionAuthorityOwner(access);
     try {
       return context.json(
         ConnectionUseGrantRevocationResponse.parse({
           scope: "user",
-          grant: await revokeSelfConnectionUseGrant(deps.db, {
-            accountId: access.grant.accountId,
-            workspaceId,
-            subjectId,
-            grantId: grantId.data,
-          }),
+          grant: await revokeManagedHumanUserResourceGrant(deps, access, workspaceId, grantId.data),
         }),
       );
     } catch (error) {

--- a/apps/api/src/routes/user-resource-authorities.ts
+++ b/apps/api/src/routes/user-resource-authorities.ts
@@ -4,35 +4,22 @@ import {
   ListUserResourceAuthoritiesResponse,
   RevokeUserResourceGrantQuery,
   UserResourceGrantMutationResponse,
+  UserResourceGrantRevocationResponse,
 } from "@opengeni/contracts";
 import {
+  issueManagedHumanUserResourceGrant,
+  listManagedHumanUserResourceAuthorities,
   requireAccessGrantAuthorization,
-  type AccessGrantAuthorization,
+  revokeManagedHumanUserResourceGrant,
+  SessionAuthorizationDeniedError,
+  SessionAuthorizationUnavailableError,
+  SessionTenancyManagedHumanRequiredError,
   type ApiRouteDeps,
 } from "@opengeni/core";
-import {
-  issueSelfUserResourceGrant,
-  listSelfUserResourceAuthorities,
-  nestedPostgresSqlState,
-  revokeSelfUserResourceGrant,
-} from "@opengeni/db";
+import { nestedPostgresSqlState, SessionTenancyNotActivatedError } from "@opengeni/db";
 import type { Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
-
-function requireAuthenticatedHuman(access: AccessGrantAuthorization): string {
-  if (
-    !access.contextIntegrity ||
-    access.authenticatedSubjectId !== access.grant.subjectId ||
-    access.grant.principalKind !== "human_session" ||
-    access.grant.serviceInitiator ||
-    access.grant.serviceInitiatorContext ||
-    access.grant.subjectId.startsWith("api_key:")
-  ) {
-    throw new HTTPException(403, { message: "authenticated human session required" });
-  }
-  return access.grant.subjectId;
-}
 
 async function body<S extends z.ZodType>(context: Context, schema: S): Promise<z.infer<S>> {
   const parsed = schema.safeParse(await context.req.json().catch(() => null));
@@ -41,6 +28,16 @@ async function body<S extends z.ZodType>(context: Context, schema: S): Promise<z
 }
 
 function lifecycleError(error: unknown): never {
+  if (
+    error instanceof SessionAuthorizationDeniedError ||
+    error instanceof SessionTenancyManagedHumanRequiredError ||
+    error instanceof SessionTenancyNotActivatedError
+  ) {
+    throw new HTTPException(403, { message: "user-resource authority denied" });
+  }
+  if (error instanceof SessionAuthorizationUnavailableError) {
+    throw new HTTPException(503, { message: "session authorization unavailable" });
+  }
   if (nestedPostgresSqlState(error) === "42501") {
     throw new HTTPException(403, { message: "user-resource authority denied" });
   }
@@ -53,7 +50,12 @@ function lifecycleError(error: unknown): never {
 export function registerUserResourceAuthorityRoutes(app: Hono, deps: ApiRouteDeps): void {
   const base = "/v1/workspaces/:workspaceId/user-resource-authorities";
   app.get(base, async (context) => {
-    const query = ListUserResourceAuthoritiesQuery.safeParse({ scope: context.req.query("scope") });
+    const query = ListUserResourceAuthoritiesQuery.safeParse({
+      scope: context.req.query("scope"),
+      resourceKind: context.req.query("resourceKind"),
+      cursor: context.req.query("cursor"),
+      limit: context.req.query("limit"),
+    });
     if (!query.success) throw new HTTPException(422, { message: "explicit scope=user required" });
     const workspaceId = context.req.param("workspaceId");
     const access = await requireAccessGrantAuthorization(
@@ -62,16 +64,17 @@ export function registerUserResourceAuthorityRoutes(app: Hono, deps: ApiRouteDep
       workspaceId,
       "workspace:read",
     );
-    const subjectId = requireAuthenticatedHuman(access);
     try {
+      const page = await listManagedHumanUserResourceAuthorities(
+        deps,
+        access,
+        workspaceId,
+        query.data,
+      );
       return context.json(
         ListUserResourceAuthoritiesResponse.parse({
           scope: "user",
-          authorities: await listSelfUserResourceAuthorities(deps.db, {
-            accountId: access.grant.accountId,
-            workspaceId,
-            subjectId,
-          }),
+          ...page,
         }),
       );
     } catch (error) {
@@ -90,22 +93,18 @@ export function registerUserResourceAuthorityRoutes(app: Hono, deps: ApiRouteDep
       workspaceId,
       "workspace:read",
     );
-    const subjectId = requireAuthenticatedHuman(access);
     try {
       return context.json(
         UserResourceGrantMutationResponse.parse({
           scope: "user",
-          grant: await issueSelfUserResourceGrant(deps.db, {
-            accountId: access.grant.accountId,
+          grant: await issueManagedHumanUserResourceGrant(
+            deps,
+            access,
             workspaceId,
-            subjectId,
-            authorityId: authorityId.data,
-            action: request.action,
-            mode: request.mode,
-            context: request.context,
-            sessionId: request.sessionId ?? null,
-            workspaceSharedAcknowledged: request.workspaceSharedAcknowledged,
-          }),
+            authorityId.data,
+            request,
+            "http",
+          ),
         }),
       );
     } catch (error) {
@@ -125,17 +124,13 @@ export function registerUserResourceAuthorityRoutes(app: Hono, deps: ApiRouteDep
       workspaceId,
       "workspace:read",
     );
-    const subjectId = requireAuthenticatedHuman(access);
     try {
-      return context.json({
-        scope: "user",
-        grant: await revokeSelfUserResourceGrant(deps.db, {
-          accountId: access.grant.accountId,
-          workspaceId,
-          subjectId,
-          grantId: grantId.data,
+      return context.json(
+        UserResourceGrantRevocationResponse.parse({
+          scope: "user",
+          grant: await revokeManagedHumanUserResourceGrant(deps, access, workspaceId, grantId.data),
         }),
-      });
+      );
     } catch (error) {
       return lifecycleError(error);
     }

--- a/apps/api/test/connection-authority-owner.test.ts
+++ b/apps/api/test/connection-authority-owner.test.ts
@@ -44,6 +44,7 @@ describe("connection authority API owner boundary", () => {
         mode: "session",
         context: "workspace_shared",
         sessionId: id("3"),
+        expectedAuthorityEpoch: 7,
         workspaceSharedAcknowledged: true,
       }),
     ).toEqual({
@@ -51,6 +52,7 @@ describe("connection authority API owner boundary", () => {
       mode: "session",
       context: "workspace_shared",
       sessionId: id("3"),
+      expectedAuthorityEpoch: 7,
       workspaceSharedAcknowledged: true,
     });
     expect(() =>
@@ -66,39 +68,62 @@ describe("connection authority API owner boundary", () => {
 
   test("projects only opaque connection authority rows", () => {
     expect(
-      projectSelfConnectionAuthorities([
-        {
-          authorityId: id("4"),
-          resourceKind: "connection",
-          generation: 1,
-          status: "active",
-          grants: [
-            {
-              grantId: id("5"),
-              targetWorkspaceId: id("2"),
-              targetSessionId: null,
-              action: "connection.use",
-              mode: "always",
-              context: "user_private",
-              generation: 1,
-              status: "active",
-              expiresAt: null,
-            },
-          ],
-        },
-        {
-          authorityId: id("6"),
-          resourceKind: "rig",
-          generation: 1,
-          status: "active",
-          grants: [],
-        },
-      ]),
+      projectSelfConnectionAuthorities({
+        authorities: [
+          {
+            authorityId: id("4"),
+            resourceKind: "connection",
+            resourceId: id("7"),
+            originWorkspaceId: id("8"),
+            generation: 1,
+            status: "active",
+            grants: [
+              {
+                grantId: id("5"),
+                targetWorkspaceId: id("2"),
+                targetSessionId: null,
+                action: "connection.use",
+                mode: "always",
+                context: "user_private",
+                authorityEpoch: null,
+                generation: 1,
+                status: "active",
+                expiresAt: null,
+                delegation: {
+                  authorityId: id("4"),
+                  grantId: id("5"),
+                  organizationId: id("1"),
+                  workspaceId: id("2"),
+                  sessionId: null,
+                  action: "connection.use",
+                  mode: "always",
+                  context: "user_private",
+                  authorityEpoch: null,
+                  authorityGeneration: 1,
+                  grantGeneration: 1,
+                },
+              },
+            ],
+          },
+          {
+            authorityId: id("6"),
+            resourceKind: "rig",
+            resourceId: id("9"),
+            originWorkspaceId: null,
+            generation: 1,
+            status: "active",
+            grants: [],
+          },
+        ],
+        nextCursor: id("6"),
+      }),
     ).toEqual({
       scope: "user",
       authorities: [
         {
           authorityId: id("4"),
+          resourceId: id("7"),
+          originWorkspaceId: id("8"),
           generation: 1,
           status: "active",
           grants: [
@@ -109,13 +134,28 @@ describe("connection authority API owner boundary", () => {
               action: "connection.use",
               mode: "always",
               context: "user_private",
+              authorityEpoch: null,
               generation: 1,
               status: "active",
               expiresAt: null,
+              delegation: {
+                authorityId: id("4"),
+                grantId: id("5"),
+                organizationId: id("1"),
+                workspaceId: id("2"),
+                sessionId: null,
+                action: "connection.use",
+                mode: "always",
+                context: "user_private",
+                authorityEpoch: null,
+                authorityGeneration: 1,
+                grantGeneration: 1,
+              },
             },
           ],
         },
       ],
+      nextCursor: id("6"),
     });
   });
 });

--- a/apps/api/test/personal-workspace-session-surface.test.ts
+++ b/apps/api/test/personal-workspace-session-surface.test.ts
@@ -1176,3 +1176,92 @@ describe("the in-scope resolver refuses to be an arbitrary-subject oracle", () =
     ).rejects.toThrow(/does not match the applied RLS scope/);
   }, 180_000);
 });
+
+describe("managed personal-resource grant HTTP lifecycle", () => {
+  test("returns RFC3339 expiry/revoke times, reissues expiry, and revokes without connections:read", async () => {
+    if (!shared || !client) return;
+    const human = await provisionManagedHuman();
+    await activateSessionTenancy(human);
+    const [membership] = await shared.admin<Array<{ id: string }>>`
+      select id from organization_memberships
+      where account_id = ${human.accountId} and subject_id = ${human.subjectId}`;
+    if (!membership) throw new Error("managed human membership missing");
+    const authorityId = crypto.randomUUID();
+    await shared.admin`
+      insert into organization_user_resource_authorities (
+        id, account_id, organization_membership_id, resource_kind, resource_id,
+        origin_workspace_id, generation, status
+      ) values (
+        ${authorityId}, ${human.accountId}, ${membership.id}, 'connection',
+        ${crypto.randomUUID()}, ${human.personalWorkspaceId}, 1, 'active'
+      )`;
+    const app = buildApp(undefined, true);
+    const headers = { cookie: human.cookie, "content-type": "application/json" };
+    const issue = async (workspaceId: string, connectionWrapper = false): Promise<Response> =>
+      await app.request(
+        `http://x/v1/workspaces/${workspaceId}/${
+          connectionWrapper ? "connection-authorities" : "user-resource-authorities"
+        }/${authorityId}/grants`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            scope: "user",
+            ...(connectionWrapper ? {} : { resourceKind: "connection" }),
+            mode: "always",
+            context: "user_private",
+          }),
+        },
+      );
+
+    const firstResponse = await issue(human.personalWorkspaceId);
+    expect(firstResponse.status).toBe(200);
+    const first = (await firstResponse.json()) as { grant: { grantId: string } };
+    await shared.admin`
+      update organization_user_resource_grants
+      set expires_at = clock_timestamp() - interval '1 second'
+      where id = ${first.grant.grantId}`;
+
+    const listResponse = await app.request(
+      `http://x/v1/workspaces/${human.personalWorkspaceId}/user-resource-authorities?scope=user&resourceKind=connection`,
+      { headers },
+    );
+    expect(listResponse.status).toBe(200);
+    const listed = (await listResponse.json()) as {
+      authorities: Array<{
+        grants: Array<{ grantId: string; status: string; expiresAt: string | null }>;
+      }>;
+    };
+    const expired = listed.authorities
+      .flatMap((authority) => authority.grants)
+      .find((grant) => grant.grantId === first.grant.grantId);
+    expect(expired).toMatchObject({ status: "expired" });
+    expect(expired?.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/u);
+
+    const reissueResponse = await issue(human.personalWorkspaceId);
+    expect(reissueResponse.status).toBe(200);
+    const reissued = (await reissueResponse.json()) as { grant: { grantId: string } };
+    expect(reissued.grant.grantId).not.toBe(first.grant.grantId);
+
+    const routeGrantResponse = await issue(human.legacyWorkspaceId, true);
+    expect(routeGrantResponse.status).toBe(200);
+    const routeGrant = (await routeGrantResponse.json()) as { grant: { grantId: string } };
+    await shared.admin`
+      update workspace_memberships
+      set permissions = permissions - 'connections:read'
+      where account_id = ${human.accountId}
+        and workspace_id = ${human.legacyWorkspaceId}
+        and subject_id = ${human.subjectId}`;
+
+    const revokeResponse = await app.request(
+      `http://x/v1/workspaces/${human.legacyWorkspaceId}/connection-authorities/grants/${routeGrant.grant.grantId}?scope=user`,
+      { method: "DELETE", headers },
+    );
+    expect(revokeResponse.status).toBe(200);
+    const revoked = (await revokeResponse.json()) as {
+      grant: { status: string; revokedAt: string };
+    };
+    expect(revoked.grant.status).toBe("revoked");
+    expect(revoked.grant.revokedAt).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/u);
+  }, 180_000);
+});

--- a/apps/api/test/user-resource-authorities-routes.test.ts
+++ b/apps/api/test/user-resource-authorities-routes.test.ts
@@ -25,7 +25,7 @@ describe("user-resource authority routes", () => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           scope: "user",
-          action: "rig.use",
+          resourceKind: "rig",
           mode: "always",
           context: "workspace_shared",
           workspaceSharedAcknowledged: false,

--- a/apps/worker/test/scheduled-alert-occurrence.test.ts
+++ b/apps/worker/test/scheduled-alert-occurrence.test.ts
@@ -1224,6 +1224,13 @@ describe("scheduled alert canonical responder session (real PostgreSQL)", () => 
         'owner', '[]'::jsonb
       )
     `;
+    await admin`
+      insert into session_tenancy_activations (
+        account_id, activation_version, inventory_digest, parity_digest, activated_by
+      ) values (
+        ${workspace.accountId}, 1, ${"0".repeat(64)}, ${"1".repeat(64)}, 'worker-test'
+      ) on conflict (account_id) do nothing
+    `;
     const rig = await createRig(client.db, {
       accountId: workspace.accountId,
       workspaceId: personalWorkspace!.id,
@@ -1237,15 +1244,17 @@ describe("scheduled alert canonical responder session (real PostgreSQL)", () => 
         accountId: workspace.accountId,
         workspaceId: personalWorkspace!.id,
         subjectId: workspace.subjectId,
+        resourceKind: "rig",
+        limit: 50,
       })
-    ).find((candidate) => candidate.resourceKind === "rig");
+    ).authorities.find((candidate) => candidate.resourceId === rig.id);
     if (!authority) throw new Error("personal Rig authority missing");
     await issueSelfUserResourceGrant(client.db, {
       accountId: workspace.accountId,
       workspaceId: workspace.workspaceId,
       subjectId: workspace.subjectId,
       authorityId: authority.authorityId,
-      action: "rig.use",
+      resourceKind: "rig",
       mode: "always",
       context: "workspace_shared",
       workspaceSharedAcknowledged: true,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -353,7 +353,18 @@ Grant rows carry the owning membership and a canonical action; `once` and
 `session` are fenced to one exact session plus positive authority epoch, while
 `always` is a standing grant with null session and epoch. Migration 0264's
 bounded Connection activation consumes `once` atomically at accepted-turn
-admission; Slice B itself does not create any authority or grant rows. The first
+admission; Slice B itself does not create any authority or grant rows. Migration
+0305 makes owner management activation-gated and canonical-managed-cookie-only:
+one kind derives its action and permission gate, lists are route-workspace-
+filtered bounded keyset pages, session issuance passes the ordinary session
+authorization seam with an expected epoch, and revocation proves the target
+route workspace. Its SDK exposes only `session` and `always`; standalone `once`
+remains an internal atomic-consumption primitive. Its rolling backfill opens and
+closes one transactional owner-only FORCE-RLS window, expires past-due active
+rows, revokes active cross-kind/arbitrary actions, and omits invalid terminal
+history from typed lists without rewriting it. The runtime functions use one
+dedicated lifecycle marker and an exact hardened target-schema search path while
+the app role keeps zero direct authority-table DML. The first
 disjoint runtime activation
 appends the exact active membership's personal workspace only to the
 authenticated owning managed human's `AccessContext.workspaceGrants`, after the

--- a/docs/organization-tenancy.md
+++ b/docs/organization-tenancy.md
@@ -47,6 +47,44 @@ target workspace must belong to the same organization and remain accessible to
 the owner. `workspace_shared` requires an explicit durable shared-output
 acknowledgement. Revocation is immediate and advances grant generation.
 
+Migration `0305_personal_resource_grant_management.sql` replaces the ambient
+owner-management seam with the activated product contract. Only a canonical
+managed-cookie context for the exact subject may use it; API keys, delegated or
+service principals, agents, and account/organization administrators receive no
+ambient personal-resource authority. Lists are deterministic bounded keyset
+pages for one exact resource kind, include the opaque resource/origin identity,
+and return only grants targeting the route workspace. Resource kind derives the
+only accepted action (`connection.use`, `document.read`, `variable_set.use`,
+`rig.use`, or `connected_machine.use`) and its exact product permission gate.
+
+Public issuance supports `session` and `always`. Session grants are authorized
+through the ordinary session authorization seam after all target-free
+principal, permission, and activation gates, and require the caller's expected
+authority epoch; missing and inaccessible targets share the ordinary
+non-enumerating session denial. Always grants remain unbound and require
+session-create authority. Shared context requires the durable acknowledgement.
+The server returns the complete credential-free `UserResourceDelegation`,
+including organization, authority generation, grant generation, and session
+epoch. Revocation proves the grant's route workspace but intentionally remains
+available after a resource permission is removed because it only narrows
+authority. Expiry is not authorable on this public surface; historical active
+rows already past expiry are normalized to `expired` and no longer block exact
+reissuance, and every projected timestamp is RFC3339 UTC. Historical active
+grants whose action is arbitrary or belongs to a different resource kind are
+deterministically revoked; invalid terminal history remains durable but is
+omitted from typed management lists rather than rewritten or misrepresented.
+The migration performs those backfills as the non-bypass table owner inside one
+transactional `NO FORCE`/`FORCE` window over both the grant table and its
+authority join, then restores FORCE RLS. Runtime list/issue/revoke uses a narrow
+lifecycle policy marker inside schema-local, PUBLIC-revoked SECURITY DEFINER
+functions with `pg_catalog`, the target schema, and `pg_temp` as their exact
+search path; the app role retains zero direct table DML. The Connection-specific
+REST wrappers converge on this lifecycle, including permission-independent
+revocation after baseline route-workspace access is proved.
+Standalone `once`, custom expiry, new-session atomic attachment, cross-workspace
+grant/fork UX, schedules, MCP/agent administration, and web UI remain outside
+this backend prerequisite.
+
 For direct and scheduled personal Variable Set/Rig use, personal-workspace and
 origin-workspace columns are provenance/lifecycle facts only. Authorization is
 the active server-derived owner organization membership, same organization,

--- a/packages/contracts/src/connection-authority.ts
+++ b/packages/contracts/src/connection-authority.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 import {
   ConnectionKind,
+  ManagedUserResourceGrantMode,
   SessionTenancyVisibility,
   UserResourceAuthorityGrant,
   UserResourceDelegation,
-  UserResourceLifecycleGrantMode,
 } from "./index";
 
 /** The only generic grant action that authorizes use of a connection. */
@@ -57,6 +57,8 @@ export type ConnectionAuthorityGrant = z.infer<typeof ConnectionAuthorityGrant>;
 export const ConnectionAuthoritySummary = z
   .object({
     authorityId: z.string().uuid(),
+    resourceId: z.string().uuid(),
+    originWorkspaceId: z.string().uuid().nullable(),
     generation: z.number().int().positive(),
     status: z.enum(["active", "retained", "revoked"]),
     grants: z.array(ConnectionAuthorityGrant),
@@ -64,20 +66,28 @@ export const ConnectionAuthoritySummary = z
   .strict();
 export type ConnectionAuthoritySummary = z.infer<typeof ConnectionAuthoritySummary>;
 
-export const ListConnectionAuthoritiesQuery = z.object({ scope: z.literal("user") }).strict();
+export const ListConnectionAuthoritiesQuery = z
+  .object({
+    scope: z.literal("user"),
+    cursor: z.string().uuid().optional(),
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+  })
+  .strict();
 export const ListConnectionAuthoritiesResponse = z
   .object({
     scope: z.literal("user"),
     authorities: z.array(ConnectionAuthoritySummary),
+    nextCursor: z.string().uuid().nullable(),
   })
   .strict();
 
 export const IssueConnectionUseGrantRequest = z
   .object({
     scope: z.literal("user"),
-    mode: UserResourceLifecycleGrantMode,
+    mode: ManagedUserResourceGrantMode,
     context: SessionTenancyVisibility,
     sessionId: z.string().uuid().nullable().optional(),
+    expectedAuthorityEpoch: z.number().int().positive().nullable().optional(),
     workspaceSharedAcknowledged: z.boolean().default(false),
   })
   .strict()
@@ -89,14 +99,14 @@ export const IssueConnectionUseGrantRequest = z
         message: "workspace_shared requires durable shared-output acknowledgement",
       });
     }
-    if (value.mode === "always" && value.sessionId) {
+    if (value.mode === "always" && (value.sessionId || value.expectedAuthorityEpoch)) {
       context.addIssue({ code: "custom", path: ["sessionId"], message: "always is unbound" });
     }
-    if (value.mode !== "always" && !value.sessionId) {
+    if (value.mode === "session" && (!value.sessionId || !value.expectedAuthorityEpoch)) {
       context.addIssue({
         code: "custom",
         path: ["sessionId"],
-        message: "once/session require a target session",
+        message: "session requires a target session and expectedAuthorityEpoch",
       });
     }
   });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1088,39 +1088,73 @@ export type PersonalResourceRetentionMode = z.infer<typeof PersonalResourceReten
 export const SessionTenancyVisibility = z.enum(["user_private", "workspace_shared"]);
 
 export const UserResourceAuthorityScope = z.literal("user");
+export const UserResourceKind = z.enum([
+  "connection",
+  "document",
+  "variable_set",
+  "rig",
+  "connected_machine",
+]);
+export type UserResourceKind = z.infer<typeof UserResourceKind>;
+
+export const USER_RESOURCE_ACTION_BY_KIND = {
+  connection: "connection.use",
+  document: "document.read",
+  variable_set: "variable_set.use",
+  rig: "rig.use",
+  connected_machine: "connected_machine.use",
+} as const satisfies Record<UserResourceKind, string>;
+
 export const UserResourceLifecycleGrantMode = z.enum(["once", "session", "always"]);
+/** Public owner-management deliberately excludes race-prone standalone `once`. */
+export const ManagedUserResourceGrantMode = z.enum(["session", "always"]);
 export const UserResourceAuthorityGrant = z.object({
   grantId: z.string().uuid(),
   targetWorkspaceId: z.string().uuid(),
   targetSessionId: z.string().uuid().nullable(),
-  action: z.string().min(1).max(64),
+  action: z.enum([
+    "connection.use",
+    "document.read",
+    "variable_set.use",
+    "rig.use",
+    "connected_machine.use",
+  ]),
   mode: UserResourceLifecycleGrantMode,
   context: SessionTenancyVisibility,
+  authorityEpoch: z.number().int().positive().nullable(),
   generation: z.number().int().positive(),
   status: z.enum(["active", "consumed", "revoked", "expired"]),
   expiresAt: z.string().datetime().nullable(),
+  delegation: z.lazy(() => UserResourceDelegation),
 });
 export const UserResourceAuthoritySummary = z.object({
   authorityId: z.string().uuid(),
-  resourceKind: z.string().min(1).max(64),
+  resourceKind: UserResourceKind,
+  resourceId: z.string().uuid(),
+  originWorkspaceId: z.string().uuid().nullable(),
   generation: z.number().int().positive(),
   status: z.enum(["active", "retained", "revoked"]),
   grants: z.array(UserResourceAuthorityGrant),
 });
 export const ListUserResourceAuthoritiesQuery = z.object({
   scope: UserResourceAuthorityScope,
+  resourceKind: UserResourceKind,
+  cursor: z.string().uuid().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
 });
 export const ListUserResourceAuthoritiesResponse = z.object({
   scope: UserResourceAuthorityScope,
   authorities: z.array(UserResourceAuthoritySummary),
+  nextCursor: z.string().uuid().nullable(),
 });
 export const IssueUserResourceGrantRequest = z
   .object({
     scope: UserResourceAuthorityScope,
-    action: z.string().min(1).max(64),
-    mode: UserResourceLifecycleGrantMode,
+    resourceKind: UserResourceKind,
+    mode: ManagedUserResourceGrantMode,
     context: SessionTenancyVisibility,
     sessionId: z.string().uuid().nullable().optional(),
+    expectedAuthorityEpoch: z.number().int().positive().nullable().optional(),
     workspaceSharedAcknowledged: z.boolean().default(false),
   })
   .superRefine((value, context) => {
@@ -1131,18 +1165,18 @@ export const IssueUserResourceGrantRequest = z
         message: "workspace_shared requires durable shared-output acknowledgement",
       });
     }
-    if (value.mode === "always" && value.sessionId) {
+    if (value.mode === "always" && (value.sessionId || value.expectedAuthorityEpoch)) {
       context.addIssue({
         code: "custom",
         path: ["sessionId"],
-        message: "always is unbound",
+        message: "always is unbound from session authority",
       });
     }
-    if (value.mode !== "always" && !value.sessionId) {
+    if (value.mode === "session" && (!value.sessionId || !value.expectedAuthorityEpoch)) {
       context.addIssue({
         code: "custom",
         path: ["sessionId"],
-        message: "once/session require a target session",
+        message: "session grants require a target session and expectedAuthorityEpoch",
       });
     }
   });
@@ -1150,9 +1184,29 @@ export const UserResourceGrantMutationResponse = z.object({
   scope: UserResourceAuthorityScope,
   grant: UserResourceAuthorityGrant,
 });
+export const UserResourceGrantRevocationResponse = z.object({
+  scope: UserResourceAuthorityScope,
+  grant: z.object({
+    grantId: z.string().uuid(),
+    generation: z.number().int().positive(),
+    status: z.literal("revoked"),
+    revokedAt: z.string().datetime(),
+  }),
+});
 export const RevokeUserResourceGrantQuery = z.object({
   scope: UserResourceAuthorityScope,
 });
+export type UserResourceAuthorityGrant = z.infer<typeof UserResourceAuthorityGrant>;
+export type UserResourceAuthoritySummary = z.infer<typeof UserResourceAuthoritySummary>;
+export type ListUserResourceAuthoritiesQuery = z.infer<typeof ListUserResourceAuthoritiesQuery>;
+export type ListUserResourceAuthoritiesResponse = z.infer<
+  typeof ListUserResourceAuthoritiesResponse
+>;
+export type IssueUserResourceGrantRequest = z.infer<typeof IssueUserResourceGrantRequest>;
+export type UserResourceGrantMutationResponse = z.infer<typeof UserResourceGrantMutationResponse>;
+export type UserResourceGrantRevocationResponse = z.infer<
+  typeof UserResourceGrantRevocationResponse
+>;
 export type SessionTenancyVisibility = z.infer<typeof SessionTenancyVisibility>;
 
 /** Public/session API vocabulary. Persistence keeps the explicit tenancy names. */
@@ -5753,6 +5807,7 @@ export const SessionAuthorizationOperation = z.enum([
   "session.child.create",
   "session.visibility.write",
   "session.fork.create",
+  "session.personal_resource.grant",
 ]);
 export type SessionAuthorizationOperation = z.infer<typeof SessionAuthorizationOperation>;
 

--- a/packages/contracts/test/connection-authority.test.ts
+++ b/packages/contracts/test/connection-authority.test.ts
@@ -57,9 +57,12 @@ describe("connection authority contracts", () => {
     ).toBe(false);
     const clean = {
       scope: "user" as const,
+      nextCursor: null,
       authorities: [
         {
           authorityId: id("1"),
+          resourceId: id("8"),
+          originWorkspaceId: id("4"),
           generation: 1,
           status: "active" as const,
           grants: [
@@ -70,9 +73,17 @@ describe("connection authority contracts", () => {
               action: "connection.use" as const,
               mode: "always" as const,
               context: "user_private" as const,
+              authorityEpoch: null,
               generation: 1,
               status: "active" as const,
               expiresAt: null,
+              delegation: {
+                ...delegation,
+                sessionId: null,
+                mode: "always" as const,
+                context: "user_private" as const,
+                authorityEpoch: null,
+              },
             },
           ],
         },
@@ -87,7 +98,7 @@ describe("connection authority contracts", () => {
             ...clean.authorities[0],
             authorityId: id("1"),
             ownerSubjectId: "must-not-survive",
-            connectionId: id("8"),
+            connectionId: id("9"),
           },
         ],
       }).success,

--- a/packages/contracts/test/organization-tenancy-foundation.test.ts
+++ b/packages/contracts/test/organization-tenancy-foundation.test.ts
@@ -28,11 +28,15 @@ const ids = {
 describe("organization tenancy foundation contracts", () => {
   test("requires explicit user scope and durable shared-output acknowledgement", () => {
     expect(ListUserResourceAuthoritiesQuery.safeParse({}).success).toBe(false);
-    expect(ListUserResourceAuthoritiesQuery.parse({ scope: "user" })).toEqual({ scope: "user" });
+    expect(ListUserResourceAuthoritiesQuery.parse({ scope: "user", resourceKind: "rig" })).toEqual({
+      scope: "user",
+      resourceKind: "rig",
+      limit: 50,
+    });
     expect(
       IssueUserResourceGrantRequest.parse({
         scope: "user",
-        action: "rig.use",
+        resourceKind: "rig",
         mode: "always",
         context: "workspace_shared",
         workspaceSharedAcknowledged: true,
@@ -43,10 +47,13 @@ describe("organization tenancy foundation contracts", () => {
   test("keeps lifecycle lists opaque", () => {
     const result = ListUserResourceAuthoritiesResponse.parse({
       scope: "user",
+      nextCursor: null,
       authorities: [
         {
           authorityId: ids.authority,
           resourceKind: "rig",
+          resourceId: ids.resourceVersion,
+          originWorkspaceId: ids.workspace,
           generation: 1,
           status: "active",
           ownerSubjectId: "must-not-survive",
@@ -58,9 +65,23 @@ describe("organization tenancy foundation contracts", () => {
               action: "rig.use",
               mode: "always",
               context: "user_private",
+              authorityEpoch: null,
               generation: 1,
               status: "active",
               expiresAt: null,
+              delegation: {
+                authorityId: ids.authority,
+                grantId: ids.grant,
+                organizationId: ids.organization,
+                workspaceId: ids.workspace,
+                sessionId: null,
+                action: "rig.use",
+                mode: "always",
+                context: "user_private",
+                authorityEpoch: null,
+                authorityGeneration: 1,
+                grantGeneration: 1,
+              },
               membershipId: ids.membership,
               secret: "must-not-survive",
             },

--- a/packages/core/src/application/session-tenancy.ts
+++ b/packages/core/src/application/session-tenancy.ts
@@ -37,7 +37,7 @@ export class SessionTenancyPersistenceOutcomeUnknownError extends Error {
   }
 }
 
-function requireCanonicalManagedHuman(
+export function requireCanonicalManagedHuman(
   authorization: AccessGrantAuthorization,
   workspaceId: string,
 ): void {

--- a/packages/core/src/application/user-resource-grants.ts
+++ b/packages/core/src/application/user-resource-grants.ts
@@ -1,0 +1,129 @@
+import type {
+  IssueUserResourceGrantRequest,
+  Permission,
+  SessionAuthorizationSurface,
+  UserResourceKind,
+} from "@opengeni/contracts";
+import {
+  issueSelfUserResourceGrant,
+  listSelfUserResourceAuthorities,
+  revokeSelfUserResourceGrant,
+  sessionTenancyProductActivated,
+  SessionTenancyNotActivatedError,
+} from "@opengeni/db";
+import { requirePermission, type AccessGrantAuthorization } from "../access";
+import type { AppDependencies } from "../dependencies";
+import { requireSessionAuthorization } from "../session-authorization";
+import { requireCanonicalManagedHuman } from "./session-tenancy";
+
+type UserResourceGrantDependencies = Pick<AppDependencies, "db" | "sessionAuthorization">;
+
+const LIST_PERMISSIONS = {
+  connection: ["connections:read"],
+  document: ["documents:search"],
+  variable_set: ["variable-sets:list"],
+  rig: ["rigs:use"],
+  connected_machine: ["enrollments:read"],
+} as const satisfies Record<UserResourceKind, readonly Permission[]>;
+
+const ISSUE_PERMISSIONS = {
+  connection: ["connections:read"],
+  document: ["documents:search"],
+  variable_set: ["variable-sets:list", "variable-sets:attach", "variable-sets:use"],
+  rig: ["rigs:use"],
+  connected_machine: ["enrollments:read"],
+} as const satisfies Record<UserResourceKind, readonly Permission[]>;
+
+async function requireOwnerProductGate(
+  deps: Pick<UserResourceGrantDependencies, "db">,
+  authorization: AccessGrantAuthorization,
+  workspaceId: string,
+  permissions: readonly Permission[],
+): Promise<void> {
+  // Target-free gates must run before an optional target-session lookup or host
+  // callback so rejected principals cannot use grant management as an oracle.
+  requireCanonicalManagedHuman(authorization, workspaceId);
+  for (const permission of permissions) requirePermission(authorization.grant, permission);
+  if (!(await sessionTenancyProductActivated(deps.db, workspaceId))) {
+    throw new SessionTenancyNotActivatedError();
+  }
+}
+
+export async function listManagedHumanUserResourceAuthorities(
+  deps: Pick<UserResourceGrantDependencies, "db">,
+  authorization: AccessGrantAuthorization,
+  workspaceId: string,
+  input: { resourceKind: UserResourceKind; cursor?: string | undefined; limit: number },
+) {
+  await requireOwnerProductGate(
+    deps,
+    authorization,
+    workspaceId,
+    LIST_PERMISSIONS[input.resourceKind],
+  );
+  return await listSelfUserResourceAuthorities(deps.db, {
+    accountId: authorization.grant.accountId,
+    workspaceId,
+    subjectId: authorization.grant.subjectId,
+    ...input,
+  });
+}
+
+export async function issueManagedHumanUserResourceGrant(
+  deps: UserResourceGrantDependencies,
+  authorization: AccessGrantAuthorization,
+  workspaceId: string,
+  authorityId: string,
+  request: IssueUserResourceGrantRequest,
+  authorizationSurface: SessionAuthorizationSurface = "core",
+) {
+  const modePermissions: Permission[] =
+    request.mode === "session" ? ["sessions:control"] : ["sessions:create"];
+  await requireOwnerProductGate(deps, authorization, workspaceId, [
+    ...ISSUE_PERMISSIONS[request.resourceKind],
+    ...modePermissions,
+  ]);
+
+  if (request.mode === "session") {
+    // Contract refinement guarantees both fields. Keep the defensive check so
+    // direct core callers cannot accidentally weaken the target fence.
+    if (!request.sessionId || !request.expectedAuthorityEpoch) {
+      throw new TypeError("session grant requires its exact authority epoch");
+    }
+    await requireSessionAuthorization(deps, authorization.grant, {
+      sessionId: request.sessionId,
+      operation: "session.personal_resource.grant",
+      surface: authorizationSurface,
+    });
+  }
+
+  return await issueSelfUserResourceGrant(deps.db, {
+    accountId: authorization.grant.accountId,
+    workspaceId,
+    subjectId: authorization.grant.subjectId,
+    authorityId,
+    resourceKind: request.resourceKind,
+    mode: request.mode,
+    context: request.context,
+    sessionId: request.sessionId ?? null,
+    expectedAuthorityEpoch: request.expectedAuthorityEpoch ?? null,
+    workspaceSharedAcknowledged: request.workspaceSharedAcknowledged,
+  });
+}
+
+export async function revokeManagedHumanUserResourceGrant(
+  deps: Pick<UserResourceGrantDependencies, "db">,
+  authorization: AccessGrantAuthorization,
+  workspaceId: string,
+  grantId: string,
+) {
+  // Revocation narrows authority. It intentionally does not require the
+  // resource-specific permission that may have been removed since issuance.
+  await requireOwnerProductGate(deps, authorization, workspaceId, []);
+  return await revokeSelfUserResourceGrant(deps.db, {
+    accountId: authorization.grant.accountId,
+    workspaceId,
+    subjectId: authorization.grant.subjectId,
+    grantId,
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,6 +85,7 @@ export * from "./domain/organization-membership-lifecycle";
 export * from "./application/new-session-drafts";
 export * from "./application/session-commands";
 export * from "./application/session-tenancy";
+export * from "./application/user-resource-grants";
 
 // Durable editable-artifact live broker, ticket, ports, and projection types.
 export * from "./editable-artifact-live";

--- a/packages/core/test/session-tenancy.test.ts
+++ b/packages/core/test/session-tenancy.test.ts
@@ -15,11 +15,17 @@ import {
 } from "@opengeni/testing";
 import type { AccessGrantAuthorization } from "../src/access";
 import { HTTPException } from "hono/http-exception";
+import { SessionAuthorizationDeniedError } from "../src/session-authorization";
 import {
   forkManagedHumanSessionPrivate,
   SessionTenancyManagedHumanRequiredError,
   updateManagedHumanSessionVisibility,
 } from "../src/application/session-tenancy";
+import {
+  issueManagedHumanUserResourceGrant,
+  listManagedHumanUserResourceAuthorities,
+  revokeManagedHumanUserResourceGrant,
+} from "../src/application/user-resource-grants";
 
 let shared: SharedTestDatabase | null = null;
 let client: DbClient | null = null;
@@ -41,6 +47,197 @@ afterAll(async () => {
 }, 180_000);
 
 describe("managed-human session tenancy application service", () => {
+  test("lists, issues, reissues expired identities, and route-fences revocation", async () => {
+    if (!shared || !client) return;
+    const userId = `core-personal-grants-${crypto.randomUUID()}`;
+    const subjectId = `user:${userId}`;
+    const access = await ensureManagedAccessForUser(client.db, {
+      userId,
+      email: `${userId}@example.test`,
+      name: "Core personal grants",
+    });
+    const personalGrant = access.workspaceGrants.find(
+      (candidate) => candidate.workspaceId !== access.defaultWorkspaceId,
+    );
+    if (!personalGrant) throw new Error("managed human has no personal workspace grant");
+    await shared.admin`
+      insert into session_tenancy_activations (
+        account_id, activation_version, inventory_digest, parity_digest, activated_by
+      ) values (
+        ${personalGrant.accountId}, 1, ${"3".repeat(64)}, ${"4".repeat(64)}, 'grant-test'
+      )`;
+    const [membership] = await shared.admin<{ id: string }[]>`
+      select id from organization_memberships
+      where account_id = ${personalGrant.accountId} and subject_id = ${subjectId}`;
+    if (!membership) throw new Error("managed human membership missing");
+    const authorityIds = [crypto.randomUUID(), crypto.randomUUID()];
+    const resourceIds = [crypto.randomUUID(), crypto.randomUUID()];
+    for (let index = 0; index < authorityIds.length; index += 1) {
+      await shared.admin`
+        insert into organization_user_resource_authorities (
+          id, account_id, organization_membership_id, resource_kind, resource_id,
+          origin_workspace_id, generation, status, created_at
+        ) values (
+          ${authorityIds[index]}, ${personalGrant.accountId}, ${membership.id}, 'rig',
+          ${resourceIds[index]}, ${personalGrant.workspaceId}, 1, 'active',
+          clock_timestamp() + (${index}::text || ' milliseconds')::interval
+        )`;
+    }
+    const authorization = {
+      grant: {
+        ...personalGrant,
+        permissions: [...new Set([...personalGrant.permissions, "rigs:use", "sessions:control"])],
+      },
+      accountGrant: access.accountGrants[0] ?? null,
+      authenticatedSubjectId: subjectId,
+      contextIntegrity: true,
+      canonicalManagedHumanSession: true,
+    } satisfies AccessGrantAuthorization;
+    const session = await createSession(client.db, {
+      accountId: personalGrant.accountId,
+      workspaceId: personalGrant.workspaceId,
+      initialMessage: "grant target",
+      resources: [],
+      metadata: {},
+      createdBy: { kind: "subject", subjectId },
+      model: "test-model",
+      reasoningEffort: "medium",
+      latencyMode: "standard",
+      sandboxBackend: "none",
+    });
+    const grantOperations: SessionAuthorizationOperation[] = [];
+    const deps = {
+      db: client.db,
+      sessionAuthorization: {
+        authorizeSession: async (input) => {
+          grantOperations.push(input.operation);
+          return { allowed: true as const, relatedSessionAccess: "root" as const };
+        },
+        resolveListScope: async () => ({ kind: "all" as const }),
+      },
+    };
+
+    const firstPage = await listManagedHumanUserResourceAuthorities(
+      deps,
+      authorization,
+      personalGrant.workspaceId,
+      { resourceKind: "rig", limit: 1 },
+    );
+    expect(firstPage.authorities).toHaveLength(1);
+    expect(firstPage.nextCursor).toBe(firstPage.authorities[0]?.authorityId ?? null);
+    const secondPage = await listManagedHumanUserResourceAuthorities(
+      deps,
+      authorization,
+      personalGrant.workspaceId,
+      { resourceKind: "rig", cursor: firstPage.nextCursor ?? undefined, limit: 1 },
+    );
+    expect(secondPage.authorities).toHaveLength(1);
+    expect(secondPage.nextCursor).toBeNull();
+
+    const issued = await issueManagedHumanUserResourceGrant(
+      deps,
+      authorization,
+      personalGrant.workspaceId,
+      authorityIds[0]!,
+      {
+        scope: "user",
+        resourceKind: "rig",
+        mode: "session",
+        context: "workspace_shared",
+        sessionId: session.id,
+        expectedAuthorityEpoch: 1,
+        workspaceSharedAcknowledged: true,
+      },
+    );
+    expect(issued).toMatchObject({
+      action: "rig.use",
+      authorityEpoch: 1,
+      mode: "session",
+      status: "active",
+      delegation: {
+        authorityId: authorityIds[0],
+        organizationId: personalGrant.accountId,
+        workspaceId: personalGrant.workspaceId,
+        sessionId: session.id,
+        authorityEpoch: 1,
+        authorityGeneration: 1,
+        grantGeneration: 1,
+      },
+    });
+    expect(grantOperations).toEqual(["session.personal_resource.grant"]);
+    await shared.admin`
+      update organization_user_resource_grants
+      set expires_at = clock_timestamp() - interval '1 second'
+      where id = ${issued.grantId}`;
+    const reissued = await issueManagedHumanUserResourceGrant(
+      deps,
+      authorization,
+      personalGrant.workspaceId,
+      authorityIds[0]!,
+      {
+        scope: "user",
+        resourceKind: "rig",
+        mode: "session",
+        context: "workspace_shared",
+        sessionId: session.id,
+        expectedAuthorityEpoch: 1,
+        workspaceSharedAcknowledged: true,
+      },
+    );
+    expect(reissued).toMatchObject({ status: "active", action: "rig.use" });
+    expect(reissued.grantId).not.toBe(issued.grantId);
+    await expect(
+      issueManagedHumanUserResourceGrant(
+        deps,
+        authorization,
+        personalGrant.workspaceId,
+        authorityIds[1]!,
+        {
+          scope: "user",
+          resourceKind: "rig",
+          mode: "session",
+          context: "workspace_shared",
+          sessionId: crypto.randomUUID(),
+          expectedAuthorityEpoch: 1,
+          workspaceSharedAcknowledged: true,
+        },
+      ),
+    ).rejects.toBeInstanceOf(SessionAuthorizationDeniedError);
+    expect(grantOperations).toEqual([
+      "session.personal_resource.grant",
+      "session.personal_resource.grant",
+    ]);
+
+    const revoked = await revokeManagedHumanUserResourceGrant(
+      deps,
+      authorization,
+      personalGrant.workspaceId,
+      reissued.grantId,
+    );
+    expect(revoked).toMatchObject({ grantId: reissued.grantId, status: "revoked", generation: 2 });
+    const replay = await revokeManagedHumanUserResourceGrant(
+      deps,
+      authorization,
+      personalGrant.workspaceId,
+      reissued.grantId,
+    );
+    expect(replay).toEqual(revoked);
+
+    const otherWorkspaceGrant = access.workspaceGrants.find(
+      (candidate) => candidate.workspaceId === access.defaultWorkspaceId,
+    );
+    if (!otherWorkspaceGrant) throw new Error("managed human has no shared workspace grant");
+    const otherAuthorization = { ...authorization, grant: otherWorkspaceGrant };
+    await expect(
+      revokeManagedHumanUserResourceGrant(
+        deps,
+        otherAuthorization,
+        otherWorkspaceGrant.workspaceId,
+        reissued.grantId,
+      ),
+    ).rejects.toBeDefined();
+  }, 180_000);
+
   test("authorizes, mutates, publishes the exact durable events, and replays without a wake", async () => {
     if (!shared || !client) return;
     const userId = `core-session-tenancy-${crypto.randomUUID()}`;

--- a/packages/db/drizzle/0305_personal_resource_grant_management.sql
+++ b/packages/db/drizzle/0305_personal_resource_grant_management.sql
@@ -1,0 +1,584 @@
+-- deployment-mode: rolling
+-- Harden owner-managed personal-resource grants behind the activated session-
+-- tenancy product boundary. Old lifecycle signatures are revoked from the
+-- runtime role so rolling old callers fail closed rather than retain ambient
+-- cross-workspace inventory or caller-selected action authority.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+-- This table is FORCE-RLS. Production migrations run as its NOSUPERUSER,
+-- NOBYPASSRLS owner without tenant GUCs, so the owner must be made visible for
+-- this exact transactional backfill window. Ordinary roles remain policy-bound.
+ALTER TABLE "organization_user_resource_grants" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE "organization_user_resource_authorities" NO FORCE ROW LEVEL SECURITY;
+
+-- Sparse upgrade fixtures may predate the action-contract trigger. When it is
+-- present, retain its exact enabled mode across this transactional maintenance
+-- window instead of assuming the ordinary-origin state.
+DO $migration$
+DECLARE
+  prior_trigger_state text;
+BEGIN
+  SELECT trigger_value.tgenabled::text
+  INTO prior_trigger_state
+  FROM pg_catalog.pg_trigger trigger_value
+  WHERE trigger_value.tgrelid = 'organization_user_resource_grants'::regclass
+    AND trigger_value.tgname = 'organization_user_resource_grants_action_contract'
+    AND NOT trigger_value.tgisinternal;
+
+  PERFORM pg_catalog.set_config(
+    'opengeni.migration_0305_action_contract_trigger_state',
+    coalesce(prior_trigger_state, 'missing'),
+    true
+  );
+  IF prior_trigger_state IS NOT NULL AND prior_trigger_state <> 'D' THEN
+    ALTER TABLE "organization_user_resource_grants"
+      DISABLE TRIGGER organization_user_resource_grants_action_contract;
+  END IF;
+END
+$migration$;
+
+UPDATE "organization_user_resource_grants"
+SET status = 'expired', updated_at = clock_timestamp()
+WHERE status = 'active' AND expires_at IS NOT NULL AND expires_at <= clock_timestamp();
+
+-- Old generic issue callers could author an arbitrary action. Preserve those
+-- rows as history, but settle every still-active mismatch so it can never be
+-- admitted as authority under a different resource kind.
+UPDATE "organization_user_resource_grants" grant_value
+SET status = 'revoked', revoked_at = coalesce(grant_value.revoked_at, clock_timestamp()),
+    generation = grant_value.generation + 1, updated_at = clock_timestamp()
+FROM "organization_user_resource_authorities" authority
+WHERE authority.id = grant_value.authority_id
+  AND authority.account_id = grant_value.account_id
+  AND grant_value.status = 'active'
+  AND grant_value.action IS DISTINCT FROM CASE authority.resource_kind
+    WHEN 'connection' THEN 'connection.use'
+    WHEN 'document' THEN 'document.read'
+    WHEN 'variable_set' THEN 'variable_set.use'
+    WHEN 'rig' THEN 'rig.use'
+    WHEN 'connected_machine' THEN 'connected_machine.use'
+    ELSE NULL
+  END;
+
+ALTER TABLE "organization_user_resource_grants" FORCE ROW LEVEL SECURITY;
+ALTER TABLE "organization_user_resource_authorities" FORCE ROW LEVEL SECURITY;
+DO $migration$
+DECLARE
+  prior_trigger_state text := pg_catalog.current_setting(
+    'opengeni.migration_0305_action_contract_trigger_state', true
+  );
+BEGIN
+  IF prior_trigger_state = 'O' THEN
+    ALTER TABLE "organization_user_resource_grants"
+      ENABLE TRIGGER organization_user_resource_grants_action_contract;
+  ELSIF prior_trigger_state = 'D' THEN
+    ALTER TABLE "organization_user_resource_grants"
+      DISABLE TRIGGER organization_user_resource_grants_action_contract;
+  ELSIF prior_trigger_state = 'R' THEN
+    ALTER TABLE "organization_user_resource_grants"
+      ENABLE REPLICA TRIGGER organization_user_resource_grants_action_contract;
+  ELSIF prior_trigger_state = 'A' THEN
+    ALTER TABLE "organization_user_resource_grants"
+      ENABLE ALWAYS TRIGGER organization_user_resource_grants_action_contract;
+  ELSIF prior_trigger_state IS DISTINCT FROM 'missing' THEN
+    RAISE EXCEPTION 'invalid saved action-contract trigger state'
+      USING ERRCODE = '55000';
+  END IF;
+END
+$migration$;
+
+-- Runtime management remains lifecycle-only under FORCE RLS. The application
+-- role still has zero table privileges; these policy branches are reachable
+-- only inside the constrained SECURITY DEFINER routines below.
+ALTER POLICY organization_tenancy_lifecycle ON "organization_memberships"
+  USING (current_setting('opengeni.organization_tenancy_lifecycle', true)
+    IN (
+      'managed_human_provisioning',
+      'session_visibility_activation',
+      'organization_membership_lifecycle',
+      'personal_resource_grant_management'
+    ))
+  WITH CHECK (current_setting('opengeni.organization_tenancy_lifecycle', true)
+    IN (
+      'managed_human_provisioning',
+      'session_visibility_activation',
+      'organization_membership_lifecycle',
+      'personal_resource_grant_management'
+    ));
+ALTER POLICY organization_tenancy_lifecycle ON "organization_user_resource_authorities"
+  USING (current_setting('opengeni.organization_tenancy_lifecycle', true)
+    IN (
+      'managed_human_provisioning',
+      'organization_membership_lifecycle',
+      'personal_resource_grant_management'
+    ))
+  WITH CHECK (current_setting('opengeni.organization_tenancy_lifecycle', true)
+    IN (
+      'managed_human_provisioning',
+      'organization_membership_lifecycle',
+      'personal_resource_grant_management'
+    ));
+ALTER POLICY organization_tenancy_lifecycle ON "organization_user_resource_grants"
+  USING (current_setting('opengeni.organization_tenancy_lifecycle', true)
+    IN (
+      'managed_human_provisioning',
+      'session_visibility_activation',
+      'organization_membership_lifecycle',
+      'personal_resource_grant_management'
+    ))
+  WITH CHECK (current_setting('opengeni.organization_tenancy_lifecycle', true)
+    IN (
+      'managed_human_provisioning',
+      'session_visibility_activation',
+      'organization_membership_lifecycle',
+      'personal_resource_grant_management'
+    ));
+
+CREATE OR REPLACE FUNCTION list_self_user_resource_authorities(
+  p_account_id uuid,
+  p_workspace_id uuid,
+  p_resource_kind text,
+  p_after_authority_id uuid DEFAULT NULL,
+  p_limit integer DEFAULT 50
+) RETURNS TABLE (
+  authority_id uuid, organization_id uuid, resource_kind text, resource_id uuid,
+  origin_workspace_id uuid, authority_generation bigint, authority_status text,
+  grant_id uuid, target_workspace_id uuid, target_session_id uuid, action text,
+  grant_mode text, grant_context text, authority_epoch integer,
+  grant_generation bigint, grant_status text, expires_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $body$
+#variable_conflict use_column
+DECLARE
+  caller_subject text := nullif(current_setting('opengeni.subject_id', true), '');
+  owner_membership_id uuid;
+  cursor_created_at timestamptz;
+  cursor_id uuid;
+BEGIN
+  PERFORM set_config(
+    'opengeni.organization_tenancy_lifecycle', 'personal_resource_grant_management', true
+  );
+  IF p_account_id IS DISTINCT FROM nullif(current_setting('opengeni.account_id', true), '')::uuid
+    OR p_workspace_id IS DISTINCT FROM nullif(
+      current_setting('opengeni.workspace_id', true), ''
+    )::uuid
+    OR caller_subject IS NULL
+  THEN
+    RAISE EXCEPTION 'user-resource authority scope mismatch' USING ERRCODE = '42501';
+  END IF;
+  IF p_resource_kind IS NULL OR p_resource_kind NOT IN (
+    'connection', 'document', 'variable_set', 'rig', 'connected_machine'
+  ) OR p_limit IS NULL OR p_limit NOT BETWEEN 1 AND 101 THEN
+    RAISE EXCEPTION 'invalid user-resource authority page' USING ERRCODE = '22023';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM session_tenancy_activations activation
+    WHERE activation.account_id = p_account_id AND activation.activation_version = 1
+  ) THEN
+    RAISE EXCEPTION 'session tenancy product is not activated' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT membership.id INTO owner_membership_id
+  FROM organization_memberships membership
+  WHERE membership.account_id = p_account_id
+    AND membership.subject_id = caller_subject
+    AND membership.status = 'active'
+    AND membership.revoked_at IS NULL
+  FOR SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'owner membership not found or access denied' USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM 1 FROM workspaces workspace_value
+  WHERE workspace_value.id = p_workspace_id
+    AND workspace_value.account_id = p_account_id
+    AND EXISTS (
+      SELECT 1 FROM organization_memberships membership
+      WHERE membership.id = owner_membership_id
+        AND (
+          membership.personal_workspace_id = p_workspace_id
+          OR EXISTS (
+            SELECT 1 FROM workspace_memberships workspace_membership
+            WHERE workspace_membership.account_id = p_account_id
+              AND workspace_membership.workspace_id = p_workspace_id
+              AND workspace_membership.subject_id = caller_subject
+          )
+        )
+    )
+  FOR SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'owner lacks current route-workspace access' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_after_authority_id IS NOT NULL THEN
+    SELECT authority.created_at, authority.id
+      INTO cursor_created_at, cursor_id
+    FROM organization_user_resource_authorities authority
+    WHERE authority.id = p_after_authority_id
+      AND authority.account_id = p_account_id
+      AND authority.organization_membership_id = owner_membership_id
+      AND authority.resource_kind = p_resource_kind;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'invalid user-resource authority cursor' USING ERRCODE = '22023';
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  WITH authority_page AS MATERIALIZED (
+    SELECT authority.*
+    FROM organization_user_resource_authorities authority
+    WHERE authority.account_id = p_account_id
+      AND authority.organization_membership_id = owner_membership_id
+      AND authority.resource_kind = p_resource_kind
+      AND (
+        p_after_authority_id IS NULL
+        OR (authority.created_at, authority.id) > (cursor_created_at, cursor_id)
+      )
+    ORDER BY authority.created_at, authority.id
+    LIMIT p_limit
+  )
+  SELECT authority.id, authority.account_id, authority.resource_kind,
+    authority.resource_id, authority.origin_workspace_id, authority.generation,
+    authority.status, grant_value.id, grant_value.workspace_id,
+    grant_value.session_id, grant_value.action, grant_value.mode,
+    grant_value.context, grant_value.authority_epoch, grant_value.generation,
+    CASE
+      WHEN grant_value.status = 'active'
+        AND grant_value.expires_at IS NOT NULL
+        AND grant_value.expires_at <= clock_timestamp()
+      THEN 'expired'
+      ELSE grant_value.status
+    END,
+    grant_value.expires_at
+  FROM authority_page authority
+  LEFT JOIN organization_user_resource_grants grant_value
+    ON grant_value.account_id = authority.account_id
+   AND grant_value.authority_id = authority.id
+   AND grant_value.owner_organization_membership_id = owner_membership_id
+   AND grant_value.workspace_id = p_workspace_id
+   AND grant_value.action = CASE authority.resource_kind
+     WHEN 'connection' THEN 'connection.use'
+     WHEN 'document' THEN 'document.read'
+     WHEN 'variable_set' THEN 'variable_set.use'
+     WHEN 'rig' THEN 'rig.use'
+     WHEN 'connected_machine' THEN 'connected_machine.use'
+     ELSE NULL
+   END
+  ORDER BY authority.created_at, authority.id, grant_value.created_at, grant_value.id;
+END
+$body$;
+
+CREATE OR REPLACE FUNCTION issue_self_user_resource_grant(
+  p_account_id uuid,
+  p_authority_id uuid,
+  p_workspace_id uuid,
+  p_resource_kind text,
+  p_mode text,
+  p_context text,
+  p_session_id uuid DEFAULT NULL,
+  p_expected_authority_epoch integer DEFAULT NULL,
+  p_workspace_shared_acknowledged boolean DEFAULT false
+) RETURNS TABLE (
+  grant_id uuid, organization_id uuid, authority_generation bigint,
+  target_workspace_id uuid, target_session_id uuid, action text,
+  grant_mode text, grant_context text, authority_epoch integer,
+  grant_generation bigint, grant_status text, expires_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $body$
+#variable_conflict use_column
+DECLARE
+  caller_subject text := nullif(current_setting('opengeni.subject_id', true), '');
+  owner_membership_id uuid;
+  target_epoch integer;
+  target_visibility text;
+  canonical_action text;
+BEGIN
+  PERFORM set_config(
+    'opengeni.organization_tenancy_lifecycle', 'personal_resource_grant_management', true
+  );
+  IF p_account_id IS DISTINCT FROM nullif(current_setting('opengeni.account_id', true), '')::uuid
+    OR p_workspace_id IS DISTINCT FROM nullif(
+      current_setting('opengeni.workspace_id', true), ''
+    )::uuid
+    OR caller_subject IS NULL
+  THEN
+    RAISE EXCEPTION 'user-resource grant scope mismatch' USING ERRCODE = '42501';
+  END IF;
+  canonical_action := CASE p_resource_kind
+    WHEN 'connection' THEN 'connection.use'
+    WHEN 'document' THEN 'document.read'
+    WHEN 'variable_set' THEN 'variable_set.use'
+    WHEN 'rig' THEN 'rig.use'
+    WHEN 'connected_machine' THEN 'connected_machine.use'
+    ELSE NULL
+  END;
+  IF p_resource_kind IS NULL OR canonical_action IS NULL
+    OR p_mode IS NULL OR p_mode NOT IN ('session', 'always')
+    OR p_context IS NULL OR p_context NOT IN ('user_private', 'workspace_shared')
+    OR (p_mode = 'always' AND (p_session_id IS NOT NULL OR p_expected_authority_epoch IS NOT NULL))
+    OR (p_mode = 'session' AND (p_session_id IS NULL OR p_expected_authority_epoch IS NULL))
+    OR coalesce(p_expected_authority_epoch, 1) <= 0
+  THEN
+    RAISE EXCEPTION 'invalid user-resource grant request' USING ERRCODE = '22023';
+  END IF;
+  IF p_context = 'workspace_shared' AND p_workspace_shared_acknowledged IS NOT TRUE THEN
+    RAISE EXCEPTION 'workspace_shared requires durable shared-output acknowledgement'
+      USING ERRCODE = '42501';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM session_tenancy_activations activation
+    WHERE activation.account_id = p_account_id AND activation.activation_version = 1
+  ) THEN
+    RAISE EXCEPTION 'session tenancy product is not activated' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT membership.id INTO owner_membership_id
+  FROM organization_memberships membership
+  WHERE membership.account_id = p_account_id
+    AND membership.subject_id = caller_subject
+    AND membership.status = 'active'
+    AND membership.revoked_at IS NULL
+  FOR SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'owner membership not found or access denied' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT authority.generation INTO authority_generation
+  FROM organization_user_resource_authorities authority
+  WHERE authority.id = p_authority_id
+    AND authority.account_id = p_account_id
+    AND authority.organization_membership_id = owner_membership_id
+    AND authority.resource_kind = p_resource_kind
+    AND authority.status = 'active'
+    AND authority.revoked_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'user-resource authority not found or access denied' USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM 1 FROM workspaces workspace_value
+  WHERE workspace_value.id = p_workspace_id AND workspace_value.account_id = p_account_id
+  FOR SHARE;
+  IF NOT FOUND OR NOT EXISTS (
+    SELECT 1 FROM organization_memberships membership
+    WHERE membership.id = owner_membership_id
+      AND (
+        membership.personal_workspace_id = p_workspace_id
+        OR EXISTS (
+          SELECT 1 FROM workspace_memberships workspace_membership
+          WHERE workspace_membership.account_id = p_account_id
+            AND workspace_membership.workspace_id = p_workspace_id
+            AND workspace_membership.subject_id = caller_subject
+        )
+      )
+  ) THEN
+    RAISE EXCEPTION 'owner lacks current target-workspace access' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_session_id IS NOT NULL THEN
+    SELECT session_value.authority_epoch, session_value.visibility
+      INTO target_epoch, target_visibility
+    FROM sessions session_value
+    WHERE session_value.id = p_session_id
+      AND session_value.account_id = p_account_id
+      AND session_value.workspace_id = p_workspace_id
+      AND session_value.status <> 'cancelled'
+    FOR SHARE;
+    IF NOT FOUND
+      OR target_visibility IS DISTINCT FROM p_context
+      OR target_epoch IS DISTINCT FROM p_expected_authority_epoch
+    THEN
+      RAISE EXCEPTION 'target session not found or access denied' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  UPDATE organization_user_resource_grants grant_value
+  SET status = 'expired', updated_at = clock_timestamp()
+  WHERE grant_value.account_id = p_account_id
+    AND grant_value.authority_id = p_authority_id
+    AND grant_value.status = 'active'
+    AND grant_value.expires_at IS NOT NULL
+    AND grant_value.expires_at <= clock_timestamp();
+
+  INSERT INTO organization_user_resource_grants (
+    account_id, authority_id, owner_organization_membership_id, workspace_id,
+    session_id, action, mode, context, authority_epoch, generation, status
+  ) VALUES (
+    p_account_id, p_authority_id, owner_membership_id, p_workspace_id,
+    p_session_id, canonical_action, p_mode, p_context, target_epoch, 1, 'active'
+  )
+  ON CONFLICT (account_id, authority_id, workspace_id, action, mode, context,
+    (coalesce(session_id, '00000000-0000-0000-0000-000000000000'::uuid)),
+    (coalesce(authority_epoch, 0))) WHERE status = 'active'
+  DO UPDATE SET updated_at = organization_user_resource_grants.updated_at
+  RETURNING id, workspace_id, session_id, organization_user_resource_grants.action,
+    mode, context, organization_user_resource_grants.authority_epoch, generation,
+    status, organization_user_resource_grants.expires_at
+  INTO grant_id, target_workspace_id, target_session_id, action, grant_mode,
+    grant_context, authority_epoch, grant_generation, grant_status, expires_at;
+  organization_id := p_account_id;
+  RETURN NEXT;
+END
+$body$;
+
+CREATE OR REPLACE FUNCTION revoke_self_user_resource_grant(
+  p_account_id uuid,
+  p_workspace_id uuid,
+  p_grant_id uuid
+) RETURNS TABLE (
+  grant_id uuid, grant_generation bigint, grant_status text, revoked_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path FROM CURRENT
+AS $body$
+#variable_conflict use_column
+DECLARE
+  caller_subject text := nullif(current_setting('opengeni.subject_id', true), '');
+  owner_membership_id uuid;
+BEGIN
+  PERFORM set_config(
+    'opengeni.organization_tenancy_lifecycle', 'personal_resource_grant_management', true
+  );
+  IF p_account_id IS DISTINCT FROM nullif(current_setting('opengeni.account_id', true), '')::uuid
+    OR p_workspace_id IS DISTINCT FROM nullif(
+      current_setting('opengeni.workspace_id', true), ''
+    )::uuid
+    OR caller_subject IS NULL
+  THEN
+    RAISE EXCEPTION 'user-resource revoke scope mismatch' USING ERRCODE = '42501';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM session_tenancy_activations activation
+    WHERE activation.account_id = p_account_id AND activation.activation_version = 1
+  ) THEN
+    RAISE EXCEPTION 'session tenancy product is not activated' USING ERRCODE = '42501';
+  END IF;
+  SELECT membership.id INTO owner_membership_id
+  FROM organization_memberships membership
+  WHERE membership.account_id = p_account_id
+    AND membership.subject_id = caller_subject
+    AND membership.status = 'active'
+    AND membership.revoked_at IS NULL
+  FOR SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'owner membership not found or access denied' USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE organization_user_resource_grants grant_value
+  SET status = 'revoked', revoked_at = clock_timestamp(),
+      generation = grant_value.generation + 1, updated_at = clock_timestamp()
+  FROM organization_user_resource_authorities authority
+  WHERE grant_value.id = p_grant_id
+    AND grant_value.account_id = p_account_id
+    AND grant_value.workspace_id = p_workspace_id
+    AND authority.id = grant_value.authority_id
+    AND authority.account_id = grant_value.account_id
+    AND authority.organization_membership_id = owner_membership_id
+    AND grant_value.owner_organization_membership_id = owner_membership_id
+    AND grant_value.status <> 'revoked'
+  RETURNING grant_value.id, grant_value.generation, grant_value.status, grant_value.revoked_at
+  INTO grant_id, grant_generation, grant_status, revoked_at;
+  IF FOUND THEN RETURN NEXT; RETURN; END IF;
+
+  SELECT grant_value.id, grant_value.generation, grant_value.status, grant_value.revoked_at
+    INTO grant_id, grant_generation, grant_status, revoked_at
+  FROM organization_user_resource_grants grant_value
+  JOIN organization_user_resource_authorities authority
+    ON authority.id = grant_value.authority_id AND authority.account_id = grant_value.account_id
+  WHERE grant_value.id = p_grant_id
+    AND grant_value.account_id = p_account_id
+    AND grant_value.workspace_id = p_workspace_id
+    AND authority.organization_membership_id = owner_membership_id
+    AND grant_value.owner_organization_membership_id = owner_membership_id
+    AND grant_value.status = 'revoked';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'self-owned user-resource grant not found' USING ERRCODE = '42501';
+  END IF;
+  RETURN NEXT;
+END
+$body$;
+
+-- `SET search_path FROM CURRENT` captures the target schema during function
+-- creation. Replace that broad migration path with the exact immutable runtime
+-- path before this transaction can commit.
+DO $harden_runtime_search_paths$
+DECLARE
+  data_schema text := current_schema();
+BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.list_self_user_resource_authorities(uuid, uuid, text, uuid, integer) SET search_path = pg_catalog, %I, pg_temp',
+    data_schema, data_schema
+  );
+  EXECUTE format(
+    'ALTER FUNCTION %I.issue_self_user_resource_grant(uuid, uuid, uuid, text, text, text, uuid, integer, boolean) SET search_path = pg_catalog, %I, pg_temp',
+    data_schema, data_schema
+  );
+  EXECUTE format(
+    'ALTER FUNCTION %I.revoke_self_user_resource_grant(uuid, uuid, uuid) SET search_path = pg_catalog, %I, pg_temp',
+    data_schema, data_schema
+  );
+END
+$harden_runtime_search_paths$;
+
+REVOKE ALL ON FUNCTION list_self_user_resource_authorities(uuid, uuid, text, uuid, integer)
+  FROM PUBLIC;
+REVOKE ALL ON FUNCTION issue_self_user_resource_grant(
+  uuid, uuid, uuid, text, text, text, uuid, integer, boolean
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION revoke_self_user_resource_grant(uuid, uuid, uuid) FROM PUBLIC;
+
+DO $runtime_grants$
+DECLARE
+  legacy_signature text;
+  legacy_function regprocedure;
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'opengeni_app') THEN
+    FOREACH legacy_signature IN ARRAY ARRAY[
+      'list_self_user_resource_authorities(uuid)',
+      'issue_self_user_resource_grant(uuid,uuid,uuid,text,text,text,uuid,boolean)',
+      'revoke_self_user_resource_grant(uuid,uuid)',
+      'list_self_connection_authorities(uuid)',
+      'issue_self_connection_use_grant(uuid,uuid,uuid,text,text,uuid,boolean)',
+      'revoke_self_connection_use_grant(uuid,uuid)'
+    ]
+    LOOP
+      legacy_function := pg_catalog.to_regprocedure(
+        pg_catalog.format('%I.%s', pg_catalog.current_schema(), legacy_signature)
+      );
+      IF legacy_function IS NOT NULL THEN
+        EXECUTE pg_catalog.format(
+          'REVOKE ALL ON FUNCTION %s FROM opengeni_app', legacy_function
+        );
+      END IF;
+    END LOOP;
+
+    GRANT EXECUTE ON FUNCTION
+      list_self_user_resource_authorities(uuid, uuid, text, uuid, integer)
+      TO opengeni_app;
+    GRANT EXECUTE ON FUNCTION issue_self_user_resource_grant(
+      uuid, uuid, uuid, text, text, text, uuid, integer, boolean
+    ) TO opengeni_app;
+    GRANT EXECUTE ON FUNCTION revoke_self_user_resource_grant(uuid, uuid, uuid)
+      TO opengeni_app;
+    REVOKE ALL ON TABLE organization_user_resource_authorities FROM opengeni_app;
+    REVOKE ALL ON TABLE organization_user_resource_grants FROM opengeni_app;
+  END IF;
+END
+$runtime_grants$;
+
+COMMENT ON FUNCTION list_self_user_resource_authorities(uuid, uuid, text, uuid, integer) IS
+  'Bounded owner-only personal-resource page filtered to one kind and route workspace.';
+COMMENT ON FUNCTION issue_self_user_resource_grant(
+  uuid, uuid, uuid, text, text, text, uuid, integer, boolean
+) IS 'Issues server-action-derived session/always grants after exact owner and tenancy fences.';
+COMMENT ON FUNCTION revoke_self_user_resource_grant(uuid, uuid, uuid) IS
+  'Idempotently revokes an exact owner grant only through its route workspace.';

--- a/packages/db/src/connection-authority.ts
+++ b/packages/db/src/connection-authority.ts
@@ -15,20 +15,11 @@ import {
 } from "@opengeni/contracts";
 import { sql } from "drizzle-orm";
 import { rawRows, setSubjectRlsContext, withRlsContext, type Database } from "./database";
-
-type ConnectionAuthorityRow = {
-  authorityId: string;
-  authorityGeneration: number;
-  authorityStatus: "active" | "retained" | "revoked";
-  grantId: string | null;
-  targetWorkspaceId: string | null;
-  targetSessionId: string | null;
-  mode: "once" | "session" | "always" | null;
-  context: "user_private" | "workspace_shared" | null;
-  grantGeneration: number | null;
-  grantStatus: "active" | "consumed" | "revoked" | "expired" | null;
-  expiresAt: string | null;
-};
+import {
+  issueSelfUserResourceGrant,
+  listSelfUserResourceAuthorities,
+  revokeSelfUserResourceGrant,
+} from "./user-resource-authority";
 
 async function withOwnerContext<T>(
   db: Database,
@@ -45,56 +36,14 @@ export async function listSelfConnectionAuthorities(
   db: Database,
   input: { accountId: string; workspaceId: string; subjectId: string },
 ): Promise<ConnectionAuthoritySummary[]> {
-  return await withOwnerContext(db, input, async (scopedDb) => {
-    const rows = await rawRows<ConnectionAuthorityRow>(
-      scopedDb,
-      sql`
-        select authority_id as "authorityId",
-          authority_generation::int as "authorityGeneration",
-          authority_status as "authorityStatus", grant_id as "grantId",
-          target_workspace_id as "targetWorkspaceId",
-          target_session_id as "targetSessionId", grant_mode as mode,
-          grant_context as context, grant_generation::int as "grantGeneration",
-          grant_status as "grantStatus", expires_at::text as "expiresAt"
-        from list_self_connection_authorities(${input.accountId}::uuid)
-      `,
-    );
-    const grouped = new Map<string, ConnectionAuthoritySummary>();
-    for (const row of rows) {
-      const authority =
-        grouped.get(row.authorityId) ??
-        ConnectionAuthoritySummary.parse({
-          authorityId: row.authorityId,
-          generation: row.authorityGeneration,
-          status: row.authorityStatus,
-          grants: [],
-        });
-      if (
-        row.grantId &&
-        row.targetWorkspaceId &&
-        row.mode &&
-        row.context &&
-        row.grantGeneration &&
-        row.grantStatus
-      ) {
-        authority.grants.push(
-          ConnectionAuthorityGrant.parse({
-            grantId: row.grantId,
-            targetWorkspaceId: row.targetWorkspaceId,
-            targetSessionId: row.targetSessionId,
-            action: "connection.use",
-            mode: row.mode,
-            context: row.context,
-            generation: row.grantGeneration,
-            status: row.grantStatus,
-            expiresAt: row.expiresAt,
-          }),
-        );
-      }
-      grouped.set(row.authorityId, authority);
-    }
-    return [...grouped.values()];
+  const page = await listSelfUserResourceAuthorities(db, {
+    ...input,
+    resourceKind: "connection",
+    limit: 100,
   });
+  return page.authorities.map(({ resourceKind: _resourceKind, ...authority }) =>
+    ConnectionAuthoritySummary.parse(authority),
+  );
 }
 
 export async function issueSelfConnectionUseGrant(
@@ -107,60 +56,27 @@ export async function issueSelfConnectionUseGrant(
     request: IssueConnectionUseGrantRequest;
   },
 ) {
-  return await withOwnerContext(db, input, async (scopedDb) => {
-    const [row] = await rawRows<{
-      grantId: string;
-      targetWorkspaceId: string;
-      targetSessionId: string | null;
-      action: "connection.use";
-      mode: "once" | "session" | "always";
-      context: "user_private" | "workspace_shared";
-      generation: number;
-      status: "active" | "consumed" | "revoked" | "expired";
-      expiresAt: string | null;
-    }>(
-      scopedDb,
-      sql`
-        select grant_id as "grantId", target_workspace_id as "targetWorkspaceId",
-          target_session_id as "targetSessionId", action, grant_mode as mode,
-          grant_context as context, grant_generation::int as generation,
-          grant_status as status, expires_at::text as "expiresAt"
-        from issue_self_connection_use_grant(
-          ${input.accountId}::uuid, ${input.authorityId}::uuid,
-          ${input.workspaceId}::uuid, ${input.request.mode}, ${input.request.context},
-          ${input.request.sessionId ?? null}::uuid,
-          ${input.request.workspaceSharedAcknowledged}
-        )
-      `,
-    );
-    if (!row) throw new Error("connection use grant was not returned");
-    return ConnectionAuthorityGrant.parse(row);
-  });
+  return ConnectionAuthorityGrant.parse(
+    await issueSelfUserResourceGrant(db, {
+      accountId: input.accountId,
+      workspaceId: input.workspaceId,
+      subjectId: input.subjectId,
+      authorityId: input.authorityId,
+      resourceKind: "connection",
+      mode: input.request.mode,
+      context: input.request.context,
+      sessionId: input.request.sessionId ?? null,
+      expectedAuthorityEpoch: input.request.expectedAuthorityEpoch ?? null,
+      workspaceSharedAcknowledged: input.request.workspaceSharedAcknowledged,
+    }),
+  );
 }
 
 export async function revokeSelfConnectionUseGrant(
   db: Database,
   input: { accountId: string; workspaceId: string; subjectId: string; grantId: string },
 ): Promise<{ grantId: string; generation: number; status: "revoked"; revokedAt: string }> {
-  return await withOwnerContext(db, input, async (scopedDb) => {
-    const [row] = await rawRows<{
-      grantId: string;
-      generation: number;
-      status: "revoked";
-      revokedAt: string;
-    }>(
-      scopedDb,
-      sql`
-        select grant_id as "grantId", grant_generation::int as generation,
-          grant_status as status, revoked_at::text as "revokedAt"
-        from revoke_self_connection_use_grant(
-          ${input.accountId}::uuid, ${input.grantId}::uuid
-        )
-      `,
-    );
-    if (!row) throw new Error("connection use grant was not returned");
-    return row;
-  });
+  return await revokeSelfUserResourceGrant(db, input);
 }
 
 /**

--- a/packages/db/src/provision-roles.ts
+++ b/packages/db/src/provision-roles.ts
@@ -1296,25 +1296,31 @@ BEGIN
         ${literal(role)}
       );
     END IF;
-    IF to_regprocedure(format('%I.list_self_user_resource_authorities(uuid)', ${literal(schema)}))
+    IF to_regprocedure(format('%I.list_self_user_resource_authorities(uuid,uuid,text,uuid,integer)', ${literal(schema)}))
       IS NOT NULL THEN
       EXECUTE format('REVOKE ALL ON FUNCTION %I.list_self_user_resource_authorities(uuid) FROM PUBLIC', ${literal(schema)});
-      EXECUTE format('GRANT EXECUTE ON FUNCTION %I.list_self_user_resource_authorities(uuid) TO %I', ${literal(schema)}, ${literal(role)});
+      EXECUTE format('REVOKE ALL ON FUNCTION %I.list_self_user_resource_authorities(uuid) FROM %I', ${literal(schema)}, ${literal(role)});
       EXECUTE format('REVOKE ALL ON FUNCTION %I.issue_self_user_resource_grant(uuid, uuid, uuid, text, text, text, uuid, boolean) FROM PUBLIC', ${literal(schema)});
-      EXECUTE format('GRANT EXECUTE ON FUNCTION %I.issue_self_user_resource_grant(uuid, uuid, uuid, text, text, text, uuid, boolean) TO %I', ${literal(schema)}, ${literal(role)});
+      EXECUTE format('REVOKE ALL ON FUNCTION %I.issue_self_user_resource_grant(uuid, uuid, uuid, text, text, text, uuid, boolean) FROM %I', ${literal(schema)}, ${literal(role)});
       EXECUTE format('REVOKE ALL ON FUNCTION %I.revoke_self_user_resource_grant(uuid, uuid) FROM PUBLIC', ${literal(schema)});
-      EXECUTE format('GRANT EXECUTE ON FUNCTION %I.revoke_self_user_resource_grant(uuid, uuid) TO %I', ${literal(schema)}, ${literal(role)});
+      EXECUTE format('REVOKE ALL ON FUNCTION %I.revoke_self_user_resource_grant(uuid, uuid) FROM %I', ${literal(schema)}, ${literal(role)});
+      EXECUTE format('REVOKE ALL ON FUNCTION %I.list_self_user_resource_authorities(uuid, uuid, text, uuid, integer) FROM PUBLIC', ${literal(schema)});
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %I.list_self_user_resource_authorities(uuid, uuid, text, uuid, integer) TO %I', ${literal(schema)}, ${literal(role)});
+      EXECUTE format('REVOKE ALL ON FUNCTION %I.issue_self_user_resource_grant(uuid, uuid, uuid, text, text, text, uuid, integer, boolean) FROM PUBLIC', ${literal(schema)});
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %I.issue_self_user_resource_grant(uuid, uuid, uuid, text, text, text, uuid, integer, boolean) TO %I', ${literal(schema)}, ${literal(role)});
+      EXECUTE format('REVOKE ALL ON FUNCTION %I.revoke_self_user_resource_grant(uuid, uuid, uuid) FROM PUBLIC', ${literal(schema)});
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %I.revoke_self_user_resource_grant(uuid, uuid, uuid) TO %I', ${literal(schema)}, ${literal(role)});
       EXECUTE format('REVOKE ALL ON FUNCTION %I.authorize_session_attempt_personal_resource_reads(uuid, uuid, uuid) FROM PUBLIC', ${literal(schema)});
       EXECUTE format('GRANT EXECUTE ON FUNCTION %I.authorize_session_attempt_personal_resource_reads(uuid, uuid, uuid) TO %I', ${literal(schema)}, ${literal(role)});
     END IF;
     IF to_regprocedure(format('%I.resolve_connection_use_authority(uuid,uuid,uuid,jsonb)', ${literal(schema)}))
       IS NOT NULL THEN
       EXECUTE format('REVOKE ALL ON FUNCTION %I.list_self_connection_authorities(uuid) FROM PUBLIC', ${literal(schema)});
-      EXECUTE format('GRANT EXECUTE ON FUNCTION %I.list_self_connection_authorities(uuid) TO %I', ${literal(schema)}, ${literal(role)});
+      EXECUTE format('REVOKE ALL ON FUNCTION %I.list_self_connection_authorities(uuid) FROM %I', ${literal(schema)}, ${literal(role)});
       EXECUTE format('REVOKE ALL ON FUNCTION %I.issue_self_connection_use_grant(uuid, uuid, uuid, text, text, uuid, boolean) FROM PUBLIC', ${literal(schema)});
-      EXECUTE format('GRANT EXECUTE ON FUNCTION %I.issue_self_connection_use_grant(uuid, uuid, uuid, text, text, uuid, boolean) TO %I', ${literal(schema)}, ${literal(role)});
+      EXECUTE format('REVOKE ALL ON FUNCTION %I.issue_self_connection_use_grant(uuid, uuid, uuid, text, text, uuid, boolean) FROM %I', ${literal(schema)}, ${literal(role)});
       EXECUTE format('REVOKE ALL ON FUNCTION %I.revoke_self_connection_use_grant(uuid, uuid) FROM PUBLIC', ${literal(schema)});
-      EXECUTE format('GRANT EXECUTE ON FUNCTION %I.revoke_self_connection_use_grant(uuid, uuid) TO %I', ${literal(schema)}, ${literal(role)});
+      EXECUTE format('REVOKE ALL ON FUNCTION %I.revoke_self_connection_use_grant(uuid, uuid) FROM %I', ${literal(schema)}, ${literal(role)});
       EXECUTE format('REVOKE ALL ON FUNCTION %I.resolve_connection_use_authority(uuid, uuid, uuid, jsonb) FROM PUBLIC', ${literal(schema)});
       EXECUTE format('GRANT EXECUTE ON FUNCTION %I.resolve_connection_use_authority(uuid, uuid, uuid, jsonb) TO %I', ${literal(schema)}, ${literal(role)});
       IF to_regprocedure(format('%I.resolve_personal_connection_authority_selection(uuid,uuid,text,uuid,jsonb)', ${literal(schema)})) IS NOT NULL THEN

--- a/packages/db/src/runtime-posture.ts
+++ b/packages/db/src/runtime-posture.ts
@@ -127,15 +127,12 @@ const MANAGED_HUMAN_PERSONAL_WORKSPACE_AUTHORITY_TABLES = [
 const PERSONAL_RESOURCE_ATTEMPT_RESOLVER_ROUTINE =
   "resolve_session_attempt_personal_resources(uuid, uuid, uuid)";
 const USER_RESOURCE_LIFECYCLE_ROUTINES = [
-  "list_self_user_resource_authorities(uuid)",
-  "issue_self_user_resource_grant(uuid, uuid, uuid, text, text, text, uuid, boolean)",
-  "revoke_self_user_resource_grant(uuid, uuid)",
+  "list_self_user_resource_authorities(uuid, uuid, text, uuid, integer)",
+  "issue_self_user_resource_grant(uuid, uuid, uuid, text, text, text, uuid, integer, boolean)",
+  "revoke_self_user_resource_grant(uuid, uuid, uuid)",
   "authorize_session_attempt_personal_resource_reads(uuid, uuid, uuid)",
 ] as const;
 const CONNECTION_AUTHORITY_ROUTINES = [
-  "list_self_connection_authorities(uuid)",
-  "issue_self_connection_use_grant(uuid, uuid, uuid, text, text, uuid, boolean)",
-  "revoke_self_connection_use_grant(uuid, uuid)",
   "resolve_personal_connection_authority_selection(uuid, uuid, text, uuid, jsonb)",
   "resolve_accepted_connection_use(uuid, uuid, uuid, uuid, uuid, integer, uuid, text, text, uuid, text, text, text, text)",
   "resolve_connection_use_authority(uuid, uuid, uuid, jsonb)",
@@ -346,6 +343,7 @@ export const RUNTIME_TARGET_SCHEMA_CAPABILITY_ROUTINES = [
   MANAGED_HUMAN_PERSONAL_WORKSPACE_ROUTINE,
   ...ORGANIZATION_MEMBERSHIP_LIFECYCLE_ROUTINES,
   PERSONAL_RESOURCE_ATTEMPT_RESOLVER_ROUTINE,
+  ...USER_RESOURCE_LIFECYCLE_ROUTINES,
   PREFERENCE_KNOWLEDGE_PROPOSAL_ROUTINE,
   ...VARIABLE_SET_AUTHORITY_ROUTINES,
   ...CONNECTION_AUTHORITY_ROUTINES,

--- a/packages/db/src/user-resource-authority.ts
+++ b/packages/db/src/user-resource-authority.ts
@@ -1,3 +1,8 @@
+import {
+  USER_RESOURCE_ACTION_BY_KIND,
+  type UserResourceDelegation,
+  type UserResourceKind,
+} from "@opengeni/contracts";
 import { sql } from "drizzle-orm";
 import { rawRows, setSubjectRlsContext, withRlsContext, type Database } from "./database";
 
@@ -5,30 +10,47 @@ export type UserResourceAuthorityGrant = {
   grantId: string;
   targetWorkspaceId: string;
   targetSessionId: string | null;
-  action: string;
+  action: (typeof USER_RESOURCE_ACTION_BY_KIND)[UserResourceKind];
   mode: "once" | "session" | "always";
   context: "user_private" | "workspace_shared";
+  authorityEpoch: number | null;
   generation: number;
   status: "active" | "consumed" | "revoked" | "expired";
   expiresAt: string | null;
+  delegation: UserResourceDelegation;
 };
 
 export type UserResourceAuthoritySummary = {
   authorityId: string;
-  resourceKind: string;
+  resourceKind: UserResourceKind;
+  resourceId: string;
+  originWorkspaceId: string | null;
   generation: number;
   status: "active" | "retained" | "revoked";
   grants: UserResourceAuthorityGrant[];
 };
 
-type AuthorityRow = Omit<UserResourceAuthorityGrant, "grantId" | "targetWorkspaceId"> & {
+type AuthorityRow = Omit<
+  UserResourceAuthorityGrant,
+  "grantId" | "targetWorkspaceId" | "delegation"
+> & {
   authorityId: string;
-  resourceKind: string;
+  organizationId: string;
+  resourceKind: UserResourceKind;
+  resourceId: string;
+  originWorkspaceId: string | null;
   authorityGeneration: number;
   authorityStatus: UserResourceAuthoritySummary["status"];
   grantId: string | null;
   targetWorkspaceId: string | null;
 };
+
+function rfc3339(value: string | null): string | null {
+  if (value === null) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) throw new Error("invalid database timestamptz projection");
+  return date.toISOString();
+}
 
 async function withOwnerContext<T>(
   db: Database,
@@ -43,20 +65,33 @@ async function withOwnerContext<T>(
 
 export async function listSelfUserResourceAuthorities(
   db: Database,
-  input: { accountId: string; workspaceId: string; subjectId: string },
-): Promise<UserResourceAuthoritySummary[]> {
+  input: {
+    accountId: string;
+    workspaceId: string;
+    subjectId: string;
+    resourceKind: UserResourceKind;
+    cursor?: string | undefined;
+    limit: number;
+  },
+): Promise<{ authorities: UserResourceAuthoritySummary[]; nextCursor: string | null }> {
   return await withOwnerContext(db, input, async (scopedDb) => {
     const rows = await rawRows<AuthorityRow>(
       scopedDb,
       sql`
-      select authority_id as "authorityId", resource_kind as "resourceKind",
+      select authority_id as "authorityId", organization_id as "organizationId",
+        resource_kind as "resourceKind", resource_id as "resourceId",
+        origin_workspace_id as "originWorkspaceId",
         authority_generation::int as "authorityGeneration",
         authority_status as "authorityStatus", grant_id as "grantId",
         target_workspace_id as "targetWorkspaceId", target_session_id as "targetSessionId",
         action, grant_mode as mode, grant_context as context,
+        authority_epoch::int as "authorityEpoch",
         grant_generation::int as generation, grant_status as status,
         expires_at::text as "expiresAt"
-      from list_self_user_resource_authorities(${input.accountId}::uuid)
+      from list_self_user_resource_authorities(
+        ${input.accountId}::uuid, ${input.workspaceId}::uuid, ${input.resourceKind},
+        ${input.cursor ?? null}::uuid, ${input.limit + 1}
+      )
     `,
     );
     const grouped = new Map<string, UserResourceAuthoritySummary>();
@@ -64,6 +99,8 @@ export async function listSelfUserResourceAuthorities(
       const authority = grouped.get(row.authorityId) ?? {
         authorityId: row.authorityId,
         resourceKind: row.resourceKind,
+        resourceId: row.resourceId,
+        originWorkspaceId: row.originWorkspaceId,
         generation: row.authorityGeneration,
         status: row.authorityStatus,
         grants: [],
@@ -76,14 +113,34 @@ export async function listSelfUserResourceAuthorities(
           action: row.action,
           mode: row.mode,
           context: row.context,
+          authorityEpoch: row.authorityEpoch,
           generation: row.generation,
           status: row.status,
-          expiresAt: row.expiresAt,
+          expiresAt: rfc3339(row.expiresAt),
+          delegation: {
+            authorityId: row.authorityId,
+            grantId: row.grantId,
+            organizationId: row.organizationId,
+            workspaceId: row.targetWorkspaceId,
+            sessionId: row.targetSessionId,
+            action: row.action,
+            mode: row.mode,
+            context: row.context,
+            authorityEpoch: row.authorityEpoch,
+            authorityGeneration: row.authorityGeneration,
+            grantGeneration: row.generation,
+          },
         });
       }
       grouped.set(row.authorityId, authority);
     }
-    return [...grouped.values()];
+    const values = [...grouped.values()];
+    const hasMore = values.length > input.limit;
+    const authorities = hasMore ? values.slice(0, input.limit) : values;
+    return {
+      authorities,
+      nextCursor: hasMore ? (authorities.at(-1)?.authorityId ?? null) : null,
+    };
   });
 }
 
@@ -94,30 +151,57 @@ export async function issueSelfUserResourceGrant(
     workspaceId: string;
     subjectId: string;
     authorityId: string;
-    action: string;
-    mode: "once" | "session" | "always";
+    resourceKind: UserResourceKind;
+    mode: "session" | "always";
     context: "user_private" | "workspace_shared";
     sessionId?: string | null;
+    expectedAuthorityEpoch?: number | null;
     workspaceSharedAcknowledged: boolean;
   },
 ): Promise<UserResourceAuthorityGrant> {
   return await withOwnerContext(db, input, async (scopedDb) => {
-    const [row] = await rawRows<UserResourceAuthorityGrant>(
+    const [row] = await rawRows<
+      Omit<UserResourceAuthorityGrant, "delegation"> & {
+        organizationId: string;
+        authorityGeneration: number;
+      }
+    >(
       scopedDb,
       sql`
-      select grant_id as "grantId", target_workspace_id as "targetWorkspaceId",
+      select grant_id as "grantId", organization_id as "organizationId",
+        authority_generation::int as "authorityGeneration",
+        target_workspace_id as "targetWorkspaceId",
         target_session_id as "targetSessionId", action, grant_mode as mode,
-        grant_context as context, grant_generation::int as generation,
+        grant_context as context, authority_epoch::int as "authorityEpoch",
+        grant_generation::int as generation,
         grant_status as status, expires_at::text as "expiresAt"
       from issue_self_user_resource_grant(
         ${input.accountId}::uuid, ${input.authorityId}::uuid, ${input.workspaceId}::uuid,
-        ${input.action}, ${input.mode}, ${input.context}, ${input.sessionId ?? null}::uuid,
+        ${input.resourceKind}, ${input.mode}, ${input.context},
+        ${input.sessionId ?? null}::uuid, ${input.expectedAuthorityEpoch ?? null}::integer,
         ${input.workspaceSharedAcknowledged}
       )
     `,
     );
     if (!row) throw new Error("user-resource grant was not returned");
-    return row;
+    const { organizationId, authorityGeneration, ...grant } = row;
+    return {
+      ...grant,
+      expiresAt: rfc3339(grant.expiresAt),
+      delegation: {
+        authorityId: input.authorityId,
+        grantId: grant.grantId,
+        organizationId,
+        workspaceId: grant.targetWorkspaceId,
+        sessionId: grant.targetSessionId,
+        action: grant.action,
+        mode: grant.mode,
+        context: grant.context,
+        authorityEpoch: grant.authorityEpoch,
+        authorityGeneration,
+        grantGeneration: grant.generation,
+      },
+    };
   });
 }
 
@@ -136,11 +220,13 @@ export async function revokeSelfUserResourceGrant(
       sql`
       select grant_id as "grantId", grant_generation::int as generation,
         grant_status as status, revoked_at::text as "revokedAt"
-      from revoke_self_user_resource_grant(${input.accountId}::uuid, ${input.grantId}::uuid)
+      from revoke_self_user_resource_grant(
+        ${input.accountId}::uuid, ${input.workspaceId}::uuid, ${input.grantId}::uuid
+      )
     `,
     );
     if (!row) throw new Error("user-resource grant was not returned");
-    return row;
+    return { ...row, revokedAt: rfc3339(row.revokedAt)! };
   });
 }
 

--- a/packages/db/test/migration-0218-organization-tenancy-foundation.test.ts
+++ b/packages/db/test/migration-0218-organization-tenancy-foundation.test.ts
@@ -33,14 +33,10 @@ const historicalTenancySystemOnlyPolicy = "organization_tenancy_system_only";
 const currentLedgerTenancyLifecyclePolicy = "organization_tenancy_lifecycle";
 const currentManagedHumanTenancyLifecycleExpression =
   "(current_setting('opengeni.organization_tenancy_lifecycle'::text, true) = ANY (ARRAY['managed_human_provisioning'::text, 'organization_membership_lifecycle'::text]))";
+const currentPersonalResourceTenancyLifecycleExpression =
+  "(current_setting('opengeni.organization_tenancy_lifecycle'::text, true) = ANY (ARRAY['managed_human_provisioning'::text, 'organization_membership_lifecycle'::text, 'personal_resource_grant_management'::text]))";
 const currentSessionVisibilityTenancyLifecycleExpression =
-  "(current_setting('opengeni.organization_tenancy_lifecycle'::text, true) = ANY (ARRAY['managed_human_provisioning'::text, 'session_visibility_activation'::text, 'organization_membership_lifecycle'::text]))";
-// Migration 0290 adds the read-only `organization_membership_backfill` marker
-// to `organization_memberships`' USING clause ONLY. Its WITH CHECK keeps
-// exactly the three pre-existing write markers, so the backfill enumeration is
-// structurally incapable of writing that table.
-const currentMembershipBackfillTenancyLifecycleReadExpression =
-  "(current_setting('opengeni.organization_tenancy_lifecycle'::text, true) = ANY (ARRAY['managed_human_provisioning'::text, 'session_visibility_activation'::text, 'organization_membership_lifecycle'::text, 'organization_membership_backfill'::text]))";
+  "(current_setting('opengeni.organization_tenancy_lifecycle'::text, true) = ANY (ARRAY['managed_human_provisioning'::text, 'session_visibility_activation'::text, 'organization_membership_lifecycle'::text, 'personal_resource_grant_management'::text]))";
 
 let shared: SharedTestDatabase | null = null;
 let client: DbClient | null = null;
@@ -528,20 +524,18 @@ describe("migration 0218 organization tenancy foundation", () => {
     // assert the current lifecycle policy while the static checks above preserve
     // 0218's historical deny-all contract. Migration 0263 retains managed-human
     // provisioning and session-visibility activation while adding only its exact
-    // organization-membership capability; direct app privileges remain deny-all.
+    // organization-membership capability. Migration 0305 replaces those exact
+    // policies with the same prior write markers plus only its constrained
+    // personal-resource lifecycle marker; direct app privileges remain deny-all.
     expect([...policyRows]).toEqual(
       [...tenancyTables].sort().map((tableName) => {
         const lifecycleExpression =
           tableName === "organization_memberships" ||
           tableName === "organization_user_resource_grants"
             ? currentSessionVisibilityTenancyLifecycleExpression
-            : currentManagedHumanTenancyLifecycleExpression;
-        // 0290's read-only marker widens exactly one USING clause; every
-        // WITH CHECK on every tenancy table stays on the write markers.
-        const readExpression =
-          tableName === "organization_memberships"
-            ? currentMembershipBackfillTenancyLifecycleReadExpression
-            : lifecycleExpression;
+            : tableName === "organization_user_resource_authorities"
+              ? currentPersonalResourceTenancyLifecycleExpression
+              : currentManagedHumanTenancyLifecycleExpression;
         return {
           tableName,
           rlsEnabled: true,
@@ -549,7 +543,7 @@ describe("migration 0218 organization tenancy foundation", () => {
           policyCount: 1,
           policyNames: [currentLedgerTenancyLifecyclePolicy],
           policyCommands: ["*"],
-          usingExpressions: [readExpression],
+          usingExpressions: [lifecycleExpression],
           checkExpressions: [lifecycleExpression],
           appSelect: false,
           appInsert: false,

--- a/packages/db/test/migration-0249-personal-resource-delegation-authority-correction.test.ts
+++ b/packages/db/test/migration-0249-personal-resource-delegation-authority-correction.test.ts
@@ -184,6 +184,22 @@ describe("migration 0249 personal-resource delegation authority correction", () 
         target: "personal",
         workspaceMembership: false,
       });
+      const legacySignatures = [
+        "list_self_user_resource_authorities(uuid)",
+        "issue_self_user_resource_grant(uuid,uuid,uuid,text,text,text,uuid,boolean)",
+        "revoke_self_user_resource_grant(uuid,uuid)",
+        "list_self_connection_authorities(uuid)",
+        "issue_self_connection_use_grant(uuid,uuid,uuid,text,text,uuid,boolean)",
+        "revoke_self_connection_use_grant(uuid,uuid)",
+      ];
+      const legacyFunctions = await sql<Array<{ signature: string; procedure: string | null }>>`
+        select signature,
+          to_regprocedure(format('%I.%s', current_schema(), signature))::text as procedure
+        from unnest(${sql.array(legacySignatures)}::text[]) as signature
+        order by signature`;
+      expect(Array.from(legacyFunctions)).toEqual(
+        [...legacySignatures].sort().map((signature) => ({ signature, procedure: null })),
+      );
       await expect(insertAttempt(sql, ids, ids.attemptId)).rejects.toThrow(
         "initiating human lacks target-workspace membership",
       );

--- a/packages/db/test/migration-0254-scoped-variable-set-authority.test.ts
+++ b/packages/db/test/migration-0254-scoped-variable-set-authority.test.ts
@@ -204,6 +204,11 @@ describe("migration 0254 scoped variable-set authority", () => {
           (${account.id}, ${workspaceA.id}, ${otherSubject}),
           (${account.id}, ${workspaceB.id}, ${otherSubject})
       `;
+      await admin`
+        insert into session_tenancy_activations (
+          account_id, activation_version, inventory_digest, parity_digest, activated_by
+        ) values (${account.id}, 1, ${"5".repeat(64)}, ${"6".repeat(64)}, '0254-test')
+      `;
 
       const ownerWorkspaceA: ActorScope = {
         accountId: account.id,
@@ -346,7 +351,9 @@ describe("migration 0254 scoped variable-set authority", () => {
           select authority_id as "authorityId",
             authority_generation::int as "authorityGeneration",
             authority_status as "authorityStatus", grant_id as "grantId"
-          from list_self_user_resource_authorities(${account.id}::uuid)
+          from list_self_user_resource_authorities(
+            ${account.id}::uuid, ${workspaceB.id}::uuid, 'variable_set', null, 100
+          )
         `,
       );
       expect(
@@ -402,8 +409,8 @@ describe("migration 0254 scoped variable-set authority", () => {
               grant_status as "grantStatus"
             from issue_self_user_resource_grant(
               ${account.id}::uuid, ${ownerAuthority!.authorityId}::uuid,
-              ${workspaceB.id}::uuid, 'variable_set.use', 'session',
-              'workspace_shared', ${session.id}::uuid, true
+              ${workspaceB.id}::uuid, 'variable_set', 'session',
+              'workspace_shared', ${session.id}::uuid, 1, true
             )
           `,
         );
@@ -501,7 +508,8 @@ describe("migration 0254 scoped variable-set authority", () => {
         const [revoked] = await tx<Array<{ grantStatus: string; grantGeneration: number }>>`
           select grant_status as "grantStatus", grant_generation::int as "grantGeneration"
           from revoke_self_user_resource_grant(
-            ${account.id}::uuid, ${revokedAttempt.grant.grantId}::uuid
+            ${account.id}::uuid, ${workspaceB.id}::uuid,
+            ${revokedAttempt.grant.grantId}::uuid
           )
         `;
         expect(revoked).toEqual({ grantStatus: "revoked", grantGeneration: 2 });
@@ -526,8 +534,8 @@ describe("migration 0254 scoped variable-set authority", () => {
           select grant_id as "grantId"
           from issue_self_user_resource_grant(
             ${account.id}::uuid, ${deleteAuthority!.authorityId}::uuid,
-            ${workspaceB.id}::uuid, 'variable_set.use', 'always',
-            'workspace_shared', null, true
+            ${workspaceB.id}::uuid, 'variable_set', 'always',
+            'workspace_shared', null, null, true
           )
         `,
       );
@@ -577,7 +585,9 @@ describe("migration 0254 scoped variable-set authority", () => {
             authority_generation::int as "authorityGeneration",
             authority_status as "authorityStatus", grant_id as "grantId",
             grant_generation::int as "grantGeneration", grant_status as "grantStatus"
-          from list_self_user_resource_authorities(${account.id}::uuid)
+          from list_self_user_resource_authorities(
+            ${account.id}::uuid, ${workspaceB.id}::uuid, 'variable_set', null, 100
+          )
         `,
       );
       expect(

--- a/packages/db/test/migration-0258-three-scope-document-knowledge-authority.test.ts
+++ b/packages/db/test/migration-0258-three-scope-document-knowledge-authority.test.ts
@@ -116,6 +116,10 @@ describe("migration 0258 three-scope Document/Knowledge authority", () => {
           (${account!.id}, ${workspaceA.id}, ${ownerSubject}),
           (${account!.id}, ${workspaceB.id}, ${ownerSubject}),
           (${account!.id}, ${workspaceB.id}, ${otherSubject})`;
+      await admin`
+        insert into session_tenancy_activations (
+          account_id, activation_version, inventory_digest, parity_digest, activated_by
+        ) values (${account!.id}, 1, ${"7".repeat(64)}, ${"8".repeat(64)}, '0258-test')`;
 
       const ownerA = {
         accountId: account!.id,
@@ -305,17 +309,15 @@ describe("migration 0258 three-scope Document/Knowledge authority", () => {
         select visibility, authority_epoch as epoch,
           owner_organization_membership_id as "membershipId"
         from sessions where id = ${session.id}`;
-      const [grant] = await withScope(
-        app,
-        ownerB,
-        async (tx) =>
-          await tx<Array<{ grantId: string }>>`
-          select grant_id as "grantId" from issue_self_user_resource_grant(
-            ${account!.id}::uuid, ${authority!.authorityId}::uuid,
-            ${workspaceB.id}::uuid, 'document.read', 'once',
-            'workspace_shared', ${session.id}::uuid, true
-          )`,
-      );
+      const [grant] = await admin<Array<{ grantId: string }>>`
+        insert into organization_user_resource_grants (
+          account_id, authority_id, owner_organization_membership_id, workspace_id,
+          session_id, action, mode, context, authority_epoch, generation, status
+        ) values (
+          ${account!.id}, ${authority!.authorityId}, ${ownerMembership!.id},
+          ${workspaceB.id}, ${session.id}, 'document.read', 'once', 'workspace_shared',
+          ${sessionAuthority!.epoch}, 1, 'active'
+        ) returning id as "grantId"`;
       const [turn] = await admin<Array<{ id: string }>>`
         insert into session_turns (
           account_id, workspace_id, session_id, trigger_event_id, temporal_workflow_id,
@@ -351,8 +353,8 @@ describe("migration 0258 three-scope Document/Knowledge authority", () => {
       await withScope(app, ownerB, async (tx) => {
         await tx`select issue_self_user_resource_grant(
           ${account!.id}::uuid, ${lateAuthority!.authorityId}::uuid,
-          ${workspaceB.id}::uuid, 'document.read', 'always',
-          'workspace_shared', null, true
+          ${workspaceB.id}::uuid, 'document', 'always',
+          'workspace_shared', null, null, true
         )`;
       });
 
@@ -369,7 +371,7 @@ describe("migration 0258 three-scope Document/Knowledge authority", () => {
       expect(await resolve()).toEqual([documentId]);
       await withScope(app, ownerB, async (tx) => {
         await tx`select revoke_self_user_resource_grant(
-          ${account!.id}::uuid, ${grant!.grantId}::uuid
+          ${account!.id}::uuid, ${workspaceB.id}::uuid, ${grant!.grantId}::uuid
         )`;
       });
       await expect(resolve()).rejects.toThrow(/snapshot is no longer live/iu);

--- a/packages/db/test/migration-0262-scoped-connected-machines-and-rigs.test.ts
+++ b/packages/db/test/migration-0262-scoped-connected-machines-and-rigs.test.ts
@@ -119,6 +119,11 @@ describe("migration 0262 scoped Connected Machines and Rigs", () => {
           (${account!.id}, ${workspaceA.id}, ${otherSubject}),
           (${account!.id}, ${workspaceB.id}, ${otherSubject})
       `;
+      await admin`
+        insert into session_tenancy_activations (
+          account_id, activation_version, inventory_digest, parity_digest, activated_by
+        ) values (${account!.id}, 1, ${"9".repeat(64)}, ${"a".repeat(64)}, '0262-test')
+      `;
 
       const ownerA: Actor = {
         accountId: account!.id,
@@ -257,8 +262,8 @@ describe("migration 0262 scoped Connected Machines and Rigs", () => {
         await tx`
           select grant_id from issue_self_user_resource_grant(
             ${account!.id}::uuid, ${machineAuthority!.id}::uuid,
-            ${workspaceB.id}::uuid, 'connected_machine.use', 'session',
-            'workspace_shared', ${session.id}::uuid, true
+            ${workspaceB.id}::uuid, 'connected_machine', 'session',
+            'workspace_shared', ${session.id}::uuid, 1, true
           )
         `;
       });
@@ -412,8 +417,8 @@ describe("migration 0262 scoped Connected Machines and Rigs", () => {
         await tx`
           select grant_id from issue_self_user_resource_grant(
             ${account!.id}::uuid, ${sideMachineAuthority!.id}::uuid,
-            ${workspaceB.id}::uuid, 'connected_machine.use', 'always',
-            'user_private', null, true
+            ${workspaceB.id}::uuid, 'connected_machine', 'always',
+            'user_private', null, null, true
           )
         `;
       });
@@ -422,8 +427,8 @@ describe("migration 0262 scoped Connected Machines and Rigs", () => {
         await tx`
           select grant_id from issue_self_user_resource_grant(
             ${account!.id}::uuid, ${sideMachineAuthority!.id}::uuid,
-            ${workspaceA.id}::uuid, 'connected_machine.use', 'always',
-            'workspace_shared', null, true
+            ${workspaceA.id}::uuid, 'connected_machine', 'always',
+            'workspace_shared', null, null, true
           )
         `;
       });
@@ -432,8 +437,8 @@ describe("migration 0262 scoped Connected Machines and Rigs", () => {
         await tx`
           select grant_id from issue_self_user_resource_grant(
             ${account!.id}::uuid, ${sideMachineAuthority!.id}::uuid,
-            ${workspaceB.id}::uuid, 'connected_machine.use', 'session',
-            'workspace_shared', ${session.id}::uuid, true
+            ${workspaceB.id}::uuid, 'connected_machine', 'session',
+            'workspace_shared', ${session.id}::uuid, 1, true
           )
         `;
       });

--- a/packages/db/test/migration-0305-personal-resource-grant-management.test.ts
+++ b/packages/db/test/migration-0305-personal-resource-grant-management.test.ts
@@ -1,0 +1,340 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  acquireOwnerMigratedTestDatabase,
+  type OwnerMigratedTestDatabase,
+} from "@opengeni/testing";
+import type postgres from "postgres";
+import { migrate } from "../src/migrate";
+
+const migrationName = "0305_personal_resource_grant_management.sql";
+const migrationPath = join(dirname(fileURLToPath(import.meta.url)), "../drizzle", migrationName);
+const requireRealDatabase = process.env.OPENGENI_REQUIRE_REAL_DB === "1";
+
+async function expectSqlState(run: () => Promise<unknown>, code: string): Promise<void> {
+  let captured: unknown;
+  try {
+    await run();
+  } catch (error) {
+    captured = error;
+  }
+  expect(captured).toBeDefined();
+  expect((captured as { code?: string }).code).toBe(code);
+}
+
+describe("migration 0305 personal-resource grant management", () => {
+  test("opens and closes one exact FORCE-RLS backfill window and hardens runtime paths", async () => {
+    const source = await readFile(migrationPath, "utf8");
+    const noForce = 'ALTER TABLE "organization_user_resource_grants" NO FORCE ROW LEVEL SECURITY;';
+    const force = 'ALTER TABLE "organization_user_resource_grants" FORCE ROW LEVEL SECURITY;';
+    const authorityNoForce =
+      'ALTER TABLE "organization_user_resource_authorities" NO FORCE ROW LEVEL SECURITY;';
+    const authorityForce =
+      'ALTER TABLE "organization_user_resource_authorities" FORCE ROW LEVEL SECURITY;';
+    expect(source.indexOf(noForce)).toBeGreaterThan(-1);
+    expect(source.indexOf(force)).toBeGreaterThan(source.indexOf(noForce));
+    expect(source.indexOf(authorityNoForce)).toBeGreaterThan(source.indexOf(noForce));
+    expect(source.indexOf(authorityForce)).toBeGreaterThan(source.indexOf(force));
+    expect(source).toContain("coalesce(prior_trigger_state, 'missing')");
+    expect(source).toContain("prior_trigger_state IS NOT NULL AND prior_trigger_state <> 'D'");
+    expect(source).toContain("ENABLE TRIGGER organization_user_resource_grants_action_contract");
+    expect(source).toContain(
+      "ENABLE REPLICA TRIGGER organization_user_resource_grants_action_contract",
+    );
+    expect(source).toContain(
+      "ENABLE ALWAYS TRIGGER organization_user_resource_grants_action_contract",
+    );
+    expect(source.indexOf('UPDATE "organization_user_resource_grants"')).toBeGreaterThan(
+      source.indexOf(noForce),
+    );
+    expect(source.indexOf('UPDATE "organization_user_resource_grants" grant_value')).toBeLessThan(
+      source.indexOf(force),
+    );
+    expect(source).toContain("ALTER FUNCTION %I.list_self_user_resource_authorities");
+    expect(source).toContain("SET search_path = pg_catalog, %I, pg_temp");
+    expect(source).toContain("grant_value.action = CASE authority.resource_kind");
+    expect(source).toContain("p_workspace_shared_acknowledged IS NOT TRUE");
+    expect(source).toContain("p_limit IS NULL");
+    expect(source).toContain("p_resource_kind IS NULL");
+    expect(source).toContain("p_mode IS NULL");
+    expect(source).toContain("p_context IS NULL");
+    expect(source).toContain("FOREACH legacy_signature IN ARRAY ARRAY[");
+    const legacyRevocationBlock = source.match(
+      /FOREACH legacy_signature IN ARRAY ARRAY\[(.*?)\]\s+LOOP/s,
+    )?.[1];
+    expect(
+      Array.from(legacyRevocationBlock?.matchAll(/'([^']+\([^']*\))'/g) ?? []).map(
+        (match) => match[1],
+      ),
+    ).toEqual([
+      "list_self_user_resource_authorities(uuid)",
+      "issue_self_user_resource_grant(uuid,uuid,uuid,text,text,text,uuid,boolean)",
+      "revoke_self_user_resource_grant(uuid,uuid)",
+      "list_self_connection_authorities(uuid)",
+      "issue_self_connection_use_grant(uuid,uuid,uuid,text,text,uuid,boolean)",
+      "revoke_self_connection_use_grant(uuid,uuid)",
+    ]);
+    expect(source).toContain("pg_catalog.format('%I.%s', pg_catalog.current_schema()");
+  });
+});
+
+describe("migration 0305 under a NOSUPERUSER NOBYPASSRLS owner", () => {
+  let owned: OwnerMigratedTestDatabase | null = null;
+
+  beforeAll(async () => {
+    owned = await acquireOwnerMigratedTestDatabase("migration-0305-owner-migrated");
+    if (!owned) {
+      if (requireRealDatabase) {
+        throw new Error(
+          "[migration-0305] OPENGENI_REQUIRE_REAL_DB=1 but PostgreSQL is unavailable",
+        );
+      }
+      return;
+    }
+    await migrate(owned.ownerUrl);
+  }, 900_000);
+
+  afterAll(async () => {
+    await owned?.release();
+  }, 180_000);
+
+  test("expires canonical grants, revokes active mismatches, omits invalid history, and restores FORCE RLS", async () => {
+    if (!owned) return;
+    const { admin, ownerRole, ownerUrl } = owned;
+    const [identity] = await admin<Array<{ superuser: boolean; bypassRls: boolean }>>`
+      select rolsuper as "superuser", rolbypassrls as "bypassRls"
+      from pg_roles where rolname = ${ownerRole}`;
+    expect(identity).toEqual({ superuser: false, bypassRls: false });
+
+    const accountId = crypto.randomUUID();
+    const workspaceId = crypto.randomUUID();
+    const subjectId = `user:migration-0305-${crypto.randomUUID()}`;
+    const authorityId = crypto.randomUUID();
+    const connectionAuthorityId = crypto.randomUUID();
+    await admin`
+      insert into managed_accounts (id, name, external_source, external_id)
+      values (${accountId}, 'migration-0305', 'better-auth:user', ${accountId})`;
+    await admin`
+      insert into workspaces (id, account_id, name)
+      values (${workspaceId}, ${accountId}, 'migration-0305 personal')`;
+    await admin`
+      insert into workspace_inference_controls (workspace_id, account_id)
+      values (${workspaceId}, ${accountId})`;
+    const [membership] = await admin<Array<{ id: string }>>`
+      insert into organization_memberships (
+        account_id, subject_id, status, personal_workspace_id
+      ) values (${accountId}, ${subjectId}, 'active', ${workspaceId})
+      returning id`;
+    if (!membership) throw new Error("membership insert returned no row");
+    await admin`
+      insert into session_tenancy_activations (
+        account_id, activation_version, inventory_digest, parity_digest, activated_by
+      ) values (${accountId}, 1, ${"5".repeat(64)}, ${"6".repeat(64)}, 'migration-0305')`;
+    await admin`
+      insert into organization_user_resource_authorities (
+        id, account_id, organization_membership_id, resource_kind, resource_id,
+        origin_workspace_id, generation, status
+      ) values (
+        ${authorityId}, ${accountId}, ${membership.id}, 'rig', ${crypto.randomUUID()},
+        ${workspaceId}, 1, 'active'
+      )`;
+    await admin`
+      insert into organization_user_resource_authorities (
+        id, account_id, organization_membership_id, resource_kind, resource_id,
+        origin_workspace_id, generation, status
+      ) values (
+        ${connectionAuthorityId}, ${accountId}, ${membership.id}, 'connection',
+        ${crypto.randomUUID()}, ${workspaceId}, 1, 'active'
+      )`;
+
+    const expiredId = crypto.randomUUID();
+    const arbitraryId = crypto.randomUUID();
+    const crossKindId = crypto.randomUUID();
+    const invalidConnectionId = crypto.randomUUID();
+    const terminalId = crypto.randomUUID();
+    await admin`
+      alter table organization_user_resource_grants
+        disable trigger organization_user_resource_grants_action_contract`;
+    await admin`
+      insert into organization_user_resource_grants (
+        id, account_id, authority_id, owner_organization_membership_id, workspace_id,
+        action, mode, context, generation, status, expires_at, revoked_at
+      ) values
+        (${expiredId}, ${accountId}, ${authorityId}, ${membership.id}, ${workspaceId},
+          'rig.use', 'always', 'user_private', 1, 'active', now() - interval '1 hour', null),
+        (${arbitraryId}, ${accountId}, ${authorityId}, ${membership.id}, ${workspaceId},
+          'provider.admin', 'always', 'user_private', 1, 'active', null, null),
+        (${crossKindId}, ${accountId}, ${authorityId}, ${membership.id}, ${workspaceId},
+          'connection.use', 'always', 'user_private', 1, 'active', null, null),
+        (${invalidConnectionId}, ${accountId}, ${connectionAuthorityId}, ${membership.id},
+          ${workspaceId}, 'provider.admin', 'always', 'user_private', 1, 'active', null, null),
+        (${terminalId}, ${accountId}, ${authorityId}, ${membership.id}, ${workspaceId},
+          'legacy.read', 'always', 'user_private', 5, 'revoked', null, now() - interval '2 hours')`;
+    await admin`
+      alter table organization_user_resource_grants
+        enable trigger organization_user_resource_grants_action_contract`;
+
+    await admin`delete from schema_migrations where name = ${migrationName}`;
+    await migrate(ownerUrl);
+
+    const rows = await admin<
+      Array<{ id: string; status: string; generation: number; revokedAt: string | null }>
+    >`
+      select id, status, generation::int, revoked_at::text as "revokedAt"
+      from organization_user_resource_grants
+      where id in (
+        ${expiredId}, ${arbitraryId}, ${crossKindId}, ${invalidConnectionId}, ${terminalId}
+      )
+      order by id`;
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    expect(byId.get(expiredId)).toMatchObject({ status: "expired", generation: 1 });
+    expect(byId.get(arbitraryId)).toMatchObject({ status: "revoked", generation: 2 });
+    expect(byId.get(arbitraryId)?.revokedAt).not.toBeNull();
+    expect(byId.get(crossKindId)).toMatchObject({ status: "revoked", generation: 2 });
+    expect(byId.get(crossKindId)?.revokedAt).not.toBeNull();
+    expect(byId.get(invalidConnectionId)).toMatchObject({ status: "revoked", generation: 2 });
+    expect(byId.get(invalidConnectionId)?.revokedAt).not.toBeNull();
+    expect(byId.get(terminalId)).toMatchObject({ status: "revoked", generation: 5 });
+
+    const [posture] = await admin<Array<{ forced: boolean }>>`
+      select relforcerowsecurity as forced
+      from pg_class
+      where oid = 'organization_user_resource_grants'::regclass`;
+    expect(posture).toEqual({ forced: true });
+    const [trigger] = await admin<Array<{ enabled: string }>>`
+      select tgenabled as enabled from pg_trigger
+      where tgrelid = 'organization_user_resource_grants'::regclass
+        and tgname = 'organization_user_resource_grants_action_contract'`;
+    expect(trigger).toEqual({ enabled: "O" });
+
+    await admin`
+      alter table organization_user_resource_grants
+        disable trigger organization_user_resource_grants_action_contract`;
+    await admin`delete from schema_migrations where name = ${migrationName}`;
+    await migrate(ownerUrl);
+    const [disabledTrigger] = await admin<Array<{ enabled: string }>>`
+      select tgenabled as enabled from pg_trigger
+      where tgrelid = 'organization_user_resource_grants'::regclass
+        and tgname = 'organization_user_resource_grants_action_contract'`;
+    expect(disabledTrigger).toEqual({ enabled: "D" });
+    await admin`
+      alter table organization_user_resource_grants
+        enable trigger organization_user_resource_grants_action_contract`;
+    const legacySignatures = [
+      "list_self_user_resource_authorities(uuid)",
+      "issue_self_user_resource_grant(uuid,uuid,uuid,text,text,text,uuid,boolean)",
+      "revoke_self_user_resource_grant(uuid,uuid)",
+      "list_self_connection_authorities(uuid)",
+      "issue_self_connection_use_grant(uuid,uuid,uuid,text,text,uuid,boolean)",
+      "revoke_self_connection_use_grant(uuid,uuid)",
+    ];
+    const legacyPrivileges = await admin<Array<{ signature: string; executable: boolean }>>`
+      select signature,
+        has_function_privilege(
+          'opengeni_app',
+          to_regprocedure(format('%I.%s', current_schema(), signature)),
+          'EXECUTE'
+        ) as executable
+      from unnest(${admin.array(legacySignatures)}::text[]) as signature
+      order by signature`;
+    expect(Array.from(legacyPrivileges)).toEqual(
+      [...legacySignatures].sort().map((signature) => ({ signature, executable: false })),
+    );
+    const routines = await admin<Array<{ name: string; settings: string[] | null }>>`
+      select proname as name, proconfig as settings
+      from pg_proc
+      where oid in (
+        'list_self_user_resource_authorities(uuid,uuid,text,uuid,integer)'::regprocedure,
+        'issue_self_user_resource_grant(uuid,uuid,uuid,text,text,text,uuid,integer,boolean)'::regprocedure,
+        'revoke_self_user_resource_grant(uuid,uuid,uuid)'::regprocedure
+      )
+      order by proname`;
+    expect(Array.from(routines)).toEqual([
+      {
+        name: "issue_self_user_resource_grant",
+        settings: ["search_path=pg_catalog, public, pg_temp"],
+      },
+      {
+        name: "list_self_user_resource_authorities",
+        settings: ["search_path=pg_catalog, public, pg_temp"],
+      },
+      {
+        name: "revoke_self_user_resource_grant",
+        settings: ["search_path=pg_catalog, public, pg_temp"],
+      },
+    ]);
+
+    const listed = await admin.begin(async (sql) => {
+      await sql`select set_config('opengeni.account_id', ${accountId}, true)`;
+      await sql`select set_config('opengeni.workspace_id', ${workspaceId}, true)`;
+      await sql`select set_config('opengeni.subject_id', ${subjectId}, true)`;
+      return await sql<Array<{ grantId: string | null; action: string | null }>>`
+        select grant_id as "grantId", action
+        from list_self_user_resource_authorities(
+          ${accountId}::uuid, ${workspaceId}::uuid, 'rig', null, 50
+        )`;
+    });
+    expect(listed.filter((row) => row.grantId !== null)).toEqual([
+      { grantId: expiredId, action: "rig.use" },
+    ]);
+
+    const asAppRole = async (
+      run: (sql: postgres.TransactionSql) => Promise<unknown>,
+    ): Promise<unknown> =>
+      await admin.begin(async (sql) => {
+        await sql.unsafe("set local role opengeni_app");
+        await sql`select set_config('opengeni.account_id', ${accountId}, true)`;
+        await sql`select set_config('opengeni.workspace_id', ${workspaceId}, true)`;
+        await sql`select set_config('opengeni.subject_id', ${subjectId}, true)`;
+        return await run(sql as postgres.TransactionSql);
+      });
+    const issue = async (
+      resourceKind: string | null,
+      mode: string | null,
+      context: string | null,
+      acknowledged: boolean | null,
+    ): Promise<unknown> =>
+      await asAppRole(
+        async (sql) =>
+          await sql`
+          select * from issue_self_user_resource_grant(
+            ${accountId}::uuid, ${authorityId}::uuid, ${workspaceId}::uuid,
+            ${resourceKind}::text, ${mode}::text, ${context}::text,
+            null::uuid, null::integer, ${acknowledged}::boolean
+          )
+        `,
+      );
+
+    await expectSqlState(
+      () =>
+        asAppRole(
+          async (sql) =>
+            await sql`select * from list_self_user_resource_authorities(
+            ${accountId}::uuid, ${workspaceId}::uuid, null::text, null::uuid, 50
+          )`,
+        ),
+      "22023",
+    );
+    await expectSqlState(
+      () =>
+        asAppRole(
+          async (sql) =>
+            await sql`select * from list_self_user_resource_authorities(
+            ${accountId}::uuid, ${workspaceId}::uuid, 'rig', null::uuid, null::integer
+          )`,
+        ),
+      "22023",
+    );
+    await expectSqlState(() => issue(null, "always", "user_private", false), "22023");
+    await expectSqlState(() => issue("rig", null, "user_private", false), "22023");
+    await expectSqlState(() => issue("rig", "always", null, false), "22023");
+    await expectSqlState(() => issue("rig", "always", "workspace_shared", null), "42501");
+
+    const [grantCount] = await admin<Array<{ count: number }>>`
+      select count(*)::int as count from organization_user_resource_grants
+      where authority_id = ${authorityId}`;
+    expect(grantCount?.count).toBe(4);
+  }, 900_000);
+});

--- a/packages/db/test/rls-dedicated-schema-isolation.test.ts
+++ b/packages/db/test/rls-dedicated-schema-isolation.test.ts
@@ -581,6 +581,55 @@ describe("migration replay — RLS isolation under a DEDICATED schema + NON-OWNE
     }
   });
 
+  test("0305 grant routines keep exact dedicated-schema proconfig and lifecycle-only RLS", async () => {
+    if (!available) return;
+    const routines = await admin<Array<{ name: string; settings: string[] | null }>>`
+      select procedure.proname as name, procedure.proconfig as settings
+      from pg_proc procedure
+      join pg_namespace namespace on namespace.oid = procedure.pronamespace
+      where namespace.nspname = ${SCHEMA}
+        and procedure.proname in (
+          'list_self_user_resource_authorities',
+          'issue_self_user_resource_grant',
+          'revoke_self_user_resource_grant'
+        )
+        and pg_catalog.oidvectortypes(procedure.proargtypes) in (
+          'uuid, uuid, text, uuid, integer',
+          'uuid, uuid, uuid, text, text, text, uuid, integer, boolean',
+          'uuid, uuid, uuid'
+        )
+      order by procedure.proname`;
+    expect(Array.from(routines)).toEqual([
+      {
+        name: "issue_self_user_resource_grant",
+        settings: [`search_path=pg_catalog, ${SCHEMA}, pg_temp`],
+      },
+      {
+        name: "list_self_user_resource_authorities",
+        settings: [`search_path=pg_catalog, ${SCHEMA}, pg_temp`],
+      },
+      {
+        name: "revoke_self_user_resource_grant",
+        settings: [`search_path=pg_catalog, ${SCHEMA}, pg_temp`],
+      },
+    ]);
+    const policies = await admin<Array<{ tableName: string; usingExpression: string }>>`
+      select tablename as "tableName", qual as "usingExpression"
+      from pg_policies
+      where schemaname = ${SCHEMA}
+        and policyname = 'organization_tenancy_lifecycle'
+        and tablename in (
+          'organization_memberships',
+          'organization_user_resource_authorities',
+          'organization_user_resource_grants'
+        )
+      order by tablename`;
+    expect(policies).toHaveLength(3);
+    for (const policy of policies) {
+      expect(policy.usingExpression).toContain("personal_resource_grant_management");
+    }
+  });
+
   test("migrate-then-provision grants the exact target-schema knowledge authority lock", async () => {
     if (!available) return;
     expect(appRoleExistedBeforeMigration).toBe(false);

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -71,6 +71,39 @@ sandbox access have been settled. Forks copy same-workspace durable content and
 references but no live turn, goal, credential, personal grant, Variable Set,
 Rig, MCP server configuration, sandbox identity, or workflow.
 
+## Personal-resource grants
+
+The same canonical managed-cookie owner can manage explicit personal-resource
+delegations after organization activation. Pages are bounded to one exact kind;
+the server derives the only valid action and returns the full credential-free
+delegation to attach through the resource's ordinary session API.
+
+```ts
+const page = await browserClient.listUserResourceAuthorities(workspaceId, {
+  resourceKind: "connection",
+  limit: 50,
+});
+const authority = page.authorities[0];
+if (!authority) throw new Error("No personal Connection is available");
+
+const issued = await browserClient.issueUserResourceGrant(workspaceId, authority.authorityId, {
+  scope: "user",
+  resourceKind: "connection",
+  mode: "session",
+  context: "workspace_shared",
+  sessionId,
+  expectedAuthorityEpoch: current.tenancy.authorityEpoch,
+  workspaceSharedAcknowledged: true,
+});
+
+await browserClient.revokeUserResourceGrant(workspaceId, issued.grant.grantId);
+```
+
+The SDK deliberately exposes only exact-session and standing (`always`) grant
+management. It does not expose standalone `once`, custom expiry, scheduled or
+cross-workspace authority, or an atomic create-session-and-attach workflow.
+Revocation prevents future reads but cannot retract output already shared.
+
 ## Scheduled connection authority
 
 Agent schedules may carry explicit personal Connection authority. The public

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -228,6 +228,11 @@ import type {
   KnowledgeMemorySearchRequest,
   ListApiKeysResponse,
   ListManagedOrganizationMembershipsResponse,
+  ListUserResourceAuthoritiesOptions,
+  ListUserResourceAuthoritiesResponse,
+  IssueUserResourceGrantRequest,
+  UserResourceGrantMutationResponse,
+  RevokeUserResourceGrantResponse,
   ListOrganizationInvitationsPageResponse,
   ListOrganizationMembersResponse,
   AcceptOrganizationInvitationRequest,
@@ -3594,6 +3599,47 @@ export class OpenGeniClient {
     return await this.requestJson<ListManagedOrganizationMembershipsResponse>(
       "GET",
       "/v1/organization-memberships",
+    );
+  }
+
+  /** Bounded owner-only personal-resource authority page for one exact resource kind. */
+  async listUserResourceAuthorities(
+    workspaceId: string,
+    options: ListUserResourceAuthoritiesOptions,
+  ): Promise<ListUserResourceAuthoritiesResponse> {
+    const query = new URLSearchParams({
+      scope: "user",
+      resourceKind: options.resourceKind,
+    });
+    if (options.cursor) query.set("cursor", options.cursor);
+    if (options.limit !== undefined) query.set("limit", String(options.limit));
+    return await this.requestJson<ListUserResourceAuthoritiesResponse>(
+      "GET",
+      `/v1/workspaces/${workspaceId}/user-resource-authorities?${query.toString()}`,
+    );
+  }
+
+  /** Issue an exact-session or standing personal-resource grant. */
+  async issueUserResourceGrant(
+    workspaceId: string,
+    authorityId: string,
+    request: IssueUserResourceGrantRequest,
+  ): Promise<UserResourceGrantMutationResponse> {
+    return await this.requestJson<UserResourceGrantMutationResponse>(
+      "POST",
+      `/v1/workspaces/${workspaceId}/user-resource-authorities/${authorityId}/grants`,
+      request,
+    );
+  }
+
+  /** Revoke an owner grant through the exact workspace it targets. */
+  async revokeUserResourceGrant(
+    workspaceId: string,
+    grantId: string,
+  ): Promise<RevokeUserResourceGrantResponse> {
+    return await this.requestJson<RevokeUserResourceGrantResponse>(
+      "DELETE",
+      `/v1/workspaces/${workspaceId}/user-resource-authorities/grants/${grantId}?scope=user`,
     );
   }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -3377,6 +3377,83 @@ export type ListManagedOrganizationMembershipsResponse = {
   memberships: ManagedOrganizationMembership[];
 };
 
+export type UserResourceKind =
+  | "connection"
+  | "document"
+  | "variable_set"
+  | "rig"
+  | "connected_machine";
+export type UserResourceGrantAction =
+  | "connection.use"
+  | "document.read"
+  | "variable_set.use"
+  | "rig.use"
+  | "connected_machine.use";
+export type UserResourceAuthorityGrant = {
+  grantId: string;
+  targetWorkspaceId: string;
+  targetSessionId: string | null;
+  action: UserResourceGrantAction;
+  mode: "once" | "session" | "always";
+  context: "user_private" | "workspace_shared";
+  authorityEpoch: number | null;
+  generation: number;
+  status: "active" | "consumed" | "revoked" | "expired";
+  expiresAt: string | null;
+  delegation: UserResourceDelegation;
+};
+export type UserResourceAuthoritySummary = {
+  authorityId: string;
+  resourceKind: UserResourceKind;
+  resourceId: string;
+  originWorkspaceId: string | null;
+  generation: number;
+  status: "active" | "retained" | "revoked";
+  grants: UserResourceAuthorityGrant[];
+};
+export type ListUserResourceAuthoritiesOptions = {
+  resourceKind: UserResourceKind;
+  cursor?: string | undefined;
+  limit?: number | undefined;
+};
+export type ListUserResourceAuthoritiesResponse = {
+  scope: "user";
+  authorities: UserResourceAuthoritySummary[];
+  nextCursor: string | null;
+};
+export type IssueUserResourceGrantRequest =
+  | {
+      scope: "user";
+      resourceKind: UserResourceKind;
+      mode: "session";
+      context: "user_private" | "workspace_shared";
+      sessionId: string;
+      expectedAuthorityEpoch: number;
+      workspaceSharedAcknowledged?: boolean | undefined;
+    }
+  | {
+      scope: "user";
+      resourceKind: UserResourceKind;
+      mode: "always";
+      context: "user_private" | "workspace_shared";
+      sessionId?: null | undefined;
+      expectedAuthorityEpoch?: null | undefined;
+      workspaceSharedAcknowledged?: boolean | undefined;
+    };
+export type UserResourceGrantMutationResponse = {
+  scope: "user";
+  grant: UserResourceAuthorityGrant;
+};
+export type RevokeUserResourceGrantResponse = {
+  scope: "user";
+  grant: {
+    grantId: string;
+    generation: number;
+    status: "revoked";
+    revokedAt: string;
+  };
+};
+
 export type OrganizationMembershipRole = "owner" | "admin" | "member";
 export type OrganizationInvitation = {
   id: string;

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -65,6 +65,51 @@ function makeClient(responder: (request: RecordedRequest) => Response): {
 }
 
 describe("OpenGeniClient", () => {
+  test("manages bounded session/always personal grants without exposing once", async () => {
+    const authorityId = "66666666-6666-4666-8666-666666666666";
+    const grantId = "77777777-7777-4777-8777-777777777777";
+    const { client, requests } = makeClient(() => jsonResponse({}));
+    await client.listUserResourceAuthorities(WORKSPACE_ID, {
+      resourceKind: "connection",
+      cursor: authorityId,
+      limit: 25,
+    });
+    await client.issueUserResourceGrant(WORKSPACE_ID, authorityId, {
+      scope: "user",
+      resourceKind: "connection",
+      mode: "session",
+      context: "workspace_shared",
+      sessionId: SESSION_ID,
+      expectedAuthorityEpoch: 3,
+      workspaceSharedAcknowledged: true,
+    });
+    await client.revokeUserResourceGrant(WORKSPACE_ID, grantId);
+    expect(requests.map((request) => `${request.method} ${new URL(request.url).pathname}`)).toEqual(
+      [
+        `GET /v1/workspaces/${WORKSPACE_ID}/user-resource-authorities`,
+        `POST /v1/workspaces/${WORKSPACE_ID}/user-resource-authorities/${authorityId}/grants`,
+        `DELETE /v1/workspaces/${WORKSPACE_ID}/user-resource-authorities/grants/${grantId}`,
+      ],
+    );
+    const listUrl = new URL(requests[0]!.url);
+    expect(Object.fromEntries(listUrl.searchParams)).toEqual({
+      scope: "user",
+      resourceKind: "connection",
+      cursor: authorityId,
+      limit: "25",
+    });
+    expect(JSON.parse(requests[1]!.body!)).toEqual({
+      scope: "user",
+      resourceKind: "connection",
+      mode: "session",
+      context: "workspace_shared",
+      sessionId: SESSION_ID,
+      expectedAuthorityEpoch: 3,
+      workspaceSharedAcknowledged: true,
+    });
+    expect(new URL(requests[2]!.url).searchParams.get("scope")).toBe("user");
+  });
+
   test("sends explicit visibility and fork idempotency contracts without inventing defaults", async () => {
     const visibilityResponse = {
       operationId: "11111111-1111-4111-8111-111111111111",

--- a/packages/sdk/test/contract-parity.test.ts
+++ b/packages/sdk/test/contract-parity.test.ts
@@ -84,6 +84,8 @@ import {
   ForkSessionResponse as ContractForkSessionResponse,
   UpdateSessionVisibilityRequest as ContractUpdateSessionVisibilityRequest,
   UpdateSessionVisibilityResponse as ContractUpdateSessionVisibilityResponse,
+  IssueUserResourceGrantRequest as ContractIssueUserResourceGrantRequest,
+  ListUserResourceAuthoritiesResponse as ContractListUserResourceAuthoritiesResponse,
   SessionCapabilities as ContractSessionCapabilities,
   SessionEvent as ContractSessionEventSchema,
   SessionMcpServerInput as ContractSessionMcpServerInput,
@@ -220,6 +222,8 @@ import type {
   ForkSessionResponse,
   UpdateSessionVisibilityRequest,
   UpdateSessionVisibilityResponse,
+  IssueUserResourceGrantRequest,
+  ListUserResourceAuthoritiesResponse,
   SessionCapabilities,
   SessionEvent,
   SessionHumanInputRequest,
@@ -253,6 +257,21 @@ import type { TranscriptionEvent, WorkspaceTranscriptionPolicy } from "../src/tr
 // if the public contracts move, these checks fail the gate.
 
 describe("SDK / contracts parity", () => {
+  test("personal-resource management request and page shapes stay in parity", () => {
+    const request = (
+      value: IssueUserResourceGrantRequest,
+    ): z.input<typeof ContractIssueUserResourceGrantRequest> => value;
+    const pageFromSdk = (
+      value: ListUserResourceAuthoritiesResponse,
+    ): z.input<typeof ContractListUserResourceAuthoritiesResponse> => value;
+    const pageFromContract = (
+      value: z.infer<typeof ContractListUserResourceAuthoritiesResponse>,
+    ): ListUserResourceAuthoritiesResponse => value;
+    expect([request, pageFromSdk, pageFromContract].every((fn) => typeof fn === "function")).toBe(
+      true,
+    );
+  });
+
   test("session visibility and private-fork request/response shapes stay in parity", () => {
     const visibilityRequest = (
       value: UpdateSessionVisibilityRequest,

--- a/scripts/check-web-bundle-budget.ts
+++ b/scripts/check-web-bundle-budget.ts
@@ -46,9 +46,10 @@ const budgets = {
   // projection measured 572,514 gzip bytes. The workspace scope/deep-link
   // shell plus the landed catalog presentation measure 2,061,506 raw bytes on
   // macOS/arm64. The public session-tenancy SDK activation brings the merged
-  // direct-session graph to 2,063,047 raw bytes on macOS/arm64. The 2,015 KiB
-  // raw and 560 KiB gzip envelopes preserve the landed CI mapping while
-  // bounding the combined graph.
+  // direct-session graph to 2,063,047 raw bytes on macOS/arm64. PR #1676's
+  // Linux/x64 production build measured the direct-session graph at 2,064,626
+  // raw and 573,599 gzip bytes. The next full-KiB envelopes, 2,065,408 raw
+  // (2,017 KiB) and 574,464 gzip (561 KiB), truthfully bound those measurements.
   initialRaw: 1448 * kib,
   initialGzip: 400 * kib,
   // 77 KiB: the largest shared chunk sits 22 bytes over 76 KiB under CI's
@@ -56,8 +57,8 @@ const budgets = {
   // still bound the aggregate.
   initialFileGzip: 77 * kib,
   initialFiles: 17,
-  directSessionRaw: 2015 * kib,
-  directSessionGzip: 560 * kib,
+  directSessionRaw: 2017 * kib,
+  directSessionGzip: 561 * kib,
   directSessionFiles: 19,
   lazyChunkRaw: 800 * kib,
   lazyChunkGzip: 240 * kib,

--- a/scripts/release-schema-contract.test.ts
+++ b/scripts/release-schema-contract.test.ts
@@ -144,6 +144,7 @@ describe("release schema contract", () => {
       "0264_connection_authority_runtime_activation.sql",
       "0273_scheduled_variable_set_materialization.sql",
       "0304_personal_workspace_private_session_reads.sql",
+      "0305_personal_resource_grant_management.sql",
     ].filter((path) =>
       completeSourceContract.migrations.some((migration) => migration.path === path),
     );
@@ -196,6 +197,14 @@ describe("release schema contract", () => {
       ),
     ).toMatchObject({
       sha256: "cdce8c6b6644b07c672918a94c3e0e01f09d771dc33a61e38ec91eec763bf0c1",
+      deploymentMode: "rolling",
+    });
+    expect(
+      completeSourceContract.migrations.find(
+        (migration) => migration.path === "0305_personal_resource_grant_management.sql",
+      ),
+    ).toMatchObject({
+      sha256: "b6c20178b35b279314872c7cc79048f028d2b1ed070a49f5ad9e0490cb8e5b0c",
       deploymentMode: "rolling",
     });
     expect(


### PR DESCRIPTION
## Summary

- add rolling migration 0305 and bounded owner-only personal-resource authority/grant management for Variable Sets, Rigs, Connected Machines, and Connections
- require canonical managed-cookie provenance, exact organization/workspace/session authority, activation, kind-derived actions, expected epochs/generations, and durable shared-output acknowledgement
- expose bounded keyset list/issue/revoke contracts through core, API, SDK, and converged Connection wrappers
- normalize historical invalid grants and RFC3339 projections while preserving FORCE-RLS, exact SECURITY DEFINER posture, and zero direct runtime table DML

## Safety boundaries

- public management exposes only `session` and `always`; standalone `once` is intentionally not exposed
- no web grant-management UI, atomic new-session attachment, custom expiry authoring, or scheduled/cross-workspace/admin/agent grant management in this slice
- shared grants require acknowledgement `IS TRUE`; null inputs fail closed and bounded pages cannot accept `LIMIT NULL`

## Verification

- 51 focused real-PostgreSQL migration/app-role/dedicated-schema/runtime/release tests on the final repair head
- broader implementation verification: 104 contracts/core/API/SDK tests, 84 real-PostgreSQL lifecycle/route/migration tests, all 31 TypeScript projects
- lint, format, docs refs, public hygiene, changeset/release schema, RLS backfill guard, runtime packed consumer, full publish consumer, and diff checks

OPE-205
