### PR TITLE
fix(sdk): accept standard fetch responses

### DIFF
--- a/.changeset/clean-fetch-response.md
+++ b/.changeset/clean-fetch-response.md
@@ -1,0 +1,5 @@
+---
+"@opengeni/sdk": patch
+---
+
+Accept web-standard custom fetch responses without requiring Bun's non-standard `Response.textStream()` extension.

--- a/packages/sdk/src/artifact-client.ts
+++ b/packages/sdk/src/artifact-client.ts
@@ -1,4 +1,5 @@
 import { OpenGeniClient as OpenGeniCoreClient } from "./client";
+import type { FetchResponse } from "./client";
 import type {
   CreateEditableArtifactMaterializationRequest,
   CreateEditableArtifactResourceRequest,
@@ -132,7 +133,7 @@ export class OpenGeniClient extends OpenGeniCoreClient {
     artifactId: string,
     jobId: string,
     options: ReadEditableArtifactMaterializationOptions,
-  ): Promise<Response> {
+  ): Promise<FetchResponse> {
     return await this.requestResponse(
       "GET",
       `/v1/workspaces/${encodeURIComponent(workspaceId)}/editable-artifacts/${encodeURIComponent(artifactId)}/materializations/${encodeURIComponent(jobId)}/download`,

--- a/packages/sdk/src/artifacts.ts
+++ b/packages/sdk/src/artifacts.ts
@@ -14,4 +14,9 @@ export type {
   ReadEditableArtifactMaterializationOptions,
   ReadEditableArtifactResourceOptions,
 } from "./editable-artifact-resources";
-export type { FetchLike, OpenGeniClientOptions, OpenGeniRequestOptions } from "./client";
+export type {
+  FetchLike,
+  FetchResponse,
+  OpenGeniClientOptions,
+  OpenGeniRequestOptions,
+} from "./client";

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -523,7 +523,22 @@ function sessionListQuery(options: {
   };
 }
 
-export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+/**
+ * Web-standard fetch response accepted by the SDK.
+ *
+ * Bun augments the global `Response` type with the non-standard `textStream()`
+ * method. Fetch implementations such as Expo implement the web Response
+ * contract without that runtime-specific extension, so it must not be part of
+ * the adapter boundary.
+ */
+export type FetchResponse = Omit<Response, "clone" | "textStream"> & {
+  clone(): FetchResponse;
+};
+
+export type FetchLike = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<FetchResponse>;
 
 export type WorkspaceControlEventPage = {
   events: WorkspaceControlEvent[];
@@ -653,7 +668,7 @@ export class OpenGeniClient {
     if (input.durationSeconds !== undefined) {
       form.append("durationSeconds", String(input.durationSeconds));
     }
-    let response: Response;
+    let response: FetchResponse;
     try {
       response = await this.fetchImpl(this.url(`/v1/workspaces/${workspaceId}/transcriptions`), {
         method: "POST",
@@ -752,7 +767,7 @@ export class OpenGeniClient {
     input: UploadTranscriptionRecordingChunkInput,
   ): Promise<UploadTranscriptionRecordingChunkResponse> {
     const correlationId = crypto.randomUUID();
-    let response: Response;
+    let response: FetchResponse;
     try {
       response = await this.fetchImpl(
         this.url(
@@ -6526,7 +6541,7 @@ export class OpenGeniClient {
     options: OpenGeniRequestOptions = {},
   ): Promise<T> {
     const correlationId = crypto.randomUUID();
-    let response: Response;
+    let response: FetchResponse;
     try {
       response = await this.fetchImpl(this.url(path, query), {
         method,
@@ -6565,9 +6580,9 @@ export class OpenGeniClient {
     path: string,
     query: Record<string, string> = {},
     options: OpenGeniRequestOptions = {},
-  ): Promise<Response> {
+  ): Promise<FetchResponse> {
     const correlationId = crypto.randomUUID();
-    let response: Response;
+    let response: FetchResponse;
     try {
       response = await this.fetchImpl(this.url(path, query), {
         method,
@@ -6591,7 +6606,7 @@ export class OpenGeniClient {
   /** Like `requestJson` for endpoints that respond with no body (204). */
   private async requestVoid(method: string, path: string, body?: unknown): Promise<void> {
     const correlationId = crypto.randomUUID();
-    let response: Response;
+    let response: FetchResponse;
     try {
       response = await this.fetchImpl(this.url(path), {
         method,
@@ -6615,7 +6630,7 @@ export class OpenGeniClient {
   }
 }
 
-function assertApiContractResponse(response: Response): void {
+function assertApiContractResponse(response: FetchResponse): void {
   const actual = response.headers.get(OPENGENI_API_CONTRACT_HEADER);
   if (actual && actual !== OPENGENI_API_CONTRACT_REVISION) {
     throw new OpenGeniApiContractMismatchError(OPENGENI_API_CONTRACT_REVISION, actual);
@@ -6745,7 +6760,7 @@ type ApiErrorRequestContext = {
 };
 
 async function apiErrorFromResponse(
-  response: Response,
+  response: FetchResponse,
   context: ApiErrorRequestContext,
 ): Promise<OpenGeniApiError> {
   return new OpenGeniApiError(response.status, await readBoundedJsonErrorBody(response), {
@@ -6755,7 +6770,7 @@ async function apiErrorFromResponse(
 }
 
 async function assertJsonResponse(
-  response: Response,
+  response: FetchResponse,
   context: ApiErrorRequestContext,
 ): Promise<void> {
   if (isJsonContentType(response.headers.get("content-type"))) return;
@@ -6769,7 +6784,7 @@ async function assertJsonResponse(
   });
 }
 
-async function readBoundedJsonErrorBody(response: Response): Promise<string> {
+async function readBoundedJsonErrorBody(response: FetchResponse): Promise<string> {
   if (!isJsonContentType(response.headers.get("content-type"))) {
     await cancelResponseBody(response, "discarding API error body");
     return "";
@@ -6823,7 +6838,7 @@ async function sha256Hex(bytes: Uint8Array): Promise<string> {
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
-async function cancelResponseBody(response: Response, reason: string): Promise<void> {
+async function cancelResponseBody(response: FetchResponse, reason: string): Promise<void> {
   await response.body?.cancel(reason).catch(() => undefined);
 }
 
@@ -6892,7 +6907,7 @@ function parseBoundedContentLength(value: string | null): number | null {
 }
 
 async function readBoundedResponseBytes(
-  response: Response,
+  response: FetchResponse,
   maxBytes: number,
   expectedBytes: number | null,
 ): Promise<Uint8Array> {

--- a/packages/sdk/src/core.ts
+++ b/packages/sdk/src/core.ts
@@ -1,6 +1,7 @@
 export { OpenGeniClient as OpenGeniCoreClient } from "./client";
 export type {
   FetchLike,
+  FetchResponse,
   OpenGeniClientOptions,
   OpenGeniRequestOptions,
   SendMessageInput,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,7 @@
 export { OpenGeniClient } from "./artifact-client";
 export type {
   FetchLike,
+  FetchResponse,
   OpenGeniClientOptions,
   OpenGeniRequestOptions,
   SendMessageInput,

--- a/packages/sdk/test/fetch-like.test.ts
+++ b/packages/sdk/test/fetch-like.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { OpenGeniClient, type FetchLike, type FetchResponse } from "../src";
+
+declare const expoResponse: Omit<Response, "clone" | "textStream"> & {
+  clone(): typeof expoResponse;
+};
+const standardFetchTypeProof: FetchLike = async () => new Response();
+const expoFetchTypeProof: FetchLike = async () => expoResponse;
+
+declare const incompleteResponse: Omit<FetchResponse, "text">;
+// @ts-expect-error Fetch adapters must provide the complete web Response surface.
+const incompleteFetchTypeProof: FetchLike = async () => incompleteResponse;
+
+void standardFetchTypeProof;
+void expoFetchTypeProof;
+void incompleteFetchTypeProof;
+
+function webResponse(body?: BodyInit | null, init?: ResponseInit): FetchResponse {
+  const response = new Response(body, init);
+  return {
+    get body() {
+      return response.body;
+    },
+    get bodyUsed() {
+      return response.bodyUsed;
+    },
+    get headers() {
+      return response.headers;
+    },
+    get ok() {
+      return response.ok;
+    },
+    get redirected() {
+      return response.redirected;
+    },
+    get status() {
+      return response.status;
+    },
+    get statusText() {
+      return response.statusText;
+    },
+    get type() {
+      return response.type;
+    },
+    get url() {
+      return response.url;
+    },
+    arrayBuffer: () => response.arrayBuffer(),
+    blob: () => response.blob(),
+    bytes: () => response.bytes(),
+    clone: () =>
+      webResponse(response.clone().body, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+      }),
+    formData: () => response.formData(),
+    json: () => response.json(),
+    text: () => response.text(),
+  };
+}
+
+describe("FetchLike", () => {
+  test("accepts a web-standard response without Bun runtime extensions", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("streamed"));
+        controller.close();
+      },
+    });
+    const response = webResponse(body, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+    expect("textStream" in response).toBe(false);
+
+    const client = new OpenGeniClient({
+      baseUrl: "https://api.example.test",
+      fetch: async () => response,
+    });
+    const stream = await client.openEventStream("workspace", "session");
+    const reader = stream.getReader();
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    expect(new TextDecoder().decode(first.value)).toBe("streamed");
+    expect((await reader.read()).done).toBe(true);
+  });
+
+  test("uses JSON and error metadata through the structural response contract", async () => {
+    const success = new OpenGeniClient({
+      baseUrl: "https://api.example.test",
+      fetch: async () =>
+        webResponse(JSON.stringify({ value: 42 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+    expect(await success.requestJson<{ value: number }>("GET", "/value")).toEqual({ value: 42 });
+
+    const failure = new OpenGeniClient({
+      baseUrl: "https://api.example.test",
+      fetch: async () =>
+        webResponse(JSON.stringify({ message: "denied" }), {
+          status: 403,
+          headers: {
+            "content-type": "application/json",
+            "x-opengeni-correlation-id": "correlation-test",
+          },
+        }),
+    });
+    await expect(failure.requestJson("GET", "/denied")).rejects.toMatchObject({
+      status: 403,
+      correlationId: "correlation-test",
+    });
+  });
+
+  test("preserves stream cancellation and request abort signals", async () => {
+    let cancelReason: unknown;
+    let requestSignal: AbortSignal | null | undefined;
+    const response = webResponse(
+      new ReadableStream<Uint8Array>({
+        cancel(reason) {
+          cancelReason = reason;
+        },
+      }),
+      { status: 502, headers: { "content-type": "text/plain" } },
+    );
+    const client = new OpenGeniClient({
+      baseUrl: "https://api.example.test",
+      fetch: async (_input, init) => {
+        requestSignal = init?.signal;
+        return response;
+      },
+    });
+    const abort = new AbortController();
+    await expect(
+      client.requestJson("GET", "/failure", undefined, {}, { signal: abort.signal }),
+    ).rejects.toMatchObject({ status: 502 });
+    expect(requestSignal).toBe(abort.signal);
+    expect(cancelReason).toBe("discarding API error body");
+  });
+});


### PR DESCRIPTION
## Summary

- export a standards-compatible FetchResponse type that excludes Bun-only Response.textStream
- use the structural response type throughout the SDK fetch boundary, including public artifact downloads
- add type and runtime coverage for standard/Expo-like responses, streaming, JSON/error metadata, cancellation, and AbortSignal propagation
- add an SDK patch changeset

## Compatibility evidence

Peloton was tested on Bun 1.4.0 with React held at 1.0.1 and this SDK package overlaid. Native package, mobile, web, API, worker, api-client, and agent-chat-core typechecks all passed. A clean Bun install also resolved React 1.0.1 and the maintained SDK to one overridden SDK copy, so no React/timeline upgrade is required for adoption.

## Validation

- SDK suite: 402 tests, 1,656 assertions, 0 failures
- all 31 TypeScript projects
- formatting and git diff hygiene
- all 26 publishable packages built
- publish closure guard
- release-shaped publish consumer suite
- runtime embedding consumer suite

The candidate remains mergeable with current main; the intervening session-pagination commits only change an SDK error comment and do not invalidate this patch.