### PR TITLE
Fix private session creation and simplify access UI

### DIFF
--- a/apps/web/src/components/personal-resource-attachment-control.tsx
+++ b/apps/web/src/components/personal-resource-attachment-control.tsx
@@ -17,8 +17,8 @@ const MODE_OPTIONS = [
   },
   {
     value: "always" as const,
-    label: "This workspace",
-    description: "Keep standing authority for work you start in this workspace.",
+    label: "Remember here",
+    description: "Make it available for future work you start in this workspace.",
   },
 ];
 
@@ -54,7 +54,7 @@ export function PersonalResourceAttachmentControl(props: {
       <legend className="px-1 text-xs font-semibold text-fg">
         <span className="inline-flex items-center gap-1.5">
           <KeyRoundIcon className="size-3.5 text-fg-subtle" aria-hidden />
-          Personal resources
+          Your resource access
         </span>
       </legend>
       {controller.loading ? (
@@ -64,8 +64,9 @@ export function PersonalResourceAttachmentControl(props: {
       ) : controller.selected.resourceCount > 0 ? (
         <>
           <p className="text-xs text-fg-muted">
-            {names.join(" · ")} remain yours. Choose how long OpenGeni may use them for this fixed
-            session setup.
+            {names.join(" · ")} {controller.selected.resourceCount === 1 ? "belongs" : "belong"} to
+            you. Choose how long OpenGeni may use{" "}
+            {controller.selected.resourceCount === 1 ? "it" : "them"}.
           </p>
           <div className="mt-3 grid gap-2 sm:grid-cols-3" role="radiogroup">
             {MODE_OPTIONS.map((option) => (
@@ -123,8 +124,8 @@ export function PersonalResourceAttachmentControl(props: {
       {controller.error ? (
         <div className="mt-2 flex items-center justify-between gap-3" role="alert">
           <span className="text-xs text-danger">
-            Personal-resource authority could not be verified. Retry or choose a non-personal
-            resource.
+            We couldn’t check access to the selected Variable Set or Rig. Try again, or choose a
+            different resource.
           </span>
           <Button
             type="button"

--- a/apps/web/src/components/session/session-tenancy-control.test.tsx
+++ b/apps/web/src/components/session/session-tenancy-control.test.tsx
@@ -197,7 +197,7 @@ describe("SessionTenancyControl", () => {
     });
     expect(container.textContent).toContain("Workspace");
     expect(container.textContent).not.toContain("Make private");
-    expect(container.textContent).not.toContain("Private fork");
+    expect(container.textContent).not.toContain("Private copy");
 
     await act(async () => root.unmount());
     container.remove();
@@ -271,7 +271,7 @@ describe("SessionTenancyControl", () => {
     expect(keys).toHaveLength(2);
     expect(keys[1]).toBe(keys[0]);
     expect(getSession).toHaveBeenCalledTimes(2);
-    expect(container.textContent).toContain("Private");
+    expect(container.textContent).toContain("Only me");
 
     await act(async () => root.unmount());
     container.remove();
@@ -590,9 +590,9 @@ describe("SessionTenancyControl", () => {
         />,
       );
     });
-    await act(async () => button(container, "Private fork").click());
+    await act(async () => button(container, "Private copy").click());
     expect(container.textContent).toContain("independent private session in the same workspace");
-    await act(async () => button(container, "Create private fork").click());
+    await act(async () => button(container, "Create private copy").click());
     await flush();
 
     expect(keys).toHaveLength(2);
@@ -648,8 +648,8 @@ describe("SessionTenancyControl", () => {
         />,
       );
     });
-    await act(async () => button(container, "Private fork").click());
-    await act(async () => button(container, "Create private fork").click());
+    await act(async () => button(container, "Private copy").click());
+    await act(async () => button(container, "Create private copy").click());
     await flush();
 
     expect(openSession).not.toHaveBeenCalled();
@@ -709,16 +709,16 @@ describe("SessionTenancyControl", () => {
     document.body.append(container);
     let root = createRoot(container);
     await act(async () => root.render(<SessionTenancyControl {...props} />));
-    await act(async () => button(container, "Private fork").click());
-    await act(async () => button(container, "Create private fork").click());
+    await act(async () => button(container, "Private copy").click());
+    await act(async () => button(container, "Create private copy").click());
     await flush();
     await act(async () => root.unmount());
 
     root = createRoot(container);
     await act(async () => root.render(<SessionTenancyControl {...props} />));
-    expect(container.textContent).toContain("Retry private fork");
-    await act(async () => button(container, "Retry private fork").click());
-    await act(async () => dialogButton(container, "Retry private fork").click());
+    expect(container.textContent).toContain("Retry private copy");
+    await act(async () => button(container, "Retry private copy").click());
+    await act(async () => dialogButton(container, "Retry private copy").click());
     await flush();
 
     expect(keys).toHaveLength(3);
@@ -752,8 +752,8 @@ describe("SessionTenancyControl", () => {
         />,
       );
     });
-    await act(async () => button(container, "Private fork").click());
-    await act(async () => button(container, "Create private fork").click());
+    await act(async () => button(container, "Private copy").click());
+    await act(async () => button(container, "Create private copy").click());
     current = false;
     pending.reject(apiError({ status: 503, code: "upstream_unavailable", outcomeUnknown: true }));
     await flush();

--- a/apps/web/src/components/session/session-tenancy-control.tsx
+++ b/apps/web/src/components/session/session-tenancy-control.tsx
@@ -5,7 +5,6 @@ import { CopyPlusIcon, Loader2Icon, LockKeyholeIcon, UsersIcon } from "lucide-re
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Notice } from "@/components/ui/notice";
@@ -449,7 +448,7 @@ export function SessionTenancyControl({
       const fork = result.value;
       receiptConfirmed = true;
       if (fork.workspaceId !== target.workspaceId) {
-        throw new Error("The private fork response did not match this workspace.");
+        throw new Error("The private copy response did not match this workspace.");
       }
       const destination = await runCurrentTransitionInvocation({
         isCurrent: () => isCurrentInvocation(target, acceptedTransition, operationSequence),
@@ -465,8 +464,8 @@ export function SessionTenancyControl({
         throw new Error("The fork is no longer an owned private session in this workspace.");
       }
       operationController.settleFork(operationScope, attempt);
-      setAnnouncement("Private fork created in this workspace.");
-      toast.success("Private fork created");
+      setAnnouncement("Private copy created in this workspace.");
+      toast.success("Private copy created");
       onOpenSession(fork.workspaceId, fork.sessionId);
       return true;
     } catch (error) {
@@ -515,28 +514,28 @@ export function SessionTenancyControl({
     <>
       <section
         aria-label="Session access"
-        className="mx-auto mb-2 flex w-full max-w-3xl flex-wrap items-center gap-2 rounded-lg border border-border bg-surface/55 px-3 py-2 text-sm"
+        className="mx-auto mb-1 flex w-full max-w-3xl flex-wrap items-center justify-end gap-1.5 text-sm"
       >
-        <span className="inline-flex min-w-0 items-center gap-2 font-medium text-fg">
+        <span className="inline-flex min-h-8 min-w-0 items-center gap-1.5 rounded-full border border-border bg-surface/55 px-2.5 font-medium text-fg">
           {privateSession ? (
             <LockKeyholeIcon className="size-4 shrink-0 text-brand" aria-hidden="true" />
           ) : (
             <UsersIcon className="size-4 shrink-0 text-fg-muted" aria-hidden="true" />
           )}
-          <span>Access</span>
-          <Badge variant="outline">{privateSession ? "Private" : "Workspace"}</Badge>
-        </span>
-        <span className="min-w-0 flex-1 basis-44 text-xs leading-5 text-fg-muted">
-          {privateSession
-            ? "Only you can open this session."
-            : `Visible to people in ${scopeLabel}.`}
+          <span>{privateSession ? "Only me" : "Workspace"}</span>
+          <span className="sr-only">
+            {privateSession
+              ? "Only you can open this session."
+              : `Visible to people in ${scopeLabel}.`}
+          </span>
         </span>
         {mayManage ? (
-          <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-1.5">
+          <div className="flex min-w-0 flex-wrap items-center justify-end gap-1">
             <Button
               type="button"
               variant="ghost"
               size="sm"
+              aria-label={privateSession ? "Share with workspace" : visibilityAction}
               className="min-h-9 pointer-coarse:min-h-11"
               disabled={busy}
               onClick={() =>
@@ -546,23 +545,25 @@ export function SessionTenancyControl({
               {busy && confirmation?.kind === "visibility" ? (
                 <Loader2Icon className="size-3.5 animate-spin motion-reduce:animate-none" />
               ) : null}
-              {visibilityAction}
+              {privateSession ? "Share" : visibilityAction}
             </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="min-h-9 pointer-coarse:min-h-11"
-              disabled={busy}
-              onClick={() => setConfirmation({ kind: "fork" })}
-            >
-              {busy && confirmation?.kind === "fork" ? (
-                <Loader2Icon className="size-3.5 animate-spin motion-reduce:animate-none" />
-              ) : (
-                <CopyPlusIcon className="size-3.5" />
-              )}
-              {pendingFork ? "Retry private fork" : "Private fork"}
-            </Button>
+            {!privateSession ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="min-h-9 pointer-coarse:min-h-11"
+                disabled={busy}
+                onClick={() => setConfirmation({ kind: "fork" })}
+              >
+                {busy && confirmation?.kind === "fork" ? (
+                  <Loader2Icon className="size-3.5 animate-spin motion-reduce:animate-none" />
+                ) : (
+                  <CopyPlusIcon className="size-3.5" />
+                )}
+                {pendingFork ? "Retry private copy" : "Private copy"}
+              </Button>
+            ) : null}
           </div>
         ) : null}
         {failure ? (
@@ -582,14 +583,14 @@ export function SessionTenancyControl({
         }}
         title={
           confirmation?.kind === "fork"
-            ? "Create a private fork?"
+            ? "Create a private copy?"
             : confirmation?.visibility === "workspace"
               ? `Share this session with ${scopeLabel}?`
               : "Make this session private?"
         }
         description={
           confirmation?.kind === "fork"
-            ? "This creates an independent private session in the same workspace. Current work, access grants, connections, and sandbox state stay behind."
+            ? "This creates an independent private session in the same workspace. Current work, access grants, connections, and sandbox state stay with the original."
             : confirmation?.visibility === "workspace"
               ? "People who can access this workspace will be able to open the session after all current work has settled."
               : "Only you will be able to open the session. OpenGeni waits for all current work and sandbox access to settle first."
@@ -597,8 +598,8 @@ export function SessionTenancyControl({
         confirmLabel={
           confirmation?.kind === "fork"
             ? pendingFork
-              ? "Retry private fork"
-              : "Create private fork"
+              ? "Retry private copy"
+              : "Create private copy"
             : visibilityConfirmLabel
         }
         destructive={confirmation?.kind !== "fork" && confirmation?.visibility === "workspace"}

--- a/apps/web/src/lib/use-personal-resource-attachment.test.tsx
+++ b/apps/web/src/lib/use-personal-resource-attachment.test.tsx
@@ -78,6 +78,46 @@ function authorityPage(active: boolean, kind: "variable_set" | "rig") {
 }
 
 describe("usePersonalResourceAttachment", () => {
+  test("discovers personal options without surfacing authority failure when nothing is selected", async () => {
+    let calls = 0;
+    const client = {
+      listVariableSets: async () => {
+        calls += 1;
+        throw new Error("personal catalog unavailable");
+      },
+      listRigs: async () => {
+        calls += 1;
+        throw new Error("personal catalog unavailable");
+      },
+      listUserResourceAuthorities: async () => {
+        calls += 1;
+        throw new Error("personal catalog unavailable");
+      },
+    } as unknown as OpenGeniCoreClient;
+    const current = identity("owner");
+    const hook = await renderHook(
+      () =>
+        usePersonalResourceAttachment({
+          client,
+          authMode: "managedSession",
+          authSession: current.authSession,
+          accessSubjectId: "user:owner",
+          managedSelfContext: current.managedSelfContext,
+          workspace,
+          fixed: { variableSetId: null, rigId: null },
+          personalWorkspaceTarget: false,
+        }),
+      undefined,
+    );
+    await flush();
+    expect(calls).toBeGreaterThan(0);
+    expect(hook.result.current.eligible).toBe(true);
+    expect(hook.result.current.loading).toBe(false);
+    expect(hook.result.current.error).toBeNull();
+    expect(hook.result.current.requiresDecision).toBe(false);
+    await hook.unmount();
+  });
+
   test("drops a late owner response after the authenticated principal changes", async () => {
     let resolveVariable!: (value: ReturnType<typeof authorityPage>) => void;
     let resolveRig!: (value: ReturnType<typeof authorityPage>) => void;

--- a/apps/web/src/lib/use-personal-resource-attachment.ts
+++ b/apps/web/src/lib/use-personal-resource-attachment.ts
@@ -69,6 +69,7 @@ export function usePersonalResourceAttachment(input: {
   onReloadSession?: (() => Promise<void>) | undefined;
 }): PersonalResourceAttachmentController {
   const onReloadSession = input.onReloadSession;
+  const hasFixedResources = input.fixed.variableSetId !== null || input.fixed.rigId !== null;
   const resolvedScope =
     input.enabled === false
       ? null
@@ -271,12 +272,16 @@ export function usePersonalResourceAttachment(input: {
 
   return {
     eligible: scope !== null,
-    loading,
-    refreshing,
-    error: effectiveError,
+    // Catalog discovery populates the resource pickers in the background. It
+    // becomes submission UI only after the user has actually selected a fixed
+    // personal resource; an unavailable optional catalog must not turn an
+    // ordinary new-session composer into an error state.
+    loading: hasFixedResources && loading,
+    refreshing: hasFixedResources && refreshing,
+    error: hasFixedResources ? effectiveError : null,
     notice,
     sourceLost,
-    truncated: catalog?.truncated ?? false,
+    truncated: hasFixedResources && (catalog?.truncated ?? false),
     catalog,
     selected,
     mode,

--- a/packages/core/src/domain/sessions.ts
+++ b/packages/core/src/domain/sessions.ts
@@ -1546,6 +1546,11 @@ export async function createSessionForRequestWithOutcome(
     ? payload.skills
     : (parentSession?.skills ?? payload.skills);
   const toolsProvided = hasOwnProperty(rawPayload, "tools");
+  // Visibility became durable draft state after older clients had already
+  // written rows without it. Compare it only when the create request supplied
+  // the field explicitly; the parsed schema default must not manufacture a
+  // mismatch for a legacy draft.
+  const visibilityProvided = hasOwnProperty(rawPayload, "visibility");
   const requestedTools = validateToolRefs(
     toolsProvided ? payload.tools : (parentSession?.tools ?? payload.tools),
     runtimeSettings,
@@ -1709,6 +1714,7 @@ export async function createSessionForRequestWithOutcome(
           reasoningEffort,
           latencyMode,
           options: {
+            ...(visibilityProvided ? { visibility: payload.visibility } : {}),
             ...(payload.sandboxBackend ? { sandboxBackend: payload.sandboxBackend } : {}),
             ...(payload.targetSandboxId ? { targetSandboxId: payload.targetSandboxId } : {}),
             ...(payload.workingDir ? { workingDir: payload.workingDir } : {}),

--- a/packages/core/test/new-session-drafts.test.ts
+++ b/packages/core/test/new-session-drafts.test.ts
@@ -10,9 +10,12 @@ import {
 } from "@opengeni/db";
 import {
   acquireSharedTestDatabase,
+  MemoryEventBus,
   testSettings,
   type SharedTestDatabase,
 } from "@opengeni/testing";
+import type { ApiRouteDeps, SessionWorkflowClient } from "../src";
+import { createSessionForRequest } from "../src/domain/sessions";
 import {
   getActorNewSessionDraft,
   saveActorNewSessionDraft,
@@ -73,6 +76,62 @@ const settings = testSettings({
 const mcp = (id: string): ToolRef => ({ kind: "mcp", id });
 
 describe("core new-session draft hydration", () => {
+  test("accepts the exact saved visibility when creating the first session turn", async () => {
+    if (!available) return;
+    const { grant } = await fixture();
+    const saved = await saveActorNewSessionDraft(
+      { db, settings, objectStorage: null },
+      grant,
+      grant.workspaceId!,
+      {
+        expectedRevision: 0,
+        text: "Start a private-by-choice session",
+        resources: [],
+        tools: [],
+        toolsProvided: true,
+        model: settings.openaiModel,
+        reasoningEffort: settings.openaiReasoningEffort,
+        latencyMode: "standard",
+        options: { visibility: "workspace" },
+      },
+    );
+    const noop = async () => undefined;
+    const deps = {
+      settings,
+      db,
+      bus: new MemoryEventBus(),
+      workflowClient: {
+        signalUserMessage: noop,
+        wakeSessionWorkflow: noop,
+        requestSessionWorkflowWakeDispatch: noop,
+        signalApprovalDecision: noop,
+        signalSessionControl: noop,
+        syncScheduledTask: noop,
+        deleteScheduledTaskSchedule: noop,
+        triggerScheduledTask: noop,
+      } as unknown as SessionWorkflowClient,
+      objectStorage: null,
+      githubStateSecret: "test",
+      documentIndexer: { indexDocument: noop },
+      getDocumentServices: () => ({}) as never,
+    } as unknown as ApiRouteDeps;
+
+    const session = await createSessionForRequest(deps, grant, grant.workspaceId!, {
+      initialMessage: saved.text,
+      visibility: "workspace",
+      resources: [],
+      tools: [],
+      model: saved.model,
+      reasoningEffort: saved.reasoningEffort,
+      latencyMode: saved.latencyMode,
+      expectedNewSessionDraftRevision: saved.revision,
+      idempotencyKey: crypto.randomUUID(),
+    });
+
+    expect(session.id).toBeString();
+    expect(session.initialTurnId).toBeString();
+  }, 180_000);
+
   test("treats a markerless old-client save, including [], as explicit tools", async () => {
     if (!available) return;
     const { grant } = await fixture();

--- a/test/e2e/personal-resource-attachments.browser.e2e.ts
+++ b/test/e2e/personal-resource-attachments.browser.e2e.ts
@@ -58,12 +58,12 @@ describe("personal resource attachments in Chromium", () => {
     expect(await control.first().getByRole("radio").count()).toBe(3);
     await control
       .first()
-      .getByRole("radio", { name: /This workspace/ })
+      .getByRole("radio", { name: /Remember here/ })
       .check();
     expect(
       await control
         .first()
-        .getByRole("radio", { name: /This workspace/ })
+        .getByRole("radio", { name: /Remember here/ })
         .isChecked(),
     ).toBe(true);
 
@@ -143,7 +143,7 @@ describe("personal resource attachments in Chromium", () => {
     const unavailableControl = page.locator("[data-personal-resource-attachment]").first();
     expect(await unavailableControl.count()).toBe(1);
     expect(await unavailableControl.getByRole("alert").textContent()).toContain(
-      "authority could not be verified",
+      "couldn’t check access to the selected Variable Set or Rig",
     );
     expect(await unavailableControl.getByRole("button", { name: "Retry" }).count()).toBe(1);
     expect(await unavailableControl.getByRole("status").textContent()).toContain(

--- a/test/e2e/personal-workspace-accessibility.browser.e2e.ts
+++ b/test/e2e/personal-workspace-accessibility.browser.e2e.ts
@@ -123,25 +123,18 @@ describe("Personal workspace accessibility in Chromium", () => {
     const region = surface.getByRole("region", { name: "Session access", exact: true });
     const snapshot = await region.ariaSnapshot();
 
-    expect(snapshot).toContain("Access");
-    expect(snapshot).toContain("Private");
+    expect(snapshot).toContain("Only me");
     expect(snapshot).toContain("Only you can open this session.");
     expect(snapshot).toContain('button "Share with workspace"');
-    expect(snapshot).toContain('button "Private fork"');
+    expect(snapshot).not.toContain("Private copy");
 
     await page.setViewportSize({ width: 320, height: 740 });
     expect(await region.getAttribute("class")).toContain("flex-wrap");
     expect(await surface.getByRole("button", { name: "Share with workspace" }).count()).toBe(1);
-    expect(await surface.getByRole("button", { name: "Private fork" }).count()).toBe(1);
+    expect(await surface.getByRole("button", { name: "Private copy" }).count()).toBe(0);
 
     await page.locator("body").press("Tab");
-    expect(await page.evaluate(() => document.activeElement?.textContent?.trim())).toBe(
-      "Share with workspace",
-    );
-    await page.keyboard.press("Tab");
-    expect(await page.evaluate(() => document.activeElement?.textContent?.trim())).toBe(
-      "Private fork",
-    );
+    expect(await page.evaluate(() => document.activeElement?.textContent?.trim())).toBe("Share");
   });
 
   test("a suspended membership never labels the workspace Personal", async () => {


### PR DESCRIPTION
## What changed
- include the explicitly selected session visibility in exact new-session draft reconciliation, preventing a valid private/workspace draft from creating an empty session shell and then returning a false 409
- keep personal resource discovery available for the picker while hiding optional authority loading/errors unless a personal Rig or Variable Set is actually selected
- replace the large session access banner with compact `Only me` / `Workspace` state and contextual `Share` / `Private copy` actions
- replace internal personal-resource authority wording with user-facing copy

## Root cause
The web persisted `visibility` in the durable new-session draft, but core omitted it from the exact snapshot used when consuming that draft. The shell transaction therefore committed, the first-turn transaction rejected the otherwise-valid draft as changed, and the UI received a 409 while an inert session appeared later in the rail.

## Verification
- real PostgreSQL draft/create regression (session plus initial turn)
- focused core/hook/access tests: 23 pass
- full `apps/web/src`: 839 pass
- Chromium personal-resource/accessibility: 8 pass
- all 31 TypeScript projects
- lint, repository format check, public hygiene, diff check
- exact production web build, precompression, and all bundle budgets

## Deliberate boundary
Codex subscription connections are currently workspace-scoped in the backend. Personal-vs-workspace Codex ownership and a create-session selector require a separate authority/allocation/session-snapshot change; this PR does not imply that capability already exists.
