### PR TITLE
fix(ci): align portable history contracts with status omission

### DIFF
--- a/packages/codex/src/model-output-truncation.ts
+++ b/packages/codex/src/model-output-truncation.ts
@@ -25,23 +25,25 @@ export { MODEL_TOOL_OUTPUT_OVERSIZED_IMAGE_CARD_DATA_URL } from "./oversized-ima
 
 export type ModelHistoryItem = Record<string, unknown>;
 
-type WithoutOutputOnlyHistoryItemFields<T extends ModelHistoryItem> = Omit<
-  T,
-  "status" | "providerData"
-> &
-  ("providerData" extends keyof T
-    ? undefined extends T["providerData"]
+type WithoutOutputOnlyProviderDataFields<T> = T extends ModelHistoryItem ? Omit<T, "status"> : T;
+
+type WithoutOutputOnlyProviderDataField<T extends ModelHistoryItem> = "providerData" extends keyof T
+  ? string extends keyof T
+    ? {
+        providerData?: WithoutOutputOnlyProviderDataFields<T["providerData"]>;
+      }
+    : object extends Pick<T, Extract<keyof T, "providerData">>
       ? {
-          providerData?: Exclude<T["providerData"], undefined> extends ModelHistoryItem
-            ? Omit<Exclude<T["providerData"], undefined>, "status">
-            : Exclude<T["providerData"], undefined>;
+          providerData?: WithoutOutputOnlyProviderDataFields<T["providerData"]>;
         }
       : {
-          providerData: T["providerData"] extends ModelHistoryItem
-            ? Omit<T["providerData"], "status">
-            : T["providerData"];
+          providerData: WithoutOutputOnlyProviderDataFields<T["providerData"]>;
         }
-    : object);
+  : object;
+
+type WithoutOutputOnlyHistoryItemFields<T extends ModelHistoryItem> = T extends unknown
+  ? Omit<T, "status" | "providerData"> & WithoutOutputOnlyProviderDataField<T>
+  : never;
 
 /**
  * Responses output items carry `status` (`in_progress` / `completed` /

--- a/packages/codex/src/model-output-truncation.ts
+++ b/packages/codex/src/model-output-truncation.ts
@@ -25,6 +25,24 @@ export { MODEL_TOOL_OUTPUT_OVERSIZED_IMAGE_CARD_DATA_URL } from "./oversized-ima
 
 export type ModelHistoryItem = Record<string, unknown>;
 
+type WithoutOutputOnlyHistoryItemFields<T extends ModelHistoryItem> = Omit<
+  T,
+  "status" | "providerData"
+> &
+  ("providerData" extends keyof T
+    ? undefined extends T["providerData"]
+      ? {
+          providerData?: Exclude<T["providerData"], undefined> extends ModelHistoryItem
+            ? Omit<Exclude<T["providerData"], undefined>, "status">
+            : Exclude<T["providerData"], undefined>;
+        }
+      : {
+          providerData: T["providerData"] extends ModelHistoryItem
+            ? Omit<T["providerData"], "status">
+            : T["providerData"];
+        }
+    : object);
+
 /**
  * Responses output items carry `status` (`in_progress` / `completed` /
  * `incomplete`). That field is not conversation meaning — pairing is `call_id`
@@ -34,29 +52,35 @@ export type ModelHistoryItem = Record<string, unknown>;
  * Canonical history therefore omits both at persist so portable sessions can
  * cross Responses providers.
  */
