### PR TITLE
fix(observability): dedupe Codex pool alerts by workspace

### DIFF
--- a/deploy/helm/opengeni/templates/prometheusrule.yaml
+++ b/deploy/helm/opengeni/templates/prometheusrule.yaml
@@ -321,19 +321,27 @@ spec:
             summary: OpenGeni sandbox inventory telemetry is stale or absent
             description: No control replica has completed a fresh database projection for at least one sandbox inventory domain. Threshold alerts for that domain intentionally fail closed until projection health returns.
         - alert: OpenGeniCodexCredentialPoolEmpty
-          expr: increase(opengeni_codex_pool_low_total{depth="zero"}[5m]) > 0
+          expr: |
+            sum by (namespace, release, environment, component, workspace_key) (
+              increase(opengeni_codex_pool_low_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},depth="zero"}[5m])
+            ) > 0
           for: 1m
           labels:
             severity: critical
           annotations:
             summary: A Codex workspace observed no eligible subscription credentials
+            description: Workspace pool {{ "{{ $labels.workspace_key }}" }} observed zero eligible subscription credentials. Restore or reconnect an allocator-enabled credential before new Codex turns require capacity.
         - alert: OpenGeniCodexCredentialPoolSingle
-          expr: increase(opengeni_codex_pool_low_total{depth="one"}[15m]) > 0
+          expr: |
+            sum by (namespace, release, environment, component, workspace_key) (
+              increase(opengeni_codex_pool_low_total{namespace={{ .Release.Namespace | quote }},release={{ .Release.Name | quote }},environment={{ $environment | quote }},depth="one"}[15m])
+            ) > 0
           for: 5m
           labels:
             severity: warning
           annotations:
             summary: A Codex workspace is operating with only one eligible subscription credential
+            description: Workspace pool {{ "{{ $labels.workspace_key }}" }} observed exactly one eligible subscription credential. Add or restore a second allocator-enabled credential to remove the single-account failure domain.
         - alert: OpenGeniServiceDown
           expr: up{job=~".*opengeni.*"} == 0
           for: 5m

--- a/deploy/helm/opengeni/test/prometheusrule.test.ts
+++ b/deploy/helm/opengeni/test/prometheusrule.test.ts
@@ -134,6 +134,33 @@ describe("turn-capacity Prometheus alerts", () => {
         "          targetLabel: opengeni_workload_component",
     );
   });
+
+  test("deduplicates Codex pool alerts by deployment and workspace", async () => {
+    const template = await readFile(
+      new URL("../templates/prometheusrule.yaml", import.meta.url),
+      "utf8",
+    );
+
+    for (const alertName of [
+      "OpenGeniCodexCredentialPoolEmpty",
+      "OpenGeniCodexCredentialPoolSingle",
+    ]) {
+      const expression = alertExpression(template, alertName);
+      expect(expression).toContain(
+        "sum by (namespace, release, environment, component, workspace_key)",
+      );
+      expect(expression).not.toContain("pod");
+      expect(expression).not.toContain("instance");
+      for (const selector of metricSelectors(expression)) {
+        expect(selector).toContain(DEPLOYMENT_SCOPE);
+      }
+    }
+
+    expect(template).toContain('Workspace pool {{ "{{ $labels.workspace_key }}" }} observed zero');
+    expect(template).toContain(
+      'Workspace pool {{ "{{ $labels.workspace_key }}" }} observed exactly one',
+    );
+  });
 });
 
 function alertExpression(template: string, alertName: string): string {


### PR DESCRIPTION
## Summary

- aggregate Codex empty/single credential-pool events by deployment and anonymized workspace key, eliminating duplicate alerts from autoscaled worker pods
- scope both selectors to the Helm release namespace, release name, and configured environment
- include the workspace key and concrete recovery action in alert descriptions

## Testing

- [ ] `bun run typecheck` (not needed for Helm-only behavior; the changed TypeScript test ran under Bun)
- [x] `bun test deploy/helm/opengeni/test`
- [x] `helm lint deploy/helm/opengeni`
- [x] rendered `PrometheusRule` with `monitoring.coreos.com/v1`
- [x] evaluated the new PromQL against the August 20, 2026 production incident: 3 pod-scoped series became 2 workspace-scoped series without losing either affected workspace

## Delivery integrity

- [x] Candidate/version labels represent substantive source changes, not base-only refreshes.
- [x] Branch started from current `origin/main`; no base-only head rotation was performed.

## Notes

- This changes alert correlation only. It does not alter credential eligibility, allocator state, provider capacity, or customer credentials.
