### PR TITLE
fix(runtime): keep browser controller exec off the session working directory

### DIFF
--- a/apps/api/src/sandbox/channel-a.ts
+++ b/apps/api/src/sandbox/channel-a.ts
@@ -1233,7 +1233,7 @@ export function channelAOperationFailureDiagnostic(
       errorCode: "sandbox_channel_a_lifecycle_conflict",
     };
   }
-  if (error instanceof ChannelAUnavailableError) {
+  if (error instanceof ChannelAUnavailableError || error instanceof BrowserControlTransportError) {
     return {
       reason: "provider_unavailable",
       status: 503,

--- a/apps/api/test/channel-a-routes.test.ts
+++ b/apps/api/test/channel-a-routes.test.ts
@@ -296,6 +296,15 @@ describe("P4.4 Channel-A route discipline", () => {
       status: 503,
       errorCode: "sandbox_channel_a_provider_unavailable",
     });
+    expect(
+      channelAOperationFailureDiagnostic(
+        new BrowserControlTransportError("controller unreachable"),
+      ),
+    ).toEqual({
+      reason: "provider_unavailable",
+      status: 503,
+      errorCode: "sandbox_channel_a_provider_unavailable",
+    });
   });
 
   test("concurrent reads settle before one bounded transient retry", async () => {

--- a/packages/runtime/src/sandbox/browser-control-client.ts
+++ b/packages/runtime/src/sandbox/browser-control-client.ts
@@ -73,6 +73,10 @@ import { parseExecResponseBanner } from "./exec-banner";
 import { buildStreamUrl, type ExposedPortEndpoint } from "./stream-port";
 
 const CLIENT_ROOT = "/tmp/opengeni-private/browser-control-client";
+// Controller I/O uses absolute paths under /tmp. Never inherit the session
+// working directory: a missing cwd makes spawn fail with ENOENT before curl
+// can talk to the machine-local sidecar.
+const PLACEMENT_CONTROLLER_WORKDIR = "/tmp";
 export const BROWSER_CONTROL_ADMIN_TOKEN_FILE = "/tmp/opengeni-browserd/authority/admin-token";
 const COMMAND_OK = "OPENGENI_BROWSER_CONTROL_CLIENT_OK";
 const TOKEN_PATTERN = /^[A-Za-z0-9._~-]{32,2048}$/u;
@@ -99,11 +103,13 @@ type ExecResultLike = {
 export type BrowserControlPlacementSession = {
   exec?: (args: {
     cmd: string;
+    workdir?: string;
     yieldTimeMs?: number;
     maxOutputTokens?: number;
   }) => Promise<ExecResultLike | string>;
   execCommand?: (args: {
     cmd: string;
+    workdir?: string;
     yieldTimeMs?: number;
     maxOutputTokens?: number;
   }) => Promise<string>;
@@ -2007,11 +2013,13 @@ async function writePrivateFile(
   const started = session.exec
     ? await session.exec({
         cmd: command,
+        workdir: PLACEMENT_CONTROLLER_WORKDIR,
         yieldTimeMs: 250,
         maxOutputTokens: 2_000,
       })
     : await session.execCommand!({
         cmd: command,
+        workdir: PLACEMENT_CONTROLLER_WORKDIR,
         yieldTimeMs: 250,
         maxOutputTokens: 2_000,
       });
@@ -2055,11 +2063,13 @@ async function runChecked(
   const result = session.exec
     ? await session.exec({
         cmd: command,
+        workdir: PLACEMENT_CONTROLLER_WORKDIR,
         yieldTimeMs: bounded,
         maxOutputTokens: 2_000,
       })
     : await session.execCommand!({
         cmd: command,
+        workdir: PLACEMENT_CONTROLLER_WORKDIR,
         yieldTimeMs: bounded,
         maxOutputTokens: 2_000,
       });
@@ -2078,12 +2088,14 @@ async function runBestEffort(
     if (session.exec) {
       await session.exec({
         cmd: command,
+        workdir: PLACEMENT_CONTROLLER_WORKDIR,
         yieldTimeMs: 15_000,
         maxOutputTokens: 100,
       });
     } else if (session.execCommand) {
       await session.execCommand({
         cmd: command,
+        workdir: PLACEMENT_CONTROLLER_WORKDIR,
         yieldTimeMs: 15_000,
         maxOutputTokens: 100,
       });
@@ -2175,11 +2187,13 @@ async function runPrivateReadCommand(
   const result = session.exec
     ? await session.exec({
         cmd: command,
+        workdir: PLACEMENT_CONTROLLER_WORKDIR,
         yieldTimeMs: bounded,
         maxOutputTokens,
       })
     : await session.execCommand!({
         cmd: command,
+        workdir: PLACEMENT_CONTROLLER_WORKDIR,
         yieldTimeMs: bounded,
         maxOutputTokens,
       });

--- a/packages/runtime/src/sandbox/browser-control-server.ts
+++ b/packages/runtime/src/sandbox/browser-control-server.ts
@@ -40,15 +40,21 @@ type ExecResultLike = {
 type ExecCapableSession = {
   exec?: (args: {
     cmd: string;
+    workdir?: string;
     yieldTimeMs?: number;
     maxOutputTokens?: number;
   }) => Promise<ExecResultLike>;
   execCommand?: (args: {
     cmd: string;
+    workdir?: string;
     yieldTimeMs?: number;
     maxOutputTokens?: number;
   }) => Promise<string>;
 };
+
+// Image-backed controller spawn uses absolute /tmp paths. Do not inherit a
+// session working directory; a missing cwd makes spawn fail with ENOENT.
+const PLACEMENT_CONTROLLER_WORKDIR = "/tmp";
 
 export type EnsureBrowserControlServerOptions = {
   port?: number;
@@ -100,8 +106,18 @@ export async function ensureBrowserControlServer(
     ...(options.allowedOrigins ? { allowedOrigins: options.allowedOrigins } : {}),
   });
   const result = target.exec
-    ? await target.exec({ cmd, yieldTimeMs: timeoutMs, maxOutputTokens: 4_000 })
-    : await target.execCommand!({ cmd, yieldTimeMs: timeoutMs, maxOutputTokens: 4_000 });
+    ? await target.exec({
+        cmd,
+        workdir: PLACEMENT_CONTROLLER_WORKDIR,
+        yieldTimeMs: timeoutMs,
+        maxOutputTokens: 4_000,
+      })
+    : await target.execCommand!({
+        cmd,
+        workdir: PLACEMENT_CONTROLLER_WORKDIR,
+        yieldTimeMs: timeoutMs,
+        maxOutputTokens: 4_000,
+      });
   const output = outputOf(result);
   const exitCode = exitCodeOf(result) ?? inferExitCode(output);
   if (exitCode !== 0) throw new BrowserControlServerError(exitCode, output);
@@ -120,12 +136,14 @@ export async function tearDownBrowserControlServer(session: unknown): Promise<vo
   if (target?.exec) {
     await target.exec({
       cmd: BROWSER_CONTROL_SERVER_DOWN_BIN,
+      workdir: PLACEMENT_CONTROLLER_WORKDIR,
       yieldTimeMs: 15_000,
       maxOutputTokens: 4_000,
     });
   } else if (target?.execCommand) {
     await target.execCommand({
       cmd: BROWSER_CONTROL_SERVER_DOWN_BIN,
+      workdir: PLACEMENT_CONTROLLER_WORKDIR,
       yieldTimeMs: 15_000,
       maxOutputTokens: 4_000,
     });

--- a/packages/runtime/test/browser-control-client.test.ts
+++ b/packages/runtime/test/browser-control-client.test.ts
@@ -850,6 +850,21 @@ describe("BrowserControlClient", () => {
     }
   });
 
+  test("placement controller execs do not inherit a session working directory", async () => {
+    const workdirs: Array<string | undefined> = [];
+    const placement = await localPlacement({ fakeControllerStartup: true });
+    const inner = placement.session.exec!;
+    placement.session.exec = async (args) => {
+      workdirs.push(args.workdir);
+      return inner(args);
+    };
+    await provisionBrowserControlClient(placement.session, {
+      adminToken: `ogb_${"a".repeat(48)}`,
+    });
+    expect(workdirs.length).toBeGreaterThan(0);
+    expect(workdirs.every((workdir) => workdir === "/tmp")).toBe(true);
+  });
+
   test("uses agent-supervised sidecar and typed browser relay on connected machines", async () => {
     const ensured: unknown[] = [];
     const opened: unknown[] = [];


### PR DESCRIPTION
## Summary
Connected-machine and image-backed browser control talk to a machine-local sidecar through placement `exec`/`curl`. Those commands already used absolute `/tmp` paths, but they still inherited the session working directory. If that directory does not exist, spawn fails with ENOENT before curl can reach the sidecar, and the API surfaces a Channel-A 503 (`unexpected` / temporarily unavailable) even though Chromium placement is the connected machine.

Pin controller execs at `/tmp` so sidecar I/O does not depend on the session cwd. Classify `BrowserControlTransportError` as provider unavailable so the same failure is no longer logged as an unexpected 500.

## Test plan
- [x] `bun test packages/runtime/test/browser-control-client.test.ts packages/runtime/test/browser-control-server.test.ts apps/api/test/channel-a-routes.test.ts`
- [ ] CI