### PR TITLE
Fix session unread markers reappearing after navigation

### DIFF
--- a/apps/web/src/components/rail/session-list.tsx
+++ b/apps/web/src/components/rail/session-list.tsx
@@ -101,6 +101,12 @@ import {
   subscribeToSessionPinChanges,
 } from "@/lib/session-pins";
 import {
+  applySessionAttentionProjection,
+  latestSessionAttentionProjection,
+  subscribeToSessionAttentionChanges,
+  type SessionAttentionProjection,
+} from "@/lib/session-attention";
+import {
   buildPinnedRailSections,
   channelRailSections,
   filterSessionsForBrowse,
@@ -337,6 +343,9 @@ export function SessionList() {
   const [archiveTransitions, setArchiveTransitions] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
+  const [attentionOverrides, setAttentionOverrides] = useState<
+    ReadonlyMap<string, SessionAttentionProjection>
+  >(() => new Map());
   const archiving = useRef(new Set<string>());
   const pinOperation = useRef(0);
   const pinning = useRef(new Set<string>());
@@ -393,8 +402,26 @@ export function SessionList() {
           : override.session,
       );
     }
+    for (const [id, override] of attentionOverrides) {
+      const current = source.get(id);
+      if (current) source.set(id, applySessionAttentionProjection(current, override));
+    }
     return [...source.values()];
-  }, [pinOverrides, serverSessions]);
+  }, [attentionOverrides, pinOverrides, serverSessions]);
+
+  useEffect(() => {
+    setAttentionOverrides(new Map());
+    return subscribeToSessionAttentionChanges((projection) => {
+      setAttentionOverrides((current) => {
+        const latest = latestSessionAttentionProjection(current.get(projection.id), projection);
+        if (latest !== projection) return current;
+        const next = new Map(current);
+        next.set(projection.id, latest);
+        if (next.size > 64) next.delete(next.keys().next().value!);
+        return next;
+      });
+    });
+  }, [rail.workspaceId]);
   const creatorLabels = useMemo(() => sessionCreatorLabelMap(allSessions), [allSessions]);
   const creatorOptions = useMemo(() => {
     return [...creatorLabels].map(([value, label]) => ({ value, label }));

--- a/apps/web/src/lib/session-attention.test.ts
+++ b/apps/web/src/lib/session-attention.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Session } from "@/types";
+import {
+  applySessionAttentionProjection,
+  latestSessionAttentionProjection,
+  notifySessionAttentionChanged,
+  subscribeToSessionAttentionChanges,
+} from "./session-attention";
+
+const session = {
+  id: "00000000-0000-4000-8000-000000000026",
+  workspaceId: "00000000-0000-4000-8000-000000000001",
+  unread: true,
+  activelyWorking: false,
+  attentionVersion: 4,
+  lastSequence: 20,
+} as Session;
+
+describe("session attention reconciliation", () => {
+  test("keeps a route acknowledgement over an equal stale rail page", () => {
+    const acknowledged = applySessionAttentionProjection(session, {
+      ...session,
+      unread: false,
+    });
+
+    expect(acknowledged).toMatchObject({ unread: false, attentionVersion: 4 });
+  });
+
+  test("does not hide a newer explicit state or newer durable activity", () => {
+    const optimistic = { ...session, unread: false };
+    const newerMutation = { ...session, attentionVersion: 5 } as Session;
+    const newerEvent = { ...session, lastSequence: 21 } as Session;
+
+    expect(applySessionAttentionProjection(newerMutation, optimistic)).toBe(newerMutation);
+    expect(applySessionAttentionProjection(newerEvent, optimistic)).toBe(newerEvent);
+  });
+
+  test("keeps the newest override when HTTP responses arrive out of order", () => {
+    const newest = { ...session, unread: false, attentionVersion: 6, lastSequence: 21 };
+    const delayed = { ...session, unread: false, attentionVersion: 5, lastSequence: 20 };
+
+    expect(latestSessionAttentionProjection(newest, delayed)).toBe(newest);
+    expect(latestSessionAttentionProjection(delayed, newest)).toBe(newest);
+  });
+
+  test("notifies and unsubscribes same-tab listeners", () => {
+    const received: string[] = [];
+    const unsubscribe = subscribeToSessionAttentionChanges((projection) => {
+      received.push(projection.id);
+    });
+
+    notifySessionAttentionChanged(session);
+    unsubscribe();
+    notifySessionAttentionChanged(session);
+
+    expect(received).toEqual([session.id]);
+  });
+});

--- a/apps/web/src/lib/session-attention.ts
+++ b/apps/web/src/lib/session-attention.ts
@@ -1,0 +1,62 @@
+import type { Session } from "@/types";
+
+export type SessionAttentionProjection = Pick<
+  Session,
+  "id" | "workspaceId" | "unread" | "attentionVersion" | "lastSequence"
+>;
+
+// RailShell renders exactly one desktop-or-mobile SessionList at a time.
+let listener: ((projection: SessionAttentionProjection) => void) | null = null;
+
+function isOlder(
+  current: Pick<SessionAttentionProjection, "attentionVersion" | "lastSequence">,
+  projected: SessionAttentionProjection,
+): boolean {
+  return (
+    projected.attentionVersion! < current.attentionVersion! ||
+    projected.lastSequence < current.lastSequence
+  );
+}
+
+/**
+ * Apply a same-tab attention result without allowing an older list poll to
+ * resurrect a read marker. Attention revisions order explicit mutations,
+ * while lastSequence orders new durable activity; either older coordinate is
+ * stale. Equal coordinates let the latest mutation response replace the page
+ * projection immediately. The rail calls this only after an id-keyed lookup,
+ * so both arguments represent the same session.
+ */
+export function applySessionAttentionProjection(
+  current: Session,
+  projected: SessionAttentionProjection,
+): Session {
+  const currentVersion = current.attentionVersion!;
+  const projectedVersion = projected.attentionVersion!;
+  if (
+    isOlder(current, projected) ||
+    (current.unread === projected.unread && currentVersion === projectedVersion)
+  ) {
+    return current;
+  }
+  return { ...current, unread: projected.unread, attentionVersion: projectedVersion };
+}
+
+export function latestSessionAttentionProjection(
+  current: SessionAttentionProjection | undefined,
+  projected: SessionAttentionProjection,
+): SessionAttentionProjection {
+  return current && isOlder(current, projected) ? current : projected;
+}
+
+export function notifySessionAttentionChanged(projection: SessionAttentionProjection): void {
+  listener?.(projection);
+}
+
+export function subscribeToSessionAttentionChanges(
+  onChange: (projection: SessionAttentionProjection) => void,
+): () => void {
+  listener = onChange;
+  return () => {
+    if (listener === onChange) listener = null;
+  };
+}

--- a/apps/web/src/routes/session.tsx
+++ b/apps/web/src/routes/session.tsx
@@ -88,6 +88,10 @@ import {
   runnableLatencyModesForModel,
 } from "@/lib/model-policy";
 import { sessionTimelineEmptyStateCopy } from "@/lib/session-empty-state";
+import {
+  applySessionAttentionProjection,
+  notifySessionAttentionChanged,
+} from "@/lib/session-attention";
 import { mergeSessionContextProjection } from "@/lib/session-pins";
 import { createWorkspaceRetainedArtifactLoader } from "@/lib/retained-artifact-loader";
 import { downloadSandboxFileArtifact } from "@/lib/sandbox-artifact-download";
@@ -272,15 +276,12 @@ export function SessionRoute({
         expectedVersion: session.attentionVersion ?? 0,
       })
       .then((updated) => {
+        // The rail owns separately polled page objects. Keep the completed
+        // acknowledgement there so leaving this route cannot resurrect the
+        // stale dot while the next 15-second poll settles.
+        notifySessionAttentionChanged(updated);
         setContextSession((current) =>
-          current?.id === updated.id
-            ? {
-                ...current,
-                unread: updated.unread,
-                activelyWorking: updated.activelyWorking,
-                attentionVersion: updated.attentionVersion,
-              }
-            : current,
+          current?.id === updated.id ? applySessionAttentionProjection(current, updated) : current,
         );
       })
       .catch(() => {


### PR DESCRIPTION
## Summary
- propagate a completed session acknowledgement into the separately polled rail projection
- retain a bounded same-tab reconciliation overlay so stale 15-second polls cannot resurrect the unread dot
- order reconciliation by attention revision and durable event sequence, so newer explicit state or real activity still wins

## Staging diagnosis
The observed ~10 second delay matches the rail's 15 second polling interval. Staging API writes around the reproduced clicks completed in about 0.2–0.7 seconds and session-list reads in about 0.1–0.3 seconds; this is a client projection handoff bug, not a 10-second database write.

## Verification
- `bun run lint`
- `bun run format:check`
- `bun run --cwd apps/web typecheck`
- 30 focused web tests
- `bun run --cwd apps/web build` including production bundle budgets