-export function omitOutputOnlyHistoryItemFields<T extends ModelHistoryItem>(item: T): T {
-  if (!item || typeof item !== "object") return item;
+export function omitOutputOnlyHistoryItemFields<T extends ModelHistoryItem>(
+  item: T,
+): WithoutOutputOnlyHistoryItemFields<T> {
+  if (!item || typeof item !== "object") {
+    return item as unknown as WithoutOutputOnlyHistoryItemFields<T>;
+  }
   const providerData =
     item.providerData && typeof item.providerData === "object"
       ? (item.providerData as Record<string, unknown>)
       : null;
   const hasTopStatus = "status" in item;
   const hasNestedStatus = Boolean(providerData && "status" in providerData);
-  if (!hasTopStatus && !hasNestedStatus) return item;
-  const next = { ...item } as T;
+  if (!hasTopStatus && !hasNestedStatus) {
+    return item as unknown as WithoutOutputOnlyHistoryItemFields<T>;
+  }
+  const next = { ...item };
   if (hasTopStatus) delete (next as Record<string, unknown>).status;
   if (hasNestedStatus && providerData) {
     const { status: _dropped, ...rest } = providerData;
     (next as Record<string, unknown>).providerData = rest;
   }
-  return next;
+  return next as unknown as WithoutOutputOnlyHistoryItemFields<T>;
 }
 
 /** Persist/replay boundary: drop output-only fields, then bound tool output. */
 export function canonicalizePersistedHistoryItem<T extends ModelHistoryItem>(
   item: T,
   policyTokens = DEFAULT_MODEL_TOOL_OUTPUT_TRUNCATION_TOKENS,
-): T {
+): WithoutOutputOnlyHistoryItemFields<T> {
   return boundModelToolOutputItem(omitOutputOnlyHistoryItemFields(item), policyTokens);
 }
 

--- a/packages/codex/test/model-output-truncation.test.ts
+++ b/packages/codex/test/model-output-truncation.test.ts
@@ -534,6 +534,54 @@ describe("Codex-parity model tool-output truncation", () => {
     expect(withNested.providerData.status).toBe("completed");
   });
 
+  test("preserves discriminated union fields while omitting output-only status types", () => {
+    type UnionItem =
+      | {
+          type: "function_call_result";
+          status: "completed";
+          output: { text: string };
+        }
+      | {
+          type: "reasoning";
+          content: string[];
+          providerData?: {
+            status: "completed";
+            encrypted_content: string;
+          };
+        };
+
+    const verify = (item: UnionItem) => {
+      const omitted = omitOutputOnlyHistoryItemFields(item);
+      if (omitted.type === "function_call_result") {
+        expect(omitted.output.text).toBe("done");
+        // @ts-expect-error output-only status is absent from the canonical type
+        void omitted.status;
+      } else {
+        expect(omitted.content).toEqual([]);
+        expect(omitted.providerData?.encrypted_content).toBe("opaque");
+        // @ts-expect-error nested output-only status is absent from the canonical type
+        void omitted.providerData?.status;
+      }
+    };
+
+    verify({
+      type: "function_call_result",
+      status: "completed",
+      output: { text: "done" },
+    });
+    verify({
+      type: "reasoning",
+      content: [],
+      providerData: { status: "completed", encrypted_content: "opaque" },
+    });
+
+    const requiredProviderData = omitOutputOnlyHistoryItemFields({
+      type: "reasoning",
+      providerData: { status: "completed", encrypted_content: "required" },
+    });
+    expect(requiredProviderData.providerData.encrypted_content).toBe("required");
+  });
+
   test("persist canonicalize drops status then bounds tool output", () => {
     const item = {
       type: "function_call_result",

--- a/packages/db/test/migration-0263-organization-membership-lifecycle.test.ts
+++ b/packages/db/test/migration-0263-organization-membership-lifecycle.test.ts
@@ -1524,7 +1524,7 @@ describe("migration 0263 organization membership lifecycle", () => {
             and history.turn_id = ${requiresActionTurnId}
             and history.item ->> 'type' = 'function_call_result'
             and history.item ->> 'callId' = ${pendingToolCallId}
-            and history.item ->> 'status' = 'incomplete') as "interruptedHistoryItems",
+            and not (history.item ? 'status')) as "interruptedHistoryItems",
         (select count(*)::int from session_events event_row
           where event_row.workspace_id = ${sharedWorkspaceId}
             and event_row.session_id = ${recoveringSession.id}

--- a/packages/db/test/migration-0263-organization-membership-lifecycle.test.ts
+++ b/packages/db/test/migration-0263-organization-membership-lifecycle.test.ts
@@ -1503,6 +1503,7 @@ describe("migration 0263 organization membership lifecycle", () => {
         pendingToolCalls: number;
         humanInputStatus: string;
         interruptedHistoryItems: number;
+        interruptedHistoryItemsWithOutputStatus: number;
         toolOutputEvents: number;
         humanInputEvents: number;
         systemUpdateEvents: number;
@@ -1523,8 +1524,17 @@ describe("migration 0263 organization membership lifecycle", () => {
             and history.session_id = ${recoveringSession.id}
             and history.turn_id = ${requiresActionTurnId}
             and history.item ->> 'type' = 'function_call_result'
+            and history.item ->> 'callId' = ${pendingToolCallId}) as "interruptedHistoryItems",
+        (select count(*)::int from session_history_items history
+          where history.workspace_id = ${sharedWorkspaceId}
+            and history.session_id = ${recoveringSession.id}
+            and history.turn_id = ${requiresActionTurnId}
+            and history.item ->> 'type' = 'function_call_result'
             and history.item ->> 'callId' = ${pendingToolCallId}
-            and not (history.item ? 'status')) as "interruptedHistoryItems",
+            and (
+              history.item ? 'status'
+              or (history.item -> 'providerData') ? 'status'
+            )) as "interruptedHistoryItemsWithOutputStatus",
         (select count(*)::int from session_events event_row
           where event_row.workspace_id = ${sharedWorkspaceId}
             and event_row.session_id = ${recoveringSession.id}
@@ -1554,6 +1564,7 @@ describe("migration 0263 organization membership lifecycle", () => {
       pendingToolCalls: 0,
       humanInputStatus: "cancelled",
       interruptedHistoryItems: 1,
+      interruptedHistoryItemsWithOutputStatus: 0,
       toolOutputEvents: 1,
       humanInputEvents: 1,
       systemUpdateEvents: 1,
@@ -1616,6 +1627,7 @@ describe("migration 0263 organization membership lifecycle", () => {
       Array<{
         pendingToolCalls: number;
         interruptedHistoryItems: number;
+        interruptedHistoryItemsWithOutputStatus: number;
         lifecycleProtocolEvents: number;
         lastSequence: number;
       }>
@@ -1629,8 +1641,17 @@ describe("migration 0263 organization membership lifecycle", () => {
             and history.session_id = ${recoveringSession.id}
             and history.turn_id = ${requiresActionTurnId}
             and history.item ->> 'type' = 'function_call_result'
+            and history.item ->> 'callId' = ${pendingToolCallId}) as "interruptedHistoryItems",
+        (select count(*)::int from session_history_items history
+          where history.workspace_id = ${sharedWorkspaceId}
+            and history.session_id = ${recoveringSession.id}
+            and history.turn_id = ${requiresActionTurnId}
+            and history.item ->> 'type' = 'function_call_result'
             and history.item ->> 'callId' = ${pendingToolCallId}
-            and not (history.item ? 'status')) as "interruptedHistoryItems",
+            and (
+              history.item ? 'status'
+              or (history.item -> 'providerData') ? 'status'
+            )) as "interruptedHistoryItemsWithOutputStatus",
         (select count(*)::int from session_events event_row
           where event_row.workspace_id = ${sharedWorkspaceId}
             and event_row.session_id = ${recoveringSession.id}
@@ -1644,6 +1665,7 @@ describe("migration 0263 organization membership lifecycle", () => {
     expect(replayEvidence).toEqual({
       pendingToolCalls: 0,
       interruptedHistoryItems: 1,
+      interruptedHistoryItemsWithOutputStatus: 0,
       lifecycleProtocolEvents: 4,
       lastSequence: protocolSettlement!.lastSequence,
     });

--- a/packages/db/test/migration-0263-organization-membership-lifecycle.test.ts
+++ b/packages/db/test/migration-0263-organization-membership-lifecycle.test.ts
@@ -1630,7 +1630,7 @@ describe("migration 0263 organization membership lifecycle", () => {
             and history.turn_id = ${requiresActionTurnId}
             and history.item ->> 'type' = 'function_call_result'
             and history.item ->> 'callId' = ${pendingToolCallId}
-            and history.item ->> 'status' = 'incomplete') as "interruptedHistoryItems",
+            and not (history.item ? 'status')) as "interruptedHistoryItems",
         (select count(*)::int from session_events event_row
           where event_row.workspace_id = ${sharedWorkspaceId}
             and event_row.session_id = ${recoveringSession.id}


### PR DESCRIPTION
## Summary

- type status-stripping helpers by their actual property-removing output while preserving the remaining item shape
- keep both initial and replay migration lifecycle proofs aligned with status-free canonical history
- repair the current-main typecheck and unit failures introduced by portable history normalization

## Validation

- `bun scripts/typecheck.ts`
- `bun test packages/codex/test/model-output-truncation.test.ts packages/codex/test/normalize.test.ts`
- `OPENGENI_REQUIRE_REAL_DB=1 bun test packages/db/test/migration-0263-organization-membership-lifecycle.test.ts` (23 pass, 0 fail, 165 assertions in a Docker-capable Linux environment)
- `bunx oxfmt --check packages/codex/src/model-output-truncation.ts packages/db/test/migration-0263-organization-membership-lifecycle.test.ts`