### PR TITLE
fix(observability): make compaction alert model-aware

### DIFF
--- a/.changeset/model-aware-compaction-alert.md
+++ b/.changeset/model-aware-compaction-alert.md
@@ -1,0 +1,6 @@
+---
+"@opengeni/worker-bundle": patch
+---
+
+Make the compaction-not-firing alert follow durable, model-aware automatic
+compaction starts instead of a static token histogram threshold.

--- a/apps/worker/src/activities/agent-turn.ts
+++ b/apps/worker/src/activities/agent-turn.ts
@@ -415,6 +415,7 @@ import {
   modelCallAccountContext,
   recordBatchFlush,
   recordContextCompaction,
+  recordContextCompactionStarted,
   recordCreditMicros,
   recordModelCacheTokens,
   recordModelInputTokens,
@@ -6646,6 +6647,8 @@ export function createRunAgentTurnActivity(services: () => Promise<ActivityServi
       const compactionModeOptions = {
         codexCompactionMode: session.codexCompactionMode,
         isCodexSubscriptionTurn: isCodexTurn,
+        onCompactionStarted: (compactionTrigger: "auto" | "operator" | "proactive" | "overflow") =>
+          recordContextCompactionStarted(observability, compactionTrigger),
         publishLiveEvents: publishCompactionLiveEvents,
         ...(remoteCompactionRequester
           ? { requestRemoteCompactionV2: remoteCompactionRequester }

--- a/apps/worker/src/activities/context-compaction.ts
+++ b/apps/worker/src/activities/context-compaction.ts
@@ -99,6 +99,8 @@ export async function maybeCompactContext(
      * append again — the event is already durable.
      */
     publishLiveEvents?: (events: SessionEvent[]) => Promise<void>;
+    /** Observe the durable start only after its attempt-fenced transition commits. */
+    onCompactionStarted?: (trigger: "auto" | "operator" | "proactive" | "overflow") => void;
     /** Materialize retained screenshot receipts only in the attempt-local model view. */
     materializeHistory?: (items: CompactionItem[]) => Promise<CompactionItem[]>;
     /** Turn-scoped attachment/modality view; canonical persisted rows stay untouched. */
@@ -208,6 +210,7 @@ export async function maybeCompactContext(
       `turn attempt was fenced while recording context compaction start: ${started.reason}`,
     );
   }
+  options.onCompactionStarted?.(trigger);
   await options.publishLiveEvents?.(started.events);
 
   if (useRemoteV2) {

--- a/apps/worker/src/observability-metrics.ts
+++ b/apps/worker/src/observability-metrics.ts
@@ -1508,13 +1508,28 @@ export function recordModelInputTokens(
   });
 }
 
-/** A context compaction actually fired, by trigger (operator | overflow | proactive
- *  | auto). The rate of this — against the input-tokens histogram above — is how an
- *  operator sees compaction working (or silently not). */
+/** A context compaction actually completed, by trigger (operator | overflow |
+ *  proactive | auto). Paired with durable starts below, this shows whether
+ *  compaction is completing after the attempt fence commits. */
 export function recordContextCompaction(observability: Observability, trigger: string): void {
   observability.incrementCounter({
     name: "opengeni_context_compactions_total",
     help: "Total context compactions performed, by trigger.",
+    labels: { trigger },
+  });
+}
+
+/** A durable context-compaction start, recorded only after the attempt-fenced
+ *  `compaction.started` transition commits. Paired with completed compactions,
+ *  this distinguishes a real model-aware compaction attempt from a coarse
+ *  input-token histogram estimate. */
+export function recordContextCompactionStarted(
+  observability: Observability,
+  trigger: string,
+): void {
+  observability.incrementCounter({
+    name: "opengeni_context_compaction_starts_total",
+    help: "Total durable context compaction starts, by trigger.",
     labels: { trigger },
   });
 }

--- a/apps/worker/test/context-compaction-activity.test.ts
+++ b/apps/worker/test/context-compaction-activity.test.ts
@@ -1620,6 +1620,7 @@ describe("standalone context compaction execution", () => {
       session.id,
       attemptId,
     );
+    const compactionStarts: string[] = [];
 
     const outcome = await maybeCompactContext(
       client.db,
@@ -1634,9 +1635,15 @@ describe("standalone context compaction execution", () => {
       },
       null,
       async () => "larger replacement ".repeat(1_000),
-      { force: true, clearRequestedCompaction: true, trigger: "operator" },
+      {
+        force: true,
+        clearRequestedCompaction: true,
+        trigger: "operator",
+        onCompactionStarted: (trigger) => compactionStarts.push(trigger),
+      },
     );
 
+    expect(compactionStarts).toEqual(["operator"]);
     expect(outcome).toMatchObject({
       compacted: false,
       reason: "replacement_not_smaller",

--- a/apps/worker/test/streaming-slis.test.ts
+++ b/apps/worker/test/streaming-slis.test.ts
@@ -5,6 +5,7 @@ import {
   ModelRequestLifecycleMetrics,
   recordBatchFlush,
   recordContextCompaction,
+  recordContextCompactionStarted,
   recordCompanyBrainContributions,
   recordModelInputTokens,
   recordModelRequestPhase,
@@ -446,11 +447,19 @@ describe("context-pressure signals", () => {
 
   test("compaction counter increments by trigger", async () => {
     const observability = worker();
+    recordContextCompactionStarted(observability, "auto");
+    recordContextCompactionStarted(observability, "operator");
     recordContextCompaction(observability, "overflow");
     recordContextCompaction(observability, "overflow");
     recordContextCompaction(observability, "operator");
 
     const metrics = await observability.prometheusMetrics();
+    expect(metrics).toMatch(
+      /opengeni_context_compaction_starts_total\{[^}]*trigger="auto"[^}]*\} 1\b/,
+    );
+    expect(metrics).toMatch(
+      /opengeni_context_compaction_starts_total\{[^}]*trigger="operator"[^}]*\} 1\b/,
+    );
     expect(metrics).toMatch(
       /opengeni_context_compactions_total\{[^}]*trigger="overflow"[^}]*\} 2\b/,
     );

--- a/deploy/helm/opengeni/templates/prometheusrule.yaml
+++ b/deploy/helm/opengeni/templates/prometheusrule.yaml
@@ -488,22 +488,22 @@ spec:
             description: The best-effort NATS live fan-out p99 is above 500ms for 10m — live delivery is degraded (events stay durable and reconcile on stream replay).
         # ── Context / compaction ─────────────────────────────────────────────
         - alert: OpenGeniCompactionNotFiring
-          # Contexts running hot (p90 observed input tokens high) while NO
-          # compaction has fired in 30m — sessions are drifting toward overflow.
-          # The 150k token threshold assumes a ~200k-window model; tune to yours.
-          # `or vector(0)` is load-bearing: on a fresh cluster the compaction
-          # counter has NEVER been created, so a bare `sum(increase(...)) == 0`
-          # is an EMPTY vector, not 0 — the conjunction would silently never fire
-          # exactly when compaction has never fired. The fallback forces a real 0.
+          # A durable automatic compaction start means the runtime's exact,
+          # model-specific threshold was reached and the attempt fence committed.
+          # Alert only when no compaction completed in the same rolling window;
+          # this avoids guessing from coarse histogram buckets or one static
+          # token threshold across models. Both fallbacks are load-bearing on a
+          # fresh cluster where either counter may never have been created.
           expr: |
-            histogram_quantile(0.9, sum by (le) (rate(opengeni_model_input_tokens_bucket[30m]))) > 150000
+            (sum(increase(opengeni_context_compaction_starts_total{trigger="auto"}[30m])) or vector(0)) > 0
             and on()
             (sum(increase(opengeni_context_compactions_total[30m])) or vector(0)) == 0
           for: 15m
           labels:
             severity: warning
           annotations:
-            summary: OpenGeni contexts are running hot but compaction has not fired in 30m
+            summary: OpenGeni automatic compaction started but no compaction completed in 30m
+            description: At least one model-aware automatic context compaction durably started, but no context compaction completed in the rolling 30-minute window. Inspect worker compaction failures and attempt fencing.
         - alert: OpenGeniCodexPromptCacheHitRatioLow
           # The codex-subscription prompt cache is doing little work: median per-call
           # cache-hit ratio below 40% over 30m while codex calls are actually flowing.

--- a/scripts/helm-upgrade-contract.test.ts
+++ b/scripts/helm-upgrade-contract.test.ts
@@ -87,6 +87,19 @@ describe("Helm database upgrade contract", () => {
     expect(configMap).not.toContain('hasKey .Values.config "OPENGENI_MCP_URL"');
   });
 
+  test("alerts on durable model-aware compaction starts instead of a static token guess", async () => {
+    const rules = await source("deploy/helm/opengeni/templates/prometheusrule.yaml");
+    const alertStart = rules.indexOf("- alert: OpenGeniCompactionNotFiring");
+    const nextAlert = rules.indexOf("- alert:", alertStart + 1);
+    const alert = rules.slice(alertStart, nextAlert);
+
+    expect(alertStart).toBeGreaterThan(-1);
+    expect(alert).toContain('opengeni_context_compaction_starts_total{trigger="auto"}[30m]');
+    expect(alert).toContain("opengeni_context_compactions_total[30m]");
+    expect(alert).not.toContain("opengeni_model_input_tokens_bucket");
+    expect(alert).not.toContain("150000");
+  });
+
   test("projects only dedicated credentials into the artifact materializer", async () => {
     const values = await source("deploy/helm/opengeni/values.yaml");
     const materializer = await source(


### PR DESCRIPTION
## Summary

- record a bounded `opengeni_context_compaction_starts_total{trigger=...}` counter only after the attempt-fenced `compaction.started` transition commits
- make `OpenGeniCompactionNotFiring` require a real automatic compaction start and no completed compaction in the rolling 30-minute window
- remove the static 150k histogram-quantile guess that interpolated ~218k-token GPT-5.6 Sol calls above their actual 244,800-token compaction threshold
- add metric, compaction callback, Helm-rule contract coverage, and a worker-bundle patch changeset

## Testing

- [x] `cd apps/worker && bun run typecheck`
- [x] `bun test apps/worker/test/streaming-slis.test.ts scripts/helm-upgrade-contract.test.ts` (29 passed)
- [x] `bun test apps/worker/test/agent-turn.test.ts --timeout 30000` (202 passed)
- [x] targeted `oxlint --deny-warnings` and `oxfmt --check`
- [x] `changeset status --since origin/main`
- [ ] `bun test apps/worker/test/context-compaction-activity.test.ts --timeout 30000` (sandbox has no PostgreSQL test database; setup failed before tests ran)
- [ ] Helm render/lint (Helm is not installed in this sandbox; the static rendered-rule contract passed)

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] Candidate head `fe077c7d7ae9ccc050809ec21f432199d8463351` remains frozen and was created from current `origin/main` `3a1a13f7e2ef59413d40cf67d99637348b94267d`.

## Notes

The production warning self-cleared after proactive compaction. Investigation found no compaction failures: the alert was a false positive caused by Prometheus interpolation across the coarse 200k–300k histogram bucket. This change does not alter compaction behavior or model thresholds; it makes the alert follow the existing model-aware durable compaction decision.
