### PR TITLE
Fix session tenancy activation inventory validation

### DIFF
--- a/scripts/activate-session-tenancy.test.ts
+++ b/scripts/activate-session-tenancy.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { assertSessionTenancyActivationEvidence } from "./activate-session-tenancy";
 
 const cleanInventory = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   organizationMemberships: { activeWithoutPersonalWorkspace: 0 },
   workspaceMemberSubjectsWithoutMembershipAnchor: 0,
   // Legitimate service/API-key sessions and immutable pre-0277 writer history
@@ -56,7 +56,7 @@ describe("session tenancy activation evidence", () => {
 
   test("fails closed on malformed report versions", () => {
     expect(() =>
-      assertSessionTenancyActivationEvidence({ ...cleanInventory, schemaVersion: 2 }, cleanParity),
+      assertSessionTenancyActivationEvidence({ ...cleanInventory, schemaVersion: 1 }, cleanParity),
     ).toThrow(/inventory report is structurally invalid/);
     expect(() =>
       assertSessionTenancyActivationEvidence(cleanInventory, {

--- a/scripts/activate-session-tenancy.ts
+++ b/scripts/activate-session-tenancy.ts
@@ -5,6 +5,7 @@ import postgres from "postgres";
 const REQUIRED_MIGRATIONS = [
   "0285_organization_tenancy_inventory.sql",
   "0291_resource_authority_classification_assertion.sql",
+  "0292_truthful_tenancy_inventory_counters.sql",
   "0297_session_ownership_classification_and_backfill.sql",
   "0298_organization_tenancy_parity.sql",
   "0300_tenancy_backfill_ledger.sql",
@@ -75,7 +76,7 @@ export function assertSessionTenancyActivationEvidence(inventory: unknown, parit
   if (
     inventory === null ||
     typeof inventory !== "object" ||
-    numberAt(inventory, ["schemaVersion"]) !== 1
+    numberAt(inventory, ["schemaVersion"]) !== 2
   ) {
     throw new Error("Session tenancy activation inventory report is structurally invalid");
   }


### PR DESCRIPTION
## Summary

- accept the current organization tenancy inventory schema v2
- require migration 0292, which introduced the truthful v2 counters, before activation
- keep activation fail-closed for stale or malformed inventory/parity evidence

## Why

A fully migrated database returns inventory schema v2, but the operator activation command still required schema v1. That made the documented local/production activation path fail with `inventory report is structurally invalid`, leaving shared-workspace private sessions unavailable even when operators followed the activation procedure.

## Verification

- `bun test scripts/activate-session-tenancy.test.ts`
- `bun run typecheck` (31/31 projects)
- focused oxfmt and oxlint
- `git diff --check`
- canonical activation command successfully installed a v1 product receipt against a fully migrated local PostgreSQL database using v2 inventory evidence